### PR TITLE
Enable decimalV2 cast to different precision

### DIFF
--- a/fe/src/main/java/org/apache/doris/analysis/CastExpr.java
+++ b/fe/src/main/java/org/apache/doris/analysis/CastExpr.java
@@ -176,7 +176,7 @@ public class CastExpr extends Expr {
         Type childType = getChild(0).getType();
 
         // this cast may result in loss of precision, but the user requested it
-        if (childType.equals(type)) {
+        if (childType.matchesType(type)) {
             noOp = true;
             return;
         }


### PR DESCRIPTION
The precision of cast function is useless. For example,
Query: select cast(10 as decimal(1,0));
Result: 10
Although numeric field is overflow, the numeric could be return.

So, the cast function from decimal(a,b) to decimal(c,d) could not be executed.