### PR TITLE
Fix some tablet scheduler bug

### DIFF
--- a/fe/src/main/java/org/apache/doris/catalog/TabletInvertedIndex.java
+++ b/fe/src/main/java/org/apache/doris/catalog/TabletInvertedIndex.java
@@ -474,7 +474,7 @@ public class TabletInvertedIndex {
             if (replicaMetaTable.containsRow(tabletId)) {
                 return Lists.newArrayList(replicaMetaTable.row(tabletId).values());
             }
-            return null;
+            return Lists.newArrayList();
         } finally {
             readUnlock();
         }

--- a/fe/src/main/java/org/apache/doris/clone/BackendLoadStatistic.java
+++ b/fe/src/main/java/org/apache/doris/clone/BackendLoadStatistic.java
@@ -25,6 +25,7 @@ import org.apache.doris.common.Config;
 import org.apache.doris.common.util.DebugUtil;
 import org.apache.doris.system.Backend;
 import org.apache.doris.system.SystemInfoService;
+import org.apache.doris.thrift.TStorageMedium;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
@@ -241,15 +242,14 @@ public class BackendLoadStatistic implements Comparable<BackendLoadStatistic> {
 
     /*
      * Classify the paths into 'low', 'mid' and 'high',
-     * and skip offline path
+     * and skip offline path, and path with different storage medium 
      */
     public void getPathStatisticByClass(
-            Set<Long> low,
-            Set<Long> mid,
-            Set<Long> high) {
+            Set<Long> low, Set<Long> mid, Set<Long> high, TStorageMedium storageMedium) {
 
         for (RootPathLoadStatistic pathStat : pathStatistics) {
-            if (pathStat.getDiskState() == DiskState.OFFLINE) {
+            if (pathStat.getDiskState() == DiskState.OFFLINE
+                    || (storageMedium != null && pathStat.getStorageMedium() != storageMedium)) {
                 continue;
             }
 

--- a/fe/src/main/java/org/apache/doris/clone/LoadBalancer.java
+++ b/fe/src/main/java/org/apache/doris/clone/LoadBalancer.java
@@ -119,7 +119,7 @@ public class LoadBalancer {
             Set<Long> pathLow = Sets.newHashSet();
             Set<Long> pathMid = Sets.newHashSet();
             Set<Long> pathHigh = Sets.newHashSet();
-            beStat.getPathStatisticByClass(pathLow, pathMid, pathHigh);
+            beStat.getPathStatisticByClass(pathLow, pathMid, pathHigh, null);
             // we only select tablets from available mid and high load path
             pathHigh.addAll(pathMid);
             
@@ -273,7 +273,7 @@ public class LoadBalancer {
                 Set<Long> pathLow = Sets.newHashSet();
                 Set<Long> pathMid = Sets.newHashSet();
                 Set<Long> pathHigh = Sets.newHashSet();
-                beStat.getPathStatisticByClass(pathLow, pathMid, pathHigh);
+                beStat.getPathStatisticByClass(pathLow, pathMid, pathHigh, tabletCtx.getStorageMedium());
                 pathLow.addAll(pathMid);
 
                 long pathHash = slot.takeAnAvailBalanceSlotFrom(pathLow);

--- a/fe/src/main/java/org/apache/doris/clone/TabletSchedCtx.java
+++ b/fe/src/main/java/org/apache/doris/clone/TabletSchedCtx.java
@@ -494,7 +494,9 @@ public class TabletSchedCtx implements Comparable<TabletSchedCtx> {
                 continue;
             }
 
-            if (replica.getLastFailedVersion() <= 0) {
+            if (replica.getLastFailedVersion() <= 0 && replica.getVersion() == visibleVersion
+                    && replica.getVersionHash() == visibleVersionHash) {
+                // skip healthy replica
                 continue;
             }
             


### PR DESCRIPTION
1. The balance task does not taking storage medium into account.
2. When repairing tablet with version incomplete, tablet with replica (2-xx), (2-xx), (2-0) can't be handled.
3. Show proc stmt may throw null pointer exception when all replicas are missing.

#685 