### PR TITLE
Added the fix to mysql build error.

### DIFF
--- a/docs/admin_guide/install.md
+++ b/docs/admin_guide/install.md
@@ -95,7 +95,7 @@ Palo 主要包括 Frontend（FE）和 Backend（BE）两个进程。其中 FE �
 * 启动 BE
 
     `sh bin/start_be.sh`
-    
+
     BE 进程将启动并进入后台执行。日志默认存放在 be/log/ 目录下。如启动失败，可以通过查看 be/log/be.log 或者 be/log/be.out 查看错误信息。
 
 * 查看BE状态
@@ -160,7 +160,7 @@ broker 以插件的形式，独立于 Palo 部署。如果需要从第三方存�
 
     重新执行：`sh build-thirdparty.sh`
 
-* 编译 Boost：Boost.Context fails to build -> Call of overloaded 'callcc(...) is ambiguous' 
+* 编译 Boost：Boost.Context fails to build -> Call of overloaded 'callcc(...) is ambiguous'
 
     如果你使用 gcc 4.8 或 4.9 版本，则可能出现这个问题。执行以下命令：
 
@@ -171,7 +171,17 @@ broker 以插件的形式，独立于 Palo 部署。如果需要从第三方存�
     之后重新执行：`sh build-thirdparty.sh`；
 
     > 参考：https://github.com/boostorg/fiber/issues/121
- 
+
+* 编译 mysql：Inconsistency detected by ld.so: dl-version.c: 224: _dl_check_map_versions: Assertion `needed != ((void *)0)' failed!
+
+    如果你使用 Ubuntu 14.04 LTS apt-get 安装的 cmake 2.8.2 版本，则可能出现这个问题。
+
+    用 apt-get 删除 cmake，并从cmake官网下载安装最新的 cmake。
+
+    之后重新执行：`sh build-thirdparty.sh`；
+
+    > 参考：https://forum.directadmin.com/archive/index.php/t-51343.html
+
 * 编译 thrift：syntax error near unexpected token `GLIB,'
 
     检查是否安装了 pkg-config，并且版本高于 0.22。如果已经安装，但依然出现此问题，请删除 `thirdparty/src/thrift-0.9.3` 后，重新执行：sh build-thirdparty.sh`
@@ -186,7 +196,7 @@ broker 以插件的形式，独立于 Palo 部署。如果需要从第三方存�
 
 * 编译 Palo FE 和 BE：cstddef: no member named 'max_align_t' in the global namespace
 
-    在 Ubuntu 16.04 环境下可能会遇到此问题。首先通过 `locate cstddef` 定位到系统的 cstddef 文件位置。打开 cstddef 文件，修改如下片段：
+    在 Ubuntu 14.04 LTS 和 16.04 环境下可能会遇到此问题。首先通过 `locate cstddef` 定位到系统的 cstddef 文件位置。打开 cstddef 文件，修改如下片段：
     ```
     namespace std {
       // We handle size_t, ptrdiff_t, and nullptr_t in c++config.h.
@@ -204,25 +214,25 @@ broker 以插件的形式，独立于 Palo 部署。如果需要从第三方存�
 ## 5. FE 高可用
 
 FE 分为 leader，follower 和 observer 三种角色。 默认一个集群，只能有一个 leader，可以有多个 follower 和 observer。其中 leader 和 follower 组成一个 Paxos 选择组，如果 leader 宕机，则剩下的 follower 会自动选出新的 leader，保证写入高可用。observer 同步 leader 的数据，但是不参加选举。如果只部署一个 FE，则 FE默认就是 leader。
-    
+
 第一个启动的 FE 自动成为 leader。在此基础上，可以添加若干 follower 和 observer。
-    
+
 添加 follower 或 observer。使用 mysql-client 连接到已启动的 FE，并执行：
 
 `ALTER SYSTEM ADD FOLLOWER "host:port";`
 
 或
 
-`ALTER SYSTEM ADD OBSERVER "host:port";` 
+`ALTER SYSTEM ADD OBSERVER "host:port";`
 
 其中 host 为 follower 或 observer 所在节点 ip；port 为其配置文件fe.conf中的 edit_log_port。
-    
+
 配置及启动 follower 或 observer。follower 和 observer 的配置同 leader 的配置。第一次启动时，需执行以下命令：
 
 `sh bin/start_fe.sh -helper host:port`
 
 其中host为 Leader 所在节点 ip；port 为 Leader 的配置文件 fe.conf 中的 edit_log_port。-helper 参数仅在 follower 和 observer 第一次启动时才需要。
-    
+
 查看 Follower 或 Observer 运行状态。使用 mysql-client 连接到任一已启动的 FE，并执行：SHOW PROC '/frontend'; 可以查看当前已加入集群的 FE 及其对应角色。
 
 ## 6. Docker 镜像
@@ -232,28 +242,28 @@ FE 分为 leader，follower 和 observer 三种角色。 默认一个集群，�
 * 加载 Docker 镜像
 
     `docker load -i palo-0.8.0-centos-docker.tar`
-    
+
 * 创建工作目录
 
     `cd /your/workspace/ && mkdir -p fe/palo-meta fe/log be/data/ be/log`
-        
+
     以上目录分别用于存放 FE 元信息、FE 日志、BE 数据、BE 日志。
-    
+
 * 启动 container
 
     `docker run --privileged -p 9030:9030 -p 8030:8030 -p 9010:9010 -p 9020:9020 -p 9060:9060 -p 9070:9070 -p 8040:8040 -p 9050:9050 -v $PWD/fe/log:/home/palo/run/fe/log -v $PWD/fe/palo-meta:/home/palo/run/fe/palo-meta -v $PWD/be/log:/home/palo/run/be/log -v $PWD/be/data:/home/palo/run/be/data -d -i -t palo:0.8.0 /bin/bash`
-        
+
     该命令将 FE 和 BE 所需的所有端口映射到宿主机对应端口，并将 FE 和 BE 所需的持久化目录（元信息、数据、日志）挂载到之前创建的工作目录下。
-    
+
 * Attach container
 
     执行 `docker ps -l` 获取 `CONTAINER_ID`。
-        
+
     执行 `docker attach CONTAINER_ID` 进入 container。之后按照前文所述，启动 FE 和 BE 即可。
-    
+
 * 退出 container
 
     若想保持 container 运行，执行 `ctrl + pq` 退出。
-        
+
     若需退出并关闭 container，执行 `ctrl + d`。
-    
+


### PR DESCRIPTION
This PR added the fix when building mysql error:

```
Inconsistency detected by ld.so: dl-version.c: 224: _dl_check_map_versions: Assertion `needed != ((void *)0)' failed!
```

It also removed the trailing whitespaces.

Finally, `max_align_t` error when building be may also happen in `Ubuntu 14.04 LTS`.