### PR TITLE
Fix bug that failed to choose dest replica for version incomplete repair

### DIFF
--- a/fe/src/main/java/org/apache/doris/clone/TabletSchedCtx.java
+++ b/fe/src/main/java/org/apache/doris/clone/TabletSchedCtx.java
@@ -498,8 +498,8 @@ public class TabletSchedCtx implements Comparable<TabletSchedCtx> {
                 continue;
             }
 
-            if (replica.getLastFailedVersion() <= 0 && replica.getVersion() == visibleVersion
-                    && replica.getVersionHash() == visibleVersionHash) {
+            if (replica.getLastFailedVersion() <= 0 && ((replica.getVersion() == visibleVersion
+                    && replica.getVersionHash() == visibleVersionHash) || replica.getVersion() > visibleVersion)) {
                 // skip healthy replica
                 continue;
             }


### PR DESCRIPTION
We should skip the replica which version is larger than visible version.
ISSUE: #995 