### PR TITLE
Refactor clone task

### DIFF
--- a/be/src/agent/task_worker_pool.h
+++ b/be/src/agent/task_worker_pool.h
@@ -139,9 +139,6 @@ private:
     AgentUtils* _agent_utils;
     MasterServerClient* _master_client;
     ExecEnv* _env;
-#ifdef BE_TEST
-    AgentServerClient* _agent_client;
-#endif
 
     std::deque<TAgentTaskRequest> _tasks;
     Mutex _worker_thread_lock;

--- a/be/src/agent/utils.cpp
+++ b/be/src/agent/utils.cpp
@@ -59,60 +59,6 @@ using apache::thrift::transport::TTransportException;
 
 namespace doris {
 
-
-AgentServerClient::AgentServerClient(const TBackend backend) :
-        _socket(new TSocket(backend.host, backend.be_port)),
-        _transport(new TBufferedTransport(_socket)),
-        _protocol(new TBinaryProtocol(_transport)),
-        _agent_service_client(_protocol) {
-}
-
-AgentServerClient::~AgentServerClient() {
-    if (_transport != NULL) {
-        _transport->close();
-    }
-}
-
-AgentStatus AgentServerClient::make_snapshot(
-        const TSnapshotRequest& snapshot_request,
-        TAgentResult* result) {
-    AgentStatus status = DORIS_SUCCESS;
-
-    TAgentResult thrift_result;
-    try {
-        _transport->open();
-        _agent_service_client.make_snapshot(thrift_result, snapshot_request);
-        *result = thrift_result;
-        _transport->close();
-    } catch (TException& e) {
-        OLAP_LOG_WARNING("agent clinet make snapshot, "
-                         "get exception, error: %s", e.what());
-        _transport->close();
-        status = DORIS_ERROR;
-    }
-
-    return status;
-}
-
-AgentStatus AgentServerClient::release_snapshot(
-        const string& snapshot_path,
-        TAgentResult* result) {
-    AgentStatus status = DORIS_SUCCESS;
-
-    try {
-        _transport->open();
-        _agent_service_client.release_snapshot(*result, snapshot_path);
-        _transport->close();
-    } catch (TException& e) {
-        OLAP_LOG_WARNING("agent clinet make snapshot, "
-                         "get exception, error: %s", e.what());
-        _transport->close();
-        status = DORIS_ERROR;
-    }
-    
-    return status;
-}
-
 MasterServerClient::MasterServerClient(
         const TMasterInfo& master_info,
         FrontendServiceClientCache* client_cache) :

--- a/be/src/agent/utils.h
+++ b/be/src/agent/utils.h
@@ -34,46 +34,6 @@
 
 namespace doris {
 
-// client cache
-// All service client should be defined in client_cache.h
-//class MasterServiceClient;
-//typedef ClientCache<MasterServiceClient> MasterServiceClientCache;
-//typedef ClientConnection<MasterServiceClient> MasterServiceConnection;
-
-class AgentServerClient {
-public:
-    explicit AgentServerClient(const TBackend backend);
-    virtual ~AgentServerClient();
-    
-    // Make a snapshot of tablet
-    //
-    // Input parameters:
-    // * tablet_id: The id of tablet to make snapshot
-    // * schema_hash: The schema hash of tablet to make snapshot
-    //
-    // Output parameters:
-    // * result: The result of make snapshot
-    virtual AgentStatus make_snapshot(
-            const TSnapshotRequest& snapshot_request,
-            TAgentResult* result);
-
-    // Release the snapshot
-    //
-    // Input parameters:
-    // * snapshot_path: The path of snapshot
-    //
-    // Output parameters:
-    // * result: The result of release snapshot
-    virtual AgentStatus release_snapshot(const std::string& snapshot_path, TAgentResult* result);
-
-private:
-    boost::shared_ptr<apache::thrift::transport::TTransport> _socket;
-    boost::shared_ptr<apache::thrift::transport::TTransport> _transport;
-    boost::shared_ptr<apache::thrift::protocol::TProtocol> _protocol;
-    BackendServiceClient _agent_service_client;
-    DISALLOW_COPY_AND_ASSIGN(AgentServerClient);
-};  // class AgentServerClient
-
 class MasterServerClient {
 public:
     MasterServerClient(const TMasterInfo& master_info, FrontendServiceClientCache* client_cache);

--- a/be/src/olap/snapshot_manager.cpp
+++ b/be/src/olap/snapshot_manager.cpp
@@ -123,7 +123,7 @@ OLAPStatus SnapshotManager::release_snapshot(const string& snapshot_path) {
 
 // TODO support beta rowset
 OLAPStatus SnapshotManager::convert_rowset_ids(const string& clone_dir, int64_t tablet_id,
-    const int32_t& schema_hash, TabletSharedPtr tablet) {
+    const int32_t& schema_hash) {
     OLAPStatus res = OLAP_SUCCESS;   
     // check clone dir existed
     if (!FileUtils::check_exist(clone_dir)) {

--- a/be/src/olap/snapshot_manager.h
+++ b/be/src/olap/snapshot_manager.h
@@ -65,7 +65,7 @@ public:
     static SnapshotManager* instance();
 
     OLAPStatus convert_rowset_ids(const string& clone_dir, int64_t tablet_id,
-            const int32_t& schema_hash, TabletSharedPtr tablet);
+            const int32_t& schema_hash);
 
 private:
     SnapshotManager()

--- a/be/src/olap/task/engine_clone_task.h
+++ b/be/src/olap/task/engine_clone_task.h
@@ -45,28 +45,45 @@ public:
 
 private:
     
-    virtual OLAPStatus _finish_clone(TabletSharedPtr tablet, const std::string& clone_dir,
+    virtual OLAPStatus _finish_clone(Tablet* tablet, const std::string& clone_dir,
                                     int64_t committed_version, bool is_incremental_clone);
     
-    OLAPStatus _clone_incremental_data(TabletSharedPtr tablet, const TabletMeta& cloned_tablet_meta,
+    OLAPStatus _clone_incremental_data(Tablet* tablet, const TabletMeta& cloned_tablet_meta,
                                      int64_t committed_version);
 
-    OLAPStatus _clone_full_data(TabletSharedPtr tablet, TabletMeta* cloned_tablet_meta);
+    OLAPStatus _clone_full_data(Tablet* tablet, TabletMeta* cloned_tablet_meta);
 
     AgentStatus _clone_copy(DataDir& data_dir,
-        const TCloneReq& clone_req,
-        int64_t signature,
         const string& local_data_path,
         TBackend* src_host,
         string* src_file_path,
         vector<string>* error_msgs,
         const vector<Version>* missing_versions,
-        bool* allow_incremental_clone, 
-        TabletSharedPtr tablet);
+        bool* allow_incremental_clone);
         
     OLAPStatus _convert_to_new_snapshot(const string& clone_dir, int64_t tablet_id);
 
     void _set_tablet_info(AgentStatus status, bool is_new_tablet);
+
+    // Download tablet files from 
+    Status _download_files(
+        DataDir* data_dir,
+        const std::string& remote_url_prefix,
+        const std::string& local_path);
+
+    Status _make_snapshot(
+        const std::string& ip, int port,
+        TTableId tablet_id,
+        TSchemaHash schema_hash,
+        int timeout_s,
+        const std::vector<Version>* missed_versions,
+        std::string* snapshot_path,
+        bool* allow_incremental_clone,
+        int32_t* snapshot_version);
+
+    Status _release_snapshot(
+        const std::string& ip, int port,
+        const std::string& snapshot_path);
 
 private:
     const TCloneReq& _clone_req;

--- a/be/src/olap/task/engine_storage_migration_task.cpp
+++ b/be/src/olap/task/engine_storage_migration_task.cpp
@@ -193,7 +193,7 @@ OLAPStatus EngineStorageMigrationTask::_storage_medium_migrate(
 
         // it will change rowset id and its create time
         // rowset create time is useful when load tablet from meta to check which tablet is the tablet to load
-        res = SnapshotManager::instance()->convert_rowset_ids(schema_hash_path, tablet_id, schema_hash, nullptr);
+        res = SnapshotManager::instance()->convert_rowset_ids(schema_hash_path, tablet_id, schema_hash);
         if (res != OLAP_SUCCESS) {
             LOG(WARNING) << "failed to convert rowset id when do storage migration"
                          << " path = " << schema_hash_path;

--- a/be/src/runtime/snapshot_loader.cpp
+++ b/be/src/runtime/snapshot_loader.cpp
@@ -567,7 +567,7 @@ Status SnapshotLoader::move(
 
     // rename the rowset ids and tabletid info in rowset meta
     OLAPStatus convert_status = SnapshotManager::instance()->convert_rowset_ids(
-        snapshot_path, tablet_id, schema_hash, tablet);
+        snapshot_path, tablet_id, schema_hash);
     if (convert_status != OLAP_SUCCESS) {
         std::stringstream ss;
         ss << "failed to convert rowsetids in snapshot: " << snapshot_path


### PR DESCRIPTION
In the previous implementation, clone task will continue download files
even if some error happened. This may cause unexpected problem. This
Change List refactor it to that when error happends, clone task will
fail total and try to clone from another remote source.

Besides above change, I call FileUtils::remove_all and create_dir
instead of boost one, which may cause exception. What's more
AgentMasterClient is replaced with ThriftRpcHelper, by this change
conncection can be reused.

#2280 