### PR TITLE
Change the default bdbje sync policy to SYNC

### DIFF
--- a/fe/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/src/main/java/org/apache/doris/common/Config.java
@@ -132,6 +132,11 @@ public class Config extends ConfigBase {
      * more info, see: http://docs.oracle.com/cd/E17277_02/html/java/com/sleepycat/je/Durability.ReplicaAckPolicy.html
      */
     @ConfField public static String replica_ack_policy = "SIMPLE_MAJORITY"; // ALL, NONE, SIMPLE_MAJORITY
+    
+    /*
+     * the max txn number which bdbje can rollback when trying to rejoin the group
+     */
+    @ConfField public static int txn_rollback_limit = 100;
 
     /*
      * Specified an IP for frontend, instead of the ip get by *InetAddress.getByName*.

--- a/fe/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/src/main/java/org/apache/doris/common/Config.java
@@ -118,13 +118,15 @@ public class Config extends ConfigBase {
     @ConfField public static int meta_delay_toleration_second = 300;    // 5 min
     /*
      * Master FE sync policy of bdbje.
+     * If you only deploy one Follower FE, set this to 'SYNC'. If you deploy more than 3 Follower FE,
+     * you can set this and the following 'replica_sync_policy' to WRITE_NO_SYNC.
      * more info, see: http://docs.oracle.com/cd/E17277_02/html/java/com/sleepycat/je/Durability.SyncPolicy.html
      */
-    @ConfField public static String master_sync_policy = "WRITE_NO_SYNC"; // SYNC, NO_SYNC, WRITE_NO_SYNC
+    @ConfField public static String master_sync_policy = "SYNC"; // SYNC, NO_SYNC, WRITE_NO_SYNC
     /*
      * Follower FE sync policy of bdbje.
      */
-    @ConfField public static String replica_sync_policy = "WRITE_NO_SYNC"; // SYNC, NO_SYNC, WRITE_NO_SYNC
+    @ConfField public static String replica_sync_policy = "SYNC"; // SYNC, NO_SYNC, WRITE_NO_SYNC
     /*
      * Replica ack policy of bdbje.
      * more info, see: http://docs.oracle.com/cd/E17277_02/html/java/com/sleepycat/je/Durability.ReplicaAckPolicy.html

--- a/fe/src/main/java/org/apache/doris/journal/bdbje/BDBEnvironment.java
+++ b/fe/src/main/java/org/apache/doris/journal/bdbje/BDBEnvironment.java
@@ -105,6 +105,8 @@ public class BDBEnvironment {
         replicationConfig.setGroupName(PALO_JOURNAL_GROUP);
         replicationConfig.setConfigParam(ReplicationConfig.ENV_UNKNOWN_STATE_TIMEOUT, "10");
         replicationConfig.setMaxClockDelta(Config.max_bdbje_clock_delta_ms, TimeUnit.MILLISECONDS);
+        replicationConfig.setConfigParam(ReplicationConfig.TXN_ROLLBACK_LIMIT,
+                String.valueOf(Config.txn_rollback_limit));
 
         if (isElectable) {
             replicationConfig.setReplicaAckTimeout(2, TimeUnit.SECONDS);


### PR DESCRIPTION
Also add a new config 'txn_rollback_limit'.
In case that only one Master FE is deployed and 'master_sync_policy' is set to 'WRITE_NO_SYNC',
the meta journal may be lost when system crash. So that some journal which are already synced to other FEs should be rollbacked.
And the default 'txn_rollback_limit' is only 10 in bdbje, which is not enough for some cases