### PR TITLE
Fix bug that rename table to an existing rollup index name should not be allowed

### DIFF
--- a/fe/src/main/java/org/apache/doris/backup/BackupHandler.java
+++ b/fe/src/main/java/org/apache/doris/backup/BackupHandler.java
@@ -378,9 +378,11 @@ public class BackupHandler extends Daemon implements Writable {
         RestoreJob restoreJob = new RestoreJob(stmt.getLabel(), stmt.getBackupTimestamp(),
                 db.getId(), db.getFullName(), jobInfo, stmt.allowLoad(), stmt.getReplicationNum(),
                 stmt.getTimeoutMs(), stmt.getMetaVersion(), catalog, repository.getId());
+        catalog.getEditLog().logRestoreJob(restoreJob);
+
+        // must put to dbIdToBackupOrRestoreJob after edit log, otherwise the state of job may be changed.
         dbIdToBackupOrRestoreJob.put(db.getId(), restoreJob);
 
-        catalog.getEditLog().logRestoreJob(restoreJob);
         LOG.info("finished to submit restore job: {}", restoreJob);
     }
 

--- a/fe/src/main/java/org/apache/doris/catalog/Catalog.java
+++ b/fe/src/main/java/org/apache/doris/catalog/Catalog.java
@@ -4839,6 +4839,16 @@ public class Catalog {
             throw new DdlException("Table name[" + newTableName + "] is already used");
         }
 
+        // check if rollup has same name
+        if (table.getType() == TableType.OLAP) {
+            OlapTable olapTable = (OlapTable) table;
+            for (String idxName: olapTable.getIndexNameToId().keySet()) {
+                if (idxName.equals(newTableName)) {
+                    throw new DdlException("New name conflicts with rollup index name: " + idxName);
+                }
+            }
+        }
+
         table.setName(newTableName);
 
         db.dropTable(tableName);


### PR DESCRIPTION
Also fix another bug that backup/restore job should add to task map after writing edit log.
ISSUE: #522 