### PR TITLE
Optimize backup & restore process

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -81,9 +81,9 @@ namespace config {
     // the count of thread to check consistency
     CONF_Int32(check_consistency_worker_count, "1");
     // the count of thread to upload
-    CONF_Int32(upload_worker_count, "3");
+    CONF_Int32(upload_worker_count, "1");
     // the count of thread to download
-    CONF_Int32(download_worker_count, "3");
+    CONF_Int32(download_worker_count, "1");
     // the count of thread to make snapshot
     CONF_Int32(make_snapshot_worker_count, "5");
     // the count of thread to release snapshot

--- a/be/src/runtime/exec_env.h
+++ b/be/src/runtime/exec_env.h
@@ -43,7 +43,6 @@ class PriorityThreadPool;
 class PullLoadTaskMgr;
 class ReservationTracker;
 class ResultBufferMgr;
-class SnapshotLoader;
 class TMasterInfo;
 class TabletWriterMgr;
 class TestExecEnv;
@@ -104,7 +103,6 @@ public:
     BfdParser* bfd_parser() const { return _bfd_parser; }
     PullLoadTaskMgr* pull_load_task_mgr() const { return _pull_load_task_mgr; }
     BrokerMgr* broker_mgr() const { return _broker_mgr; }
-    SnapshotLoader* snapshot_loader() const { return _snapshot_loader; }
     BrpcStubCache* brpc_stub_cache() const { return _brpc_stub_cache; }
     ReservationTracker* buffer_reservation() { return _buffer_reservation; }
     BufferPool* buffer_pool() { return _buffer_pool; }
@@ -151,7 +149,6 @@ private:
     BrokerMgr* _broker_mgr = nullptr;
     TabletWriterMgr* _tablet_writer_mgr = nullptr;
     LoadStreamMgr* _load_stream_mgr = nullptr;
-    SnapshotLoader* _snapshot_loader = nullptr;
     BrpcStubCache* _brpc_stub_cache = nullptr;
 
     ReservationTracker* _buffer_reservation = nullptr;

--- a/be/src/runtime/exec_env_init.cpp
+++ b/be/src/runtime/exec_env_init.cpp
@@ -45,7 +45,6 @@
 #include "runtime/load_path_mgr.h"
 #include "runtime/load_stream_mgr.h"
 #include "runtime/pull_load_task_mgr.h"
-#include "runtime/snapshot_loader.h"
 #include "util/pretty_printer.h"
 #include "util/doris_metrics.h"
 #include "util/brpc_stub_cache.h"
@@ -93,7 +92,6 @@ Status ExecEnv::_init(const std::vector<StorePath>& store_paths) {
     _broker_mgr = new BrokerMgr(this);
     _tablet_writer_mgr = new TabletWriterMgr(this);
     _load_stream_mgr = new LoadStreamMgr();
-    _snapshot_loader = new SnapshotLoader(this);
     _brpc_stub_cache = new BrpcStubCache();
 
     _client_cache->init_metrics(DorisMetrics::metrics(), "backend");
@@ -182,7 +180,6 @@ void ExecEnv::_init_buffer_pool(int64_t min_page_size,
 
 void ExecEnv::_destory() {
     delete _brpc_stub_cache;
-    delete _snapshot_loader;
     delete _load_stream_mgr;
     delete _tablet_writer_mgr;
     delete _broker_mgr;

--- a/be/src/runtime/runtime_state.cpp
+++ b/be/src/runtime/runtime_state.cpp
@@ -72,30 +72,6 @@ RuntimeState::RuntimeState(
 }
 
 RuntimeState::RuntimeState(
-        const TUniqueId& fragment_instance_id,
-        const TQueryOptions& query_options,
-        const std::string& now, ExecEnv* exec_env) :
-            _obj_pool(new ObjectPool()),
-            _data_stream_recvrs_pool(new ObjectPool()),
-            _unreported_error_idx(0),
-            _profile(_obj_pool.get(), "Fragment " + print_id(fragment_instance_id)),
-            _fragment_mem_tracker(NULL),
-            _is_cancelled(false),
-            _per_fragment_instance_idx(0),
-            _root_node_id(-1),
-            _num_rows_load_success(0),
-            _num_rows_load_filtered(0),
-            _num_print_error_rows(0),
-            _normal_row_number(0),
-            _error_row_number(0),
-            _error_log_file(nullptr),
-            _is_running(true),
-            _instance_buffer_reservation(new ReservationTracker) {
-    Status status = init(fragment_instance_id, query_options, now, exec_env);
-    DCHECK(status.ok());
-}
-
-RuntimeState::RuntimeState(
         const TExecPlanFragmentParams& fragment_params,
         const TQueryOptions& query_options,
         const std::string& now, ExecEnv* exec_env) :

--- a/be/src/runtime/runtime_state.cpp
+++ b/be/src/runtime/runtime_state.cpp
@@ -46,6 +46,31 @@
 
 namespace doris {
 
+// for ut only
+RuntimeState::RuntimeState(
+        const TUniqueId& fragment_instance_id,
+        const TQueryOptions& query_options,
+        const std::string& now, ExecEnv* exec_env) :
+            _obj_pool(new ObjectPool()),
+            _data_stream_recvrs_pool(new ObjectPool()),
+            _unreported_error_idx(0),
+            _profile(_obj_pool.get(), "Fragment " + print_id(fragment_instance_id)),
+            _fragment_mem_tracker(NULL),
+            _is_cancelled(false),
+            _per_fragment_instance_idx(0),
+            _root_node_id(-1),
+            _num_rows_load_success(0),
+            _num_rows_load_filtered(0),
+            _num_print_error_rows(0),
+            _normal_row_number(0),
+            _error_row_number(0),
+            _error_log_file(nullptr),
+            _is_running(true),
+            _instance_buffer_reservation(new ReservationTracker) {
+    Status status = init(fragment_instance_id, query_options, now, exec_env);
+    DCHECK(status.ok());
+}
+
 RuntimeState::RuntimeState(
         const TUniqueId& fragment_instance_id,
         const TQueryOptions& query_options,

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -71,6 +71,11 @@ public:
         const TQueryOptions& query_options,
         const std::string& now, ExecEnv* exec_env);
 
+    // for ut only
+    RuntimeState(const TUniqueId& fragment_instance_id,
+                 const TQueryOptions& query_options,
+                 const std::string& now, ExecEnv* exec_env);
+
     RuntimeState(
         const TExecPlanFragmentParams& fragment_params,
         const TQueryOptions& query_options,

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -65,12 +65,6 @@ class RowDescriptor;
 // query and shared across all execution nodes of that query.
 class RuntimeState {
 public:
-    // NOTE: only used to unit test
-    RuntimeState(
-        const TUniqueId& fragment_instance_id,
-        const TQueryOptions& query_options,
-        const std::string& now, ExecEnv* exec_env);
-
     // for ut only
     RuntimeState(const TUniqueId& fragment_instance_id,
                  const TQueryOptions& query_options,

--- a/be/src/runtime/snapshot_loader.cpp
+++ b/be/src/runtime/snapshot_loader.cpp
@@ -83,6 +83,11 @@ Status SnapshotLoader::upload(
               << broker_addr << ", job: " << _job_id
               << ", task" << _task_id;
 
+    // check if job has already been cancelled
+    int tmp_counter = 1;
+    RETURN_IF_ERROR(_report_every(0, &tmp_counter, 0, 0,
+            TTaskType::type::UPLOAD));
+
     Status status = Status::OK;
     // 1. validate local tablet snapshot paths
     RETURN_IF_ERROR(_check_local_snapshot_paths(src_to_dest_path, true));
@@ -253,6 +258,11 @@ Status SnapshotLoader::download(
               << src_to_dest_path.size() << ", broker addr: "
               << broker_addr << ", job: " << _job_id
               << ", task id: " << _task_id;
+
+    // check if job has already been cancelled
+    int tmp_counter = 1;
+    RETURN_IF_ERROR(_report_every(0, &tmp_counter, 0, 0,
+            TTaskType::type::DOWNLOAD));
 
     Status status = Status::OK;
     // 1. validate local tablet snapshot paths

--- a/be/src/runtime/snapshot_loader.cpp
+++ b/be/src/runtime/snapshot_loader.cpp
@@ -167,7 +167,6 @@ Status SnapshotLoader::upload(
 
             if (!need_upload) {
                 VLOG(2) << "file exist in remote path, no need to upload: " << local_file;
-                finished_num++;
                 continue;
             }
 
@@ -226,10 +225,10 @@ Status SnapshotLoader::upload(
                     full_remote_file + ".part",
                     full_remote_file + "." + md5sum,
                     broker_prop));
-            finished_num++;
         } // end for each tablet's local files
 
         tablet_files->emplace(tablet_id, local_files_with_checksum);
+        finished_num++;
         LOG(INFO) << "finished to write tablet to remote. local path: "
                 << src_path << ", remote path: " << dest_path;
     } // end for each tablet path
@@ -345,7 +344,6 @@ Status SnapshotLoader::download(
             if (!need_download) {
                 LOG(INFO) << "remote file already exist in local, no need to download."
                           << ", file: " << remote_file;
-                finished_num++;
                 continue;
             }
 
@@ -435,7 +433,6 @@ Status SnapshotLoader::download(
             local_files.push_back(local_file_name);
             LOG(INFO) << "finished to download file via broker. file: " <<
                 full_local_file << ", length: " << file_len;
-            finished_num++;
         } // end for all remote files
 
         // finally, delete local files which are not in remote
@@ -464,6 +461,8 @@ Status SnapshotLoader::download(
                         << ", ignore it";
             }
         }
+
+        finished_num++;
     } // end for src_to_dest_path
 
     LOG(INFO) << "finished to download snapshots. job: " << _job_id
@@ -1017,6 +1016,8 @@ Status SnapshotLoader::_report_every(
     // reset
     *counter = 0;
     if (report_st.status_code == TStatusCode::CANCELLED) {
+        LOG(INFO) << "job is cancelled. job id: " << _job_id
+                << ", task id: " << _task_id;
         return Status::CANCELLED;
     }
     return Status::OK;

--- a/be/src/runtime/snapshot_loader.cpp
+++ b/be/src/runtime/snapshot_loader.cpp
@@ -984,7 +984,7 @@ Status SnapshotLoader::_report_every(
         TTaskType::type type) {
 
     ++*counter;
-    if (*counter < report_threshold) {
+    if (*counter <= report_threshold) {
         return Status::OK;
     }
 

--- a/be/src/runtime/snapshot_loader.h
+++ b/be/src/runtime/snapshot_loader.h
@@ -61,7 +61,7 @@ struct FileStat {
  */
 class SnapshotLoader {
 public:
-    SnapshotLoader(ExecEnv* env);
+    SnapshotLoader(ExecEnv* env, int64_t job_id, int64_t task_id);
 
     ~SnapshotLoader();
 
@@ -69,21 +69,18 @@ public:
         const std::map<std::string, std::string>& src_to_dest_path,
         const TNetworkAddress& broker_addr,
         const std::map<std::string, std::string>& broker_prop,
-        int64_t job_id,
         std::map<int64_t, std::vector<std::string>>* tablet_files);
 
     Status download(
         const std::map<std::string, std::string>& src_to_dest_path,
         const TNetworkAddress& broker_addr,
         const std::map<std::string, std::string>& broker_prop,
-        int64_t job_id,
         std::vector<int64_t>* downloaded_tablet_ids);
 
     Status move(
         const std::string& snapshot_path,
         const std::string& tablet_path,
         const std::string& store_path,
-        int64_t job_id,
         bool overwrite);
 
 private:
@@ -133,8 +130,15 @@ private:
         const std::string& remote_path,
         int64_t* tablet_id);
 
+    Status _report_every(
+        int report_threshold, int* counter,
+        int finished_num, int total_num,
+        TTaskType::type type);
+
 private:
     ExecEnv* _env;
+    int64_t _job_id;
+    int64_t _task_id;
 };
 
 } // end namespace doris

--- a/be/test/runtime/snapshot_loader_test.cpp
+++ b/be/test/runtime/snapshot_loader_test.cpp
@@ -37,7 +37,7 @@ private:
 };
 
 TEST_F(SnapshotLoaderTest, NormalCase) {
-    SnapshotLoader loader(_exec_env);
+    SnapshotLoader loader(_exec_env, 1L, 2L);
 
     ASSERT_TRUE(loader._end_with("abt.dat", ".dat"));
     ASSERT_FALSE(loader._end_with("abt.dat", ".da"));

--- a/docs/help/Contents/Data Definition/ddl_stmt.md
+++ b/docs/help/Contents/Data Definition/ddl_stmt.md
@@ -752,7 +752,7 @@
 ## example
     1. 创建名为 bos_repo 的仓库，依赖 BOS broker "bos_broker"，数据根目录为：bos://palo_backup
         CREATE REPOSITORY `bos_repo`
-        WITH BROKER `bos_broker `
+        WITH BROKER `bos_broker`
         ON LOCATION "bos://palo_backup"
         PROPERTIES
         (
@@ -763,7 +763,7 @@
      
     2. 创建和示例 1 相同的仓库，但属性为只读：
         CREATE READ ONLY REPOSITORY `bos_repo`
-        WITH BROKER `bos_broker `
+        WITH BROKER `bos_broker`
         ON LOCATION "bos://palo_backup"
         PROPERTIES
         (
@@ -774,7 +774,7 @@
 
     3. 创建名为 hdfs_repo 的仓库，依赖 Baidu hdfs broker "hdfs_broker"，数据根目录为：hdfs://hadoop-name-node:54310/path/to/repo/
         CREATE REPOSITORY `hdfs_repo`
-        WITH BROKER `hdfs_broker `
+        WITH BROKER `hdfs_broker`
         ON LOCATION "hdfs://hadoop-name-node:54310/path/to/repo/"
         PROPERTIES
         (
@@ -867,7 +867,7 @@
 
 ## example
     1. 从 example_repo 中恢复备份 snapshot_1 中的表 backup_tbl 到数据库 example_db1，时间版本为 "2018-05-04-16-45-08"。恢复为 1 个副本：
-        RESTORE SNAPSHOT example_db1.`snapshot_1 `
+        RESTORE SNAPSHOT example_db1.`snapshot_1`
         FROM `example_repo`
         ON ( `backup_tbl` )
         PROPERTIES
@@ -877,8 +877,8 @@
         );
         
     2. 从 example_repo 中恢复备份 snapshot_2 中的表 backup_tbl 的分区 p1,p2，以及表 backup_tbl2 到数据库 example_db1，并重命名为 new_tbl，时间版本为 "2018-05-04-17-11-01"。默认恢复为 3 个副本：
-        RESTORE SNAPSHOT example_db1.`snapshot_2 `
-        FROM `example_repo `
+        RESTORE SNAPSHOT example_db1.`snapshot_2`
+        FROM `example_repo`
         ON
         (
             `backup_tbl` PARTITION (`p1`, `p2`) AS `backup_tbl2`,

--- a/fe/src/main/java/org/apache/doris/analysis/ShowBackupStmt.java
+++ b/fe/src/main/java/org/apache/doris/analysis/ShowBackupStmt.java
@@ -35,7 +35,7 @@ public class ShowBackupStmt extends ShowStmt {
     public static final ImmutableList<String> TITLE_NAMES = new ImmutableList.Builder<String>()
             .add("JobId").add("SnapshotName").add("DbName").add("State").add("BackupObjs").add("CreateTime")
             .add("SnapshotFinishedTime").add("UploadFinishedTime").add("FinishedTime").add("UnfinishedTasks")
-            .add("TaskErrMsg").add("Status").add("Timeout")
+            .add("Progress").add("TaskErrMsg").add("Status").add("Timeout")
             .build();
 
     private String dbName;
@@ -89,5 +89,10 @@ public class ShowBackupStmt extends ShowStmt {
     @Override
     public String toString() {
         return toSql();
+    }
+
+    @Override
+    public RedirectStatus getRedirectStatus() {
+        return RedirectStatus.FORWARD_NO_SYNC;
     }
 }

--- a/fe/src/main/java/org/apache/doris/analysis/ShowRestoreStmt.java
+++ b/fe/src/main/java/org/apache/doris/analysis/ShowRestoreStmt.java
@@ -36,8 +36,8 @@ public class ShowRestoreStmt extends ShowStmt {
             .add("JobId").add("Label").add("Timestamp").add("DbName").add("State")
             .add("AllowLoad").add("ReplicationNum")
             .add("RestoreObjs").add("CreateTime").add("MetaPreparedTime").add("SnapshotFinishedTime")
-            .add("DownloadFinishedTime").add("FinishedTime").add("UnfinishedTasks").add("TaskErrMsg")
-            .add("Status").add("Timeout")
+            .add("DownloadFinishedTime").add("FinishedTime").add("UnfinishedTasks").add("Progress")
+            .add("TaskErrMsg").add("Status").add("Timeout")
             .build();
 
     private String dbName;
@@ -99,6 +99,11 @@ public class ShowRestoreStmt extends ShowStmt {
     @Override
     public String toString() {
         return toSql();
+    }
+
+    @Override
+    public RedirectStatus getRedirectStatus() {
+        return RedirectStatus.FORWARD_NO_SYNC;
     }
 }
 

--- a/fe/src/main/java/org/apache/doris/backup/AbstractJob.java
+++ b/fe/src/main/java/org/apache/doris/backup/AbstractJob.java
@@ -18,6 +18,7 @@
 package org.apache.doris.backup;
 
 import org.apache.doris.catalog.Catalog;
+import org.apache.doris.common.Pair;
 import org.apache.doris.common.io.Text;
 import org.apache.doris.common.io.Writable;
 
@@ -67,6 +68,9 @@ public abstract class AbstractJob implements Writable {
     protected long createTime = -1;
     protected long finishedTime = -1;
     protected long timeoutMs;
+
+    // task signature -> <finished num / total num>
+    protected Map<Long, Pair<Integer, Integer>> taskProgress = Maps.newConcurrentMap();
 
     protected boolean isTypeRead = false;
 

--- a/fe/src/main/java/org/apache/doris/backup/BackupHandler.java
+++ b/fe/src/main/java/org/apache/doris/backup/BackupHandler.java
@@ -25,6 +25,7 @@ import org.apache.doris.analysis.CreateRepositoryStmt;
 import org.apache.doris.analysis.DropRepositoryStmt;
 import org.apache.doris.analysis.RestoreStmt;
 import org.apache.doris.analysis.TableRef;
+import org.apache.doris.backup.AbstractJob.JobType;
 import org.apache.doris.backup.BackupJob.BackupJobState;
 import org.apache.doris.backup.BackupJobInfo.BackupTableInfo;
 import org.apache.doris.catalog.Catalog;
@@ -38,6 +39,7 @@ import org.apache.doris.common.Config;
 import org.apache.doris.common.DdlException;
 import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.ErrorReport;
+import org.apache.doris.common.Pair;
 import org.apache.doris.common.io.Writable;
 import org.apache.doris.common.util.Daemon;
 import org.apache.doris.task.DirMoveTask;
@@ -45,6 +47,7 @@ import org.apache.doris.task.DownloadTask;
 import org.apache.doris.task.SnapshotTask;
 import org.apache.doris.task.UploadTask;
 import org.apache.doris.thrift.TFinishTaskRequest;
+import org.apache.doris.thrift.TTaskType;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
@@ -523,6 +526,23 @@ public class BackupHandler extends Daemon implements Writable {
             job.replayRun();
         }
         dbIdToBackupOrRestoreJob.put(job.getDbId(), job);
+    }
+
+    public boolean report(TTaskType type, long jobId, long taskId, int finishedNum, int totalNum) {
+        for (AbstractJob job : dbIdToBackupOrRestoreJob.values()) {
+            if (job.getType() == JobType.BACKUP) {
+                if (job.getJobId() == jobId && type == TTaskType.UPLOAD) {
+                    job.taskProgress.put(taskId, Pair.create(finishedNum, totalNum));
+                    return true;
+                }
+            } else if (job.getType() == JobType.RESTORE) {
+                if (job.getJobId() == jobId && type == TTaskType.DOWNLOAD) {
+                    job.taskProgress.put(taskId, Pair.create(finishedNum, totalNum));
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 
     public static BackupHandler read(DataInput in) throws IOException {

--- a/fe/src/main/java/org/apache/doris/backup/BackupHandler.java
+++ b/fe/src/main/java/org/apache/doris/backup/BackupHandler.java
@@ -531,12 +531,12 @@ public class BackupHandler extends Daemon implements Writable {
     public boolean report(TTaskType type, long jobId, long taskId, int finishedNum, int totalNum) {
         for (AbstractJob job : dbIdToBackupOrRestoreJob.values()) {
             if (job.getType() == JobType.BACKUP) {
-                if (job.getJobId() == jobId && type == TTaskType.UPLOAD) {
+                if (!job.isDone() && job.getJobId() == jobId && type == TTaskType.UPLOAD) {
                     job.taskProgress.put(taskId, Pair.create(finishedNum, totalNum));
                     return true;
                 }
             } else if (job.getType() == JobType.RESTORE) {
-                if (job.getJobId() == jobId && type == TTaskType.DOWNLOAD) {
+                if (!job.isDone() && job.getJobId() == jobId && type == TTaskType.DOWNLOAD) {
                     job.taskProgress.put(taskId, Pair.create(finishedNum, totalNum));
                     return true;
                 }

--- a/fe/src/main/java/org/apache/doris/backup/BackupJob.java
+++ b/fe/src/main/java/org/apache/doris/backup/BackupJob.java
@@ -295,7 +295,10 @@ public class BackupJob extends AbstractJob {
                 break;
         }
 
-        if (!status.ok()) {
+        // we don't want to cancel the job if we already in state UPLOAD_INFO,
+        // which is the final step of backup job. just retry it.
+        // if it encounters some unrecoverable errors, just retry it until timeout.
+        if (!status.ok() && state != BackupJobState.UPLOAD_INFO) {
             cancelInternal();
         }
     }

--- a/fe/src/main/java/org/apache/doris/backup/BackupJob.java
+++ b/fe/src/main/java/org/apache/doris/backup/BackupJob.java
@@ -161,6 +161,7 @@ public class BackupJob extends AbstractJob {
                 request.getSnapshot_files());
         
         snapshotInfos.put(task.getTabletId(), info);
+        taskProgress.remove(task.getTabletId());
         boolean res = unfinishedTaskIds.remove(task.getTabletId());
         taskErrMsg.remove(task.getTabletId());
         LOG.debug("get finished snapshot info: {}, unfinished tasks num: {}, remove result: {}. {}",
@@ -217,6 +218,7 @@ public class BackupJob extends AbstractJob {
             info.setFiles(tabletFileMap.get(tabletId));
         }
 
+        taskProgress.remove(task.getSignature());
         boolean res = unfinishedTaskIds.remove(task.getSignature());
         taskErrMsg.remove(task.getTabletId());
         LOG.debug("get finished upload snapshot task, unfinished tasks num: {}, remove result: {}. {}",
@@ -363,6 +365,7 @@ public class BackupJob extends AbstractJob {
             }
 
             unfinishedTaskIds.clear();
+            taskProgress.clear();
             taskErrMsg.clear();
             // create snapshot tasks
             for (TableRef tblRef : tableRefs) {
@@ -457,6 +460,7 @@ public class BackupJob extends AbstractJob {
     private void uploadSnapshot() {
         // reuse this set to save all unfinished tablets
         unfinishedTaskIds.clear();
+        taskProgress.clear();
         taskErrMsg.clear();
 
         // We classify the snapshot info by backend
@@ -701,9 +705,11 @@ public class BackupJob extends AbstractJob {
         info.add(TimeUtils.longToTimeString(snapshopUploadFinishedTime));
         info.add(TimeUtils.longToTimeString(finishedTime));
         info.add(Joiner.on(", ").join(unfinishedTaskIds));
-        List<String> msgs = taskErrMsg.entrySet().stream().map(n -> "[" + n.getKey() + ": " + n.getValue()
-                + "]").collect(Collectors.toList());
-        info.add(Joiner.on(", ").join(msgs));
+        info.add(Joiner.on(", ").join(taskProgress.entrySet().stream().map(
+                e -> "[" + e.getKey() + ": " + e.getValue().first + "/" + e.getValue().second + "]").collect(
+                        Collectors.toList())));
+        info.add(Joiner.on(", ").join(taskErrMsg.entrySet().stream().map(n -> "[" + n.getKey() + ": " + n.getValue()
+                + "]").collect(Collectors.toList())));
         info.add(status.toString());
         info.add(String.valueOf(timeoutMs / 1000));
         return info;

--- a/fe/src/main/java/org/apache/doris/backup/Repository.java
+++ b/fe/src/main/java/org/apache/doris/backup/Repository.java
@@ -604,7 +604,7 @@ public class Repository implements Writable {
                         info.add(snapshotName);
                         info.add(timestamp);
                         info.add(jobInfo.dbName);
-                        info.add(jobInfo.toString(1));
+                        info.add(jobInfo.getBrief());
                         info.add("OK");
                     } catch (IOException e) {
                         info.add(snapshotName);

--- a/fe/src/main/java/org/apache/doris/backup/Repository.java
+++ b/fe/src/main/java/org/apache/doris/backup/Repository.java
@@ -373,8 +373,14 @@ public class Repository implements Writable {
         String tmpRemotePath = assembleFileNameWithSuffix(remoteFilePath, SUFFIX_TMP_FILE);
         LOG.debug("get md5sum of file: {}. tmp remote path: {}", localFilePath, tmpRemotePath);
 
+        // this may be a retry, so we should first delete remote file
+        Status st = storage.delete(tmpRemotePath);
+        if (!st.ok()) {
+            return st;
+        }
+
         // upload tmp file
-        Status st = storage.upload(localFilePath, tmpRemotePath);
+        st = storage.upload(localFilePath, tmpRemotePath);
         if (!st.ok()) {
             return st;
         }

--- a/fe/src/main/java/org/apache/doris/backup/RestoreJob.java
+++ b/fe/src/main/java/org/apache/doris/backup/RestoreJob.java
@@ -644,9 +644,9 @@ public class RestoreJob extends AbstractJob {
             }
             AgentTaskExecutor.submit(batchTask);
 
-            // estimate timeout, at most 10 seconds
+            // estimate timeout, at most 10 min
             long timeout = Config.tablet_create_timeout_second * 1000L * batchTask.getTaskNum();
-            timeout = Math.min(10 * 1000, timeout);
+            timeout = Math.min(10 * 60 * 1000, timeout);
             boolean ok = false;
             try {
                 LOG.info("begin to send create replica tasks to BE for restore. total {} tasks. timeout: {}",

--- a/fe/src/main/java/org/apache/doris/catalog/Catalog.java
+++ b/fe/src/main/java/org/apache/doris/catalog/Catalog.java
@@ -4486,6 +4486,10 @@ public class Catalog {
         return this.helperNodes.get(0);
     }
 
+    public List<Pair<String, Integer>> getHelperNodes() {
+        return Lists.newArrayList(helperNodes);
+    }
+
     public Pair<String, Integer> getSelfNode() {
         return this.selfNode;
     }

--- a/fe/src/main/java/org/apache/doris/catalog/Column.java
+++ b/fe/src/main/java/org/apache/doris/catalog/Column.java
@@ -17,13 +17,15 @@
 
 package org.apache.doris.catalog;
 
-import com.google.common.base.Strings;
 import org.apache.doris.common.DdlException;
 import org.apache.doris.common.FeMetaVersion;
 import org.apache.doris.common.io.Text;
 import org.apache.doris.common.io.Writable;
 import org.apache.doris.thrift.TColumn;
 import org.apache.doris.thrift.TColumnType;
+
+import com.google.common.base.Strings;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -249,7 +251,7 @@ public class Column implements Writable {
         StringBuilder sb = new StringBuilder();
         sb.append("`").append(name).append("` ");
         sb.append(type.toSql()).append(" ");
-        if (aggregationType != null && !isAggregationTypeImplicit) {
+        if (aggregationType != null && aggregationType != AggregateType.NONE && !isAggregationTypeImplicit) {
             sb.append(aggregationType.name()).append(" ");
         }
         if (!isAllowNull) {

--- a/fe/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/src/main/java/org/apache/doris/common/Config.java
@@ -185,7 +185,6 @@ public class Config extends ConfigBase {
     @ConfField public static int http_port = 8030;
     /*
      * FE thrift server port
-     * 
      */
     @ConfField public static int rpc_port = 9020;
     /*

--- a/fe/src/main/java/org/apache/doris/common/io/DeepCopy.java
+++ b/fe/src/main/java/org/apache/doris/common/io/DeepCopy.java
@@ -17,6 +17,9 @@
 
 package org.apache.doris.common.io;
 
+import org.apache.doris.common.FeConstants;
+import org.apache.doris.meta.MetaContext;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -27,6 +30,10 @@ public class DeepCopy {
     private static final Logger LOG = LogManager.getLogger(DeepCopy.class);
 
     public static boolean copy(Writable orig, Writable copied) {
+        MetaContext metaContext = new MetaContext();
+        metaContext.setMetaVersion(FeConstants.meta_version);
+        metaContext.setThreadLocalInfo();
+
         FastByteArrayOutputStream byteArrayOutputStream = new FastByteArrayOutputStream();
         DataOutputStream out = new DataOutputStream(byteArrayOutputStream);
         try {
@@ -41,6 +48,8 @@ public class DeepCopy {
             e.printStackTrace();
             LOG.warn("failed to copy object.", e);
             return false;
+        } finally {
+            MetaContext.remove();
         }
         return true;
     }

--- a/fe/src/main/java/org/apache/doris/common/util/BrokerUtil.java
+++ b/fe/src/main/java/org/apache/doris/common/util/BrokerUtil.java
@@ -95,4 +95,8 @@ public class BrokerUtil {
         }
     }
 
+    public static String printBroker(String brokerName, TNetworkAddress address) {
+        return brokerName + "[" + address.toString() + "]";
+    }
+
 }

--- a/fe/src/main/java/org/apache/doris/qe/QeService.java
+++ b/fe/src/main/java/org/apache/doris/qe/QeService.java
@@ -18,8 +18,6 @@
 package org.apache.doris.qe;
 
 import org.apache.doris.catalog.Catalog;
-import org.apache.doris.common.Config;
-import org.apache.doris.common.UserException;
 import org.apache.doris.mysql.MysqlServer;
 
 import org.apache.logging.log4j.LogManager;
@@ -48,20 +46,6 @@ public class QeService {
             LOG.error("Help module failed, because:", e);
         }
         this.port = port;
-        mysqlServer = new MysqlServer(port, scheduler);
-    }
-
-    @Deprecated
-    public void setup() throws IOException, UserException {
-        // Set up help module
-        try {
-            HelpModule.getInstance().setUpModule();
-        } catch (Exception e) {
-            LOG.error("Help module failed, because:", e);
-        }
-        // setup MySQL protocol service
-        // TODO(zhaochun): remove settings.
-        ConnectScheduler scheduler = new ConnectScheduler(Config.qe_max_connection);
         mysqlServer = new MysqlServer(port, scheduler);
     }
 

--- a/fe/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
+++ b/fe/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
@@ -79,6 +79,7 @@ import org.apache.doris.thrift.TReportExecStatusResult;
 import org.apache.doris.thrift.TReportRequest;
 import org.apache.doris.thrift.TShowVariableRequest;
 import org.apache.doris.thrift.TShowVariableResult;
+import org.apache.doris.thrift.TSnapshotLoaderReportRequest;
 import org.apache.doris.thrift.TStatus;
 import org.apache.doris.thrift.TStatusCode;
 import org.apache.doris.thrift.TStreamLoadPutRequest;
@@ -90,13 +91,13 @@ import org.apache.doris.thrift.TUpdateMiniEtlTaskStatusRequest;
 import org.apache.doris.transaction.LabelAlreadyExistsException;
 import org.apache.doris.transaction.TabletCommitInfo;
 import org.apache.doris.transaction.TransactionState;
+import org.apache.doris.transaction.TxnCommitAttachment;
 
 import com.google.common.base.Joiner;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 
-import org.apache.doris.transaction.TxnCommitAttachment;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.thrift.TException;
@@ -759,6 +760,15 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         } finally {
             db.readUnlock();
         }
+    }
+
+    @Override
+    public TStatus snapshotLoaderReport(TSnapshotLoaderReportRequest request) throws TException {
+        if (Catalog.getCurrentCatalog().getBackupHandler().report(request.getTask_type(), request.getJob_id(),
+                request.getTask_id(), request.getFinished_num(), request.getTotal_num())) {
+            return new TStatus(TStatusCode.OK);
+        }
+        return new TStatus(TStatusCode.CANCELLED);
     }
 }
 

--- a/fe/src/main/java/org/apache/doris/system/BrokerHbResponse.java
+++ b/fe/src/main/java/org/apache/doris/system/BrokerHbResponse.java
@@ -48,7 +48,7 @@ public class BrokerHbResponse extends HeartbeatResponse implements Writable {
 
     public BrokerHbResponse(String name, String host, int port, String errMsg) {
         super(HeartbeatResponse.Type.BROKER);
-        this.status = HbStatus.OK;
+        this.status = HbStatus.BAD;
         this.name = name;
         this.host = host;
         this.port = port;

--- a/fe/src/test/java/org/apache/doris/backup/RepositoryTest.java
+++ b/fe/src/test/java/org/apache/doris/backup/RepositoryTest.java
@@ -201,6 +201,9 @@ public class RepositoryTest {
 
                 storage.rename(anyString, anyString);
                 result = Status.OK;
+
+                storage.delete(anyString);
+                result = Status.OK;
             }
         };
 

--- a/fe/src/test/java/org/apache/doris/common/GenericPoolTest.java
+++ b/fe/src/test/java/org/apache/doris/common/GenericPoolTest.java
@@ -64,37 +64,36 @@ public class GenericPoolTest {
     static ThriftServer service;
     static String ip = "127.0.0.1";
     static int port = 39401;
-    
+
     static void close() {
         if (service != null) {
             service.stop();
         }
     }
-    
+
     @BeforeClass
     public static void beforeClass() throws IOException {
         try {
             GenericKeyedObjectPoolConfig config = new GenericKeyedObjectPoolConfig();
-            config.setLifo(true);     // set Last In First Out strategy
-            config.setMaxIdlePerKey(2);      // (default 8)
-            config.setMinIdlePerKey(0);      // (default 0)
-            config.setMaxTotalPerKey(2);    // (default 8)
-            config.setMaxTotal(3);          // (default -1) 
-            config.setMaxWaitMillis(500);  
+            config.setLifo(true); // set Last In First Out strategy
+            config.setMaxIdlePerKey(2); // (default 8)
+            config.setMinIdlePerKey(0); // (default 0)
+            config.setMaxTotalPerKey(2); // (default 8)
+            config.setMaxTotal(3); // (default -1)
+            config.setMaxWaitMillis(500);
             // new ClientPool
             backendService = new GenericPool("BackendService", config, 0);
             // new ThriftService
-            TProcessor tprocessor = 
-                    new BackendService.Processor<BackendService.Iface>(
-                            new InternalProcessor());
+            TProcessor tprocessor = new BackendService.Processor<BackendService.Iface>(
+                    new InternalProcessor());
             service = new ThriftServer(port, tprocessor);
-            service.start();            
+            service.start();
         } catch (Exception e) {
             e.printStackTrace();
             close();
         }
     }
-    
+
     @AfterClass
     public static void afterClass() throws IOException {
         close();
@@ -104,18 +103,22 @@ public class GenericPoolTest {
         public InternalProcessor() {
             //
         }
+
         @Override
         public TExecPlanFragmentResult exec_plan_fragment(TExecPlanFragmentParams params) {
             return new TExecPlanFragmentResult();
         }
+
         @Override
         public TCancelPlanFragmentResult cancel_plan_fragment(TCancelPlanFragmentParams params) {
             return new TCancelPlanFragmentResult();
         }
+
         @Override
         public TTransmitDataResult transmit_data(TTransmitDataParams params) {
             return new TTransmitDataResult();
         }
+
         @Override
         public TFetchDataResult fetch_data(TFetchDataParams params) {
             TFetchDataResult result = new TFetchDataResult();
@@ -215,7 +218,7 @@ public class GenericPoolTest {
             return null;
         }
     }
-    
+
     @Test
     public void testNormal() throws Exception {
         TNetworkAddress address = new TNetworkAddress(ip, port);
@@ -234,13 +237,13 @@ public class GenericPoolTest {
         BackendService.Client object1;
         BackendService.Client object2;
         BackendService.Client object3;
-        
+
         // first success
         object1 = backendService.borrowObject(address);
-        
+
         // second success
         object2 = backendService.borrowObject(address);
-        
+
         // third fail, because the max connection is 2
         boolean flag = false;
         try {
@@ -251,19 +254,19 @@ public class GenericPoolTest {
         } catch (Exception e) {
             // can't get here
             Assert.fail();
-        } 
+        }
         Assert.assertTrue(flag);
-        
+
         // fouth success, beacuse we drop the object1
         backendService.returnObject(address, object1);
         object3 = null;
         object3 = backendService.borrowObject(address);
-        Assert.assertTrue(object3 != null);  
-        
+        Assert.assertTrue(object3 != null);
+
         backendService.returnObject(address, object2);
         backendService.returnObject(address, object3);
     }
-    
+
     @Test
     public void testException() throws Exception {
         TNetworkAddress address = new TNetworkAddress(ip, port);

--- a/fe/src/test/java/org/apache/doris/system/HeartbeatMgrTest.java
+++ b/fe/src/test/java/org/apache/doris/system/HeartbeatMgrTest.java
@@ -25,6 +25,7 @@ import org.apache.doris.system.HeartbeatMgr.BrokerHeartbeatHandler;
 import org.apache.doris.system.HeartbeatMgr.FrontendHeartbeatHandler;
 import org.apache.doris.system.HeartbeatResponse.HbStatus;
 import org.apache.doris.thrift.TBrokerOperationStatus;
+import org.apache.doris.thrift.TBrokerOperationStatusCode;
 import org.apache.doris.thrift.TBrokerPingBrokerRequest;
 import org.apache.doris.thrift.TNetworkAddress;
 import org.apache.doris.thrift.TPaloBrokerService;
@@ -86,6 +87,7 @@ public class HeartbeatMgrTest {
     @Test
     public void testBrokerHbHandler(@Mocked TPaloBrokerService.Client client) throws Exception {
         TBrokerOperationStatus status = new TBrokerOperationStatus();
+        status.setStatusCode(TBrokerOperationStatusCode.OK);
 
         new MockUp<GenericPool<TPaloBrokerService.Client>>() {
             @Mock

--- a/fs_brokers/apache_hdfs_broker/src/main/java/org/apache/doris/broker/hdfs/FileSystemManager.java
+++ b/fs_brokers/apache_hdfs_broker/src/main/java/org/apache/doris/broker/hdfs/FileSystemManager.java
@@ -17,17 +17,25 @@
 
 package org.apache.doris.broker.hdfs;
 
-import com.google.common.base.Strings;
 import org.apache.doris.thrift.TBrokerFD;
 import org.apache.doris.thrift.TBrokerFileStatus;
 import org.apache.doris.thrift.TBrokerOperationStatusCode;
+
+import com.google.common.base.Strings;
+
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.*;
+import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.util.StringUtils;
 import org.apache.log4j.Logger;
 
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.net.InetAddress;
@@ -37,7 +45,12 @@ import java.net.UnknownHostException;
 import java.nio.ByteBuffer;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -329,6 +342,10 @@ public class FileSystemManager {
                 }
                 resultFileStatus.add(brokerFileStatus);
             }
+        } catch (FileNotFoundException e) {
+            logger.info("file not found: " + e.getMessage());
+            throw new BrokerException(TBrokerOperationStatusCode.FILE_NOT_FOUND,
+                    e, "file not found");
         } catch (Exception e) {
             logger.error("errors while get file status ", e);
             fileSystem.closeFileSystem();

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -560,6 +560,13 @@ struct TLoadTxnRollbackResult {
     1: required Status.TStatus status
 }
 
+struct TSnapshotLoaderReportRequest {
+    1: required i64 job_id
+    2: required i64 task_id
+    3: required Types.TTaskType task_type
+    4: optional i32 finished_num
+    5: optional i32 total_num
+}
 
 service FrontendService {
     TGetDbsResult getDbNames(1:TGetDbsParams params)
@@ -587,4 +594,5 @@ service FrontendService {
 
     TStreamLoadPutResult streamLoadPut(1: TStreamLoadPutRequest request)
 
+    Status.TStatus snapshotLoaderReport(1: TSnapshotLoaderReportRequest request)
 }


### PR DESCRIPTION
1. Print broker address for debug.
2. Do not letting backup job cancelled if it already in state UPLOAD_INFO.
3. Cancel task on Backends when job is cancelled.
4. Show detail progress of backup and restore job.
5. Make 'show snapshot' result more readable.
6. Change upload and download thread num of backup and restore in Backend to 1.