### PR TITLE
Fix some load bugs

### DIFF
--- a/fe/src/main/java/org/apache/doris/alter/SchemaChangeJob.java
+++ b/fe/src/main/java/org/apache/doris/alter/SchemaChangeJob.java
@@ -1044,7 +1044,9 @@ public class SchemaChangeJob extends AlterJob {
         db.writeLock();
         try {
             OlapTable olapTable = (OlapTable) db.getTable(tableId);
-            olapTable.setState(OlapTableState.NORMAL);
+            if (olapTable != null) {
+                olapTable.setState(OlapTableState.NORMAL);
+            }
         } finally {
             db.writeUnlock();
         }

--- a/fe/src/main/java/org/apache/doris/analysis/ShowRoutineLoadTaskStmt.java
+++ b/fe/src/main/java/org/apache/doris/analysis/ShowRoutineLoadTaskStmt.java
@@ -42,6 +42,7 @@ public class ShowRoutineLoadTaskStmt extends ShowStmt {
             new ImmutableList.Builder<String>()
                     .add("TaskId")
                     .add("TxnId")
+                    .add("TxnStatus")
                     .add("JobId")
                     .add("CreateTime")
                     .add("ExecuteStartTime")

--- a/fe/src/main/java/org/apache/doris/catalog/Catalog.java
+++ b/fe/src/main/java/org/apache/doris/catalog/Catalog.java
@@ -1109,7 +1109,7 @@ public class Catalog {
     /*
      * Add anything necessary here if there is meta data need to be fixed.
      */
-    private void fixBugAfterMetadataReplayed(boolean waitCatalogReady) {
+    public void fixBugAfterMetadataReplayed(boolean waitCatalogReady) {
         if (waitCatalogReady) {
             while (!isReady()) {
                 try {

--- a/fe/src/main/java/org/apache/doris/catalog/Catalog.java
+++ b/fe/src/main/java/org/apache/doris/catalog/Catalog.java
@@ -272,7 +272,7 @@ public class Catalog {
     private BackupHandler backupHandler;
     private PublishVersionDaemon publishVersionDaemon;
 
-    private Daemon labelCleaner; // To clean old LabelInfo, ExportJobInfos
+    private MasterDaemon labelCleaner; // To clean old LabelInfo, ExportJobInfos
     private MasterDaemon txnCleaner; // To clean aborted or timeout txns
     private Daemon replayer;
     private Daemon timePrinter;
@@ -1086,6 +1086,11 @@ public class Catalog {
         MasterInfo info = new MasterInfo(this.masterIp, this.masterHttpPort, this.masterRpcPort);
         editLog.logMasterInfo(info);
 
+        // for master, the 'isReady' is set behind.
+        // but we are sure that all metadata is replayed if we get here.
+        // so no need to check 'isReady' flag in this method
+        fixBugAfterMetadataReplayed(false);
+
         // start all daemon threads that only running on MASTER FE
         startMasterOnlyDaemonThreads();
         // start other daemon threads that should running on all FE
@@ -1099,6 +1104,24 @@ public class Catalog {
         String msg = "master finished to replay journal, can write now.";
         Util.stdoutWithTime(msg);
         LOG.info(msg);
+    }
+
+    /*
+     * Add anything necessary here if there is meta data need to be fixed.
+     */
+    private void fixBugAfterMetadataReplayed(boolean waitCatalogReady) {
+        if (waitCatalogReady) {
+            while (!isReady()) {
+                try {
+                    Thread.sleep(10 * 1000);
+                } catch (InterruptedException e) {
+                    e.printStackTrace();
+                }
+            }
+        }
+
+        LOG.info("start to fix meta data bug");
+        loadManager.transferLoadingStateToCommitted(globalTransactionMgr);
     }
 
     // start all daemon threads only running on Master
@@ -1193,6 +1216,9 @@ public class Catalog {
             createReplayer();
             replayer.start();
         }
+
+        // 'isReady' will be set to true in 'setCanRead()' method
+        fixBugAfterMetadataReplayed(true);
 
         startNonMasterDaemonThreads();
 
@@ -1720,7 +1746,6 @@ public class Catalog {
     public long loadLoadJobsV2(DataInputStream in, long checksum) throws IOException {
         if (Catalog.getCurrentCatalogJournalVersion() >= FeMetaVersion.VERSION_50) {
             loadManager.readFields(in);
-            loadManager.transferLoadingStateToCommitted(globalTransactionMgr);
         }
         return checksum;
     }
@@ -2055,9 +2080,9 @@ public class Catalog {
     }
 
     public void createLabelCleaner() {
-        labelCleaner = new Daemon("LoadLabelCleaner", Config.label_clean_interval_second * 1000L) {
+        labelCleaner = new MasterDaemon("LoadLabelCleaner", Config.label_clean_interval_second * 1000L) {
             @Override
-            protected void runOneCycle() {
+            protected void runAfterCatalogReady() {
                 load.removeOldLoadJobs();
                 load.removeOldDeleteJobs();
                 loadManager.removeOldLoadJob();

--- a/fe/src/main/java/org/apache/doris/catalog/Catalog.java
+++ b/fe/src/main/java/org/apache/doris/catalog/Catalog.java
@@ -1121,7 +1121,7 @@ public class Catalog {
         }
 
         LOG.info("start to fix meta data bug");
-        loadManager.transferLoadingStateToCommitted(globalTransactionMgr);
+        loadManager.fixLoadJobMetaBugs(globalTransactionMgr);
     }
 
     // start all daemon threads only running on Master

--- a/fe/src/main/java/org/apache/doris/catalog/DomainResolver.java
+++ b/fe/src/main/java/org/apache/doris/catalog/DomainResolver.java
@@ -47,8 +47,9 @@ public class DomainResolver extends MasterDaemon {
         this.auth = auth;
     }
 
+    // 'public' for test
     @Override
-    protected void runAfterCatalogReady() {
+    public void runAfterCatalogReady() {
         // qualified user name -> domain name
         Map<String, Set<String>> userMap = Maps.newHashMap();
         auth.getCopiedWhiteList(userMap);

--- a/fe/src/main/java/org/apache/doris/catalog/DomainResolver.java
+++ b/fe/src/main/java/org/apache/doris/catalog/DomainResolver.java
@@ -17,7 +17,7 @@
 
 package org.apache.doris.catalog;
 
-import org.apache.doris.common.util.Daemon;
+import org.apache.doris.common.util.MasterDaemon;
 import org.apache.doris.mysql.privilege.PaloAuth;
 
 import com.google.common.base.Strings;
@@ -35,15 +35,12 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicBoolean;
 
-public class DomainResolver extends Daemon {
+public class DomainResolver extends MasterDaemon {
     private static final Logger LOG = LogManager.getLogger(DomainResolver.class);
     private static final String BNS_RESOLVER_TOOLS_PATH = "/usr/bin/get_instance_by_service";
 
     private PaloAuth auth;
-
-    private AtomicBoolean isStart = new AtomicBoolean(false);
 
     public DomainResolver(PaloAuth auth) {
         super("domain resolver", 10 * 1000);
@@ -51,14 +48,7 @@ public class DomainResolver extends Daemon {
     }
 
     @Override
-    public synchronized void start() {
-        if (isStart.compareAndSet(false, true)) {
-            super.start();
-        }
-    }
-
-    @Override
-    public void runOneCycle() {
+    protected void runAfterCatalogReady() {
         // qualified user name -> domain name
         Map<String, Set<String>> userMap = Maps.newHashMap();
         auth.getCopiedWhiteList(userMap);

--- a/fe/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/src/main/java/org/apache/doris/common/Config.java
@@ -934,6 +934,5 @@ public class Config extends ConfigBase {
      */
     @ConfField(mutable = true, masterOnly = true)
     public static boolean force_do_metadata_checkpoint = false;
-
 }
 

--- a/fe/src/main/java/org/apache/doris/external/EsStateStore.java
+++ b/fe/src/main/java/org/apache/doris/external/EsStateStore.java
@@ -30,20 +30,16 @@ import org.apache.doris.catalog.Table.TableType;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.DdlException;
-import org.apache.doris.common.util.Daemon;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.apache.doris.common.util.MasterDaemon;
+
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Range;
-import okhttp3.Authenticator;
-import okhttp3.Call;
-import okhttp3.Credentials;
-import okhttp3.OkHttpClient;
-import okhttp3.Request;
-import okhttp3.Response;
-import okhttp3.Route;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.json.JSONObject;
+
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Comparator;
@@ -51,8 +47,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-
-import org.json.JSONObject;
+import okhttp3.Authenticator;
+import okhttp3.Call;
+import okhttp3.Credentials;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.Route;
 
 
 /**

--- a/fe/src/main/java/org/apache/doris/load/FailMsg.java
+++ b/fe/src/main/java/org/apache/doris/load/FailMsg.java
@@ -32,7 +32,8 @@ public class FailMsg implements Writable {
         ETL_QUALITY_UNSATISFIED,
         LOAD_RUN_FAIL,
         TIMEOUT,
-        UNKNOWN
+        UNKNOWN,
+        TXN_UNKNOWN // cancelled because txn status is unknown
     }
     
     private CancelType cancelType;

--- a/fe/src/main/java/org/apache/doris/load/loadv2/LoadJob.java
+++ b/fe/src/main/java/org/apache/doris/load/loadv2/LoadJob.java
@@ -628,7 +628,9 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
         Catalog.getCurrentGlobalTransactionMgr().getCallbackFactory().removeCallback(id);
         state = JobState.FINISHED;
 
-        MetricRepo.COUNTER_LOAD_FINISHED.increase(1L);
+        if (MetricRepo.isInit.get()) {
+            MetricRepo.COUNTER_LOAD_FINISHED.increase(1L);
+        }
     }
 
     protected boolean checkDataQuality() {

--- a/fe/src/main/java/org/apache/doris/load/loadv2/LoadManager.java
+++ b/fe/src/main/java/org/apache/doris/load/loadv2/LoadManager.java
@@ -33,6 +33,7 @@ import org.apache.doris.common.UserException;
 import org.apache.doris.common.io.Writable;
 import org.apache.doris.common.util.LogBuilder;
 import org.apache.doris.common.util.LogKey;
+import org.apache.doris.common.util.TimeUtils;
 import org.apache.doris.load.EtlJobType;
 import org.apache.doris.load.FailMsg;
 import org.apache.doris.load.FailMsg.CancelType;
@@ -677,8 +678,8 @@ public class LoadManager implements Writable{
                     
                     // use CancelType.UNKNOWN, so that we can set finish time to be the same as the create time
                     job.cancelJobWithoutCheck(new FailMsg(CancelType.TXN_UNKNOWN, "transaction status is unknown"), false, false);
-                    LOG.info("finish load job {} from {} to CANCELLED, because transaction status is unknown. label: {}, db: {}",
-                            job.getId(), prevState, job.getLabel(), job.getDbId());
+                    LOG.info("finish load job {} from {} to CANCELLED, because transaction status is unknown. label: {}, db: {}, create: {}",
+                            job.getId(), prevState, job.getLabel(), job.getDbId(), TimeUtils.longToTimeString(job.getCreateTimestamp()));
                 }
             }
         }

--- a/fe/src/main/java/org/apache/doris/load/routineload/RoutineLoadTaskInfo.java
+++ b/fe/src/main/java/org/apache/doris/load/routineload/RoutineLoadTaskInfo.java
@@ -185,6 +185,7 @@ public abstract class RoutineLoadTaskInfo {
         List<String> row = Lists.newArrayList();
         row.add(DebugUtil.printId(id));
         row.add(String.valueOf(txnId));
+        row.add(txnStatus.name());
         row.add(String.valueOf(jobId));
         row.add(String.valueOf(TimeUtils.longToTimeString(createTimeMs)));
         row.add(String.valueOf(TimeUtils.longToTimeString(executeStartTimeMs)));

--- a/fe/src/main/java/org/apache/doris/master/Checkpoint.java
+++ b/fe/src/main/java/org/apache/doris/master/Checkpoint.java
@@ -104,6 +104,8 @@ public class Checkpoint extends MasterDaemon {
                           checkPointVersion, catalog.getReplayedJournalId());
                 return;
             }
+            catalog.fixBugAfterMetadataReplayed(false);
+
             catalog.saveImage();
             replayedJournalId = catalog.getReplayedJournalId();
             if (MetricRepo.isInit.get()) {

--- a/fe/src/main/java/org/apache/doris/planner/BrokerScanNode.java
+++ b/fe/src/main/java/org/apache/doris/planner/BrokerScanNode.java
@@ -304,31 +304,20 @@ public class BrokerScanNode extends LoadScanNode {
 
     private TScanRangeLocations newLocations(TBrokerScanRangeParams params, String brokerName)
             throws UserException {
-        List<Backend> candidateBes = Lists.newArrayList();
-        // Get backend
-        int numBe = Math.min(3, backends.size());
-        for (int i = 0; i < numBe; ++i) {
-            candidateBes.add(backends.get(nextBe++));
-            nextBe = nextBe % backends.size();
-        }
-        // we shuffle it because if we only has 3 backends
-        // we will always choose the same backends without shuffle
-        Collections.shuffle(candidateBes);
+        Backend selectedBackend = backends.get(nextBe++);
+        nextBe = nextBe % backends.size();
 
         // Generate on broker scan range
         TBrokerScanRange brokerScanRange = new TBrokerScanRange();
         brokerScanRange.setParams(params);
-        int numBroker = Math.min(3, numBe);
-        for (int i = 0; i < numBroker; ++i) {
-            FsBroker broker = null;
-            try {
-                broker = Catalog.getInstance().getBrokerMgr().getBroker(
-                        brokerName, candidateBes.get(i).getHost());
-            } catch (AnalysisException e) {
-                throw new UserException(e.getMessage());
-            }
-            brokerScanRange.addToBroker_addresses(new TNetworkAddress(broker.ip, broker.port));
+
+        FsBroker broker = null;
+        try {
+            broker = Catalog.getInstance().getBrokerMgr().getBroker(brokerName, selectedBackend.getHost());
+        } catch (AnalysisException e) {
+            throw new UserException(e.getMessage());
         }
+        brokerScanRange.addToBroker_addresses(new TNetworkAddress(broker.ip, broker.port));
 
         // Scan range
         TScanRange scanRange = new TScanRange();
@@ -337,12 +326,11 @@ public class BrokerScanNode extends LoadScanNode {
         // Locations
         TScanRangeLocations locations = new TScanRangeLocations();
         locations.setScan_range(scanRange);
-        for (Backend be : candidateBes) {
-            TScanRangeLocation location = new TScanRangeLocation();
-            location.setBackend_id(be.getId());
-            location.setServer(new TNetworkAddress(be.getHost(), be.getBePort()));
-            locations.addToLocations(location);
-        }
+
+        TScanRangeLocation location = new TScanRangeLocation();
+        location.setBackend_id(selectedBackend.getId());
+        location.setServer(new TNetworkAddress(selectedBackend.getHost(), selectedBackend.getBePort()));
+        locations.addToLocations(location);
 
         return locations;
     }
@@ -401,12 +389,12 @@ public class BrokerScanNode extends LoadScanNode {
     private void assignBackends() throws UserException {
         backends = Lists.newArrayList();
         for (Backend be : Catalog.getCurrentSystemInfo().getIdToBackend().values()) {
-            if (be.isAlive()) {
+            if (be.isAvailable()) {
                 backends.add(be);
             }
         }
         if (backends.isEmpty()) {
-            throw new UserException("No Alive backends");
+            throw new UserException("No available backends");
         }
         Collections.shuffle(backends, random);
     }

--- a/fe/src/main/java/org/apache/doris/transaction/GlobalTransactionMgr.java
+++ b/fe/src/main/java/org/apache/doris/transaction/GlobalTransactionMgr.java
@@ -216,10 +216,10 @@ public class GlobalTransactionMgr implements Writable {
     private void checkRunningTxnExceedLimit(long dbId, LoadJobSourceType sourceType) throws BeginTransactionException {
         switch (sourceType) {
             case ROUTINE_LOAD_TASK:
-                // we do not limit the txn num of routine load here. for 2 reasons:
-                // 1. the number of running routine load tasks is limited by Config.max_routine_load_task_num_per_be
-                // 2. if we add routine load txn to runningTxnNums, runningTxnNums will always be occupied by routine load,
-                //    and other txn may not be able to submitted.
+                if (runningRoutineLoadTxnNums.getOrDefault(dbId, 0) >= Config.max_running_txn_num_per_db) {
+                    throw new BeginTransactionException("current routine load running txns on db " + dbId + " is "
+                            + runningTxnNums.get(dbId) + ", larger than limit " + Config.max_running_txn_num_per_db);
+                }
                 break;
             default:
                 if (runningTxnNums.getOrDefault(dbId, 0) >= Config.max_running_txn_num_per_db) {

--- a/fe/src/main/java/org/apache/doris/transaction/GlobalTransactionMgr.java
+++ b/fe/src/main/java/org/apache/doris/transaction/GlobalTransactionMgr.java
@@ -216,10 +216,10 @@ public class GlobalTransactionMgr implements Writable {
     private void checkRunningTxnExceedLimit(long dbId, LoadJobSourceType sourceType) throws BeginTransactionException {
         switch (sourceType) {
             case ROUTINE_LOAD_TASK:
-                if (runningRoutineLoadTxnNums.getOrDefault(dbId, 0) >= Config.max_running_txn_num_per_db) {
-                    throw new BeginTransactionException("current routine load running txns on db " + dbId + " is "
-                            + runningTxnNums.get(dbId) + ", larger than limit " + Config.max_running_txn_num_per_db);
-                }
+                // no need to check limit for routine load task:
+                // 1. the number of running routine load tasks is limited by Config.max_routine_load_task_num_per_be
+                // 2. if we add routine load txn to runningTxnNums, runningTxnNums will always be occupied by routine load,
+                //    and other txn may not be able to submitted.
                 break;
             default:
                 if (runningTxnNums.getOrDefault(dbId, 0) >= Config.max_running_txn_num_per_db) {

--- a/fe/src/test/java/org/apache/doris/http/DorisHttpTestCase.java
+++ b/fe/src/test/java/org/apache/doris/http/DorisHttpTestCase.java
@@ -110,7 +110,7 @@ abstract public class DorisHttpTestCase {
     public static final int HTTP_PORT;
     static {
         Random r = new Random(System.currentTimeMillis());
-        HTTP_PORT = 30000 + r.nextInt(10000);
+        HTTP_PORT = 20000 + r.nextInt(10000);
     }
 
     protected static final String URI = "http://localhost:" + HTTP_PORT + "/api/" + DB_NAME + "/" + TABLE_NAME;

--- a/fe/src/test/java/org/apache/doris/mysql/privilege/AuthTest.java
+++ b/fe/src/test/java/org/apache/doris/mysql/privilege/AuthTest.java
@@ -247,7 +247,7 @@ public class AuthTest {
         }
         
         // 5.1 resolve domain [palo.domain1]
-        resolver.runOneCycle();
+        resolver.runAfterCatalogReady();
         
         // 6. check if user from resolved ip can access to palo
         Assert.assertTrue(auth.checkPlainPassword(SystemInfoService.DEFAULT_CLUSTER + ":zhangsan", "10.1.1.1",
@@ -296,7 +296,7 @@ public class AuthTest {
         }
 
         // 8.1 resolve domain [palo.domain2]
-        resolver.runOneCycle();
+        resolver.runAfterCatalogReady();
 
         Assert.assertTrue(auth.checkPlainPassword(SystemInfoService.DEFAULT_CLUSTER + ":lisi", "20.1.1.1",
                                                   "123456"));
@@ -470,7 +470,7 @@ public class AuthTest {
                                             SystemInfoService.DEFAULT_CLUSTER + ":zhangsan",
                                             PrivPredicate.ALTER));
 
-        resolver.runOneCycle();
+        resolver.runAfterCatalogReady();
 
         Assert.assertTrue(auth.checkDbPriv("10.1.1.1", SystemInfoService.DEFAULT_CLUSTER + ":db3",
                                             SystemInfoService.DEFAULT_CLUSTER + ":zhangsan",
@@ -502,7 +502,7 @@ public class AuthTest {
                                             SystemInfoService.DEFAULT_CLUSTER + ":zhangsan",
                                             PrivPredicate.SELECT));
 
-        resolver.runOneCycle();
+        resolver.runAfterCatalogReady();
 
         Assert.assertTrue(auth.checkDbPriv("10.1.1.1", SystemInfoService.DEFAULT_CLUSTER + ":db3",
                                            SystemInfoService.DEFAULT_CLUSTER + ":zhangsan",
@@ -714,7 +714,7 @@ public class AuthTest {
         Assert.assertTrue(auth.checkDbPriv("10.1.1.1", SystemInfoService.DEFAULT_CLUSTER + ":db3",
                                             SystemInfoService.DEFAULT_CLUSTER + ":zhangsan",
                                             PrivPredicate.DROP));
-        resolver.runOneCycle();
+        resolver.runAfterCatalogReady();
         Assert.assertFalse(auth.checkDbPriv("10.1.1.1", SystemInfoService.DEFAULT_CLUSTER + ":db3",
                                             SystemInfoService.DEFAULT_CLUSTER + ":zhangsan",
                                             PrivPredicate.DROP));
@@ -851,7 +851,7 @@ public class AuthTest {
         Assert.assertFalse(auth.checkDbPriv("20.1.1.1", SystemInfoService.DEFAULT_CLUSTER + ":db4",
                                             SystemInfoService.DEFAULT_CLUSTER + ":chenliu",
                                             PrivPredicate.DROP));
-        resolver.runOneCycle();
+        resolver.runAfterCatalogReady();
         Assert.assertTrue(auth.checkDbPriv("20.1.1.1", SystemInfoService.DEFAULT_CLUSTER + ":db4",
                                            SystemInfoService.DEFAULT_CLUSTER + ":chenliu",
                                            PrivPredicate.DROP));
@@ -894,7 +894,7 @@ public class AuthTest {
         Assert.assertTrue(auth.checkDbPriv("20.1.1.1", SystemInfoService.DEFAULT_CLUSTER + ":db4",
                                            SystemInfoService.DEFAULT_CLUSTER + ":chenliu",
                                            PrivPredicate.DROP));
-        resolver.runOneCycle();
+        resolver.runAfterCatalogReady();
         Assert.assertFalse(auth.checkDbPriv("20.1.1.1", SystemInfoService.DEFAULT_CLUSTER + ":db4",
                                            SystemInfoService.DEFAULT_CLUSTER + ":chenliu",
                                            PrivPredicate.DROP));


### PR DESCRIPTION
For #2383 
1. Limit the concurrent transactions of routine load job
2. Create new routine load task when txn is VISIBLE, not after COMMITTED.

For #2267 
1. All non-master daemon thread should also be started after catalog is ready.

For #2354 
1. `fixLoadJobMetaError()` should be called after all meta data is read, including image and edit logs.
2. Mini load job should set to CANCELLED when corresponding transaction is not found, instead
of UNKNOWN.