### PR TITLE
Fix rowset build validate failure

### DIFF
--- a/be/src/olap/olap_index.h
+++ b/be/src/olap/olap_index.h
@@ -176,7 +176,7 @@ public:
                     size_t short_key_num, std::vector<TabletColumn>* short_key_columns);
 
     // 加载一个segment到内存
-    OLAPStatus load_segment(const char* file, size_t *current_num_rows_per_row_block);
+    OLAPStatus load_segment(const char* file, size_t *current_num_rows_per_row_block, bool use_cache = true);
 
     // Return the IndexOffset of the first element, physically, it's (0, 0)
     const OLAPIndexOffset begin() const {

--- a/be/src/olap/rowset/alpha_rowset.cpp
+++ b/be/src/olap/rowset/alpha_rowset.cpp
@@ -55,7 +55,7 @@ OLAPStatus AlphaRowset::init() {
     return status;
 }
 
-OLAPStatus AlphaRowset::load() {
+OLAPStatus AlphaRowset::load(bool use_cache) {
     // load is depend on init, so that check if init here and do init if not
     if (!is_inited()) {
         OLAPStatus res = init();
@@ -76,7 +76,7 @@ OLAPStatus AlphaRowset::load() {
                 // if load segment group failed, rowset init failed
             return OLAP_ERR_TABLE_INDEX_VALIDATE_ERROR;
         }
-        OLAPStatus res = segment_group->load();
+        OLAPStatus res = segment_group->load(use_cache);
         if (res != OLAP_SUCCESS) {
             LOG(WARNING) << "fail to load segment_group. res=" << res << ", "
                     << "version=" << start_version() << "-"

--- a/be/src/olap/rowset/alpha_rowset.h
+++ b/be/src/olap/rowset/alpha_rowset.h
@@ -46,7 +46,7 @@ public:
 
     // this api is for lazy loading data
     // always means that there are some io
-    OLAPStatus load() override;
+    OLAPStatus load(bool use_cache = true) override;
 
     std::shared_ptr<RowsetReader> create_reader() override;
 

--- a/be/src/olap/rowset/alpha_rowset_writer.cpp
+++ b/be/src/olap/rowset/alpha_rowset_writer.cpp
@@ -115,14 +115,7 @@ OLAPStatus AlphaRowsetWriter::add_rowset(RowsetSharedPtr rowset) {
         _cur_segment_group->add_zone_maps(segment_group->get_zone_maps());
         RETURN_NOT_OK(flush());
         _num_rows_written += segment_group->num_rows();
-        // Add log to trace rowset validation failure problem
-        // This log will be deleted in the future
-        LOG(INFO) << "add rowset's segment group:" << segment_group->rowset_path_prefix()
-                << ", num_rows:" << segment_group->num_rows();
     }
-    // Add log to trace rowset validation failure problem
-    // This log will be deleted in the future
-    LOG(INFO) << "clone add_rowset:" << _num_rows_written << ", rowset path:" << alpha_rowset->rowset_path();
     return OLAP_SUCCESS;
 }
 
@@ -324,16 +317,9 @@ bool AlphaRowsetWriter::_validate_rowset() {
         num_rows += segment_group->num_rows();
     }
     if (num_rows != _current_rowset_meta->num_rows()) {
-        // Add log to trace rowset validation failure problem
-        // This log will be deleted in the future
-        std::stringstream ss;
-        for (auto& segment_group : _segment_groups) {
-            ss << segment_group->rowset_path_prefix() << ",";
-        }
         LOG(WARNING) << "num_rows between rowset and segment_groups do not match. "
                      << "num_rows of segment_groups:" << num_rows
-                     << ", num_rows of rowset:" << _current_rowset_meta->num_rows()
-                     << ", own segment group path:" << ss.str();
+                     << ", num_rows of rowset:" << _current_rowset_meta->num_rows();
 
         return false;
     }

--- a/be/src/olap/rowset/rowset.h
+++ b/be/src/olap/rowset/rowset.h
@@ -60,7 +60,7 @@ public:
 
     // this api is for lazy loading data
     // always means that there are some io
-    virtual OLAPStatus load() = 0;
+    virtual OLAPStatus load(bool use_cache = true) = 0;
 
     virtual std::shared_ptr<RowsetReader> create_reader() = 0;
 

--- a/be/src/olap/rowset/segment_group.cpp
+++ b/be/src/olap/rowset/segment_group.cpp
@@ -313,7 +313,7 @@ OLAPStatus SegmentGroup::add_zone_maps(
     return OLAP_SUCCESS;
 }
 
-OLAPStatus SegmentGroup::load() {
+OLAPStatus SegmentGroup::load(bool use_cache) {
     if (_empty) {
         _index_loaded = true;
         return OLAP_SUCCESS;
@@ -347,7 +347,7 @@ OLAPStatus SegmentGroup::load() {
         
         // get full path for one segment
         std::string path = construct_index_file_path(seg_id);
-        if ((res = _index.load_segment(path.c_str(), &_current_num_rows_per_row_block))
+        if ((res = _index.load_segment(path.c_str(), &_current_num_rows_per_row_block, use_cache))
                 != OLAP_SUCCESS) {
             LOG(WARNING) << "fail to load segment. [path='" << path << "']";
             

--- a/be/src/olap/rowset/segment_group.h
+++ b/be/src/olap/rowset/segment_group.h
@@ -60,7 +60,7 @@ public:
     virtual ~SegmentGroup();
 
     // Load the index into memory.
-    OLAPStatus load();
+    OLAPStatus load(bool use_cache = true);
     bool index_loaded();
     OLAPStatus load_pb(const char* file, uint32_t seg_id);
 

--- a/be/src/olap/snapshot_manager.cpp
+++ b/be/src/olap/snapshot_manager.cpp
@@ -241,7 +241,10 @@ OLAPStatus SnapshotManager::_rename_rowset_id(const RowsetMetaPB& rs_meta_pb, co
     alpha_rowset_meta->init_from_pb(rs_meta_pb);
     RowsetSharedPtr org_rowset(new AlphaRowset(&tablet_schema, new_path, &data_dir, alpha_rowset_meta));
     RETURN_NOT_OK(org_rowset->init());
-    RETURN_NOT_OK(org_rowset->load());
+    // do not use cache to load index
+    // because the index file may conflict
+    // and the cached fd may be invalid
+    RETURN_NOT_OK(org_rowset->load(false));
     RowsetMetaSharedPtr org_rowset_meta = org_rowset->rowset_meta();
     RowsetWriterContext context;
     context.rowset_id = rowset_id;
@@ -268,10 +271,6 @@ OLAPStatus SnapshotManager::_rename_rowset_id(const RowsetMetaPB& rs_meta_pb, co
                      << " to rowset " << rowset_id;
         return res;
     }
-    // Add log to trace rowset validation failure problem
-    // This log will be deleted in the future
-    AlphaRowsetSharedPtr org_alpha_rowset = std::dynamic_pointer_cast<AlphaRowset>(org_rowset);
-    LOG(INFO) << "original rowset path:" << org_alpha_rowset->rowset_path();
     RowsetSharedPtr new_rowset = rs_writer->build();
     if (new_rowset == nullptr) {
         LOG(WARNING) << "failed to build rowset when rename rowset id";


### PR DESCRIPTION
The reason for validate failure is the cloned file's names
may conflict and load segment read file througth cache and
cache key is file name, so index may read wrong file. The
solution is load index without use file handle cache.