### PR TITLE
Reopen the thrift client when got exception

### DIFF
--- a/be/src/agent/utils.cpp
+++ b/be/src/agent/utils.cpp
@@ -156,6 +156,7 @@ AgentStatus MasterServerClient::finish_task(
             client->finishTask(*result, request);
         }
     } catch (TException& e) {
+        client.reopen(config::thrift_rpc_timeout_ms);
         OLAP_LOG_WARNING("master client, finishTask execute failed."
                          "host: %s, port: %d, error: %s",
                          _master_info.network_address.hostname.c_str(),
@@ -212,6 +213,7 @@ AgentStatus MasterServerClient::report(const TReportRequest request, TMasterResu
             }   
         }   
     } catch (TException& e) {
+        client.reopen(config::thrift_rpc_timeout_ms);
         LOG(WARNING) << "master client. finish report failed. host: " << _master_info.network_address.hostname
                     << ". port: " << _master_info.network_address.port << ". code: " << client_status.code();
         return DORIS_ERROR;

--- a/be/src/exec/schema_scanner/frontend_helper.cpp
+++ b/be/src/exec/schema_scanner/frontend_helper.cpp
@@ -115,15 +115,15 @@ Status FrontendHelper::rpc(
         std::function<void (FrontendServiceConnection&)> callback,
         int timeout_ms) {
     TNetworkAddress address = make_network_address(ip, port);
-    try {
-        Status status;
-        FrontendServiceConnection client(
+    Status status;
+    FrontendServiceConnection client(
             _s_exec_env->frontend_client_cache(), address, timeout_ms, &status);
-        if (!status.ok()) {
-            LOG(WARNING) << "Connect frontent failed, address=" << address
-                << ", status=" << status.get_error_msg();
-            return status;
-        }
+    if (!status.ok()) {
+        LOG(WARNING) << "Connect frontent failed, address=" << address
+            << ", status=" << status.get_error_msg();
+        return status;
+    }
+    try {
         try {
             callback(client);
         } catch (apache::thrift::transport::TTransportException& e) {
@@ -138,6 +138,8 @@ Status FrontendHelper::rpc(
             callback(client);
         }
     } catch (apache::thrift::TException& e) {
+        // just reopen to disable this connection
+        client.reopen(timeout_ms);
         LOG(WARNING) << "call frontend service failed, address=" << address
             << ", reason=" << e.what();
         return Status(TStatusCode::THRIFT_RPC_ERROR,

--- a/be/src/http/action/mini_load.cpp
+++ b/be/src/http/action/mini_load.cpp
@@ -213,6 +213,8 @@ Status MiniLoadAction::_load(
         }
     } catch (apache::thrift::TException& e) {
         // failed when retry.
+        // reopen to disable this connection
+        client.reopen(config::thrift_rpc_timeout_ms);
         std::stringstream ss;
         ss << "Request miniload from master("
             << master_address.hostname << ":" << master_address.port
@@ -291,6 +293,8 @@ Status MiniLoadAction::check_auth(
         }
     } catch (apache::thrift::TException& e) {
         // failed when retry.
+        // reopen to disable this connection
+        client.reopen(config::thrift_rpc_timeout_ms);
         std::stringstream ss;
         ss << "Request miniload from master("
             << master_address.hostname << ":" << master_address.port

--- a/be/src/runtime/export_task_mgr.cpp
+++ b/be/src/runtime/export_task_mgr.cpp
@@ -197,7 +197,7 @@ void ExportTaskMgr::report_to_master(PlanFragmentExecutor* executor) {
     }
     const TNetworkAddress& master_address = _exec_env->master_info()->network_address;
     FrontendServiceConnection client(
-            _exec_env->frontend_client_cache(), master_address, 500, &status);
+            _exec_env->frontend_client_cache(), master_address, config::thrift_rpc_timeout_ms, &status);
     if (!status.ok()) {
         std::stringstream ss;
         ss << "Connect master failed, with address("
@@ -217,7 +217,7 @@ void ExportTaskMgr::report_to_master(PlanFragmentExecutor* executor) {
             LOG(WARNING) << "Retrying report export tasks status to master("
                     << master_address.hostname << ":" << master_address.port
                     << ") because: " << e.what();
-            status = client.reopen(500);
+            status = client.reopen(config::thrift_rpc_timeout_ms);
             if (!status.ok()) {
                 LOG(WARNING) << "Client repoen failed. with address("
                     << master_address.hostname << ":" << master_address.port << ")";
@@ -227,6 +227,8 @@ void ExportTaskMgr::report_to_master(PlanFragmentExecutor* executor) {
         }
     } catch (apache::thrift::TException& e) {
         // failed when retry.
+        // reopen to disable this connection
+        client.reopen(config::thrift_rpc_timeout_ms);
         std::stringstream ss;
         ss << "Fail to report export task to master("
             << master_address.hostname << ":" << master_address.port


### PR DESCRIPTION
To avoid broken connection being reused.