### PR TITLE
Fix bug that load statistic in show load result is incorrect

### DIFF
--- a/fe/src/main/java/org/apache/doris/load/loadv2/BrokerLoadJob.java
+++ b/fe/src/main/java/org/apache/doris/load/loadv2/BrokerLoadJob.java
@@ -63,7 +63,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
-import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * There are 3 steps in BrokerLoadJob: BrokerPendingTask, LoadLoadingTask, CommitAndPublishTxn.
@@ -239,13 +238,11 @@ public class BrokerLoadJob extends LoadJob {
                 // retry task
                 idToTasks.remove(loadTask.getSignature());
                 if (loadTask instanceof LoadLoadingTask) {
-                    loadStatistic.numScannedRowsMap.remove(((LoadLoadingTask) loadTask).getLoadId());
+                    loadStatistic.removeLoad(((LoadLoadingTask) loadTask).getLoadId());
                 }
                 loadTask.updateRetryInfo();
                 idToTasks.put(loadTask.getSignature(), loadTask);
-                if (loadTask instanceof LoadLoadingTask) {
-                    loadStatistic.numScannedRowsMap.put(((LoadLoadingTask) loadTask).getLoadId(), new AtomicLong(0));
-                }
+                // load id will be added to loadStatistic when executing this task
                 Catalog.getCurrentCatalog().getLoadTaskScheduler().submit(loadTask);
                 return;
             }
@@ -365,7 +362,7 @@ public class BrokerLoadJob extends LoadJob {
                 // idToTasks contains previous LoadPendingTasks, so idToTasks is just used to save all tasks.
                 // use newLoadingTasks to save new created loading tasks and submit them later.
                 newLoadingTasks.add(task);
-                loadStatistic.numScannedRowsMap.put(loadId, new AtomicLong(0));
+                // load id will be added to loadStatistic when executing this task
 
                 // save all related tables and rollups in transaction state
                 TransactionState txnState = Catalog.getCurrentGlobalTransactionMgr().getTransactionState(transactionId);

--- a/fe/src/main/java/org/apache/doris/load/loadv2/LoadManager.java
+++ b/fe/src/main/java/org/apache/doris/load/loadv2/LoadManager.java
@@ -560,10 +560,17 @@ public class LoadManager implements Writable{
         return false;
     }
 
-    public void updateJobScannedRows(Long jobId, TUniqueId loadId, long scannedRows) {
+    public void initJobScannedRows(Long jobId, TUniqueId loadId, Set<TUniqueId> fragmentIds) {
         LoadJob job = idToLoadJob.get(jobId);
         if (job != null) {
-            job.updateScannedRows(loadId, scannedRows);
+            job.initScannedRows(loadId, fragmentIds);
+        }
+    }
+
+    public void updateJobScannedRows(Long jobId, TUniqueId loadId, TUniqueId fragmentId, long scannedRows) {
+        LoadJob job = idToLoadJob.get(jobId);
+        if (job != null) {
+            job.updateScannedRows(loadId, fragmentId, scannedRows);
         }
     }
 

--- a/fe/src/main/java/org/apache/doris/qe/Coordinator.java
+++ b/fe/src/main/java/org/apache/doris/qe/Coordinator.java
@@ -400,10 +400,11 @@ public class Coordinator {
                     toBrpcHost(topParams.instanceExecParams.get(0).host),
                     queryOptions.query_timeout * 1000);
         } else {
-            // This is a insert statement.
+            // This is a load process.
             this.queryOptions.setIs_report_success(true);
             deltaUrls = Lists.newArrayList();
             loadCounters = Maps.newHashMap();
+            Catalog.getCurrentCatalog().getLoadManager().initJobScannedRows(jobId, queryId, instanceIds);
         }
 
         // to keep things simple, make async Cancel() calls wait until plan fragment
@@ -1191,7 +1192,8 @@ public class Coordinator {
         }
 
         if (params.isSetLoaded_rows()) {
-            Catalog.getCurrentCatalog().getLoadManager().updateJobScannedRows(jobId, params.query_id, params.loaded_rows);
+            Catalog.getCurrentCatalog().getLoadManager().updateJobScannedRows(
+                    jobId, params.query_id, params.fragment_instance_id, params.loaded_rows);
         }
 
         return;


### PR DESCRIPTION
Each load job has several load tasks, and each task is a query plan
with serveral plan fragments. Each plan fragment report query profile
independently.
So we need to collect each plan fragment's report, separately.

ISSUE #1879 