### PR TITLE
Fix bug that BE may crash when closing OlapTableSink

### DIFF
--- a/be/src/exec/tablet_sink.cpp
+++ b/be/src/exec/tablet_sink.cpp
@@ -588,9 +588,12 @@ Status OlapTableSink::send(RuntimeState* state, RowBatch* input_batch) {
 }
 
 Status OlapTableSink::close(RuntimeState* state, Status close_status) {
-    SCOPED_TIMER(_profile->total_time_counter());
     Status status = close_status;
     if (status.ok()) {
+        // SCOPED_TIMER should only be called is status is ok.
+        // if status is not ok, this OlapTableSink may not be prepared,
+        // so the `_profile` may be null. 
+        SCOPED_TIMER(_profile->total_time_counter());
         {
             SCOPED_TIMER(_close_timer);
             for (auto channel : _channels) {


### PR DESCRIPTION
The `_profile` in OlapTableSink may not be initialized if `prepare()`
method is not called. So when close the OlapTableSink, we should
check if `_profile` is initialized.

#1506 