### PR TITLE
Remove length equal restrict in schema change

### DIFF
--- a/fe/src/main/java/org/apache/doris/catalog/Column.java
+++ b/fe/src/main/java/org/apache/doris/catalog/Column.java
@@ -255,7 +255,7 @@ public class Column implements Writable {
         if ((getDataType() == PrimitiveType.VARCHAR && other.getDataType() == PrimitiveType.VARCHAR)
                 || (getDataType() == PrimitiveType.CHAR && other.getDataType() == PrimitiveType.VARCHAR)
                 || (getDataType() == PrimitiveType.CHAR && other.getDataType() == PrimitiveType.CHAR)) {
-            if (getStrLen() >= other.getStrLen()) {
+            if (getStrLen() > other.getStrLen()) {
                 throw new DdlException("Cannot shorten string length");
             }
         }


### PR DESCRIPTION
#1920 

I found out that it was the length after schema change must be greater than or equal to the length before schema change. But "=" is unnecessary and restricts other normal operations, such as converting non-null types to nullable types without modifying the character length.

And If the user sends a schema change request of the same length, the operation of schema chang is not performed.  Doris can throw exception "ERROR 1064 (HY000): Nothing is changed. please check your alter stmt."