### PR TITLE
Fix bugs of Broker load

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -259,6 +259,7 @@ namespace config {
     CONF_Int64(load_data_reserve_hours, "4");
     // log error log will be removed after this time
     CONF_Int64(load_error_log_reserve_hours, "48");
+    // Deprecated, use streaming_load_max_mb instead
     CONF_Int64(mini_load_max_mb, "2048");
     CONF_Int32(number_tablet_writer_threads, "16");
 
@@ -266,11 +267,11 @@ namespace config {
     // the alive time of a TabletsChannel.
     // If the channel does not receive any data till this time,
     // the channel will be removed.
-    CONF_Int32(streaming_load_rpc_max_alive_time_sec, "600");
+    CONF_Int32(streaming_load_rpc_max_alive_time_sec, "1200");
     // the timeout of a rpc to process one batch in tablet writer.
     // you may need to increase this timeout if using larger 'streaming_load_max_mb',
     // or encounter 'tablet writer write failed' error when loading.
-    CONF_Int32(tablet_writer_rpc_timeout_sec, "180");
+    CONF_Int32(tablet_writer_rpc_timeout_sec, "600");
 
     // Fragment thread pool
     CONF_Int32(fragment_pool_thread_num, "64");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -263,7 +263,14 @@ namespace config {
     CONF_Int32(number_tablet_writer_threads, "16");
 
     CONF_Int64(streaming_load_max_mb, "10240");
+    // the alive time of a TabletsChannel.
+    // If the channel does not receive any data till this time,
+    // the channel will be removed.
     CONF_Int32(streaming_load_rpc_max_alive_time_sec, "600");
+    // the timeout of a rpc to process one batch in tablet writer.
+    // you may need to increase this timeout if using larger 'streaming_load_max_mb',
+    // or encounter 'tablet writer write failed' error when loading.
+    CONF_Int32(tablet_writer_rpc_timeout_sec, "180");
 
     // Fragment thread pool
     CONF_Int32(fragment_pool_thread_num, "64");

--- a/be/src/exec/tablet_sink.cpp
+++ b/be/src/exec/tablet_sink.cpp
@@ -78,6 +78,7 @@ Status NodeChannel::init(RuntimeState* state) {
     _add_batch_request.set_index_id(_index_id);
     _add_batch_request.set_sender_id(_parent->_sender_id);
 
+    _rpc_timeout_ms = config::tablet_writer_rpc_timeout_sec * 1000;
     return Status::OK();
 }
 

--- a/be/src/exec/tablet_sink.cpp
+++ b/be/src/exec/tablet_sink.cpp
@@ -209,7 +209,7 @@ Status NodeChannel::_wait_in_flight_packet() {
     }
 
     if (_add_batch_closure->result.has_execution_time_us()) {
-        _parent->increase_node_add_batch_time_us(_node_id,
+        _parent->update_node_add_batch_counter(_node_id,
                 _add_batch_closure->result.execution_time_us(),
                 _add_batch_closure->result.wait_lock_time_us());
     }
@@ -624,10 +624,10 @@ Status OlapTableSink::close(RuntimeState* state, Status close_status) {
         std::stringstream ss;
         ss << "finished to close olap table sink. load_id=" << print_id(_load_id)
                 << ", txn_id=" << _txn_id << ", node add batch time(ms)/wait lock time(ms)/num: ";
-        for (auto const& pair: _node_add_batch_time_map) {
-            ss << "{" << pair.first << ":(" << (pair.second / 1000) << ")("
-               << (_node_add_batch_wait_time_map[pair.first] / 1000) << ")("
-               << _node_add_batch_num_map[pair.first] << ")} ";
+        for (auto const& pair : _node_add_batch_counter_map) {
+            ss << "{" << pair.first << ":(" << (pair.second.add_batch_execution_time_ns / 1000) << ")("
+               << (pair.second.add_batch_wait_lock_time_ns / 1000) << ")("
+               << pair.second.add_batch_num << ")} ";
         }
         LOG(INFO) << ss.str();
 

--- a/be/src/exec/tablet_sink.cpp
+++ b/be/src/exec/tablet_sink.cpp
@@ -621,9 +621,9 @@ Status OlapTableSink::close(RuntimeState* state, Status close_status) {
         // print log of add batch time of all node, for tracing load performance easily
         std::stringstream ss;
         ss << "finished to close olap table sink. load_id=" << print_id(_load_id)
-                << ", txn_id=" << _txn_id << ", node add batch time(ns): ";
+                << ", txn_id=" << _txn_id << ", node add batch time(ns) and num: ";
         for (auto const& pair: _node_add_batch_time_map) {
-            ss << "{" << pair.first << "=" << pair.second << "}";
+            ss << "{" << pair.first << "=" << pair.second << "(" << _node_add_batch_num_map[pair.first] << ")}";
         }
         LOG(INFO) << ss.str();
 

--- a/be/src/exec/tablet_sink.cpp
+++ b/be/src/exec/tablet_sink.cpp
@@ -625,9 +625,9 @@ Status OlapTableSink::close(RuntimeState* state, Status close_status) {
         ss << "finished to close olap table sink. load_id=" << print_id(_load_id)
                 << ", txn_id=" << _txn_id << ", node add batch time(ms)/wait lock time(ms)/num: ";
         for (auto const& pair: _node_add_batch_time_map) {
-            ss << "{" << pair.first << "=" << (pair.second / 1000) << "("
-               << (_node_add_batch_wait_time_ns[pair.first] / 1000) << ")(";
-               << _node_add_batch_num_map[pair.first] << ")}";
+            ss << "{" << pair.first << ":(" << (pair.second / 1000) << ")("
+               << (_node_add_batch_wait_time_map[pair.first] / 1000) << ")("
+               << _node_add_batch_num_map[pair.first] << ")} ";
         }
         LOG(INFO) << ss.str();
 

--- a/be/src/exec/tablet_sink.h
+++ b/be/src/exec/tablet_sink.h
@@ -175,6 +175,7 @@ public:
     int64_t* mutable_serialize_batch_ns() { return &_serialize_batch_ns; }
     void increase_node_add_batch_time_us(int64_t be_id, int64_t time_ns) {
         _node_add_batch_time_map[be_id] += time_ns;
+        _node_add_batch_num_map[be_id] += 1;
     }
 
 private:
@@ -264,6 +265,7 @@ private:
 
     // BE id -> execution time of add batch in us
     std::unordered_map<int64_t, int64_t> _node_add_batch_time_map;
+    std::unordered_map<int64_t, int64_t> _node_add_batch_num_map;
 };
 
 }

--- a/be/src/exec/tablet_sink.h
+++ b/be/src/exec/tablet_sink.h
@@ -174,7 +174,7 @@ public:
     int64_t* mutable_wait_in_flight_packet_ns() { return &_wait_in_flight_packet_ns; }
     int64_t* mutable_serialize_batch_ns() { return &_serialize_batch_ns; }
     void increase_node_add_batch_time_us(int64_t be_id, int64_t add_batch_time_ns, int64_t wait_lock_time_ns) {
-        _node_add_batch_time_map[be_id] += time_ns;
+        _node_add_batch_time_map[be_id] += add_batch_time_ns;
         _node_add_batch_wait_time_map[be_id] += wait_lock_time_ns;
         _node_add_batch_num_map[be_id] += 1;
     }

--- a/be/src/exec/tablet_sink.h
+++ b/be/src/exec/tablet_sink.h
@@ -97,7 +97,8 @@ private:
 
     bool _already_failed = false;
     bool _has_in_flight_packet = false;
-    int _rpc_timeout_ms = 50000;
+    // this should be set in init() using config
+    int _rpc_timeout_ms = 0;
     int64_t _next_packet_seq = 0;
 
     std::unique_ptr<RowBatch> _batch;

--- a/be/src/exec/tablet_sink.h
+++ b/be/src/exec/tablet_sink.h
@@ -173,8 +173,9 @@ public:
     // at a time can modify them.
     int64_t* mutable_wait_in_flight_packet_ns() { return &_wait_in_flight_packet_ns; }
     int64_t* mutable_serialize_batch_ns() { return &_serialize_batch_ns; }
-    void increase_node_add_batch_time_us(int64_t be_id, int64_t time_ns) {
+    void increase_node_add_batch_time_us(int64_t be_id, int64_t add_batch_time_ns, int64_t wait_lock_time_ns) {
         _node_add_batch_time_map[be_id] += time_ns;
+        _node_add_batch_wait_time_map[be_id] += wait_lock_time_ns;
         _node_add_batch_num_map[be_id] += 1;
     }
 
@@ -265,6 +266,7 @@ private:
 
     // BE id -> execution time of add batch in us
     std::unordered_map<int64_t, int64_t> _node_add_batch_time_map;
+    std::unordered_map<int64_t, int64_t> _node_add_batch_wait_time_map;
     std::unordered_map<int64_t, int64_t> _node_add_batch_num_map;
 };
 

--- a/be/src/exec/tablet_sink.h
+++ b/be/src/exec/tablet_sink.h
@@ -193,7 +193,7 @@ public:
         AddBatchCounter& counter = _node_add_batch_counter_map[be_id];
         counter.add_batch_execution_time_ns += add_batch_time_ns;
         counter.add_batch_wait_lock_time_ns += wait_lock_time_ns;
-        counter._node_add_batch_num_map += 1;
+        counter.add_batch_num += 1;
     }
 
 private:

--- a/be/src/http/action/mini_load.cpp
+++ b/be/src/http/action/mini_load.cpp
@@ -397,7 +397,7 @@ bool MiniLoadAction::_is_streaming(HttpRequest* req) {
 
 Status MiniLoadAction::_on_header(HttpRequest* req) {
     size_t body_bytes = 0;
-    size_t max_body_bytes = config::mini_load_max_mb * 1024 * 1024;
+    size_t max_body_bytes = config::streaming_load_max_mb * 1024 * 1024;
     if (!req->header(HttpHeaders::CONTENT_LENGTH).empty()) {
         body_bytes = std::stol(req->header(HttpHeaders::CONTENT_LENGTH));
         if (body_bytes > max_body_bytes) {
@@ -733,7 +733,7 @@ Status MiniLoadAction::_process_put(HttpRequest* req, StreamLoadContext* ctx) {
 // new on_header of mini load
 Status MiniLoadAction::_on_new_header(HttpRequest* req) {
     size_t body_bytes = 0;
-    size_t max_body_bytes = config::mini_load_max_mb * 1024 * 1024;
+    size_t max_body_bytes = config::streaming_load_max_mb * 1024 * 1024;
     if (!req->header(HttpHeaders::CONTENT_LENGTH).empty()) {
         body_bytes = std::stol(req->header(HttpHeaders::CONTENT_LENGTH));
         if (body_bytes > max_body_bytes) {

--- a/be/src/runtime/plan_fragment_executor.cpp
+++ b/be/src/runtime/plan_fragment_executor.cpp
@@ -448,7 +448,7 @@ void PlanFragmentExecutor::send_report(bool done) {
     // no need to report it.
     // This is case for the case that the load plan's _is_report_success is always true,
     // but we only need the last report when plan is done.
-    if (_runtime_state.query_options().query_type == TQueryType::LOAD && !done && status.ok()) {
+    if (_runtime_state->query_options().query_type == TQueryType::LOAD && !done && status.ok()) {
         return;
     }
 

--- a/be/src/runtime/plan_fragment_executor.cpp
+++ b/be/src/runtime/plan_fragment_executor.cpp
@@ -430,11 +430,25 @@ void PlanFragmentExecutor::send_report(bool done) {
         status = _status;
     }
 
+    // If plan is done successfully, but _is_report_success is false,
+    // no need to send report.
     if (!_is_report_success && done && status.ok()) {
         return;
     }
 
+    // If both _is_report_success and _is_report_on_cancel are false,
+    // which means no matter query is success or failed, no report is needed.
+    // This may happen when the query limit reached and
+    // a internal cancellation being processed
     if (!_is_report_success && !_is_report_on_cancel) {
+        return;
+    }
+
+    // If this is a load plan, and it is not finished, and it still running ok,
+    // no need to report it.
+    // This is case for the case that the load plan's _is_report_success is always true,
+    // but we only need the last report when plan is done.
+    if (_runtime_state.query_options().query_type == TQueryType::LOAD && !done && status.ok()) {
         return;
     }
 

--- a/be/src/runtime/tablet_writer_mgr.cpp
+++ b/be/src/runtime/tablet_writer_mgr.cpp
@@ -283,6 +283,7 @@ Status TabletWriterMgr::add_batch(
     std::shared_ptr<TabletsChannel> channel;
     {
         MonotonicStopWatch timer;
+        timer.start();
         std::lock_guard<std::mutex> l(_lock);
         *wait_lock_time_ns += timer.elapsed_time();
         auto value = _tablets_channels.seek(key);
@@ -313,6 +314,7 @@ Status TabletWriterMgr::add_batch(
         }
         if (finished) {
             MonotonicStopWatch timer;
+            timer.start();
             std::lock_guard<std::mutex> l(_lock);
             *wait_lock_time_ns += timer.elapsed_time();
             _tablets_channels.erase(key);

--- a/be/src/runtime/tablet_writer_mgr.cpp
+++ b/be/src/runtime/tablet_writer_mgr.cpp
@@ -174,7 +174,7 @@ Status TabletsChannel::close(int sender_id, bool* finished,
         *finished = (_num_remaining_senders == 0);
         return _close_status;
     }
-    LOG(INFO) << "close tablets channel: " << _key;
+    LOG(INFO) << "close tablets channel: " << _key << ", sender id: " << sender_id;
     for (auto pid : partition_ids) {
         _partition_ids.emplace(pid);
     }

--- a/be/src/runtime/tablet_writer_mgr.h
+++ b/be/src/runtime/tablet_writer_mgr.h
@@ -76,7 +76,8 @@ public:
     // this batch must belong to a index in one transaction
     // when batch.
     Status add_batch(const PTabletWriterAddBatchRequest& request,
-                     google::protobuf::RepeatedPtrField<PTabletInfo>* tablet_vec);
+                     google::protobuf::RepeatedPtrField<PTabletInfo>* tablet_vec,
+                     int64_t* wait_lock_time_ns);
 
     // cancel all tablet stream for 'load_id' load
     // id: stream load's id

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -103,9 +103,10 @@ void PInternalServiceImpl<T>::tablet_writer_add_batch(google::protobuf::RpcContr
         [request, response, done, this] () {
             brpc::ClosureGuard closure_guard(done);
             int64_t execution_time_ns = 0;
+            int64_t wait_lock_time_ns = 0;
             { 
                 SCOPED_RAW_TIMER(&execution_time_ns);
-                auto st = _exec_env->tablet_writer_mgr()->add_batch(*request, response->mutable_tablet_vec());
+                auto st = _exec_env->tablet_writer_mgr()->add_batch(*request, response->mutable_tablet_vec(), &wait_lock_time_ns);
                 if (!st.ok()) {
                     LOG(WARNING) << "tablet writer add batch failed, message=" << st.get_error_msg()
                         << ", id=" << request->id()
@@ -115,6 +116,7 @@ void PInternalServiceImpl<T>::tablet_writer_add_batch(google::protobuf::RpcContr
                 st.to_protobuf(response->mutable_status());
             }
             response->set_execution_time_us(execution_time_ns / 1000);
+            response->set_wait_lock_time_us(wait_lock_time_ns / 1000);
         });
 }
 

--- a/be/test/exec/tablet_sink_test.cpp
+++ b/be/test/exec/tablet_sink_test.cpp
@@ -21,6 +21,7 @@
 
 #include "gen_cpp/HeartbeatService_types.h"
 #include "gen_cpp/internal_service.pb.h"
+#include "common/config.h"
 #include "runtime/decimal_value.h"
 #include "runtime/exec_env.h"
 #include "runtime/row_batch.h"
@@ -49,6 +50,8 @@ public:
         _env._master_info = new TMasterInfo();
         _env._load_stream_mgr = new LoadStreamMgr();
         _env._brpc_stub_cache = new BrpcStubCache();
+
+        config::tablet_writer_rpc_timeout_sec = 600;
     }
     void TearDown() override {
         delete _env._brpc_stub_cache;

--- a/be/test/exec/tablet_sink_test.cpp
+++ b/be/test/exec/tablet_sink_test.cpp
@@ -935,6 +935,11 @@ TEST_F(OlapTableSinkTest, decimal) {
 }
 
 int main(int argc, char* argv[]) {
+    std::string conffile = std::string(getenv("DORIS_HOME")) + "/conf/be.conf";
+    if (!doris::config::init(conffile.c_str(), false)) {
+        fprintf(stderr, "error read config file. \n");
+        return -1;
+    }
     doris::CpuInfo::init();
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();

--- a/be/test/exec/tablet_sink_test.cpp
+++ b/be/test/exec/tablet_sink_test.cpp
@@ -938,11 +938,6 @@ TEST_F(OlapTableSinkTest, decimal) {
 }
 
 int main(int argc, char* argv[]) {
-    std::string conffile = std::string(getenv("DORIS_HOME")) + "/conf/be.conf";
-    if (!doris::config::init(conffile.c_str(), false)) {
-        fprintf(stderr, "error read config file. \n");
-        return -1;
-    }
     doris::CpuInfo::init();
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();

--- a/fe/src/main/java/org/apache/doris/load/loadv2/BrokerLoadJob.java
+++ b/fe/src/main/java/org/apache/doris/load/loadv2/BrokerLoadJob.java
@@ -221,7 +221,7 @@ public class BrokerLoadJob extends LoadJob {
                 return;
             }
             if (loadTask.getRetryTime() <= 0) {
-                executeCancel(failMsg, true);
+                unprotectedExecuteCancel(failMsg, true);
             } else {
                 // retry task
                 idToTasks.remove(loadTask.getSignature());

--- a/fe/src/main/java/org/apache/doris/load/loadv2/BrokerLoadJob.java
+++ b/fe/src/main/java/org/apache/doris/load/loadv2/BrokerLoadJob.java
@@ -39,6 +39,7 @@ import org.apache.doris.load.EtlJobType;
 import org.apache.doris.load.FailMsg;
 import org.apache.doris.load.PullLoadSourceInfo;
 import org.apache.doris.service.FrontendOptions;
+import org.apache.doris.thrift.TUniqueId;
 import org.apache.doris.transaction.BeginTransactionException;
 import org.apache.doris.transaction.TabletCommitInfo;
 import org.apache.doris.transaction.TransactionState;
@@ -56,6 +57,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 
 /**
  * There are 3 steps in BrokerLoadJob: BrokerPendingTask, LoadLoadingTask, CommitAndPublishTxn.
@@ -304,7 +306,9 @@ public class BrokerLoadJob extends LoadJob {
                 LoadLoadingTask task = new LoadLoadingTask(db, table, brokerDesc,
                                                            entry.getValue(), getDeadlineMs(), execMemLimit,
                                                            strictMode, transactionId, this);
-                task.init(attachment.getFileStatusByTable(tableId),
+                UUID uuid = UUID.randomUUID();
+                TUniqueId loadId = new TUniqueId(uuid.getMostSignificantBits(), uuid.getLeastSignificantBits());
+                task.init(loadId, attachment.getFileStatusByTable(tableId),
                           attachment.getFileNumByTable(tableId));
                 // Add tasks into list and pool
                 idToTasks.put(task.getSignature(), task);

--- a/fe/src/main/java/org/apache/doris/load/loadv2/BrokerLoadPendingTask.java
+++ b/fe/src/main/java/org/apache/doris/load/loadv2/BrokerLoadPendingTask.java
@@ -84,8 +84,8 @@ public class BrokerLoadPendingTask extends LoadTask {
                 }
                 totalFileSize += groupFileSize;
                 totalFileNum += fileStatuses.size();
-                LOG.info("get {} files to in file group {}. size: {}. job: {}",
-                        fileStatuses.size(), groupNum, groupFileSize, callback.getCallbackId());
+                LOG.info("get {} files in file group {} for table {}. size: {}. job: {}",
+                        fileStatuses.size(), groupNum, entry.getKey(), groupFileSize, callback.getCallbackId());
                 groupNum++;
             }
 

--- a/fe/src/main/java/org/apache/doris/load/loadv2/BrokerLoadPendingTask.java
+++ b/fe/src/main/java/org/apache/doris/load/loadv2/BrokerLoadPendingTask.java
@@ -65,24 +65,31 @@ public class BrokerLoadPendingTask extends LoadTask {
 
             List<List<TBrokerFileStatus>> fileStatusList = Lists.newArrayList();
             List<BrokerFileGroup> fileGroups = entry.getValue();
+            long totalFileSize = 0;
+            int totalFileNum = 0;
             for (BrokerFileGroup fileGroup : fileGroups) {
+                long groupFileSize = 0;
                 List<TBrokerFileStatus> fileStatuses = Lists.newArrayList();
                 for (String path : fileGroup.getFilePaths()) {
                     BrokerUtil.parseBrokerFile(path, brokerDesc, fileStatuses);
                 }
                 fileStatusList.add(fileStatuses);
-                if (LOG.isDebugEnabled()) {
-                    for (TBrokerFileStatus fstatus : fileStatuses) {
+                for (TBrokerFileStatus fstatus : fileStatuses) {
+                    groupFileSize += fstatus.getSize();
+                    if (LOG.isDebugEnabled()) {
                         LOG.debug(new LogBuilder(LogKey.LOAD_JOB, callback.getCallbackId())
-                                          .add("file_status", fstatus)
-                                          .build());
+                                .add("file_status", fstatus).build());
                     }
                 }
+                totalFileSize += groupFileSize;
+                totalFileNum += fileStatuses.size();
+                LOG.info("get {} files to in one group. size: {} job: {}",
+                        fileStatuses.size(), groupFileSize, callback.getCallbackId());
             }
 
             ((BrokerPendingTaskAttachment) attachment).addFileStatus(tableId, fileStatusList);
-            LOG.info("get {} files to be loaded. cost: {} ms, job: {}",
-                    fileStatusList.size(), (System.currentTimeMillis() - start), callback.getCallbackId());
+            LOG.info("get {} files to be loaded. total size: {}. cost: {} ms, job: {}",
+                    totalFileNum, totalFileSize, (System.currentTimeMillis() - start), callback.getCallbackId());
         }
     }
 }

--- a/fe/src/main/java/org/apache/doris/load/loadv2/BrokerLoadPendingTask.java
+++ b/fe/src/main/java/org/apache/doris/load/loadv2/BrokerLoadPendingTask.java
@@ -67,6 +67,7 @@ public class BrokerLoadPendingTask extends LoadTask {
             List<BrokerFileGroup> fileGroups = entry.getValue();
             long totalFileSize = 0;
             int totalFileNum = 0;
+            int groupNum = 0;
             for (BrokerFileGroup fileGroup : fileGroups) {
                 long groupFileSize = 0;
                 List<TBrokerFileStatus> fileStatuses = Lists.newArrayList();
@@ -83,8 +84,9 @@ public class BrokerLoadPendingTask extends LoadTask {
                 }
                 totalFileSize += groupFileSize;
                 totalFileNum += fileStatuses.size();
-                LOG.info("get {} files to in one group. size: {} job: {}",
-                        fileStatuses.size(), groupFileSize, callback.getCallbackId());
+                LOG.info("get {} files to in file group {}. size: {}. job: {}",
+                        fileStatuses.size(), groupNum, groupFileSize, callback.getCallbackId());
+                groupNum++;
             }
 
             ((BrokerPendingTaskAttachment) attachment).addFileStatus(tableId, fileStatusList);

--- a/fe/src/main/java/org/apache/doris/load/loadv2/LoadJob.java
+++ b/fe/src/main/java/org/apache/doris/load/loadv2/LoadJob.java
@@ -48,6 +48,7 @@ import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.Coordinator;
 import org.apache.doris.qe.QeProcessorImpl;
 import org.apache.doris.thrift.TEtlState;
+import org.apache.doris.thrift.TUniqueId;
 import org.apache.doris.transaction.AbstractTxnStateChangeCallback;
 import org.apache.doris.transaction.BeginTransactionException;
 import org.apache.doris.transaction.TransactionException;
@@ -308,7 +309,7 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
             if (isCompleted() || getDeadlineMs() >= System.currentTimeMillis() || isCommitting) {
                 return;
             }
-            executeCancel(new FailMsg(FailMsg.CancelType.TIMEOUT, "loading timeout to cancel"), true);
+            unprotectedExecuteCancel(new FailMsg(FailMsg.CancelType.TIMEOUT, "loading timeout to cancel"), true);
         } finally {
             writeUnlock();
         }
@@ -354,7 +355,7 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
     public void cancelJobWithoutCheck(FailMsg failMsg, boolean abortTxn) {
         writeLock();
         try {
-            executeCancel(failMsg, abortTxn);
+            unprotectedExecuteCancel(failMsg, abortTxn);
         } finally {
             writeUnlock();
         }
@@ -383,7 +384,7 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
             }
 
             checkAuth("CANCEL LOAD");
-            executeCancel(failMsg, true);
+            unprotectedExecuteCancel(failMsg, true);
         } finally {
             writeUnlock();
         }
@@ -447,7 +448,7 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
      * @param failMsg
      * @param abortTxn true: abort txn when cancel job, false: only change the state of job and ignore abort txn
      */
-    protected void executeCancel(FailMsg failMsg, boolean abortTxn) {
+    protected void unprotectedExecuteCancel(FailMsg failMsg, boolean abortTxn) {
         LOG.warn(new LogBuilder(LogKey.LOAD_JOB, id)
                          .add("transaction_id", transactionId)
                          .add("error_msg", "Failed to execute load with error " + failMsg.getMsg())
@@ -456,9 +457,13 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
         // clean the loadingStatus
         loadingStatus.setState(TEtlState.CANCELLED);
 
-        // tasks will not be removed from task pool.
-        // it will be aborted on the stage of onTaskFinished or onTaskFailed.
-        idToTasks.clear();
+        // get load ids of all loading tasks, we will cancel their coordinator process later
+        List<TUniqueId> loadIds = Lists.newArrayList();
+        for (LoadTask loadTask : idToTasks.values()) {
+            if (loadTask instanceof LoadLoadingTask ) {
+                loadIds.add(((LoadLoadingTask)loadTask).getLoadId());
+            }
+        }
 
         // set failMsg and state
         this.failMsg = failMsg;
@@ -482,7 +487,13 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
             }
         }
         
-        Coordinator coordinator = QeProcessorImpl.INSTANCE.getQ
+        // cancel all running coordinators, so that the scheduler's worker thread will be released
+        for (TUniqueId loadId : loadIds) {
+            Coordinator coordinator = QeProcessorImpl.INSTANCE.getCoordinator(loadId);
+            if (coordinator != null) {
+                coordinator.cancel();
+            }
+        }
 
         // change state
         state = JobState.CANCELLED;
@@ -686,7 +697,7 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
             // record attachment in load job
             executeAfterAborted(txnState);
             // cancel load job
-            executeCancel(new FailMsg(FailMsg.CancelType.LOAD_RUN_FAIL, txnStatusChangeReason), false);
+            unprotectedExecuteCancel(new FailMsg(FailMsg.CancelType.LOAD_RUN_FAIL, txnStatusChangeReason), false);
         } finally {
             writeUnlock();
         }

--- a/fe/src/main/java/org/apache/doris/load/loadv2/LoadJob.java
+++ b/fe/src/main/java/org/apache/doris/load/loadv2/LoadJob.java
@@ -464,6 +464,7 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
                 loadIds.add(((LoadLoadingTask)loadTask).getLoadId());
             }
         }
+        idToTasks.clear();
 
         // set failMsg and state
         this.failMsg = failMsg;

--- a/fe/src/main/java/org/apache/doris/load/loadv2/LoadJob.java
+++ b/fe/src/main/java/org/apache/doris/load/loadv2/LoadJob.java
@@ -45,6 +45,8 @@ import org.apache.doris.metric.MetricRepo;
 import org.apache.doris.mysql.privilege.PaloPrivilege;
 import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.qe.Coordinator;
+import org.apache.doris.qe.QeProcessorImpl;
 import org.apache.doris.thrift.TEtlState;
 import org.apache.doris.transaction.AbstractTxnStateChangeCallback;
 import org.apache.doris.transaction.BeginTransactionException;
@@ -479,6 +481,8 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
                                  .build());
             }
         }
+        
+        Coordinator coordinator = QeProcessorImpl.INSTANCE.getQ
 
         // change state
         state = JobState.CANCELLED;

--- a/fe/src/main/java/org/apache/doris/load/loadv2/LoadLoadingTask.java
+++ b/fe/src/main/java/org/apache/doris/load/loadv2/LoadLoadingTask.java
@@ -83,6 +83,10 @@ public class LoadLoadingTask extends LoadTask {
         planner.plan(loadId, fileStatusList, fileNum);
     }
 
+    public TUniqueId getLoadId() {
+        return loadId;
+    }
+
     @Override
     protected void executeTask() throws Exception{
         LOG.info("begin to execute loading task. load id: {} job: {}. left retry: {}",

--- a/fe/src/main/java/org/apache/doris/load/loadv2/LoadLoadingTask.java
+++ b/fe/src/main/java/org/apache/doris/load/loadv2/LoadLoadingTask.java
@@ -44,6 +44,11 @@ import java.util.UUID;
 public class LoadLoadingTask extends LoadTask {
     private static final Logger LOG = LogManager.getLogger(LoadLoadingTask.class);
 
+    /*
+     * load id is used for plan.
+     * It should be changed each time we retry this load plan
+     */
+    private TUniqueId loadId;
     private final Database db;
     private final OlapTable table;
     private final BrokerDesc brokerDesc;
@@ -69,37 +74,36 @@ public class LoadLoadingTask extends LoadTask {
         this.strictMode = strictMode;
         this.txnId = txnId;
         this.failMsg = new FailMsg(FailMsg.CancelType.LOAD_RUN_FAIL);
-        this.retryTime = 3;
+        this.retryTime = 2; // 2 times is enough
     }
 
-    public void init(List<List<TBrokerFileStatus>> fileStatusList, int fileNum) throws UserException {
+    public void init(TUniqueId loadId, List<List<TBrokerFileStatus>> fileStatusList, int fileNum) throws UserException {
+        this.loadId = loadId;
         planner = new LoadingTaskPlanner(callback.getCallbackId(), txnId, db.getId(), table, brokerDesc, fileGroups, strictMode);
-        planner.plan(fileStatusList, fileNum);
+        planner.plan(loadId, fileStatusList, fileNum);
     }
 
     @Override
     protected void executeTask() throws Exception{
-        LOG.info("begin to execute loading task. job: {}. left retry: {}", callback.getCallbackId(), retryTime);
+        LOG.info("begin to execute loading task. load id: {} job: {}. left retry: {}",
+                DebugUtil.printId(loadId), callback.getCallbackId(), retryTime);
         retryTime--;
         executeOnce();
     }
 
     private void executeOnce() throws Exception {
         // New one query id,
-        UUID uuid = UUID.randomUUID();
-        TUniqueId executeId = new TUniqueId(uuid.getMostSignificantBits(), uuid.getLeastSignificantBits());
-        Coordinator curCoordinator = new Coordinator(callback.getCallbackId(), executeId, planner.getDescTable(),
+        Coordinator curCoordinator = new Coordinator(callback.getCallbackId(), loadId, planner.getDescTable(),
                                                      planner.getFragments(), planner.getScanNodes(), db.getClusterName());
         curCoordinator.setQueryType(TQueryType.LOAD);
         curCoordinator.setExecMemoryLimit(execMemLimit);
         curCoordinator.setTimeout((int) (getLeftTimeMs() / 1000));
 
         try {
-            QeProcessorImpl.INSTANCE
-                    .registerQuery(executeId, curCoordinator);
+            QeProcessorImpl.INSTANCE.registerQuery(loadId, curCoordinator);
             actualExecute(curCoordinator);
         } finally {
-            QeProcessorImpl.INSTANCE.unregisterQuery(executeId);
+            QeProcessorImpl.INSTANCE.unregisterQuery(loadId);
         }
     }
 
@@ -134,5 +138,13 @@ public class LoadLoadingTask extends LoadTask {
 
     private long getLeftTimeMs() {
         return jobDeadlineMs - System.currentTimeMillis();
+    }
+
+    @Override
+    public void updateRetryInfo() {
+        super.updateRetryInfo();
+        UUID uuid = UUID.randomUUID();
+        this.loadId = new TUniqueId(uuid.getMostSignificantBits(), uuid.getLeastSignificantBits());
+        planner.updateLoadId(this.loadId);
     }
 }

--- a/fe/src/main/java/org/apache/doris/load/loadv2/LoadTask.java
+++ b/fe/src/main/java/org/apache/doris/load/loadv2/LoadTask.java
@@ -73,6 +73,7 @@ public abstract class LoadTask extends MasterTask {
         return retryTime;
     }
 
+    // Derived class may need to override this.
     public void updateRetryInfo() {
         this.retryTime--;
         this.signature = Catalog.getCurrentCatalog().getNextId();

--- a/fe/src/main/java/org/apache/doris/load/routineload/KafkaTaskInfo.java
+++ b/fe/src/main/java/org/apache/doris/load/routineload/KafkaTaskInfo.java
@@ -99,16 +99,11 @@ public class KafkaTaskInfo extends RoutineLoadTaskInfo {
     }
 
     private TExecPlanFragmentParams updateTExecPlanFragmentParams(RoutineLoadJob routineLoadJob) throws UserException {
+        TUniqueId loadId = new TUniqueId(id.getMostSignificantBits(), id.getLeastSignificantBits());
         // plan for each task, in case table has change(rollup or schema change)
-        TExecPlanFragmentParams tExecPlanFragmentParams = routineLoadJob.plan();
+        TExecPlanFragmentParams tExecPlanFragmentParams = routineLoadJob.plan(loadId);
         TPlanFragment tPlanFragment = tExecPlanFragmentParams.getFragment();
-        // we use task id as both query id(TPlanFragmentExecParams) and load id(olap table sink/scan range desc)
-        TUniqueId queryId = new TUniqueId(id.getMostSignificantBits(), id.getLeastSignificantBits());
-        tPlanFragment.getOutput_sink().getOlap_table_sink().setLoad_id(queryId);
         tPlanFragment.getOutput_sink().getOlap_table_sink().setTxn_id(this.txnId);
-        tExecPlanFragmentParams.getParams().setQuery_id(queryId);
-        tExecPlanFragmentParams.getParams().getPer_node_scan_ranges().values().stream()
-                .forEach(entity -> entity.get(0).getScan_range().getBroker_scan_range().getRanges().get(0).setLoad_id(queryId));
         return tExecPlanFragmentParams;
     }
 }

--- a/fe/src/main/java/org/apache/doris/load/routineload/KafkaTaskInfo.java
+++ b/fe/src/main/java/org/apache/doris/load/routineload/KafkaTaskInfo.java
@@ -85,7 +85,7 @@ public class KafkaTaskInfo extends RoutineLoadTaskInfo {
         tKafkaLoadInfo.setProperties(routineLoadJob.getConvertedCustomProperties());
         tRoutineLoadTask.setKafka_load_info(tKafkaLoadInfo);
         tRoutineLoadTask.setType(TLoadSourceType.KAFKA);
-        tRoutineLoadTask.setParams(updateTExecPlanFragmentParams(routineLoadJob));
+        tRoutineLoadTask.setParams(rePlan(routineLoadJob));
         tRoutineLoadTask.setMax_interval_s(routineLoadJob.getMaxBatchIntervalS());
         tRoutineLoadTask.setMax_batch_rows(routineLoadJob.getMaxBatchRows());
         tRoutineLoadTask.setMax_batch_size(routineLoadJob.getMaxBatchSizeBytes());
@@ -98,7 +98,7 @@ public class KafkaTaskInfo extends RoutineLoadTaskInfo {
         return gson.toJson(partitionIdToOffset);
     }
 
-    private TExecPlanFragmentParams updateTExecPlanFragmentParams(RoutineLoadJob routineLoadJob) throws UserException {
+    private TExecPlanFragmentParams rePlan(RoutineLoadJob routineLoadJob) throws UserException {
         TUniqueId loadId = new TUniqueId(id.getMostSignificantBits(), id.getLeastSignificantBits());
         // plan for each task, in case table has change(rollup or schema change)
         TExecPlanFragmentParams tExecPlanFragmentParams = routineLoadJob.plan(loadId);

--- a/fe/src/main/java/org/apache/doris/load/routineload/RoutineLoadJob.java
+++ b/fe/src/main/java/org/apache/doris/load/routineload/RoutineLoadJob.java
@@ -46,6 +46,7 @@ import org.apache.doris.persist.RoutineLoadOperation;
 import org.apache.doris.planner.StreamLoadPlanner;
 import org.apache.doris.task.StreamLoadTask;
 import org.apache.doris.thrift.TExecPlanFragmentParams;
+import org.apache.doris.thrift.TUniqueId;
 import org.apache.doris.transaction.AbstractTxnStateChangeCallback;
 import org.apache.doris.transaction.TransactionException;
 import org.apache.doris.transaction.TransactionState;
@@ -559,7 +560,7 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback impl
         planner = new StreamLoadPlanner(db, (OlapTable) db.getTable(this.tableId), streamLoadTask);
     }
 
-    public TExecPlanFragmentParams plan() throws UserException {
+    public TExecPlanFragmentParams plan(TUniqueId loadId) throws UserException {
         Preconditions.checkNotNull(planner);
         Database db = Catalog.getCurrentCatalog().getDb(dbId);
         if (db == null) {
@@ -567,7 +568,7 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback impl
         }
         db.readLock();
         try {
-            return planner.plan();
+            return planner.plan(loadId);
         } finally {
             db.readUnlock();
         }

--- a/fe/src/main/java/org/apache/doris/planner/BrokerScanNode.java
+++ b/fe/src/main/java/org/apache/doris/planner/BrokerScanNode.java
@@ -724,4 +724,5 @@ public class BrokerScanNode extends ScanNode {
         }
         return output.toString();
     }
+
 }

--- a/fe/src/main/java/org/apache/doris/planner/OlapTableSink.java
+++ b/fe/src/main/java/org/apache/doris/planner/OlapTableSink.java
@@ -118,6 +118,10 @@ public class OlapTableSink extends DataSink {
         }
     }
 
+    public void updateLoadId(TUniqueId newLoadId) {
+        tDataSink.getOlap_table_sink().setLoad_id(newLoadId);
+    }
+
     // must called after tupleDescriptor is computed
     public void finalize() throws UserException {
         TOlapTableSink tSink = tDataSink.getOlap_table_sink();

--- a/fe/src/main/java/org/apache/doris/planner/StreamLoadScanNode.java
+++ b/fe/src/main/java/org/apache/doris/planner/StreamLoadScanNode.java
@@ -17,7 +17,6 @@
 
 package org.apache.doris.planner;
 
-import org.apache.doris.catalog.AggregateType;
 import org.apache.doris.analysis.Analyzer;
 import org.apache.doris.analysis.ArithmeticExpr;
 import org.apache.doris.analysis.Expr;
@@ -30,6 +29,7 @@ import org.apache.doris.analysis.SlotDescriptor;
 import org.apache.doris.analysis.SlotRef;
 import org.apache.doris.analysis.StringLiteral;
 import org.apache.doris.analysis.TupleDescriptor;
+import org.apache.doris.catalog.AggregateType;
 import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.PrimitiveType;
 import org.apache.doris.catalog.ScalarType;
@@ -47,6 +47,7 @@ import org.apache.doris.thrift.TPlanNode;
 import org.apache.doris.thrift.TPlanNodeType;
 import org.apache.doris.thrift.TScanRange;
 import org.apache.doris.thrift.TScanRangeLocations;
+import org.apache.doris.thrift.TUniqueId;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -64,6 +65,7 @@ import java.util.Map;
 public class StreamLoadScanNode extends ScanNode {
     private static final Logger LOG = LogManager.getLogger(StreamLoadScanNode.class);
 
+    private TUniqueId loadId;
     // TODO(zc): now we use scanRange
     // input parameter
     private Table dstTable;
@@ -79,8 +81,9 @@ public class StreamLoadScanNode extends ScanNode {
 
     // used to construct for streaming loading
     public StreamLoadScanNode(
-            PlanNodeId id, TupleDescriptor tupleDesc, Table dstTable, StreamLoadTask streamLoadTask) {
+            TUniqueId loadId, PlanNodeId id, TupleDescriptor tupleDesc, Table dstTable, StreamLoadTask streamLoadTask) {
         super(id, tupleDesc, "StreamLoadScanNode");
+        this.loadId = loadId;
         this.dstTable = dstTable;
         this.streamLoadTask = streamLoadTask;
     }
@@ -103,7 +106,7 @@ public class StreamLoadScanNode extends ScanNode {
                 break;
             case FILE_STREAM:
                 rangeDesc.path = "Invalid Path";
-                rangeDesc.load_id = streamLoadTask.getId();
+                rangeDesc.load_id = loadId;
                 break;
             default:
                 throw new UserException("unsupported file type, type=" + streamLoadTask.getFileType());

--- a/fe/src/main/java/org/apache/doris/qe/Coordinator.java
+++ b/fe/src/main/java/org/apache/doris/qe/Coordinator.java
@@ -664,7 +664,7 @@ public class Coordinator {
         if (profileDoneSignal != null) {
             // count down to zero to notify all objects waiting for this
             profileDoneSignal.countDownToZero();
-            LOG.info("unfinished instance: {}", profileDoneSignal.getLeftMarks());
+            LOG.info("unfinished instance: {}", profileDoneSignal.getLeftMarks().stream().map(e->DebugUtil.printId(e.getKey())).toArray());
         }
     }
 

--- a/fe/src/main/java/org/apache/doris/qe/QeProcessor.java
+++ b/fe/src/main/java/org/apache/doris/qe/QeProcessor.java
@@ -36,4 +36,6 @@ public interface QeProcessor {
     void unregisterQuery(TUniqueId queryId);
 
     Map<String, QueryStatisticsItem> getQueryStatistics();
+
+    Coordinator getCoordinator(TUniqueId queryId);
 }

--- a/fe/src/main/java/org/apache/doris/qe/QeProcessorImpl.java
+++ b/fe/src/main/java/org/apache/doris/qe/QeProcessorImpl.java
@@ -50,6 +50,15 @@ public final class QeProcessorImpl implements QeProcessor {
     }
 
     @Override
+    public Coordinator getCoordinator(TUniqueId queryId) {
+        QueryInfo queryInfo = coordinatorMap.get(queryId);
+        if (queryInfo != null) {
+            return queryInfo.getCoord();
+        }
+        return null;
+    }
+
+    @Override
     public void registerQuery(TUniqueId queryId, Coordinator coord) throws UserException {
         registerQuery(queryId, new QueryInfo(coord));
     }

--- a/fe/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
+++ b/fe/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
@@ -810,8 +810,9 @@ public class FrontendServiceImpl implements FrontendService.Iface {
             if (!(table instanceof OlapTable)) {
                 throw new UserException("load table type is not OlapTable, type=" + table.getClass());
             }
-            StreamLoadPlanner planner = new StreamLoadPlanner(db, (OlapTable) table, StreamLoadTask.fromTStreamLoadPutRequest(request));
-            return planner.plan();
+            StreamLoadTask streamLoadTask = StreamLoadTask.fromTStreamLoadPutRequest(request);
+            StreamLoadPlanner planner = new StreamLoadPlanner(db, (OlapTable) table, streamLoadTask);
+            return planner.plan(streamLoadTask.getId());
         } finally {
             db.readUnlock();
         }

--- a/fe/src/test/java/org/apache/doris/planner/StreamLoadPlannerTest.java
+++ b/fe/src/test/java/org/apache/doris/planner/StreamLoadPlannerTest.java
@@ -75,8 +75,8 @@ public class StreamLoadPlannerTest {
         request.setLoadId(new TUniqueId(2, 3));
         request.setFileType(TFileType.FILE_STREAM);
         request.setFormatType(TFileFormatType.FORMAT_CSV_PLAIN);
-        StreamLoadPlanner planner = new StreamLoadPlanner(db, destTable,
-                                                          StreamLoadTask.fromTStreamLoadPutRequest(request));
-        planner.plan();
+        StreamLoadTask streamLoadTask = StreamLoadTask.fromTStreamLoadPutRequest(request);
+        StreamLoadPlanner planner = new StreamLoadPlanner(db, destTable, streamLoadTask);
+        planner.plan(streamLoadTask.getId());
     }
 }

--- a/fe/src/test/java/org/apache/doris/planner/StreamLoadScanNodeTest.java
+++ b/fe/src/test/java/org/apache/doris/planner/StreamLoadScanNodeTest.java
@@ -123,6 +123,13 @@ public class StreamLoadScanNodeTest {
 
         return columns;
     }
+    
+    private StreamLoadScanNode getStreamLoadScanNode(TupleDescriptor dstDesc, TStreamLoadPutRequest request)
+            throws UserException {
+        StreamLoadTask streamLoadTask = StreamLoadTask.fromTStreamLoadPutRequest(request);
+        StreamLoadScanNode scanNode = new StreamLoadScanNode(streamLoadTask.getId(), new PlanNodeId(1), dstDesc, dstTable, streamLoadTask);
+        return scanNode;
+    }
 
     @Test
     public void testNormal() throws UserException {
@@ -143,8 +150,7 @@ public class StreamLoadScanNodeTest {
         }
 
         TStreamLoadPutRequest request = getBaseRequest();
-        StreamLoadScanNode scanNode = new StreamLoadScanNode(new PlanNodeId(1), dstDesc, dstTable,
-                                                             StreamLoadTask.fromTStreamLoadPutRequest(request));
+        StreamLoadScanNode scanNode = getStreamLoadScanNode(dstDesc, request);
         new Expectations() {{
             dstTable.getBaseSchema(); result = columns;
         }};
@@ -178,8 +184,8 @@ public class StreamLoadScanNodeTest {
 
         TStreamLoadPutRequest request = getBaseRequest();
         request.setColumns("k1, k2, v1");
-        StreamLoadScanNode scanNode = new StreamLoadScanNode(new PlanNodeId(1), dstDesc, dstTable,
-                                                             StreamLoadTask.fromTStreamLoadPutRequest(request));
+        StreamLoadTask streamLoadTask = StreamLoadTask.fromTStreamLoadPutRequest(request);
+        StreamLoadScanNode scanNode = getStreamLoadScanNode(dstDesc, request);
 
         scanNode.init(analyzer);
         scanNode.finalize(analyzer);
@@ -208,8 +214,8 @@ public class StreamLoadScanNodeTest {
 
         TStreamLoadPutRequest request = getBaseRequest();
         request.setColumns("k1 k2 v1");
-        StreamLoadScanNode scanNode = new StreamLoadScanNode(new PlanNodeId(1), dstDesc, dstTable,
-                                                             StreamLoadTask.fromTStreamLoadPutRequest(request));
+        StreamLoadTask streamLoadTask = StreamLoadTask.fromTStreamLoadPutRequest(request);
+        StreamLoadScanNode scanNode = getStreamLoadScanNode(dstDesc, request);
 
         scanNode.init(analyzer);
         scanNode.finalize(analyzer);
@@ -254,9 +260,8 @@ public class StreamLoadScanNodeTest {
 
         TStreamLoadPutRequest request = getBaseRequest();
         request.setColumns("k1,k2,v1, v2=k2");
-        StreamLoadScanNode scanNode = new StreamLoadScanNode(new PlanNodeId(1), dstDesc, dstTable,
-                                                             StreamLoadTask.fromTStreamLoadPutRequest(request));
-
+        StreamLoadTask streamLoadTask = StreamLoadTask.fromTStreamLoadPutRequest(request);
+        StreamLoadScanNode scanNode = getStreamLoadScanNode(dstDesc, request);
         scanNode.init(analyzer);
         scanNode.finalize(analyzer);
         scanNode.getNodeExplainString("", TExplainLevel.NORMAL);
@@ -303,8 +308,8 @@ public class StreamLoadScanNodeTest {
         TStreamLoadPutRequest request = getBaseRequest();
         request.setFileType(TFileType.FILE_STREAM);
         request.setColumns("k1,k2, v1=hll_hash(k2)");
-        StreamLoadScanNode scanNode = new StreamLoadScanNode(new PlanNodeId(1), dstDesc, dstTable,
-                                                             StreamLoadTask.fromTStreamLoadPutRequest(request));
+        StreamLoadTask streamLoadTask = StreamLoadTask.fromTStreamLoadPutRequest(request);
+        StreamLoadScanNode scanNode = getStreamLoadScanNode(dstDesc, request);
 
         scanNode.init(analyzer);
         scanNode.finalize(analyzer);
@@ -358,8 +363,8 @@ public class StreamLoadScanNodeTest {
         TStreamLoadPutRequest request = getBaseRequest();
         request.setFileType(TFileType.FILE_LOCAL);
         request.setColumns("k1,k2, v1=hll_hash1(k2)");
-        StreamLoadScanNode scanNode = new StreamLoadScanNode(new PlanNodeId(1), dstDesc, dstTable,
-                                                             StreamLoadTask.fromTStreamLoadPutRequest(request));
+        StreamLoadTask streamLoadTask = StreamLoadTask.fromTStreamLoadPutRequest(request);
+        StreamLoadScanNode scanNode = getStreamLoadScanNode(dstDesc, request);
 
         scanNode.init(analyzer);
         scanNode.finalize(analyzer);
@@ -389,8 +394,7 @@ public class StreamLoadScanNodeTest {
         TStreamLoadPutRequest request = getBaseRequest();
         request.setFileType(TFileType.FILE_LOCAL);
         request.setColumns("k1,k2, v1=k2");
-        StreamLoadScanNode scanNode = new StreamLoadScanNode(new PlanNodeId(1), dstDesc, dstTable,
-                                                             StreamLoadTask.fromTStreamLoadPutRequest(request));
+        StreamLoadScanNode scanNode = getStreamLoadScanNode(dstDesc, request);
 
         scanNode.init(analyzer);
         scanNode.finalize(analyzer);
@@ -420,8 +424,7 @@ public class StreamLoadScanNodeTest {
         TStreamLoadPutRequest request = getBaseRequest();
         request.setFileType(TFileType.FILE_BROKER);
         request.setColumns("k1,k2,v1, v2=k2");
-        StreamLoadScanNode scanNode = new StreamLoadScanNode(new PlanNodeId(1), dstDesc, dstTable,
-                                                             StreamLoadTask.fromTStreamLoadPutRequest(request));
+        StreamLoadScanNode scanNode = getStreamLoadScanNode(dstDesc, request);
 
         scanNode.init(analyzer);
         scanNode.finalize(analyzer);
@@ -450,8 +453,7 @@ public class StreamLoadScanNodeTest {
 
         TStreamLoadPutRequest request = getBaseRequest();
         request.setColumns("k1,k2,v1, v2=k3");
-        StreamLoadScanNode scanNode = new StreamLoadScanNode(new PlanNodeId(1), dstDesc, dstTable,
-                                                             StreamLoadTask.fromTStreamLoadPutRequest(request));
+        StreamLoadScanNode scanNode = getStreamLoadScanNode(dstDesc, request);
 
         scanNode.init(analyzer);
         scanNode.finalize(analyzer);
@@ -497,8 +499,7 @@ public class StreamLoadScanNodeTest {
         TStreamLoadPutRequest request = getBaseRequest();
         request.setColumns("k1,k2,v1, v2=k1");
         request.setWhere("k1 = 1");
-        StreamLoadScanNode scanNode = new StreamLoadScanNode(new PlanNodeId(1), dstDesc, dstTable,
-                                                             StreamLoadTask.fromTStreamLoadPutRequest(request));
+        StreamLoadScanNode scanNode = getStreamLoadScanNode(dstDesc, request);
 
         scanNode.init(analyzer);
         scanNode.finalize(analyzer);
@@ -548,8 +549,9 @@ public class StreamLoadScanNodeTest {
         TStreamLoadPutRequest request = getBaseRequest();
         request.setColumns("k1,k2,v1, v2=k2");
         request.setWhere("k1   1");
-        StreamLoadScanNode scanNode = new StreamLoadScanNode(new PlanNodeId(1), dstDesc, dstTable,
-                                                             StreamLoadTask.fromTStreamLoadPutRequest(request));
+        StreamLoadTask streamLoadTask = StreamLoadTask.fromTStreamLoadPutRequest(request);
+        StreamLoadScanNode scanNode = new StreamLoadScanNode(streamLoadTask.getId(), new PlanNodeId(1), dstDesc, dstTable,
+                                                             streamLoadTask);
 
         scanNode.init(analyzer);
         scanNode.finalize(analyzer);
@@ -579,8 +581,7 @@ public class StreamLoadScanNodeTest {
         TStreamLoadPutRequest request = getBaseRequest();
         request.setColumns("k1,k2,v1, v2=k1");
         request.setWhere("k5 = 1");
-        StreamLoadScanNode scanNode = new StreamLoadScanNode(new PlanNodeId(1), dstDesc, dstTable,
-                                                             StreamLoadTask.fromTStreamLoadPutRequest(request));
+        StreamLoadScanNode scanNode = getStreamLoadScanNode(dstDesc, request);
 
         scanNode.init(analyzer);
         scanNode.finalize(analyzer);
@@ -610,8 +611,7 @@ public class StreamLoadScanNodeTest {
         TStreamLoadPutRequest request = getBaseRequest();
         request.setColumns("k1,k2,v1, v2=k1");
         request.setWhere("k1 + v2");
-        StreamLoadScanNode scanNode = new StreamLoadScanNode(new PlanNodeId(1), dstDesc, dstTable,
-                                                             StreamLoadTask.fromTStreamLoadPutRequest(request));
+        StreamLoadScanNode scanNode = getStreamLoadScanNode(dstDesc, request);
 
         scanNode.init(analyzer);
         scanNode.finalize(analyzer);

--- a/gensrc/proto/internal_service.proto
+++ b/gensrc/proto/internal_service.proto
@@ -96,6 +96,7 @@ message PTabletWriterAddBatchResult {
     required PStatus status = 1;
     repeated PTabletInfo tablet_vec = 2;
     optional int64 execution_time_us = 3;
+    optional int64 wait_lock_time_us = 4;
 };
 
 // tablet writer cancel


### PR DESCRIPTION
1. Use same UUID as query ID and load ID of a load execution plan.
Each load execution plan has a load ID, and as a plan, there is also a query ID.
We can use same UUID as query ID and load ID, for tracing the load process more easily.

2. Change the load ID when retrying a load execution plan.
When a load execution plan retry, the load ID should be changed, otherwise BE can not
distinguish the old and new load requests.

3. Cancel the running loading task when cancelling the broker load.
When user cancel a broker load, the running loading task should also be cancelled, or
it may occupies the worker thread for a long time.

4. Remove the unnecessary query report when doing load execution plan.
Only the last query report is needed.

5. Add a new BE config `tablet_writer_rpc_timeout_sec`.
It is used for RPC of tablet sink. The default is 600 seconds. which is long enough for flushing
about 6GB data. The long timeout config will reduce the possibility of encountering `fail to send batch` error when loading.

6. Use `streaming_load_max_mb` instead of `mini_load_max_mb` in BE config.

7. Add more logs for tracing a broker load process easily.