### PR TITLE
Add multi-path in RowsetGraph

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -240,7 +240,8 @@ namespace config {
 
     // cumulative compaction policy: max delta file's size unit:B
     CONF_Int32(cumulative_compaction_check_interval_seconds, "10");
-    CONF_Int64(cumulative_compaction_num_singleton_deltas, "5");
+    CONF_Int64(min_cumulative_compaction_num_singleton_deltas, "5");
+    CONF_Int64(max_cumulative_compaction_num_singleton_deltas, "1000");
     CONF_Int32(cumulative_compaction_num_threads, "1");
     CONF_Int32(cumulative_compaction_num_threads_per_disk, "1");
     CONF_Int64(cumulative_compaction_budgeted_bytes, "104857600");

--- a/be/src/olap/cumulative_compaction.cpp
+++ b/be/src/olap/cumulative_compaction.cpp
@@ -85,7 +85,7 @@ OLAPStatus CumulativeCompaction::pick_rowsets_to_compact() {
         // So the ultimate singleton rowset is revserved.
         RowsetSharedPtr rowset = candidate_rowsets[i];
         if (_tablet->version_for_delete_predicate(rowset->version())) {
-            if (transient_rowsets.size() > config::cumulative_compaction_num_singleton_deltas) {
+            if (transient_rowsets.size() > config::min_cumulative_compaction_num_singleton_deltas) {
                 _input_rowsets = transient_rowsets;
                 break;
             }
@@ -93,10 +93,14 @@ OLAPStatus CumulativeCompaction::pick_rowsets_to_compact() {
             continue;
         }
 
+        if (transient_rowsets.size() >= config::max_cumulative_compaction_num_singleton_deltas) {
+            // the threshold of files to compacted one time
+            break;
+        }
         transient_rowsets.push_back(rowset); 
     }
 
-    if (transient_rowsets.size() > config::cumulative_compaction_num_singleton_deltas) {
+    if (transient_rowsets.size() > config::min_cumulative_compaction_num_singleton_deltas) {
         _input_rowsets = transient_rowsets;
     }
 		


### PR DESCRIPTION
1. Do not remove rowset from RowsetGraph after compaction
2. Collect unused rowset at interval
3. Remove inc_version and related code