### PR TITLE
Check get_header status returned

### DIFF
--- a/be/src/olap/olap_define.h
+++ b/be/src/olap/olap_define.h
@@ -332,6 +332,7 @@ enum OLAPStatus {
     OLAP_ERR_META_PUT = -3004,
     OLAP_ERR_META_ITERATOR = -3005,
     OLAP_ERR_META_DELETE = -3006,
+    OLAP_ERR_META_ALREADY_EXIST  = -3007,
 };
 
 enum ColumnFamilyIndex {


### PR DESCRIPTION
When performing storage_medium_migration, the header may be already droped.
In this scenario, header returned will be null pointer.
Saving data to a null pointer will cause core dump.