### PR TITLE
Use different ID instead of table ID for base index of an OLAP table

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -208,7 +208,7 @@ namespace config {
     CONF_Int32(default_num_rows_per_column_file_block, "1024");
     CONF_Int32(max_tablet_num_per_shard, "1024");
     // pending data policy
-    CONF_Int32(pending_data_expire_time_sec, "60");
+    CONF_Int32(pending_data_expire_time_sec, "1800");
     // inc_rowset expired interval
     CONF_Int32(inc_rowset_expired_sec, "1800");
     // garbage sweep policy

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -208,7 +208,7 @@ namespace config {
     CONF_Int32(default_num_rows_per_column_file_block, "1024");
     CONF_Int32(max_tablet_num_per_shard, "1024");
     // pending data policy
-    CONF_Int32(pending_data_expire_time_sec, "1800");
+    CONF_Int32(pending_data_expire_time_sec, "60");
     // inc_rowset expired interval
     CONF_Int32(inc_rowset_expired_sec, "1800");
     // garbage sweep policy

--- a/be/src/exec/tablet_sink.cpp
+++ b/be/src/exec/tablet_sink.cpp
@@ -590,9 +590,8 @@ Status OlapTableSink::send(RuntimeState* state, RowBatch* input_batch) {
 Status OlapTableSink::close(RuntimeState* state, Status close_status) {
     Status status = close_status;
     if (status.ok()) {
-        // SCOPED_TIMER should only be called is status is ok.
-        // if status is not ok, this OlapTableSink may not be prepared,
-        // so the `_profile` may be null. 
+        // only if status is ok can we call this _profile->total_time_counter().
+        // if status is not ok, this sink may not be prepared, so that _profile is null
         SCOPED_TIMER(_profile->total_time_counter());
         {
             SCOPED_TIMER(_close_timer);

--- a/fe/src/main/java/org/apache/doris/alter/SchemaChangeHandler.java
+++ b/fe/src/main/java/org/apache/doris/alter/SchemaChangeHandler.java
@@ -732,7 +732,7 @@ public class SchemaChangeHandler extends AlterHandler {
         Set<String> bfColumns = null;
         double bfFpp = 0;
         try {
-            bfColumns = PropertyAnalyzer.analyzeBloomFilterColumns(propertyMap, indexSchemaMap.get(olapTable.getId()));
+            bfColumns = PropertyAnalyzer.analyzeBloomFilterColumns(propertyMap, indexSchemaMap.get(olapTable.getBaseIndexId()));
             bfFpp = PropertyAnalyzer.analyzeBloomFilterFpp(propertyMap);
         } catch (AnalysisException e) {
             throw new DdlException(e.getMessage());
@@ -927,7 +927,7 @@ public class SchemaChangeHandler extends AlterHandler {
                             break;
                         }
                     } // end for alterColumns
-                    if (!found && alterIndexId == tableId) {
+                    if (!found && alterIndexId == olapTable.getBaseIndexId()) {
                         // 2.1 partition column cannot be deleted.
                         throw new DdlException("Partition column[" + partitionCol.getName()
                                 + "] cannot be dropped. index[" + olapTable.getIndexNameById(alterIndexId) + "]");
@@ -955,7 +955,7 @@ public class SchemaChangeHandler extends AlterHandler {
                             break;
                         }
                     } // end for alterColumns
-                    if (!found && alterIndexId == tableId) {
+                    if (!found && alterIndexId == olapTable.getBaseIndexId()) {
                         // 2.2 distribution column cannot be deleted.
                         throw new DdlException("Distribution column[" + distributionCol.getName()
                                 + "] cannot be dropped. index[" + olapTable.getIndexNameById(alterIndexId) + "]");

--- a/fe/src/main/java/org/apache/doris/alter/SchemaChangeHandler.java
+++ b/fe/src/main/java/org/apache/doris/alter/SchemaChangeHandler.java
@@ -97,7 +97,7 @@ public class SchemaChangeHandler extends AlterHandler {
         String baseIndexName = olapTable.getName();
         checkAssignedTargetIndexName(baseIndexName, targetIndexName);
 
-        long baseIndexId = olapTable.getId();
+        long baseIndexId = olapTable.getBaseIndexId();
         long targetIndexId = -1L;
         if (targetIndexName != null) {
             targetIndexId = olapTable.getIndexIdByName(targetIndexName);
@@ -125,7 +125,7 @@ public class SchemaChangeHandler extends AlterHandler {
         String baseIndexName = olapTable.getName();
         checkAssignedTargetIndexName(baseIndexName, targetIndexName);
 
-        long baseIndexId = olapTable.getId();
+        long baseIndexId = olapTable.getBaseIndexId();
         long targetIndexId = -1L;
         if (targetIndexName != null) {
             targetIndexId = olapTable.getIndexIdByName(targetIndexName);
@@ -152,7 +152,7 @@ public class SchemaChangeHandler extends AlterHandler {
         checkAssignedTargetIndexName(baseIndexName, targetIndexName);
         
         if (KeysType.UNIQUE_KEYS == olapTable.getKeysType()) {
-            long baseIndexId = olapTable.getId();
+            long baseIndexId = olapTable.getBaseIndexId();
             List<Column> baseSchema = indexSchemaMap.get(baseIndexId);
             boolean isKey = false;
             for (Column column : baseSchema) {
@@ -169,7 +169,7 @@ public class SchemaChangeHandler extends AlterHandler {
         } else if (KeysType.AGG_KEYS == olapTable.getKeysType()) {
             if (null == targetIndexName) {
                 // drop column in base table
-                long baseIndexId = olapTable.getId();
+                long baseIndexId = olapTable.getBaseIndexId();
                 List<Column> baseSchema = indexSchemaMap.get(baseIndexId);
                 boolean isKey = false;
                 boolean hasReplaceColumn = false;
@@ -203,7 +203,7 @@ public class SchemaChangeHandler extends AlterHandler {
             }
         }
         
-        long baseIndexId = olapTable.getId();
+        long baseIndexId = olapTable.getBaseIndexId();
         if (targetIndexName == null) {
             // drop base index and all rollup indices's column
             List<Long> indexIds = new ArrayList<Long>();

--- a/fe/src/main/java/org/apache/doris/alter/SchemaChangeJob.java
+++ b/fe/src/main/java/org/apache/doris/alter/SchemaChangeJob.java
@@ -1011,7 +1011,7 @@ public class SchemaChangeJob extends AlterJob {
                 if (newStorageType != null) {
                     olapTable.setIndexStorageType(indexId, newStorageType);
                 }
-                if (indexId == olapTable.getId()) {
+                if (indexId == olapTable.getBaseIndexId()) {
                     olapTable.setNewBaseSchema(entry.getValue());
                 }
             }

--- a/fe/src/main/java/org/apache/doris/alter/SchemaChangeJob.java
+++ b/fe/src/main/java/org/apache/doris/alter/SchemaChangeJob.java
@@ -847,8 +847,8 @@ public class SchemaChangeJob extends AlterJob {
                 }
 
                 // 3. update base schema if changed
-                if (this.changedIndexIdToSchema.containsKey(tableId)) {
-                    table.setNewBaseSchema(this.changedIndexIdToSchema.get(tableId));
+                if (this.changedIndexIdToSchema.containsKey(olapTable.getBaseIndexId())) {
+                    table.setNewBaseSchema(this.changedIndexIdToSchema.get(olapTable.getBaseIndexId()));
                 }
 
                 // 4. update table bloom filter columns

--- a/fe/src/main/java/org/apache/doris/analysis/DescribeStmt.java
+++ b/fe/src/main/java/org/apache/doris/analysis/DescribeStmt.java
@@ -117,7 +117,12 @@ public class DescribeStmt extends ShowStmt {
             if (!isAllTables) {
                 // show base table schema only
                 String procString = "/dbs/" + db.getId() + "/" + table.getId() + "/" + TableProcDir.INDEX_SCHEMA
-                        + "/" + table.getId();
+                        + "/";
+                if (table.getType() == TableType.OLAP) {
+                    procString += ((OlapTable) table).getBaseIndexId();
+                } else {
+                    procString += table.getId();
+                }
 
                 node = ProcService.getInstance().open(procString);
                 if (node == null) {
@@ -132,9 +137,9 @@ public class DescribeStmt extends ShowStmt {
 
                     // indices order
                     List<Long> indices = Lists.newArrayList();
-                    indices.add(olapTable.getId());
+                    indices.add(olapTable.getBaseIndexId());
                     for (Long indexId : indexIdToSchema.keySet()) {
-                        if (indexId != olapTable.getId()) {
+                        if (indexId != olapTable.getBaseIndexId()) {
                             indices.add(indexId);
                         }
                     }

--- a/fe/src/main/java/org/apache/doris/backup/RestoreJob.java
+++ b/fe/src/main/java/org/apache/doris/backup/RestoreJob.java
@@ -814,7 +814,7 @@ public class RestoreJob extends AbstractJob {
             MaterializedIndex remoteIdx = remotePart.getIndex(remoteIdxId);
             long localIdxId = localIdxNameToId.get(localidxName);
             remoteIdx.setIdForRestore(localIdxId);
-            if (localIdxId != localTbl.getId()) {
+            if (localIdxId != localTbl.getBaseIndexId()) {
                 // not base table, reset
                 remotePart.deleteRollupIndex(remoteIdxId);
                 remotePart.createRollupIndex(remoteIdx);

--- a/fe/src/main/java/org/apache/doris/catalog/Catalog.java
+++ b/fe/src/main/java/org/apache/doris/catalog/Catalog.java
@@ -3348,6 +3348,10 @@ public class Catalog {
         long tableId = Catalog.getInstance().getNextId();
         OlapTable olapTable = new OlapTable(tableId, tableName, baseSchema, keysType, partitionInfo, distributionInfo);
 
+        // set base index id
+        long baseIndexId = getNextId();
+        olapTable.setBaseIndexId(baseIndexId);
+
         // set base index info to table
         // this should be done before create partition.
         // get base index storage type. default is COLUMN
@@ -3358,9 +3362,7 @@ public class Catalog {
         } catch (AnalysisException e) {
             throw new DdlException(e.getMessage());
         }
-
         Preconditions.checkNotNull(baseIndexStorageType);
-        long baseIndexId = olapTable.getId();
         olapTable.setStorageTypeToIndex(baseIndexId, baseIndexStorageType);
 
         // analyze bloom filter columns
@@ -3452,9 +3454,6 @@ public class Catalog {
             throw new DdlException(e.getMessage());
         }
         Preconditions.checkNotNull(versionInfo);
-
-        // set base index id
-        olapTable.setBaseIndexId(getNextId());
 
         // a set to record every new tablet created when create table
         // if failed in any step, use this set to do clear things

--- a/fe/src/main/java/org/apache/doris/catalog/OlapTable.java
+++ b/fe/src/main/java/org/apache/doris/catalog/OlapTable.java
@@ -115,6 +115,14 @@ public class OlapTable extends Table {
     private double bfFpp;
 
     private String colocateGroup;
+    
+    // In former implementation, base index id is same as table id.
+    // But when refactoring the process of alter table job, we find that
+    // using same id is not suitable for our new framework.
+    // So we add this 'baseIndexId' to explicitly specify the base index id,
+    // which should be different with table id.
+    // The init value is -1, which means there is not partition and index at all.
+    private long baseIndexId = -1;
 
     public OlapTable() {
         // for persist
@@ -163,6 +171,14 @@ public class OlapTable extends Table {
         this.bfFpp = 0;
 
         this.colocateGroup = null;
+    }
+
+    public void setBaseIndexId(long baseIndexId) {
+        this.baseIndexId = baseIndexId;
+    }
+
+    public long getBaseIndexId() {
+        return baseIndexId;
     }
 
     public void setState(OlapTableState state) {
@@ -254,12 +270,10 @@ public class OlapTable extends Table {
 
         // reset all 'indexIdToXXX' map
         for (Map.Entry<Long, String> entry : origIdxIdToName.entrySet()) {
-            long newIdxId = 0;
+            long newIdxId = catalog.getNextId();
             if (entry.getValue().equals(name)) {
                 // base index
-                newIdxId = id;
-            } else {
-                newIdxId = catalog.getNextId();
+                baseIndexId = id;
             }
             indexIdToSchema.put(newIdxId, indexIdToSchema.remove(entry.getKey()));
             indexIdToSchemaHash.put(newIdxId, indexIdToSchemaHash.remove(entry.getKey()));
@@ -309,7 +323,7 @@ public class OlapTable extends Table {
                 long newIdxId = indexNameToId.get(entry2.getValue());
                 int schemaHash = indexIdToSchemaHash.get(newIdxId);
                 idx.setIdForRestore(newIdxId);
-                if (newIdxId != id) {
+                if (newIdxId != baseIndexId) {
                     // not base table, reset
                     partition.deleteRollupIndex(entry2.getKey());
                     partition.createRollupIndex(idx);
@@ -797,6 +811,8 @@ public class OlapTable extends Table {
             out.writeBoolean(true);
             Text.writeString(out, colocateGroup);
         }
+
+        out.writeLong(baseIndexId);
     }
 
     @Override
@@ -883,6 +899,13 @@ public class OlapTable extends Table {
             if (in.readBoolean()) {
                 colocateGroup = Text.readString(in);
             }
+        }
+
+        if (Catalog.getCurrentCatalogJournalVersion() >= FeMetaVersion.VERSION_57) {
+            baseIndexId = in.readLong();
+        } else {
+            // the old table use table id as base index id
+            baseIndexId = id;
         }
     }
 

--- a/fe/src/main/java/org/apache/doris/catalog/OlapTable.java
+++ b/fe/src/main/java/org/apache/doris/catalog/OlapTable.java
@@ -273,7 +273,7 @@ public class OlapTable extends Table {
             long newIdxId = catalog.getNextId();
             if (entry.getValue().equals(name)) {
                 // base index
-                baseIndexId = id;
+                baseIndexId = newIdxId;
             }
             indexIdToSchema.put(newIdxId, indexIdToSchema.remove(entry.getKey()));
             indexIdToSchemaHash.put(newIdxId, indexIdToSchemaHash.remove(entry.getKey()));

--- a/fe/src/main/java/org/apache/doris/catalog/TabletInvertedIndex.java
+++ b/fe/src/main/java/org/apache/doris/catalog/TabletInvertedIndex.java
@@ -195,6 +195,10 @@ public class TabletInvertedIndex {
                                         } else if (transactionState.getTransactionStatus() == TransactionStatus.VISIBLE) {
                                             TableCommitInfo tableCommitInfo = transactionState.getTableCommitInfo(tabletMeta.getTableId());
                                             PartitionCommitInfo partitionCommitInfo = tableCommitInfo.getPartitionCommitInfo(partitionId);
+                                            if (partitionCommitInfo == null) {
+                                                LOG.warn("failed to find partition commit info. table: {}, partition: {}, tablet: {}, txn id: {}",
+                                                        tabletMeta.getTableId(), partitionId, tabletId, transactionState.getTransactionId());
+                                            }
                                             TPartitionVersionInfo versionInfo = new TPartitionVersionInfo(tabletMeta.getPartitionId(), 
                                                     partitionCommitInfo.getVersion(),
                                                     partitionCommitInfo.getVersionHash());

--- a/fe/src/main/java/org/apache/doris/common/FeConstants.java
+++ b/fe/src/main/java/org/apache/doris/common/FeConstants.java
@@ -35,5 +35,5 @@ public class FeConstants {
 
     // general model
     // Current meta data version. Use this version to write journals and image
-    public static int meta_version = FeMetaVersion.VERSION_56;
+    public static int meta_version = FeMetaVersion.VERSION_57;
 }

--- a/fe/src/main/java/org/apache/doris/common/FeMetaVersion.java
+++ b/fe/src/main/java/org/apache/doris/common/FeMetaVersion.java
@@ -122,4 +122,6 @@ public final class FeMetaVersion {
     public static final int VERSION_55 = 55;
     // persist auth info in load job
     public static final int VERSION_56 = 56;
+    // for base index using different id
+    public static final int VERSION_57 = 57;
 }

--- a/fe/src/main/java/org/apache/doris/common/proc/IndexInfoProcDir.java
+++ b/fe/src/main/java/org/apache/doris/common/proc/IndexInfoProcDir.java
@@ -65,9 +65,9 @@ public class IndexInfoProcDir implements ProcDirInterface {
 
                 // indices order
                 List<Long> indices = Lists.newArrayList();
-                indices.add(olapTable.getId());
+                indices.add(olapTable.getBaseIndexId());
                 for (Long indexId : olapTable.getIndexIdToSchema().keySet()) {
-                    if (indexId != olapTable.getId()) {
+                    if (indexId != olapTable.getBaseIndexId()) {
                         indices.add(indexId);
                     }
                 }

--- a/fe/src/test/java/org/apache/doris/analysis/AccessTestUtil.java
+++ b/fe/src/test/java/org/apache/doris/analysis/AccessTestUtil.java
@@ -81,7 +81,7 @@ public class AccessTestUtil {
             Catalog catalog = EasyMock.createMock(Catalog.class);
             EasyMock.expect(catalog.getAuth()).andReturn(fetchAdminAccess()).anyTimes();
             Database db = new Database(50000L, "testCluster:testDb");
-            MaterializedIndex baseIndex = new MaterializedIndex(30000, IndexState.NORMAL);
+            MaterializedIndex baseIndex = new MaterializedIndex(30001, IndexState.NORMAL);
 
             RandomDistributionInfo distributionInfo = new RandomDistributionInfo(10);
 
@@ -91,6 +91,7 @@ public class AccessTestUtil {
                     KeysType.AGG_KEYS, new SinglePartitionInfo(), distributionInfo);
             table.setIndexSchemaInfo(baseIndex.getId(), "testTbl", baseSchema, 0, 1, (short) 1);
             table.addPartition(partition);
+            table.setBaseIndexId(baseIndex.getId());
             db.createTable(table);
 
             EasyMock.expect(catalog.getDb("testCluster:testDb")).andReturn(db).anyTimes();

--- a/fe/src/test/java/org/apache/doris/catalog/CatalogTestUtil.java
+++ b/fe/src/test/java/org/apache/doris/catalog/CatalogTestUtil.java
@@ -212,6 +212,7 @@ public class CatalogTestUtil {
                 distributionInfo);
         table.addPartition(partition);
         table.setIndexSchemaInfo(indexId, testIndex1, columns, 0, testSchemaHash1, (short) 1);
+        table.setBaseIndexId(indexId);
         // db
         Database db = new Database(dbId, testDb1);
         db.createTable(table);


### PR DESCRIPTION
In current implementation, the id of a base index of a OLAP table use the same id
as table's id. Because in origin design, we considered that a OLAP table must has and
only has one unique base index. So using same ID is OK.

But when we refactor the alter table process(#1429 ), and when trying to replace the base index with a new created base index, we find that it is very difficult to change the base index's ID. Because if we want to change it, the table's ID should be changed as well, such leading to a cascading impacts on many other process.

So, we decide to change it, by using different ID for base index and table, decouple  these 2 IDs will let us more easy to go on.

Also increase the FE meta version to VERSION_57, for `baseIndexId` in OlapTable.