### PR TITLE
Support for custom build toolchains

### DIFF
--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -408,7 +408,12 @@ message(STATUS "${LINUX_VERSION_LOWER}")
 #     message(FATAL_ERROR "Currently not support system ${LINUX_VERSION}")
 # endif()
 
+if(DEFINED ENV{CLANG_COMPATIBLE_FLAGS})
+    set(CLANG_COMPATIBLE_FLAGS $ENV{CLANG_COMPATIBLE_FLAGS})
+endif()
+
 message(STATUS "CLANG_BASE_FLAGS: ${CLANG_BASE_FLAGS}")
+message(STATUS "CLANG_COMPATIBLE_FLAGS: ${CLANG_COMPATIBLE_FLAGS}")
 
 set(CLANG_INCLUDE_FLAGS
     "-I${LLVM_HOME}/include"
@@ -419,6 +424,7 @@ set(CLANG_INCLUDE_FLAGS
     "-I${THIRDPARTY_DIR}/include/event/"
     "-I${GPERFTOOLS_HOME}/include"
     ${CLANG_BASE_FLAGS}
+    ${CLANG_COMPATIBLE_FLAGS}
 )
 
 # Set include dirs

--- a/env.sh
+++ b/env.sh
@@ -80,3 +80,11 @@ if [[ ! "$(printf '%s\n' "$required_ver" "$gcc_ver" | sort -V | head -n1)" = "$r
     exit 1
 fi
 
+# export include path
+ABS_DORIS_GCC_HOME=`readlink -f $DORIS_GCC_HOME`
+INCLUDE_PATH_1=`locate cstddef | grep $ABS_DORIS_GCC_HOME | tail -1 | xargs dirname`
+INCLUDE_PATH_TMP=`locate c++config.h | grep $ABS_DORIS_GCC_HOME | grep -v "32\/bits" | tail -1 | xargs dirname`
+INCLUDE_PATH_2=${INCLUDE_PATH_TMP%/bits}
+export CPLUS_INCLUDE_PATH=$INCLUDE_PATH_1:$INCLUDE_PATH_2
+
+

--- a/env.sh
+++ b/env.sh
@@ -80,11 +80,8 @@ if [[ ! "$(printf '%s\n' "$required_ver" "$gcc_ver" | sort -V | head -n1)" = "$r
     exit 1
 fi
 
-# export include path
-ABS_DORIS_GCC_HOME=`readlink -f $DORIS_GCC_HOME`
-INCLUDE_PATH_1=`locate cstddef | grep $ABS_DORIS_GCC_HOME | tail -1 | xargs dirname`
-INCLUDE_PATH_TMP=`locate c++config.h | grep $ABS_DORIS_GCC_HOME | grep -v "32\/bits" | tail -1 | xargs dirname`
-INCLUDE_PATH_2=${INCLUDE_PATH_TMP%/bits}
-export CPLUS_INCLUDE_PATH=$INCLUDE_PATH_1:$INCLUDE_PATH_2
+# export CLANG COMPATIBLE FLAGS
+export CLANG_COMPATIBLE_FLAGS=`echo | ${DORIS_GCC_HOME}/bin/gcc -Wp,-v -xc++ - -fsyntax-only 2>&1 \
+                | grep -E '^\s+/' | awk '{print "-I" $1}' | tr '\n' ' '`
 
 


### PR DESCRIPTION
ISSUE #297

Locate the header file path of DORIS_GCC_HOME, add them to the CPLUS_INCLUDE_PATH environment variable.
So clang can find it.