### PR TITLE
Fix the duplicated request bug of mini load

### DIFF
--- a/fe/src/main/java/org/apache/doris/common/DuplicatedRequestException.java
+++ b/fe/src/main/java/org/apache/doris/common/DuplicatedRequestException.java
@@ -19,7 +19,14 @@ package org.apache.doris.common;
 
 public class DuplicatedRequestException extends DdlException {
 
-    public DuplicatedRequestException(String msg) {
+    private String duplicatedRequestId;
+
+    public DuplicatedRequestException(String duplicatedRequestId, String msg) {
         super(msg);
+        this.duplicatedRequestId = duplicatedRequestId;
+    }
+
+    public String getDuplicatedRequestId() {
+        return duplicatedRequestId;
     }
 }

--- a/fe/src/main/java/org/apache/doris/load/loadv2/BrokerLoadJob.java
+++ b/fe/src/main/java/org/apache/doris/load/loadv2/BrokerLoadJob.java
@@ -59,7 +59,7 @@ import java.util.Set;
 
 /**
  * There are 3 steps in BrokerLoadJob: BrokerPendingTask, LoadLoadingTask, CommitAndPublishTxn.
- * Step1: BrokerPendingTask will be created on method of executeJob.
+ * Step1: BrokerPendingTask will be created on method of unprotectedExecuteJob.
  * Step2: LoadLoadingTasks will be created by the method of onTaskFinished when BrokerPendingTask is finished.
  * Step3: CommitAndPublicTxn will be called by the method of onTaskFinished when all of LoadLoadingTasks are finished.
  */
@@ -179,7 +179,7 @@ public class BrokerLoadJob extends LoadJob {
     }
 
     @Override
-    protected void executeJob() {
+    protected void unprotectedExecuteJob() {
         LoadTask task = new BrokerLoadPendingTask(this, dataSourceInfo.getIdToFileGroups(), brokerDesc);
         idToTasks.put(task.getSignature(), task);
         Catalog.getCurrentCatalog().getLoadTaskScheduler().submit(task);

--- a/fe/src/main/java/org/apache/doris/load/loadv2/LoadJob.java
+++ b/fe/src/main/java/org/apache/doris/load/loadv2/LoadJob.java
@@ -283,17 +283,21 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
     public void execute() throws LabelAlreadyUsedException, BeginTransactionException, AnalysisException {
         writeLock();
         try {
-            // check if job state is pending
-            if (state != JobState.PENDING) {
-                return;
-            }
-            // the limit of job will be restrict when begin txn
-            beginTxn();
-            executeJob();
-            unprotectedUpdateState(JobState.LOADING);
+            unprotectedExecute();
         } finally {
             writeUnlock();
         }
+    }
+
+    public void unprotectedExecute() throws LabelAlreadyUsedException, BeginTransactionException, AnalysisException {
+        // check if job state is pending
+        if (state != JobState.PENDING) {
+            return;
+        }
+        // the limit of job will be restrict when begin txn
+        beginTxn();
+        unprotectedExecuteJob();
+        unprotectedUpdateState(JobState.LOADING);
     }
 
     public void processTimeout() {
@@ -309,7 +313,7 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
         logFinalOperation();
     }
 
-    protected void executeJob() {
+    protected void unprotectedExecuteJob() {
     }
 
     /**

--- a/fe/src/main/java/org/apache/doris/load/loadv2/MiniLoadJob.java
+++ b/fe/src/main/java/org/apache/doris/load/loadv2/MiniLoadJob.java
@@ -86,7 +86,6 @@ public class MiniLoadJob extends LoadJob {
 
     @Override
     public void beginTxn() throws LabelAlreadyUsedException, BeginTransactionException, AnalysisException {
-
         transactionId = Catalog.getCurrentGlobalTransactionMgr()
                 .beginTransaction(dbId, label, -1, "FE: " + FrontendOptions.getLocalHostAddress(),
                                   TransactionState.LoadJobSourceType.BACKEND_STREAMING, id,

--- a/fe/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
+++ b/fe/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
@@ -36,6 +36,7 @@ import org.apache.doris.common.PatternMatcher;
 import org.apache.doris.common.ThriftServerContext;
 import org.apache.doris.common.ThriftServerEventProcessor;
 import org.apache.doris.common.UserException;
+import org.apache.doris.common.util.DebugUtil;
 import org.apache.doris.load.EtlStatus;
 import org.apache.doris.load.LoadJob;
 import org.apache.doris.load.MiniEtlTaskInfo;
@@ -760,8 +761,9 @@ public class FrontendServiceImpl implements FrontendService.Iface {
     @Override
     public TStreamLoadPutResult streamLoadPut(TStreamLoadPutRequest request) throws TException {
         String clientAddr = getClientAddrAsString();
-        LOG.info("receive stream load put request. db:{}, tbl: {}, txn id: {}, backend: {}",
-                request.getDb(), request.getTbl(), request.getTxnId(), clientAddr);
+        LOG.info("receive stream load put request. db:{}, tbl: {}, txn id: {}, load id: {}, backend: {}",
+                 request.getDb(), request.getTbl(), request.getTxnId(), DebugUtil.printId(request.getLoadId()),
+                 clientAddr);
         LOG.debug("stream load put request: {}", request);
 
         TStreamLoadPutResult result = new TStreamLoadPutResult();

--- a/fe/src/test/java/org/apache/doris/load/loadv2/BrokerLoadJobTest.java
+++ b/fe/src/test/java/org/apache/doris/load/loadv2/BrokerLoadJobTest.java
@@ -191,7 +191,7 @@ public class BrokerLoadJobTest {
     @Test
     public void testExecuteJob(@Mocked MasterTaskExecutor masterTaskExecutor) {
         BrokerLoadJob brokerLoadJob = new BrokerLoadJob();
-        brokerLoadJob.executeJob();
+        brokerLoadJob.unprotectedExecuteJob();
 
         Map<Long, LoadTask> idToTasks = Deencapsulation.getField(brokerLoadJob, "idToTasks");
         Assert.assertEquals(1, idToTasks.size());


### PR DESCRIPTION
The function of miniLoadBegin will return the txn_id.
If the backend sends the duplicated request to frontend, frontend will return the txn_id which was created by the same mini load.

The issue is that frontend returns the txn_id when the last same request hasn't been begun the txn.
The frontend returns the zero which is initialized txn_id and the be could not execute the load plan with a error txn_id.

The commit conbines the `createLoadJob` and `execute` together in the write lock. It protects the atomicity of `create` and `beginTxn`.
So the duplicated request cannot get the txn id before the last same request is finished.