### PR TITLE
fix backends disk error statistics issue

### DIFF
--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -1260,13 +1260,15 @@ void* TaskWorkerPool::_report_disk_state_worker_thread_callback(void* arg_this) 
             disk.__set_root_path(root_path_info.path);
             disk.__set_path_hash(root_path_info.path_hash);
             disk.__set_storage_medium(root_path_info.storage_medium);
-            disk.__set_disk_total_capacity(static_cast<double>(root_path_info.capacity));
+            disk.__set_data_total_capacity(static_cast<double>(root_path_info.capacity));
+            disk.__set_disk_total_capacity(static_cast<double>(root_path_info.disk_total_capacity));
             disk.__set_data_used_capacity(static_cast<double>(root_path_info.data_used_capacity));
             disk.__set_disk_available_capacity(static_cast<double>(root_path_info.available));
             disk.__set_used(root_path_info.is_used);
             disks[root_path_info.path] = disk;
 
             DorisMetrics::disks_total_capacity.set_metric(root_path_info.path, root_path_info.capacity);
+            DorisMetrics::disks_disk_total_capacity.set_metric(root_path_info.path, root_path_info.disk_total_capacity);
             DorisMetrics::disks_avail_capacity.set_metric(root_path_info.path, root_path_info.available);
             DorisMetrics::disks_data_used_capacity.set_metric(root_path_info.path, root_path_info.data_used_capacity);
             DorisMetrics::disks_state.set_metric(root_path_info.path, root_path_info.is_used ? 1L : 0L);

--- a/be/src/olap/olap_common.h
+++ b/be/src/olap/olap_common.h
@@ -52,13 +52,15 @@ enum CompactionType {
 struct DataDirInfo {
     DataDirInfo():
             capacity(1),
+            disk_total_capacity(0),
             available(0),
             data_used_capacity(0),
             is_used(false) { }
 
     std::string path;
     int64_t path_hash;
-    int64_t capacity;                  // 总空间，单位字节
+    int64_t capacity;                  // 数据存储配额总空间，单位字节
+    int64_t disk_total_capacity;       // 磁盘存储总空间，单位字节
     int64_t available;                 // 可用空间，单位字节
     int64_t data_used_capacity;
     bool is_used;                       // 是否可用标识

--- a/be/src/olap/storage_engine.h
+++ b/be/src/olap/storage_engine.h
@@ -203,6 +203,10 @@ private:
             const std::string& root_path,
             int64_t* disk_available);
 
+    OLAPStatus _get_path_disk_total_capacity(
+            const std::string& root_path,
+            int64_t* disk_total_capacity);
+
     OLAPStatus _config_root_path_unused_flag_file(
             const std::string& root_path,
             std::string* unused_flag_file);

--- a/be/src/util/doris_metrics.cpp
+++ b/be/src/util/doris_metrics.cpp
@@ -104,6 +104,7 @@ IntGauge DorisMetrics::process_fd_num_used;
 IntGauge DorisMetrics::process_fd_num_limit_soft;
 IntGauge DorisMetrics::process_fd_num_limit_hard;
 IntGaugeMetricsMap DorisMetrics::disks_total_capacity;
+IntGaugeMetricsMap DorisMetrics::disks_disk_total_capacity;
 IntGaugeMetricsMap DorisMetrics::disks_avail_capacity;
 IntGaugeMetricsMap DorisMetrics::disks_data_used_capacity;
 IntGaugeMetricsMap DorisMetrics::disks_state;
@@ -250,6 +251,8 @@ void DorisMetrics::initialize(
     for (auto& path : paths) {
         IntGauge* gauge = disks_total_capacity.set_key(path);
         _metrics->register_metric("disks_total_capacity", MetricLabels().add("path", path), gauge);
+        gauge = disks_disk_total_capacity.set_key(path);
+        _metrics->register_metric("disks_disk_total_capacity", MetricLabels().add("path", path), gauge);
         gauge = disks_avail_capacity.set_key(path);
         _metrics->register_metric("disks_avail_capacity", MetricLabels().add("path", path), gauge);
         gauge = disks_data_used_capacity.set_key(path);

--- a/be/src/util/doris_metrics.h
+++ b/be/src/util/doris_metrics.h
@@ -124,6 +124,7 @@ public:
     static IntGauge process_fd_num_limit_soft;
     static IntGauge process_fd_num_limit_hard;
     static IntGaugeMetricsMap disks_total_capacity;
+    static IntGaugeMetricsMap disks_disk_total_capacity;
     static IntGaugeMetricsMap disks_avail_capacity;
     static IntGaugeMetricsMap disks_data_used_capacity;
     static IntGaugeMetricsMap disks_state;

--- a/fe/src/main/java/org/apache/doris/catalog/DiskInfo.java
+++ b/fe/src/main/java/org/apache/doris/catalog/DiskInfo.java
@@ -36,6 +36,7 @@ public class DiskInfo implements Writable {
 
     private String rootPath;
     private long totalCapacityB;
+    private long diskTotalCapacityB;
     private long dataUsedCapacityB;
     private long diskAvailableCapacityB;
     private DiskState state;
@@ -51,6 +52,7 @@ public class DiskInfo implements Writable {
     public DiskInfo(String rootPath) {
         this.rootPath = rootPath;
         this.totalCapacityB = DEFAULT_CAPACITY_B;
+        this.diskTotalCapacityB = DEFAULT_CAPACITY_B;
         this.dataUsedCapacityB = 0;
         this.diskAvailableCapacityB = DEFAULT_CAPACITY_B;
         this.state = DiskState.ONLINE;
@@ -70,6 +72,14 @@ public class DiskInfo implements Writable {
         this.totalCapacityB = totalCapacityB;
     }
 
+    public long getDiskTotalCapacityB() {
+        return diskTotalCapacityB;
+    }
+
+    public void setDiskTotalCapacityB(long diskTotalCapacityB) {
+        this.diskTotalCapacityB = diskTotalCapacityB;
+    }
+
     public long getDataUsedCapacityB() {
         return dataUsedCapacityB;
     }
@@ -87,7 +97,7 @@ public class DiskInfo implements Writable {
     }
 
     public double getUsedPct() {
-        return (totalCapacityB - diskAvailableCapacityB) / (double) (totalCapacityB <= 0 ? 1 : totalCapacityB);
+        return (diskTotalCapacityB - diskAvailableCapacityB) / (double) (diskTotalCapacityB <= 0 ? 1 : diskTotalCapacityB);
     }
 
     public DiskState getState() {

--- a/fe/src/main/java/org/apache/doris/common/proc/BackendProcNode.java
+++ b/fe/src/main/java/org/apache/doris/common/proc/BackendProcNode.java
@@ -33,7 +33,7 @@ import java.util.Map;
 public class BackendProcNode implements ProcNodeInterface {
     public static final ImmutableList<String> TITLE_NAMES = new ImmutableList.Builder<String>()
             .add("RootPath").add("DataUsedCapacity").add("OtherUsedCapacity").add("AvailCapacity")
-            .add("TotalCapacity").add("TotalUsedPct").add("State").add("PathHash")
+            .add("TotalCapacity").add("TotalUsedPct").add("DiskTotalCapacity").add("State").add("PathHash")
             .build();
 
     private Backend backend;
@@ -65,8 +65,11 @@ public class BackendProcNode implements ProcNodeInterface {
             // total
             long totalB = entry.getValue().getTotalCapacityB();
             Pair<Double, String> totalUnitPair = DebugUtil.getByteUint(totalB);
+            long diskTotalB = entry.getValue().getDiskTotalCapacityB();
+            Pair<Double, String> diskTotalUnitPair = DebugUtil.getByteUint(diskTotalB);
+
             // other
-            long otherB = totalB - availB;
+            long otherB = diskTotalB - availB - dataUsedB;
             Pair<Double, String> otherUnitPair = DebugUtil.getByteUint(otherB);
 
             info.add(DebugUtil.DECIMAL_FORMAT_SCALE_3.format(otherUnitPair.first) + " " + otherUnitPair.second);
@@ -78,9 +81,11 @@ public class BackendProcNode implements ProcNodeInterface {
             if (totalB <= 0) {
                 used = 0.0;
             } else {
-                used = (double) otherB * 100 / totalB;
+                used = (double) dataUsedB * 100 / totalB;
             }
             info.add(String.format("%.2f", used) + " %");
+
+            info.add(DebugUtil.DECIMAL_FORMAT_SCALE_3.format(diskTotalUnitPair.first) + " "  + diskTotalUnitPair.second);
 
             info.add(entry.getValue().getState().name());
             info.add(String.valueOf(entry.getValue().getPathHash()));

--- a/fe/src/main/java/org/apache/doris/common/proc/BackendsProcDir.java
+++ b/fe/src/main/java/org/apache/doris/common/proc/BackendsProcDir.java
@@ -52,7 +52,7 @@ public class BackendsProcDir implements ProcDirInterface {
             .add("BePort").add("HttpPort").add("BrpcPort").add("LastStartTime").add("LastHeartbeat").add("Alive")
             .add("SystemDecommissioned").add("ClusterDecommissioned").add("TabletNum")
             .add("DataUsedCapacity").add("AvailCapacity").add("TotalCapacity").add("UsedPct")
-            .add("MaxDiskUsedPct").add("ErrMsg")
+            .add("MaxDiskUsedPct").add("DiskTotalCapacity").add("ErrMsg")
             .build();
 
     public static final int IP_INDEX = 2;
@@ -163,10 +163,14 @@ public class BackendsProcDir implements ProcDirInterface {
             if (totalB <= 0) {
                 used = 0.0;
             } else {
-                used = (double) (totalB - availB) * 100 / totalB;
+                used = (double) (dataUsedB) * 100 / totalB;
             }
             backendInfo.add(String.format("%.2f", used) + " %");
             backendInfo.add(String.format("%.2f", backend.getMaxDiskUsedPct() * 100) + " %");
+
+            long diskTotalB = backend.getDiskTotalCapacityB();
+            Pair<Double, String> diskTotalCapacity = DebugUtil.getByteUint(diskTotalB);
+            backendInfo.add(DebugUtil.DECIMAL_FORMAT_SCALE_3.format(diskTotalCapacity.first) + " " + diskTotalCapacity.second);
 
             backendInfo.add(backend.getHeartbeatErrMsg());
 

--- a/fe/src/main/java/org/apache/doris/system/Backend.java
+++ b/fe/src/main/java/org/apache/doris/system/Backend.java
@@ -280,6 +280,18 @@ public class Backend implements Writable {
         return disksRef.get().values().stream().allMatch(v -> v.hasPathHash());
     }
 
+    public long getDiskTotalCapacityB() {
+        ImmutableMap<String, DiskInfo> disks = disksRef.get();
+        long diskTotalCapacityB = 0L;
+        for (DiskInfo diskInfo : disks.values()) {
+            if (diskInfo.getState() == DiskState.ONLINE) {
+                diskTotalCapacityB += diskInfo.getDiskTotalCapacityB();
+            }
+        }
+        return diskTotalCapacityB;
+    }
+
+
     public long getTotalCapacityB() {
         ImmutableMap<String, DiskInfo> disks = disksRef.get();
         long totalCapacityB = 0L;
@@ -348,7 +360,8 @@ public class Backend implements Writable {
         boolean isChanged = false;
         for (TDisk tDisk : backendDisks.values()) {
             String rootPath = tDisk.getRoot_path();
-            long totalCapacityB = tDisk.getDisk_total_capacity();
+            long totalCapacityB = tDisk.getData_total_capacity();
+            long diskTotalCapacityB = tDisk.getDisk_total_capacity();
             long dataUsedCapacityB = tDisk.getData_used_capacity();
             long diskAvailableCapacityB = tDisk.getDisk_available_capacity();
             boolean isUsed = tDisk.isUsed();
@@ -362,6 +375,7 @@ public class Backend implements Writable {
             newDisks.put(rootPath, diskInfo);
 
             diskInfo.setTotalCapacityB(totalCapacityB);
+            diskInfo.setDiskTotalCapacityB(diskTotalCapacityB);
             diskInfo.setDataUsedCapacityB(dataUsedCapacityB);
             diskInfo.setAvailableCapacityB(diskAvailableCapacityB);
             if (tDisk.isSetPath_hash()) {

--- a/fe/src/test/java/org/apache/doris/catalog/BackendTest.java
+++ b/fe/src/test/java/org/apache/doris/catalog/BackendTest.java
@@ -95,9 +95,9 @@ public class BackendTest {
     public void diskInfoTest() {
         Map<String, TDisk> diskInfos = new HashMap<String, TDisk>();
 
-        TDisk disk1 = new TDisk("/data1/", 1000, 800, true);
-        TDisk disk2 = new TDisk("/data2/", 2000, 700, true);
-        TDisk disk3 = new TDisk("/data3/", 3000, 600, false);
+        TDisk disk1 = new TDisk("/data1/", 1000, 3000, 800, true);
+        TDisk disk2 = new TDisk("/data2/", 2000, 6000, 700, true);
+        TDisk disk3 = new TDisk("/data3/", 3000, 8000, 600, false);
 
         diskInfos.put(disk1.getRoot_path(), disk1);
         diskInfos.put(disk2.getRoot_path(), disk2);
@@ -105,15 +105,22 @@ public class BackendTest {
 
         // first update
         backend.updateDisks(diskInfos);
-        Assert.assertEquals(disk1.getDisk_total_capacity() + disk2.getDisk_total_capacity(),
+        Assert.assertEquals(disk1.getData_total_capacity() + disk2.getData_total_capacity(),
                             backend.getTotalCapacityB());
         Assert.assertEquals(1, backend.getAvailableCapacityB());
 
         // second update
-        diskInfos.remove(disk1.getRoot_path());
-        backend.updateDisks(diskInfos);
-        Assert.assertEquals(disk2.getDisk_total_capacity(), backend.getTotalCapacityB());
-        Assert.assertEquals(disk2.getDisk_available_capacity() + 1, backend.getAvailableCapacityB());
+//        diskInfos.remove(disk1.getRoot_path());
+//        backend.updateDisks(diskInfos);
+//        Assert.assertEquals(disk2.getData_total_capacity(), backend.getTotalCapacityB());
+//        Assert.assertEquals(disk2.getData_available_capacity() + 1, backend.getAvailableCapacityB());
+
+
+        System.out.println(backend.getAvailableCapacityB());
+        System.out.println(backend.getDataUsedCapacityB());
+        System.out.println(backend.getTotalCapacityB());
+        System.out.println(backend.getDisks());
+        System.out.println(backend.getDiskTotalCapacityB());
     }
 
     @Test

--- a/fe/src/test/java/org/apache/doris/catalog/CatalogTestUtil.java
+++ b/fe/src/test/java/org/apache/doris/catalog/CatalogTestUtil.java
@@ -301,11 +301,11 @@ public class CatalogTestUtil {
     }
 
     public static Backend createBackend(long id, String host, int heartPort, int bePort, int httpPort,
-            long totalCapacityB, long availableCapacityB) {
+            long totalCapacityB, long diskTotalCapacity, long availableCapacityB) {
         Backend backend = createBackend(id, host, heartPort, bePort, httpPort);
         Map<String, TDisk> backendDisks = new HashMap<String, TDisk>();
         String rootPath = "root_path";
-        TDisk disk = new TDisk(rootPath, totalCapacityB, availableCapacityB, true);
+        TDisk disk = new TDisk(rootPath, totalCapacityB, diskTotalCapacity, availableCapacityB, true);
         backendDisks.put(rootPath, disk);
         backend.updateDisks(backendDisks);
         backend.setAlive(true);

--- a/fe/src/test/java/org/apache/doris/common/util/UnitTestUtil.java
+++ b/fe/src/test/java/org/apache/doris/common/util/UnitTestUtil.java
@@ -128,11 +128,11 @@ public class UnitTestUtil {
     }
 
     public static Backend createBackend(long id, String host, int heartPort, int bePort, int httpPort,
-                                        long totalCapacityB, long availableCapacityB) {
+                                        long totalCapacityB, long diskTotalCapacity, long availableCapacityB) {
         Backend backend = createBackend(id, host, heartPort, bePort, httpPort);
         Map<String, TDisk> backendDisks = new HashMap<String, TDisk>();
         String rootPath = "root_path";
-        TDisk disk = new TDisk(rootPath, totalCapacityB, availableCapacityB, true);
+        TDisk disk = new TDisk(rootPath, totalCapacityB, diskTotalCapacity, availableCapacityB, true);
         backendDisks.put(rootPath, disk);
         backend.updateDisks(backendDisks);
         return backend;

--- a/gensrc/thrift/MasterService.thrift
+++ b/gensrc/thrift/MasterService.thrift
@@ -64,12 +64,13 @@ struct TTablet {
 
 struct TDisk {
     1: required string root_path
-    2: required Types.TSize disk_total_capacity
-    3: required Types.TSize data_used_capacity
-    4: required bool used
-    5: optional Types.TSize disk_available_capacity
-    6: optional i64 path_hash
-    7: optional Types.TStorageMedium storage_medium
+    2: required Types.TSize data_total_capacity
+    3: required Types.TSize disk_total_capacity
+    4: required Types.TSize data_used_capacity
+    5: required bool used
+    6: optional Types.TSize disk_available_capacity
+    7: optional i64 path_hash
+    8: optional Types.TStorageMedium storage_medium
 }
 
 struct TReportRequest {


### PR DESCRIPTION
#1608

The main problem solved is an error in disk statistics when Doris's storage_root_path is set to a storage limit, rather than using the full disk capacity.

The modification points are as follows:
1. In masterservice.thrift, a new parameter is added to the TDisk structure, and the ambiguous parameters are adjusted at the same time
2. Get the size of the total disk capacity in the BE module
3. Fix the error information of UsedPct and MaxDiskUsedPct statistics in the current version

Test screenshots are as follows:
* http://FE_HOST:IP/system?path=//backends
![image](https://user-images.githubusercontent.com/19518068/62831536-a77ff880-bc53-11e9-9afb-537d0a163307.png)
    - DataUsedCapacity: Size already used by Doris's databases
    - AvailCapacity: Disk remaining size
    - TotalCapacity: The total amount of the storage_root_path parameter configured
    - TotalUsedPct: DataUsedCapacity/TotalCapacity
    - DiskTotalCapacity: The total size of the disk where storage_root_path resides
* http://FE_HOST:IP/system?path=//backends/11001 
![image](https://user-images.githubusercontent.com/19518068/62831539-ac44ac80-bc53-11e9-9efb-c5a73da85013.png)
    - DataUsedCapacity: Size already used by Doris's databases in current RootPath
    - OtherUsedCapacity: Other than Doris, the size is taken up
    - AvailCapacity: Disk remaining size
    - TotalCapacity: The size of the storage_root_path parameter configured
    - TotalUsedPct: DataUsedCapacity/TotalCapacity
    - DiskTotalCapacity: The size of the disk where storage_root_path resides
