### PR TITLE
Fix += decimal error

### DIFF
--- a/be/src/olap/field_info.h
+++ b/be/src/olap/field_info.h
@@ -149,7 +149,7 @@ struct decimal12_t {
         }
 
         // if sign of fraction is different from integer
-        if ((fraction ^ integer) < 0) {
+        if ((fraction != 0) && (integer != 0) && (fraction ^ integer) < 0) {
             bool sign = integer < 0;
             integer += (sign ? 1 : -1);
             fraction += (sign ? -FRAC_RATIO : FRAC_RATIO);

--- a/be/test/olap/field_info_test.cpp
+++ b/be/test/olap/field_info_test.cpp
@@ -21,7 +21,7 @@
 
 namespace doris {
 
-TEST(FieldInfoTest, HandleNoneZeroInput) {
+TEST(FieldInfoTest, Add) {
     int64_t a_integer = 9223372036854775806L;
     int a_fraction = 1;
     decimal12_t a(a_integer, a_fraction);
@@ -36,6 +36,30 @@ TEST(FieldInfoTest, HandleNoneZeroInput) {
     a += b;
     ASSERT_EQ(-9223372036854775807L, a.integer);
     ASSERT_EQ(-1, a.fraction);
+  
+    a.integer = -1;
+    a.fraction = 0;
+    b.integer = -7;
+    b.fraction = 0;
+    a += b;
+    ASSERT_EQ(-8, a.integer);
+    ASSERT_EQ(0, a.fraction);
+
+    a.integer = 0;
+    a.fraction = -1;
+    b.integer = 0;
+    b.fraction = -2;
+    a +=b;
+    ASSERT_EQ(0, a.integer);
+    ASSERT_EQ(-3, a.fraction);
+
+    a.integer = 0;
+    a.fraction = -999999999;
+    b.integer = 0;
+    b.fraction = -1;
+    a += b;
+    ASSERT_EQ(-1, a.integer);
+    ASSERT_EQ(0, a.fraction);
 }
 
 } // namespace doris


### PR DESCRIPTION
This change fix the +=decimal error when integer is zero or fraction is zero.
In this situation, the += operator will make a mistake.