### PR TITLE
Invalid hash value of DateLiteral

### DIFF
--- a/fe/src/main/java/org/apache/doris/analysis/DateLiteral.java
+++ b/fe/src/main/java/org/apache/doris/analysis/DateLiteral.java
@@ -280,11 +280,7 @@ public class DateLiteral extends LiteralExpr {
 
     @Override
     public String getStringValue() {
-        if (type == Type.DATE) {
-            return convertToString(PrimitiveType.DATE);
-        } else {
-            return convertToString(PrimitiveType.DATETIME);
-        }
+        return convertToString(type.getPrimitiveType());
     }
 
     private String convertToString(PrimitiveType type) {

--- a/fe/src/main/java/org/apache/doris/analysis/DateLiteral.java
+++ b/fe/src/main/java/org/apache/doris/analysis/DateLiteral.java
@@ -250,7 +250,7 @@ public class DateLiteral extends LiteralExpr {
     // Date column and Datetime column's hash value is not same.
     @Override
     public ByteBuffer getHashValue(PrimitiveType type) {
-        String value = getStringValue();
+        String value = convertToString(type);
         ByteBuffer buffer;
         try {
             buffer = ByteBuffer.wrap(value.getBytes("UTF-8"));
@@ -281,6 +281,14 @@ public class DateLiteral extends LiteralExpr {
     @Override
     public String getStringValue() {
         if (type == Type.DATE) {
+            return convertToString(PrimitiveType.DATE);
+        } else {
+            return convertToString(PrimitiveType.DATETIME);
+        }
+    }
+
+    private String convertToString(PrimitiveType type) {
+        if (type == PrimitiveType.DATE) {
             return String.format("%04d-%02d-%02d", year, month, day);
         } else {
             return String.format("%04d-%02d-%02d %02d:%02d:%02d", year, month, day, hour, minute, second);


### PR DESCRIPTION
A query which can be pruned by distribution column filters will return invalid result if it contains date type distribution column filters.
The _type_ property of DateLiteral, which is _DATETIME_ by default,  is unchecked. It can be fixed by calculate hash value according to the parameter of method _getHashValue_.
