### PR TITLE
Implement BetaRowsetWriter

### DIFF
--- a/be/src/olap/aggregate_func.h
+++ b/be/src/olap/aggregate_func.h
@@ -298,16 +298,14 @@ struct AggregateFuncTraits<OLAP_FIELD_AGGREGATION_HLL_UNION, OLAP_FIELD_TYPE_HLL
     }
 
     static void update(RowCursorCell* dst, const RowCursorCell& src, Arena* arena) {
-        Slice* l_slice = reinterpret_cast<Slice*>(dst->mutable_cell_ptr());
-        size_t hll_ptr = *(size_t*)(l_slice->data - sizeof(HllContext*));
-        HllContext* context = (reinterpret_cast<HllContext*>(hll_ptr));
+        auto l_slice = reinterpret_cast<Slice*>(dst->mutable_cell_ptr());
+        auto context = reinterpret_cast<HllContext*>(l_slice->data - sizeof(HllContext*));
         HllSetHelper::fill_set((const char*)src.cell_ptr(), context);
     }
 
     static void finalize(char* data, Arena* arena) {
-        Slice* slice = reinterpret_cast<Slice*>(data);
-        size_t hll_ptr = *(size_t*)(slice->data - sizeof(HllContext*));
-        HllContext* context = (reinterpret_cast<HllContext*>(hll_ptr));
+        auto slice = reinterpret_cast<Slice*>(data);
+        auto context = reinterpret_cast<HllContext*>(slice->data - sizeof(HllContext*));
         std::map<int, uint8_t> index_to_value;
         if (context->has_sparse_or_full ||
                 context->hash64_set->size() > HLL_EXPLICLIT_INT64_NUM) {

--- a/be/src/olap/field.h
+++ b/be/src/olap/field.h
@@ -199,9 +199,15 @@ public:
     template<typename DstCellType, typename SrcCellType>
     void agg_init(DstCellType* dst, const SrcCellType& src) const;
 
-    // copy filed content from src to dest without nullbyte
-    inline void copy_content(char* dest, const char* src, MemPool* mem_pool) const {
-        _type_info->deep_copy(dest, src, mem_pool);
+    // deep copy filed content from `src` to `dst` without null-byte
+    inline void deep_copy_content(char* dst, const char* src, MemPool* mem_pool) const {
+        _type_info->deep_copy(dst, src, mem_pool);
+    }
+
+    // shallow copy filed content from `src` to `dst` without null-byte.
+    // for string like type, shallow copy only copies Slice, not the actual data pointed by slice.
+    inline void shallow_copy_content(char* dst, const char* src) const {
+        _type_info->shallow_copy(dst, src);
     }
 
     // Copy srouce content to destination in index format.

--- a/be/src/olap/hll.h
+++ b/be/src/olap/hll.h
@@ -30,7 +30,7 @@ namespace doris {
 const static int HLL_COLUMN_PRECISION = 14;
 const static int HLL_EXPLICLIT_INT64_NUM = 160;
 const static int HLL_REGISTERS_COUNT = 16384;
-// registers (2^14) + 1 (type)
+// maximum size in byte of serialized HLL: type(1) + registers (2^14)
 const static int HLL_COLUMN_DEFAULT_LEN = 16385;
 
 struct HllContext {

--- a/be/src/olap/merger.cpp
+++ b/be/src/olap/merger.cpp
@@ -25,6 +25,8 @@
 #include "olap/tablet.h"
 #include "olap/reader.h"
 #include "olap/row_cursor.h"
+#include "runtime/mem_pool.h"
+#include "runtime/mem_tracker.h"
 
 using std::list;
 using std::string;
@@ -64,9 +66,11 @@ OLAPStatus Merger::merge(const vector<RowsetReaderSharedPtr>& rs_readers,
     }
 
     bool eof = false;
+    MemTracker mem_tracker;
+    MemPool mem_pool(&mem_tracker);
     // The following procedure would last for long time, half of one day, etc.
     while (!has_error) {
-        row_cursor.allocate_memory_for_string_type(_tablet->tablet_schema(), _rs_writer->mem_pool());
+        row_cursor.allocate_memory_for_string_type(_tablet->tablet_schema(), &mem_pool);
 
         // Read one row into row_cursor
         OLAPStatus res = reader.next_row_with_aggregation(&row_cursor, &eof);

--- a/be/src/olap/merger.cpp
+++ b/be/src/olap/merger.cpp
@@ -25,8 +25,6 @@
 #include "olap/tablet.h"
 #include "olap/reader.h"
 #include "olap/row_cursor.h"
-#include "runtime/mem_pool.h"
-#include "runtime/mem_tracker.h"
 
 using std::list;
 using std::string;
@@ -66,11 +64,9 @@ OLAPStatus Merger::merge(const vector<RowsetReaderSharedPtr>& rs_readers,
     }
 
     bool eof = false;
-    MemTracker mem_tracker;
-    MemPool mem_pool(&mem_tracker);
+    row_cursor.allocate_memory_for_string_type(_tablet->tablet_schema());
     // The following procedure would last for long time, half of one day, etc.
     while (!has_error) {
-        row_cursor.allocate_memory_for_string_type(_tablet->tablet_schema(), &mem_pool);
 
         // Read one row into row_cursor
         OLAPStatus res = reader.next_row_with_aggregation(&row_cursor, &eof);

--- a/be/src/olap/olap_define.h
+++ b/be/src/olap/olap_define.h
@@ -36,6 +36,8 @@ static const uint32_t OLAP_DEFAULT_MAX_PACKED_ROW_BLOCK_SIZE = 1024 * 1024 * 20;
 static const uint32_t OLAP_DEFAULT_MAX_UNPACKED_ROW_BLOCK_SIZE = 1024 * 1024 * 100;
 // 列存储文件的块大小,由于可能会被全部载入内存,所以需要严格控制大小, 这里定义为256MB
 static const uint32_t OLAP_MAX_COLUMN_SEGMENT_FILE_SIZE = 268435456;
+// 列存储文件大小的伸缩性
+static const float OLAP_COLUMN_FILE_SEGMENT_SIZE_SCALE = 0.9f;
 // 在列存储文件中, 数据分块压缩, 每个块的默认压缩前的大小
 static const uint32_t OLAP_DEFAULT_COLUMN_STREAM_BUFFER_SIZE = 10 * 1024;
 // 在列存储文件中, 对字符串使用字典编码的字典大小门限
@@ -78,9 +80,6 @@ static const std::string INCREMENTAL_DELTA_PREFIX = "/incremental_delta";
 static const std::string CLONE_PREFIX = "/clone";
 
 static const int32_t OLAP_DATA_VERSION_APPLIED = DORIS_V1;
-
-// column文件大小的伸缩性
-static const float OLAP_COLUMN_FILE_SEGMENT_SIZE_SCALE = 0.9f;
 
 static const uint32_t MAX_POSITION_SIZE = 16;
 

--- a/be/src/olap/push_handler.h
+++ b/be/src/olap/push_handler.h
@@ -129,7 +129,7 @@ public:
     virtual OLAPStatus init(TabletSharedPtr tablet, BinaryFile* file) = 0;
     virtual OLAPStatus finalize() = 0;
 
-    virtual OLAPStatus next(RowCursor* row, MemPool* mem_pool) = 0;
+    virtual OLAPStatus next(RowCursor* row) = 0;
 
     virtual bool eof() = 0;
 
@@ -166,7 +166,7 @@ public:
     virtual OLAPStatus init(TabletSharedPtr tablet, BinaryFile* file);
     virtual OLAPStatus finalize();
 
-    virtual OLAPStatus next(RowCursor* row, MemPool* mem_pool);
+    virtual OLAPStatus next(RowCursor* row);
 
     virtual bool eof() {
         return _curr >= _content_len;
@@ -187,7 +187,7 @@ public:
     virtual OLAPStatus init(TabletSharedPtr tablet, BinaryFile* file);
     virtual OLAPStatus finalize();
 
-    virtual OLAPStatus next(RowCursor* row, MemPool* mem_pool);
+    virtual OLAPStatus next(RowCursor* row);
 
     virtual bool eof() {
         return _curr >= _content_len && _row_num == 0;

--- a/be/src/olap/row_cursor.cpp
+++ b/be/src/olap/row_cursor.cpp
@@ -28,18 +28,14 @@ using std::vector;
 namespace doris {
 RowCursor::RowCursor() :
         _fixed_len(0),
-        _variable_len(0),
-        _variable_buf_allocated_by_pool(false) {}
+        _variable_len(0) {}
 
 RowCursor::~RowCursor() {
     delete [] _owned_fixed_buf;
-    if (!_variable_buf_allocated_by_pool) {
-        for (HllContext* context : hll_contexts) {
-            delete context;
-        }
-
-        delete [] _variable_buf;
+    for (HllContext* context : hll_contexts) {
+        delete context;
     }
+    delete [] _variable_buf;
 }
 
 OLAPStatus RowCursor::_init(const std::vector<TabletColumn>& schema,
@@ -176,25 +172,12 @@ OLAPStatus RowCursor::init_scan_key(const TabletSchema& schema,
     return OLAP_SUCCESS;
 }
 
-OLAPStatus RowCursor::allocate_memory_for_string_type(
-        const TabletSchema& schema,
-        MemPool* mem_pool) {
+OLAPStatus RowCursor::allocate_memory_for_string_type(const TabletSchema& schema) {
     // allocate memory for string type(char, varchar, hll)
     // The memory allocated in this function is used in aggregate and copy function
     if (_variable_len == 0) { return OLAP_SUCCESS; }
-    if (mem_pool != nullptr) {
-        /*
-         * It is called by row_cursor of row_block in sc(schema change)
-         * or be/ce if mem_pool is not null. RowCursor in rowblock do not
-         * allocate memory for string type in initialization. So memory
-         * for string and hllcontext are all administrated by mem_pool.
-         */
-        _variable_buf = reinterpret_cast<char*>(mem_pool->allocate(_variable_len));
-        _variable_buf_allocated_by_pool = true;
-    } else {
-        DCHECK(_variable_buf == nullptr) << "allocate memory twice";
-        _variable_buf = new (nothrow) char[_variable_len];
-    }
+    DCHECK(_variable_buf == nullptr) << "allocate memory twice";
+    _variable_buf = new (nothrow) char[_variable_len];
     memset(_variable_buf, 0, _variable_len);
 
     // init slice of char, varchar, hll type
@@ -217,14 +200,8 @@ OLAPStatus RowCursor::allocate_memory_for_string_type(
         } else if (type == OLAP_FIELD_TYPE_HLL) {
             // slice.data points to serialized HLL, (slice.data - 8) points to HllContext object used to aggregate HLL
             auto slice = reinterpret_cast<Slice*>(fixed_ptr + 1);
-            HllContext* context = nullptr;
-            if (mem_pool != nullptr) {
-                char* mem = reinterpret_cast<char*>(mem_pool->allocate(sizeof(HllContext)));
-                context = new (mem) HllContext;
-            } else {
-                context = new HllContext();
-                hll_contexts.push_back(context);
-            }
+            HllContext* context = new HllContext();
+            hll_contexts.push_back(context);
 
             *(size_t*)(variable_ptr) = (size_t)(context);
             variable_ptr += sizeof(HllContext*);

--- a/be/src/olap/row_cursor.h
+++ b/be/src/olap/row_cursor.h
@@ -81,10 +81,16 @@ public:
         column_schema(index)->to_index(&dst_cell, cell(index));
     }
 
-    // set field content without nullbyte
+    // deep copy field content (ignore null-byte)
     void set_field_content(size_t index, const char* buf, MemPool* mem_pool) {
         char* dest = cell_ptr(index);
-        column_schema(index)->copy_content(dest, buf, mem_pool);
+        column_schema(index)->deep_copy_content(dest, buf, mem_pool);
+    }
+
+    // shallow copy field content (ignore null-byte)
+    void set_field_content_shallow(size_t index, const char* buf) {
+        char* dst_cell = cell_ptr(index);
+        column_schema(index)->shallow_copy_content(dst_cell, buf);
     }
 
     // 从传入的字符串数组反序列化内部各field的值

--- a/be/src/olap/row_cursor.h
+++ b/be/src/olap/row_cursor.h
@@ -59,8 +59,7 @@ public:
                              const std::vector<std::string>& keys);
 
     //allocate memory for string type, which include char, varchar, hyperloglog
-    OLAPStatus allocate_memory_for_string_type(const TabletSchema& schema,
-                                               MemPool* mem_pool = nullptr);
+    OLAPStatus allocate_memory_for_string_type(const TabletSchema& schema);
 
     RowCursorCell cell(uint32_t cid) const {
         return RowCursorCell(nullable_cell_ptr(cid));
@@ -166,7 +165,6 @@ private:
 
     char* _variable_buf = nullptr;
     size_t _variable_len;
-    bool _variable_buf_allocated_by_pool;
     std::vector<HllContext*> hll_contexts;
 
     DISALLOW_COPY_AND_ASSIGN(RowCursor);

--- a/be/src/olap/rowset/CMakeLists.txt
+++ b/be/src/olap/rowset/CMakeLists.txt
@@ -43,5 +43,5 @@ add_library(Rowset STATIC
     alpha_rowset_writer.cpp
     alpha_rowset_meta.cpp
     beta_rowset.cpp
-    rowset_id_generator.cpp
-)
+    beta_rowset_writer.cpp
+    rowset_id_generator.cpp)

--- a/be/src/olap/rowset/alpha_rowset.cpp
+++ b/be/src/olap/rowset/alpha_rowset.cpp
@@ -119,10 +119,9 @@ void AlphaRowset::make_visible_extra(Version version,  VersionHash version_hash)
     }
 }
 
-OLAPStatus AlphaRowset::make_snapshot(const std::string& snapshot_path,
-                                      std::vector<std::string>* success_links) {
+OLAPStatus AlphaRowset::link_files_to(const std::string& dir, RowsetId new_rowset_id) {
     for (auto& segment_group : _segment_groups) {
-        OLAPStatus status = segment_group->make_snapshot(snapshot_path, success_links);
+        auto status = segment_group->link_segments_to_path(dir, new_rowset_id);
         if (status != OLAP_SUCCESS) {
             LOG(WARNING) << "create hard links failed for segment group:"
                          << segment_group->segment_group_id();
@@ -132,14 +131,13 @@ OLAPStatus AlphaRowset::make_snapshot(const std::string& snapshot_path,
     return OLAP_SUCCESS;
 }
                                     
-OLAPStatus AlphaRowset::copy_files_to_path(const std::string& dest_path,
-                                           std::vector<std::string>* success_files) {
+OLAPStatus AlphaRowset::copy_files_to(const std::string& dir) {
     for (auto& segment_group : _segment_groups) {
-        OLAPStatus status = segment_group->copy_files_to_path(dest_path, success_files);
+        OLAPStatus status = segment_group->copy_files_to(dir);
         if (status != OLAP_SUCCESS) {
             LOG(WARNING) << "copy files failed for segment group."
                          << " segment_group_id:" << segment_group->segment_group_id()
-                         << ", dest_path:" << dest_path;
+                         << ", dest_path:" << dir;
             return status;
         }
     }

--- a/be/src/olap/rowset/alpha_rowset.h
+++ b/be/src/olap/rowset/alpha_rowset.h
@@ -55,10 +55,9 @@ public:
 
     OLAPStatus remove() override;
 
-    OLAPStatus make_snapshot(const std::string& snapshot_path,
-                             std::vector<std::string>* success_links) override;
-    OLAPStatus copy_files_to_path(const std::string& dest_path,
-                                  std::vector<std::string>* success_files) override;
+    OLAPStatus link_files_to(const std::string& dir, RowsetId new_rowset_id) override;
+
+    OLAPStatus copy_files_to(const std::string& dir) override;
 
     OLAPStatus convert_from_old_files(const std::string& snapshot_path,
                                  std::vector<std::string>* success_files);

--- a/be/src/olap/rowset/alpha_rowset_writer.cpp
+++ b/be/src/olap/rowset/alpha_rowset_writer.cpp
@@ -38,7 +38,7 @@ AlphaRowsetWriter::AlphaRowsetWriter() :
 AlphaRowsetWriter::~AlphaRowsetWriter() {
     SAFE_DELETE(_column_data_writer);
     if (!_rowset_build) {
-        garbage_collection();
+        _garbage_collection();
     }
     for (auto& segment_group : _segment_groups) {
         segment_group->release();
@@ -222,23 +222,7 @@ RowsetSharedPtr AlphaRowsetWriter::build() {
     return rowset;
 }
 
-MemPool* AlphaRowsetWriter::mem_pool() {
-    if (_column_data_writer != nullptr) {
-        return _column_data_writer->mem_pool();
-    } else {
-        return nullptr;
-    }
-}
-
-Version AlphaRowsetWriter::version() {
-    return _rowset_writer_context.version;
-}
-
-int64_t AlphaRowsetWriter::num_rows() {
-    return _num_rows_written;
-}
-
-OLAPStatus AlphaRowsetWriter::garbage_collection() {
+OLAPStatus AlphaRowsetWriter::_garbage_collection() {
     for (auto& segment_group : _segment_groups) {
         bool ret = segment_group->delete_all_files();
         if (!ret) {
@@ -249,10 +233,6 @@ OLAPStatus AlphaRowsetWriter::garbage_collection() {
         }
     }
     return OLAP_SUCCESS;
-}
-
-DataDir* AlphaRowsetWriter::data_dir() {
-    return _rowset_writer_context.data_dir;
 }
 
 OLAPStatus AlphaRowsetWriter::_init() {

--- a/be/src/olap/rowset/beta_rowset.h
+++ b/be/src/olap/rowset/beta_rowset.h
@@ -18,6 +18,7 @@
 #ifndef DORIS_SRC_OLAP_ROWSET_BETA_ROWSET_H_
 #define DORIS_SRC_OLAP_ROWSET_BETA_ROWSET_H_
 
+#include "olap/olap_common.h"
 #include "olap/olap_define.h"
 #include "olap/rowset/rowset.h"
 #include "olap/rowset/rowset_meta.h"
@@ -37,6 +38,8 @@ public:
 
     virtual ~BetaRowset() {}
 
+    static std::string segment_file_path(const std::string& segment_dir, RowsetId rowset_id, int segment_id);
+
     OLAPStatus init() override;
 
     OLAPStatus load(bool use_cache = true) override;
@@ -45,11 +48,9 @@ public:
 
     OLAPStatus remove() override;
 
-    OLAPStatus make_snapshot(const std::string& snapshot_path,
-                             std::vector<std::string>* success_links) override;
+    OLAPStatus link_files_to(const std::string& dir, RowsetId new_rowset_id) override;
 
-    OLAPStatus copy_files_to_path(const std::string& dest_path,
-                                  std::vector<std::string>* success_files) override;
+    OLAPStatus copy_files_to(const std::string& dir) override;
 
     // only applicable to alpha rowset, no op here
     OLAPStatus remove_old_files(std::vector<std::string>* files_to_remove) override {
@@ -59,8 +60,6 @@ public:
     bool check_path(const std::string& path) override;
 
 private:
-    std::string _segment_file_path(const std::string& segment_dir, int segment_id);
-
     // TODO segment readers member
 };
 

--- a/be/src/olap/rowset/beta_rowset_writer.cpp
+++ b/be/src/olap/rowset/beta_rowset_writer.cpp
@@ -1,0 +1,184 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "olap/rowset/beta_rowset_writer.h"
+
+#include <cmath> // lround
+#include <cstdio> // remove
+#include <cstring> // strerror_r
+#include <ctime> // time
+
+#include "common/config.h"
+#include "common/logging.h"
+#include "olap/rowset/beta_rowset.h"
+#include <olap/rowset/segment_v2/segment_writer.h>
+#include "olap/olap_define.h"
+#include "olap/row.h" // ContiguousRow
+#include "olap/row_cursor.h" // RowCursor
+
+namespace doris {
+
+BetaRowsetWriter::BetaRowsetWriter()
+    : _rowset_meta(nullptr),
+      _num_segment(0),
+      _segment_writer(nullptr),
+      _num_rows_written(0),
+      _total_data_size(0) {
+    auto size = static_cast<double>(OLAP_MAX_COLUMN_SEGMENT_FILE_SIZE);
+    size *= OLAP_COLUMN_FILE_SEGMENT_SIZE_SCALE;
+    _max_segment_size = static_cast<uint32_t>(lround(size));
+}
+
+BetaRowsetWriter::~BetaRowsetWriter() {
+    if (!_rowset_build) { // abnormal exit, remove all files generated
+        _segment_writer.reset(nullptr); // ensure all files are closed
+        for (int i = 0; i < _num_segment; ++i) {
+            auto path = BetaRowset::segment_file_path(_context.rowset_path_prefix, _context.rowset_id, i);
+            if (::remove(path.c_str()) != 0) {
+                char errmsg[64];
+                LOG(WARNING) << "failed to delete file. err=" << strerror_r(errno, errmsg, 64)
+                             << ", path=" << path;
+            }
+        }
+    }
+}
+
+OLAPStatus BetaRowsetWriter::init(const RowsetWriterContext& rowset_writer_context) {
+    _context = rowset_writer_context;
+    _rowset_meta.reset(new RowsetMeta);
+    _rowset_meta->set_rowset_id(_context.rowset_id);
+    _rowset_meta->set_partition_id(_context.partition_id);
+    _rowset_meta->set_tablet_id(_context.tablet_id);
+    _rowset_meta->set_tablet_schema_hash(_context.tablet_schema_hash);
+    _rowset_meta->set_rowset_type(_context.rowset_type);
+    _rowset_meta->set_rowset_state(_context.rowset_state);
+    if (_context.rowset_state == PREPARED || _context.rowset_state == COMMITTED) {
+        _is_pending = true;
+        _rowset_meta->set_txn_id(_context.txn_id);
+        _rowset_meta->set_load_id(_context.load_id);
+    } else {
+        _rowset_meta->set_version(_context.version);
+        _rowset_meta->set_version_hash(_context.version_hash);
+    }
+    _rowset_meta->set_tablet_uid(_context.tablet_uid);
+
+    return OLAP_SUCCESS;
+}
+
+template<typename RowType>
+OLAPStatus BetaRowsetWriter::_add_row(const RowType& row) {
+    if (PREDICT_FALSE(_segment_writer == nullptr)) {
+        RETURN_NOT_OK(_create_segment_writer());
+    }
+    // TODO update rowset's zonemap
+    auto s = _segment_writer->append_row(row);
+    if (PREDICT_FALSE(!s.ok())) {
+        LOG(WARNING) << "failed to append row: " << s.to_string();
+        return OLAP_ERR_WRITER_DATA_WRITE_ERROR;
+    }
+    if (PREDICT_FALSE(_segment_writer->estimate_segment_size() >= _max_segment_size)) {
+        RETURN_NOT_OK(_flush_segment_writer());
+    }
+    _num_rows_written++;
+    return OLAP_SUCCESS;
+}
+
+template OLAPStatus BetaRowsetWriter::_add_row(const RowCursor& row);
+template OLAPStatus BetaRowsetWriter::_add_row(const ContiguousRow& row);
+
+OLAPStatus BetaRowsetWriter::add_rowset(RowsetSharedPtr rowset) {
+    assert(rowset->rowset_meta()->rowset_type() == BETA_ROWSET);
+    RETURN_NOT_OK(rowset->link_files_to(_context.rowset_path_prefix, _context.rowset_id));
+    _num_rows_written += rowset->num_rows();
+    _total_data_size += rowset->rowset_meta()->data_disk_size();
+    _num_segment += rowset->num_segments();
+    // TODO update zonemap
+    if (rowset->rowset_meta()->has_delete_predicate()) {
+        _rowset_meta->set_delete_predicate(rowset->rowset_meta()->delete_predicate());
+    }
+    return OLAP_SUCCESS;
+}
+
+OLAPStatus BetaRowsetWriter::add_rowset_for_linked_schema_change(RowsetSharedPtr rowset,
+                                                                 const SchemaMapping& schema_mapping) {
+    // TODO use schema_mapping to transfer zonemap
+    return add_rowset(rowset);
+}
+
+OLAPStatus BetaRowsetWriter::flush() {
+    if (_segment_writer != nullptr) {
+        RETURN_NOT_OK(_flush_segment_writer());
+    }
+    return OLAP_SUCCESS;
+}
+
+RowsetSharedPtr BetaRowsetWriter::build() {
+    _rowset_meta->set_num_rows(_num_rows_written);
+    _rowset_meta->set_total_disk_size(_total_data_size);
+    _rowset_meta->set_data_disk_size(_total_data_size);
+    _rowset_meta->set_index_disk_size(0); // TODO collect index size
+    // TODO write zonemap to meta
+    _rowset_meta->set_empty(_num_rows_written == 0);
+    _rowset_meta->set_creation_time(time(nullptr));
+    _rowset_meta->set_num_segments(_num_segment);
+    if (_is_pending) {
+        _rowset_meta->set_rowset_state(COMMITTED);
+    } else {
+        _rowset_meta->set_rowset_state(VISIBLE);
+    }
+
+    RowsetSharedPtr rowset(new BetaRowset(_context.tablet_schema,
+                                          _context.rowset_path_prefix,
+                                          _context.data_dir,
+                                          _rowset_meta));
+    auto status = rowset->init();
+    if (status != OLAP_SUCCESS) {
+        LOG(WARNING) << "rowset init failed when build new rowset";
+        return nullptr;
+    }
+    _rowset_build = true;
+    return rowset;
+}
+
+OLAPStatus BetaRowsetWriter::_create_segment_writer() {
+    auto path = BetaRowset::segment_file_path(_context.rowset_path_prefix, _context.rowset_id, _num_segment);
+    segment_v2::SegmentWriterOptions writer_options;
+    _segment_writer.reset(new segment_v2::SegmentWriter(path, _num_segment, _context.tablet_schema, writer_options));
+    // TODO set write_mbytes_per_sec based on writer type (load/base compaction/cumulative compaction)
+    auto s = _segment_writer->init(config::push_write_mbytes_per_sec);
+    if (!s.ok()) {
+        LOG(WARNING) << "failed to init segment writer: " << s.to_string();
+        return OLAP_ERR_INIT_FAILED;
+    }
+    _num_segment++;
+    return OLAP_SUCCESS;
+}
+
+OLAPStatus BetaRowsetWriter::_flush_segment_writer() {
+    uint32_t segment_size;
+    auto s = _segment_writer->finalize(&segment_size);
+    if (!s.ok()) {
+        LOG(WARNING) << "failed to finalize segment: " << s.to_string();
+        return OLAP_ERR_WRITER_DATA_WRITE_ERROR;
+    }
+    // TODO calc index size also
+    _total_data_size += segment_size;
+    _segment_writer.reset(nullptr);
+    return OLAP_SUCCESS;
+}
+
+} // namespace doris

--- a/be/src/olap/rowset/beta_rowset_writer.h
+++ b/be/src/olap/rowset/beta_rowset_writer.h
@@ -3,7 +3,7 @@
 // distributed with this work for additional information
 // regarding copyright ownership.  The ASF licenses this file
 // to you under the Apache License, Version 2.0 (the
-// "License") override; you may not use this file except in compliance
+// "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at
 //
 //   http://www.apache.org/licenses/LICENSE-2.0
@@ -15,27 +15,22 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#ifndef DORIS_BE_SRC_OLAP_ROWSET_ALPHA_ROWSET_WRITER_H
-#define DORIS_BE_SRC_OLAP_ROWSET_ALPHA_ROWSET_WRITER_H
+#ifndef DORIS_BE_SRC_OLAP_ROWSET_BETA_ROWSET_WRITER_H
+#define DORIS_BE_SRC_OLAP_ROWSET_BETA_ROWSET_WRITER_H
 
 #include "olap/rowset/rowset_writer.h"
-#include "olap/rowset/segment_group.h"
-#include "olap/rowset/column_data_writer.h"
-
-#include <vector>
 
 namespace doris {
 
-enum WriterState {
-    WRITER_CREATED,
-    WRITER_INITED,
-    WRITER_FLUSHED
-};
+namespace segment_v2 {
+class SegmentWriter;
+} // namespace segment_v2
 
-class AlphaRowsetWriter : public RowsetWriter {
+class BetaRowsetWriter : public RowsetWriter {
 public:
-    AlphaRowsetWriter();
-    virtual ~AlphaRowsetWriter();
+    BetaRowsetWriter();
+
+    ~BetaRowsetWriter() override;
 
     OLAPStatus init(const RowsetWriterContext& rowset_writer_context) override;
 
@@ -48,48 +43,47 @@ public:
 
     // add rowset by create hard link
     OLAPStatus add_rowset(RowsetSharedPtr rowset) override;
+
     OLAPStatus add_rowset_for_linked_schema_change(
-            RowsetSharedPtr rowset, const SchemaMapping& schema_mapping) override;
+        RowsetSharedPtr rowset, const SchemaMapping& schema_mapping) override;
 
     OLAPStatus flush() override;
 
-    // get a rowset
     RowsetSharedPtr build() override;
 
-    Version version() override { return _rowset_writer_context.version; }
+    Version version() override { return _context.version; }
 
     int64_t num_rows() override { return _num_rows_written; }
 
-    RowsetId rowset_id() override { return _rowset_writer_context.rowset_id; }
+    RowsetId rowset_id() override { return _context.rowset_id; }
 
-    DataDir* data_dir() override { return _rowset_writer_context.data_dir; }
+    DataDir* data_dir() override { return _context.data_dir; }
 
 private:
-    OLAPStatus _init();
-
     template<typename RowType>
     OLAPStatus _add_row(const RowType& row);
-    
-    // validate rowset build arguments before create rowset to make sure correctness
-    bool _validate_rowset();
 
-    OLAPStatus _garbage_collection();
+    OLAPStatus _create_segment_writer();
+
+    OLAPStatus _flush_segment_writer();
 
 private:
-    int32_t _segment_group_id;
-    SegmentGroup* _cur_segment_group;
-    ColumnDataWriter* _column_data_writer;
-    std::shared_ptr<RowsetMeta> _current_rowset_meta;
-    bool _is_pending_rowset;
+    RowsetWriterContext _context;
+    std::shared_ptr<RowsetMeta> _rowset_meta;
+
+    int _num_segment;
+    uint32_t _max_segment_size;
+    std::unique_ptr<segment_v2::SegmentWriter> _segment_writer;
+
+    // counters and statistics maintained during data write
     int64_t _num_rows_written;
-    RowsetWriterContext _rowset_writer_context;
-    std::vector<SegmentGroup*> _segment_groups;
-    bool _rowset_build;
-    WriterState _writer_state;
-    // add_rowset does not need to call column_data_writer.finalize()
-    bool _need_column_data_writer;
+    int64_t _total_data_size;
+    // TODO rowset's Zonemap
+
+    bool _is_pending = false;
+    bool _rowset_build = false;
 };
 
 } // namespace doris
 
-#endif // DORIS_BE_SRC_OLAP_ROWSET_ALPHA_ROWSET_WRITER_H
+#endif //DORIS_BE_SRC_OLAP_ROWSET_BETA_ROWSET_WRITER_H

--- a/be/src/olap/rowset/column_data_writer.cpp
+++ b/be/src/olap/rowset/column_data_writer.cpp
@@ -124,7 +124,10 @@ OLAPStatus ColumnDataWriter::_init_segment() {
 
 template<typename RowType>
 OLAPStatus ColumnDataWriter::write(const RowType& row) {
-    _row_block->set_row(_row_index, row);
+    // copy input row to row block
+    _row_block->get_row(_row_index, &_cursor);
+    copy_row(&_cursor, row, _row_block->mem_pool());
+
     next(row);
     if (_row_index >= _segment_group->get_num_rows_per_row_block()) {
         if (OLAP_SUCCESS != _flush_row_block(false)) {

--- a/be/src/olap/rowset/rowset.h
+++ b/be/src/olap/rowset/rowset.h
@@ -98,12 +98,14 @@ public:
     virtual std::shared_ptr<RowsetReader> create_reader() = 0;
 
     // remove all files in this rowset
+    // TODO should we rename the method to remove_files() to be more specific?
     virtual OLAPStatus remove() = 0;
 
-    virtual OLAPStatus make_snapshot(const std::string& snapshot_path,
-                                     std::vector<std::string>* success_links) = 0;
-    virtual OLAPStatus copy_files_to_path(const std::string& dest_path,
-                                          std::vector<std::string>* success_files) = 0;
+    // hard link all files in this rowset to `dir` to form a new rowset with id `new_rowset_id`.
+    virtual OLAPStatus link_files_to(const std::string& dir, RowsetId new_rowset_id) = 0;
+
+    // copy all files to `dir`
+    virtual OLAPStatus copy_files_to(const std::string& dir) = 0;
 
     virtual OLAPStatus remove_old_files(std::vector<std::string>* files_to_remove) = 0;
 

--- a/be/src/olap/rowset/rowset_writer.h
+++ b/be/src/olap/rowset/rowset_writer.h
@@ -21,7 +21,6 @@
 #include "olap/rowset/rowset.h"
 #include "olap/rowset/rowset_writer_context.h"
 #include "gen_cpp/types.pb.h"
-#include "runtime/mem_pool.h"
 #include "olap/column_mapping.h"
 
 namespace doris {
@@ -37,6 +36,8 @@ public:
 
     virtual OLAPStatus init(const RowsetWriterContext& rowset_writer_context) = 0;
 
+    // Note that `row` may reference to other memory objects (such as the actual slice data) that are not necessarily
+    // get copied inside add_row. It is the caller's responsibilities to ensure those objects are alive before flush().
     virtual OLAPStatus add_row(const RowCursor& row) = 0;
     virtual OLAPStatus add_row(const ContiguousRow& row) = 0;
 
@@ -49,16 +50,11 @@ public:
     // get a rowset
     virtual RowsetSharedPtr build() = 0;
 
-    // TODO(hkp): this interface should be optimized!
-    virtual MemPool* mem_pool() = 0;
-
     virtual Version version() = 0;
 
     virtual int64_t num_rows() = 0;
 
     virtual RowsetId rowset_id() = 0;
-
-    virtual OLAPStatus garbage_collection() = 0;
 
     virtual DataDir* data_dir() = 0;
 };

--- a/be/src/olap/rowset/rowset_writer.h
+++ b/be/src/olap/rowset/rowset_writer.h
@@ -18,6 +18,7 @@
 #ifndef DORIS_BE_SRC_OLAP_ROWSET_ROWSET_WRITER_H
 #define DORIS_BE_SRC_OLAP_ROWSET_ROWSET_WRITER_H
 
+#include "gutil/macros.h"
 #include "olap/rowset/rowset.h"
 #include "olap/rowset/rowset_writer_context.h"
 #include "gen_cpp/types.pb.h"
@@ -32,12 +33,14 @@ using RowsetWriterSharedPtr = std::shared_ptr<RowsetWriter>;
 
 class RowsetWriter {
 public:
-    virtual ~RowsetWriter() { }
+    RowsetWriter() = default;
+    virtual ~RowsetWriter() = default;
+    DISALLOW_COPY_AND_ASSIGN(RowsetWriter);
 
     virtual OLAPStatus init(const RowsetWriterContext& rowset_writer_context) = 0;
 
-    // Note that `row` may reference to other memory objects (such as the actual slice data) that are not necessarily
-    // get copied inside add_row. It is the caller's responsibilities to ensure those objects are alive before flush().
+    // Memory note: input `row` is guaranteed to be copied into writer's internal buffer, including all slice data
+    // referenced by `row`. That means callers are free to de-allocate memory for `row` after this method returns.
     virtual OLAPStatus add_row(const RowCursor& row) = 0;
     virtual OLAPStatus add_row(const ContiguousRow& row) = 0;
 

--- a/be/src/olap/rowset/segment_group.cpp
+++ b/be/src/olap/rowset/segment_group.cpp
@@ -863,27 +863,23 @@ OLAPStatus SegmentGroup::link_segments_to_path(const std::string& dest_path, int
     for (int segment_id = 0; segment_id < _num_segments; segment_id++) {
         std::string data_file_name = _construct_file_name(rowset_id, segment_id, ".dat");
         std::string new_data_file_path = dest_path + "/" + data_file_name;
-        if (check_dir_existed(new_data_file_path)) {
-            LOG(WARNING) << "fail to create hard link, file already exist: " << new_data_file_path;
-            return OLAP_ERR_FILE_ALREADY_EXIST;
-        }
-        std::string origin_data_file_path = construct_data_file_path(_rowset_path_prefix, segment_id);
-        if (link(origin_data_file_path.c_str(), new_data_file_path.c_str()) != 0) {
-            LOG(WARNING) << "fail to create hard link. from=" << origin_data_file_path
-                         << ", to=" << new_data_file_path << ", error=" << strerror(errno);
-            return OLAP_ERR_OS_ERROR;
+        if (!check_dir_existed(new_data_file_path)) {
+            std::string origin_data_file_path = construct_data_file_path(_rowset_path_prefix, segment_id);
+            if (link(origin_data_file_path.c_str(), new_data_file_path.c_str()) != 0) {
+                LOG(WARNING) << "fail to create hard link. from=" << origin_data_file_path
+                             << ", to=" << new_data_file_path << ", error=" << strerror(errno);
+                return OLAP_ERR_OS_ERROR;
+            }
         }
         std::string index_file_name = _construct_file_name(rowset_id, segment_id, ".idx");
         std::string new_index_file_path = dest_path + "/" + index_file_name;
-        if (check_dir_existed(new_index_file_path)) {
-            LOG(WARNING) << "fail to create hard link, file already exist: " << new_index_file_path;
-            return OLAP_ERR_FILE_ALREADY_EXIST;
-        }
-        std::string origin_idx_file_path = construct_index_file_path(_rowset_path_prefix, segment_id);
-        if (link(origin_idx_file_path.c_str(), new_index_file_path.c_str()) != 0) {
-            LOG(WARNING) << "fail to create hard link. from=" << origin_idx_file_path
-                         << ", to=" << new_index_file_path << ", error=" << strerror(errno);
-            return OLAP_ERR_OS_ERROR;
+        if (!check_dir_existed(new_index_file_path)) {
+            std::string origin_idx_file_path = construct_index_file_path(_rowset_path_prefix, segment_id);
+            if (link(origin_idx_file_path.c_str(), new_index_file_path.c_str()) != 0) {
+                LOG(WARNING) << "fail to create hard link. from=" << origin_idx_file_path
+                             << ", to=" << new_index_file_path << ", error=" << strerror(errno);
+                return OLAP_ERR_OS_ERROR;
+            }
         }
     }
     return OLAP_SUCCESS;

--- a/be/src/olap/rowset/segment_group.cpp
+++ b/be/src/olap/rowset/segment_group.cpp
@@ -707,49 +707,12 @@ int64_t SegmentGroup::get_tablet_id() {
     return _tablet_id;
 }
 
-OLAPStatus SegmentGroup::make_snapshot(const std::string& snapshot_path,
-                                       std::vector<std::string>* success_links) {
+OLAPStatus SegmentGroup::copy_files_to(const std::string& dir) {
     if (_empty) {
         return OLAP_SUCCESS;
     }
     for (int segment_id = 0; segment_id < _num_segments; segment_id++) {
-        std::string snapshot_data_file_name = construct_data_file_path(snapshot_path, segment_id);
-        if (check_dir_existed(snapshot_data_file_name)) {
-            LOG(WARNING) << "snapshot dest file already exist, fail to make snapshot."
-                         << " file=" << snapshot_data_file_name;
-            return OLAP_ERR_FILE_ALREADY_EXIST;
-        }
-        std::string cur_data_file_name = construct_data_file_path(segment_id);
-        if (link(cur_data_file_name.c_str(), snapshot_data_file_name.c_str()) != 0) {
-            LOG(WARNING) << "fail to create hard link. from=" << cur_data_file_name << ", "
-                << "to=" << snapshot_data_file_name << ", " << "errno=" << Errno::no();
-            return OLAP_ERR_OS_ERROR;
-        }
-        success_links->push_back(snapshot_data_file_name);
-        std::string snapshot_index_file_name = construct_index_file_path(snapshot_path, segment_id);
-        if (check_dir_existed(snapshot_index_file_name)) {
-            LOG(WARNING) << "snapshot dest file already exist, fail to make snapshot."
-                         << " file=" << snapshot_index_file_name;
-            return OLAP_ERR_FILE_ALREADY_EXIST;
-        }
-        std::string cur_index_file_name = construct_index_file_path(segment_id);
-        if (link(cur_index_file_name.c_str(), snapshot_index_file_name.c_str()) != 0) {
-            LOG(WARNING) << "fail to create hard link. from=" << cur_index_file_name << ", "
-                << "to=" << snapshot_index_file_name << ", " << "errno=" << Errno::no();
-            return OLAP_ERR_OS_ERROR;
-        }
-        success_links->push_back(snapshot_index_file_name);
-    }
-    return OLAP_SUCCESS;
-}
-
-OLAPStatus SegmentGroup::copy_files_to_path(const std::string& dest_path,
-                                            std::vector<std::string>* success_files) {
-    if (_empty) {
-        return OLAP_SUCCESS;
-    }
-    for (int segment_id = 0; segment_id < _num_segments; segment_id++) {
-        std::string dest_data_file = construct_data_file_path(dest_path, segment_id);
+        std::string dest_data_file = construct_data_file_path(dir, segment_id);
         if (check_dir_existed(dest_data_file)) {
             LOG(WARNING) << "file already exists:" << dest_data_file;
             return OLAP_ERR_FILE_ALREADY_EXIST;
@@ -761,8 +724,7 @@ OLAPStatus SegmentGroup::copy_files_to_path(const std::string& dest_path,
                          << ", errno=" << Errno::no();
             return OLAP_ERR_OS_ERROR;
         }
-        success_files->push_back(dest_data_file);
-        std::string dest_index_file = construct_index_file_path(dest_path, segment_id);
+        std::string dest_index_file = construct_index_file_path(dir, segment_id);
         if (check_dir_existed(dest_index_file)) {
             LOG(WARNING) << "file already exists:" << dest_index_file;
             return OLAP_ERR_FILE_ALREADY_EXIST;
@@ -774,7 +736,6 @@ OLAPStatus SegmentGroup::copy_files_to_path(const std::string& dest_path,
                          << ", errno=" << Errno::no();
             return OLAP_ERR_OS_ERROR;
         }
-        success_files->push_back(dest_index_file);
     }
     return OLAP_SUCCESS;
 }
@@ -902,23 +863,27 @@ OLAPStatus SegmentGroup::link_segments_to_path(const std::string& dest_path, int
     for (int segment_id = 0; segment_id < _num_segments; segment_id++) {
         std::string data_file_name = _construct_file_name(rowset_id, segment_id, ".dat");
         std::string new_data_file_path = dest_path + "/" + data_file_name;
-        if (!check_dir_existed(new_data_file_path)) {
-            std::string origin_data_file_path = construct_data_file_path(_rowset_path_prefix, segment_id);
-            if (link(origin_data_file_path.c_str(), new_data_file_path.c_str()) != 0) {
-                LOG(WARNING) << "fail to create hard link. from=" << origin_data_file_path
-                             << ", to=" << new_data_file_path << ", error=" << strerror(errno);
-                return OLAP_ERR_OS_ERROR;
-            }
+        if (check_dir_existed(new_data_file_path)) {
+            LOG(WARNING) << "fail to create hard link, file already exist: " << new_data_file_path;
+            return OLAP_ERR_FILE_ALREADY_EXIST;
+        }
+        std::string origin_data_file_path = construct_data_file_path(_rowset_path_prefix, segment_id);
+        if (link(origin_data_file_path.c_str(), new_data_file_path.c_str()) != 0) {
+            LOG(WARNING) << "fail to create hard link. from=" << origin_data_file_path
+                         << ", to=" << new_data_file_path << ", error=" << strerror(errno);
+            return OLAP_ERR_OS_ERROR;
         }
         std::string index_file_name = _construct_file_name(rowset_id, segment_id, ".idx");
         std::string new_index_file_path = dest_path + "/" + index_file_name;
-        if (!check_dir_existed(new_index_file_path)) {
-            std::string origin_idx_file_path = construct_index_file_path(_rowset_path_prefix, segment_id);
-            if (link(origin_idx_file_path.c_str(), new_index_file_path.c_str()) != 0) {
-                LOG(WARNING) << "fail to create hard link. from=" << origin_idx_file_path
-                             << ", to=" << new_index_file_path << ", error=" << strerror(errno);
-                return OLAP_ERR_OS_ERROR;
-            }
+        if (check_dir_existed(new_index_file_path)) {
+            LOG(WARNING) << "fail to create hard link, file already exist: " << new_index_file_path;
+            return OLAP_ERR_FILE_ALREADY_EXIST;
+        }
+        std::string origin_idx_file_path = construct_index_file_path(_rowset_path_prefix, segment_id);
+        if (link(origin_idx_file_path.c_str(), new_index_file_path.c_str()) != 0) {
+            LOG(WARNING) << "fail to create hard link. from=" << origin_idx_file_path
+                         << ", to=" << new_index_file_path << ", error=" << strerror(errno);
+            return OLAP_ERR_OS_ERROR;
         }
     }
     return OLAP_SUCCESS;

--- a/be/src/olap/rowset/segment_group.h
+++ b/be/src/olap/rowset/segment_group.h
@@ -260,10 +260,7 @@ public:
 
     OLAPStatus remove_old_files(std::vector<std::string>* linkes_to_remove);
 
-    OLAPStatus make_snapshot(const std::string& snapshot_path,
-                             std::vector<std::string>* success_links);
-    OLAPStatus copy_files_to_path(const std::string& dest_path,
-                                  std::vector<std::string>* success_files);
+    OLAPStatus copy_files_to(const std::string& dir);
 
     OLAPStatus link_segments_to_path(const std::string& dest_path, int64_t rowset_id);
 

--- a/be/src/olap/rowset/segment_v2/segment_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_writer.cpp
@@ -18,6 +18,7 @@
 #include "olap/rowset/segment_v2/segment_writer.h"
 
 #include "env/env.h" // Env
+#include "olap/row.h" // ContiguousRow
 #include "olap/row_block.h" // RowBlock
 #include "olap/row_cursor.h" // RowCursor
 #include "olap/rowset/segment_v2/column_writer.h" // ColumnWriter
@@ -30,7 +31,7 @@ const char* k_segment_magic = "D0R1";
 const uint32_t k_segment_magic_length = 4;
 
 SegmentWriter::SegmentWriter(std::string fname, uint32_t segment_id,
-                             const std::shared_ptr<TabletSchema>& tablet_schema,
+                             const TabletSchema* tablet_schema,
                              const SegmentWriterOptions& opts)
         : _fname(std::move(fname)),
         _segment_id(segment_id),
@@ -88,6 +89,7 @@ Status SegmentWriter::append_row(const RowType& row) {
 }
 
 template Status SegmentWriter::append_row(const RowCursor& row);
+template Status SegmentWriter::append_row(const ContiguousRow& row);
 
 uint64_t SegmentWriter::estimate_segment_size() {
     return 0;

--- a/be/src/olap/rowset/segment_v2/segment_writer.h
+++ b/be/src/olap/rowset/segment_v2/segment_writer.h
@@ -49,7 +49,7 @@ class SegmentWriter {
 public:
     explicit SegmentWriter(std::string file_name,
                            uint32_t segment_id,
-                           const std::shared_ptr<TabletSchema>& tablet_schema,
+                           const TabletSchema* tablet_schema,
                            const SegmentWriterOptions& opts);
 
     ~SegmentWriter();
@@ -72,7 +72,7 @@ private:
 private:
     std::string _fname;
     uint32_t _segment_id;
-    std::shared_ptr<TabletSchema> _tablet_schema;
+    const TabletSchema* _tablet_schema;
     size_t _num_short_keys;
     SegmentWriterOptions _opts;
 

--- a/be/src/olap/schema_change.cpp
+++ b/be/src/olap/schema_change.cpp
@@ -575,7 +575,7 @@ bool RowBlockMerger::merge(
 
     _make_heap(row_block_arr);
 
-    row_cursor.allocate_memory_for_string_type(_tablet->tablet_schema(), nullptr);
+    row_cursor.allocate_memory_for_string_type(_tablet->tablet_schema());
     while (_heap.size() > 0) {
         init_row_with_others(&row_cursor, *(_heap.top().row_cursor));
 

--- a/be/src/olap/schema_change.h
+++ b/be/src/olap/schema_change.h
@@ -39,8 +39,6 @@ class Tablet;
 class RowBlock;
 // defined in 'row_cursor.h'
 class RowCursor;
-// defined in 'mem_pool.h'
-class MemPool;
 
 class RowBlockChanger {
 public:
@@ -162,10 +160,9 @@ public:
 private:
     const RowBlockChanger& _row_block_changer;
     RowBlockAllocator* _row_block_allocator;
-    RowCursor* _src_cursor;
-    RowCursor* _dst_cursor;
+    RowCursor* _cursor;
 
-    bool _write_row_block(RowsetWriterSharedPtr rowset_builder, RowBlock* row_block, MemPool* mem_pool);
+    bool _write_row_block(RowsetWriter* rowset_builder, RowBlock* row_block);
 
     DISALLOW_COPY_AND_ASSIGN(SchemaChangeDirectly);
 };

--- a/be/src/olap/schema_change.h
+++ b/be/src/olap/schema_change.h
@@ -39,6 +39,8 @@ class Tablet;
 class RowBlock;
 // defined in 'row_cursor.h'
 class RowCursor;
+// defined in 'mem_pool.h'
+class MemPool;
 
 class RowBlockChanger {
 public:
@@ -163,7 +165,7 @@ private:
     RowCursor* _src_cursor;
     RowCursor* _dst_cursor;
 
-    bool _write_row_block(RowsetWriterSharedPtr rowset_builder, RowBlock* row_block);
+    bool _write_row_block(RowsetWriterSharedPtr rowset_builder, RowBlock* row_block, MemPool* mem_pool);
 
     DISALLOW_COPY_AND_ASSIGN(SchemaChangeDirectly);
 };

--- a/be/src/olap/snapshot_manager.cpp
+++ b/be/src/olap/snapshot_manager.cpp
@@ -334,8 +334,7 @@ OLAPStatus SnapshotManager::_link_index_and_data_files(
         const std::vector<RowsetSharedPtr>& consistent_rowsets) {
     OLAPStatus res = OLAP_SUCCESS;
     for (auto& rs : consistent_rowsets) {
-        std::vector<std::string> success_files;
-        RETURN_NOT_OK(rs->make_snapshot(schema_hash_path, &success_files));
+        RETURN_NOT_OK(rs->link_files_to(schema_hash_path, rs->rowset_id()));
     }
     return res;
 }
@@ -458,8 +457,7 @@ OLAPStatus SnapshotManager::_create_snapshot_files(
 
         vector<RowsetMetaSharedPtr> rs_metas;
         for (auto& rs : consistent_rowsets) {
-            std::vector<std::string> success_files;
-            res = rs->make_snapshot(schema_full_path, &success_files);
+            res = rs->link_files_to(schema_full_path, rs->rowset_id());
             if (res != OLAP_SUCCESS) { break; }
             rs_metas.push_back(rs->rowset_meta());
             VLOG(3) << "add rowset meta to clone list. " 

--- a/be/src/olap/task/engine_storage_migration_task.cpp
+++ b/be/src/olap/task/engine_storage_migration_task.cpp
@@ -250,10 +250,9 @@ OLAPStatus EngineStorageMigrationTask::_copy_index_and_data_files(
         const string& schema_hash_path,
         const TabletSharedPtr& ref_tablet,
         std::vector<RowsetSharedPtr>& consistent_rowsets) {
-    std::vector<std::string> success_files;
     OLAPStatus status = OLAP_SUCCESS;
     for (auto& rs : consistent_rowsets) {
-        status = rs->copy_files_to_path(schema_hash_path, &success_files);
+        status = rs->copy_files_to(schema_hash_path);
         if (status != OLAP_SUCCESS) {
             if (remove_all_dir(schema_hash_path) != OLAP_SUCCESS) {
                 LOG(FATAL) << "remove storage migration path failed. "

--- a/be/src/olap/types.cpp
+++ b/be/src/olap/types.cpp
@@ -23,6 +23,7 @@ template<typename TypeTraitsClass>
 TypeInfo::TypeInfo(TypeTraitsClass t)
       : _equal(TypeTraitsClass::equal),
         _cmp(TypeTraitsClass::cmp),
+        _shallow_copy(TypeTraitsClass::shallow_copy),
         _deep_copy(TypeTraitsClass::deep_copy),
         _copy_with_arena(TypeTraitsClass::copy_with_arena),
         _direct_copy(TypeTraitsClass::direct_copy),

--- a/be/src/olap/types.h
+++ b/be/src/olap/types.h
@@ -48,6 +48,10 @@ public:
         return _cmp(left, right);
     }
 
+    inline void shallow_copy(void* dest, const void* src) const {
+        _shallow_copy(dest, src);
+    }
+
     inline void deep_copy(void* dest, const void* src, MemPool* mem_pool) const {
         _deep_copy(dest, src, mem_pool);
     }
@@ -77,6 +81,7 @@ private:
     bool (*_equal)(const void* left, const void* right);
     int (*_cmp)(const void* left, const void* right);
 
+    void (*_shallow_copy)(void* dest, const void* src);
     void (*_deep_copy)(void* dest, const void* src, MemPool* mem_pool);
     void (*_copy_with_arena)(void* dest, const void* src, Arena* arena);
     void (*_direct_copy)(void* dest, const void* src);
@@ -178,6 +183,10 @@ struct BaseFieldtypeTraits : public CppTypeTraits<field_type> {
         } else {
             return 0;
         }
+    }
+
+    static inline void shallow_copy(void* dest, const void* src) {
+        *reinterpret_cast<CppType*>(dest) = *reinterpret_cast<const CppType*>(src);
     }
 
     static inline void deep_copy(void* dest, const void* src, MemPool* mem_pool) {
@@ -325,8 +334,12 @@ struct FieldTypeTraits<OLAP_FIELD_TYPE_LARGEINT> : public BaseFieldtypeTraits<OL
 
         return std::string(buf);
     }
+
     // GCC7.3 will generate movaps instruction, which will lead to SEGV when buf is
     // not aligned to 16 byte
+    static void shallow_copy(void* dest, const void* src) {
+        *reinterpret_cast<PackedInt128*>(dest) = *reinterpret_cast<const PackedInt128*>(src);
+    }
     static void deep_copy(void* dest, const void* src, MemPool* mem_pool) {
         *reinterpret_cast<PackedInt128*>(dest) = *reinterpret_cast<const PackedInt128*>(src);
     }
@@ -485,13 +498,13 @@ struct FieldTypeTraits<OLAP_FIELD_TYPE_DATETIME> : public BaseFieldtypeTraits<OL
 template<>
 struct FieldTypeTraits<OLAP_FIELD_TYPE_CHAR> : public BaseFieldtypeTraits<OLAP_FIELD_TYPE_CHAR> {
     static bool equal(const void* left, const void* right) {
-        const Slice* l_slice = reinterpret_cast<const Slice*>(left);
-        const Slice* r_slice = reinterpret_cast<const Slice*>(right);
+        auto l_slice = reinterpret_cast<const Slice*>(left);
+        auto r_slice = reinterpret_cast<const Slice*>(right);
         return *l_slice == *r_slice;
     }
     static int cmp(const void* left, const void* right) {
-        const Slice* l_slice = reinterpret_cast<const Slice*>(left);
-        const Slice* r_slice = reinterpret_cast<const Slice*>(right);
+        auto l_slice = reinterpret_cast<const Slice*>(left);
+        auto r_slice = reinterpret_cast<const Slice*>(right);
         return l_slice->compare(*r_slice);
     }
     static OLAPStatus from_string(void* buf, const std::string& scan_key) {
@@ -502,7 +515,7 @@ struct FieldTypeTraits<OLAP_FIELD_TYPE_CHAR> : public BaseFieldtypeTraits<OLAP_F
             return OLAP_ERR_INPUT_PARAMETER_ERROR;
         }
 
-        Slice* slice = reinterpret_cast<Slice*>(buf);
+        auto slice = reinterpret_cast<Slice*>(buf);
         memory_copy(slice->data, scan_key.c_str(), value_len);
         if (slice->size < value_len) {
             /*
@@ -515,41 +528,41 @@ struct FieldTypeTraits<OLAP_FIELD_TYPE_CHAR> : public BaseFieldtypeTraits<OLAP_F
         return OLAP_SUCCESS;
     }
     static std::string to_string(const void* src) {
-        const Slice* slice = reinterpret_cast<const Slice*>(src);
+        auto slice = reinterpret_cast<const Slice*>(src);
         return slice->to_string();
     }
     static void deep_copy(void* dest, const void* src, MemPool* mem_pool) {
-        Slice* l_slice = reinterpret_cast<Slice*>(dest);
-        const Slice* r_slice = reinterpret_cast<const Slice*>(src);
+        auto l_slice = reinterpret_cast<Slice*>(dest);
+        auto r_slice = reinterpret_cast<const Slice*>(src);
         l_slice->data = reinterpret_cast<char*>(mem_pool->allocate(r_slice->size));
         memory_copy(l_slice->data, r_slice->data, r_slice->size);
         l_slice->size = r_slice->size;
     }
     static void copy_with_arena(void* dest, const void* src, Arena* arena) {
-        Slice* l_slice = reinterpret_cast<Slice*>(dest);
-        const Slice* r_slice = reinterpret_cast<const Slice*>(src);
+        auto l_slice = reinterpret_cast<Slice*>(dest);
+        auto r_slice = reinterpret_cast<const Slice*>(src);
         l_slice->data = reinterpret_cast<char*>(arena->Allocate(r_slice->size));
         memory_copy(l_slice->data, r_slice->data, r_slice->size);
         l_slice->size = r_slice->size;
     }
     static void direct_copy(void* dest, const void* src) {
-        Slice* l_slice = reinterpret_cast<Slice*>(dest);
-        const Slice* r_slice = reinterpret_cast<const Slice*>(src);
+        auto l_slice = reinterpret_cast<Slice*>(dest);
+        auto r_slice = reinterpret_cast<const Slice*>(src);
         memory_copy(l_slice->data, r_slice->data, r_slice->size);
         l_slice->size = r_slice->size;
     }
     static void set_to_max(void* buf) {
         // this function is used by scan key,
         // the size may be greater than length in schema.
-        Slice* slice = reinterpret_cast<Slice*>(buf);
+        auto slice = reinterpret_cast<Slice*>(buf);
         memset(slice->data, 0xff, slice->size);
     }
     static void set_to_min(void* buf) {
-        Slice* slice = reinterpret_cast<Slice*>(buf);
+        auto slice = reinterpret_cast<Slice*>(buf);
         memset(slice->data, 0, slice->size);
     }
     static uint32_t hash_code(const void* data, uint32_t seed) {
-        const Slice* slice = reinterpret_cast<const Slice*>(data);
+        auto slice = reinterpret_cast<const Slice*>(data);
         return HashUtil::hash(slice->data, slice->size, seed);
     }
 };
@@ -564,18 +577,18 @@ struct FieldTypeTraits<OLAP_FIELD_TYPE_VARCHAR> : public FieldTypeTraits<OLAP_FI
             return OLAP_ERR_INPUT_PARAMETER_ERROR;
         }
 
-        Slice* slice = reinterpret_cast<Slice*>(buf);
+        auto slice = reinterpret_cast<Slice*>(buf);
         memory_copy(slice->data, scan_key.c_str(), value_len);
         slice->size = value_len;
         return OLAP_SUCCESS;
     }
     static void set_to_max(void* buf) {
-        Slice* slice = reinterpret_cast<Slice*>(buf);
+        auto slice = reinterpret_cast<Slice*>(buf);
         slice->size = 1;
         memset(slice->data, 0xFF, 1);
     }
     static void set_to_min(void* buf) {
-        Slice* slice = reinterpret_cast<Slice*>(buf);
+        auto slice = reinterpret_cast<Slice*>(buf);
         slice->size = 0;
     }
 };

--- a/be/test/olap/rowset/segment_v2/segment_test.cpp
+++ b/be/test/olap/rowset/segment_v2/segment_test.cpp
@@ -64,7 +64,7 @@ TEST_F(SegmentReaderWriterTest, normal) {
     opts.num_rows_per_block = num_rows_per_block;
 
     std::string fname = dname + "/int_case";
-    SegmentWriter writer(fname, 0, tablet_schema, opts);
+    SegmentWriter writer(fname, 0, tablet_schema.get(), opts);
     auto st = writer.init(10);
     ASSERT_TRUE(st.ok());
 


### PR DESCRIPTION
BetaRowsetWriter is used to write rowset in V2 segment format.

This PR contains several interface changes
1. Rowset.make_snapshot() is renamed to `link_files_to` because hard links are also useful in copy task, linked schema change, etc
2. Rowset.copy_files_to_path() is renamed to `copy_files_to` to be consistent with other names
3. RowsetWriter.mem_pool() is removed because not all rowset writers use MemPool
4. RowsetWriter.garbage_collection() is removed because it's not used by clients
5. SegmentGroup's make_snapshot() is removed because link_segments_to_path() provides similar functionality

Future works
1. implement zonemap for beta rowset writer
2. collect index size in beta rowset
3. choose `write_mbytes_per_sec` based on writer type (load/base compaction/cumulative compaction)