### PR TITLE
merge to fbc08a22bafa643aa9e0d7eb5cb90248ea47bbf8

### DIFF
--- a/be/src/exprs/timestamp_functions.cpp
+++ b/be/src/exprs/timestamp_functions.cpp
@@ -138,8 +138,8 @@ bool TimestampFunctions::check_format(const StringVal& format, DateTimeValue& t)
 
 void TimestampFunctions::report_bad_format(const StringVal* format) {
     std::string format_str((char *)format->ptr, format->len);
-    LOG(WARNING) << "Bad date/time conversion format: " << format_str
-                 << " Format must be: 'yyyy-MM-dd[ HH:mm:ss]'";
+    // LOG(WARNING) << "Bad date/time conversion format: " << format_str
+    //              << " Format must be: 'yyyy-MM-dd[ HH:mm:ss]'";
 }
 
 IntVal TimestampFunctions::year(


### PR DESCRIPTION
removed unused logs when datetime format is error