### PR TITLE
Avoid SerDe for aggregation query with object pool

### DIFF
--- a/be/src/common/object_pool.h
+++ b/be/src/common/object_pool.h
@@ -56,6 +56,13 @@ public:
         _objects.clear();
     }
 
+    // Absorb all objects from src pool
+    // Note: This method is not thread safe
+    void acquire_data(ObjectPool* src) {
+        _objects.insert(_objects.end(), src->_objects.begin(), src->_objects.end());
+        src->_objects.clear();
+    }
+
 private:
     struct GenericElement {
         virtual ~GenericElement() {}

--- a/be/src/exec/exec_node.cpp
+++ b/be/src/exec/exec_node.cpp
@@ -530,6 +530,25 @@ void ExecNode::collect_scan_nodes(vector<ExecNode*>* nodes) {
     collect_nodes(TPlanNodeType::ES_HTTP_SCAN_NODE, nodes);
 }
 
+void ExecNode::try_do_aggregate_serde_improve() {
+    std::vector<ExecNode*> agg_node;
+    collect_nodes(TPlanNodeType::AGGREGATION_NODE, &agg_node);
+    if (agg_node.size() != 1) {
+        return;
+    }
+
+    if (agg_node[0]->_children.size() != 1) {
+        return;
+    }
+
+    if (agg_node[0]->_children[0]->type() != TPlanNodeType::OLAP_SCAN_NODE) {
+        return;
+    }
+
+    OlapScanNode* scan_node = static_cast<OlapScanNode*>(agg_node[0]->_children[0]);
+    scan_node->set_no_agg_finalize();
+}
+
 void ExecNode::init_runtime_profile(const std::string& name) {
     std::stringstream ss;
     ss << name << " (id=" << _id << ")";

--- a/be/src/exec/exec_node.h
+++ b/be/src/exec/exec_node.h
@@ -159,6 +159,12 @@ public:
     // Collect all scan node types.
     void collect_scan_nodes(std::vector<ExecNode*>* nodes);
 
+    // When the agg node is the scan node direct parent,
+    // we directly return agg object from scan node to agg node,
+    // and don't serialize the agg object.
+    // This improve is cautious, we ensure the correctness firstly.
+    void try_do_aggregate_serde_improve();
+
     typedef bool (*EvalConjunctsFn)(ExprContext* const* ctxs, int num_ctxs, TupleRow* row);
     // Evaluate exprs over row.  Returns true if all exprs return true.
     // TODO: This doesn't use the vector<Expr*> signature because I haven't figured

--- a/be/src/exec/olap_scan_node.cpp
+++ b/be/src/exec/olap_scan_node.cpp
@@ -150,7 +150,6 @@ Status OlapScanNode::prepare(RuntimeState* state) {
     _rows_pushed_cond_filtered_counter =
         ADD_COUNTER(_runtime_profile, "RowsPushedCondFiltered", TUnit::UNIT);
     _init_counter(state);
-
     _tuple_desc = state->desc_tbl().get_tuple_descriptor(_tuple_id);
     if (_tuple_desc == NULL) {
         // TODO: make sure we print all available diagnostic output to our error log
@@ -696,7 +695,7 @@ Status OlapScanNode::start_scan_thread(RuntimeState* state) {
                 scanner_ranges.push_back((*ranges)[i].get());
             }
             OlapScanner* scanner = new OlapScanner(
-                state, this, _olap_scan_node.is_preaggregation, *scan_range, scanner_ranges);
+                state, this, _olap_scan_node.is_preaggregation, _need_agg_finalize, *scan_range, scanner_ranges);
             _scanner_pool->add(scanner);
             _olap_scanners.push_back(scanner);
         }

--- a/be/src/exec/olap_scan_node.h
+++ b/be/src/exec/olap_scan_node.h
@@ -58,7 +58,9 @@ public:
     Status collect_query_statistics(QueryStatistics* statistics) override;
     virtual Status close(RuntimeState* state);
     virtual Status set_scan_ranges(const std::vector<TScanRangeParams>& scan_ranges);
-
+    inline void set_no_agg_finalize() {
+        _need_agg_finalize = false;
+    }
 protected:
     typedef struct {
         Tuple* tuple;
@@ -241,6 +243,8 @@ private:
     int64_t _buffered_bytes;
     int64_t _running_thread;
     EvalConjunctsFn _eval_conjuncts_fn;
+
+    bool _need_agg_finalize = true;
 
     // Counters
     RuntimeProfile::Counter* _io_timer = nullptr;

--- a/be/src/exec/olap_scanner.h
+++ b/be/src/exec/olap_scanner.h
@@ -53,6 +53,7 @@ public:
         RuntimeState* runtime_state,
         OlapScanNode* parent,
         bool aggregation,
+        bool need_agg_finalize,
         const TPaloScanRange& scan_range,
         const std::vector<OlapScanRange*>& key_ranges);
 
@@ -107,6 +108,7 @@ private:
     int _id;
     bool _is_open;
     bool _aggregation;
+    bool _need_agg_finalize = true;
     bool _has_update_counter = false;
 
     Status _ctor_status;

--- a/be/src/exprs/aggregate_functions.cpp
+++ b/be/src/exprs/aggregate_functions.cpp
@@ -1191,7 +1191,7 @@ void AggregateFunctions::hll_union_agg_update(FunctionContext* ctx,
     }
     DCHECK(!dst->is_null);
 
-    dst->agg_parse_and_cal(src);
+    dst->agg_parse_and_cal(ctx, src);
     return ;
 }
 

--- a/be/src/exprs/hll_function.cpp
+++ b/be/src/exprs/hll_function.cpp
@@ -64,10 +64,15 @@ void HllFunctions::hll_update(FunctionContext *, const T &src, StringVal* dst) {
         dst_hll->update(hash_value);
     }
 }
+
 void HllFunctions::hll_merge(FunctionContext*, const StringVal &src, StringVal* dst) {
-    HyperLogLog src_hll((uint8_t*)src.ptr);
     auto* dst_hll = reinterpret_cast<HyperLogLog*>(dst->ptr);
-    dst_hll->merge(src_hll);
+    // zero size means the src input is a agg object
+    if (src.len == 0) {
+        dst_hll->merge(*reinterpret_cast<HyperLogLog*>(src.ptr));
+    } else {
+        dst_hll->merge(HyperLogLog(src.ptr));
+    }
 }
 
 BigIntVal HllFunctions::hll_finalize(FunctionContext*, const StringVal &src) {

--- a/be/src/olap/field.h
+++ b/be/src/olap/field.h
@@ -66,8 +66,8 @@ public:
         _agg_info->finalize(dst, arena);
     }
 
-    virtual void consume(RowCursorCell* dst, const char* src, bool src_null, Arena* arena) const {
-        _agg_info->init(dst, src, src_null, arena);
+    virtual void consume(RowCursorCell* dst, const char* src, bool src_null, Arena* arena, ObjectPool* agg_pool) const {
+        _agg_info->init(dst, src, src_null, arena, agg_pool);
     }
 
     // todo(kks): Unify AggregateInfo::init method and Field::agg_init method
@@ -76,7 +76,7 @@ public:
     // This functionn differs copy functionn in that if this filed
     // contain aggregate information, this functionn will initialize
     // destination in aggregate format, and update with srouce content.
-    virtual void agg_init(RowCursorCell* dst, const RowCursorCell& src, Arena* arena) const {
+    virtual void agg_init(RowCursorCell* dst, const RowCursorCell& src, Arena* arena, ObjectPool* agg_pool) const {
         direct_copy(dst, src);
     }
 
@@ -344,7 +344,7 @@ public:
     }
 
     // the char field is especial, which need the _length info when consume raw data
-    void consume(RowCursorCell* dst, const char* src, bool src_null, Arena* arena) const override {
+    void consume(RowCursorCell* dst, const char* src, bool src_null, Arena* arena, ObjectPool* agg_pool) const override {
         dst->set_is_null(src_null);
         if (src_null) {
             return;
@@ -403,8 +403,8 @@ public:
     }
 
     // bitmap storage data always not null
-    void agg_init(RowCursorCell* dst, const RowCursorCell& src, Arena* arena) const override {
-        _agg_info->init(dst, (const char*)src.cell_ptr(), false, arena);
+    void agg_init(RowCursorCell* dst, const RowCursorCell& src, Arena* arena, ObjectPool* agg_pool) const override {
+        _agg_info->init(dst, (const char*)src.cell_ptr(), false, arena, agg_pool);
     }
 
     char* allocate_memory(char* cell_ptr, char* variable_ptr) const override {
@@ -424,8 +424,8 @@ public:
     }
 
     // Hll storage data always not null
-    void agg_init(RowCursorCell* dst, const RowCursorCell& src, Arena* arena) const override {
-        _agg_info->init(dst, (const char*)src.cell_ptr(), false, arena);
+    void agg_init(RowCursorCell* dst, const RowCursorCell& src, Arena* arena, ObjectPool* agg_pool) const override {
+        _agg_info->init(dst, (const char*)src.cell_ptr(), false, arena, agg_pool);
     }
 
     char* allocate_memory(char* cell_ptr, char* variable_ptr) const override {

--- a/be/src/olap/memtable.cpp
+++ b/be/src/olap/memtable.cpp
@@ -68,7 +68,7 @@ void MemTable::insert(Tuple* tuple) {
 
         bool is_null = tuple->is_null(slot->null_indicator_offset());
         void* value = tuple->get_slot(slot->tuple_offset());
-        _schema->column(i)->consume(&cell, (const char *)value, is_null, _skip_list->arena());
+        _schema->column(i)->consume(&cell, (const char *)value, is_null, _skip_list->arena(), &_agg_object_pool);
     }
 
     bool overwritten = false;

--- a/be/src/olap/memtable.h
+++ b/be/src/olap/memtable.h
@@ -18,6 +18,7 @@
 #ifndef DORIS_BE_SRC_OLAP_MEMTABLE_H
 #define DORIS_BE_SRC_OLAP_MEMTABLE_H
 
+#include "common/object_pool.h"
 #include "olap/schema.h"
 #include "olap/skiplist.h"
 #include "runtime/tuple.h"
@@ -57,6 +58,7 @@ private:
 
     RowCursorComparator _row_comparator;
     Arena _arena;
+    ObjectPool _agg_object_pool;
 
     typedef SkipList<char*, RowCursorComparator> Table;
     char* _tuple_buf;

--- a/be/src/olap/merger.cpp
+++ b/be/src/olap/merger.cpp
@@ -44,14 +44,14 @@ OLAPStatus Merger::merge_rowsets(TabletSharedPtr tablet,
     RETURN_NOT_OK_LOG(row_cursor.init(tablet->tablet_schema()),
                  "failed to init row cursor when merging rowsets of tablet " + tablet->full_name());
     row_cursor.allocate_memory_for_string_type(tablet->tablet_schema());
-
     // The following procedure would last for long time, half of one day, etc.
     int64_t output_rows = 0;
     while (true) {
         Arena arena;
+        ObjectPool objectPool;
         bool eof = false;
         // Read one row into row_cursor
-        RETURN_NOT_OK_LOG(reader.next_row_with_aggregation(&row_cursor, &arena, &eof),
+        RETURN_NOT_OK_LOG(reader.next_row_with_aggregation(&row_cursor, &arena, &objectPool, &eof),
                           "failed to read next row when merging rowsets of tablet " + tablet->full_name());
         if (eof) {
             break;

--- a/be/src/olap/reader.cpp
+++ b/be/src/olap/reader.cpp
@@ -345,7 +345,7 @@ OLAPStatus Reader::init(const ReaderParams& read_params) {
     return OLAP_SUCCESS;
 }
 
-OLAPStatus Reader::_dup_key_next_row(RowCursor* row_cursor, Arena* arena, bool* eof) {
+OLAPStatus Reader::_dup_key_next_row(RowCursor* row_cursor, Arena* arena, ObjectPool* agg_pool, bool* eof) {
     if (UNLIKELY(_next_key == nullptr)) {
         *eof = true;
         return OLAP_SUCCESS;
@@ -360,12 +360,12 @@ OLAPStatus Reader::_dup_key_next_row(RowCursor* row_cursor, Arena* arena, bool* 
     return OLAP_SUCCESS;
 }
 
-OLAPStatus Reader::_agg_key_next_row(RowCursor* row_cursor, Arena* arena, bool* eof) {
+OLAPStatus Reader::_agg_key_next_row(RowCursor* row_cursor, Arena* arena, ObjectPool* agg_pool, bool* eof) {
     if (UNLIKELY(_next_key == nullptr)) {
         *eof = true;
         return OLAP_SUCCESS;
     }
-    init_row_with_others(row_cursor, *_next_key, arena);
+    init_row_with_others(row_cursor, *_next_key, arena, agg_pool);
     int64_t merged_count = 0;
     do {
         auto res = _collect_iter->next(&_next_key, &_next_delete_flag);
@@ -389,11 +389,15 @@ OLAPStatus Reader::_agg_key_next_row(RowCursor* row_cursor, Arena* arena, bool* 
         ++merged_count;
     } while (true);
     _merged_rows += merged_count;
-    agg_finalize_row(_value_cids, row_cursor, arena);
+    // For agg query, we don't need finalize agg object and directly pass agg object to agg node
+    if (_need_agg_finalize) {
+        agg_finalize_row(_value_cids, row_cursor, arena);
+    }
+
     return OLAP_SUCCESS;
 }
 
-OLAPStatus Reader::_unique_key_next_row(RowCursor* row_cursor, Arena* arena, bool* eof) {
+OLAPStatus Reader::_unique_key_next_row(RowCursor* row_cursor, Arena* arena, ObjectPool* agg_pool, bool* eof) {
     *eof = false;
     bool cur_delete_flag = false;
     do {
@@ -403,7 +407,7 @@ OLAPStatus Reader::_unique_key_next_row(RowCursor* row_cursor, Arena* arena, boo
         }
     
         cur_delete_flag = _next_delete_flag;
-        init_row_with_others(row_cursor, *_next_key, arena);
+        init_row_with_others(row_cursor, *_next_key, arena, agg_pool);
 
         int64_t merged_count = 0;
         while (NULL != _next_key) {
@@ -564,6 +568,7 @@ OLAPStatus Reader::_init_params(const ReaderParams& read_params) {
     read_params.check_validation();
     OLAPStatus res = OLAP_SUCCESS;
     _aggregation = read_params.aggregation;
+    _need_agg_finalize = read_params.need_agg_finalize;
     _reader_type = read_params.reader_type;
     _tablet = read_params.tablet;
     _version = read_params.version;

--- a/be/src/olap/reader.h
+++ b/be/src/olap/reader.h
@@ -53,6 +53,7 @@ struct ReaderParams {
     TabletSharedPtr tablet;
     ReaderType reader_type;
     bool aggregation;
+    bool need_agg_finalize = true;
     Version version;
     // possible values are "gt", "ge", "eq"
     std::string range;
@@ -125,8 +126,8 @@ public:
     // Return OLAP_SUCCESS and set `*eof` to false when next row is read into `row_cursor`.
     // Return OLAP_SUCCESS and set `*eof` to true when no more rows can be read.
     // Return others when unexpected error happens.
-    OLAPStatus next_row_with_aggregation(RowCursor *row_cursor, Arena* arena, bool *eof) {
-        return (this->*_next_row_func)(row_cursor, arena, eof);
+    OLAPStatus next_row_with_aggregation(RowCursor *row_cursor, Arena* arena, ObjectPool* agg_pool, bool *eof) {
+        return (this->*_next_row_func)(row_cursor, arena, agg_pool, eof);
     }
 
     uint64_t merged_rows() const {
@@ -200,9 +201,9 @@ private:
 
     OLAPStatus _init_load_bf_columns(const ReaderParams& read_params);
 
-    OLAPStatus _dup_key_next_row(RowCursor* row_cursor, Arena* arena, bool* eof);
-    OLAPStatus _agg_key_next_row(RowCursor* row_cursor, Arena* arena, bool* eof);
-    OLAPStatus _unique_key_next_row(RowCursor* row_cursor, Arena* arena, bool* eof);
+    OLAPStatus _dup_key_next_row(RowCursor* row_cursor, Arena* arena, ObjectPool* agg_pool, bool* eof);
+    OLAPStatus _agg_key_next_row(RowCursor* row_cursor, Arena* arena, ObjectPool* agg_pool, bool* eof);
+    OLAPStatus _unique_key_next_row(RowCursor* row_cursor, Arena* arena, ObjectPool* agg_pool, bool* eof);
 
     TabletSharedPtr tablet() { return _tablet; }
 
@@ -233,9 +234,11 @@ private:
 
     DeleteHandler _delete_handler;
 
-    OLAPStatus (Reader::*_next_row_func)(RowCursor* row_cursor, Arena* arena, bool* eof) = nullptr;
+    OLAPStatus (Reader::*_next_row_func)(RowCursor* row_cursor, Arena* arena, ObjectPool* agg_pool, bool* eof) = nullptr;
 
     bool _aggregation;
+    // for agg query, we don't need to finalize when scan agg object data
+    bool _need_agg_finalize = true;
     bool _version_locked;
     ReaderType _reader_type;
     bool _next_delete_flag;

--- a/be/src/olap/row.h
+++ b/be/src/olap/row.h
@@ -107,10 +107,10 @@ int index_compare_row(const LhsRowType& lhs, const RhsRowType& rhs) {
 // function will first initialize destination column and then update with source column
 // value.
 template<typename DstRowType, typename SrcRowType>
-void init_row_with_others(DstRowType* dst, const SrcRowType& src, Arena* arena) {
+void init_row_with_others(DstRowType* dst, const SrcRowType& src, Arena* arena, ObjectPool* agg_pool) {
     for (auto cid : dst->schema()->column_ids()) {
         auto dst_cell = dst->cell(cid);
-        dst->schema()->column(cid)->agg_init(&dst_cell, src.cell(cid), arena);
+        dst->schema()->column(cid)->agg_init(&dst_cell, src.cell(cid), arena, agg_pool);
     }
 }
 

--- a/be/src/runtime/plan_fragment_executor.cpp
+++ b/be/src/runtime/plan_fragment_executor.cpp
@@ -173,6 +173,8 @@ Status PlanFragmentExecutor::prepare(const TExecPlanFragmentParams& request) {
     VLOG(1) << "scan_nodes.size()=" << scan_nodes.size();
     VLOG(1) << "params.per_node_scan_ranges.size()=" << params.per_node_scan_ranges.size();
 
+    _plan->try_do_aggregate_serde_improve();
+
     for (int i = 0; i < scan_nodes.size(); ++i) {
         ScanNode* scan_node = static_cast<ScanNode*>(scan_nodes[i]);
         const std::vector<TScanRangeParams>& scan_ranges =

--- a/be/src/udf/udf.cpp
+++ b/be/src/udf/udf.cpp
@@ -471,9 +471,9 @@ void HllVal::agg_parse_and_cal(FunctionContext* ctx, const HllVal& other) {
     // zero size means the src input is a HyperLogLog object
     if (other.len == 0) {
         auto* hll = reinterpret_cast<doris::HyperLogLog*>(other.ptr);
-        uint8_t* ptr = ctx->allocate(doris::HLL_COLUMN_DEFAULT_LEN);
-        int len = hll->serialize(ptr);
-        resolver.init((char*)ptr, len);
+        uint8_t* other_ptr = ctx->allocate(doris::HLL_COLUMN_DEFAULT_LEN);
+        int other_len = hll->serialize(ptr);
+        resolver.init((char*)other_ptr, other_len);
     } else {
         resolver.init((char*)other.ptr, other.len);
     }

--- a/be/src/udf/udf.h
+++ b/be/src/udf/udf.h
@@ -777,7 +777,7 @@ struct HllVal : public StringVal {
 
     void init(FunctionContext* ctx);
 
-    void agg_parse_and_cal(const HllVal &other);
+    void agg_parse_and_cal(FunctionContext* ctx, const HllVal& other);
 
     void agg_merge(const HllVal &other);
 };

--- a/be/src/util/arena.h
+++ b/be/src/util/arena.h
@@ -34,6 +34,11 @@ public:
         return memory_usage_.load(std::memory_order_relaxed);
     }
 
+    // For the object wasn't allocated from Arena, but need to
+    // collect and control the object memory usage.
+    void track_memory(size_t bytes) {
+        memory_usage_.store(MemoryUsage() + bytes,std::memory_order_relaxed);
+    }
 private:
     char* AllocateFallback(size_t bytes);
     char* AllocateNewBlock(size_t block_bytes);

--- a/be/test/olap/aggregate_func_test.cpp
+++ b/be/test/olap/aggregate_func_test.cpp
@@ -19,6 +19,7 @@
 
 #include <gtest/gtest.h>
 
+#include "common/object_pool.h"
 #include "olap/decimal12.h"
 #include "olap/uint24.h"
 
@@ -37,6 +38,7 @@ void test_min() {
     char buf[64];
 
     Arena arena;
+    ObjectPool agg_object_pool;
     const AggregateInfo* agg = get_aggregate_info(OLAP_FIELD_AGGREGATION_MIN, field_type);
 
     RowCursorCell dst(buf);
@@ -44,7 +46,7 @@ void test_min() {
     {
         char val_buf[16];
         *(bool*)val_buf = true;
-        agg->init(&dst, val_buf, true, &arena);
+        agg->init(&dst, val_buf, true, &arena, &agg_object_pool);
         ASSERT_TRUE(*(bool*)(buf));
     }
     // 100
@@ -110,6 +112,7 @@ void test_max() {
     char buf[64];
 
     Arena arena;
+    ObjectPool agg_object_pool;
     const AggregateInfo* agg = get_aggregate_info(OLAP_FIELD_AGGREGATION_MAX, field_type);
 
     RowCursorCell dst(buf);
@@ -117,7 +120,7 @@ void test_max() {
     {
         char val_buf[16];
         *(bool*)val_buf = true;
-        agg->init(&dst, val_buf, true, &arena);
+        agg->init(&dst, val_buf, true, &arena, &agg_object_pool);
         ASSERT_TRUE(*(bool*)(buf));
     }
     // 100
@@ -183,13 +186,14 @@ void test_sum() {
     RowCursorCell dst(buf);
 
     Arena arena;
+    ObjectPool agg_object_pool;
     const AggregateInfo* agg = get_aggregate_info(OLAP_FIELD_AGGREGATION_SUM, field_type);
 
     // null
     {
         char val_buf[16];
         *(bool*)val_buf = true;
-        agg->init(&dst, val_buf, true, &arena);
+        agg->init(&dst, val_buf, true, &arena, &agg_object_pool);
         ASSERT_TRUE(*(bool*)(buf));
     }
     // 100
@@ -255,13 +259,14 @@ void test_replace() {
     RowCursorCell dst(buf);
 
     Arena arena;
+    ObjectPool agg_object_pool;
     const AggregateInfo* agg = get_aggregate_info(OLAP_FIELD_AGGREGATION_REPLACE, field_type);
 
     // null
     {
         char val_buf[16];
         *(bool*)val_buf = true;
-        agg->init(&dst, val_buf, true, &arena);
+        agg->init(&dst, val_buf, true, &arena, &agg_object_pool);
         ASSERT_TRUE(*(bool*)(buf));
     }
     // 100
@@ -312,6 +317,7 @@ void test_replace_string() {
     dst_slice->size = 0;
 
     Arena arena;
+    ObjectPool agg_object_pool;
     const AggregateInfo* agg = get_aggregate_info(OLAP_FIELD_AGGREGATION_REPLACE, field_type);
 
     char src[string_field_size];
@@ -320,7 +326,7 @@ void test_replace_string() {
     // null
     {
         src_cell.set_null();
-        agg->init(&dst_cell, (const char*)src_slice, true, &arena);
+        agg->init(&dst_cell, (const char*)src_slice, true, &arena, &agg_object_pool);
         ASSERT_TRUE(dst_cell.is_null());
     }
     // "12345"

--- a/be/test/olap/row_cursor_test.cpp
+++ b/be/test/olap/row_cursor_test.cpp
@@ -17,6 +17,7 @@
 
 #include <gtest/gtest.h>
 
+#include "common/object_pool.h"
 #include "olap/row_cursor.h"
 #include "olap/tablet_schema.h"
 #include "olap/row.h"
@@ -470,7 +471,8 @@ TEST_F(TestRowCursor, AggregateWithoutNull) {
     left.set_field_content(4, reinterpret_cast<char*>(&l_decimal), _mem_pool.get());
     left.set_field_content(5, reinterpret_cast<char*>(&l_varchar), _mem_pool.get());
 
-    init_row_with_others(&row, left, arena.get());
+    ObjectPool agg_object_pool;
+    init_row_with_others(&row, left, arena.get(), &agg_object_pool);
 
     RowCursor right;
     res = right.init(tablet_schema);
@@ -528,7 +530,8 @@ TEST_F(TestRowCursor, AggregateWithNull) {
     left.set_null(4);
     left.set_field_content(5, reinterpret_cast<char*>(&l_varchar), _mem_pool.get());
 
-    init_row_with_others(&row, left, arena.get());
+    ObjectPool agg_object_pool;
+    init_row_with_others(&row, left, arena.get(), &agg_object_pool);
 
     RowCursor right;
     res = right.init(tablet_schema);


### PR DESCRIPTION
For https://github.com/apache/incubator-doris/pull/1610  "avoid serialize and deserialize from Scannode to Aggnode".

For aggregation query, we directly pass agg object from scan node to Agg node and avoid unnecessary serialize and deserialize.


