### PR TITLE
Fix view missed parenthesis bug

### DIFF
--- a/fe/src/main/cup/sql_parser.cup
+++ b/fe/src/main/cup/sql_parser.cup
@@ -3139,7 +3139,10 @@ non_pred_expr ::=
   | arithmetic_expr:e
   {: RESULT = e; :}
   | LPAREN non_pred_expr:e RPAREN
-  {: RESULT = e; :}
+  {:
+    e.setPrintSqlInParens(true);
+    RESULT = e;
+  :}
   /* TODO(zc): add other trim function */
   | KW_TRIM:id LPAREN function_params:params RPAREN
   {: RESULT = new FunctionCallExpr(new FunctionName(null, id), params); :}
@@ -3365,7 +3368,10 @@ predicate ::=
   | like_predicate:p
   {: RESULT = p; :}
   | LPAREN predicate:p RPAREN
-  {: RESULT = p; :}
+  {:
+    p.setPrintSqlInParens(true);
+    RESULT = p;
+  :}
   ;
 
 comparison_predicate ::=

--- a/fe/src/main/java/org/apache/doris/analysis/AnalyticExpr.java
+++ b/fe/src/main/java/org/apache/doris/analysis/AnalyticExpr.java
@@ -785,7 +785,7 @@ public class AnalyticExpr extends Expr {
     }
 
     @Override
-    public String toSql() {
+    public String toSqlImpl() {
         if (sqlString != null) {
             return sqlString;
         }

--- a/fe/src/main/java/org/apache/doris/analysis/ArithmeticExpr.java
+++ b/fe/src/main/java/org/apache/doris/analysis/ArithmeticExpr.java
@@ -150,7 +150,7 @@ public class ArithmeticExpr extends Expr {
     }
 
     @Override
-    public String toSql() {
+    public String toSqlImpl() {
         if (children.size() == 1) {
             return op.toString() + " " + getChild(0).toSql();
         } else {

--- a/fe/src/main/java/org/apache/doris/analysis/BetweenPredicate.java
+++ b/fe/src/main/java/org/apache/doris/analysis/BetweenPredicate.java
@@ -85,7 +85,7 @@ public class BetweenPredicate extends Predicate {
     }
 
     @Override
-    public String toSql() {
+    public String toSqlImpl() {
         String notStr = (isNotBetween) ? "NOT " : "";
         return children.get(0).toSql() + " " + notStr + "BETWEEN " +
           children.get(1).toSql() + " AND " + children.get(2).toSql();

--- a/fe/src/main/java/org/apache/doris/analysis/BinaryPredicate.java
+++ b/fe/src/main/java/org/apache/doris/analysis/BinaryPredicate.java
@@ -219,7 +219,7 @@ public class BinaryPredicate extends Predicate implements Writable {
     }
 
     @Override
-    public String toSql() {
+    public String toSqlImpl() {
         return getChild(0).toSql() + " " + op.toString() + " " + getChild(1).toSql();
     }
 

--- a/fe/src/main/java/org/apache/doris/analysis/BoolLiteral.java
+++ b/fe/src/main/java/org/apache/doris/analysis/BoolLiteral.java
@@ -78,7 +78,7 @@ public class BoolLiteral extends LiteralExpr {
     }
 
     @Override
-    public String toSql() {
+    public String toSqlImpl() {
         return getStringValue();
     }
 

--- a/fe/src/main/java/org/apache/doris/analysis/CaseExpr.java
+++ b/fe/src/main/java/org/apache/doris/analysis/CaseExpr.java
@@ -103,7 +103,7 @@ public class CaseExpr extends Expr {
     }
 
     @Override
-    public String toSql() {
+    public String toSqlImpl() {
         StringBuilder output = new StringBuilder("CASE");
         int childIdx = 0;
         if (hasCaseExpr) {

--- a/fe/src/main/java/org/apache/doris/analysis/CastExpr.java
+++ b/fe/src/main/java/org/apache/doris/analysis/CastExpr.java
@@ -154,7 +154,7 @@ public class CastExpr extends Expr {
     }
 
     @Override
-    public String toSql() {
+    public String toSqlImpl() {
         if (isImplicit) {
             return getChild(0).toSql();
         }

--- a/fe/src/main/java/org/apache/doris/analysis/CompoundPredicate.java
+++ b/fe/src/main/java/org/apache/doris/analysis/CompoundPredicate.java
@@ -67,7 +67,7 @@ public class CompoundPredicate extends Predicate {
     }
 
     @Override
-    public String toSql() {
+    public String toSqlImpl() {
         if (children.size() == 1) {
             Preconditions.checkState(op == Operator.NOT);
             return "NOT " + getChild(0).toSql();

--- a/fe/src/main/java/org/apache/doris/analysis/DateLiteral.java
+++ b/fe/src/main/java/org/apache/doris/analysis/DateLiteral.java
@@ -144,7 +144,7 @@ public class DateLiteral extends LiteralExpr {
     }
 
     @Override
-    public String toSql() {
+    public String toSqlImpl() {
         return "'" + getStringValue() + "'";
     }
 

--- a/fe/src/main/java/org/apache/doris/analysis/DecimalLiteral.java
+++ b/fe/src/main/java/org/apache/doris/analysis/DecimalLiteral.java
@@ -159,7 +159,7 @@ public class DecimalLiteral extends LiteralExpr {
     }
 
     @Override
-    public String toSql() {
+    public String toSqlImpl() {
         return getStringValue();
     }
 

--- a/fe/src/main/java/org/apache/doris/analysis/ExistsPredicate.java
+++ b/fe/src/main/java/org/apache/doris/analysis/ExistsPredicate.java
@@ -59,7 +59,7 @@ public class ExistsPredicate extends Predicate {
     @Override
     public Expr clone() { return new ExistsPredicate(this); }
 
-    public String toSql() {
+    public String toSqlImpl() {
         StringBuilder strBuilder = new StringBuilder();
         if (notExists) {
             strBuilder.append("NOT ");

--- a/fe/src/main/java/org/apache/doris/analysis/Expr.java
+++ b/fe/src/main/java/org/apache/doris/analysis/Expr.java
@@ -232,6 +232,10 @@ abstract public class Expr extends TreeNode<Expr> implements ParseNode, Cloneabl
     // Cached value of IsConstant(), set during analyze() and valid if isAnalyzed_ is true.
     private boolean isConstant_;
 
+    // Flag to indicate whether to wrap this expr's toSql() in parenthesis. Set by parser.
+    // Needed for properly capturing expr precedences in the SQL string.
+    protected boolean printSqlInParens = false;
+
     protected Expr() {
         super();
         type = Type.INVALID;
@@ -252,6 +256,7 @@ abstract public class Expr extends TreeNode<Expr> implements ParseNode, Cloneabl
         opcode = other.opcode;
         isConstant_ = other.isConstant_;
         fn = other.fn;
+        printSqlInParens = other.printSqlInParens;
         children = Expr.cloneList(other.children);
     }
 
@@ -316,6 +321,14 @@ abstract public class Expr extends TreeNode<Expr> implements ParseNode, Cloneabl
     public void setIsAuxExpr() { isAuxExpr = true; }
     public Function getFn() {
         return fn;
+    }
+
+    public boolean getPrintSqlInParens() {
+        return printSqlInParens;
+    }
+
+    public void setPrintSqlInParens(boolean b) {
+        printSqlInParens = b;
     }
 
     /**
@@ -781,7 +794,15 @@ abstract public class Expr extends TreeNode<Expr> implements ParseNode, Cloneabl
         }
     }
 
-    public abstract String toSql();
+    public String toSql() {
+        return (printSqlInParens) ? "(" + toSqlImpl() + ")" : toSqlImpl();
+    }
+
+    /**
+     * Returns a SQL string representing this expr. Subclasses should override this method
+     * instead of toSql() to ensure that parenthesis are properly added around the toSql().
+     */
+    protected abstract String toSqlImpl();
 
     public String toMySql() {
         return toSql();
@@ -1363,7 +1384,10 @@ abstract public class Expr extends TreeNode<Expr> implements ParseNode, Cloneabl
         if (root instanceof CompoundPredicate) {
             Expr left = pushNegationToOperands(root.getChild(0));
             Expr right = pushNegationToOperands(root.getChild(1));
-            return new CompoundPredicate(((CompoundPredicate)root).getOp(), left, right);
+            CompoundPredicate compoundPredicate =
+                    new CompoundPredicate(((CompoundPredicate)root).getOp(), left, right);
+            compoundPredicate.setPrintSqlInParens(root.getPrintSqlInParens());
+            return compoundPredicate;
         }
 
         return root;

--- a/fe/src/main/java/org/apache/doris/analysis/FloatLiteral.java
+++ b/fe/src/main/java/org/apache/doris/analysis/FloatLiteral.java
@@ -121,7 +121,7 @@ public class FloatLiteral extends LiteralExpr {
     }
 
     @Override
-    public String toSql() {
+    public String toSqlImpl() {
         return getStringValue();
     }
 

--- a/fe/src/main/java/org/apache/doris/analysis/FunctionCallExpr.java
+++ b/fe/src/main/java/org/apache/doris/analysis/FunctionCallExpr.java
@@ -171,7 +171,7 @@ public class FunctionCallExpr extends Expr {
     }
 
     @Override
-    public String toSql() {
+    public String toSqlImpl() {
         StringBuilder sb = new StringBuilder();
         sb.append(fnName).append("(");
         if (fnParams.isStar()) {

--- a/fe/src/main/java/org/apache/doris/analysis/InPredicate.java
+++ b/fe/src/main/java/org/apache/doris/analysis/InPredicate.java
@@ -223,7 +223,7 @@ public class InPredicate extends Predicate {
     }
 
     @Override
-    public String toSql() {
+    public String toSqlImpl() {
         StringBuilder strBuilder = new StringBuilder();
         String notStr = (isNotIn) ? "NOT " : "";
         strBuilder.append(getChild(0).toSql() + " " + notStr + "IN (");

--- a/fe/src/main/java/org/apache/doris/analysis/InformationFunction.java
+++ b/fe/src/main/java/org/apache/doris/analysis/InformationFunction.java
@@ -73,7 +73,7 @@ public class InformationFunction extends Expr {
     }
 
     @Override
-    public String toSql() {
+    public String toSqlImpl() {
         return funcType + "()";
     }
 }

--- a/fe/src/main/java/org/apache/doris/analysis/IntLiteral.java
+++ b/fe/src/main/java/org/apache/doris/analysis/IntLiteral.java
@@ -279,7 +279,7 @@ public class IntLiteral extends LiteralExpr {
     }
 
     @Override
-    public String toSql() {
+    public String toSqlImpl() {
         return getStringValue();
     }
 

--- a/fe/src/main/java/org/apache/doris/analysis/IsNullPredicate.java
+++ b/fe/src/main/java/org/apache/doris/analysis/IsNullPredicate.java
@@ -92,7 +92,7 @@ public class IsNullPredicate extends Predicate {
     }
 
     @Override
-    public String toSql() {
+    public String toSqlImpl() {
         return getChild(0).toSql() + (isNotNull ? " IS NOT NULL" : " IS NULL");
     }
 

--- a/fe/src/main/java/org/apache/doris/analysis/LargeIntLiteral.java
+++ b/fe/src/main/java/org/apache/doris/analysis/LargeIntLiteral.java
@@ -173,7 +173,7 @@ public class LargeIntLiteral extends LiteralExpr {
     }
 
     @Override
-    public String toSql() {
+    public String toSqlImpl() {
         return getStringValue();
     }
 

--- a/fe/src/main/java/org/apache/doris/analysis/LikePredicate.java
+++ b/fe/src/main/java/org/apache/doris/analysis/LikePredicate.java
@@ -102,7 +102,7 @@ public class LikePredicate extends Predicate {
     }
 
     @Override
-    public String toSql() {
+    public String toSqlImpl() {
         return getChild(0).toSql() + " " + op.toString() + " " + getChild(1).toSql();
     }
 

--- a/fe/src/main/java/org/apache/doris/analysis/MaxLiteral.java
+++ b/fe/src/main/java/org/apache/doris/analysis/MaxLiteral.java
@@ -53,7 +53,7 @@ public final class MaxLiteral extends LiteralExpr {
     }
 
     @Override
-    public String toSql() {
+    public String toSqlImpl() {
         return "MAXVALUE";
     }
 

--- a/fe/src/main/java/org/apache/doris/analysis/NullLiteral.java
+++ b/fe/src/main/java/org/apache/doris/analysis/NullLiteral.java
@@ -89,7 +89,7 @@ public class NullLiteral extends LiteralExpr {
     }
 
     @Override
-    public String toSql() {
+    public String toSqlImpl() {
         return getStringValue();
     }
 

--- a/fe/src/main/java/org/apache/doris/analysis/SlotRef.java
+++ b/fe/src/main/java/org/apache/doris/analysis/SlotRef.java
@@ -148,7 +148,7 @@ public class SlotRef extends Expr {
     }
 
     @Override
-    public String toSql() {
+    public String toSqlImpl() {
         StringBuilder sb = new StringBuilder();
 
         // if (desc != null) {

--- a/fe/src/main/java/org/apache/doris/analysis/StringLiteral.java
+++ b/fe/src/main/java/org/apache/doris/analysis/StringLiteral.java
@@ -112,7 +112,7 @@ public class StringLiteral extends LiteralExpr {
     }
 
     @Override
-    public String toSql() {
+    public String toSqlImpl() {
         return "'" + value + "'";
     }
 

--- a/fe/src/main/java/org/apache/doris/analysis/Subquery.java
+++ b/fe/src/main/java/org/apache/doris/analysis/Subquery.java
@@ -51,7 +51,7 @@ public class Subquery extends Expr {
     public QueryStmt getStatement() { return stmt; }
 
     @Override
-    public String toSql() { return "(" + stmt.toSql() + ")"; }
+    public String toSqlImpl() { return "(" + stmt.toSql() + ")"; }
 
     /**
      * C'tor that initializes a Subquery from a QueryStmt.

--- a/fe/src/main/java/org/apache/doris/analysis/SysVariableDesc.java
+++ b/fe/src/main/java/org/apache/doris/analysis/SysVariableDesc.java
@@ -115,7 +115,7 @@ public class SysVariableDesc extends Expr {
     }
 
     @Override
-    public String toSql() {
+    public String toSqlImpl() {
         StringBuilder sb = new StringBuilder("@@");
         if (setType == SetType.GLOBAL) {
             sb.append("GLOBAL.");

--- a/fe/src/main/java/org/apache/doris/analysis/TableRef.java
+++ b/fe/src/main/java/org/apache/doris/analysis/TableRef.java
@@ -546,7 +546,7 @@ public class TableRef implements ParseNode, Writable {
         if (usingColNames != null) {
             output.append("USING (").append(Joiner.on(", ").join(usingColNames)).append(")");
         } else if (onClause != null) {
-            output.append("ON (").append(onClause.toSql()).append(")");
+            output.append("ON ").append(onClause.toSql());
         }
         return output.toString();
     }

--- a/fe/src/main/java/org/apache/doris/analysis/TimestampArithmeticExpr.java
+++ b/fe/src/main/java/org/apache/doris/analysis/TimestampArithmeticExpr.java
@@ -255,7 +255,7 @@ public class TimestampArithmeticExpr extends Expr {
     }
 
     @Override
-    public String toSql() {
+    public String toSqlImpl() {
         StringBuilder strBuilder = new StringBuilder();
         if (funcName != null) {
             // Function-call like version.

--- a/fe/src/main/java/org/apache/doris/analysis/TupleIsNullPredicate.java
+++ b/fe/src/main/java/org/apache/doris/analysis/TupleIsNullPredicate.java
@@ -145,7 +145,7 @@ public class TupleIsNullPredicate extends Predicate {
     }
 
     @Override
-    public String toSql() {
+    public String toSqlImpl() {
         return "";
     }
 }


### PR DESCRIPTION
### How to Reproduce
1 Create a view
```
create view test_view (id) as select (1 + 2) % 3 as id;
```
2 query the view
```
select * from test_view;
```
the result is 
```

id
--
3
```
The right result for this sql should be 0, not 3.

the result for `show create view`:
```
CREATE VIEW `test_view` AS SELECT 1 + 2 % 3 AS `id`;
```
we found the parenthesis in view has lost.

### How to solve

Refer to IMPALA-495 and IMPALA-4325