### PR TITLE
[Spark Doris Connector] Avoid consistency problem when has no more data

### DIFF
--- a/be/src/runtime/memory_scratch_sink.cpp
+++ b/be/src/runtime/memory_scratch_sink.cpp
@@ -223,7 +223,7 @@ Status MemoryScratchSink::close(RuntimeState* state, Status exec_status) {
         return Status::OK();
     }
     // put sentinel
-    if (_queue) {
+    if (_queue != nullptr) {
         _queue->blocking_put(nullptr);
     }
     Expr::close(_output_expr_ctxs, state);

--- a/be/src/runtime/memory_scratch_sink.cpp
+++ b/be/src/runtime/memory_scratch_sink.cpp
@@ -222,7 +222,7 @@ Status MemoryScratchSink::close(RuntimeState* state, Status exec_status) {
     if (_closed) {
         return Status::OK();
     }
-    // shutdown queue, then blocking_get return false, put sentinel
+    // put sentinel
     if (_queue) {
         _queue->blocking_put(nullptr);
     }

--- a/be/src/runtime/result_queue_mgr.cpp
+++ b/be/src/runtime/result_queue_mgr.cpp
@@ -47,6 +47,10 @@ Status ResultQueueMgr::fetch_result(const TUniqueId& fragment_instance_id, std::
         // sentinel nullptr indicates scan end
         if (*result == nullptr) {
             *eos = true;
+            // put sentinel for consistency, avoid repeated invoking fetch result when hava no rowbatch
+            if (_queue) {
+                _queue->blocking_put(nullptr);
+            }
         } else {
             *eos = false;
         }

--- a/be/src/runtime/result_queue_mgr.cpp
+++ b/be/src/runtime/result_queue_mgr.cpp
@@ -48,8 +48,8 @@ Status ResultQueueMgr::fetch_result(const TUniqueId& fragment_instance_id, std::
         if (*result == nullptr) {
             *eos = true;
             // put sentinel for consistency, avoid repeated invoking fetch result when hava no rowbatch
-            if (_queue) {
-                _queue->blocking_put(nullptr);
+            if (queue != nullptr) {
+                queue->blocking_put(nullptr);
             }
         } else {
             *eos = false;


### PR DESCRIPTION
When all result data returned, fetch_result blocked unexpected  by `blocking_get` after multi invoking .  Put sentinel nullptr for the BlockingQueue to keep consistent for repeated invoking fetch result.