### PR TITLE
Fix bug that encounter "No more data to read" when accessing broker

### DIFF
--- a/fs_brokers/apache_hdfs_broker/src/main/java/org/apache/doris/broker/hdfs/BrokerException.java
+++ b/fs_brokers/apache_hdfs_broker/src/main/java/org/apache/doris/broker/hdfs/BrokerException.java
@@ -63,7 +63,7 @@ public class BrokerException extends RuntimeException {
     
     public TBrokerOperationStatus generateFailedOperationStatus() {
         TBrokerOperationStatus errorStatus = new TBrokerOperationStatus(errorCode);
-        errorStatus.setMessage(super.getMessage() + ", cause by: " + getCause() != null ? getCause().getMessage() : "null");
+        errorStatus.setMessage(super.getMessage() + ", cause by: " + (getCause() != null ? getCause().getMessage() : "null"));
         return errorStatus;
     }
 }


### PR DESCRIPTION
The errorMsg in TBrokerOperationStatus is set to null because of
invalid string joint operation.

```
String str = null;
System.out.println("get string: " + str != null ? str : "null string");
```
Above code will get `null`, but excepted: `get string: null string`
This should be right:

```
System.out.println("get string: " + (str != null ? str : "null string"));
```