### PR TITLE
Add path info of replica in catalog

### DIFF
--- a/be/src/agent/heartbeat_server.cpp
+++ b/be/src/agent/heartbeat_server.cpp
@@ -73,6 +73,8 @@ void HeartbeatServer::heartbeat(
 
 Status HeartbeatServer::_heartbeat(
         const TMasterInfo& master_info) {
+    
+    std::lock_guard<std::mutex> lk(_hb_mtx);
 
     if (master_info.__isset.backend_ip) {
         if (master_info.backend_ip != BackendOptions::get_localhost()) {
@@ -143,8 +145,7 @@ Status HeartbeatServer::_heartbeat(
 
     if (need_report) {
         LOG(INFO) << "Master FE is changed or restarted. report tablet and disk info immediately";
-        std::unique_lock<std::mutex> lk(OLAPEngine::get_instance()->report_mtx);
-        OLAPEngine::get_instance()->report_cv.notify_all();
+        _olap_engine->report_notify(true);
     }
 
     return Status::OK;

--- a/be/src/agent/heartbeat_server.h
+++ b/be/src/agent/heartbeat_server.h
@@ -18,6 +18,8 @@
 #ifndef DORIS_BE_SRC_AGENT_HEARTBEAT_SERVER_H
 #define DORIS_BE_SRC_AGENT_HEARTBEAT_SERVER_H
 
+#include <mutex>
+
 #include "thrift/transport/TTransportUtils.h"
 
 #include "agent/status.h"
@@ -48,14 +50,18 @@ public:
     // Output parameters:
     // * heartbeat_result: The result of heartbeat set
     virtual void heartbeat(THeartbeatResult& heartbeat_result, const TMasterInfo& master_info);
-private:
 
+private:
     Status _heartbeat(
         const TMasterInfo& master_info);
 
-    TMasterInfo* _master_info;
     OLAPEngine* _olap_engine;
+
+    // mutex to protect master_info and _epoch
+    std::mutex _hb_mtx;
+    TMasterInfo* _master_info;
     int64_t _epoch;
+
     DISALLOW_COPY_AND_ASSIGN(HeartbeatServer);
 };  // class HeartBeatServer
 

--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -1852,12 +1852,8 @@ void* TaskWorkerPool::_report_disk_state_worker_thread_callback(void* arg_this) 
 
 #ifndef BE_TEST
         // wait for notifying until timeout
-        std::unique_lock<std::mutex> lk(OLAPEngine::get_instance()->report_mtx);
-        auto cv_status = OLAPEngine::get_instance()->report_cv.wait_for(lk, 
-                std::chrono::seconds(config::report_disk_state_interval_seconds));
-        if (cv_status == std::cv_status::no_timeout) {
-            OLAPEngine::get_instance()->is_report_disk_state_already = true;
-        }
+        OLAPEngine::get_instance()->wait_for_report_notify(
+                config::report_disk_state_interval_seconds, false);
     }
 #endif
 
@@ -1893,12 +1889,8 @@ void* TaskWorkerPool::_report_olap_table_worker_thread_callback(void* arg_this) 
                              report_all_tablets_info_status);
 #ifndef BE_TEST
             // wait for notifying until timeout
-            std::unique_lock<std::mutex> lk(OLAPEngine::get_instance()->report_mtx);
-            auto cv_status = OLAPEngine::get_instance()->report_cv.wait_for(lk,
-                    std::chrono::seconds(config::report_olap_table_interval_seconds));
-            if (cv_status == std::cv_status::no_timeout) {
-                OLAPEngine::get_instance()->is_report_olap_table_already =  true;
-            }
+            OLAPEngine::get_instance()->wait_for_report_notify(
+                    config::report_olap_table_interval_seconds, true);
             continue;
 #else
             return (void*)0;
@@ -1917,12 +1909,8 @@ void* TaskWorkerPool::_report_olap_table_worker_thread_callback(void* arg_this) 
 
 #ifndef BE_TEST
         // wait for notifying until timeout
-        std::unique_lock<std::mutex> lk(OLAPEngine::get_instance()->report_mtx);
-        auto cv_status = OLAPEngine::get_instance()->report_cv.wait_for(lk,
-                std::chrono::seconds(config::report_olap_table_interval_seconds));
-        if (cv_status == std::cv_status::no_timeout) {
-            OLAPEngine::get_instance()->is_report_olap_table_already =  true;
-        }
+        OLAPEngine::get_instance()->wait_for_report_notify(
+                config::report_olap_table_interval_seconds, true);
     }
 #endif
 

--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -19,6 +19,7 @@
 #include <pthread.h>
 #include <sys/stat.h>
 #include <atomic>
+#include <chrono>
 #include <csignal>
 #include <ctime>
 #include <fstream>
@@ -27,6 +28,7 @@
 #include <sstream>
 #include <string>
 #include <sys/stat.h>
+
 #include "boost/filesystem.hpp"
 #include "boost/lexical_cast.hpp"
 #include "agent/pusher.h"
@@ -80,8 +82,6 @@ map<TTaskType::type, map<string, uint32_t>> TaskWorkerPool::_s_running_task_user
 map<TTaskType::type, map<string, uint32_t>> TaskWorkerPool::_s_total_task_user_count;
 map<TTaskType::type, uint32_t> TaskWorkerPool::_s_total_task_count;
 FrontendServiceClientCache TaskWorkerPool::_master_service_client_cache;
-std::mutex TaskWorkerPool::_disk_broken_lock;
-std::chrono::seconds TaskWorkerPool::_wait_duration;
 
 TaskWorkerPool::TaskWorkerPool(
         const TaskWorkerType task_worker_type,
@@ -167,12 +167,10 @@ void TaskWorkerPool::start() {
         _callback_function = _report_task_worker_thread_callback;
         break;
     case TaskWorkerType::REPORT_DISK_STATE:
-        _wait_duration = std::chrono::seconds(config::report_disk_state_interval_seconds);
         _worker_count = REPORT_DISK_STATE_WORKER_COUNT;
         _callback_function = _report_disk_state_worker_thread_callback;
         break;
     case TaskWorkerType::REPORT_OLAP_TABLE:
-        _wait_duration = std::chrono::seconds(config::report_disk_state_interval_seconds);
         _worker_count = REPORT_OLAP_TABLE_WORKER_COUNT;
         _callback_function = _report_olap_table_worker_thread_callback;
         break;
@@ -1825,15 +1823,14 @@ void* TaskWorkerPool::_report_disk_state_worker_thread_callback(void* arg_this) 
             continue;
         }
 #endif
-
         vector<RootPathInfo> root_paths_info;
-
         worker_pool_this->_env->olap_engine()->get_all_root_path_info(&root_paths_info);
 
         map<string, TDisk> disks;
         for (auto root_path_info : root_paths_info) {
             TDisk disk;
             disk.__set_root_path(root_path_info.path);
+            disk.__set_path_hash(root_path_info.path_hash);
             disk.__set_disk_total_capacity(static_cast<double>(root_path_info.capacity));
             disk.__set_data_used_capacity(static_cast<double>(root_path_info.data_used_capacity));
             disk.__set_disk_available_capacity(static_cast<double>(root_path_info.available));
@@ -1854,15 +1851,12 @@ void* TaskWorkerPool::_report_disk_state_worker_thread_callback(void* arg_this) 
         }
 
 #ifndef BE_TEST
-        {
-            // wait disk_broken_cv awaken
-            // if awaken, set is_report_disk_state_already to true, it will not notify again
-            // if overtime, while will go to next cycle
-            std::unique_lock<std::mutex> lk(_disk_broken_lock);
-            auto cv_status = OLAPEngine::get_instance()->disk_broken_cv.wait_for(lk, _wait_duration);
-            if (cv_status == std::cv_status::no_timeout) {
-                OLAPEngine::get_instance()->is_report_disk_state_already = true;
-            }
+        // wait for notifying until timeout
+        std::unique_lock<std::mutex> lk(OLAPEngine::get_instance()->report_mtx);
+        auto cv_status = OLAPEngine::get_instance()->report_cv.wait_for(lk, 
+                std::chrono::seconds(config::report_disk_state_interval_seconds));
+        if (cv_status == std::cv_status::no_timeout) {
+            OLAPEngine::get_instance()->is_report_disk_state_already = true;
         }
     }
 #endif
@@ -1889,7 +1883,6 @@ void* TaskWorkerPool::_report_olap_table_worker_thread_callback(void* arg_this) 
             continue;
         }
 #endif
-
         request.tablets.clear();
 
         request.__set_report_version(_s_report_version);
@@ -1899,11 +1892,10 @@ void* TaskWorkerPool::_report_olap_table_worker_thread_callback(void* arg_this) 
             OLAP_LOG_WARNING("report get all tablets info failed. status: %d",
                              report_all_tablets_info_status);
 #ifndef BE_TEST
-            // wait disk_broken_cv awaken
-            // if awaken, set is_report_olap_table_already to true, it will not notify again
-            // if overtime, while will go to next cycle
-            std::unique_lock<std::mutex> lk(_disk_broken_lock);
-            auto cv_status = OLAPEngine::get_instance()->disk_broken_cv.wait_for(lk, _wait_duration);
+            // wait for notifying until timeout
+            std::unique_lock<std::mutex> lk(OLAPEngine::get_instance()->report_mtx);
+            auto cv_status = OLAPEngine::get_instance()->report_cv.wait_for(lk,
+                    std::chrono::seconds(config::report_olap_table_interval_seconds));
             if (cv_status == std::cv_status::no_timeout) {
                 OLAPEngine::get_instance()->is_report_olap_table_already =  true;
             }
@@ -1924,11 +1916,10 @@ void* TaskWorkerPool::_report_olap_table_worker_thread_callback(void* arg_this) 
         }
 
 #ifndef BE_TEST
-        // wait disk_broken_cv awaken
-        // if awaken, set is_report_olap_table_already to true, it will not notify again
-        // if overtime, while will go to next cycle
-        std::unique_lock<std::mutex> lk(_disk_broken_lock);
-        auto cv_status = OLAPEngine::get_instance()->disk_broken_cv.wait_for(lk, _wait_duration);
+        // wait for notifying until timeout
+        std::unique_lock<std::mutex> lk(OLAPEngine::get_instance()->report_mtx);
+        auto cv_status = OLAPEngine::get_instance()->report_cv.wait_for(lk,
+                std::chrono::seconds(config::report_olap_table_interval_seconds));
         if (cv_status == std::cv_status::no_timeout) {
             OLAPEngine::get_instance()->is_report_olap_table_already =  true;
         }

--- a/be/src/agent/task_worker_pool.h
+++ b/be/src/agent/task_worker_pool.h
@@ -177,9 +177,6 @@ private:
     static Mutex _s_running_task_user_count_lock;
     static FrontendServiceClientCache _master_service_client_cache;
 
-    static std::mutex _disk_broken_lock;
-    static std::chrono::seconds _wait_duration;
-
     DISALLOW_COPY_AND_ASSIGN(TaskWorkerPool);
 };  // class TaskWorkerPool
 }  // namespace doris

--- a/be/src/olap/olap_engine.h
+++ b/be/src/olap/olap_engine.h
@@ -57,6 +57,7 @@ struct RootPathInfo {
             is_used(false) { }
 
     std::string path;
+    int64_t path_hash;
     int64_t capacity;                  // 总空间，单位字节
     int64_t available;                 // 可用空间，单位字节
     int64_t data_used_capacity;
@@ -206,7 +207,8 @@ public:
     // 清理trash和snapshot文件，返回清理后的磁盘使用量
     OLAPStatus start_trash_sweep(double *usage);
 
-    std::condition_variable disk_broken_cv;
+    std::mutex report_mtx;
+    std::condition_variable report_cv;
     std::atomic_bool is_report_disk_state_already;
     std::atomic_bool is_report_olap_table_already;
 

--- a/be/src/olap/olap_engine.h
+++ b/be/src/olap/olap_engine.h
@@ -207,11 +207,6 @@ public:
     // 清理trash和snapshot文件，返回清理后的磁盘使用量
     OLAPStatus start_trash_sweep(double *usage);
 
-    std::mutex report_mtx;
-    std::condition_variable report_cv;
-    std::atomic_bool is_report_disk_state_already;
-    std::atomic_bool is_report_olap_table_already;
-
     template<bool include_unused = false>
     std::vector<OlapStore*> get_stores();
     Status set_cluster_id(int32_t cluster_id);
@@ -358,6 +353,21 @@ public:
     OLAPStatus push(
         const TPushReq& request,
         std::vector<TTabletInfo>* tablet_info_vec);
+
+    // call this if you want to trigger a disk and tablet report
+    void report_notify(bool is_all) {
+        is_all ? _report_cv.notify_all() : _report_cv.notify_one();
+    }
+
+    // call this to wait a report notification until timeout
+    void wait_for_report_notify(int64_t timeout_sec, bool is_tablet_report) {
+        std::unique_lock<std::mutex> lk(_report_mtx);
+        auto cv_status = _report_cv.wait_for(lk, std::chrono::seconds(timeout_sec));
+        if (cv_status == std::cv_status::no_timeout) {
+            is_tablet_report ? _is_report_olap_table_already = true : 
+                    _is_report_disk_state_already = true;
+        }
+    }
 
 private:
     OLAPStatus check_all_root_path_cluster_id();
@@ -597,6 +607,12 @@ private:
     std::thread _fd_cache_clean_thread;
 
     static atomic_t _s_request_number;
+
+    // for tablet and disk report
+    std::mutex _report_mtx;
+    std::condition_variable _report_cv;
+    std::atomic_bool _is_report_disk_state_already;
+    std::atomic_bool _is_report_olap_table_already;
 };
 
 }  // namespace doris

--- a/be/src/olap/options.h
+++ b/be/src/olap/options.h
@@ -29,6 +29,7 @@ struct StorePath {
     StorePath(const std::string& path_, int64_t capacity_bytes_)
         : path(path_), capacity_bytes(capacity_bytes_) { }
     std::string path;
+    int64_t path_hash;
     int64_t capacity_bytes;
 };
 

--- a/be/src/olap/options.h
+++ b/be/src/olap/options.h
@@ -29,7 +29,6 @@ struct StorePath {
     StorePath(const std::string& path_, int64_t capacity_bytes_)
         : path(path_), capacity_bytes(capacity_bytes_) { }
     std::string path;
-    int64_t path_hash;
     int64_t capacity_bytes;
 };
 

--- a/be/src/olap/store.cpp
+++ b/be/src/olap/store.cpp
@@ -277,8 +277,7 @@ Status OlapStore::_init_file_system() {
 
 Status OlapStore::_init_meta() {
     // init path hash
-    PathHash path_hash;
-    _path_hash = path_hash(BackendOptions::get_localhost(), _path);
+    _path_hash = hash_of_path(BackendOptions::get_localhost(), _path);
     LOG(INFO) << "get hash of path: " << _path
               << ": " << _path_hash;
 

--- a/be/src/olap/store.h
+++ b/be/src/olap/store.h
@@ -42,12 +42,14 @@ public:
     Status load();
 
     const std::string& path() const { return _path; }
+    const int64_t path_hash() const { return _path_hash; }
     bool is_used() const { return _is_used; }
     void set_is_used(bool is_used) { _is_used = is_used; }
     int32_t cluster_id() const { return _cluster_id; }
     RootPathInfo to_root_path_info() {
         RootPathInfo info;
         info.path = _path;
+        info.path_hash = _path_hash;
         info.is_used = _is_used;
         info.capacity = _capacity_bytes;
         return info;
@@ -105,6 +107,7 @@ private:
     friend class OLAPEngine;
     
     std::string _path;
+    int64_t _path_hash;
     int32_t _cluster_id;
     uint32_t _rand_seed;
 

--- a/be/src/util/CMakeLists.txt
+++ b/be/src/util/CMakeLists.txt
@@ -71,6 +71,7 @@ add_library(Util STATIC
   core_local.cpp
   uid_util.cpp
   aes_util.cpp
+  string_util.cpp
 )
 
 #ADD_BE_TEST(integer-array-test)

--- a/be/src/util/string_util.cpp
+++ b/be/src/util/string_util.cpp
@@ -1,0 +1,36 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "util/string_util.h"
+
+namespace doris {
+
+std::size_t hash_of_path(const std::string& identifier, const std::string& path) {
+    std::size_t hash = std::hash<std::string>()(identifier);
+    std::vector<std::string> path_parts;
+    boost::split(path_parts, path, boost::is_any_of("/"));
+    for (auto& part : path_parts) {
+        if (part.empty()) {
+            continue;
+        }
+
+        boost::hash_combine<std::string>(hash, part);
+    }
+    return hash;
+}
+
+} // end of namespace

--- a/be/src/util/string_util.h
+++ b/be/src/util/string_util.h
@@ -22,8 +22,10 @@
 #include <string>
 #include <unordered_set>
 #include <unordered_map>
+#include <vector>
 
 #include <boost/algorithm/string/case_conv.hpp> // to_lower_copy
+#include <boost/functional/hash.hpp>
 
 namespace doris {
 
@@ -54,6 +56,23 @@ public:
             return lhs.size() < rhs.size();
         }
         return cmp < 0;
+    }
+};
+
+struct PathHash {
+public:
+    std::size_t operator()(const std::string& identifier, const std::string& path) const {
+        std::size_t hash = std::hash<std::string>()(identifier);
+        std::vector<std::string> path_parts;
+        boost::split(path_parts, path, boost::is_any_of("/"));
+        for (std::string part : path_parts) {
+            if (part.empty()) {
+                continue;
+            }
+
+            boost::hash_combine<std::string>(hash, part);
+        }
+        return hash;
     }
 };
 

--- a/be/src/util/string_util.h
+++ b/be/src/util/string_util.h
@@ -66,7 +66,7 @@ public:
         std::size_t hash = std::hash<std::string>()(identifier);
         std::vector<std::string> path_parts;
         boost::split(path_parts, path, boost::is_any_of("/"));
-        for (std::string part : path_parts) {
+        for (auto& part : path_parts) {
             if (part.empty()) {
                 continue;
             }

--- a/be/src/util/string_util.h
+++ b/be/src/util/string_util.h
@@ -24,6 +24,7 @@
 #include <unordered_map>
 #include <vector>
 
+#include <boost/algorithm/string.hpp>
 #include <boost/algorithm/string/case_conv.hpp> // to_lower_copy
 #include <boost/functional/hash.hpp>
 

--- a/be/src/util/string_util.h
+++ b/be/src/util/string_util.h
@@ -60,22 +60,7 @@ public:
     }
 };
 
-struct PathHash {
-public:
-    std::size_t operator()(const std::string& identifier, const std::string& path) const {
-        std::size_t hash = std::hash<std::string>()(identifier);
-        std::vector<std::string> path_parts;
-        boost::split(path_parts, path, boost::is_any_of("/"));
-        for (auto& part : path_parts) {
-            if (part.empty()) {
-                continue;
-            }
-
-            boost::hash_combine<std::string>(hash, part);
-        }
-        return hash;
-    }
-};
+std::size_t hash_of_path(const std::string& identifier, const std::string& path);
 
 using StringCaseSet = std::set<std::string, StringCaseLess>;
 using StringCaseUnorderedSet = std::unordered_set<std::string, StringCaseHasher, StringCaseEqual>;

--- a/be/test/util/string_util_test.cpp
+++ b/be/test/util/string_util_test.cpp
@@ -70,21 +70,20 @@ TEST_F(StringUtilTest, normal) {
         ASSERT_EQ(0, test_map.count("ab"));
     }
     {
-        PathHash path_hash;
         std::string ip1 = "192.168.1.1";
         std::string ip2 = "192.168.1.2";
-        int64_t hash1 = path_hash(ip1, "/home/disk1/palo2.HDD");
-        int64_t hash2 = path_hash(ip1, "/home/disk1//palo2.HDD/");
-        int64_t hash3 = path_hash(ip1, "home/disk1/palo2.HDD/");
+        int64_t hash1 = hash_of_path(ip1, "/home/disk1/palo2.HDD");
+        int64_t hash2 = hash_of_path(ip1, "/home/disk1//palo2.HDD/");
+        int64_t hash3 = hash_of_path(ip1, "home/disk1/palo2.HDD/");
         ASSERT_EQ(hash1, hash2);
         ASSERT_EQ(hash3, hash2);
 
-        int64_t hash4 = path_hash(ip1, "/home/disk1/palo2.HDD/");
-        int64_t hash5 = path_hash(ip2, "/home/disk1/palo2.HDD/");
+        int64_t hash4 = hash_of_path(ip1, "/home/disk1/palo2.HDD/");
+        int64_t hash5 = hash_of_path(ip2, "/home/disk1/palo2.HDD/");
         ASSERT_NE(hash4, hash5);
 
-        int64_t hash6 = path_hash(ip1, "/");
-        int64_t hash7 = path_hash(ip1, "//");
+        int64_t hash6 = hash_of_path(ip1, "/");
+        int64_t hash7 = hash_of_path(ip1, "//");
         ASSERT_EQ(hash6, hash7);
     }
 }

--- a/be/test/util/string_util_test.cpp
+++ b/be/test/util/string_util_test.cpp
@@ -69,6 +69,24 @@ TEST_F(StringUtilTest, normal) {
         ASSERT_EQ(345, test_map["abcE"]);
         ASSERT_EQ(0, test_map.count("ab"));
     }
+    {
+        PathHash path_hash;
+        std::string ip1 = "192.168.1.1";
+        std::string ip2 = "192.168.1.2";
+        int64_t hash1 = path_hash(ip1, "/home/disk1/palo2.HDD");
+        int64_t hash2 = path_hash(ip1, "/home/disk1//palo2.HDD/");
+        int64_t hash3 = path_hash(ip1, "home/disk1/palo2.HDD/");
+        ASSERT_EQ(hash1, hash2);
+        ASSERT_EQ(hash3, hash2);
+
+        int64_t hash4 = path_hash(ip1, "/home/disk1/palo2.HDD/");
+        int64_t hash5 = path_hash(ip2, "/home/disk1/palo2.HDD/");
+        ASSERT_NE(hash4, hash5);
+
+        int64_t hash6 = path_hash(ip1, "/");
+        int64_t hash7 = path_hash(ip1, "//");
+        ASSERT_EQ(hash6, hash7);
+    }
 }
 
 }

--- a/fe/src/main/java/org/apache/doris/backup/Repository.java
+++ b/fe/src/main/java/org/apache/doris/backup/Repository.java
@@ -17,6 +17,12 @@
 
 package org.apache.doris.backup;
 
+import com.google.common.base.Joiner;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
+import com.google.common.collect.Lists;
+
+import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.doris.backup.Status.ErrCode;
 import org.apache.doris.catalog.BrokerMgr.BrokerAddress;
 import org.apache.doris.catalog.Catalog;
@@ -26,13 +32,6 @@ import org.apache.doris.common.io.Text;
 import org.apache.doris.common.io.Writable;
 import org.apache.doris.common.util.TimeUtils;
 import org.apache.doris.system.Backend;
-
-import com.google.common.base.Joiner;
-import com.google.common.base.Preconditions;
-import com.google.common.base.Strings;
-import com.google.common.collect.Lists;
-
-import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.json.JSONObject;

--- a/fe/src/main/java/org/apache/doris/catalog/DiskInfo.java
+++ b/fe/src/main/java/org/apache/doris/catalog/DiskInfo.java
@@ -39,6 +39,9 @@ public class DiskInfo implements Writable {
     private long diskAvailableCapacityB;
     private DiskState state;
 
+    // path hash is reported be Backend and no need to persist
+    private long pathHash;
+
     private DiskInfo() {
         // for persist
     }
@@ -49,6 +52,7 @@ public class DiskInfo implements Writable {
         this.dataUsedCapacityB = 0;
         this.diskAvailableCapacityB = DEFAULT_CAPACITY_B;
         this.state = DiskState.ONLINE;
+        this.pathHash = -1;
     }
 
     public String getRootPath() {
@@ -88,10 +92,19 @@ public class DiskInfo implements Writable {
         this.state = state;
     }
 
+    public long getPathHash() {
+        return pathHash;
+    }
+
+    public void setPathHash(long pathHash) {
+        this.pathHash = pathHash;
+    }
+
     @Override
     public String toString() {
-        return "DiskInfo [rootPath=" + rootPath + ", totalCapacityB=" + totalCapacityB + ", dataUsedCapacityB="
-                + dataUsedCapacityB + ", diskAvailableCapacityB=" + diskAvailableCapacityB + ", state=" + state + "]";
+        return "DiskInfo [rootPath=" + rootPath + "(" + pathHash + "), totalCapacityB=" + totalCapacityB
+                + ", dataUsedCapacityB=" + dataUsedCapacityB + ", diskAvailableCapacityB="
+                + diskAvailableCapacityB + ", state=" + state + "]";
     }
 
     @Override

--- a/fe/src/main/java/org/apache/doris/catalog/Replica.java
+++ b/fe/src/main/java/org/apache/doris/catalog/Replica.java
@@ -20,7 +20,6 @@ package org.apache.doris.catalog;
 import org.apache.doris.common.FeMetaVersion;
 import org.apache.doris.common.io.Text;
 import org.apache.doris.common.io.Writable;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -67,6 +66,8 @@ public class Replica implements Writable {
     private long lastSuccessVersionHash = 0L;
 
 	private AtomicLong versionCount = new AtomicLong(-1);
+
+    private long pathHash = -1;
     
     public Replica() {
     }
@@ -150,6 +151,15 @@ public class Replica implements Writable {
     public long getLastSuccessVersionHash() {
         return lastSuccessVersionHash;
     }
+
+    public long getPathHash() {
+        return pathHash;
+    }
+
+    public void setPathHash(long pathHash) {
+        this.pathHash = pathHash;
+    }
+
     // only update data size and row num
     public synchronized void updateStat(long dataSize, long rowNum) {
         this.dataSize = dataSize;

--- a/fe/src/main/java/org/apache/doris/catalog/TabletInvertedIndex.java
+++ b/fe/src/main/java/org/apache/doris/catalog/TabletInvertedIndex.java
@@ -17,6 +17,13 @@
 
 package org.apache.doris.catalog;
 
+import com.google.common.base.Preconditions;
+import com.google.common.collect.HashBasedTable;
+import com.google.common.collect.ListMultimap;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Table;
+
 import org.apache.doris.task.RecoverTabletTask;
 import org.apache.doris.thrift.TPartitionVersionInfo;
 import org.apache.doris.thrift.TStorageMedium;
@@ -27,14 +34,6 @@ import org.apache.doris.transaction.PartitionCommitInfo;
 import org.apache.doris.transaction.TableCommitInfo;
 import org.apache.doris.transaction.TransactionState;
 import org.apache.doris.transaction.TransactionStatus;
-
-import com.google.common.base.Preconditions;
-import com.google.common.collect.HashBasedTable;
-import com.google.common.collect.ListMultimap;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
-import com.google.common.collect.Table;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -134,6 +133,13 @@ public class TabletInvertedIndex {
                                     tabletSyncMap.put(tabletMeta.getDbId(), tabletId);
                                 }
                                 
+                                // check and set path
+                                // path info of replica is only saved in Master FE
+                                if (backendTabletInfo.isSetPath_hash() &&
+                                        replica.getPathHash() != backendTabletInfo.getPath_hash()) {
+                                    replica.setPathHash(backendTabletInfo.getPath_hash());
+                                }
+
                                 if (checkNeedRecover(replica, backendTabletInfo.getVersion(),
                                         backendTabletInfo.getVersion_hash())) {
                                     RecoverTabletTask recoverTabletTask = new RecoverTabletTask(backendId, 

--- a/fe/src/main/java/org/apache/doris/common/proc/BackendProcNode.java
+++ b/fe/src/main/java/org/apache/doris/common/proc/BackendProcNode.java
@@ -17,17 +17,19 @@
 
 package org.apache.doris.common.proc;
 
-import org.apache.doris.common.AnalysisException;
-import org.apache.doris.common.Pair;
-import org.apache.doris.common.util.DebugUtil;
-import org.apache.doris.system.Backend;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 
+import org.apache.doris.common.AnalysisException;
+import org.apache.doris.common.Pair;
+import org.apache.doris.common.util.DebugUtil;
+import org.apache.doris.system.Backend;
+
 public class BackendProcNode implements ProcNodeInterface {
     public static final ImmutableList<String> TITLE_NAMES = new ImmutableList.Builder<String>()
-            .add("RootPath").add("TotalCapacity").add("DataUsedCapacity").add("DiskAvailableCapacity").add("State")
+            .add("RootPath").add("TotalCapacity").add("DataUsedCapacity").add("DiskAvailableCapacity")
+            .add("State").add("PathHash")
             .build();
 
     private Backend backend;
@@ -46,7 +48,7 @@ public class BackendProcNode implements ProcNodeInterface {
 
         for (String infoString : backend.getDiskInfosAsString()) {
             String[] infos = infoString.split("\\|");
-            Preconditions.checkState(infos.length == 5);
+            Preconditions.checkState(infos.length == 6);
 
             Pair<Double, String> totalUnitPair = DebugUtil.getByteUint(Long.valueOf(infos[1]));
             Pair<Double, String> dataUsedUnitPair = DebugUtil.getByteUint(Long.valueOf(infos[2]));
@@ -60,7 +62,7 @@ public class BackendProcNode implements ProcNodeInterface {
                     diskAvailableUnitPair.first) + " " + diskAvailableUnitPair.second;
 
             result.addRow(Lists.newArrayList(infos[0], readableTotalCapacity, readableDataUsedCapacity,
-                  readableDiskAvailableCapacity, infos[4]));
+                                             readableDiskAvailableCapacity, infos[4], infos[5]));
         }
 
         long totalCapacityB = backend.getTotalCapacityB();
@@ -77,7 +79,7 @@ public class BackendProcNode implements ProcNodeInterface {
         String readableDiskAvailableCapacity = DebugUtil.DECIMAL_FORMAT_SCALE_3.format(unitPair.first) + " "
                 + unitPair.second;
         result.addRow(Lists.newArrayList("Total", readableTotalCapacity, readableDataUsedCapacity,
-              readableDiskAvailableCapacity, ""));
+                                         readableDiskAvailableCapacity, "", ""));
 
         return result;
     }

--- a/fe/src/main/java/org/apache/doris/common/proc/TabletsProcDir.java
+++ b/fe/src/main/java/org/apache/doris/common/proc/TabletsProcDir.java
@@ -17,18 +17,18 @@
 
 package org.apache.doris.common.proc;
 
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+
 import org.apache.doris.catalog.Catalog;
 import org.apache.doris.catalog.Database;
-import org.apache.doris.catalog.Replica;
 import org.apache.doris.catalog.MaterializedIndex;
+import org.apache.doris.catalog.Replica;
 import org.apache.doris.catalog.Tablet;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.util.ListComparator;
 import org.apache.doris.common.util.TimeUtils;
 import org.apache.doris.system.Backend;
-
-import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableList;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
@@ -46,7 +46,7 @@ public class TabletsProcDir implements ProcDirInterface {
             .add("VersionHash").add("LastSuccessVersion").add("LastSuccessVersionHash")
             .add("LastFailedVersion").add("LastFailedTime").add("DataSize").add("RowCount").add("State")
             .add("LastConsistencyCheckTime").add("CheckVersion").add("CheckVersionHash")
-			.add("VersionCount")
+            .add("VersionCount").add("PathHash")
             .build();
 
     private Database db;
@@ -86,6 +86,7 @@ public class TabletsProcDir implements ProcDirInterface {
                     tabletInfo.add(-1);
                     tabletInfo.add(-1);
                     tabletInfo.add(-1);
+                    tabletInfo.add(-1);
 
                     tabletInfos.add(tabletInfo);
                 } else {
@@ -122,7 +123,8 @@ public class TabletsProcDir implements ProcDirInterface {
                         tabletInfo.add(TimeUtils.longToTimeString(tablet.getLastCheckTime()));
                         tabletInfo.add(tablet.getCheckedVersion());
                         tabletInfo.add(tablet.getCheckedVersionHash());
-						tabletInfo.add(replica.getVersionCount());
+                        tabletInfo.add(replica.getVersionCount());
+                        tabletInfo.add(replica.getPathHash());
 
                         tabletInfos.add(tabletInfo);
                     }

--- a/fe/src/main/java/org/apache/doris/load/Load.java
+++ b/fe/src/main/java/org/apache/doris/load/Load.java
@@ -17,6 +17,15 @@
 
 package org.apache.doris.load;
 
+import com.google.common.base.Joiner;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import com.google.gson.Gson;
+
+import org.apache.commons.lang.StringUtils;
 import org.apache.doris.analysis.BinaryPredicate;
 import org.apache.doris.analysis.CancelLoadStmt;
 import org.apache.doris.analysis.ColumnSeparator;
@@ -86,18 +95,6 @@ import org.apache.doris.transaction.TableCommitInfo;
 import org.apache.doris.transaction.TransactionState;
 import org.apache.doris.transaction.TransactionState.LoadJobSourceType;
 import org.apache.doris.transaction.TransactionStatus;
-
-import com.google.common.base.Joiner;
-import com.google.common.base.Preconditions;
-import com.google.common.base.Strings;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
-import com.google.gson.Gson;
-
-import io.fabric8.kubernetes.api.model.extensions.Job;
-
-import org.apache.commons.lang.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 

--- a/fe/src/test/java/org/apache/doris/common/proc/BackendProcNodeTest.java
+++ b/fe/src/test/java/org/apache/doris/common/proc/BackendProcNodeTest.java
@@ -85,7 +85,7 @@ public class BackendProcNodeTest {
 
         Assert.assertTrue(result.getRows().size() >= 1);
         Assert.assertEquals(Lists.newArrayList("RootPath", "TotalCapacity", "DataUsedCapacity",
-                                               "DiskAvailableCapacity", "State"),
+                                               "DiskAvailableCapacity", "State", "PathHash"),
                             result.getColumnNames());
     }
 

--- a/gensrc/thrift/MasterService.thrift
+++ b/gensrc/thrift/MasterService.thrift
@@ -33,6 +33,7 @@ struct TTabletInfo {
     7: optional Types.TStorageMedium storage_medium
     8: optional list<Types.TTransactionId> transaction_ids
     9: optional i64 version_count
+    10: optional i64 path_hash
 }
 
 struct TFinishTaskRequest {
@@ -62,6 +63,7 @@ struct TDisk {
     3: required Types.TSize data_used_capacity
     4: required bool used
     5: optional Types.TSize disk_available_capacity
+    6: optional i64 path_hash
 }
 
 struct TReportRequest {
@@ -71,6 +73,7 @@ struct TReportRequest {
     4: optional map<Types.TTabletId, TTablet> tablets
     5: optional map<string, TDisk> disks // string root_path
     6: optional bool force_recovery
+    7: optional list<TTablet> tablet_list
 }
 
 struct TMasterResult {

--- a/run-ut.sh
+++ b/run-ut.sh
@@ -149,6 +149,7 @@ ${DORIS_TEST_BINARY_DIR}/util/json_util_test
 ${DORIS_TEST_BINARY_DIR}/util/byte_buffer_test2
 ${DORIS_TEST_BINARY_DIR}/util/uid_util_test
 ${DORIS_TEST_BINARY_DIR}/util/aes_util_test
+${DORIS_TEST_BINARY_DIR}/util/string_util_test
 
 ## Running common Unittest
 ${DORIS_TEST_BINARY_DIR}/common/resource_tls_test


### PR DESCRIPTION
ISSUE #315

Also fix a bug that when calling check_none_row_oriented_table,
store is null, it cannot be used to create table.
Instead, OLAPHeader can be used to get storage type information.