### PR TITLE
Multi distinct + no group by + big data is stuck

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -484,6 +484,9 @@ namespace config {
     // Valid configs: ALPHA, BETA
     CONF_String(default_rowset_type, "ALPHA");
     CONF_String(compaction_rowset_type, "ALPHA");
+
+    // brpc config
+    CONF_Int64(brpc_max_body_size, "67108864")
 } // namespace config
 
 } // namespace doris

--- a/be/src/service/brpc.h
+++ b/be/src/service/brpc.h
@@ -54,3 +54,6 @@
 #include <brpc/controller.h>
 #include <brpc/server.h>
 #include <brpc/closure_guard.h>
+#include <brpc/reloadable_flags.h>
+#include <brpc/protocol.h>
+#include <gflags/gflags_declare.h>

--- a/be/src/service/brpc.h
+++ b/be/src/service/brpc.h
@@ -56,4 +56,3 @@
 #include <brpc/closure_guard.h>
 #include <brpc/reloadable_flags.h>
 #include <brpc/protocol.h>
-#include <gflags/gflags_declare.h>

--- a/be/src/service/brpc_service.cpp
+++ b/be/src/service/brpc_service.cpp
@@ -23,11 +23,21 @@
 #include "service/brpc.h"
 #include "service/internal_service.h"
 
+
+namespace brpc {
+
+DECLARE_uint64(max_body_size);
+BRPC_VALIDATE_GFLAG(max_body_size, PassValidate);
+
+}
+
 namespace doris {
 
 BRpcService::BRpcService(ExecEnv* exec_env)
         : _exec_env(exec_env),
         _server(new brpc::Server()) {
+    // Set config
+    brpc::FLAGS_max_body_size = config::brpc_max_body_size;
 }
 
 BRpcService::~BRpcService() {

--- a/be/src/service/brpc_service.h
+++ b/be/src/service/brpc_service.h
@@ -18,7 +18,6 @@
 #pragma once
 
 #include <memory>
-
 #include "common/status.h"
 
 namespace brpc {

--- a/docs/documentation/cn/administrator-guide/config/fe_config.md
+++ b/docs/documentation/cn/administrator-guide/config/fe_config.md
@@ -1,0 +1,7 @@
+# 基本配置
+
+## brpc_max_body_size
+
+  这个配置主要用来修改 brpc 的参数 max_body_size ，默认配置是 64M。一般发生在 multi distinct + 无 group by + 超过1T 数据量的情况下。尤其如果发现查询卡死，且 BE 出现类似 body_size is too large 的字样。
+
+  由于这是一个 brpc 的配置，用户也可以在运行中直接修改该参数。通过访问 http://host:brpc_port/flags 修改。

--- a/docs/documentation/en/administrator-guide/config/fe_config_en.md
+++ b/docs/documentation/en/administrator-guide/config/fe_config_en.md
@@ -1,0 +1,7 @@
+# Configuration
+
+## brpc_max_body_size
+
+  This configuration is mainly used to modify the parameter max_body_size of brpc. The default configuration is 64M. It usually occurs in multi distinct + no group by + exceeds 1t data. In particular, if you find that the query is stuck, and be appears the word "body size is too large" in log.
+
+  Because this is a brpc configuration, users can also directly modify this parameter on-the-fly by visiting ```http://host:brpc_port/flags```


### PR DESCRIPTION
ISSUE-2069: This kind of query could be stuck.
The sender failed to send the last packet to receiver.
Also, the failure does not be reportted to FE , so the query is not cancelled.
The error log sames as "body_size=xxxx from xxx:xxx is too large".
The reason of the socket is that the packet of the query is too big which is more then the max_body_size of brpc.

This commit add a config named brpc_max_body_size whcih is used to change the max_body_size of brpc.
Also, user can change the max_body_size directly on-the-fly by "http://host:brpc_port/flags".