### PR TITLE
Replace std::regex with RE2

### DIFF
--- a/be/src/olap/tablet_manager.h
+++ b/be/src/olap/tablet_manager.h
@@ -96,6 +96,15 @@ public:
                                TabletUid tablet_uid, bool include_deleted = false,
                                std::string* err = nullptr);
 
+    // Extract tablet_id and schema_hash from given path.
+    //
+    // The normal path pattern is like "/data/{shard_id}/{tablet_id}/{schema_hash}/xxx.data".
+    // Besides that, this also support empty tablet path, which path looks like
+    // "/data/{shard_id}/{tablet_id}"
+    //
+    // Return true when the path matches the path pattern, and tablet_id and schema_hash is
+    // saved in input params. When input path is an empty tablet directory, schema_hash will
+    // be set to 0. Return false if the path don't match valid pattern.
     bool get_tablet_id_and_schema_hash_from_path(const std::string& path,
             TTabletId* tablet_id, TSchemaHash* schema_hash);
 

--- a/be/test/olap/tablet_mgr_test.cpp
+++ b/be/test/olap/tablet_mgr_test.cpp
@@ -210,18 +210,76 @@ TEST_F(TabletMgrTest, DropTablet) {
 }
 
 TEST_F(TabletMgrTest, GetRowsetId) {
-    std::string path = _engine_data_path + "/data/0/15007/368169781/020000000000000100000000000000020000000000000003_0_0.dat";
-    TTabletId tid;
-    TSchemaHash schema_hash;
-    ASSERT_TRUE(_tablet_mgr.get_tablet_id_and_schema_hash_from_path(path, &tid, &schema_hash));
-    ASSERT_EQ(15007, tid);
-    ASSERT_EQ(368169781, schema_hash);
+    // normal case
+    {
+        std::string path = _engine_data_path + "/data/0/15007/368169781";
+        TTabletId tid;
+        TSchemaHash schema_hash;
+        ASSERT_TRUE(_tablet_mgr.get_tablet_id_and_schema_hash_from_path(path, &tid, &schema_hash));
+        ASSERT_EQ(15007, tid);
+        ASSERT_EQ(368169781, schema_hash);
+    }
+    {
+        std::string path = _engine_data_path + "/data/0/15007/368169781/";
+        TTabletId tid;
+        TSchemaHash schema_hash;
+        ASSERT_TRUE(_tablet_mgr.get_tablet_id_and_schema_hash_from_path(path, &tid, &schema_hash));
+        ASSERT_EQ(15007, tid);
+        ASSERT_EQ(368169781, schema_hash);
+    }
+    // normal case
+    {
+        std::string path = _engine_data_path + "/data/0/15007/368169781/020000000000000100000000000000020000000000000003_0_0.dat";
+        TTabletId tid;
+        TSchemaHash schema_hash;
+        ASSERT_TRUE(_tablet_mgr.get_tablet_id_and_schema_hash_from_path(path, &tid, &schema_hash));
+        ASSERT_EQ(15007, tid);
+        ASSERT_EQ(368169781, schema_hash);
 
-    RowsetId id;
-    ASSERT_TRUE(_tablet_mgr.get_rowset_id_from_path(path, &id));
-    EXPECT_EQ(2UL << 56 | 1, id.hi);
-    ASSERT_EQ(2, id.mi);
-    ASSERT_EQ(3, id.lo);
+        RowsetId id;
+        ASSERT_TRUE(_tablet_mgr.get_rowset_id_from_path(path, &id));
+        EXPECT_EQ(2UL << 56 | 1, id.hi);
+        ASSERT_EQ(2, id.mi);
+        ASSERT_EQ(3, id.lo);
+    }
+    // empty tablet directory
+    {
+        std::string path = _engine_data_path + "/data/0/15007";
+        TTabletId tid;
+        TSchemaHash schema_hash;
+        ASSERT_TRUE(_tablet_mgr.get_tablet_id_and_schema_hash_from_path(path, &tid, &schema_hash));
+        ASSERT_EQ(15007, tid);
+        ASSERT_EQ(0, schema_hash);
+
+        RowsetId id;
+        ASSERT_FALSE(_tablet_mgr.get_rowset_id_from_path(path, &id));
+    }
+    // empty tablet directory
+    {
+        std::string path = _engine_data_path + "/data/0/15007/";
+        TTabletId tid;
+        TSchemaHash schema_hash;
+        ASSERT_TRUE(_tablet_mgr.get_tablet_id_and_schema_hash_from_path(path, &tid, &schema_hash));
+        ASSERT_EQ(15007, tid);
+        ASSERT_EQ(0, schema_hash);
+    }
+    // empty tablet directory
+    {
+        std::string path = _engine_data_path + "/data/0/15007abc";
+        TTabletId tid;
+        TSchemaHash schema_hash;
+        ASSERT_FALSE(_tablet_mgr.get_tablet_id_and_schema_hash_from_path(path, &tid, &schema_hash));
+    }
+    // not match pattern
+    {
+        std::string path = _engine_data_path + "/data/0/15007/123abc/020000000000000100000000000000020000000000000003_0_0.dat";
+        TTabletId tid;
+        TSchemaHash schema_hash;
+        ASSERT_FALSE(_tablet_mgr.get_tablet_id_and_schema_hash_from_path(path, &tid, &schema_hash));
+
+        RowsetId id;
+        ASSERT_FALSE(_tablet_mgr.get_rowset_id_from_path(path, &id));
+    }
 }
 
 }  // namespace doris

--- a/be/test/olap/tablet_mgr_test.cpp
+++ b/be/test/olap/tablet_mgr_test.cpp
@@ -209,6 +209,21 @@ TEST_F(TabletMgrTest, DropTablet) {
     ASSERT_TRUE(!dir_exist);
 }
 
+TEST_F(TabletMgrTest, GetRowsetId) {
+    std::string path = _engine_data_path + "/data/0/15007/368169781/020000000000000100000000000000020000000000000003_0_0.dat";
+    TTabletId tid;
+    TSchemaHash schema_hash;
+    ASSERT_TRUE(_tablet_mgr.get_tablet_id_and_schema_hash_from_path(path, &tid, &schema_hash));
+    ASSERT_EQ(15007, tid);
+    ASSERT_EQ(368169781, schema_hash);
+
+    RowsetId id;
+    ASSERT_TRUE(_tablet_mgr.get_rowset_id_from_path(path, &id));
+    EXPECT_EQ(2UL << 56 | 1, id.hi);
+    ASSERT_EQ(2, id.mi);
+    ASSERT_EQ(3, id.lo);
+}
+
 }  // namespace doris
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
In Storage Engine GC, TabletManger use std::regex to extract tablet id
and schema hash from path. But it will construct regex pattern for
every path to check, this is a huge waste. This change list make this
pattern a global static pattern, and replace it with RE2, which has
better performance.

For #1928 