### PR TITLE
Set version for base_compaction

### DIFF
--- a/be/src/olap/merger.cpp
+++ b/be/src/olap/merger.cpp
@@ -49,6 +49,10 @@ OLAPStatus Merger::merge(const vector<RowsetReaderSharedPtr>& rs_readers,
     reader_params.reader_type = _reader_type;
     reader_params.rs_readers = rs_readers;
 
+    if (_reader_type == READER_BASE_COMPACTION) {
+        reader_params.version = _rs_writer->version();
+    }
+
     if (OLAP_SUCCESS != reader.init(reader_params)) {
         LOG(WARNING) << "fail to initiate reader. tablet=" << _tablet->full_name();
         return OLAP_ERR_INIT_FAILED;

--- a/be/src/olap/merger.h
+++ b/be/src/olap/merger.h
@@ -49,7 +49,6 @@ private:
     RowsetWriterSharedPtr _rs_writer;
     ReaderType _reader_type;
     uint64_t _row_count;
-    Version _simple_merge_version;
 
     DISALLOW_COPY_AND_ASSIGN(Merger);
 };

--- a/be/src/olap/reader.cpp
+++ b/be/src/olap/reader.cpp
@@ -560,6 +560,7 @@ OLAPStatus Reader::_capture_rs_readers(const ReaderParams& read_params) {
 }
 
 OLAPStatus Reader::_init_params(const ReaderParams& read_params) {
+    read_params.check_validation();
     OLAPStatus res = OLAP_SUCCESS;
     _aggregation = read_params.aggregation;
     _reader_type = read_params.reader_type;

--- a/be/src/olap/reader.h
+++ b/be/src/olap/reader.h
@@ -69,12 +69,19 @@ struct ReaderParams {
     ReaderParams() :
             reader_type(READER_QUERY),
             aggregation(false),
+            version(-1, 0),
             profile(NULL),
             runtime_state(NULL) {
         start_key.clear();
         end_key.clear();
         conditions.clear();
         rs_readers.clear();
+    }
+
+    void check_validation() const {
+        if (version.first == -1) {
+            LOG(FATAL) << "verison is not set. tablet=" << tablet->full_name();
+        }
     }
 
     std::string to_string() {


### PR DESCRIPTION
Upon base compaction, delete handler use version to init del_pred_array,
So the version should be set.