### PR TITLE
Check _empty when convert old files or make snapshots

### DIFF
--- a/be/src/olap/olap_snapshot_converter.h
+++ b/be/src/olap/olap_snapshot_converter.h
@@ -68,7 +68,8 @@ public:
 
     // from olap header to tablet meta
     OLAPStatus to_new_snapshot(const OLAPHeaderMessage& olap_header, const string& old_data_path_prefix, 
-        const string& new_data_path_prefix, DataDir& data_dir, TabletMetaPB* tablet_meta_pb, vector<RowsetMetaPB>* pending_rowsets);
+        const string& new_data_path_prefix, DataDir& data_dir, TabletMetaPB* tablet_meta_pb, 
+        vector<RowsetMetaPB>* pending_rowsets, bool is_startup);
 
     // from tablet meta to olap header
     OLAPStatus to_old_snapshot(const TabletMetaPB& tablet_meta_pb, string& new_data_path_prefix, 

--- a/be/src/olap/olap_snapshot_converter.h
+++ b/be/src/olap/olap_snapshot_converter.h
@@ -75,6 +75,9 @@ public:
         string& old_data_path_prefix, OLAPHeaderMessage* olap_header);
     
     OLAPStatus save(const string& file_path, const OLAPHeaderMessage& olap_header);
+
+private:
+    void _modify_old_segment_group_id(RowsetMetaPB& rowset_meta);
 };
 
 }

--- a/be/src/olap/rowset/segment_group.cpp
+++ b/be/src/olap/rowset/segment_group.cpp
@@ -150,8 +150,14 @@ SegmentGroup::~SegmentGroup() {
 }
 
 std::string SegmentGroup::_construct_file_name(int32_t segment_id, const string& suffix) const {
+    // during convert from old files, the segment group id == -1, but we want to convert
+    // it to 0
+    int32_t tmp_sg_id = 0;
+    if (_segment_group_id > 0) {
+        tmp_sg_id = _segment_group_id;
+    }
     std::string file_name = std::to_string(_rowset_id) + "_"
-            + std::to_string(_segment_group_id) + "_" + std::to_string(segment_id) + suffix;
+            + std::to_string(tmp_sg_id) + "_" + std::to_string(segment_id) + suffix;
     return file_name;
 }
 
@@ -398,6 +404,7 @@ OLAPStatus SegmentGroup::validate() {
 }
 
 bool SegmentGroup::check() {
+    // if the segment group is converted from old files, _empty == false but _num_segments == 0
     if (_empty && (_num_segments > 0 || !zero_num_rows())) {
         LOG(WARNING) << "invalid num segments for empty segment group, _num_segments:" << _num_segments
                 << ",num rows:" << num_rows();
@@ -687,6 +694,9 @@ int64_t SegmentGroup::get_tablet_id() {
 
 OLAPStatus SegmentGroup::make_snapshot(const std::string& snapshot_path,
                                        std::vector<std::string>* success_links) {
+    if (_empty) {
+        return OLAP_SUCCESS;
+    }
     for (int segment_id = 0; segment_id < _num_segments; segment_id++) {
         std::string snapshot_data_file_name = construct_data_file_path(snapshot_path, segment_id);
         if (!check_dir_existed(snapshot_data_file_name)) {
@@ -714,6 +724,10 @@ OLAPStatus SegmentGroup::make_snapshot(const std::string& snapshot_path,
 
 OLAPStatus SegmentGroup::convert_from_old_files(const std::string& snapshot_path,
                                        std::vector<std::string>* success_links) {
+    if (_empty) {
+        // the segment group is empty, it does not have files, just return
+        return OLAP_SUCCESS;
+    }
     for (int segment_id = 0; segment_id < _num_segments; segment_id++) {
         std::string new_data_file_name = construct_data_file_path(_rowset_path_prefix, segment_id);
         if (!check_dir_existed(new_data_file_name)) {
@@ -747,6 +761,9 @@ OLAPStatus SegmentGroup::convert_from_old_files(const std::string& snapshot_path
 
 OLAPStatus SegmentGroup::convert_to_old_files(const std::string& snapshot_path,
                                        std::vector<std::string>* success_links) {
+    if (_empty) {
+        return OLAP_SUCCESS;
+    }
     for (int segment_id = 0; segment_id < _num_segments; segment_id++) {
         std::string new_data_file_name = construct_data_file_path(_rowset_path_prefix, segment_id);
         std::string old_data_file_name = construct_old_data_file_path(snapshot_path, segment_id);

--- a/be/src/olap/tablet_manager.cpp
+++ b/be/src/olap/tablet_manager.cpp
@@ -510,11 +510,7 @@ OLAPStatus TabletManager::_drop_tablet_unlock(
     TSchemaHash related_schema_hash = alter_task->related_schema_hash();;
 
     // Check tablet is in schema change or not, is base tablet or not
-    bool is_schema_change_finished = true;
-    // alter finished? or alter_failed?
-    if (alter_state != ALTER_FINISHED) { 
-        is_schema_change_finished = false;
-    }
+    bool is_schema_change_finished = (alter_state == ALTER_FINISHED || alter_state == ALTER_FAILED);
 
     bool is_drop_base_tablet = false;
     TabletSharedPtr related_tablet = _get_tablet_with_no_lock(

--- a/be/src/olap/task/engine_clone_task.cpp
+++ b/be/src/olap/task/engine_clone_task.cpp
@@ -640,7 +640,8 @@ OLAPStatus EngineCloneTask::_convert_to_new_snapshot(DataDir& data_dir, const st
     OlapSnapshotConverter converter;
     TabletMetaPB tablet_meta_pb;
     vector<RowsetMetaPB> pending_rowsets;
-    res = converter.to_new_snapshot(olap_header_msg, clone_dir, clone_dir, data_dir, &tablet_meta_pb, &pending_rowsets);
+    res = converter.to_new_snapshot(olap_header_msg, clone_dir, clone_dir, data_dir, &tablet_meta_pb, 
+        &pending_rowsets, false);
     if (res != OLAP_SUCCESS) {
         LOG(WARNING) << "fail to convert snapshot to new format. dir='" << clone_dir;
         return res;

--- a/be/test/olap/olap_snapshot_converter_test.cpp
+++ b/be/test/olap/olap_snapshot_converter_test.cpp
@@ -119,7 +119,7 @@ TEST_F(OlapSnapshotConverterTest, ToNewAndToOldSnapshot) {
     TabletMetaPB tablet_meta_pb;
     vector<RowsetMetaPB> pending_rowsets;
     OLAPStatus status = converter.to_new_snapshot(header_msg, _tablet_data_path, _tablet_data_path, 
-        *_data_dir, &tablet_meta_pb, &pending_rowsets);
+        *_data_dir, &tablet_meta_pb, &pending_rowsets, true);
     ASSERT_TRUE(status == OLAP_SUCCESS);
 
     TabletSchema tablet_schema;

--- a/gensrc/proto/olap_file.proto
+++ b/gensrc/proto/olap_file.proto
@@ -193,8 +193,8 @@ enum AlterTabletState {
 }
 
 enum AlterTabletType {
-    SCHEMA_CHANGE = 0;
-    ROLLUP = 1;
+    SCHEMA_CHANGE = 1;
+    ROLLUP = 2;
 }
 
 message AlterTabletPB {


### PR DESCRIPTION
1. check _empty when convert old files or make snapshots
2. change segment group id from -1 to 0 when convert old files.