### PR TITLE
fix memory leak in wrapper field #1852

### DIFF
--- a/be/src/olap/field.h
+++ b/be/src/olap/field.h
@@ -156,6 +156,16 @@ public:
         return _type_info->direct_copy(dst->mutable_cell_ptr(), src.cell_ptr());
     }
 
+    // Copy source content to destination cell directly.
+    // For string type, this function assume that destination has
+    // enough space and copy source content into destination without
+    // memory allocation.
+    template<typename DstCellType>
+    void direct_copy(DstCellType* dst, const char* src) const {
+        dst->set_is_null(false);
+        return _type_info->direct_copy(dst->mutable_cell_ptr(), src);
+    }
+
     // deep copy source cell' content to destination cell.
     // For string type, this will allocate data form pool,
     // and copy srouce's conetent.

--- a/be/src/olap/field.h
+++ b/be/src/olap/field.h
@@ -156,16 +156,6 @@ public:
         return _type_info->direct_copy(dst->mutable_cell_ptr(), src.cell_ptr());
     }
 
-    // Copy source content to destination cell directly.
-    // For string type, this function assume that destination has
-    // enough space and copy source content into destination without
-    // memory allocation.
-    template<typename DstCellType>
-    void direct_copy(DstCellType* dst, const char* src) const {
-        dst->set_is_null(false);
-        return _type_info->direct_copy(dst->mutable_cell_ptr(), src);
-    }
-
     // deep copy source cell' content to destination cell.
     // For string type, this will allocate data form pool,
     // and copy srouce's conetent.

--- a/be/src/olap/types.h
+++ b/be/src/olap/types.h
@@ -524,6 +524,9 @@ struct FieldTypeTraits<OLAP_FIELD_TYPE_CHAR> : public BaseFieldtypeTraits<OLAP_F
              * inputed by user may be greater than fixed length.
              */
             slice->size = value_len;
+        } else {
+            // append \0 to the tail
+            memset(slice->data + value_len, 0, slice->size - value_len);
         }
         return OLAP_SUCCESS;
     }

--- a/be/src/olap/wrapper_field.cpp
+++ b/be/src/olap/wrapper_field.cpp
@@ -79,7 +79,6 @@ WrapperField::WrapperField(Field* rep, size_t variable_len, bool is_string_type)
         slice->size = _var_length;
         _string_content.reset(new char[slice->size]);
         slice->data = _string_content.get();
-        memset(slice->data, 0, slice->size);
     }
 }
 

--- a/be/src/olap/wrapper_field.cpp
+++ b/be/src/olap/wrapper_field.cpp
@@ -77,7 +77,8 @@ WrapperField::WrapperField(Field* rep, size_t variable_len, bool is_string_type)
         _var_length = variable_len > 0 ? variable_len : DEFAULT_STRING_LENGTH;
         Slice* slice = reinterpret_cast<Slice*>(buf);
         slice->size = _var_length;
-        slice->data = _arena.Allocate(_var_length);
+        _string_content.reset(new char[slice->size]);
+        slice->data = _string_content.get();
         memset(slice->data, 0, slice->size);
     }
 }

--- a/be/src/olap/wrapper_field.h
+++ b/be/src/olap/wrapper_field.h
@@ -98,21 +98,6 @@ public:
         _rep->direct_copy(this, *field);
     }
 
-    void copy(const char* value) {
-        set_is_null(false);
-        if (_is_string_type) {
-            const Slice* src = reinterpret_cast<const Slice*>(value);
-            if (src->size > _var_length) {
-                _string_content.reset(new char[src->size]);
-                _var_length = src->size;
-                Slice* slice = reinterpret_cast<Slice*>(cell_ptr());
-                slice->size = _var_length;
-                slice->data = _string_content.get();
-            }
-        }
-        _rep->direct_copy(this, value);
-    }
-
 private:
     Field* _rep = nullptr;
     bool _is_string_type;

--- a/be/src/olap/wrapper_field.h
+++ b/be/src/olap/wrapper_field.h
@@ -53,7 +53,8 @@ public:
             if (value_string.size() > _var_length) {
                 Slice* slice = reinterpret_cast<Slice*>(cell_ptr());
                 slice->size = value_string.size();
-                slice->data = _arena.Allocate(slice->size);
+                _string_content.reset(new char[slice->size]);
+                slice->data = _string_content.get();
                 memset(slice->data, 0, slice->size);
             }
         }
@@ -112,7 +113,10 @@ private:
     //include fixed and variable length and null bytes
     size_t _length;
     size_t _var_length;
+    // used for copy
     Arena _arena;
+    // memory for string type field
+    std::unique_ptr<char> _string_content;
 };
 
 }

--- a/be/src/olap/wrapper_field.h
+++ b/be/src/olap/wrapper_field.h
@@ -56,7 +56,6 @@ public:
                 _var_length = slice->size;
                 _string_content.reset(new char[slice->size]);
                 slice->data = _string_content.get();
-                memset(slice->data, 0, slice->size);
             }
         }
         return _rep->from_string(_field_buf + 1, value_string);

--- a/be/src/olap/wrapper_field.h
+++ b/be/src/olap/wrapper_field.h
@@ -109,7 +109,6 @@ public:
                 Slice* slice = reinterpret_cast<Slice*>(cell_ptr());
                 slice->size = _var_length;
                 slice->data = _string_content.get();
-                memset(slice->data, 0, slice->size);
             }
         }
         _rep->direct_copy(this, value);


### PR DESCRIPTION
Use unique_ptr + new to replace arena to allocate and manage memory for string type fields.