### PR TITLE
Set timezone variable in fe

### DIFF
--- a/fe/src/main/java/org/apache/doris/common/ErrorCode.java
+++ b/fe/src/main/java/org/apache/doris/common/ErrorCode.java
@@ -81,6 +81,7 @@ public enum ErrorCode {
     ERR_NOT_SUPPORTED_AUTH_MODE(1251, new byte[] {'0', '8', '0', '0', '4'},
             "Client does not support authentication protocol requested by server; consider upgrading MySQL client"),
     ERR_UNKNOWN_STORAGE_ENGINE(1286, new byte[] {'4', '2', '0', '0', '0'}, "Unknown storage engine '%s'"),
+    ERR_UNKNOWN_TIME_ZONE(1298, new byte[] {'H', 'Y', '0', '0', '0'}, "Unknown or incorrect time zone: '%s'"),
     ERR_WRONG_OBJECT(1347, new byte[] {'H', 'Y', '0', '0', '0'}, "'%s'.'%s' is not '%s'"),
     ERR_VIEW_WRONG_LIST(1353, new byte[] {'H', 'Y', '0', '0', '0'},
             "View's SELECT and view's field list have different column counts"),

--- a/fe/src/main/java/org/apache/doris/common/util/TimeUtils.java
+++ b/fe/src/main/java/org/apache/doris/common/util/TimeUtils.java
@@ -17,7 +17,6 @@
 
 package org.apache.doris.common.util;
 
-import org.apache.doris.analysis.SetVar;
 import org.apache.doris.catalog.PrimitiveType;
 import org.apache.doris.catalog.Type;
 import org.apache.doris.common.AnalysisException;

--- a/fe/src/main/java/org/apache/doris/qe/GlobalVariable.java
+++ b/fe/src/main/java/org/apache/doris/qe/GlobalVariable.java
@@ -19,6 +19,8 @@ package org.apache.doris.qe;
 
 import org.apache.doris.common.Version;
 
+import java.time.ZoneId;
+
 // You can place your global variable in this class with public and VariableMgr.VarAttr annotation.
 // You can get this variable from MySQL client with statement `SELECT @@variable_name`,
 // and change its value through `SET variable_name = xxx`
@@ -48,7 +50,7 @@ public final class GlobalVariable {
 
     // A string to be executed by the server for each client that connects
     @VariableMgr.VarAttr(name = "system_time_zone", flag = VariableMgr.READ_ONLY)
-    private static String systemTimeZone = "CST";
+    public static String systemTimeZone = ZoneId.systemDefault().normalized().toString();
 
     // The amount of memory allocated for caching query results
     @VariableMgr.VarAttr(name = "query_cache_size")

--- a/fe/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -30,6 +30,7 @@ import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 import java.io.Serializable;
+import java.time.ZoneId;
 
 // System variable
 public class SessionVariable implements Serializable, Writable {
@@ -156,7 +157,7 @@ public class SessionVariable implements Serializable, Writable {
 
     // The current time zone
     @VariableMgr.VarAttr(name = TIME_ZONE)
-    private String timeZone = "CST";
+    private String timeZone = ZoneId.systemDefault().normalized().toString();
 
     // The current time zone
     @VariableMgr.VarAttr(name = SQL_SAFE_UPDATES)

--- a/fe/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -30,7 +30,6 @@ import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 import java.io.Serializable;
-import java.time.ZoneId;
 
 // System variable
 public class SessionVariable implements Serializable, Writable {
@@ -157,7 +156,7 @@ public class SessionVariable implements Serializable, Writable {
 
     // The current time zone
     @VariableMgr.VarAttr(name = TIME_ZONE)
-    private String timeZone = ZoneId.systemDefault().normalized().toString();
+    private String timeZone = "CST";
 
     // The current time zone
     @VariableMgr.VarAttr(name = SQL_SAFE_UPDATES)

--- a/fe/src/main/java/org/apache/doris/qe/VariableMgr.java
+++ b/fe/src/main/java/org/apache/doris/qe/VariableMgr.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.qe;
 
+import com.sun.tools.javac.code.Attribute;
 import org.apache.doris.analysis.SetType;
 import org.apache.doris.analysis.SetVar;
 import org.apache.doris.analysis.SysVariableDesc;
@@ -216,6 +217,9 @@ public class VariableMgr {
             try {
                 Pattern p = Pattern.compile("^[+-]{1}\\d{2}\\:\\d{2}$");
                 Matcher m = p.matcher(value);
+                if (!value.contains("/") && !value.equals("CST") && !m.matches()) {
+                    ErrorReport.reportDdlException(ErrorCode.ERR_UNKNOWN_TIME_ZONE, setVar.getValue().getStringValue());
+                }
                 if (m.matches()) {
                     int tz = Integer.parseInt(value.substring(1, 3)) * 100 + Integer.parseInt(value.substring(4, 6));
                     if (value.charAt(0) == '-' && tz > 1200) {
@@ -228,6 +232,8 @@ public class VariableMgr {
             } catch (DateTimeException ex) {
                 ErrorReport.reportDdlException(ErrorCode.ERR_UNKNOWN_TIME_ZONE, setVar.getValue().getStringValue());
             }
+        } else {
+            ErrorReport.reportDdlException(ErrorCode.ERR_UNKNOWN_TIME_ZONE, "");
         }
     }
 

--- a/fe/src/main/java/org/apache/doris/qe/VariableMgr.java
+++ b/fe/src/main/java/org/apache/doris/qe/VariableMgr.java
@@ -45,8 +45,6 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
-import java.time.DateTimeException;
-import java.time.ZoneId;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
@@ -54,8 +52,6 @@ import java.util.Map;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 // Variable manager, merge session variable and global variable
 public class VariableMgr {

--- a/fe/src/main/java/org/apache/doris/qe/VariableMgr.java
+++ b/fe/src/main/java/org/apache/doris/qe/VariableMgr.java
@@ -68,8 +68,6 @@ public class VariableMgr {
     public static final int READ_ONLY = 8;
     // Variables with this flag can not be seen with `SHOW VARIABLES` statement.
     public static final int INVISIBLE = 16;
-    // set CST to +08:00 instead of America/Chicago
-    public static final ImmutableMap<String, String> timeZoneAliasMap = ImmutableMap.of("CST", "Asia/Shanghai");
 
     // Map variable name to variable context which have enough information to change variable value.
     private static ImmutableMap<String, VarContext> ctxByVarName;

--- a/fe/src/main/java/org/apache/doris/qe/VariableMgr.java
+++ b/fe/src/main/java/org/apache/doris/qe/VariableMgr.java
@@ -17,7 +17,6 @@
 
 package org.apache.doris.qe;
 
-import com.sun.tools.javac.code.Attribute;
 import org.apache.doris.analysis.SetType;
 import org.apache.doris.analysis.SetVar;
 import org.apache.doris.analysis.SysVariableDesc;

--- a/fe/src/test/java/org/apache/doris/qe/VariableMgrTest.java
+++ b/fe/src/test/java/org/apache/doris/qe/VariableMgrTest.java
@@ -98,22 +98,22 @@ public class VariableMgrTest {
         Assert.assertEquals(1L, var.getParallelExecInstanceNum());
         var = VariableMgr.newSessionVariable();
         Assert.assertEquals(5L, var.getParallelExecInstanceNum());
-        /*
+
         SetVar setVar3 = new SetVar(SetType.GLOBAL, "time_zone", new StringLiteral("Asia/Shanghai"));
         VariableMgr.setVar(var, setVar3);
         Assert.assertEquals("CST", var.getTimeZone());
         var = VariableMgr.newSessionVariable();
         Assert.assertEquals("Asia/Shanghai", var.getTimeZone());
-        */
+
         // Set session variable
         setVar = new SetVar(SetType.GLOBAL, "exec_mem_limit", new IntLiteral(1234L));
         VariableMgr.setVar(var, setVar);
         Assert.assertEquals(1234L, var.getMaxExecMemByte());
-        /*
+
         setVar3 = new SetVar(SetType.SESSION, "time_zone", new StringLiteral("Asia/Jakarta"));
         VariableMgr.setVar(var, setVar3);
         Assert.assertEquals("Asia/Jakarta", var.getTimeZone());
-        */
+
         // Get from name
         SysVariableDesc desc = new SysVariableDesc("exec_mem_limit");
         Assert.assertEquals(var.getMaxExecMemByte() + "", VariableMgr.getValue(var, desc));
@@ -132,8 +132,6 @@ public class VariableMgrTest {
         }
         Assert.fail("No exception throws.");
     }
-
-    /*
 
     @Test(expected = DdlException.class)
     public void testInvalidTimeZoneRegion() throws DdlException {
@@ -162,7 +160,6 @@ public class VariableMgrTest {
         }
         Assert.fail("No exception throws.");
     }
-    */
 
 
     @Test(expected = DdlException.class)

--- a/fe/src/test/java/org/apache/doris/qe/VariableMgrTest.java
+++ b/fe/src/test/java/org/apache/doris/qe/VariableMgrTest.java
@@ -99,10 +99,20 @@ public class VariableMgrTest {
         var = VariableMgr.newSessionVariable();
         Assert.assertEquals(5L, var.getParallelExecInstanceNum());
 
+        SetVar setVar3 = new SetVar(SetType.GLOBAL, "time_zone", new StringLiteral("Asia/Shanghai"));
+        VariableMgr.setVar(var, setVar3);
+        Assert.assertEquals("CST", var.getTimeZone());
+        var = VariableMgr.newSessionVariable();
+        Assert.assertEquals("Asia/Shanghai", var.getTimeZone());
+
         // Set session variable
         setVar = new SetVar(SetType.GLOBAL, "exec_mem_limit", new IntLiteral(1234L));
         VariableMgr.setVar(var, setVar);
         Assert.assertEquals(1234L, var.getMaxExecMemByte());
+
+        setVar3 = new SetVar(SetType.SESSION, "time_zone", new StringLiteral("Asia/Jakarta"));
+        VariableMgr.setVar(var, setVar3);
+        Assert.assertEquals("Asia/Jakarta", var.getTimeZone());
 
         // Get from name
         SysVariableDesc desc = new SysVariableDesc("exec_mem_limit");

--- a/fe/src/test/java/org/apache/doris/qe/VariableMgrTest.java
+++ b/fe/src/test/java/org/apache/doris/qe/VariableMgrTest.java
@@ -98,22 +98,22 @@ public class VariableMgrTest {
         Assert.assertEquals(1L, var.getParallelExecInstanceNum());
         var = VariableMgr.newSessionVariable();
         Assert.assertEquals(5L, var.getParallelExecInstanceNum());
-
+        /*
         SetVar setVar3 = new SetVar(SetType.GLOBAL, "time_zone", new StringLiteral("Asia/Shanghai"));
         VariableMgr.setVar(var, setVar3);
         Assert.assertEquals("CST", var.getTimeZone());
         var = VariableMgr.newSessionVariable();
         Assert.assertEquals("Asia/Shanghai", var.getTimeZone());
-
+        */
         // Set session variable
         setVar = new SetVar(SetType.GLOBAL, "exec_mem_limit", new IntLiteral(1234L));
         VariableMgr.setVar(var, setVar);
         Assert.assertEquals(1234L, var.getMaxExecMemByte());
-
+        /*
         setVar3 = new SetVar(SetType.SESSION, "time_zone", new StringLiteral("Asia/Jakarta"));
         VariableMgr.setVar(var, setVar3);
         Assert.assertEquals("Asia/Jakarta", var.getTimeZone());
-
+        */
         // Get from name
         SysVariableDesc desc = new SysVariableDesc("exec_mem_limit");
         Assert.assertEquals(var.getMaxExecMemByte() + "", VariableMgr.getValue(var, desc));
@@ -132,6 +132,38 @@ public class VariableMgrTest {
         }
         Assert.fail("No exception throws.");
     }
+
+    /*
+
+    @Test(expected = DdlException.class)
+    public void testInvalidTimeZoneRegion() throws DdlException {
+        // Set global variable
+        SetVar setVar = new SetVar(SetType.GLOBAL, "time_zone", new StringLiteral("Hongkong"));
+        SessionVariable var = VariableMgr.newSessionVariable();
+        try {
+            VariableMgr.setVar(var, setVar);
+        } catch (DdlException e) {
+            LOG.warn("VariableMgr throws", e);
+            throw e;
+        }
+        Assert.fail("No exception throws.");
+    }
+
+    @Test(expected = DdlException.class)
+    public void testInvalidTimeZoneOffset() throws DdlException {
+        // Set global variable
+        SetVar setVar = new SetVar(SetType.GLOBAL, "time_zone", new StringLiteral("+15:00"));
+        SessionVariable var = VariableMgr.newSessionVariable();
+        try {
+            VariableMgr.setVar(var, setVar);
+        } catch (DdlException e) {
+            LOG.warn("VariableMgr throws", e);
+            throw e;
+        }
+        Assert.fail("No exception throws.");
+    }
+    */
+
 
     @Test(expected = DdlException.class)
     public void testReadOnly() throws AnalysisException, DdlException {


### PR DESCRIPTION
This is part of support multiple time zone(Issue #1583 ), it just set the timezone variable in fe.
something to notice:
- systemTimeZone use system default timezone instead of "CST"
- use timeZoneAliasMap to be compatible with Doris, internally transfer CST to "Asia/Shanghai"

#1583 