### PR TITLE
Add show load of loadv2

### DIFF
--- a/be/src/util/uid_util.cpp
+++ b/be/src/util/uid_util.cpp
@@ -26,13 +26,13 @@ std::ostream& operator<<(std::ostream& os, const UniqueId& uid) {
 
 std::string print_id(const TUniqueId& id) {
     std::stringstream out;
-    out << std::hex << id.hi << ":" << id.lo;
+    out << std::hex << id.hi << "-" << id.lo;
     return out.str();
 }
 
 std::string print_id(const PUniqueId& id) {
     std::stringstream out;
-    out << std::hex << id.hi() << ":" << id.lo();
+    out << std::hex << id.hi() << "-" << id.lo();
     return out.str();
 }
 
@@ -40,7 +40,7 @@ bool parse_id(const std::string& s, TUniqueId* id) {
     DCHECK(id != NULL);
 
     const char* hi_part = s.c_str();
-    char* colon = const_cast<char*>(strchr(hi_part, ':'));
+    char* colon = const_cast<char*>(strchr(hi_part, '-'));
 
     if (colon == NULL) {
         return false;

--- a/fe/src/main/java/org/apache/doris/analysis/LoadStmt.java
+++ b/fe/src/main/java/org/apache/doris/analysis/LoadStmt.java
@@ -21,6 +21,8 @@ import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.DdlException;
 import org.apache.doris.common.UserException;
 import org.apache.doris.common.util.PrintableMap;
+import org.apache.doris.load.Load;
+import org.apache.doris.load.loadv2.LoadManager;
 import org.apache.doris.qe.ConnectContext;
 
 import com.google.common.base.Function;
@@ -57,6 +59,7 @@ public class LoadStmt extends DdlStmt {
     public static final String LOAD_DELETE_FLAG_PROPERTY = "load_delete_flag";
     public static final String EXEC_MEM_LIMIT = "exec_mem_limit";
     public static final String CLUSTER_PROPERTY = "cluster";
+    private static final String VERSION = "version";
     
     // for load data from Baidu Object Store(BOS)
     public static final String BOS_ENDPOINT = "bos_endpoint";
@@ -78,6 +81,8 @@ public class LoadStmt extends DdlStmt {
     private final Map<String, String> properties;
     private String user;
 
+    private static String version = "v1";
+
     // properties set
     private final static ImmutableSet<String> PROPERTIES_SET = new ImmutableSet.Builder<String>()
             .add(TIMEOUT_PROPERTY)
@@ -85,6 +90,7 @@ public class LoadStmt extends DdlStmt {
             .add(LOAD_DELETE_FLAG_PROPERTY)
             .add(EXEC_MEM_LIMIT)
             .add(CLUSTER_PROPERTY)
+            .add(VERSION)
             .build();
     
     public LoadStmt(LabelName label, List<DataDescription> dataDescriptions,
@@ -170,6 +176,17 @@ public class LoadStmt extends DdlStmt {
                 throw new DdlException(MAX_FILTER_RATIO_PROPERTY + " is not a number.");
             }
         }
+
+        // version
+        final String versionProperty = properties.get(VERSION);
+        // TODO(ml): only support v1
+        if (versionProperty != null) {
+            if (!versionProperty.equalsIgnoreCase(LoadManager.VERSION)) {
+                throw new DdlException(VERSION + " must be " + LoadManager.VERSION);
+            }
+            version = LoadManager.VERSION;
+        }
+
     }
 
     @Override
@@ -201,6 +218,10 @@ public class LoadStmt extends DdlStmt {
             return true;
         }
         return false;
+    }
+
+    public String getVersion() {
+        return version;
     }
 
     @Override

--- a/fe/src/main/java/org/apache/doris/catalog/Catalog.java
+++ b/fe/src/main/java/org/apache/doris/catalog/Catalog.java
@@ -1080,6 +1080,9 @@ public class Catalog {
         LoadChecker.init(Config.load_checker_interval_second * 1000L);
         LoadChecker.startAll();
 
+        // New load scheduler
+        loadJobScheduler.start();
+
         // Export checker
         ExportChecker.init(Config.export_checker_interval_second * 1000L);
         ExportChecker.startAll();

--- a/fe/src/main/java/org/apache/doris/common/proc/LoadProcDir.java
+++ b/fe/src/main/java/org/apache/doris/common/proc/LoadProcDir.java
@@ -60,7 +60,7 @@ public class LoadProcDir implements ProcDirInterface {
         result.setNames(TITLE_NAMES);
 
         LinkedList<List<Comparable>> loadJobInfos = load.getLoadJobInfosByDb(db.getId(), db.getFullName(),
-                                                                             null, false, null, null);
+                                                                             null, false, null);
         int counter = 0;
         Iterator<List<Comparable>> iterator = loadJobInfos.descendingIterator();
         while (iterator.hasNext()) {

--- a/fe/src/main/java/org/apache/doris/load/Load.java
+++ b/fe/src/main/java/org/apache/doris/load/Load.java
@@ -1399,7 +1399,7 @@ public class Load {
     }
 
     public LinkedList<List<Comparable>> getLoadJobInfosByDb(long dbId, String dbName, String labelValue,
-                                                            boolean accurateMatch, Set<JobState> states, ArrayList<OrderByPair> orderByPairs) {
+                                                            boolean accurateMatch, Set<JobState> states) {
         LinkedList<List<Comparable>> loadJobInfos = new LinkedList<List<Comparable>>();
         readLock();
         try {
@@ -1549,15 +1549,6 @@ public class Load {
             readUnlock();
         }
 
-        ListComparator<List<Comparable>> comparator = null;
-        if (orderByPairs != null) {
-            OrderByPair[] orderByPairArr = new OrderByPair[orderByPairs.size()];
-            comparator = new ListComparator<List<Comparable>>(orderByPairs.toArray(orderByPairArr));
-        } else {
-            // sort by id asc
-            comparator = new ListComparator<List<Comparable>>(0);
-        }
-        Collections.sort(loadJobInfos, comparator);
         return loadJobInfos;
     }
 

--- a/fe/src/main/java/org/apache/doris/load/loadv2/BrokerLoadPendingTask.java
+++ b/fe/src/main/java/org/apache/doris/load/loadv2/BrokerLoadPendingTask.java
@@ -26,6 +26,7 @@ import org.apache.doris.common.util.BrokerUtil;
 import org.apache.doris.common.util.LogBuilder;
 import org.apache.doris.common.util.LogKey;
 import org.apache.doris.load.BrokerFileGroup;
+import org.apache.doris.load.FailMsg;
 import org.apache.doris.thrift.TBrokerFileStatus;
 
 import com.google.common.collect.Lists;
@@ -47,9 +48,10 @@ public class BrokerLoadPendingTask extends LoadTask {
                                  Map<Long, List<BrokerFileGroup>> tableToBrokerFileList,
                                  BrokerDesc brokerDesc) {
         super(loadTaskCallback);
-        this.attachment = new BrokerPendingTaskAttachment();
+        this.attachment = new BrokerPendingTaskAttachment(signature);
         this.tableToBrokerFileList = tableToBrokerFileList;
         this.brokerDesc = brokerDesc;
+        this.failMsg = new FailMsg(FailMsg.CancelType.ETL_RUN_FAIL, null);
     }
 
     @Override

--- a/fe/src/main/java/org/apache/doris/load/loadv2/BrokerLoadingTaskAttachment.java
+++ b/fe/src/main/java/org/apache/doris/load/loadv2/BrokerLoadingTaskAttachment.java
@@ -25,14 +25,15 @@ import org.apache.doris.transaction.TabletCommitInfo;
 import java.util.List;
 import java.util.Map;
 
-public class BrokerLoadingTaskAttachment implements TaskAttachment{
+public class BrokerLoadingTaskAttachment extends TaskAttachment {
 
     private Map<String, String> counters;
     private String trackingUrl;
     private List<TabletCommitInfo> commitInfoList;
 
-    public BrokerLoadingTaskAttachment(Map<String, String> counters, String trackingUrl,
+    public BrokerLoadingTaskAttachment(long taskId, Map<String, String> counters, String trackingUrl,
                                        List<TabletCommitInfo> commitInfoList) {
+        super(taskId);
         this.trackingUrl = trackingUrl;
         this.counters = counters;
         this.commitInfoList = commitInfoList;

--- a/fe/src/main/java/org/apache/doris/load/loadv2/BrokerPendingTaskAttachment.java
+++ b/fe/src/main/java/org/apache/doris/load/loadv2/BrokerPendingTaskAttachment.java
@@ -27,12 +27,16 @@ import com.google.common.collect.Maps;
 import java.util.List;
 import java.util.Map;
 
-public class BrokerPendingTaskAttachment implements TaskAttachment {
+public class BrokerPendingTaskAttachment extends TaskAttachment {
 
     // table id -> file status
     private Map<Long, List<List<TBrokerFileStatus>>> fileStatusMap = Maps.newHashMap();
     // table id -> total file num
     private Map<Long, Integer> fileNumMap = Maps.newHashMap();
+
+    public BrokerPendingTaskAttachment(long taskId) {
+        super(taskId);
+    }
 
     public void addFileStatus(long tableId, List<List<TBrokerFileStatus>> fileStatusList) {
         fileStatusMap.put(tableId, fileStatusList);

--- a/fe/src/main/java/org/apache/doris/load/loadv2/LoadJob.java
+++ b/fe/src/main/java/org/apache/doris/load/loadv2/LoadJob.java
@@ -52,7 +52,6 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 
-import org.apache.commons.lang.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -89,7 +88,7 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
     protected long transactionId;
     protected FailMsg failMsg;
     protected List<LoadTask> tasks = Lists.newArrayList();
-    protected List<Long> finishedTaskIds = Lists.newArrayList();
+    protected Set<Long> finishedTaskIds = Sets.newHashSet();
     protected EtlStatus loadingStatus = new EtlStatus();
     // 0: the job status is pending
     // n/100: n is the number of task which has been finished
@@ -327,7 +326,6 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
         }
 
         // clean the loadingStatus
-        loadingStatus.reset();
         loadingStatus.setState(TEtlState.CANCELLED);
 
         // tasks will not be removed from task pool.

--- a/fe/src/main/java/org/apache/doris/load/loadv2/LoadJobScheduler.java
+++ b/fe/src/main/java/org/apache/doris/load/loadv2/LoadJobScheduler.java
@@ -74,7 +74,7 @@ public class LoadJobScheduler extends Daemon {
                 LOG.warn(new LogBuilder(LogKey.LOAD_JOB, loadJob.getId())
                                  .add("error_msg", "There are error properties in job. Job will be cancelled")
                                  .build(), e);
-                loadJob.cancelJobWithoutCheck(FailMsg.CancelType.ETL_SUBMIT_FAIL, e.getMessage());
+                loadJob.cancelJobWithoutCheck(new FailMsg(FailMsg.CancelType.ETL_SUBMIT_FAIL, e.getMessage()));
                 continue;
             } catch (BeginTransactionException e) {
                 LOG.warn(new LogBuilder(LogKey.LOAD_JOB, loadJob.getId())

--- a/fe/src/main/java/org/apache/doris/load/loadv2/LoadManager.java
+++ b/fe/src/main/java/org/apache/doris/load/loadv2/LoadManager.java
@@ -26,15 +26,23 @@ import org.apache.doris.catalog.Database;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.DdlException;
 import org.apache.doris.common.LabelAlreadyUsedException;
+import org.apache.doris.common.util.LogBuilder;
 import org.apache.doris.task.MasterTaskExecutor;
 import org.apache.doris.transaction.TransactionState;
 
+import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.Iterator;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.stream.Collectors;
@@ -43,6 +51,9 @@ import java.util.stream.Collectors;
  * The broker and mini load jobs(v2) are included in this class.
  */
 public class LoadManager {
+    private static final Logger LOG = LogManager.getLogger(LoadManager.class);
+    public static final String VERSION = "v2";
+
     private Map<Long, LoadJob> idToLoadJob = Maps.newConcurrentMap();
     private Map<Long, Map<String, List<LoadJob>>> dbIdToLabelToLoadJobs = Maps.newConcurrentMap();
     private LoadJobScheduler loadJobScheduler;
@@ -118,10 +129,57 @@ public class LoadManager {
         idToLoadJob.values().stream().forEach(entity -> entity.processTimeout());
     }
 
+    public List<List<Comparable>> getLoadJobInfosByDb(long dbId, String labelValue,
+                                                      boolean accurateMatch, List<String> statesValue) {
+        LinkedList<List<Comparable>> loadJobInfos = new LinkedList<List<Comparable>>();
+        if (!dbIdToLabelToLoadJobs.containsKey(dbId)) {
+            return loadJobInfos;
+        }
+
+        List<JobState> states = Lists.newArrayList();
+        if (statesValue == null || statesValue.size() == 0) {
+            states.addAll(EnumSet.allOf(JobState.class));
+        } else {
+            for (String stateValue : statesValue) {
+                try {
+                    states.add(JobState.valueOf(stateValue));
+                } catch (IllegalArgumentException e) {
+                    // ignore this state
+                }
+            }
+        }
+
+        readLock();
+        try {
+            Map<String, List<LoadJob>> labelToLoadJobs = dbIdToLabelToLoadJobs.get(dbId);
+            if (accurateMatch) {
+                if (!labelToLoadJobs.containsKey(labelValue)) {
+                    return loadJobInfos;
+                }
+                loadJobInfos.addAll(labelToLoadJobs.get(labelValue).stream()
+                                            .filter(entity -> states.contains(entity.getState()))
+                                            .map(entity -> entity.getShowInfo()).collect(Collectors.toList()));
+                return loadJobInfos;
+            }
+
+            for (Map.Entry<String, List<LoadJob>> entry : labelToLoadJobs.entrySet()) {
+                if (entry.getKey().contains(labelValue)) {
+                    loadJobInfos.addAll(entry.getValue().stream()
+                                                .filter(entity -> states.contains(entity.getState()))
+                                                .map(entity -> entity.getShowInfo()).collect(Collectors.toList()));
+                }
+            }
+            return loadJobInfos;
+        } finally {
+            readUnlock();
+        }
+    }
+
     private Database checkDb(String dbName) throws DdlException {
         // get db
         Database db = Catalog.getInstance().getDb(dbName);
         if (db == null) {
+            LOG.warn("Database {} does not exist", dbName);
             throw new DdlException("Database[" + dbName + "] does not exist");
         }
         return db;
@@ -145,6 +203,7 @@ public class LoadManager {
             if (labelToLoadJobs.containsKey(label)) {
                 List<LoadJob> labelLoadJobs = labelToLoadJobs.get(label);
                 if (labelLoadJobs.stream().filter(entity -> !entity.isFinished()).count() != 0) {
+                    LOG.warn("Failed to add load job when label {} has been used.", label);
                     throw new LabelAlreadyUsedException(label);
                 }
             }

--- a/fe/src/main/java/org/apache/doris/load/loadv2/LoadTaskCallback.java
+++ b/fe/src/main/java/org/apache/doris/load/loadv2/LoadTaskCallback.java
@@ -20,10 +20,12 @@
 
 package org.apache.doris.load.loadv2;
 
+import org.apache.doris.load.FailMsg;
+
 public interface LoadTaskCallback {
     long getCallbackId();
 
     void onTaskFinished(TaskAttachment attachment);
 
-    void onTaskFailed(String errMsg);
+    void onTaskFailed(FailMsg failMsg);
 }

--- a/fe/src/main/java/org/apache/doris/load/loadv2/TaskAttachment.java
+++ b/fe/src/main/java/org/apache/doris/load/loadv2/TaskAttachment.java
@@ -20,5 +20,14 @@
 
 package org.apache.doris.load.loadv2;
 
-public interface TaskAttachment {
+public class TaskAttachment {
+    private long taskId;
+
+    public TaskAttachment(long taskId) {
+        this.taskId = taskId;
+    }
+
+    public long getTaskId() {
+        return taskId;
+    }
 }

--- a/fe/src/main/java/org/apache/doris/load/routineload/RoutineLoadJob.java
+++ b/fe/src/main/java/org/apache/doris/load/routineload/RoutineLoadJob.java
@@ -50,7 +50,6 @@ import org.apache.doris.transaction.AbstractTxnStateChangeCallback;
 import org.apache.doris.transaction.TransactionException;
 import org.apache.doris.transaction.TransactionState;
 import org.apache.doris.transaction.TransactionStatus;
-import org.apache.doris.transaction.TxnStateChangeCallback;
 
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;

--- a/fe/src/main/java/org/apache/doris/qe/DdlExecutor.java
+++ b/fe/src/main/java/org/apache/doris/qe/DdlExecutor.java
@@ -67,6 +67,7 @@ import org.apache.doris.catalog.Catalog;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.DdlException;
 import org.apache.doris.load.LoadJob.EtlJobType;
+import org.apache.doris.load.loadv2.LoadManager;
 
 /**
  * Created by zhaochun on 14/11/10.
@@ -112,7 +113,12 @@ public class DdlExecutor {
                 }
                 jobType = EtlJobType.HADOOP;
             }
-            catalog.getLoadInstance().addLoadJob(loadStmt, jobType, System.currentTimeMillis());
+            // TODO(ml): WIP
+            if (loadStmt.getVersion().equals(LoadManager.VERSION)) {
+                catalog.getLoadManager().createLoadJobFromStmt(loadStmt);
+            } else {
+                catalog.getLoadInstance().addLoadJob(loadStmt, jobType, System.currentTimeMillis());
+            }
         } else if (ddlStmt instanceof CancelLoadStmt) {
             catalog.getLoadInstance().cancelLoadJob((CancelLoadStmt) ddlStmt);
         } else if (ddlStmt instanceof CreateRoutineLoadStmt) {

--- a/fe/src/main/java/org/apache/doris/qe/ShowExecutor.java
+++ b/fe/src/main/java/org/apache/doris/qe/ShowExecutor.java
@@ -648,17 +648,20 @@ public class ShowExecutor {
         }
         long dbId = db.getId();
 
+        // combine the List<LoadInfo> of load(v1) and loadManager(v2)
         Load load = catalog.getLoadInstance();
         List<List<Comparable>> loadInfos = load.getLoadJobInfosByDb(dbId, db.getFullName(),
                                                                     showStmt.getLabelValue(),
                                                                     showStmt.isAccurateMatch(),
                                                                     showStmt.getStates());
-        List<String> statesValue = showStmt.getStates() == null ? null : showStmt.getStates().stream()
+        Set<String> statesValue = showStmt.getStates() == null ? null : showStmt.getStates().stream()
                 .map(entity -> entity.name())
-                .collect(Collectors.toList());
+                .collect(Collectors.toSet());
         loadInfos.addAll(catalog.getLoadManager().getLoadJobInfosByDb(dbId, showStmt.getLabelValue(),
                                                                       showStmt.isAccurateMatch(),
                                                                       statesValue));
+
+        // order the result of List<LoadInfo> by orderByPairs in show stmt
         List<OrderByPair> orderByPairs = showStmt.getOrderByPairs();
         ListComparator<List<Comparable>> comparator = null;
         if (orderByPairs != null) {

--- a/fe/src/main/java/org/apache/doris/transaction/TabletCommitInfo.java
+++ b/fe/src/main/java/org/apache/doris/transaction/TabletCommitInfo.java
@@ -21,6 +21,7 @@ import org.apache.doris.common.io.Writable;
 import org.apache.doris.thrift.TTabletCommitInfo;
 
 import com.google.common.collect.Lists;
+import com.google.gson.Gson;
 
 import java.io.DataInput;
 import java.io.DataOutput;
@@ -64,5 +65,11 @@ public class TabletCommitInfo implements Writable {
     public void readFields(DataInput in) throws IOException {
         tabletId = in.readLong();
         backendId = in.readLong();
+    }
+
+    @Override
+    public String toString() {
+        Gson gson = new Gson();
+        return gson.toJson(this);
     }
 }


### PR DESCRIPTION
This change include the show load of loadv2 and some bug fix of loadv2.
Firstly, the show load will perform both load and loadv2 info. According to loadv2, the ETL progress of loadv2 is N/A during the period of loading.
Secondly, the loadv2 will be created when version of property is v2.
This is a temporary property which will not influence the old broker load.
After the loadv2 is finished, the default load will be changed to loadv2.
Finally, there are some bug in LoadingTaskPlanner fixed by this change.