### PR TITLE
Add a frontend interface for committing RoutineLoadTask

### DIFF
--- a/fe/src/main/java/org/apache/doris/analysis/InsertStmt.java
+++ b/fe/src/main/java/org/apache/doris/analysis/InsertStmt.java
@@ -71,7 +71,7 @@ public class InsertStmt extends DdlStmt {
     private final List<String> planHints;
     private Boolean isRepartition;
     private boolean isStreaming = false;
-    
+
     private Map<Long, Integer> indexIdToSchemaHash = null;
 
     // set after parse all columns and expr in query statement
@@ -129,11 +129,11 @@ public class InsertStmt extends DdlStmt {
     public Map<Long, Integer> getIndexIdToSchemaHash() {
         return this.indexIdToSchemaHash;
     }
-    
+
     public long getTransactionId() {
         return this.transactionId;
     }
-    
+
     public Boolean isRepartition() {
         return isRepartition;
     }
@@ -226,7 +226,7 @@ public class InsertStmt extends DdlStmt {
 
         // create data sink
         createDataSink();
-        
+
         if (targetTable instanceof OlapTable) {
             String dbName = tblName.getDb();
             // check exist
@@ -236,11 +236,11 @@ public class InsertStmt extends DdlStmt {
             // if all previous job finished
             UUID uuid = UUID.randomUUID();
             String jobLabel = "insert_" + uuid;
-            LoadJobSourceType sourceType = isStreaming ? LoadJobSourceType.INSERT_STREAMING 
+            LoadJobSourceType sourceType = isStreaming ? LoadJobSourceType.INSERT_STREAMING
                     : LoadJobSourceType.FRONTEND;
             transactionId = Catalog.getCurrentGlobalTransactionMgr().beginTransaction(db.getId(),
-                    jobLabel,
-                    "fe", sourceType);
+                                                                                      jobLabel,
+                                                                                      "fe", sourceType);
             if (isStreaming) {
                 OlapTableSink sink = (OlapTableSink) dataSink;
                 TUniqueId loadId = new TUniqueId(uuid.getMostSignificantBits(), uuid.getLeastSignificantBits());
@@ -308,7 +308,7 @@ public class InsertStmt extends DdlStmt {
 
             if (!brokerTable.isWritable()) {
                 throw new AnalysisException("table " + brokerTable.getName()
-                        + "is not writable. path should be an dir");
+                                                    + "is not writable. path should be an dir");
             }
 
         } else {
@@ -401,9 +401,9 @@ public class InsertStmt extends DdlStmt {
         // TargeTable's hll column must be hll_hash's result
         if (col.getType().equals(Type.HLL)) {
             final String hllMismatchLog = "Column's type is HLL,"
-                    + " SelectList must contains HLL or hll_hash function's result, column=" + col.getName(); 
+                    + " SelectList must contains HLL or hll_hash function's result, column=" + col.getName();
             if (expr instanceof SlotRef) {
-                final SlotRef slot = (SlotRef)expr;
+                final SlotRef slot = (SlotRef) expr;
                 if (!slot.getType().equals(Type.HLL)) {
                     throw new AnalysisException(hllMismatchLog);
                 }

--- a/fe/src/main/java/org/apache/doris/common/FeMetaVersion.java
+++ b/fe/src/main/java/org/apache/doris/common/FeMetaVersion.java
@@ -79,10 +79,10 @@ public final class FeMetaVersion {
 
     // paralle exec param and batch size
     public static final int VERSION_38 = 38;
-    
+
     // schema change support row to column
     public static final int VERSION_39 = 39;
-    
+
     // persistent brpc port in Backend
     public static final int VERSION_40 = 40;
 
@@ -98,6 +98,5 @@ public final class FeMetaVersion {
     // streaming load
     public static final int VERSION_45 = 45;
 
-    // colocate join
-    public static final int VERSION_46 = 46;
+    // TODO(ml):VERSION_ROUTINE_LOAD add extra in transaction state for routine load
 }

--- a/fe/src/main/java/org/apache/doris/load/Load.java
+++ b/fe/src/main/java/org/apache/doris/load/Load.java
@@ -153,18 +153,18 @@ public class Load {
         pendingDestStates.add(JobState.ETL);
         pendingDestStates.add(JobState.CANCELLED);
         STATE_CHANGE_MAP.put(JobState.PENDING, pendingDestStates);
-        
+
         Set<JobState> etlDestStates = Sets.newHashSet();
         etlDestStates.add(JobState.LOADING);
         etlDestStates.add(JobState.CANCELLED);
         STATE_CHANGE_MAP.put(JobState.ETL, etlDestStates);
-        
+
         Set<JobState> loadingDestStates = Sets.newHashSet();
         loadingDestStates.add(JobState.FINISHED);
         loadingDestStates.add(JobState.QUORUM_FINISHED);
         loadingDestStates.add(JobState.CANCELLED);
         STATE_CHANGE_MAP.put(JobState.LOADING, loadingDestStates);
-        
+
         Set<JobState> quorumFinishedDestStates = Sets.newHashSet();
         quorumFinishedDestStates.add(JobState.FINISHED);
         STATE_CHANGE_MAP.put(JobState.QUORUM_FINISHED, quorumFinishedDestStates);
@@ -268,7 +268,7 @@ public class Load {
             if (!Strings.isNullOrEmpty(specifiedColumns)) {
                 columnNames = Arrays.asList(specifiedColumns.split(","));
             }
-      
+
             final String hll = params.get(LoadStmt.KEY_IN_PARAM_HLL);
             if (!Strings.isNullOrEmpty(hll)) {
                 hllColumnPairList = Arrays.asList(hll.split(":"));
@@ -287,7 +287,7 @@ public class Load {
         }
 
         DataDescription dataDescription = new DataDescription(tableName, partitionNames, filePaths, columnNames,
-                columnSeparator, false, null);
+                                                              columnSeparator, false, null);
         dataDescription.setLineDelimiter(lineDelimiter);
         dataDescription.setBeAddr(beAddr);
         // parse hll param pair
@@ -297,7 +297,7 @@ public class Load {
                 final List<String> pairList = Arrays.asList(pairStr.split(","));
                 if (pairList.size() != 2) {
                     throw new DdlException("hll param format error");
-                }   
+                }
 
                 final String resultColumn = pairList.get(0);
                 final String hashColumn = pairList.get(1);
@@ -350,10 +350,10 @@ public class Load {
     }
 
     // for insert select from or create as stmt
-    public void addLoadJob(String label, String dbName, 
-                long tableId, Map<Long, Integer> indexIdToSchemaHash, 
-                long transactionId,
-                List<String> fileList, long timestamp) throws DdlException {
+    public void addLoadJob(String label, String dbName,
+                           long tableId, Map<Long, Integer> indexIdToSchemaHash,
+                           long transactionId,
+                           List<String> fileList, long timestamp) throws DdlException {
         // get db and table
         Database db = Catalog.getInstance().getDb(dbName);
         if (db == null) {
@@ -373,7 +373,7 @@ public class Load {
 
         // create job
         DataDescription desc = new DataDescription(table.getName(), null, Lists.newArrayList(""),
-                null, null, false, null);
+                                                   null, null, false, null);
         LoadStmt stmt = new LoadStmt(new LabelName(dbName, label), Lists.newArrayList(desc), null, null, null);
         LoadJob job = createLoadJob(stmt, EtlJobType.INSERT, db, timestamp);
 
@@ -409,20 +409,20 @@ public class Load {
             db.checkQuota();
         }
 
-		// check if table is in restore process
-		db.readLock();
-		try {
-			for (Long tblId : job.getIdToTableLoadInfo().keySet()) {
-				Table tbl = db.getTable(tblId);
-				if (tbl != null && tbl.getType() == TableType.OLAP
-						&& ((OlapTable) tbl).getState() == OlapTableState.RESTORE) {
+        // check if table is in restore process
+        db.readLock();
+        try {
+            for (Long tblId : job.getIdToTableLoadInfo().keySet()) {
+                Table tbl = db.getTable(tblId);
+                if (tbl != null && tbl.getType() == TableType.OLAP
+                        && ((OlapTable) tbl).getState() == OlapTableState.RESTORE) {
                     throw new DdlException("Table " + tbl.getName() + " is in restore process. "
-							+ "Can not load into it"); 
-				}
-			}
-		} finally {
-			db.readUnlock();
-		}
+                                                   + "Can not load into it");
+                }
+            }
+        } finally {
+            db.readUnlock();
+        }
 
         writeLock();
         try {
@@ -435,13 +435,13 @@ public class Load {
         LOG.info("add load job. job: {}", job);
     }
 
-    private LoadJob createLoadJob(LoadStmt stmt, EtlJobType etlJobType, 
-                Database db, long timestamp) throws DdlException {
+    private LoadJob createLoadJob(LoadStmt stmt, EtlJobType etlJobType,
+                                  Database db, long timestamp) throws DdlException {
         // get params
         String label = stmt.getLabel().getLabelName();
         List<DataDescription> dataDescriptions = stmt.getDataDescriptions();
         Map<String, String> properties = stmt.getProperties();
- 
+
         // check params
         try {
             FeNameFormat.checkLabel(label);
@@ -508,13 +508,13 @@ public class Load {
         for (DataDescription dataDescription : dataDescriptions) {
             // create source
             createSource(db, dataDescription, tableToPartitionSources, job.getDeleteFlag());
-			job.addTableName(dataDescription.getTableName());
+            job.addTableName(dataDescription.getTableName());
         }
         for (Entry<Long, Map<Long, List<Source>>> tableEntry : tableToPartitionSources.entrySet()) {
             long tableId = tableEntry.getKey();
             Map<Long, List<Source>> partitionToSources = tableEntry.getValue();
-            
-            Map<Long, PartitionLoadInfo>  idToPartitionLoadInfo = Maps.newHashMap();
+
+            Map<Long, PartitionLoadInfo> idToPartitionLoadInfo = Maps.newHashMap();
             for (Entry<Long, List<Source>> partitionEntry : partitionToSources.entrySet()) {
                 PartitionLoadInfo info = new PartitionLoadInfo(partitionEntry.getValue());
                 idToPartitionLoadInfo.put(partitionEntry.getKey(), info);
@@ -533,7 +533,7 @@ public class Load {
             job.setPullLoadSourceInfo(sourceInfo);
             LOG.info("Source info is {}", sourceInfo);
         }
-        
+
         if (etlJobType == EtlJobType.MINI) {
             // mini etl tasks
             Map<Long, MiniEtlTaskInfo> idToEtlTask = Maps.newHashMap();
@@ -549,7 +549,7 @@ public class Load {
 
                     TNetworkAddress beAddress = dataDescription.getBeAddr();
                     Backend backend = Catalog.getCurrentSystemInfo().getBackendWithBePort(beAddress.getHostname(),
-                                                                                           beAddress.getPort());
+                                                                                          beAddress.getPort());
                     if (!Catalog.getCurrentSystemInfo().checkBackendAvailable(backend.getId())) {
                         throw new DdlException("Etl backend is null or not available");
                     }
@@ -626,12 +626,12 @@ public class Load {
 
         // job id
         job.setId(Catalog.getInstance().getNextId());
-        
+
         return job;
     }
 
-    private void createSource(Database db, DataDescription dataDescription, 
-            Map<Long, Map<Long, List<Source>>> tableToPartitionSources, boolean deleteFlag) throws DdlException {
+    private void createSource(Database db, DataDescription dataDescription,
+                              Map<Long, Map<Long, List<Source>>> tableToPartitionSources, boolean deleteFlag) throws DdlException {
         Source source = new Source(dataDescription.getFilePathes());
         long tableId = -1;
         Set<Long> sourcePartitionIds = Sets.newHashSet();
@@ -657,7 +657,7 @@ public class Load {
             if (((OlapTable) table).getKeysType() != KeysType.AGG_KEYS && dataDescription.isNegative()) {
                 throw new DdlException("Load for AGG_KEYS table should not specify NEGATIVE");
             }
-            
+
             if (((OlapTable) table).getKeysType() != KeysType.UNIQUE_KEYS && deleteFlag) {
                 throw new DdlException("Delete flag can only be used for UNIQUE_KEYS table");
             }
@@ -743,7 +743,7 @@ public class Load {
                     Pair<String, List<String>> function = entry.getValue();
                     try {
                         DataDescription.validateMappingFunction(function.first, function.second, columnNameMap,
-                                mappingColumn, dataDescription.isPullLoad());
+                                                                mappingColumn, dataDescription.isPullLoad());
                     } catch (AnalysisException e) {
                         throw new DdlException(e.getMessage());
                     }
@@ -771,22 +771,22 @@ public class Load {
         } finally {
             db.readUnlock();
         }
-        
+
         // column separator
         String columnSeparator = dataDescription.getColumnSeparator();
         if (!Strings.isNullOrEmpty(columnSeparator)) {
             source.setColumnSeparator(columnSeparator);
-        } 
-        
+        }
+
         // line delimiter
         String lineDelimiter = dataDescription.getLineDelimiter();
         if (!Strings.isNullOrEmpty(lineDelimiter)) {
             source.setLineDelimiter(lineDelimiter);
         }
-        
+
         // source negative
         source.setNegative(dataDescription.isNegative());
-        
+
         // column mapping functions
         if (columnToFunction != null) {
             source.setColumnToFunction(columnToFunction);
@@ -816,7 +816,7 @@ public class Load {
         long jobId = job.getId();
         long dbId = job.getDbId();
         String label = job.getLabel();
-        
+
         if (!isReplay && getAllUnfinishedLoadJob() > Config.max_unfinished_load_job) {
             throw new DdlException(
                     "Number of unfinished load jobs exceed the max number: " + Config.max_unfinished_load_job);
@@ -833,7 +833,7 @@ public class Load {
             if (isLabelUsed(dbId, label, -1, checkMini)) {
                 throw new DdlException("Same data label[" + label + "] already used");
             }
-    
+
             // add job
             Map<String, List<LoadJob>> labelToLoadJobs = null;
             if (dbLabelToLoadJobs.containsKey(dbId)) {
@@ -849,7 +849,7 @@ public class Load {
                 labelLoadJobs = Lists.newArrayList();
                 labelToLoadJobs.put(label, labelLoadJobs);
             }
-            
+
             List<LoadJob> dbLoadJobs = null;
             if (dbToLoadJobs.containsKey(dbId)) {
                 dbLoadJobs = dbToLoadJobs.get(dbId);
@@ -871,9 +871,9 @@ public class Load {
             idToLoadJob.put(jobId, job);
             dbDeleteJobs.add(job);
         }
-        
+
         // beginTransaction Here
-        
+
         switch (job.getState()) {
             case PENDING:
                 idToPendingLoadJob.put(jobId, job);
@@ -913,15 +913,15 @@ public class Load {
             writeUnlock();
         }
     }
-    
+
     public void unprotectEtlLoadJob(LoadJob job) {
         long jobId = job.getId();
         idToPendingLoadJob.remove(jobId);
         idToEtlLoadJob.put(jobId, job);
-        
+
         replaceLoadJob(job);
     }
-    
+
     public void replayEtlLoadJob(LoadJob job) throws DdlException {
         writeLock();
         try {
@@ -930,7 +930,7 @@ public class Load {
             writeUnlock();
         }
     }
-    
+
     public void unprotectLoadingLoadJob(LoadJob job) {
         long jobId = job.getId();
         idToEtlLoadJob.remove(jobId);
@@ -952,7 +952,7 @@ public class Load {
     }
 
     public boolean registerMiniLabel(
-              String fullDbName, String label, long timestamp) throws DdlException {
+            String fullDbName, String label, long timestamp) throws DdlException {
         Database db = Catalog.getInstance().getDb(fullDbName);
         if (db == null) {
             throw new DdlException("Db does not exist. name: " + fullDbName);
@@ -964,7 +964,7 @@ public class Load {
             if (isLabelUsed(dbId, label, -1, true)) {
                 return false;
             }
-            
+
             Map<String, Long> miniLabels = null;
             if (dbToMiniLabels.containsKey(dbId)) {
                 miniLabels = dbToMiniLabels.get(dbId);
@@ -979,7 +979,7 @@ public class Load {
 
         return true;
     }
-    
+
     public void deregisterMiniLabel(String fullDbName, String label) throws DdlException {
         Database db = Catalog.getInstance().getDb(fullDbName);
         if (db == null) {
@@ -1016,7 +1016,7 @@ public class Load {
             readUnlock();
         }
     }
-    
+
     /*
      * if timestamp does not equals to -1, this is a retry request:
      * 1. if label has been used, and job's timestamp equals to the given one, return true.
@@ -1030,7 +1030,7 @@ public class Load {
      */
     private boolean isLabelUsed(long dbId, String label, long timestamp, boolean checkMini)
             throws DdlException {
-        
+
         // check dbLabelToLoadJobs
         if (dbLabelToLoadJobs.containsKey(dbId)) {
             Map<String, List<LoadJob>> labelToLoadJobs = dbLabelToLoadJobs.get(dbId);
@@ -1084,7 +1084,7 @@ public class Load {
         // get params
         String dbName = stmt.getDbName();
         String label = stmt.getLabel();
-        
+
         // get load job and check state
         Database db = Catalog.getInstance().getDb(dbName);
         if (db == null) {
@@ -1097,7 +1097,7 @@ public class Load {
             if (labelToLoadJobs == null) {
                 throw new DdlException("Load job does not exist");
             }
-            
+
             List<LoadJob> loadJobs = labelToLoadJobs.get(label);
             if (loadJobs == null) {
                 throw new DdlException("Load job does not exist");
@@ -1114,33 +1114,33 @@ public class Load {
             readUnlock();
         }
 
-		// check auth here, cause we need table info
-		Set<String> tableNames = job.getTableNames();
-		if (tableNames.isEmpty()) {
-			// forward compatibility
-			if (!Catalog.getCurrentCatalog().getAuth().checkDbPriv(ConnectContext.get(), dbName,
-						PrivPredicate.LOAD)) {
-				ErrorReport.reportDdlException(ErrorCode.ERR_SPECIFIC_ACCESS_DENIED_ERROR, "CANCEL LOAD");
-			}
-		} else {
-			for (String tblName : tableNames) {
-				if (!Catalog.getCurrentCatalog().getAuth().checkTblPriv(ConnectContext.get(), dbName, tblName,
-							PrivPredicate.LOAD)) {
-					ErrorReport.reportDdlException(ErrorCode.ERR_TABLEACCESS_DENIED_ERROR, "CANCEL LOAD",
-							ConnectContext.get().getQualifiedUser(),
-							ConnectContext.get().getRemoteIP(), tblName);
-				}
-			}
-		}
+        // check auth here, cause we need table info
+        Set<String> tableNames = job.getTableNames();
+        if (tableNames.isEmpty()) {
+            // forward compatibility
+            if (!Catalog.getCurrentCatalog().getAuth().checkDbPriv(ConnectContext.get(), dbName,
+                                                                   PrivPredicate.LOAD)) {
+                ErrorReport.reportDdlException(ErrorCode.ERR_SPECIFIC_ACCESS_DENIED_ERROR, "CANCEL LOAD");
+            }
+        } else {
+            for (String tblName : tableNames) {
+                if (!Catalog.getCurrentCatalog().getAuth().checkTblPriv(ConnectContext.get(), dbName, tblName,
+                                                                        PrivPredicate.LOAD)) {
+                    ErrorReport.reportDdlException(ErrorCode.ERR_TABLEACCESS_DENIED_ERROR, "CANCEL LOAD",
+                                                   ConnectContext.get().getQualifiedUser(),
+                                                   ConnectContext.get().getRemoteIP(), tblName);
+                }
+            }
+        }
 
         // cancel job
         if (!cancelLoadJob(job, CancelType.USER_CANCEL, "user cancel")) {
             throw new DdlException("Cancel load job fail");
         }
-        
+
         return true;
     }
-     
+
     public boolean cancelLoadJob(LoadJob job, CancelType cancelType, String msg) {
         // update job to cancelled
         JobState srcState = job.getState();
@@ -1148,7 +1148,7 @@ public class Load {
             LOG.warn("cancel load job failed. job: {}", job, new Exception());
             return false;
         }
-        
+
         // clear
         if (job.getHadoopDppConfig() != null) {
             clearJob(job, srcState);
@@ -1163,7 +1163,7 @@ public class Load {
         LOG.info("cancel load job success. job: {}", job);
         return true;
     }
-    
+
     public void unprotectCancelLoadJob(LoadJob job) {
         long jobId = job.getId();
         LoadJob oldJob = idToLoadJob.get(jobId);
@@ -1191,7 +1191,7 @@ public class Load {
 
         replaceLoadJob(job);
     }
-    
+
     public void replayCancelLoadJob(LoadJob job) {
         writeLock();
         try {
@@ -1200,7 +1200,7 @@ public class Load {
             writeUnlock();
         }
     }
-    
+
     public void removeDeleteJobAndSetState(AsyncDeleteJob job) {
         job.clearTasks();
         writeLock();
@@ -1246,7 +1246,7 @@ public class Load {
             int loadJobNum = 0;
             for (LoadJob loadJob : idToLoadJob.values()) {
                 if (!loadJob.isSyncDeleteJob()) {
-                    ++ loadJobNum;
+                    ++loadJobNum;
                 }
             }
             return loadJobNum;
@@ -1254,19 +1254,19 @@ public class Load {
             readUnlock();
         }
     }
-    
+
     public Map<Long, LoadJob> getIdToLoadJob() {
         return idToLoadJob;
     }
-    
+
     public Map<Long, List<LoadJob>> getDbToLoadJobs() {
         return dbToLoadJobs;
     }
-    
+
     public Map<Long, List<LoadJob>> getDbToDeleteJobs() {
         return dbToDeleteJobs;
     }
-    
+
     public Map<Long, List<DeleteInfo>> getDbToDeleteInfos() {
         return dbToDeleteInfos;
     }
@@ -1295,7 +1295,7 @@ public class Load {
             readUnlock();
         }
     }
- 
+
     public List<LoadJob> getLoadJobs(JobState jobState) {
         List<LoadJob> jobs = new ArrayList<LoadJob>();
         Collection<LoadJob> stateJobs = null;
@@ -1345,7 +1345,7 @@ public class Load {
             readUnlock();
         }
     }
-   
+
     public LoadJob getLoadJob(long jobId) {
         readLock();
         try {
@@ -1372,9 +1372,9 @@ public class Load {
             readUnlock();
         }
     }
-  
+
     public LinkedList<List<Comparable>> getLoadJobInfosByDb(long dbId, String dbName, String labelValue,
-            boolean accurateMatch, Set<JobState> states, ArrayList<OrderByPair> orderByPairs) {
+                                                            boolean accurateMatch, Set<JobState> states, ArrayList<OrderByPair> orderByPairs) {
         LinkedList<List<Comparable>> loadJobInfos = new LinkedList<List<Comparable>>();
         readLock();
         try {
@@ -1383,13 +1383,13 @@ public class Load {
                 return loadJobInfos;
             }
 
-			long start = System.currentTimeMillis();
-			LOG.debug("begin to get load job info, size: {}", loadJobs.size());
+            long start = System.currentTimeMillis();
+            LOG.debug("begin to get load job info, size: {}", loadJobs.size());
             for (LoadJob loadJob : loadJobs) {
                 // filter first
                 String label = loadJob.getLabel();
                 JobState state = loadJob.getState();
-                
+
                 if (labelValue != null) {
                     if (accurateMatch) {
                         if (!label.equals(labelValue)) {
@@ -1401,35 +1401,35 @@ public class Load {
                         }
                     }
                 }
-                
+
                 if (states != null) {
                     if (!states.contains(state)) {
                         continue;
                     }
                 }
 
-				// check auth
-				Set<String> tableNames = loadJob.getTableNames();
-				if (tableNames.isEmpty()) {
-					// forward compatibility
-					if (!Catalog.getCurrentCatalog().getAuth().checkDbPriv(ConnectContext.get(), dbName,
-								PrivPredicate.SHOW)) {
-						continue;
-					}
-				} else {
-					boolean auth = true;
-					for (String tblName : tableNames) {
-						if (!Catalog.getCurrentCatalog().getAuth().checkTblPriv(ConnectContext.get(), dbName,
-									tblName, PrivPredicate.SHOW)) {
-							auth = false;
-							break;
-						}
-					}
-					if (!auth) {
-						continue;
-					}
-				}
-                
+                // check auth
+                Set<String> tableNames = loadJob.getTableNames();
+                if (tableNames.isEmpty()) {
+                    // forward compatibility
+                    if (!Catalog.getCurrentCatalog().getAuth().checkDbPriv(ConnectContext.get(), dbName,
+                                                                           PrivPredicate.SHOW)) {
+                        continue;
+                    }
+                } else {
+                    boolean auth = true;
+                    for (String tblName : tableNames) {
+                        if (!Catalog.getCurrentCatalog().getAuth().checkTblPriv(ConnectContext.get(), dbName,
+                                                                                tblName, PrivPredicate.SHOW)) {
+                            auth = false;
+                            break;
+                        }
+                    }
+                    if (!auth) {
+                        continue;
+                    }
+                }
+
                 List<Comparable> jobInfo = new ArrayList<Comparable>();
 
                 // jobId
@@ -1475,7 +1475,7 @@ public class Load {
                         // XXX: internal etl job return all counters
                         if (key.equalsIgnoreCase("HDFS bytes read")
                                 || key.equalsIgnoreCase("Map input records")
-                                || key.startsWith("dpp.") 
+                                || key.startsWith("dpp.")
                                 || loadJob.getEtlJobType() == EtlJobType.MINI) {
                             info.add(key + "=" + counters.get(key));
                         }
@@ -1489,8 +1489,8 @@ public class Load {
 
                 // task info
                 jobInfo.add("cluster:" + loadJob.getHadoopCluster()
-                        + "; timeout(s):" + loadJob.getTimeoutSecond() 
-                        + "; max_filter_ratio:" + loadJob.getMaxFilterRatio());
+                                    + "; timeout(s):" + loadJob.getTimeoutSecond()
+                                    + "; max_filter_ratio:" + loadJob.getMaxFilterRatio());
 
                 // error msg
                 if (loadJob.getState() == JobState.CANCELLED) {
@@ -1516,7 +1516,7 @@ public class Load {
                 loadJobInfos.add(jobInfo);
             } // end for loadJobs
 
-			LOG.debug("finished to get load job info, cost: {}", (System.currentTimeMillis() - start));
+            LOG.debug("finished to get load job info, cost: {}", (System.currentTimeMillis() - start));
         } finally {
             readUnlock();
         }
@@ -1534,7 +1534,7 @@ public class Load {
     }
 
     public long getLatestJobIdByLabel(long dbId, String labelValue) {
-		LoadJob job = null;
+        LoadJob job = null;
         long jobId = 0;
         try {
             readLock();
@@ -1556,7 +1556,7 @@ public class Load {
 
                 if (currJobId > jobId) {
                     jobId = currJobId;
-					job = loadJob;
+                    job = loadJob;
                 }
             }
         } finally {
@@ -1647,11 +1647,11 @@ public class Load {
         } finally {
             readUnlock();
         }
-        
+
         // sort by version, backendId
         ListComparator<List<Comparable>> comparator = new ListComparator<List<Comparable>>(3, 0);
         Collections.sort(infos, comparator);
-        
+
         return infos;
     }
 
@@ -1666,8 +1666,8 @@ public class Load {
     // Note: althrough this.loadErrorHubInfo is volatile, no need to lock.
     //       but editlog need be locked
     public void changeLoadErrorHubInfo(LoadErrorHub.Param info) {
-		writeLock();
-		try {
+        writeLock();
+        try {
             this.loadErrorHubInfo = info;
             Catalog.getInstance().getEditLog().logSetLoadErrorHub(info);
         } finally {
@@ -1677,7 +1677,7 @@ public class Load {
 
     public static class JobInfo {
         public String dbName;
-		public Set<String> tblNames = Sets.newHashSet();
+        public Set<String> tblNames = Sets.newHashSet();
         public String label;
         public String clusterName;
         public JobState state;
@@ -1695,7 +1695,7 @@ public class Load {
     // result saved in info
     public void getJobInfo(JobInfo info) throws DdlException {
         String fullDbName = ClusterNamespace.getFullName(info.clusterName, info.dbName);
-		info.dbName = fullDbName;
+        info.dbName = fullDbName;
         Database db = Catalog.getInstance().getDb(fullDbName);
         if (db == null) {
             throw new DdlException("Unknown database(" + info.dbName + ")");
@@ -1713,9 +1713,9 @@ public class Load {
             // only the last one should be running
             LoadJob job = loadJobs.get(loadJobs.size() - 1);
 
-			if (!job.getTableNames().isEmpty()) {
-				info.tblNames.addAll(job.getTableNames());
-			}
+            if (!job.getTableNames().isEmpty()) {
+                info.tblNames.addAll(job.getTableNames());
+            }
 
             info.state = job.getState();
             if (info.state == JobState.QUORUM_FINISHED) {
@@ -1728,13 +1728,13 @@ public class Load {
             readUnlock();
         }
     }
-  
+
     public void unprotectQuorumLoadJob(LoadJob job, Database db) {
         // in real time load replica info and partition version is set by transaction manager not by job
         if (job.getTransactionId() < 0) {
             // remove loading partitions
             removeLoadingPartitions(job);
-    
+
             // Update database information first
             Map<Long, ReplicaPersistInfo> replicaInfos = job.getReplicaPersistInfos();
             if (replicaInfos != null) {
@@ -1759,17 +1759,17 @@ public class Load {
                         LOG.warn("the tablet[{}] is missing", info.getTabletId());
                         continue;
                     }
-    
+
                     Replica replica = tablet.getReplicaById(info.getReplicaId());
                     if (replica == null) {
                         LOG.warn("the replica[{}] is missing", info.getReplicaId());
                         continue;
                     }
                     replica.updateVersionInfo(info.getVersion(), info.getVersionHash(),
-                                       info.getDataSize(), info.getRowCount());
+                                              info.getDataSize(), info.getRowCount());
                 }
             }
-    
+
             long jobId = job.getId();
             Map<Long, TableLoadInfo> idToTableLoadInfo = job.getIdToTableLoadInfo();
             if (idToTableLoadInfo != null) {
@@ -1784,9 +1784,9 @@ public class Load {
                         if (!partitionLoadInfo.isNeedLoad()) {
                             continue;
                         }
-                        updatePartitionVersion(partition, partitionLoadInfo.getVersion(), 
+                        updatePartitionVersion(partition, partitionLoadInfo.getVersion(),
                                                partitionLoadInfo.getVersionHash(), jobId);
-                        
+
                         // update table row count
                         for (MaterializedIndex materializedIndex : partition.getMaterializedIndices()) {
                             long tableRowCount = 0L;
@@ -1805,13 +1805,13 @@ public class Load {
                     } // end for partitions
                 } // end for tables
             }
-            
+
             idToLoadingLoadJob.remove(jobId);
             idToQuorumFinishedLoadJob.put(jobId, job);
         }
         replaceLoadJob(job);
     }
-    
+
     public void replayQuorumLoadJob(LoadJob job, Catalog catalog) throws DdlException {
         // TODO: need to call this.writeLock()?
         Database db = catalog.getDb(job.getDbId());
@@ -1827,13 +1827,13 @@ public class Load {
             db.writeUnlock();
         }
     }
-    
+
     public void unprotectFinishLoadJob(LoadJob job, Database db) {
         // in real time load, replica info is not set by job, it is set by transaction manager
         long jobId = job.getId();
         if (job.getTransactionId() < 0) {
             idToQuorumFinishedLoadJob.remove(jobId);
-            
+
             // Update database information
             Map<Long, ReplicaPersistInfo> replicaInfos = job.getReplicaPersistInfos();
             if (replicaInfos != null) {
@@ -1858,14 +1858,14 @@ public class Load {
                         LOG.warn("the tablet[{}] is missing", info.getTabletId());
                         continue;
                     }
-    
+
                     Replica replica = tablet.getReplicaById(info.getReplicaId());
                     if (replica == null) {
                         LOG.warn("the replica[{}] is missing", info.getReplicaId());
                         continue;
                     }
                     replica.updateVersionInfo(info.getVersion(), info.getVersionHash(),
-                                       info.getDataSize(), info.getRowCount());
+                                              info.getDataSize(), info.getRowCount());
                 }
             }
         } else {
@@ -1879,7 +1879,7 @@ public class Load {
         }
         replaceLoadJob(job);
     }
-    
+
     public void replayFinishLoadJob(LoadJob job, Catalog catalog) {
         // TODO: need to call this.writeLock()?
         Database db = catalog.getDb(job.getDbId());
@@ -1895,7 +1895,7 @@ public class Load {
             db.writeUnlock();
         }
     }
-    
+
     public void replayClearRollupInfo(ReplicaPersistInfo info, Catalog catalog) {
         Database db = catalog.getDb(info.getDbId());
         db.writeLock();
@@ -1911,7 +1911,7 @@ public class Load {
 
     private void replaceLoadJob(LoadJob job) {
         long jobId = job.getId();
-        
+
         // Replace LoadJob in idToLoadJob
         if (!idToLoadJob.containsKey(jobId)) {
             // This may happen when we drop db while there are still load jobs running
@@ -1919,13 +1919,13 @@ public class Load {
             return;
         }
         idToLoadJob.put(jobId, job);
-        
+
         if (!job.isSyncDeleteJob()) {
             // Replace LoadJob in dbToLoadJobs
             List<LoadJob> jobs = dbToLoadJobs.get(job.getDbId());
             if (jobs == null) {
-                LOG.warn("Does not find db in dbToLoadJobs. DbId : {}", 
-                        job.getDbId());
+                LOG.warn("Does not find db in dbToLoadJobs. DbId : {}",
+                         job.getDbId());
                 return;
             }
             int pos = 0;
@@ -1936,23 +1936,23 @@ public class Load {
                 pos++;
             }
             if (pos == jobs.size()) {
-                LOG.warn("Does not find load job for db. DbId : {}, jobId : {}", 
-                        job.getDbId(), jobId);
+                LOG.warn("Does not find load job for db. DbId : {}, jobId : {}",
+                         job.getDbId(), jobId);
                 return;
             }
             jobs.remove(pos);
             jobs.add(pos, job);
-            
+
             // Replace LoadJob in dbLabelToLoadJobs
             if (dbLabelToLoadJobs.get(job.getDbId()) == null) {
-                LOG.warn("Does not find db in dbLabelToLoadJobs. DbId : {}", 
-                        job.getDbId());
+                LOG.warn("Does not find db in dbLabelToLoadJobs. DbId : {}",
+                         job.getDbId());
                 return;
             }
             jobs = dbLabelToLoadJobs.get(job.getDbId()).get(job.getLabel());
             if (jobs == null) {
-                LOG.warn("Does not find label for db. label : {}, DbId : {}", 
-                        job.getLabel(), job.getDbId());
+                LOG.warn("Does not find label for db. label : {}, DbId : {}",
+                         job.getLabel(), job.getDbId());
                 return;
             }
             pos = 0;
@@ -1963,8 +1963,8 @@ public class Load {
                 pos++;
             }
             if (pos == jobs.size()) {
-                LOG.warn("Does not find load job for label. label : {}, DbId : {}", 
-                        job.getLabel(), job.getDbId());
+                LOG.warn("Does not find load job for label. label : {}, DbId : {}",
+                         job.getLabel(), job.getDbId());
                 return;
             }
             jobs.remove(pos);
@@ -1973,8 +1973,8 @@ public class Load {
             // Replace LoadJob in dbToLoadJobs
             List<LoadJob> jobs = dbToDeleteJobs.get(job.getDbId());
             if (jobs == null) {
-                LOG.warn("Does not find db in dbToDeleteJobs. DbId : {}", 
-                        job.getDbId());
+                LOG.warn("Does not find db in dbToDeleteJobs. DbId : {}",
+                         job.getDbId());
                 return;
             }
             int pos = 0;
@@ -1985,15 +1985,15 @@ public class Load {
                 pos++;
             }
             if (pos == jobs.size()) {
-                LOG.warn("Does not find delete load job for db. DbId : {}, jobId : {}", 
-                        job.getDbId(), jobId);
+                LOG.warn("Does not find delete load job for db. DbId : {}, jobId : {}",
+                         job.getDbId(), jobId);
                 return;
             }
             jobs.remove(pos);
             jobs.add(pos, job);
         }
     }
- 
+
     // remove all db jobs from dbToLoadJobs and dbLabelToLoadJobs
     // only remove finished or cancelled job from idToLoadJob
     // LoadChecker will update other state jobs to cancelled or finished, 
@@ -2025,7 +2025,7 @@ public class Load {
     // This function is called periodically. every Configure.label_keep_max_second seconds
     public void removeOldLoadJobs() {
         long currentTimeMs = System.currentTimeMillis();
-        
+
         writeLock();
         try {
             Iterator<Map.Entry<Long, LoadJob>> iter = idToLoadJob.entrySet().iterator();
@@ -2038,7 +2038,7 @@ public class Load {
                     String label = job.getLabel();
                     // Remove job from idToLoadJob
                     iter.remove();
-                    
+
                     // Remove job from dbToLoadJobs
                     List<LoadJob> loadJobs = dbToLoadJobs.get(dbId);
                     if (loadJobs != null) {
@@ -2047,7 +2047,7 @@ public class Load {
                             dbToLoadJobs.remove(dbId);
                         }
                     }
-                    
+
                     // remove delete job from dbToDeleteJobs
                     List<LoadJob> deleteJobs = dbToDeleteJobs.get(dbId);
                     if (deleteJobs != null) {
@@ -2056,7 +2056,7 @@ public class Load {
                             dbToDeleteJobs.remove(dbId);
                         }
                     }
-                    
+
                     // Remove job from dbLabelToLoadJobs
                     Map<String, List<LoadJob>> mapLabelToJobs = dbLabelToLoadJobs.get(dbId);
                     if (mapLabelToJobs != null) {
@@ -2098,12 +2098,12 @@ public class Load {
                         LOG.warn("kill etl job error", e);
                     }
                 }
-                
+
                 // delete all dirs releated to job label, use "" instead of job.getEtlOutputDir()
                 // hdfs://host:port/outputPath/dbId/loadLabel/
                 DppConfig dppConfig = job.getHadoopDppConfig();
                 String outputPath = DppScheduler.getEtlOutputPath(dppConfig.getFsDefaultName(),
-                        dppConfig.getOutputPath(), job.getDbId(), job.getLabel(), "");
+                                                                  dppConfig.getOutputPath(), job.getDbId(), job.getLabel(), "");
                 try {
                     dppScheduler.deleteEtlOutputPath(outputPath);
                 } catch (Exception e) {
@@ -2118,14 +2118,14 @@ public class Load {
                         LOG.warn("backend does not exist. id: {}", backendId);
                         break;
                     }
-                    
+
                     long dbId = job.getDbId();
                     Database db = Catalog.getInstance().getDb(dbId);
                     if (db == null) {
                         LOG.warn("db does not exist. id: {}", dbId);
                         break;
                     }
-                    
+
                     AgentClient client = new AgentClient(backend.getHost(), backend.getBePort());
                     client.deleteEtlFiles(dbId, job.getId(), db.getFullName(), job.getLabel());
                 }
@@ -2141,11 +2141,11 @@ public class Load {
                 break;
         }
     }
-    
+
     public boolean updateLoadJobState(LoadJob job, JobState destState) {
         return updateLoadJobState(job, destState, CancelType.UNKNOWN, null);
     }
-   
+
     public boolean updateLoadJobState(LoadJob job, JobState destState, CancelType cancelType, String msg) {
         boolean result = true;
         JobState srcState = null;
@@ -2180,10 +2180,10 @@ public class Load {
                     Set<JobState> destStates = STATE_CHANGE_MAP.get(srcState);
                     if (!destStates.contains(destState)) {
                         LOG.warn("state change error. src state: {}, dest state: {}",
-                                srcState.name(), destState.name());
+                                 srcState.name(), destState.name());
                         return false;
                     }
-                    
+
                     switch (destState) {
                         case ETL:
                             idToPendingLoadJob.remove(jobId);
@@ -2223,8 +2223,8 @@ public class Load {
                                     DeleteInfo deleteInfo = job.getDeleteInfo();
                                     TableCommitInfo tableCommitInfo = transactionState.getTableCommitInfo(deleteInfo.getTableId());
                                     PartitionCommitInfo partitionCommitInfo = tableCommitInfo.getPartitionCommitInfo(deleteInfo.getPartitionId());
-                                    deleteInfo.updatePartitionVersionInfo(partitionCommitInfo.getVersion(), 
-                                            partitionCommitInfo.getVersionHash());
+                                    deleteInfo.updatePartitionVersionInfo(partitionCommitInfo.getVersion(),
+                                                                          partitionCommitInfo.getVersionHash());
                                 }
                             }
                             MetricRepo.COUNTER_LOAD_FINISHED.increase(1L);
@@ -2259,14 +2259,14 @@ public class Load {
                 db.writeUnlock();
             }
         }
-        
+
         // check current job state
         if (destState != job.getState()) {
             result = false;
         }
         return result;
     }
-    
+
     private boolean processQuorumFinished(LoadJob job, Database db) {
         long jobId = job.getId();
         // remove partition from loading set
@@ -2312,9 +2312,9 @@ public class Load {
                     continue;
                 }
 
-                updatePartitionVersion(partition, partitionLoadInfo.getVersion(), 
+                updatePartitionVersion(partition, partitionLoadInfo.getVersion(),
                                        partitionLoadInfo.getVersionHash(), jobId);
-                
+
                 for (MaterializedIndex materializedIndex : partition.getMaterializedIndices()) {
                     long tableRowCount = 0L;
                     for (Tablet tablet : materializedIndex.getTablets()) {
@@ -2331,10 +2331,10 @@ public class Load {
                 }
             }
         }
-        
+
         // When start up or checkpoint, Job may stay in pending queue. So remove it.
         idToPendingLoadJob.remove(jobId);
-        
+
         idToLoadingLoadJob.remove(jobId);
         idToQuorumFinishedLoadJob.put(jobId, job);
         job.setProgress(100);
@@ -2349,7 +2349,7 @@ public class Load {
         LOG.info("update partition version success. version: {}, version hash: {}, job id: {}, partition id: {}",
                  version, versionHash, jobId, partitionId);
     }
-   
+
     private boolean processCancelled(LoadJob job, CancelType cancelType, String msg) {
         long jobId = job.getId();
         JobState srcState = job.getState();
@@ -2358,7 +2358,7 @@ public class Load {
         // then there will be rubbish transactions in transaction manager
         try {
             Catalog.getCurrentGlobalTransactionMgr().abortTransaction(
-                    job.getTransactionId(), 
+                    job.getTransactionId(),
                     job.getFailMsg().toString());
         } catch (Exception e) {
             LOG.info("errors while abort transaction", e);
@@ -2397,7 +2397,7 @@ public class Load {
         job.setFailMsg(failMsg);
         job.setLoadFinishTimeMs(System.currentTimeMillis());
         job.setState(JobState.CANCELLED);
-        
+
         // clear push tasks
         if (srcState == JobState.LOADING || srcState == JobState.QUORUM_FINISHED) {
             for (PushTask pushTask : job.getPushTasks()) {
@@ -2406,14 +2406,14 @@ public class Load {
                                               pushTask.getPushType(), pushTask.getTaskType());
             }
         }
-        
+
         // Clear the Map and Set in this job, reduce the memory cost of canceled load job.
         job.clearRedundantInfoForHistoryJob();
         Catalog.getInstance().getEditLog().logLoadCancel(job);
 
         return true;
     }
-    
+
     public boolean addLoadingPartitions(Set<Long> partitionIds) {
         writeLock();
         try {
@@ -2529,7 +2529,7 @@ public class Load {
                 Tablet tablet = index.getTablet(info.getTabletId());
                 Replica replica = tablet.getReplicaById(info.getReplicaId());
                 replica.updateVersionInfo(info.getVersion(), info.getVersionHash(),
-                                   info.getDataSize(), info.getRowCount());
+                                          info.getDataSize(), info.getRowCount());
             }
         }
 
@@ -2550,7 +2550,7 @@ public class Load {
             LOG.info("unprotected add asyncDeleteJob: {}", asyncDeleteJob.getJobId());
         }
     }
-    
+
     public void replayFinishAsyncDeleteJob(AsyncDeleteJob deleteJob, Catalog catalog) {
         Database db = catalog.getDb(deleteJob.getDbId());
         db.writeLock();
@@ -2588,7 +2588,7 @@ public class Load {
                             continue;
                         }
                         replica.updateVersionInfo(info.getVersion(), info.getVersionHash(),
-                                           info.getDataSize(), info.getRowCount());
+                                                  info.getDataSize(), info.getRowCount());
                     }
                 }
             } finally {
@@ -2616,8 +2616,9 @@ public class Load {
             db.writeUnlock();
         }
     }
+
     private void checkDeleteV2(OlapTable table, Partition partition, List<Predicate> conditions, List<String> deleteConditions, boolean preCheck)
-                    throws DdlException {
+            throws DdlException {
 
         // check partition state
         PartitionState state = partition.getState();
@@ -2626,7 +2627,7 @@ public class Load {
             throw new DdlException("Partition[" + partition.getName() + "]' state is not NORNAL: " + state.name());
         }
         // do not need check whether partition has loading job
-        
+
         // async delete job does not exist any more
 
         // check condition column is key column and condition value
@@ -2647,13 +2648,13 @@ public class Load {
             if (!nameToColumn.containsKey(columnName)) {
                 ErrorReport.reportDdlException(ErrorCode.ERR_BAD_FIELD_ERROR, columnName, table.getName());
             }
-            
+
             Column column = nameToColumn.get(columnName);
             if (!column.isKey()) {
                 // ErrorReport.reportDdlException(ErrorCode.ERR_NOT_KEY_COLUMN, columnName);
                 throw new DdlException("Column[" + columnName + "] is not key column");
             }
-            
+
             if (condition instanceof BinaryPredicate) {
                 String value = null;
                 try {
@@ -2697,9 +2698,9 @@ public class Load {
             }
 
             // do not need to check replica version and backend alive
-            
+
         } // end for indices
-        
+
         if (deleteConditions == null) {
             return;
         }
@@ -2712,7 +2713,7 @@ public class Load {
                 String columnName = slotRef.getColumnName();
                 StringBuilder sb = new StringBuilder();
                 sb.append(columnName).append(" ").append(binaryPredicate.getOp().name()).append(" \"")
-                    .append(((LiteralExpr) binaryPredicate.getChild(1)).getStringValue()).append("\"");
+                        .append(((LiteralExpr) binaryPredicate.getChild(1)).getStringValue()).append("\"");
                 deleteConditions.add(sb.toString());
             } else if (condition instanceof IsNullPredicate) {
                 IsNullPredicate isNullPredicate = (IsNullPredicate) condition;
@@ -2729,7 +2730,7 @@ public class Load {
             }
         }
     }
-    
+
     private void checkDelete(OlapTable table, Partition partition, List<Predicate> conditions,
                              long checkVersion, long checkVersionHash, List<String> deleteConditions,
                              Map<Long, Set<Long>> asyncTabletIdToBackends, boolean preCheck)
@@ -2740,14 +2741,14 @@ public class Load {
             // ErrorReport.reportDdlException(ErrorCode.ERR_BAD_PARTITION_STATE, partition.getName(), state.name());
             throw new DdlException("Partition[" + partition.getName() + "]' state is not NORNAL: " + state.name());
         }
-        
+
         // check running load job
         List<LoadJob> quorumFinishedLoadJobs = Lists.newArrayList();
         if (!checkPartitionLoadFinished(partition.getId(), quorumFinishedLoadJobs)) {
             // ErrorReport.reportDdlException(ErrorCode.ERR_PARTITION_HAS_LOADING_JOBS, partition.getName());
             throw new DdlException("Partition[" + partition.getName() + "] has unfinished load jobs");
         }
-        
+
         // get running async delete job
         List<AsyncDeleteJob> asyncDeleteJobs = getCopiedAsyncDeleteJobs();
 
@@ -2769,13 +2770,13 @@ public class Load {
             if (!nameToColumn.containsKey(columnName)) {
                 ErrorReport.reportDdlException(ErrorCode.ERR_BAD_FIELD_ERROR, columnName, table.getName());
             }
-            
+
             Column column = nameToColumn.get(columnName);
             if (!column.isKey()) {
                 // ErrorReport.reportDdlException(ErrorCode.ERR_NOT_KEY_COLUMN, columnName);
                 throw new DdlException("Column[" + columnName + "] is not key column");
             }
-            
+
             if (condition instanceof BinaryPredicate) {
                 String value = null;
                 try {
@@ -2791,7 +2792,7 @@ public class Load {
             // set schema column name
             slotRef.setCol(column.getName());
         }
-        
+
         long tableId = table.getId();
         long partitionId = partition.getId();
         Map<Long, List<Column>> indexIdToSchema = table.getIndexIdToSchema();
@@ -2886,12 +2887,12 @@ public class Load {
                                 } else {
                                     // this should not happend. add log to observe.
                                     LOG.error("replica version does not catch up with version: {}-{}. "
-                                            + "replica: {}-{}-{}-{}",
+                                                      + "replica: {}-{}-{}-{}",
                                               checkVersion, checkVersionHash, replica.getId(), tablet.getId(),
                                               replica.getBackendId(), replica.getState());
                                     throw new DdlException("Replica[" + tablet.getId() + "-" + replica.getId()
-                                            + "] is not catch up with version: " + checkVersion + "-"
-                                            + replica.getVersion());
+                                                                   + "] is not catch up with version: " + checkVersion + "-"
+                                                                   + replica.getVersion());
                                 }
                             }
                         }
@@ -2904,7 +2905,7 @@ public class Load {
                     String backendsStr = Joiner.on(", ").join(needAsyncBackendIds);
                     LOG.warn("too many unavailable replica in tablet[{}], backends:[{}]", tablet.getId(), backendsStr);
                     throw new DdlException("Too many replicas are not available. Wait 10 mins and try again."
-                            + " if still not work, contact Palo RD");
+                                                   + " if still not work, contact Palo RD");
                 }
 
                 if (!needAsyncBackendIds.isEmpty()) {
@@ -2914,7 +2915,7 @@ public class Load {
                 }
             } // end for tablets
         } // end for indices
-        
+
         if (deleteConditions == null) {
             return;
         }
@@ -2927,7 +2928,7 @@ public class Load {
                 String columnName = slotRef.getColumnName();
                 StringBuilder sb = new StringBuilder();
                 sb.append(columnName).append(" ").append(binaryPredicate.getOp().name()).append(" \"")
-                    .append(((LiteralExpr) binaryPredicate.getChild(1)).getStringValue()).append("\"");
+                        .append(((LiteralExpr) binaryPredicate.getChild(1)).getStringValue()).append("\"");
                 deleteConditions.add(sb.toString());
             } else if (condition instanceof IsNullPredicate) {
                 IsNullPredicate isNullPredicate = (IsNullPredicate) condition;
@@ -2974,16 +2975,16 @@ public class Load {
             for (AsyncDeleteJob job : idToQuorumFinishedDeleteJob.values()) {
                 if (job.getPartitionId() == partitionId) {
                     throw new DdlException("Partition[" + partitionName + "] has running async delete job. "
-                            + "See 'SHOW DELETE'");
+                                                   + "See 'SHOW DELETE'");
                 }
             }
             for (long dbId : dbToDeleteJobs.keySet()) {
                 List<LoadJob> loadJobs = dbToDeleteJobs.get(dbId);
                 for (LoadJob loadJob : loadJobs) {
-                    if (loadJob.getDeleteInfo().getPartitionId() == partitionId 
+                    if (loadJob.getDeleteInfo().getPartitionId() == partitionId
                             && loadJob.getState() == JobState.LOADING) {
                         throw new DdlException("Partition[" + partitionName + "] has running async delete job. "
-                                + "See 'SHOW DELETE'");
+                                                       + "See 'SHOW DELETE'");
                     }
                 }
             }
@@ -3036,17 +3037,17 @@ public class Load {
             List<String> deleteConditions = Lists.newArrayList();
             // pre check
             checkDeleteV2(olapTable, partition, conditions,
-                    deleteConditions, true);
+                          deleteConditions, true);
             checkAndAddRunningSyncDeleteJob(partitionId, partitionName);
             // do not use transaction id generator, or the id maybe duplicated
             long jobId = Catalog.getInstance().getNextId();
             String jobLabel = "delete_" + UUID.randomUUID();
             // the version info in delete info will be updated after job finished
             DeleteInfo deleteInfo = new DeleteInfo(db.getId(), tableId, tableName,
-                                        partition.getId(), partitionName, 
-                                        -1, 0, deleteConditions);
-            loadDeleteJob = new LoadJob(jobId, db.getId(), tableId, 
-                    partitionId, jobLabel, olapTable.getIndexIdToSchemaHash(), conditions, deleteInfo);
+                                                   partition.getId(), partitionName,
+                                                   -1, 0, deleteConditions);
+            loadDeleteJob = new LoadJob(jobId, db.getId(), tableId,
+                                        partitionId, jobLabel, olapTable.getIndexIdToSchemaHash(), conditions, deleteInfo);
             Map<Long, TabletLoadInfo> idToTabletLoadInfo = Maps.newHashMap();
             for (MaterializedIndex materializedIndex : partition.getMaterializedIndices()) {
                 for (Tablet tablet : materializedIndex.getTablets()) {
@@ -3058,8 +3059,8 @@ public class Load {
             }
             loadDeleteJob.setIdToTabletLoadInfo(idToTabletLoadInfo);
             loadDeleteJob.setState(JobState.LOADING);
-            long transactionId = Catalog.getCurrentGlobalTransactionMgr().beginTransaction(db.getId(), jobLabel, 
-                    "fe", LoadJobSourceType.FRONTEND);
+            long transactionId = Catalog.getCurrentGlobalTransactionMgr().beginTransaction(db.getId(), jobLabel,
+                                                                                           "fe", LoadJobSourceType.FRONTEND);
             loadDeleteJob.setTransactionId(transactionId);
             // the delete job will be persist in editLog
             addLoadJob(loadDeleteJob, db);
@@ -3076,7 +3077,7 @@ public class Load {
             while (true) {
                 db.writeLock();
                 try {
-                    if (loadDeleteJob.getState() == JobState.FINISHED 
+                    if (loadDeleteJob.getState() == JobState.FINISHED
                             || loadDeleteJob.getState() == JobState.CANCELLED) {
                         break;
                     }
@@ -3107,7 +3108,7 @@ public class Load {
             }
         }
     }
-    
+
     public void deleteOld(DeleteStmt stmt) throws DdlException {
         String dbName = stmt.getDbName();
         String tableName = stmt.getTableName();
@@ -3117,7 +3118,7 @@ public class Load {
         if (db == null) {
             throw new DdlException("Db does not exist. name: " + dbName);
         }
-        
+
         DeleteInfo deleteInfo = null;
 
         long tableId = -1;
@@ -3151,7 +3152,7 @@ public class Load {
                 throw new DdlException("Partition does not exist. name: " + partitionName);
             }
             partitionId = partition.getId();
-            
+
             // pre check
             visibleVersion = partition.getVisibleVersion();
             visibleVersionHash = partition.getVisibleVersionHash();
@@ -3161,9 +3162,9 @@ public class Load {
             newVersion = visibleVersion + 1;
             newVersionHash = Util.generateVersionHash();
             deleteInfo = new DeleteInfo(db.getId(), tableId, tableName,
-                                        partition.getId(), partitionName, 
+                                        partition.getId(), partitionName,
                                         newVersion, newVersionHash, null);
-            
+
             checkAndAddRunningSyncDeleteJob(deleteInfo.getPartitionId(), partitionName);
 
             // create sync delete tasks
@@ -3195,7 +3196,7 @@ public class Load {
         } finally {
             db.readUnlock();
         }
-        
+
         // send tasks to backends
         MarkedCountDownLatch countDownLatch = new MarkedCountDownLatch(totalReplicaNum);
         for (AgentTask task : deleteBatchTask.getAllTasks()) {
@@ -3265,7 +3266,7 @@ public class Load {
                                                                            replica.getVersion(),
                                                                            replica.getVersionHash(),
                                                                            replica.getDataSize(),
-                                                                           replica.getRowCount(), 
+                                                                           replica.getRowCount(),
                                                                            replica.getLastFailedVersion(),
                                                                            replica.getLastFailedVersionHash(),
                                                                            replica.getLastSuccessVersion(),
@@ -3289,7 +3290,7 @@ public class Load {
                         idToQuorumFinishedDeleteJob.put(asyncDeleteJob.getJobId(), asyncDeleteJob);
                         LOG.info("finished create async delete job: {}", asyncDeleteJob.getJobId());
                     }
-                    
+
                     // save delete info
                     List<DeleteInfo> deleteInfos = dbToDeleteInfos.get(db.getId());
                     if (deleteInfos == null) {
@@ -3376,7 +3377,7 @@ public class Load {
 
         return infos;
     }
-    
+
     public int getDeleteJobNumByState(long dbId, JobState state) {
         readLock();
         try {
@@ -3387,7 +3388,7 @@ public class Load {
                 int deleteJobNum = 0;
                 for (LoadJob job : deleteJobs) {
                     if (job.getState() == state) {
-                        ++ deleteJobNum;
+                        ++deleteJobNum;
                     }
                 }
                 return deleteJobNum;
@@ -3413,12 +3414,12 @@ public class Load {
 
     public List<List<Comparable>> getDeleteInfosByDb(long dbId, boolean forUser) {
         LinkedList<List<Comparable>> infos = new LinkedList<List<Comparable>>();
-		Database db = Catalog.getInstance().getDb(dbId);
-		if (db == null) {
-			return infos;
-		}
+        Database db = Catalog.getInstance().getDb(dbId);
+        if (db == null) {
+            return infos;
+        }
 
-		String dbName = db.getFullName();
+        String dbName = db.getFullName();
         readLock();
         try {
             List<LoadJob> deleteJobs = dbToDeleteJobs.get(dbId);
@@ -3597,7 +3598,7 @@ public class Load {
                     ++num;
                 }
             }
-            
+
         } finally {
             readUnlock();
         }

--- a/fe/src/main/java/org/apache/doris/load/TxnStateChangeListener.java
+++ b/fe/src/main/java/org/apache/doris/load/TxnStateChangeListener.java
@@ -1,0 +1,50 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.load;
+
+import org.apache.doris.transaction.AbortTransactionException;
+import org.apache.doris.transaction.TransactionState;
+
+public interface TxnStateChangeListener {
+
+    /**
+     * update catalog of job which has related txn after transaction has been committed
+     *
+     * @param txnState
+     */
+    void onCommitted(TransactionState txnState);
+
+    /**
+     * this interface is executed before txn aborted, you can check if txn could be abort in this stage
+     *
+     * @param txnState
+     * @param txnStatusChangeReason maybe null
+     * @throws AbortTransactionException if transaction could not be abort or there are some exception before aborted,
+     *                                   it will throw this exception
+     */
+    void beforeAborted(TransactionState txnState, TransactionState.TxnStatusChangeReason txnStatusChangeReason)
+            throws AbortTransactionException;
+
+    /**
+     * this interface is executed when transaction has been aborted
+     *
+     * @param txnState
+     * @param txnStatusChangeReason maybe null
+     */
+    void onAborted(TransactionState txnState, TransactionState.TxnStatusChangeReason txnStatusChangeReason);
+}

--- a/fe/src/main/java/org/apache/doris/load/routineload/KafkaProgress.java
+++ b/fe/src/main/java/org/apache/doris/load/routineload/KafkaProgress.java
@@ -17,15 +17,31 @@
 
 package org.apache.doris.load.routineload;
 
+import com.google.common.base.Joiner;
+import org.apache.doris.common.io.Writable;
+import org.apache.doris.thrift.TKafkaRLTaskProgress;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import java.util.HashMap;
 import java.util.Map;
 
 /**
  * this is description of kafka routine load progress
  * the data before offset was already loaded in doris
  */
-public class KafkaProgress {
+// {"partitionIdToOffset": {}}
+public class KafkaProgress extends RoutineLoadProgress {
 
     private Map<Integer, Long> partitionIdToOffset;
+
+    public KafkaProgress() {
+    }
+
+    public KafkaProgress(TKafkaRLTaskProgress tKafkaRLTaskProgress) {
+        this.partitionIdToOffset = tKafkaRLTaskProgress.getPartitionIdToOffset();
+    }
 
     public Map<Integer, Long> getPartitionIdToOffset() {
         return partitionIdToOffset;
@@ -33,5 +49,36 @@ public class KafkaProgress {
 
     public void setPartitionIdToOffset(Map<Integer, Long> partitionIdToOffset) {
         this.partitionIdToOffset = partitionIdToOffset;
+    }
+
+    @Override
+    public void update(RoutineLoadProgress progress) {
+        KafkaProgress newProgress = (KafkaProgress) progress;
+        newProgress.getPartitionIdToOffset().entrySet().parallelStream()
+                .forEach(entity -> partitionIdToOffset.put(entity.getKey(), entity.getValue()));
+    }
+
+    @Override
+    public void write(DataOutput out) throws IOException {
+        out.writeInt(partitionIdToOffset.size());
+        for (Map.Entry entry : partitionIdToOffset.entrySet()) {
+            out.writeInt((Integer) entry.getKey());
+            out.writeLong((Long) entry.getValue());
+        }
+    }
+
+    @Override
+    public void readFields(DataInput in) throws IOException {
+        int size = in.readInt();
+        partitionIdToOffset = new HashMap<>();
+        for (int i = 0; i < size; i++) {
+            partitionIdToOffset.put(in.readInt(), in.readLong());
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "KafkaProgress [partitionIdToOffset="
+                + Joiner.on("|").withKeyValueSeparator("_").join(partitionIdToOffset) + "]";
     }
 }

--- a/fe/src/main/java/org/apache/doris/load/routineload/RLTaskTxnCommitAttachment.java
+++ b/fe/src/main/java/org/apache/doris/load/routineload/RLTaskTxnCommitAttachment.java
@@ -1,0 +1,176 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.load.routineload;
+
+import org.apache.doris.common.io.Text;
+import org.apache.doris.thrift.TRLTaskTxnCommitAttachment;
+import org.apache.doris.thrift.TRoutineLoadTaskTxnExtra;
+import org.apache.doris.transaction.TxnCommitAttachment;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+
+// {"progress": "", "backendId": "", "taskSignature": "", "numOfErrorData": "",
+// "numOfTotalData": "", "taskId": "", "jobId": ""}
+public class RLTaskTxnCommitAttachment extends TxnCommitAttachment {
+
+    public enum RoutineLoadType {
+        KAFKA(1);
+
+        private final int flag;
+
+        private RoutineLoadType(int flag) {
+            this.flag = flag;
+        }
+
+        public int value() {
+            return flag;
+        }
+
+        public static RoutineLoadType valueOf(int flag) {
+            switch (flag) {
+                case 1:
+                    return KAFKA;
+                default:
+                    return null;
+            }
+        }
+    }
+
+    private RoutineLoadProgress progress;
+    private long backendId;
+    private long taskSignature;
+    private int numOfErrorData;
+    private int numOfTotalData;
+    private String taskId;
+    private String jobId;
+    private RoutineLoadType routineLoadType;
+
+    public RLTaskTxnCommitAttachment() {
+    }
+
+    public RLTaskTxnCommitAttachment(TRLTaskTxnCommitAttachment rlTaskTxnCommitAttachment) {
+        this.backendId = rlTaskTxnCommitAttachment.getBackendId();
+        this.taskSignature = rlTaskTxnCommitAttachment.getTaskSignature();
+        this.numOfErrorData = rlTaskTxnCommitAttachment.getNumOfErrorData();
+        this.numOfTotalData = rlTaskTxnCommitAttachment.getNumOfTotalData();
+        this.taskId = rlTaskTxnCommitAttachment.getTaskId();
+        this.jobId = rlTaskTxnCommitAttachment.getJobId();
+        switch (rlTaskTxnCommitAttachment.getRoutineLoadType()) {
+            case KAFKA:
+                this.progress = new KafkaProgress(rlTaskTxnCommitAttachment.getKafkaRLTaskProgress());
+        }
+    }
+
+    public RoutineLoadProgress getProgress() {
+        return progress;
+    }
+
+    public void setProgress(RoutineLoadProgress progress) {
+        this.progress = progress;
+    }
+
+    public long getBackendId() {
+        return backendId;
+    }
+
+    public void setBackendId(long backendId) {
+        this.backendId = backendId;
+    }
+
+    public long getTaskSignature() {
+        return taskSignature;
+    }
+
+    public void setTaskSignature(long taskSignature) {
+        this.taskSignature = taskSignature;
+    }
+
+    public int getNumOfErrorData() {
+        return numOfErrorData;
+    }
+
+    public void setNumOfErrorData(int numOfErrorData) {
+        this.numOfErrorData = numOfErrorData;
+    }
+
+    public int getNumOfTotalData() {
+        return numOfTotalData;
+    }
+
+    public void setNumOfTotalData(int numOfTotalData) {
+        this.numOfTotalData = numOfTotalData;
+    }
+
+    public String getTaskId() {
+        return taskId;
+    }
+
+    public void setTaskId(String taskId) {
+        this.taskId = taskId;
+    }
+
+    public String getJobId() {
+        return jobId;
+    }
+
+    public void setJobId(String jobId) {
+        this.jobId = jobId;
+    }
+
+    @Override
+    public String toString() {
+        return "RoutineLoadTaskTxnExtra [backendId=" + backendId
+                + ", taskSignature=" + taskSignature
+                + ", numOfErrorData=" + numOfErrorData
+                + ", numOfTotalData=" + numOfTotalData
+                + ", taskId=" + taskId
+                + ", jobId=" + jobId
+                + ", progress=" + progress.toString() + "]";
+    }
+
+    @Override
+    public void write(DataOutput out) throws IOException {
+        out.writeLong(backendId);
+        out.writeLong(taskSignature);
+        out.writeInt(numOfErrorData);
+        out.writeInt(numOfTotalData);
+        Text.writeString(out, taskId);
+        Text.writeString(out, jobId);
+        out.writeInt(routineLoadType.value());
+        progress.write(out);
+    }
+
+    @Override
+    public void readFields(DataInput in) throws IOException {
+        backendId = in.readLong();
+        taskSignature = in.readLong();
+        numOfErrorData = in.readInt();
+        numOfTotalData = in.readInt();
+        taskId = Text.readString(in);
+        jobId = Text.readString(in);
+        routineLoadType = RoutineLoadType.valueOf(in.readInt());
+        switch (routineLoadType) {
+            case KAFKA:
+                KafkaProgress kafkaProgress = new KafkaProgress();
+                kafkaProgress.readFields(in);
+                progress = kafkaProgress;
+        }
+    }
+}

--- a/fe/src/main/java/org/apache/doris/load/routineload/RoutineLoadJob.java
+++ b/fe/src/main/java/org/apache/doris/load/routineload/RoutineLoadJob.java
@@ -17,18 +17,34 @@
 
 package org.apache.doris.load.routineload;
 
+import com.google.common.collect.Lists;
+import org.apache.doris.catalog.Catalog;
+import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.LoadException;
 import org.apache.doris.common.MetaNotFoundException;
+import org.apache.doris.common.UserException;
 import org.apache.doris.common.io.Writable;
+import org.apache.doris.load.TxnStateChangeListener;
+import org.apache.doris.service.ExecuteEnv;
+import org.apache.doris.service.FrontendServiceImpl;
+import org.apache.doris.task.AgentTaskQueue;
+import org.apache.doris.thrift.TLoadTxnCommitRequest;
 import org.apache.doris.thrift.TResourceInfo;
+import org.apache.doris.thrift.TTaskType;
+import org.apache.doris.transaction.AbortTransactionException;
+import org.apache.doris.transaction.BeginTransactionException;
+import org.apache.doris.transaction.LabelAlreadyExistsException;
+import org.apache.doris.transaction.TransactionState;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.thrift.TException;
 
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 /**
@@ -38,12 +54,13 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
  * The desireTaskConcurrentNum means that user expect the number of concurrent stream load
  * The routine load job support different streaming medium such as KAFKA
  */
-public abstract class RoutineLoadJob implements Writable {
-
+public abstract class RoutineLoadJob implements Writable, TxnStateChangeListener {
+    
     private static final Logger LOG = LogManager.getLogger(RoutineLoadJob.class);
-
+    
     private static final int DEFAULT_TASK_TIMEOUT_SECONDS = 10;
-
+    private static final int BASE_OF_ERROR_RATE = 10000;
+    
     public enum JobState {
         NEED_SCHEDULER,
         RUNNING,
@@ -51,11 +68,11 @@ public abstract class RoutineLoadJob implements Writable {
         STOPPED,
         CANCELLED
     }
-
+    
     public enum DataSourceType {
         KAFKA
     }
-
+    
     protected String id;
     protected String name;
     protected String userName;
@@ -69,20 +86,28 @@ public abstract class RoutineLoadJob implements Writable {
     protected JobState state;
     protected DataSourceType dataSourceType;
     // max number of error data in ten thousand data
+    // maxErrorNum / BASE_OF_ERROR_RATE = max error rate of routine load job
+    // if current error rate is more then max error rate, the job will be paused
     protected int maxErrorNum;
-    protected String progress;
-
+    protected RoutineLoadProgress progress;
+    protected String pausedReason;
+    
+    // currentErrorNum and currentTotalNum will be update
+    // when currentTotalNum is more then ten thousand or currentErrorNum is more then maxErrorNum
+    protected int currentErrorNum;
+    protected int currentTotalNum;
+    
     // The tasks belong to this job
     protected List<RoutineLoadTaskInfo> routineLoadTaskInfoList;
     protected List<RoutineLoadTaskInfo> needSchedulerTaskInfoList;
-
+    
     protected ReentrantReadWriteLock lock;
     // TODO(ml): error sample
-
-
+    
+    
     public RoutineLoadJob() {
     }
-
+    
     public RoutineLoadJob(String id, String name, String userName, long dbId, long tableId,
                           String partitions, String columns, String where, String columnSeparator,
                           int desireTaskConcurrentNum, JobState state, DataSourceType dataSourceType,
@@ -101,67 +126,70 @@ public abstract class RoutineLoadJob implements Writable {
         this.dataSourceType = dataSourceType;
         this.maxErrorNum = maxErrorNum;
         this.resourceInfo = resourceInfo;
-        this.progress = "";
         this.routineLoadTaskInfoList = new ArrayList<>();
         this.needSchedulerTaskInfoList = new ArrayList<>();
         lock = new ReentrantReadWriteLock(true);
     }
-
+    
     public void readLock() {
         lock.readLock().lock();
     }
-
+    
     public void readUnlock() {
         lock.readLock().unlock();
     }
-
+    
     public void writeLock() {
         lock.writeLock().lock();
     }
-
+    
     public void writeUnlock() {
         lock.writeLock().unlock();
     }
-
+    
     // thrift object
     private TResourceInfo resourceInfo;
-
+    
     public String getId() {
         return id;
     }
-
+    
     public long getDbId() {
         return dbId;
     }
-
+    
     public long getTableId() {
         return tableId;
     }
-
+    
     public String getColumns() {
         return columns;
     }
-
+    
     public String getWhere() {
         return where;
     }
-
+    
     public String getColumnSeparator() {
         return columnSeparator;
     }
-
+    
     public JobState getState() {
         return state;
     }
-
+    
     public void setState(JobState state) {
         this.state = state;
     }
-
+    
     public TResourceInfo getResourceInfo() {
         return resourceInfo;
     }
-
+    
+    public RoutineLoadProgress getProgress() {
+        return progress;
+    }
+    
     public int getSizeOfRoutineLoadTaskInfoList() {
         readLock();
         try {
@@ -169,13 +197,13 @@ public abstract class RoutineLoadJob implements Writable {
         } finally {
             readUnlock();
         }
-
+        
     }
-
+    
     public List<RoutineLoadTaskInfo> getNeedSchedulerTaskInfoList() {
         return needSchedulerTaskInfoList;
     }
-
+    
     public void updateState(JobState jobState) {
         writeLock();
         try {
@@ -184,53 +212,85 @@ public abstract class RoutineLoadJob implements Writable {
             writeUnlock();
         }
     }
-
-    public void processTimeoutTasks() {
+    
+    public List<RoutineLoadTaskInfo> processTimeoutTasks() {
+        List<RoutineLoadTaskInfo> result = new ArrayList<>();
         writeLock();
         try {
             List<RoutineLoadTaskInfo> runningTasks = new ArrayList<>(routineLoadTaskInfoList);
             runningTasks.removeAll(needSchedulerTaskInfoList);
-
+            
             for (RoutineLoadTaskInfo routineLoadTaskInfo : runningTasks) {
                 if ((System.currentTimeMillis() - routineLoadTaskInfo.getLoadStartTimeMs())
                         > DEFAULT_TASK_TIMEOUT_SECONDS * 1000) {
                     String oldSignature = routineLoadTaskInfo.getId();
-                    if (routineLoadTaskInfo instanceof KafkaTaskInfo) {
-                        // remove old task
-                        routineLoadTaskInfoList.remove(routineLoadTaskInfo);
-                        // add new task
-                        KafkaTaskInfo kafkaTaskInfo = new KafkaTaskInfo((KafkaTaskInfo) routineLoadTaskInfo);
-                        routineLoadTaskInfoList.add(kafkaTaskInfo);
-                        needSchedulerTaskInfoList.add(kafkaTaskInfo);
+                    // abort txn if not committed
+                    try {
+                        Catalog.getCurrentGlobalTransactionMgr()
+                                .abortTransaction(routineLoadTaskInfo.getTxnId(), "routine load task of txn was timeout");
+                    } catch (UserException e) {
+                        if (e.getMessage().contains("committed")) {
+                            LOG.debug("txn of task {} has been committed, timeout task has been ignored", oldSignature);
+                            continue;
+                        }
                     }
-                    LOG.debug("Task {} was ran more then {} minutes. It was removed and rescheduled",
-                            oldSignature, DEFAULT_TASK_TIMEOUT_SECONDS);
+                    
+                    try {
+                        result.add(reNewTask(routineLoadTaskInfo));
+                        LOG.debug("Task {} was ran more then {} minutes. It was removed and rescheduled",
+                                  oldSignature, DEFAULT_TASK_TIMEOUT_SECONDS);
+                    } catch (UserException e) {
+                        state = JobState.CANCELLED;
+                        // TODO(ml): edit log
+                        LOG.warn("failed to renew a routine load task in job {} with error message {}", id, e.getMessage());
+                    }
                 }
             }
         } finally {
             writeUnlock();
         }
+        return result;
     }
-
-    public void divideRoutineLoadJob(int currentConcurrentTaskNum) {
-    }
-
+    
+    abstract List<RoutineLoadTaskInfo> divideRoutineLoadJob(int currentConcurrentTaskNum);
+    
     public int calculateCurrentConcurrentTaskNum() throws MetaNotFoundException {
         return 0;
     }
-
+    
     @Override
     public void write(DataOutput out) throws IOException {
         // TODO(ml)
     }
-
+    
     @Override
     public void readFields(DataInput in) throws IOException {
         // TODO(ml)
     }
-
-    abstract RoutineLoadTask createTask(RoutineLoadTaskInfo routineLoadTaskInfo, long beId);
-
+    
+    
+    public void removeNeedSchedulerTask(RoutineLoadTaskInfo routineLoadTaskInfo) {
+        writeLock();
+        try {
+            needSchedulerTaskInfoList.remove(routineLoadTaskInfo);
+        } finally {
+            writeUnlock();
+        }
+    }
+    
+    abstract void updateProgress(RoutineLoadProgress progress);
+    
+    public boolean containsTask(String taskId) {
+        readLock();
+        try {
+            return routineLoadTaskInfoList.parallelStream()
+                    .anyMatch(entity -> entity.getId().equals(taskId));
+        } finally {
+            readUnlock();
+        }
+    }
+    
+    // All of private method could not be call without lock
     private void checkStateTransform(RoutineLoadJob.JobState currentState, RoutineLoadJob.JobState desireState)
             throws LoadException {
         if (currentState == RoutineLoadJob.JobState.PAUSED && desireState == RoutineLoadJob.JobState.NEED_SCHEDULER) {
@@ -240,5 +300,115 @@ public abstract class RoutineLoadJob implements Writable {
             throw new LoadException("could not transform " + currentState + " to " + desireState);
         }
     }
-
+    
+    private void loadTxnCommit(TLoadTxnCommitRequest request) throws TException {
+        FrontendServiceImpl frontendService = new FrontendServiceImpl(ExecuteEnv.getInstance());
+        frontendService.loadTxnCommit(request);
+    }
+    
+    private void updateNumOfData(int numOfErrorData, int numOfTotalData) {
+        currentErrorNum += numOfErrorData;
+        currentTotalNum += numOfTotalData;
+        if (currentTotalNum > BASE_OF_ERROR_RATE) {
+            if (currentErrorNum > maxErrorNum) {
+                LOG.info("current error num {} of job {} is more then max error num {}. begin to pause job",
+                         currentErrorNum, id, maxErrorNum);
+                // remove all of task in jobs and change job state to paused
+                pausedJob("current error num of job is more then max error num");
+            }
+            
+            // reset currentTotalNum and currentErrorNum
+            currentErrorNum = 0;
+            currentTotalNum = 0;
+        } else if (currentErrorNum > maxErrorNum) {
+            LOG.info("current error num {} of job {} is more then max error num {}. begin to pause job",
+                     currentErrorNum, id, maxErrorNum);
+            // remove all of task in jobs and change job state to paused
+            pausedJob("current error num is more then max error num");
+            // reset currentTotalNum and currentErrorNum
+            currentErrorNum = 0;
+            currentTotalNum = 0;
+        }
+    }
+    
+    abstract RoutineLoadTaskInfo reNewTask(RoutineLoadTaskInfo routineLoadTaskInfo) throws AnalysisException,
+            LabelAlreadyExistsException, BeginTransactionException;
+    
+    @Override
+    public void beforeAborted(TransactionState txnState, TransactionState.TxnStatusChangeReason txnStatusChangeReason)
+            throws AbortTransactionException {
+        readLock();
+        try {
+            if (txnStatusChangeReason != null) {
+                switch (txnStatusChangeReason) {
+                    case TIMEOUT:
+                        String taskId = txnState.getLabel();
+                        if (routineLoadTaskInfoList.parallelStream().anyMatch(entity -> entity.getId().equals(taskId))) {
+                            throw new AbortTransactionException(
+                                    "there are task " + taskId + " related to this txn, "
+                                            + "txn could not be abort", txnState.getTransactionId());
+                        }
+                        break;
+                }
+            }
+        } finally {
+            readUnlock();
+        }
+    }
+    
+    @Override
+    public void onCommitted(TransactionState txnState) {
+        // step0: get progress from transaction state
+        RLTaskTxnCommitAttachment rlTaskTxnCommitAttachment = (RLTaskTxnCommitAttachment) txnState.getTxnCommitAttachment();
+        
+        writeLock();
+        try {
+            // step1: find task in job
+            Optional<RoutineLoadTaskInfo> routineLoadTaskInfoOptional =
+                    routineLoadTaskInfoList.parallelStream()
+                            .filter(entity -> entity.getId().equals(txnState.getLabel())).findFirst();
+            RoutineLoadTaskInfo routineLoadTaskInfo = routineLoadTaskInfoOptional.get();
+            
+            // step2: update job progress
+            updateProgress(rlTaskTxnCommitAttachment.getProgress());
+            
+            // step3: remove task in agentTaskQueue
+            AgentTaskQueue.removeTask(rlTaskTxnCommitAttachment.getBackendId(), TTaskType.STREAM_LOAD,
+                                      rlTaskTxnCommitAttachment.getTaskSignature());
+            
+            // step4: if rate of error data is more then max_filter_ratio, paused job
+            updateNumOfData(rlTaskTxnCommitAttachment.getNumOfErrorData(), rlTaskTxnCommitAttachment.getNumOfTotalData());
+            
+            if (state == JobState.RUNNING) {
+                // step5: create a new task for partitions
+                RoutineLoadTaskInfo newRoutineLoadTaskInfo = reNewTask(routineLoadTaskInfo);
+                Catalog.getCurrentCatalog().getRoutineLoadInstance()
+                        .getNeedSchedulerTasksQueue().addAll(Lists.newArrayList(newRoutineLoadTaskInfo));
+            }
+        } catch (Throwable e) {
+            LOG.error("failed to update offset in routine load task {} when transaction {} has been committed. "
+                              + "change job to paused",
+                      rlTaskTxnCommitAttachment.getTaskId(), txnState.getTransactionId());
+            pausedJob("failed to update offset when transaction "
+                              + txnState.getTransactionId() + " has been committed");
+        } finally {
+            writeUnlock();
+        }
+    }
+    
+    @Override
+    public void onAborted(TransactionState txnState, TransactionState.TxnStatusChangeReason txnStatusChangeReason) {
+        pausedJob(txnStatusChangeReason.name());
+        LOG.debug("job {} need to be paused while txn {} abort with reason {}",
+                  id, txnState.getTransactionId(), txnStatusChangeReason.name());
+    }
+    
+    private void pausedJob(String reason) {
+        // TODO(ml): edit log
+        // remove all of task in jobs and change job state to paused
+        pausedReason = reason;
+        state = JobState.PAUSED;
+        routineLoadTaskInfoList.clear();
+        needSchedulerTaskInfoList.clear();
+    }
 }

--- a/fe/src/main/java/org/apache/doris/load/routineload/RoutineLoadProgress.java
+++ b/fe/src/main/java/org/apache/doris/load/routineload/RoutineLoadProgress.java
@@ -15,19 +15,11 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package org.apache.doris.transaction;
+package org.apache.doris.load.routineload;
 
-import org.apache.doris.common.UserException;
+import org.apache.doris.common.io.Writable;
 
-public class TransactionCommitFailedException extends TransactionException {
-    
-    private static final long serialVersionUID = -2528170792631761535L;
+public abstract class RoutineLoadProgress implements Writable {
 
-    public TransactionCommitFailedException(String msg) {
-        super(msg);
-    }
-
-    public TransactionCommitFailedException(String msg, Throwable e) {
-        super(msg, e);
-    }
+    abstract void update(RoutineLoadProgress progress);
 }

--- a/fe/src/main/java/org/apache/doris/load/routineload/RoutineLoadScheduler.java
+++ b/fe/src/main/java/org/apache/doris/load/routineload/RoutineLoadScheduler.java
@@ -67,11 +67,19 @@ public class RoutineLoadScheduler extends Daemon {
                     break;
                 }
                 // divide job into tasks
-                routineLoadJob.divideRoutineLoadJob(currentConcurrentTaskNum);
+                List<RoutineLoadTaskInfo> needSchedulerTasksList =
+                        routineLoadJob.divideRoutineLoadJob(currentConcurrentTaskNum);
+                // save task into queue of needSchedulerTasks
+                routineLoadManager.getNeedSchedulerTasksQueue().addAll(needSchedulerTasksList);
             } catch (MetaNotFoundException e) {
                 routineLoadJob.updateState(RoutineLoadJob.JobState.CANCELLED);
             }
         }
+
+        LOG.debug("begin to check timeout tasks");
+        // check timeout tasks
+        List<RoutineLoadTaskInfo> reSchedulerTasksList = routineLoadManager.processTimeoutTasks();
+        routineLoadManager.getNeedSchedulerTasksQueue().addAll(reSchedulerTasksList);
     }
 
     private List<RoutineLoadJob> getNeedSchedulerRoutineJobs() throws LoadException {

--- a/fe/src/main/java/org/apache/doris/load/routineload/RoutineLoadTaskInfo.java
+++ b/fe/src/main/java/org/apache/doris/load/routineload/RoutineLoadTaskInfo.java
@@ -18,39 +18,70 @@
 package org.apache.doris.load.routineload;
 
 
+import org.apache.doris.catalog.Catalog;
+import org.apache.doris.common.AnalysisException;
+import org.apache.doris.task.RoutineLoadTask;
+import org.apache.doris.transaction.BeginTransactionException;
+import org.apache.doris.transaction.LabelAlreadyExistsException;
+import org.apache.doris.transaction.TransactionState;
+
 /**
  * Routine load task info is the task info include the only id (signature).
  * For the kafka type of task info, it also include partitions which will be obtained data in this task.
  * The routine load task info and routine load task are the same thing logically.
  * Differently, routine load task is a agent task include backendId which will execute this task.
  */
-public class RoutineLoadTaskInfo {
-
-    private String id;
-    private String jobId;
-
+public abstract class RoutineLoadTaskInfo {
+    
+    private RoutineLoadManager routineLoadManager = Catalog.getCurrentCatalog().getRoutineLoadInstance();
+    
+    protected String id;
+    protected long txnId;
+    protected String jobId;
     private long createTimeMs;
     private long loadStartTimeMs;
-
-    public RoutineLoadTaskInfo(String id, String jobId) {
+    
+    public RoutineLoadTaskInfo(String id, String jobId) throws BeginTransactionException,
+            LabelAlreadyExistsException, AnalysisException {
         this.id = id;
         this.jobId = jobId;
         this.createTimeMs = System.currentTimeMillis();
+        // begin a txn for task
+        RoutineLoadJob routineLoadJob = routineLoadManager.getJob(jobId);
+        txnId = Catalog.getCurrentGlobalTransactionMgr().beginTransaction(
+                routineLoadJob.getDbId(), id, "streamLoad",
+                TransactionState.LoadJobSourceType.ROUTINE_LOAD_TASK, routineLoadJob);
     }
-
+    
     public String getId() {
         return id;
     }
-
+    
     public String getJobId() {
         return jobId;
     }
-
+    
     public void setLoadStartTimeMs(long loadStartTimeMs) {
         this.loadStartTimeMs = loadStartTimeMs;
     }
-
+    
     public long getLoadStartTimeMs() {
         return loadStartTimeMs;
+    }
+    
+    public long getTxnId() {
+        return txnId;
+    }
+    
+    abstract RoutineLoadTask createStreamLoadTask(long beId);
+    
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof RoutineLoadTaskInfo) {
+            RoutineLoadTaskInfo routineLoadTaskInfo = (RoutineLoadTaskInfo) obj;
+            return this.id.equals(routineLoadTaskInfo.getId());
+        } else {
+            return false;
+        }
     }
 }

--- a/fe/src/main/java/org/apache/doris/load/routineload/RoutineLoadTaskScheduler.java
+++ b/fe/src/main/java/org/apache/doris/load/routineload/RoutineLoadTaskScheduler.java
@@ -19,15 +19,16 @@ package org.apache.doris.load.routineload;
 
 import org.apache.doris.catalog.Catalog;
 import org.apache.doris.common.LoadException;
+import org.apache.doris.common.MetaNotFoundException;
 import org.apache.doris.common.util.Daemon;
 import org.apache.doris.task.AgentBatchTask;
 import org.apache.doris.task.AgentTaskExecutor;
 import org.apache.doris.task.AgentTaskQueue;
+import org.apache.doris.task.RoutineLoadTask;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.util.Iterator;
-import java.util.List;
+import java.util.Queue;
 
 /**
  * Routine load task scheduler is a function which allocate task to be.
@@ -56,24 +57,28 @@ public class RoutineLoadTaskScheduler extends Daemon {
         // update current beIdMaps for tasks
         routineLoadManager.updateBeIdTaskMaps();
 
-        // check timeout tasks
-        routineLoadManager.processTimeoutTasks();
-
         // get idle be task num
         int clusterIdleSlotNum = routineLoadManager.getClusterIdleSlotNum();
         int scheduledTaskNum = 0;
-        List<RoutineLoadTaskInfo> routineLoadTaskList = routineLoadManager.getNeedSchedulerRoutineLoadTasks();
-        Iterator<RoutineLoadTaskInfo> iterator = routineLoadTaskList.iterator();
+        Queue<RoutineLoadTaskInfo> needSchedulerTasksQueue = routineLoadManager.getNeedSchedulerTasksQueue();
         AgentBatchTask batchTask = new AgentBatchTask();
 
         // allocate task to be
         while (clusterIdleSlotNum > 0) {
-            if (iterator.hasNext()) {
-                RoutineLoadTaskInfo routineLoadTaskInfo = iterator.next();
+            if (needSchedulerTasksQueue.peek() != null) {
+                RoutineLoadTaskInfo routineLoadTaskInfo = needSchedulerTasksQueue.poll();
                 long beId = routineLoadManager.getMinTaskBeId();
-                RoutineLoadJob routineLoadJob = routineLoadManager.getJob(routineLoadTaskInfo.getJobId());
-                RoutineLoadTask routineLoadTask = routineLoadJob.createTask(routineLoadTaskInfo, beId);
+                RoutineLoadJob routineLoadJob = null;
+                try {
+                    routineLoadJob = routineLoadManager.getJobByTaskId(routineLoadTaskInfo.getId());
+                } catch (MetaNotFoundException e) {
+                    LOG.warn("task {} has been abandoned", routineLoadTaskInfo.getId());
+                    continue;
+                }
+                RoutineLoadTask routineLoadTask = routineLoadTaskInfo.createStreamLoadTask(beId);
                 if (routineLoadTask != null) {
+                    // remove task for needSchedulerTasksList in job
+                    routineLoadJob.removeNeedSchedulerTask(routineLoadTaskInfo);
                     routineLoadTaskInfo.setLoadStartTimeMs(System.currentTimeMillis());
                     AgentTaskQueue.addTask(routineLoadTask);
                     batchTask.addTask(routineLoadTask);

--- a/fe/src/main/java/org/apache/doris/task/KafkaRoutineLoadTask.java
+++ b/fe/src/main/java/org/apache/doris/task/KafkaRoutineLoadTask.java
@@ -15,8 +15,11 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package org.apache.doris.load.routineload;
+package org.apache.doris.task;
 
+import org.apache.doris.load.routineload.KafkaProgress;
+import org.apache.doris.load.routineload.KafkaTaskInfo;
+import org.apache.doris.load.routineload.RoutineLoadJob;
 import org.apache.doris.thrift.TResourceInfo;
 import org.apache.doris.thrift.TTaskType;
 
@@ -31,9 +34,9 @@ public class KafkaRoutineLoadTask extends RoutineLoadTask {
     public KafkaRoutineLoadTask(TResourceInfo resourceInfo, long backendId,
                                 long dbId, long tableId, long partitionId, long indexId, long tabletId,
                                 String columns, String where, String columnSeparator,
-                                KafkaTaskInfo kafkaTaskInfo, KafkaProgress kafkaProgress) {
+                                KafkaTaskInfo kafkaTaskInfo, KafkaProgress kafkaProgress, long txnId) {
         super(resourceInfo, backendId, TTaskType.STREAM_LOAD, dbId, tableId, partitionId, indexId, tabletId,
-                kafkaTaskInfo.getId(), columns, where, columnSeparator, RoutineLoadJob.DataSourceType.KAFKA);
+                kafkaTaskInfo.getId(), columns, where, columnSeparator, RoutineLoadJob.DataSourceType.KAFKA, txnId);
         this.partitionIdToOffset = new HashMap<>();
         kafkaTaskInfo.getPartitions().parallelStream().forEach(entity ->
                 partitionIdToOffset.put(entity, kafkaProgress.getPartitionIdToOffset().get(entity)));

--- a/fe/src/main/java/org/apache/doris/task/RoutineLoadTask.java
+++ b/fe/src/main/java/org/apache/doris/task/RoutineLoadTask.java
@@ -15,11 +15,12 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package org.apache.doris.load.routineload;
+package org.apache.doris.task;
 
 import org.apache.doris.catalog.Catalog;
 import org.apache.doris.catalog.CatalogIdGenerator;
 import org.apache.doris.common.SystemIdGenerator;
+import org.apache.doris.load.routineload.RoutineLoadJob;
 import org.apache.doris.task.AgentTask;
 import org.apache.doris.thrift.TResourceInfo;
 import org.apache.doris.thrift.TTaskType;
@@ -27,6 +28,7 @@ import org.apache.doris.thrift.TTaskType;
 public class RoutineLoadTask extends AgentTask {
 
     private String id;
+    private long txnId;
     private String columns;
     private String where;
     private String columnSeparator;
@@ -36,10 +38,11 @@ public class RoutineLoadTask extends AgentTask {
     public RoutineLoadTask(TResourceInfo resourceInfo, long backendId, TTaskType taskType,
                            long dbId, long tableId, long partitionId, long indexId, long tabletId, String id,
                            String columns, String where, String columnSeparator,
-                           RoutineLoadJob.DataSourceType dataSourceType) {
+                           RoutineLoadJob.DataSourceType dataSourceType, long txnId) {
         super(resourceInfo, backendId, taskType, dbId, tableId, partitionId, indexId, tabletId,
                 Catalog.getCurrentCatalog().getNextId());
         this.id = id;
+        this.txnId = txnId;
         this.columns = columns;
         this.where = where;
         this.columnSeparator = columnSeparator;

--- a/fe/src/main/java/org/apache/doris/transaction/AbortTransactionException.java
+++ b/fe/src/main/java/org/apache/doris/transaction/AbortTransactionException.java
@@ -17,17 +17,18 @@
 
 package org.apache.doris.transaction;
 
-import org.apache.doris.common.UserException;
 
-public class TransactionCommitFailedException extends TransactionException {
+public class AbortTransactionException extends TransactionException {
     
-    private static final long serialVersionUID = -2528170792631761535L;
-
-    public TransactionCommitFailedException(String msg) {
+    public AbortTransactionException(String msg) {
         super(msg);
     }
-
-    public TransactionCommitFailedException(String msg, Throwable e) {
+    
+    public AbortTransactionException(String msg, Throwable e) {
         super(msg, e);
+    }
+    
+    public AbortTransactionException(String msg, long transactionId) {
+        super(msg, transactionId);
     }
 }

--- a/fe/src/main/java/org/apache/doris/transaction/TransactionException.java
+++ b/fe/src/main/java/org/apache/doris/transaction/TransactionException.java
@@ -19,15 +19,24 @@ package org.apache.doris.transaction;
 
 import org.apache.doris.common.UserException;
 
-public class TransactionCommitFailedException extends TransactionException {
+public class TransactionException extends UserException {
     
-    private static final long serialVersionUID = -2528170792631761535L;
-
-    public TransactionCommitFailedException(String msg) {
+    private long transactionId;
+    
+    public TransactionException(String msg) {
         super(msg);
     }
-
-    public TransactionCommitFailedException(String msg, Throwable e) {
+    
+    public TransactionException(String msg, Throwable e) {
         super(msg, e);
+    }
+    
+    public TransactionException(String msg, long transactionId) {
+        super(msg);
+        this.transactionId = transactionId;
+    }
+    
+    public long getTransactionId() {
+        return transactionId;
     }
 }

--- a/fe/src/main/java/org/apache/doris/transaction/TxnCommitAttachment.java
+++ b/fe/src/main/java/org/apache/doris/transaction/TxnCommitAttachment.java
@@ -1,0 +1,54 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.transaction;
+
+import org.apache.doris.common.io.Writable;
+import org.apache.doris.load.routineload.RLTaskTxnCommitAttachment;
+import org.apache.doris.thrift.TTxnCommitAttachment;
+
+import java.io.DataInput;
+import java.io.IOException;
+
+public abstract class TxnCommitAttachment implements Writable {
+
+    public static TxnCommitAttachment readTxnCommitAttachment(DataInput in,
+                                                              TransactionState.LoadJobSourceType sourceType)
+            throws IOException {
+        switch (sourceType) {
+            case ROUTINE_LOAD_TASK:
+                RLTaskTxnCommitAttachment RLTaskTxnCommitAttachment = new RLTaskTxnCommitAttachment();
+                RLTaskTxnCommitAttachment.readFields(in);
+                return RLTaskTxnCommitAttachment;
+            default:
+                return null;
+        }
+    }
+
+    public static TxnCommitAttachment fromThrift(TTxnCommitAttachment txnCommitAttachment) {
+        if (txnCommitAttachment != null) {
+            switch (txnCommitAttachment.txnSourceType) {
+                case ROUTINE_LOAD_TASK:
+                    return new RLTaskTxnCommitAttachment(txnCommitAttachment.getRlTaskTxnCommitAttachment());
+                default:
+                    return null;
+            }
+        } else {
+            return null;
+        }
+    }
+}

--- a/fe/src/test/java/org/apache/doris/load/routineload/RoutineLoadSchedulerTest.java
+++ b/fe/src/test/java/org/apache/doris/load/routineload/RoutineLoadSchedulerTest.java
@@ -17,6 +17,13 @@
 
 package org.apache.doris.load.routineload;
 
+import com.google.common.collect.Lists;
+import mockit.Deencapsulation;
+import mockit.Expectations;
+import mockit.Injectable;
+import mockit.Mock;
+import mockit.MockUp;
+import mockit.Mocked;
 import org.apache.doris.catalog.Catalog;
 import org.apache.doris.catalog.Database;
 import org.apache.doris.common.LoadException;
@@ -45,7 +52,6 @@ public class RoutineLoadSchedulerTest {
                                       @Injectable SystemInfoService systemInfoService,
                                       @Injectable Database database)
             throws LoadException, MetaNotFoundException {
-
         String clusterName = "cluster1";
         List<Long> beIds = Lists.newArrayList();
         beIds.add(1L);
@@ -58,7 +64,7 @@ public class RoutineLoadSchedulerTest {
         RoutineLoadJob routineLoadJob = new KafkaRoutineLoadJob("1", "kafka_routine_load_job", "miaoling", 1L,
                 1L, "1L", "v1", "", "", 3,
                 RoutineLoadJob.JobState.NEED_SCHEDULER, RoutineLoadJob.DataSourceType.KAFKA, 0, new TResourceInfo(),
-                "", "");
+                "", "", null);
         routineLoadJob.setState(RoutineLoadJob.JobState.NEED_SCHEDULER);
         List<RoutineLoadJob> routineLoadJobList = new ArrayList<>();
         routineLoadJobList.add(routineLoadJob);

--- a/fe/src/test/java/org/apache/doris/transaction/GlobalTransactionMgrTest.java
+++ b/fe/src/test/java/org/apache/doris/transaction/GlobalTransactionMgrTest.java
@@ -55,7 +55,7 @@ public class GlobalTransactionMgrTest {
     private static Catalog slaveCatalog;
 
     private String transactionSource = "localfe";
-    
+
 
     @Before
     public void setUp() throws InstantiationException, IllegalAccessException, IllegalArgumentException,
@@ -75,8 +75,8 @@ public class GlobalTransactionMgrTest {
     }
 
     @Test
-    public void testBeginTransaction() throws LabelAlreadyExistsException, AnalysisException, 
-        BeginTransactionException {
+    public void testBeginTransaction() throws LabelAlreadyExistsException, AnalysisException,
+            BeginTransactionException {
         FakeCatalog.setCatalog(masterCatalog);
         long transactionId = masterTransMgr.beginTransaction(CatalogTestUtil.testDbId1,
                 CatalogTestUtil.testTxnLable1,
@@ -89,16 +89,16 @@ public class GlobalTransactionMgrTest {
         assertEquals(CatalogTestUtil.testDbId1, transactionState.getDbId());
         assertEquals(transactionSource, transactionState.getCoordinator());
     }
-    
+
     @Test
-    public void testBeginTransactionWithSameLabel() throws LabelAlreadyExistsException, AnalysisException, 
-        BeginTransactionException {
+    public void testBeginTransactionWithSameLabel() throws LabelAlreadyExistsException, AnalysisException,
+            BeginTransactionException {
         FakeCatalog.setCatalog(masterCatalog);
         long transactionId = 0;
         Throwable throwable = null;
         try {
-            transactionId = masterTransMgr.beginTransaction(CatalogTestUtil.testDbId1, 
-                    CatalogTestUtil.testTxnLable1, 
+            transactionId = masterTransMgr.beginTransaction(CatalogTestUtil.testDbId1,
+                    CatalogTestUtil.testTxnLable1,
                     transactionSource,
                     LoadJobSourceType.FRONTEND);
         } catch (AnalysisException e) {
@@ -114,10 +114,10 @@ public class GlobalTransactionMgrTest {
         assertEquals(transactionSource, transactionState.getCoordinator());
 
         try {
-        transactionId = masterTransMgr.beginTransaction(CatalogTestUtil.testDbId1,
-                CatalogTestUtil.testTxnLable1,
-                transactionSource,
-                LoadJobSourceType.FRONTEND);
+            transactionId = masterTransMgr.beginTransaction(CatalogTestUtil.testDbId1,
+                    CatalogTestUtil.testTxnLable1,
+                    transactionSource,
+                    LoadJobSourceType.FRONTEND);
         } catch (Exception e) {
             // TODO: handle exception
         }
@@ -127,7 +127,7 @@ public class GlobalTransactionMgrTest {
     @Test
     public void testCommitTransaction1() throws MetaNotFoundException,
             TransactionCommitFailedException,
-            IllegalTransactionParameterException, LabelAlreadyExistsException, 
+            IllegalTransactionParameterException, LabelAlreadyExistsException,
             AnalysisException, BeginTransactionException {
         FakeCatalog.setCatalog(masterCatalog);
         long transactionId = masterTransMgr.beginTransaction(CatalogTestUtil.testDbId1,
@@ -170,7 +170,7 @@ public class GlobalTransactionMgrTest {
     @Test
     public void testCommitTransactionWithOneFailed() throws MetaNotFoundException,
             TransactionCommitFailedException,
-            IllegalTransactionParameterException, LabelAlreadyExistsException, 
+            IllegalTransactionParameterException, LabelAlreadyExistsException,
             AnalysisException, BeginTransactionException {
         TransactionState transactionState = null;
         FakeCatalog.setCatalog(masterCatalog);
@@ -272,7 +272,7 @@ public class GlobalTransactionMgrTest {
     }
 
     public void testFinishTransaction() throws MetaNotFoundException, TransactionCommitFailedException,
-            IllegalTransactionParameterException, LabelAlreadyExistsException, 
+            IllegalTransactionParameterException, LabelAlreadyExistsException,
             AnalysisException, BeginTransactionException {
         long transactionId = masterTransMgr.beginTransaction(CatalogTestUtil.testDbId1,
                 CatalogTestUtil.testTxnLable1,
@@ -316,7 +316,7 @@ public class GlobalTransactionMgrTest {
     @Test
     public void testFinishTransactionWithOneFailed() throws MetaNotFoundException,
             TransactionCommitFailedException,
-            IllegalTransactionParameterException, LabelAlreadyExistsException, 
+            IllegalTransactionParameterException, LabelAlreadyExistsException,
             AnalysisException, BeginTransactionException {
         TransactionState transactionState = null;
         Partition testPartition = masterCatalog.getDb(CatalogTestUtil.testDbId1).getTable(CatalogTestUtil.testTableId1)
@@ -442,8 +442,8 @@ public class GlobalTransactionMgrTest {
     }
 
     @Test
-    public void testDeleteTransaction() throws LabelAlreadyExistsException, 
-        AnalysisException, BeginTransactionException {
+    public void testDeleteTransaction() throws LabelAlreadyExistsException,
+            AnalysisException, BeginTransactionException {
 
         long transactionId = masterTransMgr.beginTransaction(CatalogTestUtil.testDbId1,
                 CatalogTestUtil.testTxnLable1,

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -500,6 +500,34 @@ struct TStreamLoadPutResult {
     2: optional PaloInternalService.TExecPlanFragmentParams params
 }
 
+enum TRoutineLoadType {
+    KAFKA = 1
+}
+
+struct TKafkaRLTaskProgress {
+    1: required map<i32,i64> partitionIdToOffset
+}
+
+enum TTxnSourceType {
+    ROUTINE_LOAD_TASK = 1
+}
+
+struct TRLTaskTxnCommitAttachment {
+    1: required TRoutineLoadType routineLoadType
+    2: required i64 backendId
+    3: required i64 taskSignature
+    4: required i32 numOfErrorData
+    5: required i32 numOfTotalData
+    6: required string taskId
+    7: required string jobId
+    8: optional TKafkaRLTaskProgress kafkaRLTaskProgress
+}
+
+struct TTxnCommitAttachment {
+    1: required TTxnSourceType txnSourceType
+    2: optional TRLTaskTxnCommitAttachment rlTaskTxnCommitAttachment
+}
+
 struct TLoadTxnCommitRequest {
     1: optional string cluster
     2: required string user
@@ -510,6 +538,7 @@ struct TLoadTxnCommitRequest {
     7: required i64 txnId
     8: required bool sync
     9: optional list<Types.TTabletCommitInfo> commitInfos
+    10: optional TTxnCommitAttachment txnCommitAttachment
 }
 
 struct TLoadTxnCommitResult {
@@ -530,6 +559,7 @@ struct TLoadTxnRollbackRequest {
 struct TLoadTxnRollbackResult {
     1: required Status.TStatus status
 }
+
 
 service FrontendService {
     TGetDbsResult getDbNames(1:TGetDbsParams params)


### PR DESCRIPTION
1. add a needSchedulerTasksQueue in LoadManager: the RoutineLoadTaskScheduler will poll task from this queue and schedule task.
2. add a frontend interface named rlTaskCommit: commit txn, update offset and renew a task for the same partitions
3. add a extra property in transaction state: in rlTaskCommit,the extra property which looks like {"job_id": xxx, "progress": xxx}
When fe initialize routine load job meta from logs, all of txn state which related to routine load job will be used for initializing progress of job.