### PR TITLE
Set tablet as bad when loading index failed

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -399,6 +399,10 @@ namespace config {
 
     // max consumer num in one data consumer group, for routine load
     CONF_Int32(max_consumer_num_per_group, "3");
+
+    // Is set to true, index loading failure will not causing BE exit,
+    // and the tablet will be marked as bad, so that FE will try to repair it.
+    CONF_Bool(auto_recover_index_loading_failure, "false");
 } // namespace config
 
 } // namespace doris

--- a/be/src/exec/olap_meta_reader.cpp
+++ b/be/src/exec/olap_meta_reader.cpp
@@ -43,14 +43,14 @@ Status EngineMetaReader::get_hints(
         RuntimeProfile* profile) {
     auto tablet_id = scan_range->scan_range().tablet_id;
     int32_t schema_hash = strtoul(scan_range->scan_range().schema_hash.c_str(), NULL, 10);
-    Status st;
+    std::string err;
     OLAPTablePtr table = OLAPEngine::get_instance()->get_table(
-        tablet_id, schema_hash, &st);
+        tablet_id, schema_hash, &err);
     if (table.get() == NULL) {
         std::stringstream ss;
         ss << "failed to get tablet. tablet_id=" << tablet_id << ", schema_hash="
-            << schema_hash << ", reason: " << st.get_error_msg();
-        LOG(WARNING) < ss.str();
+            << schema_hash << ", reason: " << err;
+        LOG(WARNING) << ss.str();
         return Status(ss.str());
     }
 

--- a/be/src/exec/olap_meta_reader.cpp
+++ b/be/src/exec/olap_meta_reader.cpp
@@ -45,10 +45,10 @@ Status EngineMetaReader::get_hints(
     int32_t schema_hash = strtoul(scan_range->scan_range().schema_hash.c_str(), NULL, 10);
     std::string err;
     OLAPTablePtr table = OLAPEngine::get_instance()->get_table(
-        tablet_id, schema_hash, &err);
+        tablet_id, schema_hash, true, &err);
     if (table.get() == NULL) {
         std::stringstream ss;
-        ss << "failed to get tablet. tablet_id=" << tablet_id << ", schema_hash="
+        ss << "failed to get tablet: " << tablet_id << "with schema hash: "
             << schema_hash << ", reason: " << err;
         LOG(WARNING) << ss.str();
         return Status(ss.str());

--- a/be/src/exec/olap_meta_reader.cpp
+++ b/be/src/exec/olap_meta_reader.cpp
@@ -43,13 +43,14 @@ Status EngineMetaReader::get_hints(
         RuntimeProfile* profile) {
     auto tablet_id = scan_range->scan_range().tablet_id;
     int32_t schema_hash = strtoul(scan_range->scan_range().schema_hash.c_str(), NULL, 10);
+    Status st;
     OLAPTablePtr table = OLAPEngine::get_instance()->get_table(
-        tablet_id, schema_hash);
+        tablet_id, schema_hash, &st);
     if (table.get() == NULL) {
-        LOG(WARNING) << "tablet does not exist. tablet_id=" << tablet_id << ", schema_hash="
-            << schema_hash;
         std::stringstream ss;
-        ss << "tablet does not exist: " << tablet_id;
+        ss << "failed to get tablet. tablet_id=" << tablet_id << ", schema_hash="
+            << schema_hash << ", reason: " << st.get_error_msg();
+        LOG(WARNING) < ss.str();
         return Status(ss.str());
     }
 

--- a/be/src/exec/olap_scanner.cpp
+++ b/be/src/exec/olap_scanner.cpp
@@ -79,13 +79,13 @@ Status OlapScanner::_prepare(
     VersionHash version_hash =
         strtoul(scan_range->scan_range().version_hash.c_str(), nullptr, 10);
     {
-        _olap_table = OLAPEngine::get_instance()->get_table(tablet_id, schema_hash);
+        std::string err;
+        _olap_table = OLAPEngine::get_instance()->get_table(tablet_id, schema_hash, true, &err);
         if (_olap_table.get() == nullptr) {
-            OLAP_LOG_WARNING("tablet does not exist. [tablet_id=%ld schema_hash=%d]",
-                             tablet_id, schema_hash);
-
             std::stringstream ss;
-            ss << "tablet does not exist: " << tablet_id;
+            ss << "failed to get tablet: " << tablet_id << " with schema hash: " << schema_hash
+               << ", reason: " << err;
+            LOG(WARNING) << ss.str();
             return Status(ss.str());
         }
         {

--- a/be/src/olap/olap_engine.cpp
+++ b/be/src/olap/olap_engine.cpp
@@ -785,7 +785,7 @@ OLAPTablePtr OLAPEngine::_get_table_with_no_lock(TTabletId tablet_id, SchemaHash
     return olap_table;
 }
 
-OLAPTablePtr OLAPEngine::get_table(TTabletId tablet_id, SchemaHash schema_hash, bool load_table, Status* st) {
+OLAPTablePtr OLAPEngine::get_table(TTabletId tablet_id, SchemaHash schema_hash, bool load_table, std::string* err) {
     _tablet_map_lock.rdlock();
     OLAPTablePtr olap_table;
     olap_table = _get_table_with_no_lock(tablet_id, schema_hash);
@@ -794,18 +794,18 @@ OLAPTablePtr OLAPEngine::get_table(TTabletId tablet_id, SchemaHash schema_hash, 
     if (olap_table.get() != NULL) {
         if (!olap_table->is_used()) {
             OLAP_LOG_WARNING("olap table cannot be used. [table=%ld]", tablet_id);
-            if (st != nullptr) { *st = Status("tablet cannot be used"); }
+            if (err != nullptr) { *err = "tablet cannot be used"; }
             olap_table.reset();
         } else if (load_table && !olap_table->is_loaded()) {
             OLAPStatus ost = olap_table->load();
             if (ost != OLAP_SUCCESS) {
                 OLAP_LOG_WARNING("fail to load olap table. [table=%ld]", tablet_id);
-                if (st != nullptr) { *st = Status("failed to load tablet. res: " + ost); }
+                if (err != nullptr) { *err = "failed to load tablet. res: " + ost; }
                 olap_table.reset();
             }
         }
-    } else if (st != nullptr) {
-        *st = Status("tablet does not exist");
+    } else if (err != nullptr) {
+        *err = "tablet does not exist";
     }
 
     return olap_table;

--- a/be/src/olap/olap_engine.cpp
+++ b/be/src/olap/olap_engine.cpp
@@ -835,6 +835,10 @@ OLAPStatus OLAPEngine::get_tables_by_id(
                 it = table_list->erase(it);
                 continue;
             }
+        } else if ((*it)->is_used()) {
+            LOG(WARNING) << "table is bad: " << (*it)->full_name().c_str();
+            it = table_list->erase(it); 
+            continue;
         }
         ++it;
     }
@@ -1884,7 +1888,7 @@ OLAPTablePtr OLAPEngine::_find_best_tablet_to_compaction(CompactionType compacti
     OLAPTablePtr best_table;
     for (tablet_map_t::value_type& table_ins : _tablet_map){
         for (OLAPTablePtr& table_ptr : table_ins.second.table_arr) {
-            if (!table_ptr->is_loaded() || !_can_do_compaction(table_ptr)) {
+            if (!table_ptr->is_used() || !table_ptr->is_loaded() || !_can_do_compaction(table_ptr)) {
                 continue;
             }
 

--- a/be/src/olap/olap_engine.cpp
+++ b/be/src/olap/olap_engine.cpp
@@ -800,7 +800,7 @@ OLAPTablePtr OLAPEngine::get_table(TTabletId tablet_id, SchemaHash schema_hash, 
             OLAPStatus ost = olap_table->load();
             if (ost != OLAP_SUCCESS) {
                 OLAP_LOG_WARNING("fail to load olap table. [table=%ld]", tablet_id);
-                if (err != nullptr) { *err = "failed to load tablet. res: " + ost; }
+                if (err != nullptr) { *err = "load tablet failed"; }
                 olap_table.reset();
             }
         }

--- a/be/src/olap/olap_engine.h
+++ b/be/src/olap/olap_engine.h
@@ -86,7 +86,7 @@ public:
     }
 
     // Get table pointer
-    OLAPTablePtr get_table(TTabletId tablet_id, SchemaHash schema_hash, bool load_table = true, Status* st = nullptr);
+    OLAPTablePtr get_table(TTabletId tablet_id, SchemaHash schema_hash, bool load_table = true, std::string* st = nullptr);
 
     OLAPStatus get_tables_by_id(TTabletId tablet_id, std::list<OLAPTablePtr>* table_list);    
 

--- a/be/src/olap/olap_engine.h
+++ b/be/src/olap/olap_engine.h
@@ -86,7 +86,7 @@ public:
     }
 
     // Get table pointer
-    OLAPTablePtr get_table(TTabletId tablet_id, SchemaHash schema_hash, bool load_table = true);
+    OLAPTablePtr get_table(TTabletId tablet_id, SchemaHash schema_hash, bool load_table = true, Status* st = nullptr);
 
     OLAPStatus get_tables_by_id(TTabletId tablet_id, std::list<OLAPTablePtr>* table_list);    
 

--- a/be/src/olap/olap_engine.h
+++ b/be/src/olap/olap_engine.h
@@ -86,7 +86,11 @@ public:
     }
 
     // Get table pointer
-    OLAPTablePtr get_table(TTabletId tablet_id, SchemaHash schema_hash, bool load_table = true, std::string* st = nullptr);
+    // TODO(cmy): I think it is better to return Status instead of OLAPTablePtr,
+    // so that the caller can decide what to do next based on Status.
+    // Currently, I just add a new parameter 'err' to save the error msg.
+    // This should be redesigned later.
+    OLAPTablePtr get_table(TTabletId tablet_id, SchemaHash schema_hash, bool load_table = true, std::string* err = nullptr);
 
     OLAPStatus get_tables_by_id(TTabletId tablet_id, std::list<OLAPTablePtr>* table_list);    
 

--- a/be/src/olap/olap_table.cpp
+++ b/be/src/olap/olap_table.cpp
@@ -148,7 +148,8 @@ OLAPTable::OLAPTable(OLAPHeader* header, OlapStore* store) :
         _num_key_fields(0),
         _id(0),
         _store(store),
-        _is_loaded(false) {
+        _is_loaded(false),
+        _is_bad(false) {
     if (header == NULL) {
         return;  // for convenience of mock test.
     }
@@ -316,7 +317,7 @@ OLAPStatus OLAPTable::load() {
     res = load_indices();
 
     if (res != OLAP_SUCCESS) {
-        LOG(WARN) << "fail to load indices. [res=" << res << " table='" << _full_name << "']";
+        LOG(WARNING) << "fail to load indices. [res=" << res << " table='" << _full_name << "']";
         goto EXIT;
     }
 

--- a/be/src/olap/olap_table.cpp
+++ b/be/src/olap/olap_table.cpp
@@ -317,7 +317,12 @@ OLAPStatus OLAPTable::load() {
     res = load_indices();
 
     if (res != OLAP_SUCCESS) {
-        LOG(WARNING) << "fail to load indices. [res=" << res << " table='" << _full_name << "']";
+        if (config::auto_recover_index_loading_failure) {
+            LOG(WARNING) << "fail to load indices. [res=" << res << " table='" << _full_name << "']";
+        } else {
+            // fatal log will let BE process exit
+            LOG(FATAL) << "fail to load indices. [res=" << res << " table='" << _full_name << "']";
+        }
         goto EXIT;
     }
 

--- a/be/src/olap/olap_table.h
+++ b/be/src/olap/olap_table.h
@@ -626,7 +626,7 @@ public:
 
     bool is_used();
 
-    bool set_bad(boolean is_bad) { _is_bad = is_bad; }
+    void set_bad(bool is_bad) { _is_bad = is_bad; }
 
     // 得到当前table的root path路径，路径末尾不带斜杠(/)
     std::string storage_root_path_name() {
@@ -755,7 +755,7 @@ private:
     std::string _tablet_path;
 
     bool _table_for_check;
-    std::atomic<bool> _is_bad = false;   // if this tablet is broken, set to true.
+    std::atomic<bool> _is_bad;   // if this tablet is broken, set to true. default is false
 
     DISALLOW_COPY_AND_ASSIGN(OLAPTable);
 };

--- a/be/src/olap/olap_table.h
+++ b/be/src/olap/olap_table.h
@@ -626,6 +626,8 @@ public:
 
     bool is_used();
 
+    bool set_bad(boolean is_bad) { _is_bad = is_bad; }
+
     // 得到当前table的root path路径，路径末尾不带斜杠(/)
     std::string storage_root_path_name() {
         return _storage_root_path;
@@ -753,6 +755,7 @@ private:
     std::string _tablet_path;
 
     bool _table_for_check;
+    std::atomic<bool> _is_bad = false;   // if this tablet is broken, set to true.
 
     DISALLOW_COPY_AND_ASSIGN(OLAPTable);
 };


### PR DESCRIPTION
As current implementation, BE process will exit if loading index failed,
and the tablet will be dropped as soon as the failure being detected.
Now, BE will only mark the tablet as bad, instead of dropping it,
and report it to FE. FE will repair the tablet. This is a more safe way to
fix the problem and let BE process continue to run.

But for tracing problem, I add a new BE config `auto_recover_index_loading_failure`,
the default value is false, which means, by default, BE process will still
exit if encounter index loading failure

ISSUE #1145 