### PR TITLE
Add gutil split and strip tool

### DIFF
--- a/be/src/gutil/CMakeLists.txt
+++ b/be/src/gutil/CMakeLists.txt
@@ -40,6 +40,8 @@ add_library(Gutil STATIC
   strings/join.cc
   strings/memutil.cc
   strings/numbers.cc
+  strings/split.cc
+  strings/strip.cc
   strings/strcat.cc
   strings/stringpiece.cc
   strings/substitute.cc

--- a/be/src/gutil/logging-inl.h
+++ b/be/src/gutil/logging-inl.h
@@ -1,0 +1,50 @@
+// Copyright 2012 Google Inc.
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+// All rights reserved.
+//
+// Additional constants from logging.h and its dependencies which are
+// not exported by glog.
+
+#ifndef _LOGGING_IN_H_
+#define _LOGGING_IN_H_
+
+// DFATAL is FATAL in debug mode, ERROR in normal mode
+#ifdef NDEBUG
+#define DFATAL_LEVEL ERROR
+#else
+#define DFATAL_LEVEL FATAL
+#endif
+
+// NDEBUG usage helpers related to (RAW_)DCHECK:
+//
+// GUTIL_DEBUG_MODE is for small !NDEBUG uses like
+//   if (GUTIL_DEBUG_MODE) foo.CheckThatFoo();
+// instead of substantially more verbose
+//   #ifndef NDEBUG
+//     foo.CheckThatFoo();
+//   #endif
+//
+#ifdef NDEBUG
+const bool GUTIL_DEBUG_MODE = false;
+#else
+const bool GUTIL_DEBUG_MODE = true;
+#endif
+
+#endif  // _LOGGING_IN_H_

--- a/be/src/gutil/strings/split.cc
+++ b/be/src/gutil/strings/split.cc
@@ -1,0 +1,1091 @@
+// Copyright 2008 and onwards Google Inc.  All rights reserved.
+//
+// Maintainer: Greg Miller <jgm@google.com>
+
+#include "gutil/strings/split.h"
+
+#include <assert.h>
+#include <stdlib.h>
+#include <string.h>
+#include <iterator>
+using std::back_insert_iterator;
+using std::iterator_traits;
+#include <limits>
+using std::numeric_limits;
+
+using std::unordered_map;
+using std::unordered_set;
+
+#include "gutil/integral_types.h"
+#include <common/logging.h>
+#include "gutil/logging-inl.h"
+#include "gutil/macros.h"
+#include "gutil/strtoint.h"
+#include "gutil/strings/ascii_ctype.h"
+#include "gutil/strings/util.h"
+#include "gutil/hash/hash.h"
+
+// Implementations for some of the Split2 API. Much of the Split2 API is
+// templated so it exists in header files, either strings/split.h or
+// strings/split_iternal.h.
+namespace strings {
+namespace delimiter {
+
+namespace {
+
+// This GenericFind() template function encapsulates the finding algorithm
+// shared between the Literal and AnyOf delimiters. The FindPolicy template
+// parameter allows each delimiter to customize the actual find function to use
+// and the length of the found delimiter. For example, the Literal delimiter
+// will ultimately use StringPiece::find(), and the AnyOf delimiter will use
+// StringPiece::find_first_of().
+template <typename FindPolicy>
+StringPiece GenericFind(
+    StringPiece text,
+    StringPiece delimiter,
+    FindPolicy find_policy) {
+  if (delimiter.empty() && text.length() > 0) {
+    // Special case for empty string delimiters: always return a zero-length
+    // StringPiece referring to the item at position 1.
+    return StringPiece(text.begin() + 1, 0);
+  }
+  int found_pos = StringPiece::npos;
+  StringPiece found(text.end(), 0);  // By default, not found
+  found_pos = find_policy.Find(text, delimiter);
+  if (found_pos != StringPiece::npos) {
+    found.set(text.data() + found_pos, find_policy.Length(delimiter));
+  }
+  return found;
+}
+
+// Finds using StringPiece::find(), therefore the length of the found delimiter
+// is delimiter.length().
+struct LiteralPolicy {
+  int Find(StringPiece text, StringPiece delimiter) {
+    return text.find(delimiter);
+  }
+  int Length(StringPiece delimiter) {
+    return delimiter.length();
+  }
+};
+
+// Finds using StringPiece::find_first_of(), therefore the length of the found
+// delimiter is 1.
+struct AnyOfPolicy {
+  size_t Find(StringPiece text, StringPiece delimiter) {
+    return text.find_first_of(delimiter);
+  }
+  int Length(StringPiece delimiter) {
+    return 1;
+  }
+};
+
+}  // namespace
+
+//
+// Literal
+//
+
+Literal::Literal(StringPiece sp) : delimiter_(sp.ToString()) {
+}
+
+StringPiece Literal::Find(StringPiece text) const {
+  return GenericFind(text, delimiter_, LiteralPolicy());
+}
+
+//
+// AnyOf
+//
+
+AnyOf::AnyOf(StringPiece sp) : delimiters_(sp.ToString()) {
+}
+
+StringPiece AnyOf::Find(StringPiece text) const {
+  return GenericFind(text, delimiters_, AnyOfPolicy());
+}
+
+}  // namespace delimiter
+}  // namespace strings
+
+//
+// ==================== LEGACY SPLIT FUNCTIONS ====================
+//
+
+using ::strings::SkipEmpty;
+using ::strings::delimiter::AnyOf;
+using ::strings::delimiter::Limit;
+
+namespace {
+
+// Appends the results of a split to the specified container. This function has
+// the following overloads:
+// - vector<string>           - for better performance
+// - map<string, string>      - to change append semantics
+// - unordered_map<string, string> - to change append semantics
+template <typename Container, typename Splitter>
+void AppendToImpl(Container* container, Splitter splitter) {
+  Container c = splitter;  // Calls implicit conversion operator.
+  std::copy(c.begin(), c.end(), std::inserter(*container, container->end()));
+}
+
+// Overload of AppendToImpl() that is optimized for appending to vector<string>.
+// This version eliminates a couple string copies by using a vector<StringPiece>
+// as the intermediate container.
+template <typename Splitter>
+void AppendToImpl(vector<string>* container, Splitter splitter) {
+  vector<StringPiece> vsp = splitter;  // Calls implicit conversion operator.
+  size_t container_size = container->size();
+  container->resize(container_size + vsp.size());
+  for (const auto& sp : vsp) {
+    sp.CopyToString(&(*container)[container_size++]);
+  }
+}
+
+// Here we define two AppendToImpl() overloads for map<> and unordered_map<>. Both of
+// these overloads call through to this AppendToMap() function. This is needed
+// because inserting a duplicate key into a map does NOT overwrite the previous
+// value, which was not the behavior of the split1 Split*() functions. Consider
+// this example:
+//
+//   map<string, string> m;
+//   m.insert(std::make_pair("a", "1"));
+//   m.insert(std::make_pair("a", "2"));  // <-- doesn't actually insert.
+//   ASSERT_EQ(m["a"], "1");  // <-- "a" has value "1" not "2".
+//
+// Due to this behavior of map::insert, we can't rely on a normal std::inserter
+// for a maps. Instead, maps and unordered_maps need to be special cased to implement
+// the desired append semantic of inserting an existing value overwrites the
+// previous value.
+//
+// This same issue is true with sets as well. However, since sets don't have a
+// separate key and value, failing to overwrite an existing value in a set is
+// fine because the value already exists in the set.
+//
+template <typename Map, typename Splitter>
+void AppendToMap(Map* m, Splitter splitter) {
+  Map tmp = splitter;  // Calls implicit conversion operator.
+  for (typename Map::const_iterator it = tmp.begin(); it != tmp.end(); ++it) {
+    (*m)[it->first] = it->second;
+  }
+}
+
+template <typename Splitter>
+void AppendToImpl(map<string, string>* map_container, Splitter splitter) {
+  AppendToMap(map_container, splitter);
+}
+
+template <typename Splitter>
+void AppendToImpl(unordered_map<string, string>* map_container, Splitter splitter) {
+  AppendToMap(map_container, splitter);
+}
+
+// Appends the results of a call to strings::Split() to the specified container.
+// This function is used with the new strings::Split() API to implement the
+// append semantics of the legacy Split*() functions.
+//
+// The "Splitter" template parameter is intended to be a
+// ::strings::internal::Splitter<>, which is the return value of a call to
+// strings::Split(). Sample usage:
+//
+//   vector<string> v;
+//   ... add stuff to "v" ...
+//   AppendTo(&v, strings::Split("a,b,c", ","));
+//
+template <typename Container, typename Splitter>
+void AppendTo(Container* container, Splitter splitter) {
+  if (container->empty()) {
+    // "Appending" to an empty container is by far the common case. For this we
+    // assign directly to the output container, which is more efficient than
+    // explicitly appending.
+    *container = splitter;  // Calls implicit conversion operator.
+  } else {
+    AppendToImpl(container, splitter);
+  }
+}
+
+}  // anonymous namespace
+
+// Constants for ClipString()
+static const int kMaxOverCut = 12;
+// The ellipsis to add to strings that are too long
+static const char kCutStr[] = "...";
+static const int kCutStrSize = sizeof(kCutStr) - 1;
+
+// ----------------------------------------------------------------------
+// Return the place to clip the string at, or -1
+// if the string doesn't need to be clipped.
+// ----------------------------------------------------------------------
+static int ClipStringHelper(const char* str, int max_len, bool use_ellipsis) {
+  if (strlen(str) <= max_len)
+    return -1;
+
+  int max_substr_len = max_len;
+
+  if (use_ellipsis && max_len > kCutStrSize) {
+    max_substr_len -= kCutStrSize;
+  }
+
+  const char* cut_by =
+      (max_substr_len < kMaxOverCut ? str : str + max_len - kMaxOverCut);
+  const char* cut_at = str + max_substr_len;
+  while (!ascii_isspace(*cut_at) && cut_at > cut_by)
+    cut_at--;
+
+  if (cut_at == cut_by) {
+    // No space was found
+    return max_substr_len;
+  } else {
+    return cut_at-str;
+  }
+}
+
+// ----------------------------------------------------------------------
+// ClipString
+//    Clip a string to a max length. We try to clip on a word boundary
+//    if this is possible. If the string is clipped, we append an
+//    ellipsis.
+// ----------------------------------------------------------------------
+
+void ClipString(char* str, int max_len) {
+  int cut_at = ClipStringHelper(str, max_len, true);
+  if (cut_at != -1) {
+    if (max_len > kCutStrSize) {
+      strcpy(str+cut_at, kCutStr);
+    } else {
+      strcpy(str+cut_at, "");
+    }
+  }
+}
+
+// ----------------------------------------------------------------------
+// ClipString
+//    Version of ClipString() that uses string instead of char*.
+// ----------------------------------------------------------------------
+void ClipString(string* full_str, int max_len) {
+  int cut_at = ClipStringHelper(full_str->c_str(), max_len, true);
+  if (cut_at != -1) {
+    full_str->erase(cut_at);
+    if (max_len > kCutStrSize) {
+      full_str->append(kCutStr);
+    }
+  }
+}
+
+// ----------------------------------------------------------------------
+// SplitStringToIteratorAllowEmpty()
+//    Split a string using a character delimiter. Append the components
+//    to 'result'.  If there are consecutive delimiters, this function
+//    will return corresponding empty strings. The string is split into
+//    at most the specified number of pieces greedily. This means that the
+//    last piece may possibly be split further. To split into as many pieces
+//    as possible, specify 0 as the number of pieces.
+//
+//    If "full" is the empty string, yields an empty string as the only value.
+//
+//    If "pieces" is negative for some reason, it returns the whole string
+// ----------------------------------------------------------------------
+template <typename StringType, typename ITR>
+static inline
+void SplitStringToIteratorAllowEmpty(const StringType& full,
+                                     const char* delim,
+                                     int pieces,
+                                     ITR& result) {
+  string::size_type begin_index, end_index;
+  begin_index = 0;
+
+  for (int i = 0; (i < pieces-1) || (pieces == 0); i++) {
+    end_index = full.find_first_of(delim, begin_index);
+    if (end_index == string::npos) {
+      *result++ = full.substr(begin_index);
+      return;
+    }
+    *result++ = full.substr(begin_index, (end_index - begin_index));
+    begin_index = end_index + 1;
+  }
+  *result++ = full.substr(begin_index);
+}
+
+void SplitStringIntoNPiecesAllowEmpty(const string& full,
+                                      const char* delim,
+                                      int pieces,
+                                      vector<string>* result) {
+  if (pieces == 0) {
+    // No limit when pieces is 0.
+    AppendTo(result, strings::Split(full, AnyOf(delim)));
+  } else {
+    // The input argument "pieces" specifies the max size that *result should
+    // be. However, the argument to the Limit() delimiter is the max number of
+    // delimiters, which should be one less than "pieces". Example: "a,b,c" has
+    // 3 pieces and two comma delimiters.
+    int limit = std::max(pieces - 1, 0);
+    AppendTo(result, strings::Split(full, Limit(AnyOf(delim), limit)));
+  }
+}
+
+// ----------------------------------------------------------------------
+// SplitStringAllowEmpty
+//    Split a string using a character delimiter. Append the components
+//    to 'result'.  If there are consecutive delimiters, this function
+//    will return corresponding empty strings.
+// ----------------------------------------------------------------------
+void SplitStringAllowEmpty(const string& full, const char* delim,
+                           vector<string>* result) {
+  AppendTo(result, strings::Split(full, AnyOf(delim)));
+}
+
+// If we know how much to allocate for a vector of strings, we can
+// allocate the vector<string> only once and directly to the right size.
+// This saves in between 33-66 % of memory space needed for the result,
+// and runs faster in the microbenchmarks.
+//
+// The reserve is only implemented for the single character delim.
+//
+// The implementation for counting is cut-and-pasted from
+// SplitStringToIteratorUsing. I could have written my own counting iterator,
+// and use the existing template function, but probably this is more clear
+// and more sure to get optimized to reasonable code.
+static int CalculateReserveForVector(const string& full, const char* delim) {
+  int count = 0;
+  if (delim[0] != '\0' && delim[1] == '\0') {
+    // Optimize the common case where delim is a single character.
+    char c = delim[0];
+    const char* p = full.data();
+    const char* end = p + full.size();
+    while (p != end) {
+      if (*p == c) {  // This could be optimized with hasless(v,1) trick.
+        ++p;
+      } else {
+        while (++p != end && *p != c) {
+          // Skip to the next occurence of the delimiter.
+        }
+        ++count;
+      }
+    }
+  }
+  return count;
+}
+
+// ----------------------------------------------------------------------
+// SplitStringUsing()
+// SplitStringToHashsetUsing()
+// SplitStringToSetUsing()
+// SplitStringToMapUsing()
+// SplitStringToHashmapUsing()
+//    Split a string using a character delimiter. Append the components
+//    to 'result'.
+//
+// Note: For multi-character delimiters, this routine will split on *ANY* of
+// the characters in the string, not the entire string as a single delimiter.
+// ----------------------------------------------------------------------
+template <typename StringType, typename ITR>
+static inline
+void SplitStringToIteratorUsing(const StringType& full,
+                                const char* delim,
+                                ITR& result) {
+  // Optimize the common case where delim is a single character.
+  if (delim[0] != '\0' && delim[1] == '\0') {
+    char c = delim[0];
+    const char* p = full.data();
+    const char* end = p + full.size();
+    while (p != end) {
+      if (*p == c) {
+        ++p;
+      } else {
+        const char* start = p;
+        while (++p != end && *p != c) {
+          // Skip to the next occurence of the delimiter.
+        }
+        *result++ = StringType(start, p - start);
+      }
+    }
+    return;
+  }
+
+  string::size_type begin_index, end_index;
+  begin_index = full.find_first_not_of(delim);
+  while (begin_index != string::npos) {
+    end_index = full.find_first_of(delim, begin_index);
+    if (end_index == string::npos) {
+      *result++ = full.substr(begin_index);
+      return;
+    }
+    *result++ = full.substr(begin_index, (end_index - begin_index));
+    begin_index = full.find_first_not_of(delim, end_index);
+  }
+}
+
+void SplitStringUsing(const string& full,
+                      const char* delim,
+                      vector<string>* result) {
+  result->reserve(result->size() + CalculateReserveForVector(full, delim));
+  std::back_insert_iterator< vector<string> > it(*result);
+  SplitStringToIteratorUsing(full, delim, it);
+}
+
+void SplitStringToHashsetUsing(const string& full, const char* delim,
+                               unordered_set<string>* result) {
+  AppendTo(result, strings::Split(full, AnyOf(delim), strings::SkipEmpty()));
+}
+
+void SplitStringToSetUsing(const string& full, const char* delim,
+                           set<string>* result) {
+  AppendTo(result, strings::Split(full, AnyOf(delim), strings::SkipEmpty()));
+}
+
+void SplitStringToMapUsing(const string& full, const char* delim,
+                           map<string, string>* result) {
+  AppendTo(result, strings::Split(full, AnyOf(delim), strings::SkipEmpty()));
+}
+
+void SplitStringToHashmapUsing(const string& full, const char* delim,
+                               unordered_map<string, string>* result) {
+  AppendTo(result, strings::Split(full, AnyOf(delim), strings::SkipEmpty()));
+}
+
+// ----------------------------------------------------------------------
+// SplitStringPieceToVector()
+//    Split a StringPiece into sub-StringPieces based on delim
+//    and appends the pieces to 'vec'.
+//    If omit empty strings is true, empty strings are omitted
+//    from the resulting vector.
+// ----------------------------------------------------------------------
+void SplitStringPieceToVector(const StringPiece& full,
+                              const char* delim,
+                              vector<StringPiece>* vec,
+                              bool omit_empty_strings) {
+  if (omit_empty_strings) {
+    AppendTo(vec, strings::Split(full, AnyOf(delim), SkipEmpty()));
+  } else {
+    AppendTo(vec, strings::Split(full, AnyOf(delim)));
+  }
+}
+
+// ----------------------------------------------------------------------
+// SplitUsing()
+//    Split a string using a string of delimiters, returning vector
+//    of strings. The original string is modified to insert nulls.
+// ----------------------------------------------------------------------
+
+vector<char*>* SplitUsing(char* full, const char* delim) {
+  auto vec = new vector<char*>;
+  SplitToVector(full, delim, vec, true);        // Omit empty strings
+  return vec;
+}
+
+void SplitToVector(char* full, const char* delim, vector<char*>* vec,
+                   bool omit_empty_strings) {
+  char* next  = full;
+  while ((next = gstrsep(&full, delim)) != nullptr) {
+    if (omit_empty_strings && next[0] == '\0') continue;
+    vec->push_back(next);
+  }
+  // Add last element (or full string if no delimeter found):
+  if (full != nullptr) {
+    vec->push_back(full);
+  }
+}
+
+void SplitToVector(char* full, const char* delim, vector<const char*>* vec,
+                   bool omit_empty_strings) {
+  char* next  = full;
+  while ((next = gstrsep(&full, delim)) != nullptr) {
+    if (omit_empty_strings && next[0] == '\0') continue;
+    vec->push_back(next);
+  }
+  // Add last element (or full string if no delimeter found):
+  if (full != nullptr) {
+    vec->push_back(full);
+  }
+}
+
+// ----------------------------------------------------------------------
+// SplitOneStringToken()
+//   Mainly a stringified wrapper around strpbrk()
+// ----------------------------------------------------------------------
+string SplitOneStringToken(const char ** source, const char * delim) {
+  assert(source);
+  assert(delim);
+  if (!*source) {
+    return string();
+  }
+  const char * begin = *source;
+  // Optimize the common case where delim is a single character.
+  if (delim[0] != '\0' && delim[1] == '\0') {
+    *source = strchr(*source, delim[0]);
+  } else {
+    *source = strpbrk(*source, delim);
+  }
+  if (*source) {
+    return string(begin, (*source)++);
+  } else {
+    return string(begin);
+  }
+}
+
+// ----------------------------------------------------------------------
+// SplitStringWithEscaping()
+// SplitStringWithEscapingAllowEmpty()
+// SplitStringWithEscapingToSet()
+// SplitStringWithWithEscapingToHashset()
+//   Split the string using the specified delimiters, taking escaping into
+//   account. '\' is not allowed as a delimiter.
+// ----------------------------------------------------------------------
+template <typename ITR>
+static inline
+void SplitStringWithEscapingToIterator(const string& src,
+                                       const strings::CharSet& delimiters,
+                                       const bool allow_empty,
+                                       ITR* result) {
+  CHECK(!delimiters.Test('\\')) << "\\ is not allowed as a delimiter.";
+  CHECK(result);
+  string part;
+
+  for (uint32 i = 0; i < src.size(); ++i) {
+    char current_char = src[i];
+    if (delimiters.Test(current_char)) {
+      // Push substrings when we encounter delimiters.
+      if (allow_empty || !part.empty()) {
+        *(*result)++ = part;
+        part.clear();
+      }
+    } else if (current_char == '\\' && ++i < src.size()) {
+      // If we see a backslash, the next delimiter or backslash is literal.
+      current_char = src[i];
+      if (current_char != '\\' && !delimiters.Test(current_char)) {
+        // Don't honour unknown escape sequences: emit \f for \f.
+        part.push_back('\\');
+      }
+      part.push_back(current_char);
+    } else {
+      // Otherwise, we have a normal character or trailing backslash.
+      part.push_back(current_char);
+    }
+  }
+
+  // Push the trailing part.
+  if (allow_empty || !part.empty()) {
+    *(*result)++ = part;
+  }
+}
+
+void SplitStringWithEscaping(const string &full,
+                             const strings::CharSet& delimiters,
+                             vector<string> *result) {
+  std::back_insert_iterator< vector<string> > it(*result);
+  SplitStringWithEscapingToIterator(full, delimiters, false, &it);
+}
+
+void SplitStringWithEscapingAllowEmpty(const string &full,
+                                       const strings::CharSet& delimiters,
+                                       vector<string> *result) {
+  std::back_insert_iterator< vector<string> > it(*result);
+  SplitStringWithEscapingToIterator(full, delimiters, true, &it);
+}
+
+void SplitStringWithEscapingToSet(const string &full,
+                                  const strings::CharSet& delimiters,
+                                  set<string> *result) {
+  std::insert_iterator< set<string> > it(*result, result->end());
+  SplitStringWithEscapingToIterator(full, delimiters, false, &it);
+}
+
+void SplitStringWithEscapingToHashset(const string &full,
+                                      const strings::CharSet& delimiters,
+                                      unordered_set<string> *result) {
+  std::insert_iterator< unordered_set<string> > it(*result, result->end());
+  SplitStringWithEscapingToIterator(full, delimiters, false, &it);
+}
+
+
+// ----------------------------------------------------------------------
+// SplitOneIntToken()
+// SplitOneInt32Token()
+// SplitOneUint32Token()
+// SplitOneInt64Token()
+// SplitOneUint64Token()
+// SplitOneDoubleToken()
+// SplitOneFloatToken()
+// SplitOneDecimalIntToken()
+// SplitOneDecimalInt32Token()
+// SplitOneDecimalUint32Token()
+// SplitOneDecimalInt64Token()
+// SplitOneDecimalUint64Token()
+// SplitOneHexUint32Token()
+// SplitOneHexUint64Token()
+//   Mainly a stringified wrapper around strtol/strtoul/strtod
+// ----------------------------------------------------------------------
+// Curried functions for the macro below
+static inline long strto32_0(const char * source, char ** end) {
+  return strto32(source, end, 0); }
+static inline unsigned long strtou32_0(const char * source, char ** end) {
+  return strtou32(source, end, 0); }
+static inline int64 strto64_0(const char * source, char ** end) {
+  return strto64(source, end, 0); }
+static inline uint64 strtou64_0(const char * source, char ** end) {
+  return strtou64(source, end, 0); }
+static inline long strto32_10(const char * source, char ** end) {
+  return strto32(source, end, 10); }
+static inline unsigned long strtou32_10(const char * source, char ** end) {
+  return strtou32(source, end, 10); }
+static inline int64 strto64_10(const char * source, char ** end) {
+  return strto64(source, end, 10); }
+static inline uint64 strtou64_10(const char * source, char ** end) {
+  return strtou64(source, end, 10); }
+static inline uint32 strtou32_16(const char * source, char ** end) {
+  return strtou32(source, end, 16); }
+static inline uint64 strtou64_16(const char * source, char ** end) {
+  return strtou64(source, end, 16); }
+
+#define DEFINE_SPLIT_ONE_NUMBER_TOKEN(name, type, function) \
+bool SplitOne##name##Token(const char ** source, const char * delim, \
+                           type * value) {                      \
+  assert(source);                                               \
+  assert(delim);                                                \
+  assert(value);                                                \
+  if (!*source)                                                 \
+    return false;                                               \
+  /* Parse int */                                               \
+  char * end;                                                   \
+  *value = function(*source, &end);                             \
+  if (end == *source)                                           \
+    return false; /* number not present at start of string */   \
+  if (end[0] && !strchr(delim, end[0]))                         \
+    return false; /* Garbage characters after int */            \
+  /* Advance past token */                                      \
+  if (*end != '\0')                                             \
+    *source = const_cast<const char *>(end+1);                  \
+  else                                                          \
+    *source = NULL;                                             \
+  return true;                                                  \
+}
+
+DEFINE_SPLIT_ONE_NUMBER_TOKEN(Int, int, strto32_0)
+DEFINE_SPLIT_ONE_NUMBER_TOKEN(Int32, int32, strto32_0)
+DEFINE_SPLIT_ONE_NUMBER_TOKEN(Uint32, uint32, strtou32_0)
+DEFINE_SPLIT_ONE_NUMBER_TOKEN(Int64, int64, strto64_0)
+DEFINE_SPLIT_ONE_NUMBER_TOKEN(Uint64, uint64, strtou64_0)
+DEFINE_SPLIT_ONE_NUMBER_TOKEN(Double, double, strtod)
+#ifdef _MSC_VER  // has no strtof()
+// Note: does an implicit cast to float.
+DEFINE_SPLIT_ONE_NUMBER_TOKEN(Float, float, strtod)
+#else
+DEFINE_SPLIT_ONE_NUMBER_TOKEN(Float, float, strtof)
+#endif
+DEFINE_SPLIT_ONE_NUMBER_TOKEN(DecimalInt, int, strto32_10)
+DEFINE_SPLIT_ONE_NUMBER_TOKEN(DecimalInt32, int32, strto32_10)
+DEFINE_SPLIT_ONE_NUMBER_TOKEN(DecimalUint32, uint32, strtou32_10)
+DEFINE_SPLIT_ONE_NUMBER_TOKEN(DecimalInt64, int64, strto64_10)
+DEFINE_SPLIT_ONE_NUMBER_TOKEN(DecimalUint64, uint64, strtou64_10)
+DEFINE_SPLIT_ONE_NUMBER_TOKEN(HexUint32, uint32, strtou32_16)
+DEFINE_SPLIT_ONE_NUMBER_TOKEN(HexUint64, uint64, strtou64_16)
+
+
+// ----------------------------------------------------------------------
+// SplitRange()
+//    Splits a string of the form "<from>-<to>".  Either or both can be
+//    missing.  A raw number (<to>) is interpreted as "<to>-".  Modifies
+//    parameters insofar as they're specified by the string.  RETURNS
+//    true iff the input is a well-formed range.  If it RETURNS false,
+//    from and to remain unchanged.  The range in rangestr should be
+//    terminated either by "\0" or by whitespace.
+// ----------------------------------------------------------------------
+
+#define EOS(ch)  ( (ch) == '\0' || ascii_isspace(ch) )
+bool SplitRange(const char* rangestr, int* from, int* to) {
+  // We need to do the const-cast because strol takes a char**, not const char**
+  char* val = const_cast<char*>(rangestr);
+  if (val == nullptr || EOS(*val))  return true;  // we'll say nothingness is ok
+
+  if ( val[0] == '-' && EOS(val[1]) )    // CASE 1: -
+    return true;                         // nothing changes
+
+  if ( val[0] == '-' ) {                 // CASE 2: -<i2>
+    const int int2 = strto32(val+1, &val, 10);
+    if ( !EOS(*val) )  return false;     // not a valid integer
+    *to = int2;                          // only "to" changes
+    return true;
+
+  } else {
+    const int int1 = strto32(val, &val, 10);
+    if ( EOS(*val) || (*val == '-' && EOS(*(val+1))) ) {
+      *from = int1;                      // CASE 3: <i1>, same as <i1>-
+      return true;                       // only "from" changes
+    } else if (*val != '-') {            // not a valid range
+      return false;
+    }
+    const int int2 = strto32(val+1, &val, 10);
+    if ( !EOS(*val) )  return false;     // not a valid integer
+    *from = int1;                        // CASE 4: <i1>-<i2>
+    *to = int2;
+    return true;
+  }
+}
+
+void SplitCSVLineWithDelimiter(char* line, char delimiter,
+                               vector<char*>* cols) {
+  char* end_of_line = line + strlen(line);
+  char* end;
+  char* start;
+
+  for (; line < end_of_line; line++) {
+    // Skip leading whitespace, unless said whitespace is the delimiter.
+    while (ascii_isspace(*line) && *line != delimiter)
+      ++line;
+
+    if (*line == '"' && delimiter == ',') {     // Quoted value...
+      start = ++line;
+      end = start;
+      for (; *line; line++) {
+        if (*line == '"') {
+          line++;
+          if (*line != '"')  // [""] is an escaped ["]
+            break;           // but just ["] is end of value
+        }
+        *end++ = *line;
+      }
+      // All characters after the closing quote and before the comma
+      // are ignored.
+      line = strchr(line, delimiter);
+      if (!line) line = end_of_line;
+    } else {
+      start = line;
+      line = strchr(line, delimiter);
+      if (!line) line = end_of_line;
+      // Skip all trailing whitespace, unless said whitespace is the delimiter.
+      for (end = line; end > start; --end) {
+        if (!ascii_isspace(end[-1]) || end[-1] == delimiter)
+          break;
+      }
+    }
+    const bool need_another_column =
+      (*line == delimiter) && (line == end_of_line - 1);
+    *end = '\0';
+    cols->push_back(start);
+    // If line was something like [paul,] (comma is the last character
+    // and is not proceeded by whitespace or quote) then we are about
+    // to eliminate the last column (which is empty). This would be
+    // incorrect.
+    if (need_another_column)
+      cols->push_back(end);
+
+    assert(*line == '\0' || *line == delimiter);
+  }
+}
+
+void SplitCSVLine(char* line, vector<char*>* cols) {
+  SplitCSVLineWithDelimiter(line, ',', cols);
+}
+
+void SplitCSVLineWithDelimiterForStrings(const string &line,
+                                         char delimiter,
+                                         vector<string> *cols) {
+  // Unfortunately, the interface requires char* instead of const char*
+  // which requires copying the string.
+  char *cline = strndup_with_new(line.c_str(), line.size());
+  vector<char *> v;
+  SplitCSVLineWithDelimiter(cline, delimiter, &v);
+  for (vector<char*>::const_iterator ci = v.begin(); ci != v.end(); ++ci) {
+    cols->push_back(*ci);
+  }
+  delete[] cline;
+}
+
+// ----------------------------------------------------------------------
+namespace {
+
+// Helper class used by SplitStructuredLineInternal.
+class ClosingSymbolLookup {
+ public:
+  explicit ClosingSymbolLookup(const char* symbol_pairs)
+      : closing_(),
+        valid_closing_() {
+    // Initialize the opening/closing arrays.
+    for (const char* symbol = symbol_pairs; *symbol != 0; ++symbol) {
+      unsigned char opening = *symbol;
+      ++symbol;
+      // If the string ends before the closing character has been found,
+      // use the opening character as the closing character.
+      unsigned char closing = *symbol != 0 ? *symbol : opening;
+      closing_[opening] = closing;
+      valid_closing_[closing] = true;
+      if (*symbol == 0) break;
+    }
+  }
+
+  // Returns the closing character corresponding to an opening one,
+  // or 0 if the argument is not an opening character.
+  char GetClosingChar(char opening) const {
+    return closing_[static_cast<unsigned char>(opening)];
+  }
+
+  // Returns true if the argument is a closing character.
+  bool IsClosing(char c) const {
+    return valid_closing_[static_cast<unsigned char>(c)];
+  }
+
+ private:
+  // Maps an opening character to its closing. If the entry contains 0,
+  // the character is not in the opening set.
+  char closing_[256];
+  // Valid closing characters.
+  bool valid_closing_[256];
+
+  DISALLOW_COPY_AND_ASSIGN(ClosingSymbolLookup);
+};
+
+char* SplitStructuredLineInternal(char* line,
+                                  char delimiter,
+                                  const char* symbol_pairs,
+                                  vector<char*>* cols,
+                                  bool with_escapes) {
+  ClosingSymbolLookup lookup(symbol_pairs);
+
+  // Stack of symbols expected to close the current opened expressions.
+  vector<char> expected_to_close;
+  bool in_escape = false;
+
+  CHECK(cols);
+  cols->push_back(line);
+  char* current;
+  for (current = line; *current; ++current) {
+    char c = *current;
+    if (in_escape) {
+      in_escape = false;
+    } else if (with_escapes && c == '\\') {
+      // We are escaping the next character. Note the escape still appears
+      // in the output.
+      in_escape = true;
+    } else if (expected_to_close.empty() && c == delimiter) {
+      // We don't have any open expression, this is a valid separator.
+      *current = 0;
+      cols->push_back(current + 1);
+    } else if (!expected_to_close.empty() && c == expected_to_close.back()) {
+      // Can we close the currently open expression?
+      expected_to_close.pop_back();
+    } else if (lookup.GetClosingChar(c)) {
+      // If this is an opening symbol, we open a new expression and push
+      // the expected closing symbol on the stack.
+      expected_to_close.push_back(lookup.GetClosingChar(c));
+    } else if (lookup.IsClosing(c)) {
+      // Error: mismatched closing symbol.
+      return current;
+    }
+  }
+  if (!expected_to_close.empty()) {
+    return current;  // Missing closing symbol(s)
+  }
+  return nullptr;  // Success
+}
+
+bool SplitStructuredLineInternal(StringPiece line,
+                                 char delimiter,
+                                 const char* symbol_pairs,
+                                 vector<StringPiece>* cols,
+                                 bool with_escapes) {
+  ClosingSymbolLookup lookup(symbol_pairs);
+
+  // Stack of symbols expected to close the current opened expressions.
+  vector<char> expected_to_close;
+  bool in_escape = false;
+
+  CHECK_NOTNULL(cols);
+  cols->push_back(line);
+  for (int i = 0; i < line.size(); ++i) {
+    char c = line[i];
+    if (in_escape) {
+      in_escape = false;
+    } else if (with_escapes && c == '\\') {
+      // We are escaping the next character. Note the escape still appears
+      // in the output.
+      in_escape = true;
+    } else if (expected_to_close.empty() && c == delimiter) {
+      // We don't have any open expression, this is a valid separator.
+      cols->back().remove_suffix(line.size() - i);
+      cols->push_back(StringPiece(line, i + 1));
+    } else if (!expected_to_close.empty() && c == expected_to_close.back()) {
+      // Can we close the currently open expression?
+      expected_to_close.pop_back();
+    } else if (lookup.GetClosingChar(c)) {
+      // If this is an opening symbol, we open a new expression and push
+      // the expected closing symbol on the stack.
+      expected_to_close.push_back(lookup.GetClosingChar(c));
+    } else if (lookup.IsClosing(c)) {
+      // Error: mismatched closing symbol.
+      return false;
+    }
+  }
+  if (!expected_to_close.empty()) {
+    return false;  // Missing closing symbol(s)
+  }
+  return true;  // Success
+}
+
+}  // anonymous namespace
+
+char* SplitStructuredLine(char* line,
+                          char delimiter,
+                          const char *symbol_pairs,
+                          vector<char*>* cols) {
+  return SplitStructuredLineInternal(line, delimiter, symbol_pairs, cols,
+                                     false);
+}
+
+bool SplitStructuredLine(StringPiece line,
+                         char delimiter,
+                         const char* symbol_pairs,
+                         vector<StringPiece>* cols) {
+  return SplitStructuredLineInternal(line, delimiter, symbol_pairs, cols,
+                                     false);
+}
+
+char* SplitStructuredLineWithEscapes(char* line,
+                                     char delimiter,
+                                     const char *symbol_pairs,
+                                     vector<char*>* cols) {
+  return SplitStructuredLineInternal(line, delimiter, symbol_pairs, cols,
+                                     true);
+}
+
+bool SplitStructuredLineWithEscapes(StringPiece line,
+                                     char delimiter,
+                                     const char* symbol_pairs,
+                                     vector<StringPiece>* cols) {
+  return SplitStructuredLineInternal(line, delimiter, symbol_pairs, cols,
+                                     true);
+}
+
+
+// ----------------------------------------------------------------------
+// SplitStringIntoKeyValues()
+// ----------------------------------------------------------------------
+bool SplitStringIntoKeyValues(const string& line,
+                              const string& key_value_delimiters,
+                              const string& value_value_delimiters,
+                              string *key, vector<string> *values) {
+  key->clear();
+  values->clear();
+
+  // find the key string
+  size_t end_key_pos = line.find_first_of(key_value_delimiters);
+  if (end_key_pos == string::npos) {
+    VLOG(1) << "cannot parse key from line: " << line;
+    return false;    // no key
+  }
+  key->assign(line, 0, end_key_pos);
+
+  // find the values string
+  string remains(line, end_key_pos, line.size() - end_key_pos);
+  size_t begin_values_pos = remains.find_first_not_of(key_value_delimiters);
+  if (begin_values_pos == string::npos) {
+    VLOG(1) << "cannot parse value from line: " << line;
+    return false;   // no value
+  }
+  string values_string(remains,
+                       begin_values_pos,
+                       remains.size() - begin_values_pos);
+
+  // construct the values vector
+  if (value_value_delimiters.empty()) {  // one value
+    values->push_back(values_string);
+  } else {                               // multiple values
+    SplitStringUsing(values_string, value_value_delimiters.c_str(), values);
+    if (values->size() < 1) {
+      VLOG(1) << "cannot parse value from line: " << line;
+      return false;  // no value
+    }
+  }
+  return true;
+}
+
+bool SplitStringIntoKeyValuePairs(const string& line,
+                                  const string& key_value_delimiters,
+                                  const string& key_value_pair_delimiters,
+                                  vector<pair<string, string> >* kv_pairs) {
+  kv_pairs->clear();
+
+  vector<string> pairs;
+  SplitStringUsing(line, key_value_pair_delimiters.c_str(), &pairs);
+
+  bool success = true;
+  for (const auto& pair : pairs) {
+    string key;
+    vector<string> value;
+    if (!SplitStringIntoKeyValues(pair,
+                                  key_value_delimiters,
+                                  "", &key, &value)) {
+      // Don't return here, to allow for keys without associated
+      // values; just record that our split failed.
+      success = false;
+    }
+    // we expect atmost one value because we passed in an empty vsep to
+    // SplitStringIntoKeyValues
+    DCHECK_LE(value.size(), 1);
+    kv_pairs->push_back(make_pair(key, value.empty()? "" : value[0]));
+  }
+  return success;
+}
+
+// ----------------------------------------------------------------------
+// SplitLeadingDec32Values()
+// SplitLeadingDec64Values()
+//    A simple parser for space-separated decimal int32/int64 values.
+//    Appends parsed integers to the end of the result vector, stopping
+//    at the first unparsable spot.  Skips past leading and repeated
+//    whitespace (does not consume trailing whitespace), and returns
+//    a pointer beyond the last character parsed.
+// --------------------------------------------------------------------
+const char* SplitLeadingDec32Values(const char *str, vector<int32> *result) {
+  for (;;) {
+    char *end = nullptr;
+    long value = strtol(str, &end, 10);
+    if (end == str)
+      break;
+    // Limit long values to int32 min/max.  Needed for lp64.
+    if (value > numeric_limits<int32>::max()) {
+      value = numeric_limits<int32>::max();
+    } else if (value < numeric_limits<int32>::min()) {
+      value = numeric_limits<int32>::min();
+    }
+    result->push_back(value);
+    str = end;
+    if (!ascii_isspace(*end))
+      break;
+  }
+  return str;
+}
+
+const char* SplitLeadingDec64Values(const char *str, vector<int64> *result) {
+  for (;;) {
+    char *end = nullptr;
+    const int64 value = strtoll(str, &end, 10);
+    if (end == str)
+      break;
+    result->push_back(value);
+    str = end;
+    if (!ascii_isspace(*end))
+      break;
+  }
+  return str;
+}
+
+void SplitStringToLines(const char* full,
+                        int max_len,
+                        int num_lines,
+                        vector<string>* result) {
+  if (max_len <= 0) {
+    return;
+  }
+  int pos = 0;
+  for (int i = 0; (i < num_lines || num_lines <= 0); i++) {
+    int cut_at = ClipStringHelper(full+pos, max_len, (i == num_lines - 1));
+    if (cut_at == -1) {
+      result->push_back(string(full+pos));
+      return;
+    }
+    result->push_back(string(full+pos, cut_at));
+    if (i == num_lines - 1 && max_len > kCutStrSize) {
+      result->at(i).append(kCutStr);
+    }
+    pos += cut_at;
+  }
+}

--- a/be/src/gutil/strings/split.h
+++ b/be/src/gutil/strings/split.h
@@ -1,0 +1,1205 @@
+// Copyright 2008 and onwards Google, Inc.
+//
+// #status: RECOMMENDED
+// #category: operations on strings
+// #summary: Functions for splitting strings into substrings.
+//
+// This file contains functions for splitting strings. The new and recommended
+// API for string splitting is the strings::Split() function. The old API is a
+// large collection of standalone functions declared at the bottom of this file
+// in the global scope.
+//
+// TODO(user): Rough migration plan from old API to new API
+// (1) Add comments to old Split*() functions showing how to do the same things
+//     with the new API.
+// (2) Reimplement some of the old Split*() functions in terms of the new
+//     Split() API. This will allow deletion of code in split.cc.
+// (3) (Optional) Replace old Split*() API calls at call sites with calls to new
+//     Split() API.
+//
+#ifndef STRINGS_SPLIT_H_
+#define STRINGS_SPLIT_H_
+
+#include <stddef.h>
+#include <algorithm>
+using std::copy;
+using std::max;
+using std::min;
+using std::reverse;
+using std::sort;
+using std::swap;
+#include <iterator>
+using std::back_insert_iterator;
+using std::iterator_traits;
+#include <map>
+using std::map;
+using std::multimap;
+#include <set>
+using std::multiset;
+using std::set;
+#include <string>
+using std::string;
+#include <utility>
+using std::make_pair;
+using std::pair;
+#include <vector>
+using std::vector;
+#include <unordered_map>
+#include <unordered_set>
+
+#include <common/logging.h>
+
+#include "gutil/integral_types.h"
+#include "gutil/logging-inl.h"
+#include "gutil/strings/charset.h"
+#include "gutil/strings/split_internal.h"
+#include "gutil/strings/stringpiece.h"
+#include "gutil/strings/strip.h"
+
+namespace strings {
+
+//                              The new Split API
+//                                  aka Split2
+//                              aka strings::Split()
+//
+// This string splitting API consists of a Split() function in the ::strings
+// namespace and a handful of delimiter objects in the ::strings::delimiter
+// namespace (more on delimiter objects below). The Split() function always
+// takes two arguments: the text to be split and the delimiter on which to split
+// the text. An optional third argument may also be given, which is a Predicate
+// functor that will be used to filter the results, e.g., to skip empty strings
+// (more on predicates below). The Split() function adapts the returned
+// collection to the type specified by the caller.
+//
+// Example 1:
+//   // Splits the given string on commas. Returns the results in a
+//   // vector of strings.
+//   vector<string> v = strings::Split("a,b,c", ",");
+//   assert(v.size() == 3);
+//
+// Example 2:
+//   // By default, empty strings are *included* in the output. See the
+//   // strings::SkipEmpty predicate below to omit them.
+//   vector<string> v = strings::Split("a,b,,c", ",");
+//   assert(v.size() == 4);  // "a", "b", "", "c"
+//   v = strings::Split("", ",");
+//   assert(v.size() == 1);  // v contains a single ""
+//
+// Example 3:
+//   // Splits the string as in the previous example, except that the results
+//   // are returned as StringPiece objects. Note that because we are storing
+//   // the results within StringPiece objects, we have to ensure that the input
+//   // string outlives any results.
+//   vector<StringPiece> v = strings::Split("a,b,c", ",");
+//   assert(v.size() == 3);
+//
+// Example 4:
+//   // Stores results in a set<string>.
+//   set<string> a = strings::Split("a,b,c,a,b,c", ",");
+//   assert(a.size() == 3);
+//
+// Example 5:
+//   // Stores results in a map. The map implementation assumes that the input
+//   // is provided as a series of key/value pairs. For example, the 0th element
+//   // resulting from the split will be stored as a key to the 1st element. If
+//   // an odd number of elements are resolved, the last element is paired with
+//   // a default-constructed value (e.g., empty string).
+//   map<string, string> m = strings::Split("a,b,c", ",");
+//   assert(m.size() == 2);
+//   assert(m["a"] == "b");
+//   assert(m["c"] == "");  // last component value equals ""
+//
+// Example 6:
+//   // Splits on the empty string, which results in each character of the input
+//   // string becoming one element in the output collection.
+//   vector<string> v = strings::Split("abc", "");
+//   assert(v.size() == 3);
+//
+// Example 7:
+//   // Stores first two split strings as the members in an std::pair.
+//   std::pair<string, string> p = strings::Split("a,b,c", ",");
+//   EXPECT_EQ("a", p.first);
+//   EXPECT_EQ("b", p.second);
+//   // "c" is omitted because std::pair can hold only two elements.
+//
+// As illustrated above, the Split() function adapts the returned collection to
+// the type specified by the caller. The returned collections may contain
+// string, StringPiece, Cord, or any object that has a constructor (explicit or
+// not) that takes a single StringPiece argument. This pattern works for all
+// standard STL containers including vector, list, deque, set, multiset, map,
+// multimap, unordered_set and unordered_map, and even std::pair which is not
+// actually a container.
+//
+// Splitting to std::pair is an interesting case because it can hold only two
+// elements and is not a collection type. When splitting to an std::pair the
+// first two split strings become the std::pair's .first and .second members
+// respectively. The remaining split substrings are discarded. If there are less
+// than two split substrings, the empty string is used for the corresponding
+// std::pair member.
+//
+// The strings::Split() function can be used multiple times to perform more
+// complicated splitting logic, such as intelligently parsing key-value pairs.
+// For example
+//
+//   // The input string "a=b=c,d=e,f=,g" becomes
+//   // { "a" => "b=c", "d" => "e", "f" => "", "g" => "" }
+//   map<string, string> m;
+//   for (StringPiece sp : strings::Split("a=b=c,d=e,f=,g", ",")) {
+//     m.insert(strings::Split(sp, strings::delimiter::Limit("=", 1)));
+//   }
+//   EXPECT_EQ("b=c", m.find("a")->second);
+//   EXPECT_EQ("e", m.find("d")->second);
+//   EXPECT_EQ("", m.find("f")->second);
+//   EXPECT_EQ("", m.find("g")->second);
+//
+// The above example stores the results in an std::map. But depending on your
+// data requirements, you can just as easily store the results in an
+// std::multimap or even a vector<std::pair<>>.
+//
+//
+//                                  Delimiters
+//
+// The Split() function also takes a second argument that is a delimiter. This
+// delimiter is actually an object that defines the boundaries between elements
+// in the provided input. If a string (const char*, ::string, or StringPiece) is
+// passed in place of an explicit Delimiter object, the argument is implicitly
+// converted to a ::strings::delimiter::Literal.
+//
+// With this split API comes the formal concept of a Delimiter (big D). A
+// Delimiter is an object with a Find() function that knows how find the first
+// occurrence of itself in a given StringPiece. Models of the Delimiter concept
+// represent specific kinds of delimiters, such as single characters,
+// substrings, or even regular expressions.
+//
+// The following Delimiter objects are provided as part of the Split() API:
+//
+//   - Literal (default)
+//   - AnyOf
+//   - Limit
+//
+// The following are examples of using some provided Delimiter objects:
+//
+// Example 1:
+//   // Because a string literal is converted to a strings::delimiter::Literal,
+//   // the following two splits are equivalent.
+//   vector<string> v1 = strings::Split("a,b,c", ",");           // (1)
+//   using ::strings::delimiter::Literal;
+//   vector<string> v2 = strings::Split("a,b,c", Literal(","));  // (2)
+//
+// Example 2:
+//   // Splits on any of the characters specified in the delimiter string.
+//   using ::strings::delimiter::AnyOf;
+//   vector<string> v = strings::Split("a,b;c-d", AnyOf(",;-"));
+//   assert(v.size() == 4);
+//
+// Example 3:
+//   // Uses the Limit meta-delimiter to limit the number of matches a delimiter
+//   // can have. In this case, the delimiter of a Literal comma is limited to
+//   // to matching at most one time. The last element in the returned
+//   // collection will contain all unsplit pieces, which may contain instances
+//   // of the delimiter.
+//   using ::strings::delimiter::Limit;
+//   vector<string> v = strings::Split("a,b,c", Limit(",", 1));
+//   assert(v.size() == 2);  // Limited to 1 delimiter; so two elements found
+//   assert(v[0] == "a");
+//   assert(v[1] == "b,c");
+//
+//
+//                                  Predicates
+//
+// Predicates can filter the results of a Split() operation by determining
+// whether or not a resultant element is included in the result set. A predicate
+// may be passed as an *optional* third argument to the Split() function.
+//
+// Predicates are unary functions (or functors) that take a single StringPiece
+// argument and return bool indicating whether the argument should be included
+// (true) or excluded (false).
+//
+// One example where this is useful is when filtering out empty substrings. By
+// default, empty substrings may be returned by strings::Split(), which is
+// similar to the way split functions work in other programming languages. For
+// example:
+//
+//   // Empty strings *are* included in the returned collection.
+//   vector<string> v = strings::Split(",a,,b,", ",");
+//   assert(v.size() ==  5);  // v[0] == "", v[1] == "a", v[2] == "", ...
+//
+// These empty strings can be filtered out of the results by simply passing the
+// provided SkipEmpty predicate as the third argument to the Split() function.
+// SkipEmpty does not consider a string containing all whitespace to be empty.
+// For that behavior use the SkipWhitespace predicate. For example:
+//
+// Example 1:
+//   // Uses SkipEmpty to omit empty strings. Strings containing whitespace are
+//   // not empty and are therefore not skipped.
+//   using strings::SkipEmpty;
+//   vector<string> v = strings::Split(",a, ,b,", ",", SkipEmpty());
+//   assert(v.size() == 3);
+//   assert(v[0] == "a");
+//   assert(v[1] == " ");  // <-- The whitespace makes the string not empty.
+//   assert(v[2] == "b");
+//
+// Example 2:
+//   // Uses SkipWhitespace to skip all strings that are either empty or contain
+//   // only whitespace.
+//   using strings::SkipWhitespace;
+//   vector<string> v = strings::Split(",a, ,b,", ",",  SkipWhitespace());
+//   assert(v.size() == 2);
+//   assert(v[0] == "a");
+//   assert(v[1] == "b");
+//
+//
+//                     Differences between Split1 and Split2
+//
+// Split2 is the strings::Split() API described above. Split1 is a name for the
+// collection of legacy Split*() functions declared later in this file. Most of
+// the Split1 functions follow a set of conventions that don't necessarily match
+// the conventions used in Split2. The following are some of the important
+// differences between Split1 and Split2:
+//
+// Split1 -> Split2
+// ----------------
+// Append -> Assign:
+//   The Split1 functions all returned their output collections via a pointer to
+//   an out parameter as is typical in Google code. In some cases the comments
+//   explicitly stated that results would be *appended* to the output
+//   collection. In some cases it was ambiguous whether results were appended.
+//   This ambiguity is gone in the Split2 API as results are always assigned to
+//   the output collection, never appended.
+//
+// AnyOf -> Literal:
+//   Most Split1 functions treated their delimiter argument as a string of
+//   individual byte delimiters. For example, a delimiter of ",;" would split on
+//   "," and ";", not the substring ",;". This behavior is equivalent to the
+//   Split2 delimiter strings::delimiter::AnyOf, which is *not* the default. By
+//   default, strings::Split() splits using strings::delimiter::Literal() which
+//   would treat the whole string ",;" as a single delimiter string.
+//
+// SkipEmpty -> allow empty:
+//   Most Split1 functions omitted empty substrings in the results. To keep
+//   empty substrings one would have to use an explicitly named
+//   Split*AllowEmpty() function. This behavior is reversed in Split2. By
+//   default, strings::Split() *allows* empty substrings in the output. To skip
+//   them, use the strings::SkipEmpty predicate.
+//
+// string -> user's choice:
+//   Most Split1 functions return collections of string objects. Some return
+//   char*, but the type returned is dictated by each Split1 function. With
+//   Split2 the caller can choose which string-like object to return. (Note:
+//   char* C-strings are not supported in Split2--use StringPiece instead).
+//
+
+// Definitions of the main Split() function.
+template <typename Delimiter>
+inline internal::Splitter<Delimiter> Split(StringPiece text, Delimiter d) {
+  return internal::Splitter<Delimiter>(text, d);
+}
+
+template <typename Delimiter, typename Predicate>
+inline internal::Splitter<Delimiter, Predicate> Split(
+    StringPiece text, Delimiter d, Predicate p) {
+  return internal::Splitter<Delimiter, Predicate>(text, d, p);
+}
+
+namespace delimiter {
+// A Delimiter object represents a single separator, such as a character,
+// literal string, or regular expression. A Delimiter object must have the
+// following member:
+//
+//   StringPiece Find(StringPiece text);
+//
+// This Find() member function should return a StringPiece referring to the next
+// occurrence of the represented delimiter within the given string text. If no
+// delimiter is found in the given text, a zero-length StringPiece referring to
+// text.end() should be returned (e.g., StringPiece(text.end(), 0)). It is
+// important that the returned StringPiece always be within the bounds of the
+// StringPiece given as an argument--it must not refer to a string that is
+// physically located outside of the given string. The following example is a
+// simple Delimiter object that is created with a single char and will look for
+// that char in the text given to the Find() function:
+//
+//   struct SimpleDelimiter {
+//     const char c_;
+//     explicit SimpleDelimiter(char c) : c_(c) {}
+//     StringPiece Find(StringPiece text) {
+//       int pos = text.find(c_);
+//       if (pos == StringPiece::npos) return StringPiece(text.end(), 0);
+//       return StringPiece(text, pos, 1);
+//     }
+//   };
+
+// Represents a literal string delimiter. Examples:
+//
+//   using ::strings::delimiter::Literal;
+//   vector<string> v = strings::Split("a=>b=>c", Literal("=>"));
+//   assert(v.size() == 3);
+//   assert(v[0] == "a");
+//   assert(v[1] == "b");
+//   assert(v[2] == "c");
+//
+// The next example uses the empty string as a delimiter.
+//
+//   using ::strings::delimiter::Literal;
+//   vector<string> v = strings::Split("abc", Literal(""));
+//   assert(v.size() == 3);
+//   assert(v[0] == "a");
+//   assert(v[1] == "b");
+//   assert(v[2] == "c");
+//
+class Literal {
+ public:
+  explicit Literal(StringPiece sp);
+  StringPiece Find(StringPiece text) const;
+
+ private:
+  const string delimiter_;
+};
+
+// Represents a delimiter that will match any of the given byte-sized
+// characters. AnyOf is similar to Literal, except that AnyOf uses
+// StringPiece::find_first_of() and Literal uses StringPiece::find(). AnyOf
+// examples:
+//
+//   using ::strings::delimiter::AnyOf;
+//   vector<string> v = strings::Split("a,b=c", AnyOf(",="));
+//
+//   assert(v.size() == 3);
+//   assert(v[0] == "a");
+//   assert(v[1] == "b");
+//   assert(v[2] == "c");
+//
+// If AnyOf is given the empty string, it behaves exactly like Literal and
+// matches each individual character in the input string.
+//
+// Note: The string passed to AnyOf is assumed to be a string of single-byte
+// ASCII characters. AnyOf does not work with multi-byte characters.
+class AnyOf {
+ public:
+  explicit AnyOf(StringPiece sp);
+  StringPiece Find(StringPiece text) const;
+
+ private:
+  const string delimiters_;
+};
+
+// Wraps another delimiter and sets a max number of matches for that delimiter.
+// Create LimitImpls using the Limit() function. Example:
+//
+//   using ::strings::delimiter::Limit;
+//   vector<string> v = strings::Split("a,b,c,d", Limit(",", 2));
+//
+//   assert(v.size() == 3);  // Split on 2 commas, giving a vector with 3 items
+//   assert(v[0] == "a");
+//   assert(v[1] == "b");
+//   assert(v[2] == "c,d");
+//
+template <typename Delimiter>
+class LimitImpl {
+ public:
+  LimitImpl(Delimiter delimiter, int limit)
+      : delimiter_(std::move(delimiter)), limit_(limit), count_(0) {}
+  StringPiece Find(StringPiece text) {
+    if (count_++ == limit_) {
+      return StringPiece(text.end(), 0);  // No more matches.
+    }
+    return delimiter_.Find(text);
+  }
+
+ private:
+  Delimiter delimiter_;
+  const int limit_;
+  int count_;
+};
+
+// Overloaded Limit() function to create LimitImpl<> objects. Uses the Delimiter
+// Literal as the default if string-like objects are passed as the delimiter
+// parameter. This is similar to the overloads for Split() below.
+template <typename Delimiter>
+inline LimitImpl<Delimiter> Limit(Delimiter delim, int limit) {
+  return LimitImpl<Delimiter>(delim, limit);
+}
+
+inline LimitImpl<Literal> Limit(const char* s, int limit) {
+  return LimitImpl<Literal>(Literal(s), limit);
+}
+
+inline LimitImpl<Literal> Limit(const string& s, int limit) {
+  return LimitImpl<Literal>(Literal(s), limit);
+}
+
+inline LimitImpl<Literal> Limit(StringPiece s, int limit) {
+  return LimitImpl<Literal>(Literal(s), limit);
+}
+
+}  // namespace delimiter
+
+//
+// Predicates are functors that return bool indicating whether the given
+// StringPiece should be included in the split output. If the predicate returns
+// false then the string will be excluded from the output from strings::Split().
+//
+
+// Always returns true, indicating that all strings--including empty
+// strings--should be included in the split output. This predicate is not
+// strictly needed because this is the default behavior of the strings::Split()
+// function. But it might be useful at some call sites to make the intent
+// explicit.
+//
+// vector<string> v = Split(" a , ,,b,", ",", AllowEmpty());
+// EXPECT_THAT(v, ElementsAre(" a ", " ", "", "b", ""));
+struct AllowEmpty {
+  bool operator()(StringPiece sp) const {
+    return true;
+  }
+};
+
+// Returns false if the given StringPiece is empty, indicating that the
+// strings::Split() API should omit the empty string.
+//
+// vector<string> v = Split(" a , ,,b,", ",", SkipEmpty());
+// EXPECT_THAT(v, ElementsAre(" a ", " ", "b"));
+struct SkipEmpty {
+  bool operator()(StringPiece sp) const {
+    return !sp.empty();
+  }
+};
+
+// Returns false if the given StringPiece is empty or contains only whitespace,
+// indicating that the strings::Split() API should omit the string.
+//
+// vector<string> v = Split(" a , ,,b,", ",", SkipWhitespace());
+// EXPECT_THAT(v, ElementsAre(" a ", "b"));
+struct SkipWhitespace {
+  bool operator()(StringPiece sp) const {
+    StripWhiteSpace(&sp);
+    return !sp.empty();
+  }
+};
+
+// Split() function overloads to effectively give Split() a default Delimiter
+// type of Literal. If Split() is called and a string is passed as the delimiter
+// instead of an actual Delimiter object, then one of these overloads will be
+// invoked and will create a Splitter<Literal> with the delimiter string.
+//
+// Since Split() is a function template above, these overload signatures need to
+// be explicit about the string type so they match better than the templated
+// version. These functions are overloaded for:
+//
+//   - const char*
+//   - const string&
+//   - StringPiece
+
+inline internal::Splitter<delimiter::Literal> Split(
+    StringPiece text, const char* delimiter) {
+  return internal::Splitter<delimiter::Literal>(
+      text, delimiter::Literal(delimiter));
+}
+
+inline internal::Splitter<delimiter::Literal> Split(
+    StringPiece text, const string& delimiter) {
+  return internal::Splitter<delimiter::Literal>(
+      text, delimiter::Literal(delimiter));
+}
+
+inline internal::Splitter<delimiter::Literal> Split(
+    StringPiece text, StringPiece delimiter) {
+  return internal::Splitter<delimiter::Literal>(
+      text, delimiter::Literal(delimiter));
+}
+
+// Same overloads as above, but also including a Predicate argument.
+template <typename Predicate>
+inline internal::Splitter<delimiter::Literal, Predicate> Split(
+    StringPiece text, const char* delimiter, Predicate p) {
+  return internal::Splitter<delimiter::Literal, Predicate>(
+      text, delimiter::Literal(delimiter), p);
+}
+
+template <typename Predicate>
+inline internal::Splitter<delimiter::Literal, Predicate> Split(
+    StringPiece text, const string& delimiter, Predicate p) {
+  return internal::Splitter<delimiter::Literal, Predicate>(
+      text, delimiter::Literal(delimiter), p);
+}
+
+template <typename Predicate>
+inline internal::Splitter<delimiter::Literal, Predicate> Split(
+    StringPiece text, StringPiece delimiter, Predicate p) {
+  return internal::Splitter<delimiter::Literal, Predicate>(
+      text, delimiter::Literal(delimiter), p);
+}
+
+}  // namespace strings
+
+//
+// ==================== LEGACY SPLIT FUNCTIONS ====================
+//
+
+// NOTE: The instruction below creates a Module titled
+// GlobalSplitFunctions within the auto-generated Doxygen documentation.
+// This instruction is needed to expose global functions that are not
+// within a namespace.
+//
+// START DOXYGEN SplitFunctions grouping
+/* @defgroup SplitFunctions
+ * @{ */
+
+// ----------------------------------------------------------------------
+// ClipString
+//    Clip a string to a max length. We try to clip on a word boundary
+//    if this is possible. If the string is clipped, we append an
+//    ellipsis.
+//
+//    ***NOTE***
+//    ClipString counts length with strlen.  If you have non-ASCII
+//    strings like UTF-8, this is wrong.  If you are displaying the
+//    clipped strings to users in a frontend, consider using
+//    ClipStringOnWordBoundary in
+//    webserver/util/snippets/rewriteboldtags, which considers the width
+//    of the string, not just the number of bytes.
+//
+//    TODO(user) Move ClipString back to strutil.  The problem with this is
+//    that ClipStringHelper is used behind the scenes by SplitStringToLines, but
+//    probably shouldn't be exposed in the .h files.
+// ----------------------------------------------------------------------
+void ClipString(char* str, int max_len);
+
+// ----------------------------------------------------------------------
+// ClipString
+//    Version of ClipString() that uses string instead of char*.
+//    NOTE: See comment above.
+// ----------------------------------------------------------------------
+void ClipString(string* full_str, int max_len);
+
+// ----------------------------------------------------------------------
+// SplitStringToLines() Split a string into lines of maximum length
+// 'max_len'. Append the resulting lines to 'result'. Will attempt
+// to split on word boundaries.  If 'num_lines'
+// is zero it splits up the whole string regardless of length. If
+// 'num_lines' is positive, it returns at most num_lines lines, and
+// appends a "..." to the end of the last line if the string is too
+// long to fit completely into 'num_lines' lines.
+// ----------------------------------------------------------------------
+void SplitStringToLines(const char* full,
+                        int max_len,
+                        int num_lines,
+                        vector<string>* result);
+
+// ----------------------------------------------------------------------
+// SplitOneStringToken()
+//   Returns the first "delim" delimited string from "*source" and modifies
+//   *source to point after the delimiter that was found. If no delimiter is
+//   found, *source is set to NULL.
+//
+//   If the start of *source is a delimiter, an empty string is returned.
+//   If *source is NULL, an empty string is returned.
+//
+//   "delim" is treated as a sequence of 1 or more character delimiters. Any one
+//   of the characters present in "delim" is considered to be a single
+//   delimiter; The delimiter is not "delim" as a whole. For example:
+//
+//     const char* s = "abc=;de";
+//     string r = SplitOneStringToken(&s, ";=");
+//     // r = "abc"
+//     // s points to ";de"
+// ----------------------------------------------------------------------
+string SplitOneStringToken(const char** source, const char* delim);
+
+// ----------------------------------------------------------------------
+// SplitUsing()
+//    Split a string into substrings based on the nul-terminated list
+//    of bytes at delimiters (uses strsep) and return a vector of
+//    those strings. Modifies 'full' We allocate the return vector,
+//    and you should free it.  Note that empty fields are ignored.
+//    Use SplitToVector with last argument 'false' if you want the
+//    empty fields.
+//    ----------------------------------------------------------------------
+vector<char*>* SplitUsing(char* full, const char* delimiters);
+
+// ----------------------------------------------------------------------
+// SplitToVector()
+//    Split a string into substrings based on the nul-terminated list
+//    of bytes at delim (uses strsep) and appends the split
+//    strings to 'vec'.  Modifies "full".  If omit empty strings is
+//    true, empty strings are omitted from the resulting vector.
+// ----------------------------------------------------------------------
+void SplitToVector(char* full, const char* delimiters,
+                   vector<char*>* vec,
+                   bool omit_empty_strings);
+void SplitToVector(char* full, const char* delimiters,
+                   vector<const char*>* vec,
+                   bool omit_empty_strings);
+
+// ----------------------------------------------------------------------
+// SplitStringPieceToVector
+//    Split a StringPiece into sub-StringPieces based on the
+//    nul-terminated list of bytes at delim and appends the
+//    pieces to 'vec'.  If omit empty strings is true, empty strings
+//    are omitted from the resulting vector.
+//    Expects the original string (from which 'full' is derived) to exist
+//    for the full lifespan of 'vec'.
+// ----------------------------------------------------------------------
+void SplitStringPieceToVector(const StringPiece& full,
+                              const char* delim,
+                              vector<StringPiece>* vec,
+                              bool omit_empty_strings);
+
+// ----------------------------------------------------------------------
+// SplitStringUsing()
+// SplitStringToHashsetUsing()
+// SplitStringToSetUsing()
+// SplitStringToMapUsing()
+// SplitStringToHashmapUsing()
+
+// Splits a string using one or more byte delimiters, presented as a
+// nul-terminated c string. Append the components to 'result'. If there are
+// consecutive delimiters, this function skips over all of them: in other words,
+// empty components are dropped. If you want to keep empty components, try
+// SplitStringAllowEmpty().
+//
+// NOTE: Do not use this for multi-byte delimiters such as UTF-8 strings. Use
+// strings::Split() with strings::delimiter::Literal as the delimiter.
+//
+// ==> NEW API: Consider using the new Split API defined above. <==
+// Example:
+//
+//   using strings::SkipEmpty;
+//   using strings::Split;
+//   using strings::delimiter::AnyOf;
+//
+//   vector<string> v = Split(full, AnyOf(delimiter), SkipEmpty());
+//
+// For even better performance, store the result in a vector<StringPiece>
+// to avoid string copies.
+// ----------------------------------------------------------------------
+void SplitStringUsing(const string& full, const char* delimiters,
+                      vector<string>* result);
+void SplitStringToHashsetUsing(const string& full, const char* delimiters,
+                               std::unordered_set<string>* result);
+void SplitStringToSetUsing(const string& full, const char* delimiters,
+                           set<string>* result);
+// The even-positioned (0-based) components become the keys for the
+// odd-positioned components that follow them. When there is an odd
+// number of components, the value for the last key will be unchanged
+// if the key was already present in the hash table, or will be the
+// empty string if the key is a newly inserted key.
+void SplitStringToMapUsing(const string& full, const char* delim,
+                           map<string, string>* result);
+void SplitStringToHashmapUsing(const string& full, const char* delim,
+                               std::unordered_map<string, string>* result);
+
+// ----------------------------------------------------------------------
+// SplitStringAllowEmpty()
+//
+// Split a string using one or more byte delimiters, presented as a
+// nul-terminated c string. Append the components to 'result'. If there are
+// consecutive delimiters, this function will return corresponding empty
+// strings.  If you want to drop the empty strings, try SplitStringUsing().
+//
+// If "full" is the empty string, yields an empty string as the only value.
+//
+// ==> NEW API: Consider using the new Split API defined above. <==
+//
+//   using strings::Split;
+//   using strings::delimiter::AnyOf;
+//
+//   vector<string> v = Split(full, AnyOf(delimiter));
+//
+// For even better performance, store the result in a vector<StringPiece> to
+// avoid string copies.
+// ----------------------------------------------------------------------
+void SplitStringAllowEmpty(const string& full, const char* delim,
+                           vector<string>* result);
+
+// ----------------------------------------------------------------------
+// SplitStringWithEscaping()
+// SplitStringWithEscapingAllowEmpty()
+// SplitStringWithEscapingToSet()
+// SplitStringWithEscapingToHashset()
+
+//   Split the string using the specified delimiters, taking escaping into
+//   account. '\' is not allowed as a delimiter.
+//
+//   Within the string, preserve a delimiter preceded by a backslash as a
+//   literal delimiter. In addition, preserve two consecutive backslashes as
+//   a single literal backslash. Do not unescape any other backslash-character
+//   sequence.
+//
+//   Eg. 'foo\=bar=baz\\qu\ux' split on '=' becomes ('foo=bar', 'baz\qu\ux')
+//
+//   All versions other than "AllowEmpty" discard any empty substrings.
+// ----------------------------------------------------------------------
+void SplitStringWithEscaping(const string& full,
+                             const strings::CharSet& delimiters,
+                             vector<string>* result);
+void SplitStringWithEscapingAllowEmpty(const string& full,
+                                       const strings::CharSet& delimiters,
+                                       vector<string>* result);
+void SplitStringWithEscapingToSet(const string& full,
+                                  const strings::CharSet& delimiters,
+                                  set<string>* result);
+void SplitStringWithEscapingToHashset(const string& full,
+                                      const strings::CharSet& delimiters,
+                                      std::unordered_set<string>* result);
+
+// ----------------------------------------------------------------------
+// SplitStringIntoNPiecesAllowEmpty()
+
+//    Split a string using a nul-terminated list of byte
+//    delimiters. Append the components to 'result'.  If there are
+//    consecutive delimiters, this function will return corresponding
+//    empty strings. The string is split into at most the specified
+//    number of pieces greedily. This means that the last piece may
+//    possibly be split further. To split into as many pieces as
+//    possible, specify 0 as the number of pieces.
+//
+//    If "full" is the empty string, yields an empty string as the only value.
+// ----------------------------------------------------------------------
+void SplitStringIntoNPiecesAllowEmpty(const string& full,
+                                      const char* delimiters,
+                                      int pieces,
+                                      vector<string>* result);
+
+// ----------------------------------------------------------------------
+// SplitStringAndParse()
+// SplitStringAndParseToContainer()
+// SplitStringAndParseToList()
+//    Split a string using a nul-terminated list of character
+//    delimiters.  For each component, parse using the provided
+//    parsing function and if successful, append it to 'result'.
+//    Return true if and only if all components parse successfully.
+//    If there are consecutive delimiters, this function skips over
+//    all of them.  This function will correctly handle parsing
+//    strings that have embedded \0s.
+//
+// SplitStringAndParse fills into a vector.
+// SplitStringAndParseToContainer fills into any container that implements
+//    a single-argument insert function. (i.e. insert(const value_type& x) ).
+// SplitStringAndParseToList fills into any container that implements a single-
+//    argument push_back function (i.e. push_back(const value_type& x) ), plus
+//    value_type& back() and pop_back().
+//    NOTE: This implementation relies on parsing in-place into the "back()"
+//    reference, so its performance may depend on the efficiency of back().
+//
+// Example Usage:
+//  vector<double> values;
+//  CHECK(SplitStringAndParse("1.0,2.0,3.0", ",", &safe_strtod, &values));
+//  CHECK_EQ(3, values.size());
+//
+//  vector<int64> values;
+//  CHECK(SplitStringAndParse("1M,2M,3M", ",",
+//        &HumanReadableNumBytes::ToInt64, &values));
+//  CHECK_EQ(3, values.size());
+//
+//  set<int64> values;
+//  CHECK(SplitStringAndParseToContainer("3,1,1,2", ",",
+//        &safe_strto64, &values));
+//  CHECK_EQ(4, values.size());
+//
+//  deque<int64> values;
+//  CHECK(SplitStringAndParseToList("3,1,1,2", ",", &safe_strto64, &values));
+//  CHECK_EQ(4, values.size());
+// ----------------------------------------------------------------------
+template <class T>
+bool SplitStringAndParse(StringPiece source, StringPiece delim,
+                         bool (*parse)(const string& str, T* value),
+                         vector<T>* result);
+template <class Container>
+bool SplitStringAndParseToContainer(
+    StringPiece source, StringPiece delim,
+    bool (*parse)(const string& str, typename Container::value_type* value),
+    Container* result);
+
+template <class List>
+bool SplitStringAndParseToList(
+    StringPiece source, StringPiece delim,
+    bool (*parse)(const string& str, typename List::value_type* value),
+    List* result);
+// ----------------------------------------------------------------------
+// SplitRange()
+//    Splits a string of the form "<from>-<to>".  Either or both can be
+//    missing.  A raw number (<to>) is interpreted as "<to>-".  Modifies
+//    parameters insofar as they're specified by the string.  RETURNS
+//    true iff the input is a well-formed range.  If it RETURNS false,
+//    from and to remain unchanged.  The range in rangestr should be
+//    terminated either by "\0" or by whitespace.
+// ----------------------------------------------------------------------
+bool SplitRange(const char* rangestr, int* from, int* to);
+
+// ----------------------------------------------------------------------
+// SplitCSVLineWithDelimiter()
+//    CSV lines come in many guises.  There's the Comma Separated Values
+//    variety, in which fields are separated by (surprise!) commas.  There's
+//    also the tab-separated values variant, in which tabs separate the
+//    fields.  This routine handles both, which makes it almost like
+//    SplitUsing(line, delimiter), but for some special processing.  For both
+//    delimiters, whitespace is trimmed from either side of the field value.
+//    If the delimiter is ',', we play additional games with quotes.  A
+//    field value surrounded by double quotes is allowed to contain commas,
+//    which are not treated as field separators.  Within a double-quoted
+//    string, a series of two double quotes signals an escaped single double
+//    quote.  It'll be clearer in the examples.
+//    Example:
+//     Google , x , "Buchheit, Paul", "string with "" quote in it"
+//     -->  [Google], [x], [Buchheit, Paul], [string with " quote in it]
+//
+// SplitCSVLine()
+//    A convenience wrapper around SplitCSVLineWithDelimiter which uses
+//    ',' as the delimiter.
+//
+// The following variants of SplitCSVLine() are not recommended for new code.
+// Please consider the CSV parser in //util/csv as an alternative.  Examples:
+// To parse a single line:
+//     #include "util/csv/parser.h"
+//     vector<string> fields = util::csv::ParseLine(line).fields();
+//
+// To parse an entire file:
+//     #include "util/csv/parser.h"
+//     for (Record rec : Parser(source)) {
+//       vector<string> fields = rec.fields();
+//     }
+//
+// See //util/csv/parser.h for more complete documentation.
+//
+// ----------------------------------------------------------------------
+void SplitCSVLine(char* line, vector<char*>* cols);
+void SplitCSVLineWithDelimiter(char* line, char delimiter,
+                               vector<char*>* cols);
+// SplitCSVLine string wrapper that internally makes a copy of string line.
+void SplitCSVLineWithDelimiterForStrings(const string& line, char delimiter,
+                                         vector<string>* cols);
+
+// ----------------------------------------------------------------------
+// SplitStructuredLine()
+//    Splits a line using the given delimiter, and places the columns
+//    into 'cols'. This is unlike 'SplitUsing(line, ",")' because you can
+//    define pairs of opening closing symbols inside which the delimiter should
+//    be ignored. If the symbol_pair string has an odd number of characters,
+//    the last character (which cannot be paired) will be assumed to be both an
+//    opening and closing symbol.
+//    WARNING : The input string 'line' is destroyed in the process.
+//    The function returns 0 if the line was parsed correctly (i.e all the
+//    opened braces had their closing braces) otherwise, it returns the position
+//    of the error.
+//    Example:
+//     SplitStructuredLine("item1,item2,{subitem1,subitem2},item4,[5,{6,7}]",
+//                         ',',
+//                         "{}[]", &output)
+//     --> output = { "item1", "item2", "{subitem1,subitem2}", "item4",
+//                    "[5,{6,7}]" }
+//    Example2: trying to split "item1,[item2,{4,5],5}" will fail and the
+//              function will return the position of the problem : ]
+//
+// ----------------------------------------------------------------------
+char* SplitStructuredLine(char* line,
+                          char delimiter,
+                          const char* symbol_pairs,
+                          vector<char*>* cols);
+
+// Similar to the function with the same name above, but splits a StringPiece
+// into StringPiece parts. Returns true if successful.
+bool SplitStructuredLine(StringPiece line,
+                         char delimiter,
+                         const char* symbol_pairs,
+                         vector<StringPiece>* cols);
+
+// ----------------------------------------------------------------------
+// SplitStructuredLineWithEscapes()
+//    Like SplitStructuredLine but also allows characters to be escaped.
+//
+//    WARNING: the escape characters will be replicated in the output
+//    columns rather than being consumed, i.e. if {} were the opening and
+//    closing symbols, using \{ to quote a curly brace in the middle of
+//    an option would pass this unchanged.
+//
+//    Example:
+//     SplitStructuredLineWithEscapes(
+//       "\{item1\},it\\em2,{\{subitem1\},sub\\item2},item4\,item5,[5,{6,7}]",
+//                     ',',
+//                     "{}[]",
+//                     &output)
+//     --> output = { "\{item1\}", "it\\em2", "{\{subitem1\},sub\\item2}",
+//                    "item4\,item5", "[5,{6,7}]" }
+//
+// ----------------------------------------------------------------------
+char* SplitStructuredLineWithEscapes(char* line,
+                                     char delimiter,
+                                     const char* symbol_pairs,
+                                     vector<char*>* cols);
+
+// Similar to the function with the same name above, but splits a StringPiece
+// into StringPiece parts. Returns true if successful.
+bool SplitStructuredLineWithEscapes(StringPiece line,
+                                    char delimiter,
+                                    const char* symbol_pairs,
+                                    vector<StringPiece>* cols);
+
+// ----------------------------------------------------------------------
+// DEPRECATED(jgm): See the "NEW API" comment about this function below for
+// example code showing an alternative.
+//
+// SplitStringIntoKeyValues()
+// Split a line into a key string and a vector of value strings. The line has
+// the following format:
+//
+// <key><kvsep>+<vvsep>*<value1><vvsep>+<value2><vvsep>+<value3>...<vvsep>*
+//
+// where key and value are strings; */+ means zero/one or more; <kvsep> is
+// a delimiter character to separate key and value; and <vvsep> is a delimiter
+// character to separate between values. The user can specify a bunch of
+// delimiter characters using a string. For example, if the user specifies
+// the separator string as "\t ", then either ' ' or '\t' or any combination
+// of them wil be treated as separator. For <vvsep>, the user can specify a
+// empty string to indicate there is only one value.
+//
+// Note: this function assumes the input string begins exactly with a
+// key. Therefore, if you use whitespaces to separate key and value, you
+// should not let whitespace precedes the key in the input. Otherwise, you
+// will get an empty string as the key.
+//
+// A line with no <kvsep> will return an empty string as the key, even if
+// <key> is non-empty!
+//
+// The syntax makes it impossible for a value to be the empty string.
+// It is possible for the number of values to be zero.
+//
+// Returns false if the line has no <kvsep> or if the number of values is
+// zero.
+//
+// ==> NEW API: Consider using the new Split API defined above. <==
+//
+// The SplitStringIntoKeyValues() function has some subtle and surprising
+// semantics in various corner cases. To avoid this the strings::Split API is
+// recommended. The following example shows how to split a string of delimited
+// key-value pairs into a vector of pairs using the strings::Split API.
+//
+//   using strings::Split;
+//   using strings::delimiter::AnyOf;
+//   using strings::delimiter::Limit;
+//
+//   pair<string, StringPiece> key_values =
+//       Split(line, Limit(AnyOf(kv_delim), 1));
+//   string key = key_values.first;
+//   vector<string> values = Split(key_values.second, AnyOf(vv_delim));
+//
+// ----------------------------------------------------------------------
+bool SplitStringIntoKeyValues(const string& line,
+                              const string& key_value_delimiters,
+                              const string& value_value_delimiters,
+                              string* key, vector<string>* values);
+
+// ----------------------------------------------------------------------
+// SplitStringIntoKeyValuePairs()
+// Split a line into a vector of <key, value> pairs. The line has
+// the following format:
+//
+// <kvpsep>*<key1><kvsep>+<value1><kvpsep>+<key2><kvsep>+<value2>...<kvpsep>*
+//
+// Where key and value are strings; */+ means zero/one or more. <kvsep> is
+// a delimiter character to separate key and value and <kvpsep> is a delimiter
+// character to separate key value pairs. The user can specify a bunch of
+// delimiter characters using a string.
+//
+// Note: this function assumes each key-value pair begins exactly with a
+// key. Therefore, if you use whitespaces to separate key and value, you
+// should not let whitespace precede the key in the pair. Otherwise, you
+// will get an empty string as the key.
+//
+// A pair with no <kvsep> will return empty strings as the key and value,
+// even if <key> is non-empty!
+//
+// Returns false for pairs with no <kvsep> specified and for pairs with
+// empty strings as values.
+//
+// ==> NEW API: Consider using the new Split API defined above. <==
+//
+// The SplitStringIntoKeyValuePairs() function has some subtle and surprising
+// semantics in various corner cases. To avoid this the strings::Split API is
+// recommended. The following example shows how to split a string of delimited
+// key-value pairs into a vector of pairs using the strings::Split API.
+//
+//   using strings::SkipEmpty;
+//   using strings::Split;
+//   using strings::delimiter::AnyOf;
+//   using strings::delimiter::Limit;
+//
+//   vector<pair<string, string>> pairs;  // or even map<string, string>
+//   for (StringPiece sp : Split(line, AnyOf(pair_delim), SkipEmpty())) {
+//     pairs.push_back(Split(sp, Limit(AnyOf(kv_delim), 1), SkipEmpty()));
+//   }
+//
+// ----------------------------------------------------------------------
+bool SplitStringIntoKeyValuePairs(const string& line,
+                                  const string& key_value_delimiters,
+                                  const string& key_value_pair_delimiters,
+                                  vector<pair<string, string> >* kv_pairs);
+
+
+// ----------------------------------------------------------------------
+// SplitLeadingDec32Values()
+// SplitLeadingDec64Values()
+//    A simple parser for space-separated decimal int32/int64 values.
+//    Appends parsed integers to the end of the result vector, stopping
+//    at the first unparsable spot.  Skips past leading and repeated
+//    whitespace (does not consume trailing whitespace), and returns
+//    a pointer beyond the last character parsed.
+// --------------------------------------------------------------------
+const char* SplitLeadingDec32Values(const char* next, vector<int32>* result);
+const char* SplitLeadingDec64Values(const char* next, vector<int64>* result);
+
+// ----------------------------------------------------------------------
+// SplitOneIntToken()
+// SplitOneInt32Token()
+// SplitOneUint32Token()
+// SplitOneInt64Token()
+// SplitOneUint64Token()
+// SplitOneDoubleToken()
+// SplitOneFloatToken()
+//   Parse a single "delim" delimited number from "*source" into "*value".
+//   Modify *source to point after the delimiter.
+//   If no delimiter is present after the number, set *source to NULL.
+//
+//   If the start of *source is not an number, return false.
+//   If the int is followed by the null character, return true.
+//   If the int is not followed by a character from delim, return false.
+//   If *source is NULL, return false.
+//
+//   They cannot handle decimal numbers with leading 0s, since they will be
+//   treated as octal.
+// ----------------------------------------------------------------------
+bool SplitOneIntToken(const char** source, const char* delim,
+                      int* value);
+bool SplitOneInt32Token(const char** source, const char* delim,
+                        int32* value);
+bool SplitOneUint32Token(const char** source, const char* delim,
+                         uint32* value);
+bool SplitOneInt64Token(const char** source, const char* delim,
+                        int64* value);
+bool SplitOneUint64Token(const char** source, const char* delim,
+                         uint64* value);
+bool SplitOneDoubleToken(const char** source, const char* delim,
+                         double* value);
+bool SplitOneFloatToken(const char** source, const char* delim,
+                        float* value);
+
+// Some aliases, so that the function names are standardized against the names
+// of the reflection setters/getters in proto2. This makes it easier to use
+// certain macros with reflection when creating custom text formats for protos.
+
+inline bool SplitOneUInt32Token(const char** source, const char* delim,
+                         uint32* value) {
+  return SplitOneUint32Token(source, delim, value);
+}
+
+inline bool SplitOneUInt64Token(const char** source, const char* delim,
+                         uint64* value) {
+  return SplitOneUint64Token(source, delim, value);
+}
+
+// ----------------------------------------------------------------------
+// SplitOneDecimalIntToken()
+// SplitOneDecimalInt32Token()
+// SplitOneDecimalUint32Token()
+// SplitOneDecimalInt64Token()
+// SplitOneDecimalUint64Token()
+// Parse a single "delim"-delimited number from "*source" into "*value".
+// Unlike SplitOneIntToken, etc., this function always interprets
+// the numbers as decimal.
+bool SplitOneDecimalIntToken(const char** source, const char* delim,
+                             int* value);
+bool SplitOneDecimalInt32Token(const char** source, const char* delim,
+                               int32* value);
+bool SplitOneDecimalUint32Token(const char** source, const char* delim,
+                                uint32* value);
+bool SplitOneDecimalInt64Token(const char** source, const char* delim,
+                               int64* value);
+bool SplitOneDecimalUint64Token(const char** source, const char* delim,
+                                uint64* value);
+
+// ----------------------------------------------------------------------
+// SplitOneHexUint32Token()
+// SplitOneHexUint64Token()
+// Once more, for hexadecimal numbers (unsigned only).
+bool SplitOneHexUint32Token(const char** source, const char* delim,
+                            uint32* value);
+bool SplitOneHexUint64Token(const char** source, const char* delim,
+                            uint64* value);
+
+
+// ###################### TEMPLATE INSTANTIATIONS BELOW #######################
+
+// SplitStringAndParse() -- see description above
+template <class T>
+bool SplitStringAndParse(StringPiece source, StringPiece delim,
+                         bool (*parse)(const string& str, T* value),
+                         vector<T>* result) {
+  return SplitStringAndParseToList(source, delim, parse, result);
+}
+
+namespace strings {
+namespace internal {
+
+template <class Container, class InsertPolicy>
+bool SplitStringAndParseToInserter(
+    StringPiece source, StringPiece delim,
+    bool (*parse)(const string& str, typename Container::value_type* value),
+    Container* result, InsertPolicy insert_policy) {
+  CHECK(NULL != parse);
+  CHECK(NULL != result);
+  CHECK(NULL != delim.data());
+  CHECK_GT(delim.size(), 0);
+  bool retval = true;
+  vector<StringPiece> pieces = strings::Split(source,
+                                              strings::delimiter::AnyOf(delim),
+                                              strings::SkipEmpty());
+  for (const auto& piece : pieces) {
+    typename Container::value_type t;
+    if (parse(piece.as_string(), &t)) {
+      insert_policy(result, t);
+    } else {
+      retval = false;
+    }
+  }
+  return retval;
+}
+
+// Cannot use output iterator here (e.g. std::inserter, std::back_inserter)
+// because some callers use non-standard containers that don't have iterators,
+// only an insert() or push_back() method.
+struct BasicInsertPolicy {
+  template <class C, class V>
+  void operator()(C* c, const V& v) const { c->insert(v); }
+};
+
+struct BackInsertPolicy {
+  template <class C, class V>
+  void operator()(C* c, const V& v) const { c->push_back(v); }
+};
+
+}  // namespace internal
+}  // namespace strings
+
+// SplitStringAndParseToContainer() -- see description above
+template <class Container>
+bool SplitStringAndParseToContainer(
+    StringPiece source, StringPiece delim,
+    bool (*parse)(const string& str, typename Container::value_type* value),
+    Container* result) {
+  return strings::internal::SplitStringAndParseToInserter(
+      source, delim, parse, result, strings::internal::BasicInsertPolicy());
+}
+
+// SplitStringAndParseToList() -- see description above
+template <class List>
+bool SplitStringAndParseToList(
+    StringPiece source, StringPiece delim,
+    bool (*parse)(const string& str, typename List::value_type* value),
+    List* result) {
+  return strings::internal::SplitStringAndParseToInserter(
+      source, delim, parse, result, strings::internal::BackInsertPolicy());
+}
+
+// END DOXYGEN SplitFunctions grouping
+/* @} */
+
+#endif  // STRINGS_SPLIT_H_

--- a/be/src/gutil/strings/split_internal.h
+++ b/be/src/gutil/strings/split_internal.h
@@ -1,0 +1,413 @@
+// Copyright 2012 Google Inc. All Rights Reserved.
+//
+// This file declares INTERNAL parts of the Split API that are inline/templated
+// or otherwise need to be available at compile time. The main two abstractions
+// defined in here are
+//
+//   - SplitIterator<>
+//   - Splitter<>
+//
+// Everything else is plumbing for those two.
+//
+// DO NOT INCLUDE THIS FILE DIRECTLY. Use this file by including
+// strings/split.h.
+//
+// IWYU pragma: private, include "strings/split.h"
+
+#ifndef STRINGS_SPLIT_INTERNAL_H_
+#define STRINGS_SPLIT_INTERNAL_H_
+
+#include <iterator>
+using std::back_insert_iterator;
+using std::iterator_traits;
+#include <map>
+using std::map;
+using std::multimap;
+#include <vector>
+using std::vector;
+
+#include "gutil/port.h"  // for LANG_CXX11
+#include "gutil/strings/stringpiece.h"
+
+#ifdef LANG_CXX11
+// This must be included after "base/port.h", which defines LANG_CXX11.
+#include <initializer_list>
+#endif  // LANG_CXX11
+
+namespace strings {
+
+namespace internal {
+
+// The default Predicate object, which doesn't filter out anything.
+struct NoFilter {
+  bool operator()(StringPiece /* ignored */) {
+    return true;
+  }
+};
+
+// This class splits a string using the given delimiter, returning the split
+// substrings via an iterator interface. An optional Predicate functor may be
+// supplied, which will be used to filter the split strings: strings for which
+// the predicate returns false will be skipped. A Predicate object is any
+// functor that takes a StringPiece and returns bool. By default, the NoFilter
+// Predicate is used, which does not filter out anything.
+//
+// This class is NOT part of the public splitting API.
+//
+// Usage:
+//
+//   using strings::delimiter::Literal;
+//   Literal d(",");
+//   for (SplitIterator<Literal> it("a,b,c", d), end(d); it != end; ++it) {
+//     StringPiece substring = *it;
+//     DoWork(substring);
+//   }
+//
+// The explicit single-argument constructor is used to create an "end" iterator.
+// The two-argument constructor is used to split the given text using the given
+// delimiter.
+template <typename Delimiter, typename Predicate = NoFilter>
+class SplitIterator
+    : public std::iterator<std::input_iterator_tag, StringPiece> {
+ public:
+  // Two constructors for "end" iterators.
+  explicit SplitIterator(Delimiter d)
+      : delimiter_(std::move(d)), predicate_(), is_end_(true) {}
+  SplitIterator(Delimiter d, Predicate p)
+      : delimiter_(std::move(d)), predicate_(std::move(p)), is_end_(true) {}
+  // Two constructors taking the text to iterator.
+  SplitIterator(StringPiece text, Delimiter d)
+      : text_(std::move(text)),
+        delimiter_(std::move(d)),
+        predicate_(),
+        is_end_(false) {
+    ++(*this);
+  }
+  SplitIterator(StringPiece text, Delimiter d, Predicate p)
+      : text_(std::move(text)),
+        delimiter_(std::move(d)),
+        predicate_(std::move(p)),
+        is_end_(false) {
+    ++(*this);
+  }
+
+  StringPiece operator*() { return curr_piece_; }
+  StringPiece* operator->() { return &curr_piece_; }
+
+  SplitIterator& operator++() {
+    do {
+      if (text_.end() == curr_piece_.end()) {
+        // Already consumed all of text_, so we're done.
+        is_end_ = true;
+        return *this;
+      }
+      StringPiece found_delimiter = delimiter_.Find(text_);
+      assert(found_delimiter.data() != NULL);
+      assert(text_.begin() <= found_delimiter.begin());
+      assert(found_delimiter.end() <= text_.end());
+      // found_delimiter is allowed to be empty.
+      // Sets curr_piece_ to all text up to but excluding the delimiter itself.
+      // Sets text_ to remaining data after the delimiter.
+      curr_piece_.set(text_.begin(), found_delimiter.begin() - text_.begin());
+      text_.remove_prefix(found_delimiter.end() - text_.begin());
+    } while (!predicate_(curr_piece_));
+    return *this;
+  }
+
+  SplitIterator operator++(int /* postincrement */) {
+    SplitIterator old(*this);
+    ++(*this);
+    return old;
+  }
+
+  bool operator==(const SplitIterator& other) const {
+    // Two "end" iterators are always equal. If the two iterators being compared
+    // aren't both end iterators, then we fallback to comparing their fields.
+    // Importantly, the text being split must be equal and the current piece
+    // within the text being split must also be equal. The delimiter_ and
+    // predicate_ fields need not be checked here because they're template
+    // parameters that are already part of the SplitIterator's type.
+    return (is_end_ && other.is_end_) ||
+           (is_end_ == other.is_end_ &&
+            text_ == other.text_ &&
+            text_.data() == other.text_.data() &&
+            curr_piece_ == other.curr_piece_ &&
+            curr_piece_.data() == other.curr_piece_.data());
+  }
+
+  bool operator!=(const SplitIterator& other) const {
+    return !(*this == other);
+  }
+
+ private:
+  // The text being split. Modified as delimited pieces are consumed.
+  StringPiece text_;
+  Delimiter delimiter_;
+  Predicate predicate_;
+  bool is_end_;
+  // Holds the currently split piece of text. Will always refer to string data
+  // within text_. This value is returned when the iterator is dereferenced.
+  StringPiece curr_piece_;
+};
+
+// Declares a functor that can convert a StringPiece to another type. This works
+// for any type that has a constructor (explicit or not) taking a single
+// StringPiece argument. A specialization exists for converting to string
+// because the underlying data needs to be copied. In theory, these
+// specializations could be extended to work with other types (e.g., int32), but
+// then a solution for error reporting would need to be devised.
+template <typename To>
+struct StringPieceTo {
+  To operator()(StringPiece from) const {
+    return To(from);
+  }
+};
+
+// Specialization for converting to string.
+template <>
+struct StringPieceTo<string> {
+  string operator()(StringPiece from) const {
+    return from.ToString();
+  }
+};
+
+// Specialization for converting to *const* string.
+template <>
+struct StringPieceTo<const string> {
+  string operator()(StringPiece from) const {
+    return from.ToString();
+  }
+};
+
+#ifdef LANG_CXX11
+// IsNotInitializerList<T>::type exists iff T is not an initializer_list. More
+// details below in Splitter<> where this is used.
+template <typename T>
+struct IsNotInitializerList {
+  typedef void type;
+};
+template <typename T>
+struct IsNotInitializerList<std::initializer_list<T> > {};
+#endif  // LANG_CXX11
+
+// This class implements the behavior of the split API by giving callers access
+// to the underlying split substrings in various convenient ways, such as
+// through iterators or implicit conversion functions. Do not construct this
+// class directly, rather use the Split() function instead.
+//
+// Output containers can be collections of either StringPiece or string objects.
+// StringPiece is more efficient because the underlying data will not need to be
+// copied; the returned StringPieces will all refer to the data within the
+// original input string. If a collection of string objects is used, then each
+// substring will be copied.
+//
+// An optional Predicate functor may be supplied. This predicate will be used to
+// filter the split strings: only strings for which the predicate returns true
+// will be kept. A Predicate object is any unary functor that takes a
+// StringPiece and returns bool. By default, the NoFilter predicate is used,
+// which does not filter out anything.
+template <typename Delimiter, typename Predicate = NoFilter>
+class Splitter {
+ public:
+  typedef internal::SplitIterator<Delimiter, Predicate> Iterator;
+
+  Splitter(StringPiece text, Delimiter d)
+      : begin_(text, d), end_(d) {}
+
+  Splitter(StringPiece text, Delimiter d, Predicate p)
+      : begin_(text, d, p), end_(d, p) {}
+
+  // Range functions that iterate the split substrings as StringPiece objects.
+  // These methods enable a Splitter to be used in a range-based for loop in
+  // C++11, for example:
+  //
+  //   for (StringPiece sp : my_splitter) {
+  //     DoWork(sp);
+  //   }
+  const Iterator& begin() const { return begin_; }
+  const Iterator& end() const { return end_; }
+
+#ifdef LANG_CXX11
+// Support for default template arguments for function templates was added in
+// C++11, but it is not allowed if compiled in C++98 compatibility mode. Since
+// this code is under a LANG_CXX11 guard, we can safely ignore the
+// -Wc++98-compat flag and use default template arguments on the implicit
+// conversion operator below.
+//
+// This use of default template arguments on a function template was approved
+// by tgs and sanjay on behalf of the c-style-arbiters in email thread
+//
+// All compiler flags are first saved with a diagnostic push and restored with a
+// diagnostic pop below.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpragmas"
+#pragma GCC diagnostic ignored "-Wc++98-compat"
+
+  // Uses SFINAE to restrict conversion to container-like types (by testing for
+  // the presence of a const_iterator member type) and also to disable
+  // conversion to an initializer_list (which also has a const_iterator).
+  // Otherwise, code compiled in C++11 will get an error due to ambiguous
+  // conversion paths (in C++11 vector<T>::operator= is overloaded to take
+  // either a vector<T> or an initializer_list<T>).
+  //
+  // This trick was taken from util/gtl/container_literal.h
+  template <typename Container,
+            typename IsNotInitializerListChecker =
+                typename IsNotInitializerList<Container>::type,
+            typename ContainerChecker =
+                typename Container::const_iterator>
+  operator Container() {
+    return SelectContainer<Container, is_map<Container>::value>()(this);
+  }
+
+// Restores diagnostic settings, i.e., removes the "ignore" on -Wpragmas and
+// -Wc++98-compat.
+#pragma GCC diagnostic pop
+
+#else
+  // Not under LANG_CXX11
+  template <typename Container>
+  operator Container() {
+    return SelectContainer<Container, is_map<Container>::value>()(this);
+  }
+#endif  // LANG_CXX11
+
+  template <typename First, typename Second>
+  operator std::pair<First, Second>() {
+    return ToPair<First, Second>();
+  }
+
+ private:
+  // is_map<T>::value is true iff there exists a type T::mapped_type. This is
+  // used to dispatch to one of the SelectContainer<> functors (below) from the
+  // implicit conversion operator (above).
+  template <typename T>
+  struct is_map {
+    template <typename U> static base::big_ test(typename U::mapped_type*);
+    template <typename> static base::small_ test(...);
+    static const bool value = (sizeof(test<T>(0)) == sizeof(base::big_));
+  };
+
+  // Base template handles splitting to non-map containers
+  template <typename Container, bool>
+  struct SelectContainer {
+    Container operator()(Splitter* splitter) const {
+      return splitter->template ToContainer<Container>();
+    }
+  };
+
+  // Partial template specialization for splitting to map-like containers.
+  template <typename Container>
+  struct SelectContainer<Container, true> {
+    Container operator()(Splitter* splitter) const {
+      return splitter->template ToMap<Container>();
+    }
+  };
+
+  // Inserts split results into the container. To do this the results are first
+  // stored in a vector<StringPiece>. This is where the input text is actually
+  // "parsed". This vector is then used to possibly reserve space in the output
+  // container, and the StringPieces in "v" are converted as necessary to the
+  // output container's value type.
+  //
+  // The reason to use an intermediate vector of StringPiece is so we can learn
+  // the needed capacity of the output container. This is needed when the output
+  // container is a vector<string> in which case resizes can be expensive due to
+  // copying of the ::string objects.
+  //
+  // At some point in the future we might add a C++11 move constructor to
+  // ::string, in which case the vector resizes are much less expensive and the
+  // use of this intermediate vector "v" can be removed.
+  template <typename Container>
+  Container ToContainer() {
+    vector<StringPiece> v;
+    for (Iterator it = begin(); it != end_; ++it) {
+      v.push_back(*it);
+    }
+    typedef typename Container::value_type ToType;
+    internal::StringPieceTo<ToType> converter;
+    Container c;
+    ReserveCapacity(&c, v.size());
+    std::insert_iterator<Container> inserter(c, c.begin());
+    for (const auto& sp : v) {
+      *inserter++ = converter(sp);
+    }
+    return c;
+  }
+
+  // The algorithm is to insert a new pair into the map for each even-numbered
+  // item, with the even-numbered item as the key with a default-constructed
+  // value. Each odd-numbered item will then be assigned to the last pair's
+  // value.
+  template <typename Map>
+  Map ToMap() {
+    typedef typename Map::key_type Key;
+    typedef typename Map::mapped_type Data;
+    Map m;
+    StringPieceTo<Key> key_converter;
+    StringPieceTo<Data> val_converter;
+    typename Map::iterator curr_pair;
+    bool is_even = true;
+    for (Iterator it = begin(); it != end_; ++it) {
+      if (is_even) {
+        curr_pair = InsertInMap(std::make_pair(key_converter(*it), Data()), &m);
+      } else {
+        curr_pair->second = val_converter(*it);
+      }
+      is_even = !is_even;
+    }
+    return m;
+  }
+
+  // Returns a pair with its .first and .second members set to the first two
+  // strings returned by the begin() iterator. Either/both of .first and .second
+  // will be empty strings if the iterator doesn't have a corresponding value.
+  template <typename First, typename Second>
+  std::pair<First, Second> ToPair() {
+    StringPieceTo<First> first_converter;
+    StringPieceTo<Second> second_converter;
+    StringPiece first, second;
+    Iterator it = begin();
+    if (it != end()) {
+      first = *it;
+      if (++it != end()) {
+        second = *it;
+      }
+    }
+    return std::make_pair(first_converter(first), second_converter(second));
+  }
+
+  // Overloaded InsertInMap() function. The first overload is the commonly used
+  // one for most map-like objects. The second overload is a special case for
+  // multimap, because multimap's insert() member function directly returns an
+  // iterator, rather than a pair<iterator, bool> like map's.
+  template <typename Map>
+  typename Map::iterator InsertInMap(
+      const typename Map::value_type& value, Map* map) {
+    return map->insert(value).first;
+  }
+
+  // InsertInMap overload for multimap.
+  template <typename K, typename T, typename C, typename A>
+  typename std::multimap<K, T, C, A>::iterator InsertInMap(
+      const typename std::multimap<K, T, C, A>::value_type& value,
+      typename std::multimap<K, T, C, A>* map) {
+    return map->insert(value);
+  }
+
+  // Reserves the given amount of capacity in a vector<string>
+  template <typename A>
+  void ReserveCapacity(vector<string, A>* v, size_t size) {
+    v->reserve(size);
+  }
+  void ReserveCapacity(...) {}
+
+  const Iterator begin_;
+  const Iterator end_;
+};
+
+}  // namespace internal
+
+}  // namespace strings
+
+#endif  // STRINGS_SPLIT_INTERNAL_H_

--- a/be/src/gutil/strings/strip.cc
+++ b/be/src/gutil/strings/strip.cc
@@ -1,0 +1,384 @@
+// Copyright 2011 Google Inc. All Rights Reserved.
+// based on contributions of various authors in strings/strutil_unittest.cc
+//
+// This file contains functions that remove a defined part from the string,
+// i.e., strip the string.
+
+#include "gutil/strings/strip.h"
+
+#include <assert.h>
+#include <string.h>
+#include <algorithm>
+using std::copy;
+using std::max;
+using std::min;
+using std::reverse;
+using std::sort;
+using std::swap;
+#include <string>
+using std::string;
+
+#include "gutil/strings/ascii_ctype.h"
+#include "gutil/strings/stringpiece.h"
+
+string StripPrefixString(StringPiece str, const StringPiece& prefix) {
+  if (str.starts_with(prefix))
+    str.remove_prefix(prefix.length());
+  return str.as_string();
+}
+
+bool TryStripPrefixString(StringPiece str, const StringPiece& prefix,
+                                 string* result) {
+  const bool has_prefix = str.starts_with(prefix);
+  if (has_prefix)
+    str.remove_prefix(prefix.length());
+  str.as_string().swap(*result);
+  return has_prefix;
+}
+
+string StripSuffixString(StringPiece str, const StringPiece& suffix) {
+  if (str.ends_with(suffix))
+    str.remove_suffix(suffix.length());
+  return str.as_string();
+}
+
+bool TryStripSuffixString(StringPiece str, const StringPiece& suffix,
+                                 string* result) {
+  const bool has_suffix = str.ends_with(suffix);
+  if (has_suffix)
+    str.remove_suffix(suffix.length());
+  str.as_string().swap(*result);
+  return has_suffix;
+}
+
+// ----------------------------------------------------------------------
+// StripString
+//    Replaces any occurrence of the character 'remove' (or the characters
+//    in 'remove') with the character 'replacewith'.
+// ----------------------------------------------------------------------
+void StripString(char* str, StringPiece remove, char replacewith) {
+  for (; *str != '\0'; ++str) {
+    if (remove.find(*str) != StringPiece::npos) {
+      *str = replacewith;
+    }
+  }
+}
+
+void StripString(char* str, int len, StringPiece remove, char replacewith) {
+  char* end = str + len;
+  for (; str < end; ++str) {
+    if (remove.find(*str) != StringPiece::npos) {
+      *str = replacewith;
+    }
+  }
+}
+
+void StripString(string* s, StringPiece remove, char replacewith) {
+  for (char& c : *s) {
+    if (remove.find(c) != StringPiece::npos) {
+      c = replacewith;
+    }
+  }
+}
+
+// ----------------------------------------------------------------------
+// StripWhiteSpace
+// ----------------------------------------------------------------------
+void StripWhiteSpace(const char** str, int* len) {
+  // strip off trailing whitespace
+  while ((*len) > 0 && ascii_isspace((*str)[(*len)-1])) {
+    (*len)--;
+  }
+
+  // strip off leading whitespace
+  while ((*len) > 0 && ascii_isspace((*str)[0])) {
+    (*len)--;
+    (*str)++;
+  }
+}
+
+bool StripTrailingNewline(string* s) {
+  if (!s->empty() && (*s)[s->size() - 1] == '\n') {
+    if (s->size() > 1 && (*s)[s->size() - 2] == '\r')
+      s->resize(s->size() - 2);
+    else
+      s->resize(s->size() - 1);
+    return true;
+  }
+  return false;
+}
+
+void StripWhiteSpace(string* str) {
+  int str_length = str->length();
+
+  // Strip off leading whitespace.
+  int first = 0;
+  while (first < str_length && ascii_isspace(str->at(first))) {
+    ++first;
+  }
+  // If entire string is white space.
+  if (first == str_length) {
+    str->clear();
+    return;
+  }
+  if (first > 0) {
+    str->erase(0, first);
+    str_length -= first;
+  }
+
+  // Strip off trailing whitespace.
+  int last = str_length - 1;
+  while (last >= 0 && ascii_isspace(str->at(last))) {
+    --last;
+  }
+  if (last != (str_length - 1) && last >= 0) {
+    str->erase(last + 1, string::npos);
+  }
+}
+
+// ----------------------------------------------------------------------
+// Misc. stripping routines
+// ----------------------------------------------------------------------
+void StripCurlyBraces(string* s) {
+  return StripBrackets('{', '}', s);
+}
+
+void StripBrackets(char left, char right, string* s) {
+  string::iterator opencurly = find(s->begin(), s->end(), left);
+  while (opencurly != s->end()) {
+    string::iterator closecurly = find(opencurly, s->end(), right);
+    if (closecurly == s->end())
+      return;
+    opencurly = s->erase(opencurly, closecurly + 1);
+    opencurly = find(opencurly, s->end(), left);
+  }
+}
+
+void StripMarkupTags(string* s) {
+  string::iterator openbracket = find(s->begin(), s->end(), '<');
+  while (openbracket != s->end()) {
+    string::iterator closebracket = find(openbracket, s->end(), '>');
+    if (closebracket == s->end()) {
+      s->erase(openbracket, closebracket);
+      return;
+    }
+
+    openbracket = s->erase(openbracket, closebracket + 1);
+    openbracket = find(openbracket, s->end(), '<');
+  }
+}
+
+string OutputWithMarkupTagsStripped(const string& s) {
+  string result(s);
+  StripMarkupTags(&result);
+  return result;
+}
+
+
+int TrimStringLeft(string* s, const StringPiece& remove) {
+  int i = 0;
+  while (i < s->size() && memchr(remove.data(), (*s)[i], remove.size())) {
+    ++i;
+  }
+  if (i > 0) s->erase(0, i);
+  return i;
+}
+
+int TrimStringRight(string* s, const StringPiece& remove) {
+  int i = s->size(), trimmed = 0;
+  while (i > 0 && memchr(remove.data(), (*s)[i-1], remove.size())) {
+    --i;
+  }
+  if (i < s->size()) {
+    trimmed = s->size() - i;
+    s->erase(i);
+  }
+  return trimmed;
+}
+
+// ----------------------------------------------------------------------
+// Various removal routines
+// ----------------------------------------------------------------------
+int strrm(char* str, char c) {
+  char *src, *dest;
+  for (src = dest = str; *src != '\0'; ++src)
+    if (*src != c) *(dest++) = *src;
+  *dest = '\0';
+  return dest - str;
+}
+
+int memrm(char* str, int strlen, char c) {
+  char *src, *dest;
+  for (src = dest = str; strlen-- > 0; ++src)
+    if (*src != c) *(dest++) = *src;
+  return dest - str;
+}
+
+int strrmm(char* str, const char* chars) {
+  char *src, *dest;
+  for (src = dest = str; *src != '\0'; ++src) {
+    bool skip = false;
+    for (const char* c = chars; *c != '\0'; c++) {
+      if (*src == *c) {
+        skip = true;
+        break;
+      }
+    }
+    if (!skip) *(dest++) = *src;
+  }
+  *dest = '\0';
+  return dest - str;
+}
+
+int strrmm(string* str, const string& chars) {
+  size_t str_len = str->length();
+  size_t in_index = str->find_first_of(chars);
+  if (in_index == string::npos)
+    return str_len;
+
+  size_t out_index = in_index++;
+
+  while (in_index < str_len) {
+    char c = (*str)[in_index++];
+    if (chars.find(c) == string::npos)
+      (*str)[out_index++] = c;
+  }
+
+  str->resize(out_index);
+  return out_index;
+}
+
+// ----------------------------------------------------------------------
+// StripDupCharacters
+//    Replaces any repeated occurrence of the character 'repeat_char'
+//    with single occurrence.  e.g.,
+//       StripDupCharacters("a//b/c//d", '/', 0) => "a/b/c/d"
+//    Return the number of characters removed
+// ----------------------------------------------------------------------
+int StripDupCharacters(string* s, char dup_char, int start_pos) {
+  if (start_pos < 0)
+    start_pos = 0;
+
+  // remove dups by compaction in-place
+  int input_pos = start_pos;   // current reader position
+  int output_pos = start_pos;  // current writer position
+  const int input_end = s->size();
+  while (input_pos < input_end) {
+    // keep current character
+    const char curr_char = (*s)[input_pos];
+    if (output_pos != input_pos)  // must copy
+      (*s)[output_pos] = curr_char;
+    ++input_pos;
+    ++output_pos;
+
+    if (curr_char == dup_char) {  // skip subsequent dups
+      while ((input_pos < input_end) && ((*s)[input_pos] == dup_char))
+        ++input_pos;
+    }
+  }
+  const int num_deleted = input_pos - output_pos;
+  s->resize(s->size() - num_deleted);
+  return num_deleted;
+}
+
+// ----------------------------------------------------------------------
+// RemoveExtraWhitespace()
+//   Remove leading, trailing, and duplicate internal whitespace.
+// ----------------------------------------------------------------------
+void RemoveExtraWhitespace(string* s) {
+  assert(s != nullptr);
+  // Empty strings clearly have no whitespace, and this code assumes that
+  // string length is greater than 0
+  if (s->empty())
+    return;
+
+  int input_pos = 0;   // current reader position
+  int output_pos = 0;  // current writer position
+  const int input_end = s->size();
+  // Strip off leading space
+  while (input_pos < input_end && ascii_isspace((*s)[input_pos])) input_pos++;
+
+  while (input_pos < input_end - 1) {
+    char c = (*s)[input_pos];
+    char next = (*s)[input_pos + 1];
+    // Copy each non-whitespace character to the right position.
+    // For a block of whitespace, print the last one.
+    if (!ascii_isspace(c) || !ascii_isspace(next)) {
+      if (output_pos != input_pos) {  // only copy if needed
+        (*s)[output_pos] = c;
+      }
+      output_pos++;
+    }
+    input_pos++;
+  }
+  // Pick up the last character if needed.
+  char c = (*s)[input_end - 1];
+  if (!ascii_isspace(c)) (*s)[output_pos++] = c;
+
+  s->resize(output_pos);
+}
+
+//------------------------------------------------------------------------
+// See comment in header file for a complete description.
+//------------------------------------------------------------------------
+void StripLeadingWhiteSpace(string* str) {
+  char const* const leading = StripLeadingWhiteSpace(
+      const_cast<char*>(str->c_str()));
+  if (leading != nullptr) {
+    string const tmp(leading);
+    str->assign(tmp);
+  } else {
+    str->assign("");
+  }
+}
+
+void StripTrailingWhitespace(string* const s) {
+  string::size_type i;
+  for (i = s->size(); i > 0 && ascii_isspace((*s)[i - 1]); --i) {
+  }
+
+  s->resize(i);
+}
+
+// ----------------------------------------------------------------------
+// TrimRunsInString
+//    Removes leading and trailing runs, and collapses middle
+//    runs of a set of characters into a single character (the
+//    first one specified in 'remove').  Useful for collapsing
+//    runs of repeated delimiters, whitespace, etc.  E.g.,
+//    TrimRunsInString(&s, " :,()") removes leading and trailing
+//    delimiter chars and collapses and converts internal runs
+//    of delimiters to single ' ' characters, so, for example,
+//    "  a:(b):c  " -> "a b c"
+//    "first,last::(area)phone, ::zip" -> "first last area phone zip"
+// ----------------------------------------------------------------------
+void TrimRunsInString(string* s, StringPiece remove) {
+  string::iterator dest = s->begin();
+  string::iterator src_end = s->end();
+  for (string::iterator src = s->begin(); src != src_end; ) {
+    if (remove.find(*src) == StringPiece::npos) {
+      *(dest++) = *(src++);
+    } else {
+      // Skip to the end of this run of chars that are in 'remove'.
+      for (++src; src != src_end; ++src) {
+        if (remove.find(*src) == StringPiece::npos) {
+          if (dest != s->begin()) {
+            // This is an internal run; collapse it.
+            *(dest++) = remove[0];
+          }
+          *(dest++) = *(src++);
+          break;
+        }
+      }
+    }
+  }
+  s->erase(dest, src_end);
+}
+
+// ----------------------------------------------------------------------
+// RemoveNullsInString
+//    Removes any internal \0 characters from the string.
+// ----------------------------------------------------------------------
+void RemoveNullsInString(string* s) {
+  s->erase(remove(s->begin(), s->end(), '\0'), s->end());
+}

--- a/be/src/gutil/strings/strip.h
+++ b/be/src/gutil/strings/strip.h
@@ -1,0 +1,272 @@
+// Copyright 2011 Google Inc. All Rights Reserved.
+// Refactored from contributions of various authors in strings/strutil.h
+//
+// This file contains functions that remove a defined part from the string,
+// i.e., strip the string.
+
+#ifndef STRINGS_STRIP_H_
+#define STRINGS_STRIP_H_
+
+#include <stddef.h>
+#include <string>
+using std::string;
+
+#include "gutil/strings/ascii_ctype.h"
+#include "gutil/strings/stringpiece.h"
+
+// Given a string and a putative prefix, returns the string minus the
+// prefix string if the prefix matches, otherwise the original
+// string.
+string StripPrefixString(StringPiece str, const StringPiece& prefix);
+
+// Like StripPrefixString, but return true if the prefix was
+// successfully matched.  Write the output to *result.
+// It is safe for result to point back to the input string.
+bool TryStripPrefixString(StringPiece str, const StringPiece& prefix,
+                          string* result);
+
+// Given a string and a putative suffix, returns the string minus the
+// suffix string if the suffix matches, otherwise the original
+// string.
+string StripSuffixString(StringPiece str, const StringPiece& suffix);
+
+
+// Like StripSuffixString, but return true if the suffix was
+// successfully matched.  Write the output to *result.
+// It is safe for result to point back to the input string.
+bool TryStripSuffixString(StringPiece str, const StringPiece& suffix,
+                          string* result);
+
+// ----------------------------------------------------------------------
+// StripString
+//    Replaces any occurrence of the character 'remove' (or the characters
+//    in 'remove') with the character 'replacewith'.
+//    Good for keeping html characters or protocol characters (\t) out
+//    of places where they might cause a problem.
+// ----------------------------------------------------------------------
+inline void StripString(char* str, char remove, char replacewith) {
+  for (; *str; str++) {
+    if (*str == remove)
+      *str = replacewith;
+  }
+}
+
+void StripString(char* str, StringPiece remove, char replacewith);
+void StripString(char* str, int len, StringPiece remove, char replacewith);
+void StripString(string* s, StringPiece remove, char replacewith);
+
+// ----------------------------------------------------------------------
+// StripDupCharacters
+//    Replaces any repeated occurrence of the character 'dup_char'
+//    with single occurrence.  e.g.,
+//       StripDupCharacters("a//b/c//d", '/', 0) => "a/b/c/d"
+//    Return the number of characters removed
+// ----------------------------------------------------------------------
+int StripDupCharacters(string* s, char dup_char, int start_pos);
+
+// ----------------------------------------------------------------------
+// StripWhiteSpace
+//    "Removes" whitespace from both sides of string.  Pass in a pointer to an
+//    array of characters, and its length.  The function changes the pointer
+//    and length to refer to a substring that does not contain leading or
+//    trailing spaces; it does not modify the string itself.  If the caller is
+//    using NUL-terminated strings, it is the caller's responsibility to insert
+//    the NUL character at the end of the substring."
+//
+//    Note: to be completely type safe, this function should be
+//    parameterized as a template: template<typename anyChar> void
+//    StripWhiteSpace(anyChar** str, int* len), where the expectation
+//    is that anyChar could be char, const char, w_char, const w_char,
+//    unicode_char, or any other character type we want.  However, we
+//    just provided a version for char and const char.  C++ is
+//    inconvenient, but correct, here.  Ask Amit is you want to know
+//    the type safety details.
+// ----------------------------------------------------------------------
+void StripWhiteSpace(const char** str, int* len);
+
+//------------------------------------------------------------------------
+// StripTrailingWhitespace()
+//   Removes whitespace at the end of the string *s.
+//------------------------------------------------------------------------
+void StripTrailingWhitespace(string* s);
+
+//------------------------------------------------------------------------
+// StripTrailingNewline(string*)
+//   Strips the very last trailing newline or CR+newline from its
+//   input, if one exists.  Useful for dealing with MapReduce's text
+//   input mode, which appends '\n' to each map input.  Returns true
+//   if a newline was stripped.
+//------------------------------------------------------------------------
+bool StripTrailingNewline(string* s);
+
+inline void StripWhiteSpace(char** str, int* len) {
+  // The "real" type for StripWhiteSpace is ForAll char types C, take
+  // (C, int) as input and return (C, int) as output.  We're using the
+  // cast here to assert that we can take a char*, even though the
+  // function thinks it's assigning to const char*.
+  StripWhiteSpace(const_cast<const char**>(str), len);
+}
+
+inline void StripWhiteSpace(StringPiece* str) {
+  const char* data = str->data();
+  int len = str->size();
+  StripWhiteSpace(&data, &len);
+  str->set(data, len);
+}
+
+void StripWhiteSpace(string* str);
+
+namespace strings {
+
+template <typename Collection>
+inline void StripWhiteSpaceInCollection(Collection* collection) {
+  for (typename Collection::iterator it = collection->begin();
+       it != collection->end(); ++it)
+    StripWhiteSpace(&(*it));
+}
+
+}  // namespace strings
+
+// ----------------------------------------------------------------------
+// StripLeadingWhiteSpace
+//    "Removes" whitespace from beginning of string. Returns ptr to first
+//    non-whitespace character if one is present, NULL otherwise. Assumes
+//    "line" is null-terminated.
+// ----------------------------------------------------------------------
+
+inline const char* StripLeadingWhiteSpace(const char* line) {
+  // skip leading whitespace
+  while (ascii_isspace(*line))
+    ++line;
+
+  if ('\0' == *line)  // end of line, no non-whitespace
+    return NULL;
+
+  return line;
+}
+
+// StripLeadingWhiteSpace for non-const strings.
+inline char* StripLeadingWhiteSpace(char* line) {
+  return const_cast<char*>(
+      StripLeadingWhiteSpace(const_cast<const char*>(line)));
+}
+
+void StripLeadingWhiteSpace(string* str);
+
+// Remove leading, trailing, and duplicate internal whitespace.
+void RemoveExtraWhitespace(string* s);
+
+
+// ----------------------------------------------------------------------
+// SkipLeadingWhiteSpace
+//    Returns str advanced past white space characters, if any.
+//    Never returns NULL.  "str" must be terminated by a null character.
+// ----------------------------------------------------------------------
+inline const char* SkipLeadingWhiteSpace(const char* str) {
+  while (ascii_isspace(*str))
+    ++str;
+  return str;
+}
+
+inline char* SkipLeadingWhiteSpace(char* str) {
+  while (ascii_isspace(*str))
+    ++str;
+  return str;
+}
+
+// ----------------------------------------------------------------------
+// StripCurlyBraces
+//    Strips everything enclosed in pairs of curly braces and the curly
+//    braces. Doesn't touch open braces. It doesn't handle nested curly
+//    braces. This is used for removing things like {:stopword} from
+//    queries.
+// StripBrackets does the same, but allows the caller to specify different
+//    left and right bracket characters, such as '(' and ')'.
+// ----------------------------------------------------------------------
+
+void StripCurlyBraces(string* s);
+void StripBrackets(char left, char right, string* s);
+
+
+// ----------------------------------------------------------------------
+// StripMarkupTags
+//    Strips everything enclosed in pairs of angle brackets and the angle
+//    brackets.
+//    This is used for stripping strings of markup; e.g. going from
+//    "the quick <b>brown</b> fox" to "the quick brown fox."
+//    If you want to skip entire sections of markup (e.g. the word "brown"
+//    too in that example), see webutil/pageutil/pageutil.h .
+//    This function was designed for stripping the bold tags (inserted by the
+//    docservers) from the titles of news stories being returned by RSS.
+//    This implementation DOES NOT cover all cases in html documents
+//    like tags that contain quoted angle-brackets, or HTML comment.
+//    For example <IMG SRC = "foo.gif" ALT = "A > B">
+//    or <!-- <A comment> -->
+//    See "perldoc -q html"
+// ----------------------------------------------------------------------
+
+void StripMarkupTags(string* s);
+string OutputWithMarkupTagsStripped(const string& s);
+
+// ----------------------------------------------------------------------
+// TrimStringLeft
+//    Removes any occurrences of the characters in 'remove' from the start
+//    of the string.  Returns the number of chars trimmed.
+// ----------------------------------------------------------------------
+int TrimStringLeft(string* s, const StringPiece& remove);
+
+// ----------------------------------------------------------------------
+// TrimStringRight
+//    Removes any occurrences of the characters in 'remove' from the end
+//    of the string.  Returns the number of chars trimmed.
+// ----------------------------------------------------------------------
+int TrimStringRight(string* s, const StringPiece& remove);
+
+// ----------------------------------------------------------------------
+// TrimString
+//    Removes any occurrences of the characters in 'remove' from either
+//    end of the string.
+// ----------------------------------------------------------------------
+inline int TrimString(string* s, const StringPiece& remove) {
+  return TrimStringRight(s, remove) + TrimStringLeft(s, remove);
+}
+
+// ----------------------------------------------------------------------
+// TrimRunsInString
+//    Removes leading and trailing runs, and collapses middle
+//    runs of a set of characters into a single character (the
+//    first one specified in 'remove').  Useful for collapsing
+//    runs of repeated delimiters, whitespace, etc.  E.g.,
+//    TrimRunsInString(&s, " :,()") removes leading and trailing
+//    delimiter chars and collapses and converts internal runs
+//    of delimiters to single ' ' characters, so, for example,
+//    "  a:(b):c  " -> "a b c"
+//    "first,last::(area)phone, ::zip" -> "first last area phone zip"
+// ----------------------------------------------------------------------
+void TrimRunsInString(string* s, StringPiece remove);
+
+// ----------------------------------------------------------------------
+// RemoveNullsInString
+//    Removes any internal \0 characters from the string.
+// ----------------------------------------------------------------------
+void RemoveNullsInString(string* s);
+
+// ----------------------------------------------------------------------
+// strrm()
+// memrm()
+//    Remove all occurrences of a given character from a string.
+//    Returns the new length.
+// ----------------------------------------------------------------------
+
+int strrm(char* str, char c);
+int memrm(char* str, int strlen, char c);
+
+// ----------------------------------------------------------------------
+// strrmm()
+//    Remove all occurrences of a given set of characters from a string.
+//    Returns the new length.
+// ----------------------------------------------------------------------
+int strrmm(char* str, const char* chars);
+int strrmm(string* str, const string& chars);
+
+#endif  // STRINGS_STRIP_H_


### PR DESCRIPTION
With these two tools, we can very easily perform splitting
and trimming operations on strings.

The subsequent PR will use them to replace the existing
`boost::split()` and `boost::trim()`