### PR TITLE
Ignore some compaction errors to reduce logs

### DIFF
--- a/be/src/olap/base_compaction.cpp
+++ b/be/src/olap/base_compaction.cpp
@@ -60,7 +60,7 @@ OLAPStatus BaseCompaction::pick_rowsets_to_compact() {
     _input_rowsets.clear();
     _tablet->pick_candicate_rowsets_to_base_compaction(&_input_rowsets);
     if (_input_rowsets.size() <= 1) {
-        LOG(WARNING) << "There is no enough rowsets to do base compaction."
+        LOG(INFO) << "There is no enough rowsets to do base compaction."
                      << ", the size of rowsets to compact=" << _input_rowsets.size()
                      << ", cumulative_point=" << _tablet->cumulative_layer_point();
         return OLAP_ERR_CUMULATIVE_NO_SUITABLE_VERSIONS;

--- a/be/src/olap/base_compaction.cpp
+++ b/be/src/olap/base_compaction.cpp
@@ -60,9 +60,6 @@ OLAPStatus BaseCompaction::pick_rowsets_to_compact() {
     _input_rowsets.clear();
     _tablet->pick_candicate_rowsets_to_base_compaction(&_input_rowsets);
     if (_input_rowsets.size() <= 1) {
-        LOG(INFO) << "There is no enough rowsets to do base compaction."
-                     << ", the size of rowsets to compact=" << _input_rowsets.size()
-                     << ", cumulative_point=" << _tablet->cumulative_layer_point();
         return OLAP_ERR_CUMULATIVE_NO_SUITABLE_VERSIONS;
     }
 

--- a/be/src/olap/cumulative_compaction.cpp
+++ b/be/src/olap/cumulative_compaction.cpp
@@ -68,7 +68,7 @@ OLAPStatus CumulativeCompaction::pick_rowsets_to_compact() {
     _tablet->pick_candicate_rowsets_to_cumulative_compaction(&candidate_rowsets);
 
     if (candidate_rowsets.size() <= 1) {
-        LOG(WARNING) << "There is no enough rowsets to cumulative compaction. "
+        LOG(INFO) << "There is no enough rowsets to cumulative compaction. "
                      << "The size of rowsets to compact=" << candidate_rowsets.size()
                      << ", cumulative_point=" << _tablet->cumulative_layer_point();
         return OLAP_ERR_CUMULATIVE_NO_SUITABLE_VERSIONS;

--- a/be/src/olap/cumulative_compaction.cpp
+++ b/be/src/olap/cumulative_compaction.cpp
@@ -68,9 +68,6 @@ OLAPStatus CumulativeCompaction::pick_rowsets_to_compact() {
     _tablet->pick_candicate_rowsets_to_cumulative_compaction(&candidate_rowsets);
 
     if (candidate_rowsets.size() <= 1) {
-        LOG(INFO) << "There is no enough rowsets to cumulative compaction. "
-                     << "The size of rowsets to compact=" << candidate_rowsets.size()
-                     << ", cumulative_point=" << _tablet->cumulative_layer_point();
         return OLAP_ERR_CUMULATIVE_NO_SUITABLE_VERSIONS;
     }
 
@@ -120,9 +117,6 @@ OLAPStatus CumulativeCompaction::pick_rowsets_to_compact() {
     }
 
     if (_input_rowsets.size() <= 1) {
-        LOG(INFO) << "There is no enough rowsets to cumulative compaction."
-            << ", the size of rowsets to compact=" << candidate_rowsets.size()
-            << ", cumulative_point=" << _tablet->cumulative_layer_point();
         return OLAP_ERR_CUMULATIVE_NO_SUITABLE_VERSIONS;
     }
 

--- a/be/src/olap/storage_engine.cpp
+++ b/be/src/olap/storage_engine.cpp
@@ -557,17 +557,17 @@ void StorageEngine::perform_cumulative_compaction(DataDir* data_dir) {
     CumulativeCompaction cumulative_compaction(best_tablet);
 
     OLAPStatus res = cumulative_compaction.compact();
-    if (res != OLAP_SUCCESS && res != OLAP_ERR_CUMULATIVE_NO_SUITABLE_VERSIONS) {
-        DorisMetrics::cumulative_compaction_request_failed.increment(1);
+    if (res != OLAP_SUCCESS) {
         best_tablet->set_last_compaction_failure_time(UnixMillis());
-        LOG(WARNING) << "failed to do cumulative compaction. res=" << res
-                     << ", table=" << best_tablet->full_name()
-                     << ", res=" << res;
+        if (res != OLAP_ERR_CUMULATIVE_NO_SUITABLE_VERSIONS) {
+            DorisMetrics::cumulative_compaction_request_failed.increment(1);
+            LOG(WARNING) << "failed to do cumulative compaction. res=" << res
+                        << ", table=" << best_tablet->full_name()
+                        << ", res=" << res;
+        }
         return;
     }
-    if (res != OLAP_ERR_CUMULATIVE_NO_SUITABLE_VERSIONS) {
-        best_tablet->set_last_compaction_failure_time(0);
-    }
+    best_tablet->set_last_compaction_failure_time(0);
 }
 
 void StorageEngine::perform_base_compaction(DataDir* data_dir) {
@@ -577,16 +577,16 @@ void StorageEngine::perform_base_compaction(DataDir* data_dir) {
     DorisMetrics::base_compaction_request_total.increment(1);
     BaseCompaction base_compaction(best_tablet);
     OLAPStatus res = base_compaction.compact();
-    if (res != OLAP_SUCCESS && res != OLAP_ERR_CUMULATIVE_NO_SUITABLE_VERSIONS) {
-        DorisMetrics::base_compaction_request_failed.increment(1);
+    if (res != OLAP_SUCCESS) {
         best_tablet->set_last_compaction_failure_time(UnixMillis());
-        LOG(WARNING) << "failed to init base compaction. res=" << res
-                     << ", table=" << best_tablet->full_name();
+        if (res != OLAP_ERR_CUMULATIVE_NO_SUITABLE_VERSIONS) {
+            DorisMetrics::base_compaction_request_failed.increment(1);
+            LOG(WARNING) << "failed to init base compaction. res=" << res
+                        << ", table=" << best_tablet->full_name();
+        }
         return;
     }
-    if (res != OLAP_ERR_CUMULATIVE_NO_SUITABLE_VERSIONS) {
-        best_tablet->set_last_compaction_failure_time(0);
-    }
+    best_tablet->set_last_compaction_failure_time(0);
 }
 
 void StorageEngine::get_cache_status(rapidjson::Document* document) const {


### PR DESCRIPTION
BE prints lots of WARNING logs when base compaction or cumulative compaction do not meet condition. Change its log level to INFO and do not treat them as error.