### PR TITLE
optimize the convert of row block v2 to v1 #2011

### DIFF
--- a/be/src/olap/row_block2.cpp
+++ b/be/src/olap/row_block2.cpp
@@ -56,37 +56,37 @@ RowBlockV2::~RowBlockV2() {
     delete[] _selection_vector;
 }
 
-Status RowBlockV2::copy_to_row_cursor(size_t row_idx, RowCursor* cursor) {
-    if (row_idx >= _num_rows) {
-        return Status::InvalidArgument(
-            Substitute("invalid row index $0 (num_rows=$1)", row_idx, _num_rows));
-    }
+Status RowBlockV2::convert_to_row_block(RowCursor* helper, RowBlock* dst) {
     for (auto cid : _schema.column_ids()) {
-        bool is_null = _schema.column(cid)->is_nullable() && BitmapTest(_column_null_bitmaps[cid], row_idx);
-        if (is_null) {
-            cursor->set_null(cid);
+        bool is_nullable = _schema.column(cid)->is_nullable();
+        if (is_nullable) {
+            for (uint16_t i = 0; i < _selected_size; ++i) {
+                uint16_t row_idx = _selection_vector[i];
+                dst->get_row(row_idx, helper);
+                bool is_null = BitmapTest(_column_null_bitmaps[cid], row_idx);
+                if (is_null) {
+                    helper->set_null(cid);
+                } else {
+                    helper->set_not_null(cid);
+                    helper->set_field_content_shallow(cid,
+                            reinterpret_cast<const char*>(column_block(cid).cell_ptr(row_idx)));
+                }
+            }
         } else {
-            cursor->set_not_null(cid);
-            cursor->set_field_content_shallow(cid, reinterpret_cast<const char*>(column_block(cid).cell_ptr(row_idx)));
+            for (uint16_t i = 0; i < _selected_size; ++i) {
+                uint16_t row_idx = _selection_vector[i];
+                dst->get_row(row_idx, helper);
+                helper->set_not_null(cid);
+                helper->set_field_content_shallow(cid,
+                        reinterpret_cast<const char*>(column_block(cid).cell_ptr(row_idx)));
+            }
         }
     }
-    return Status::OK();
-}
-
-Status RowBlockV2::deep_copy_to_row_cursor(size_t row_idx, RowCursor* cursor, MemPool* mem_pool) {                                                                  
-    if (row_idx >= _num_rows) {
-        return Status::InvalidArgument(
-            Substitute("invalid row index $0 (num_rows=$1)", row_idx, _num_rows));
-    }   
-    for (auto cid : _schema.column_ids()) {
-        bool is_null = _schema.column(cid)->is_nullable() && BitmapTest(_column_null_bitmaps[cid], row_idx);
-        if (is_null) {
-            cursor->set_null(cid);
-        } else {
-            cursor->set_not_null(cid);
-            cursor->set_field_content(cid, reinterpret_cast<const char*>(column_block(cid).cell_ptr(row_idx)), mem_pool);
-        }   
-    }   
+    // swap MemPool to copy string content
+    dst->mem_pool()->exchange_data(_pool.get());
+    dst->set_pos(0);
+    dst->set_limit(_selected_size);
+    dst->finalize(_selected_size);
     return Status::OK();
 }
 

--- a/be/src/olap/row_block2.h
+++ b/be/src/olap/row_block2.h
@@ -26,6 +26,7 @@
 #include "olap/schema.h"
 #include "olap/types.h"
 #include "olap/selection_vector.h"
+#include "olap/row_block.h"
 #include "runtime/mem_pool.h"
 #include "runtime/mem_tracker.h"
 
@@ -63,15 +64,8 @@ public:
         }
     }
 
-    // Copy the row_idx row's data into given row_cursor.
-    // This function will use shallow copy, so the client should
-    // notice the life time of returned value
-    Status copy_to_row_cursor(size_t row_idx, RowCursor* row_cursor);
-
-    // Copy the row_idx row's data into given row_cursor.
-    // This function will use deep copy.
-    // This function is used to convert RowBlockV2 to RowBlock
-    Status deep_copy_to_row_cursor(size_t row_idx, RowCursor* cursor, MemPool* mem_pool);
+    // convert RowBlockV2 to RowBlock
+    Status convert_to_row_block(RowCursor* helper, RowBlock* dst);
 
     // Get the column block for one of the columns in this row block.
     // `cid` must be one of `schema()->column_ids()`.


### PR DESCRIPTION
1. use MemPool exchange to avoid string copy
2. use batch convert to replace row by row