### PR TITLE
Increase the timeout of publish version task

### DIFF
--- a/fe/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/src/main/java/org/apache/doris/common/Config.java
@@ -250,10 +250,10 @@ public class Config extends ConfigBase {
     public static int tablet_create_timeout_second = 1;
     
     /*
-     * Maximal waiting time for publish version message to backend
+     * Maximal waiting time for all publish version tasks of one transaction to be finished
      */
     @ConfField(mutable = true, masterOnly = true)
-    public static int publish_version_timeout_second = 3;
+    public static int publish_version_timeout_second = 60; // 1 min
     
     /*
      * minimal intervals between two publish version action

--- a/fe/src/main/java/org/apache/doris/load/LoadJob.java
+++ b/fe/src/main/java/org/apache/doris/load/LoadJob.java
@@ -51,7 +51,6 @@ import java.io.DataOutput;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -640,11 +639,8 @@ public class LoadJob implements Writable {
     }
     
     public long getDeleteJobTimeout() {
-        long timeout = Math.max(idToTabletLoadInfo.size() 
-                * Config.tablet_delete_timeout_second * 1000L,
-                60000L);
-        timeout = Math.min(timeout, 300000L);
-        return timeout;
+        return Math.min(idToTabletLoadInfo.size() * Config.tablet_delete_timeout_second * 1000L,
+                Config.load_straggler_wait_second * 1000L);
     }
     
     @Override

--- a/fe/src/main/java/org/apache/doris/transaction/PublishVersionDaemon.java
+++ b/fe/src/main/java/org/apache/doris/transaction/PublishVersionDaemon.java
@@ -118,6 +118,7 @@ public class PublishVersionDaemon extends Daemon {
                 transactionState.addPublishVersionTask(backendId, task);
             }
             transactionState.setHasSendTask(true);
+            LOG.info("send publish tasks for transaction: {}", transactionState.getTransactionId());
         }
         if (!batchTask.getAllTasks().isEmpty()) {
             AgentTaskExecutor.submit(batchTask);

--- a/fe/src/main/java/org/apache/doris/transaction/TransactionState.java
+++ b/fe/src/main/java/org/apache/doris/transaction/TransactionState.java
@@ -430,10 +430,11 @@ public class TransactionState implements Writable {
     }
     
     public boolean isPublishTimeout() {
-        // timeout is between 3 to Config.max_txn_publish_waiting_time_ms seconds.
-        long timeoutMillis = Math.min(Config.publish_version_timeout_second * publishVersionTasks.size() * 1000,
-                                      Config.load_straggler_wait_second * 1000);
-        timeoutMillis = Math.max(timeoutMillis, 3000);
+        // the max timeout is Config.publish_version_timeout_second;
+        // here we reuse the config 'tablet_create_timeout_second', never mind the
+        // name:)
+        long timeoutMillis = Math.min(Config.tablet_create_timeout_second * publishVersionTasks.size() * 1000,
+                Config.publish_version_timeout_second * 1000);
         return System.currentTimeMillis() - publishVersionTime > timeoutMillis;
     }
     


### PR DESCRIPTION
The origin timeout of publish version task of a transaction is 3 seconds.
This timeout is too short that may cause a problem that some of publish
version tasks already finished on Backend but failed to report to Frontend
because Frontend already commit the transaction and discard all publish version
tasks. And the replica of these failed publish task will be marked as failed.

In normal case, these replicas can be repair by tablet repair process, but
if there is a running alter jobs, such as rollup job, the rollup replicas will
also be marked as failed, which may cause the entire rollup job failed.