### PR TITLE
Fixed a bug that Load job's state is incorrect when upgrading from 0.10.x to 0.11.x

### DIFF
--- a/fe/src/main/java/org/apache/doris/http/HttpServer.java
+++ b/fe/src/main/java/org/apache/doris/http/HttpServer.java
@@ -203,7 +203,7 @@ public class HttpServer {
                         .childHandler(new PaloHttpServerInitializer());
                 Channel ch = serverBootstrap.bind(port).sync().channel();
                 ch.closeFuture().sync();
-
+                LOG.info("HttpServer started with port: {}", port);
             } catch (Exception e) {
                 LOG.error("Fail to start FE query http server[port: " + port + "] ", e);
                 System.exit(-1);

--- a/fe/src/main/java/org/apache/doris/load/LoadJob.java
+++ b/fe/src/main/java/org/apache/doris/load/LoadJob.java
@@ -63,6 +63,7 @@ public class LoadJob implements Writable {
     // QUORUM_FINISHED state is internal
     // To user, it should be transformed to FINISHED
     public enum JobState {
+        UNKNOWN, // only for show load state value check, details, see LoadJobV2's JobState
         PENDING,
         ETL,
         LOADING,

--- a/fe/src/main/java/org/apache/doris/load/loadv2/JobState.java
+++ b/fe/src/main/java/org/apache/doris/load/loadv2/JobState.java
@@ -19,6 +19,7 @@ package org.apache.doris.load.loadv2;
 
 // JobState will be persisted in meta data by name, so the order of these state is not important
 public enum JobState {
+    UNKNOWN, // this is only for ISSUE #2354
     PENDING, // init state
     LOADING, // job is running
     COMMITTED, // transaction is committed but not visible

--- a/fe/src/main/java/org/apache/doris/load/loadv2/LoadJob.java
+++ b/fe/src/main/java/org/apache/doris/load/loadv2/LoadJob.java
@@ -557,7 +557,7 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
     protected void unprotectedExecuteCancel(FailMsg failMsg, boolean abortTxn) {
         LOG.warn(new LogBuilder(LogKey.LOAD_JOB, id)
                          .add("transaction_id", transactionId)
-                         .add("error_msg", "Failed to execute load with error " + failMsg.getMsg())
+                .add("error_msg", "Failed to execute load with error: " + failMsg.getMsg())
                          .build());
 
         // clean the loadingStatus

--- a/fe/src/main/java/org/apache/doris/load/loadv2/LoadJob.java
+++ b/fe/src/main/java/org/apache/doris/load/loadv2/LoadJob.java
@@ -448,9 +448,9 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
     }
 
     private void executeUnknown() {
-        // set finished timestamp to load start timestamp, so that this unknown job
-        // can be remove due to label expiration.
-        finishTimestamp = loadStartTimestamp;
+        // set finished timestamp to create timestamp, so that this unknown job
+        // can be remove due to label expiration so soon as possible
+        finishTimestamp = createTimestamp;
         state = JobState.UNKNOWN;
     }
 

--- a/fe/src/main/java/org/apache/doris/load/loadv2/LoadManager.java
+++ b/fe/src/main/java/org/apache/doris/load/loadv2/LoadManager.java
@@ -657,7 +657,8 @@ public class LoadManager implements Writable{
                 // status. But we have to set the job as FINISHED, to void user load same data twice.
                 job.updateState(JobState.UNKNOWN);
                 job.failMsg = new FailMsg(CancelType.UNKNOWN, "transaction status is unknown");
-                LOG.info("finish load job {} from {} to UNKNOWN, because transaction status is unknown", job.getId(), prevState);
+                LOG.info("finish load job {} from {} to UNKNOWN, because transaction status is unknown. label: {}",
+                        job.getId(), prevState, job.getLabel());
             }
         }
     }

--- a/fe/src/main/java/org/apache/doris/load/loadv2/LoadManager.java
+++ b/fe/src/main/java/org/apache/doris/load/loadv2/LoadManager.java
@@ -43,6 +43,7 @@ import org.apache.doris.thrift.TMiniLoadRequest;
 import org.apache.doris.thrift.TUniqueId;
 import org.apache.doris.transaction.GlobalTransactionMgr;
 import org.apache.doris.transaction.TransactionState;
+import org.apache.doris.transaction.TransactionStatus;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
@@ -604,7 +605,8 @@ public class LoadManager implements Writable{
             if (job.getState() == JobState.LOADING) {
                 // unfortunately, transaction id in load job is also not persisted, so we have to traverse
                 // all transactions to find it.
-                TransactionState txn = txnMgr.getCommittedTransactionStateByCallbackId(job.getCallbackId());
+                TransactionState txn = txnMgr.getTransactionStateByCallbackIdAndStatus(job.getCallbackId(),
+                        Sets.newHashSet(TransactionStatus.COMMITTED));
                 if (txn != null) {
                     job.updateState(JobState.COMMITTED);
                     LOG.info("transfer load job {} state from LOADING to COMMITTED, because txn {} is COMMITTED",
@@ -614,23 +616,48 @@ public class LoadManager implements Writable{
             }
 
             /*
-             * There is bug in Doris version 0.10.15.
-             * When a load job in PENDING or LOADING state was replayed from image (not through the edit log), 
-             * we forgot to add the corresponding callback id in the CallbackFactory. As a result, 
-             * the subsequent finish txn edit logs cannot properly end the job during the replay process.
-             * This results in that when the FE restarts, these load jobs that should have been completed 
-             * are re-entered into the pending state, resulting in repeated submission load tasks.
+             * There is bug in Doris version 0.10.15. When a load job in PENDING or LOADING
+             * state was replayed from image (not through the edit log), we forgot to add
+             * the corresponding callback id in the CallbackFactory. As a result, the
+             * subsequent finish txn edit logs cannot properly finish the job during the
+             * replay process. This results in that when the FE restarts, these load jobs
+             * that should have been completed are re-entered into the pending state,
+             * resulting in repeated submission load tasks.
              * 
-             * Those wrong images are unrecoverable, so that we have to cancel all load jobs in 
-             * PENDING or LOADING state when restarting FE, to avoid submit jobs repeatedly.
+             * Those wrong images are unrecoverable, so that we have to cancel all load jobs
+             * in PENDING or LOADING state when restarting FE, to avoid submit jobs
+             * repeatedly.
              * 
              * This code can be remove when upgrading from 0.11.x to future version.
              */
             if (job.getState() == JobState.LOADING || job.getState() == JobState.PENDING) {
                 JobState prevState = job.getState();
-                job.cancelJobWithoutCheck(new FailMsg(CancelType.LOAD_RUN_FAIL, "cancelled by system upgrading"),
-                        true /* abort transaction */, false /* no need to write log */);
-                LOG.info("load job {} is cancelled from {}, because of previous bugs", job.getId(), prevState);
+                TransactionState txn = txnMgr.getTransactionStateByCallbackId(job.getCallbackId());
+                if (txn != null) {
+                    // the txn has already been committed or visible, change job's state to committed or finished
+                    if (txn.getTransactionStatus() == TransactionStatus.COMMITTED) {
+                        job.updateState(JobState.COMMITTED);
+                        LOG.info("transfer load job {} state from {} to COMMITTED, because txn {} is COMMITTED",
+                                job.getId(), prevState, txn.getTransactionId());
+                    } else if (txn.getTransactionStatus() == TransactionStatus.VISIBLE) {
+                        job.updateState(JobState.FINISHED);
+                        LOG.info("transfer load job {} state from {} to FINISHED, because txn {} is VISIBLE",
+                                job.getId(), prevState, txn.getTransactionId());
+                    } else if (txn.getTransactionStatus() == TransactionStatus.ABORTED) {
+                        job.cancelJobWithoutCheck(new FailMsg(CancelType.LOAD_RUN_FAIL), false, false);
+                        LOG.info("transfer load job {} state from {} to CANCELLED, because txn {} is ABORTED",
+                                job.getId(), prevState, txn.getTransactionId());
+                    } else {
+                        // pending txn, do nothing
+                    }
+                    continue;
+                }
+                
+                // unfortunately, the txn may already been removed due to label expired, so we don't know the txn's
+                // status. But we have to set the job as FINISHED, to void user load same data twice.
+                job.updateState(JobState.UNKNOWN);
+                job.failMsg = new FailMsg(CancelType.UNKNOWN, "transaction status is unknown");
+                LOG.info("finish load job {} from {} to UNKNOWN, because transaction status is unknown", job.getId(), prevState);
             }
         }
     }

--- a/fe/src/main/java/org/apache/doris/transaction/GlobalTransactionMgr.java
+++ b/fe/src/main/java/org/apache/doris/transaction/GlobalTransactionMgr.java
@@ -942,8 +942,7 @@ public class GlobalTransactionMgr implements Writable {
     // for add/update/delete TransactionState
     private void unprotectUpsertTransactionState(TransactionState transactionState) {
         if (transactionState.getTransactionStatus() != TransactionStatus.PREPARE
-                || transactionState.getSourceType() == LoadJobSourceType.FRONTEND
-                || transactionState.getSourceType() == LoadJobSourceType.BATCH_LOAD_JOB) {
+                || transactionState.getSourceType() == LoadJobSourceType.FRONTEND) {
             // if this is a prepare txn, and load source type is not FRONTEND
             // no need to persist it. if prepare txn lost, the following commit will just be failed.
             // user only need to retry this txn.

--- a/fe/src/test/java/org/apache/doris/http/DorisHttpTestCase.java
+++ b/fe/src/test/java/org/apache/doris/http/DorisHttpTestCase.java
@@ -255,7 +255,7 @@ abstract public class DorisHttpTestCase {
         httpServer.setup();
         httpServer.start();
         // must ensure the http server started before any unit test
-        Thread.sleep(500);
+        Thread.sleep(5000);
         doSetUp();
     }
 


### PR DESCRIPTION
There is bug in Doris version 0.10.x. When a load job in PENDING or LOADING
state was replayed from image (not through the edit log), we forgot to add
the corresponding callback id in the CallbackFactory. As a result, the
subsequent finish txn edit logs cannot properly finish the job during the
replay process. This results in that when the FE restarts, these load jobs
that should have been completed are re-entered into the pending state,
resulting in repeated submission load tasks.

Those wrong images are unrecoverable, so that we have to reset all load jobs
in PENDING or LOADING state when restarting FE, depends on its corresponding
txn's status, to avoid submit jobs repeatedly.

If corresponding txn exist, set load job' state depends on txn's status.
If txn does not exist, may be the txn has been removed due to label expiration.
So that we don't know the txn is aborted or visible. So we have to set the job's state
as UNKNOWN, which need handle it manually.

ISSUE #2354 