### PR TITLE
Broker load hang when rpc failed

### DIFF
--- a/be/src/exec/broker_reader.cpp
+++ b/be/src/exec/broker_reader.cpp
@@ -126,6 +126,9 @@ Status BrokerReader::open() {
 }
 
 Status BrokerReader::read(uint8_t* buf, size_t* buf_len, bool* eof) {
+    if (*buf_len == 0) {
+        return Status::OK();
+    }
     RETURN_IF_ERROR(readat(_cur_offset, (int64_t)*buf_len, (int64_t*)buf_len, buf));
     if (*buf_len == 0) {
         *eof = true;

--- a/be/src/exec/broker_reader.cpp
+++ b/be/src/exec/broker_reader.cpp
@@ -126,9 +126,7 @@ Status BrokerReader::open() {
 }
 
 Status BrokerReader::read(uint8_t* buf, size_t* buf_len, bool* eof) {
-    if (*buf_len == 0) {
-        return Status::OK();
-    }
+    DCHECK_NE(*buf_len, 0);
     RETURN_IF_ERROR(readat(_cur_offset, (int64_t)*buf_len, (int64_t*)buf_len, buf));
     if (*buf_len == 0) {
         *eof = true;

--- a/be/src/exec/broker_reader.cpp
+++ b/be/src/exec/broker_reader.cpp
@@ -126,7 +126,7 @@ Status BrokerReader::open() {
 }
 
 Status BrokerReader::read(uint8_t* buf, size_t* buf_len, bool* eof) {
-    readat(_cur_offset, (int64_t)*buf_len, (int64_t*)buf_len, buf);
+    RETURN_IF_ERROR(readat(_cur_offset, (int64_t)*buf_len, (int64_t*)buf_len, buf));
     if (*buf_len == 0) {
         *eof = true;
     } else {


### PR DESCRIPTION
Broker load hang on broker reader when the thrift request between broker and be is failed.