### PR TITLE
Fix bug that CreateReplicaTask use wrong parameter

### DIFF
--- a/fe/src/main/java/org/apache/doris/backup/RestoreJob.java
+++ b/fe/src/main/java/org/apache/doris/backup/RestoreJob.java
@@ -621,7 +621,7 @@ public class RestoreJob extends AbstractJob {
                         Catalog.getCurrentInvertedIndex().addTablet(restoreTablet.getId(), tabletMeta);
                         for (Replica restoreReplica : restoreTablet.getReplicas()) {
                             Catalog.getCurrentInvertedIndex().addReplica(restoreTablet.getId(), restoreReplica);
-                            CreateReplicaTask task = new CreateReplicaTask(restoreReplica.getBackendId(), schemaHash,
+                            CreateReplicaTask task = new CreateReplicaTask(restoreReplica.getBackendId(), dbId,
                                     localTbl.getId(), restorePart.getId(), restoredIdx.getId(),
                                     restoreTablet.getId(), shortKeyColumnCount,
                                     schemaHash, restoreReplica.getVersion(), restoreReplica.getVersionHash(),
@@ -656,7 +656,7 @@ public class RestoreJob extends AbstractJob {
                             Catalog.getCurrentInvertedIndex().addTablet(tablet.getId(), tabletMeta);
                             for (Replica replica : tablet.getReplicas()) {
                                 Catalog.getCurrentInvertedIndex().addReplica(tablet.getId(), replica);
-                                CreateReplicaTask task = new CreateReplicaTask(replica.getBackendId(), schemaHash,
+                                CreateReplicaTask task = new CreateReplicaTask(replica.getBackendId(), dbId,
                                         restoreTbl.getId(), restorePart.getId(), index.getId(), tablet.getId(),
                                         shortKeyColumnCount, schemaHash, replica.getVersion(), replica.getVersionHash(),
                                         keysType, TStorageType.COLUMN, storageMedium, columns,

--- a/fe/src/main/java/org/apache/doris/system/SystemInfoService.java
+++ b/fe/src/main/java/org/apache/doris/system/SystemInfoService.java
@@ -886,11 +886,16 @@ public class SystemInfoService {
                 db.readLock();
                 try {
                     atomicLong.set(newReportVersion);
-                    LOG.debug("update backend {} report version: {}， db: {}", backendId, newReportVersion, dbId);
+                    LOG.debug("update backend {} report version: {}, db: {}", backendId, newReportVersion, dbId);
+                    return;
                 } finally {
                     db.readUnlock();
                 }
+            } else {
+                LOG.warn("failed to update backend report version, db {} does not exist", dbId);
             }
+        } else {
+            LOG.warn("failed to update backend report version, backend {} does not exist", backendId);
         }
     }
 


### PR DESCRIPTION
The dbId in CreateReplicaTask does not set correctly,
which may cause incorrect report result.