### PR TITLE
Support add new key column for LinkedSchemaChange

### DIFF
--- a/be/src/olap/column_mapping.h
+++ b/be/src/olap/column_mapping.h
@@ -1,0 +1,37 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#ifndef DORIS_BE_SRC_OLAP_COLUMN_MAPPING_H
+#define DORIS_BE_SRC_OLAP_COLUMN_MAPPING_H
+
+#include "olap/wrapper_field.h"
+
+namespace doris {
+
+struct ColumnMapping {
+    ColumnMapping() : ref_column(-1), default_value(NULL) {}
+    virtual ~ColumnMapping() {}
+
+    // <0: use default value
+    // >=0: use origin column
+    int32_t ref_column;
+    // normally for default value. stores values for filters
+    WrapperField* default_value;
+};
+
+}  // namespace doris
+#endif // DORIS_BE_SRC_COLUMN_MAPPING_H

--- a/be/src/olap/schema_change.h
+++ b/be/src/olap/schema_change.h
@@ -41,17 +41,6 @@ class RowCursor;
 // defined in 'writer.h'
 class ColumnDataWriter;
 
-struct ColumnMapping {
-    ColumnMapping() : ref_column(-1), default_value(NULL) {}
-    virtual ~ColumnMapping() {}
-
-    // <0: use default value
-    // >=0: use origin column
-    int32_t ref_column;
-    // normally for default value. stores values for filters
-    WrapperField* default_value;
-};
-
 class RowBlockChanger {
 public:
     typedef std::vector<ColumnMapping> SchemaMapping;

--- a/be/src/olap/schema_change.h
+++ b/be/src/olap/schema_change.h
@@ -66,6 +66,10 @@ public:
     virtual ~RowBlockChanger();
 
     ColumnMapping* get_mutable_column_mapping(size_t column_index);
+
+    SchemaMapping get__schema_mapping() const {
+        return _schema_mapping;
+    }
     
     bool change_row_block(
             const DataFileType df_type,
@@ -192,13 +196,15 @@ class LinkedSchemaChange : public SchemaChange {
 public:
     explicit LinkedSchemaChange(
                 OLAPTablePtr base_olap_table, 
-                OLAPTablePtr new_olap_table);
+                OLAPTablePtr new_olap_table,
+                const RowBlockChanger& row_block_changer);
     ~LinkedSchemaChange() {}
 
     bool process(ColumnData* olap_data, SegmentGroup* new_segment_group);
 private:
     OLAPTablePtr _base_olap_table;
     OLAPTablePtr _new_olap_table;
+    const RowBlockChanger& _row_block_changer;
     DISALLOW_COPY_AND_ASSIGN(LinkedSchemaChange);
 };
 

--- a/be/src/olap/segment_group.cpp
+++ b/be/src/olap/segment_group.cpp
@@ -27,8 +27,7 @@
 #include "olap/row_block.h"
 #include "olap/row_cursor.h"
 #include "olap/utils.h"
-#include "olap/wrapper_field.h"
-#include "olap/schema_change.h"
+#include "olap/column_mapping.h"
 
 using std::ifstream;
 using std::string;
@@ -225,13 +224,8 @@ OLAPStatus SegmentGroup::add_column_statistics_for_linked_schema_change(
         if (schema_mapping[i].ref_column == -1) {
             num_new_keys++;
 
-            if (true == column_schema.is_allow_null && column_schema.default_value.length() == 0) {
-                first->set_null();
-                second->set_null();
-            } else {
-                first->from_string(column_schema.default_value);
-                second->from_string(column_schema.default_value);
-            }
+            first->copy(schema_mapping[i].default_value);
+            second->copy(schema_mapping[i].default_value);
         } else {
             first->copy(column_statistic_fields[i - num_new_keys].first);
             second->copy(column_statistic_fields[i - num_new_keys].second);

--- a/be/src/olap/segment_group.h
+++ b/be/src/olap/segment_group.h
@@ -36,9 +36,9 @@
 #include "olap/row_cursor.h"
 #include "olap/olap_index.h"
 #include "olap/utils.h"
+#include "olap/column_mapping.h"
 
 namespace doris {
-class ColumnMapping;
 
 // Class for segments management
 // For fast key lookup, we maintain a sparse index for every data file. The

--- a/be/src/olap/segment_group.h
+++ b/be/src/olap/segment_group.h
@@ -38,6 +38,7 @@
 #include "olap/utils.h"
 
 namespace doris {
+class ColumnMapping;
 
 // Class for segments management
 // For fast key lookup, we maintain a sparse index for every data file. The
@@ -47,6 +48,8 @@ namespace doris {
 class SegmentGroup {
     friend class MemIndex;
 public:
+    typedef std::vector<ColumnMapping> SchemaMapping;
+
     SegmentGroup(OLAPTable* table, Version version, VersionHash version_hash,
               bool delete_flag, int segment_group_id, int32_t num_segments);
 
@@ -66,7 +69,8 @@ public:
     }
 
     OLAPStatus add_column_statistics_for_linked_schema_change(
-        const std::vector<std::pair<WrapperField*, WrapperField*>>& column_statistic_fields);
+        const std::vector<std::pair<WrapperField*, WrapperField*>>& column_statistic_fields,
+        const SchemaMapping& schema_mapping);
 
     OLAPStatus add_column_statistics(
         const std::vector<std::pair<WrapperField*, WrapperField*>>& column_statistic_fields);


### PR DESCRIPTION
Fix [332](https://github.com/apache/incubator-doris/issues/332)

In PR [337](https://github.com/apache/incubator-doris/pull/337), I didn't  think about this case:  user add a new key column to base table.

This PR supports add new key column for LinkedSchemaChange.

I'm not sure SegmentGroup include "olap/schema_change.h" is reasonable and the code smell is good.

@chaoyli  Please review this PR. Thanks you.
