### PR TITLE
Rowset should be loaded only once in a thread-safe manner

### DIFF
--- a/be/src/olap/rowset/alpha_rowset.h
+++ b/be/src/olap/rowset/alpha_rowset.h
@@ -40,10 +40,6 @@ class AlphaRowset : public Rowset {
 public:
     virtual ~AlphaRowset() {}
 
-    // this api is for lazy loading data
-    // always means that there are some io
-    OLAPStatus load(bool use_cache = true) override;
-
     OLAPStatus create_reader(std::shared_ptr<RowsetReader>* result) override;
 
     OLAPStatus split_range(const RowCursor& start_key,
@@ -79,14 +75,15 @@ protected:
                 DataDir* data_dir,
                 RowsetMetaSharedPtr rowset_meta);
 
+    // init segment groups
     OLAPStatus init() override;
+
+    OLAPStatus do_load_once(bool use_cache) override ;
 
     // add custom logic when rowset is published
     void make_visible_extra(Version version, VersionHash version_hash) override;
 
 private:
-    OLAPStatus _init_segment_groups();
-
     std::shared_ptr<SegmentGroup> _segment_group_with_largest_size();
 
 private:

--- a/be/src/olap/rowset/beta_rowset.h
+++ b/be/src/olap/rowset/beta_rowset.h
@@ -38,8 +38,6 @@ public:
 
     static std::string segment_file_path(const std::string& segment_dir, const RowsetId& rowset_id, int segment_id);
 
-    OLAPStatus load(bool use_cache = true) override;
-
     OLAPStatus create_reader(RowsetReaderSharedPtr* result) override;
 
     OLAPStatus split_range(const RowCursor& start_key,
@@ -69,6 +67,8 @@ protected:
                RowsetMetaSharedPtr rowset_meta);
 
     OLAPStatus init() override;
+
+    OLAPStatus do_load_once(bool use_cache) override ;
 
 private:
     friend class BetaRowsetReader;

--- a/be/src/olap/rowset/rowset.cpp
+++ b/be/src/olap/rowset/rowset.cpp
@@ -37,6 +37,10 @@ Rowset::Rowset(const TabletSchema *schema,
     }
 }
 
+OLAPStatus Rowset::load(bool use_cache) {
+    return _load_once.call([this, use_cache] { return do_load_once(use_cache); });
+}
+
 void Rowset::make_visible(Version version, VersionHash version_hash) {
     _is_pending = false;
     _rowset_meta->set_version(version);

--- a/be/src/olap/rowset/rowset.h
+++ b/be/src/olap/rowset/rowset.h
@@ -22,8 +22,10 @@
 #include <vector>
 
 #include "gen_cpp/olap_file.pb.h"
+#include "gutil/macros.h"
 #include "olap/new_status.h"
 #include "olap/rowset/rowset_meta.h"
+#include "util/once.h"
 
 namespace doris {
 
@@ -45,7 +47,10 @@ public:
 
     // Open all segment files in this rowset and load necessary metadata.
     // - `use_cache` : whether to use fd cache, only applicable to alpha rowset now
-    virtual OLAPStatus load(bool use_cache = true) = 0;
+    //
+    // May be called multiple times, subsequent calls will no-op.
+    // Derived class implements the load logic by overriding the `do_load_once()` method.
+    OLAPStatus load(bool use_cache = true);
 
     // returns OLAP_ERR_ROWSET_CREATE_READER when failed to create reader
     virtual OLAPStatus create_reader(std::shared_ptr<RowsetReader>* result) = 0;
@@ -129,6 +134,7 @@ public:
 protected:
     friend class RowsetFactory;
 
+    DISALLOW_COPY_AND_ASSIGN(Rowset);
     // this is non-public because all clients should use RowsetFactory to obtain pointer to initialized Rowset
     Rowset(const TabletSchema* schema,
            std::string rowset_path,
@@ -138,10 +144,8 @@ protected:
     // this is non-public because all clients should use RowsetFactory to obtain pointer to initialized Rowset
     virtual OLAPStatus init() = 0;
 
-    bool is_inited() const { return _is_inited; }
-    void set_inited(bool inited) { _is_inited = inited; }
-    bool is_loaded() const { return _is_loaded; }
-    void set_loaded(bool loaded) { _is_loaded= loaded; }
+    // The actual implementation of load(). Guaranteed by to called exactly once.
+    virtual OLAPStatus do_load_once(bool use_cache) = 0;
 
     // allow subclass to add custom logic when rowset is being published
     virtual void make_visible_extra(Version version, VersionHash version_hash) {}
@@ -154,8 +158,7 @@ protected:
     bool _is_pending;    // rowset is pending iff it's not in visible state
     bool _is_cumulative; // rowset is cumulative iff it's visible and start version < end version
 
-    bool _is_inited = false;
-    bool _is_loaded = false;
+    DorisCallOnce<OLAPStatus> _load_once;
     bool _need_delete_file = false;
 };
 

--- a/be/src/olap/rowset/segment_v2/column_reader.cpp
+++ b/be/src/olap/rowset/segment_v2/column_reader.cpp
@@ -85,6 +85,10 @@ ColumnReader::~ColumnReader() {
 }
 
 Status ColumnReader::init() {
+    return _init_once.call([this] { return _do_init_once(); });
+}
+
+Status ColumnReader::_do_init_once() {
     _type_info = get_type_info((FieldType)_meta.type());
     if (_type_info == nullptr) {
         return Status::NotSupported(Substitute("unsupported typeinfo, type=$0", _meta.type()));

--- a/be/src/olap/rowset/segment_v2/column_reader.h
+++ b/be/src/olap/rowset/segment_v2/column_reader.h
@@ -30,6 +30,7 @@
 #include "olap/rowset/segment_v2/column_zone_map.h" // for ColumnZoneMap
 #include "olap/rowset/segment_v2/row_ranges.h" // for RowRanges
 #include "olap/rowset/segment_v2/page_handle.h" // for PageHandle
+#include "util/once.h"
 
 namespace doris {
 
@@ -61,6 +62,7 @@ public:
             uint64_t num_rows, RandomAccessFile* file);
     ~ColumnReader();
 
+    // May be called multiple times, subsequent calls will no op.
     Status init();
 
     // create a new column iterator. Client should delete returned iterator
@@ -88,6 +90,8 @@ public:
     PagePointer get_dict_page_pointer() const;
 
 private:
+    Status _do_init_once();
+
     Status _init_ordinal_index();
 
     Status _init_column_zone_map();
@@ -103,6 +107,7 @@ private:
     uint64_t _num_rows;
     RandomAccessFile* _file = nullptr;
 
+    DorisCallOnce<Status> _init_once;
     const TypeInfo* _type_info = nullptr;
     const EncodingInfo* _encoding_info = nullptr;
     const BlockCompressionCodec* _compress_codec = nullptr;

--- a/be/src/olap/rowset/segment_v2/segment.h
+++ b/be/src/olap/rowset/segment_v2/segment.h
@@ -24,11 +24,13 @@
 
 #include "common/status.h" // Status
 #include "gen_cpp/segment_v2.pb.h"
+#include "gutil/macros.h"
 #include "olap/iterators.h"
 #include "olap/rowset/segment_v2/common.h" // rowid_t
 #include "olap/short_key_index.h"
 #include "olap/tablet_schema.h"
 #include "util/faststring.h"
+#include "util/once.h"
 
 namespace doris {
 
@@ -57,11 +59,12 @@ using SegmentSharedPtr = std::shared_ptr<Segment>;
 // change finished, client should disable all cached Segment for old TabletSchema.
 class Segment : public std::enable_shared_from_this<Segment> {
 public:
-    Segment(std::string fname, uint32_t segment_id,
-            const TabletSchema* tablet_schema);
-    ~Segment();
+    static Status open(std::string filename,
+                       uint32_t segment_id,
+                       const TabletSchema* tablet_schema,
+                       std::shared_ptr<Segment>* output);
 
-    Status open();
+    ~Segment();
 
     Status new_iterator(
             const Schema& schema,
@@ -75,18 +78,30 @@ public:
 private:
     friend class SegmentIterator;
 
-    Status new_column_iterator(uint32_t cid, ColumnIterator** iter);
-    uint32_t num_rows_per_block() const { return _sk_index_decoder->num_rows_per_block(); }
-    size_t num_short_keys() const { return _tablet_schema->num_short_key_columns(); }
-
+    DISALLOW_COPY_AND_ASSIGN(Segment);
+    Segment(std::string fname, uint32_t segment_id, const TabletSchema* tablet_schema);
+    // open segment file and read the minimum amount of necessary information (footer)
+    Status _open();
     Status _parse_footer();
-    Status _parse_index();
     Status _initial_column_readers();
 
+    Status new_column_iterator(uint32_t cid, ColumnIterator** iter);
+    size_t num_short_keys() const { return _tablet_schema->num_short_key_columns(); }
+
+    // Load and decode short key index.
+    // May be called multiple times, subsequent calls will no op.
+    Status _load_index();
+
+    uint32_t num_rows_per_block() const {
+        DCHECK(_load_index_once.has_called() && _load_index_once.stored_result().ok());
+        return _sk_index_decoder->num_rows_per_block();
+    }
     ShortKeyIndexIterator lower_bound(const Slice& key) const {
+        DCHECK(_load_index_once.has_called() && _load_index_once.stored_result().ok());
         return _sk_index_decoder->lower_bound(key);
     }
     ShortKeyIndexIterator upper_bound(const Slice& key) const {
+        DCHECK(_load_index_once.has_called() && _load_index_once.stored_result().ok());
         return _sk_index_decoder->upper_bound(key);
     }
 
@@ -94,6 +109,7 @@ private:
     // NOTE: Before call this function , client should assure that
     // this segment is not empty.
     uint32_t last_block() const {
+        DCHECK(_load_index_once.has_called() && _load_index_once.stored_result().ok());
         DCHECK(num_rows() > 0);
         return _sk_index_decoder->num_items() - 1;
     }
@@ -111,13 +127,12 @@ private:
     // after this segment is generated.
     std::vector<ColumnReader*> _column_readers;
 
+    // used to guarantee that short key index will be loaded at most once in a thread-safe way
+    DorisCallOnce<Status> _load_index_once;
     // used to store short key index
     faststring _sk_index_buf;
-
     // short key index decoder
     std::unique_ptr<ShortKeyIndexDecoder> _sk_index_decoder;
-
-    bool _index_loaded;
 
     // Map from column unique id to column ordinal in footer's ColumnMetaPB
     // If we can't find unique id from it, it means this segment is created

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -125,7 +125,7 @@ OLAPStatus Tablet::_init_once_action() {
 }
 
 OLAPStatus Tablet::init() {
-    return _init_once.init([this] { return _init_once_action(); });
+    return _init_once.call([this] { return _init_once_action(); });
 }
 
 bool Tablet::is_used() {

--- a/be/src/olap/tablet.h
+++ b/be/src/olap/tablet.h
@@ -264,7 +264,7 @@ private:
     std::string _tablet_path;
     RowsetGraph _rs_graph;
 
-    DorisInitOnce _init_once;
+    DorisCallOnce<OLAPStatus> _init_once;
     RWMutex _meta_lock;
     // meta store lock is used for prevent 2 threads do checkpoint concurrently
     // it will be used in econ-mode in the future
@@ -286,7 +286,7 @@ private:
 };
 
 inline bool Tablet::init_succeeded() {
-    return _init_once.init_succeeded();
+    return _init_once.has_called() && _init_once.stored_result() == OLAP_SUCCESS;
 }
 
 inline DataDir* Tablet::data_dir() const {

--- a/be/test/olap/rowset/segment_v2/segment_test.cpp
+++ b/be/test/olap/rowset/segment_v2/segment_test.cpp
@@ -92,8 +92,8 @@ TEST_F(SegmentReaderWriterTest, normal) {
     ASSERT_TRUE(st.ok());
     // reader
     {
-        std::shared_ptr<Segment> segment(new Segment(fname, 0, tablet_schema.get()));
-        st = segment->open();
+        std::shared_ptr<Segment> segment;
+        st = Segment::open(fname, 0, tablet_schema.get(), &segment);
         LOG(INFO) << "segment open, msg=" << st.to_string();
         ASSERT_TRUE(st.ok());
         ASSERT_EQ(4096, segment->num_rows());
@@ -277,8 +277,8 @@ TEST_F(SegmentReaderWriterTest, TestZoneMap) {
 
     // reader with condition
     {
-        std::shared_ptr<Segment> segment(new Segment(fname, 0, tablet_schema.get()));
-        st = segment->open();
+        std::shared_ptr<Segment> segment;
+        st = Segment::open(fname, 0, tablet_schema.get(), &segment);
         ASSERT_TRUE(st.ok());
         ASSERT_EQ(64 * 1024, segment->num_rows());
         Schema schema(*tablet_schema);
@@ -541,8 +541,8 @@ TEST_F(SegmentReaderWriterTest, TestDefaultValueColumn) {
         new_tablet_schema_1->_cols.push_back(
             create_int_value(5, OLAP_FIELD_AGGREGATION_SUM, true, "NULL"));
 
-        std::shared_ptr<Segment> segment(new Segment(fname, 0, new_tablet_schema_1.get()));
-        st = segment->open();
+        std::shared_ptr<Segment> segment;
+        st = Segment::open(fname, 0, new_tablet_schema_1.get(), &segment);
         ASSERT_TRUE(st.ok());
         ASSERT_EQ(4096, segment->num_rows());
         Schema schema(*new_tablet_schema_1);
@@ -596,8 +596,8 @@ TEST_F(SegmentReaderWriterTest, TestDefaultValueColumn) {
         new_tablet_schema_1->_cols.push_back(create_int_value(4));
         new_tablet_schema_1->_cols.push_back(create_int_value(5, OLAP_FIELD_AGGREGATION_SUM, true, "10086"));
 
-        std::shared_ptr<Segment> segment(new Segment(fname, 0, new_tablet_schema_1.get()));
-        st = segment->open();
+        std::shared_ptr<Segment> segment;
+        st = Segment::open(fname, 0, new_tablet_schema_1.get(), &segment);
         ASSERT_TRUE(st.ok());
         ASSERT_EQ(4096, segment->num_rows());
         Schema schema(*new_tablet_schema_1);
@@ -691,8 +691,8 @@ TEST_F(SegmentReaderWriterTest, TestStringDict) {
     ASSERT_TRUE(st.ok());
 
     {
-        std::shared_ptr<Segment> segment(new Segment(fname, 0, tablet_schema.get()));
-        st = segment->open();
+        std::shared_ptr<Segment> segment;
+        st = Segment::open(fname, 0, tablet_schema.get(), &segment);
         ASSERT_TRUE(st.ok());
         ASSERT_EQ(4096, segment->num_rows());
         Schema schema(*tablet_schema);


### PR DESCRIPTION
Fixed #2023 

This PR implements thread-safe `Rowset::load()` for both AlphaRowset and BetaRowset. The main changes are 

1. Introduce `DorisCallOnce<ReturnType>` to be the replacement for `DorisInitOnce` . It works for both Status and OLAPStatus.
2. `segment_v2::ColumnReader::init()` is now implemented by DorisCallOnce.
3. `segment_v2::Segment` is now created by a factory open() method. This guarantees all Segment instances are in opened state.
4. `segment_v2::Segment::_load_index()` is now implemented by DorisCallOnce.
5. Implement thread-safe load() for AlphaRowset and BetaRowset