### PR TITLE
Make StringValue's memory layout same with Slice

### DIFF
--- a/be/src/exec/text_converter.cpp
+++ b/be/src/exec/text_converter.cpp
@@ -37,7 +37,7 @@ void TextConverter::unescape_string(StringValue* value, MemPool* pool) {
     value->ptr = new_data;
 }
 
-void TextConverter::unescape_string(const char* src, char* dest, int* len) {
+void TextConverter::unescape_string(const char* src, char* dest, size_t* len) {
     char* dest_ptr = dest;
     const char* end = src + *len;
     bool escape_next_char = false;

--- a/be/src/exec/text_converter.h
+++ b/be/src/exec/text_converter.h
@@ -51,7 +51,7 @@ public:
     // Removes escape characters from len characters of the null-terminated string src,
     // and copies the unescaped string into dest, changing *len to the unescaped length.
     // No null-terminator is added to dest.
-    void unescape_string(const char* src, char* dest, int* len);
+    void unescape_string(const char* src, char* dest, size_t* len);
 
     // Removes escape characters from 'str', allocating a new string from pool.
     // 'str' is updated with the new ptr and length.

--- a/be/src/olap/rowset/segment_v2/binary_plain_page.h
+++ b/be/src/olap/rowset/segment_v2/binary_plain_page.h
@@ -137,6 +137,7 @@ public:
             _options(options),
             _parsed(false),
             _num_elems(0),
+            _offsets_pos(0),
             _cur_idx(0) { }
 
     Status init() override {

--- a/be/src/runtime/string_value.h
+++ b/be/src/runtime/string_value.h
@@ -33,8 +33,11 @@ struct StringValue {
     // TODO: change ptr to an offset relative to a contiguous memory block,
     // so that we can send row batches between nodes without having to swizzle
     // pointers
+    // NOTE: This struct should keep the same memory layout with Slice, otherwise
+    // it will lead to BE crash.
+    // TODO(zc): we should unify this struct with Slice some day.
     char* ptr;
-    int len;
+    size_t len;
 
     StringValue(char* ptr, int len): ptr(ptr), len(len) {}
     StringValue(): ptr(NULL), len(0) {}


### PR DESCRIPTION
In our storage engine's code, we cast StringValue to Slice. Because
their memory layout is not differenct, it may cause BE process crash.

We make their memory layout same in this patch to resolve this problem
temporary. We should improve it some day.

#1706 