### PR TITLE
Avoid load or query failed when doing alter job

### DIFF
--- a/fe/src/main/java/org/apache/doris/catalog/TabletInvertedIndex.java
+++ b/fe/src/main/java/org/apache/doris/catalog/TabletInvertedIndex.java
@@ -398,12 +398,10 @@ public class TabletInvertedIndex {
             return false;
         }
 
-        if (backendTabletInfo.getVersion() < replicaInFe.getVersion()
-                && backendTabletInfo.isSetVersion_miss() && backendTabletInfo.isVersion_miss()) {
+        if (backendTabletInfo.isSetVersion_miss() && backendTabletInfo.isVersion_miss()) {
             // even if backend version is less than fe's version, but if version_miss is false,
             // which means this may be a stale report.
             // so we only return true if version_miss is true.
-            LOG.info("replicaversion missing");
             return true;
         }
         return false;


### PR DESCRIPTION
2 cases:

1. Sometimes a missing version replica can not be repaired. Which may cause query failed
with error: `failed to initialize storage reader. tablet=xxx, res=-214`

2. Cancel the rollup job when there are load jobs on that table may cause load job fail.
    We should ignore "table not found" exception when committing the txn.