### PR TITLE
Add the cast function for if function in outer join

### DIFF
--- a/fe/src/main/java/org/apache/doris/analysis/TupleIsNullPredicate.java
+++ b/fe/src/main/java/org/apache/doris/analysis/TupleIsNullPredicate.java
@@ -119,16 +119,25 @@ public class TupleIsNullPredicate extends Predicate {
      * if required to make expr nullable. Otherwise, returns expr.
      */
     public static Expr wrapExpr(Expr expr, List<TupleId> tids, Analyzer analyzer)
-        throws UserException {
-    if (!requiresNullWrapping(expr, analyzer)) {
-        return expr;
-    }
+            throws UserException {
+        if (!requiresNullWrapping(expr, analyzer)) {
+            return expr;
+        }
         List<Expr> params = Lists.newArrayList();
         params.add(new TupleIsNullPredicate(tids));
         params.add(new NullLiteral());
         params.add(expr);
         Expr ifExpr = new FunctionCallExpr("if", params);
         ifExpr.analyzeNoThrow(analyzer);
+        // The type of function which is different from the type of expr will return the incorrect result in query.
+        // Example:
+        //   the type of expr is date
+        //   the type of function is int
+        //   So, the upper fragment will receive a int value instead of date while the result expr is date.
+        // If there is no cast function, the result of query will be incorrect.
+        if (expr.getType() != ifExpr.getType()) {
+            ifExpr = ifExpr.uncheckedCastTo(expr.getType());
+        }
         return ifExpr;
     }
 

--- a/fe/src/main/java/org/apache/doris/analysis/TupleIsNullPredicate.java
+++ b/fe/src/main/java/org/apache/doris/analysis/TupleIsNullPredicate.java
@@ -135,7 +135,7 @@ public class TupleIsNullPredicate extends Predicate {
         //   the type of function is int
         //   So, the upper fragment will receive a int value instead of date while the result expr is date.
         // If there is no cast function, the result of query will be incorrect.
-        if (expr.getType() != ifExpr.getType()) {
+        if (expr.getType().getPrimitiveType() != ifExpr.getType().getPrimitiveType()) {
             ifExpr = ifExpr.uncheckedCastTo(expr.getType());
         }
         return ifExpr;


### PR DESCRIPTION
The type of function which is different from the type of expr will return the incorrect result in query.

Example:
  the type of expr is date
  the type of function is int
  So, the upper fragment will receive a int value instead of date while the result expr is date.
  If there is no cast function, the result of query will be incorrect.