### PR TITLE
Use Env function to operate directory

### DIFF
--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -29,10 +29,12 @@
 #include <string>
 #include <sys/stat.h>
 
-#include "boost/filesystem.hpp"
-#include "boost/lexical_cast.hpp"
+#include <boost/filesystem.hpp>
+#include <boost/lexical_cast.hpp>
+
 #include "agent/status.h"
 #include "agent/utils.h"
+#include "env/env.h"
 #include "gen_cpp/FrontendService.h"
 #include "gen_cpp/Types_types.h"
 #include "http/http_client.h"
@@ -1552,7 +1554,7 @@ void* TaskWorkerPool::_make_snapshot_thread_callback(void* arg_this) {
                 std::stringstream ss;
                 ss << snapshot_path << "/" << snapshot_request.tablet_id
                     << "/" << snapshot_request.schema_hash << "/";
-                Status st = FileUtils::scan_dir(ss.str(), &snapshot_files); 
+                Status st = FileUtils::list_files(Env::Default(), ss.str(), &snapshot_files); 
                 if (!st.ok()) {
                     status_code = TStatusCode::RUNTIME_ERROR;
                     OLAP_LOG_WARNING("make_snapshot failed. tablet_id: %ld, schema_hash: %ld, version: %d,"

--- a/be/src/common/status.h
+++ b/be/src/common/status.h
@@ -129,6 +129,8 @@ public:
     bool is_thrift_rpc_error() const { return code() == TStatusCode::THRIFT_RPC_ERROR; }
 
     bool is_end_of_file() const { return code() == TStatusCode::END_OF_FILE; }
+
+    bool is_not_found() const { return code() == TStatusCode::NOT_FOUND; }
     // Convert into TStatus. Call this if 'status_container' contains an optional
     // TStatus field named 'status'. This also sets __isset.status.
     template <typename T>

--- a/be/src/env/env.h
+++ b/be/src/env/env.h
@@ -118,6 +118,22 @@ public:
     virtual Status get_children(const std::string& dir,
                                 std::vector<std::string>* result) = 0;
 
+    // Iterate the specified directory and call given callback function with child's
+    // name. This function continues execution until all children have been iterated
+    // or callback function return false.
+    // The names are relative to "dir".
+    //
+    // The function call extra cost is acceptable. Compared with returning all children
+    // into a given vector, the performance of this method is 5% worse. However this
+    // approach is more flexiable and efficient in fulfilling other requirements.
+    //
+    // Returns OK if "dir" exists.
+    //         NotFound if "dir" does not exist, the calling process does not have
+    //                  permission to access "dir", or if "dir" is invalid.
+    //         IOError if an IO Error was encountered
+    virtual Status iterate_dir(const std::string& dir,
+                               const std::function<bool(const char*)>& cb) = 0;
+
     // Delete the named file.
     virtual Status delete_file(const std::string& fname) = 0;
 

--- a/be/src/env/env_posix.cpp
+++ b/be/src/env/env_posix.cpp
@@ -565,6 +565,23 @@ public:
         return Status::OK();
     }
 
+    Status iterate_dir(const std::string& dir,
+                       const std::function<bool(const char*)>& cb) override {
+        DIR* d = opendir(dir.c_str());
+        if (d == nullptr) {
+            return io_error(dir, errno);
+        }
+        struct dirent* entry;
+        while ((entry = readdir(d)) != nullptr) {
+            // callback returning false means to terminate iteration
+            if (!cb(entry->d_name)) {
+                break;
+            }
+        }
+        closedir(d);
+        return Status::OK();
+    }
+
     Status delete_file(const std::string& fname) override {
         if (unlink(fname.c_str()) != 0) {
             return io_error(fname, errno);

--- a/be/src/http/action/restore_tablet_action.cpp
+++ b/be/src/http/action/restore_tablet_action.cpp
@@ -24,6 +24,7 @@
 #include "boost/lexical_cast.hpp"
 
 #include "agent/cgroups_mgr.h"
+#include "env/env.h"
 #include "http/http_channel.h"
 #include "http/http_headers.h"
 #include "http/http_request.h"
@@ -189,7 +190,7 @@ Status RestoreTabletAction::_restore(const std::string& key, int64_t tablet_id, 
 
 Status RestoreTabletAction::_create_hard_link_recursive(const std::string& src, const std::string& dst) {
     std::vector<std::string> files;
-    RETURN_IF_ERROR(FileUtils::scan_dir(src, &files));
+    RETURN_IF_ERROR(FileUtils::list_files(Env::Default(), src, &files));
     for (auto& file : files) {
         std::string from = src + "/" + file;
         std::string to = dst + "/" + file;

--- a/be/src/http/download_action.cpp
+++ b/be/src/http/download_action.cpp
@@ -29,6 +29,7 @@
 #include <boost/filesystem.hpp>
 
 #include "agent/cgroups_mgr.h"
+#include "env/env.h"
 #include "http/http_channel.h"
 #include "http/http_headers.h"
 #include "http/http_request.h"
@@ -138,7 +139,7 @@ void DownloadAction::handle(HttpRequest *req) {
 void DownloadAction::do_dir_response(
         const std::string& dir_path, HttpRequest *req) {
     std::vector<std::string> files;
-    Status status = FileUtils::scan_dir(dir_path, &files);
+    Status status = FileUtils::list_files(Env::Default(), dir_path, &files);
     if (!status.ok()) {
         LOG(WARNING) << "Failed to scan dir. dir=" << dir_path;
         HttpChannel::send_error(req, HttpStatus::INTERNAL_SERVER_ERROR);

--- a/be/src/olap/data_dir.cpp
+++ b/be/src/olap/data_dir.cpp
@@ -37,6 +37,7 @@
 #include <boost/filesystem.hpp>
 #include <boost/interprocess/sync/file_lock.hpp>
 
+#include "env/env.h"
 #include "olap/file_helper.h"
 #include "olap/olap_define.h"
 #include "olap/olap_snapshot_converter.h"
@@ -472,7 +473,7 @@ void DataDir::find_tablet_in_trash(int64_t tablet_id, std::vector<std::string>* 
     // path: /root_path/trash/time_label/tablet_id/schema_hash
     std::string trash_path = _path + TRASH_PREFIX;
     std::vector<std::string> sub_dirs;
-    FileUtils::scan_dir(trash_path, &sub_dirs);
+    FileUtils::list_files(Env::Default(), trash_path, &sub_dirs);
     for (auto& sub_dir : sub_dirs) {
         // sub dir is time_label
         std::string sub_path = trash_path + "/" + sub_dir;

--- a/be/src/runtime/snapshot_loader.cpp
+++ b/be/src/runtime/snapshot_loader.cpp
@@ -26,6 +26,7 @@
 #include "gen_cpp/HeartbeatService_types.h"
 
 #include "common/logging.h"
+#include "env/env.h"
 #include "exec/broker_reader.h"
 #include "exec/broker_writer.h"
 #include "olap/file_helper.h"
@@ -771,7 +772,7 @@ Status SnapshotLoader::_get_existing_files_from_local(
     const std::string& local_path,
     std::vector<std::string>* local_files) {
 
-    Status status = FileUtils::scan_dir(local_path, local_files);
+    Status status = FileUtils::list_files(Env::Default(), local_path, local_files);
     if (!status.ok()) {
         std::stringstream ss;
         ss << "failed to list files in local path: " << local_path << ", msg: "

--- a/be/src/util/doris_metrics.cpp
+++ b/be/src/util/doris_metrics.cpp
@@ -20,6 +20,8 @@
 
 #include "util/doris_metrics.h"
 
+#include "env/env.h"
+
 #include "util/debug_util.h"
 #include "util/file_utils.h"
 #include "util/system_metrics.h"
@@ -303,7 +305,7 @@ void DorisMetrics::_update_process_thread_num() {
     ss << "/proc/" << pid << "/task/";
 
     int64_t count = 0;
-    Status st = FileUtils::scan_dir(ss.str(), nullptr, &count);
+    Status st = FileUtils::get_children_count(Env::Default(), ss.str(), &count);
     if (!st.ok()) {
         LOG(WARNING) << "failed to count thread num from: " << ss.str();
         process_thread_num.set_value(0);
@@ -321,7 +323,7 @@ void DorisMetrics::_update_process_fd_num() {
     std::stringstream ss;
     ss << "/proc/" << pid << "/fd/";
     int64_t count = 0;
-    Status st = FileUtils::scan_dir(ss.str(), nullptr, &count);
+    Status st = FileUtils::get_children_count(Env::Default(), ss.str(), &count);
     if (!st.ok()) {
         LOG(WARNING) << "failed to count fd from: " << ss.str();
         process_fd_num_used.set_value(0);

--- a/be/src/util/file_utils.h
+++ b/be/src/util/file_utils.h
@@ -25,8 +25,16 @@
 
 namespace doris {
 
+class Env;
+
+// Return true if file is '.' or '..'
+inline bool is_dot_or_dotdot(const char* name) {
+    return name[0] == '.' && (name[1] == '\0' || (name[1] == '.' && name[2] == '\0'));
+}
+
 class FileUtils {
 public:
+
     // Create directory of dir_path, 
     // This function will create directory recursively,
     // if dir's parent directory doesn't exist
@@ -38,16 +46,18 @@ public:
     // Delete file recursively.
     static Status remove_all(const std::string& dir_path);
 
-    // Scan dir path and return all files in this path without '.' and '..'
-    // Item in files is the filename in 'dir_path', which is not absolute path
-    // if files == nullptr, no file names will be returned.
-    // if file_count != nullptr, it will save the number of files.
-    static Status scan_dir(
-            const std::string& dir_path, std::vector<std::string>* files,
-            int64_t* file_count = nullptr);
-    static Status scan_dir(
-        const std::string& dir_path,
-        const std::function<bool(const std::string&, const std::string&)>& callback);
+    // List all files in the specified directory without '.' and '..'.
+    // If you want retreive all files, you can use Env::iterate_dir.
+    // All valid files will be stored in given *files.
+    static Status list_files(
+        Env* env,
+        const std::string& dir,
+        std::vector<std::string>* files);
+
+    // Get the number of children belong to the specified directory, this
+    // funciton also exclude '.' and '..'.
+    // Return OK with *count is set to the count, if execute successful.
+    static Status get_children_count(Env* env, const std::string& dir, int64_t* count);
 
     // If the file_path is not exist, or is not a dir, return false.
     static bool is_dir(const std::string& file_path);


### PR DESCRIPTION
Now Env has unify all environment operation, such as file operation.
However some of our old functions don't leverage it. This change unify
FileUtils::scan_dir to use Env's function.

For #1978 