### PR TITLE
Optimize edit log write operation

### DIFF
--- a/fe/src/main/java/org/apache/doris/alter/RollupJob.java
+++ b/fe/src/main/java/org/apache/doris/alter/RollupJob.java
@@ -754,7 +754,6 @@ public class RollupJob extends AlterJob {
             db.writeUnlock();
         }
 
-        // log rollup done operation
         Catalog.getInstance().getEditLog().logFinishingRollup(this);
         LOG.info("rollup job[{}] is finishing.", this.getTableId());
 

--- a/fe/src/main/java/org/apache/doris/alter/SchemaChangeJob.java
+++ b/fe/src/main/java/org/apache/doris/alter/SchemaChangeJob.java
@@ -361,7 +361,7 @@ public class SchemaChangeJob extends AlterJob {
             db.readUnlock();
         }
 
-        LOG.info("successfully sending clear schemachange job [{}]", tableId);
+        LOG.info("successfully sending clear schema change job [{}]", tableId);
         return 0;
     }
 
@@ -863,7 +863,6 @@ public class SchemaChangeJob extends AlterJob {
             db.writeUnlock();
         }
 
-        // log schema change done operation
         Catalog.getInstance().getEditLog().logFinishingSchemaChange(this);
         LOG.info("schema change job is finishing. finishing txn id: {} table {}", transactionId, tableId);
         return 1;

--- a/fe/src/main/java/org/apache/doris/journal/bdbje/BDBJEJournal.java
+++ b/fe/src/main/java/org/apache/doris/journal/bdbje/BDBJEJournal.java
@@ -24,6 +24,7 @@ import org.apache.doris.common.io.Writable;
 import org.apache.doris.journal.Journal;
 import org.apache.doris.journal.JournalCursor;
 import org.apache.doris.journal.JournalEntity;
+import org.apache.doris.metric.MetricRepo;
 import org.apache.doris.persist.OperationType;
 
 import com.sleepycat.bind.tuple.TupleBinding;
@@ -147,6 +148,9 @@ public class BDBJEJournal implements Journal {
             e.printStackTrace();
         }
         DatabaseEntry theData = new DatabaseEntry(buffer.getData());
+        if (MetricRepo.isInit.get()) {
+            MetricRepo.COUNTER_EDIT_LOG_SIZE_BYTES.increase((long) theData.getSize());
+        }
         LOG.debug("opCode = {}, journal size = {}", op, theData.getSize()); 
         // Write the key value pair to bdb.
         boolean writeSuccessed = false;

--- a/fe/src/main/java/org/apache/doris/master/MasterImpl.java
+++ b/fe/src/main/java/org/apache/doris/master/MasterImpl.java
@@ -236,7 +236,8 @@ public class MasterImpl {
         Catalog.getCurrentSystemInfo().updateBackendReportVersion(task.getBackendId(), reportVersion, task.getDbId());
 
         createReplicaTask.countDownLatch(task.getBackendId(), task.getSignature());
-        LOG.debug("finish create replica. tablet id: {}", tabletId);
+        LOG.debug("finish create replica. tablet id: {}, be: {}, report version: {}",
+                tabletId, task.getBackendId(), reportVersion);
         AgentTaskQueue.removeTask(task.getBackendId(), TTaskType.CREATE, task.getSignature());
     }
     

--- a/fe/src/main/java/org/apache/doris/metric/MetricRepo.java
+++ b/fe/src/main/java/org/apache/doris/metric/MetricRepo.java
@@ -56,6 +56,7 @@ public final class MetricRepo {
     public static LongCounterMetric COUNTER_LOAD_FINISHED;
     public static LongCounterMetric COUNTER_EDIT_LOG_WRITE;
     public static LongCounterMetric COUNTER_EDIT_LOG_READ;
+    public static LongCounterMetric COUNTER_EDIT_LOG_SIZE_BYTES;
     public static LongCounterMetric COUNTER_IMAGE_WRITE;
     public static LongCounterMetric COUNTER_IMAGE_PUSH;
     public static LongCounterMetric COUNTER_TXN_FAILED;
@@ -159,6 +160,8 @@ public final class MetricRepo {
         PALO_METRIC_REGISTER.addPaloMetrics(COUNTER_EDIT_LOG_WRITE);
         COUNTER_EDIT_LOG_READ = new LongCounterMetric("edit_log_read", "counter of edit log read from bdbje");
         PALO_METRIC_REGISTER.addPaloMetrics(COUNTER_EDIT_LOG_READ);
+        COUNTER_EDIT_LOG_SIZE_BYTES = new LongCounterMetric("edit_log_size_bytes", "size of edit log");
+        PALO_METRIC_REGISTER.addPaloMetrics(COUNTER_EDIT_LOG_SIZE_BYTES);
         COUNTER_IMAGE_WRITE = new LongCounterMetric("image_write", "counter of image generated");
         PALO_METRIC_REGISTER.addPaloMetrics(COUNTER_IMAGE_WRITE);
         COUNTER_IMAGE_PUSH = new LongCounterMetric("image_push",

--- a/fe/src/main/java/org/apache/doris/system/SystemInfoService.java
+++ b/fe/src/main/java/org/apache/doris/system/SystemInfoService.java
@@ -886,6 +886,7 @@ public class SystemInfoService {
                 db.readLock();
                 try {
                     atomicLong.set(newReportVersion);
+                    LOG.debug("update backend {} report version: {}， db: {}", backendId, newReportVersion, dbId);
                 } finally {
                     db.readUnlock();
                 }


### PR DESCRIPTION
1. No need to write edit log for init replica version sync.
2. Add a metric to monitor edit log size in bytes