### PR TITLE
Fix bug that dead lock may happen when drop table during alter table process

### DIFF
--- a/fe/src/main/java/org/apache/doris/alter/AlterCancelException.java
+++ b/fe/src/main/java/org/apache/doris/alter/AlterCancelException.java
@@ -1,0 +1,33 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.alter;
+
+import org.apache.doris.common.DdlException;
+
+/*
+ * This exception will be thrown when the alter job(v2) being cancelled due to
+ * internal error
+ */
+public class AlterCancelException extends DdlException {
+
+    private static final long serialVersionUID = 7648387358354279124L;
+
+    public AlterCancelException(String msg) {
+        super(msg);
+    }
+}

--- a/fe/src/main/java/org/apache/doris/alter/AlterJobV2.java
+++ b/fe/src/main/java/org/apache/doris/alter/AlterJobV2.java
@@ -131,7 +131,8 @@ public abstract class AlterJobV2 implements Writable {
             return;
         }
 
-        switch (jobState) {
+        try {
+            switch (jobState) {
             case PENDING:
                 runPendingJob();
                 break;
@@ -143,6 +144,9 @@ public abstract class AlterJobV2 implements Writable {
                 break;
             default:
                 break;
+            }
+        } catch (AlterCancelException e) {
+            cancelImpl(e.getMessage());
         }
     }
 
@@ -152,11 +156,11 @@ public abstract class AlterJobV2 implements Writable {
         }
     }
 
-    protected abstract void runPendingJob();
+    protected abstract void runPendingJob() throws AlterCancelException;
 
-    protected abstract void runWaitingTxnJob();
+    protected abstract void runWaitingTxnJob() throws AlterCancelException;
 
-    protected abstract void runRunningJob();
+    protected abstract void runRunningJob() throws AlterCancelException;
 
     protected abstract boolean cancelImpl(String errMsg);
 

--- a/fe/src/main/java/org/apache/doris/alter/RollupJobV2.java
+++ b/fe/src/main/java/org/apache/doris/alter/RollupJobV2.java
@@ -34,7 +34,6 @@ import org.apache.doris.catalog.TabletMeta;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.FeConstants;
 import org.apache.doris.common.MarkedCountDownLatch;
-import org.apache.doris.common.Status;
 import org.apache.doris.common.io.Text;
 import org.apache.doris.common.util.TimeUtils;
 import org.apache.doris.task.AgentBatchTask;
@@ -43,7 +42,6 @@ import org.apache.doris.task.AgentTaskExecutor;
 import org.apache.doris.task.AgentTaskQueue;
 import org.apache.doris.task.AlterReplicaTask;
 import org.apache.doris.task.CreateReplicaTask;
-import org.apache.doris.thrift.TStatusCode;
 import org.apache.doris.thrift.TStorageMedium;
 import org.apache.doris.thrift.TStorageType;
 import org.apache.doris.thrift.TTaskType;
@@ -143,20 +141,13 @@ public class RollupJobV2 extends AlterJobV2 {
      * 3. Get a new transaction id, then set job's state to WAITING_TXN
      */
     @Override
-    protected void runPendingJob() {
+    protected void runPendingJob() throws AlterCancelException {
         Preconditions.checkState(jobState == JobState.PENDING, jobState);
 
-        Status st = runPendingJobImpl();
-        if (!st.ok()) {
-            cancelImpl(st.getErrorMsg());
-        }
-    }
-
-    private Status runPendingJobImpl() {
         LOG.info("begin to send create rollup replica tasks. job: {}", jobId);
         Database db = Catalog.getCurrentCatalog().getDb(dbId);
         if (db == null) {
-            return new Status(TStatusCode.CANCELLED, "Database " + dbId + " does not exist");
+            throw new AlterCancelException("Database " + dbId + " does not exist");
         }
 
         // 1. create rollup replicas
@@ -173,7 +164,7 @@ public class RollupJobV2 extends AlterJobV2 {
         try {
             OlapTable tbl = (OlapTable) db.getTable(tableId);
             if (tbl == null) {
-                return new Status(TStatusCode.CANCELLED, "Table " + tableId + " does not exist");
+                throw new AlterCancelException("Table " + tableId + " does not exist");
             }
             Preconditions.checkState(tbl.getState() == OlapTableState.ROLLUP);
 
@@ -240,7 +231,7 @@ public class RollupJobV2 extends AlterJobV2 {
                     errMsg = "Error replicas:" + Joiner.on(", ").join(subList);
                 }
                 LOG.warn("failed to create rollup replicas for job: {}, {}", jobId, errMsg);
-                return new Status(TStatusCode.CANCELLED, "Create rollup replicas failed. Error: " + errMsg);
+                throw new AlterCancelException("Create rollup replicas failed. Error: " + errMsg);
             }
         }
 
@@ -250,7 +241,7 @@ public class RollupJobV2 extends AlterJobV2 {
         try {
             OlapTable tbl = (OlapTable) db.getTable(tableId);
             if (tbl == null) {
-                return new Status(TStatusCode.CANCELLED, "Table " + tableId + " does not exist");
+                throw new AlterCancelException("Table " + tableId + " does not exist");
             }
             Preconditions.checkState(tbl.getState() == OlapTableState.ROLLUP);
             addRollupIndexToCatalog(tbl);
@@ -264,7 +255,6 @@ public class RollupJobV2 extends AlterJobV2 {
         // write edit log
         Catalog.getCurrentCatalog().getEditLog().logAlterJob(this);
         LOG.info("transfer rollup job {} state to {}, watershed txn id: {}", jobId, this.jobState, watershedTxnId);
-        return Status.OK;
     }
 
     private void addRollupIndexToCatalog(OlapTable tbl) {
@@ -288,7 +278,7 @@ public class RollupJobV2 extends AlterJobV2 {
      * 3. Change job state to RUNNING.
      */
     @Override
-    protected void runWaitingTxnJob() {
+    protected void runWaitingTxnJob() throws AlterCancelException {
         Preconditions.checkState(jobState == JobState.WAITING_TXN, jobState);
 
         if (!isPreviousLoadFinished()) {
@@ -296,24 +286,17 @@ public class RollupJobV2 extends AlterJobV2 {
             return;
         }
 
-        Status st = runWaitingTxnJobImpl();
-        if (!st.ok()) {
-            cancelImpl(st.getErrorMsg());
-        }
-    }
-
-    private Status runWaitingTxnJobImpl() {
         LOG.info("previous transactions are all finished, begin to send rollup tasks. job: {}", jobId);
         Database db = Catalog.getCurrentCatalog().getDb(dbId);
         if (db == null) {
-            return new Status(TStatusCode.CANCELLED, "Databasee " + dbId + " does not exist");
+            throw new AlterCancelException("Databasee " + dbId + " does not exist");
         }
         
         db.readLock();
         try {
             OlapTable tbl = (OlapTable) db.getTable(tableId);
             if (tbl == null) {
-                return new Status(TStatusCode.CANCELLED, "Table " + tableId + " does not exist");
+                throw new AlterCancelException("Table " + tableId + " does not exist");
             }
             Preconditions.checkState(tbl.getState() == OlapTableState.ROLLUP);
             for (Map.Entry<Long, MaterializedIndex> entry : this.partitionIdToRollupIndex.entrySet()) {
@@ -353,7 +336,6 @@ public class RollupJobV2 extends AlterJobV2 {
 
         // DO NOT write edit log here, tasks will be send again if FE restart or master changed.
         LOG.info("transfer rollup job {} state to {}", jobId, this.jobState);
-        return Status.OK;
     }
 
     /*
@@ -364,28 +346,22 @@ public class RollupJobV2 extends AlterJobV2 {
      * 4. Set job'state as FINISHED.
      */
     @Override
-    protected void runRunningJob() {
+    protected void runRunningJob() throws AlterCancelException {
         Preconditions.checkState(jobState == JobState.RUNNING, jobState);
-        Status st = runRunningJobImpl();
-        if (!st.ok()) {
-            cancelImpl(st.getErrorMsg());
-        }
-    }
-
-    private Status runRunningJobImpl() {
+        
         // must check if db or table still exist first.
         // or if table is dropped, the tasks will never be finished,
         // and the job will be in RUNNING state forever.
         Database db = Catalog.getCurrentCatalog().getDb(dbId);
         if (db == null) {
-            return new Status(TStatusCode.CANCELLED, "Databasee " + dbId + " does not exist");
+            throw new AlterCancelException("Databasee " + dbId + " does not exist");
         }
 
         db.readLock();
         try {
             OlapTable tbl = (OlapTable) db.getTable(tableId);
             if (tbl == null) {
-                return new Status(TStatusCode.CANCELLED, "Table " + tableId + " does not exist");
+                throw new AlterCancelException("Table " + tableId + " does not exist");
             }
         } finally {
             db.readUnlock();
@@ -393,7 +369,7 @@ public class RollupJobV2 extends AlterJobV2 {
 
         if (!rollupBatchTask.isFinished()) {
             LOG.info("rollup tasks not finished. job: {}", jobId);
-            return Status.OK;
+            return;
         }
 
         /*
@@ -404,7 +380,7 @@ public class RollupJobV2 extends AlterJobV2 {
         try {
             OlapTable tbl = (OlapTable) db.getTable(tableId);
             if (tbl == null) {
-                return new Status(TStatusCode.CANCELLED, "Table " + tableId + " does not exist");
+                throw new AlterCancelException("Table " + tableId + " does not exist");
             }
             Preconditions.checkState(tbl.getState() == OlapTableState.ROLLUP);
             for (Map.Entry<Long, MaterializedIndex> entry : this.partitionIdToRollupIndex.entrySet()) {
@@ -432,8 +408,7 @@ public class RollupJobV2 extends AlterJobV2 {
                     if (healthyReplicaNum < expectReplicationNum / 2 + 1) {
                         LOG.warn("rollup tablet {} has few healthy replicas: {}, rollup job: {}",
                                 rollupTablet.getId(), replicas, jobId);
-                        return new Status(TStatusCode.CANCELLED,
-                                "rollup tablet " + rollupTablet.getId() + " has few healthy replicas");
+                        throw new AlterCancelException("rollup tablet " + rollupTablet.getId() + " has few healthy replicas");
                     }
                 } // end for tablets
             } // end for partitions
@@ -448,7 +423,6 @@ public class RollupJobV2 extends AlterJobV2 {
 
         Catalog.getCurrentCatalog().getEditLog().logAlterJob(this);
         LOG.info("rollup job finished: {}", jobId);
-        return Status.OK;
     }
 
     private void onFinished(OlapTable tbl) {

--- a/fe/src/main/java/org/apache/doris/alter/SchemaChangeJobV2.java
+++ b/fe/src/main/java/org/apache/doris/alter/SchemaChangeJobV2.java
@@ -34,6 +34,7 @@ import org.apache.doris.common.Config;
 import org.apache.doris.common.FeConstants;
 import org.apache.doris.common.MarkedCountDownLatch;
 import org.apache.doris.common.Pair;
+import org.apache.doris.common.Status;
 import org.apache.doris.common.io.Text;
 import org.apache.doris.common.util.TimeUtils;
 import org.apache.doris.task.AgentBatchTask;
@@ -42,6 +43,7 @@ import org.apache.doris.task.AgentTaskExecutor;
 import org.apache.doris.task.AgentTaskQueue;
 import org.apache.doris.task.AlterReplicaTask;
 import org.apache.doris.task.CreateReplicaTask;
+import org.apache.doris.thrift.TStatusCode;
 import org.apache.doris.thrift.TStorageMedium;
 import org.apache.doris.thrift.TStorageType;
 import org.apache.doris.thrift.TTaskType;
@@ -154,12 +156,17 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
     @Override
     protected void runPendingJob() {
         Preconditions.checkState(jobState == JobState.PENDING, jobState);
+        Status st = runPendingJobImpl();
+        if (!st.ok()) {
+            cancelImpl(st.getErrorMsg());
+        }
+    }
 
+    private Status runPendingJobImpl() {
         LOG.info("begin to send create replica tasks. job: {}", jobId);
         Database db = Catalog.getCurrentCatalog().getDb(dbId);
         if (db == null) {
-            cancelImpl("Databasee " + dbId + " does not exist");
-            return;
+            return new Status(TStatusCode.CANCELLED, "Databasee " + dbId + " does not exist");
         }
 
         // 1. create replicas
@@ -176,28 +183,26 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
         try {
             OlapTable tbl = (OlapTable) db.getTable(tableId);
             if (tbl == null) {
-                cancelImpl("Table " + tableId + " does not exist");
-                return;
-            }
+                return new Status(TStatusCode.CANCELLED, "Table " + tableId + " does not exist");
+            } 
             Preconditions.checkState(tbl.getState() == OlapTableState.SCHEMA_CHANGE);
-
             for (long partitionId : partitionIndexMap.rowKeySet()) {
                 Partition partition = tbl.getPartition(partitionId);
                 if (partition == null) {
                     continue;
                 }
                 TStorageMedium storageMedium = tbl.getPartitionInfo().getDataProperty(partitionId).getStorageMedium();
-
+                
                 Map<Long, MaterializedIndex> shadowIndexMap = partitionIndexMap.row(partitionId);
                 for (Map.Entry<Long, MaterializedIndex> entry : shadowIndexMap.entrySet()) {
                     long shadowIdxId = entry.getKey();
                     MaterializedIndex shadowIdx = entry.getValue();
-
+                    
                     short shadowShortKeyColumnCount = indexShortKeyMap.get(shadowIdxId);
                     List<Column> shadowSchema = indexSchemaMap.get(shadowIdxId);
                     int shadowSchemaHash = indexSchemaVersionAndHashMap.get(shadowIdxId).second;
                     int originSchemaHash = tbl.getSchemaHashByIndexId(indexIdMap.get(shadowIdxId));
-
+                    
                     for (Tablet shadowTablet : shadowIdx.getTablets()) {
                         long shadowTabletId = shadowTablet.getId();
                         List<Replica> shadowReplicas = shadowTablet.getReplicas();
@@ -211,7 +216,7 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
                                     tbl.getKeysType(), TStorageType.COLUMN, storageMedium,
                                     shadowSchema, bfColumns, bfFpp, countDownLatch);
                             createReplicaTask.setBaseTablet(partitionIndexTabletMap.get(partitionId, shadowIdxId).get(shadowTabletId), originSchemaHash);
-
+                            
                             batchTask.addTask(createReplicaTask);
                         } // end for rollupReplicas
                     } // end for rollupTablets
@@ -249,8 +254,7 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
                     errMsg = "Error replicas:" + Joiner.on(", ").join(subList);
                 }
                 LOG.warn("failed to create replicas for job: {}, {}", jobId, errMsg);
-                cancelImpl("Create replicas failed. Error: " + errMsg);
-                return;
+                return new Status(TStatusCode.CANCELLED, "Create replicas failed. Error: " + errMsg);
             }
         }
 
@@ -260,8 +264,7 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
         try {
             OlapTable tbl = (OlapTable) db.getTable(tableId);
             if (tbl == null) {
-                cancelImpl("Table " + tableId + " does not exist");
-                return;
+                return new Status(TStatusCode.CANCELLED, "Table " + tableId + " does not exist");
             }
             Preconditions.checkState(tbl.getState() == OlapTableState.SCHEMA_CHANGE);
             addShadowIndexToCatalog(tbl);
@@ -275,6 +278,7 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
         // write edit log
         Catalog.getCurrentCatalog().getEditLog().logAlterJob(this);
         LOG.info("transfer schema change job {} state to {}, watershed txn id: {}", jobId, this.jobState, watershedTxnId);
+        return Status.OK;
     }
 
     private void addShadowIndexToCatalog(OlapTable tbl) {
@@ -316,19 +320,24 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
             return;
         }
 
+        Status st = runWaitingTxnJobImpl();
+        if (!st.ok()) {
+            cancelImpl(st.getErrorMsg());
+        }
+    }
+
+    private Status runWaitingTxnJobImpl() {
         LOG.info("previous transactions are all finished, begin to send schema change tasks. job: {}", jobId);
         Database db = Catalog.getCurrentCatalog().getDb(dbId);
         if (db == null) {
-            cancelImpl("Databasee " + dbId + " does not exist");
-            return;
+            return new Status(TStatusCode.CANCELLED, "Databasee " + dbId + " does not exist");
         }
         
         db.readLock();
         try {
             OlapTable tbl = (OlapTable) db.getTable(tableId);
             if (tbl == null) {
-                cancelImpl("Table " + tableId + " does not exist");
-                return;
+                return new Status(TStatusCode.CANCELLED, "Table " + tableId + " does not exist");
             }
             Preconditions.checkState(tbl.getState() == OlapTableState.SCHEMA_CHANGE);
 
@@ -376,6 +385,7 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
 
         // DO NOT write edit log here, tasks will be send again if FE restart or master changed.
         LOG.info("transfer schema change job {} state to {}", jobId, this.jobState);
+        return Status.OK;
     }
 
     /*
@@ -388,21 +398,26 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
     @Override
     protected void runRunningJob() {
         Preconditions.checkState(jobState == JobState.RUNNING, jobState);
+        Status st = runRunningJobImpl();
+        if (!st.ok()) {
+            cancelImpl(st.getErrorMsg());
+        }
+    }
+
+    private Status runRunningJobImpl() {
         // must check if db or table still exist first.
         // or if table is dropped, the tasks will never be finished,
         // and the job will be in RUNNING state forever.
         Database db = Catalog.getCurrentCatalog().getDb(dbId);
         if (db == null) {
-            cancelImpl("Databasee " + dbId + " does not exist");
-            return;
+            return new Status(TStatusCode.CANCELLED, "Database " + dbId + " does not exist");
         }
 
         db.readLock();
         try {
             OlapTable tbl = (OlapTable) db.getTable(tableId);
             if (tbl == null) {
-                cancelImpl("Table " + tableId + " does not exist");
-                return;
+                return new Status(TStatusCode.CANCELLED, "Table " + tableId + " does not exist");
             }
         } finally {
             db.readUnlock();
@@ -410,7 +425,7 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
 
         if (!schemaChangeBatchTask.isFinished()) {
             LOG.info("schema change tasks not finished. job: {}", jobId);
-            return;
+            return Status.OK;
         }
 
         /*
@@ -421,8 +436,7 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
         try {
             OlapTable tbl = (OlapTable) db.getTable(tableId);
             if (tbl == null) {
-                cancelImpl("Table " + tableId + " does not exist");
-                return;
+                return new Status(TStatusCode.CANCELLED, "Table " + tableId + " does not exist");
             }
             Preconditions.checkState(tbl.getState() == OlapTableState.SCHEMA_CHANGE);
 
@@ -451,8 +465,8 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
                         if (healthyReplicaNum < expectReplicationNum / 2 + 1) {
                             LOG.warn("shadow tablet {} has few healthy replicas: {}, schema change job: {}",
                                     shadowTablet.getId(), replicas, jobId);
-                            cancelImpl("shadow tablet " + shadowTablet.getId() + " has few healthy replicas");
-                            return;
+                            return new Status(TStatusCode.CANCELLED,
+                                    "shadow tablet " + shadowTablet.getId() + " has few healthy replicas");
                         }
                     } // end for tablets
                 }
@@ -469,6 +483,7 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
 
         Catalog.getCurrentCatalog().getEditLog().logAlterJob(this);
         LOG.info("schema change job finished: {}", jobId);
+        return Status.OK;
     }
 
     private void onFinished(OlapTable tbl) {

--- a/fe/src/main/java/org/apache/doris/load/Load.java
+++ b/fe/src/main/java/org/apache/doris/load/Load.java
@@ -923,7 +923,7 @@ public class Load {
                      * eg:
                      * (A, C) SET (B = func(xx)) 
                      * ->
-                     * (A, C) SET (B = func(xx), __doris_shadow_B = func(xxx))
+                     * (A, C) SET (B = func(xx), __doris_shadow_B = func(xx))
                      */
                     ImportColumnDesc importColumnDesc = new ImportColumnDesc(column.getName(), mappingExpr);
                     columnExprs.add(importColumnDesc);


### PR DESCRIPTION
The cancel() function will try get database's write lock, while its caller may already
hold the database's read lock.