### PR TITLE
Optimize quota unit

### DIFF
--- a/docs/help/Contents/Data Definition/ddl_stmt.md
+++ b/docs/help/Contents/Data Definition/ddl_stmt.md
@@ -677,7 +677,7 @@
 ## description
     该语句用于设置指定数据库的属性。（仅管理员使用）
     语法：
-        1) 设置数据库数据量配额，单位为字节
+        1) 设置数据库数据量配额，单位为B/K/KB/M/MB/G/GB/T/TB/P/PB
             ALTER DATABASE db_name SET DATA QUOTA quota;
             
         2) 重命名数据库
@@ -687,9 +687,15 @@
         重命名数据库后，如需要，请使用 REVOKE 和 GRANT 命令修改相应的用户权限。 
 
 ## example
-    1. 设置指定数据库数据量配额为 10 TB
+    1. 设置指定数据库数据量配额
         ALTER DATABASE example_db SET DATA QUOTA 10995116277760;
-        
+        上述单位为字节,等价于
+        ALTER DATABASE example_db SET DATA QUOTA 10T;
+
+        ALTER DATABASE example_db SET DATA QUOTA 100G;
+
+        ALTER DATABASE example_db SET DATA QUOTA 200M;
+
     2. 将数据库额 example_db 重命名为 example_db2
         ALTER DATABASE example_db RENAME example_db2;
 

--- a/fe/src/main/cup/sql_parser.cup
+++ b/fe/src/main/cup/sql_parser.cup
@@ -262,6 +262,7 @@ nonterminal describe_command, opt_full, opt_inner, opt_outer, from_or_in, keys_o
 // String
 nonterminal String user, opt_user;
 nonterminal UserIdentity user_identity;
+nonterminal String quota_expr;
 
 // Description of user
 nonterminal UserDesc grant_user;
@@ -587,13 +588,24 @@ alter_stmt ::=
     {:
         RESULT = new AlterClusterStmt(name, properties);
     :}
-    | KW_ALTER KW_DATABASE ident:dbName KW_SET KW_DATA KW_QUOTA INTEGER_LITERAL:quota
+    | KW_ALTER KW_DATABASE ident:dbName KW_SET KW_DATA KW_QUOTA quota_expr:quota
     {:
         RESULT = new AlterDatabaseQuotaStmt(dbName, quota);
     :}
     | KW_ALTER KW_DATABASE ident:dbName KW_RENAME ident:newDbName
     {:
         RESULT = new AlterDatabaseRename(dbName, newDbName);
+    :}
+    ;
+
+quota_expr ::=
+    INTEGER_LITERAL:quota
+    {:
+        RESULT = quota.toString();
+    :}
+    | ident:expr
+    {:
+        RESULT = expr;
     :}
     ;
 

--- a/fe/src/main/cup/sql_parser.cup
+++ b/fe/src/main/cup/sql_parser.cup
@@ -262,7 +262,7 @@ nonterminal describe_command, opt_full, opt_inner, opt_outer, from_or_in, keys_o
 // String
 nonterminal String user, opt_user;
 nonterminal UserIdentity user_identity;
-nonterminal String quota_expr;
+nonterminal String quantity;
 
 // Description of user
 nonterminal UserDesc grant_user;
@@ -588,9 +588,9 @@ alter_stmt ::=
     {:
         RESULT = new AlterClusterStmt(name, properties);
     :}
-    | KW_ALTER KW_DATABASE ident:dbName KW_SET KW_DATA KW_QUOTA quota_expr:quota
+    | KW_ALTER KW_DATABASE ident:dbName KW_SET KW_DATA KW_QUOTA quantity:quota_quantity
     {:
-        RESULT = new AlterDatabaseQuotaStmt(dbName, quota);
+        RESULT = new AlterDatabaseQuotaStmt(dbName, quota_quantity);
     :}
     | KW_ALTER KW_DATABASE ident:dbName KW_RENAME ident:newDbName
     {:
@@ -598,14 +598,14 @@ alter_stmt ::=
     :}
     ;
 
-quota_expr ::=
-    INTEGER_LITERAL:quota
+quantity ::=
+    INTEGER_LITERAL:number
     {:
-        RESULT = quota.toString();
+        RESULT = number.toString();
     :}
-    | ident:expr
+    | ident:number_unit
     {:
-        RESULT = expr;
+        RESULT = number_unit;
     :}
     ;
 

--- a/fe/src/main/java/org/apache/doris/analysis/AlterDatabaseQuotaStmt.java
+++ b/fe/src/main/java/org/apache/doris/analysis/AlterDatabaseQuotaStmt.java
@@ -26,15 +26,35 @@ import org.apache.doris.common.UserException;
 import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.qe.ConnectContext;
 
+import java.util.HashMap;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import com.google.common.base.Strings;
 
 public class AlterDatabaseQuotaStmt extends DdlStmt {
     private String dbName;
+    private String quotaExpression;
     private long quota;
+    private String unit = "B";
+    private HashMap<String, Long> validUnitMultiplier = new HashMap<String, Long>();
+    private String quotaPattern = "(-?\\d+)(\\D*)";
 
-    public AlterDatabaseQuotaStmt(String dbName, long quota) {
+    public AlterDatabaseQuotaStmt(String dbName, String quotaExpression) {
         this.dbName = dbName;
-        this.quota = quota;
+        this.quotaExpression = quotaExpression;
+        validUnitMultiplier.put("B", 1L);
+        validUnitMultiplier.put("Bytes", 1L);
+        validUnitMultiplier.put("K", 1024L);
+        validUnitMultiplier.put("KB", 1024L);
+        validUnitMultiplier.put("M", 1024 * 1024L);
+        validUnitMultiplier.put("MB", 1024 * 1024L);
+        validUnitMultiplier.put("G", 1024 * 1024 * 1024L);
+        validUnitMultiplier.put("GB", 1024 * 1024 * 1024L);
+        validUnitMultiplier.put("T", 1024 * 1024 * 1024 * 1024L);
+        validUnitMultiplier.put("TB", 1024 * 1024 * 1024 * 1024L);
+        validUnitMultiplier.put("P", 1024 * 1024 * 1024 * 1024 * 1024L);
+        validUnitMultiplier.put("PB", 1024 * 1024 * 1024 * 1024 * 1024L);
     }
 
     public String getDbName() {
@@ -43,6 +63,38 @@ public class AlterDatabaseQuotaStmt extends DdlStmt {
 
     public long getQuota() {
         return quota;
+    }
+
+    public String getUnit() {
+        return unit;
+    }
+
+    private boolean getQuotaFromExpression() throws UserException {
+        Pattern r = Pattern.compile(quotaPattern);
+        Matcher m = r.matcher(quotaExpression);
+        if (m.find( )) {
+            try {
+                quota = Long.parseLong(m.group(1));
+            } catch(NumberFormatException nfe) {
+                throw new AnalysisException("invalid quota:" + m.group(1));
+            }
+            if (quota < 0L) {
+                throw new AnalysisException("Quota must larger than 0");
+            }
+
+            String tmpUnit = m.group(2);
+            if (!Strings.isNullOrEmpty(tmpUnit)) {
+                unit = tmpUnit.toUpperCase();
+            }
+            if (validUnitMultiplier.containsKey(unit)) {
+                quota = quota * validUnitMultiplier.get(unit);
+            } else {
+                throw new AnalysisException("invalid unit:" + tmpUnit);
+            }
+            return true;
+        } else {
+            return false;
+        }
     }
 
     @Override
@@ -57,14 +109,12 @@ public class AlterDatabaseQuotaStmt extends DdlStmt {
             ErrorReport.reportAnalysisException(ErrorCode.ERR_NO_DB_ERROR);
         }
         dbName = ClusterNamespace.getFullName(getClusterName(), dbName);
-        if (quota < 0L) {
-            throw new AnalysisException("Quota must larger than 0");
-        }
+        getQuotaFromExpression();
     }
 
     @Override
     public String toSql() {
-        return "ALTER DATABASE " + dbName + " SET DATA QUOTA " + quota;
+        return "ALTER DATABASE " + dbName + " SET DATA QUOTA " + quotaExpression;
     }
 
 }

--- a/fe/src/main/java/org/apache/doris/analysis/AlterDatabaseQuotaStmt.java
+++ b/fe/src/main/java/org/apache/doris/analysis/AlterDatabaseQuotaStmt.java
@@ -69,7 +69,7 @@ public class AlterDatabaseQuotaStmt extends DdlStmt {
         return unit;
     }
 
-    private boolean getQuotaFromExpression() throws UserException {
+    private void getQuotaFromExpression() throws UserException {
         Pattern r = Pattern.compile(quotaPattern);
         Matcher m = r.matcher(quotaExpression);
         if (m.find( )) {
@@ -91,9 +91,8 @@ public class AlterDatabaseQuotaStmt extends DdlStmt {
             } else {
                 throw new AnalysisException("invalid unit:" + tmpUnit);
             }
-            return true;
         } else {
-            return false;
+            throw new AnalysisException("invalid quota expression:" + quotaExpression);
         }
     }
 

--- a/fe/src/main/java/org/apache/doris/analysis/AlterDatabaseQuotaStmt.java
+++ b/fe/src/main/java/org/apache/doris/analysis/AlterDatabaseQuotaStmt.java
@@ -8,7 +8,7 @@
 //
 //   http://www.apache.org/licenses/LICENSE-2.0
 //
-// Unless required by applicable law or agreed to in writing)
+// Unless required by applicable law or agreed to in writing,
 // software distributed under the License is distributed on an
 // "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 // KIND, either express or implied.  See the License for the

--- a/fe/src/test/java/org/apache/doris/analysis/AlterDatabaseQuotaStmtTest.java
+++ b/fe/src/test/java/org/apache/doris/analysis/AlterDatabaseQuotaStmtTest.java
@@ -1,0 +1,94 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.analysis;
+
+import org.apache.doris.common.AnalysisException;
+import org.apache.doris.common.UserException;
+import org.apache.doris.mysql.privilege.PaloAuth;
+import org.apache.doris.mysql.privilege.PrivPredicate;
+import org.apache.doris.qe.ConnectContext;
+
+import com.google.common.collect.Lists;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+
+import mockit.Mocked;
+import mockit.NonStrictExpectations;
+import mockit.internal.startup.Startup;
+
+public class AlterDatabaseQuotaStmtTest {
+    private Analyzer analyzer;
+
+    @Mocked
+    private PaloAuth auth;
+
+    static {
+        Startup.initializeIfPossible();
+    }
+
+    @Before
+    public void setUp() {
+        analyzer = AccessTestUtil.fetchAdminAnalyzer(false);
+
+        new NonStrictExpectations() {
+            {
+                auth.checkGlobalPriv((ConnectContext) any, (PrivPredicate) any);
+                result = true;
+
+                auth.checkDbPriv((ConnectContext) any, anyString, (PrivPredicate) any);
+                result = true;
+
+                auth.checkTblPriv((ConnectContext) any, anyString, anyString, (PrivPredicate) any);
+                result = true;
+            }
+        };
+    }
+
+    @Test
+    public void testNormal() throws AnalysisException, UserException {
+        AlterDatabaseQuotaStmt stmt = new AlterDatabaseQuotaStmt("testDb", "100mb");
+        stmt.analyze(analyzer);
+        Assert.assertEquals("ALTER DATABASE testCluster:testDb SET DATA QUOTA 100mb",
+                stmt.toSql());
+        Assert.assertEquals(100 * 1024 * 1024, stmt.getQuota());
+
+        AlterDatabaseQuotaStmt stmt_2 = new AlterDatabaseQuotaStmt("testDb", "102400");
+        stmt_2.analyze(analyzer);
+        Assert.assertEquals("ALTER DATABASE testCluster:testDb SET DATA QUOTA 102400",
+                stmt_2.toSql());
+        Assert.assertEquals(102400, stmt_2.getQuota());
+    }
+
+    @Test(expected = AnalysisException.class)
+    public void testInvalidQuota() throws AnalysisException, UserException {
+        AlterDatabaseQuotaStmt stmt = new AlterDatabaseQuotaStmt("testDb", "-100mb");
+        stmt.analyze(analyzer);
+        Assert.fail("No exception throws.");
+    }
+
+    @Test(expected = AnalysisException.class)
+    public void testInvalidUnit() throws AnalysisException, UserException {
+        AlterDatabaseQuotaStmt stmt = new AlterDatabaseQuotaStmt("testDb", "100s");
+        stmt.analyze(analyzer);
+        Assert.fail("No exception throws.");
+    }
+}

--- a/fe/src/test/java/org/apache/doris/analysis/AlterDatabaseQuotaStmtTest.java
+++ b/fe/src/test/java/org/apache/doris/analysis/AlterDatabaseQuotaStmtTest.java
@@ -62,24 +62,60 @@ public class AlterDatabaseQuotaStmtTest {
             }
         };
     }
+    
+    private void testAlterDatabaseQuotaStmt(String dbName, String quotaQuantity, long quotaSize)
+            throws AnalysisException, UserException {
+        AlterDatabaseQuotaStmt stmt = new AlterDatabaseQuotaStmt(dbName, quotaQuantity);
+        stmt.analyze(analyzer);
+        String expectedSql = "ALTER DATABASE testCluster:testDb SET DATA QUOTA " + quotaQuantity;
+        Assert.assertEquals(expectedSql, stmt.toSql());
+        Assert.assertEquals(quotaSize, stmt.getQuota());
+    }
 
     @Test
     public void testNormal() throws AnalysisException, UserException {
-        AlterDatabaseQuotaStmt stmt = new AlterDatabaseQuotaStmt("testDb", "100mb");
-        stmt.analyze(analyzer);
-        Assert.assertEquals("ALTER DATABASE testCluster:testDb SET DATA QUOTA 100mb",
-                stmt.toSql());
-        Assert.assertEquals(100 * 1024 * 1024, stmt.getQuota());
+        // byte
+        testAlterDatabaseQuotaStmt("testDb", "102400", 102400L);
+        testAlterDatabaseQuotaStmt("testDb", "102400b", 102400L);
 
-        AlterDatabaseQuotaStmt stmt_2 = new AlterDatabaseQuotaStmt("testDb", "102400");
-        stmt_2.analyze(analyzer);
-        Assert.assertEquals("ALTER DATABASE testCluster:testDb SET DATA QUOTA 102400",
-                stmt_2.toSql());
-        Assert.assertEquals(102400, stmt_2.getQuota());
+        // kb
+        testAlterDatabaseQuotaStmt("testDb", "100kb", 100L * 1024);
+        testAlterDatabaseQuotaStmt("testDb", "100Kb", 100L * 1024);
+        testAlterDatabaseQuotaStmt("testDb", "100KB", 100L * 1024);
+        testAlterDatabaseQuotaStmt("testDb", "100K", 100L * 1024);
+        testAlterDatabaseQuotaStmt("testDb", "100k", 100L * 1024);
+
+        // mb
+        testAlterDatabaseQuotaStmt("testDb", "100mb", 100L * 1024 * 1024);
+        testAlterDatabaseQuotaStmt("testDb", "100Mb", 100L * 1024 * 1024);
+        testAlterDatabaseQuotaStmt("testDb", "100MB", 100L * 1024 * 1024);
+        testAlterDatabaseQuotaStmt("testDb", "100M", 100L * 1024 * 1024);
+        testAlterDatabaseQuotaStmt("testDb", "100m", 100L * 1024 * 1024);
+
+        // gb
+        testAlterDatabaseQuotaStmt("testDb", "100gb", 100L * 1024 * 1024 * 1024);
+        testAlterDatabaseQuotaStmt("testDb", "100Gb", 100L * 1024 * 1024 * 1024);
+        testAlterDatabaseQuotaStmt("testDb", "100GB", 100L * 1024 * 1024 * 1024);
+        testAlterDatabaseQuotaStmt("testDb", "100G", 100L * 1024 * 1024 * 1024);
+        testAlterDatabaseQuotaStmt("testDb", "100g", 100L * 1024 * 1024 * 1024);
+
+        // tb
+        testAlterDatabaseQuotaStmt("testDb", "100tb", 100L * 1024 * 1024 * 1024 * 1024);
+        testAlterDatabaseQuotaStmt("testDb", "100Tb", 100L * 1024 * 1024 * 1024 * 1024);
+        testAlterDatabaseQuotaStmt("testDb", "100TB", 100L * 1024 * 1024 * 1024 * 1024);
+        testAlterDatabaseQuotaStmt("testDb", "100T", 100L * 1024 * 1024 * 1024 * 1024);
+        testAlterDatabaseQuotaStmt("testDb", "100t", 100L * 1024 * 1024 * 1024 * 1024);
+
+        // tb
+        testAlterDatabaseQuotaStmt("testDb", "100pb", 100L * 1024 * 1024 * 1024 * 1024 * 1024);
+        testAlterDatabaseQuotaStmt("testDb", "100Pb", 100L * 1024 * 1024 * 1024 * 1024 * 1024);
+        testAlterDatabaseQuotaStmt("testDb", "100PB", 100L * 1024 * 1024 * 1024 * 1024 * 1024);
+        testAlterDatabaseQuotaStmt("testDb", "100P", 100L * 1024 * 1024 * 1024 * 1024 * 1024);
+        testAlterDatabaseQuotaStmt("testDb", "100p", 100L * 1024 * 1024 * 1024 * 1024 * 1024);
     }
 
     @Test(expected = AnalysisException.class)
-    public void testInvalidQuota() throws AnalysisException, UserException {
+    public void testMinusQuota() throws AnalysisException, UserException {
         AlterDatabaseQuotaStmt stmt = new AlterDatabaseQuotaStmt("testDb", "-100mb");
         stmt.analyze(analyzer);
         Assert.fail("No exception throws.");
@@ -87,7 +123,14 @@ public class AlterDatabaseQuotaStmtTest {
 
     @Test(expected = AnalysisException.class)
     public void testInvalidUnit() throws AnalysisException, UserException {
-        AlterDatabaseQuotaStmt stmt = new AlterDatabaseQuotaStmt("testDb", "100s");
+        AlterDatabaseQuotaStmt stmt = new AlterDatabaseQuotaStmt("testDb", "100invalid_unit");
+        stmt.analyze(analyzer);
+        Assert.fail("No exception throws.");
+    }
+
+    @Test(expected = AnalysisException.class)
+    public void testInvalidQuantity() throws AnalysisException, UserException {
+        AlterDatabaseQuotaStmt stmt = new AlterDatabaseQuotaStmt("testDb", "invalid_100mb_quota");
         stmt.analyze(analyzer);
         Assert.fail("No exception throws.");
     }


### PR DESCRIPTION
Fix the problem of #306.

Originally, we can only set quota in bytes unit. This commit add quota unit:K/KB/M/MB/G/GB/T/TB/P/PB for convenience.