### PR TITLE
Forbid adding rollup with REPLACE value but without all key columns.

### DIFF
--- a/fe/src/main/java/org/apache/doris/alter/RollupHandler.java
+++ b/fe/src/main/java/org/apache/doris/alter/RollupHandler.java
@@ -124,10 +124,12 @@ public class RollupHandler extends AlterHandler {
         // 3 check if rollup columns are valid
         // a. all columns should exist in base rollup schema
         // b. value after key
+        // c. if rollup contains REPLACE column, all keys on base index should be included.
         List<Column> rollupSchema = new ArrayList<Column>();
         // check (a)(b)
         boolean meetValue = false;
         boolean hasKey = false;
+        boolean meetReplaceValue = false;
         KeysType keysType = olapTable.getKeysType();
         if (KeysType.UNIQUE_KEYS == keysType || KeysType.AGG_KEYS == keysType) {
             int keysNumOfRollup = 0;
@@ -144,6 +146,9 @@ public class RollupHandler extends AlterHandler {
                     hasKey = true;
                 } else {
                     meetValue = true;
+                    if (oneColumn.getAggregationType() == AggregateType.REPLACE) {
+                        meetReplaceValue = true;
+                    }
                 }
                 rollupSchema.add(oneColumn);
             }
@@ -152,11 +157,16 @@ public class RollupHandler extends AlterHandler {
                 throw new DdlException("No key column is found");
             }
             
-            if (KeysType.UNIQUE_KEYS == keysType) {
-                // rollup of unique key table should have all keys of basetable
+            if (KeysType.UNIQUE_KEYS == keysType || meetReplaceValue) {
+                // rollup of unique key table or rollup with REPLACE value
+                // should have all keys of base table
                 if (keysNumOfRollup !=  olapTable.getKeysNum()) {
-                    throw new DdlException("rollup should contains all unique keys in basetable");
-                }       
+                    if (KeysType.UNIQUE_KEYS == keysType) {
+                        throw new DdlException("Rollup should contains all unique keys in basetable");
+                    } else {
+                        throw new DdlException("Rollup should contains all keys if there is a REPLACE value");
+                    }
+                }
             }
         } else if (KeysType.DUP_KEYS == keysType) {
             /*

--- a/fe/src/main/java/org/apache/doris/analysis/SetPassVar.java
+++ b/fe/src/main/java/org/apache/doris/analysis/SetPassVar.java
@@ -95,6 +95,11 @@ public class SetPassVar extends SetVar {
 
     @Override
     public String toSql() {
-        return "SET PASSWORD FOR " + userIdent.toString() + " = '*XXX'";
+        StringBuilder sb = new StringBuilder("SET PASSWORD");
+        if (userIdent != null) {
+            sb.append(" FOR ").append(userIdent.toString());
+        }
+        sb.append(" = '*XXX'");
+        return sb.toString();
     }
 }

--- a/fe/src/main/java/org/apache/doris/load/loadv2/LoadJob.java
+++ b/fe/src/main/java/org/apache/doris/load/loadv2/LoadJob.java
@@ -279,7 +279,6 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
         }
     }
 
-
     public void processTimeout() {
         writeLock();
         try {


### PR DESCRIPTION
When a rollup table contains value columns of REPLACE aggregation type,
all key columns of base table should be included in this rollup.
Without all key columns, the order of rows is undefined.

For example, table schema k1,k2,k3,v1(REPLACE)

1,2,3,A
1,2,4,B
1,2,5,C

A rollup with column(k1,k2,v1):

1,2,A
1,2,B
1,2,C

No matter A or B or C be the last winner, it is meanless to user.

Also fix a bug that set password for current user on non-master FE
will throw NullPointerException.