### PR TITLE
Optimize the consumer assignment of Kafka routine load job

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -393,6 +393,9 @@ namespace config {
 
     // txn commit rpc timeout
     CONF_Int32(txn_commit_rpc_timeout_ms, "10000");
+
+    // max consumer num in one data consumer group, for routine load
+    CONF_Int32(max_consumer_num_per_group, "1");
 } // namespace config
 
 } // namespace doris

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -395,7 +395,7 @@ namespace config {
     CONF_Int32(txn_commit_rpc_timeout_ms, "10000");
 
     // max consumer num in one data consumer group, for routine load
-    CONF_Int32(max_consumer_num_per_group, "1");
+    CONF_Int32(max_consumer_num_per_group, "3");
 } // namespace config
 
 } // namespace doris

--- a/be/src/runtime/CMakeLists.txt
+++ b/be/src/runtime/CMakeLists.txt
@@ -98,6 +98,7 @@ add_library(Runtime STATIC
   stream_load/stream_load_context.cpp
   stream_load/stream_load_executor.cpp
   routine_load/data_consumer.cpp
+  routine_load/data_consumer_group.cpp
   routine_load/data_consumer_pool.cpp
   routine_load/routine_load_task_executor.cpp
 )

--- a/be/src/runtime/routine_load/data_consumer.cpp
+++ b/be/src/runtime/routine_load/data_consumer.cpp
@@ -103,7 +103,7 @@ Status KafkaDataConsumer::assign_topic_partitions(
         RdKafka::TopicPartition* tp1 = RdKafka::TopicPartition::create(
                 topic, entry.first, entry.second);
         topic_partitions.push_back(tp1);
-        ss << "partition[" << entry.first << "-" << entry.second << "] ";
+        ss << "partition[" << entry.first << ": " << entry.second << "] ";
     }
 
     VLOG(1) << "assign topic partitions: " << topic << ", " << ss.str();

--- a/be/src/runtime/routine_load/data_consumer.cpp
+++ b/be/src/runtime/routine_load/data_consumer.cpp
@@ -23,8 +23,6 @@
 #include <vector>
 
 #include "common/status.h"
-#include "runtime/stream_load/stream_load_pipe.h"
-#include "runtime/routine_load/kafka_consumer_pipe.h"
 #include "service/backend_options.h"
 #include "util/defer_op.h"
 #include "util/stopwatch.hpp"
@@ -92,20 +90,23 @@ Status KafkaDataConsumer::init(StreamLoadContext* ctx) {
     return Status::OK;
 }
 
-Status KafkaDataConsumer::assign_topic_partitions(StreamLoadContext* ctx) {
+Status KafkaDataConsumer::assign_topic_partitions(
+        const std::map<int32_t, int64_t>& begin_partition_offset,
+        const std::string& topic,
+        StreamLoadContext* ctx) {
+
     DCHECK(_k_consumer);
     // create TopicPartitions
     std::stringstream ss;
     std::vector<RdKafka::TopicPartition*> topic_partitions;
-    for (auto& entry : ctx->kafka_info->begin_offset) {
+    for (auto& entry : begin_partition_offset) {
         RdKafka::TopicPartition* tp1 = RdKafka::TopicPartition::create(
-                ctx->kafka_info->topic, entry.first, entry.second);
+                topic, entry.first, entry.second);
         topic_partitions.push_back(tp1);
         ss << "partition[" << entry.first << "-" << entry.second << "] ";
     }
 
-    VLOG(1) << "assign topic partitions: " << ctx->kafka_info->topic
-        << ", " << ss.str();
+    VLOG(1) << "assign topic partitions: " << topic << ", " << ss.str();
 
     // delete TopicPartition finally
     auto tp_deleter = [&topic_partitions] () {
@@ -125,70 +126,21 @@ Status KafkaDataConsumer::assign_topic_partitions(StreamLoadContext* ctx) {
     return Status::OK;
 }
 
-Status KafkaDataConsumer::start(StreamLoadContext* ctx) {
-    {
-        std::unique_lock<std::mutex> l(_lock);
-        if (!_init) {
-            return Status("consumer is not initialized");
-        }
-    }
-    
+void KafkaDataConsumer::group_consume(
+        BlockingQueue<RdKafka::Message*>* queue,
+        int64_t max_running_time_ms) {
     _last_visit_time = time(nullptr);
+    int64_t left_time = max_running_time_ms;
+    LOG(INFO) << "start kafka consumer: " << _id << ", grp: " << _grp_id
+            << ", max running time(ms): " << left_time;
 
-    int64_t left_time = ctx->max_interval_s * 1000;
-    int64_t left_rows = ctx->max_batch_rows;
-    int64_t left_bytes = ctx->max_batch_size;
-
-    std::shared_ptr<KafkaConsumerPipe> kakfa_pipe = std::static_pointer_cast<KafkaConsumerPipe>(ctx->body_sink);
-
-    LOG(INFO) << "start consumer"
-        << ". max time(ms): " << left_time
-        << ", batch rows: " << left_rows
-        << ", batch size: " << left_bytes
-        << ". " << ctx->brief();
-
-    // copy one
-    std::map<int32_t, int64_t> cmt_offset = ctx->kafka_info->cmt_offset;
     MonotonicStopWatch consumer_watch;
     MonotonicStopWatch watch;
     watch.start();
-    Status st;
     while (true) {
         std::unique_lock<std::mutex> l(_lock);
-        if (_cancelled) {
-            kakfa_pipe ->cancel();
-            return Status::CANCELLED;
-        }
-
-        if (_finished) {
-            kakfa_pipe ->finish();
-            ctx->kafka_info->cmt_offset = std::move(cmt_offset); 
-            return Status::OK;
-        }
-
-        if (left_time <= 0 || left_rows <= 0 || left_bytes <=0) {
-            LOG(INFO) << "kafka consume batch done"
-                    << ". consume time(ms)=" << ctx->max_interval_s * 1000 - left_time
-                    << ", received rows=" << ctx->max_batch_rows - left_rows
-                    << ", received bytes=" << ctx->max_batch_size - left_bytes
-                    << ", kafka consume time(ms)=" << consumer_watch.elapsed_time() / 1000 / 1000;
-
-
-            if (left_bytes == ctx->max_batch_size) {
-                // nothing to be consumed, cancel it
-                // we do not allow finishing stream load pipe without data
-                kakfa_pipe->cancel();
-                _cancelled = true;
-                return Status::CANCELLED;
-            } else {
-                DCHECK(left_bytes < ctx->max_batch_size);
-                DCHECK(left_rows < ctx->max_batch_rows);
-                kakfa_pipe->finish();
-                ctx->kafka_info->cmt_offset = std::move(cmt_offset); 
-                ctx->receive_bytes = ctx->max_batch_size - left_bytes;
-                _finished = true;
-                return Status::OK;
-            }
+        if (_cancelled || left_time <= 0) {
+            break;
         }
 
         // consume 1 message at a time
@@ -197,44 +149,33 @@ Status KafkaDataConsumer::start(StreamLoadContext* ctx) {
         consumer_watch.stop();
         switch (msg->err()) {
             case RdKafka::ERR_NO_ERROR:
-                VLOG(3) << "get kafka message"
-                        << ", partition: " << msg->partition()
-                        << ", offset: " << msg->offset()
-                        << ", len: " << msg->len();
-
-                st = kakfa_pipe ->append_with_line_delimiter(
-                        static_cast<const char *>(msg->payload()),
-                        static_cast<size_t>(msg->len()));
-                if (st.ok()) {
-                    left_rows--;
-                    left_bytes -= msg->len();
-                    cmt_offset[msg->partition()] = msg->offset();
-                    VLOG(3) << "consume partition[" << msg->partition()
-                            << " - " << msg->offset() << "]";
+                if (!queue->blocking_put(msg)) {
+                    // queue is shutdown
+                    _cancelled = true;
                 }
-
                 break;
             case RdKafka::ERR__TIMED_OUT:
                 // leave the status as OK, because this may happend
                 // if there is no data in kafka.
-                LOG(WARNING) << "kafka consume timeout";
+                LOG(WARNING) << "kafka consume timeout: " << _id;
                 break;
             default:
-                LOG(WARNING) << "kafka consume failed: " << msg->errstr();
-                st = Status(msg->errstr());
+                LOG(WARNING) << "kafka consume failed: " << _id
+                        << ", msg: " << msg->errstr();
+                _cancelled = true;
                 break;
         }
-        delete msg; 
 
-        if (!st.ok()) {
-            kakfa_pipe ->cancel();
-            return st;
-        }
-
-        left_time = ctx->max_interval_s * 1000 - watch.elapsed_time() / 1000 / 1000;
+        left_time = max_running_time_ms - watch.elapsed_time() / 1000 / 1000;
     }
 
-    return Status::OK;
+    LOG(INFO) << "kafka conumer done: " << _id << ", grp: " << _grp_id
+            << ". cancelled: " << _cancelled
+            << ", left time(ms): " << left_time
+            << ", total cost(ms): " << watch.elapsed_time() / 1000 / 1000
+            << ", consume cost(ms): " << consumer_watch.elapsed_time() / 1000 / 1000;
+
+    return;
 }
 
 Status KafkaDataConsumer::cancel(StreamLoadContext* ctx) {
@@ -243,17 +184,12 @@ Status KafkaDataConsumer::cancel(StreamLoadContext* ctx) {
         return Status("consumer is not initialized");
     }
 
-    if (_finished) {
-        return Status("consumer is already finished");
-    }
-
     _cancelled = true;
     return Status::OK;
 }
 
 Status KafkaDataConsumer::reset() {
     std::unique_lock<std::mutex> l(_lock);
-    _finished = false;
     _cancelled = false;
     return Status::OK;
 }

--- a/be/src/runtime/routine_load/data_consumer.h
+++ b/be/src/runtime/routine_load/data_consumer.h
@@ -139,7 +139,7 @@ public:
             StreamLoadContext* ctx);
 
     // start the consumer and put msgs to queue
-    void group_consume(BlockingQueue<RdKafka::Message*>* queue, int64_t max_running_time_ms);
+    Status group_consume(BlockingQueue<RdKafka::Message*>* queue, int64_t max_running_time_ms);
 
 private:
     std::string _brokers;

--- a/be/src/runtime/routine_load/data_consumer_group.cpp
+++ b/be/src/runtime/routine_load/data_consumer_group.cpp
@@ -95,7 +95,9 @@ Status KafkaDataConsumerGroup::start_all(StreamLoadContext* ctx) {
                     << ". consume time(ms)=" << ctx->max_interval_s * 1000 - left_time
                     << ", received rows=" << ctx->max_batch_rows - left_rows
                     << ", received bytes=" << ctx->max_batch_size - left_bytes
-                    << ", eos: " << eos;
+                    << ", eos: " << eos
+                    << ", blocking get time(us): " << _queue.total_get_wait_time() / 1000
+                    << ", blocking put time(us): " << _queue.total_put_wait_time() / 1000;
             
             // shutdown queue
             _queue.shutdown();

--- a/be/src/runtime/routine_load/data_consumer_group.cpp
+++ b/be/src/runtime/routine_load/data_consumer_group.cpp
@@ -1,0 +1,170 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+
+#include "runtime/routine_load/data_consumer_group.h"
+#include "runtime/routine_load/kafka_consumer_pipe.h"
+
+namespace doris {
+
+Status KafkaDataConsumerGroup::assign_topic_partitions(StreamLoadContext* ctx) {
+    DCHECK(ctx->kafka_info);
+    DCHECK(_consumers.size() >= 1);
+
+    // divide partitions
+    int consumer_size = _consumers.size();
+    std::vector<std::map<int32_t, int64_t>> divide_parts(consumer_size);
+    int i = 0;
+    for (auto& kv : ctx->kafka_info->begin_offset) {
+        int idx = i % consumer_size;
+        divide_parts[idx].emplace(kv.first, kv.second);
+        i++;
+    }
+
+    // assign partitions to consumers equally
+    for (int i = 0; i < consumer_size; ++i) {
+        RETURN_IF_ERROR(std::static_pointer_cast<KafkaDataConsumer>(_consumers[i])->assign_topic_partitions(
+                divide_parts[i], ctx->kafka_info->topic, ctx));
+    }
+
+    return Status::OK;
+}
+
+Status KafkaDataConsumerGroup::start_all(StreamLoadContext* ctx) {
+    // start all consumers
+    for(auto& consumer : _consumers) {
+        if (!_thread_pool.offer(
+            boost::bind<void>(&KafkaDataConsumerGroup::actual_consume, this, consumer, &_queue, ctx->max_interval_s * 1000,
+            [this] () { 
+                std::unique_lock<std::mutex> lock(_mutex);
+                _counter--;
+                if (_counter == 0) {
+                    _queue.shutdown();
+                    LOG(INFO) << "all consumers are finished. shutdown queue. group id: " << _grp_id;
+                } 
+            }))) {
+
+            LOG(WARNING) << "failed to submit data consumer: " << consumer->id();
+            return Status("failed to submit data consumer");
+        } else {
+            VLOG(1) << "submit a data consumer: " << consumer->id();
+        }
+    }
+
+    // consuming from queue and put data to stream load pipe
+    int64_t left_time = ctx->max_interval_s * 1000;
+    int64_t left_rows = ctx->max_batch_rows;
+    int64_t left_bytes = ctx->max_batch_size;
+
+    std::shared_ptr<KafkaConsumerPipe> kafka_pipe = std::static_pointer_cast<KafkaConsumerPipe>(ctx->body_sink);
+
+    LOG(INFO) << "start consumer group: " << _grp_id
+        << ". max time(ms): " << left_time
+        << ", batch rows: " << left_rows
+        << ", batch size: " << left_bytes
+        << ". " << ctx->brief();
+
+    // copy one
+    std::map<int32_t, int64_t> cmt_offset = ctx->kafka_info->cmt_offset;
+
+    MonotonicStopWatch watch;
+    watch.start();
+    Status st;
+    bool eos = false;
+    while (true) {
+        if (eos || left_time <= 0 || left_rows <= 0 || left_bytes <=0) {
+            LOG(INFO) << "consumer group done: " << _grp_id
+                    << ". consume time(ms)=" << ctx->max_interval_s * 1000 - left_time
+                    << ", received rows=" << ctx->max_batch_rows - left_rows
+                    << ", received bytes=" << ctx->max_batch_size - left_bytes
+                    << ", eos: " << eos;
+            
+            // shutdown queue
+            _queue.shutdown();
+            // cancel all consumers
+            for(auto& consumer : _consumers) { consumer->cancel(ctx); }
+            // clean the msgs left in queue
+            while(true) {
+                RdKafka::Message* msg;
+                if (_queue.blocking_get(&msg)) {
+                    delete msg;
+                    msg = nullptr;
+                } else {
+                    break;
+                }
+            }
+            DCHECK(_queue.get_size() == 0);
+
+            if (left_bytes == ctx->max_batch_size) {
+                // nothing to be consumed, we have to cancel it, because
+                // we do not allow finishing stream load pipe without data
+                kafka_pipe->cancel();
+                return Status::CANCELLED;
+            } else {
+                DCHECK(left_bytes < ctx->max_batch_size);
+                DCHECK(left_rows < ctx->max_batch_rows);
+                kafka_pipe->finish();
+                ctx->kafka_info->cmt_offset = std::move(cmt_offset);
+                ctx->receive_bytes = ctx->max_batch_size - left_bytes;
+                return Status::OK;
+            }
+        }
+
+        RdKafka::Message* msg;
+        bool res = _queue.blocking_get(&msg);
+        if (res) {
+            VLOG(3) << "get kafka message"
+                << ", partition: " << msg->partition()
+                << ", offset: " << msg->offset()
+                << ", len: " << msg->len();
+
+            st = kafka_pipe->append_with_line_delimiter(
+                    static_cast<const char *>(msg->payload()),
+                    static_cast<size_t>(msg->len()));
+            if (st.ok()) {
+                left_rows--;
+                left_bytes -= msg->len();
+                cmt_offset[msg->partition()] = msg->offset();
+                VLOG(3) << "consume partition[" << msg->partition()
+                    << " - " << msg->offset() << "]";
+            } else {
+                // failed to append this msg, we must stop
+                LOG(WARNING) << "failed to append msg to pipe";
+                eos = true;
+            }
+            delete msg;
+        } else {
+            // queue is empty and shutdown
+            eos = true;   
+        }
+
+        left_time = ctx->max_interval_s * 1000 - watch.elapsed_time() / 1000 / 1000;
+    }
+
+    return Status::OK;
+}
+
+void KafkaDataConsumerGroup::actual_consume(
+        std::shared_ptr<DataConsumer> consumer,
+        BlockingQueue<RdKafka::Message*>* queue,
+        int64_t max_running_time_ms,
+        ConsumeFinishCallback cb) {
+    std::static_pointer_cast<KafkaDataConsumer>(consumer)->group_consume(queue, max_running_time_ms);
+    cb();
+}
+
+} // end namespace

--- a/be/src/runtime/routine_load/data_consumer_group.h
+++ b/be/src/runtime/routine_load/data_consumer_group.h
@@ -1,0 +1,94 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include "runtime/routine_load/data_consumer.h"
+#include "util/blocking_queue.hpp"
+#include "util/thread_pool.hpp"
+
+namespace doris {
+
+// data consumer group saves a group of data consumers.
+// These data consumers share the same stream load pipe.
+// This class is not thread safe.
+class DataConsumerGroup {
+public:
+    typedef std::function<void ()> ConsumeFinishCallback;
+
+    DataConsumerGroup():
+        _thread_pool(3, 0) {}
+
+    virtual ~DataConsumerGroup() {
+        _consumers.clear();
+    }
+
+    const UniqueId& grp_id() { return _grp_id; }
+
+    const std::vector<std::shared_ptr<DataConsumer>>& consumers() {
+        return _consumers;
+    }
+
+    void add_consumer(std::shared_ptr<DataConsumer> consumer) {
+        consumer->set_grp(_grp_id);
+        _consumers.push_back(consumer);
+        ++_counter;
+    }
+
+    // start all consumers
+    virtual Status start_all(StreamLoadContext* ctx) { return Status::OK; }
+
+protected:
+    UniqueId _grp_id;
+    std::vector<std::shared_ptr<DataConsumer>> _consumers;
+    // thread pool to run each consumer in multi thread
+    ThreadPool _thread_pool;
+    // mutex to protect counter.
+    // the counter is init as the number of consumers.
+    // once a consumer is done, decrease the counter.
+    // when the counter becomes zero, shutdown the queue to finish
+    std::mutex _mutex;
+    int _counter;
+};
+
+// for kafka
+class KafkaDataConsumerGroup : public DataConsumerGroup {
+public:
+    KafkaDataConsumerGroup():
+        DataConsumerGroup(),
+        _queue(500) {}
+
+    virtual ~KafkaDataConsumerGroup() {}
+
+    virtual Status start_all(StreamLoadContext* ctx) override;
+    // assign topic partitions to all consumers equally
+    Status assign_topic_partitions(StreamLoadContext* ctx);
+
+private:
+    // start a single consumer
+    void actual_consume(
+            std::shared_ptr<DataConsumer> consumer,
+            BlockingQueue<RdKafka::Message*>* queue,
+            int64_t max_running_time_ms,
+            ConsumeFinishCallback cb);
+
+private:
+    // blocking queue to receive msgs from all consumers
+    BlockingQueue<RdKafka::Message*> _queue; 
+};
+
+} // end namespace doris

--- a/be/src/runtime/routine_load/data_consumer_group.h
+++ b/be/src/runtime/routine_load/data_consumer_group.h
@@ -28,10 +28,10 @@ namespace doris {
 // This class is not thread safe.
 class DataConsumerGroup {
 public:
-    typedef std::function<void ()> ConsumeFinishCallback;
+    typedef std::function<void (const Status&)> ConsumeFinishCallback;
 
     DataConsumerGroup():
-        _thread_pool(3, 0) {}
+        _thread_pool(3, 10) {}
 
     virtual ~DataConsumerGroup() {
         _consumers.clear();

--- a/be/src/runtime/routine_load/data_consumer_pool.cpp
+++ b/be/src/runtime/routine_load/data_consumer_pool.cpp
@@ -17,6 +17,7 @@
 
 #include "runtime/routine_load/data_consumer_pool.h"
 #include "runtime/routine_load/data_consumer_group.h"
+#include "common/config.h"
 
 namespace doris {
 
@@ -71,8 +72,9 @@ Status DataConsumerPool::get_consumer_grp(
 
     std::shared_ptr<KafkaDataConsumerGroup> grp = std::make_shared<KafkaDataConsumerGroup>();
 
-    // one data consumer group contains at most 3 data consumers.
-    size_t consumer_num = std::min((size_t) 3, ctx->kafka_info->begin_offset.size());
+    // one data consumer group contains at least one data consumers.
+    int max_consumer_num = config::max_consumer_num_per_group;
+    size_t consumer_num = std::min((size_t) max_consumer_num, ctx->kafka_info->begin_offset.size());
     for (int i = 0; i < consumer_num; ++i) {
         std::shared_ptr<DataConsumer> consumer;
         RETURN_IF_ERROR(get_consumer(ctx, &consumer));

--- a/be/src/runtime/routine_load/data_consumer_pool.cpp
+++ b/be/src/runtime/routine_load/data_consumer_pool.cpp
@@ -69,7 +69,7 @@ Status DataConsumerPool::get_consumer_grp(
     }
     DCHECK(ctx->kafka_info);
 
-    std::shared_ptr<KafkaDataConsumerGroup> grp = std::make_shared<KafkaDataConsumerGroup>(ctx);;
+    std::shared_ptr<KafkaDataConsumerGroup> grp = std::make_shared<KafkaDataConsumerGroup>();
 
     // one data consumer group contains at most 3 data consumers.
     size_t consumer_num = std::min((size_t) 3, ctx->kafka_info->begin_offset.size());

--- a/be/src/runtime/routine_load/data_consumer_pool.h
+++ b/be/src/runtime/routine_load/data_consumer_pool.h
@@ -28,6 +28,7 @@
 namespace doris {
 
 class DataConsumer;
+class DataConsumerGroup;
 class Status;
 
 // DataConsumerPool saves all available data consumer
@@ -47,8 +48,15 @@ public:
         StreamLoadContext* ctx,
         std::shared_ptr<DataConsumer>* ret);
 
-    // erase the specified cache
+    // get several consumers and put them into group
+    Status get_consumer_grp(
+        StreamLoadContext* ctx,
+        std::shared_ptr<DataConsumerGroup>* ret);
+
+    // return the consumer to the pool
     void return_consumer(std::shared_ptr<DataConsumer> consumer);
+    // return the consumers in consumer group to the pool
+    void return_consumers(DataConsumerGroup* grp);
 
     Status start_bg_worker();
 

--- a/be/src/runtime/routine_load/routine_load_task_executor.h
+++ b/be/src/runtime/routine_load/routine_load_task_executor.h
@@ -38,7 +38,6 @@ class TRoutineLoadTask;
 // to FE finally.
 class RoutineLoadTaskExecutor {
 public:
-    // paramater: task id
     typedef std::function<void (StreamLoadContext*)> ExecFinishCallback; 
 
     RoutineLoadTaskExecutor(ExecEnv* exec_env):

--- a/be/src/runtime/stream_load/stream_load_context.cpp
+++ b/be/src/runtime/stream_load/stream_load_context.cpp
@@ -76,7 +76,7 @@ std::string StreamLoadContext::to_json() const {
 
 std::string StreamLoadContext::brief(bool detail) const {
     std::stringstream ss;
-    ss << "id=" << id << ", txn id=" << txn_id << ", label=" << label;
+    ss << "id=" << id << ", job id=" << job_id << ", txn id=" << txn_id << ", label=" << label;
     if (detail) {
         switch(load_src_type) {
             case TLoadSourceType::KAFKA:

--- a/be/src/util/semaphore.hpp
+++ b/be/src/util/semaphore.hpp
@@ -1,0 +1,50 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <mutex>
+#include <condition_variable>
+
+namespace {
+
+class Semaphore {
+    public:
+        explicit Semaphore(int count = 0) : _count(count) {
+        }
+
+        void set_count(int count) { _count = count; }
+
+        void signal() {
+            std::unique_lock<std::mutex> lock(_mutex);
+            ++count_;
+            cv_.notify_one();
+        }
+
+        void wait() {
+            std::unique_lock<std::mutex> lock(_mutex);
+            cv_.wait(lock, [=] { return _count > 0; });
+            --_count;
+        }
+
+    private:
+        std::mutex _mutex;
+        std::condition_variable _cv;
+        int _count;
+};
+
+} // end namespace

--- a/docs/help/Contents/Data Manipulation/routine_load.md
+++ b/docs/help/Contents/Data Manipulation/routine_load.md
@@ -146,11 +146,17 @@
 
             3. kafka_partitions/kafka_offsets
 
-                指定需要订阅的 kafka partition，以及对应的每个 partition 的起始 offset。如果没有指定，则默认从 0 开始订阅 topic 下的所有 partition。
+                指定需要订阅的 kafka partition，以及对应的每个 partition 的起始 offset。
+
+                offset 可以指定从大于等于 0 的具体 offset，或者：
+                1) OFFSET_BEGINNING: 从有数据的位置开始订阅。
+                2) OFFSET_END: 从末尾开始订阅。
+
+                如果没有指定，则默认从 OFFSET_END 开始订阅 topic 下的所有 partition。
                 示例：
 
                     "kafka_partitions" = "0,1,2,3",
-                    "kafka_offsets" = "101,0,0,200"
+                    "kafka_offsets" = "101,0,OFFSET_BEGINNING,OFFSET_END"
 
 
     7. 导入数据格式样例

--- a/docs/help/Contents/Data Manipulation/routine_load.md
+++ b/docs/help/Contents/Data Manipulation/routine_load.md
@@ -33,7 +33,7 @@
 
             指定列分隔符，如：
 
-                COLUMN TERMINATED BY ","
+                COLUMNS TERMINATED BY ","
 
             默认为：\t
 

--- a/fe/src/main/java/org/apache/doris/analysis/CreateRoutineLoadStmt.java
+++ b/fe/src/main/java/org/apache/doris/analysis/CreateRoutineLoadStmt.java
@@ -384,9 +384,9 @@ public class CreateRoutineLoadStmt extends DdlStmt {
                     }
                 } catch (AnalysisException e) {
                     if (kafkaOffsetsStringList[i].equalsIgnoreCase(KafkaProgress.OFFSET_BEGINNING)) {
-                        kafkaPartitionOffsets.get(i).second = -2L;
+                        kafkaPartitionOffsets.get(i).second = KafkaProgress.OFFSET_BEGINNING_VAL;
                     } else if (kafkaOffsetsStringList[i].equalsIgnoreCase(KafkaProgress.OFFSET_END)) {
-                        kafkaPartitionOffsets.get(i).second = -1L;
+                        kafkaPartitionOffsets.get(i).second = KafkaProgress.OFFSET_END_VAL;
                     } else {
                         throw e;
                     }

--- a/fe/src/main/java/org/apache/doris/analysis/CreateRoutineLoadStmt.java
+++ b/fe/src/main/java/org/apache/doris/analysis/CreateRoutineLoadStmt.java
@@ -23,6 +23,7 @@ import org.apache.doris.common.Pair;
 import org.apache.doris.common.UserException;
 import org.apache.doris.common.util.Util;
 import org.apache.doris.load.RoutineLoadDesc;
+import org.apache.doris.load.routineload.KafkaProgress;
 import org.apache.doris.load.routineload.LoadDataSourceType;
 import org.apache.doris.load.routineload.RoutineLoadJob;
 
@@ -372,8 +373,24 @@ public class CreateRoutineLoadStmt extends DdlStmt {
             }
 
             for (int i = 0; i < kafkaOffsetsStringList.length; i++) {
-                kafkaPartitionOffsets.get(i).second = getLongValueFromString(kafkaOffsetsStringList[i],
-                        KAFKA_OFFSETS_PROPERTY);
+                // defined in librdkafka/rdkafkacpp.h
+                // OFFSET_BEGINNING: -2
+                // OFFSET_END: -1
+                try {
+                    kafkaPartitionOffsets.get(i).second = getLongValueFromString(kafkaOffsetsStringList[i],
+                            KAFKA_OFFSETS_PROPERTY);
+                    if (kafkaPartitionOffsets.get(i).second < 0) {
+                        throw new AnalysisException("Cannot specify offset smaller than 0");
+                    }
+                } catch (AnalysisException e) {
+                    if (kafkaOffsetsStringList[i].equalsIgnoreCase(KafkaProgress.OFFSET_BEGINNING)) {
+                        kafkaPartitionOffsets.get(i).second = -2L;
+                    } else if (kafkaOffsetsStringList[i].equalsIgnoreCase(KafkaProgress.OFFSET_END)) {
+                        kafkaPartitionOffsets.get(i).second = -1L;
+                    } else {
+                        throw e;
+                    }
+                }
             }
         }
     }

--- a/fe/src/main/java/org/apache/doris/load/LoadChecker.java
+++ b/fe/src/main/java/org/apache/doris/load/LoadChecker.java
@@ -28,7 +28,7 @@ import org.apache.doris.catalog.Replica;
 import org.apache.doris.catalog.Tablet;
 import org.apache.doris.catalog.TabletInvertedIndex;
 import org.apache.doris.common.Config;
-import org.apache.doris.common.MetaNotFoundException;
+import org.apache.doris.common.UserException;
 import org.apache.doris.common.util.Daemon;
 import org.apache.doris.load.AsyncDeleteJob.DeleteState;
 import org.apache.doris.load.FailMsg.CancelType;
@@ -52,7 +52,6 @@ import org.apache.doris.thrift.TPushType;
 import org.apache.doris.thrift.TTaskType;
 import org.apache.doris.transaction.GlobalTransactionMgr;
 import org.apache.doris.transaction.TabletCommitInfo;
-import org.apache.doris.transaction.TransactionException;
 import org.apache.doris.transaction.TransactionState;
 import org.apache.doris.transaction.TransactionStatus;
 
@@ -330,7 +329,7 @@ public class LoadChecker extends Daemon {
                 tabletCommitInfos.add(new TabletCommitInfo(tabletId, replica.getBackendId()));
             }
             globalTransactionMgr.commitTransaction(job.getDbId(), job.getTransactionId(), tabletCommitInfos);
-        } catch (MetaNotFoundException | TransactionException e) {
+        } catch (UserException e) {
             LOG.warn("errors while commit transaction [{}], cancel the job {}, reason is {}", 
                     transactionState.getTransactionId(), job, e);
             load.cancelLoadJob(job, CancelType.UNKNOWN, transactionState.getReason());

--- a/fe/src/main/java/org/apache/doris/load/routineload/KafkaProgress.java
+++ b/fe/src/main/java/org/apache/doris/load/routineload/KafkaProgress.java
@@ -91,9 +91,7 @@ public class KafkaProgress extends RoutineLoadProgress {
     // OFFSET_END: user set offset = OFFSET_END, no committed msg
     // OFFSET_BEGINNING: user set offset = OFFSET_BEGINNING, no committed msg
     // other: current committed msg's offset
-    @Override
-    public String toString() {
-        Map<Integer, String> showPartitionIdToOffset = Maps.newHashMap();
+    private void getReadableProgress(Map<Integer, String> showPartitionIdToOffset) {
         for (Map.Entry<Integer, Long> entry : partitionIdToOffset.entrySet()) {
             if (entry.getValue() == 0) {
                 showPartitionIdToOffset.put(entry.getKey(), OFFSET_ZERO);
@@ -105,8 +103,22 @@ public class KafkaProgress extends RoutineLoadProgress {
                 showPartitionIdToOffset.put(entry.getKey(), "" + (entry.getValue() - 1));
             }
         }
+    }
+
+    @Override
+    public String toString() {
+        Map<Integer, String> showPartitionIdToOffset = Maps.newHashMap();
+        getReadableProgress(showPartitionIdToOffset);
         return "KafkaProgress [partitionIdToOffset="
                 + Joiner.on("|").withKeyValueSeparator("_").join(showPartitionIdToOffset) + "]";
+    }
+
+    @Override
+    public String toJsonString() {
+        Map<Integer, String> showPartitionIdToOffset = Maps.newHashMap();
+        getReadableProgress(showPartitionIdToOffset);
+        Gson gson = new Gson();
+        return gson.toJson(showPartitionIdToOffset);
     }
 
     @Override
@@ -115,16 +127,6 @@ public class KafkaProgress extends RoutineLoadProgress {
         // + 1 to point to the next msg offset to be consumed
         newProgress.partitionIdToOffset.entrySet().stream()
                 .forEach(entity -> this.partitionIdToOffset.put(entity.getKey(), entity.getValue() + 1));
-    }
-
-    @Override
-    public String toJsonString() {
-        Map<Integer, Long> showPartitionIdToOffset = new HashMap<>();
-        for (Map.Entry<Integer, Long> entry : partitionIdToOffset.entrySet()) {
-            showPartitionIdToOffset.put(entry.getKey(), entry.getValue() - 1);
-        }
-        Gson gson = new Gson();
-        return gson.toJson(showPartitionIdToOffset);
     }
 
     @Override

--- a/fe/src/main/java/org/apache/doris/load/routineload/KafkaProgress.java
+++ b/fe/src/main/java/org/apache/doris/load/routineload/KafkaProgress.java
@@ -17,12 +17,12 @@
 
 package org.apache.doris.load.routineload;
 
-import com.google.gson.Gson;
 import org.apache.doris.common.Pair;
 import org.apache.doris.thrift.TKafkaRLTaskProgress;
 
 import com.google.common.base.Joiner;
 import com.google.common.collect.Maps;
+import com.google.gson.Gson;
 
 import java.io.DataInput;
 import java.io.DataOutput;
@@ -33,12 +33,20 @@ import java.util.Map;
 
 /**
  * this is description of kafka routine load progress
- * the data before offset was already loaded in doris
+ * the data before offset was already loaded in Doris
  */
 // {"partitionIdToOffset": {}}
 public class KafkaProgress extends RoutineLoadProgress {
+    public static final String OFFSET_BEGINNING = "OFFSET_BEGINNING"; // -2
+    public static final String OFFSET_END = "OFFSET_END"; // -1
+    // OFFSET_ZERO is just for show info, if user specified offset is 0
+    public static final String OFFSET_ZERO = "OFFSET_ZERO";
+
+    public static final long OFFSET_BEGINNING_VAL = -2;
+    public static final long OFFSET_END_VAL = -1;
 
     // (partition id, begin offset)
+    // the offset the next msg to be consumed
     private Map<Integer, Long> partitionIdToOffset = Maps.newConcurrentMap();
 
     public KafkaProgress() {
@@ -48,10 +56,6 @@ public class KafkaProgress extends RoutineLoadProgress {
     public KafkaProgress(TKafkaRLTaskProgress tKafkaRLTaskProgress) {
         super(LoadDataSourceType.KAFKA);
         this.partitionIdToOffset = tKafkaRLTaskProgress.getPartitionCmtOffset();
-    }
-
-    public Map<Integer, Long> getPartitionIdToOffset() {
-        return partitionIdToOffset;
     }
 
     public Map<Integer, Long> getPartitionIdToOffset(List<Integer> partitionIds) {
@@ -70,13 +74,36 @@ public class KafkaProgress extends RoutineLoadProgress {
         partitionIdToOffset.put(partitionOffset.first, partitionOffset.second);
     }
 
+    public Long getOffsetByPartition(int kafkaPartition) {
+        return partitionIdToOffset.get(kafkaPartition);
+    }
+
+    public boolean containsPartition(Integer kafkaPartition) {
+        return partitionIdToOffset.containsKey(kafkaPartition);
+    }
+
+    public boolean hasPartition() {
+        return partitionIdToOffset.isEmpty();
+    }
+
     // (partition id, end offset)
-    // end offset = -1 while begin offset of partition is 0
+    // OFFSET_ZERO: user set offset == 0, no committed msg
+    // OFFSET_END: user set offset = OFFSET_END, no committed msg
+    // OFFSET_BEGINNING: user set offset = OFFSET_BEGINNING, no committed msg
+    // other: current committed msg's offset
     @Override
     public String toString() {
-        Map<Integer, Long> showPartitionIdToOffset = new HashMap<>();
+        Map<Integer, String> showPartitionIdToOffset = Maps.newHashMap();
         for (Map.Entry<Integer, Long> entry : partitionIdToOffset.entrySet()) {
-            showPartitionIdToOffset.put(entry.getKey(), entry.getValue() - 1);
+            if (entry.getValue() == 0) {
+                showPartitionIdToOffset.put(entry.getKey(), OFFSET_ZERO);
+            } else if (entry.getValue() == -1) {
+                showPartitionIdToOffset.put(entry.getKey(), OFFSET_END);
+            } else if (entry.getValue() == -2) {
+                showPartitionIdToOffset.put(entry.getKey(), OFFSET_BEGINNING);
+            } else {
+                showPartitionIdToOffset.put(entry.getKey(), "" + (entry.getValue() - 1));
+            }
         }
         return "KafkaProgress [partitionIdToOffset="
                 + Joiner.on("|").withKeyValueSeparator("_").join(showPartitionIdToOffset) + "]";
@@ -85,8 +112,9 @@ public class KafkaProgress extends RoutineLoadProgress {
     @Override
     public void update(RoutineLoadProgress progress) {
         KafkaProgress newProgress = (KafkaProgress) progress;
-        newProgress.getPartitionIdToOffset().entrySet().parallelStream()
-                .forEach(entity -> partitionIdToOffset.put(entity.getKey(), entity.getValue() + 1));
+        // + 1 to point to the next msg offset to be consumed
+        newProgress.partitionIdToOffset.entrySet().stream()
+                .forEach(entity -> this.partitionIdToOffset.put(entity.getKey(), entity.getValue() + 1));
     }
 
     @Override

--- a/fe/src/main/java/org/apache/doris/load/routineload/KafkaRoutineLoadJob.java
+++ b/fe/src/main/java/org/apache/doris/load/routineload/KafkaRoutineLoadJob.java
@@ -266,7 +266,7 @@ public class KafkaRoutineLoadJob extends RoutineLoadJob {
         summary.put("errorRows", Long.valueOf(errorRows));
         summary.put("unselectedRows", Long.valueOf(unselectedRows));
         summary.put("receivedBytes", Long.valueOf(receivedBytes));
-        summary.put("taskExecuteTaskMs", Long.valueOf(totalTaskExcutionTimeMs));
+        summary.put("taskExecuteTimeMs", Long.valueOf(totalTaskExcutionTimeMs));
         summary.put("receivedBytesRate", Long.valueOf(receivedBytes / totalTaskExcutionTimeMs * 1000));
         summary.put("loadRowsRate", Long.valueOf((totalRows - errorRows - unselectedRows) / totalTaskExcutionTimeMs * 1000));
         summary.put("committedTaskNum", Long.valueOf(committedTaskNum));

--- a/fe/src/main/java/org/apache/doris/load/routineload/KafkaTaskInfo.java
+++ b/fe/src/main/java/org/apache/doris/load/routineload/KafkaTaskInfo.java
@@ -17,8 +17,6 @@
 
 package org.apache.doris.load.routineload;
 
-import com.google.common.collect.Lists;
-import com.google.gson.Gson;
 import org.apache.doris.catalog.Catalog;
 import org.apache.doris.catalog.Database;
 import org.apache.doris.common.AnalysisException;
@@ -34,7 +32,7 @@ import org.apache.doris.thrift.TUniqueId;
 import org.apache.doris.transaction.BeginTransactionException;
 
 import com.google.common.base.Joiner;
-import com.google.common.collect.Maps;
+import com.google.gson.Gson;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/fe/src/main/java/org/apache/doris/load/routineload/RoutineLoadScheduler.java
+++ b/fe/src/main/java/org/apache/doris/load/routineload/RoutineLoadScheduler.java
@@ -20,6 +20,7 @@ package org.apache.doris.load.routineload;
 import org.apache.doris.catalog.Catalog;
 import org.apache.doris.common.LoadException;
 import org.apache.doris.common.MetaNotFoundException;
+import org.apache.doris.common.UserException;
 import org.apache.doris.common.util.Daemon;
 import org.apache.doris.common.util.LogBuilder;
 import org.apache.doris.common.util.LogKey;
@@ -58,7 +59,7 @@ public class RoutineLoadScheduler extends Daemon {
         }
     }
 
-    private void process() {
+    private void process() throws UserException {
         // update
         routineLoadManager.updateRoutineLoadJob();
         // get need schedule routine jobs

--- a/fe/src/main/java/org/apache/doris/metric/MetricRepo.java
+++ b/fe/src/main/java/org/apache/doris/metric/MetricRepo.java
@@ -221,6 +221,8 @@ public final class MetricRepo {
         final String DISK_STATE = "disk_state";
         // remove all previous 'capacity' metric
         PALO_METRIC_REGISTER.removeMetrics(CAPACITY);
+        PALO_METRIC_REGISTER.removeMetrics(TABLET_NUM);
+        PALO_METRIC_REGISTER.removeMetrics(DISK_STATE);
 
         LOG.info("begin to generate capacity metrics");
         SystemInfoService infoService = Catalog.getCurrentSystemInfo();

--- a/fe/src/main/java/org/apache/doris/transaction/PublishVersionDaemon.java
+++ b/fe/src/main/java/org/apache/doris/transaction/PublishVersionDaemon.java
@@ -21,6 +21,7 @@ import org.apache.doris.catalog.Catalog;
 import org.apache.doris.catalog.Replica;
 import org.apache.doris.catalog.TabletInvertedIndex;
 import org.apache.doris.common.Config;
+import org.apache.doris.common.UserException;
 import org.apache.doris.common.util.Daemon;
 import org.apache.doris.task.AgentBatchTask;
 import org.apache.doris.task.AgentTaskExecutor;
@@ -57,7 +58,7 @@ public class PublishVersionDaemon extends Daemon {
         }
     }
     
-    private void publishVersion() {
+    private void publishVersion() throws UserException {
         GlobalTransactionMgr globalTransactionMgr = Catalog.getCurrentGlobalTransactionMgr();
         List<TransactionState> readyTransactionStates = globalTransactionMgr.getReadyToPublishTransactions();
         if (readyTransactionStates == null || readyTransactionStates.isEmpty()) {

--- a/fe/src/main/java/org/apache/doris/transaction/TransactionState.java
+++ b/fe/src/main/java/org/apache/doris/transaction/TransactionState.java
@@ -20,6 +20,7 @@ package org.apache.doris.transaction;
 import org.apache.doris.catalog.Catalog;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.FeMetaVersion;
+import org.apache.doris.common.UserException;
 import org.apache.doris.common.io.Text;
 import org.apache.doris.common.io.Writable;
 import org.apache.doris.metric.MetricRepo;
@@ -268,12 +269,12 @@ public class TransactionState implements Writable {
     }
     
     public void setTransactionStatus(TransactionStatus transactionStatus)
-            throws TransactionException {
+            throws UserException {
         setTransactionStatus(transactionStatus, null);
     }
     
     public void setTransactionStatus(TransactionStatus transactionStatus, String txnStatusChangeReason)
-            throws TransactionException {
+            throws UserException {
         // before status changed
         TxnStateChangeListener listener = Catalog.getCurrentGlobalTransactionMgr().getListenerRegistry().getListener(listenerId);
         if (listener != null) {

--- a/fe/src/main/java/org/apache/doris/transaction/TxnStateChangeListener.java
+++ b/fe/src/main/java/org/apache/doris/transaction/TxnStateChangeListener.java
@@ -17,6 +17,8 @@
 
 package org.apache.doris.transaction;
 
+import org.apache.doris.common.UserException;
+
 public interface TxnStateChangeListener {
 
     public enum ListenResult {
@@ -32,7 +34,7 @@ public interface TxnStateChangeListener {
      *
      * @param txnState
      */
-    public ListenResult onCommitted(TransactionState txnState) throws TransactionException;
+    public ListenResult onCommitted(TransactionState txnState) throws UserException;
 
     public void replayOnCommitted(TransactionState txnState);
 
@@ -55,7 +57,7 @@ public interface TxnStateChangeListener {
      *            maybe null
      * @return
      */
-    public ListenResult onAborted(TransactionState txnState, String txnStatusChangeReason);
+    public ListenResult onAborted(TransactionState txnState, String txnStatusChangeReason) throws UserException;
 
     public void replayOnAborted(TransactionState txnState);
 }

--- a/fe/src/test/java/org/apache/doris/load/routineload/KafkaRoutineLoadJobTest.java
+++ b/fe/src/test/java/org/apache/doris/load/routineload/KafkaRoutineLoadJobTest.java
@@ -165,7 +165,7 @@ public class KafkaRoutineLoadJobTest {
                                          @Injectable RoutineLoadManager routineLoadManager,
                                          @Injectable RoutineLoadTaskScheduler routineLoadTaskScheduler,
                                          @Mocked RoutineLoadDesc routineLoadDesc)
-            throws BeginTransactionException, LabelAlreadyUsedException, AnalysisException {
+            throws UserException {
 
         RoutineLoadJob routineLoadJob =
                 new KafkaRoutineLoadJob(1L, "kafka_routine_load_job", "default", 1L,

--- a/fe/src/test/java/org/apache/doris/load/routineload/KafkaRoutineLoadJobTest.java
+++ b/fe/src/test/java/org/apache/doris/load/routineload/KafkaRoutineLoadJobTest.java
@@ -17,7 +17,6 @@
 
 package org.apache.doris.load.routineload;
 
-import com.sleepycat.je.tree.IN;
 import org.apache.doris.analysis.ColumnSeparator;
 import org.apache.doris.analysis.CreateRoutineLoadStmt;
 import org.apache.doris.analysis.LabelName;
@@ -33,7 +32,6 @@ import org.apache.doris.common.LabelAlreadyUsedException;
 import org.apache.doris.common.LoadException;
 import org.apache.doris.common.MetaNotFoundException;
 import org.apache.doris.common.Pair;
-import org.apache.doris.common.SystemIdGenerator;
 import org.apache.doris.common.UserException;
 import org.apache.doris.load.RoutineLoadDesc;
 import org.apache.doris.qe.ConnectContext;
@@ -41,7 +39,6 @@ import org.apache.doris.system.SystemInfoService;
 import org.apache.doris.thrift.TResourceInfo;
 import org.apache.doris.transaction.BeginTransactionException;
 import org.apache.doris.transaction.GlobalTransactionMgr;
-import org.apache.doris.transaction.TransactionState;
 
 import com.google.common.base.Joiner;
 import com.google.common.collect.Lists;
@@ -60,14 +57,11 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.Queue;
 import java.util.UUID;
 
 import mockit.Deencapsulation;
 import mockit.Expectations;
 import mockit.Injectable;
-import mockit.Mock;
-import mockit.MockUp;
 import mockit.Mocked;
 import mockit.Verifications;
 
@@ -111,28 +105,56 @@ public class KafkaRoutineLoadJobTest {
                              @Mocked SystemInfoService systemInfoService,
                              @Mocked Database database,
                              @Mocked RoutineLoadDesc routineLoadDesc) throws MetaNotFoundException {
-        List<Integer> partitionList = new ArrayList<>();
-        partitionList.add(1);
-        partitionList.add(2);
-        List<Long> beIds = Lists.newArrayList(1L);
+        List<Integer> partitionList1 = Lists.newArrayList(1, 2);
+        List<Integer> partitionList2 = Lists.newArrayList(1, 2, 3);
+        List<Integer> partitionList3 = Lists.newArrayList(1, 2, 3, 4);
+        List<Integer> partitionList4 = Lists.newArrayList(1, 2, 3, 4, 5, 6, 7);
+        List<Long> beIds1 = Lists.newArrayList(1L);
+        List<Long> beIds2 = Lists.newArrayList(1L, 2L, 3L, 4L);
 
-        String clusterName = "default";
+        String clusterName1 = "default1";
+        String clusterName2 = "default2";
 
         new Expectations() {
             {
                 Catalog.getCurrentSystemInfo();
                 result = systemInfoService;
-                systemInfoService.getClusterBackendIds(clusterName, true);
-                result = beIds;
+                systemInfoService.getClusterBackendIds(clusterName1, true);
+                result = beIds1;
+                systemInfoService.getClusterBackendIds(clusterName2, true);
+                result = beIds2;
+                minTimes = 0;
             }
         };
 
+        // 2 partitions, 1 be
         RoutineLoadJob routineLoadJob =
-                new KafkaRoutineLoadJob(1L, "kafka_routine_load_job", clusterName, 1L,
+                new KafkaRoutineLoadJob(1L, "kafka_routine_load_job", clusterName1, 1L,
                                         1L, "127.0.0.1:9020", "topic1");
         Deencapsulation.setField(routineLoadJob, "consumer", kafkaConsumer);
-        Deencapsulation.setField(routineLoadJob, "currentKafkaPartitions", partitionList);
+        Deencapsulation.setField(routineLoadJob, "currentKafkaPartitions", partitionList1);
         Assert.assertEquals(1, routineLoadJob.calculateCurrentConcurrentTaskNum());
+
+        // 3 partitions, 4 be
+        routineLoadJob = new KafkaRoutineLoadJob(1L, "kafka_routine_load_job", clusterName2, 1L,
+                1L, "127.0.0.1:9020", "topic1");
+        Deencapsulation.setField(routineLoadJob, "consumer", kafkaConsumer);
+        Deencapsulation.setField(routineLoadJob, "currentKafkaPartitions", partitionList2);
+        Assert.assertEquals(1, routineLoadJob.calculateCurrentConcurrentTaskNum());
+
+        // 4 partitions, 4 be
+        routineLoadJob = new KafkaRoutineLoadJob(1L, "kafka_routine_load_job", clusterName2, 1L,
+                1L, "127.0.0.1:9020", "topic1");
+        Deencapsulation.setField(routineLoadJob, "consumer", kafkaConsumer);
+        Deencapsulation.setField(routineLoadJob, "currentKafkaPartitions", partitionList3);
+        Assert.assertEquals(2, routineLoadJob.calculateCurrentConcurrentTaskNum());
+
+        // 7 partitions, 4 be
+        routineLoadJob = new KafkaRoutineLoadJob(1L, "kafka_routine_load_job", clusterName2, 1L,
+                1L, "127.0.0.1:9020", "topic1");
+        Deencapsulation.setField(routineLoadJob, "consumer", kafkaConsumer);
+        Deencapsulation.setField(routineLoadJob, "currentKafkaPartitions", partitionList4);
+        Assert.assertEquals(3, routineLoadJob.calculateCurrentConcurrentTaskNum());
     }
 
 

--- a/fe/src/test/java/org/apache/doris/load/routineload/RoutineLoadManagerTest.java
+++ b/fe/src/test/java/org/apache/doris/load/routineload/RoutineLoadManagerTest.java
@@ -17,7 +17,8 @@
 
 package org.apache.doris.load.routineload;
 
-import com.sleepycat.je.tree.IN;
+import static mockit.Deencapsulation.invoke;
+
 import org.apache.doris.analysis.ColumnSeparator;
 import org.apache.doris.analysis.CreateRoutineLoadStmt;
 import org.apache.doris.analysis.LabelName;
@@ -55,8 +56,6 @@ import mockit.Injectable;
 import mockit.Mock;
 import mockit.MockUp;
 import mockit.Mocked;
-
-import static mockit.Deencapsulation.invoke;
 
 public class RoutineLoadManagerTest {
 


### PR DESCRIPTION
1. Use a data consumer group to share a single stream load pipe with multi data consumers. This will increase the consuming speed of Kafka messages, as well as reducing the task number of routine
load job. 

Test results：

* 1 consumer, 1 partitions:
    consume time: 4.469s, rows: 990140, bytes: 128737139.  221557 rows/s, 28M/s
* 1 consumer, 3 partitions:
    consume time: 12.765s, rows: 2000143, bytes: 258631271. 156689 rows/s, 20M/s
    blocking get time(us): 12268241, blocking put time(us): 1886431
* 3 consumers, 3 partitions:
    consume time(all 3): 6.095s, rows: 2000503, bytes: 258631576. 328220 rows/s, 42M/s
    blocking get time(us): 1041639, blocking put time(us): 10356581

The next 2 cases show that we can achieve higher speed by adding more consumers. But the bottle neck transfers from Kafka consumer to Doris ingestion, so 3 consumers in a group is enough.

I also add a Backend config `max_consumer_num_per_group` to change the number of consumers in a data consumer group, and default value is 3.

In my test(1 Backend, 2 tablets, 1 replicas), 1 routine load task can achieve 10M/s, which is same as raw stream load.

2. Add OFFSET_BEGINNING and OFFSET_END support for Kafka routine load 