### PR TITLE
Add timeout on snapshot of data

### DIFF
--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -1525,7 +1525,7 @@ void* TaskWorkerPool::_make_snapshot_thread_callback(void* arg_this) {
                       << ", snapshot_path:" << snapshot_path;
             if (snapshot_request.__isset.list_files) {
                 // list and save all snapshot files
-                // snapshot_path like: data/snapshot/20180417205230.1
+                // snapshot_path like: data/snapshot/20180417205230.1.86400
                 // we need to add subdir: tablet_id/schema_hash/
                 std::stringstream ss;
                 ss << snapshot_path << "/" << snapshot_request.tablet_id

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -212,8 +212,8 @@ namespace config {
     // inc_rowset expired interval
     CONF_Int32(inc_rowset_expired_sec, "1800");
     // garbage sweep policy
-    CONF_Int32(max_garbage_sweep_interval, "43200");
-    CONF_Int32(min_garbage_sweep_interval, "200");
+    CONF_Int32(max_garbage_sweep_interval, "14400");
+    CONF_Int32(min_garbage_sweep_interval, "180");
     CONF_Int32(snapshot_expire_time_sec, "172800");
     // 仅仅是建议值，当磁盘空间不足时，trash下的文件保存期可不遵守这个参数
     CONF_Int32(trash_file_expire_time_sec, "259200");

--- a/be/src/olap/snapshot_manager.cpp
+++ b/be/src/olap/snapshot_manager.cpp
@@ -362,7 +362,7 @@ OLAPStatus SnapshotManager::_create_snapshot_files(
     string snapshot_id_path;
     int64_t timeout_s = config::snapshot_expire_time_sec;
     if (request.__isset.timeout) {
-        timeout_s = request.__isset.timeout;
+        timeout_s = request.timeout;
     }
     res = _calc_snapshot_id_path(ref_tablet, timeout_s, &snapshot_id_path);
     if (res != OLAP_SUCCESS) {

--- a/be/src/olap/snapshot_manager.cpp
+++ b/be/src/olap/snapshot_manager.cpp
@@ -108,7 +108,7 @@ OLAPStatus SnapshotManager::release_snapshot(const string& snapshot_path) {
                 && snapshot_path.compare(abs_path.size(),
                         SNAPSHOT_PREFIX.size(), SNAPSHOT_PREFIX) == 0) {
             remove_all_dir(snapshot_path);
-            VLOG(3) << "success to release snapshot path. [path='" << snapshot_path << "']";
+            LOG(INFO) << "success to release snapshot path. [path='" << snapshot_path << "']";
 
             return OLAP_SUCCESS;
         }
@@ -283,8 +283,11 @@ OLAPStatus SnapshotManager::_rename_rowset_id(const RowsetMetaPB& rs_meta_pb, co
     return OLAP_SUCCESS;
 }
 
+// get snapshot path: curtime.seq.timeout
+// eg: 20190819221234.3.86400
 OLAPStatus SnapshotManager::_calc_snapshot_id_path(
         const TabletSharedPtr& tablet,
+        int64_t timeout_s,
         string* out_path) {
     OLAPStatus res = OLAP_SUCCESS;
     if (out_path == nullptr) {
@@ -303,7 +306,8 @@ OLAPStatus SnapshotManager::_calc_snapshot_id_path(
     stringstream snapshot_id_path_stream;
     MutexLock auto_lock(&_snapshot_mutex); // will automatically unlock when function return.
     snapshot_id_path_stream << tablet->data_dir()->path() << SNAPSHOT_PREFIX
-                            << "/" << time_str << "." << _snapshot_base_id++;
+                            << "/" << time_str << "." << _snapshot_base_id++
+                            << "." << timeout_s;
     *out_path = snapshot_id_path_stream.str();
     return res;
 }
@@ -356,7 +360,11 @@ OLAPStatus SnapshotManager::_create_snapshot_files(
     }
 
     string snapshot_id_path;
-    res = _calc_snapshot_id_path(ref_tablet, &snapshot_id_path);
+    int64_t timeout_s = config::snapshot_expire_time_sec;
+    if (request.__isset.timeout) {
+        timeout_s = request.__isset.timeout;
+    }
+    res = _calc_snapshot_id_path(ref_tablet, timeout_s, &snapshot_id_path);
     if (res != OLAP_SUCCESS) {
         LOG(WARNING) << "failed to calc snapshot_id_path, ref tablet="
                      << ref_tablet->data_dir()->path();

--- a/be/src/olap/snapshot_manager.h
+++ b/be/src/olap/snapshot_manager.h
@@ -73,6 +73,7 @@ private:
 
     OLAPStatus _calc_snapshot_id_path(
             const TabletSharedPtr& tablet,
+            int64_t timeout_s,
             std::string* out_path);
 
     std::string _get_header_full_path(

--- a/be/src/olap/storage_engine.h
+++ b/be/src/olap/storage_engine.h
@@ -222,7 +222,7 @@ private:
     void _clean_unused_txns();
     
     OLAPStatus _do_sweep(
-            const std::string& scan_root, const time_t& local_tm_now, const uint32_t expire);
+            const std::string& scan_root, const time_t& local_tm_now, const int32_t expire);
 
     // Thread functions
     // unused rowset monitor thread

--- a/be/src/olap/task/engine_clone_task.cpp
+++ b/be/src/olap/task/engine_clone_task.cpp
@@ -323,6 +323,10 @@ AgentStatus EngineCloneTask::_clone_copy(
             } 
             snapshot_request.__set_missing_version(snapshot_versions);
         }
+        if (clone_req.__isset.timeout_s) {
+            snapshot_request.__set_timeout(clone_req.timeout_s);
+        }
+
         agent_client.make_snapshot(
                 snapshot_request,
                 &make_snapshot_result);

--- a/fe/src/main/java/org/apache/doris/backup/SnapshotInfo.java
+++ b/fe/src/main/java/org/apache/doris/backup/SnapshotInfo.java
@@ -36,7 +36,7 @@ public class SnapshotInfo implements Writable {
     private long tabletId;
     private long beId;
     private int schemaHash;
-    // eg: /path/to/your/be/data/snapshot/20180410102311.0/
+    // eg: /path/to/your/be/data/snapshot/20180410102311.0.86400/
     private String path;
     // eg:
     // 10006_0_1_0_0.dat

--- a/fe/src/main/java/org/apache/doris/clone/TabletSchedCtx.java
+++ b/fe/src/main/java/org/apache/doris/clone/TabletSchedCtx.java
@@ -669,6 +669,8 @@ public class TabletSchedCtx implements Comparable<TabletSchedCtx> {
                 "dest backend " + srcReplica.getBackendId() + " does not exist");
         }
         
+        taskTimeoutMs = getApproximateTimeoutMs();
+
         // create the clone task and clone replica.
         // we use visible version in clone task, but set the clone replica's last failed version to
         // committed version.
@@ -682,7 +684,7 @@ public class TabletSchedCtx implements Comparable<TabletSchedCtx> {
         TBackend tSrcBe = new TBackend(srcBe.getHost(), srcBe.getBePort(), srcBe.getHttpPort());
         cloneTask = new CloneTask(destBackendId, dbId, tblId, partitionId, indexId,
                 tabletId, schemaHash, Lists.newArrayList(tSrcBe), storageMedium,
-                visibleVersion, visibleVersionHash);
+                visibleVersion, visibleVersionHash, (int) (taskTimeoutMs / 1000));
         cloneTask.setPathHash(srcPathHash, destPathHash);
         
         // if this is a balance task, or this is a repair task with REPLICA_MISSING/REPLICA_RELOCATING or REPLICA_MISSING_IN_CLUSTER,
@@ -713,8 +715,6 @@ public class TabletSchedCtx implements Comparable<TabletSchedCtx> {
                         + "current: " + replica.getPathHash() + ", scheduled: " + destPathHash);
             }
         }
-        
-        taskTimeoutMs = getApproximateTimeoutMs();
         
         this.state = State.RUNNING;
         return cloneTask;

--- a/fe/src/main/java/org/apache/doris/task/CloneTask.java
+++ b/fe/src/main/java/org/apache/doris/task/CloneTask.java
@@ -38,18 +38,21 @@ public class CloneTask extends AgentTask {
 
     private long srcPathHash = -1;
     private long destPathHash = -1;
+    
+    private int timeoutS;
 
     private int taskVersion = VERSION_1;
 
     public CloneTask(long backendId, long dbId, long tableId, long partitionId, long indexId,
                      long tabletId, int schemaHash, List<TBackend> srcBackends, TStorageMedium storageMedium,
-                     long visibleVersion, long visibleVersionHash) {
+                     long visibleVersion, long visibleVersionHash, int timeoutS) {
         super(null, backendId, TTaskType.CLONE, dbId, tableId, partitionId, indexId, tabletId);
         this.schemaHash = schemaHash;
         this.srcBackends = srcBackends;
         this.storageMedium = storageMedium;
         this.visibleVersion = visibleVersion;
         this.visibleVersionHash = visibleVersionHash;
+        this.timeoutS = timeoutS;
     }
 
     public int getSchemaHash() {
@@ -88,6 +91,7 @@ public class CloneTask extends AgentTask {
             request.setSrc_path_hash(srcPathHash);
             request.setDest_path_hash(destPathHash);
         }
+        request.setTimeout_s(timeoutS);
 
         return request;
     }

--- a/fe/src/main/java/org/apache/doris/task/ExportPendingTask.java
+++ b/fe/src/main/java/org/apache/doris/task/ExportPendingTask.java
@@ -113,6 +113,7 @@ public class ExportPendingTask extends MasterTask {
                 snapshotRequest.setSchema_hash(Integer.parseInt(paloScanRange.getSchema_hash()));
                 snapshotRequest.setVersion(Long.parseLong(paloScanRange.getVersion()));
                 snapshotRequest.setVersion_hash(Long.parseLong(paloScanRange.getVersion_hash()));
+                snapshotRequest.setTimeout(job.getTimeoutSecond());
 
                 AgentClient client = new AgentClient(host, port);
                 TAgentResult result = client.makeSnapshot(snapshotRequest);

--- a/fe/src/main/java/org/apache/doris/task/SnapshotTask.java
+++ b/fe/src/main/java/org/apache/doris/task/SnapshotTask.java
@@ -29,13 +29,13 @@ public class SnapshotTask extends AgentTask {
 
     private int schemaHash;
 
-    private long timeout;
+    private long timeoutMs;
 
     private boolean isRestoreTask;
 
     public SnapshotTask(TResourceInfo resourceInfo, long backendId, long signature, long jobId,
             long dbId, long tableId, long partitionId, long indexId, long tabletId,
-            long version, long versionHash, int schemaHash, long timeout, boolean isRestoreTask) {
+            long version, long versionHash, int schemaHash, long timeoutMs, boolean isRestoreTask) {
         super(resourceInfo, backendId, TTaskType.MAKE_SNAPSHOT, dbId, tableId, partitionId, indexId, tabletId,
                 signature);
 
@@ -45,7 +45,7 @@ public class SnapshotTask extends AgentTask {
         this.versionHash = versionHash;
         this.schemaHash = schemaHash;
 
-        this.timeout = timeout;
+        this.timeoutMs = timeoutMs;
 
         this.isRestoreTask = isRestoreTask;
     }
@@ -66,8 +66,8 @@ public class SnapshotTask extends AgentTask {
         return schemaHash;
     }
 
-    public long getTimeout() {
-        return timeout;
+    public long getTimeoutMs() {
+        return timeoutMs;
     }
 
     public boolean isRestoreTask() {
@@ -80,6 +80,7 @@ public class SnapshotTask extends AgentTask {
         request.setVersion_hash(versionHash);
         request.setList_files(true);
         request.setPreferred_snapshot_version(2);
+        request.setTimeout(timeoutMs / 1000);
         return request;
     }
 }

--- a/fe/src/test/java/org/apache/doris/task/AgentTaskTest.java
+++ b/fe/src/test/java/org/apache/doris/task/AgentTaskTest.java
@@ -125,7 +125,7 @@ public class AgentTaskTest {
         // clone
         cloneTask =
                 new CloneTask(backendId1, dbId, tableId, partitionId, indexId1, tabletId1, schemaHash1,
-                        Arrays.asList(new TBackend("host1", 8290, 8390)), TStorageMedium.HDD, -1, -1);
+                        Arrays.asList(new TBackend("host1", 8290, 8390)), TStorageMedium.HDD, -1, -1, 3600);
 
         // rollup
         rollupTask =

--- a/gensrc/thrift/AgentService.thrift
+++ b/gensrc/thrift/AgentService.thrift
@@ -118,6 +118,7 @@ struct TCloneReq {
     7: optional i32 task_version;
     8: optional i64 src_path_hash;
     9: optional i64 dest_path_hash;
+    10: optional i32 timeout_s;
 }
 
 struct TStorageMediumMigrateReq {


### PR DESCRIPTION
The new snapshot dir should looks like: `timestamp.seq.timeout`
eg: `20190818221223.3.86400`
And GC thread on BE will remove the snapshot after timeout.

And backup and restore process will release the snapshot actively 
after job is finished or cancelled.