### PR TITLE
BugFix:issue:#889

### DIFF
--- a/fe/src/main/java/org/apache/doris/common/ConfigBase.java
+++ b/fe/src/main/java/org/apache/doris/common/ConfigBase.java
@@ -125,7 +125,7 @@ public class ConfigBase {
             // ensure that field has property string
             String confKey = anno.value().equals("") ? f.getName() : anno.value();
             String confVal = props.getProperty(confKey);
-            if (confVal == null) {
+            if (Strings.isNullOrEmpty(confVal)) {
                 continue;
             }
             


### PR DESCRIPTION
Having sys_log_verbose_modules =  in fe.conf will lead no log because empty strings are assigned to Config variables. So filter empty strings of properties in file fe.conf