### PR TITLE
Add node dead num metrics for all types of node

### DIFF
--- a/docs/documentation/cn/administrator-guide/http-actions/fe-get-log-file.md
+++ b/docs/documentation/cn/administrator-guide/http-actions/fe-get-log-file.md
@@ -43,7 +43,7 @@ under the License.
 
     示例：
     
-    `curl -X HEAD -uuser:passwd http://fe_host:http_port/api/get_log_file?type=fe.audit.log`
+    `curl -v -X HEAD -uuser:passwd http://fe_host:http_port/api/get_log_file?type=fe.audit.log`
     
     返回结果：
     

--- a/docs/documentation/en/administrator-guide/http-actions/fe-get-log-file_EN.md
+++ b/docs/documentation/en/administrator-guide/http-actions/fe-get-log-file_EN.md
@@ -41,7 +41,7 @@ To get FE log via HTTP
 
     Example
     
-    `curl -X HEAD -uuser:passwd http://fe_host:http_port/api/get_log_file?type=fe.audit.log`
+    `curl -v -X HEAD -uuser:passwd http://fe_host:http_port/api/get_log_file?type=fe.audit.log`
     
     Returns:
     

--- a/fe/src/main/java/org/apache/doris/alter/AlterHandler.java
+++ b/fe/src/main/java/org/apache/doris/alter/AlterHandler.java
@@ -164,6 +164,10 @@ public abstract class AlterHandler extends Daemon {
         return alterJobsV2.values().stream().filter(e -> e.getJobState() == state && e.getDbId() == dbId).count();
     }
 
+    public Long getAlterJobV2Num(org.apache.doris.alter.AlterJobV2.JobState state) {
+        return alterJobsV2.values().stream().filter(e -> e.getJobState() == state).count();
+    }
+
     @Deprecated
     public Map<Long, AlterJob> unprotectedGetAlterJobs() {
         return this.alterJobs;

--- a/fe/src/main/java/org/apache/doris/catalog/BrokerMgr.java
+++ b/fe/src/main/java/org/apache/doris/catalog/BrokerMgr.java
@@ -66,6 +66,19 @@ public class BrokerMgr {
         return brokerListMap;
     }
 
+    public List<FsBroker> getAllBrokers() {
+        List<FsBroker> brokers = Lists.newArrayList();
+        lock.lock();
+        try {
+            for (List<FsBroker> list : brokerListMap.values()) {
+                brokers.addAll(list);
+            }
+        } finally {
+            lock.unlock();
+        }
+        return brokers;
+    }
+
     public void execute(ModifyBrokerClause clause) throws DdlException {
         switch (clause.getOp()) {
             case OP_ADD:

--- a/fe/src/main/java/org/apache/doris/load/loadv2/LoadJob.java
+++ b/fe/src/main/java/org/apache/doris/load/loadv2/LoadJob.java
@@ -232,6 +232,10 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
         return state;
     }
 
+    public EtlJobType getJobType() {
+        return jobType;
+    }
+
     public long getCreateTimestamp() {
         return createTimestamp;
     }

--- a/fe/src/main/java/org/apache/doris/load/loadv2/LoadManager.java
+++ b/fe/src/main/java/org/apache/doris/load/loadv2/LoadManager.java
@@ -332,6 +332,15 @@ public class LoadManager implements Writable{
         }
     }
 
+    public long getLoadJobNum(JobState jobState, EtlJobType jobType) {
+        readLock();
+        try {
+            return idToLoadJob.values().stream().filter(j -> j.getState() == jobState && j.getJobType() == jobType).count();
+        } finally {
+            readUnlock();
+        }
+    }
+
     public void removeOldLoadJob() {
         long currentTimeMs = System.currentTimeMillis();
 

--- a/fe/src/main/java/org/apache/doris/metric/MetricCalculator.java
+++ b/fe/src/main/java/org/apache/doris/metric/MetricCalculator.java
@@ -17,8 +17,6 @@
 
 package org.apache.doris.metric;
 
-import org.apache.doris.catalog.Catalog;
-
 import java.util.TimerTask;
 
 /*
@@ -65,14 +63,6 @@ public class MetricCalculator extends TimerTask {
         double errRate = (double) (currentErrCounter - lastQueryErrCounter) / interval;
         MetricRepo.GAUGE_QUERY_ERR_RATE.setValue(errRate < 0 ? 0.0 : errRate);
         lastQueryErrCounter = currentErrCounter;
-        
-        // node down
-        long feDownNum = Catalog.getCurrentCatalog().getFrontends(null).stream().filter(f -> !f.isAlive()).count();
-        MetricRepo.GAUGE_FRONTEND_DOWN_NUM.setValue(feDownNum);
-        long beDownNum = Catalog.getCurrentSystemInfo().getIdToBackend().values().stream().filter(b -> !b.isAlive()).count();
-        MetricRepo.GAUGE_BACKEND_DOWN_NUM.setValue(beDownNum);
-        long brokerDownNum = Catalog.getCurrentCatalog().getBrokerMgr().getAllBrokers().stream().filter(b -> !b.isAlive).count();
-        MetricRepo.GAUGE_BROKER_DOWN_NUM.setValue(brokerDownNum);
 
         lastTs = currentTs;
     }

--- a/fe/src/main/java/org/apache/doris/metric/MetricCalculator.java
+++ b/fe/src/main/java/org/apache/doris/metric/MetricCalculator.java
@@ -17,6 +17,8 @@
 
 package org.apache.doris.metric;
 
+import org.apache.doris.catalog.Catalog;
+
 import java.util.TimerTask;
 
 /*
@@ -63,6 +65,14 @@ public class MetricCalculator extends TimerTask {
         double errRate = (double) (currentErrCounter - lastQueryErrCounter) / interval;
         MetricRepo.GAUGE_QUERY_ERR_RATE.setValue(errRate < 0 ? 0.0 : errRate);
         lastQueryErrCounter = currentErrCounter;
+        
+        // node down
+        long feDownNum = Catalog.getCurrentCatalog().getFrontends(null).stream().filter(f -> !f.isAlive()).count();
+        MetricRepo.GAUGE_FRONTEND_DOWN_NUM.setValue(feDownNum);
+        long beDownNum = Catalog.getCurrentSystemInfo().getIdToBackend().values().stream().filter(b -> !b.isAlive()).count();
+        MetricRepo.GAUGE_BACKEND_DOWN_NUM.setValue(beDownNum);
+        long brokerDownNum = Catalog.getCurrentCatalog().getBrokerMgr().getAllBrokers().stream().filter(b -> !b.isAlive).count();
+        MetricRepo.GAUGE_BROKER_DOWN_NUM.setValue(brokerDownNum);
 
         lastTs = currentTs;
     }

--- a/fe/src/main/java/org/apache/doris/metric/MetricRepo.java
+++ b/fe/src/main/java/org/apache/doris/metric/MetricRepo.java
@@ -76,9 +76,6 @@ public final class MetricRepo {
     public static GaugeMetricImpl<Double> GAUGE_QUERY_PER_SECOND;
     public static GaugeMetricImpl<Double> GAUGE_REQUEST_PER_SECOND;
     public static GaugeMetricImpl<Double> GAUGE_QUERY_ERR_RATE;
-    public static GaugeMetricImpl<Long> GAUGE_FRONTEND_DOWN_NUM;
-    public static GaugeMetricImpl<Long> GAUGE_BACKEND_DOWN_NUM;
-    public static GaugeMetricImpl<Long> GAUGE_BROKER_DOWN_NUM;
 
     private static Timer metricTimer = new Timer();
     private static MetricCalculator metricCalculator = new MetricCalculator();
@@ -188,16 +185,6 @@ public final class MetricRepo {
         GAUGE_QUERY_ERR_RATE = new GaugeMetricImpl<>("query_err_rate", "query_error_rate");
         PALO_METRIC_REGISTER.addPaloMetrics(GAUGE_QUERY_ERR_RATE);
         GAUGE_QUERY_ERR_RATE.setValue(0.0);
-        // node down num
-        GAUGE_FRONTEND_DOWN_NUM = new GaugeMetricImpl<>("frontend_down_num", "frontend down number");
-        GAUGE_FRONTEND_DOWN_NUM.setValue(0L);
-        PALO_METRIC_REGISTER.addPaloMetrics(GAUGE_FRONTEND_DOWN_NUM);
-        GAUGE_BACKEND_DOWN_NUM = new GaugeMetricImpl<>("backend_down_num", "backend down number");
-        GAUGE_BACKEND_DOWN_NUM.setValue(0L);
-        PALO_METRIC_REGISTER.addPaloMetrics(GAUGE_BACKEND_DOWN_NUM);
-        GAUGE_BROKER_DOWN_NUM = new GaugeMetricImpl<>("broker_down_num", "broker down number");
-        GAUGE_BROKER_DOWN_NUM.setValue(0L);
-        PALO_METRIC_REGISTER.addPaloMetrics(GAUGE_BROKER_DOWN_NUM);
 
         // 2. counter
         COUNTER_REQUEST_ALL = new LongCounterMetric("request_total", "total request");
@@ -242,8 +229,7 @@ public final class MetricRepo {
 
         // 3. histogram
         HISTO_QUERY_LATENCY = METRIC_REGISTER.histogram(MetricRegistry.name("query", "latency", "ms"));
-        HISTO_EDIT_LOG_WRITE_LATENCY = METRIC_REGISTER.histogram(MetricRegistry.name("editlog", "write", "latency",
-                                                                                     "ms"));
+        HISTO_EDIT_LOG_WRITE_LATENCY = METRIC_REGISTER.histogram(MetricRegistry.name("editlog", "write", "latency", "ms"));
 
         isInit.set(true);
 

--- a/fe/src/main/java/org/apache/doris/metric/SimpleCoreMetricVisitor.java
+++ b/fe/src/main/java/org/apache/doris/metric/SimpleCoreMetricVisitor.java
@@ -124,13 +124,11 @@ public class SimpleCoreMetricVisitor extends MetricVisitor {
 
     @Override
     public void getNodeInfo(StringBuilder sb) {
-        final String NODE_INFO = "node_info";
-        sb.append(Joiner.on(" ").join("# TYPE", NODE_INFO, "gauge\n"));
-        sb.append(NODE_INFO).append("{type=\"fe_node_num\", state=\"dead\"} ").append(
-                Catalog.getCurrentCatalog().getFrontends(null).stream().filter(f -> !f.isAlive()).count()).append("\n");
-        sb.append(NODE_INFO).append("{type=\"be_node_num\", state=\"dead\"} ").append(
-                Catalog.getCurrentSystemInfo().getIdToBackend().values().stream().filter(b -> !b.isAlive()).count()).append("\n");
-        sb.append(NODE_INFO).append("{type=\"broker_node_num\", state=\"dead\"} ").append(
-                Catalog.getCurrentCatalog().getBrokerMgr().getAllBrokers().stream().filter(b -> !b.isAlive).count()).append("\n");
+        long feDeadNum = Catalog.getCurrentCatalog().getFrontends(null).stream().filter(f -> !f.isAlive()).count();
+        long beDeadNum = Catalog.getCurrentSystemInfo().getIdToBackend().values().stream().filter(b -> !b.isAlive()).count();
+        long brokerDeadNum =  Catalog.getCurrentCatalog().getBrokerMgr().getAllBrokers().stream().filter(b -> !b.isAlive).count();
+        sb.append(prefix + "_frontend_dead_num").append(" ").append(String.valueOf(feDeadNum)).append("\n");
+        sb.append(prefix + "_backend_dead_num").append(" ").append(String.valueOf(beDeadNum)).append("\n");
+        sb.append(prefix + "_broker_dead_num").append(" ").append(String.valueOf(brokerDeadNum)).append("\n");
     }
 }

--- a/fe/src/main/java/org/apache/doris/metric/SimpleCoreMetricVisitor.java
+++ b/fe/src/main/java/org/apache/doris/metric/SimpleCoreMetricVisitor.java
@@ -53,6 +53,10 @@ public class SimpleCoreMetricVisitor extends MetricVisitor {
     public static final String REQUEST_PER_SECOND = "rps";
     public static final String QUERY_ERR_RATE = "query_err_rate";
 
+    public static final String FRONTEND_DOWN_NUM = "frontend_down_num";
+    public static final String BACKEND_DOWN_NUM = "backend_down_num";
+    public static final String BROKER_DOWN_NUM = "broker_down_num";
+
     private static final Map<String, String> CORE_METRICS = Maps.newHashMap();
     static {
         CORE_METRICS.put(MAX_JOURMAL_ID, TYPE_LONG);
@@ -61,6 +65,9 @@ public class SimpleCoreMetricVisitor extends MetricVisitor {
         CORE_METRICS.put(QUERY_PER_SECOND, TYPE_DOUBLE);
         CORE_METRICS.put(REQUEST_PER_SECOND, TYPE_DOUBLE);
         CORE_METRICS.put(QUERY_ERR_RATE, TYPE_DOUBLE);
+        CORE_METRICS.put(FRONTEND_DOWN_NUM, TYPE_LONG);
+        CORE_METRICS.put(BACKEND_DOWN_NUM, TYPE_LONG);
+        CORE_METRICS.put(BROKER_DOWN_NUM, TYPE_LONG);
     }
 
     public SimpleCoreMetricVisitor(String prefix) {

--- a/fe/src/main/java/org/apache/doris/metric/SimpleCoreMetricVisitor.java
+++ b/fe/src/main/java/org/apache/doris/metric/SimpleCoreMetricVisitor.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.metric;
 
+import org.apache.doris.catalog.Catalog;
 import org.apache.doris.monitor.jvm.JvmStats;
 import org.apache.doris.monitor.jvm.JvmStats.MemoryPool;
 import org.apache.doris.monitor.jvm.JvmStats.Threads;
@@ -53,10 +54,6 @@ public class SimpleCoreMetricVisitor extends MetricVisitor {
     public static final String REQUEST_PER_SECOND = "rps";
     public static final String QUERY_ERR_RATE = "query_err_rate";
 
-    public static final String FRONTEND_DOWN_NUM = "frontend_down_num";
-    public static final String BACKEND_DOWN_NUM = "backend_down_num";
-    public static final String BROKER_DOWN_NUM = "broker_down_num";
-
     private static final Map<String, String> CORE_METRICS = Maps.newHashMap();
     static {
         CORE_METRICS.put(MAX_JOURMAL_ID, TYPE_LONG);
@@ -65,9 +62,6 @@ public class SimpleCoreMetricVisitor extends MetricVisitor {
         CORE_METRICS.put(QUERY_PER_SECOND, TYPE_DOUBLE);
         CORE_METRICS.put(REQUEST_PER_SECOND, TYPE_DOUBLE);
         CORE_METRICS.put(QUERY_ERR_RATE, TYPE_DOUBLE);
-        CORE_METRICS.put(FRONTEND_DOWN_NUM, TYPE_LONG);
-        CORE_METRICS.put(BACKEND_DOWN_NUM, TYPE_LONG);
-        CORE_METRICS.put(BROKER_DOWN_NUM, TYPE_LONG);
     }
 
     public SimpleCoreMetricVisitor(String prefix) {
@@ -130,6 +124,13 @@ public class SimpleCoreMetricVisitor extends MetricVisitor {
 
     @Override
     public void getNodeInfo(StringBuilder sb) {
-        return;
+        final String NODE_INFO = "node_info";
+        sb.append(Joiner.on(" ").join("# TYPE", NODE_INFO, "gauge\n"));
+        sb.append(NODE_INFO).append("{type=\"fe_node_num\", state=\"dead\"} ").append(
+                Catalog.getCurrentCatalog().getFrontends(null).stream().filter(f -> !f.isAlive()).count()).append("\n");
+        sb.append(NODE_INFO).append("{type=\"be_node_num\", state=\"dead\"} ").append(
+                Catalog.getCurrentSystemInfo().getIdToBackend().values().stream().filter(b -> !b.isAlive()).count()).append("\n");
+        sb.append(NODE_INFO).append("{type=\"broker_node_num\", state=\"dead\"} ").append(
+                Catalog.getCurrentCatalog().getBrokerMgr().getAllBrokers().stream().filter(b -> !b.isAlive).count()).append("\n");
     }
 }


### PR DESCRIPTION
Add 3 new metrics to `http://fe:http_port/metrics?type=core`:

doris_fe_frontend_dead_num 0
doris_fe_backend_dead_num 0
doris_fe_broker_dead_num 0

Indicate FE/BE/BROKER nodes dead number