### PR TITLE
Add report queue size limit to avoid too many report requests

### DIFF
--- a/fe/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/src/main/java/org/apache/doris/common/Config.java
@@ -744,5 +744,19 @@ public class Config extends ConfigBase {
      */
     @ConfField(mutable = true, masterOnly = true)
     public static boolean disable_balance = false;
+    
+    // This threshold is to avoid piling up too many report task in FE, which may cause OOM exception.
+    // In some large Doris cluster, eg: 100 Backends with ten million replicas, a tablet report may cost
+    // several seconds after some modification of metadata(drop partition, etc..).
+    // And one Backend will report tablets info every 1 min, so unlimited receiving reports is unacceptable.
+    // TODO(cmy): we will optimize the processing speed of tablet report in future, but now, just discard
+    // the report if queue size exceeding limit.
+    // Some online time cost:
+    // 1. disk report: 0-1 ms
+    // 2. task report: 0-1 ms
+    // 3. tablet report 
+    //      10000 replicas: 200ms
+    @ConfField(mutable = true, masterOnly = true)
+    public static int report_queue_size = 100;
 }
 

--- a/fe/src/main/java/org/apache/doris/metric/MetricRepo.java
+++ b/fe/src/main/java/org/apache/doris/metric/MetricRepo.java
@@ -312,5 +312,10 @@ public final class MetricRepo {
 
         return sb.toString();
     }
+
+    public static void addMetric(Metric<?> metric) {
+        init();
+        PALO_METRIC_REGISTER.addPaloMetrics(metric);
+    }
 }
 


### PR DESCRIPTION
Add a limit of report queue size to avoid this problem.
ISSUE: #845 