### PR TITLE
Fix BE do_tablet_meta_checkpoint retain _meta_lock for a long time

### DIFF
--- a/be/src/olap/rowset/rowset_meta.h
+++ b/be/src/olap/rowset/rowset_meta.h
@@ -296,6 +296,19 @@ public:
         return  has_version() && _rowset_meta_pb.start_version() == _rowset_meta_pb.end_version();
     }
 
+    // Some time, we may check if this rowset is in rowset meta manager's meta by using RowsetMetaManager::check_rowset_meta.
+    // But, this check behavior may cost a lot of time when it is frequent.
+    // If we explicitly remove this rowset from rowset meta manager's meta, we can set _is_removed_from_rowset_meta to true,
+    // And next time when we want to check if this rowset is in rowset mata manager's meta, we can
+    // check is_remove_from_rowset_meta() first.
+    void set_remove_from_rowset_meta() {
+        _is_removed_from_rowset_meta = true;
+    }
+
+    bool is_remove_from_rowset_meta() {
+        return _is_removed_from_rowset_meta;
+    }
+
 private:
     friend class AlphaRowsetMeta;
     bool _deserialize_from_pb(const std::string& value) {
@@ -332,6 +345,7 @@ private:
 private:
     RowsetMetaPB _rowset_meta_pb;
     RowsetId _rowset_id;
+    bool _is_removed_from_rowset_meta = false;
 };
 
 } // namespace doris

--- a/be/src/olap/rowset/rowset_meta.h
+++ b/be/src/olap/rowset/rowset_meta.h
@@ -305,7 +305,7 @@ public:
         _is_removed_from_rowset_meta = true;
     }
 
-    bool is_remove_from_rowset_meta() {
+    bool is_remove_from_rowset_meta() const {
         return _is_removed_from_rowset_meta;
     }
 

--- a/be/src/olap/storage_engine.cpp
+++ b/be/src/olap/storage_engine.cpp
@@ -1021,7 +1021,7 @@ void* StorageEngine::_tablet_checkpoint_callback(void* arg) {
 #endif
     LOG(INFO) << "try to start tablet meta checkpoint thread!";
     while (true) {
-        LOG(INFO) << "begin to do tablet meta checkpoint";
+        LOG(INFO) << "begin to do tablet meta checkpoint:" << ((DataDir*)arg)->path();
         int64_t start_time = UnixMillis();
         _tablet_manager->do_tablet_meta_checkpoint((DataDir*)arg);
         int64_t used_time = (UnixMillis() - start_time) / 1000;


### PR DESCRIPTION
Fix #2419
Add a flag in RowsetMeta to record whether it has been deleted from rowset meta.
Before this PR, 37156 rowsets only cost 1642 s.
With this PR, 37319 rowsets just cost 1 s.