### PR TITLE
fix a bug in BetaRowsetReader which results in empty result

### DIFF
--- a/be/src/olap/rowset/beta_rowset_reader.cpp
+++ b/be/src/olap/rowset/beta_rowset_reader.cpp
@@ -114,6 +114,8 @@ OLAPStatus BetaRowsetReader::next_block(RowBlock** block) {
             return OLAP_ERR_ROWSET_READ_FAILED;
         }
     }
+    _output_block->set_pos(0);
+    _output_block->set_limit(_input_block->num_rows());
     _output_block->finalize(_input_block->num_rows());
     *block = _output_block.get();
     return OLAP_SUCCESS;

--- a/be/test/olap/rowset/beta_rowset_test.cpp
+++ b/be/test/olap/rowset/beta_rowset_test.cpp
@@ -189,6 +189,8 @@ TEST_F(BetaRowsetTest, BasicFunctionTest) {
         while ((s = rowset_reader->next_block(&output_block)) == OLAP_SUCCESS) {
             ASSERT_TRUE(output_block != nullptr);
             ASSERT_GT(output_block->row_num(), 0);
+            ASSERT_EQ(0, output_block->pos());
+            ASSERT_EQ(output_block->row_num(), output_block->limit());
             ASSERT_EQ(return_columns, output_block->row_block_info().column_ids);
             // after sort merge segments, k1 will be 0, 1, 2, 10, 11, 12, 20, 21, 22, ..., 40950, 40951, 40952
             for (int i = 0; i < output_block->row_num(); ++i) {
@@ -227,6 +229,8 @@ TEST_F(BetaRowsetTest, BasicFunctionTest) {
         while ((s = rowset_reader->next_block(&output_block)) == OLAP_SUCCESS) {
             ASSERT_TRUE(output_block != nullptr);
             ASSERT_GT(output_block->row_num(), 0);
+            ASSERT_EQ(0, output_block->pos());
+            ASSERT_EQ(output_block->row_num(), output_block->limit());
             ASSERT_EQ(return_columns, output_block->row_block_info().column_ids);
             // for unordered result, k3 will be 0, 1, 2, ..., 4096*3-1
             for (int i = 0; i < output_block->row_num(); ++i) {


### PR DESCRIPTION
I didn't notice that `Reader` [relies on](https://github.com/apache/incubator-doris/blob/master/be/src/olap/reader.cpp#L120) the `_pos` and `_limit` fields of `DataBlock`(), and forgot to update them in `BetaRowsetReader::next_block`, which results in empty results when querying V2 table.