### PR TITLE
Add log to trace writer validate failure

### DIFF
--- a/be/src/olap/rowset/alpha_rowset.h
+++ b/be/src/olap/rowset/alpha_rowset.h
@@ -126,7 +126,7 @@ public:
 
     std::string unique_id() override;
 
-    std::string rowset_path() const {
+    const std::string& rowset_path() const {
         return _rowset_path;
     }
 

--- a/be/src/olap/rowset/alpha_rowset.h
+++ b/be/src/olap/rowset/alpha_rowset.h
@@ -126,6 +126,10 @@ public:
 
     std::string unique_id() override;
 
+    std::string rowset_path() const {
+        return _rowset_path;
+    }
+
 private:
     OLAPStatus _init_segment_groups();
 

--- a/be/src/olap/snapshot_manager.cpp
+++ b/be/src/olap/snapshot_manager.cpp
@@ -268,6 +268,10 @@ OLAPStatus SnapshotManager::_rename_rowset_id(const RowsetMetaPB& rs_meta_pb, co
                      << " to rowset " << rowset_id;
         return res;
     }
+    // Add log to trace rowset validation failure problem
+    // This log will be deleted in the future
+    AlphaRowsetSharedPtr org_alpha_rowset = std::dynamic_pointer_cast<AlphaRowset>(org_rowset);
+    LOG(INFO) << "original rowset path:" << org_alpha_rowset->rowset_path();
     RowsetSharedPtr new_rowset = rs_writer->build();
     if (new_rowset == nullptr) {
         LOG(WARNING) << "failed to build rowset when rename rowset id";


### PR DESCRIPTION
AlphaRowsetWriter validate rowset failed when build rowset
because rowset's num_rows is not equal to segment groups'
num_rows when add_rowset api is called. So add some log to
trace the process to debug the problems. The logs will be
deleted in the future.