### PR TITLE
Fix compile issue of thirdparty library

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -36,7 +36,7 @@ export DORIS_HOME=${ROOT}
 . ${DORIS_HOME}/env.sh
 
 # build thirdparty libraries if necessary
-if [[ ! -d ${DORIS_THIRDPARTY}/installed ]]; then
+if [[ ! -f ${DORIS_THIRDPARTY}/installed/lib/librdkafka.a ]]; then
     echo "Thirdparty libraries need to be build ..."
     ${DORIS_THIRDPARTY}/build-thirdparty.sh
 fi

--- a/build.sh
+++ b/build.sh
@@ -35,6 +35,18 @@ export DORIS_HOME=${ROOT}
 
 . ${DORIS_HOME}/env.sh
 
+# build thirdparty libraries if necessary
+if [[ ! -d ${DORIS_THIRDPARTY}/installed ]]; then
+    echo "Thirdparty libraries need to be build ..."
+    ${DORIS_THIRDPARTY}/build-thirdparty.sh
+fi
+
+# check java home
+if [[ -z ${JAVA_HOME} ]]; then
+    echo "Warning: JAVA_HOME is not set, use thirdparty/installed/jdk1.8.0_131"
+    export JAVA_HOME=${DORIS_THIRDPARTY}/installed/jdk1.8.0_131
+fi
+
 PARALLEL=$[$(nproc)/4+1]
 
 # Check args

--- a/env.sh
+++ b/env.sh
@@ -1,4 +1,3 @@
-#!/usr/bin/env bash
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -32,23 +31,14 @@ if [[ -z ${DORIS_THIRDPARTY} ]]; then
     export DORIS_THIRDPARTY=${DORIS_HOME}/thirdparty
 fi
 
-# build thirdparty libraries if necessary
-if [[ ! -d ${DORIS_THIRDPARTY}/installed ]]; then
-    echo "Thirdparty libraries need to be build ..."
-    ${DORIS_THIRDPARTY}/build-thirdparty.sh
-fi
-
 # check java version
-if [[ -z ${JAVA_HOME} ]]; then
-    echo "Error: JAVA_HOME is not set, use thirdparty/installed/jdk1.8.0_131"
-    export JAVA_HOME=${DORIS_THIRDPARTY}/installed/jdk1.8.0_131
-fi
-
-export JAVA=${JAVA_HOME}/bin/java
-JAVA_VER=$(${JAVA} -version 2>&1 | sed 's/.* version "\(.*\)\.\(.*\)\..*"/\1\2/; 1q' | cut -f1 -d " ")
-if [[ $JAVA_VER -lt 18 ]]; then
-    echo "Error: require JAVA with JDK version at least 1.8"
-    exit 1
+if [[ ! -z ${JAVA_HOME} ]]; then
+    export JAVA=${JAVA_HOME}/bin/java
+    JAVA_VER=$(${JAVA} -version 2>&1 | sed 's/.* version "\(.*\)\.\(.*\)\..*"/\1\2/; 1q' | cut -f1 -d " ")
+    if [[ $JAVA_VER -lt 18 ]]; then
+        echo "Error: require JAVA with JDK version at least 1.8"
+        return 1
+    fi
 fi
 
 # check maven

--- a/thirdparty/build-thirdparty.sh
+++ b/thirdparty/build-thirdparty.sh
@@ -64,6 +64,7 @@ if [[ -z ${DORIS_GCC_HOME} ]]; then
     export CXX=${DORIS_GCC_HOME}/bin/g++
 else
     echo "DORIS_GCC_HOME environment variable is not set"
+    exit 1
 fi
 
 # prepare installed prefix

--- a/thirdparty/build-thirdparty.sh
+++ b/thirdparty/build-thirdparty.sh
@@ -35,8 +35,8 @@ export DORIS_HOME=$curdir/..
 export TP_DIR=$curdir
 
 # include custom environment variables
-if [[ -f ${DORIS_HOME}/custom_env.sh ]]; then
-    . ${DORIS_HOME}/custom_env.sh
+if [[ -f ${DORIS_HOME}/env.sh ]]; then
+    . ${DORIS_HOME}/env.sh
 fi
 
 if [[ ! -f ${TP_DIR}/download-thirdparty.sh ]]; then
@@ -57,16 +57,17 @@ ${TP_DIR}/download-thirdparty.sh
 
 export LD_LIBRARY_PATH=$TP_DIR/installed/lib:$LD_LIBRARY_PATH
 
-if [ -f ${DORIS_TOOLCHAIN}/gcc730/bin/gcc ]; then
-    GCC_HOME=${DORIS_TOOLCHAIN}/gcc730
-    export CC=${GCC_HOME}/bin/gcc
-    export CPP=${GCC_HOME}/bin/cpp
-    export CXX=${GCC_HOME}/bin/g++
+# set COMPILER
+if [[ -z ${DORIS_GCC_HOME} ]]; then
+    export CC=${DORIS_GCC_HOME}/bin/gcc
+    export CPP=${DORIS_GCC_HOME}/bin/cpp
+    export CXX=${DORIS_GCC_HOME}/bin/g++
 else
-    export CC=gcc
-    export CPP=cpp
-    export CXX=g++
+    echo "DORIS_GCC_HOME environment variable is not set"
 fi
+
+# prepare installed prefix
+mkdir -p ${TP_DIR}/installed
 
 check_prerequest() {
     local CMD=$1
@@ -119,7 +120,6 @@ check_prerequest "libtoolize --version" "libtool"
 #########################
 # build all thirdparties
 #########################
-GCC_VERSION="$($CC -dumpversion)"
 
 CMAKE_CMD=`which cmake`
 

--- a/thirdparty/download-thirdparty.sh
+++ b/thirdparty/download-thirdparty.sh
@@ -47,7 +47,6 @@ fi
 . ${TP_DIR}/vars.sh
 
 mkdir -p ${TP_DIR}/src
-mkdir -p ${TP_DIR}/installed
 
 download() {
     local FILENAME=$1


### PR DESCRIPTION
1.  Fix compile issue when run script in thirdparty directly.
2. Enable continue download and compile when download is interrupted.