### PR TITLE
Fixed bdbje heartbeat timeout config format bug

### DIFF
--- a/fe/src/main/java/org/apache/doris/journal/bdbje/BDBEnvironment.java
+++ b/fe/src/main/java/org/apache/doris/journal/bdbje/BDBEnvironment.java
@@ -107,8 +107,8 @@ public class BDBEnvironment {
         replicationConfig.setMaxClockDelta(Config.max_bdbje_clock_delta_ms, TimeUnit.MILLISECONDS);
         replicationConfig.setConfigParam(ReplicationConfig.TXN_ROLLBACK_LIMIT,
                 String.valueOf(Config.txn_rollback_limit));
-        replicationConfig.setConfigParam(ReplicationConfig.REPLICA_TIMEOUT, String.valueOf(Config.bdbje_heartbeat_timeout_second));
-        replicationConfig.setConfigParam(ReplicationConfig.FEEDER_TIMEOUT, String.valueOf(Config.bdbje_heartbeat_timeout_second));
+        replicationConfig.setConfigParam(ReplicationConfig.REPLICA_TIMEOUT, Config.bdbje_heartbeat_timeout_second + " s");
+        replicationConfig.setConfigParam(ReplicationConfig.FEEDER_TIMEOUT, Config.bdbje_heartbeat_timeout_second + " s");
 
         if (isElectable) {
             replicationConfig.setReplicaAckTimeout(2, TimeUnit.SECONDS);


### PR DESCRIPTION
The heartbeat config format should be like "30 s", not "30"
This CL is related to commit 261072ecdda7e8eb3ce685c557c6dab15488d1f3

ISSUE #2357 