### PR TITLE
Fix some compile and script errors

### DIFF
--- a/be/test/olap/file_utils_test.cpp
+++ b/be/test/olap/file_utils_test.cpp
@@ -68,7 +68,7 @@ TEST_F(FileUtilsTest, TestCopyFile) {
     char* large_bytes2[(1 << 12)];
     memset(large_bytes2, 0, sizeof(char)*((1 << 12)));
     int i = 0;
-    while (i < 1 << 19) {
+    while (i < 1 << 10) {
         src_file_handler.write(large_bytes2, ((1 << 12)));
         ++i;
     }
@@ -80,7 +80,7 @@ TEST_F(FileUtilsTest, TestCopyFile) {
     FileHandler dst_file_handler;
     dst_file_handler.open(dst_file_name, O_RDONLY);
     int64_t dst_length = dst_file_handler.length();
-    int64_t src_length = 2147483661;
+    int64_t src_length = 4194317;
     ASSERT_EQ(src_length, dst_length);
 }
 

--- a/bin/start_fe.sh
+++ b/bin/start_fe.sh
@@ -51,12 +51,6 @@ JAVA=$JAVA_HOME/bin/java
 for f in $DORIS_HOME/lib/*.jar; do
   CLASSPATH=$f:${CLASSPATH};
 done
-for f in $DORIS_HOME/lib/kudu-client/*.jar; do
-  CLASSPATH=$f:${CLASSPATH};
-done
-for f in $DORIS_HOME/lib/k8s-client/*.jar; do
-  CLASSPATH=$f:${CLASSPATH};
-done
 export CLASSPATH=${CLASSPATH}:${DORIS_HOME}/lib
 
 if [ ! -d $LOG_DIR ]; then
@@ -79,6 +73,6 @@ else
 fi
 
 echo `date` >> $LOG_DIR/fe.out
-nohup $LIMIT $JAVA $JAVA_OPTS com.baidu.palo.PaloFe "$@" >> $LOG_DIR/fe.out 2>&1 </dev/null &
+nohup $LIMIT $JAVA $JAVA_OPTS org.apache.doris.PaloFe "$@" >> $LOG_DIR/fe.out 2>&1 </dev/null &
 
 echo $! > $pidfile

--- a/fe/src/test/java/org/apache/doris/task/LoadEtlTaskTest.java
+++ b/fe/src/test/java/org/apache/doris/task/LoadEtlTaskTest.java
@@ -49,6 +49,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.api.easymock.PowerMock;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
@@ -60,6 +61,7 @@ import java.util.Set;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({ HadoopLoadEtlTask.class, Catalog.class })
+@PowerMockIgnore("javax.management.*")
 public class LoadEtlTaskTest {
     private long dbId;
     private long tableId;

--- a/fe/src/test/java/org/apache/doris/task/LoadPendingTaskTest.java
+++ b/fe/src/test/java/org/apache/doris/task/LoadPendingTaskTest.java
@@ -43,6 +43,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.api.easymock.PowerMock;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
@@ -53,6 +54,7 @@ import java.util.Map;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({ HadoopLoadPendingTask.class, Catalog.class })
+@PowerMockIgnore("javax.management.*")
 public class LoadPendingTaskTest {
     private long dbId;
     private long tableId;

--- a/fe/src/test/resources/log4j2.xml
+++ b/fe/src/test/resources/log4j2.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN">
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{YYYY-MM-dd HH:mm:ss} [%t] %-5p %c{1}:%L - %msg%n" />
+        </Console>
+
+        <RollingFile name="RollingFile" filename="log/fe_test.log"
+            filepattern="${logPath}/%d{YYYYMMddHHmmss}-fargo.log">
+            <PatternLayout pattern="%d{YYYY-MM-dd HH:mm:ss} [%t] %-5p %c{1}:%L - %msg%n" />
+            <Policies>
+                <SizeBasedTriggeringPolicy size="100 MB" />
+            </Policies>
+            <DefaultRolloverStrategy max="20" />
+        </RollingFile>
+
+    </Appenders>
+    <Loggers>
+        <Root level="info">
+            <AppenderRef ref="Console" />
+            <AppenderRef ref="RollingFile" />
+        </Root>
+    </Loggers>
+</Configuration>

--- a/fs_brokers/apache_hdfs_broker/bin/start_broker.sh
+++ b/fs_brokers/apache_hdfs_broker/bin/start_broker.sh
@@ -60,6 +60,6 @@ if [ ! -d $BROKER_LOG_DIR ]; then
 fi
 
 echo `date` >> $BROKER_LOG_DIR/apache_hdfs_broker.out
-nohup $LIMIT $JAVA $JAVA_OPTS com.baidu.palo.broker.hdfs.BrokerBootstrap "$@" >> $BROKER_LOG_DIR/apache_hdfs_broker.out 2>&1 </dev/null &
+nohup $LIMIT $JAVA $JAVA_OPTS org.apache.doris.broker.hdfs.BrokerBootstrap "$@" >> $BROKER_LOG_DIR/apache_hdfs_broker.out 2>&1 </dev/null &
 
 echo $! > $pidfile


### PR DESCRIPTION
1. Fix error class in start_fe.sh and start_broker.sh.
2. Add log4j2.xml in fe/src/test/resources/ to run fe ut without log4j warnings.
3. Reduce the test file size in be ut.