### PR TITLE
Fix bug that OlapTableSink use invalid column as distribution column for RANDOM distribution table

### DIFF
--- a/fe/src/main/java/org/apache/doris/planner/OlapTableSink.java
+++ b/fe/src/main/java/org/apache/doris/planner/OlapTableSink.java
@@ -198,7 +198,9 @@ public class OlapTableSink extends DataSink {
             }
             case RANDOM: {
                 for (Column column : table.getBaseSchema()) {
-                    distColumns.add(column.getName());
+                    if (column.isKey()) {
+                        distColumns.add(column.getName());
+                    }
                 }
                 break;
             }


### PR DESCRIPTION
RANDOM distribution is deprecated long time ago, this is just for compatibility and bug fix.