### PR TITLE
Fix trivial log issue

### DIFF
--- a/fe/src/main/java/org/apache/doris/analysis/InsertStmt.java
+++ b/fe/src/main/java/org/apache/doris/analysis/InsertStmt.java
@@ -233,7 +233,6 @@ public class InsertStmt extends DdlStmt {
                 sink.init(loadId, transactionId, db.getId());
             }
         }
-        LOG.info("analyzer is {}", analyzer.getDescTbl().debugString());
     }
 
     private void analyzeTargetTable(Analyzer analyzer) throws AnalysisException {

--- a/fe/src/main/java/org/apache/doris/analysis/InsertStmt.java
+++ b/fe/src/main/java/org/apache/doris/analysis/InsertStmt.java
@@ -233,7 +233,7 @@ public class InsertStmt extends DdlStmt {
                 sink.init(loadId, transactionId, db.getId());
             }
         }
-        LOG.info("analyzer is ", analyzer.getDescTbl().debugString());
+        LOG.info("analyzer is {}", analyzer.getDescTbl().debugString());
     }
 
     private void analyzeTargetTable(Analyzer analyzer) throws AnalysisException {


### PR DESCRIPTION
Currently,  `explain insert into t1 SelectStmt` output is empty.

After fixing this bug, `explain insert into t1 select * from t2;` output is following:

```
+----------------------------------------------------------------------------------------------------------------------+
| Explain String                                                                                                       |
+----------------------------------------------------------------------------------------------------------------------+
| PLAN FRAGMENT 0                                                                                                      |
|  OUTPUT EXPRS:`default_cluster:test.t2`.`dt` | `default_cluster:test.t2`.`id` | `default_cluster:test.t2`.`value` |  |
|   PARTITION: RANGE_PARTITIONED: <slot 0>                                                                             |
|                                                                                                                      |
|   DPP SINK                                                                                                           |
|     TABLE NAME: t1                                                                                                   |
|     PARTITIONS: 10008, 10009, 10010                                                                                  |
|                                                                                                                      |
|   2:EXCHANGE                                                                                                         |
|      tuple ids: 0                                                                                                    |
|                                                                                                                      |
| PLAN FRAGMENT 1                                                                                                      |
|  OUTPUT EXPRS:                                                                                                       |
|   PARTITION: RANDOM                                                                                                  |
|                                                                                                                      |
|   STREAM DATA SINK                                                                                                   |
|     EXCHANGE ID: 02                                                                                                  |
|     RANGE_PARTITIONED: <slot 0>                                                                                      |
|                                                                                                                      |
|   1:OLAP REWRITE NODE                                                                                                |
|   |  tuple ids: 0                                                                                                    |
|   |                                                                                                                  |
|   0:OlapScanNode                                                                                                     |
|      TABLE: t2                                                                                                       |
|      PREAGGREGATION: ON                                                                                              |
|      partitions=1/1                                                                                                  |
|      rollup: t2                                                                                                      |
|      buckets=10/10                                                                                                   |
|      cardinality=2                                                                                                   |
|      avgRowSize=1889.4286                                                                                            |
|      tuple ids: 1                                                                                                    |
+----------------------------------------------------------------------------------------------------------------------+
```