### PR TITLE
Return not_acceptable response for stream load when load task is failed

### DIFF
--- a/be/src/http/action/stream_load.cpp
+++ b/be/src/http/action/stream_load.cpp
@@ -125,7 +125,11 @@ void StreamLoadAction::handle(HttpRequest* req) {
     }
 
     auto str = ctx->to_json();
-    HttpChannel::send_reply(req, str);
+    HttpStatus http_status = HttpStatus::OK;
+    if (!ctx->status.ok()) {
+        http_status = HttpStatus::NOT_ACCEPTABLE;
+    }
+    HttpChannel::send_reply(req, http_status, str);
 
     // update statstics
     k_streaming_load_requests_total.increment(1);

--- a/samples/stream_load/java/DorisStreamLoad.java
+++ b/samples/stream_load/java/DorisStreamLoad.java
@@ -79,7 +79,7 @@ import java.nio.charset.StandardCharsets;
  *     at shaded.org.apache.http.impl.execchain.RedirectExec.execute(RedirectExec.java:110)
  *     at shaded.org.apache.http.impl.client.InternalHttpClient.doExecute(InternalHttpClient.java:184)
  *
- *2 run this class more than once, the status code for http response is still ok, and you will see
+ *2 run this class more than once, the status code for http response is NOT_ACCEPTABLE(406), and you will see
  *  the following output:
  *
  * {


### PR DESCRIPTION
when stream load task failed, the http response status code should not be 200, which indicate task failed