### PR TITLE
Segment v2 stream load core dump(#2037)

### DIFF
--- a/be/src/olap/rowset/segment_v2/binary_dict_page.cpp
+++ b/be/src/olap/rowset/segment_v2/binary_dict_page.cpp
@@ -99,13 +99,13 @@ Status BinaryDictPageBuilder::add(const uint8_t* vals, size_t* count) {
     }
 }
 
-Slice BinaryDictPageBuilder::finish() {
+OwnedSlice BinaryDictPageBuilder::release() {
     _finished = true;
 
-    Slice data_slice = _data_page_builder->finish();
-    _buffer.append(data_slice.data, data_slice.size);
+    OwnedSlice data_slice(_data_page_builder->release());
+    _buffer.append(data_slice.slice.data, data_slice.slice.size);
     encode_fixed32_le(&_buffer[0], _encoding_type);
-    return Slice(_buffer);
+    return OwnedSlice(Slice(_buffer.release(), _buffer.size()));
 }
 
 void BinaryDictPageBuilder::reset() {
@@ -131,7 +131,7 @@ uint64_t BinaryDictPageBuilder::size() const {
     return _pool.total_allocated_bytes() + _data_page_builder->size();
 }
 
-Status BinaryDictPageBuilder::get_dictionary_page(Slice* dictionary_page) {
+Status BinaryDictPageBuilder::get_dictionary_page(OwnedSlice* dictionary_page) {
     _dictionary.clear();
     _dict_builder->reset();
     size_t add_count = 1;
@@ -140,8 +140,7 @@ Status BinaryDictPageBuilder::get_dictionary_page(Slice* dictionary_page) {
     for (auto& dict_item: _dict_items) {
         RETURN_IF_ERROR(_dict_builder->add(reinterpret_cast<const uint8_t*>(&dict_item), &add_count));
     }
-    *dictionary_page = _dict_builder->finish();
-    _dict_builder->release();
+    *dictionary_page = _dict_builder->release();
     _dict_items.clear();
     return Status::OK();
 }

--- a/be/src/olap/rowset/segment_v2/binary_dict_page.h
+++ b/be/src/olap/rowset/segment_v2/binary_dict_page.h
@@ -32,7 +32,6 @@
 #include "runtime/mem_tracker.h"
 #include "gen_cpp/segment_v2.pb.h"
 #include "gutil/hash/string_hash.h"
-#include <util/owned_slice.h>
 
 namespace doris {
 namespace segment_v2 {
@@ -59,6 +58,11 @@ public:
 
     Status add(const uint8_t* vals, size_t* count) override;
 
+    // this api will release the memory ownership of encoded data
+    // Note:
+    //     reset() should be called after this function before reuse the builder
+    OwnedSlice finish() override;
+
     void reset() override;
 
     size_t count() const override;
@@ -66,11 +70,6 @@ public:
     uint64_t size() const override;
 
     Status get_dictionary_page(OwnedSlice* dictionary_page) override;
-
-    // this api will release the memory ownership of encoded data
-    // Note:
-    //     reset() should be called after this function before reuse the builder
-    OwnedSlice release() override;
 
 private:
     PageBuilderOptions _options;

--- a/be/src/olap/rowset/segment_v2/binary_dict_page.h
+++ b/be/src/olap/rowset/segment_v2/binary_dict_page.h
@@ -32,6 +32,7 @@
 #include "runtime/mem_tracker.h"
 #include "gen_cpp/segment_v2.pb.h"
 #include "gutil/hash/string_hash.h"
+#include <util/owned_slice.h>
 
 namespace doris {
 namespace segment_v2 {
@@ -58,24 +59,18 @@ public:
 
     Status add(const uint8_t* vals, size_t* count) override;
 
-    Slice finish() override;
-
     void reset() override;
 
     size_t count() const override;
 
     uint64_t size() const override;
 
-    Status get_dictionary_page(Slice* dictionary_page) override;
+    Status get_dictionary_page(OwnedSlice* dictionary_page) override;
 
     // this api will release the memory ownership of encoded data
     // Note:
-    //     release() should be called after finish
     //     reset() should be called after this function before reuse the builder
-    void release() override {
-        uint8_t* ret = _buffer.release();
-        (void)ret;
-    }
+    OwnedSlice release() override;
 
 private:
     PageBuilderOptions _options;

--- a/be/src/olap/rowset/segment_v2/column_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/column_writer.cpp
@@ -32,6 +32,7 @@
 #include "util/faststring.h" // for fastring
 #include "util/rle_encoding.h" // for RleEncoder
 #include "util/block_compression.h"
+#include "util/owned_slice.h" // for OwnedSlice
 
 namespace doris {
 namespace segment_v2 {
@@ -186,7 +187,7 @@ uint64_t ColumnWriter::estimate_buffer_size() {
     uint64_t size = 0;
     Page* page = _pages.head;
     while (page != nullptr) {
-        size += page->data.get_size();
+        size += page->data.slice.get_size();
         if (_is_nullable) {
             size += page->null_bitmap.get_size();
         }
@@ -215,10 +216,10 @@ Status ColumnWriter::write_data() {
     }
     // write column dict
     if (_encoding_info->encoding() == DICT_ENCODING) {
-        Slice dict_page;
+        OwnedSlice dict_page;
         _page_builder->get_dictionary_page(&dict_page);
         std::vector<Slice> origin_data;
-        origin_data.push_back(dict_page);
+        origin_data.push_back(dict_page.slice);
         RETURN_IF_ERROR(_write_physical_page(&origin_data, &_dict_page_pp));
     }
     return Status::OK();
@@ -232,8 +233,8 @@ Status ColumnWriter::write_ordinal_index() {
 
 Status ColumnWriter::write_zone_map() {
     if (_opts.need_zone_map) {
-        Slice data = _column_zone_map_builder->finish();
-        std::vector<Slice> slices{data};
+        OwnedSlice data(_column_zone_map_builder->finish());
+        std::vector<Slice> slices{data.slice};
         return _write_physical_page(&slices, &_zone_map_pp);
     }
     return Status::OK();
@@ -270,7 +271,7 @@ Status ColumnWriter::_write_data_page(Page* page) {
     if (_is_nullable) {
         origin_data.push_back(page->null_bitmap);
     }
-    origin_data.push_back(page->data);
+    origin_data.push_back(page->data.slice);
     // TODO(zc): upadte page's statistics
 
     PagePointer pp;
@@ -328,8 +329,7 @@ Status ColumnWriter::_finish_current_page() {
     Page* page = new Page();
     page->first_rowid = _last_first_rowid;
     page->num_rows = _next_rowid - _last_first_rowid;
-    page->data = _page_builder->finish();
-    _page_builder->release();
+    page->data = _page_builder->release();
     _page_builder->reset();
     if (_is_nullable) {
         page->null_bitmap = _null_bitmap_builder->finish();

--- a/be/src/olap/rowset/segment_v2/column_writer.h
+++ b/be/src/olap/rowset/segment_v2/column_writer.h
@@ -22,7 +22,7 @@
 #include "common/status.h" // for Status
 #include "gen_cpp/segment_v2.pb.h" // for EncodingTypePB
 #include "util/bitmap.h" // for BitmapChange
-#include "util/slice.h" // for slice
+#include "util/owned_slice.h" // for owned slice
 #include "olap/rowset/segment_v2/common.h" // for rowid_t
 #include "olap/rowset/segment_v2/page_pointer.h" // for PagePointer
 #include "olap/rowset/segment_v2/column_zone_map.h" // for ColumnZoneMapBuilder
@@ -103,7 +103,7 @@ private:
         int32_t first_rowid;
         int32_t num_rows;
         Slice null_bitmap = Slice((const uint8_t*)nullptr, 0);
-        OwnedSlice data = OwnedSlice(Slice((const uint8_t*)nullptr, 0));
+        OwnedSlice data = OwnedSlice((uint8_t*)nullptr, 0);
 
         Page* next = nullptr;
 

--- a/be/src/olap/rowset/segment_v2/column_writer.h
+++ b/be/src/olap/rowset/segment_v2/column_writer.h
@@ -102,14 +102,13 @@ private:
     struct Page {
         int32_t first_rowid;
         int32_t num_rows;
-        Slice null_bitmap = Slice((uint8_t*)nullptr, 0);
-        Slice data = Slice((uint8_t*)nullptr, 0);
+        Slice null_bitmap = Slice((const uint8_t*)nullptr, 0);
+        OwnedSlice data = OwnedSlice(Slice((const uint8_t*)nullptr, 0));
 
         Page* next = nullptr;
 
         ~Page() {
             delete[] null_bitmap.data;
-            delete[] data.data;
         }
     };
 

--- a/be/src/olap/rowset/segment_v2/column_zone_map.h
+++ b/be/src/olap/rowset/segment_v2/column_zone_map.h
@@ -21,7 +21,7 @@
 #include <memory>
 
 #include "common/status.h"
-#include "util/owned_slice.h"
+#include "util/slice.h"
 #include "olap/field.h"
 #include "gen_cpp/segment_v2.pb.h"
 #include "olap/rowset/segment_v2/binary_plain_page.h"
@@ -65,7 +65,7 @@ public:
     }
 
     OwnedSlice finish() {
-        return _page_builder->release();
+        return _page_builder->finish();
     }
 
 private:

--- a/be/src/olap/rowset/segment_v2/column_zone_map.h
+++ b/be/src/olap/rowset/segment_v2/column_zone_map.h
@@ -21,7 +21,7 @@
 #include <memory>
 
 #include "common/status.h"
-#include "util/slice.h"
+#include "util/owned_slice.h"
 #include "olap/field.h"
 #include "gen_cpp/segment_v2.pb.h"
 #include "olap/rowset/segment_v2/binary_plain_page.h"
@@ -64,8 +64,8 @@ public:
         return _page_builder->size();
     }
 
-    Slice finish() {
-        return _page_builder->finish();
+    OwnedSlice finish() {
+        return _page_builder->release();
     }
 
 private:

--- a/be/src/olap/rowset/segment_v2/frame_of_reference_page.h
+++ b/be/src/olap/rowset/segment_v2/frame_of_reference_page.h
@@ -49,12 +49,6 @@ public:
         return Status::OK();
     }
 
-    Slice finish() override {
-        _finished = true;
-        _encoder->flush();
-        return Slice(_buf.data(), _buf.size());
-    }
-
     void reset() override {
         _count = 0;
         _finished = false;
@@ -71,11 +65,11 @@ public:
 
     // this api will release the memory ownership of encoded data
     // Note:
-    //     release() should be called after finish
     //     reset() should be called after this function before reuse the builder
-    void release() override {
-        uint8_t* ret = _buf.release();
-        (void)ret;
+    OwnedSlice release() override {
+        _finished = true;
+        _encoder->flush();
+        return OwnedSlice(Slice(_buf.release(), _buf.size()));
     }
 
 private:

--- a/be/src/olap/rowset/segment_v2/frame_of_reference_page.h
+++ b/be/src/olap/rowset/segment_v2/frame_of_reference_page.h
@@ -49,6 +49,17 @@ public:
         return Status::OK();
     }
 
+    // this api will release the memory ownership of encoded data
+    // Note:
+    //     reset() should be called after this function before reuse the builder
+    OwnedSlice finish() override {
+        _finished = true;
+        _encoder->flush();
+
+        size_t buf_size = _buf.size();
+        return OwnedSlice(_buf.release(), buf_size);
+    }
+
     void reset() override {
         _count = 0;
         _finished = false;
@@ -61,15 +72,6 @@ public:
 
     uint64_t size() const override {
         return _buf.size();
-    }
-
-    // this api will release the memory ownership of encoded data
-    // Note:
-    //     reset() should be called after this function before reuse the builder
-    OwnedSlice release() override {
-        _finished = true;
-        _encoder->flush();
-        return OwnedSlice(Slice(_buf.release(), _buf.size()));
     }
 
 private:

--- a/be/src/olap/rowset/segment_v2/page_builder.h
+++ b/be/src/olap/rowset/segment_v2/page_builder.h
@@ -52,6 +52,11 @@ public:
     // vals size should be decided according to the page build type
     virtual doris::Status add(const uint8_t* vals, size_t* count) = 0;
 
+    // This api is for release the resource owned by builder
+    // It means it will transfer the ownership of some resource to other.
+    // This api should be followed by reset() before reuse the builder
+    virtual OwnedSlice finish() = 0;
+
     // Get the dictionary page for dictionary encoding mode column.
     virtual Status get_dictionary_page(OwnedSlice* dictionary_page) {
         return Status::NotSupported("get_dictionary_page not implemented");
@@ -67,11 +72,6 @@ public:
 
     // Return the total bytes of pageBuilder that have been added to the page.
     virtual uint64_t size() const = 0;
-
-    // This api is for release the resource owned by builder
-    // It means it will transfer the ownership of some resource to other.
-    // This api should be followed by reset() before reuse the builder
-    virtual OwnedSlice release() = 0;
 
 private:
     DISALLOW_COPY_AND_ASSIGN(PageBuilder);

--- a/be/src/olap/rowset/segment_v2/page_builder.h
+++ b/be/src/olap/rowset/segment_v2/page_builder.h
@@ -21,7 +21,7 @@
 #include <vector>
 
 #include "gutil/macros.h"
-#include "util/slice.h"
+#include "util/owned_slice.h"
 #include "common/status.h"
 #include "olap/rowset/segment_v2/common.h"
 
@@ -53,14 +53,9 @@ public:
     virtual doris::Status add(const uint8_t* vals, size_t* count) = 0;
 
     // Get the dictionary page for dictionary encoding mode column.
-    virtual Status get_dictionary_page(Slice* dictionary_page) {
+    virtual Status get_dictionary_page(OwnedSlice* dictionary_page) {
         return Status::NotSupported("get_dictionary_page not implemented");
     }
-
-    // Return a Slice which represents the encoded data of current page.
-    //
-    // This Slice points to internal data of this builder.
-    virtual Slice finish() = 0;
 
     // Reset the internal state of the page builder.
     //
@@ -75,9 +70,8 @@ public:
 
     // This api is for release the resource owned by builder
     // It means it will transfer the ownership of some resource to other.
-    // This api is always called after finish
-    // and should be followed by reset() before reuse the builder
-    virtual void release() = 0;
+    // This api should be followed by reset() before reuse the builder
+    virtual OwnedSlice release() = 0;
 
 private:
     DISALLOW_COPY_AND_ASSIGN(PageBuilder);

--- a/be/src/util/owned_slice.h
+++ b/be/src/util/owned_slice.h
@@ -44,7 +44,7 @@ namespace doris {
 class OwnedSlice {
 
 public:
-    OwnedSlice() {_slice.data = nullptr;_slice.size=0;}
+    OwnedSlice() : _slice((uint8_t*)nullptr, 0) {}
 
     explicit OwnedSlice(Slice slice) : _slice(slice) {}
 
@@ -64,8 +64,6 @@ public:
     OwnedSlice& operator = (OwnedSlice&& src) {
         if (this != &src) {
             std::swap(_slice, src._slice);
-            delete[] src._slice.data;
-            src._slice.size = 0;
         }
         return *this;
     }
@@ -74,9 +72,9 @@ public:
         return _slice;
     }
 
-    private:
-        DISALLOW_COPY_AND_ASSIGN(OwnedSlice);
-        Slice _slice;
+private:
+    DISALLOW_COPY_AND_ASSIGN(OwnedSlice);
+    Slice _slice;
 };
 
 }// namespace doris

--- a/be/src/util/owned_slice.h
+++ b/be/src/util/owned_slice.h
@@ -1,0 +1,68 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include "gutil/macros.h"
+#include "util/slice.h"
+
+/**
+ *  used for maintain slice' life cycle
+ *  Attention!!!  the input slice must own a data（char*） which using new to allocate memory,or will cause error
+ */
+
+namespace doris {
+
+class OwnedSlice {
+
+public:
+    Slice slice;
+
+    OwnedSlice() {slice.data = nullptr;}
+
+    OwnedSlice(Slice _slice) : slice(_slice) {}
+
+    ~OwnedSlice(){
+        if (slice.data != nullptr) {
+            delete[] slice.data;
+        }
+    }
+
+    OwnedSlice(OwnedSlice&& src) {
+        slice.data = src.slice.data;
+        slice.size = src.slice.size;
+        src.slice.data = nullptr;
+        src.slice.size = 0;
+    }
+
+    OwnedSlice& operator = (OwnedSlice&& src) {
+        if (this != &src) {
+            if (slice.data != nullptr) {
+                delete[] slice.data;
+            }
+            slice.data = src.slice.data;
+            slice.size = src.slice.size;
+            src.slice.data = nullptr;
+            src.slice.size = 0;
+        }
+        return *this;
+    }
+
+private:
+    DISALLOW_COPY_AND_ASSIGN(OwnedSlice);
+};
+} // namespace doris

--- a/be/test/olap/rowset/segment_v2/binary_dict_page_test.cpp
+++ b/be/test/olap/rowset/segment_v2/binary_dict_page_test.cpp
@@ -46,17 +46,17 @@ public:
         const Slice *ptr = &slices[0];
         Status ret = page_builder.add(reinterpret_cast<const uint8_t *>(ptr), &count);
 
-        Slice s = page_builder.finish();
+        OwnedSlice s = page_builder.release();
         ASSERT_EQ(slices.size(), page_builder.count());
         ASSERT_FALSE(page_builder.is_page_full());
 
         // construct dict page
-        Slice dict_slice;
+        OwnedSlice dict_slice;
         Status status = page_builder.get_dictionary_page(&dict_slice);
         ASSERT_TRUE(status.ok());
         PageDecoderOptions dict_decoder_options;
         std::unique_ptr<BinaryPlainPageDecoder> dict_page_decoder(
-                new BinaryPlainPageDecoder(dict_slice, dict_decoder_options));
+                new BinaryPlainPageDecoder(dict_slice.slice, dict_decoder_options));
         status = dict_page_decoder->init();
         ASSERT_TRUE(status.ok());
         // because every slice is unique
@@ -64,7 +64,7 @@ public:
 
         // decode
         PageDecoderOptions decoder_options;
-        BinaryDictPageDecoder page_decoder(s, decoder_options);
+        BinaryDictPageDecoder page_decoder(s.slice, decoder_options);
         page_decoder.set_dict_decoder(dict_page_decoder.get());
 
         status = page_decoder.init();
@@ -110,7 +110,7 @@ public:
         options.dict_page_size = 1 * 1024 * 1024;
         BinaryDictPageBuilder page_builder(options);
         size_t count = contents.size();
-        std::vector<Slice> results;
+        std::vector<OwnedSlice> results;
         std::vector<size_t> page_start_ids;
         size_t total_size = 0;
         page_start_ids.push_back(0);
@@ -119,29 +119,27 @@ public:
             const Slice* ptr = &contents[i];
             Status ret = page_builder.add(reinterpret_cast<const uint8_t *>(ptr), &add_num);
             if (page_builder.is_page_full()) {
-                Slice s = page_builder.finish();
-                total_size += s.size;
-                results.emplace_back(s);
-                page_builder.release();
+                OwnedSlice s = page_builder.release();
+                total_size += s.slice.size;
+                results.emplace_back(std::move(s));
                 page_builder.reset();
                 page_start_ids.push_back(i + 1);
             }
             i += add_num;
         }
-        Slice s = page_builder.finish();
-        total_size += s.size;
-        results.emplace_back(s);
-        page_builder.release();
+        OwnedSlice s = page_builder.release();
+        total_size += s.slice.size;
+        results.emplace_back(std::move(s));
 
         page_start_ids.push_back(count);
 
-        Slice dict_slice;
+        OwnedSlice dict_slice;
         Status status = page_builder.get_dictionary_page(&dict_slice);
         size_t data_size = total_size;
-        total_size += dict_slice.size;
+        total_size += dict_slice.slice.size;
         ASSERT_TRUE(status.ok());
         LOG(INFO) << "total size:" << total_size << ", data size:" << data_size
-                << ", dict size:" << dict_slice.size
+                << ", dict size:" << dict_slice.slice.size
                 << " result page size:" << results.size();
         
         // validate
@@ -152,13 +150,13 @@ public:
             //int slice_index = 1;
             PageDecoderOptions dict_decoder_options;
             std::unique_ptr<BinaryPlainPageDecoder> dict_page_decoder(
-                    new BinaryPlainPageDecoder(dict_slice, dict_decoder_options));
+                    new BinaryPlainPageDecoder(dict_slice.slice, dict_decoder_options));
             status = dict_page_decoder->init();
             ASSERT_TRUE(status.ok());
 
             // decode
             PageDecoderOptions decoder_options;
-            BinaryDictPageDecoder page_decoder(results[slice_index], decoder_options);
+            BinaryDictPageDecoder page_decoder(results[slice_index].slice, decoder_options);
             status = page_decoder.init();
             page_decoder.set_dict_decoder(dict_page_decoder.get());
             ASSERT_TRUE(status.ok());

--- a/be/test/olap/rowset/segment_v2/binary_dict_page_test.cpp
+++ b/be/test/olap/rowset/segment_v2/binary_dict_page_test.cpp
@@ -46,7 +46,7 @@ public:
         const Slice *ptr = &slices[0];
         Status ret = page_builder.add(reinterpret_cast<const uint8_t *>(ptr), &count);
 
-        OwnedSlice s = page_builder.release();
+        OwnedSlice s = page_builder.finish();
         ASSERT_EQ(slices.size(), page_builder.count());
         ASSERT_FALSE(page_builder.is_page_full());
 
@@ -56,7 +56,7 @@ public:
         ASSERT_TRUE(status.ok());
         PageDecoderOptions dict_decoder_options;
         std::unique_ptr<BinaryPlainPageDecoder> dict_page_decoder(
-                new BinaryPlainPageDecoder(dict_slice.slice, dict_decoder_options));
+                new BinaryPlainPageDecoder(dict_slice.slice(), dict_decoder_options));
         status = dict_page_decoder->init();
         ASSERT_TRUE(status.ok());
         // because every slice is unique
@@ -64,7 +64,7 @@ public:
 
         // decode
         PageDecoderOptions decoder_options;
-        BinaryDictPageDecoder page_decoder(s.slice, decoder_options);
+        BinaryDictPageDecoder page_decoder(s.slice(), decoder_options);
         page_decoder.set_dict_decoder(dict_page_decoder.get());
 
         status = page_decoder.init();
@@ -119,16 +119,16 @@ public:
             const Slice* ptr = &contents[i];
             Status ret = page_builder.add(reinterpret_cast<const uint8_t *>(ptr), &add_num);
             if (page_builder.is_page_full()) {
-                OwnedSlice s = page_builder.release();
-                total_size += s.slice.size;
+                OwnedSlice s = page_builder.finish();
+                total_size += s.slice().size;
                 results.emplace_back(std::move(s));
                 page_builder.reset();
                 page_start_ids.push_back(i + 1);
             }
             i += add_num;
         }
-        OwnedSlice s = page_builder.release();
-        total_size += s.slice.size;
+        OwnedSlice s = page_builder.finish();
+        total_size += s.slice().size;
         results.emplace_back(std::move(s));
 
         page_start_ids.push_back(count);
@@ -136,10 +136,10 @@ public:
         OwnedSlice dict_slice;
         Status status = page_builder.get_dictionary_page(&dict_slice);
         size_t data_size = total_size;
-        total_size += dict_slice.slice.size;
+        total_size += dict_slice.slice().size;
         ASSERT_TRUE(status.ok());
         LOG(INFO) << "total size:" << total_size << ", data size:" << data_size
-                << ", dict size:" << dict_slice.slice.size
+                << ", dict size:" << dict_slice.slice().size
                 << " result page size:" << results.size();
         
         // validate
@@ -150,13 +150,13 @@ public:
             //int slice_index = 1;
             PageDecoderOptions dict_decoder_options;
             std::unique_ptr<BinaryPlainPageDecoder> dict_page_decoder(
-                    new BinaryPlainPageDecoder(dict_slice.slice, dict_decoder_options));
+                    new BinaryPlainPageDecoder(dict_slice.slice(), dict_decoder_options));
             status = dict_page_decoder->init();
             ASSERT_TRUE(status.ok());
 
             // decode
             PageDecoderOptions decoder_options;
-            BinaryDictPageDecoder page_decoder(results[slice_index].slice, decoder_options);
+            BinaryDictPageDecoder page_decoder(results[slice_index].slice(), decoder_options);
             status = page_decoder.init();
             page_decoder.set_dict_decoder(dict_page_decoder.get());
             ASSERT_TRUE(status.ok());

--- a/be/test/olap/rowset/segment_v2/binary_plain_page_test.cpp
+++ b/be/test/olap/rowset/segment_v2/binary_plain_page_test.cpp
@@ -53,9 +53,9 @@ public:
         Slice *ptr = &slices[0];
         Status ret = page_builder.add(reinterpret_cast<const uint8_t *>(ptr), &count);
 
-        OwnedSlice owned_slice = page_builder.release();
+        OwnedSlice owned_slice = page_builder.finish();
         PageDecoderOptions decoder_options;
-        PageDecoderType page_decoder(owned_slice.slice, decoder_options);
+        PageDecoderType page_decoder(owned_slice.slice(), decoder_options);
         Status status = page_decoder.init();
         ASSERT_TRUE(status.ok());
 

--- a/be/test/olap/rowset/segment_v2/binary_plain_page_test.cpp
+++ b/be/test/olap/rowset/segment_v2/binary_plain_page_test.cpp
@@ -52,10 +52,10 @@ public:
 
         Slice *ptr = &slices[0];
         Status ret = page_builder.add(reinterpret_cast<const uint8_t *>(ptr), &count);
-        
-        Slice s = page_builder.finish();
+
+        OwnedSlice owned_slice = page_builder.release();
         PageDecoderOptions decoder_options;
-        PageDecoderType page_decoder(s, decoder_options);
+        PageDecoderType page_decoder(owned_slice.slice, decoder_options);
         Status status = page_decoder.init();
         ASSERT_TRUE(status.ok());
 

--- a/be/test/olap/rowset/segment_v2/bitshuffle_page_test.cpp
+++ b/be/test/olap/rowset/segment_v2/bitshuffle_page_test.cpp
@@ -56,12 +56,12 @@ public:
         PageBuilderType page_builder(options);
 
         page_builder.add(reinterpret_cast<const uint8_t *>(src), &size);
-        OwnedSlice s = page_builder.release();
-        LOG(INFO) << "RLE Encoded size for 10k values: " << s.slice.size
+        OwnedSlice s = page_builder.finish();
+        LOG(INFO) << "RLE Encoded size for 10k values: " << s.slice().size
                 << ", original size:" << size * sizeof(CppType);
 
         segment_v2::PageDecoderOptions decoder_options;
-        PageDecoderType page_decoder(s.slice, decoder_options);
+        PageDecoderType page_decoder(s.slice(), decoder_options);
         Status status = page_decoder.init();
         ASSERT_TRUE(status.ok());
         ASSERT_EQ(0, page_decoder.current_index());

--- a/be/test/olap/rowset/segment_v2/bitshuffle_page_test.cpp
+++ b/be/test/olap/rowset/segment_v2/bitshuffle_page_test.cpp
@@ -56,12 +56,12 @@ public:
         PageBuilderType page_builder(options);
 
         page_builder.add(reinterpret_cast<const uint8_t *>(src), &size);
-        Slice s = page_builder.finish();
-        LOG(INFO) << "RLE Encoded size for 10k values: " << s.size
+        OwnedSlice s = page_builder.release();
+        LOG(INFO) << "RLE Encoded size for 10k values: " << s.slice.size
                 << ", original size:" << size * sizeof(CppType);
 
         segment_v2::PageDecoderOptions decoder_options;
-        PageDecoderType page_decoder(s, decoder_options);
+        PageDecoderType page_decoder(s.slice, decoder_options);
         Status status = page_decoder.init();
         ASSERT_TRUE(status.ok());
         ASSERT_EQ(0, page_decoder.current_index());

--- a/be/test/olap/rowset/segment_v2/column_zone_map_test.cpp
+++ b/be/test/olap/rowset/segment_v2/column_zone_map_test.cpp
@@ -45,8 +45,8 @@ public:
             builder.add(nullptr, 1);
         }
         builder.flush();
-        Slice zone_map_page = builder.finish();
-        ColumnZoneMap column_zone_map(zone_map_page);
+        OwnedSlice zone_map_page = builder.finish();
+        ColumnZoneMap column_zone_map(zone_map_page.slice);
         Status status = column_zone_map.load();
         ASSERT_TRUE(status.ok());
         ASSERT_EQ(3, column_zone_map.num_pages());
@@ -88,8 +88,8 @@ TEST_F(ColumnZoneMapTest, NormalTestIntPage) {
         builder.add(nullptr, 1);
     }
     builder.flush();
-    Slice zone_map_page = builder.finish();
-    ColumnZoneMap column_zone_map(zone_map_page);
+    OwnedSlice zone_map_page = builder.finish();
+    ColumnZoneMap column_zone_map(zone_map_page.slice);
     Status status = column_zone_map.load();
     ASSERT_TRUE(status.ok());
     ASSERT_EQ(3, column_zone_map.num_pages());

--- a/be/test/olap/rowset/segment_v2/column_zone_map_test.cpp
+++ b/be/test/olap/rowset/segment_v2/column_zone_map_test.cpp
@@ -46,7 +46,7 @@ public:
         }
         builder.flush();
         OwnedSlice zone_map_page = builder.finish();
-        ColumnZoneMap column_zone_map(zone_map_page.slice);
+        ColumnZoneMap column_zone_map(zone_map_page.slice());
         Status status = column_zone_map.load();
         ASSERT_TRUE(status.ok());
         ASSERT_EQ(3, column_zone_map.num_pages());
@@ -89,7 +89,7 @@ TEST_F(ColumnZoneMapTest, NormalTestIntPage) {
     }
     builder.flush();
     OwnedSlice zone_map_page = builder.finish();
-    ColumnZoneMap column_zone_map(zone_map_page.slice);
+    ColumnZoneMap column_zone_map(zone_map_page.slice());
     Status status = column_zone_map.load();
     ASSERT_TRUE(status.ok());
     ASSERT_EQ(3, column_zone_map.num_pages());

--- a/be/test/olap/rowset/segment_v2/frame_of_reference_page_test.cpp
+++ b/be/test/olap/rowset/segment_v2/frame_of_reference_page_test.cpp
@@ -53,13 +53,13 @@ public:
         builder_options.data_page_size = 256 * 1024;
         PageBuilderType for_page_builder(builder_options);
         for_page_builder.add(reinterpret_cast<const uint8_t *>(src), &size);
-        OwnedSlice s = for_page_builder.release();
+        OwnedSlice s = for_page_builder.finish();
         ASSERT_EQ(size, for_page_builder.count());
-        LOG(INFO) << "FrameOfReference Encoded size for 10k values: " << s.slice.size
+        LOG(INFO) << "FrameOfReference Encoded size for 10k values: " << s.slice().size
                   << ", original size:" << size * sizeof(CppType);
 
         PageDecoderOptions decoder_options;
-        PageDecoderType for_page_decoder(s.slice, decoder_options);
+        PageDecoderType for_page_decoder(s.slice(), decoder_options);
         Status status = for_page_decoder.init();
         ASSERT_TRUE(status.ok());
         ASSERT_EQ(0, for_page_decoder.current_index());
@@ -153,10 +153,10 @@ TEST_F(FrameOfReferencePageTest, TestInt32SequenceBlockEncoderSize) {
     builder_options.data_page_size = 256 * 1024;
     segment_v2::FrameOfReferencePageBuilder<OLAP_FIELD_TYPE_INT> page_builder(builder_options);
     page_builder.add(reinterpret_cast<const uint8_t *>(ints.get()), &size);
-    OwnedSlice s = page_builder.release();
+    OwnedSlice s = page_builder.finish();
     // body: 4 bytes min value + 128 * 1 /8 packing value = 20
     // header: 1 + 1 + 4 = 6
-    ASSERT_EQ(26, s.slice.size);
+    ASSERT_EQ(26, s.slice().size);
 }
 
 TEST_F(FrameOfReferencePageTest, TestInt32NormalBlockEncoderSize) {
@@ -169,10 +169,10 @@ TEST_F(FrameOfReferencePageTest, TestInt32NormalBlockEncoderSize) {
     builder_options.data_page_size = 256 * 1024;
     segment_v2::FrameOfReferencePageBuilder<OLAP_FIELD_TYPE_INT> page_builder(builder_options);
     page_builder.add(reinterpret_cast<const uint8_t *>(ints.get()), &size);
-    OwnedSlice s = page_builder.release();
+    OwnedSlice s = page_builder.finish();
     // body: 4 bytes min value + 128 * 7 /8 packing value = 116
     // header: 1 + 1 + 4 = 6
-    ASSERT_EQ(122, s.slice.size);
+    ASSERT_EQ(122, s.slice().size);
 }
 
 }

--- a/be/test/olap/rowset/segment_v2/frame_of_reference_page_test.cpp
+++ b/be/test/olap/rowset/segment_v2/frame_of_reference_page_test.cpp
@@ -53,13 +53,13 @@ public:
         builder_options.data_page_size = 256 * 1024;
         PageBuilderType for_page_builder(builder_options);
         for_page_builder.add(reinterpret_cast<const uint8_t *>(src), &size);
-        Slice s = for_page_builder.finish();
+        OwnedSlice s = for_page_builder.release();
         ASSERT_EQ(size, for_page_builder.count());
-        LOG(INFO) << "FrameOfReference Encoded size for 10k values: " << s.size
+        LOG(INFO) << "FrameOfReference Encoded size for 10k values: " << s.slice.size
                   << ", original size:" << size * sizeof(CppType);
 
         PageDecoderOptions decoder_options;
-        PageDecoderType for_page_decoder(s, decoder_options);
+        PageDecoderType for_page_decoder(s.slice, decoder_options);
         Status status = for_page_decoder.init();
         ASSERT_TRUE(status.ok());
         ASSERT_EQ(0, for_page_decoder.current_index());
@@ -153,10 +153,10 @@ TEST_F(FrameOfReferencePageTest, TestInt32SequenceBlockEncoderSize) {
     builder_options.data_page_size = 256 * 1024;
     segment_v2::FrameOfReferencePageBuilder<OLAP_FIELD_TYPE_INT> page_builder(builder_options);
     page_builder.add(reinterpret_cast<const uint8_t *>(ints.get()), &size);
-    Slice s = page_builder.finish();
+    OwnedSlice s = page_builder.release();
     // body: 4 bytes min value + 128 * 1 /8 packing value = 20
     // header: 1 + 1 + 4 = 6
-    ASSERT_EQ(26, s.size);
+    ASSERT_EQ(26, s.slice.size);
 }
 
 TEST_F(FrameOfReferencePageTest, TestInt32NormalBlockEncoderSize) {
@@ -169,10 +169,10 @@ TEST_F(FrameOfReferencePageTest, TestInt32NormalBlockEncoderSize) {
     builder_options.data_page_size = 256 * 1024;
     segment_v2::FrameOfReferencePageBuilder<OLAP_FIELD_TYPE_INT> page_builder(builder_options);
     page_builder.add(reinterpret_cast<const uint8_t *>(ints.get()), &size);
-    Slice s = page_builder.finish();
+    OwnedSlice s = page_builder.release();
     // body: 4 bytes min value + 128 * 7 /8 packing value = 116
     // header: 1 + 1 + 4 = 6
-    ASSERT_EQ(122, s.size);
+    ASSERT_EQ(122, s.slice.size);
 }
 
 }

--- a/be/test/olap/rowset/segment_v2/plain_page_test.cpp
+++ b/be/test/olap/rowset/segment_v2/plain_page_test.cpp
@@ -67,10 +67,10 @@ public:
         PageBuilderType page_builder(options);
 
         page_builder.add(reinterpret_cast<const uint8_t *>(src), &size);
-        OwnedSlice s = page_builder.release();
+        OwnedSlice s = page_builder.finish();
 
         PageDecoderOptions decoder_options;
-        PageDecoderType page_decoder(s.slice, decoder_options);
+        PageDecoderType page_decoder(s.slice(), decoder_options);
         Status status = page_decoder.init();
         ASSERT_TRUE(status.ok());
         

--- a/be/test/olap/rowset/segment_v2/plain_page_test.cpp
+++ b/be/test/olap/rowset/segment_v2/plain_page_test.cpp
@@ -67,10 +67,10 @@ public:
         PageBuilderType page_builder(options);
 
         page_builder.add(reinterpret_cast<const uint8_t *>(src), &size);
-        Slice s = page_builder.finish();
+        OwnedSlice s = page_builder.release();
 
         PageDecoderOptions decoder_options;
-        PageDecoderType page_decoder(s, decoder_options);
+        PageDecoderType page_decoder(s.slice, decoder_options);
         Status status = page_decoder.init();
         ASSERT_TRUE(status.ok());
         

--- a/be/test/olap/rowset/segment_v2/rle_page_test.cpp
+++ b/be/test/olap/rowset/segment_v2/rle_page_test.cpp
@@ -56,13 +56,13 @@ public:
         builder_options.data_page_size = 256 * 1024;
         PageBuilderType rle_page_builder(builder_options);
         rle_page_builder.add(reinterpret_cast<const uint8_t *>(src), &size);
-        Slice s = rle_page_builder.finish();
+        OwnedSlice s = rle_page_builder.release();
         ASSERT_EQ(size, rle_page_builder.count());
-        LOG(INFO) << "RLE Encoded size for 10k values: " << s.size
+        LOG(INFO) << "RLE Encoded size for 10k values: " << s.slice.size
                 << ", original size:" << size * sizeof(CppType);
 
         PageDecoderOptions decodeder_options;
-        PageDecoderType rle_page_decoder(s, decodeder_options);
+        PageDecoderType rle_page_decoder(s.slice, decodeder_options);
         Status status = rle_page_decoder.init();
         ASSERT_TRUE(status.ok());
         ASSERT_EQ(0, rle_page_decoder.current_index());
@@ -146,11 +146,11 @@ TEST_F(RlePageTest, TestRleInt32BlockEncoderSize) {
     builder_options.data_page_size = 256 * 1024;
     segment_v2::RlePageBuilder<OLAP_FIELD_TYPE_INT> rle_page_builder(builder_options);
     rle_page_builder.add(reinterpret_cast<const uint8_t *>(ints.get()), &size);
-    Slice s = rle_page_builder.finish();
+    OwnedSlice s = rle_page_builder.release();
     // 4 bytes header
     // 2 bytes indicate_value(): 0x64 << 1 | 1 = 201
     // 4 bytes values
-    ASSERT_EQ(10, s.size);
+    ASSERT_EQ(10, s.slice.size);
 }
 
 TEST_F(RlePageTest, TestRleBoolBlockEncoderRandom) {
@@ -180,11 +180,11 @@ TEST_F(RlePageTest, TestRleBoolBlockEncoderSize) {
     builder_options.data_page_size = 256 * 1024;
     segment_v2::RlePageBuilder<OLAP_FIELD_TYPE_BOOL> rle_page_builder(builder_options);
     rle_page_builder.add(reinterpret_cast<const uint8_t *>(bools.get()), &size);
-    Slice s = rle_page_builder.finish();
+    OwnedSlice s = rle_page_builder.release();
     // 4 bytes header
     // 2 bytes indicate_value(): 0x64 << 1 | 1 = 201
     // 1 bytes values
-    ASSERT_EQ(7, s.size);
+    ASSERT_EQ(7, s.slice.size);
 }
 
 }

--- a/be/test/olap/rowset/segment_v2/rle_page_test.cpp
+++ b/be/test/olap/rowset/segment_v2/rle_page_test.cpp
@@ -56,13 +56,13 @@ public:
         builder_options.data_page_size = 256 * 1024;
         PageBuilderType rle_page_builder(builder_options);
         rle_page_builder.add(reinterpret_cast<const uint8_t *>(src), &size);
-        OwnedSlice s = rle_page_builder.release();
+        OwnedSlice s = rle_page_builder.finish();
         ASSERT_EQ(size, rle_page_builder.count());
-        LOG(INFO) << "RLE Encoded size for 10k values: " << s.slice.size
+        LOG(INFO) << "RLE Encoded size for 10k values: " << s.slice().size
                 << ", original size:" << size * sizeof(CppType);
 
         PageDecoderOptions decodeder_options;
-        PageDecoderType rle_page_decoder(s.slice, decodeder_options);
+        PageDecoderType rle_page_decoder(s.slice(), decodeder_options);
         Status status = rle_page_decoder.init();
         ASSERT_TRUE(status.ok());
         ASSERT_EQ(0, rle_page_decoder.current_index());
@@ -146,11 +146,11 @@ TEST_F(RlePageTest, TestRleInt32BlockEncoderSize) {
     builder_options.data_page_size = 256 * 1024;
     segment_v2::RlePageBuilder<OLAP_FIELD_TYPE_INT> rle_page_builder(builder_options);
     rle_page_builder.add(reinterpret_cast<const uint8_t *>(ints.get()), &size);
-    OwnedSlice s = rle_page_builder.release();
+    OwnedSlice s = rle_page_builder.finish();
     // 4 bytes header
     // 2 bytes indicate_value(): 0x64 << 1 | 1 = 201
     // 4 bytes values
-    ASSERT_EQ(10, s.slice.size);
+    ASSERT_EQ(10, s.slice().size);
 }
 
 TEST_F(RlePageTest, TestRleBoolBlockEncoderRandom) {
@@ -180,11 +180,11 @@ TEST_F(RlePageTest, TestRleBoolBlockEncoderSize) {
     builder_options.data_page_size = 256 * 1024;
     segment_v2::RlePageBuilder<OLAP_FIELD_TYPE_BOOL> rle_page_builder(builder_options);
     rle_page_builder.add(reinterpret_cast<const uint8_t *>(bools.get()), &size);
-    OwnedSlice s = rle_page_builder.release();
+    OwnedSlice s = rle_page_builder.finish();
     // 4 bytes header
     // 2 bytes indicate_value(): 0x64 << 1 | 1 = 201
     // 1 bytes values
-    ASSERT_EQ(7, s.slice.size);
+    ASSERT_EQ(7, s.slice().size);
 }
 
 }


### PR DESCRIPTION
see #2037
1, fix mem leak when calling string builder.get_dictionary_page;
2, fix delete invalid mem addr in bitshuffleBuilder when no array grow happends
     when bitshuffleBuilder didn't grow array, the data page which not use new to allocate will be 
     returned  to ColumnWriter.
     When ColumnWriter destructs, the data page will be deleted,this causes core dump
