### PR TITLE
Remove query status report from BE when query is cancelled normally

### DIFF
--- a/be/src/runtime/fragment_mgr.cpp
+++ b/be/src/runtime/fragment_mgr.cpp
@@ -80,7 +80,7 @@ public:
 
     Status execute();
 
-    Status cancel(const PCancelPlanFragmentRequest::CancelReason& reason);
+    Status cancel(const PCancelReason& reason);
 
     TUniqueId fragment_instance_id() const {
         return _fragment_instance_id;
@@ -209,10 +209,10 @@ Status FragmentExecState::execute() {
     return Status::OK();
 }
 
-Status FragmentExecState::cancel(const PCancelPlanFragmentRequest::CancelReason& reason) {
+Status FragmentExecState::cancel(const PCancelReason& reason) {
     std::lock_guard<std::mutex> l(_status_lock);
     RETURN_IF_ERROR(_exec_status);
-    if (reason != PCancelPlanFragmentRequest::INTERNAL_ERROR) {
+    if (reason == PCancelReason::LIMIT_REACH) {
         _executor.set_is_report_on_cancel(false);
     }
     _executor.cancel();
@@ -465,7 +465,7 @@ Status FragmentMgr::exec_plan_fragment(
     return Status::OK();
 }
 
-Status FragmentMgr::cancel(const TUniqueId& id, const PCancelPlanFragmentRequest::CancelReason& reason) {
+Status FragmentMgr::cancel(const TUniqueId& id, const PCancelReason& reason) {
     std::shared_ptr<FragmentExecState> exec_state;
     {
         std::lock_guard<std::mutex> lock(_lock);

--- a/be/src/runtime/fragment_mgr.cpp
+++ b/be/src/runtime/fragment_mgr.cpp
@@ -80,7 +80,7 @@ public:
 
     Status execute();
 
-    Status cancel();
+    Status cancel(const PCancelPlanFragmentRequest::CancelReason& reason);
 
     TUniqueId fragment_instance_id() const {
         return _fragment_instance_id;
@@ -209,9 +209,12 @@ Status FragmentExecState::execute() {
     return Status::OK();
 }
 
-Status FragmentExecState::cancel() {
+Status FragmentExecState::cancel(const PCancelPlanFragmentRequest::CancelReason& reason) {
     std::lock_guard<std::mutex> l(_status_lock);
     RETURN_IF_ERROR(_exec_status);
+    if (reason != PCancelPlanFragmentRequest::INTERNAL_ERROR) {
+        _executor.set_is_report_on_cancel(false);
+    }
     _executor.cancel();
     return Status::OK();
 }
@@ -462,7 +465,7 @@ Status FragmentMgr::exec_plan_fragment(
     return Status::OK();
 }
 
-Status FragmentMgr::cancel(const TUniqueId& id) {
+Status FragmentMgr::cancel(const TUniqueId& id, const PCancelPlanFragmentRequest::CancelReason& reason) {
     std::shared_ptr<FragmentExecState> exec_state;
     {
         std::lock_guard<std::mutex> lock(_lock);
@@ -473,7 +476,7 @@ Status FragmentMgr::cancel(const TUniqueId& id) {
         }
         exec_state = iter->second;
     }
-    exec_state->cancel();
+    exec_state->cancel(reason);
 
     return Status::OK();
 }

--- a/be/src/runtime/fragment_mgr.cpp
+++ b/be/src/runtime/fragment_mgr.cpp
@@ -80,7 +80,7 @@ public:
 
     Status execute();
 
-    Status cancel(const PCancelReason& reason);
+    Status cancel(const PPlanFragmentCancelReason& reason);
 
     TUniqueId fragment_instance_id() const {
         return _fragment_instance_id;
@@ -209,10 +209,10 @@ Status FragmentExecState::execute() {
     return Status::OK();
 }
 
-Status FragmentExecState::cancel(const PCancelReason& reason) {
+Status FragmentExecState::cancel(const PPlanFragmentCancelReason& reason) {
     std::lock_guard<std::mutex> l(_status_lock);
     RETURN_IF_ERROR(_exec_status);
-    if (reason == PCancelReason::LIMIT_REACH) {
+    if (reason == PPlanFragmentCancelReason::LIMIT_REACH) {
         _executor.set_is_report_on_cancel(false);
     }
     _executor.cancel();
@@ -465,7 +465,7 @@ Status FragmentMgr::exec_plan_fragment(
     return Status::OK();
 }
 
-Status FragmentMgr::cancel(const TUniqueId& id, const PCancelReason& reason) {
+Status FragmentMgr::cancel(const TUniqueId& id, const PPlanFragmentCancelReason& reason) {
     std::shared_ptr<FragmentExecState> exec_state;
     {
         std::lock_guard<std::mutex> lock(_lock);

--- a/be/src/runtime/fragment_mgr.h
+++ b/be/src/runtime/fragment_mgr.h
@@ -55,10 +55,10 @@ public:
     Status exec_plan_fragment(const TExecPlanFragmentParams& params, FinishCallback cb);
 
     Status cancel(const TUniqueId& fragment_id) {
-        return cancel(fragment_id, PCancelReason::INTERNAL_ERROR);
+        return cancel(fragment_id, PPlanFragmentCancelReason::INTERNAL_ERROR);
     }
 
-    Status cancel(const TUniqueId& fragment_id, const PCancelReason& reason);
+    Status cancel(const TUniqueId& fragment_id, const PPlanFragmentCancelReason& reason);
 
     void cancel_worker();
 

--- a/be/src/runtime/fragment_mgr.h
+++ b/be/src/runtime/fragment_mgr.h
@@ -54,7 +54,11 @@ public:
     // TODO(zc): report this is over
     Status exec_plan_fragment(const TExecPlanFragmentParams& params, FinishCallback cb);
 
-    Status cancel(const TUniqueId& fragment_id);
+    Status cancel(const TUniqueId& fragment_id) {
+        return cancel(fragment_id, PCancelPlanFragmentRequest::INTERNAL_ERROR);
+    }
+
+    Status cancel(const TUniqueId& fragment_id, const PCancelPlanFragmentRequest::CancelReason& reason);
 
     void cancel_worker();
 

--- a/be/src/runtime/fragment_mgr.h
+++ b/be/src/runtime/fragment_mgr.h
@@ -55,10 +55,10 @@ public:
     Status exec_plan_fragment(const TExecPlanFragmentParams& params, FinishCallback cb);
 
     Status cancel(const TUniqueId& fragment_id) {
-        return cancel(fragment_id, PCancelPlanFragmentRequest::INTERNAL_ERROR);
+        return cancel(fragment_id, PCancelReason::INTERNAL_ERROR);
     }
 
-    Status cancel(const TUniqueId& fragment_id, const PCancelPlanFragmentRequest::CancelReason& reason);
+    Status cancel(const TUniqueId& fragment_id, const PCancelReason& reason);
 
     void cancel_worker();
 

--- a/be/src/runtime/plan_fragment_executor.cpp
+++ b/be/src/runtime/plan_fragment_executor.cpp
@@ -55,6 +55,7 @@ PlanFragmentExecutor::PlanFragmentExecutor(
       _closed(false),
       _has_thread_token(false),
       _is_report_success(true),
+      _is_report_on_cancel(true),
       _collect_query_statistics_with_every_batch(false) {
 }
 
@@ -430,6 +431,10 @@ void PlanFragmentExecutor::send_report(bool done) {
     }
 
     if (!_is_report_success && done && status.ok()) {
+        return;
+    }
+
+    if (!_is_report_success && !_is_report_on_cancel) {
         return;
     }
 

--- a/be/src/runtime/plan_fragment_executor.h
+++ b/be/src/runtime/plan_fragment_executor.h
@@ -141,6 +141,10 @@ public:
         _stop_report_thread_cv.notify_one();
     }
 
+    void set_is_report_on_cancel(bool val) {
+        _is_report_on_cancel = val;
+    }
+
 private:
     ExecEnv* _exec_env;  // not owned
     ExecNode* _plan;  // lives in _runtime_state->obj_pool()
@@ -175,6 +179,10 @@ private:
     bool _has_thread_token;
 
     bool _is_report_success;
+
+    // If this is set to false, and '_is_report_success' is false as well,
+    // This executor will not report status to FE on being cancelled.
+    bool _is_report_on_cancel;
 
     // Overall execution status. Either ok() or set to the first error status that
     // was encountered.

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -155,11 +155,12 @@ void PInternalServiceImpl<T>::cancel_plan_fragment(
     tid.__set_hi(request->finst_id().hi());
     tid.__set_lo(request->finst_id().lo());
 
-    LOG(INFO) << "cancel framgent, fragment_instance_id=" << print_id(tid);
     Status st;
     if (request->has_cancel_reason())  {
+        LOG(INFO) << "cancel framgent, fragment_instance_id=" << print_id(tid) << ", reason: " << request->cancel_reason();
         st = _exec_env->fragment_mgr()->cancel(tid, request->cancel_reason());
     } else {
+        LOG(INFO) << "cancel framgent, fragment_instance_id=" << print_id(tid);
         st = _exec_env->fragment_mgr()->cancel(tid);
     }
     if (!st.ok()) {

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -154,8 +154,14 @@ void PInternalServiceImpl<T>::cancel_plan_fragment(
     TUniqueId tid;
     tid.__set_hi(request->finst_id().hi());
     tid.__set_lo(request->finst_id().lo());
+
     LOG(INFO) << "cancel framgent, fragment_instance_id=" << print_id(tid);
-    auto st = _exec_env->fragment_mgr()->cancel(tid);
+    Status st;
+    if (request->has_cancel_reason())  {
+        st = _exec_env->fragment_mgr()->cancel(tid, request->cancel_reason());
+    } else {
+        st = _exec_env->fragment_mgr()->cancel(tid);
+    }
     if (!st.ok()) {
         LOG(WARNING) << "cancel plan fragment failed, errmsg=" << st.get_error_msg();
     }

--- a/fe/src/main/java/org/apache/doris/qe/QeProcessorImpl.java
+++ b/fe/src/main/java/org/apache/doris/qe/QeProcessorImpl.java
@@ -96,7 +96,8 @@ public final class QeProcessorImpl implements QeProcessor {
     @Override
     public TReportExecStatusResult reportExecStatus(TReportExecStatusParams params) {
         LOG.info("ReportExecStatus(): fragment_instance_id=" + DebugUtil.printId(params.fragment_instance_id)
-                + ", query id=" + DebugUtil.printId(params.query_id) + " params=" + params);
+                + ", query id=" + DebugUtil.printId(params.query_id));
+        LOG.debug("params: {}", params);
         final TReportExecStatusResult result = new TReportExecStatusResult();
         final QueryInfo info = coordinatorMap.get(params.query_id);
         if (info == null) {

--- a/fe/src/main/java/org/apache/doris/rpc/BackendServiceProxy.java
+++ b/fe/src/main/java/org/apache/doris/rpc/BackendServiceProxy.java
@@ -20,13 +20,13 @@ package org.apache.doris.rpc;
 import org.apache.doris.common.Config;
 import org.apache.doris.proto.PCancelPlanFragmentRequest;
 import org.apache.doris.proto.PCancelPlanFragmentResult;
+import org.apache.doris.proto.PCancelReason;
 import org.apache.doris.proto.PExecPlanFragmentResult;
 import org.apache.doris.proto.PFetchDataResult;
 import org.apache.doris.proto.PProxyRequest;
 import org.apache.doris.proto.PProxyResult;
 import org.apache.doris.proto.PTriggerProfileReportResult;
 import org.apache.doris.proto.PUniqueId;
-import org.apache.doris.qe.Coordinator.CancelReason;
 import org.apache.doris.thrift.TExecPlanFragmentParams;
 import org.apache.doris.thrift.TNetworkAddress;
 import org.apache.doris.thrift.TUniqueId;
@@ -112,12 +112,13 @@ public class BackendServiceProxy {
     }
 
     public Future<PCancelPlanFragmentResult> cancelPlanFragmentAsync(
-            TNetworkAddress address, TUniqueId finstId, CancelReason cancelReason) throws RpcException {
+            TNetworkAddress address, TUniqueId finstId, PCancelReason cancelReason) throws RpcException {
         final PCancelPlanFragmentRequest pRequest = new PCancelPlanFragmentRequest();
         PUniqueId uid = new PUniqueId();
         uid.hi = finstId.hi;
         uid.lo = finstId.lo;
         pRequest.finst_id = uid;
+        pRequest.cancel_reason = cancelReason;
         try {
             final PBackendService service = getProxy(address);
             return service.cancelPlanFragmentAsync(pRequest);

--- a/fe/src/main/java/org/apache/doris/rpc/BackendServiceProxy.java
+++ b/fe/src/main/java/org/apache/doris/rpc/BackendServiceProxy.java
@@ -20,7 +20,7 @@ package org.apache.doris.rpc;
 import org.apache.doris.common.Config;
 import org.apache.doris.proto.PCancelPlanFragmentRequest;
 import org.apache.doris.proto.PCancelPlanFragmentResult;
-import org.apache.doris.proto.PCancelReason;
+import org.apache.doris.proto.PPlanFragmentCancelReason;
 import org.apache.doris.proto.PExecPlanFragmentResult;
 import org.apache.doris.proto.PFetchDataResult;
 import org.apache.doris.proto.PProxyRequest;
@@ -112,7 +112,7 @@ public class BackendServiceProxy {
     }
 
     public Future<PCancelPlanFragmentResult> cancelPlanFragmentAsync(
-            TNetworkAddress address, TUniqueId finstId, PCancelReason cancelReason) throws RpcException {
+            TNetworkAddress address, TUniqueId finstId, PPlanFragmentCancelReason cancelReason) throws RpcException {
         final PCancelPlanFragmentRequest pRequest = new PCancelPlanFragmentRequest();
         PUniqueId uid = new PUniqueId();
         uid.hi = finstId.hi;

--- a/fe/src/main/java/org/apache/doris/rpc/BackendServiceProxy.java
+++ b/fe/src/main/java/org/apache/doris/rpc/BackendServiceProxy.java
@@ -26,6 +26,7 @@ import org.apache.doris.proto.PProxyRequest;
 import org.apache.doris.proto.PProxyResult;
 import org.apache.doris.proto.PTriggerProfileReportResult;
 import org.apache.doris.proto.PUniqueId;
+import org.apache.doris.qe.Coordinator.CancelReason;
 import org.apache.doris.thrift.TExecPlanFragmentParams;
 import org.apache.doris.thrift.TNetworkAddress;
 import org.apache.doris.thrift.TUniqueId;
@@ -111,7 +112,7 @@ public class BackendServiceProxy {
     }
 
     public Future<PCancelPlanFragmentResult> cancelPlanFragmentAsync(
-            TNetworkAddress address, TUniqueId finstId) throws RpcException {
+            TNetworkAddress address, TUniqueId finstId, CancelReason cancelReason) throws RpcException {
         final PCancelPlanFragmentRequest pRequest = new PCancelPlanFragmentRequest();
         PUniqueId uid = new PUniqueId();
         uid.hi = finstId.hi;

--- a/gensrc/proto/internal_service.proto
+++ b/gensrc/proto/internal_service.proto
@@ -114,14 +114,16 @@ message PExecPlanFragmentResult {
     required PStatus status = 1;
 };
 
+enum PCancelReason {
+    // 0 is reserved
+    LIMIT_REACH = 1;
+    USER_CANCEL = 2;
+    INTERNAL_ERROR = 3;
+};
+
 message PCancelPlanFragmentRequest {
     required PUniqueId finst_id = 1;
-    enum CancelReason {
-        LIMIT_REACH = 0;
-        USER_CANCEL = 1;
-        INTERNAL_ERROR = 2;
-    }
-    optional CancelReason cancel_reason = 2;
+    optional PCancelReason cancel_reason = 2;
 };
 
 message PCancelPlanFragmentResult {

--- a/gensrc/proto/internal_service.proto
+++ b/gensrc/proto/internal_service.proto
@@ -114,7 +114,7 @@ message PExecPlanFragmentResult {
     required PStatus status = 1;
 };
 
-enum PCancelReason {
+enum PPlanFragmentCancelReason {
     // 0 is reserved
     LIMIT_REACH = 1;
     USER_CANCEL = 2;
@@ -123,7 +123,7 @@ enum PCancelReason {
 
 message PCancelPlanFragmentRequest {
     required PUniqueId finst_id = 1;
-    optional PCancelReason cancel_reason = 2;
+    optional PPlanFragmentCancelReason cancel_reason = 2;
 };
 
 message PCancelPlanFragmentResult {

--- a/gensrc/proto/internal_service.proto
+++ b/gensrc/proto/internal_service.proto
@@ -116,6 +116,12 @@ message PExecPlanFragmentResult {
 
 message PCancelPlanFragmentRequest {
     required PUniqueId finst_id = 1;
+    enum CancelReason {
+        LIMIT_REACH = 0;
+        USER_CANCEL = 1;
+        INTERNAL_ERROR = 2;
+    }
+    optional CancelReason cancel_reason = 2;
 };
 
 message PCancelPlanFragmentResult {


### PR DESCRIPTION
When query result reach limit, the Coordinator in FE will send a cancel
request to BE to cancel the query. And when being cancelled, BE will report
query status to FE for debug purpose. But actually it is not necessary
and will generate too many logs.

So I add a CancelReason to distinguish the difference between 'normally'
cancellation and 'internal error' cancellation. if 'normally' cancelled,
no status will be reported to FE.

When query reach limit, or user cancel it actively, it is being cancelled 'normally'.
Otherwise, the query is cancelled due to internal error, which will need
a report from BE.