### PR TITLE
Refactor CreateTableTest

### DIFF
--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -160,13 +160,6 @@ under the License.
             <version>15.0</version>
         </dependency>
 
-        <!-- https://mvnrepository.com/artifact/org.hamcrest/hamcrest-core -->
-        <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-core</artifactId>
-            <version>1.1</version>
-        </dependency>
-
         <!-- https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-core -->
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
For issue [578](https://github.com/apache/incubator-doris/issues/578)

why remove hamcrest-core in pom?

If we use ExpectedException, there will be `java.lang.NoClassDefFoundError: org/hamcrest/TypeSafeMatcher`.

The junit has a dependency on  hamcrest-core, So I think we can remove hamcrest-core dependency.
```
[INFO] +- junit:junit:jar:4.12:test
[INFO] |  \- org.hamcrest:hamcrest-core:jar:1.3:test
```
All FE UT passed.
