### PR TITLE
 Support grant GRANT_PRIV on database or table level

### DIFF
--- a/docs/help/Contents/Account Management/help.md
+++ b/docs/help/Contents/Account Management/help.md
@@ -109,6 +109,7 @@ privilege_list 是需要赋予的权限列表，以逗号分隔。当前 Doris �
 
     NODE_PRIV：集群节点操作权限，包括节点上下线等操作，只有 root 用户有该权限，不可赋予其他用户。
     ADMIN_PRIV：除 NODE_PRIV 以外的所有权限。
+    GRANt_PRIV: 操作权限的权限。包括创建删除用户、角色，授权和撤权，设置密码等。
     SELECT_PRIV：对指定的库或表的读取权限
     LOAD_PRIV：对指定的库或表的导入权限
     ALTER_PRIV：对指定的库或表的schema变更权限

--- a/docs/help/Contents/Account Management/help.md
+++ b/docs/help/Contents/Account Management/help.md
@@ -109,7 +109,7 @@ privilege_list 是需要赋予的权限列表，以逗号分隔。当前 Doris �
 
     NODE_PRIV：集群节点操作权限，包括节点上下线等操作，只有 root 用户有该权限，不可赋予其他用户。
     ADMIN_PRIV：除 NODE_PRIV 以外的所有权限。
-    GRANt_PRIV: 操作权限的权限。包括创建删除用户、角色，授权和撤权，设置密码等。
+    GRANT_PRIV: 操作权限的权限。包括创建删除用户、角色，授权和撤权，设置密码等。
     SELECT_PRIV：对指定的库或表的读取权限
     LOAD_PRIV：对指定的库或表的导入权限
     ALTER_PRIV：对指定的库或表的schema变更权限

--- a/fe/src/main/java/org/apache/doris/analysis/CreateRoleStmt.java
+++ b/fe/src/main/java/org/apache/doris/analysis/CreateRoleStmt.java
@@ -17,9 +17,15 @@
 
 package org.apache.doris.analysis;
 
+import org.apache.doris.catalog.Catalog;
 import org.apache.doris.cluster.ClusterNamespace;
+import org.apache.doris.common.ErrorCode;
+import org.apache.doris.common.ErrorReport;
 import org.apache.doris.common.FeNameFormat;
 import org.apache.doris.common.UserException;
+import org.apache.doris.mysql.privilege.PaloAuth.PrivLevel;
+import org.apache.doris.mysql.privilege.PrivPredicate;
+import org.apache.doris.qe.ConnectContext;
 
 public class CreateRoleStmt extends DdlStmt {
 
@@ -38,6 +44,11 @@ public class CreateRoleStmt extends DdlStmt {
         super.analyze(analyzer);
         FeNameFormat.checkRoleName(role, false /* can not be admin */, "Can not create role");
         role = ClusterNamespace.getFullName(analyzer.getClusterName(), role);
+
+        // check if current user has GRANT priv on GLOBAL or DATABASE level.
+        if (!Catalog.getCurrentCatalog().getAuth().checkHasPriv(ConnectContext.get(), PrivPredicate.GRANT, PrivLevel.GLOBAL, PrivLevel.DATABASE)) {
+            ErrorReport.reportAnalysisException(ErrorCode.ERR_SPECIFIC_ACCESS_DENIED_ERROR, "CREATE USER");
+        }
     }
 
     @Override

--- a/fe/src/main/java/org/apache/doris/analysis/CreateRoleStmt.java
+++ b/fe/src/main/java/org/apache/doris/analysis/CreateRoleStmt.java
@@ -23,7 +23,6 @@ import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.ErrorReport;
 import org.apache.doris.common.FeNameFormat;
 import org.apache.doris.common.UserException;
-import org.apache.doris.mysql.privilege.PaloAuth.PrivLevel;
 import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.qe.ConnectContext;
 
@@ -45,8 +44,8 @@ public class CreateRoleStmt extends DdlStmt {
         FeNameFormat.checkRoleName(role, false /* can not be admin */, "Can not create role");
         role = ClusterNamespace.getFullName(analyzer.getClusterName(), role);
 
-        // check if current user has GRANT priv on GLOBAL or DATABASE level.
-        if (!Catalog.getCurrentCatalog().getAuth().checkHasPriv(ConnectContext.get(), PrivPredicate.GRANT, PrivLevel.GLOBAL, PrivLevel.DATABASE)) {
+        // check if current user has GRANT priv on GLOBAL level.
+        if (!Catalog.getCurrentCatalog().getAuth().checkGlobalPriv(ConnectContext.get(), PrivPredicate.GRANT)) {
             ErrorReport.reportAnalysisException(ErrorCode.ERR_SPECIFIC_ACCESS_DENIED_ERROR, "CREATE USER");
         }
     }

--- a/fe/src/main/java/org/apache/doris/analysis/CreateUserStmt.java
+++ b/fe/src/main/java/org/apache/doris/analysis/CreateUserStmt.java
@@ -131,7 +131,7 @@ public class CreateUserStmt extends DdlStmt {
 
         // check if current user has GRANT priv on GLOBAL or DATABASE level.
         if (!Catalog.getCurrentCatalog().getAuth().checkHasPriv(ConnectContext.get(), PrivPredicate.GRANT, PrivLevel.GLOBAL, PrivLevel.DATABASE)) {
-            ErrorReport.reportAnalysisException(ErrorCode.ERR_SPECIFIC_ACCESS_DENIED_ERROR, "CREATE USER");
+            ErrorReport.reportAnalysisException(ErrorCode.ERR_SPECIFIC_ACCESS_DENIED_ERROR, "GRANT");
         }
     }
 

--- a/fe/src/main/java/org/apache/doris/analysis/CreateUserStmt.java
+++ b/fe/src/main/java/org/apache/doris/analysis/CreateUserStmt.java
@@ -25,6 +25,7 @@ import org.apache.doris.common.ErrorReport;
 import org.apache.doris.common.FeNameFormat;
 import org.apache.doris.common.UserException;
 import org.apache.doris.mysql.MysqlPassword;
+import org.apache.doris.mysql.privilege.PaloAuth.PrivLevel;
 import org.apache.doris.mysql.privilege.PaloRole;
 import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.qe.ConnectContext;
@@ -129,7 +130,8 @@ public class CreateUserStmt extends DdlStmt {
             role = ClusterNamespace.getFullName(analyzer.getClusterName(), role);
         }
 
-        if (!Catalog.getCurrentCatalog().getAuth().checkGlobalPriv(ConnectContext.get(), PrivPredicate.GRANT)) {
+        // check if current user has GRANT priv on GLOBAL or DATABASE level.
+        if (!Catalog.getCurrentCatalog().getAuth().checkHasPriv(ConnectContext.get(), PrivPredicate.GRANT, PrivLevel.GLOBAL, PrivLevel.DATABASE)) {
             ErrorReport.reportAnalysisException(ErrorCode.ERR_SPECIFIC_ACCESS_DENIED_ERROR, "CREATE USER");
         }
     }

--- a/fe/src/main/java/org/apache/doris/analysis/CreateUserStmt.java
+++ b/fe/src/main/java/org/apache/doris/analysis/CreateUserStmt.java
@@ -19,7 +19,6 @@ package org.apache.doris.analysis;
 
 import org.apache.doris.catalog.Catalog;
 import org.apache.doris.cluster.ClusterNamespace;
-import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.ErrorReport;
 import org.apache.doris.common.FeNameFormat;
@@ -106,7 +105,7 @@ public class CreateUserStmt extends DdlStmt {
     }
 
     @Override
-    public void analyze(Analyzer analyzer) throws AnalysisException, UserException {
+    public void analyze(Analyzer analyzer) throws UserException {
         super.analyze(analyzer);
         userIdent.analyze(analyzer.getClusterName());
         // convert plain password to hashed password

--- a/fe/src/main/java/org/apache/doris/analysis/DropRoleStmt.java
+++ b/fe/src/main/java/org/apache/doris/analysis/DropRoleStmt.java
@@ -17,9 +17,14 @@
 
 package org.apache.doris.analysis;
 
+import org.apache.doris.catalog.Catalog;
 import org.apache.doris.cluster.ClusterNamespace;
+import org.apache.doris.common.ErrorCode;
+import org.apache.doris.common.ErrorReport;
 import org.apache.doris.common.FeNameFormat;
 import org.apache.doris.common.UserException;
+import org.apache.doris.mysql.privilege.PrivPredicate;
+import org.apache.doris.qe.ConnectContext;
 
 public class DropRoleStmt extends DdlStmt {
 
@@ -38,6 +43,11 @@ public class DropRoleStmt extends DdlStmt {
         super.analyze(analyzer);
         FeNameFormat.checkRoleName(role, false /* can not be superuser */, "Can not drop role");
         role = ClusterNamespace.getFullName(analyzer.getClusterName(), role);
+
+        // check if current user has GRANT priv on GLOBAL level.
+        if (!Catalog.getCurrentCatalog().getAuth().checkGlobalPriv(ConnectContext.get(), PrivPredicate.GRANT)) {
+            ErrorReport.reportAnalysisException(ErrorCode.ERR_SPECIFIC_ACCESS_DENIED_ERROR, "CREATE USER");
+        }
     }
 
     @Override

--- a/fe/src/main/java/org/apache/doris/analysis/DropUserStmt.java
+++ b/fe/src/main/java/org/apache/doris/analysis/DropUserStmt.java
@@ -46,10 +46,9 @@ public class DropUserStmt extends DdlStmt {
             throw new AnalysisException("Can not drop user with specified host: " + userIdent.getHost());
         }
 
-        // check authenticate
+        // only user with GLOBAL level's GRANT_PRIV can drop user.
         if (!Catalog.getCurrentCatalog().getAuth().checkGlobalPriv(ConnectContext.get(), PrivPredicate.GRANT)) {
-            ErrorReport.reportAnalysisException(ErrorCode.ERR_SPECIFIC_ACCESS_DENIED_ERROR,
-                                                "DROP USER");
+            ErrorReport.reportAnalysisException(ErrorCode.ERR_SPECIFIC_ACCESS_DENIED_ERROR, "DROP USER");
         }
     }
 

--- a/fe/src/main/java/org/apache/doris/analysis/GrantStmt.java
+++ b/fe/src/main/java/org/apache/doris/analysis/GrantStmt.java
@@ -101,11 +101,6 @@ public class GrantStmt extends DdlStmt {
         if (tblPattern.getPrivLevel() != PrivLevel.GLOBAL && privileges.contains(PaloPrivilege.ADMIN_PRIV)) {
             throw new AnalysisException("ADMIN_PRIV privilege can only be granted on *.*");
         }
-        
-        // GRANT_PRIV can only be granted on GLOBAL level and DATABASE level
-        if (!(tblPattern.getPrivLevel() == PrivLevel.GLOBAL || tblPattern.getPrivLevel() == PrivLevel.DATABASE) && privileges.contains(PaloPrivilege.GRANT_PRIV)) {
-            throw new AnalysisException("GRANT_PRIV privilege can only be granted on *.* or db.*");
-        }
 
         if (role != null) {
             // 1. can not grant to admin or operator role
@@ -123,17 +118,16 @@ public class GrantStmt extends DdlStmt {
                 if (!Catalog.getCurrentCatalog().getAuth().checkGlobalPriv(ConnectContext.get(), PrivPredicate.GRANT)) {
                     ErrorReport.reportAnalysisException(ErrorCode.ERR_SPECIFIC_ACCESS_DENIED_ERROR, "GRANT");
                 }
-            } else {
+            } else if (tblPattern.getPrivLevel() == PrivLevel.DATABASE){
                 if (!Catalog.getCurrentCatalog().getAuth().checkDbPriv(ConnectContext.get(), tblPattern.getQuolifiedDb(), PrivPredicate.GRANT)) {
                     ErrorReport.reportAnalysisException(ErrorCode.ERR_SPECIFIC_ACCESS_DENIED_ERROR, "GRANT");
                 }
+            } else {
+                // table level
+                if (!Catalog.getCurrentCatalog().getAuth().checkTblPriv(ConnectContext.get(), tblPattern.getQuolifiedDb(), tblPattern.getTbl(), PrivPredicate.GRANT)) {
+                    ErrorReport.reportAnalysisException(ErrorCode.ERR_SPECIFIC_ACCESS_DENIED_ERROR, "GRANT");
+                }
             }
-        }
-
-
-        if (!Catalog.getCurrentCatalog().getAuth().checkGlobalPriv(ConnectContext.get(), PrivPredicate.GRANT)) {
-            ErrorReport.reportAnalysisException(ErrorCode.ERR_SPECIFIC_ACCESS_DENIED_ERROR,
-                                                "GRANT");
         }
     }
 

--- a/fe/src/main/java/org/apache/doris/analysis/GrantStmt.java
+++ b/fe/src/main/java/org/apache/doris/analysis/GrantStmt.java
@@ -81,7 +81,8 @@ public class GrantStmt extends DdlStmt {
         if (userIdent != null) {
             userIdent.analyze(analyzer.getClusterName());
         } else {
-            FeNameFormat.checkUserName(role);
+            FeNameFormat.checkRoleName(role, false /* can not be admin */, "Can not grant to role");
+            role = ClusterNamespace.getFullName(analyzer.getClusterName(), role);
         }
 
         tblPattern.analyze(analyzer.getClusterName());
@@ -116,8 +117,6 @@ public class GrantStmt extends DdlStmt {
 
         if (role != null) {
             // Rule 3 and 4
-            FeNameFormat.checkRoleName(role, false /* can not be admin */, "Can not grant to role");
-            role = ClusterNamespace.getFullName(analyzer.getClusterName(), role);
             if (!Catalog.getCurrentCatalog().getAuth().checkGlobalPriv(ConnectContext.get(), PrivPredicate.GRANT)) {
                 ErrorReport.reportAnalysisException(ErrorCode.ERR_SPECIFIC_ACCESS_DENIED_ERROR, "GRANT");
             }

--- a/fe/src/main/java/org/apache/doris/mysql/privilege/DbPrivEntry.java
+++ b/fe/src/main/java/org/apache/doris/mysql/privilege/DbPrivEntry.java
@@ -56,7 +56,7 @@ public class DbPrivEntry extends PrivEntry {
         
         PatternMatcher userPattern = PatternMatcher.createMysqlPattern(user, CaseSensibility.USER.getCaseSensibility());
 
-        if (privs.containsNodeOrGrantPriv()) {
+        if (privs.containsNodePriv()) {
             throw new AnalysisException("Db privilege can not contains global privileges: " + privs);
         }
 

--- a/fe/src/main/java/org/apache/doris/mysql/privilege/DbPrivTable.java
+++ b/fe/src/main/java/org/apache/doris/mysql/privilege/DbPrivTable.java
@@ -32,6 +32,11 @@ import java.io.IOException;
 public class DbPrivTable extends PrivTable {
     private static final Logger LOG = LogManager.getLogger(DbPrivTable.class);
 
+    /*
+     * Return all privs which match the user@host on db.*
+     * All returned privs will be saved in 'savedPrivs'.
+     * If the given db is null, it will not check if database is match 
+     */
     public void getPrivs(String host, String db, String user, PrivBitSet savedPrivs) {
         DbPrivEntry matchedEntry = null;
         for (PrivEntry entry : entries) {
@@ -43,7 +48,7 @@ public class DbPrivTable extends PrivTable {
             }
 
             // check db
-            if (!dbPrivEntry.isAnyDb() && !dbPrivEntry.getDbPattern().match(db)) {
+            if (db != null && !dbPrivEntry.isAnyDb() && !dbPrivEntry.getDbPattern().match(db)) {
                 continue;
             }
 

--- a/fe/src/main/java/org/apache/doris/mysql/privilege/PaloAuth.java
+++ b/fe/src/main/java/org/apache/doris/mysql/privilege/PaloAuth.java
@@ -351,7 +351,6 @@ public class PaloAuth implements Writable {
     }
 
     private boolean checkHasPrivInternal(String host, String user, PrivPredicate priv, PrivLevel... levels) {
-        PrivBitSet savedPrivs = PrivBitSet.of();
         for (PrivLevel privLevel : levels) {
             switch (privLevel) {
             case GLOBAL:
@@ -372,7 +371,7 @@ public class PaloAuth implements Writable {
                 break;
             }
         }
-        return savedPrivs.satisfy(priv);
+        return false;
     }
 
     private boolean checkGlobalInternal(String host, String user, PrivPredicate wanted, PrivBitSet savedPrivs) {

--- a/fe/src/main/java/org/apache/doris/mysql/privilege/PaloAuth.java
+++ b/fe/src/main/java/org/apache/doris/mysql/privilege/PaloAuth.java
@@ -355,13 +355,18 @@ public class PaloAuth implements Writable {
         for (PrivLevel privLevel : levels) {
             switch (privLevel) {
             case GLOBAL:
-                userPrivTable.getPrivs(host, user, savedPrivs);
-                break;
+                if (userPrivTable.hasPriv(host, user, priv)) {
+                    return true;
+                }
             case DATABASE:
-                dbPrivTable.getPrivs(host, null, user, savedPrivs);
+                if (dbPrivTable.hasPriv(host, user, priv)) {
+                    return true;
+                }
                 break;
             case TABLE:
-                tablePrivTable.getPrivs(host, null, user, null, savedPrivs);
+                if (tablePrivTable.hasPriv(host, user, priv)) {
+                    return true;
+                }
                 break;
             default:
                 break;

--- a/fe/src/main/java/org/apache/doris/mysql/privilege/PaloAuth.java
+++ b/fe/src/main/java/org/apache/doris/mysql/privilege/PaloAuth.java
@@ -306,8 +306,8 @@ public class PaloAuth implements Writable {
         if (!Config.enable_auth_check) {
             return true;
         }
-        if (wanted.getPrivs().containsNodeOrGrantPriv()) {
-            LOG.debug("should be check NODE or GRANT priv in Db level. host: {}, user: {}, db: {}",
+        if (wanted.getPrivs().containsNodePriv()) {
+            LOG.debug("should check NODE priv in GLOBAL level. host: {}, user: {}, db: {}",
                       host, user, db);
             return false;
         }

--- a/fe/src/main/java/org/apache/doris/mysql/privilege/PaloPrivilege.java
+++ b/fe/src/main/java/org/apache/doris/mysql/privilege/PaloPrivilege.java
@@ -20,13 +20,12 @@ package org.apache.doris.mysql.privilege;
 public enum PaloPrivilege {
     NODE_PRIV("Node_priv", 0, "Privilege for cluster node operations"),
     ADMIN_PRIV("Admin_priv", 1, "Privilege for admin user"),
-    GRANT_PRIV("Grant_priv", 2, "Privilege for granting privlege"),
+    GRANT_PRIV("Grant_priv", 2, "Privilege for granting privilege"),
     SELECT_PRIV("Select_priv", 3, "Privilege for select data in tables"),
     LOAD_PRIV("Load_priv", 4, "Privilege for loading data into tables"),
     ALTER_PRIV("Alter_priv", 5, "Privilege for alter database or table"),
     CREATE_PRIV("Create_priv", 6, "Privilege for createing database or table"),
     DROP_PRIV("Drop_priv", 7, "Privilege for dropping database or table");
-
 
     public static PaloPrivilege[] privileges = {
             NODE_PRIV,

--- a/fe/src/main/java/org/apache/doris/mysql/privilege/PrivBitSet.java
+++ b/fe/src/main/java/org/apache/doris/mysql/privilege/PrivBitSet.java
@@ -83,11 +83,6 @@ public class PrivBitSet implements Writable {
         } else {
             return (set & wantPrivs.getPrivs().set) != 0;
         }
-
-    }
-    
-    public boolean containsNodeOrGrantPriv() {
-        return containsPrivs(PaloPrivilege.NODE_PRIV, PaloPrivilege.GRANT_PRIV);
     }
 
     public boolean containsNodePriv() {

--- a/fe/src/main/java/org/apache/doris/mysql/privilege/PrivBitSet.java
+++ b/fe/src/main/java/org/apache/doris/mysql/privilege/PrivBitSet.java
@@ -90,6 +90,10 @@ public class PrivBitSet implements Writable {
         return containsPrivs(PaloPrivilege.NODE_PRIV, PaloPrivilege.GRANT_PRIV);
     }
 
+    public boolean containsNodePriv() {
+        return containsPrivs(PaloPrivilege.NODE_PRIV);
+    }
+
     public boolean containsPrivs(PaloPrivilege... privs) {
         for (PaloPrivilege priv : privs) {
             if (get(priv.getIdx())) {

--- a/fe/src/main/java/org/apache/doris/mysql/privilege/TablePrivEntry.java
+++ b/fe/src/main/java/org/apache/doris/mysql/privilege/TablePrivEntry.java
@@ -56,7 +56,7 @@ public class TablePrivEntry extends DbPrivEntry {
         PatternMatcher tblPattern = PatternMatcher.createMysqlPattern(tbl.equals(ANY_TBL) ? "%" : tbl,
                                                                       CaseSensibility.TABLE.getCaseSensibility());
 
-        if (privs.containsNodeOrGrantPriv()) {
+        if (privs.containsNodePriv()) {
             throw new AnalysisException("Table privilege can not contains global privileges: " + privs);
         }
 

--- a/fe/src/main/java/org/apache/doris/mysql/privilege/TablePrivTable.java
+++ b/fe/src/main/java/org/apache/doris/mysql/privilege/TablePrivTable.java
@@ -30,6 +30,11 @@ import java.io.IOException;
  */
 public class TablePrivTable extends PrivTable {
 
+    /*
+     * Return all privs which match the user@host on db.tbl
+     * All returned privs will be saved in 'savedPrivs'.
+     * If the given db or table is null, it will not check if database or table is match 
+     */
     public void getPrivs(String host, String db, String user, String tbl, PrivBitSet savedPrivs) {
         TablePrivEntry matchedEntry = null;
         for (PrivEntry entry : entries) {
@@ -42,7 +47,7 @@ public class TablePrivTable extends PrivTable {
 
             // check db
             Preconditions.checkState(!tblPrivEntry.isAnyDb());
-            if (!tblPrivEntry.getDbPattern().match(db)) {
+            if (db != null && !tblPrivEntry.getDbPattern().match(db)) {
                 continue;
             }
 
@@ -52,7 +57,7 @@ public class TablePrivTable extends PrivTable {
             }
 
             // check table
-            if (!tblPrivEntry.getTblPattern().match(tbl)) {
+            if (tbl != null && !tblPrivEntry.getTblPattern().match(tbl)) {
                 continue;
             }
 

--- a/fe/src/main/java/org/apache/doris/mysql/privilege/TablePrivTable.java
+++ b/fe/src/main/java/org/apache/doris/mysql/privilege/TablePrivTable.java
@@ -31,9 +31,8 @@ import java.io.IOException;
 public class TablePrivTable extends PrivTable {
 
     /*
-     * Return all privs which match the user@host on db.tbl
-     * All returned privs will be saved in 'savedPrivs'.
-     * If the given db or table is null, it will not check if database or table is match 
+     * Return first priv which match the user@host on db.tbl The returned priv will
+     * be saved in 'savedPrivs'.
      */
     public void getPrivs(String host, String db, String user, String tbl, PrivBitSet savedPrivs) {
         TablePrivEntry matchedEntry = null;
@@ -47,7 +46,7 @@ public class TablePrivTable extends PrivTable {
 
             // check db
             Preconditions.checkState(!tblPrivEntry.isAnyDb());
-            if (db != null && !tblPrivEntry.getDbPattern().match(db)) {
+            if (!tblPrivEntry.getDbPattern().match(db)) {
                 continue;
             }
 
@@ -57,7 +56,7 @@ public class TablePrivTable extends PrivTable {
             }
 
             // check table
-            if (tbl != null && !tblPrivEntry.getTblPattern().match(tbl)) {
+            if (!tblPrivEntry.getTblPattern().match(tbl)) {
                 continue;
             }
 
@@ -69,6 +68,28 @@ public class TablePrivTable extends PrivTable {
         }
 
         savedPrivs.or(matchedEntry.getPrivSet());
+    }
+
+    /*
+     * Check if user@host has specified privilege on any table
+     */
+    public boolean hasPriv(String host, String user, PrivPredicate wanted) {
+        for (PrivEntry entry : entries) {
+            TablePrivEntry tblPrivEntry = (TablePrivEntry) entry;
+            // check host
+            if (!tblPrivEntry.isAnyHost() && !tblPrivEntry.getHostPattern().match(host)) {
+                continue;
+            }
+            // check user
+            if (!tblPrivEntry.isAnyUser() && !tblPrivEntry.getUserPattern().match(user)) {
+                continue;
+            }
+            // check priv
+            if (tblPrivEntry.privSet.satisfy(wanted)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     public boolean hasPrivsOfDb(String host, String db, String user) {

--- a/fe/src/main/java/org/apache/doris/mysql/privilege/UserPrivTable.java
+++ b/fe/src/main/java/org/apache/doris/mysql/privilege/UserPrivTable.java
@@ -63,6 +63,27 @@ public class UserPrivTable extends PrivTable {
         savedPrivs.or(matchedEntry.getPrivSet());
     }
 
+    /*
+     * Check if user@host has specified privilege
+     */
+    public boolean hasPriv(String host, String user, PrivPredicate wanted) {
+        for (PrivEntry entry : entries) {
+            GlobalPrivEntry globalPrivEntry = (GlobalPrivEntry) entry;
+            // check host
+            if (!globalPrivEntry.isAnyHost() && !globalPrivEntry.getHostPattern().match(host)) {
+                continue;
+            }
+            // check user
+            if (!globalPrivEntry.isAnyUser() && !globalPrivEntry.getUserPattern().match(user)) {
+                continue;
+            }
+            if (globalPrivEntry.getPrivSet().satisfy(wanted)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     // validate the connection by host, user and password.
     // return true if this connection is valid, and 'savedPrivs' save all global privs got from user table.
     // if currentUser is not null, save the current user identity

--- a/fe/src/test/java/org/apache/doris/mysql/privilege/AuthTest.java
+++ b/fe/src/test/java/org/apache/doris/mysql/privilege/AuthTest.java
@@ -146,16 +146,16 @@ public class AuthTest {
         // 1. create cmy@%
         UserIdentity userIdentity = new UserIdentity("cmy", "%");
         UserDesc userDesc = new UserDesc(userIdentity, "12345", true);
-        CreateUserStmt userStmt = new CreateUserStmt(false, userDesc, null);
+        CreateUserStmt createUserStmt = new CreateUserStmt(false, userDesc, null);
         try {
-            userStmt.analyze(analyzer);
+            createUserStmt.analyze(analyzer);
         } catch (UserException e) {
             e.printStackTrace();
             Assert.fail();
         }
 
         try {
-            auth.createUser(userStmt);
+            auth.createUser(createUserStmt);
         } catch (DdlException e) {
             Assert.fail();
         }
@@ -169,16 +169,16 @@ public class AuthTest {
         // 3. create another user: zhangsan@"192.%"
         userIdentity = new UserIdentity("zhangsan", "192.%");
         userDesc = new UserDesc(userIdentity, "12345", true);
-        userStmt = new CreateUserStmt(false, userDesc, null);
+        createUserStmt = new CreateUserStmt(false, userDesc, null);
         try {
-            userStmt.analyze(analyzer);
+            createUserStmt.analyze(analyzer);
         } catch (UserException e) {
             e.printStackTrace();
             Assert.fail();
         }
 
         try {
-            auth.createUser(userStmt);
+            auth.createUser(createUserStmt);
         } catch (DdlException e) {
             Assert.fail();
         }
@@ -193,9 +193,9 @@ public class AuthTest {
         // 4.1 check if we can create same user
         userIdentity = new UserIdentity("zhangsan", "192.%");
         userDesc = new UserDesc(userIdentity, "12345", true);
-        userStmt = new CreateUserStmt(false, userDesc, null);
+        createUserStmt = new CreateUserStmt(false, userDesc, null);
         try {
-            userStmt.analyze(analyzer);
+            createUserStmt.analyze(analyzer);
         } catch (UserException e) {
             e.printStackTrace();
             Assert.fail();
@@ -203,7 +203,7 @@ public class AuthTest {
 
         boolean hasException = false;
         try {
-            auth.createUser(userStmt);
+            auth.createUser(createUserStmt);
         } catch (DdlException e) {
             e.printStackTrace();
             hasException = true;
@@ -213,16 +213,16 @@ public class AuthTest {
         // 4.2 check if we can create same user name with different host
         userIdentity = new UserIdentity("zhangsan", "172.18.1.1");
         userDesc = new UserDesc(userIdentity, "12345", true);
-        userStmt = new CreateUserStmt(false, userDesc, null);
+        createUserStmt = new CreateUserStmt(false, userDesc, null);
         try {
-            userStmt.analyze(analyzer);
+            createUserStmt.analyze(analyzer);
         } catch (UserException e) {
             e.printStackTrace();
             Assert.fail();
         }
 
         try {
-            auth.createUser(userStmt);
+            auth.createUser(createUserStmt);
         } catch (DdlException e) {
             Assert.fail();
         }
@@ -232,15 +232,15 @@ public class AuthTest {
         // 5. create a user with domain [palo.domain]
         userIdentity = new UserIdentity("zhangsan", "palo.domain1", true);
         userDesc = new UserDesc(userIdentity, "12345", true);
-        userStmt = new CreateUserStmt(false, userDesc, null);
+        createUserStmt = new CreateUserStmt(false, userDesc, null);
         try {
-            userStmt.analyze(analyzer);
+            createUserStmt.analyze(analyzer);
         } catch (UserException e) {
             e.printStackTrace();
             Assert.fail();
         }
         try {
-            auth.createUser(userStmt);
+            auth.createUser(createUserStmt);
         } catch (DdlException e) {
             Assert.fail();
         }
@@ -259,9 +259,9 @@ public class AuthTest {
         // 7. add duplicated user@['palo.domain1']
         userIdentity = new UserIdentity("zhangsan", "palo.domain1", true);
         userDesc = new UserDesc(userIdentity, "12345", true);
-        userStmt = new CreateUserStmt(false, userDesc, null);
+        createUserStmt = new CreateUserStmt(false, userDesc, null);
         try {
-            userStmt.analyze(analyzer);
+            createUserStmt.analyze(analyzer);
         } catch (UserException e) {
             e.printStackTrace();
             Assert.fail();
@@ -269,7 +269,7 @@ public class AuthTest {
 
         hasException = false;
         try {
-            auth.createUser(userStmt);
+            auth.createUser(createUserStmt);
         } catch (DdlException e) {
             e.printStackTrace();
             hasException = true;
@@ -279,16 +279,16 @@ public class AuthTest {
         // 8. add another user@['palo.domain2']
         userIdentity = new UserIdentity("lisi", "palo.domain2", true);
         userDesc = new UserDesc(userIdentity, "123456", true);
-        userStmt = new CreateUserStmt(false, userDesc, null);
+        createUserStmt = new CreateUserStmt(false, userDesc, null);
         try {
-            userStmt.analyze(analyzer);
+            createUserStmt.analyze(analyzer);
         } catch (UserException e) {
             e.printStackTrace();
             Assert.fail();
         }
 
         try {
-            auth.createUser(userStmt);
+            auth.createUser(createUserStmt);
         } catch (DdlException e) {
             e.printStackTrace();
             Assert.fail();
@@ -757,7 +757,7 @@ public class AuthTest {
         Assert.assertTrue(hasException);
 
         // 24. create role
-        roleStmt = new CreateRoleStmt("rolo1");
+        roleStmt = new CreateRoleStmt("role1");
         try {
             roleStmt.analyze(analyzer);
         } catch (UserException e1) {
@@ -808,9 +808,9 @@ public class AuthTest {
         // 27. create user and set it as role1
         userIdentity = new UserIdentity("wangwu", "%");
         userDesc = new UserDesc(userIdentity, "12345", true);
-        userStmt = new CreateUserStmt(false, userDesc, "role1");
+        createUserStmt = new CreateUserStmt(false, userDesc, "role1");
         try {
-            userStmt.analyze(analyzer);
+            createUserStmt.analyze(analyzer);
         } catch (UserException e) {
             e.printStackTrace();
             Assert.fail();
@@ -820,8 +820,9 @@ public class AuthTest {
                                             SystemInfoService.DEFAULT_CLUSTER + ":wangwu",
                                             PrivPredicate.DROP));
         try {
-            auth.createUser(userStmt);
+            auth.createUser(createUserStmt);
         } catch (DdlException e) {
+            e.printStackTrace();
             Assert.fail();
         }
         Assert.assertTrue(auth.checkDbPriv("10.17.2.1", SystemInfoService.DEFAULT_CLUSTER + ":db4",
@@ -831,16 +832,16 @@ public class AuthTest {
         // 28. create user@domain and set it as role1
         userIdentity = new UserIdentity("chenliu", "palo.domain2", true);
         userDesc = new UserDesc(userIdentity, "12345", true);
-        userStmt = new CreateUserStmt(false, userDesc, "role1");
+        createUserStmt = new CreateUserStmt(false, userDesc, "role1");
         try {
-            userStmt.analyze(analyzer);
+            createUserStmt.analyze(analyzer);
         } catch (UserException e) {
             e.printStackTrace();
             Assert.fail();
         }
 
         try {
-            auth.createUser(userStmt);
+            auth.createUser(createUserStmt);
         } catch (DdlException e) {
             e.printStackTrace();
             Assert.fail();

--- a/fe/src/test/java/org/apache/doris/mysql/privilege/MockedAuth.java
+++ b/fe/src/test/java/org/apache/doris/mysql/privilege/MockedAuth.java
@@ -36,6 +36,8 @@ public class MockedAuth {
 
                 auth.checkTblPriv((ConnectContext) any, anyString, anyString, (PrivPredicate) any);
                 result = true;
+
+                // auth.checkHasPriv((ConnectContext) any,, priv, levels)
             }
         };
     }

--- a/fe/src/test/java/org/apache/doris/mysql/privilege/PrivTest.java
+++ b/fe/src/test/java/org/apache/doris/mysql/privilege/PrivTest.java
@@ -448,7 +448,16 @@ public class PrivTest {
         }
         Assert.assertTrue(hasException);
         
-        // 3. use cmy3 to grant CREATE priv on db1.* and db1.tbl1 to cmy5 (cmy5 does not exist, but we just test GrantStmt in analyze phase, so it is ok)
+        // 4. use cmy2 to create cmy4
+        createUserStmt = new CreateUserStmt(new UserDesc(new UserIdentity("cmy4", "%"), "123", true));
+        try {
+            createUserStmt.analyze(analyzer);
+            auth.createUser(createUserStmt);
+        } catch (Exception e) {
+            Assert.fail(e.getMessage());
+        }
+
+        // 5. use cmy3 to grant CREATE priv on db1.* and db1.tbl1 to cmy5 (cmy5 does not exist, but we just test GrantStmt in analyze phase, so it is ok)
         ctx = new ConnectContext(null);
         ctx.setRemoteIP("192.168.1.1");
         ctx.setQualifiedUser("default_cluster:cmy3");


### PR DESCRIPTION
Currently, GRANT_PRIV can only be granted on global level, which means
it can only be granted on `*.*`. Grant it on `db.*` or `db.tbl` are not allowed.

This will not be able to meet the requirement to create a user who has privilege
to grant privileges to other users on specified database or table, such as:

`GRANT SELECT_PRIV ON db1.* TO cmy@'%';`

So I extend the range of GRANT_PRIV. User can now grant GRANT_PRIV on
database or even table level, such as:

`GRANT GRANT_PRIV ON db1.* TO cmy@'%';`

And after being granted, the user `cmy@'%'` can now grant GRANT_PRIV on `db1.*` to
other users.

More details can be seen in `docs/documentation/cn/administrator-guide/privilege.md`

ISSUE: #1473