### PR TITLE
Fix bug that publish task missing dbId parameter

### DIFF
--- a/fe/src/main/java/org/apache/doris/master/ReportHandler.java
+++ b/fe/src/main/java/org/apache/doris/master/ReportHandler.java
@@ -459,8 +459,8 @@ public class ReportHandler extends Daemon {
                             }
 
                             ++syncCounter;
-                            LOG.debug("sync replica {} of tablet {} in backend {} in db {}.",
-                                    replica.getId(), tabletId, backendId, dbId);
+                            LOG.debug("sync replica {} of tablet {} in backend {} in db {}. report version: {}",
+                                    replica.getId(), tabletId, backendId, dbId, backendReportVersion);
                         } else {
                             LOG.debug("replica {} of tablet {} in backend {} version is changed"
                                     + " between check and real sync. meta[{}-{}]. backend[{}-{}]",

--- a/fe/src/main/java/org/apache/doris/task/PublishVersionTask.java
+++ b/fe/src/main/java/org/apache/doris/task/PublishVersionTask.java
@@ -37,7 +37,7 @@ public class PublishVersionTask extends AgentTask {
 
     public PublishVersionTask(long backendId, long transactionId, long dbId,
             List<TPartitionVersionInfo> partitionVersionInfos) {
-        super(null, backendId, TTaskType.PUBLISH_VERSION, -1L, -1L, -1L, -1L, -1L, transactionId);
+        super(null, backendId, TTaskType.PUBLISH_VERSION, dbId, -1L, -1L, -1L, -1L, transactionId);
         this.transactionId = transactionId;
         this.partitionVersionInfos = partitionVersionInfos;
         this.errorTablets = new ArrayList<Long>();


### PR DESCRIPTION
Without dbId parameter, the backend report version can not be
updated when publish task report to FE, which may cause incorrect
order of report.

Related commit: 5c1b4f6