### PR TITLE
Fix bug. For example, we start the process for the first time. The pi…

### DIFF
--- a/fe/src/main/java/org/apache/doris/PaloFe.java
+++ b/fe/src/main/java/org/apache/doris/PaloFe.java
@@ -256,6 +256,7 @@ public class PaloFe {
             pid.deleteOnExit();
 
             String name = ManagementFactory.getRuntimeMXBean().getName();
+            file.setLength(0);
             file.write(name.split("@")[0].getBytes(Charsets.UTF_8));
 
             return true;


### PR DESCRIPTION
…d is 12345. Due to the accident, the process is killed and the fe.pid exists. Then we start the process for the second time. The pid is 6789. The fe.pid shows 67895 , Because file.write only cover the first four digits. This case can happen easily when we use supervise. Then I add the file.setLength(0) and delete the old data.