### PR TITLE
Limit the number of balance task

### DIFF
--- a/fe/src/main/java/org/apache/doris/clone/BackendLoadStatistic.java
+++ b/fe/src/main/java/org/apache/doris/clone/BackendLoadStatistic.java
@@ -270,6 +270,10 @@ public class BackendLoadStatistic implements Comparable<BackendLoadStatistic> {
         return pathStatistics;
     }
 
+    public long getAvailPathNum() {
+        return pathStatistics.stream().filter(p -> p.getDiskState() == DiskState.ONLINE).count();
+    }
+
     public String getBrief() {
         StringBuilder sb = new StringBuilder();
         sb.append(beId).append(": replica: ").append(totalReplicaNum);


### PR DESCRIPTION
1. Limit the number of balance tablet selection. The number of
   tablet selection should be less than the low load path number.
2. Limit the max number of balance task to 500.