### PR TITLE
Fix bug that failed to limit the mem usage of HLL column when loading

### DIFF
--- a/be/src/olap/aggregate_func.h
+++ b/be/src/olap/aggregate_func.h
@@ -406,7 +406,8 @@ struct AggregateFuncTraits<OLAP_FIELD_AGGREGATION_HLL_UNION, OLAP_FIELD_TYPE_HLL
         auto* dst_slice = reinterpret_cast<Slice*>(dst->mutable_cell_ptr());
 
         dst_slice->size = sizeof(HyperLogLog);
-        dst_slice->data = (char*)new HyperLogLog(src_slice->data);;
+        char* mem = arena->Allocate(dst_slice->size);
+        dst_slice->data = (char*) new (mem) HyperLogLog(src_slice->data);
     }
 
     static void update(RowCursorCell* dst, const RowCursorCell& src, Arena* arena) {
@@ -435,7 +436,7 @@ struct AggregateFuncTraits<OLAP_FIELD_AGGREGATION_HLL_UNION, OLAP_FIELD_TYPE_HLL
         slice->data = arena->Allocate(HLL_COLUMN_DEFAULT_LEN);
         slice->size = hll->serialize(slice->data);
 
-        delete hll;
+        hll->~HyperLogLog();
     }
 };
 // when data load, after bitmap_init fucntion, bitmap_union column won't be null

--- a/be/src/olap/aggregate_func.h
+++ b/be/src/olap/aggregate_func.h
@@ -425,7 +425,7 @@ struct AggregateFuncTraits<OLAP_FIELD_AGGREGATION_HLL_UNION, OLAP_FIELD_TYPE_HLL
             auto* src_hll = reinterpret_cast<HyperLogLog*>(src_slice->data);
             dst_hll->merge(*src_hll);
 
-            delete src_hll;
+            src_hll->~HyperLogLog();
         }
     }
 

--- a/docs/documentation/cn/sql-reference/sql-statements/Data Definition/CREATE TABLE.md
+++ b/docs/documentation/cn/sql-reference/sql-statements/Data Definition/CREATE TABLE.md
@@ -32,7 +32,7 @@
                                 支持科学计数法
                             DOUBLE（12字节）
                                 支持科学计数法
-                            DECIMAL[(precision, scale)] (40字节)
+                            DECIMAL[(precision, scale)] (16字节)
                                 保证精度的小数类型。默认是 DECIMAL(10, 0)
                                 precision: 1 ~ 27
                                 scale: 0 ~ 9

--- a/docs/documentation/en/sql-reference/sql-statements/Data Definition/CREATE TABLE_EN.md
+++ b/docs/documentation/en/sql-reference/sql-statements/Data Definition/CREATE TABLE_EN.md
@@ -36,7 +36,7 @@ CREATE [EXTERNAL] TABLE [IF NOT EXISTS] [database.]table_name
             Support scientific notation
         DOUBLE(12 Bytes)
             Support scientific notation
-        DECIMAL[(precision, scale)] (40 Bytes)
+        DECIMAL[(precision, scale)] (16 Bytes)
             Default is DECIMAL(10, 0)
             precision: 1 ~ 27
             scale: 0 ~ 9


### PR DESCRIPTION
Should use arena to allocate mem for HyperLogLog column.

ISSUE: #1777 