### PR TITLE
Set ref_tablet id when do alter task

### DIFF
--- a/be/src/olap/push_handler.cpp
+++ b/be/src/olap/push_handler.cpp
@@ -117,7 +117,7 @@ OLAPStatus PushHandler::_do_streaming_ingestion(
       // if related tablet not exists, only push current tablet
       if (NULL == related_tablet.get()) {
         LOG(WARNING) << "can't find related tablet, only push current tablet. "
-                     << "[tablet=%s related_tablet_id=" << tablet->full_name()
+                     << "related_tablet_id=" << related_tablet_id
                      << ", related_schema_hash=" << related_schema_hash;
 
         // if current tablet is new tablet, only push current tablet

--- a/be/src/olap/schema_change.cpp
+++ b/be/src/olap/schema_change.cpp
@@ -1201,7 +1201,9 @@ OLAPStatus SchemaChangeHandler::process_alter_tablet(AlterTabletType type,
     base_tablet->obtain_push_lock();
     base_tablet->obtain_header_wrlock();
     new_tablet->obtain_header_wrlock();
-    _save_alter_state(ALTER_PREPARED, base_tablet, new_tablet);
+    // store schema change information into tablet header
+    vector<Version> empty_version_list;
+    res = _add_alter_task(type, base_tablet, new_tablet, empty_version_list);
     new_tablet->release_header_lock();
     base_tablet->release_header_lock();
 

--- a/be/src/olap/storage_engine.cpp
+++ b/be/src/olap/storage_engine.cpp
@@ -904,7 +904,8 @@ void* StorageEngine::_path_gc_thread_callback(void* arg) {
 
     while (true) {
         LOG(INFO) << "try to perform path gc!";
-        ((DataDir*)arg)->perform_path_gc();
+        // TODO(ygl): stop gc temp because could not define all pending dirs currently
+        // ((DataDir*)arg)->perform_path_gc();
         usleep(interval * 1000000);
     }
 

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -287,7 +287,7 @@ OLAPStatus Tablet::modify_rowsets(const vector<RowsetSharedPtr>& to_add,
 const RowsetSharedPtr Tablet::get_rowset_by_version(const Version& version) const {
     auto iter = _rs_version_map.find(version);
     if (iter == _rs_version_map.end()) {
-        LOG(WARNING) << "no rowset for version:" << version.first << "-" << version.second;
+        LOG(INFO) << "no rowset for version:" << version.first << "-" << version.second;
         return nullptr;
     }
     RowsetSharedPtr rowset = iter->second;

--- a/be/src/olap/tablet_meta.cpp
+++ b/be/src/olap/tablet_meta.cpp
@@ -599,6 +599,7 @@ OLAPStatus TabletMeta::delete_alter_task() {
     return OLAP_SUCCESS;
 }
 
+// TODO(ygl): if alter task is nullptr, return error?
 void TabletMeta::set_alter_state(AlterTabletState alter_state) {
     WriteLock wrlock(&_meta_lock);
     if (_alter_task == nullptr) {

--- a/be/src/olap/task/engine_clone_task.cpp
+++ b/be/src/olap/task/engine_clone_task.cpp
@@ -867,6 +867,11 @@ OLAPStatus EngineCloneTask::_clone_full_data(TabletSharedPtr tablet, TabletMeta*
     }
 
     // clone_data to tablet
+    // only replace rowet info, must not modify other info such as alter task info. for example
+    // 1. local tablet finished alter task
+    // 2. local tablet has error in push
+    // 3. local tablet cloned rowset from other nodes
+    // 4. if cleared alter task info, then push will not write to new tablet, the report info is error
     OLAPStatus clone_res = tablet->revise_tablet_meta(rowsets_to_clone, versions_to_delete);
     LOG(INFO) << "finish to full clone. tablet=" << tablet->full_name() << ", res=" << clone_res;
     // in previous step, copy all files from CLONE_DIR to tablet dir

--- a/be/test/olap/tablet_mgr_test.cpp
+++ b/be/test/olap/tablet_mgr_test.cpp
@@ -25,6 +25,7 @@
 #include "olap/rowset/rowset_meta_manager.h"
 #include "olap/rowset/alpha_rowset.h"
 #include "olap/rowset/alpha_rowset_meta.h"
+#include "olap/tablet_meta_manager.h"
 #include "olap/txn_manager.h"
 #include "olap/new_status.h"
 #include "boost/filesystem.hpp"
@@ -129,6 +130,10 @@ TEST_F(TabletMgrTest, CreateTablet) {
     // check dir exist
     bool dir_exist = check_dir_existed(tablet->tablet_path());
     ASSERT_TRUE(dir_exist);
+    // check meta has this tablet
+    TabletMetaSharedPtr new_tablet_meta(new TabletMeta());
+    OLAPStatus check_meta_st = TabletMetaManager::get_header(_data_dir, 111, 3333, new_tablet_meta);
+    ASSERT_TRUE(check_meta_st == OLAP_SUCCESS);
 
     // retry create should be successfully
     create_st = _tablet_mgr.create_tablet(create_tablet_req, data_dirs);


### PR DESCRIPTION
- Set ref_tablet id when do alter task
- Stop gc thread temporary because could not define all pending dirs currently
- Reset tablet id and schema hash when convert rowsetids because restore process's tablet id and schema hash is different from snapshot