### PR TITLE
Fix wrong query result when column value is Null

### DIFF
--- a/be/src/exec/olap_common.h
+++ b/be/src/exec/olap_common.h
@@ -662,6 +662,8 @@ Status OlapScanKeys::extend_scan_key(ColumnValueRange<T>& range) {
         return Status::OK;
     }
 
+    bool _has_converted = false;
+
     if (range.is_fixed_value_range()) {
         if ((_begin_scan_keys.empty() && range.get_fixed_value_size() > config::doris_max_scan_key_num)
                 || range.get_fixed_value_size() * _begin_scan_keys.size() > config::doris_max_scan_key_num) {
@@ -676,11 +678,13 @@ Status OlapScanKeys::extend_scan_key(ColumnValueRange<T>& range) {
             if (_begin_scan_keys.empty()) {
                 if (range.get_convertible_fixed_value_size() < config::doris_max_scan_key_num) {
                     range.convert_to_fixed_value();
+                    _has_converted = true;
                 }
             } else {
                 if (range.get_convertible_fixed_value_size() * _begin_scan_keys.size()
                         < config::doris_max_scan_key_num) {
                     range.convert_to_fixed_value();
+                    _has_converted = true;
                 }
             }
         }
@@ -698,6 +702,14 @@ Status OlapScanKeys::extend_scan_key(ColumnValueRange<T>& range) {
                 _begin_scan_keys.back().add_value(cast_to_string(*iter));
                 _end_scan_keys.emplace_back();
                 _end_scan_keys.back().add_value(cast_to_string(*iter));
+            }
+
+            //when convert to fixed values, we should add null value
+            if (_has_converted) {
+                 _begin_scan_keys.emplace_back();
+                 _begin_scan_keys.back().add_null();
+                 _end_scan_keys.emplace_back();
+                 _end_scan_keys.back().add_null();
             }
         } // 3.1.2 produces the Cartesian product of ScanKey and fixed_value
         else {
@@ -722,6 +734,14 @@ Status OlapScanKeys::extend_scan_key(ColumnValueRange<T>& range) {
                         _end_scan_keys.push_back(end_base_key_range);
                         _end_scan_keys.back().add_value(cast_to_string(*iter));
                     }
+                }
+
+                //when convert to fixed values, we should add null value
+                if (_has_converted) {
+                    _begin_scan_keys.push_back(start_base_key_range);
+                    _begin_scan_keys.back().add_null();
+                    _end_scan_keys.push_back(end_base_key_range);
+                    _end_scan_keys.back().add_null();
                 }
             }
         }

--- a/be/src/exec/olap_common.h
+++ b/be/src/exec/olap_common.h
@@ -662,7 +662,7 @@ Status OlapScanKeys::extend_scan_key(ColumnValueRange<T>& range) {
         return Status::OK;
     }
 
-    bool _has_converted = false;
+    bool has_converted = false;
 
     if (range.is_fixed_value_range()) {
         if ((_begin_scan_keys.empty() && range.get_fixed_value_size() > config::doris_max_scan_key_num)
@@ -678,13 +678,13 @@ Status OlapScanKeys::extend_scan_key(ColumnValueRange<T>& range) {
             if (_begin_scan_keys.empty()) {
                 if (range.get_convertible_fixed_value_size() < config::doris_max_scan_key_num) {
                     range.convert_to_fixed_value();
-                    _has_converted = true;
+                    has_converted = true;
                 }
             } else {
                 if (range.get_convertible_fixed_value_size() * _begin_scan_keys.size()
                         < config::doris_max_scan_key_num) {
                     range.convert_to_fixed_value();
-                    _has_converted = true;
+                    has_converted = true;
                 }
             }
         }
@@ -705,7 +705,7 @@ Status OlapScanKeys::extend_scan_key(ColumnValueRange<T>& range) {
             }
 
             //when convert to fixed values, we should add null value
-            if (_has_converted) {
+            if (has_converted) {
                  _begin_scan_keys.emplace_back();
                  _begin_scan_keys.back().add_null();
                  _end_scan_keys.emplace_back();
@@ -737,7 +737,7 @@ Status OlapScanKeys::extend_scan_key(ColumnValueRange<T>& range) {
                 }
 
                 //when convert to fixed values, we should add null value
-                if (_has_converted) {
+                if (has_converted) {
                     _begin_scan_keys.push_back(start_base_key_range);
                     _begin_scan_keys.back().add_null();
                     _end_scan_keys.push_back(end_base_key_range);


### PR DESCRIPTION
Fix [343](https://github.com/apache/incubator-doris/issues/343)

The root cause for [343](https://github.com/apache/incubator-doris/issues/343) is ScanKey is wrong.
```
I1122 18:12:51.577086 21470 olap_scan_node.cpp:380] BuildScanKey
I1122 18:12:51.579259 21470 olap_common.h:200] ScanKeys:
I1122 18:12:51.579268 21470 olap_common.h:203] ScanKey=[3001,3,-128,1090050 : 3001,3,-128,1090050]
I1122 18:12:51.579274 21470 olap_common.h:203] ScanKey=[3001,3,-127,1090050 : 3001,3,-127,1090050]
I1122 18:12:51.579279 21470 olap_common.h:203] ScanKey=[3001,3,-126,1090050 : 3001,3,-126,1090050]


I1122 18:12:51.580550 21470 olap_common.h:203] ScanKey=[3001,3,126,1090050 : 3001,3,126,1090050]
I1122 18:12:51.580555 21470 olap_common.h:203] ScanKey=[3001,3,127,1090050 : 3001,3,127,1090050]
```
So we should add null to ScanKey when ColumnValueRange convert_to_fixed_value.

I will add a test case to olap_common_test  tomorrow
