### PR TITLE
Add a variable to specifically limit the memory usage of the load part in the insert operation

### DIFF
--- a/be/src/exec/tablet_sink.cpp
+++ b/be/src/exec/tablet_sink.cpp
@@ -513,8 +513,7 @@ Status OlapTableSink::prepare(RuntimeState* state) {
     _close_timer = ADD_TIMER(_profile, "CloseTime");
     _wait_in_flight_packet_timer = ADD_TIMER(_profile, "WaitInFlightPacketTime");
     _serialize_batch_timer = ADD_TIMER(_profile, "SerializeBatchTime");
-    // use query mem limit as load mem limit for remote load channels
-    _load_mem_limit = state->query_mem_tracker()->limit();
+    _load_mem_limit = state->get_load_mem_limit();
 
     // open all channels
     auto& partitions = _partition->get_partitions();

--- a/be/src/runtime/runtime_state.cpp
+++ b/be/src/runtime/runtime_state.cpp
@@ -531,5 +531,14 @@ Status RuntimeState::get_codegen(LlvmCodeGen** codegen) {
 Status RuntimeState::StartSpilling(MemTracker* mem_tracker) {
     return Status::InternalError("Mem limit exceeded.");
 }
+
+int64_t RuntimeState::get_load_mem_limit() {
+    if (_query_options.__isset.load_mem_limit && _query_options.load_mem_limit > 0) {
+        return  _query_options.load_mem_limit;
+    } else {
+        return _query_mem_tracker->limit();
+    }
+}
+
 } // end namespace doris
 

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -501,6 +501,16 @@ public:
     /// Helper to call QueryState::StartSpilling().
     Status StartSpilling(MemTracker* mem_tracker);
 
+    // get mem limit for load channel
+    // if load mem limit is not set, or is zero, using query mem limit instead.
+    int64_t get_load_mem_limit() {
+        if (_query_options.__isset.load_mem_limit && _query_options.load_mem_limit > 0) {
+            return  _query_options.load_mem_limit;
+        } else {
+            return _query_mem_tracker->limit();
+        }
+    }
+
 private:
     // Allow TestEnv to set block_mgr manually for testing.
     friend class TestEnv;

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -503,13 +503,7 @@ public:
 
     // get mem limit for load channel
     // if load mem limit is not set, or is zero, using query mem limit instead.
-    int64_t get_load_mem_limit() {
-        if (_query_options.__isset.load_mem_limit && _query_options.load_mem_limit > 0) {
-            return  _query_options.load_mem_limit;
-        } else {
-            return _query_mem_tracker->limit();
-        }
-    }
+    int64_t get_load_mem_limit();
 
 private:
     // Allow TestEnv to set block_mgr manually for testing.

--- a/docs/documentation/cn/administrator-guide/load-data/broker-load-manual.md
+++ b/docs/documentation/cn/administrator-guide/load-data/broker-load-manual.md
@@ -215,7 +215,7 @@ Label 的另一个作用，是防止用户重复导入相同的数据。**强烈
 
 + strict\_mode
 
-    Broker load 导入可以开启 strict mode 模式。开启方式为 ```properties ("strict_mode" = "true")``` 。默认的 strict mode 为开启。
+    Broker load 导入可以开启 strict mode 模式。开启方式为 ```properties ("strict_mode" = "true")``` 。默认的 strict mode 为关闭。
 
     strict mode 模式的意思是：对于导入过程中的列类型转换进行严格过滤。严格过滤的策略如下：
 

--- a/docs/documentation/cn/administrator-guide/load-data/routine-load-manual.md
+++ b/docs/documentation/cn/administrator-guide/load-data/routine-load-manual.md
@@ -150,7 +150,7 @@ FE 中的 JobScheduler 根据汇报结果，继续生成后续新的 Task，或�
 
 * strict\_mode
 
-    Routine load 导入可以开启 strict mode 模式。开启方式为在 job\_properties 中增加 ```"strict_mode" = "true"``` 。默认的 strict mode 为开启。
+    Routine load 导入可以开启 strict mode 模式。开启方式为在 job\_properties 中增加 ```"strict_mode" = "true"``` 。默认的 strict mode 为关闭。
 
     strict mode 模式的意思是：对于导入过程中的列类型转换进行严格过滤。严格过滤的策略如下：
 

--- a/docs/documentation/cn/administrator-guide/load-data/stream-load-manual.md
+++ b/docs/documentation/cn/administrator-guide/load-data/stream-load-manual.md
@@ -139,7 +139,7 @@ Stream load 由于使用的是 HTTP 协议，所以所有导入任务有关的�
 
 + strict\_mode
 
-    Stream load 导入可以开启 strict mode 模式。开启方式为在 HEADER 中声明 ```strict_mode=true``` 。默认的 strict mode 为开启。
+    Stream load 导入可以开启 strict mode 模式。开启方式为在 HEADER 中声明 ```strict_mode=true``` 。默认的 strict mode 为关闭。
 
     strict mode 模式的意思是：对于导入过程中的列类型转换进行严格过滤。严格过滤的策略如下：
 

--- a/docs/documentation/cn/administrator-guide/variables.md
+++ b/docs/documentation/cn/administrator-guide/variables.md
@@ -52,14 +52,8 @@ SET time_zone = "Asia/Shanghai";
 SET GLOBAL exec_mem_limit = 137438953472
 ```
 
-同时，变量设置也支持常量表达式。如：
-
-```
-SET exec_mem_limit = 10 * 1024 * 1024 * 1024;
-SET forward_to_master = concat('tr', 'u', 'e');
-```
-
 > 注1：只有 ADMIN 用户可以设置变量的全局生效。
+> 注2：全局生效的变量不影响当前会话的变量值，仅影响新的会话中的变量。
 
 支持全局生效的变量包括：
 
@@ -71,7 +65,14 @@ SET forward_to_master = concat('tr', 'u', 'e');
 * `exec_mem_limit`
 * `batch_size`
 * `parallel_fragment_exec_instance_num`
-* `parallel_fragment_exec_instance_num`
+* `parallel_exchange_instance_num`
+
+同时，变量设置也支持常量表达式。如：
+
+```
+SET exec_mem_limit = 10 * 1024 * 1024 * 1024;
+SET forward_to_master = concat('tr', 'u', 'e');
+```
 
 ## 支持的变量
 
@@ -209,6 +210,14 @@ SET forward_to_master = concat('tr', 'u', 'e');
 * `license`
     
     显示 Doris 的 License。无其他作用。
+
+* `load_mem_limit`
+
+    用于指定导入操作的内存限制。默认为 0，即表示不使用该变量，而采用 `exec_mem_limit` 作为导入操作的内存限制。
+    
+    这个变量仅用于 INSERT 操作。因为 INSERT 操作设计查询和导入两个部分，如果用户不设置此变量，则查询和导入操作各自的内存限制均为 `exec_mem_limit`。否则，INSERT 的查询部分内存限制为 `exec_mem_limit`，而导入部分限制为 `load_mem_limit`。
+    
+    其他导入方式，如 BROKER LOAD，STREAM LOAD 的内存限制依然使用 `exec_mem_limit`。
     
 * `lower_case_table_names`
 
@@ -236,7 +245,7 @@ SET forward_to_master = concat('tr', 'u', 'e');
     
     在一个分布式的查询执行计划中，上层节点通常有一个或多个 exchange node 用于接收来自下层节点在不同 BE 上的执行实例的数据。通常 exchange node 数量等于下层节点执行实例数量。
     
-    如果用户需要减少上层节点的 exchange node 数量，可以设置该值。
+    在一些聚合查询场景下，如果底层需要扫描的数据量较大，但聚合之后的数据量很小，则可以尝试修改此变量为一个较小的值，可以降低此类查询的资源开销。如在 DUPLICATE KEY 明细模型上进行聚合查询的场景。
     
 * `parallel_fragment_exec_instance_num`
 

--- a/docs/documentation/en/administrator-guide/load-data/broker-load-manual_EN.md
+++ b/docs/documentation/en/administrator-guide/load-data/broker-load-manual_EN.md
@@ -211,7 +211,7 @@ The following is a detailed explanation of some parameters of the import operati
 
 + strict\_mode
 
-	Broker load 导入可以开启 strict mode 模式。开启方式为 ```properties ("strict_mode" = "true")``` 。默认的 strict mode 为开启。
+	Broker load 导入可以开启 strict mode 模式。开启方式为 ```properties ("strict_mode" = "true")``` 。默认的 strict mode 为关闭。
 
 	The strict mode means that the column type conversion in the import process is strictly filtered. The strategy of strict filtering is as follows:
 

--- a/docs/documentation/en/administrator-guide/load-data/routine-load-manual_EN.md
+++ b/docs/documentation/en/administrator-guide/load-data/routine-load-manual_EN.md
@@ -150,7 +150,7 @@ The detailed syntax for creating a routine load task can be connected to Doris a
 
 * strict\_mode
 
-    Routine load load can turn on strict mode mode. The way to open it is to add ```"strict_mode" = "true"``` to job\_properties. The default strict mode is on.
+    Routine load load can turn on strict mode mode. The way to open it is to add ```"strict_mode" = "true"``` to job\_properties. The default strict mode is off.
 
     The strict mode mode means strict filtering of column type conversions during the load process. The strict filtering strategy is as follows:
 

--- a/docs/documentation/en/administrator-guide/variables_EN.md
+++ b/docs/documentation/en/administrator-guide/variables_EN.md
@@ -52,14 +52,8 @@ For global-level, set by `SET GLOBALE var_name=xxx;`. Such as:
 SET GLOBAL exec_mem_limit = 137438953472
 ```
 
-At the same time, variable settings also support constant expressions. Such as:
-
-```
-SET exec_mem_limit = 10 * 1024 * 1024 * 1024;
-SET forward_to_master = concat('tr', 'u', 'e');
-```
-
 > Note 1: Only ADMIN users can set variable at global-level.
+> Note 2: Global-level variables do not affect variable values in the current session, only variables in new sessions.
 
 Variables that support global-level setting include:
 
@@ -71,7 +65,14 @@ Variables that support global-level setting include:
 * `exec_mem_limit`
 * `batch_size`
 * `parallel_fragment_exec_instance_num`
-* `parallel_fragment_exec_instance_num`
+* `parallel_exchange_instance_num`
+
+At the same time, variable settings also support constant expressions. Such as:
+
+```
+SET exec_mem_limit = 10 * 1024 * 1024 * 1024;
+SET forward_to_master = concat('tr', 'u', 'e');
+```
 
 ## Supported variables
 
@@ -210,6 +211,14 @@ Variables that support global-level setting include:
 * `license`
     
     Show Doris's license. No other effect.
+
+* `load_mem_limit`
+
+    Used to specify the memory limit of the load operation. The default is 0, which means that this variable is not used, and `exec_mem_limit` is used as the memory limit for the load operation.
+
+    This variable is usually used for INSERT operations. Because the INSERT operation has both query and load part. If the user does not set this variable, the respective memory limits of the query and load part are `exec_mem_limit`. Otherwise, the memory of query part of INSERT is limited to `exec_mem_limit`, and the load part is limited to` load_mem_limit`.
+
+    For other load methods, such as BROKER LOAD, STREAM LOAD, the memory limit still uses `exec_mem_limit`.
     
 * `lower_case_table_names`
 
@@ -237,7 +246,7 @@ Variables that support global-level setting include:
     
     In a distributed query execution plan, the upper node usually has one or more exchange nodes for receiving data from the execution instances of the lower nodes on different BEs. Usually the number of exchange nodes is equal to the number of execution instances of the lower nodes.
     
-    This value can be set if the user needs to reduce the number of exchange nodes of the upper node.
+    In some aggregate query scenarios, if the amount of data to be scanned at the bottom is large, but the amount of data after aggregation is small, you can try to modify this variable to a smaller value, which can reduce the resource overhead of such queries. Such as the scenario of aggregation query on the DUPLICATE KEY data model.
 
 * `parallel_fragment_exec_instance_num`
 

--- a/fe/src/main/java/org/apache/doris/common/FeConstants.java
+++ b/fe/src/main/java/org/apache/doris/common/FeConstants.java
@@ -38,5 +38,5 @@ public class FeConstants {
 
     // general model
     // Current meta data version. Use this version to write journals and image
-    public static int meta_version = FeMetaVersion.VERSION_66;
+    public static int meta_version = FeMetaVersion.VERSION_67;
 }

--- a/fe/src/main/java/org/apache/doris/common/FeMetaVersion.java
+++ b/fe/src/main/java/org/apache/doris/common/FeMetaVersion.java
@@ -142,4 +142,6 @@ public final class FeMetaVersion {
     public static final int VERSION_65 = 65;
     // routine load/stream load persist session variables
     public static final int VERSION_66 = 66;
+    // load_mem_limit session variable
+    public static final int VERSION_67 = 67;
 }

--- a/fe/src/main/java/org/apache/doris/common/util/ParseUtil.java
+++ b/fe/src/main/java/org/apache/doris/common/util/ParseUtil.java
@@ -1,0 +1,74 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.common.util;
+
+import org.apache.doris.common.AnalysisException;
+import org.apache.doris.common.UserException;
+
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class ParseUtil {
+    private static ImmutableMap<String, Long> validDataVolumnUnitMultiplier =
+            ImmutableMap.<String, Long>builder().put("B", 1L)
+            .put("K", 1024L)
+            .put("KB", 1024L)
+            .put("M", 1024L * 1024)
+            .put("MB", 1024L * 1024)
+            .put("G", 1024L * 1024 * 1024)
+            .put("GB", 1024L * 1024 * 1024)
+            .put("T", 1024L * 1024 * 1024 * 1024)
+            .put("TB", 1024L * 1024 * 1024 * 1024)
+            .put("P", 1024L * 1024 * 1024 * 1024 * 1024)
+            .put("PB", 1024L * 1024 * 1024 * 1024 * 1024).build();
+
+    private static Pattern dataVolumnPattern = Pattern.compile("(\\d+)(\\D*)");
+
+    public static long analyzeDataVolumn(String dataVolumnStr) throws UserException {
+        long dataVolumn = 0;
+        Matcher m = dataVolumnPattern.matcher(dataVolumnStr);
+        if (m.matches()) {
+            try {
+                dataVolumn = Long.parseLong(m.group(1));
+            } catch (NumberFormatException nfe) {
+                throw new AnalysisException("invalid data volumn:" + m.group(1));
+            }
+            if (dataVolumn < 0L) {
+                throw new AnalysisException("Data volumn must larger than 0");
+            }
+
+            String unit = "B";
+            String tmpUnit = m.group(2);
+            if (!Strings.isNullOrEmpty(tmpUnit)) {
+                unit = tmpUnit.toUpperCase();
+            }
+            if (validDataVolumnUnitMultiplier.containsKey(unit)) {
+                dataVolumn = dataVolumn * validDataVolumnUnitMultiplier.get(unit);
+            } else {
+                throw new AnalysisException("invalid unit:" + tmpUnit);
+            }
+        } else {
+            throw new AnalysisException("invalid data volumn expression:" + dataVolumnStr);
+        }
+        return dataVolumn;
+    }
+
+}

--- a/fe/src/main/java/org/apache/doris/load/loadv2/LoadJob.java
+++ b/fe/src/main/java/org/apache/doris/load/loadv2/LoadJob.java
@@ -95,7 +95,7 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
     protected long timeoutSecond = Config.broker_load_default_timeout_second;
     protected long execMemLimit = 2147483648L; // 2GB;
     protected double maxFilterRatio = 0;
-    protected boolean strictMode = true;
+    protected boolean strictMode = false; // default is false
     protected String timezone = TimeUtils.DEFAULT_TIME_ZONE;
     @Deprecated
     protected boolean deleteFlag = false;

--- a/fe/src/main/java/org/apache/doris/load/loadv2/LoadLoadingTask.java
+++ b/fe/src/main/java/org/apache/doris/load/loadv2/LoadLoadingTask.java
@@ -103,6 +103,14 @@ public class LoadLoadingTask extends LoadTask {
                 planner.getFragments(), planner.getScanNodes(), db.getClusterName(), planner.getTimezone());
         curCoordinator.setQueryType(TQueryType.LOAD);
         curCoordinator.setExecMemoryLimit(execMemLimit);
+        /*
+         * For broker load job, user only need to set mem limit by 'exec_mem_limit' property.
+         * And the variable 'load_mem_limit' does not make any effect.
+         * However, in order to ensure the consistency of semantics when executing on the BE side, 
+         * and to prevent subsequent modification from incorrectly setting the load_mem_limit, 
+         * here we use exec_mem_limit to directly override the load_mem_limit property.
+         */
+        curCoordinator.setLoadMemLimit(execMemLimit);
         curCoordinator.setTimeout((int) (getLeftTimeMs() / 1000));
 
         try {

--- a/fe/src/main/java/org/apache/doris/load/routineload/RoutineLoadJob.java
+++ b/fe/src/main/java/org/apache/doris/load/routineload/RoutineLoadJob.java
@@ -97,7 +97,7 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback impl
     public static final long DEFAULT_MAX_INTERVAL_SECOND = 10;
     public static final long DEFAULT_MAX_BATCH_ROWS = 200000;
     public static final long DEFAULT_MAX_BATCH_SIZE = 100 * 1024 * 1024; // 100MB
-    public static final boolean DEFAULT_STRICT_MODE = true;
+    public static final boolean DEFAULT_STRICT_MODE = false; // default is false
 
     protected static final String STAR_STRING = "*";
      /*

--- a/fe/src/main/java/org/apache/doris/persist/EditLog.java
+++ b/fe/src/main/java/org/apache/doris/persist/EditLog.java
@@ -1028,7 +1028,6 @@ public class EditLog {
         logEdit(OperationType.OP_GLOBAL_VARIABLE, variable);
     }
 
-
     public void logCreateCluster(Cluster cluster) {
         logEdit(OperationType.OP_CREATE_CLUSTER, cluster);
     }

--- a/fe/src/main/java/org/apache/doris/planner/StreamLoadPlanner.java
+++ b/fe/src/main/java/org/apache/doris/planner/StreamLoadPlanner.java
@@ -145,6 +145,8 @@ public class StreamLoadPlanner {
         queryOptions.setQuery_type(TQueryType.LOAD);
         queryOptions.setQuery_timeout(streamLoadTask.getTimeout());
         queryOptions.setMem_limit(streamLoadTask.getMemLimit());
+        // for stream load, we use exec_mem_limit to limit the memory usage of load channel.
+        queryOptions.setLoad_mem_limit(streamLoadTask.getMemLimit());
         params.setQuery_options(queryOptions);
         TQueryGlobals queryGlobals = new TQueryGlobals();
         queryGlobals.setNow_string(DATE_FORMAT.format(new Date()));

--- a/fe/src/main/java/org/apache/doris/qe/ConnectProcessor.java
+++ b/fe/src/main/java/org/apache/doris/qe/ConnectProcessor.java
@@ -345,6 +345,9 @@ public class ConnectProcessor {
         if (request.isSetSqlMode()) {
             ctx.getSessionVariable().setSqlMode(request.sqlMode);
         }
+        if (request.isSetLoadMemLimit()) {
+            ctx.getSessionVariable().setLoadMemLimit(request.loadMemLimit);
+        }
 
         ctx.setThreadLocalInfo();
 

--- a/fe/src/main/java/org/apache/doris/qe/ConnectProcessor.java
+++ b/fe/src/main/java/org/apache/doris/qe/ConnectProcessor.java
@@ -348,6 +348,9 @@ public class ConnectProcessor {
         if (request.isSetLoadMemLimit()) {
             ctx.getSessionVariable().setLoadMemLimit(request.loadMemLimit);
         }
+        if (request.isSetEnableStrictMode()) {
+            ctx.getSessionVariable().setEnableInsertStrict(request.enableStrictMode);
+        }
 
         ctx.setThreadLocalInfo();
 

--- a/fe/src/main/java/org/apache/doris/qe/Coordinator.java
+++ b/fe/src/main/java/org/apache/doris/qe/Coordinator.java
@@ -75,7 +75,6 @@ import org.apache.doris.thrift.TScanRangeParams;
 import org.apache.doris.thrift.TStatusCode;
 import org.apache.doris.thrift.TTabletCommitInfo;
 import org.apache.doris.thrift.TUniqueId;
-import org.apache.doris.transaction.TransactionState.LoadJobSourceType;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
@@ -298,28 +297,6 @@ public class Coordinator {
 
     public List<TTabletCommitInfo> getCommitInfos() {
         return commitInfos;
-    }
-
-    /*
-     * calculate the set mem limit for load channel on BE.
-     * 1. For INSERT operation:
-     *      The memory consumption includes the query part and the load part.
-     *      But the user only needs to set a parameter exec_mem_limit to limit the overall memory limit.
-     *      We use a ratio of 8:2 to allocate memory to the query and load part.
-     *      And memory limit of load part should larger than 2GB
-     * 2. For BROKER/MINI/STREAMING load
-     *      The memory consumption is mainly concentrated in the load section.
-     *      So we allocate all the memory to the load part
-     */
-    public void calcLoadMemLimit(LoadJobSourceType loadType) {
-        switch (loadType) {
-            case INSERT_STREAMING:
-                break;
-            default:
-                this.queryOptions.setLoad_mem_limit(queryOptions.getMem_limit());
-                break;
-        }
-
     }
 
     // Initialize

--- a/fe/src/main/java/org/apache/doris/qe/Coordinator.java
+++ b/fe/src/main/java/org/apache/doris/qe/Coordinator.java
@@ -276,6 +276,10 @@ public class Coordinator {
         this.queryOptions.setMem_limit(execMemoryLimit);
     }
 
+    public void setLoadMemLimit(long loadMemLimit) {
+        this.queryOptions.setLoad_mem_limit(loadMemLimit);
+    }
+
     public void setTimeout(int timeout) {
         this.queryOptions.setQuery_timeout(timeout);
     }

--- a/fe/src/main/java/org/apache/doris/qe/Coordinator.java
+++ b/fe/src/main/java/org/apache/doris/qe/Coordinator.java
@@ -75,6 +75,7 @@ import org.apache.doris.thrift.TScanRangeParams;
 import org.apache.doris.thrift.TStatusCode;
 import org.apache.doris.thrift.TTabletCommitInfo;
 import org.apache.doris.thrift.TUniqueId;
+import org.apache.doris.transaction.TransactionState.LoadJobSourceType;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
@@ -190,8 +191,6 @@ public class Coordinator {
     // parallel execute
     private final TUniqueId nextInstanceId;
 
-    private boolean isQueryCoordinator;
-
     // Used for query/insert
     public Coordinator(ConnectContext context, Analyzer analyzer, Planner planner) {
         this.isBlockQuery = planner.isBlockQuery();
@@ -299,6 +298,28 @@ public class Coordinator {
 
     public List<TTabletCommitInfo> getCommitInfos() {
         return commitInfos;
+    }
+
+    /*
+     * calculate the set mem limit for load channel on BE.
+     * 1. For INSERT operation:
+     *      The memory consumption includes the query part and the load part.
+     *      But the user only needs to set a parameter exec_mem_limit to limit the overall memory limit.
+     *      We use a ratio of 8:2 to allocate memory to the query and load part.
+     *      And memory limit of load part should larger than 2GB
+     * 2. For BROKER/MINI/STREAMING load
+     *      The memory consumption is mainly concentrated in the load section.
+     *      So we allocate all the memory to the load part
+     */
+    public void calcLoadMemLimit(LoadJobSourceType loadType) {
+        switch (loadType) {
+            case INSERT_STREAMING:
+                break;
+            default:
+                this.queryOptions.setLoad_mem_limit(queryOptions.getMem_limit());
+                break;
+        }
+
     }
 
     // Initialize

--- a/fe/src/main/java/org/apache/doris/qe/MasterOpExecutor.java
+++ b/fe/src/main/java/org/apache/doris/qe/MasterOpExecutor.java
@@ -83,6 +83,7 @@ public class MasterOpExecutor {
         params.setUser_ip(ctx.getRemoteIP());
         params.setTime_zone(ctx.getSessionVariable().getTimeZone());
         params.setStmt_id(ctx.getStmtId());
+        params.setLoadMemLimit(ctx.getSessionVariable().getLoadMemLimit());
 
         LOG.info("Forward statement {} to Master {}", ctx.getStmtId(), thriftAddress);
 

--- a/fe/src/main/java/org/apache/doris/qe/MasterOpExecutor.java
+++ b/fe/src/main/java/org/apache/doris/qe/MasterOpExecutor.java
@@ -84,6 +84,7 @@ public class MasterOpExecutor {
         params.setTime_zone(ctx.getSessionVariable().getTimeZone());
         params.setStmt_id(ctx.getStmtId());
         params.setLoadMemLimit(ctx.getSessionVariable().getLoadMemLimit());
+        params.setEnableStrictMode(ctx.getSessionVariable().getEnableInsertStrict());
 
         LOG.info("Forward statement {} to Master {}", ctx.getStmtId(), thriftAddress);
 

--- a/fe/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -368,6 +368,10 @@ public class SessionVariable implements Serializable, Writable {
 
     public boolean getEnableInsertStrict() { return enableInsertStrict; }
 
+    public void setEnableInsertStrict(boolean enableInsertStrict) {
+        this.enableInsertStrict = enableInsertStrict;
+    }
+
     public boolean getForwardToMaster() {
         return forwardToMaster;
     }

--- a/fe/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -75,6 +75,16 @@ public class SessionVariable implements Serializable, Writable {
     public static final String FORWARD_TO_MASTER = "forward_to_master";
     // user can set instance num after exchange, no need to be equal to nums of before exchange
     public static final String PARALLEL_EXCHANGE_INSTANCE_NUM = "parallel_exchange_instance_num";
+    /*
+     * configure the mem limit of load process on BE. 
+     * Previously users used exec_mem_limit to set memory limits.
+     * To maintain compatibility, the default value of load_mem_limit is 0,
+     * which means that the load memory limit is still using exec_mem_limit.
+     * Users can set a value greater than zero to explicitly specify the load memory limit.
+     * This variable is mainly for INSERT operation, because INSERT operation has both query and load part.
+     * Using only the exec_mem_limit variable does not make a good distinction of memory limit between the two parts.
+     */
+    public static final String LOAD_MEM_LIMIT = "load_mem_limit";
 
     // max memory used on every backend.
     @VariableMgr.VarAttr(name = EXEC_MEM_LIMIT)
@@ -197,8 +207,15 @@ public class SessionVariable implements Serializable, Writable {
     @VariableMgr.VarAttr(name = FORWARD_TO_MASTER)
     private boolean forwardToMaster = false;
 
+    @VariableMgr.VarAttr(name = LOAD_MEM_LIMIT)
+    private long loadMemLimit = 0L;
+
     public long getMaxExecMemByte() {
         return maxExecMemByte;
+    }
+
+    public long getLoadMemLimit() {
+        return loadMemLimit;
     }
 
     public int getQueryTimeoutS() {
@@ -225,140 +242,72 @@ public class SessionVariable implements Serializable, Writable {
         return autoCommit;
     }
 
-    public void setAutoCommit(boolean autoCommit) {
-        this.autoCommit = autoCommit;
-    }
-
     public String getTxIsolation() {
         return txIsolation;
-    }
-
-    public void setTxIsolation(String txIsolation) {
-        this.txIsolation = txIsolation;
     }
 
     public String getCharsetClient() {
         return charsetClient;
     }
 
-    public void setCharsetClient(String charsetClient) {
-        this.charsetClient = charsetClient;
-    }
-
     public String getCharsetConnection() {
         return charsetConnection;
-    }
-
-    public void setCharsetConnection(String charsetConnection) {
-        this.charsetConnection = charsetConnection;
     }
 
     public String getCharsetResults() {
         return charsetResults;
     }
 
-    public void setCharsetResults(String charsetResults) {
-        this.charsetResults = charsetResults;
-    }
-
     public String getCharsetServer() {
         return charsetServer;
-    }
-
-    public void setCharsetServer(String charsetServer) {
-        this.charsetServer = charsetServer;
     }
 
     public String getCollationConnection() {
         return collationConnection;
     }
 
-    public void setCollationConnection(String collationConnection) {
-        this.collationConnection = collationConnection;
-    }
-
     public String getCollationDatabase() {
         return collationDatabase;
-    }
-
-    public void setCollationDatabase(String collationDatabase) {
-        this.collationDatabase = collationDatabase;
     }
 
     public String getCollationServer() {
         return collationServer;
     }
 
-    public void setCollationServer(String collationServer) {
-        this.collationServer = collationServer;
-    }
-
     public boolean isSqlAutoIsNull() {
         return sqlAutoIsNull;
-    }
-
-    public void setSqlAutoIsNull(boolean sqlAutoIsNull) {
-        this.sqlAutoIsNull = sqlAutoIsNull;
     }
 
     public long getSqlSelectLimit() {
         return sqlSelectLimit;
     }
 
-    public void setSqlSelectLimit(long sqlSelectLimit) {
-        this.sqlSelectLimit = sqlSelectLimit;
-    }
-
     public int getMaxAllowedPacket() {
         return maxAllowedPacket;
-    }
-
-    public void setMaxAllowedPacket(int maxAllowedPacket) {
-        this.maxAllowedPacket = maxAllowedPacket;
     }
 
     public int getAutoIncrementIncrement() {
         return autoIncrementIncrement;
     }
 
-    public void setAutoIncrementIncrement(int autoIncrementIncrement) {
-        this.autoIncrementIncrement = autoIncrementIncrement;
-    }
-
     public int getQueryCacheType() {
         return queryCacheType;
-    }
-
-    public void setQueryCacheType(int queryCacheType) {
-        this.queryCacheType = queryCacheType;
     }
 
     public int getInteractiveTimeout() {
         return interactiveTimeout;
     }
 
-    public void setInteractiveTimeout(int interactiveTimeout) {
-        this.interactiveTimeout = interactiveTimeout;
-    }
-
-    public void setWaitTimeout(int waitTimeout) {
-        this.waitTimeout = waitTimeout;
+    public int getWaitTimeout() {
+        return waitTimeout;
     }
 
     public int getNetWriteTimeout() {
         return netWriteTimeout;
     }
 
-    public void setNetWriteTimeout(int netWriteTimeout) {
-        this.netWriteTimeout = netWriteTimeout;
-    }
-
     public int getNetReadTimeout() {
         return netReadTimeout;
-    }
-
-    public void setNetReadTimeout(int netReadTimeout) {
-        this.netReadTimeout = netReadTimeout;
     }
 
     public String getTimeZone() {
@@ -373,24 +322,12 @@ public class SessionVariable implements Serializable, Writable {
         return sqlSafeUpdates;
     }
 
-    public void setSqlSafeUpdates(int sqlSafeUpdates) {
-        this.sqlSafeUpdates = sqlSafeUpdates;
-    }
-
     public int getNetBufferLength() {
         return netBufferLength;
     }
 
-    public void setNetBufferLength(int netBufferLength) {
-        this.netBufferLength = netBufferLength;
-    }
-
     public int getCodegenLevel() {
         return codegenLevel;
-    }
-
-    public void setCodegenLevel(int codegenLevel) {
-        this.codegenLevel = codegenLevel;
     }
 
     public void setMaxExecMemByte(long maxExecMemByte) {
@@ -401,12 +338,12 @@ public class SessionVariable implements Serializable, Writable {
         }
     }
 
-    public void setQueryTimeoutS(int queryTimeoutS) {
-        this.queryTimeoutS = queryTimeoutS;
+    public void setLoadMemLimit(long loadMemLimit) {
+        this.loadMemLimit = loadMemLimit;
     }
 
-    public void setReportSucc(boolean isReportSucc) {
-        this.isReportSucc = isReportSucc;
+    public void setQueryTimeoutS(int queryTimeoutS) {
+        this.queryTimeoutS = queryTimeoutS;
     }
 
     public String getResourceGroup() {
@@ -421,10 +358,6 @@ public class SessionVariable implements Serializable, Writable {
         return disableColocateJoin;
     }
 
-    public void setDisableColocateJoin(boolean disableColocateJoin) {
-        this.disableColocateJoin = disableColocateJoin;
-    }
-
     public int getParallelExecInstanceNum() {
         return parallelExecInstanceNum;
     }
@@ -433,27 +366,10 @@ public class SessionVariable implements Serializable, Writable {
         return exchangeInstanceParallel;
     }
 
-    public void setParallelExecInstanceNum(int parallelExecInstanceNum) {
-        if (parallelExecInstanceNum < MIN_EXEC_INSTANCE_NUM) {
-            this.parallelExecInstanceNum = MIN_EXEC_INSTANCE_NUM;
-        } else if (parallelExecInstanceNum > MAX_EXEC_INSTANCE_NUM) {
-            this.parallelExecInstanceNum = MAX_EXEC_INSTANCE_NUM;
-        } else {
-            this.parallelExecInstanceNum = parallelExecInstanceNum;
-        }
-    }
-
     public boolean getEnableInsertStrict() { return enableInsertStrict; }
-    public void setEnableInsertStrict(boolean enableInsertStrict) { this.enableInsertStrict = enableInsertStrict; }
 
-
-   // Serialize to thrift object
     public boolean getForwardToMaster() {
         return forwardToMaster;
-    }
-
-    public void setForwardToMaster(boolean forwardToMaster) {
-        this.forwardToMaster = forwardToMaster;
     }
 
     // Serialize to thrift object
@@ -474,6 +390,7 @@ public class SessionVariable implements Serializable, Writable {
 
         tResult.setBatch_size(batchSize);
         tResult.setDisable_stream_preaggregations(disableStreamPreaggregations);
+        tResult.setLoad_mem_limit(loadMemLimit);
         return tResult;
     }
 
@@ -510,6 +427,14 @@ public class SessionVariable implements Serializable, Writable {
         out.writeBoolean(disableStreamPreaggregations);
         out.writeInt(parallelExecInstanceNum);
         out.writeInt(exchangeInstanceParallel);
+
+        out.writeLong(loadMemLimit);
+        // false means there are no more variables. It you need to add more variables to persist,
+        // change this to true, and add:
+        //      out.writeXXX(new_var_name);
+        //      out.writeBoolean(false);
+        // By doing this, we no longer need to change the FE meta version when adding new variables to persist.
+        out.writeBoolean(false);   
     }
 
     @Override
@@ -556,6 +481,13 @@ public class SessionVariable implements Serializable, Writable {
         }
         if (Catalog.getCurrentCatalogJournalVersion() >= FeMetaVersion.VERSION_62) {
             exchangeInstanceParallel = in.readInt();
+        }
+
+        if (Catalog.getCurrentCatalogJournalVersion() >= FeMetaVersion.VERSION_67) {
+            loadMemLimit = in.readLong();
+            if (in.readBoolean()) {
+                // add new variables here
+            }
         }
     }
 }

--- a/fe/src/main/java/org/apache/doris/qe/VariableMgr.java
+++ b/fe/src/main/java/org/apache/doris/qe/VariableMgr.java
@@ -204,7 +204,6 @@ public class VariableMgr {
         }
     }
 
-
     // Get from show name to field
     public static void setVar(SessionVariable sessionVariable, SetVar setVar) throws DdlException {
         VarContext ctx = ctxByVarName.get(setVar.getVariable());
@@ -239,13 +238,14 @@ public class VariableMgr {
                 wlock.unlock();
             }
             writeGlobalVariableUpdate(globalSessionVariable, "update global variables");
+        } else {
+            // set global variable should not affect variables of current session.
+            // global variable will only make effect when connecting in.
+            setValue(sessionVariable, ctx.getField(), value);
         }
-
-        // whether it is session or global, set variables in current session, to make it effective.
-        setValue(sessionVariable, ctx.getField(), value);
     }
 
-    // global variable persisitence
+    // global variable persistence
     public static void write(DataOutputStream out) throws IOException {
         globalSessionVariable.write(out);
     }
@@ -276,7 +276,7 @@ public class VariableMgr {
                 field.setAccessible(true);
 
                 VarContext ctx = ctxByVarName.get(attr.name());
-                if (ctx.getFlag() == SESSION) {
+                if (ctx.getFlag() == GLOBAL) {
                     String value = getValue(variable, ctx.getField());
                     setValue(ctx.getObj(), ctx.getField(), value);
                 }

--- a/fe/src/main/java/org/apache/doris/qe/VariableMgr.java
+++ b/fe/src/main/java/org/apache/doris/qe/VariableMgr.java
@@ -276,7 +276,7 @@ public class VariableMgr {
                 field.setAccessible(true);
 
                 VarContext ctx = ctxByVarName.get(attr.name());
-                if (ctx.getFlag() == GLOBAL) {
+                if (ctx.getFlag() == SESSION) {
                     String value = getValue(variable, ctx.getField());
                     setValue(ctx.getObj(), ctx.getField(), value);
                 }

--- a/fe/src/main/java/org/apache/doris/task/StreamLoadTask.java
+++ b/fe/src/main/java/org/apache/doris/task/StreamLoadTask.java
@@ -59,7 +59,7 @@ public class StreamLoadTask {
     private String partitions;
     private String path;
     private boolean negative;
-    private boolean strictMode = true;
+    private boolean strictMode = false; // default is false
     private String timezone = TimeUtils.DEFAULT_TIME_ZONE;
     private int timeout = Config.stream_load_default_timeout_second;
     private long execMemLimit = 2 * 1024 * 1024 * 1024L; // default is 2GB

--- a/fe/src/test/java/org/apache/doris/qe/VariableMgrTest.java
+++ b/fe/src/test/java/org/apache/doris/qe/VariableMgrTest.java
@@ -90,19 +90,19 @@ public class VariableMgrTest {
         // Set global variable
         SetVar setVar = new SetVar(SetType.GLOBAL, "exec_mem_limit", new IntLiteral(1234L));
         VariableMgr.setVar(var, setVar);
-        Assert.assertEquals(1234L, var.getMaxExecMemByte());
+        Assert.assertEquals(2147483648L, var.getMaxExecMemByte());
         var = VariableMgr.newSessionVariable();
         Assert.assertEquals(1234L, var.getMaxExecMemByte());
 
         SetVar setVar2 = new SetVar(SetType.GLOBAL, "parallel_fragment_exec_instance_num", new IntLiteral(5L));
         VariableMgr.setVar(var, setVar2);
-        Assert.assertEquals(5L, var.getParallelExecInstanceNum());
+        Assert.assertEquals(1L, var.getParallelExecInstanceNum());
         var = VariableMgr.newSessionVariable();
         Assert.assertEquals(5L, var.getParallelExecInstanceNum());
 
         SetVar setVar3 = new SetVar(SetType.GLOBAL, "time_zone", new StringLiteral("Asia/Shanghai"));
         VariableMgr.setVar(var, setVar3);
-        Assert.assertEquals("Asia/Shanghai", var.getTimeZone());
+        Assert.assertEquals("CST", var.getTimeZone());
         var = VariableMgr.newSessionVariable();
         Assert.assertEquals("Asia/Shanghai", var.getTimeZone());
 

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -415,6 +415,7 @@ struct TMasterOpRequest {
     10: optional i64 stmt_id
     11: optional i64 sqlMode
     12: optional i64 loadMemLimit
+    13: optional bool enableStrictMode
 }
 
 struct TColumnDefinition {

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -414,6 +414,7 @@ struct TMasterOpRequest {
     9: optional string time_zone
     10: optional i64 stmt_id
     11: optional i64 sqlMode
+    12: optional i64 loadMemLimit
 }
 
 struct TColumnDefinition {

--- a/gensrc/thrift/PaloInternalService.thrift
+++ b/gensrc/thrift/PaloInternalService.thrift
@@ -126,6 +126,9 @@ struct TQueryOptions {
 
   // multithreaded degree of intra-node parallelism
   27: optional i32 mt_dop = 0;
+  // if this is a query option for LOAD, load_mem_limit should be set to limit the mem comsuption
+  // of load channel.
+  28: optional i64 load_mem_limit = 0;
 }
 
 // A scan range plus the parameters needed to execute that scan.


### PR DESCRIPTION
The insert operation is divided into two parts, query and import. Currently, only one variable of `exec_mem_limit` is used to limit the memory of the insert operation. Currently, both load and query has same mem limit, equals to `exec_mem_limit`. But in many cases, queries require more memory and load requires less memory.

Therefore, a `load_mem_limit` variable is added to specify the memory limit of the load part in the insert operation.

Also, revert the CL that setting global variables should not make effect on current session's variables.

ISSUE: #2304 

* Fix bug that variable `enable_insert_strict` does not forward to master FE. #1542 
* Change default strict_mode to false of all kinds of load operation.