### PR TITLE
Added: Add tdigest compression param for pencentile_approx function

### DIFF
--- a/be/src/exprs/aggregate_functions.cpp
+++ b/be/src/exprs/aggregate_functions.cpp
@@ -247,7 +247,6 @@ public:
 void AggregateFunctions::percentile_approx_init(FunctionContext* ctx, StringVal* dst) {
     dst->is_null = false;
     dst->len = sizeof(PercentileApproxState);
-    std::cout << ctx->get_num_args() << std::endl;
     const AnyVal* digest_compression = ctx->get_constant_arg(2);
     if (digest_compression != nullptr) {
         double compression = reinterpret_cast<const DoubleVal*>(digest_compression)->val;

--- a/be/src/exprs/aggregate_functions.h
+++ b/be/src/exprs/aggregate_functions.h
@@ -71,6 +71,10 @@ public:
     template <typename T>
     static void percentile_approx_update(FunctionContext* ctx, const T& src, const DoubleVal& quantile, StringVal* dst);
 
+    template <typename T>
+    static void percentile_approx_update(FunctionContext* ctx, const T& src, const DoubleVal& quantile,
+            const DoubleVal& digest_compression, StringVal* dst);
+
     static void percentile_approx_merge(FunctionContext* ctx, const StringVal& src, StringVal* dst);
 
     static DoubleVal percentile_approx_finalize(FunctionContext* ctx, const StringVal& src);
@@ -198,13 +202,13 @@ dst);
     template <typename T>
     static BigIntVal count_or_sum_distinct_numeric_finalize(FunctionContext* ctx, const StringVal& state_sv);
 
-    // count distinct in multi distinct for string 
+    // count distinct in multi distinct for string
     static void count_distinct_string_init(doris_udf::FunctionContext* ctx, doris_udf::StringVal* dst);
     static void count_distinct_string_update(FunctionContext* ctx, StringVal& src, StringVal* dst);
     static void count_distinct_string_merge(FunctionContext* ctx, StringVal& src, StringVal* dst);
     static StringVal count_distinct_string_serialize(FunctionContext* ctx, const StringVal& state_sv);
     static BigIntVal count_distinct_string_finalize(FunctionContext* ctx, const StringVal& state_sv);
- 
+
     // count distinct in multi distinct for decimal
     static void count_or_sum_distinct_decimal_init(doris_udf::FunctionContext* ctx, doris_udf::StringVal* dst);
     static void count_or_sum_distinct_decimalv2_init(doris_udf::FunctionContext* ctx, doris_udf::StringVal* dst);
@@ -225,13 +229,13 @@ dst);
     static void count_distinct_date_merge(FunctionContext* ctx, StringVal& src, StringVal* dst);
     static StringVal count_distinct_date_serialize(FunctionContext* ctx, const StringVal& state_sv);
     static BigIntVal count_distinct_date_finalize(FunctionContext* ctx, const StringVal& state_sv);
- 
+
     template <typename T>
     static BigIntVal sum_distinct_bigint_finalize(FunctionContext* ctx, const StringVal& state_sv);
     template <typename T>
     static LargeIntVal sum_distinct_largeint_finalize(FunctionContext* ctx, const StringVal& state_sv);
     template <typename T>
-    static DoubleVal sum_distinct_double_finalize(FunctionContext* ctx, const StringVal& state_sv); 
+    static DoubleVal sum_distinct_double_finalize(FunctionContext* ctx, const StringVal& state_sv);
 
     /// Knuth's variance algorithm, more numerically stable than canonical stddev
     /// algorithms; reference implementation:

--- a/docs/documentation/cn/sql-reference/sql-functions/aggregate-functions/percentile_approx.md
+++ b/docs/documentation/cn/sql-reference/sql-functions/aggregate-functions/percentile_approx.md
@@ -2,10 +2,13 @@
 ## description
 ### Syntax
 
-`PERCENTILE_APPROX(expr, DOUBLE p)`
+`PERCENTILE_APPROX(expr, DOUBLE p[, DOUBLE compression])`
 
 
 返回第p个百分位点的近似值，p的值介于0到1之间
+
+compression参数是可选项，可设置范围是(0, 10000)，值越大，精度越高，内存消耗越大，计算耗时越长。
+compression参数未指定或设置的值在(0, 10000)范围外，以10000的默认值运行
 
 该函数使用固定大小的内存，因此对于高基数的列可以使用更少的内存，可用于计算tp99等统计值
 
@@ -16,6 +19,13 @@ MySQL > select `table`, percentile_approx(cost_time,0.99) from log_statis group 
 | table    | percentile_approx(`cost_time`, 0.99) |
 +----------+--------------------------------------+
 | test     |                                54.22 |
++----------+--------------------------------------+
+
+MySQL > select `table`, percentile_approx(cost_time,0.99, 100) from log_statis group by `table`;
++---------------------+---------------------------+
+| table    | percentile_approx(`cost_time`, 0.99, 100) |
++----------+--------------------------------------+
+| test     |                                54.21 |
 +----------+--------------------------------------+
 ##keyword
 PERCENTILE_APPROX,PERCENTILE,APPROX

--- a/docs/documentation/en/sql-reference/sql-functions/aggregate-functions/percentile_approx_EN.md
+++ b/docs/documentation/en/sql-reference/sql-functions/aggregate-functions/percentile_approx_EN.md
@@ -2,10 +2,11 @@
 ## Description
 ### Syntax
 
-`PERCENTILE_APPROX(expr, DOUBLE p)`
-
+`PERCENTILE_APPROX(expr, DOUBLE p[, DOUBLE compression])`
 
 Return the approximation of the point p, where the value of P is between 0 and 1.
+
+Compression param is optional and can be setted to a value in the range of (0, 10000). The bigger compression you set, the more precise result and more time cost you will get. If it is not setted or not setted in the correct range, PERCENTILE_APPROX function will run with a default compression param of 10000.
 
 This function uses fixed size memory, so less memory can be used for columns with high cardinality, and can be used to calculate statistics such as tp99.
 
@@ -16,6 +17,12 @@ MySQL > select `table`, percentile_approx(cost_time,0.99) from log_statis group 
 | table    | percentile_approx(`cost_time`, 0.99) |
 +----------+--------------------------------------+
 | test     |                                54.22 |
++----------+--------------------------------------+
+MySQL > select `table`, percentile_approx(cost_time,0.99, 100) from log_statis group by `table`;
++---------------------+---------------------------+
+| table    | percentile_approx(`cost_time`, 0.99, 100) |
++----------+--------------------------------------+
+| test     |                                54.21 |
 +----------+--------------------------------------+
 ##keyword
 PERCENTILE_APPROX,PERCENTILE,APPROX

--- a/fe/src/main/java/org/apache/doris/analysis/AnalyticWindow.java
+++ b/fe/src/main/java/org/apache/doris/analysis/AnalyticWindow.java
@@ -350,7 +350,7 @@ public class AnalyticWindow {
 
         if (e.isConstant() && e.getType().isNumericType()) {
             try {
-                val=e.getConstFromExpr(e);
+                val = Expr.getConstFromExpr(e);
 //                val = TColumnValueUtil.getNumericVal(
 //                        FeSupport.EvalConstExpr(e, analyzer.getQueryGlobals()));
 
@@ -400,8 +400,8 @@ public class AnalyticWindow {
         try {
 //            TColumnValue val1 = FeSupport.EvalConstExpr(e1, analyzer.getQueryGlobals());
 //            TColumnValue val2 = FeSupport.EvalConstExpr(e2, analyzer.getQueryGlobals());
-            double left = e1.getConstFromExpr(e1);
-            double right = e2.getConstFromExpr(e2);
+            double left = Expr.getConstFromExpr(e1);
+            double right = Expr.getConstFromExpr(e2);
 
             if (left > right) {
                 throw new AnalysisException(

--- a/fe/src/main/java/org/apache/doris/analysis/Expr.java
+++ b/fe/src/main/java/org/apache/doris/analysis/Expr.java
@@ -632,7 +632,7 @@ abstract public class Expr extends TreeNode<Expr> implements ParseNode, Cloneabl
      * If smap is null, this function is equivalent to clone().
      * If preserveRootType is true, the resulting expr tree will be cast if necessary to
      * the type of 'this'.
-     * 
+     *
      * @throws AnalysisException
      */
     public Expr substitute(ExprSubstitutionMap smap, Analyzer analyzer, boolean preserveRootType)
@@ -1322,7 +1322,7 @@ abstract public class Expr extends TreeNode<Expr> implements ParseNode, Cloneabl
         return this;
     }
 
-    public double getConstFromExpr(Expr e) throws AnalysisException{
+    public static double getConstFromExpr(Expr e) throws AnalysisException{
         Preconditions.checkState(e.isConstant());
         double value = 0;
         if( e instanceof LiteralExpr){

--- a/fe/src/main/java/org/apache/doris/analysis/FunctionCallExpr.java
+++ b/fe/src/main/java/org/apache/doris/analysis/FunctionCallExpr.java
@@ -167,7 +167,7 @@ public class FunctionCallExpr extends Expr {
             fn = null;
         }
     }
-    
+
     @Override
     public boolean equals(Object obj) {
         if (!super.equals(obj)) {
@@ -278,7 +278,7 @@ public class FunctionCallExpr extends Expr {
                 throw new AnalysisException(
                         "COUNT must have DISTINCT for multiple arguments: " + this.toSql());
             }
-            
+
             for (int i = 0; i < children.size(); i++) {
                 if (children.get(i).type.isHllType()) {
                     throw new AnalysisException(
@@ -319,7 +319,7 @@ public class FunctionCallExpr extends Expr {
                 if (arg0.type.isHllType()) {
                     throw new AnalysisException(
                             "group_concat requires second parameter can't be of type HLL: " + this.toSql());
-                } 
+                }
             }
             return;
         }
@@ -368,7 +368,7 @@ public class FunctionCallExpr extends Expr {
                     "SUM_DISTINCT requires a numeric parameter: " + this.toSql());
         }
 
-        if ((fnName.getFunction().equalsIgnoreCase("min") 
+        if ((fnName.getFunction().equalsIgnoreCase("min")
                 || fnName.getFunction().equalsIgnoreCase("max")
                 || fnName.getFunction().equalsIgnoreCase("DISTINCT_PC")
                 || fnName.getFunction().equalsIgnoreCase("DISTINCT_PCSA")
@@ -421,12 +421,18 @@ public class FunctionCallExpr extends Expr {
         }
 
         if (fnName.getFunction().equalsIgnoreCase("percentile_approx")) {
-            if (children.size() != 2) {
-                throw new AnalysisException("percentile_approx(expr, DOUBLE) requires two parameters");
+            if (children.size() != 2 && children.size() != 3) {
+                throw new AnalysisException("percentile_approx(expr, DOUBLE [, B]) requires two or three parameters");
             }
             if (!getChild(1).isConstant()) {
                 throw new AnalysisException("percentile_approx requires second parameter must be a constant : "
                         + this.toSql());
+            }
+            if (children.size() == 3) {
+                if (!getChild(2).isConstant()) {
+                    throw new AnalysisException("percentile_approx requires the third parameter must be a constant : "
+                            + this.toSql());
+                }
             }
         }
         return;
@@ -558,7 +564,7 @@ public class FunctionCallExpr extends Expr {
             LOG.warn("fn {} not exists", fnName.getFunction());
             throw new AnalysisException(getFunctionNotFoundError(collectChildReturnTypes()));
         }
-        
+
         if (fn.getFunctionName().getFunction().equals("time_diff")) {
             fn.getReturnType().getPrimitiveType().setTimeType();
             return;

--- a/fe/src/main/java/org/apache/doris/catalog/FunctionSet.java
+++ b/fe/src/main/java/org/apache/doris/catalog/FunctionSet.java
@@ -127,7 +127,7 @@ public class FunctionSet {
                     "3maxIN9doris_udf11LargeIntValEEEvPNS2_15FunctionContextERKT_PS6_")
                .build();
 
-    private static final Map<Type, Type> MULTI_DISTINCT_SUM_RETURN_TYPE = 
+    private static final Map<Type, Type> MULTI_DISTINCT_SUM_RETURN_TYPE =
              ImmutableMap.<Type, Type>builder()
                     .put(Type.TINYINT, Type.BIGINT)
                     .put(Type.SMALLINT, Type.BIGINT)
@@ -138,7 +138,7 @@ public class FunctionSet {
                     .put(Type.LARGEINT, Type.LARGEINT)
                     .put(Type.DECIMAL, Type.DECIMAL)
                     .put(Type.DECIMALV2, Type.DECIMALV2)
-                    .build(); 
+                    .build();
 
     private static final Map<Type, String> MULTI_DISTINCT_INIT_SYMBOL =
             ImmutableMap.<Type, String>builder()
@@ -229,8 +229,8 @@ public class FunctionSet {
                     .put(Type.LARGEINT,
                             "38count_or_sum_distinct_numeric_finalizeIN9doris_udf11LargeIntValEEENS2_9BigIntValEPNS2_15FunctionContextERKNS2_9StringValE")
                     .build();
-   
-    
+
+
     private static final Map<Type, String> MULTI_DISTINCT_SUM_FINALIZE_SYMBOL =
              ImmutableMap.<Type, String>builder()
                     .put(Type.BIGINT,
@@ -290,7 +290,7 @@ public class FunctionSet {
                 .put(Type.LARGEINT,
                     "10hll_updateIN9doris_udf11LargeIntValEEEvPNS2_15FunctionContextERKT_PNS2_9StringValE")
                 .build();
-   
+
 
     private static final Map<Type, String> HLL_UNION_AGG_UPDATE_SYMBOL =
         ImmutableMap.<Type, String>builder()
@@ -299,7 +299,7 @@ public class FunctionSet {
                 .put(Type.HLL,
                         "_ZN5doris12HllFunctions9hll_mergeEPN9doris_udf15FunctionContextERKNS1_9StringValEPS4_")
                 .build();
- 
+
     private static final Map<Type, String> OFFSET_FN_INIT_SYMBOL =
         ImmutableMap.<Type, String>builder()
                 .put(Type.BOOLEAN,
@@ -571,7 +571,7 @@ public class FunctionSet {
     }
 
     /**
-     * There are essential differences in the implementation of some functions for different 
+     * There are essential differences in the implementation of some functions for different
      * types params, which should be prohibited.
      * @param desc
      * @param candicate
@@ -581,7 +581,7 @@ public class FunctionSet {
         final String functionName = desc.getFunctionName().getFunction();
         final Type[] descArgTypes = desc.getArgs();
         final Type[] candicateArgTypes = candicate.getArgs();
-        if (functionName.equalsIgnoreCase("hex") 
+        if (functionName.equalsIgnoreCase("hex")
                 || functionName.equalsIgnoreCase("greast")
                 || functionName.equalsIgnoreCase("least")) {
             final ScalarType descArgType = (ScalarType)descArgTypes[0];
@@ -704,18 +704,18 @@ public class FunctionSet {
                     prefix + "12count_removeEPN9doris_udf15FunctionContextERKNS1_6AnyValEPNS1_9BigIntValE",
                     null, false, true, true));
 
-           
+
             // count in multi distinct
             if (t == Type.CHAR || t == Type.VARCHAR) {
-               addBuiltin(AggregateFunction.createBuiltin("multi_distinct_count", Lists.newArrayList(t), 
+               addBuiltin(AggregateFunction.createBuiltin("multi_distinct_count", Lists.newArrayList(t),
                     Type.BIGINT,
-                    Type.VARCHAR, 
+                    Type.VARCHAR,
                     prefix + "26count_distinct_string_initEPN9doris_udf15FunctionContextEPNS1_9StringValE",
                     prefix + "28count_distinct_string_updateEPN9doris_udf15FunctionContextERNS1_9StringValEPS4_",
-                    prefix + "27count_distinct_string_mergeEPN9doris_udf15FunctionContextERNS1_9StringValEPS4_", 
-                    prefix + "31count_distinct_string_serializeEPN9doris_udf15FunctionContextERKNS1_9StringValE",  
-                    null,      
-                    null, 
+                    prefix + "27count_distinct_string_mergeEPN9doris_udf15FunctionContextERNS1_9StringValEPS4_",
+                    prefix + "31count_distinct_string_serializeEPN9doris_udf15FunctionContextERKNS1_9StringValE",
+                    null,
+                    null,
                     prefix + "30count_distinct_string_finalizeEPN9doris_udf15FunctionContextERKNS1_9StringValE",
                     false, true, true));
 
@@ -729,31 +729,31 @@ public class FunctionSet {
                     "_ZN5doris15BitmapFunctions16bitmap_serializeEPN9doris_udf15FunctionContextERKNS1_9StringValE",
                     true, false, true));
 
-            } else if (t == Type.TINYINT || t == Type.SMALLINT || t == Type.INT 
+            } else if (t == Type.TINYINT || t == Type.SMALLINT || t == Type.INT
                 || t == Type.BIGINT || t == Type.LARGEINT || t == Type.DOUBLE) {
-               addBuiltin(AggregateFunction.createBuiltin("multi_distinct_count", Lists.newArrayList(t), 
+               addBuiltin(AggregateFunction.createBuiltin("multi_distinct_count", Lists.newArrayList(t),
                     Type.BIGINT,
-                    Type.VARCHAR, 
+                    Type.VARCHAR,
                     prefix + MULTI_DISTINCT_INIT_SYMBOL.get(t),
                     prefix + MULTI_DISTINCT_UPDATE_SYMBOL.get(t),
-                    prefix + MULTI_DISTINCT_MERGE_SYMBOL.get(t), 
-                    prefix + MULTI_DISTINCT_SERIALIZE_SYMBOL.get(t),  
-                    null,                      
-                    null, 
+                    prefix + MULTI_DISTINCT_MERGE_SYMBOL.get(t),
+                    prefix + MULTI_DISTINCT_SERIALIZE_SYMBOL.get(t),
+                    null,
+                    null,
                     prefix + MULTI_DISTINCT_COUNT_FINALIZE_SYMBOL.get(t),
                     false, true, true));
             } else if (t == Type.DATE || t == Type.DATETIME) {
-               addBuiltin(AggregateFunction.createBuiltin("multi_distinct_count", Lists.newArrayList(t), 
+               addBuiltin(AggregateFunction.createBuiltin("multi_distinct_count", Lists.newArrayList(t),
                     Type.BIGINT,
-                    Type.VARCHAR, 
+                    Type.VARCHAR,
                     prefix + "24count_distinct_date_initEPN9doris_udf15FunctionContextEPNS1_9StringValE",
                     prefix + "26count_distinct_date_updateEPN9doris_udf15FunctionContextERNS1_11DateTimeValEPNS1_9StringValE",
                     prefix + "25count_distinct_date_mergeEPN9doris_udf15FunctionContextERNS1_9StringValEPS4_",
-                    prefix + "29count_distinct_date_serializeEPN9doris_udf15FunctionContextERKNS1_9StringValE",  
-                    null,    
-                    null, 
+                    prefix + "29count_distinct_date_serializeEPN9doris_udf15FunctionContextERKNS1_9StringValE",
+                    null,
+                    null,
                     prefix + "28count_distinct_date_finalizeEPN9doris_udf15FunctionContextERKNS1_9StringValE",
-                    false, true, true)); 
+                    false, true, true));
             } else if (t == Type.DECIMAL) {
                addBuiltin(AggregateFunction.createBuiltin("multi_distinct_count", Lists.newArrayList(t),
                     Type.BIGINT,
@@ -765,7 +765,7 @@ public class FunctionSet {
                     null,
                     null,
                     prefix + "31count_distinct_decimal_finalizeEPN9doris_udf15FunctionContextERKNS1_9StringValE",
-                    false, true, true)); 
+                    false, true, true));
             } else if (t == Type.DECIMALV2) {
                addBuiltin(AggregateFunction.createBuiltin("multi_distinct_count", Lists.newArrayList(t),
                     Type.BIGINT,
@@ -777,20 +777,20 @@ public class FunctionSet {
                     null,
                     null,
                     prefix + "33count_distinct_decimalv2_finalizeEPN9doris_udf15FunctionContextERKNS1_9StringValE",
-                    false, true, true)); 
+                    false, true, true));
             }
 
             // sum in multi distinct
             if (t == Type.BIGINT || t == Type.LARGEINT || t == Type.DOUBLE) {
-                addBuiltin(AggregateFunction.createBuiltin("multi_distinct_sum", Lists.newArrayList(t), 
+                addBuiltin(AggregateFunction.createBuiltin("multi_distinct_sum", Lists.newArrayList(t),
                     t,
-                    Type.VARCHAR, 
+                    Type.VARCHAR,
                     prefix + MULTI_DISTINCT_INIT_SYMBOL.get(t),
                     prefix + MULTI_DISTINCT_UPDATE_SYMBOL.get(t),
-                    prefix + MULTI_DISTINCT_MERGE_SYMBOL.get(t), 
-                    prefix + MULTI_DISTINCT_SERIALIZE_SYMBOL.get(t),  
-                    null,                      
-                    null, 
+                    prefix + MULTI_DISTINCT_MERGE_SYMBOL.get(t),
+                    prefix + MULTI_DISTINCT_SERIALIZE_SYMBOL.get(t),
+                    null,
+                    null,
                     prefix + MULTI_DISTINCT_SUM_FINALIZE_SYMBOL.get(t),
                     false, true, true));
             }  else if (t == Type.DECIMAL) {
@@ -998,7 +998,14 @@ public class FunctionSet {
                 prefix + "27percentile_approx_serializeEPN9doris_udf15FunctionContextERKNS1_9StringValE",
                 prefix + "26percentile_approx_finalizeEPN9doris_udf15FunctionContextERKNS1_9StringValE",
                 false, false, false));
-
+        addBuiltin(AggregateFunction.createBuiltin("percentile_approx",
+                Lists.<Type>newArrayList(Type.DOUBLE, Type.DOUBLE, Type.DOUBLE), Type.DOUBLE, Type.VARCHAR,
+                prefix + "22percentile_approx_initEPN9doris_udf15FunctionContextEPNS1_9StringValE",
+                prefix + "24percentile_approx_updateIN9doris_udf9DoubleValEEEvPNS2_15FunctionContextERKT_RKS3_SA_PNS2_9StringValE",
+                prefix + "23percentile_approx_mergeEPN9doris_udf15FunctionContextERKNS1_9StringValEPS4_",
+                prefix + "27percentile_approx_serializeEPN9doris_udf15FunctionContextERKNS1_9StringValE",
+                prefix + "26percentile_approx_finalizeEPN9doris_udf15FunctionContextERKNS1_9StringValE",
+                false, false, false));
 
         // Avg
         // TODO: switch to CHAR(sizeof(AvgIntermediateType) when that becomes available


### PR DESCRIPTION
Add tdigest compression param for pencentile_approx function. The compression param should be in range (0, 10000] and we can get a more precise result and cost more time when setting the param a bigger value.