### PR TITLE
Make class name compatible with the old name

### DIFF
--- a/fe/src/main/java/org/apache/doris/analysis/AlterClause.java
+++ b/fe/src/main/java/org/apache/doris/analysis/AlterClause.java
@@ -46,6 +46,10 @@ public class AlterClause implements Writable {
 
     public static AlterClause read(DataInput in) throws IOException {
         String className = Text.readString(in);
+        if (className.startsWith("com.baidu.palo")) {
+            // we need to be compatible with former class name
+            className = className.replaceFirst("com.baidu.palo", "org.apache.doris");
+        }
         AlterClause alterClause = null;
         try {
             Class<? extends AlterClause> derivedClass = (Class<? extends AlterClause>) Class.forName(className);

--- a/fe/src/main/java/org/apache/doris/mysql/privilege/PrivEntry.java
+++ b/fe/src/main/java/org/apache/doris/mysql/privilege/PrivEntry.java
@@ -176,6 +176,10 @@ public abstract class PrivEntry implements Comparable<PrivEntry>, Writable {
      */
     public static PrivEntry read(DataInput in) throws IOException {
         String className = Text.readString(in);
+        if (className.startsWith("com.baidu.palo")) {
+            // we need to be compatible with former class name
+            className = className.replaceFirst("com.baidu.palo", "org.apache.doris");
+        }
         PrivEntry privEntry = null;
         try {
             Class<? extends PrivEntry> derivedClass = (Class<? extends PrivEntry>) Class.forName(className);

--- a/fe/src/main/java/org/apache/doris/mysql/privilege/PrivTable.java
+++ b/fe/src/main/java/org/apache/doris/mysql/privilege/PrivTable.java
@@ -178,6 +178,10 @@ public abstract class PrivTable implements Writable {
 
     public static PrivTable read(DataInput in) throws IOException {
         String className = Text.readString(in);
+        if (className.startsWith("com.baidu.palo")) {
+            // we need to be compatible with former class name
+            className = className.replaceFirst("com.baidu.palo", "org.apache.doris");
+        }
         PrivTable privTable = null;
         try {
             Class<? extends PrivTable> derivedClass = (Class<? extends PrivTable>) Class.forName(className);


### PR DESCRIPTION
We wrote the old name 'com.baidu.palo.xxx' in bdbje as meta journal.
So we need to make it compatible with 'org.apache.doris.xxx'.