### PR TITLE
Fix bug that schema change on restored table will lose data

### DIFF
--- a/fe/src/main/java/org/apache/doris/backup/RestoreJob.java
+++ b/fe/src/main/java/org/apache/doris/backup/RestoreJob.java
@@ -17,6 +17,16 @@
 
 package org.apache.doris.backup;
 
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
 import org.apache.doris.backup.BackupJobInfo.BackupIndexInfo;
 import org.apache.doris.backup.BackupJobInfo.BackupPartitionInfo;
 import org.apache.doris.backup.BackupJobInfo.BackupTableInfo;
@@ -61,6 +71,8 @@ import org.apache.doris.thrift.TStatusCode;
 import org.apache.doris.thrift.TStorageMedium;
 import org.apache.doris.thrift.TStorageType;
 import org.apache.doris.thrift.TTaskType;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
@@ -70,19 +82,6 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Range;
 import com.google.common.collect.Table.Cell;
-
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
-import java.io.DataInput;
-import java.io.DataOutput;
-import java.io.IOException;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Set;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 
 public class RestoreJob extends AbstractJob {
     private static final Logger LOG = LogManager.getLogger(RestoreJob.class);
@@ -615,9 +614,9 @@ public class RestoreJob extends AbstractJob {
                     int schemaHash = localTbl.getSchemaHashByIndexId(restoredIdx.getId());
                     KeysType keysType = localTbl.getKeysType();
                     List<Column> columns = localTbl.getSchemaByIndexId(restoredIdx.getId());
+                    TabletMeta tabletMeta = new TabletMeta(db.getId(), localTbl.getId(), restorePart.getId(),
+                            restoredIdx.getId(), schemaHash);
                     for (Tablet restoreTablet : restoredIdx.getTablets()) {
-                        TabletMeta tabletMeta = new TabletMeta(db.getId(), localTbl.getId(),
-                                restorePart.getId(), restoredIdx.getId(), schemaHash);
                         Catalog.getCurrentInvertedIndex().addTablet(restoreTablet.getId(), tabletMeta);
                         for (Replica restoreReplica : restoreTablet.getReplicas()) {
                             Catalog.getCurrentInvertedIndex().addReplica(restoreTablet.getId(), restoreReplica);
@@ -650,9 +649,9 @@ public class RestoreJob extends AbstractJob {
                         int schemaHash = restoreTbl.getSchemaHashByIndexId(index.getId());
                         KeysType keysType = restoreTbl.getKeysType();
                         List<Column> columns = restoreTbl.getSchemaByIndexId(index.getId());
+                        TabletMeta tabletMeta = new TabletMeta(db.getId(), restoreTbl.getId(), restorePart.getId(),
+                                index.getId(), schemaHash);
                         for (Tablet tablet : index.getTablets()) {
-                            TabletMeta tabletMeta = new TabletMeta(db.getId(), restoreTbl.getId(),
-                                    restorePart.getId(), index.getId(), schemaHash);
                             Catalog.getCurrentInvertedIndex().addTablet(tablet.getId(), tabletMeta);
                             for (Replica replica : tablet.getReplicas()) {
                                 Catalog.getCurrentInvertedIndex().addReplica(tablet.getId(), replica);
@@ -926,9 +925,9 @@ public class RestoreJob extends AbstractJob {
                 // modify tablet inverted index
                 for (MaterializedIndex restoreIdx : restorePart.getMaterializedIndices()) {
                     int schemaHash = localTbl.getSchemaHashByIndexId(restoreIdx.getId());
+                    TabletMeta tabletMeta = new TabletMeta(db.getId(), localTbl.getId(), restorePart.getId(),
+                            restoreIdx.getId(), schemaHash);
                     for (Tablet restoreTablet : restoreIdx.getTablets()) {
-                        TabletMeta tabletMeta = new TabletMeta(db.getId(), localTbl.getId(),
-                                restorePart.getId(), restoreIdx.getId(), schemaHash);
                         Catalog.getCurrentInvertedIndex().addTablet(restoreTablet.getId(), tabletMeta);
                         for (Replica restoreReplica : restoreTablet.getReplicas()) {
                             Catalog.getCurrentInvertedIndex().addReplica(restoreTablet.getId(), restoreReplica);
@@ -944,9 +943,9 @@ public class RestoreJob extends AbstractJob {
                 for (Partition restorePart : restoreTbl.getPartitions()) {
                     for (MaterializedIndex restoreIdx : restorePart.getMaterializedIndices()) {
                         int schemaHash = restoreTbl.getSchemaHashByIndexId(restoreIdx.getId());
+                        TabletMeta tabletMeta = new TabletMeta(db.getId(), restoreTbl.getId(), restorePart.getId(),
+                                restoreIdx.getId(), schemaHash);
                         for (Tablet restoreTablet : restoreIdx.getTablets()) {
-                            TabletMeta tabletMeta = new TabletMeta(db.getId(), restoreTbl.getId(),
-                                    restorePart.getId(), restoreIdx.getId(), schemaHash);
                             Catalog.getCurrentInvertedIndex().addTablet(restoreTablet.getId(), tabletMeta);
                             for (Replica restoreReplica : restoreTablet.getReplicas()) {
                                 Catalog.getCurrentInvertedIndex().addReplica(restoreTablet.getId(), restoreReplica);

--- a/fe/src/main/java/org/apache/doris/backup/RestoreJob.java
+++ b/fe/src/main/java/org/apache/doris/backup/RestoreJob.java
@@ -17,16 +17,6 @@
 
 package org.apache.doris.backup;
 
-import java.io.DataInput;
-import java.io.DataOutput;
-import java.io.IOException;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Set;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
-
 import org.apache.doris.backup.BackupJobInfo.BackupIndexInfo;
 import org.apache.doris.backup.BackupJobInfo.BackupPartitionInfo;
 import org.apache.doris.backup.BackupJobInfo.BackupTableInfo;
@@ -71,8 +61,6 @@ import org.apache.doris.thrift.TStatusCode;
 import org.apache.doris.thrift.TStorageMedium;
 import org.apache.doris.thrift.TStorageType;
 import org.apache.doris.thrift.TTaskType;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
@@ -82,6 +70,19 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Range;
 import com.google.common.collect.Table.Cell;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 public class RestoreJob extends AbstractJob {
     private static final Logger LOG = LogManager.getLogger(RestoreJob.class);


### PR DESCRIPTION
In TabletInvertedIndex calss, The instance of TabletMeta in
'tabletMetaMap' and 'tabletMetaTable' should be same.
Otherwise when we change the schema hash info of TabletMeta
in 'tabletMetaMap', TabletMeta in 'tabletMetaTable' left
unchanged, which will cause inconsistency of meta.