### PR TITLE
Tablet report does not set version miss

### DIFF
--- a/be/src/olap/olap_common.h
+++ b/be/src/olap/olap_common.h
@@ -180,7 +180,24 @@ enum ReaderType {
 
 // <start_version_id, end_version_id>, such as <100, 110>
 //using Version = std::pair<TupleVersion, TupleVersion>;
-typedef std::pair<int64_t, int64_t> Version;
+
+struct Version {
+    int64_t first;  
+    int64_t second;
+
+    Version(int64_t first, int64_t second) : first(first), second(second) {}
+
+    Version() : first(0), second(0) {}
+
+    bool operator!=(const Version& rhs) const {
+        return first != rhs.first || second != rhs.second;
+    }
+
+    bool operator==(const Version& rhs) const {
+        return first == rhs.first && second == rhs.second;
+    }
+};
+
 typedef std::vector<Version> Versions;
 
 

--- a/be/src/olap/olap_common.h
+++ b/be/src/olap/olap_common.h
@@ -185,7 +185,7 @@ struct Version {
     int64_t first;  
     int64_t second;
 
-    Version(int64_t first, int64_t second) : first(first), second(second) {}
+    Version(int64_t first_, int64_t second_) : first(first_), second(second_) {}
 
     Version() : first(0), second(0) {}
 

--- a/be/src/olap/rowset_graph.cpp
+++ b/be/src/olap/rowset_graph.cpp
@@ -248,9 +248,9 @@ OLAPStatus RowsetGraph::capture_consistent_versions(
 
         // tmp_start_vertex_value mustn't be equal to tmp_end_vertex_value
         if (tmp_start_vertex_value <= tmp_end_vertex_value) {
-            version_path->push_back(std::make_pair(tmp_start_vertex_value, tmp_end_vertex_value - 1));
+            version_path->emplace_back(tmp_start_vertex_value, tmp_end_vertex_value - 1);
         } else {
-            version_path->push_back(std::make_pair(tmp_end_vertex_value, tmp_start_vertex_value - 1));
+            version_path->emplace_back(tmp_end_vertex_value, tmp_start_vertex_value - 1);
         }
 
         shortest_path_for_debug << (*version_path)[version_path->size() - 1].first << '-'

--- a/be/src/olap/storage_engine.cpp
+++ b/be/src/olap/storage_engine.cpp
@@ -240,9 +240,6 @@ void StorageEngine::_update_storage_medium_type_count() {
     }
 
     _available_storage_medium_type_count = available_storage_medium_types.size();
-    if (_tablet_manager != nullptr) {
-        _tablet_manager->update_storage_medium_type_count(_available_storage_medium_type_count);
-    }
 }
 
 OLAPStatus StorageEngine::_judge_and_update_effective_cluster_id(int32_t cluster_id) {

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -749,6 +749,10 @@ void Tablet::calc_missed_versions_unlock(int64_t spec_version,
 
 OLAPStatus Tablet::max_continuous_version_from_begining(Version* version, VersionHash* v_hash) {
     ReadLock rdlock(&_meta_lock);
+    return _max_continuous_version_from_begining(version, v_hash);
+}
+
+OLAPStatus Tablet::_max_continuous_version_from_begining(Version* version, VersionHash* v_hash) {
     vector<pair<Version, VersionHash>> existing_versions;
     for (auto& rs : _tablet_meta->all_rs_metas()) {
         existing_versions.emplace_back(rs->version() , rs->version_hash());
@@ -1082,6 +1086,29 @@ bool Tablet::contains_rowset(const RowsetId rowset_id) {
         }
     }
     return false;
+}
+
+void Tablet::build_tablet_report_info(TTabletInfo* tablet_info) {
+    ReadLock rdlock(&_meta_lock);
+    tablet_info->tablet_id = _tablet_meta->tablet_id();
+    tablet_info->schema_hash = _tablet_meta->schema_hash();
+    tablet_info->row_count = _tablet_meta->num_rows();
+    tablet_info->data_size = _tablet_meta->tablet_footprint();
+    Version version = { -1, 0 };
+    VersionHash v_hash = 0;
+    _max_continuous_version_from_begining(&version, &v_hash);
+    auto max_rowset = rowset_with_max_version();
+    if (max_rowset != nullptr) {
+        if (max_rowset->version() != version) {
+            tablet_info->__set_version_miss(true);
+        }
+    }
+    tablet_info->version = version.second;
+    tablet_info->version_hash = v_hash;
+    tablet_info->__set_partition_id(_tablet_meta->partition_id());
+    tablet_info->__set_storage_medium(_data_dir->storage_medium());
+    tablet_info->__set_version_count(_tablet_meta->version_count());
+    tablet_info->__set_path_hash(_data_dir->path_hash());
 }
 
 }  // namespace doris

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -1102,6 +1102,12 @@ void Tablet::build_tablet_report_info(TTabletInfo* tablet_info) {
         if (max_rowset->version() != version) {
             tablet_info->__set_version_miss(true);
         }
+    } else {
+        // if the tablet is in running state, it is not under schema change
+        // and could not get rowset, it is bad should clone it
+        if (tablet_state() == TABLET_RUNNING) {
+            tablet_info->__set_used(false);
+        }
     }
     tablet_info->version = version.second;
     tablet_info->version_hash = v_hash;

--- a/be/src/olap/tablet.h
+++ b/be/src/olap/tablet.h
@@ -26,6 +26,7 @@
 #include <vector>
 
 #include "gen_cpp/AgentService_types.h"
+#include "gen_cpp/MasterService_types.h"
 #include "gen_cpp/olap_file.pb.h"
 #include "olap/olap_define.h"
 #include "olap/tuple.h"
@@ -239,10 +240,13 @@ public:
 
     bool contains_rowset(const RowsetId rowset_id);
 
+    void build_tablet_report_info(TTabletInfo* tablet_info);
+
 private:
     OLAPStatus _init_once_action();
     void _print_missed_versions(const std::vector<Version>& missed_versions) const;
     OLAPStatus _check_added_rowset(const RowsetSharedPtr& rowset);
+    OLAPStatus _max_continuous_version_from_begining(Version* version, VersionHash* v_hash);
 
 private:
     TabletState _state;

--- a/be/src/olap/tablet_manager.h
+++ b/be/src/olap/tablet_manager.h
@@ -140,8 +140,6 @@ public:
 
     void update_root_path_info(std::map<std::string, DataDirInfo>* path_map, int* tablet_counter);
 
-    void update_storage_medium_type_count(uint32_t storage_medium_type_count);
-
     void get_partition_related_tablets(int64_t partition_id, std::set<TabletInfo>* tablet_infos);
 
     void do_tablet_meta_checkpoint(DataDir* data_dir);
@@ -159,8 +157,6 @@ private:
     OLAPStatus _add_tablet_to_map(TTabletId tablet_id, SchemaHash schema_hash,
                                  const TabletSharedPtr& tablet, bool update_meta, 
                                  bool keep_files, bool drop_old);
-
-    void _build_tablet_info(TabletSharedPtr tablet, TTabletInfo* tablet_info);
     
     void _build_tablet_stat();
     bool _check_tablet_id_exist_unlock(TTabletId tablet_id);


### PR DESCRIPTION
#1960

1. Move build tablet info to tablet since it requires a lot of information and need meta lock.
2. Using struct as Version type, override != and == operators.