### PR TITLE
EsTable without partition info

### DIFF
--- a/fe/src/main/java/org/apache/doris/catalog/EsTable.java
+++ b/fe/src/main/java/org/apache/doris/catalog/EsTable.java
@@ -161,6 +161,7 @@ public class EsTable extends Table {
     public void readFields(DataInput in) throws IOException {
         super.readFields(in);
         hosts = Text.readString(in);
+        seeds = hosts.split(",");
         userName = Text.readString(in);
         passwd = Text.readString(in);
         indexName = Text.readString(in);

--- a/fe/src/main/java/org/apache/doris/external/EsIndexState.java
+++ b/fe/src/main/java/org/apache/doris/external/EsIndexState.java
@@ -68,8 +68,12 @@ public class EsIndexState {
                 JSONObject shard = shardRouting.getJSONObject(i);
                 String shardState = shard.getString("state");
                 if ("STARTED".equalsIgnoreCase(shardState)) {
-                    singleShardRouting.add(EsShardRouting.parseShardRoutingV55(shardState, 
-                            shardKey, shard, nodesMap));
+                    try {
+                        singleShardRouting.add(EsShardRouting.parseShardRoutingV55(shardState, 
+                                shardKey, shard, nodesMap));
+                    } catch (Exception e) {
+                        LOG.info("errors while parse shard routing from json [{}], ignore this shard", shard.toString(), e);
+                    }
                 } 
             }
             if (singleShardRouting.isEmpty()) {
@@ -80,7 +84,7 @@ public class EsIndexState {
 
         // get some meta info from es, could be used to prune index when query
         // index.bpack.partition.upperbound: stu_age
-        if (partitionInfo instanceof RangePartitionInfo) {
+        if (partitionInfo != null && partitionInfo instanceof RangePartitionInfo) {
             JSONObject indexMeta = indicesMetaMap.getJSONObject(indexName);
             JSONObject partitionSetting = EsUtil.getJsonObject(indexMeta, "settings.index.bpack.partition", 0);
             LOG.debug("index {} range partition setting is {}", indexName, 

--- a/fe/src/main/java/org/apache/doris/external/EsStateStore.java
+++ b/fe/src/main/java/org/apache/doris/external/EsStateStore.java
@@ -85,9 +85,13 @@ public class EsStateStore extends Daemon {
     
     protected void runOneCycle() {
         for (EsTable esTable : esTables.values()) {
-            EsTableState esTableState = loadEsIndexMetadataV55(esTable);
-            if (esTableState != null) {
-                esTable.setEsTableState(esTableState);
+            try {
+                EsTableState esTableState = loadEsIndexMetadataV55(esTable);
+                if (esTableState != null) {
+                    esTable.setEsTableState(esTableState);
+                }
+            } catch (Throwable e) {
+                LOG.error("errors while load table {} state from es", esTable.getName());
             }
         }
     }

--- a/fe/src/main/java/org/apache/doris/planner/EsScanNode.java
+++ b/fe/src/main/java/org/apache/doris/planner/EsScanNode.java
@@ -240,6 +240,9 @@ public class EsScanNode extends ScanNode {
      * @throws AnalysisException
      */
     private Collection<Long> partitionPrune(PartitionInfo partitionInfo) throws AnalysisException {
+        if (partitionInfo == null) {
+            return null;
+        }
         PartitionPruner partitionPruner = null;
         switch (partitionInfo.getType()) {
         case RANGE: {

--- a/fe/src/test/java/org/apache/doris/catalog/CatalogTestUtil.java
+++ b/fe/src/test/java/org/apache/doris/catalog/CatalogTestUtil.java
@@ -279,7 +279,7 @@ public class CatalogTestUtil {
                                                                            .newArrayList("100")),
                                                                    null));
 
-        RangePartitionInfo partitionInfo = new RangePartitionInfo(partitionColumns);
+        SinglePartitionInfo partitionInfo = new SinglePartitionInfo();
         Map<String, String> properties = Maps.newHashMap();
         properties.put(EsTable.HOSTS, "xxx");
         properties.put(EsTable.INDEX, "indexa");

--- a/fe/src/test/java/org/apache/doris/es/EsStateStoreTest.java
+++ b/fe/src/test/java/org/apache/doris/es/EsStateStoreTest.java
@@ -62,6 +62,8 @@ public class EsStateStoreTest {
     private static String clusterStateStr1 = "";
     private static String clusterStateStr2 = "";
     private static String clusterStateStr3 = "";
+    private static String clusterStateStr4 = "";
+    private static String clusterStateStr5 = "";
     private EsStateStore esStateStore;
     
     @BeforeClass
@@ -79,6 +81,8 @@ public class EsStateStoreTest {
         clusterStateStr1 = loadJsonFromFile("data/es/clusterstate1.json");
         clusterStateStr2 = loadJsonFromFile("data/es/clusterstate2.json");
         clusterStateStr3 = loadJsonFromFile("data/es/clusterstate3.json");
+        clusterStateStr4 = loadJsonFromFile("data/es/clusterstate4.json");
+        clusterStateStr5 = loadJsonFromFile("data/es/clusterstate5.json");
     }
     
     @Before
@@ -90,7 +94,6 @@ public class EsStateStoreTest {
      * partitioned es table schema: k1(date), k2(int), v(double)
      * @throws AnalysisException 
      */
-    @Ignore
     @Test
     public void testParsePartitionedClusterState() throws AnalysisException {
         EsTable esTable = (EsTable) Catalog.getCurrentCatalog()
@@ -138,7 +141,6 @@ public class EsStateStoreTest {
      * 2 indices, one with partition desc, the other does not contains partition desc
      * @throws AnalysisException 
      */
-    @Ignore
     @Test
     public void testParsePartitionedClusterStateTwoIndices() throws AnalysisException {
         EsTable esTable = (EsTable) Catalog.getCurrentCatalog()
@@ -178,6 +180,75 @@ public class EsStateStoreTest {
         EsIndexState esIndexState2 = esTableState.getUnPartitionedIndexStates().get("index2");
         assertEquals("index2", esIndexState2.getIndexName());
         assertEquals(6, esIndexState2.getShardRoutings().size());
+    }
+    
+    /**
+     * partitioned es table schema: k1(date), k2(int), v(double)
+     * scenario desc:
+     * 2 indices, both of them does not contains partition desc and es table does not have partition info
+     * but cluster state have partition info
+     * @throws AnalysisException 
+     */
+    @Test
+    public void testParseUnPartitionedClusterStateTwoIndices() throws AnalysisException {
+        EsTable esTable = (EsTable) Catalog.getCurrentCatalog()
+                                            .getDb(CatalogTestUtil.testDb1)
+                                            .getTable(CatalogTestUtil.testUnPartitionedEsTableId1);
+        boolean hasException = false;
+        EsTableState esTableState = null;
+        try {
+            esTableState = esStateStore.parseClusterState55(clusterStateStr4, esTable);
+        } catch (Exception e) {
+            e.printStackTrace();
+            hasException = true;
+        }
+        assertFalse(hasException);
+        assertNotNull(esTableState);
+        
+        // check 
+        assertEquals(0, esTableState.getPartitionedIndexStates().size());
+        assertEquals(2, esTableState.getUnPartitionedIndexStates().size());
+        
+        // check index with no partition desc
+        EsIndexState esIndexState1 = esTableState.getUnPartitionedIndexStates().get("index1");
+        assertEquals("index1", esIndexState1.getIndexName());
+        EsIndexState esIndexState2 = esTableState.getUnPartitionedIndexStates().get("index2");
+        assertEquals("index2", esIndexState2.getIndexName());
+        assertEquals(6, esIndexState2.getShardRoutings().size());
+    }
+    
+    /**
+     * test node without thrift info, parse without error, but es index state is empty
+     * @throws AnalysisException 
+     */
+    @Test
+    public void testParseUnPartitionedWithoutThriftInfo() throws AnalysisException {
+        EsTable esTable = (EsTable) Catalog.getCurrentCatalog()
+                                            .getDb(CatalogTestUtil.testDb1)
+                                            .getTable(CatalogTestUtil.testUnPartitionedEsTableId1);
+        boolean hasException = false;
+        EsTableState esTableState = null;
+        try {
+            esTableState = esStateStore.parseClusterState55(clusterStateStr5, esTable);
+        } catch (Exception e) {
+            e.printStackTrace();
+            hasException = true;
+        }
+        assertFalse(hasException);
+        assertNotNull(esTableState);
+        
+        // check 
+        assertEquals(0, esTableState.getPartitionedIndexStates().size());
+        assertEquals(2, esTableState.getUnPartitionedIndexStates().size());
+        
+        // check index with no partition desc
+        EsIndexState esIndexState1 = esTableState.getUnPartitionedIndexStates().get("index1");
+        assertEquals("index1", esIndexState1.getIndexName());
+        EsIndexState esIndexState2 = esTableState.getUnPartitionedIndexStates().get("index2");
+        assertEquals("index2", esIndexState2.getIndexName());
+        assertEquals(6, esIndexState2.getShardRoutings().size());
+        
+        assertEquals(0, esIndexState1.getShardRoutings().get(1).size());
     }
     
     /**

--- a/fe/src/test/resources/data/es/clusterstate4.json
+++ b/fe/src/test/resources/data/es/clusterstate4.json
@@ -1,0 +1,747 @@
+{
+    "cluster_name": "elasticsearch",
+    "version": 28,
+    "state_uuid": "C6WNazFPSPyZcQlE-cNw1g",
+    "master_node": "ejy2E2sMTg6nqnjhF9KfsQ",
+    "blocks": {},
+    "nodes": {
+      "ejy2E2sMTg6nqnjhF9KfsQ": {
+        "name": "ejy2E2s",
+        "ephemeral_id": "HO-_F6BLSqedHuv7-yhkNQ",
+        "transport_address": "192.168.0.1:9209",
+        "attributes": {
+	  "thrift_port": "9210"
+	}
+      }
+    },
+    "metadata": {
+      "cluster_uuid": "_na_",
+      "templates": {},
+      "indices": {
+        "index2": {
+          "state": "open",
+          "settings": {
+            "index": {
+              "number_of_shards": "5",
+              "provided_name": "index2",
+              "creation_date": "1539592090322",
+              "number_of_replicas": "1",
+              "uuid": "T-Kg83WaTOSIXmiO0ZANzg",
+              "version": {
+                "created": "5050099"
+              }
+            }
+          },
+          "mappings": {},
+          "aliases": [
+            "indexa"
+          ],
+          "primary_terms": {
+            "0": 1,
+            "1": 1,
+            "2": 1,
+            "3": 1,
+            "4": 1
+          },
+          "in_sync_allocations": {
+            "0": [
+              "gbBnb3KFQOyXHl3eaVV6nA"
+            ],
+            "1": [
+              "sNsOyQBnSdKQuFETNtRYng"
+            ],
+            "2": [
+              "4UZfdxQeT7CMUxI9Fl5tYA"
+            ],
+            "3": [
+              "70TzfLRxQ_KL-tT81-QO4w"
+            ],
+            "4": [
+              "GhBM4mIdTAG-IVjGYFazkQ"
+            ]
+          }
+        },
+        "index1": {
+          "state": "open",
+          "settings": {
+            "index": {
+              "bpack": {
+                "partition": {
+                  "upperbound": "2018-10-01"
+                }
+              },
+              "number_of_shards": "5",
+              "provided_name": "index1",
+              "creation_date": "1539592085059",
+              "number_of_replicas": "1",
+              "uuid": "hjbl6RxaTyCYFfAJwaSjCA",
+              "version": {
+                "created": "5050099"
+              }
+            }
+          },
+          "mappings": {},
+          "aliases": [
+            "indexa"
+          ],
+          "primary_terms": {
+            "0": 1,
+            "1": 1,
+            "2": 1,
+            "3": 1,
+            "4": 1
+          },
+          "in_sync_allocations": {
+            "0": [
+              "WFVdvk1eQrmOfemq6UoBIw"
+            ],
+            "1": [
+              "_ASJYn1bRO2MnCN0HKH5BA"
+            ],
+            "2": [
+              "o5kBd295ReKi2g4g1bpjyA"
+            ],
+            "3": [
+              "orpHABU0S8eJ0Nd82U_SQA"
+            ],
+            "4": [
+              "6I6OQ1QfTgCvHigkIdmuPA"
+            ]
+          }
+        }
+      },
+      "index-graveyard": {
+        "tombstones": []
+      }
+    },
+    "routing_table": {
+      "indices": {
+        "index2": {
+          "shards": {
+            "0": [
+              {
+                "state": "STARTED",
+                "primary": true,
+                "node": "ejy2E2sMTg6nqnjhF9KfsQ",
+                "relocating_node": null,
+                "shard": 0,
+                "index": "index2",
+                "allocation_id": {
+                  "id": "gbBnb3KFQOyXHl3eaVV6nA"
+                }
+              },
+              {
+                "state": "UNASSIGNED",
+                "primary": false,
+                "node": null,
+                "relocating_node": null,
+                "shard": 0,
+                "index": "index2",
+                "recovery_source": {
+                  "type": "PEER"
+                },
+                "unassigned_info": {
+                  "reason": "INDEX_CREATED",
+                  "at": "2018-10-15T08:28:10.325Z",
+                  "delayed": false,
+                  "allocation_status": "no_attempt"
+                }
+              }
+            ],
+            "1": [
+              {
+                "state": "STARTED",
+                "primary": true,
+                "node": "ejy2E2sMTg6nqnjhF9KfsQ",
+                "relocating_node": null,
+                "shard": 1,
+                "index": "index2",
+                "allocation_id": {
+                  "id": "sNsOyQBnSdKQuFETNtRYng"
+                }
+              },
+              {
+                "state": "UNASSIGNED",
+                "primary": false,
+                "node": null,
+                "relocating_node": null,
+                "shard": 1,
+                "index": "index2",
+                "recovery_source": {
+                  "type": "PEER"
+                },
+                "unassigned_info": {
+                  "reason": "INDEX_CREATED",
+                  "at": "2018-10-15T08:28:10.325Z",
+                  "delayed": false,
+                  "allocation_status": "no_attempt"
+                }
+              }
+            ],
+            "2": [
+              {
+                "state": "STARTED",
+                "primary": true,
+                "node": "ejy2E2sMTg6nqnjhF9KfsQ",
+                "relocating_node": null,
+                "shard": 2,
+                "index": "index2",
+                "allocation_id": {
+                  "id": "4UZfdxQeT7CMUxI9Fl5tYA"
+                }
+              },
+              {
+                "state": "UNASSIGNED",
+                "primary": false,
+                "node": null,
+                "relocating_node": null,
+                "shard": 2,
+                "index": "index2",
+                "recovery_source": {
+                  "type": "PEER"
+                },
+                "unassigned_info": {
+                  "reason": "INDEX_CREATED",
+                  "at": "2018-10-15T08:28:10.325Z",
+                  "delayed": false,
+                  "allocation_status": "no_attempt"
+                }
+              }
+            ],
+            "3": [
+              {
+                "state": "STARTED",
+                "primary": true,
+                "node": "ejy2E2sMTg6nqnjhF9KfsQ",
+                "relocating_node": null,
+                "shard": 3,
+                "index": "index2",
+                "allocation_id": {
+                  "id": "70TzfLRxQ_KL-tT81-QO4w"
+                }
+              },
+              {
+                "state": "UNASSIGNED",
+                "primary": false,
+                "node": null,
+                "relocating_node": null,
+                "shard": 3,
+                "index": "index2",
+                "recovery_source": {
+                  "type": "PEER"
+                },
+                "unassigned_info": {
+                  "reason": "INDEX_CREATED",
+                  "at": "2018-10-15T08:28:10.325Z",
+                  "delayed": false,
+                  "allocation_status": "no_attempt"
+                }
+              }
+            ],
+            "4": [
+              {
+                "state": "STARTED",
+                "primary": true,
+                "node": "ejy2E2sMTg6nqnjhF9KfsQ",
+                "relocating_node": null,
+                "shard": 4,
+                "index": "index2",
+                "allocation_id": {
+                  "id": "GhBM4mIdTAG-IVjGYFazkQ"
+                }
+              },
+              {
+                "state": "UNASSIGNED",
+                "primary": false,
+                "node": null,
+                "relocating_node": null,
+                "shard": 4,
+                "index": "index2",
+                "recovery_source": {
+                  "type": "PEER"
+                },
+                "unassigned_info": {
+                  "reason": "INDEX_CREATED",
+                  "at": "2018-10-15T08:28:10.325Z",
+                  "delayed": false,
+                  "allocation_status": "no_attempt"
+                }
+              }
+            ],
+            "5": [
+              {
+                "state": "STARTED",
+                "primary": true,
+                "node": "ejy2E2sMTg6nqnjhF9KfsQ",
+                "relocating_node": null,
+                "shard": 4,
+                "index": "index2",
+                "allocation_id": {
+                  "id": "GhBM4mIdTAG-IVjGYFazkQ"
+                }
+              },
+              {
+                "state": "UNASSIGNED",
+                "primary": false,
+                "node": null,
+                "relocating_node": null,
+                "shard": 4,
+                "index": "index2",
+                "recovery_source": {
+                  "type": "PEER"
+                },
+                "unassigned_info": {
+                  "reason": "INDEX_CREATED",
+                  "at": "2018-10-15T08:28:10.325Z",
+                  "delayed": false,
+                  "allocation_status": "no_attempt"
+                }
+              }
+            ]
+          }
+        },
+        "index1": {
+          "shards": {
+            "0": [
+              {
+                "state": "STARTED",
+                "primary": true,
+                "node": "ejy2E2sMTg6nqnjhF9KfsQ",
+                "relocating_node": null,
+                "shard": 0,
+                "index": "index1",
+                "allocation_id": {
+                  "id": "WFVdvk1eQrmOfemq6UoBIw"
+                }
+              },
+              {
+                "state": "UNASSIGNED",
+                "primary": false,
+                "node": null,
+                "relocating_node": null,
+                "shard": 0,
+                "index": "index1",
+                "recovery_source": {
+                  "type": "PEER"
+                },
+                "unassigned_info": {
+                  "reason": "INDEX_CREATED",
+                  "at": "2018-10-15T08:28:05.063Z",
+                  "delayed": false,
+                  "allocation_status": "no_attempt"
+                }
+              }
+            ],
+            "1": [
+              {
+                "state": "STARTED",
+                "primary": true,
+                "node": "ejy2E2sMTg6nqnjhF9KfsQ",
+                "relocating_node": null,
+                "shard": 1,
+                "index": "index1",
+                "allocation_id": {
+                  "id": "_ASJYn1bRO2MnCN0HKH5BA"
+                }
+              },
+              {
+                "state": "UNASSIGNED",
+                "primary": false,
+                "node": null,
+                "relocating_node": null,
+                "shard": 1,
+                "index": "index1",
+                "recovery_source": {
+                  "type": "PEER"
+                },
+                "unassigned_info": {
+                  "reason": "INDEX_CREATED",
+                  "at": "2018-10-15T08:28:05.063Z",
+                  "delayed": false,
+                  "allocation_status": "no_attempt"
+                }
+              }
+            ],
+            "2": [
+              {
+                "state": "STARTED",
+                "primary": true,
+                "node": "ejy2E2sMTg6nqnjhF9KfsQ",
+                "relocating_node": null,
+                "shard": 2,
+                "index": "index1",
+                "allocation_id": {
+                  "id": "o5kBd295ReKi2g4g1bpjyA"
+                }
+              },
+              {
+                "state": "UNASSIGNED",
+                "primary": false,
+                "node": null,
+                "relocating_node": null,
+                "shard": 2,
+                "index": "index1",
+                "recovery_source": {
+                  "type": "PEER"
+                },
+                "unassigned_info": {
+                  "reason": "INDEX_CREATED",
+                  "at": "2018-10-15T08:28:05.063Z",
+                  "delayed": false,
+                  "allocation_status": "no_attempt"
+                }
+              }
+            ],
+            "3": [
+              {
+                "state": "STARTED",
+                "primary": true,
+                "node": "ejy2E2sMTg6nqnjhF9KfsQ",
+                "relocating_node": null,
+                "shard": 3,
+                "index": "index1",
+                "allocation_id": {
+                  "id": "orpHABU0S8eJ0Nd82U_SQA"
+                }
+              },
+              {
+                "state": "UNASSIGNED",
+                "primary": false,
+                "node": null,
+                "relocating_node": null,
+                "shard": 3,
+                "index": "index1",
+                "recovery_source": {
+                  "type": "PEER"
+                },
+                "unassigned_info": {
+                  "reason": "INDEX_CREATED",
+                  "at": "2018-10-15T08:28:05.063Z",
+                  "delayed": false,
+                  "allocation_status": "no_attempt"
+                }
+              }
+            ],
+            "4": [
+              {
+                "state": "STARTED",
+                "primary": true,
+                "node": "ejy2E2sMTg6nqnjhF9KfsQ",
+                "relocating_node": null,
+                "shard": 4,
+                "index": "index1",
+                "allocation_id": {
+                  "id": "6I6OQ1QfTgCvHigkIdmuPA"
+                }
+              },
+              {
+                "state": "UNASSIGNED",
+                "primary": false,
+                "node": null,
+                "relocating_node": null,
+                "shard": 4,
+                "index": "index1",
+                "recovery_source": {
+                  "type": "PEER"
+                },
+                "unassigned_info": {
+                  "reason": "INDEX_CREATED",
+                  "at": "2018-10-15T08:28:05.063Z",
+                  "delayed": false,
+                  "allocation_status": "no_attempt"
+                }
+              }
+            ]
+          }
+        }
+      }
+    },
+    "routing_nodes": {
+      "unassigned": [
+        {
+          "state": "UNASSIGNED",
+          "primary": false,
+          "node": null,
+          "relocating_node": null,
+          "shard": 2,
+          "index": "index2",
+          "recovery_source": {
+            "type": "PEER"
+          },
+          "unassigned_info": {
+            "reason": "INDEX_CREATED",
+            "at": "2018-10-15T08:28:10.325Z",
+            "delayed": false,
+            "allocation_status": "no_attempt"
+          }
+        },
+        {
+          "state": "UNASSIGNED",
+          "primary": false,
+          "node": null,
+          "relocating_node": null,
+          "shard": 1,
+          "index": "index2",
+          "recovery_source": {
+            "type": "PEER"
+          },
+          "unassigned_info": {
+            "reason": "INDEX_CREATED",
+            "at": "2018-10-15T08:28:10.325Z",
+            "delayed": false,
+            "allocation_status": "no_attempt"
+          }
+        },
+        {
+          "state": "UNASSIGNED",
+          "primary": false,
+          "node": null,
+          "relocating_node": null,
+          "shard": 4,
+          "index": "index2",
+          "recovery_source": {
+            "type": "PEER"
+          },
+          "unassigned_info": {
+            "reason": "INDEX_CREATED",
+            "at": "2018-10-15T08:28:10.325Z",
+            "delayed": false,
+            "allocation_status": "no_attempt"
+          }
+        },
+        {
+          "state": "UNASSIGNED",
+          "primary": false,
+          "node": null,
+          "relocating_node": null,
+          "shard": 3,
+          "index": "index2",
+          "recovery_source": {
+            "type": "PEER"
+          },
+          "unassigned_info": {
+            "reason": "INDEX_CREATED",
+            "at": "2018-10-15T08:28:10.325Z",
+            "delayed": false,
+            "allocation_status": "no_attempt"
+          }
+        },
+        {
+          "state": "UNASSIGNED",
+          "primary": false,
+          "node": null,
+          "relocating_node": null,
+          "shard": 0,
+          "index": "index2",
+          "recovery_source": {
+            "type": "PEER"
+          },
+          "unassigned_info": {
+            "reason": "INDEX_CREATED",
+            "at": "2018-10-15T08:28:10.325Z",
+            "delayed": false,
+            "allocation_status": "no_attempt"
+          }
+        },
+        {
+          "state": "UNASSIGNED",
+          "primary": false,
+          "node": null,
+          "relocating_node": null,
+          "shard": 2,
+          "index": "index1",
+          "recovery_source": {
+            "type": "PEER"
+          },
+          "unassigned_info": {
+            "reason": "INDEX_CREATED",
+            "at": "2018-10-15T08:28:05.063Z",
+            "delayed": false,
+            "allocation_status": "no_attempt"
+          }
+        },
+        {
+          "state": "UNASSIGNED",
+          "primary": false,
+          "node": null,
+          "relocating_node": null,
+          "shard": 1,
+          "index": "index1",
+          "recovery_source": {
+            "type": "PEER"
+          },
+          "unassigned_info": {
+            "reason": "INDEX_CREATED",
+            "at": "2018-10-15T08:28:05.063Z",
+            "delayed": false,
+            "allocation_status": "no_attempt"
+          }
+        },
+        {
+          "state": "UNASSIGNED",
+          "primary": false,
+          "node": null,
+          "relocating_node": null,
+          "shard": 4,
+          "index": "index1",
+          "recovery_source": {
+            "type": "PEER"
+          },
+          "unassigned_info": {
+            "reason": "INDEX_CREATED",
+            "at": "2018-10-15T08:28:05.063Z",
+            "delayed": false,
+            "allocation_status": "no_attempt"
+          }
+        },
+        {
+          "state": "UNASSIGNED",
+          "primary": false,
+          "node": null,
+          "relocating_node": null,
+          "shard": 3,
+          "index": "index1",
+          "recovery_source": {
+            "type": "PEER"
+          },
+          "unassigned_info": {
+            "reason": "INDEX_CREATED",
+            "at": "2018-10-15T08:28:05.063Z",
+            "delayed": false,
+            "allocation_status": "no_attempt"
+          }
+        },
+        {
+          "state": "UNASSIGNED",
+          "primary": false,
+          "node": null,
+          "relocating_node": null,
+          "shard": 0,
+          "index": "index1",
+          "recovery_source": {
+            "type": "PEER"
+          },
+          "unassigned_info": {
+            "reason": "INDEX_CREATED",
+            "at": "2018-10-15T08:28:05.063Z",
+            "delayed": false,
+            "allocation_status": "no_attempt"
+          }
+        }
+      ],
+      "nodes": {
+        "ejy2E2sMTg6nqnjhF9KfsQ": [
+          {
+            "state": "STARTED",
+            "primary": true,
+            "node": "ejy2E2sMTg6nqnjhF9KfsQ",
+            "relocating_node": null,
+            "shard": 2,
+            "index": "index2",
+            "allocation_id": {
+              "id": "4UZfdxQeT7CMUxI9Fl5tYA"
+            }
+          },
+          {
+            "state": "STARTED",
+            "primary": true,
+            "node": "ejy2E2sMTg6nqnjhF9KfsQ",
+            "relocating_node": null,
+            "shard": 1,
+            "index": "index2",
+            "allocation_id": {
+              "id": "sNsOyQBnSdKQuFETNtRYng"
+            }
+          },
+          {
+            "state": "STARTED",
+            "primary": true,
+            "node": "ejy2E2sMTg6nqnjhF9KfsQ",
+            "relocating_node": null,
+            "shard": 4,
+            "index": "index2",
+            "allocation_id": {
+              "id": "GhBM4mIdTAG-IVjGYFazkQ"
+            }
+          },
+          {
+            "state": "STARTED",
+            "primary": true,
+            "node": "ejy2E2sMTg6nqnjhF9KfsQ",
+            "relocating_node": null,
+            "shard": 3,
+            "index": "index2",
+            "allocation_id": {
+              "id": "70TzfLRxQ_KL-tT81-QO4w"
+            }
+          },
+          {
+            "state": "STARTED",
+            "primary": true,
+            "node": "ejy2E2sMTg6nqnjhF9KfsQ",
+            "relocating_node": null,
+            "shard": 0,
+            "index": "index2",
+            "allocation_id": {
+              "id": "gbBnb3KFQOyXHl3eaVV6nA"
+            }
+          },
+          {
+            "state": "STARTED",
+            "primary": true,
+            "node": "ejy2E2sMTg6nqnjhF9KfsQ",
+            "relocating_node": null,
+            "shard": 2,
+            "index": "index1",
+            "allocation_id": {
+              "id": "o5kBd295ReKi2g4g1bpjyA"
+            }
+          },
+          {
+            "state": "STARTED",
+            "primary": true,
+            "node": "ejy2E2sMTg6nqnjhF9KfsQ",
+            "relocating_node": null,
+            "shard": 1,
+            "index": "index1",
+            "allocation_id": {
+              "id": "_ASJYn1bRO2MnCN0HKH5BA"
+            }
+          },
+          {
+            "state": "STARTED",
+            "primary": true,
+            "node": "ejy2E2sMTg6nqnjhF9KfsQ",
+            "relocating_node": null,
+            "shard": 4,
+            "index": "index1",
+            "allocation_id": {
+              "id": "6I6OQ1QfTgCvHigkIdmuPA"
+            }
+          },
+          {
+            "state": "STARTED",
+            "primary": true,
+            "node": "ejy2E2sMTg6nqnjhF9KfsQ",
+            "relocating_node": null,
+            "shard": 3,
+            "index": "index1",
+            "allocation_id": {
+              "id": "orpHABU0S8eJ0Nd82U_SQA"
+            }
+          },
+          {
+            "state": "STARTED",
+            "primary": true,
+            "node": "ejy2E2sMTg6nqnjhF9KfsQ",
+            "relocating_node": null,
+            "shard": 0,
+            "index": "index1",
+            "allocation_id": {
+              "id": "WFVdvk1eQrmOfemq6UoBIw"
+            }
+          }
+        ]
+      }
+    }
+  }

--- a/fe/src/test/resources/data/es/clusterstate5.json
+++ b/fe/src/test/resources/data/es/clusterstate5.json
@@ -1,0 +1,751 @@
+{
+    "cluster_name": "elasticsearch",
+    "version": 28,
+    "state_uuid": "C6WNazFPSPyZcQlE-cNw1g",
+    "master_node": "ejy2E2sMTg6nqnjhF9KfsQ",
+    "blocks": {},
+    "nodes": {
+      "ejy2E2sMTg6nqnjhF9KfsQ": {
+        "name": "ejy2E2s",
+        "ephemeral_id": "HO-_F6BLSqedHuv7-yhkNQ",
+        "transport_address": "192.168.0.1:9209",
+        "attributes": {
+	}
+      }
+    },
+    "metadata": {
+      "cluster_uuid": "_na_",
+      "templates": {},
+      "indices": {
+        "index2": {
+          "state": "open",
+          "settings": {
+            "index": {
+              "bpack": {
+                "partition": {
+                  "upperbound": "2018-10-02"
+                }
+              },
+              "number_of_shards": "5",
+              "provided_name": "index2",
+              "creation_date": "1539592090322",
+              "number_of_replicas": "1",
+              "uuid": "T-Kg83WaTOSIXmiO0ZANzg",
+              "version": {
+                "created": "5050099"
+              }
+            }
+          },
+          "mappings": {},
+          "aliases": [
+            "indexa"
+          ],
+          "primary_terms": {
+            "0": 1,
+            "1": 1,
+            "2": 1,
+            "3": 1,
+            "4": 1
+          },
+          "in_sync_allocations": {
+            "0": [
+              "gbBnb3KFQOyXHl3eaVV6nA"
+            ],
+            "1": [
+              "sNsOyQBnSdKQuFETNtRYng"
+            ],
+            "2": [
+              "4UZfdxQeT7CMUxI9Fl5tYA"
+            ],
+            "3": [
+              "70TzfLRxQ_KL-tT81-QO4w"
+            ],
+            "4": [
+              "GhBM4mIdTAG-IVjGYFazkQ"
+            ]
+          }
+        },
+        "index1": {
+          "state": "open",
+          "settings": {
+            "index": {
+              "bpack": {
+                "partition": {
+                  "upperbound": "2018-10-01"
+                }
+              },
+              "number_of_shards": "5",
+              "provided_name": "index1",
+              "creation_date": "1539592085059",
+              "number_of_replicas": "1",
+              "uuid": "hjbl6RxaTyCYFfAJwaSjCA",
+              "version": {
+                "created": "5050099"
+              }
+            }
+          },
+          "mappings": {},
+          "aliases": [
+            "indexa"
+          ],
+          "primary_terms": {
+            "0": 1,
+            "1": 1,
+            "2": 1,
+            "3": 1,
+            "4": 1
+          },
+          "in_sync_allocations": {
+            "0": [
+              "WFVdvk1eQrmOfemq6UoBIw"
+            ],
+            "1": [
+              "_ASJYn1bRO2MnCN0HKH5BA"
+            ],
+            "2": [
+              "o5kBd295ReKi2g4g1bpjyA"
+            ],
+            "3": [
+              "orpHABU0S8eJ0Nd82U_SQA"
+            ],
+            "4": [
+              "6I6OQ1QfTgCvHigkIdmuPA"
+            ]
+          }
+        }
+      },
+      "index-graveyard": {
+        "tombstones": []
+      }
+    },
+    "routing_table": {
+      "indices": {
+        "index2": {
+          "shards": {
+            "0": [
+              {
+                "state": "STARTED",
+                "primary": true,
+                "node": "ejy2E2sMTg6nqnjhF9KfsQ",
+                "relocating_node": null,
+                "shard": 0,
+                "index": "index2",
+                "allocation_id": {
+                  "id": "gbBnb3KFQOyXHl3eaVV6nA"
+                }
+              },
+              {
+                "state": "UNASSIGNED",
+                "primary": false,
+                "node": null,
+                "relocating_node": null,
+                "shard": 0,
+                "index": "index2",
+                "recovery_source": {
+                  "type": "PEER"
+                },
+                "unassigned_info": {
+                  "reason": "INDEX_CREATED",
+                  "at": "2018-10-15T08:28:10.325Z",
+                  "delayed": false,
+                  "allocation_status": "no_attempt"
+                }
+              }
+            ],
+            "1": [
+              {
+                "state": "STARTED",
+                "primary": true,
+                "node": "ejy2E2sMTg6nqnjhF9KfsQ",
+                "relocating_node": null,
+                "shard": 1,
+                "index": "index2",
+                "allocation_id": {
+                  "id": "sNsOyQBnSdKQuFETNtRYng"
+                }
+              },
+              {
+                "state": "UNASSIGNED",
+                "primary": false,
+                "node": null,
+                "relocating_node": null,
+                "shard": 1,
+                "index": "index2",
+                "recovery_source": {
+                  "type": "PEER"
+                },
+                "unassigned_info": {
+                  "reason": "INDEX_CREATED",
+                  "at": "2018-10-15T08:28:10.325Z",
+                  "delayed": false,
+                  "allocation_status": "no_attempt"
+                }
+              }
+            ],
+            "2": [
+              {
+                "state": "STARTED",
+                "primary": true,
+                "node": "ejy2E2sMTg6nqnjhF9KfsQ",
+                "relocating_node": null,
+                "shard": 2,
+                "index": "index2",
+                "allocation_id": {
+                  "id": "4UZfdxQeT7CMUxI9Fl5tYA"
+                }
+              },
+              {
+                "state": "UNASSIGNED",
+                "primary": false,
+                "node": null,
+                "relocating_node": null,
+                "shard": 2,
+                "index": "index2",
+                "recovery_source": {
+                  "type": "PEER"
+                },
+                "unassigned_info": {
+                  "reason": "INDEX_CREATED",
+                  "at": "2018-10-15T08:28:10.325Z",
+                  "delayed": false,
+                  "allocation_status": "no_attempt"
+                }
+              }
+            ],
+            "3": [
+              {
+                "state": "STARTED",
+                "primary": true,
+                "node": "ejy2E2sMTg6nqnjhF9KfsQ",
+                "relocating_node": null,
+                "shard": 3,
+                "index": "index2",
+                "allocation_id": {
+                  "id": "70TzfLRxQ_KL-tT81-QO4w"
+                }
+              },
+              {
+                "state": "UNASSIGNED",
+                "primary": false,
+                "node": null,
+                "relocating_node": null,
+                "shard": 3,
+                "index": "index2",
+                "recovery_source": {
+                  "type": "PEER"
+                },
+                "unassigned_info": {
+                  "reason": "INDEX_CREATED",
+                  "at": "2018-10-15T08:28:10.325Z",
+                  "delayed": false,
+                  "allocation_status": "no_attempt"
+                }
+              }
+            ],
+            "4": [
+              {
+                "state": "STARTED",
+                "primary": true,
+                "node": "ejy2E2sMTg6nqnjhF9KfsQ",
+                "relocating_node": null,
+                "shard": 4,
+                "index": "index2",
+                "allocation_id": {
+                  "id": "GhBM4mIdTAG-IVjGYFazkQ"
+                }
+              },
+              {
+                "state": "UNASSIGNED",
+                "primary": false,
+                "node": null,
+                "relocating_node": null,
+                "shard": 4,
+                "index": "index2",
+                "recovery_source": {
+                  "type": "PEER"
+                },
+                "unassigned_info": {
+                  "reason": "INDEX_CREATED",
+                  "at": "2018-10-15T08:28:10.325Z",
+                  "delayed": false,
+                  "allocation_status": "no_attempt"
+                }
+              }
+            ],
+            "5": [
+              {
+                "state": "STARTED",
+                "primary": true,
+                "node": "ejy2E2sMTg6nqnjhF9KfsQ",
+                "relocating_node": null,
+                "shard": 4,
+                "index": "index2",
+                "allocation_id": {
+                  "id": "GhBM4mIdTAG-IVjGYFazkQ"
+                }
+              },
+              {
+                "state": "UNASSIGNED",
+                "primary": false,
+                "node": null,
+                "relocating_node": null,
+                "shard": 4,
+                "index": "index2",
+                "recovery_source": {
+                  "type": "PEER"
+                },
+                "unassigned_info": {
+                  "reason": "INDEX_CREATED",
+                  "at": "2018-10-15T08:28:10.325Z",
+                  "delayed": false,
+                  "allocation_status": "no_attempt"
+                }
+              }
+            ]
+          }
+        },
+        "index1": {
+          "shards": {
+            "0": [
+              {
+                "state": "STARTED",
+                "primary": true,
+                "node": "ejy2E2sMTg6nqnjhF9KfsQ",
+                "relocating_node": null,
+                "shard": 0,
+                "index": "index1",
+                "allocation_id": {
+                  "id": "WFVdvk1eQrmOfemq6UoBIw"
+                }
+              },
+              {
+                "state": "UNASSIGNED",
+                "primary": false,
+                "node": null,
+                "relocating_node": null,
+                "shard": 0,
+                "index": "index1",
+                "recovery_source": {
+                  "type": "PEER"
+                },
+                "unassigned_info": {
+                  "reason": "INDEX_CREATED",
+                  "at": "2018-10-15T08:28:05.063Z",
+                  "delayed": false,
+                  "allocation_status": "no_attempt"
+                }
+              }
+            ],
+            "1": [
+              {
+                "state": "STARTED",
+                "primary": true,
+                "node": "ejy2E2sMTg6nqnjhF9KfsQ",
+                "relocating_node": null,
+                "shard": 1,
+                "index": "index1",
+                "allocation_id": {
+                  "id": "_ASJYn1bRO2MnCN0HKH5BA"
+                }
+              },
+              {
+                "state": "UNASSIGNED",
+                "primary": false,
+                "node": null,
+                "relocating_node": null,
+                "shard": 1,
+                "index": "index1",
+                "recovery_source": {
+                  "type": "PEER"
+                },
+                "unassigned_info": {
+                  "reason": "INDEX_CREATED",
+                  "at": "2018-10-15T08:28:05.063Z",
+                  "delayed": false,
+                  "allocation_status": "no_attempt"
+                }
+              }
+            ],
+            "2": [
+              {
+                "state": "STARTED",
+                "primary": true,
+                "node": "ejy2E2sMTg6nqnjhF9KfsQ",
+                "relocating_node": null,
+                "shard": 2,
+                "index": "index1",
+                "allocation_id": {
+                  "id": "o5kBd295ReKi2g4g1bpjyA"
+                }
+              },
+              {
+                "state": "UNASSIGNED",
+                "primary": false,
+                "node": null,
+                "relocating_node": null,
+                "shard": 2,
+                "index": "index1",
+                "recovery_source": {
+                  "type": "PEER"
+                },
+                "unassigned_info": {
+                  "reason": "INDEX_CREATED",
+                  "at": "2018-10-15T08:28:05.063Z",
+                  "delayed": false,
+                  "allocation_status": "no_attempt"
+                }
+              }
+            ],
+            "3": [
+              {
+                "state": "STARTED",
+                "primary": true,
+                "node": "ejy2E2sMTg6nqnjhF9KfsQ",
+                "relocating_node": null,
+                "shard": 3,
+                "index": "index1",
+                "allocation_id": {
+                  "id": "orpHABU0S8eJ0Nd82U_SQA"
+                }
+              },
+              {
+                "state": "UNASSIGNED",
+                "primary": false,
+                "node": null,
+                "relocating_node": null,
+                "shard": 3,
+                "index": "index1",
+                "recovery_source": {
+                  "type": "PEER"
+                },
+                "unassigned_info": {
+                  "reason": "INDEX_CREATED",
+                  "at": "2018-10-15T08:28:05.063Z",
+                  "delayed": false,
+                  "allocation_status": "no_attempt"
+                }
+              }
+            ],
+            "4": [
+              {
+                "state": "STARTED",
+                "primary": true,
+                "node": "ejy2E2sMTg6nqnjhF9KfsQ",
+                "relocating_node": null,
+                "shard": 4,
+                "index": "index1",
+                "allocation_id": {
+                  "id": "6I6OQ1QfTgCvHigkIdmuPA"
+                }
+              },
+              {
+                "state": "UNASSIGNED",
+                "primary": false,
+                "node": null,
+                "relocating_node": null,
+                "shard": 4,
+                "index": "index1",
+                "recovery_source": {
+                  "type": "PEER"
+                },
+                "unassigned_info": {
+                  "reason": "INDEX_CREATED",
+                  "at": "2018-10-15T08:28:05.063Z",
+                  "delayed": false,
+                  "allocation_status": "no_attempt"
+                }
+              }
+            ]
+          }
+        }
+      }
+    },
+    "routing_nodes": {
+      "unassigned": [
+        {
+          "state": "UNASSIGNED",
+          "primary": false,
+          "node": null,
+          "relocating_node": null,
+          "shard": 2,
+          "index": "index2",
+          "recovery_source": {
+            "type": "PEER"
+          },
+          "unassigned_info": {
+            "reason": "INDEX_CREATED",
+            "at": "2018-10-15T08:28:10.325Z",
+            "delayed": false,
+            "allocation_status": "no_attempt"
+          }
+        },
+        {
+          "state": "UNASSIGNED",
+          "primary": false,
+          "node": null,
+          "relocating_node": null,
+          "shard": 1,
+          "index": "index2",
+          "recovery_source": {
+            "type": "PEER"
+          },
+          "unassigned_info": {
+            "reason": "INDEX_CREATED",
+            "at": "2018-10-15T08:28:10.325Z",
+            "delayed": false,
+            "allocation_status": "no_attempt"
+          }
+        },
+        {
+          "state": "UNASSIGNED",
+          "primary": false,
+          "node": null,
+          "relocating_node": null,
+          "shard": 4,
+          "index": "index2",
+          "recovery_source": {
+            "type": "PEER"
+          },
+          "unassigned_info": {
+            "reason": "INDEX_CREATED",
+            "at": "2018-10-15T08:28:10.325Z",
+            "delayed": false,
+            "allocation_status": "no_attempt"
+          }
+        },
+        {
+          "state": "UNASSIGNED",
+          "primary": false,
+          "node": null,
+          "relocating_node": null,
+          "shard": 3,
+          "index": "index2",
+          "recovery_source": {
+            "type": "PEER"
+          },
+          "unassigned_info": {
+            "reason": "INDEX_CREATED",
+            "at": "2018-10-15T08:28:10.325Z",
+            "delayed": false,
+            "allocation_status": "no_attempt"
+          }
+        },
+        {
+          "state": "UNASSIGNED",
+          "primary": false,
+          "node": null,
+          "relocating_node": null,
+          "shard": 0,
+          "index": "index2",
+          "recovery_source": {
+            "type": "PEER"
+          },
+          "unassigned_info": {
+            "reason": "INDEX_CREATED",
+            "at": "2018-10-15T08:28:10.325Z",
+            "delayed": false,
+            "allocation_status": "no_attempt"
+          }
+        },
+        {
+          "state": "UNASSIGNED",
+          "primary": false,
+          "node": null,
+          "relocating_node": null,
+          "shard": 2,
+          "index": "index1",
+          "recovery_source": {
+            "type": "PEER"
+          },
+          "unassigned_info": {
+            "reason": "INDEX_CREATED",
+            "at": "2018-10-15T08:28:05.063Z",
+            "delayed": false,
+            "allocation_status": "no_attempt"
+          }
+        },
+        {
+          "state": "UNASSIGNED",
+          "primary": false,
+          "node": null,
+          "relocating_node": null,
+          "shard": 1,
+          "index": "index1",
+          "recovery_source": {
+            "type": "PEER"
+          },
+          "unassigned_info": {
+            "reason": "INDEX_CREATED",
+            "at": "2018-10-15T08:28:05.063Z",
+            "delayed": false,
+            "allocation_status": "no_attempt"
+          }
+        },
+        {
+          "state": "UNASSIGNED",
+          "primary": false,
+          "node": null,
+          "relocating_node": null,
+          "shard": 4,
+          "index": "index1",
+          "recovery_source": {
+            "type": "PEER"
+          },
+          "unassigned_info": {
+            "reason": "INDEX_CREATED",
+            "at": "2018-10-15T08:28:05.063Z",
+            "delayed": false,
+            "allocation_status": "no_attempt"
+          }
+        },
+        {
+          "state": "UNASSIGNED",
+          "primary": false,
+          "node": null,
+          "relocating_node": null,
+          "shard": 3,
+          "index": "index1",
+          "recovery_source": {
+            "type": "PEER"
+          },
+          "unassigned_info": {
+            "reason": "INDEX_CREATED",
+            "at": "2018-10-15T08:28:05.063Z",
+            "delayed": false,
+            "allocation_status": "no_attempt"
+          }
+        },
+        {
+          "state": "UNASSIGNED",
+          "primary": false,
+          "node": null,
+          "relocating_node": null,
+          "shard": 0,
+          "index": "index1",
+          "recovery_source": {
+            "type": "PEER"
+          },
+          "unassigned_info": {
+            "reason": "INDEX_CREATED",
+            "at": "2018-10-15T08:28:05.063Z",
+            "delayed": false,
+            "allocation_status": "no_attempt"
+          }
+        }
+      ],
+      "nodes": {
+        "ejy2E2sMTg6nqnjhF9KfsQ": [
+          {
+            "state": "STARTED",
+            "primary": true,
+            "node": "ejy2E2sMTg6nqnjhF9KfsQ",
+            "relocating_node": null,
+            "shard": 2,
+            "index": "index2",
+            "allocation_id": {
+              "id": "4UZfdxQeT7CMUxI9Fl5tYA"
+            }
+          },
+          {
+            "state": "STARTED",
+            "primary": true,
+            "node": "ejy2E2sMTg6nqnjhF9KfsQ",
+            "relocating_node": null,
+            "shard": 1,
+            "index": "index2",
+            "allocation_id": {
+              "id": "sNsOyQBnSdKQuFETNtRYng"
+            }
+          },
+          {
+            "state": "STARTED",
+            "primary": true,
+            "node": "ejy2E2sMTg6nqnjhF9KfsQ",
+            "relocating_node": null,
+            "shard": 4,
+            "index": "index2",
+            "allocation_id": {
+              "id": "GhBM4mIdTAG-IVjGYFazkQ"
+            }
+          },
+          {
+            "state": "STARTED",
+            "primary": true,
+            "node": "ejy2E2sMTg6nqnjhF9KfsQ",
+            "relocating_node": null,
+            "shard": 3,
+            "index": "index2",
+            "allocation_id": {
+              "id": "70TzfLRxQ_KL-tT81-QO4w"
+            }
+          },
+          {
+            "state": "STARTED",
+            "primary": true,
+            "node": "ejy2E2sMTg6nqnjhF9KfsQ",
+            "relocating_node": null,
+            "shard": 0,
+            "index": "index2",
+            "allocation_id": {
+              "id": "gbBnb3KFQOyXHl3eaVV6nA"
+            }
+          },
+          {
+            "state": "STARTED",
+            "primary": true,
+            "node": "ejy2E2sMTg6nqnjhF9KfsQ",
+            "relocating_node": null,
+            "shard": 2,
+            "index": "index1",
+            "allocation_id": {
+              "id": "o5kBd295ReKi2g4g1bpjyA"
+            }
+          },
+          {
+            "state": "STARTED",
+            "primary": true,
+            "node": "ejy2E2sMTg6nqnjhF9KfsQ",
+            "relocating_node": null,
+            "shard": 1,
+            "index": "index1",
+            "allocation_id": {
+              "id": "_ASJYn1bRO2MnCN0HKH5BA"
+            }
+          },
+          {
+            "state": "STARTED",
+            "primary": true,
+            "node": "ejy2E2sMTg6nqnjhF9KfsQ",
+            "relocating_node": null,
+            "shard": 4,
+            "index": "index1",
+            "allocation_id": {
+              "id": "6I6OQ1QfTgCvHigkIdmuPA"
+            }
+          },
+          {
+            "state": "STARTED",
+            "primary": true,
+            "node": "ejy2E2sMTg6nqnjhF9KfsQ",
+            "relocating_node": null,
+            "shard": 3,
+            "index": "index1",
+            "allocation_id": {
+              "id": "orpHABU0S8eJ0Nd82U_SQA"
+            }
+          },
+          {
+            "state": "STARTED",
+            "primary": true,
+            "node": "ejy2E2sMTg6nqnjhF9KfsQ",
+            "relocating_node": null,
+            "shard": 0,
+            "index": "index1",
+            "allocation_id": {
+              "id": "WFVdvk1eQrmOfemq6UoBIw"
+            }
+          }
+        ]
+      }
+    }
+  }


### PR DESCRIPTION
- EsScanNode throws exception when es table without partition info.
- Ignore failed shard routing when parse es cluster state.
- add more unit test for es table without partition info.