### PR TITLE
support multiple key ranges in RowwiseIterator and StorageReadOptions

### DIFF
--- a/be/src/olap/iterators.h
+++ b/be/src/olap/iterators.h
@@ -58,33 +58,14 @@ public:
         bool include_upper;
     };
 
-    StorageReadOptions() = default;
-
-    StorageReadOptions(const std::vector<KeyRange>& key_ranges, Conditions* conditions)
-        : _key_ranges(key_ranges), _conditions(conditions) {
-    }
-
-    const std::vector<KeyRange>& key_ranges() const { return _key_ranges; }
-    StorageReadOptions& add_key_range(const KeyRange& key_range) {
-        _key_ranges.push_back(key_range);
-        return *this;
-    }
-
-    const Conditions* column_predicates() const { return _conditions; }
-    StorageReadOptions& set_column_predicates(Conditions* conditions) {
-        _conditions = conditions;
-        return *this;
-    }
-
-private:
     // reader's key ranges, empty if not existed.
     // used by short key index to filter row blocks
-    std::vector<KeyRange> _key_ranges;
+    std::vector<KeyRange> key_ranges;
 
     // reader's column predicates, nullptr if not existed.
     // used by column index to filter pages and rows
     // TODO use vector<ColumnPredicate*> instead
-    Conditions* _conditions = nullptr;
+    const Conditions* conditions = nullptr;
 };
 
 // Used to read data in RowBlockV2 one by one

--- a/be/src/olap/iterators.h
+++ b/be/src/olap/iterators.h
@@ -28,27 +28,63 @@ class RowBlockV2;
 class Schema;
 class Conditions;
 
-struct StorageReadOptions {
-    // lower_bound defines the smallest key at which iterator will
-    // return data.
-    // If lower_bound is null, won't return
-    std::shared_ptr<RowCursor> lower_bound;
+class StorageReadOptions {
+public:
+    struct KeyRange {
+        KeyRange()
+            : lower_key(nullptr),
+              include_lower(false),
+              upper_key(nullptr),
+              include_upper(false) {
+        }
 
-    // If include_lower_bound is true, data equal with lower_bound will
-    // be read
-    bool include_lower_bound = false;
+        KeyRange(const RowCursor* lower_key_,
+                 bool include_lower_,
+                 const RowCursor* upper_key_,
+                 bool include_upper_)
+            : lower_key(lower_key_),
+              include_lower(include_lower_),
+              upper_key(upper_key_),
+              include_upper(include_upper_) {
+        }
 
-    // upper_bound defines the extend upto which the iterator can return
-    // data.
-    std::shared_ptr<RowCursor> upper_bound;
+        // the lower bound of the range, nullptr if not existed
+        const RowCursor* lower_key;
+        // whether `lower_key` is included in the range
+        bool include_lower;
+        // the upper bound of the range, nullptr if not existed
+        const RowCursor* upper_key;
+        // whether `upper_key` is included in the range
+        bool include_upper;
+    };
 
-    // If include_upper_bound is true, data equal with upper_bound will
-    // be read
-    bool include_upper_bound = false;
+    StorageReadOptions() = default;
 
-    // reader's column predicates
-    // used by zone map/bloom filter/secondary index to prune data
-    std::shared_ptr<Conditions> conditions;
+    StorageReadOptions(const std::vector<KeyRange>& key_ranges, Conditions* conditions)
+        : _key_ranges(key_ranges), _conditions(conditions) {
+    }
+
+    const std::vector<KeyRange>& key_ranges() const { return _key_ranges; }
+    StorageReadOptions& add_key_range(const KeyRange& key_range) {
+        _key_ranges.push_back(key_range);
+        return *this;
+    }
+
+    const Conditions* column_predicates() const { return _conditions; }
+    StorageReadOptions& set_column_predicates(Conditions* conditions) {
+        _conditions = conditions;
+        return *this;
+    }
+
+private:
+    // reader's key ranges, empty if not existed.
+    // used by short key index to filter row blocks
+    std::vector<KeyRange> _key_ranges;
+
+    // reader's column predicates, nullptr if not existed.
+    // used by column index to filter pages and rows
+    // TODO use vector<ColumnPredicate*> instead
+    Conditions* _conditions = nullptr;
 };
 
 // Used to read data in RowBlockV2 one by one

--- a/be/src/olap/row_block.cpp
+++ b/be/src/olap/row_block.cpp
@@ -49,7 +49,6 @@ RowBlock::~RowBlock() {
 }
 
 OLAPStatus RowBlock::init(const RowBlockInfo& block_info) {
-    _field_count = _schema->num_columns();
     _info = block_info;
     _null_supported = block_info.null_supported;
     _capacity = _info.row_num;

--- a/be/src/olap/row_block.h
+++ b/be/src/olap/row_block.h
@@ -162,9 +162,6 @@ private:
     
     bool _null_supported;
 
-    size_t _field_count = 0;
-    bool _need_checksum = true;
-
     // Data in memory is construct from row cursors, these row cursors's size is equal
     char* _mem_buf = nullptr;
     // equal with _mem_row_bytes * _info.row_num

--- a/be/src/olap/rowset/column_data.cpp
+++ b/be/src/olap/rowset/column_data.cpp
@@ -482,21 +482,6 @@ OLAPStatus ColumnData::get_first_row_block(RowBlock** row_block) {
     return OLAP_SUCCESS;
 }
 
-OLAPStatus ColumnData::get_next_row_block(RowBlock** row_block) {
-    _is_normal_read = true;
-    OLAPStatus res = _get_block(false);
-    if (res != OLAP_SUCCESS) {
-        if (res != OLAP_ERR_DATA_EOF) {
-            OLAP_LOG_WARNING("fail to load data to row block. [res=%d]", res);
-        }
-        *row_block = nullptr;
-        return res;
-    }
-
-    *row_block = _read_block.get();
-    return OLAP_SUCCESS;
-}
-
 bool ColumnData::rowset_pruning_filter() {
     if (empty() || zero_num_rows()) {
         return true;
@@ -516,7 +501,7 @@ int ColumnData::delete_pruning_filter() {
         return DEL_NOT_SATISFIED;
     }
 
-    if (false == _segment_group->has_zone_maps()) {
+    if (!_segment_group->has_zone_maps()) {
         /*
          * if segment_group has no column statistics, we cannot judge whether the data can be filtered or not
          */
@@ -549,9 +534,9 @@ int ColumnData::delete_pruning_filter() {
         }
     }
 
-    if (true == del_stastified) {
+    if (del_stastified) {
         ret = DEL_SATISFIED;
-    } else if (true == del_partial_stastified) {
+    } else if (del_partial_stastified) {
         ret = DEL_PARTIAL_SATISFIED;
     } else {
         ret = DEL_NOT_SATISFIED;

--- a/be/src/olap/rowset/column_data.h
+++ b/be/src/olap/rowset/column_data.h
@@ -76,7 +76,6 @@ public:
             RuntimeState* runtime_state);
 
     OLAPStatus get_first_row_block(RowBlock** row_block);
-    OLAPStatus get_next_row_block(RowBlock** row_block);
 
     // Only used to binary search in full-key find row
     const RowCursor* seek_and_get_current_row(const RowBlockPosition& position);

--- a/be/src/olap/rowset/segment_v2/segment.cpp
+++ b/be/src/olap/rowset/segment_v2/segment.cpp
@@ -69,9 +69,10 @@ Status Segment::open() {
     return Status::OK();
 }
 
-Status Segment::new_iterator(const Schema& schema, std::unique_ptr<SegmentIterator>* output) {
-    output->reset(new SegmentIterator(this->shared_from_this(), schema));
-    return Status::OK();
+std::unique_ptr<SegmentIterator> Segment::new_iterator(const Schema& schema, const StorageReadOptions& read_options) {
+    auto it = std::unique_ptr<SegmentIterator>(new SegmentIterator(this->shared_from_this(), schema));
+    it->init(read_options);
+    return it;
 }
 
 // Read data at offset of input file, check if the file content match the magic

--- a/be/src/olap/rowset/segment_v2/segment.cpp
+++ b/be/src/olap/rowset/segment_v2/segment.cpp
@@ -34,12 +34,10 @@ using strings::Substitute;
 
 Segment::Segment(
         std::string fname, uint32_t segment_id,
-        const std::shared_ptr<TabletSchema>& tablet_schema,
-        size_t num_rows_per_block)
+        const TabletSchema* tablet_schema)
         : _fname(std::move(fname)),
         _segment_id(segment_id),
-        _tablet_schema(tablet_schema),
-        _num_rows_per_block(num_rows_per_block) {
+        _tablet_schema(tablet_schema) {
 }
 
 Segment::~Segment() {

--- a/be/src/olap/rowset/segment_v2/segment.h
+++ b/be/src/olap/rowset/segment_v2/segment.h
@@ -33,7 +33,6 @@ namespace doris {
 
 class RandomAccessFile;
 class SegmentGroup;
-class FieldInfo;
 class TabletSchema;
 class ShortKeyIndexDecoder;
 class Schema;
@@ -42,7 +41,9 @@ namespace segment_v2 {
 
 class ColumnReader;
 class ColumnIterator;
+class Segment;
 class SegmentIterator;
+using SegmentSharedPtr = std::shared_ptr<Segment>;
 
 // A Segment is used to represent a segment in memory format. When segment is
 // generated, it won't be modified, so this struct aimed to help read operation.
@@ -55,8 +56,7 @@ class SegmentIterator;
 class Segment : public std::enable_shared_from_this<Segment> {
 public:
     Segment(std::string fname, uint32_t segment_id,
-            const std::shared_ptr<TabletSchema>& tablet_schema,
-            size_t num_rows_per_block);
+            const TabletSchema* tablet_schema);
     ~Segment();
 
     Status open();
@@ -71,7 +71,7 @@ private:
     friend class SegmentIterator;
 
     Status new_column_iterator(uint32_t cid, ColumnIterator** iter);
-    uint32_t num_rows_per_block() const { return _num_rows_per_block; }
+    uint32_t num_rows_per_block() const { return _sk_index_decoder->num_rows_per_block(); }
     size_t num_short_keys() const { return _tablet_schema->num_short_key_columns(); }
 
     Status _check_magic(uint64_t offset);
@@ -97,8 +97,7 @@ private:
 private:
     std::string _fname;
     uint32_t _segment_id;
-    std::shared_ptr<TabletSchema> _tablet_schema;
-    uint32_t _num_rows_per_block;
+    const TabletSchema* _tablet_schema;
 
     SegmentFooterPB _footer;
     std::unique_ptr<RandomAccessFile> _input_file;

--- a/be/src/olap/rowset/segment_v2/segment.h
+++ b/be/src/olap/rowset/segment_v2/segment.h
@@ -36,6 +36,7 @@ class SegmentGroup;
 class TabletSchema;
 class ShortKeyIndexDecoder;
 class Schema;
+class StorageReadOptions;
 
 namespace segment_v2 {
 
@@ -61,7 +62,7 @@ public:
 
     Status open();
 
-    Status new_iterator(const Schema& schema, std::unique_ptr<SegmentIterator>* iter);
+    std::unique_ptr<SegmentIterator> new_iterator(const Schema& schema, const StorageReadOptions& read_options);
 
     uint64_t id() const { return _segment_id; }
 

--- a/be/src/olap/schema.h
+++ b/be/src/olap/schema.h
@@ -99,7 +99,7 @@ public:
     ~Schema();
 
     const std::vector<Field*>& columns() const { return _cols; }
-    const Field* column(int idx) const { return _cols[idx]; }
+    const Field* column(ColumnId cid) const { return _cols[cid]; }
 
     size_t num_key_columns() const {
         return _num_key_columns;
@@ -133,8 +133,11 @@ public:
     size_t num_column_ids() const { return _col_ids.size(); }
     const std::vector<ColumnId>& column_ids() const { return _col_ids; }
 private:
-    std::vector<Field*> _cols;
+    // all valid ColumnIds in this schema
     std::vector<ColumnId> _col_ids;
+    // _cols[cid] is ony valid when cid is contained in `_col_ids`
+    std::vector<Field*> _cols;
+    // _col_offsets[cid] is ony valid when cid is contained in `_col_ids`
     std::vector<size_t> _col_offsets;
     size_t _num_key_columns;
     size_t _schema_size;

--- a/be/src/olap/short_key_index.h
+++ b/be/src/olap/short_key_index.h
@@ -236,6 +236,8 @@ public:
 
     uint32_t num_items() const { return _footer.num_items(); }
 
+    uint32_t num_rows_per_block() const { return _footer.num_rows_per_block(); }
+
     Slice key(ssize_t ordinal) const {
         DCHECK(ordinal >= 0 && ordinal < num_items());
         return {_key_data.data + _offsets[ordinal], _offsets[ordinal + 1] - _offsets[ordinal]};

--- a/be/src/util/doris_metrics.h
+++ b/be/src/util/doris_metrics.h
@@ -107,9 +107,14 @@ public:
     static IntCounter meta_read_request_total;
     static IntCounter meta_read_request_duration_us;
 
+    // Counters for segment_v2
+    // -----------------------
     static IntCounter segment_read_total;
+    // total number of rows in queried segments (before index pruning)
     static IntCounter segment_row_total;
+    // total number of rows selected by short key index
     static IntCounter segment_rows_by_short_key;
+    // total number of rows selected by zone map index
     static IntCounter segment_rows_read_by_zone_map;
 
     static IntCounter txn_begin_request_total;

--- a/be/src/util/doris_metrics.h
+++ b/be/src/util/doris_metrics.h
@@ -109,6 +109,7 @@ public:
 
     // Counters for segment_v2
     // -----------------------
+    // total number of segments read
     static IntCounter segment_read_total;
     // total number of rows in queried segments (before index pruning)
     static IntCounter segment_row_total;


### PR DESCRIPTION
Main changes

- support multiple key ranges in RowwiseIterator and StorageReadOptions
- remove unused fields and member functions in RowBlock and ColumnData
- read `num_rows_per_block` from short key index footer