### PR TITLE
Add new keyword in ident (include keyword)

### DIFF
--- a/fe/src/main/cup/sql_parser.cup
+++ b/fe/src/main/cup/sql_parser.cup
@@ -3964,26 +3964,36 @@ keyword ::=
     | KW_WORK:id
     {: RESULT = id; :}
     | KW_CLUSTER:id
-	{: RESULT = id; :}
- 	| KW_CLUSTERS:id
-	{: RESULT = id; :} 
+    {: RESULT = id; :}
+    | KW_CLUSTERS:id
+    {: RESULT = id; :}
     | KW_LINK:id
-	{: RESULT = id; :}
+    {: RESULT = id; :}
     | KW_MIGRATE:id
-	{: RESULT = id; :}
-	| KW_MIGRATIONS:id
-	{: RESULT = id; :}
-	| KW_COUNT:id
-	{: RESULT = id; :}
-	| KW_SUM:id
-	{: RESULT = id; :}
-	| KW_MIN:id
-	{: RESULT = id; :}
-	| KW_MAX:id
-	{: RESULT = id; :}
-	| KW_FREE:id
-	{: RESULT = id; :}
-	;
+    {: RESULT = id; :}
+    | KW_MIGRATIONS:id
+    {: RESULT = id; :}
+    | KW_COUNT:id
+    {: RESULT = id; :}
+    | KW_SUM:id
+    {: RESULT = id; :}
+    | KW_MIN:id
+    {: RESULT = id; :}
+    | KW_MAX:id
+    {: RESULT = id; :}
+    | KW_FREE:id
+    {: RESULT = id; :}
+    | KW_TASK:id
+    {: RESULT = id; :}
+    | KW_ROUTINE:id
+    {: RESULT = id; :}
+    | KW_PAUSE:id
+    {: RESULT = id; :}
+    | KW_RESUME:id
+    {: RESULT = id; :}
+    | KW_STOP:id
+    {: RESULT = id; :}
+    ;
 
 // Identifier that contain keyword
 ident ::=


### PR DESCRIPTION
1. new keyword is added in ident in order to avoid syntax error when keyword is a string