### PR TITLE
Fix bug that WrapperField does not consider HLL column type when creating

### DIFF
--- a/be/src/olap/wrapper_field.cpp
+++ b/be/src/olap/wrapper_field.cpp
@@ -21,7 +21,7 @@ namespace doris {
 
 WrapperField* WrapperField::create(const TabletColumn& column, uint32_t len) {
     bool is_string_type =
-        (column.type() == OLAP_FIELD_TYPE_CHAR || column.type() == OLAP_FIELD_TYPE_VARCHAR);
+        (column.type() == OLAP_FIELD_TYPE_CHAR || column.type() == OLAP_FIELD_TYPE_VARCHAR || column.type() == OLAP_FIELD_TYPE_HLL);
     if (is_string_type && len > OLAP_STRING_MAX_LENGTH) {
         OLAP_LOG_WARNING("length of string parameter is too long[len=%lu, max_len=%lu].",
                         len, OLAP_STRING_MAX_LENGTH);
@@ -36,7 +36,7 @@ WrapperField* WrapperField::create(const TabletColumn& column, uint32_t len) {
     size_t variable_len = 0;
     if (column.type() == OLAP_FIELD_TYPE_CHAR) {
         variable_len = std::max(len, (uint32_t)(column.length()));
-    } else if (column.type() == OLAP_FIELD_TYPE_VARCHAR) {
+    } else if (column.type() == OLAP_FIELD_TYPE_VARCHAR || column.type() == OLAP_FIELD_TYPE_HLL) {
         variable_len = std::max(len,
                 static_cast<uint32_t>(column.length() - sizeof(StringLengthType)));
     } else {


### PR DESCRIPTION
This bug may cause BE crash when handling HLL column in some process.
This bug is introduced by code merge. Version 0.10 does not have this bug.