### PR TITLE
add where/orderby/limit after “SHOW ALTER TABLE COLUMN“ syntax

### DIFF
--- a/docs/documentation/cn/sql-reference/sql-statements/Data Manipulation/SHOW ALTER.md
+++ b/docs/documentation/cn/sql-reference/sql-statements/Data Manipulation/SHOW ALTER.md
@@ -33,11 +33,14 @@ under the License.
 ## example
     1. 展示默认 db 的所有修改列的任务执行情况
         SHOW ALTER TABLE COLUMN;
-        
-    2. 展示指定 db 的创建或删除 ROLLUP index 的任务执行情况
+    
+    2. 展示某个表最近一次修改列的任务执行情况
+        SHOW ALTER TABLE COLUMN WHERE TableName = "table1" ORDER BY CreateTime DESC LIMIT 1;
+ 
+    3. 展示指定 db 的创建或删除 ROLLUP index 的任务执行情况
         SHOW ALTER TABLE ROLLUP FROM example_db;
         
-    3. 展示集群操作相关任务（仅管理员使用！待实现...）
+    4. 展示集群操作相关任务（仅管理员使用！待实现...）
         SHOW ALTER CLUSTER;
         
 ## keyword

--- a/docs/documentation/cn/sql-reference/sql-statements/Data Manipulation/SHOW ALTER.md
+++ b/docs/documentation/cn/sql-reference/sql-statements/Data Manipulation/SHOW ALTER.md
@@ -25,6 +25,7 @@ under the License.
         
     说明：
         TABLE COLUMN：展示修改列的 ALTER 任务
+                      支持语法[WHERE TableName|CreateTime|FinishTime|State] [ORDER BY] [LIMIT]
         TABLE ROLLUP：展示创建或删除 ROLLUP index 的任务
         如果不指定 db_name，使用当前默认 db
         CLUSTER: 展示集群操作相关任务情况（仅管理员使用！待实现...）

--- a/docs/documentation/en/sql-reference/sql-statements/Data Manipulation/SHOW ALTER_EN.md
+++ b/docs/documentation/en/sql-reference/sql-statements/Data Manipulation/SHOW ALTER_EN.md
@@ -34,10 +34,13 @@ CLUSTER: Show the cluster operation related tasks (only administrators use! To b
 1. Show the task execution of all modified columns of default DB
 SHOW ALTER TABLE COLUMN;
 
-2. Show the execution of tasks to create or delete ROLLUP index for specified DB
+2. Show the last task execution of modified columns of some table
+SHOW ALTER TABLE COLUMN WHERE TableName = "table1" ORDER BY CreateTime LIMIT 1;
+
+3. Show the execution of tasks to create or delete ROLLUP index for specified DB
 SHOW ALTER TABLE ROLLUP FROM example_db;
 
-3. Show cluster operations related tasks (only administrators use! To be realized...
+4. Show cluster operations related tasks (only administrators use! To be realized...
 SHOW ALTER CLUSTER;
 
 ## keyword

--- a/docs/documentation/en/sql-reference/sql-statements/Data Manipulation/SHOW ALTER_EN.md
+++ b/docs/documentation/en/sql-reference/sql-statements/Data Manipulation/SHOW ALTER_EN.md
@@ -24,7 +24,8 @@ Grammar:
 SHOW ALTER [CLUSTER | TABLE [COLUMN | ROLLUP] [FROM db_name]];
 
 Explain:
-TABLE COLUMN：展示修改列的 ALTER 任务
+TABLE COLUMN：Shows the task of alter table column.
+              Support grammar [WHERE TableName|CreateTime|FinishTime|State] [ORDER BY] [LIMIT]
 TABLE ROLLUP: Shows the task of creating or deleting ROLLUP index
 If db_name is not specified, use the current default DB
 CLUSTER: Show the cluster operation related tasks (only administrators use! To be realized...

--- a/fe/src/main/cup/sql_parser.cup
+++ b/fe/src/main/cup/sql_parser.cup
@@ -1932,9 +1932,9 @@ show_param ::=
         RESULT = new ShowDeleteStmt(db);
     :}
     /* Show alter table statement: used to show process of alter table statement */
-    | KW_ALTER KW_TABLE opt_alter_type:type opt_db:db
+    | KW_ALTER KW_TABLE opt_alter_type:type opt_db:db opt_wild_where order_by_clause:orderByClause limit_clause:limitClause
     {:
-        RESULT = new ShowAlterStmt(type, db);
+        RESULT = new ShowAlterStmt(type, db, parser.where, orderByClause, limitClause);
     :}
     /* Show data statement: used to show data size of specified range */
     | KW_DATA

--- a/fe/src/main/java/org/apache/doris/analysis/LimitElement.java
+++ b/fe/src/main/java/org/apache/doris/analysis/LimitElement.java
@@ -20,7 +20,7 @@ package org.apache.doris.analysis;
 /**
  * Combination of limit and offset expressions.
  */
-class LimitElement {
+public class LimitElement {
     public static LimitElement NO_LIMIT = new LimitElement();
     
     /////////////////////////////////////////

--- a/fe/src/main/java/org/apache/doris/analysis/ShowAlterStmt.java
+++ b/fe/src/main/java/org/apache/doris/analysis/ShowAlterStmt.java
@@ -17,9 +17,10 @@
 
 package org.apache.doris.analysis;
 
-import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.Database;
+import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.ScalarType;
+import org.apache.doris.catalog.Type;
 import org.apache.doris.cluster.ClusterNamespace;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.ErrorCode;
@@ -29,6 +30,7 @@ import org.apache.doris.common.proc.ProcNodeInterface;
 import org.apache.doris.common.proc.ProcService;
 import org.apache.doris.common.proc.RollupProcDir;
 import org.apache.doris.common.proc.SchemaChangeProcNode;
+import org.apache.doris.common.util.OrderByPair;
 import org.apache.doris.qe.ShowResultSetMetaData;
 
 import com.google.common.base.Preconditions;
@@ -38,10 +40,14 @@ import com.google.common.collect.ImmutableList;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
 /*
  * ShowAlterStmt: used to show process state of alter statement.
  * Syntax:
- *      SHOW ALTER [COLUMN | ROLLUP] [FROM dbName]
+ *      SHOW ALTER TABLE [COLUMN | ROLLUP] [FROM dbName] [WHERE TableName="xxx"] [ORDER BY CreateTime DESC] [LIMIT [offset,]rows]
  */
 public class ShowAlterStmt extends ShowStmt {
     private static final Logger LOG = LogManager.getLogger(ShowAlterStmt.class);
@@ -52,28 +58,92 @@ public class ShowAlterStmt extends ShowStmt {
 
     private AlterType type;
     private String dbName;
+    private Expr whereClause;
+    private HashMap<String, Expr> filterMap;
+    private List<OrderByElement> orderByElements;
+    private ArrayList<OrderByPair> orderByPairs;
+    private LimitElement limitElement;
 
     private ProcNodeInterface node;
 
-    public AlterType getType() {
-        return type;
-    }
-
-    public String getDbName() {
-        return dbName;
-    }
+    public AlterType getType() { return type; }
+    public String getDbName() { return dbName; }
+    public HashMap<String, Expr> getFilterMap() { return filterMap; }
+    public LimitElement getLimitElement(){ return limitElement; }
+    public ArrayList<OrderByPair> getOrderPairs(){ return orderByPairs; }
 
     public ProcNodeInterface getNode() {
         return this.node;
     }
 
-    public ShowAlterStmt(AlterType type, String dbName) {
+    public ShowAlterStmt(AlterType type, String dbName, Expr whereClause, List<OrderByElement> orderByElements,
+                         LimitElement limitElement) {
         this.type = type;
         this.dbName = dbName;
+        this.whereClause = whereClause;
+        this.orderByElements = orderByElements;
+        this.limitElement = limitElement;
+        this.filterMap = new HashMap<String, Expr>();
+    }
+
+    private boolean getPredicateValue(Expr subExpr) throws AnalysisException {
+        if (!(subExpr instanceof BinaryPredicate)) {
+            return false;
+        }
+        BinaryPredicate binaryPredicate = (BinaryPredicate) subExpr;
+        if (!(subExpr.getChild(0) instanceof SlotRef)) {
+            return false;
+        }
+        String leftKey = ((SlotRef) subExpr.getChild(0)).getColumnName().toLowerCase();
+        if (leftKey.equals("tablename") || leftKey.equals("state")) {
+            if (!(subExpr.getChild(1) instanceof StringLiteral) ||
+                    binaryPredicate.getOp() != BinaryPredicate.Operator.EQ) {
+                return false;
+            }
+        } else if (leftKey.equals("createtime") || leftKey.equals("finishtime")) {
+            if (!(subExpr.getChild(1) instanceof StringLiteral)) {
+                return false;
+            }
+            subExpr.setChild(1,((StringLiteral) subExpr.getChild(1)).castTo(Type.DATETIME));
+        } else {
+            return false;
+        }
+        filterMap.put(leftKey, subExpr);
+        return true;
+    }
+
+    private void analyzeSubPredicate(Expr subExpr) throws AnalysisException {
+        if (subExpr == null) {
+            return;
+        }
+        if (subExpr instanceof CompoundPredicate) {
+            CompoundPredicate cp = (CompoundPredicate) subExpr;
+            if (cp.getOp() != org.apache.doris.analysis.CompoundPredicate.Operator.AND) {
+                throw new AnalysisException("Only allow compound predicate with operator AND");
+            }
+            analyzeSubPredicate(cp.getChild(0));
+            analyzeSubPredicate(cp.getChild(1));
+            return;
+        }
+        boolean valid = getPredicateValue(subExpr);
+        if (!valid) {
+            filterMap.clear();
+            throw new AnalysisException("Where clause should looks like: TableName = \"tablename\","
+                    + " or State = \"FINISHED|CANCELLED|RUNNING|PENDING|WAITING_TXN\", or CreateTime =/>=/<=/>/< \"2019-12-02\","
+                    + " FinishTime =/>=/<=/>/< \"2019-12-02 14:54:00\" or compound predicate with operator AND");
+        }
     }
 
     @Override
     public void analyze(Analyzer analyzer) throws AnalysisException, UserException {
+        //first analyze 
+        analyzeSyntax(analyzer);        
+
+        // check auth when get job info
+        handleShowAlterTable(analyzer);
+    }
+    
+    public void analyzeSyntax(Analyzer analyzer) throws AnalysisException, UserException {
         super.analyze(analyzer);
         if (Strings.isNullOrEmpty(dbName)) {
             dbName = analyzer.getDefaultDb();
@@ -86,11 +156,41 @@ public class ShowAlterStmt extends ShowStmt {
 
         Preconditions.checkNotNull(type);
 
-        // check auth when get job info
-        handleShowAlterTable(analyzer);
-    }
+        // analyze where clause if not null
+        if (whereClause != null) {
+            if (whereClause instanceof CompoundPredicate) {
+                CompoundPredicate cp = (CompoundPredicate) whereClause;
+                if (cp.getOp() != org.apache.doris.analysis.CompoundPredicate.Operator.AND) {
+                    throw new AnalysisException("Only allow compound predicate with operator AND");
+                }
+                analyzeSubPredicate(cp.getChild(0));
+                analyzeSubPredicate(cp.getChild(1));
+            } else {
+                analyzeSubPredicate(whereClause);
+            }
+        }
 
-    private void handleShowAlterTable(Analyzer analyzer) throws AnalysisException, UserException {
+        // order by
+        if (orderByElements != null && !orderByElements.isEmpty()) {
+            orderByPairs = new ArrayList<OrderByPair>();
+            for (OrderByElement orderByElement : orderByElements) {
+                if (!(orderByElement.getExpr() instanceof SlotRef)) {
+                    throw new AnalysisException("Should order by column");
+                }
+                SlotRef slotRef = (SlotRef) orderByElement.getExpr();
+                int index = SchemaChangeProcNode.analyzeColumn(slotRef.getColumnName());
+                OrderByPair orderByPair = new OrderByPair(index, !orderByElement.getIsAsc());
+                orderByPairs.add(orderByPair);
+            }
+        }
+
+        if (limitElement != null) {
+            limitElement.analyze(analyzer);
+        }
+    }
+    
+    
+    public void handleShowAlterTable(Analyzer analyzer) throws AnalysisException, UserException {
         final String dbNameWithoutPrefix = ClusterNamespace.getNameFromFullName(dbName);
         Database db = analyzer.getCatalog().getDb(dbName);
         if (db == null) {
@@ -121,11 +221,30 @@ public class ShowAlterStmt extends ShowStmt {
     @Override
     public String toSql() {
         StringBuilder sb = new StringBuilder();
-        sb.append("SHOW ALTER ").append(type.name()).append(" ");
+        sb.append("SHOW ALTER TABLE ").append(type.name()).append(" ");
         if (!Strings.isNullOrEmpty(dbName)) {
             sb.append("FROM `").append(dbName).append("`");
         }
+        if (whereClause != null) {
+            sb.append(" WHERE ").append(whereClause.toSql());
+        }
+        // Order By clause
+        if (orderByElements != null) {
+            sb.append(" ORDER BY ");
+            for (int i = 0; i < orderByElements.size(); ++i) {
+                sb.append(orderByElements.get(i).getExpr().toSql());
+                sb.append((orderByElements.get(i).getIsAsc()) ? " ASC" : " DESC");
+                sb.append((i + 1 != orderByElements.size()) ? ", " : "");
+            }
+        }
 
+        if (limitElement != null && limitElement.hasLimit()) {
+            sb.append(" LIMIT ").append(limitElement.getLimit());
+            if (limitElement.hasOffset()) {
+                sb.append(" OFFSET ").append(limitElement.getOffset());
+            }
+        }
+        LOG.info("AlterSQL '{}'", sb.toString());
         return sb.toString();
     }
 

--- a/fe/src/main/java/org/apache/doris/analysis/ShowAlterStmt.java
+++ b/fe/src/main/java/org/apache/doris/analysis/ShowAlterStmt.java
@@ -88,11 +88,11 @@ public class ShowAlterStmt extends ShowStmt {
 
     private void getPredicateValue(Expr subExpr) throws AnalysisException {
         if (!(subExpr instanceof BinaryPredicate)) {
-            return;
+            throw new AnalysisException("The operator =|>=|<=|>|<|!= are supported."); 
         }
         BinaryPredicate binaryPredicate = (BinaryPredicate) subExpr;
         if (!(subExpr.getChild(0) instanceof SlotRef)) {
-            return;
+            throw new AnalysisException("Only support column = xxx syntax."); 
         }
         String leftKey = ((SlotRef) subExpr.getChild(0)).getColumnName().toLowerCase();
         if (leftKey.equals("tablename") || leftKey.equals("state")) {

--- a/fe/src/main/java/org/apache/doris/common/proc/SchemaChangeProcNode.java
+++ b/fe/src/main/java/org/apache/doris/common/proc/SchemaChangeProcNode.java
@@ -18,13 +18,27 @@
 package org.apache.doris.common.proc;
 
 import org.apache.doris.alter.SchemaChangeHandler;
+import org.apache.doris.analysis.Expr;
+import org.apache.doris.analysis.LimitElement;
+import org.apache.doris.analysis.BinaryPredicate;
+import org.apache.doris.analysis.StringLiteral;
+import org.apache.doris.analysis.DateLiteral;
 import org.apache.doris.catalog.Database;
+import org.apache.doris.catalog.Type;
 import org.apache.doris.common.AnalysisException;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
+import org.apache.doris.common.util.ListComparator;
+import org.apache.doris.common.util.OrderByPair;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map.Entry;
 import java.util.List;
 
 public class SchemaChangeProcNode implements ProcNodeInterface {
@@ -34,12 +48,118 @@ public class SchemaChangeProcNode implements ProcNodeInterface {
             .add("TransactionId").add("State").add("Msg").add("Progress").add("Timeout")
             .build();
 
+    private static final Logger LOG = LogManager.getLogger(SchemaChangeProcNode.class);
+
     private SchemaChangeHandler schemaChangeHandler;
     private Database db;
 
     public SchemaChangeProcNode(SchemaChangeHandler schemaChangeHandler, Database db) {
         this.schemaChangeHandler = schemaChangeHandler;
         this.db = db;
+    }
+
+    boolean filterResult(String columnName, Comparable element, HashMap<String, Expr> filter) throws AnalysisException {
+        if (filter == null) {
+            return true;
+        }
+        Expr subExpr = filter.get(columnName.toLowerCase());
+        if (subExpr == null) {
+            return true;
+        }
+        BinaryPredicate binaryPredicate = (BinaryPredicate) subExpr;
+        if (subExpr.getChild(1) instanceof StringLiteral && binaryPredicate.getOp() == BinaryPredicate.Operator.EQ) {
+            LOG.info("SubExpr value " + ((StringLiteral) subExpr.getChild(1)).getValue() + ", real value " + element);
+            return ((StringLiteral) subExpr.getChild(1)).getValue().equals(element);
+        }
+        if (subExpr.getChild(1) instanceof DateLiteral) {
+            Long leftVal = (new DateLiteral((String) element, Type.DATETIME)).getLongValue();
+            Long rightVal = ((DateLiteral) subExpr.getChild(1)).getLongValue();
+            LOG.info("Left value " + leftVal + ", right value " + rightVal);
+            switch( binaryPredicate.getOp()) {
+                case EQ:
+                case EQ_FOR_NULL:
+                    return leftVal == rightVal;
+                case GE:
+                    return leftVal >= rightVal;
+                case GT:
+                    return leftVal > rightVal;
+                case LE:
+                    return leftVal <= rightVal;
+                case LT:
+                    return leftVal < rightVal;
+                case NE:
+                    return leftVal != rightVal;
+                default:
+                    Preconditions.checkState(false, "No defined binary operator.");
+            }
+        }
+        return true;
+    }
+
+    public ProcResult fetchResultByFilter(HashMap<String, Expr> filter, ArrayList<OrderByPair> orderByPairs,
+                                          LimitElement limitElement) throws AnalysisException {
+        Preconditions.checkNotNull(db);
+        Preconditions.checkNotNull(schemaChangeHandler);
+
+        List<List<Comparable>> schemaChangeJobInfos = schemaChangeHandler.getAlterJobInfosByDb(db);
+
+        LOG.info("Begin fetch data.Filter size " + filter.size() );
+        for(Entry<String, Expr> entry : filter.entrySet()){
+            LOG.info("key " + entry.getKey() + ", value" + entry.getValue().getChild(1));
+        }
+
+        //where
+        List<List<Comparable>> jobInfos = new ArrayList<List<Comparable>>();
+        for (List<Comparable> infoStr : schemaChangeJobInfos) {
+            if (infoStr.size() != TITLE_NAMES.size()) {
+                LOG.warn("SchemaChangeJobInfos.size() " + schemaChangeJobInfos.size()
+                    + " not equal TITLE_NAMES.size() " + TITLE_NAMES.size());
+                continue;
+            }
+            List<Comparable> jobInfo = new ArrayList<Comparable>();
+            boolean isNeed = true;
+            for (int i = 0; i < infoStr.size(); i++) {
+                Comparable element = infoStr.get(i);
+                isNeed = filterResult(TITLE_NAMES.get(i), element, filter);
+                LOG.info("column "+ TITLE_NAMES.get(i) +", value " + element + ",isNeed " + isNeed);
+                if (!isNeed) {
+                    break;
+                }
+                jobInfo.add(element.toString());
+            }
+            if (isNeed) {
+                jobInfos.add(jobInfo);
+            }
+        }
+
+        // order by
+        if (orderByPairs != null) {
+            ListComparator<List<Comparable>> comparator = null;
+            OrderByPair[] orderByPairArr = new OrderByPair[orderByPairs.size()];
+            comparator = new ListComparator<List<Comparable>>(orderByPairs.toArray(orderByPairArr));
+            Collections.sort(jobInfos, comparator);
+        }
+
+        //limit
+        if (limitElement != null && limitElement.hasLimit()) {
+            int beginIndex = (int) limitElement.getOffset();
+            int endIndex = (int) (beginIndex + limitElement.getLimit());
+            if (endIndex > jobInfos.size()) {
+                endIndex = jobInfos.size();
+            }
+            jobInfos = jobInfos.subList(beginIndex,endIndex);
+        }
+
+        BaseProcResult result = new BaseProcResult();
+        result.setNames(TITLE_NAMES);
+        for (List<Comparable> jobInfo : jobInfos) {
+            List<String> oneResult = new ArrayList<String>(jobInfos.size());
+            for (Comparable column : jobInfo) {
+                oneResult.add(column.toString());
+            }
+            result.addRow(oneResult);
+        }
+        return result;
     }
 
     @Override
@@ -61,4 +181,12 @@ public class SchemaChangeProcNode implements ProcNodeInterface {
         return result;
     }
 
+    public static int analyzeColumn(String columnName) throws AnalysisException {
+        for (String title : TITLE_NAMES) {
+            if (title.equalsIgnoreCase(columnName)) {
+                return TITLE_NAMES.indexOf(title);
+            }
+        }
+        throw new AnalysisException("Title name[" + columnName + "] does not exist");
+    }
 }

--- a/fe/src/main/java/org/apache/doris/common/proc/SchemaChangeProcNode.java
+++ b/fe/src/main/java/org/apache/doris/common/proc/SchemaChangeProcNode.java
@@ -176,9 +176,9 @@ public class SchemaChangeProcNode implements ProcNodeInterface {
     }
 
     public static int analyzeColumn(String columnName) throws AnalysisException {
-        for (String title : TITLE_NAMES) {
-            if (title.equalsIgnoreCase(columnName)) {
-                return TITLE_NAMES.indexOf(title);
+        for (int i = 0; i < TITLE_NAMES.size(); ++i) {
+            if (TITLE_NAMES.get(i).equalsIgnoreCase(columnName)) {
+                return i;
             }
         }
         throw new AnalysisException("Title name[" + columnName + "] does not exist");

--- a/fe/src/main/java/org/apache/doris/qe/ShowExecutor.java
+++ b/fe/src/main/java/org/apache/doris/qe/ShowExecutor.java
@@ -91,12 +91,13 @@ import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.ErrorReport;
 import org.apache.doris.common.MetaNotFoundException;
 import org.apache.doris.common.PatternMatcher;
-import org.apache.doris.common.proc.BackendsProcDir;
-import org.apache.doris.common.proc.FrontendsProcNode;
-import org.apache.doris.common.proc.LoadProcDir;
-import org.apache.doris.common.proc.PartitionsProcDir;
 import org.apache.doris.common.proc.ProcNodeInterface;
+import org.apache.doris.common.proc.BackendsProcDir;
+import org.apache.doris.common.proc.LoadProcDir;
+import org.apache.doris.common.proc.SchemaChangeProcNode;
+import org.apache.doris.common.proc.PartitionsProcDir;
 import org.apache.doris.common.proc.TabletsProcDir;
+import org.apache.doris.common.proc.FrontendsProcNode;
 import org.apache.doris.common.util.ListComparator;
 import org.apache.doris.common.util.LogBuilder;
 import org.apache.doris.common.util.LogKey;
@@ -1017,8 +1018,14 @@ public class ShowExecutor {
         ShowAlterStmt showStmt = (ShowAlterStmt) stmt;
         ProcNodeInterface procNodeI = showStmt.getNode();
         Preconditions.checkNotNull(procNodeI);
-        List<List<String>> rows = procNodeI.fetchResult().getRows();
-
+        List<List<String>> rows;
+        //Only SchemaChangeProc support where/order by/limit syntax 
+        if (procNodeI instanceof SchemaChangeProcNode) {
+            rows = ((SchemaChangeProcNode) procNodeI).fetchResultByFilter(showStmt.getFilterMap(),
+                    showStmt.getOrderPairs(), showStmt.getLimitElement()).getRows();
+        } else {
+            rows = procNodeI.fetchResult().getRows();
+        }
         resultSet = new ShowResultSet(showStmt.getMetaData(), rows);
     }
 

--- a/fe/src/test/java/org/apache/doris/analysis/ShowAlterStmtTest.java
+++ b/fe/src/test/java/org/apache/doris/analysis/ShowAlterStmtTest.java
@@ -19,6 +19,7 @@ package org.apache.doris.analysis;
 
 import org.apache.doris.analysis.BinaryPredicate.Operator;
 import org.apache.doris.catalog.Catalog;
+import org.apache.doris.system.SystemInfoService;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.UserException;
 
@@ -32,19 +33,25 @@ import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
+import javax.validation.constraints.Null;
+
 @RunWith(PowerMockRunner.class)
 @PowerMockIgnore({ "org.apache.log4j.*", "javax.management.*" })
 @PrepareForTest(Catalog.class)
 public class ShowAlterStmtTest {
     private Analyzer analyzer;
     private Catalog catalog;
+    private SystemInfoService systemInfo;
 
     @Before
     public void setUp() {
         catalog = AccessTestUtil.fetchAdminCatalog();
+        systemInfo = new SystemInfoService();
 
         PowerMock.mockStatic(Catalog.class);
         EasyMock.expect(Catalog.getInstance()).andReturn(catalog).anyTimes();
+        EasyMock.expect(Catalog.getCurrentSystemInfo()).andReturn(systemInfo).anyTimes();
+        EasyMock.expect(Catalog.getCurrentCatalog()).andReturn(catalog).anyTimes();
         PowerMock.replay(Catalog.class);
 
         analyzer = EasyMock.createMock(Analyzer.class);
@@ -56,34 +63,33 @@ public class ShowAlterStmtTest {
     }
 
     @Test
-    public void testNormal() throws UserException, AnalysisException {
-        ShowLoadStmt stmt = new ShowLoadStmt(null, null, null, null);
-        stmt.analyze(analyzer);
-        Assert.assertEquals("SHOW LOAD FROM `testDb`", stmt.toString());
-
-        SlotRef slotRef = new SlotRef(null, "label");
+    public void testAlterStmt1() throws UserException, AnalysisException {
+        ShowAlterStmt stmt = new ShowAlterStmt(ShowAlterStmt.AlterType.COLUMN,null, null,
+                null,null);
+        stmt.analyzeSyntax(analyzer);
+        Assert.assertEquals("SHOW ALTER TABLE COLUMN FROM `testDb`", stmt.toString());
+    }
+    
+    @Test
+    public void testAlterStmt2() throws UserException, AnalysisException {
+        SlotRef slotRef = new SlotRef(null, "TableName");
         StringLiteral stringLiteral = new StringLiteral("abc");
         BinaryPredicate binaryPredicate = new BinaryPredicate(Operator.EQ, slotRef, stringLiteral);
-        stmt = new ShowLoadStmt(null, binaryPredicate, null, new LimitElement(10));
-        stmt.analyze(analyzer);
-        Assert.assertEquals("SHOW LOAD FROM `testDb` WHERE `label` = \'abc\' LIMIT 10", stmt.toString());
-
-        LikePredicate likePredicate = new LikePredicate(org.apache.doris.analysis.LikePredicate.Operator.LIKE,
-                                                        slotRef, stringLiteral);
-        stmt = new ShowLoadStmt(null, likePredicate, null, new LimitElement(10));
-        stmt.analyze(analyzer);
-        Assert.assertEquals("SHOW LOAD FROM `testDb` WHERE `label` LIKE \'abc\' LIMIT 10", stmt.toString());
+        ShowAlterStmt stmt = new ShowAlterStmt(ShowAlterStmt.AlterType.COLUMN, null, binaryPredicate, null,
+                new LimitElement(1,2));
+        stmt.analyzeSyntax(analyzer);
+        Assert.assertEquals("SHOW ALTER TABLE COLUMN FROM `testDb` WHERE `TableName` = \'abc\' LIMIT 2 OFFSET 1",
+                stmt.toString());
     }
-
-    @Test(expected = AnalysisException.class)
-    public void testNoDb() throws UserException, AnalysisException {
-        analyzer = EasyMock.createMock(Analyzer.class);
-        EasyMock.expect(analyzer.getDefaultDb()).andReturn("").anyTimes();
-        EasyMock.expect(analyzer.getClusterName()).andReturn("testCluster").anyTimes();
-        EasyMock.replay(analyzer);
-
-        ShowLoadStmt stmt = new ShowLoadStmt(null, null, null, null);
-        stmt.analyze(analyzer);
-        Assert.fail("No exception throws.");
+    
+    @Test
+    public void testAlterStmt3() throws UserException, AnalysisException {
+        SlotRef slotRef = new SlotRef(null, "CreateTime");
+        StringLiteral stringLiteral = new StringLiteral("2019-12-04");
+        BinaryPredicate binaryPredicate = new BinaryPredicate(Operator.EQ, slotRef, stringLiteral);
+        ShowAlterStmt stmt = new ShowAlterStmt(ShowAlterStmt.AlterType.COLUMN, null, binaryPredicate, null, null);
+        stmt.analyzeSyntax(analyzer);
+        Assert.assertEquals("SHOW ALTER TABLE COLUMN FROM `testDb` WHERE `CreateTime` = \'2019-12-04 00:00:00\'",
+                stmt.toString());
     }
 }

--- a/fe/src/test/java/org/apache/doris/analysis/ShowAlterStmtTest.java
+++ b/fe/src/test/java/org/apache/doris/analysis/ShowAlterStmtTest.java
@@ -78,7 +78,7 @@ public class ShowAlterStmtTest {
         ShowAlterStmt stmt = new ShowAlterStmt(ShowAlterStmt.AlterType.COLUMN, null, binaryPredicate, null,
                 new LimitElement(1,2));
         stmt.analyzeSyntax(analyzer);
-        Assert.assertEquals("SHOW ALTER TABLE COLUMN FROM `testDb` WHERE `TableName` = \'abc\' LIMIT 2 OFFSET 1",
+        Assert.assertEquals("SHOW ALTER TABLE COLUMN FROM `testDb` WHERE `TableName` = \'abc\' LIMIT 1, 2",
                 stmt.toString());
     }
     

--- a/run-fe-ut.sh
+++ b/run-fe-ut.sh
@@ -36,6 +36,7 @@ Usage: $0 <options>
   Eg.
     $0                      build and run ut
     $0 --coverage           build and run coverage statistic
+    $0 --run xxx            build and run the specified class
   "
   exit 1
 }
@@ -44,6 +45,7 @@ OPTS=$(getopt \
   -n $0 \
   -o '' \
   -l 'coverage' \
+  -l 'run' \
   -- "$@")
 
 if [ $? != 0 ] ; then
@@ -52,15 +54,19 @@ fi
 
 eval set -- "$OPTS"
 
+RUN=
 COVERAGE=
 if [ $# == 1 ] ; then
     #default
+    RUN=0
     COVERAGE=0
 else
+    RUN=0
     COVERAGE=0
     while true; do 
         case "$1" in
             --coverage) COVERAGE=1 ; shift ;;
+            --run) RUN=1 ; shift ;;
             --) shift ;  break ;;
             *) ehco "Internal error" ; exit 1 ;;
         esac
@@ -83,6 +89,11 @@ if [ ${COVERAGE} -eq 1 ]; then
     echo "Run coverage statistic"
     ant cover-test
 else
-    echo "Run Frontend UT"
-    $MVN test    
+    if [ ${RUN} -eq 1 ]; then
+        echo "Run the specified class"  
+        $MVN test -D test=$1
+    else    
+        echo "Run Frontend UT"
+        $MVN test   
+    fi 
 fi


### PR DESCRIPTION
#2314

Features：
1、Support WHERE/ORDER BY/LIMIT
2、Columns：TableName、CreatTime、FinishTime、State
3、Only  “And” between conditions
4、TableName and State column only support "=" operator
5、CreateTime and FinishTime column support “=”,“>=”,"<=",">","<","!=" operators
6、CreateTime and FinishTime column support Date and DateTime string, eg:"2019-12-04" or "2019-12-04 17:18:00"

TestCase:
MySQL [haibotest]> show alter table column where State='FINISHED' and CreateTime > '2019-12-03' order by FinishTime desc limit 0,2;
+-------+---------------+---------------------+---------------------+---------------+---------+---------------+---------------+---------------+----------+------+----------+---------+
| JobId | TableName | CreateTime | FinishTime | IndexName | IndexId | OriginIndexId | SchemaVersion | TransactionId | State | Msg | Progress | Timeout |
+-------+---------------+---------------------+---------------------+---------------+---------+---------------+---------------+---------------+----------+------+----------+---------+
| 11134 | test_schema_2 | 2019-12-03 19:21:42 | 2019-12-03 19:22:11 | test_schema_2 | 11135 | 11059 | 1:192010000 | 3 | FINISHED | | N/A | 86400 |
| 11096 | test_schema_3 | 2019-12-03 19:21:31 | 2019-12-03 19:21:51 | test_schema_3 | 11097 | 11018 | 1:2063361382 | 2 | FINISHED | | N/A | 86400 |
+-------+---------------+---------------------+---------------------+---------------+---------+---------------+---------------+---------------+----------+------+----------+---------+
2 rows in set (0.00 sec)
