### PR TITLE
Add the unchecked cast from date literal to others

### DIFF
--- a/fe/src/main/java/org/apache/doris/analysis/DateLiteral.java
+++ b/fe/src/main/java/org/apache/doris/analysis/DateLiteral.java
@@ -313,6 +313,8 @@ public class DateLiteral extends LiteralExpr {
             return this;
         } else if (targetType.isStringType()) {
             return new StringLiteral(getStringValue());
+        } else if (Type.isImplicitlyCastable(this.type, targetType, true)) {
+            return new CastExpr(targetType, this);
         }
         Preconditions.checkState(false);
         return this;


### PR DESCRIPTION
Fix the ISSUE:2017
This commit enable the cast function in date.
The date literal can be cast to target type which is implicitly castable such as int, bigint, largeint.