### PR TITLE
Fix get_tablet_stat data race and base_compaction deletion check bug

### DIFF
--- a/be/src/olap/olap_engine.h
+++ b/be/src/olap/olap_engine.h
@@ -556,6 +556,7 @@ private:
     // cache to save tablets' statistics, such as data size and row
     // TODO(cmy): for now, this is a naive implementation
     std::map<int64_t, TTabletStat> _tablet_stat_cache;
+    std::mutex _tablet_stat_mutex;
     // last update time of tablet stat cache
     int64_t _tablet_stat_cache_update_time_ms;
 


### PR DESCRIPTION
1. It is wrong to use _tablet_map_lock to protect critical region in get_tablet_stat function.
   Add a _tablet_stat_mutex to protect critical region.
2. When base_compaction finished, it checks where there is version missed in tablet.
   If answer is yes, BE will be cored dump. Now check tablet's integrity in advance.