### PR TITLE
Split tasks from storage engine

### DIFF
--- a/be/src/agent/agent_server.cpp
+++ b/be/src/agent/agent_server.cpp
@@ -35,6 +35,7 @@
 #include "gen_cpp/MasterService_types.h"
 #include "gen_cpp/Status_types.h"
 #include "olap/utils.h"
+#include "olap/snapshot_manager.h"
 #include "runtime/exec_env.h"
 #include "runtime/etl_job_mgr.h"
 #include "util/debug_util.h"
@@ -433,7 +434,7 @@ void AgentServer::make_snapshot(TAgentResult& return_value,
 
     string snapshot_path;
     OLAPStatus make_snapshot_status =
-            _exec_env->olap_engine()->make_snapshot(snapshot_request, &snapshot_path);
+            SnapshotManager::instance()->make_snapshot(snapshot_request, &snapshot_path);
     if (make_snapshot_status != OLAP_SUCCESS) {
         status_code = TStatusCode::RUNTIME_ERROR;
         OLAP_LOG_WARNING("make_snapshot failed. tablet_id: %ld, schema_hash: %ld, status: %d",
@@ -460,7 +461,7 @@ void AgentServer::release_snapshot(TAgentResult& return_value, const std::string
     TStatusCode::type status_code = TStatusCode::OK;
 
     OLAPStatus release_snapshot_status =
-            _exec_env->olap_engine()->release_snapshot(snapshot_path);
+            SnapshotManager::instance()->release_snapshot(snapshot_path);
     if (release_snapshot_status != OLAP_SUCCESS) {
         status_code = TStatusCode::RUNTIME_ERROR;
         LOG(WARNING) << "release_snapshot failed. snapshot_path: " << snapshot_path << ", status: " << release_snapshot_status;

--- a/be/src/agent/pusher.cpp
+++ b/be/src/agent/pusher.cpp
@@ -30,9 +30,13 @@
 #include "gen_cpp/AgentService_types.h"
 #include "olap/olap_common.h"
 #include "olap/olap_define.h"
+#include "olap/push_handler.h"
 #include "olap/storage_engine.h"
 #include "olap/tablet.h"
+#include "util/doris_metrics.h"
+#include "util/pretty_printer.h"
 
+using apache::thrift::ThriftDebugString;
 using std::list;
 using std::string;
 using std::vector;
@@ -58,7 +62,7 @@ AgentStatus Pusher::init() {
 
     // Check replica exist
     TabletSharedPtr tablet;
-    tablet = _engine->get_tablet(
+    tablet = TabletManager::instance()->get_tablet(
             _push_req.tablet_id,
             _push_req.schema_hash);
     if (tablet.get() == NULL) {
@@ -252,7 +256,7 @@ AgentStatus Pusher::process(vector<TTabletInfo>* tablet_infos) {
     if (status == DORIS_SUCCESS) {
         // Load delta file
         time_t push_begin = time(NULL);
-        OLAPStatus push_status = _engine->push(_push_req, tablet_infos);
+        OLAPStatus push_status = _push(_push_req, tablet_infos);
         time_t push_finish = time(NULL);
         LOG(INFO) << "Push finish, cost time: " << (push_finish - push_begin);
         if (push_status == OLAPStatus::OLAP_ERR_PUSH_TRANSACTION_ALREADY_EXIST) {
@@ -273,4 +277,102 @@ AgentStatus Pusher::process(vector<TTabletInfo>* tablet_infos) {
 
     return status;
 }
+
+OLAPStatus Pusher::_push(const TPushReq& request,
+                        vector<TTabletInfo>* tablet_info_vec) {
+    OLAPStatus res = OLAP_SUCCESS;
+    LOG(INFO) << "begin to process push. tablet_id=" << request.tablet_id
+              << ", version=" << request.version;
+
+    if (tablet_info_vec == NULL) {
+        OLAP_LOG_WARNING("invalid output parameter which is null pointer.");
+        DorisMetrics::push_requests_fail_total.increment(1);
+        return OLAP_ERR_CE_CMD_PARAMS_ERROR;
+    }
+
+    TabletSharedPtr tablet = TabletManager::instance()->get_tablet(
+            request.tablet_id, request.schema_hash);
+    if (NULL == tablet.get()) {
+        OLAP_LOG_WARNING("false to find tablet. [tablet=%ld schema_hash=%d]",
+                         request.tablet_id, request.schema_hash);
+        DorisMetrics::push_requests_fail_total.increment(1);
+        return OLAP_ERR_TABLE_NOT_FOUND;
+    }
+
+    PushType type = PUSH_NORMAL;
+    if (request.push_type == TPushType::LOAD_DELETE) {
+        type = PUSH_FOR_LOAD_DELETE;
+    }
+
+    int64_t duration_ns = 0;
+    PushHandler push_handler;
+    if (request.__isset.transaction_id) {
+        {
+            SCOPED_RAW_TIMER(&duration_ns);
+            res = push_handler.process_realtime_push(tablet, request, type, tablet_info_vec);
+        }
+    } else {
+        {
+            SCOPED_RAW_TIMER(&duration_ns);
+            res = OLAP_ERR_PUSH_BATCH_PROCESS_REMOVED;
+        }
+    }
+
+    if (res != OLAP_SUCCESS) {
+        LOG(WARNING) << "fail to push delta, tablet=" << tablet->full_name().c_str()
+            << ",cost=" << PrettyPrinter::print(duration_ns, TUnit::TIME_NS);
+        DorisMetrics::push_requests_fail_total.increment(1);
+    } else {
+        LOG(INFO) << "success to push delta, tablet=" << tablet->full_name().c_str()
+            << ",cost=" << PrettyPrinter::print(duration_ns, TUnit::TIME_NS);
+        DorisMetrics::push_requests_success_total.increment(1);
+        DorisMetrics::push_request_duration_us.increment(duration_ns / 1000);
+        DorisMetrics::push_request_write_bytes.increment(push_handler.write_bytes());
+        DorisMetrics::push_request_write_rows.increment(push_handler.write_rows());
+    }
+    return res;
+}
+
+
+OLAPStatus Pusher::delete_data(
+        const TPushReq& request,
+        vector<TTabletInfo>* tablet_info_vec) {
+    LOG(INFO) << "begin to process delete data. request=" << ThriftDebugString(request);
+    DorisMetrics::delete_requests_total.increment(1);
+
+    OLAPStatus res = OLAP_SUCCESS;
+
+    if (tablet_info_vec == NULL) {
+        OLAP_LOG_WARNING("invalid output parameter which is null pointer.");
+        return OLAP_ERR_CE_CMD_PARAMS_ERROR;
+    }
+
+    // 1. Get all tablets with same tablet_id
+    TabletSharedPtr tablet = TabletManager::instance()->get_tablet(request.tablet_id, request.schema_hash);
+    if (tablet.get() == NULL) {
+        OLAP_LOG_WARNING("can't find tablet. [tablet=%ld schema_hash=%d]",
+                         request.tablet_id, request.schema_hash);
+        return OLAP_ERR_TABLE_NOT_FOUND;
+    }
+
+    // 2. Process delete data by push interface
+    PushHandler push_handler;
+    if (request.__isset.transaction_id) {
+        res = push_handler.process_realtime_push(tablet, request, PUSH_FOR_DELETE, tablet_info_vec);
+    } else {
+        res = OLAP_ERR_PUSH_BATCH_PROCESS_REMOVED;
+    }
+
+    if (res != OLAP_SUCCESS) {
+        OLAP_LOG_WARNING("fail to push empty version for delete data. "
+                         "[res=%d tablet='%s']",
+                         res, tablet->full_name().c_str());
+        DorisMetrics::delete_requests_failed.increment(1);
+        return res;
+    }
+
+    LOG(INFO) << "finish to process delete data. res=" << res;
+    return res;
+}
+
 } // namespace doris

--- a/be/src/agent/pusher.h
+++ b/be/src/agent/pusher.h
@@ -47,9 +47,23 @@ public:
     // * tablet_infos: The info of pushed tablet after push data
     virtual AgentStatus process(std::vector<TTabletInfo>* tablet_infos);
 
+    // Delete data of specified tablet according to delete conditions,
+    // once delete_data command submit success, deleted data is not visible,
+    // but not actually deleted util delay_delete_time run out.
+    //
+    // @param [in] request specify tablet and delete conditions
+    // @param [out] tablet_info_vec return tablet lastest status, which
+    //              include version info, row count, data size, etc
+    // @return OLAP_SUCCESS if submit delete_data success
+    virtual OLAPStatus delete_data(
+            const TPushReq& request,
+            std::vector<TTabletInfo>* tablet_info_vec);
+
 private:
     AgentStatus _get_tmp_file_dir(const std::string& root_path, std::string* local_path);
     AgentStatus _download_file();
+    OLAPStatus _push(const TPushReq& request,
+                    std::vector<TTabletInfo>* tablet_info_vec);
     void _get_file_name_from_path(const std::string& file_path, std::string* file_name);
     
     bool _is_init = false;

--- a/be/src/agent/task_worker_pool.h
+++ b/be/src/agent/task_worker_pool.h
@@ -131,10 +131,6 @@ private:
             const TTaskType::type task_type,
             TFinishTaskRequest* finish_task_request);
 
-    AlterTableStatus _show_alter_tablet_status(
-            const TTabletId tablet_id,
-            const TSchemaHash schema_hash);
-
     AgentStatus _drop_tablet(const TDropTabletReq& drop_tablet_req);
 
     AgentStatus _get_tablet_info(

--- a/be/src/exec/olap_meta_reader.cpp
+++ b/be/src/exec/olap_meta_reader.cpp
@@ -43,7 +43,7 @@ Status EngineMetaReader::get_hints(
         RuntimeProfile* profile) {
     auto tablet_id = scan_range->scan_range().tablet_id;
     int32_t schema_hash = strtoul(scan_range->scan_range().schema_hash.c_str(), NULL, 10);
-    TabletSharedPtr table = StorageEngine::get_instance()->get_tablet(
+    TabletSharedPtr table = TabletManager::instance()->get_tablet(
         tablet_id, schema_hash);
     if (table.get() == NULL) {
         LOG(WARNING) << "tablet does not exist. tablet_id=" << tablet_id << ", schema_hash="

--- a/be/src/exec/olap_scanner.cpp
+++ b/be/src/exec/olap_scanner.cpp
@@ -79,7 +79,7 @@ Status OlapScanner::_prepare(
     VersionHash version_hash =
         strtoul(scan_range->scan_range().version_hash.c_str(), nullptr, 10);
     {
-        _tablet = StorageEngine::get_instance()->get_tablet(tablet_id, schema_hash);
+        _tablet = TabletManager::instance()->get_tablet(tablet_id, schema_hash);
         if (_tablet.get() == nullptr) {
             OLAP_LOG_WARNING("tablet does not exist. [tablet_id=%ld schema_hash=%d]",
                              tablet_id, schema_hash);

--- a/be/src/http/action/checksum_action.cpp
+++ b/be/src/http/action/checksum_action.cpp
@@ -31,6 +31,7 @@
 #include "http/http_status.h"
 #include "olap/olap_define.h"
 #include "olap/storage_engine.h"
+#include "olap/task/engine_checksum_task.h"
 #include "runtime/exec_env.h"
 
 namespace doris {
@@ -127,8 +128,8 @@ int64_t ChecksumAction::do_checksum(int64_t tablet_id, int64_t version, int64_t 
 
     OLAPStatus res = OLAPStatus::OLAP_SUCCESS;
     uint32_t checksum;
-    res = _exec_env->olap_engine()->compute_checksum(
-            tablet_id, schema_hash, version, version_hash, &checksum);
+    EngineChecksumTask engine_task(tablet_id, schema_hash, version, version_hash, &checksum);
+    res = engine_task.execute();
     if (res != OLAPStatus::OLAP_SUCCESS) {
         LOG(WARNING) << "checksum failed. status: " << res
                      << ", signature: " << tablet_id;

--- a/be/src/http/action/meta_action.cpp
+++ b/be/src/http/action/meta_action.cpp
@@ -49,7 +49,7 @@ Status MetaAction::_handle_header(HttpRequest *req, std::string* json_header) {
     }
     uint64_t tablet_id = std::stoull(req_tablet_id);
     uint32_t schema_hash = std::stoul(req_schema_hash);
-    TabletSharedPtr tablet = StorageEngine::get_instance()->get_tablet(tablet_id, schema_hash);
+    TabletSharedPtr tablet = TabletManager::instance()->get_tablet(tablet_id, schema_hash);
     if (tablet == nullptr) {
         LOG(WARNING) << "no tablet for tablet_id:" << tablet_id << " schema hash:" << schema_hash;
         return Status("no tablet exist");

--- a/be/src/http/action/restore_tablet_action.cpp
+++ b/be/src/http/action/restore_tablet_action.cpp
@@ -85,7 +85,7 @@ Status RestoreTabletAction::_handle(HttpRequest *req) {
     LOG(INFO) << "get restore tablet action request: " << tablet_id << "-" << schema_hash;
 
     TabletSharedPtr tablet =
-            StorageEngine::get_instance()->get_tablet(tablet_id, schema_hash);
+            TabletManager::instance()->get_tablet(tablet_id, schema_hash);
     if (tablet.get() != nullptr) {
         LOG(WARNING) << "find tablet. tablet_id=" << tablet_id << " schema_hash=" << schema_hash;
         return Status("tablet already exists, can not restore.");

--- a/be/src/http/action/snapshot_action.cpp
+++ b/be/src/http/action/snapshot_action.cpp
@@ -33,6 +33,7 @@
 #include "runtime/exec_env.h"
 #include "olap/olap_define.h"
 #include "olap/storage_engine.h"
+#include "olap/snapshot_manager.h"
 
 namespace doris {
 
@@ -104,7 +105,7 @@ int64_t SnapshotAction::make_snapshot(int64_t tablet_id, int32_t schema_hash,
     request.schema_hash = schema_hash;
 
     OLAPStatus res = OLAPStatus::OLAP_SUCCESS;
-    res = _exec_env->olap_engine()->make_snapshot(request, snapshot_path);
+    res = SnapshotManager::instance()->make_snapshot(request, snapshot_path);
     if (res != OLAPStatus::OLAP_SUCCESS) {
         LOG(WARNING) << "make snapshot failed. status: " << res
                      << ", signature: " << tablet_id;

--- a/be/src/olap/CMakeLists.txt
+++ b/be/src/olap/CMakeLists.txt
@@ -49,7 +49,6 @@ add_library(Olap STATIC
     olap_index.cpp
     olap_meta.cpp
     olap_server.cpp
-    olap_snapshot.cpp
     options.cpp
     out_stream.cpp
     push_handler.cpp
@@ -60,6 +59,7 @@ add_library(Olap STATIC
     serialize.cpp
     storage_engine.cpp
     data_dir.cpp
+    snapshot_manager.cpp
     stream_index_common.cpp
     stream_index_reader.cpp
     stream_index_writer.cpp
@@ -72,4 +72,10 @@ add_library(Olap STATIC
     types.cpp 
     utils.cpp
     wrapper_field.cpp
+    rowset/rowset_meta_manager.cpp
+    rowset/alpha_rowset.cpp
+    rowset/alpha_rowset_reader.cpp
+    rowset/alpha_rowset_builder.cpp
+    rowset/alpha_rowset_meta.cpp
+    task/engine_schema_change_task.cpp
 )

--- a/be/src/olap/delta_writer.cpp
+++ b/be/src/olap/delta_writer.cpp
@@ -61,7 +61,7 @@ void DeltaWriter::_garbage_collection() {
 }
 
 OLAPStatus DeltaWriter::init() {
-    _tablet = StorageEngine::get_instance()->get_tablet(_req.tablet_id, _req.schema_hash);
+    _tablet = TabletManager::instance()->get_tablet(_req.tablet_id, _req.schema_hash);
     if (_tablet == nullptr) {
         LOG(WARNING) << "tablet_id: " << _req.tablet_id << ", "
                      << "schema_hash: " << _req.schema_hash << " not found";
@@ -70,9 +70,9 @@ OLAPStatus DeltaWriter::init() {
 
     {
         MutexLock push_lock(_tablet->get_push_lock());
-        RETURN_NOT_OK(StorageEngine::get_instance()->add_transaction(
+        RETURN_NOT_OK(TxnManager::instance()->add_txn(
                             _req.partition_id, _req.transaction_id,
-                            _req.tablet_id, _req.schema_hash, _req.load_id));
+                            _req.tablet_id, _req.schema_hash, _req.load_id, NULL));
         //_segment_group_id = _tablet->current_pending_segment_group_id(_req.transaction_id);
         if (_req.need_gen_rollup) {
             TTabletId new_tablet_id;
@@ -88,10 +88,10 @@ OLAPStatus DeltaWriter::init() {
                           << "new_tablet_id: " << new_tablet_id << ", "
                           << "new_schema_hash: " << new_schema_hash << ", "
                           << "transaction_id: " << _req.transaction_id;
-                _new_tablet = StorageEngine::get_instance()->get_tablet(new_tablet_id, new_schema_hash);
-                StorageEngine::get_instance()->add_transaction(
+                _new_tablet = TabletManager::instance()->get_tablet(new_tablet_id, new_schema_hash);
+                TxnManager::instance()->add_txn(
                                     _req.partition_id, _req.transaction_id,
-                                    new_tablet_id, new_schema_hash, _req.load_id);
+                                    new_tablet_id, new_schema_hash, _req.load_id, NULL);
             }
         }
 

--- a/be/src/olap/olap_define.h
+++ b/be/src/olap/olap_define.h
@@ -236,6 +236,7 @@ enum OLAPStatus {
     OLAP_ERR_PUSH_TRANSACTION_ALREADY_EXIST = -911,
     // only support realtime push api, batch process is deprecated and is removed
     OLAP_ERR_PUSH_BATCH_PROCESS_REMOVED = -912, 
+    OLAP_ERR_PUSH_COMMIT_ROWSET = -913, 
 
     // SegmentGroup
     // [-1000, -1100)
@@ -348,6 +349,7 @@ static const std::string DEFAULT_COLUMN_FAMILY = "default";
 static const std::string DORIS_COLUMN_FAMILY = "doris";
 static const std::string META_COLUMN_FAMILY = "meta";
 static const std::string IS_HEADER_CONVERTED = "is_header_converted";
+static const std::string END_ROWSET_ID = "end_rowset_id";
 static const std::string CONVERTED_FLAG = "true";
 const std::string TABLET_ID_KEY = "tablet_id";
 const std::string TABLET_SCHEMA_HASH_KEY = "schema_hash";

--- a/be/src/olap/push_handler.cpp
+++ b/be/src/olap/push_handler.cpp
@@ -64,9 +64,9 @@ OLAPStatus PushHandler::process_realtime_push(
     PUniqueId load_id;
     load_id.set_hi(0);
     load_id.set_lo(0);
-    res = StorageEngine::get_instance()->add_transaction(
+    res = TxnManager::instance()->add_txn(
         request.partition_id, request.transaction_id,
-        tablet->tablet_id(), tablet->schema_hash(), load_id);
+        tablet->tablet_id(), tablet->schema_hash(), load_id, NULL);
 
     // if transaction exists, exit
     if (res == OLAP_ERR_PUSH_TRANSACTION_ALREADY_EXIST) {
@@ -101,7 +101,7 @@ OLAPStatus PushHandler::process_realtime_push(
                       << ", related_tablet_id=" << related_tablet_id
                       << ", related_schema_hash=" << related_schema_hash
                       << ", transaction_id=" << request.transaction_id;
-            TabletSharedPtr related_tablet = StorageEngine::get_instance()->get_tablet(
+            TabletSharedPtr related_tablet = TabletManager::instance()->get_tablet(
                 related_tablet_id, related_schema_hash);
 
             // if related tablet not exists, only push current tablet
@@ -123,9 +123,9 @@ OLAPStatus PushHandler::process_realtime_push(
                 PUniqueId load_id;
                 load_id.set_hi(0);
                 load_id.set_lo(0);
-                res = StorageEngine::get_instance()->add_transaction(
+                res = TxnManager::instance()->add_txn(
                     request.partition_id, request.transaction_id,
-                    related_tablet->tablet_id(), related_tablet->schema_hash(), load_id);
+                    related_tablet->tablet_id(), related_tablet->schema_hash(), load_id, NULL);
 
                 // if related tablet's transaction exists, only push current tablet
                 if (res == OLAP_ERR_PUSH_TRANSACTION_ALREADY_EXIST) {
@@ -269,7 +269,7 @@ void PushHandler::_get_tablet_infos(
         TTabletInfo tablet_info;
         tablet_info.tablet_id = tablet_var.tablet->tablet_id();
         tablet_info.schema_hash = tablet_var.tablet->schema_hash();
-        StorageEngine::get_instance()->report_tablet_info(&tablet_info);
+        TabletManager::instance()->report_tablet_info(&tablet_info);
         tablet_info_vec->push_back(tablet_info);
     }
 }

--- a/be/src/olap/rowset/rowset_id_generator.cpp
+++ b/be/src/olap/rowset/rowset_id_generator.cpp
@@ -1,0 +1,79 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+#include <string>
+#include <fstream>
+
+#include "olap/rowset/rowset_id_generator.h"
+
+namespace doris {
+
+RowsetIdGenerator* RowsetIdGenerator::_s_instance = nullptr;
+std::mutex RowsetIdGenerator::_mlock;
+
+RowsetIdGenerator RowsetIdGenerator::instance() {
+    if (_s_instance == nullptr) {
+        std::lock_guard<std::mutex> lock(_mlock);
+        if (_s_instance == nullptr) {
+            _s_instance = new RowsetIdGenerator();
+        }
+    }
+    return _s_instance;
+}
+
+OLAPStatus RowsetIdGenerator::get_next_id(DataDir* dir, RowsetId& gen_rowset_id) {
+    WriteLock wrlock(&_ids_lock);
+    // if could not find the dir in map, then load the start id from meta
+    RowsetId batch_end_id = 10000;
+    OLAPStatus s = OK;
+    if (_dir_ids.find(dir) == _dir_ids.end()) {
+        // could not find dir in map, it means this dir is not loaded
+        std::string value;
+        std::string key = END_ROWSET_ID;
+        OlapMeta* meta = dir->get_meta();
+        OLAPStatus s = meta->get(DEFAULT_COLUMN_FAMILY_INDEX, key, value);
+        if (s != OLAP_SUCCESS) {
+            if (s == OLAP_ERR_META_KEY_NOT_FOUND) {
+                s = meta->put(DEFAULT_COLUMN_FAMILY_INDEX, key, std::to_string(batch_end_id));
+                if (s != OLAP_SUCCESS) {
+                    return s;
+                }
+                _dir_ids[dir] = std::pair<RowsetId, RowsetId>(batch_end_id, batch_end_id);
+            } else { 
+                return s;
+            }
+        } else {
+            batch_end_id = std::stol(value);
+            _dir_end_ids[dir] = std::pair<RowsetId, RowsetId>(batch_end_id, batch_end_id);
+        }
+    }
+
+    std::pair<RowsetId, RowsetId>& start_end_id = _dir_ids[dir];
+    if (start_end_id.first + 1 >= start_end_id.second) {
+        start_end_id.second = start_end_id.second + _batch_interval;
+        s = meta->put(DEFAULT_COLUMN_FAMILY_INDEX, key, std::to_string(start_end_id.second));
+        if (s != OLAP_SUCCESS) {
+            return s;
+        }
+    } 
+
+    start_end_id.first = start_end_id.first + 1;
+    gen_rowset_id = start_end_id.first;
+
+    return OLAP_SUCCESS;
+} // get_next_id
+
+} // doris

--- a/be/src/olap/rowset/rowset_id_generator.h
+++ b/be/src/olap/rowset/rowset_id_generator.h
@@ -1,0 +1,49 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#ifndef DORIS_BE_SRC_OLAP_ROWSET_ROWSET_ID_GENERATOR_H
+#define DORIS_BE_SRC_OLAP_ROWSET_ROWSET_ID_GENERATOR_H
+
+#include "olap/data_dir.h"
+#include "olap/olap_define.h"
+
+namespace doris {
+
+class RowsetIdGenerator {
+
+public:    
+    ~RowsetIdGenerator() {}
+
+    static RowsetIdGenerator* instance();
+
+    // generator a id according to data dir
+    // rowsetid is not globally unique, it is dir level
+    // it saves the batch end id into meta env
+    OLAPStatus get_next_id(DataDir* dir, RowsetId& rowset_id); 
+
+private:
+    RowsetIdGenerator(){}
+    RWMutex _ids_lock;
+    RowsetId _batch_interval = 10000;
+    // data dir -> (cur_id, batch_end_id)
+    std::map<DataDir*, std::pair<RowsetId,RowsetId>> _dir_ids; 
+    static RowsetIdGenerator* _s_instance;
+    static std::mutex _mlock;
+} // RowsetIdGenerator
+
+} // namespace doris
+#endif // DORIS_BE_SRC_OLAP_ROWSET_ROWSET_ID_GENERATOR_H

--- a/be/src/olap/rowset/rowset_meta.h
+++ b/be/src/olap/rowset/rowset_meta.h
@@ -32,6 +32,7 @@ namespace doris {
 
 class RowsetMeta;
 using RowsetMetaSharedPtr = std::shared_ptr<RowsetMeta>;
+typedef uint64_t RowsetId;
 
 class RowsetMeta {
 public:

--- a/be/src/olap/schema_change.cpp
+++ b/be/src/olap/schema_change.cpp
@@ -1232,48 +1232,7 @@ EXTERNAL_SORTING_ERR:
     return false;
 }
 
-OLAPStatus SchemaChangeHandler::clear_schema_change_single_info(
-        TTabletId tablet_id,
-        SchemaHash schema_hash,
-        AlterTabletType* alter_tablet_type,
-        bool only_one,
-        bool check_only) {
-    TabletSharedPtr tablet = StorageEngine::get_instance()->get_tablet(tablet_id, schema_hash);
-    return clear_schema_change_single_info(tablet, alter_tablet_type, only_one, check_only);
-}
-
-OLAPStatus SchemaChangeHandler::clear_schema_change_single_info(
-        TabletSharedPtr tablet,
-        AlterTabletType* type,
-        bool only_one,
-        bool check_only) {
-    OLAPStatus res = OLAP_SUCCESS;
-
-    if (NULL == tablet.get()) {
-        return res;
-    }
-
-    vector<Version> versions_to_be_changed;
-    if (tablet->get_schema_change_request(NULL,
-                                              NULL,
-                                              &versions_to_be_changed,
-                                              NULL)) {
-        if (versions_to_be_changed.size() != 0) {
-            OLAP_LOG_WARNING("schema change is not allowed now, "
-                             "until previous schema change is done. [tablet='%s']",
-                             tablet->full_name().c_str());
-            return OLAP_ERR_PREVIOUS_SCHEMA_CHANGE_NOT_FINISHED;
-        }
-    }
-
-    if (!check_only) {
-        VLOG(3) << "broke old schema change chain";
-        tablet->clear_schema_change_request();
-    }
-
-    return res;
-}
-
+// MOVE TO TABLET and then add rdlock to schema change request
 OLAPStatus SchemaChangeHandler::_check_and_clear_schema_change_info(
         TabletSharedPtr tablet,
         const TAlterTabletReq& request) {
@@ -1312,8 +1271,7 @@ OLAPStatus SchemaChangeHandler::_check_and_clear_schema_change_info(
     // clear schema change info of current tablet
     {
         WriteLock wrlock(tablet->get_header_lock_ptr());
-        res = clear_schema_change_single_info(
-                tablet->tablet_id(), tablet->schema_hash(), &type, true, false);
+        res = tablet->clear_schema_change_info(&type, true, false);
         if (res != OLAP_SUCCESS) {
             OLAP_LOG_WARNING("fail to clear schema change info. [res=%d full_name='%s']",
                              res, tablet->full_name().c_str());
@@ -1329,7 +1287,7 @@ OLAPStatus SchemaChangeHandler::_check_and_clear_schema_change_info(
     }
 
     // clear schema change info of related tablet
-    TabletSharedPtr related_tablet = StorageEngine::get_instance()->get_tablet(
+    TabletSharedPtr related_tablet = TabletManager::instance()->get_tablet(
             tablet_id, schema_hash);
     if (related_tablet.get() == NULL) {
         OLAP_LOG_WARNING("get null tablet! [tablet_id=%ld schema_hash=%d]",
@@ -1339,8 +1297,7 @@ OLAPStatus SchemaChangeHandler::_check_and_clear_schema_change_info(
 
     {
         WriteLock wrlock(related_tablet->get_header_lock_ptr());
-        res = clear_schema_change_single_info(
-                tablet_id, schema_hash, &type, true, false);
+        res = related_tablet->clear_schema_change_info(&type, true, false);
         if (res != OLAP_SUCCESS) {
             OLAP_LOG_WARNING("fail to clear schema change info. [res=%d full_name='%s']",
                              res, related_tablet->full_name().c_str());
@@ -1365,19 +1322,19 @@ OLAPStatus SchemaChangeHandler::process_alter_tablet(
     LOG(INFO) << "begin to validate alter tablet request.";
 
     // 1. Lock schema_change_lock util schema change info is stored in tablet header
-    if (!StorageEngine::get_instance()->try_schema_change_lock(request.base_tablet_id)) {
+    if (!TabletManager::instance()->try_schema_change_lock(request.base_tablet_id)) {
         OLAP_LOG_WARNING("failed to obtain schema change lock. [res=%d tablet=%ld]",
                          res, request.base_tablet_id);
         return OLAP_ERR_TRY_LOCK_FAILED;
     }
 
     // 2. Get base tablet
-    TabletSharedPtr ref_tablet = StorageEngine::get_instance()->get_tablet(
+    TabletSharedPtr ref_tablet = TabletManager::instance()->get_tablet(
             request.base_tablet_id, request.base_schema_hash);
     if (ref_tablet.get() == NULL) {
         OLAP_LOG_WARNING("fail to find base tablet. [base_tablet=%ld base_schema_hash=%d]",
                          request.base_tablet_id, request.base_schema_hash);
-        StorageEngine::get_instance()->release_schema_change_lock(request.base_tablet_id);
+        TabletManager::instance()->release_schema_change_lock(request.base_tablet_id);
         return OLAP_ERR_TABLE_NOT_FOUND;
     }
 
@@ -1387,12 +1344,12 @@ OLAPStatus SchemaChangeHandler::process_alter_tablet(
     if (res != OLAP_SUCCESS) {
         OLAP_LOG_WARNING("failed to check and clear schema change info. [tablet='%s']",
                          ref_tablet->full_name().c_str());
-        StorageEngine::get_instance()->release_schema_change_lock(request.base_tablet_id);
+        TabletManager::instance()->release_schema_change_lock(request.base_tablet_id);
         return res;
     }
 
     // 4. return failed if new tablet already exist in StorageEngine.
-    TabletSharedPtr new_tablet = StorageEngine::get_instance()->get_tablet(
+    TabletSharedPtr new_tablet = TabletManager::instance()->get_tablet(
             request.new_tablet_req.tablet_id, request.new_tablet_req.tablet_schema.schema_hash);
     if (new_tablet.get() != NULL) {
         res = OLAP_SUCCESS;
@@ -1400,7 +1357,7 @@ OLAPStatus SchemaChangeHandler::process_alter_tablet(
         res = _do_alter_tablet(type, ref_tablet, request);
     }
 
-    StorageEngine::get_instance()->release_schema_change_lock(request.base_tablet_id);
+    TabletManager::instance()->release_schema_change_lock(request.base_tablet_id);
 
     return res;
 }
@@ -1440,7 +1397,7 @@ OLAPStatus SchemaChangeHandler::_do_alter_tablet(
                          "[base=%s new=%s res=%d]", ref_tablet->full_name().c_str(),
                          new_tablet->full_name().c_str(), res);
         ref_tablet->release_push_lock();
-        StorageEngine::get_instance()->drop_tablet(
+        TabletManager::instance()->drop_tablet(
                 new_tablet->tablet_id(), new_tablet->schema_hash());
         return res;
     }
@@ -1448,8 +1405,7 @@ OLAPStatus SchemaChangeHandler::_do_alter_tablet(
     // get current transactions
     int64_t partition_id;
     std::set<int64_t> transaction_ids;
-    StorageEngine::get_instance()->
-        get_transactions_by_tablet(ref_tablet, &partition_id, &transaction_ids);
+    TxnManager::instance()->get_tablet_related_txns(ref_tablet, &partition_id, &transaction_ids);
     ref_tablet->release_push_lock();
 
     // wait transactions to publish version
@@ -1467,7 +1423,7 @@ OLAPStatus SchemaChangeHandler::_do_alter_tablet(
         // erase finished transaction
         vector<int64_t> finished_transactions;
         for (int64_t transaction_id : transaction_ids) {
-            if (!StorageEngine::get_instance()->has_transaction(
+            if (!TxnManager::instance()->has_txn(
                 partition_id, transaction_id,
                 ref_tablet->tablet_id(), ref_tablet->schema_hash())) {
                 finished_transactions.push_back(transaction_id);
@@ -1532,7 +1488,7 @@ OLAPStatus SchemaChangeHandler::_do_alter_tablet(
             new_tablet->release_header_lock();
             ref_tablet->release_header_lock();
             ref_tablet->release_push_lock();
-            StorageEngine::get_instance()->drop_tablet(
+            TabletManager::instance()->drop_tablet(
                     new_tablet->tablet_id(), new_tablet->schema_hash());
             OLAP_LOG_WARNING("fail to remove data from new tablet when schema_change. "
                              "[new_tablet=%s]", new_tablet->full_name().c_str());
@@ -1635,7 +1591,7 @@ OLAPStatus SchemaChangeHandler::_do_alter_tablet(
                  << "request=" << sc_params.debug_message;
     } else {
         // Delete tablet when submit alter tablet failed.
-        StorageEngine::get_instance()->drop_tablet(
+        TabletManager::instance()->drop_tablet(
                 new_tablet->tablet_id(), new_tablet->schema_hash());
     }
 
@@ -1685,7 +1641,7 @@ OLAPStatus SchemaChangeHandler::_create_new_tablet(
         }
 
         // 3. Add tablet to StorageEngine will make it visiable to user
-        res = StorageEngine::get_instance()->get_tablet_mgr()->add_tablet(
+        res = TabletManager::instance()->add_tablet(
                 request.tablet_id,
                 request.tablet_schema.schema_hash,
                 new_tablet, 
@@ -1710,7 +1666,7 @@ OLAPStatus SchemaChangeHandler::_create_new_tablet(
         }
 
         TabletSharedPtr tablet;
-        tablet = StorageEngine::get_instance()->get_tablet(
+        tablet = TabletManager::instance()->get_tablet(
                 request.tablet_id, request.tablet_schema.schema_hash);
         if (tablet.get() == NULL) {
             OLAP_LOG_WARNING("failed to get tablet from StorageEngine. [tablet=%ld schema_hash=%d]",
@@ -1727,7 +1683,7 @@ OLAPStatus SchemaChangeHandler::_create_new_tablet(
 
     if (res != OLAP_SUCCESS) {
         if (is_tablet_added) {
-            res = StorageEngine::get_instance()->drop_tablet(
+            res = TabletManager::instance()->drop_tablet(
                     request.tablet_id, request.tablet_schema.schema_hash);
             if (res != OLAP_SUCCESS) {
                 LOG(WARNING) << "fail to drop tablet when create tablet failed. res=" << res
@@ -1930,7 +1886,7 @@ OLAPStatus SchemaChangeHandler::_save_schema_change_info(
 
     // check new tablet exists,
     // prevent to set base's status after new's dropping (clear base's status)
-    if (StorageEngine::get_instance()->get_tablet(
+    if (TabletManager::instance()->get_tablet(
             new_tablet->tablet_id(), new_tablet->schema_hash()).get() == NULL) {
         OLAP_LOG_WARNING("fail to find tablet before saving status. [tablet='%s']",
                          new_tablet->full_name().c_str());
@@ -2188,9 +2144,7 @@ PROCESS_ALTER_EXIT:
 
     if (res == OLAP_SUCCESS) {
         // ref的状态只有2个new table都完成后，才能设置为done
-        sc_params->ref_tablet->obtain_header_rdlock();
-        res = clear_schema_change_single_info(sc_params->ref_tablet, NULL, false, true);
-        sc_params->ref_tablet->release_header_lock();
+        res = sc_params->ref_tablet->clear_schema_change_info(NULL, false, true);
 
         if (OLAP_SUCCESS == res) {
             sc_params->ref_tablet->set_schema_change_status(
@@ -2409,7 +2363,7 @@ OLAPStatus SchemaChange::create_init_version(
         }
 
         // Get tablet and generate new index
-        tablet = StorageEngine::get_instance()->get_tablet(tablet_id, schema_hash);
+        tablet = TabletManager::instance()->get_tablet(tablet_id, schema_hash);
         if (tablet.get() == NULL) {
             OLAP_LOG_WARNING("fail to find tablet. [tablet=%ld]", tablet_id);
             res = OLAP_ERR_TABLE_NOT_FOUND;

--- a/be/src/olap/schema_change.h
+++ b/be/src/olap/schema_change.h
@@ -276,32 +276,6 @@ public:
                                       std::vector<SegmentGroup*>* ref_segment_groups,
                                       std::vector<SegmentGroup*>* new_segment_groups);
 
-    // 清空一个table下的schema_change信息：包括split_talbe以及其他schema_change信息
-    //  这里只清理自身的out链，不考虑related的tablet
-    // NOTE 需要外部lock header
-    // Params:
-    //   alter_tablet_type
-    //     为NULL时，同时检查table_split和其他普通schema_change
-    //               否则只检查指定type的信息
-    //   only_one:
-    //     为true时：如果其out链只有一个，且可删除，才可能进行clear
-    //     为false时：如果发现有大于1个out链，不管是否可删除，都不进行删除
-    //   check_only:
-    //     检查通过也不删除schema
-    // Returns:
-    //  成功：有的都可以清理（没有就直接跳过）
-    //  失败：如果有信息但不能清理（有version没完成）,或不符合only_one条件
-    static OLAPStatus clear_schema_change_single_info(TTabletId tablet_id,
-                                                      SchemaHash schema_hash,
-                                                      AlterTabletType* alter_tablet_type,
-                                                      bool only_one,
-                                                      bool check_only);
-
-    static OLAPStatus clear_schema_change_single_info(TabletSharedPtr tablet,
-                                                      AlterTabletType* alter_tablet_type,
-                                                      bool only_one,
-                                                      bool check_only);
-
 
 private:
     // 检查schema_change相关的状态:清理"一对"schema_change table间的信息

--- a/be/src/olap/snapshot_manager.h
+++ b/be/src/olap/snapshot_manager.h
@@ -1,0 +1,150 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#ifndef DORIS_BE_SRC_OLAP_SNAPSHOT_MANAGER_H
+#define DORIS_BE_SRC_OLAP_SNAPSHOT_MANAGER_H
+
+#include <ctime>
+#include <list>
+#include <map>
+#include <mutex>
+#include <condition_variable>
+#include <set>
+#include <string>
+#include <vector>
+#include <thread>
+
+#include "common/status.h"
+#include "olap/field.h"
+#include "olap/olap_common.h"
+#include "olap/rowset/column_data.h"
+#include "olap/olap_define.h"
+#include "olap/tablet.h"
+#include "olap/tablet_meta_manager.h"
+#include "olap/push_handler.h"
+#include "olap/data_dir.h"
+#include "util/file_utils.h"
+#include "util/doris_metrics.h"
+
+namespace doris {
+
+class SnapshotManager {
+
+public:
+    ~SnapshotManager() {}
+    // @brief 创建snapshot
+    // @param tablet_id [in] 原表的id
+    // @param schema_hash [in] 原表的schema，与tablet_id参数合起来唯一确定一张表
+    // @param snapshot_path [out] 新生成的snapshot的路径
+    OLAPStatus make_snapshot(
+            const TSnapshotRequest& request,
+            std::string* snapshot_path);
+
+    // @brief 释放snapshot
+    // @param snapshot_path [in] 要被释放的snapshot的路径，只包含到ID
+    OLAPStatus release_snapshot(const std::string& snapshot_path);
+
+    static SnapshotManager* instance();
+
+private:
+    SnapshotManager()
+        : _snapshot_base_id(0) {}
+
+    OLAPStatus _calc_snapshot_id_path(
+            const TabletSharedPtr& tablet,
+            std::string* out_path);
+
+    std::string _get_schema_hash_full_path(
+            const TabletSharedPtr& ref_tablet,
+            const std::string& location) const;
+
+    std::string _get_header_full_path(
+            const TabletSharedPtr& ref_tablet,
+            const std::string& schema_hash_path) const;
+
+    void _update_header_file_info(
+            const std::vector<VersionEntity>& shortest_version_entity,
+            TabletMeta* header);
+
+    // TODO: hkp
+    // rewrite this function
+    OLAPStatus _link_index_and_data_files(
+            const std::string& header_path,
+            const TabletSharedPtr& ref_tablet,
+            const std::vector<VersionEntity>& version_entity_vec);
+
+    // TODO: hkp
+    // rewrite this function
+    OLAPStatus _copy_index_and_data_files(
+            const std::string& header_path,
+            const TabletSharedPtr& ref_tablet,
+            std::vector<VersionEntity>& version_entity_vec);
+
+    OLAPStatus _create_snapshot_files(
+            const TabletSharedPtr& ref_tablet,
+            const TSnapshotRequest& request,
+            std::string* snapshot_path);
+
+    OLAPStatus _create_incremental_snapshot_files(
+           const TabletSharedPtr& ref_tablet,
+           const TSnapshotRequest& request,
+           std::string* snapshot_path);
+
+    OLAPStatus _prepare_snapshot_dir(const TabletSharedPtr& ref_tablet,
+           std::string* snapshot_id_path);
+
+    OLAPStatus _append_single_delta(
+            const TSnapshotRequest& request,
+            DataDir* store);
+
+    // TODO: hkp
+    // rewrite this function
+    std::string _construct_index_file_path(
+            const std::string& tablet_path_prefix,
+            const Version& version,
+            VersionHash version_hash,
+            int32_t segment_group_id, int32_t segment) const;
+
+    // TODO: hkp
+    // rewrite this function
+    std::string _construct_data_file_path(
+            const std::string& tablet_path_prefix,
+            const Version& version,
+            VersionHash version_hash,
+            int32_t segment_group_id, int32_t segment) const;
+
+    OLAPStatus _generate_new_header(
+            DataDir* store,
+            const uint64_t new_shard,
+            const TabletSharedPtr& tablet,
+            const std::vector<VersionEntity>& version_entity_vec, TabletMeta* new_tablet_meta);
+
+    OLAPStatus _create_hard_link(const std::string& from_path, const std::string& to_path);
+
+private:
+    static SnapshotManager* _s_instance;
+    static std::mutex _mlock;
+
+
+    // snapshot
+    Mutex _snapshot_mutex;
+    uint64_t _snapshot_base_id;
+}; // SnapshotManager
+
+} // doris
+
+#endif 

--- a/be/src/olap/storage_engine.cpp
+++ b/be/src/olap/storage_engine.cpp
@@ -41,6 +41,7 @@
 #include "olap/tablet_meta_manager.h"
 #include "olap/push_handler.h"
 #include "olap/reader.h"
+#include "olap/rowset/rowset_meta_manager.h"
 #include "olap/schema_change.h"
 #include "olap/data_dir.h"
 #include "olap/utils.h"
@@ -109,11 +110,8 @@ StorageEngine::StorageEngine(const EngineOptions& options)
         _is_all_cluster_id_exist(true),
         _is_drop_tables(false),
         _index_stream_lru_cache(NULL),
-        _snapshot_base_id(0),
         _is_report_disk_state_already(false),
-        _is_report_tablet_already(false),
-        _txn_mgr(),
-        _tablet_mgr() {
+        _is_report_tablet_already(false){
     if (_s_instance == nullptr) {
         _s_instance = this;
     }
@@ -133,11 +131,48 @@ OLAPStatus StorageEngine::_load_data_dir(DataDir* data_dir) {
         LOG(WARNING) << "get convert flag from meta failed";
         return res;
     }
+
+    // load rowset meta from metaenv and create rowset
+    // COMMITTED: add to txn manager
+    // VISIBLE: add to tablet
+    // if one rowset load failed, then the total data dir will not be loaded
+    std::vector<std::shared_ptr<RowsetMeta>> dir_rowset_metas;
+    if (is_header_converted) {
+        LOG(INFO) << "begin loading rowset from meta";
+        bool has_error = false;
+        auto load_rowset_func = [this, data_dir, &has_error, &dir_rowset_metas](RowsetId rowset_id, const std::string& meta_str) -> bool {
+            std::shared_ptr<RowsetMeta> rowset_meta(new RowsetMeta());
+            bool parsed = rowset_meta->init(meta_str);
+            if (!parsed) {
+                LOG(WARNING) << "parse rowset meta string failed for rowset_id:" << rowset_id;
+                has_error = true;
+                // return false will break meta iterator
+                return false;
+            }
+            dir_rowset_metas.push_back(rowset_meta);
+            return true;
+        };
+        OLAPStatus s = RowsetMetaManager::traverse_rowset_metas(data_dir->get_meta(), load_rowset_func);
+        if (has_error) {
+            LOG(WARN) << "errors when load rowset meta from meta env, skip this data dir:" << data_dir_path;
+            return OLAP_ERR_META_ITERATOR;
+        }
+        LOG(INFO) << "load header from meta finished";
+        if (s != OLAP_SUCCESS) {
+            LOG(WARNING) << "errors when load rowset meta from meta env, skip this data dir:" << data_dir_path;
+            return s;
+        } else {
+            return OLAP_SUCCESS;
+        }
+    }
+    // load tablet
+    // create tablet from tablet meta and add it to tablet mgr
     if (is_header_converted) {
         LOG(INFO) << "load header from meta";
         auto load_tablet_func = [this, data_dir](long tablet_id,
             long schema_hash, const std::string& value) -> bool {
-            OLAPStatus status = this->_tablet_mgr.load_tablet_from_header(data_dir, tablet_id, schema_hash, value);
+            
+            OLAPStatus status = TabletManager::instance()->load_tablet_from_header(data_dir, tablet_id, schema_hash, value);
             if (status != OLAP_SUCCESS) {
                 LOG(WARNING) << "load tablet from header failed. status:" << status
                     << "tablet=" << tablet_id << "." << schema_hash;
@@ -158,6 +193,13 @@ OLAPStatus StorageEngine::_load_data_dir(DataDir* data_dir) {
         LOG(WARNING) << "header is not converted to tablet meta yet, could not use this Doris version. " 
                     << "[dir path =" << data_dir_path << "]";
         return OLAP_ERR_INIT_FAILED;
+    }
+
+    for (auto rowset_meta : dir_rowset_metas) {
+        // TODO(ygl)
+        // 1. build rowset from meta
+        // 2. add committed rowset to txn
+        // 3. add visible rowset to tablet
     }
 }
 
@@ -200,7 +242,7 @@ OLAPStatus StorageEngine::open() {
     auto cache = new_lru_cache(config::file_descriptor_cache_capacity);
     if (cache == nullptr) {
         OLAP_LOG_WARNING("failed to init file descriptor LRUCache");
-        _tablet_mgr.clear();
+        TabletManager::instance()->clear();
         return OLAP_ERR_INIT_FAILED;
     }
     FileHandler::set_fd_cache(cache);
@@ -210,7 +252,7 @@ OLAPStatus StorageEngine::open() {
     _index_stream_lru_cache = new_lru_cache(config::index_stream_cache_capacity);
     if (_index_stream_lru_cache == NULL) {
         OLAP_LOG_WARNING("failed to init index stream LRUCache");
-        _tablet_mgr.clear();
+        TabletManager::instance()->clear();
         return OLAP_ERR_INIT_FAILED;
     }
 
@@ -221,10 +263,10 @@ OLAPStatus StorageEngine::open() {
     _max_cumulative_compaction_task_per_disk = (cumulative_compaction_num_threads + file_system_num - 1) / file_system_num;
     _max_base_compaction_task_per_disk = (base_compaction_num_threads + file_system_num - 1) / file_system_num;
 
-    auto stores = get_stores();
-    load_data_dirs(stores);
+    auto dirs = get_stores();
+    load_data_dirs(dirs);
     // 取消未完成的SchemaChange任务
-    _tablet_mgr.cancel_unfinished_schema_change();
+    TabletManager::instance()->cancel_unfinished_schema_change();
 
     return OLAP_SUCCESS;
 }
@@ -240,7 +282,7 @@ void StorageEngine::_update_storage_medium_type_count() {
     }
 
     _available_storage_medium_type_count = available_storage_medium_types.size();
-    _tablet_mgr.update_storage_medium_type_count(_available_storage_medium_type_count);
+    TabletManager::instance()->update_storage_medium_type_count(_available_storage_medium_type_count);
 }
 
 
@@ -337,7 +379,7 @@ OLAPStatus StorageEngine::get_all_data_dir_info(vector<DataDirInfo>* data_dir_in
 
     // for each tablet, get it's data size, and accumulate the path 'data_used_capacity'
     // which the tablet belongs to.
-    _tablet_mgr.update_root_path_info(&path_map, &tablet_counter);
+    TabletManager::instance()->update_root_path_info(&path_map, &tablet_counter);
 
     // add path info to data_dir_infos
     for (auto& entry : path_map) {
@@ -483,7 +525,7 @@ void StorageEngine::_delete_tables_on_unused_root_path() {
         _is_drop_tables = true;
     }
     
-    _tablet_mgr.drop_tablets_on_error_root_path(tablet_info_vec);
+    TabletManager::instance()->drop_tablets_on_error_root_path(tablet_info_vec);
 }
 
 OLAPStatus StorageEngine::_get_path_available_capacity(
@@ -512,56 +554,20 @@ OLAPStatus StorageEngine::clear() {
     return OLAP_SUCCESS;
 }
 
-TabletSharedPtr StorageEngine::get_tablet(TTabletId tablet_id, SchemaHash schema_hash, bool load_tablet) {
-    
-    return _tablet_mgr.get_tablet(tablet_id, schema_hash, load_tablet);
-}
-
-OLAPStatus StorageEngine::get_tables_by_id(
-        TTabletId tablet_id,
-        list<TabletSharedPtr>* tablet_list) {
-    return _tablet_mgr.get_tablets_by_id(tablet_id, tablet_list);
-}
-
-bool StorageEngine::check_tablet_id_exist(TTabletId tablet_id) {
-
-    return _tablet_mgr.check_tablet_id_exist(tablet_id);
-}
-
-OLAPStatus StorageEngine::add_transaction(
-    TPartitionId partition_id, TTransactionId transaction_id,
-    TTabletId tablet_id, SchemaHash schema_hash, const PUniqueId& load_id) {
-    
-    OLAPStatus status = _txn_mgr.add_txn(partition_id, transaction_id, 
-        tablet_id, schema_hash, load_id);
-    return status;
-}
-
 void StorageEngine::delete_transaction(
     TPartitionId partition_id, TTransactionId transaction_id,
     TTabletId tablet_id, SchemaHash schema_hash, bool delete_from_tablet) {
 
     // call txn manager to delete txn from memory
-    OLAPStatus res = _txn_mgr.delete_txn(partition_id, transaction_id, 
+    OLAPStatus res = TxnManager::instance()->delete_txn(partition_id, transaction_id, 
         tablet_id, schema_hash);
     // delete transaction from tablet
     if (res == OLAP_SUCCESS && delete_from_tablet) {
-        TabletSharedPtr tablet = get_tablet(tablet_id, schema_hash);
+        TabletSharedPtr tablet = TabletManager::instance()->get_tablet(tablet_id, schema_hash);
         if (tablet.get() != nullptr) {
             tablet->delete_pending_data(transaction_id);
         }
     }
-}
-
-void StorageEngine::get_transactions_by_tablet(TabletSharedPtr tablet, int64_t* partition_id,
-                                            set<int64_t>* transaction_ids) {
-    _txn_mgr.get_tablet_related_txns(tablet, partition_id, transaction_ids);
-}
-
-bool StorageEngine::has_transaction(TPartitionId partition_id, TTransactionId transaction_id,
-                                 TTabletId tablet_id, SchemaHash schema_hash) {
-    bool found = _txn_mgr.has_txn(partition_id, transaction_id, tablet_id, schema_hash);
-    return found;
 }
 
 OLAPStatus StorageEngine::publish_version(const TPublishVersionRequest& publish_version_req,
@@ -578,7 +584,8 @@ OLAPStatus StorageEngine::publish_version(const TPublishVersionRequest& publish_
 
         int64_t partition_id = partitionVersionInfo.partition_id;
         vector<TabletInfo> tablet_infos;
-        _txn_mgr.get_txn_related_tablets(transaction_id, partition_id, &tablet_infos);
+        vector<RowsetSharedPtr> rowsets;
+        TxnManager::instance()->get_txn_related_tablets(transaction_id, partition_id, &tablet_infos, &rowsets);
 
         Version version(partitionVersionInfo.version, partitionVersionInfo.version);
         VersionHash version_hash = partitionVersionInfo.version_hash;
@@ -591,7 +598,7 @@ OLAPStatus StorageEngine::publish_version(const TPublishVersionRequest& publish_
                     << ", version=" << version.first
                     << ", version_hash=" << version_hash
                     << ", transaction_id=" << transaction_id;
-            TabletSharedPtr tablet = get_tablet(tablet_info.tablet_id, tablet_info.schema_hash);
+            TabletSharedPtr tablet = TabletManager::instance()->get_tablet(tablet_info.tablet_id, tablet_info.schema_hash);
 
             if (tablet.get() == NULL) {
                 OLAP_LOG_WARNING("can't get tablet when publish version. [tablet_id=%ld schema_hash=%d]",
@@ -601,7 +608,8 @@ OLAPStatus StorageEngine::publish_version(const TPublishVersionRequest& publish_
                 continue;
             }
 
-
+            // get rowsets from txn manager according to tablet and txn id
+            // TODO(ygl) just add rowset to tablet
             // publish version
             OLAPStatus publish_status = tablet->publish_version(
                 transaction_id, version, version_hash);
@@ -618,7 +626,7 @@ OLAPStatus StorageEngine::publish_version(const TPublishVersionRequest& publish_
             } else if (publish_status == OLAP_SUCCESS) {
                 LOG(INFO) << "publish version successfully on tablet. tablet=" << tablet->full_name()
                           << ", transaction_id=" << transaction_id << ", version=" << version.first;
-                _txn_mgr.delete_txn(partition_id, transaction_id, 
+                TxnManager::instance()->delete_txn(partition_id, transaction_id, 
                     tablet_info.tablet_id, tablet_info.schema_hash);
             } else {
                 OLAP_LOG_WARNING("fail to publish version on tablet. "
@@ -643,7 +651,7 @@ void StorageEngine::clear_transaction_task(const TTransactionId transaction_id,
 
     for (const TPartitionId& partition_id : partition_ids) {
         vector<TabletInfo> tablet_infos;
-        _txn_mgr.get_txn_related_tablets(transaction_id, partition_id, &tablet_infos);
+        TxnManager::instance()->get_txn_related_tablets(transaction_id, partition_id, &tablet_infos, NULL);
 
         // each tablet
         for (auto& tablet_info : tablet_infos) {
@@ -652,168 +660,6 @@ void StorageEngine::clear_transaction_task(const TTransactionId transaction_id,
         }
     }
     LOG(INFO) << "finish to clear transaction task. transaction_id=" << transaction_id;
-}
-
-OLAPStatus StorageEngine::clone_incremental_data(TabletSharedPtr tablet, TabletMeta& clone_header,
-                                              int64_t committed_version) {
-    LOG(INFO) << "begin to incremental clone. tablet=" << tablet->full_name()
-              << ", committed_version=" << committed_version;
-
-    // calculate missing version again
-    vector<Version> missing_versions;
-    tablet->get_missing_versions_with_header_locked(committed_version, &missing_versions);
-
-    // add least complete version
-    // prevent lastest version not replaced (if need to rewrite) when restart
-    const PDelta* least_complete_version = tablet->least_complete_version(missing_versions);
-
-    vector<Version> versions_to_delete;
-    vector<const PDelta*> versions_to_clone;
-
-    // it's not a merged version in principle
-    if (least_complete_version != NULL &&
-        least_complete_version->start_version() == least_complete_version->end_version()) {
-
-        Version version(least_complete_version->start_version(), least_complete_version->end_version());
-        const PDelta* clone_src_version = clone_header.get_incremental_version(version);
-
-        // if least complete version not found in clone src, return error
-        if (clone_src_version == nullptr) {
-            OLAP_LOG_WARNING("failed to find least complete version in clone header. "
-                    "[clone_header_file=%s least_complete_version=%d-%d]",
-                    clone_header.file_name().c_str(),
-                    least_complete_version->start_version(), least_complete_version->end_version());
-            return OLAP_ERR_VERSION_NOT_EXIST;
-
-        // if least complete version_hash in clone src is different, clone it
-        } else if (clone_src_version->version_hash() != least_complete_version->version_hash()) {
-            versions_to_clone.push_back(clone_src_version);
-            versions_to_delete.push_back(Version(
-                least_complete_version->start_version(),
-                least_complete_version->end_version()));
-
-            VLOG(3) << "least complete version_hash in clone src is different, replace it. "
-                    << "tablet=" << tablet->full_name()
-                    << ", least_complete_version=" << least_complete_version->start_version()
-                    << "-" << least_complete_version->end_version()
-                    << ", local_hash=" << least_complete_version->version_hash()
-                    << ", clone_hash=" << clone_src_version->version_hash();
-        }
-    }
-
-    VLOG(3) << "get missing versions again when incremental clone. "
-            << "tablet=" << tablet->full_name() 
-            << ", committed_version=" << committed_version
-            << ", missing_versions_size=" << missing_versions.size();
-
-    // check missing versions exist in clone src
-    for (Version version : missing_versions) {
-        const PDelta* clone_src_version = clone_header.get_incremental_version(version);
-        if (clone_src_version == NULL) {
-           LOG(WARNING) << "missing version not found in clone src."
-                        << "clone_header_file=" << clone_header.file_name()
-                        << ", missing_version=" << version.first << "-" << version.second;
-            return OLAP_ERR_VERSION_NOT_EXIST;
-        }
-
-        versions_to_clone.push_back(clone_src_version);
-    }
-
-    // clone_data to tablet
-    OLAPStatus clone_res = tablet->clone_data(clone_header, versions_to_clone, versions_to_delete);
-    LOG(INFO) << "finish to incremental clone. [tablet=" << tablet->full_name() << " res=" << clone_res << "]";
-    return clone_res;
-}
-
-OLAPStatus StorageEngine::clone_full_data(TabletSharedPtr tablet, TabletMeta& clone_header) {
-    Version clone_latest_version = clone_header.get_latest_version();
-    LOG(INFO) << "begin to full clone. tablet=" << tablet->full_name() << ","
-        << "clone_latest_version=" << clone_latest_version.first << "-" << clone_latest_version.second;
-    vector<Version> versions_to_delete;
-
-    // check local versions
-    for (int i = 0; i < tablet->file_delta_size(); i++) {
-        Version local_version(tablet->get_delta(i)->start_version(),
-                              tablet->get_delta(i)->end_version());
-        VersionHash local_version_hash = tablet->get_delta(i)->version_hash();
-        LOG(INFO) << "check local delta when full clone."
-            << "tablet=" << tablet->full_name()
-            << ", local_version=" << local_version.first << "-" << local_version.second;
-
-        // if local version cross src latest, clone failed
-        if (local_version.first <= clone_latest_version.second
-            && local_version.second > clone_latest_version.second) {
-            LOG(WARNING) << "stop to full clone, version cross src latest."
-                    << "tablet=" << tablet->full_name()
-                    << ", local_version=" << local_version.first << "-" << local_version.second;
-            return OLAP_ERR_TABLE_VERSION_DUPLICATE_ERROR;
-
-        } else if (local_version.second <= clone_latest_version.second) {
-            // if local version smaller than src, check if existed in src, will not clone it
-            bool existed_in_src = false;
-
-            // if delta labeled with local_version is same with the specified version in clone header,
-            // there is no necessity to clone it.
-            for (int j = 0; j < clone_header.file_delta_size(); ++j) {
-                if (clone_header.get_delta(j)->start_version() == local_version.first
-                    && clone_header.get_delta(j)->end_version() == local_version.second
-                    && clone_header.get_delta(j)->version_hash() == local_version_hash) {
-                    existed_in_src = true;
-                    LOG(INFO) << "Delta has already existed in local header, no need to clone."
-                        << "tablet=" << tablet->full_name()
-                        << ", version='" << local_version.first<< "-" << local_version.second
-                        << ", version_hash=" << local_version_hash;
-
-                    OLAPStatus delete_res = clone_header.delete_version(local_version);
-                    if (delete_res != OLAP_SUCCESS) {
-                        LOG(WARNING) << "failed to delete existed version from clone src when full clone. "
-                                  << "clone_header_file=" << clone_header.file_name()
-                                  << "version=" << local_version.first << "-" << local_version.second;
-                        return delete_res;
-                    }
-                    break;
-                }
-            }
-
-            // Delta labeled in local_version is not existed in clone header,
-            // some overlapping delta will be cloned to replace it.
-            // And also, the specified delta should deleted from local header.
-            if (!existed_in_src) {
-                versions_to_delete.push_back(local_version);
-                LOG(INFO) << "Delete delta not included by the clone header, should delete it from local header."
-                          << "tablet=" << tablet->full_name() << ","
-                          << ", version=" << local_version.first<< "-" << local_version.second
-                          << ", version_hash=" << local_version_hash;
-            }
-        }
-    }
-    vector<const PDelta*> clone_deltas;
-    for (int i = 0; i < clone_header.file_delta_size(); ++i) {
-        clone_deltas.push_back(clone_header.get_delta(i));
-        LOG(INFO) << "Delta to clone."
-            << "tablet=" << tablet->full_name() << ","
-            << ", version=" << clone_header.get_delta(i)->start_version() << "-"
-                << clone_header.get_delta(i)->end_version()
-            << ", version_hash=" << clone_header.get_delta(i)->version_hash();
-    }
-
-    // clone_data to tablet
-    OLAPStatus clone_res = tablet->clone_data(clone_header, clone_deltas, versions_to_delete);
-    LOG(INFO) << "finish to full clone. [tablet=" << tablet->full_name() << ", res=" << clone_res << "]";
-    return clone_res;
-}
-
-// Drop tablet specified, the main logical is as follows:
-// 1. tablet not in schema change:
-//      drop specified tablet directly;
-// 2. tablet in schema change:
-//      a. schema change not finished && dropped tablet is base :
-//          base tablet cannot be dropped;
-//      b. other cases:
-//          drop specified tablet and clear schema change info.
-OLAPStatus StorageEngine::drop_tablet(
-        TTabletId tablet_id, SchemaHash schema_hash, bool keep_files) {
-    return _tablet_mgr.drop_tablet(tablet_id, schema_hash, keep_files);
 }
 
 TabletSharedPtr StorageEngine::create_tablet(
@@ -832,32 +678,8 @@ TabletSharedPtr StorageEngine::create_tablet(
         stores.push_back(ref_tablet->data_dir());
     }
 
-    return _tablet_mgr.create_tablet(request, ref_root_path, 
+    return TabletManager::instance()->create_tablet(request, ref_root_path, 
         is_schema_change_tablet, ref_tablet, stores);
-}
-
-bool StorageEngine::try_schema_change_lock(TTabletId tablet_id) {
-
-    return _tablet_mgr.try_schema_change_lock(tablet_id);
-}
-
-void StorageEngine::release_schema_change_lock(TTabletId tablet_id) {
-    
-    _tablet_mgr.release_schema_change_lock(tablet_id);
-}
-
-OLAPStatus StorageEngine::report_tablet_info(TTabletInfo* tablet_info) {
-    
-    return _tablet_mgr.report_tablet_info(tablet_info);
-}
-
-OLAPStatus StorageEngine::report_all_tablets_info(std::map<TTabletId, TTablet>* tablets_info) {
-    
-    return _tablet_mgr.report_all_tablets_info(tablets_info);
-}
-
-void StorageEngine::get_tablet_stat(TTabletStatResult& result) {
-    _tablet_mgr.get_tablet_stat(result);
 }
 
 void StorageEngine::start_clean_fd_cache() {
@@ -867,7 +689,7 @@ void StorageEngine::start_clean_fd_cache() {
 }
 
 void StorageEngine::perform_cumulative_compaction() {
-    TabletSharedPtr best_tablet = _tablet_mgr.find_best_tablet_to_compaction(CompactionType::CUMULATIVE_COMPACTION);
+    TabletSharedPtr best_tablet = TabletManager::instance()->find_best_tablet_to_compaction(CompactionType::CUMULATIVE_COMPACTION);
     if (best_tablet == nullptr) { return; }
 
     CumulativeCompaction cumulative_compaction;
@@ -885,7 +707,7 @@ void StorageEngine::perform_cumulative_compaction() {
 }
 
 void StorageEngine::perform_base_compaction() {
-    TabletSharedPtr best_tablet = _tablet_mgr.find_best_tablet_to_compaction(CompactionType::BASE_COMPACTION);
+    TabletSharedPtr best_tablet = TabletManager::instance()->find_best_tablet_to_compaction(CompactionType::BASE_COMPACTION);
     if (best_tablet == nullptr) { return; }
 
     BaseCompaction base_compaction;
@@ -958,7 +780,7 @@ OLAPStatus StorageEngine::start_trash_sweep(double* usage) {
     }
 
     // clear expire incremental segment_group
-    _tablet_mgr.start_trash_sweep();
+    TabletManager::instance()->start_trash_sweep();
 
     return res;
 }
@@ -1050,361 +872,17 @@ OLAPStatus StorageEngine::create_tablet(const TCreateTabletReq& request) {
         LOG(WARNING) << "there is no available disk that can be used to create tablet.";
         return OLAP_ERR_CE_CMD_PARAMS_ERROR;
     }
-    return _tablet_mgr.create_tablet(request, stores);
-}
-
-OLAPStatus StorageEngine::schema_change(const TAlterTabletReq& request) {
-    LOG(INFO) << "begin to schema change. old_tablet_id=" << request.base_tablet_id
-              << ", new_tablet_id=" << request.new_tablet_req.tablet_id;
-
-    DorisMetrics::schema_change_requests_total.increment(1);
-
-    OLAPStatus res = OLAP_SUCCESS;
-
-    SchemaChangeHandler handler;
-    res = handler.process_alter_tablet(ALTER_TABLET_SCHEMA_CHANGE, request);
-
-    if (res != OLAP_SUCCESS) {
-        OLAP_LOG_WARNING("failed to do schema change. "
-                         "[base_tablet=%ld new_tablet=%ld] [res=%d]",
-                         request.base_tablet_id, request.new_tablet_req.tablet_id, res);
-        DorisMetrics::schema_change_requests_failed.increment(1);
-        return res;
-    }
-
-    LOG(INFO) << "success to submit schema change."
-              << "old_tablet_id=" << request.base_tablet_id
-              << ", new_tablet_id=" << request.new_tablet_req.tablet_id;
-    return res;
-}
-
-OLAPStatus StorageEngine::create_rollup_tablet(const TAlterTabletReq& request) {
-    
-    return _tablet_mgr.create_rollup_tablet(request);
-}
-
-AlterTableStatus StorageEngine::show_alter_tablet_status(
-        TTabletId tablet_id,
-        TSchemaHash schema_hash) {
-
-    return _tablet_mgr.show_alter_tablet_status(tablet_id, schema_hash);
-}
-
-OLAPStatus StorageEngine::compute_checksum(
-        TTabletId tablet_id,
-        TSchemaHash schema_hash,
-        TVersion version,
-        TVersionHash version_hash,
-        uint32_t* checksum) {
-    LOG(INFO) << "begin to process compute checksum."
-              << "tablet_id=" << tablet_id
-              << ", schema_hash=" << schema_hash
-              << ", version=" << version;
-    OLAPStatus res = OLAP_SUCCESS;
-
-    if (checksum == NULL) {
-        OLAP_LOG_WARNING("invalid output parameter which is null pointer.");
-        return OLAP_ERR_CE_CMD_PARAMS_ERROR;
-    }
-
-    TabletSharedPtr tablet = get_tablet(tablet_id, schema_hash);
-    if (NULL == tablet.get()) {
-        OLAP_LOG_WARNING("can't find tablet. [tablet_id=%ld schema_hash=%d]",
-                         tablet_id, schema_hash);
-        return OLAP_ERR_TABLE_NOT_FOUND;
-    }
-
-    {
-        ReadLock rdlock(tablet->get_header_lock_ptr());
-        const PDelta* message = tablet->lastest_version();
-        if (message == NULL) {
-            LOG(FATAL) << "fail to get latest version. tablet_id=" << tablet_id;
-            return OLAP_ERR_VERSION_NOT_EXIST;
-        }
-
-        if (message->end_version() == version
-                && message->version_hash() != version_hash) {
-            OLAP_LOG_WARNING("fail to check latest version hash. "
-                             "[res=%d tablet_id=%ld version_hash=%ld request_version_hash=%ld]",
-                             res, tablet_id, message->version_hash(), version_hash);
-            return OLAP_ERR_CE_CMD_PARAMS_ERROR;
-        }
-    }
-
-    Reader reader;
-    ReaderParams reader_params;
-    reader_params.tablet = tablet;
-    reader_params.reader_type = READER_CHECKSUM;
-    reader_params.version = Version(0, version);
-
-    // ignore float and double type considering to precision lose
-    for (size_t i = 0; i < tablet->tablet_schema().size(); ++i) {
-        FieldType type = tablet->get_field_type_by_index(i);
-        if (type == OLAP_FIELD_TYPE_FLOAT || type == OLAP_FIELD_TYPE_DOUBLE) {
-            continue;
-        }
-
-        reader_params.return_columns.push_back(i);
-    }
-
-    res = reader.init(reader_params);
-    if (res != OLAP_SUCCESS) {
-        OLAP_LOG_WARNING("initiate reader fail. [res=%d]", res);
-        return res;
-    }
-
-    RowCursor row;
-    res = row.init(tablet->tablet_schema(), reader_params.return_columns);
-    if (res != OLAP_SUCCESS) {
-        OLAP_LOG_WARNING("failed to init row cursor. [res=%d]", res);
-        return res;
-    }
-    row.allocate_memory_for_string_type(tablet->tablet_schema());
-
-    bool eof = false;
-    uint32_t row_checksum = 0;
-    while (true) {
-        OLAPStatus res = reader.next_row_with_aggregation(&row, &eof);
-        if (res == OLAP_SUCCESS && eof) {
-            VLOG(3) << "reader reads to the end.";
-            break;
-        } else if (res != OLAP_SUCCESS) {
-            OLAP_LOG_WARNING("fail to read in reader. [res=%d]", res);
-            return res;
-        }
-
-        row_checksum = row.hash_code(row_checksum);
-    }
-
-    LOG(INFO) << "success to finish compute checksum. checksum=" << row_checksum;
-    *checksum = row_checksum;
-    return OLAP_SUCCESS;
-}
-
-OLAPStatus StorageEngine::cancel_delete(const TCancelDeleteDataReq& request) {
-    LOG(INFO) << "begin to process cancel delete."
-              << "tablet=" << request.tablet_id
-              << ", version=" << request.version;
-
-    DorisMetrics::cancel_delete_requests_total.increment(1);
-
-    OLAPStatus res = OLAP_SUCCESS;
-
-    // 1. Get all tablets with same tablet_id
-    list<TabletSharedPtr> table_list;
-    res = get_tables_by_id(request.tablet_id, &table_list);
-    if (res != OLAP_SUCCESS) {
-        OLAP_LOG_WARNING("can't find tablet. [tablet=%ld]", request.tablet_id);
-        return OLAP_ERR_TABLE_NOT_FOUND;
-    }
-
-    // 2. Remove delete conditions from each tablet.
-    DeleteConditionHandler cond_handler;
-    for (TabletSharedPtr temp_tablet : table_list) {
-        temp_tablet->obtain_header_wrlock();
-        res = cond_handler.delete_cond(&temp_tablet->delete_predicates(), request.version, false);
-        if (res != OLAP_SUCCESS) {
-            temp_tablet->release_header_lock();
-            OLAP_LOG_WARNING("cancel delete failed. [res=%d tablet=%s]",
-                             res, temp_tablet->full_name().c_str());
-            break;
-        }
-
-        res = temp_tablet->save_tablet_meta();
-        if (res != OLAP_SUCCESS) {
-            temp_tablet->release_header_lock();
-            OLAP_LOG_WARNING("fail to save header. [res=%d tablet=%s]",
-                             res, temp_tablet->full_name().c_str());
-            break;
-        }
-        temp_tablet->release_header_lock();
-    }
-
-    // Show delete conditions in tablet header.
-    for (TabletSharedPtr tablet : table_list) {
-        cond_handler.log_conds(tablet->full_name(), tablet->delete_predicates());
-    }
-
-    LOG(INFO) << "finish to process cancel delete. res=" << res;
-    return res;
-}
-
-OLAPStatus StorageEngine::delete_data(
-        const TPushReq& request,
-        vector<TTabletInfo>* tablet_info_vec) {
-    LOG(INFO) << "begin to process delete data. request=" << ThriftDebugString(request);
-    DorisMetrics::delete_requests_total.increment(1);
-
-    OLAPStatus res = OLAP_SUCCESS;
-
-    if (tablet_info_vec == NULL) {
-        OLAP_LOG_WARNING("invalid output parameter which is null pointer.");
-        return OLAP_ERR_CE_CMD_PARAMS_ERROR;
-    }
-
-    // 1. Get all tablets with same tablet_id
-    TabletSharedPtr tablet = get_tablet(request.tablet_id, request.schema_hash);
-    if (tablet.get() == NULL) {
-        OLAP_LOG_WARNING("can't find tablet. [tablet=%ld schema_hash=%d]",
-                         request.tablet_id, request.schema_hash);
-        return OLAP_ERR_TABLE_NOT_FOUND;
-    }
-
-    // 2. Process delete data by push interface
-    PushHandler push_handler;
-    if (request.__isset.transaction_id) {
-        res = push_handler.process_realtime_push(tablet, request, PUSH_FOR_DELETE, tablet_info_vec);
-    } else {
-        res = OLAP_ERR_PUSH_BATCH_PROCESS_REMOVED;
-    }
-
-    if (res != OLAP_SUCCESS) {
-        OLAP_LOG_WARNING("fail to push empty version for delete data. "
-                         "[res=%d tablet='%s']",
-                         res, tablet->full_name().c_str());
-        DorisMetrics::delete_requests_failed.increment(1);
-        return res;
-    }
-
-    LOG(INFO) << "finish to process delete data. res=" << res;
-    return res;
+    return TabletManager::instance()->create_tablet(request, stores);
 }
 
 OLAPStatus StorageEngine::recover_tablet_until_specfic_version(
         const TRecoverTabletReq& recover_tablet_req) {
-    TabletSharedPtr tablet = get_tablet(recover_tablet_req.tablet_id,
+    TabletSharedPtr tablet = TabletManager::instance()->get_tablet(recover_tablet_req.tablet_id,
                                    recover_tablet_req.schema_hash);
     if (tablet == nullptr) { return OLAP_ERR_TABLE_NOT_FOUND; }
     RETURN_NOT_OK(tablet->recover_tablet_until_specfic_version(recover_tablet_req.version,
                                                         recover_tablet_req.version_hash));
     return OLAP_SUCCESS;
-}
-
-string StorageEngine::get_info_before_incremental_clone(TabletSharedPtr tablet,
-    int64_t committed_version, vector<Version>* missing_versions) {
-
-    // get missing versions
-    tablet->obtain_header_rdlock();
-    tablet->get_missing_versions_with_header_locked(committed_version, missing_versions);
-
-    // get least complete version
-    // prevent lastest version not replaced (if need to rewrite) after node restart
-    const PDelta* least_complete_version = tablet->least_complete_version(*missing_versions);
-    if (least_complete_version != NULL) {
-        // TODO: Used in upgraded. If old Doris version, version can be converted.
-        Version version(least_complete_version->start_version(), least_complete_version->end_version()); 
-        missing_versions->push_back(version);
-        LOG(INFO) << "least complete version for incremental clone. tablet=" << tablet->full_name()
-                  << ", least_complete_version=" << least_complete_version->end_version();
-    }
-
-    tablet->release_header_lock();
-    LOG(INFO) << "finish to calculate missing versions when clone. [tablet=" << tablet->full_name()
-              << ", committed_version=" << committed_version << " missing_versions_size=" << missing_versions->size() << "]";
-
-    // get download path
-    return tablet->tablet_path() + CLONE_PREFIX;
-}
-
-OLAPStatus StorageEngine::finish_clone(TabletSharedPtr tablet, const string& clone_dir,
-                                         int64_t committed_version, bool is_incremental_clone) {
-    OLAPStatus res = OLAP_SUCCESS;
-    vector<string> linked_success_files;
-
-    // clone and compaction operation should be performed sequentially
-    tablet->obtain_base_compaction_lock();
-    tablet->obtain_cumulative_lock();
-
-    tablet->obtain_push_lock();
-    tablet->obtain_header_wrlock();
-    do {
-        // check clone dir existed
-        if (!check_dir_existed(clone_dir)) {
-            res = OLAP_ERR_DIR_NOT_EXIST;
-            OLAP_LOG_WARNING("clone dir not existed when clone. [clone_dir=%s]",
-                             clone_dir.c_str());
-            break;
-        }
-
-        // load src header
-        string clone_header_file = clone_dir + "/" + std::to_string(tablet->tablet_id()) + ".hdr";
-        TabletMeta clone_header(clone_header_file);
-        if ((res = clone_header.load_and_init()) != OLAP_SUCCESS) {
-            OLAP_LOG_WARNING("fail to load src header when clone. [clone_header_file=%s]",
-                             clone_header_file.c_str());
-            break;
-        }
-
-        // check all files in /clone and /tablet
-        set<string> clone_files;
-        if ((res = dir_walk(clone_dir, NULL, &clone_files)) != OLAP_SUCCESS) {
-            LOG(WARNING) << "failed to dir walk when clone. [clone_dir=" << clone_dir << "]";
-            break;
-        }
-
-        set<string> local_files;
-        string tablet_dir = tablet->tablet_path();
-        if ((res = dir_walk(tablet_dir, NULL, &local_files)) != OLAP_SUCCESS) {
-            LOG(WARNING) << "failed to dir walk when clone. [tablet_dir=" << tablet_dir << "]";
-            break;
-        }
-
-        // link files from clone dir, if file exists, skip it
-        for (const string& clone_file : clone_files) {
-            if (local_files.find(clone_file) != local_files.end()) {
-                VLOG(3) << "find same file when clone, skip it. "
-                        << "tablet=" << tablet->full_name()
-                        << ", clone_file=" << clone_file;
-                continue;
-            }
-
-            string from = clone_dir + "/" + clone_file;
-            string to = tablet_dir + "/" + clone_file;
-            LOG(INFO) << "src file:" << from << "dest file:" << to;
-            if (link(from.c_str(), to.c_str()) != 0) {
-                OLAP_LOG_WARNING("fail to create hard link when clone. [from=%s to=%s]",
-                                 from.c_str(), to.c_str());
-                res = OLAP_ERR_OS_ERROR;
-                break;
-            }
-            linked_success_files.emplace_back(std::move(to));
-        }
-
-        if (res != OLAP_SUCCESS) {
-            break;
-        }
-
-        if (is_incremental_clone) {
-            res = clone_incremental_data(
-                                              tablet, clone_header, committed_version);
-        } else {
-            res = clone_full_data(tablet, clone_header);
-        }
-
-        // if full clone success, need to update cumulative layer point
-        if (!is_incremental_clone && res == OLAP_SUCCESS) {
-            tablet->set_cumulative_layer_point(clone_header.cumulative_layer_point());
-        }
-
-    } while (0);
-
-    // clear linked files if errors happen
-    if (res != OLAP_SUCCESS) {
-        remove_files(linked_success_files);
-    }
-    tablet->release_header_lock();
-    tablet->release_push_lock();
-
-    tablet->release_cumulative_lock();
-    tablet->release_base_compaction_lock();
-
-    // clear clone dir
-    boost::filesystem::path clone_dir_path(clone_dir);
-    boost::filesystem::remove_all(clone_dir_path);
-    LOG(INFO) << "finish to clone data, clear downloaded data. res=" << res
-              << ", tablet=" << tablet->full_name()
-              << ", clone_dir=" << clone_dir;
-    return res;
 }
 
 OLAPStatus StorageEngine::obtain_shard_path(
@@ -1468,7 +946,7 @@ OLAPStatus StorageEngine::load_header(
     schema_hash_path_stream << shard_path
                             << "/" << request.tablet_id
                             << "/" << request.schema_hash;
-    res =  _tablet_mgr.load_one_tablet(
+    res =  TabletManager::instance()->load_one_tablet(
             store,
             request.tablet_id, request.schema_hash,
             schema_hash_path_stream.str(), false);
@@ -1494,7 +972,7 @@ OLAPStatus StorageEngine::load_header(
     schema_hash_path_stream << shard_path
                             << "/" << tablet_id
                             << "/" << schema_hash;
-    res =  _tablet_mgr.load_one_tablet(
+    res =  TabletManager::instance()->load_one_tablet(
             store,
             tablet_id, schema_hash,
             schema_hash_path_stream.str(), 
@@ -1512,7 +990,7 @@ OLAPStatus StorageEngine::clear_alter_task(const TTabletId tablet_id,
                                         const TSchemaHash schema_hash) {
     LOG(INFO) << "begin to process clear alter task. tablet_id=" << tablet_id
               << ", schema_hash=" << schema_hash;
-    TabletSharedPtr tablet = get_tablet(tablet_id, schema_hash);
+    TabletSharedPtr tablet = TabletManager::instance()->get_tablet(tablet_id, schema_hash);
     if (tablet.get() == NULL) {
         OLAP_LOG_WARNING("can't find tablet when process clear alter task. ",
                          "[tablet_id=%ld, schema_hash=%d]", tablet_id, schema_hash);
@@ -1549,7 +1027,7 @@ OLAPStatus StorageEngine::clear_alter_task(const TTabletId tablet_id,
     tablet->release_header_lock();
 
     // clear related tablet's schema change info
-    TabletSharedPtr related_tablet = get_tablet(related_tablet_id, related_schema_hash);
+    TabletSharedPtr related_tablet = TabletManager::instance()->get_tablet(related_tablet_id, related_schema_hash);
     if (related_tablet.get() == NULL) {
         OLAP_LOG_WARNING("related tablet not found when process clear alter task. "
                          "[tablet_id=%ld schema_hash=%d "
@@ -1572,62 +1050,6 @@ OLAPStatus StorageEngine::clear_alter_task(const TTabletId tablet_id,
               << "tablet_id=" << related_tablet_id
               << ", schema_hash=" << related_schema_hash;
     return OLAP_SUCCESS;
-}
-
-OLAPStatus StorageEngine::push(
-        const TPushReq& request,
-        vector<TTabletInfo>* tablet_info_vec) {
-    OLAPStatus res = OLAP_SUCCESS;
-    LOG(INFO) << "begin to process push. tablet_id=" << request.tablet_id
-              << ", version=" << request.version;
-
-    if (tablet_info_vec == NULL) {
-        OLAP_LOG_WARNING("invalid output parameter which is null pointer.");
-        DorisMetrics::push_requests_fail_total.increment(1);
-        return OLAP_ERR_CE_CMD_PARAMS_ERROR;
-    }
-
-    TabletSharedPtr tablet = get_tablet(
-            request.tablet_id, request.schema_hash);
-    if (NULL == tablet.get()) {
-        OLAP_LOG_WARNING("false to find tablet. [tablet=%ld schema_hash=%d]",
-                         request.tablet_id, request.schema_hash);
-        DorisMetrics::push_requests_fail_total.increment(1);
-        return OLAP_ERR_TABLE_NOT_FOUND;
-    }
-
-    PushType type = PUSH_NORMAL;
-    if (request.push_type == TPushType::LOAD_DELETE) {
-        type = PUSH_FOR_LOAD_DELETE;
-    }
-
-    int64_t duration_ns = 0;
-    PushHandler push_handler;
-    if (request.__isset.transaction_id) {
-        {
-            SCOPED_RAW_TIMER(&duration_ns);
-            res = push_handler.process_realtime_push(tablet, request, type, tablet_info_vec);
-        }
-    } else {
-        {
-            SCOPED_RAW_TIMER(&duration_ns);
-            res = OLAP_ERR_PUSH_BATCH_PROCESS_REMOVED;
-        }
-    }
-
-    if (res != OLAP_SUCCESS) {
-        LOG(WARNING) << "fail to push delta, tablet=" << tablet->full_name().c_str()
-            << ",cost=" << PrettyPrinter::print(duration_ns, TUnit::TIME_NS);
-        DorisMetrics::push_requests_fail_total.increment(1);
-    } else {
-        LOG(INFO) << "success to push delta, tablet=" << tablet->full_name().c_str()
-            << ",cost=" << PrettyPrinter::print(duration_ns, TUnit::TIME_NS);
-        DorisMetrics::push_requests_success_total.increment(1);
-        DorisMetrics::push_request_duration_us.increment(duration_ns / 1000);
-        DorisMetrics::push_request_write_bytes.increment(push_handler.write_bytes());
-        DorisMetrics::push_request_write_rows.increment(push_handler.write_rows());
-    }
-    return res;
 }
 
 }  // namespace doris

--- a/be/src/olap/storage_engine.h
+++ b/be/src/olap/storage_engine.h
@@ -71,13 +71,6 @@ public:
         return _s_instance;
     }
 
-    // Get tablet pointer
-    TabletSharedPtr get_tablet(TTabletId tablet_id, SchemaHash schema_hash, bool load_tablet = true);
-
-    OLAPStatus get_tables_by_id(TTabletId tablet_id, std::list<TabletSharedPtr>* table_list);    
-
-    bool check_tablet_id_exist(TTabletId tablet_id);
-
     OLAPStatus create_tablet(const TCreateTabletReq& request);
 
     // Create new tablet for StorageEngine
@@ -88,51 +81,15 @@ public:
                               const bool is_schema_change_tablet,
                               const TabletSharedPtr ref_tablet);
 
-    OLAPStatus add_transaction(TPartitionId partition_id, TTransactionId transaction_id,
-                               TTabletId tablet_id, SchemaHash schema_hash,
-                               const PUniqueId& load_id);
-
     void delete_transaction(TPartitionId partition_id, TTransactionId transaction_id,
                             TTabletId tablet_id, SchemaHash schema_hash,
                             bool delete_from_tablet = true);
-
-    void get_transactions_by_tablet(TabletSharedPtr tablet, int64_t* partition_id,
-                                    std::set<int64_t>* transaction_ids);
-
-    bool has_transaction(TPartitionId partition_id, TTransactionId transaction_id,
-                         TTabletId tablet_id, SchemaHash schema_hash);
 
     OLAPStatus publish_version(const TPublishVersionRequest& publish_version_req,
                          std::vector<TTabletId>* error_tablet_ids);
 
     void clear_transaction_task(const TTransactionId transaction_id,
                                 const std::vector<TPartitionId> partition_ids);
-
-    OLAPStatus clone_incremental_data(TabletSharedPtr tablet, TabletMeta& clone_header,
-                                     int64_t committed_version);
-
-    OLAPStatus clone_full_data(TabletSharedPtr tablet, TabletMeta& clone_header);
-
-    // Drop a tablet by description
-    // If set keep_files == true, files will NOT be deleted when deconstruction.
-    // Return OLAP_SUCCESS, if run ok
-    //        OLAP_ERR_TABLE_DELETE_NOEXIST_ERROR, if tablet not exist
-    //        OLAP_ERR_NOT_INITED, if not inited
-    OLAPStatus drop_tablet(
-            TTabletId tablet_id, SchemaHash schema_hash, bool keep_files = false);
-
-    // Prevent schema change executed concurrently.
-    bool try_schema_change_lock(TTabletId tablet_id);
-    void release_schema_change_lock(TTabletId tablet_id);
-
-    // 获取所有tables的名字
-    //
-    // Return OLAP_SUCCESS, if run ok
-    //        OLAP_ERR_INPUT_PARAMETER_ERROR, if tables is null
-    OLAPStatus report_tablet_info(TTabletInfo* tablet_info);
-    OLAPStatus report_all_tablets_info(std::map<TTabletId, TTablet>* tablets_info);
-
-    void get_tablet_stat(TTabletStatResult& result);
 
     // Instance should be inited from create_instance
     // MUST NOT be called in other circumstances.
@@ -195,18 +152,6 @@ public:
         return _store_map.size();
     }
 
-    // @brief 创建snapshot
-    // @param tablet_id [in] 原表的id
-    // @param schema_hash [in] 原表的schema，与tablet_id参数合起来唯一确定一张表
-    // @param snapshot_path [out] 新生成的snapshot的路径
-    OLAPStatus make_snapshot(
-            const TSnapshotRequest& request,
-            std::string* snapshot_path);
-
-    // @brief 释放snapshot
-    // @param snapshot_path [in] 要被释放的snapshot的路径，只包含到ID
-    OLAPStatus release_snapshot(const std::string& snapshot_path);
-
     // @brief 迁移数据，从一种存储介质到另一种存储介质
     OLAPStatus storage_medium_migrate(
             TTabletId tablet_id,
@@ -217,64 +162,8 @@ public:
 
     void add_unused_index(SegmentGroup* olap_index);
 
-    // ######################### ALTER TABLE BEGIN #########################
-    // The following interfaces are all about alter tablet operation, 
-    // the main logical is that generating a new tablet with different
-    // schema on base tablet.
-    
-    // Create rollup tablet on base tablet, after create_rollup_tablet,
-    // both base tablet and new tablet is effective.
-    //
-    // @param [in] request specify base tablet, new tablet and its schema
-    // @return OLAP_SUCCESS if submit success
-    OLAPStatus create_rollup_tablet(const TAlterTabletReq& request);
-
-    // Do schema change on tablet, StorageEngine support
-    // add column, drop column, alter column type and order,
-    // after schema_change, base tablet is abandoned.
-    // Note that the two tablets has same tablet_id but different schema_hash
-    // 
-    // @param [in] request specify base tablet, new tablet and its schema
-    // @return OLAP_SUCCESS if submit success
-    OLAPStatus schema_change(const TAlterTabletReq& request);
-
-    // Show status of all alter tablet operation.
-    // 
-    // @param [in] tablet_id & schema_hash specify a tablet
-    // @return alter tablet status
-    AlterTableStatus show_alter_tablet_status(TTabletId tablet_id, TSchemaHash schema_hash);
-
-    OLAPStatus compute_checksum(
-        TTabletId tablet_id,
-        TSchemaHash schema_hash,
-        TVersion version,
-        TVersionHash version_hash,
-        uint32_t* checksum);
-
-    OLAPStatus cancel_delete(const TCancelDeleteDataReq& request);
-
-    // Delete data of specified tablet according to delete conditions,
-    // once delete_data command submit success, deleted data is not visible,
-    // but not actually deleted util delay_delete_time run out.
-    //
-    // @param [in] request specify tablet and delete conditions
-    // @param [out] tablet_info_vec return tablet lastest status, which
-    //              include version info, row count, data size, etc
-    // @return OLAP_SUCCESS if submit delete_data success
-    virtual OLAPStatus delete_data(
-            const TPushReq& request,
-            std::vector<TTabletInfo>* tablet_info_vec);
-
     OLAPStatus recover_tablet_until_specfic_version(
         const TRecoverTabletReq& recover_tablet_req);
-
-    // before doing incremental clone,
-    // need to calculate tablet's download dir and tablet's missing versions
-    virtual std::string get_info_before_incremental_clone(TabletSharedPtr tablet,
-        int64_t committed_version, std::vector<Version>* missing_versions);
-
-    virtual OLAPStatus finish_clone(TabletSharedPtr tablet, const std::string& clone_dir,
-                                    int64_t committed_version, bool is_incremental_clone);
 
     // Obtain shard path for new tablet.
     //
@@ -292,6 +181,7 @@ public:
     // @return OLAP_SUCCESS if load tablet success
     virtual OLAPStatus load_header(
         const std::string& shard_path, const TCloneReq& request);
+        
     virtual OLAPStatus load_header(
         DataDir* store,
             const std::string& shard_path,
@@ -300,9 +190,6 @@ public:
 
     OLAPStatus clear_alter_task(const TTabletId tablet_id,
                                 const TSchemaHash schema_hash);
-    OLAPStatus push(
-        const TPushReq& request,
-        std::vector<TTabletInfo>* tablet_info_vec);
 
     // call this if you want to trigger a disk and tablet report
     void report_notify(bool is_all) {
@@ -318,8 +205,6 @@ public:
                     _is_report_disk_state_already = true;
         }
     }
-
-    TabletManager* get_tablet_mgr() { return &_tablet_mgr; }
 
 private:
     OLAPStatus check_all_root_path_cluster_id();
@@ -339,77 +224,6 @@ private:
     void _update_storage_medium_type_count();
 
     OLAPStatus _judge_and_update_effective_cluster_id(int32_t cluster_id);
-
-    OLAPStatus _calc_snapshot_id_path(
-            const TabletSharedPtr& tablet,
-            std::string* out_path);
-
-    std::string _get_schema_hash_full_path(
-            const TabletSharedPtr& ref_tablet,
-            const std::string& location) const;
-
-    std::string _get_header_full_path(
-            const TabletSharedPtr& ref_tablet,
-            const std::string& schema_hash_path) const;
-
-    void _update_header_file_info(
-            const std::vector<VersionEntity>& shortest_version_entity,
-            TabletMeta* header);
-
-    // TODO: hkp
-    // rewrite this function
-    OLAPStatus _link_index_and_data_files(
-            const std::string& header_path,
-            const TabletSharedPtr& ref_tablet,
-            const std::vector<VersionEntity>& version_entity_vec);
-
-    // TODO: hkp
-    // rewrite this function
-    OLAPStatus _copy_index_and_data_files(
-            const std::string& header_path,
-            const TabletSharedPtr& ref_tablet,
-            std::vector<VersionEntity>& version_entity_vec);
-
-    OLAPStatus _create_snapshot_files(
-            const TabletSharedPtr& ref_tablet,
-            const TSnapshotRequest& request,
-            std::string* snapshot_path);
-
-    OLAPStatus _create_incremental_snapshot_files(
-           const TabletSharedPtr& ref_tablet,
-           const TSnapshotRequest& request,
-           std::string* snapshot_path);
-
-    OLAPStatus _prepare_snapshot_dir(const TabletSharedPtr& ref_tablet,
-           std::string* snapshot_id_path);
-
-    OLAPStatus _append_single_delta(
-            const TSnapshotRequest& request,
-            DataDir* store);
-
-    // TODO: hkp
-    // rewrite this function
-    std::string _construct_index_file_path(
-            const std::string& tablet_path_prefix,
-            const Version& version,
-            VersionHash version_hash,
-            int32_t segment_group_id, int32_t segment) const;
-
-    // TODO: hkp
-    // rewrite this function
-    std::string _construct_data_file_path(
-            const std::string& tablet_path_prefix,
-            const Version& version,
-            VersionHash version_hash,
-            int32_t segment_group_id, int32_t segment) const;
-
-    OLAPStatus _generate_new_header(
-            DataDir* store,
-            const uint64_t new_shard,
-            const TabletSharedPtr& tablet,
-            const std::vector<VersionEntity>& version_entity_vec, TabletMeta* new_tablet_meta);
-
-    OLAPStatus _create_hard_link(const std::string& from_path, const std::string& to_path);
 
     OLAPStatus _start_bg_worker();
 
@@ -495,10 +309,6 @@ private:
 
     static StorageEngine* _s_instance;
 
-    // snapshot
-    Mutex _snapshot_mutex;
-    uint64_t _snapshot_base_id;
-
     std::unordered_map<SegmentGroup*, std::vector<std::string>> _gc_files;
     Mutex _gc_mutex;
 
@@ -526,8 +336,6 @@ private:
     std::condition_variable _report_cv;
     std::atomic_bool _is_report_disk_state_already;
     std::atomic_bool _is_report_tablet_already;
-    TxnManager _txn_mgr;
-    TabletManager _tablet_mgr;
 };
 
 }  // namespace doris

--- a/be/src/olap/tablet.h
+++ b/be/src/olap/tablet.h
@@ -286,10 +286,7 @@ public:
     uint32_t segment_size() const;
     void set_io_error();
     RowsetSharedPtr rowset_with_largest_size();
-<<<<<<< HEAD
     SegmentGroup* get_largest_index();
-=======
-    Rowset* rowset_with_largest_size();
 
     // 清空一个table下的schema_change信息：包括split_talbe以及其他schema_change信息
     //  这里只清理自身的out链，不考虑related的tablet
@@ -314,7 +311,6 @@ private:
     OLAPStatus _unprotect_clear_schema_change_info(AlterTabletType* alter_tablet_type,
                                                 bool only_one,
                                                 bool check_only);
->>>>>>> Move clear schema change info to tablet
 public:
     DataDir* _data_dir;
     TabletState _state;

--- a/be/src/olap/tablet.h
+++ b/be/src/olap/tablet.h
@@ -286,7 +286,35 @@ public:
     uint32_t segment_size() const;
     void set_io_error();
     RowsetSharedPtr rowset_with_largest_size();
+<<<<<<< HEAD
     SegmentGroup* get_largest_index();
+=======
+    Rowset* rowset_with_largest_size();
+
+    // 清空一个table下的schema_change信息：包括split_talbe以及其他schema_change信息
+    //  这里只清理自身的out链，不考虑related的tablet
+    // NOTE 需要外部lock header
+    // Params:
+    //   alter_tablet_type
+    //     为NULL时，同时检查table_split和其他普通schema_change
+    //               否则只检查指定type的信息
+    //   only_one:
+    //     为true时：如果其out链只有一个，且可删除，才可能进行clear
+    //     为false时：如果发现有大于1个out链，不管是否可删除，都不进行删除
+    //   check_only:
+    //     检查通过也不删除schema
+    // Returns:
+    //  成功：有的都可以清理（没有就直接跳过）
+    //  失败：如果有信息但不能清理（有version没完成）,或不符合only_one条件
+    OLAPStatus clear_schema_change_info(AlterTabletType* alter_tablet_type,
+                                                bool only_one,
+                                                bool check_only);
+private:
+
+    OLAPStatus _unprotect_clear_schema_change_info(AlterTabletType* alter_tablet_type,
+                                                bool only_one,
+                                                bool check_only);
+>>>>>>> Move clear schema change info to tablet
 public:
     DataDir* _data_dir;
     TabletState _state;

--- a/be/src/olap/tablet_manager.h
+++ b/be/src/olap/tablet_manager.h
@@ -52,7 +52,6 @@ class DataDir;
 // TabletManager provides get,add, delete tablet method for storage engine
 class TabletManager {
 public:
-    TabletManager();
     ~TabletManager() {
         _tablet_map.clear();
         _global_tablet_id = 0;
@@ -91,18 +90,6 @@ public:
                               const bool is_schema_change_tablet,
                               const TabletSharedPtr ref_tablet, 
                               std::vector<DataDir*> stores);
-
-    // ######################### ALTER TABLE BEGIN #########################
-    // The following interfaces are all about alter tablet operation, 
-    // the main logical is that generating a new tablet with different
-    // schema on base tablet.
-    
-    // Create rollup tablet on base tablet, after create_rollup_tablet,
-    // both base tablet and new tablet is effective.
-    //
-    // @param [in] request specify base tablet, new tablet and its schema
-    // @return OLAP_SUCCESS if submit success
-    OLAPStatus create_rollup_tablet(const TAlterTabletReq& request);
 
     // Show status of all alter tablet operation.
     // 
@@ -157,7 +144,11 @@ public:
 
     void update_storage_medium_type_count(uint32_t storage_medium_type_count);
 
+    static TabletManager* instance();
+
 private:
+    TabletManager();
+    
     void _build_tablet_info(TabletSharedPtr tablet, TTabletInfo* tablet_info);
     
     void _build_tablet_stat();
@@ -196,6 +187,10 @@ private:
     int64_t _tablet_stat_cache_update_time_ms;
 
     uint32_t _available_storage_medium_type_count;
+
+    // singleton
+    static TabletManager* _s_instance;
+    static std::mutex _mlock;
 };
 
 }  // namespace doris

--- a/be/src/olap/task/engine_cancel_delete_task.cpp
+++ b/be/src/olap/task/engine_cancel_delete_task.cpp
@@ -1,0 +1,78 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "olap/task/engine_cancel_delete_task.h"
+
+namespace doris {
+
+EngineCancelDeleteTask(const TCancelDeleteDataReq& request):_request(request) {
+
+}
+
+OLAPStatus EngineCancelDeleteTask::execute() {
+    return _cancel_delete();
+} // execute
+
+OLAPStatus EngineCancelDeleteTask::_cancel_delete() {
+    LOG(INFO) << "begin to process cancel delete."
+              << "tablet=" << _request.tablet_id
+              << ", version=" << _request.version;
+
+    DorisMetrics::cancel_delete_requests_total.increment(1);
+
+    OLAPStatus res = OLAP_SUCCESS;
+
+    // 1. Get all tablets with same tablet_id
+    list<TabletSharedPtr> table_list;
+    res = TabletManager::instance()->get_tablets_by_id(_request.tablet_id, &table_list);
+    if (res != OLAP_SUCCESS) {
+        OLAP_LOG_WARNING("can't find tablet. [tablet=%ld]", _request.tablet_id);
+        return OLAP_ERR_TABLE_NOT_FOUND;
+    }
+
+    // 2. Remove delete conditions from each tablet.
+    DeleteConditionHandler cond_handler;
+    for (TabletSharedPtr temp_tablet : table_list) {
+        temp_tablet->obtain_header_wrlock();
+        res = cond_handler.delete_cond(temp_tablet, _request.version, false);
+        if (res != OLAP_SUCCESS) {
+            temp_tablet->release_header_lock();
+            OLAP_LOG_WARNING("cancel delete failed. [res=%d tablet=%s]",
+                             res, temp_tablet->full_name().c_str());
+            break;
+        }
+
+        res = temp_tablet->save_tablet_meta();
+        if (res != OLAP_SUCCESS) {
+            temp_tablet->release_header_lock();
+            OLAP_LOG_WARNING("fail to save header. [res=%d tablet=%s]",
+                             res, temp_tablet->full_name().c_str());
+            break;
+        }
+        temp_tablet->release_header_lock();
+    }
+
+    // Show delete conditions in tablet header.
+    for (TabletSharedPtr tablet : table_list) {
+        cond_handler.log_conds(tablet);
+    }
+
+    LOG(INFO) << "finish to process cancel delete. res=" << res;
+    return res;
+} //_cancel_delete
+
+} // doris

--- a/be/src/olap/task/engine_cancel_delete_task.h
+++ b/be/src/olap/task/engine_cancel_delete_task.h
@@ -1,0 +1,47 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#ifndef DORIS_BE_SRC_OLAP_TASK_ENGINE_CANCEL_DELETE_TASK_H
+#define DORIS_BE_SRC_OLAP_TASK_ENGINE_CANCEL_DELETE_TASK_H
+
+#include "gen_cpp/AgentService_types.h"
+#include "olap/olap_define.h"
+#include "olap/task/engine_task.h"
+
+namespace doris {
+
+// base class for storage engine
+// add "Engine" as task prefix to prevent duplicate name with agent task
+class EngineCancelDeleteTask : public EngineTask {
+
+public:
+    virtual OLAPStatus execute();
+
+public:
+    EngineCancelDeleteTask(const TCancelDeleteDataReq& request);
+    ~EngineCancelDeleteTask() {}
+
+private:
+    OLAPStatus _cancel_delete(const TCancelDeleteDataReq& request);
+
+private:
+    TCancelDeleteDataReq& _request;
+
+}; // EngineTask
+
+} // doris
+#endif //DORIS_BE_SRC_OLAP_TASK_ENGINE_CANCEL_DELETE_TASK_H

--- a/be/src/olap/task/engine_checksum_task.cpp
+++ b/be/src/olap/task/engine_checksum_task.cpp
@@ -1,0 +1,123 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "olap/task/engine_checksum_task.h"
+
+namespace doris {
+
+EngineChecksumTask(TTabletId tablet_id, TSchemaHash schema_hash, 
+        TVersion version, TVersionHash version_hash, uint32_t* checksum)
+        :_tablet_id(tablet_id),
+         _schema_hash(schema_hash),
+         _version(version),
+         _version_hash(version_hash),
+         _checksum(checksum) {
+
+}
+
+OLAPStatus EngineChecksumTask::execute() {
+    return _compute_checksum();
+} // execute
+
+
+OLAPStatus StorageEngine::_compute_checksum() {
+    LOG(INFO) << "begin to process compute checksum."
+              << "tablet_id=" << _tablet_id
+              << ", schema_hash=" << _schema_hash
+              << ", version=" << _version;
+    OLAPStatus res = OLAP_SUCCESS;
+
+    if (_checksum == NULL) {
+        OLAP_LOG_WARNING("invalid output parameter which is null pointer.");
+        return OLAP_ERR_CE_CMD_PARAMS_ERROR;
+    }
+
+    TabletSharedPtr tablet = TabletManager::instance()->get_tablet(_tablet_id, _schema_hash);
+    if (NULL == tablet.get()) {
+        OLAP_LOG_WARNING("can't find tablet. [tablet_id=%ld schema_hash=%d]",
+                         _tablet_id, _schema_hash);
+        return OLAP_ERR_TABLE_NOT_FOUND;
+    }
+
+    {
+        ReadLock rdlock(tablet->get_header_lock_ptr());
+        const PDelta* message = tablet->lastest_version();
+        if (message == NULL) {
+            LOG(FATAL) << "fail to get latest version. tablet_id=" << _tablet_id;
+            return OLAP_ERR_VERSION_NOT_EXIST;
+        }
+
+        if (message->end_version() == _version
+                && message->version_hash() != _version_hash) {
+            OLAP_LOG_WARNING("fail to check latest version hash. "
+                             "[res=%d tablet_id=%ld version_hash=%ld request_version_hash=%ld]",
+                             res, _tablet_id, message->version_hash(), _version_hash);
+            return OLAP_ERR_CE_CMD_PARAMS_ERROR;
+        }
+    }
+
+    Reader reader;
+    ReaderParams reader_params;
+    reader_params.tablet = tablet;
+    reader_params.reader_type = READER_CHECKSUM;
+    reader_params.version = Version(0, _version);
+
+    // ignore float and double type considering to precision lose
+    for (size_t i = 0; i < tablet->tablet_schema().size(); ++i) {
+        FieldType type = tablet->get_field_type_by_index(i);
+        if (type == OLAP_FIELD_TYPE_FLOAT || type == OLAP_FIELD_TYPE_DOUBLE) {
+            continue;
+        }
+
+        reader_params.return_columns.push_back(i);
+    }
+
+    res = reader.init(reader_params);
+    if (res != OLAP_SUCCESS) {
+        OLAP_LOG_WARNING("initiate reader fail. [res=%d]", res);
+        return res;
+    }
+
+    RowCursor row;
+    res = row.init(tablet->tablet_schema(), reader_params.return_columns);
+    if (res != OLAP_SUCCESS) {
+        OLAP_LOG_WARNING("failed to init row cursor. [res=%d]", res);
+        return res;
+    }
+    row.allocate_memory_for_string_type(tablet->tablet_schema());
+
+    bool eof = false;
+    uint32_t row_checksum = 0;
+    while (true) {
+        OLAPStatus res = reader.next_row_with_aggregation(&row, &eof);
+        if (res == OLAP_SUCCESS && eof) {
+            VLOG(3) << "reader reads to the end.";
+            break;
+        } else if (res != OLAP_SUCCESS) {
+            OLAP_LOG_WARNING("fail to read in reader. [res=%d]", res);
+            return res;
+        }
+
+        row_checksum = row.hash_code(row_checksum);
+    }
+
+    LOG(INFO) << "success to finish compute checksum. checksum=" << row_checksum;
+    *_checksum = row_checksum;
+    return OLAP_SUCCESS;
+}
+
+} // doris

--- a/be/src/olap/task/engine_checksum_task.h
+++ b/be/src/olap/task/engine_checksum_task.h
@@ -1,0 +1,54 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#ifndef DORIS_BE_SRC_OLAP_TASK_ENGINE_CHECKSUM_TASK_H
+#define DORIS_BE_SRC_OLAP_TASK_ENGINE_CHECKSUM_TASK_H
+
+#include "gen_cpp/AgentService_types.h"
+#include "olap/olap_define.h"
+#include "olap/task/engine_task.h"
+
+namespace doris {
+
+// base class for storage engine
+// add "Engine" as task prefix to prevent duplicate name with agent task
+class EngineChecksumTask : public EngineTask {
+
+public:
+    virtual OLAPStatus execute();
+
+public:
+    EngineChecksumTask(TTabletId tablet_id, TSchemaHash schema_hash, 
+        TVersion version,
+        TVersionHash version_hash,
+        uint32_t* checksum);
+
+    ~EngineChecksumTask() {}
+
+private:
+    OLAPStatus _compute_checksum();
+
+private:
+    TTabletId _tablet_id;
+    TSchemaHash _schema_hash; 
+    TVersion _version;
+    TVersionHash _version_hash;
+    uint32_t* _checksum;
+}; // EngineTask
+
+} // doris
+#endif //DORIS_BE_SRC_OLAP_TASK_ENGINE_CHECKSUM_TASK_H

--- a/be/src/olap/task/engine_clone_task.cpp
+++ b/be/src/olap/task/engine_clone_task.cpp
@@ -1,0 +1,823 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "olap/task/engine_clone_task.h"
+
+namespace doris {
+
+EngineCloneTask(TCloneReq& _clone_req, vector<string>& error_msgs) :
+    _clone_req(clone_req),
+    _error_msgs(error_msgs), 
+    _tablet_infos(tablet_infos) {}
+
+OLAPStatus EngineCloneTask::execute() {
+    string src_file_path;
+    TBackend src_host;
+    // Check local tablet exist or not
+    TabletSharedPtr tablet =
+            TabletManager::instance()->get_tablet(
+            _clone_req.tablet_id, _clone_req.schema_hash);
+    if (tablet.get() != NULL) {
+        LOG(INFO) << "clone tablet exist yet, begin to incremental clone. "
+                    << "signature:" << agent_task_req.signature
+                    << ", tablet_id:" << _clone_req.tablet_id
+                    << ", schema_hash:" << _clone_req.schema_hash
+                    << ", committed_version:" << _clone_req.committed_version;
+
+        // try to incremental clone
+        vector<Version> missing_versions;
+        string local_data_path = _get_info_before_incremental_clone(tablet, _clone_req.committed_version, &missing_versions);
+
+        bool allow_incremental_clone = false;
+        status = _clone_copy(clone_req,
+                                                agent_task_req.signature,
+                                                local_data_path,
+                                                &src_host,
+                                                &src_file_path,
+                                                &_error_msgs,
+                                                &missing_versions,
+                                                &allow_incremental_clone);
+        if (status == DORIS_SUCCESS) {
+            OLAPStatus olap_status = _finish_clone(tablet, local_data_path, _clone_req.committed_version, allow_incremental_clone);
+            if (olap_status != OLAP_SUCCESS) {
+                LOG(WARNING) << "failed to finish incremental clone. [table=" << tablet->full_name()
+                                << " res=" << olap_status << "]";
+                _error_msgs.push_back("incremental clone error.");
+                status = DORIS_ERROR;
+            }
+        } else {
+            // begin to full clone if incremental failed
+            LOG(INFO) << "begin to full clone. [table=" << tablet->full_name();
+            status = _clone_copy(clone_req,
+                                                    agent_task_req.signature,
+                                                    local_data_path,
+                                                    &src_host,
+                                                    &src_file_path,
+                                                    &_error_msgs,
+                                                    NULL, NULL);
+            if (status == DORIS_SUCCESS) {
+                LOG(INFO) << "download successfully when full clone. [table=" << tablet->full_name()
+                            << " src_host=" << src_host.host << " src_file_path=" << src_file_path
+                            << " local_data_path=" << local_data_path << "]";
+
+                OLAPStatus olap_status = _finish_clone(tablet, local_data_path, _clone_req.committed_version, false);
+
+                if (olap_status != OLAP_SUCCESS) {
+                    LOG(WARNING) << "fail to finish full clone. [table=" << tablet->full_name()
+                                    << " res=" << olap_status << "]";
+                    _error_msgs.push_back("full clone error.");
+                    status = DORIS_ERROR;
+                }
+            }
+        }
+    } else {
+
+        // Get local disk from olap
+        string local_shard_root_path;
+        DataDir* store = nullptr;
+        OLAPStatus olap_status = worker_pool_this->_env->olap_engine()->obtain_shard_path(
+            _clone_req.storage_medium, &local_shard_root_path, &store);
+        if (olap_status != OLAP_SUCCESS) {
+            OLAP_LOG_WARNING("clone get local root path failed. signature: %ld",
+                                agent_task_req.signature);
+            _error_msgs.push_back("clone get local root path failed.");
+            status = DORIS_ERROR;
+        }
+
+        if (status == DORIS_SUCCESS) {
+            stringstream tablet_dir_stream;
+            tablet_dir_stream << local_shard_root_path
+                                << "/" << _clone_req.tablet_id
+                                << "/" << _clone_req.schema_hash;
+            status = _clone_copy(clone_req,
+                                                    agent_task_req.signature,
+                                                    tablet_dir_stream.str(),
+                                                    &src_host,
+                                                    &src_file_path,
+                                                    &_error_msgs,
+                                                    NULL, NULL);
+        }
+
+        if (status == DORIS_SUCCESS) {
+            LOG(INFO) << "clone copy done. src_host: " << src_host.host
+                        << " src_file_path: " << src_file_path;
+            // Load header
+            OLAPStatus load_header_status =
+                worker_pool_this->_env->olap_engine()->load_header(
+                    store,
+                    local_shard_root_path,
+                    _clone_req.tablet_id,
+                    _clone_req.schema_hash);
+            if (load_header_status != OLAP_SUCCESS) {
+                LOG(WARNING) << "load header failed. local_shard_root_path: '" << local_shard_root_path
+                                << "' schema_hash: " << _clone_req.schema_hash << ". status: " << load_header_status
+                                << ". signature: " << agent_task_req.signature;
+                _error_msgs.push_back("load header failed.");
+                status = DORIS_ERROR;
+            }
+        }
+
+#ifndef BE_TEST
+        // Clean useless dir, if failed, ignore it.
+        if (status != DORIS_SUCCESS && status != DORIS_CREATE_TABLE_EXIST) {
+            stringstream local_data_path_stream;
+            local_data_path_stream << local_shard_root_path
+                                    << "/" << _clone_req.tablet_id;
+            string local_data_path = local_data_path_stream.str();
+            LOG(INFO) << "clone failed. want to delete local dir: " << local_data_path
+                        << ". signature: " << agent_task_req.signature;
+            try {
+                boost::filesystem::path local_path(local_data_path);
+                if (boost::filesystem::exists(local_path)) {
+                    boost::filesystem::remove_all(local_path);
+                }
+            } catch (boost::filesystem::filesystem_error e) {
+                // Ignore the error, OLAP will delete it
+                OLAP_LOG_WARNING("clone delete useless dir failed. "
+                                    "error: %s, local dir: %s, signature: %ld",
+                                    e.what(), local_data_path.c_str(),
+                                    agent_task_req.signature);
+            }
+        }
+#endif
+    }
+
+    // Get clone tablet info
+    if (status == DORIS_SUCCESS || status == DORIS_CREATE_TABLE_EXIST) {
+        TTabletInfo tablet_info;
+        tablet_info.__set_tablet_id(tablet_id);
+        tablet_info.__set_schema_hash(schema_hash);
+        OLAPStatus get_tablet_info_status = TabletManager::instance()->report_tablet_info(tablet_info);
+        if (get_tablet_info_status != OLAP_SUCCESS) {
+            OLAP_LOG_WARNING("clone success, but get tablet info failed."
+                                "tablet id: %ld, schema hash: %ld, signature: %ld",
+                                _clone_req.tablet_id, _clone_req.schema_hash,
+                                agent_task_req.signature);
+            _error_msgs.push_back("clone success, but get tablet info failed.");
+            status = DORIS_ERROR;
+        } else if (
+            (clone_req.__isset.committed_version
+                    && _clone_req.__isset.committed_version_hash)
+                    && (tablet_info.version < _clone_req.committed_version ||
+                        (tablet_info.version == _clone_req.committed_version
+                        && tablet_info.version_hash != _clone_req.committed_version_hash))) {
+
+            // we need to check if this cloned table's version is what we expect.
+            // if not, maybe this is a stale remaining table which is waiting for drop.
+            // we drop it.
+            LOG(INFO) << "begin to drop the stale table. tablet_id:" << _clone_req.tablet_id
+                        << ", schema_hash:" << _clone_req.schema_hash
+                        << ", signature:" << agent_task_req.signature
+                        << ", version:" << tablet_info.version
+                        << ", version_hash:" << tablet_info.version_hash
+                        << ", expected_version: " << _clone_req.committed_version
+                        << ", version_hash:" << _clone_req.committed_version_hash;
+            AgentStatus status = DORIS_SUCCESS;
+            OLAPStatus drop_status = TabletManager::instance()->drop_tablet(_clone_req.tablet_id, _clone_req.schema_hash);
+            if (drop_status != OLAP_SUCCESS && drop_status != OLAP_ERR_TABLE_NOT_FOUND) {
+                // just log
+                OLAP_LOG_WARNING(
+                    "drop stale cloned table failed! tabelt id: %ld", _clone_req.tablet_id);
+            }
+
+            status = DORIS_ERROR;
+        } else {
+            LOG(INFO) << "clone get tablet info success. tablet_id:" << _clone_req.tablet_id
+                        << ", schema_hash:" << _clone_req.schema_hash
+                        << ", signature:" << agent_task_req.signature
+                        << ", version:" << tablet_info.version
+                        << ", version_hash:" << tablet_info.version_hash;
+            _tablet_infos.push_back(tablet_info);
+        }
+    }
+}
+
+string EngineCloneTask::_get_info_before_incremental_clone(TabletSharedPtr tablet,
+    int64_t committed_version, vector<Version>* missing_versions) {
+
+    // get missing versions
+    tablet->obtain_header_rdlock();
+    tablet->get_missing_versions_with_header_locked(committed_version, missing_versions);
+
+    // get least complete version
+    // prevent lastest version not replaced (if need to rewrite) after node restart
+    const PDelta* least_complete_version = tablet->least_complete_version(*missing_versions);
+    if (least_complete_version != NULL) {
+        // TODO: Used in upgraded. If old Doris version, version can be converted.
+        Version version(least_complete_version->start_version(), least_complete_version->end_version()); 
+        missing_versions->push_back(version);
+        LOG(INFO) << "least complete version for incremental clone. tablet=" << tablet->full_name()
+                  << ", least_complete_version=" << least_complete_version->end_version();
+    }
+
+    tablet->release_header_lock();
+    LOG(INFO) << "finish to calculate missing versions when clone. [tablet=" << tablet->full_name()
+              << ", committed_version=" << committed_version << " missing_versions_size=" << missing_versions->size() << "]";
+
+    // get download path
+    return tablet->tablet_path() + CLONE_PREFIX;
+}
+
+OLAPStatus EngineCloneTask::_clone_copy(
+        const TCloneReq& clone_req,
+        int64_t signature,
+        const string& local_data_path,
+        TBackend* src_host,
+        string* src_file_path,
+        vector<string>* error_msgs,
+        const vector<Version>* missing_versions,
+        bool* allow_incremental_clone) {
+    OLAPStatus status = OLAP_SUCCESS;
+
+    std::string token = _master_info.token;
+    for (auto src_backend : clone_req.src_backends) {
+        stringstream http_host_stream;
+        http_host_stream << "http://" << src_backend.host << ":" << src_backend.http_port;
+        string http_host = http_host_stream.str();
+        // Make snapshot in remote olap engine
+        *src_host = src_backend;
+#ifndef BE_TEST
+        AgentServerClient agent_client(*src_host);
+#endif
+        TAgentResult make_snapshot_result;
+        status = DORIS_SUCCESS;
+
+        LOG(INFO) << "pre make snapshot. backend_ip: " << src_host->host;
+        TSnapshotRequest snapshot_request;
+        snapshot_request.__set_tablet_id(clone_req.tablet_id);
+        snapshot_request.__set_schema_hash(clone_req.schema_hash);
+        if (missing_versions != NULL) {
+            // TODO: missing version composed of singleton delta.
+            // if not, this place should be rewrote.
+            vector<int64_t> snapshot_versions;
+            for (Version version : *missing_versions) {
+               snapshot_versions.push_back(version.first); 
+            } 
+            snapshot_request.__set_missing_version(snapshot_versions);
+        }
+#ifndef BE_TEST
+        agent_client.make_snapshot(
+                snapshot_request,
+                &make_snapshot_result);
+#else
+        _agent_client->make_snapshot(
+                snapshot_request,
+                &make_snapshot_result);
+#endif
+
+        if (make_snapshot_result.__isset.allow_incremental_clone) {
+            // During upgrading, some BE nodes still be installed an old previous old.
+            // which incremental clone is not ready in those nodes.
+            // should add a symbol to indicate it.
+            *allow_incremental_clone = make_snapshot_result.allow_incremental_clone;
+        }
+        if (make_snapshot_result.status.status_code == TStatusCode::OK) {
+            if (make_snapshot_result.__isset.snapshot_path) {
+                *src_file_path = make_snapshot_result.snapshot_path;
+                if (src_file_path->at(src_file_path->length() - 1) != '/') {
+                    src_file_path->append("/");
+                }
+                LOG(INFO) << "make snapshot success. backend_ip: " << src_host->host << ". src_file_path: "
+                          << *src_file_path << ". signature: " << signature;
+            } else {
+                OLAP_LOG_WARNING("clone make snapshot success, "
+                                 "but get src file path failed. signature: %ld",
+                                 signature);
+                status = DORIS_ERROR;
+                continue;
+            }
+        } else {
+            LOG(WARNING) << "make snapshot failed. tablet_id: " << clone_req.tablet_id
+                         << ". schema_hash: " << clone_req.schema_hash << ". backend_ip: " << src_host->host
+                         << ". backend_port: " << src_host->be_port << ". signature: " << signature;
+            error_msgs->push_back("make snapshot failed. backend_ip: " + src_host->host);
+            status = DORIS_ERROR;
+            continue;
+        }
+
+        // Get remote and local full path
+        stringstream src_file_full_path_stream;
+        stringstream local_file_full_path_stream;
+
+        if (status == DORIS_SUCCESS) {
+            src_file_full_path_stream << *src_file_path
+                                      << "/" << clone_req.tablet_id
+                                      << "/" << clone_req.schema_hash << "/";
+            local_file_full_path_stream << local_data_path  << "/";
+        }
+        string src_file_full_path = src_file_full_path_stream.str();
+        string local_file_full_path = local_file_full_path_stream.str();
+
+#ifndef BE_TEST
+        // Check local path exist, if exist, remove it, then create the dir
+        if (status == DORIS_SUCCESS) {
+            boost::filesystem::path local_file_full_dir(local_file_full_path);
+            if (boost::filesystem::exists(local_file_full_dir)) {
+                boost::filesystem::remove_all(local_file_full_dir);
+            }
+            boost::filesystem::create_directories(local_file_full_dir);
+        }
+#endif
+
+        // Get remove dir file list
+        FileDownloader::FileDownloaderParam downloader_param;
+        downloader_param.remote_file_path = http_host + HTTP_REQUEST_PREFIX
+            + HTTP_REQUEST_TOKEN_PARAM + token
+            + HTTP_REQUEST_FILE_PARAM + src_file_full_path;
+        downloader_param.curl_opt_timeout = LIST_REMOTE_FILE_TIMEOUT;
+
+#ifndef BE_TEST
+        FileDownloader* file_downloader_ptr = new FileDownloader(downloader_param);
+        if (file_downloader_ptr == NULL) {
+            OLAP_LOG_WARNING("clone copy create file downloader failed. try next backend");
+            status = DORIS_ERROR;
+        }
+#endif
+
+        string file_list_str;
+        AgentStatus download_status = DORIS_SUCCESS;
+        uint32_t download_retry_time = 0;
+        while (status == DORIS_SUCCESS && download_retry_time < DOWNLOAD_FILE_MAX_RETRY) {
+#ifndef BE_TEST
+            download_status = file_downloader_ptr->list_file_dir(&file_list_str);
+#else
+            download_status = _file_downloader_ptr->list_file_dir(&file_list_str);
+#endif
+            if (download_status != DORIS_SUCCESS) {
+                OLAP_LOG_WARNING("clone get remote file list failed. backend_ip: %s, "
+                                 "src_file_path: %s, signature: %ld",
+                                 src_host->host.c_str(),
+                                 downloader_param.remote_file_path.c_str(),
+                                 signature);
+                ++download_retry_time;
+#ifndef BE_TEST
+                sleep(download_retry_time);
+#endif
+            } else {
+                break;
+            }
+        }
+
+#ifndef BE_TEST
+        if (file_downloader_ptr != NULL) {
+            delete file_downloader_ptr;
+            file_downloader_ptr = NULL;
+        }
+#endif
+
+        vector<string> file_name_list;
+        if (download_status != DORIS_SUCCESS) {
+            OLAP_LOG_WARNING("clone get remote file list failed over max time. backend_ip: %s, "
+                             "src_file_path: %s, signature: %ld",
+                             src_host->host.c_str(),
+                             downloader_param.remote_file_path.c_str(),
+                             signature);
+            status = DORIS_ERROR;
+        } else {
+            size_t start_position = 0;
+            size_t end_position = file_list_str.find("\n");
+
+            // Split file name from file_list_str
+            while (end_position != string::npos) {
+                string file_name = file_list_str.substr(
+                        start_position, end_position - start_position);
+                // If the header file is not exist, the table could't loaded by olap engine.
+                // Avoid of data is not complete, we copy the header file at last.
+                // The header file's name is end of .hdr.
+                if (file_name.size() > 4 && file_name.substr(file_name.size() - 4, 4) == ".hdr") {
+                    file_name_list.push_back(file_name);
+                } else {
+                    file_name_list.insert(file_name_list.begin(), file_name);
+                }
+
+                start_position = end_position + 1;
+                end_position = file_list_str.find("\n", start_position);
+            }
+            if (start_position != file_list_str.size()) {
+                string file_name = file_list_str.substr(
+                        start_position, file_list_str.size() - start_position);
+                if (file_name.size() > 4 && file_name.substr(file_name.size() - 4, 4) == ".hdr") {
+                    file_name_list.push_back(file_name);
+                } else {
+                    file_name_list.insert(file_name_list.begin(), file_name);
+                }
+            }
+        }
+
+        // Get copy from remote
+        for (auto file_name : file_name_list) {
+            download_retry_time = 0;
+            downloader_param.remote_file_path = http_host + HTTP_REQUEST_PREFIX
+                + HTTP_REQUEST_TOKEN_PARAM + token
+                + HTTP_REQUEST_FILE_PARAM + src_file_full_path + file_name;
+            downloader_param.local_file_path = local_file_full_path + file_name;
+
+            // Get file length
+            uint64_t file_size = 0;
+            uint64_t estimate_time_out = 0;
+
+            downloader_param.curl_opt_timeout = GET_LENGTH_TIMEOUT;
+#ifndef BE_TEST
+            file_downloader_ptr = new FileDownloader(downloader_param);
+            if (file_downloader_ptr == NULL) {
+                OLAP_LOG_WARNING("clone copy create file downloader failed. try next backend");
+                status = DORIS_ERROR;
+                break;
+            }
+#endif
+            while (download_retry_time < DOWNLOAD_FILE_MAX_RETRY) {
+#ifndef BE_TEST
+                download_status = file_downloader_ptr->get_length(&file_size);
+#else
+                download_status = _file_downloader_ptr->get_length(&file_size);
+#endif
+                if (download_status != DORIS_SUCCESS) {
+                    OLAP_LOG_WARNING("clone copy get file length failed. backend_ip: %s, "
+                                     "src_file_path: %s, signature: %ld",
+                                     src_host->host.c_str(),
+                                     downloader_param.remote_file_path.c_str(),
+                                     signature);
+                    ++download_retry_time;
+#ifndef BE_TEST
+                    sleep(download_retry_time);
+#endif
+                } else {
+                    break;
+                }
+            }
+
+#ifndef BE_TEST
+            if (file_downloader_ptr != NULL) {
+                delete file_downloader_ptr;
+                file_downloader_ptr = NULL;
+            }
+#endif
+            if (download_status != DORIS_SUCCESS) {
+                OLAP_LOG_WARNING("clone copy get file length failed over max time. "
+                                 "backend_ip: %s, src_file_path: %s, signature: %ld",
+                                 src_host->host.c_str(),
+                                 downloader_param.remote_file_path.c_str(),
+                                 signature);
+                status = DORIS_ERROR;
+                break;
+            }
+
+            estimate_time_out = file_size / config::download_low_speed_limit_kbps / 1024;
+            if (estimate_time_out < config::download_low_speed_time) {
+                estimate_time_out = config::download_low_speed_time;
+            }
+
+            // Download the file
+            download_retry_time = 0;
+            downloader_param.curl_opt_timeout = estimate_time_out;
+#ifndef BE_TEST
+            file_downloader_ptr = new FileDownloader(downloader_param);
+            if (file_downloader_ptr == NULL) {
+                OLAP_LOG_WARNING("clone copy create file downloader failed. try next backend");
+                status = DORIS_ERROR;
+                break;
+            }
+#endif
+            while (download_retry_time < DOWNLOAD_FILE_MAX_RETRY) {
+#ifndef BE_TEST
+                download_status = file_downloader_ptr->download_file();
+#else
+                download_status = _file_downloader_ptr->download_file();
+#endif
+                if (download_status != DORIS_SUCCESS) {
+                    OLAP_LOG_WARNING("download file failed. backend_ip: %s, "
+                                     "src_file_path: %s, signature: %ld",
+                                     src_host->host.c_str(),
+                                     downloader_param.remote_file_path.c_str(),
+                                     signature);
+                } else {
+                    // Check file length
+                    boost::filesystem::path local_file_path(downloader_param.local_file_path);
+                    uint64_t local_file_size = boost::filesystem::file_size(local_file_path);
+                    if (local_file_size != file_size) {
+                        OLAP_LOG_WARNING("download file length error. backend_ip: %s, "
+                                         "src_file_path: %s, signature: %ld,"
+                                         "remote file size: %d, local file size: %d",
+                                         src_host->host.c_str(),
+                                         downloader_param.remote_file_path.c_str(),
+                                         signature, file_size, local_file_size);
+                        download_status = DORIS_FILE_DOWNLOAD_FAILED;
+                    } else {
+                        chmod(downloader_param.local_file_path.c_str(), S_IRUSR | S_IWUSR);
+                        break;
+                    }
+                }
+                ++download_retry_time;
+#ifndef BE_TEST
+                sleep(download_retry_time);
+#endif
+            } // Try to download a file from remote backend
+
+#ifndef BE_TEST
+            if (file_downloader_ptr != NULL) {
+                delete file_downloader_ptr;
+                file_downloader_ptr = NULL;
+            }
+#endif
+
+            if (download_status != DORIS_SUCCESS) {
+                OLAP_LOG_WARNING("download file failed over max retry. backend_ip: %s, "
+                                 "src_file_path: %s, signature: %ld",
+                                 src_host->host.c_str(),
+                                 downloader_param.remote_file_path.c_str(),
+                                 signature);
+                status = DORIS_ERROR;
+                break;
+            }
+        } // Clone files from remote backend
+
+        // Release snapshot, if failed, ignore it. OLAP engine will drop useless snapshot
+        TAgentResult release_snapshot_result;
+#ifndef BE_TEST
+        agent_client.release_snapshot(
+                make_snapshot_result.snapshot_path,
+                &release_snapshot_result);
+#else
+        _agent_client->release_snapshot(
+                make_snapshot_result.snapshot_path,
+                &release_snapshot_result);
+#endif
+        if (release_snapshot_result.status.status_code != TStatusCode::OK) {
+            LOG(WARNING) << "release snapshot failed. src_file_path: " << *src_file_path
+                         << ". signature: " << signature;
+        }
+
+        if (status == DORIS_SUCCESS) {
+            break;
+        }
+    } // clone copy from one backend
+    return status;
+}
+
+
+OLAPStatus StorageEngine::_finish_clone(TabletSharedPtr tablet, const string& clone_dir,
+                                         int64_t committed_version, bool is_incremental_clone) {
+    OLAPStatus res = OLAP_SUCCESS;
+    vector<string> linked_success_files;
+
+    // clone and compaction operation should be performed sequentially
+    tablet->obtain_base_compaction_lock();
+    tablet->obtain_cumulative_lock();
+
+    tablet->obtain_push_lock();
+    tablet->obtain_header_wrlock();
+    do {
+        // check clone dir existed
+        if (!check_dir_existed(clone_dir)) {
+            res = OLAP_ERR_DIR_NOT_EXIST;
+            OLAP_LOG_WARNING("clone dir not existed when clone. [clone_dir=%s]",
+                             clone_dir.c_str());
+            break;
+        }
+
+        // load src header
+        string clone_header_file = clone_dir + "/" + std::to_string(tablet->tablet_id()) + ".hdr";
+        TabletMeta clone_header(clone_header_file);
+        if ((res = clone_header.load_and_init()) != OLAP_SUCCESS) {
+            OLAP_LOG_WARNING("fail to load src header when clone. [clone_header_file=%s]",
+                             clone_header_file.c_str());
+            break;
+        }
+
+        // check all files in /clone and /tablet
+        set<string> clone_files;
+        if ((res = dir_walk(clone_dir, NULL, &clone_files)) != OLAP_SUCCESS) {
+            LOG(WARNING) << "failed to dir walk when clone. [clone_dir=" << clone_dir << "]";
+            break;
+        }
+
+        set<string> local_files;
+        string tablet_dir = tablet->tablet_path();
+        if ((res = dir_walk(tablet_dir, NULL, &local_files)) != OLAP_SUCCESS) {
+            LOG(WARNING) << "failed to dir walk when clone. [tablet_dir=" << tablet_dir << "]";
+            break;
+        }
+
+        // link files from clone dir, if file exists, skip it
+        for (const string& clone_file : clone_files) {
+            if (local_files.find(clone_file) != local_files.end()) {
+                VLOG(3) << "find same file when clone, skip it. "
+                        << "tablet=" << tablet->full_name()
+                        << ", clone_file=" << clone_file;
+                continue;
+            }
+
+            string from = clone_dir + "/" + clone_file;
+            string to = tablet_dir + "/" + clone_file;
+            LOG(INFO) << "src file:" << from << "dest file:" << to;
+            if (link(from.c_str(), to.c_str()) != 0) {
+                OLAP_LOG_WARNING("fail to create hard link when clone. [from=%s to=%s]",
+                                 from.c_str(), to.c_str());
+                res = OLAP_ERR_OS_ERROR;
+                break;
+            }
+            linked_success_files.emplace_back(std::move(to));
+        }
+
+        if (res != OLAP_SUCCESS) {
+            break;
+        }
+
+        if (is_incremental_clone) {
+            res = _clone_incremental_data(
+                                              tablet, clone_header, committed_version);
+        } else {
+            res = _clone_full_data(tablet, clone_header);
+        }
+
+        // if full clone success, need to update cumulative layer point
+        if (!is_incremental_clone && res == OLAP_SUCCESS) {
+            tablet->set_cumulative_layer_point(clone_header.cumulative_layer_point());
+        }
+
+    } while (0);
+
+    // clear linked files if errors happen
+    if (res != OLAP_SUCCESS) {
+        remove_files(linked_success_files);
+    }
+    tablet->release_header_lock();
+    tablet->release_push_lock();
+
+    tablet->release_cumulative_lock();
+    tablet->release_base_compaction_lock();
+
+    // clear clone dir
+    boost::filesystem::path clone_dir_path(clone_dir);
+    boost::filesystem::remove_all(clone_dir_path);
+    LOG(INFO) << "finish to clone data, clear downloaded data. res=" << res
+              << ", tablet=" << tablet->full_name()
+              << ", clone_dir=" << clone_dir;
+    return res;
+}
+
+
+OLAPStatus EngineCloneTask::_clone_incremental_data(TabletSharedPtr tablet, TabletMeta& clone_header,
+                                              int64_t committed_version) {
+    LOG(INFO) << "begin to incremental clone. tablet=" << tablet->full_name()
+              << ", committed_version=" << committed_version;
+
+    // calculate missing version again
+    vector<Version> missing_versions;
+    tablet->get_missing_versions_with_header_locked(committed_version, &missing_versions);
+
+    // add least complete version
+    // prevent lastest version not replaced (if need to rewrite) when restart
+    const PDelta* least_complete_version = tablet->least_complete_version(missing_versions);
+
+    vector<Version> versions_to_delete;
+    vector<const PDelta*> versions_to_clone;
+
+    // it's not a merged version in principle
+    if (least_complete_version != NULL &&
+        least_complete_version->start_version() == least_complete_version->end_version()) {
+
+        Version version(least_complete_version->start_version(), least_complete_version->end_version());
+        const PDelta* clone_src_version = clone_header.get_incremental_version(version);
+
+        // if least complete version not found in clone src, return error
+        if (clone_src_version == nullptr) {
+            OLAP_LOG_WARNING("failed to find least complete version in clone header. "
+                    "[clone_header_file=%s least_complete_version=%d-%d]",
+                    clone_header.file_name().c_str(),
+                    least_complete_version->start_version(), least_complete_version->end_version());
+            return OLAP_ERR_VERSION_NOT_EXIST;
+
+        // if least complete version_hash in clone src is different, clone it
+        } else if (clone_src_version->version_hash() != least_complete_version->version_hash()) {
+            versions_to_clone.push_back(clone_src_version);
+            versions_to_delete.push_back(Version(
+                least_complete_version->start_version(),
+                least_complete_version->end_version()));
+
+            VLOG(3) << "least complete version_hash in clone src is different, replace it. "
+                    << "tablet=" << tablet->full_name()
+                    << ", least_complete_version=" << least_complete_version->start_version()
+                    << "-" << least_complete_version->end_version()
+                    << ", local_hash=" << least_complete_version->version_hash()
+                    << ", clone_hash=" << clone_src_version->version_hash();
+        }
+    }
+
+    VLOG(3) << "get missing versions again when incremental clone. "
+            << "tablet=" << tablet->full_name() 
+            << ", committed_version=" << committed_version
+            << ", missing_versions_size=" << missing_versions.size();
+
+    // check missing versions exist in clone src
+    for (Version version : missing_versions) {
+        const PDelta* clone_src_version = clone_header.get_incremental_version(version);
+        if (clone_src_version == NULL) {
+           LOG(WARNING) << "missing version not found in clone src."
+                        << "clone_header_file=" << clone_header.file_name()
+                        << ", missing_version=" << version.first << "-" << version.second;
+            return OLAP_ERR_VERSION_NOT_EXIST;
+        }
+
+        versions_to_clone.push_back(clone_src_version);
+    }
+
+    // clone_data to tablet
+    OLAPStatus clone_res = tablet->clone_data(clone_header, versions_to_clone, versions_to_delete);
+    LOG(INFO) << "finish to incremental clone. [tablet=" << tablet->full_name() << " res=" << clone_res << "]";
+    return clone_res;
+}
+
+OLAPStatus EngineCloneTask::_clone_full_data(TabletSharedPtr tablet, TabletMeta& clone_header) {
+    Version clone_latest_version = clone_header.get_latest_version();
+    LOG(INFO) << "begin to full clone. tablet=" << tablet->full_name() << ","
+        << "clone_latest_version=" << clone_latest_version.first << "-" << clone_latest_version.second;
+    vector<Version> versions_to_delete;
+
+    // check local versions
+    for (int i = 0; i < tablet->file_delta_size(); i++) {
+        Version local_version(tablet->get_delta(i)->start_version(),
+                              tablet->get_delta(i)->end_version());
+        VersionHash local_version_hash = tablet->get_delta(i)->version_hash();
+        LOG(INFO) << "check local delta when full clone."
+            << "tablet=" << tablet->full_name()
+            << ", local_version=" << local_version.first << "-" << local_version.second;
+
+        // if local version cross src latest, clone failed
+        if (local_version.first <= clone_latest_version.second
+            && local_version.second > clone_latest_version.second) {
+            LOG(WARNING) << "stop to full clone, version cross src latest."
+                    << "tablet=" << tablet->full_name()
+                    << ", local_version=" << local_version.first << "-" << local_version.second;
+            return OLAP_ERR_TABLE_VERSION_DUPLICATE_ERROR;
+
+        } else if (local_version.second <= clone_latest_version.second) {
+            // if local version smaller than src, check if existed in src, will not clone it
+            bool existed_in_src = false;
+
+            // if delta labeled with local_version is same with the specified version in clone header,
+            // there is no necessity to clone it.
+            for (int j = 0; j < clone_header.file_delta_size(); ++j) {
+                if (clone_header.get_delta(j)->start_version() == local_version.first
+                    && clone_header.get_delta(j)->end_version() == local_version.second
+                    && clone_header.get_delta(j)->version_hash() == local_version_hash) {
+                    existed_in_src = true;
+                    LOG(INFO) << "Delta has already existed in local header, no need to clone."
+                        << "tablet=" << tablet->full_name()
+                        << ", version='" << local_version.first<< "-" << local_version.second
+                        << ", version_hash=" << local_version_hash;
+
+                    OLAPStatus delete_res = clone_header.delete_version(local_version);
+                    if (delete_res != OLAP_SUCCESS) {
+                        LOG(WARNING) << "failed to delete existed version from clone src when full clone. "
+                                  << "clone_header_file=" << clone_header.file_name()
+                                  << "version=" << local_version.first << "-" << local_version.second;
+                        return delete_res;
+                    }
+                    break;
+                }
+            }
+
+            // Delta labeled in local_version is not existed in clone header,
+            // some overlapping delta will be cloned to replace it.
+            // And also, the specified delta should deleted from local header.
+            if (!existed_in_src) {
+                versions_to_delete.push_back(local_version);
+                LOG(INFO) << "Delete delta not included by the clone header, should delete it from local header."
+                          << "tablet=" << tablet->full_name() << ","
+                          << ", version=" << local_version.first<< "-" << local_version.second
+                          << ", version_hash=" << local_version_hash;
+            }
+        }
+    }
+    vector<const PDelta*> clone_deltas;
+    for (int i = 0; i < clone_header.file_delta_size(); ++i) {
+        clone_deltas.push_back(clone_header.get_delta(i));
+        LOG(INFO) << "Delta to clone."
+            << "tablet=" << tablet->full_name() << ","
+            << ", version=" << clone_header.get_delta(i)->start_version() << "-"
+                << clone_header.get_delta(i)->end_version()
+            << ", version_hash=" << clone_header.get_delta(i)->version_hash();
+    }
+
+    // clone_data to tablet
+    OLAPStatus clone_res = tablet->clone_data(clone_header, clone_deltas, versions_to_delete);
+    LOG(INFO) << "finish to full clone. [tablet=" << tablet->full_name() << ", res=" << clone_res << "]";
+    return clone_res;
+}
+
+} // doris

--- a/be/src/olap/task/engine_clone_task.h
+++ b/be/src/olap/task/engine_clone_task.h
@@ -1,0 +1,63 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#ifndef DORIS_BE_SRC_OLAP_TASK_ENGINE_CLONE_TASK_H
+#define DORIS_BE_SRC_OLAP_TASK_ENGINE_CLONE_TASK_H
+
+#include "gen_cpp/AgentService_types.h"
+#include "olap/olap_define.h"
+#include "olap/task/engine_task.h"
+
+namespace doris {
+
+// base class for storage engine
+// add "Engine" as task prefix to prevent duplicate name with agent task
+class EngineCloneTask : public EngineTask {
+
+public:
+    virtual OLAPStatus execute();
+
+public:
+    EngineCloneTask(TCloneReq& _clone_req, vector<string>& error_msgs, vector<TTabletInfo> tablet_infos);
+    ~EngineCloneTask() {}
+
+private:
+    
+    // before doing incremental clone,
+    // need to calculate tablet's download dir and tablet's missing versions
+    virtual std::string _get_info_before_incremental_clone(TabletSharedPtr tablet,
+        int64_t committed_version, std::vector<Version>* missing_versions);
+
+    
+    virtual OLAPStatus _finish_clone(TabletSharedPtr tablet, const std::string& clone_dir,
+                                    int64_t committed_version, bool is_incremental_clone);
+    
+
+
+    OLAPStatus _clone_incremental_data(TabletSharedPtr tablet, TabletMeta& clone_header,
+                                     int64_t committed_version);
+
+    OLAPStatus _clone_full_data(TabletSharedPtr tablet, TabletMeta& clone_header);
+
+private:
+    TCloneReq& _clone_req;
+    vector<string>& _error_msgs;
+    vector<TTabletInfo> _tablet_infos;
+}; // EngineTask
+
+} // doris
+#endif //DORIS_BE_SRC_OLAP_TASK_ENGINE_CLONE_TASK_H

--- a/be/src/olap/task/engine_schema_change_task.cpp
+++ b/be/src/olap/task/engine_schema_change_task.cpp
@@ -1,0 +1,137 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "olap/task/engine_schema_change_task.h"
+
+namespace doris {
+
+EngineSchemaChangeTask(const TAlterTabletReq& alter_tablet_request, 
+        int64_t signature):
+        _alter_tablet_req(alter_tablet_request),
+        _signature(signature) {
+
+}
+
+OLAPStatus EngineSchemaChangeTask::execute() {
+    OLAPStatus status = OLAP_SUCCESS;
+    TTabletId base_tablet_id = _alter_tablet_req.base_tablet_id;
+    TSchemaHash base_schema_hash = _alter_tablet_req.base_schema_hash;
+
+    // Check last schema change status, if failed delete tablet file
+    // Do not need to adjust delete success or not
+    // Because if delete failed create rollup will failed
+    // Check lastest schema change status
+    AlterTableStatus alter_tablet_status = TabletManager::instance()->show_alter_tablet_status(
+            base_tablet_id,
+            base_schema_hash);
+    LOG(INFO) << "get alter table status:" << alter_tablet_status
+                << ", signature:" << _signature;
+
+    // Delete failed alter table tablet file
+    if (alter_tablet_status == ALTER_TABLE_FAILED) {
+        // !!! could not drop failed tablet
+        // schema change job is in finishing state in fe, be restarts, then the tablet is in ALTER_TABLE_FAILED state
+        // if drop the old tablet, then data is lost
+        status = TabletManager::instance()->drop_tablet(_alter_tablet_req.new_tablet_req.tablet_id, 
+                                                            _alter_tablet_req.new_tablet_req.tablet_schema.schema_hash);
+
+        if (status != OLAP_SUCCESS) {
+            OLAP_LOG_WARNING("delete failed rollup file failed, status: %d, "
+                                "signature: %ld.",
+                                status, _signature);
+            error_msgs.push_back("delete failed rollup file failed, "
+                                    "signature: " + to_string(_signature));
+        }
+    }
+
+    if (status == OLAP_SUCCESS) {
+        // if there is one running alter task, then not start current task
+        if (alter_tablet_status == ALTER_TABLE_FINISHED
+                || alter_tablet_status == ALTER_TABLE_FAILED
+                || alter_tablet_status == ALTER_TABLE_WAITING) {
+            // Create rollup table
+            switch (task_type) {
+            case TTaskType::ROLLUP:
+                status = _create_rollup_tablet(_alter_tablet_req);
+                break;
+            case TTaskType::SCHEMA_CHANGE:
+                status = _schema_change(_alter_tablet_req);
+                break;
+            default:
+                // pass
+                break;
+            }
+            if (status != OLAPStatus::OLAP_SUCCESS) {
+                LOG(WARNING) << process_name << " failed. signature: " << _signature << " status: " << status;
+            }
+        }
+    }
+    return status;
+} // execute
+
+OLAPStatus EngineSchemaChangeTask::_create_rollup_tablet(const TAlterTabletReq& request) {
+    LOG(INFO) << "begin to create rollup tablet. "
+              << "old_tablet_id=" << request.base_tablet_id
+              << ", new_tablet_id=" << request.new_tablet_req.tablet_id;
+
+    DorisMetrics::create_rollup_requests_total.increment(1);
+
+    OLAPStatus res = OLAP_SUCCESS;
+
+    SchemaChangeHandler handler;
+    res = handler.process_alter_tablet(ALTER_TABLET_CREATE_ROLLUP_TABLE, request);
+
+    if (res != OLAP_SUCCESS) {
+        OLAP_LOG_WARNING("failed to do rollup. "
+                         "[base_tablet=%ld new_tablet=%ld] [res=%d]",
+                         request.base_tablet_id, request.new_tablet_req.tablet_id, res);
+        DorisMetrics::create_rollup_requests_failed.increment(1);
+        return res;
+    }
+
+    LOG(INFO) << "success to create rollup tablet. res=" << res
+              << ", old_tablet_id=" << request.base_tablet_id 
+              << ", new_tablet_id=" << request.new_tablet_req.tablet_id;
+    return res;
+} // create_rollup_tablet
+
+OLAPStatus EngineSchemaChangeTask::_schema_change(const TAlterTabletReq& request) {
+    LOG(INFO) << "begin to schema change. old_tablet_id=" << request.base_tablet_id
+              << ", new_tablet_id=" << request.new_tablet_req.tablet_id;
+
+    DorisMetrics::schema_change_requests_total.increment(1);
+
+    OLAPStatus res = OLAP_SUCCESS;
+
+    SchemaChangeHandler handler;
+    res = handler.process_alter_tablet(ALTER_TABLET_SCHEMA_CHANGE, request);
+
+    if (res != OLAP_SUCCESS) {
+        OLAP_LOG_WARNING("failed to do schema change. "
+                         "[base_tablet=%ld new_tablet=%ld] [res=%d]",
+                         request.base_tablet_id, request.new_tablet_req.tablet_id, res);
+        DorisMetrics::schema_change_requests_failed.increment(1);
+        return res;
+    }
+
+    LOG(INFO) << "success to submit schema change."
+              << "old_tablet_id=" << request.base_tablet_id
+              << ", new_tablet_id=" << request.new_tablet_req.tablet_id;
+    return res;
+}
+
+} // doris

--- a/be/src/olap/task/engine_schema_change_task.h
+++ b/be/src/olap/task/engine_schema_change_task.h
@@ -1,0 +1,67 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#ifndef DORIS_BE_SRC_OLAP_TASK_ENGINE_SCHEMA_CHANGE_TASK_H
+#define DORIS_BE_SRC_OLAP_TASK_ENGINE_SCHEMA_CHANGE_TASK_H
+
+#include "gen_cpp/AgentService_types.h"
+#include "olap/olap_define.h"
+#include "olap/task/engine_task.h"
+
+namespace doris {
+
+// base class for storage engine
+// add "Engine" as task prefix to prevent duplicate name with agent task
+class EngineSchemaChangeTask : public EngineTask {
+
+public:
+    virtual OLAPStatus execute();
+
+public:
+    EngineSchemaChangeTask(const TAlterTabletReq& alter_tablet_request, int64_t signature);
+    ~EngineSchemaChangeTask() {}
+
+private:
+    // ######################### ALTER TABLE BEGIN #########################
+    // The following interfaces are all about alter tablet operation, 
+    // the main logical is that generating a new tablet with different
+    // schema on base tablet.
+    
+    // Create rollup tablet on base tablet, after create_rollup_tablet,
+    // both base tablet and new tablet is effective.
+    //
+    // @param [in] request specify base tablet, new tablet and its schema
+    // @return OLAP_SUCCESS if submit success
+    OLAPStatus _create_rollup_tablet(const TAlterTabletReq& request);
+
+    // Do schema change on tablet, StorageEngine support
+    // add column, drop column, alter column type and order,
+    // after schema_change, base tablet is abandoned.
+    // Note that the two tablets has same tablet_id but different schema_hash
+    // 
+    // @param [in] request specify base tablet, new tablet and its schema
+    // @return OLAP_SUCCESS if submit success
+    OLAPStatus _schema_change(const TAlterTabletReq& request);
+
+private:
+    TAlterTabletReq& _alter_tablet_req;
+    int64_t _signature;
+
+}; // EngineTask
+
+} // doris
+#endif //DORIS_BE_SRC_OLAP_TASK_ENGINE_SCHEMA_CHANGE_TASK_H

--- a/be/src/olap/task/engine_task.h
+++ b/be/src/olap/task/engine_task.h
@@ -1,0 +1,37 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#ifndef DORIS_BE_SRC_OLAP_TASK_ENGINE_TASK_H
+#define DORIS_BE_SRC_OLAP_TASK_ENGINE_TASK_H
+
+#include "olap/olap_define.h"
+
+namespace doris {
+
+// base class for storage engine
+// add "Engine" as task prefix to prevent duplicate name with agent task
+class EngineTask {
+
+public:
+    virtual OLAPStatus prepare() { return OLAP_SUCCESS; }
+    virtual OLAPStatus execute() { return OLAP_SUCCESS; }
+    virtual OLAPStatus finish() { return OLAP_SUCCESS; }
+    virtual OLAPStatus clean() { return OLAP_SUCCESS; }
+}; // EngineTask
+
+} // doris
+#endif //DORIS_BE_SRC_OLAP_TASK_ENGINE_TASK_H

--- a/be/src/olap/txn_manager.cpp
+++ b/be/src/olap/txn_manager.cpp
@@ -70,30 +70,55 @@ using std::vector;
 
 namespace doris {
 
+TxnManager* TxnManager::_s_instance = nullptr;
+std::mutex TxnManager::_mlock;
+
+TxnManager* TxnManager::instance() {
+    if (_s_instance == nullptr) {
+        std::lock_guard<std::mutex> lock(_mlock);
+        if (_s_instance == nullptr) {
+            _s_instance = new TxnManager();
+        }
+    }
+    return _s_instance;
+}
+
 OLAPStatus TxnManager::add_txn(
     TPartitionId partition_id, TTransactionId transaction_id,
-    TTabletId tablet_id, SchemaHash schema_hash, const PUniqueId& load_id) {
+    TTabletId tablet_id, SchemaHash schema_hash, 
+    const PUniqueId& load_id, RowsetSharedPtr rowset_ptr) {
 
     pair<int64_t, int64_t> key(partition_id, transaction_id);
     TabletInfo tablet_info(tablet_id, schema_hash);
     WriteLock wrlock(&_txn_map_lock);
-    auto it = _transaction_tablet_map.find(key);
-    if (it != _transaction_tablet_map.end()) {
-        auto load_info = it->second.find(tablet_info);
-        if (load_info != it->second.end()) {
-            for (PUniqueId& pid : load_info->second) {
-                if (pid.hi() == load_id.hi() && pid.lo() == load_id.lo()) {
-                    LOG(WARNING) << "find transaction exists when add to engine."
-                        << "partition_id: " << key.first
-                        << ", transaction_id: " << key.second
-                        << ", tablet: " << tablet_info.to_string();
-                    return OLAP_ERR_PUSH_TRANSACTION_ALREADY_EXIST;
-                }
+    auto it = _txn_tablet_map.find(key);
+    if (it != _txn_tablet_map.end()) {
+        auto load_itr = it->second.find(tablet_info);
+        if (load_itr != it->second.end()) {
+            // found load for txn,tablet
+            // case 1: user commit rowset, then the load id must be equal
+            std::pair<PUniqueId, RowsetSharedPtr>& load_info = load_itr->second;
+            // check if load id is equal
+            if (!(load_info.first.hi() == load_id.hi() && load_info.first.lo() == load_id.lo())) {
+                LOG(WARNING) << "find transaction exists when add to engine."
+                    << "partition_id: " << key.first
+                    << ", transaction_id: " << key.second
+                    << ", tablet: " << tablet_info.to_string();
+                return OLAP_ERR_PUSH_TRANSACTION_ALREADY_EXIST;
             }
+            // in this case, user is committing rowset, then rowset_ptr must not be null
+            if (rowset_ptr == NULL || rowset_ptr.get() == NULL) {
+                return OLAP_ERR_PUSH_COMMIT_ROWSET;
+            }
+            _txn_tablet_map[key][tablet_info].second = rowset_ptr;
+            return OLAP_SUCCESS;
         }
     }
-
-    _transaction_tablet_map[key][tablet_info].push_back(load_id);
+    // not found load id
+    // case 1: user start a new txn, rowset_ptr = null
+    // case 2: loading txn from meta env
+    std::pair<PUniqueId, RowsetSharedPtr> load_info(load_id, rowset_ptr); 
+    _txn_tablet_map[key][tablet_info] = load_info;
     VLOG(3) << "add transaction to engine successfully."
             << "partition_id: " << key.first
             << ", transaction_id: " << key.second
@@ -109,27 +134,16 @@ OLAPStatus TxnManager::delete_txn(
     TabletInfo tablet_info(tablet_id, schema_hash);
     WriteLock wrlock(&_txn_map_lock);
 
-    auto it = _transaction_tablet_map.find(key);
-    if (it != _transaction_tablet_map.end()) {
+    auto it = _txn_tablet_map.find(key);
+    if (it != _txn_tablet_map.end()) {
         VLOG(3) << "delete transaction to engine successfully."
                 << ",partition_id: " << key.first
                 << ", transaction_id: " << key.second
                 << ", tablet: " << tablet_info.to_string();
         it->second.erase(tablet_info);
         if (it->second.empty()) {
-            _transaction_tablet_map.erase(it);
+            _txn_tablet_map.erase(it);
         }
-
-        // delete transaction from tablet
-        // delete from tablet is useless and it should be called at storageengine
-        /*
-        if (delete_from_tablet) {
-            TabletSharedPtr tablet = get_tablet(tablet_info.tablet_id, tablet_info.schema_hash);
-            if (tablet.get() != nullptr) {
-                tablet->delete_pending_data(transaction_id);
-            }
-        }
-        */
        return OLAP_SUCCESS;
     } else {
         return OLAP_ERR_TRANSACTION_NOT_EXIST;
@@ -145,7 +159,7 @@ void TxnManager::get_tablet_related_txns(TabletSharedPtr tablet, int64_t* partit
 
     TabletInfo tablet_info(tablet->tablet_id(), tablet->schema_hash());
     ReadLock rdlock(&_txn_map_lock);
-    for (auto& it : _transaction_tablet_map) {
+    for (auto& it : _txn_tablet_map) {
         if (it.second.find(tablet_info) != it.second.end()) {
             *partition_id = it.first.first;
             transaction_ids->insert(it.first.second);
@@ -159,27 +173,30 @@ void TxnManager::get_tablet_related_txns(TabletSharedPtr tablet, int64_t* partit
 
 void TxnManager::get_txn_related_tablets(const TTransactionId transaction_id,
                                         TPartitionId partition_id,
-                                        std::vector<TabletInfo>* tablet_infos) {
+                                        std::vector<TabletInfo>* tablet_infos,
+                                        std::vector<RowsetSharedPtr>* rowset_infos) {
     // get tablets in this transaction
     pair<int64_t, int64_t> key(partition_id, transaction_id);
 
     _txn_map_lock.rdlock();
-    auto it = _transaction_tablet_map.find(key);
-    if (it == _transaction_tablet_map.end()) {
+    auto it = _txn_tablet_map.find(key);
+    if (it == _txn_tablet_map.end()) {
         OLAP_LOG_WARNING("could not find tablet for [partition_id=%ld transaction_id=%ld]",
                             partition_id, transaction_id);
         _txn_map_lock.unlock();
         return;
     }
-    std::map<TabletInfo, std::vector<PUniqueId>> load_info_map = it->second;
-    _txn_map_lock.unlock();
+    std::map<TabletInfo, std::pair<PUniqueId, RowsetSharedPtr>> load_info_map = it->second;
 
     // each tablet
     for (auto& load_info : load_info_map) {
         const TabletInfo& tablet_info = load_info.first;
         tablet_infos->push_back(tablet_info);
+        if (rowset_infos != NULL) {
+            rowset_infos->push_back(load_info.second);
+        }
     }
-
+    _txn_map_lock.unlock();
 }
                                 
 
@@ -189,8 +206,8 @@ bool TxnManager::has_txn(TPartitionId partition_id, TTransactionId transaction_i
     TabletInfo tablet_info(tablet_id, schema_hash);
 
     _txn_map_lock.rdlock();
-    auto it = _transaction_tablet_map.find(key);
-    bool found = it != _transaction_tablet_map.end()
+    auto it = _txn_tablet_map.find(key);
+    bool found = it != _txn_tablet_map.end()
                  && it->second.find(tablet_info) != it->second.end();
     _txn_map_lock.unlock();
 

--- a/be/src/runtime/snapshot_loader.cpp
+++ b/be/src/runtime/snapshot_loader.cpp
@@ -556,7 +556,7 @@ Status SnapshotLoader::move(
         // than we merge the 2 .hdr file before reloading it.
     
         // load header in tablet dir to get the base vesion
-        TabletSharedPtr tablet = StorageEngine::get_instance()->get_tablet(
+        TabletSharedPtr tablet = TabletManager::instance()->get_tablet(
                 tablet_id, schema_hash);
         if (tablet.get() == NULL) {
             std::stringstream ss;
@@ -667,7 +667,7 @@ Status SnapshotLoader::move(
         LOG(WARNING) << ss.str();
         return Status(ss.str());
     }
-    OLAPStatus ost = StorageEngine::get_instance()->get_tablet_mgr()->load_one_tablet(
+    OLAPStatus ost = TabletManager::instance()->load_one_tablet(
             store, tablet_id, schema_hash, tablet_path, true);
     if (ost != OLAP_SUCCESS) {
         std::stringstream ss;

--- a/be/src/service/backend_service.cpp
+++ b/be/src/service/backend_service.cpp
@@ -225,7 +225,7 @@ void BackendService::erase_export_task(TStatus& t_status, const TUniqueId& task_
 }
 
 void BackendService::get_tablet_stat(TTabletStatResult& result) {
-    StorageEngine::get_instance()->get_tablet_stat(result);
+    TabletManager::instance()->get_tablet_stat(result);
 }
 
 } // namespace doris

--- a/be/test/olap/delta_writer_test.cpp
+++ b/be/test/olap/delta_writer_test.cpp
@@ -394,7 +394,7 @@ TEST_F(TestDeltaWriter, write) {
     ASSERT_EQ(res, OLAP_SUCCESS);
 
     // publish version success
-    TabletSharedPtr tablet = StorageEngine::get_instance()->get_tablet(write_req.tablet_id, write_req.schema_hash);
+    TabletSharedPtr tablet = TabletManager::instance()->get_tablet(write_req.tablet_id, write_req.schema_hash);
     TPublishVersionRequest publish_req;
     publish_req.transaction_id = write_req.transaction_id;
     TPartitionVersionInfo info;
@@ -585,7 +585,7 @@ TEST_F(TestSchemaChange, schema_change) {
     ASSERT_EQ(res, OLAP_SUCCESS);
 
     // publish version success
-    TabletSharedPtr tablet = StorageEngine::get_instance()->get_tablet(write_req.tablet_id, write_req.schema_hash);
+    TabletSharedPtr tablet = TabletManager::instance()->get_tablet(write_req.tablet_id, write_req.schema_hash);
     TPublishVersionRequest publish_req;
     publish_req.transaction_id = write_req.transaction_id;
     TPartitionVersionInfo info;

--- a/gensrc/proto/olap_file.proto
+++ b/gensrc/proto/olap_file.proto
@@ -91,6 +91,7 @@ message RowsetMetaPB {
     required PUniqueId load_id = 18;
     // spare field id for future use
     optional bytes extra_properties = 50;
+
 }
 
 message AlphaRowsetExtraMetaPB {


### PR DESCRIPTION
- define RowsetId Type
- move clear_schema_change_info from storage engine to tablet
- split clone, schemachange tasks from storage engine to seperate tasks