### PR TITLE
Thrown TabletQuorumFailedException in commitTxn

### DIFF
--- a/fe/src/main/java/org/apache/doris/load/LoadChecker.java
+++ b/fe/src/main/java/org/apache/doris/load/LoadChecker.java
@@ -51,6 +51,7 @@ import org.apache.doris.thrift.TPushType;
 import org.apache.doris.thrift.TTaskType;
 import org.apache.doris.transaction.GlobalTransactionMgr;
 import org.apache.doris.transaction.TabletCommitInfo;
+import org.apache.doris.transaction.TabletQuorumFailedException;
 import org.apache.doris.transaction.TransactionState;
 import org.apache.doris.transaction.TransactionStatus;
 
@@ -333,6 +334,8 @@ public class LoadChecker extends Daemon {
                 tabletCommitInfos.add(new TabletCommitInfo(tabletId, replica.getBackendId()));
             }
             globalTransactionMgr.commitTransaction(job.getDbId(), job.getTransactionId(), tabletCommitInfos);
+        } catch (TabletQuorumFailedException e) {
+            // wait the upper application retry
         } catch (UserException e) {
             LOG.warn("errors while commit transaction [{}], cancel the job {}, reason is {}", 
                     transactionState.getTransactionId(), job, e);

--- a/fe/src/main/java/org/apache/doris/load/loadv2/BrokerLoadJob.java
+++ b/fe/src/main/java/org/apache/doris/load/loadv2/BrokerLoadJob.java
@@ -374,6 +374,10 @@ public class BrokerLoadJob extends LoadJob {
         }
         db.writeLock();
         try {
+            LOG.info(new LogBuilder(LogKey.LOAD_JOB, id)
+                             .add("txn_id", transactionId)
+                             .add("msg", "Load job try to commit txn")
+                             .build());
             Catalog.getCurrentGlobalTransactionMgr().commitTransaction(
                     dbId, transactionId, commitInfos,
                     new LoadJobFinalOperation(id, loadingStatus, progress, loadStartTimestamp,
@@ -381,7 +385,7 @@ public class BrokerLoadJob extends LoadJob {
         } catch (UserException e) {
             LOG.warn(new LogBuilder(LogKey.LOAD_JOB, id)
                              .add("database_id", dbId)
-                             .add("error_msg", "Failed to commit txn.")
+                             .add("error_msg", "Failed to commit txn with error:" + e.getMessage())
                              .build(), e);
             cancelJobWithoutCheck(new FailMsg(FailMsg.CancelType.LOAD_RUN_FAIL, e.getMessage()),true);
             return;

--- a/fe/src/main/java/org/apache/doris/transaction/GlobalTransactionMgr.java
+++ b/fe/src/main/java/org/apache/doris/transaction/GlobalTransactionMgr.java
@@ -401,9 +401,8 @@ public class GlobalTransactionMgr {
                                              + "while error backends {}",
                                      transactionId, tablet.getId(), successReplicaNum, quorumReplicaNum,
                                      Joiner.on(",").join(errorBackendIdsForTablet));
-                            throw new TabletQuorumFailedException("Tablet success replica num is less then quorum "
-                                                                          + "replica num",
-                                                                  transactionId, tablet.getId(),
+                            throw new TabletQuorumFailedException(transactionId, tablet.getId(),
+                                                                  successReplicaNum, quorumReplicaNum,
                                                                   errorBackendIdsForTablet);
                         }
                     }

--- a/fe/src/main/java/org/apache/doris/transaction/GlobalTransactionMgr.java
+++ b/fe/src/main/java/org/apache/doris/transaction/GlobalTransactionMgr.java
@@ -396,12 +396,15 @@ public class GlobalTransactionMgr {
                             }
                         }
                         if (index.getState() != IndexState.ROLLUP && successReplicaNum < quorumReplicaNum) {
-                            // not throw exception here, wait the upper application retry
-                            LOG.info("Tablet [{}] success replica num is {} < quorum replica num {} "
+                            LOG.warn("Failed to commit txn []. "
+                                             + "Tablet [{}] success replica num is {} < quorum replica num {} "
                                              + "while error backends {}",
-                                     tablet.getId(), successReplicaNum, quorumReplicaNum,
+                                     transactionId, tablet.getId(), successReplicaNum, quorumReplicaNum,
                                      Joiner.on(",").join(errorBackendIdsForTablet));
-                            return;
+                            throw new TabletQuorumFailedException("Tablet success replica num is less then quorum "
+                                                                          + "replica num",
+                                                                  transactionId, tablet.getId(),
+                                                                  errorBackendIdsForTablet);
                         }
                     }
                 }

--- a/fe/src/main/java/org/apache/doris/transaction/TabletQuorumFailedException.java
+++ b/fe/src/main/java/org/apache/doris/transaction/TabletQuorumFailedException.java
@@ -39,6 +39,6 @@ public class TabletQuorumFailedException extends TransactionException {
                             Joiner.on(",").join(errorBackendIdsForTablet)),
               transactionId);
         this.tabletId = tabletId;
-        this.errorBackendIdsForTablet=errorBackendIdsForTablet;
+        this.errorBackendIdsForTablet = errorBackendIdsForTablet;
     }
 }

--- a/fe/src/main/java/org/apache/doris/transaction/TabletQuorumFailedException.java
+++ b/fe/src/main/java/org/apache/doris/transaction/TabletQuorumFailedException.java
@@ -17,18 +17,27 @@
 
 package org.apache.doris.transaction;
 
+import com.google.common.base.Joiner;
 import com.google.common.collect.Sets;
 
 import java.util.Set;
 
 public class TabletQuorumFailedException extends TransactionException {
 
+    private static final String TABLET_QUORUM_FAILED_MSG = "Failed to commit txn %s. "
+            + "Tablet [%s] success replica num %s is less then quorum "
+            + "replica num %s while error backends %s";
+
     private long tabletId;
     private Set<Long> errorBackendIdsForTablet = Sets.newHashSet();
 
-    public TabletQuorumFailedException(String msg, long transactionId,
-                                       long tabletId, Set<Long> errorBackendIdsForTablet) {
-        super(msg, transactionId);
+    public TabletQuorumFailedException(long transactionId, long tabletId,
+                                       int successReplicaNum, int quorumReplicaNum,
+                                       Set<Long> errorBackendIdsForTablet) {
+        super(String.format(TABLET_QUORUM_FAILED_MSG, transactionId, tabletId,
+                            successReplicaNum, quorumReplicaNum,
+                            Joiner.on(",").join(errorBackendIdsForTablet)),
+              transactionId);
         this.tabletId = tabletId;
         this.errorBackendIdsForTablet=errorBackendIdsForTablet;
     }

--- a/fe/src/main/java/org/apache/doris/transaction/TabletQuorumFailedException.java
+++ b/fe/src/main/java/org/apache/doris/transaction/TabletQuorumFailedException.java
@@ -1,0 +1,35 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.transaction;
+
+import com.google.common.collect.Sets;
+
+import java.util.Set;
+
+public class TabletQuorumFailedException extends TransactionException {
+
+    private long tabletId;
+    private Set<Long> errorBackendIdsForTablet = Sets.newHashSet();
+
+    public TabletQuorumFailedException(String msg, long transactionId,
+                                       long tabletId, Set<Long> errorBackendIdsForTablet) {
+        super(msg, transactionId);
+        this.tabletId = tabletId;
+        this.errorBackendIdsForTablet=errorBackendIdsForTablet;
+    }
+}

--- a/fe/src/test/java/org/apache/doris/transaction/GlobalTransactionMgrTest.java
+++ b/fe/src/test/java/org/apache/doris/transaction/GlobalTransactionMgrTest.java
@@ -17,10 +17,7 @@
 
 package org.apache.doris.transaction;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 import org.apache.doris.catalog.Catalog;
 import org.apache.doris.catalog.CatalogTestUtil;
@@ -226,10 +223,14 @@ public class GlobalTransactionMgrTest {
         transTablets = Lists.newArrayList();
         transTablets.add(tabletCommitInfo1);
         transTablets.add(tabletCommitInfo3);
-        masterTransMgr.commitTransaction(CatalogTestUtil.testDbId1, transactionId2, transTablets);
-        transactionState = masterTransMgr.getTransactionState(transactionId2);
-        // check status is prepare, because the commit failed
-        assertEquals(TransactionStatus.PREPARE, transactionState.getTransactionStatus());
+        try {
+            masterTransMgr.commitTransaction(CatalogTestUtil.testDbId1, transactionId2, transTablets);
+            Assert.fail();
+        } catch (TabletQuorumFailedException e) {
+            transactionState = masterTransMgr.getTransactionState(transactionId2);
+            // check status is prepare, because the commit failed
+            assertEquals(TransactionStatus.PREPARE, transactionState.getTransactionStatus());
+        }
         // check replica version
         Partition testPartition = masterCatalog.getDb(CatalogTestUtil.testDbId1).getTable(CatalogTestUtil.testTableId1)
                 .getPartition(CatalogTestUtil.testPartition1);
@@ -533,10 +534,14 @@ public class GlobalTransactionMgrTest {
         transTablets = Lists.newArrayList();
         transTablets.add(tabletCommitInfo1);
         transTablets.add(tabletCommitInfo3);
-        masterTransMgr.commitTransaction(CatalogTestUtil.testDbId1, transactionId2, transTablets);
-        transactionState = masterTransMgr.getTransactionState(transactionId2);
-        // check status is prepare, because the commit failed
-        assertEquals(TransactionStatus.PREPARE, transactionState.getTransactionStatus());
+        try {
+            masterTransMgr.commitTransaction(CatalogTestUtil.testDbId1, transactionId2, transTablets);
+            Assert.fail();
+        } catch (TabletQuorumFailedException e) {
+            transactionState = masterTransMgr.getTransactionState(transactionId2);
+            // check status is prepare, because the commit failed
+            assertEquals(TransactionStatus.PREPARE, transactionState.getTransactionStatus());
+        }
 
         // commit the second transaction with 1,2,3 success
         tabletCommitInfo1 = new TabletCommitInfo(CatalogTestUtil.testTabletId1, CatalogTestUtil.testBackendId1);


### PR DESCRIPTION
The TabletQuorumFailedException will be thrown in commitTxn while the success replica num of tablet is less then quorom replica num.
The Hadoop load does not handle this exception because the push task will retry it later.
The streaming broker, insert, stream and mini load will catch this exception and abort the txn after that.