### PR TITLE
Redesign the access to meta version

### DIFF
--- a/docs/help/Contents/Data Definition/ddl_stmt.md
+++ b/docs/help/Contents/Data Definition/ddl_stmt.md
@@ -860,6 +860,7 @@
                 "backup_timestamp" = "2018-05-04-16-45-08"：指定了恢复对应备份的哪个时间版本，必填。该信息可以通过 `SHOW SNAPSHOT ON repo;` 语句获得。
                 "replication_num" = "3"：指定恢复的表或分区的副本数。默认为3。若恢复已存在的表或分区，则副本数必须和已存在表或分区的副本数相同。同时，必须有足够的 host 容纳多个副本。
                 "timeout" = "3600"：任务超时时间，默认为一天。单位秒。
+                "meta_version" = 40：使用指定的 meta_version 来读取之前备份的元数据。注意，该参数作为临时方案，仅用于恢复老版本 Doris 备份的数据。最新版本的备份数据中已经包含 meta version，无需再指定。
 
 ## example
     1. 从 example_repo 中恢复备份 snapshot_1 中的表 backup_tbl 到数据库 example_db1，时间版本为 "2018-05-04-16-45-08"。恢复为 1 个副本：

--- a/fe/src/main/java/org/apache/doris/analysis/RestoreStmt.java
+++ b/fe/src/main/java/org/apache/doris/analysis/RestoreStmt.java
@@ -36,10 +36,12 @@ public class RestoreStmt extends AbstractBackupStmt {
     private final static String PROP_ALLOW_LOAD = "allow_load";
     private final static String PROP_REPLICATION_NUM = "replication_num";
     private final static String PROP_BACKUP_TIMESTAMP = "backup_timestamp";
+    private final static String PROP_META_VERSION = "meta_version";
 
     private boolean allowLoad = false;
     private int replicationNum = FeConstants.default_replication_num;
     private String backupTimestamp = null;
+    private int metaVersion = -1;
 
     public RestoreStmt(LabelName labelName, String repoName, List<TableRef> tblRefs, Map<String, String> properties) {
         super(labelName, repoName, tblRefs, properties);
@@ -55,6 +57,10 @@ public class RestoreStmt extends AbstractBackupStmt {
 
     public String getBackupTimestamp() {
         return backupTimestamp;
+    }
+
+    public int getMetaVersion() {
+        return metaVersion;
     }
 
     @Override
@@ -112,6 +118,18 @@ public class RestoreStmt extends AbstractBackupStmt {
         } else {
             ErrorReport.reportAnalysisException(ErrorCode.ERR_COMMON_ERROR,
                                                 "Missing " + PROP_BACKUP_TIMESTAMP + " property");
+        }
+
+        // meta version
+        if (copiedProperties.containsKey(PROP_META_VERSION)) {
+            try {
+                metaVersion = Integer.valueOf(copiedProperties.get(PROP_META_VERSION));
+            } catch (NumberFormatException e) {
+                ErrorReport.reportAnalysisException(ErrorCode.ERR_COMMON_ERROR,
+                        "Invalid meta version format: "
+                                + copiedProperties.get(PROP_META_VERSION));
+            }
+            copiedProperties.remove(PROP_META_VERSION);
         }
 
         if (!copiedProperties.isEmpty()) {

--- a/fe/src/main/java/org/apache/doris/backup/BackupHandler.java
+++ b/fe/src/main/java/org/apache/doris/backup/BackupHandler.java
@@ -326,7 +326,7 @@ public class BackupHandler extends Daemon implements Writable {
                 // as base snapshot.
                 // But first we need to check if the existing snapshot has same meta.
                 List<BackupMeta> backupMetas = Lists.newArrayList();
-                st = repository.getSnapshotMetaFile(stmt.getLabel(), backupMetas);
+                st = repository.getSnapshotMetaFile(stmt.getLabel(), backupMetas, -1);
                 if (!st.ok()) {
                     ErrorReport.reportDdlException(ErrorCode.ERR_COMMON_ERROR,
                                                    "Failed to get existing meta info for repository: "
@@ -373,7 +373,7 @@ public class BackupHandler extends Daemon implements Writable {
         // Create a restore job
         RestoreJob restoreJob = new RestoreJob(stmt.getLabel(), stmt.getBackupTimestamp(),
                 db.getId(), db.getFullName(), jobInfo, stmt.allowLoad(), stmt.getReplicationNum(),
-                stmt.getTimeoutMs(), catalog, repository.getId());
+                stmt.getTimeoutMs(), stmt.getMetaVersion(), catalog, repository.getId());
         dbIdToBackupOrRestoreJob.put(db.getId(), restoreJob);
 
         catalog.getEditLog().logRestoreJob(restoreJob);

--- a/fe/src/main/java/org/apache/doris/backup/BackupMeta.java
+++ b/fe/src/main/java/org/apache/doris/backup/BackupMeta.java
@@ -71,7 +71,7 @@ public class BackupMeta implements Writable {
     public static BackupMeta fromFile(String filePath, int metaVersion) throws IOException {
         File file = new File(filePath);
         MetaContext metaContext = new MetaContext();
-        metaContext.setJournalVersion(metaVersion);
+        metaContext.setMetaVersion(metaVersion);
         metaContext.setThreadLocalInfo();
         try (DataInputStream dis = new DataInputStream(new FileInputStream(file))) {
             BackupMeta backupMeta = BackupMeta.read(dis);

--- a/fe/src/main/java/org/apache/doris/backup/BackupMeta.java
+++ b/fe/src/main/java/org/apache/doris/backup/BackupMeta.java
@@ -19,6 +19,7 @@ package org.apache.doris.backup;
 
 import org.apache.doris.catalog.Table;
 import org.apache.doris.common.io.Writable;
+import org.apache.doris.meta.MetaContext;
 
 import com.google.common.collect.Maps;
 
@@ -67,11 +68,16 @@ public class BackupMeta implements Writable {
         return tblIdMap.get(tblId);
     }
 
-    public static BackupMeta fromFile(String filePath) throws IOException {
+    public static BackupMeta fromFile(String filePath, int metaVersion) throws IOException {
         File file = new File(filePath);
+        MetaContext metaContext = new MetaContext();
+        metaContext.setJournalVersion(metaVersion);
+        metaContext.setThreadLocalInfo();
         try (DataInputStream dis = new DataInputStream(new FileInputStream(file))) {
             BackupMeta backupMeta = BackupMeta.read(dis);
             return backupMeta;
+        } finally {
+            MetaContext.remove();
         }
     }
 

--- a/fe/src/main/java/org/apache/doris/backup/Repository.java
+++ b/fe/src/main/java/org/apache/doris/backup/Repository.java
@@ -331,7 +331,7 @@ public class Repository implements Writable {
         return Status.OK;
     }
 
-    public Status getSnapshotMetaFile(String label, List<BackupMeta> backupMetas) {
+    public Status getSnapshotMetaFile(String label, List<BackupMeta> backupMetas, int metaVersion) {
         String remoteMetaFilePath = assembleMetaInfoFilePath(label);
         File localMetaFile = new File(BackupHandler.BACKUP_ROOT_DIR + PATH_DELIMITER
                 + "meta_" + System.currentTimeMillis());
@@ -343,7 +343,7 @@ public class Repository implements Writable {
             }
 
             // read file to backupMeta
-            BackupMeta backupMeta = BackupMeta.fromFile(localMetaFile.getAbsolutePath());
+            BackupMeta backupMeta = BackupMeta.fromFile(localMetaFile.getAbsolutePath(), metaVersion);
             backupMetas.add(backupMeta);
         } catch (IOException e) {
             return new Status(ErrCode.COMMON_ERROR, "Failed create backup meta from file: "

--- a/fe/src/main/java/org/apache/doris/catalog/Catalog.java
+++ b/fe/src/main/java/org/apache/doris/catalog/Catalog.java
@@ -1109,6 +1109,7 @@ public class Catalog {
 
         if (replayer == null) {
             createReplayer();
+            replayer.setNeedMetaContext(true);
             replayer.setName("replayer");
             replayer.setInterval(REPLAY_INTERVAL_MS);
             replayer.start();

--- a/fe/src/main/java/org/apache/doris/catalog/Catalog.java
+++ b/fe/src/main/java/org/apache/doris/catalog/Catalog.java
@@ -231,7 +231,6 @@ public class Catalog {
 
     // Current journal meta data version. Use this version to load journals
     // private int journalVersion = 0;
-    private MetaContext metaContext;
     private long epoch = 0;
 
     // Lock to perform atomic modification on map like 'idToDb' and 'fullNameToDb'.
@@ -444,9 +443,6 @@ public class Catalog {
         this.domainResolver = new DomainResolver(auth);
 
         this.esStateStore = new EsStateStore();
-
-        this.metaContext = new MetaContext();
-        metaContext.setThreadLocalInfo();
     }
 
     public static void destroyCheckpoint() {
@@ -611,6 +607,7 @@ public class Catalog {
 
         // 6. start state listener thread
         createStateListener();
+        listener.setNeedMetaContext(true);
         listener.setName("stateListener");
         listener.setInterval(STATE_CHANGE_CHECK_INTERVAL_MS);
         listener.start();
@@ -1014,6 +1011,7 @@ public class Catalog {
 
         // start checkpoint thread
         checkpointer = new Checkpoint(editLog);
+        checkpointer.setNeedMetaContext(true);
         checkpointer.setName("leaderCheckpointer");
         checkpointer.setInterval(FeConstants.checkpoint_interval_second * 1000L);
 

--- a/fe/src/main/java/org/apache/doris/catalog/Catalog.java
+++ b/fe/src/main/java/org/apache/doris/catalog/Catalog.java
@@ -521,7 +521,7 @@ public class Catalog {
 
     // use this to get correct Catalog's journal version
     public static int getCurrentCatalogJournalVersion() {
-        return MetaContext.get().getJournalVersion();
+        return MetaContext.get().getMetaVersion();
     }
 
     public static final boolean isCheckpointThread() {
@@ -982,10 +982,10 @@ public class Catalog {
         editLog.rollEditLog();
 
         // Log meta_version
-        long journalVersion = MetaContext.get().getJournalVersion();
+        long journalVersion = MetaContext.get().getMetaVersion();
         if (journalVersion < FeConstants.meta_version) {
             editLog.logMetaVersion(FeConstants.meta_version);
-            MetaContext.get().setJournalVersion(FeConstants.meta_version);
+            MetaContext.get().setMetaVersion(FeConstants.meta_version);
         }
 
         // Log the first frontend
@@ -1320,7 +1320,7 @@ public class Catalog {
     public long loadHeader(DataInputStream dis, long checksum) throws IOException {
         int journalVersion = dis.readInt();
         long newChecksum = checksum ^ journalVersion;
-        MetaContext.get().setJournalVersion(journalVersion);
+        MetaContext.get().setMetaVersion(journalVersion);
 
         long replayedJournalId = dis.readLong();
         newChecksum ^= replayedJournalId;
@@ -5637,7 +5637,7 @@ public class Catalog {
     }
 
     public long loadBrokers(DataInputStream dis, long checksum) throws IOException, DdlException {
-        if (MetaContext.get().getJournalVersion() >= FeMetaVersion.VERSION_31) {
+        if (MetaContext.get().getMetaVersion() >= FeMetaVersion.VERSION_31) {
             int count = dis.readInt();
             checksum ^= count;
             for (long i = 0; i < count; ++i) {

--- a/fe/src/main/java/org/apache/doris/common/util/Daemon.java
+++ b/fe/src/main/java/org/apache/doris/common/util/Daemon.java
@@ -17,8 +17,10 @@
 
 package org.apache.doris.common.util;
 
-import org.apache.logging.log4j.Logger;
+import org.apache.doris.meta.MetaContext;
+
 import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -30,6 +32,8 @@ public class Daemon extends Thread {
     private AtomicBoolean isStop;
     private Runnable runnable;
     
+    private boolean needMetaContext = false;
+
     {
         setDaemon(true);
     }
@@ -70,6 +74,10 @@ public class Daemon extends Thread {
         return runnable;
     }
     
+    public void setNeedMetaContext(boolean needMetaContext) {
+        this.needMetaContext = needMetaContext;
+    }
+
     public void exit() {
         isStop.set(true);
     }
@@ -91,6 +99,11 @@ public class Daemon extends Thread {
 
     @Override
     public void run() {
+        if (needMetaContext) {
+            MetaContext metaContext = new MetaContext();
+            metaContext.setThreadLocalInfo();
+        }
+
         while (!isStop.get()) {
             try {
                 runOneCycle();
@@ -103,6 +116,10 @@ public class Daemon extends Thread {
             } catch (InterruptedException e) {
                 LOG.error("InterruptedException: ", e);
             }
+        }
+
+        if (needMetaContext) {
+            MetaContext.remove();
         }
         LOG.error("daemon thread exits. name=" + this.getName());
     }

--- a/fe/src/main/java/org/apache/doris/common/util/Daemon.java
+++ b/fe/src/main/java/org/apache/doris/common/util/Daemon.java
@@ -32,7 +32,7 @@ public class Daemon extends Thread {
     private AtomicBoolean isStop;
     private Runnable runnable;
     
-    private boolean needMetaContext = false;
+    private MetaContext metaContext = null;
 
     {
         setDaemon(true);
@@ -74,8 +74,8 @@ public class Daemon extends Thread {
         return runnable;
     }
     
-    public void setNeedMetaContext(boolean needMetaContext) {
-        this.needMetaContext = needMetaContext;
+    public void setMetaContext(MetaContext metaContext) {
+        this.metaContext = metaContext;
     }
 
     public void exit() {
@@ -99,8 +99,7 @@ public class Daemon extends Thread {
 
     @Override
     public void run() {
-        if (needMetaContext) {
-            MetaContext metaContext = new MetaContext();
+        if (metaContext != null) {
             metaContext.setThreadLocalInfo();
         }
 
@@ -118,7 +117,7 @@ public class Daemon extends Thread {
             }
         }
 
-        if (needMetaContext) {
+        if (metaContext != null) {
             MetaContext.remove();
         }
         LOG.error("daemon thread exits. name=" + this.getName());

--- a/fe/src/main/java/org/apache/doris/journal/bdbje/BDBTool.java
+++ b/fe/src/main/java/org/apache/doris/journal/bdbje/BDBTool.java
@@ -123,7 +123,7 @@ public class BDBTool {
                     
                     // meta version
                     MetaContext metaContext = new MetaContext();
-                    metaContext.setJournalVersion(options.getMetaVersion());
+                    metaContext.setMetaVersion(options.getMetaVersion());
                     metaContext.setThreadLocalInfo();
 
                     for (Long key = fromKey; key <= endKey; key++) {

--- a/fe/src/main/java/org/apache/doris/journal/bdbje/BDBTool.java
+++ b/fe/src/main/java/org/apache/doris/journal/bdbje/BDBTool.java
@@ -19,6 +19,7 @@ package org.apache.doris.journal.bdbje;
 
 import org.apache.doris.catalog.Catalog;
 import org.apache.doris.journal.JournalEntity;
+import org.apache.doris.meta.MetaContext;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
@@ -121,7 +122,9 @@ public class BDBTool {
                     }
                     
                     // meta version
-                    Catalog.getInstance().setJournalVersion(options.getMetaVersion());
+                    MetaContext metaContext = new MetaContext();
+                    metaContext.setJournalVersion(options.getMetaVersion());
+                    metaContext.setThreadLocalInfo();
 
                     for (Long key = fromKey; key <= endKey; key++) {
                         getValueByKey(db, key);

--- a/fe/src/main/java/org/apache/doris/master/Checkpoint.java
+++ b/fe/src/main/java/org/apache/doris/master/Checkpoint.java
@@ -67,10 +67,6 @@ public class Checkpoint extends Daemon {
         this.imageDir = Catalog.IMAGE_DIR;
         this.editLog = editLog;
     }
-    
-    public Checkpoint() {
-        
-    }
 
     public static class NullOutputStream extends OutputStream {
         public void write(byte[] b, int off, int len) throws IOException {

--- a/fe/src/main/java/org/apache/doris/meta/MetaContext.java
+++ b/fe/src/main/java/org/apache/doris/meta/MetaContext.java
@@ -1,0 +1,32 @@
+package org.apache.doris.meta;
+
+public class MetaContext {
+
+    private int journalVersion;
+
+    private static ThreadLocal<MetaContext> threadLocalInfo = new ThreadLocal<MetaContext>();
+
+    public MetaContext() {
+
+    }
+
+    public void setJournalVersion(int journalVersion) {
+        this.journalVersion = journalVersion;
+    }
+
+    public int getJournalVersion() {
+        return journalVersion;
+    }
+
+    public void setThreadLocalInfo() {
+        threadLocalInfo.set(this);
+    }
+    
+    public static MetaContext get() {
+        return threadLocalInfo.get();
+    }
+
+    public static void remove() {
+        threadLocalInfo.remove();
+    }
+}

--- a/fe/src/main/java/org/apache/doris/meta/MetaContext.java
+++ b/fe/src/main/java/org/apache/doris/meta/MetaContext.java
@@ -1,8 +1,29 @@
 package org.apache.doris.meta;
 
+//Licensed to the Apache Software Foundation (ASF) under one
+//or more contributor license agreements.  See the NOTICE file
+//distributed with this work for additional information
+//regarding copyright ownership.  The ASF licenses this file
+//to you under the Apache License, Version 2.0 (the
+//"License"); you may not use this file except in compliance
+//with the License.  You may obtain a copy of the License at
+//
+//http://www.apache.org/licenses/LICENSE-2.0
+//
+//Unless required by applicable law or agreed to in writing,
+//software distributed under the License is distributed on an
+//"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//KIND, either express or implied.  See the License for the
+//specific language governing permissions and limitations
+//under the License.
+
+/*
+ * MetaContext saved the current meta version.
+ * And we need to create a thread local meta context for all threads which are about to reading meta.
+ */
 public class MetaContext {
 
-    private int journalVersion;
+    private int metaVersion;
 
     private static ThreadLocal<MetaContext> threadLocalInfo = new ThreadLocal<MetaContext>();
 
@@ -10,12 +31,12 @@ public class MetaContext {
 
     }
 
-    public void setJournalVersion(int journalVersion) {
-        this.journalVersion = journalVersion;
+    public void setMetaVersion(int metaVersion) {
+        this.metaVersion = metaVersion;
     }
 
-    public int getJournalVersion() {
-        return journalVersion;
+    public int getMetaVersion() {
+        return metaVersion;
     }
 
     public void setThreadLocalInfo() {

--- a/fe/src/main/java/org/apache/doris/persist/EditLog.java
+++ b/fe/src/main/java/org/apache/doris/persist/EditLog.java
@@ -505,13 +505,13 @@ public class EditLog {
                 case OperationType.OP_META_VERSION: {
                     String versionString = ((Text) journal.getData()).toString();
                     int version = Integer.parseInt(versionString);
-                    if (MetaContext.get().getJournalVersion() > FeConstants.meta_version) {
+                    if (MetaContext.get().getMetaVersion() > FeConstants.meta_version) {
                         LOG.error("meta data version is out of date, image: {}. meta: {}."
                                         + "please update FeConstants.meta_version and restart.",
-                                MetaContext.get().getJournalVersion(), FeConstants.meta_version);
+                                MetaContext.get().getMetaVersion(), FeConstants.meta_version);
                         System.exit(-1);
                     }
-                    MetaContext.get().setJournalVersion(version);
+                    MetaContext.get().setMetaVersion(version);
                     break;
                 }
                 case OperationType.OP_GLOBAL_VARIABLE: {

--- a/fe/src/main/java/org/apache/doris/persist/EditLog.java
+++ b/fe/src/main/java/org/apache/doris/persist/EditLog.java
@@ -50,6 +50,7 @@ import org.apache.doris.load.Load;
 import org.apache.doris.load.LoadErrorHub;
 import org.apache.doris.load.LoadJob;
 import org.apache.doris.load.routineload.RoutineLoadJob;
+import org.apache.doris.meta.MetaContext;
 import org.apache.doris.metric.MetricRepo;
 import org.apache.doris.mysql.privilege.UserProperty;
 import org.apache.doris.mysql.privilege.UserPropertyInfo;
@@ -504,13 +505,13 @@ public class EditLog {
                 case OperationType.OP_META_VERSION: {
                     String versionString = ((Text) journal.getData()).toString();
                     int version = Integer.parseInt(versionString);
-                    if (catalog.getJournalVersion() > FeConstants.meta_version) {
+                    if (MetaContext.get().getJournalVersion() > FeConstants.meta_version) {
                         LOG.error("meta data version is out of date, image: {}. meta: {}."
                                         + "please update FeConstants.meta_version and restart.",
-                                catalog.getJournalVersion(), FeConstants.meta_version);
+                                MetaContext.get().getJournalVersion(), FeConstants.meta_version);
                         System.exit(-1);
                     }
-                    catalog.setJournalVersion(version);
+                    MetaContext.get().setJournalVersion(version);
                     break;
                 }
                 case OperationType.OP_GLOBAL_VARIABLE: {

--- a/fe/src/test/java/org/apache/doris/alter/RollupJobTest.java
+++ b/fe/src/test/java/org/apache/doris/alter/RollupJobTest.java
@@ -39,6 +39,7 @@ import org.apache.doris.catalog.Replica;
 import org.apache.doris.catalog.Tablet;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.FeMetaVersion;
+import org.apache.doris.meta.MetaContext;
 import org.apache.doris.task.AgentTask;
 import org.apache.doris.task.AgentTaskQueue;
 import org.apache.doris.thrift.TTabletInfo;
@@ -90,8 +91,11 @@ public class RollupJobTest {
         fakeTransactionIDGenerator = new FakeTransactionIDGenerator();
         masterCatalog = CatalogTestUtil.createTestCatalog();
         slaveCatalog = CatalogTestUtil.createTestCatalog();
-        masterCatalog.setJournalVersion(FeMetaVersion.VERSION_40);
-        slaveCatalog.setJournalVersion(FeMetaVersion.VERSION_40);
+        MetaContext metaContext = new MetaContext();
+        metaContext.setJournalVersion(FeMetaVersion.VERSION_40);
+        metaContext.setThreadLocalInfo();
+        // masterCatalog.setJournalVersion(FeMetaVersion.VERSION_40);
+        // slaveCatalog.setJournalVersion(FeMetaVersion.VERSION_40);
         masterTransMgr = masterCatalog.getGlobalTransactionMgr();
         masterTransMgr.setEditLog(masterCatalog.getEditLog());
 

--- a/fe/src/test/java/org/apache/doris/alter/RollupJobTest.java
+++ b/fe/src/test/java/org/apache/doris/alter/RollupJobTest.java
@@ -92,7 +92,7 @@ public class RollupJobTest {
         masterCatalog = CatalogTestUtil.createTestCatalog();
         slaveCatalog = CatalogTestUtil.createTestCatalog();
         MetaContext metaContext = new MetaContext();
-        metaContext.setJournalVersion(FeMetaVersion.VERSION_40);
+        metaContext.setMetaVersion(FeMetaVersion.VERSION_40);
         metaContext.setThreadLocalInfo();
         // masterCatalog.setJournalVersion(FeMetaVersion.VERSION_40);
         // slaveCatalog.setJournalVersion(FeMetaVersion.VERSION_40);

--- a/fe/src/test/java/org/apache/doris/alter/SchemaChangeJobTest.java
+++ b/fe/src/test/java/org/apache/doris/alter/SchemaChangeJobTest.java
@@ -96,7 +96,7 @@ public class SchemaChangeJobTest {
         masterCatalog = CatalogTestUtil.createTestCatalog();
         slaveCatalog = CatalogTestUtil.createTestCatalog();
         MetaContext metaContext = new MetaContext();
-        metaContext.setJournalVersion(FeMetaVersion.VERSION_40);
+        metaContext.setMetaVersion(FeMetaVersion.VERSION_40);
         metaContext.setThreadLocalInfo();
 
         // masterCatalog.setJournalVersion(FeMetaVersion.VERSION_40);

--- a/fe/src/test/java/org/apache/doris/backup/BackupJobTest.java
+++ b/fe/src/test/java/org/apache/doris/backup/BackupJobTest.java
@@ -282,7 +282,7 @@ public class BackupJobTest {
         BackupMeta restoreMetaInfo = null;
         BackupJobInfo restoreJobInfo = null;
         try {
-            restoreMetaInfo = BackupMeta.fromFile(job.getLocalMetaInfoFilePath());
+            restoreMetaInfo = BackupMeta.fromFile(job.getLocalMetaInfoFilePath(), -1);
             Assert.assertEquals(1, restoreMetaInfo.getTables().size());
             OlapTable olapTable = (OlapTable) restoreMetaInfo.getTable(tblId);
             Assert.assertNotNull(olapTable);

--- a/fe/src/test/java/org/apache/doris/backup/RestoreJobTest.java
+++ b/fe/src/test/java/org/apache/doris/backup/RestoreJobTest.java
@@ -177,7 +177,7 @@ public class RestoreJobTest {
                 minTimes = 0;
 
                 List<BackupMeta> backupMetas = Lists.newArrayList();
-                repo.getSnapshotMetaFile(label, backupMetas);
+                repo.getSnapshotMetaFile(label, backupMetas, -1);
                 result = new Delegate() {
                     public Status getSnapshotMetaFile(String label, List<BackupMeta> backupMetas) {
                         backupMetas.add(backupMeta);
@@ -236,7 +236,7 @@ public class RestoreJobTest {
         db.dropTable(expectedRestoreTbl.getName());
         
         job = new RestoreJob(label, "2018-01-01 01:01:01", db.getId(), db.getFullName(),
-                jobInfo, false, 3, 100000, catalog, repo.getId());
+                jobInfo, false, 3, 100000, -1, catalog, repo.getId());
         
         List<Table> tbls = Lists.newArrayList();
         tbls.add(expectedRestoreTbl);

--- a/fe/src/test/java/org/apache/doris/catalog/CatalogTest.java
+++ b/fe/src/test/java/org/apache/doris/catalog/CatalogTest.java
@@ -25,6 +25,7 @@ import org.apache.doris.cluster.Cluster;
 import org.apache.doris.common.FeConstants;
 import org.apache.doris.load.Load;
 import org.apache.doris.load.LoadJob;
+import org.apache.doris.meta.MetaContext;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -133,7 +134,7 @@ public class CatalogTest {
         file.createNewFile();
         DataOutputStream dos = new DataOutputStream(new FileOutputStream(file));
         Catalog catalog = Catalog.getInstance();
-        catalog.setJournalVersion(FeConstants.meta_version);
+        MetaContext.get().setJournalVersion(FeConstants.meta_version);
         Field field = catalog.getClass().getDeclaredField("load");
         field.setAccessible(true);
         field.set(catalog, new Load());
@@ -161,7 +162,7 @@ public class CatalogTest {
         DataOutputStream dos = new DataOutputStream(new FileOutputStream(file));
 
         Catalog catalog = Catalog.getInstance();
-        catalog.setJournalVersion(FeConstants.meta_version);
+        MetaContext.get().setJournalVersion(FeConstants.meta_version);
         Field field = catalog.getClass().getDeclaredField("load");
         field.setAccessible(true);
         field.set(catalog, new Load());
@@ -196,7 +197,7 @@ public class CatalogTest {
         file.createNewFile();
         DataOutputStream dos = new DataOutputStream(new FileOutputStream(file));
         Catalog catalog = Catalog.getInstance();
-        catalog.setJournalVersion(FeConstants.meta_version);
+        MetaContext.get().setJournalVersion(FeConstants.meta_version);
         Field field = catalog.getClass().getDeclaredField("load");
         field.setAccessible(true);
         field.set(catalog, new Load());

--- a/fe/src/test/java/org/apache/doris/catalog/CatalogTest.java
+++ b/fe/src/test/java/org/apache/doris/catalog/CatalogTest.java
@@ -134,7 +134,7 @@ public class CatalogTest {
         file.createNewFile();
         DataOutputStream dos = new DataOutputStream(new FileOutputStream(file));
         Catalog catalog = Catalog.getInstance();
-        MetaContext.get().setJournalVersion(FeConstants.meta_version);
+        MetaContext.get().setMetaVersion(FeConstants.meta_version);
         Field field = catalog.getClass().getDeclaredField("load");
         field.setAccessible(true);
         field.set(catalog, new Load());
@@ -162,7 +162,7 @@ public class CatalogTest {
         DataOutputStream dos = new DataOutputStream(new FileOutputStream(file));
 
         Catalog catalog = Catalog.getInstance();
-        MetaContext.get().setJournalVersion(FeConstants.meta_version);
+        MetaContext.get().setMetaVersion(FeConstants.meta_version);
         Field field = catalog.getClass().getDeclaredField("load");
         field.setAccessible(true);
         field.set(catalog, new Load());
@@ -197,7 +197,7 @@ public class CatalogTest {
         file.createNewFile();
         DataOutputStream dos = new DataOutputStream(new FileOutputStream(file));
         Catalog catalog = Catalog.getInstance();
-        MetaContext.get().setJournalVersion(FeConstants.meta_version);
+        MetaContext.get().setMetaVersion(FeConstants.meta_version);
         Field field = catalog.getClass().getDeclaredField("load");
         field.setAccessible(true);
         field.set(catalog, new Load());

--- a/fe/src/test/java/org/apache/doris/catalog/FakeCatalog.java
+++ b/fe/src/test/java/org/apache/doris/catalog/FakeCatalog.java
@@ -17,8 +17,6 @@
 
 package org.apache.doris.catalog;
 
-import org.apache.doris.common.FeMetaVersion;
-
 import mockit.Mock;
 import mockit.MockUp;
 
@@ -30,10 +28,10 @@ public class FakeCatalog extends MockUp<Catalog> {
         FakeCatalog.catalog = catalog;
     }
     
-    @Mock
-    public int getJournalVersion() {
-        return FeMetaVersion.VERSION_45;
-    }
+    // @Mock
+    // public int getJournalVersion() {
+    // return FeMetaVersion.VERSION_45;
+    // }
     
     @Mock
     private static Catalog getCurrentCatalog() {

--- a/fe/src/test/java/org/apache/doris/catalog/TabletTest.java
+++ b/fe/src/test/java/org/apache/doris/catalog/TabletTest.java
@@ -67,8 +67,6 @@ public class TabletTest {
         tablet.addReplica(replica1);
         tablet.addReplica(replica2);
         tablet.addReplica(replica3);
-
-
     }
 
     @Test

--- a/fe/src/test/java/org/apache/doris/es/EsStateStoreTest.java
+++ b/fe/src/test/java/org/apache/doris/es/EsStateStoreTest.java
@@ -22,20 +22,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.lang.reflect.InvocationTargetException;
-import java.net.URISyntaxException;
-import java.util.Map;
-
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
-
 import org.apache.doris.catalog.Catalog;
 import org.apache.doris.catalog.CatalogTestUtil;
 import org.apache.doris.catalog.EsTable;
@@ -48,8 +34,24 @@ import org.apache.doris.common.FeMetaVersion;
 import org.apache.doris.external.EsIndexState;
 import org.apache.doris.external.EsStateStore;
 import org.apache.doris.external.EsTableState;
+import org.apache.doris.meta.MetaContext;
+
 import com.google.common.collect.Lists;
 import com.google.common.collect.Range;
+
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.lang.reflect.InvocationTargetException;
+import java.net.URISyntaxException;
+import java.util.Map;
 
 public class EsStateStoreTest {
 
@@ -68,7 +70,10 @@ public class EsStateStoreTest {
         fakeEditLog = new FakeEditLog();
         fakeCatalog = new FakeCatalog();
         masterCatalog = CatalogTestUtil.createTestCatalog();
-        masterCatalog.setJournalVersion(FeMetaVersion.VERSION_40);
+        MetaContext metaContext = new MetaContext();
+        metaContext.setJournalVersion(FeMetaVersion.VERSION_40);
+        metaContext.setThreadLocalInfo();
+        // masterCatalog.setJournalVersion(FeMetaVersion.VERSION_40);
         FakeCatalog.setCatalog(masterCatalog);
         clusterStateStr1 = loadJsonFromFile("data/es/clusterstate1.json");
         clusterStateStr2 = loadJsonFromFile("data/es/clusterstate2.json");

--- a/fe/src/test/java/org/apache/doris/es/EsStateStoreTest.java
+++ b/fe/src/test/java/org/apache/doris/es/EsStateStoreTest.java
@@ -71,7 +71,7 @@ public class EsStateStoreTest {
         fakeCatalog = new FakeCatalog();
         masterCatalog = CatalogTestUtil.createTestCatalog();
         MetaContext metaContext = new MetaContext();
-        metaContext.setJournalVersion(FeMetaVersion.VERSION_40);
+        metaContext.setMetaVersion(FeMetaVersion.VERSION_40);
         metaContext.setThreadLocalInfo();
         // masterCatalog.setJournalVersion(FeMetaVersion.VERSION_40);
         FakeCatalog.setCatalog(masterCatalog);

--- a/fe/src/test/java/org/apache/doris/transaction/GlobalTransactionMgrTest.java
+++ b/fe/src/test/java/org/apache/doris/transaction/GlobalTransactionMgrTest.java
@@ -32,6 +32,7 @@ import org.apache.doris.catalog.Tablet;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.FeMetaVersion;
 import org.apache.doris.common.MetaNotFoundException;
+import org.apache.doris.meta.MetaContext;
 import org.apache.doris.transaction.TransactionState.LoadJobSourceType;
 
 import com.google.common.collect.Lists;
@@ -65,8 +66,12 @@ public class GlobalTransactionMgrTest {
         fakeTransactionIDGenerator = new FakeTransactionIDGenerator();
         masterCatalog = CatalogTestUtil.createTestCatalog();
         slaveCatalog = CatalogTestUtil.createTestCatalog();
-        masterCatalog.setJournalVersion(FeMetaVersion.VERSION_40);
-        slaveCatalog.setJournalVersion(FeMetaVersion.VERSION_40);
+        MetaContext metaContext = new MetaContext();
+        metaContext.setJournalVersion(FeMetaVersion.VERSION_40);
+        metaContext.setThreadLocalInfo();
+
+        // masterCatalog.setJournalVersion(FeMetaVersion.VERSION_40);
+        // slaveCatalog.setJournalVersion(FeMetaVersion.VERSION_40);
         masterTransMgr = masterCatalog.getGlobalTransactionMgr();
         masterTransMgr.setEditLog(masterCatalog.getEditLog());
 

--- a/fe/src/test/java/org/apache/doris/transaction/GlobalTransactionMgrTest.java
+++ b/fe/src/test/java/org/apache/doris/transaction/GlobalTransactionMgrTest.java
@@ -67,7 +67,7 @@ public class GlobalTransactionMgrTest {
         masterCatalog = CatalogTestUtil.createTestCatalog();
         slaveCatalog = CatalogTestUtil.createTestCatalog();
         MetaContext metaContext = new MetaContext();
-        metaContext.setJournalVersion(FeMetaVersion.VERSION_40);
+        metaContext.setMetaVersion(FeMetaVersion.VERSION_40);
         metaContext.setThreadLocalInfo();
 
         // masterCatalog.setJournalVersion(FeMetaVersion.VERSION_40);


### PR DESCRIPTION
Because the meta version is only be used in catalog saving and loading.
So currently this version is a field of Catalog class. And we can get this
version only by calling Catalog.getCurrentCatalogJournalVersion().

But in restore process, we need to read the meta data which is saved with
a specified meta version. So we need a flexible way to read a meta data
using a specified meta version, not only the version from Catalog.

So we create a new class called MetaContext. Currently it only has one field,
'journalVersion', to save the current journal version. And it is a
thread local variable, so that we can create a MetaContext anywhere we want,
and setting the 'journalVersion' which we want to use for reading meta.

Currently, there are 4 threads which is related to meta data  saving and loading.

1. The Frontend starting thread, which will call Catalog.initialize() to load the image.
2. the Frontend state listener thread, which will listen the state changing, and call 
    transferToMaster() or transferToNonMaster().
3. Edit log replayed thread, which is created when calling transferToNonMaster().
    It will replay edit log
4. Checkpoint thread, which is created when calling transferToMaster(). It will do
    the checkpoint periodically.

Notice that we get the 'current meta version' only when 'READING' the meta (not WRITING).
So we only need to take care of all 'READING' threads.
We create MetaContext thread local variable for these 4 threads, and thread 2,3,4's
meta context inherit from thread 1's meta context. Because thread 1 will load the origin
image file and get the very first meta version.

And we leave the Catalog.getCurrentCatalogJournalVersion()'s name unchanged, just
change its content, because we don't want change a lot codes this time.

On the other hand, we add the current meta version in backup job info file when doing 
backup job. So that when restoring from a backup snapshot, we can know which meta
version we should use for read the meta.
And also , we add a new property "meta_version" for Restore stmt, so that we can specify
the meta version used for reading backup meta. It is for those old backup snapshots
which do not has meta version saving in backup job info file.

