### PR TITLE
Fix fe.conf audit_log_moudles,sys_log_roll_mode,audit_log_roll_mode s…

### DIFF
--- a/conf/fe.conf
+++ b/conf/fe.conf
@@ -34,12 +34,12 @@ edit_log_port = 9010
 
 # Advanced configurations 
 # sys_log_dir = ${DORIS_HOME}/log
-# sys_log_roll_mode = "SIZE-MB-1024"
+# sys_log_roll_mode = SIZE-MB-1024
 # sys_log_roll_num = 10
 # sys_log_verbose_modules = 
 # audit_log_dir = 
-# audit_log_modules = {"slow_query", "query"}
-# audit_log_roll_mode = "TIME-DAY"
+# audit_log_modules = slow_query, query
+# audit_log_roll_mode = TIME-DAY
 # audit_log_roll_num = 10
 # meta_delay_toleration_second = 10
 # qe_max_connection = 1024


### PR DESCRIPTION
I am sorry that i have made a mistake for the last pull request. In fact i just test the FE config.java on my computer locally, and found the problem of fe.conf default values.

1. when i uncomment the `audit_log_modules` variable with value remains the same as source code, i found the value will be parsed like this: `["{"slow_query"",""query}""]
`
![image](https://user-images.githubusercontent.com/7459785/48660083-00d94380-ea97-11e8-8083-998f4396030c.png)
it makes AuditLog can not locate Logger named `audit.slow_query ,audit.query
`
only when i change the audit_log_modules setting like this: `audit_log_modules = slow_query, query`, can the value be parsed in the right way:

![image](https://user-images.githubusercontent.com/7459785/48660148-d6d45100-ea97-11e8-85c8-cf1288f5345c.png)


2. The problem of `audit_log_roll_mode, sys_log_roll_mode` is the same as `audit_log_modules`