### PR TITLE
Fix datediff function 

### DIFF
--- a/fe/src/main/java/org/apache/doris/rewrite/FEFunctions.java
+++ b/fe/src/main/java/org/apache/doris/rewrite/FEFunctions.java
@@ -57,7 +57,7 @@ public class FEFunctions {
     public static IntLiteral dateDiff(LiteralExpr first, LiteralExpr second) throws AnalysisException {
         String[] parsePatterns = { "yyyyMMdd" };
         try {
-            //DATEDIFF function only uses the date part for calculations and ignores the time part
+            // DATEDIFF function only uses the date part for calculations and ignores the time part
             long diff = DateUtils.parseDate(first.getStringValue(), parsePatterns).getTime()
                     - DateUtils.parseDate(second.getStringValue(), parsePatterns).getTime();
             long datediff = diff / 1000 / 60 / 60 / 24;

--- a/fe/src/main/java/org/apache/doris/rewrite/FEFunctions.java
+++ b/fe/src/main/java/org/apache/doris/rewrite/FEFunctions.java
@@ -17,7 +17,6 @@
 
 package org.apache.doris.rewrite;
 
-import com.google.common.collect.Lists;
 import org.apache.doris.analysis.DateLiteral;
 import org.apache.doris.analysis.DecimalLiteral;
 import org.apache.doris.analysis.FloatLiteral;

--- a/fe/src/main/java/org/apache/doris/rewrite/FEFunctions.java
+++ b/fe/src/main/java/org/apache/doris/rewrite/FEFunctions.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.rewrite;
 
+import com.google.common.collect.Lists;
 import org.apache.doris.analysis.DateLiteral;
 import org.apache.doris.analysis.DecimalLiteral;
 import org.apache.doris.analysis.FloatLiteral;
@@ -55,9 +56,15 @@ public class FEFunctions {
 
     @FEFunction(name = "datediff", argTypes = { "DATETIME", "DATETIME" }, returnType = "INT")
     public static IntLiteral dateDiff(LiteralExpr first, LiteralExpr second) throws AnalysisException {
-        long diff = getTime(first) - getTime(second);
-        long datediff = diff / 1000 / 60 / 60 / 24;
-        return new IntLiteral(datediff, Type.INT);
+        String[] parsePatterns = { "yyyyMMdd" };
+        try {
+            long diff = DateUtils.parseDate(first.getStringValue(), parsePatterns).getTime()
+                    - DateUtils.parseDate(second.getStringValue(), parsePatterns).getTime();
+            long datediff = diff / 1000 / 60 / 60 / 24;
+            return new IntLiteral(datediff, Type.INT);
+        } catch (ParseException e) {
+            throw new AnalysisException(e.getLocalizedMessage());
+        }
     }
 
     @FEFunction(name = "date_add", argTypes = { "DATETIME", "INT" }, returnType = "DATETIME")

--- a/fe/src/main/java/org/apache/doris/rewrite/FEFunctions.java
+++ b/fe/src/main/java/org/apache/doris/rewrite/FEFunctions.java
@@ -57,6 +57,7 @@ public class FEFunctions {
     public static IntLiteral dateDiff(LiteralExpr first, LiteralExpr second) throws AnalysisException {
         String[] parsePatterns = { "yyyyMMdd" };
         try {
+            //DATEDIFF function only uses the date part for calculations and ignores the time part
             long diff = DateUtils.parseDate(first.getStringValue(), parsePatterns).getTime()
                     - DateUtils.parseDate(second.getStringValue(), parsePatterns).getTime();
             long datediff = diff / 1000 / 60 / 60 / 24;

--- a/fe/src/main/java/org/apache/doris/rewrite/FEFunctions.java
+++ b/fe/src/main/java/org/apache/doris/rewrite/FEFunctions.java
@@ -38,6 +38,7 @@ import java.text.ParseException;
 import org.joda.time.format.DateTimeFormatter;
 import org.joda.time.format.DateTimeFormatterBuilder;
 
+import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.Locale;
@@ -55,11 +56,10 @@ public class FEFunctions {
 
     @FEFunction(name = "datediff", argTypes = { "DATETIME", "DATETIME" }, returnType = "INT")
     public static IntLiteral dateDiff(LiteralExpr first, LiteralExpr second) throws AnalysisException {
-        String[] parsePatterns = { "yyyyMMdd" };
+        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
         try {
             // DATEDIFF function only uses the date part for calculations and ignores the time part
-            long diff = DateUtils.parseDate(first.getStringValue(), parsePatterns).getTime()
-                    - DateUtils.parseDate(second.getStringValue(), parsePatterns).getTime();
+            long diff = sdf.parse(first.getStringValue()).getTime() - sdf.parse(second.getStringValue()).getTime();
             long datediff = diff / 1000 / 60 / 60 / 24;
             return new IntLiteral(datediff, Type.INT);
         } catch (ParseException e) {

--- a/fe/src/test/java/org/apache/doris/rewrite/FEFunctionsTest.java
+++ b/fe/src/test/java/org/apache/doris/rewrite/FEFunctionsTest.java
@@ -54,11 +54,11 @@ public class FEFunctionsTest {
 
     @Test
     public void dateDiffTest() throws AnalysisException {
-        IntLiteral actualResult = FEFunctions.dateDiff(new StringLiteral("2010-11-30 23:59:59"), new StringLiteral("2010-12-31"));
+        IntLiteral actualResult = FEFunctions.dateDiff(new DateLiteral("2010-11-30 23:59:59", Type.DATETIME), new DateLiteral("2010-12-31", Type.DATE));
         IntLiteral expectedResult = new IntLiteral(-31);
         Assert.assertEquals(expectedResult, actualResult);
 
-        actualResult = FEFunctions.dateDiff(new StringLiteral("2010-11-30 23:59:50"), new StringLiteral("2010-12-30 23:59:59"));
+        actualResult = FEFunctions.dateDiff(new DateLiteral("2010-11-30 23:59:50", Type.DATETIME), new DateLiteral("2010-12-30 23:59:59", Type.DATETIME));
         expectedResult = new IntLiteral(-30);
         Assert.assertEquals(expectedResult, actualResult);
     }

--- a/fe/src/test/java/org/apache/doris/rewrite/FEFunctionsTest.java
+++ b/fe/src/test/java/org/apache/doris/rewrite/FEFunctionsTest.java
@@ -58,7 +58,7 @@ public class FEFunctionsTest {
         IntLiteral expectedResult = new IntLiteral(-31);
         Assert.assertEquals(expectedResult, actualResult);
 
-        actualResult = FEFunctions.dateDiff(new StringLiteral("2010-11-30 23:59:50"), new StringLiteral("2010-12-30  23:59:59"));
+        actualResult = FEFunctions.dateDiff(new StringLiteral("2010-11-30 23:59:50"), new StringLiteral("2010-12-30 23:59:59"));
         expectedResult = new IntLiteral(-30);
         Assert.assertEquals(expectedResult, actualResult);
     }

--- a/fe/src/test/java/org/apache/doris/rewrite/FEFunctionsTest.java
+++ b/fe/src/test/java/org/apache/doris/rewrite/FEFunctionsTest.java
@@ -53,6 +53,17 @@ public class FEFunctionsTest {
     }
 
     @Test
+    public void dateDiffTest() throws AnalysisException {
+        IntLiteral actualResult = FEFunctions.dateDiff(new StringLiteral("2010-11-30 23:59:59"), new StringLiteral("2010-12-31"));
+        IntLiteral expectedResult = new IntLiteral(-31);
+        Assert.assertEquals(expectedResult, actualResult);
+
+        actualResult = FEFunctions.dateDiff(new StringLiteral("2010-11-30 23:59:50"), new StringLiteral("2010-12-30  23:59:59"));
+        expectedResult = new IntLiteral(-30);
+        Assert.assertEquals(expectedResult, actualResult);
+    }
+
+    @Test
     public void dateAddTest() throws AnalysisException {
         DateLiteral actualResult = FEFunctions.dateAdd(new StringLiteral("2018-08-08"), new IntLiteral(1));
         DateLiteral expectedResult = new DateLiteral("2018-08-09", Type.DATE);


### PR DESCRIPTION
Fix the datediff function to compatible with MySQL function logic
The DATEDIFF function only uses the date part for calculations and ignores the time part