### PR TITLE
Fix bug : num_of_columns_from_file incompatibility cause BE crashed during the upgrade

### DIFF
--- a/be/src/exec/broker_scanner.cpp
+++ b/be/src/exec/broker_scanner.cpp
@@ -447,7 +447,9 @@ bool BrokerScanner::line_to_src_tuple(const Slice& line) {
         str_slot->len = value.size;
     }
 
-    fill_slots_of_columns_from_path(range.num_of_columns_from_file, columns_from_path);
+    if (range.__isset.num_of_columns_from_file) {
+        fill_slots_of_columns_from_path(range.num_of_columns_from_file, columns_from_path);
+    }
 
     return true;
 }

--- a/be/src/exec/parquet_scanner.cpp
+++ b/be/src/exec/parquet_scanner.cpp
@@ -145,7 +145,7 @@ Status ParquetScanner::open_next_reader() {
             file_reader->close();
             continue;
         }
-        if (range.__isset.num_of_columns_from_file ) {
+        if (range.__isset.num_of_columns_from_file) {
             _cur_file_reader = new ParquetReaderWrap(file_reader.release(), range.num_of_columns_from_file);
         } else {
             _cur_file_reader = new ParquetReaderWrap(file_reader.release(), _src_slot_descs.size());

--- a/be/src/exec/parquet_scanner.cpp
+++ b/be/src/exec/parquet_scanner.cpp
@@ -72,12 +72,14 @@ Status ParquetScanner::get_next(Tuple* tuple, MemPool* tuple_pool, bool* eof) {
         RETURN_IF_ERROR(_cur_file_reader->read(_src_tuple, _src_slot_descs, tuple_pool, &_cur_file_eof));
         // range of current file
         const TBrokerRangeDesc& range = _ranges.at(_next_range - 1);
-        fill_slots_of_columns_from_path(range.num_of_columns_from_file, range.columns_from_path);
-        {
-            COUNTER_UPDATE(_rows_read_counter, 1);
-            SCOPED_TIMER(_materialize_timer);
-            if (fill_dest_tuple(Slice(), tuple, tuple_pool)) {
-                break;// break iff true
+        if (range.__isset.num_of_columns_from_file) {
+            fill_slots_of_columns_from_path(range.num_of_columns_from_file, range.columns_from_path);
+            {
+                COUNTER_UPDATE(_rows_read_counter, 1);
+                SCOPED_TIMER(_materialize_timer);
+                if (fill_dest_tuple(Slice(), tuple, tuple_pool)) {
+                    break;// break if true
+                }
             }
         }
     }
@@ -143,7 +145,11 @@ Status ParquetScanner::open_next_reader() {
             file_reader->close();
             continue;
         }
-        _cur_file_reader = new ParquetReaderWrap(file_reader.release(), range.num_of_columns_from_file);
+        if (range.__isset.num_of_columns_from_file ) {
+            _cur_file_reader = new ParquetReaderWrap(file_reader.release(), range.num_of_columns_from_file);
+        } else {
+            _cur_file_reader = new ParquetReaderWrap(file_reader.release(), _src_slot_descs.size());
+        }
         Status status = _cur_file_reader->init_parquet_reader(_src_slot_descs);
         if (status.is_end_of_file()) {
             continue;

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -116,7 +116,7 @@ struct TBrokerRangeDesc {
     // total size of the file
     8: optional i64 file_size
     // number of columns from file
-    9: optional i32 num_of_columns_from_file = 0
+    9: optional i32 num_of_columns_from_file
     // columns parsed from file path should be after the columns read from file
     10: optional list<string> columns_from_path
 }


### PR DESCRIPTION
#2186 
After checking, I found that broker load in 0.11 added num_of_columns_from_file parameter in thrift. This parameter does not consider compatibility in BE. 
So broker load could cause BE crashed during the upgrade
