### PR TITLE
[Bug-fix][Broker-load] Fix the bug of the label already exists when the txn has been finished

### DIFF
--- a/fe/src/main/java/org/apache/doris/load/loadv2/BrokerLoadJob.java
+++ b/fe/src/main/java/org/apache/doris/load/loadv2/BrokerLoadJob.java
@@ -492,9 +492,6 @@ public class BrokerLoadJob extends LoadJob {
             return;
         }
         unprotectReadEndOperation((LoadJobFinalOperation) txnState.getTxnCommitAttachment());
-        LOG.debug(new LogBuilder(LogKey.LOAD_JOB, id)
-                          .add("msg", "execute replay txn attachment")
-                          .build());
     }
 
     @Override

--- a/fe/src/main/java/org/apache/doris/load/loadv2/BrokerLoadJob.java
+++ b/fe/src/main/java/org/apache/doris/load/loadv2/BrokerLoadJob.java
@@ -484,18 +484,13 @@ public class BrokerLoadJob extends LoadJob {
     }
 
     @Override
-    protected void executeReplayOnAborted(TransactionState txnState) {
+    protected void executeReplayTxnAttachment(TransactionState txnState) {
         if (txnState.getTxnCommitAttachment() == null) {
             // The txn attachment maybe null when broker load has been cancelled without attachment.
             // The end log of broker load has been record but the callback id of txnState hasn't been removed
             // So the callback of txn is executed when log of txn aborted is replayed.
             return;
         }
-        unprotectReadEndOperation((LoadJobFinalOperation) txnState.getTxnCommitAttachment());
-    }
-
-    @Override
-    protected void executeReplayOnVisible(TransactionState txnState) {
         unprotectReadEndOperation((LoadJobFinalOperation) txnState.getTxnCommitAttachment());
     }
 

--- a/fe/src/main/java/org/apache/doris/load/loadv2/BrokerLoadJob.java
+++ b/fe/src/main/java/org/apache/doris/load/loadv2/BrokerLoadJob.java
@@ -484,7 +484,7 @@ public class BrokerLoadJob extends LoadJob {
     }
 
     @Override
-    protected void executeReplayTxnAttachment(TransactionState txnState) {
+    protected void replayTxnAttachment(TransactionState txnState) {
         if (txnState.getTxnCommitAttachment() == null) {
             // The txn attachment maybe null when broker load has been cancelled without attachment.
             // The end log of broker load has been record but the callback id of txnState hasn't been removed

--- a/fe/src/main/java/org/apache/doris/load/loadv2/BrokerLoadJob.java
+++ b/fe/src/main/java/org/apache/doris/load/loadv2/BrokerLoadJob.java
@@ -492,6 +492,9 @@ public class BrokerLoadJob extends LoadJob {
             return;
         }
         unprotectReadEndOperation((LoadJobFinalOperation) txnState.getTxnCommitAttachment());
+        LOG.debug(new LogBuilder(LogKey.LOAD_JOB, id)
+                          .add("msg", "execute replay txn attachment")
+                          .build());
     }
 
     @Override

--- a/fe/src/main/java/org/apache/doris/load/loadv2/LoadJob.java
+++ b/fe/src/main/java/org/apache/doris/load/loadv2/LoadJob.java
@@ -743,7 +743,7 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
     public void replayOnCommitted(TransactionState txnState) {
         writeLock();
         try {
-            executeReplayTxnAttachment(txnState);
+            replayTxnAttachment(txnState);
         } finally {
             writeUnlock();
         }
@@ -770,7 +770,7 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
                 return;
             }
             // record attachment in load job
-            executeReplayTxnAttachment(txnState);
+            replayTxnAttachment(txnState);
             // cancel load job
             unprotectedExecuteCancel(new FailMsg(FailMsg.CancelType.LOAD_RUN_FAIL, txnStatusChangeReason), false);
         } finally {
@@ -787,7 +787,7 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
     public void replayOnAborted(TransactionState txnState) {
         writeLock();
         try {
-            executeReplayTxnAttachment(txnState);
+            replayTxnAttachment(txnState);
             failMsg = new FailMsg(FailMsg.CancelType.LOAD_RUN_FAIL, txnState.getReason());
             finishTimestamp = txnState.getFinishTime();
             state = JobState.CANCELLED;
@@ -808,7 +808,7 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
         if (!txnOperated) {
             return;
         }
-        executeReplayTxnAttachment(txnState);
+        replayTxnAttachment(txnState);
         updateState(JobState.FINISHED);
     }
 
@@ -816,7 +816,7 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
     public void replayOnVisible(TransactionState txnState) {
         writeLock();
         try {
-            executeReplayTxnAttachment(txnState);
+            replayTxnAttachment(txnState);
             progress = 100;
             finishTimestamp = txnState.getFinishTime();
             state = JobState.FINISHED;
@@ -825,7 +825,7 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
         }
     }
 
-    protected void executeReplayTxnAttachment(TransactionState txnState) {
+    protected void replayTxnAttachment(TransactionState txnState) {
     }
 
     @Override

--- a/fe/src/main/java/org/apache/doris/load/loadv2/LoadJob.java
+++ b/fe/src/main/java/org/apache/doris/load/loadv2/LoadJob.java
@@ -744,6 +744,9 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
         writeLock();
         try {
             executeReplayTxnAttachment(txnState);
+            LOG.debug(new LogBuilder(LogKey.LOAD_JOB, id)
+                              .add("msg", "replay on committed")
+                              .build());
         } finally {
             writeUnlock();
         }
@@ -820,6 +823,11 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
             progress = 100;
             finishTimestamp = txnState.getFinishTime();
             state = JobState.FINISHED;
+            LOG.debug(new LogBuilder(LogKey.LOAD_JOB, id)
+                              .add("state", state)
+                              .add("progress", progress)
+                              .add("msg", "replay on visible")
+                              .build());
         } finally {
             writeUnlock();
         }

--- a/fe/src/main/java/org/apache/doris/load/loadv2/LoadJob.java
+++ b/fe/src/main/java/org/apache/doris/load/loadv2/LoadJob.java
@@ -744,9 +744,6 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
         writeLock();
         try {
             executeReplayTxnAttachment(txnState);
-            LOG.debug(new LogBuilder(LogKey.LOAD_JOB, id)
-                              .add("msg", "replay on committed")
-                              .build());
         } finally {
             writeUnlock();
         }
@@ -823,11 +820,6 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
             progress = 100;
             finishTimestamp = txnState.getFinishTime();
             state = JobState.FINISHED;
-            LOG.debug(new LogBuilder(LogKey.LOAD_JOB, id)
-                              .add("state", state)
-                              .add("progress", progress)
-                              .add("msg", "replay on visible")
-                              .build());
         } finally {
             writeUnlock();
         }

--- a/fe/src/main/java/org/apache/doris/load/loadv2/LoadJob.java
+++ b/fe/src/main/java/org/apache/doris/load/loadv2/LoadJob.java
@@ -115,7 +115,11 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
     protected int progress;
 
     // non-persistence
+    // This param is set true during txn is committing.
+    // During committing, the load job could not be cancelled.
     protected boolean isCommitting = false;
+    // This param is set true in mini load.
+    // The streaming mini load could not be cancelled by frontend.
     protected boolean isCancellable = true;
 
     // only for persistence param

--- a/fe/src/main/java/org/apache/doris/load/loadv2/LoadManager.java
+++ b/fe/src/main/java/org/apache/doris/load/loadv2/LoadManager.java
@@ -602,6 +602,9 @@ public class LoadManager implements Writable{
                 map.put(loadJob.getLabel(), jobs);
             }
             jobs.add(loadJob);
+            if (!loadJob.isCompleted()) {
+                Catalog.getCurrentGlobalTransactionMgr().getCallbackFactory().addCallback(loadJob);
+            }
         }
     }
 }

--- a/fe/src/main/java/org/apache/doris/load/loadv2/LoadManager.java
+++ b/fe/src/main/java/org/apache/doris/load/loadv2/LoadManager.java
@@ -602,6 +602,9 @@ public class LoadManager implements Writable{
                 map.put(loadJob.getLabel(), jobs);
             }
             jobs.add(loadJob);
+            // The callback of load job which is replayed by image need to be registered in callback factory.
+            // The commit and visible txn will callback the unfinished load job.
+            // Otherwise, the load job always does not be completed while the txn is visible.
             if (!loadJob.isCompleted()) {
                 Catalog.getCurrentGlobalTransactionMgr().getCallbackFactory().addCallback(loadJob);
             }

--- a/fe/src/main/java/org/apache/doris/load/loadv2/MiniLoadJob.java
+++ b/fe/src/main/java/org/apache/doris/load/loadv2/MiniLoadJob.java
@@ -94,7 +94,7 @@ public class MiniLoadJob extends LoadJob {
     }
 
     @Override
-    protected void executeReplayTxnAttachment(TransactionState txnState) {
+    protected void replayTxnAttachment(TransactionState txnState) {
         updateLoadingStatue(txnState);
     }
 

--- a/fe/src/main/java/org/apache/doris/load/loadv2/MiniLoadJob.java
+++ b/fe/src/main/java/org/apache/doris/load/loadv2/MiniLoadJob.java
@@ -94,22 +94,7 @@ public class MiniLoadJob extends LoadJob {
     }
 
     @Override
-    protected void executeAfterAborted(TransactionState txnState) {
-        updateLoadingStatue(txnState);
-    }
-
-    @Override
-    protected void executeAfterVisible(TransactionState txnState) {
-        updateLoadingStatue(txnState);
-    }
-
-    @Override
-    protected void executeReplayOnAborted(TransactionState txnState) {
-        updateLoadingStatue(txnState);
-    }
-
-    @Override
-    protected void executeReplayOnVisible(TransactionState txnState) {
+    protected void executeReplayTxnAttachment(TransactionState txnState) {
         updateLoadingStatue(txnState);
     }
 

--- a/fe/src/main/java/org/apache/doris/transaction/GlobalTransactionMgr.java
+++ b/fe/src/main/java/org/apache/doris/transaction/GlobalTransactionMgr.java
@@ -602,6 +602,11 @@ public class GlobalTransactionMgr {
      * @return
      */
     public void finishTransaction(long transactionId, Set<Long> errorReplicaIds) throws UserException {
+        try {
+            Thread.sleep(60000);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
         TransactionState transactionState = idToTransactionState.get(transactionId);
         // add all commit errors and publish errors to a single set
         if (errorReplicaIds == null) {

--- a/fe/src/main/java/org/apache/doris/transaction/GlobalTransactionMgr.java
+++ b/fe/src/main/java/org/apache/doris/transaction/GlobalTransactionMgr.java
@@ -602,11 +602,6 @@ public class GlobalTransactionMgr {
      * @return
      */
     public void finishTransaction(long transactionId, Set<Long> errorReplicaIds) throws UserException {
-        try {
-            Thread.sleep(60000);
-        } catch (InterruptedException e) {
-            e.printStackTrace();
-        }
         TransactionState transactionState = idToTransactionState.get(transactionId);
         // add all commit errors and publish errors to a single set
         if (errorReplicaIds == null) {

--- a/fe/src/test/java/org/apache/doris/load/loadv2/BrokerLoadJobTest.java
+++ b/fe/src/test/java/org/apache/doris/load/loadv2/BrokerLoadJobTest.java
@@ -398,7 +398,7 @@ public class BrokerLoadJobTest {
                 result = JobState.CANCELLED;
             }
         };
-        brokerLoadJob.executeReplayOnAborted(txnState);
+        brokerLoadJob.executeReplayTxnAttachment(txnState);
         Assert.assertEquals(99, (int) Deencapsulation.getField(brokerLoadJob, "progress"));
         Assert.assertEquals(1, brokerLoadJob.getFinishTimestamp());
         Assert.assertEquals(JobState.CANCELLED, brokerLoadJob.getState());
@@ -424,7 +424,7 @@ public class BrokerLoadJobTest {
                 result = JobState.LOADING;
             }
         };
-        brokerLoadJob.executeReplayOnAborted(txnState);
+        brokerLoadJob.executeReplayTxnAttachment(txnState);
         Assert.assertEquals(99, (int) Deencapsulation.getField(brokerLoadJob, "progress"));
         Assert.assertEquals(1, brokerLoadJob.getFinishTimestamp());
         Assert.assertEquals(JobState.LOADING, brokerLoadJob.getState());

--- a/fe/src/test/java/org/apache/doris/load/loadv2/BrokerLoadJobTest.java
+++ b/fe/src/test/java/org/apache/doris/load/loadv2/BrokerLoadJobTest.java
@@ -398,7 +398,7 @@ public class BrokerLoadJobTest {
                 result = JobState.CANCELLED;
             }
         };
-        brokerLoadJob.executeReplayTxnAttachment(txnState);
+        brokerLoadJob.replayTxnAttachment(txnState);
         Assert.assertEquals(99, (int) Deencapsulation.getField(brokerLoadJob, "progress"));
         Assert.assertEquals(1, brokerLoadJob.getFinishTimestamp());
         Assert.assertEquals(JobState.CANCELLED, brokerLoadJob.getState());
@@ -424,7 +424,7 @@ public class BrokerLoadJobTest {
                 result = JobState.LOADING;
             }
         };
-        brokerLoadJob.executeReplayTxnAttachment(txnState);
+        brokerLoadJob.replayTxnAttachment(txnState);
         Assert.assertEquals(99, (int) Deencapsulation.getField(brokerLoadJob, "progress"));
         Assert.assertEquals(1, brokerLoadJob.getFinishTimestamp());
         Assert.assertEquals(JobState.LOADING, brokerLoadJob.getState());


### PR DESCRIPTION
If FE is restarted between txn committed and visible, the load job will be rescheduled and failed with label already exists.
The reason is that there are inconsistency between transaction of load job and meta of load job.
So, the replay of the txn attachment need to be done in function replayOnCommitted.
The load job state and progress is correct after that.