### PR TITLE
Fix some bugs of alter table operation

### DIFF
--- a/docs/help/Contents/Administration/admin_show_stmt.md
+++ b/docs/help/Contents/Administration/admin_show_stmt.md
@@ -15,6 +15,7 @@
             OK:             replica 处于健康状态
             DEAD:           replica 所在 Backend 不可用
             VERSION_ERROR:  replica 数据版本有缺失
+            SCHEMA_ERROR:   replica 的 schema hash 不正确
             MISSING:        replica 不存在
 
 ## example

--- a/docs/help/Contents/Data Manipulation/manipulation_stmt.md
+++ b/docs/help/Contents/Data Manipulation/manipulation_stmt.md
@@ -716,8 +716,9 @@
         SHOW DATA [FROM db_name[.table_name]];
         
     说明：
-        如果不指定 FROM 子句，使用展示当前 db 下细分到各个 table 的数据量
-        如果指定 FROM 子句，则展示 table 下细分到各个 index 的数据量
+        1. 如果不指定 FROM 子句，使用展示当前 db 下细分到各个 table 的数据量
+        2. 如果指定 FROM 子句，则展示 table 下细分到各个 index 的数据量
+        3. 如果想查看各个 Partition 的大小，请参阅 help show partitions
 
 ## example
     1. 展示默认 db 的各个 table 的数据量及汇总数据量
@@ -743,7 +744,7 @@
         SHOW PARTITIONS FROM example_db.table_name PARTITION p1;
 
 ## keyword
-    SHOW,PARTITION
+    SHOW,PARTITIONS
     
 # SHOW TABLET
 ## description

--- a/fe/src/main/java/org/apache/doris/alter/AlterHandler.java
+++ b/fe/src/main/java/org/apache/doris/alter/AlterHandler.java
@@ -67,7 +67,7 @@ public abstract class AlterHandler extends Daemon {
     }
     
     public AlterHandler(String name) {
-        super(name);
+        super(name, 20000);
     }
 
     protected void addAlterJob(AlterJob alterJob) {

--- a/fe/src/main/java/org/apache/doris/alter/RollupHandler.java
+++ b/fe/src/main/java/org/apache/doris/alter/RollupHandler.java
@@ -359,9 +359,10 @@ public class RollupHandler extends AlterHandler {
                     // the new replica's init version is -1 until finished history rollup
                     Replica rollupReplica = new Replica(rollupReplicaId, backendId, rollupSchemaHash,
                             ReplicaState.ROLLUP);
-                    // new replica's last failed version is equal to the partition's next version - 1
-                    // has to set failed verison and version hash here, because there will be no load after rollup
-                    // so that if not set here, last failed version will not be set
+                    // new replica's last failed version should be set to the partition's next version - 1,
+                    // if all go well, the last failed version will be overwritten when rollup task finished and update
+                    // replica version info.
+                    // If not set, there is no other way to know that this replica has failed version.
                     rollupReplica.updateVersionInfo(rollupReplica.getVersion(), rollupReplica.getVersionHash(), 
                             partition.getCommittedVersion(), partition.getCommittedVersionHash(), 
                             rollupReplica.getLastSuccessVersion(), rollupReplica.getLastSuccessVersionHash());

--- a/fe/src/main/java/org/apache/doris/alter/RollupJob.java
+++ b/fe/src/main/java/org/apache/doris/alter/RollupJob.java
@@ -953,7 +953,7 @@ public class RollupJob extends AlterJob {
         }
 
         this.finishedTime = System.currentTimeMillis();
-        LOG.info("finished schema change job: {}", tableId);
+        LOG.info("finished rollup job: {}", tableId);
     }
 
     @Override

--- a/fe/src/main/java/org/apache/doris/alter/RollupJob.java
+++ b/fe/src/main/java/org/apache/doris/alter/RollupJob.java
@@ -502,7 +502,7 @@ public class RollupJob extends AlterJob {
         }
 
         this.state = JobState.CANCELLED;
-        if (!Strings.isNullOrEmpty(cancelMsg) && !Strings.isNullOrEmpty(msg)) {
+        if (Strings.isNullOrEmpty(cancelMsg) && !Strings.isNullOrEmpty(msg)) {
             this.cancelMsg = msg;
         }
 
@@ -592,7 +592,6 @@ public class RollupJob extends AlterJob {
         long rowCount = finishTabletInfo.getRow_count();
         // yiguolei: not check version here because the replica's first version will be set by rollup job
         // the version is not set now
-        // the finish task thread doesn't own db lock here, maybe a bug?
         rollupReplica.updateVersionInfo(version, versionHash, dataSize, rowCount);
 
         setReplicaFinished(partitionId, rollupReplicaId);
@@ -654,7 +653,8 @@ public class RollupJob extends AlterJob {
                                 errorReplicas.add(replica);
                             } else if (replica.getLastFailedVersion() > 0
                                     && !partitionIdToUnfinishedReplicaIds.get(partitionId).contains(replica.getId())) {
-                                // if the replica is finished history data, but failed during load, then it is a abnormal
+                                // if the replica has finished converting history data,
+                                // but failed during load, then it is a abnormal.
                                 // remove it from replica set
                                 // have to use delete replica, it will remove it from tablet inverted index
                                 LOG.warn("replica [{}] last failed version > 0 and have finished history rollup job,"
@@ -670,7 +670,8 @@ public class RollupJob extends AlterJob {
                         }
 
                         if (rollupTablet.getReplicas().size() < (expectReplicationNum / 2 + 1)) {
-                            cancelMsg = String.format("rollup job[%d] cancelled. tablet[%d] has few health replica."
+                            cancelMsg = String.format(
+                                    "rollup job[%d] cancelled. rollup tablet[%d] has few health replica."
                                     + " num: %d", tableId, rollupTablet.getId(), replicas.size());
                             LOG.warn(cancelMsg);
                             return -1;

--- a/fe/src/main/java/org/apache/doris/alter/RollupJob.java
+++ b/fe/src/main/java/org/apache/doris/alter/RollupJob.java
@@ -952,6 +952,9 @@ public class RollupJob extends AlterJob {
             db.writeUnlock();
         }
 
+        List<Integer> list = new ArrayList<>();
+        Integer[] arr = list.toArray(new Integer[0]);
+
         this.finishedTime = System.currentTimeMillis();
         LOG.info("finished rollup job: {}", tableId);
     }
@@ -966,9 +969,6 @@ public class RollupJob extends AlterJob {
         // table name
         jobInfo.add(tbl.getName());
 
-        // transactionid
-        jobInfo.add(transactionId);
-
         // create time
         jobInfo.add(TimeUtils.longToTimeString(createTime));
 
@@ -977,6 +977,13 @@ public class RollupJob extends AlterJob {
         // base index and rollup index name
         jobInfo.add(baseIndexName);
         jobInfo.add(rollupIndexName);
+        
+        // rollup id
+        jobInfo.add(rollupIndexId);
+
+        // transaction id
+        jobInfo.add(transactionId);
+
 
         // job state
         jobInfo.add(state.name());

--- a/fe/src/main/java/org/apache/doris/alter/SchemaChangeJob.java
+++ b/fe/src/main/java/org/apache/doris/alter/SchemaChangeJob.java
@@ -533,7 +533,7 @@ public class SchemaChangeJob extends AlterJob {
         }
 
         this.state = JobState.CANCELLED;
-        if (!Strings.isNullOrEmpty(cancelMsg) && !Strings.isNullOrEmpty(msg)) {
+        if (Strings.isNullOrEmpty(cancelMsg) && !Strings.isNullOrEmpty(msg)) {
             this.cancelMsg = msg;
         }
 

--- a/fe/src/main/java/org/apache/doris/alter/SchemaChangeJob.java
+++ b/fe/src/main/java/org/apache/doris/alter/SchemaChangeJob.java
@@ -1086,7 +1086,7 @@ public class SchemaChangeJob extends AlterJob {
 
     @Override
     public void getJobInfo(List<List<Comparable>> jobInfos, OlapTable tbl) {
-        if (changedIndexIdToSchemaVersion == null) {
+        if (changedIndexIdToSchema == null) {
             // for compatibility
             if (state == JobState.FINISHED || state == JobState.CANCELLED) {
                 List<Comparable> jobInfo = new ArrayList<Comparable>();
@@ -1105,9 +1105,9 @@ public class SchemaChangeJob extends AlterJob {
                 return;
             }
 
-            // in previous version, changedIndexIdToSchemaVersion is set to null
+            // in previous version, changedIndexIdToSchema is set to null
             // when job is finished or cancelled.
-            // so if changedIndexIdToSchemaVersion == null, the job'state must be FINISHED or CANCELLED
+            // so if changedIndexIdToSchema == null, the job'state must be FINISHED or CANCELLED
             return;
         }
 

--- a/fe/src/main/java/org/apache/doris/analysis/AdminShowReplicaStatusStmt.java
+++ b/fe/src/main/java/org/apache/doris/analysis/AdminShowReplicaStatusStmt.java
@@ -20,8 +20,8 @@ package org.apache.doris.analysis;
 import org.apache.doris.analysis.BinaryPredicate.Operator;
 import org.apache.doris.catalog.Catalog;
 import org.apache.doris.catalog.Column;
-import org.apache.doris.catalog.ScalarType;
 import org.apache.doris.catalog.Replica.ReplicaStatus;
+import org.apache.doris.catalog.ScalarType;
 import org.apache.doris.cluster.ClusterNamespace;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.ErrorCode;
@@ -40,7 +40,7 @@ import java.util.List;
 public class AdminShowReplicaStatusStmt extends ShowStmt {
     public static final ImmutableList<String> TITLE_NAMES = new ImmutableList.Builder<String>()
             .add("TabletId").add("ReplicaId").add("BackendId").add("Version").add("LastFailedVersion")
-            .add("LastSuccessVersion").add("CommittedVersion").add("VersionNum")
+            .add("LastSuccessVersion").add("CommittedVersion").add("SchemaHash").add("VersionNum")
             .add("State").add("Status")
             .build();
 
@@ -83,7 +83,7 @@ public class AdminShowReplicaStatusStmt extends ShowStmt {
 
         if (!analyzeWhere()) {
             throw new AnalysisException(
-                    "Where clause should looks like: status =/!= 'OK/DEAD/VERSION_ERROR/MISSING'");
+                    "Where clause should looks like: status =/!= 'OK/DEAD/VERSION_ERROR/SCHEMA_ERROR/MISSING'");
         }
     }
 

--- a/fe/src/main/java/org/apache/doris/analysis/CreateTableStmt.java
+++ b/fe/src/main/java/org/apache/doris/analysis/CreateTableStmt.java
@@ -266,7 +266,7 @@ public class CreateTableStmt extends DdlStmt {
             rowLengthBytes += columnDef.getType().getStorageLayoutBytes();
         }
 
-        if (rowLengthBytes > Config.max_layout_length_per_row) {
+        if (rowLengthBytes > Config.max_layout_length_per_row && engineName.equals("olap")) {
             throw new AnalysisException("The size of a row (" + rowLengthBytes + ") exceed the maximal row size: "
                     + Config.max_layout_length_per_row);
         }

--- a/fe/src/main/java/org/apache/doris/analysis/DescribeStmt.java
+++ b/fe/src/main/java/org/apache/doris/analysis/DescribeStmt.java
@@ -19,10 +19,10 @@ package org.apache.doris.analysis;
 
 import org.apache.doris.catalog.Catalog;
 import org.apache.doris.catalog.Column;
-import org.apache.doris.catalog.ScalarType;
 import org.apache.doris.catalog.Database;
 import org.apache.doris.catalog.MysqlTable;
 import org.apache.doris.catalog.OlapTable;
+import org.apache.doris.catalog.ScalarType;
 import org.apache.doris.catalog.Table;
 import org.apache.doris.catalog.Table.TableType;
 import org.apache.doris.common.AnalysisException;
@@ -117,7 +117,7 @@ public class DescribeStmt extends ShowStmt {
             if (!isAllTables) {
                 // show base table schema only
                 String procString = "/dbs/" + db.getId() + "/" + table.getId() + "/" + TableProcDir.INDEX_SCHEMA
-                        + "/" + table.getName();
+                        + "/" + table.getId();
 
                 node = ProcService.getInstance().open(procString);
                 if (node == null) {

--- a/fe/src/main/java/org/apache/doris/backup/BackupJob.java
+++ b/fe/src/main/java/org/apache/doris/backup/BackupJob.java
@@ -644,7 +644,7 @@ public class BackupJob extends AbstractJob {
         Collections.sort(replicaIds);
         for (Long replicaId : replicaIds) {
             Replica replica = tablet.getReplicaById(replicaId);
-            if (replica.getLastFailedVersion() <= 0 && (replica.getVersion() > visibleVersion
+            if (replica.getLastFailedVersion() < 0 && (replica.getVersion() > visibleVersion
                     || (replica.getVersion() == visibleVersion && replica.getVersionHash() == visibleVersionHash))) {
                 return replica;
             }

--- a/fe/src/main/java/org/apache/doris/backup/RestoreJob.java
+++ b/fe/src/main/java/org/apache/doris/backup/RestoreJob.java
@@ -723,7 +723,7 @@ public class RestoreJob extends AbstractJob {
                         Range<PartitionKey> remoteRange = remotePartitionInfo.getRange(remotePartId);
                         DataProperty remoteDataProperty = remotePartitionInfo.getDataProperty(remotePartId);
                         localPartitionInfo.addPartition(restoredPart.getId(), remoteRange,
-                                                                  remoteDataProperty, (short) restoreReplicationNum);
+                                remoteDataProperty, (short) restoreReplicationNum);
                         localTbl.addPartition(restoredPart);
                     }
 
@@ -1205,8 +1205,8 @@ public class RestoreJob extends AbstractJob {
                         continue;
                     }
 
-                    // update partition committed version
-                    part.updateVisibleVersionAndVersionHash(entry.getValue().first, entry.getValue().second);
+                    // update partition visible version
+                    part.updateVersionForRestore(entry.getValue().first, entry.getValue().second);
 
                     // we also need to update the replica version of these overwritten restored partitions
                     for (MaterializedIndex idx : part.getMaterializedIndices()) {

--- a/fe/src/main/java/org/apache/doris/backup/RestoreJob.java
+++ b/fe/src/main/java/org/apache/doris/backup/RestoreJob.java
@@ -502,7 +502,7 @@ public class RestoreJob extends AbstractJob {
                                                 + " in table " + localTbl.getName()
                                                 + " has different replication num '"
                                                 + localRangePartInfo.getReplicationNum(localPartition.getId())
-                                                + "' with parition in repository");
+                                                + "' with parition in repository, which is " + restoreReplicationNum);
                                         return;
                                     }
                                     genFileMapping(localOlapTbl, localPartition, tblInfo.id, backupPartInfo,
@@ -524,7 +524,7 @@ public class RestoreJob extends AbstractJob {
                                             + " in table " + localTbl.getName()
                                             + " has different replication num '"
                                             + localPartInfo.getReplicationNum(localPartition.getId())
-                                            + "' with parition in repository");
+                                            + "' with parition in repository, which is " + restoreReplicationNum);
                                     return;
                                 }
 

--- a/fe/src/main/java/org/apache/doris/backup/RestoreJob.java
+++ b/fe/src/main/java/org/apache/doris/backup/RestoreJob.java
@@ -1116,7 +1116,7 @@ public class RestoreJob extends AbstractJob {
 
         state = RestoreJobState.DOWNLOADING;
 
-        // No log here
+        // No edit log here
         LOG.info("finished to send download tasks to BE. num: {}. {}", batchTask.getTaskNum(), this);
         return;
     }

--- a/fe/src/main/java/org/apache/doris/catalog/Catalog.java
+++ b/fe/src/main/java/org/apache/doris/catalog/Catalog.java
@@ -3791,8 +3791,8 @@ public class Catalog {
 
             // 1. storage type
             sb.append("\"").append(PropertyAnalyzer.PROPERTIES_STORAGE_TYPE).append("\" = \"");
-            TStorageType storageType = olapTable
-                    .getStorageTypeByIndexId(olapTable.getIndexIdByName(olapTable.getName()));
+            TStorageType storageType = olapTable.getStorageTypeByIndexId(
+                    olapTable.getIndexIdByName(olapTable.getName()));
             sb.append(storageType.name()).append("\"");
 
             // 2. bloom filter
@@ -3919,6 +3919,7 @@ public class Catalog {
         }
 
         createTableStmt.add(sb.toString());
+
         // 2. add partition
         if (separatePartition && (table instanceof OlapTable)
                 && ((OlapTable) table).getPartitionInfo().getType() == PartitionType.RANGE

--- a/fe/src/main/java/org/apache/doris/catalog/Partition.java
+++ b/fe/src/main/java/org/apache/doris/catalog/Partition.java
@@ -116,6 +116,10 @@ public class Partition extends MetaObject implements Writable {
         this.state = state;
     }
 
+    /*
+     * If a partition is overwritten by a restore job, we need to reset all version info to
+     * the restored partition version info》
+     */
     public void updateVersionForRestore(long visibleVersion, long visibleVersionHash) {
         this.visibleVersion = visibleVersion;
         this.visibleVersionHash = visibleVersionHash;

--- a/fe/src/main/java/org/apache/doris/catalog/Partition.java
+++ b/fe/src/main/java/org/apache/doris/catalog/Partition.java
@@ -24,6 +24,9 @@ import org.apache.doris.common.io.Writable;
 import org.apache.doris.common.util.Util;
 import org.apache.doris.meta.MetaContext;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -37,6 +40,8 @@ import java.util.Map.Entry;
  * Internal representation of partition-related metadata.
  */
 public class Partition extends MetaObject implements Writable {
+    private static final Logger LOG = LogManager.getLogger(Partition.class);
+
     public static final long PARTITION_INIT_VERSION = 1L;
     public static final long PARTITION_INIT_VERSION_HASH = 0L;
 
@@ -109,6 +114,16 @@ public class Partition extends MetaObject implements Writable {
 
     public void setState(PartitionState state) {
         this.state = state;
+    }
+
+    public void updateVersionForRestore(long visibleVersion, long visibleVersionHash) {
+        this.visibleVersion = visibleVersion;
+        this.visibleVersionHash = visibleVersionHash;
+        this.nextVersion = this.visibleVersion + 1;
+        this.nextVersionHash = Util.generateVersionHash();
+        this.committedVersionHash = visibleVersionHash;
+        LOG.info("update partition {} version for restore: visible: {}-{}, next: {}-{}",
+                visibleVersion, visibleVersionHash, nextVersion, nextVersionHash);
     }
 
     public void updateVisibleVersionAndVersionHash(long visibleVersion, long visibleVersionHash) {

--- a/fe/src/main/java/org/apache/doris/catalog/Replica.java
+++ b/fe/src/main/java/org/apache/doris/catalog/Replica.java
@@ -58,8 +58,8 @@ public class Replica implements Writable {
     private long versionHash;
     private int schemaHash = -1;
 
-    private long dataSize;
-    private long rowCount;
+    private long dataSize = 0;
+    private long rowCount = 0;
     private ReplicaState state;
     
     private long lastFailedVersion = -1L;

--- a/fe/src/main/java/org/apache/doris/catalog/Replica.java
+++ b/fe/src/main/java/org/apache/doris/catalog/Replica.java
@@ -48,7 +48,8 @@ public class Replica implements Writable {
         OK, // health
         DEAD, // backend is not available
         VERSION_ERROR, // missing version
-        MISSING // replica does not exist
+        MISSING, // replica does not exist
+        SCHEMA_ERROR // replica's schema hash does not equal to index's schema hash
     }
     
     private long id;

--- a/fe/src/main/java/org/apache/doris/catalog/Replica.java
+++ b/fe/src/main/java/org/apache/doris/catalog/Replica.java
@@ -218,6 +218,9 @@ public class Replica implements Writable {
             long lastFailedVersion, long lastFailedVersionHash, 
             long lastSuccessVersion, long lastSuccessVersionHash, 
             long newDataSize, long newRowCount) {
+
+        LOG.debug("before update: {}", this.toString());
+
         if (newVersion < this.version) {
             LOG.warn("replica[" + id + "] new version is lower than meta version. " + newVersion + " vs " + version);
             // yiguolei: could not find any reason why new version less than this.version should run???
@@ -282,7 +285,7 @@ public class Replica implements Writable {
             }
         }
 
-        LOG.debug("update {}", this.toString()); 
+        LOG.debug("after update {}", this.toString());
     }
     
     public synchronized void updateLastFailedVersion(long lastFailedVersion, long lastFailedVersionHash) {

--- a/fe/src/main/java/org/apache/doris/common/proc/IndexSchemaProcNode.java
+++ b/fe/src/main/java/org/apache/doris/common/proc/IndexSchemaProcNode.java
@@ -31,7 +31,7 @@ import java.util.List;
 import java.util.Set;
 
 /*
- * SHOW PROC /dbs/dbId/tableId/index_schema/"index name"
+ * SHOW PROC /dbs/dbId/tableId/index_schema/indexId"
  * show index schema
  */
 public class IndexSchemaProcNode implements ProcNodeInterface {

--- a/fe/src/main/java/org/apache/doris/common/proc/ReplicasProcNode.java
+++ b/fe/src/main/java/org/apache/doris/common/proc/ReplicasProcNode.java
@@ -34,7 +34,7 @@ public class ReplicasProcNode implements ProcNodeInterface {
             .add("ReplicaId").add("BackendId").add("Version").add("VersionHash")
             .add("LstSuccessVersion").add("LstSuccessVersionHash")
             .add("LstFailedVersion").add("LstFailedVersionHash")
-            .add("LstFailedTime").add("DataSize").add("RowCount").add("State")
+            .add("LstFailedTime").add("SchemaHash").add("DataSize").add("RowCount").add("State")
             .add("VersionCount").add("PathHash")
             .build();
     
@@ -59,6 +59,7 @@ public class ReplicasProcNode implements ProcNodeInterface {
                                         String.valueOf(replica.getLastFailedVersion()),
                                         String.valueOf(replica.getLastFailedVersionHash()),
                                         TimeUtils.longToTimeString(replica.getLastFailedTimestamp()),
+                                        String.valueOf(replica.getSchemaHash()),
                                         String.valueOf(replica.getDataSize()),
                                         String.valueOf(replica.getRowCount()),
                                         String.valueOf(replica.getState()),

--- a/fe/src/main/java/org/apache/doris/common/proc/RollupProcDir.java
+++ b/fe/src/main/java/org/apache/doris/common/proc/RollupProcDir.java
@@ -32,9 +32,9 @@ import java.util.List;
 
 public class RollupProcDir implements ProcDirInterface {
     public static final ImmutableList<String> TITLE_NAMES = new ImmutableList.Builder<String>()
-            .add("JobId").add("TableName").add("TransactionId").add("CreateTime").add("FinishedTime")
-            .add("BaseIndexName").add("RollupIndexName").add("State").add("Msg")
-            .add("Progress")
+            .add("JobId").add("TableName").add("CreateTime").add("FinishedTime")
+            .add("BaseIndexName").add("RollupIndexName").add("RollupId").add("TransactionId")
+            .add("State").add("Msg") .add("Progress")
             .build();
 
     private RollupHandler rollupHandler;

--- a/fe/src/main/java/org/apache/doris/common/proc/SchemaChangeProcNode.java
+++ b/fe/src/main/java/org/apache/doris/common/proc/SchemaChangeProcNode.java
@@ -29,8 +29,9 @@ import java.util.List;
 
 public class SchemaChangeProcNode implements ProcNodeInterface {
     public static final ImmutableList<String> TITLE_NAMES = new ImmutableList.Builder<String>()
-            .add("JobId").add("TableName").add("TransactionId").add("CreateTime").add("FinishTime")
-            .add("IndexName").add("IndexState").add("State").add("Msg")
+            .add("JobId").add("TableName").add("CreateTime").add("FinishTime")
+            .add("IndexName").add("IndexId").add("SchemaVersion").add("IndexState")
+            .add("TransactionId").add("State").add("Msg")
             .add("Progress")
             .build();
 

--- a/fe/src/main/java/org/apache/doris/common/proc/SchemaChangeProcNode.java
+++ b/fe/src/main/java/org/apache/doris/common/proc/SchemaChangeProcNode.java
@@ -31,8 +31,7 @@ public class SchemaChangeProcNode implements ProcNodeInterface {
     public static final ImmutableList<String> TITLE_NAMES = new ImmutableList.Builder<String>()
             .add("JobId").add("TableName").add("CreateTime").add("FinishTime")
             .add("IndexName").add("IndexId").add("SchemaVersion").add("IndexState")
-            .add("TransactionId").add("State").add("Msg")
-            .add("Progress")
+            .add("TransactionId").add("State").add("Progress").add("Msg")
             .build();
 
     private SchemaChangeHandler schemaChangeHandler;


### PR DESCRIPTION
1. Fix bug that failed to query restored table after schema change.
2. Fix bug that failed to add rollup to restored table.
3. Optimize the info of SHOW ALTER TABLE stmt.
4. Optimize the info of some PROCs.
5. Optimize the tablet checker to avoid adding too much task to scheduler.