### PR TITLE
RowsetFactory as a single entry for Rowset creation

### DIFF
--- a/be/src/olap/rowset/alpha_rowset.cpp
+++ b/be/src/olap/rowset/alpha_rowset.cpp
@@ -41,16 +41,7 @@ OLAPStatus AlphaRowset::init() {
 }
 
 OLAPStatus AlphaRowset::load(bool use_cache) {
-    // load is depend on init, so that check if init here and do init if not
-    // TODO remove the following if block when rowset is guaranteed to be initialized
-    if (!is_inited()) {
-        OLAPStatus res = init();
-        if (res != OLAP_SUCCESS) {
-            LOG(WARNING) << "failed to init rowset before load"
-                         << " rowset id " << rowset_id();
-            return res;
-        }
-    }
+    DCHECK(is_inited()) << "should init() rowset " << unique_id() << " before load()";
     if (is_loaded()) {
         return OLAP_SUCCESS;
     }

--- a/be/src/olap/rowset/alpha_rowset.h
+++ b/be/src/olap/rowset/alpha_rowset.h
@@ -33,25 +33,23 @@ class AlphaRowset;
 using AlphaRowsetSharedPtr = std::shared_ptr<AlphaRowset>;
 class AlphaRowsetWriter;
 class AlphaRowsetReader;
+class OlapSnapshotConverter;
+class RowsetFactory;
 
 class AlphaRowset : public Rowset {
 public:
-    AlphaRowset(const TabletSchema* schema,
-                std::string rowset_path,
-                DataDir* data_dir,
-                RowsetMetaSharedPtr rowset_meta);
-
     virtual ~AlphaRowset() {}
-
-    static bool is_valid_rowset_path(std::string path);
-
-    OLAPStatus init() override;
 
     // this api is for lazy loading data
     // always means that there are some io
     OLAPStatus load(bool use_cache = true) override;
 
     OLAPStatus create_reader(std::shared_ptr<RowsetReader>* result) override;
+
+    OLAPStatus split_range(const RowCursor& start_key,
+                           const RowCursor& end_key,
+                           uint64_t request_block_row_count,
+                           std::vector<OlapTuple>* ranges) override;
 
     OLAPStatus remove() override;
 
@@ -66,12 +64,6 @@ public:
                                  std::vector<std::string>* success_files);
 
     OLAPStatus remove_old_files(std::vector<std::string>* files_to_remove) override;
-
-    OLAPStatus split_range(
-            const RowCursor& start_key,
-            const RowCursor& end_key,
-            uint64_t request_block_row_count,
-            vector<OlapTuple>* ranges);
     
     bool check_path(const std::string& path) override;
 
@@ -80,6 +72,15 @@ public:
     OLAPStatus reset_sizeinfo();
 
 protected:
+    friend class RowsetFactory;
+
+    AlphaRowset(const TabletSchema* schema,
+                std::string rowset_path,
+                DataDir* data_dir,
+                RowsetMetaSharedPtr rowset_meta);
+
+    OLAPStatus init() override;
+
     // add custom logic when rowset is published
     void make_visible_extra(Version version, VersionHash version_hash) override;
 
@@ -91,6 +92,7 @@ private:
 private:
     friend class AlphaRowsetWriter;
     friend class AlphaRowsetReader;
+    friend class OlapSnapshotConverter;
 
     std::vector<std::shared_ptr<SegmentGroup>> _segment_groups;
 };

--- a/be/src/olap/rowset/alpha_rowset_writer.cpp
+++ b/be/src/olap/rowset/alpha_rowset_writer.cpp
@@ -19,6 +19,7 @@
 
 #include "olap/rowset/alpha_rowset_writer.h"
 #include "olap/rowset/alpha_rowset_meta.h"
+#include "olap/rowset/rowset_factory.h"
 #include "olap/rowset/rowset_meta_manager.h"
 #include "olap/row.h"
 
@@ -213,14 +214,14 @@ RowsetSharedPtr AlphaRowsetWriter::build() {
         return nullptr;
     }
 
-    RowsetSharedPtr rowset(new(std::nothrow) AlphaRowset(_rowset_writer_context.tablet_schema,
-                                    _rowset_writer_context.rowset_path_prefix,
-                                    _rowset_writer_context.data_dir, _current_rowset_meta));
-    DCHECK(rowset != nullptr) << "new rowset failed when build new rowset";
-
-    OLAPStatus status = rowset->init();
+    RowsetSharedPtr rowset;
+    auto status = RowsetFactory::create_rowset(_rowset_writer_context.tablet_schema,
+                                               _rowset_writer_context.rowset_path_prefix,
+                                               _rowset_writer_context.data_dir,
+                                               _current_rowset_meta,
+                                               &rowset);
     if (status != OLAP_SUCCESS) {
-        LOG(WARNING) << "rowset init failed when build new rowset";
+        LOG(WARNING) << "rowset init failed when build new rowset, res=" << status;
         return nullptr;
     }
     _rowset_build = true;

--- a/be/src/olap/rowset/beta_rowset.cpp
+++ b/be/src/olap/rowset/beta_rowset.cpp
@@ -51,16 +51,7 @@ OLAPStatus BetaRowset::init() {
 
 // `use_cache` is ignored because beta rowset doesn't support fd cache now
 OLAPStatus BetaRowset::load(bool use_cache) {
-    // DCHECK(is_inited()) << "should init() rowset " << unique_id() << " before load()";
-    // TODO remove the following if block when rowset is guaranteed to be initialized
-    if (!is_inited()) {
-        OLAPStatus res = init();
-        if (res != OLAP_SUCCESS) {
-            LOG(WARNING) << "failed to init rowset before load"
-                         << " rowset id " << rowset_id();
-            return res;
-        }
-    }
+    DCHECK(is_inited()) << "should init() rowset " << unique_id() << " before load()";
     if (is_loaded()) {
         return OLAP_SUCCESS;
     }
@@ -84,6 +75,15 @@ OLAPStatus BetaRowset::create_reader(RowsetReaderSharedPtr* result) {
         }
     }
     result->reset(new BetaRowsetReader(std::static_pointer_cast<BetaRowset>(shared_from_this())));
+    return OLAP_SUCCESS;
+}
+
+OLAPStatus BetaRowset::split_range(const RowCursor& start_key,
+                                   const RowCursor& end_key,
+                                   uint64_t request_block_row_count,
+                                   std::vector<OlapTuple>* ranges) {
+    ranges->emplace_back(start_key.to_tuple());
+    ranges->emplace_back(end_key.to_tuple());
     return OLAP_SUCCESS;
 }
 

--- a/be/src/olap/rowset/beta_rowset.h
+++ b/be/src/olap/rowset/beta_rowset.h
@@ -30,23 +30,22 @@ namespace doris {
 class BetaRowset;
 using BetaRowsetSharedPtr = std::shared_ptr<BetaRowset>;
 class BetaRowsetReader;
+class RowsetFactory;
 
 class BetaRowset : public Rowset {
 public:
-    BetaRowset(const TabletSchema* schema,
-               std::string rowset_path,
-               DataDir* data_dir,
-               RowsetMetaSharedPtr rowset_meta);
-
     virtual ~BetaRowset() {}
 
     static std::string segment_file_path(const std::string& segment_dir, const RowsetId& rowset_id, int segment_id);
 
-    OLAPStatus init() override;
-
     OLAPStatus load(bool use_cache = true) override;
 
     OLAPStatus create_reader(RowsetReaderSharedPtr* result) override;
+
+    OLAPStatus split_range(const RowCursor& start_key,
+                           const RowCursor& end_key,
+                           uint64_t request_block_row_count,
+                           std::vector<OlapTuple>* ranges) override;
 
     OLAPStatus remove() override;
 
@@ -60,6 +59,16 @@ public:
     };
 
     bool check_path(const std::string& path) override;
+
+protected:
+    friend class RowsetFactory;
+
+    BetaRowset(const TabletSchema* schema,
+               std::string rowset_path,
+               DataDir* data_dir,
+               RowsetMetaSharedPtr rowset_meta);
+
+    OLAPStatus init() override;
 
 private:
     friend class BetaRowsetReader;

--- a/be/src/olap/rowset/beta_rowset_writer.cpp
+++ b/be/src/olap/rowset/beta_rowset_writer.cpp
@@ -24,9 +24,10 @@
 
 #include "common/config.h"
 #include "common/logging.h"
-#include "olap/rowset/beta_rowset.h"
-#include <olap/rowset/segment_v2/segment_writer.h>
 #include "olap/olap_define.h"
+#include "olap/rowset/beta_rowset.h"
+#include "olap/rowset/rowset_factory.h"
+#include "olap/rowset/segment_v2/segment_writer.h"
 #include "olap/row.h" // ContiguousRow
 #include "olap/row_cursor.h" // RowCursor
 
@@ -142,13 +143,14 @@ RowsetSharedPtr BetaRowsetWriter::build() {
         _rowset_meta->set_rowset_state(VISIBLE);
     }
 
-    RowsetSharedPtr rowset(new BetaRowset(_context.tablet_schema,
-                                          _context.rowset_path_prefix,
-                                          _context.data_dir,
-                                          _rowset_meta));
-    auto status = rowset->init();
+    RowsetSharedPtr rowset;
+    auto status = RowsetFactory::create_rowset(_context.tablet_schema,
+                                               _context.rowset_path_prefix,
+                                               _context.data_dir,
+                                               _rowset_meta,
+                                               &rowset);
     if (status != OLAP_SUCCESS) {
-        LOG(WARNING) << "rowset init failed when build new rowset";
+        LOG(WARNING) << "rowset init failed when build new rowset, res=" << status;
         return nullptr;
     }
     _rowset_build = true;

--- a/be/src/olap/rowset/rowset_writer.h
+++ b/be/src/olap/rowset/rowset_writer.h
@@ -53,7 +53,8 @@ public:
     // note that `add_row` could also trigger flush when certain conditions are met
     virtual OLAPStatus flush() = 0;
 
-    // get a rowset
+    // finish building and return pointer to the built rowset (guaranteed to be inited).
+    // return nullptr when failed
     virtual RowsetSharedPtr build() = 0;
 
     virtual Version version() = 0;

--- a/be/src/olap/snapshot_manager.cpp
+++ b/be/src/olap/snapshot_manager.cpp
@@ -233,7 +233,6 @@ OLAPStatus SnapshotManager::_rename_rowset_id(const RowsetMetaPB& rs_meta_pb, co
         LOG(WARNING) << "failed to build rowset when rename rowset id";
         return OLAP_ERR_MALLOC_ERROR; 
     }
-    RETURN_NOT_OK(new_rowset->init());
     RETURN_NOT_OK(new_rowset->load());
     new_rowset->rowset_meta()->to_rowset_pb(new_rs_meta_pb);
     org_rowset->remove();

--- a/be/src/olap/tablet.h
+++ b/be/src/olap/tablet.h
@@ -53,7 +53,6 @@ public:
     Tablet(TabletMetaSharedPtr tablet_meta, DataDir* data_dir);
     ~Tablet();
 
-    OLAPStatus init_once();
     OLAPStatus init();
     inline bool init_succeeded();
 
@@ -235,6 +234,7 @@ public:
     inline bool in_eco_mode() { return false; }
 
 private:
+    OLAPStatus _init_once_action();
     void _print_missed_versions(const std::vector<Version>& missed_versions) const;
     OLAPStatus _check_added_rowset(const RowsetSharedPtr& rowset);
 

--- a/be/src/olap/task/engine_clone_task.cpp
+++ b/be/src/olap/task/engine_clone_task.cpp
@@ -22,11 +22,8 @@
 #include "http/http_client.h"
 #include "olap/olap_snapshot_converter.h"
 #include "olap/snapshot_manager.h"
-#include "olap/rowset/alpha_rowset.h"
-#include "olap/rowset/alpha_rowset_writer.h"
 #include "olap/rowset/rowset.h"
-#include "olap/rowset/rowset_id_generator.h"
-#include "olap/rowset/rowset_writer.h"
+#include "olap/rowset/rowset_factory.h"
 
 using std::set;
 using std::stringstream;
@@ -847,10 +844,19 @@ OLAPStatus EngineCloneTask::_clone_full_data(TabletSharedPtr tablet, TabletMeta*
     // in previous step, copy all files from CLONE_DIR to tablet dir
     // but some rowset is useless, so that remove them here
     for (auto& rs_meta_ptr : rs_metas_found_in_src) {
-        RowsetSharedPtr org_rowset(new AlphaRowset(&(cloned_tablet_meta->tablet_schema()), 
-            tablet->tablet_path(), tablet->data_dir(), rs_meta_ptr));
-        if (org_rowset->init() == OLAP_SUCCESS && org_rowset->load() == OLAP_SUCCESS) {
-            org_rowset->remove();
+        RowsetSharedPtr rowset_to_remove;
+        auto s = RowsetFactory::create_rowset(&(cloned_tablet_meta->tablet_schema()),
+                                              tablet->tablet_path(),
+                                              tablet->data_dir(),
+                                              rs_meta_ptr,
+                                              &rowset_to_remove);
+        if (s != OLAP_SUCCESS) {
+            LOG(WARNING) << "failed to init rowset to remove: " << rs_meta_ptr->rowset_id().to_string();
+            continue;
+        }
+        s = rowset_to_remove->remove();
+        if (s != OLAP_SUCCESS) {
+            LOG(WARNING) << "failed to remove rowset " << rs_meta_ptr->rowset_id().to_string() << ", res=" << s;
         }
     }
     return clone_res;

--- a/be/test/olap/txn_manager_test.cpp
+++ b/be/test/olap/txn_manager_test.cpp
@@ -22,8 +22,9 @@
 #include "gtest/gtest.h"
 #include "gmock/gmock.h"
 #include "olap/olap_meta.h"
+#include "olap/rowset/rowset.h"
+#include "olap/rowset/rowset_factory.h"
 #include "olap/rowset/rowset_meta_manager.h"
-#include "olap/rowset/alpha_rowset.h"
 #include "olap/rowset/alpha_rowset_meta.h"
 #include "olap/txn_manager.h"
 #include "olap/new_status.h"
@@ -82,8 +83,10 @@ public:
         RowsetMetaSharedPtr rowset_meta(new AlphaRowsetMeta());
         rowset_meta->init_from_json(_json_rowset_meta);
         ASSERT_EQ(rowset_meta->rowset_id(), rowset_id);
-        _alpha_rowset.reset(new AlphaRowset(nullptr, rowset_meta_path, nullptr, rowset_meta));
-        _alpha_rowset_same_id.reset(new AlphaRowset(nullptr, rowset_meta_path, nullptr, rowset_meta));
+        ASSERT_EQ(OLAP_SUCCESS, RowsetFactory::create_rowset(
+            nullptr, rowset_meta_path, nullptr, rowset_meta, &_alpha_rowset));
+        ASSERT_EQ(OLAP_SUCCESS, RowsetFactory::create_rowset(
+            nullptr, rowset_meta_path, nullptr, rowset_meta, &_alpha_rowset_same_id));
 
         // init rowset meta 2
         _json_rowset_meta = "";
@@ -99,7 +102,8 @@ public:
         RowsetMetaSharedPtr rowset_meta2(new AlphaRowsetMeta());
         rowset_meta2->init_from_json(_json_rowset_meta);
         ASSERT_EQ(rowset_meta2->rowset_id(), rowset_id);
-        _alpha_rowset_diff_id.reset(new AlphaRowset(nullptr, rowset_meta_path_2, nullptr, rowset_meta2));
+        ASSERT_EQ(OLAP_SUCCESS, RowsetFactory::create_rowset(
+            nullptr, rowset_meta_path_2, nullptr, rowset_meta2, &_alpha_rowset_diff_id));
         _tablet_uid = TabletUid(10, 10);
     }
 


### PR DESCRIPTION
In this PR, all creations of Rowset are done through the `RowsetFactory.create_rowset` factory method (except OlapSnapshotConverter which depends on AlphaRowset directly). This removes hard coding around `AlphaRowset` and also guarantees all rowset are initialized before use.