### PR TITLE
Fixbug： It can not create a new partition when paritions of a table is empty

### DIFF
--- a/fe/src/main/java/org/apache/doris/alter/Alter.java
+++ b/fe/src/main/java/org/apache/doris/alter/Alter.java
@@ -167,7 +167,7 @@ public class Alter {
 
             OlapTable olapTable = (OlapTable) table;
 
-            if (olapTable.getPartitions().size() == 0) {
+            if (olapTable.getPartitions().size() == 0 && !hasPartition) {
                 throw new DdlException("table with empty parition cannot do schema change. [" + tableName + "]");
             }
 


### PR DESCRIPTION
It can not create a new partition when paritions of a table is empty