### PR TITLE
Modify insert operation's behavior

### DIFF
--- a/fe/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/src/main/java/org/apache/doris/common/Config.java
@@ -826,10 +826,10 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true, masterOnly = true) public static boolean disable_colocate_balance = false;
 
     /*
-     * If set to true, the insert stmt with empty select result will still return a label to user.
+     * If set to true, the insert stmt with processing error will still return a label to user.
      * And user can use this label to check the load job's status.
-     * The default value is false, which means if select result is empty, an 'all partitions have no load data'
-     * exception will be thrown to user client.
+     * The default value is false, which means if insert operation encounter errors,
+     * exception will be thrown to user client directly without load label.
      */
     @ConfField(mutable = true, masterOnly = true) public static boolean using_old_load_usage_pattern = false;
 }

--- a/fe/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/src/main/java/org/apache/doris/common/Config.java
@@ -824,5 +824,13 @@ public class Config extends ConfigBase {
      */
     @ConfField(mutable = true, masterOnly = true) public static boolean disable_colocate_relocate = false;
     @ConfField(mutable = true, masterOnly = true) public static boolean disable_colocate_balance = false;
+
+    /*
+     * If set to true, the insert stmt with empty select result will still return a label to user.
+     * And user can use this label to check the load job's status.
+     * The default value is false, which means if select result is empty, an 'all partitions have no load data'
+     * exception will be thrown to user client.
+     */
+    @ConfField(mutable = true, masterOnly = true) public static boolean using_old_load_usage_pattern = false;
 }
 

--- a/fe/src/main/java/org/apache/doris/load/loadv2/InsertLoadJob.java
+++ b/fe/src/main/java/org/apache/doris/load/loadv2/InsertLoadJob.java
@@ -23,6 +23,10 @@ import org.apache.doris.catalog.Table;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.MetaNotFoundException;
 import org.apache.doris.load.EtlJobType;
+import org.apache.doris.load.FailMsg;
+import org.apache.doris.load.FailMsg.CancelType;
+
+import com.google.common.base.Strings;
 
 import java.io.DataInput;
 import java.io.DataOutput;
@@ -46,14 +50,20 @@ public class InsertLoadJob extends LoadJob {
         this.jobType = EtlJobType.INSERT;
     }
 
-    public InsertLoadJob(String label, long dbId, long tableId, long createTimestamp) {
+    public InsertLoadJob(String label, long dbId, long tableId, long createTimestamp, String failMsg) {
         super(dbId, label);
         this.tableId = tableId;
         this.createTimestamp = createTimestamp;
         this.loadStartTimestamp = createTimestamp;
         this.finishTimestamp = System.currentTimeMillis();
-        this.state = JobState.FINISHED;
-        this.progress = 100;
+        if (Strings.isNullOrEmpty(failMsg)) {
+            this.state = JobState.FINISHED;
+            this.progress = 100;
+        } else {
+            this.state = JobState.CANCELLED;
+            this.failMsg = new FailMsg(CancelType.ETL_RUN_FAIL, failMsg);
+            this.progress = 0;
+        }
         this.jobType = EtlJobType.INSERT;
         this.timeoutSecond = Config.insert_load_default_timeout_second;
     }

--- a/fe/src/main/java/org/apache/doris/load/loadv2/InsertLoadJob.java
+++ b/fe/src/main/java/org/apache/doris/load/loadv2/InsertLoadJob.java
@@ -61,7 +61,7 @@ public class InsertLoadJob extends LoadJob {
             this.progress = 100;
         } else {
             this.state = JobState.CANCELLED;
-            this.failMsg = new FailMsg(CancelType.ETL_RUN_FAIL, failMsg);
+            this.failMsg = new FailMsg(CancelType.LOAD_RUN_FAIL, failMsg);
             this.progress = 0;
         }
         this.jobType = EtlJobType.INSERT;

--- a/fe/src/main/java/org/apache/doris/load/loadv2/LoadManager.java
+++ b/fe/src/main/java/org/apache/doris/load/loadv2/LoadManager.java
@@ -251,7 +251,7 @@ public class LoadManager implements Writable{
     }
 
     public void recordFinishedLoadJob(String label, String dbName, long tableId, EtlJobType jobType,
-                                      long createTimestamp) throws MetaNotFoundException {
+            long createTimestamp, String failMsg) throws MetaNotFoundException {
 
         // get db id
         Database db = Catalog.getCurrentCatalog().getDb(dbName);
@@ -262,7 +262,7 @@ public class LoadManager implements Writable{
         LoadJob loadJob;
         switch (jobType) {
             case INSERT:
-                loadJob = new InsertLoadJob(label, db.getId(), tableId, createTimestamp);
+                loadJob = new InsertLoadJob(label, db.getId(), tableId, createTimestamp, failMsg);
                 break;
             default:
                 return;

--- a/fe/src/main/java/org/apache/doris/transaction/TransactionCommitFailedException.java
+++ b/fe/src/main/java/org/apache/doris/transaction/TransactionCommitFailedException.java
@@ -22,6 +22,8 @@ public class TransactionCommitFailedException extends TransactionException {
     
     private static final long serialVersionUID = -2528170792631761535L;
 
+    public static final String NO_DATA_TO_LOAD_MSG = "all partitions have no load data";
+
     public TransactionCommitFailedException(String msg) {
         super(msg);
     }

--- a/fe/src/test/java/org/apache/doris/load/loadv2/InsertLoadJobTest.java
+++ b/fe/src/test/java/org/apache/doris/load/loadv2/InsertLoadJobTest.java
@@ -38,7 +38,7 @@ public class InsertLoadJobTest {
     public void testGetTableNames(@Mocked Catalog catalog,
                                   @Injectable Database database,
                                   @Injectable Table table) throws MetaNotFoundException {
-        InsertLoadJob insertLoadJob = new InsertLoadJob("label", 1L, 1L, 1000);
+        InsertLoadJob insertLoadJob = new InsertLoadJob("label", 1L, 1L, 1000, "");
         String tableName = "table1";
         new Expectations() {
             {

--- a/fe/src/test/java/org/apache/doris/load/loadv2/LoadManagerTest.java
+++ b/fe/src/test/java/org/apache/doris/load/loadv2/LoadManagerTest.java
@@ -17,11 +17,6 @@
 
 package org.apache.doris.load.loadv2;
 
-import mockit.Deencapsulation;
-import mockit.Expectations;
-import mockit.Injectable;
-import mockit.Mocked;
-
 import org.apache.doris.analysis.LabelName;
 import org.apache.doris.analysis.LoadStmt;
 import org.apache.doris.catalog.Catalog;
@@ -48,6 +43,11 @@ import java.io.FileOutputStream;
 import java.util.List;
 import java.util.Map;
 
+import mockit.Deencapsulation;
+import mockit.Expectations;
+import mockit.Injectable;
+import mockit.Mocked;
+
 public class LoadManagerTest {
     private LoadManager loadManager;
     private static final String methodName = "getIdToLoadJobs";
@@ -55,7 +55,7 @@ public class LoadManagerTest {
     @Before
     public void setUp() throws Exception {
         loadManager = new LoadManager(new LoadJobScheduler());
-        LoadJob job1 = new InsertLoadJob("job1", 1L, 1L, System.currentTimeMillis());
+        LoadJob job1 = new InsertLoadJob("job1", 1L, 1L, System.currentTimeMillis(), "");
         Deencapsulation.invoke(loadManager, "addLoadJob", job1);
     }
 


### PR DESCRIPTION
Before changing default insert operation to streaming load, even if the insert operation
encounter errors, a label will be returned to the user, and user
can use this label to check the insert load job's status.

After changing the insert operation, if the the insert operation encounter errors, 
an exception will be thrown to user client directly without any label.

This new usage pattern is not friendly to the already existed users, which is forcing
them to change their way of using insert operation.

So I add a new FE config 'using_old_load_usage_pattern', default is false.
If set to true, a label will be returned to user even if the insert operation encounter errors.