### PR TITLE
Parse thrift port from cluster state

### DIFF
--- a/fe/src/main/java/org/apache/doris/catalog/Catalog.java
+++ b/fe/src/main/java/org/apache/doris/catalog/Catalog.java
@@ -3875,10 +3875,10 @@ public class Catalog {
 
             // properties
             sb.append("\nPROPERTIES (\n");
-            sb.append("\"host\" = \"").append(esTable.getHosts()).append("\",\n");
+            sb.append("\"hosts\" = \"").append(esTable.getHosts()).append("\",\n");
             sb.append("\"user\" = \"").append(esTable.getUserName()).append("\",\n");
             sb.append("\"password\" = \"").append(hidePassword ? "" : esTable.getPasswd()).append("\",\n");
-            sb.append("\"index\" = \"").append(esTable.getIndexName()).append("\"\n");
+            sb.append("\"index\" = \"").append(esTable.getIndexName()).append("\",\n");
             sb.append("\"type\" = \"").append(esTable.getMappingType()).append("\"\n");
             sb.append(");");
         }

--- a/fe/src/main/java/org/apache/doris/catalog/EsTable.java
+++ b/fe/src/main/java/org/apache/doris/catalog/EsTable.java
@@ -74,7 +74,7 @@ public class EsTable extends Table {
     private void validate(Map<String, String> properties) throws DdlException {
         if (properties == null) {
             throw new DdlException("Please set properties of elasticsearch table, "
-                    + "they are: hosts, thrift_port, http_port, user, password, index");
+                    + "they are: hosts, user, password, index");
         }
 
         hosts = properties.get(HOSTS);

--- a/fe/src/main/java/org/apache/doris/external/EsShardRouting.java
+++ b/fe/src/main/java/org/apache/doris/external/EsShardRouting.java
@@ -41,8 +41,9 @@ public class EsShardRouting {
         String nodeId = shardInfo.getString("node");
         JSONObject nodeInfo = nodesMap.getJSONObject(nodeId);
         String[] transportAddr = nodeInfo.getString("transport_address").split(":");
-        // TODO(ygl) should get thrift port from node info
-        TNetworkAddress addr = new TNetworkAddress(transportAddr[0], Integer.valueOf(transportAddr[1]));
+        // get thrift port from node info
+        String thriftPort = nodeInfo.getJSONObject("attributes").getString("thrift_port");
+        TNetworkAddress addr = new TNetworkAddress(transportAddr[0], Integer.valueOf(thriftPort));
         boolean isPrimary = shardInfo.getBoolean("primary");
         return new EsShardRouting(indexName, Integer.valueOf(shardKey), 
                 isPrimary, addr);


### PR DESCRIPTION
1. Parse thrift port from cluster state. 
2. Fix bug: the sql returned by show create es table is not valid.