### PR TITLE
Fix some bugs about load label

### DIFF
--- a/docs/documentation/cn/sql-reference/sql-statements/Data Manipulation/insert.md
+++ b/docs/documentation/cn/sql-reference/sql-statements/Data Manipulation/insert.md
@@ -23,8 +23,8 @@ under the License.
 
 ```
 INSERT INTO table_name
+    [ PARTITION (p1, ...) ]
     [ WITH LABEL label]
-    [ PARTITION (, ...) ]
     [ (column [, ...]) ]
     [ [ hint [, ...] ] ]
     { VALUES ( { expression | DEFAULT } [, ...] ) [, ...] | query }
@@ -34,9 +34,9 @@ INSERT INTO table_name
 
 > tablet_name: 导入数据的目的表。可以是 `db_name.table_name` 形式
 >
-> label: 为 Insert 任务指定一个 label
+> partitions: 指定待导入的分区，必须是 `table_name` 中存在的分区，多个分区名称用逗号分隔
 >
-> partition_names: 指定待导入的分区，必须是 `table_name` 中存在的分区，多个分区名称用逗号分隔
+> label: 为 Insert 任务指定一个 label
 >
 > column_name: 指定的目的列，必须是 `table_name` 中存在的列
 >
@@ -88,10 +88,10 @@ INSERT INTO test SELECT * FROM test2;
 INSERT INTO test (c1, c2) SELECT * from test2;
 ```
 
-4. 向 `test` 表中导入一个查询语句结果，并指定 label
+4. 向 `test` 表中导入一个查询语句结果，并指定 partition 和 label
 
 ```
-INSERT INTO test WITH LABEL `label1` SELECT * FROM test2;
+INSERT INTO test PARTITION(p1, p2) WITH LABEL `label1` SELECT * FROM test2;
 INSERT INTO test WITH LABEL `label1` (c1, c2) SELECT * from test2;
 ```
 

--- a/docs/documentation/en/sql-reference/sql-statements/Data Manipulation/insert_EN.md
+++ b/docs/documentation/en/sql-reference/sql-statements/Data Manipulation/insert_EN.md
@@ -23,8 +23,8 @@ under the License.
 
 ```
 INSERT INTO table_name
+[ PARTITION (p1, ...)]
 [ WITH LABEL label]
-[ PARTICIPATION [...]
 [ (column [, ...]) ]
 [ [ hint [, ...] ] ]
 { VALUES ( { expression | DEFAULT } [, ...] ) [, ...] | query }
@@ -34,9 +34,9 @@ INSERT INTO table_name
 
 > tablet_name: Target table for loading data. It can be in the form of `db_name.table_name`.
 >
-> label: Specifies a label for Insert job.
+> partitions: Specifies the partitions to be loaded, with multiple partition names separated by commas. The partitions must exist in `table_name`, 
 >
-> partition_names: Specifies the partitions to be loaded, with multiple partition names separated by commas. The partitions must exist in `table_name`, 
+> label: Specifies a label for Insert job.
 >
 > column_name: The specified destination columns must be columns that exists in `table_name`.
 >
@@ -89,10 +89,10 @@ INSERT INTO test SELECT * FROM test2
 INSERT INTO test (c1, c2) SELECT * from test2
 ```
 
-4. Insert into table `test` with specified label
+4. Insert into table `test` with specified partition and label
 
 ```
-INSERT INTO test WITH LABEL `label1` SELECT * FROM test2;
+INSERT INTO test PARTITION(p1, p2) WITH LABEL `label1` SELECT * FROM test2;
 INSERT INTO test WITH LABEL `label1` (c1, c2) SELECT * from test2;
 ```
 

--- a/fe/src/main/java/org/apache/doris/catalog/Catalog.java
+++ b/fe/src/main/java/org/apache/doris/catalog/Catalog.java
@@ -1337,13 +1337,12 @@ public class Catalog {
             checksum = loadExportJob(dis, checksum);
             checksum = loadBackupHandler(dis, checksum);
             checksum = loadPaloAuth(dis, checksum);
+            // global transaction must be replayed before load jobs v2
             checksum = loadTransactionState(dis, checksum);
             checksum = loadColocateTableIndex(dis, checksum);
             checksum = loadRoutineLoadJobs(dis, checksum);
             checksum = loadLoadJobsV2(dis, checksum);
             checksum = loadSmallFiles(dis, checksum);
-
-
 
             long remoteChecksum = dis.readLong();
             Preconditions.checkState(remoteChecksum == checksum, remoteChecksum + " vs. " + checksum);
@@ -1719,7 +1718,8 @@ public class Catalog {
 
     public long loadLoadJobsV2(DataInputStream in, long checksum) throws IOException {
         if (Catalog.getCurrentCatalogJournalVersion() >= FeMetaVersion.VERSION_50) {
-            Catalog.getCurrentCatalog().getLoadManager().readFields(in);
+            loadManager.readFields(in);
+            loadManager.transferLoadingStateToCommitted(globalTransactionMgr);
         }
         return checksum;
     }

--- a/fe/src/main/java/org/apache/doris/common/DuplicatedRequestException.java
+++ b/fe/src/main/java/org/apache/doris/common/DuplicatedRequestException.java
@@ -20,10 +20,22 @@ package org.apache.doris.common;
 public class DuplicatedRequestException extends DdlException {
 
     private String duplicatedRequestId;
+    // save exist txn id
+    private long txnId;
 
     public DuplicatedRequestException(String duplicatedRequestId, String msg) {
         super(msg);
         this.duplicatedRequestId = duplicatedRequestId;
+    }
+
+    public DuplicatedRequestException(String duplicatedRequestId, long txnId, String msg) {
+        super(msg);
+        this.duplicatedRequestId = duplicatedRequestId;
+        this.txnId = txnId;
+    }
+
+    public long getTxnId() {
+        return txnId;
     }
 
     public String getDuplicatedRequestId() {

--- a/fe/src/main/java/org/apache/doris/common/DuplicatedRequestException.java
+++ b/fe/src/main/java/org/apache/doris/common/DuplicatedRequestException.java
@@ -17,6 +17,12 @@
 
 package org.apache.doris.common;
 
+/*
+ * This exception throws when the request from Backend is duplicated.
+ * It is currently used for mini load and stream load's begin txn requests.
+ * Because the request may be a retry request, so that we should throw this exception
+ * and return the 'already-begun' txn id.
+ */
 public class DuplicatedRequestException extends DdlException {
 
     private String duplicatedRequestId;

--- a/fe/src/main/java/org/apache/doris/common/DuplicatedRequestException.java
+++ b/fe/src/main/java/org/apache/doris/common/DuplicatedRequestException.java
@@ -29,11 +29,6 @@ public class DuplicatedRequestException extends DdlException {
     // save exist txn id
     private long txnId;
 
-    public DuplicatedRequestException(String duplicatedRequestId, String msg) {
-        super(msg);
-        this.duplicatedRequestId = duplicatedRequestId;
-    }
-
     public DuplicatedRequestException(String duplicatedRequestId, long txnId, String msg) {
         super(msg);
         this.duplicatedRequestId = duplicatedRequestId;

--- a/fe/src/main/java/org/apache/doris/load/loadv2/BrokerLoadJob.java
+++ b/fe/src/main/java/org/apache/doris/load/loadv2/BrokerLoadJob.java
@@ -224,10 +224,10 @@ public class BrokerLoadJob extends LoadJob {
         writeLock();
         try {
             // check if job has been completed
-            if (isCompleted()) {
+            if (isTxnDone()) {
                 LOG.warn(new LogBuilder(LogKey.LOAD_JOB, id)
                                  .add("state", state)
-                                 .add("error_msg", "this task will be ignored when job is completed")
+                                 .add("error_msg", "this task will be ignored when job is: " + state)
                                  .build());
                 return;
             }
@@ -298,13 +298,14 @@ public class BrokerLoadJob extends LoadJob {
         writeLock();
         try {
             // check if job has been cancelled
-            if (isCompleted()) {
+            if (isTxnDone()) {
                 LOG.warn(new LogBuilder(LogKey.LOAD_JOB, id)
                                  .add("state", state)
-                                 .add("error_msg", "this task will be ignored when job is completed")
+                                 .add("error_msg", "this task will be ignored when job is: " + state)
                                  .build());
                 return;
             }
+
             if (finishedTaskIds.contains(attachment.getTaskId())) {
                 LOG.warn(new LogBuilder(LogKey.LOAD_JOB, id)
                                  .add("task_id", attachment.getTaskId())
@@ -387,10 +388,10 @@ public class BrokerLoadJob extends LoadJob {
         writeLock();
         try {
             // check if job has been cancelled
-            if (isCompleted()) {
+            if (isTxnDone()) {
                 LOG.warn(new LogBuilder(LogKey.LOAD_JOB, id)
                                  .add("state", state)
-                                 .add("error_msg", "this task will be ignored when job is completed")
+                                 .add("error_msg", "this task will be ignored when job is: " + state)
                                  .build());
                 return;
             }

--- a/fe/src/main/java/org/apache/doris/load/loadv2/BrokerLoadJob.java
+++ b/fe/src/main/java/org/apache/doris/load/loadv2/BrokerLoadJob.java
@@ -282,7 +282,7 @@ public class BrokerLoadJob extends LoadJob {
                              .add("msg", "The failure happens in analyze, the load job will be cancelled with error:"
                                      + e.getMessage())
                              .build(), e);
-            cancelJobWithoutCheck(new FailMsg(FailMsg.CancelType.LOAD_RUN_FAIL, e.getMessage()), false);
+            cancelJobWithoutCheck(new FailMsg(FailMsg.CancelType.LOAD_RUN_FAIL, e.getMessage()), false, true);
         }
     }
 
@@ -326,7 +326,7 @@ public class BrokerLoadJob extends LoadJob {
                              .add("database_id", dbId)
                              .add("error_msg", "Failed to divide job into loading task.")
                              .build(), e);
-            cancelJobWithoutCheck(new FailMsg(FailMsg.CancelType.ETL_RUN_FAIL, e.getMessage()), true);
+            cancelJobWithoutCheck(new FailMsg(FailMsg.CancelType.ETL_RUN_FAIL, e.getMessage()), true, true);
             return;
         }
 
@@ -421,7 +421,8 @@ public class BrokerLoadJob extends LoadJob {
 
         // check data quality
         if (!checkDataQuality()) {
-            cancelJobWithoutCheck(new FailMsg(FailMsg.CancelType.ETL_QUALITY_UNSATISFIED, QUALITY_FAIL_MSG),true);
+            cancelJobWithoutCheck(new FailMsg(FailMsg.CancelType.ETL_QUALITY_UNSATISFIED, QUALITY_FAIL_MSG),
+                    true, true);
             return;
         }
         Database db = null;
@@ -432,7 +433,7 @@ public class BrokerLoadJob extends LoadJob {
                              .add("database_id", dbId)
                              .add("error_msg", "db has been deleted when job is loading")
                              .build(), e);
-            cancelJobWithoutCheck(new FailMsg(FailMsg.CancelType.LOAD_RUN_FAIL, e.getMessage()), true);
+            cancelJobWithoutCheck(new FailMsg(FailMsg.CancelType.LOAD_RUN_FAIL, e.getMessage()), true, true);
         }
         db.writeLock();
         try {
@@ -449,7 +450,7 @@ public class BrokerLoadJob extends LoadJob {
                              .add("database_id", dbId)
                              .add("error_msg", "Failed to commit txn with error:" + e.getMessage())
                              .build(), e);
-            cancelJobWithoutCheck(new FailMsg(FailMsg.CancelType.LOAD_RUN_FAIL, e.getMessage()),true);
+            cancelJobWithoutCheck(new FailMsg(FailMsg.CancelType.LOAD_RUN_FAIL, e.getMessage()), true, true);
             return;
         } finally {
             db.writeUnlock();

--- a/fe/src/main/java/org/apache/doris/load/loadv2/BrokerLoadJob.java
+++ b/fe/src/main/java/org/apache/doris/load/loadv2/BrokerLoadJob.java
@@ -31,6 +31,7 @@ import org.apache.doris.catalog.Table;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.DdlException;
+import org.apache.doris.common.DuplicatedRequestException;
 import org.apache.doris.common.FeMetaVersion;
 import org.apache.doris.common.LabelAlreadyUsedException;
 import org.apache.doris.common.MetaNotFoundException;
@@ -186,7 +187,8 @@ public class BrokerLoadJob extends LoadJob {
     }
 
     @Override
-    public void beginTxn() throws LabelAlreadyUsedException, BeginTransactionException, AnalysisException {
+    public void beginTxn()
+            throws LabelAlreadyUsedException, BeginTransactionException, AnalysisException, DuplicatedRequestException {
         transactionId = Catalog.getCurrentGlobalTransactionMgr()
                 .beginTransaction(dbId, label, null, "FE: " + FrontendOptions.getLocalHostAddress(),
                                   TransactionState.LoadJobSourceType.BATCH_LOAD_JOB, id,

--- a/fe/src/main/java/org/apache/doris/load/loadv2/BrokerLoadJob.java
+++ b/fe/src/main/java/org/apache/doris/load/loadv2/BrokerLoadJob.java
@@ -237,6 +237,8 @@ public class BrokerLoadJob extends LoadJob {
             }
             if (loadTask.getRetryTime() <= 0) {
                 unprotectedExecuteCancel(failMsg, true);
+                logFinalOperation();
+                return;
             } else {
                 // retry task
                 idToTasks.remove(loadTask.getSignature());
@@ -252,8 +254,6 @@ public class BrokerLoadJob extends LoadJob {
         } finally {
             writeUnlock();
         }
-
-        logFinalOperation();
     }
 
     /**

--- a/fe/src/main/java/org/apache/doris/load/loadv2/JobState.java
+++ b/fe/src/main/java/org/apache/doris/load/loadv2/JobState.java
@@ -18,8 +18,9 @@
 package org.apache.doris.load.loadv2;
 
 public enum JobState {
-    PENDING,
-    LOADING,
-    FINISHED,
-    CANCELLED
+    PENDING, // init state
+    LOADING, // job is running
+    COMMITTED, // transaction is committed but not visible
+    FINISHED, // transaction is visible and job is finished
+    CANCELLED // transaction is aborted and job is cancelled
 }

--- a/fe/src/main/java/org/apache/doris/load/loadv2/JobState.java
+++ b/fe/src/main/java/org/apache/doris/load/loadv2/JobState.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.load.loadv2;
 
+// JobState will be persisted in meta data by name, so the order of these state is not important
 public enum JobState {
     PENDING, // init state
     LOADING, // job is running

--- a/fe/src/main/java/org/apache/doris/load/loadv2/LoadJob.java
+++ b/fe/src/main/java/org/apache/doris/load/loadv2/LoadJob.java
@@ -530,7 +530,8 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
      * This method will cancel job without edit log and lock
      *
      * @param failMsg
-     * @param abortTxn true: abort txn when cancel job, false: only change the state of job and ignore abort txn
+     * @param abortTxn
+     *            true: abort txn when cancel job, false: only change the state of job and ignore abort txn
      */
     protected void unprotectedExecuteCancel(FailMsg failMsg, boolean abortTxn) {
         LOG.warn(new LogBuilder(LogKey.LOAD_JOB, id)
@@ -567,9 +568,9 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
                 Catalog.getCurrentGlobalTransactionMgr().abortTransaction(transactionId, failMsg.getMsg());
             } catch (UserException e) {
                 LOG.warn(new LogBuilder(LogKey.LOAD_JOB, id)
-                                 .add("transaction_id", transactionId)
-                                 .add("error_msg", "failed to abort txn when job is cancelled, txn will be aborted later")
-                                 .build());
+                        .add("transaction_id", transactionId)
+                        .add("error_msg", "failed to abort txn when job is cancelled. " + e.getMessage())
+                        .build());
             }
         }
         

--- a/fe/src/main/java/org/apache/doris/load/loadv2/LoadJob.java
+++ b/fe/src/main/java/org/apache/doris/load/loadv2/LoadJob.java
@@ -398,6 +398,10 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
                 return;
             }
 
+            if (!isTimeout()) {
+                return;
+            }
+
             unprotectedExecuteCancel(new FailMsg(FailMsg.CancelType.TIMEOUT, "loading timeout to cancel"), false);
             logFinalOperation();
         } finally {

--- a/fe/src/main/java/org/apache/doris/load/loadv2/LoadJob.java
+++ b/fe/src/main/java/org/apache/doris/load/loadv2/LoadJob.java
@@ -772,6 +772,7 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
         writeLock();
         try {
             replayTxnAttachment(txnState);
+            transactionId = txnState.getTransactionId();
             state = JobState.COMMITTED;
         } finally {
             writeUnlock();

--- a/fe/src/main/java/org/apache/doris/load/loadv2/LoadJob.java
+++ b/fe/src/main/java/org/apache/doris/load/loadv2/LoadJob.java
@@ -24,6 +24,7 @@ import org.apache.doris.catalog.Database;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.DdlException;
+import org.apache.doris.common.DuplicatedRequestException;
 import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.ErrorReport;
 import org.apache.doris.common.FeMetaVersion;
@@ -353,7 +354,7 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
         isJobTypeRead = jobTypeRead;
     }
 
-    public void beginTxn() throws LabelAlreadyUsedException, BeginTransactionException, AnalysisException {
+    public void beginTxn() throws LabelAlreadyUsedException, BeginTransactionException, AnalysisException, DuplicatedRequestException {
     }
 
     /**
@@ -363,8 +364,9 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
      * @throws LabelAlreadyUsedException the job is duplicated
      * @throws BeginTransactionException the limit of load job is exceeded
      * @throws AnalysisException there are error params in job
+     * @throws DuplicatedRequestException 
      */
-    public void execute() throws LabelAlreadyUsedException, BeginTransactionException, AnalysisException {
+    public void execute() throws LabelAlreadyUsedException, BeginTransactionException, AnalysisException, DuplicatedRequestException {
         writeLock();
         try {
             unprotectedExecute();
@@ -373,7 +375,8 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
         }
     }
 
-    public void unprotectedExecute() throws LabelAlreadyUsedException, BeginTransactionException, AnalysisException {
+    public void unprotectedExecute()
+            throws LabelAlreadyUsedException, BeginTransactionException, AnalysisException, DuplicatedRequestException {
         // check if job state is pending
         if (state != JobState.PENDING) {
             return;

--- a/fe/src/main/java/org/apache/doris/load/loadv2/LoadJobScheduler.java
+++ b/fe/src/main/java/org/apache/doris/load/loadv2/LoadJobScheduler.java
@@ -73,7 +73,8 @@ public class LoadJobScheduler extends Daemon {
                 LOG.warn(new LogBuilder(LogKey.LOAD_JOB, loadJob.getId())
                                  .add("error_msg", "There are error properties in job. Job will be cancelled")
                                  .build(), e);
-                loadJob.cancelJobWithoutCheck(new FailMsg(FailMsg.CancelType.ETL_SUBMIT_FAIL, e.getMessage()), false);
+                loadJob.cancelJobWithoutCheck(new FailMsg(FailMsg.CancelType.ETL_SUBMIT_FAIL, e.getMessage()),
+                        false, true);
                 continue;
             } catch (BeginTransactionException e) {
                 LOG.warn(new LogBuilder(LogKey.LOAD_JOB, loadJob.getId())

--- a/fe/src/main/java/org/apache/doris/load/loadv2/LoadJobScheduler.java
+++ b/fe/src/main/java/org/apache/doris/load/loadv2/LoadJobScheduler.java
@@ -19,6 +19,7 @@ package org.apache.doris.load.loadv2;
 
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.Config;
+import org.apache.doris.common.DuplicatedRequestException;
 import org.apache.doris.common.LabelAlreadyUsedException;
 import org.apache.doris.common.util.Daemon;
 import org.apache.doris.common.util.LogBuilder;
@@ -76,6 +77,13 @@ public class LoadJobScheduler extends Daemon {
                 loadJob.cancelJobWithoutCheck(new FailMsg(FailMsg.CancelType.ETL_SUBMIT_FAIL, e.getMessage()),
                         false, true);
                 continue;
+            } catch (DuplicatedRequestException e) {
+                // should not happen in load job scheduler, there is no request id.
+                LOG.warn(new LogBuilder(LogKey.LOAD_JOB, loadJob.getId())
+                        .add("error_msg", "Failed to begin txn with duplicate request. Job will be rescheduled later")
+                        .build(), e);
+                needScheduleJobs.put(loadJob);
+                return;
             } catch (BeginTransactionException e) {
                 LOG.warn(new LogBuilder(LogKey.LOAD_JOB, loadJob.getId())
                                  .add("error_msg", "Failed to begin txn when job is scheduling. "

--- a/fe/src/main/java/org/apache/doris/load/loadv2/LoadManager.java
+++ b/fe/src/main/java/org/apache/doris/load/loadv2/LoadManager.java
@@ -225,20 +225,20 @@ public class LoadManager implements Writable{
     }
 
     public void replayCreateLoadJob(LoadJob loadJob) {
-        addLoadJob(loadJob);
+        addLoadJobImpl(loadJob);
         LOG.info(new LogBuilder(LogKey.LOAD_JOB, loadJob.getId())
                          .add("msg", "replay create load job")
                          .build());
     }
 
     private void addLoadJob(LoadJob loadJob) {
-        addLoadJob(loadJob);
+        addLoadJobImpl(loadJob);
         // add callback before txn created, because callback will be performed on replay without txn begin
         // register txn state listener
         Catalog.getCurrentGlobalTransactionMgr().getCallbackFactory().addCallback(loadJob);
     }
 
-    private void addLoadJob(LoadJob loadJob) {
+    private void addLoadJobImpl(LoadJob loadJob) {
         idToLoadJob.put(loadJob.getId(), loadJob);
         long dbId = loadJob.getDbId();
         if (!dbIdToLabelToLoadJobs.containsKey(dbId)) {

--- a/fe/src/main/java/org/apache/doris/load/loadv2/LoadManager.java
+++ b/fe/src/main/java/org/apache/doris/load/loadv2/LoadManager.java
@@ -109,7 +109,7 @@ public class LoadManager implements Writable{
                                                + "please retry later.");
             }
             loadJob = BrokerLoadJob.fromLoadStmt(stmt, originStmt);
-            addLoadJob(loadJob);
+            createLoadJob(loadJob);
         } finally {
             writeUnlock();
         }
@@ -146,7 +146,7 @@ public class LoadManager implements Writable{
             // Mini load job must be executed before release write lock.
             // Otherwise, the duplicated request maybe get the transaction id before transaction of mini load is begun.
             loadJob.unprotectedExecute();
-            addLoadJob(loadJob);
+            createLoadJob(loadJob);
         } catch (DuplicatedRequestException e) {
             // this is a duplicate request, just return previous txn id
             LOG.info("deplicate request for mini load. request id: {}, txn: {}", e.getDuplicatedRequestId(), e.getTxnId());
@@ -240,6 +240,7 @@ public class LoadManager implements Writable{
                          .build());
     }
 
+    // add load job and also add to to callback factory
     private void createLoadJob(LoadJob loadJob) {
         addLoadJob(loadJob);
         // add callback before txn created, because callback will be performed on replay without txn begin

--- a/fe/src/main/java/org/apache/doris/load/loadv2/LoadManager.java
+++ b/fe/src/main/java/org/apache/doris/load/loadv2/LoadManager.java
@@ -41,6 +41,9 @@ import org.apache.doris.system.SystemInfoService;
 import org.apache.doris.thrift.TMiniLoadBeginRequest;
 import org.apache.doris.thrift.TMiniLoadRequest;
 import org.apache.doris.thrift.TUniqueId;
+import org.apache.doris.transaction.GlobalTransactionMgr;
+import org.apache.doris.transaction.TransactionState;
+import org.apache.doris.transaction.TransactionStatus;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
@@ -293,7 +296,7 @@ public class LoadManager implements Writable{
             if (loadJobList == null) {
                 throw new DdlException("Load job does not exist");
             }
-            Optional<LoadJob> loadJobOptional = loadJobList.stream().filter(entity -> !entity.isCompleted()).findFirst();
+            Optional<LoadJob> loadJobOptional = loadJobList.stream().filter(entity -> !entity.isTxnDone()).findFirst();
             if (!loadJobOptional.isPresent()) {
                 throw new DdlException("There is no uncompleted job which label is " + stmt.getLabel());
             }
@@ -586,6 +589,25 @@ public class LoadManager implements Writable{
         if (job != null) {
             job.updateScannedRows(loadId, fragmentId, scannedRows);
         }
+    }
+
+    // in previous implementation, there is a bug that when the job's corresponding transaction is
+    // COMMITTED but not VISIBLE, the load job's state is LOADING, so that the job may be CANCELLED
+    // by timeout checker, which is not right.
+    // So here we will check each LOADING load jobs' txn status, if it is COMMITTED, change load job's
+    // state to COMMITTED.
+    public void transferLoadingStateToCommitted(GlobalTransactionMgr txnMgr) {
+        for (LoadJob job : idToLoadJob.values()) {
+            if (job.getState() == JobState.LOADING) {
+                TransactionState txn = txnMgr.getTransactionState(job.getTransactionId());
+                if (txn != null && txn.getTransactionStatus() == TransactionStatus.COMMITTED) {
+                    job.updateState(JobState.COMMITTED);
+                    LOG.info("transfer load job {} state from LOADING to COMMITTED, because txn {} is COMMITTED",
+                            job.getId(), txn.getTransactionId());
+                }
+            }
+        }
+
     }
 
     @Override

--- a/fe/src/main/java/org/apache/doris/load/loadv2/LoadManager.java
+++ b/fe/src/main/java/org/apache/doris/load/loadv2/LoadManager.java
@@ -371,6 +371,7 @@ public class LoadManager implements Writable{
         }
     }
 
+    // only for those jobs which transaction is not started
     public void processTimeoutJobs() {
         idToLoadJob.values().stream().forEach(entity -> entity.processTimeout());
     }

--- a/fe/src/main/java/org/apache/doris/load/loadv2/LoadTimeoutChecker.java
+++ b/fe/src/main/java/org/apache/doris/load/loadv2/LoadTimeoutChecker.java
@@ -24,9 +24,9 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 /**
- * LoadTimeoutChecker is performed to cancel the timeout job.
- * The job which is not finished, not cancelled, not isCommitting will be checked.
- * The standard of timeout is CurrentTS > (CreateTs + timeoutSeconds * 1000).
+ * LoadTimeoutChecker will try to cancel the timeout load jobs.
+ * And it will not handle the job which the corresponding transaction is started.
+ * For those jobs, global transaction manager cancel the corresponding job while aborting the timeout transaction.
  */
 public class LoadTimeoutChecker extends Daemon {
     private static final Logger LOG = LogManager.getLogger(LoadTimeoutChecker.class);

--- a/fe/src/main/java/org/apache/doris/load/loadv2/MiniLoadJob.java
+++ b/fe/src/main/java/org/apache/doris/load/loadv2/MiniLoadJob.java
@@ -61,7 +61,6 @@ public class MiniLoadJob extends LoadJob {
         if (request.isSetMax_filter_ratio()) {
             this.maxFilterRatio = request.getMax_filter_ratio();
         }
-        this.isCancellable = false;
         this.createTimestamp = request.getCreate_timestamp();
         this.loadStartTimestamp = createTimestamp;
         this.authorizationInfo = gatherAuthInfo();

--- a/fe/src/main/java/org/apache/doris/load/loadv2/MiniLoadJob.java
+++ b/fe/src/main/java/org/apache/doris/load/loadv2/MiniLoadJob.java
@@ -22,6 +22,7 @@ import org.apache.doris.catalog.Catalog;
 import org.apache.doris.catalog.Database;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.Config;
+import org.apache.doris.common.DuplicatedRequestException;
 import org.apache.doris.common.LabelAlreadyUsedException;
 import org.apache.doris.common.MetaNotFoundException;
 import org.apache.doris.common.io.Text;
@@ -86,9 +87,10 @@ public class MiniLoadJob extends LoadJob {
     }
 
     @Override
-    public void beginTxn() throws LabelAlreadyUsedException, BeginTransactionException, AnalysisException {
+    public void beginTxn()
+            throws LabelAlreadyUsedException, BeginTransactionException, AnalysisException, DuplicatedRequestException {
         transactionId = Catalog.getCurrentGlobalTransactionMgr()
-                .beginTransaction(dbId, label, null, "FE: " + FrontendOptions.getLocalHostAddress(),
+                .beginTransaction(dbId, label, requestId, "FE: " + FrontendOptions.getLocalHostAddress(),
                                   TransactionState.LoadJobSourceType.BACKEND_STREAMING, id,
                                   timeoutSecond);
     }

--- a/fe/src/main/java/org/apache/doris/load/routineload/RoutineLoadTaskInfo.java
+++ b/fe/src/main/java/org/apache/doris/load/routineload/RoutineLoadTaskInfo.java
@@ -20,6 +20,7 @@ package org.apache.doris.load.routineload;
 
 import org.apache.doris.catalog.Catalog;
 import org.apache.doris.common.AnalysisException;
+import org.apache.doris.common.DuplicatedRequestException;
 import org.apache.doris.common.LabelAlreadyUsedException;
 import org.apache.doris.common.UserException;
 import org.apache.doris.common.util.DebugUtil;
@@ -148,6 +149,10 @@ public abstract class RoutineLoadTaskInfo {
                     routineLoadJob.getDbId(), DebugUtil.printId(id), null, "FE: " + FrontendOptions.getLocalHostAddress(),
                     TransactionState.LoadJobSourceType.ROUTINE_LOAD_TASK, routineLoadJob.getId(),
                     timeoutMs / 1000);
+        } catch (DuplicatedRequestException e) {
+            // should not happen, because we didn't pass request id in when begin transaction
+            LOG.warn("failed to begin txn for routine load task: {}, {}", DebugUtil.printId(id), e.getMessage());
+            return false;
         } catch (LabelAlreadyUsedException e) {
             // this should not happen for a routine load task, throw it out
             throw e;

--- a/fe/src/main/java/org/apache/doris/persist/EditLog.java
+++ b/fe/src/main/java/org/apache/doris/persist/EditLog.java
@@ -564,7 +564,6 @@ public class EditLog {
                     final TransactionState state = (TransactionState) journal.getData();
                     Catalog.getCurrentGlobalTransactionMgr().replayUpsertTransactionState(state);
                     LOG.debug("opcode: {}, tid: {}", opCode, state.getTransactionId());
-
                     break;
                 }
                 case OperationType.OP_DELETE_TRANSACTION_STATE: {

--- a/fe/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
+++ b/fe/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
@@ -31,6 +31,7 @@ import org.apache.doris.common.AuditLog;
 import org.apache.doris.common.AuthenticationException;
 import org.apache.doris.common.CaseSensibility;
 import org.apache.doris.common.Config;
+import org.apache.doris.common.DuplicatedRequestException;
 import org.apache.doris.common.LabelAlreadyUsedException;
 import org.apache.doris.common.PatternMatcher;
 import org.apache.doris.common.ThriftServerContext;
@@ -609,6 +610,10 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         result.setStatus(status);
         try {
             result.setTxnId(loadTxnBeginImpl(request, clientAddr));
+        } catch (DuplicatedRequestException e) {
+            // this is a duplicate request, just return previous txn id
+            LOG.info("deplicate request for stream load. request id: {}, txn: {}", e.getDuplicatedRequestId(), e.getTxnId());
+            result.setTxnId(e.getTxnId());
         } catch (LabelAlreadyUsedException e) {
             status.setStatus_code(TStatusCode.LABEL_ALREADY_EXISTS);
             status.addToError_msgs(e.getMessage());

--- a/fe/src/main/java/org/apache/doris/transaction/GlobalTransactionMgr.java
+++ b/fe/src/main/java/org/apache/doris/transaction/GlobalTransactionMgr.java
@@ -35,6 +35,7 @@ import org.apache.doris.common.LabelAlreadyUsedException;
 import org.apache.doris.common.LoadException;
 import org.apache.doris.common.MetaNotFoundException;
 import org.apache.doris.common.UserException;
+import org.apache.doris.common.io.Writable;
 import org.apache.doris.common.util.TimeUtils;
 import org.apache.doris.common.util.Util;
 import org.apache.doris.metric.MetricRepo;
@@ -62,6 +63,7 @@ import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -77,7 +79,7 @@ import java.util.stream.Collectors;
  * 3. abort
  * Attention: all api in txn manager should get db lock or load lock first, then get txn manager's lock, or there will be dead lock
  */
-public class GlobalTransactionMgr {
+public class GlobalTransactionMgr implements Writable {
     private static final Logger LOG = LogManager.getLogger(GlobalTransactionMgr.class);
     
     // the lock is used to control the access to transaction states
@@ -87,8 +89,12 @@ public class GlobalTransactionMgr {
     
     // transactionId -> TransactionState
     private Map<Long, TransactionState> idToTransactionState = Maps.newConcurrentMap();
-    // db id -> (label -> txn id)
-    private com.google.common.collect.Table<Long, String, Long> dbIdToTxnLabels = HashBasedTable.create();
+    // db id -> (label -> txn ids)
+    // this is used for checking if label already used. a label may correspond to multiple txns,
+    // and only one is success.
+    // this member should be consistent with idToTransactionState, which means if a txn exist in idToTransactionState,
+    // it must exists in dbIdToTxnLabels, and vice versa
+    private com.google.common.collect.Table<Long, String, Set<Long>> dbIdToTxnLabels = HashBasedTable.create();
     // count the number of running txns of each database, except for the routine load txn
     private Map<Long, Integer> runningTxnNums = Maps.newHashMap();
     // count only the number of running routine load txns of each database
@@ -145,20 +151,37 @@ public class GlobalTransactionMgr {
             Preconditions.checkNotNull(coordinator);
             Preconditions.checkNotNull(label);
             FeNameFormat.checkLabel(label);
-            Map<String, Long> txnLabels = dbIdToTxnLabels.row(dbId);
-            if (txnLabels != null && txnLabels.containsKey(label)) {
-                TransactionState existTxn = getTransactionState(txnLabels.get(label));
-                // check timestamp
-                if (requestId != null) {
-                    if (existTxn != null && existTxn.getTransactionStatus() == TransactionStatus.PREPARE
-                            && existTxn.getRequsetId() != null && existTxn.getRequsetId().equals(requestId)) {
-                        // this may be a retry request for same job, just return existing txn id.
-                        return txnLabels.get(label);
+
+            /*
+             * Check if label already used, by following steps
+             * 1. get all existing transactions
+             * 2. if there is a PREPARE transaction, check if this is a retry request. If yes, return the
+             *    existing txn id.
+             * 3. if there is a non-aborted transaction, throw label already used exception.
+             */
+            Set<Long> existingTxnIds = dbIdToTxnLabels.get(dbId, label);
+            if (existingTxnIds != null && !existingTxnIds.isEmpty()) {
+                List<TransactionState> notAbortedTxns = Lists.newArrayList();
+                for (long txnId : existingTxnIds) {
+                    TransactionState txn = idToTransactionState.get(txnId);
+                    Preconditions.checkNotNull(txn);
+                    if (txn.getTransactionStatus() != TransactionStatus.ABORTED) {
+                        notAbortedTxns.add(txn);
                     }
                 }
-                throw new LabelAlreadyUsedException(label, existTxn.getTransactionStatus());
+                // there should be at most 1 txn in PREPARE/COMMITTED/VISIBLE status
+                Preconditions.checkState(notAbortedTxns.size() <= 1, notAbortedTxns);
+                if (requestId != null && !notAbortedTxns.isEmpty()) {
+                    TransactionState notAbortedTxn = notAbortedTxns.get(0);
+                    if (notAbortedTxn.getTransactionStatus() == TransactionStatus.PREPARE
+                            && notAbortedTxn.getRequsetId() != null && notAbortedTxn.getRequsetId().equals(requestId)) {
+                        // this may be a retry request for same job, just return existing txn id.
+                        return notAbortedTxn.getTransactionId();
+                    }
+                    throw new LabelAlreadyUsedException(label, notAbortedTxn.getTransactionStatus());
+                }
             }
-            
+
             checkRunningTxnExceedLimit(dbId, sourceType);
           
             long tid = idGenerator.getNextTransactionId();
@@ -203,15 +226,13 @@ public class GlobalTransactionMgr {
     public TransactionStatus getLabelState(long dbId, String label) {
         readLock();
         try {
-            Map<String, Long> txnLabels = dbIdToTxnLabels.row(dbId);
-            if (txnLabels == null) {
+            Set<Long> existingTxnIds = dbIdToTxnLabels.get(dbId, label);
+            if (existingTxnIds == null || existingTxnIds.isEmpty()) {
                 return TransactionStatus.UNKNOWN;
             }
-            Long transactionId = txnLabels.get(label);
-            if (transactionId == null) {
-                return TransactionStatus.UNKNOWN;
-            }
-            return idToTransactionState.get(transactionId).getTransactionStatus();
+            // find the latest txn (which id is largest)
+            long maxTxnId = existingTxnIds.stream().max(Comparator.comparingLong(Long::valueOf)).get();
+            return idToTransactionState.get(maxTxnId).getTransactionStatus();
         } finally {
             readUnlock();
         }
@@ -224,8 +245,8 @@ public class GlobalTransactionMgr {
             if (state == null) {
                 return;
             }
-            editLog.logDeleteTransactionState(state);
             replayDeleteTransactionState(state);
+            editLog.logDeleteTransactionState(state);
         } finally {
             writeUnlock();
         }
@@ -493,18 +514,29 @@ public class GlobalTransactionMgr {
     public void abortTransaction(Long dbId, String label, String reason) throws UserException {
         Preconditions.checkNotNull(label);
         Long transactionId = null;
-        writeLock();
+        readLock();
         try {
-            Map<String, Long> dbTxns = dbIdToTxnLabels.row(dbId);
-            if (dbTxns == null) {
+            Set<Long> existingTxns = dbIdToTxnLabels.get(dbId, label);
+            if (existingTxns == null || existingTxns.isEmpty()) {
                 throw new UserException("transaction not found, label=" + label);
             }
-            transactionId = dbTxns.get(label);
-            if (transactionId == null) {
+            // find PREPARE txn
+            TransactionState prepareTxn = null;
+            for (Long txnId : existingTxns) {
+                TransactionState txn = idToTransactionState.get(txnId);
+                if (txn.getTransactionStatus() == TransactionStatus.PREPARE) {
+                    prepareTxn = txn;
+                    break;
+                }
+            }
+
+            if (prepareTxn == null) {
                 throw new UserException("transaction not found, label=" + label);
             }
+
+            transactionId = prepareTxn.getTransactionId();
         } finally {
-            writeUnlock();
+            readUnlock();
         }
         abortTransaction(transactionId, reason);
     }
@@ -837,7 +869,7 @@ public class GlobalTransactionMgr {
 
         List<Long> timeoutTxns = Lists.newArrayList();
         List<Long> expiredTxns = Lists.newArrayList();
-        writeLock();
+        readLock();
         try {
             for (TransactionState transactionState : idToTransactionState.values()) {
                 if (transactionState.isExpired(currentMillis)) {
@@ -849,7 +881,7 @@ public class GlobalTransactionMgr {
                 }
             }
         } finally {
-            writeUnlock();
+            readUnlock();
         }
 
         // delete expired txns
@@ -1000,7 +1032,11 @@ public class GlobalTransactionMgr {
         writeLock();
         try {
             idToTransactionState.remove(transactionState.getTransactionId());
-            dbIdToTxnLabels.remove(transactionState.getDbId(), transactionState.getLabel());
+            Set<Long> txnIds = dbIdToTxnLabels.get(transactionState.getDbId(), transactionState.getLabel());
+            txnIds.remove(transactionState.getTransactionId());
+            if (txnIds.isEmpty()) {
+                dbIdToTxnLabels.remove(transactionState.getDbId(), transactionState.getLabel());
+            }
         } finally {
             writeUnlock();
         }
@@ -1112,13 +1148,12 @@ public class GlobalTransactionMgr {
     }
     
     private void updateTxnLabels(TransactionState transactionState) {
-        // if the transaction is aborted, then its label could be reused
-        if (transactionState.getTransactionStatus() == TransactionStatus.ABORTED) {
-            dbIdToTxnLabels.remove(transactionState.getDbId(), transactionState.getLabel());
-        } else {
-            dbIdToTxnLabels.put(transactionState.getDbId(), transactionState.getLabel(),
-                                transactionState.getTransactionId());
+        Set<Long> txnIds = dbIdToTxnLabels.get(transactionState.getDbId(), transactionState.getLabel());
+        if (txnIds == null) {
+            txnIds = Sets.newHashSet();
+            dbIdToTxnLabels.put(transactionState.getDbId(), transactionState.getLabel(), txnIds);
         }
+        txnIds.add(transactionState.getTransactionId());
     }
     
     private void updateDBRunningTxnNum(TransactionStatus preStatus, TransactionState curTxnState) {
@@ -1278,7 +1313,7 @@ public class GlobalTransactionMgr {
         return this.idGenerator;
     }
 
-    // this two function used to read snapshot or write snapshot
+    @Override
     public void write(DataOutput out) throws IOException {
         int numTransactions = idToTransactionState.size();
         out.writeInt(numTransactions);
@@ -1288,6 +1323,7 @@ public class GlobalTransactionMgr {
         idGenerator.write(out);
     }
     
+    @Override
     public void readFields(DataInput in) throws IOException {
         int numTransactions = in.readInt();
         for (int i = 0; i < numTransactions; ++i) {

--- a/fe/src/main/java/org/apache/doris/transaction/GlobalTransactionMgr.java
+++ b/fe/src/main/java/org/apache/doris/transaction/GlobalTransactionMgr.java
@@ -1345,4 +1345,18 @@ public class GlobalTransactionMgr implements Writable {
         }
         idGenerator.readFields(in);
     }
+
+    public TransactionState getCommittedTransactionStateByCallbackId(long callbackId) {
+        readLock();
+        try {
+            for (TransactionState txn : idToTransactionState.values()) {
+                if (txn.getCallbackId() == callbackId && txn.getTransactionStatus() == TransactionStatus.COMMITTED) {
+                    return txn;
+                }
+            }
+        } finally {
+            readUnlock();
+        }
+        return null;
+    }
 }

--- a/fe/src/main/java/org/apache/doris/transaction/GlobalTransactionMgr.java
+++ b/fe/src/main/java/org/apache/doris/transaction/GlobalTransactionMgr.java
@@ -991,7 +991,8 @@ public class GlobalTransactionMgr implements Writable {
         }
         if (transactionState.getTransactionStatus() == TransactionStatus.COMMITTED
                 || transactionState.getTransactionStatus() == TransactionStatus.VISIBLE) {
-            throw new UserException("transaction's state is already committed or visible, could not abort");
+            throw new UserException("transaction's state is already "
+                    + transactionState.getTransactionStatus() + ", could not abort");
         }
         transactionState.setFinishTime(System.currentTimeMillis());
         transactionState.setReason(reason);
@@ -1012,10 +1013,10 @@ public class GlobalTransactionMgr implements Writable {
             transactionState.replaySetTransactionStatus();
             Database db = catalog.getDb(transactionState.getDbId());
             if (transactionState.getTransactionStatus() == TransactionStatus.COMMITTED) {
-                LOG.debug("replay a committed transaction {}", transactionState);
+                LOG.info("replay a committed transaction {}", transactionState);
                 updateCatalogAfterCommitted(transactionState, db);
             } else if (transactionState.getTransactionStatus() == TransactionStatus.VISIBLE) {
-                LOG.debug("replay a visible transaction {}", transactionState);
+                LOG.info("replay a visible transaction {}", transactionState);
                 updateCatalogAfterVisible(transactionState, db);
             }
             TransactionState preTxnState = idToTransactionState.get(transactionState.getTransactionId());

--- a/fe/src/main/java/org/apache/doris/transaction/GlobalTransactionMgr.java
+++ b/fe/src/main/java/org/apache/doris/transaction/GlobalTransactionMgr.java
@@ -527,7 +527,7 @@ public class GlobalTransactionMgr implements Writable {
             if (existingTxns == null || existingTxns.isEmpty()) {
                 throw new UserException("transaction not found, label=" + label);
             }
-            // find PREPARE txn
+            // find PREPARE txn. For one load label, there should be only one PREPARE txn.
             TransactionState prepareTxn = null;
             for (Long txnId : existingTxns) {
                 TransactionState txn = idToTransactionState.get(txnId);

--- a/fe/src/main/java/org/apache/doris/transaction/GlobalTransactionMgr.java
+++ b/fe/src/main/java/org/apache/doris/transaction/GlobalTransactionMgr.java
@@ -171,9 +171,9 @@ public class GlobalTransactionMgr implements Writable {
                 }
                 // there should be at most 1 txn in PREPARE/COMMITTED/VISIBLE status
                 Preconditions.checkState(notAbortedTxns.size() <= 1, notAbortedTxns);
-                if (requestId != null && !notAbortedTxns.isEmpty()) {
+                if (!notAbortedTxns.isEmpty()) {
                     TransactionState notAbortedTxn = notAbortedTxns.get(0);
-                    if (notAbortedTxn.getTransactionStatus() == TransactionStatus.PREPARE
+                    if (requestId != null && notAbortedTxn.getTransactionStatus() == TransactionStatus.PREPARE
                             && notAbortedTxn.getRequsetId() != null && notAbortedTxn.getRequsetId().equals(requestId)) {
                         // this may be a retry request for same job, just return existing txn id.
                         return notAbortedTxn.getTransactionId();

--- a/fe/src/main/java/org/apache/doris/transaction/TransactionState.java
+++ b/fe/src/main/java/org/apache/doris/transaction/TransactionState.java
@@ -336,7 +336,8 @@ public class TransactionState implements Writable {
             switch (transactionStatus) {
                 case COMMITTED:
                     // Maybe listener has been deleted. The txn need to be aborted later.
-                    throw new TransactionException("Failed to commit txn when callback could not be found");
+                    throw new TransactionException(
+                            "Failed to commit txn when callback " + callbackId + "could not be found");
                 default:
                     break;
             }

--- a/fe/src/main/java/org/apache/doris/transaction/TransactionState.java
+++ b/fe/src/main/java/org/apache/doris/transaction/TransactionState.java
@@ -469,6 +469,7 @@ public class TransactionState implements Writable {
         sb.append("transaction id: ").append(transactionId);
         sb.append(", label: ").append(label);
         sb.append(", db id: ").append(dbId);
+        sb.append(", callback id: ").append(callbackId);
         sb.append(", coordinator: ").append(coordinator);
         sb.append(", transaction status: ").append(transactionStatus);
         sb.append(", error replicas num: ").append(errorReplicas.size());

--- a/fe/src/main/java/org/apache/doris/transaction/TxnStateCallbackFactory.java
+++ b/fe/src/main/java/org/apache/doris/transaction/TxnStateCallbackFactory.java
@@ -40,8 +40,9 @@ public class TxnStateCallbackFactory {
     }
 
     public synchronized void removeCallback(long id) {
-        callbacks.remove(id);
-        LOG.info("remove callback of txn state : {}", id);
+        if (callbacks.remove(id) != null) {
+            LOG.info("remove callback of txn state : {}", id);
+        }
     }
 
     public synchronized TxnStateChangeCallback getCallback(long id) {

--- a/fe/src/test/java/org/apache/doris/http/DorisHttpTestCase.java
+++ b/fe/src/test/java/org/apache/doris/http/DorisHttpTestCase.java
@@ -61,6 +61,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
 import junit.framework.AssertionFailedError;
@@ -106,7 +107,11 @@ abstract public class DorisHttpTestCase {
     public static long testPartitionCurrentVersionHash = 12312;
     public static long testPartitionNextVersionHash = 123123123;
 
-    public static final int HTTP_PORT = 32474;
+    public static final int HTTP_PORT;
+    static {
+        Random r = new Random(System.currentTimeMillis());
+        HTTP_PORT = 30000 + r.nextInt(10000);
+    }
 
     protected static final String URI = "http://localhost:" + HTTP_PORT + "/api/" + DB_NAME + "/" + TABLE_NAME;
 

--- a/fe/src/test/java/org/apache/doris/load/loadv2/LoadJobTest.java
+++ b/fe/src/test/java/org/apache/doris/load/loadv2/LoadJobTest.java
@@ -22,6 +22,7 @@ import org.apache.doris.analysis.LoadStmt;
 import org.apache.doris.catalog.Catalog;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.DdlException;
+import org.apache.doris.common.DuplicatedRequestException;
 import org.apache.doris.common.LabelAlreadyUsedException;
 import org.apache.doris.common.MetaNotFoundException;
 import org.apache.doris.metric.LongCounterMetric;
@@ -100,7 +101,7 @@ public class LoadJobTest {
     @Test
     public void testExecute(@Mocked GlobalTransactionMgr globalTransactionMgr,
                             @Mocked MasterTaskExecutor masterTaskExecutor)
-            throws LabelAlreadyUsedException, BeginTransactionException, AnalysisException {
+            throws LabelAlreadyUsedException, BeginTransactionException, AnalysisException, DuplicatedRequestException {
         LoadJob loadJob = new BrokerLoadJob();
         new Expectations() {
             {

--- a/fe/src/test/java/org/apache/doris/transaction/GlobalTransactionMgrTest.java
+++ b/fe/src/test/java/org/apache/doris/transaction/GlobalTransactionMgrTest.java
@@ -31,6 +31,7 @@ import org.apache.doris.catalog.Replica;
 import org.apache.doris.catalog.Tablet;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.Config;
+import org.apache.doris.common.DuplicatedRequestException;
 import org.apache.doris.common.FeMetaVersion;
 import org.apache.doris.common.LabelAlreadyUsedException;
 import org.apache.doris.common.UserException;
@@ -103,7 +104,7 @@ public class GlobalTransactionMgrTest {
 
     @Test
     public void testBeginTransaction() throws LabelAlreadyUsedException, AnalysisException,
-            BeginTransactionException {
+            BeginTransactionException, DuplicatedRequestException {
         FakeCatalog.setCatalog(masterCatalog);
         long transactionId = masterTransMgr.beginTransaction(CatalogTestUtil.testDbId1,
                 CatalogTestUtil.testTxnLable1,
@@ -119,7 +120,7 @@ public class GlobalTransactionMgrTest {
 
     @Test
     public void testBeginTransactionWithSameLabel() throws LabelAlreadyUsedException, AnalysisException,
-            BeginTransactionException {
+            BeginTransactionException, DuplicatedRequestException {
         FakeCatalog.setCatalog(masterCatalog);
         long transactionId = 0;
         try {
@@ -599,7 +600,7 @@ public class GlobalTransactionMgrTest {
 
     @Test
     public void testDeleteTransaction() throws LabelAlreadyUsedException,
-            AnalysisException, BeginTransactionException {
+            AnalysisException, BeginTransactionException, DuplicatedRequestException {
 
         long transactionId = masterTransMgr.beginTransaction(CatalogTestUtil.testDbId1,
                 CatalogTestUtil.testTxnLable1,


### PR DESCRIPTION
1. `dbIdToTxnLabels` in `GlobalTransactionMgr` should be consistent with `idToTransactionState`, not only contains running or finished transactions' labels.

2. callback id should be removed when replaying transaction abort or visible edit log.

3. `LabelAlreadyUsed` exception should be thrown before adding load job. Otherwise, there will be lots of CANCELLED load jobs when reason "label already used".

4. LoadTimeoutChecker should check txn's status before deciding weather to cancel the job, instead of only checking job' state.

ISSUE #2240 