### PR TITLE
Remove drop repository name toLowerCase

### DIFF
--- a/fe/src/main/java/org/apache/doris/backup/RepositoryMgr.java
+++ b/fe/src/main/java/org/apache/doris/backup/RepositoryMgr.java
@@ -90,7 +90,7 @@ public class RepositoryMgr extends Daemon implements Writable {
     }
 
     public Repository getRepo(String repoName) {
-        return repoNameMap.get(repoName.toLowerCase());
+        return repoNameMap.get(repoName);
     }
 
     public Repository getRepo(long repoId) {
@@ -100,7 +100,7 @@ public class RepositoryMgr extends Daemon implements Writable {
     public Status removeRepo(String repoName, boolean isReplay) {
         lock.lock();
         try {
-            Repository repo = repoNameMap.remove(repoName.toLowerCase());
+            Repository repo = repoNameMap.remove(repoName);
             if (repo != null) {
                 repoIdMap.remove(repo.getId());
 


### PR DESCRIPTION
fix bug #2057 Create and drop repository using same repo name in lowercase and uppercase occurs error
