### PR TITLE
Fix the null pointer exception when ReplayOnAborted of txn in broker load

### DIFF
--- a/fe/src/main/java/org/apache/doris/load/loadv2/BrokerLoadJob.java
+++ b/fe/src/main/java/org/apache/doris/load/loadv2/BrokerLoadJob.java
@@ -414,6 +414,12 @@ public class BrokerLoadJob extends LoadJob {
 
     @Override
     protected void executeReplayOnAborted(TransactionState txnState) {
+        if (txnState.getTxnCommitAttachment() == null) {
+            // The txn attachment maybe null when broker load has been cancelled without attachment.
+            // The end log of broker load has been record but the callback id of txnState hasn't been removed
+            // So the callback of txn is executed when log of txn aborted is replayed.
+            return;
+        }
         unprotectReadEndOperation((LoadJobFinalOperation) txnState.getTxnCommitAttachment());
     }
 


### PR DESCRIPTION
The txn attachment maybe null when broker load has been cancelled without attachment.
The end log of broker load has been record but the callback id of txnState hasn't been removed
So the callback of txn is executed when log of txn aborted is replayed.