### PR TITLE
Change sqlmode 'required' to 'optional' in forward master request, 

### DIFF
--- a/fe/src/main/java/org/apache/doris/qe/ConnectProcessor.java
+++ b/fe/src/main/java/org/apache/doris/qe/ConnectProcessor.java
@@ -321,7 +321,6 @@ public class ConnectProcessor {
         ctx.setQualifiedUser(request.user);
         ctx.setCatalog(Catalog.getInstance());
         ctx.getState().reset();
-        ctx.getSessionVariable().setSqlMode(request.sqlMode);
         if (request.isSetCluster()) {
             ctx.setCluster(request.cluster);
         }
@@ -342,6 +341,9 @@ public class ConnectProcessor {
         }
         if (request.isSetStmt_id()) {
             ctx.setForwardedStmtId(request.getStmt_id());
+        }
+        if (request.isSetSqlMode()) {
+            ctx.getSessionVariable().setSqlMode(request.sqlMode);
         }
 
         ctx.setThreadLocalInfo();

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -413,7 +413,7 @@ struct TMasterOpRequest {
     8: optional string user_ip
     9: optional string time_zone
     10: optional i64 stmt_id
-    11: required i64 sqlMode
+    11: optional i64 sqlMode
 }
 
 struct TColumnDefinition {


### PR DESCRIPTION
Fix the previous pull request #2216 .
This commit will change sqlMode param's modifier from 'required' to 'optional' in forward master request.