### PR TITLE
Ubuntu llvm compile

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The simplicity (of developing, deploying and using) and meeting many data servin
 ## 4. Compile and install
 
 Currently support Docker environment and Linux OS: 
-Docker（Linux/Windows/Mac), Ubuntu and CentOS.
+Docker (Linux / Windows / Mac), Ubuntu and CentOS.
 
 ### 4.1 For Docker
 
@@ -74,7 +74,7 @@ After successfully building, it will install binary files in the directory outpu
 
 #### Prerequisites
 
-GCC 5.3.1+，Oracle JDK 1.8+，Python 2.7+, Apache Maven 3.5.4+
+GCC 5.3.1+, Oracle JDK 1.8+, Python 2.7+, Apache Maven 3.5+, CMake 3.4.3+
 
 * For Ubuntu: 
 

--- a/thirdparty/build-thirdparty.sh
+++ b/thirdparty/build-thirdparty.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information

--- a/thirdparty/vars.sh
+++ b/thirdparty/vars.sh
@@ -80,9 +80,9 @@ CLANG_NAME=cfe-3.4.2.src.tar.gz
 CLANG_SOURCE=cfe-3.4.2.src
 
 # compiler-rt
-COMPILER_RT_DOWNLOAD="http://releases.llvm.org/4.0.0/compiler-rt-4.0.0.src.tar.xz"
-COMPILER_RT_NAME=compiler-rt-4.0.0.src.tar.xz
-COMPILER_RT_SOURCE=compiler-rt-4.0.0.src
+COMPILER_RT_DOWNLOAD="http://releases.llvm.org/5.0.0/compiler-rt-5.0.0.src.tar.xz"
+COMPILER_RT_NAME=compiler-rt-5.0.0.src.tar.xz
+COMPILER_RT_SOURCE=compiler-rt-5.0.0.src
 
 # protobuf
 PROTOBUF_DOWNLOAD="https://github.com/google/protobuf/archive/v3.5.1.tar.gz"

--- a/thirdparty/vars.sh
+++ b/thirdparty/vars.sh
@@ -80,9 +80,9 @@ CLANG_NAME=cfe-3.4.2.src.tar.gz
 CLANG_SOURCE=cfe-3.4.2.src
 
 # compiler-rt
-COMPILER_RT_DOWNLOAD="http://releases.llvm.org/3.4/compiler-rt-3.4.src.tar.gz"
-COMPILER_RT_NAME=compiler-rt-3.4.src.tar.gz
-COMPILER_RT_SOURCE=compiler-rt-3.4
+COMPILER_RT_DOWNLOAD="http://releases.llvm.org/4.0.0/compiler-rt-4.0.0.src.tar.xz"
+COMPILER_RT_NAME=compiler-rt-4.0.0.src.tar.xz
+COMPILER_RT_SOURCE=compiler-rt-4.0.0.src
 
 # protobuf
 PROTOBUF_DOWNLOAD="https://github.com/google/protobuf/archive/v3.5.1.tar.gz"


### PR DESCRIPTION
Using compiler-rt-5.0.0 to avoid compile error in Ubuntu 18.04, and the side-effect is CMake 3.4.3 or higher is required. 