### PR TITLE
fix is not null bug #2278

### DIFF
--- a/be/src/olap/null_predicate.cpp
+++ b/be/src/olap/null_predicate.cpp
@@ -41,8 +41,6 @@ void NullPredicate::evaluate(VectorizedRowBatch* batch) const {
     }
 
     if (batch->column(_column_id)->no_nulls() && !_is_null) {
-        batch->set_size(n);
-        batch->set_selected_in_use(false);
         return;
     }
 


### PR DESCRIPTION
query with is not null predicate returns invalid result
Issue: #2278 