### PR TITLE
Improve publish version performance

### DIFF
--- a/fe/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/src/main/java/org/apache/doris/common/Config.java
@@ -297,7 +297,7 @@ public class Config extends ConfigBase {
     /*
      * minimal intervals between two publish version action
      */
-    @ConfField public static int publish_version_interval_ms = 100;
+    @ConfField public static int publish_version_interval_ms = 10;
 
     /*
      * Maximal wait seconds for straggler node in load


### PR DESCRIPTION
The reason for publish version is slow under high concurrent is:

1. publish version is serial，could not concurrent
2. publish version need hold the `GlobalTransactionMgr writeLock`
3. publish version schedule interval is too big
4. handle publish version task result isn't  timely

This PR improve in 2,3,4 point.


Remove the db check when publish, because we will check when finish txn.
```
            for (TransactionState transactionState : allCommittedTransactionState) {
                long dbId = transactionState.getDbId();
                Database db = catalog.getDb(dbId);
                if (null == db) {
                    transactionState.setTransactionStatus(TransactionStatus.ABORTED);
                    unprotectUpsertTransactionState(transactionState);
                    continue;
                }
            }
```