### PR TITLE
Add bdbje heartbeat timeout as a configuration of FE

### DIFF
--- a/fe/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/src/main/java/org/apache/doris/common/Config.java
@@ -177,6 +177,14 @@ public class Config extends ConfigBase {
     @ConfField public static String replica_ack_policy = "SIMPLE_MAJORITY"; // ALL, NONE, SIMPLE_MAJORITY
     
     /*
+     * The heartbeat timeout of bdbje between master and follower.
+     * the default is 30 seconds, which is same as default value in bdbje.
+     * If the network is experiencing transient problems, of some unexpected long java GC annoying you,
+     * you can try to increase this value to decrease the chances of false timeouts
+     */
+    @ConfField public static int bdbje_heartbeat_timeout_second = 30;
+    
+    /*
      * the max txn number which bdbje can rollback when trying to rejoin the group
      */
     @ConfField public static int txn_rollback_limit = 100;

--- a/fe/src/main/java/org/apache/doris/journal/bdbje/BDBEnvironment.java
+++ b/fe/src/main/java/org/apache/doris/journal/bdbje/BDBEnvironment.java
@@ -107,6 +107,8 @@ public class BDBEnvironment {
         replicationConfig.setMaxClockDelta(Config.max_bdbje_clock_delta_ms, TimeUnit.MILLISECONDS);
         replicationConfig.setConfigParam(ReplicationConfig.TXN_ROLLBACK_LIMIT,
                 String.valueOf(Config.txn_rollback_limit));
+        replicationConfig.setConfigParam(ReplicationConfig.REPLICA_TIMEOUT, String.valueOf(Config.bdbje_heartbeat_timeout_second));
+        replicationConfig.setConfigParam(ReplicationConfig.FEEDER_TIMEOUT, String.valueOf(Config.bdbje_heartbeat_timeout_second));
 
         if (isElectable) {
             replicationConfig.setReplicaAckTimeout(2, TimeUnit.SECONDS);


### PR DESCRIPTION
The timeline for this question is as follows:

1. For some reason, the master have lost contact with the other two followers.
Judging from the logs of the master, for almost 40 seconds, the master did not print any logs.
It is suspected that it is stuck due to full gc or other reasons, causing the
other two followers to think that the master has been disconnected.

2. After the other two followers re-elected, they continued to provide services.

3. The master node is manually restarted afterwards. When restarting it for the first time,
it needs to rollback some committed logs, so it needs to be closed and restarted again.
After restarting again, it returns to normal.

The main reason is that the master got stuck for 40 seconds for some reason.
This issue requires further observation.

At the same time, in order to alleviate this problem, we decided to set bdbje's heartbeat timeout
as a configurable value. The default is 30 seconds. Can be configured to 1 minute,
try to avoid this problem first.

ISSUE #2357 