### PR TITLE
Add copy_object() method for HLL and Bitmap columns when loading

### DIFF
--- a/be/src/olap/field.h
+++ b/be/src/olap/field.h
@@ -144,7 +144,7 @@ public:
 
     // Used to compare short key index. Because short key will truncate
     // a varchar column, this function will handle in this condition.
-    template<typename LhsCellType, typename RhsCellType> 
+    template<typename LhsCellType, typename RhsCellType>
     inline int index_cmp(const LhsCellType& lhs, const RhsCellType& rhs) const;
 
     // Copy source cell's content to destination cell directly.
@@ -159,6 +159,19 @@ public:
             return;
         }
         return _type_info->direct_copy(dst->mutable_cell_ptr(), src.cell_ptr());
+    }
+
+    // deep copy source cell' content to destination cell.
+    // For string type, this will allocate data form pool,
+    // and copy srouce's conetent.
+    template<typename DstCellType, typename SrcCellType>
+    void copy_object(DstCellType* dst, const SrcCellType& src, MemPool* pool) const {
+        bool is_null = src.is_null();
+        dst->set_is_null(is_null);
+        if (is_null) {
+            return;
+        }
+        _type_info->copy_object(dst->mutable_cell_ptr(), src.cell_ptr(), pool);
     }
 
     // deep copy source cell' content to destination cell.
@@ -238,7 +251,7 @@ public:
     void full_encode_ascending(const void* value, std::string* buf) const {
         _key_coder->full_encode_ascending(value, buf);
     }
-    
+
     Status decode_ascending(Slice* encoded_key, uint8_t* cell_ptr, MemPool* pool) const {
         return _key_coder->decode_ascending(encoded_key, _index_size, cell_ptr, pool);
     }

--- a/be/src/olap/memtable.cpp
+++ b/be/src/olap/memtable.cpp
@@ -87,7 +87,7 @@ void MemTable::insert(const Tuple* tuple) {
     } else {
         _tuple_buf = _table_mem_pool->allocate(_schema_size);
         ContiguousRow dst_row(_schema, _tuple_buf);
-        copy_row(&dst_row, src_row, _table_mem_pool.get());
+        copy_row_in_memtable(&dst_row, src_row, _table_mem_pool.get());
         _skip_list->InsertWithHint((TableKey)_tuple_buf, is_exist, &_hint);
     }
 

--- a/be/src/olap/row.h
+++ b/be/src/olap/row.h
@@ -134,6 +134,19 @@ void copy_row(DstRowType* dst, const SrcRowType& src, MemPool* pool) {
     }
 }
 
+// NOTE: only use in MemTable for now, it is same with copy_row(), but for HLL and Object type,
+// its content is in Slice->data, other than a normal Slice, so we just assign the Slice->data
+// pointer, instead of memcpy the data.
+// TODO(lingbin): remove this method
+template<typename DstRowType, typename SrcRowType>
+void copy_row_in_memtable(DstRowType* dst, const SrcRowType& src, MemPool* pool) {
+    for (auto cid : dst->schema()->column_ids()) {
+        auto dst_cell = dst->cell(cid);
+        auto src_cell = src.cell(cid);
+        dst->schema()->column(cid)->copy_object(&dst_cell, src_cell, pool);
+    }
+}
+
 template<typename DstRowType, typename SrcRowType>
 void agg_update_row(DstRowType* dst, const SrcRowType& src, MemPool* mem_pool) {
     for (uint32_t cid = dst->schema()->num_key_columns(); cid < dst->schema()->num_columns(); ++cid) {

--- a/be/src/olap/types.cpp
+++ b/be/src/olap/types.cpp
@@ -27,6 +27,7 @@ TypeInfo::TypeInfo(TypeTraitsClass t)
         _cmp(TypeTraitsClass::cmp),
         _shallow_copy(TypeTraitsClass::shallow_copy),
         _deep_copy(TypeTraitsClass::deep_copy),
+        _copy_object(TypeTraitsClass::copy_object),
         _direct_copy(TypeTraitsClass::direct_copy),
         _convert_from(TypeTraitsClass::convert_from),
         _from_string(TypeTraitsClass::from_string),

--- a/be/src/olap/types.h
+++ b/be/src/olap/types.h
@@ -56,6 +56,12 @@ public:
         _deep_copy(dest, src, mem_pool);
     }
 
+    // See copy_row_in_memtable() in olap/row.h, will be removed in future.
+    // It is same with deep_copy() for all type except for HLL and OBJECT type
+    inline void copy_object(void* dest, const void* src, MemPool* mem_pool) const {
+        _copy_object(dest, src, mem_pool);
+    }
+
     inline void direct_copy(void* dest, const void* src) const {
         _direct_copy(dest, src);
     }
@@ -84,6 +90,7 @@ private:
 
     void (*_shallow_copy)(void* dest, const void* src);
     void (*_deep_copy)(void* dest, const void* src, MemPool* mem_pool);
+    void (*_copy_object)(void* dest, const void* src, MemPool* mem_pool);
     void (*_direct_copy)(void* dest, const void* src);
     OLAPStatus (*_convert_from)(void* dest, const void* src, const TypeInfo* src_type, MemPool* mem_pool);
 
@@ -194,6 +201,10 @@ struct BaseFieldtypeTraits : public CppTypeTraits<field_type> {
     }
 
     static inline void deep_copy(void* dest, const void* src, MemPool* mem_pool) {
+        *reinterpret_cast<CppType*>(dest) = *reinterpret_cast<const CppType*>(src);
+    }
+
+    static inline void copy_object(void* dest, const void* src, MemPool* mem_pool) {
         *reinterpret_cast<CppType*>(dest) = *reinterpret_cast<const CppType*>(src);
     }
 
@@ -317,7 +328,7 @@ struct FieldTypeTraits<OLAP_FIELD_TYPE_LARGEINT> : public BaseFieldtypeTraits<OL
             }
 
             // the max value of uint64_t is 18446744073709551615UL,
-            // so use Z19_UINT64 to divide uint128_t 
+            // so use Z19_UINT64 to divide uint128_t
             const static uint64_t Z19_UINT64 = 10000000000000000000ULL;
             uint64_t suffix = abs_value % Z19_UINT64;
             uint64_t middle = abs_value / Z19_UINT64 % Z19_UINT64;
@@ -345,6 +356,10 @@ struct FieldTypeTraits<OLAP_FIELD_TYPE_LARGEINT> : public BaseFieldtypeTraits<OL
         *reinterpret_cast<PackedInt128*>(dest) = *reinterpret_cast<const PackedInt128*>(src);
     }
     static void deep_copy(void* dest, const void* src, MemPool* mem_pool) {
+        *reinterpret_cast<PackedInt128*>(dest) = *reinterpret_cast<const PackedInt128*>(src);
+    }
+
+    static void copy_object(void* dest, const void* src, MemPool* mem_pool) {
         *reinterpret_cast<PackedInt128*>(dest) = *reinterpret_cast<const PackedInt128*>(src);
     }
     static void direct_copy(void* dest, const void* src) {
@@ -390,8 +405,8 @@ struct FieldTypeTraits<OLAP_FIELD_TYPE_DOUBLE> : public BaseFieldtypeTraits<OLAP
         if (src_type->type() == OLAP_FIELD_TYPE_FLOAT) {
             using SrcType = typename CppTypeTraits<OLAP_FIELD_TYPE_FLOAT>::CppType;
             //http://www.softelectro.ru/ieee754_en.html
-            //According to the definition of IEEE754, the effect of converting a float binary to a double binary 
-            //is the same as that of static_cast . Data precision cannot be guaranteed, but the progress of 
+            //According to the definition of IEEE754, the effect of converting a float binary to a double binary
+            //is the same as that of static_cast . Data precision cannot be guaranteed, but the progress of
             //decimal system can be guaranteed by converting a float to a char buffer and then to a double.
             //float v2 = static_cast<double>(v1),
             //float 0.3000000 is: 0 | 01111101 | 00110011001100110011010
@@ -403,7 +418,7 @@ struct FieldTypeTraits<OLAP_FIELD_TYPE_DOUBLE> : public BaseFieldtypeTraits<OLAP
             snprintf(buf, 64, "%f", *reinterpret_cast<const SrcType*>(src));
             char* tg;
             *reinterpret_cast<CppType*>(dest) = strtod(buf,&tg);
-            return OLAPStatus::OLAP_SUCCESS;    
+            return OLAPStatus::OLAP_SUCCESS;
         }
         return OLAPStatus::OLAP_ERR_INVALID_SCHEMA;
     }
@@ -470,7 +485,7 @@ struct FieldTypeTraits<OLAP_FIELD_TYPE_DATE> : public BaseFieldtypeTraits<OLAP_F
             CppType mon = static_cast<CppType>((part1 / 100) % 100);
             CppType mday = static_cast<CppType>(part1 % 100);
             *reinterpret_cast<CppType*>(dest) = (year << 9) + (mon << 5) + mday;
-            return OLAPStatus::OLAP_SUCCESS;    
+            return OLAPStatus::OLAP_SUCCESS;
         }
 
         if (src_type->type() == FieldType::OLAP_FIELD_TYPE_INT) {
@@ -487,7 +502,7 @@ struct FieldTypeTraits<OLAP_FIELD_TYPE_DATE> : public BaseFieldtypeTraits<OLAP_F
             return OLAPStatus::OLAP_SUCCESS;
         }
 
-        return OLAPStatus::OLAP_ERR_INVALID_SCHEMA;    
+        return OLAPStatus::OLAP_ERR_INVALID_SCHEMA;
     }
     static void set_to_max(void* buf) {
         // max is 9999 * 16 * 32 + 12 * 32 + 31;
@@ -606,6 +621,11 @@ struct FieldTypeTraits<OLAP_FIELD_TYPE_CHAR> : public BaseFieldtypeTraits<OLAP_F
         memory_copy(l_slice->data, r_slice->data, r_slice->size);
         l_slice->size = r_slice->size;
     }
+
+    static void copy_object(void* dest, const void* src, MemPool* mem_pool) {
+        deep_copy(dest, src, mem_pool);
+    }
+
     static void direct_copy(void* dest, const void* src) {
         auto l_slice = reinterpret_cast<Slice*>(dest);
         auto r_slice = reinterpret_cast<const Slice*>(src);
@@ -655,6 +675,15 @@ struct FieldTypeTraits<OLAP_FIELD_TYPE_HLL> : public FieldTypeTraits<OLAP_FIELD_
      * cmp/from_string/set_to_max/set_to_min function
      * in this struct has no significance
      */
+
+    // See copy_row_in_memtable() in olap/row.h, will be removed in future.
+    static void copy_object(void* dest, const void* src, MemPool* mem_pool) {
+        auto dst_slice = reinterpret_cast<Slice*>(dest);
+        auto src_slice = reinterpret_cast<const Slice*>(src);
+        DCHECK_EQ(src_slice->size, 0);
+        dst_slice->data = src_slice->data;
+        dst_slice->size = 0;
+    }
 };
 
 template<>
@@ -664,6 +693,15 @@ struct FieldTypeTraits<OLAP_FIELD_TYPE_OBJECT> : public FieldTypeTraits<OLAP_FIE
      * cmp/from_string/set_to_max/set_to_min function
      * in this struct has no significance
      */
+
+    // See copy_row_in_memtable() in olap/row.h, will be removed in future.
+    static void copy_object(void* dest, const void* src, MemPool* mem_pool) {
+        auto dst_slice = reinterpret_cast<Slice*>(dest);
+        auto src_slice = reinterpret_cast<const Slice*>(src);
+        DCHECK_EQ(src_slice->size, 0);
+        dst_slice->data = src_slice->data;
+        dst_slice->size = 0;
+    }
 };
 
 // Instantiate this template to get static access to the type traits.


### PR DESCRIPTION
#2341 

Currently, special treatment is used for HLL types (and OBJECT types).
When loading data, because there is no need to serialize HLL content
(the upper layer has already done), we directly save the pointer
of `HyperLogLog` object in `Slice->data` (at the corresponding `Cell`
in each `Row`) and make `Slice->size` to be 0. This logic is different
from when reading the HLL column.  When reading, we need to deserialize
the HLL object from the `Slice` object. This causes us to have different
implementations of `copy_row()` when loading and reading.

In the optimization(commit: 177fec8917304e399aa7f3facc4cc4804e72ce8b),
the logic of `copy_row()` was added before a row can be added into the
`MemTable`, but the current `copy_row()` treats the `HLL column Cell`
as a normal Slice object(i.e. will memcpy its data according its size).

So this change adds a `copy_object()` method to `TypeInfo`, which is
used to copy the HLL column during loading data.

Note: The `row-copy` method should be unified in the future. At that
time, we can delete the `copy_object()` method.