### PR TITLE
add buckets limit: buckets > 0 while add partition

### DIFF
--- a/fe/src/main/java/org/apache/doris/catalog/Catalog.java
+++ b/fe/src/main/java/org/apache/doris/catalog/Catalog.java
@@ -2869,12 +2869,16 @@ public class Catalog {
                 }
 
                 if (distributionInfo.getType() == DistributionInfoType.HASH) {
-                    List<Column> newDistriCols = ((HashDistributionInfo) distributionInfo).getDistributionColumns();
+                    HashDistributionInfo hashDistributionInfo = (HashDistributionInfo) distributionInfo;
+                    List<Column> newDistriCols = hashDistributionInfo.getDistributionColumns();
                     List<Column> defaultDistriCols = ((HashDistributionInfo) defaultDistributionInfo)
                             .getDistributionColumns();
                     if (!newDistriCols.equals(defaultDistriCols)) {
                         throw new DdlException("Cannot assign hash distribution with different distribution cols. "
                                 + "default is: " + defaultDistriCols);
+                    }
+                    if (hashDistributionInfo.getBucketNum() <= 0) {
+                        throw new DdlException("Cannot assign hash distribution buckets less than 1");
                     }
                 }
             } else {


### PR DESCRIPTION
doris support buckets = 0 while execute add partition statment like below:
![image](https://user-images.githubusercontent.com/55084968/65496587-4c485380-deeb-11e9-9d66-cf2a6b2a606e.png)

then the be core down when loading data into the partition:
look at line 590, partition->num_buckets=0 and then core down
![image](https://user-images.githubusercontent.com/55084968/65496994-0d66cd80-deec-11e9-991a-0917b9a0cb2e.png)

core like below:
![image](https://user-images.githubusercontent.com/55084968/65497632-1efca500-deed-11e9-8f0c-ea59ec90defd.png)

so add bucket limit, and not support set buckets=0 while add partition:
![image](https://user-images.githubusercontent.com/55084968/65496735-96313980-deeb-11e9-989e-2a95122798e5.png)
