### PR TITLE
Refactor txn manager methods

### DIFF
--- a/be/src/olap/delta_writer.cpp
+++ b/be/src/olap/delta_writer.cpp
@@ -58,7 +58,7 @@ DeltaWriter::~DeltaWriter() {
 void DeltaWriter::_garbage_collection() {
     OLAPStatus rollback_status = OLAP_SUCCESS;
     if (_tablet != nullptr) {
-        rollback_status = _storage_engine->txn_manager()->rollback_txn(_tablet, _req.txn_id);
+        rollback_status = _storage_engine->txn_manager()->rollback_txn(_req.partition_id, _tablet, _req.txn_id);
     }
     // has to check rollback status, because the rowset maybe committed in this thread and
     // published in another thread, then rollback will failed
@@ -67,7 +67,7 @@ void DeltaWriter::_garbage_collection() {
         _storage_engine->add_unused_rowset(_cur_rowset);
     }
     if (_new_tablet != nullptr) {
-        rollback_status = _storage_engine->txn_manager()->rollback_txn(_new_tablet, _req.txn_id);
+        rollback_status = _storage_engine->txn_manager()->rollback_txn(_req.partition_id, _new_tablet, _req.txn_id);
         if (rollback_status == OLAP_SUCCESS) {
             _storage_engine->add_unused_rowset(_new_rowset);
         }
@@ -88,7 +88,7 @@ OLAPStatus DeltaWriter::init() {
             return OLAP_ERR_RWLOCK_ERROR;
         }
         MutexLock push_lock(_tablet->get_push_lock());
-        RETURN_NOT_OK(_storage_engine->txn_manager()->prepare_txn(_tablet, _req.txn_id, _req.load_id));
+        RETURN_NOT_OK(_storage_engine->txn_manager()->prepare_txn(_req.partition_id, _tablet, _req.txn_id, _req.load_id));
         if (_req.need_gen_rollup) {
             AlterTabletTaskSharedPtr alter_task = _tablet->alter_task();
             if (alter_task != nullptr && alter_task->alter_state() != ALTER_FAILED) {
@@ -109,7 +109,7 @@ OLAPStatus DeltaWriter::init() {
                 if (!new_migration_rlock.own_lock()) {
                     return OLAP_ERR_RWLOCK_ERROR;
                 }
-                _storage_engine->txn_manager()->prepare_txn(_new_tablet, _req.txn_id, _req.load_id);
+                _storage_engine->txn_manager()->prepare_txn(_req.partition_id, _new_tablet, _req.txn_id, _req.load_id);
             }
         }
     }
@@ -182,7 +182,7 @@ OLAPStatus DeltaWriter::close_wait(google::protobuf::RepeatedPtrField<PTabletInf
         LOG(WARNING) << "fail to build rowset";
         return OLAP_ERR_MALLOC_ERROR;
     }
-    OLAPStatus res = _storage_engine->txn_manager()->commit_txn(_tablet, _req.txn_id, 
+    OLAPStatus res = _storage_engine->txn_manager()->commit_txn(_req.partition_id, _tablet, _req.txn_id, 
         _req.load_id, _cur_rowset, false);
     if (res != OLAP_SUCCESS && res != OLAP_ERR_PUSH_TRANSACTION_ALREADY_EXIST) {
         LOG(WARNING) << "commit txn: " << _req.txn_id
@@ -202,7 +202,7 @@ OLAPStatus DeltaWriter::close_wait(google::protobuf::RepeatedPtrField<PTabletInf
             return res;
         }
 
-        res = _storage_engine->txn_manager()->commit_txn(_new_tablet, _req.txn_id,
+        res = _storage_engine->txn_manager()->commit_txn(_req.partition_id, _new_tablet, _req.txn_id,
             _req.load_id, _new_rowset, false);
 
         if (res != OLAP_SUCCESS && res != OLAP_ERR_PUSH_TRANSACTION_ALREADY_EXIST) {

--- a/be/src/olap/delta_writer.cpp
+++ b/be/src/olap/delta_writer.cpp
@@ -58,8 +58,7 @@ DeltaWriter::~DeltaWriter() {
 void DeltaWriter::_garbage_collection() {
     OLAPStatus rollback_status = OLAP_SUCCESS;
     if (_tablet != nullptr) {
-        rollback_status = _storage_engine->txn_manager()->rollback_txn(_req.partition_id,
-            _req.txn_id,_req.tablet_id, _req.schema_hash, _tablet->tablet_uid());
+        rollback_status = _storage_engine->txn_manager()->rollback_txn(_tablet, _req.txn_id);
     }
     // has to check rollback status, because the rowset maybe committed in this thread and
     // published in another thread, then rollback will failed
@@ -68,8 +67,7 @@ void DeltaWriter::_garbage_collection() {
         _storage_engine->add_unused_rowset(_cur_rowset);
     }
     if (_new_tablet != nullptr) {
-        rollback_status = _storage_engine->txn_manager()->rollback_txn(_req.partition_id, _req.txn_id,
-            _new_tablet->tablet_id(), _new_tablet->schema_hash(), _new_tablet->tablet_uid());
+        rollback_status = _storage_engine->txn_manager()->rollback_txn(_new_tablet, _req.txn_id);
         if (rollback_status == OLAP_SUCCESS) {
             _storage_engine->add_unused_rowset(_new_rowset);
         }
@@ -90,9 +88,7 @@ OLAPStatus DeltaWriter::init() {
             return OLAP_ERR_RWLOCK_ERROR;
         }
         MutexLock push_lock(_tablet->get_push_lock());
-        RETURN_NOT_OK(_storage_engine->txn_manager()->prepare_txn(
-                            _req.partition_id, _req.txn_id,
-                            _req.tablet_id, _req.schema_hash, _tablet->tablet_uid(), _req.load_id));
+        RETURN_NOT_OK(_storage_engine->txn_manager()->prepare_txn(_tablet, _req.txn_id, _req.load_id));
         if (_req.need_gen_rollup) {
             AlterTabletTaskSharedPtr alter_task = _tablet->alter_task();
             if (alter_task != nullptr && alter_task->alter_state() != ALTER_FAILED) {
@@ -113,9 +109,7 @@ OLAPStatus DeltaWriter::init() {
                 if (!new_migration_rlock.own_lock()) {
                     return OLAP_ERR_RWLOCK_ERROR;
                 }
-                _storage_engine->txn_manager()->prepare_txn(
-                                    _req.partition_id, _req.txn_id,
-                                    new_tablet_id, new_schema_hash, _new_tablet->tablet_uid(), _req.load_id);
+                _storage_engine->txn_manager()->prepare_txn(_new_tablet, _req.txn_id, _req.load_id);
             }
         }
     }
@@ -188,8 +182,7 @@ OLAPStatus DeltaWriter::close_wait(google::protobuf::RepeatedPtrField<PTabletInf
         LOG(WARNING) << "fail to build rowset";
         return OLAP_ERR_MALLOC_ERROR;
     }
-    OLAPStatus res = _storage_engine->txn_manager()->commit_txn(_tablet->data_dir()->get_meta(),
-        _req.partition_id, _req.txn_id,_req.tablet_id, _req.schema_hash, _tablet->tablet_uid(), 
+    OLAPStatus res = _storage_engine->txn_manager()->commit_txn(_tablet, _req.txn_id, 
         _req.load_id, _cur_rowset, false);
     if (res != OLAP_SUCCESS && res != OLAP_ERR_PUSH_TRANSACTION_ALREADY_EXIST) {
         LOG(WARNING) << "commit txn: " << _req.txn_id
@@ -209,10 +202,8 @@ OLAPStatus DeltaWriter::close_wait(google::protobuf::RepeatedPtrField<PTabletInf
             return res;
         }
 
-        res = _storage_engine->txn_manager()->commit_txn(_new_tablet->data_dir()->get_meta(),
-                    _req.partition_id, _req.txn_id, _new_tablet->tablet_id(), 
-                    _new_tablet->schema_hash(), _new_tablet->tablet_uid(),
-                    _req.load_id, _new_rowset, false);
+        res = _storage_engine->txn_manager()->commit_txn(_new_tablet, _req.txn_id,
+            _req.load_id, _new_rowset, false);
 
         if (res != OLAP_SUCCESS && res != OLAP_ERR_PUSH_TRANSACTION_ALREADY_EXIST) {
             LOG(WARNING) << "save pending rowset failed. rowset_id:"

--- a/be/src/olap/push_handler.cpp
+++ b/be/src/olap/push_handler.cpp
@@ -93,7 +93,7 @@ OLAPStatus PushHandler::_do_streaming_ingestion(
   PUniqueId load_id;
   load_id.set_hi(0);
   load_id.set_lo(0);
-  OLAPStatus res = StorageEngine::instance()->txn_manager()->prepare_txn(
+  OLAPStatus res = StorageEngine::instance()->txn_manager()->prepare_txn(request.partition_id,
       tablet, request.transaction_id, load_id);
 
   // prepare txn will be always successful
@@ -140,7 +140,7 @@ OLAPStatus PushHandler::_do_streaming_ingestion(
         PUniqueId load_id;
         load_id.set_hi(0);
         load_id.set_lo(0);
-        res = StorageEngine::instance()->txn_manager()->prepare_txn(
+        res = StorageEngine::instance()->txn_manager()->prepare_txn(request.partition_id,
             related_tablet, request.transaction_id, load_id);
         // prepare txn will always be successful
         tablet_vars->push_back(TabletVars());
@@ -197,7 +197,8 @@ OLAPStatus PushHandler::_do_streaming_ingestion(
       }
 
       OLAPStatus rollback_status =
-          StorageEngine::instance()->txn_manager()->rollback_txn(tablet_var.tablet, request.transaction_id);
+          StorageEngine::instance()->txn_manager()->rollback_txn(request.partition_id, 
+            tablet_var.tablet, request.transaction_id);
       // has to check rollback status to ensure not delete a committed rowset
       if (rollback_status == OLAP_SUCCESS) {
         // actually, olap_index may has been deleted in delete_transaction()
@@ -219,7 +220,7 @@ OLAPStatus PushHandler::_do_streaming_ingestion(
       del_preds.pop();
     }
     OLAPStatus commit_status =
-        StorageEngine::instance()->txn_manager()->commit_txn(
+        StorageEngine::instance()->txn_manager()->commit_txn(request.partition_id,
             tablet_var.tablet, request.transaction_id,
             load_id, tablet_var.rowset_to_add, false);
     if (commit_status != OLAP_SUCCESS &&

--- a/be/src/olap/storage_engine.cpp
+++ b/be/src/olap/storage_engine.cpp
@@ -515,11 +515,10 @@ void StorageEngine::clear_transaction_task(const TTransactionId transaction_id,
             // should use tablet uid to ensure clean txn correctly
             TabletSharedPtr tablet = _tablet_manager->get_tablet(tablet_info.first.tablet_id, 
                 tablet_info.first.schema_hash, tablet_info.first.tablet_uid);
-            OlapMeta* meta = nullptr;
-            if (tablet != nullptr) {
-                meta = tablet->data_dir()->get_meta();
+            if (tablet == nullptr) {
+                return;
             }
-            StorageEngine::instance()->txn_manager()->delete_txn(partition_id, tablet_info.first, transaction_id);
+            StorageEngine::instance()->txn_manager()->delete_txn(partition_id, tablet, transaction_id);
         }
     }
     LOG(INFO) << "finish to clear transaction task. transaction_id=" << transaction_id;

--- a/be/src/olap/storage_engine.cpp
+++ b/be/src/olap/storage_engine.cpp
@@ -519,9 +519,7 @@ void StorageEngine::clear_transaction_task(const TTransactionId transaction_id,
             if (tablet != nullptr) {
                 meta = tablet->data_dir()->get_meta();
             }
-            StorageEngine::instance()->txn_manager()->delete_txn(meta, partition_id, transaction_id,
-                                tablet_info.first.tablet_id, tablet_info.first.schema_hash, 
-                                tablet_info.first.tablet_uid);
+            StorageEngine::instance()->txn_manager()->delete_txn(partition_id, tablet_info.first, transaction_id);
         }
     }
     LOG(INFO) << "finish to clear transaction task. transaction_id=" << transaction_id;

--- a/be/src/olap/task/engine_publish_version_task.cpp
+++ b/be/src/olap/task/engine_publish_version_task.cpp
@@ -90,10 +90,8 @@ OLAPStatus EnginePublishVersionTask::finish() {
                 continue;
             }
 
-            publish_status = StorageEngine::instance()->txn_manager()->publish_txn(tablet->data_dir()->get_meta(), 
-                partition_id, 
-                transaction_id, tablet_info.tablet_id, tablet_info.schema_hash, tablet_info.tablet_uid, 
-                version, version_hash);
+            publish_status = StorageEngine::instance()->txn_manager()->publish_txn(tablet, 
+                transaction_id, version, version_hash);
             
             if (publish_status != OLAP_SUCCESS) {
                 LOG(WARNING) << "failed to publish for rowset_id:" << rowset->rowset_id()

--- a/be/src/olap/task/engine_publish_version_task.cpp
+++ b/be/src/olap/task/engine_publish_version_task.cpp
@@ -90,7 +90,7 @@ OLAPStatus EnginePublishVersionTask::finish() {
                 continue;
             }
 
-            publish_status = StorageEngine::instance()->txn_manager()->publish_txn(tablet, 
+            publish_status = StorageEngine::instance()->txn_manager()->publish_txn(partition_id, tablet, 
                 transaction_id, version, version_hash);
             
             if (publish_status != OLAP_SUCCESS) {

--- a/be/src/olap/txn_manager.cpp
+++ b/be/src/olap/txn_manager.cpp
@@ -76,29 +76,29 @@ TxnManager::TxnManager() {
     }
 }
 
-OLAPStatus TxnManager::prepare_txn(TPartitionId partition_id, const TabletSharedPtr tablet, const TTransactionId transaction_id, 
+OLAPStatus TxnManager::prepare_txn(TPartitionId partition_id, const TabletSharedPtr& tablet, const TTransactionId transaction_id, 
                                    const PUniqueId& load_id) {
     return prepare_txn(partition_id, transaction_id, tablet->tablet_id(), tablet->schema_hash(), tablet->tablet_uid(), load_id);
 }
 
-OLAPStatus TxnManager::commit_txn(TPartitionId partition_id, const TabletSharedPtr tablet, const TTransactionId transaction_id,
+OLAPStatus TxnManager::commit_txn(TPartitionId partition_id, const TabletSharedPtr& tablet, const TTransactionId transaction_id,
                                   const PUniqueId& load_id, RowsetSharedPtr rowset_ptr, bool is_recovery) {
     return commit_txn(tablet->data_dir()->get_meta(), partition_id, transaction_id, tablet->tablet_id(), 
         tablet->schema_hash(), tablet->tablet_uid(), load_id, rowset_ptr, is_recovery);
 }
 
-OLAPStatus TxnManager::publish_txn(TPartitionId partition_id, const TabletSharedPtr tablet, TTransactionId transaction_id,
+OLAPStatus TxnManager::publish_txn(TPartitionId partition_id, const TabletSharedPtr& tablet, TTransactionId transaction_id,
                                    const Version& version, VersionHash& version_hash) {
     return publish_txn(tablet->data_dir()->get_meta(), partition_id, transaction_id, tablet->tablet_id(), 
         tablet->schema_hash(), tablet->tablet_uid(), version, version_hash);
 }
 
 // delete the txn from manager if it is not committed(not have a valid rowset)
-OLAPStatus TxnManager::rollback_txn(TPartitionId partition_id, const TabletSharedPtr tablet, TTransactionId transaction_id) {
+OLAPStatus TxnManager::rollback_txn(TPartitionId partition_id, const TabletSharedPtr& tablet, TTransactionId transaction_id) {
     return rollback_txn(partition_id, transaction_id, tablet->tablet_id(), tablet->schema_hash(), tablet->tablet_uid());
 }
 
-OLAPStatus TxnManager::delete_txn(TPartitionId partition_id, const TabletSharedPtr tablet, TTransactionId transaction_id) {
+OLAPStatus TxnManager::delete_txn(TPartitionId partition_id, const TabletSharedPtr& tablet, TTransactionId transaction_id) {
     return delete_txn(tablet->data_dir()->get_meta(), partition_id, transaction_id, tablet->tablet_id(), 
         tablet->schema_hash(), tablet->tablet_uid());
 }

--- a/be/src/olap/txn_manager.cpp
+++ b/be/src/olap/txn_manager.cpp
@@ -82,7 +82,7 @@ OLAPStatus TxnManager::prepare_txn(TPartitionId partition_id, const TabletShared
 }
 
 OLAPStatus TxnManager::commit_txn(TPartitionId partition_id, const TabletSharedPtr& tablet, TTransactionId transaction_id,
-                                  const PUniqueId& load_id, RowsetSharedPtr& rowset_ptr, bool is_recovery) {
+                                  const PUniqueId& load_id, const RowsetSharedPtr& rowset_ptr, bool is_recovery) {
     return commit_txn(tablet->data_dir()->get_meta(), partition_id, transaction_id, tablet->tablet_id(), 
         tablet->schema_hash(), tablet->tablet_uid(), load_id, rowset_ptr, is_recovery);
 }
@@ -149,7 +149,7 @@ OLAPStatus TxnManager::prepare_txn(
 OLAPStatus TxnManager::commit_txn(
     OlapMeta* meta, TPartitionId partition_id, TTransactionId transaction_id,
     TTabletId tablet_id, SchemaHash schema_hash, TabletUid tablet_uid,
-    const PUniqueId& load_id, RowsetSharedPtr& rowset_ptr, bool is_recovery) {
+    const PUniqueId& load_id, const RowsetSharedPtr& rowset_ptr, bool is_recovery) {
     if (partition_id < 1 || transaction_id < 1 || tablet_id < 1) {
         LOG(FATAL) << "invalid commit req "
                    << " partition_id=" << partition_id

--- a/be/src/olap/txn_manager.cpp
+++ b/be/src/olap/txn_manager.cpp
@@ -76,19 +76,19 @@ TxnManager::TxnManager() {
     }
 }
 
-OLAPStatus TxnManager::prepare_txn(TPartitionId partition_id, const TabletSharedPtr& tablet, const TTransactionId transaction_id, 
+OLAPStatus TxnManager::prepare_txn(TPartitionId partition_id, const TabletSharedPtr& tablet, TTransactionId transaction_id, 
                                    const PUniqueId& load_id) {
     return prepare_txn(partition_id, transaction_id, tablet->tablet_id(), tablet->schema_hash(), tablet->tablet_uid(), load_id);
 }
 
-OLAPStatus TxnManager::commit_txn(TPartitionId partition_id, const TabletSharedPtr& tablet, const TTransactionId transaction_id,
-                                  const PUniqueId& load_id, RowsetSharedPtr rowset_ptr, bool is_recovery) {
+OLAPStatus TxnManager::commit_txn(TPartitionId partition_id, const TabletSharedPtr& tablet, TTransactionId transaction_id,
+                                  const PUniqueId& load_id, RowsetSharedPtr& rowset_ptr, bool is_recovery) {
     return commit_txn(tablet->data_dir()->get_meta(), partition_id, transaction_id, tablet->tablet_id(), 
         tablet->schema_hash(), tablet->tablet_uid(), load_id, rowset_ptr, is_recovery);
 }
 
 OLAPStatus TxnManager::publish_txn(TPartitionId partition_id, const TabletSharedPtr& tablet, TTransactionId transaction_id,
-                                   const Version& version, VersionHash& version_hash) {
+                                   const Version& version, VersionHash version_hash) {
     return publish_txn(tablet->data_dir()->get_meta(), partition_id, transaction_id, tablet->tablet_id(), 
         tablet->schema_hash(), tablet->tablet_uid(), version, version_hash);
 }
@@ -149,7 +149,7 @@ OLAPStatus TxnManager::prepare_txn(
 OLAPStatus TxnManager::commit_txn(
     OlapMeta* meta, TPartitionId partition_id, TTransactionId transaction_id,
     TTabletId tablet_id, SchemaHash schema_hash, TabletUid tablet_uid,
-    const PUniqueId& load_id, RowsetSharedPtr rowset_ptr, bool is_recovery) {
+    const PUniqueId& load_id, RowsetSharedPtr& rowset_ptr, bool is_recovery) {
     if (partition_id < 1 || transaction_id < 1 || tablet_id < 1) {
         LOG(FATAL) << "invalid commit req "
                    << " partition_id=" << partition_id
@@ -238,7 +238,7 @@ OLAPStatus TxnManager::commit_txn(
 // remove a txn from txn manager
 OLAPStatus TxnManager::publish_txn(OlapMeta* meta, TPartitionId partition_id, TTransactionId transaction_id,
                                    TTabletId tablet_id, SchemaHash schema_hash, TabletUid tablet_uid,
-                                   const Version& version, VersionHash& version_hash) {
+                                   const Version& version, VersionHash version_hash) {
     pair<int64_t, int64_t> key(partition_id, transaction_id);
     TabletInfo tablet_info(tablet_id, schema_hash, tablet_uid);
     RowsetSharedPtr rowset_ptr = nullptr;

--- a/be/src/olap/txn_manager.cpp
+++ b/be/src/olap/txn_manager.cpp
@@ -238,7 +238,7 @@ OLAPStatus TxnManager::commit_txn(
 // remove a txn from txn manager
 OLAPStatus TxnManager::publish_txn(OlapMeta* meta, TPartitionId partition_id, TTransactionId transaction_id,
                                    TTabletId tablet_id, SchemaHash schema_hash, TabletUid tablet_uid,
-                                   Version& version, VersionHash& version_hash) {
+                                   const Version& version, VersionHash& version_hash) {
     pair<int64_t, int64_t> key(partition_id, transaction_id);
     TabletInfo tablet_info(tablet_id, schema_hash, tablet_uid);
     RowsetSharedPtr rowset_ptr = nullptr;

--- a/be/src/olap/txn_manager.cpp
+++ b/be/src/olap/txn_manager.cpp
@@ -76,6 +76,33 @@ TxnManager::TxnManager() {
     }
 }
 
+OLAPStatus TxnManager::prepare_txn(TPartitionId partition_id, const TabletSharedPtr tablet, const TTransactionId transaction_id, 
+                                   const PUniqueId& load_id) {
+    return prepare_txn(partition_id, transaction_id, tablet->tablet_id(), tablet->schema_hash(), tablet->tablet_uid(), load_id);
+}
+
+OLAPStatus TxnManager::commit_txn(TPartitionId partition_id, const TabletSharedPtr tablet, const TTransactionId transaction_id,
+                                  const PUniqueId& load_id, RowsetSharedPtr rowset_ptr, bool is_recovery) {
+    return commit_txn(tablet->data_dir()->get_meta(), partition_id, transaction_id, tablet->tablet_id(), 
+        tablet->schema_hash(), tablet->tablet_uid(), load_id, rowset_ptr, is_recovery);
+}
+
+OLAPStatus TxnManager::publish_txn(TPartitionId partition_id, const TabletSharedPtr tablet, TTransactionId transaction_id,
+                                   const Version& version, VersionHash& version_hash) {
+    return publish_txn(tablet->data_dir()->get_meta(), partition_id, transaction_id, tablet->tablet_id(), 
+        tablet->schema_hash(), tablet->tablet_uid(), version, version_hash);
+}
+
+// delete the txn from manager if it is not committed(not have a valid rowset)
+OLAPStatus TxnManager::rollback_txn(TPartitionId partition_id, const TabletSharedPtr tablet, TTransactionId transaction_id) {
+    return rollback_txn(partition_id, transaction_id, tablet->tablet_id(), tablet->schema_hash(), tablet->tablet_uid());
+}
+
+OLAPStatus TxnManager::delete_txn(TPartitionId partition_id, const TabletSharedPtr tablet, TTransactionId transaction_id) {
+    return delete_txn(tablet->data_dir()->get_meta(), partition_id, transaction_id, tablet->tablet_id(), 
+        tablet->schema_hash(), tablet->tablet_uid());
+}
+
 // prepare txn should always be allowed because ingest task will be retried 
 // could not distinguish rollup, schema change or base table, prepare txn successfully will allow
 // ingest retried

--- a/be/src/olap/txn_manager.h
+++ b/be/src/olap/txn_manager.h
@@ -73,15 +73,15 @@ public:
         _txn_locks.clear();
     }
 
-    OLAPStatus prepare_txn(TPartitionId partition_id, const TabletSharedPtr& tablet, const TTransactionId transaction_id, 
+    OLAPStatus prepare_txn(TPartitionId partition_id, const TabletSharedPtr& tablet, TTransactionId transaction_id, 
                            const PUniqueId& load_id);
 
-    OLAPStatus commit_txn(TPartitionId partition_id, const TabletSharedPtr& tablet, const TTransactionId transaction_id,
-                          const PUniqueId& load_id, RowsetSharedPtr rowset_ptr, 
+    OLAPStatus commit_txn(TPartitionId partition_id, const TabletSharedPtr& tablet, TTransactionId transaction_id,
+                          const PUniqueId& load_id, RowsetSharedPtr& rowset_ptr, 
                           bool is_recovery);
 
     OLAPStatus publish_txn(TPartitionId partition_id, const TabletSharedPtr& tablet, TTransactionId transaction_id,
-                           const Version& version, VersionHash& version_hash);
+                           const Version& version, VersionHash version_hash);
 
     // delete the txn from manager if it is not committed(not have a valid rowset)
     OLAPStatus rollback_txn(TPartitionId partition_id, const TabletSharedPtr& tablet, TTransactionId transaction_id);
@@ -97,14 +97,14 @@ public:
     
     OLAPStatus commit_txn(OlapMeta* meta, TPartitionId partition_id, TTransactionId transaction_id,
                           TTabletId tablet_id, SchemaHash schema_hash, TabletUid tablet_uid, 
-                          const PUniqueId& load_id, RowsetSharedPtr rowset_ptr, 
+                          const PUniqueId& load_id, RowsetSharedPtr& rowset_ptr, 
                           bool is_recovery);
     
     // remove a txn from txn manager
     // not persist rowset meta because 
     OLAPStatus publish_txn(OlapMeta* meta, TPartitionId partition_id, TTransactionId transaction_id,
                            TTabletId tablet_id, SchemaHash schema_hash, TabletUid tablet_uid, 
-                           const Version& version, VersionHash& version_hash);
+                           const Version& version, VersionHash version_hash);
 
     // delete the txn from manager if it is not committed(not have a valid rowset)
     OLAPStatus rollback_txn(TPartitionId partition_id, TTransactionId transaction_id,

--- a/be/src/olap/txn_manager.h
+++ b/be/src/olap/txn_manager.h
@@ -73,21 +73,21 @@ public:
         _txn_locks.clear();
     }
 
-    OLAPStatus prepare_txn(TPartitionId partition_id, const TabletSharedPtr tablet, const TTransactionId transaction_id, 
+    OLAPStatus prepare_txn(TPartitionId partition_id, const TabletSharedPtr& tablet, const TTransactionId transaction_id, 
                            const PUniqueId& load_id);
 
-    OLAPStatus commit_txn(TPartitionId partition_id, const TabletSharedPtr tablet, const TTransactionId transaction_id,
+    OLAPStatus commit_txn(TPartitionId partition_id, const TabletSharedPtr& tablet, const TTransactionId transaction_id,
                           const PUniqueId& load_id, RowsetSharedPtr rowset_ptr, 
                           bool is_recovery);
 
-    OLAPStatus publish_txn(TPartitionId partition_id, const TabletSharedPtr tablet, TTransactionId transaction_id,
+    OLAPStatus publish_txn(TPartitionId partition_id, const TabletSharedPtr& tablet, TTransactionId transaction_id,
                            const Version& version, VersionHash& version_hash);
 
     // delete the txn from manager if it is not committed(not have a valid rowset)
-    OLAPStatus rollback_txn(TPartitionId partition_id, const TabletSharedPtr tablet, TTransactionId transaction_id);
+    OLAPStatus rollback_txn(TPartitionId partition_id, const TabletSharedPtr& tablet, TTransactionId transaction_id);
 
 
-    OLAPStatus delete_txn(TPartitionId partition_id, const TabletSharedPtr tablet, TTransactionId transaction_id);
+    OLAPStatus delete_txn(TPartitionId partition_id, const TabletSharedPtr& tablet, TTransactionId transaction_id);
 
     // add a txn to manager
     // partition id is useful in publish version stage because version is associated with partition

--- a/be/src/olap/txn_manager.h
+++ b/be/src/olap/txn_manager.h
@@ -77,7 +77,7 @@ public:
                            const PUniqueId& load_id);
 
     OLAPStatus commit_txn(TPartitionId partition_id, const TabletSharedPtr& tablet, TTransactionId transaction_id,
-                          const PUniqueId& load_id, RowsetSharedPtr& rowset_ptr, 
+                          const PUniqueId& load_id, const RowsetSharedPtr& rowset_ptr, 
                           bool is_recovery);
 
     OLAPStatus publish_txn(TPartitionId partition_id, const TabletSharedPtr& tablet, TTransactionId transaction_id,
@@ -97,7 +97,7 @@ public:
     
     OLAPStatus commit_txn(OlapMeta* meta, TPartitionId partition_id, TTransactionId transaction_id,
                           TTabletId tablet_id, SchemaHash schema_hash, TabletUid tablet_uid, 
-                          const PUniqueId& load_id, RowsetSharedPtr& rowset_ptr, 
+                          const PUniqueId& load_id, const RowsetSharedPtr& rowset_ptr, 
                           bool is_recovery);
     
     // remove a txn from txn manager

--- a/be/src/olap/txn_manager.h
+++ b/be/src/olap/txn_manager.h
@@ -73,7 +73,8 @@ public:
         _txn_locks.clear();
     }
 
-    OLAPStatus prepare_txn(TPartitionId partition_id, const TabletSharedPtr tablet, const TTransactionId transaction_id, const PUniqueId& load_id);
+    OLAPStatus prepare_txn(TPartitionId partition_id, const TabletSharedPtr tablet, const TTransactionId transaction_id, 
+                           const PUniqueId& load_id);
 
     OLAPStatus commit_txn(TPartitionId partition_id, const TabletSharedPtr tablet, const TTransactionId transaction_id,
                           const PUniqueId& load_id, RowsetSharedPtr rowset_ptr, 

--- a/be/src/olap/txn_manager.h
+++ b/be/src/olap/txn_manager.h
@@ -104,7 +104,7 @@ public:
     // not persist rowset meta because 
     OLAPStatus publish_txn(OlapMeta* meta, TPartitionId partition_id, TTransactionId transaction_id,
                            TTabletId tablet_id, SchemaHash schema_hash, TabletUid tablet_uid, 
-                           Version& version, VersionHash& version_hash);
+                           const Version& version, VersionHash& version_hash);
 
     // delete the txn from manager if it is not committed(not have a valid rowset)
     OLAPStatus rollback_txn(TPartitionId partition_id, TTransactionId transaction_id,

--- a/be/src/olap/txn_manager.h
+++ b/be/src/olap/txn_manager.h
@@ -72,6 +72,22 @@ public:
         _txn_tablet_map.clear();
         _txn_locks.clear();
     }
+
+    OLAPStatus prepare_txn(TPartitionId partition_id, const TabletSharedPtr tablet, const TTransactionId transaction_id, const PUniqueId& load_id);
+
+    OLAPStatus commit_txn(TPartitionId partition_id, const TabletSharedPtr tablet, const TTransactionId transaction_id,
+                          const PUniqueId& load_id, RowsetSharedPtr rowset_ptr, 
+                          bool is_recovery);
+
+    OLAPStatus publish_txn(TPartitionId partition_id, const TabletSharedPtr tablet, TTransactionId transaction_id,
+                           const Version& version, VersionHash& version_hash);
+
+    // delete the txn from manager if it is not committed(not have a valid rowset)
+    OLAPStatus rollback_txn(TPartitionId partition_id, const TabletSharedPtr tablet, TTransactionId transaction_id);
+
+
+    OLAPStatus delete_txn(TPartitionId partition_id, const TabletSharedPtr tablet, TTransactionId transaction_id);
+
     // add a txn to manager
     // partition id is useful in publish version stage because version is associated with partition
     OLAPStatus prepare_txn(TPartitionId partition_id, TTransactionId transaction_id,


### PR DESCRIPTION
Most methods in TxnManager depend on tablet id , schema hash, tablet uid. All of them could be extracted from tablet object. So that using tablet as parameter instead of tablet_id, schema has, tablet uid.