### PR TITLE
Fix column nullable property in show create table stmt result

### DIFF
--- a/fe/src/main/java/org/apache/doris/catalog/Column.java
+++ b/fe/src/main/java/org/apache/doris/catalog/Column.java
@@ -260,7 +260,9 @@ public class Column implements Writable {
         if (aggregationType != null && aggregationType != AggregateType.NONE && !isAggregationTypeImplicit) {
             sb.append(aggregationType.name()).append(" ");
         }
-        if (!isAllowNull) {
+        if (isAllowNull) {
+            sb.append("NULL ");
+        } else {
             sb.append("NOT NULL ");
         }
         if (defaultValue != null && getDataType() != PrimitiveType.HLL) {


### PR DESCRIPTION
Since the default nullable of a column changed to NOT NULL,
result of show table stmt should show the correct nullable property
of a column.