### PR TITLE
Fix bug for showing columns from non exist table doesn't prompt error

### DIFF
--- a/fe/src/main/java/org/apache/doris/qe/ShowExecutor.java
+++ b/fe/src/main/java/org/apache/doris/qe/ShowExecutor.java
@@ -624,10 +624,14 @@ public class ShowExecutor {
                                                         aggType));
                         }
                     }
+                } else {
+                    ErrorReport.reportAnalysisException(ErrorCode.ERR_BAD_TABLE_ERROR, db.getFullName() + "." + showStmt.getTable());
                 }
             } finally {
                 db.readUnlock();
             }
+        } else {
+            ErrorReport.reportAnalysisException(ErrorCode.ERR_BAD_TABLE_ERROR, showStmt.getDb() + "." + showStmt.getTable());
         }
         resultSet = new ShowResultSet(showStmt.getMetaData(), rows);
     }


### PR DESCRIPTION
when we execute show columns statement for non exist table, the response from doris is nothing, which may make user confused