### PR TITLE
Allow the null default in insert into stmt

### DIFF
--- a/fe/src/main/java/org/apache/doris/analysis/InsertStmt.java
+++ b/fe/src/main/java/org/apache/doris/analysis/InsertStmt.java
@@ -500,11 +500,15 @@ public class InsertStmt extends DdlStmt {
             if (exprByName.containsKey(col.getName())) {
                 resultExprs.add(exprByName.get(col.getName()));
             } else {
-                if (col.getDefaultValue() == null && col.isAllowNull()) {
+                if (col.getDefaultValue() == null) {
+                    /*
+                    The import stmt has been filtered in function checkColumnCoverage when
+                        the default value of column is null and column is not nullable.
+                    So the default value of column may simply be null when column is nullable
+                     */
+                    Preconditions.checkState(col.isAllowNull());
                     resultExprs.add(NullLiteral.create(col.getType()));
                 }
-                // Situation: column is not nullable and the default value of column is null
-                // Solution: the import stmt has been filtered in function: checkColumnCoverage
                 else {
                     resultExprs.add(checkTypeCompatibility(col, new StringLiteral(col.getDefaultValue())));
                 }

--- a/fe/src/main/java/org/apache/doris/analysis/InsertStmt.java
+++ b/fe/src/main/java/org/apache/doris/analysis/InsertStmt.java
@@ -340,7 +340,7 @@ public class InsertStmt extends DdlStmt {
             if (mentionedCols.contains(col.getName())) {
                 continue;
             }
-            if (col.getDefaultValue() == null) {
+            if (col.getDefaultValue() == null && !col.isAllowNull()) {
                 ErrorReport.reportAnalysisException(ErrorCode.ERR_COL_NOT_MENTIONED, col.getName());
             }
         }
@@ -500,7 +500,11 @@ public class InsertStmt extends DdlStmt {
             if (exprByName.containsKey(col.getName())) {
                 resultExprs.add(exprByName.get(col.getName()));
             } else {
-                resultExprs.add(checkTypeCompatibility(col, new StringLiteral(col.getDefaultValue())));
+                if (col.getDefaultValue() == null && col.isAllowNull()) {
+                    resultExprs.add(NullLiteral.create(col.getType()));
+                } else {
+                    resultExprs.add(checkTypeCompatibility(col, new StringLiteral(col.getDefaultValue())));
+                }
             }
         }
     }

--- a/fe/src/main/java/org/apache/doris/analysis/InsertStmt.java
+++ b/fe/src/main/java/org/apache/doris/analysis/InsertStmt.java
@@ -502,7 +502,10 @@ public class InsertStmt extends DdlStmt {
             } else {
                 if (col.getDefaultValue() == null && col.isAllowNull()) {
                     resultExprs.add(NullLiteral.create(col.getType()));
-                } else {
+                }
+                // Situation: column is not nullable and the default value of column is null
+                // Solution: the import stmt has been filtered in function: checkColumnCoverage
+                else {
                     resultExprs.add(checkTypeCompatibility(col, new StringLiteral(col.getDefaultValue())));
                 }
             }


### PR DESCRIPTION
The default value of null is forbidden in insert into stmt while null column has not been mentioned in stmt.
This is a bug because the unmentioned column has default value. The values should be inserted successfully although the default value is null.

So the column may simply be not assigned default value when the column is not allowed null and the default value of column is null.