### PR TITLE
Add report version for publish task

### DIFF
--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -902,6 +902,7 @@ void* TaskWorkerPool::_publish_version_worker_thread_callback(void* arg_this) {
             finish_task_request.__set_error_tablet_ids(error_tablet_ids);
             DorisMetrics::publish_task_failed_total.increment(1);
         } else {
+            _s_report_version++;
             LOG(INFO) << "publish_version success. signature:" << agent_task_req.signature;
         }
 
@@ -912,6 +913,7 @@ void* TaskWorkerPool::_publish_version_worker_thread_callback(void* arg_this) {
         finish_task_request.__set_backend(worker_pool_this->_backend);
         finish_task_request.__set_task_type(agent_task_req.task_type);
         finish_task_request.__set_signature(agent_task_req.signature);
+        finish_task_request.__set_report_version(_s_report_version);
 
         worker_pool_this->_finish_task(finish_task_request);
         worker_pool_this->_remove_task_info(agent_task_req.task_type, agent_task_req.signature, "");

--- a/fe/src/main/java/org/apache/doris/catalog/OlapTable.java
+++ b/fe/src/main/java/org/apache/doris/catalog/OlapTable.java
@@ -990,7 +990,7 @@ public class OlapTable extends Table {
                             infoService, clusterName, visibleVersion, visibleVersionHash, replicationNum,
                             availableBackendsNum);
                     if (statusPair.first != TabletStatus.HEALTHY) {
-                        LOG.debug("table {} is not stable because tablet {} status is {}. replicas: {}",
+                        LOG.info("table {} is not stable because tablet {} status is {}. replicas: {}",
                                 id, tablet.getId(), statusPair.first, tablet.getReplicas());
                         return false;
                     }

--- a/fe/src/main/java/org/apache/doris/catalog/OlapTable.java
+++ b/fe/src/main/java/org/apache/doris/catalog/OlapTable.java
@@ -990,6 +990,8 @@ public class OlapTable extends Table {
                             infoService, clusterName, visibleVersion, visibleVersionHash, replicationNum,
                             availableBackendsNum);
                     if (statusPair.first != TabletStatus.HEALTHY) {
+                        LOG.debug("table {} is not stable because tablet {} status is {}. replicas: {}",
+                                id, tablet.getId(), statusPair.first, tablet.getReplicas());
                         return false;
                     }
                 }

--- a/fe/src/main/java/org/apache/doris/master/MasterImpl.java
+++ b/fe/src/main/java/org/apache/doris/master/MasterImpl.java
@@ -559,9 +559,17 @@ public class MasterImpl {
         if (request.isSetError_tablet_ids()) {
             errorTabletIds = request.getError_tablet_ids();
         }
+
+        if (request.isSetReport_version()) {
+            // report version is required. here we check if set, for compatibility.
+            long reportVersion = request.getReport_version();
+            Catalog.getCurrentSystemInfo().updateBackendReportVersion(task.getBackendId(), reportVersion, task.getDbId());
+        }
+
         PublishVersionTask publishVersionTask = (PublishVersionTask) task;
         publishVersionTask.addErrorTablets(errorTabletIds);
         publishVersionTask.setIsFinished(true);
+
         AgentTaskQueue.removeTask(publishVersionTask.getBackendId(), 
                                   publishVersionTask.getTaskType(), 
                                   publishVersionTask.getSignature());

--- a/fe/src/main/java/org/apache/doris/task/PublishVersionTask.java
+++ b/fe/src/main/java/org/apache/doris/task/PublishVersionTask.java
@@ -35,7 +35,7 @@ public class PublishVersionTask extends AgentTask {
     private List<Long> errorTablets;
     private boolean isFinished;
 
-    public PublishVersionTask(long backendId, long transactionId, 
+    public PublishVersionTask(long backendId, long transactionId, long dbId,
             List<TPartitionVersionInfo> partitionVersionInfos) {
         super(null, backendId, TTaskType.PUBLISH_VERSION, -1L, -1L, -1L, -1L, -1L, transactionId);
         this.transactionId = transactionId;

--- a/fe/src/main/java/org/apache/doris/transaction/PublishVersionDaemon.java
+++ b/fe/src/main/java/org/apache/doris/transaction/PublishVersionDaemon.java
@@ -108,9 +108,10 @@ public class PublishVersionDaemon extends Daemon {
             }
 
             for (long backendId : publishBackends) {
-                PublishVersionTask task = new PublishVersionTask(backendId, 
-                                                                 transactionState.getTransactionId(), 
-                                                                 partitionVersionInfos);
+                PublishVersionTask task = new PublishVersionTask(backendId,
+                        transactionState.getTransactionId(),
+                        transactionState.getDbId(),
+                        partitionVersionInfos);
                 // add to AgentTaskQueue for handling finish report.
                 // not check return value, because the add will success
                 AgentTaskQueue.addTask(task);

--- a/fe/src/test/java/org/apache/doris/load/DppSchedulerTest.java
+++ b/fe/src/test/java/org/apache/doris/load/DppSchedulerTest.java
@@ -52,7 +52,6 @@ public class DppSchedulerTest {
         // mock palo home env
         PowerMock.mockStatic(System.class);
         EasyMock.expect(System.getenv("DORIS_HOME")).andReturn(".").anyTimes();
-        EasyMock.expect(System.currentTimeMillis()).andReturn(1000L).anyTimes();
         PowerMock.replay(System.class);
 
         UnitTestUtil.initDppConfig();
@@ -221,7 +220,7 @@ public class DppSchedulerTest {
         DppConfig dppConfig = Load.dppDefaultConfig.getCopiedDppConfig();
         long dbId = 0;
         String loadLabel = "test_label";
-        String etlOutputDir = String.valueOf(System.currentTimeMillis());
+        String etlOutputDir = "10000";
 
         String actualPath = DppScheduler.getEtlOutputPath(dppConfig.getFsDefaultName(), dppConfig.getOutputPath(),
                 dbId, loadLabel, etlOutputDir);


### PR DESCRIPTION
Backend report version is a mechanism to avoid replica's version rollback.
Replica's version rollback can happen when tablet report carrying stale replica info.
For example:

```
                        Time
                          +
 Replica report thread    |   Publish task report
                          |
     1. Start collecting  |
        replica info      |
                          |
                          |  2. publish task finished
                          |
                          |  3. Update replica version
                          |     when publish task report
4. update replica version |
   (using stale info)     |
                          |
                          |
                          v

```

When publish task finished on Backend, the report version of this Backend should
increase to indicate that the info of this Backend is updated. And this report version
should be carried with publish task report to Frontend, so that Frontend can update
the report version of this Backend saved in Frontend. 

Also add a INFO level log when encountering unstable table in alter job