### PR TITLE
Fix es_scan_reader_test in debug mode

### DIFF
--- a/be/src/exec/es/es_scan_reader.cpp
+++ b/be/src/exec/es/es_scan_reader.cpp
@@ -104,9 +104,6 @@ Status ESScanReader::get_next(bool* scan_eos, std::unique_ptr<ScrollParser>& scr
             LOG(WARNING) << "request scroll search failure[" 
                          << "http status" << status
                          << ", response: " << (response.empty() ? "empty response" : response);
-            if (status == 404) {
-                    return Status::InternalError("No search context found for " + _scroll_id);
-                }
             return Status::InternalError("request scroll search failure: " + (response.empty() ? "empty response" : response));        
         }
     }
@@ -125,11 +122,7 @@ Status ESScanReader::get_next(bool* scan_eos, std::unique_ptr<ScrollParser>& scr
         return Status::OK();
     }
 
-    if (scroll_parser->get_size() < _batch_size) {
-        _eos = true;
-    } else {
-        _eos = false;
-    }
+    _eos = scroll_parser->get_size() < _batch_size;
 
     *scan_eos = false;
     return Status::OK();

--- a/be/test/exec/es_scan_reader_test.cpp
+++ b/be/test/exec/es_scan_reader_test.cpp
@@ -112,7 +112,7 @@ public:
                     end_search_result.AddMember("_scroll_id", scroll_id_value, allocator);
 
                     rapidjson::Value outer_hits(rapidjson::kObjectType);
-                    outer_hits.AddMember("total", 10, allocator);
+                    outer_hits.AddMember("total", 0, allocator);
                     end_search_result.AddMember("hits", outer_hits, allocator);
                     rapidjson::StringBuffer buffer;  
                     rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
@@ -130,7 +130,7 @@ public:
                     search_result.AddMember("_scroll_id", scroll_id_value, allocator);
 
                     rapidjson::Value outer_hits(rapidjson::kObjectType);
-                    outer_hits.AddMember("total", 10, allocator);
+                    outer_hits.AddMember("total", 1, allocator);
                     rapidjson::Value inner_hits(rapidjson::kArrayType);
                     rapidjson::Value source_docuement(rapidjson::kObjectType);
                     source_docuement.AddMember("id", start, allocator);
@@ -225,11 +225,12 @@ TEST_F(MockESServerTest, workflow) {
     props[ESScanReader::KEY_QUERY] = ESScrollQueryBuilder::build(props, fields, predicates);
     ESScanReader reader(target, props);
     auto st = reader.open();
-    // ASSERT_TRUE(st.ok());
+    ASSERT_TRUE(st.ok());
     bool eos = false;
     std::unique_ptr<ScrollParser> parser = nullptr;
     while(!eos){
         st = reader.get_next(&eos, parser);
+        ASSERT_TRUE(st.ok());
         if(eos) {
             break;
         }


### PR DESCRIPTION
```
es_scan_reader_test: /home/kangkaisen/palo/thirdparty/installed/include/rapidjson/document.h:1053: rapidjson::GenericValue<Encoding, Allocator>& rapidjson::GenericValue<Encoding, Allocator>::operator[](const rapidjson::GenericValue<Encoding, SourceAllocator>&) [with SourceAllocator = rapidjson::MemoryPoolAllocator<>; Encoding = rapidjson::UTF8<>; Allocator = rapidjson::MemoryPoolAllocator<>]: Assertion `false' failed.
run-ut.sh: line 140: 194835 Aborted                 (core dumped) ${DORIS_TEST_BINARY_DIR}/exec/es_scan_reader_test
```
The mock_es_server response:
```
{"_scroll_id":"1","hits":{"total":10,"hits":[{"id":1,"value":"1"}]}}
{"_scroll_id":"2","hits":{"total":10,"hits":[{"id":2,"value":"2"}]}}
{"_scroll_id":"3","hits":{"total":10,"hits":[{"id":3,"value":"3"}]}}
{"_scroll_id":"4","hits":{"total":10,"hits":[{"id":4,"value":"4"}]}}
{"_scroll_id":"5","hits":{"total":10,"hits":[{"id":5,"value":"5"}]}}
{"_scroll_id":"6","hits":{"total":10,"hits":[{"id":6,"value":"6"}]}}
{"_scroll_id":"7","hits":{"total":10,"hits":[{"id":7,"value":"7"}]}}
{"_scroll_id":"8","hits":{"total":10,"hits":[{"id":8,"value":"8"}]}}
{"_scroll_id":"9","hits":{"total":10,"hits":[{"id":9,"value":"9"}]}}
{"_scroll_id":"10","hits":{"total":10,"hits":[{"id":10,"value":"10"}]}}
{"_scroll_id":"11","hits":{"total":10,"hits":[{"id":11,"value":"11"}]}}
{"_scroll_id":"11","hits":{"total":10}}
```