### PR TITLE
Use double when converting TIME type value 

### DIFF
--- a/be/src/exprs/time_operators.cpp
+++ b/be/src/exprs/time_operators.cpp
@@ -60,7 +60,7 @@ StringVal TimeOperators::cast_to_string_val(
     if (val.is_null) {
         return StringVal::null();
     }
-    return AnyValUtil::from_string_temp(ctx, time_str_from_int(val.val));
+    return AnyValUtil::from_string_temp(ctx, time_str_from_double(val.val));
 }
 
 DateTimeVal TimeOperators::cast_to_datetime_val(

--- a/be/src/runtime/datetime_value.h
+++ b/be/src/runtime/datetime_value.h
@@ -470,9 +470,6 @@ private:
         _hour = (hms >> 12);
         _neg = 0;
         _type = TIME_DATETIME;
-
-        LOG(INFO) << "from_packed_time: " << packed_time << ": " << _day << ", " << _month << "," << _year << ","
-            << _second << ", " << _minute << "," <<  _hour << ", " << _neg << ", " << _type;
     }
 
     int64_t make_packed_time(int64_t time, int64_t second_part) const {

--- a/be/src/runtime/datetime_value.h
+++ b/be/src/runtime/datetime_value.h
@@ -470,6 +470,9 @@ private:
         _hour = (hms >> 12);
         _neg = 0;
         _type = TIME_DATETIME;
+
+        LOG(INFO) << "from_packed_time: " << packed_time << ": " << _day << ", " << _month << "," << _year << ","
+            << _second << ", " << _minute << "," <<  _hour << ", " << _neg << ", " << _type;
     }
 
     int64_t make_packed_time(int64_t time, int64_t second_part) const {

--- a/be/src/runtime/memory_scratch_sink.cpp
+++ b/be/src/runtime/memory_scratch_sink.cpp
@@ -140,7 +140,7 @@ Status MemoryScratchSink::add_per_col(RuntimeState* state, TupleRow* row, std::s
                 break;
             case TYPE_TIME: {
                 double time = *static_cast<double *>(item);
-                std::string time_str = time_str_from_int((int64_t) time);
+                std::string time_str = time_str_from_double(time);
                 result->cols[i].__isset.string_vals = true;
                 result->cols[i].string_vals.push_back(std::move(time_str));
                 break;

--- a/be/src/runtime/memory_scratch_sink.cpp
+++ b/be/src/runtime/memory_scratch_sink.cpp
@@ -140,7 +140,7 @@ Status MemoryScratchSink::add_per_col(RuntimeState* state, TupleRow* row, std::s
                 break;
             case TYPE_TIME: {
                 double time = *static_cast<double *>(item);
-                std::string time_str = time_str_from_int((int) time);
+                std::string time_str = time_str_from_int((int64_t) time);
                 result->cols[i].__isset.string_vals = true;
                 result->cols[i].string_vals.push_back(std::move(time_str));
                 break;

--- a/be/src/runtime/result_writer.cpp
+++ b/be/src/runtime/result_writer.cpp
@@ -107,7 +107,7 @@ Status ResultWriter::add_one_row(TupleRow* row) {
 
         case TYPE_TIME: {
             double time = *static_cast<double *>(item);
-            std::string time_str = time_str_from_int((int) time);
+            std::string time_str = time_str_from_int((int64_t) time);
             buf_ret = _row_buffer->push_string(time_str.c_str(), time_str.size());
             break;
         }

--- a/be/src/runtime/result_writer.cpp
+++ b/be/src/runtime/result_writer.cpp
@@ -107,7 +107,7 @@ Status ResultWriter::add_one_row(TupleRow* row) {
 
         case TYPE_TIME: {
             double time = *static_cast<double *>(item);
-            std::string time_str = time_str_from_int((int64_t) time);
+            std::string time_str = time_str_from_double(time);
             buf_ret = _row_buffer->push_string(time_str.c_str(), time_str.size());
             break;
         }

--- a/be/src/util/date_func.cpp
+++ b/be/src/util/date_func.cpp
@@ -58,13 +58,13 @@ uint24_t timestamp_from_date(const std::string& date_str) {
     return uint24_t(value);
 }
 
-std::string time_str_from_int(int time) {
+std::string time_str_from_int(int64_t time) {
     std::stringstream time_ss;
     if (time < 0) {
         time_ss << "-";
         time = -time;
     }
-    int hour = time / 60 / 60;
+    int64_t hour = time / 60 / 60;
     int minute = time / 60 % 60;
     int second = time % 60;
     

--- a/be/src/util/date_func.cpp
+++ b/be/src/util/date_func.cpp
@@ -58,7 +58,7 @@ uint24_t timestamp_from_date(const std::string& date_str) {
     return uint24_t(value);
 }
 
-std::string time_str_from_int(int64_t time) {
+std::string time_str_from_double(double time) {
     std::stringstream time_ss;
     if (time < 0) {
         time_ss << "-";

--- a/be/src/util/date_func.cpp
+++ b/be/src/util/date_func.cpp
@@ -65,8 +65,8 @@ std::string time_str_from_double(double time) {
         time = -time;
     }
     int64_t hour = time / 60 / 60;
-    int minute = time / 60 % 60;
-    int second = time % 60;
+    int minute = ((int64_t)(time / 60)) % 60;
+    int second = ((int64_t) time) % 60;
     
     time_ss << std::setw(2) << std::setfill('0') << hour 
         << ":" << std::setw(2) << std::setfill('0') << minute 

--- a/be/src/util/date_func.h
+++ b/be/src/util/date_func.h
@@ -27,7 +27,7 @@ namespace doris {
 
 uint64_t timestamp_from_datetime(const std::string& datetime_str);
 uint24_t timestamp_from_date(const std::string& date_str);
-std::string time_str_from_int(int time);
+std::string time_str_from_int(int64_t time);
 
 }  // namespace doris
 

--- a/be/src/util/date_func.h
+++ b/be/src/util/date_func.h
@@ -27,7 +27,7 @@ namespace doris {
 
 uint64_t timestamp_from_datetime(const std::string& datetime_str);
 uint24_t timestamp_from_date(const std::string& date_str);
-std::string time_str_from_int(int64_t time);
+std::string time_str_from_double(double time);
 
 }  // namespace doris
 

--- a/docs/documentation/cn/sql-reference/sql-functions/date-time-functions/from_unixtime.md
+++ b/docs/documentation/cn/sql-reference/sql-functions/date-time-functions/from_unixtime.md
@@ -5,15 +5,22 @@
 `DATETIME FROM_UNIXTIME(INT unix_timestamp[, VARCHAR string_format])`
 
 
-将unix时间戳转化位对应的time格式，返回的格式由string_format指定
+将 unix 时间戳转化位对应的 time 格式，返回的格式由 `string_format` 指定
 
-默认为yyyy-MM-dd HH:mm:ss
+默认为 yyyy-MM-dd HH:mm:ss
 
 传入的是整形，返回的是字符串类型
 
-目前string_format只支持两种类型的格式：yyyy-MM-dd，yyyy-MM-dd HH:mm:ss
+目前 `string_format` 支持格式：
 
-其余string_format格式是非法的，返回NULL
+    %Y：年。例：2014，1900
+    %m：月。例：12，09
+    %d：日。例：11，01
+    %H：时。例：23，01，12
+    %i：分。例：05，11
+    %s：秒。例：59，01
+
+其余 `string_format` 格式是非法的，返回NULL
 
 如果给定的时间戳小于 0 或大于 253402271999，则返回 NULL。即时间戳范围是：
 
@@ -29,16 +36,16 @@ mysql> select from_unixtime(1196440219);
 | 2007-12-01 00:30:19       |
 +---------------------------+
 
-mysql> select from_unixtime(1196440219, 'yyyy-MM-dd');
+mysql> select from_unixtime(1196440219, '%Y-%m-%d');
 +-----------------------------------------+
-| from_unixtime(1196440219, 'yyyy-MM-dd') |
+| from_unixtime(1196440219, '%Y-%m-%d') |
 +-----------------------------------------+
 | 2007-12-01                              |
 +-----------------------------------------+
 
-mysql> select from_unixtime(1196440219, 'yyyy-MM-dd HH:mm:ss');
+mysql> select from_unixtime(1196440219, '%Y-%m-%d %H:%i:%s');
 +--------------------------------------------------+
-| from_unixtime(1196440219, 'yyyy-MM-dd HH:mm:ss') |
+| from_unixtime(1196440219, '%Y-%m-%d %H:%i:%s') |
 +--------------------------------------------------+
 | 2007-12-01 00:30:19                              |
 +--------------------------------------------------+

--- a/docs/documentation/en/sql-reference/sql-functions/date-time-functions/from_unixtime_EN.md
+++ b/docs/documentation/en/sql-reference/sql-functions/date-time-functions/from_unixtime_EN.md
@@ -1,21 +1,27 @@
-'35; from unixtime
-Description
-'35;'35;' 35; Syntax
+# from_unixtime
+## description
+### syntax
 
-'DATETIME FROM UNIXTIME (INT unix timestamp [, VARCHAR string format]'
+`DATETIME FROM UNIXTIME (INT unix timestamp [, VARCHAR string format]`
 
-
-Convert the UNIX timestamp to the corresponding time format of bits, and the format returned is specified by string_format
-
-Default yyyy-MM-dd HH:mm:ss
+Convert the UNIX timestamp to the corresponding time format of bits, and the format returned is specified by `string_format`
 
 Input is an integer and return is a string type
 
-Currently string_format supports only two types of formats: yyyy-MM-dd, yyyy-MM-dd HH: mm:ss.
+Currently, `string_format` supports following formats：
 
-The rest of the string_format format is illegal and returns NULL
+    %Y: Year. 	eg. 2014，1900
+    %m: Month. 	eg. 12，09
+    %d: Day.    eg. 11，01
+    %H: Hour.   eg. 23，01，12
+    %i: Minute. eg. 05，11
+    %s: Second. eg. 59，01
 
-'35;'35; example
+Default is `%Y-%m-%d %H:%i:%s`
+
+Other `string_format` is illegal and will returns NULL.
+
+## example
 
 ```
 mysql> select from_unixtime(1196440219);
@@ -25,18 +31,20 @@ mysql> select from_unixtime(1196440219);
 | 2007-12-01 00:30:19       |
 +---------------------------+
 
-mysql> select from_unixtime(1196440219, 'yyyy-MM-dd');
+mysql> select from_unixtime(1196440219, '%Y-%m-%d');
 +-----------------------------------------+
-| from_unixtime(1196440219, 'yyyy-MM-dd') |
+| from_unixtime(1196440219, '%Y-%m-%d')   |
 +-----------------------------------------+
 | 2007-12-01                              |
 +-----------------------------------------+
 
-mysql> select from_unixtime(1196440219, 'yyyy-MM-dd HH:mm:ss');
+mysql> select from_unixtime(1196440219, '%Y-%m-%d %H:%i:%s');
 +--------------------------------------------------+
-From unixtime (1196440219,'yyyy -MM -dd HH:mm:ss')
+|From unixtime (1196440219,'%Y-%m-%d %H:%i:%s')    |
 +--------------------------------------------------+
 | 2007-12-01 00:30:19                              |
 +--------------------------------------------------+
+
 ##keyword
-FROM_UNIXTIME,FROM,UNIXTIME
+
+    FROM_UNIXTIME,FROM,UNIXTIME

--- a/fe/src/main/java/org/apache/doris/analysis/DateLiteral.java
+++ b/fe/src/main/java/org/apache/doris/analysis/DateLiteral.java
@@ -398,13 +398,12 @@ public class DateLiteral extends LiteralExpr {
     //Return the date stored in the dateliteral as pattern format.
     //eg : "%Y-%m-%d" or "%Y-%m-%d %H:%i:%s"
     public String dateFormat(String pattern) throws AnalysisException {
-        DateTimeFormatterBuilder builder = new DateTimeFormatterBuilder();
         if (type == Type.DATE) {
             return DATE_FORMATTER.parseLocalDateTime(getStringValue())
-                .toString(formatBuilder(pattern).toFormatter());
+                    .toString(formatBuilder(pattern).toFormatter());
         } else {
             return DATE_TIME_FORMATTER.parseLocalDateTime(getStringValue())
-                .toString(formatBuilder(pattern).toFormatter());
+                    .toString(formatBuilder(pattern).toFormatter());
         }
     }
 

--- a/fe/src/main/java/org/apache/doris/qe/JournalObserver.java
+++ b/fe/src/main/java/org/apache/doris/qe/JournalObserver.java
@@ -85,6 +85,7 @@ public class JournalObserver implements Comparable<JournalObserver> {
             } while (leftTimeoutMs > 0);
 
             if (!ok) {
+                LOG.warn("timeout waiting result from master. timeout ms: {}", timeoutMs);
                 throw new DdlException("Execute timeout, the command may be succeed, you'd better retry");
             }
 

--- a/fe/src/test/java/org/apache/doris/rewrite/FEFunctionsTest.java
+++ b/fe/src/test/java/org/apache/doris/rewrite/FEFunctionsTest.java
@@ -17,6 +17,8 @@
 
 package org.apache.doris.rewrite;
 
+import static org.junit.Assert.fail;
+
 import org.apache.doris.analysis.DateLiteral;
 import org.apache.doris.analysis.DecimalLiteral;
 import org.apache.doris.analysis.FloatLiteral;
@@ -31,7 +33,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import static org.junit.Assert.fail;
+import java.util.Locale;
 
 /*
  * Author: Chenmingyu
@@ -123,7 +125,7 @@ public class FEFunctionsTest {
     @Test
     public void dateFormatUtilTest() {
         try {
-
+            Locale.setDefault(Locale.ENGLISH);
             DateLiteral testDate = new DateLiteral("2001-01-09 13:04:05", Type.DATETIME);
             Assert.assertEquals("Tue", FEFunctions.dateFormat(testDate, new StringLiteral("%a")).getStringValue());
             Assert.assertEquals("Jan", FEFunctions.dateFormat(testDate, new StringLiteral("%b")).getStringValue());
@@ -499,5 +501,15 @@ public class FEFunctionsTest {
         actualResult = FEFunctions.divideDecimalV2(new DecimalLiteral("-1.1"), new DecimalLiteral("-10.0"));
         expectedResult = new DecimalLiteral("0.11");
         Assert.assertEquals(expectedResult, actualResult);
+    }
+
+    @Test
+    public void timeDiffTest() throws AnalysisException {
+        DateLiteral d1 = new DateLiteral("1019-02-28 00:00:00", Type.DATETIME);
+        DateLiteral d2 = new DateLiteral("2019-02-28 00:00:00", Type.DATETIME);
+        DateLiteral d3 = new DateLiteral("2019-03-28 00:00:00", Type.DATETIME);
+        Assert.assertEquals(31556995543L, FEFunctions.timeDiff(d2, d1).getLongValue());
+        Assert.assertEquals(31559414743L, FEFunctions.timeDiff(d3, d1).getLongValue());
+        Assert.assertEquals(2419200, FEFunctions.timeDiff(d3, d2).getLongValue());
     }
 }


### PR DESCRIPTION
TIME type value is saved in DOUBLE, so just using double when converting to time string