### PR TITLE
Fix the deadlock of database and loadjob

### DIFF
--- a/fe/src/main/java/org/apache/doris/catalog/Database.java
+++ b/fe/src/main/java/org/apache/doris/catalog/Database.java
@@ -51,6 +51,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
@@ -111,7 +112,7 @@ public class Database extends MetaObject implements Writable {
             this.fullQualifiedName = "";
         }
         this.rwLock = new ReentrantReadWriteLock(true);
-        this.idToTable = new HashMap<Long, Table>();
+        this.idToTable = new ConcurrentHashMap<>();
         this.nameToTable = new HashMap<String, Table>();
         this.dataQuotaBytes = FeConstants.default_db_data_quota_bytes;
         this.dbState = DbState.NORMAL;
@@ -333,6 +334,11 @@ public class Database extends MetaObject implements Writable {
         return null;
     }
 
+    /**
+     * This is a thread-safe method when idToTable is a concurrent hash map
+     * @param tableId
+     * @return
+     */
     public Table getTable(long tableId) {
         return idToTable.get(tableId);
     }

--- a/fe/src/main/java/org/apache/doris/load/loadv2/BrokerLoadJob.java
+++ b/fe/src/main/java/org/apache/doris/load/loadv2/BrokerLoadJob.java
@@ -119,17 +119,14 @@ public class BrokerLoadJob extends LoadJob {
         if (database == null) {
             throw new MetaNotFoundException("Database " + dbId + "has been deleted");
         }
-        database.readLock();
-        try {
-            for (long tableId : dataSourceInfo.getIdToFileGroups().keySet()) {
-                Table table = database.getTable(tableId);
-                if (table == null) {
-                    throw new MetaNotFoundException("Failed to find table " + tableId + " in db " + dbId);
-                }
-                result.add(table.getName());
+        // The database will not be locked in here.
+        // The getTable is a thread-safe method called without read lock of database
+        for (long tableId : dataSourceInfo.getIdToFileGroups().keySet()) {
+            Table table = database.getTable(tableId);
+            if (table == null) {
+                throw new MetaNotFoundException("Failed to find table " + tableId + " in db " + dbId);
             }
-        } finally {
-            database.readUnlock();
+            result.add(table.getName());
         }
         return result;
     }

--- a/fe/src/main/java/org/apache/doris/load/loadv2/InsertLoadJob.java
+++ b/fe/src/main/java/org/apache/doris/load/loadv2/InsertLoadJob.java
@@ -64,16 +64,13 @@ public class InsertLoadJob extends LoadJob {
         if (database == null) {
             throw new MetaNotFoundException("Database " + dbId + "has been deleted");
         }
-        database.readLock();
-        try {
-            Table table = database.getTable(tableId);
-            if (table == null) {
-                throw new MetaNotFoundException("Failed to find table " + tableId + " in db " + dbId);
-            }
-            return new HashSet<>(Arrays.asList(table.getName()));
-        } finally {
-            database.readUnlock();
+        // The database will not be locked in here.
+        // The getTable is a thread-safe method called without read lock of database
+        Table table = database.getTable(tableId);
+        if (table == null) {
+            throw new MetaNotFoundException("Failed to find table " + tableId + " in db " + dbId);
         }
+        return new HashSet<>(Arrays.asList(table.getName()));
     }
 
     @Override


### PR DESCRIPTION
This commit change the idToTable to concurrent hashmap in database. It don't need to lock the database before getTable.
The database will be locked in GlobalTxnManager. The load job will be locked after that.
So the lock sequence is: database, load manager, load job.