### PR TITLE
Fix null pointer error when async load

### DIFF
--- a/fe/src/main/java/org/apache/doris/qe/Coordinator.java
+++ b/fe/src/main/java/org/apache/doris/qe/Coordinator.java
@@ -847,7 +847,7 @@ public class Coordinator {
             } else {
                 //normat fragment
                 Iterator iter = fragmentExecParamsMap.get(fragment.getFragmentId()).scanRangeAssignment.entrySet().iterator();
-                int parallelExecInstanceNum = ConnectContext.get().getSessionVariable().getParallelExecInstanceNum();
+                int parallelExecInstanceNum = fragment.getParallel_exec_num();
                 while (iter.hasNext()) {
                     Map.Entry entry = (Map.Entry) iter.next();
                     TNetworkAddress key = (TNetworkAddress) entry.getKey();


### PR DESCRIPTION
1. Add parallel number property in fragment
2. Parallel number will be init in contrustor of fragment
3. Async plan will use the default value while sync plan will use the parallelExecInstanceNum of SessionVariable