### PR TITLE
Fix compaction and ingestion core

### DIFF
--- a/be/src/olap/merger.cpp
+++ b/be/src/olap/merger.cpp
@@ -106,6 +106,11 @@ OLAPStatus Merger::merge(const vector<ColumnData*>& olap_data_arr,
         ++_row_count;
     }
 
+    if (has_error) {
+        LOG(WARNING) << "base compaction failed.";
+        return OLAP_ERR_OTHER_ERROR;
+    }
+
     if (OLAP_SUCCESS != writer->finalize()) {
         OLAP_LOG_WARNING("fail to finalize writer. [table='%s']",
                 _table->full_name().c_str());

--- a/be/src/olap/push_handler.cpp
+++ b/be/src/olap/push_handler.cpp
@@ -664,6 +664,11 @@ OLAPStatus PushHandler::_convert(
             }
         }
 
+        if (res != OLAP_SUCCESS) {
+            LOG(WARNING) << "ingest data failed. res" << res;
+            break;
+        }
+
         if (OLAP_SUCCESS != (res = writer->finalize())) {
             OLAP_LOG_WARNING("fail to finalize writer. [res=%d]", res);
             break;


### PR DESCRIPTION
Error occurs when reading data by compaction and ingestion.
Under the circumstance, the two operation should stop and return error.