### PR TITLE
Change PaloMetrics' name and Catalog's Id generator

### DIFF
--- a/fe/src/main/java/org/apache/doris/catalog/Catalog.java
+++ b/fe/src/main/java/org/apache/doris/catalog/Catalog.java
@@ -279,9 +279,6 @@ public class Catalog {
     private int masterHttpPort;
     private String masterIp;
 
-    @Deprecated
-    private AtomicLong nextId = new AtomicLong(NEXT_ID_INIT_VALUE);
-    // for now, use this one
     private CatalogIdGenerator idGenerator = new CatalogIdGenerator(NEXT_ID_INIT_VALUE);
 
     private String metaDir;

--- a/fe/src/main/java/org/apache/doris/catalog/CatalogIdGenerator.java
+++ b/fe/src/main/java/org/apache/doris/catalog/CatalogIdGenerator.java
@@ -17,31 +17,23 @@
 
 package org.apache.doris.catalog;
 
-import org.apache.doris.common.io.Writable;
 import org.apache.doris.persist.EditLog;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
-import java.io.DataInput;
-import java.io.DataOutput;
-import java.io.IOException;
 
 // This new Id generator is just same as TransactionIdGenerator.
 // But we can't just use TransactionIdGenerator to replace the old catalog's 'nextId' for compatibility reason.
 // cause they are using different edit log operation type.
-public class CatalogIdGenerator implements Writable {
-    private static final Logger LOG = LogManager.getLogger(CatalogIdGenerator.class);
-
+public class CatalogIdGenerator {
     private static final int BATCH_ID_INTERVAL = 1000;
 
+    // nextId is always less then batchEndId
     private long nextId;
-    // has to set it to an invalid value, then it will be logged when id is firstly increment
-    private long batchEndId = -1;
+    private long batchEndId;
 
     private EditLog editLog;
 
     public CatalogIdGenerator(long initValue) {
-        nextId = initValue;
+        nextId = initValue + 1;
+        batchEndId = initValue;
     }
 
     public void setEditLog(EditLog editLog) {
@@ -50,15 +42,12 @@ public class CatalogIdGenerator implements Writable {
 
     // performance is more quickly
     public synchronized long getNextId() {
-        if (nextId < batchEndId) {
-            ++nextId;
-            LOG.debug("get next id: " + nextId);
-            return nextId;
+        if (nextId + 1 < batchEndId) {
+            return nextId++;
         } else {
             batchEndId = batchEndId + BATCH_ID_INTERVAL;
             editLog.logSaveNextId(batchEndId);
-            ++nextId;
-            return nextId;
+            return nextId++;
         }
     }
 
@@ -73,18 +62,4 @@ public class CatalogIdGenerator implements Writable {
     public long getBatchEndId() {
         return batchEndId;
     }
-
-    @Override
-    public void write(DataOutput out) throws IOException {
-        out.writeLong(batchEndId);
-    }
-
-    @Override
-    public void readFields(DataInput in) throws IOException {
-        long endId = in.readLong();
-        batchEndId = endId;
-        // maybe a little rough
-        nextId = batchEndId;
-    }
-
 }

--- a/fe/src/main/java/org/apache/doris/catalog/CatalogIdGenerator.java
+++ b/fe/src/main/java/org/apache/doris/catalog/CatalogIdGenerator.java
@@ -25,7 +25,6 @@ import org.apache.doris.persist.EditLog;
 public class CatalogIdGenerator {
     private static final int BATCH_ID_INTERVAL = 1000;
 
-    // nextId is always less then batchEndId
     private long nextId;
     private long batchEndId;
 
@@ -42,7 +41,7 @@ public class CatalogIdGenerator {
 
     // performance is more quickly
     public synchronized long getNextId() {
-        if (nextId + 1 < batchEndId) {
+        if (nextId < batchEndId) {
             return nextId++;
         } else {
             batchEndId = batchEndId + BATCH_ID_INTERVAL;

--- a/fe/src/main/java/org/apache/doris/catalog/CatalogIdGenerator.java
+++ b/fe/src/main/java/org/apache/doris/catalog/CatalogIdGenerator.java
@@ -15,61 +15,76 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package org.apache.doris.transaction;
+package org.apache.doris.catalog;
+
+import org.apache.doris.common.io.Writable;
+import org.apache.doris.persist.EditLog;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 
-import org.apache.doris.persist.EditLog;
+// This new Id generator is just same as TransactionIdGenerator.
+// But we can't just use TransactionIdGenerator to replace the old catalog's 'nextId' for compatibility reason.
+// cause they are using different edit log operation type.
+public class CatalogIdGenerator implements Writable {
+    private static final Logger LOG = LogManager.getLogger(CatalogIdGenerator.class);
 
-public class TransactionIDGenerator {
-
-    public static final long NEXT_ID_INIT_VALUE = 1;
     private static final int BATCH_ID_INTERVAL = 1000;
-    
-    private long nextId = NEXT_ID_INIT_VALUE;
+
+    private long nextId;
     // has to set it to an invalid value, then it will be logged when id is firstly increment
     private long batchEndId = -1;
-    
+
     private EditLog editLog;
-    
-    public TransactionIDGenerator() {
+
+    public CatalogIdGenerator(long initValue) {
+        nextId = initValue;
     }
-    
+
     public void setEditLog(EditLog editLog) {
         this.editLog = editLog;
     }
-    
+
     // performance is more quickly
-    public synchronized long getNextTransactionId() {
+    public synchronized long getNextId() {
         if (nextId < batchEndId) {
-            ++ nextId;
+            ++nextId;
+            LOG.debug("get next id: " + nextId);
             return nextId;
         } else {
             batchEndId = batchEndId + BATCH_ID_INTERVAL;
-            editLog.logSaveTransactionId(batchEndId);
-            ++ nextId;
+            editLog.logSaveNextId(batchEndId);
+            ++nextId;
             return nextId;
         }
     }
 
-    public synchronized void initTransactionId(long id) {
+    public synchronized void setId(long id) {
         if (id > batchEndId) {
             batchEndId = id;
             nextId = id;
         }
     }
-    
-    // this two function used to read snapshot or write snapshot
+
+    // just for checkpoint, so no need to synchronize
+    public long getBatchEndId() {
+        return batchEndId;
+    }
+
+    @Override
     public void write(DataOutput out) throws IOException {
         out.writeLong(batchEndId);
     }
 
+    @Override
     public void readFields(DataInput in) throws IOException {
         long endId = in.readLong();
         batchEndId = endId;
         // maybe a little rough
         nextId = batchEndId;
     }
+
 }

--- a/fe/src/main/java/org/apache/doris/metric/CounterMetric.java
+++ b/fe/src/main/java/org/apache/doris/metric/CounterMetric.java
@@ -18,11 +18,13 @@
 package org.apache.doris.metric;
 
 /*
- * Gauge metric is updated every time it is visited
+ * Counter metric can only be increased
  */
-public abstract class PaloGaugeMetric<T> extends PaloMetric<T> {
+public abstract class CounterMetric<T> extends Metric<T> {
 
-    public PaloGaugeMetric(String name, String description) {
-        super(name, MetricType.GAUGE, description);
+    public CounterMetric(String name, String description) {
+        super(name, MetricType.COUNTER, description);
     }
+
+    abstract public void increase(T delta);
 }

--- a/fe/src/main/java/org/apache/doris/metric/DorisMetricRegistry.java
+++ b/fe/src/main/java/org/apache/doris/metric/DorisMetricRegistry.java
@@ -17,23 +17,28 @@
 
 package org.apache.doris.metric;
 
-import org.apache.doris.monitor.jvm.JvmStats;
+import com.google.common.collect.Lists;
 
-import com.codahale.metrics.Histogram;
+import java.util.List;
+import java.util.stream.Collectors;
 
-public abstract class PaloMetricVisitor {
+public class DorisMetricRegistry {
 
-    protected String prefix;
+    private List<Metric> paloMetrics = Lists.newArrayList();
 
-    public PaloMetricVisitor(String prefix) {
-        this.prefix = prefix;
+    public DorisMetricRegistry() {
+
     }
 
-    public abstract String visitJvm(JvmStats jvmStats);
+    public synchronized void addPaloMetrics(Metric paloMetric) {
+        paloMetrics.add(paloMetric);
+    }
 
-    public abstract String visit(PaloMetric metric);
+    public synchronized List<Metric> getPaloMetrics() {
+        return Lists.newArrayList(paloMetrics);
+    }
 
-    public abstract String visitHistogram(String name, Histogram histogram);
-
-    public abstract String getPaloNodeInfo();
+    public synchronized void removeMetrics(String name) {
+        paloMetrics = paloMetrics.stream().filter(m -> !(m.getName().equals(name))).collect(Collectors.toList());
+    }
 }

--- a/fe/src/main/java/org/apache/doris/metric/DoubleCounterMetric.java
+++ b/fe/src/main/java/org/apache/doris/metric/DoubleCounterMetric.java
@@ -17,14 +17,23 @@
 
 package org.apache.doris.metric;
 
-/*
- * Counter metric can only be increased
- */
-public abstract class PaloCounterMetric<T> extends PaloMetric<T> {
+import com.google.common.util.concurrent.AtomicDouble;
 
-    public PaloCounterMetric(String name, String description) {
-        super(name, MetricType.COUNTER, description);
+public class DoubleCounterMetric extends CounterMetric<Double> {
+
+    public DoubleCounterMetric(String name, String description) {
+        super(name, description);
     }
 
-    abstract public void increase(T delta);
+    private AtomicDouble value = new AtomicDouble(0.0);
+
+    @Override
+    public void increase(Double delta) {
+        value.addAndGet(delta);
+    }
+
+    @Override
+    public Double getValue() {
+        return value.get();
+    }
 }

--- a/fe/src/main/java/org/apache/doris/metric/GaugeMetric.java
+++ b/fe/src/main/java/org/apache/doris/metric/GaugeMetric.java
@@ -17,23 +17,12 @@
 
 package org.apache.doris.metric;
 
-import java.util.concurrent.atomic.AtomicLong;
+/*
+ * Gauge metric is updated every time it is visited
+ */
+public abstract class GaugeMetric<T> extends Metric<T> {
 
-public class PaloLongCounterMetric extends PaloCounterMetric<Long> {
-
-    public PaloLongCounterMetric(String name, String description) {
-        super(name, description);
-    }
-
-    private AtomicLong value = new AtomicLong(0L);
-
-    @Override
-    public void increase(Long delta) {
-        value.addAndGet(delta);
-    }
-
-    @Override
-    public Long getValue() {
-        return value.get();
+    public GaugeMetric(String name, String description) {
+        super(name, MetricType.GAUGE, description);
     }
 }

--- a/fe/src/main/java/org/apache/doris/metric/LongCounterMetric.java
+++ b/fe/src/main/java/org/apache/doris/metric/LongCounterMetric.java
@@ -17,23 +17,23 @@
 
 package org.apache.doris.metric;
 
-import com.google.common.util.concurrent.AtomicDouble;
+import java.util.concurrent.atomic.AtomicLong;
 
-public class PaloDoubleCounterMetric extends PaloCounterMetric<Double> {
+public class LongCounterMetric extends CounterMetric<Long> {
 
-    public PaloDoubleCounterMetric(String name, String description) {
+    public LongCounterMetric(String name, String description) {
         super(name, description);
     }
 
-    private AtomicDouble value = new AtomicDouble(0.0);
+    private AtomicLong value = new AtomicLong(0L);
 
     @Override
-    public void increase(Double delta) {
+    public void increase(Long delta) {
         value.addAndGet(delta);
     }
 
     @Override
-    public Double getValue() {
+    public Long getValue() {
         return value.get();
     }
 }

--- a/fe/src/main/java/org/apache/doris/metric/Metric.java
+++ b/fe/src/main/java/org/apache/doris/metric/Metric.java
@@ -21,7 +21,7 @@ import com.google.common.collect.Lists;
 
 import java.util.List;
 
-public abstract class PaloMetric<T> {
+public abstract class Metric<T> {
     public enum MetricType {
         GAUGE, COUNTER
     }
@@ -31,7 +31,7 @@ public abstract class PaloMetric<T> {
     protected List<MetricLabel> labels = Lists.newArrayList();
     protected String description;
 
-    public PaloMetric(String name, MetricType type, String description) {
+    public Metric(String name, MetricType type, String description) {
         this.name = name;
         this.type = type;
         this.description = description;
@@ -49,7 +49,7 @@ public abstract class PaloMetric<T> {
         return description;
     }
 
-    public PaloMetric<T> addLabel(MetricLabel label) {
+    public Metric<T> addLabel(MetricLabel label) {
         if (labels.contains(label)) {
             return this;
         }

--- a/fe/src/main/java/org/apache/doris/metric/MetricVisitor.java
+++ b/fe/src/main/java/org/apache/doris/metric/MetricVisitor.java
@@ -17,28 +17,23 @@
 
 package org.apache.doris.metric;
 
-import com.google.common.collect.Lists;
+import org.apache.doris.monitor.jvm.JvmStats;
 
-import java.util.List;
-import java.util.stream.Collectors;
+import com.codahale.metrics.Histogram;
 
-public class PaloMetricRegistry {
+public abstract class MetricVisitor {
 
-    private List<PaloMetric> paloMetrics = Lists.newArrayList();
+    protected String prefix;
 
-    public PaloMetricRegistry() {
-
+    public MetricVisitor(String prefix) {
+        this.prefix = prefix;
     }
 
-    public synchronized void addPaloMetrics(PaloMetric paloMetric) {
-        paloMetrics.add(paloMetric);
-    }
+    public abstract String visitJvm(JvmStats jvmStats);
 
-    public synchronized List<PaloMetric> getPaloMetrics() {
-        return Lists.newArrayList(paloMetrics);
-    }
+    public abstract String visit(Metric metric);
 
-    public synchronized void removeMetrics(String name) {
-        paloMetrics = paloMetrics.stream().filter(m -> !(m.getName().equals(name))).collect(Collectors.toList());
-    }
+    public abstract String visitHistogram(String name, Histogram histogram);
+
+    public abstract String getPaloNodeInfo();
 }

--- a/fe/src/main/java/org/apache/doris/metric/PrometheusMetricVisitor.java
+++ b/fe/src/main/java/org/apache/doris/metric/PrometheusMetricVisitor.java
@@ -38,7 +38,7 @@ import java.util.stream.Collectors;
  * # TYPE palo_fe_job_load_broker_cost_ms gauge 
  * palo_fe_job{job="load", type="mini", state="pending"} 0
  */
-public class PrometheusMetricVisitor extends PaloMetricVisitor {
+public class PrometheusMetricVisitor extends MetricVisitor {
     // jvm
     private static final String JVM_HEAP_SIZE_BYTES = "jvm_heap_size_bytes";
     private static final String JVM_NON_HEAP_SIZE_BYTES = "jvm_non_heap_size_bytes";
@@ -131,7 +131,7 @@ public class PrometheusMetricVisitor extends PaloMetricVisitor {
     }
 
     @Override
-    public String visit(@SuppressWarnings("rawtypes") PaloMetric metric) {
+    public String visit(@SuppressWarnings("rawtypes") Metric metric) {
         // title
         final String fullName = prefix + "_" + metric.getName();
         StringBuilder sb = new StringBuilder();

--- a/fe/src/main/java/org/apache/doris/persist/EditLog.java
+++ b/fe/src/main/java/org/apache/doris/persist/EditLog.java
@@ -660,7 +660,9 @@ public class EditLog {
         long end = System.currentTimeMillis();
         numTransactions++;
         totalTimeTransactions += (end - start);
-        MetricRepo.HISTO_EDIT_LOG_WRITE_LATENCY.update((end - start));
+        if (MetricRepo.isInit.get()) {
+            MetricRepo.HISTO_EDIT_LOG_WRITE_LATENCY.update((end - start));
+        }
 
         if (LOG.isDebugEnabled()) {
             LOG.debug("nextId = {}, numTransactions = {}, totalTimeTransactions = {}, op = {}",

--- a/fe/src/main/java/org/apache/doris/persist/EditLog.java
+++ b/fe/src/main/java/org/apache/doris/persist/EditLog.java
@@ -57,7 +57,6 @@ import org.apache.doris.qe.SessionVariable;
 import org.apache.doris.system.Backend;
 import org.apache.doris.system.Frontend;
 import org.apache.doris.transaction.TransactionState;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -135,7 +134,7 @@ public class EditLog {
                 case OperationType.OP_SAVE_TRANSACTION_ID: {
                     String idString = ((Text) journal.getData()).toString();
                     long id = Long.parseLong(idString);
-                    catalog.getCurrentGlobalTransactionMgr().getTransactionIDGenerator().initTransactionId(id + 1);
+                    Catalog.getCurrentGlobalTransactionMgr().getTransactionIDGenerator().initTransactionId(id + 1);
                     break;
                 }
                 case OperationType.OP_CREATE_DB: {
@@ -651,7 +650,7 @@ public class EditLog {
             journal.write(op, writable);
         } catch (Exception e) {
             LOG.error("Fatal Error : write stream Exception", e);
-            Runtime.getRuntime().exit(-1);
+            System.exit(-1);
         }
 
         // get a new transactionId
@@ -661,6 +660,7 @@ public class EditLog {
         long end = System.currentTimeMillis();
         numTransactions++;
         totalTimeTransactions += (end - start);
+        MetricRepo.HISTO_EDIT_LOG_WRITE_LATENCY.update((end - start));
 
         if (LOG.isDebugEnabled()) {
             LOG.debug("nextId = {}, numTransactions = {}, totalTimeTransactions = {}, op = {}",

--- a/fe/src/main/java/org/apache/doris/transaction/GlobalTransactionMgr.java
+++ b/fe/src/main/java/org/apache/doris/transaction/GlobalTransactionMgr.java
@@ -85,7 +85,7 @@ public class GlobalTransactionMgr {
     private Map<Long, TransactionState> idToTransactionState;
     private com.google.common.collect.Table<Long, String, Long> dbIdToTxnLabels; 
     private Map<Long, Integer> runningTxnNums;
-    private TransactionIDGenerator idGenerator;
+    private TransactionIdGenerator idGenerator;
     
     private Catalog catalog;
     
@@ -94,7 +94,7 @@ public class GlobalTransactionMgr {
         dbIdToTxnLabels = HashBasedTable.create();  
         runningTxnNums = Maps.newHashMap();
         this.catalog = catalog;
-        this.idGenerator = new TransactionIDGenerator();
+        this.idGenerator = new TransactionIdGenerator();
     }
 
     /**
@@ -1145,7 +1145,7 @@ public class GlobalTransactionMgr {
         return this.idToTransactionState.size();
     }
     
-    public TransactionIDGenerator getTransactionIDGenerator() {
+    public TransactionIdGenerator getTransactionIDGenerator() {
         return this.idGenerator;
     }
     

--- a/fe/src/main/java/org/apache/doris/transaction/TransactionIdGenerator.java
+++ b/fe/src/main/java/org/apache/doris/transaction/TransactionIdGenerator.java
@@ -1,0 +1,75 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.transaction;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+
+import org.apache.doris.persist.EditLog;
+
+public class TransactionIdGenerator {
+
+    public static final long NEXT_ID_INIT_VALUE = 1;
+    private static final int BATCH_ID_INTERVAL = 1000;
+    
+    private long nextId = NEXT_ID_INIT_VALUE;
+    // has to set it to an invalid value, then it will be logged when id is firstly increment
+    private long batchEndId = -1;
+    
+    private EditLog editLog;
+    
+    public TransactionIdGenerator() {
+    }
+    
+    public void setEditLog(EditLog editLog) {
+        this.editLog = editLog;
+    }
+    
+    // performance is more quickly
+    public synchronized long getNextTransactionId() {
+        if (nextId < batchEndId) {
+            ++ nextId;
+            return nextId;
+        } else {
+            batchEndId = batchEndId + BATCH_ID_INTERVAL;
+            editLog.logSaveTransactionId(batchEndId);
+            ++ nextId;
+            return nextId;
+        }
+    }
+
+    public synchronized void initTransactionId(long id) {
+        if (id > batchEndId) {
+            batchEndId = id;
+            nextId = id;
+        }
+    }
+    
+    // this two function used to read snapshot or write snapshot
+    public void write(DataOutput out) throws IOException {
+        out.writeLong(batchEndId);
+    }
+
+    public void readFields(DataInput in) throws IOException {
+        long endId = in.readLong();
+        batchEndId = endId;
+        // maybe a little rough
+        nextId = batchEndId;
+    }
+}

--- a/fe/src/test/java/org/apache/doris/transaction/FakeTransactionIDGenerator.java
+++ b/fe/src/test/java/org/apache/doris/transaction/FakeTransactionIDGenerator.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 import mockit.Mock;
 import mockit.MockUp;
 
-public final class FakeTransactionIDGenerator extends MockUp<TransactionIDGenerator> {
+public final class FakeTransactionIDGenerator extends MockUp<TransactionIdGenerator> {
 
     private long currentId = 1000L;
 


### PR DESCRIPTION
1. Add a new CatalogIdGenerator to replace the old AtomicLong, to avoid too many edit logs.
2. Remove 'Palo' prefix of class PaloMetric.
3. Add a new histogram to monitor write latency of edit log write.

ISSUE: #328 