### PR TITLE
Release push_lock when schema change failed

### DIFF
--- a/be/src/olap/schema_change.cpp
+++ b/be/src/olap/schema_change.cpp
@@ -2098,6 +2098,7 @@ OLAPStatus SchemaChangeHandler::_alter_table(SchemaChangeParams* sc_params) {
 
                 sc_params->new_olap_table->release_header_lock();
                 sc_params->ref_olap_table->release_header_lock();
+                sc_params->new_olap_table->release_push_lock();
 
                 goto PROCESS_ALTER_EXIT;
             }
@@ -2127,6 +2128,7 @@ OLAPStatus SchemaChangeHandler::_alter_table(SchemaChangeParams* sc_params) {
 
             sc_params->new_olap_table->release_header_lock();
             sc_params->ref_olap_table->release_header_lock();
+            sc_params->new_olap_table->release_push_lock();
 
             res = OLAP_ERR_INPUT_PARAMETER_ERROR;
             goto PROCESS_ALTER_EXIT;


### PR DESCRIPTION
SchemaChange still hold push_lock when failed. 
GC tablet will destroy push_lock. If it still referenced by another thread, BE process will core dump.