### PR TITLE
fix AlphaRowsetTest by remove StorageEngine #2078

### DIFF
--- a/be/src/olap/compaction.cpp
+++ b/be/src/olap/compaction.cpp
@@ -94,7 +94,6 @@ OLAPStatus Compaction::construct_output_rowset_writer() {
     context.rowset_path_prefix = _tablet->tablet_path();
     context.tablet_schema = &(_tablet->tablet_schema());
     context.rowset_state = VISIBLE;
-    context.data_dir = _tablet->data_dir();
     context.version = _output_version;
     context.version_hash = _output_version_hash;
     RETURN_NOT_OK(RowsetFactory::create_rowset_writer(context, &_output_rs_writer));

--- a/be/src/olap/data_dir.cpp
+++ b/be/src/olap/data_dir.cpp
@@ -546,7 +546,7 @@ OLAPStatus DataDir::_convert_old_tablet() {
         }
         string old_data_path_prefix = get_absolute_tablet_path(olap_header_msg, true);
         OLAPStatus status = converter.to_new_snapshot(olap_header_msg, old_data_path_prefix,
-            old_data_path_prefix, *this, &tablet_meta_pb, &pending_rowsets, true);
+            old_data_path_prefix, &tablet_meta_pb, &pending_rowsets, true);
         if (status != OLAP_SUCCESS) {
             LOG(FATAL) << "convert olap header to tablet meta failed when convert header and files tablet="
                          << tablet_id << "." << schema_hash;
@@ -622,7 +622,7 @@ OLAPStatus DataDir::remove_old_meta_and_files() {
             rowset_meta->init_from_pb(visible_rowset);
 
             RowsetSharedPtr rowset;
-            auto s = RowsetFactory::create_rowset(&tablet_schema, data_path_prefix, this, rowset_meta, &rowset);
+            auto s = RowsetFactory::create_rowset(&tablet_schema, data_path_prefix, rowset_meta, &rowset);
             if (s != OLAP_SUCCESS) {
                 LOG(INFO) << "errors while init rowset. tablet_path=" << data_path_prefix;
                 return true;
@@ -755,7 +755,6 @@ OLAPStatus DataDir::load() {
         RowsetSharedPtr rowset;
         OLAPStatus create_status = RowsetFactory::create_rowset(&tablet->tablet_schema(),
                                                               tablet->tablet_path(),
-                                                              tablet->data_dir(),
                                                               rowset_meta, &rowset);
         if (create_status != OLAP_SUCCESS) {
             LOG(WARNING) << "could not create rowset from rowsetmeta: "

--- a/be/src/olap/delta_writer.cpp
+++ b/be/src/olap/delta_writer.cpp
@@ -64,8 +64,8 @@ DeltaWriter::~DeltaWriter() {
         _flush_handler->wait();
     }
 
-    if (_new_tablet != nullptr) {
-        _new_tablet->data_dir()->remove_pending_ids(ROWSET_ID_PREFIX + _rowset_writer->rowset_id().to_string());
+    if (_tablet != nullptr) {
+        _tablet->data_dir()->remove_pending_ids(ROWSET_ID_PREFIX + _rowset_writer->rowset_id().to_string());
     }
 }
 

--- a/be/src/olap/delta_writer.cpp
+++ b/be/src/olap/delta_writer.cpp
@@ -64,8 +64,8 @@ DeltaWriter::~DeltaWriter() {
         _flush_handler->wait();
     }
 
-    if (_rowset_writer != nullptr) {
-        _rowset_writer->data_dir()->remove_pending_ids(ROWSET_ID_PREFIX + _rowset_writer->rowset_id().to_string());
+    if (_new_tablet != nullptr) {
+        _new_tablet->data_dir()->remove_pending_ids(ROWSET_ID_PREFIX + _rowset_writer->rowset_id().to_string());
     }
 }
 
@@ -138,7 +138,6 @@ OLAPStatus DeltaWriter::init() {
     writer_context.rowset_path_prefix = _tablet->tablet_path();
     writer_context.tablet_schema = &(_tablet->tablet_schema());
     writer_context.rowset_state = PREPARED;
-    writer_context.data_dir = _tablet->data_dir();
     writer_context.txn_id = _req.txn_id;
     writer_context.load_id = _req.load_id;
     RETURN_NOT_OK(RowsetFactory::create_rowset_writer(writer_context, &_rowset_writer));

--- a/be/src/olap/olap_snapshot_converter.cpp
+++ b/be/src/olap/olap_snapshot_converter.cpp
@@ -397,8 +397,8 @@ OLAPStatus OlapSnapshotConverter::to_alter_tablet_pb(const SchemaChangeStatusMes
 }
 
 // from olap header to tablet meta
-OLAPStatus OlapSnapshotConverter::to_new_snapshot(const OLAPHeaderMessage& olap_header, const string& old_data_path_prefix, 
-    const string& new_data_path_prefix, DataDir& data_dir, TabletMetaPB* tablet_meta_pb, 
+OLAPStatus OlapSnapshotConverter::to_new_snapshot(const OLAPHeaderMessage& olap_header, const string& old_data_path_prefix,
+    const string& new_data_path_prefix, TabletMetaPB* tablet_meta_pb,
     vector<RowsetMetaPB>* pending_rowsets, bool is_startup) {
     RETURN_NOT_OK(to_tablet_meta_pb(olap_header, tablet_meta_pb, pending_rowsets));
 
@@ -410,7 +410,7 @@ OLAPStatus OlapSnapshotConverter::to_new_snapshot(const OLAPHeaderMessage& olap_
         RowsetMetaSharedPtr alpha_rowset_meta(new AlphaRowsetMeta());
         alpha_rowset_meta->init_from_pb(visible_rowset);
         alpha_rowset_meta->set_tablet_uid(tablet_meta_pb->tablet_uid());
-        AlphaRowset rowset(&tablet_schema, new_data_path_prefix, &data_dir, alpha_rowset_meta);
+        AlphaRowset rowset(&tablet_schema, new_data_path_prefix, alpha_rowset_meta);
         RETURN_NOT_OK(rowset.init());
         std::vector<std::string> success_files;
         RETURN_NOT_OK(rowset.convert_from_old_files(old_data_path_prefix, &success_files));
@@ -422,7 +422,7 @@ OLAPStatus OlapSnapshotConverter::to_new_snapshot(const OLAPHeaderMessage& olap_
         RowsetMetaSharedPtr alpha_rowset_meta(new AlphaRowsetMeta());
         alpha_rowset_meta->init_from_pb(inc_rowset);
         alpha_rowset_meta->set_tablet_uid(tablet_meta_pb->tablet_uid());
-        AlphaRowset rowset(&tablet_schema, new_data_path_prefix, &data_dir, alpha_rowset_meta);
+        AlphaRowset rowset(&tablet_schema, new_data_path_prefix, alpha_rowset_meta);
         RETURN_NOT_OK(rowset.init());
         std::vector<std::string> success_files;
         std::string inc_data_path = old_data_path_prefix;
@@ -439,7 +439,7 @@ OLAPStatus OlapSnapshotConverter::to_new_snapshot(const OLAPHeaderMessage& olap_
         RowsetMetaSharedPtr alpha_rowset_meta(new AlphaRowsetMeta());
         alpha_rowset_meta->init_from_pb(*it);
         alpha_rowset_meta->set_tablet_uid(tablet_meta_pb->tablet_uid());
-        AlphaRowset rowset(&tablet_schema, new_data_path_prefix, &data_dir, alpha_rowset_meta);
+        AlphaRowset rowset(&tablet_schema, new_data_path_prefix, alpha_rowset_meta);
         RETURN_NOT_OK(rowset.init());
         std::vector<std::string> success_files;
         // std::string pending_delta_path = old_data_path_prefix + PENDING_DELTA_PREFIX;
@@ -468,7 +468,7 @@ OLAPStatus OlapSnapshotConverter::to_old_snapshot(const TabletMetaPB& tablet_met
     for (auto& visible_rowset : tablet_meta_pb.rs_metas()) {
         RowsetMetaSharedPtr alpha_rowset_meta(new AlphaRowsetMeta());
         alpha_rowset_meta->init_from_pb(visible_rowset);
-        AlphaRowset rowset(&tablet_schema, new_data_path_prefix, nullptr, alpha_rowset_meta);
+        AlphaRowset rowset(&tablet_schema, new_data_path_prefix, alpha_rowset_meta);
         RETURN_NOT_OK(rowset.init());
         RETURN_NOT_OK(rowset.load());
         std::vector<std::string> success_files;
@@ -479,7 +479,7 @@ OLAPStatus OlapSnapshotConverter::to_old_snapshot(const TabletMetaPB& tablet_met
     for (auto& inc_rowset : tablet_meta_pb.inc_rs_metas()) {
         RowsetMetaSharedPtr alpha_rowset_meta(new AlphaRowsetMeta());
         alpha_rowset_meta->init_from_pb(inc_rowset);
-        AlphaRowset rowset(&tablet_schema, new_data_path_prefix, nullptr, alpha_rowset_meta);
+        AlphaRowset rowset(&tablet_schema, new_data_path_prefix, alpha_rowset_meta);
         RETURN_NOT_OK(rowset.init());
         RETURN_NOT_OK(rowset.load());
         std::vector<std::string> success_files;

--- a/be/src/olap/olap_snapshot_converter.h
+++ b/be/src/olap/olap_snapshot_converter.h
@@ -68,11 +68,11 @@ public:
 
     // from olap header to tablet meta
     OLAPStatus to_new_snapshot(const OLAPHeaderMessage& olap_header, const string& old_data_path_prefix, 
-        const string& new_data_path_prefix, DataDir& data_dir, TabletMetaPB* tablet_meta_pb, 
+        const string& new_data_path_prefix, TabletMetaPB* tablet_meta_pb,
         vector<RowsetMetaPB>* pending_rowsets, bool is_startup);
 
     // from tablet meta to olap header
-    OLAPStatus to_old_snapshot(const TabletMetaPB& tablet_meta_pb, string& new_data_path_prefix, 
+    OLAPStatus to_old_snapshot(const TabletMetaPB& tablet_meta_pb, string& new_data_path_prefix,
         string& old_data_path_prefix, OLAPHeaderMessage* olap_header);
     
     OLAPStatus save(const string& file_path, const OLAPHeaderMessage& olap_header);

--- a/be/src/olap/push_handler.cpp
+++ b/be/src/olap/push_handler.cpp
@@ -319,7 +319,6 @@ OLAPStatus PushHandler::_convert(TabletSharedPtr cur_tablet,
         context.rowset_path_prefix = cur_tablet->tablet_path();
         context.tablet_schema = &(cur_tablet->tablet_schema());
         context.rowset_state = PREPARED;
-        context.data_dir = cur_tablet->data_dir();
         context.txn_id = _request.transaction_id;
         context.load_id = load_id;
 

--- a/be/src/olap/rowset/alpha_rowset.cpp
+++ b/be/src/olap/rowset/alpha_rowset.cpp
@@ -26,9 +26,8 @@ namespace doris {
 
 AlphaRowset::AlphaRowset(const TabletSchema* schema,
                          std::string rowset_path,
-                         DataDir* data_dir,
                          RowsetMetaSharedPtr rowset_meta)
-    : Rowset(schema, std::move(rowset_path), data_dir, std::move(rowset_meta)) {
+    : Rowset(schema, std::move(rowset_path), std::move(rowset_meta)) {
 }
 
 OLAPStatus AlphaRowset::do_load_once(bool use_cache) {

--- a/be/src/olap/rowset/alpha_rowset.h
+++ b/be/src/olap/rowset/alpha_rowset.h
@@ -72,7 +72,6 @@ protected:
 
     AlphaRowset(const TabletSchema* schema,
                 std::string rowset_path,
-                DataDir* data_dir,
                 RowsetMetaSharedPtr rowset_meta);
 
     // init segment groups

--- a/be/src/olap/rowset/alpha_rowset_writer.cpp
+++ b/be/src/olap/rowset/alpha_rowset_writer.cpp
@@ -217,7 +217,6 @@ RowsetSharedPtr AlphaRowsetWriter::build() {
     RowsetSharedPtr rowset;
     auto status = RowsetFactory::create_rowset(_rowset_writer_context.tablet_schema,
                                                _rowset_writer_context.rowset_path_prefix,
-                                               _rowset_writer_context.data_dir,
                                                _current_rowset_meta,
                                                &rowset);
     if (status != OLAP_SUCCESS) {

--- a/be/src/olap/rowset/alpha_rowset_writer.h
+++ b/be/src/olap/rowset/alpha_rowset_writer.h
@@ -62,8 +62,6 @@ public:
 
     RowsetId rowset_id() override { return _rowset_writer_context.rowset_id; }
 
-    DataDir* data_dir() override { return _rowset_writer_context.data_dir; }
-
 private:
     OLAPStatus _init();
 

--- a/be/src/olap/rowset/beta_rowset.cpp
+++ b/be/src/olap/rowset/beta_rowset.cpp
@@ -32,9 +32,8 @@ std::string BetaRowset::segment_file_path(const std::string& dir, const RowsetId
 
 BetaRowset::BetaRowset(const TabletSchema* schema,
                        string rowset_path,
-                       DataDir* data_dir,
                        RowsetMetaSharedPtr rowset_meta)
-    : Rowset(schema, std::move(rowset_path), data_dir, std::move(rowset_meta)) {
+    : Rowset(schema, std::move(rowset_path), std::move(rowset_meta)) {
 }
 
 OLAPStatus BetaRowset::init() {

--- a/be/src/olap/rowset/beta_rowset.h
+++ b/be/src/olap/rowset/beta_rowset.h
@@ -63,7 +63,6 @@ protected:
 
     BetaRowset(const TabletSchema* schema,
                std::string rowset_path,
-               DataDir* data_dir,
                RowsetMetaSharedPtr rowset_meta);
 
     OLAPStatus init() override;

--- a/be/src/olap/rowset/beta_rowset_writer.cpp
+++ b/be/src/olap/rowset/beta_rowset_writer.cpp
@@ -146,7 +146,6 @@ RowsetSharedPtr BetaRowsetWriter::build() {
     RowsetSharedPtr rowset;
     auto status = RowsetFactory::create_rowset(_context.tablet_schema,
                                                _context.rowset_path_prefix,
-                                               _context.data_dir,
                                                _rowset_meta,
                                                &rowset);
     if (status != OLAP_SUCCESS) {

--- a/be/src/olap/rowset/beta_rowset_writer.h
+++ b/be/src/olap/rowset/beta_rowset_writer.h
@@ -57,8 +57,6 @@ public:
 
     RowsetId rowset_id() override { return _context.rowset_id; }
 
-    DataDir* data_dir() override { return _context.data_dir; }
-
 private:
     template<typename RowType>
     OLAPStatus _add_row(const RowType& row);

--- a/be/src/olap/rowset/column_data.cpp
+++ b/be/src/olap/rowset/column_data.cpp
@@ -42,7 +42,7 @@ ColumnData::ColumnData(SegmentGroup* segment_group)
     if (StorageEngine::instance() != nullptr) {
         _lru_cache = StorageEngine::instance()->index_stream_lru_cache();
     } else {
-        // for test
+        // for independent usage, eg: unit test/segment tool
         _lru_cache = new_lru_cache(config::index_stream_cache_capacity);
     }
     _num_rows_per_block = _segment_group->get_num_rows_per_row_block();

--- a/be/src/olap/rowset/column_data.cpp
+++ b/be/src/olap/rowset/column_data.cpp
@@ -38,7 +38,13 @@ ColumnData::ColumnData(SegmentGroup* segment_group)
         _runtime_state(nullptr),
         _is_using_cache(false),
         _segment_reader(nullptr),
-        _lru_cache(StorageEngine::instance()->index_stream_lru_cache()) {
+        _lru_cache(nullptr) {
+    if (StorageEngine::instance() != nullptr) {
+        _lru_cache = StorageEngine::instance()->index_stream_lru_cache();
+    } else {
+        // for test
+        _lru_cache = new_lru_cache(config::index_stream_cache_capacity);
+    }
     _num_rows_per_block = _segment_group->get_num_rows_per_row_block();
 }
 

--- a/be/src/olap/rowset/rowset.cpp
+++ b/be/src/olap/rowset/rowset.cpp
@@ -21,11 +21,9 @@ namespace doris {
 
 Rowset::Rowset(const TabletSchema *schema,
                std::string rowset_path,
-               DataDir *data_dir,
                RowsetMetaSharedPtr rowset_meta)
         : _schema(schema),
          _rowset_path(std::move(rowset_path)),
-         _data_dir(data_dir),
          _rowset_meta(std::move(rowset_meta)) {
 
     _is_pending = !_rowset_meta->has_version();

--- a/be/src/olap/rowset/rowset.h
+++ b/be/src/olap/rowset/rowset.h
@@ -137,7 +137,6 @@ protected:
     // this is non-public because all clients should use RowsetFactory to obtain pointer to initialized Rowset
     Rowset(const TabletSchema* schema,
            std::string rowset_path,
-           DataDir* data_dir,
            RowsetMetaSharedPtr rowset_meta);
 
     // this is non-public because all clients should use RowsetFactory to obtain pointer to initialized Rowset
@@ -151,7 +150,6 @@ protected:
 
     const TabletSchema* _schema;
     std::string _rowset_path;
-    DataDir* _data_dir;
     RowsetMetaSharedPtr _rowset_meta;
     // init in constructor
     bool _is_pending;    // rowset is pending iff it's not in visible state

--- a/be/src/olap/rowset/rowset_factory.cpp
+++ b/be/src/olap/rowset/rowset_factory.cpp
@@ -27,17 +27,15 @@
 namespace doris {
 
 OLAPStatus RowsetFactory::create_rowset(const TabletSchema* schema,
-                                      const std::string& rowset_path,
-                                      DataDir* data_dir,
-                                      RowsetMetaSharedPtr rowset_meta, 
-                                      RowsetSharedPtr* rowset) {
-
+                                        const std::string& rowset_path,
+                                        RowsetMetaSharedPtr rowset_meta,
+                                        RowsetSharedPtr* rowset) {
     if (rowset_meta->rowset_type() == ALPHA_ROWSET) {
-        rowset->reset(new AlphaRowset(schema, rowset_path, data_dir, rowset_meta));
+        rowset->reset(new AlphaRowset(schema, rowset_path, rowset_meta));
         return (*rowset)->init();
     }
     if (rowset_meta->rowset_type() == BETA_ROWSET)  {
-        rowset->reset(new BetaRowset(schema, rowset_path, data_dir, rowset_meta));
+        rowset->reset(new BetaRowset(schema, rowset_path, rowset_meta));
         return (*rowset)->init();
     }
     return OLAP_ERR_ROWSET_TYPE_NOT_FOUND; // should never happen

--- a/be/src/olap/rowset/rowset_factory.h
+++ b/be/src/olap/rowset/rowset_factory.h
@@ -34,7 +34,6 @@ public:
     // return others if failed to create or init rowset.
     static OLAPStatus create_rowset(const TabletSchema* schema,
                                   const std::string& rowset_path,
-                                  DataDir* data_dir,
                                   RowsetMetaSharedPtr rowset_meta,
                                   RowsetSharedPtr* rowset);
 

--- a/be/src/olap/rowset/rowset_writer.h
+++ b/be/src/olap/rowset/rowset_writer.h
@@ -63,8 +63,6 @@ public:
 
     virtual RowsetId rowset_id() = 0;
 
-    virtual DataDir* data_dir() = 0;
-
 private:
     DISALLOW_COPY_AND_ASSIGN(RowsetWriter);
 };

--- a/be/src/olap/rowset/rowset_writer_context.h
+++ b/be/src/olap/rowset/rowset_writer_context.h
@@ -36,7 +36,6 @@ struct RowsetWriterContext {
         rowset_path_prefix(""),
         tablet_schema(nullptr),
         rowset_state(PREPARED),
-        data_dir(nullptr),
         version(Version(0, 0)),
         version_hash(0),
         txn_id(0),
@@ -54,7 +53,6 @@ struct RowsetWriterContext {
     // PREPARED/COMMITTED for pending rowset
     // VISIBLE for non-pending rowset
     RowsetStatePB rowset_state;
-    DataDir* data_dir;
     // properties for non-pending rowset
     Version version;
     VersionHash version_hash;

--- a/be/src/olap/rowset/segment_group.cpp
+++ b/be/src/olap/rowset/segment_group.cpp
@@ -586,11 +586,14 @@ OLAPStatus SegmentGroup::add_short_key(const RowCursor& short_key, const uint32_
     OLAPStatus res = OLAP_SUCCESS;
     if (!_new_segment_created) {
         string file_path = construct_index_file_path(_num_segments - 1);
-        boost::filesystem::path tablet_path(_rowset_path_prefix);
-        boost::filesystem::path data_dir_path = tablet_path.parent_path().parent_path().parent_path().parent_path();
-        std::string data_dir_string = data_dir_path.string();
-        DataDir* data_dir = StorageEngine::instance()->get_store(data_dir_string);
-        data_dir->add_pending_ids(ROWSET_ID_PREFIX + _rowset_id.to_string());
+        StorageEngine* engine = StorageEngine::instance();
+        if (engine != nullptr) {
+            boost::filesystem::path tablet_path(_rowset_path_prefix);
+            boost::filesystem::path data_dir_path = tablet_path.parent_path().parent_path().parent_path().parent_path();
+            std::string data_dir_string = data_dir_path.string();
+            DataDir* data_dir = engine->get_store(data_dir_string);
+            data_dir->add_pending_ids(ROWSET_ID_PREFIX + _rowset_id.to_string());
+        }
         res = _current_file_handler.open_with_mode(
                         file_path.c_str(), O_CREAT | O_EXCL | O_WRONLY, S_IRUSR | S_IWUSR);
         if (res != OLAP_SUCCESS) {

--- a/be/src/olap/schema_change.cpp
+++ b/be/src/olap/schema_change.cpp
@@ -1095,7 +1095,6 @@ bool SchemaChangeWithSorting::_internal_sorting(const vector<RowBlock*>& row_blo
     context.rowset_path_prefix = new_tablet->tablet_path();
     context.tablet_schema = &(new_tablet->tablet_schema());
     context.rowset_state = VISIBLE;
-    context.data_dir = new_tablet->data_dir();
     context.version = version;
     context.version_hash = version_hash;
     VLOG(3) << "init rowset builder. tablet=" << new_tablet->full_name()

--- a/be/src/olap/snapshot_manager.h
+++ b/be/src/olap/snapshot_manager.h
@@ -64,8 +64,8 @@ public:
                 
     static SnapshotManager* instance();
 
-    OLAPStatus convert_rowset_ids(DataDir& data_dir, const string& clone_dir, int64_t tablet_id, 
-        const int32_t& schema_hash, TabletSharedPtr tablet);
+    OLAPStatus convert_rowset_ids(const string& clone_dir, int64_t tablet_id,
+            const int32_t& schema_hash, TabletSharedPtr tablet);
 
 private:
     SnapshotManager()
@@ -93,9 +93,9 @@ private:
 
     OLAPStatus _prepare_snapshot_dir(const TabletSharedPtr& ref_tablet,
            std::string* snapshot_id_path);
-    
+
     OLAPStatus _rename_rowset_id(const RowsetMetaPB& rs_meta_pb, const string& new_path, 
-        DataDir& data_dir, TabletSchema& tablet_schema, const RowsetId& next_id, RowsetMetaPB* new_rs_meta_pb);
+            TabletSchema& tablet_schema, const RowsetId& next_id, RowsetMetaPB* new_rs_meta_pb);
 
 private:
     static SnapshotManager* _s_instance;

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -91,7 +91,7 @@ OLAPStatus Tablet::_init_once_action() {
     for (auto& rs_meta :  _tablet_meta->all_rs_metas()) {
         Version version = { rs_meta->start_version(), rs_meta->end_version() };
         RowsetSharedPtr rowset;
-        res = RowsetFactory::create_rowset(&_schema, _tablet_path, _data_dir, rs_meta, &rowset);
+        res = RowsetFactory::create_rowset(&_schema, _tablet_path, rs_meta, &rowset);
         if (res != OLAP_SUCCESS) {
             LOG(WARNING) << "fail to init rowset. tablet_id:" << tablet_id()
                          << ", schema_hash:" << schema_hash()
@@ -107,7 +107,7 @@ OLAPStatus Tablet::_init_once_action() {
         Version version = { inc_rs_meta->start_version(), inc_rs_meta->end_version() };
         RowsetSharedPtr rowset = get_rowset_by_version(version);
         if (rowset == nullptr) {
-            res = RowsetFactory::create_rowset(&_schema, _tablet_path, _data_dir, inc_rs_meta, &rowset);
+            res = RowsetFactory::create_rowset(&_schema, _tablet_path, inc_rs_meta, &rowset);
             if (res != OLAP_SUCCESS) {
                 LOG(WARNING) << "fail to init incremental rowset. tablet_id:" << tablet_id()
                              << ", schema_hash:" << schema_hash()
@@ -226,7 +226,7 @@ OLAPStatus Tablet::revise_tablet_meta(
     for (auto& rs_meta : rowsets_to_clone) {
         Version version = { rs_meta->start_version(), rs_meta->end_version() };
         RowsetSharedPtr rowset;
-        res = RowsetFactory::create_rowset(&_schema, _tablet_path, _data_dir, rs_meta, &rowset);
+        res = RowsetFactory::create_rowset(&_schema, _tablet_path, rs_meta, &rowset);
         if (res != OLAP_SUCCESS) {
             LOG(WARNING) << "fail to init rowset. version=" << version.first << "-" << version.second;
             return res;

--- a/be/src/olap/tablet_manager.cpp
+++ b/be/src/olap/tablet_manager.cpp
@@ -1194,7 +1194,6 @@ OLAPStatus TabletManager::_create_inital_rowset(
             context.rowset_path_prefix = tablet->tablet_path();
             context.tablet_schema = &(tablet->tablet_schema());
             context.rowset_state = VISIBLE;
-            context.data_dir = tablet->data_dir();
             context.version = version;
             context.version_hash = request.version_hash;
 

--- a/be/src/olap/task/engine_clone_task.h
+++ b/be/src/olap/task/engine_clone_task.h
@@ -64,7 +64,7 @@ private:
         bool* allow_incremental_clone, 
         TabletSharedPtr tablet);
         
-    OLAPStatus _convert_to_new_snapshot(DataDir& data_dir, const string& clone_dir, int64_t tablet_id);
+    OLAPStatus _convert_to_new_snapshot(const string& clone_dir, int64_t tablet_id);
 
     void _set_tablet_info(AgentStatus status, bool is_new_tablet);
 

--- a/be/src/olap/task/engine_storage_migration_task.cpp
+++ b/be/src/olap/task/engine_storage_migration_task.cpp
@@ -185,7 +185,7 @@ OLAPStatus EngineStorageMigrationTask::_storage_medium_migrate(
 
         // it will change rowset id and its create time
         // rowset create time is useful when load tablet from meta to check which tablet is the tablet to load
-        res = SnapshotManager::instance()->convert_rowset_ids(*(stores[0]), schema_hash_path, tablet_id, schema_hash, nullptr);
+        res = SnapshotManager::instance()->convert_rowset_ids(schema_hash_path, tablet_id, schema_hash, nullptr);
         if (res != OLAP_SUCCESS) {
             LOG(WARNING) << "failed to convert rowset id when do storage migration"
                          << " path = " << schema_hash_path;

--- a/be/src/runtime/snapshot_loader.cpp
+++ b/be/src/runtime/snapshot_loader.cpp
@@ -566,7 +566,7 @@ Status SnapshotLoader::move(
     }
 
     // rename the rowset ids and tabletid info in rowset meta
-    OLAPStatus convert_status = SnapshotManager::instance()->convert_rowset_ids(*store, 
+    OLAPStatus convert_status = SnapshotManager::instance()->convert_rowset_ids(
         snapshot_path, tablet_id, schema_hash, tablet);
     if (convert_status != OLAP_SUCCESS) {
         std::stringstream ss;

--- a/be/test/olap/olap_snapshot_converter_test.cpp
+++ b/be/test/olap/olap_snapshot_converter_test.cpp
@@ -130,7 +130,7 @@ TEST_F(OlapSnapshotConverterTest, ToNewAndToOldSnapshot) {
     TabletMetaPB tablet_meta_pb;
     vector<RowsetMetaPB> pending_rowsets;
     OLAPStatus status = converter.to_new_snapshot(header_msg, _tablet_data_path, _tablet_data_path, 
-        *_data_dir, &tablet_meta_pb, &pending_rowsets, true);
+        &tablet_meta_pb, &pending_rowsets, true);
     ASSERT_TRUE(status == OLAP_SUCCESS);
 
     TabletSchema tablet_schema;
@@ -156,7 +156,7 @@ TEST_F(OlapSnapshotConverterTest, ToNewAndToOldSnapshot) {
     for (auto& visible_rowset : tablet_meta_pb.rs_metas()) {
         RowsetMetaSharedPtr alpha_rowset_meta(new AlphaRowsetMeta());
         alpha_rowset_meta->init_from_pb(visible_rowset);
-        AlphaRowset rowset(&tablet_schema, data_path_prefix, _data_dir, alpha_rowset_meta);
+        AlphaRowset rowset(&tablet_schema, data_path_prefix, alpha_rowset_meta);
         ASSERT_TRUE(rowset.init() == OLAP_SUCCESS);
         ASSERT_TRUE(rowset.load() == OLAP_SUCCESS);
         std::vector<std::string> old_files;
@@ -181,11 +181,11 @@ TEST_F(OlapSnapshotConverterTest, ToNewAndToOldSnapshot) {
     for (auto& inc_rowset : tablet_meta_pb.inc_rs_metas()) {
         RowsetMetaSharedPtr alpha_rowset_meta(new AlphaRowsetMeta());
         alpha_rowset_meta->init_from_pb(inc_rowset);
-        AlphaRowset rowset(&tablet_schema, data_path_prefix, _data_dir, alpha_rowset_meta);
+        AlphaRowset rowset(&tablet_schema, data_path_prefix, alpha_rowset_meta);
         ASSERT_TRUE(rowset.init() == OLAP_SUCCESS);
         ASSERT_TRUE(rowset.load() == OLAP_SUCCESS);
         AlphaRowset tmp_rowset(&tablet_schema, data_path_prefix + "/incremental_delta", 
-            _data_dir, alpha_rowset_meta);
+            alpha_rowset_meta);
         ASSERT_TRUE(tmp_rowset.init() == OLAP_SUCCESS);
         std::vector<std::string> old_files;
         tmp_rowset.remove_old_files(&old_files);
@@ -209,7 +209,7 @@ TEST_F(OlapSnapshotConverterTest, ToNewAndToOldSnapshot) {
     for (auto& pending_rowset : pending_rowsets) {
         RowsetMetaSharedPtr alpha_rowset_meta(new AlphaRowsetMeta());
         alpha_rowset_meta->init_from_pb(pending_rowset);
-        AlphaRowset rowset(&tablet_schema, data_path_prefix, _data_dir, alpha_rowset_meta);
+        AlphaRowset rowset(&tablet_schema, data_path_prefix, alpha_rowset_meta);
         ASSERT_TRUE(rowset.init() == OLAP_SUCCESS);
         ASSERT_TRUE(rowset.load() == OLAP_SUCCESS);
         std::vector<std::string> old_files;

--- a/be/test/olap/rowset/alpha_rowset_test.cpp
+++ b/be/test/olap/rowset/alpha_rowset_test.cpp
@@ -47,8 +47,6 @@ namespace doris {
 
 static const uint32_t MAX_PATH_LEN = 1024;
 
-StorageEngine* k_engine = nullptr;
-
 void set_up() {
     config::path_gc_check = false;
     char buffer[MAX_PATH_LEN];
@@ -71,20 +69,13 @@ void set_up() {
     std::string schema_hash_path = tablet_path + "/1111";
     res = create_dir(schema_hash_path);
     ASSERT_EQ(OLAP_SUCCESS, res);
-
-    doris::EngineOptions options;
-    options.store_paths = paths;
-    doris::StorageEngine::open(options, &k_engine);
 }
 
 void tear_down() {
-    delete k_engine;
-    k_engine = nullptr;
     remove_all_dir(config::storage_root_path);
-    remove_all_dir(std::string(getenv("DORIS_HOME")) + UNUSED_PREFIX);
 }
 
-void create_rowset_writer_context(TabletSchema* tablet_schema, DataDir* data_dir,
+void create_rowset_writer_context(TabletSchema* tablet_schema,
         RowsetWriterContext* rowset_writer_context) {
     RowsetId rowset_id;
     rowset_id.init(10000);
@@ -95,7 +86,6 @@ void create_rowset_writer_context(TabletSchema* tablet_schema, DataDir* data_dir
     rowset_writer_context->rowset_type = ALPHA_ROWSET;
     rowset_writer_context->rowset_path_prefix = config::storage_root_path + "/data/0/12345/1111";
     rowset_writer_context->rowset_state = VISIBLE;
-    rowset_writer_context->data_dir = data_dir;
     rowset_writer_context->tablet_schema = tablet_schema;
     rowset_writer_context->version.first = 0;
     rowset_writer_context->version.second = 1;
@@ -164,8 +154,6 @@ class AlphaRowsetTest : public testing::Test {
 public:
     virtual void SetUp() {
         set_up();
-        _data_dir = k_engine->get_store(config::storage_root_path);
-        ASSERT_TRUE(_data_dir != nullptr);
         _mem_tracker.reset(new MemTracker(-1));
         _mem_pool.reset(new MemPool(_mem_tracker.get()));
     }
@@ -175,42 +163,45 @@ public:
     }
 
 private:
-    DataDir* _data_dir;
+    std::unique_ptr<RowsetWriter> _alpha_rowset_writer;
     std::unique_ptr<MemTracker> _mem_tracker;
     std::unique_ptr<MemPool> _mem_pool;
 };
-/*
+
 TEST_F(AlphaRowsetTest, TestAlphaRowsetWriter) {
     TabletSchema tablet_schema;
     create_tablet_schema(AGG_KEYS, &tablet_schema);
     RowsetWriterContext rowset_writer_context;
-    create_rowset_writer_context(&tablet_schema, _data_dir, &rowset_writer_context);
-    _alpha_rowset_writer->init(rowset_writer_context);
+    create_rowset_writer_context(&tablet_schema, &rowset_writer_context);
+    ASSERT_EQ(OLAP_SUCCESS, RowsetFactory::create_rowset_writer(rowset_writer_context, &_alpha_rowset_writer));
     RowCursor row;
     OLAPStatus res = row.init(tablet_schema);
     ASSERT_EQ(OLAP_SUCCESS, res);
-    
+
     int32_t field_0 = 10;
     row.set_field_content(0, reinterpret_cast<char*>(&field_0), _mem_pool.get());
     Slice field_1("well");
     row.set_field_content(1, reinterpret_cast<char*>(&field_1), _mem_pool.get());
     int32_t field_2 = 100;
     row.set_field_content(2, reinterpret_cast<char*>(&field_2), _mem_pool.get());
-    _alpha_rowset_writer->add_row(&row);
+    _alpha_rowset_writer->add_row(row);
     _alpha_rowset_writer->flush();
+    auto cache = new_lru_cache(config::file_descriptor_cache_capacity);
+    FileHandler::set_fd_cache(cache);
     RowsetSharedPtr alpha_rowset = _alpha_rowset_writer->build();
     ASSERT_TRUE(alpha_rowset != nullptr);
-    ASSERT_EQ(10000, alpha_rowset->rowset_id());
+    RowsetId rowset_id;
+    rowset_id.init(10000);
+    ASSERT_EQ(rowset_id, alpha_rowset->rowset_id());
     ASSERT_EQ(1, alpha_rowset->num_rows());
 }
-*/
+
 TEST_F(AlphaRowsetTest, TestAlphaRowsetReader) {
     TabletSchema tablet_schema;
     create_tablet_schema(AGG_KEYS, &tablet_schema);
     RowsetWriterContext rowset_writer_context;
-    create_rowset_writer_context(&tablet_schema, _data_dir, &rowset_writer_context);
+    create_rowset_writer_context(&tablet_schema, &rowset_writer_context);
 
-    std::unique_ptr<RowsetWriter> _alpha_rowset_writer;
     ASSERT_EQ(OLAP_SUCCESS, RowsetFactory::create_rowset_writer(rowset_writer_context, &_alpha_rowset_writer));
 
     RowCursor row;
@@ -230,6 +221,8 @@ TEST_F(AlphaRowsetTest, TestAlphaRowsetReader) {
     ASSERT_EQ(OLAP_SUCCESS, res);
     res = _alpha_rowset_writer->flush();
     ASSERT_EQ(OLAP_SUCCESS, res);
+    auto cache = new_lru_cache(config::file_descriptor_cache_capacity);
+    FileHandler::set_fd_cache(cache);
     RowsetSharedPtr alpha_rowset = _alpha_rowset_writer->build();
     ASSERT_TRUE(alpha_rowset != nullptr);
     RowsetId rowset_id;

--- a/be/test/olap/txn_manager_test.cpp
+++ b/be/test/olap/txn_manager_test.cpp
@@ -129,9 +129,9 @@ public:
         rowset_meta->init_from_json(_json_rowset_meta);
         ASSERT_EQ(rowset_meta->rowset_id(), rowset_id);
         ASSERT_EQ(OLAP_SUCCESS, RowsetFactory::create_rowset(
-            _schema.get(), rowset_meta_path, nullptr, rowset_meta, &_alpha_rowset));
+            _schema.get(), rowset_meta_path, rowset_meta, &_alpha_rowset));
         ASSERT_EQ(OLAP_SUCCESS, RowsetFactory::create_rowset(
-            _schema.get(), rowset_meta_path, nullptr, rowset_meta, &_alpha_rowset_same_id));
+            _schema.get(), rowset_meta_path, rowset_meta, &_alpha_rowset_same_id));
 
         // init rowset meta 2
         _json_rowset_meta = "";
@@ -148,7 +148,7 @@ public:
         rowset_meta2->init_from_json(_json_rowset_meta);
         ASSERT_EQ(rowset_meta2->rowset_id(), rowset_id);
         ASSERT_EQ(OLAP_SUCCESS, RowsetFactory::create_rowset(
-            _schema.get(), rowset_meta_path_2, nullptr, rowset_meta2, &_alpha_rowset_diff_id));
+            _schema.get(), rowset_meta_path_2, rowset_meta2, &_alpha_rowset_diff_id));
         _tablet_uid = TabletUid(10, 10);
     }
 


### PR DESCRIPTION
AlphaRowsetTest core dump because of detached thread in StorageEngine.
It is not good to use StorageEngine in AlphaRowsetTest from encapsulation.
Fix this problem by:
1. remove StorageEngine from AlphaRowsetTest.
2. remove DataDir from AlphaRowsetWriter.
3. remove DataDir from Rowset