### PR TITLE
Fix string bug in segment v2

### DIFF
--- a/be/src/olap/iterators.h
+++ b/be/src/olap/iterators.h
@@ -20,6 +20,7 @@
 #include <memory>
 
 #include "common/status.h"
+#include "olap/olap_common.h"
 
 namespace doris {
 

--- a/be/src/olap/iterators.h
+++ b/be/src/olap/iterators.h
@@ -75,6 +75,9 @@ public:
     // TODO(hkp): refactor the column predicate framework
     // to unify Conditions and ColumnPredicate
     const std::vector<ColumnPredicate*>* column_predicates = nullptr;
+
+    // reader statistics
+    OlapReaderStatistics* stats = nullptr;
 };
 
 // Used to read data in RowBlockV2 one by one

--- a/be/src/olap/row_block2.h
+++ b/be/src/olap/row_block2.h
@@ -66,6 +66,11 @@ public:
     // notice the life time of returned value
     Status copy_to_row_cursor(size_t row_idx, RowCursor* row_cursor);
 
+    // Copy the row_idx row's data into given row_cursor.
+    // This function will use deep copy.
+    // This function is used to convert RowBlockV2 to RowBlock
+    Status deep_copy_to_row_cursor(size_t row_idx, RowCursor* cursor, MemPool* mem_pool);
+
     // Get the column block for one of the columns in this row block.
     // `cid` must be one of `schema()->column_ids()`.
     ColumnBlock column_block(ColumnId cid) const {

--- a/be/src/olap/rowset/segment_v2/segment_iterator.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.cpp
@@ -339,7 +339,11 @@ Status SegmentIterator::next_batch(RowBlockV2* block) {
     RETURN_IF_ERROR(_next_batch(block, &rows_to_read));
     _cur_rowid += rows_to_read;
     block->set_num_rows(rows_to_read);
-
+    // update raw_rows_read counter
+    // judge nullptr for unit test case
+    if (_context->stats != nullptr) {
+        _context->stats->raw_rows_read += block->num_rows();
+    }
     if (block->num_rows() == 0) {
         return Status::EndOfFile("no more data in segment");
     }

--- a/be/src/olap/rowset/segment_v2/segment_iterator.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.cpp
@@ -341,8 +341,8 @@ Status SegmentIterator::next_batch(RowBlockV2* block) {
     block->set_num_rows(rows_to_read);
     // update raw_rows_read counter
     // judge nullptr for unit test case
-    if (_context->stats != nullptr) {
-        _context->stats->raw_rows_read += block->num_rows();
+    if (_opts.stats != nullptr) {
+        _opts.stats->raw_rows_read += block->num_rows();
     }
     if (block->num_rows() == 0) {
         return Status::EndOfFile("no more data in segment");


### PR DESCRIPTION
string type read failed because of invalid memory ptr. In BetaRowsetReader, RowBlockV2 is converted to RowBlock by using shallow copy, which will lead to invalid slice ptr because RowBlockV2 use Arena and RowBlock use MemPool to manage dynamic memory space.