### PR TITLE
fix ambari deploy bug. add bdbje clock delta config

### DIFF
--- a/fe/src/com/baidu/palo/common/Config.java
+++ b/fe/src/com/baidu/palo/common/Config.java
@@ -160,6 +160,13 @@ public class Config extends ConfigBase {
     @ConfField public static boolean ignore_meta_check = false;
 
     /*
+     * Set the maximum acceptable clock skew between non-master FE to Master FE host.
+     * This value is checked whenever a non-master FE establishes a connection to master FE via BDBJE.
+     * The connection is abandoned if the clock skew is larger than this value.
+     */
+    @ConfField public static long max_bdbje_clock_delta_ms = 5000; // 5s
+
+    /*
      * Fe http port
      * Currently, all FEs' http port must be same.
      */

--- a/fe/src/com/baidu/palo/deploy/DeployManager.java
+++ b/fe/src/com/baidu/palo/deploy/DeployManager.java
@@ -149,7 +149,7 @@ public class DeployManager extends Daemon {
 
         if (!Strings.isNullOrEmpty(brokerServiceGroup)) {
             LOG.info("Broker service group is found");
-            hasObserverService = true;
+            hasBrokerService = true;
         }
 
         LOG.info("get electableFeServiceGroup: {}, observerFeServiceGroup: {}, backendServiceGroup: {}"

--- a/fe/src/com/baidu/palo/journal/bdbje/BDBEnvironment.java
+++ b/fe/src/com/baidu/palo/journal/bdbje/BDBEnvironment.java
@@ -20,6 +20,7 @@ import com.baidu.palo.common.Config;
 import com.baidu.palo.ha.BDBHA;
 import com.baidu.palo.ha.BDBStateChangeListener;
 import com.baidu.palo.ha.HAProtocol;
+
 import com.sleepycat.je.Database;
 import com.sleepycat.je.DatabaseConfig;
 import com.sleepycat.je.DatabaseException;
@@ -102,6 +103,8 @@ public class BDBEnvironment {
         replicationConfig.setHelperHosts(helperHostPort);
         replicationConfig.setGroupName(PALO_JOURNAL_GROUP);
         replicationConfig.setConfigParam(ReplicationConfig.ENV_UNKNOWN_STATE_TIMEOUT, "10");
+        replicationConfig.setMaxClockDelta(Config.max_bdbje_clock_delta_ms, TimeUnit.MILLISECONDS);
+
         if (isElectable) {
             replicationConfig.setConsistencyPolicy(new NoConsistencyRequiredPolicy());
             replicationConfig.setReplicaAckTimeout(2, TimeUnit.SECONDS);


### PR DESCRIPTION
The default clock delta tolerance between 2 bdbje node is 2 sec. If delta is larger than 2 sec, bdbje can not connect to the feeder