### PR TITLE
Reduce memory RowBlock needed

### DIFF
--- a/be/src/exec/olap_scanner.cpp
+++ b/be/src/exec/olap_scanner.cpp
@@ -465,6 +465,7 @@ void OlapScanner::update_counter() {
 
 void OlapScanner::_update_realtime_counter() {
     COUNTER_UPDATE(_parent->bytes_read_counter(), _reader->stats().bytes_read);
+    _reader->mutable_stats()->bytes_read = 0;
 }
 
 Status OlapScanner::close(RuntimeState* state) {

--- a/be/src/olap/column_data.cpp
+++ b/be/src/olap/column_data.cpp
@@ -476,6 +476,7 @@ void ColumnData::set_read_params(
     RowBlockInfo block_info;
     block_info.row_num = _num_rows_per_block;
     block_info.null_supported = true;
+    block_info.column_ids = _seek_columns;
     _read_block->init(block_info);
 }
 

--- a/be/src/olap/data_writer.cpp
+++ b/be/src/olap/data_writer.cpp
@@ -101,7 +101,7 @@ OLAPStatus ColumnDataWriter::init() {
 
     VLOG(3) << "init ColumnData writer. [table='" << _table->full_name()
             << "' block_row_size=" << _table->num_rows_per_row_block() << "]";
-    RowBlockInfo block_info(0U, _table->num_rows_per_row_block(), 0);
+    RowBlockInfo block_info(0U, _table->num_rows_per_row_block());
     block_info.data_file_type = DataFileType::COLUMN_ORIENTED_FILE;
     block_info.null_supported = true;
 

--- a/be/src/olap/reader.h
+++ b/be/src/olap/reader.h
@@ -124,6 +124,7 @@ public:
     }
 
     const OlapReaderStatistics& stats() const { return _stats; }
+    OlapReaderStatistics* mutable_stats() { return &_stats; }
 
 private:
     struct KeysParam {

--- a/be/src/olap/row_block.cpp
+++ b/be/src/olap/row_block.cpp
@@ -21,6 +21,7 @@
 
 #include <algorithm>
 #include <cstring>
+#include <limits>
 
 #include "exprs/expr.h"
 #include "olap/field.h"
@@ -45,7 +46,6 @@ RowBlock::RowBlock(const vector<FieldInfo>& tablet_schema) :
 
 RowBlock::~RowBlock() {
     delete[] _mem_buf;
-    delete[] _storage_buf;
 }
 
 OLAPStatus RowBlock::init(const RowBlockInfo& block_info) {
@@ -56,206 +56,7 @@ OLAPStatus RowBlock::init(const RowBlockInfo& block_info) {
     _capacity = _info.row_num;
     _compute_layout();
     _mem_buf = new char[_mem_buf_bytes];
-    _storage_buf = new char[_storage_buf_bytes];
     return OLAP_SUCCESS;
-}
-
-OLAPStatus RowBlock::serialize_to_row_format(
-        char* dest_buffer, size_t dest_len, size_t* written_len,
-        OLAPCompressionType compression_type) {
-    _convert_memory_to_storage(_info.row_num);
-    _info.checksum = olap_crc32(CRC32_INIT, _storage_buf, _storage_buf_used_bytes);
-    _info.unpacked_len = _storage_buf_used_bytes;
-    return olap_compress(_storage_buf,
-                         _storage_buf_used_bytes,
-                         dest_buffer,
-                         dest_len,
-                         written_len,
-                         compression_type);
-}
-
-OLAPStatus RowBlock::decompress(const char* src_buffer,
-                            size_t src_len,
-                            OLAPCompressionType compression_type) {
-    size_t written_len = 0;
-    OLAPStatus res = olap_decompress(src_buffer,
-                                     src_len,
-                                     _storage_buf,
-                                     _storage_buf_bytes,
-                                     &written_len,
-                                     compression_type);
-    if (res != OLAP_SUCCESS) {
-        OLAP_LOG_WARNING("fail to do olap_decompress. [res=%d]", res);
-        return res;
-    }
-    if (_need_checksum) {
-        uint32_t checksum = olap_crc32(CRC32_INIT, _storage_buf, written_len);
-        if (_info.checksum != checksum) {
-            OLAP_LOG_WARNING("crc32 value does not match. [crc32_value=%u _info.checksum=%u]",
-                             checksum,
-                             _info.checksum);
-            return OLAP_ERR_CHECKSUM_ERROR;
-        }
-    }
-    _convert_storage_to_memory();
-    return OLAP_SUCCESS;
-}
-
-void RowBlock::_convert_storage_to_memory() {
-    /*
-     * This function is used to convert storage
-     * layout to memory layout for row-oriented storage.
-     * In this procedure, string type(Varchar/Char/Hyperloglog)
-     * should be converted with caution.
-     * This function will not be called in columnar-oriented storage.
-     */
-
-    char* storage_ptr = _storage_buf;
-
-    // some data file in history not suppored null
-    size_t null_byte = has_nullbyte() ? 1 : 0;
-    for (int col = 0; col < _field_count; ++col) {
-        char* memory_ptr = _mem_buf + _field_offset_in_memory[col];
-        if (_tablet_schema[col].type == OLAP_FIELD_TYPE_VARCHAR ||
-                _tablet_schema[col].type == OLAP_FIELD_TYPE_HLL) {
-            for (int row = 0; row < _info.row_num; ++row) {
-                /*
-                 * Varchar is in offset -> nullbyte|length|content format in storage
-                 * Varchar is in nullbyte|length|ptr in memory
-                 * We need copy three part: nullbyte|length|content
-                 * 1. get values' pointer using offset
-                 * 2. copy null byte
-                 * 3. copy length and content into addrs pointed by ptr
-                 */
-
-                // 1: work out the string pointer by offset
-                uint32_t offset = *reinterpret_cast<StringOffsetType*>(storage_ptr);
-                storage_ptr += sizeof(StringOffsetType);
-                char* value_ptr = _storage_buf + offset;
-
-                // 2: copy null byte
-                *reinterpret_cast<bool*>(memory_ptr) = false;
-                memory_copy(memory_ptr, value_ptr, null_byte);
-
-                // 3. copy length and content
-                size_t storage_field_bytes =
-                    *(StringLengthType*)(value_ptr + null_byte);
-                value_ptr += sizeof(StringLengthType);
-                Slice* slice = reinterpret_cast<Slice*>(memory_ptr + 1);
-                slice->data = value_ptr + null_byte;
-                slice->size = storage_field_bytes;
-
-                memory_ptr += _mem_row_bytes;
-            }
-        } else if (_tablet_schema[col].type == OLAP_FIELD_TYPE_CHAR) {
-            size_t storage_field_bytes = _tablet_schema[col].length;
-            for (int row = 0; row < _info.row_num; ++row) {
-                /*
-                 * Char is in nullbyte|content with fixed length in storage
-                 * Char is in nullbyte|length|ptr in memory
-                 * We need copy three part: nullbyte|length|content
-                 * 1. copy null byte
-                 * 2. copy length and content into addrs pointed by ptr
-                 */
-
-                // 1. copy null byte
-                *reinterpret_cast<bool*>(memory_ptr) = false;
-                memory_copy(memory_ptr, storage_ptr, null_byte);
-
-                // 2. copy length and content
-                Slice* slice = reinterpret_cast<Slice*>(memory_ptr + 1);
-                slice->data = storage_ptr + null_byte;
-                slice->size = storage_field_bytes;
-
-                storage_ptr += storage_field_bytes + null_byte;
-                memory_ptr += _mem_row_bytes;
-            }
-        } else {
-            size_t storage_field_bytes = _tablet_schema[col].length;
-            for (int row = 0; row < _info.row_num; ++row) {
-                // Content of not string type can be copied using addr
-                *reinterpret_cast<bool*>(memory_ptr) = false;
-                memory_copy(memory_ptr + 1 - null_byte, storage_ptr, storage_field_bytes + null_byte);
-
-                storage_ptr += storage_field_bytes + null_byte;
-                memory_ptr += _mem_row_bytes;
-            }
-        }
-    }
-}
-
-void RowBlock::_convert_memory_to_storage(uint32_t num_rows) {
-    // this function is reverse procedure of convert_storage_to_memory
-
-    char* storage_ptr = _storage_buf;
-    // Point to start of storage viriable part
-    char* storage_variable_ptr = _storage_buf + num_rows * _storage_row_fixed_bytes;
-    size_t null_byte = has_nullbyte() ? 1 : 0;
-    for (int col = 0; col < _field_count; ++col) {
-        char* memory_ptr = _mem_buf + _field_offset_in_memory[col];
-        if (_tablet_schema[col].type == OLAP_FIELD_TYPE_VARCHAR ||
-                _tablet_schema[col].type == OLAP_FIELD_TYPE_HLL) {
-            for (int row = 0; row < num_rows; ++row) {
-                /*
-                 * Varchar is in offset -> nullbyte|length|content format in storage
-                 * Varchar is in nullbyte|length|ptr in memory
-                 * We need set three part: offset -> nullbyte|length|content
-                 * 1. set offset
-                 * 2. copy null byte
-                 * 3. copy length and content into sucessive addrs
-                 */
-
-                // 1: set offset
-                size_t offset = storage_variable_ptr - _storage_buf;
-                *reinterpret_cast<StringOffsetType*>(storage_ptr) = offset;
-                storage_ptr += sizeof(StringOffsetType);
-
-                // 2: copy null byte
-                memory_copy(storage_variable_ptr, memory_ptr, null_byte);
-                storage_variable_ptr += null_byte;
-
-                // 3. copy length and content
-                Slice* slice = reinterpret_cast<Slice*>(memory_ptr + 1);
-                *reinterpret_cast<StringLengthType*>(storage_variable_ptr) = slice->size;
-                storage_variable_ptr += sizeof(StringLengthType);
-                memory_copy(storage_variable_ptr, slice->data, slice->size);
-                storage_variable_ptr += slice->size;
-
-                memory_ptr += _mem_row_bytes;
-            }
-        } else if (_tablet_schema[col].type == OLAP_FIELD_TYPE_CHAR) {
-            size_t storage_field_bytes = _tablet_schema[col].length;
-            for (int row = 0; row < num_rows; ++row) {
-                /*
-                 * Char is in nullbyte|content with fixed length in storage
-                 * Char is in nullbyte|length|ptr in memory
-                 * We need set two part: nullbyte|content
-                 * 1. copy null byte
-                 * 2. copy content
-                 */
-
-                // 1. copy null byte
-                memory_copy(storage_ptr, memory_ptr, null_byte);
-
-                // 2. copy content
-                Slice* slice = reinterpret_cast<Slice*>(memory_ptr + 1);
-                memory_copy(storage_ptr + null_byte, slice->data, slice->size);
-                memory_ptr += _mem_row_bytes;
-                storage_ptr += storage_field_bytes + null_byte;
-            }
-        } else {
-            // Memory layout is equal with storage layout, there is nullbyte
-            // for all field. So we need to copy this to storage
-            size_t storage_field_bytes = _tablet_schema[col].length;
-            char* memory_ptr = _mem_buf + _field_offset_in_memory[col];
-            for (int row = 0; row < num_rows; ++row) {
-                memory_copy(storage_ptr, memory_ptr + 1 - null_byte, storage_field_bytes + null_byte);
-                storage_ptr += storage_field_bytes + null_byte;
-                memory_ptr += _mem_row_bytes;
-            }
-        }
-    }
-    _storage_buf_used_bytes = storage_variable_ptr - _storage_buf;
 }
 
 OLAPStatus RowBlock::finalize(uint32_t row_num) {
@@ -314,51 +115,29 @@ void RowBlock::clear() {
 }
 
 void RowBlock::_compute_layout() {
+    std::unordered_set<uint32_t> column_set(_info.column_ids.begin(), _info.column_ids.end());
     size_t memory_size = 0;
-    size_t storage_fixed_bytes = 0;
-    size_t storage_variable_bytes = 0;
-    for (auto& field : _tablet_schema) {
+    for (int i = 0; i < _tablet_schema.size(); ++i) {
+        auto& field = _tablet_schema[i];
+        if (!column_set.empty() && column_set.find(i) == std::end(column_set)) {
+            // which may lead BE crash
+            _field_offset_in_memory.push_back(std::numeric_limits<std::size_t>::max());
+            continue;
+        }
+
         _field_offset_in_memory.push_back(memory_size);
 
         // All field has a nullbyte in memory
-        if (field.type == OLAP_FIELD_TYPE_VARCHAR || field.type == OLAP_FIELD_TYPE_HLL) {
+        if (field.type == OLAP_FIELD_TYPE_VARCHAR || field.type == OLAP_FIELD_TYPE_HLL
+                || field.type == OLAP_FIELD_TYPE_CHAR) {
             // 变长部分额外计算下实际最大的字符串长度（此处length已经包括记录Length的2个字节）
-            storage_fixed_bytes += sizeof(StringOffsetType);
-            storage_variable_bytes += field.length;
-            if (has_nullbyte()) {
-                storage_variable_bytes += sizeof(char);
-            }
             memory_size += sizeof(Slice) + sizeof(char);
         } else {
-            storage_fixed_bytes += field.length;
-            if (has_nullbyte()) {
-                storage_fixed_bytes += sizeof(char);
-            }
-            if (field.type == OLAP_FIELD_TYPE_CHAR) {
-                memory_size += sizeof(Slice) + sizeof(char);
-            } else {
-                memory_size += field.length + sizeof(char);
-            }
+            memory_size += field.length + sizeof(char);
         }
     }
     _mem_row_bytes = memory_size;
     _mem_buf_bytes = _mem_row_bytes * _info.row_num;
-
-    _storage_row_fixed_bytes = storage_fixed_bytes;
-    _storage_buf_bytes = (storage_fixed_bytes + storage_variable_bytes) * _info.row_num;
-    if (_info.unpacked_len != 0) {
-        // If we already known unpacked length, just use this length
-        _storage_buf_bytes = _info.unpacked_len;
-    }
-}
-
-inline bool RowBlock::_check_memory_limit(size_t buf_len) const {
-    uint64_t max_unpacked_row_block_size = config::max_unpacked_row_block_size;
-    max_unpacked_row_block_size =
-            max_unpacked_row_block_size == 0 ? OLAP_DEFAULT_MAX_UNPACKED_ROW_BLOCK_SIZE
-            : max_unpacked_row_block_size;
-
-    return buf_len <= max_unpacked_row_block_size;
 }
 
 }  // namespace doris

--- a/be/src/olap/schema_change.cpp
+++ b/be/src/olap/schema_change.cpp
@@ -511,7 +511,7 @@ OLAPStatus RowBlockAllocator::allocate(RowBlock** row_block,
         return OLAP_ERR_MALLOC_ERROR;
     }
 
-    RowBlockInfo row_block_info(0U, num_rows, 0);
+    RowBlockInfo row_block_info(0U, num_rows);
     row_block_info.data_file_type = data_file_type;
     row_block_info.null_supported = null_supported;
     OLAPStatus res = OLAP_SUCCESS;

--- a/be/src/runtime/vectorized_row_batch.h
+++ b/be/src/runtime/vectorized_row_batch.h
@@ -78,8 +78,8 @@ public:
         int capacity);
 
     ~VectorizedRowBatch() {
-        for (auto& item: _col_map) {
-            delete item.second;
+        for (auto vec: _col_vectors) {
+            delete vec;
         }
         delete[] _selected;
     }
@@ -89,7 +89,7 @@ public:
     }
 
     ColumnVector* column(int column_index) {
-        return _col_map[column_index];
+        return _col_vectors[column_index];
     }
 
     const std::vector<uint32_t>& columns() const { return _cols; }
@@ -144,7 +144,7 @@ private:
     const uint16_t _capacity;
     uint16_t _size = 0;
     uint16_t* _selected = nullptr;
-    std::map<ColumnId, ColumnVector*> _col_map;
+    std::vector<ColumnVector*> _col_vectors;
 
     bool _selected_in_use = false;
     uint8_t _block_status;

--- a/be/test/olap/row_block_test.cpp
+++ b/be/test/olap/row_block_test.cpp
@@ -88,8 +88,7 @@ TEST_F(TestRowBlock, init) {
         block_info.null_supported = true;
         auto res = block.init(block_info);
         ASSERT_EQ(OLAP_SUCCESS, res);
-        // num_rows * (num_nullbytes + bigint + char + varchar)
-        ASSERT_EQ(1024 * (3 + 8 + 10 + (4 + 20)), block.buf_len());
+        ASSERT_EQ(9 + 17 + 17, block._mem_row_bytes);
     }
     {
         // has nullbyte
@@ -100,8 +99,22 @@ TEST_F(TestRowBlock, init) {
         block_info.null_supported = false;
         auto res = block.init(block_info);
         ASSERT_EQ(OLAP_SUCCESS, res);
-        // num_rows * (num_nullbytes + bigint + char + varchar)
-        ASSERT_EQ(1024 * (3 + 8 + 10 + (4 + 20)), block.buf_len());
+        ASSERT_EQ(9 + 17 + 17, block._mem_row_bytes);
+    }
+    {
+        RowBlock block(fields);
+        RowBlockInfo block_info;
+        block_info.row_num = 1024;
+        block_info.data_file_type = COLUMN_ORIENTED_FILE;
+        block_info.null_supported = true;
+        block_info.column_ids.push_back(1);
+        auto res = block.init(block_info);
+        ASSERT_EQ(OLAP_SUCCESS, res);
+        // null + sizeof(Slice)
+        ASSERT_EQ(17, block._mem_row_bytes);
+        ASSERT_EQ(std::numeric_limits<size_t>::max(), block._field_offset_in_memory[0]);
+        ASSERT_EQ(0, block._field_offset_in_memory[1]);
+        ASSERT_EQ(std::numeric_limits<size_t>::max(), block._field_offset_in_memory[2]);
     }
 }
 
@@ -178,47 +191,6 @@ TEST_F(TestRowBlock, write_and_read) {
     }
     block.finalize(5);
     ASSERT_EQ(5, block.row_num());
-
-    char serialized_buf[2048];
-    size_t written_len = 0;
-    res = block.serialize_to_row_format(serialized_buf, 2048, &written_len, OLAP_COMP_STORAGE);
-    ASSERT_EQ(OLAP_SUCCESS, res);
-
-    {
-        RowBlock resolve_block(fields);
-        block_info.checksum = block.row_block_info().checksum;
-        block_info.row_num = 5;
-        res = resolve_block.init(block_info);
-        ASSERT_EQ(OLAP_SUCCESS, res);
-
-        res = resolve_block.decompress(serialized_buf, written_len, OLAP_COMP_STORAGE);
-        ASSERT_EQ(OLAP_SUCCESS, res);
-
-        ASSERT_EQ(5, resolve_block.row_num());
-        for (int i = 0; i < 5; ++i) {
-            resolve_block.get_row(i, &row);
-            {
-                ASSERT_FALSE(row.is_null(0));
-                ASSERT_EQ(i, *(int64_t*)row.get_field_content_ptr(0));
-            }
-            {
-                ASSERT_FALSE(row.is_null(1));
-                Slice* slice = (Slice*)row.get_field_content_ptr(1);
-                char buf[10];
-                memset(buf, 'a' + i, 10);
-                ASSERT_EQ(10, slice->size);
-                ASSERT_EQ(0, memcmp(buf, slice->data, 10));
-            }
-            {
-                ASSERT_FALSE(row.is_null(2));
-                Slice* slice = (Slice*)row.get_field_content_ptr(2);
-                char buf[20];
-                memset(buf, '0' + i, 10);
-                ASSERT_EQ(10, slice->size);
-                ASSERT_EQ(0, memcmp(buf, slice->data, 10));
-            }
-        }
-    }
 }
 
 TEST_F(TestRowBlock, write_and_read_without_nullbyte) {
@@ -294,47 +266,6 @@ TEST_F(TestRowBlock, write_and_read_without_nullbyte) {
     }
     block.finalize(5);
     ASSERT_EQ(5, block.row_num());
-
-    char serialized_buf[2048];
-    size_t written_len = 0;
-    res = block.serialize_to_row_format(serialized_buf, 2048, &written_len, OLAP_COMP_STORAGE);
-    ASSERT_EQ(OLAP_SUCCESS, res);
-
-    {
-        RowBlock resolve_block(fields);
-        block_info.checksum = block.row_block_info().checksum;
-        block_info.row_num = 5;
-        res = resolve_block.init(block_info);
-        ASSERT_EQ(OLAP_SUCCESS, res);
-
-        res = resolve_block.decompress(serialized_buf, written_len, OLAP_COMP_STORAGE);
-        ASSERT_EQ(OLAP_SUCCESS, res);
-
-        ASSERT_EQ(5, resolve_block.row_num());
-        for (int i = 0; i < 5; ++i) {
-            resolve_block.get_row(i, &row);
-            {
-                ASSERT_FALSE(row.is_null(0));
-                ASSERT_EQ(i, *(int64_t*)row.get_field_content_ptr(0));
-            }
-            {
-                ASSERT_FALSE(row.is_null(1));
-                Slice* slice = (Slice*)row.get_field_content_ptr(1);
-                char buf[10];
-                memset(buf, 'a' + i, 10);
-                ASSERT_EQ(10, slice->size);
-                ASSERT_EQ(0, memcmp(buf, slice->data, 10));
-            }
-            {
-                ASSERT_FALSE(row.is_null(2));
-                Slice* slice = (Slice*)row.get_field_content_ptr(2);
-                char buf[20];
-                memset(buf, '0' + i, 10);
-                ASSERT_EQ(10, slice->size);
-                ASSERT_EQ(0, memcmp(buf, slice->data, 10));
-            }
-        }
-    }
 }
 
 TEST_F(TestRowBlock, compress_failed) {
@@ -407,11 +338,6 @@ TEST_F(TestRowBlock, compress_failed) {
     }
     block.finalize(5);
     ASSERT_EQ(5, block.row_num());
-
-    char serialized_buf[2048];
-    size_t written_len = 0;
-    res = block.serialize_to_row_format(serialized_buf, 1, &written_len, OLAP_COMP_STORAGE);
-    ASSERT_NE(OLAP_SUCCESS, res);
 }
 
 TEST_F(TestRowBlock, decompress_failed) {
@@ -484,34 +410,6 @@ TEST_F(TestRowBlock, decompress_failed) {
     }
     block.finalize(5);
     ASSERT_EQ(5, block.row_num());
-
-    char serialized_buf[2048];
-    size_t written_len = 0;
-    res = block.serialize_to_row_format(serialized_buf, 2048, &written_len, OLAP_COMP_STORAGE);
-    ASSERT_EQ(OLAP_SUCCESS, res);
-
-    {
-        // checksum failed
-        RowBlock resolve_block(fields);
-        block_info.checksum = 0;
-        block_info.row_num = 5;
-        res = resolve_block.init(block_info);
-        ASSERT_EQ(OLAP_SUCCESS, res);
-
-        res = resolve_block.decompress(serialized_buf, written_len, OLAP_COMP_STORAGE);
-        ASSERT_NE(OLAP_SUCCESS, res);
-    }
-    {
-        // buffer is not ok
-        RowBlock resolve_block(fields);
-        block_info.checksum = block.row_block_info().checksum;
-        block_info.row_num = 5;
-        res = resolve_block.init(block_info);
-        ASSERT_EQ(OLAP_SUCCESS, res);
-
-        res = resolve_block.decompress(serialized_buf, written_len - 1, OLAP_COMP_STORAGE);
-        ASSERT_NE(OLAP_SUCCESS, res);
-    }
 }
 
 TEST_F(TestRowBlock, find_row) {


### PR DESCRIPTION
Before RowBlock will reserve memory for all columns in schema, even if
it is not queried. Which will cause bad performance when quering wide
table.

In this patch, RowBlock will reserve memory for needed columns. In a
case, this reduce ConvertBatchTime from 10s to 60ms when quering a wide
table who has 178 columns.

 #1236