### PR TITLE
Bug-fix: error result of union stmt

### DIFF
--- a/fe/src/main/java/org/apache/doris/analysis/UnionStmt.java
+++ b/fe/src/main/java/org/apache/doris/analysis/UnionStmt.java
@@ -451,7 +451,8 @@ public class UnionStmt extends QueryStmt {
                 Expr resultExpr = op.getQueryStmt().getResultExprs().get(i);
                 slotDesc.addSourceExpr(resultExpr);
                 SlotRef slotRef = resultExpr.unwrapSlotRef(false);
-                if (slotRef == null || slotRef.getDesc().getIsNullable()) isNullable = true;
+                if (slotRef == null || slotRef.getDesc().getIsNullable()
+                        || analyzer.isOuterJoined(slotRef.getDesc().getParent().getId())) isNullable = true;
                 if (op.hasAnalyticExprs()) continue;
                 slotRef = resultExpr.unwrapSlotRef(true);
                 if (slotRef == null) continue;


### PR DESCRIPTION
ISSUES-1725: The result of union stmt whose child is outer join stmt is incorrect.

Example:
sql: (select k1 from empty) union all (select b.k1 k1 from left_table a left join empty  b on a.k2 = b.k2);
context: the empty table has no data.
error result: 0
expect result: null

Reason:
The judgment (columns k1 who belongs to union tuple is nullable ) is incorrect.
It could not be determined by slot attribute of children when the slot is produced by the outer join.
The slot A is not nullable while the result of outer join is nullable which is same as slot A.
So, the judgment needs to consider if the slot is come from the outer join.