### PR TITLE
Print src tuple in error_sample file

### DIFF
--- a/be/src/exec/base_scanner.cpp
+++ b/be/src/exec/base_scanner.cpp
@@ -154,9 +154,10 @@ bool BaseScanner::fill_dest_tuple(const Slice& line, Tuple* dest_tuple, MemPool*
                     raw_string = raw_value->to_string();
                 }
                 std::stringstream error_msg;
-                error_msg << " column(" << slot_desc->col_name() << ") value is incorrect "
-                                << "while strict mode is " << std::boolalpha << _strict_mode;
-                            _state->append_error_msg_to_file(raw_string, error_msg.str());
+                error_msg << "column(" << slot_desc->col_name() << ") value is incorrect "
+                    << "while strict mode is " << std::boolalpha << _strict_mode 
+                    << "src value is " << raw_string;
+                _state->append_error_msg_to_file(_src_tuple_row->to_string(*(_row_desc.get())), error_msg.str());
                 _counter->num_rows_filtered++;
                 return false;
             }
@@ -164,7 +165,7 @@ bool BaseScanner::fill_dest_tuple(const Slice& line, Tuple* dest_tuple, MemPool*
                 std::stringstream error_msg;
                 error_msg << "column(" << slot_desc->col_name() << ") value is null "
                           << "while columns is not nullable";
-                _state->append_error_msg_to_file("", error_msg.str());
+                _state->append_error_msg_to_file(_src_tuple_row->to_string(*(_row_desc.get())), error_msg.str());
                 _counter->num_rows_filtered++;
                 return false;
             }

--- a/be/src/exec/base_scanner.cpp
+++ b/be/src/exec/base_scanner.cpp
@@ -156,7 +156,7 @@ bool BaseScanner::fill_dest_tuple(const Slice& line, Tuple* dest_tuple, MemPool*
                 std::stringstream error_msg;
                 error_msg << "column(" << slot_desc->col_name() << ") value is incorrect "
                     << "while strict mode is " << std::boolalpha << _strict_mode 
-                    << "src value is " << raw_string;
+                    << ", src value is " << raw_string;
                 _state->append_error_msg_to_file(_src_tuple_row->to_string(*(_row_desc.get())), error_msg.str());
                 _counter->num_rows_filtered++;
                 return false;

--- a/be/src/runtime/raw_value.cpp
+++ b/be/src/runtime/raw_value.cpp
@@ -209,7 +209,9 @@ void RawValue::print_value(const void* value, const TypeDescriptor& type, int sc
         std::stringstream ss;
         ss << "ptr:" << (void*)string_val->ptr << " len" << string_val->len;
         tmp = ss.str();
-        //tmp.assign(static_cast<char*>(string_val->ptr), string_val->len);
+        if (string_val->len <= 1000) {
+            tmp.assign(static_cast<char*>(string_val->ptr), string_val->len);
+        }
         str->swap(tmp);
         return;
     }


### PR DESCRIPTION
The src tuple could not be print in error_sample file when the value is filtered by strict mode.
This commit fix this issue.