### PR TITLE
Fix bug that premature updating schema hash of replica when reporting

### DIFF
--- a/fe/src/main/java/org/apache/doris/catalog/TabletInvertedIndex.java
+++ b/fe/src/main/java/org/apache/doris/catalog/TabletInvertedIndex.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.catalog;
 
+import org.apache.doris.catalog.Replica.ReplicaState;
 import org.apache.doris.thrift.TPartitionVersionInfo;
 import org.apache.doris.thrift.TStorageMedium;
 import org.apache.doris.thrift.TTablet;
@@ -141,8 +142,9 @@ public class TabletInvertedIndex {
                                     replica.setPathHash(backendTabletInfo.getPath_hash());
                                 }
 
-                                if (backendTabletInfo.isSetSchema_hash()
+                                if (backendTabletInfo.isSetSchema_hash() && replica.getState() == ReplicaState.NORMAL
                                         && replica.getSchemaHash() != backendTabletInfo.getSchema_hash()) {
+                                    // update the schema hash only when replica is normal
                                     replica.setSchemaHash(backendTabletInfo.getSchema_hash());
                                 }
 


### PR DESCRIPTION
The new schema hash should only be updated when schema changing finished.
ISSUE: #1083 