### PR TITLE
Use mem_pool replace arena first step

### DIFF
--- a/be/src/olap/aggregate_func.h
+++ b/be/src/olap/aggregate_func.h
@@ -24,14 +24,15 @@
 #include "runtime/datetime_value.h"
 #include "runtime/decimalv2_value.h"
 #include "runtime/string_value.h"
-#include "util/arena.h"
+#include "runtime/mem_pool.h"
+#include "runtime/mem_tracker.h"
 #include "util/bitmap.h"
 
 namespace doris {
 
-using AggInitFunc = void (*)(RowCursorCell* dst, const char* src, bool src_null, Arena* arena, ObjectPool* agg_pool);
-using AggUpdateFunc = void (*)(RowCursorCell* dst, const RowCursorCell& src, Arena* arena);
-using AggFinalizeFunc = void (*)(RowCursorCell* src, Arena* arena);
+using AggInitFunc = void (*)(RowCursorCell* dst, const char* src, bool src_null, MemPool* mem_pool, ObjectPool* agg_pool);
+using AggUpdateFunc = void (*)(RowCursorCell* dst, const RowCursorCell& src, MemPool* mem_pool);
+using AggFinalizeFunc = void (*)(RowCursorCell* src, MemPool* mem_pool);
 
 // This class contains information about aggregate operation.
 class AggregateInfo {
@@ -44,8 +45,8 @@ public:
     // Memory Note: For plain memory can be allocated from arena, whose lifetime
     // will last util finalize function is called. Memory allocated from heap should
     // be freed in finalize functioin to avoid memory leak.
-    inline void init(RowCursorCell* dst, const char* src, bool src_null, Arena* arena, ObjectPool* agg_pool) const {
-        _init_fn(dst, src, src_null, arena, agg_pool);
+    inline void init(RowCursorCell* dst, const char* src, bool src_null, MemPool* mem_pool, ObjectPool* agg_pool) const {
+        _init_fn(dst, src, src_null, mem_pool, agg_pool);
     }
 
     // Update aggregated intermediate data. Data stored in engine is aggregated.
@@ -55,8 +56,8 @@ public:
     // will be added to sum.
 
     // Memory Note: Same with init function.
-    inline void update(RowCursorCell* dst, const RowCursorCell& src, Arena* arena) const {
-        _update_fn(dst, src, arena);
+    inline void update(RowCursorCell* dst, const RowCursorCell& src, MemPool* mem_pool) const {
+        _update_fn(dst, src, mem_pool);
     }
 
     // Finalize function convert intermediate context into final format. For example:
@@ -67,16 +68,16 @@ public:
     // Memory Note: All heap memory allocated in init and update function should be freed
     // before this function return. Memory allocated from arena will be still available
     // and will be freed by client.
-    inline void finalize(RowCursorCell* src, Arena* arena) const {
-        _finalize_fn(src, arena);
+    inline void finalize(RowCursorCell* src, MemPool* mem_pool) const {
+        _finalize_fn(src, mem_pool);
     }
 
     FieldAggregationMethod agg_method() const { return _agg_method; }
 
 private:
-    void (*_init_fn)(RowCursorCell* dst, const char* src, bool src_null, Arena* arena, ObjectPool* agg_pool);
-    void (*_update_fn)(RowCursorCell* dst, const RowCursorCell& src, Arena* arena);
-    void (*_finalize_fn)(RowCursorCell* src, Arena* arena);
+    void (*_init_fn)(RowCursorCell* dst, const char* src, bool src_null, MemPool* mem_pool, ObjectPool* agg_pool);
+    void (*_update_fn)(RowCursorCell* dst, const RowCursorCell& src, MemPool* mem_pool);
+    void (*_finalize_fn)(RowCursorCell* src, MemPool* mem_pool);
 
     friend class AggregateFuncResolver;
 
@@ -88,22 +89,22 @@ private:
 
 template<FieldType field_type>
 struct BaseAggregateFuncs {
-    static void init(RowCursorCell* dst, const char* src, bool src_null, Arena* arena, ObjectPool* agg_pool) {
+    static void init(RowCursorCell* dst, const char* src, bool src_null, MemPool* mem_pool, ObjectPool* agg_pool) {
         dst->set_is_null(src_null);
         if (src_null) {
             return;
         }
 
         const TypeInfo* _type_info = get_type_info(field_type);
-        _type_info->deep_copy_with_arena(dst->mutable_cell_ptr(), src, arena);
+        _type_info->deep_copy(dst->mutable_cell_ptr(), src, mem_pool);
     }
 
     // Default update do nothing.
-    static void update(RowCursorCell* dst, const RowCursorCell& src, Arena* arena) {
+    static void update(RowCursorCell* dst, const RowCursorCell& src, MemPool* mem_pool) {
     }
 
     // Default finalize do nothing.
-    static void finalize(RowCursorCell* src, Arena* arena) {
+    static void finalize(RowCursorCell* src, MemPool* mem_pool) {
     }
 };
 
@@ -114,7 +115,7 @@ struct AggregateFuncTraits : public BaseAggregateFuncs<field_type> {
 template <>
 struct AggregateFuncTraits<OLAP_FIELD_AGGREGATION_NONE, OLAP_FIELD_TYPE_DECIMAL> :
         public BaseAggregateFuncs<OLAP_FIELD_TYPE_DECIMAL>  {
-    static void init(RowCursorCell* dst, const char* src, bool src_null, Arena* arena, ObjectPool* agg_pool) {
+    static void init(RowCursorCell* dst, const char* src, bool src_null, MemPool* mem_pool, ObjectPool* agg_pool) {
         dst->set_is_null(src_null);
         if (src_null) {
             return;
@@ -130,7 +131,7 @@ struct AggregateFuncTraits<OLAP_FIELD_AGGREGATION_NONE, OLAP_FIELD_TYPE_DECIMAL>
 template <>
 struct AggregateFuncTraits<OLAP_FIELD_AGGREGATION_NONE, OLAP_FIELD_TYPE_DATETIME> :
         public BaseAggregateFuncs<OLAP_FIELD_TYPE_DECIMAL> {
-    static void init(RowCursorCell* dst, const char* src, bool src_null, Arena* arena, ObjectPool* agg_pool) {
+    static void init(RowCursorCell* dst, const char* src, bool src_null, MemPool* mem_pool, ObjectPool* agg_pool) {
         dst->set_is_null(src_null);
         if (src_null) {
             return;
@@ -145,7 +146,7 @@ struct AggregateFuncTraits<OLAP_FIELD_AGGREGATION_NONE, OLAP_FIELD_TYPE_DATETIME
 template <>
 struct AggregateFuncTraits<OLAP_FIELD_AGGREGATION_NONE, OLAP_FIELD_TYPE_DATE> :
         public BaseAggregateFuncs<OLAP_FIELD_TYPE_DECIMAL> {
-    static void init(RowCursorCell* dst, const char* src, bool src_null, Arena* arena, ObjectPool* agg_pool) {
+    static void init(RowCursorCell* dst, const char* src, bool src_null, MemPool* mem_pool, ObjectPool* agg_pool) {
         dst->set_is_null(src_null);
         if (src_null) {
             return;
@@ -162,7 +163,7 @@ struct AggregateFuncTraits<OLAP_FIELD_AGGREGATION_MIN, field_type> :
         public AggregateFuncTraits<OLAP_FIELD_AGGREGATION_NONE, field_type> {
     typedef typename FieldTypeTraits<field_type>::CppType CppType;
 
-    static void update(RowCursorCell* dst, const RowCursorCell& src, Arena* arena) {
+    static void update(RowCursorCell* dst, const RowCursorCell& src, MemPool* mem_pool) {
         bool src_null = src.is_null();
         // ignore null value
         if (src_null) return;
@@ -182,7 +183,7 @@ struct AggregateFuncTraits<OLAP_FIELD_AGGREGATION_MIN, OLAP_FIELD_TYPE_LARGEINT>
         public BaseAggregateFuncs<OLAP_FIELD_TYPE_LARGEINT> {
     typedef typename FieldTypeTraits<OLAP_FIELD_TYPE_LARGEINT>::CppType CppType;
 
-    static void update(RowCursorCell* dst, const RowCursorCell& src, Arena* arena) {
+    static void update(RowCursorCell* dst, const RowCursorCell& src, MemPool* mem_pool) {
         bool src_null = src.is_null();
         // ignore null value
         if (src_null) return;
@@ -207,7 +208,7 @@ struct AggregateFuncTraits<OLAP_FIELD_AGGREGATION_MIN, OLAP_FIELD_TYPE_LARGEINT>
 template <>
 struct AggregateFuncTraits<OLAP_FIELD_AGGREGATION_MIN, OLAP_FIELD_TYPE_VARCHAR> :
         public AggregateFuncTraits<OLAP_FIELD_AGGREGATION_NONE, OLAP_FIELD_TYPE_VARCHAR> {
-    static void update(RowCursorCell* dst, const RowCursorCell& src, Arena* arena) {
+    static void update(RowCursorCell* dst, const RowCursorCell& src, MemPool* mem_pool) {
         bool src_null = src.is_null();
         // ignore null value
         if (src_null) return;
@@ -217,11 +218,11 @@ struct AggregateFuncTraits<OLAP_FIELD_AGGREGATION_MIN, OLAP_FIELD_TYPE_VARCHAR> 
         Slice* dst_slice = reinterpret_cast<Slice*>(dst->mutable_cell_ptr());
         const Slice* src_slice = reinterpret_cast<const Slice*>(src.cell_ptr());
         if (dst_null || src_slice->compare(*dst_slice) < 0) {
-            if (arena == nullptr || (!dst_null && dst_slice->size >= src_slice->size)) {
+            if (mem_pool == nullptr || (!dst_null && dst_slice->size >= src_slice->size)) {
                 memory_copy(dst_slice->data, src_slice->data, src_slice->size);
                 dst_slice->size = src_slice->size;
             } else {
-                dst_slice->data = arena->Allocate(src_slice->size);
+                dst_slice->data = (char*)mem_pool->allocate(src_slice->size);
                 memory_copy(dst_slice->data, src_slice->data, src_slice->size);
                 dst_slice->size = src_slice->size;
             }
@@ -239,7 +240,7 @@ struct AggregateFuncTraits<OLAP_FIELD_AGGREGATION_MAX, field_type> :
         public AggregateFuncTraits<OLAP_FIELD_AGGREGATION_NONE, field_type> {
     typedef typename FieldTypeTraits<field_type>::CppType CppType;
 
-    static void update(RowCursorCell* dst, const RowCursorCell& src, Arena* arena) {
+    static void update(RowCursorCell* dst, const RowCursorCell& src, MemPool* mem_pool) {
         bool src_null = src.is_null();
         // ignore null value
         if (src_null) return;
@@ -259,7 +260,7 @@ struct AggregateFuncTraits<OLAP_FIELD_AGGREGATION_MAX, OLAP_FIELD_TYPE_LARGEINT>
         public BaseAggregateFuncs<OLAP_FIELD_TYPE_LARGEINT> {
     typedef typename FieldTypeTraits<OLAP_FIELD_TYPE_LARGEINT>::CppType CppType;
 
-    static void update(RowCursorCell* dst, const RowCursorCell& src, Arena* arena) {
+    static void update(RowCursorCell* dst, const RowCursorCell& src, MemPool* mem_pool) {
         bool src_null = src.is_null();
         // ignore null value
         if (src_null) return;
@@ -278,7 +279,7 @@ struct AggregateFuncTraits<OLAP_FIELD_AGGREGATION_MAX, OLAP_FIELD_TYPE_LARGEINT>
 template <>
 struct AggregateFuncTraits<OLAP_FIELD_AGGREGATION_MAX, OLAP_FIELD_TYPE_VARCHAR> :
         public AggregateFuncTraits<OLAP_FIELD_AGGREGATION_NONE, OLAP_FIELD_TYPE_VARCHAR> {
-    static void update(RowCursorCell* dst, const RowCursorCell& src, Arena* arena) {
+    static void update(RowCursorCell* dst, const RowCursorCell& src, MemPool* mem_pool) {
         bool src_null = src.is_null();
         // ignore null value
         if (src_null) return;
@@ -288,11 +289,11 @@ struct AggregateFuncTraits<OLAP_FIELD_AGGREGATION_MAX, OLAP_FIELD_TYPE_VARCHAR> 
         Slice* dst_slice = reinterpret_cast<Slice*>(dst->mutable_cell_ptr());
         const Slice* src_slice = reinterpret_cast<const Slice*>(src.cell_ptr());
         if (dst_null || src_slice->compare(*dst_slice) > 0) {
-            if (arena == nullptr || (!dst_null && dst_slice->size >= src_slice->size)) {
+            if (mem_pool == nullptr || (!dst_null && dst_slice->size >= src_slice->size)) {
                 memory_copy(dst_slice->data, src_slice->data, src_slice->size);
                 dst_slice->size = src_slice->size;
             } else {
-                dst_slice->data = arena->Allocate(src_slice->size);
+                dst_slice->data = (char*)mem_pool->allocate(src_slice->size);
                 memory_copy(dst_slice->data, src_slice->data, src_slice->size);
                 dst_slice->size = src_slice->size;
             }
@@ -310,7 +311,7 @@ struct AggregateFuncTraits<OLAP_FIELD_AGGREGATION_SUM, field_type> :
         public AggregateFuncTraits<OLAP_FIELD_AGGREGATION_NONE, field_type>  {
     typedef typename FieldTypeTraits<field_type>::CppType CppType;
 
-    static void update(RowCursorCell* dst, const RowCursorCell& src, Arena* arena) {
+    static void update(RowCursorCell* dst, const RowCursorCell& src, MemPool* mem_pool) {
         bool src_null = src.is_null();
         if (src_null) {
             return;
@@ -332,7 +333,7 @@ struct AggregateFuncTraits<OLAP_FIELD_AGGREGATION_SUM, OLAP_FIELD_TYPE_LARGEINT>
         public BaseAggregateFuncs<OLAP_FIELD_TYPE_LARGEINT> {
     typedef typename FieldTypeTraits<OLAP_FIELD_TYPE_LARGEINT>::CppType CppType;
 
-    static void update(RowCursorCell* dst, const RowCursorCell& src, Arena* arena) {
+    static void update(RowCursorCell* dst, const RowCursorCell& src, MemPool* mem_pool) {
         bool src_null = src.is_null();
         if (src_null) {
             return;
@@ -357,7 +358,7 @@ struct AggregateFuncTraits<OLAP_FIELD_AGGREGATION_REPLACE, field_type> :
         public AggregateFuncTraits<OLAP_FIELD_AGGREGATION_NONE, field_type>  {
     typedef typename FieldTypeTraits<field_type>::CppType CppType;
 
-    static void update(RowCursorCell* dst, const RowCursorCell& src, Arena* arena) {
+    static void update(RowCursorCell* dst, const RowCursorCell& src, MemPool* mem_pool) {
         bool src_null = src.is_null();
         dst->set_is_null(src_null);
         if (!src_null) {
@@ -369,7 +370,7 @@ struct AggregateFuncTraits<OLAP_FIELD_AGGREGATION_REPLACE, field_type> :
 template <>
 struct AggregateFuncTraits<OLAP_FIELD_AGGREGATION_REPLACE, OLAP_FIELD_TYPE_VARCHAR> :
         public AggregateFuncTraits<OLAP_FIELD_AGGREGATION_NONE, OLAP_FIELD_TYPE_VARCHAR> {
-    static void update(RowCursorCell* dst, const RowCursorCell& src, Arena* arena) {
+    static void update(RowCursorCell* dst, const RowCursorCell& src, MemPool* mem_pool) {
         bool dst_null = dst->is_null();
         bool src_null = src.is_null();
         dst->set_is_null(src_null);
@@ -379,11 +380,11 @@ struct AggregateFuncTraits<OLAP_FIELD_AGGREGATION_REPLACE, OLAP_FIELD_TYPE_VARCH
 
         Slice* dst_slice = reinterpret_cast<Slice*>(dst->mutable_cell_ptr());
         const Slice* src_slice = reinterpret_cast<const Slice*>(src.cell_ptr());
-        if (arena == nullptr || (!dst_null && dst_slice->size >= src_slice->size)) {
+        if (mem_pool == nullptr || (!dst_null && dst_slice->size >= src_slice->size)) {
             memory_copy(dst_slice->data, src_slice->data, src_slice->size);
             dst_slice->size = src_slice->size;
         } else {
-            dst_slice->data = arena->Allocate(src_slice->size);
+            dst_slice->data = (char*)mem_pool->allocate(src_slice->size);
             memory_copy(dst_slice->data, src_slice->data, src_slice->size);
             dst_slice->size = src_slice->size;
         }
@@ -399,7 +400,7 @@ struct AggregateFuncTraits<OLAP_FIELD_AGGREGATION_REPLACE, OLAP_FIELD_TYPE_CHAR>
 // so when init, update hll, the src is not null
 template <>
 struct AggregateFuncTraits<OLAP_FIELD_AGGREGATION_HLL_UNION, OLAP_FIELD_TYPE_HLL> {
-    static void init(RowCursorCell* dst, const char* src, bool src_null, Arena* arena, ObjectPool* agg_pool) {
+    static void init(RowCursorCell* dst, const char* src, bool src_null, MemPool* mem_pool, ObjectPool* agg_pool) {
         DCHECK_EQ(src_null, false);
         dst->set_not_null();
 
@@ -411,12 +412,12 @@ struct AggregateFuncTraits<OLAP_FIELD_AGGREGATION_HLL_UNION, OLAP_FIELD_TYPE_HLL
         auto* hll = new HyperLogLog((const uint8_t*) src_slice->data);
         dst_slice->data = reinterpret_cast<char*>(hll);
 
-        arena->track_memory(sizeof(HyperLogLog));
+        mem_pool->mem_tracker()->consume(sizeof(HyperLogLog));
 
         agg_pool->add(hll);
     }
 
-    static void update(RowCursorCell* dst, const RowCursorCell& src, Arena* arena) {
+    static void update(RowCursorCell* dst, const RowCursorCell& src, MemPool* mem_pool) {
         DCHECK_EQ(src.is_null(), false);
 
         auto* dst_slice = reinterpret_cast<Slice*>(dst->mutable_cell_ptr());
@@ -424,7 +425,7 @@ struct AggregateFuncTraits<OLAP_FIELD_AGGREGATION_HLL_UNION, OLAP_FIELD_TYPE_HLL
         auto* dst_hll = reinterpret_cast<HyperLogLog*>(dst_slice->data);
 
         // fixme(kks): trick here, need improve
-        if (arena == nullptr) { // for query
+        if (mem_pool == nullptr) { // for query
             HyperLogLog src_hll((const uint8_t*)src_slice->data);
             dst_hll->merge(src_hll);
         } else {   // for stream load
@@ -434,11 +435,11 @@ struct AggregateFuncTraits<OLAP_FIELD_AGGREGATION_HLL_UNION, OLAP_FIELD_TYPE_HLL
     }
 
     // The HLL object memory will be released by ObjectPool
-    static void finalize(RowCursorCell* src, Arena* arena) {
+    static void finalize(RowCursorCell* src, MemPool* mem_pool) {
         auto *slice = reinterpret_cast<Slice*>(src->mutable_cell_ptr());
         auto *hll = reinterpret_cast<HyperLogLog*>(slice->data);
 
-        slice->data = arena->Allocate(HLL_COLUMN_DEFAULT_LEN);
+        slice->data = (char*)mem_pool->allocate(HLL_COLUMN_DEFAULT_LEN);
         slice->size = hll->serialize((uint8_t*)slice->data);
     }
 };
@@ -446,7 +447,7 @@ struct AggregateFuncTraits<OLAP_FIELD_AGGREGATION_HLL_UNION, OLAP_FIELD_TYPE_HLL
 // so when init, update bitmap, the src is not null
 template <>
 struct AggregateFuncTraits<OLAP_FIELD_AGGREGATION_BITMAP_UNION, OLAP_FIELD_TYPE_VARCHAR> {
-    static void init(RowCursorCell* dst, const char* src, bool src_null, Arena* arena, ObjectPool* agg_pool) {
+    static void init(RowCursorCell* dst, const char* src, bool src_null, MemPool* mem_pool, ObjectPool* agg_pool) {
         DCHECK_EQ(src_null, false);
         dst->set_not_null();
         auto* src_slice = reinterpret_cast<const Slice*>(src);
@@ -457,12 +458,12 @@ struct AggregateFuncTraits<OLAP_FIELD_AGGREGATION_BITMAP_UNION, OLAP_FIELD_TYPE_
         auto* bitmap = new RoaringBitmap(src_slice->data);
         dst_slice->data = (char*) bitmap;
 
-        arena->track_memory(sizeof(RoaringBitmap));
+        mem_pool->mem_tracker()->consume(sizeof(RoaringBitmap));
 
         agg_pool->add(bitmap);
     }
 
-    static void update(RowCursorCell* dst, const RowCursorCell& src, Arena* arena) {
+    static void update(RowCursorCell* dst, const RowCursorCell& src, MemPool* mem_pool) {
         DCHECK_EQ(src.is_null(), false);
 
         auto* dst_slice = reinterpret_cast<Slice*>(dst->mutable_cell_ptr());
@@ -470,7 +471,7 @@ struct AggregateFuncTraits<OLAP_FIELD_AGGREGATION_BITMAP_UNION, OLAP_FIELD_TYPE_
         auto* dst_bitmap = reinterpret_cast<RoaringBitmap*>(dst_slice->data);
 
         // fixme(kks): trick here, need improve
-        if (arena == nullptr) { // for query
+        if (mem_pool == nullptr) { // for query
             RoaringBitmap src_bitmap = RoaringBitmap(src_slice->data);
             dst_bitmap->merge(src_bitmap);
         } else {   // for stream load
@@ -480,12 +481,12 @@ struct AggregateFuncTraits<OLAP_FIELD_AGGREGATION_BITMAP_UNION, OLAP_FIELD_TYPE_
     }
 
     // The RoaringBitmap object memory will be released by ObjectPool
-    static void finalize(RowCursorCell* src, Arena *arena) {
+    static void finalize(RowCursorCell* src, MemPool* mem_pool) {
         auto *slice = reinterpret_cast<Slice*>(src->mutable_cell_ptr());
         auto *bitmap = reinterpret_cast<RoaringBitmap*>(slice->data);
 
         slice->size = bitmap->size();
-        slice->data = arena->Allocate(slice->size);
+        slice->data = (char*)mem_pool->allocate(slice->size);
         bitmap->serialize(slice->data);
     }
 };

--- a/be/src/olap/field.h
+++ b/be/src/olap/field.h
@@ -58,16 +58,16 @@ public:
     inline void set_to_max(char* buf) const { return _type_info->set_to_max(buf); }
     inline void set_to_min(char* buf) const { return _type_info->set_to_min(buf); }
 
-    inline void agg_update(RowCursorCell* dest, const RowCursorCell& src, Arena* arena = nullptr) const {
-        _agg_info->update(dest, src, arena);
+    inline void agg_update(RowCursorCell* dest, const RowCursorCell& src, MemPool* mem_pool = nullptr) const {
+        _agg_info->update(dest, src, mem_pool);
     }
 
-    inline void agg_finalize(RowCursorCell* dst, Arena* arena) const {
-        _agg_info->finalize(dst, arena);
+    inline void agg_finalize(RowCursorCell* dst, MemPool* mem_pool) const {
+        _agg_info->finalize(dst, mem_pool);
     }
 
-    virtual void consume(RowCursorCell* dst, const char* src, bool src_null, Arena* arena, ObjectPool* agg_pool) const {
-        _agg_info->init(dst, src, src_null, arena, agg_pool);
+    virtual void consume(RowCursorCell* dst, const char* src, bool src_null, MemPool* mem_pool, ObjectPool* agg_pool) const {
+        _agg_info->init(dst, src, src_null, mem_pool, agg_pool);
     }
 
     // todo(kks): Unify AggregateInfo::init method and Field::agg_init method
@@ -76,7 +76,7 @@ public:
     // This functionn differs copy functionn in that if this filed
     // contain aggregate information, this functionn will initialize
     // destination in aggregate format, and update with srouce content.
-    virtual void agg_init(RowCursorCell* dst, const RowCursorCell& src, Arena* arena, ObjectPool* agg_pool) const {
+    virtual void agg_init(RowCursorCell* dst, const RowCursorCell& src, MemPool* mem_pool, ObjectPool* agg_pool) const {
         direct_copy(dst, src);
     }
 
@@ -344,7 +344,7 @@ public:
     }
 
     // the char field is especial, which need the _length info when consume raw data
-    void consume(RowCursorCell* dst, const char* src, bool src_null, Arena* arena, ObjectPool* agg_pool) const override {
+    void consume(RowCursorCell* dst, const char* src, bool src_null, MemPool* mem_pool, ObjectPool* agg_pool) const override {
         dst->set_is_null(src_null);
         if (src_null) {
             return;
@@ -353,7 +353,7 @@ public:
         auto* value = reinterpret_cast<const StringValue*>(src);
         auto* dest_slice = (Slice*)(dst->mutable_cell_ptr());
         dest_slice->size = _length;
-        dest_slice->data = arena->Allocate(dest_slice->size);
+        dest_slice->data = (char*)mem_pool->allocate(dest_slice->size);
         memcpy(dest_slice->data, value->ptr, value->len);
         memset(dest_slice->data + value->len, 0, dest_slice->size - value->len);
     }
@@ -403,8 +403,8 @@ public:
     }
 
     // bitmap storage data always not null
-    void agg_init(RowCursorCell* dst, const RowCursorCell& src, Arena* arena, ObjectPool* agg_pool) const override {
-        _agg_info->init(dst, (const char*)src.cell_ptr(), false, arena, agg_pool);
+    void agg_init(RowCursorCell* dst, const RowCursorCell& src, MemPool* mem_pool, ObjectPool* agg_pool) const override {
+        _agg_info->init(dst, (const char*)src.cell_ptr(), false, mem_pool, agg_pool);
     }
 
     char* allocate_memory(char* cell_ptr, char* variable_ptr) const override {
@@ -424,8 +424,8 @@ public:
     }
 
     // Hll storage data always not null
-    void agg_init(RowCursorCell* dst, const RowCursorCell& src, Arena* arena, ObjectPool* agg_pool) const override {
-        _agg_info->init(dst, (const char*)src.cell_ptr(), false, arena, agg_pool);
+    void agg_init(RowCursorCell* dst, const RowCursorCell& src, MemPool* mem_pool, ObjectPool* agg_pool) const override {
+        _agg_info->init(dst, (const char*)src.cell_ptr(), false, mem_pool, agg_pool);
     }
 
     char* allocate_memory(char* cell_ptr, char* variable_ptr) const override {

--- a/be/src/olap/memtable.cpp
+++ b/be/src/olap/memtable.cpp
@@ -38,8 +38,10 @@ MemTable::MemTable(int64_t tablet_id, Schema* schema, const TabletSchema* tablet
       _row_comparator(_schema),
       _rowset_writer(rowset_writer) {
     _schema_size = _schema->schema_size();
-    _tuple_buf = _arena.Allocate(_schema_size);
-    _skip_list = new Table(_row_comparator, &_arena);
+    _tracker.reset(new MemTracker(config::write_buffer_size * 2));
+    _mem_pool.reset(new MemPool(_tracker.get()));
+    _tuple_buf = _mem_pool->allocate(_schema_size);
+    _skip_list = new Table(_row_comparator, _mem_pool.get());
 }
 
 MemTable::~MemTable() {
@@ -56,7 +58,7 @@ int MemTable::RowCursorComparator::operator()(const char* left, const char* righ
 }
 
 size_t MemTable::memory_usage() {
-    return _arena.MemoryUsage();
+    return _mem_pool->mem_tracker()->consumption();
 }
 
 void MemTable::insert(Tuple* tuple) {
@@ -68,13 +70,13 @@ void MemTable::insert(Tuple* tuple) {
 
         bool is_null = tuple->is_null(slot->null_indicator_offset());
         void* value = tuple->get_slot(slot->tuple_offset());
-        _schema->column(i)->consume(&cell, (const char *)value, is_null, _skip_list->arena(), &_agg_object_pool);
+        _schema->column(i)->consume(&cell, (const char *)value, is_null, _mem_pool.get(), &_agg_object_pool);
     }
 
     bool overwritten = false;
-    _skip_list->Insert(_tuple_buf, &overwritten, _keys_type);
+    _skip_list->Insert((char*)_tuple_buf, &overwritten, _keys_type);
     if (!overwritten) {
-        _tuple_buf = _arena.Allocate(_schema_size);
+        _tuple_buf = _mem_pool->allocate(_schema_size);
     }
 }
 
@@ -86,7 +88,7 @@ OLAPStatus MemTable::flush() {
         for (it.SeekToFirst(); it.Valid(); it.Next()) {
             char* row = (char*)it.key();
             ContiguousRow dst_row(_schema, row);
-            agg_finalize_row(&dst_row, _skip_list->arena());
+            agg_finalize_row(&dst_row, _mem_pool.get());
             RETURN_NOT_OK(_rowset_writer->add_row(dst_row));
         }
         RETURN_NOT_OK(_rowset_writer->flush());

--- a/be/src/olap/memtable.h
+++ b/be/src/olap/memtable.h
@@ -57,11 +57,12 @@ private:
     };
 
     RowCursorComparator _row_comparator;
-    Arena _arena;
+    std::unique_ptr<MemTracker> _tracker;
+    std::unique_ptr<MemPool> _mem_pool;
     ObjectPool _agg_object_pool;
 
     typedef SkipList<char*, RowCursorComparator> Table;
-    char* _tuple_buf;
+    u_int8_t* _tuple_buf;
     size_t _schema_size;
     Table* _skip_list;
 

--- a/be/src/olap/merger.cpp
+++ b/be/src/olap/merger.cpp
@@ -44,14 +44,17 @@ OLAPStatus Merger::merge_rowsets(TabletSharedPtr tablet,
     RETURN_NOT_OK_LOG(row_cursor.init(tablet->tablet_schema()),
                  "failed to init row cursor when merging rowsets of tablet " + tablet->full_name());
     row_cursor.allocate_memory_for_string_type(tablet->tablet_schema());
+
+    std::unique_ptr<MemTracker> tracker(new MemTracker(-1));
+    std::unique_ptr<MemPool> mem_pool(new MemPool(tracker.get()));
+
     // The following procedure would last for long time, half of one day, etc.
     int64_t output_rows = 0;
     while (true) {
-        Arena arena;
         ObjectPool objectPool;
         bool eof = false;
         // Read one row into row_cursor
-        RETURN_NOT_OK_LOG(reader.next_row_with_aggregation(&row_cursor, &arena, &objectPool, &eof),
+        RETURN_NOT_OK_LOG(reader.next_row_with_aggregation(&row_cursor, mem_pool.get(), &objectPool, &eof),
                           "failed to read next row when merging rowsets of tablet " + tablet->full_name());
         if (eof) {
             break;
@@ -59,6 +62,9 @@ OLAPStatus Merger::merge_rowsets(TabletSharedPtr tablet,
         RETURN_NOT_OK_LOG(dst_rowset_writer->add_row(row_cursor),
                           "failed to write row when merging rowsets of tablet " + tablet->full_name());
         output_rows++;
+        // the memory allocate by mem pool has been copied,
+        // so we should release memory immediately
+        mem_pool->clear();
     }
 
     if (stats_output != nullptr) {

--- a/be/src/olap/reader.cpp
+++ b/be/src/olap/reader.cpp
@@ -345,7 +345,7 @@ OLAPStatus Reader::init(const ReaderParams& read_params) {
     return OLAP_SUCCESS;
 }
 
-OLAPStatus Reader::_dup_key_next_row(RowCursor* row_cursor, Arena* arena, ObjectPool* agg_pool, bool* eof) {
+OLAPStatus Reader::_dup_key_next_row(RowCursor* row_cursor, MemPool* mem_pool, ObjectPool* agg_pool, bool* eof) {
     if (UNLIKELY(_next_key == nullptr)) {
         *eof = true;
         return OLAP_SUCCESS;
@@ -360,12 +360,12 @@ OLAPStatus Reader::_dup_key_next_row(RowCursor* row_cursor, Arena* arena, Object
     return OLAP_SUCCESS;
 }
 
-OLAPStatus Reader::_agg_key_next_row(RowCursor* row_cursor, Arena* arena, ObjectPool* agg_pool, bool* eof) {
+OLAPStatus Reader::_agg_key_next_row(RowCursor* row_cursor, MemPool* mem_pool, ObjectPool* agg_pool, bool* eof) {
     if (UNLIKELY(_next_key == nullptr)) {
         *eof = true;
         return OLAP_SUCCESS;
     }
-    init_row_with_others(row_cursor, *_next_key, arena, agg_pool);
+    init_row_with_others(row_cursor, *_next_key, mem_pool, agg_pool);
     int64_t merged_count = 0;
     do {
         auto res = _collect_iter->next(&_next_key, &_next_delete_flag);
@@ -391,13 +391,13 @@ OLAPStatus Reader::_agg_key_next_row(RowCursor* row_cursor, Arena* arena, Object
     _merged_rows += merged_count;
     // For agg query, we don't need finalize agg object and directly pass agg object to agg node
     if (_need_agg_finalize) {
-        agg_finalize_row(_value_cids, row_cursor, arena);
+        agg_finalize_row(_value_cids, row_cursor, mem_pool);
     }
 
     return OLAP_SUCCESS;
 }
 
-OLAPStatus Reader::_unique_key_next_row(RowCursor* row_cursor, Arena* arena, ObjectPool* agg_pool, bool* eof) {
+OLAPStatus Reader::_unique_key_next_row(RowCursor* row_cursor, MemPool* mem_pool, ObjectPool* agg_pool, bool* eof) {
     *eof = false;
     bool cur_delete_flag = false;
     do {
@@ -407,7 +407,7 @@ OLAPStatus Reader::_unique_key_next_row(RowCursor* row_cursor, Arena* arena, Obj
         }
     
         cur_delete_flag = _next_delete_flag;
-        init_row_with_others(row_cursor, *_next_key, arena, agg_pool);
+        init_row_with_others(row_cursor, *_next_key, mem_pool, agg_pool);
 
         int64_t merged_count = 0;
         while (NULL != _next_key) {
@@ -423,12 +423,12 @@ OLAPStatus Reader::_unique_key_next_row(RowCursor* row_cursor, Arena* arena, Obj
             //   1. DUP_KEYS keys type has no semantic to aggregate,
             //   2. to make cost of  each scan round reasonable, we will control merged_count.
             if (_aggregation && merged_count > config::doris_scanner_row_num) {
-                agg_finalize_row(_value_cids, row_cursor, arena);
+                agg_finalize_row(_value_cids, row_cursor, mem_pool);
                 break;
             }
             // break while can NOT doing aggregation
             if (!equal_row(_key_cids, *row_cursor, *_next_key)) {
-                agg_finalize_row(_value_cids, row_cursor, arena);
+                agg_finalize_row(_value_cids, row_cursor, mem_pool);
                 break;
             }
 

--- a/be/src/olap/reader.h
+++ b/be/src/olap/reader.h
@@ -126,8 +126,8 @@ public:
     // Return OLAP_SUCCESS and set `*eof` to false when next row is read into `row_cursor`.
     // Return OLAP_SUCCESS and set `*eof` to true when no more rows can be read.
     // Return others when unexpected error happens.
-    OLAPStatus next_row_with_aggregation(RowCursor *row_cursor, Arena* arena, ObjectPool* agg_pool, bool *eof) {
-        return (this->*_next_row_func)(row_cursor, arena, agg_pool, eof);
+    OLAPStatus next_row_with_aggregation(RowCursor *row_cursor, MemPool* mem_pool, ObjectPool* agg_pool, bool *eof) {
+        return (this->*_next_row_func)(row_cursor, mem_pool, agg_pool, eof);
     }
 
     uint64_t merged_rows() const {
@@ -201,9 +201,9 @@ private:
 
     OLAPStatus _init_load_bf_columns(const ReaderParams& read_params);
 
-    OLAPStatus _dup_key_next_row(RowCursor* row_cursor, Arena* arena, ObjectPool* agg_pool, bool* eof);
-    OLAPStatus _agg_key_next_row(RowCursor* row_cursor, Arena* arena, ObjectPool* agg_pool, bool* eof);
-    OLAPStatus _unique_key_next_row(RowCursor* row_cursor, Arena* arena, ObjectPool* agg_pool, bool* eof);
+    OLAPStatus _dup_key_next_row(RowCursor* row_cursor, MemPool* mem_pool, ObjectPool* agg_pool, bool* eof);
+    OLAPStatus _agg_key_next_row(RowCursor* row_cursor, MemPool* mem_pool, ObjectPool* agg_pool, bool* eof);
+    OLAPStatus _unique_key_next_row(RowCursor* row_cursor, MemPool* mem_pool, ObjectPool* agg_pool, bool* eof);
 
     TabletSharedPtr tablet() { return _tablet; }
 
@@ -234,7 +234,7 @@ private:
 
     DeleteHandler _delete_handler;
 
-    OLAPStatus (Reader::*_next_row_func)(RowCursor* row_cursor, Arena* arena, ObjectPool* agg_pool, bool* eof) = nullptr;
+    OLAPStatus (Reader::*_next_row_func)(RowCursor* row_cursor, MemPool* mem_pool, ObjectPool* agg_pool, bool* eof) = nullptr;
 
     bool _aggregation;
     // for agg query, we don't need to finalize when scan agg object data

--- a/be/src/olap/row.h
+++ b/be/src/olap/row.h
@@ -107,10 +107,10 @@ int index_compare_row(const LhsRowType& lhs, const RhsRowType& rhs) {
 // function will first initialize destination column and then update with source column
 // value.
 template<typename DstRowType, typename SrcRowType>
-void init_row_with_others(DstRowType* dst, const SrcRowType& src, Arena* arena, ObjectPool* agg_pool) {
+void init_row_with_others(DstRowType* dst, const SrcRowType& src, MemPool* mem_pool, ObjectPool* agg_pool) {
     for (auto cid : dst->schema()->column_ids()) {
         auto dst_cell = dst->cell(cid);
-        dst->schema()->column(cid)->agg_init(&dst_cell, src.cell(cid), arena, agg_pool);
+        dst->schema()->column(cid)->agg_init(&dst_cell, src.cell(cid), mem_pool, agg_pool);
     }
 }
 
@@ -145,11 +145,11 @@ void copy_row(DstRowType* dst, const SrcRowType& src, Arena* arena) {
 }
 
 template<typename DstRowType, typename SrcRowType>
-void agg_update_row(DstRowType* dst, const SrcRowType& src, Arena* arena) {
+void agg_update_row(DstRowType* dst, const SrcRowType& src, MemPool* mem_pool) {
     for (uint32_t cid = dst->schema()->num_key_columns(); cid < dst->schema()->num_columns(); ++cid) {
         auto dst_cell = dst->cell(cid);
         auto src_cell = src.cell(cid);
-        dst->schema()->column(cid)->agg_update(&dst_cell, src_cell, arena);
+        dst->schema()->column(cid)->agg_update(&dst_cell, src_cell, mem_pool);
     }
 }
 
@@ -166,18 +166,18 @@ void agg_update_row(const std::vector<uint32_t>& cids, DstRowType* dst, const Sr
 }
 
 template<typename RowType>
-void agg_finalize_row(RowType* row, Arena* arena) {
+void agg_finalize_row(RowType* row, MemPool* mem_pool) {
     for (uint32_t cid = row->schema()->num_key_columns(); cid < row->schema()->num_columns(); ++cid) {
         auto cell = row->cell(cid);
-        row->schema()->column(cid)->agg_finalize(&cell, arena);
+        row->schema()->column(cid)->agg_finalize(&cell, mem_pool);
     }
 }
 
 template<typename RowType>
-void agg_finalize_row(const std::vector<uint32_t>& ids, RowType* row, Arena* arena) {
+void agg_finalize_row(const std::vector<uint32_t>& ids, RowType* row, MemPool* mem_pool) {
     for (uint32_t id : ids) {
         auto cell = row->cell(id);
-        row->schema()->column(id)->agg_finalize(&cell, arena);
+        row->schema()->column(id)->agg_finalize(&cell, mem_pool);
     }
 }
 

--- a/be/src/olap/skiplist.h
+++ b/be/src/olap/skiplist.h
@@ -31,13 +31,11 @@
 
 #include "common/logging.h"
 #include "gen_cpp/olap_file.pb.h"
-#include "util/arena.h"
+#include "runtime/mem_pool.h"
 #include "util/random.h"
 #include "olap/row.h"
 
 namespace doris {
-
-class Arena;
 
 template<typename Key, class Comparator>
 class SkipList {
@@ -48,7 +46,7 @@ public:
     // Create a new SkipList object that will use "cmp" for comparing keys,
     // and will allocate memory using "*arena".  Objects allocated in the arena
     // must remain allocated for the lifetime of the skiplist object.
-    explicit SkipList(Comparator cmp, Arena* arena);
+    explicit SkipList(Comparator cmp, MemPool* mem_pool);
 
     // Insert key into the list.
     // REQUIRES: nothing that compares equal to key is currently in the list.
@@ -97,14 +95,12 @@ public:
         // Intentionally copyable
     };
 
-    Arena* arena() const { return arena_; }
-
 private:
     enum { kMaxHeight = 12 };
 
     // Immutable after construction
     Comparator const compare_;
-    Arena* const arena_;    // Arena used for allocations of nodes
+    MemPool* const _mem_pool;    // MemPool used for allocations of nodes
 
     Node* const head_;
 
@@ -186,7 +182,7 @@ struct SkipList<Key,Comparator>::Node {
 template<typename Key, class Comparator>
 typename SkipList<Key,Comparator>::Node*
 SkipList<Key,Comparator>::NewNode(const Key& key, int height) {
-    char* mem = arena_->AllocateAligned(
+    char* mem = (char*)_mem_pool->allocate(
             sizeof(Node) + sizeof(std::atomic<Node*>) * (height - 1));
     return new (mem) Node(key);
 }
@@ -326,9 +322,9 @@ SkipList<Key,Comparator>::FindLast() const {
 }
 
 template<typename Key, class Comparator>
-SkipList<Key,Comparator>::SkipList(Comparator cmp, Arena* arena)
+SkipList<Key,Comparator>::SkipList(Comparator cmp, MemPool* mem_pool)
     : compare_(cmp),
-    arena_(arena),
+    _mem_pool(mem_pool),
     head_(NewNode(0 /* any key will do */, kMaxHeight)),
     max_height_(1),
     rnd_(0xdeadbeef) {
@@ -341,7 +337,7 @@ template<typename Key, class Comparator>
 void SkipList<Key, Comparator>::Aggregate(const Key& k1, const Key& k2) {
     ContiguousRow dst_row(compare_._schema, k1);
     ContiguousRow src_row(compare_._schema, k2);
-    agg_update_row(&dst_row, src_row, arena_);
+    agg_update_row(&dst_row, src_row, _mem_pool);
 }
 
 template<typename Key, class Comparator>

--- a/be/src/runtime/mem_tracker.cpp
+++ b/be/src/runtime/mem_tracker.cpp
@@ -184,11 +184,6 @@ MemTracker* MemTracker::CreateQueryMemTracker(const TUniqueId& id,
 }
 
 MemTracker::~MemTracker() {
-    DCHECK_EQ(_consumption->current_value(), 0) << _label << "\n"
-        << get_stack_trace() << "\n"
-        << LogUsage("");
-    // TODO chenhao
-    //DCHECK(_closed) << _label;
     delete _reservation_counters.load();
 }
 

--- a/be/test/olap/row_cursor_test.cpp
+++ b/be/test/olap/row_cursor_test.cpp
@@ -448,7 +448,7 @@ TEST_F(TestRowCursor, AggregateWithoutNull) {
     set_tablet_schema_for_cmp_and_aggregate(&tablet_schema);
 
     RowCursor row;
-    std::unique_ptr<Arena> arena(new Arena());
+
     OLAPStatus res = row.init(tablet_schema);
     ASSERT_EQ(res, OLAP_SUCCESS);
     ASSERT_EQ(row.get_fixed_len(), 78);
@@ -471,8 +471,10 @@ TEST_F(TestRowCursor, AggregateWithoutNull) {
     left.set_field_content(4, reinterpret_cast<char*>(&l_decimal), _mem_pool.get());
     left.set_field_content(5, reinterpret_cast<char*>(&l_varchar), _mem_pool.get());
 
+    std::unique_ptr<MemTracker> tracker(new MemTracker(-1));
+    std::unique_ptr<MemPool> mem_pool(new MemPool(tracker.get()));
     ObjectPool agg_object_pool;
-    init_row_with_others(&row, left, arena.get(), &agg_object_pool);
+    init_row_with_others(&row, left, mem_pool.get(), &agg_object_pool);
 
     RowCursor right;
     res = right.init(tablet_schema);
@@ -509,7 +511,7 @@ TEST_F(TestRowCursor, AggregateWithNull) {
     set_tablet_schema_for_cmp_and_aggregate(&tablet_schema);
 
     RowCursor row;
-    std::unique_ptr<Arena> arena(new Arena());
+
     OLAPStatus res = row.init(tablet_schema);
     ASSERT_EQ(res, OLAP_SUCCESS);
     ASSERT_EQ(row.get_fixed_len(), 78);
@@ -530,8 +532,10 @@ TEST_F(TestRowCursor, AggregateWithNull) {
     left.set_null(4);
     left.set_field_content(5, reinterpret_cast<char*>(&l_varchar), _mem_pool.get());
 
+    std::unique_ptr<MemTracker> tracker(new MemTracker(-1));
+    std::unique_ptr<MemPool> mem_pool(new MemPool(tracker.get()));
     ObjectPool agg_object_pool;
-    init_row_with_others(&row, left, arena.get(), &agg_object_pool);
+    init_row_with_others(&row, left, mem_pool.get(), &agg_object_pool);
 
     RowCursor right;
     res = right.init(tablet_schema);


### PR DESCRIPTION
For https://github.com/apache/incubator-doris/issues/1898

Why use mem_pool replace arena?

1. **The mem_pool and arena is the same essentially**
2. **mem_pool is more powerful than arena**
3. **mem_pool is widely used**

We should use mem_pool replace arena step by step, and finally remove arena.

