### PR TITLE
Optimize tablet report with expired transaction.

### DIFF
--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -883,7 +883,8 @@ void* TaskWorkerPool::_clear_transaction_task_worker_thread_callback(void* arg_t
             worker_pool_this->_tasks.pop_front();
         }
         LOG(INFO) << "get clear transaction task task, signature:" << agent_task_req.signature
-                  << ", transaction_id:" << clear_transaction_task_req.transaction_id;
+                  << ", transaction_id: " << clear_transaction_task_req.transaction_id
+                  << ", partition id size: " << clear_transaction_task_req.partition_id.size();
 
         TStatusCode::type status_code = TStatusCode::OK;
         vector<string> error_msgs;
@@ -893,7 +894,7 @@ void* TaskWorkerPool::_clear_transaction_task_worker_thread_callback(void* arg_t
             // transaction_id should be greater than zero.
             // If it is not greater than zero, no need to execute
             // the following clear_transaction_task() function.
-            if (clear_transaction_task_req.partition_id.empty()) {
+            if (!clear_transaction_task_req.partition_id.empty()) {
                 worker_pool_this->_env->storage_engine()->clear_transaction_task(
                         clear_transaction_task_req.transaction_id, clear_transaction_task_req.partition_id);
             } else {
@@ -901,10 +902,10 @@ void* TaskWorkerPool::_clear_transaction_task_worker_thread_callback(void* arg_t
                         clear_transaction_task_req.transaction_id);
             }
             LOG(INFO) << "finish to clear transaction task. signature:" << agent_task_req.signature
-                      << ", transaction_id:" << clear_transaction_task_req.transaction_id;
+                      << ", transaction_id: " << clear_transaction_task_req.transaction_id;
         } else {
             LOG(WARNING) << "invalid transaction id: " << clear_transaction_task_req.transaction_id
-                         << ", signature:" << agent_task_req.signature;
+                         << ", signature: " << agent_task_req.signature;
         }
 
         task_status.__set_status_code(status_code);

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -494,7 +494,7 @@ namespace config {
 
     // max number of txns in txn manager
     // this is a self protection to avoid too many txns saving in manager
-    CONF_Int64(max_runnings_transactions, "1000");
+    CONF_Int64(max_runnings_transactions, "200");
 
 } // namespace config
 

--- a/be/src/olap/rowset/rowset_meta_manager.cpp
+++ b/be/src/olap/rowset/rowset_meta_manager.cpp
@@ -94,7 +94,7 @@ OLAPStatus RowsetMetaManager::save(OlapMeta* meta, TabletUid tablet_uid, const R
 
 OLAPStatus RowsetMetaManager::remove(OlapMeta* meta, TabletUid tablet_uid, const RowsetId& rowset_id) {
     std::string key = ROWSET_PREFIX + tablet_uid.to_string() + "_" + rowset_id.to_string();
-    LOG(INFO) << "start to remove rowset, key:" << key;
+    VLOG(3) << "start to remove rowset, key:" << key;
     OLAPStatus status = meta->remove(META_COLUMN_FAMILY_INDEX, key);
     LOG(INFO) << "remove rowset key:" << key << " finished";
     return status;

--- a/be/src/olap/tablet_manager.cpp
+++ b/be/src/olap/tablet_manager.cpp
@@ -946,8 +946,7 @@ OLAPStatus TabletManager::report_all_tablets_info(std::map<TTabletId, TTablet>* 
             TTabletInfo tablet_info;
             tablet_ptr->build_tablet_report_info(&tablet_info);
 
-            // report expire transaction
-            // first, we build a expired map to avoid iterating txn map too many times.
+            // find expire transaction corresponding to this tablet
             TabletInfo tinfo = TabletInfo(tablet_ptr->tablet_id(), tablet_ptr->schema_hash(), tablet_ptr->tablet_uid());
             vector<int64_t> transaction_ids;
             auto find = expire_txn_map.find(tinfo);
@@ -956,10 +955,6 @@ OLAPStatus TabletManager::report_all_tablets_info(std::map<TTabletId, TTablet>* 
                     transaction_ids.push_back(it);
                 }
             }
-
-            // TODO(ygl): tablet manager and txn manager may be dead lock
-            // StorageEngine::instance()->txn_manager()->get_expire_txns(tablet_ptr->tablet_id(), 
-            //    tablet_ptr->schema_hash(), tablet_ptr->tablet_uid(), &transaction_ids);
             tablet_info.__set_transaction_ids(transaction_ids);
 
             tablet.tablet_infos.push_back(tablet_info);

--- a/be/src/olap/tablet_manager.cpp
+++ b/be/src/olap/tablet_manager.cpp
@@ -923,7 +923,7 @@ OLAPStatus TabletManager::report_all_tablets_info(std::map<TTabletId, TTablet>* 
 
     // build the expired txn map first, outside the tablet map lock
     std::map<TabletInfo, std::set<int64_t>> expire_txn_map;
-    StorageEngine::instance()->txn_manager()->build_expire_txn_map(expire_txn_map);
+    StorageEngine::instance()->txn_manager()->build_expire_txn_map(&expire_txn_map);
 
     ReadLock rlock(&_tablet_map_lock);
     DorisMetrics::report_all_tablets_requests_total.increment(1);

--- a/be/src/olap/txn_manager.h
+++ b/be/src/olap/txn_manager.h
@@ -132,7 +132,9 @@ public:
     bool has_txn(TPartitionId partition_id, TTransactionId transaction_id,
                  TTabletId tablet_id, SchemaHash schema_hash, TabletUid tablet_uid);
 
-    bool get_expire_txns(TTabletId tablet_id, SchemaHash schema_hash, TabletUid tablet_uid, std::vector<int64_t>* transaction_ids);
+    // get all expired txns and save tham in expire_txn_map.
+    // This is currently called before reporting all tablet info, to avoid iterating txn map for every tablets.
+    void build_expire_txn_map(std::map<TabletInfo, std::set<int64_t>>& expire_txn_map);
 
     void force_rollback_tablet_related_txns(OlapMeta* meta, TTabletId tablet_id, SchemaHash schema_hash, TabletUid tablet_uid);
 

--- a/be/src/olap/txn_manager.h
+++ b/be/src/olap/txn_manager.h
@@ -134,7 +134,7 @@ public:
 
     // get all expired txns and save tham in expire_txn_map.
     // This is currently called before reporting all tablet info, to avoid iterating txn map for every tablets.
-    void build_expire_txn_map(std::map<TabletInfo, std::set<int64_t>>& expire_txn_map);
+    void build_expire_txn_map(std::map<TabletInfo, std::set<int64_t>>* expire_txn_map);
 
     void force_rollback_tablet_related_txns(OlapMeta* meta, TTabletId tablet_id, SchemaHash schema_hash, TabletUid tablet_uid);
 

--- a/fe/src/main/java/org/apache/doris/master/ReportHandler.java
+++ b/fe/src/main/java/org/apache/doris/master/ReportHandler.java
@@ -897,7 +897,6 @@ public class ReportHandler extends Daemon {
             ClearTransactionTask clearTransactionTask = new ClearTransactionTask(backendId, 
                     transactionId, transactionsToClear.get(transactionId));
             batchTask.addTask(clearTransactionTask);
-            AgentTaskQueue.addTask(clearTransactionTask);
         }
         
         AgentTaskExecutor.submit(batchTask);

--- a/fe/src/main/java/org/apache/doris/qe/SimpleScheduler.java
+++ b/fe/src/main/java/org/apache/doris/qe/SimpleScheduler.java
@@ -29,15 +29,15 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
-
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 
 public class SimpleScheduler {
     private static AtomicLong nextId = new AtomicLong(0);
@@ -173,7 +173,7 @@ public class SimpleScheduler {
                             Long backendId = entry.getKey();
                             
                             // remove from blacklist if
-                            // 1. backend does not exist antmore
+                            // 1. backend does not exist anymore
                             // 2. backend is alive
                             if (clusterInfoService.getBackend(backendId) == null
                                     || clusterInfoService.checkBackendAvailable(backendId)) {


### PR DESCRIPTION
When there are lots of expired transactions on BE, and with large
number of tablet, the report thread may become to slow. Because it
has to iterate the whole transaction map for each tablet.

But this is unnecessary. We should first build a expired transaction
map with 'tablet id' as key. And for each tablet, we only need to seek
the expired transaction map once with tablet id, instead of traversing
the whole transaction map.

ISSUE: #2214 