### PR TITLE
Auto fix missing version replica

### DIFF
--- a/docs/help/Contents/Data Manipulation/broker_load.md
+++ b/docs/help/Contents/Data Manipulation/broker_load.md
@@ -218,7 +218,6 @@
         LOAD LABEL example_db.label3
         (
         DATA INFILE("hdfs://hdfs_host:hdfs_port/user/palo/data/input/*")
-        NEGATIVE
         INTO TABLE `my_table`
         COLUMNS TERMINATED BY "\\x01"
         )

--- a/fe/src/main/java/org/apache/doris/alter/RollupJob.java
+++ b/fe/src/main/java/org/apache/doris/alter/RollupJob.java
@@ -992,9 +992,7 @@ public class RollupJob extends AlterJob {
         jobInfo.add(cancelMsg);
 
         // progress
-        if (state == JobState.PENDING) {
-            jobInfo.add("0%");
-        } else if (state == JobState.RUNNING) {
+        if (state == JobState.RUNNING) {
             int unfinishedReplicaNum = getUnfinishedReplicaNum();
             int totalReplicaNum = getTotalReplicaNum();
             Preconditions.checkState(unfinishedReplicaNum <= totalReplicaNum);

--- a/fe/src/main/java/org/apache/doris/alter/SchemaChangeJob.java
+++ b/fe/src/main/java/org/apache/doris/alter/SchemaChangeJob.java
@@ -1090,16 +1090,18 @@ public class SchemaChangeJob extends AlterJob {
             // for compatibility
             if (state == JobState.FINISHED || state == JobState.CANCELLED) {
                 List<Comparable> jobInfo = new ArrayList<Comparable>();
-                jobInfo.add(tableId);
-                jobInfo.add(tbl.getName());
-                jobInfo.add(transactionId);
+                jobInfo.add(tableId); // job id
+                jobInfo.add(tbl.getName()); // table name
                 jobInfo.add(TimeUtils.longToTimeString(createTime));
                 jobInfo.add(TimeUtils.longToTimeString(finishedTime));
-                jobInfo.add("N/A");
-                jobInfo.add("N/A");
-                jobInfo.add(state.name());
+                jobInfo.add("N/A"); // index name
+                jobInfo.add("N/A"); // index id
+                jobInfo.add("N/A"); // schema version
+                jobInfo.add("N/A"); // index state
+                jobInfo.add(-1); // transaction id
+                jobInfo.add(state.name()); // job state
+                jobInfo.add("N/A"); // progress
                 jobInfo.add(cancelMsg);
-                jobInfo.add("N/A");
 
                 jobInfos.add(jobInfo);
                 return;
@@ -1163,6 +1165,8 @@ public class SchemaChangeJob extends AlterJob {
 
             if (state == JobState.RUNNING) {
                 jobInfo.add(indexProgress.get(indexId) == null ? "N/A" : indexProgress.get(indexId)); // progress
+            } else {
+                jobInfo.add("N/A");
             }
 
             jobInfo.add(cancelMsg);

--- a/fe/src/main/java/org/apache/doris/analysis/CreateTableStmt.java
+++ b/fe/src/main/java/org/apache/doris/analysis/CreateTableStmt.java
@@ -308,7 +308,7 @@ public class CreateTableStmt extends DdlStmt {
 
         for (ColumnDef columnDef : columnDefs) {
             Column col = columnDef.toColumn();
-            if (keysDesc.getKeysType() == KeysType.UNIQUE_KEYS) {
+            if (keysDesc != null && keysDesc.getKeysType() == KeysType.UNIQUE_KEYS) {
                 if (!col.isKey()) {
                     col.setAggregationTypeImplicit(true);
                 }

--- a/fe/src/main/java/org/apache/doris/catalog/Replica.java
+++ b/fe/src/main/java/org/apache/doris/catalog/Replica.java
@@ -196,6 +196,25 @@ public class Replica implements Writable {
                 lastSuccessVersion, lastSuccessVersionHash, dataSize, rowCount);
     }
     
+    public void updateVersionInfoForRecovery(
+            long newVersion, long newVersionHash,
+            long lastFailedVersion, long lastFailedVersionHash,
+            long lastSuccessVersion, long lastSuccessVersionHash) {
+
+        LOG.warn("update replica {} on backend {}'s version for recovery. version: {}-{}:{}-{}."
+                + " last failed version: {}-{}:{}-{}, last success version: {}-{}:{}-{}",
+                this.version, this.versionHash, newVersion, newVersionHash,
+                this.lastFailedVersion, this.lastFailedVersionHash, lastFailedVersion, lastFailedVersionHash,
+                this.lastSuccessVersion, this.lastSuccessVersionHash, lastSuccessVersion, lastSuccessVersionHash);
+
+        this.version = newVersion;
+        this.versionHash = newVersionHash;
+        this.lastFailedVersion = lastFailedVersion;
+        this.lastFailedVersionHash = lastFailedVersionHash;
+        this.lastSuccessVersion = lastSuccessVersion;
+        this.lastSuccessVersionHash = lastSuccessVersionHash;
+    }
+
     /* last failed version:  LFV
      * last success version: LSV
      * version:              V
@@ -223,14 +242,16 @@ public class Replica implements Writable {
         LOG.debug("before update: {}", this.toString());
 
         if (newVersion < this.version) {
-            LOG.warn("replica[" + id + "] new version is lower than meta version. " + newVersion + " vs " + version);
             // yiguolei: could not find any reason why new version less than this.version should run???
-            return;
+            LOG.warn("replica {} on backend {}'s new version {} is lower than meta version {}",
+                    id, backendId, newVersion, this.version);
         }
+
         this.version = newVersion;
         this.versionHash = newVersionHash;
         this.dataSize = newDataSize;
         this.rowCount = newRowCount;
+
         // just check it
         if (lastSuccessVersion <= this.version) {
             lastSuccessVersion = this.version;


### PR DESCRIPTION
In some cases, BE may lose some version (which is a bug).
We should be also to recover from this situation.

If version is lost in replica, eg: 1,2,3,5,6, version 4 is lost, than BE will
report this tablet as version 3. In FE, this replica's version is 6,
so there is a missing version replica found.
And we will set this replica's last failed version as 4 (3+1) in FE, and let Tablet Scheduler
fix this tablet.
