### PR TITLE
Make bitmap_union agg column support insert into and broker load

### DIFF
--- a/be/src/exec/tablet_sink.cpp
+++ b/be/src/exec/tablet_sink.cpp
@@ -707,6 +707,12 @@ int OlapTableSink::_validate_data(RuntimeState* state, RowBatch* batch, Bitmap* 
             case TYPE_VARCHAR: {
                 // Fixed length string
                 StringValue* str_val = (StringValue*)slot;
+                // todo(kks): varchar(0) means bitmap_union agg type
+                // we will remove this special handle when we add a special type for bitmap_union
+                if (desc->type().type == TYPE_VARCHAR && desc->type().len == 0) {
+                    continue;
+                }
+
                 if (str_val->len > desc->type().len) {
                     std::stringstream ss;
                     ss << "the length of input is too long than schema. "

--- a/docs/documentation/cn/sql-reference/sql-functions/aggregate-functions/bitmap.md
+++ b/docs/documentation/cn/sql-reference/sql-functions/aggregate-functions/bitmap.md
@@ -5,7 +5,7 @@
 
 `TO_BITMAP(expr)` : 将TINYINT,SMALLINT和INT类型的列转为Bitmap
 
-`BITMAP_UNION(expr)` : 计算两个Bitmap的交集，返回值是序列化后的Bitmap值
+`BITMAP_UNION(expr)` : 计算两个Bitmap的并集，返回值是序列化后的Bitmap值
 
 `BITMAP_COUNT(expr)` : 计算Bitmap中不同值的个数
 
@@ -49,7 +49,7 @@ mysql> select bitmap_union_int (id2) from bitmap_udaf;
 
 CREATE TABLE `bitmap_test` (
   `id` int(11) NULL COMMENT "",
-  `id2` varchar(20) bitmap_union NULL
+  `id2` varchar(0) bitmap_union NULL  // 注意： bitmap_union的varchar长度需要指定为0
 ) ENGINE=OLAP
 AGGREGATE KEY(`id`)
 DISTRIBUTED BY HASH(`id`) BUCKETS 10;

--- a/docs/documentation/cn/sql-reference/sql-statements/Data Definition/CREATE TABLE.md
+++ b/docs/documentation/cn/sql-reference/sql-statements/Data Definition/CREATE TABLE.md
@@ -301,8 +301,8 @@
         (
         k1 TINYINT,
         k2 DECIMAL(10, 2) DEFAULT "10.5",
-        v1 VARCHAR(20) BITMAP_UNION,
-        v2 VARCHAR(20) BITMAP_UNION
+        v1 VARCHAR(0) BITMAP_UNION,  // 注意： bitmap_union的varchar长度需要指定为0
+        v2 VARCHAR(0) BITMAP_UNION
         )
         ENGINE=olap
         AGGREGATE KEY(k1, k2)

--- a/fe/src/main/java/org/apache/doris/analysis/SelectStmt.java
+++ b/fe/src/main/java/org/apache/doris/analysis/SelectStmt.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.analysis;
 
+import org.apache.doris.catalog.AggregateType;
 import org.apache.doris.catalog.Catalog;
 import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.Database;
@@ -729,6 +730,10 @@ public class SelectStmt extends QueryStmt {
             if (col.getDataType() == PrimitiveType.HLL && !fromInsert) {
                 throw new AnalysisException (
                         "hll only use in HLL_UNION_AGG or HLL_CARDINALITY , HLL_HASH and so on.");
+            }
+            if (col.getAggregationType() == AggregateType.BITMAP_UNION && !fromInsert) {
+                throw new AnalysisException (
+                        "BITMAP_UNION agg column only use in TO_BITMAP or BITMAP_UNION , BITMAP_COUNT and so on.");
             }
             resultExprs.add(new SlotRef(tblName, col.getName()));
             colLabels.add(col.getName());

--- a/fe/src/main/java/org/apache/doris/analysis/TypeDef.java
+++ b/fe/src/main/java/org/apache/doris/analysis/TypeDef.java
@@ -92,7 +92,10 @@ public class TypeDef implements ParseNode {
         }
         int len = scalarType.getLength();
         // len is decided by child, when it is -1.
-        if (len <= 0) {
+
+        // todo(kks) : varchar(0) for bitmap_union agg type,
+        // we should forbid the len equal zero when we add a special type for bitmap_union
+        if (len < 0) {
           throw new AnalysisException(name + " size must be > 0: " + len);
         }
         if (scalarType.getLength() > maxLen) {

--- a/fe/src/main/java/org/apache/doris/planner/BrokerScanNode.java
+++ b/fe/src/main/java/org/apache/doris/planner/BrokerScanNode.java
@@ -463,6 +463,8 @@ public class BrokerScanNode extends ScanNode {
                 expr.setType(Type.HLL);
             }
 
+            checkBitmapCompatibility(destSlotDesc, expr);
+
             // analyze negative
             if (isNegative && destSlotDesc.getColumn().getAggregationType() == AggregateType.SUM) {
                 expr = new ArithmeticExpr(ArithmeticExpr.Operator.MULTIPLY, expr, new IntLiteral(-1));

--- a/fe/src/main/java/org/apache/doris/planner/ScanNode.java
+++ b/fe/src/main/java/org/apache/doris/planner/ScanNode.java
@@ -18,9 +18,13 @@
 package org.apache.doris.planner;
 
 import org.apache.doris.analysis.Expr;
+import org.apache.doris.analysis.FunctionCallExpr;
 import org.apache.doris.analysis.SlotDescriptor;
 import org.apache.doris.analysis.TupleDescriptor;
+import org.apache.doris.catalog.AggregateType;
+import org.apache.doris.catalog.FunctionSet;
 import org.apache.doris.catalog.PrimitiveType;
+import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.UserException;
 import org.apache.doris.thrift.TNetworkAddress;
 import org.apache.doris.thrift.TScanRangeLocations;
@@ -73,6 +77,24 @@ abstract public class ScanNode extends PlanNode {
             return expr.castTo(slotDesc.getType());
         } else {
             return expr;
+        }
+    }
+
+    protected void checkBitmapCompatibility(SlotDescriptor slotDesc, Expr expr) throws AnalysisException {
+        boolean isCompatible = true;
+        if (slotDesc.getColumn().getAggregationType() == AggregateType.BITMAP_UNION) {
+            if (!(expr instanceof FunctionCallExpr)) {
+                isCompatible = false;
+            } else {
+                FunctionCallExpr fn = (FunctionCallExpr) expr;
+                if (!fn.getFnName().getFunction().equalsIgnoreCase(FunctionSet.TO_BITMAP)) {
+                    isCompatible = false;
+                }
+            }
+        }
+        if (!isCompatible) {
+            throw new AnalysisException("bitmap_union column must use to_bitmap function, like "
+                    + slotDesc.getColumn().getName() + "=to_bitmap(xxx)");
         }
     }
 

--- a/fe/src/main/java/org/apache/doris/planner/StreamLoadScanNode.java
+++ b/fe/src/main/java/org/apache/doris/planner/StreamLoadScanNode.java
@@ -288,6 +288,9 @@ public class StreamLoadScanNode extends ScanNode {
                 }
                 expr.setType(Type.HLL);
             }
+
+            checkBitmapCompatibility(dstSlotDesc, expr);
+
             if (negative && dstSlotDesc.getColumn().getAggregationType() == AggregateType.SUM) {
                 expr = new ArithmeticExpr(ArithmeticExpr.Operator.MULTIPLY, expr, new IntLiteral(-1));
                 expr.analyze(analyzer);

--- a/fe/src/test/java/org/apache/doris/catalog/ColumnTypeTest.java
+++ b/fe/src/test/java/org/apache/doris/catalog/ColumnTypeTest.java
@@ -95,7 +95,7 @@ public class ColumnTypeTest {
 
     @Test(expected = AnalysisException.class)
     public void testCharInvalid() throws AnalysisException {
-        TypeDef type = TypeDef.createVarchar(0);
+        TypeDef type = TypeDef.createVarchar(-1);
         type.analyze(null);
         Assert.fail("No Exception throws");
     }


### PR DESCRIPTION
For https://github.com/apache/incubator-doris/pull/1610, make bitmap_union support insert into select and broker load

1 Add a check for select * with bitmap_union
2 Define the bitmap_union column type to varchar(0), because the bitmap real length is variable, when insert into, the bitmap real length maybe larger than origin varchar length.


Test the following case:

1 
```
insert into bitmap_test_2 select id, id2 from bitmap_test_3;
```
2 
```
insert into bitmap_test_2 select id, to_bitmap(id2) from bitmap_int;
```
3
```
INSERT INTO bitmap_test_2 (id, id2) VALUES (1000, to_bitmap(1000)), (1000, to_bitmap(2000));
```