### PR TITLE
Resolve the problem of accidental pause in RoutineLoadJob

### DIFF
--- a/fe/src/main/java/org/apache/doris/load/routineload/RoutineLoadJob.java
+++ b/fe/src/main/java/org/apache/doris/load/routineload/RoutineLoadJob.java
@@ -620,14 +620,8 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback impl
                 switch (transactionStatus) {
                     case COMMITTED:
                         throw new TransactionException("txn " + txnState.getTransactionId()
-                                                               + " could not be " + transactionStatus
-                                                               + " while task " + txnState.getLabel() + " has been aborted.");
-                    case ABORTED:
-                        // reset attachment in txn state
-                        // txn will be aborted normal but without attachment
-                        // task will not be update when attachment is null
-                        txnState.setTxnCommitAttachment(null);
-                        break;
+                                                       + " could not be " + transactionStatus
+                                                       + " while task " + txnState.getLabel() + " has been aborted.");
                 }
             }
             passCheck = true;
@@ -685,13 +679,13 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback impl
         long taskBeId = -1L;
         try {
             if (txnOperated) {
-                if (txnState.getTxnCommitAttachment() == null) {
-                    // this is a task which already has been aborted by fe
-                    return;
-                }
                 // step0: find task in job
                 Optional<RoutineLoadTaskInfo> routineLoadTaskInfoOptional = routineLoadTaskInfoList.stream().filter(
                         entity -> entity.getTxnId() == txnState.getTransactionId()).findFirst();
+                if (!routineLoadTaskInfoOptional.isPresent()) {
+                    // task will not be update when task has been aborted by fe
+                    return;
+                }
                 RoutineLoadTaskInfo routineLoadTaskInfo = routineLoadTaskInfoOptional.get();
                 taskBeId = routineLoadTaskInfo.getBeId();
                 // step1: job state will be changed depending on txnStatusChangeReasonString

--- a/fe/src/main/java/org/apache/doris/load/routineload/RoutineLoadJob.java
+++ b/fe/src/main/java/org/apache/doris/load/routineload/RoutineLoadJob.java
@@ -622,6 +622,8 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback impl
                         throw new TransactionException("txn " + txnState.getTransactionId()
                                                        + " could not be " + transactionStatus
                                                        + " while task " + txnState.getLabel() + " has been aborted.");
+                    default:
+                        break;
                 }
             }
             passCheck = true;


### PR DESCRIPTION
The issue is following:
Request1:
  be aborts the txn.
  Attachment of txn is set.
  Attachment of txn is changed to null without lock of txn because the task has been aborted by fe.
Request2:
  be abortes the txn again.
  Attachment of txn is set again.
Request1:
  The attachment is not null so the job wants to find the task and commit it.
  The job could not find the task so it is paused.

The attachment of txn is not changed in this commit.
The new condition of committing task is that the task is in the job or not.