### PR TITLE
fix several races in stream load that could cause BE crash

### DIFF
--- a/be/src/http/action/mini_load.cpp
+++ b/be/src/http/action/mini_load.cpp
@@ -525,6 +525,7 @@ void MiniLoadAction::free_handler_ctx(void* param) {
         if (streaming_ctx != nullptr) {
             // sender is going, make receiver know it
             if (streaming_ctx->body_sink != nullptr) {
+                LOG(WARNING) << "cancel stream load " << streaming_ctx->id.to_string() << " because sender failed";
                 streaming_ctx->body_sink->cancel();
             }
             if (streaming_ctx->unref()) {

--- a/be/src/olap/delta_writer.h
+++ b/be/src/olap/delta_writer.h
@@ -52,6 +52,8 @@ struct WriteRequest {
     const std::vector<SlotDescriptor*>* slots;
 };
 
+// Writer for a particular (load, index, tablet).
+// This class is NOT thread-safe, external synchronization is required.
 class DeltaWriter {
 public:
     static OLAPStatus open(WriteRequest* req, MemTracker* mem_tracker, DeltaWriter** writer);
@@ -65,9 +67,12 @@ public:
     OLAPStatus write(Tuple* tuple);
     // flush the last memtable to flush queue, must call it before close_wait()
     OLAPStatus close();
-    // wait for all memtables being flushed
+    // wait for all memtables to be flushed.
+    // mem_consumption() should be 0 after this function returns.
     OLAPStatus close_wait(google::protobuf::RepeatedPtrField<PTabletInfo>* tablet_vec);
 
+    // abandon current memtable and wait for all pending-flushing memtables to be destructed.
+    // mem_consumption() should be 0 after this function returns.
     OLAPStatus cancel();
 
     // submit current memtable to flush queue, and wait all memtables in flush queue

--- a/be/src/olap/memtable.h
+++ b/be/src/olap/memtable.h
@@ -18,6 +18,8 @@
 #ifndef DORIS_BE_SRC_OLAP_MEMTABLE_H
 #define DORIS_BE_SRC_OLAP_MEMTABLE_H
 
+#include <ostream>
+
 #include "common/object_pool.h"
 #include "olap/skiplist.h"
 #include "olap/olap_define.h"
@@ -40,10 +42,8 @@ public:
              KeysType keys_type, RowsetWriter* rowset_writer, MemTracker* mem_tracker);
     ~MemTable();
 
-    int64_t tablet_id() { return _tablet_id; }
-    size_t memory_usage() {
-        return _mem_tracker->consumption();
-    }
+    int64_t tablet_id() const { return _tablet_id; }
+    size_t memory_usage() const { return _mem_tracker->consumption(); }
     void insert(const Tuple* tuple);
     OLAPStatus flush();
     OLAPStatus close();
@@ -89,6 +89,11 @@ private:
     RowsetWriter* _rowset_writer;
 
 }; // class MemTable
+
+ostream& operator<<(ostream& os, const MemTable& table) {
+    os << "MemTable(addr=" << &table << ", tablet=" << table.tablet_id() << ", mem=" << table.memory_usage();
+    return os;
+}
 
 } // namespace doris
 

--- a/be/src/olap/memtable.h
+++ b/be/src/olap/memtable.h
@@ -90,7 +90,7 @@ private:
 
 }; // class MemTable
 
-ostream& operator<<(ostream& os, const MemTable& table) {
+inline std::ostream& operator<<(std::ostream& os, const MemTable& table) {
     os << "MemTable(addr=" << &table << ", tablet=" << table.tablet_id() << ", mem=" << table.memory_usage();
     return os;
 }

--- a/be/src/olap/memtable_flush_executor.cpp
+++ b/be/src/olap/memtable_flush_executor.cpp
@@ -31,7 +31,7 @@ OLAPStatus FlushHandler::submit(std::shared_ptr<MemTable> memtable) {
     ctx.memtable = std::move(memtable);
     ctx.flush_handler = this->shared_from_this();
     _counter_cond.inc();
-    VLOG(5) << "submitting" << *(ctx.memtable) << " to flush queue " << _flush_queue_idx;
+    VLOG(5) << "submitting " << *(ctx.memtable) << " to flush queue " << _flush_queue_idx;
     RETURN_NOT_OK(_flush_executor->_push_memtable(_flush_queue_idx, ctx));
     return OLAP_SUCCESS; 
 }

--- a/be/src/olap/memtable_flush_executor.cpp
+++ b/be/src/olap/memtable_flush_executor.cpp
@@ -28,16 +28,16 @@ namespace doris {
 OLAPStatus FlushHandler::submit(std::shared_ptr<MemTable> memtable) {
     RETURN_NOT_OK(_last_flush_status.load());
     MemTableFlushContext ctx;
-    ctx.memtable = memtable;
+    ctx.memtable = std::move(memtable);
     ctx.flush_handler = this->shared_from_this();
     _counter_cond.inc();
+    VLOG(5) << "submitting" << *(ctx.memtable) << " to flush queue " << _flush_queue_idx;
     RETURN_NOT_OK(_flush_executor->_push_memtable(_flush_queue_idx, ctx));
-    return OLAP_SUCCESS;
+    return OLAP_SUCCESS; 
 }
 
 OLAPStatus FlushHandler::wait() {
-    // wait util encoutering error, or all submitted memtables are finished
-    RETURN_NOT_OK(_last_flush_status.load());
+    // wait all submitted tasks to be finished or cancelled
     _counter_cond.block_wait();
     return _last_flush_status.load();
 }
@@ -45,13 +45,11 @@ OLAPStatus FlushHandler::wait() {
 void FlushHandler::on_flush_finished(const FlushResult& res) {
     if (res.flush_status != OLAP_SUCCESS) {
         _last_flush_status.store(res.flush_status);
-        // if one failed, all other memtables no need to flush
-        _counter_cond.dec_to_zero();
     } else {
         _stats.flush_time_ns.fetch_add(res.flush_time_ns);
         _stats.flush_count.fetch_add(1);
-        _counter_cond.dec();
     }
+    _counter_cond.dec();
 }
 
 OLAPStatus MemTableFlushExecutor::create_flush_handler(
@@ -136,6 +134,7 @@ void MemTableFlushExecutor::_flush_memtable(int32_t queue_idx) {
 
         // if last flush of this tablet already failed, just skip
         if (ctx.flush_handler->is_cancelled()) {
+            VLOG(5) << "skip flushing " << *(ctx.memtable) << " due to cancellation";
             // must release memtable before notifying
             ctx.memtable.reset();
             ctx.flush_handler->on_flush_cancelled();
@@ -143,12 +142,15 @@ void MemTableFlushExecutor::_flush_memtable(int32_t queue_idx) {
         }
 
         // flush the memtable
+        VLOG(5) << "begin to flush " << *(ctx.memtable);
         FlushResult res;
         MonotonicStopWatch timer;
         timer.start();
         res.flush_status = ctx.memtable->flush();
         res.flush_time_ns = timer.elapsed_time();
         res.flush_size_bytes = ctx.memtable->memory_usage();
+        VLOG(5) << "flushed " << *(ctx.memtable) << " in " << res.flush_time_ns / 1000 / 1000
+                << " ms, status=" << res.flush_status;
         // must release memtable before notifying
         ctx.memtable.reset();
         // callback

--- a/be/src/olap/memtable_flush_executor.h
+++ b/be/src/olap/memtable_flush_executor.h
@@ -91,8 +91,7 @@ public:
     void on_flush_finished(const FlushResult& res);
     // called when a flush memtable execution is cancelled
     void on_flush_cancelled() {
-        // for now, if one memtable cancelled, no more memtables will be flushed, so dec to zero.
-        _counter_cond.dec_to_zero();
+        _counter_cond.dec();
     }
 
     bool is_cancelled() { return _last_flush_status.load() != OLAP_SUCCESS || _is_cancelled.load(); }

--- a/be/src/runtime/load_channel.cpp
+++ b/be/src/runtime/load_channel.cpp
@@ -113,8 +113,12 @@ void LoadChannel::handle_mem_exceed_limit(bool force) {
         return;
     }
 
-    VLOG(1) << "mem consumption: " << _mem_tracker->consumption()
-        << " may exceed limit. force: " << force << ", load id: " << _load_id;
+    if (!force) {
+        LOG(INFO) << "reducing memory of " << *this
+                  << " because its mem consumption " << _mem_tracker->consumption()
+                  << " has exceeded limit " << _mem_tracker->limit();
+    }
+
     std::shared_ptr<TabletsChannel> channel;
     if (_find_largest_max_consumption_tablets_channel(&channel)) {
         channel->reduce_mem_usage();

--- a/be/src/runtime/load_channel.h
+++ b/be/src/runtime/load_channel.h
@@ -19,6 +19,7 @@
 
 #include <unordered_map>
 #include <mutex>
+#include <ostream>
 
 #include "common/status.h"
 #include "gen_cpp/Types_types.h"
@@ -92,5 +93,12 @@ private:
     // if channel is timeout, it will be removed by load channel manager.
     int64_t _timeout_s;
 };
+
+inline std::ostream& operator<<(std::ostream& os, const LoadChannel& load_channel) {
+    os << "LoadChannel(id=" << load_channel.load_id()
+       << ", mem=" << load_channel.mem_consumption()
+       << ", last_update_time=" << static_cast<uint64_t>(load_channel.last_updated_time()) << ")";
+    return os;
+}
 
 }

--- a/be/src/runtime/load_channel_mgr.cpp
+++ b/be/src/runtime/load_channel_mgr.cpp
@@ -143,7 +143,7 @@ Status LoadChannelMgr::add_batch(
                 load_id.to_string(), nullptr, 1, dummy_deleter);
             _lastest_success_channel->release(handle);
         }
-        LOG(INFO) << "removed load channel " << load_id;
+        VLOG(1) << "removed load channel " << load_id;
     }
     return Status::OK();
 }
@@ -218,16 +218,15 @@ Status LoadChannelMgr::_start_bg_worker() {
 
 Status LoadChannelMgr::_start_load_channels_clean() {
     std::vector<std::shared_ptr<LoadChannel>> need_delete_channels;
-    const int32_t max_alive_time = config::streaming_load_rpc_max_alive_time_sec;
-    LOG(INFO) << "start cleaning load channel which is not active for more than " << max_alive_time << " seconds";
+    LOG(INFO) << "start cleaning load channels that have timed out";
     time_t now = time(nullptr);
     {
         std::vector<UniqueId> need_delete_channel_ids;
         std::lock_guard<std::mutex> l(_lock);
-        LOG(INFO) << "there are " << _load_channels.size() << " running load channels";
+        VLOG(1) << "there are " << _load_channels.size() << " running load channels";
         int i = 0;
         for (auto& kv : _load_channels) {
-            LOG(INFO) << "load channel[" << i++ << "]: " << *(kv.second);
+            VLOG(1) << "load channel[" << i++ << "]: " << *(kv.second);
             time_t last_updated_time = kv.second->last_updated_time();
             if (difftime(now, last_updated_time) >= kv.second->timeout()) {
                 need_delete_channel_ids.emplace_back(kv.first);

--- a/be/src/runtime/mem_tracker.cpp
+++ b/be/src/runtime/mem_tracker.cpp
@@ -184,6 +184,14 @@ MemTracker* MemTracker::CreateQueryMemTracker(const TUniqueId& id,
 }
 
 MemTracker::~MemTracker() {
+    int64_t remaining_bytes = consumption();
+    // work around some scenario where consume() is not paired with release()
+    // e.g., in the initialization of hll and bitmap aggregator (see aggregate_func.h)
+    if (remaining_bytes > 0) {
+        for (auto tracker : _all_trackers) {
+            tracker->_consumption->add(-remaining_bytes);
+        }
+    }
     delete _reservation_counters.load();
 }
 

--- a/be/src/runtime/mem_tracker.cpp
+++ b/be/src/runtime/mem_tracker.cpp
@@ -187,6 +187,8 @@ MemTracker::~MemTracker() {
     int64_t remaining_bytes = consumption();
     // work around some scenario where consume() is not paired with release()
     // e.g., in the initialization of hll and bitmap aggregator (see aggregate_func.h)
+    // TODO(gaodayue) should be replaced with `DCHECK_EQ(consumption(), 0);` when
+    // we fixed thoses invalid usages
     if (remaining_bytes > 0) {
         for (auto tracker : _all_trackers) {
             tracker->_consumption->add(-remaining_bytes);

--- a/be/src/runtime/tablets_channel.h
+++ b/be/src/runtime/tablets_channel.h
@@ -88,6 +88,13 @@ private:
     // make execute sequece
     std::mutex _lock;
 
+    enum State {
+        kInitialized,
+        kOpened,
+        kFinished // closed or cancelled
+    };
+    State _state;
+
     // initialized in open function
     int64_t _txn_id = -1;
     int64_t _index_id = -1;
@@ -95,7 +102,6 @@ private:
     TupleDescriptor* _tuple_desc = nullptr;
     // row_desc used to construct
     RowDescriptor* _row_desc = nullptr;
-    bool _opened = false;
 
     // next sequence we expect
     int _num_remaining_senders = 0;

--- a/be/src/util/counter_cond_variable.hpp
+++ b/be/src/util/counter_cond_variable.hpp
@@ -42,9 +42,6 @@ namespace doris {
 //          cond.dec();
 //          ... do work...
 //          cond.dec();
-//          or
-//          ... failed ...
-//          cond.dec_to_zero();
 //
 //      thread3(waiter):    
 //          cond.block_wait();            
@@ -60,18 +57,13 @@ public:
         _count += inc;
     }
 
-    // decrease the counter, and notify all waiters
+    // decrease the counter, and notify all waiters when counter <= 0
     void dec(int dec = 1) {
         std::unique_lock<std::mutex> lock(_lock);
         _count -= dec;
-        _cv.notify_all();
-    }
-
-    // decrease the counter to zero
-    void dec_to_zero() {
-        std::unique_lock<std::mutex> lock(_lock);
-        _count = 0;
-        _cv.notify_all();
+        if (_count <= 0) {
+            _cv.notify_all();
+        }
     }
 
     // wait until count down to zero

--- a/be/test/util/counter_cond_variable_test.cpp
+++ b/be/test/util/counter_cond_variable_test.cpp
@@ -64,17 +64,13 @@ TEST_F(CounterCondVariableTest, test) {
     std::thread submit(submitter);
     std::thread wait1(waiter);
     std::thread wait2(waiter);
-    std::thread work1(worker);
-    std::thread work2(worker);
+    std::thread work(worker);
 
     submit.join();
     wait1.join();
     wait2.join();
-    work1.join();
-    work2.join();
+    work.join();
 
-    g_cond.inc(10);
-    g_cond.dec_to_zero();
     g_cond.block_wait();
 }
 


### PR DESCRIPTION
Fixes #2413 and #1984 

This CL fixes the following problems
1. check whether TabletsChannel has been closed/cancelled in `reduce_mem_usage` to avoid using a closed DeltaWriter
2. make `FlushHandle.wait` wait for all submitted tasks to finish so that memtable is deallocated before its delta writer
3. make `~MemTracker()` release its consumption bytes to accommodate situations in aggregate_func.h that bitmap and hll call `MemTracker::consume` without corresponding `MemTracker::release`, which cause the consumption of root tracker never drops to zero

Besides I also add various verbose logging that helps me locate these concurrency bugs and hopefully would be helpful for others.
