### PR TITLE
fix schema change core dump because of null stats

### DIFF
--- a/be/src/olap/schema_change.cpp
+++ b/be/src/olap/schema_change.cpp
@@ -1312,6 +1312,7 @@ OLAPStatus SchemaChangeHandler::_do_process_alter_tablet_v2(const TAlterTabletRe
         _reader_context.return_columns = &return_columns;
         // for schema change, seek_columns is the same to return_columns
         _reader_context.seek_columns = &return_columns;
+        _reader_context.stats = &_stats;
 
         for (auto& rs_reader : rs_readers) {
             rs_reader->init(&_reader_context);
@@ -1428,6 +1429,7 @@ OLAPStatus SchemaChangeHandler::schema_version_convert(
     _reader_context.delete_handler = &delete_handler;
     _reader_context.return_columns = &return_columns;
     _reader_context.seek_columns = &return_columns;
+    _reader_context.stats = &_stats;
 
     RowsetReaderSharedPtr rowset_reader;
     RETURN_NOT_OK((*base_rowset)->create_reader(&rowset_reader));

--- a/be/src/olap/schema_change.h
+++ b/be/src/olap/schema_change.h
@@ -267,6 +267,8 @@ private:
 private:
     RowsetReaderContext _reader_context;
 
+    OlapReaderStatistics _stats;
+
     DISALLOW_COPY_AND_ASSIGN(SchemaChangeHandler);
 };
 


### PR DESCRIPTION
schema change core dump because of OlapReaderStatistics is null.
Issue: #2038