### PR TITLE
Remove batch process code from push handler (#385)

### DIFF
--- a/be/src/olap/olap_define.h
+++ b/be/src/olap/olap_define.h
@@ -234,6 +234,8 @@ enum OLAPStatus {
     OLAP_ERR_PUSH_TABLE_NOT_EXIST = -909,
     OLAP_ERR_PUSH_INPUT_DATA_ERROR = -910,
     OLAP_ERR_PUSH_TRANSACTION_ALREADY_EXIST = -911,
+    // only support realtime push api, batch process is deprecated and is removed
+    OLAP_ERR_PUSH_BATCH_PROCESS_REMOVED = -912, 
 
     // SegmentGroup
     // [-1000, -1100)

--- a/be/src/olap/olap_engine.cpp
+++ b/be/src/olap/olap_engine.cpp
@@ -2598,7 +2598,7 @@ OLAPStatus OLAPEngine::delete_data(
     if (request.__isset.transaction_id) {
         res = push_handler.process_realtime_push(table, request, PUSH_FOR_DELETE, tablet_info_vec);
     } else {
-        res = push_handler.process(table, request, PUSH_FOR_DELETE, tablet_info_vec);
+        res = OLAP_ERR_PUSH_BATCH_PROCESS_REMOVED;
     }
 
     if (res != OLAP_SUCCESS) {
@@ -2953,7 +2953,7 @@ OLAPStatus OLAPEngine::push(
     } else {
         {
             SCOPED_RAW_TIMER(&duration_ns);
-            res = push_handler.process(olap_table, request, type, tablet_info_vec);
+            res = OLAP_ERR_PUSH_BATCH_PROCESS_REMOVED;
         }
     }
 


### PR DESCRIPTION
- remove process method and related code from push_handler since doris is using realtime process in the future.
- process is only used in snapshot because snapshot uses process to add an empty delta into the snapshot data. This is a todo in the future.