### PR TITLE
[CHANGE] change default storage model from aggregate to duplicate(#2318)

### DIFF
--- a/docs/documentation/cn/sql-reference/sql-statements/Data Definition/CREATE TABLE.md
+++ b/docs/documentation/cn/sql-reference/sql-statements/Data Definition/CREATE TABLE.md
@@ -134,6 +134,7 @@ under the License.
                                  适合按key列进行增删改查的点查询业务。
                     DUPLICATE KEY:key列相同的记录，同时存在于Palo中，
                                  适合存储明细数据或者数据无聚合特性的业务场景。
+            默认为DUPLICATE KEY，key列为列定义中的所有列。
         注意：
             除AGGREGATE KEY外，其他key_type在建表时，value列不需要指定聚合类型。
 

--- a/docs/documentation/cn/sql-reference/sql-statements/Data Definition/CREATE TABLE.md
+++ b/docs/documentation/cn/sql-reference/sql-statements/Data Definition/CREATE TABLE.md
@@ -134,7 +134,7 @@ under the License.
                                  适合按key列进行增删改查的点查询业务。
                     DUPLICATE KEY:key列相同的记录，同时存在于Palo中，
                                  适合存储明细数据或者数据无聚合特性的业务场景。
-            默认为DUPLICATE KEY，key列为列定义中的所有列。
+            默认为DUPLICATE KEY，key列为列定义中前36个字节, 如果前36个字节的列数小于3，将使用前三列。
         注意：
             除AGGREGATE KEY外，其他key_type在建表时，value列不需要指定聚合类型。
 

--- a/docs/documentation/en/sql-reference/sql-statements/Data Definition/CREATE TABLE_EN.md
+++ b/docs/documentation/en/sql-reference/sql-statements/Data Definition/CREATE TABLE_EN.md
@@ -160,8 +160,8 @@ under the License.
             DUPLICATE KEY:
 
                     All incoming rows will be saved.
-        the default key_type is DUPLICATE KEY, and key columns are first 36 bytes of the columns in define order,
-         if the columns number of first 36 bytes is less than 3, the first 3 columns will be used.
+        the default key_type is DUPLICATE KEY, and key columns are first 36 bytes of the columns in define order.
+         If the number of columns in the first 36 is less than 3, the first 3 columns will be used.
                     
     NOTICE: 
         Except for AGGREGATE KEY, no need to specify aggregation type for value columns.

--- a/docs/documentation/en/sql-reference/sql-statements/Data Definition/CREATE TABLE_EN.md
+++ b/docs/documentation/en/sql-reference/sql-statements/Data Definition/CREATE TABLE_EN.md
@@ -160,6 +160,7 @@ under the License.
             DUPLICATE KEY:
 
                     All incoming rows will be saved.
+        the default key_type is DUPLICATE KEY, and key columns are all columns in column_definition.
                     
     NOTICE: 
         Except for AGGREGATE KEY, no need to specify aggregation type for value columns.

--- a/docs/documentation/en/sql-reference/sql-statements/Data Definition/CREATE TABLE_EN.md
+++ b/docs/documentation/en/sql-reference/sql-statements/Data Definition/CREATE TABLE_EN.md
@@ -160,7 +160,8 @@ under the License.
             DUPLICATE KEY:
 
                     All incoming rows will be saved.
-        the default key_type is DUPLICATE KEY, and key columns are all columns in column_definition.
+        the default key_type is DUPLICATE KEY, and key columns are first 36 bytes of the columns in define order,
+         if the columns number of first 36 bytes is less than 3, the first 3 columns will be used.
                     
     NOTICE: 
         Except for AGGREGATE KEY, no need to specify aggregation type for value columns.

--- a/fe/src/main/java/org/apache/doris/analysis/CreateTableStmt.java
+++ b/fe/src/main/java/org/apache/doris/analysis/CreateTableStmt.java
@@ -55,8 +55,8 @@ public class CreateTableStmt extends DdlStmt {
 
     private static final String DEFAULT_ENGINE_NAME = "olap";
 
-    private static final int MAX_DUP_KEYS_COUNT = 3;
-    private static final int MAX_DUP_KEYS_BYTES = 36;
+    private static final int DEFAULT_DUP_KEYS_COUNT = 3;
+    private static final int DEFAULT_DUP_KEYS_BYTES = 36;
 
     private boolean ifNotExists;
     private boolean isExternal;
@@ -223,7 +223,7 @@ public class CreateTableStmt extends DdlStmt {
                         if (columnDef.getAggregateType() == null) {
                             keyLength += columnDef.getType().getColumnSize() == null ? 0:
                                     columnDef.getType().getColumnSize();
-                            if (keysColumnNames.size() < MAX_DUP_KEYS_COUNT || keyLength < MAX_DUP_KEYS_BYTES) {
+                            if (keysColumnNames.size() < DEFAULT_DUP_KEYS_COUNT || keyLength < DEFAULT_DUP_KEYS_BYTES) {
                                 keysColumnNames.add(columnDef.getName());
                             }
                         }

--- a/fe/src/main/java/org/apache/doris/analysis/CreateTableStmt.java
+++ b/fe/src/main/java/org/apache/doris/analysis/CreateTableStmt.java
@@ -221,8 +221,7 @@ public class CreateTableStmt extends DdlStmt {
                     int keyLength = 0;
                     for (ColumnDef columnDef : columnDefs) {
                         if (columnDef.getAggregateType() == null) {
-                            keyLength += columnDef.getType().getColumnSize() == null ? 0:
-                                    columnDef.getType().getColumnSize();
+                            keyLength += columnDef.getType().getStorageLayoutBytes();
                             if (keysColumnNames.size() < DEFAULT_DUP_KEYS_COUNT || keyLength < DEFAULT_DUP_KEYS_BYTES) {
                                 keysColumnNames.add(columnDef.getName());
                             }

--- a/fe/src/main/java/org/apache/doris/analysis/CreateTableStmt.java
+++ b/fe/src/main/java/org/apache/doris/analysis/CreateTableStmt.java
@@ -220,7 +220,7 @@ public class CreateTableStmt extends DdlStmt {
                             keysColumnNames.add(columnDef.getName());
                         }
                     }
-                    keysDesc = new KeysDesc(KeysType.AGG_KEYS, keysColumnNames);
+                    keysDesc = new KeysDesc(KeysType.DUP_KEYS, keysColumnNames);
                 }
 
                 keysDesc.analyze(columnDefs);

--- a/fe/src/main/java/org/apache/doris/catalog/ScalarType.java
+++ b/fe/src/main/java/org/apache/doris/catalog/ScalarType.java
@@ -727,30 +727,26 @@ public class ScalarType extends Type {
     public int getStorageLayoutBytes() {
         switch (type) {
             case BOOLEAN:
-                return 0;
             case TINYINT:
                 return 1;
             case SMALLINT:
                 return 2;
             case INT:
+            case FLOAT:
                 return 4;
             case BIGINT:
             case TIME:
+            case DATETIME:
                 return 8;
             case LARGEINT:
+            case DECIMALV2:
                 return 16;
-            case FLOAT:
-                return 4;
             case DOUBLE:
                 return 12;
             case DATE:
                 return 3;
-            case DATETIME:
-                return 8;
             case DECIMAL:
                 return 40;
-            case DECIMALV2:
-                return 16;
             case CHAR:
             case VARCHAR:
                 return len;


### PR DESCRIPTION
 change default storage model from aggregate to duplicate
for sql  `create table t (k1 int) DISTRIBUTED BY HASH(k1) BUCKETS 10 PROPERTIES("replication_num" = "1");`
before: 
```
 CREATE TABLE `t` (
  `k1` int(11) NULL COMMENT ""
) ENGINE=OLAP
AGGREGATE KEY(`k1`)
COMMENT "OLAP"
DISTRIBUTED BY HASH(`k1`) BUCKETS 10
PROPERTIES (
"storage_type" = "COLUMN"
);
```
after:
```
CREATE TABLE `t` (
  `k1` int(11) NULL COMMENT ""
) ENGINE=OLAP
DUPLICATE KEY(`k1`)
COMMENT "OLAP"
DISTRIBUTED BY HASH(`k1`) BUCKETS 10
PROPERTIES (
"storage_type" = "COLUMN"
);
```

#2318