### PR TITLE
Optimize the publish logic of streaming load

### DIFF
--- a/be/src/http/action/stream_load.cpp
+++ b/be/src/http/action/stream_load.cpp
@@ -330,6 +330,7 @@ int StreamLoadAction::on_header(HttpRequest* req) {
         }
         auto str = ctx->to_json();
         HttpChannel::send_reply(req, str);
+        k_streaming_load_current_processing.increment(-1);
         return -1;
     }
     return 0;

--- a/be/test/olap/file_helper_test.cpp
+++ b/be/test/olap/file_helper_test.cpp
@@ -91,10 +91,10 @@ TEST_F(FileHandlerTest, TestWrite) {
     ASSERT_EQ(22, length);
 
     
-    char* large_bytes2[(1 << 12)];
+    char* large_bytes2[(1 << 10)];
     memset(large_bytes2, 0, sizeof(char)*((1 << 12)));
     int i = 1;
-    while (i < 1 << 20) {
+    while (i < 1 << 17) {
         file_handler.write(large_bytes2, ((1 << 12)));
         ++i;
     }

--- a/fe/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/src/main/java/org/apache/doris/common/Config.java
@@ -241,6 +241,9 @@ public class Config extends ConfigBase {
      *      if (current_time - t1) > 300s, then palo will treat C as a failure node
      *      will call transaction manager to commit the transaction and tell transaction manager 
      *      that C is failed
+     * 
+     * This is also used when waiting for publish tasks
+     * 
      * TODO this parameter is the default value for all job and the DBA could specify it for separate job
      */
     @ConfField public static int load_straggler_wait_second = 300;

--- a/fe/src/main/java/org/apache/doris/master/MasterImpl.java
+++ b/fe/src/main/java/org/apache/doris/master/MasterImpl.java
@@ -46,9 +46,9 @@ import org.apache.doris.task.ClearTransactionTask;
 import org.apache.doris.task.CloneTask;
 import org.apache.doris.task.CreateReplicaTask;
 import org.apache.doris.task.CreateRollupTask;
-import org.apache.doris.task.PublishVersionTask;
 import org.apache.doris.task.DirMoveTask;
 import org.apache.doris.task.DownloadTask;
+import org.apache.doris.task.PublishVersionTask;
 import org.apache.doris.task.PushTask;
 import org.apache.doris.task.SchemaChangeTask;
 import org.apache.doris.task.SnapshotTask;
@@ -555,7 +555,7 @@ public class MasterImpl {
         if (request.isSetError_tablet_ids()) {
             errorTabletIds = request.getError_tablet_ids();
         }
-        PublishVersionTask publishVersionTask = (PublishVersionTask)task;
+        PublishVersionTask publishVersionTask = (PublishVersionTask) task;
         publishVersionTask.addErrorTablets(errorTabletIds);
         publishVersionTask.setIsFinished(true);
         AgentTaskQueue.removeTask(publishVersionTask.getBackendId(), 

--- a/fe/src/main/java/org/apache/doris/metric/MetricRepo.java
+++ b/fe/src/main/java/org/apache/doris/metric/MetricRepo.java
@@ -17,9 +17,6 @@
 
 package org.apache.doris.metric;
 
-import com.codahale.metrics.Histogram;
-import com.codahale.metrics.MetricRegistry;
-
 import org.apache.doris.alter.Alter;
 import org.apache.doris.alter.AlterJob.JobType;
 import org.apache.doris.catalog.Catalog;
@@ -33,6 +30,10 @@ import org.apache.doris.persist.EditLog;
 import org.apache.doris.service.ExecuteEnv;
 import org.apache.doris.system.Backend;
 import org.apache.doris.system.SystemInfoService;
+
+import com.codahale.metrics.Histogram;
+import com.codahale.metrics.MetricRegistry;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -57,6 +58,8 @@ public final class MetricRepo {
     public static LongCounterMetric COUNTER_EDIT_LOG_READ;
     public static LongCounterMetric COUNTER_IMAGE_WRITE;
     public static LongCounterMetric COUNTER_IMAGE_PUSH;
+    public static LongCounterMetric COUNTER_TXN_FAILED;
+    public static LongCounterMetric COUNTER_TXN_SUCCESS;
     public static Histogram HISTO_QUERY_LATENCY;
     public static Histogram HISTO_EDIT_LOG_WRITE_LATENCY;
 
@@ -161,6 +164,12 @@ public final class MetricRepo {
         COUNTER_IMAGE_PUSH = new LongCounterMetric("image_push",
                 "counter of image succeeded in pushing to other frontends");
         PALO_METRIC_REGISTER.addPaloMetrics(COUNTER_IMAGE_PUSH);
+        COUNTER_TXN_SUCCESS = new LongCounterMetric("txn_success",
+                "counter of success transactions");
+        PALO_METRIC_REGISTER.addPaloMetrics(COUNTER_TXN_SUCCESS);
+        COUNTER_TXN_FAILED = new LongCounterMetric("txn_failed",
+                "counter of failed transactions");
+        PALO_METRIC_REGISTER.addPaloMetrics(COUNTER_TXN_FAILED);
 
         // 3. histogram
         HISTO_QUERY_LATENCY = METRIC_REGISTER.histogram(MetricRegistry.name("query", "latency", "ms"));

--- a/fe/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
+++ b/fe/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
@@ -634,7 +634,7 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         return result;
     }
 
-    // return true if commit success and publish success, return false if publish timout
+    // return true if commit success and publish success, return false if publish timeout
     private boolean loadTxnCommitImpl(TLoadTxnCommitRequest request) throws UserException {
         String cluster = request.getCluster();
         if (Strings.isNullOrEmpty(cluster)) {
@@ -655,6 +655,7 @@ public class FrontendServiceImpl implements FrontendService.Iface {
             }
             throw new UserException("unknown database, database=" + dbName);
         }
+
         return Catalog.getCurrentGlobalTransactionMgr().commitAndPublishTransaction(
                 db, request.getTxnId(),
                 TabletCommitInfo.fromThrift(request.getCommitInfos()),

--- a/fe/src/main/java/org/apache/doris/task/PublishVersionTask.java
+++ b/fe/src/main/java/org/apache/doris/task/PublishVersionTask.java
@@ -17,15 +17,15 @@
 
 package org.apache.doris.task;
 
-import java.util.ArrayList;
-import java.util.List;
+import org.apache.doris.thrift.TPartitionVersionInfo;
+import org.apache.doris.thrift.TPublishVersionRequest;
+import org.apache.doris.thrift.TTaskType;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import org.apache.doris.thrift.TPartitionVersionInfo;
-import org.apache.doris.thrift.TPublishVersionRequest;
-import org.apache.doris.thrift.TTaskType;
+import java.util.ArrayList;
+import java.util.List;
 
 public class PublishVersionTask extends AgentTask {
     private static final Logger LOG = LogManager.getLogger(PublishVersionTask.class);

--- a/fe/src/main/java/org/apache/doris/transaction/PublishVersionDaemon.java
+++ b/fe/src/main/java/org/apache/doris/transaction/PublishVersionDaemon.java
@@ -17,11 +17,8 @@
 
 package org.apache.doris.transaction;
 
-import com.google.common.collect.Sets;
-
 import org.apache.doris.catalog.Catalog;
 import org.apache.doris.catalog.Replica;
-import org.apache.doris.catalog.Replica.ReplicaState;
 import org.apache.doris.catalog.TabletInvertedIndex;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.util.Daemon;
@@ -31,6 +28,10 @@ import org.apache.doris.task.AgentTaskQueue;
 import org.apache.doris.task.PublishVersionTask;
 import org.apache.doris.thrift.TPartitionVersionInfo;
 import org.apache.doris.thrift.TTaskType;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -38,14 +39,14 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 public class PublishVersionDaemon extends Daemon {
     
     private static final Logger LOG = LogManager.getLogger(PublishVersionDaemon.class);
     
     public PublishVersionDaemon() {
-        super("PUBLISH_VERSION");
-        setInterval(Config.publish_version_interval_millis);
+        super("PUBLISH_VERSION", Config.publish_version_interval_millis);
     }
     
     protected void runOneCycle() {
@@ -64,7 +65,7 @@ public class PublishVersionDaemon extends Daemon {
         }
         // TODO yiguolei: could publish transaction state according to multi-tenant cluster info
         // but should do more work. for example, if a table is migrate from one cluster to another cluster
-        // should pulish to two clusters. 
+        // should publish to two clusters.
         // attention here, we publish transaction state to all backends including dead backend, if not publish to dead backend
         // then transaction manager will treat it as success
         List<Long> allBackends = Catalog.getCurrentSystemInfo().getBackendIds(false);
@@ -97,13 +98,14 @@ public class PublishVersionDaemon extends Daemon {
                 }
             }
             Set<Long> publishBackends = transactionState.getPublishVersionTasks().keySet();
+            // public version tasks are not persisted in catalog, so publishBackends may be empty.
+            // so we have to try publish to all backends;
             if (publishBackends.isEmpty()) {
                 // could not just add to it, should new a new object, or the back map will destroyed
                 publishBackends = Sets.newHashSet();
-                // this is useful if fe master transfer to another master, because publish version task is not
-                // persistent to edit log, then it should publish to all backends
                 publishBackends.addAll(allBackends);
             }
+
             for (long backendId : publishBackends) {
                 PublishVersionTask task = new PublishVersionTask(backendId, 
                                                                  transactionState.getTransactionId(), 
@@ -130,6 +132,7 @@ public class PublishVersionDaemon extends Daemon {
             }
             Map<Long, PublishVersionTask> transTasks = transactionState.getPublishVersionTasks();
             Set<Replica> transErrorReplicas = Sets.newHashSet();
+            List<PublishVersionTask> unfinishedTasks = Lists.newArrayList();
             for (PublishVersionTask publishVersionTask : transTasks.values()) {
                 if (publishVersionTask.isFinished()) {
                     // sometimes backend finish publish version task, but it maybe failed to change transactionid to version for some tablets
@@ -145,44 +148,48 @@ public class PublishVersionDaemon extends Daemon {
                         }
                     }
                 } else {
-                    // if task is not finished in time, then set all replica in the backend to error state
-                    List<TPartitionVersionInfo> versionInfos = publishVersionTask.getPartitionVersionInfos();
-                    Set<Long> errorPartitionIds = Sets.newHashSet();
-                    for (TPartitionVersionInfo versionInfo : versionInfos) {
-                        errorPartitionIds.add(versionInfo.getPartition_id());
-                    }
-                    if (errorPartitionIds.isEmpty()) {
-                        continue;
-                    }
-                    List<Long> tabletIds = tabletInvertedIndex.getTabletIdsByBackendId(publishVersionTask.getBackendId());
-                    for (long tabletId : tabletIds) {
-                        long partitionId = tabletInvertedIndex.getPartitionId(tabletId);
-                        if (errorPartitionIds.contains(partitionId)) {
-                            Replica replica = tabletInvertedIndex.getReplica(tabletId, publishVersionTask.getBackendId());
-                            transErrorReplicas.add(replica);
+                    unfinishedTasks.add(publishVersionTask);
+                }
+            }
+
+            boolean shouldFinishTxn = false;
+            if (!unfinishedTasks.isEmpty()) {
+                if (transactionState.isPublishTimeout()) {
+                    // transaction's publish is timeout, but there still has unfinished tasks.
+                    // we need to collect all error replicas, and try to finish this txn.
+                    for (PublishVersionTask unfinishedTask : unfinishedTasks) {
+                        // set all replica in the backend to error state
+                        List<TPartitionVersionInfo> versionInfos = unfinishedTask.getPartitionVersionInfos();
+                        Set<Long> errorPartitionIds = Sets.newHashSet();
+                        for (TPartitionVersionInfo versionInfo : versionInfos) {
+                            errorPartitionIds.add(versionInfo.getPartition_id());
+                        }
+                        if (errorPartitionIds.isEmpty()) {
+                            continue;
+                        }
+
+                        // TODO(cmy): this is inefficient, but just keep it simple. will change it later.
+                        List<Long> tabletIds = tabletInvertedIndex.getTabletIdsByBackendId(unfinishedTask.getBackendId());
+                        for (long tabletId : tabletIds) {
+                            long partitionId = tabletInvertedIndex.getPartitionId(tabletId);
+                            if (errorPartitionIds.contains(partitionId)) {
+                                Replica replica = tabletInvertedIndex.getReplica(tabletId,
+                                                                                 unfinishedTask.getBackendId());
+                                transErrorReplicas.add(replica);
+                            }
                         }
                     }
+
+                    shouldFinishTxn = true;
                 }
+                // transaction's publish is not timeout, waiting next round.
+            } else {
+                // all publish tasks are finished, try to finish this txn.
+                shouldFinishTxn = true;
             }
-            // the timeout value is related with backend num
-            long timeoutMillis = Math.min(Config.publish_version_timeout_second * transTasks.size() * 1000, 10000);
-            // the minimal internal should be 3s
-            timeoutMillis = Math.max(timeoutMillis, 3000);
             
-            // should not wait clone replica or replica's that with last failed version > 0
-            // if wait for them, the publish process will be very slow
-            int normalReplicasNotRespond = 0;
-            Set<Long> allErrorReplicas = Sets.newHashSet();
-            for (Replica replica : transErrorReplicas) {
-                allErrorReplicas.add(replica.getId());
-                if (replica.getState() != ReplicaState.CLONE 
-                        && replica.getLastFailedVersion() < 1) {
-                    ++normalReplicasNotRespond;
-                }
-            }
-            if (normalReplicasNotRespond == 0 
-                    || System.currentTimeMillis() - transactionState.getPublishVersionTime() > timeoutMillis) {
-                LOG.debug("transTask num {}, error replica id num {}", transTasks.size(), transErrorReplicas.size());
+            if (shouldFinishTxn) {
+                Set<Long> allErrorReplicas = transErrorReplicas.stream().map(v -> v.getId()).collect(Collectors.toSet());
                 globalTransactionMgr.finishTransaction(transactionState.getTransactionId(), allErrorReplicas);
                 if (transactionState.getTransactionStatus() != TransactionStatus.VISIBLE) {
                     // if finish transaction state failed, then update publish version time, should check 
@@ -192,11 +199,12 @@ public class PublishVersionDaemon extends Daemon {
                             transactionState, transErrorReplicas.size());
                 }
             }
+
             if (transactionState.getTransactionStatus() == TransactionStatus.VISIBLE) {
                 for (PublishVersionTask task : transactionState.getPublishVersionTasks().values()) {
                     AgentTaskQueue.removeTask(task.getBackendId(), TTaskType.PUBLISH_VERSION, task.getSignature());
                 }
             }
-        }
+        } // end for readyTransactionStates
     }
 }

--- a/fe/src/main/java/org/apache/doris/transaction/TransactionState.java
+++ b/fe/src/main/java/org/apache/doris/transaction/TransactionState.java
@@ -332,8 +332,9 @@ public class TransactionState implements Writable {
     }
 
     public boolean isPublishTimeout() {
-        // timeout is between 3 to 10 seconds.
-        long timeoutMillis = Math.min(Config.publish_version_timeout_second * publishVersionTasks.size() * 1000, 10000);
+        // timeout is between 3 to Config.max_txn_publish_waiting_time_ms seconds.
+        long timeoutMillis = Math.min(Config.publish_version_timeout_second * publishVersionTasks.size() * 1000,
+                                      Config.load_straggler_wait_second * 1000);
         timeoutMillis = Math.max(timeoutMillis, 3000);
         return System.currentTimeMillis() - publishVersionTime > timeoutMillis;
     }

--- a/fe/src/main/java/org/apache/doris/transaction/TransactionState.java
+++ b/fe/src/main/java/org/apache/doris/transaction/TransactionState.java
@@ -17,8 +17,10 @@
 
 package org.apache.doris.transaction;
 
+import org.apache.doris.common.Config;
 import org.apache.doris.common.io.Text;
 import org.apache.doris.common.io.Writable;
+import org.apache.doris.metric.MetricRepo;
 import org.apache.doris.task.PublishVersionTask;
 
 import com.google.common.collect.Maps;
@@ -253,6 +255,13 @@ public class TransactionState implements Writable {
         this.transactionStatus = transactionStatus;
         if (transactionStatus == TransactionStatus.VISIBLE) {
             this.latch.countDown();
+            if (MetricRepo.isInit.get()) {
+                MetricRepo.COUNTER_TXN_SUCCESS.increase(1L);
+            }
+        } else if (transactionStatus == TransactionStatus.ABORTED) {
+            if (MetricRepo.isInit.get()) {
+                MetricRepo.COUNTER_TXN_FAILED.increase(1L);
+            }
         }
     }
     
@@ -320,5 +329,12 @@ public class TransactionState implements Writable {
 
     public Map<Long, PublishVersionTask> getPublishVersionTasks() {
         return publishVersionTasks;
+    }
+
+    public boolean isPublishTimeout() {
+        // timeout is between 3 to 10 seconds.
+        long timeoutMillis = Math.min(Config.publish_version_timeout_second * publishVersionTasks.size() * 1000, 10000);
+        timeoutMillis = Math.max(timeoutMillis, 3000);
+        return System.currentTimeMillis() - publishVersionTime > timeoutMillis;
     }
 }

--- a/fe/src/test/java/org/apache/doris/load/routineload/RoutineLoadSchedulerTest.java
+++ b/fe/src/test/java/org/apache/doris/load/routineload/RoutineLoadSchedulerTest.java
@@ -17,31 +17,25 @@
 
 package org.apache.doris.load.routineload;
 
-import com.google.common.collect.Lists;
-import mockit.Deencapsulation;
-import mockit.Expectations;
-import mockit.Injectable;
-import mockit.Mock;
-import mockit.MockUp;
-import mockit.Mocked;
 import org.apache.doris.catalog.Catalog;
 import org.apache.doris.catalog.Database;
 import org.apache.doris.common.LoadException;
 import org.apache.doris.common.MetaNotFoundException;
-import org.apache.doris.persist.EditLog;
 import org.apache.doris.system.SystemInfoService;
 import org.apache.doris.thrift.TResourceInfo;
-import org.easymock.EasyMock;
+
+import com.google.common.collect.Lists;
+
 import org.junit.Assert;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.powermock.api.easymock.PowerMock;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
+
+import mockit.Deencapsulation;
+import mockit.Expectations;
+import mockit.Injectable;
+import mockit.Mocked;
 
 public class RoutineLoadSchedulerTest {
 
@@ -71,18 +65,6 @@ public class RoutineLoadSchedulerTest {
 
         Deencapsulation.setField(routineLoadJob, "kafkaPartitions", partitions);
         Deencapsulation.setField(routineLoadJob, "desireTaskConcurrentNum", 3);
-
-        new MockUp<Catalog>() {
-            @Mock
-            public SystemInfoService getCurrentSystemInfo() {
-                return systemInfoService;
-            }
-
-            @Mock
-            public Catalog getCurrentCatalog() {
-                return catalog;
-            }
-        };
 
         new Expectations() {
             {


### PR DESCRIPTION
1. Only collect all error replicas if publish task is timeout.
2. Add 2 metrics to monitor the success and failure of txn.