### PR TITLE
Make default rowset type to config

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -483,9 +483,9 @@ namespace config {
     CONF_Int32(tablet_meta_checkpoint_min_interval_secs, "600");
 
     // config for default rowset type
-    // Valid configs: ALPHA_ROWSET, BETA_ROWSET
-    CONF_String(default_rowset_type, "ALPHA_ROWSET");
-    CONF_String(compaction_rowset_type, "ALPHA_ROWSET");
+    // Valid configs: ALPHA, BETA
+    CONF_String(default_rowset_type, "ALPHA");
+    CONF_String(compaction_rowset_type, "ALPHA");
 } // namespace config
 
 } // namespace doris

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -481,6 +481,12 @@ namespace config {
     // config for tablet meta checkpoint
     CONF_Int32(tablet_meta_checkpoint_min_new_rowsets_num, "10");
     CONF_Int32(tablet_meta_checkpoint_min_interval_secs, "600");
+
+    // config for default rowset type
+    // 0: ALPHA_ROWSET
+    // 1: BETA_ROWSET
+    CONF_Int32(default_rowset_type, 0);
+    CONF_Int32(compaction_rowset_type, 0);
 } // namespace config
 
 } // namespace doris

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -483,10 +483,9 @@ namespace config {
     CONF_Int32(tablet_meta_checkpoint_min_interval_secs, "600");
 
     // config for default rowset type
-    // 0: ALPHA_ROWSET
-    // 1: BETA_ROWSET
-    CONF_Int32(default_rowset_type, "0");
-    CONF_Int32(compaction_rowset_type, "0");
+    // Valid configs: ALPHA_ROWSET, BETA_ROWSET
+    CONF_String(default_rowset_type, "ALPHA_ROWSET");
+    CONF_String(compaction_rowset_type, "ALPHA_ROWSET");
 } // namespace config
 
 } // namespace doris

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -485,8 +485,8 @@ namespace config {
     // config for default rowset type
     // 0: ALPHA_ROWSET
     // 1: BETA_ROWSET
-    CONF_Int32(default_rowset_type, 0);
-    CONF_Int32(compaction_rowset_type, 0);
+    CONF_Int32(default_rowset_type, "0");
+    CONF_Int32(compaction_rowset_type, "0");
 } // namespace config
 
 } // namespace doris

--- a/be/src/olap/compaction.cpp
+++ b/be/src/olap/compaction.cpp
@@ -90,7 +90,7 @@ OLAPStatus Compaction::construct_output_rowset_writer() {
     context.tablet_id = _tablet->tablet_id();
     context.partition_id = _tablet->partition_id();
     context.tablet_schema_hash = _tablet->schema_hash();
-    context.rowset_type = (RowsetTypePB)config::compaction_rowset_type;
+    context.rowset_type = StorageEngine::instance()->compaction_rowset_type();
     context.rowset_path_prefix = _tablet->tablet_path();
     context.tablet_schema = &(_tablet->tablet_schema());
     context.rowset_state = VISIBLE;

--- a/be/src/olap/compaction.cpp
+++ b/be/src/olap/compaction.cpp
@@ -90,7 +90,7 @@ OLAPStatus Compaction::construct_output_rowset_writer() {
     context.tablet_id = _tablet->tablet_id();
     context.partition_id = _tablet->partition_id();
     context.tablet_schema_hash = _tablet->schema_hash();
-    context.rowset_type = config::compaction_rowset_type;
+    context.rowset_type = (RowsetTypePB)config::compaction_rowset_type;
     context.rowset_path_prefix = _tablet->tablet_path();
     context.tablet_schema = &(_tablet->tablet_schema());
     context.rowset_state = VISIBLE;

--- a/be/src/olap/compaction.cpp
+++ b/be/src/olap/compaction.cpp
@@ -90,7 +90,7 @@ OLAPStatus Compaction::construct_output_rowset_writer() {
     context.tablet_id = _tablet->tablet_id();
     context.partition_id = _tablet->partition_id();
     context.tablet_schema_hash = _tablet->schema_hash();
-    context.rowset_type = DEFAULT_ROWSET_TYPE;
+    context.rowset_type = config::compaction_rowset_type;
     context.rowset_path_prefix = _tablet->tablet_path();
     context.tablet_schema = &(_tablet->tablet_schema());
     context.rowset_state = VISIBLE;

--- a/be/src/olap/delta_writer.cpp
+++ b/be/src/olap/delta_writer.cpp
@@ -130,7 +130,7 @@ OLAPStatus DeltaWriter::init() {
     writer_context.tablet_id = _req.tablet_id;
     writer_context.partition_id = _req.partition_id;
     writer_context.tablet_schema_hash = _req.schema_hash;
-    writer_context.rowset_type = (RowsetTypePB)config::default_rowset_type;
+    writer_context.rowset_type = _storage_engine->default_rowset_type();
     writer_context.rowset_path_prefix = _tablet->tablet_path();
     writer_context.tablet_schema = &(_tablet->tablet_schema());
     writer_context.rowset_state = PREPARED;

--- a/be/src/olap/delta_writer.cpp
+++ b/be/src/olap/delta_writer.cpp
@@ -130,7 +130,7 @@ OLAPStatus DeltaWriter::init() {
     writer_context.tablet_id = _req.tablet_id;
     writer_context.partition_id = _req.partition_id;
     writer_context.tablet_schema_hash = _req.schema_hash;
-    writer_context.rowset_type = DEFAULT_ROWSET_TYPE;
+    writer_context.rowset_type = config::default_rowset_type;
     writer_context.rowset_path_prefix = _tablet->tablet_path();
     writer_context.tablet_schema = &(_tablet->tablet_schema());
     writer_context.rowset_state = PREPARED;

--- a/be/src/olap/delta_writer.cpp
+++ b/be/src/olap/delta_writer.cpp
@@ -130,7 +130,7 @@ OLAPStatus DeltaWriter::init() {
     writer_context.tablet_id = _req.tablet_id;
     writer_context.partition_id = _req.partition_id;
     writer_context.tablet_schema_hash = _req.schema_hash;
-    writer_context.rowset_type = config::default_rowset_type;
+    writer_context.rowset_type = (RowsetTypePB)config::default_rowset_type;
     writer_context.rowset_path_prefix = _tablet->tablet_path();
     writer_context.tablet_schema = &(_tablet->tablet_schema());
     writer_context.rowset_state = PREPARED;

--- a/be/src/olap/push_handler.cpp
+++ b/be/src/olap/push_handler.cpp
@@ -315,7 +315,7 @@ OLAPStatus PushHandler::_convert(TabletSharedPtr cur_tablet,
         context.tablet_id = cur_tablet->tablet_id();
         context.partition_id = _request.partition_id;
         context.tablet_schema_hash = cur_tablet->schema_hash();
-        context.rowset_type = (RowsetTypePB)config::default_rowset_type;
+        context.rowset_type = StorageEngine::instance()->default_rowset_type();
         context.rowset_path_prefix = cur_tablet->tablet_path();
         context.tablet_schema = &(cur_tablet->tablet_schema());
         context.rowset_state = PREPARED;

--- a/be/src/olap/push_handler.cpp
+++ b/be/src/olap/push_handler.cpp
@@ -315,7 +315,7 @@ OLAPStatus PushHandler::_convert(TabletSharedPtr cur_tablet,
         context.tablet_id = cur_tablet->tablet_id();
         context.partition_id = _request.partition_id;
         context.tablet_schema_hash = cur_tablet->schema_hash();
-        context.rowset_type = DEFAULT_ROWSET_TYPE;
+        context.rowset_type = config::default_rowset_type;
         context.rowset_path_prefix = cur_tablet->tablet_path();
         context.tablet_schema = &(cur_tablet->tablet_schema());
         context.rowset_state = PREPARED;

--- a/be/src/olap/push_handler.cpp
+++ b/be/src/olap/push_handler.cpp
@@ -315,7 +315,7 @@ OLAPStatus PushHandler::_convert(TabletSharedPtr cur_tablet,
         context.tablet_id = cur_tablet->tablet_id();
         context.partition_id = _request.partition_id;
         context.tablet_schema_hash = cur_tablet->schema_hash();
-        context.rowset_type = config::default_rowset_type;
+        context.rowset_type = (RowsetTypePB)config::default_rowset_type;
         context.rowset_path_prefix = cur_tablet->tablet_path();
         context.tablet_schema = &(cur_tablet->tablet_schema());
         context.rowset_state = PREPARED;

--- a/be/src/olap/rowset/segment_v2/segment_iterator.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.cpp
@@ -339,6 +339,7 @@ Status SegmentIterator::next_batch(RowBlockV2* block) {
     RETURN_IF_ERROR(_next_batch(block, &rows_to_read));
     _cur_rowid += rows_to_read;
     block->set_num_rows(rows_to_read);
+    block->set_selected_size(rows_to_read);
     // update raw_rows_read counter
     // judge nullptr for unit test case
     if (_opts.stats != nullptr) {

--- a/be/src/olap/rowset/segment_v2/segment_iterator.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.cpp
@@ -362,6 +362,5 @@ Status SegmentIterator::next_batch(RowBlockV2* block) {
     return Status::OK();
 }
 
-
 }
 }

--- a/be/src/olap/storage_engine.cpp
+++ b/be/src/olap/storage_engine.cpp
@@ -115,7 +115,9 @@ StorageEngine::StorageEngine(const EngineOptions& options)
         _is_report_tablet_already(false), 
         _tablet_manager(new TabletManager()),
         _txn_manager(new TxnManager()),
-        _rowset_id_generator(new UniqueRowsetIdGenerator(options.backend_uid)) {
+        _rowset_id_generator(new UniqueRowsetIdGenerator(options.backend_uid)),
+        _default_rowset_type(ALPHA_ROWSET),
+        _compaction_rowset_type(ALPHA_ROWSET) {
     if (_s_instance == nullptr) {
         _s_instance = this;
     }
@@ -739,7 +741,7 @@ OLAPStatus StorageEngine::_do_sweep(
 void StorageEngine::_parse_default_rowset_type() {
     std::string default_rowset_type_config = config::default_rowset_type;
     boost::to_upper(default_rowset_type_config);
-    if (default_rowset_type_config == "BETA_ROWSET") {
+    if (default_rowset_type_config == "BETA") {
         _default_rowset_type = BETA_ROWSET;
     } else {
         _default_rowset_type = ALPHA_ROWSET;
@@ -747,7 +749,7 @@ void StorageEngine::_parse_default_rowset_type() {
 
     std::string compaction_rowset_type_config = config::compaction_rowset_type;
     boost::to_upper(compaction_rowset_type_config);
-    if (compaction_rowset_type_config == "BETA_ROWSET") {
+    if (compaction_rowset_type_config == "BETA") {
         _compaction_rowset_type = BETA_ROWSET;
     } else {
         _compaction_rowset_type = BETA_ROWSET;

--- a/be/src/olap/storage_engine.cpp
+++ b/be/src/olap/storage_engine.cpp
@@ -202,6 +202,8 @@ OLAPStatus StorageEngine::open() {
     _memtable_flush_executor = new MemTableFlushExecutor();
     _memtable_flush_executor->init(dirs);
 
+    _parse_default_rowset_type();
+
     return OLAP_SUCCESS;
 }
 

--- a/be/src/olap/storage_engine.cpp
+++ b/be/src/olap/storage_engine.cpp
@@ -733,6 +733,25 @@ OLAPStatus StorageEngine::_do_sweep(
     return res;
 }
 
+// invalid rowset type config will return ALPHA_ROWSET for system to run smoothly
+void StorageEngine::_parse_default_rowset_type() {
+    std::string default_rowset_type_config = config::default_rowset_type;
+    boost::to_upper(default_rowset_type_config);
+    if (default_rowset_type_config == "BETA_ROWSET") {
+        _default_rowset_type = BETA_ROWSET;
+    } else {
+        _default_rowset_type = ALPHA_ROWSET;
+    }
+
+    std::string compaction_rowset_type_config = config::compaction_rowset_type;
+    boost::to_upper(compaction_rowset_type_config);
+    if (compaction_rowset_type_config == "BETA_ROWSET") {
+        _compaction_rowset_type = BETA_ROWSET;
+    } else {
+        _compaction_rowset_type = BETA_ROWSET;
+    }
+}
+
 void StorageEngine::start_delete_unused_rowset() {
     _gc_mutex.lock();
     for (auto it = _unused_rowsets.begin(); it != _unused_rowsets.end();) {

--- a/be/src/olap/storage_engine.h
+++ b/be/src/olap/storage_engine.h
@@ -206,6 +206,10 @@ public:
 
     MemTableFlushExecutor* memtable_flush_executor() { return _memtable_flush_executor; }
 
+    RowsetTypePB default_rowset_type() { return _default_rowset_type; }
+
+    RowsetTypePB compaction_rowset_type() { return _compaction_rowset_type; }
+
 private:
 
     OLAPStatus _check_file_descriptor_number();
@@ -258,6 +262,9 @@ private:
     void* _path_scan_thread_callback(void* arg);
 
     void* _tablet_checkpoint_callback(void* arg);
+
+    // parse the default rowset type config to RowsetTypePB
+    void _parse_default_rowset_type();
 
 private:
 
@@ -356,6 +363,13 @@ private:
     std::unique_ptr<RowsetIdGenerator> _rowset_id_generator;
 
     MemTableFlushExecutor* _memtable_flush_executor;
+
+    // default rowset type for load
+    // used to decide the type of new loaded data
+    RowsetTypePB _default_rowset_type;
+    // default rowset type for compaction.
+    // used to control the the process of converting old data
+    RowsetTypePB _compaction_rowset_type;
 
     DISALLOW_COPY_AND_ASSIGN(StorageEngine);
 };

--- a/be/src/olap/storage_engine.h
+++ b/be/src/olap/storage_engine.h
@@ -206,9 +206,9 @@ public:
 
     MemTableFlushExecutor* memtable_flush_executor() { return _memtable_flush_executor; }
 
-    RowsetTypePB default_rowset_type() { return _default_rowset_type; }
+    RowsetTypePB default_rowset_type() const { return _default_rowset_type; }
 
-    RowsetTypePB compaction_rowset_type() { return _compaction_rowset_type; }
+    RowsetTypePB compaction_rowset_type() const { return _compaction_rowset_type; }
 
 private:
 

--- a/be/src/olap/tablet_manager.cpp
+++ b/be/src/olap/tablet_manager.cpp
@@ -1230,7 +1230,7 @@ OLAPStatus TabletManager::_create_inital_rowset(
             context.tablet_id = tablet->tablet_id();
             context.partition_id = tablet->partition_id();
             context.tablet_schema_hash = tablet->schema_hash();
-            context.rowset_type = DEFAULT_ROWSET_TYPE;
+            context.rowset_type = config::default_rowset_type;
             context.rowset_path_prefix = tablet->tablet_path();
             context.tablet_schema = &(tablet->tablet_schema());
             context.rowset_state = VISIBLE;

--- a/be/src/olap/tablet_manager.cpp
+++ b/be/src/olap/tablet_manager.cpp
@@ -1230,7 +1230,7 @@ OLAPStatus TabletManager::_create_inital_rowset(
             context.tablet_id = tablet->tablet_id();
             context.partition_id = tablet->partition_id();
             context.tablet_schema_hash = tablet->schema_hash();
-            context.rowset_type = (RowsetTypePB)config::default_rowset_type;
+            context.rowset_type = StorageEngine::instance()->default_rowset_type();
             context.rowset_path_prefix = tablet->tablet_path();
             context.tablet_schema = &(tablet->tablet_schema());
             context.rowset_state = VISIBLE;

--- a/be/src/olap/tablet_manager.cpp
+++ b/be/src/olap/tablet_manager.cpp
@@ -1230,7 +1230,7 @@ OLAPStatus TabletManager::_create_inital_rowset(
             context.tablet_id = tablet->tablet_id();
             context.partition_id = tablet->partition_id();
             context.tablet_schema_hash = tablet->schema_hash();
-            context.rowset_type = config::default_rowset_type;
+            context.rowset_type = (RowsetTypePB)config::default_rowset_type;
             context.rowset_path_prefix = tablet->tablet_path();
             context.tablet_schema = &(tablet->tablet_schema());
             context.rowset_state = VISIBLE;


### PR DESCRIPTION
For test convenience and rolling deploy, the default rowset type should be configurable.
I use two configs because I will control loading and compaction seperately. BTW, schema change will use the original rowset type of the base table.