### PR TITLE
Fix rollup bug when init RowCursor in MergeContext

### DIFF
--- a/be/src/olap/rowset/alpha_rowset_reader.cpp
+++ b/be/src/olap/rowset/alpha_rowset_reader.cpp
@@ -99,14 +99,18 @@ OLAPStatus AlphaRowsetReader::init(RowsetReaderContext* read_context) {
             // Upon rollup/alter table, seek_columns is nullptr.
             // Under this circumstance, init RowCursor with all columns.
             _dst_cursor->init(*(_current_read_context->tablet_schema));
+            for (size_t i = 0; i < _merge_ctxs.size(); ++i) {
+                _merge_ctxs[i].row_cursor.reset(new (std::nothrow) RowCursor());
+                _merge_ctxs[i].row_cursor->init(*(_current_read_context->tablet_schema));
+            }
         } else {
             _dst_cursor->init(*(_current_read_context->tablet_schema),
                               *(_current_read_context->seek_columns));
-        }
-        for (size_t i = 0; i < _merge_ctxs.size(); ++i) {
-            _merge_ctxs[i].row_cursor.reset(new (std::nothrow) RowCursor());
-            _merge_ctxs[i].row_cursor->init(*(_current_read_context->tablet_schema),
-                                            *(_current_read_context->seek_columns));
+            for (size_t i = 0; i < _merge_ctxs.size(); ++i) {
+                _merge_ctxs[i].row_cursor.reset(new (std::nothrow) RowCursor());
+                _merge_ctxs[i].row_cursor->init(*(_current_read_context->tablet_schema),
+                                                *(_current_read_context->seek_columns));
+            }
         }
     }
     return OLAP_SUCCESS;


### PR DESCRIPTION
When doing rollup, seek_columns equals to the complete set of tablet's columns.
There is no necessity to set it.