### PR TITLE
Fix AlphaRowsetWriter double flush problem

### DIFF
--- a/be/src/olap/memtable.cpp
+++ b/be/src/olap/memtable.cpp
@@ -152,13 +152,16 @@ void MemTable::insert(Tuple* tuple) {
 
 OLAPStatus MemTable::flush(RowsetWriterSharedPtr rowset_writer) {
     Table::Iterator it(_skip_list);
+    bool need_flush = false;
     for (it.SeekToFirst(); it.Valid(); it.Next()) {
         const char* row = it.key();
         _schema->finalize(row);
         RETURN_NOT_OK(rowset_writer->add_row(row, _schema));
+        need_flush = true;
     }
-
-    RETURN_NOT_OK(rowset_writer->flush());
+    if (need_flush) {
+        RETURN_NOT_OK(rowset_writer->flush());
+    }
     return OLAP_SUCCESS;
 }
 

--- a/be/src/olap/rowset/alpha_rowset_writer.h
+++ b/be/src/olap/rowset/alpha_rowset_writer.h
@@ -67,14 +67,14 @@ private:
 
 private:
     int32_t _segment_group_id;
-    std::shared_ptr<SegmentGroup> _cur_segment_group;
+    SegmentGroup* _cur_segment_group;
     ColumnDataWriter* _column_data_writer;
     std::shared_ptr<RowsetMeta> _current_rowset_meta;
     bool _is_pending_rowset;
     int _num_rows_written;
     bool _is_inited;
     RowsetWriterContext _rowset_writer_context;
-    std::vector<std::shared_ptr<SegmentGroup>> _segment_groups;
+    std::vector<SegmentGroup*> _segment_groups;
     bool _rowset_build;
 };
 


### PR DESCRIPTION
When the memtable is flushed(this will call AlphaRowsetWriter.flush), and there is no data written any more. memtable will call close, leading to double call AlphaRowsetWriter.flush without call  AlphaRowsetWriter.init. It will lead to DCHECK failure.