### PR TITLE
Change the relationship between txn and task

### DIFF
--- a/be/src/runtime/stream_load/stream_load_context.h
+++ b/be/src/runtime/stream_load/stream_load_context.h
@@ -43,7 +43,8 @@ public:
     KafkaLoadInfo(const TKafkaLoadInfo& t_info):
         brokers(t_info.brokers),
         topic(t_info.topic),
-        begin_offset(t_info.partition_begin_offset) {
+        begin_offset(t_info.partition_begin_offset),
+        cmt_offset(t_info.partition_begin_offset) {
 
         if (t_info.__isset.max_interval_s) { max_interval_s = t_info.max_interval_s; }
         if (t_info.__isset.max_batch_rows) { max_batch_rows = t_info.max_batch_rows; }

--- a/fe/src/main/java/org/apache/doris/load/TxnStateChangeListener.java
+++ b/fe/src/main/java/org/apache/doris/load/TxnStateChangeListener.java
@@ -18,16 +18,19 @@
 package org.apache.doris.load;
 
 import org.apache.doris.transaction.AbortTransactionException;
+import org.apache.doris.transaction.TransactionException;
 import org.apache.doris.transaction.TransactionState;
 
 public interface TxnStateChangeListener {
+
+    void beforeCommitted(TransactionState txnState) throws TransactionException;
 
     /**
      * update catalog of job which has related txn after transaction has been committed
      *
      * @param txnState
      */
-    void onCommitted(TransactionState txnState);
+    void onCommitted(TransactionState txnState) throws TransactionException;
 
     /**
      * this interface is executed before txn aborted, you can check if txn could be abort in this stage
@@ -37,7 +40,7 @@ public interface TxnStateChangeListener {
      * @throws AbortTransactionException if transaction could not be abort or there are some exception before aborted,
      *                                   it will throw this exception
      */
-    void beforeAborted(TransactionState txnState, TransactionState.TxnStatusChangeReason txnStatusChangeReason)
+    void beforeAborted(TransactionState txnState, String txnStatusChangeReason)
             throws AbortTransactionException;
 
     /**
@@ -46,5 +49,5 @@ public interface TxnStateChangeListener {
      * @param txnState
      * @param txnStatusChangeReason maybe null
      */
-    void onAborted(TransactionState txnState, TransactionState.TxnStatusChangeReason txnStatusChangeReason);
+    void onAborted(TransactionState txnState, String txnStatusChangeReason);
 }

--- a/fe/src/main/java/org/apache/doris/load/routineload/KafkaProgress.java
+++ b/fe/src/main/java/org/apache/doris/load/routineload/KafkaProgress.java
@@ -35,6 +35,7 @@ import java.util.Map;
 // {"partitionIdToOffset": {}}
 public class KafkaProgress extends RoutineLoadProgress {
 
+    // (partition id, begin offset)
     private Map<Integer, Long> partitionIdToOffset;
 
     public KafkaProgress() {
@@ -57,7 +58,7 @@ public class KafkaProgress extends RoutineLoadProgress {
     public void update(RoutineLoadProgress progress) {
         KafkaProgress newProgress = (KafkaProgress) progress;
         newProgress.getPartitionIdToOffset().entrySet().parallelStream()
-                .forEach(entity -> partitionIdToOffset.put(entity.getKey(), entity.getValue()));
+                .forEach(entity -> partitionIdToOffset.put(entity.getKey(), entity.getValue() + 1));
     }
 
     @Override
@@ -78,9 +79,15 @@ public class KafkaProgress extends RoutineLoadProgress {
         }
     }
 
+    // (partition id, end offset)
+    // end offset = -1 while begin offset of partition is 0
     @Override
     public String toString() {
+        Map<Integer, Long> showPartitionIdToOffset = new HashMap<>();
+        for (Map.Entry<Integer, Long> entry : partitionIdToOffset.entrySet()) {
+            showPartitionIdToOffset.put(entry.getKey(), entry.getValue() - 1);
+        }
         return "KafkaProgress [partitionIdToOffset="
-                + Joiner.on("|").withKeyValueSeparator("_").join(partitionIdToOffset) + "]";
+                + Joiner.on("|").withKeyValueSeparator("_").join(showPartitionIdToOffset) + "]";
     }
 }

--- a/fe/src/main/java/org/apache/doris/load/routineload/KafkaRoutineLoadJob.java
+++ b/fe/src/main/java/org/apache/doris/load/routineload/KafkaRoutineLoadJob.java
@@ -119,7 +119,7 @@ public class KafkaRoutineLoadJob extends RoutineLoadJob {
     }
 
     @Override
-    public List<RoutineLoadTaskInfo> divideRoutineLoadJob(int currentConcurrentTaskNum) {
+    public void divideRoutineLoadJob(int currentConcurrentTaskNum) {
         List<RoutineLoadTaskInfo> result = new ArrayList<>();
         writeLock();
         try {
@@ -148,7 +148,6 @@ public class KafkaRoutineLoadJob extends RoutineLoadJob {
         } finally {
             writeUnlock();
         }
-        return result;
     }
 
     @Override
@@ -261,9 +260,7 @@ public class KafkaRoutineLoadJob extends RoutineLoadJob {
     private void updateNewPartitionProgress() {
         // update the progress of new partitions
         for (Integer kafkaPartition : currentKafkaPartitions) {
-            if (((KafkaProgress) progress).getPartitionIdToOffset().containsKey(kafkaPartition)) {
-                ((KafkaProgress) progress).getPartitionIdToOffset().get(kafkaPartition);
-            } else {
+            if (!((KafkaProgress) progress).getPartitionIdToOffset().containsKey(kafkaPartition)) {
                 ((KafkaProgress) progress).getPartitionIdToOffset().put(kafkaPartition, 0L);
             }
         }
@@ -290,6 +287,12 @@ public class KafkaRoutineLoadJob extends RoutineLoadJob {
         }
         if (stmt.getKafkaPartitions() != null) {
             setCustomKafkaPartitions(stmt.getKafkaPartitions());
+            if (stmt.getKafkaOffsets() != null) {
+                for (int i = 0; i < customKafkaPartitions.size(); i++) {
+                    ((KafkaProgress) progress).getPartitionIdToOffset()
+                            .put(customKafkaPartitions.get(i), stmt.getKafkaOffsets().get(i));
+                }
+            }
         }
     }
 }

--- a/fe/src/main/java/org/apache/doris/load/routineload/KafkaTaskInfo.java
+++ b/fe/src/main/java/org/apache/doris/load/routineload/KafkaTaskInfo.java
@@ -52,7 +52,7 @@ public class KafkaTaskInfo extends RoutineLoadTaskInfo {
 
     public KafkaTaskInfo(KafkaTaskInfo kafkaTaskInfo) throws LabelAlreadyUsedException,
             BeginTransactionException, AnalysisException {
-        super(UUID.randomUUID(), kafkaTaskInfo.getJobId());
+        super(UUID.randomUUID(), kafkaTaskInfo.getJobId(), kafkaTaskInfo.getPreviousBeId());
         this.partitions = kafkaTaskInfo.getPartitions();
     }
 
@@ -109,6 +109,10 @@ public class KafkaTaskInfo extends RoutineLoadTaskInfo {
         TExecPlanFragmentParams tExecPlanFragmentParams = routineLoadJob.gettExecPlanFragmentParams();
         TPlanFragment tPlanFragment = tExecPlanFragmentParams.getFragment();
         tPlanFragment.getOutput_sink().getOlap_table_sink().setTxn_id(this.txnId);
+        TUniqueId queryId = new TUniqueId(id.getMostSignificantBits(), id.getLeastSignificantBits());
+        tExecPlanFragmentParams.getParams().setQuery_id(queryId);
+        tExecPlanFragmentParams.getParams().getPer_node_scan_ranges().values().stream()
+                .forEach(entity -> entity.get(0).getScan_range().getBroker_scan_range().getRanges().get(0).setLoad_id(queryId));
         return tExecPlanFragmentParams;
     }
 }

--- a/fe/src/main/java/org/apache/doris/load/routineload/RoutineLoadJob.java
+++ b/fe/src/main/java/org/apache/doris/load/routineload/RoutineLoadJob.java
@@ -508,7 +508,8 @@ public abstract class RoutineLoadJob implements Writable, TxnStateChangeListener
         try {
             String taskId = txnState.getLabel();
             if (routineLoadTaskInfoList.parallelStream().anyMatch(entity -> entity.getId().toString().equals(taskId))) {
-                LOG.debug("there are a txn of routine load task will be aborted");
+                LOG.debug("there is a txn{} of routine load task {} will be aborted",
+                          txnState.getTransactionId(), taskId);
             }
         } finally {
             readUnlock();

--- a/fe/src/main/java/org/apache/doris/load/routineload/RoutineLoadScheduler.java
+++ b/fe/src/main/java/org/apache/doris/load/routineload/RoutineLoadScheduler.java
@@ -96,8 +96,7 @@ public class RoutineLoadScheduler extends Daemon {
 
         LOG.debug("begin to check timeout tasks");
         // check timeout tasks
-        List<RoutineLoadTaskInfo> rescheduleTasksList = routineLoadManager.processTimeoutTasks();
-        routineLoadManager.addTasksToNeedScheduleQueue(rescheduleTasksList);
+        routineLoadManager.processTimeoutTasks();
     }
 
     private List<RoutineLoadJob> getNeedScheduleRoutineJobs() throws LoadException {

--- a/fe/src/main/java/org/apache/doris/load/routineload/RoutineLoadTaskInfo.java
+++ b/fe/src/main/java/org/apache/doris/load/routineload/RoutineLoadTaskInfo.java
@@ -23,8 +23,6 @@ import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.LabelAlreadyUsedException;
 import org.apache.doris.common.LoadException;
 import org.apache.doris.common.UserException;
-import org.apache.doris.task.RoutineLoadTask;
-import org.apache.doris.thrift.TExecPlanFragmentParams;
 import org.apache.doris.thrift.TRoutineLoadTask;
 import org.apache.doris.transaction.BeginTransactionException;
 import org.apache.doris.transaction.TransactionState;
@@ -46,12 +44,22 @@ public abstract class RoutineLoadTaskInfo {
     protected long jobId;
     private long createTimeMs;
     private long loadStartTimeMs;
-    private TExecPlanFragmentParams tExecPlanFragmentParams;
+    // the be id of previous task
+    protected long previousBeId = -1L;
+    // the be id of this task
+    protected long beId = -1L;
 
     public RoutineLoadTaskInfo(UUID id, long jobId) {
         this.id = id;
         this.jobId = jobId;
         this.createTimeMs = System.currentTimeMillis();
+    }
+
+    public RoutineLoadTaskInfo(UUID id, long jobId, long previousBeId) {
+        this.id = id;
+        this.jobId = jobId;
+        this.createTimeMs = System.currentTimeMillis();
+        this.previousBeId = previousBeId;
     }
     
     public UUID getId() {
@@ -65,7 +73,19 @@ public abstract class RoutineLoadTaskInfo {
     public void setLoadStartTimeMs(long loadStartTimeMs) {
         this.loadStartTimeMs = loadStartTimeMs;
     }
-    
+
+    public long getPreviousBeId() {
+        return previousBeId;
+    }
+
+    public void setBeId(long beId) {
+        this.beId = beId;
+    }
+
+    public long getBeId() {
+        return beId;
+    }
+
     public long getLoadStartTimeMs() {
         return loadStartTimeMs;
     }

--- a/fe/src/main/java/org/apache/doris/planner/StreamLoadScanNode.java
+++ b/fe/src/main/java/org/apache/doris/planner/StreamLoadScanNode.java
@@ -124,7 +124,7 @@ public class StreamLoadScanNode extends ScanNode {
         // columns: k1, k2, v1, v2=k1 + k2
         // this means that there are three columns(k1, k2, v1) in source file,
         // and v2 is derived from (k1 + k2)
-        if (streamLoadTask.getColumnToColumnExpr() != null || streamLoadTask.getColumnToColumnExpr().size() != 0) {
+        if (streamLoadTask.getColumnToColumnExpr() != null && streamLoadTask.getColumnToColumnExpr().size() != 0) {
             for (Map.Entry<String, Expr> entry : streamLoadTask.getColumnToColumnExpr().entrySet()) {
                 // make column name case match with real column name
                 String column = entry.getKey();

--- a/fe/src/main/java/org/apache/doris/qe/ShowExecutor.java
+++ b/fe/src/main/java/org/apache/doris/qe/ShowExecutor.java
@@ -798,7 +798,7 @@ public class ShowExecutor {
         RoutineLoadJob routineLoadJob =
                 Catalog.getCurrentCatalog().getRoutineLoadManager().getJobByName(showRoutineLoadStmt.getName());
         if (routineLoadJob == null) {
-            throw new AnalysisException("There is no routine load job with id " + showRoutineLoadStmt.getName());
+            throw new AnalysisException("There is no routine load job with name " + showRoutineLoadStmt.getName());
         }
 
         // check auth
@@ -831,6 +831,7 @@ public class ShowExecutor {
         row.add(routineLoadJob.getState().name());
         row.add(routineLoadJob.getDesiredConcurrentNumber());
         row.add(routineLoadJob.getProgress().toString());
+        rows.add(row);
 
         resultSet = new ShowResultSet(showRoutineLoadStmt.getMetaData(), rows);
     }

--- a/fe/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
+++ b/fe/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
@@ -688,7 +688,8 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         }
 
         Catalog.getCurrentGlobalTransactionMgr().abortTransaction(request.getTxnId(),
-                                                                  request.isSetReason() ? request.getReason() : "system cancel");
+                                                                  request.isSetReason() ? request.getReason() : "system cancel",
+                                                                  TxnCommitAttachment.fromThrift(request.getTxnCommitAttachment()));
     }
 
     @Override

--- a/fe/src/main/java/org/apache/doris/transaction/TransactionState.java
+++ b/fe/src/main/java/org/apache/doris/transaction/TransactionState.java
@@ -309,7 +309,7 @@ public class TransactionState implements Writable {
         setTransactionStatus(transactionStatus, null);
     }
     
-    public void setTransactionStatus(TransactionStatus transactionStatus, TxnStatusChangeReason txnStatusChangeReason)
+    public void setTransactionStatus(TransactionStatus transactionStatus, String txnStatusChangeReason)
             throws TransactionException {
         // before state changed
         if (txnStateChangeListener != null) {
@@ -317,6 +317,8 @@ public class TransactionState implements Writable {
                 case ABORTED:
                     txnStateChangeListener.beforeAborted(this, txnStatusChangeReason);
                     break;
+                case COMMITTED:
+                    txnStateChangeListener.beforeCommitted(this);
                 default:
                     break;
             }

--- a/fe/src/test/java/org/apache/doris/load/routineload/RoutineLoadManagerTest.java
+++ b/fe/src/test/java/org/apache/doris/load/routineload/RoutineLoadManagerTest.java
@@ -110,6 +110,7 @@ public class RoutineLoadManagerTest {
         Assert.assertEquals(jobName, routineLoadJob.getName());
         Assert.assertEquals(1L, routineLoadJob.getTableId());
         Assert.assertEquals(RoutineLoadJob.JobState.NEED_SCHEDULE, routineLoadJob.getState());
+        Assert.assertEquals(true, routineLoadJob instanceof KafkaRoutineLoadJob);
 
         Map<Long, Map<String, List<RoutineLoadJob>>> dbToNameToRoutineLoadJob =
                 Deencapsulation.getField(routineLoadManager, "dbToNameToRoutineLoadJob");
@@ -244,7 +245,7 @@ public class RoutineLoadManagerTest {
         };
 
         RoutineLoadManager routineLoadManager = new RoutineLoadManager();
-        routineLoadManager.addNumOfConcurrentTasksByBeId(1L);
+//        routineLoadManager.increaseNumOfConcurrentTasksByBeId(1L);
         Assert.assertEquals(2L, routineLoadManager.getMinTaskBeId("default"));
     }
 
@@ -264,7 +265,7 @@ public class RoutineLoadManagerTest {
         };
 
         RoutineLoadManager routineLoadManager = new RoutineLoadManager();
-        routineLoadManager.addNumOfConcurrentTasksByBeId(1L);
+//        routineLoadManager.increaseNumOfConcurrentTasksByBeId(1L);
         Assert.assertEquals(DEFAULT_BE_CONCURRENT_TASK_NUM * 2 - 1, routineLoadManager.getClusterIdleSlotNum());
     }
 

--- a/fe/src/test/java/org/apache/doris/load/routineload/RoutineLoadTaskSchedulerTest.java
+++ b/fe/src/test/java/org/apache/doris/load/routineload/RoutineLoadTaskSchedulerTest.java
@@ -115,7 +115,7 @@ public class RoutineLoadTaskSchedulerTest {
                 result = routineLoadTaskInfoQueue;
                 routineLoadManager.getMinTaskBeId(anyString);
                 result = beId;
-                routineLoadManager.getJobByTaskId(anyString);
+                routineLoadManager.getJobByTaskId((UUID) any);
                 result = kafkaRoutineLoadJob1;
                 routineLoadManager.getJob(anyLong);
                 result = kafkaRoutineLoadJob1;
@@ -147,8 +147,8 @@ public class RoutineLoadTaskSchedulerTest {
                 Assert.assertEquals(200L,
                         (long) ((KafkaRoutineLoadTask) routineLoadTask).getPartitionIdToOffset().get(2));
 
-                routineLoadManager.addNumOfConcurrentTasksByBeId(beId);
-                times = 1;
+//                routineLoadManager.increaseNumOfConcurrentTasksByBeId(beId);
+//                times = 1;
             }
         };
     }


### PR DESCRIPTION
1. Check if properties is null before check routine load properties
2. Change transactionStateChange reason to string
3. calculate current num by beId
4. Add kafka offset properties
5. Perfer to use previous be id
6. Add before commit listerner of txn: if txn is committed after task is aborted, commit will be aborted
7. queryId of stream load plan = taskId