### PR TITLE
Cast the type of constant value in binary predicate to column type.

### DIFF
--- a/fe/src/main/java/org/apache/doris/analysis/BinaryPredicate.java
+++ b/fe/src/main/java/org/apache/doris/analysis/BinaryPredicate.java
@@ -324,7 +324,7 @@ public class BinaryPredicate extends Predicate implements Writable {
             return child1.getType();
         }
 
-        // double can be cast to any types
+        // any type can be cast to double
         return Type.DOUBLE;
     }
 

--- a/fe/src/main/java/org/apache/doris/rewrite/FoldConstantsRule.java
+++ b/fe/src/main/java/org/apache/doris/rewrite/FoldConstantsRule.java
@@ -23,6 +23,7 @@ import org.apache.doris.analysis.CastExpr;
 import org.apache.doris.analysis.Expr;
 import org.apache.doris.analysis.NullLiteral;
 import org.apache.doris.common.AnalysisException;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 


### PR DESCRIPTION
If one child of a binary predicate is column, and the other is a constant expr,
set the compatible type to column's type.
eg:
k1(int):
... WHERE k1 = "123"  -->  k1 = cast("123" as int);

k2(varchar):
... WHERE 123 = k2 --> cast(123 as varchar) = k2

This optimization is for the case that some users may use a int column to save date, eg: 20190703,
but query with predicate: col = "20190703".

If not casting "20190703" to int, query optimizer can not do partition prune correctly.