### PR TITLE
fix tablet meta tool command argument bug

### DIFF
--- a/docs/documentation/cn/administrator-guide/operation/tablet-meta-tool.md
+++ b/docs/documentation/cn/administrator-guide/operation/tablet-meta-tool.md
@@ -48,7 +48,7 @@ api：
 命令：
 
 ```
-./lib/meta_tool --root_path=/path/to/root_path --operation=get_header --tablet_id=xxx --schema_hash=xxx
+./lib/meta_tool --root_path=/path/to/root_path --operation=get_meta --tablet_id=xxx --schema_hash=xxx
 ```
 
 > root_path: 在 be.conf 中配置的对应的 root_path 路径。
@@ -62,7 +62,7 @@ api：
 命令：
 
 ```
-./lib/meta_tool --operation=load_header --root_path=/path/to/root_path --json_header_path=path
+./lib/meta_tool --operation=load_meta --root_path=/path/to/root_path --json_header_path=path
 ```
 
 ### 删除 header
@@ -72,7 +72,7 @@ api：
 命令:
 
 ```
-./lib/meta_tool --operation=delete_header --root_path=/path/to/root_path --tablet_id=xxx --schema_hash=xxx
+./lib/meta_tool --operation=delete_meta --root_path=/path/to/root_path --tablet_id=xxx --schema_hash=xxx
 ```
 
 ### 展示 pb 格式的 TabletMeta
@@ -82,7 +82,7 @@ api：
 命令：
 
 ```
-./lib/meta_tool --operation=show_header --root_path=/path/to/root_path --pb_header_path=path
+./lib/meta_tool --operation=show_meta --root_path=/path/to/root_path --pb_header_path=path
 ```
 
 

--- a/docs/documentation/en/administrator-guide/operation/tablet-meta-tool_EN.md
+++ b/docs/documentation/en/administrator-guide/operation/tablet-meta-tool_EN.md
@@ -48,7 +48,7 @@ Get Tablet Meta on a disk based on the meta\ tool tool.
 Order:
 
 ```
-./lib/meta_tool --root_path=/path/to/root_path --operation=get_header --tablet_id=xxx --schema_hash=xxx
+./lib/meta_tool --root_path=/path/to/root_path --operation=get_meta --tablet_id=xxx --schema_hash=xxx
 ```
 
 > root_path: The corresponding root_path path path configured in be.conf.
@@ -62,7 +62,7 @@ The function of loading header is provided to realize manual migration of tablet
 Order:
 
 ```
-./lib/meta_tool --operation=load_header --root_path=/path/to/root_path --json_header_path=path
+./lib/meta_tool --operation=load_meta --root_path=/path/to/root_path --json_header_path=path
 ```
 
 ### Delete header
@@ -72,7 +72,7 @@ In order to realize the function of deleting a tablet from a disk of a be.
 Order:
 
 ```
-./lib/meta_tool --operation=delete_header --root_path=/path/to/root_path --tablet_id=xxx --schema_hash=xxx`
+./lib/meta_tool --operation=delete_meta --root_path=/path/to/root_path --tablet_id=xxx --schema_hash=xxx`
 ```
 
 ### TabletMeta in Pb format
@@ -82,5 +82,5 @@ This command is to view the old file-based management PB format Tablet Meta, and
 Order:
 
 ```
-./lib/meta_tool --operation=show_header --root_path=/path/to/root_path --pb_header_path=path
+./lib/meta_tool --operation=show_meta --root_path=/path/to/root_path --pb_header_path=path
 ```


### PR DESCRIPTION
In tablet-meta-tool document, the commad to get a tablet meta as following will cause a invalid operation, I found the correct argument in code is get_meta.

`./lib/meta_tool --root_path=/path/to/root_path --operation=get_header --tablet_id=xxx --schema_hash=xxx`
