### PR TITLE
Reduce the number of partition info in BrokerScanNode param

### DIFF
--- a/be/src/exec/broker_scan_node.cpp
+++ b/be/src/exec/broker_scan_node.cpp
@@ -342,26 +342,6 @@ Status BrokerScanNode::scanner_scan(
                 continue;
             }
 
-            // user may not specify the target partitions, or the table is unpartitioned.
-            // so here we only check if target partition is set.
-            // the OlapTableSink will check partition again, so don't worry about passing
-            // invalid rows.
-            if (scan_range.params.__isset.partition_ids && !partition_expr_ctxs.empty()) {
-                int64_t partition_id = get_partition_id(partition_expr_ctxs, row);
-                if (partition_id == -1 || 
-                        !std::binary_search(scan_range.params.partition_ids.begin(), 
-                                           scan_range.params.partition_ids.end(), 
-                                           partition_id)) {
-                    counter->num_rows_filtered++;
-
-                    std::stringstream error_msg;
-                    error_msg << "No corresponding partition, partition id: " << partition_id;
-                    _runtime_state->append_error_msg_to_file(Tuple::to_string(tuple, *_tuple_desc), 
-                                                             error_msg.str());
-                    continue;
-                }
-            }
-
             // eval conjuncts of this row.
             if (eval_conjuncts(&conjunct_ctxs[0], conjunct_ctxs.size(), row)) {
                 row_batch->commit_last_row();

--- a/be/src/exec/broker_scan_node.cpp
+++ b/be/src/exec/broker_scan_node.cpp
@@ -342,10 +342,10 @@ Status BrokerScanNode::scanner_scan(
                 continue;
             }
 
-            // The reason we check if partition_expr_ctxs is empty is when loading data to
-            // a unpartitioned table who has no partition_expr_ctxs, user can specify
-            // a partition name. And we check here to avoid crash and make our
-            // process run as normal
+            // user may not specify the target partitions, or the table is unpartitioned.
+            // so here we only check if target partition is set.
+            // the OlapTableSink will check partition again, so don't worry about passing
+            // invalid rows.
             if (scan_range.params.__isset.partition_ids && !partition_expr_ctxs.empty()) {
                 int64_t partition_id = get_partition_id(partition_expr_ctxs, row);
                 if (partition_id == -1 || 

--- a/fe/src/main/java/org/apache/doris/planner/BrokerScanNode.java
+++ b/fe/src/main/java/org/apache/doris/planner/BrokerScanNode.java
@@ -68,6 +68,7 @@ import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -205,7 +206,7 @@ public class BrokerScanNode extends ScanNode {
         this.strictMode = strictMode;
     }
 
-    private void createPartitionInfos() throws AnalysisException {
+    private void createPartitionInfos(List<Long> targetPartitionIds) throws AnalysisException {
         if (partitionInfos != null) {
             return;
         }
@@ -218,7 +219,7 @@ public class BrokerScanNode extends ScanNode {
 
         partitionExprs = Lists.newArrayList();
         partitionInfos = DataSplitSink.EtlRangePartitionInfo.createParts(
-                (OlapTable) targetTable, exprByName, null, partitionExprs);
+                (OlapTable) targetTable, exprByName, Sets.newHashSet(targetPartitionIds), partitionExprs);
     }
 
     // Called from init, construct source tuple information
@@ -235,7 +236,7 @@ public class BrokerScanNode extends ScanNode {
         List<Long> partitionIds = fileGroup.getPartitionIds();
         if (partitionIds != null && partitionIds.size() > 0) {
             params.setPartition_ids(partitionIds);
-            createPartitionInfos();
+            createPartitionInfos(partitionIds);
         }
 
         params.setProperties(brokerDesc.getProperties());

--- a/fe/src/main/java/org/apache/doris/planner/DataSplitSink.java
+++ b/fe/src/main/java/org/apache/doris/planner/DataSplitSink.java
@@ -362,7 +362,7 @@ public class DataSplitSink extends DataSink {
         }
 
         public static List<EtlRangePartitionInfo> createParts(
-                OlapTable tbl, Map<String, Expr> exprByCol, Set<String> targetPartitions,
+                OlapTable tbl, Map<String, Expr> exprByCol, Set<Long> targetPartitionIds,
                 List<Expr> partitionExprs) throws AnalysisException {
             List<EtlRangePartitionInfo> parts = Lists.newArrayList();
             PartitionInfo partInfo = tbl.getPartitionInfo();
@@ -372,7 +372,7 @@ public class DataSplitSink extends DataSink {
                     partitionExprs.add(exprByCol.get(col.getName()));
                 }
                 for (Partition part : tbl.getPartitions()) {
-                    if (targetPartitions != null && !targetPartitions.contains(part.getName())) {
+                    if (targetPartitionIds != null && !targetPartitionIds.contains(part.getId())) {
                         continue;
                     }
                     DistributionInfo distInfo = part.getDistributionInfo();


### PR DESCRIPTION
And we should reduce the number of partition info in BrokerScanNode param if user already
set target partitions to load, instead of adding all partitions' info.
It will cause the size of RPC packet too large.

ISSUE: #1674 