### PR TITLE
Add routine load job cleaner

### DIFF
--- a/fe/src/main/java/org/apache/doris/load/routineload/RoutineLoadTaskScheduler.java
+++ b/fe/src/main/java/org/apache/doris/load/routineload/RoutineLoadTaskScheduler.java
@@ -96,10 +96,10 @@ public class RoutineLoadTaskScheduler extends Daemon {
         int scheduledTaskNum = 0;
         // get idle be task num
         // allocate task to be
-        if (needScheduleTaskNum == 0) {
-            Thread.sleep(1000);
-            return;
-        }
+//        if (needScheduleTaskNum == 0) {
+//            Thread.sleep(1000);
+//            return;
+//        }
         while (needScheduleTaskNum > 0) {
             // allocate be to task and begin transaction for task
             RoutineLoadTaskInfo routineLoadTaskInfo = null;
@@ -107,7 +107,7 @@ public class RoutineLoadTaskScheduler extends Daemon {
                 routineLoadTaskInfo = needScheduleTasksQueue.take();
             } catch (InterruptedException e) {
                 LOG.warn("Taking routine load task from queue has been interrupted with error msg {}",
-                         e.getMessage());
+                         e.getMessage(),e);
                 return;
             }
             RoutineLoadJob routineLoadJob = null;
@@ -192,6 +192,7 @@ public class RoutineLoadTaskScheduler extends Daemon {
             if (routineLoadManager.checkBeToTask(routineLoadTaskInfo.getPreviousBeId(), routineLoadJob.getClusterName())) {
                 LOG.debug(new LogBuilder(LogKey.ROUINTE_LOAD_TASK, routineLoadTaskInfo.getId())
                                   .add("job_id", routineLoadJob.getId())
+                                  .add("previous_be_id", routineLoadTaskInfo.getPreviousBeId())
                                   .add("msg", "task use the previous be id")
                                   .build());
                 routineLoadTaskInfo.setBeId(routineLoadTaskInfo.getPreviousBeId());

--- a/fe/src/main/java/org/apache/doris/transaction/TransactionState.java
+++ b/fe/src/main/java/org/apache/doris/transaction/TransactionState.java
@@ -86,7 +86,27 @@ public class TransactionState implements Writable {
     
     public enum TxnStatusChangeReason {
         DB_DROPPED,
-        TIMEOUT
+        TIMEOUT,
+        OFFSET_OUT_OF_RANGE;
+
+        public static TxnStatusChangeReason fromString(String reasonString) {
+            for (TxnStatusChangeReason txnStatusChangeReason : TxnStatusChangeReason.values()) {
+                if (reasonString.contains(txnStatusChangeReason.toString())) {
+                    return txnStatusChangeReason;
+                }
+            }
+            return null;
+        }
+
+        @Override
+        public String toString() {
+            switch (this) {
+                case OFFSET_OUT_OF_RANGE:
+                    return "Offset out of range";
+                default:
+                    return this.name();
+            }
+        }
     }
     
     private long dbId;

--- a/fe/src/test/java/org/apache/doris/load/routineload/KafkaProducerTest.java
+++ b/fe/src/test/java/org/apache/doris/load/routineload/KafkaProducerTest.java
@@ -45,14 +45,12 @@ public class KafkaProducerTest {
     public static void main(String[] args) throws InterruptedException {
         KafkaProducerTest kafkaProducerTest = new KafkaProducerTest();
         Producer<Long, String> kafkaProducer = kafkaProducerTest.createProducer();
-        int i = 411;
+        int i = 1;
         while (true) {
             String value = String.valueOf(i);
-//            if (i % 5 == 0) {
-//                value = value + "\t" + value;
-//            } else if (i % 6 == 0) {
-//                value = value + "\t" + value;
-//            }
+            if (i % 10000 == 0) {
+                value = value + "\t" + value;
+            }
             ProducerRecord<Long, String> record = new ProducerRecord<>("miaoling", value);
             try {
                 RecordMetadata metadata = kafkaProducer.send(record).get();
@@ -65,8 +63,6 @@ public class KafkaProducerTest {
                 System.out.println(e);
             }
             i++;
-            Thread.sleep(500);
-
         }
     }
 


### PR DESCRIPTION
1. the stopped and cancelled job will be cleaned after the interval of clean second
2. the interval of clean second * 1000 = current timestamp - end timestamp
3. if job could not fetch topic metadata when need_schedule, job will be cancelled
4. fix the deadlock of job and txn. the lock of txn must be in front of the lock of job
5. the job will be paused or cancelled depend on the abort reason of txn
6. the job will be cancelled immediately if the abort reason named offsets out of range
