### PR TITLE
Fix bug of using symbolic link dir as storage path

### DIFF
--- a/be/src/http/download_action.cpp
+++ b/be/src/http/download_action.cpp
@@ -50,16 +50,16 @@ const std::string TOKEN_PARAMETER = "token";
 
 DownloadAction::DownloadAction(ExecEnv* exec_env, const std::vector<std::string>& allow_dirs) :
     _exec_env(exec_env),
-    _download_type(NORMAL),
-    _allow_paths(allow_dirs) {
-
+    _download_type(NORMAL) {
+    for (auto& dir : allow_dirs) {
+        _allow_paths.emplace_back(std::move(canonical(dir).string()));
+    }
 }
 
 DownloadAction::DownloadAction(ExecEnv* exec_env, const std::string& error_log_root_dir) :
     _exec_env(exec_env),
-    _download_type(ERROR_LOG),
-    _error_log_root_dir(error_log_root_dir) {
-
+    _download_type(ERROR_LOG) {
+    _error_log_root_dir = canonical(error_log_root_dir).string();
 }
 
 void DownloadAction::handle_normal(
@@ -248,7 +248,7 @@ Status DownloadAction::check_path_is_allowed(const std::string& file_path) {
     DCHECK_EQ(_download_type, NORMAL);
     std::string canonical_file_path = canonical(file_path).string();
     for (auto& allow_path : _allow_paths) {
-        if (FileSystemUtil::contain_path(canonical(allow_path).string(), canonical_file_path)) {
+        if (FileSystemUtil::contain_path(allow_path, canonical_file_path)) {
             return Status::OK;
         }
     }
@@ -259,7 +259,7 @@ Status DownloadAction::check_path_is_allowed(const std::string& file_path) {
 Status DownloadAction::check_log_path_is_allowed(const std::string& file_path) {
     DCHECK_EQ(_download_type, ERROR_LOG);
     std::string canonical_file_path = canonical(file_path).string();
-    if (FileSystemUtil::contain_path(canonical(_error_log_root_dir).string(), canonical_file_path)) {
+    if (FileSystemUtil::contain_path(_error_log_root_dir, canonical_file_path)) {
         return Status::OK;
     }
 

--- a/be/src/http/download_action.cpp
+++ b/be/src/http/download_action.cpp
@@ -52,7 +52,7 @@ DownloadAction::DownloadAction(ExecEnv* exec_env, const std::vector<std::string>
     _exec_env(exec_env),
     _download_type(NORMAL) {
     for (auto& dir : allow_dirs) {
-        _allow_paths.emplace_back(std::move(canonical(dir).string()));
+        _allow_paths.emplace_back(canonical(dir).string());
     }
 }
 

--- a/be/src/http/download_action.cpp
+++ b/be/src/http/download_action.cpp
@@ -26,6 +26,7 @@
 #include <sstream>
 
 #include "boost/lexical_cast.hpp"
+#include <boost/filesystem.hpp>
 
 #include "agent/cgroups_mgr.h"
 #include "http/http_channel.h"
@@ -37,6 +38,8 @@
 #include "util/file_utils.h"
 #include "util/filesystem_util.h"
 #include "runtime/exec_env.h"
+
+using boost::filesystem::canonical;
 
 namespace doris {
 
@@ -243,8 +246,9 @@ Status DownloadAction::check_token(HttpRequest *req) {
 
 Status DownloadAction::check_path_is_allowed(const std::string& file_path) {
     DCHECK_EQ(_download_type, NORMAL);
+    std::string canonical_file_path = canonical(file_path).string();
     for (auto& allow_path : _allow_paths) {
-        if (FileSystemUtil::contain_path(allow_path, file_path)) {
+        if (FileSystemUtil::contain_path(canonical(allow_path).string(), canonical_file_path)) {
             return Status::OK;
         }
     }
@@ -254,7 +258,8 @@ Status DownloadAction::check_path_is_allowed(const std::string& file_path) {
 
 Status DownloadAction::check_log_path_is_allowed(const std::string& file_path) {
     DCHECK_EQ(_download_type, ERROR_LOG);
-    if (FileSystemUtil::contain_path(_error_log_root_dir, file_path)) {
+    std::string canonical_file_path = canonical(file_path).string();
+    if (FileSystemUtil::contain_path(canonical(_error_log_root_dir).string(), canonical_file_path)) {
         return Status::OK;
     }
 


### PR DESCRIPTION
There is a bug to use symbolic link directory as storage root path.
It is a problem that whether the path is canonical