### PR TITLE
Allow repair VERSION_IMCOMPLETE tablet when altering table

### DIFF
--- a/fe/src/main/java/org/apache/doris/catalog/Table.java
+++ b/fe/src/main/java/org/apache/doris/catalog/Table.java
@@ -18,7 +18,6 @@
 package org.apache.doris.catalog;
 
 import org.apache.doris.analysis.CreateTableStmt;
-import org.apache.doris.catalog.OlapTable.OlapTableState;
 import org.apache.doris.common.UserException;
 import org.apache.doris.common.io.Text;
 import org.apache.doris.common.io.Writable;
@@ -269,7 +268,8 @@ public class Table extends MetaObject implements Writable {
     /*
      * 1. Only schedule OLAP table.
      * 2. If table is colocate with other table, not schedule it.
-     * 3. if table's state is not NORMAL, not schedule it.
+     * 3. if table's state is not NORMAL, we will schedule it, but will only repair VERSION_IMCOMPLETE status,
+     *      this will be checked in TabletScheduler.
      */
     public boolean needSchedule() {
         if (type != TableType.OLAP) {
@@ -283,12 +283,6 @@ public class Table extends MetaObject implements Writable {
             return false;
         }
 
-        if (olapTable.getState() != OlapTableState.NORMAL) {
-            LOG.info("table {}'s state is not NORMAL: {}, skip tablet scheduler.",
-                    name, olapTable.getState().name());
-            return false;
-        }
-        
         return true;
     }
 }

--- a/fe/src/main/java/org/apache/doris/common/proc/BackendProcNode.java
+++ b/fe/src/main/java/org/apache/doris/common/proc/BackendProcNode.java
@@ -79,6 +79,9 @@ public class BackendProcNode implements ProcNodeInterface {
             }
             info.add(String.format("%.2f", used) + " %");
 
+            info.add(entry.getValue().getState().name());
+            info.add(String.valueOf(entry.getValue().getPathHash()));
+
             result.addRow(info);
         }
 

--- a/fe/src/main/java/org/apache/doris/transaction/TransactionState.java
+++ b/fe/src/main/java/org/apache/doris/transaction/TransactionState.java
@@ -24,6 +24,7 @@ import org.apache.doris.load.TxnStateChangeListener;
 import org.apache.doris.metric.MetricRepo;
 import org.apache.doris.task.PublishVersionTask;
 
+import com.google.common.base.Joiner;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 
@@ -102,6 +103,7 @@ public class TransactionState implements Writable {
     private long commitTime;
     private long finishTime;
     private String reason;
+    // error replica ids
     private Set<Long> errorReplicas;
     private CountDownLatch latch;
     
@@ -397,6 +399,7 @@ public class TransactionState implements Writable {
         sb.append(", coordinator: ").append(coordinator);
         sb.append(", transaction status: ").append(transactionStatus);
         sb.append(", error replicas num: ").append(errorReplicas.size());
+        sb.append(", replica ids: ").append(Joiner.on(",").join(errorReplicas.stream().limit(5).toArray()));
         sb.append(", prepare time: ").append(prepareTime);
         sb.append(", commit time: ").append(commitTime);
         sb.append(", finish time: ").append(finishTime);


### PR DESCRIPTION
Previously we do not allow repair tablet if the table it belongs
to is under ALTER process. But it will possibly let the alter job
failed due to some replica's failure of load.