### PR TITLE
Fix bug that cluster balance may cause load job failed

### DIFF
--- a/fe/src/main/java/org/apache/doris/alter/RollupHandler.java
+++ b/fe/src/main/java/org/apache/doris/alter/RollupHandler.java
@@ -361,6 +361,7 @@ public class RollupHandler extends AlterHandler {
                     long rollupReplicaId = catalog.getNextId();
                     long backendId = baseReplica.getBackendId();
                     if (baseReplica.getState() == ReplicaState.CLONE 
+                            || baseReplica.getState() == ReplicaState.DECOMMISSION
                             || baseReplica.getLastFailedVersion() > 0) {
                         // just skip it.
                         continue;

--- a/fe/src/main/java/org/apache/doris/alter/SchemaChangeHandler.java
+++ b/fe/src/main/java/org/apache/doris/alter/SchemaChangeHandler.java
@@ -973,6 +973,7 @@ public class SchemaChangeHandler extends AlterHandler {
                     int replicaNum = 0;
                     for (Replica replica : tablet.getReplicas()) {
                         if (replica.getState() == ReplicaState.CLONE 
+                                || replica.getState() == ReplicaState.DECOMMISSION
                                 || replica.getLastFailedVersion() > 0) {
                             // just skip it (replica cloned from old schema will be deleted)
                             continue;
@@ -1052,7 +1053,9 @@ public class SchemaChangeHandler extends AlterHandler {
                 // set replica state
                 for (Tablet tablet : alterIndex.getTablets()) {
                     for (Replica replica : tablet.getReplicas()) {
-                        if (replica.getState() == ReplicaState.CLONE || replica.getLastFailedVersion() > 0) {
+                        if (replica.getState() == ReplicaState.CLONE 
+                                || replica.getState() == ReplicaState.DECOMMISSION
+                                || replica.getLastFailedVersion() > 0) {
                             // this should not happen, cause we only allow schema change when table is stable.
                             LOG.error("replica {} of tablet {} on backend {} is not NORMAL: {}",
                                     replica.getId(), tablet.getId(), replica.getBackendId(), replica);

--- a/fe/src/main/java/org/apache/doris/alter/SchemaChangeJob.java
+++ b/fe/src/main/java/org/apache/doris/alter/SchemaChangeJob.java
@@ -514,7 +514,9 @@ public class SchemaChangeJob extends AlterJob {
                     for (Tablet tablet : index.getTablets()) {
                         long tabletId = tablet.getId();
                         for (Replica replica : tablet.getReplicas()) {
-                            if (replica.getState() == ReplicaState.CLONE || replica.getState() == ReplicaState.NORMAL) {
+                            if (replica.getState() == ReplicaState.CLONE
+                                    || replica.getState() == ReplicaState.DECOMMISSION
+                                    || replica.getState() == ReplicaState.NORMAL) {
                                 continue;
                             }
                             Preconditions.checkState(replica.getState() == ReplicaState.SCHEMA_CHANGE);
@@ -918,7 +920,8 @@ public class SchemaChangeJob extends AlterJob {
                     // set state to SCHEMA_CHANGE
                     for (Tablet tablet : index.getTablets()) {
                         for (Replica replica : tablet.getReplicas()) {
-                            if (replica.getState() == ReplicaState.CLONE) {
+                            if (replica.getState() == ReplicaState.CLONE
+                                    || replica.getState() == ReplicaState.DECOMMISSION) {
                                 // add log here, because there should no more CLONE replica when processing alter jobs.
                                 LOG.warn(String.format(
                                         "replica %d of tablet %d in backend %d state is invalid: %s",
@@ -1063,7 +1066,9 @@ public class SchemaChangeJob extends AlterJob {
                     }
                     for (Tablet tablet : index.getTablets()) {
                         for (Replica replica : tablet.getReplicas()) {
-                            if (replica.getState() == ReplicaState.CLONE || replica.getState() == ReplicaState.NORMAL) {
+                            if (replica.getState() == ReplicaState.CLONE
+                                    || replica.getState() == ReplicaState.DECOMMISSION
+                                    || replica.getState() == ReplicaState.NORMAL) {
                                 continue;
                             }
                             replica.setState(ReplicaState.NORMAL);

--- a/fe/src/main/java/org/apache/doris/catalog/Replica.java
+++ b/fe/src/main/java/org/apache/doris/catalog/Replica.java
@@ -75,6 +75,16 @@ public class Replica implements Writable {
 
     private boolean bad = false;
 
+    /*
+     * If set to true, with means this replica need to be repaired. explicitly.
+     * This can happen when this replica is created by a balance clone task, and
+     * when task finished, the version of this replica is behind the partition's visible version.
+     * So this replica need a further repair.
+     * If we do not do this, this replica will be treated as version stale, and will be removed,
+     * so that the balance task is failed, which is unexpected.
+     */
+    private boolean needFurtherRepair = false;
+
     public Replica() {
     }
     
@@ -190,6 +200,14 @@ public class Replica implements Writable {
         }
         this.bad = bad;
         return true;
+    }
+
+    public boolean needFurtherRepair() {
+        return needFurtherRepair;
+    }
+
+    public void setNeedFurtherRepair(boolean needFurtherRepair) {
+        this.needFurtherRepair = needFurtherRepair;
     }
 
     // only update data size and row num

--- a/fe/src/main/java/org/apache/doris/catalog/Replica.java
+++ b/fe/src/main/java/org/apache/doris/catalog/Replica.java
@@ -37,11 +37,17 @@ public class Replica implements Writable {
     private static final Logger LOG = LogManager.getLogger(Replica.class);
     public static final VersionComparator<Replica> VERSION_DESC_COMPARATOR = new VersionComparator<Replica>();
 
+    private long watermarkTxnId = -1;
+
     public enum ReplicaState {
         NORMAL,
         ROLLUP,
         SCHEMA_CHANGE,
-        CLONE
+        CLONE;
+
+        public boolean isLoadable() {
+            return this == ReplicaState.NORMAL || this == ReplicaState.SCHEMA_CHANGE;
+        }
     }
     
     public enum ReplicaStatus {
@@ -509,5 +515,13 @@ public class Replica implements Writable {
                 return -1;
             }
         }
+    }
+
+    public void setWatermarkTxnId(long watermarkTxnId) {
+        this.watermarkTxnId = watermarkTxnId;
+    }
+
+    public long getWatermarkTxnId() {
+        return watermarkTxnId;
     }
 }

--- a/fe/src/main/java/org/apache/doris/catalog/Replica.java
+++ b/fe/src/main/java/org/apache/doris/catalog/Replica.java
@@ -37,8 +37,6 @@ public class Replica implements Writable {
     private static final Logger LOG = LogManager.getLogger(Replica.class);
     public static final VersionComparator<Replica> VERSION_DESC_COMPARATOR = new VersionComparator<Replica>();
 
-    private long watermarkTxnId = -1;
-
     public enum ReplicaState {
         NORMAL,
         ROLLUP,
@@ -96,6 +94,10 @@ public class Replica implements Writable {
     private boolean needFurtherRepair = false;
     private long furtherRepairSetTime = -1;
     private static final long FURTHER_REPAIR_TIMEOUT_MS = 20 * 60 * 1000L; // 20min
+
+    // if this watermarkTxnId is set, which means before deleting a replica,
+    // we should ensure that all txns on this replicas are finished.
+    private long watermarkTxnId = -1;
 
     public Replica() {
     }

--- a/fe/src/main/java/org/apache/doris/catalog/Replica.java
+++ b/fe/src/main/java/org/apache/doris/catalog/Replica.java
@@ -41,7 +41,8 @@ public class Replica implements Writable {
         NORMAL,
         ROLLUP,
         SCHEMA_CHANGE,
-        CLONE;
+        CLONE,
+        DECOMMISSION; // replica is ready to be deleted
 
         public boolean isLoadable() {
             return this == ReplicaState.NORMAL || this == ReplicaState.SCHEMA_CHANGE;

--- a/fe/src/main/java/org/apache/doris/catalog/Tablet.java
+++ b/fe/src/main/java/org/apache/doris/catalog/Tablet.java
@@ -73,8 +73,6 @@ public class Tablet extends MetaObject implements Writable {
     // no need to persist
     private long lastStatusCheckTime = -1;
     
-    private long watermarkTxnId = -1;
-
     public Tablet() {
         this(0L, new ArrayList<Replica>());
     }
@@ -567,13 +565,5 @@ public class Tablet extends MetaObject implements Writable {
 
     public void setLastStatusCheckTime(long lastStatusCheckTime) {
         this.lastStatusCheckTime = lastStatusCheckTime;
-    }
-
-    public void setWatermarkTxnId(long watermarkTxnId) {
-        this.watermarkTxnId = watermarkTxnId;
-    }
-
-    public long getWatermarkTxnId() {
-        return watermarkTxnId;
     }
 }

--- a/fe/src/main/java/org/apache/doris/catalog/Tablet.java
+++ b/fe/src/main/java/org/apache/doris/catalog/Tablet.java
@@ -389,6 +389,7 @@ public class Tablet extends MetaObject implements Writable {
         for (Replica replica : replicas) {
             Backend backend = systemInfoService.getBackend(replica.getBackendId());
             if (backend == null || !backend.isAlive() || replica.getState() == ReplicaState.CLONE
+                    || replica.getState() == ReplicaState.DECOMMISSION
                     || replica.isBad() || !hosts.add(backend.getHost())) {
                 // this replica is not alive,
                 // or if this replica is on same host with another replica, we also treat it as 'dead',

--- a/fe/src/main/java/org/apache/doris/catalog/Tablet.java
+++ b/fe/src/main/java/org/apache/doris/catalog/Tablet.java
@@ -49,15 +49,16 @@ public class Tablet extends MetaObject implements Writable {
     
     public enum TabletStatus {
         HEALTHY,
-        REPLICA_MISSING, // not enough alive replica num
-        VERSION_INCOMPLETE, // alive replica num is enough, but version is missing
-        REPLICA_RELOCATING, // replica is healthy, but is under relocating (eg. BE is decommission)
-        REDUNDANT, // too much replicas
-        REPLICA_MISSING_IN_CLUSTER, // not enough healthy replicas in correct cluster
+        REPLICA_MISSING, // not enough alive replica num.
+        VERSION_INCOMPLETE, // alive replica num is enough, but version is missing.
+        REPLICA_RELOCATING, // replica is healthy, but is under relocating (eg. BE is decommission).
+        REDUNDANT, // too much replicas.
+        REPLICA_MISSING_IN_CLUSTER, // not enough healthy replicas in correct cluster.
         FORCE_REDUNDANT, // some replica is missing or bad, but there is no other backends for repair,
                          // at least one replica has to be deleted first to make room for new replica.
         COLOCATE_MISMATCH, // replicas do not all locate in right colocate backends set.
-        COLOCATE_REDUNDANT, // replicas match the colocate backends set, but redundant
+        COLOCATE_REDUNDANT, // replicas match the colocate backends set, but redundant.
+        NEED_FURTHER_REPAIR, // one of replicas need a definite repair.
     }
 
     private long id;
@@ -383,6 +384,7 @@ public class Tablet extends MetaObject implements Writable {
         int stable = 0;
         int availableInCluster = 0;
         
+        Replica needFurtherRepairReplica = null;
         Set<String> hosts = Sets.newHashSet();
         for (Replica replica : replicas) {
             Backend backend = systemInfoService.getBackend(replica.getBackendId());
@@ -414,6 +416,10 @@ public class Tablet extends MetaObject implements Writable {
                 continue;
             }
             availableInCluster++;
+
+            if (replica.needFurtherRepair() && needFurtherRepairReplica == null) {
+                needFurtherRepairReplica = replica;
+            }
         }
 
         // 1. alive replicas are not enough
@@ -440,6 +446,10 @@ public class Tablet extends MetaObject implements Writable {
         } else if (aliveAndVersionComplete < replicationNum) {
             return Pair.create(TabletStatus.VERSION_INCOMPLETE, TabletSchedCtx.Priority.NORMAL);
         } else if (aliveAndVersionComplete > replicationNum) {
+            if (needFurtherRepairReplica != null) {
+                return Pair.create(TabletStatus.NEED_FURTHER_REPAIR, TabletSchedCtx.Priority.HIGH);
+            }
+            // we set REDUNDANT as VERY_HIGH, because delete redundant replicas can free the space quickly.
             return Pair.create(TabletStatus.REDUNDANT, TabletSchedCtx.Priority.VERY_HIGH);
         }
 
@@ -454,6 +464,9 @@ public class Tablet extends MetaObject implements Writable {
         if (availableInCluster < replicationNum) {
             return Pair.create(TabletStatus.REPLICA_MISSING_IN_CLUSTER, TabletSchedCtx.Priority.LOW);
         } else if (replicas.size() > replicationNum) {
+            if (needFurtherRepairReplica != null) {
+                return Pair.create(TabletStatus.NEED_FURTHER_REPAIR, TabletSchedCtx.Priority.HIGH);
+            }
             // we set REDUNDANT as VERY_HIGH, because delete redundant replicas can free the space quickly.
             return Pair.create(TabletStatus.REDUNDANT, TabletSchedCtx.Priority.VERY_HIGH);
         }

--- a/fe/src/main/java/org/apache/doris/catalog/Tablet.java
+++ b/fe/src/main/java/org/apache/doris/catalog/Tablet.java
@@ -72,6 +72,8 @@ public class Tablet extends MetaObject implements Writable {
     // last time that the tablet checker checks this tablet.
     // no need to persist
     private long lastStatusCheckTime = -1;
+    
+    private long watermarkTxnId = -1;
 
     public Tablet() {
         this(0L, new ArrayList<Replica>());
@@ -565,5 +567,13 @@ public class Tablet extends MetaObject implements Writable {
 
     public void setLastStatusCheckTime(long lastStatusCheckTime) {
         this.lastStatusCheckTime = lastStatusCheckTime;
+    }
+
+    public void setWatermarkTxnId(long watermarkTxnId) {
+        this.watermarkTxnId = watermarkTxnId;
+    }
+
+    public long getWatermarkTxnId() {
+        return watermarkTxnId;
     }
 }

--- a/fe/src/main/java/org/apache/doris/clone/TabletSchedCtx.java
+++ b/fe/src/main/java/org/apache/doris/clone/TabletSchedCtx.java
@@ -866,6 +866,15 @@ public class TabletSchedCtx implements Comparable<TabletSchedCtx> {
             replica.updateVersionInfo(reportedTablet.getVersion(), reportedTablet.getVersion_hash(),
                     reportedTablet.getData_size(), reportedTablet.getRow_count());
             
+            if (this.type == Type.BALANCE) {
+                long partitionVisibleVersion = partition.getVisibleVersion();
+                if (replica.getVersion() < partitionVisibleVersion) {
+                    // see comment 'needFurtherRepair' of Replica for explanation.
+                    // no need to persist this info. If FE restart, just do it again.
+                    replica.setNeedFurtherRepair(true);
+                }
+            }
+
             state = State.FINISHED;
             
             ReplicaPersistInfo info = ReplicaPersistInfo.createForClone(dbId, tblId, partitionId, indexId,

--- a/fe/src/main/java/org/apache/doris/clone/TabletSchedCtx.java
+++ b/fe/src/main/java/org/apache/doris/clone/TabletSchedCtx.java
@@ -884,7 +884,6 @@ public class TabletSchedCtx implements Comparable<TabletSchedCtx> {
                     // no need to persist this info. If FE restart, just do it again.
                     replica.setNeedFurtherRepair(true);
                 }
-                tablet.setWatermarkTxnId(Catalog.getCurrentGlobalTransactionMgr().getTransactionIDGenerator().getNextTransactionId());
             } else {
                 replica.setNeedFurtherRepair(false);
             }

--- a/fe/src/main/java/org/apache/doris/clone/TabletScheduler.java
+++ b/fe/src/main/java/org/apache/doris/clone/TabletScheduler.java
@@ -866,6 +866,14 @@ public class TabletScheduler extends Daemon {
 
     private void deleteReplicaInternal(TabletSchedCtx tabletCtx, Replica replica, String reason, boolean force) throws SchedException {
 
+        /*
+         * Before deleting a replica, we should make sure that there is no running txn on it and no more txns will be on it.
+         * So we do followings:
+         * 1. If replica is loadable, set a watermark txn id on it and set it state as CLONE, but not deleting it this time.
+         *      The CLONE state will ensure that no more txns will be on this replicas.
+         * 2. Wait for any txns before the watermark txn id to be finished. If all are finished, which means this replica is
+         *      safe to be deleted.
+         */
         if (!force && replica.getState().isLoadable() && replica.getWatermarkTxnId() == -1) {
             long nextTxnId = Catalog.getCurrentGlobalTransactionMgr().getTransactionIDGenerator().getNextTransactionId();
             replica.setWatermarkTxnId(nextTxnId);

--- a/fe/src/main/java/org/apache/doris/common/proc/StatisticProcDir.java
+++ b/fe/src/main/java/org/apache/doris/common/proc/StatisticProcDir.java
@@ -129,7 +129,8 @@ public class StatisticProcDir implements ProcDirInterface {
                                         replicationNum, availableBackendsNum);
 
                                 // here we treat REDUNDANT as HEALTHY, for user friendly.
-                                if (res.first != TabletStatus.HEALTHY && res.first != TabletStatus.REDUNDANT) {
+                                if (res.first != TabletStatus.HEALTHY && res.first != TabletStatus.REDUNDANT
+                                        && res.first != TabletStatus.COLOCATE_REDUNDANT && res.first != TabletStatus.NEED_FURTHER_REPAIR) {
                                     unhealthyTabletIds.put(dbId, tablet.getId());
                                 }
 

--- a/fe/src/main/java/org/apache/doris/consistency/CheckConsistencyJob.java
+++ b/fe/src/main/java/org/apache/doris/consistency/CheckConsistencyJob.java
@@ -23,11 +23,11 @@ import org.apache.doris.catalog.MaterializedIndex;
 import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.catalog.Partition;
 import org.apache.doris.catalog.Replica;
+import org.apache.doris.catalog.Replica.ReplicaState;
 import org.apache.doris.catalog.Table;
 import org.apache.doris.catalog.Tablet;
 import org.apache.doris.catalog.TabletInvertedIndex;
 import org.apache.doris.catalog.TabletMeta;
-import org.apache.doris.catalog.Replica.ReplicaState;
 import org.apache.doris.common.Config;
 import org.apache.doris.persist.ConsistencyCheckInfo;
 import org.apache.doris.qe.ConnectContext;
@@ -172,7 +172,8 @@ public class CheckConsistencyJob {
             long maxDataSize = 0;
             for (Replica replica : tablet.getReplicas()) {
                 // 1. if state is CLONE, do not send task at this time
-                if (replica.getState() == ReplicaState.CLONE) {
+                if (replica.getState() == ReplicaState.CLONE
+                        || replica.getState() == ReplicaState.DECOMMISSION) {
                     continue;
                 }
 

--- a/fe/src/main/java/org/apache/doris/transaction/GlobalTransactionMgr.java
+++ b/fe/src/main/java/org/apache/doris/transaction/GlobalTransactionMgr.java
@@ -763,7 +763,7 @@ public class GlobalTransactionMgr {
                     continue;
                 }
                 if (entry.getKey() <= endTransactionId) {
-                    LOG.info("find a running txn with txn_id={}, less than schema change txn_id {}", 
+                    LOG.debug("find a running txn with txn_id={}, less than schema change txn_id {}", 
                             entry.getKey(), endTransactionId);
                     return false;
                 }


### PR DESCRIPTION
The bug is described in issue #1580 . And this patch will fix 2 cases of cluster balance

1. After finish adding the new replica, the new replica's version may not catch up with
the visible version, so the new replica may be treated as a stale and redundant replica, which
will be deleting at next tablet checking round.

    I add a mark named `needFurtherRepair` to the newly added replica, only mark it when that replica's version does not catch up with visible version. This replica will receive a further repair at next tablet checking round, instead of being deleted.

2. When deleting the redundant replicas, there may be some load jobs on it. Delete these replicas may cause the load job fail.

    Before deleting a redundant replica, I first mark the next txn id on that replica, and set replica's
state to CLONE. The CLONE state will ensure that no more load jobs will be on that replica, and we
will wait all load jobs before the marked txn id to be finished. After that, the replica can be deleted safely.

ISSUE: #1580