### PR TITLE
[Doris On ES][Bug-Fix] Fix errors when es username and passwd is empty

### DIFF
--- a/fe/src/main/java/org/apache/doris/external/EsRestClient.java
+++ b/fe/src/main/java/org/apache/doris/external/EsRestClient.java
@@ -121,7 +121,7 @@ public class EsRestClient {
             }
             nextNode = selectNextNode();
             if (!nextNode) {
-                LOG.error("try all nodes [{}],no other nodes left", nodes);
+                LOG.warn("try all nodes [{}],no other nodes left", nodes);
             }
         } while (nextNode);
         return null;

--- a/fe/src/main/java/org/apache/doris/external/EsRestClient.java
+++ b/fe/src/main/java/org/apache/doris/external/EsRestClient.java
@@ -95,6 +95,7 @@ public class EsRestClient {
 
     /**
      * execute request for specific path
+     *
      * @param path the path must not leading with '/'
      * @return
      */
@@ -102,11 +103,14 @@ public class EsRestClient {
         selectNextNode();
         boolean nextNode;
         do {
-            Request request = new Request.Builder()
-                    .get()
-                    .addHeader("Authorization", basicAuth)
+            Request.Builder builder = new Request.Builder();
+            if (!Strings.isEmpty(basicAuth)) {
+                builder.addHeader("Authorization", basicAuth);
+            }
+            Request request = builder.get()
                     .url(currentNode + "/" + path)
                     .build();
+            LOG.trace("es rest client request URL: {}", currentNode + "/" + path);
             try {
                 Response response = networkClient.newCall(request).execute();
                 if (response.isSuccessful()) {

--- a/fe/src/main/java/org/apache/doris/external/EsStateStore.java
+++ b/fe/src/main/java/org/apache/doris/external/EsStateStore.java
@@ -103,7 +103,7 @@ public class EsStateStore extends Daemon {
                 }
                 esTable.setEsTableState(esTableState);
             } catch (Throwable e) {
-                LOG.error("errors while load table {} state from es", esTable.getName());
+                LOG.error("Exception happens when fetch index [{}] meta data from remote es cluster", esTable.getName(), e);
             }
         }
     }

--- a/fe/src/main/java/org/apache/doris/external/EsStateStore.java
+++ b/fe/src/main/java/org/apache/doris/external/EsStateStore.java
@@ -103,7 +103,7 @@ public class EsStateStore extends Daemon {
                 }
                 esTable.setEsTableState(esTableState);
             } catch (Throwable e) {
-                LOG.error("Exception happens when fetch index [{}] meta data from remote es cluster", esTable.getName(), e);
+                LOG.warn("Exception happens when fetch index [{}] meta data from remote es cluster", esTable.getName(), e);
             }
         }
     }


### PR DESCRIPTION
Create external es table, when username and password is empty,  EsRestClient#execute Request.Builder throws NullPointerException. 