### PR TITLE
Import TabletState and remove mutex in TabletMeta

### DIFF
--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -1627,7 +1627,7 @@ AgentStatus TaskWorkerPool::_move_dir(
         return DORIS_TASK_REQUEST_ERROR;
     }
 
-    std::string dest_tablet_dir = tablet->construct_dir_path();
+    std::string dest_tablet_dir = tablet->tablet_path();
     std::string store_path = tablet->data_dir()->path();
 
     SnapshotLoader* loader = _env->snapshot_loader();

--- a/be/src/olap/base_compaction.cpp
+++ b/be/src/olap/base_compaction.cpp
@@ -43,7 +43,7 @@ namespace doris {
 OLAPStatus BaseCompaction::init(TabletSharedPtr tablet, bool is_manual_trigger) {
     // 表在首次查询或PUSH等操作时，会被加载到内存
     // 如果表没有被加载，表明该表上目前没有任何操作，所以不进行BE操作
-    if (!tablet->init_success()) {
+    if (!tablet->init_succeeded()) {
         return OLAP_ERR_INPUT_PARAMETER_ERROR;
     }
 

--- a/be/src/olap/base_compaction.cpp
+++ b/be/src/olap/base_compaction.cpp
@@ -43,7 +43,7 @@ namespace doris {
 OLAPStatus BaseCompaction::init(TabletSharedPtr tablet, bool is_manual_trigger) {
     // 表在首次查询或PUSH等操作时，会被加载到内存
     // 如果表没有被加载，表明该表上目前没有任何操作，所以不进行BE操作
-    if (!tablet->is_loaded()) {
+    if (!tablet->init_success()) {
         return OLAP_ERR_INPUT_PARAMETER_ERROR;
     }
 
@@ -200,7 +200,7 @@ bool BaseCompaction::_check_whether_satisfy_policy(bool is_manual_trigger,
         // base文件
         if (temp.first == 0) {
             _old_base_version = temp;
-            base_size = _tablet->get_version_data_size(temp);
+            base_size = _tablet->get_rowset_size_by_version(temp);
             base_creation_time = _tablet->get_rowset_by_version(temp)->creation_time();
             continue;
         }
@@ -257,7 +257,7 @@ bool BaseCompaction::_check_whether_satisfy_policy(bool is_manual_trigger,
             continue;
         }
         // cumulative文件
-        cumulative_total_size += _tablet->get_version_data_size(temp);
+        cumulative_total_size += _tablet->get_rowset_size_by_version(temp);
     }
 
     // 检查是否满足base compaction的触发条件
@@ -440,7 +440,7 @@ OLAPStatus BaseCompaction::_update_header(uint64_t row_count, const vector<Rowse
 
     // 如果保存Header失败, 所有新增的信息会在下次启动时丢失, 属于严重错误
     // 暂时没办法做很好的处理,报FATAL
-    res = _tablet->save_tablet_meta();
+    res = _tablet->save_meta();
     if (res != OLAP_SUCCESS) {
         LOG(FATAL) << "fail to save tablet meta. res=" << res
                    << ", tablet=" << _tablet->full_name()

--- a/be/src/olap/cumulative_compaction.cpp
+++ b/be/src/olap/cumulative_compaction.cpp
@@ -42,7 +42,7 @@ OLAPStatus CumulativeCompaction::init(TabletSharedPtr tablet) {
         return OLAP_ERR_CUMULATIVE_REPEAT_INIT;
     }
 
-    if (!tablet->init_success()) {
+    if (!tablet->init_succeeded()) {
         return OLAP_ERR_CUMULATIVE_INVALID_PARAMETERS;
     }
 

--- a/be/src/olap/delete_handler.h
+++ b/be/src/olap/delete_handler.h
@@ -45,7 +45,7 @@ typedef google::protobuf::RepeatedPtrField<DeletePredicatePB> DelPredicateArray;
 //    res = cond_handler.log_conds(tablet);
 // 注:
 //    *  在调用这个类存储和移除删除条件时，需要先对Header文件加写锁；
-//       并在调用完成之后调用tablet->save_tablet_meta()，然后再释放Header文件的锁
+//       并在调用完成之后调用tablet->save_meta()，然后再释放Header文件的锁
 //    *  在调用log_conds()的时候，只需要加读锁
 class DeleteConditionHandler {
 public:

--- a/be/src/olap/schema_change.cpp
+++ b/be/src/olap/schema_change.cpp
@@ -1222,7 +1222,7 @@ OLAPStatus SchemaChangeHandler::_do_alter_tablet(
         const TAlterTabletReq& request) {
     OLAPStatus res = OLAP_SUCCESS;
     TabletSharedPtr new_tablet;
-    string base_root_path = ref_tablet->storage_root_path_name();
+    string base_root_path = ref_tablet->dir_path();
 
     LOG(INFO) << "begin to do alter tablet job. new_tablet_id=" << request.new_tablet_req.tablet_id;
     // 1. Create new tablet and register into StorageEngine
@@ -1459,7 +1459,7 @@ OLAPStatus SchemaChangeHandler::_create_new_tablet(
         if (res != OLAP_SUCCESS) {
             OLAP_LOG_WARNING("fail to register tablet into root path. "
                              "[root_path='%s' tablet='%s']",
-                             new_tablet->storage_root_path_name().c_str(),
+                             new_tablet->dir_path().c_str(),
                              new_tablet->full_name().c_str());
             break;
         }
@@ -1699,14 +1699,14 @@ OLAPStatus SchemaChangeHandler::_save_schema_change_info(
                                alter_tablet_type);
 
     // save new tablet header :只有一个父ref tablet
-    res = new_tablet->save_tablet_meta();
+    res = new_tablet->save_meta();
     if (res != OLAP_SUCCESS) {
         LOG(FATAL) << "fail to save new tablet header. res=" << res
                    << ", tablet=" << new_tablet->full_name();
         return res;
     }
 
-    res = ref_tablet->save_tablet_meta();
+    res = ref_tablet->save_meta();
     if (res != OLAP_SUCCESS) {
         LOG(FATAL) << "fail to save ref tablet header. res=" << res
                    << ", tablet=" << ref_tablet->full_name().c_str();
@@ -1834,7 +1834,7 @@ OLAPStatus SchemaChangeHandler::_alter_tablet(SchemaChangeParams* sc_params) {
         sc_params->ref_tablet->obtain_header_wrlock();
         sc_params->new_tablet->obtain_header_wrlock();
 
-        if (!sc_params->new_tablet->has_version((*it)->version())) {
+        if (!sc_params->new_tablet->check_version_exist((*it)->version())) {
             // register version
             RowsetSharedPtr new_rowset = rowset_writer->build();
             res = sc_params->new_tablet->add_rowset(new_rowset);
@@ -1862,13 +1862,13 @@ OLAPStatus SchemaChangeHandler::_alter_tablet(SchemaChangeParams* sc_params) {
         }
 
         // 保存header
-        if (OLAP_SUCCESS != sc_params->new_tablet->save_tablet_meta()) {
+        if (OLAP_SUCCESS != sc_params->new_tablet->save_meta()) {
             LOG(FATAL) << "fail to save header. res=" << res
                        << ", tablet=" << sc_params->new_tablet->full_name();
         }
 
         // 保存header
-        if (OLAP_SUCCESS != sc_params->ref_tablet->save_tablet_meta()) {
+        if (OLAP_SUCCESS != sc_params->ref_tablet->save_meta()) {
             LOG(FATAL) << "failed to save header. tablet=" << sc_params->new_tablet->full_name();
         }
 
@@ -1888,7 +1888,7 @@ OLAPStatus SchemaChangeHandler::_alter_tablet(SchemaChangeParams* sc_params) {
 PROCESS_ALTER_EXIT:
     if (res == OLAP_SUCCESS) {
         Version test_version(0, end_version);
-        res = sc_params->new_tablet->test_version(test_version);
+        res = sc_params->new_tablet->check_version_integrity(test_version);
     }
 
     if (res == OLAP_SUCCESS) {

--- a/be/src/olap/schema_change.cpp
+++ b/be/src/olap/schema_change.cpp
@@ -1222,7 +1222,7 @@ OLAPStatus SchemaChangeHandler::_do_alter_tablet(
         const TAlterTabletReq& request) {
     OLAPStatus res = OLAP_SUCCESS;
     TabletSharedPtr new_tablet;
-    string base_root_path = ref_tablet->dir_path();
+    string base_root_path = ref_tablet->data_dir()->path();
 
     LOG(INFO) << "begin to do alter tablet job. new_tablet_id=" << request.new_tablet_req.tablet_id;
     // 1. Create new tablet and register into StorageEngine
@@ -1457,10 +1457,9 @@ OLAPStatus SchemaChangeHandler::_create_new_tablet(
         // Example: unregister all tables when a bad disk found.
         res = new_tablet->register_tablet_into_dir();
         if (res != OLAP_SUCCESS) {
-            OLAP_LOG_WARNING("fail to register tablet into root path. "
-                             "[root_path='%s' tablet='%s']",
-                             new_tablet->dir_path().c_str(),
-                             new_tablet->full_name().c_str());
+            LOG(WARNING) << "fail to register tablet into data dir. "
+                         << "root_path=" << new_tablet->data_dir()->path()
+                         << ", tablet=" << new_tablet->full_name();
             break;
         }
 

--- a/be/src/olap/snapshot_manager.cpp
+++ b/be/src/olap/snapshot_manager.cpp
@@ -134,7 +134,7 @@ OLAPStatus SnapshotManager::_calc_snapshot_id_path(
 
     stringstream snapshot_id_path_stream;
     MutexLock auto_lock(&_snapshot_mutex); // will automatically unlock when function return.
-    snapshot_id_path_stream << tablet->storage_root_path_name() << SNAPSHOT_PREFIX
+    snapshot_id_path_stream << tablet->dir_path() << SNAPSHOT_PREFIX
                             << "/" << time_str << "." << _snapshot_base_id++;
     *out_path = snapshot_id_path_stream.str();
     return res;
@@ -198,7 +198,7 @@ OLAPStatus SnapshotManager::_create_snapshot_files(
     res = _calc_snapshot_id_path(ref_tablet, &snapshot_id_path);
     if (res != OLAP_SUCCESS) {
         OLAP_LOG_WARNING("failed to calc snapshot_id_path, [ref tablet=%s]",
-                ref_tablet->storage_root_path_name().c_str());
+                ref_tablet->dir_path().c_str());
         return res;
     }
 
@@ -352,7 +352,7 @@ OLAPStatus SnapshotManager::_create_incremental_snapshot_files(
     res = _calc_snapshot_id_path(ref_tablet, &snapshot_id_path);
     if (res != OLAP_SUCCESS) {
         OLAP_LOG_WARNING("failed to calc snapshot_id_path, [ref tablet=%s]",
-                ref_tablet->storage_root_path_name().c_str());
+                ref_tablet->dir_path().c_str());
         return res;
     }
 
@@ -443,14 +443,14 @@ OLAPStatus SnapshotManager::_append_single_delta(
                          request.tablet_id, request.schema_hash);
         return res;
     }
-    auto tablet = Tablet::create_from_tablet_meta(new_tablet_meta, store);
+    auto tablet = Tablet::create_tablet_from_meta(new_tablet_meta, store);
     if (tablet == NULL) {
         OLAP_LOG_WARNING("fail to load tablet. [res=%d tablet_id='%ld, schema_hash=%d']",
                          res, request.tablet_id, request.schema_hash);
         return OLAP_ERR_INPUT_PARAMETER_ERROR;
     }
 
-    res = tablet->load();
+    res = tablet->init();
     if (res != OLAP_SUCCESS) {
         LOG(WARNING) << "fail to load tablet. [res=" << res << " header_path=" << store->path();
         return res;

--- a/be/src/olap/snapshot_manager.cpp
+++ b/be/src/olap/snapshot_manager.cpp
@@ -30,8 +30,6 @@
 #include <boost/date_time/posix_time/posix_time.hpp>
 #include <boost/filesystem.hpp>
 
-
-
 using boost::filesystem::canonical;
 using boost::filesystem::copy_file;
 using boost::filesystem::copy_option;
@@ -134,7 +132,7 @@ OLAPStatus SnapshotManager::_calc_snapshot_id_path(
 
     stringstream snapshot_id_path_stream;
     MutexLock auto_lock(&_snapshot_mutex); // will automatically unlock when function return.
-    snapshot_id_path_stream << tablet->dir_path() << SNAPSHOT_PREFIX
+    snapshot_id_path_stream << tablet->data_dir()->path() << SNAPSHOT_PREFIX
                             << "/" << time_str << "." << _snapshot_base_id++;
     *out_path = snapshot_id_path_stream.str();
     return res;
@@ -197,8 +195,8 @@ OLAPStatus SnapshotManager::_create_snapshot_files(
     string snapshot_id_path;
     res = _calc_snapshot_id_path(ref_tablet, &snapshot_id_path);
     if (res != OLAP_SUCCESS) {
-        OLAP_LOG_WARNING("failed to calc snapshot_id_path, [ref tablet=%s]",
-                ref_tablet->dir_path().c_str());
+        LOG(WARNING) << "failed to calc snapshot_id_path, ref tablet="
+                     << ref_tablet->data_dir()->path();
         return res;
     }
 
@@ -351,8 +349,8 @@ OLAPStatus SnapshotManager::_create_incremental_snapshot_files(
     string snapshot_id_path;
     res = _calc_snapshot_id_path(ref_tablet, &snapshot_id_path);
     if (res != OLAP_SUCCESS) {
-        OLAP_LOG_WARNING("failed to calc snapshot_id_path, [ref tablet=%s]",
-                ref_tablet->dir_path().c_str());
+        LOG(WARNING) << "failed to calc snapshot_id_path, ref tablet="
+                     << ref_tablet->data_dir()->path();
         return res;
     }
 

--- a/be/src/olap/storage_engine.h
+++ b/be/src/olap/storage_engine.h
@@ -43,6 +43,7 @@
 #include "olap/tablet.h"
 #include "olap/olap_meta.h"
 #include "olap/options.h"
+#include "olap/rowset/segment_group.h"
 #include "olap/tablet_manager.h"
 #include "olap/txn_manager.h"
 #include "olap/task/engine_task.h"

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -151,10 +151,6 @@ bool Tablet::is_used() {
     return _data_dir->is_used();
 }
 
-string Tablet::dir_path() const {
-    return _data_dir->path();
-}
-
 string Tablet::tablet_path() const {
     return _tablet_path;
 }

--- a/be/src/olap/tablet.h
+++ b/be/src/olap/tablet.h
@@ -65,12 +65,11 @@ public:
 
     OLAPStatus init_once();
     OLAPStatus init();
-    inline bool init_success();
+    inline bool init_succeeded();
 
     bool is_used();
     inline DataDir* data_dir() const;
     OLAPStatus register_tablet_into_dir();
-    std::string dir_path() const;
     std::string tablet_path() const;
 
     // operation for TabletState
@@ -251,8 +250,8 @@ private:
     DISALLOW_COPY_AND_ASSIGN(Tablet);
 };
 
-inline bool Tablet::init_success() {
-    return _init_once.init_success();
+inline bool Tablet::init_succeeded() {
+    return _init_once.init_succeeded();
 }
 
 inline DataDir* Tablet::data_dir() const {

--- a/be/src/olap/tablet.h
+++ b/be/src/olap/tablet.h
@@ -27,171 +27,178 @@
 
 #include "gen_cpp/AgentService_types.h"
 #include "gen_cpp/olap_file.pb.h"
-#include "olap/field.h"
 #include "olap/olap_define.h"
-#include "olap/tablet_meta.h"
 #include "olap/tuple.h"
 #include "olap/row_cursor.h"
 #include "olap/rowset_graph.h"
-#include "olap/utils.h"
+#include "olap/rowset/rowset.h"
 #include "olap/rowset/rowset_reader.h"
+#include "olap/tablet_meta.h"
+#include "olap/utils.h"
+#include "util/once.h"
+
+using std::pair;
+using std::nothrow;
+using std::sort;
+using std::string;
+using std::vector;
 
 namespace doris {
-class TabletMeta;
-class Rowset;
-class Tablet;
-class RowBlockPosition;
+
 class DataDir;
-class RowsetReader;
-class ColumnData;
-class SegmentGroup;
+class Tablet;
+class TabletMeta;
 
 using TabletSharedPtr = std::shared_ptr<Tablet>;
 
 class Tablet : public std::enable_shared_from_this<Tablet> {
 public:
-    static TabletSharedPtr create_from_tablet_meta_file(
+    static TabletSharedPtr create_tablet_from_meta_file(
             const std::string& header_file,
             DataDir* data_dir = nullptr);
-    static TabletSharedPtr create_from_tablet_meta(
+    static TabletSharedPtr create_tablet_from_meta(
             TabletMeta* meta,
             DataDir* data_dir  = nullptr);
 
     Tablet(TabletMeta* tablet_meta, DataDir* data_dir);
     ~Tablet();
 
-    OLAPStatus load();
-    OLAPStatus load_rowsets();
-    inline bool is_loaded();
-    OLAPStatus save_tablet_meta();
+    OLAPStatus init_once();
+    OLAPStatus init();
+    inline bool init_success();
 
-    bool has_expired_incremental_rowset();
-    void delete_expired_incremental_rowset();
+    bool is_used();
+    inline DataDir* data_dir() const;
+    OLAPStatus register_tablet_into_dir();
+    std::string dir_path() const;
+    std::string tablet_path() const;
+
+    // operation for TabletState
+    TabletState tablet_state() const { return _state; }
+    inline OLAPStatus set_tablet_state(TabletState state);
+    void mark_dropped() { _is_dropped = true; }
+
+    // Property encapsulated in TabletMeta
+    inline const TabletMeta& tablet_meta();
+    OLAPStatus save_meta();
+    OLAPStatus merge_tablet_meta(const TabletMeta& hdr, int to_version);
     OLAPStatus revise_tablet_meta(const TabletMeta& tablet_meta,
                                   const std::vector<RowsetMetaSharedPtr>& rowsets_to_clone,
                                   const std::vector<Version>& versions_to_delete);
-    OLAPStatus compute_all_versions_hash(const std::vector<Version>& versions,
-                                         VersionHash* version_hash) const;
-    OLAPStatus merge_tablet_meta(const TabletMeta& hdr, int to_version);
-    bool has_version(const Version& version) const;
-    void list_versions(std::vector<Version>* versions) const;
-    void mark_dropped() { _is_dropped = true; }
-    bool is_dropped() { return _is_dropped; }
-    void delete_all_files();
-    void obtain_header_rdlock() { _meta_lock.rdlock(); }
-    void obtain_header_wrlock() { _meta_lock.wrlock(); }
-    void release_header_lock() { _meta_lock.unlock(); }
-    RWMutex* get_header_lock_ptr() { return &_meta_lock; }
-    void obtain_push_lock() { _ingest_lock.lock(); }
-    void release_push_lock() { _ingest_lock.unlock(); }
-    Mutex* get_push_lock() { return &_ingest_lock; }
-    bool try_base_compaction_lock() { return _base_lock.trylock() == OLAP_SUCCESS; }
-    void obtain_base_compaction_lock() { _base_lock.lock(); }
-    void release_base_compaction_lock() { _base_lock.unlock(); }
-    bool try_cumulative_lock() { return (OLAP_SUCCESS == _cumulative_lock.trylock()); }
-    void obtain_cumulative_lock() { _cumulative_lock.lock(); }
-    void release_cumulative_lock() { _cumulative_lock.unlock(); }
-    std::string construct_dir_path() const;
-    int version_count() const;
-    const uint32_t calc_cumulative_compaction_score() const;
-    const uint32_t calc_base_compaction_score() const;
-    inline KeysType keys_type() const;
-    bool version_for_delete_predicate(const Version& version);
-    bool version_for_load_deletion(const Version& version);
+
+    inline int64_t table_id() const;
+    inline const std::string full_name() const;
+    inline int64_t partition_id() const;
+    inline int64_t tablet_id() const;
+    inline int64_t schema_hash() const;
+    inline int16_t shard_id();
     inline const int64_t creation_time() const;
-    void set_creation_time(int64_t creation_time);
+    inline void set_creation_time(int64_t creation_time);
     inline const int32_t cumulative_layer_point() const;
     inline void set_cumulative_layer_point(const int32_t new_point);
-    AlterTabletState alter_state();
-    OLAPStatus set_alter_state(AlterTabletState state);
-    bool is_schema_changing();
-    OLAPStatus delete_alter_task();
-    OLAPStatus protected_delete_alter_task();
-    void add_alter_task(int64_t tablet_id, int64_t schema_hash,
-                        const vector<Version>& versions_to_alter,
-                        const AlterTabletType alter_type);
-    const AlterTabletTask& alter_task();
-    bool is_used();
-    std::string storage_root_path_name() const;
-    std::string tablet_path() const;
-    OLAPStatus test_version(const Version& version);
-    size_t get_version_data_size(const Version& version);
-    OLAPStatus recover_tablet_until_specfic_version(const int64_t& spec_version,
-                                                    const int64_t& version_hash);
-    const std::string& rowset_path_prefix();
-    const size_t id() { return _id; }
-    void set_id(size_t id) { _id = id; }
-    OLAPStatus register_tablet_into_dir();
 
+    inline bool equal(int64_t tablet_id, int64_t schema_hash);
+    inline size_t tablet_footprint(); // disk space occupied by tablet
+    inline size_t num_rows();
+    inline int version_count() const;
+    inline Version max_version() const;
 
+    // propreties encapsulated in TabletSchema
+    inline const TabletSchema& tablet_schema() const;
+    inline KeysType keys_type() const;
+    inline size_t num_columns() const;
+    inline size_t num_null_columns() const;
+    inline size_t num_key_columns() const ;
+    inline size_t num_short_key_columns() const;
+    inline size_t num_rows_per_row_block() const;
+    inline CompressKind compress_kind() const;
+    inline double bloom_filter_fpp() const;
+    inline size_t next_unique_id() const;
+    inline size_t row_size() const;
+    inline size_t field_index(const string& field_name) const;
 
+    // operation in rowsets
+    OLAPStatus add_rowset(RowsetSharedPtr rowset);
+    OLAPStatus modify_rowsets(std::vector<Version>* old_version,
+                              const vector<RowsetSharedPtr>& to_add,
+                              const vector<RowsetSharedPtr>& to_delete);
+    const RowsetSharedPtr get_rowset_by_version(const Version& version) const;
+    size_t get_rowset_size_by_version(const Version& version);
+    const RowsetSharedPtr rowset_with_max_version() const;
+    RowsetSharedPtr rowset_with_largest_size();
 
-    OLAPStatus init_once();
+    OLAPStatus add_inc_rowset(const RowsetSharedPtr& rowset);
+    bool has_expired_inc_rowset();
+    void delete_inc_rowset_by_version(const Version& version,
+                                      const VersionHash& version_hash,
+                                      vector<string>* files_to_remove);
+    void delete_expired_inc_rowsets();
+
+    OLAPStatus capture_consistent_versions(const Version& version, vector<Version>* span_versions) const;
+    OLAPStatus check_version_integrity(const Version& version);
+    bool check_version_exist(const Version& version) const;
+    void list_versions(std::vector<Version>* versions) const;
+
     OLAPStatus capture_consistent_rowsets(const Version& spec_version,
                                           vector<RowsetSharedPtr>* rowsets) const;
-    OLAPStatus capture_consistent_rowsets(const vector<Version>& version_vec,
+    OLAPStatus capture_consistent_rowsets(const vector<Version>& version_path,
                                           vector<RowsetSharedPtr>* rowsets) const;
     OLAPStatus release_rowsets(vector<RowsetSharedPtr>* rowsets) const;
+
     OLAPStatus capture_rs_readers(const Version& spec_version,
                                   vector<RowsetReaderSharedPtr>* rs_readers) const;
     OLAPStatus capture_rs_readers(const vector<Version>& version_path,
                                   vector<RowsetReaderSharedPtr>* rs_readers) const;
     OLAPStatus release_rs_readers(vector<RowsetReaderSharedPtr>* rs_readers) const;
-    OLAPStatus capture_consistent_versions(const Version& version, vector<Version>* span_versions) const;
-    OLAPStatus modify_rowsets(std::vector<Version>* old_version,
-                              const vector<RowsetSharedPtr>& to_add,
-                              const vector<RowsetSharedPtr>& to_delete);
-    OLAPStatus add_rowset(RowsetSharedPtr rowset);
 
-    inline const TabletMeta& tablet_meta();
-    inline int64_t table_id() const;
-    inline std::string table_name() const;
-    inline int64_t partition_id() const;
-    inline int64_t tablet_id() const;
-    inline int64_t schema_hash() const;
-    inline int16_t shard_id();
-    inline DataDir* data_dir() const;
-    inline bool equal(int64_t tablet_id, int64_t schema_hash);
+    // operation for delete predicate
+    OLAPStatus add_delete_predicates(const DeletePredicatePB& delete_predicate, int64_t version) {
+        return _tablet_meta->add_delete_predicate(delete_predicate, version);
+    }
+    DelPredicateArray delete_predicates() { return _tablet_meta->delete_predicates(); }
+    bool version_for_delete_predicate(const Version& version);
+    bool version_for_load_deletion(const Version& version);
 
-    inline const TabletSchema& tablet_schema() const;
-    inline const std::string full_name() const;
-    inline size_t num_columns() const;
-    inline size_t num_null_columns() const;
-    inline size_t num_key_columns() const ;
-    inline size_t num_short_key_columns() const;
-    inline size_t next_unique_id() const;
-    inline size_t num_rows_per_row_block() const;
-    inline CompressKind compress_kind() const;
-    inline double bloom_filter_fpp() const;
+    // message for alter task
+    AlterTabletState alter_state();
+    bool is_schema_changing();
+    OLAPStatus set_alter_state(AlterTabletState state);
+    const AlterTabletTask& alter_task();
+    void add_alter_task(int64_t tablet_id, int64_t schema_hash,
+                        const vector<Version>& versions_to_alter,
+                        const AlterTabletType alter_type);
+    OLAPStatus delete_alter_task();
+    OLAPStatus protected_delete_alter_task();
 
-    size_t field_index(const string& field_name) const;
-    size_t row_size() const;
-    size_t get_index_size() const;
-    size_t all_rowsets_size() const;
-    size_t get_data_size();
-    size_t num_rows();
-    size_t get_rowset_size(const Version& version);
-    OLAPStatus get_tablet_info(TTabletInfo* tablet_info);
+    // meta lock
+    inline void obtain_header_rdlock() { _meta_lock.rdlock(); }
+    inline void obtain_header_wrlock() { _meta_lock.wrlock(); }
+    inline void release_header_lock() { _meta_lock.unlock(); }
+    inline RWMutex* get_header_lock_ptr() { return &_meta_lock; }
 
-    TabletState tablet_state() const;
+    // ingest lock
+    inline void obtain_push_lock() { _ingest_lock.lock(); }
+    inline void release_push_lock() { _ingest_lock.unlock(); }
+    inline Mutex* get_push_lock() { return &_ingest_lock; }
 
-    const RowsetSharedPtr get_rowset_by_version(const Version& version) const;
-    Version max_version() const;
-    const RowsetSharedPtr rowset_with_max_version() const;
-    RowsetSharedPtr rowset_with_largest_size();
-    OLAPStatus all_rowsets(vector<RowsetSharedPtr> rowsets);
+    // base lock
+    inline bool try_base_compaction_lock() { return _base_lock.trylock() == OLAP_SUCCESS; }
+    inline void obtain_base_compaction_lock() { _base_lock.lock(); }
+    inline void release_base_compaction_lock() { _base_lock.unlock(); }
 
-    OLAPStatus add_inc_rowset(const RowsetSharedPtr& rowset);
-    RowsetSharedPtr get_inc_rowset(const Version& version) const;
-    OLAPStatus delete_inc_rowset_by_version(const Version& version);
-    OLAPStatus delete_expired_inc_rowset();
-    bool is_deletion_rowset(const Version& version);
+    // cumulative lock
+    inline bool try_cumulative_lock() { return (OLAP_SUCCESS == _cumulative_lock.trylock()); }
+    inline void obtain_cumulative_lock() { _cumulative_lock.lock(); }
+    inline void release_cumulative_lock() { _cumulative_lock.unlock(); }
 
-    RWMutex* meta_lock();
-    Mutex* ingest_lock();
-    Mutex* base_lock();
-    Mutex* cumulative_lock();
+    // operation for compaction
+    bool can_do_compaction();
+    const uint32_t calc_cumulative_compaction_score() const;
+    const uint32_t calc_base_compaction_score() const;
+    OLAPStatus compute_all_versions_hash(const std::vector<Version>& versions,
+                                         VersionHash* version_hash) const;
 
+    // operation for clone
     void calc_missed_versions(int64_t spec_version, vector<Version>* missed_versions);
 
     // This function to find max continous version from the beginning.
@@ -199,49 +206,32 @@ public:
     // Version 3 is target.
     OLAPStatus max_continuous_version_from_begining(Version* version, VersionHash* v_hash);
 
-    size_t deletion_rowset_size();
-    bool can_do_compaction();
-
-    OLAPStatus add_delete_predicates(const DeletePredicatePB& delete_predicate, int64_t version) {
-        return _tablet_meta->add_delete_predicate(delete_predicate, version);
-    }
-
-    google::protobuf::RepeatedPtrField<DeletePredicatePB>
-    delete_predicates() {
-        return _tablet_meta->delete_predicates();
-    }
-
-    google::protobuf::RepeatedPtrField<DeletePredicatePB>*
-    mutable_delete_predicate();
-
-    DeletePredicatePB* mutable_delete_predicate(int index);
-
+    // operation for query
     OLAPStatus split_range(
             const OlapTuple& start_key_strings,
             const OlapTuple& end_key_strings,
             uint64_t request_block_row_count,
             vector<OlapTuple>* ranges);
 
-    uint32_t segment_size() const;
+    // operation for recover tablet
+    OLAPStatus recover_tablet_until_specfic_version(const int64_t& spec_version,
+                                                    const int64_t& version_hash);
+
+    // I/O Error handler
     void set_io_error();
+    void delete_all_files();
 
 private:
-    void _delete_incremental_rowset(const Version& version,
-                                    const VersionHash& version_hash,
-                                    vector<string>* files_to_remove);
-
+    TabletState _state;
     TabletMeta* _tablet_meta;
     TabletSchema _schema;
+
     DataDir* _data_dir;
     std::string _tablet_path;
-
-    TabletState _state;
     RowsetGraph _rs_graph;
 
-    std::atomic<bool> _is_loaded;
     bool _is_dropped;
-    size_t _id;
-    Mutex _load_lock;
+    DorisInitOnce _init_once;
     RWMutex _meta_lock;
     Mutex _ingest_lock;
     Mutex _base_lock;
@@ -261,8 +251,17 @@ private:
     DISALLOW_COPY_AND_ASSIGN(Tablet);
 };
 
-inline bool Tablet::is_loaded() {
-    return _is_loaded;
+inline bool Tablet::init_success() {
+    return _init_once.init_success();
+}
+
+inline DataDir* Tablet::data_dir() const {
+    return _data_dir;
+}
+
+inline OLAPStatus Tablet::set_tablet_state(TabletState state) {
+    RETURN_NOT_OK(_tablet_meta->set_tablet_state(state));
+    _state = state;
 }
 
 inline const TabletMeta& Tablet::tablet_meta() {
@@ -271,6 +270,13 @@ inline const TabletMeta& Tablet::tablet_meta() {
 
 inline int64_t Tablet::table_id() const {
     return _tablet_meta->table_id();
+}
+
+inline const std::string Tablet::full_name() const {
+    std::string tablet_name = std::to_string(_tablet_meta->tablet_id())
+                              + "." +
+                              std::to_string(_tablet_meta->schema_hash());
+    return tablet_name;
 }
 
 inline int64_t Tablet::partition_id() const {
@@ -289,23 +295,50 @@ inline int16_t Tablet::shard_id() {
     return _tablet_meta->shard_id();
 }
 
-inline DataDir* Tablet::data_dir() const {
-    return _data_dir;
+inline const int64_t Tablet::creation_time() const {
+    return _tablet_meta->creation_time();
+}  // namespace doris
+
+inline void Tablet::set_creation_time(int64_t creation_time) {
+    _tablet_meta->set_creation_time(creation_time);
+}
+
+inline const int32_t Tablet::cumulative_layer_point() const {
+    return _tablet_meta->cumulative_layer_point();
+}
+
+void inline Tablet::set_cumulative_layer_point(const int32_t new_point) {
+    return _tablet_meta->set_cumulative_layer_point(new_point);
 }
 
 inline bool Tablet::equal(int64_t tablet_id, int64_t schema_hash) {
     return (_tablet_meta->tablet_id() == tablet_id) && (_tablet_meta->schema_hash() == schema_hash);
 }
 
+inline size_t Tablet::tablet_footprint() {
+    ReadLock rdlock(&_meta_lock);
+    return _tablet_meta->tablet_footprint();
+}
+
+inline size_t Tablet::num_rows() {
+    ReadLock rdlock(&_meta_lock);
+    return _tablet_meta->num_rows();
+}
+
+inline int Tablet::version_count() const {
+    return _tablet_meta->version_count();
+}
+
+inline Version Tablet::max_version() const {
+    return _tablet_meta->max_version();
+}
+
 inline const TabletSchema& Tablet::tablet_schema() const {
     return _schema;
 }
 
-inline const std::string Tablet::full_name() const {
-    std::string tablet_name = std::to_string(_tablet_meta->tablet_id())
-                              + "." +
-                              std::to_string(_tablet_meta->schema_hash());
-    return tablet_name;
+inline KeysType Tablet::keys_type() const {
+    return _schema.keys_type();
 }
 
 inline size_t Tablet::num_columns() const {
@@ -324,10 +357,6 @@ inline size_t Tablet::num_short_key_columns() const {
     return _schema.num_short_key_columns();
 }
 
-inline size_t Tablet::next_unique_id() const {
-    return _schema.next_column_unique_id();
-}
-
 inline size_t Tablet::num_rows_per_row_block() const {
     return _schema.num_rows_per_row_block();
 }
@@ -340,28 +369,16 @@ inline double Tablet::bloom_filter_fpp() const {
     return _schema.bloom_filter_fpp();
 }
 
-inline KeysType Tablet::keys_type() const {
-    return _schema.keys_type();
+inline size_t Tablet::next_unique_id() const {
+    return _schema.next_column_unique_id();
 }
 
-inline const int64_t Tablet::creation_time() const {
-    return _tablet_meta->creation_time();
-}  // namespace doris
-
-inline void Tablet::set_creation_time(int64_t creation_time) {
-    _tablet_meta->set_creation_time(creation_time);
+inline size_t Tablet::field_index(const string& field_name) const {
+    return _schema.field_index(field_name);
 }
 
-inline int Tablet::version_count() const {
-    return _tablet_meta->version_count();
-}
-
-inline const int32_t Tablet::cumulative_layer_point() const {
-    return _tablet_meta->cumulative_layer_point();
-}
-
-void inline Tablet::set_cumulative_layer_point(const int32_t new_point) {
-    return _tablet_meta->set_cumulative_layer_point(new_point);
+inline size_t Tablet::row_size() const {
+    return _schema.row_size();
 }
 
 }

--- a/be/src/olap/tablet_manager.cpp
+++ b/be/src/olap/tablet_manager.cpp
@@ -89,8 +89,7 @@ bool _sort_tablet_by_creation_time(const TabletSharedPtr& a, const TabletSharedP
 }
 
 TabletManager::TabletManager()
-    : _global_tablet_id(0),
-      _tablet_stat_cache_update_time_ms(0),
+    : _tablet_stat_cache_update_time_ms(0),
       _available_storage_medium_type_count(0) { }
 
 OLAPStatus TabletManager::add_tablet(TTabletId tablet_id, SchemaHash schema_hash,
@@ -100,8 +99,6 @@ OLAPStatus TabletManager::add_tablet(TTabletId tablet_id, SchemaHash schema_hash
             << "tablet_id=" << tablet_id << ", schema_hash=" << schema_hash
             << ", force=" << force;
     _tablet_map_lock.wrlock();
-
-    tablet->set_id(_global_tablet_id++);
 
     TabletSharedPtr table_item;
     for (TabletSharedPtr item : _tablet_map[tablet_id].table_arr) {
@@ -354,7 +351,7 @@ OLAPStatus TabletManager::create_tablet(const TCreateTabletReq& request,
         res = tablet_ptr->register_tablet_into_dir();
         if (res != OLAP_SUCCESS) {
             OLAP_LOG_WARNING("fail to register tablet into StorageEngine. [res=%d, root_path=%s]",
-                    res, tablet_ptr->storage_root_path_name().c_str());
+                    res, tablet_ptr->dir_path().c_str());
             break;
         }
 
@@ -400,7 +397,7 @@ TabletSharedPtr TabletManager::create_tablet(
             break;
         }
 
-        tablet = Tablet::create_from_tablet_meta(tablet_meta, store);
+        tablet = Tablet::create_tablet_from_meta(tablet_meta, store);
         if (tablet == nullptr) {
             LOG(WARNING) << "fail to load tablet from tablet_meta. root_path:" << store->path();
             break;
@@ -489,7 +486,7 @@ OLAPStatus TabletManager::drop_tablet(
     _tablet_map_lock.wrlock();
     related_tablet->obtain_header_wrlock();
     related_tablet->delete_alter_task();
-    res = related_tablet->save_tablet_meta();
+    res = related_tablet->save_meta();
     if (res != OLAP_SUCCESS) {
         LOG(FATAL) << "fail to save tablet header. res=" << res
                    << ", tablet=" << related_tablet->full_name();
@@ -555,8 +552,8 @@ TabletSharedPtr TabletManager::get_tablet(TTabletId tablet_id, SchemaHash schema
         if (!tablet->is_used()) {
             OLAP_LOG_WARNING("tablet cannot be used. [tablet=%ld]", tablet_id);
             tablet.reset();
-        } else if (load_tablet && !tablet->is_loaded()) {
-            if (tablet->load() != OLAP_SUCCESS) {
+        } else if (load_tablet && !tablet->init_success()) {
+            if (tablet->init() != OLAP_SUCCESS) {
                 OLAP_LOG_WARNING("fail to load tablet. [tablet=%ld]", tablet_id);
                 tablet.reset();
             }
@@ -591,7 +588,7 @@ TabletSharedPtr TabletManager::find_best_tablet_to_compaction(CompactionType com
     TabletSharedPtr best_tablet;
     for (tablet_map_t::value_type& table_ins : _tablet_map){
         for (TabletSharedPtr& table_ptr : table_ins.second.table_arr) {
-            if (!table_ptr->is_loaded() || !table_ptr->can_do_compaction()) {
+            if (!table_ptr->init_success() || !table_ptr->can_do_compaction()) {
                 continue;
             }
 
@@ -622,7 +619,7 @@ OLAPStatus TabletManager::load_tablet_from_meta(DataDir* data_dir, TTabletId tab
 
     // init must be called
     TabletSharedPtr tablet =
-        Tablet::create_from_tablet_meta(tablet_meta.release(), data_dir);
+        Tablet::create_tablet_from_meta(tablet_meta.release(), data_dir);
     if (tablet == nullptr) {
         LOG(WARNING) << "fail to new tablet. tablet_id=" << tablet_id << ", schema_hash:" << schema_hash;
         return OLAP_ERR_TABLE_CREATE_FROM_HEADER_ERROR;
@@ -648,7 +645,7 @@ OLAPStatus TabletManager::load_tablet_from_meta(DataDir* data_dir, TTabletId tab
     }
     res = tablet->register_tablet_into_dir();
     if (res != OLAP_SUCCESS) {
-        LOG(WARNING) << "fail to register tablet into root path. root_path=" << tablet->storage_root_path_name();
+        LOG(WARNING) << "fail to register tablet into root path. root_path=" << tablet->dir_path();
         if (drop_tablet(tablet_id, schema_hash, false) != OLAP_SUCCESS) {
             LOG(WARNING) << "fail to drop tablet when create tablet failed. "
                 <<"tablet=" << tablet_id << " schema_hash=" << schema_hash;
@@ -673,7 +670,7 @@ OLAPStatus TabletManager::load_one_tablet(
         return OLAP_ERR_FILE_NOT_EXIST;
     }
 
-    auto tablet = Tablet::create_from_tablet_meta_file(header_path, store);
+    auto tablet = Tablet::create_tablet_from_meta_file(header_path, store);
     if (tablet == NULL) {
         LOG(WARNING) << "fail to load tablet. [header_path=" << header_path << "]";
         move_to_trash(boost_schema_hash_path, boost_schema_hash_path);
@@ -831,7 +828,7 @@ OLAPStatus TabletManager::start_trash_sweep() {
             if (tablet == nullptr) {
                 continue;
             }
-            tablet->delete_expired_incremental_rowset();
+            tablet->delete_expired_inc_rowsets();
         }
     }
     _tablet_map_lock.unlock();
@@ -862,8 +859,8 @@ void TabletManager::update_root_path_info(std::map<std::string, DataDirInfo>* pa
         TableInstances& instance = entry.second;
         for (auto& tablet : instance.table_arr) {
             (*tablet_counter) ++ ;
-            int64_t data_size = tablet->get_data_size();
-            auto find = path_map->find(tablet->storage_root_path_name()); 
+            int64_t data_size = tablet->tablet_footprint();
+            auto find = path_map->find(tablet->dir_path()); 
             if (find == path_map->end()) {
                 continue;
             }
@@ -880,7 +877,15 @@ void TabletManager::update_storage_medium_type_count(uint32_t storage_medium_typ
 }
 
 void TabletManager::_build_tablet_info(TabletSharedPtr tablet, TTabletInfo* tablet_info) {
-    tablet->get_tablet_info(tablet_info);
+    tablet_info->tablet_id = tablet->tablet_id();
+    tablet_info->schema_hash = tablet->schema_hash();
+    tablet_info->row_count = tablet->num_rows();
+    tablet_info->data_size = tablet->tablet_footprint();
+    Version version = { -1, 0 };
+    VersionHash v_hash = 0;
+    tablet->max_continuous_version_from_begining(&version, &v_hash);
+    tablet_info->version = version.second;
+    tablet_info->version_hash = v_hash;
 }
 
 void TabletManager::_build_tablet_stat() {
@@ -898,10 +903,10 @@ void TabletManager::_build_tablet_stat() {
             }
                 
             // we only get base tablet's stat
-            stat.__set_data_size(tablet->get_data_size());
+            stat.__set_data_size(tablet->tablet_footprint());
             stat.__set_row_num(tablet->num_rows());
             VLOG(3) << "tablet_id=" << item.first 
-                    << ", data_size=" << tablet->get_data_size()
+                    << ", data_size=" << tablet->tablet_footprint()
                     << ", row_num:" << tablet->num_rows();
             break;
         }
@@ -933,7 +938,7 @@ OLAPStatus TabletManager::_create_inital_rowset(
 
     tablet->obtain_header_wrlock();
     tablet->set_cumulative_layer_point(request.version + 1);
-    res = tablet->save_tablet_meta();
+    res = tablet->save_meta();
     tablet->release_header_lock();
     if (res != OLAP_SUCCESS) {
         LOG(WARNING) << "fail to save header. [tablet=" << tablet->full_name() << "]";

--- a/be/src/olap/tablet_manager.h
+++ b/be/src/olap/tablet_manager.h
@@ -54,7 +54,6 @@ class TabletManager {
 public:
     ~TabletManager() {
         _tablet_map.clear();
-        _global_tablet_id = 0;
     }
 
     // Add a tablet pointer to StorageEngine
@@ -174,7 +173,6 @@ private:
     typedef std::map<int64_t, TableInstances> tablet_map_t;
     RWMutex _tablet_map_lock;
     tablet_map_t _tablet_map;
-    size_t _global_tablet_id;
     std::map<std::string, DataDir*> _store_map;
 
     // cache to save tablets' statistics, such as data size and row

--- a/be/src/olap/tablet_meta.h
+++ b/be/src/olap/tablet_meta.h
@@ -140,6 +140,7 @@ public:
     void set_cumulative_layer_point(int32_t new_point);
 
     inline const size_t num_rows() const;
+    // disk space occupied by tablet
     inline const size_t tablet_footprint() const;
     inline const size_t version_count() const;
     Version max_version() const;

--- a/be/src/olap/tablet_meta_manager.cpp
+++ b/be/src/olap/tablet_meta_manager.cpp
@@ -71,11 +71,9 @@ OLAPStatus TabletMetaManager::get_json_header(DataDir* store,
     if (s != OLAP_SUCCESS) {
         return s;
     }
-    TabletMetaPB tablet_meta_pb;
-    tablet_meta.to_tablet_pb(&tablet_meta_pb);
     json2pb::Pb2JsonOptions json_options;
     json_options.pretty_json = true;
-    json2pb::ProtoMessageToJson(tablet_meta_pb, json_header, json_options);
+    tablet_meta.to_json(json_header, json_options);
     return OLAP_SUCCESS;
 }
 

--- a/be/src/olap/tablet_schema.cpp
+++ b/be/src/olap/tablet_schema.cpp
@@ -83,6 +83,7 @@ TabletSchema::TabletSchema()
       _num_short_key_columns(0) { }
 
 OLAPStatus TabletSchema::init_from_pb(const TabletSchemaPB& schema) {
+    _keys_type = schema.keys_type();
     for (auto& column_pb : schema.column()) {
         TabletColumn column;
         column.init_from_pb(column_pb);
@@ -97,7 +98,6 @@ OLAPStatus TabletSchema::init_from_pb(const TabletSchemaPB& schema) {
     }
     _num_short_key_columns = schema.num_short_key_columns();
     _num_rows_per_row_block = schema.num_rows_per_row_block();
-    _keys_type = schema.keys_type();
     _compress_kind = schema.compress_kind();
     _next_column_unique_id = schema.next_column_unique_id();
     if (schema.has_bf_fpp()) {
@@ -109,13 +109,13 @@ OLAPStatus TabletSchema::init_from_pb(const TabletSchemaPB& schema) {
 }
 
 OLAPStatus TabletSchema::to_schema_pb(TabletSchemaPB* tablet_meta_pb) {
+    tablet_meta_pb->set_keys_type(_keys_type);
     for (auto& col : _cols) {
         ColumnPB* column = tablet_meta_pb->add_column();
         col.to_schema_pb(column);
     }
     tablet_meta_pb->set_num_short_key_columns(_num_short_key_columns);
     tablet_meta_pb->set_num_rows_per_row_block(_num_rows_per_row_block);
-    tablet_meta_pb->set_keys_type(_keys_type);
     tablet_meta_pb->set_compress_kind(_compress_kind);
     tablet_meta_pb->set_bf_fpp(_bf_fpp);
     tablet_meta_pb->set_next_column_unique_id(_next_column_unique_id);

--- a/be/src/olap/tablet_schema.h
+++ b/be/src/olap/tablet_schema.h
@@ -96,13 +96,13 @@ public:
     inline size_t next_column_unique_id() const { return _next_column_unique_id; }
     inline double bloom_filter_fpp() const { return _bf_fpp; }
 private:
+    KeysType _keys_type;
     std::vector<TabletColumn> _cols;
     size_t _num_columns;
     size_t _num_key_columns;
     size_t _num_null_columns;
     size_t _num_short_key_columns;
     size_t _num_rows_per_row_block;
-    KeysType _keys_type;
     CompressKind _compress_kind;
     size_t _next_column_unique_id;
     double _bf_fpp;

--- a/be/src/olap/task/engine_batch_load_task.cpp
+++ b/be/src/olap/task/engine_batch_load_task.cpp
@@ -131,7 +131,7 @@ AgentStatus EngineBatchLoadTask::_init() {
 
         // Get local download path
         LOG(INFO) << "start get file. remote_full_path: " << remote_full_path;
-        string root_path = tablet->storage_root_path_name();
+        string root_path = tablet->dir_path();
 
         status = _get_tmp_file_dir(root_path, &tmp_file_dir);
         if (DORIS_SUCCESS != status) {

--- a/be/src/olap/task/engine_batch_load_task.cpp
+++ b/be/src/olap/task/engine_batch_load_task.cpp
@@ -131,7 +131,7 @@ AgentStatus EngineBatchLoadTask::_init() {
 
         // Get local download path
         LOG(INFO) << "start get file. remote_full_path: " << remote_full_path;
-        string root_path = tablet->dir_path();
+        string root_path = tablet->data_dir()->path();
 
         status = _get_tmp_file_dir(root_path, &tmp_file_dir);
         if (DORIS_SUCCESS != status) {

--- a/be/src/olap/task/engine_storage_migration_task.cpp
+++ b/be/src/olap/task/engine_storage_migration_task.cpp
@@ -139,7 +139,7 @@ OLAPStatus EngineStorageMigrationTask::_storage_medium_migrate(
         }
 
         // load the new tablet into OLAPEngine
-        auto tablet = Tablet::create_from_tablet_meta(new_tablet_meta, stores[0]);
+        auto tablet = Tablet::create_tablet_from_meta(new_tablet_meta, stores[0]);
         if (tablet == NULL) {
             OLAP_LOG_WARNING("failed to create from header");
             res = OLAP_ERR_TABLE_CREATE_FROM_HEADER_ERROR;
@@ -185,7 +185,7 @@ OLAPStatus EngineStorageMigrationTask::_generate_new_header(
     OLAPStatus res = OLAP_SUCCESS;
 
     DataDir* ref_store =
-            StorageEngine::instance()->get_store(tablet->storage_root_path_name());
+            StorageEngine::instance()->get_store(tablet->dir_path());
     TabletMetaManager::get_header(ref_store, tablet->tablet_id(), tablet->schema_hash(), new_tablet_meta);
     SnapshotManager::instance()->update_header_file_info(consistent_rowsets, new_tablet_meta);
     new_tablet_meta->set_shard_id(new_shard);

--- a/be/src/olap/task/engine_storage_migration_task.cpp
+++ b/be/src/olap/task/engine_storage_migration_task.cpp
@@ -172,7 +172,6 @@ OLAPStatus EngineStorageMigrationTask::_storage_medium_migrate(
     return res;
 }
 
-
 OLAPStatus EngineStorageMigrationTask::_generate_new_header(
         DataDir* store,
         const uint64_t new_shard,
@@ -185,7 +184,7 @@ OLAPStatus EngineStorageMigrationTask::_generate_new_header(
     OLAPStatus res = OLAP_SUCCESS;
 
     DataDir* ref_store =
-            StorageEngine::instance()->get_store(tablet->dir_path());
+            StorageEngine::instance()->get_store(tablet->data_dir()->path());
     TabletMetaManager::get_header(ref_store, tablet->tablet_id(), tablet->schema_hash(), new_tablet_meta);
     SnapshotManager::instance()->update_header_file_info(consistent_rowsets, new_tablet_meta);
     new_tablet_meta->set_shard_id(new_shard);

--- a/be/src/util/once.h
+++ b/be/src/util/once.h
@@ -1,0 +1,61 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#ifndef DORIS_BE_SRC_UTIL_ONCE_H
+#define DORIS_BE_SRC_UTIL_ONCE_H
+
+#include <atomic>
+
+#include "olap/olap_common.h"
+
+namespace doris {
+
+// Similar to the KuduOnceDynamic class, but accepts a lambda function.
+class DorisInitOnce {
+public:
+    DorisInitOnce()
+        : _init_success(false) {}
+
+    // If the underlying `once_flag` has yet to be invoked, invokes the provided
+    // lambda and stores its return value. Otherwise, returns the stored Status.
+    template<typename Fn>
+    OLAPStatus init(Fn fn) {
+        std::call_once(_once_flag, [this, fn] {
+            _status = fn();
+            if (OLAP_SUCCESS == _status) {
+                _init_success.store(true, std::memory_order_release);
+            }
+        });
+        return _status;
+    }
+
+    // std::memory_order_acquire here and std::memory_order_release in
+    // init(), taken together, mean that threads can safely synchronize on
+    // _init_success.
+    bool init_success() const {
+        return _init_success.load(std::memory_order_acquire);
+    }
+
+private:
+    std::atomic<bool> _init_success;
+    std::once_flag _once_flag;
+    OLAPStatus _status;
+};
+
+} // namespace doris
+
+#endif // DORIS_BE_SRC_UTIL_ONCE_H

--- a/be/src/util/once.h
+++ b/be/src/util/once.h
@@ -28,7 +28,7 @@ namespace doris {
 class DorisInitOnce {
 public:
     DorisInitOnce()
-        : _init_success(false) {}
+        : _init_succeeded(false) {}
 
     // If the underlying `once_flag` has yet to be invoked, invokes the provided
     // lambda and stores its return value. Otherwise, returns the stored Status.
@@ -37,7 +37,7 @@ public:
         std::call_once(_once_flag, [this, fn] {
             _status = fn();
             if (OLAP_SUCCESS == _status) {
-                _init_success.store(true, std::memory_order_release);
+                _init_succeeded.store(true, std::memory_order_release);
             }
         });
         return _status;
@@ -45,13 +45,13 @@ public:
 
     // std::memory_order_acquire here and std::memory_order_release in
     // init(), taken together, mean that threads can safely synchronize on
-    // _init_success.
-    bool init_success() const {
-        return _init_success.load(std::memory_order_acquire);
+    // _init_succeeded.
+    bool init_succeeded() const {
+        return _init_succeeded.load(std::memory_order_acquire);
     }
 
 private:
-    std::atomic<bool> _init_success;
+    std::atomic<bool> _init_succeeded;
     std::once_flag _once_flag;
     OLAPStatus _status;
 };

--- a/gensrc/proto/olap_file.proto
+++ b/gensrc/proto/olap_file.proto
@@ -241,10 +241,10 @@ message ColumnPB {
 }
 
 message TabletSchemaPB {
-    repeated ColumnPB column = 1;
-    optional int32 num_short_key_columns = 2;
-    optional int32 num_rows_per_row_block = 3;
-    optional KeysType keys_type = 4;
+    optional KeysType keys_type = 1;
+    repeated ColumnPB column = 2;
+    optional int32 num_short_key_columns = 3;
+    optional int32 num_rows_per_row_block = 4;
     optional CompressKind compress_kind = 5;
     optional double bf_fpp = 6;
     optional uint32 next_column_unique_id = 7;
@@ -267,10 +267,10 @@ message TabletMetaPB {
     optional int64 creation_time = 6;
     optional int32 cumulative_layer_point = 7;
 
-    optional TabletSchemaPB schema = 8;
-    repeated RowsetMetaPB rs_metas = 9;
-    repeated RowsetMetaPB inc_rs_metas = 10;
-    optional TabletStatePB tablet_state = 11;
+    optional TabletStatePB tablet_state = 8;
+    optional TabletSchemaPB schema = 9;
+    repeated RowsetMetaPB rs_metas = 10;
+    repeated RowsetMetaPB inc_rs_metas = 11;
     optional AlterTabletPB alter_tablet_task = 12;
 }
 


### PR DESCRIPTION
1.  Import TabletState to describe tablet state transitions.
2. There is no necessary to use std::mutex in TabletMeta,
     because concurrency conflict addressed by Tablet.