### PR TITLE
Commit kafka offset in routine load

### DIFF
--- a/be/src/runtime/routine_load/data_consumer.cpp
+++ b/be/src/runtime/routine_load/data_consumer.cpp
@@ -304,6 +304,16 @@ Status KafkaDataConsumer::reset() {
     return Status::OK();
 }
 
+Status KafkaDataConsumer::commit(std::vector<RdKafka::TopicPartition*>& offset) {
+    RdKafka::ErrorCode err = _k_consumer->commitSync(offset);
+    if (err != RdKafka::ERR_NO_ERROR) {
+        std::stringstream ss;
+        ss << "failed to commit kafka offset : " << RdKafka::err2str(err);
+        return Status::InternalError(ss.str());                                   
+    }
+    return Status::OK();
+}
+
 // if the kafka brokers and topic are same,
 // we considered this consumer as matched, thus can be reused.
 bool KafkaDataConsumer::match(StreamLoadContext* ctx) {

--- a/be/src/runtime/routine_load/data_consumer.h
+++ b/be/src/runtime/routine_load/data_consumer.h
@@ -133,6 +133,8 @@ public:
     // reassign partition topics
     virtual Status reset() override;
     virtual bool match(StreamLoadContext* ctx) override;
+    // commit kafka offset
+    Status commit(std::vector<RdKafka::TopicPartition*>& offset);
 
     Status assign_topic_partitions(
             const std::map<int32_t, int64_t>& begin_partition_offset,

--- a/be/src/runtime/stream_load/stream_load_executor.cpp
+++ b/be/src/runtime/stream_load/stream_load_executor.cpp
@@ -277,7 +277,7 @@ bool StreamLoadExecutor::collect_load_stat(StreamLoadContext* ctx, TTxnCommitAtt
             rl_attach.loadSourceType = TLoadSourceType::KAFKA;
 
             TKafkaRLTaskProgress kafka_progress;
-            kafka_progress.partitionCmtOffset = std::move(ctx->kafka_info->cmt_offset);
+            kafka_progress.partitionCmtOffset = ctx->kafka_info->cmt_offset;
 
             rl_attach.kafkaRLTaskProgress = std::move(kafka_progress);
             rl_attach.__isset.kafkaRLTaskProgress = true;


### PR DESCRIPTION
Commit kafka offset in routine load

Kafka will decide whether to delete data based on whether all consumer group is commit offset or not. 
If there is no commit offset, the kafka server disk may be full