### PR TITLE
Fix bug of wrong judgement for Hll type column's default value

### DIFF
--- a/fe/src/main/java/org/apache/doris/analysis/ColumnDef.java
+++ b/fe/src/main/java/org/apache/doris/analysis/ColumnDef.java
@@ -150,8 +150,8 @@ public class ColumnDef {
         }
 
         if (type.getPrimitiveType() == PrimitiveType.HLL) {
-            if (defaultValue != null) {
-                throw new AnalysisException("Hll can not set default value");
+            if (defaultValue.isSet) {
+                throw new AnalysisException("Hll type column can not set default value");
             }
             defaultValue = DefaultValue.HLL_EMPTY_DEFAULT_VALUE;
         }


### PR DESCRIPTION
Fix the bug that user may receive '"Hll can not set default value' error
when creating table with Hll type columns.