### PR TITLE
Make node info metrics available on all FE node

### DIFF
--- a/fe/src/main/java/org/apache/doris/metric/MetricRepo.java
+++ b/fe/src/main/java/org/apache/doris/metric/MetricRepo.java
@@ -293,10 +293,8 @@ public final class MetricRepo {
             visitor.visitHistogram(sb, entry.getKey(), entry.getValue());
         }
         
-        // master info
-        if (Catalog.getInstance().isMaster()) {
-            visitor.getNodeInfo(sb);
-        }
+        // node info
+        visitor.getNodeInfo(sb);
 
         return sb.toString();
     }


### PR DESCRIPTION
Previously, only Master FE has node info metrics to indicate which node is alive.
But this info should be available on every FE, so that the monitor system
can get all metrics from any FE.

ISSUE: #2352 