### PR TITLE
Avoid 'No more data to read' error when handling stream load RPC

### DIFF
--- a/fe/src/main/java/org/apache/doris/common/UserException.java
+++ b/fe/src/main/java/org/apache/doris/common/UserException.java
@@ -17,24 +17,26 @@
 
 package org.apache.doris.common;
 
+import com.google.common.base.Strings;
+
 /**
  * Thrown for internal server errors.
  */
 public class UserException extends Exception {
     public UserException(String msg, Throwable cause) {
-        super(msg, cause);
+        super(Strings.nullToEmpty(msg), cause);
     }
 
     public UserException(Throwable cause) {
         super(cause);
     }
 
-    public UserException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
-        super(message, cause, enableSuppression, writableStackTrace);
+    public UserException(String msg, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super(Strings.nullToEmpty(msg), cause, enableSuppression, writableStackTrace);
     }
 
     public UserException(String msg) {
-        super(msg);
+        super(Strings.nullToEmpty(msg));
     }
 
 }

--- a/fe/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
+++ b/fe/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
@@ -396,11 +396,11 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         } catch (UserException e) {
             LOG.warn("add mini load error", e);
             status.setStatus_code(TStatusCode.ANALYSIS_ERROR);
-            status.setError_msgs(Lists.newArrayList(e.getMessage()));
+            status.addToError_msgs(e.getMessage());
         } catch (Throwable e) {
             LOG.warn("unexpected exception when adding mini load", e);
             status.setStatus_code(TStatusCode.ANALYSIS_ERROR);
-            status.setError_msgs(Lists.newArrayList(e.getMessage()));
+            status.addToError_msgs(Strings.nullToEmpty(e.getMessage()));
         } finally {
             ConnectContext.remove();
         }
@@ -465,7 +465,7 @@ public class FrontendServiceImpl implements FrontendService.Iface {
             String failMsg = "job does not exist. id: " + jobId;
             LOG.warn(failMsg);
             status.setStatus_code(TStatusCode.CANCELLED);
-            status.setError_msgs(Lists.newArrayList(failMsg));
+            status.addToError_msgs(failMsg);
             return result;
         }
 
@@ -474,7 +474,7 @@ public class FrontendServiceImpl implements FrontendService.Iface {
             String failMsg = "task info does not exist. task id: " + taskId + ", job id: " + jobId;
             LOG.warn(failMsg);
             status.setStatus_code(TStatusCode.CANCELLED);
-            status.setError_msgs(Lists.newArrayList(failMsg));
+            status.addToError_msgs(failMsg);
             return result;
         }
 
@@ -554,12 +554,12 @@ public class FrontendServiceImpl implements FrontendService.Iface {
                                   request.getTbl(), request.getUser_ip(), PrivPredicate.LOAD);
         } catch (UserException e) {
             status.setStatus_code(TStatusCode.ANALYSIS_ERROR);
-            status.setError_msgs(Lists.newArrayList(e.getMessage()));
+            status.addToError_msgs(e.getMessage());
             return result;
         } catch (Throwable e) {
             LOG.warn("catch unknown result.", e);
             status.setStatus_code(TStatusCode.INTERNAL_ERROR);
-            status.setError_msgs(Lists.newArrayList(Strings.nullToEmpty(e.getMessage())));
+            status.addToError_msgs(Strings.nullToEmpty(e.getMessage()));
             return result;
         }
 
@@ -576,14 +576,14 @@ public class FrontendServiceImpl implements FrontendService.Iface {
             result.setTxnId(loadTxnBeginImpl(request));
         } catch (LabelAlreadyExistsException e) {
             status.setStatus_code(TStatusCode.LABEL_ALREADY_EXISTS);
-            status.setError_msgs(Lists.newArrayList(e.getMessage()));
+            status.addToError_msgs(e.getMessage());
         } catch (UserException e) {
             status.setStatus_code(TStatusCode.ANALYSIS_ERROR);
-            status.setError_msgs(Lists.newArrayList(e.getMessage()));
+            status.addToError_msgs(e.getMessage());
         } catch (Throwable e) {
             LOG.warn("catch unknown result.", e);
             status.setStatus_code(TStatusCode.INTERNAL_ERROR);
-            status.setError_msgs(Lists.newArrayList(Strings.nullToEmpty(e.getMessage())));
+            status.addToError_msgs(Strings.nullToEmpty(e.getMessage()));
             return result;
         }
 
@@ -630,8 +630,7 @@ public class FrontendServiceImpl implements FrontendService.Iface {
             if (!loadTxnCommitImpl(request)) {
                 // committed success but not visible
                 status.setStatus_code(TStatusCode.PUBLISH_TIMEOUT);
-                status.setError_msgs(
-                        Lists.newArrayList("transaction commit successfully, BUT data will be visible later"));
+                status.addToError_msgs("transaction commit successfully, BUT data will be visible later");
             }
         } catch (UserException e) {
             status.setStatus_code(TStatusCode.ANALYSIS_ERROR);
@@ -639,7 +638,7 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         } catch (Throwable e) {
             LOG.warn("catch unknown result.", e);
             status.setStatus_code(TStatusCode.INTERNAL_ERROR);
-            status.setError_msgs(Lists.newArrayList(Strings.nullToEmpty(e.getMessage())));
+            status.addToError_msgs(Strings.nullToEmpty(e.getMessage()));
             return result;
         }
         return result;
@@ -688,7 +687,7 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         } catch (Throwable e) {
             LOG.warn("catch unknown result.", e);
             status.setStatus_code(TStatusCode.INTERNAL_ERROR);
-            status.setError_msgs(Lists.newArrayList(Strings.nullToEmpty(e.getMessage())));
+            status.addToError_msgs(Strings.nullToEmpty(e.getMessage()));
             return result;
         }
 
@@ -723,7 +722,7 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         } catch (Throwable e) {
             LOG.warn("catch unknown result.", e);
             status.setStatus_code(TStatusCode.INTERNAL_ERROR);
-            status.setError_msgs(Lists.newArrayList(Strings.nullToEmpty(e.getMessage())));
+            status.addToError_msgs(Strings.nullToEmpty(e.getMessage()));
             return result;
         }
         return result;

--- a/fe/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
+++ b/fe/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
@@ -559,7 +559,7 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         } catch (Throwable e) {
             LOG.warn("catch unknown result.", e);
             status.setStatus_code(TStatusCode.INTERNAL_ERROR);
-            status.setError_msgs(Lists.newArrayList(e.getMessage()));
+            status.setError_msgs(Lists.newArrayList(Strings.nullToEmpty(e.getMessage())));
             return result;
         }
 
@@ -580,7 +580,13 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         } catch (UserException e) {
             status.setStatus_code(TStatusCode.ANALYSIS_ERROR);
             status.setError_msgs(Lists.newArrayList(e.getMessage()));
+        } catch (Throwable e) {
+            LOG.warn("catch unknown result.", e);
+            status.setStatus_code(TStatusCode.INTERNAL_ERROR);
+            status.setError_msgs(Lists.newArrayList(Strings.nullToEmpty(e.getMessage())));
+            return result;
         }
+
         return result;
     }
 
@@ -630,6 +636,11 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         } catch (UserException e) {
             status.setStatus_code(TStatusCode.ANALYSIS_ERROR);
             status.addToError_msgs(e.getMessage());
+        } catch (Throwable e) {
+            LOG.warn("catch unknown result.", e);
+            status.setStatus_code(TStatusCode.INTERNAL_ERROR);
+            status.setError_msgs(Lists.newArrayList(Strings.nullToEmpty(e.getMessage())));
+            return result;
         }
         return result;
     }
@@ -674,6 +685,11 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         } catch (UserException e) {
             status.setStatus_code(TStatusCode.ANALYSIS_ERROR);
             status.addToError_msgs(e.getMessage());
+        } catch (Throwable e) {
+            LOG.warn("catch unknown result.", e);
+            status.setStatus_code(TStatusCode.INTERNAL_ERROR);
+            status.setError_msgs(Lists.newArrayList(Strings.nullToEmpty(e.getMessage())));
+            return result;
         }
 
         return result;
@@ -704,6 +720,11 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         } catch (UserException e) {
             status.setStatus_code(TStatusCode.ANALYSIS_ERROR);
             status.addToError_msgs(e.getMessage());
+        } catch (Throwable e) {
+            LOG.warn("catch unknown result.", e);
+            status.setStatus_code(TStatusCode.INTERNAL_ERROR);
+            status.setError_msgs(Lists.newArrayList(Strings.nullToEmpty(e.getMessage())));
+            return result;
         }
         return result;
     }


### PR DESCRIPTION
1. Catch throwable of all stream load rpc.
2. Avoid setting null string as error msg of rpc result status.