### PR TITLE
Change the prefix of table info apis

### DIFF
--- a/fe/src/main/java/org/apache/doris/http/rest/CancelStreamLoad.java
+++ b/fe/src/main/java/org/apache/doris/http/rest/CancelStreamLoad.java
@@ -32,8 +32,6 @@ import com.google.common.base.Strings;
 import io.netty.handler.codec.http.HttpMethod;
 
 public class CancelStreamLoad extends RestBaseAction {
-    private static final String LABEL_KEY = "label";
-
     public CancelStreamLoad(ActionController controller) {
         super(controller);
     }

--- a/fe/src/main/java/org/apache/doris/http/rest/CancelStreamLoad.java
+++ b/fe/src/main/java/org/apache/doris/http/rest/CancelStreamLoad.java
@@ -32,7 +32,6 @@ import com.google.common.base.Strings;
 import io.netty.handler.codec.http.HttpMethod;
 
 public class CancelStreamLoad extends RestBaseAction {
-    private static final String DB_KEY = "db";
     private static final String LABEL_KEY = "label";
 
     public CancelStreamLoad(ActionController controller) {

--- a/fe/src/main/java/org/apache/doris/http/rest/GetLoadInfoAction.java
+++ b/fe/src/main/java/org/apache/doris/http/rest/GetLoadInfoAction.java
@@ -32,7 +32,6 @@ import io.netty.handler.codec.http.HttpMethod;
 
 // Get load information of one load job
 public class GetLoadInfoAction extends RestBaseAction {
-    private static final String DB_KEY = "db";
     private static final String LABEL_KEY = "label";
 
     public GetLoadInfoAction(ActionController controller) {
@@ -42,7 +41,7 @@ public class GetLoadInfoAction extends RestBaseAction {
     public static void registerAction(ActionController controller)
             throws IllegalArgException {
         GetLoadInfoAction action = new GetLoadInfoAction(controller);
-        controller.registerHandler(HttpMethod.GET, "/api/{db}/_load_info", action);
+        controller.registerHandler(HttpMethod.GET, "/api/{" + DB_KEY + "}/_load_info", action);
     }
 
     @Override

--- a/fe/src/main/java/org/apache/doris/http/rest/GetLoadInfoAction.java
+++ b/fe/src/main/java/org/apache/doris/http/rest/GetLoadInfoAction.java
@@ -32,8 +32,6 @@ import io.netty.handler.codec.http.HttpMethod;
 
 // Get load information of one load job
 public class GetLoadInfoAction extends RestBaseAction {
-    private static final String LABEL_KEY = "label";
-
     public GetLoadInfoAction(ActionController controller) {
         super(controller);
     }

--- a/fe/src/main/java/org/apache/doris/http/rest/GetStreamLoadState.java
+++ b/fe/src/main/java/org/apache/doris/http/rest/GetStreamLoadState.java
@@ -31,7 +31,6 @@ import com.google.common.base.Strings;
 import io.netty.handler.codec.http.HttpMethod;
 
 public class GetStreamLoadState extends RestBaseAction {
-    private static final String DB_KEY = "db";
     private static final String LABEL_KEY = "label";
 
     public GetStreamLoadState(ActionController controller) {

--- a/fe/src/main/java/org/apache/doris/http/rest/GetStreamLoadState.java
+++ b/fe/src/main/java/org/apache/doris/http/rest/GetStreamLoadState.java
@@ -31,8 +31,6 @@ import com.google.common.base.Strings;
 import io.netty.handler.codec.http.HttpMethod;
 
 public class GetStreamLoadState extends RestBaseAction {
-    private static final String LABEL_KEY = "label";
-
     public GetStreamLoadState(ActionController controller) {
         super(controller);
     }

--- a/fe/src/main/java/org/apache/doris/http/rest/LoadAction.java
+++ b/fe/src/main/java/org/apache/doris/http/rest/LoadAction.java
@@ -43,7 +43,6 @@ public class LoadAction extends RestBaseAction {
     private static final Logger LOG = LogManager.getLogger(LoadAction.class);
 
     public static final String CLUSTER_NAME_PARAM = "cluster";
-    public static final String DB_NAME_PARAM = "db";
     public static final String TABLE_NAME_PARAM = "table";
     public static final String LABEL_NAME_PARAM = "label";
     public static final String SUB_LABEL_NAME_PARAM = "sub_label";
@@ -65,11 +64,11 @@ public class LoadAction extends RestBaseAction {
         ExecuteEnv execEnv = ExecuteEnv.getInstance();
         LoadAction action = new LoadAction(controller, execEnv);
         controller.registerHandler(HttpMethod.PUT,
-                "/api/{" + DB_NAME_PARAM + "}/{" + TABLE_NAME_PARAM + "}/_load", action);
+                                   "/api/{" + DB_KEY + "}/{" + TABLE_NAME_PARAM + "}/_load", action);
 
         controller.registerHandler(HttpMethod.PUT,
-                "/api/{" + DB_NAME_PARAM + "}/{" + TABLE_NAME_PARAM + "}/_stream_load",
-                new LoadAction(controller, execEnv, true));
+                                   "/api/{" + DB_KEY + "}/{" + TABLE_NAME_PARAM + "}/_stream_load",
+                                   new LoadAction(controller, execEnv, true));
     }
 
     @Override
@@ -86,7 +85,7 @@ public class LoadAction extends RestBaseAction {
             throw new DdlException("No cluster selected.");
         }
 
-        String dbName = request.getSingleParameter(DB_NAME_PARAM);
+        String dbName = request.getSingleParameter(DB_KEY);
         if (Strings.isNullOrEmpty(dbName)) {
             throw new DdlException("No database selected.");
         }

--- a/fe/src/main/java/org/apache/doris/http/rest/LoadAction.java
+++ b/fe/src/main/java/org/apache/doris/http/rest/LoadAction.java
@@ -42,9 +42,6 @@ import io.netty.handler.codec.http.HttpMethod;
 public class LoadAction extends RestBaseAction {
     private static final Logger LOG = LogManager.getLogger(LoadAction.class);
 
-    public static final String CLUSTER_NAME_PARAM = "cluster";
-    public static final String TABLE_NAME_PARAM = "table";
-    public static final String LABEL_NAME_PARAM = "label";
     public static final String SUB_LABEL_NAME_PARAM = "sub_label";
 
     private ExecuteEnv execEnv;
@@ -64,10 +61,10 @@ public class LoadAction extends RestBaseAction {
         ExecuteEnv execEnv = ExecuteEnv.getInstance();
         LoadAction action = new LoadAction(controller, execEnv);
         controller.registerHandler(HttpMethod.PUT,
-                                   "/api/{" + DB_KEY + "}/{" + TABLE_NAME_PARAM + "}/_load", action);
+                                   "/api/{" + DB_KEY + "}/{" + TABLE_KEY + "}/_load", action);
 
         controller.registerHandler(HttpMethod.PUT,
-                                   "/api/{" + DB_KEY + "}/{" + TABLE_NAME_PARAM + "}/_stream_load",
+                                   "/api/{" + DB_KEY + "}/{" + TABLE_KEY + "}/_stream_load",
                                    new LoadAction(controller, execEnv, true));
     }
 
@@ -90,14 +87,14 @@ public class LoadAction extends RestBaseAction {
             throw new DdlException("No database selected.");
         }
 
-        String tableName = request.getSingleParameter(TABLE_NAME_PARAM);
+        String tableName = request.getSingleParameter(TABLE_KEY);
         if (Strings.isNullOrEmpty(dbName)) {
             throw new DdlException("No table selected.");
         }
         
         String fullDbName = ClusterNamespace.getFullName(authInfo.cluster, dbName);
 
-        String label = request.getSingleParameter(LABEL_NAME_PARAM);
+        String label = request.getSingleParameter(LABEL_KEY);
         if (!isStreamLoad) {
             if (Strings.isNullOrEmpty(label)) {
                 throw new DdlException("No label selected.");

--- a/fe/src/main/java/org/apache/doris/http/rest/MultiAbort.java
+++ b/fe/src/main/java/org/apache/doris/http/rest/MultiAbort.java
@@ -31,7 +31,6 @@ import com.google.common.base.Strings;
 import io.netty.handler.codec.http.HttpMethod;
 
 public class MultiAbort extends RestBaseAction {
-    private static final String DB_KEY = "db";
     private static final String LABEL_KEY = "label";
 
     private ExecuteEnv execEnv;
@@ -44,7 +43,7 @@ public class MultiAbort extends RestBaseAction {
     public static void registerAction(ActionController controller) throws IllegalArgException {
         ExecuteEnv executeEnv = ExecuteEnv.getInstance();
         MultiAbort action = new MultiAbort(controller, executeEnv);
-        controller.registerHandler(HttpMethod.POST, "/api/{db}/_multi_abort", action);
+        controller.registerHandler(HttpMethod.POST, "/api/{" + DB_KEY + "}/_multi_abort", action);
     }
 
     @Override

--- a/fe/src/main/java/org/apache/doris/http/rest/MultiAbort.java
+++ b/fe/src/main/java/org/apache/doris/http/rest/MultiAbort.java
@@ -31,8 +31,6 @@ import com.google.common.base.Strings;
 import io.netty.handler.codec.http.HttpMethod;
 
 public class MultiAbort extends RestBaseAction {
-    private static final String LABEL_KEY = "label";
-
     private ExecuteEnv execEnv;
 
     public MultiAbort(ActionController controller, ExecuteEnv execEnv) {

--- a/fe/src/main/java/org/apache/doris/http/rest/MultiCommit.java
+++ b/fe/src/main/java/org/apache/doris/http/rest/MultiCommit.java
@@ -31,7 +31,6 @@ import com.google.common.base.Strings;
 import io.netty.handler.codec.http.HttpMethod;
 
 public class MultiCommit extends RestBaseAction {
-    private static final String DB_KEY = "db";
     private static final String LABEL_KEY = "label";
 
     private ExecuteEnv execEnv;
@@ -44,7 +43,7 @@ public class MultiCommit extends RestBaseAction {
     public static void registerAction(ActionController controller) throws IllegalArgException {
         ExecuteEnv executeEnv = ExecuteEnv.getInstance();
         MultiCommit action = new MultiCommit(controller, executeEnv);
-        controller.registerHandler(HttpMethod.POST, "/api/{db}/_multi_commit", action);
+        controller.registerHandler(HttpMethod.POST, "/api/{" + DB_KEY + "}/_multi_commit", action);
     }
 
     @Override

--- a/fe/src/main/java/org/apache/doris/http/rest/MultiCommit.java
+++ b/fe/src/main/java/org/apache/doris/http/rest/MultiCommit.java
@@ -31,8 +31,6 @@ import com.google.common.base.Strings;
 import io.netty.handler.codec.http.HttpMethod;
 
 public class MultiCommit extends RestBaseAction {
-    private static final String LABEL_KEY = "label";
-
     private ExecuteEnv execEnv;
 
     public MultiCommit(ActionController controller, ExecuteEnv execEnv) {

--- a/fe/src/main/java/org/apache/doris/http/rest/MultiDesc.java
+++ b/fe/src/main/java/org/apache/doris/http/rest/MultiDesc.java
@@ -35,8 +35,6 @@ import io.netty.handler.codec.http.HttpMethod;
 
 // List all labels of one multi-load
 public class MultiDesc extends RestBaseAction {
-    private static final String LABEL_KEY = "label";
-
     private ExecuteEnv execEnv;
 
     public MultiDesc(ActionController controller, ExecuteEnv execEnv) {

--- a/fe/src/main/java/org/apache/doris/http/rest/MultiDesc.java
+++ b/fe/src/main/java/org/apache/doris/http/rest/MultiDesc.java
@@ -35,7 +35,6 @@ import io.netty.handler.codec.http.HttpMethod;
 
 // List all labels of one multi-load
 public class MultiDesc extends RestBaseAction {
-    private static final String DB_KEY = "db";
     private static final String LABEL_KEY = "label";
 
     private ExecuteEnv execEnv;
@@ -48,7 +47,7 @@ public class MultiDesc extends RestBaseAction {
     public static void registerAction(ActionController controller) throws IllegalArgException {
         ExecuteEnv executeEnv = ExecuteEnv.getInstance();
         MultiDesc action = new MultiDesc(controller, executeEnv);
-        controller.registerHandler(HttpMethod.POST, "/api/{db}/_multi_desc", action);
+        controller.registerHandler(HttpMethod.POST, "/api/{" + DB_KEY + "}/_multi_desc", action);
     }
 
     @Override

--- a/fe/src/main/java/org/apache/doris/http/rest/MultiList.java
+++ b/fe/src/main/java/org/apache/doris/http/rest/MultiList.java
@@ -35,7 +35,6 @@ import io.netty.handler.codec.http.HttpMethod;
 
 // list all multi load before commit
 public class MultiList extends RestBaseAction {
-    private static final String DB_KEY = "db";
 
     private ExecuteEnv execEnv;
 
@@ -47,7 +46,7 @@ public class MultiList extends RestBaseAction {
     public static void registerAction(ActionController controller) throws IllegalArgException {
         ExecuteEnv executeEnv = ExecuteEnv.getInstance();
         MultiList action = new MultiList(controller, executeEnv);
-        controller.registerHandler(HttpMethod.POST, "/api/{db}/_multi_list", action);
+        controller.registerHandler(HttpMethod.POST, "/api/{" + DB_KEY + "}/_multi_list", action);
     }
 
     @Override

--- a/fe/src/main/java/org/apache/doris/http/rest/MultiStart.java
+++ b/fe/src/main/java/org/apache/doris/http/rest/MultiStart.java
@@ -36,7 +36,6 @@ import io.netty.handler.codec.http.HttpMethod;
 
 // Start multi action
 public class MultiStart extends RestBaseAction {
-    private static final String DB_KEY = "db";
     private static final String LABEL_KEY = "label";
 
     private ExecuteEnv execEnv;
@@ -49,7 +48,7 @@ public class MultiStart extends RestBaseAction {
     public static void registerAction(ActionController controller) throws IllegalArgException {
         ExecuteEnv executeEnv = ExecuteEnv.getInstance();
         MultiStart action = new MultiStart(controller, executeEnv);
-        controller.registerHandler(HttpMethod.POST, "/api/{db}/_multi_start", action);
+        controller.registerHandler(HttpMethod.POST, "/api/{" + DB_KEY + "}/_multi_start", action);
     }
 
     @Override

--- a/fe/src/main/java/org/apache/doris/http/rest/MultiStart.java
+++ b/fe/src/main/java/org/apache/doris/http/rest/MultiStart.java
@@ -36,8 +36,6 @@ import io.netty.handler.codec.http.HttpMethod;
 
 // Start multi action
 public class MultiStart extends RestBaseAction {
-    private static final String LABEL_KEY = "label";
-
     private ExecuteEnv execEnv;
 
     public MultiStart(ActionController controller, ExecuteEnv execEnv) {

--- a/fe/src/main/java/org/apache/doris/http/rest/MultiUnload.java
+++ b/fe/src/main/java/org/apache/doris/http/rest/MultiUnload.java
@@ -31,7 +31,6 @@ import com.google.common.base.Strings;
 import io.netty.handler.codec.http.HttpMethod;
 
 public class MultiUnload extends RestBaseAction {
-    private static final String DB_KEY = "db";
     private static final String LABEL_KEY = "label";
     private static final String SUB_LABEL_KEY = "label";
 
@@ -45,7 +44,7 @@ public class MultiUnload extends RestBaseAction {
     public static void registerAction(ActionController controller) throws IllegalArgException {
         ExecuteEnv executeEnv = ExecuteEnv.getInstance();
         MultiUnload action = new MultiUnload(controller, executeEnv);
-        controller.registerHandler(HttpMethod.POST, "/api/{db}/_multi_unload", action);
+        controller.registerHandler(HttpMethod.POST, "/api/{" + DB_KEY + "}/_multi_unload", action);
     }
 
     @Override

--- a/fe/src/main/java/org/apache/doris/http/rest/MultiUnload.java
+++ b/fe/src/main/java/org/apache/doris/http/rest/MultiUnload.java
@@ -31,8 +31,7 @@ import com.google.common.base.Strings;
 import io.netty.handler.codec.http.HttpMethod;
 
 public class MultiUnload extends RestBaseAction {
-    private static final String LABEL_KEY = "label";
-    private static final String SUB_LABEL_KEY = "label";
+    private static final String SUB_LABEL_KEY = "sub_label";
 
     private ExecuteEnv execEnv;
 

--- a/fe/src/main/java/org/apache/doris/http/rest/RestBaseAction.java
+++ b/fe/src/main/java/org/apache/doris/http/rest/RestBaseAction.java
@@ -37,6 +37,7 @@ import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpResponseStatus;
 
 public class RestBaseAction extends BaseAction {
+    protected static final String DB_KEY = "db";
     private static final Logger LOG = LogManager.getLogger(RestBaseAction.class);
 
     public RestBaseAction(ActionController controller) {

--- a/fe/src/main/java/org/apache/doris/http/rest/RestBaseAction.java
+++ b/fe/src/main/java/org/apache/doris/http/rest/RestBaseAction.java
@@ -38,6 +38,8 @@ import io.netty.handler.codec.http.HttpResponseStatus;
 
 public class RestBaseAction extends BaseAction {
     protected static final String DB_KEY = "db";
+    protected static final String TABLE_KEY = "table";
+    protected static final String LABEL_KEY = "label";
     private static final Logger LOG = LogManager.getLogger(RestBaseAction.class);
 
     public RestBaseAction(ActionController controller) {

--- a/fe/src/main/java/org/apache/doris/http/rest/RowCountAction.java
+++ b/fe/src/main/java/org/apache/doris/http/rest/RowCountAction.java
@@ -47,8 +47,6 @@ import io.netty.handler.codec.http.HttpMethod;
  * fe_host:fe_http_port/api/rowcount?db=dbname&table=tablename
  */
 public class RowCountAction extends RestBaseAction {
-    public static final String DB_NAME_PARAM = "db";
-    public static final String TABLE_NAME_PARAM = "table";
 
     public RowCountAction(ActionController controller) {
         super(controller);
@@ -63,12 +61,12 @@ public class RowCountAction extends RestBaseAction {
         ActionAuthorizationInfo authInfo = getAuthorizationInfo(request);
         checkGlobalAuth(authInfo, PrivPredicate.ADMIN);
 
-        String dbName = request.getSingleParameter(DB_NAME_PARAM);
+        String dbName = request.getSingleParameter(DB_KEY);
         if (Strings.isNullOrEmpty(dbName)) {
             throw new DdlException("No database selected.");
         }
 
-        String tableName = request.getSingleParameter(TABLE_NAME_PARAM);
+        String tableName = request.getSingleParameter(TABLE_KEY);
         if (Strings.isNullOrEmpty(tableName)) {
             throw new DdlException("No table selected.");
         }

--- a/fe/src/main/java/org/apache/doris/http/rest/StorageTypeCheckAction.java
+++ b/fe/src/main/java/org/apache/doris/http/rest/StorageTypeCheckAction.java
@@ -54,7 +54,7 @@ public class StorageTypeCheckAction extends RestBaseAction {
         ActionAuthorizationInfo authInfo = getAuthorizationInfo(request);
         checkGlobalAuth(authInfo, PrivPredicate.ADMIN);
 
-        String dbName = request.getSingleParameter("db");
+        String dbName = request.getSingleParameter(DB_KEY);
         if (Strings.isNullOrEmpty(dbName)) {
             throw new DdlException("Parameter db is missing");
         }

--- a/fe/src/main/java/org/apache/doris/http/rest/TableQueryPlanAction.java
+++ b/fe/src/main/java/org/apache/doris/http/rest/TableQueryPlanAction.java
@@ -81,10 +81,10 @@ public class TableQueryPlanAction extends RestBaseAction {
 
     public static void registerAction(ActionController controller) throws IllegalArgException {
         controller.registerHandler(HttpMethod.POST,
-                                   "/api/{" + DB_KEY + "}/{table}/_query_plan",
+                                   "/api/{" + DB_KEY + "}/{" + TABLE_KEY + "}/_query_plan",
                                    new TableQueryPlanAction(controller));
         controller.registerHandler(HttpMethod.GET,
-                                   "/api/{" + DB_KEY + "}/{database}/{table}/_query_plan",
+                                   "/api/{" + DB_KEY + "}/{" + TABLE_KEY + "}/_query_plan",
                                    new TableQueryPlanAction(controller));
     }
 
@@ -94,7 +94,7 @@ public class TableQueryPlanAction extends RestBaseAction {
         // just allocate 2 slot for top holder map
         Map<String, Object> resultMap = new HashMap<>(4);
         String dbName = request.getSingleParameter(DB_KEY);
-        String tableName = request.getSingleParameter("table");
+        String tableName = request.getSingleParameter(TABLE_KEY);
         String postContent = request.getContent();
         try {
             // may be these common validate logic should be moved to one base class

--- a/fe/src/main/java/org/apache/doris/http/rest/TableQueryPlanAction.java
+++ b/fe/src/main/java/org/apache/doris/http/rest/TableQueryPlanAction.java
@@ -77,9 +77,9 @@ public class TableQueryPlanAction extends RestBaseAction {
 
     public static void registerAction(ActionController controller) throws IllegalArgException {
         controller.registerHandler(HttpMethod.POST,
-                "/api/{cluster}/{database}/{table}/_query_plan", new TableQueryPlanAction(controller));
+                "/api/external/{cluster}/{database}/{table}/_query_plan", new TableQueryPlanAction(controller));
         controller.registerHandler(HttpMethod.GET,
-                "/api/{cluster}/{database}/{table}/_query_plan", new TableQueryPlanAction(controller));
+                "/api/external/{cluster}/{database}/{table}/_query_plan", new TableQueryPlanAction(controller));
     }
 
     @Override

--- a/fe/src/main/java/org/apache/doris/http/rest/TableRowCountAction.java
+++ b/fe/src/main/java/org/apache/doris/http/rest/TableRowCountAction.java
@@ -55,7 +55,8 @@ public class TableRowCountAction extends RestBaseAction {
 
     public static void registerAction(ActionController controller) throws IllegalArgException {
         controller.registerHandler(HttpMethod.GET,
-                                   "/api/{" + DB_KEY + "}/{table}/_count", new TableRowCountAction(controller));
+                                   "/api/{" + DB_KEY + "}/{" + TABLE_KEY + "}/_count",
+                                   new TableRowCountAction(controller));
     }
 
     @Override
@@ -64,7 +65,7 @@ public class TableRowCountAction extends RestBaseAction {
         // just allocate 2 slot for top holder map
         Map<String, Object> resultMap = new HashMap<>(4);
         String dbName = request.getSingleParameter(DB_KEY);
-        String tableName = request.getSingleParameter("table");
+        String tableName = request.getSingleParameter(TABLE_KEY);
         try {
             if (Strings.isNullOrEmpty(dbName)
                     || Strings.isNullOrEmpty(tableName)) {

--- a/fe/src/main/java/org/apache/doris/http/rest/TableRowCountAction.java
+++ b/fe/src/main/java/org/apache/doris/http/rest/TableRowCountAction.java
@@ -52,9 +52,7 @@ public class TableRowCountAction extends RestBaseAction {
 
     public static void registerAction(ActionController controller) throws IllegalArgException {
         controller.registerHandler(HttpMethod.GET,
-                "/api/{cluster}/{database}/{table}/_count", new TableRowCountAction(controller));
-        controller.registerHandler(HttpMethod.GET,
-                "/api/{database}/{table}/_count", new TableRowCountAction(controller));
+                "/api/external/{cluster}/{database}/{table}/_count", new TableRowCountAction(controller));
     }
 
     @Override

--- a/fe/src/main/java/org/apache/doris/http/rest/TableRowCountAction.java
+++ b/fe/src/main/java/org/apache/doris/http/rest/TableRowCountAction.java
@@ -17,9 +17,6 @@
 
 package org.apache.doris.http.rest;
 
-import com.google.common.base.Strings;
-import io.netty.handler.codec.http.HttpMethod;
-import io.netty.handler.codec.http.HttpResponseStatus;
 import org.apache.doris.catalog.Catalog;
 import org.apache.doris.catalog.Database;
 import org.apache.doris.catalog.OlapTable;
@@ -32,10 +29,16 @@ import org.apache.doris.http.BaseRequest;
 import org.apache.doris.http.BaseResponse;
 import org.apache.doris.http.IllegalArgException;
 import org.apache.doris.mysql.privilege.PrivPredicate;
+
+import com.google.common.base.Strings;
+
 import org.codehaus.jackson.map.ObjectMapper;
 
 import java.util.HashMap;
 import java.util.Map;
+
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpResponseStatus;
 
 /**
  * This class is responsible for fetch the approximate row count of the specified table from cluster-meta data,
@@ -52,21 +55,20 @@ public class TableRowCountAction extends RestBaseAction {
 
     public static void registerAction(ActionController controller) throws IllegalArgException {
         controller.registerHandler(HttpMethod.GET,
-                "/api/external/{cluster}/{database}/{table}/_count", new TableRowCountAction(controller));
+                                   "/api/{" + DB_KEY + "}/{table}/_count", new TableRowCountAction(controller));
     }
 
     @Override
-    protected void executeWithoutPassword(ActionAuthorizationInfo authInfo, BaseRequest request, BaseResponse response) throws DdlException {
+    protected void executeWithoutPassword(ActionAuthorizationInfo authInfo, BaseRequest request, BaseResponse response)
+            throws DdlException {
         // just allocate 2 slot for top holder map
         Map<String, Object> resultMap = new HashMap<>(4);
-        String clusterName = request.getSingleParameter("cluster");
-        String dbName = request.getSingleParameter("database");
+        String dbName = request.getSingleParameter(DB_KEY);
         String tableName = request.getSingleParameter("table");
         try {
-            if (Strings.isNullOrEmpty(clusterName)
-                    || Strings.isNullOrEmpty(dbName)
+            if (Strings.isNullOrEmpty(dbName)
                     || Strings.isNullOrEmpty(tableName)) {
-                throw new DorisHttpException(HttpResponseStatus.BAD_REQUEST, "{cluster}/{database}/{table} must be selected");
+                throw new DorisHttpException(HttpResponseStatus.BAD_REQUEST, "{database}/{table} must be selected");
             }
             String fullDbName = ClusterNamespace.getFullName(authInfo.cluster, dbName);
             // check privilege for select, otherwise return HTTP 401

--- a/fe/src/main/java/org/apache/doris/http/rest/TableSchemaAction.java
+++ b/fe/src/main/java/org/apache/doris/http/rest/TableSchemaAction.java
@@ -58,9 +58,9 @@ public class TableSchemaAction extends RestBaseAction {
     public static void registerAction(ActionController controller) throws IllegalArgException {
         // the extra `/api` path is so disgusting
         controller.registerHandler(HttpMethod.GET,
-                                   "/api/{" + DB_KEY + "}/{table}/_schema", new TableSchemaAction(controller));
+                                   "/api/{" + DB_KEY + "}/{" + TABLE_KEY + "}/_schema", new TableSchemaAction
+                                           (controller));
     }
-
 
     @Override
     protected void executeWithoutPassword(ActionAuthorizationInfo authInfo,
@@ -68,7 +68,7 @@ public class TableSchemaAction extends RestBaseAction {
         // just allocate 2 slot for top holder map
         Map<String, Object> resultMap = new HashMap<>(2);
         String dbName = request.getSingleParameter(DB_KEY);
-        String tableName = request.getSingleParameter("table");
+        String tableName = request.getSingleParameter(TABLE_KEY);
         try {
             if (Strings.isNullOrEmpty(dbName)
                     || Strings.isNullOrEmpty(tableName)) {

--- a/fe/src/main/java/org/apache/doris/http/rest/TableSchemaAction.java
+++ b/fe/src/main/java/org/apache/doris/http/rest/TableSchemaAction.java
@@ -17,9 +17,6 @@
 
 package org.apache.doris.http.rest;
 
-import com.google.common.base.Strings;
-import io.netty.handler.codec.http.HttpMethod;
-import io.netty.handler.codec.http.HttpResponseStatus;
 import org.apache.doris.catalog.Catalog;
 import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.Database;
@@ -36,12 +33,18 @@ import org.apache.doris.http.BaseRequest;
 import org.apache.doris.http.BaseResponse;
 import org.apache.doris.http.IllegalArgException;
 import org.apache.doris.mysql.privilege.PrivPredicate;
+
+import com.google.common.base.Strings;
+
 import org.codehaus.jackson.map.ObjectMapper;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpResponseStatus;
 
 /**
  * Get table schema for specified cluster.database.table with privilege checking
@@ -55,7 +58,7 @@ public class TableSchemaAction extends RestBaseAction {
     public static void registerAction(ActionController controller) throws IllegalArgException {
         // the extra `/api` path is so disgusting
         controller.registerHandler(HttpMethod.GET,
-                "/api/external/{cluster}/{database}/{table}/_schema", new TableSchemaAction(controller));
+                                   "/api/{" + DB_KEY + "}/{table}/_schema", new TableSchemaAction(controller));
     }
 
 
@@ -64,14 +67,12 @@ public class TableSchemaAction extends RestBaseAction {
                                           BaseRequest request, BaseResponse response) throws DdlException {
         // just allocate 2 slot for top holder map
         Map<String, Object> resultMap = new HashMap<>(2);
-        String clusterName = request.getSingleParameter("cluster");
-        String dbName = request.getSingleParameter("database");
+        String dbName = request.getSingleParameter(DB_KEY);
         String tableName = request.getSingleParameter("table");
         try {
-            if (Strings.isNullOrEmpty(clusterName)
-                    || Strings.isNullOrEmpty(dbName)
+            if (Strings.isNullOrEmpty(dbName)
                     || Strings.isNullOrEmpty(tableName)) {
-                throw new DorisHttpException(HttpResponseStatus.BAD_REQUEST, "No cluster or database or table selected.");
+                throw new DorisHttpException(HttpResponseStatus.BAD_REQUEST, "No database or table selected.");
             }
             String fullDbName = ClusterNamespace.getFullName(authInfo.cluster, dbName);
             // check privilege for select, otherwise return 401 HTTP status

--- a/fe/src/main/java/org/apache/doris/http/rest/TableSchemaAction.java
+++ b/fe/src/main/java/org/apache/doris/http/rest/TableSchemaAction.java
@@ -55,7 +55,7 @@ public class TableSchemaAction extends RestBaseAction {
     public static void registerAction(ActionController controller) throws IllegalArgException {
         // the extra `/api` path is so disgusting
         controller.registerHandler(HttpMethod.GET,
-                "/api/{cluster}/{database}/{table}/_schema", new TableSchemaAction(controller));
+                "/api/external/{cluster}/{database}/{table}/_schema", new TableSchemaAction(controller));
     }
 
 

--- a/fe/src/test/java/org/apache/doris/common/path/PathTrieTest.java
+++ b/fe/src/test/java/org/apache/doris/common/path/PathTrieTest.java
@@ -19,10 +19,21 @@ package org.apache.doris.common.path;
 
 import static com.google.common.collect.Maps.newHashMap;
 
+import org.apache.doris.http.ActionController;
+import org.apache.doris.http.rest.MultiStart;
+import org.apache.doris.http.rest.TableQueryPlanAction;
+import org.apache.doris.http.rest.TableRowCountAction;
+import org.apache.doris.http.rest.TableSchemaAction;
+import org.apache.doris.service.ExecuteEnv;
+
+import com.google.common.collect.Maps;
+
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.Map;
+
+import mockit.Injectable;
 
 public class PathTrieTest {
     @Test
@@ -152,5 +163,20 @@ public class PathTrieTest {
         params = newHashMap();
         Assert.assertEquals(trie.retrieve("a/*/_endpoint", params), "test5");
         Assert.assertEquals(params.get("test"), "*");
+    }
+
+    @Test
+    public void testInsert(@Injectable ActionController controller,
+                           @Injectable ExecuteEnv execEnv) {
+        PathTrie pathTrie = new PathTrie();
+        pathTrie.insert("/api/{db}/_multi_start", new MultiStart(controller, execEnv));
+        pathTrie.insert("/api/external/{cluster}/{database}/{table}/_count", new TableRowCountAction(controller));
+        pathTrie.insert("/api/external/{cluster}/{database}/{table}/_schema", new TableSchemaAction(controller));
+        pathTrie.insert("/api/external/{cluster}/{database}/{table}/_query_plan", new TableQueryPlanAction(controller));
+        Map<String, String> params = Maps.newHashMap();
+        pathTrie.retrieve("/api/test/_multi_start", params);
+        Assert.assertEquals("test", params.get("db"));
+
+
     }
 }

--- a/fe/src/test/java/org/apache/doris/common/path/PathTrieTest.java
+++ b/fe/src/test/java/org/apache/doris/common/path/PathTrieTest.java
@@ -170,9 +170,9 @@ public class PathTrieTest {
                            @Injectable ExecuteEnv execEnv) {
         PathTrie pathTrie = new PathTrie();
         pathTrie.insert("/api/{db}/_multi_start", new MultiStart(controller, execEnv));
-        pathTrie.insert("/api/external/{cluster}/{database}/{table}/_count", new TableRowCountAction(controller));
-        pathTrie.insert("/api/external/{cluster}/{database}/{table}/_schema", new TableSchemaAction(controller));
-        pathTrie.insert("/api/external/{cluster}/{database}/{table}/_query_plan", new TableQueryPlanAction(controller));
+        pathTrie.insert("/api/{db}/{table}/_count", new TableRowCountAction(controller));
+        pathTrie.insert("/api/{db}/{table}/_schema", new TableSchemaAction(controller));
+        pathTrie.insert("/api/{db}/{table}/_query_plan", new TableQueryPlanAction(controller));
         Map<String, String> params = Maps.newHashMap();
         pathTrie.retrieve("/api/test/_multi_start", params);
         Assert.assertEquals("test", params.get("db"));

--- a/fe/src/test/java/org/apache/doris/http/DorisHttpTestCase.java
+++ b/fe/src/test/java/org/apache/doris/http/DorisHttpTestCase.java
@@ -17,12 +17,6 @@
 
 package org.apache.doris.http;
 
-import com.google.common.collect.Lists;
-import junit.framework.AssertionFailedError;
-import mockit.internal.startup.Startup;
-import okhttp3.Credentials;
-import okhttp3.MediaType;
-import okhttp3.OkHttpClient;
 import org.apache.doris.alter.RollupHandler;
 import org.apache.doris.alter.SchemaChangeHandler;
 import org.apache.doris.catalog.Catalog;
@@ -51,6 +45,9 @@ import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.system.Backend;
 import org.apache.doris.system.SystemInfoService;
 import org.apache.doris.thrift.TStorageMedium;
+
+import com.google.common.collect.Lists;
+
 import org.easymock.EasyMock;
 import org.junit.After;
 import org.junit.Before;
@@ -65,6 +62,12 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+
+import junit.framework.AssertionFailedError;
+import mockit.internal.startup.Startup;
+import okhttp3.Credentials;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
 
 @RunWith(PowerMockRunner.class)
 @PowerMockIgnore({ "org.apache.log4j.*", "javax.management.*", "javax.net.ssl.*"})
@@ -107,7 +110,7 @@ abstract public class DorisHttpTestCase {
 
     public static final int HTTP_PORT = 32474;
 
-    protected static final String URI = "http://localhost:" + HTTP_PORT + "/api/" + CLUSTER_NAME + "/" + DB_NAME + "/" + TABLE_NAME;
+    protected static final String URI = "http://localhost:" + HTTP_PORT + "/api/" + DB_NAME + "/" + TABLE_NAME;
 
 
     protected String rootAuth = Credentials.basic("root", "");

--- a/fe/src/test/java/org/apache/doris/http/TableQueryPlanActionTest.java
+++ b/fe/src/test/java/org/apache/doris/http/TableQueryPlanActionTest.java
@@ -17,10 +17,8 @@
 
 package org.apache.doris.http;
 
-import okhttp3.Request;
-import okhttp3.RequestBody;
-import okhttp3.Response;
 import org.apache.doris.thrift.TQueryPlanInfo;
+
 import org.apache.thrift.TDeserializer;
 import org.apache.thrift.TException;
 import org.json.JSONObject;
@@ -30,10 +28,14 @@ import org.junit.Test;
 import java.io.IOException;
 import java.util.Base64;
 
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+
 public class TableQueryPlanActionTest extends DorisHttpTestCase {
 
     private static final String PATH_URI = "/_query_plan";
-    protected static final String ES_TABLE_URL = "http://localhost:" + HTTP_PORT + "/api/" + CLUSTER_NAME + "/" + DB_NAME + "/es_table";
+    protected static final String ES_TABLE_URL = "http://localhost:" + HTTP_PORT + "/api/" + DB_NAME + "/es_table";
 
     @Test
     public void testQueryPlanAction() throws IOException, TException {


### PR DESCRIPTION
The pathtrie could not distinguish the different param key with the same prefix path.
So the prefix of table info apis has been change to /api/external which is used by spark-doris-connector.