### PR TITLE
Fix NullPointerException when creating mini load in LoadManager

### DIFF
--- a/fe/src/main/java/org/apache/doris/load/loadv2/LoadManager.java
+++ b/fe/src/main/java/org/apache/doris/load/loadv2/LoadManager.java
@@ -149,7 +149,9 @@ public class LoadManager implements Writable{
                     .stream().filter(entity -> entity.getState() != JobState.CANCELLED).findFirst()
                     .get().getTransactionId();
         } catch (UserException e) {
-            loadJob.cancelJobWithoutCheck(new FailMsg(LOAD_RUN_FAIL, e.getMessage()), false);
+            if (loadJob != null) {
+                loadJob.cancelJobWithoutCheck(new FailMsg(LOAD_RUN_FAIL, e.getMessage()), false);
+            }
             throw e;
         } finally {
             writeUnlock();

--- a/fe/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
+++ b/fe/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
@@ -500,6 +500,7 @@ public class FrontendServiceImpl implements FrontendService.Iface {
             }
             return result;
         } catch (UserException e) {
+            LOG.warn("catch unknown result.", e);
             status.setStatus_code(TStatusCode.ANALYSIS_ERROR);
             status.addToError_msgs(e.getMessage());
             return result;

--- a/fe/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
+++ b/fe/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
@@ -500,7 +500,6 @@ public class FrontendServiceImpl implements FrontendService.Iface {
             }
             return result;
         } catch (UserException e) {
-            LOG.warn("catch unknown result.", e);
             status.setStatus_code(TStatusCode.ANALYSIS_ERROR);
             status.addToError_msgs(e.getMessage());
             return result;


### PR DESCRIPTION
The catch statement cancel the load job in the function named createMiniLoad.
But sometimes, the load job hasn't been created in catch statement. It will throw the NullPointerException when the loadjob is cancelled.
This commit fix this bug.