### PR TITLE
Bug Fix: sql mode

### DIFF
--- a/fe/src/main/java/org/apache/doris/analysis/SetVar.java
+++ b/fe/src/main/java/org/apache/doris/analysis/SetVar.java
@@ -27,8 +27,6 @@ import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.mysql.privilege.UserResource;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.SessionVariable;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 // change one variable.
 public class SetVar {

--- a/fe/src/main/java/org/apache/doris/analysis/SetVar.java
+++ b/fe/src/main/java/org/apache/doris/analysis/SetVar.java
@@ -27,6 +27,7 @@ import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.mysql.privilege.UserResource;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.SessionVariable;
+import org.apache.doris.system.HeartbeatFlags;
 
 // change one variable.
 public class SetVar {

--- a/fe/src/main/java/org/apache/doris/analysis/SetVar.java
+++ b/fe/src/main/java/org/apache/doris/analysis/SetVar.java
@@ -114,18 +114,18 @@ public class SetVar {
 
         result = (LiteralExpr)literalExpr;
 
-        if (variable.equalsIgnoreCase(SessionVariable.SQL_MODE)) {
-            // For the case like "set sql_mode = PIPES_AS_CONCAT"
-            if (result instanceof StringLiteral) {
-                String sqlMode = result.getStringValue();
-                result = new StringLiteral(SqlModeHelper.encode(sqlMode).toString());
-            }
-            // For the case like "set sql_mode = 3"
-            else if (result instanceof IntLiteral) {
-                String sqlMode = SqlModeHelper.decode(result.getLongValue());
-                result = new IntLiteral(SqlModeHelper.encode(sqlMode).toString(), Type.BIGINT);
-            }
-        }
+//        if (variable.equalsIgnoreCase(SessionVariable.SQL_MODE)) {
+//            // For the case like "set sql_mode = PIPES_AS_CONCAT"
+//            if (result instanceof StringLiteral) {
+//                String sqlMode = result.getStringValue();
+//                result = new StringLiteral(SqlModeHelper.encode(sqlMode).toString());
+//            }
+//            // For the case like "set sql_mode = 3"
+//            else if (result instanceof IntLiteral) {
+//                String sqlMode = SqlModeHelper.decode(result.getLongValue());
+//                result = new IntLiteral(SqlModeHelper.encode(sqlMode).toString(), Type.BIGINT);
+//            }
+//        }
 
         // Need to check if group is valid
         if (variable.equalsIgnoreCase(SessionVariable.RESOURCE_VARIABLE)) {

--- a/fe/src/main/java/org/apache/doris/analysis/SetVar.java
+++ b/fe/src/main/java/org/apache/doris/analysis/SetVar.java
@@ -19,7 +19,6 @@ package org.apache.doris.analysis;
 
 import com.google.common.base.Strings;
 import org.apache.doris.catalog.Catalog;
-import org.apache.doris.catalog.Type;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.ErrorReport;
@@ -28,8 +27,8 @@ import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.mysql.privilege.UserResource;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.SessionVariable;
-import org.apache.doris.qe.SqlModeHelper;
-import org.apache.doris.system.HeartbeatFlags;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 // change one variable.
 public class SetVar {
@@ -113,19 +112,6 @@ public class SetVar {
         }
 
         result = (LiteralExpr)literalExpr;
-
-//        if (variable.equalsIgnoreCase(SessionVariable.SQL_MODE)) {
-//            // For the case like "set sql_mode = PIPES_AS_CONCAT"
-//            if (result instanceof StringLiteral) {
-//                String sqlMode = result.getStringValue();
-//                result = new StringLiteral(SqlModeHelper.encode(sqlMode).toString());
-//            }
-//            // For the case like "set sql_mode = 3"
-//            else if (result instanceof IntLiteral) {
-//                String sqlMode = SqlModeHelper.decode(result.getLongValue());
-//                result = new IntLiteral(SqlModeHelper.encode(sqlMode).toString(), Type.BIGINT);
-//            }
-//        }
 
         // Need to check if group is valid
         if (variable.equalsIgnoreCase(SessionVariable.RESOURCE_VARIABLE)) {

--- a/fe/src/main/java/org/apache/doris/analysis/SysVariableDesc.java
+++ b/fe/src/main/java/org/apache/doris/analysis/SysVariableDesc.java
@@ -20,6 +20,8 @@ package org.apache.doris.analysis;
 import com.google.common.base.Strings;
 import org.apache.doris.catalog.Type;
 import org.apache.doris.common.AnalysisException;
+import org.apache.doris.common.DdlException;
+import org.apache.doris.common.ErrorReport;
 import org.apache.doris.qe.SessionVariable;
 import org.apache.doris.qe.SqlModeHelper;
 import org.apache.doris.qe.VariableMgr;
@@ -69,7 +71,11 @@ public class SysVariableDesc extends Expr {
         VariableMgr.fillValue(analyzer.getContext().getSessionVariable(), this);
         if (!Strings.isNullOrEmpty(name) && name.equalsIgnoreCase(SessionVariable.SQL_MODE)) {
             setType(Type.VARCHAR);
-            setStringValue(SqlModeHelper.decode(intValue));
+            try {
+                setStringValue(SqlModeHelper.decode(intValue));
+            } catch (DdlException e) {
+                ErrorReport.reportAnalysisException(e.getMessage());
+            }
         }
     }
 

--- a/fe/src/main/java/org/apache/doris/qe/SqlModeHelper.java
+++ b/fe/src/main/java/org/apache/doris/qe/SqlModeHelper.java
@@ -152,7 +152,7 @@ public class SqlModeHelper {
         for (String key : names) {
             if (StringUtils.isNumeric(key)) {
                 value |= expand(Long.valueOf(key));
-                LOG.warn("Set sql mode with numerical value");
+                LOG.debug("Set sql mode with numerical value " + key);
                 continue;
             }
             // the SQL MODE must be supported, set sql mode repeatedly is not allowed

--- a/fe/src/main/java/org/apache/doris/qe/SqlModeHelper.java
+++ b/fe/src/main/java/org/apache/doris/qe/SqlModeHelper.java
@@ -22,7 +22,6 @@ import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
 import com.google.common.collect.Maps;
 import org.apache.commons.lang.StringUtils;
-import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.DdlException;
 import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.ErrorReport;

--- a/fe/src/main/java/org/apache/doris/qe/SqlModeHelper.java
+++ b/fe/src/main/java/org/apache/doris/qe/SqlModeHelper.java
@@ -152,6 +152,8 @@ public class SqlModeHelper {
         for (String key : names) {
             if (StringUtils.isNumeric(key)) {
                 value |= expand(Long.valueOf(key));
+                LOG.warn("Set sql mode with numerical value");
+                continue;
             }
             // the SQL MODE must be supported, set sql mode repeatedly is not allowed
             if (!isSupportedSqlMode(key) || (value & getSupportedSqlMode().get(key)) != 0) {
@@ -177,12 +179,12 @@ public class SqlModeHelper {
             ErrorReport.reportDdlException(ErrorCode.ERR_WRONG_VALUE_FOR_VAR, SessionVariable.SQL_MODE, sqlMode);
         }
         value &= MODE_COMBINE_MASK;
-        if ((value & (value - 1)) > 0) {
+        if ((value & (value - 1)) != 0) {
             ErrorReport.reportDdlException(ErrorCode.ERR_WRONG_VALUE_FOR_VAR, SessionVariable.SQL_MODE, sqlMode);
         }
         for (String key : getCombineMode().keySet()) {
             if (value == getSupportedSqlMode().get(key)) {
-                sqlMode &= getCombineMode().get(key);
+                sqlMode |= getCombineMode().get(key);
             }
         }
         return sqlMode;

--- a/fe/src/main/java/org/apache/doris/qe/VariableMgr.java
+++ b/fe/src/main/java/org/apache/doris/qe/VariableMgr.java
@@ -133,41 +133,42 @@ public class VariableMgr {
     // Set value to a variable
     private static boolean setValue(Object obj, Field field, String value) throws DdlException {
         VarAttr attr = field.getAnnotation(VarAttr.class);
+        String convertedVal = VariableVarConverters.convert(attr.name(), value);
         try {
             switch (field.getType().getSimpleName()) {
                 case "boolean":
-                    if (value.equalsIgnoreCase("ON")
-                            || value.equalsIgnoreCase("TRUE")
-                            || value.equalsIgnoreCase("1")) {
+                    if (convertedVal.equalsIgnoreCase("ON")
+                            || convertedVal.equalsIgnoreCase("TRUE")
+                            || convertedVal.equalsIgnoreCase("1")) {
                         field.setBoolean(obj, true);
-                    } else if (value.equalsIgnoreCase("OFF")
-                            || value.equalsIgnoreCase("FALSE")
-                            || value.equalsIgnoreCase("0")) {
+                    } else if (convertedVal.equalsIgnoreCase("OFF")
+                            || convertedVal.equalsIgnoreCase("FALSE")
+                            || convertedVal.equalsIgnoreCase("0")) {
                         field.setBoolean(obj, false);
                     } else {
                         throw new IllegalAccessException();
                     }
                     break;
                 case "byte":
-                    field.setByte(obj, Byte.valueOf(value));
+                    field.setByte(obj, Byte.valueOf(convertedVal));
                     break;
                 case "short":
-                    field.setShort(obj, Short.valueOf(value));
+                    field.setShort(obj, Short.valueOf(convertedVal));
                     break;
                 case "int":
-                    field.setInt(obj, Integer.valueOf(value));
+                    field.setInt(obj, Integer.valueOf(convertedVal));
                     break;
                 case "long":
-                    field.setLong(obj, Long.valueOf(value));
+                    field.setLong(obj, Long.valueOf(convertedVal));
                     break;
                 case "float":
-                    field.setFloat(obj, Float.valueOf(value));
+                    field.setFloat(obj, Float.valueOf(convertedVal));
                     break;
                 case "double":
-                    field.setDouble(obj, Double.valueOf(value));
+                    field.setDouble(obj, Double.valueOf(convertedVal));
                     break;
                 case "String":
-                    field.set(obj, value);
+                    field.set(obj, convertedVal);
                     break;
                 default:
                     // Unsupported type variable.

--- a/fe/src/main/java/org/apache/doris/qe/VariableMgr.java
+++ b/fe/src/main/java/org/apache/doris/qe/VariableMgr.java
@@ -424,7 +424,7 @@ public class VariableMgr {
                 if (row.size() > 1 && row.get(0).equalsIgnoreCase(SessionVariable.SQL_MODE)) {
                     try {
                         row.set(1, SqlModeHelper.decode(Long.valueOf(row.get(1))));
-                    } catch (AnalysisException e) {
+                    } catch (DdlException e) {
                         row.set(1, "");
                         LOG.warn("Decode sql mode failed");
                     }

--- a/fe/src/main/java/org/apache/doris/qe/VariableVarConverterI.java
+++ b/fe/src/main/java/org/apache/doris/qe/VariableVarConverterI.java
@@ -1,0 +1,24 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.qe;
+
+import org.apache.doris.common.DdlException;
+
+public interface VariableVarConverterI {
+    public String convert(String value) throws DdlException;
+}

--- a/fe/src/main/java/org/apache/doris/qe/VariableVarConverters.java
+++ b/fe/src/main/java/org/apache/doris/qe/VariableVarConverters.java
@@ -1,0 +1,46 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.qe;
+
+import com.google.common.collect.Maps;
+import org.apache.doris.common.DdlException;
+
+import java.util.Map;
+
+public class VariableVarConverters {
+
+    public static final Map<String, VariableVarConverterI> converters = Maps.newHashMap();
+    static {
+        SqlModeConverter sqlModeConverter = new SqlModeConverter();
+        converters.put(SessionVariable.SQL_MODE, sqlModeConverter);
+    }
+
+    public static String convert(String varName, String value) throws DdlException {
+        if (converters.containsKey(varName)) {
+            return converters.get(varName).convert(value);
+        }
+        return value;
+    }
+
+    public static class SqlModeConverter implements VariableVarConverterI {
+        @Override
+        public String convert(String value) throws DdlException {
+            return SqlModeHelper.encode(value).toString();
+        }
+    }
+}

--- a/fe/src/main/java/org/apache/doris/qe/VariableVarConverters.java
+++ b/fe/src/main/java/org/apache/doris/qe/VariableVarConverters.java
@@ -22,6 +22,10 @@ import org.apache.doris.common.DdlException;
 
 import java.util.Map;
 
+// Helper class to drives the convert of session variables according to the converters.
+// You can define your converter that implements interface VariableVarConverterI in here.
+// Each converter should put in map (variable name -> converters) and only converts the variable
+// with specified name.
 public class VariableVarConverters {
 
     public static final Map<String, VariableVarConverterI> converters = Maps.newHashMap();
@@ -37,6 +41,9 @@ public class VariableVarConverters {
         return value;
     }
 
+    /* Converters */
+
+    // Converter to convert sql mode variable
     public static class SqlModeConverter implements VariableVarConverterI {
         @Override
         public String convert(String value) throws DdlException {

--- a/fe/src/test/java/org/apache/doris/analysis/SetVarTest.java
+++ b/fe/src/test/java/org/apache/doris/analysis/SetVarTest.java
@@ -69,18 +69,4 @@ public class SetVarTest {
         var.analyze(analyzer);
         Assert.fail("No exception throws.");
     }
-
-    @Test(expected = AnalysisException.class)
-    public void testInvalidSqlModeValue() throws UserException, AnalysisException {
-        SetVar var = new SetVar(SetType.SESSION, "sql_mode", new IntLiteral(SqlModeHelper.MODE_LAST));
-        var.analyze(analyzer);
-        Assert.fail("No exception throws");
-    }
-
-    @Test(expected = AnalysisException.class)
-    public void testInvalidSqlMode() throws UserException, AnalysisException {
-        SetVar var = new SetVar(SetType.SESSION, "sql_mode", new StringLiteral("WRONG_MODE"));
-        var.analyze(analyzer);
-        Assert.fail("No exception throws");
-    }
 }

--- a/fe/src/test/java/org/apache/doris/qe/SqlModeHelperTest.java
+++ b/fe/src/test/java/org/apache/doris/qe/SqlModeHelperTest.java
@@ -17,14 +17,14 @@
 
 package org.apache.doris.qe;
 
-import org.apache.doris.common.AnalysisException;
+import org.apache.doris.common.DdlException;
 import org.junit.Assert;
 import org.junit.Test;
 
 public class SqlModeHelperTest {
 
     @Test
-    public void testNormal() throws AnalysisException {
+    public void testNormal() throws DdlException {
         String sqlMode = "PIPES_AS_CONCAT";
         Assert.assertEquals(new Long(2L), SqlModeHelper.encode(sqlMode));
 
@@ -38,22 +38,22 @@ public class SqlModeHelperTest {
         Assert.assertEquals("", SqlModeHelper.decode(sqlModeValue));
     }
 
-    @Test(expected = AnalysisException.class)
-    public void testInvalidSqlMode() throws AnalysisException {
+    @Test(expected = DdlException.class)
+    public void testInvalidSqlMode() throws DdlException {
         String sqlMode = "PIPES_AS_CONCAT, WRONG_MODE";
         SqlModeHelper.encode(sqlMode);
         Assert.fail("No exception throws");
     }
 
-    @Test(expected = AnalysisException.class)
-    public void testMultiSqlMode() throws AnalysisException {
+    @Test(expected = DdlException.class)
+    public void testMultiSqlMode() throws DdlException {
         String sqlMode = "ANSI, TRADITIONAL";
         SqlModeHelper.encode(sqlMode);
         Assert.fail("No exception throws");
     }
 
-    @Test(expected = AnalysisException.class)
-    public void testInvalidDecode() throws AnalysisException {
+    @Test(expected = DdlException.class)
+    public void testInvalidDecode() throws DdlException {
         long sqlMode = SqlModeHelper.MODE_LAST;
         SqlModeHelper.decode(sqlMode);
         Assert.fail("No exception throws");

--- a/fe/src/test/java/org/apache/doris/qe/SqlModeHelperTest.java
+++ b/fe/src/test/java/org/apache/doris/qe/SqlModeHelperTest.java
@@ -49,13 +49,6 @@ public class SqlModeHelperTest {
     }
 
     @Test(expected = DdlException.class)
-    public void testMultiSqlMode() throws DdlException {
-        String sqlMode = "ANSI, TRADITIONAL";
-        SqlModeHelper.encode(sqlMode);
-        Assert.fail("No exception throws");
-    }
-
-    @Test(expected = DdlException.class)
     public void testInvalidDecode() throws DdlException {
         long sqlMode = SqlModeHelper.MODE_LAST;
         SqlModeHelper.decode(sqlMode);

--- a/fe/src/test/java/org/apache/doris/qe/SqlModeHelperTest.java
+++ b/fe/src/test/java/org/apache/doris/qe/SqlModeHelperTest.java
@@ -31,6 +31,9 @@ public class SqlModeHelperTest {
         sqlMode = "";
         Assert.assertEquals(new Long(0L), SqlModeHelper.encode(sqlMode));
 
+        sqlMode = "0,1, PIPES_AS_CONCAT";
+        Assert.assertEquals(new Long(3L), SqlModeHelper.encode(sqlMode));
+
         long sqlModeValue = 2L;
         Assert.assertEquals("PIPES_AS_CONCAT", SqlModeHelper.decode(sqlModeValue));
 


### PR DESCRIPTION
Issue #2365 
This commit fixs the bug below,

FE throws a unexpected exception when encounter a query like :
Set sql_mode = '0,PIPES_AS_CONCAT'.

and make some change to sql mode analyze process, now the analyze process is no longer put in SetVar.class, but in VariableMgr.class.