### PR TITLE
Revert "Cast the type of constant value in binary predicate to column type. (#1422)"

### DIFF
--- a/fe/src/main/java/org/apache/doris/analysis/BinaryPredicate.java
+++ b/fe/src/main/java/org/apache/doris/analysis/BinaryPredicate.java
@@ -271,11 +271,8 @@ public class BinaryPredicate extends Predicate implements Writable {
     }
 
     private Type getCmpType() {
-        Expr child0 = getChild(0);
-        Expr child1 = getChild(1);
-
-        PrimitiveType t1 = child0.getType().getResultType().getPrimitiveType();
-        PrimitiveType t2 = child1.getType().getResultType().getPrimitiveType();
+        PrimitiveType t1 = getChild(0).getType().getResultType().getPrimitiveType();
+        PrimitiveType t2 = getChild(1).getType().getResultType().getPrimitiveType();
 
         if (canCompareDate(getChild(0).getType().getPrimitiveType(), getChild(1).getType().getPrimitiveType())) {
             return Type.DATETIME;
@@ -302,29 +299,6 @@ public class BinaryPredicate extends Predicate implements Writable {
             return Type.LARGEINT;
         }
         
-        /*
-         * If one child is SlotRef and the other is a constant expr,
-         * set the compatible type to SlotRef's column type.
-         * eg:
-         * k1(int):
-         * ... WHERE k1 = "123"  -->  k1 = cast("123" as int);
-         * 
-         * k2(varchar):
-         * ... WHERE 123 = k2 --> cast(123 as varchar) = k2
-         * 
-         * This optimization is for the case that some user may using a int column to save date, eg: 20190703,
-         * but query with predicate: col = "20190703".
-         * 
-         * If not casting "20190703" to int, query optimizer can not do partition prune correctly.
-         * 
-         */
-        if (child0 instanceof SlotRef && child1.isConstant()) {
-            return child0.getType();
-        } else if (child1 instanceof SlotRef && child0.isConstant()) {
-            return child1.getType();
-        }
-
-        // any type can be cast to double
         return Type.DOUBLE;
     }
 

--- a/fe/src/main/java/org/apache/doris/rewrite/FoldConstantsRule.java
+++ b/fe/src/main/java/org/apache/doris/rewrite/FoldConstantsRule.java
@@ -23,7 +23,6 @@ import org.apache.doris.analysis.CastExpr;
 import org.apache.doris.analysis.Expr;
 import org.apache.doris.analysis.NullLiteral;
 import org.apache.doris.common.AnalysisException;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 


### PR DESCRIPTION
This reverts commit 687f5a10868ce62d2d25d028152f84f3385b73f4,
which may cause incorrect query results.