### PR TITLE
 Do not get file size in Broker openReader() method

### DIFF
--- a/be/src/exec/broker_reader.cpp
+++ b/be/src/exec/broker_reader.cpp
@@ -118,9 +118,8 @@ Status BrokerReader::open() {
     // This will be removed later.
     if (response.__isset.size) {
         _file_size = response.size;
-    } else {
-        _file_size = 0;
     }
+
     _fd = response.fd;
     _is_fd_valid = true;
     return Status::OK();

--- a/be/src/exec/broker_reader.cpp
+++ b/be/src/exec/broker_reader.cpp
@@ -36,14 +36,15 @@ BrokerReader::BrokerReader(
         const std::vector<TNetworkAddress>& broker_addresses,
         const std::map<std::string, std::string>& properties,
         const std::string& path,
-        int64_t start_offset) :
+        int64_t start_offset,
+        int64_t file_size) :
             _env(env),
             _addresses(broker_addresses),
             _properties(properties),
             _path(path),
             _cur_offset(start_offset),
             _is_fd_valid(false),
-            _file_size(0),
+            _file_size(file_size),
             _addr_idx(0) {
 }
 
@@ -112,6 +113,9 @@ Status BrokerReader::open() {
         LOG(WARNING) << ss.str();
         return Status::InternalError(ss.str());
     }
+    // TODO(cmy): The file size is no longer got from openReader() method.
+    // But leave the code here for compatibility.
+    // This will be removed later.
     if (response.__isset.size) {
         _file_size = response.size;
     } else {
@@ -183,7 +187,7 @@ Status BrokerReader::readat(int64_t position, int64_t nbytes, int64_t* bytes_rea
     return Status::OK();
 }
 
-int64_t BrokerReader::size () {
+int64_t BrokerReader::file_size() {
     return _file_size;
 }
 

--- a/be/src/exec/broker_reader.cpp
+++ b/be/src/exec/broker_reader.cpp
@@ -187,7 +187,7 @@ Status BrokerReader::readat(int64_t position, int64_t nbytes, int64_t* bytes_rea
     return Status::OK();
 }
 
-int64_t BrokerReader::file_size() {
+int64_t BrokerReader::size() {
     return _file_size;
 }
 

--- a/be/src/exec/broker_reader.h
+++ b/be/src/exec/broker_reader.h
@@ -37,11 +37,14 @@ class RuntimeState;
 // Reader of broker file
 class BrokerReader : public FileReader {
 public:
+    // If the reader need the file size, set it when construct BrokerReader.
+    // There is no other way to set the file size.
     BrokerReader(ExecEnv* env,
                  const std::vector<TNetworkAddress>& broker_addresses,
                  const std::map<std::string, std::string>& properties,
                  const std::string& path,
-                 int64_t start_offset);
+                 int64_t start_offset,
+                 int64_t file_size = 0);
     virtual ~BrokerReader();
 
     virtual Status open() override;
@@ -49,7 +52,7 @@ public:
     // Read 
     virtual Status read(uint8_t* buf, size_t* buf_len, bool* eof) override;
     virtual Status readat(int64_t position, int64_t nbytes, int64_t* bytes_read, void* out) override;
-    virtual int64_t size () override;
+    virtual int64_t file_size() override;
     virtual Status seek(int64_t position) override;
     virtual Status tell(int64_t* position) override;
     virtual void close() override;

--- a/be/src/exec/broker_reader.h
+++ b/be/src/exec/broker_reader.h
@@ -52,7 +52,7 @@ public:
     // Read 
     virtual Status read(uint8_t* buf, size_t* buf_len, bool* eof) override;
     virtual Status readat(int64_t position, int64_t nbytes, int64_t* bytes_read, void* out) override;
-    virtual int64_t file_size() override;
+    virtual int64_t size() override;
     virtual Status seek(int64_t position) override;
     virtual Status tell(int64_t* position) override;
     virtual void close() override;

--- a/be/src/exec/parquet_reader.cpp
+++ b/be/src/exec/parquet_reader.cpp
@@ -471,7 +471,7 @@ arrow::Status ParquetFile::ReadAt(int64_t position, int64_t nbytes, int64_t* byt
 }
 
 arrow::Status ParquetFile::GetSize(int64_t* size) {
-    *size = _file->file_size();
+    *size = _file->size();
     return arrow::Status::OK();
 }
 

--- a/be/src/exec/parquet_reader.cpp
+++ b/be/src/exec/parquet_reader.cpp
@@ -471,7 +471,7 @@ arrow::Status ParquetFile::ReadAt(int64_t position, int64_t nbytes, int64_t* byt
 }
 
 arrow::Status ParquetFile::GetSize(int64_t* size) {
-    *size = _file->size();
+    *size = _file->file_size();
     return arrow::Status::OK();
 }
 

--- a/be/src/exec/parquet_scanner.cpp
+++ b/be/src/exec/parquet_scanner.cpp
@@ -112,8 +112,11 @@ Status ParquetScanner::open_next_reader() {
                 break;
             }
             case TFileType::FILE_BROKER: {
+                int64_t file_size = 0;
+                // for compatibility
+                if (range.__isset.file_size) { file_size = range.file_size; }
                 file_reader.reset(new BrokerReader(_state->exec_env(), _broker_addresses, _params.properties,
-                                               range.path, range.start_offset));
+                                               range.path, range.start_offset, file_size));
                 break;
             }
 #if 0
@@ -134,7 +137,7 @@ Status ParquetScanner::open_next_reader() {
             }
         }
         RETURN_IF_ERROR(file_reader->open());
-        if (file_reader->size() == 0) {
+        if (file_reader->file_size() == 0) {
             file_reader->close();
             continue;
         }

--- a/be/src/exec/parquet_scanner.cpp
+++ b/be/src/exec/parquet_scanner.cpp
@@ -137,7 +137,7 @@ Status ParquetScanner::open_next_reader() {
             }
         }
         RETURN_IF_ERROR(file_reader->open());
-        if (file_reader->file_size() == 0) {
+        if (file_reader->size() == 0) {
             file_reader->close();
             continue;
         }

--- a/fs_brokers/apache_hdfs_broker/src/main/java/org/apache/doris/broker/hdfs/BrokerException.java
+++ b/fs_brokers/apache_hdfs_broker/src/main/java/org/apache/doris/broker/hdfs/BrokerException.java
@@ -63,7 +63,7 @@ public class BrokerException extends RuntimeException {
     
     public TBrokerOperationStatus generateFailedOperationStatus() {
         TBrokerOperationStatus errorStatus = new TBrokerOperationStatus(errorCode);
-        errorStatus.setMessage(super.getMessage());
+        errorStatus.setMessage(super.getMessage() + ", cause by: " + getCause() != null ? getCause().getMessage() : "null");
         return errorStatus;
     }
 }

--- a/fs_brokers/apache_hdfs_broker/src/main/java/org/apache/doris/broker/hdfs/HDFSBrokerServiceImpl.java
+++ b/fs_brokers/apache_hdfs_broker/src/main/java/org/apache/doris/broker/hdfs/HDFSBrokerServiceImpl.java
@@ -138,16 +138,11 @@ public class HDFSBrokerServiceImpl implements TPaloBrokerService.Iface {
             TBrokerFD fd = fileSystemManager.openReader(request.clientId, request.path,
                     request.startOffset, request.properties);
             response.setFd(fd);
-            // get file size
-            List<TBrokerFileStatus> fileStatuses = fileSystemManager.listPath(request.path,
-                    false, request.properties);
-            response.setSize(fileStatuses.get(0).size);
             response.setOpStatus(generateOKStatus());
         } catch (BrokerException e) {
             logger.warn("failed to open reader for path: " + request.path, e);
             TBrokerOperationStatus errorStatus = e.generateFailedOperationStatus();
             response.setOpStatus(errorStatus);
-            response.setSize(0);
         }
         return response;
     }

--- a/gensrc/thrift/PaloBrokerService.thrift
+++ b/gensrc/thrift/PaloBrokerService.thrift
@@ -67,7 +67,7 @@ struct TBrokerListResponse {
 struct TBrokerOpenReaderResponse {
     1: required TBrokerOperationStatus opStatus;
     2: optional TBrokerFD fd;
-    3: optional i64 size; //file size
+    3: optional i64 size; // file size(Deprecated)
 }
 
 struct TBrokerReadResponse {

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -112,6 +112,8 @@ struct TBrokerRangeDesc {
     6: required i64 size
     // used to get stream for this load
     7: optional Types.TUniqueId load_id
+    // total size of the file
+    8: optional i64 file_size
 }
 
 struct TBrokerScanRangeParams {


### PR DESCRIPTION
The file is already got when listing files.
Get file size in openReader() again is unnecessary and inefficient.