### PR TITLE
Reconstruct _rs_graph and _rs_version_map when clone finished

### DIFF
--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -156,9 +156,9 @@ OLAPStatus Tablet::save_meta() {
     return res;
 }
 
-OLAPStatus Tablet::revise_tablet_meta(const TabletMeta& tablet_meta,
-                              const vector<RowsetMetaSharedPtr>& rowsets_to_clone,
-                              const vector<Version>& versions_to_delete) {
+OLAPStatus Tablet::revise_tablet_meta(
+        const vector<RowsetMetaSharedPtr>& rowsets_to_clone,
+        const vector<Version>& versions_to_delete) {
     LOG(INFO) << "begin to clone data to tablet. tablet=" << full_name()
               << ", rowsets_to_clone=" << rowsets_to_clone.size()
               << ", versions_to_delete_size=" << versions_to_delete.size();
@@ -208,18 +208,23 @@ OLAPStatus Tablet::revise_tablet_meta(const TabletMeta& tablet_meta,
 
     for (auto& version : versions_to_delete) {
         auto it = _rs_version_map.find(version);
+        StorageEngine::instance()->add_unused_rowset(it->second);
         _rs_version_map.erase(it);
     }
+    for (auto& it : _inc_rs_version_map) {
+        StorageEngine::instance()->add_unused_rowset(it.second);
+    }
+    _inc_rs_version_map.clear();
 
     for (auto& rs_meta : rowsets_to_clone) {
         Version version = { rs_meta->start_version(), rs_meta->end_version() };
         RowsetSharedPtr rowset(new AlphaRowset(&_schema, _tablet_path, _data_dir, rs_meta));
-        _rs_version_map[version] = rowset;
         res = rowset->init();
         if (res != OLAP_SUCCESS) {
             LOG(WARNING) << "fail to init rowset. version=" << version.first << "-" << version.second;
-            break;
+            return res;
         }
+        _rs_version_map[version] = rowset;
     }
 
     _rs_graph.reconstruct_rowset_graph(_tablet_meta->all_rs_metas());

--- a/be/src/olap/tablet.h
+++ b/be/src/olap/tablet.h
@@ -75,8 +75,7 @@ public:
     inline const TabletMetaSharedPtr tablet_meta();
     OLAPStatus save_meta();
     OLAPStatus merge_tablet_meta(const TabletMeta& hdr, int to_version);
-    OLAPStatus revise_tablet_meta(const TabletMeta& tablet_meta,
-                                  const std::vector<RowsetMetaSharedPtr>& rowsets_to_clone,
+    OLAPStatus revise_tablet_meta(const std::vector<RowsetMetaSharedPtr>& rowsets_to_clone,
                                   const std::vector<Version>& versions_to_delete);
 
     inline int64_t table_id() const;

--- a/be/src/olap/tablet_manager.cpp
+++ b/be/src/olap/tablet_manager.cpp
@@ -710,7 +710,6 @@ OLAPStatus TabletManager::load_tablet_from_meta(DataDir* data_dir, TTabletId tab
         return OLAP_ERR_TABLE_CREATE_FROM_HEADER_ERROR;
     }
 
-
     if (tablet_meta->tablet_state() == TABLET_SHUTDOWN) {
         LOG(INFO) << "tablet is to be deleted, skip load it"
                   << " tablet id = " << tablet_meta->tablet_id()

--- a/be/src/olap/task/engine_clone_task.cpp
+++ b/be/src/olap/task/engine_clone_task.cpp
@@ -785,7 +785,7 @@ OLAPStatus EngineCloneTask::_clone_incremental_data(TabletSharedPtr tablet, cons
     }
 
     // clone_data to tablet
-    OLAPStatus clone_res = tablet->revise_tablet_meta(cloned_tablet_meta, rowsets_to_clone, versions_to_delete);
+    OLAPStatus clone_res = tablet->revise_tablet_meta(rowsets_to_clone, versions_to_delete);
     LOG(INFO) << "finish to incremental clone. [tablet=" << tablet->full_name() << " res=" << clone_res << "]";
     return clone_res;
 }
@@ -869,7 +869,7 @@ OLAPStatus EngineCloneTask::_clone_full_data(TabletSharedPtr tablet, TabletMeta*
     }
 
     // clone_data to tablet
-    OLAPStatus clone_res = tablet->revise_tablet_meta(*cloned_tablet_meta, rowsets_to_clone, versions_to_delete);
+    OLAPStatus clone_res = tablet->revise_tablet_meta(rowsets_to_clone, versions_to_delete);
     LOG(INFO) << "finish to full clone. tablet=" << tablet->full_name() << ", res=" << clone_res;
     // in previous step, copy all files from CLONE_DIR to tablet dir
     // but some rowset is useless, so that remove them here

--- a/be/src/olap/task/engine_clone_task.cpp
+++ b/be/src/olap/task/engine_clone_task.cpp
@@ -213,6 +213,13 @@ OLAPStatus EngineCloneTask::execute() {
                     && (tablet_info.version < _clone_req.committed_version ||
                         (tablet_info.version == _clone_req.committed_version
                         && tablet_info.version_hash != _clone_req.committed_version_hash))) {
+            LOG(INFO) << "tablet to clone. tablet_id:" << _clone_req.tablet_id
+                      << ", schema_hash:" << _clone_req.schema_hash
+                      << ", signature:" << _signature
+                      << ", version:" << tablet_info.version
+                      << ", version_hash:" << tablet_info.version_hash
+                      << ", expected_version: " << _clone_req.committed_version
+                      << ", version_hash:" << _clone_req.committed_version_hash;
             // if it is a new tablet and clone failed, then remove the tablet
             // if it is incremental clone, then must not drop the tablet
             if (is_new_tablet) {


### PR DESCRIPTION
Upon finishing clone, tablet_meta has been changed.
_rs_graph and _rs_version_map should be reconstructed to be consistent with tablet_meta been changed.