### PR TITLE
Fix bug that bad tablet blocking compaction of other tablets

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -248,6 +248,10 @@ namespace config {
     CONF_Int64(cumulative_compaction_budgeted_bytes, "104857600");
     CONF_Int32(cumulative_compaction_write_mbytes_per_sec, "100");
 
+    // if compaction of a tablet failed, this tablet should not be chosen to
+    // compaction until this interval passes.
+    CONF_Int64(min_compaction_failure_interval_ms, "600000") // 10 min
+
     // Port to start debug webserver on
     CONF_Int32(webserver_port, "8040");
     // Interface to start debug webserver on. If blank, webserver binds to 0.0.0.0

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -250,7 +250,7 @@ namespace config {
 
     // if compaction of a tablet failed, this tablet should not be chosen to
     // compaction until this interval passes.
-    CONF_Int64(min_compaction_failure_interval_ms, "600000") // 10 min
+    CONF_Int64(min_compaction_failure_interval_sec, "600") // 10 min
 
     // Port to start debug webserver on
     CONF_Int32(webserver_port, "8040");

--- a/be/src/olap/olap_engine.cpp
+++ b/be/src/olap/olap_engine.cpp
@@ -1904,7 +1904,7 @@ OLAPTablePtr OLAPEngine::_find_best_tablet_to_compaction(CompactionType compacti
                 continue;
             }
 
-            if (now - table_ptr->last_compaction_failure_time() <= config::min_compaction_failure_interval_ms) {
+            if (now - table_ptr->last_compaction_failure_time() <= config::min_compaction_failure_interval_sec * 1000) {
                 LOG(INFO) << "tablet last compaction failure time is: " << table_ptr->last_compaction_failure_time()
                         << ", skip it";
                 continue;

--- a/be/src/olap/olap_engine.cpp
+++ b/be/src/olap/olap_engine.cpp
@@ -1860,6 +1860,7 @@ void OLAPEngine::perform_cumulative_compaction() {
                      << ", res=" << res;
         return;
     }
+    best_table->set_last_compaction_failure_time(0);
 }
 
 void OLAPEngine::perform_base_compaction() {
@@ -1889,6 +1890,7 @@ void OLAPEngine::perform_base_compaction() {
                      << ", res=" << res;
         return;
     }
+    best_table->set_last_compaction_failure_time(0);
 }
 
 OLAPTablePtr OLAPEngine::_find_best_tablet_to_compaction(CompactionType compaction_type) {

--- a/be/src/olap/olap_engine.cpp
+++ b/be/src/olap/olap_engine.cpp
@@ -1843,6 +1843,7 @@ void OLAPEngine::perform_cumulative_compaction() {
     if (res != OLAP_SUCCESS) {
         if (res != OLAP_ERR_CUMULATIVE_REPEAT_INIT && res != OLAP_ERR_CE_TRY_CE_LOCK_ERROR) {
             DorisMetrics::cumulative_compaction_request_failed.increment(1);
+            best_table->set_last_compaction_failure_time(UnixMillis());
             LOG(WARNING) << "failed to init cumulative compaction"
                 << ", table=" << best_table->full_name()
                 << ", res=" << res;
@@ -1853,6 +1854,7 @@ void OLAPEngine::perform_cumulative_compaction() {
     res = cumulative_compaction.run();
     if (res != OLAP_SUCCESS) {
         DorisMetrics::cumulative_compaction_request_failed.increment(1);
+        best_table->set_last_compaction_failure_time(UnixMillis());
         LOG(WARNING) << "failed to do cumulative compaction"
                      << ", table=" << best_table->full_name()
                      << ", res=" << res;
@@ -1870,6 +1872,7 @@ void OLAPEngine::perform_base_compaction() {
     if (res != OLAP_SUCCESS) {
         if (res != OLAP_ERR_BE_TRY_BE_LOCK_ERROR && res != OLAP_ERR_BE_NO_SUITABLE_VERSION) {
             DorisMetrics::base_compaction_request_failed.increment(1);
+            best_table->set_last_compaction_failure_time(UnixMillis());
             LOG(WARNING) << "failed to init base compaction"
                 << ", table=" << best_table->full_name()
                 << ", res=" << res;
@@ -1880,6 +1883,7 @@ void OLAPEngine::perform_base_compaction() {
     res = base_compaction.run();
     if (res != OLAP_SUCCESS) {
         DorisMetrics::base_compaction_request_failed.increment(1);
+        best_table->set_last_compaction_failure_time(UnixMillis());
         LOG(WARNING) << "failed to init base compaction"
                      << ", table=" << best_table->full_name()
                      << ", res=" << res;
@@ -1891,9 +1895,16 @@ OLAPTablePtr OLAPEngine::_find_best_tablet_to_compaction(CompactionType compacti
     ReadLock tablet_map_rdlock(&_tablet_map_lock);
     uint32_t highest_score = 0;
     OLAPTablePtr best_table;
+    int64_t now = UnixMillis();
     for (tablet_map_t::value_type& table_ins : _tablet_map){
         for (OLAPTablePtr& table_ptr : table_ins.second.table_arr) {
             if (!table_ptr->is_used() || !table_ptr->is_loaded() || !_can_do_compaction(table_ptr)) {
+                continue;
+            }
+
+            if (now - table_ptr->last_compaction_failure_time() <= config::min_compaction_failure_interval_ms) {
+                LOG(INFO) << "tablet last compaction failure time is: " << table_ptr->last_compaction_failure_time()
+                        << ", skip it";
                 continue;
             }
 

--- a/be/src/olap/olap_header.cpp
+++ b/be/src/olap/olap_header.cpp
@@ -754,7 +754,7 @@ OLAPStatus OLAPHeader::select_versions_to_span(const Version& target_version,
 
     VLOG(10) << "calculated shortest path. "
              << "version=" << target_version.first << "-" << target_version.second
-             << "path=" << shortest_path_for_debug.str();
+             << " path=" << shortest_path_for_debug.str();
 
     return OLAP_SUCCESS;
 }

--- a/be/src/olap/olap_table.cpp
+++ b/be/src/olap/olap_table.cpp
@@ -149,7 +149,8 @@ OLAPTable::OLAPTable(OLAPHeader* header, OlapStore* store) :
         _id(0),
         _store(store),
         _is_loaded(false),
-        _is_bad(false) {
+        _is_bad(false),
+        _last_compaction_failure_time(0) {
     if (header == NULL) {
         return;  // for convenience of mock test.
     }

--- a/be/src/olap/olap_table.h
+++ b/be/src/olap/olap_table.h
@@ -628,6 +628,12 @@ public:
 
     void set_bad(bool is_bad) { _is_bad = is_bad; }
 
+    int64_t last_compaction_failure_time() { return _last_compaction_failure_time; }
+
+    void set_last_compaction_failure_time(int64_t time) {
+        _last_compaction_failure_time = time;
+    }
+
     // 得到当前table的root path路径，路径末尾不带斜杠(/)
     std::string storage_root_path_name() {
         return _storage_root_path;
@@ -756,6 +762,7 @@ private:
 
     bool _table_for_check;
     std::atomic<bool> _is_bad;   // if this tablet is broken, set to true. default is false
+    std::atomic<int64_t> _last_compaction_failure_time; // timestamp of last compaction failure
 
     DISALLOW_COPY_AND_ASSIGN(OLAPTable);
 };

--- a/fe/src/main/java/org/apache/doris/analysis/Expr.java
+++ b/fe/src/main/java/org/apache/doris/analysis/Expr.java
@@ -632,10 +632,15 @@ abstract public class Expr extends TreeNode<Expr> implements ParseNode, Cloneabl
      * If smap is null, this function is equivalent to clone().
      * If preserveRootType is true, the resulting expr tree will be cast if necessary to
      * the type of 'this'.
+     * 
+     * @throws AnalysisException
      */
-    public Expr substitute(ExprSubstitutionMap smap, Analyzer analyzer, boolean preserveRootType) {
+    public Expr substitute(ExprSubstitutionMap smap, Analyzer analyzer, boolean preserveRootType)
+            throws AnalysisException {
         try {
             return trySubstitute(smap, analyzer, preserveRootType);
+        } catch (AnalysisException e) {
+            throw e;
         } catch (Exception e) {
             throw new IllegalStateException("Failed analysis after expr substitution.", e);
         }

--- a/fe/src/main/java/org/apache/doris/analysis/OrderByElement.java
+++ b/fe/src/main/java/org/apache/doris/analysis/OrderByElement.java
@@ -17,11 +17,12 @@
 
 package org.apache.doris.analysis;
 
+import org.apache.doris.common.AnalysisException;
+
+import com.google.common.collect.Lists;
+
 import java.util.ArrayList;
 import java.util.List;
-
-import org.apache.doris.common.AnalysisException;
-import com.google.common.collect.Lists;
 
 /**
  * Combination of expr and ASC/DESC, and nulls ordering.
@@ -97,7 +98,7 @@ public class OrderByElement {
      * @throws AnalysisException
      */
     public static ArrayList<OrderByElement> substitute(List<OrderByElement> src,
-            ExprSubstitutionMap smap, Analyzer analyzer) {
+            ExprSubstitutionMap smap, Analyzer analyzer) throws AnalysisException {
         ArrayList<OrderByElement> result = Lists.newArrayListWithCapacity(src.size());
 
         for (OrderByElement element: src) {

--- a/thirdparty/build-thirdparty.sh
+++ b/thirdparty/build-thirdparty.sh
@@ -176,8 +176,8 @@ build_openssl() {
     make -j$PARALLEL && make install
     if [ -f $TP_INSTALL_DIR/lib64/libcrypto.a ]; then
         mkdir -p $TP_INSTALL_DIR/lib && \
-        ln -s $TP_INSTALL_DIR/lib64/libcrypto.a $TP_INSTALL_DIR/lib/libcrypto.a && \
-        ln -s $TP_INSTALL_DIR/lib64/libssl.a $TP_INSTALL_DIR/lib/libssl.a
+        cp $TP_INSTALL_DIR/lib64/libcrypto.a $TP_INSTALL_DIR/lib/libcrypto.a && \
+        cp $TP_INSTALL_DIR/lib64/libssl.a $TP_INSTALL_DIR/lib/libssl.a
     fi
     # NOTE(zc): remove this dynamic library files to make libcurl static link.
     # If I don't remove this files, I don't known how to make libcurl link static library
@@ -327,12 +327,12 @@ build_snappy() {
     -DSNAPPY_BUILD_TESTS=0 ../
     make -j$PARALLEL && make install
     if [ -f $TP_INSTALL_DIR/lib64/libsnappy.a ]; then
-        mkdir -p $TP_INSTALL_DIR/lib && ln -s $TP_INSTALL_DIR/lib64/libsnappy.a $TP_INSTALL_DIR/lib/libsnappy.a
+        mkdir -p $TP_INSTALL_DIR/lib && cp $TP_INSTALL_DIR/lib64/libsnappy.a $TP_INSTALL_DIR/lib/libsnappy.a
         #build for libarrow.a
-        ln -s $TP_INCLUDE_DIR/snappy/snappy-c.h  $TP_INCLUDE_DIR/snappy-c.h && \
-        ln -s $TP_INCLUDE_DIR/snappy/snappy-sinksource.h  $TP_INCLUDE_DIR/snappy-sinksource.h && \
-        ln -s $TP_INCLUDE_DIR/snappy/snappy-stubs-public.h  $TP_INCLUDE_DIR/snappy-stubs-public.h && \
-        ln -s $TP_INCLUDE_DIR/snappy/snappy.h  $TP_INCLUDE_DIR/snappy.h
+        cp $TP_INCLUDE_DIR/snappy/snappy-c.h  $TP_INCLUDE_DIR/snappy-c.h && \
+        cp $TP_INCLUDE_DIR/snappy/snappy-sinksource.h  $TP_INCLUDE_DIR/snappy-sinksource.h && \
+        cp $TP_INCLUDE_DIR/snappy/snappy-stubs-public.h  $TP_INCLUDE_DIR/snappy-stubs-public.h && \
+        cp $TP_INCLUDE_DIR/snappy/snappy.h  $TP_INCLUDE_DIR/snappy.h
     fi
 }
 
@@ -493,7 +493,7 @@ build_brpc() {
     -DProtobuf_PROTOC_EXECUTABLE=$TP_INSTALL_DIR/bin/protoc ..
     make -j$PARALLEL && make install
     if [ -f $TP_INSTALL_DIR/lib/libbrpc.a ]; then
-        mkdir -p $TP_INSTALL_DIR/lib64 && ln -s $TP_INSTALL_DIR/lib/libbrpc.a $TP_INSTALL_DIR/lib64/libbrpc.a
+        mkdir -p $TP_INSTALL_DIR/lib64 && cp $TP_INSTALL_DIR/lib/libbrpc.a $TP_INSTALL_DIR/lib64/libbrpc.a
     fi
 }
 


### PR DESCRIPTION
A bad tablet is always be chosen to do compaction, and failed again
and again, which may block compaction of other tablets.
Add a BE config 'min_compaction_failure_interval_ms' to avoid choosing
bad tablet again at a certain interval, so that other tablets have
chance to do the compaction.

Also fix a bug that using avg() function on varchar column return
unexpected exception. ISSUE: #363 