### PR TITLE
use RowsetFactory to create and init RowsetWriter

### DIFF
--- a/be/src/olap/CMakeLists.txt
+++ b/be/src/olap/CMakeLists.txt
@@ -94,7 +94,6 @@ add_library(Olap STATIC
     rowset/segment_v2/segment_iterator.cpp
     rowset/segment_v2/segment_writer.cpp
     rowset/segment_v2/column_zone_map.cpp
-    rowset_factory.cpp
     task/engine_batch_load_task.cpp
     task/engine_checksum_task.cpp
     task/engine_clear_alter_task.cpp

--- a/be/src/olap/compaction.cpp
+++ b/be/src/olap/compaction.cpp
@@ -84,10 +84,8 @@ OLAPStatus Compaction::do_compaction() {
 }
 
 OLAPStatus Compaction::construct_output_rowset_writer() {
-    RowsetId rowset_id;
-    RETURN_NOT_OK(StorageEngine::instance()->next_rowset_id(&rowset_id));
     RowsetWriterContext context;
-    context.rowset_id = rowset_id;
+    context.rowset_id = StorageEngine::instance()->next_rowset_id();
     context.tablet_uid = _tablet->tablet_uid();
     context.tablet_id = _tablet->tablet_id();
     context.partition_id = _tablet->partition_id();

--- a/be/src/olap/compaction.cpp
+++ b/be/src/olap/compaction.cpp
@@ -15,7 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#include "gutil/strings/substitute.h"
 #include "olap/compaction.h"
+#include "olap/rowset/rowset_factory.h"
 
 using std::vector;
 
@@ -46,10 +48,9 @@ OLAPStatus Compaction::do_compaction() {
     RETURN_NOT_OK(construct_output_rowset_writer());
     RETURN_NOT_OK(construct_input_rowset_readers());
 
-    Merger merger(_tablet, compaction_type(), _output_rs_writer, _input_rs_readers);
-    OLAPStatus res = merger.merge();
-
-    // 2. 如果merge失败，执行清理工作，返回错误码退出
+    // 2. write merged rows to output rowset
+    Merger::Statistics stats;
+    auto res = Merger::merge_rowsets(_tablet, compaction_type(), _input_rs_readers, _output_rs_writer.get(), &stats);
     if (res != OLAP_SUCCESS) {
         LOG(WARNING) << "fail to do " << compaction_name()
                      << ". res=" << res
@@ -68,7 +69,7 @@ OLAPStatus Compaction::do_compaction() {
     }
 
     // 3. check correctness
-    RETURN_NOT_OK(check_correctness(merger));
+    RETURN_NOT_OK(check_correctness(stats));
 
     // 4. modify rowsets in memory
     RETURN_NOT_OK(modify_rowsets());
@@ -91,16 +92,14 @@ OLAPStatus Compaction::construct_output_rowset_writer() {
     context.tablet_id = _tablet->tablet_id();
     context.partition_id = _tablet->partition_id();
     context.tablet_schema_hash = _tablet->schema_hash();
-    context.rowset_type = ALPHA_ROWSET;
+    context.rowset_type = DEFAULT_ROWSET_TYPE;
     context.rowset_path_prefix = _tablet->tablet_path();
     context.tablet_schema = &(_tablet->tablet_schema());
     context.rowset_state = VISIBLE;
     context.data_dir = _tablet->data_dir();
     context.version = _output_version;
     context.version_hash = _output_version_hash;
-
-    _output_rs_writer.reset(new (std::nothrow)AlphaRowsetWriter());
-    RETURN_NOT_OK(_output_rs_writer->init(context));
+    RETURN_NOT_OK(RowsetFactory::create_rowset_writer(context, &_output_rs_writer));
     return OLAP_SUCCESS;
 }
 
@@ -169,13 +168,13 @@ OLAPStatus Compaction::check_version_continuity(const vector<RowsetSharedPtr>& r
     return OLAP_SUCCESS;
 }
 
-OLAPStatus Compaction::check_correctness(const Merger& merger) {
+OLAPStatus Compaction::check_correctness(const Merger::Statistics& stats) {
     // 1. check row number
-    if (_input_row_num != _output_rowset->num_rows() + merger.merged_rows() + merger.filted_rows()) {
+    if (_input_row_num != _output_rowset->num_rows() + stats.merged_rows + stats.filtered_rows) {
         LOG(FATAL) << "row_num does not match between cumulative input and output! "
                    << "input_row_num=" << _input_row_num
-                   << ", merged_row_num=" << merger.merged_rows()
-                   << ", filted_row_num=" << merger.filted_rows()
+                   << ", merged_row_num=" << stats.merged_rows
+                   << ", filted_row_num=" << stats.filtered_rows
                    << ", output_row_num=" << _output_rowset->num_rows();
         return OLAP_ERR_CHECK_LINES_ERROR;
     }

--- a/be/src/olap/compaction.h
+++ b/be/src/olap/compaction.h
@@ -27,7 +27,6 @@
 #include "olap/tablet.h"
 #include "olap/tablet_meta.h"
 #include "olap/utils.h"
-#include "rowset/alpha_rowset_writer.h"
 #include "rowset/rowset_id_generator.h"
 
 namespace doris {
@@ -62,7 +61,7 @@ protected:
     OLAPStatus construct_input_rowset_readers();
 
     OLAPStatus check_version_continuity(const std::vector<RowsetSharedPtr>& rowsets);
-    OLAPStatus check_correctness(const Merger& merger);
+    OLAPStatus check_correctness(const Merger::Statistics& stats);
 
 protected:
     TabletSharedPtr _tablet;
@@ -73,7 +72,7 @@ protected:
     int64_t _input_row_num;
 
     RowsetSharedPtr _output_rowset;
-    RowsetWriterSharedPtr _output_rs_writer;
+    std::unique_ptr<RowsetWriter> _output_rs_writer;
 
     enum CompactionState {
         INITED = 0,

--- a/be/src/olap/data_dir.cpp
+++ b/be/src/olap/data_dir.cpp
@@ -48,7 +48,7 @@
 #include "olap/rowset/rowset_meta_manager.h"
 #include "olap/rowset/alpha_rowset_meta.h"
 #include "olap/rowset/alpha_rowset.h"
-#include "olap/rowset_factory.h"
+#include "olap/rowset/rowset_factory.h"
 
 namespace doris {
 
@@ -794,10 +794,10 @@ OLAPStatus DataDir::load() {
             continue;
         }
         RowsetSharedPtr rowset;
-        OLAPStatus create_status = RowsetFactory::load_rowset(tablet->tablet_schema(), 
-                                                             tablet->tablet_path(), 
-                                                             tablet->data_dir(), 
-                                                             rowset_meta, &rowset);
+        OLAPStatus create_status = RowsetFactory::create_rowset(&tablet->tablet_schema(),
+                                                              tablet->tablet_path(),
+                                                              tablet->data_dir(),
+                                                              rowset_meta, &rowset);
         if (create_status != OLAP_SUCCESS) {
             LOG(WARNING) << "could not create rowset from rowsetmeta: "
                          << " rowset_id: " << rowset_meta->rowset_id()

--- a/be/src/olap/delta_writer.cpp
+++ b/be/src/olap/delta_writer.cpp
@@ -115,14 +115,8 @@ OLAPStatus DeltaWriter::init() {
         }
     }
 
-    RowsetId rowset_id; // get rowset_id from id generator
-    OLAPStatus status = StorageEngine::instance()->next_rowset_id(&rowset_id);
-    if (status != OLAP_SUCCESS) {
-        LOG(WARNING) << "generate rowset id failed, status:" << status;
-        return OLAP_ERR_ROWSET_GENERATE_ID_FAILED;
-    }
     RowsetWriterContext writer_context;
-    writer_context.rowset_id = rowset_id;
+    writer_context.rowset_id = StorageEngine::instance()->next_rowset_id();
     writer_context.tablet_uid = _tablet->tablet_uid();
     writer_context.tablet_id = _req.tablet_id;
     writer_context.partition_id = _req.partition_id;

--- a/be/src/olap/delta_writer.cpp
+++ b/be/src/olap/delta_writer.cpp
@@ -20,7 +20,7 @@
 #include "olap/schema.h"
 #include "olap/memtable.h"
 #include "olap/data_dir.h"
-#include "olap/rowset/alpha_rowset_writer.h"
+#include "olap/rowset/rowset_factory.h"
 #include "olap/rowset/rowset_meta_manager.h"
 #include "olap/rowset/rowset_id_generator.h"
 
@@ -127,17 +127,14 @@ OLAPStatus DeltaWriter::init() {
     writer_context.tablet_id = _req.tablet_id;
     writer_context.partition_id = _req.partition_id;
     writer_context.tablet_schema_hash = _req.schema_hash;
-    writer_context.rowset_type = ALPHA_ROWSET;
+    writer_context.rowset_type = DEFAULT_ROWSET_TYPE;
     writer_context.rowset_path_prefix = _tablet->tablet_path();
     writer_context.tablet_schema = &(_tablet->tablet_schema());
     writer_context.rowset_state = PREPARED;
     writer_context.data_dir = _tablet->data_dir();
     writer_context.txn_id = _req.txn_id;
     writer_context.load_id = _req.load_id;
-
-    // TODO: new RowsetBuilder according to tablet storage type
-    _rowset_writer.reset(new AlphaRowsetWriter());
-    RETURN_NOT_OK(_rowset_writer->init(writer_context));
+    RETURN_NOT_OK(RowsetFactory::create_rowset_writer(writer_context, &_rowset_writer));
 
     const std::vector<SlotDescriptor*>& slots = _req.tuple_desc->slots();
     const TabletSchema& schema = _tablet->tablet_schema();
@@ -167,7 +164,7 @@ OLAPStatus DeltaWriter::write(Tuple* tuple) {
 
     _mem_table->insert(tuple);
     if (_mem_table->memory_usage() >= config::write_buffer_size) {
-        RETURN_NOT_OK(_mem_table->flush(_rowset_writer));
+        RETURN_NOT_OK(_mem_table->flush(_rowset_writer.get()));
 
         SAFE_DELETE(_mem_table);
         _mem_table = new MemTable(_schema, _tablet_schema, &_col_ids,
@@ -183,7 +180,7 @@ OLAPStatus DeltaWriter::close(google::protobuf::RepeatedPtrField<PTabletInfo>* t
             return st;
         }
     }
-    RETURN_NOT_OK(_mem_table->close(_rowset_writer));
+    RETURN_NOT_OK(_mem_table->close(_rowset_writer.get()));
 
     OLAPStatus res = OLAP_SUCCESS;
     // use rowset meta manager to save meta

--- a/be/src/olap/delta_writer.h
+++ b/be/src/olap/delta_writer.h
@@ -72,7 +72,7 @@ private:
     RowsetSharedPtr _cur_rowset;
     RowsetSharedPtr _new_rowset;
     TabletSharedPtr _new_tablet;
-    RowsetWriterSharedPtr _rowset_writer;
+    std::unique_ptr<RowsetWriter> _rowset_writer;
     MemTable* _mem_table;
     Schema* _schema;
     const TabletSchema* _tablet_schema;

--- a/be/src/olap/memtable.cpp
+++ b/be/src/olap/memtable.cpp
@@ -87,7 +87,7 @@ void MemTable::insert(Tuple* tuple) {
     }
 }
 
-OLAPStatus MemTable::flush(RowsetWriterSharedPtr rowset_writer) {
+OLAPStatus MemTable::flush(RowsetWriter* rowset_writer) {
     int64_t duration_ns = 0;
     {
         SCOPED_RAW_TIMER(&duration_ns);
@@ -105,7 +105,7 @@ OLAPStatus MemTable::flush(RowsetWriterSharedPtr rowset_writer) {
     return OLAP_SUCCESS;
 }
 
-OLAPStatus MemTable::close(RowsetWriterSharedPtr rowset_writer) {
+OLAPStatus MemTable::close(RowsetWriter* rowset_writer) {
     return flush(rowset_writer);
 }
 

--- a/be/src/olap/memtable.h
+++ b/be/src/olap/memtable.h
@@ -37,8 +37,8 @@ public:
     ~MemTable();
     size_t memory_usage();
     void insert(Tuple* tuple);
-    OLAPStatus flush(RowsetWriterSharedPtr rowset_writer);
-    OLAPStatus close(RowsetWriterSharedPtr rowset_writer);
+    OLAPStatus flush(RowsetWriter* rowset_writer);
+    OLAPStatus close(RowsetWriter* rowset_writer);
 private:
     Schema* _schema;
     const TabletSchema* _tablet_schema;

--- a/be/src/olap/merger.cpp
+++ b/be/src/olap/merger.cpp
@@ -21,109 +21,11 @@
 #include <vector>
 
 #include "olap/olap_define.h"
-#include "olap/rowset/segment_group.h"
 #include "olap/tablet.h"
 #include "olap/reader.h"
 #include "olap/row_cursor.h"
 
-using std::list;
-using std::string;
-using std::unique_ptr;
-using std::vector;
-
 namespace doris {
-
-Merger::Merger(TabletSharedPtr tablet, RowsetWriterSharedPtr writer, ReaderType type) :
-        _tablet(tablet),
-        _output_rs_writer(writer),
-        _reader_type(type),
-        _row_count(0) {}
-
-Merger::Merger(TabletSharedPtr tablet, ReaderType type, RowsetWriterSharedPtr writer,
-               const std::vector<RowsetReaderSharedPtr>& rs_readers) :
-        _tablet(tablet),
-        _output_rs_writer(writer),
-        _input_rs_readers(rs_readers),
-        _reader_type(type),
-        _row_count(0) {}
-
-OLAPStatus Merger::merge(const vector<RowsetReaderSharedPtr>& rs_readers,
-                         int64_t* merged_rows, int64_t* filted_rows) {
-    _input_rs_readers = rs_readers;
-    OLAPStatus res = merge();
-    if (res == OLAP_SUCCESS) {
-        *merged_rows= _merged_rows;
-        *filted_rows = _filted_rows;
-    }
-    return res;
-}
-
-OLAPStatus Merger::merge() {
-    // Create and initiate reader for scanning and multi-merging specified
-    // OLAPDatas.
-    Reader reader;
-    ReaderParams reader_params;
-    reader_params.tablet = _tablet;
-    reader_params.reader_type = _reader_type;
-    reader_params.rs_readers = _input_rs_readers;
-    reader_params.version = _output_rs_writer->version();
-
-    if (OLAP_SUCCESS != reader.init(reader_params)) {
-        LOG(WARNING) << "fail to initiate reader. tablet=" << _tablet->full_name();
-        return OLAP_ERR_INIT_FAILED;
-    }
-
-    bool has_error = false;
-    RowCursor row_cursor;
-
-    if (OLAP_SUCCESS != row_cursor.init(_tablet->tablet_schema())) {
-        LOG(WARNING) << "fail to init row cursor.";
-        has_error = true;
-    }
-
-    std::unique_ptr<Arena> arena(new Arena());
-    bool eof = false;
-    row_cursor.allocate_memory_for_string_type(_tablet->tablet_schema());
-    // The following procedure would last for long time, half of one day, etc.
-    while (!has_error) {
-        // Read one row into row_cursor
-        OLAPStatus res = reader.next_row_with_aggregation(&row_cursor, arena.get(), &eof);
-        if (OLAP_SUCCESS == res && eof) {
-            VLOG(3) << "reader read to the end.";
-            break;
-        } else if (OLAP_SUCCESS != res) {
-            LOG(WARNING) << "reader read failed.";
-            has_error = true;
-            break;
-        }
-
-        if (OLAP_SUCCESS != _output_rs_writer->add_row(row_cursor)) {
-            LOG(WARNING) << "add row to builder failed. tablet=" << _tablet->full_name();
-            has_error = true;
-            break;
-        }
-
-        // the memory allocate by arena has been copied,
-        // so we should release these memory immediately
-        arena.reset(new Arena());
-
-        // Goto next row position in the row block being written
-        ++_row_count;
-    }
-
-    if (_output_rs_writer->flush() != OLAP_SUCCESS) {
-        LOG(WARNING) << "fail to finalize writer. "
-                     << "tablet=" << _tablet->full_name();
-        has_error = true;
-    }
-
-    if (!has_error) {
-        _merged_rows = reader.merged_rows();
-        _filted_rows = reader.filtered_rows();
-    }
-
-    return has_error ? OLAP_ERR_OTHER_ERROR : OLAP_SUCCESS;
-}
 
 OLAPStatus Merger::merge_rowsets(TabletSharedPtr tablet,
                                  ReaderType reader_type,

--- a/be/src/olap/merger.cpp
+++ b/be/src/olap/merger.cpp
@@ -124,4 +124,50 @@ OLAPStatus Merger::merge() {
 
     return has_error ? OLAP_ERR_OTHER_ERROR : OLAP_SUCCESS;
 }
+
+OLAPStatus Merger::merge_rowsets(TabletSharedPtr tablet,
+                                 ReaderType reader_type,
+                                 const std::vector<RowsetReaderSharedPtr>& src_rowset_readers,
+                                 RowsetWriter* dst_rowset_writer,
+                                 Merger::Statistics* stats_output) {
+    Reader reader;
+    ReaderParams reader_params;
+    reader_params.tablet = std::move(tablet);
+    reader_params.reader_type = reader_type;
+    reader_params.rs_readers = src_rowset_readers;
+    reader_params.version = dst_rowset_writer->version();
+    RETURN_NOT_OK(reader.init(reader_params));
+
+    RowCursor row_cursor;
+    RETURN_NOT_OK_LOG(row_cursor.init(tablet->tablet_schema()),
+                 "failed to init row cursor when merging rowsets of tablet " + tablet->full_name());
+    row_cursor.allocate_memory_for_string_type(tablet->tablet_schema());
+
+    // The following procedure would last for long time, half of one day, etc.
+    int64_t output_rows = 0;
+    while (true) {
+        Arena arena;
+        bool eof = false;
+        // Read one row into row_cursor
+        RETURN_NOT_OK_LOG(reader.next_row_with_aggregation(&row_cursor, &arena, &eof),
+                          "failed to read next row when merging rowsets of tablet " + tablet->full_name());
+        if (eof) {
+            break;
+        }
+        RETURN_NOT_OK_LOG(dst_rowset_writer->add_row(row_cursor),
+                          "failed to write row when merging rowsets of tablet " + tablet->full_name());
+        output_rows++;
+    }
+
+    if (stats_output != nullptr) {
+        stats_output->output_rows = output_rows;
+        stats_output->merged_rows = reader.merged_rows();
+        stats_output->filtered_rows = reader.filtered_rows();
+    }
+
+    RETURN_NOT_OK_LOG(dst_rowset_writer->flush(),
+                 "failed to flush rowset when merging rowsets of tablet " + tablet->full_name());
+    return OLAP_SUCCESS;
+}
+
 }  // namespace doris

--- a/be/src/olap/merger.cpp
+++ b/be/src/olap/merger.cpp
@@ -34,7 +34,7 @@ OLAPStatus Merger::merge_rowsets(TabletSharedPtr tablet,
                                  Merger::Statistics* stats_output) {
     Reader reader;
     ReaderParams reader_params;
-    reader_params.tablet = std::move(tablet);
+    reader_params.tablet = tablet;
     reader_params.reader_type = reader_type;
     reader_params.rs_readers = src_rowset_readers;
     reader_params.version = dst_rowset_writer->version();

--- a/be/src/olap/olap_snapshot_converter.cpp
+++ b/be/src/olap/olap_snapshot_converter.cpp
@@ -122,8 +122,7 @@ OLAPStatus OlapSnapshotConverter::to_tablet_meta_pb(const OLAPHeaderMessage& ola
 
     std::unordered_map<Version, RowsetMetaPB*, HashOfVersion> _rs_version_map;
     for (auto& delta : olap_header.delta()) {
-        RowsetId next_id;
-        RETURN_NOT_OK(StorageEngine::instance()->next_rowset_id(&next_id));
+        RowsetId next_id = StorageEngine::instance()->next_rowset_id();
         RowsetMetaPB* rowset_meta = tablet_meta_pb->add_rs_metas();
         convert_to_rowset_meta(delta, next_id, olap_header.tablet_id(), olap_header.schema_hash(), rowset_meta);
         Version rowset_version = { delta.start_version(), delta.end_version() };
@@ -139,15 +138,13 @@ OLAPStatus OlapSnapshotConverter::to_tablet_meta_pb(const OLAPHeaderMessage& ola
             *rowset_meta = *(exist_rs->second);
             continue;
         }
-        RowsetId next_id;
-        RETURN_NOT_OK(StorageEngine::instance()->next_rowset_id(&next_id));
+        RowsetId next_id = StorageEngine::instance()->next_rowset_id();
         RowsetMetaPB* rowset_meta = tablet_meta_pb->add_inc_rs_metas();
         convert_to_rowset_meta(inc_delta, next_id, olap_header.tablet_id(), olap_header.schema_hash(), rowset_meta);
     }
 
     for (auto& pending_delta : olap_header.pending_delta()) {
-        RowsetId next_id;
-        RETURN_NOT_OK(StorageEngine::instance()->next_rowset_id(&next_id));
+        RowsetId next_id = StorageEngine::instance()->next_rowset_id();
         RowsetMetaPB rowset_meta;
         convert_to_rowset_meta(pending_delta, next_id, olap_header.tablet_id(), olap_header.schema_hash(), &rowset_meta);
         pending_rowsets->emplace_back(std::move(rowset_meta));

--- a/be/src/olap/push_handler.cpp
+++ b/be/src/olap/push_handler.cpp
@@ -23,7 +23,7 @@
 
 #include <boost/filesystem.hpp>
 
-#include "olap/rowset/alpha_rowset_writer.h"
+#include "olap/rowset/rowset_factory.h"
 #include "olap/rowset/rowset_id_generator.h"
 #include "olap/rowset/rowset_meta_manager.h"
 #include "olap/schema_change.h"
@@ -263,12 +263,6 @@ OLAPStatus PushHandler::_convert(TabletSharedPtr cur_tablet,
     RowCursor row;
     BinaryFile raw_file;
     IBinaryReader* reader = NULL;
-    RowsetWriterSharedPtr rowset_writer(new AlphaRowsetWriter());
-    if (rowset_writer == nullptr) {
-        LOG(WARNING) << "new rowset writer failed.";
-        return OLAP_ERR_MALLOC_ERROR;
-    }
-    RowsetWriterContext context;
     uint32_t num_rows = 0;
     RowsetId rowset_id;
     RETURN_NOT_OK(StorageEngine::instance()->next_rowset_id(&rowset_id));
@@ -331,14 +325,22 @@ OLAPStatus PushHandler::_convert(TabletSharedPtr cur_tablet,
         context.tablet_id = cur_tablet->tablet_id();
         context.partition_id = _request.partition_id;
         context.tablet_schema_hash = cur_tablet->schema_hash();
-        context.rowset_type = ALPHA_ROWSET;
+        context.rowset_type = DEFAULT_ROWSET_TYPE;
         context.rowset_path_prefix = cur_tablet->tablet_path();
         context.tablet_schema = &(cur_tablet->tablet_schema());
         context.rowset_state = PREPARED;
         context.data_dir = cur_tablet->data_dir();
         context.txn_id = _request.transaction_id;
         context.load_id = load_id;
-        rowset_writer->init(context);
+
+        std::unique_ptr<RowsetWriter> rowset_writer;
+        res = RowsetFactory::create_rowset_writer(context, &rowset_writer);
+        if (OLAP_SUCCESS != res) {
+            LOG(WARNING) << "failed to init rowset writer, tablet=" << cur_tablet->full_name()
+                         << ", txn_id=" << _request.transaction_id
+                         << ", res=" << res;
+            break;
+        }
 
         // 3. New RowsetBuilder to write data into rowset
         VLOG(3) << "init rowset builder. tablet=" << cur_tablet->full_name()

--- a/be/src/olap/push_handler.cpp
+++ b/be/src/olap/push_handler.cpp
@@ -264,8 +264,6 @@ OLAPStatus PushHandler::_convert(TabletSharedPtr cur_tablet,
     BinaryFile raw_file;
     IBinaryReader* reader = NULL;
     uint32_t num_rows = 0;
-    RowsetId rowset_id;
-    RETURN_NOT_OK(StorageEngine::instance()->next_rowset_id(&rowset_id));
     PUniqueId load_id;
     load_id.set_hi(0);
     load_id.set_lo(0);
@@ -320,7 +318,7 @@ OLAPStatus PushHandler::_convert(TabletSharedPtr cur_tablet,
         // 2. init RowsetBuilder of cur_tablet for current push
         VLOG(3) << "init RowsetBuilder.";
         RowsetWriterContext context;
-        context.rowset_id = rowset_id;
+        context.rowset_id = StorageEngine::instance()->next_rowset_id();
         context.tablet_uid = cur_tablet->tablet_uid();
         context.tablet_id = cur_tablet->tablet_id();
         context.partition_id = _request.partition_id;

--- a/be/src/olap/reader.h
+++ b/be/src/olap/reader.h
@@ -122,6 +122,9 @@ public:
     void close();
 
     // Reader next row with aggregation.
+    // Return OLAP_SUCCESS and set `*eof` to false when next row is read into `row_cursor`.
+    // Return OLAP_SUCCESS and set `*eof` to true when no more rows can be read.
+    // Return others when unexpected error happens.
     OLAPStatus next_row_with_aggregation(RowCursor *row_cursor, Arena* arena, bool *eof) {
         return (this->*_next_row_func)(row_cursor, arena, eof);
     }

--- a/be/src/olap/rowset/CMakeLists.txt
+++ b/be/src/olap/rowset/CMakeLists.txt
@@ -37,6 +37,7 @@ add_library(Rowset STATIC
     segment_reader.cpp
     segment_writer.cpp
     rowset.cpp
+    rowset_factory.cpp
     rowset_meta_manager.cpp
     alpha_rowset.cpp
     alpha_rowset_reader.cpp

--- a/be/src/olap/rowset/rowset.h
+++ b/be/src/olap/rowset/rowset.h
@@ -32,6 +32,9 @@ using RowsetSharedPtr = std::shared_ptr<Rowset>;
 class RowsetReader;
 class TabletSchema;
 
+// TODO(gaodayue) change to BETA_ROWSET when we're going to release segment v2
+const RowsetTypePB DEFAULT_ROWSET_TYPE = ALPHA_ROWSET;
+
 class Rowset : public std::enable_shared_from_this<Rowset> {
 public:
     // TODO don't make this public, all clients should use RowsetFactory to obtain initialized RowsetSharedPtr

--- a/be/src/olap/rowset/rowset_factory.cpp
+++ b/be/src/olap/rowset/rowset_factory.cpp
@@ -15,24 +15,45 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include "olap/rowset_factory.h"
+#include <memory>
+#include "olap/rowset/rowset_factory.h"
 #include "gen_cpp/olap_file.pb.h"
 #include "olap/rowset/alpha_rowset.h"
+#include "olap/rowset/alpha_rowset_writer.h"
+#include "beta_rowset.h"
+#include "olap/rowset/beta_rowset_writer.h"
+#include "olap/rowset/rowset_writer.h"
 
 namespace doris {
 
-OLAPStatus RowsetFactory::load_rowset(const TabletSchema& schema,
+OLAPStatus RowsetFactory::create_rowset(const TabletSchema* schema,
                                       const std::string& rowset_path,
                                       DataDir* data_dir,
                                       RowsetMetaSharedPtr rowset_meta, 
                                       RowsetSharedPtr* rowset) {
 
-    if (rowset_meta->rowset_type() == RowsetTypePB::ALPHA_ROWSET) {
-        rowset->reset(new AlphaRowset(&schema, rowset_path, data_dir, rowset_meta));
+    if (rowset_meta->rowset_type() == ALPHA_ROWSET) {
+        rowset->reset(new AlphaRowset(schema, rowset_path, data_dir, rowset_meta));
         return (*rowset)->init();
-    } else {
-        return OLAP_ERR_ROWSET_TYPE_NOT_FOUND;
     }
+    if (rowset_meta->rowset_type() == BETA_ROWSET)  {
+        rowset->reset(new BetaRowset(schema, rowset_path, data_dir, rowset_meta));
+        return (*rowset)->init();
+    }
+    return OLAP_ERR_ROWSET_TYPE_NOT_FOUND; // should never happen
+}
+
+OLAPStatus RowsetFactory::create_rowset_writer(const RowsetWriterContext& context,
+                                               std::unique_ptr<RowsetWriter>* output) {
+    if (context.rowset_type == ALPHA_ROWSET) {
+        output->reset(new AlphaRowsetWriter);
+        return (*output)->init(context);
+    }
+    if (context.rowset_type == BETA_ROWSET) {
+        output->reset(new BetaRowsetWriter);
+        return (*output)->init(context);
+    }
+    return OLAP_ERR_ROWSET_TYPE_NOT_FOUND;
 }
 
 } // namespace doris

--- a/be/src/olap/rowset/rowset_factory.h
+++ b/be/src/olap/rowset/rowset_factory.h
@@ -20,17 +20,29 @@
 
 #include "gen_cpp/olap_file.pb.h"
 #include "olap/data_dir.h"
+#include "olap/rowset/rowset.h"
 
 namespace doris {
+
+class RowsetWriter;
+class RowsetWriterContext;
 
 class RowsetFactory {
 
 public:
-    static OLAPStatus load_rowset(const TabletSchema& schema,
+    // return OLAP_SUCCESS and set inited rowset in `*rowset`.
+    // return others if failed to create or init rowset.
+    static OLAPStatus create_rowset(const TabletSchema* schema,
                                   const std::string& rowset_path,
                                   DataDir* data_dir,
                                   RowsetMetaSharedPtr rowset_meta,
                                   RowsetSharedPtr* rowset);
+
+    // create and init rowset writer.
+    // return OLAP_SUCCESS and set `*output` to inited rowset writer.
+    // return others if failed
+    static OLAPStatus create_rowset_writer(const RowsetWriterContext& context,
+                                           std::unique_ptr<RowsetWriter>* output);
 };
 
 } // namespace doris

--- a/be/src/olap/rowset/rowset_id_generator.h
+++ b/be/src/olap/rowset/rowset_id_generator.h
@@ -26,17 +26,16 @@ namespace doris {
 
 class OlapMeta;
 
+// all implementations must be thread-safe
 class RowsetIdGenerator {
 public:    
     RowsetIdGenerator() {}
     virtual ~RowsetIdGenerator() {}
 
-    // generator a id according to data dir
-    // rowsetid is not globally unique, it is dir level
-    // it saves the batch end id into meta env
-    virtual OLAPStatus next_id(RowsetId* rowset_id) = 0;
+    // generate and return the next global unique rowset id
+    virtual RowsetId next_id() = 0;
 
-    // check whether the rowset id is userful or validate
+    // check whether the rowset id is useful or validate
     // for example, during gc logic, gc thread finds a file
     // and it could not find it under rowset list. but it maybe in use
     // during load procedure. Gc thread will check it using this method.

--- a/be/src/olap/rowset/rowset_writer.h
+++ b/be/src/olap/rowset/rowset_writer.h
@@ -35,7 +35,6 @@ class RowsetWriter {
 public:
     RowsetWriter() = default;
     virtual ~RowsetWriter() = default;
-    DISALLOW_COPY_AND_ASSIGN(RowsetWriter);
 
     virtual OLAPStatus init(const RowsetWriterContext& rowset_writer_context) = 0;
 
@@ -44,10 +43,15 @@ public:
     virtual OLAPStatus add_row(const RowCursor& row) = 0;
     virtual OLAPStatus add_row(const ContiguousRow& row) = 0;
 
+    // Precondition: the input `rowset` should have the same type of the rowset we're building
     virtual OLAPStatus add_rowset(RowsetSharedPtr rowset) = 0;
+
+    // Precondition: the input `rowset` should have the same type of the rowset we're building
     virtual OLAPStatus add_rowset_for_linked_schema_change(
                 RowsetSharedPtr rowset, const SchemaMapping& schema_mapping) = 0;
 
+    // explicit flush all buffered rows into segment file.
+    // note that `add_row` could also trigger flush when certain conditions are met
     virtual OLAPStatus flush() = 0;
 
     // get a rowset
@@ -60,6 +64,9 @@ public:
     virtual RowsetId rowset_id() = 0;
 
     virtual DataDir* data_dir() = 0;
+
+private:
+    DISALLOW_COPY_AND_ASSIGN(RowsetWriter);
 };
 
 } // namespace doris

--- a/be/src/olap/rowset/rowset_writer.h
+++ b/be/src/olap/rowset/rowset_writer.h
@@ -29,7 +29,6 @@ namespace doris {
 class ContiguousRow;
 class RowCursor;
 class RowsetWriter;
-using RowsetWriterSharedPtr = std::shared_ptr<RowsetWriter>;
 
 class RowsetWriter {
 public:

--- a/be/src/olap/rowset/unique_rowset_id_generator.cpp
+++ b/be/src/olap/rowset/unique_rowset_id_generator.cpp
@@ -26,11 +26,12 @@ UniqueRowsetIdGenerator::UniqueRowsetIdGenerator(const UniqueId& backend_uid) :
 }
 
 // generate a unique rowset id and save it in a set to check whether it is valid in the future
-OLAPStatus UniqueRowsetIdGenerator::next_id(RowsetId* rowset_id) {
+RowsetId UniqueRowsetIdGenerator::next_id() {
     std::lock_guard<SpinLock> l(_lock);
-    rowset_id->init(_version, ++_inc_id, _backend_uid.hi, _backend_uid.lo);
-    _valid_rowset_ids.insert(*rowset_id);
-    return OLAP_SUCCESS;
+    RowsetId rowset_id;
+    rowset_id.init(_version, ++_inc_id, _backend_uid.hi, _backend_uid.lo);
+    _valid_rowset_ids.insert(rowset_id);
+    return rowset_id;
 }
 
 bool UniqueRowsetIdGenerator::id_in_use(const RowsetId& rowset_id) {

--- a/be/src/olap/rowset/unique_rowset_id_generator.h
+++ b/be/src/olap/rowset/unique_rowset_id_generator.h
@@ -28,10 +28,7 @@ public:
     UniqueRowsetIdGenerator(const UniqueId& backend_uid);
     ~UniqueRowsetIdGenerator() {}
 
-    // generator a id according to data dir
-    // rowsetid is not globally unique, it is dir level
-    // it saves the batch end id into meta env
-    OLAPStatus next_id(RowsetId* rowset_id) override; 
+    RowsetId next_id() override;
 
     bool id_in_use(const RowsetId& rowset_id) override;
 

--- a/be/src/olap/schema_change.cpp
+++ b/be/src/olap/schema_change.cpp
@@ -995,6 +995,7 @@ bool SchemaChangeWithSorting::process(
                                Version(_temp_delta_versions.second, _temp_delta_versions.second),
                                rowset_reader->version_hash(),
                                new_tablet,
+                               rowset_reader->rowset()->rowset_meta()->rowset_type(),
                                &rowset)) {
             LOG(WARNING) << "failed to sorting internally.";
             result = false;

--- a/be/src/olap/schema_change.cpp
+++ b/be/src/olap/schema_change.cpp
@@ -30,8 +30,8 @@
 #include "olap/row_cursor.h"
 #include "olap/wrapper_field.h"
 #include "olap/row.h"
+#include "olap/rowset/rowset_factory.h"
 #include "olap/rowset/rowset_id_generator.h"
-#include "olap/rowset/alpha_rowset_writer.h"
 #include "runtime/mem_pool.h"
 #include "runtime/mem_tracker.h"
 #include "common/resource_tls.h"
@@ -70,7 +70,7 @@ public:
 
     bool merge(
             const std::vector<RowBlock*>& row_block_arr,
-            RowsetWriterSharedPtr rowset_writer,
+            RowsetWriter* rowset_writer,
             uint64_t* merged_rows);
 
 private:
@@ -564,7 +564,7 @@ RowBlockMerger::~RowBlockMerger() {}
 
 bool RowBlockMerger::merge(
         const vector<RowBlock*>& row_block_arr,
-        RowsetWriterSharedPtr rowset_writer,
+        RowsetWriter* rowset_writer,
         uint64_t* merged_rows) {
     uint64_t tmp_merged_rows = 0;
     RowCursor row_cursor;
@@ -664,7 +664,7 @@ bool RowBlockMerger::_pop_heap() {
 
 bool LinkedSchemaChange::process(
         RowsetReaderSharedPtr rowset_reader,
-        RowsetWriterSharedPtr new_rowset_writer,
+        RowsetWriter* new_rowset_writer,
         TabletSharedPtr new_tablet,
         TabletSharedPtr base_tablet) {
     OLAPStatus status = new_rowset_writer->add_rowset_for_linked_schema_change(
@@ -705,7 +705,7 @@ bool SchemaChangeDirectly::_write_row_block(RowsetWriter* rowset_writer, RowBloc
     return true;
 }
 
-bool SchemaChangeDirectly::process(RowsetReaderSharedPtr rowset_reader, RowsetWriterSharedPtr rowset_writer,
+bool SchemaChangeDirectly::process(RowsetReaderSharedPtr rowset_reader, RowsetWriter* rowset_writer,
         TabletSharedPtr new_tablet,
         TabletSharedPtr base_tablet) {
     if (_row_block_allocator == nullptr) {
@@ -795,7 +795,7 @@ bool SchemaChangeDirectly::process(RowsetReaderSharedPtr rowset_reader, RowsetWr
         }
         add_filtered_rows(filtered_rows);
 
-        if (!_write_row_block(rowset_writer.get(), new_row_block)) {
+        if (!_write_row_block(rowset_writer, new_row_block)) {
             LOG(WARNING) << "failed to write row block.";
             result = false;
             goto DIRECTLY_PROCESS_ERR;
@@ -863,7 +863,7 @@ SchemaChangeWithSorting::~SchemaChangeWithSorting() {
 
 bool SchemaChangeWithSorting::process(
             RowsetReaderSharedPtr rowset_reader,
-            RowsetWriterSharedPtr new_rowset_writer,
+            RowsetWriter* new_rowset_writer,
         TabletSharedPtr new_tablet,
         TabletSharedPtr base_tablet) {
     if (_row_block_allocator == nullptr) {
@@ -939,6 +939,7 @@ bool SchemaChangeWithSorting::process(
                                            _temp_delta_versions.second),
                                    rowset_reader->version_hash(),
                                    new_tablet,
+                                   rowset_reader->rowset()->rowset_meta()->rowset_type(),
                                    &rowset)) {
                 LOG(WARNING) << "failed to sorting internally.";
                 result = false;
@@ -1065,15 +1066,11 @@ bool SchemaChangeWithSorting::_internal_sorting(const vector<RowBlock*>& row_blo
                                                 const Version& version,
                                                 VersionHash version_hash,
                                                 TabletSharedPtr new_tablet,
+                                                RowsetTypePB new_rowset_type,
                                                 RowsetSharedPtr* rowset) {
     uint64_t merged_rows = 0;
     RowBlockMerger merger(new_tablet);
 
-    RowsetWriterSharedPtr rowset_writer(new AlphaRowsetWriter());
-    if (rowset_writer == nullptr) {
-        LOG(WARNING) << "new rowset builder failed";
-        return false;
-    }
     RowsetId rowset_id;
     OLAPStatus status = StorageEngine::instance()->next_rowset_id(&rowset_id);
     if (status != OLAP_SUCCESS) {
@@ -1086,7 +1083,7 @@ bool SchemaChangeWithSorting::_internal_sorting(const vector<RowBlock*>& row_blo
     context.tablet_id = new_tablet->tablet_id();
     context.partition_id = new_tablet->partition_id();
     context.tablet_schema_hash = new_tablet->schema_hash();
-    context.rowset_type = ALPHA_ROWSET;
+    context.rowset_type = new_rowset_type;
     context.rowset_path_prefix = new_tablet->tablet_path();
     context.tablet_schema = &(new_tablet->tablet_schema());
     context.rowset_state = VISIBLE;
@@ -1095,8 +1092,14 @@ bool SchemaChangeWithSorting::_internal_sorting(const vector<RowBlock*>& row_blo
     context.version_hash = version_hash;
     VLOG(3) << "init rowset builder. tablet=" << new_tablet->full_name()
             << ", block_row_size=" << new_tablet->num_rows_per_row_block();
-    rowset_writer->init(context);
-    if (!merger.merge(row_block_arr, rowset_writer, &merged_rows)) {
+
+    std::unique_ptr<RowsetWriter> rowset_writer;
+    status = RowsetFactory::create_rowset_writer(context, &rowset_writer);
+    if (status != OLAP_SUCCESS) {
+        return false;
+    }
+
+    if (!merger.merge(row_block_arr, rowset_writer.get(), &merged_rows)) {
         LOG(WARNING) << "failed to merge row blocks.";
         new_tablet->data_dir()->remove_pending_ids(ROWSET_ID_PREFIX + rowset_writer->rowset_id().to_string());
         return false;
@@ -1107,34 +1110,30 @@ bool SchemaChangeWithSorting::_internal_sorting(const vector<RowBlock*>& row_blo
     return true;
 }
 
-bool SchemaChangeWithSorting::_external_sorting(
-        vector<RowsetSharedPtr>& src_rowsets,
-        RowsetWriterSharedPtr rowset_writer,
-        TabletSharedPtr new_tablet) {
-    Merger merger(new_tablet, rowset_writer, READER_ALTER_TABLE);
-
-    int64_t merged_rows = 0;
-    int64_t filtered_rows = 0;
+bool SchemaChangeWithSorting::_external_sorting(vector<RowsetSharedPtr>& src_rowsets,
+                                                RowsetWriter* rowset_writer,
+                                                TabletSharedPtr new_tablet) {
     vector<RowsetReaderSharedPtr> rs_readers;
     for (auto& rowset : src_rowsets) {
         RowsetReaderSharedPtr rs_reader;
         auto res = rowset->create_reader(&rs_reader);
         if (res != OLAP_SUCCESS) {
-            LOG(WARNING) << "fail to create rowset reader.";
+            LOG(WARNING) << "failed to create rowset reader.";
             return false;
         }
         rs_readers.push_back(std::move(rs_reader));
     }
 
-    if (OLAP_SUCCESS != merger.merge(rs_readers, &merged_rows, &filtered_rows)) {
-        LOG(WARNING) << "fail to merge rowsets. tablet=" << new_tablet->full_name()
+    Merger::Statistics stats;
+    auto res = Merger::merge_rowsets(new_tablet, READER_ALTER_TABLE, rs_readers, rowset_writer, &stats);
+    if (res != OLAP_SUCCESS) {
+        LOG(WARNING) << "failed to merge rowsets. tablet=" << new_tablet->full_name()
                      << ", version=" << rowset_writer->version().first
                      << "-" << rowset_writer->version().second;
         return false;
     }
-    add_merged_rows(merged_rows);
-    add_filtered_rows(filtered_rows);
-
+    add_merged_rows(stats.merged_rows);
+    add_filtered_rows(stats.filtered_rows);
     return true;
 }
 
@@ -1676,17 +1675,18 @@ OLAPStatus SchemaChangeHandler::schema_version_convert(
     writer_context.tablet_id = new_tablet->tablet_id();
     writer_context.partition_id = (*base_rowset)->partition_id();
     writer_context.tablet_schema_hash = new_tablet->schema_hash();
-    writer_context.rowset_type = ALPHA_ROWSET;
+    writer_context.rowset_type = (*base_rowset)->rowset_meta()->rowset_type();
     writer_context.rowset_path_prefix = new_tablet->tablet_path();
     writer_context.tablet_schema = &(new_tablet->tablet_schema());
     writer_context.rowset_state = PREPARED;
     writer_context.txn_id = (*base_rowset)->txn_id();
     writer_context.load_id.set_hi((*base_rowset)->load_id().hi());
     writer_context.load_id.set_lo((*base_rowset)->load_id().lo());
-    RowsetWriterSharedPtr rowset_writer(new AlphaRowsetWriter());
-    rowset_writer->init(writer_context);
 
-    if (!sc_procedure->process(rowset_reader, rowset_writer, new_tablet, base_tablet)) {
+    std::unique_ptr<RowsetWriter> rowset_writer;
+    RowsetFactory::create_rowset_writer(writer_context, &rowset_writer);
+
+    if (!sc_procedure->process(rowset_reader, rowset_writer.get(), new_tablet, base_tablet)) {
         if ((*base_rowset)->is_pending()) {
             LOG(WARNING) << "failed to process the transaction when schema change. "
                          << "tablet=" << new_tablet->full_name() << "'"
@@ -1906,20 +1906,22 @@ OLAPStatus SchemaChangeHandler::_convert_historical_rowsets(const SchemaChangePa
         writer_context.tablet_id = new_tablet->tablet_id();
         writer_context.partition_id = new_tablet->partition_id();
         writer_context.tablet_schema_hash = new_tablet->schema_hash();
-        writer_context.rowset_type = ALPHA_ROWSET;
+        // linked schema change can't change rowset type, therefore we preserve rowset type in schema change now
+        writer_context.rowset_type = rs_reader->rowset()->rowset_meta()->rowset_type();
         writer_context.rowset_path_prefix = new_tablet->tablet_path();
         writer_context.tablet_schema = &(new_tablet->tablet_schema());
         writer_context.rowset_state = VISIBLE;
         writer_context.version = rs_reader->version();
         writer_context.version_hash = rs_reader->version_hash();
-        RowsetWriterSharedPtr rowset_writer(new AlphaRowsetWriter());
-        OLAPStatus status = rowset_writer->init(writer_context);
+
+        std::unique_ptr<RowsetWriter> rowset_writer;
+        OLAPStatus status = RowsetFactory::create_rowset_writer(writer_context, &rowset_writer);
         if (status != OLAP_SUCCESS) {
             res = OLAP_ERR_ROWSET_BUILDER_INIT;
             goto PROCESS_ALTER_EXIT;
         }
 
-        if (!sc_procedure->process(rs_reader, rowset_writer, sc_params.new_tablet, sc_params.base_tablet)) {
+        if (!sc_procedure->process(rs_reader, rowset_writer.get(), sc_params.new_tablet, sc_params.base_tablet)) {
             LOG(WARNING) << "failed to process the version."
                          << " version=" << rs_reader->version().first
                          << "-" << rs_reader->version().second;

--- a/be/src/olap/schema_change.h
+++ b/be/src/olap/schema_change.h
@@ -95,7 +95,7 @@ public:
     virtual ~SchemaChange() {}
 
     virtual bool process(RowsetReaderSharedPtr rowset_reader,
-                         RowsetWriterSharedPtr new_rowset_builder,
+                         RowsetWriter* new_rowset_builder,
                          TabletSharedPtr tablet,
                          TabletSharedPtr base_tablet) = 0;
 
@@ -135,9 +135,9 @@ public:
     ~LinkedSchemaChange() {}
 
     bool process(RowsetReaderSharedPtr rowset_reader,
-                 RowsetWriterSharedPtr new_rowset_writer,
+                 RowsetWriter* new_rowset_writer,
                  TabletSharedPtr new_tablet,
-                 TabletSharedPtr base_tablet);
+                 TabletSharedPtr base_tablet) override;
 private:
     const RowBlockChanger& _row_block_changer;
     DISALLOW_COPY_AND_ASSIGN(LinkedSchemaChange);
@@ -153,9 +153,9 @@ public:
     virtual ~SchemaChangeDirectly();
 
     virtual bool process(RowsetReaderSharedPtr rowset_reader,
-                         RowsetWriterSharedPtr new_rowset_writer,
+                         RowsetWriter* new_rowset_writer,
                          TabletSharedPtr new_tablet,
-                         TabletSharedPtr base_tablet);
+                         TabletSharedPtr base_tablet) override;
 
 private:
     const RowBlockChanger& _row_block_changer;
@@ -176,9 +176,9 @@ public:
     virtual ~SchemaChangeWithSorting();
 
     virtual bool process(RowsetReaderSharedPtr rowset_reader,
-                         RowsetWriterSharedPtr new_rowset_builder,
+                         RowsetWriter* new_rowset_builder,
                          TabletSharedPtr new_tablet,
-                         TabletSharedPtr base_tablet);
+                         TabletSharedPtr base_tablet) override;
 
 private:
     bool _internal_sorting(
@@ -186,11 +186,12 @@ private:
             const Version& temp_delta_versions,
             const VersionHash version_hash,
             TabletSharedPtr new_tablet,
+            RowsetTypePB new_rowset_type,
             RowsetSharedPtr* rowset);
 
     bool _external_sorting(
             std::vector<RowsetSharedPtr>& src_rowsets,
-            RowsetWriterSharedPtr rowset_writer,
+            RowsetWriter* rowset_writer,
             TabletSharedPtr new_tablet);
 
     const RowBlockChanger& _row_block_changer;

--- a/be/src/olap/snapshot_manager.cpp
+++ b/be/src/olap/snapshot_manager.cpp
@@ -160,8 +160,7 @@ OLAPStatus SnapshotManager::convert_rowset_ids(DataDir& data_dir, const string& 
     std::unordered_map<Version, RowsetMetaPB*, HashOfVersion> _rs_version_map;
     for (auto& visible_rowset : cloned_tablet_meta_pb.rs_metas()) {
         RowsetMetaPB* rowset_meta = new_tablet_meta_pb.add_rs_metas();
-        RowsetId rowset_id;
-        RETURN_NOT_OK(StorageEngine::instance()->next_rowset_id(&rowset_id));
+        RowsetId rowset_id = StorageEngine::instance()->next_rowset_id();
         RETURN_NOT_OK(_rename_rowset_id(visible_rowset, clone_dir, data_dir, tablet_schema, rowset_id, rowset_meta));
         rowset_meta->set_tablet_id(tablet_id);
         rowset_meta->set_tablet_schema_hash(schema_hash);
@@ -178,8 +177,7 @@ OLAPStatus SnapshotManager::convert_rowset_ids(DataDir& data_dir, const string& 
             continue;
         }
         RowsetMetaPB* rowset_meta = new_tablet_meta_pb.add_inc_rs_metas();
-        RowsetId rowset_id;
-        RETURN_NOT_OK(StorageEngine::instance()->next_rowset_id(&rowset_id));
+        RowsetId rowset_id = StorageEngine::instance()->next_rowset_id();
         RETURN_NOT_OK(_rename_rowset_id(inc_rowset, clone_dir, data_dir, tablet_schema, rowset_id, rowset_meta));
         rowset_meta->set_tablet_id(tablet_id);
         rowset_meta->set_tablet_schema_hash(schema_hash);

--- a/be/src/olap/snapshot_manager.cpp
+++ b/be/src/olap/snapshot_manager.cpp
@@ -30,7 +30,7 @@
 #include <boost/filesystem.hpp>
 
 #include "olap/olap_snapshot_converter.h"
-#include "olap/rowset/alpha_rowset.h"
+#include "olap/rowset/alpha_rowset_meta.h"
 #include "olap/rowset/rowset.h"
 #include "olap/rowset/rowset_factory.h"
 #include "olap/rowset/rowset_id_generator.h"

--- a/be/src/olap/snapshot_manager.cpp
+++ b/be/src/olap/snapshot_manager.cpp
@@ -31,9 +31,8 @@
 
 #include "olap/olap_snapshot_converter.h"
 #include "olap/rowset/alpha_rowset.h"
-#include "olap/rowset/alpha_rowset_meta.h"
-#include "olap/rowset/alpha_rowset_writer.h"
 #include "olap/rowset/rowset.h"
+#include "olap/rowset/rowset_factory.h"
 #include "olap/rowset/rowset_id_generator.h"
 #include "olap/rowset/rowset_writer.h"
 
@@ -119,7 +118,7 @@ OLAPStatus SnapshotManager::release_snapshot(const string& snapshot_path) {
     return OLAP_ERR_CE_CMD_PARAMS_ERROR;
 }
 
-
+// TODO support beta rowset
 OLAPStatus SnapshotManager::convert_rowset_ids(DataDir& data_dir, const string& clone_dir, int64_t tablet_id, 
     const int32_t& schema_hash, TabletSharedPtr tablet) {
     OLAPStatus res = OLAP_SUCCESS;   
@@ -198,10 +197,11 @@ OLAPStatus SnapshotManager::convert_rowset_ids(DataDir& data_dir, const string& 
 OLAPStatus SnapshotManager::_rename_rowset_id(const RowsetMetaPB& rs_meta_pb, const string& new_path, 
     DataDir& data_dir, TabletSchema& tablet_schema, const RowsetId& rowset_id, RowsetMetaPB* new_rs_meta_pb) {
     OLAPStatus res = OLAP_SUCCESS;
+    // TODO use factory to obtain RowsetMeta when SnapshotManager::convert_rowset_ids supports beta rowset
     RowsetMetaSharedPtr alpha_rowset_meta(new AlphaRowsetMeta());
     alpha_rowset_meta->init_from_pb(rs_meta_pb);
-    RowsetSharedPtr org_rowset(new AlphaRowset(&tablet_schema, new_path, &data_dir, alpha_rowset_meta));
-    RETURN_NOT_OK(org_rowset->init());
+    RowsetSharedPtr org_rowset;
+    RETURN_NOT_OK(RowsetFactory::create_rowset(&tablet_schema, new_path, &data_dir, alpha_rowset_meta, &org_rowset));
     // do not use cache to load index
     // because the index file may conflict
     // and the cached fd may be invalid
@@ -219,12 +219,10 @@ OLAPStatus SnapshotManager::_rename_rowset_id(const RowsetMetaPB& rs_meta_pb, co
     context.data_dir = &data_dir;
     context.version = org_rowset_meta->version();
     context.version_hash = org_rowset_meta->version_hash();
-    RowsetWriterSharedPtr rs_writer(new AlphaRowsetWriter());
-    if (rs_writer == nullptr) {
-        LOG(WARNING) << "fail to new rowset.";
-        return OLAP_ERR_MALLOC_ERROR;
-    }
-    rs_writer->init(context);
+
+    std::unique_ptr<RowsetWriter> rs_writer;
+    RETURN_NOT_OK(RowsetFactory::create_rowset_writer(context, &rs_writer));
+
     res = rs_writer->add_rowset(org_rowset);
     if (res != OLAP_SUCCESS) {
         LOG(WARNING) << "failed to add rowset " 

--- a/be/src/olap/storage_engine.cpp
+++ b/be/src/olap/storage_engine.cpp
@@ -42,7 +42,6 @@
 #include "olap/reader.h"
 #include "olap/rowset/rowset_meta_manager.h"
 #include "olap/rowset/alpha_rowset.h"
-#include "olap/rowset_factory.h"
 #include "olap/schema_change.h"
 #include "olap/data_dir.h"
 #include "olap/utils.h"

--- a/be/src/olap/storage_engine.h
+++ b/be/src/olap/storage_engine.h
@@ -197,7 +197,7 @@ public:
     // TODO(ygl)
     TabletSyncService* tablet_sync_service() { return nullptr; }
 
-    OLAPStatus next_rowset_id(RowsetId* rowset_id) { return _rowset_id_generator->next_id(rowset_id); };
+    RowsetId next_rowset_id() { return _rowset_id_generator->next_id(); };
 
     bool rowset_id_in_use(const RowsetId& rowset_id) { return _rowset_id_generator->id_in_use(rowset_id); };
 

--- a/be/src/olap/tablet_manager.cpp
+++ b/be/src/olap/tablet_manager.cpp
@@ -1226,13 +1226,8 @@ OLAPStatus TabletManager::_create_inital_rowset(
                 res = OLAP_ERR_INPUT_PARAMETER_ERROR;
                 break;
             }
-            RowsetId rowset_id;
-            RETURN_NOT_OK(StorageEngine::instance()->next_rowset_id(&rowset_id));
-            // if we know this is the first rowset in this tablet, then not call
-            // tablet to generate rowset id, just set it to 1
-            // RETURN_NOT_OK(tablet->next_rowset_id(&rowset_id));
             RowsetWriterContext context;
-            context.rowset_id = rowset_id;
+            context.rowset_id = StorageEngine::instance()->next_rowset_id();
             context.tablet_uid = tablet->tablet_uid();
             context.tablet_id = tablet->tablet_id();
             context.partition_id = tablet->partition_id();

--- a/be/src/olap/tablet_manager.cpp
+++ b/be/src/olap/tablet_manager.cpp
@@ -47,6 +47,7 @@
 #include "olap/utils.h"
 #include "olap/olap_common.h"
 #include "olap/rowset/column_data_writer.h"
+#include "olap/rowset/rowset_factory.h"
 #include "olap/rowset/rowset_id_generator.h"
 #include "util/time.h"
 #include "util/doris_metrics.h"
@@ -1236,41 +1237,40 @@ OLAPStatus TabletManager::_create_inital_rowset(
             context.tablet_id = tablet->tablet_id();
             context.partition_id = tablet->partition_id();
             context.tablet_schema_hash = tablet->schema_hash();
-            context.rowset_type = ALPHA_ROWSET;
+            context.rowset_type = DEFAULT_ROWSET_TYPE;
             context.rowset_path_prefix = tablet->tablet_path();
             context.tablet_schema = &(tablet->tablet_schema());
             context.rowset_state = VISIBLE;
             context.data_dir = tablet->data_dir();
             context.version = version;
             context.version_hash = request.version_hash;
-            RowsetWriter* builder = new (std::nothrow)AlphaRowsetWriter(); 
-            if (builder == nullptr) {
-                LOG(WARNING) << "fail to new rowset.";
-                res = OLAP_ERR_MALLOC_ERROR;
+
+            std::unique_ptr<RowsetWriter> builder;
+            res = RowsetFactory::create_rowset_writer(context, &builder);
+            if (res != OLAP_SUCCESS) {
+                LOG(WARNING) << "failed to init rowset writer for tablet " << tablet->full_name();
                 break;
             }
-            builder->init(context);
             res = builder->flush();
-            if (OLAP_SUCCESS != res) {
-                LOG(WARNING) << "fail to finalize writer. tablet=" << tablet->full_name();
+            if (res != OLAP_SUCCESS) {
+                LOG(WARNING) << "failed to flush rowset writer for tablet " << tablet->full_name();
                 break;
             }
 
             new_rowset = builder->build();
             res = tablet->add_rowset(new_rowset);
             if (res != OLAP_SUCCESS) {
-                LOG(WARNING) << "fail to add rowset to tablet. "
-                            << "tablet=" << tablet->full_name();
+                LOG(WARNING) << "failed to add rowset for tablet " << tablet->full_name();
                 break;
             }
         } while (0);
 
         // Unregister index and delete files(index and data) if failed
         if (res != OLAP_SUCCESS) {
-            StorageEngine::instance()->add_unused_rowset(new_rowset);
-            LOG(WARNING) << "fail to create init base version. " 
+            LOG(WARNING) << "fail to create init base version. "
                          << " res=" << res 
                          << " version=" << request.version;
+            StorageEngine::instance()->add_unused_rowset(new_rowset);
             return res;
         }
     }

--- a/be/test/olap/rowset/alpha_rowset_test.cpp
+++ b/be/test/olap/rowset/alpha_rowset_test.cpp
@@ -25,6 +25,7 @@
 #include "json2pb/json_to_pb.h"
 #include "util/logging.h"
 #include "olap/olap_meta.h"
+#include "olap/rowset/rowset_writer.h"
 #include "olap/rowset/rowset_writer_context.h"
 #include "olap/rowset/rowset_reader_context.h"
 #include "olap/rowset/alpha_rowset.h"

--- a/be/test/olap/rowset/alpha_rowset_test.cpp
+++ b/be/test/olap/rowset/alpha_rowset_test.cpp
@@ -28,7 +28,7 @@
 #include "olap/rowset/rowset_writer_context.h"
 #include "olap/rowset/rowset_reader_context.h"
 #include "olap/rowset/alpha_rowset.h"
-#include "olap/rowset/alpha_rowset_writer.h"
+#include "olap/rowset/rowset_factory.h"
 #include "olap/rowset/alpha_rowset_reader.h"
 #include "olap/data_dir.h"
 #include "olap/storage_engine.h"
@@ -166,20 +166,16 @@ public:
         set_up();
         _data_dir = k_engine->get_store(config::storage_root_path);
         ASSERT_TRUE(_data_dir != nullptr);
-        _alpha_rowset_writer = new(std::nothrow) AlphaRowsetWriter();
         _mem_tracker.reset(new MemTracker(-1));
         _mem_pool.reset(new MemPool(_mem_tracker.get()));
     }
 
     virtual void TearDown() {
-        delete _alpha_rowset_writer;
-        _alpha_rowset_writer = nullptr;
         tear_down();
     }
 
 private:
     DataDir* _data_dir;
-    AlphaRowsetWriter* _alpha_rowset_writer;
     std::unique_ptr<MemTracker> _mem_tracker;
     std::unique_ptr<MemPool> _mem_pool;
 };
@@ -213,7 +209,10 @@ TEST_F(AlphaRowsetTest, TestAlphaRowsetReader) {
     create_tablet_schema(AGG_KEYS, &tablet_schema);
     RowsetWriterContext rowset_writer_context;
     create_rowset_writer_context(&tablet_schema, _data_dir, &rowset_writer_context);
-    _alpha_rowset_writer->init(rowset_writer_context);
+
+    std::unique_ptr<RowsetWriter> _alpha_rowset_writer;
+    ASSERT_EQ(OLAP_SUCCESS, RowsetFactory::create_rowset_writer(rowset_writer_context, &_alpha_rowset_writer));
+
     RowCursor row;
     OLAPStatus res = row.init(tablet_schema);
     ASSERT_EQ(OLAP_SUCCESS, res);

--- a/be/test/olap/rowset/beta_rowset_test.cpp
+++ b/be/test/olap/rowset/beta_rowset_test.cpp
@@ -24,6 +24,7 @@
 #include "olap/rowset/beta_rowset_reader.h"
 #include "olap/rowset/rowset_factory.h"
 #include "olap/rowset/rowset_reader_context.h"
+#include "olap/rowset/rowset_writer.h"
 #include "olap/rowset/rowset_writer_context.h"
 #include "olap/row_cursor.h"
 #include "olap/storage_engine.h"

--- a/be/test/olap/rowset/beta_rowset_test.cpp
+++ b/be/test/olap/rowset/beta_rowset_test.cpp
@@ -22,7 +22,7 @@
 #include "olap/data_dir.h"
 #include "olap/row_block.h"
 #include "olap/rowset/beta_rowset_reader.h"
-#include "olap/rowset/beta_rowset_writer.h"
+#include "olap/rowset/rowset_factory.h"
 #include "olap/rowset/rowset_reader_context.h"
 #include "olap/rowset/rowset_writer_context.h"
 #include "olap/row_cursor.h"
@@ -139,8 +139,8 @@ TEST_F(BetaRowsetTest, BasicFunctionTest) {
         RowsetWriterContext writer_context;
         create_rowset_writer_context(&tablet_schema, &writer_context);
 
-        RowsetWriterSharedPtr rowset_writer(new BetaRowsetWriter);
-        s = rowset_writer->init(writer_context);
+        std::unique_ptr<RowsetWriter> rowset_writer;
+        s = RowsetFactory::create_rowset_writer(writer_context, &rowset_writer);
         ASSERT_EQ(OLAP_SUCCESS, s);
 
         RowCursor input_row;

--- a/be/test/olap/rowset/unique_rowset_id_generator_test.cpp
+++ b/be/test/olap/rowset/unique_rowset_id_generator_test.cpp
@@ -67,17 +67,14 @@ TEST_F(UniqueRowsetIdGeneratorTest, GenerateIdTest) {
     UniqueRowsetIdGenerator id_generator(backend_uid);
     UniqueRowsetIdGenerator id_generator2(backend_uid2);
     {
-        RowsetId rowset_id1;
-        id_generator.next_id(&rowset_id1);
-        RowsetId rowset_id2;
-        id_generator2.next_id(&rowset_id2);
+        RowsetId rowset_id1 = id_generator.next_id();
+        RowsetId rowset_id2 = id_generator2.next_id();
         ASSERT_TRUE(rowset_id1.hi != rowset_id2.hi);
     }
     {
         int64_t max_id = 2;
         max_id = max_id << 56;
-        RowsetId rowset_id;
-        id_generator.next_id(&rowset_id);
+        RowsetId rowset_id = id_generator.next_id();
         ASSERT_TRUE(rowset_id.hi == (1 + max_id));
         ASSERT_TRUE(rowset_id.version == 2);
         ASSERT_TRUE(backend_uid.lo == rowset_id.lo);
@@ -90,7 +87,7 @@ TEST_F(UniqueRowsetIdGeneratorTest, GenerateIdTest) {
         ASSERT_TRUE(in_use == false);
 
         int64_t high = rowset_id.hi + 1;
-        id_generator.next_id(&rowset_id);
+        rowset_id = id_generator.next_id();
         ASSERT_TRUE(rowset_id.hi == high);
         in_use = id_generator.id_in_use(rowset_id);
         ASSERT_TRUE(in_use == true);


### PR DESCRIPTION
The PR contains the following changes

- a factory method `create_rowset_writer` is added to `RowsetFactory`. All clients of RowsetWriter have been rewritten to use the factory method to obtain RowsetWriter instance.
- a global constant `DEFAULT_ROWSET_TYPE` is added to represent the default rowset type for newly generated rowset. Currently it's set ALPHA_ROWSET, but can be changed to BETA_ROWSET when V2 segment is ready to be released as the default type.
- `Merger` is refactored to provides simpler interface to its clients
- There is no reason to use shared ownership for RowsetWriter. As a result, `RowsetWriterSharedPtr` is removed and all clients are switched to unique_ptr<RowsetWriter>.
- `RowsetIdGenerator.next_id()` is refactored to return RowsetId instead of OLAPStatus since the operation can't fail. It makes the client code much more cleaner.
- a new macro `RETURN_NOT_OK_LOG` is added to oneliner the common if-error-then-warn-and-return pattern.