### PR TITLE
Fix bug when doing linked schema change.

### DIFF
--- a/be/src/olap/column_mapping.h
+++ b/be/src/olap/column_mapping.h
@@ -33,5 +33,7 @@ struct ColumnMapping {
     WrapperField* default_value;
 };
 
+typedef std::vector<ColumnMapping> SchemaMapping;
+
 }  // namespace doris
 #endif // DORIS_BE_SRC_COLUMN_MAPPING_H

--- a/be/src/olap/rowset/alpha_rowset_writer.h
+++ b/be/src/olap/rowset/alpha_rowset_writer.h
@@ -48,6 +48,8 @@ public:
 
     // add rowset by create hard link
     OLAPStatus add_rowset(RowsetSharedPtr rowset) override;
+    OLAPStatus add_rowset_for_linked_schema_change(
+            RowsetSharedPtr rowset, const SchemaMapping& schema_mapping) override;
 
     OLAPStatus flush() override;
 

--- a/be/src/olap/rowset/rowset_writer.h
+++ b/be/src/olap/rowset/rowset_writer.h
@@ -44,6 +44,8 @@ public:
     virtual OLAPStatus add_row_block(RowBlock* row_block) = 0;
 
     virtual OLAPStatus add_rowset(RowsetSharedPtr rowset) = 0;
+    virtual OLAPStatus add_rowset_for_linked_schema_change(
+                RowsetSharedPtr rowset, const SchemaMapping& schema_mapping) = 0;
 
     virtual OLAPStatus flush() = 0;
 

--- a/be/src/olap/rowset/segment_group.cpp
+++ b/be/src/olap/rowset/segment_group.cpp
@@ -242,10 +242,10 @@ OLAPStatus SegmentGroup::add_zone_maps_for_linked_schema_change(
         return OLAP_SUCCESS;
     }
 
-    //1. rollup tablet num_key_columns() will less than base tablet zone_map_fields.size().
-    //   For LinkedSchemaChange, the rollup tablet keys order is the same as base tablet
-    //2. adding column to existed table, num_key_columns() will larger than
-    //   zone_map_fields.size()
+    // 1. rollup tablet num_key_columns() will less than base tablet zone_map_fields.size().
+    //    For LinkedSchemaChange, the rollup tablet keys order is the same as base tablet
+    // 2. adding column to existed table, num_key_columns() will larger than
+    //    zone_map_fields.size()
 
     int num_new_keys = 0;
     for (size_t i = 0; i < _schema->num_key_columns(); ++i) {
@@ -257,7 +257,7 @@ OLAPStatus SegmentGroup::add_zone_maps_for_linked_schema_change(
         WrapperField* second = WrapperField::create(column);
         DCHECK(second != NULL) << "failed to allocate memory for field: " << i;
 
-        //for new key column, use default value to fill into column_statistics
+        // for new key column, use default value to fill into column_statistics
         if (schema_mapping[i].ref_column == -1) {
             num_new_keys++;
 

--- a/be/src/olap/rowset/segment_group.cpp
+++ b/be/src/olap/rowset/segment_group.cpp
@@ -23,15 +23,16 @@
 #include <fstream>
 #include <sstream>
 
+#include "olap/data_dir.h"
+#include "olap/column_mapping.h"
 #include "olap/rowset/column_data.h"
 #include "olap/row_block.h"
 #include "olap/row_cursor.h"
+#include "olap/schema.h"
+#include "olap/storage_engine.h"
 #include "olap/utils.h"
 #include "olap/wrapper_field.h"
-#include "olap/schema.h"
 #include "util/stack_util.h"
-#include "olap/storage_engine.h"
-#include "olap/data_dir.h"
 
 using std::ifstream;
 using std::string;
@@ -234,27 +235,42 @@ bool SegmentGroup::delete_all_files() {
 }
 
 OLAPStatus SegmentGroup::add_zone_maps_for_linked_schema_change(
-        const std::vector<std::pair<WrapperField*, WrapperField*>>& zone_map_fields) {
+        const std::vector<std::pair<WrapperField*, WrapperField*>>& zone_map_fields,
+        const SchemaMapping& schema_mapping) {
     //When add rollup tablet, the base tablet index maybe empty
     if (zone_map_fields.size() == 0) {
         return OLAP_SUCCESS;
     }
 
-    //Should use _num_key_columns, not zone_map_fields.size()
-    //as rollup tablet num_key_columns will less than base tablet zone_map_fields.size().
-    //For LinkedSchemaChange, the rollup tablet keys order is the same as base tablet
+    //1. rollup tablet num_key_columns() will less than base tablet zone_map_fields.size().
+    //   For LinkedSchemaChange, the rollup tablet keys order is the same as base tablet
+    //2. adding column to existed table, num_key_columns() will larger than
+    //   zone_map_fields.size()
+
+    int num_new_keys = 0;
     for (size_t i = 0; i < _schema->num_key_columns(); ++i) {
         const TabletColumn& column = _schema->column(i);
+
         WrapperField* first = WrapperField::create(column);
         DCHECK(first != NULL) << "failed to allocate memory for field: " << i;
-        first->copy(zone_map_fields[i].first);
 
         WrapperField* second = WrapperField::create(column);
         DCHECK(second != NULL) << "failed to allocate memory for field: " << i;
-        second->copy(zone_map_fields[i].second);
+
+        //for new key column, use default value to fill into column_statistics
+        if (schema_mapping[i].ref_column == -1) {
+            num_new_keys++;
+
+            first->copy(schema_mapping[i].default_value);
+            second->copy(schema_mapping[i].default_value);
+        } else {
+            first->copy(zone_map_fields[i - num_new_keys].first);
+            second->copy(zone_map_fields[i - num_new_keys].second);
+        }
 
         _zone_maps.push_back(std::make_pair(first, second));
     }
+
     return OLAP_SUCCESS;
 }
 

--- a/be/src/olap/rowset/segment_group.h
+++ b/be/src/olap/rowset/segment_group.h
@@ -69,7 +69,8 @@ public:
     }
 
     OLAPStatus add_zone_maps_for_linked_schema_change(
-        const std::vector<std::pair<WrapperField*, WrapperField*>>& zone_map_fields);
+        const std::vector<std::pair<WrapperField*, WrapperField*>>& zone_map_fields,
+        const SchemaMapping& schema_mapping);
 
     OLAPStatus add_zone_maps(
         const std::vector<std::pair<WrapperField*, WrapperField*>>& zone_map_fields);

--- a/be/src/olap/schema_change.cpp
+++ b/be/src/olap/schema_change.cpp
@@ -634,7 +634,8 @@ bool LinkedSchemaChange::process(
         RowsetWriterSharedPtr new_rowset_writer,
         TabletSharedPtr new_tablet,
         TabletSharedPtr base_tablet) {
-    OLAPStatus status = new_rowset_writer->add_rowset(rowset_reader->rowset());
+    OLAPStatus status = new_rowset_writer->add_rowset_for_linked_schema_change(
+                            rowset_reader->rowset(), _row_block_changer.get_schema_mapping());
     if (status != OLAP_SUCCESS) {
         LOG(WARNING) << "fail to convert rowset."
                      << ", new_tablet=" << new_tablet->full_name()
@@ -1426,7 +1427,7 @@ OLAPStatus SchemaChangeHandler::schema_version_convert(
         sc_procedure = new(nothrow) SchemaChangeDirectly(rb_changer);
     } else {
         LOG(INFO) << "doing linked schema change.";
-        sc_procedure = new(nothrow) LinkedSchemaChange();
+        sc_procedure = new(nothrow) LinkedSchemaChange(rb_changer);
     }
 
     if (sc_procedure == nullptr) {
@@ -1652,7 +1653,7 @@ OLAPStatus SchemaChangeHandler::_convert_historical_rowsets(const SchemaChangePa
         sc_procedure = new(nothrow) SchemaChangeDirectly(rb_changer);
     } else {
         LOG(INFO) << "doing linked schema change.";
-        sc_procedure = new(nothrow) LinkedSchemaChange();
+        sc_procedure = new(nothrow) LinkedSchemaChange(rb_changer);
     }
 
     if (sc_procedure == nullptr) {

--- a/be/src/olap/schema_change.h
+++ b/be/src/olap/schema_change.h
@@ -42,8 +42,6 @@ class RowCursor;
 
 class RowBlockChanger {
 public:
-    typedef std::vector<ColumnMapping> SchemaMapping;
-
     RowBlockChanger(const TabletSchema& tablet_schema,
                     const TabletSharedPtr& base_tablet,
                     const DeleteHandler& delete_handler);
@@ -177,7 +175,8 @@ private:
 
 class LinkedSchemaChange : public SchemaChange {
 public:
-    explicit LinkedSchemaChange() { }
+    explicit LinkedSchemaChange(const RowBlockChanger& row_block_changer)
+        : _row_block_changer(row_block_changer) { }
     ~LinkedSchemaChange() {}
 
     bool process(RowsetReaderSharedPtr rowset_reader,
@@ -185,6 +184,7 @@ public:
                  TabletSharedPtr new_tablet,
                  TabletSharedPtr base_tablet);
 private:
+    const RowBlockChanger& _row_block_changer;
     DISALLOW_COPY_AND_ASSIGN(LinkedSchemaChange);
 };
 


### PR DESCRIPTION
1. rollup will create table with num_key_columns is less than base table.
2. adding column to existed table, num_key_columns is larger than base table.
When meets two events, we should handle them carefully.