### PR TITLE
Fix bug when use SELECT * FROM TABLE LIMIT 1

### DIFF
--- a/be/src/exec/olap_scanner.cpp
+++ b/be/src/exec/olap_scanner.cpp
@@ -326,7 +326,7 @@ Status OlapScanner::get_batch(
 
                 // compute pushdown conjuncts filter rate
                 if (_use_pushdown_conjuncts) {
-                    // check this rate after 
+                    // check this rate after
                     if (_num_rows_read > 32768) {
                         int32_t pushdown_return_rate
                             = _num_rows_read * 100 / (_num_rows_read + _num_rows_pushed_cond_filtered);
@@ -447,6 +447,8 @@ void OlapScanner::update_counter() {
     COUNTER_UPDATE(_parent->_block_convert_timer, _reader->stats().block_convert_ns);
 
     COUNTER_UPDATE(_parent->_raw_rows_counter, _reader->stats().raw_rows_read);
+    // if raw_rows_read is reset, scanNode will scan all table rows which may cause BE crash
+    _raw_rows_read += _reader->mutable_stats()->raw_rows_read;
     // COUNTER_UPDATE(_parent->_filtered_rows_counter, _reader->stats().num_rows_filtered);
 
     COUNTER_UPDATE(_parent->_vec_cond_timer, _reader->stats().vec_cond_ns);
@@ -467,6 +469,7 @@ void OlapScanner::_update_realtime_counter() {
     COUNTER_UPDATE(_parent->_read_compressed_counter, _reader->stats().compressed_bytes_read);
     COUNTER_UPDATE(_parent->_raw_rows_counter, _reader->stats().raw_rows_read);
     _reader->mutable_stats()->compressed_bytes_read = 0;
+    _raw_rows_read += _reader->mutable_stats()->raw_rows_read;
     _reader->mutable_stats()->raw_rows_read = 0;
 }
 

--- a/be/src/exec/olap_scanner.h
+++ b/be/src/exec/olap_scanner.h
@@ -77,7 +77,7 @@ public:
     bool is_open() const { return _is_open; }
     void set_opened() { _is_open = true; }
 
-    int64_t raw_rows_read() const { return _reader->stats().raw_rows_read; }
+    int64_t raw_rows_read() const { return _raw_rows_read; }
 
     void update_counter();
 private:
@@ -135,6 +135,7 @@ private:
 
     RuntimeProfile::Counter* _rows_read_counter = nullptr;
     int64_t _num_rows_read = 0;
+    int64_t _raw_rows_read = 0;
 
     RuntimeProfile::Counter* _rows_pushed_cond_filtered_counter = nullptr;
     // number rows filtered by pushed condition


### PR DESCRIPTION
When I use SQL Statement SELECT * FROM TABLE LIMIT 1 in a table with large datas, the query statement will cause BE crash.The profile shows that the query statement actually scan all table rows, that's the reason why my BE crashed.