### PR TITLE
Fix BetaRowsetTest in debug mode

### DIFF
--- a/be/src/olap/generic_iterators.cpp
+++ b/be/src/olap/generic_iterators.cpp
@@ -210,7 +210,7 @@ public:
     Status next_batch(RowBlockV2* block) override;
 
     const Schema& schema() const override {
-        return *_schema.get();
+        return *_schema;
     }
 private:
     std::vector<RowwiseIterator*> _origin_iters;

--- a/be/src/olap/rowset/alpha_rowset_reader.cpp
+++ b/be/src/olap/rowset/alpha_rowset_reader.cpp
@@ -167,7 +167,7 @@ OLAPStatus AlphaRowsetReader::_pull_next_row_for_merge_rowset(RowCursor** row) {
 
     size_t ordinal = 0;
     while (ordinal < _merge_ctxs.size()) {
-        MergeContext* merge_ctx = &(_merge_ctxs[ordinal]);
+        AlphaMergeContext* merge_ctx = &(_merge_ctxs[ordinal]);
         if (merge_ctx->row_block == nullptr || !merge_ctx->row_block->has_remaining()) {
             OLAPStatus status = _pull_next_block(merge_ctx);
             if (status == OLAP_ERR_DATA_EOF) {
@@ -194,7 +194,7 @@ OLAPStatus AlphaRowsetReader::_pull_next_row_for_merge_rowset(RowCursor** row) {
     return OLAP_SUCCESS;
 }
 
-OLAPStatus AlphaRowsetReader::_pull_next_block(MergeContext* merge_ctx) {
+OLAPStatus AlphaRowsetReader::_pull_next_block(AlphaMergeContext* merge_ctx) {
     OLAPStatus status = OLAP_SUCCESS;
     if (OLAP_UNLIKELY(merge_ctx->first_read_symbol)) {
         if (_key_range_size > 0) {
@@ -220,7 +220,7 @@ OLAPStatus AlphaRowsetReader::_pull_next_block(MergeContext* merge_ctx) {
     return status;
 }
 
-OLAPStatus AlphaRowsetReader::_pull_first_block(MergeContext* merge_ctx) {
+OLAPStatus AlphaRowsetReader::_pull_first_block(AlphaMergeContext* merge_ctx) {
     OLAPStatus status = OLAP_SUCCESS;
     merge_ctx->key_range_index++;
     while (merge_ctx->key_range_index < _key_range_size) {
@@ -310,7 +310,7 @@ OLAPStatus AlphaRowsetReader::_init_merge_ctxs(RowsetReaderContext* read_context
                     << new_column_data->version().first << ", " << new_column_data->version().second;
             new_column_data->set_delete_status(DEL_NOT_SATISFIED);
         }
-        MergeContext merge_ctx;
+        AlphaMergeContext merge_ctx;
         merge_ctx.column_data = std::move(new_column_data);
         _merge_ctxs.emplace_back(std::move(merge_ctx));
     }

--- a/be/src/olap/rowset/alpha_rowset_reader.h
+++ b/be/src/olap/rowset/alpha_rowset_reader.h
@@ -29,7 +29,7 @@
 namespace doris {
 
 // Each segment group corresponds to a MergeContext, which is able to produce ordered rows.
-struct MergeContext {
+struct AlphaMergeContext {
     std::unique_ptr<ColumnData> column_data = nullptr;
 
     int key_range_index = -1;
@@ -72,12 +72,12 @@ private:
     OLAPStatus _union_block(RowBlock** block);
     OLAPStatus _merge_block(RowBlock** block);
     OLAPStatus _pull_next_row_for_merge_rowset(RowCursor** row);
-    OLAPStatus _pull_next_block(MergeContext* merge_ctx);
+    OLAPStatus _pull_next_block(AlphaMergeContext* merge_ctx);
 
     // Doris will split query predicates to several scan keys
     // This function is used to fetch block when advancing
     // current scan key to next scan key.
-    OLAPStatus _pull_first_block(MergeContext* merge_ctx);
+    OLAPStatus _pull_first_block(AlphaMergeContext* merge_ctx);
 
 private:
     int _num_rows_per_row_block;
@@ -86,7 +86,7 @@ private:
     AlphaRowsetMeta* _alpha_rowset_meta;
     const std::vector<std::shared_ptr<SegmentGroup>>& _segment_groups;
 
-    std::vector<MergeContext> _merge_ctxs;
+    std::vector<AlphaMergeContext> _merge_ctxs;
     std::unique_ptr<RowBlock> _read_block;
     OLAPStatus (AlphaRowsetReader::*_next_block)(RowBlock** block) = nullptr;
     RowCursor* _dst_cursor = nullptr;


### PR DESCRIPTION
```
#8  0x0000000000bfa7be in std::default_delete<doris::Schema>::operator() (this=0x3988268, __ptr=0x3988270)
    at /usr/local/include/c++/7.2.0/bits/unique_ptr.h:78

    Program terminated with signal 4, Illegal instruction

```
The `MergeContext ` in alpha_rowset_reader.h is conflicted with `MergeContext` in generic_iterators.cpp.
