### PR TITLE
Bug-fix: Enable StringLiteral cast to Varchar

### DIFF
--- a/fe/src/main/java/org/apache/doris/analysis/AnalyticExpr.java
+++ b/fe/src/main/java/org/apache/doris/analysis/AnalyticExpr.java
@@ -17,10 +17,6 @@
 
 package org.apache.doris.analysis;
 
-import com.google.common.base.Joiner;
-import com.google.common.base.Objects;
-import com.google.common.base.Preconditions;
-import com.google.common.collect.Lists;
 import org.apache.doris.analysis.AnalyticWindow.Boundary;
 import org.apache.doris.analysis.AnalyticWindow.BoundaryType;
 import org.apache.doris.catalog.AggregateFunction;
@@ -30,6 +26,12 @@ import org.apache.doris.catalog.Type;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.TreeNode;
 import org.apache.doris.thrift.TExprNode;
+
+import com.google.common.base.Joiner;
+import com.google.common.base.Objects;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -285,6 +287,10 @@ public class AnalyticExpr extends Expr {
         Expr val = getFnCall().getChild(2);
 
         if (!(val instanceof LiteralExpr)) {
+            return;
+        }
+
+        if (!getFnCall().getChild(0).getType().getPrimitiveType().isNumericType()) {
             return;
         }
 

--- a/fe/src/main/java/org/apache/doris/analysis/StringLiteral.java
+++ b/fe/src/main/java/org/apache/doris/analysis/StringLiteral.java
@@ -28,6 +28,7 @@ import org.apache.doris.thrift.TExprNodeType;
 import org.apache.doris.thrift.TStringLiteral;
 
 import com.google.common.base.Preconditions;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -202,6 +203,11 @@ public class StringLiteral extends LiteralExpr {
             } catch (AnalysisException e) {
                 // pass;
             }
+        } else if (targetType.equals(type)) {
+            return this;
+        } else if (targetType.isStringType()) {
+            type = targetType;
+            return this;
         }
         return super.uncheckedCastTo(targetType);
     }


### PR DESCRIPTION
For issue: https://github.com/apache/incubator-doris/issues/1842
StringLiteral could be cast to VARCHAR or CHAR.
The default value of lead and lag function could be 'String' when the column type is CHAR or VARCHAR.