### PR TITLE
Fixed LinkedSchemaChange error

### DIFF
--- a/be/src/olap/file_helper.h
+++ b/be/src/olap/file_helper.h
@@ -351,9 +351,9 @@ OLAPStatus FileHeader<MessageType, ExtraType, FileHandlerType>::unserialize(
     if (OLAP_SUCCESS != file_handler->pread(&_fixed_file_header,
                                             _fixed_file_header_size, 0)) {
         char errmsg[64];
-        LOG(WARNING) << "fail to load header structure from file. [file='"
+        LOG(WARNING) << "fail to load header structure from file. file="
                      << file_handler->file_name()
-                     << "' err='" << strerror_r(errno, errmsg, 64) << "']";
+                     << ", error=" << strerror_r(errno, errmsg, 64);
         return OLAP_ERR_IO_ERROR;
     }
 
@@ -364,9 +364,9 @@ OLAPStatus FileHeader<MessageType, ExtraType, FileHandlerType>::unserialize(
         if (OLAP_SUCCESS != file_handler->pread(&tmp_header,
                                                 sizeof(tmp_header), 0)) {
             char errmsg[64];
-            LOG(WARNING) << "fail to load header structure from file. [file='"
+            LOG(WARNING) << "fail to load header structure from file. file="
                          << file_handler->file_name()
-                         << "' err='" << strerror_r(errno, errmsg, 64) << "']";
+                         << ", error=" << strerror_r(errno, errmsg, 64);
             return OLAP_ERR_IO_ERROR;
         }
 
@@ -389,9 +389,9 @@ OLAPStatus FileHeader<MessageType, ExtraType, FileHandlerType>::unserialize(
     if (OLAP_SUCCESS != file_handler->pread(&_extra_fixed_header,
             sizeof(_extra_fixed_header), _fixed_file_header_size)) {
         char errmsg[64];
-        LOG(WARNING) << "fail to load extra fixed header from file. [file='"
+        LOG(WARNING) << "fail to load extra fixed header from file. file="
                      << file_handler->file_name()
-                     << "' err='" << strerror_r(errno, errmsg, 64) << "']";
+                     << ", error=" << strerror_r(errno, errmsg, 64);
         return OLAP_ERR_IO_ERROR;
     }
 
@@ -399,27 +399,27 @@ OLAPStatus FileHeader<MessageType, ExtraType, FileHandlerType>::unserialize(
 
     if (NULL == buf.get()) {
         char errmsg[64];
-        LOG(WARNING) << "malloc protobuf buf error. [file='"
+        LOG(WARNING) << "malloc protobuf buf error. file="
                      << file_handler->file_name()
-                     << "' err='" << strerror_r(errno, errmsg, 64) << "']";
+                     << ", error=" << strerror_r(errno, errmsg, 64);
         return OLAP_ERR_MALLOC_ERROR;
     }
 
     if (OLAP_SUCCESS != file_handler->pread(buf.get(), _fixed_file_header.protobuf_length,
             _fixed_file_header_size + sizeof(_extra_fixed_header))) {
         char errmsg[64];
-        LOG(WARNING) << "fail to load protobuf from file. [file='"
+        LOG(WARNING) << "fail to load protobuf from file. file="
                      << file_handler->file_name()
-                     << "' err='" << strerror_r(errno, errmsg, 64) << "']";
+                     << ", error=" << strerror_r(errno, errmsg, 64);
         return OLAP_ERR_IO_ERROR;
     }
 
     real_file_length = file_handler->length();
 
     if (file_length() != static_cast<uint64_t>(real_file_length)) {
-        LOG(WARNING) << "file length is not match. [file='" << file_handler->file_name()
-                     << "' file_length=" << file_length()
-                     << " real_file_length=" << real_file_length << "]";
+        LOG(WARNING) << "file length is not match. file=" << file_handler->file_name()
+                     << ", file_length=" << file_length()
+                     << ", real_file_length=" << real_file_length;
         return OLAP_ERR_FILE_DATA_ERROR;
     }
 
@@ -428,9 +428,9 @@ OLAPStatus FileHeader<MessageType, ExtraType, FileHandlerType>::unserialize(
                                           buf.get(), _fixed_file_header.protobuf_length);
 
     if (real_protobuf_checksum != _fixed_file_header.protobuf_checksum) {
-        LOG(WARNING) << "checksum is not match. [file='" << file_handler->file_name()
-                     << "' expect=" << _fixed_file_header.protobuf_checksum
-                     << " actual=" << real_protobuf_checksum << "]";
+        LOG(WARNING) << "checksum is not match. file=" << file_handler->file_name()
+                     << ", expect=" << _fixed_file_header.protobuf_checksum
+                     << ", actual=" << real_protobuf_checksum;
         return OLAP_ERR_CHECKSUM_ERROR;
     }
 
@@ -438,12 +438,12 @@ OLAPStatus FileHeader<MessageType, ExtraType, FileHandlerType>::unserialize(
         std::string protobuf_str(buf.get(), _fixed_file_header.protobuf_length);
 
         if (!_proto.ParseFromString(protobuf_str)) {
-            LOG(WARNING) << "fail to parse file content to protobuf object. [file='"
-                         << file_handler->file_name() << "']";
+            LOG(WARNING) << "fail to parse file content to protobuf object. file="
+                         << file_handler->file_name();
             return OLAP_ERR_PARSE_PROTOBUF_ERROR;
         }
     } catch (...) {
-        LOG(WARNING) << "fail to load protobuf. [file='" << file_handler->file_name() << "']";
+        LOG(WARNING) << "fail to load protobuf. file='" << file_handler->file_name();
         return OLAP_ERR_PARSE_PROTOBUF_ERROR;
     }
 

--- a/be/src/olap/olap_index.cpp
+++ b/be/src/olap/olap_index.cpp
@@ -62,20 +62,18 @@ OLAPStatus MemIndex::load_segment(const char* file, size_t *current_num_rows_per
 
     if (file == NULL) {
         res = OLAP_ERR_INPUT_PARAMETER_ERROR;
-        OLAP_LOG_WARNING("load segment for loading index error. [file=%s; res=%d]", file, res);
+        LOG(WARNING) << "load index error. file=" << file << ", res=" << res;
         return res;
     }
 
     FileHandler file_handler;
     if ((res = file_handler.open_with_cache(file, O_RDONLY)) != OLAP_SUCCESS) {
-        OLAP_LOG_WARNING("fail to open index file. [file='%s']", file);
-        OLAP_LOG_WARNING("load segment for loading index error. [file=%s; res=%d]", file, res);
+        LOG(WARNING) << "load index error. file=" << file << ", res=" << res;
         return res;
     }
 
     if ((res = meta.file_header.unserialize(&file_handler)) != OLAP_SUCCESS) {
-        OLAP_LOG_WARNING("fail to read index file header. [file='%s']", file);
-        OLAP_LOG_WARNING("load segment for loading index error. [file=%s; res=%d]", file, res);
+        LOG(WARNING) << "load index error. file=" << file << ", res=" << res;
         file_handler.close();
         return res;
     }
@@ -101,8 +99,7 @@ OLAPStatus MemIndex::load_segment(const char* file, size_t *current_num_rows_per
     }
     if (!is_align) {
         res = OLAP_ERR_INDEX_LOAD_ERROR;
-        OLAP_LOG_WARNING("fail to load_segment, buffer length is not correct.");
-        OLAP_LOG_WARNING("load segment for loading index error. [file=%s; res=%d]", file, res);
+        LOG(WARNING) << "load index error. file=" << file << ", res=" << res;
         file_handler.close();
         return res;
     }

--- a/be/src/olap/rowset/alpha_rowset_writer.cpp
+++ b/be/src/olap/rowset/alpha_rowset_writer.cpp
@@ -116,10 +116,12 @@ OLAPStatus AlphaRowsetWriter::add_rowset(RowsetSharedPtr rowset) {
     // this is feasible because LinkedSchemaChange is done on the same disk
     AlphaRowsetSharedPtr alpha_rowset = std::dynamic_pointer_cast<AlphaRowset>(rowset);
     for (auto& segment_group : alpha_rowset->_segment_groups) {
-        RETURN_NOT_OK(segment_group->copy_segments_to_path(_rowset_writer_context.rowset_path_prefix));
+        RETURN_NOT_OK(segment_group->copy_segments_to_path(_rowset_writer_context.rowset_path_prefix,
+                                                           _rowset_writer_context.rowset_id));
         _cur_segment_group->set_empty(segment_group->empty());
         _cur_segment_group->set_num_segments(segment_group->num_segments());
         _cur_segment_group->add_zone_maps_for_linked_schema_change(segment_group->get_zone_maps());
+        RETURN_NOT_OK(_cur_segment_group->load());
         _num_rows_written += alpha_rowset->num_rows();
     }
     return OLAP_SUCCESS;
@@ -135,7 +137,6 @@ OLAPStatus AlphaRowsetWriter::flush() {
 }
 
 RowsetSharedPtr AlphaRowsetWriter::build() {
-    LOG(INFO) << "segment group size=" << _segment_groups.size();
     for (auto& segment_group : _segment_groups) {
         _current_rowset_meta->set_data_disk_size(_current_rowset_meta->data_disk_size() + segment_group->data_size());
         _current_rowset_meta->set_index_disk_size(_current_rowset_meta->index_disk_size() + segment_group->index_size());
@@ -240,7 +241,6 @@ int32_t AlphaRowsetWriter::num_rows() {
 
 void AlphaRowsetWriter::_init() {
     _segment_group_id++;
-    LOG(INFO) << "segment_group_id:" << _segment_group_id;
     if (_is_pending_rowset) {
         _cur_segment_group.reset(new SegmentGroup(
                 _rowset_writer_context.tablet_id,
@@ -263,12 +263,11 @@ void AlphaRowsetWriter::_init() {
     _cur_segment_group->acquire();
     //_cur_segment_group->set_load_id(_rowset_writer_context.load_id);
     _segment_groups.push_back(_cur_segment_group);
-    LOG(INFO) << "segment_group_size:" << _segment_groups.size();
 
     _column_data_writer = ColumnDataWriter::create(_cur_segment_group.get(), true,
                                                    _rowset_writer_context.tablet_schema->compress_kind(),
                                                    _rowset_writer_context.tablet_schema->bloom_filter_fpp());
-    DCHECK(_column_data_writer != nullptr) << "memory error occur when creating writer";
+    DCHECK(_column_data_writer != nullptr) << "memory error occurs when creating writer";
 }
 
 } // namespace doris

--- a/be/src/olap/rowset/segment_group.cpp
+++ b/be/src/olap/rowset/segment_group.cpp
@@ -153,6 +153,12 @@ std::string SegmentGroup::_construct_file_name(int32_t segment_id, const string&
     return file_name;
 }
 
+std::string SegmentGroup::_construct_file_name(int64_t rowset_id, int32_t segment_id, const string& suffix) const {
+    std::string file_name = std::to_string(rowset_id) + "_"
+            + std::to_string(_segment_group_id) + "_" + std::to_string(segment_id) + suffix;
+    return file_name;
+}
+
 std::string SegmentGroup::construct_index_file_path(const std::string& snapshot_path, int32_t segment_id) const {
     std::string file_path = snapshot_path;
     file_path.append("/");
@@ -795,12 +801,12 @@ OLAPStatus SegmentGroup::remove_old_files(std::vector<std::string>* links_to_rem
     return OLAP_SUCCESS;
 }
 
-OLAPStatus SegmentGroup::copy_segments_to_path(const std::string& dest_path) {
+OLAPStatus SegmentGroup::copy_segments_to_path(const std::string& dest_path, int64_t rowset_id) {
     if (dest_path.empty() || dest_path == _rowset_path_prefix) {
         return OLAP_SUCCESS;
     }
     for (int segment_id = 0; segment_id < _num_segments; segment_id++) {
-        std::string data_file_name = _construct_file_name(segment_id, ".dat");
+        std::string data_file_name = _construct_file_name(rowset_id, segment_id, ".dat");
         std::string new_data_file_path = dest_path + "/" + data_file_name;
         if (!check_dir_existed(new_data_file_path)) {
             std::string origin_data_file_path = construct_data_file_path(_rowset_path_prefix, segment_id);
@@ -810,10 +816,10 @@ OLAPStatus SegmentGroup::copy_segments_to_path(const std::string& dest_path) {
                 return OLAP_ERR_OS_ERROR;
             }
         }
-        std::string index_file_name = _construct_file_name(segment_id, ".idx");
+        std::string index_file_name = _construct_file_name(rowset_id, segment_id, ".idx");
         std::string new_index_file_path = dest_path + "/" + index_file_name;
         if (!check_dir_existed(new_index_file_path)) {
-            std::string origin_idx_file_path = construct_data_file_path(_rowset_path_prefix, segment_id);
+            std::string origin_idx_file_path = construct_index_file_path(_rowset_path_prefix, segment_id);
             if (link(origin_idx_file_path.c_str(), new_index_file_path.c_str()) != 0) {
                 LOG(WARNING) << "fail to create hard link. from=" << origin_idx_file_path
                              << ", to=" << new_index_file_path << ", error=" << strerror(errno);

--- a/be/src/olap/rowset/segment_group.h
+++ b/be/src/olap/rowset/segment_group.h
@@ -268,11 +268,12 @@ public:
     OLAPStatus make_snapshot(const std::string& snapshot_path,
                              std::vector<std::string>* success_links);
 
-    OLAPStatus copy_segments_to_path(const std::string& dest_path);
+    OLAPStatus copy_segments_to_path(const std::string& dest_path, int64_t rowset_id);
 
 private:
     
     std::string _construct_file_name(int32_t segment_id, const std::string& suffix) const;
+    std::string _construct_file_name(int64_t rowset_id, int32_t segment_id, const std::string& suffix) const;
 
     std::string _construct_old_pending_file_path(const std::string& path_prefix, int32_t segment_id, const std::string& suffix) const;
     

--- a/be/src/olap/rowset_factory.cpp
+++ b/be/src/olap/rowset_factory.cpp
@@ -22,7 +22,7 @@
 namespace doris {
 
 OLAPStatus RowsetFactory::load_rowset(const TabletSchema& schema,
-                                      const std::string rowset_path,
+                                      const std::string& rowset_path,
                                       DataDir* data_dir,
                                       RowsetMetaSharedPtr rowset_meta, 
                                       RowsetSharedPtr* rowset) {

--- a/be/src/olap/rowset_factory.h
+++ b/be/src/olap/rowset_factory.h
@@ -27,10 +27,10 @@ class RowsetFactory {
 
 public:
     static OLAPStatus load_rowset(const TabletSchema& schema,
-                                    const std::string rowset_path,
-                                    DataDir* data_dir,
-                                    RowsetMetaSharedPtr rowset_meta, 
-                                    RowsetSharedPtr* rowset);
+                                  const std::string& rowset_path,
+                                  DataDir* data_dir,
+                                  RowsetMetaSharedPtr rowset_meta,
+                                  RowsetSharedPtr* rowset);
 };
 
 } // namespace doris

--- a/be/src/olap/schema_change.cpp
+++ b/be/src/olap/schema_change.cpp
@@ -629,15 +629,10 @@ bool LinkedSchemaChange::process(
         TabletSharedPtr base_tablet) {
     OLAPStatus status = new_rowset_writer->add_rowset(rowset_reader->rowset());
     if (status != OLAP_SUCCESS) {
-        LOG(WARNING) << "fail to reload index."
+        LOG(WARNING) << "fail to convert rowset."
                      << " tablet='"<< _new_tablet->full_name()
                      << ", version=" << new_rowset_writer->version().first
                      << "-" << new_rowset_writer->version().second;
-        return false;
-    }
-
-    if (new_rowset_writer->flush() != OLAP_SUCCESS) {
-        LOG(WARNING) << "failed to finalizing writer.";
         return false;
     }
 
@@ -1743,7 +1738,7 @@ OLAPStatus SchemaChangeHandler::_convert_historical_rowsets(const SchemaChangePa
         }
 
         if (!sc_procedure->process(rs_reader, rowset_writer, sc_params.new_tablet, sc_params.base_tablet)) {
-            LOG(WARNING) << "failed to process the version. "
+            LOG(WARNING) << "failed to process the version."
                          << " version=" << rs_reader->version().first
                          << "-" << rs_reader->version().second;
             res = OLAP_ERR_INPUT_PARAMETER_ERROR;

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -39,6 +39,12 @@
 
 namespace doris {
 
+using std::pair;
+using std::nothrow;
+using std::sort;
+using std::string;
+using std::vector;
+
 TabletSharedPtr Tablet::create_tablet_from_meta_file(
             const string& file_path, DataDir* data_dir) {
     TabletMeta* tablet_meta = NULL;
@@ -466,7 +472,6 @@ void Tablet::add_alter_task(int64_t tablet_id,
                             int64_t schema_hash,
                             const vector<Version>& versions_to_alter,
                             const AlterTabletType alter_type) {
-    delete_alter_task();
     AlterTabletTask alter_task;
     alter_task.set_alter_state(ALTER_RUNNING);
     alter_task.set_related_tablet_id(tablet_id);

--- a/be/src/olap/tablet.h
+++ b/be/src/olap/tablet.h
@@ -37,12 +37,6 @@
 #include "olap/utils.h"
 #include "util/once.h"
 
-using std::pair;
-using std::nothrow;
-using std::sort;
-using std::string;
-using std::vector;
-
 namespace doris {
 
 class DataDir;

--- a/be/src/olap/tablet_meta_manager.cpp
+++ b/be/src/olap/tablet_meta_manager.cpp
@@ -91,7 +91,7 @@ OLAPStatus TabletMetaManager::save(DataDir* store,
     std::stringstream key_stream;
     key_stream << header_prefix << tablet_id << "_" << schema_hash;
     std::string key = key_stream.str();
-    VLOG(3) << "save tablet meta to meta store: key = " << key; 
+    VLOG(3) << "save tablet meta to meta store: key = " << key;
     OlapMeta* meta = store->get_meta();
     return meta->put(META_COLUMN_FAMILY_INDEX, key, meta_binary);
 }

--- a/be/src/olap/task/engine_batch_load_task.cpp
+++ b/be/src/olap/task/engine_batch_load_task.cpp
@@ -42,7 +42,6 @@ using std::string;
 using std::vector;
 
 namespace doris {
-
     
 EngineBatchLoadTask::EngineBatchLoadTask(TPushReq& push_req, 
     std::vector<TTabletInfo>* tablet_infos, 


### PR DESCRIPTION
1. LinkedSchemaChange should not call flush(), because _column_data_writer had not written any data.
2. copy_segments_to_path should receive new rowset_id paramter generated by LinkedSchemaChange.