### PR TITLE
Get rid of compaction on rowset when making snapshot

### DIFF
--- a/be/src/olap/snapshot_manager.cpp
+++ b/be/src/olap/snapshot_manager.cpp
@@ -349,7 +349,7 @@ OLAPStatus SnapshotManager::_create_snapshot_files(
             ReadLock rdlock(ref_tablet->get_header_lock_ptr());
             for (int64_t missed_version : request.missing_version) {
                 Version version = { missed_version, missed_version };
-                const RowsetSharedPtr rowset = ref_tablet->get_rowset_by_version(version);
+                const RowsetSharedPtr rowset = ref_tablet->get_inc_rowset_by_version(version);
                 if (rowset != nullptr) {
                     consistent_rowsets.push_back(rowset);
                 } else {

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -328,6 +328,20 @@ const RowsetSharedPtr Tablet::get_rowset_by_version(const Version& version) cons
     return rowset;
 }
 
+// This function only be called by SnapshotManager to perform incremental clone.
+// Interal data structure will be protected in SnapSshotManager.
+// There is no necessity to add lock in this place.
+const RowsetSharedPtr Tablet::get_inc_rowset_by_version(const Version& version) const {
+    auto iter = _inc_rs_version_map.find(version);
+    if (iter == _inc_rs_version_map.end()) {
+        LOG(INFO) << "no rowset for version:" << version.first << "-" << version.second
+                  << ", tablet: " << full_name();
+        return nullptr;
+    }
+    RowsetSharedPtr rowset = iter->second;
+    return rowset;
+}
+
 size_t Tablet::get_rowset_size_by_version(const Version& version) {
     DCHECK(_rs_version_map.find(version) != _rs_version_map.end())
             << "invalid version:" << version.first << "-" << version.second;

--- a/be/src/olap/tablet.h
+++ b/be/src/olap/tablet.h
@@ -111,7 +111,12 @@ public:
     OLAPStatus add_rowset(RowsetSharedPtr rowset, bool need_persist = true);
     OLAPStatus modify_rowsets(const vector<RowsetSharedPtr>& to_add,
                               const vector<RowsetSharedPtr>& to_delete);
+
+    // _rs_version_map and _inc_rs_version_map should be protected by _meta_lock
+    // The caller must call hold _meta_lock when call this two function.
     const RowsetSharedPtr get_rowset_by_version(const Version& version) const;
+    const RowsetSharedPtr get_inc_rowset_by_version(const Version& version) const;
+
     size_t get_rowset_size_by_version(const Version& version);
     const RowsetSharedPtr rowset_with_max_version() const;
     RowsetSharedPtr rowset_with_largest_size();


### PR DESCRIPTION
When making snapshot for incremental clone, missed singleton versions may have been compacted.
So get_rowset_by_version() will not acquire any rowset.
This rowset should be acquired from _inc_rs_version_map.
