### PR TITLE
Persist auth info in LoadJob

### DIFF
--- a/fe/src/main/java/org/apache/doris/catalog/AuthorizationInfo.java
+++ b/fe/src/main/java/org/apache/doris/catalog/AuthorizationInfo.java
@@ -1,0 +1,100 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.catalog;
+
+import org.apache.doris.common.io.Text;
+import org.apache.doris.common.io.Writable;
+
+import com.google.common.collect.Sets;
+import com.google.gson.Gson;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import java.util.Set;
+
+/**
+ * This class is used to save the authorization info which needs to be persisted.
+ * The stmt of http connection info is not included.
+ * <p>
+ * When the table has been deleted, the table name could not be found by table id.
+ * The job could not check the priv without table name.
+ * This class is used to resolve this problem.
+ * The auth info needs to be persisted by job.
+ * The job checks the priv by auth info.
+ */
+public class AuthorizationInfo implements Writable {
+    private String dbName;
+    private Set<String> tableNameList;
+
+    // only for persist
+    public AuthorizationInfo() {
+    }
+
+    public AuthorizationInfo(String dbName, Set<String> tableNameList) {
+        this.dbName = dbName;
+        this.tableNameList = tableNameList;
+    }
+
+    public String getDbName() {
+        return dbName;
+    }
+
+    public Set<String> getTableNameList() {
+        return tableNameList;
+    }
+
+    @Override
+    public void write(DataOutput out) throws IOException {
+        if (dbName == null) {
+            out.writeBoolean(false);
+        } else {
+            out.writeBoolean(true);
+            Text.writeString(out, dbName);
+        }
+        if (tableNameList == null) {
+            out.writeBoolean(false);
+        } else {
+            out.writeBoolean(true);
+            out.writeInt(tableNameList.size());
+            for (String tableName : tableNameList) {
+                Text.writeString(out, tableName);
+            }
+        }
+    }
+
+    @Override
+    public void readFields(DataInput in) throws IOException {
+        if (in.readBoolean()) {
+            dbName = Text.readString(in);
+        }
+        if (in.readBoolean()) {
+            tableNameList = Sets.newHashSet();
+            int size = in.readInt();
+            for (int i = 0; i < size; i++) {
+                tableNameList.add(Text.readString(in));
+            }
+        }
+    }
+
+    @Override
+    public String toString() {
+        Gson gson = new Gson();
+        return gson.toJson(this);
+    }
+}

--- a/fe/src/main/java/org/apache/doris/common/FeConstants.java
+++ b/fe/src/main/java/org/apache/doris/common/FeConstants.java
@@ -35,5 +35,5 @@ public class FeConstants {
 
     // general model
     // Current meta data version. Use this version to write journals and image
-    public static int meta_version = FeMetaVersion.VERSION_55;
+    public static int meta_version = FeMetaVersion.VERSION_56;
 }

--- a/fe/src/main/java/org/apache/doris/common/FeMetaVersion.java
+++ b/fe/src/main/java/org/apache/doris/common/FeMetaVersion.java
@@ -120,4 +120,6 @@ public final class FeMetaVersion {
     public static final int VERSION_54 = 54;
     // modify colocation join
     public static final int VERSION_55 = 55;
+    // persist auth info in load job
+    public static final int VERSION_56 = 56;
 }

--- a/fe/src/main/java/org/apache/doris/http/BaseAction.java
+++ b/fe/src/main/java/org/apache/doris/http/BaseAction.java
@@ -262,7 +262,7 @@ public abstract class BaseAction implements IAction {
         }
     }
 
-    public static class AuthorizationInfo {
+    public static class ActionAuthorizationInfo {
         public String fullUserName;
         public String remoteIp;
         public String password;
@@ -277,7 +277,7 @@ public abstract class BaseAction implements IAction {
         }
     }
 
-    protected void checkGlobalAuth(AuthorizationInfo authInfo, PrivPredicate predicate) throws UnauthorizedException {
+    protected void checkGlobalAuth(ActionAuthorizationInfo authInfo, PrivPredicate predicate) throws UnauthorizedException {
         if (!Catalog.getCurrentCatalog().getAuth().checkGlobalPriv(authInfo.remoteIp,
                                                                    authInfo.fullUserName,
                                                                    predicate)) {
@@ -286,7 +286,7 @@ public abstract class BaseAction implements IAction {
         }
     }
 
-    protected void checkDbAuth(AuthorizationInfo authInfo, String db, PrivPredicate predicate)
+    protected void checkDbAuth(ActionAuthorizationInfo authInfo, String db, PrivPredicate predicate)
             throws UnauthorizedException {
         if (!Catalog.getCurrentCatalog().getAuth().checkDbPriv(authInfo.remoteIp, db, authInfo.fullUserName,
                                                                predicate)) {
@@ -295,7 +295,7 @@ public abstract class BaseAction implements IAction {
         }
     }
 
-    protected void checkTblAuth(AuthorizationInfo authInfo, String db, String tbl, PrivPredicate predicate) 
+    protected void checkTblAuth(ActionAuthorizationInfo authInfo, String db, String tbl, PrivPredicate predicate)
             throws UnauthorizedException {
         if (!Catalog.getCurrentCatalog().getAuth().checkTblPriv(authInfo.remoteIp, db, authInfo.fullUserName,
                                                                 tbl, predicate)) {
@@ -304,7 +304,7 @@ public abstract class BaseAction implements IAction {
         }
     }
 
-    protected void checkPassword(AuthorizationInfo authInfo)
+    protected void checkPassword(ActionAuthorizationInfo authInfo)
             throws UnauthorizedException {
         if (!Catalog.getCurrentCatalog().getAuth().checkPlainPassword(authInfo.fullUserName,
                                                                       authInfo.remoteIp,
@@ -314,9 +314,9 @@ public abstract class BaseAction implements IAction {
         }
     }
 
-    public AuthorizationInfo getAuthorizationInfo(BaseRequest request)
+    public ActionAuthorizationInfo getAuthorizationInfo(BaseRequest request)
             throws UnauthorizedException {
-        AuthorizationInfo authInfo = new AuthorizationInfo();
+        ActionAuthorizationInfo authInfo = new ActionAuthorizationInfo();
         if (!parseAuthInfo(request, authInfo)) {
             throw new UnauthorizedException("Need auth information.");
         }
@@ -324,7 +324,7 @@ public abstract class BaseAction implements IAction {
         return authInfo;
     }
 
-    private boolean parseAuthInfo(BaseRequest request, AuthorizationInfo authInfo) {
+    private boolean parseAuthInfo(BaseRequest request, ActionAuthorizationInfo authInfo) {
         String encodedAuthString = request.getAuthorizationHeader();
         if (Strings.isNullOrEmpty(encodedAuthString)) {
             return false;

--- a/fe/src/main/java/org/apache/doris/http/action/WebBaseAction.java
+++ b/fe/src/main/java/org/apache/doris/http/action/WebBaseAction.java
@@ -142,7 +142,7 @@ public class WebBaseAction extends BaseAction {
         }
 
         // cookie is invalid.
-        AuthorizationInfo authInfo;
+        ActionAuthorizationInfo authInfo;
         try {
             authInfo = getAuthorizationInfo(request);
             checkPassword(authInfo);

--- a/fe/src/main/java/org/apache/doris/http/meta/ColocateMetaService.java
+++ b/fe/src/main/java/org/apache/doris/http/meta/ColocateMetaService.java
@@ -91,7 +91,7 @@ public class ColocateMetaService {
         }
 
         @Override
-        public void executeWithoutPassword(AuthorizationInfo authInfo, BaseRequest request, BaseResponse response)
+        public void executeWithoutPassword(ActionAuthorizationInfo authInfo, BaseRequest request, BaseResponse response)
                 throws DdlException {
             if (redirectToMaster(request, response)) {
                 return;
@@ -101,7 +101,7 @@ public class ColocateMetaService {
         }
 
         // implement in derived classes
-        protected void executeInMasterWithAdmin(AuthorizationInfo authInfo, BaseRequest request, BaseResponse response)
+        protected void executeInMasterWithAdmin(ActionAuthorizationInfo authInfo, BaseRequest request, BaseResponse response)
                 throws DdlException {
             throw new DdlException("Not implemented");
         }
@@ -119,7 +119,7 @@ public class ColocateMetaService {
         }
 
         @Override
-        public void executeInMasterWithAdmin(AuthorizationInfo authInfo, BaseRequest request, BaseResponse response)
+        public void executeInMasterWithAdmin(ActionAuthorizationInfo authInfo, BaseRequest request, BaseResponse response)
                 throws DdlException {
             response.setContentType("application/json");
             RestResult result = new RestResult();
@@ -141,7 +141,7 @@ public class ColocateMetaService {
         }
 
         @Override
-        public void executeInMasterWithAdmin(AuthorizationInfo authInfo, BaseRequest request, BaseResponse response)
+        public void executeInMasterWithAdmin(ActionAuthorizationInfo authInfo, BaseRequest request, BaseResponse response)
                 throws DdlException {
             GroupId groupId = checkAndGetGroupId(request);
 
@@ -173,7 +173,7 @@ public class ColocateMetaService {
         }
 
         @Override
-        public void executeInMasterWithAdmin(AuthorizationInfo authInfo, BaseRequest request, BaseResponse response)
+        public void executeInMasterWithAdmin(ActionAuthorizationInfo authInfo, BaseRequest request, BaseResponse response)
                 throws DdlException {
             final String clusterName = authInfo.cluster;
             if (Strings.isNullOrEmpty(clusterName)) {

--- a/fe/src/main/java/org/apache/doris/http/rest/CancelStreamLoad.java
+++ b/fe/src/main/java/org/apache/doris/http/rest/CancelStreamLoad.java
@@ -46,7 +46,7 @@ public class CancelStreamLoad extends RestBaseAction {
     }
 
     @Override
-    public void executeWithoutPassword(AuthorizationInfo authInfo, BaseRequest request, BaseResponse response)
+    public void executeWithoutPassword(ActionAuthorizationInfo authInfo, BaseRequest request, BaseResponse response)
             throws DdlException {
 
         if (redirectToMaster(request, response)) {

--- a/fe/src/main/java/org/apache/doris/http/rest/CheckDecommissionAction.java
+++ b/fe/src/main/java/org/apache/doris/http/rest/CheckDecommissionAction.java
@@ -54,7 +54,7 @@ public class CheckDecommissionAction extends RestBaseAction {
     }
 
     @Override
-    public void executeWithoutPassword(AuthorizationInfo authInfo, BaseRequest request, BaseResponse response)
+    public void executeWithoutPassword(ActionAuthorizationInfo authInfo, BaseRequest request, BaseResponse response)
             throws DdlException {
         checkGlobalAuth(authInfo, PrivPredicate.OPERATOR);
 

--- a/fe/src/main/java/org/apache/doris/http/rest/GetDdlStmtAction.java
+++ b/fe/src/main/java/org/apache/doris/http/rest/GetDdlStmtAction.java
@@ -60,7 +60,7 @@ public class GetDdlStmtAction extends RestBaseAction {
     }
 
     @Override
-    public void executeWithoutPassword(AuthorizationInfo authInfo, BaseRequest request, BaseResponse response)
+    public void executeWithoutPassword(ActionAuthorizationInfo authInfo, BaseRequest request, BaseResponse response)
             throws DdlException {
         checkGlobalAuth(authInfo, PrivPredicate.ADMIN);
 

--- a/fe/src/main/java/org/apache/doris/http/rest/GetLogFileAction.java
+++ b/fe/src/main/java/org/apache/doris/http/rest/GetLogFileAction.java
@@ -61,7 +61,7 @@ public class GetLogFileAction extends RestBaseAction {
     }
 
     @Override
-    public void executeWithoutPassword(AuthorizationInfo authInfo, BaseRequest request, BaseResponse response) {
+    public void executeWithoutPassword(ActionAuthorizationInfo authInfo, BaseRequest request, BaseResponse response) {
         String logType = request.getSingleParameter("type");
         String logFile = request.getSingleParameter("file");
         

--- a/fe/src/main/java/org/apache/doris/http/rest/GetStreamLoadState.java
+++ b/fe/src/main/java/org/apache/doris/http/rest/GetStreamLoadState.java
@@ -45,7 +45,7 @@ public class GetStreamLoadState extends RestBaseAction {
     }
 
     @Override
-    public void executeWithoutPassword(AuthorizationInfo authInfo, BaseRequest request, BaseResponse response)
+    public void executeWithoutPassword(ActionAuthorizationInfo authInfo, BaseRequest request, BaseResponse response)
             throws DdlException {
 
         if (redirectToMaster(request, response)) {

--- a/fe/src/main/java/org/apache/doris/http/rest/LoadAction.java
+++ b/fe/src/main/java/org/apache/doris/http/rest/LoadAction.java
@@ -73,7 +73,7 @@ public class LoadAction extends RestBaseAction {
     }
 
     @Override
-    public void executeWithoutPassword(AuthorizationInfo authInfo,
+    public void executeWithoutPassword(ActionAuthorizationInfo authInfo,
             BaseRequest request, BaseResponse response) throws DdlException {
 
         // A 'Load' request must have 100-continue header

--- a/fe/src/main/java/org/apache/doris/http/rest/MetaReplayerCheckAction.java
+++ b/fe/src/main/java/org/apache/doris/http/rest/MetaReplayerCheckAction.java
@@ -48,7 +48,7 @@ public class MetaReplayerCheckAction extends RestBaseAction {
 
     @Override
     public void execute(BaseRequest request, BaseResponse response) throws DdlException {
-        AuthorizationInfo authInfo = getAuthorizationInfo(request);
+        ActionAuthorizationInfo authInfo = getAuthorizationInfo(request);
         checkGlobalAuth(authInfo, PrivPredicate.ADMIN);
 
         Map<String, String> resultMap = Catalog.getInstance().getMetaReplayState().getInfo();

--- a/fe/src/main/java/org/apache/doris/http/rest/MigrationAction.java
+++ b/fe/src/main/java/org/apache/doris/http/rest/MigrationAction.java
@@ -67,7 +67,7 @@ public class MigrationAction extends RestBaseAction {
 
     @Override
     public void execute(BaseRequest request, BaseResponse response) throws DdlException {
-        AuthorizationInfo authInfo = getAuthorizationInfo(request);
+        ActionAuthorizationInfo authInfo = getAuthorizationInfo(request);
         checkGlobalAuth(authInfo, PrivPredicate.ADMIN);
 
         String dbName = request.getSingleParameter(DB_PARAM);

--- a/fe/src/main/java/org/apache/doris/http/rest/MultiAbort.java
+++ b/fe/src/main/java/org/apache/doris/http/rest/MultiAbort.java
@@ -48,7 +48,7 @@ public class MultiAbort extends RestBaseAction {
     }
 
     @Override
-    public void executeWithoutPassword(AuthorizationInfo authInfo, BaseRequest request, BaseResponse response)
+    public void executeWithoutPassword(ActionAuthorizationInfo authInfo, BaseRequest request, BaseResponse response)
             throws DdlException {
         String db = request.getSingleParameter(DB_KEY);
         if (Strings.isNullOrEmpty(db)) {

--- a/fe/src/main/java/org/apache/doris/http/rest/MultiCommit.java
+++ b/fe/src/main/java/org/apache/doris/http/rest/MultiCommit.java
@@ -48,7 +48,7 @@ public class MultiCommit extends RestBaseAction {
     }
 
     @Override
-    public void executeWithoutPassword(AuthorizationInfo authInfo, BaseRequest request, BaseResponse response)
+    public void executeWithoutPassword(ActionAuthorizationInfo authInfo, BaseRequest request, BaseResponse response)
             throws DdlException {
         String db = request.getSingleParameter(DB_KEY);
         if (Strings.isNullOrEmpty(db)) {

--- a/fe/src/main/java/org/apache/doris/http/rest/MultiDesc.java
+++ b/fe/src/main/java/org/apache/doris/http/rest/MultiDesc.java
@@ -52,7 +52,7 @@ public class MultiDesc extends RestBaseAction {
     }
 
     @Override
-    public void executeWithoutPassword(AuthorizationInfo authInfo, BaseRequest request, BaseResponse response)
+    public void executeWithoutPassword(ActionAuthorizationInfo authInfo, BaseRequest request, BaseResponse response)
             throws DdlException {
         String db = request.getSingleParameter(DB_KEY);
         if (Strings.isNullOrEmpty(db)) {

--- a/fe/src/main/java/org/apache/doris/http/rest/MultiList.java
+++ b/fe/src/main/java/org/apache/doris/http/rest/MultiList.java
@@ -51,7 +51,7 @@ public class MultiList extends RestBaseAction {
     }
 
     @Override
-    public void executeWithoutPassword(AuthorizationInfo authInfo, BaseRequest request, BaseResponse response)
+    public void executeWithoutPassword(ActionAuthorizationInfo authInfo, BaseRequest request, BaseResponse response)
             throws DdlException {
         String db = request.getSingleParameter(DB_KEY);
         if (Strings.isNullOrEmpty(db)) {

--- a/fe/src/main/java/org/apache/doris/http/rest/MultiStart.java
+++ b/fe/src/main/java/org/apache/doris/http/rest/MultiStart.java
@@ -53,7 +53,7 @@ public class MultiStart extends RestBaseAction {
     }
 
     @Override
-    public void executeWithoutPassword(AuthorizationInfo authInfo, BaseRequest request, BaseResponse response)
+    public void executeWithoutPassword(ActionAuthorizationInfo authInfo, BaseRequest request, BaseResponse response)
             throws DdlException {
         String db = request.getSingleParameter(DB_KEY);
         if (Strings.isNullOrEmpty(db)) {

--- a/fe/src/main/java/org/apache/doris/http/rest/MultiUnload.java
+++ b/fe/src/main/java/org/apache/doris/http/rest/MultiUnload.java
@@ -49,7 +49,7 @@ public class MultiUnload extends RestBaseAction {
     }
 
     @Override
-    public void executeWithoutPassword(AuthorizationInfo authInfo, BaseRequest request, BaseResponse response)
+    public void executeWithoutPassword(ActionAuthorizationInfo authInfo, BaseRequest request, BaseResponse response)
             throws DdlException {
         String db = request.getSingleParameter(DB_KEY);
         if (Strings.isNullOrEmpty(db)) {

--- a/fe/src/main/java/org/apache/doris/http/rest/RestBaseAction.java
+++ b/fe/src/main/java/org/apache/doris/http/rest/RestBaseAction.java
@@ -24,6 +24,7 @@ import org.apache.doris.http.BaseAction;
 import org.apache.doris.http.BaseRequest;
 import org.apache.doris.http.BaseResponse;
 import org.apache.doris.http.UnauthorizedException;
+import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.thrift.TNetworkAddress;
 
 import org.apache.logging.log4j.LogManager;
@@ -59,15 +60,20 @@ public class RestBaseAction extends BaseAction {
 
     @Override
     public void execute(BaseRequest request, BaseResponse response) throws DdlException {
-        AuthorizationInfo authInfo = getAuthorizationInfo(request);
+        ActionAuthorizationInfo authInfo = getAuthorizationInfo(request);
         // check password
         checkPassword(authInfo);
+        ConnectContext ctx = new ConnectContext(null);
+        ctx.setQualifiedUser(authInfo.fullUserName);
+        ctx.setRemoteIP(authInfo.remoteIp);
+        ctx.setCluster(authInfo.cluster);
+        ctx.setThreadLocalInfo();
         executeWithoutPassword(authInfo, request, response);
     }
 
     // If user password should be checked, the derived class should implement this method, NOT 'execute()',
     // otherwise, override 'execute()' directly
-    protected void executeWithoutPassword(AuthorizationInfo authInfo, BaseRequest request, BaseResponse response)
+    protected void executeWithoutPassword(ActionAuthorizationInfo authInfo, BaseRequest request, BaseResponse response)
             throws DdlException {
         throw new DdlException("Not implemented");
     }

--- a/fe/src/main/java/org/apache/doris/http/rest/RowCountAction.java
+++ b/fe/src/main/java/org/apache/doris/http/rest/RowCountAction.java
@@ -60,7 +60,7 @@ public class RowCountAction extends RestBaseAction {
 
     @Override
     public void execute(BaseRequest request, BaseResponse response) throws DdlException {
-        AuthorizationInfo authInfo = getAuthorizationInfo(request);
+        ActionAuthorizationInfo authInfo = getAuthorizationInfo(request);
         checkGlobalAuth(authInfo, PrivPredicate.ADMIN);
 
         String dbName = request.getSingleParameter(DB_NAME_PARAM);

--- a/fe/src/main/java/org/apache/doris/http/rest/SetConfigAction.java
+++ b/fe/src/main/java/org/apache/doris/http/rest/SetConfigAction.java
@@ -58,7 +58,7 @@ public class SetConfigAction extends RestBaseAction {
 
     @Override
     public void execute(BaseRequest request, BaseResponse response) throws DdlException {
-        AuthorizationInfo authInfo = getAuthorizationInfo(request);
+        ActionAuthorizationInfo authInfo = getAuthorizationInfo(request);
         checkGlobalAuth(authInfo, PrivPredicate.ADMIN);
 
         Map<String, List<String>> configs = request.getAllParameters();

--- a/fe/src/main/java/org/apache/doris/http/rest/ShowProcAction.java
+++ b/fe/src/main/java/org/apache/doris/http/rest/ShowProcAction.java
@@ -60,7 +60,7 @@ public class ShowProcAction extends RestBaseAction {
     @Override
     public void execute(BaseRequest request, BaseResponse response) {
         // check authority
-        AuthorizationInfo authInfo;
+        ActionAuthorizationInfo authInfo;
         try {
             authInfo = getAuthorizationInfo(request);
             checkGlobalAuth(authInfo, PrivPredicate.ADMIN);

--- a/fe/src/main/java/org/apache/doris/http/rest/StorageTypeCheckAction.java
+++ b/fe/src/main/java/org/apache/doris/http/rest/StorageTypeCheckAction.java
@@ -51,7 +51,7 @@ public class StorageTypeCheckAction extends RestBaseAction {
 
     @Override
     public void execute(BaseRequest request, BaseResponse response) throws DdlException {
-        AuthorizationInfo authInfo = getAuthorizationInfo(request);
+        ActionAuthorizationInfo authInfo = getAuthorizationInfo(request);
         checkGlobalAuth(authInfo, PrivPredicate.ADMIN);
 
         String dbName = request.getSingleParameter("db");

--- a/fe/src/main/java/org/apache/doris/load/loadv2/InsertLoadJob.java
+++ b/fe/src/main/java/org/apache/doris/load/loadv2/InsertLoadJob.java
@@ -28,7 +28,6 @@ import org.apache.doris.load.FailMsg;
 import org.apache.doris.load.FailMsg.CancelType;
 
 import com.google.common.base.Strings;
-
 import com.google.common.collect.Sets;
 
 import java.io.DataInput;
@@ -51,7 +50,8 @@ public class InsertLoadJob extends LoadJob {
         this.jobType = EtlJobType.INSERT;
     }
 
-    public InsertLoadJob(String label, long dbId, long tableId, long createTimestamp, String failMsg) {
+    public InsertLoadJob(String label, long dbId, long tableId, long createTimestamp, String failMsg)
+            throws MetaNotFoundException {
         super(dbId, label);
         this.tableId = tableId;
         this.createTimestamp = createTimestamp;
@@ -67,15 +67,15 @@ public class InsertLoadJob extends LoadJob {
         }
         this.jobType = EtlJobType.INSERT;
         this.timeoutSecond = Config.insert_load_default_timeout_second;
+        this.authorizationInfo = gatherAuthInfo();
     }
 
-    @Override
-    public void setAuthorizationInfo() throws MetaNotFoundException {
+    public AuthorizationInfo gatherAuthInfo() throws MetaNotFoundException {
         Database database = Catalog.getCurrentCatalog().getDb(dbId);
         if (database == null) {
             throw new MetaNotFoundException("Database " + dbId + "has been deleted");
         }
-        this.authorizationInfo = new AuthorizationInfo(database.getFullName(), getTableNames());
+        return new AuthorizationInfo(database.getFullName(), getTableNames());
     }
 
     @Override

--- a/fe/src/main/java/org/apache/doris/load/loadv2/LoadJob.java
+++ b/fe/src/main/java/org/apache/doris/load/loadv2/LoadJob.java
@@ -197,7 +197,7 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
     /**
      * Return the real table names by table ids.
      * The method is invoked by 'checkAuth' when authorization info is null in job.
-     * Also it is invoked by 'setAuthorizationInfo' which saves the auth info in the beginning of job.
+     * Also it is invoked by 'gatherAuthInfo' which saves the auth info in the constructor of job.
      * Throw MetaNofFoundException when table name could not be found.
      * @return
      */
@@ -253,8 +253,6 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
             }
         }
     }
-
-    abstract void setAuthorizationInfo() throws MetaNotFoundException;
 
     protected static void checkDataSourceInfo(Database db, List<DataDescription> dataDescriptions) throws DdlException {
         for (DataDescription dataDescription : dataDescriptions) {

--- a/fe/src/main/java/org/apache/doris/load/loadv2/LoadJob.java
+++ b/fe/src/main/java/org/apache/doris/load/loadv2/LoadJob.java
@@ -80,6 +80,7 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
     protected String label;
     protected JobState state = JobState.PENDING;
     protected EtlJobType jobType;
+    // the auth info could be null when load job is created before commit named 'Persist auth info in load job'
     protected AuthorizationInfo authorizationInfo;
 
     // optional properties
@@ -195,6 +196,8 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
 
     /**
      * Return the real table names by table ids.
+     * The method is invoked by 'checkAuth' when authorization info is null in job.
+     * Also it is invoked by 'setAuthorizationInfo' which saves the auth info in the beginning of job.
      * Throw MetaNofFoundException when table name could not be found.
      * @return
      */
@@ -391,9 +394,7 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
         if (!Catalog.getCurrentCatalog().getAuth().checkPrivByAuthInfo(ConnectContext.get(), authorizationInfo,
                                                                        PrivPredicate.LOAD)) {
             ErrorReport.reportDdlException(ErrorCode.ERR_SPECIFIC_ACCESS_DENIED_ERROR,
-                                           ConnectContext.get().getQualifiedUser(),
-                                           ConnectContext.get().getRemoteIP(),
-                                           authorizationInfo.toString());
+                                           PrivPredicate.LOAD);
         }
     }
 

--- a/fe/src/main/java/org/apache/doris/load/loadv2/LoadJob.java
+++ b/fe/src/main/java/org/apache/doris/load/loadv2/LoadJob.java
@@ -406,7 +406,7 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
     private void checkAuthWithoutAuthInfo(String command) throws DdlException {
         Database db = Catalog.getInstance().getDb(dbId);
         if (db == null) {
-            ErrorReport.reportDdlException(ErrorCode.ERR_BAD_DB_ERROR);
+            ErrorReport.reportDdlException(ErrorCode.ERR_BAD_DB_ERROR, dbId);
         }
 
         // check auth
@@ -431,7 +431,7 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
                 }
             }
         } catch (MetaNotFoundException e) {
-            ErrorReport.reportDdlException(ErrorCode.ERR_TABLE_EXISTS_ERROR);
+            throw new DdlException(e.getMessage());
         }
     }
 

--- a/fe/src/main/java/org/apache/doris/load/loadv2/LoadManager.java
+++ b/fe/src/main/java/org/apache/doris/load/loadv2/LoadManager.java
@@ -136,6 +136,7 @@ public class LoadManager implements Writable{
         try {
             checkLabelUsed(database.getId(), request.getLabel(), request.getCreate_timestamp());
             loadJob = new MiniLoadJob(database.getId(), request);
+            loadJob.setAuthorizationInfo();
             createLoadJob(loadJob);
         } catch (DuplicatedRequestException e) {
             return dbIdToLabelToLoadJobs.get(database.getId()).get(request.getLabel())
@@ -272,7 +273,7 @@ public class LoadManager implements Writable{
         Catalog.getCurrentCatalog().getEditLog().logCreateLoadJob(loadJob);
     }
 
-    public void cancelLoadJob(CancelLoadStmt stmt) throws DdlException, MetaNotFoundException {
+    public void cancelLoadJob(CancelLoadStmt stmt) throws DdlException {
         Database db = Catalog.getInstance().getDb(stmt.getDbName());
         if (db == null) {
             throw new DdlException("Db does not exist. name: " + stmt.getDbName());
@@ -416,7 +417,7 @@ public class LoadManager implements Writable{
                     }
                     // add load job info
                     loadJobInfos.add(loadJob.getShowInfo());
-                } catch (DdlException | MetaNotFoundException e) {
+                } catch (DdlException e) {
                     continue;
                 }
             }
@@ -426,7 +427,7 @@ public class LoadManager implements Writable{
         }
     }
 
-    public void getLoadJobInfo(Load.JobInfo info) throws DdlException, MetaNotFoundException {
+    public void getLoadJobInfo(Load.JobInfo info) throws DdlException {
         String fullDbName = ClusterNamespace.getFullName(info.clusterName, info.dbName);
         info.dbName = fullDbName;
         Database database = checkDb(info.dbName);

--- a/fe/src/main/java/org/apache/doris/load/loadv2/LoadManager.java
+++ b/fe/src/main/java/org/apache/doris/load/loadv2/LoadManager.java
@@ -136,7 +136,6 @@ public class LoadManager implements Writable{
         try {
             checkLabelUsed(database.getId(), request.getLabel(), request.getCreate_timestamp());
             loadJob = new MiniLoadJob(database.getId(), request);
-            loadJob.setAuthorizationInfo();
             createLoadJob(loadJob);
         } catch (DuplicatedRequestException e) {
             return dbIdToLabelToLoadJobs.get(database.getId()).get(request.getLabel())

--- a/fe/src/main/java/org/apache/doris/load/loadv2/MiniLoadJob.java
+++ b/fe/src/main/java/org/apache/doris/load/loadv2/MiniLoadJob.java
@@ -17,7 +17,9 @@
 
 package org.apache.doris.load.loadv2;
 
+import org.apache.doris.catalog.AuthorizationInfo;
 import org.apache.doris.catalog.Catalog;
+import org.apache.doris.catalog.Database;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.LabelAlreadyUsedException;
@@ -29,11 +31,11 @@ import org.apache.doris.thrift.TMiniLoadBeginRequest;
 import org.apache.doris.transaction.BeginTransactionException;
 import org.apache.doris.transaction.TransactionState;
 
+import com.google.common.collect.Sets;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.HashSet;
 import java.util.Set;
 
 public class MiniLoadJob extends LoadJob {
@@ -64,8 +66,22 @@ public class MiniLoadJob extends LoadJob {
     }
 
     @Override
+    public Set<String> getTableNamesForShow() {
+        return Sets.newHashSet(tableName);
+    }
+
+    @Override
     public Set<String> getTableNames() throws MetaNotFoundException {
-        return new HashSet<>(Arrays.asList(tableName));
+        return Sets.newHashSet(tableName);
+    }
+
+    @Override
+    public void setAuthorizationInfo() throws MetaNotFoundException {
+        Database database = Catalog.getCurrentCatalog().getDb(dbId);
+        if (database == null) {
+            throw new MetaNotFoundException("Database " + dbId + "has been deleted");
+        }
+        this.authorizationInfo = new AuthorizationInfo(database.getFullName(), getTableNames());
     }
 
     @Override

--- a/fe/src/main/java/org/apache/doris/load/loadv2/MiniLoadJob.java
+++ b/fe/src/main/java/org/apache/doris/load/loadv2/MiniLoadJob.java
@@ -48,7 +48,7 @@ public class MiniLoadJob extends LoadJob {
         this.jobType = EtlJobType.MINI;
     }
 
-    public MiniLoadJob(long dbId, TMiniLoadBeginRequest request) {
+    public MiniLoadJob(long dbId, TMiniLoadBeginRequest request) throws MetaNotFoundException {
         super(dbId, request.getLabel());
         this.jobType = EtlJobType.MINI;
         this.tableName = request.getTbl();
@@ -63,6 +63,7 @@ public class MiniLoadJob extends LoadJob {
         this.isCancellable = false;
         this.createTimestamp = request.getCreate_timestamp();
         this.loadStartTimestamp = createTimestamp;
+        this.authorizationInfo = gatherAuthInfo();
     }
 
     @Override
@@ -75,13 +76,12 @@ public class MiniLoadJob extends LoadJob {
         return Sets.newHashSet(tableName);
     }
 
-    @Override
-    public void setAuthorizationInfo() throws MetaNotFoundException {
+    public AuthorizationInfo gatherAuthInfo() throws MetaNotFoundException {
         Database database = Catalog.getCurrentCatalog().getDb(dbId);
         if (database == null) {
             throw new MetaNotFoundException("Database " + dbId + "has been deleted");
         }
-        this.authorizationInfo = new AuthorizationInfo(database.getFullName(), getTableNames());
+        return new AuthorizationInfo(database.getFullName(), getTableNames());
     }
 
     @Override

--- a/fe/src/main/java/org/apache/doris/mysql/privilege/PaloAuth.java
+++ b/fe/src/main/java/org/apache/doris/mysql/privilege/PaloAuth.java
@@ -28,6 +28,7 @@ import org.apache.doris.analysis.SetUserPropertyStmt;
 import org.apache.doris.analysis.TablePattern;
 import org.apache.doris.analysis.UserIdentity;
 import org.apache.doris.catalog.AccessPrivilege;
+import org.apache.doris.catalog.AuthorizationInfo;
 import org.apache.doris.catalog.Catalog;
 import org.apache.doris.catalog.InfoSchemaDb;
 import org.apache.doris.cluster.ClusterNamespace;
@@ -316,6 +317,25 @@ public class PaloAuth implements Writable {
 
         LOG.debug("failed to get wanted privs: {}, ganted: {}", wanted, savedPrivs);
         return false;
+    }
+
+    public boolean checkPrivByAuthInfo(ConnectContext ctx, AuthorizationInfo authInfo, PrivPredicate wanted) {
+        if (authInfo == null) {
+            return false;
+        }
+        if (authInfo.getDbName() == null) {
+            return false;
+        }
+        if (authInfo.getTableNameList() == null || authInfo.getTableNameList().isEmpty()) {
+            return checkDbPriv(ctx, authInfo.getDbName(), wanted);
+        }
+        for (String tblName : authInfo.getTableNameList()) {
+            if (!Catalog.getCurrentCatalog().getAuth().checkTblPriv(ConnectContext.get(), authInfo.getDbName(),
+                                                                    tblName, wanted)) {
+                return false;
+            }
+        }
+        return true;
     }
 
     private boolean checkGlobalInternal(String host, String user, PrivPredicate wanted, PrivBitSet savedPrivs) {

--- a/fe/src/test/java/org/apache/doris/load/loadv2/BrokerLoadJobTest.java
+++ b/fe/src/test/java/org/apache/doris/load/loadv2/BrokerLoadJobTest.java
@@ -184,8 +184,8 @@ public class BrokerLoadJobTest {
             }
         };
 
-        Assert.assertEquals(1, brokerLoadJob.getTableNames().size());
-        Assert.assertEquals(true, brokerLoadJob.getTableNames().contains(tableName));
+        Assert.assertEquals(1, brokerLoadJob.getTableNamesForShow().size());
+        Assert.assertEquals(true, brokerLoadJob.getTableNamesForShow().contains(tableName));
     }
 
     @Test

--- a/fe/src/test/java/org/apache/doris/load/loadv2/InsertLoadJobTest.java
+++ b/fe/src/test/java/org/apache/doris/load/loadv2/InsertLoadJobTest.java
@@ -50,7 +50,7 @@ public class InsertLoadJobTest {
                 result = tableName;
             }
         };
-        Set<String> tableNames = insertLoadJob.getTableNames();
+        Set<String> tableNames = insertLoadJob.getTableNamesForShow();
         Assert.assertEquals(1, tableNames.size());
         Assert.assertEquals(true, tableNames.contains(tableName));
         Assert.assertEquals(JobState.FINISHED, insertLoadJob.getState());

--- a/fe/src/test/java/org/apache/doris/load/loadv2/LoadManagerTest.java
+++ b/fe/src/test/java/org/apache/doris/load/loadv2/LoadManagerTest.java
@@ -21,6 +21,7 @@ import org.apache.doris.analysis.LabelName;
 import org.apache.doris.analysis.LoadStmt;
 import org.apache.doris.catalog.Catalog;
 import org.apache.doris.catalog.Database;
+import org.apache.doris.catalog.Table;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.DdlException;
 import org.apache.doris.common.FeMetaVersion;
@@ -54,9 +55,7 @@ public class LoadManagerTest {
 
     @Before
     public void setUp() throws Exception {
-        loadManager = new LoadManager(new LoadJobScheduler());
-        LoadJob job1 = new InsertLoadJob("job1", 1L, 1L, System.currentTimeMillis(), "");
-        Deencapsulation.invoke(loadManager, "addLoadJob", job1);
+
     }
 
     @Test
@@ -100,13 +99,25 @@ public class LoadManagerTest {
     }
 
     @Test
-    public void testSerializationNormal(@Mocked MetaContext metaContext) throws Exception {
+    public void testSerializationNormal(@Mocked Catalog catalog,
+                                        @Injectable Database database,
+                                        @Injectable Table table) throws Exception {
         new Expectations(){
             {
-                metaContext.getMetaVersion();
-                result = FeMetaVersion.VERSION_54;
+                catalog.getDb(anyLong);
+                result = database;
+                database.getTable(anyLong);
+                result = table;
+                table.getName();
+                result = "tablename";
+                Catalog.getCurrentCatalogJournalVersion();
+                result = FeMetaVersion.VERSION_56;
             }
         };
+
+        loadManager = new LoadManager(new LoadJobScheduler());
+        LoadJob job1 = new InsertLoadJob("job1", 1L, 1L, System.currentTimeMillis(), "");
+        Deencapsulation.invoke(loadManager, "addLoadJob", job1);
 
         File file = serializeToFile(loadManager);
 
@@ -118,7 +129,25 @@ public class LoadManagerTest {
     }
 
     @Test
-    public void testSerializationWithJobRemoved() throws Exception {
+    public void testSerializationWithJobRemoved(@Mocked MetaContext metaContext,
+                                                @Mocked Catalog catalog,
+                                                @Injectable Database database,
+                                                @Injectable Table table) throws Exception {
+        new Expectations(){
+            {
+                catalog.getDb(anyLong);
+                result = database;
+                database.getTable(anyLong);
+                result = table;
+                table.getName();
+                result = "tablename";
+            }
+        };
+
+        loadManager = new LoadManager(new LoadJobScheduler());
+        LoadJob job1 = new InsertLoadJob("job1", 1L, 1L, System.currentTimeMillis(), "");
+        Deencapsulation.invoke(loadManager, "addLoadJob", job1);
+
         //make job1 don't serialize
         Config.label_keep_max_second = 1;
         Thread.sleep(2000);


### PR DESCRIPTION
The new class named 'AuthorizationInfo' is used to save the auth info in jobs.
The job doesn't need to retrieve the auth info by meta id which maybe throw the exception when db or table has been dropped.
The persistence of 'AuthorizationInfo' take effect in META_VERSION 56