### PR TITLE
Add a configuration to modify the reverse time of load error log

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -257,8 +257,10 @@ namespace config {
     // Period to update rate counters and sampling counters in ms.
     CONF_Int32(periodic_counter_update_period_ms, "500");
 
-    // Used for mini Load
+    // Used for mini Load. mini load data file will be removed after this time.
     CONF_Int64(load_data_reserve_hours, "4");
+    // log error log will be removed after this time
+    CONF_Int64(load_error_log_reserve_hours, "48");
     CONF_Int64(mini_load_max_mb, "2048");
     CONF_Int32(number_tablet_writer_threads, "16");
 

--- a/be/src/runtime/load_path_mgr.h
+++ b/be/src/runtime/load_path_mgr.h
@@ -55,11 +55,11 @@ public:
     }
 
 private:
-    bool is_too_old(time_t cur_time, const std::string& label_dir);
+    bool is_too_old(time_t cur_time, const std::string& label_dir, int64_t reserve_hours);
     void clean_one_path(const std::string& path);
     void clean_error_log();
     void clean();
-    void process_path(time_t now, const std::string& path);
+    void process_path(time_t now, const std::string& path, int64_t reserve_hours);
 
     static void* cleaner(void* param);
 


### PR DESCRIPTION
Currently, the load error log on BE will be cleaned along with the
intermediate data of load, configured by 'load_data_reserve_hours'.
Sometimes user want to reserve the error log for longer time.