### PR TITLE
Check tablet state before update it

### DIFF
--- a/be/src/olap/schema_change.cpp
+++ b/be/src/olap/schema_change.cpp
@@ -1146,7 +1146,7 @@ bool SchemaChangeWithSorting::_external_sorting(vector<RowsetSharedPtr>& src_row
 
 OLAPStatus SchemaChangeHandler::process_alter_tablet_v2(const TAlterTabletReqV2& request) {
     LOG(INFO) << "begin to do request alter tablet: base_tablet_id=" << request.base_tablet_id
-              << ", base_schema_hash" << request.base_schema_hash
+              << ", base_schema_hash=" << request.base_schema_hash
               << ", new_tablet_id=" << request.new_tablet_id
               << ", new_schema_hash=" << request.new_schema_hash
               << ", alter_version=" << request.alter_version

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -140,6 +140,16 @@ string Tablet::tablet_path() const {
     return _tablet_path;
 }
 
+OLAPStatus Tablet::set_tablet_state(TabletState state) {
+    if (_tablet_meta->tablet_state() == TABLET_SHUTDOWN && state != TABLET_SHUTDOWN) {
+        LOG(WARNING) << "could not change tablet state from shutdown to " << state;
+        return OLAP_ERR_META_INVALID_ARGUMENT;
+    }
+    RETURN_NOT_OK(_tablet_meta->set_tablet_state(state));
+    _state = state;
+    return OLAP_SUCCESS;
+}
+
 // should save tablet meta to remote meta store
 // if it's a primary replica
 OLAPStatus Tablet::save_meta() {

--- a/be/src/olap/tablet.h
+++ b/be/src/olap/tablet.h
@@ -65,7 +65,7 @@ public:
 
     // operation for TabletState
     TabletState tablet_state() const { return _state; }
-    inline OLAPStatus set_tablet_state(TabletState state);
+    OLAPStatus set_tablet_state(TabletState state);
 
     // Property encapsulated in TabletMeta
     inline const TabletMetaSharedPtr tablet_meta();
@@ -286,12 +286,6 @@ inline bool Tablet::init_succeeded() {
 
 inline DataDir* Tablet::data_dir() const {
     return _data_dir;
-}
-
-inline OLAPStatus Tablet::set_tablet_state(TabletState state) {
-    RETURN_NOT_OK(_tablet_meta->set_tablet_state(state));
-    _state = state;
-    return OLAP_SUCCESS;
 }
 
 inline const TabletMetaSharedPtr Tablet::tablet_meta() {


### PR DESCRIPTION
BE will set tablet state to running after alter job. But the tablet maybe dropped before the alter job finished. In this case, the tablet is changed to running and its files will not be deleted.