### PR TITLE
Fix unused tablet bug

### DIFF
--- a/be/src/olap/olap_engine.cpp
+++ b/be/src/olap/olap_engine.cpp
@@ -1724,6 +1724,7 @@ OLAPStatus OLAPEngine::report_all_tablets_info(std::map<TTabletId, TTablet>* tab
 
             tablet_info.__set_version_count(olap_table->file_delta_size());
             tablet_info.__set_path_hash(olap_table->store()->path_hash());
+            tablet_info.__set_used(olap_table->is_used());
 
             tablet.tablet_infos.push_back(tablet_info);
         }

--- a/gensrc/thrift/MasterService.thrift
+++ b/gensrc/thrift/MasterService.thrift
@@ -35,6 +35,7 @@ struct TTabletInfo {
     9: optional i64 version_count
     10: optional i64 path_hash
     11: optional bool version_miss
+    12: optional bool used
 }
 
 struct TFinishTaskRequest {


### PR DESCRIPTION
When the store is judged as unused, the tablets in the store will be unused. But FE still coordinate the write/read request to the unused tablet, causing problems.
Here just add tablet used state for BE.