### PR TITLE
Remove redundant method in rowset meta manager

### DIFF
--- a/be/src/olap/data_dir.cpp
+++ b/be/src/olap/data_dir.cpp
@@ -573,11 +573,9 @@ OLAPStatus DataDir::_convert_old_tablet() {
 
         // write pending rowset to olap meta
         for (auto& rowset_pb : pending_rowsets) {
-            string meta_binary;
-            rowset_pb.SerializeToString(&meta_binary);
             RowsetId rowset_id;
             rowset_id.init(rowset_pb.rowset_id_v2());
-            status = RowsetMetaManager::save(_meta, rowset_pb.tablet_uid(), rowset_id, meta_binary);
+            status = RowsetMetaManager::save(_meta, rowset_pb.tablet_uid(), rowset_id, rowset_pb);
             if (status != OLAP_SUCCESS) {
                 LOG(FATAL) << "convert olap header to tablet meta failed when save rowset meta tablet=" 
                              << tablet_id << "." << schema_hash;

--- a/be/src/olap/rowset/rowset_meta_manager.cpp
+++ b/be/src/olap/rowset/rowset_meta_manager.cpp
@@ -139,7 +139,9 @@ OLAPStatus RowsetMetaManager::load_json_rowset_meta(OlapMeta* meta, const std::s
     }
     RowsetId rowset_id = rowset_meta.rowset_id();
     TabletUid tablet_uid = rowset_meta.tablet_uid();
-    OLAPStatus status = save(meta, tablet_uid, rowset_id, &rowset_meta);
+    RowsetMetaPB rowset_meta_pb;
+    rowset_meta.to_rowset_pb(&rowset_meta_pb);
+    OLAPStatus status = save(meta, tablet_uid, rowset_id, rowset_meta_pb);
     return status;
 }
 

--- a/be/src/olap/rowset/rowset_meta_manager.cpp
+++ b/be/src/olap/rowset/rowset_meta_manager.cpp
@@ -79,22 +79,16 @@ OLAPStatus RowsetMetaManager::get_json_rowset_meta(OlapMeta* meta, TabletUid tab
     return OLAP_SUCCESS;
 }
 
-OLAPStatus RowsetMetaManager::save(OlapMeta* meta, TabletUid tablet_uid, const RowsetId& rowset_id, RowsetMeta* rowset_meta) {
+OLAPStatus RowsetMetaManager::save(OlapMeta* meta, TabletUid tablet_uid, const RowsetId& rowset_id, const RowsetMetaPB& rowset_meta_pb) {
     std::string key = ROWSET_PREFIX + tablet_uid.to_string() + "_" + rowset_id.to_string();
     std::string value;
-    bool ret = rowset_meta->serialize(&value);
+    bool ret = rowset_meta_pb.SerializeToString(&value);;
     if (!ret) {
         std::string error_msg = "serialize rowset pb failed. rowset id:" + key;
         LOG(WARNING) << error_msg;
         return OLAP_ERR_SERIALIZE_PROTOBUF_ERROR;
     }
     OLAPStatus status = meta->put(META_COLUMN_FAMILY_INDEX, key, value);
-    return status;
-}
-
-OLAPStatus RowsetMetaManager::save(OlapMeta* meta, TabletUid tablet_uid, const RowsetId& rowset_id, const string& meta_binary) {
-    std::string key = ROWSET_PREFIX + tablet_uid.to_string() + "_" + rowset_id.to_string();
-    OLAPStatus status = meta->put(META_COLUMN_FAMILY_INDEX, key, meta_binary);
     return status;
 }
 

--- a/be/src/olap/rowset/rowset_meta_manager.h
+++ b/be/src/olap/rowset/rowset_meta_manager.h
@@ -37,9 +37,7 @@ public:
 
     static OLAPStatus get_json_rowset_meta(OlapMeta* meta, TabletUid tablet_uid, const RowsetId& rowset_id, std::string* json_rowset_meta);
 
-    static OLAPStatus save(OlapMeta* meta, TabletUid tablet_uid, const RowsetId& rowset_id, RowsetMeta* rowset_meta);
-
-    static OLAPStatus save(OlapMeta* meta, TabletUid tablet_uid, const RowsetId& rowset_id, const string& meta_binary);
+    static OLAPStatus save(OlapMeta* meta, TabletUid tablet_uid, const RowsetId& rowset_id, const RowsetMetaPB& rowset_meta_pb);
 
     static OLAPStatus remove(OlapMeta* meta, TabletUid tablet_uid, const RowsetId& rowset_id);
 

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -275,8 +275,10 @@ OLAPStatus Tablet::add_rowset(RowsetSharedPtr rowset, bool need_persist) {
     modify_rowsets(std::vector<RowsetSharedPtr>(), rowsets_to_delete);
 
     if (need_persist) {
+        RowsetMetaPB rowset_meta_pb;
+        rowset->rowset_meta()->to_rowset_pb(&rowset_meta_pb);
         OLAPStatus res = RowsetMetaManager::save(data_dir()->get_meta(), tablet_uid(), 
-            rowset->rowset_id(), rowset->rowset_meta().get());
+            rowset->rowset_id(), rowset_meta_pb);
         if (res != OLAP_SUCCESS) {
             LOG(FATAL) << "failed to save rowset to local meta store" << rowset->rowset_id();
         }

--- a/be/src/olap/txn_manager.cpp
+++ b/be/src/olap/txn_manager.cpp
@@ -182,8 +182,9 @@ OLAPStatus TxnManager::commit_txn(
     // save meta need access disk, it maybe very slow, so that it is not in global txn lock
     // it is under a single txn lock
     if (!is_recovery) {
-        OLAPStatus save_status = RowsetMetaManager::save(meta, tablet_uid, rowset_ptr->rowset_id(),
-            rowset_ptr->rowset_meta().get());
+        RowsetMetaPB rowset_meta_pb;
+        rowset->rowset_meta()->to_rowset_pb(&rowset_meta_pb);
+        OLAPStatus save_status = RowsetMetaManager::save(meta, tablet_uid, rowset_ptr->rowset_id(), rowset_meta_pb);
         if (save_status != OLAP_SUCCESS) {
             LOG(WARNING) << "save committed rowset failed. when commit txn rowset_id:"
                         << rowset_ptr->rowset_id()
@@ -234,9 +235,9 @@ OLAPStatus TxnManager::publish_txn(OlapMeta* meta, TPartitionId partition_id, TT
         // TODO(ygl): rowset is already set version here, memory is changed, if save failed
         // it maybe a fatal error
         rowset_ptr->make_visible(version, version_hash);
-        OLAPStatus save_status = RowsetMetaManager::save(meta, tablet_uid, 
-            rowset_ptr->rowset_id(),
-            rowset_ptr->rowset_meta().get());
+        RowsetMetaPB rowset_meta_pb;
+        rowset->rowset_meta()->to_rowset_pb(&rowset_meta_pb);
+        OLAPStatus save_status = RowsetMetaManager::save(meta, tablet_uid, rowset_ptr->rowset_id(), rowset_meta_pb);
         if (save_status != OLAP_SUCCESS) {
             LOG(WARNING) << "save committed rowset failed. when publish txn rowset_id:"
                          << rowset_ptr->rowset_id()

--- a/be/src/olap/txn_manager.cpp
+++ b/be/src/olap/txn_manager.cpp
@@ -183,7 +183,7 @@ OLAPStatus TxnManager::commit_txn(
     // it is under a single txn lock
     if (!is_recovery) {
         RowsetMetaPB rowset_meta_pb;
-        rowset->rowset_meta()->to_rowset_pb(&rowset_meta_pb);
+        rowset_ptr->rowset_meta()->to_rowset_pb(&rowset_meta_pb);
         OLAPStatus save_status = RowsetMetaManager::save(meta, tablet_uid, rowset_ptr->rowset_id(), rowset_meta_pb);
         if (save_status != OLAP_SUCCESS) {
             LOG(WARNING) << "save committed rowset failed. when commit txn rowset_id:"
@@ -236,7 +236,7 @@ OLAPStatus TxnManager::publish_txn(OlapMeta* meta, TPartitionId partition_id, TT
         // it maybe a fatal error
         rowset_ptr->make_visible(version, version_hash);
         RowsetMetaPB rowset_meta_pb;
-        rowset->rowset_meta()->to_rowset_pb(&rowset_meta_pb);
+        rowset_ptr->rowset_meta()->to_rowset_pb(&rowset_meta_pb);
         OLAPStatus save_status = RowsetMetaManager::save(meta, tablet_uid, rowset_ptr->rowset_id(), rowset_meta_pb);
         if (save_status != OLAP_SUCCESS) {
             LOG(WARNING) << "save committed rowset failed. when publish txn rowset_id:"

--- a/be/test/olap/rowset/rowset_meta_manager_test.cpp
+++ b/be/test/olap/rowset/rowset_meta_manager_test.cpp
@@ -92,7 +92,9 @@ TEST_F(RowsetMetaManagerTest, TestSaveAndGetAndRemove) {
     RowsetMeta rowset_meta;
     rowset_meta.init_from_json(_json_rowset_meta);
     ASSERT_EQ(rowset_meta.rowset_id(), rowset_id);
-    OLAPStatus status = RowsetMetaManager::save(_meta, _tablet_uid, rowset_id, &rowset_meta);
+    RowsetMetaPB rowset_meta_pb;
+    rowset_meta.to_rowset_pb(&rowset_meta_pb);
+    OLAPStatus status = RowsetMetaManager::save(_meta, _tablet_uid, rowset_id, rowset_meta_pb);
     ASSERT_TRUE(status == OLAP_SUCCESS);
     ASSERT_TRUE(RowsetMetaManager::check_rowset_meta(_meta, _tablet_uid, rowset_id));
     std::string json_rowset_meta_read;


### PR DESCRIPTION
There are two save rowset method in rowset meta manager using different parameters. One is rowset meta and the other is string. Most of the code is same, and it is very difficult to maintain in ECON mode, so that I remove them and using the RowsetMetaPB.