### PR TITLE
Modify FE sys log and audit log configuration

### DIFF
--- a/conf/fe.conf
+++ b/conf/fe.conf
@@ -8,7 +8,7 @@
 LOG_DIR = ${DORIS_HOME}/log
 
 DATE = `date +%Y%m%d-%H%M%S`
-JAVA_OPTS="-Xmx2024m -XX:+UseMembar -XX:SurvivorRatio=8 -XX:MaxTenuringThreshold=7 -XX:+PrintGCDateStamps -XX:+PrintGCDetails -XX:+UseConcMarkSweepGC -XX:+UseParNewGC -XX:+UseCMSCompactAtFullCollection -XX:CMSFullGCsBeforeCompaction=0 -XX:+CMSClassUnloadingEnabled -XX:-CMSParallelRemarkEnabled -XX:CMSInitiatingOccupancyFraction=80 -XX:SoftRefLRUPolicyMSPerMB=0 -Xloggc:$DORIS_HOME/log/fe.gc.log.$DATE"
+JAVA_OPTS="-Xmx4096m -XX:+UseMembar -XX:SurvivorRatio=8 -XX:MaxTenuringThreshold=7 -XX:+PrintGCDateStamps -XX:+PrintGCDetails -XX:+UseConcMarkSweepGC -XX:+UseParNewGC -XX:+UseCMSCompactAtFullCollection -XX:CMSFullGCsBeforeCompaction=0 -XX:+CMSClassUnloadingEnabled -XX:-CMSParallelRemarkEnabled -XX:CMSInitiatingOccupancyFraction=80 -XX:SoftRefLRUPolicyMSPerMB=0 -Xloggc:$DORIS_HOME/log/fe.gc.log.$DATE"
 
 ##
 ## the lowercase properties are read by main program.
@@ -33,13 +33,12 @@ edit_log_port = 9010
 # priority_networks = 10.10.10.0/24;192.168.0.0/16
 
 # Advanced configurations 
+# log_roll_size_mb = 1024
 # sys_log_dir = ${DORIS_HOME}/log
-# sys_log_roll_mode = SIZE-MB-1024
 # sys_log_roll_num = 10
 # sys_log_verbose_modules = 
-# audit_log_dir = 
+# audit_log_dir = ${DORIS_HOME}/log
 # audit_log_modules = slow_query, query
-# audit_log_roll_mode = TIME-DAY
 # audit_log_roll_num = 10
 # meta_delay_toleration_second = 10
 # qe_max_connection = 1024

--- a/fe/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/src/main/java/org/apache/doris/common/Config.java
@@ -18,46 +18,67 @@
 package org.apache.doris.common;
 
 public class Config extends ConfigBase {
+    
+    /*
+     * The max size of one sys log and audit log
+     */
+    @ConfField public static int log_roll_size_mb = 1024; // 1 GB
 
     /*
-     * This specifies FE log dir. FE will produces 2 log files:
-     * fe.log:      all logs of FE process.
-     * fe.warn.log  all WARNING and ERROR log of FE process.
+     * sys_log_dir:
+     *      This specifies FE log dir. FE will produces 2 log files:
+     *      fe.log:      all logs of FE process.
+     *      fe.warn.log  all WARNING and ERROR log of FE process.
+     *      
+     * sys_log_level:
+     *      INFO, WARNING, ERROR, FATAL
+     *      
+     * sys_log_roll_num:
+     *      Maximal FE log files to be kept.
+     *      
+     * sys_log_verbose_modules:
+     *      Verbose modules. VERBOSE level is implemented by log4j DEBUG level.
+     *      eg:
+     *          sys_log_verbose_modules = org.apache.doris.catalog
+     *      This will only print debug log of files in package org.apache.doris.catalog and all its sub packages.
+     *      
+     * sys_log_roll_interval:
+     *      DAY:  log suffix is yyyyMMdd
+     *      HOUR: log suffix is yyyyMMddHH
      */
     @ConfField public static String sys_log_dir = System.getenv("DORIS_HOME") + "/log";
-    @ConfField public static String sys_log_level = "INFO"; // INFO, WARNING, ERROR, FATAL
-    /*
-     * The roll mode of FE log files.
-     * TIME-DAY:    roll every day.
-     * TIME-HOUR:   roll every hour.
-     * SIZE-MB-nnn: roll by size.
-     */
-    @ConfField public static String sys_log_roll_mode = "SIZE-MB-1024"; // TIME-DAY， TIME-HOUR， SIZE-MB-nnn
-    /*
-     * Maximal FE log files to be kept.
-     * Doesn't work if roll mode is TIME-*
-     */
+    @ConfField public static String sys_log_level = "INFO"; 
     @ConfField public static int sys_log_roll_num = 10;
-
-    /*
-     * Verbose modules. VERBOSE level is implemented by log4j DEBUG level.
-     * eg:
-     *      sys_log_verbose_modules = org.apache.doris.catalog
-     *  This will only print verbose log of files in package org.apache.doris.catalog and all its sub packages.
-     */
     @ConfField public static String[] sys_log_verbose_modules = {};
+    @ConfField public static String sys_log_roll_interval = "DAY";
+    @Deprecated
+    @ConfField public static String sys_log_roll_mode = "SIZE-MB-1024";
 
     /*
-     * This specifies FE audit log dir.
-     * Audit log fe.audit.log contains all SQL queries with related infos such as user, host, cost, status, etc.
+     * audit_log_dir:
+     *      This specifies FE audit log dir.
+     *      Audit log fe.audit.log contains all requests with related infos such as user, host, cost, status, etc.
+     * 
+     * audit_log_roll_num:
+     *      Maximal FE audit log files to be kept.
+     *      
+     * audit_log_modules:
+     *       Slow query contains all queries which cost exceed *qe_slow_log_ms*
+     *       
+     * qe_slow_log_ms:
+     *      If the response time of a query exceed this threshold, it will be recored in audit log as slow_query.
+     *      
+     * audit_log_roll_interval:
+     *      DAY:  log suffix is yyyyMMdd
+     *      HOUR: log suffix is yyyyMMddHH
      */
     @ConfField public static String audit_log_dir = System.getenv("DORIS_HOME") + "/log";
-    /*
-     * Slow query contains all queries which cost exceed *qe_slow_log_ms*
-     */
+    @ConfField public static int audit_log_roll_num = 90; // nearly 3 months
     @ConfField public static String[] audit_log_modules = {"slow_query", "query"};
-    @ConfField public static String audit_log_roll_mode = "TIME-DAY"; // TIME-DAY， TIME-HOUR， SIZE-MB-nnn
-    @ConfField public static int audit_log_roll_num = 10; // Doesn't work if roll mode is TIME-*
+    @ConfField(mutable = true) public static long qe_slow_log_ms = 5000;
+    @ConfField public static String audit_log_roll_interval = "DAY";
+    @Deprecated
+    @ConfField public static String audit_log_roll_mode = "TIME-DAY";
 
     /*
      * Labels of finished or cancelled load jobs will be removed after *label_keep_max_second*
@@ -522,11 +543,7 @@ public class Config extends ConfigBase {
      * Maximal number of connections per user, per FE.
      */
     @ConfField public static int max_conn_per_user = 100;
-    /*
-     * If the response time of a query exceed this threshold, it will be recored in audit log as slow_query.
-     */
-    @ConfField(mutable = true)
-    public static long qe_slow_log_ms = 5000;
+
     /*
     * The memory_limit for colocote join PlanFragment instance =
     * exec_mem_limit / min (query_colocate_join_memory_limit_penalty_factor, instance_num)


### PR DESCRIPTION
Change all FE logs with suffix `yyyyMMdd` or `yyyyMMddHH`, specified by 2 new
configurations: 'sys_log_roll_interval' and 'audit_log_roll_interval'

All FE logs are now rolling at max size of 1024MB(default), specified by new
configuration: 'log_roll_size_mb'

By default, the new FE logs will look like this:

log/
    fe.audit.log
    fe.audit.log.20190524-1
    fe.audit.log.20190523-2
    fe.log
    fe.log.20190524-1
    fe.log.20190524-2
    fe.log.20190523-3
    fe.warn.log
    fe.warn.log.20190524-1
    fe.warn.log.20190523-2
    fe.gc.log.20190524

Configurations 'sys_log_roll_mode' and 'audit_log_roll_mode' are deprecated.

ISSUE: #1197 