### PR TITLE
Fix bug that using wrong capacity in trash sweep policy

### DIFF
--- a/be/src/olap/olap_engine.cpp
+++ b/be/src/olap/olap_engine.cpp
@@ -1944,7 +1944,7 @@ OLAPStatus OLAPEngine::start_trash_sweep(double* usage) {
             continue;
         }
 
-        double curr_usage = info.data_used_capacity
+        double curr_usage = (info.capacity - info.available)
                 / (double) info.capacity;
         *usage = *usage > curr_usage ? *usage : curr_usage;
 


### PR DESCRIPTION
We should use total disk used capacity instead of data used capacity,
otherwise, the config 'disk_capacity_insufficient_percentage' will not work.