### PR TITLE
Fix a problem which may cause nullptr in ResultBufferMgr

### DIFF
--- a/be/src/runtime/result_buffer_mgr.cpp
+++ b/be/src/runtime/result_buffer_mgr.cpp
@@ -50,17 +50,19 @@ Status ResultBufferMgr::init() {
 Status ResultBufferMgr::create_sender(
     const TUniqueId& query_id, int buffer_size,
     boost::shared_ptr<BufferControlBlock>* sender) {
-    if (find_control_block(query_id).get() != NULL) {
+    *sender = find_control_block(query_id);
+    if (*sender != nullptr) {
         LOG(WARNING) << "already have buffer control block for this instance "
                      << query_id;
-        *sender = find_control_block(query_id);
         return Status::OK;
     }
 
     boost::shared_ptr<BufferControlBlock> control_block(
         new BufferControlBlock(query_id, buffer_size));
-    boost::lock_guard<boost::mutex> l(_lock);
-    _buffer_map.insert(std::make_pair(query_id, control_block));
+    {
+        boost::lock_guard<boost::mutex> l(_lock);
+        _buffer_map.insert(std::make_pair(query_id, control_block));
+    }
     *sender = control_block;
     return Status::OK;
 }


### PR DESCRIPTION
Because there is no lock in the middle call to findBlock(),
even if the first call returns non-null, the second call
may still get a null block

ISSUE: #883 