### PR TITLE
Fixed a bug that HttpServer in unit test does not start correctly.

### DIFF
--- a/fe/src/main/java/org/apache/doris/http/HttpServer.java
+++ b/fe/src/main/java/org/apache/doris/http/HttpServer.java
@@ -205,9 +205,11 @@ public class HttpServer {
                         .channel(NioServerSocketChannel.class)
                         .childHandler(new PaloHttpServerInitializer());
                 Channel ch = serverBootstrap.bind(port).sync().channel();
-                ch.closeFuture().sync();
+
                 isStarted.set(true);
                 LOG.info("HttpServer started with port {}", port);
+                // block until server is closed
+                ch.closeFuture().sync();
             } catch (Exception e) {
                 LOG.error("Fail to start FE query http server[port: " + port + "] ", e);
                 System.exit(-1);

--- a/fe/src/test/java/org/apache/doris/http/DorisHttpTestCase.java
+++ b/fe/src/test/java/org/apache/doris/http/DorisHttpTestCase.java
@@ -255,7 +255,9 @@ abstract public class DorisHttpTestCase {
         httpServer.setup();
         httpServer.start();
         // must ensure the http server started before any unit test
-        Thread.sleep(500);
+        while (!httpServer.isStarted()) {
+            Thread.sleep(500);
+        }
         doSetUp();
     }
 


### PR DESCRIPTION
Because the http client in unit test try to connect to the server when
server is not ready yet.

Add a boolean flag `isStarted` to indicate that the server thread is ready or not.