### PR TITLE
[Tag System] Forbid cluster related operations

### DIFF
--- a/fe/src/main/java/org/apache/doris/alter/Alter.java
+++ b/fe/src/main/java/org/apache/doris/alter/Alter.java
@@ -223,7 +223,7 @@ public class Alter {
         }
     }
 
-    public void processAlterCluster(AlterSystemStmt stmt) throws DdlException {
+    public void processAlterCluster(AlterSystemStmt stmt) throws UserException {
         clusterHandler.process(Arrays.asList(stmt.getAlterClause()), stmt.getClusterName(), null, null);
     }
 

--- a/fe/src/main/java/org/apache/doris/analysis/AlterClusterClause.java
+++ b/fe/src/main/java/org/apache/doris/analysis/AlterClusterClause.java
@@ -18,6 +18,7 @@
 package org.apache.doris.analysis;
 
 import org.apache.doris.common.AnalysisException;
+import org.apache.doris.common.Config;
 import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.ErrorReport;
 
@@ -38,6 +39,9 @@ public class AlterClusterClause extends AlterClause {
 
     @Override
     public void analyze(Analyzer analyzer) throws AnalysisException {
+        if (Config.disable_cluster_feature) {
+            ErrorReport.reportAnalysisException(ErrorCode.ERR_INVALID_OPERATION, "ALTER CLUSTER");
+        }
 
         if (properties == null || properties.size() == 0) {
             ErrorReport.reportAnalysisException(ErrorCode.ERR_CLUSTER_NO_PARAMETER);

--- a/fe/src/main/java/org/apache/doris/analysis/AlterClusterClause.java
+++ b/fe/src/main/java/org/apache/doris/analysis/AlterClusterClause.java
@@ -24,6 +24,7 @@ import org.apache.doris.common.ErrorReport;
 
 import java.util.Map;
 
+@Deprecated
 public class AlterClusterClause extends AlterClause {
     private AlterClusterType type;
     private Map<String, String> properties;

--- a/fe/src/main/java/org/apache/doris/analysis/AlterClusterStmt.java
+++ b/fe/src/main/java/org/apache/doris/analysis/AlterClusterStmt.java
@@ -19,6 +19,7 @@ package org.apache.doris.analysis;
 
 import org.apache.doris.catalog.Catalog;
 import org.apache.doris.common.AnalysisException;
+import org.apache.doris.common.Config;
 import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.ErrorReport;
 import org.apache.doris.mysql.privilege.PrivPredicate;
@@ -26,6 +27,7 @@ import org.apache.doris.qe.ConnectContext;
 
 import java.util.Map;
 
+@Deprecated
 public class AlterClusterStmt extends DdlStmt {
 
     private Map<String, String> properties;
@@ -40,6 +42,10 @@ public class AlterClusterStmt extends DdlStmt {
 
     @Override
     public void analyze(Analyzer analyzer) throws AnalysisException {
+        if (Config.disable_cluster_feature) {
+            ErrorReport.reportAnalysisException(ErrorCode.ERR_INVALID_OPERATION, "ALTER CLUSTER");
+        }
+
         if (!Catalog.getCurrentCatalog().getAuth().checkGlobalPriv(ConnectContext.get(), PrivPredicate.OPERATOR)) {
             ErrorReport.reportAnalysisException(ErrorCode.ERR_CLUSTER_NO_AUTHORITY, "NODE");
         }

--- a/fe/src/main/java/org/apache/doris/analysis/CreateClusterStmt.java
+++ b/fe/src/main/java/org/apache/doris/analysis/CreateClusterStmt.java
@@ -18,7 +18,7 @@
 package org.apache.doris.analysis;
 
 import org.apache.doris.catalog.Catalog;
-import org.apache.doris.common.AnalysisException;
+import org.apache.doris.common.Config;
 import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.ErrorReport;
 import org.apache.doris.common.FeNameFormat;
@@ -31,6 +31,7 @@ import com.google.common.base.Strings;
 
 import java.util.Map;
 
+@Deprecated
 public class CreateClusterStmt extends DdlStmt {
     public static String CLUSTER_INSTANCE_NUM = "instance_num";
     public static String CLUSTER_SUPERMAN_PASSWORD = "password";
@@ -66,7 +67,10 @@ public class CreateClusterStmt extends DdlStmt {
     }
 
     @Override
-    public void analyze(Analyzer analyzer) throws AnalysisException, UserException {
+    public void analyze(Analyzer analyzer) throws UserException {
+        if (Config.disable_cluster_feature) {
+            ErrorReport.reportAnalysisException(ErrorCode.ERR_INVALID_OPERATION, "CREATE CLUSTER");
+        }
         FeNameFormat.checkDbName(clusterName);
         if (!Catalog.getCurrentCatalog().getAuth().checkGlobalPriv(ConnectContext.get(), PrivPredicate.OPERATOR)) {
             ErrorReport.reportAnalysisException(ErrorCode.ERR_CLUSTER_NO_AUTHORITY, analyzer.getQualifiedUser());

--- a/fe/src/main/java/org/apache/doris/analysis/DropClusterStmt.java
+++ b/fe/src/main/java/org/apache/doris/analysis/DropClusterStmt.java
@@ -19,6 +19,7 @@ package org.apache.doris.analysis;
 
 import org.apache.doris.catalog.Catalog;
 import org.apache.doris.common.AnalysisException;
+import org.apache.doris.common.Config;
 import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.ErrorReport;
 import org.apache.doris.common.UserException;
@@ -28,6 +29,7 @@ import org.apache.doris.system.SystemInfoService;
 
 import com.google.common.base.Strings;
 
+@Deprecated
 public class DropClusterStmt extends DdlStmt {
     private boolean ifExists;
     private String name;
@@ -39,6 +41,10 @@ public class DropClusterStmt extends DdlStmt {
 
     @Override
     public void analyze(Analyzer analyzer) throws AnalysisException, UserException {
+        if (Config.disable_cluster_feature) {
+            ErrorReport.reportAnalysisException(ErrorCode.ERR_INVALID_OPERATION, "DROP CLUSTER");
+        }
+
         if (Strings.isNullOrEmpty(name)) {
             ErrorReport.reportAnalysisException(ErrorCode.ERR_CLUSTER_NAME_NULL);
         }

--- a/fe/src/main/java/org/apache/doris/analysis/LinkDbStmt.java
+++ b/fe/src/main/java/org/apache/doris/analysis/LinkDbStmt.java
@@ -20,6 +20,7 @@ package org.apache.doris.analysis;
 import org.apache.doris.catalog.Catalog;
 import org.apache.doris.cluster.ClusterNamespace;
 import org.apache.doris.common.AnalysisException;
+import org.apache.doris.common.Config;
 import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.ErrorReport;
 import org.apache.doris.common.UserException;
@@ -28,6 +29,7 @@ import org.apache.doris.qe.ConnectContext;
 
 import com.google.common.base.Strings;
 
+@Deprecated
 public class LinkDbStmt extends DdlStmt {
 
     private ClusterName src;
@@ -60,6 +62,10 @@ public class LinkDbStmt extends DdlStmt {
 
     @Override
     public void analyze(Analyzer analyzer) throws AnalysisException, UserException {
+        if (Config.disable_cluster_feature) {
+            ErrorReport.reportAnalysisException(ErrorCode.ERR_INVALID_OPERATION, "LINK DATABASE");
+        }
+
         src.analyze(analyzer);
         dest.analyze(analyzer);
 

--- a/fe/src/main/java/org/apache/doris/analysis/MigrateDbStmt.java
+++ b/fe/src/main/java/org/apache/doris/analysis/MigrateDbStmt.java
@@ -20,12 +20,14 @@ package org.apache.doris.analysis;
 import org.apache.doris.catalog.Catalog;
 import org.apache.doris.cluster.ClusterNamespace;
 import org.apache.doris.common.AnalysisException;
+import org.apache.doris.common.Config;
 import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.ErrorReport;
 import org.apache.doris.common.UserException;
 import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.qe.ConnectContext;
 
+@Deprecated
 public class MigrateDbStmt extends DdlStmt {
 
     private ClusterName src;
@@ -58,6 +60,10 @@ public class MigrateDbStmt extends DdlStmt {
 
     @Override
     public void analyze(Analyzer analyzer) throws AnalysisException, UserException {
+        if (Config.disable_cluster_feature) {
+            ErrorReport.reportAnalysisException(ErrorCode.ERR_INVALID_OPERATION, "MIGRATION CLUSTER");
+        }
+
         src.analyze(analyzer);
         dest.analyze(analyzer);
 

--- a/fe/src/main/java/org/apache/doris/catalog/Catalog.java
+++ b/fe/src/main/java/org/apache/doris/catalog/Catalog.java
@@ -5328,7 +5328,7 @@ public class Catalog {
      * @param stmt
      * @throws DdlException
      */
-    public void processModifyCluster(AlterClusterStmt stmt) throws DdlException {
+    public void processModifyCluster(AlterClusterStmt stmt) throws UserException {
         final String clusterName = stmt.getAlterClusterName();
         final int newInstanceNum = stmt.getInstanceNum();
         if (!tryLock(false)) {

--- a/fe/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/src/main/java/org/apache/doris/common/Config.java
@@ -934,5 +934,16 @@ public class Config extends ConfigBase {
      */
     @ConfField(mutable = true, masterOnly = true)
     public static boolean force_do_metadata_checkpoint = false;
+
+    /*
+     * The multi cluster feature will be deprecated in version 0.12
+     * set this config to true will disable all operations related to cluster feature, include:
+     *   create/drop cluster
+     *   add free backend/add backend to cluster/decommission cluster balance
+     *   change the backends num of cluster
+     *   link/migration db
+     */
+    @ConfField(mutable = true)
+    public static boolean disable_cluster_feature = true;
 }
 

--- a/fe/src/main/java/org/apache/doris/common/ErrorCode.java
+++ b/fe/src/main/java/org/apache/doris/common/ErrorCode.java
@@ -213,7 +213,8 @@ public enum ErrorCode {
     ERR_COLOCATE_TABLE_MUST_HAS_SAME_DISTRIBUTION_COLUMN_TYPE(5063, new byte[] { '4', '2', '0', '0', '0' },
             "Colocate tables distribution columns must have the same data type: %s should be %s"), 
     ERR_COLOCATE_NOT_COLOCATE_TABLE(5064, new byte[] { '4', '2', '0', '0', '0' },
-            "Table %s is not a colocated table"),;
+            "Table %s is not a colocated table"),
+    ERR_INVALID_OPERATION(5065, new byte[] { '4', '2', '0', '0', '0' }, "Operation %s is invalid");
 
     ErrorCode(int code, byte[] sqlState, String errorMsg) {
         this.code = code;

--- a/fe/src/test/java/org/apache/doris/analysis/AlterClusterStmtTest.java
+++ b/fe/src/test/java/org/apache/doris/analysis/AlterClusterStmtTest.java
@@ -18,6 +18,7 @@
 package org.apache.doris.analysis;
 
 import org.apache.doris.common.AnalysisException;
+import org.apache.doris.common.Config;
 import org.apache.doris.common.UserException;
 import org.apache.doris.mysql.privilege.MockedAuth;
 import org.apache.doris.mysql.privilege.PaloAuth;
@@ -48,6 +49,7 @@ public class AlterClusterStmtTest {
 
     @Before()
     public void setUp() {
+        Config.disable_cluster_feature = false;
         analyzer = AccessTestUtil.fetchAdminAnalyzer(true);
         MockedAuth.mockedAuth(auth);
         MockedAuth.mockedConnectContext(ctx, "root", "192.168.1.1");

--- a/fe/src/test/java/org/apache/doris/analysis/CreateClusterStmtTest.java
+++ b/fe/src/test/java/org/apache/doris/analysis/CreateClusterStmtTest.java
@@ -18,6 +18,7 @@
 package org.apache.doris.analysis;
 
 import org.apache.doris.common.AnalysisException;
+import org.apache.doris.common.Config;
 import org.apache.doris.common.UserException;
 import org.apache.doris.mysql.privilege.MockedAuth;
 import org.apache.doris.mysql.privilege.PaloAuth;
@@ -47,6 +48,7 @@ public class CreateClusterStmtTest {
 
     @Before()
     public void setUp() {
+        Config.disable_cluster_feature = false;
         analyzer = AccessTestUtil.fetchAdminAnalyzer(true);
         MockedAuth.mockedAuth(auth);
         MockedAuth.mockedConnectContext(ctx, "root", "192.168.1.1");

--- a/fe/src/test/java/org/apache/doris/analysis/DropClusterStmtTest.java
+++ b/fe/src/test/java/org/apache/doris/analysis/DropClusterStmtTest.java
@@ -18,6 +18,7 @@
 package org.apache.doris.analysis;
 
 import org.apache.doris.common.AnalysisException;
+import org.apache.doris.common.Config;
 import org.apache.doris.common.UserException;
 import org.apache.doris.mysql.privilege.PaloAuth;
 import org.apache.doris.mysql.privilege.PrivPredicate;
@@ -44,6 +45,7 @@ public class DropClusterStmtTest {
 
     @Before
     public void setUp() {
+        Config.disable_cluster_feature = false;
         analyzer = AccessTestUtil.fetchAdminAnalyzer(true);
 
         new NonStrictExpectations() {

--- a/fe/src/test/java/org/apache/doris/analysis/LinkDbStmtTest.java
+++ b/fe/src/test/java/org/apache/doris/analysis/LinkDbStmtTest.java
@@ -18,6 +18,7 @@
 package org.apache.doris.analysis;
 
 import org.apache.doris.common.AnalysisException;
+import org.apache.doris.common.Config;
 import org.apache.doris.common.UserException;
 import org.apache.doris.mysql.privilege.MockedAuth;
 import org.apache.doris.mysql.privilege.PaloAuth;
@@ -45,6 +46,7 @@ public class LinkDbStmtTest {
 
     @Before
     public void setUp() {
+        Config.disable_cluster_feature = false;
         analyzer = AccessTestUtil.fetchAdminAnalyzer(true);
         MockedAuth.mockedAuth(auth);
         MockedAuth.mockedConnectContext(ctx, "root", "192.168.1.1");

--- a/fe/src/test/java/org/apache/doris/analysis/MigrateDbStmtTest.java
+++ b/fe/src/test/java/org/apache/doris/analysis/MigrateDbStmtTest.java
@@ -18,6 +18,7 @@
 package org.apache.doris.analysis;
 
 import org.apache.doris.common.AnalysisException;
+import org.apache.doris.common.Config;
 import org.apache.doris.common.UserException;
 import org.apache.doris.mysql.privilege.MockedAuth;
 import org.apache.doris.mysql.privilege.PaloAuth;
@@ -45,6 +46,7 @@ public class MigrateDbStmtTest {
 
     @Before
     public void setUp() {
+        Config.disable_cluster_feature = false;
         analyzer = AccessTestUtil.fetchAdminAnalyzer(true);
         MockedAuth.mockedAuth(auth);
         MockedAuth.mockedConnectContext(ctx, "root", "192.168.1.1");


### PR DESCRIPTION
The multi cluster feature will be deprecated soon.
Add a FE config "disable_cluster_feature", and default is true, to
forbid any cluster related operations, include:

    * create/drop cluster
    * add free backend/add backend to cluster/decommission cluster balance
    * change the backends num of cluster
    * link/migration db

ISSUE: #1723 