### PR TITLE
Change Null-safe equal operator from cross join to hash join

### DIFF
--- a/be/src/exec/aggregation_node.cpp
+++ b/be/src/exec/aggregation_node.cpp
@@ -148,7 +148,8 @@ Status AggregationNode::prepare(RuntimeState* state) {
 
     // TODO: how many buckets?
     _hash_tbl.reset(new HashTable(
-            _build_expr_ctxs, _probe_expr_ctxs, 1, true, id(), mem_tracker(), 1024));
+            _build_expr_ctxs, _probe_expr_ctxs, 1, true, 
+            vector<bool>(_build_expr_ctxs.size(), false), id(), mem_tracker(), 1024));
 
     if (_probe_expr_ctxs.empty()) {
         // create single output tuple now; we need to output something

--- a/be/src/exec/hash_join_node.cpp
+++ b/be/src/exec/hash_join_node.cpp
@@ -71,6 +71,12 @@ Status HashJoinNode::init(const TPlanNode& tnode, RuntimeState* state) {
         _probe_expr_ctxs.push_back(ctx);
         RETURN_IF_ERROR(Expr::create_expr_tree(_pool, eq_join_conjuncts[i].right, &ctx));
         _build_expr_ctxs.push_back(ctx);
+        if (eq_join_conjuncts[i].__isset.opcode 
+            && eq_join_conjuncts[i].opcode == TExprOpcode::EQ_FOR_NULL) {
+            _is_null_safe_eq_join.push_back(true);
+        } else {
+            _is_null_safe_eq_join.push_back(false);
+        }
     }
 
     RETURN_IF_ERROR(
@@ -131,13 +137,13 @@ Status HashJoinNode::prepare(RuntimeState* state) {
     _build_tuple_row_size = num_build_tuples * sizeof(Tuple*);
 
     // TODO: default buckets
-    const bool stores_nulls = _join_op == TJoinOp::RIGHT_OUTER_JOIN
+    const bool null_preserved = _join_op == TJoinOp::RIGHT_OUTER_JOIN
         || _join_op == TJoinOp::FULL_OUTER_JOIN
         || _join_op == TJoinOp::RIGHT_ANTI_JOIN
         || _join_op == TJoinOp::RIGHT_SEMI_JOIN;
     _hash_tbl.reset(new HashTable(
             _build_expr_ctxs, _probe_expr_ctxs, _build_tuple_size,
-            stores_nulls, id(), mem_tracker(), 1024));
+            null_preserved, _is_null_safe_eq_join, id(), mem_tracker(), 1024));
 
     _probe_batch.reset(new RowBatch(child(0)->row_desc(), state->batch_size(), mem_tracker()));
 
@@ -283,6 +289,11 @@ Status HashJoinNode::open(RuntimeState* state) {
 
     if (_children[0]->type() == TPlanNodeType::EXCHANGE_NODE
             && _children[1]->type() == TPlanNodeType::EXCHANGE_NODE) {
+        _is_push_down = false;
+    }
+
+    if (std::find(_is_null_safe_eq_join.begin(), _is_null_safe_eq_join.end(),
+                                    true) != _is_null_safe_eq_join.end()) {
         _is_push_down = false;
     }
 

--- a/be/src/exec/hash_join_node.cpp
+++ b/be/src/exec/hash_join_node.cpp
@@ -292,6 +292,10 @@ Status HashJoinNode::open(RuntimeState* state) {
         _is_push_down = false;
     }
 
+    // The predicate could not be pushed down when there is Null-safe equal operator.
+    // The in predicate will filter the null value in child[0] while it is needed in the Null-safe equal join.
+    // For example: select * from a join b where a.id<=>b.id
+    // the null value in table a should be return by scan node instead of filtering it by In-predicate.
     if (std::find(_is_null_safe_eq_join.begin(), _is_null_safe_eq_join.end(),
                                     true) != _is_null_safe_eq_join.end()) {
         _is_push_down = false;

--- a/be/src/exec/hash_join_node.h
+++ b/be/src/exec/hash_join_node.h
@@ -78,6 +78,9 @@ private:
     // _build_exprs (over child(1)) and _probe_exprs (over child(0))
     std::vector<ExprContext*> _probe_expr_ctxs;
     std::vector<ExprContext*> _build_expr_ctxs;
+    // true: the operator of eq join predicate is null safe equal => '<=>'
+    // false: the operator of eq join predicate is equal => '='
+    std::vector<bool> _is_null_safe_eq_join;
     std::list<ExprContext*> _push_down_expr_ctxs;
 
     // non-equi-join conjuncts from the JOIN clause

--- a/be/src/exec/hash_table.cpp
+++ b/be/src/exec/hash_table.cpp
@@ -43,7 +43,7 @@ const char* HashTable::_s_llvm_class_name = "class.doris::HashTable";
 HashTable::HashTable(const vector<ExprContext*>& build_expr_ctxs,
                      const vector<ExprContext*>& probe_expr_ctxs,
                      int num_build_tuples, bool null_preserved, 
-                     const std::vector<bool> finds_nulls,
+                     const std::vector<bool>& finds_nulls,
                      int32_t initial_seed,
                      MemTracker* mem_tracker, int64_t num_buckets) :
         _build_expr_ctxs(build_expr_ctxs),

--- a/be/src/exec/hash_table.h
+++ b/be/src/exec/hash_table.h
@@ -98,7 +98,9 @@ public:
     HashTable(
         const std::vector<ExprContext*>& build_exprs,
         const std::vector<ExprContext*>& probe_exprs,
-        int num_build_tuples, bool stores_nulls, int32_t initial_seed,
+        int num_build_tuples, bool stores_nulls, 
+        const std::vector<bool> finds_nulls,
+        int32_t initial_seed,
         MemTracker* mem_tracker,
         int64_t num_buckets);
 
@@ -384,6 +386,12 @@ private:
 
     // Number of Tuple* in the build tuple row
     const int _num_build_tuples;
+    // the row in hash table is preserved such as RIGHT_OUTER_JOIN
+    const bool _null_preserved;
+    // true: the null value should be keep in 
+    // false: the null value should be filter
+    const std::vector<bool> _finds_nulls;
+    // outer join || has null equal join should be true
     const bool _stores_nulls;
 
     const int32_t _initial_seed;

--- a/be/src/exec/hash_table.h
+++ b/be/src/exec/hash_table.h
@@ -388,8 +388,8 @@ private:
     const int _num_build_tuples;
     // the row in hash table is preserved such as RIGHT_OUTER_JOIN
     const bool _null_preserved;
-    // true: the null value should be keep in 
-    // false: the null value should be filter
+    // true: the null-safe equal '<=>' is true. The row with null shoud be judged.
+    // false: the equal '=' is false. The row with null should be filtered.
     const std::vector<bool> _finds_nulls;
     // outer join || has null equal join should be true
     const bool _stores_nulls;

--- a/be/src/exec/hash_table.h
+++ b/be/src/exec/hash_table.h
@@ -99,7 +99,7 @@ public:
         const std::vector<ExprContext*>& build_exprs,
         const std::vector<ExprContext*>& probe_exprs,
         int num_build_tuples, bool stores_nulls, 
-        const std::vector<bool> finds_nulls,
+        const std::vector<bool>& finds_nulls,
         int32_t initial_seed,
         MemTracker* mem_tracker,
         int64_t num_buckets);

--- a/be/src/exec/olap_scan_node.cpp
+++ b/be/src/exec/olap_scan_node.cpp
@@ -193,8 +193,7 @@ Status OlapScanNode::open(RuntimeState* state) {
     SCOPED_TIMER(_runtime_profile->total_time_counter());
     RETURN_IF_CANCELLED(state);
     RETURN_IF_ERROR(ExecNode::open(state));
-
-    LOG(INFO) << "olap scan node conjunct in open " << Expr::debug_string(_conjunct_ctxs);
+   
     for (int conj_idx = 0; conj_idx < _conjunct_ctxs.size(); ++conj_idx) {
         // if conjunct is constant, compute direct and set eos = true
 

--- a/be/src/exec/olap_scan_node.cpp
+++ b/be/src/exec/olap_scan_node.cpp
@@ -194,8 +194,10 @@ Status OlapScanNode::open(RuntimeState* state) {
     RETURN_IF_CANCELLED(state);
     RETURN_IF_ERROR(ExecNode::open(state));
 
+    LOG(INFO) << "olap scan node conjunct in open " << Expr::debug_string(_conjunct_ctxs);
     for (int conj_idx = 0; conj_idx < _conjunct_ctxs.size(); ++conj_idx) {
         // if conjunct is constant, compute direct and set eos = true
+
         if (_conjunct_ctxs[conj_idx]->root()->is_constant()) {
             void* value = _conjunct_ctxs[conj_idx]->get_value(NULL);
             if (value == NULL || *reinterpret_cast<bool*>(value) == false) {

--- a/fe/src/main/java/org/apache/doris/analysis/Analyzer.java
+++ b/fe/src/main/java/org/apache/doris/analysis/Analyzer.java
@@ -821,7 +821,7 @@ public class Analyzer {
             return;
         }
         BinaryPredicate binaryPred = (BinaryPredicate) e;
-        if (binaryPred.getOp() != BinaryPredicate.Operator.EQ) {
+        if (!binaryPred.getOp().isEquivalence()) {
             return;
         }
         if (tupleIds.size() < 2) {

--- a/fe/src/main/java/org/apache/doris/planner/DistributedPlanner.java
+++ b/fe/src/main/java/org/apache/doris/planner/DistributedPlanner.java
@@ -384,10 +384,10 @@ public class DistributedPlanner {
             // TODO: create equivalence classes based on equality predicates
 
             // first, extract join exprs
-            List<BinaryPredicate> eqJoinPredicates = node.getEqJoinConjuncts();
+            List<BinaryPredicate> eqJoinConjuncts = node.getEqJoinConjuncts();
             List<Expr> lhsJoinExprs = Lists.newArrayList();
             List<Expr> rhsJoinExprs = Lists.newArrayList();
-            for (BinaryPredicate eqJoinPredicate : eqJoinPredicates) {
+            for (BinaryPredicate eqJoinPredicate : eqJoinConjuncts) {
                 // no remapping necessary
                 lhsJoinExprs.add(eqJoinPredicate.getChild(0).clone(null));
                 rhsJoinExprs.add(eqJoinPredicate.getChild(1).clone(null));

--- a/fe/src/main/java/org/apache/doris/planner/DistributedPlanner.java
+++ b/fe/src/main/java/org/apache/doris/planner/DistributedPlanner.java
@@ -384,7 +384,7 @@ public class DistributedPlanner {
             // TODO: create equivalence classes based on equality predicates
 
             // first, extract join exprs
-            List<BinaryPredicate> eqJoinPredicates = node.getEqJoinPredicates();
+            List<BinaryPredicate> eqJoinPredicates = node.getEqJoinConjuncts();
             List<Expr> lhsJoinExprs = Lists.newArrayList();
             List<Expr> rhsJoinExprs = Lists.newArrayList();
             for (BinaryPredicate eqJoinPredicate : eqJoinPredicates) {
@@ -489,7 +489,7 @@ public class DistributedPlanner {
             List<Column> leftColumns = ((HashDistributionInfo) leftDistribution).getDistributionColumns();
             List<Column> rightColumns = ((HashDistributionInfo) rightDistribution).getDistributionColumns();
 
-            List<BinaryPredicate> eqJoinPredicates = node.getEqJoinPredicates();
+            List<BinaryPredicate> eqJoinPredicates = node.getEqJoinConjuncts();
             for (BinaryPredicate eqJoinPredicate : eqJoinPredicates) {
                 Expr lhsJoinExpr = eqJoinPredicate.getChild(0);
                 Expr rhsJoinExpr = eqJoinPredicate.getChild(1);

--- a/fe/src/main/java/org/apache/doris/planner/DistributedPlanner.java
+++ b/fe/src/main/java/org/apache/doris/planner/DistributedPlanner.java
@@ -18,6 +18,7 @@
 package org.apache.doris.planner;
 
 import org.apache.doris.analysis.AggregateInfo;
+import org.apache.doris.analysis.BinaryPredicate;
 import org.apache.doris.analysis.Expr;
 import org.apache.doris.analysis.InsertStmt;
 import org.apache.doris.analysis.JoinOperator;
@@ -33,7 +34,6 @@ import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.catalog.Table;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.Config;
-import org.apache.doris.common.Pair;
 import org.apache.doris.common.UserException;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.thrift.TPartitionType;
@@ -384,13 +384,13 @@ public class DistributedPlanner {
             // TODO: create equivalence classes based on equality predicates
 
             // first, extract join exprs
-            List<Pair<Expr, Expr>> eqJoinConjuncts = node.getEqJoinConjuncts();
+            List<BinaryPredicate> eqJoinPredicates = node.getEqJoinPredicates();
             List<Expr> lhsJoinExprs = Lists.newArrayList();
             List<Expr> rhsJoinExprs = Lists.newArrayList();
-            for (Pair<Expr, Expr> pair : eqJoinConjuncts) {
+            for (BinaryPredicate eqJoinPredicate : eqJoinPredicates) {
                 // no remapping necessary
-                lhsJoinExprs.add(pair.first.clone(null));
-                rhsJoinExprs.add(pair.second.clone(null));
+                lhsJoinExprs.add(eqJoinPredicate.getChild(0).clone(null));
+                rhsJoinExprs.add(eqJoinPredicate.getChild(1).clone(null));
             }
 
             // create the parent fragment containing the HashJoin node
@@ -489,14 +489,16 @@ public class DistributedPlanner {
             List<Column> leftColumns = ((HashDistributionInfo) leftDistribution).getDistributionColumns();
             List<Column> rightColumns = ((HashDistributionInfo) rightDistribution).getDistributionColumns();
 
-            List<Pair<Expr, Expr>> eqJoinConjuncts = node.getEqJoinConjuncts();
-            for (Pair<Expr, Expr> eqJoinPredicate : eqJoinConjuncts) {
-                if (eqJoinPredicate.first.unwrapSlotRef() == null || eqJoinPredicate.second.unwrapSlotRef() == null) {
+            List<BinaryPredicate> eqJoinPredicates = node.getEqJoinPredicates();
+            for (BinaryPredicate eqJoinPredicate : eqJoinPredicates) {
+                Expr lhsJoinExpr = eqJoinPredicate.getChild(0);
+                Expr rhsJoinExpr = eqJoinPredicate.getChild(1);
+                if (lhsJoinExpr.unwrapSlotRef() == null || rhsJoinExpr.unwrapSlotRef() == null) {
                     continue;
                 }
 
-                SlotDescriptor leftSlot = eqJoinPredicate.first.unwrapSlotRef().getDesc();
-                SlotDescriptor rightSlot = eqJoinPredicate.second.unwrapSlotRef().getDesc();
+                SlotDescriptor leftSlot = lhsJoinExpr.unwrapSlotRef().getDesc();
+                SlotDescriptor rightSlot = rhsJoinExpr.unwrapSlotRef().getDesc();
 
                 //3 the eqJoinConjuncts must contain the distributionColumns
                 if (leftColumns.contains(leftSlot.getColumn()) && rightColumns.contains(rightSlot.getColumn())) {

--- a/fe/src/main/java/org/apache/doris/planner/DistributedPlanner.java
+++ b/fe/src/main/java/org/apache/doris/planner/DistributedPlanner.java
@@ -489,8 +489,8 @@ public class DistributedPlanner {
             List<Column> leftColumns = ((HashDistributionInfo) leftDistribution).getDistributionColumns();
             List<Column> rightColumns = ((HashDistributionInfo) rightDistribution).getDistributionColumns();
 
-            List<BinaryPredicate> eqJoinPredicates = node.getEqJoinConjuncts();
-            for (BinaryPredicate eqJoinPredicate : eqJoinPredicates) {
+            List<BinaryPredicate> eqJoinConjuncts = node.getEqJoinConjuncts();
+            for (BinaryPredicate eqJoinPredicate : eqJoinConjuncts) {
                 Expr lhsJoinExpr = eqJoinPredicate.getChild(0);
                 Expr rhsJoinExpr = eqJoinPredicate.getChild(1);
                 if (lhsJoinExpr.unwrapSlotRef() == null || rhsJoinExpr.unwrapSlotRef() == null) {

--- a/fe/src/main/java/org/apache/doris/planner/HashJoinNode.java
+++ b/fe/src/main/java/org/apache/doris/planner/HashJoinNode.java
@@ -54,7 +54,7 @@ public class HashJoinNode extends PlanNode {
 
     private final TableRef     innerRef;
     private final JoinOperator joinOp;
-    // predicates of the form "<lhs> = <rhs>", recorded as Pair(<lhs>, <rhs>)
+    // predicates of the form 'a=b' or 'a<=>b'
     private List<BinaryPredicate> eqJoinConjuncts = Lists.newArrayList();
     // join conjuncts from the JOIN clause that aren't equi-join predicates
     private  List<Expr> otherJoinConjuncts;

--- a/fe/src/main/java/org/apache/doris/planner/HashJoinNode.java
+++ b/fe/src/main/java/org/apache/doris/planner/HashJoinNode.java
@@ -138,9 +138,9 @@ public class HashJoinNode extends PlanNode {
         //assignedConjuncts = analyzr.getAssignedConjuncts();
 
         ExprSubstitutionMap combinedChildSmap = getCombinedChildWithoutTupleIsNullSmap();
-        List<Expr> newEqJoinPredicates =
+        List<Expr> newEqJoinConjuncts =
                 Expr.substituteList(eqJoinConjuncts, combinedChildSmap, analyzer, false);
-        eqJoinConjuncts = newEqJoinPredicates.stream()
+        eqJoinConjuncts = newEqJoinConjuncts.stream()
                 .map(entity -> (BinaryPredicate) entity).collect(Collectors.toList());
         otherJoinConjuncts =
             Expr.substituteList(otherJoinConjuncts, combinedChildSmap, analyzer, false);

--- a/fe/src/main/java/org/apache/doris/planner/SingleNodePlanner.java
+++ b/fe/src/main/java/org/apache/doris/planner/SingleNodePlanner.java
@@ -1390,7 +1390,7 @@ public class SingleNodePlanner {
         }
 
         HashJoinNode result =
-                new HashJoinNode(ctx_.getNextNodeId(), outer, inner, innerRef, eqJoinConjuncts,
+                new HashJoinNode(ctx_.getNextNodeId(), outer, inner, innerRef, eqJoinPredicates,
                         ojConjuncts);
         result.init(analyzer);
         return result;

--- a/fe/src/main/java/org/apache/doris/planner/SingleNodePlanner.java
+++ b/fe/src/main/java/org/apache/doris/planner/SingleNodePlanner.java
@@ -56,7 +56,6 @@ import org.apache.doris.catalog.Table;
 import org.apache.doris.catalog.FunctionSet;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.catalog.AggregateFunction;
-import org.apache.doris.common.Pair;
 import org.apache.doris.common.Reference;
 import org.apache.doris.common.UserException;
 import org.apache.logging.log4j.LogManager;

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -20,6 +20,7 @@ namespace java org.apache.doris.thrift
 
 include "Exprs.thrift"
 include "Types.thrift"
+include "Opcodes.thrift"
 include "Partitions.thrift"
 
 enum TPlanNodeType {
@@ -260,6 +261,8 @@ struct TEqJoinCondition {
   1: required Exprs.TExpr left;
   // right-hand side of "<a> = <b>"
   2: required Exprs.TExpr right;
+  // operator of equal join
+  3: optional Opcodes.TExprOpcode opcode; 
 }
 
 enum TJoinOp {


### PR DESCRIPTION
ISSUE-2136

This commit change the join method from cross join to hash join when the equal operator is Null-safe '<=>'.
It will improve the speed of query which has the Null-safe equal operator.
The finds_nulls field is used to save if there is Null-safe operator.
The finds_nulls[i] is true means that the i-th equal operator is Null-safe.
The equal function in hash table will return true, if both val and loc are NULL when finds_nulls[i] is true.