### PR TITLE
Fix bug that unable to delete replica if version is missing

### DIFF
--- a/fe/src/main/java/org/apache/doris/master/ReportHandler.java
+++ b/fe/src/main/java/org/apache/doris/master/ReportHandler.java
@@ -631,7 +631,7 @@ public class ReportHandler extends Daemon {
         for (Long tabletId : backendTablets.keySet()) {
             TTablet backendTablet = backendTablets.get(tabletId);
             for (TTabletInfo backendTabletInfo : backendTablet.getTablet_infos()) {
-                boolean needDelete = false;
+                boolean needDelete = true;
                 if (!foundTabletsWithValidSchema.contains(tabletId)
                         && isBackendReplicaHealthy(backendTabletInfo)) {
                     // if this tablet is not in meta. try adding it.


### PR DESCRIPTION
If there is a redundant replica on BE which version is missing,
the tablet report logic can not drop it correctly.

ISSUE: #1584 