### PR TITLE
Dealing with ALTER_FINISHED state

### DIFF
--- a/be/src/olap/delete_handler.cpp
+++ b/be/src/olap/delete_handler.cpp
@@ -69,6 +69,7 @@ OLAPStatus DeleteConditionHandler::generate_delete_predicate(
         del_pred->add_sub_predicates(condition_str);
         LOG(INFO) << "store one sub-delete condition. condition=" << condition_str;
     }
+    del_pred->set_version(-1);
 
     return OLAP_SUCCESS;
 }

--- a/be/src/olap/delta_writer.cpp
+++ b/be/src/olap/delta_writer.cpp
@@ -80,13 +80,14 @@ OLAPStatus DeltaWriter::init() {
                             _req.tablet_id, _req.schema_hash, _req.load_id));
         if (_req.need_gen_rollup) {
             _tablet->obtain_header_rdlock();
+            bool has_alter_task = _tablet->has_alter_task();
             const AlterTabletTask& alter_task = _tablet->alter_task();
             AlterTabletState alter_state = alter_task.alter_state();
             TTabletId new_tablet_id = alter_task.related_tablet_id();
             TSchemaHash new_schema_hash = alter_task.related_schema_hash();;
             _tablet->release_header_lock();
 
-            if (alter_state == ALTER_RUNNING) {
+            if (has_alter_task && alter_state != ALTER_FAILED) {
                 LOG(INFO) << "load with schema change." << "old_tablet_id: " << _tablet->tablet_id() << ", "
                           << "old_schema_hash: " << _tablet->schema_hash() <<  ", "
                           << "new_tablet_id: " << new_tablet_id << ", "

--- a/be/src/olap/push_handler.cpp
+++ b/be/src/olap/push_handler.cpp
@@ -101,13 +101,14 @@ OLAPStatus PushHandler::_do_streaming_ingestion(
                 << ", transaction_id=" << request.transaction_id;
 
         tablet->obtain_header_rdlock();
+        bool has_alter_task = tablet->has_alter_task();
         const AlterTabletTask& alter_task = tablet->alter_task();
         AlterTabletState alter_state = alter_task.alter_state();
         TTabletId related_tablet_id = alter_task.related_tablet_id();
         TSchemaHash related_schema_hash = alter_task.related_schema_hash();;
         tablet->release_header_lock();
 
-        if (alter_state == ALTER_RUNNING) {
+        if (has_alter_task && alter_state != ALTER_FAILED) {
             LOG(INFO) << "find schema_change status when realtime push. "
                       << "tablet=" << tablet->full_name() 
                       << ", related_tablet_id=" << related_tablet_id

--- a/be/src/olap/task/engine_clear_alter_task.cpp
+++ b/be/src/olap/task/engine_clear_alter_task.cpp
@@ -20,14 +20,10 @@
 namespace doris {
 
 EngineClearAlterTask::EngineClearAlterTask(const TClearAlterTaskRequest& request)
-    :_clear_alter_task_req(request) {
-
-}
+    :_clear_alter_task_req(request) { }
 
 OLAPStatus EngineClearAlterTask::execute() {
-    OLAPStatus status = _clear_alter_task(_clear_alter_task_req.tablet_id, _clear_alter_task_req.schema_hash);
-
-    return status;
+    return _clear_alter_task(_clear_alter_task_req.tablet_id, _clear_alter_task_req.schema_hash);
 }
 
 OLAPStatus EngineClearAlterTask::_clear_alter_task(const TTabletId tablet_id,
@@ -35,9 +31,10 @@ OLAPStatus EngineClearAlterTask::_clear_alter_task(const TTabletId tablet_id,
     LOG(INFO) << "begin to process clear alter task. tablet_id=" << tablet_id
               << ", schema_hash=" << schema_hash;
     TabletSharedPtr tablet = StorageEngine::instance()->tablet_manager()->get_tablet(tablet_id, schema_hash);
-    if (tablet.get() == NULL) {
-        OLAP_LOG_WARNING("can't find tablet when process clear alter task. ",
-                         "[tablet_id=%ld, schema_hash=%d]", tablet_id, schema_hash);
+    if (tablet == nullptr) {
+        LOG(WARNING) << "can't find tablet when process clear alter task."
+                     << " tablet_id=" << tablet_id 
+                     << ", schema_hash=" << schema_hash;
         return OLAP_SUCCESS;
     }
 
@@ -57,8 +54,8 @@ OLAPStatus EngineClearAlterTask::_clear_alter_task(const TTabletId tablet_id,
     TSchemaHash related_schema_hash = alter_task.related_schema_hash();
     tablet->release_header_lock();
 
-    if (alter_state == ALTER_RUNNING) {
-        LOG(WARNING) << "find alter task unfinished when process clear alter task. "
+    if (alter_state == ALTER_PREPARED || alter_state == ALTER_RUNNING) {
+        LOG(WARNING) << "Alter task is not finished when processing clear alter task. "
                      << "tablet=" << tablet->full_name();
         return OLAP_ERR_PREVIOUS_SCHEMA_CHANGE_NOT_FINISHED;
     }
@@ -68,7 +65,7 @@ OLAPStatus EngineClearAlterTask::_clear_alter_task(const TTabletId tablet_id,
 
     // clear related tablet's schema change info
     TabletSharedPtr related_tablet = StorageEngine::instance()->tablet_manager()->get_tablet(related_tablet_id, related_schema_hash);
-    if (related_tablet.get() == NULL) {
+    if (related_tablet == nullptr) {
         LOG(WARNING) << "related tablet not found when process clear alter task."
                      << " tablet_id=" << tablet_id << ", schema_hash=" << schema_hash
                      << ", related_tablet_id=" << related_tablet_id


### PR DESCRIPTION
In previous release, alter task will be handled when tablet under ALTER_FINISHED state.
Now, ALTER_FINISHED prohibits following alter task until clear_alter_task or drop_tablet
request clear alter_task belongs to tablet.