### PR TITLE
Fix the error unit of create timestamp in mini load

### DIFF
--- a/be/src/http/action/mini_load.cpp
+++ b/be/src/http/action/mini_load.cpp
@@ -646,7 +646,7 @@ Status MiniLoadAction::_begin_mini_load(StreamLoadContext* ctx) {
     if (ctx->max_filter_ratio != 0.0) {
         request.__set_max_filter_ratio(ctx->max_filter_ratio);
     }
-    request.__set_create_timestamp(GetCurrentTimeMicros());
+    request.__set_create_timestamp(UnixMillis());
     // begin load by master
     const TNetworkAddress& master_addr = _exec_env->master_info()->network_address;
     TMiniLoadBeginResult res;


### PR DESCRIPTION
The unit of old create timestamp is micros while the unit of create timestamp in fe is millisecond.