### PR TITLE
Use remove_all_dir to remote non-empty dir

### DIFF
--- a/be/src/olap/data_dir.cpp
+++ b/be/src/olap/data_dir.cpp
@@ -658,7 +658,7 @@ OLAPStatus DataDir::remove_old_meta_and_files() {
         std::string pending_delta_path = data_path_prefix + PENDING_DELTA_PREFIX;
         if (check_dir_existed(pending_delta_path)) {
             LOG(INFO) << "remove pending delta path:" << pending_delta_path;
-            if(remove_dir(pending_delta_path) != OLAP_SUCCESS) {
+            if(remove_all_dir(pending_delta_path) != OLAP_SUCCESS) {
                 LOG(INFO) << "errors while remove pending delta path. tablet_path=" << data_path_prefix;
                 return true;
             }
@@ -667,7 +667,7 @@ OLAPStatus DataDir::remove_old_meta_and_files() {
         std::string incremental_delta_path = data_path_prefix + INCREMENTAL_DELTA_PREFIX;
         if (check_dir_existed(incremental_delta_path)) {
             LOG(INFO) << "remove incremental delta path:" << incremental_delta_path;
-            if(remove_dir(incremental_delta_path) != OLAP_SUCCESS) {
+            if(remove_all_dir(incremental_delta_path) != OLAP_SUCCESS) {
                 LOG(INFO) << "errors while remove incremental delta path. tablet_path=" << data_path_prefix;
                 return true;
             }

--- a/be/src/olap/rowset/segment_group.cpp
+++ b/be/src/olap/rowset/segment_group.cpp
@@ -860,7 +860,7 @@ OLAPStatus SegmentGroup::remove_old_files(std::vector<std::string>* links_to_rem
     std::string pending_delta_path = _rowset_path_prefix + PENDING_DELTA_PREFIX;
     if (check_dir_existed(pending_delta_path)) {
         LOG(INFO) << "remove pending delta path:" << pending_delta_path;
-        RETURN_NOT_OK(remove_dir(pending_delta_path));
+        RETURN_NOT_OK(remove_all_dir(pending_delta_path));
     }
     return OLAP_SUCCESS;
 }


### PR DESCRIPTION
1. Use remove_all_dir to remote non-empty dir
2. Gc should not hold write lock too much time
3. skip tablet dir if dir already exists when create tablet