### PR TITLE
Fix InsertStmt reAnalyze bug

### DIFF
--- a/fe/src/main/java/org/apache/doris/analysis/InsertStmt.java
+++ b/fe/src/main/java/org/apache/doris/analysis/InsertStmt.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.analysis;
 
+import com.google.common.base.Preconditions;
 import org.apache.doris.catalog.BrokerTable;
 import org.apache.doris.catalog.Catalog;
 import org.apache.doris.catalog.Column;
@@ -38,6 +39,7 @@ import org.apache.doris.planner.DataSplitSink;
 import org.apache.doris.planner.ExportSink;
 import org.apache.doris.planner.OlapTableSink;
 import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.rewrite.ExprRewriter;
 import org.apache.doris.thrift.TUniqueId;
 import org.apache.doris.transaction.TransactionState.LoadJobSourceType;
 
@@ -167,6 +169,18 @@ public class InsertStmt extends DdlStmt {
 
     public QueryStmt getQueryStmt() {
         return queryStmt;
+    }
+
+
+    @Override
+    public void rewriteExprs(ExprRewriter rewriter) throws AnalysisException {
+        Preconditions.checkState(isAnalyzed());
+        queryStmt.rewriteExprs(rewriter);
+    }
+
+    @Override
+    public boolean isExplain() {
+        return queryStmt.isExplain();
     }
 
     public boolean isStreaming() {

--- a/fe/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -395,21 +395,14 @@ public class StmtExecutor {
             lock(dbs);
             try {
                 parsedStmt.analyze(analyzer);
-                // TODO chenhao16, InsertStmt's QueryStmt rewrite
-                StatementBase originStmt = null;
-                if (parsedStmt instanceof InsertStmt) {
-                    originStmt = parsedStmt;
-                    parsedStmt = ((InsertStmt) parsedStmt).getQueryStmt();
-                }
-                if (parsedStmt instanceof QueryStmt) {
-                    QueryStmt queryStmt1 = (QueryStmt)parsedStmt;
-                    boolean isExplain = ((QueryStmt) parsedStmt).isExplain();
+                if (parsedStmt instanceof QueryStmt || parsedStmt instanceof InsertStmt) {
+                    boolean isExplain = parsedStmt.isExplain();
                     // Apply expr and subquery rewrites.
                     boolean reAnalyze = false;
 
                     ExprRewriter rewriter = analyzer.getExprRewriter();
                     rewriter.reset();
-                    queryStmt1.rewriteExprs(rewriter);
+                    parsedStmt.rewriteExprs(rewriter);
                     reAnalyze = rewriter.changed();
                     if (analyzer.containSubquery()) {
                         StmtRewriter.rewrite(analyzer, parsedStmt);
@@ -421,27 +414,22 @@ public class StmtExecutor {
                         // types and column labels to restore them after the rewritten stmt has been
                         // reset() and re-analyzed.
                         List<Type> origResultTypes = Lists.newArrayList();
-                        for (Expr e: queryStmt1.getResultExprs()) {
+                        for (Expr e: parsedStmt.getResultExprs()) {
                             origResultTypes.add(e.getType());
                         }
                         List<String> origColLabels =
-                                Lists.newArrayList(queryStmt1.getColLabels());
+                                Lists.newArrayList(parsedStmt.getColLabels());
 
                         // Re-analyze the stmt with a new analyzer.
                         analyzer = new Analyzer(context.getCatalog(), context);
-                        // TODO chenhao16 , merge Impala
-                        // insert re-analyze
-                        if (originStmt != null) {
-                            originStmt.reset();
-                            originStmt.analyze(analyzer);
-                        } else {
-                            // query re-analyze
-                            parsedStmt.reset();
-                            parsedStmt.analyze(analyzer);
-                        }
+
+                        // query re-analyze
+                        parsedStmt.reset();
+                        parsedStmt.analyze(analyzer);
+
                         // Restore the original result types and column labels.
-                        queryStmt1.castResultExprs(origResultTypes);
-                        queryStmt1.setColLabels(origColLabels);
+                        parsedStmt.castResultExprs(origResultTypes);
+                        parsedStmt.setColLabels(origColLabels);
                         if (LOG.isTraceEnabled()) {
                             LOG.trace("rewrittenStmt: " + parsedStmt.toSql());
                         }
@@ -449,9 +437,6 @@ public class StmtExecutor {
                     }
                 }
 
-                if (originStmt != null && originStmt instanceof InsertStmt) {
-                    parsedStmt = originStmt;
-                }
                 // create plan
                 planner = new Planner();
                 if (parsedStmt instanceof QueryStmt || parsedStmt instanceof InsertStmt) {


### PR DESCRIPTION
SQL1:
```
insert into A
select 
     cis_poi_id,
     cis_flag,
     cis_flag_id,
     dt,
     aor_id,
     aor_type,
     aor_id_last
from (
      select dt,
             cis_flag,
             cis_poi_id,
             1 as cis_flag_id,
             aor_id,
             1 as aor_type,
             1 as aor_id_last
        from B
       where dt in (20180710, 20180711)
     ) t
where t.dt=20180711 ;
```

SQL2:
```
insert into mart_waimai.dim_cis_poi_aor_change_d
select 
     cis_poi_id,
     cis_flag,
     cis_flag_id,
     dt,
     aor_id,
     aor_type,
     aor_id_last
from (
      select dt,
             cis_flag,
             cis_poi_id,
             1 as cis_flag_id,
             1 as aor_id,
             1 as aor_type,
             1 as aor_id_last
        from topic_contest_poi_info_dd
       where dt between 20180710 and 20180711
     ) t
where t.dt=20180711 ;
```
The only difference for SQL1 and SQL2 is InPredicate and BetweenPredicate. The SQL1 will success , but the SQL2 will failed.

The cause is BetweenPredicate will Rewrite, but InsertStmt doesn't support rewrite.

The InsertStmt should support rewrite and we should simplify the code logic in StmtExecutor.