### PR TITLE
Fix parquet directory have empty file

### DIFF
--- a/be/src/exec/parquet_reader.cpp
+++ b/be/src/exec/parquet_reader.cpp
@@ -55,6 +55,9 @@ Status ParquetReaderWrap::init_parquet_reader(const std::vector<SlotDescriptor*>
         _file_metadata = _reader->parquet_reader()->metadata();
         // initial members
         _total_groups = _file_metadata->num_row_groups();
+        if (_total_groups == 0) {
+            return Status::EndOfFile("Empty Parquet File");
+        }
         _rows_of_group = _file_metadata->RowGroup(0)->num_rows();
 
         // map

--- a/be/src/exec/parquet_scanner.cpp
+++ b/be/src/exec/parquet_scanner.cpp
@@ -143,7 +143,7 @@ Status ParquetScanner::open_next_reader() {
         }
         _cur_file_reader = new ParquetReaderWrap(file_reader.release());
         Status status = _cur_file_reader->init_parquet_reader(_src_slot_descs);
-        if(status.is_end_of_file()) {
+        if (status.is_end_of_file()) {
             continue;
         } else {
             return status;

--- a/be/src/exec/parquet_scanner.cpp
+++ b/be/src/exec/parquet_scanner.cpp
@@ -142,7 +142,12 @@ Status ParquetScanner::open_next_reader() {
             continue;
         }
         _cur_file_reader = new ParquetReaderWrap(file_reader.release());
-        return _cur_file_reader->init_parquet_reader(_src_slot_descs);
+        Status status = _cur_file_reader->init_parquet_reader(_src_slot_descs);
+        if(status.is_end_of_file()) {
+            continue;
+        } else {
+            return status;
+        }
     }
 }
 


### PR DESCRIPTION
When you import the parquet type file directory generated by SPARK. 
you might have multiple files, but some of them have only headers and no data. 
But this is a normal situation that can lead to overall failure.

#1594