### PR TITLE
Fix a sending signal error when starting Doris BE

### DIFF
--- a/bin/start_be.sh
+++ b/bin/start_be.sh
@@ -55,14 +55,14 @@ rm -f ${UDF_RUNTIME_DIR}/*
 pidfile=$PID_DIR/be.pid
 
 if [ -f $pidfile ]; then
-    if kill -0 $(cat $pidfile); then
+    if [ -d /proc/$(cat $pidfile) ]; then
         echo "Backend running as process `cat $pidfile`. Stop it first."
         exit 1
     else
         rm $pidfile
     fi
 fi
- 
+
 chmod 755 ${DORIS_HOME}/lib/palo_be
 echo "start time: "$(date) >> $LOG_DIR/be.out
 

--- a/bin/start_be.sh
+++ b/bin/start_be.sh
@@ -55,7 +55,7 @@ rm -f ${UDF_RUNTIME_DIR}/*
 pidfile=$PID_DIR/be.pid
 
 if [ -f $pidfile ]; then
-    if [ -d /proc/$(cat $pidfile) ]; then
+    if kill -0 $(cat $pidfile) > /dev/null 2>&1; then
         echo "Backend running as process `cat $pidfile`. Stop it first."
         exit 1
     else


### PR DESCRIPTION
ISSUE #365

To check whether the process is started, a better way is to verify the existence of the /proc/$pid path.