### PR TITLE
Add --daemon option to start script

### DIFF
--- a/bin/start_be.sh
+++ b/bin/start_be.sh
@@ -19,6 +19,23 @@
 curdir=`dirname "$0"`
 curdir=`cd "$curdir"; pwd`
 
+OPTS=$(getopt \
+  -n $0 \
+  -o '' \
+  -l 'daemon' \
+  -- "$@")
+
+eval set -- "$OPTS"
+
+RUN_DAEMON=0
+while true; do
+    case "$1" in
+        --daemon) RUN_DAEMON=1 ; shift ;;
+        --) shift ;  break ;;
+        *) ehco "Internal error" ; exit 1 ;;
+    esac
+done
+
 export DORIS_HOME=`cd "$curdir/.."; pwd`
 
 # export env variables from be.conf
@@ -72,4 +89,8 @@ else
     LIMIT="/bin/limit3 -c 0 -n 65536"
 fi
 
-nohup $LIMIT ${DORIS_HOME}/lib/palo_be "$@" >> $LOG_DIR/be.out 2>&1 </dev/null &
+if [ ${RUN_DAEMON} -eq 1 ]; then
+    nohup $LIMIT ${DORIS_HOME}/lib/palo_be "$@" >> $LOG_DIR/be.out 2>&1 </dev/null &
+else
+    $LIMIT ${DORIS_HOME}/lib/palo_be "$@" >> $LOG_DIR/be.out 2>&1 </dev/null
+fi

--- a/fs_brokers/apache_hdfs_broker/bin/start_broker.sh
+++ b/fs_brokers/apache_hdfs_broker/bin/start_broker.sh
@@ -19,6 +19,23 @@
 curdir=`dirname "$0"`
 curdir=`cd "$curdir"; pwd`
 
+OPTS=$(getopt \
+  -n $0 \
+  -o '' \
+  -l 'daemon' \
+  -- "$@")
+
+eval set -- "$OPTS"
+
+RUN_DAEMON=0
+while true; do
+    case "$1" in
+        --daemon) RUN_DAEMON=1 ; shift ;;
+        --) shift ;  break ;;
+        *) ehco "Internal error" ; exit 1 ;;
+    esac
+done
+
 export BROKER_HOME=`cd "$curdir/.."; pwd`
 export PID_DIR=`cd "$curdir"; pwd`
 
@@ -61,6 +78,11 @@ if [ ! -d $BROKER_LOG_DIR ]; then
 fi
 
 echo `date` >> $BROKER_LOG_DIR/apache_hdfs_broker.out
-nohup $LIMIT $JAVA $JAVA_OPTS org.apache.doris.broker.hdfs.BrokerBootstrap "$@" >> $BROKER_LOG_DIR/apache_hdfs_broker.out 2>&1 </dev/null &
+
+if [ ${RUN_DAEMON} -eq 1 ]; then
+    nohup $LIMIT $JAVA $JAVA_OPTS org.apache.doris.broker.hdfs.BrokerBootstrap "$@" >> $BROKER_LOG_DIR/apache_hdfs_broker.out 2>&1 </dev/null &
+else
+    $LIMIT $JAVA $JAVA_OPTS org.apache.doris.broker.hdfs.BrokerBootstrap "$@" >> $BROKER_LOG_DIR/apache_hdfs_broker.out 2>&1 </dev/null
+fi
 
 echo $! > $pidfile


### PR DESCRIPTION
Add --daemon option to start_fe.sh/start_be.sh/start_broker.sh
If run scripte without --daemon, it will run as a foreground process.