### PR TITLE
Add trim in hdfs broker name node string

### DIFF
--- a/fs_brokers/apache_hdfs_broker/src/main/java/org/apache/doris/broker/hdfs/FileSystemManager.java
+++ b/fs_brokers/apache_hdfs_broker/src/main/java/org/apache/doris/broker/hdfs/FileSystemManager.java
@@ -269,6 +269,7 @@ public class FileSystemManager {
                                 "invalid " + dfsHaNameNodesKey + " configuration");
                     } else {
                         for (String nameNode : nameNodes) {
+                            nameNode = nameNode.trim();
                             String nameNodeRpcAddress =
                                     DFS_HA_NAMENODE_RPC_ADDRESS_PREFIX + dfsNameServices + "." + nameNode;
                             if (!properties.containsKey(nameNodeRpcAddress)) {


### PR DESCRIPTION
Add trim in hdfs broker name node string
eg : "dfs.ha.namenodes.ns1017" = "nn1,     nn2"