### PR TITLE
fixup leak memory

### DIFF
--- a/be/src/olap/store.cpp
+++ b/be/src/olap/store.cpp
@@ -118,6 +118,7 @@ Status OlapStore::_check_path_exist() {
         closedir(dirp);
         return Status("readdir failed");
     }
+    closedir(dirp);
     return Status::OK;
 }
 


### PR DESCRIPTION
When I declared that the compilation mode was BUILD_TYPE=LSAN, there was a memory leak after running doris.

be.out:
Direct leak of 32816 byte(s) in 1 object(s) allocated from:
    #0 0x1089666 in __interceptor_malloc ../../../../libsanitizer/lsan/lsan_interceptors.cc:53
    #1 0x7ff459547280 in __alloc_dir (/lib64/libc.so.6+0xc0280)

SUMMARY: LeakSanitizer: 32816 byte(s) leaked in 1 allocation(s).