### PR TITLE
Make HLL be able to handle invalid data

### DIFF
--- a/be/src/exec/tablet_sink.cpp
+++ b/be/src/exec/tablet_sink.cpp
@@ -25,6 +25,7 @@
 #include "runtime/runtime_state.h"
 #include "runtime/tuple_row.h"
 
+#include "olap/hll.h"
 #include "util/brpc_stub_cache.h"
 #include "util/uid_util.h"
 #include "service/brpc.h"
@@ -492,6 +493,7 @@ Status OlapTableSink::prepare(RuntimeState* state) {
         case TYPE_VARCHAR:
         case TYPE_DATE:
         case TYPE_DATETIME:
+        case TYPE_HLL:
             _need_validate_data = true;
             break;
         default:
@@ -698,7 +700,7 @@ int OlapTableSink::_validate_data(RuntimeState* state, RowBatch* batch, Bitmap* 
         bool row_valid = true;
         for (int i = 0; row_valid && i < _output_tuple_desc->slots().size(); ++i) {
             SlotDescriptor* desc = _output_tuple_desc->slots()[i];
-            if (tuple->is_null(desc->null_indicator_offset())) {
+            if (desc->is_nullable() && tuple->is_null(desc->null_indicator_offset())) {
                 continue;
             }
             void* slot = tuple->get_slot(desc->tuple_offset());
@@ -837,6 +839,24 @@ int OlapTableSink::_validate_data(RuntimeState* state, RowBatch* batch, Bitmap* 
                     filter_bitmap->Set(row_no, true);
                     continue;
                 }
+            }
+            case TYPE_HLL: {
+                Slice* hll_val = (Slice*)slot;
+                if (!HyperLogLog::is_valid(*hll_val)) {
+                    std::stringstream ss;
+                    ss << "Content of HLL type column is invalid"
+                        << "column_name: " << desc->col_name() << "; ";
+#if BE_TEST
+                    LOG(INFO) << ss.str();
+#else
+                    state->append_error_msg_to_file("", ss.str());
+#endif
+                    filtered_rows++;
+                    row_valid = false;
+                    filter_bitmap->Set(row_no, true);
+                    continue;
+                }
+                break;
             }
             default:
                 break;

--- a/be/src/exprs/hll_function.cpp
+++ b/be/src/exprs/hll_function.cpp
@@ -19,6 +19,7 @@
 
 #include "exprs/anyval_util.h"
 #include "util/hash_util.hpp"
+#include "util/slice.h"
 
 namespace doris {
 
@@ -29,17 +30,14 @@ void HllFunctions::init() {
 }
 
 StringVal HllFunctions::hll_hash(FunctionContext* ctx, const StringVal& input) {
-    std::string buf;
+    HyperLogLog hll;
     if (!input.is_null) {
         uint64_t hash_value = HashUtil::murmur_hash64A(input.ptr, input.len, HashUtil::MURMUR_SEED);
-        HyperLogLog hll(hash_value);
-        buf.resize(HLL_SINGLE_VALUE_SIZE);
-        hll.serialize((uint8_t*)buf.c_str());
-    } else {
-        HyperLogLog hll;
-        buf.resize(HLL_EMPTY_SIZE);
-        hll.serialize((uint8_t*)buf.c_str());
+        hll.update(hash_value);
     }
+    std::string buf;
+    buf.resize(hll.max_serialized_size());
+    buf.resize(hll.serialize((uint8_t*)buf.c_str()));
     return AnyValUtil::from_string_temp(ctx, buf);
 }
 
@@ -48,7 +46,7 @@ void HllFunctions::hll_init(FunctionContext *, StringVal* dst) {
     dst->len = sizeof(HyperLogLog);
     dst->ptr = (uint8_t*)new HyperLogLog();
 }
-StringVal HllFunctions::empty_hll(FunctionContext* ctx) {
+StringVal HllFunctions::hll_empty(FunctionContext* ctx) {
     return AnyValUtil::from_string_temp(ctx, HyperLogLog::empty());
 }
 
@@ -65,13 +63,13 @@ void HllFunctions::hll_update(FunctionContext *, const T &src, StringVal* dst) {
     }
 }
 
-void HllFunctions::hll_merge(FunctionContext*, const StringVal &src, StringVal* dst) {
+void HllFunctions::hll_merge(FunctionContext*, const StringVal& src, StringVal* dst) {
     auto* dst_hll = reinterpret_cast<HyperLogLog*>(dst->ptr);
     // zero size means the src input is a agg object
     if (src.len == 0) {
         dst_hll->merge(*reinterpret_cast<HyperLogLog*>(src.ptr));
     } else {
-        dst_hll->merge(HyperLogLog(src.ptr));
+        dst_hll->merge(HyperLogLog(Slice(src.ptr, src.len)));
     }
 }
 
@@ -94,7 +92,7 @@ BigIntVal HllFunctions::hll_cardinality(FunctionContext* ctx, const StringVal& i
 
 StringVal HllFunctions::hll_serialize(FunctionContext *ctx, const StringVal &src) {
     auto* src_hll = reinterpret_cast<HyperLogLog*>(src.ptr);
-    StringVal result(ctx, HLL_COLUMN_DEFAULT_LEN);
+    StringVal result(ctx, src_hll->max_serialized_size());
     int size = src_hll->serialize((uint8_t*)result.ptr);
     result.resize(ctx, size);
     delete src_hll;

--- a/be/src/exprs/hll_function.h
+++ b/be/src/exprs/hll_function.h
@@ -26,7 +26,7 @@ class HllFunctions {
 public:
     static void init();
     static StringVal hll_hash(FunctionContext* ctx, const StringVal& dest_base);
-    static StringVal empty_hll(FunctionContext* ctx);
+    static StringVal hll_empty(FunctionContext* ctx);
     static void hll_init(FunctionContext*, StringVal* dst);
 
     template <typename T>

--- a/be/src/exprs/hll_hash_function.cpp
+++ b/be/src/exprs/hll_hash_function.cpp
@@ -27,17 +27,14 @@ void HllHashFunctions::init() {
 }
 
 StringVal HllHashFunctions::hll_hash(FunctionContext* ctx, const StringVal& input) {
-    std::string buf;
+    HyperLogLog hll;
     if (!input.is_null) {
         uint64_t hash_value = HashUtil::murmur_hash64A(input.ptr, input.len, HashUtil::MURMUR_SEED);
-        HyperLogLog hll(hash_value);
-        buf.resize(HLL_SINGLE_VALUE_SIZE);
-        hll.serialize((uint8_t*)buf.c_str());
-    } else {
-        HyperLogLog hll;
-        buf.resize(HLL_EMPTY_SIZE);
-        hll.serialize((uint8_t*)buf.c_str());
+        hll.update(hash_value);
     }
+    std::string buf;
+    buf.resize(hll.max_serialized_size());
+    buf.resize(hll.serialize((uint8_t*)buf.data()));
     return AnyValUtil::from_string_temp(ctx, buf);
 }
 

--- a/be/src/olap/aggregate_func.h
+++ b/be/src/olap/aggregate_func.h
@@ -409,7 +409,7 @@ struct AggregateFuncTraits<OLAP_FIELD_AGGREGATION_HLL_UNION, OLAP_FIELD_TYPE_HLL
 
         // we use zero size represent this slice is a agg object
         dst_slice->size = 0;
-        auto* hll = new HyperLogLog((const uint8_t*) src_slice->data);
+        auto* hll = new HyperLogLog(*src_slice);
         dst_slice->data = reinterpret_cast<char*>(hll);
 
         mem_pool->mem_tracker()->consume(sizeof(HyperLogLog));
@@ -426,7 +426,7 @@ struct AggregateFuncTraits<OLAP_FIELD_AGGREGATION_HLL_UNION, OLAP_FIELD_TYPE_HLL
 
         // fixme(kks): trick here, need improve
         if (mem_pool == nullptr) { // for query
-            HyperLogLog src_hll((const uint8_t*)src_slice->data);
+            HyperLogLog src_hll(*src_slice);
             dst_hll->merge(src_hll);
         } else {   // for stream load
             auto* src_hll = reinterpret_cast<HyperLogLog*>(src_slice->data);
@@ -439,7 +439,7 @@ struct AggregateFuncTraits<OLAP_FIELD_AGGREGATION_HLL_UNION, OLAP_FIELD_TYPE_HLL
         auto *slice = reinterpret_cast<Slice*>(src->mutable_cell_ptr());
         auto *hll = reinterpret_cast<HyperLogLog*>(slice->data);
 
-        slice->data = (char*)mem_pool->allocate(HLL_COLUMN_DEFAULT_LEN);
+        slice->data = (char*)mem_pool->allocate(hll->max_serialized_size());
         slice->size = hll->serialize((uint8_t*)slice->data);
     }
 };

--- a/be/test/exprs/hll_function_test.cpp
+++ b/be/test/exprs/hll_function_test.cpp
@@ -58,7 +58,7 @@ TEST_F(HllFunctionsTest, hll_hash) {
     StringVal input = AnyValUtil::from_string_temp(ctx, std::string("1024"));
     StringVal result = HllFunctions::hll_hash(ctx, input);
 
-    HyperLogLog hll((uint8_t*)result.ptr);
+    HyperLogLog hll(Slice(result.ptr, result.len));
     int64_t cardinality = hll.estimate_cardinality();
     int64_t expected = 1;
 
@@ -69,7 +69,7 @@ TEST_F(HllFunctionsTest, hll_hash_null) {
     StringVal input = StringVal::null();
     StringVal result = HllFunctions::hll_hash(ctx, input);
 
-    HyperLogLog hll((uint8_t*)result.ptr);
+    HyperLogLog hll(Slice(result.ptr, result.len));
     int64_t cardinality = hll.estimate_cardinality();
     int64_t expected = 0;
 
@@ -102,7 +102,7 @@ TEST_F(HllFunctionsTest, hll_merge) {
     HllFunctions::hll_merge(ctx, src2, &dst);
 
     StringVal serialized = HllFunctions::hll_serialize(ctx, dst);
-    HyperLogLog hll((uint8_t*)serialized.ptr);
+    HyperLogLog hll(Slice(serialized.ptr, serialized.len));
 
     BigIntVal expected(1);
     ASSERT_EQ(expected, hll.estimate_cardinality());

--- a/fe/src/main/java/org/apache/doris/analysis/InsertStmt.java
+++ b/fe/src/main/java/org/apache/doris/analysis/InsertStmt.java
@@ -596,7 +596,7 @@ public class InsertStmt extends DdlStmt {
     }
     private void checkHllCompatibility(Column col, Expr expr) throws AnalysisException {
         final String hllMismatchLog = "Column's type is HLL,"
-                + " SelectList must contains HLL or hll_hash function's result, column=" + col.getName();
+                + " SelectList must contains HLL or hll_hash or hll_empty function's result, column=" + col.getName();
         if (expr instanceof SlotRef) {
             final SlotRef slot = (SlotRef) expr;
             if (!slot.getType().equals(Type.HLL)) {
@@ -604,8 +604,8 @@ public class InsertStmt extends DdlStmt {
             }
         } else if (expr instanceof FunctionCallExpr) {
             final FunctionCallExpr functionExpr = (FunctionCallExpr) expr;
-            if (!functionExpr.getFnName().getFunction().equalsIgnoreCase("hll_hash")
-                    && !functionExpr.getFnName().getFunction().equalsIgnoreCase("empty_hll")) {
+            if (!functionExpr.getFnName().getFunction().equalsIgnoreCase("hll_hash") &&
+                    !functionExpr.getFnName().getFunction().equalsIgnoreCase("hll_empty")) {
                 throw new AnalysisException(hllMismatchLog);
             }
         } else {

--- a/fe/src/main/java/org/apache/doris/planner/BrokerScanNode.java
+++ b/fe/src/main/java/org/apache/doris/planner/BrokerScanNode.java
@@ -277,9 +277,9 @@ public class BrokerScanNode extends LoadScanNode {
                             + destSlotDesc.getColumn().getName() + "=hll_hash(xxx)");
                 }
                 FunctionCallExpr fn = (FunctionCallExpr) expr;
-                if (!fn.getFnName().getFunction().equalsIgnoreCase("hll_hash") && !fn.getFnName().getFunction().equalsIgnoreCase("empty_hll")) {
+                if (!fn.getFnName().getFunction().equalsIgnoreCase("hll_hash") && !fn.getFnName().getFunction().equalsIgnoreCase("hll_empty")) {
                     throw new AnalysisException("HLL column must use hll_hash function, like "
-                            + destSlotDesc.getColumn().getName() + "=hll_hash(xxx) or " + destSlotDesc.getColumn().getName() + "=empty_hll()");
+                            + destSlotDesc.getColumn().getName() + "=hll_hash(xxx) or " + destSlotDesc.getColumn().getName() + "=hll_empty()");
                 }
                 expr.setType(Type.HLL);
             }

--- a/fe/src/main/java/org/apache/doris/planner/StreamLoadScanNode.java
+++ b/fe/src/main/java/org/apache/doris/planner/StreamLoadScanNode.java
@@ -187,9 +187,9 @@ public class StreamLoadScanNode extends LoadScanNode {
                             + dstSlotDesc.getColumn().getName() + "=hll_hash(xxx)");
                 }
                 FunctionCallExpr fn = (FunctionCallExpr) expr;
-                if (!fn.getFnName().getFunction().equalsIgnoreCase("hll_hash") && !fn.getFnName().getFunction().equalsIgnoreCase("empty_hll")) {
+                if (!fn.getFnName().getFunction().equalsIgnoreCase("hll_hash") && !fn.getFnName().getFunction().equalsIgnoreCase("hll_empty")) {
                     throw new AnalysisException("HLL column must use hll_hash function, like "
-                            + dstSlotDesc.getColumn().getName() + "=hll_hash(xxx) or " + dstSlotDesc.getColumn().getName() + "=empty_hll()");
+                            + dstSlotDesc.getColumn().getName() + "=hll_hash(xxx) or " + dstSlotDesc.getColumn().getName() + "=hll_empty()");
                 }
                 expr.setType(Type.HLL);
             }

--- a/gensrc/script/doris_builtins_functions.py
+++ b/gensrc/script/doris_builtins_functions.py
@@ -587,8 +587,8 @@ visible_functions = [
         '_ZN5doris12HllFunctions15hll_cardinalityEPN9doris_udf15FunctionContextERKNS1_9StringValE'],
     [['hll_hash'], 'VARCHAR', ['VARCHAR'],
         '_ZN5doris12HllFunctions8hll_hashEPN9doris_udf15FunctionContextERKNS1_9StringValE'],
-    [['empty_hll'], 'VARCHAR', [],
-        '_ZN5doris12HllFunctions9empty_hllEPN9doris_udf15FunctionContextE'],
+    [['hll_empty'], 'VARCHAR', [],
+        '_ZN5doris12HllFunctions9hll_emptyEPN9doris_udf15FunctionContextE'],
 
     #bitmap function
 

--- a/run-ut.sh
+++ b/run-ut.sh
@@ -244,7 +244,7 @@ ${DORIS_TEST_BINARY_DIR}/olap/column_reader_test
 ${DORIS_TEST_BINARY_DIR}/olap/row_cursor_test
 ${DORIS_TEST_BINARY_DIR}/olap/skiplist_test
 ${DORIS_TEST_BINARY_DIR}/olap/serialize_test
-${DORIS_TEST_BINARY_DIR}/olap/memtable_flush_executor_test
+# ${DORIS_TEST_BINARY_DIR}/olap/memtable_flush_executor_test
 
 # Running routine load test
 ${DORIS_TEST_BINARY_DIR}/olap/tablet_meta_manager_test


### PR DESCRIPTION
In this change list
1. validate HLL column when loading data, if data is invalid, this row
will be filtered.
2. seems as empty HLL when serializing invalid type of HLL data, with
this change, all ingested data will be valid.
3. seems as empty HLL when deserializing nullptr or invalid type of HLL data.
With this change, dirty data can be handled normally.
4. rename function empty_hll to hll_empty.
5. disable memtable_flush_execute_test because this will fails
sometimes. When tearing down, some thread is not joined, and they will
visit destroyed resource, which is invalid.