### PR TITLE
Fix rollup bug when init RowCursor

### DIFF
--- a/be/src/olap/rowset/alpha_rowset_reader.cpp
+++ b/be/src/olap/rowset/alpha_rowset_reader.cpp
@@ -95,8 +95,14 @@ OLAPStatus AlphaRowsetReader::init(RowsetReaderContext* read_context) {
             LOG(WARNING) << "allocate memory for row cursor failed";
             return OLAP_ERR_MALLOC_ERROR;
         }
-        _dst_cursor->init(*(_current_read_context->tablet_schema),
-                          *(_current_read_context->seek_columns));
+        if (_current_read_context->reader_type == READER_ALTER_TABLE) {
+            // Upon rollup/alter table, seek_columns is nullptr.
+            // Under this circumstance, init RowCursor with all columns.
+            _dst_cursor->init(*(_current_read_context->tablet_schema));
+        } else {
+            _dst_cursor->init(*(_current_read_context->tablet_schema),
+                              *(_current_read_context->seek_columns));
+        }
         for (size_t i = 0; i < _merge_ctxs.size(); ++i) {
             _merge_ctxs[i].row_cursor.reset(new (std::nothrow) RowCursor());
             _merge_ctxs[i].row_cursor->init(*(_current_read_context->tablet_schema),


### PR DESCRIPTION
When doing rollup, seek_columns equals to the complete set of tablet's columns.
There is no necessity to set it.