### PR TITLE
Unify the msg of 'Memory exceed limit'

### DIFF
--- a/be/src/exec/aggregation_node.cpp
+++ b/be/src/exec/aggregation_node.cpp
@@ -199,9 +199,7 @@ Status AggregationNode::open(RuntimeState* state) {
     while (true) {
         bool eos = false;
         RETURN_IF_CANCELLED(state);
-        std::stringstream msg;
-        msg << "Aggregation, before getting next from child 0.";
-        RETURN_IF_ERROR(state->check_query_state(msg.str()));
+        RETURN_IF_ERROR(state->check_query_state("Aggregation, before getting next from child 0."));
         RETURN_IF_ERROR(_children[0]->get_next(state, &batch, &eos));
         // SCOPED_TIMER(_build_timer);
         if (VLOG_ROW_IS_ON) {
@@ -229,10 +227,7 @@ Status AggregationNode::open(RuntimeState* state) {
         }
 
         // RETURN_IF_LIMIT_EXCEEDED(state);
-        msg.clear();
-        msg.str(std::string());
-        msg << "Aggregation, after hashing the child 0.";
-        RETURN_IF_ERROR(state->check_query_state(msg.str()));
+        RETURN_IF_ERROR(state->check_query_state("Aggregation, after hashing the child 0."));
 
         COUNTER_SET(_hash_table_buckets_counter, _hash_tbl->num_buckets());
         COUNTER_SET(memory_used_counter(),
@@ -243,10 +238,7 @@ Status AggregationNode::open(RuntimeState* state) {
 
         batch.reset();
 
-        msg.clear();
-        msg.str(std::string());
-        msg << "Aggregation, after setting the counter.";
-        RETURN_IF_ERROR(state->check_query_state(msg.str()));
+        RETURN_IF_ERROR(state->check_query_state("Aggregation, after setting the counter."));
         if (eos) {
             break;
         }
@@ -270,9 +262,7 @@ Status AggregationNode::get_next(RuntimeState* state, RowBatch* row_batch, bool*
     SCOPED_TIMER(_runtime_profile->total_time_counter());
     RETURN_IF_ERROR(exec_debug_action(TExecNodePhase::GETNEXT));
     RETURN_IF_CANCELLED(state);
-    std::stringstream msg;
-    msg << "Aggregation, before evaluating conjuncts.";
-    RETURN_IF_ERROR(state->check_query_state(msg.str()));
+    RETURN_IF_ERROR(state->check_query_state("Aggregation, before evaluating conjuncts."));
     SCOPED_TIMER(_get_results_timer);
 
     if (reached_limit()) {
@@ -290,10 +280,7 @@ Status AggregationNode::get_next(RuntimeState* state, RowBatch* row_batch, bool*
         // maintenance every N iterations.
         if (count++ % N == 0) {
             RETURN_IF_CANCELLED(state);
-            msg.clear();
-            msg.str(std::string());
-            msg << "Aggregation, while evaluating conjuncts.";
-            RETURN_IF_ERROR(state->check_query_state(msg.str()));
+            RETURN_IF_ERROR(state->check_query_state("Aggregation, while evaluating conjuncts."));
         }
         int row_idx = row_batch->add_row();
         TupleRow* row = row_batch->get_row(row_idx);

--- a/be/src/exec/cross_join_node.cpp
+++ b/be/src/exec/cross_join_node.cpp
@@ -66,9 +66,7 @@ Status CrossJoinNode::construct_build_side(RuntimeState* state) {
         RETURN_IF_ERROR(child(1)->get_next(state, batch, &eos));
 
         // to prevent use too many memory
-        std::stringstream msg;
-        msg << "Cross join, while getting next from the child 1.";
-        RETURN_IF_LIMIT_EXCEEDED(state, msg.str());
+        RETURN_IF_LIMIT_EXCEEDED(state, "Cross join, while getting next from the child 1.");
 
         SCOPED_TIMER(_build_timer);
         _build_batches.add_row_batch(batch);

--- a/be/src/exec/cross_join_node.cpp
+++ b/be/src/exec/cross_join_node.cpp
@@ -66,8 +66,9 @@ Status CrossJoinNode::construct_build_side(RuntimeState* state) {
         RETURN_IF_ERROR(child(1)->get_next(state, batch, &eos));
 
         // to prevent use too many memory
-        RETURN_IF_LIMIT_EXCEEDED(state, 
-                "Cross join was getting next from the child.");
+        std::stringstream msg;
+        msg << "Cross join, while getting next from the child 1.";
+        RETURN_IF_LIMIT_EXCEEDED(state, msg.str());
 
         SCOPED_TIMER(_build_timer);
         _build_batches.add_row_batch(batch);

--- a/be/src/exec/exchange_node.cpp
+++ b/be/src/exec/exchange_node.cpp
@@ -209,9 +209,7 @@ Status ExchangeNode::get_next(RuntimeState* state, RowBatch* output_batch, bool*
 Status ExchangeNode::get_next_merging(RuntimeState* state, RowBatch* output_batch, bool* eos) {
     DCHECK_EQ(output_batch->num_rows(), 0);
     RETURN_IF_CANCELLED(state);
-    std::stringstream msg;
-    msg << "Exchange, while merging next.";
-    RETURN_IF_ERROR(state->check_query_state(msg.str()));
+    RETURN_IF_ERROR(state->check_query_state("Exchange, while merging next."));
 
     RETURN_IF_ERROR(_stream_recvr->get_next(output_batch, eos));
     while ((_num_rows_skipped < _offset)) {

--- a/be/src/exec/exchange_node.cpp
+++ b/be/src/exec/exchange_node.cpp
@@ -151,8 +151,6 @@ Status ExchangeNode::get_next(RuntimeState* state, RowBatch* output_batch, bool*
         {
             SCOPED_TIMER(_convert_row_batch_timer);
             RETURN_IF_CANCELLED(state);
-            // RETURN_IF_ERROR(QueryMaintenance(state));
-            RETURN_IF_ERROR(state->check_query_state());
             // copy rows until we hit the limit/capacity or until we exhaust _input_batch
             while (!reached_limit() && !output_batch->at_capacity()
                     && _input_batch != NULL && _next_row_idx < _input_batch->capacity()) {
@@ -211,8 +209,9 @@ Status ExchangeNode::get_next(RuntimeState* state, RowBatch* output_batch, bool*
 Status ExchangeNode::get_next_merging(RuntimeState* state, RowBatch* output_batch, bool* eos) {
     DCHECK_EQ(output_batch->num_rows(), 0);
     RETURN_IF_CANCELLED(state);
-    // RETURN_IF_ERROR(QueryMaintenance(state));
-    RETURN_IF_ERROR(state->check_query_state());
+    std::stringstream msg;
+    msg << "Exchange, while merging next.";
+    RETURN_IF_ERROR(state->check_query_state(msg.str()));
 
     RETURN_IF_ERROR(_stream_recvr->get_next(output_batch, eos));
     while ((_num_rows_skipped < _offset)) {

--- a/be/src/exec/exec_node.cpp
+++ b/be/src/exec/exec_node.cpp
@@ -724,7 +724,7 @@ Status ExecNode::enable_deny_reservation_debug_action() {
 }
 */
 
-Status ExecNode::QueryMaintenance(RuntimeState* state, std::string* msg) {
+Status ExecNode::QueryMaintenance(RuntimeState* state, const char* msg) {
   // TODO chenhao , when introduce latest AnalyticEvalNode open it
   // ScalarExprEvaluator::FreeLocalAllocations(evals_to_free_);
   return state->check_query_state(*msg);

--- a/be/src/exec/exec_node.cpp
+++ b/be/src/exec/exec_node.cpp
@@ -724,10 +724,10 @@ Status ExecNode::enable_deny_reservation_debug_action() {
 }
 */
 
-Status ExecNode::QueryMaintenance(RuntimeState* state, const char* msg) {
+Status ExecNode::QueryMaintenance(RuntimeState* state, const std::string& msg) {
   // TODO chenhao , when introduce latest AnalyticEvalNode open it
   // ScalarExprEvaluator::FreeLocalAllocations(evals_to_free_);
-  return state->check_query_state(*msg);
+  return state->check_query_state(msg);
 }
 
 }

--- a/be/src/exec/exec_node.cpp
+++ b/be/src/exec/exec_node.cpp
@@ -724,10 +724,10 @@ Status ExecNode::enable_deny_reservation_debug_action() {
 }
 */
 
-Status ExecNode::QueryMaintenance(RuntimeState* state) {
+Status ExecNode::QueryMaintenance(RuntimeState* state, std::string* msg) {
   // TODO chenhao , when introduce latest AnalyticEvalNode open it
   // ScalarExprEvaluator::FreeLocalAllocations(evals_to_free_);
-  return state->check_query_state();
+  return state->check_query_state(*msg);
 }
 
 }

--- a/be/src/exec/exec_node.h
+++ b/be/src/exec/exec_node.h
@@ -388,7 +388,7 @@ protected:
     /// Nodes may override this to add extra periodic cleanup, e.g. freeing other local
     /// allocations. ExecNodes overriding this function should return
     /// ExecNode::QueryMaintenance().
-    virtual Status QueryMaintenance(RuntimeState* state, const char* msg) WARN_UNUSED_RESULT;
+    virtual Status QueryMaintenance(RuntimeState* state, const std::string& msg) WARN_UNUSED_RESULT;
 
 private:
     bool _is_closed;

--- a/be/src/exec/exec_node.h
+++ b/be/src/exec/exec_node.h
@@ -388,7 +388,7 @@ protected:
     /// Nodes may override this to add extra periodic cleanup, e.g. freeing other local
     /// allocations. ExecNodes overriding this function should return
     /// ExecNode::QueryMaintenance().
-    virtual Status QueryMaintenance(RuntimeState* state, std::string* msg) WARN_UNUSED_RESULT;
+    virtual Status QueryMaintenance(RuntimeState* state, const char* msg) WARN_UNUSED_RESULT;
 
 private:
     bool _is_closed;

--- a/be/src/exec/hash_join_node.cpp
+++ b/be/src/exec/hash_join_node.cpp
@@ -232,8 +232,9 @@ Status HashJoinNode::construct_hash_table(RuntimeState* state) {
         SCOPED_TIMER(_build_timer);
         // take ownership of tuple data of build_batch
         _build_pool->acquire_data(build_batch.tuple_data_pool(), false);
-        RETURN_IF_LIMIT_EXCEEDED(state, 
-                "Hash join was constructing the hash table.");
+        std::stringstream msg;
+        msg << "Hash join, while constructing the hash table.";
+        RETURN_IF_LIMIT_EXCEEDED(state, msg.str());
 
         // Call codegen version if possible
         if (_process_build_batch_fn == NULL) {

--- a/be/src/exec/hash_join_node.cpp
+++ b/be/src/exec/hash_join_node.cpp
@@ -232,9 +232,7 @@ Status HashJoinNode::construct_hash_table(RuntimeState* state) {
         SCOPED_TIMER(_build_timer);
         // take ownership of tuple data of build_batch
         _build_pool->acquire_data(build_batch.tuple_data_pool(), false);
-        std::stringstream msg;
-        msg << "Hash join, while constructing the hash table.";
-        RETURN_IF_LIMIT_EXCEEDED(state, msg.str());
+        RETURN_IF_LIMIT_EXCEEDED(state, "Hash join, while constructing the hash table.");
 
         // Call codegen version if possible
         if (_process_build_batch_fn == NULL) {

--- a/be/src/exec/new_partitioned_aggregation_node.cc
+++ b/be/src/exec/new_partitioned_aggregation_node.cc
@@ -305,8 +305,8 @@ Status NewPartitionedAggregationNode::open(RuntimeState* state) {
   bool eos = false;
   do {
     RETURN_IF_CANCELLED(state);
-    RETURN_IF_ERROR(state->check_query_state("New partitioned aggregation, "
-                                             + "while getting next from child 0."));
+    RETURN_IF_ERROR(state->check_query_state(
+            "New partitioned aggregation, while getting next from child 0."));
     RETURN_IF_ERROR(_children[0]->get_next(state, &batch, &eos));
     if (UNLIKELY(VLOG_ROW_IS_ON)) {
       for (int i = 0; i < batch.num_rows(); ++i) {
@@ -487,8 +487,8 @@ Status NewPartitionedAggregationNode::GetRowsFromPartition(RuntimeState* state,
     // maintenance every N iterations.
     if ((count++ & (N - 1)) == 0) {
       RETURN_IF_CANCELLED(state);
-      RETURN_IF_ERROR(state->check_query_state("New partitioned aggregation, "
-                                               + "while getting rows from partition."));
+      RETURN_IF_ERROR(state->check_query_state(
+            "New partitioned aggregation, while getting rows from partition."));
     }
 
     int row_idx = row_batch->add_row();
@@ -529,8 +529,8 @@ Status NewPartitionedAggregationNode::GetRowsStreaming(RuntimeState* state,
   do {
     DCHECK_EQ(out_batch->num_rows(), 0);
     RETURN_IF_CANCELLED(state);
-    RETURN_IF_ERROR(state->check_query_state("New partitioned aggregation, "
-                                             + "while getting rows in streaming."));
+    RETURN_IF_ERROR(state->check_query_state(
+            "New partitioned aggregation, while getting rows in streaming."));
 
     RETURN_IF_ERROR(child(0)->get_next(state, child_batch_.get(), &child_eos_));
     SCOPED_TIMER(streaming_timer_);

--- a/be/src/exec/new_partitioned_aggregation_node.cc
+++ b/be/src/exec/new_partitioned_aggregation_node.cc
@@ -305,9 +305,8 @@ Status NewPartitionedAggregationNode::open(RuntimeState* state) {
   bool eos = false;
   do {
     RETURN_IF_CANCELLED(state);
-    std::stringstream msg;
-    msg << "New partitioned aggregation, while getting next from child 0.";
-    RETURN_IF_ERROR(state->check_query_state(msg.str()));
+    RETURN_IF_ERROR(state->check_query_state("New partitioned aggregation, "
+                                             + "while getting next from child 0."));
     RETURN_IF_ERROR(_children[0]->get_next(state, &batch, &eos));
     if (UNLIKELY(VLOG_ROW_IS_ON)) {
       for (int i = 0; i < batch.num_rows(); ++i) {
@@ -409,9 +408,7 @@ Status NewPartitionedAggregationNode::GetNextInternal(RuntimeState* state,
   SCOPED_TIMER(_runtime_profile->total_time_counter());
   RETURN_IF_ERROR(exec_debug_action(TExecNodePhase::GETNEXT));
   RETURN_IF_CANCELLED(state);
-  std::stringstream msg;
-  msg << "New partitioned aggregation, while getting next.";
-  RETURN_IF_ERROR(state->check_query_state(msg.str()));
+  RETURN_IF_ERROR(state->check_query_state("New partitioned aggregation, while getting next."));
   // clear tmp expr result alocations
   expr_results_pool_->clear();
 
@@ -490,9 +487,8 @@ Status NewPartitionedAggregationNode::GetRowsFromPartition(RuntimeState* state,
     // maintenance every N iterations.
     if ((count++ & (N - 1)) == 0) {
       RETURN_IF_CANCELLED(state);
-      std::stringstream msg;
-      msg << "New partitioned aggregation, while getting rows from partition.";
-      RETURN_IF_ERROR(state->check_query_state(msg.str()));
+      RETURN_IF_ERROR(state->check_query_state("New partitioned aggregation, "
+                                               + "while getting rows from partition."));
     }
 
     int row_idx = row_batch->add_row();
@@ -533,9 +529,8 @@ Status NewPartitionedAggregationNode::GetRowsStreaming(RuntimeState* state,
   do {
     DCHECK_EQ(out_batch->num_rows(), 0);
     RETURN_IF_CANCELLED(state);
-    std::stringstream msg;
-    msg << "New partitioned aggregation, while getting rows in streaming.";
-    RETURN_IF_ERROR(state->check_query_state(msg.str()));
+    RETURN_IF_ERROR(state->check_query_state("New partitioned aggregation, "
+                                             + "while getting rows in streaming."));
 
     RETURN_IF_ERROR(child(0)->get_next(state, child_batch_.get(), &child_eos_));
     SCOPED_TIMER(streaming_timer_);
@@ -1357,9 +1352,7 @@ Status NewPartitionedAggregationNode::ProcessStream(BufferedTupleStream3* input_
       RETURN_IF_ERROR(input_stream->GetNext(&batch, &eos));
       RETURN_IF_ERROR(
           ProcessBatch<AGGREGATED_ROWS>(&batch, ht_ctx_.get()));
-      std::stringstream msg;
-      msg << "New partitioned aggregation, while processing stream.";
-      RETURN_IF_ERROR(state_->check_query_state(msg.str()));
+      RETURN_IF_ERROR(state_->check_query_state("New partitioned aggregation, while processing stream."));
       batch.reset();
     } while (!eos);
   }

--- a/be/src/exec/new_partitioned_hash_table.cc
+++ b/be/src/exec/new_partitioned_hash_table.cc
@@ -23,6 +23,7 @@
 
 #include "codegen/codegen_anyval.h"
 #include "codegen/llvm_codegen.h"
+#include "exec/exec_node.h"
 #include "exprs/expr.h"
 #include "exprs/expr_context.h"
 #include "exprs/slot_ref.h"
@@ -118,7 +119,7 @@ Status NewPartitionedHashTableCtx::Init(ObjectPool* pool, RuntimeState* state, i
   int scratch_row_size = sizeof(Tuple*) * num_build_tuples;
   scratch_row_ = reinterpret_cast<TupleRow*>(malloc(scratch_row_size));
   if (UNLIKELY(scratch_row_ == NULL)) {
-    return Status::InternalError(Substitute("Failed to allocate $0 bytes for scratch row of "
+      return Status::InternalError(Substitute("Failed to allocate $0 bytes for scratch row of "
         "NewPartitionedHashTableCtx.", scratch_row_size));
   }
 

--- a/be/src/exec/partitioned_aggregation_node.cc
+++ b/be/src/exec/partitioned_aggregation_node.cc
@@ -232,9 +232,7 @@ Status PartitionedAggregationNode::open(RuntimeState* state) {
     bool eos = false;
     do {
         RETURN_IF_CANCELLED(state);
-        std::stringstream msg;
-        msg << "Partitioned aggregation, while getting next from child 0.";
-        RETURN_IF_ERROR(state->check_query_state(msg.str()));
+        RETURN_IF_ERROR(state->check_query_state("Partitioned aggregation, while getting next from child 0."));
         RETURN_IF_ERROR(_children[0]->get_next(state, &batch, &eos));
 
         if (UNLIKELY(VLOG_ROW_IS_ON)) {
@@ -278,9 +276,7 @@ Status PartitionedAggregationNode::get_next(RuntimeState* state, RowBatch* row_b
     SCOPED_TIMER(_runtime_profile->total_time_counter());
     RETURN_IF_ERROR(exec_debug_action(TExecNodePhase::GETNEXT));
     RETURN_IF_CANCELLED(state);
-    std::stringstream msg;
-    msg << "Partitioned aggregation, before evaluating conjuncts.";
-    RETURN_IF_ERROR(state->check_query_state(msg.str()));
+    RETURN_IF_ERROR(state->check_query_state("Partitioned aggregation, before evaluating conjuncts."));
 
     if (reached_limit()) {
         *eos = true;
@@ -337,10 +333,7 @@ Status PartitionedAggregationNode::get_next(RuntimeState* state, RowBatch* row_b
         // maintenance every N iterations.
         if ((count++ & (N - 1)) == 0) {
             RETURN_IF_CANCELLED(state);
-            msg.clear();
-            msg.str(std::string());
-            msg << "Partitioned aggregation, while evaluating conjuncts.";
-            RETURN_IF_ERROR(state->check_query_state(msg.str()));
+            RETURN_IF_ERROR(state->check_query_state("Partitioned aggregation, while evaluating conjuncts."));
         }
 
         int row_idx = row_batch->add_row();

--- a/be/src/exec/sort_node.cpp
+++ b/be/src/exec/sort_node.cpp
@@ -146,8 +146,9 @@ Status SortNode::sort_input(RuntimeState* state) {
         RETURN_IF_ERROR(child(0)->get_next(state, &batch, &eos));
         RETURN_IF_ERROR(_sorter->add_batch(&batch));
         RETURN_IF_CANCELLED(state);
-        RETURN_IF_LIMIT_EXCEEDED(state, 
-                "Sort node was getting next from the child.");
+        std::stringstream msg;
+        msg << "Sort, while getting next from the child.";
+        RETURN_IF_LIMIT_EXCEEDED(state, msg.str());
         // RETURN_IF_ERROR(QueryMaintenance(state));
     } while (!eos);
     RETURN_IF_ERROR(_sorter->input_done());

--- a/be/src/exec/sort_node.cpp
+++ b/be/src/exec/sort_node.cpp
@@ -146,9 +146,7 @@ Status SortNode::sort_input(RuntimeState* state) {
         RETURN_IF_ERROR(child(0)->get_next(state, &batch, &eos));
         RETURN_IF_ERROR(_sorter->add_batch(&batch));
         RETURN_IF_CANCELLED(state);
-        std::stringstream msg;
-        msg << "Sort, while getting next from the child.";
-        RETURN_IF_LIMIT_EXCEEDED(state, msg.str());
+        RETURN_IF_LIMIT_EXCEEDED(state, "Sort, while getting next from the child.");
         // RETURN_IF_ERROR(QueryMaintenance(state));
     } while (!eos);
     RETURN_IF_ERROR(_sorter->input_done());

--- a/be/src/exec/spill_sort_node.cc
+++ b/be/src/exec/spill_sort_node.cc
@@ -56,9 +56,7 @@ Status SpillSortNode::open(RuntimeState* state) {
     RETURN_IF_ERROR(ExecNode::open(state));
     RETURN_IF_ERROR(_sort_exec_exprs.open(state));
     RETURN_IF_CANCELLED(state);
-    std::stringstream msg;
-    msg << "Spill sort, while open.";
-    RETURN_IF_ERROR(state->check_query_state(msg.str()));
+    RETURN_IF_ERROR(state->check_query_state("Spill sort, while open."));
     RETURN_IF_ERROR(child(0)->open(state));
 
     // These objects must be created after opening the _sort_exec_exprs. Avoid creating
@@ -89,9 +87,7 @@ Status SpillSortNode::get_next(RuntimeState* state, RowBatch* row_batch, bool* e
     // RETURN_IF_ERROR(exec_debug_action(TExecNodePhase::GETNEXT, state));
     RETURN_IF_ERROR(exec_debug_action(TExecNodePhase::GETNEXT));
     RETURN_IF_CANCELLED(state);
-    std::stringstream msg;
-    msg << "Spill sort, while getting next.";
-    RETURN_IF_ERROR(state->check_query_state(msg.str()));
+    RETURN_IF_ERROR(state->check_query_state("Spill sort, while getting next."));
 
     if (reached_limit()) {
         *eos = true;
@@ -168,9 +164,7 @@ Status SpillSortNode::sort_input(RuntimeState* state) {
         RETURN_IF_ERROR(child(0)->get_next(state, &batch, &eos));
         RETURN_IF_ERROR(_sorter->add_batch(&batch));
         RETURN_IF_CANCELLED(state);
-        std::stringstream msg;
-        msg << "Spill sort, while sorting input.";
-        RETURN_IF_ERROR(state->check_query_state(msg.str()));
+        RETURN_IF_ERROR(state->check_query_state("Spill sort, while sorting input."));
     } while (!eos);
 
     RETURN_IF_ERROR(_sorter->input_done());

--- a/be/src/exec/spill_sort_node.cc
+++ b/be/src/exec/spill_sort_node.cc
@@ -56,8 +56,9 @@ Status SpillSortNode::open(RuntimeState* state) {
     RETURN_IF_ERROR(ExecNode::open(state));
     RETURN_IF_ERROR(_sort_exec_exprs.open(state));
     RETURN_IF_CANCELLED(state);
-    // RETURN_IF_ERROR(QueryMaintenance(state));
-    RETURN_IF_ERROR(state->check_query_state());
+    std::stringstream msg;
+    msg << "Spill sort, while open.";
+    RETURN_IF_ERROR(state->check_query_state(msg.str()));
     RETURN_IF_ERROR(child(0)->open(state));
 
     // These objects must be created after opening the _sort_exec_exprs. Avoid creating
@@ -88,8 +89,9 @@ Status SpillSortNode::get_next(RuntimeState* state, RowBatch* row_batch, bool* e
     // RETURN_IF_ERROR(exec_debug_action(TExecNodePhase::GETNEXT, state));
     RETURN_IF_ERROR(exec_debug_action(TExecNodePhase::GETNEXT));
     RETURN_IF_CANCELLED(state);
-    // RETURN_IF_ERROR(QueryMaintenance(state));
-    RETURN_IF_ERROR(state->check_query_state());
+    std::stringstream msg;
+    msg << "Spill sort, while getting next.";
+    RETURN_IF_ERROR(state->check_query_state(msg.str()));
 
     if (reached_limit()) {
         *eos = true;
@@ -166,8 +168,9 @@ Status SpillSortNode::sort_input(RuntimeState* state) {
         RETURN_IF_ERROR(child(0)->get_next(state, &batch, &eos));
         RETURN_IF_ERROR(_sorter->add_batch(&batch));
         RETURN_IF_CANCELLED(state);
-        // RETURN_IF_ERROR(QueryMaintenance(state));
-        RETURN_IF_ERROR(state->check_query_state());
+        std::stringstream msg;
+        msg << "Spill sort, while sorting input.";
+        RETURN_IF_ERROR(state->check_query_state(msg.str()));
     } while (!eos);
 
     RETURN_IF_ERROR(_sorter->input_done());

--- a/be/src/exec/topn_node.cpp
+++ b/be/src/exec/topn_node.cpp
@@ -87,9 +87,7 @@ Status TopNNode::open(RuntimeState* state) {
     SCOPED_TIMER(_runtime_profile->total_time_counter());
     RETURN_IF_ERROR(ExecNode::open(state));
     RETURN_IF_CANCELLED(state);
-    std::stringstream msg;
-    msg << "Top n, before open.";
-    RETURN_IF_ERROR(state->check_query_state(msg.str()));
+    RETURN_IF_ERROR(state->check_query_state("Top n, before open."));
     RETURN_IF_ERROR(_sort_exec_exprs.open(state));
 
     // Avoid creating them after every Reset()/Open().
@@ -123,10 +121,7 @@ Status TopNNode::open(RuntimeState* state) {
                 insert_tuple_row(batch.get_row(i));
             }
             RETURN_IF_CANCELLED(state);
-            msg.clear();
-            msg.str(std::string());
-            msg << "Top n, while getting next from child 0.";
-            RETURN_IF_ERROR(state->check_query_state(msg.str()));
+            RETURN_IF_ERROR(state->check_query_state("Top n, while getting next from child 0."));
         } while (!eos);
     }
 
@@ -145,9 +140,7 @@ Status TopNNode::get_next(RuntimeState* state, RowBatch* row_batch, bool* eos) {
     SCOPED_TIMER(_runtime_profile->total_time_counter());
     RETURN_IF_ERROR(exec_debug_action(TExecNodePhase::GETNEXT));
     RETURN_IF_CANCELLED(state);
-    std::stringstream msg;
-    msg << "Top n, before moving result to row_batch.";
-    RETURN_IF_ERROR(state->check_query_state(msg.str()));
+    RETURN_IF_ERROR(state->check_query_state("Top n, before moving result to row_batch."));
 
     while (!row_batch->at_capacity() && (_get_next_iter != _sorted_top_n.end())) {
         if (_num_rows_skipped < _offset) {

--- a/be/src/exec/topn_node.cpp
+++ b/be/src/exec/topn_node.cpp
@@ -87,8 +87,9 @@ Status TopNNode::open(RuntimeState* state) {
     SCOPED_TIMER(_runtime_profile->total_time_counter());
     RETURN_IF_ERROR(ExecNode::open(state));
     RETURN_IF_CANCELLED(state);
-    // RETURN_IF_ERROR(QueryMaintenance(state));
-    RETURN_IF_ERROR(state->check_query_state());
+    std::stringstream msg;
+    msg << "Top n, before open.";
+    RETURN_IF_ERROR(state->check_query_state(msg.str()));
     RETURN_IF_ERROR(_sort_exec_exprs.open(state));
 
     // Avoid creating them after every Reset()/Open().
@@ -122,8 +123,10 @@ Status TopNNode::open(RuntimeState* state) {
                 insert_tuple_row(batch.get_row(i));
             }
             RETURN_IF_CANCELLED(state);
-            // RETURN_IF_LIMIT_EXCEEDED(state);
-            RETURN_IF_ERROR(state->check_query_state());
+            msg.clear();
+            msg.str(std::string());
+            msg << "Top n, while getting next from child 0.";
+            RETURN_IF_ERROR(state->check_query_state(msg.str()));
         } while (!eos);
     }
 
@@ -142,8 +145,9 @@ Status TopNNode::get_next(RuntimeState* state, RowBatch* row_batch, bool* eos) {
     SCOPED_TIMER(_runtime_profile->total_time_counter());
     RETURN_IF_ERROR(exec_debug_action(TExecNodePhase::GETNEXT));
     RETURN_IF_CANCELLED(state);
-    // RETURN_IF_ERROR(QueryMaintenance(state));
-    RETURN_IF_ERROR(state->check_query_state());
+    std::stringstream msg;
+    msg << "Top n, before moving result to row_batch.";
+    RETURN_IF_ERROR(state->check_query_state(msg.str()));
 
     while (!row_batch->at_capacity() && (_get_next_iter != _sorted_top_n.end())) {
         if (_num_rows_skipped < _offset) {

--- a/be/src/runtime/buffered_block_mgr.cpp
+++ b/be/src/runtime/buffered_block_mgr.cpp
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#include "exec/exec_node.h"
 #include "runtime/buffered_block_mgr.h"
 #include "runtime/runtime_state.h"
 #include "runtime/mem_pool.h"
@@ -76,9 +77,9 @@ Status BufferedBlockMgr::get_new_block(Block** block, int64_t len) {
     new_block->_buffer_desc->block = new_block;
     *block = new_block;
 
-    if (UNLIKELY(_state->instance_mem_tracker()->any_limit_exceeded())) {
-        return Status::MemoryLimitExceeded("Memory limit exceeded");
-    }
+    std::stringstream msg;
+    msg << "Buffered block mgr, while getting new block";
+    RETURN_IF_LIMIT_EXCEEDED(_state, msg.str());
 
     return Status::OK();
 }

--- a/be/src/runtime/buffered_block_mgr.cpp
+++ b/be/src/runtime/buffered_block_mgr.cpp
@@ -77,9 +77,7 @@ Status BufferedBlockMgr::get_new_block(Block** block, int64_t len) {
     new_block->_buffer_desc->block = new_block;
     *block = new_block;
 
-    std::stringstream msg;
-    msg << "Buffered block mgr, while getting new block";
-    RETURN_IF_LIMIT_EXCEEDED(_state, msg.str());
+    RETURN_IF_LIMIT_EXCEEDED(_state, "Buffered block mgr, while getting new block");
 
     return Status::OK();
 }

--- a/be/src/runtime/mem_tracker.cpp
+++ b/be/src/runtime/mem_tracker.cpp
@@ -24,6 +24,7 @@
 //#include <boost/shared_ptr.hpp>
 //include <boost/weak_ptr.hpp>
 
+#include "exec/exec_node.h"
 #include "gutil/strings/substitute.h"
 #include "runtime/exec_env.h"
 #include "runtime/runtime_state.h"
@@ -320,9 +321,7 @@ Status MemTracker::MemLimitExceeded(RuntimeState* state, const std::string& deta
     // }
     // ss << tracker_to_log->LogUsage();
     // Status status = Status::MemLimitExceeded(ss.str());
-    Status status = Status::MemoryLimitExceeded("Memory limit exceeded");
-    if (state != nullptr) state->log_error(status.get_error_msg());
-    return status;
+    LIMIT_EXCEEDED(this, state, ss.str());
 }
 
 void MemTracker::AddGcFunction(GcFunction f) {

--- a/be/src/runtime/plan_fragment_executor.cpp
+++ b/be/src/runtime/plan_fragment_executor.cpp
@@ -514,7 +514,7 @@ void PlanFragmentExecutor::update_status(const Status& status) {
 
         if (_status.ok()) {
             if (status.is_mem_limit_exceeded()) {
-                _runtime_state->set_mem_limit_exceeded();
+                _runtime_state->set_mem_limit_exceeded(status.get_error_msg());
             }
             _status = status;
         }

--- a/be/src/runtime/runtime_state.cpp
+++ b/be/src/runtime/runtime_state.cpp
@@ -397,7 +397,7 @@ Status RuntimeState::set_mem_limit_exceeded(
     return _process_status;
 }
 
-Status RuntimeState::check_query_state(const char* msg) {
+Status RuntimeState::check_query_state(const std::string& msg) {
     // TODO: it would be nice if this also checked for cancellation, but doing so breaks
     // cases where we use Status::Cancelled("Cancelled") to indicate that the limit was reached.
     RETURN_IF_LIMIT_EXCEEDED(this, msg);

--- a/be/src/runtime/runtime_state.cpp
+++ b/be/src/runtime/runtime_state.cpp
@@ -397,7 +397,7 @@ Status RuntimeState::set_mem_limit_exceeded(
     return _process_status;
 }
 
-Status RuntimeState::check_query_state(const std::string& msg) {
+Status RuntimeState::check_query_state(const char* msg) {
     // TODO: it would be nice if this also checked for cancellation, but doing so breaks
     // cases where we use Status::Cancelled("Cancelled") to indicate that the limit was reached.
     RETURN_IF_LIMIT_EXCEEDED(this, msg);

--- a/be/src/runtime/runtime_state.cpp
+++ b/be/src/runtime/runtime_state.cpp
@@ -25,6 +25,7 @@
 #include "codegen/llvm_codegen.h"
 #include "common/object_pool.h"
 #include "common/status.h"
+#include "exec/exec_node.h"
 #include "exprs/expr.h"
 #include "exprs/timezone_db.h"
 #include "runtime/buffered_block_mgr.h"
@@ -396,12 +397,10 @@ Status RuntimeState::set_mem_limit_exceeded(
     return _process_status;
 }
 
-Status RuntimeState::check_query_state() {
+Status RuntimeState::check_query_state(const std::string& msg) {
     // TODO: it would be nice if this also checked for cancellation, but doing so breaks
     // cases where we use Status::Cancelled("Cancelled") to indicate that the limit was reached.
-    if (_instance_mem_tracker->any_limit_exceeded()) {
-        return set_mem_limit_exceeded();
-    }
+    RETURN_IF_LIMIT_EXCEEDED(this, msg);
     return query_status();
 }
 

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -334,7 +334,7 @@ public:
     // Returns a non-OK status if query execution should stop (e.g., the query was cancelled
     // or a mem limit was exceeded). Exec nodes should check this periodically so execution
     // doesn't continue if the query terminates abnormally.
-    Status check_query_state(const std::string& msg);
+    Status check_query_state(const char* msg);
 
     std::vector<std::string>& output_files() {
         return _output_files;

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -334,7 +334,7 @@ public:
     // Returns a non-OK status if query execution should stop (e.g., the query was cancelled
     // or a mem limit was exceeded). Exec nodes should check this periodically so execution
     // doesn't continue if the query terminates abnormally.
-    Status check_query_state();
+    Status check_query_state(const std::string& msg);
 
     std::vector<std::string>& output_files() {
         return _output_files;

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -334,7 +334,7 @@ public:
     // Returns a non-OK status if query execution should stop (e.g., the query was cancelled
     // or a mem limit was exceeded). Exec nodes should check this periodically so execution
     // doesn't continue if the query terminates abnormally.
-    Status check_query_state(const char* msg);
+    Status check_query_state(const std::string& msg);
 
     std::vector<std::string>& output_files() {
         return _output_files;


### PR DESCRIPTION
The new msg of limit exceed: "Memory exceed limit. %msg, Backend:%ip, fragment:%id Used:% , Limit:%. xxx".
This commit unifies the msg of 'Memory exceed limit' such as check_query_state, RETURN_IF_LIMIT_EXCEEDED and LIMIT_EXCEEDED.