### PR TITLE
Support enable_insert_strict

### DIFF
--- a/be/src/runtime/data_spliter.cpp
+++ b/be/src/runtime/data_spliter.cpp
@@ -170,6 +170,8 @@ Status DataSpliter::process_partition(
             std::stringstream error_log;
             error_log << "there is no corresponding partition for this key: ";
             ctx->print_value(row, &error_log);
+            state->update_num_rows_load_filtered(1);
+            state->update_num_rows_load_success(-1);
             return Status(error_log.str(), true);
         }
         *info = _partition_infos[*part_index];

--- a/fe/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -68,6 +68,7 @@ public class SessionVariable implements Serializable, Writable {
     public static final String DISABLE_STREAMING_PREAGGREGATIONS = "disable_streaming_preaggregations";
     public static final String DISABLE_COLOCATE_JOIN = "disable_colocate_join";
     public static final String PARALLEL_FRAGMENT_EXEC_INSTANCE_NUM = "parallel_fragment_exec_instance_num";
+    public static final String ENABLE_INSERT_STRICT = "enable_insert_strict";
     public static final int MIN_EXEC_INSTANCE_NUM = 1;
     public static final int MAX_EXEC_INSTANCE_NUM = 32;
 
@@ -182,6 +183,10 @@ public class SessionVariable implements Serializable, Writable {
      */
     @VariableMgr.VarAttr(name = PARALLEL_FRAGMENT_EXEC_INSTANCE_NUM)
     private int parallelExecInstanceNum = 1;
+
+    @VariableMgr.VarAttr(name = ENABLE_INSERT_STRICT)
+    private boolean enableInsertStrict = false;
+
 
     public long getMaxExecMemByte() {
         return maxExecMemByte;
@@ -428,6 +433,10 @@ public class SessionVariable implements Serializable, Writable {
             this.parallelExecInstanceNum = parallelExecInstanceNum;
         }
     }
+
+    public boolean getEnableInsertStrict() { return enableInsertStrict; }
+    public void setEnableInsertStrict(boolean enableInsertStrict) { this.enableInsertStrict = enableInsertStrict; }
+
     
    // Serialize to thrift object
     TQueryOptions toThrift() {


### PR DESCRIPTION
Add a variable enable_insert_strict, this default value is false. When
this value is set to true, insert will fail if there is any filtered
data. If this value is false, insert will ignore filtered data and
success

#990 