### PR TITLE
Improve the Backend's disk info report performance

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -88,12 +88,12 @@ namespace config {
     CONF_Int32(make_snapshot_worker_count, "5");
     // the count of thread to release snapshot
     CONF_Int32(release_snapshot_worker_count, "5");
-    // the interval time(seconds) for agent report tasks signatrue to dm
+    // the interval time(seconds) for agent report tasks signatrue to FE
     CONF_Int32(report_task_interval_seconds, "10");
-    // the interval time(seconds) for agent report disk state to dm
-    CONF_Int32(report_disk_state_interval_seconds, "600");
-    // the interval time(seconds) for agent report olap table to dm
-    CONF_Int32(report_olap_table_interval_seconds, "600");
+    // the interval time(seconds) for agent report disk state to FE
+    CONF_Int32(report_disk_state_interval_seconds, "60");
+    // the interval time(seconds) for agent report olap table to FE
+    CONF_Int32(report_olap_table_interval_seconds, "60");
     // the timeout(seconds) for alter table
     CONF_Int32(alter_table_timeout_seconds, "86400");
     // the timeout(seconds) for make snapshot

--- a/be/src/olap/olap_engine.h
+++ b/be/src/olap/olap_engine.h
@@ -374,9 +374,8 @@ private:
 
     bool _used_disk_not_enough(uint32_t unused_num, uint32_t total_num);
 
-    OLAPStatus _get_root_path_capacity(
+    OLAPStatus _get_path_available_capacity(
             const std::string& root_path,
-            int64_t* data_used,
             int64_t* disk_available);
 
     OLAPStatus _config_root_path_unused_flag_file(


### PR DESCRIPTION
1. Use the data size save in tablet's header to calculate the disk used capacity.
2. Decrease the default interval of disk and tablet report, from 10 min to 1 min.

ISSUE: #348 