### PR TITLE
Clean timeout tablets channel in TabletWriterMgr

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -265,7 +265,7 @@ namespace config {
     CONF_Int32(number_tablet_writer_threads, "16");
 
     CONF_Int64(streaming_load_max_mb, "10240");
-    CONF_Int32(streaming_load_max_duration_time_sec, "3600");
+    CONF_Int32(streaming_load_rpc_max_alive_time_sec, "600");
 
     // Fragment thread pool
     CONF_Int32(fragment_pool_thread_num, "64");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -265,6 +265,7 @@ namespace config {
     CONF_Int32(number_tablet_writer_threads, "16");
 
     CONF_Int64(streaming_load_max_mb, "10240");
+    CONF_Int32(streaming_load_max_duration_time_sec, "3600");
 
     // Fragment thread pool
     CONF_Int32(fragment_pool_thread_num, "64");

--- a/be/src/runtime/exec_env_init.cpp
+++ b/be/src/runtime/exec_env_init.cpp
@@ -114,7 +114,9 @@ Status ExecEnv::_init(const std::vector<StorePath>& store_paths) {
         exit(-1);
     }
     _broker_mgr->init();
-    return _init_mem_tracker();
+    _init_mem_tracker();
+    RETURN_IF_ERROR(_tablet_writer_mgr->start_bg_worker());
+    return Status::OK;
 }
 
 Status ExecEnv::_init_mem_tracker() {

--- a/be/src/runtime/tablet_writer_mgr.cpp
+++ b/be/src/runtime/tablet_writer_mgr.cpp
@@ -355,7 +355,7 @@ Status TabletWriterMgr::_start_tablets_channel_clean() {
             }
         }
 
-        for(auto key: need_delete_keys) {
+        for(auto& key: need_delete_keys) {
             _tablets_channels.erase(key);
             LOG(INFO) << "erase timeout tablets channel: " << key;
         }

--- a/be/src/runtime/tablet_writer_mgr.cpp
+++ b/be/src/runtime/tablet_writer_mgr.cpp
@@ -326,22 +326,19 @@ Status TabletWriterMgr::cancel(const PTabletWriterCancelRequest& params) {
 
 Status TabletWriterMgr::start_bg_worker() {
     _tablets_channel_clean_thread = std::thread(
-         [this] {
-             _tablets_channel_clean_thread_callback(nullptr);
-         });
+        [this] {
+            #ifdef GOOGLE_PROFILER
+                ProfilerRegisterThread();
+            #endif
+
+            uint32_t interval = 60;
+            while (true) {
+                _start_tablets_channel_clean();
+                sleep(interval);
+            }
+        });
     _tablets_channel_clean_thread.detach();
     return Status::OK;
-}
-
-void* TabletWriterMgr::_tablets_channel_clean_thread_callback(void* arg) {
-#ifdef GOOGLE_PROFILER
-        ProfilerRegisterThread();
-#endif
-        uint32_t interval = 60;
-        while (true) {
-            _start_tablets_channel_clean();
-            sleep(interval);
-        }
 }
 
 Status TabletWriterMgr::_start_tablets_channel_clean() {

--- a/be/src/runtime/tablet_writer_mgr.h
+++ b/be/src/runtime/tablet_writer_mgr.h
@@ -97,8 +97,6 @@ private:
 
     Cache* _lastest_success_channel = nullptr;
 
-    std::unordered_map<TabletsChannelKey, time_t,TabletsChannelKeyHasher> _key_time_map;
-
     // thread to clean timeout tablets_channel
     std::thread _tablets_channel_clean_thread;
 

--- a/be/src/runtime/tablet_writer_mgr.h
+++ b/be/src/runtime/tablet_writer_mgr.h
@@ -101,8 +101,6 @@ private:
     std::thread _tablets_channel_clean_thread;
 
     Status _start_tablets_channel_clean();
-
-    void* _tablets_channel_clean_thread_callback(void* arg);
 };
 
 std::ostream& operator<<(std::ostream& os, const TabletsChannelKey&);


### PR DESCRIPTION
Fix https://github.com/apache/incubator-doris/issues/690

Add a config `streaming_load_max_duration_time_sec` , a thread `_tablets_channel_clean_thread` and a `std::unordered_map<TabletsChannelKey, time_t,TabletsChannelKeyHasher> _key_time_map`

If a tablets_channel alive time exceed the `streaming_load_max_duration_time_sec`, we will erase the tablets_channel.

This PR is testing because the test need a long time.
