### PR TITLE
Remove BE starting error message when the process in the pid file doe…

### DIFF
--- a/bin/start_be.sh
+++ b/bin/start_be.sh
@@ -55,14 +55,14 @@ rm -f ${UDF_RUNTIME_DIR}/*
 pidfile=$PID_DIR/be.pid
 
 if [ -f $pidfile ]; then
-    if kill -0 $(cat $pidfile); then
+    if kill -0 $(cat $pidfile) > /dev/null 2>&1; then
         echo "Backend running as process `cat $pidfile`. Stop it first."
         exit 1
     else
         rm $pidfile
     fi
 fi
- 
+
 chmod 755 ${DORIS_HOME}/lib/palo_be
 echo "start time: "$(date) >> $LOG_DIR/be.out
 


### PR DESCRIPTION
…s not exist (#365)

Redirect output message of `kill` to /dev/null.