### PR TITLE
refactor RowsetReaderContext

### DIFF
--- a/be/src/olap/reader.h
+++ b/be/src/olap/reader.h
@@ -46,7 +46,6 @@ class RowCursor;
 class RowBlock;
 class CollectIterator;
 class RuntimeState;
-class ColumnData;
 
 // Params for Reader,
 // mainly include tablet, data version and fetch range.
@@ -55,7 +54,9 @@ struct ReaderParams {
     ReaderType reader_type;
     bool aggregation;
     Version version;
+    // possible values are "gt", "ge", "eq"
     std::string range;
+    // possible values are "lt", "le"
     std::string end_range;
     std::vector<OlapTuple> start_key;
     std::vector<OlapTuple> end_key;

--- a/be/src/olap/rowset/alpha_rowset_reader.h
+++ b/be/src/olap/rowset/alpha_rowset_reader.h
@@ -27,6 +27,7 @@
 
 namespace doris {
 
+// Each segment group corresponds to a MergeContext, which is able to produce ordered rows.
 struct MergeContext {
     std::unique_ptr<ColumnData> column_data = nullptr;
 
@@ -36,12 +37,8 @@ struct MergeContext {
     // ScanKey should be sought in this case.
     bool first_read_symbol = true;
 
-    // For singleton Rowset, there are several SegmentGroups
-    // Each of SegmentGroups correponds to a row_block upon scan
     RowBlock* row_block = nullptr;
 
-    // For singleton Rowset, there are several SegmentGroups
-    // Each of SegmentGroups correponds to a row_cursor
     std::unique_ptr<RowCursor> row_cursor = nullptr;
 };
 
@@ -49,26 +46,26 @@ class AlphaRowsetReader : public RowsetReader {
 public:
     AlphaRowsetReader(int num_rows_per_row_block, RowsetSharedPtr rowset);
 
-    ~AlphaRowsetReader();
+    ~AlphaRowsetReader() override;
 
     // reader init
-    virtual OLAPStatus init(RowsetReaderContext* read_context);
+    OLAPStatus init(RowsetReaderContext* read_context) override;
 
     // read next block data
-    virtual OLAPStatus next_block(RowBlock** block);
+    OLAPStatus next_block(RowBlock** block) override;
 
-    virtual bool delete_flag();
+    bool delete_flag() override;
 
-    virtual Version version();
+    Version version() override;
 
-    virtual VersionHash version_hash();
+    VersionHash version_hash() override;
 
     // close reader
-    virtual void close();
+    void close() override;
 
-    virtual RowsetSharedPtr rowset();
+    RowsetSharedPtr rowset() override;
 
-    virtual int64_t filtered_rows();
+    int64_t filtered_rows() override;
 
 private:
 

--- a/be/src/olap/rowset/column_data.cpp
+++ b/be/src/olap/rowset/column_data.cpp
@@ -20,6 +20,7 @@
 #include "olap/rowset/segment_reader.h"
 #include "olap/olap_cond.h"
 #include "olap/row_block.h"
+#include "olap/storage_engine.h"
 
 namespace doris {
 
@@ -36,7 +37,8 @@ ColumnData::ColumnData(SegmentGroup* segment_group)
         _delete_status(DEL_NOT_SATISFIED),
         _runtime_state(nullptr),
         _is_using_cache(false),
-        _segment_reader(nullptr) {
+        _segment_reader(nullptr),
+        _lru_cache(StorageEngine::instance()->index_stream_lru_cache()) {
     _num_rows_per_block = _segment_group->get_num_rows_per_row_block();
 }
 

--- a/be/src/olap/rowset/column_data.h
+++ b/be/src/olap/rowset/column_data.h
@@ -85,10 +85,6 @@ public:
         _is_using_cache = is_using_cache;
     }
 
-    void set_lru_cache(Cache* lru_cache) {
-        _lru_cache = lru_cache;
-    }
-
     void set_stats(OlapReaderStatistics* stats) {
         _stats = stats;
     }

--- a/be/src/olap/rowset/rowset_reader_context.h
+++ b/be/src/olap/rowset/rowset_reader_context.h
@@ -18,8 +18,8 @@
 #ifndef DORIS_BE_SRC_OLAP_ROWSET_ROWSET_READER_CONTEXT_H
 #define DORIS_BE_SRC_OLAP_ROWSET_ROWSET_READER_CONTEXT_H
 
+#include "olap/olap_common.h"
 #include "olap/column_predicate.h"
-#include "olap/lru_cache.h"
 #include "runtime/runtime_state.h"
 
 namespace doris {
@@ -30,47 +30,28 @@ class DeleteHandler;
 class TabletSchema;
 
 struct RowsetReaderContext {
-    RowsetReaderContext() : reader_type(READER_QUERY),
-        tablet_schema(nullptr),
-        preaggregation(false),
-        return_columns(nullptr),
-        seek_columns(nullptr),
-        load_bf_columns(nullptr),
-        conditions(nullptr),
-        predicates(nullptr),
-        lower_bound_keys(nullptr),
-        is_lower_keys_included(nullptr),
-        upper_bound_keys(nullptr),
-        is_upper_keys_included(nullptr),
-        delete_handler(nullptr),
-        stats(nullptr),
-        is_using_cache(false),
-        lru_cache(nullptr),
-        runtime_state(nullptr) { }
-
-    ReaderType reader_type;
-    const TabletSchema* tablet_schema;
-    bool preaggregation;
+    ReaderType reader_type = READER_QUERY;
+    const TabletSchema* tablet_schema = nullptr;
+    // whether rowset should return ordered rows.
+    bool need_ordered_result = true;
     // projection columns
-    const std::vector<uint32_t>* return_columns;
-    const std::vector<uint32_t>* seek_columns;
+    const std::vector<uint32_t>* return_columns = nullptr;
+    const std::vector<uint32_t>* seek_columns = nullptr;
     // columns to load bloom filter index
     // including columns in "=" or "in" conditions
-    const std::set<uint32_t>* load_bf_columns;
+    const std::set<uint32_t>* load_bf_columns = nullptr;
     // column filter conditions by delete sql
-    const Conditions* conditions;
+    const Conditions* conditions = nullptr;
     // column name -> column predicate
     // adding column_name for predicate to make use of column selectivity
-    const std::vector<ColumnPredicate*>* predicates;
-    const std::vector<RowCursor*>* lower_bound_keys;
-    const std::vector<bool>* is_lower_keys_included;
-    const std::vector<RowCursor*>* upper_bound_keys;
-    const std::vector<bool>* is_upper_keys_included;
-    const DeleteHandler* delete_handler;
-    OlapReaderStatistics* stats;
-    bool is_using_cache;
-    Cache* lru_cache;
-    RuntimeState* runtime_state;
+    const std::vector<ColumnPredicate*>* predicates = nullptr;
+    const std::vector<RowCursor*>* lower_bound_keys = nullptr;
+    const std::vector<bool>* is_lower_keys_included = nullptr;
+    const std::vector<RowCursor*>* upper_bound_keys = nullptr;
+    const std::vector<bool>* is_upper_keys_included = nullptr;
+    const DeleteHandler* delete_handler = nullptr;
+    OlapReaderStatistics* stats = nullptr;
+    RuntimeState* runtime_state = nullptr;
 };
 
 } // namespace doris

--- a/be/src/olap/schema_change.cpp
+++ b/be/src/olap/schema_change.cpp
@@ -1289,10 +1289,8 @@ OLAPStatus SchemaChangeHandler::_do_process_alter_tablet_v2(const TAlterTabletRe
 
         _reader_context.reader_type = READER_ALTER_TABLE;
         _reader_context.tablet_schema= &base_tablet->tablet_schema();
-        _reader_context.preaggregation = true;
+        _reader_context.need_ordered_result = true;
         _reader_context.delete_handler = &delete_handler;
-        _reader_context.is_using_cache = false;
-        _reader_context.lru_cache = StorageEngine::instance()->index_stream_lru_cache();
 
         for (auto& rs_reader : rs_readers) {
             rs_reader->init(&_reader_context);
@@ -1558,10 +1556,8 @@ OLAPStatus SchemaChangeHandler::process_alter_tablet(AlterTabletType type,
 
         _reader_context.reader_type = READER_ALTER_TABLE;
         _reader_context.tablet_schema= &base_tablet->tablet_schema();
-        _reader_context.preaggregation = true;
+        _reader_context.need_ordered_result = true;
         _reader_context.delete_handler = &delete_handler;
-        _reader_context.is_using_cache = false;
-        _reader_context.lru_cache = StorageEngine::instance()->index_stream_lru_cache();
 
         for (auto& rs_reader : rs_readers) {
             rs_reader->init(&_reader_context);
@@ -1660,10 +1656,8 @@ OLAPStatus SchemaChangeHandler::schema_version_convert(
     DeleteHandler delete_handler;
     _reader_context.reader_type = READER_ALTER_TABLE;
     _reader_context.tablet_schema = &base_tablet->tablet_schema();
-    _reader_context.preaggregation = true;
+    _reader_context.need_ordered_result = true;
     _reader_context.delete_handler = &delete_handler;
-    _reader_context.is_using_cache = false;
-    _reader_context.lru_cache = StorageEngine::instance()->index_stream_lru_cache();
 
     RowsetReaderSharedPtr rowset_reader = (*base_rowset)->create_reader();
     rowset_reader->init(&_reader_context);

--- a/be/test/olap/rowset/alpha_rowset_test.cpp
+++ b/be/test/olap/rowset/alpha_rowset_test.cpp
@@ -104,10 +104,9 @@ void create_rowset_reader_context(TabletSchema* tablet_schema, const std::vector
         std::set<uint32_t>* load_bf_columns, Conditions* conditions, RowsetReaderContext* rowset_reader_context) {
     rowset_reader_context->reader_type = READER_ALTER_TABLE;
     rowset_reader_context->tablet_schema = tablet_schema;
-    rowset_reader_context->preaggregation = false;
+    rowset_reader_context->need_ordered_result = true;
     rowset_reader_context->return_columns = return_columns;
     rowset_reader_context->delete_handler = delete_handler;
-    rowset_reader_context->is_using_cache = false;
     rowset_reader_context->lower_bound_keys = nullptr;
     rowset_reader_context->is_lower_keys_included = nullptr;
     rowset_reader_context->upper_bound_keys = nullptr;
@@ -115,7 +114,6 @@ void create_rowset_reader_context(TabletSchema* tablet_schema, const std::vector
     rowset_reader_context->predicates = predicates;
     rowset_reader_context->load_bf_columns = load_bf_columns;
     rowset_reader_context->conditions = conditions;
-    rowset_reader_context->lru_cache = k_engine->index_stream_lru_cache();
 }
 
 void create_tablet_schema(KeysType keys_type, TabletSchema* tablet_schema) {


### PR DESCRIPTION
This PR refactors RowsetReaderContext and adds more comments to help developers understand the read path.

Tha main changes are

- move index stream cache stuff (`is_using_cache` and `lru_cache`) out of RowsetReaderContext because that's specific to alpha rowset and whether to use that cache  can be determined solely by `reader_type`
- `preaggregation` is replaced with `need_ordered_result` to improve code understandability and to simplify RowsetReader implementations