### PR TITLE
Copy the latest source code from local in dockerfile

### DIFF
--- a/docker/Docker_build.md
+++ b/docker/Docker_build.md
@@ -1,8 +1,15 @@
 ## Doris Develop Environment based on docker
+### 0. Download the latest source code
+
+```
+git clone https://github.com/apache/incubator-doris.git
+cp incubator-doris/docker/Dockerfile .
+
+```
+
 ### 1. Build docker image
 
 ```aidl
-cd docker
 
 docker build -t doris:v1.0  .
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -97,9 +97,9 @@ WORKDIR ${DEFAULT_DIR}
 # there is a repo which is included all of thirdparty
 ENV REPOSITORY_URL=https://doris-incubating-repo.bj.bcebos.com/thirdparty
 
-# clone lastest source code, download and build third party
-RUN git clone https://github.com/apache/incubator-doris.git \
-    && cd ${DEFAULT_DIR}/incubator-doris && /bin/bash thirdparty/build-thirdparty.sh \
+# clone lastest source code from local dir(please update local dir before docker build), download and build third party
+COPY incubator-doris ${DEFAULT_DIR}/incubator-doris
+RUN cd ${DEFAULT_DIR}/incubator-doris && /bin/bash thirdparty/build-thirdparty.sh \
     && rm -rf ${DEFAULT_DIR}/incubator-doris/thirdparty/src \
     && rm -rf ${DEFAULT_DIR}/doris-thirdparty.tar.gz \
     && rm -rf ${DEFAULT_DIR}/doris-thirdparty \


### PR DESCRIPTION
1. Run git clone may not been executed when docker use cached layer, so I change it to copy latest code from local.
2. Before building docker image, please clone the latest source code firstly.