### PR TITLE
Add more logs and metrics to trace the broker load process

### DIFF
--- a/be/src/exec/tablet_sink.h
+++ b/be/src/exec/tablet_sink.h
@@ -172,6 +172,9 @@ public:
     // at a time can modify them.
     int64_t* mutable_wait_in_flight_packet_ns() { return &_wait_in_flight_packet_ns; }
     int64_t* mutable_serialize_batch_ns() { return &_serialize_batch_ns; }
+    void increase_node_add_batch_time_us(int64_t be_id, int64_t time_ns) {
+        _node_add_batch_time_map[be_id] += time_ns;
+    }
 
 private:
     // convert input batch to output batch which will be loaded into OLAP table.
@@ -257,6 +260,9 @@ private:
     RuntimeProfile::Counter* _close_timer = nullptr;
     RuntimeProfile::Counter* _wait_in_flight_packet_timer = nullptr;
     RuntimeProfile::Counter* _serialize_batch_timer = nullptr;
+
+    // BE id -> execution time of add batch in us
+    std::unordered_map<int64_t, int64_t> _node_add_batch_time_map;
 };
 
 }

--- a/be/src/olap/txn_manager.cpp
+++ b/be/src/olap/txn_manager.cpp
@@ -166,7 +166,7 @@ OLAPStatus TxnManager::commit_txn(
                     && load_info.rowset != nullptr
                     && load_info.rowset->rowset_id() != rowset_ptr->rowset_id()) {
                     // find a rowset with different rowset id, then it should not happen, just return errors
-                    LOG(WARNING) << "find transaction exists when add to engine."
+                    LOG(WARNING) << "find transaction exists when add to engine. but rowset ids are not same."
                                  << "partition_id: " << key.first
                                  << ", transaction_id: " << key.second
                                  << ", tablet: " << tablet_info.to_string()

--- a/be/src/util/doris_metrics.cpp
+++ b/be/src/util/doris_metrics.cpp
@@ -94,6 +94,9 @@ IntCounter DorisMetrics::txn_exec_plan_total;
 IntCounter DorisMetrics::stream_receive_bytes_total;
 IntCounter DorisMetrics::stream_load_rows_total;
 
+IntCounter DorisMetrics::memtable_flush_total;
+IntCounter DorisMetrics::memtable_flush_duration_us;
+
 // gauges
 IntGauge DorisMetrics::memory_pool_bytes_total;
 IntGauge DorisMetrics::process_thread_num;
@@ -137,6 +140,9 @@ void DorisMetrics::initialize(
     REGISTER_DORIS_METRIC(query_scan_bytes);
     REGISTER_DORIS_METRIC(query_scan_rows);
     REGISTER_DORIS_METRIC(ranges_processed_total);
+
+    REGISTER_DORIS_METRIC(memtable_flush_total);
+    REGISTER_DORIS_METRIC(memtable_flush_duration_us);
 
     // push request
     _metrics->register_metric(

--- a/be/src/util/doris_metrics.h
+++ b/be/src/util/doris_metrics.h
@@ -114,6 +114,9 @@ public:
     static IntCounter stream_receive_bytes_total;
     static IntCounter stream_load_rows_total;
 
+    static IntCounter memtable_flush_total;
+    static IntCounter memtable_flush_duration_us;
+
     // Gauges
     static IntGauge memory_pool_bytes_total;
     static IntGauge process_thread_num;

--- a/fe/src/main/java/org/apache/doris/catalog/Catalog.java
+++ b/fe/src/main/java/org/apache/doris/catalog/Catalog.java
@@ -481,7 +481,7 @@ public class Catalog {
         this.tabletScheduler = new TabletScheduler(this, systemInfo, tabletInvertedIndex, stat);
         this.tabletChecker = new TabletChecker(this, systemInfo, tabletScheduler, stat);
 
-        this.loadTaskScheduler = new MasterTaskExecutor(10);
+        this.loadTaskScheduler = new MasterTaskExecutor(Config.async_load_task_pool_size);
         this.loadJobScheduler = new LoadJobScheduler();
         this.loadManager = new LoadManager(loadJobScheduler);
         this.loadTimeoutChecker = new LoadTimeoutChecker(loadManager);

--- a/fe/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/src/main/java/org/apache/doris/common/Config.java
@@ -259,13 +259,6 @@ public class Config extends ConfigBase {
      * minimal intervals between two publish version action
      */
     @ConfField public static int publish_version_interval_ms = 100;
-    
-    /*
-     * maximun concurrent running txn num including prepare, commit txns under a single db
-     * txn manager will reject coming txns
-     */
-    @ConfField(mutable = true, masterOnly = true)
-    public static int max_running_txn_num_per_db = 100;
 
     /*
      * Maximal wait seconds for straggler node in load
@@ -392,6 +385,20 @@ public class Config extends ConfigBase {
      */
     @ConfField(mutable = true, masterOnly = true)
     public static int desired_max_waiting_jobs = 100;
+
+    /*
+     * maximun concurrent running txn num including prepare, commit txns under a single db
+     * txn manager will reject coming txns
+     */
+    @ConfField(mutable = true, masterOnly = true)
+    public static int max_running_txn_num_per_db = 100;
+
+    /*
+     * The load task executor pool size. This pool size limits the max running load tasks.
+     * Currently, it only limits the load task of broker load, pending and loading phases.
+     * It should be less than 'max_running_txn_num_per_db'
+     */
+    public static int async_load_task_pool_size = 10;
 
     /*
      * Same meaning as *tablet_create_timeout_second*, but used when delete a tablet.

--- a/fe/src/main/java/org/apache/doris/load/loadv2/BrokerLoadPendingTask.java
+++ b/fe/src/main/java/org/apache/doris/load/loadv2/BrokerLoadPendingTask.java
@@ -53,11 +53,13 @@ public class BrokerLoadPendingTask extends LoadTask {
 
     @Override
     void executeTask() throws UserException {
+        LOG.info("begin to execute broker pending task. job: {}", callback.getCallbackId());
         getAllFileStatus();
     }
 
     private void getAllFileStatus()
             throws UserException {
+        long start = System.currentTimeMillis();
         for (Map.Entry<Long, List<BrokerFileGroup>> entry : tableToBrokerFileList.entrySet()) {
             long tableId = entry.getKey();
 
@@ -79,6 +81,8 @@ public class BrokerLoadPendingTask extends LoadTask {
             }
 
             ((BrokerPendingTaskAttachment) attachment).addFileStatus(tableId, fileStatusList);
+            LOG.info("get {} files to be loaded. cost: {} ms, job: {}",
+                    fileStatusList.size(), (System.currentTimeMillis() - start), callback.getCallbackId());
         }
     }
 }

--- a/fe/src/main/java/org/apache/doris/load/loadv2/LoadLoadingTask.java
+++ b/fe/src/main/java/org/apache/doris/load/loadv2/LoadLoadingTask.java
@@ -73,7 +73,7 @@ public class LoadLoadingTask extends LoadTask {
     }
 
     public void init(List<List<TBrokerFileStatus>> fileStatusList, int fileNum) throws UserException {
-        planner = new LoadingTaskPlanner(txnId, db.getId(), table, brokerDesc, fileGroups, strictMode);
+        planner = new LoadingTaskPlanner(callback.getCallbackId(), txnId, db.getId(), table, brokerDesc, fileGroups, strictMode);
         planner.plan(fileStatusList, fileNum);
     }
 

--- a/fe/src/main/java/org/apache/doris/load/loadv2/LoadLoadingTask.java
+++ b/fe/src/main/java/org/apache/doris/load/loadv2/LoadLoadingTask.java
@@ -55,8 +55,6 @@ public class LoadLoadingTask extends LoadTask {
 
     private LoadingTaskPlanner planner;
 
-    private String errMsg;
-
     public LoadLoadingTask(Database db, OlapTable table,
                            BrokerDesc brokerDesc, List<BrokerFileGroup> fileGroups,
                            long jobDeadlineMs, long execMemLimit, boolean strictMode,
@@ -81,6 +79,7 @@ public class LoadLoadingTask extends LoadTask {
 
     @Override
     protected void executeTask() throws Exception{
+        LOG.info("begin to execute loading task. job: {}. left retry: {}", callback.getCallbackId(), retryTime);
         retryTime--;
         executeOnce();
     }

--- a/fe/src/main/java/org/apache/doris/load/loadv2/LoadTask.java
+++ b/fe/src/main/java/org/apache/doris/load/loadv2/LoadTask.java
@@ -36,7 +36,7 @@ public abstract class LoadTask extends MasterTask {
     protected FailMsg failMsg = new FailMsg();
     protected int retryTime = 1;
 
-    public LoadTask(LoadTaskCallback callback){
+    public LoadTask(LoadTaskCallback callback) {
         this.signature = Catalog.getCurrentCatalog().getNextId();
         this.callback = callback;
     }

--- a/fe/src/main/java/org/apache/doris/load/loadv2/LoadingTaskPlanner.java
+++ b/fe/src/main/java/org/apache/doris/load/loadv2/LoadingTaskPlanner.java
@@ -60,6 +60,7 @@ public class LoadingTaskPlanner {
     private static final Logger LOG = LogManager.getLogger(LoadingTaskPlanner.class);
 
     // Input params
+    private final long loadJobId;
     private final long txnId;
     private final long dbId;
     private final OlapTable table;
@@ -77,9 +78,10 @@ public class LoadingTaskPlanner {
 
     private int nextNodeId = 0;
 
-    public LoadingTaskPlanner(long txnId, long dbId, OlapTable table,
+    public LoadingTaskPlanner(Long loadJobId, long txnId, long dbId, OlapTable table,
                               BrokerDesc brokerDesc, List<BrokerFileGroup> brokerFileGroups,
                               boolean strictMode) {
+        this.loadJobId = loadJobId;
         this.txnId = txnId;
         this.dbId = dbId;
         this.table = table;
@@ -108,7 +110,7 @@ public class LoadingTaskPlanner {
         // 1. Broker scan node
         BrokerScanNode scanNode = new BrokerScanNode(new PlanNodeId(nextNodeId++), tupleDesc, "BrokerScanNode",
                                                      fileStatusesList, filesAdded);
-        scanNode.setLoadInfo(table, brokerDesc, fileGroups, strictMode);
+        scanNode.setLoadInfo(loadJobId, txnId, table, brokerDesc, fileGroups, strictMode);
         scanNode.init(analyzer);
         scanNode.finalize(analyzer);
         scanNodes.add(scanNode);

--- a/fe/src/main/java/org/apache/doris/qe/QeProcessor.java
+++ b/fe/src/main/java/org/apache/doris/qe/QeProcessor.java
@@ -18,6 +18,7 @@
 package org.apache.doris.qe;
 
 import org.apache.doris.common.UserException;
+import org.apache.doris.thrift.TNetworkAddress;
 import org.apache.doris.thrift.TReportExecStatusParams;
 import org.apache.doris.thrift.TReportExecStatusResult;
 import org.apache.doris.thrift.TUniqueId;
@@ -26,7 +27,7 @@ import java.util.Map;
 
 public interface QeProcessor {
 
-    TReportExecStatusResult reportExecStatus(TReportExecStatusParams params);
+    TReportExecStatusResult reportExecStatus(TReportExecStatusParams params, TNetworkAddress beAddr);
 
     void registerQuery(TUniqueId queryId, Coordinator coord) throws UserException;
 

--- a/fe/src/main/java/org/apache/doris/qe/QeProcessorImpl.java
+++ b/fe/src/main/java/org/apache/doris/qe/QeProcessorImpl.java
@@ -20,6 +20,7 @@ package org.apache.doris.qe;
 
 import org.apache.doris.common.UserException;
 import org.apache.doris.common.util.DebugUtil;
+import org.apache.doris.thrift.TNetworkAddress;
 import org.apache.doris.thrift.TReportExecStatusParams;
 import org.apache.doris.thrift.TReportExecStatusResult;
 import org.apache.doris.thrift.TStatus;
@@ -94,9 +95,10 @@ public final class QeProcessorImpl implements QeProcessor {
     }
 
     @Override
-    public TReportExecStatusResult reportExecStatus(TReportExecStatusParams params) {
-        LOG.info("ReportExecStatus(): fragment_instance_id=" + DebugUtil.printId(params.fragment_instance_id)
-                + ", query id=" + DebugUtil.printId(params.query_id));
+    public TReportExecStatusResult reportExecStatus(TReportExecStatusParams params, TNetworkAddress beAddr) {
+        LOG.info("ReportExecStatus(): fragment_instance_id={}, query id={}, backend num: {}, ip: {}",
+                DebugUtil.printId(params.fragment_instance_id), DebugUtil.printId(params.query_id),
+                params.backend_num, beAddr);
         LOG.debug("params: {}", params);
         final TReportExecStatusResult result = new TReportExecStatusResult();
         final QueryInfo info = coordinatorMap.get(params.query_id);

--- a/fe/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
+++ b/fe/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
@@ -317,7 +317,7 @@ public class FrontendServiceImpl implements FrontendService.Iface {
 
     @Override
     public TReportExecStatusResult reportExecStatus(TReportExecStatusParams params) throws TException {
-        return QeProcessorImpl.INSTANCE.reportExecStatus(params);
+        return QeProcessorImpl.INSTANCE.reportExecStatus(params, getClientAddr());
     }
 
     @Override

--- a/gensrc/proto/internal_service.proto
+++ b/gensrc/proto/internal_service.proto
@@ -95,6 +95,7 @@ message PTabletWriterAddBatchRequest {
 message PTabletWriterAddBatchResult {
     required PStatus status = 1;
     repeated PTabletInfo tablet_vec = 2;
+    optional int64 execution_time_us = 3;
 };
 
 // tablet writer cancel


### PR DESCRIPTION
1. The Operator wants to known when the job being scheduled as PENDING
and LOADING. And how long it takes to finish these sub states. So I add log
at the beginning of each state.

2. Add 2 metrics on BE to monitor the memtable's flush time.
`memtable_flush_total` and `memtable_flush_duration_us`

3. Add a log when closing OlapTableSink, to record the add_batch() time of each
Backend, cumulative.