### PR TITLE
Clear client pool when heartbeat failed

### DIFF
--- a/fe/src/main/java/org/apache/doris/common/GenericPool.java
+++ b/fe/src/main/java/org/apache/doris/common/GenericPool.java
@@ -17,8 +17,6 @@
 
 package org.apache.doris.common;
 
-import java.lang.reflect.Constructor;
-
 import org.apache.doris.thrift.TNetworkAddress;
 
 import org.apache.commons.pool2.BaseKeyedPooledObjectFactory;
@@ -26,13 +24,15 @@ import org.apache.commons.pool2.PooledObject;
 import org.apache.commons.pool2.impl.DefaultPooledObject;
 import org.apache.commons.pool2.impl.GenericKeyedObjectPool;
 import org.apache.commons.pool2.impl.GenericKeyedObjectPoolConfig;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.thrift.protocol.TBinaryProtocol;
 import org.apache.thrift.protocol.TProtocol;
 import org.apache.thrift.transport.TSocket;
 import org.apache.thrift.transport.TTransport;
 import org.apache.thrift.transport.TTransportException;
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
+
+import java.lang.reflect.Constructor;
 
 public class GenericPool<VALUE extends org.apache.thrift.TServiceClient>  {
     private static final Logger LOG = LogManager.getLogger(GenericPool.class);
@@ -71,6 +71,10 @@ public class GenericPool<VALUE extends org.apache.thrift.TServiceClient>  {
             ok = false;
         }
         return ok;
+    }
+
+    public void clearPool(TNetworkAddress addr) {
+        pool.clear(addr);
     }
 
     public boolean peak(VALUE object) {

--- a/fe/src/main/java/org/apache/doris/system/HeartbeatMgr.java
+++ b/fe/src/main/java/org/apache/doris/system/HeartbeatMgr.java
@@ -26,7 +26,6 @@ import org.apache.doris.common.util.Daemon;
 import org.apache.doris.common.util.Util;
 import org.apache.doris.http.rest.BootstrapFinishAction;
 import org.apache.doris.persist.HbPackage;
-import org.apache.doris.system.BackendEvent.BackendEventType;
 import org.apache.doris.system.HeartbeatResponse.HbStatus;
 import org.apache.doris.thrift.HeartbeatService;
 import org.apache.doris.thrift.TBackendInfo;
@@ -165,9 +164,9 @@ public class HeartbeatMgr extends Daemon {
                 Backend be = nodeMgr.getBackend(hbResponse.getBeId());
                 if (be != null) {
                     boolean isChanged = be.handleHbResponse(hbResponse);
-                    if (hbResponse.getStatus() != HbStatus.OK && !isReplay) {
-                        nodeMgr.getEventBus().post(new BackendEvent(BackendEventType.BACKEND_DOWN,
-                                "missing heartbeat", Long.valueOf(hbResponse.getBeId())));
+                    if (hbResponse.getStatus() != HbStatus.OK) {
+                        // invalid all connections cached in ClientPool
+                        ClientPool.backendPool.clearPool(new TNetworkAddress(be.getHost(), be.getBePort()));
                     }
                     return isChanged;
                 }
@@ -178,7 +177,12 @@ public class HeartbeatMgr extends Daemon {
                 FsBroker broker = Catalog.getCurrentCatalog().getBrokerMgr().getBroker(
                         hbResponse.getName(), hbResponse.getHost(), hbResponse.getPort());
                 if (broker != null) {
-                    return broker.handleHbResponse(hbResponse);
+                    boolean isChanged =  broker.handleHbResponse(hbResponse);
+                    if (hbResponse.getStatus() != HbStatus.OK) {
+                        // invalid all connections cached in ClientPool
+                        ClientPool.brokerPool.clearPool(new TNetworkAddress(broker.ip, broker.port));
+                    }
+                    return isChanged;
                 }
                 break;
             }


### PR DESCRIPTION
When heartbeat failed, we should clear the connections cached
in client pool, or we will get broken connections from the pool.
Since we don't have the REOPEN logic(which may cause ugly code style),
a broken connection may cause a rpc blocked and failed.
So clear them all and recreate them when needed is a simple way to
resolve this problem.

We only clear connections in backend and broker pool.
No need to clear heartbeat pool because heartbeat is very frequent,
such the connections can be invalid automatically.