### PR TITLE
Dockerfile:  update maven to 3.6.3

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -71,9 +71,9 @@ RUN touch  ${DEFAULT_DIR}/install_jdk.sh \
 
 ENV JAVA_HOME /usr/java/jdk
 
-# install maven 3.6.0
-ARG MAVEN_VERSION=3.6.0
-ARG SHA=fae9c12b570c3ba18116a4e26ea524b29f7279c17cbaadc3326ca72927368924d9131d11b9e851b8dc9162228b6fdea955446be41207a5cfc61283dd8a561d2f
+# install maven 3.6.3
+ARG MAVEN_VERSION=3.6.3
+ARG SHA=c35a1803a6e70a126e80b2b3ae33eed961f83ed74d18fcd16909b2d44d7dada3203f1ffe726c17ef8dcca2dcaa9fca676987befeadc9b9f759967a8cb77181c0
 ARG BASE_URL=https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries
 
 RUN mkdir -p /usr/share/maven /usr/share/maven/ref \


### PR DESCRIPTION
ref https://github.com/apache/incubator-doris/issues/2388
maven 3.6.0 download URL is outdated, update it to 3.6.3