### PR TITLE
Modify alter tablet implementation and change ColumnPruning to ZoneMap

### DIFF
--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -276,7 +276,7 @@ void TaskWorkerPool::_remove_task_info(
     std::string task_name;
     EnumToString(TTaskType, task_type, task_name);
     LOG(INFO) << "type: " << task_name
-              << ", signature: " << signature << ", has been erased."
+              << ", signature: " << signature << ", has been erased"
               << ", queue size: " << signature_set.size();
 }
 

--- a/be/src/olap/base_compaction.cpp
+++ b/be/src/olap/base_compaction.cpp
@@ -101,7 +101,7 @@ OLAPStatus BaseCompaction::run() {
         return res;
     }
 
-    VLOG(10) << "new_base_version_hash" << new_base_version_hash;
+    VLOG(10) << "new_base_version_hash:" << new_base_version_hash;
 
     // 2. 获取生成新base需要的data sources
     vector<RowsetSharedPtr> rowsets;
@@ -174,7 +174,7 @@ OLAPStatus BaseCompaction::run() {
     LOG(INFO) << "succeed to do base compaction. tablet=" << _tablet->full_name()
               << ", base_version=" << _new_base_version.first << "-" << _new_base_version.second
               << ". elapsed time of doing base compaction"
-              << ", time=" << stage_watch.get_elapse_time_us() / (100000.0) << "s";
+              << ", time=" << stage_watch.get_elapse_second() << "s";
 
     return OLAP_SUCCESS;
 }

--- a/be/src/olap/base_compaction.cpp
+++ b/be/src/olap/base_compaction.cpp
@@ -146,8 +146,6 @@ OLAPStatus BaseCompaction::run() {
         return OLAP_ERR_BE_ERROR_DELETE_ACTION;
     }
 
-    VLOG(3) << "elapsed time of doing base compaction:" << stage_watch.get_elapse_time_us();
-
     // 4. make new versions visable.
     //    If success, remove files belong to old versions;
     //    If fail, gc files belong to new versions.
@@ -174,7 +172,10 @@ OLAPStatus BaseCompaction::run() {
     _release_base_compaction_lock();
 
     LOG(INFO) << "succeed to do base compaction. tablet=" << _tablet->full_name()
-              << ", base_version=" << _new_base_version.first << "-" << _new_base_version.second;
+              << ", base_version=" << _new_base_version.first << "-" << _new_base_version.second
+              << ". elapsed time of doing base compaction"
+              << ", time=" << stage_watch.get_elapse_time_us() / (100000.0) << "s";
+
     return OLAP_SUCCESS;
 }
 

--- a/be/src/olap/cumulative_compaction.cpp
+++ b/be/src/olap/cumulative_compaction.cpp
@@ -176,7 +176,7 @@ OLAPStatus CumulativeCompaction::run() {
               << ", cumulative_version=" << _cumulative_version.first
               << "-" << _cumulative_version.second
               << ". elapsed time of doing cumulative compaction"
-              << ", time=" << watch.get_elapse_time_us() / (100000.0) << "s";
+              << ", time=" << watch.get_elapse_second() << "s";
     return res;
 }
 
@@ -451,7 +451,7 @@ OLAPStatus CumulativeCompaction::_do_cumulative_compaction() {
     _release_header_lock();
 
     // 6. delete delta files which have been merged into new cumulative file
-    _delete_unused_delta_files(&unused_rowsets);
+    _delete_unused_rowsets(&unused_rowsets);
 
     return res;
 }
@@ -478,7 +478,7 @@ OLAPStatus CumulativeCompaction::_update_header(const vector<RowsetSharedPtr>& u
     return res;
 }
 
-void CumulativeCompaction::_delete_unused_delta_files(vector<RowsetSharedPtr>* unused_rowsets) {
+void CumulativeCompaction::_delete_unused_rowsets(vector<RowsetSharedPtr>* unused_rowsets) {
     if (!unused_rowsets->empty()) {
         StorageEngine* storage_engine = StorageEngine::instance();
 

--- a/be/src/olap/cumulative_compaction.cpp
+++ b/be/src/olap/cumulative_compaction.cpp
@@ -169,19 +169,20 @@ OLAPStatus CumulativeCompaction::run() {
     if (res != OLAP_SUCCESS && _rowset != NULL) {
         StorageEngine::instance()->add_unused_rowset(_rowset);
     }
-    
+
     _tablet->release_cumulative_lock();
 
-    VLOG(10) << "elapsed time of doing cumulative compaction. "
-             << "time=" << watch.get_elapse_time_us();
+    LOG(INFO) << "succeed to do cumulative compaction. tablet=" << _tablet->full_name()
+              << ", cumulative_version=" << _cumulative_version.first
+              << "-" << _cumulative_version.second
+              << ". elapsed time of doing cumulative compaction"
+              << ", time=" << watch.get_elapse_time_us() / (100000.0) << "s";
     return res;
 }
 
 OLAPStatus CumulativeCompaction::_calculate_need_merged_versions() {
-    OLAPStatus res = OLAP_SUCCESS;
-    
     Versions delta_versions;
-    res = _get_delta_versions(&delta_versions);
+    OLAPStatus res = _get_delta_versions(&delta_versions);
     if (res != OLAP_SUCCESS) {
         LOG(INFO) << "failed to get delta versions.";
         return res;
@@ -452,9 +453,6 @@ OLAPStatus CumulativeCompaction::_do_cumulative_compaction() {
     // 6. delete delta files which have been merged into new cumulative file
     _delete_unused_delta_files(&unused_rowsets);
 
-    LOG(INFO) << "succeed to do cumulative compaction. tablet=" << _tablet->full_name()
-              << ", cumulative_version=" << _cumulative_version.first << "-"
-              << _cumulative_version.second;
     return res;
 }
 

--- a/be/src/olap/cumulative_compaction.h
+++ b/be/src/olap/cumulative_compaction.h
@@ -118,7 +118,7 @@ private:
     //
     // 输入输出参数
     // - unused_rowsets: 待删除的不再使用的delta文件对应的olap index
-    void _delete_unused_delta_files(std::vector<RowsetSharedPtr>* unused_rowsets);
+    void _delete_unused_rowsets(std::vector<RowsetSharedPtr>* unused_rowsets);
 
     // 验证得到的m_need_merged_versions是否正确
     //

--- a/be/src/olap/olap_cond.h
+++ b/be/src/olap/olap_cond.h
@@ -68,16 +68,16 @@ public:
     ~Cond();
 
     OLAPStatus init(const TCondition& tcond, const TabletColumn& column);
-    
+
     // 用一行数据的指定列同条件进行比较，如果符合过滤条件，
     // 即按照此条件，行应被过滤掉，则返回true，否则返回false
     bool eval(char* right) const;
-    
-    bool eval(const std::pair<WrapperField*, WrapperField*>& statistic) const;
-    int del_eval(const std::pair<WrapperField*, WrapperField*>& stat) const;
+
+    bool eval(const KeyRange& statistic) const;
+    int del_eval(const KeyRange& stat) const;
 
     bool eval(const BloomFilter& bf) const;
-    
+
     CondOp op;
     // valid when op is not OP_IN
     WrapperField* operand_field;
@@ -150,7 +150,7 @@ public:
     
     bool delete_conditions_eval(const RowCursor& row) const;
     
-    bool delta_pruning_filter(const std::vector<KeyRange>& zone_maps) const;
+    bool rowset_pruning_filter(const std::vector<KeyRange>& zone_maps) const;
     int delete_pruning_filter(const std::vector<KeyRange>& zone_maps) const;
 
     const CondColumns& columns() const {

--- a/be/src/olap/olap_cond.h
+++ b/be/src/olap/olap_cond.h
@@ -150,10 +150,8 @@ public:
     
     bool delete_conditions_eval(const RowCursor& row) const;
     
-    bool delta_pruning_filter(
-        const std::vector<std::pair<WrapperField*, WrapperField*>>& column_statistics) const;
-    int delete_pruning_filter(
-        const std::vector<std::pair<WrapperField*, WrapperField*>>& column_statistics) const;
+    bool delta_pruning_filter(const std::vector<KeyRange>& zone_maps) const;
+    int delete_pruning_filter(const std::vector<KeyRange>& zone_maps) const;
 
     const CondColumns& columns() const {
         return _columns;

--- a/be/src/olap/reader.cpp
+++ b/be/src/olap/reader.cpp
@@ -123,12 +123,6 @@ private:
                 if (_row_block->has_remaining()) {
                     size_t pos = _row_block->pos();
                     _row_block->get_row(pos, &_row_cursor);
-                    if (_row_block->block_status() == DEL_PARTIAL_SATISFIED &&
-                        _reader->_delete_handler.is_filter_data(_rs_reader->version().second, _row_cursor)) {
-                        _reader->_stats.rows_del_filtered++;
-                        _row_block->pos_inc();
-                        continue;
-                    }
                     _current_row = &_row_cursor;
                     return OLAP_SUCCESS;
                 } else {

--- a/be/src/olap/rowset/alpha_rowset.cpp
+++ b/be/src/olap/rowset/alpha_rowset.cpp
@@ -141,13 +141,13 @@ void AlphaRowset::set_version_and_version_hash(Version version,  VersionHash ver
         segment_group_pb.set_index_size(segment_group->index_size());
         segment_group_pb.set_data_size(segment_group->data_size());
         segment_group_pb.set_num_rows(segment_group->num_rows());
-        const std::vector<KeyRange>& column_statistics = segment_group->get_column_statistics();
-        if (column_statistics.size() > 0) {
-            for (size_t i = 0; i < column_statistics.size(); ++i) {
-                ColumnPruning* column_pruning = segment_group_pb.add_column_pruning();
-                column_pruning->set_min(column_statistics.at(i).first->to_string());
-                column_pruning->set_max(column_statistics.at(i).second->to_string());
-                column_pruning->set_null_flag(column_statistics.at(i).first->is_null());
+        const std::vector<KeyRange>& zone_maps = segment_group->get_zone_maps();
+        if (zone_maps.size() > 0) {
+            for (size_t i = 0; i < zone_maps.size(); ++i) {
+                ZoneMap* new_zone_map = segment_group_pb.add_zone_maps();
+                new_zone_map->set_min(zone_maps.at(i).first->to_string());
+                new_zone_map->set_max(zone_maps.at(i).second->to_string());
+                new_zone_map->set_null_flag(zone_maps.at(i).first->is_null());
             }
         }
         segment_group_pb.set_empty(segment_group->empty());
@@ -361,28 +361,28 @@ OLAPStatus AlphaRowset::_init_non_pending_segment_groups() {
                 // if load segment group failed, rowset init failed
             return OLAP_ERR_TABLE_INDEX_VALIDATE_ERROR;
         }
-        if (segment_group_meta.column_pruning_size() != 0) {
-            size_t column_pruning_size = segment_group_meta.column_pruning_size();
+        if (segment_group_meta.zone_maps_size() != 0) {
+            size_t zone_maps_size = segment_group_meta.zone_maps_size();
             size_t num_key_columns = _schema->num_key_columns();
-            if (num_key_columns != column_pruning_size) {
+            if (num_key_columns != zone_maps_size) {
                 LOG(ERROR) << "column pruning size is error."
-                        << "column_pruning_size=" << column_pruning_size << ", "
+                        << "zone_maps_size=" << zone_maps_size << ", "
                         << "num_key_columns=" << _schema->num_key_columns();
                 return OLAP_ERR_TABLE_INDEX_VALIDATE_ERROR;
             }
-            std::vector<std::pair<std::string, std::string>> column_statistic_strings(num_key_columns);
+            std::vector<std::pair<std::string, std::string>> zone_map_strings(num_key_columns);
             std::vector<bool> null_vec(num_key_columns);
             for (size_t j = 0; j < num_key_columns; ++j) {
-                ColumnPruning column_pruning = segment_group_meta.column_pruning(j);
-                column_statistic_strings[j].first = column_pruning.min();
-                column_statistic_strings[j].second = column_pruning.max();
-                if (column_pruning.has_null_flag()) {
-                    null_vec[j] = column_pruning.null_flag();
+                const ZoneMap& zone_map = segment_group_meta.zone_maps(j);
+                zone_map_strings[j].first = zone_map.min();
+                zone_map_strings[j].second = zone_map.max();
+                if (zone_map.has_null_flag()) {
+                    null_vec[j] = zone_map.null_flag();
                 } else {
                     null_vec[j] = false;
                 }
             }
-            OLAPStatus status = segment_group->add_column_statistics(column_statistic_strings, null_vec);
+            OLAPStatus status = segment_group->add_zone_maps(zone_map_strings, null_vec);
             if (status != OLAP_SUCCESS) {
                 LOG(WARNING) << "segment group add column statistics failed, status:" << status;
                 return status;
@@ -437,28 +437,28 @@ OLAPStatus AlphaRowset::_init_pending_segment_groups() {
             return OLAP_ERR_TABLE_INDEX_VALIDATE_ERROR;
         }
 
-        if (pending_segment_group_meta.column_pruning_size() != 0) {
-            size_t column_pruning_size = pending_segment_group_meta.column_pruning_size();
+        if (pending_segment_group_meta.zone_maps_size() != 0) {
+            size_t zone_maps_size = pending_segment_group_meta.zone_maps_size();
             size_t num_key_columns = _schema->num_key_columns();
-            if (num_key_columns != column_pruning_size) {
+            if (num_key_columns != zone_maps_size) {
                 LOG(ERROR) << "column pruning size is error."
-                        << "column_pruning_size=" << column_pruning_size << ", "
+                        << "zone_maps_size=" << zone_maps_size << ", "
                         << "num_key_columns=" << _schema->num_key_columns();
                 return OLAP_ERR_TABLE_INDEX_VALIDATE_ERROR;
             }
-            std::vector<std::pair<std::string, std::string>> column_statistic_strings(num_key_columns);
+            std::vector<std::pair<std::string, std::string>> zone_map_strings(num_key_columns);
             std::vector<bool> null_vec(num_key_columns);
             for (size_t j = 0; j < num_key_columns; ++j) {
-                ColumnPruning column_pruning = pending_segment_group_meta.column_pruning(j);
-                column_statistic_strings[j].first = column_pruning.min();
-                column_statistic_strings[j].second = column_pruning.max();
-                if (column_pruning.has_null_flag()) {
-                    null_vec[j] = column_pruning.null_flag();
+                const ZoneMap& zone_map = pending_segment_group_meta.zone_maps(j);
+                zone_map_strings[j].first = zone_map.min();
+                zone_map_strings[j].second = zone_map.max();
+                if (zone_map.has_null_flag()) {
+                    null_vec[j] = zone_map.null_flag();
                 } else {
                     null_vec[j] = false;
                 }
             }
-            OLAPStatus status = segment_group->add_column_statistics(column_statistic_strings, null_vec);
+            OLAPStatus status = segment_group->add_zone_maps(zone_map_strings, null_vec);
             if (status != OLAP_SUCCESS) {
                 LOG(WARNING) << "segment group add column statistics failed, status:" << status;
                 return status;

--- a/be/src/olap/rowset/alpha_rowset.cpp
+++ b/be/src/olap/rowset/alpha_rowset.cpp
@@ -52,9 +52,8 @@ OLAPStatus AlphaRowset::init() {
 
 std::shared_ptr<RowsetReader> AlphaRowset::create_reader() {
     return std::shared_ptr<RowsetReader>(new AlphaRowsetReader(
-            _schema->num_key_columns(), _schema->num_short_key_columns(),
-            _schema->num_rows_per_row_block(), _rowset_path,
-            _rowset_meta.get(), _segment_groups, shared_from_this()));
+            _schema->num_rows_per_row_block(), _rowset_meta.get(),
+            _segment_groups, shared_from_this()));
 }
 
 OLAPStatus AlphaRowset::copy(RowsetWriter* dest_rowset_writer) {

--- a/be/src/olap/rowset/alpha_rowset_reader.cpp
+++ b/be/src/olap/rowset/alpha_rowset_reader.cpp
@@ -328,11 +328,11 @@ OLAPStatus AlphaRowsetReader::_init_column_datas(RowsetReaderContext* read_conte
 OLAPStatus AlphaRowsetReader::_refresh_next_block(size_t pos, RowBlock** next_block) {
     ColumnData* column_data = _column_datas[pos].get();
     OLAPStatus status = column_data->get_next_block(next_block);
-    if (status == OLAP_ERR_DATA_EOF) {
+    if (status == OLAP_ERR_DATA_EOF && _key_range_size > 0) {
         // currently, SegmentReader can only support filter one key range a time
         // use the next predicate range to get data from segment here
         _key_range_indices[pos]++;
-        while (_key_range_size > 0 && _key_range_indices[pos] < _key_range_size) {
+        while (_key_range_indices[pos] < _key_range_size) {
             status = column_data->prepare_block_read(_current_read_context->lower_bound_keys->at(_key_range_indices[pos]),
                     _current_read_context->is_lower_keys_included->at(_key_range_indices[pos]),
                     _current_read_context->upper_bound_keys->at(_key_range_indices[pos]),

--- a/be/src/olap/rowset/alpha_rowset_reader.h
+++ b/be/src/olap/rowset/alpha_rowset_reader.h
@@ -29,10 +29,9 @@ namespace doris {
 
 class AlphaRowsetReader : public RowsetReader {
 public:
-    AlphaRowsetReader(int num_key_columns, int num_short_key_columns,
-        int num_rows_per_row_block, const std::string rowset_path,
-        RowsetMeta* rowset_meta, std::vector<std::shared_ptr<SegmentGroup>> segment_groups,
-        RowsetSharedPtr rowset);
+    AlphaRowsetReader(int num_rows_per_row_block, RowsetMeta* rowset_meta,
+                      std::vector<std::shared_ptr<SegmentGroup>> segment_groups,
+                      RowsetSharedPtr rowset);
 
     // reader init
     virtual OLAPStatus init(RowsetReaderContext* read_context);
@@ -54,9 +53,6 @@ public:
 
     // close reader
     virtual void close();
-
-    // TODO(hkp)
-    virtual int32_t get_filtered_rows() { return 0; }
 
     virtual RowsetSharedPtr rowset();
 

--- a/be/src/olap/rowset/column_data.cpp
+++ b/be/src/olap/rowset/column_data.cpp
@@ -527,7 +527,7 @@ OLAPStatus ColumnData::get_next_row_block(RowBlock** row_block) {
     return OLAP_SUCCESS;
 }
 
-bool ColumnData::delta_pruning_filter() {
+bool ColumnData::rowset_pruning_filter() {
     if (empty() || zero_num_rows()) {
         return true;
     }
@@ -536,7 +536,7 @@ bool ColumnData::delta_pruning_filter() {
         return false;
     }
 
-    return _conditions->delta_pruning_filter(_segment_group->get_zone_maps());
+    return _conditions->rowset_pruning_filter(_segment_group->get_zone_maps());
 }
 
 int ColumnData::delete_pruning_filter() {

--- a/be/src/olap/rowset/column_data.cpp
+++ b/be/src/olap/rowset/column_data.cpp
@@ -532,11 +532,11 @@ bool ColumnData::delta_pruning_filter() {
         return true;
     }
 
-    if (!_segment_group->has_column_statistics()) {
+    if (!_segment_group->has_zone_maps()) {
         return false;
     }
 
-    return _conditions->delta_pruning_filter(_segment_group->get_column_statistics());
+    return _conditions->delta_pruning_filter(_segment_group->get_zone_maps());
 }
 
 int ColumnData::delete_pruning_filter() {
@@ -546,7 +546,7 @@ int ColumnData::delete_pruning_filter() {
         return DEL_NOT_SATISFIED;
     }
 
-    if (false == _segment_group->has_column_statistics()) {
+    if (false == _segment_group->has_zone_maps()) {
         /*
          * if segment_group has no column statistics, we cannot judge whether the data can be filtered or not
          */
@@ -568,7 +568,7 @@ int ColumnData::delete_pruning_filter() {
         }
 
         Conditions* del_cond = delete_condtion.del_cond;
-        int del_ret = del_cond->delete_pruning_filter(_segment_group->get_column_statistics());
+        int del_ret = del_cond->delete_pruning_filter(_segment_group->get_zone_maps());
         if (DEL_SATISFIED == del_ret) {
             del_stastified = true;
             break;

--- a/be/src/olap/rowset/column_data.h
+++ b/be/src/olap/rowset/column_data.h
@@ -109,7 +109,7 @@ public:
     bool empty() const { return _segment_group->empty(); }
     bool zero_num_rows() const { return _segment_group->zero_num_rows(); }
 
-    bool delta_pruning_filter();
+    bool rowset_pruning_filter();
     int delete_pruning_filter();
     uint64_t get_filted_rows();
 

--- a/be/src/olap/rowset/column_data_writer.cpp
+++ b/be/src/olap/rowset/column_data_writer.cpp
@@ -198,7 +198,7 @@ OLAPStatus ColumnDataWriter::finalize() {
 
     res = _segment_group->add_zone_maps(_zone_maps);
     if (res != OLAP_SUCCESS) {
-        OLAP_LOG_WARNING("Fail to set delta pruning![res=%d]", res);
+        LOG(WARNING) << "Fail to set zone_map! res=" << res;
         return res;
     }
 

--- a/be/src/olap/rowset/column_data_writer.h
+++ b/be/src/olap/rowset/column_data_writer.h
@@ -60,7 +60,7 @@ private:
     CompressKind _compress_kind;
     double _bloom_filter_fpp;
     // first is min, second is max
-    std::vector<std::pair<WrapperField*, WrapperField*>> _column_statistics;
+    std::vector<std::pair<WrapperField*, WrapperField*>> _zone_maps;
     uint32_t _row_index;
 
     RowBlock* _row_block;      // 使用RowBlcok缓存要写入的数据

--- a/be/src/olap/rowset/column_writer.cpp
+++ b/be/src/olap/rowset/column_writer.cpp
@@ -399,7 +399,6 @@ OLAPStatus ColumnWriter::finalize(ColumnDataHeaderMessage* header) {
     column->set_is_bf_column(is_bf_column());
 
     save_encoding(header->add_column_encoding());
-    //segment_statistics()->save(header->add_column_statistics());
 
 FINALIZE_EXIT:
     SAFE_DELETE_ARRAY(index_buf);

--- a/be/src/olap/rowset/column_writer.h
+++ b/be/src/olap/rowset/column_writer.h
@@ -73,7 +73,7 @@ public:
     //   * column_unique_id
     //   * column_type
     //   * column_encoding
-    //   * column_statistics
+    //   * zone_maps 
     virtual OLAPStatus finalize(ColumnDataHeaderMessage* header);
     virtual void save_encoding(ColumnEncodingMessage* encoding);
     uint32_t column_id() const {

--- a/be/src/olap/rowset/rowset_meta.h
+++ b/be/src/olap/rowset/rowset_meta.h
@@ -195,22 +195,22 @@ public:
         _rowset_meta_pb.set_index_disk_size(index_disk_size);
     }
 
-    void column_statistics(std::vector<ColumnPruning>* column_statistics) {
-        for (const ColumnPruning& column_statistic : _rowset_meta_pb.column_statistics()) {
-            column_statistics->push_back(column_statistic);
+    void zone_maps(std::vector<ZoneMap>* zone_maps) {
+        for (const ZoneMap& zone_map: _rowset_meta_pb.zone_maps()) {
+            zone_maps->push_back(zone_map);
         }
     }
 
-    void set_column_statistics(const std::vector<ColumnPruning>& column_statistics) {
-        for (const ColumnPruning& column_statistic : column_statistics) {
-            ColumnPruning* new_column_statistic = _rowset_meta_pb.add_column_statistics();
-            *new_column_statistic = column_statistic;
+    void set_zone_maps(const std::vector<ZoneMap>& zone_maps) {
+        for (const ZoneMap& zone_map : zone_maps) {
+            ZoneMap* new_zone_map = _rowset_meta_pb.add_zone_maps();
+            *new_zone_map = zone_map;
         }
     }
 
-    void add_column_statistic(const ColumnPruning& column_statistic) {
-        ColumnPruning* new_column_statistic = _rowset_meta_pb.add_column_statistics();
-        *new_column_statistic = column_statistic;
+    void add_zone_map(const ZoneMap& zone_map) {
+        ZoneMap* new_zone_map = _rowset_meta_pb.add_zone_maps();
+        *new_zone_map = zone_map;
     }
 
     bool has_delete_predicate() {

--- a/be/src/olap/rowset/rowset_reader.h
+++ b/be/src/olap/rowset/rowset_reader.h
@@ -58,8 +58,6 @@ public:
     // close reader
     virtual void close() = 0;
 
-    virtual int32_t get_filtered_rows() = 0;
-
     virtual int32_t num_rows() = 0;
 };
 

--- a/be/src/olap/rowset/segment_group.h
+++ b/be/src/olap/rowset/segment_group.h
@@ -63,22 +63,22 @@ public:
     bool index_loaded();
     OLAPStatus load_pb(const char* file, uint32_t seg_id);
 
-    bool has_column_statistics() {
-        return _column_statistics.size() != 0;
+    bool has_zone_maps() {
+        return _zone_maps.size() != 0;
     }
 
-    OLAPStatus add_column_statistics_for_linked_schema_change(
-        const std::vector<std::pair<WrapperField*, WrapperField*>>& column_statistic_fields);
+    OLAPStatus add_zone_maps_for_linked_schema_change(
+        const std::vector<std::pair<WrapperField*, WrapperField*>>& zone_map_fields);
 
-    OLAPStatus add_column_statistics(
-        const std::vector<std::pair<WrapperField*, WrapperField*>>& column_statistic_fields);
+    OLAPStatus add_zone_maps(
+        const std::vector<std::pair<WrapperField*, WrapperField*>>& zone_map_fields);
 
-    OLAPStatus add_column_statistics(
-        std::vector<std::pair<std::string, std::string>> &column_statistic_strings,
+    OLAPStatus add_zone_maps(
+        std::vector<std::pair<std::string, std::string>> &zone_map_strings,
         std::vector<bool> &null_vec);
 
-    const std::vector<std::pair<WrapperField*, WrapperField*>>& get_column_statistics() {
-        return _column_statistics;
+    const std::vector<std::pair<WrapperField*, WrapperField*>>& get_zone_maps() {
+        return _zone_maps;
     }
 
     // 检查index文件和data文件的有效性
@@ -316,7 +316,7 @@ private:
     mutable boost::mutex _index_load_lock;
     size_t _current_num_rows_per_row_block;
 
-    std::vector<std::pair<WrapperField*, WrapperField*>> _column_statistics;
+    std::vector<std::pair<WrapperField*, WrapperField*>> _zone_maps;
     std::unordered_map<uint32_t, FileHeader<ColumnDataHeaderMessage> > _seg_pb_map;
 
 };

--- a/be/src/olap/rowset/segment_writer.cpp
+++ b/be/src/olap/rowset/segment_writer.cpp
@@ -153,7 +153,7 @@ OLAPStatus SegmentWriter::_make_file_header(ColumnDataHeaderMessage* file_header
         //   * column_unique_id
         //   * column_type
         //   * column_encoding
-        //   * column_statistics
+        //   * zone_maps
         res = (*it)->finalize(file_header);
 
         if (OLAP_UNLIKELY(OLAP_SUCCESS != res)) {

--- a/be/src/olap/schema_change.cpp
+++ b/be/src/olap/schema_change.cpp
@@ -773,7 +773,8 @@ bool SchemaChangeDirectly::process(RowsetReaderSharedPtr rowset_reader, RowsetWr
         goto DIRECTLY_PROCESS_ERR;
     }
 
-    add_filted_rows(rowset_reader->get_filtered_rows());
+    //TODO: unify filtered_rows
+    //add_filted_rows(rowset_reader->get_filtered_rows());
 
     // Check row num changes
     if (config::row_nums_check) {
@@ -981,7 +982,8 @@ bool SchemaChangeWithSorting::process(
         goto SORTING_PROCESS_ERR;
     }
 
-    add_filted_rows(rowset_reader->get_filtered_rows());
+    //TODO: unify get_filtered_rows
+    //add_filted_rows(rowset_reader->get_filtered_rows());
 
     // Check row num changes
     if (config::row_nums_check) {
@@ -1419,7 +1421,7 @@ OLAPStatus SchemaChangeHandler::_create_new_tablet(
                     << ", tablet=" << request.tablet_id
                     << ":" << request.tablet_schema.schema_hash;
             }
-        } else if (NULL != tablet_to_create) {
+        } else if (tablet_to_create != nullptr) {
             tablet_to_create->delete_all_files();
         }
     }
@@ -1634,16 +1636,16 @@ OLAPStatus SchemaChangeHandler::_save_alter_tablet_state(
     base_tablet->set_alter_state(state);
     OLAPStatus res = base_tablet->save_meta();
     if (res != OLAP_SUCCESS) {
-        LOG(FATAL) << "fail to save ref tablet header. res=" << res
-                   << ", tablet=" << base_tablet->full_name();
+        LOG(FATAL) << "fail to save base tablet meta. res=" << res
+                   << ", base_tablet=" << base_tablet->full_name();
         return res;
     }
 
     new_tablet->set_alter_state(state);
     res = new_tablet->save_meta();
     if (res != OLAP_SUCCESS) {
-        LOG(FATAL) << "fail to save ref tablet header. res=" << res
-                   << ", tablet=" << base_tablet->full_name();
+        LOG(FATAL) << "fail to save new tablet meta. res=" << res
+                   << ", new_tablet=" << base_tablet->full_name();
         return res;
     }
 

--- a/be/src/olap/schema_change.cpp
+++ b/be/src/olap/schema_change.cpp
@@ -46,12 +46,12 @@ using std::vector;
 namespace doris {
 
 RowBlockChanger::RowBlockChanger(const TabletSchema& tablet_schema,
-                                 const TabletSharedPtr &ref_tablet) {
+                                 const TabletSharedPtr &base_tablet) {
     _schema_mapping.resize(tablet_schema.num_columns());
 }
 
 RowBlockChanger::RowBlockChanger(const TabletSchema& tablet_schema,
-                                 const TabletSharedPtr& ref_tablet,
+                                 const TabletSharedPtr& base_tablet,
                                  const DeleteHandler& delete_handler) {
     _schema_mapping.resize(tablet_schema.num_columns());
     _delete_handler = delete_handler;
@@ -717,7 +717,7 @@ bool SchemaChangeDirectly::process(RowsetReaderSharedPtr rowset_reader, RowsetWr
     }
 
     VLOG(3) << "init writer. tablet=" << _tablet->full_name()
-        << "block_row_size=" << _tablet->num_rows_per_row_block();
+            << "block_row_number=" << _tablet->num_rows_per_row_block();
     bool result = true;
     RowBlock* new_row_block = NULL;
 
@@ -1161,9 +1161,9 @@ OLAPStatus SchemaChangeHandler::_check_and_clear_schema_change_info(
     // clear schema change info of related tablet
     TabletSharedPtr related_tablet = TabletManager::instance()->get_tablet(
             tablet_id, schema_hash);
-    if (related_tablet.get() == NULL) {
-        OLAP_LOG_WARNING("get null tablet! [tablet_id=%ld schema_hash=%d]",
-                         tablet_id, schema_hash);
+    if (related_tablet == nullptr) {
+        LOG(WARNING) << "tablet does not exist. tablet_id=" << tablet_id
+                     << ", schema_hash=" << schema_hash;
         return OLAP_ERR_TABLE_NOT_FOUND;
     }
     res = related_tablet->protected_delete_alter_task();
@@ -1172,32 +1172,32 @@ OLAPStatus SchemaChangeHandler::_check_and_clear_schema_change_info(
 
 OLAPStatus SchemaChangeHandler::process_alter_tablet(AlterTabletType type,
                                                      const TAlterTabletReq& request) {
-    OLAPStatus res = OLAP_SUCCESS;
-    LOG(INFO) << "begin to validate alter tablet request.";
+    LOG(INFO) << "begin to validate alter tablet request. base_tablet_id=" << request.base_tablet_id
+              << ", new_tablet_id=" << request.new_tablet_req.tablet_id;
 
     // 1. Lock schema_change_lock util schema change info is stored in tablet header
     if (!TabletManager::instance()->try_schema_change_lock(request.base_tablet_id)) {
-        OLAP_LOG_WARNING("failed to obtain schema change lock. [res=%d tablet=%ld]",
-                         res, request.base_tablet_id);
+        LOG(WARNING) << "failed to obtain schema change lock. "
+                     << "base_tablet=" << request.base_tablet_id;
         return OLAP_ERR_TRY_LOCK_FAILED;
     }
 
     // 2. Get base tablet
-    TabletSharedPtr ref_tablet = TabletManager::instance()->get_tablet(
+    TabletSharedPtr base_tablet = TabletManager::instance()->get_tablet(
             request.base_tablet_id, request.base_schema_hash);
-    if (ref_tablet.get() == NULL) {
-        OLAP_LOG_WARNING("fail to find base tablet. [base_tablet=%ld base_schema_hash=%d]",
-                         request.base_tablet_id, request.base_schema_hash);
+    if (base_tablet == nullptr) {
+        LOG(WARNING) << "fail to find base tablet. base_tablet=" << request.base_tablet_id
+                     << ", base_schema_hash=" << request.base_schema_hash;
         TabletManager::instance()->release_schema_change_lock(request.base_tablet_id);
         return OLAP_ERR_TABLE_NOT_FOUND;
     }
 
     // 3. Check if history schema change information exist,
     //    if exist, it will be cleaned only when all delta versions converted
-    res = _check_and_clear_schema_change_info(ref_tablet, request);
+    OLAPStatus res = _check_and_clear_schema_change_info(base_tablet, request);
     if (res != OLAP_SUCCESS) {
-        OLAP_LOG_WARNING("failed to check and clear schema change info. [tablet='%s']",
-                         ref_tablet->full_name().c_str());
+        LOG(WARNING) << "failed to check and clear schema change info."
+                     << " base_tablet=" << base_tablet->full_name();
         TabletManager::instance()->release_schema_change_lock(request.base_tablet_id);
         return res;
     }
@@ -1205,67 +1205,32 @@ OLAPStatus SchemaChangeHandler::process_alter_tablet(AlterTabletType type,
     // 4. return failed if new tablet already exist in StorageEngine.
     TabletSharedPtr new_tablet = TabletManager::instance()->get_tablet(
             request.new_tablet_req.tablet_id, request.new_tablet_req.tablet_schema.schema_hash);
-    if (new_tablet.get() != NULL) {
-        res = OLAP_SUCCESS;
-    } else {
-        res = _do_alter_tablet(type, ref_tablet, request);
+    if (new_tablet != nullptr) {
+        TabletManager::instance()->release_schema_change_lock(request.base_tablet_id);
+        return OLAP_SUCCESS;
     }
 
-    TabletManager::instance()->release_schema_change_lock(request.base_tablet_id);
+    LOG(INFO) << "finish to validate alter tablet request. base_tablet_id=" << request.base_tablet_id
+              << ", new_tablet_id=" << request.new_tablet_req.tablet_id;
 
-    return res;
-}
-
-OLAPStatus SchemaChangeHandler::_do_alter_tablet(
-        AlterTabletType type,
-        TabletSharedPtr ref_tablet,
-        const TAlterTabletReq& request) {
-    OLAPStatus res = OLAP_SUCCESS;
-    TabletSharedPtr new_tablet;
-    string base_root_path = ref_tablet->data_dir()->path();
-
-    LOG(INFO) << "begin to do alter tablet job. new_tablet_id=" << request.new_tablet_req.tablet_id;
-    // 1. Create new tablet and register into StorageEngine
-    res = _create_new_tablet(ref_tablet,
-                                 request.new_tablet_req,
-                                 &base_root_path,
-                                 &new_tablet);
+    // 5. Create new tablet and register into StorageEngine
+    res = _create_new_tablet(base_tablet, request.new_tablet_req, &new_tablet);
     if (res != OLAP_SUCCESS) {
-        OLAP_LOG_WARNING("fail to create new tablet. [tablet=%ld]",
-                         request.new_tablet_req.tablet_id);
+        LOG(WARNING) << "fail to create new tablet. tablet=" << request.new_tablet_req.tablet_id;
         return res;
     }
 
-    // set schema change status temporarily,
-    // after waiting transactions to finish, will calculate versions again
-    vector<Version> tmp_versions_to_be_changed;
-    tmp_versions_to_be_changed.push_back(Version(-1, -1));
-    ref_tablet->obtain_push_lock();
-    ref_tablet->obtain_header_wrlock();
-    new_tablet->obtain_header_wrlock();
-    res = _save_schema_change_info(type, ref_tablet, new_tablet, tmp_versions_to_be_changed);
-    new_tablet->release_header_lock();
-    ref_tablet->release_header_lock();
-    if (res != OLAP_SUCCESS) {
-        OLAP_LOG_WARNING("fail to save schema change info before waiting transactions. "
-                         "[base=%s new=%s res=%d]", ref_tablet->full_name().c_str(),
-                         new_tablet->full_name().c_str(), res);
-        ref_tablet->release_push_lock();
-        TabletManager::instance()->drop_tablet(
-                new_tablet->tablet_id(), new_tablet->schema_hash());
-        return res;
-    }
-
+    base_tablet->obtain_push_lock();
     // get current transactions
     int64_t partition_id;
     std::set<int64_t> transaction_ids;
-    TxnManager::instance()->get_tablet_related_txns(ref_tablet, &partition_id, &transaction_ids);
-    ref_tablet->release_push_lock();
+    TxnManager::instance()->get_tablet_related_txns(base_tablet, &partition_id, &transaction_ids);
+    base_tablet->release_push_lock();
 
     // wait transactions to publish version
     int num = 0;
     while (!transaction_ids.empty()) {
-        VLOG(3) << "wait transactions when schema change. tablet=" << ref_tablet->full_name()
+        VLOG(3) << "wait transactions when schema change. tablet=" << base_tablet->full_name()
                 << ", transaction_size=" << transaction_ids.size();
         num++;
         if (num % 100 == 0) {
@@ -1279,56 +1244,48 @@ OLAPStatus SchemaChangeHandler::_do_alter_tablet(
         for (int64_t transaction_id : transaction_ids) {
             if (!TxnManager::instance()->has_txn(
                 partition_id, transaction_id,
-                ref_tablet->tablet_id(), ref_tablet->schema_hash())) {
+                base_tablet->tablet_id(), base_tablet->schema_hash())) {
                 finished_transactions.push_back(transaction_id);
             }
         }
         for (int64_t transaction_id : finished_transactions) {
             transaction_ids.erase(transaction_id);
             VLOG(3) << "transaction finished when schema change is waiting. "
-                    << "tablet=" << ref_tablet->full_name()
+                    << "tablet=" << base_tablet->full_name()
                     << ", transaction_id=" << transaction_id
                     << ", transaction_size=" << transaction_ids.size();
         }
     }
 
     // 2. Get version_to_be_changed and store into tablet header
-    ref_tablet->obtain_push_lock();
-    ref_tablet->obtain_header_wrlock();
+    base_tablet->obtain_push_lock();
+    base_tablet->obtain_header_wrlock();
     new_tablet->obtain_header_wrlock();
-
-    // before calculating version_to_be_changed,
-    // remove all data from new tablet, prevent to rewrite data(those double pushed when wait)
-    VLOG(3) << "begin to remove all data from new tablet to prevent rewrite. "
-            << "new_tablet=" << new_tablet->full_name();
 
     vector<Version> versions_to_be_changed;
     vector<RowsetReaderSharedPtr> rs_readers;
     // delete handlers for new tablet
     DeleteHandler delete_handler;
     do {
-        // inherit cumulative_layer_point from ref_tablet
-        new_tablet->set_cumulative_layer_point(ref_tablet->cumulative_layer_point());
+        // inherit cumulative_layer_point from base_tablet
+        new_tablet->set_cumulative_layer_point(base_tablet->cumulative_layer_point());
 
         // get history versions to be changed
-        res = _get_versions_to_be_changed(ref_tablet, versions_to_be_changed);
+        res = _get_versions_to_be_changed(base_tablet, versions_to_be_changed);
         if (res != OLAP_SUCCESS) {
-            OLAP_LOG_WARNING("fail to get version to be changed. [res=%d]", res);
+            LOG(WARNING) << "fail to get version to be changed. res=" << res;
             break;
         }
 
         // store schema change information into tablet header
-        res = _save_schema_change_info(type,
-                                       ref_tablet,
-                                       new_tablet,
-                                       versions_to_be_changed);
+        res = _add_alter_tablet_task(type, base_tablet, new_tablet, versions_to_be_changed);
         if (res != OLAP_SUCCESS) {
-            OLAP_LOG_WARNING("fail to save schema change info. [res=%d]", res);
+            LOG(WARNING) << "fail to save schema change info. res=" << res;
             break;
         }
 
         // acquire data sources correspond to history versions
-        ref_tablet->capture_rs_readers(versions_to_be_changed, &rs_readers);
+        base_tablet->capture_rs_readers(versions_to_be_changed, &rs_readers);
         if (rs_readers.size() < 1) {
             LOG(WARNING) << "fail to acquire all data sources. "
                          << "version_num=" << versions_to_be_changed.size()
@@ -1347,8 +1304,8 @@ OLAPStatus SchemaChangeHandler::_do_alter_tablet(
 
         res = delete_handler.init(new_tablet->tablet_schema(), new_tablet->delete_predicates(), end_version);
         if (res != OLAP_SUCCESS) {
-            OLAP_LOG_WARNING("init delete handler failed. [tablet=%s; end_version=%d]",
-                             ref_tablet->full_name().c_str(), end_version);
+            LOG(WARNING) << "init delete handler failed. base_tablet=" << base_tablet->full_name()
+                         << ", end_version=" << end_version;
 
             // release delete handlers which have been inited successfully.
             delete_handler.finalize();
@@ -1357,56 +1314,47 @@ OLAPStatus SchemaChangeHandler::_do_alter_tablet(
     } while (0);
 
     new_tablet->release_header_lock();
-    ref_tablet->release_header_lock();
-    ref_tablet->release_push_lock();
+    base_tablet->release_header_lock();
+    base_tablet->release_push_lock();
 
-    if (res == OLAP_SUCCESS) {
-        // 3. Generate alter job
-        SchemaChangeParams sc_params;
-        sc_params.alter_tablet_type = type;
-        sc_params.ref_tablet = ref_tablet;
-        sc_params.new_tablet = new_tablet;
-        sc_params.ref_rowset_readers = rs_readers;
-        sc_params.delete_handler = delete_handler;
+    if (res != OLAP_SUCCESS) {
+        TabletManager::instance()->release_schema_change_lock(request.base_tablet_id);
 
-
-        // 4. Update schema change status of ref_tablet and new_tablets
-        new_tablet->set_alter_state(AlterTabletState::ALTER_ALTERING);
-        ref_tablet->set_alter_state(AlterTabletState::ALTER_ALTERING);
-
-        // add tid to cgroup
-        CgroupsMgr::apply_system_cgroup();
-
-        // process the job : special for query tablet split key
-        VLOG(10) << "starts to alter tablet. "
-                 << "old_tablet=" << sc_params.ref_tablet->full_name()
-                 << ", new_tablet=" << sc_params.new_tablet->full_name();
-
-        if ((res = _alter_tablet(&sc_params)) != OLAP_SUCCESS) {
-            OLAP_LOG_WARNING("failed to alter tablet. [request='%s']",
-                             sc_params.debug_message.c_str());
-        }
-
-        VLOG(10) << "schema change thread completed the job. "
-                 << "request=" << sc_params.debug_message;
-    } else {
         // Delete tablet when submit alter tablet failed.
-        TabletManager::instance()->drop_tablet(
-                new_tablet->tablet_id(), new_tablet->schema_hash());
+        TabletManager::instance()->drop_tablet(new_tablet->tablet_id(), new_tablet->schema_hash());
+        return _save_alter_tablet_state(AlterTabletState::ALTER_FAILED, base_tablet, new_tablet);
     }
 
-    OLAP_LOG_WARNING("finish to generate alter tablet job. [res=%d]", res);
+    // 3. Generate alter job
+    SchemaChangeParams sc_params;
+    sc_params.alter_tablet_type = type;
+    sc_params.base_tablet = base_tablet;
+    sc_params.new_tablet = new_tablet;
+    sc_params.ref_rowset_readers = rs_readers;
+    sc_params.delete_handler = delete_handler;
+
+    res = _convert_historical_rowsets(sc_params);
+    if (res != OLAP_SUCCESS) {
+        LOG(WARNING) << "failed to alter tablet. request=" << sc_params.debug_message;
+        TabletManager::instance()->release_schema_change_lock(request.base_tablet_id);
+        return _save_alter_tablet_state(AlterTabletState::ALTER_FAILED, base_tablet, new_tablet);
+    }
+
+    _save_alter_tablet_state(AlterTabletState::ALTER_FINISHED, base_tablet, new_tablet);
+    TabletManager::instance()->release_schema_change_lock(request.base_tablet_id);
+
+    LOG(INFO) << "schema change thread completed the job. "
+              << "request=" << sc_params.debug_message;
     return res;
 }
 
 OLAPStatus SchemaChangeHandler::_create_new_tablet(
-        const TabletSharedPtr ref_tablet,
+        const TabletSharedPtr base_tablet,
         const TCreateTabletReq& request,
-        const string* ref_root_path,
-        TabletSharedPtr* out_new_tablet) {
+        TabletSharedPtr* new_tablet) {
     OLAPStatus res = OLAP_SUCCESS;
-    Tablet* new_tablet = NULL;
     bool is_tablet_added = false;
+    TabletSharedPtr tablet_to_create;
 
     // 1. Lock to ensure that all _create_new_tablet operation execute in serial
     static Mutex create_tablet_lock;
@@ -1414,11 +1362,10 @@ OLAPStatus SchemaChangeHandler::_create_new_tablet(
 
     do {
         // 2. Create tablet with only header, no deltas
-        TabletSharedPtr new_tablet = StorageEngine::instance()->create_tablet(request, true, ref_tablet);
-        if (new_tablet == NULL) {
-            OLAP_LOG_WARNING("failed to create tablet. [tablet=%ld xml_path=%d]",
-                             request.tablet_id,
-                             request.tablet_schema.schema_hash);
+        TabletSharedPtr tablet_to_create = StorageEngine::instance()->create_tablet(request, true, base_tablet);
+        if (tablet_to_create == nullptr) {
+            LOG(WARNING) << "failed to create tablet. tablet=" << request.tablet_id
+                         << ", schema_hash=" << request.tablet_schema.schema_hash;
             res = OLAP_ERR_INPUT_PARAMETER_ERROR;
             break;
         }
@@ -1430,24 +1377,21 @@ OLAPStatus SchemaChangeHandler::_create_new_tablet(
         //
         // 当出现以上2种情况时，为了能够区分alter得到的新表和旧表，这里把新表的creation_time设置为
         // 旧表的creation_time加1
-        if (new_tablet->creation_time() <= ref_tablet->creation_time()) {
-            OLAP_LOG_WARNING("new tablet's creation time is less than or equal to old tablet"
-                             "[new_tablet_creation_time=%ld; old_tablet_creation_time=%ld]",
-                             new_tablet->creation_time(),
-                             ref_tablet->creation_time());
-            int64_t new_creation_time = ref_tablet->creation_time() + 1;
-            new_tablet->set_creation_time(new_creation_time);
+        if (tablet_to_create->creation_time() <= base_tablet->creation_time()) {
+            LOG(WARNING) << "new tablet's creation time is less than or equal to old tablet"
+                         << "new_tablet_creation_time=" << tablet_to_create->creation_time()
+                         << ", base_tablet_creation_time=" << base_tablet->creation_time();
+            int64_t new_creation_time = base_tablet->creation_time() + 1;
+            tablet_to_create->set_creation_time(new_creation_time);
         }
 
         // 3. Add tablet to StorageEngine will make it visiable to user
-        res = TabletManager::instance()->add_tablet(
-                request.tablet_id,
-                request.tablet_schema.schema_hash,
-                new_tablet, 
-                false);
+        res = TabletManager::instance()->add_tablet(request.tablet_id,
+                                                    request.tablet_schema.schema_hash,
+                                                    tablet_to_create, false);
         if (res != OLAP_SUCCESS) {
-            OLAP_LOG_WARNING("failed to add tablet to StorageEngine. [res=%d tablet='%s']",
-                             res, new_tablet->full_name().c_str());
+            LOG(WARNING) << "failed to add tablet to StorageEngine. res=" << res
+                         << ", tablet=" << tablet_to_create->full_name();
             break;
         }
         is_tablet_added = true;
@@ -1455,28 +1399,15 @@ OLAPStatus SchemaChangeHandler::_create_new_tablet(
         // 4. Register tablet into store, so that we can manage tablet from
         // the perspective of root path.
         // Example: unregister all tables when a bad disk found.
-        res = new_tablet->register_tablet_into_dir();
+        res = tablet_to_create->register_tablet_into_dir();
         if (res != OLAP_SUCCESS) {
             LOG(WARNING) << "fail to register tablet into data dir. "
-                         << "root_path=" << new_tablet->data_dir()->path()
-                         << ", tablet=" << new_tablet->full_name();
+                         << "root_path=" << tablet_to_create->data_dir()->path()
+                         << ", tablet=" << tablet_to_create->full_name();
             break;
         }
 
-        TabletSharedPtr tablet;
-        tablet = TabletManager::instance()->get_tablet(
-                request.tablet_id, request.tablet_schema.schema_hash);
-        if (tablet.get() == NULL) {
-            OLAP_LOG_WARNING("failed to get tablet from StorageEngine. [tablet=%ld schema_hash=%d]",
-                             request.tablet_id,
-                             request.tablet_schema.schema_hash);
-            res = OLAP_ERR_OTHER_ERROR;
-            break;
-        }
-
-        if (out_new_tablet != NULL) {
-            *out_new_tablet = tablet;
-        }
+        *new_tablet = tablet_to_create;
     } while (0);
 
     if (res != OLAP_SUCCESS) {
@@ -1488,8 +1419,8 @@ OLAPStatus SchemaChangeHandler::_create_new_tablet(
                     << ", tablet=" << request.tablet_id
                     << ":" << request.tablet_schema.schema_hash;
             }
-        } else if (NULL != new_tablet) {
-            new_tablet->delete_all_files();
+        } else if (NULL != tablet_to_create) {
+            tablet_to_create->delete_all_files();
         }
     }
 
@@ -1509,7 +1440,7 @@ OLAPStatus SchemaChangeHandler::schema_version_convert(
 
     OLAPStatus res = OLAP_SUCCESS;
     LOG(INFO) << "begin to convert delta version for schema changing. "
-              << "old_tablet=" << src_tablet->full_name()
+              << "base_tablet=" << src_tablet->full_name()
               << ", dest_tablet=" << dest_tablet->full_name();
 
     // a. 解析Alter请求，转换成内部的表示形式
@@ -1632,45 +1563,30 @@ SCHEMA_VERSION_CONVERT_ERR:
 }
 
 OLAPStatus SchemaChangeHandler::_get_versions_to_be_changed(
-        TabletSharedPtr ref_tablet,
+        TabletSharedPtr base_tablet,
         vector<Version>& versions_to_be_changed) {
-    int32_t request_version = 0;
-    RowsetSharedPtr rowset = ref_tablet->rowset_with_max_version();
-    if (rowset != NULL) {
-        request_version = rowset->version().second - 1;
-    } else {
-        LOG(WARNING) << "Table has no version. path=" << ref_tablet->full_name();
+    Version request_version = { -1, 0 };
+    RowsetSharedPtr rowset = base_tablet->rowset_with_max_version();
+    if (rowset == nullptr) {
+        LOG(WARNING) << "Tablet has no version. base_tablet=" << base_tablet->full_name();
         return OLAP_ERR_ALTER_DELTA_DOES_NOT_EXISTS;
+    } else {
+        request_version = rowset->version();
     }
 
-    // 最新版本的delta可以被重导覆盖，因此计算获取的路径中，
-    // 必须包含最新版本的delta
-    if (request_version >= 0) {
-        vector<Version> span_versions;
-        ref_tablet->capture_consistent_versions(Version(0, request_version), &span_versions);
-
-        // get all version list
-        vector<Version> all_versions;
-        ref_tablet->list_versions(&all_versions);
-        if (0 == all_versions.size()) {
-            LOG(WARNING) << "there'is no any version in the tablet. tablet=" << ref_tablet->full_name();
-            return OLAP_ERR_VERSION_NOT_EXIST;
-        }
-
-        for (uint32_t i = 0; i < span_versions.size(); i++) {
-            versions_to_be_changed.push_back(span_versions[i]);
-        }
+    vector<Version> span_versions;
+    base_tablet->capture_consistent_versions(request_version, &span_versions);
+    for (uint32_t i = 0; i < span_versions.size(); i++) {
+        versions_to_be_changed.push_back(span_versions[i]);
     }
-    versions_to_be_changed.push_back(
-            Version(rowset->version().first, rowset->version().second));
 
     return OLAP_SUCCESS;
 }
 
 // 增加A->(B|C|...) 的schema_change信息
-OLAPStatus SchemaChangeHandler::_save_schema_change_info(
+OLAPStatus SchemaChangeHandler::_add_alter_tablet_task(
         AlterTabletType alter_tablet_type,
-        TabletSharedPtr ref_tablet,
+        TabletSharedPtr base_tablet,
         TabletSharedPtr new_tablet,
         const vector<Version>& versions_to_be_changed) {
 
@@ -1678,26 +1594,29 @@ OLAPStatus SchemaChangeHandler::_save_schema_change_info(
     // prevent to set base's status after new's dropping (clear base's status)
     if (TabletManager::instance()->get_tablet(
             new_tablet->tablet_id(), new_tablet->schema_hash()).get() == NULL) {
-        OLAP_LOG_WARNING("fail to find tablet before saving status. [tablet='%s']",
-                         new_tablet->full_name().c_str());
+        LOG(WARNING) << "new_tablet does not exist. tablet=" << new_tablet->full_name();
         return OLAP_ERR_TABLE_NOT_FOUND;
     }
 
-    OLAPStatus res = OLAP_SUCCESS;
-
     // 1. 在新表和旧表中添加schema change标志
-    ref_tablet->delete_alter_task();
-    ref_tablet->add_alter_task(new_tablet->tablet_id(),
-                               new_tablet->schema_hash(),
-                               versions_to_be_changed,
-                               alter_tablet_type);
+    base_tablet->delete_alter_task();
+    base_tablet->add_alter_task(new_tablet->tablet_id(),
+                                new_tablet->schema_hash(),
+                                versions_to_be_changed,
+                                alter_tablet_type);
+    base_tablet->set_alter_state(AlterTabletState::ALTER_ALTERING);
+    OLAPStatus res = base_tablet->save_meta();
+    if (res != OLAP_SUCCESS) {
+        LOG(FATAL) << "fail to save ref tablet header. res=" << res
+                   << ", tablet=" << base_tablet->full_name();
+        return res;
+    }
 
-    new_tablet->add_alter_task(ref_tablet->tablet_id(),
-                               ref_tablet->schema_hash(),
+    new_tablet->add_alter_task(base_tablet->tablet_id(),
+                               base_tablet->schema_hash(),
                                vector<Version>(),  // empty versions
                                alter_tablet_type);
-
-    // save new tablet header :只有一个父ref tablet
+    new_tablet->set_alter_state(AlterTabletState::ALTER_ALTERING);
     res = new_tablet->save_meta();
     if (res != OLAP_SUCCESS) {
         LOG(FATAL) << "fail to save new tablet header. res=" << res
@@ -1705,93 +1624,95 @@ OLAPStatus SchemaChangeHandler::_save_schema_change_info(
         return res;
     }
 
-    res = ref_tablet->save_meta();
+    return res;
+}
+
+OLAPStatus SchemaChangeHandler::_save_alter_tablet_state(
+        AlterTabletState state,
+        TabletSharedPtr base_tablet,
+        TabletSharedPtr new_tablet) {
+    base_tablet->set_alter_state(state);
+    OLAPStatus res = base_tablet->save_meta();
     if (res != OLAP_SUCCESS) {
         LOG(FATAL) << "fail to save ref tablet header. res=" << res
-                   << ", tablet=" << ref_tablet->full_name().c_str();
+                   << ", tablet=" << base_tablet->full_name();
+        return res;
+    }
+
+    new_tablet->set_alter_state(state);
+    res = new_tablet->save_meta();
+    if (res != OLAP_SUCCESS) {
+        LOG(FATAL) << "fail to save ref tablet header. res=" << res
+                   << ", tablet=" << base_tablet->full_name();
         return res;
     }
 
     return res;
 }
-
 // @static
-OLAPStatus SchemaChangeHandler::_alter_tablet(SchemaChangeParams* sc_params) {
-    OLAPStatus res = OLAP_SUCCESS;
-    LOG(INFO) << "begin to process alter tablet job. "
-              << "old_tablet=" << sc_params->ref_tablet->full_name()
-              << ", new_tablet=" << sc_params->new_tablet->full_name();
+OLAPStatus SchemaChangeHandler::_convert_historical_rowsets(const SchemaChangeParams& sc_params) {
+    LOG(INFO) << "begin to convert rowsets for new_tablet from base_tablet. "
+              << "base_tablet=" << sc_params.base_tablet->full_name()
+              << ", new_tablet=" << sc_params.new_tablet->full_name();
 
     // find end version
     int32_t end_version = -1;
-    for (size_t i = 0; i < sc_params->ref_rowset_readers.size(); ++i) {
-        if (sc_params->ref_rowset_readers[i]->version().second > end_version) {
-            end_version = sc_params->ref_rowset_readers[i]->version().second;
+    for (size_t i = 0; i < sc_params.ref_rowset_readers.size(); ++i) {
+        if (sc_params.ref_rowset_readers[i]->version().second > end_version) {
+            end_version = sc_params.ref_rowset_readers[i]->version().second;
         }
     }
 
     // change中增加了filter信息，在_parse_request中会设置filter的column信息
     // 并在每次row block的change时，过滤一些数据
-    RowBlockChanger rb_changer(sc_params->new_tablet->tablet_schema(),
-                               sc_params->ref_tablet,
-                               sc_params->delete_handler);
+    RowBlockChanger rb_changer(sc_params.new_tablet->tablet_schema(),
+                               sc_params.base_tablet, sc_params.delete_handler);
 
     bool sc_sorting = false;
     bool sc_directly = false;
     SchemaChange* sc_procedure = NULL;
 
     // a. 解析Alter请求，转换成内部的表示形式
-    res = _parse_request(sc_params->ref_tablet,
-                         sc_params->new_tablet,
-                         &rb_changer,
-                         &sc_sorting,
-                         &sc_directly);
+    OLAPStatus res = _parse_request(sc_params.base_tablet, sc_params.new_tablet,
+                                    &rb_changer, &sc_sorting, &sc_directly);
     if (res != OLAP_SUCCESS) {
         OLAP_LOG_WARNING("failed to parse the request. [res=%d]", res);
         goto PROCESS_ALTER_EXIT;
     }
 
     // b. 生成历史数据转换器
-    if (true == sc_sorting) {
+    if (sc_sorting) {
         size_t memory_limitation = config::memory_limitation_per_thread_for_schema_change;
         LOG(INFO) << "doing schema change with sorting.";
-        sc_procedure = new(nothrow) SchemaChangeWithSorting(
-                               sc_params->new_tablet,
-                               rb_changer,
-                               memory_limitation * 1024 * 1024 * 1024);
-    } else if (true == sc_directly) {
+        sc_procedure = new(nothrow) SchemaChangeWithSorting(sc_params.new_tablet, rb_changer,
+                                                            memory_limitation * 1024 * 1024 * 1024);
+    } else if (sc_directly) {
         LOG(INFO) << "doing schema change directly.";
-        sc_procedure = new(nothrow) SchemaChangeDirectly(
-                sc_params->new_tablet, rb_changer);
+        sc_procedure = new(nothrow) SchemaChangeDirectly(sc_params.new_tablet, rb_changer);
     } else {
         LOG(INFO) << "doing linked schema change.";
-        sc_procedure = new(nothrow) LinkedSchemaChange(
-                                sc_params->ref_tablet,
-                                sc_params->new_tablet);
+        sc_procedure = new(nothrow) LinkedSchemaChange(sc_params.base_tablet, sc_params.new_tablet);
     }
 
-    if (NULL == sc_procedure) {
-        OLAP_LOG_WARNING("failed to malloc SchemaChange. [size=%ld]",
-                         sizeof(SchemaChangeWithSorting));
+    if (sc_procedure == nullptr) {
+        LOG(WARNING) << "failed to malloc SchemaChange. "
+                     << "malloc_size=" << sizeof(SchemaChangeWithSorting);
         res = OLAP_ERR_MALLOC_ERROR;
         goto PROCESS_ALTER_EXIT;
     }
 
     // c. 转换历史数据
-    for (vector<RowsetReaderSharedPtr>::iterator it = sc_params->ref_rowset_readers.end() - 1;
-            it >= sc_params->ref_rowset_readers.begin(); --it) {
-        VLOG(10) << "begin to convert a history delta. "
-                 << "version=" << (*it)->version().first << "-" << (*it)->version().second;
+    for (auto& rs_reader : sc_params.ref_rowset_readers) {
+        VLOG(10) << "begin to convert a history rowset. version="
+                 << rs_reader->version().first << "-" << rs_reader->version().second;
 
         // set status for monitor
         // 只要有一个new_table为running，ref table就设置为running
         // NOTE 如果第一个sub_table先fail，这里会继续按正常走
-        sc_params->ref_tablet->set_alter_state(AlterTabletState::ALTER_ALTERING);
-        sc_params->new_tablet->set_alter_state(AlterTabletState::ALTER_ALTERING);
 
         RowsetId rowset_id = 0;
-        TabletSharedPtr new_tablet = sc_params->new_tablet;
-        res = RowsetIdGenerator::instance()->get_next_id(sc_params->new_tablet->data_dir(), &rowset_id);
+        TabletSharedPtr new_tablet = sc_params.new_tablet;
+        res = RowsetIdGenerator::instance()->get_next_id(sc_params.new_tablet->data_dir(), &rowset_id);
         if (res != OLAP_SUCCESS) {
             LOG(WARNING) << "generate next id failed";
             goto PROCESS_ALTER_EXIT;
@@ -1806,8 +1727,8 @@ OLAPStatus SchemaChangeHandler::_alter_tablet(SchemaChangeParams* sc_params) {
                        .set_rowset_path_prefix(new_tablet->tablet_path())
                        .set_tablet_schema(&(new_tablet->tablet_schema()))
                        .set_rowset_state(VISIBLE)
-                       .set_version((*it)->version())
-                       .set_version_hash((*it)->version_hash());
+                       .set_version(rs_reader->version())
+                       .set_version_hash(rs_reader->version_hash());
         RowsetWriterContext builder_context = context_builder.build();
 
         RowsetWriterSharedPtr rowset_writer(new AlphaRowsetWriter());
@@ -1817,10 +1738,10 @@ OLAPStatus SchemaChangeHandler::_alter_tablet(SchemaChangeParams* sc_params) {
             goto PROCESS_ALTER_EXIT;
         }
 
-        if (!sc_procedure->process(*it, rowset_writer, sc_params->new_tablet)) {
+        if (!sc_procedure->process(rs_reader, rowset_writer, sc_params.new_tablet)) {
             LOG(WARNING) << "failed to process the version. "
-                         << " version=" << (*it)->version().first
-                         << "-" << (*it)->version().second;
+                         << " version=" << rs_reader->version().first
+                         << "-" << rs_reader->version().second;
             rowset_writer->release();
 
             res = OLAP_ERR_INPUT_PARAMETER_ERROR;
@@ -1829,57 +1750,59 @@ OLAPStatus SchemaChangeHandler::_alter_tablet(SchemaChangeParams* sc_params) {
 
         // 将新版本的数据加入header
         // 为了防止死锁的出现，一定要先锁住旧表，再锁住新表
-        sc_params->new_tablet->obtain_push_lock();
-        sc_params->ref_tablet->obtain_header_wrlock();
-        sc_params->new_tablet->obtain_header_wrlock();
+        sc_params.new_tablet->obtain_push_lock();
+        sc_params.base_tablet->obtain_header_wrlock();
+        sc_params.new_tablet->obtain_header_wrlock();
 
-        if (!sc_params->new_tablet->check_version_exist((*it)->version())) {
+        if (!sc_params.new_tablet->check_version_exist(rs_reader->version())) {
             // register version
             RowsetSharedPtr new_rowset = rowset_writer->build();
-            res = sc_params->new_tablet->add_rowset(new_rowset);
+            res = sc_params.new_tablet->add_rowset(new_rowset);
             if (OLAP_SUCCESS != res) {
                 LOG(WARNING) << "failed to register new version. "
-                             << " tablet='%s'" << sc_params->new_tablet->full_name()
-                             << " version='" << (*it)->version().first
-                             << "-" << (*it)->version().second << "'";
+                             << " tablet=" << sc_params.new_tablet->full_name()
+                             << ", version=" << rs_reader->version().first
+                             << "-" << rs_reader->version().second;
                 new_rowset->remove();
 
-                sc_params->new_tablet->release_header_lock();
-                sc_params->ref_tablet->release_header_lock();
+                sc_params.new_tablet->release_header_lock();
+                sc_params.base_tablet->release_header_lock();
 
                 goto PROCESS_ALTER_EXIT;
             }
 
-            VLOG(3) << "register new version. tablet=" << sc_params->new_tablet->full_name()
-                    << ", version=" << (*it)->version().first << "-" << (*it)->version().second;
+            VLOG(3) << "register new version. tablet=" << sc_params.new_tablet->full_name()
+                    << ", version=" << rs_reader->version().first
+                    << "-" << rs_reader->version().second;
         } else {
             LOG(WARNING) << "version already exist, version revert occured. "
-                         << "[tablet=" << sc_params->new_tablet->full_name()
-                         << " version='" << (*it)->version().first
-                         << "-" << (*it)->version().second << "']";
+                         << "tablet=" << sc_params.new_tablet->full_name()
+                         << ", version='" << rs_reader->version().first
+                         << "-" << rs_reader->version().second;
             rowset_writer->release();
         }
 
         // 保存header
-        if (OLAP_SUCCESS != sc_params->new_tablet->save_meta()) {
+        if (OLAP_SUCCESS != sc_params.new_tablet->save_meta()) {
             LOG(FATAL) << "fail to save header. res=" << res
-                       << ", tablet=" << sc_params->new_tablet->full_name();
+                       << ", tablet=" << sc_params.new_tablet->full_name();
         }
 
         // 保存header
-        if (OLAP_SUCCESS != sc_params->ref_tablet->save_meta()) {
-            LOG(FATAL) << "failed to save header. tablet=" << sc_params->new_tablet->full_name();
+        if (OLAP_SUCCESS != sc_params.base_tablet->save_meta()) {
+            LOG(FATAL) << "failed to save header. tablet=" << sc_params.new_tablet->full_name();
         }
 
-        sc_params->new_tablet->release_header_lock();
-        sc_params->ref_tablet->release_header_lock();
-        sc_params->new_tablet->release_push_lock();
+        sc_params.new_tablet->release_header_lock();
+        sc_params.base_tablet->release_header_lock();
+        sc_params.new_tablet->release_push_lock();
 
         VLOG(10) << "succeed to convert a history version."
-            << ", version=" << (*it)->version().first << "-" << (*it)->version().second;
+                 << ", version=" << rs_reader->version().first
+                 << "-" << rs_reader->version().second;
 
         // 释放RowsetReader
-        (*it)->close();
+        rs_reader->close();
     }
 
     // XXX: 此时应该不取消SchemaChange状态，因为新Delta还要转换成新旧Schema的版本
@@ -1887,33 +1810,23 @@ OLAPStatus SchemaChangeHandler::_alter_tablet(SchemaChangeParams* sc_params) {
 PROCESS_ALTER_EXIT:
     if (res == OLAP_SUCCESS) {
         Version test_version(0, end_version);
-        res = sc_params->new_tablet->check_version_integrity(test_version);
+        res = sc_params.new_tablet->check_version_integrity(test_version);
     }
 
-    if (res == OLAP_SUCCESS) {
-        sc_params->ref_tablet->set_alter_state(AlterTabletState::ALTER_FINISHED);
-        sc_params->new_tablet->set_alter_state(AlterTabletState::ALTER_FINISHED);
-        VLOG(3) << "set alter tablet job status. "
-                << "state=" << sc_params->ref_tablet->alter_state();
-    } else {
-        sc_params->ref_tablet->set_alter_state(AlterTabletState::ALTER_FAILED);
-        sc_params->new_tablet->set_alter_state(AlterTabletState::ALTER_FAILED);
-        VLOG(3) << "set alter tablet job status. "
-                << "state=" << sc_params->ref_tablet->alter_state();
-    }
-
-    for (auto& rs_reader : sc_params->ref_rowset_readers) {
+    for (auto& rs_reader : sc_params.ref_rowset_readers) {
         rs_reader->close();
     }
     SAFE_DELETE(sc_procedure);
 
-    LOG(INFO) << "finish to process alter tablet job. res=" << res;
+    LOG(INFO) << "finish converting rowsets for new_tablet from base_tablet. "
+              << "base_tablet=" << sc_params.base_tablet->full_name()
+              << ", new_tablet=" << sc_params.new_tablet->full_name();
     return res;
 }
 
 // @static
 // 分析column的mapping以及filter key的mapping
-OLAPStatus SchemaChangeHandler::_parse_request(TabletSharedPtr ref_tablet,
+OLAPStatus SchemaChangeHandler::_parse_request(TabletSharedPtr base_tablet,
                                                TabletSharedPtr new_tablet,
                                                RowBlockChanger* rb_changer,
                                                bool* sc_sorting,
@@ -1928,7 +1841,7 @@ OLAPStatus SchemaChangeHandler::_parse_request(TabletSharedPtr ref_tablet,
         ColumnMapping* column_mapping = rb_changer->get_mutable_column_mapping(i);
 
         if (new_column.has_reference_column()) {
-            int32_t column_index = ref_tablet->field_index(new_column.referenced_column());
+            int32_t column_index = base_tablet->field_index(new_column.referenced_column());
 
             if (column_index < 0) {
                 LOG(WARNING) << "referenced column was missing. "
@@ -1943,7 +1856,7 @@ OLAPStatus SchemaChangeHandler::_parse_request(TabletSharedPtr ref_tablet,
             continue;
         }
 
-        int32_t column_index = ref_tablet->field_index(column_name);
+        int32_t column_index = base_tablet->field_index(column_name);
         if (column_index >= 0) {
             column_mapping->ref_column = column_index;
             continue;
@@ -1954,7 +1867,7 @@ OLAPStatus SchemaChangeHandler::_parse_request(TabletSharedPtr ref_tablet,
         {
             column_mapping->ref_column = -1;
 
-            if (i < ref_tablet->num_short_key_columns()) {
+            if (i < base_tablet->num_short_key_columns()) {
                 *sc_directly = true;
             }
 
@@ -2007,13 +1920,13 @@ OLAPStatus SchemaChangeHandler::_parse_request(TabletSharedPtr ref_tablet,
         }
     }
 
-    if (ref_tablet->num_short_key_columns() != new_tablet->num_short_key_columns()) {
+    if (base_tablet->num_short_key_columns() != new_tablet->num_short_key_columns()) {
         // the number of short_keys changed, can't do linked schema change
         *sc_directly = true;
         return OLAP_SUCCESS;
     }
 
-    const TabletSchema& ref_tablet_schema = ref_tablet->tablet_schema();
+    const TabletSchema& ref_tablet_schema = base_tablet->tablet_schema();
     const TabletSchema& new_tablet_schema = new_tablet->tablet_schema();
     for (size_t i = 0; i < new_tablet->num_columns(); ++i) {
         ColumnMapping* column_mapping = rb_changer->get_mutable_column_mapping(i);
@@ -2037,7 +1950,7 @@ OLAPStatus SchemaChangeHandler::_parse_request(TabletSharedPtr ref_tablet,
         }
     }
 
-    if (ref_tablet->delete_predicates().size() != 0){
+    if (base_tablet->delete_predicates().size() != 0){
         //there exists delete condtion in header, can't do linked schema change
         *sc_directly = true;
     }

--- a/be/src/olap/schema_change.h
+++ b/be/src/olap/schema_change.h
@@ -55,11 +55,11 @@ public:
     typedef std::vector<ColumnMapping> SchemaMapping;
 
     RowBlockChanger(const TabletSchema& tablet_schema,
-                    const TabletSharedPtr& ref_tablet,
+                    const TabletSharedPtr& base_tablet,
                     const DeleteHandler& delete_handler);
 
     RowBlockChanger(const TabletSchema& tablet_schema,
-                    const TabletSharedPtr& ref_tablet);
+                    const TabletSharedPtr& base_tablet);
     
     virtual ~RowBlockChanger();
 
@@ -268,7 +268,7 @@ public:
     OLAPStatus process_alter_tablet(AlterTabletType alter_tablet_type,
                                    const TAlterTabletReq& request);
 
-    OLAPStatus schema_version_convert(TabletSharedPtr ref_tablet,
+    OLAPStatus schema_version_convert(TabletSharedPtr base_tablet,
                                       TabletSharedPtr new_tablet,
                                       std::vector<RowsetSharedPtr>* old_rowsets,
                                       std::vector<RowsetSharedPtr>* new_rowsets);
@@ -283,17 +283,13 @@ private:
     OLAPStatus _check_and_clear_schema_change_info(TabletSharedPtr tablet,
                                                    const TAlterTabletReq& request);
 
-    OLAPStatus _get_versions_to_be_changed(TabletSharedPtr ref_tablet,
+    OLAPStatus _get_versions_to_be_changed(TabletSharedPtr base_tablet,
                                            std::vector<Version>& versions_to_be_changed);
-
-    OLAPStatus _do_alter_tablet(AlterTabletType type,
-                               TabletSharedPtr ref_tablet,
-                               const TAlterTabletReq& request);
 
     struct SchemaChangeParams {
         // 为了让calc_split_key也可使用普通schema_change的线程，才设置了此type
         AlterTabletType alter_tablet_type;
-        TabletSharedPtr ref_tablet;
+        TabletSharedPtr base_tablet;
         TabletSharedPtr new_tablet;
         std::vector<RowsetReaderSharedPtr> ref_rowset_readers;
         std::string debug_message;
@@ -304,25 +300,27 @@ private:
     };
 
     // 根据给定的table_desc，创建Tablet，并挂接到StorageEngine中
-    OLAPStatus _create_new_tablet(const TabletSharedPtr ref_tablet,
-                                      const TCreateTabletReq& create_tablet_req,
-                                      const std::string* ref_root_path,
-                                      TabletSharedPtr* out_new_tablet);
+    OLAPStatus _create_new_tablet(const TabletSharedPtr base_tablet,
+                                  const TCreateTabletReq& create_tablet_req,
+                                  TabletSharedPtr* new_tablet);
 
     // 增加A->(B|C|...) 的schema_change信息
     //  在split table时，增加split-tablet status相关的信息
     //  其他的都增加在schema-change status中
-    OLAPStatus _save_schema_change_info(AlterTabletType alter_tablet_type,
-                                        TabletSharedPtr ref_tablet,
-                                        TabletSharedPtr new_tablet,
-                                        const std::vector<Version>& versions_to_be_changed);
+    OLAPStatus _add_alter_tablet_task(AlterTabletType alter_tablet_type,
+                                      TabletSharedPtr base_tablet,
+                                      TabletSharedPtr new_tablet,
+                                      const std::vector<Version>& versions_to_be_changed);
+    OLAPStatus _save_alter_tablet_state(AlterTabletState state,
+                                        TabletSharedPtr base_tablet,
+                                        TabletSharedPtr new_tablet);
 
-    static OLAPStatus _alter_tablet(SchemaChangeParams* sc_params);
+    static OLAPStatus _convert_historical_rowsets(const SchemaChangeParams& sc_params);
 
-    static OLAPStatus _parse_request(TabletSharedPtr ref_tablet,
+    static OLAPStatus _parse_request(TabletSharedPtr base_tablet,
                                      TabletSharedPtr new_tablet,
                                      RowBlockChanger* rb_changer,
-                                     bool* sc_sorting, 
+                                     bool* sc_sorting,
                                      bool* sc_directly);
 
     // 需要新建default_value时的初始化设置

--- a/be/src/olap/storage_engine.cpp
+++ b/be/src/olap/storage_engine.cpp
@@ -612,7 +612,7 @@ void StorageEngine::clear_transaction_task(const TTransactionId transaction_id,
 TabletSharedPtr StorageEngine::create_tablet(const TCreateTabletReq& request,
                                              const bool is_schema_change_tablet,
                                              const TabletSharedPtr ref_tablet) {
-    // Get all available stores, use data_dir of ref_tablet when doing schema change 
+    // Get all available stores, use data_dir of ref_tablet when doing schema change
     std::vector<DataDir*> stores;
     if (!is_schema_change_tablet) {
         stores = get_stores_for_create_tablet(request.storage_medium);

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -504,8 +504,8 @@ OLAPStatus Tablet::protected_delete_alter_task() {
 
     res = save_meta();
     if (res != OLAP_SUCCESS) {
-        LOG(WARNING) << "fail to save tablet header. [res=" << res 
-                     << " , full_name=" << full_name().c_str() << "]";
+        LOG(WARNING) << "fail to save tablet header. res=" << res
+                     << ", full_name=" << full_name();
         return res;
     }
     return res;

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -325,7 +325,7 @@ bool Tablet::has_expired_inc_rowset() {
 void Tablet::delete_inc_rowset_by_version(const Version& version,
                                           const VersionHash& version_hash,
                                           vector<string>* files_to_remove) {
-    RowsetMetaSharedPtr rowset = _tablet_meta->acquire_inc_rs_meta(version);
+    RowsetMetaSharedPtr rowset = _tablet_meta->acquire_inc_rs_meta_by_version(version);
     if (rowset == nullptr) { return; }
 
     _tablet_meta->delete_inc_rs_meta_by_version(version);
@@ -481,7 +481,8 @@ void Tablet::add_alter_task(int64_t tablet_id,
     alter_task.set_related_tablet_id(tablet_id);
     alter_task.set_related_schema_hash(schema_hash);
     for (auto& version : versions_to_alter) {
-        RowsetMetaSharedPtr rs_meta = _tablet_meta->acquire_inc_rs_meta(version);
+        RowsetMetaSharedPtr rs_meta = _tablet_meta->acquire_rs_meta_by_version(version);
+        alter_task.add_rowset_to_alter(rs_meta);
     }
 
     alter_task.set_alter_type(alter_type);

--- a/be/src/olap/tablet_meta.cpp
+++ b/be/src/olap/tablet_meta.cpp
@@ -437,6 +437,18 @@ OLAPStatus TabletMeta::add_inc_rs_meta(const RowsetMetaSharedPtr& rs_meta) {
     return OLAP_SUCCESS;
 }
 
+RowsetMetaSharedPtr TabletMeta::acquire_rs_meta_by_version(const Version& version) const {
+    RowsetMetaSharedPtr rs_meta = nullptr;
+    for (int i = 0; i < _rs_metas.size(); ++i) {
+        if (_rs_metas[i]->version().first == version.first
+              && _rs_metas[i]->version().second == version.second) {
+            rs_meta = _rs_metas[i];
+            break;
+        }
+    }
+    return rs_meta;
+}
+
 OLAPStatus TabletMeta::delete_inc_rs_meta_by_version(const Version& version) {
     auto it = _inc_rs_metas.begin();
     bool modified = false;
@@ -459,7 +471,7 @@ OLAPStatus TabletMeta::delete_inc_rs_meta_by_version(const Version& version) {
     return OLAP_SUCCESS;
 }
 
-RowsetMetaSharedPtr TabletMeta::acquire_inc_rs_meta(const Version& version) const {
+RowsetMetaSharedPtr TabletMeta::acquire_inc_rs_meta_by_version(const Version& version) const {
     RowsetMetaSharedPtr rs_meta = nullptr;
     for (int i = 0; i < _inc_rs_metas.size(); ++i) {
         if (_inc_rs_metas[i]->version().first == version.first

--- a/be/src/olap/tablet_meta.h
+++ b/be/src/olap/tablet_meta.h
@@ -86,6 +86,9 @@ public:
     void set_alter_type(AlterTabletType alter_type) { _alter_type = alter_type; }
 
     const vector<RowsetMetaSharedPtr>& rowsets_to_alter() const { return _rowsets_to_alter; }
+    void add_rowset_to_alter(const RowsetMetaSharedPtr& rs_meta) {
+        return _rowsets_to_alter.push_back(rs_meta);
+    }
 
 private:
     AlterTabletState _alter_state;
@@ -152,6 +155,7 @@ public:
 
     inline const vector<RowsetMetaSharedPtr>& all_rs_metas() const;
     OLAPStatus add_rs_meta(const RowsetMetaSharedPtr& rs_meta);
+    RowsetMetaSharedPtr acquire_rs_meta_by_version(const Version& version) const;
     OLAPStatus delete_rs_meta_by_version(const Version& version);
     OLAPStatus modify_rs_metas(const vector<RowsetMetaSharedPtr>& to_add,
                                const vector<RowsetMetaSharedPtr>& to_delete);
@@ -160,7 +164,7 @@ public:
     inline const vector<RowsetMetaSharedPtr>& all_inc_rs_metas() const;
     OLAPStatus add_inc_rs_meta(const RowsetMetaSharedPtr& rs_meta);
     OLAPStatus delete_inc_rs_meta_by_version(const Version& version);
-    RowsetMetaSharedPtr acquire_inc_rs_meta(const Version& version) const;
+    RowsetMetaSharedPtr acquire_inc_rs_meta_by_version(const Version& version) const;
 
     OLAPStatus add_delete_predicate(const DeletePredicatePB& delete_predicate, int64_t version);
     OLAPStatus remove_delete_predicate_by_version(const Version& version);

--- a/be/src/olap/task/engine_clone_task.cpp
+++ b/be/src/olap/task/engine_clone_task.cpp
@@ -670,7 +670,7 @@ OLAPStatus EngineCloneTask::_clone_incremental_data(TabletSharedPtr tablet, cons
 
     // check missing versions exist in clone src
     for (Version version : missed_versions) {
-        RowsetMetaSharedPtr inc_rs_meta = cloned_tablet_meta.acquire_inc_rs_meta(version);
+        RowsetMetaSharedPtr inc_rs_meta = cloned_tablet_meta.acquire_inc_rs_meta_by_version(version);
         if (inc_rs_meta == nullptr) {
             LOG(WARNING) << "missed version is not found in cloned tablet meta."
                          << ", missed_version=" << version.first << "-" << version.second;

--- a/be/src/olap/task/engine_schema_change_task.cpp
+++ b/be/src/olap/task/engine_schema_change_task.cpp
@@ -53,7 +53,7 @@ OLAPStatus EngineSchemaChangeTask::execute() {
         // schema change job is in finishing state in fe, be restarts, then the tablet is in ALTER_TABLE_FAILED state
         // if drop the old tablet, then data is lost
         status = TabletManager::instance()->drop_tablet(_alter_tablet_req.new_tablet_req.tablet_id, 
-                                                            _alter_tablet_req.new_tablet_req.tablet_schema.schema_hash);
+                                                        _alter_tablet_req.new_tablet_req.tablet_schema.schema_hash);
 
         if (status != OLAP_SUCCESS) {
             OLAP_LOG_WARNING("delete failed rollup file failed, status: %d, "
@@ -92,7 +92,7 @@ OLAPStatus EngineSchemaChangeTask::execute() {
 
 OLAPStatus EngineSchemaChangeTask::_create_rollup_tablet(const TAlterTabletReq& request) {
     LOG(INFO) << "begin to create rollup tablet. "
-              << "old_tablet_id=" << request.base_tablet_id
+              << "base_tablet_id=" << request.base_tablet_id
               << ", new_tablet_id=" << request.new_tablet_req.tablet_id;
 
     DorisMetrics::create_rollup_requests_total.increment(1);
@@ -103,21 +103,21 @@ OLAPStatus EngineSchemaChangeTask::_create_rollup_tablet(const TAlterTabletReq& 
     res = handler.process_alter_tablet(ROLLUP, request);
 
     if (res != OLAP_SUCCESS) {
-        OLAP_LOG_WARNING("failed to do rollup. "
-                         "[base_tablet=%ld new_tablet=%ld] [res=%d]",
-                         request.base_tablet_id, request.new_tablet_req.tablet_id, res);
+        LOG(WARNING) << "failed to do rollup. res=" << res
+                     << "base_tablet=" << request.base_tablet_id
+                     << ", new_tablet=" << request.new_tablet_req.tablet_id;
         DorisMetrics::create_rollup_requests_failed.increment(1);
         return res;
     }
 
     LOG(INFO) << "success to create rollup tablet. res=" << res
-              << ", old_tablet_id=" << request.base_tablet_id 
+              << ", base_tablet_id=" << request.base_tablet_id 
               << ", new_tablet_id=" << request.new_tablet_req.tablet_id;
     return res;
 } // create_rollup_tablet
 
 OLAPStatus EngineSchemaChangeTask::_schema_change(const TAlterTabletReq& request) {
-    LOG(INFO) << "begin to schema change. old_tablet_id=" << request.base_tablet_id
+    LOG(INFO) << "begin to schema change. base_tablet_id=" << request.base_tablet_id
               << ", new_tablet_id=" << request.new_tablet_req.tablet_id;
 
     DorisMetrics::schema_change_requests_total.increment(1);
@@ -128,15 +128,15 @@ OLAPStatus EngineSchemaChangeTask::_schema_change(const TAlterTabletReq& request
     res = handler.process_alter_tablet(SCHEMA_CHANGE, request);
 
     if (res != OLAP_SUCCESS) {
-        OLAP_LOG_WARNING("failed to do schema change. "
-                         "[base_tablet=%ld new_tablet=%ld] [res=%d]",
-                         request.base_tablet_id, request.new_tablet_req.tablet_id, res);
+        LOG(WARNING) << "failed to do schema change. res=" << res
+                     << "base_tablet=" << request.base_tablet_id
+                     << ", new_tablet=" << request.new_tablet_req.tablet_id;
         DorisMetrics::schema_change_requests_failed.increment(1);
         return res;
     }
 
-    LOG(INFO) << "success to submit schema change."
-              << "old_tablet_id=" << request.base_tablet_id
+    LOG(INFO) << "success to do schema change."
+              << "base_tablet_id=" << request.base_tablet_id
               << ", new_tablet_id=" << request.new_tablet_req.tablet_id;
     return res;
 }

--- a/be/src/olap/utils.h
+++ b/be/src/olap/utils.h
@@ -68,6 +68,10 @@ public:
                           (now.tv_usec - _begin_time.tv_usec));
     }
 
+    double get_elapse_second() {
+        return get_elapse_time_us() / 100000.0;
+    }
+
     void reset() {
         gettimeofday(&_begin_time, 0);
     }

--- a/gensrc/proto/olap_file.proto
+++ b/gensrc/proto/olap_file.proto
@@ -21,14 +21,14 @@ package doris;
 import "olap_common.proto";
 import "types.proto";
 
-message ColumnPruning {
+message ZoneMap {
     required bytes min = 1;
     required bytes max = 2;
     optional bool null_flag = 3;
 }
 
 message DeltaPruning {
-    repeated ColumnPruning column_pruning = 1;
+    repeated ZoneMap zone_maps = 1;
 }
 
 // define OLAP FileVersion Message, Base, delta and cumulative delta 
@@ -85,7 +85,7 @@ message RowsetMetaPB {
     optional int64 data_disk_size = 13;
     optional int64 index_disk_size = 14;
     // column min/max/null flag statistic info
-    repeated ColumnPruning column_statistics = 15;
+    repeated ZoneMap zone_maps = 15;
     optional DeletePredicatePB delete_predicate = 16;
     optional bool empty = 17;
     optional string rowset_path = 18;
@@ -107,7 +107,7 @@ message SegmentGroupPB {
     required int64 index_size = 3;
     required int64 data_size = 4;
     required int64 num_rows = 5;
-    repeated ColumnPruning column_pruning = 6;
+    repeated ZoneMap zone_maps = 6;
     optional bool empty = 7;
 }
 
@@ -123,7 +123,7 @@ message PendingSegmentGroupPB {
     required int32 pending_segment_group_id = 1;
     required int32 num_segments = 2;
     required PUniqueId load_id = 3;
-    repeated ColumnPruning column_pruning = 4;
+    repeated ZoneMap zone_maps = 4;
     optional bool empty = 5;
 }
 


### PR DESCRIPTION
1. Unify alter table state resided in memory and disk.
2. Merge the two process_alter_tablet and _do_alter_tablet function.
3. Rename _alter_tablet to _convert_historical_rowsets.
4. Rename ColumnPruning to ZoneMap.