### PR TITLE
Fix add Rollup bug

### DIFF
--- a/be/src/olap/rowset.h
+++ b/be/src/olap/rowset.h
@@ -65,6 +65,9 @@ public:
         return _column_statistics.size() != 0;
     }
 
+    OLAPStatus add_column_statistics_for_linked_schema_change(
+        const std::vector<std::pair<WrapperField*, WrapperField*>>& column_statistic_fields);
+
     OLAPStatus add_column_statistics(
         const std::vector<std::pair<WrapperField*, WrapperField*>>& column_statistic_fields);
 

--- a/be/src/olap/schema_change.cpp
+++ b/be/src/olap/schema_change.cpp
@@ -715,7 +715,7 @@ bool LinkedSchemaChange::process(ColumnData* olap_data, Rowset* new_rowset) {
 
     new_rowset->set_empty(olap_data->empty());
     new_rowset->set_num_segments(olap_data->olap_index()->num_segments());
-    new_rowset->add_column_statistics(olap_data->olap_index()->get_column_statistics());
+    new_rowset->add_column_statistics_for_linked_schema_change(olap_data->olap_index()->get_column_statistics());
 
     if (OLAP_SUCCESS != new_rowset->load()) {
         OLAP_LOG_WARNING("fail to reload index. [table='%s' version='%d-%d']",


### PR DESCRIPTION
Fix [332](https://github.com/apache/incubator-doris/issues/332)

1 when add_column_statistics, we should use use _table->num_key_fields(), not column_statistic_fields.size(), as  rollup table num_key_fields will less than base table column_statistic_fields.size()

2 when adding rollup table, the base table column_statistic_fields maybe empty.