### PR TITLE
[Doris On ES][Bug-Fix] Query ES table would fail when thrift_port not set

### DIFF
--- a/fe/src/main/java/org/apache/doris/external/EsShardRouting.java
+++ b/fe/src/main/java/org/apache/doris/external/EsShardRouting.java
@@ -18,6 +18,7 @@
 package org.apache.doris.external;
 
 
+import org.apache.commons.lang.StringUtils;
 import org.json.JSONObject;
 
 import org.apache.doris.thrift.TNetworkAddress;
@@ -46,8 +47,12 @@ public class EsShardRouting {
         JSONObject nodeInfo = nodesMap.getJSONObject(nodeId);
         String[] transportAddr = nodeInfo.getString("transport_address").split(":");
         // get thrift port from node info
-        String thriftPort = nodeInfo.getJSONObject("attributes").getString("thrift_port");
-        TNetworkAddress addr = new TNetworkAddress(transportAddr[0], Integer.valueOf(thriftPort));
+        String thriftPort = nodeInfo.getJSONObject("attributes").optString("thrift_port");
+        // In http transport mode, should ignore thrift_port, set address to null
+        TNetworkAddress addr = null;
+        if (!StringUtils.isEmpty(thriftPort)) {
+            addr = new TNetworkAddress(transportAddr[0], Integer.valueOf(thriftPort));
+        }
         boolean isPrimary = shardInfo.getBoolean("primary");
         return new EsShardRouting(indexName, Integer.valueOf(shardKey),
                 isPrimary, addr, nodeId);

--- a/fe/src/test/java/org/apache/doris/es/EsStateStoreTest.java
+++ b/fe/src/test/java/org/apache/doris/es/EsStateStoreTest.java
@@ -216,40 +216,7 @@ public class EsStateStoreTest {
         assertEquals("index2", esIndexState2.getIndexName());
         assertEquals(6, esIndexState2.getShardRoutings().size());
     }
-    
-    /**
-     * test node without thrift info, parse without error, but es index state is empty
-     * @throws AnalysisException 
-     */
-    @Test
-    public void testParseUnPartitionedWithoutThriftInfo() throws AnalysisException {
-        EsTable esTable = (EsTable) Catalog.getCurrentCatalog()
-                                            .getDb(CatalogTestUtil.testDb1)
-                                            .getTable(CatalogTestUtil.testUnPartitionedEsTableId1);
-        boolean hasException = false;
-        EsTableState esTableState = null;
-        try {
-            esTableState = esStateStore.parseClusterState55(clusterStateStr5, esTable);
-        } catch (Exception e) {
-            e.printStackTrace();
-            hasException = true;
-        }
-        assertFalse(hasException);
-        assertNotNull(esTableState);
-        
-        // check 
-        assertEquals(0, esTableState.getPartitionedIndexStates().size());
-        assertEquals(2, esTableState.getUnPartitionedIndexStates().size());
-        
-        // check index with no partition desc
-        EsIndexState esIndexState1 = esTableState.getUnPartitionedIndexStates().get("index1");
-        assertEquals("index1", esIndexState1.getIndexName());
-        EsIndexState esIndexState2 = esTableState.getUnPartitionedIndexStates().get("index2");
-        assertEquals("index2", esIndexState2.getIndexName());
-        assertEquals(6, esIndexState2.getShardRoutings().size());
-        
-        assertEquals(0, esIndexState1.getShardRoutings().get(1).size());
-    }
+
     
     /**
      * partitioned es table schema: k1(date), k2(int), v(double)


### PR DESCRIPTION
When create ES external table without the thrift_port not configure,  query  ES external table  using HTTP Transport Mode  would fail because all available shards would be ignored.


