### PR TITLE
Support to create materialized view

### DIFF
--- a/fe/src/main/cup/sql_parser.cup
+++ b/fe/src/main/cup/sql_parser.cup
@@ -225,7 +225,7 @@ terminal String KW_ADD, KW_ADMIN, KW_AFTER, KW_AGGREGATE, KW_ALL, KW_ALTER, KW_A
     KW_TABLE, KW_TABLES, KW_TABLET, KW_TERMINATED, KW_THAN, KW_THEN, KW_TIMESTAMP, KW_TINYINT,
     KW_TO, KW_TRANSACTION, KW_TRIGGERS, KW_TRIM, KW_TRUE, KW_TRUNCATE, KW_TYPE, KW_TYPES,
     KW_UNCOMMITTED, KW_UNBOUNDED, KW_UNION, KW_UNIQUE, KW_UNSIGNED, KW_USE, KW_USER, KW_USING,
-    KW_VALUE, KW_VALUES, KW_VARCHAR, KW_VARIABLES, KW_VIEW,
+    KW_VALUE, KW_VALUES, KW_VARCHAR, KW_VARIABLES, KW_VIEW, KW_MATERIALIZED,
     KW_WARNINGS, KW_WHEN, KW_WHITELIST, KW_WHERE, KW_WITH, KW_WORK, KW_WRITE;
 
 terminal COMMA, DOT, DOTDOTDOT, AT, STAR, LPAREN, RPAREN, SEMICOLON, LBRACKET, RBRACKET, DIVIDE, MOD, ADD, SUBTRACT;
@@ -724,6 +724,10 @@ alter_table_clause ::=
     | KW_ADD KW_ROLLUP ident:rollupName LPAREN ident_list:cols RPAREN opt_dup_keys:dup_keys opt_from_rollup:baseRollup opt_properties:properties
     {:
         RESULT = new AddRollupClause(rollupName, cols, dup_keys, baseRollup, properties);
+    :}
+    | KW_ADD KW_MATERIALIZED KW_VIEW ident:mvName LPAREN select_stmt:selectStmt RPAREN opt_properties:properties
+    {:
+        RESULT = new AddMaterializedViewClause(mvName, selectStmt, properties);
     :}
     | KW_DROP KW_COLUMN ident:col opt_from_rollup:rollup opt_properties:properties
     {:
@@ -4223,6 +4227,8 @@ keyword ::=
     | KW_VALUE:id
     {: RESULT = id; :}
     | KW_VIEW:id
+    {: RESULT = id; :}
+    | KW_MATERIALIZED:id
     {: RESULT = id; :}
     | KW_WARNINGS:id
     {: RESULT = id; :}

--- a/fe/src/main/cup/sql_parser.cup
+++ b/fe/src/main/cup/sql_parser.cup
@@ -652,6 +652,7 @@ opt_user ::=
 
     :}
     ;
+
 alter_table_clause_list ::=
     alter_table_clause:clause
     {:
@@ -724,10 +725,6 @@ alter_table_clause ::=
     | KW_ADD KW_ROLLUP ident:rollupName LPAREN ident_list:cols RPAREN opt_dup_keys:dup_keys opt_from_rollup:baseRollup opt_properties:properties
     {:
         RESULT = new AddRollupClause(rollupName, cols, dup_keys, baseRollup, properties);
-    :}
-    | KW_ADD KW_MATERIALIZED KW_VIEW ident:mvName LPAREN select_stmt:selectStmt RPAREN opt_properties:properties
-    {:
-        RESULT = new AddMaterializedViewClause(mvName, selectStmt, properties);
     :}
     | KW_DROP KW_COLUMN ident:col opt_from_rollup:rollup opt_properties:properties
     {:
@@ -923,6 +920,10 @@ create_stmt ::=
     | KW_CREATE KW_FILE STRING_LITERAL:fileName opt_db:db KW_PROPERTIES LPAREN key_value_map:properties RPAREN
     {:
         RESULT = new CreateFileStmt(fileName, db, properties);
+    :}
+    | KW_CREATE KW_MATERIALIZED KW_VIEW ident:mvName KW_AS select_stmt:selectStmt opt_properties:properties
+    {:
+        RESULT = new CreateMaterializedViewStmt(mvName, selectStmt, properties);
     :}
     ;
 

--- a/fe/src/main/java/org/apache/doris/alter/Alter.java
+++ b/fe/src/main/java/org/apache/doris/alter/Alter.java
@@ -19,6 +19,7 @@ package org.apache.doris.alter;
 
 import org.apache.doris.analysis.AddColumnClause;
 import org.apache.doris.analysis.AddColumnsClause;
+import org.apache.doris.analysis.AddMaterializedViewClause;
 import org.apache.doris.analysis.AddPartitionClause;
 import org.apache.doris.analysis.AddRollupClause;
 import org.apache.doris.analysis.AlterClause;
@@ -59,18 +60,18 @@ public class Alter {
     private static final Logger LOG = LogManager.getLogger(Alter.class);
 
     private AlterHandler schemaChangeHandler;
-    private AlterHandler rollupHandler;
+    private AlterHandler materializedViewHandler;
     private SystemHandler clusterHandler;
 
     public Alter() {
         schemaChangeHandler = new SchemaChangeHandler();
-        rollupHandler = new RollupHandler();
+        materializedViewHandler = new MaterializedViewHandler();
         clusterHandler = new SystemHandler();
     }
 
     public void start() {
         schemaChangeHandler.start();
-        rollupHandler.start();
+        materializedViewHandler.start();
         clusterHandler.start();
     }
 
@@ -89,8 +90,8 @@ public class Alter {
 
         // schema change ops can appear several in one alter stmt without other alter ops entry
         boolean hasSchemaChange = false;
-        // rollup ops, if has, should appear one and only one add or drop rollup entry
-        boolean hasAddRollup = false;
+        // materialized view ops (include rollup), if has, should appear one and only one add or drop mv entry
+        boolean hasAddMaterializedView = false;
         boolean hasDropRollup = false;
         // partition ops, if has, should appear one and only one entry
         boolean hasPartition = false;
@@ -124,29 +125,30 @@ public class Alter {
                     || alterClause instanceof DropColumnClause
                     || alterClause instanceof ModifyColumnClause
                     || alterClause instanceof ReorderColumnsClause)
-                    && !hasAddRollup && !hasDropRollup && !hasPartition && !hasRename) {
+                    && !hasAddMaterializedView && !hasDropRollup && !hasPartition && !hasRename) {
                 hasSchemaChange = true;
-            } else if (alterClause instanceof AddRollupClause && !hasSchemaChange && !hasAddRollup && !hasDropRollup
+            } else if ((alterClause instanceof AddRollupClause || alterClause instanceof AddMaterializedViewClause)
+                    && !hasSchemaChange && !hasAddMaterializedView && !hasDropRollup
                     && !hasPartition && !hasRename && !hasModifyProp) {
-                hasAddRollup = true;
-            } else if (alterClause instanceof DropRollupClause && !hasSchemaChange && !hasAddRollup && !hasDropRollup
+                hasAddMaterializedView = true;
+            } else if (alterClause instanceof DropRollupClause && !hasSchemaChange && !hasAddMaterializedView && !hasDropRollup
                     && !hasPartition && !hasRename && !hasModifyProp) {
                 hasDropRollup = true;
-            } else if (alterClause instanceof AddPartitionClause && !hasSchemaChange && !hasAddRollup && !hasDropRollup
+            } else if (alterClause instanceof AddPartitionClause && !hasSchemaChange && !hasAddMaterializedView && !hasDropRollup
                     && !hasPartition && !hasRename && !hasModifyProp) {
                 hasPartition = true;
-            } else if (alterClause instanceof DropPartitionClause && !hasSchemaChange && !hasAddRollup && !hasDropRollup
+            } else if (alterClause instanceof DropPartitionClause && !hasSchemaChange && !hasAddMaterializedView && !hasDropRollup
                     && !hasPartition && !hasRename && !hasModifyProp) {
                 hasPartition = true;
-            } else if (alterClause instanceof ModifyPartitionClause && !hasSchemaChange && !hasAddRollup
+            } else if (alterClause instanceof ModifyPartitionClause && !hasSchemaChange && !hasAddMaterializedView
                     && !hasDropRollup && !hasPartition && !hasRename && !hasModifyProp) {
                 hasPartition = true;
             } else if ((alterClause instanceof TableRenameClause || alterClause instanceof RollupRenameClause
                     || alterClause instanceof PartitionRenameClause || alterClause instanceof ColumnRenameClause)
-                    && !hasSchemaChange && !hasAddRollup && !hasDropRollup && !hasPartition && !hasRename
+                    && !hasSchemaChange && !hasAddMaterializedView && !hasDropRollup && !hasPartition && !hasRename
                     && !hasModifyProp) {
                 hasRename = true;
-            } else if (alterClause instanceof ModifyTablePropertiesClause && !hasSchemaChange && !hasAddRollup
+            } else if (alterClause instanceof ModifyTablePropertiesClause && !hasSchemaChange && !hasAddMaterializedView
                     && !hasDropRollup && !hasPartition && !hasRename && !hasModifyProp) {
                 hasModifyProp = true;
             } else {
@@ -177,7 +179,7 @@ public class Alter {
                 throw new DdlException("Table[" + table.getName() + "]'s state is not NORMAL. Do not allow doing ALTER ops");
             }
             
-            if (hasSchemaChange || hasModifyProp || hasAddRollup) {
+            if (hasSchemaChange || hasModifyProp || hasAddMaterializedView) {
                 // check if all tablets are healthy, and no tablet is in tablet scheduler
                 boolean isStable = olapTable.isStable(Catalog.getCurrentSystemInfo(),
                         Catalog.getCurrentCatalog().getTabletScheduler(),
@@ -192,8 +194,8 @@ public class Alter {
 
             if (hasSchemaChange || hasModifyProp) {
                 schemaChangeHandler.process(alterClauses, clusterName, db, olapTable);
-            } else if (hasAddRollup || hasDropRollup) {
-                rollupHandler.process(alterClauses, clusterName, db, olapTable);
+            } else if (hasAddMaterializedView || hasDropRollup) {
+                materializedViewHandler.process(alterClauses, clusterName, db, olapTable);
             } else if (hasPartition) {
                 Preconditions.checkState(alterClauses.size() == 1);
                 AlterClause alterClause = alterClauses.get(0);
@@ -251,8 +253,8 @@ public class Alter {
         return this.schemaChangeHandler;
     }
 
-    public AlterHandler getRollupHandler() {
-        return this.rollupHandler;
+    public AlterHandler getMaterializedViewHandler() {
+        return this.materializedViewHandler;
     }
 
     public AlterHandler getClusterHandler() {

--- a/fe/src/main/java/org/apache/doris/alter/MaterializedViewHandler.java
+++ b/fe/src/main/java/org/apache/doris/alter/MaterializedViewHandler.java
@@ -18,11 +18,13 @@
 package org.apache.doris.alter;
 
 import org.apache.doris.alter.AlterJob.JobState;
+import org.apache.doris.analysis.AddMaterializedViewClause;
 import org.apache.doris.analysis.AddRollupClause;
 import org.apache.doris.analysis.AlterClause;
 import org.apache.doris.analysis.CancelAlterTableStmt;
 import org.apache.doris.analysis.CancelStmt;
 import org.apache.doris.analysis.DropRollupClause;
+import org.apache.doris.analysis.MVColumnItem;
 import org.apache.doris.catalog.AggregateType;
 import org.apache.doris.catalog.Catalog;
 import org.apache.doris.catalog.Column;
@@ -39,10 +41,13 @@ import org.apache.doris.catalog.Table;
 import org.apache.doris.catalog.Tablet;
 import org.apache.doris.catalog.TabletInvertedIndex;
 import org.apache.doris.catalog.TabletMeta;
+import org.apache.doris.common.AnalysisException;
+import org.apache.doris.common.Config;
 import org.apache.doris.common.DdlException;
 import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.ErrorReport;
 import org.apache.doris.common.util.ListComparator;
+import org.apache.doris.common.util.PropertyAnalyzer;
 import org.apache.doris.common.util.Util;
 import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.persist.DropInfo;
@@ -67,59 +72,239 @@ import java.util.Map;
 import java.util.Set;
 
 /*
- * RollupHandler is responsible for ADD/DROP rollup.
+ * MaterializedViewHandler is responsible for ADD/DROP materialized view.
+ * For compatible with older version, it is also responsible for ADD/DROP rollup.
+ * In function level, the mv completely covers the rollup in the future.
+ * In grammar level, there is some difference between mv and rollup.
  */
-public class RollupHandler extends AlterHandler {
-    private static final Logger LOG = LogManager.getLogger(RollupHandler.class);
+public class MaterializedViewHandler extends AlterHandler {
+    private static final Logger LOG = LogManager.getLogger(MaterializedViewHandler.class);
 
-    public RollupHandler() {
-        super("rollup");
+    public MaterializedViewHandler() {
+        super("materialized view");
     }
 
-    /*
-     * Handle the Add Rollup request.
-     * 3 main steps:
-     * 1. Validate the request.
-     * 2. Create RollupJob with rollup index
-     *      All replicas of the rollup index will be created in meta and added to TabletInvertedIndex
-     * 3. Set table's state to ROLLUP.
+    /**
+     * There are 2 main steps in this function.
+     * Step1: validate the request.
+     *   Step1.1: semantic analysis: the name of olapTable must be same as the base table name in addMVClause.
+     *   Step1.2: base table validation: the status of base table and partition could be NORMAL.
+     *   Step1.3: materialized view validation: the name and columns of mv is checked.
+     * Step2: create mv job
+     * @param addMVClause
+     * @param db
+     * @param olapTable
+     * @throws DdlException
+     */
+    private void processAddMaterializedView(AddMaterializedViewClause addMVClause, Database db, OlapTable olapTable)
+            throws DdlException, AnalysisException {
+        // Step1.1: semantic analysis
+        // TODO(ML): support the materialized view as base index
+        if (!addMVClause.getBaseIndexName().equals(olapTable.getName())) {
+            throw new DdlException("The name of table in from clause must be same as the name of alter table");
+        }
+        // Step1.2: base table validation
+        String baseIndexName = addMVClause.getBaseIndexName();
+        String mvIndexName = addMVClause.getMVName();
+        LOG.info("process add materialized view[{}] based on [{}]", mvIndexName, baseIndexName);
+        long baseIndexId = checkAndGetBaseIndex(baseIndexName, olapTable);
+        // Step1.3: mv clause validation
+        List<Column> mvColumns = checkAndPrepareMaterializedView(addMVClause, olapTable);
+
+        // Step2: create mv job
+        createMaterializedViewJob(mvIndexName, baseIndexName, mvColumns,
+                                  addMVClause.getProperties(), olapTable, db, baseIndexId);
+    }
+
+    /**
+     * There are 2 main steps.
+     * Step1: validate the request
+     *   Step1.1: base table validation: the status of base table and partition could be NORMAL.
+     *   Step1.2: rollup validation: the name and columns of rollup is checked.
+     * Step2: create rollup job
+     * @param alterClause
+     * @param db
+     * @param olapTable
+     * @throws DdlException
+     * @throws AnalysisException
      */
     private void processAddRollup(AddRollupClause alterClause, Database db, OlapTable olapTable)
-            throws DdlException {
-        
-        // table is under rollup or has a finishing alter job
-        if (olapTable.getState() == OlapTableState.ROLLUP || this.hasUnfinishedAlterJob(olapTable.getId())) {
-            throw new DdlException("Table[" + olapTable.getName() + "]'s is under ROLLUP");
-        }
-        // up to here, table's state can only be NORMAL
-        Preconditions.checkState(olapTable.getState() == OlapTableState.NORMAL, olapTable.getState().name());
-
-        String rollupIndexName = alterClause.getRollupName();
+            throws DdlException, AnalysisException {
         String baseIndexName = alterClause.getBaseRollupName();
-        List<String> rollupColumnNames = alterClause.getColumnNames();
-
-        LOG.info("process add rollup[{}] based on [{}]", rollupIndexName, baseIndexName);
-
-        // 1. check if rollup index already exists
-        if (olapTable.hasMaterializedIndex(rollupIndexName)) {
-            throw new DdlException("Rollup index[" + rollupIndexName + "] already exists");
-        }
-
-        // 2. get base index schema
+        String rollupIndexName = alterClause.getRollupName();
+        // get base index schema
         if (baseIndexName == null) {
             // use table name as base table name
             baseIndexName = olapTable.getName();
         }
-        Long baseIndexId = olapTable.getIndexIdByName(baseIndexName);
-        if (baseIndexId == null) {
-            throw new DdlException("Base index[" + baseIndexName + "] does not exist");
-        }
+        // Step1.1 check base table and base index
+        // Step1.2 alter clause validation
+        LOG.info("process add rollup[{}] based on [{}]", rollupIndexName, baseIndexName);
+        Long baseIndexId = checkAndGetBaseIndex(baseIndexName, olapTable);
+        List<Column> rollupSchema = checkAndPrepareMaterializedView(alterClause, olapTable, baseIndexId);
 
-        // check state
+        // Step2: create materialized view job
+        createMaterializedViewJob(rollupIndexName, baseIndexName, rollupSchema, alterClause.getProperties(),
+                                  olapTable, db, baseIndexId);
+    }
+
+    /**
+     * Step1: All replicas of the materialized view index will be created in meta and added to TabletInvertedIndex
+     * Step2: Set table's state to ROLLUP.
+     *
+     * @param mvName
+     * @param baseIndexName
+     * @param mvColumns
+     * @param properties
+     * @param olapTable
+     * @param db
+     * @param baseIndexId
+     * @throws DdlException
+     * @throws AnalysisException
+     */
+    private void createMaterializedViewJob(String mvName, String baseIndexName,
+                                           List<Column> mvColumns, Map<String, String> properties,
+                                           OlapTable olapTable, Database db, long baseIndexId)
+            throws DdlException, AnalysisException {
+        // assign rollup index's key type, same as base index's
+        KeysType mvKeysType = olapTable.getKeysType();
+        // get rollup schema hash
+        int mvSchemaHash = Util.schemaHash(0 /* init schema version */, mvColumns, olapTable.getCopiedBfColumns(),
+                                           olapTable.getBfFpp());
+        // get short key column count
+        short mvShortKeyColumnCount = Catalog.calcShortKeyColumnCount(mvColumns, properties);
+        // get timeout
+        long timeoutMs = PropertyAnalyzer.analyzeTimeout(properties, Config.alter_table_timeout_second) * 1000;
+
+        // create rollup job
+        long dbId = db.getId();
+        long tableId = olapTable.getId();
+        int baseSchemaHash = olapTable.getSchemaHashByIndexId(baseIndexId);
+        Catalog catalog = Catalog.getCurrentCatalog();
+        long jobId = catalog.getNextId();
+        long mvIndexId = catalog.getNextId();
+        RollupJobV2 mvJob = new RollupJobV2(jobId, dbId, tableId, olapTable.getName(), timeoutMs,
+                                            baseIndexId, mvIndexId, baseIndexName, mvName,
+                                            mvColumns, baseSchemaHash, mvSchemaHash,
+                                            mvKeysType, mvShortKeyColumnCount);
+
+        /*
+         * create all rollup indexes. and set state.
+         * After setting, Tables' state will be ROLLUP
+         */
         for (Partition partition : olapTable.getPartitions()) {
+            long partitionId = partition.getId();
+            TStorageMedium medium = olapTable.getPartitionInfo().getDataProperty(partitionId).getStorageMedium();
+            // index state is SHADOW
+            MaterializedIndex mvIndex = new MaterializedIndex(mvIndexId, IndexState.SHADOW);
             MaterializedIndex baseIndex = partition.getIndex(baseIndexId);
-            // up to here. index's state should only be NORMAL
-            Preconditions.checkState(baseIndex.getState() == IndexState.NORMAL, baseIndex.getState().name());
+            TabletMeta mvTabletMeta = new TabletMeta(dbId, tableId, partitionId, mvIndexId, mvSchemaHash,
+                                                     medium);
+            for (Tablet baseTablet : baseIndex.getTablets()) {
+                long baseTabletId = baseTablet.getId();
+                long mvTabletId = catalog.getNextId();
+
+                Tablet newTablet = new Tablet(mvTabletId);
+                mvIndex.addTablet(newTablet, mvTabletMeta);
+
+                mvJob.addTabletIdMap(partitionId, mvTabletId, baseTabletId);
+                List<Replica> baseReplicas = baseTablet.getReplicas();
+
+                for (Replica baseReplica : baseReplicas) {
+                    long mvReplicaId = catalog.getNextId();
+                    long backendId = baseReplica.getBackendId();
+                    if (baseReplica.getState() == ReplicaState.CLONE
+                            || baseReplica.getState() == ReplicaState.DECOMMISSION
+                            || baseReplica.getLastFailedVersion() > 0) {
+                        // just skip it.
+                        continue;
+                    }
+                    Preconditions.checkState(baseReplica.getState() == ReplicaState.NORMAL);
+                    // replica's init state is ALTER, so that tablet report process will ignore its report
+                    Replica mvReplica = new Replica(mvReplicaId, backendId, ReplicaState.ALTER,
+                                                    Partition.PARTITION_INIT_VERSION, Partition
+                                                            .PARTITION_INIT_VERSION_HASH,
+                                                    mvSchemaHash);
+                    newTablet.addReplica(mvReplica);
+                } // end for baseReplica
+            } // end for baseTablets
+
+            mvJob.addMVIndex(partitionId, mvIndex);
+
+            LOG.debug("create materialized view index {} based on index {} in partition {}",
+                      mvIndexId, baseIndexId, partitionId);
+        } // end for partitions
+
+        // update table state
+        olapTable.setState(OlapTableState.ROLLUP);
+
+        addAlterJobV2(mvJob);
+
+        // log rollup operation
+        catalog.getEditLog().logAlterJob(mvJob);
+        LOG.info("finished to create materialized view job: {}", mvJob.getJobId());
+    }
+
+    private List<Column> checkAndPrepareMaterializedView(AddMaterializedViewClause addMVClause, OlapTable olapTable)
+            throws DdlException {
+        // check if mv index already exists
+        if (olapTable.hasMaterializedIndex(addMVClause.getMVName())) {
+            throw new DdlException("Materialized view[" + addMVClause.getMVName() + "] already exists");
+        }
+        // check if rollup columns are valid
+        // a. all columns should exist in base rollup schema
+        // b. For aggregate table, mv columns with aggregate function should be same as base schema
+        // c. For aggregate table, the column which is the key of base table should be the key of mv as well.
+        // update mv columns
+        List<MVColumnItem> mvColumnItemList = addMVClause.getMVColumnItemList();
+        List<Column> newMVColumns = Lists.newArrayList();
+        int numOfKeys = 0;
+        for (MVColumnItem mvColumnItem : mvColumnItemList) {
+            String mvColumnName = mvColumnItem.getName();
+            Column baseColumn = olapTable.getColumn(mvColumnName);
+            if (baseColumn == null) {
+                throw new DdlException("Column[" + mvColumnName + "] does not exist");
+            }
+            if (mvColumnItem.isKey()) {
+                ++numOfKeys;
+            }
+            AggregateType baseAggregationType = baseColumn.getAggregationType();
+            AggregateType mvAggregationType = mvColumnItem.getAggregationType();
+            if (olapTable.getKeysType().isAggregationFamily()) {
+                if (baseColumn.isKey() && !mvColumnItem.isKey()) {
+                    throw new DdlException("The column[" + mvColumnName + "] must be the key of materialized view");
+                }
+                if (baseAggregationType != mvAggregationType) {
+                    throw new DdlException("The aggregation type of column[" + mvColumnName + "] must be same as "
+                                                   + "the aggregate type of base column in aggregate table");
+                }
+                if (baseAggregationType != null && baseAggregationType.isReplaceFamily()
+                        && olapTable.getKeysNum() != numOfKeys) {
+                    throw new DdlException("The materialized view should contain all keys of base table if there is a"
+                                                   + " REPLACE value");
+                }
+            }
+            if (olapTable.getKeysType() == KeysType.DUP_KEYS && mvAggregationType != null
+                    && mvAggregationType.isReplaceFamily()) {
+                throw new DdlException("The aggregation type of REPLACE AND REPLACE IF NOT NULL is forbidden in "
+                                               + "duplicate table");
+            }
+            Column newMVColumn = new Column(baseColumn);
+            newMVColumn.setIsKey(mvColumnItem.isKey());
+            newMVColumn.setAggregationType(mvAggregationType, mvColumnItem.isAggregationTypeImplicit());
+            newMVColumns.add(newMVColumn);
+        }
+        return newMVColumns;
+    }
+
+    private List<Column> checkAndPrepareMaterializedView(AddRollupClause addRollupClause, OlapTable olapTable,
+                                                         long baseIndexId)
+            throws DdlException {
+        String rollupIndexName = addRollupClause.getRollupName();
+        List<String> rollupColumnNames = addRollupClause.getColumnNames();
+        // 2. check if rollup index already exists
+        if (olapTable.hasMaterializedIndex(rollupIndexName)) {
+            throw new DdlException("Rollup index[" + rollupIndexName + "] already exists");
         }
 
         // 3. check if rollup columns are valid
@@ -132,7 +317,7 @@ public class RollupHandler extends AlterHandler {
         boolean hasKey = false;
         boolean meetReplaceValue = false;
         KeysType keysType = olapTable.getKeysType();
-        if (KeysType.UNIQUE_KEYS == keysType || KeysType.AGG_KEYS == keysType) {
+        if (keysType.isAggregationFamily()) {
             int keysNumOfRollup = 0;
             for (String columnName : rollupColumnNames) {
                 Column oneColumn = olapTable.getColumn(columnName);
@@ -147,8 +332,7 @@ public class RollupHandler extends AlterHandler {
                     hasKey = true;
                 } else {
                     meetValue = true;
-                    if (oneColumn.getAggregationType() == AggregateType.REPLACE ||
-                            oneColumn.getAggregationType() == AggregateType.REPLACE_IF_NOT_NULL) {
+                    if (oneColumn.getAggregationType().isReplaceFamily()) {
                         meetReplaceValue = true;
                     }
                 }
@@ -158,11 +342,11 @@ public class RollupHandler extends AlterHandler {
             if (!hasKey) {
                 throw new DdlException("No key column is found");
             }
-            
+
             if (KeysType.UNIQUE_KEYS == keysType || meetReplaceValue) {
                 // rollup of unique key table or rollup with REPLACE value
                 // should have all keys of base table
-                if (keysNumOfRollup !=  olapTable.getKeysNum()) {
+                if (keysNumOfRollup != olapTable.getKeysNum()) {
                     if (KeysType.UNIQUE_KEYS == keysType) {
                         throw new DdlException("Rollup should contains all unique keys in basetable");
                     } else {
@@ -178,13 +362,13 @@ public class RollupHandler extends AlterHandler {
              * 1. (k1) dup key (k1)
              * 2. (k2,k3) dup key (k2)
              * 3. (k1,k2,k3) dup key (k1,k2)
-             * 
+             *
              * The following rollup is forbidden:
              * 1. (k1) dup key (k2)
              * 2. (k2,k3) dup key (k3,k2)
              * 3. (k1,k2,k3) dup key (k2,k3)
              */
-            if (alterClause.getDupKeys() == null || alterClause.getDupKeys().isEmpty()) {
+            if (addRollupClause.getDupKeys() == null || addRollupClause.getDupKeys().isEmpty()) {
                 // user does not specify duplicate key for rollup,
                 // use base table's duplicate key.
                 // so we should check if rollup columns contains all base table's duplicate key.
@@ -209,7 +393,7 @@ public class RollupHandler extends AlterHandler {
                     }
                     if (!found) {
                         throw new DdlException("Rollup should contains all base table's duplicate keys if "
-                                + "no duplicate key is specified: " + baseIdxKeyColName);
+                                                       + "no duplicate key is specified: " + baseIdxKeyColName);
                     }
                 }
 
@@ -235,7 +419,7 @@ public class RollupHandler extends AlterHandler {
                 }
             } else {
                 // user specify the duplicate keys for rollup index
-                List<String> dupKeys = alterClause.getDupKeys();
+                List<String> dupKeys = addRollupClause.getDupKeys();
                 if (dupKeys.size() > rollupColumnNames.size()) {
                     throw new DdlException("Num of duplicate keys should less than or equal to num of rollup columns.");
                 }
@@ -273,89 +457,24 @@ public class RollupHandler extends AlterHandler {
                 }
             }
         }
+        return rollupSchema;
+    }
 
-        // assign rollup index's key type, same as base index's
-        KeysType rollupKeysType = keysType;
-        
+    private long checkAndGetBaseIndex(String baseIndexName, OlapTable olapTable) throws DdlException {
+        // up to here, table's state can only be NORMAL
+        Preconditions.checkState(olapTable.getState() == OlapTableState.NORMAL, olapTable.getState().name());
 
-        // get rollup schema hash
-        int rollupSchemaHash = Util.schemaHash(0 /* init schema version */, rollupSchema, olapTable.getCopiedBfColumns(),
-                                               olapTable.getBfFpp());
-
-        // get short key column count
-        Map<String, String> properties = alterClause.getProperties();
-        short rollupShortKeyColumnCount = Catalog.calcShortKeyColumnCount(rollupSchema, properties);
-        
-        // get timeout
-        long timeoutMs = alterClause.getTimeoutSecond() * 1000;
-
-        // 4. create rollup job
-        long dbId = db.getId();
-        long tableId = olapTable.getId();
-        int baseSchemaHash = olapTable.getSchemaHashByIndexId(baseIndexId);
-
-        Catalog catalog = Catalog.getCurrentCatalog();
-        long jobId = catalog.getNextId();
-        long rollupIndexId = catalog.getNextId();
-        
-        RollupJobV2 rollupJob = new RollupJobV2(jobId, dbId, tableId, olapTable.getName(), timeoutMs,
-                baseIndexId, rollupIndexId, baseIndexName, rollupIndexName,
-                rollupSchema, baseSchemaHash, rollupSchemaHash,
-                rollupKeysType, rollupShortKeyColumnCount);
-
-        /*
-         * create all rollup indexes. and set state.
-         * After setting, Tables' state will be ROLLUP
-         */
+        Long baseIndexId = olapTable.getIndexIdByName(baseIndexName);
+        if (baseIndexId == null) {
+            throw new DdlException("Base index[" + baseIndexName + "] does not exist");
+        }
+        // check state
         for (Partition partition : olapTable.getPartitions()) {
-            long partitionId = partition.getId();
-            TStorageMedium medium = olapTable.getPartitionInfo().getDataProperty(partitionId).getStorageMedium();
-            // index state is SHADOW
-            MaterializedIndex rollupIndex = new MaterializedIndex(rollupIndexId, IndexState.SHADOW);
             MaterializedIndex baseIndex = partition.getIndex(baseIndexId);
-            TabletMeta rollupTabletMeta = new TabletMeta(dbId, tableId, partitionId, rollupIndexId, rollupSchemaHash, medium);
-            for (Tablet baseTablet : baseIndex.getTablets()) {
-                long baseTabletId = baseTablet.getId();
-                long rollupTabletId = catalog.getNextId();
-
-                Tablet newTablet = new Tablet(rollupTabletId);
-                rollupIndex.addTablet(newTablet, rollupTabletMeta);
-
-                rollupJob.addTabletIdMap(partitionId, rollupTabletId, baseTabletId);
-                List<Replica> baseReplicas = baseTablet.getReplicas();
-
-                for (Replica baseReplica : baseReplicas) {
-                    long rollupReplicaId = catalog.getNextId();
-                    long backendId = baseReplica.getBackendId();
-                    if (baseReplica.getState() == ReplicaState.CLONE 
-                            || baseReplica.getState() == ReplicaState.DECOMMISSION
-                            || baseReplica.getLastFailedVersion() > 0) {
-                        // just skip it.
-                        continue;
-                    }
-                    Preconditions.checkState(baseReplica.getState() == ReplicaState.NORMAL);
-                    // replica's init state is ALTER, so that tablet report process will ignore its report
-                    Replica rollupReplica = new Replica(rollupReplicaId, backendId, ReplicaState.ALTER,
-                            Partition.PARTITION_INIT_VERSION, Partition.PARTITION_INIT_VERSION_HASH,
-                            rollupSchemaHash);
-                    newTablet.addReplica(rollupReplica);
-                } // end for baseReplica
-            } // end for baseTablets
-
-            rollupJob.addRollupIndex(partitionId, rollupIndex);
-
-            LOG.debug("create rollup index {} based on index {} in partition {}",
-                    rollupIndexId, baseIndexId, partitionId);
-        } // end for partitions
-
-        // update table state
-        olapTable.setState(OlapTableState.ROLLUP);
-
-        addAlterJobV2(rollupJob);
-
-        // log rollup operation
-        catalog.getEditLog().logAlterJob(rollupJob);
-        LOG.info("finished to create rollup job: {}", rollupJob.getJobId());
+            // up to here. index's state should only be NORMAL
+            Preconditions.checkState(baseIndex.getState() == IndexState.NORMAL, baseIndex.getState().name());
+        }
+        return baseIndexId;
     }
 
     public void processDropRollup(DropRollupClause alterClause, Database db, OlapTable olapTable)
@@ -637,10 +756,13 @@ public class RollupHandler extends AlterHandler {
 
     @Override
     public void process(List<AlterClause> alterClauses, String clusterName, Database db, OlapTable olapTable)
-            throws DdlException {
+            throws DdlException, AnalysisException {
         for (AlterClause alterClause : alterClauses) {
             if (alterClause instanceof AddRollupClause) {
                 processAddRollup((AddRollupClause) alterClause, db, olapTable);
+            } else if (alterClause instanceof AddMaterializedViewClause) {
+                // TODO(ml): remove it
+                throw new AnalysisException("The materialized view is coming soon");
             } else if (alterClause instanceof DropRollupClause) {
                 processDropRollup((DropRollupClause) alterClause, db, olapTable);
             } else {

--- a/fe/src/main/java/org/apache/doris/alter/MaterializedViewHandler.java
+++ b/fe/src/main/java/org/apache/doris/alter/MaterializedViewHandler.java
@@ -18,7 +18,7 @@
 package org.apache.doris.alter;
 
 import org.apache.doris.alter.AlterJob.JobState;
-import org.apache.doris.analysis.AddMaterializedViewClause;
+import org.apache.doris.analysis.CreateMaterializedViewStmt;
 import org.apache.doris.analysis.AddRollupClause;
 import org.apache.doris.analysis.AlterClause;
 import org.apache.doris.analysis.CancelAlterTableStmt;
@@ -96,7 +96,7 @@ public class MaterializedViewHandler extends AlterHandler {
      * @param olapTable
      * @throws DdlException
      */
-    private void processAddMaterializedView(AddMaterializedViewClause addMVClause, Database db, OlapTable olapTable)
+    public void processCreateMaterializedView(CreateMaterializedViewStmt addMVClause, Database db, OlapTable olapTable)
             throws DdlException, AnalysisException {
         // Step1.1: semantic analysis
         // TODO(ML): support the materialized view as base index
@@ -245,7 +245,7 @@ public class MaterializedViewHandler extends AlterHandler {
         LOG.info("finished to create materialized view job: {}", mvJob.getJobId());
     }
 
-    private List<Column> checkAndPrepareMaterializedView(AddMaterializedViewClause addMVClause, OlapTable olapTable)
+    private List<Column> checkAndPrepareMaterializedView(CreateMaterializedViewStmt addMVClause, OlapTable olapTable)
             throws DdlException {
         // check if mv index already exists
         if (olapTable.hasMaterializedIndex(addMVClause.getMVName())) {
@@ -760,9 +760,6 @@ public class MaterializedViewHandler extends AlterHandler {
         for (AlterClause alterClause : alterClauses) {
             if (alterClause instanceof AddRollupClause) {
                 processAddRollup((AddRollupClause) alterClause, db, olapTable);
-            } else if (alterClause instanceof AddMaterializedViewClause) {
-                // TODO(ml): remove it
-                throw new AnalysisException("The materialized view is coming soon");
             } else if (alterClause instanceof DropRollupClause) {
                 processDropRollup((DropRollupClause) alterClause, db, olapTable);
             } else {

--- a/fe/src/main/java/org/apache/doris/alter/RollupJobV2.java
+++ b/fe/src/main/java/org/apache/doris/alter/RollupJobV2.java
@@ -124,8 +124,8 @@ public class RollupJobV2 extends AlterJobV2 {
         tabletIdMap.put(rollupTabletId, baseTabletId);
     }
 
-    public void addRollupIndex(long partitionId, MaterializedIndex rollupIndex) {
-        this.partitionIdToRollupIndex.put(partitionId, rollupIndex);
+    public void addMVIndex(long partitionId, MaterializedIndex mvIndex) {
+        this.partitionIdToRollupIndex.put(partitionId, mvIndex);
     }
 
     /*

--- a/fe/src/main/java/org/apache/doris/analysis/AddMaterializedViewClause.java
+++ b/fe/src/main/java/org/apache/doris/analysis/AddMaterializedViewClause.java
@@ -1,0 +1,253 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.analysis;
+
+import org.apache.doris.catalog.AggregateType;
+import org.apache.doris.common.AnalysisException;
+import org.apache.doris.common.Config;
+import org.apache.doris.common.ErrorCode;
+import org.apache.doris.common.ErrorReport;
+import org.apache.doris.common.FeNameFormat;
+import org.apache.doris.common.UserException;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Materialized view is performed to materialize the results of query.
+ * This clause is used to create a new materialized view for a specified table
+ * through a specified query stmt.
+ * <p>
+ * Syntax:
+ * ALTER TABLE [Table name] ADD Materialized View [MV name] (
+ *     SELECT select_expr[, select_expr ...]
+ *     FROM [Base view name]
+ *     GROUP BY column_name[, column_name ...]
+ *     ORDER BY column_name[, column_name ...])
+ * [PROPERTIES ("key": "value")]
+ */
+public class AddMaterializedViewClause extends AlterClause {
+    private String mvName;
+    private SelectStmt selectStmt;
+    private Map<String, String> properties;
+
+    /**
+     * origin stmt: select k1, k2, v1, sum(v2) from base_table group by k1, k2, v1 order by k1, k2
+     * mvColumnItemList: [k1: {name: k1, isKey: true, aggType: null, isAggregationTypeImplicit: false},
+     *                    k2: {name: k2, isKey: true, aggType: null, isAggregationTypeImplicit: false},
+     *                    v1: {name: v1, isKey: false, aggType: none, isAggregationTypeImplicit: true},
+     *                    v2: {name: v2, isKey: false, aggType: sum, isAggregationTypeImplicit: false}]
+     * This order of mvColumnItemList is meaningful.
+     */
+    private List<MVColumnItem> mvColumnItemList = Lists.newArrayList();
+    private String baseIndexName;
+
+    public AddMaterializedViewClause(String mvName, SelectStmt selectStmt,
+                                     Map<String, String> properties) {
+        this.mvName = mvName;
+        this.selectStmt = selectStmt;
+        this.properties = properties;
+    }
+
+    public String getMVName() {
+        return mvName;
+    }
+
+    public List<MVColumnItem> getMVColumnItemList() {
+        return mvColumnItemList;
+    }
+
+    public String getBaseIndexName() {
+        return baseIndexName;
+    }
+
+    @Override
+    public void analyze(Analyzer analyzer) throws UserException {
+        FeNameFormat.checkTableName(mvName);
+        // TODO(ml): the mv name in from clause should pass the analyze without error.
+        selectStmt.analyze(analyzer);
+        analyzeSelectClause();
+        analyzeFromClause();
+        if (selectStmt.getWhereClause() != null) {
+            throw new AnalysisException("The where clause is not supported in add materialized view clause, expr:"
+                                                + selectStmt.getWhereClause().toSql());
+        }
+        if (selectStmt.getHavingPred() != null) {
+            throw new AnalysisException("The having clause is not supported in add materialized view clause, expr:"
+                                                + selectStmt.getHavingPred().toSql());
+        }
+        analyzeOrderByClause();
+        if (selectStmt.getLimit() != -1) {
+            throw new AnalysisException("The limit clause is not supported in add materialized view clause, expr:"
+                                                + " limit " + selectStmt.getLimit());
+        }
+    }
+
+    private void analyzeSelectClause() throws AnalysisException {
+        SelectList selectList = selectStmt.getSelectList();
+        if (selectList.getItems().isEmpty()) {
+            throw new AnalysisException("The materialized view must contain at least one column");
+        }
+        boolean meetAggregate = false;
+        Set<String> mvColumnNameSet = Sets.newHashSet();
+        /**
+         * 1. The columns of mv must be a single column or a aggregate column without any calculate.
+         *    Also the children of aggregate column must be a single column without any calculate.
+         *    For example:
+         *        a, sum(b) is legal.
+         *        a+b, sum(a+b) is illegal.
+         * 2. The SUM, MIN, MAX function is supported. The other function will be supported in the future.
+         * 3. The aggregate column must be declared after the single column.
+         */
+        for (SelectListItem selectListItem : selectList.getItems()) {
+            Expr selectListItemExpr = selectListItem.getExpr();
+            if (!(selectListItemExpr instanceof SlotRef) && !(selectListItemExpr instanceof FunctionCallExpr)) {
+                throw new AnalysisException("The materialized view only support the single column or function expr. "
+                                                    + "Error column: " + selectListItemExpr.toSql());
+            }
+            if (selectListItem.getExpr() instanceof SlotRef) {
+                if (meetAggregate) {
+                    throw new AnalysisException("The aggregate column should be after the single column");
+                }
+                SlotRef slotRef = (SlotRef) selectListItem.getExpr();
+                String columnName = slotRef.getColumnName().toLowerCase();
+                if (!mvColumnNameSet.add(columnName)) {
+                    ErrorReport.reportAnalysisException(ErrorCode.ERR_DUP_FIELDNAME, columnName);
+                }
+                MVColumnItem mvColumnItem = new MVColumnItem(columnName);
+                mvColumnItemList.add(mvColumnItem);
+            } else if (selectListItem.getExpr() instanceof FunctionCallExpr) {
+                FunctionCallExpr functionCallExpr = (FunctionCallExpr) selectListItem.getExpr();
+                String functionName = functionCallExpr.getFnName().getFunction();
+                // TODO(ml): support REPLACE, REPLACE_IF_NOT_NULL only for aggregate table, HLL_UNION, BITMAP_UNION
+                if (!functionName.equalsIgnoreCase("sum")
+                        && !functionName.equalsIgnoreCase("min")
+                        && !functionName.equalsIgnoreCase("max")) {
+                    throw new AnalysisException("The materialized view only support the sum, min and max aggregate "
+                                                        + "function. Error function: " + functionCallExpr.toSqlImpl());
+                }
+                Preconditions.checkState(functionCallExpr.getChildren().size() == 1);
+                Expr functionChild0 = functionCallExpr.getChild(0);
+                SlotRef slotRef;
+                if (functionChild0 instanceof SlotRef) {
+                    slotRef = (SlotRef) functionChild0;
+                }
+                else if (functionChild0 instanceof CastExpr
+                        && (functionChild0.getChild(0) instanceof SlotRef)) {
+                    slotRef = (SlotRef) functionChild0.getChild(0);
+                } else {
+                    throw new AnalysisException("The children of aggregate function only support one original column. "
+                                                        + "Error function: " + functionCallExpr.toSqlImpl());
+                }
+                meetAggregate = true;
+                String columnName = slotRef.getColumnName().toLowerCase();
+                if (!mvColumnNameSet.add(columnName)) {
+                    ErrorReport.reportAnalysisException(ErrorCode.ERR_DUP_FIELDNAME, columnName);
+                }
+                MVColumnItem mvColumnItem = new MVColumnItem(columnName);
+                mvColumnItem.setAggregationType(AggregateType.valueOf(functionName.toUpperCase()), false);
+                mvColumnItemList.add(mvColumnItem);
+            }
+        }
+        // TODO(ML): only value columns of materialized view, such as select sum(v1) from table
+    }
+
+    private void analyzeFromClause() throws AnalysisException {
+        List<TableRef> tableRefList = selectStmt.getTableRefs();
+        if (tableRefList.size() != 1) {
+            throw new AnalysisException("The materialized view only support one table in from clause.");
+        }
+        baseIndexName = tableRefList.get(0).getName().getTbl();
+    }
+
+    private void analyzeOrderByClause() throws AnalysisException {
+        if (selectStmt.getOrderByElements() == null) {
+            /**
+             * Supplement keys of MV columns
+             * For example: select k1, k2 ... kn , sum(v1), sum(v2) from t1
+             * The default key columns are first 36 bytes of the columns in define order.
+             * If the number of columns in the first 36 is less than 3, the first 3 columns will be used.
+             * column: k1, k2, k3... km. The key is true.
+             * Supplement non-key and non-value of MV columns
+             * column: km... kn. The key is false, aggregation type is none, isAggregationTypeImplicit is true.
+             */
+            int keyStorageLayoutBytes = 0;
+            for (int i = 0; i < selectStmt.getResultExprs().size(); i++) {
+                MVColumnItem mvColumnItem = mvColumnItemList.get(i);
+                Expr resultColumn = selectStmt.getResultExprs().get(i);
+                if (mvColumnItem.getAggregationType() != null) {
+                    break;
+                }
+                keyStorageLayoutBytes += resultColumn.getType().getStorageLayoutBytes();
+                if ((i + 1) <= Config.DEFAULT_DUP_KEYS_COUNT || keyStorageLayoutBytes < Config.DEFAULT_DUP_KEYS_BYTES) {
+                    mvColumnItem.setIsKey(true);
+                } else {
+                    mvColumnItem.setAggregationType(AggregateType.NONE, true);
+                }
+            }
+            return;
+        }
+
+        List<OrderByElement> orderByElements = selectStmt.getOrderByElements();
+        if (orderByElements.size() > mvColumnItemList.size()) {
+            throw new AnalysisException("The number of columns in order clause must be less then "
+                                                + "the number of columns in select clause");
+        }
+        for (int i = 0; i < orderByElements.size(); i++) {
+            Expr orderByElement = orderByElements.get(i).getExpr();
+            if (!(orderByElement instanceof SlotRef)) {
+                throw new AnalysisException("The column in order clause must be original column without calculation. "
+                                                    + "Error column: " + orderByElement.toSql());
+            }
+            MVColumnItem mvColumnItem = mvColumnItemList.get(i);
+            SlotRef slotRef = (SlotRef) orderByElement;
+            if (!mvColumnItem.getName().equalsIgnoreCase(slotRef.getColumnName())) {
+                throw new AnalysisException("The order of columns in order by clause must be same as "
+                                                    + "the order of columns in select list");
+            }
+            Preconditions.checkState(mvColumnItem.getAggregationType() == null);
+            mvColumnItem.setIsKey(true);
+        }
+
+        // supplement none aggregate type
+        for (MVColumnItem mvColumnItem : mvColumnItemList) {
+            if (mvColumnItem.isKey()) {
+                continue;
+            }
+            if (mvColumnItem.getAggregationType() != null) {
+                break;
+            }
+            mvColumnItem.setAggregationType(AggregateType.NONE, true);
+        }
+    }
+
+    @Override
+    public Map<String, String> getProperties() {
+        return properties;
+    }
+
+    @Override
+    public String toSql() {
+        return null;
+    }
+}

--- a/fe/src/main/java/org/apache/doris/analysis/AddRollupClause.java
+++ b/fe/src/main/java/org/apache/doris/analysis/AddRollupClause.java
@@ -18,11 +18,9 @@
 package org.apache.doris.analysis;
 
 import org.apache.doris.common.AnalysisException;
-import org.apache.doris.common.Config;
 import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.ErrorReport;
 import org.apache.doris.common.FeNameFormat;
-import org.apache.doris.common.util.PropertyAnalyzer;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
@@ -42,7 +40,6 @@ public class AddRollupClause extends AlterClause {
     private List<String> columnNames;
     private String baseRollupName;
     private List<String> dupKeys;
-    private long timeoutSecond;
 
     private Map<String, String> properties;
 
@@ -65,10 +62,6 @@ public class AddRollupClause extends AlterClause {
 
     public String getBaseRollupName() {
         return baseRollupName;
-    }
-
-    public long getTimeoutSecond() {
-        return timeoutSecond;
     }
 
     public AddRollupClause(String rollupName, List<String> columnNames,
@@ -98,8 +91,6 @@ public class AddRollupClause extends AlterClause {
             }
         }
         baseRollupName = Strings.emptyToNull(baseRollupName);
-
-        timeoutSecond = PropertyAnalyzer.analyzeTimeout(properties, Config.alter_table_timeout_second);
     }
 
     @Override

--- a/fe/src/main/java/org/apache/doris/analysis/AlterClause.java
+++ b/fe/src/main/java/org/apache/doris/analysis/AlterClause.java
@@ -17,23 +17,14 @@
 
 package org.apache.doris.analysis;
 
-import org.apache.doris.common.AnalysisException;
-
 import org.apache.commons.lang.NotImplementedException;
 
 import java.util.Map;
 
 // Alter table clause.
-public class AlterClause {
-    public void analyze(Analyzer analyzer) throws AnalysisException {
-        throw new NotImplementedException();
-    }
+public abstract class AlterClause implements ParseNode {
 
     public Map<String, String> getProperties() {
-        throw new NotImplementedException();
-    }
-
-    public String toSql() {
         throw new NotImplementedException();
     }
 }

--- a/fe/src/main/java/org/apache/doris/analysis/AlterClusterClause.java
+++ b/fe/src/main/java/org/apache/doris/analysis/AlterClusterClause.java
@@ -22,6 +22,8 @@ import org.apache.doris.common.Config;
 import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.ErrorReport;
 
+import org.apache.commons.lang.NotImplementedException;
+
 import java.util.Map;
 
 @Deprecated
@@ -59,7 +61,7 @@ public class AlterClusterClause extends AlterClause {
     @Override
     public String toSql() {
         // TODO Auto-generated method stub
-        return super.toSql();
+        throw new NotImplementedException();
     }
 
     public int getInstanceNum() {

--- a/fe/src/main/java/org/apache/doris/analysis/AlterSystemStmt.java
+++ b/fe/src/main/java/org/apache/doris/analysis/AlterSystemStmt.java
@@ -18,9 +18,9 @@
 package org.apache.doris.analysis;
 
 import org.apache.doris.catalog.Catalog;
-import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.ErrorReport;
+import org.apache.doris.common.UserException;
 import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.qe.ConnectContext;
 
@@ -39,7 +39,7 @@ public class AlterSystemStmt extends DdlStmt {
     }
 
     @Override
-    public void analyze(Analyzer analyzer) throws AnalysisException {
+    public void analyze(Analyzer analyzer) throws UserException {
 
         if (!Catalog.getCurrentCatalog().getAuth().checkGlobalPriv(ConnectContext.get(), PrivPredicate.OPERATOR)) {
             ErrorReport.reportAnalysisException(ErrorCode.ERR_SPECIFIC_ACCESS_DENIED_ERROR,

--- a/fe/src/main/java/org/apache/doris/analysis/CreateMaterializedViewStmt.java
+++ b/fe/src/main/java/org/apache/doris/analysis/CreateMaterializedViewStmt.java
@@ -22,6 +22,7 @@ import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.ErrorReport;
+import org.apache.doris.common.FeConstants;
 import org.apache.doris.common.FeNameFormat;
 import org.apache.doris.common.UserException;
 
@@ -228,7 +229,8 @@ public class CreateMaterializedViewStmt extends DdlStmt {
                 MVColumnItem mvColumnItem = mvColumnItemList.get(i);
                 Expr resultColumn = selectStmt.getResultExprs().get(i);
                 keyStorageLayoutBytes += resultColumn.getType().getStorageLayoutBytes();
-                if ((i + 1) <= Config.DEFAULT_DUP_KEYS_COUNT || keyStorageLayoutBytes < Config.DEFAULT_DUP_KEYS_BYTES) {
+                if ((i + 1) <= FeConstants.shortkey_max_column_count
+                        || keyStorageLayoutBytes < FeConstants.shortkey_maxsize_bytes) {
                     mvColumnItem.setIsKey(true);
                 } else {
                     mvColumnItem.setAggregationType(AggregateType.NONE, true);

--- a/fe/src/main/java/org/apache/doris/analysis/CreateTableStmt.java
+++ b/fe/src/main/java/org/apache/doris/analysis/CreateTableStmt.java
@@ -55,9 +55,6 @@ public class CreateTableStmt extends DdlStmt {
 
     private static final String DEFAULT_ENGINE_NAME = "olap";
 
-    private static final int DEFAULT_DUP_KEYS_COUNT = 3;
-    private static final int DEFAULT_DUP_KEYS_BYTES = 36;
-
     private boolean ifNotExists;
     private boolean isExternal;
     private TableName tableName;
@@ -236,7 +233,8 @@ public class CreateTableStmt extends DdlStmt {
                     } else {
                         for (ColumnDef columnDef : columnDefs) {
                             keyLength += columnDef.getType().getStorageLayoutBytes();
-                            if (keysColumnNames.size() < DEFAULT_DUP_KEYS_COUNT || keyLength < DEFAULT_DUP_KEYS_BYTES) {
+                            if (keysColumnNames.size() < Config.DEFAULT_DUP_KEYS_COUNT
+                                    || keyLength < Config.DEFAULT_DUP_KEYS_BYTES) {
                                 keysColumnNames.add(columnDef.getName());
                             }
                         }

--- a/fe/src/main/java/org/apache/doris/analysis/CreateTableStmt.java
+++ b/fe/src/main/java/org/apache/doris/analysis/CreateTableStmt.java
@@ -28,6 +28,7 @@ import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.ErrorReport;
+import org.apache.doris.common.FeConstants;
 import org.apache.doris.common.FeNameFormat;
 import org.apache.doris.common.NotImplementedException;
 import org.apache.doris.common.UserException;
@@ -233,8 +234,8 @@ public class CreateTableStmt extends DdlStmt {
                     } else {
                         for (ColumnDef columnDef : columnDefs) {
                             keyLength += columnDef.getType().getStorageLayoutBytes();
-                            if (keysColumnNames.size() < Config.DEFAULT_DUP_KEYS_COUNT
-                                    || keyLength < Config.DEFAULT_DUP_KEYS_BYTES) {
+                            if (keysColumnNames.size() < FeConstants.shortkey_max_column_count
+                                    || keyLength < FeConstants.shortkey_maxsize_bytes) {
                                 keysColumnNames.add(columnDef.getName());
                             }
                         }

--- a/fe/src/main/java/org/apache/doris/analysis/MVColumnItem.java
+++ b/fe/src/main/java/org/apache/doris/analysis/MVColumnItem.java
@@ -1,0 +1,62 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.analysis;
+
+import org.apache.doris.catalog.AggregateType;
+
+/**
+ * This is a result of semantic analysis for AddMaterializedViewClause.
+ * It is used to construct real mv column in MaterializedViewHandler.
+ * It does not include all of column properties.
+ * It just a intermediate variable between semantic analysis and final handler.
+ */
+public class MVColumnItem {
+    private String name;
+    private boolean isKey;
+    private AggregateType aggregationType;
+    private boolean isAggregationTypeImplicit;
+
+    public MVColumnItem(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setIsKey(boolean key) {
+        isKey = key;
+    }
+
+    public boolean isKey() {
+        return isKey;
+    }
+
+    public void setAggregationType(AggregateType aggregationType, boolean isAggregationTypeImplicit) {
+        this.aggregationType = aggregationType;
+        this.isAggregationTypeImplicit = isAggregationTypeImplicit;
+    }
+
+    public AggregateType getAggregationType() {
+        return aggregationType;
+    }
+
+    public boolean isAggregationTypeImplicit() {
+        return isAggregationTypeImplicit;
+    }
+}

--- a/fe/src/main/java/org/apache/doris/analysis/ParseNode.java
+++ b/fe/src/main/java/org/apache/doris/analysis/ParseNode.java
@@ -29,11 +29,11 @@ public interface ParseNode {
      * @param analyzer
      * @throws AnalysisException, InternalException
      */
-    public void analyze(Analyzer analyzer) throws AnalysisException, UserException;
+    void analyze(Analyzer analyzer) throws UserException;
 
     /**
      * @return SQL syntax corresponding to this node.
      */
-    public String toSql();
+    String toSql();
 
 }

--- a/fe/src/main/java/org/apache/doris/analysis/SelectStmt.java
+++ b/fe/src/main/java/org/apache/doris/analysis/SelectStmt.java
@@ -190,6 +190,10 @@ public class SelectStmt extends QueryStmt {
         return whereClause;
     }
 
+    public ArrayList<Expr> getGroupingExprs() {
+        return groupingExprs;
+    }
+
     public void setWhereClause(Expr whereClause) {
         this.whereClause = whereClause;
     }

--- a/fe/src/main/java/org/apache/doris/catalog/AggregateType.java
+++ b/fe/src/main/java/org/apache/doris/catalog/AggregateType.java
@@ -123,8 +123,8 @@ public enum AggregateType {
         return checkCompatibility(this, priType);
     }
 
-    public boolean isReplaceFamily(){
-        switch (this){
+    public boolean isReplaceFamily() {
+        switch (this) {
             case REPLACE:
             case REPLACE_IF_NOT_NULL:
                 return true;

--- a/fe/src/main/java/org/apache/doris/catalog/AggregateType.java
+++ b/fe/src/main/java/org/apache/doris/catalog/AggregateType.java
@@ -123,6 +123,16 @@ public enum AggregateType {
         return checkCompatibility(this, priType);
     }
 
+    public boolean isReplaceFamily(){
+        switch (this){
+            case REPLACE:
+            case REPLACE_IF_NOT_NULL:
+                return true;
+            default:
+                return false;
+        }
+    }
+
     public TAggregationType toThrift() {
         switch (this) {
             case SUM:

--- a/fe/src/main/java/org/apache/doris/catalog/Catalog.java
+++ b/fe/src/main/java/org/apache/doris/catalog/Catalog.java
@@ -40,6 +40,7 @@ import org.apache.doris.analysis.ColumnRenameClause;
 import org.apache.doris.analysis.CreateClusterStmt;
 import org.apache.doris.analysis.CreateDbStmt;
 import org.apache.doris.analysis.CreateFunctionStmt;
+import org.apache.doris.analysis.CreateMaterializedViewStmt;
 import org.apache.doris.analysis.CreateTableStmt;
 import org.apache.doris.analysis.CreateUserStmt;
 import org.apache.doris.analysis.CreateViewStmt;
@@ -4731,6 +4732,12 @@ public class Catalog {
      */
     public void alterTable(AlterTableStmt stmt) throws DdlException, UserException {
         this.alter.processAlterTable(stmt);
+    }
+
+    public void createMaterializedView(CreateMaterializedViewStmt stmt) throws AnalysisException, DdlException {
+        // TODO(ml): remove it
+//        throw new AnalysisException("The materialized view is coming soon");
+        this.alter.processCreateMaterializedView(stmt);
     }
 
     /*

--- a/fe/src/main/java/org/apache/doris/catalog/Catalog.java
+++ b/fe/src/main/java/org/apache/doris/catalog/Catalog.java
@@ -22,7 +22,7 @@ import org.apache.doris.alter.AlterJob;
 import org.apache.doris.alter.AlterJob.JobType;
 import org.apache.doris.alter.AlterJobV2;
 import org.apache.doris.alter.DecommissionBackendJob.DecommissionType;
-import org.apache.doris.alter.RollupHandler;
+import org.apache.doris.alter.MaterializedViewHandler;
 import org.apache.doris.alter.SchemaChangeHandler;
 import org.apache.doris.alter.SystemHandler;
 import org.apache.doris.analysis.AddPartitionClause;
@@ -4505,8 +4505,8 @@ public class Catalog {
         return (SchemaChangeHandler) this.alter.getSchemaChangeHandler();
     }
 
-    public RollupHandler getRollupHandler() {
-        return (RollupHandler) this.alter.getRollupHandler();
+    public MaterializedViewHandler getRollupHandler() {
+        return (MaterializedViewHandler) this.alter.getMaterializedViewHandler();
     }
 
     public SystemHandler getClusterHandler() {

--- a/fe/src/main/java/org/apache/doris/catalog/Catalog.java
+++ b/fe/src/main/java/org/apache/doris/catalog/Catalog.java
@@ -4736,8 +4736,8 @@ public class Catalog {
 
     public void createMaterializedView(CreateMaterializedViewStmt stmt) throws AnalysisException, DdlException {
         // TODO(ml): remove it
-//        throw new AnalysisException("The materialized view is coming soon");
-        this.alter.processCreateMaterializedView(stmt);
+        throw new AnalysisException("The materialized view is coming soon");
+//        this.alter.processCreateMaterializedView(stmt);
     }
 
     /*

--- a/fe/src/main/java/org/apache/doris/catalog/Column.java
+++ b/fe/src/main/java/org/apache/doris/catalog/Column.java
@@ -42,9 +42,14 @@ public class Column implements Writable {
     private static final Logger LOG = LogManager.getLogger(Column.class);
     private String name;
     private Type type;
+    // column is key: aggregate type is null
+    // column is not key and has no aggregate type: aggregate type is none
+    // column is not key and has aggregate type: aggregate type is name of aggregate function.
     private AggregateType aggregationType;
 
     // if isAggregationTypeImplicit is true, the actual aggregation type will not be shown in show create table
+    // the key type of table is duplicate or unique: the isAggregationTypeImplicit of value columns are true
+    // other cases: the isAggregationTypeImplicit is false
     private boolean isAggregationTypeImplicit;
     private boolean isKey;
     private boolean isAllowNull;

--- a/fe/src/main/java/org/apache/doris/catalog/KeysType.java
+++ b/fe/src/main/java/org/apache/doris/catalog/KeysType.java
@@ -25,6 +25,16 @@ public enum KeysType {
     UNIQUE_KEYS,
     AGG_KEYS;
 
+    public boolean isAggregationFamily(){
+        switch (this){
+            case AGG_KEYS:
+            case UNIQUE_KEYS:
+                return true;
+            default:
+                return false;
+        }
+    }
+
     public TKeysType toThrift() {
         switch (this) {
             case PRIMARY_KEYS:

--- a/fe/src/main/java/org/apache/doris/catalog/KeysType.java
+++ b/fe/src/main/java/org/apache/doris/catalog/KeysType.java
@@ -25,8 +25,8 @@ public enum KeysType {
     UNIQUE_KEYS,
     AGG_KEYS;
 
-    public boolean isAggregationFamily(){
-        switch (this){
+    public boolean isAggregationFamily() {
+        switch (this) {
             case AGG_KEYS:
             case UNIQUE_KEYS:
                 return true;

--- a/fe/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/src/main/java/org/apache/doris/common/Config.java
@@ -340,6 +340,9 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true, masterOnly = true)
     public static int max_layout_length_per_row = 100000; // 100k
 
+    public static final int DEFAULT_DUP_KEYS_COUNT = 3;
+    public static final int DEFAULT_DUP_KEYS_BYTES = 36;
+
     /*
      * Load checker's running interval.
      * A load job will transfer its state from PENDING to ETL to LOADING to FINISHED.

--- a/fe/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/src/main/java/org/apache/doris/common/Config.java
@@ -341,11 +341,11 @@ public class Config extends ConfigBase {
     public static int max_layout_length_per_row = 100000; // 100k
 
     /*
-     * The default number of keys in duplicate table.
+     * Those two fields is responsible for determining the default key columns in duplicate table.
      * If user does not specify key of duplicate table in create table stmt,
-     * the default keys will be supplemented by Doris.
+     * the default key columns will be supplemented by Doris.
      * The default key columns are first 36 bytes(DEFAULT_DUP_KEYS_BYTES) of the columns in define order.
-     * If the number of columns in the first 36 is less than 3(DEFAULT_DUP_KEYS_COUNT),
+     * If the number of key columns in the first 36 is less than 3(DEFAULT_DUP_KEYS_COUNT),
      * the first 3 columns will be used.
      */
     public static final int DEFAULT_DUP_KEYS_COUNT = 3;

--- a/fe/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/src/main/java/org/apache/doris/common/Config.java
@@ -341,17 +341,6 @@ public class Config extends ConfigBase {
     public static int max_layout_length_per_row = 100000; // 100k
 
     /*
-     * Those two fields is responsible for determining the default key columns in duplicate table.
-     * If user does not specify key of duplicate table in create table stmt,
-     * the default key columns will be supplemented by Doris.
-     * The default key columns are first 36 bytes(DEFAULT_DUP_KEYS_BYTES) of the columns in define order.
-     * If the number of key columns in the first 36 is less than 3(DEFAULT_DUP_KEYS_COUNT),
-     * the first 3 columns will be used.
-     */
-    public static final int DEFAULT_DUP_KEYS_COUNT = 3;
-    public static final int DEFAULT_DUP_KEYS_BYTES = 36;
-
-    /*
      * Load checker's running interval.
      * A load job will transfer its state from PENDING to ETL to LOADING to FINISHED.
      * So a load job will cost at least 3 check intervals to finish.

--- a/fe/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/src/main/java/org/apache/doris/common/Config.java
@@ -340,6 +340,14 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true, masterOnly = true)
     public static int max_layout_length_per_row = 100000; // 100k
 
+    /*
+     * The default number of keys in duplicate table.
+     * If user does not specify key of duplicate table in create table stmt,
+     * the default keys will be supplemented by Doris.
+     * The default key columns are first 36 bytes(DEFAULT_DUP_KEYS_BYTES) of the columns in define order.
+     * If the number of columns in the first 36 is less than 3(DEFAULT_DUP_KEYS_COUNT),
+     * the first 3 columns will be used.
+     */
     public static final int DEFAULT_DUP_KEYS_COUNT = 3;
     public static final int DEFAULT_DUP_KEYS_BYTES = 36;
 

--- a/fe/src/main/java/org/apache/doris/common/FeConstants.java
+++ b/fe/src/main/java/org/apache/doris/common/FeConstants.java
@@ -20,7 +20,15 @@ package org.apache.doris.common;
 public class FeConstants {
     // Database and table's default configurations, we will never change them
     public static short default_replication_num = 3;
-    public static int shortkey_max_column_count = 5;
+    /*
+     * Those two fields is responsible for determining the default key columns in duplicate table.
+     * If user does not specify key of duplicate table in create table stmt,
+     * the default key columns will be supplemented by Doris.
+     * The default key columns are first 36 bytes(DEFAULT_DUP_KEYS_BYTES) of the columns in define order.
+     * If the number of key columns in the first 36 is less than 3(DEFAULT_DUP_KEYS_COUNT),
+     * the first 3 columns will be used.
+     */
+    public static int shortkey_max_column_count = 3;
     public static int shortkey_maxsize_bytes = 36;
     public static long default_db_data_quota_bytes = 1024 * 1024 * 1024 * 1024L; // 1TB
 

--- a/fe/src/main/java/org/apache/doris/common/proc/JobsProcDir.java
+++ b/fe/src/main/java/org/apache/doris/common/proc/JobsProcDir.java
@@ -17,7 +17,7 @@
 
 package org.apache.doris.common.proc;
 
-import org.apache.doris.alter.RollupHandler;
+import org.apache.doris.alter.MaterializedViewHandler;
 import org.apache.doris.alter.SchemaChangeHandler;
 import org.apache.doris.catalog.Catalog;
 import org.apache.doris.catalog.Database;
@@ -118,12 +118,12 @@ public class JobsProcDir implements ProcDirInterface {
                                          cancelledNum.toString(), totalNum.toString()));
 
         // rollup
-        RollupHandler rollupHandler = Catalog.getInstance().getRollupHandler();
-        pendingNum = rollupHandler.getAlterJobV2Num(org.apache.doris.alter.AlterJobV2.JobState.PENDING, dbId);
-        runningNum = rollupHandler.getAlterJobV2Num(org.apache.doris.alter.AlterJobV2.JobState.WAITING_TXN, dbId)
-                + rollupHandler.getAlterJobV2Num(org.apache.doris.alter.AlterJobV2.JobState.RUNNING, dbId);
-        finishedNum = rollupHandler.getAlterJobV2Num(org.apache.doris.alter.AlterJobV2.JobState.FINISHED, dbId);
-        cancelledNum = rollupHandler.getAlterJobV2Num(org.apache.doris.alter.AlterJobV2.JobState.CANCELLED, dbId);
+        MaterializedViewHandler materializedViewHandler = Catalog.getInstance().getRollupHandler();
+        pendingNum = materializedViewHandler.getAlterJobV2Num(org.apache.doris.alter.AlterJobV2.JobState.PENDING, dbId);
+        runningNum = materializedViewHandler.getAlterJobV2Num(org.apache.doris.alter.AlterJobV2.JobState.WAITING_TXN, dbId)
+                + materializedViewHandler.getAlterJobV2Num(org.apache.doris.alter.AlterJobV2.JobState.RUNNING, dbId);
+        finishedNum = materializedViewHandler.getAlterJobV2Num(org.apache.doris.alter.AlterJobV2.JobState.FINISHED, dbId);
+        cancelledNum = materializedViewHandler.getAlterJobV2Num(org.apache.doris.alter.AlterJobV2.JobState.CANCELLED, dbId);
         totalNum = pendingNum + runningNum + finishedNum + cancelledNum;
         result.addRow(Lists.newArrayList(ROLLUP, pendingNum.toString(), runningNum.toString(), finishedNum.toString(),
                                          cancelledNum.toString(), totalNum.toString()));

--- a/fe/src/main/java/org/apache/doris/common/proc/RollupProcDir.java
+++ b/fe/src/main/java/org/apache/doris/common/proc/RollupProcDir.java
@@ -18,7 +18,7 @@
 package org.apache.doris.common.proc;
 
 import org.apache.doris.alter.AlterJobV2;
-import org.apache.doris.alter.RollupHandler;
+import org.apache.doris.alter.MaterializedViewHandler;
 import org.apache.doris.alter.RollupJobV2;
 import org.apache.doris.catalog.Database;
 import org.apache.doris.common.AnalysisException;
@@ -37,23 +37,23 @@ public class RollupProcDir implements ProcDirInterface {
             .add("State").add("Msg").add("Progress").add("Timeout")
             .build();
 
-    private RollupHandler rollupHandler;
+    private MaterializedViewHandler materializedViewHandler;
     private Database db;
 
-    public RollupProcDir(RollupHandler rollupHandler, Database db) {
-        this.rollupHandler = rollupHandler;
+    public RollupProcDir(MaterializedViewHandler materializedViewHandler, Database db) {
+        this.materializedViewHandler = materializedViewHandler;
         this.db = db;
     }
 
     @Override
     public ProcResult fetchResult() throws AnalysisException {
         Preconditions.checkNotNull(db);
-        Preconditions.checkNotNull(rollupHandler);
+        Preconditions.checkNotNull(materializedViewHandler);
 
         BaseProcResult result = new BaseProcResult();
         result.setNames(TITLE_NAMES);
 
-        List<List<Comparable>> rollupJobInfos = rollupHandler.getAlterJobInfosByDb(db);
+        List<List<Comparable>> rollupJobInfos = materializedViewHandler.getAlterJobInfosByDb(db);
         for (List<Comparable> infoStr : rollupJobInfos) {
             List<String> oneInfo = new ArrayList<String>(TITLE_NAMES.size());
             for (Comparable element : infoStr) {
@@ -83,7 +83,7 @@ public class RollupProcDir implements ProcDirInterface {
         }
 
         Preconditions.checkState(jobId != -1L);
-        AlterJobV2 job = rollupHandler.getUnfinishedAlterJobV2(jobId);
+        AlterJobV2 job = materializedViewHandler.getUnfinishedAlterJobV2(jobId);
         if (job == null) {
             return null;
         }

--- a/fe/src/main/java/org/apache/doris/common/util/KuduUtil.java
+++ b/fe/src/main/java/org/apache/doris/common/util/KuduUtil.java
@@ -305,7 +305,7 @@ public class KuduUtil {
 
     public static void analyzeKeyDesc(KeysDesc keysDesc) throws AnalysisException {
         if (keysDesc.getKeysType() != KeysType.PRIMARY_KEYS) {
-            throw new AnalysisException("Create kudu table shoudl specify PRIMARY KEYS");
+            throw new AnalysisException("Create kudu table should specify PRIMARY KEYS");
         }
     }
 

--- a/fe/src/main/java/org/apache/doris/master/MasterImpl.java
+++ b/fe/src/main/java/org/apache/doris/master/MasterImpl.java
@@ -19,7 +19,7 @@ package org.apache.doris.master;
 
 import org.apache.doris.alter.AlterJob;
 import org.apache.doris.alter.AlterJobV2.JobType;
-import org.apache.doris.alter.RollupHandler;
+import org.apache.doris.alter.MaterializedViewHandler;
 import org.apache.doris.alter.RollupJob;
 import org.apache.doris.alter.SchemaChangeHandler;
 import org.apache.doris.alter.SchemaChangeJob;
@@ -383,8 +383,8 @@ public class MasterImpl {
         MaterializedIndex index = partition.getIndex(indexId);
         if (index == null) { 
             // this means the index is under rollup
-            RollupHandler rollupHandler = Catalog.getInstance().getRollupHandler();
-            AlterJob alterJob = rollupHandler.getAlterJob(olapTable.getId());
+            MaterializedViewHandler materializedViewHandler = Catalog.getInstance().getRollupHandler();
+            AlterJob alterJob = materializedViewHandler.getAlterJob(olapTable.getId());
             if (alterJob == null && olapTable.getState() == OlapTableState.ROLLUP) {
                 // this happens when:
                 // a rollup job is finish and a delete job is the next first job (no load job before)
@@ -608,8 +608,8 @@ public class MasterImpl {
                 return null;
             }
 
-            RollupHandler rollupHandler = Catalog.getInstance().getRollupHandler();
-            AlterJob alterJob = rollupHandler.getAlterJob(olapTable.getId());
+            MaterializedViewHandler materializedViewHandler = Catalog.getInstance().getRollupHandler();
+            AlterJob alterJob = materializedViewHandler.getAlterJob(olapTable.getId());
             if (alterJob == null) {
                 // this happends when:
                 // a rollup job is finish and a delete job is the next first job (no load job before)
@@ -689,8 +689,8 @@ public class MasterImpl {
         Preconditions.checkArgument(finishTabletInfos.size() == 1);
 
         CreateRollupTask createRollupTask = (CreateRollupTask) task;
-        RollupHandler rollupHandler = Catalog.getInstance().getRollupHandler();
-        rollupHandler.handleFinishedReplica(createRollupTask, finishTabletInfos.get(0), -1L);
+        MaterializedViewHandler materializedViewHandler = Catalog.getInstance().getRollupHandler();
+        materializedViewHandler.handleFinishedReplica(createRollupTask, finishTabletInfos.get(0), -1L);
         AgentTaskQueue.removeTask(task.getBackendId(), TTaskType.ROLLUP, task.getSignature());
     }
 

--- a/fe/src/main/java/org/apache/doris/metric/MetricRepo.java
+++ b/fe/src/main/java/org/apache/doris/metric/MetricRepo.java
@@ -129,7 +129,7 @@ public final class MetricRepo {
                     if (jobType == JobType.SCHEMA_CHANGE) {
                         return alter.getSchemaChangeHandler().getAlterJobV2Num(org.apache.doris.alter.AlterJobV2.JobState.RUNNING);
                     } else {
-                        return alter.getRollupHandler().getAlterJobV2Num(org.apache.doris.alter.AlterJobV2.JobState.RUNNING);
+                        return alter.getMaterializedViewHandler().getAlterJobV2Num(org.apache.doris.alter.AlterJobV2.JobState.RUNNING);
                     }
                 }
             };

--- a/fe/src/main/java/org/apache/doris/qe/DdlExecutor.java
+++ b/fe/src/main/java/org/apache/doris/qe/DdlExecutor.java
@@ -34,6 +34,7 @@ import org.apache.doris.analysis.CreateClusterStmt;
 import org.apache.doris.analysis.CreateDbStmt;
 import org.apache.doris.analysis.CreateFileStmt;
 import org.apache.doris.analysis.CreateFunctionStmt;
+import org.apache.doris.analysis.CreateMaterializedViewStmt;
 import org.apache.doris.analysis.CreateRepositoryStmt;
 import org.apache.doris.analysis.CreateRoleStmt;
 import org.apache.doris.analysis.CreateRoutineLoadStmt;
@@ -96,6 +97,8 @@ public class DdlExecutor {
             catalog.createTable((CreateTableStmt) ddlStmt);
         } else if (ddlStmt instanceof DropTableStmt) {
             catalog.dropTable((DropTableStmt) ddlStmt);
+        } else if (ddlStmt instanceof CreateMaterializedViewStmt) {
+            catalog.createMaterializedView((CreateMaterializedViewStmt) ddlStmt);
         } else if (ddlStmt instanceof AlterTableStmt) {
             catalog.alterTable((AlterTableStmt) ddlStmt);
         } else if (ddlStmt instanceof CancelAlterTableStmt) {

--- a/fe/src/main/jflex/sql_scanner.flex
+++ b/fe/src/main/jflex/sql_scanner.flex
@@ -346,6 +346,7 @@ import org.apache.doris.qe.SqlModeHelper;
         keywordMap.put("varchar", new Integer(SqlParserSymbols.KW_VARCHAR));
         keywordMap.put("variables", new Integer(SqlParserSymbols.KW_VARIABLES));
         keywordMap.put("view", new Integer(SqlParserSymbols.KW_VIEW));
+        keywordMap.put("materialized", new Integer(SqlParserSymbols.KW_MATERIALIZED));
         keywordMap.put("warnings", new Integer(SqlParserSymbols.KW_WARNINGS));
         keywordMap.put("whitelist", new Integer(SqlParserSymbols.KW_WHITELIST));
         keywordMap.put("when", new Integer(SqlParserSymbols.KW_WHEN));

--- a/fe/src/test/java/org/apache/doris/alter/MaterializedViewHandlerTest.java
+++ b/fe/src/test/java/org/apache/doris/alter/MaterializedViewHandlerTest.java
@@ -1,0 +1,268 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.alter;
+
+import org.apache.doris.analysis.AddMaterializedViewClause;
+import org.apache.doris.analysis.MVColumnItem;
+import org.apache.doris.catalog.AggregateType;
+import org.apache.doris.catalog.Column;
+import org.apache.doris.catalog.Database;
+import org.apache.doris.catalog.KeysType;
+import org.apache.doris.catalog.MaterializedIndex;
+import org.apache.doris.catalog.OlapTable;
+import org.apache.doris.catalog.Partition;
+import org.apache.doris.catalog.Type;
+import org.apache.doris.common.jmockit.Deencapsulation;
+
+import com.google.common.collect.Lists;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.List;
+
+import mockit.Expectations;
+import mockit.Injectable;
+
+public class MaterializedViewHandlerTest {
+    @Test
+    public void testDifferentBaseTable(@Injectable AddMaterializedViewClause addMVClause,
+                                       @Injectable Database db,
+                                       @Injectable OlapTable olapTable) {
+        new Expectations() {
+            {
+                addMVClause.getBaseIndexName();
+                result = "t1";
+                olapTable.getName();
+                result = "t2";
+            }
+        };
+        MaterializedViewHandler materializedViewHandler = new MaterializedViewHandler();
+        try {
+            Deencapsulation.invoke(materializedViewHandler, "processAddMaterializedView", addMVClause, db, olapTable);
+            Assert.fail();
+        } catch (Exception e) {
+            System.out.print(e.getMessage());
+        }
+    }
+
+    @Test
+    public void testNotNormalTable(@Injectable AddMaterializedViewClause addMVClause,
+                                   @Injectable Database db,
+                                   @Injectable OlapTable olapTable) {
+        final String baseIndexName = "t1";
+        new Expectations() {
+            {
+                addMVClause.getBaseIndexName();
+                result = baseIndexName;
+                olapTable.getName();
+                result = baseIndexName;
+                olapTable.getState();
+                result = OlapTable.OlapTableState.ROLLUP;
+            }
+        };
+        MaterializedViewHandler materializedViewHandler = new MaterializedViewHandler();
+        try {
+            Deencapsulation.invoke(materializedViewHandler, "processAddMaterializedView", addMVClause, db, olapTable);
+            Assert.fail();
+        } catch (Exception e) {
+            System.out.print(e.getMessage());
+        }
+    }
+
+    @Test
+    public void testErrorBaseIndexName(@Injectable AddMaterializedViewClause addMVClause,
+                                       @Injectable Database db,
+                                       @Injectable OlapTable olapTable) {
+        final String baseIndexName = "t1";
+        new Expectations() {
+            {
+                addMVClause.getBaseIndexName();
+                result = baseIndexName;
+                olapTable.getName();
+                result = baseIndexName;
+                olapTable.getState();
+                result = OlapTable.OlapTableState.NORMAL;
+                olapTable.getIndexIdByName(baseIndexName);
+                result = null;
+            }
+        };
+        MaterializedViewHandler materializedViewHandler = new MaterializedViewHandler();
+        try {
+            Deencapsulation.invoke(materializedViewHandler, "processAddMaterializedView", addMVClause, db, olapTable);
+            Assert.fail();
+        } catch (Exception e) {
+            System.out.print(e.getMessage());
+        }
+    }
+
+    @Test
+    public void testRollupReplica(@Injectable AddMaterializedViewClause addMVClause,
+                                  @Injectable Database db,
+                                  @Injectable OlapTable olapTable,
+                                  @Injectable Partition partition,
+                                  @Injectable MaterializedIndex materializedIndex) {
+        final String baseIndexName = "t1";
+        final Long baseIndexId = new Long(1);
+        new Expectations() {
+            {
+                addMVClause.getBaseIndexName();
+                result = baseIndexName;
+                olapTable.getName();
+                result = baseIndexName;
+                olapTable.getState();
+                result = OlapTable.OlapTableState.NORMAL;
+                olapTable.getIndexIdByName(baseIndexName);
+                result = baseIndexId;
+                olapTable.getPartitions();
+                result = Lists.newArrayList(partition);
+                partition.getIndex(baseIndexId);
+                result =  materializedIndex;
+                materializedIndex.getState();
+                result = MaterializedIndex.IndexState.SHADOW;
+            }
+        };
+        MaterializedViewHandler materializedViewHandler = new MaterializedViewHandler();
+        try {
+            Deencapsulation.invoke(materializedViewHandler, "processAddMaterializedView", addMVClause, db, olapTable);
+            Assert.fail();
+        } catch (Exception e) {
+            System.out.print(e.getMessage());
+        }
+    }
+
+    @Test
+    public void testDuplicateMVName(@Injectable AddMaterializedViewClause addMVClause,
+                                  @Injectable OlapTable olapTable) {
+        final String mvName = "mv1";
+        new Expectations() {
+            {
+                olapTable.hasMaterializedIndex(mvName);
+                result = true;
+                addMVClause.getMVName();
+                result = mvName;
+            }
+        };
+        MaterializedViewHandler materializedViewHandler = new MaterializedViewHandler();
+        try {
+            Deencapsulation.invoke(materializedViewHandler, "checkAndPrepareMaterializedView", addMVClause, olapTable);
+            Assert.fail();
+        } catch (Exception e) {
+            System.out.print(e.getMessage());
+        }
+    }
+
+    @Test
+    public void testInvalidMVColumn(@Injectable AddMaterializedViewClause addMVClause,
+                                    @Injectable OlapTable olapTable) {
+        final String mvName = "mv1";
+        final String mvColumnName = "mv_k1";
+        MVColumnItem mvColumnItem = new MVColumnItem(mvColumnName);
+        new Expectations() {
+            {
+                olapTable.hasMaterializedIndex(mvName);
+                result = false;
+                addMVClause.getMVName();
+                result = mvName;
+                addMVClause.getMVColumnItemList();
+                result = Lists.newArrayList(mvColumnItem);
+                olapTable.getColumn(mvColumnName);
+                result = null;
+            }
+        };
+        MaterializedViewHandler materializedViewHandler = new MaterializedViewHandler();
+        try {
+            Deencapsulation.invoke(materializedViewHandler, "checkAndPrepareMaterializedView", addMVClause, olapTable);
+            Assert.fail();
+        } catch (Exception e) {
+            System.out.print(e.getMessage());
+        }
+    }
+
+    @Test
+    public void testInvalidAggregateType(@Injectable AddMaterializedViewClause addMVClause,
+                                         @Injectable OlapTable olapTable) {
+        final String mvName = "mv1";
+        final String columnName = "mv_k1";
+        Column baseColumn = new Column(columnName, Type.INT, false, AggregateType.SUM, "", "");
+        MVColumnItem mvColumnItem = new MVColumnItem(columnName);
+        mvColumnItem.setIsKey(true);
+        mvColumnItem.setAggregationType(null, false);
+        new Expectations() {
+            {
+                olapTable.hasMaterializedIndex(mvName);
+                result = false;
+                addMVClause.getMVName();
+                result = mvName;
+                addMVClause.getMVColumnItemList();
+                result = Lists.newArrayList(mvColumnItem);
+                olapTable.getColumn(columnName);
+                result = baseColumn;
+                olapTable.getKeysType();
+                result = KeysType.AGG_KEYS;
+            }
+        };
+        MaterializedViewHandler materializedViewHandler = new MaterializedViewHandler();
+        try {
+            Deencapsulation.invoke(materializedViewHandler, "checkAndPrepareMaterializedView", addMVClause, olapTable);
+            Assert.fail();
+        } catch (Exception e) {
+            System.out.print(e.getMessage());
+        }
+    }
+
+    @Test
+    public void testDuplicateTable(@Injectable AddMaterializedViewClause addMVClause,
+                                   @Injectable OlapTable olapTable) {
+        final String mvName = "mv1";
+        final String columnName1 = "k1";
+        Column baseColumn1 = new Column(columnName1, Type.VARCHAR, false, AggregateType.NONE, "", "");
+        MVColumnItem mvColumnItem = new MVColumnItem(columnName1);
+        mvColumnItem.setIsKey(true);
+        mvColumnItem.setAggregationType(null, false);
+        new Expectations() {
+            {
+                olapTable.hasMaterializedIndex(mvName);
+                result = false;
+                addMVClause.getMVName();
+                result = mvName;
+                addMVClause.getMVColumnItemList();
+                result = Lists.newArrayList(mvColumnItem);
+                olapTable.getColumn(columnName1);
+                result = baseColumn1;
+                olapTable.getKeysType();
+                result = KeysType.DUP_KEYS;
+            }
+        };
+        MaterializedViewHandler materializedViewHandler = new MaterializedViewHandler();
+        try {
+            List<Column> mvColumns = Deencapsulation.invoke(materializedViewHandler,
+                                                            "checkAndPrepareMaterializedView", addMVClause, olapTable);
+            Assert.assertEquals(1, mvColumns.size());
+            Column newMVColumn = mvColumns.get(0);
+            Assert.assertEquals(columnName1, newMVColumn.getName());
+            Assert.assertTrue(newMVColumn.isKey());
+            Assert.assertEquals(null, newMVColumn.getAggregationType());
+            Assert.assertEquals(false, newMVColumn.isAggregationTypeImplicit());
+            Assert.assertEquals(Type.VARCHAR, newMVColumn.getType());
+        } catch (Exception e) {
+            Assert.fail(e.getMessage());
+        }
+    }
+
+}

--- a/fe/src/test/java/org/apache/doris/alter/MaterializedViewHandlerTest.java
+++ b/fe/src/test/java/org/apache/doris/alter/MaterializedViewHandlerTest.java
@@ -17,7 +17,7 @@
 
 package org.apache.doris.alter;
 
-import org.apache.doris.analysis.AddMaterializedViewClause;
+import org.apache.doris.analysis.CreateMaterializedViewStmt;
 import org.apache.doris.analysis.MVColumnItem;
 import org.apache.doris.catalog.AggregateType;
 import org.apache.doris.catalog.Column;
@@ -41,12 +41,12 @@ import mockit.Injectable;
 
 public class MaterializedViewHandlerTest {
     @Test
-    public void testDifferentBaseTable(@Injectable AddMaterializedViewClause addMVClause,
+    public void testDifferentBaseTable(@Injectable CreateMaterializedViewStmt createMaterializedViewStmt,
                                        @Injectable Database db,
                                        @Injectable OlapTable olapTable) {
         new Expectations() {
             {
-                addMVClause.getBaseIndexName();
+                createMaterializedViewStmt.getBaseIndexName();
                 result = "t1";
                 olapTable.getName();
                 result = "t2";
@@ -54,7 +54,8 @@ public class MaterializedViewHandlerTest {
         };
         MaterializedViewHandler materializedViewHandler = new MaterializedViewHandler();
         try {
-            Deencapsulation.invoke(materializedViewHandler, "processAddMaterializedView", addMVClause, db, olapTable);
+            Deencapsulation.invoke(materializedViewHandler, "processCreateMaterializedView", createMaterializedViewStmt,
+                                   db, olapTable);
             Assert.fail();
         } catch (Exception e) {
             System.out.print(e.getMessage());
@@ -62,13 +63,13 @@ public class MaterializedViewHandlerTest {
     }
 
     @Test
-    public void testNotNormalTable(@Injectable AddMaterializedViewClause addMVClause,
+    public void testNotNormalTable(@Injectable CreateMaterializedViewStmt createMaterializedViewStmt,
                                    @Injectable Database db,
                                    @Injectable OlapTable olapTable) {
         final String baseIndexName = "t1";
         new Expectations() {
             {
-                addMVClause.getBaseIndexName();
+                createMaterializedViewStmt.getBaseIndexName();
                 result = baseIndexName;
                 olapTable.getName();
                 result = baseIndexName;
@@ -78,7 +79,8 @@ public class MaterializedViewHandlerTest {
         };
         MaterializedViewHandler materializedViewHandler = new MaterializedViewHandler();
         try {
-            Deencapsulation.invoke(materializedViewHandler, "processAddMaterializedView", addMVClause, db, olapTable);
+            Deencapsulation.invoke(materializedViewHandler, "processCreateMaterializedView", createMaterializedViewStmt,
+                                   db, olapTable);
             Assert.fail();
         } catch (Exception e) {
             System.out.print(e.getMessage());
@@ -86,13 +88,13 @@ public class MaterializedViewHandlerTest {
     }
 
     @Test
-    public void testErrorBaseIndexName(@Injectable AddMaterializedViewClause addMVClause,
+    public void testErrorBaseIndexName(@Injectable CreateMaterializedViewStmt createMaterializedViewStmt,
                                        @Injectable Database db,
                                        @Injectable OlapTable olapTable) {
         final String baseIndexName = "t1";
         new Expectations() {
             {
-                addMVClause.getBaseIndexName();
+                createMaterializedViewStmt.getBaseIndexName();
                 result = baseIndexName;
                 olapTable.getName();
                 result = baseIndexName;
@@ -104,7 +106,8 @@ public class MaterializedViewHandlerTest {
         };
         MaterializedViewHandler materializedViewHandler = new MaterializedViewHandler();
         try {
-            Deencapsulation.invoke(materializedViewHandler, "processAddMaterializedView", addMVClause, db, olapTable);
+            Deencapsulation.invoke(materializedViewHandler, "processCreateMaterializedView",
+                                   createMaterializedViewStmt, db, olapTable);
             Assert.fail();
         } catch (Exception e) {
             System.out.print(e.getMessage());
@@ -112,7 +115,7 @@ public class MaterializedViewHandlerTest {
     }
 
     @Test
-    public void testRollupReplica(@Injectable AddMaterializedViewClause addMVClause,
+    public void testRollupReplica(@Injectable CreateMaterializedViewStmt createMaterializedViewStmt,
                                   @Injectable Database db,
                                   @Injectable OlapTable olapTable,
                                   @Injectable Partition partition,
@@ -121,7 +124,7 @@ public class MaterializedViewHandlerTest {
         final Long baseIndexId = new Long(1);
         new Expectations() {
             {
-                addMVClause.getBaseIndexName();
+                createMaterializedViewStmt.getBaseIndexName();
                 result = baseIndexName;
                 olapTable.getName();
                 result = baseIndexName;
@@ -139,7 +142,8 @@ public class MaterializedViewHandlerTest {
         };
         MaterializedViewHandler materializedViewHandler = new MaterializedViewHandler();
         try {
-            Deencapsulation.invoke(materializedViewHandler, "processAddMaterializedView", addMVClause, db, olapTable);
+            Deencapsulation.invoke(materializedViewHandler, "processCreateMaterializedView",
+                                   createMaterializedViewStmt, db, olapTable);
             Assert.fail();
         } catch (Exception e) {
             System.out.print(e.getMessage());
@@ -147,20 +151,21 @@ public class MaterializedViewHandlerTest {
     }
 
     @Test
-    public void testDuplicateMVName(@Injectable AddMaterializedViewClause addMVClause,
-                                  @Injectable OlapTable olapTable) {
+    public void testDuplicateMVName(@Injectable CreateMaterializedViewStmt createMaterializedViewStmt,
+                                    @Injectable OlapTable olapTable) {
         final String mvName = "mv1";
         new Expectations() {
             {
                 olapTable.hasMaterializedIndex(mvName);
                 result = true;
-                addMVClause.getMVName();
+                createMaterializedViewStmt.getMVName();
                 result = mvName;
             }
         };
         MaterializedViewHandler materializedViewHandler = new MaterializedViewHandler();
         try {
-            Deencapsulation.invoke(materializedViewHandler, "checkAndPrepareMaterializedView", addMVClause, olapTable);
+            Deencapsulation.invoke(materializedViewHandler, "checkAndPrepareMaterializedView",
+                                   createMaterializedViewStmt, olapTable);
             Assert.fail();
         } catch (Exception e) {
             System.out.print(e.getMessage());
@@ -168,7 +173,7 @@ public class MaterializedViewHandlerTest {
     }
 
     @Test
-    public void testInvalidMVColumn(@Injectable AddMaterializedViewClause addMVClause,
+    public void testInvalidMVColumn(@Injectable CreateMaterializedViewStmt createMaterializedViewStmt,
                                     @Injectable OlapTable olapTable) {
         final String mvName = "mv1";
         final String mvColumnName = "mv_k1";
@@ -177,9 +182,9 @@ public class MaterializedViewHandlerTest {
             {
                 olapTable.hasMaterializedIndex(mvName);
                 result = false;
-                addMVClause.getMVName();
+                createMaterializedViewStmt.getMVName();
                 result = mvName;
-                addMVClause.getMVColumnItemList();
+                createMaterializedViewStmt.getMVColumnItemList();
                 result = Lists.newArrayList(mvColumnItem);
                 olapTable.getColumn(mvColumnName);
                 result = null;
@@ -187,7 +192,8 @@ public class MaterializedViewHandlerTest {
         };
         MaterializedViewHandler materializedViewHandler = new MaterializedViewHandler();
         try {
-            Deencapsulation.invoke(materializedViewHandler, "checkAndPrepareMaterializedView", addMVClause, olapTable);
+            Deencapsulation.invoke(materializedViewHandler, "checkAndPrepareMaterializedView",
+                                   createMaterializedViewStmt, olapTable);
             Assert.fail();
         } catch (Exception e) {
             System.out.print(e.getMessage());
@@ -195,7 +201,7 @@ public class MaterializedViewHandlerTest {
     }
 
     @Test
-    public void testInvalidAggregateType(@Injectable AddMaterializedViewClause addMVClause,
+    public void testInvalidAggregateType(@Injectable CreateMaterializedViewStmt createMaterializedViewStmt,
                                          @Injectable OlapTable olapTable) {
         final String mvName = "mv1";
         final String columnName = "mv_k1";
@@ -207,9 +213,9 @@ public class MaterializedViewHandlerTest {
             {
                 olapTable.hasMaterializedIndex(mvName);
                 result = false;
-                addMVClause.getMVName();
+                createMaterializedViewStmt.getMVName();
                 result = mvName;
-                addMVClause.getMVColumnItemList();
+                createMaterializedViewStmt.getMVColumnItemList();
                 result = Lists.newArrayList(mvColumnItem);
                 olapTable.getColumn(columnName);
                 result = baseColumn;
@@ -219,7 +225,8 @@ public class MaterializedViewHandlerTest {
         };
         MaterializedViewHandler materializedViewHandler = new MaterializedViewHandler();
         try {
-            Deencapsulation.invoke(materializedViewHandler, "checkAndPrepareMaterializedView", addMVClause, olapTable);
+            Deencapsulation.invoke(materializedViewHandler, "checkAndPrepareMaterializedView",
+                                   createMaterializedViewStmt, olapTable);
             Assert.fail();
         } catch (Exception e) {
             System.out.print(e.getMessage());
@@ -227,7 +234,7 @@ public class MaterializedViewHandlerTest {
     }
 
     @Test
-    public void testDuplicateTable(@Injectable AddMaterializedViewClause addMVClause,
+    public void testDuplicateTable(@Injectable CreateMaterializedViewStmt createMaterializedViewStmt,
                                    @Injectable OlapTable olapTable) {
         final String mvName = "mv1";
         final String columnName1 = "k1";
@@ -239,9 +246,9 @@ public class MaterializedViewHandlerTest {
             {
                 olapTable.hasMaterializedIndex(mvName);
                 result = false;
-                addMVClause.getMVName();
+                createMaterializedViewStmt.getMVName();
                 result = mvName;
-                addMVClause.getMVColumnItemList();
+                createMaterializedViewStmt.getMVColumnItemList();
                 result = Lists.newArrayList(mvColumnItem);
                 olapTable.getColumn(columnName1);
                 result = baseColumn1;
@@ -252,7 +259,8 @@ public class MaterializedViewHandlerTest {
         MaterializedViewHandler materializedViewHandler = new MaterializedViewHandler();
         try {
             List<Column> mvColumns = Deencapsulation.invoke(materializedViewHandler,
-                                                            "checkAndPrepareMaterializedView", addMVClause, olapTable);
+                                                            "checkAndPrepareMaterializedView",
+                                                            createMaterializedViewStmt, olapTable);
             Assert.assertEquals(1, mvColumns.size());
             Column newMVColumn = mvColumns.get(0);
             Assert.assertEquals(columnName1, newMVColumn.getName());

--- a/fe/src/test/java/org/apache/doris/analysis/AccessTestUtil.java
+++ b/fe/src/test/java/org/apache/doris/analysis/AccessTestUtil.java
@@ -17,7 +17,7 @@
 
 package org.apache.doris.analysis;
 
-import org.apache.doris.alter.RollupHandler;
+import org.apache.doris.alter.MaterializedViewHandler;
 import org.apache.doris.alter.SchemaChangeHandler;
 import org.apache.doris.catalog.BrokerMgr;
 import org.apache.doris.catalog.Catalog;
@@ -101,7 +101,7 @@ public class AccessTestUtil {
             EasyMock.expect(catalog.getDbNames()).andReturn(Lists.newArrayList("testCluster:testDb")).anyTimes();
             EasyMock.expect(catalog.getLoadInstance()).andReturn(new Load()).anyTimes();
             EasyMock.expect(catalog.getSchemaChangeHandler()).andReturn(new SchemaChangeHandler()).anyTimes();
-            EasyMock.expect(catalog.getRollupHandler()).andReturn(new RollupHandler()).anyTimes();
+            EasyMock.expect(catalog.getRollupHandler()).andReturn(new MaterializedViewHandler()).anyTimes();
             EasyMock.expect(catalog.getEditLog()).andReturn(EasyMock.createMock(EditLog.class)).anyTimes();
             EasyMock.expect(catalog.getClusterDbNames("testCluster")).andReturn(Lists.newArrayList("testCluster:testDb")).anyTimes();
             catalog.changeDb(EasyMock.isA(ConnectContext.class), EasyMock.eq("blockDb"));

--- a/fe/src/test/java/org/apache/doris/analysis/AddMaterializedViewClauseTest.java
+++ b/fe/src/test/java/org/apache/doris/analysis/AddMaterializedViewClauseTest.java
@@ -1,0 +1,490 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.analysis;
+
+import org.apache.doris.catalog.AggregateType;
+import org.apache.doris.common.UserException;
+
+import com.google.common.collect.Lists;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import mockit.Expectations;
+import mockit.Injectable;
+import mockit.Mocked;
+
+public class AddMaterializedViewClauseTest {
+
+    @Mocked
+    private Analyzer analyzer;
+    @Mocked
+    private ExprSubstitutionMap exprSubstitutionMap;
+
+    @Test
+    public void testFunctionColumnInSelectClause(@Injectable ArithmeticExpr arithmeticExpr) {
+        SelectList selectList = new SelectList();
+        SelectListItem selectListItem = new SelectListItem(arithmeticExpr, null);
+        selectList.addItem(selectListItem);
+        FromClause fromClause = new FromClause();
+        SelectStmt selectStmt = new SelectStmt(selectList, fromClause, null, null, null, null, LimitElement.NO_LIMIT);
+
+        new Expectations() {
+            {
+                analyzer.getClusterName();
+                result = "default";
+            }
+        };
+        AddMaterializedViewClause addMaterializedViewClause = new AddMaterializedViewClause("test", selectStmt, null);
+        try {
+            addMaterializedViewClause.analyze(analyzer);
+            Assert.fail();
+        } catch (UserException e) {
+            System.out.print(e.getMessage());
+        }
+    }
+
+    @Test
+    public void testAggregateWithFunctionColumnInSelectClause(@Injectable ArithmeticExpr arithmeticExpr,
+                                                              @Injectable SelectStmt selectStmt) throws UserException {
+        FunctionCallExpr functionCallExpr = new FunctionCallExpr("sum", Lists.newArrayList(arithmeticExpr));
+        SelectList selectList = new SelectList();
+        SelectListItem selectListItem = new SelectListItem(functionCallExpr, null);
+        selectList.addItem(selectListItem);
+        new Expectations() {
+            {
+                selectStmt.analyze(analyzer);
+                selectStmt.getSelectList();
+                result = selectList;
+                arithmeticExpr.toSql();
+                result = "a+b";
+            }
+        };
+
+        AddMaterializedViewClause addMaterializedViewClause = new AddMaterializedViewClause("test", selectStmt, null);
+        try {
+            addMaterializedViewClause.analyze(analyzer);
+            Assert.fail();
+        } catch (UserException e) {
+            System.out.print(e.getMessage());
+        }
+    }
+
+    @Test
+    public void testJoinSelectClause(@Injectable SlotRef slotRef,
+                                     @Injectable TableRef tableRef1,
+                                     @Injectable TableRef tableRef2,
+                                     @Injectable SelectStmt selectStmt) throws UserException {
+        SelectListItem selectListItem = new SelectListItem(slotRef, null);
+        SelectList selectList = new SelectList();
+        selectList.addItem(selectListItem);
+        new Expectations() {
+            {
+                selectStmt.analyze(analyzer);
+                selectStmt.getTableRefs();
+                result = Lists.newArrayList(tableRef1, tableRef2);
+                selectStmt.getSelectList();
+                result = selectList;
+                slotRef.getColumnName();
+                result = "k1";
+            }
+        };
+
+        AddMaterializedViewClause addMaterializedViewClause = new AddMaterializedViewClause("test", selectStmt, null);
+        try {
+            addMaterializedViewClause.analyze(analyzer);
+            Assert.fail();
+        } catch (UserException e) {
+            System.out.print(e.getMessage());
+        }
+    }
+
+    @Test
+    public void testSelectClauseWithWhereClause(@Injectable SlotRef slotRef,
+                                                @Injectable TableRef tableRef,
+                                                @Injectable Expr whereClause,
+                                                @Injectable SelectStmt selectStmt) throws UserException {
+        SelectList selectList = new SelectList();
+        SelectListItem selectListItem = new SelectListItem(slotRef, null);
+        selectList.addItem(selectListItem);
+        new Expectations() {
+            {
+                selectStmt.analyze(analyzer);
+                selectStmt.getSelectList();
+                result = selectList;
+                selectStmt.getTableRefs();
+                result = Lists.newArrayList(tableRef);
+                selectStmt.getWhereClause();
+                result = whereClause;
+                slotRef.getColumnName();
+                result = "k1";
+            }
+        };
+
+        AddMaterializedViewClause addMaterializedViewClause = new AddMaterializedViewClause("test", selectStmt, null);
+        try {
+            addMaterializedViewClause.analyze(analyzer);
+            Assert.fail();
+        } catch (UserException e) {
+            System.out.print(e.getMessage());
+        }
+    }
+
+    @Test
+    public void testSelectClauseWithHavingClause(@Injectable SlotRef slotRef,
+                                                 @Injectable TableRef tableRef,
+                                                 @Injectable Expr havingClause,
+                                                 @Injectable SelectStmt selectStmt) throws UserException {
+        SelectList selectList = new SelectList();
+        SelectListItem selectListItem = new SelectListItem(slotRef, null);
+        selectList.addItem(selectListItem);
+
+        new Expectations() {
+            {
+                selectStmt.analyze(analyzer);
+                selectStmt.getSelectList();
+                result = selectList;
+                selectStmt.getTableRefs();
+                result = Lists.newArrayList(tableRef);
+                selectStmt.getWhereClause();
+                result = null;
+                selectStmt.getHavingPred();
+                result = havingClause;
+                slotRef.getColumnName();
+                result = "k1";
+            }
+        };
+        AddMaterializedViewClause addMaterializedViewClause = new AddMaterializedViewClause("test", selectStmt, null);
+        try {
+            addMaterializedViewClause.analyze(analyzer);
+            Assert.fail();
+        } catch (UserException e) {
+            System.out.print(e.getMessage());
+        }
+    }
+
+    @Test
+    public void testOrderOfColumn(@Injectable SlotRef slotRef1,
+                                  @Injectable SlotRef slotRef2,
+                                  @Injectable TableRef tableRef,
+                                  @Injectable SelectStmt selectStmt) throws UserException {
+        SelectList selectList = new SelectList();
+        SelectListItem selectListItem1 = new SelectListItem(slotRef1, null);
+        selectList.addItem(selectListItem1);
+        SelectListItem selectListItem2 = new SelectListItem(slotRef2, null);
+        selectList.addItem(selectListItem2);
+        OrderByElement orderByElement1 = new OrderByElement(slotRef2, false, false);
+        OrderByElement orderByElement2 = new OrderByElement(slotRef1, false, false);
+        ArrayList<OrderByElement> orderByElementList = Lists.newArrayList(orderByElement1, orderByElement2);
+
+        new Expectations() {
+            {
+                selectStmt.analyze(analyzer);
+                selectStmt.getSelectList();
+                result = selectList;
+                selectStmt.getTableRefs();
+                result = Lists.newArrayList(tableRef);
+                selectStmt.getWhereClause();
+                result = null;
+                selectStmt.getHavingPred();
+                result = null;
+                selectStmt.getOrderByElements();
+                result = orderByElementList;
+                slotRef1.getColumnName();
+                result = "k1";
+                slotRef2.getColumnName();
+                result = "k2";
+            }
+        };
+        AddMaterializedViewClause addMaterializedViewClause = new AddMaterializedViewClause("test", selectStmt, null);
+        try {
+            addMaterializedViewClause.analyze(analyzer);
+            Assert.fail();
+        } catch (UserException e) {
+            System.out.print(e.getMessage());
+        }
+    }
+
+    @Test
+    public void testOrderByAggregateColumn(@Injectable SlotRef slotRef1,
+                                           @Injectable SlotRef slotRef2,
+                                           @Injectable FunctionCallExpr functionCallExpr,
+                                           @Injectable TableRef tableRef,
+                                           @Injectable SelectStmt selectStmt) throws UserException {
+        SelectList selectList = new SelectList();
+        SelectListItem selectListItem1 = new SelectListItem(slotRef1, null);
+        selectList.addItem(selectListItem1);
+        SelectListItem selectListItem2 = new SelectListItem(functionCallExpr, null);
+        selectList.addItem(selectListItem2);
+        OrderByElement orderByElement1 = new OrderByElement(functionCallExpr, false, false);
+        OrderByElement orderByElement2 = new OrderByElement(slotRef1, false, false);
+        ArrayList<OrderByElement> orderByElementList = Lists.newArrayList(orderByElement1, orderByElement2);
+
+        new Expectations() {
+            {
+                selectStmt.analyze(analyzer);
+                selectStmt.getSelectList();
+                result = selectList;
+                selectStmt.getTableRefs();
+                result = Lists.newArrayList(tableRef);
+                selectStmt.getWhereClause();
+                result = null;
+                selectStmt.getHavingPred();
+                result = null;
+                selectStmt.getOrderByElements();
+                result = orderByElementList;
+                slotRef1.getColumnName();
+                result = "k1";
+                slotRef2.getColumnName();
+                result = "v1";
+                functionCallExpr.getFnName().getFunction();
+                result = "sum";
+                functionCallExpr.getChildren();
+                result = Lists.newArrayList(slotRef2);
+                functionCallExpr.getChild(0);
+                result = slotRef2;
+            }
+        };
+        AddMaterializedViewClause addMaterializedViewClause = new AddMaterializedViewClause("test", selectStmt, null);
+        try {
+            addMaterializedViewClause.analyze(analyzer);
+            Assert.fail();
+        } catch (UserException e) {
+            System.out.print(e.getMessage());
+        }
+    }
+
+    @Test
+    public void testDuplicateColumn(@Injectable SlotRef slotRef1,
+                                    @Injectable FunctionCallExpr functionCallExpr,
+                                    @Injectable SelectStmt selectStmt) throws UserException {
+        SelectList selectList = new SelectList();
+        SelectListItem selectListItem1 = new SelectListItem(slotRef1, null);
+        selectList.addItem(selectListItem1);
+        SelectListItem selectListItem2 = new SelectListItem(functionCallExpr, null);
+        selectList.addItem(selectListItem2);
+
+        new Expectations() {
+            {
+                selectStmt.analyze(analyzer);
+                selectStmt.getSelectList();
+                result = selectList;
+                slotRef1.getColumnName();
+                result = "k1";
+                functionCallExpr.getFnName().getFunction();
+                result = "sum";
+                functionCallExpr.getChildren();
+                result = Lists.newArrayList(slotRef1);
+                functionCallExpr.getChild(0);
+                result = slotRef1;
+            }
+        };
+        AddMaterializedViewClause addMaterializedViewClause = new AddMaterializedViewClause("test", selectStmt, null);
+        try {
+            addMaterializedViewClause.analyze(analyzer);
+            Assert.fail();
+        } catch (UserException e) {
+            System.out.print(e.getMessage());
+        }
+    }
+
+    @Test
+    public void testMVColumnsWithoutOrderby(@Injectable SlotRef slotRef1,
+                                            @Injectable SlotRef slotRef2,
+                                            @Injectable SlotRef slotRef3,
+                                            @Injectable SlotRef slotRef4,
+                                            @Injectable FunctionCallExpr functionCallExpr,
+                                            @Injectable SlotRef functionChild0,
+                                            @Injectable TableRef tableRef,
+                                            @Injectable SelectStmt selectStmt) throws UserException {
+        SelectList selectList = new SelectList();
+        SelectListItem selectListItem1 = new SelectListItem(slotRef1, null);
+        selectList.addItem(selectListItem1);
+        SelectListItem selectListItem2 = new SelectListItem(slotRef2, null);
+        selectList.addItem(selectListItem2);
+        SelectListItem selectListItem3 = new SelectListItem(slotRef3, null);
+        selectList.addItem(selectListItem3);
+        SelectListItem selectListItem4 = new SelectListItem(slotRef4, null);
+        selectList.addItem(selectListItem4);
+
+        SelectListItem selectListItem5 = new SelectListItem(functionCallExpr, null);
+        selectList.addItem(selectListItem5);
+        final String columnName1 = "k1";
+        final String columnName2 = "k2";
+        final String columnName3 = "k3";
+        final String columnName4 = "v1";
+        final String columnName5 = "sum_v2";
+        new Expectations() {
+            {
+                selectStmt.getSelectList();
+                result = selectList;
+                selectStmt.getTableRefs();
+                result = Lists.newArrayList(tableRef);
+                selectStmt.getWhereClause();
+                result = null;
+                selectStmt.getHavingPred();
+                result = null;
+                selectStmt.getOrderByElements();
+                result = null;
+                selectStmt.getLimit();
+                result = -1;
+                selectStmt.analyze(analyzer);
+                functionCallExpr.getChild(0);
+                result = functionChild0;
+                functionCallExpr.getChildren();
+                result = Lists.newArrayList(functionChild0);
+                functionCallExpr.getFnName().getFunction();
+                result = "sum";
+                slotRef1.getColumnName();
+                result = columnName1;
+                slotRef2.getColumnName();
+                result = columnName2;
+                slotRef3.getColumnName();
+                result = columnName3;
+                slotRef4.getColumnName();
+                result = columnName4;
+                functionChild0.getColumnName();
+                result = columnName5;
+                selectStmt.getResultExprs();
+                result = Lists.newArrayList(slotRef1, slotRef2, slotRef3, slotRef4, functionCallExpr);
+                slotRef1.getType().getStorageLayoutBytes();
+                result = 35;
+                slotRef2.getType().getStorageLayoutBytes();
+                result = 2;
+                slotRef3.getType().getStorageLayoutBytes();
+                result = 3;
+                slotRef4.getType().getStorageLayoutBytes();
+                result = 4;
+            }
+        };
+
+
+        AddMaterializedViewClause addMaterializedViewClause = new AddMaterializedViewClause("test", selectStmt, null);
+        try {
+            addMaterializedViewClause.analyze(analyzer);
+            List<MVColumnItem> mvColumns = addMaterializedViewClause.getMVColumnItemList();
+            Assert.assertEquals(5, mvColumns.size());
+            MVColumnItem mvColumn0 = mvColumns.get(0);
+            Assert.assertTrue(mvColumn0.isKey());
+            Assert.assertFalse(mvColumn0.isAggregationTypeImplicit());
+            Assert.assertEquals(columnName1, mvColumn0.getName());
+            Assert.assertEquals(null, mvColumn0.getAggregationType());
+            MVColumnItem mvColumn1 = mvColumns.get(1);
+            Assert.assertTrue(mvColumn1.isKey());
+            Assert.assertFalse(mvColumn1.isAggregationTypeImplicit());
+            Assert.assertEquals(columnName2, mvColumn1.getName());
+            Assert.assertEquals(null, mvColumn1.getAggregationType());
+            MVColumnItem mvColumn2 = mvColumns.get(2);
+            Assert.assertTrue(mvColumn2.isKey());
+            Assert.assertFalse(mvColumn2.isAggregationTypeImplicit());
+            Assert.assertEquals(columnName3, mvColumn2.getName());
+            Assert.assertEquals(null, mvColumn2.getAggregationType());
+            MVColumnItem mvColumn3 = mvColumns.get(3);
+            Assert.assertFalse(mvColumn3.isKey());
+            Assert.assertTrue(mvColumn3.isAggregationTypeImplicit());
+            Assert.assertEquals(columnName4, mvColumn3.getName());
+            Assert.assertEquals(AggregateType.NONE, mvColumn3.getAggregationType());
+            MVColumnItem mvColumn4 = mvColumns.get(4);
+            Assert.assertFalse(mvColumn4.isKey());
+            Assert.assertFalse(mvColumn4.isAggregationTypeImplicit());
+            Assert.assertEquals(columnName5, mvColumn4.getName());
+            Assert.assertEquals(AggregateType.SUM, mvColumn4.getAggregationType());
+        } catch (UserException e) {
+            Assert.fail(e.getMessage());
+        }
+    }
+
+    @Test
+    public void testMVColumns(@Injectable SlotRef slotRef1,
+                              @Injectable SlotRef slotRef2,
+                              @Injectable FunctionCallExpr functionCallExpr,
+                              @Injectable SlotRef functionChild0,
+                              @Injectable TableRef tableRef,
+                              @Injectable SelectStmt selectStmt) throws UserException {
+        SelectList selectList = new SelectList();
+        SelectListItem selectListItem1 = new SelectListItem(slotRef1, null);
+        selectList.addItem(selectListItem1);
+        SelectListItem selectListItem2 = new SelectListItem(slotRef2, null);
+        selectList.addItem(selectListItem2);
+        SelectListItem selectListItem3 = new SelectListItem(functionCallExpr, null);
+        selectList.addItem(selectListItem3);
+        OrderByElement orderByElement1 = new OrderByElement(slotRef1, false, false);
+        ArrayList<OrderByElement> orderByElementList = Lists.newArrayList(orderByElement1);
+        final String columnName1 = "k1";
+        final String columnName2 = "v1";
+        final String columnName3 = "sum_v2";
+        new Expectations() {
+            {
+                selectStmt.getSelectList();
+                result = selectList;
+                selectStmt.getTableRefs();
+                result = Lists.newArrayList(tableRef);
+                selectStmt.getWhereClause();
+                result = null;
+                selectStmt.getHavingPred();
+                result = null;
+                selectStmt.getOrderByElements();
+                result = orderByElementList;
+                selectStmt.getLimit();
+                result = -1;
+                selectStmt.analyze(analyzer);
+                functionCallExpr.getChild(0);
+                result = functionChild0;
+                functionCallExpr.getChildren();
+                result = Lists.newArrayList(functionChild0);
+                functionCallExpr.getFnName().getFunction();
+                result = "sum";
+                slotRef1.getColumnName();
+                result = columnName1;
+                slotRef2.getColumnName();
+                result = columnName2;
+                functionChild0.getColumnName();
+                result = columnName3;
+            }
+        };
+
+        AddMaterializedViewClause addMaterializedViewClause = new AddMaterializedViewClause("test", selectStmt, null);
+        try {
+            addMaterializedViewClause.analyze(analyzer);
+            List<MVColumnItem> mvColumns = addMaterializedViewClause.getMVColumnItemList();
+            Assert.assertEquals(3, mvColumns.size());
+            MVColumnItem mvColumn0 = mvColumns.get(0);
+            Assert.assertTrue(mvColumn0.isKey());
+            Assert.assertFalse(mvColumn0.isAggregationTypeImplicit());
+            Assert.assertEquals(columnName1, mvColumn0.getName());
+            Assert.assertEquals(null, mvColumn0.getAggregationType());
+            MVColumnItem mvColumn1 = mvColumns.get(1);
+            Assert.assertFalse(mvColumn1.isKey());
+            Assert.assertTrue(mvColumn1.isAggregationTypeImplicit());
+            Assert.assertEquals(columnName2, mvColumn1.getName());
+            Assert.assertEquals(AggregateType.NONE, mvColumn1.getAggregationType());
+            MVColumnItem mvColumn2 = mvColumns.get(2);
+            Assert.assertFalse(mvColumn2.isKey());
+            Assert.assertFalse(mvColumn2.isAggregationTypeImplicit());
+            Assert.assertEquals(columnName3, mvColumn2.getName());
+            Assert.assertEquals(AggregateType.SUM, mvColumn2.getAggregationType());
+        } catch (UserException e) {
+            Assert.fail(e.getMessage());
+        }
+
+
+    }
+}

--- a/fe/src/test/java/org/apache/doris/analysis/CreateMaterializedViewStmtTest.java
+++ b/fe/src/test/java/org/apache/doris/analysis/CreateMaterializedViewStmtTest.java
@@ -32,7 +32,7 @@ import mockit.Expectations;
 import mockit.Injectable;
 import mockit.Mocked;
 
-public class AddMaterializedViewClauseTest {
+public class CreateMaterializedViewStmtTest {
 
     @Mocked
     private Analyzer analyzer;
@@ -53,9 +53,9 @@ public class AddMaterializedViewClauseTest {
                 result = "default";
             }
         };
-        AddMaterializedViewClause addMaterializedViewClause = new AddMaterializedViewClause("test", selectStmt, null);
+        CreateMaterializedViewStmt createMaterializedViewStmt = new CreateMaterializedViewStmt("test", selectStmt, null);
         try {
-            addMaterializedViewClause.analyze(analyzer);
+            createMaterializedViewStmt.analyze(analyzer);
             Assert.fail();
         } catch (UserException e) {
             System.out.print(e.getMessage());
@@ -71,6 +71,8 @@ public class AddMaterializedViewClauseTest {
         selectList.addItem(selectListItem);
         new Expectations() {
             {
+                analyzer.getClusterName();
+                result = "default";
                 selectStmt.analyze(analyzer);
                 selectStmt.getSelectList();
                 result = selectList;
@@ -79,9 +81,9 @@ public class AddMaterializedViewClauseTest {
             }
         };
 
-        AddMaterializedViewClause addMaterializedViewClause = new AddMaterializedViewClause("test", selectStmt, null);
+        CreateMaterializedViewStmt createMaterializedViewStmt = new CreateMaterializedViewStmt("test", selectStmt, null);
         try {
-            addMaterializedViewClause.analyze(analyzer);
+            createMaterializedViewStmt.analyze(analyzer);
             Assert.fail();
         } catch (UserException e) {
             System.out.print(e.getMessage());
@@ -98,6 +100,8 @@ public class AddMaterializedViewClauseTest {
         selectList.addItem(selectListItem);
         new Expectations() {
             {
+                analyzer.getClusterName();
+                result = "default";
                 selectStmt.analyze(analyzer);
                 selectStmt.getTableRefs();
                 result = Lists.newArrayList(tableRef1, tableRef2);
@@ -108,9 +112,9 @@ public class AddMaterializedViewClauseTest {
             }
         };
 
-        AddMaterializedViewClause addMaterializedViewClause = new AddMaterializedViewClause("test", selectStmt, null);
+        CreateMaterializedViewStmt createMaterializedViewStmt = new CreateMaterializedViewStmt("test", selectStmt, null);
         try {
-            addMaterializedViewClause.analyze(analyzer);
+            createMaterializedViewStmt.analyze(analyzer);
             Assert.fail();
         } catch (UserException e) {
             System.out.print(e.getMessage());
@@ -127,6 +131,8 @@ public class AddMaterializedViewClauseTest {
         selectList.addItem(selectListItem);
         new Expectations() {
             {
+                analyzer.getClusterName();
+                result = "default";
                 selectStmt.analyze(analyzer);
                 selectStmt.getSelectList();
                 result = selectList;
@@ -139,9 +145,9 @@ public class AddMaterializedViewClauseTest {
             }
         };
 
-        AddMaterializedViewClause addMaterializedViewClause = new AddMaterializedViewClause("test", selectStmt, null);
+        CreateMaterializedViewStmt createMaterializedViewStmt = new CreateMaterializedViewStmt("test", selectStmt, null);
         try {
-            addMaterializedViewClause.analyze(analyzer);
+            createMaterializedViewStmt.analyze(analyzer);
             Assert.fail();
         } catch (UserException e) {
             System.out.print(e.getMessage());
@@ -159,6 +165,8 @@ public class AddMaterializedViewClauseTest {
 
         new Expectations() {
             {
+                analyzer.getClusterName();
+                result = "default";
                 selectStmt.analyze(analyzer);
                 selectStmt.getSelectList();
                 result = selectList;
@@ -172,9 +180,9 @@ public class AddMaterializedViewClauseTest {
                 result = "k1";
             }
         };
-        AddMaterializedViewClause addMaterializedViewClause = new AddMaterializedViewClause("test", selectStmt, null);
+        CreateMaterializedViewStmt createMaterializedViewStmt = new CreateMaterializedViewStmt("test", selectStmt, null);
         try {
-            addMaterializedViewClause.analyze(analyzer);
+            createMaterializedViewStmt.analyze(analyzer);
             Assert.fail();
         } catch (UserException e) {
             System.out.print(e.getMessage());
@@ -197,6 +205,8 @@ public class AddMaterializedViewClauseTest {
 
         new Expectations() {
             {
+                analyzer.getClusterName();
+                result = "default";
                 selectStmt.analyze(analyzer);
                 selectStmt.getSelectList();
                 result = selectList;
@@ -214,9 +224,9 @@ public class AddMaterializedViewClauseTest {
                 result = "k2";
             }
         };
-        AddMaterializedViewClause addMaterializedViewClause = new AddMaterializedViewClause("test", selectStmt, null);
+        CreateMaterializedViewStmt createMaterializedViewStmt = new CreateMaterializedViewStmt("test", selectStmt, null);
         try {
-            addMaterializedViewClause.analyze(analyzer);
+            createMaterializedViewStmt.analyze(analyzer);
             Assert.fail();
         } catch (UserException e) {
             System.out.print(e.getMessage());
@@ -240,6 +250,8 @@ public class AddMaterializedViewClauseTest {
 
         new Expectations() {
             {
+                analyzer.getClusterName();
+                result = "default";
                 selectStmt.analyze(analyzer);
                 selectStmt.getSelectList();
                 result = selectList;
@@ -263,9 +275,9 @@ public class AddMaterializedViewClauseTest {
                 result = slotRef2;
             }
         };
-        AddMaterializedViewClause addMaterializedViewClause = new AddMaterializedViewClause("test", selectStmt, null);
+        CreateMaterializedViewStmt createMaterializedViewStmt = new CreateMaterializedViewStmt("test", selectStmt, null);
         try {
-            addMaterializedViewClause.analyze(analyzer);
+            createMaterializedViewStmt.analyze(analyzer);
             Assert.fail();
         } catch (UserException e) {
             System.out.print(e.getMessage());
@@ -284,6 +296,8 @@ public class AddMaterializedViewClauseTest {
 
         new Expectations() {
             {
+                analyzer.getClusterName();
+                result = "default";
                 selectStmt.analyze(analyzer);
                 selectStmt.getSelectList();
                 result = selectList;
@@ -297,9 +311,64 @@ public class AddMaterializedViewClauseTest {
                 result = slotRef1;
             }
         };
-        AddMaterializedViewClause addMaterializedViewClause = new AddMaterializedViewClause("test", selectStmt, null);
+        CreateMaterializedViewStmt createMaterializedViewStmt = new CreateMaterializedViewStmt("test", selectStmt, null);
         try {
-            addMaterializedViewClause.analyze(analyzer);
+            createMaterializedViewStmt.analyze(analyzer);
+            Assert.fail();
+        } catch (UserException e) {
+            System.out.print(e.getMessage());
+        }
+    }
+
+    @Test
+    public void testOrderByColumnsLessThenGroupByColumns(@Injectable SlotRef slotRef1,
+                                                         @Injectable SlotRef slotRef2,
+                                                         @Injectable FunctionCallExpr functionCallExpr,
+                                                         @Injectable SlotRef functionChild0,
+                                                         @Injectable TableRef tableRef,
+                                                         @Injectable SelectStmt selectStmt) throws UserException {
+        SelectList selectList = new SelectList();
+        SelectListItem selectListItem1 = new SelectListItem(slotRef1, null);
+        selectList.addItem(selectListItem1);
+        SelectListItem selectListItem2 = new SelectListItem(slotRef2, null);
+        selectList.addItem(selectListItem2);
+        SelectListItem selectListItem3 = new SelectListItem(functionCallExpr, null);
+        selectList.addItem(selectListItem3);
+        OrderByElement orderByElement1 = new OrderByElement(slotRef1, false, false);
+        ArrayList<OrderByElement> orderByElementList = Lists.newArrayList(orderByElement1);
+
+        new Expectations() {
+            {
+                analyzer.getClusterName();
+                result = "default";
+                selectStmt.analyze(analyzer);
+                selectStmt.getSelectList();
+                result = selectList;
+                selectStmt.getTableRefs();
+                result = Lists.newArrayList(tableRef);
+                selectStmt.getWhereClause();
+                result = null;
+                selectStmt.getHavingPred();
+                result = null;
+                selectStmt.getOrderByElements();
+                result = orderByElementList;
+                slotRef1.getColumnName();
+                result = "k1";
+                slotRef2.getColumnName();
+                result = "non-k2";
+                functionChild0.getColumnName();
+                result = "v1";
+                functionCallExpr.getFnName().getFunction();
+                result = "sum";
+                functionCallExpr.getChildren();
+                result = Lists.newArrayList(slotRef1);
+                functionCallExpr.getChild(0);
+                result = functionChild0;
+            }
+        };
+        CreateMaterializedViewStmt createMaterializedViewStmt = new CreateMaterializedViewStmt("test", selectStmt, null);
+        try {
+            createMaterializedViewStmt.analyze(analyzer);
             Assert.fail();
         } catch (UserException e) {
             System.out.print(e.getMessage());
@@ -334,6 +403,8 @@ public class AddMaterializedViewClauseTest {
         final String columnName5 = "sum_v2";
         new Expectations() {
             {
+                analyzer.getClusterName();
+                result = "default";
                 selectStmt.getSelectList();
                 result = selectList;
                 selectStmt.getTableRefs();
@@ -363,8 +434,93 @@ public class AddMaterializedViewClauseTest {
                 result = columnName4;
                 functionChild0.getColumnName();
                 result = columnName5;
+            }
+        };
+
+
+        CreateMaterializedViewStmt createMaterializedViewStmt = new CreateMaterializedViewStmt("test", selectStmt, null);
+        try {
+            createMaterializedViewStmt.analyze(analyzer);
+            List<MVColumnItem> mvColumns = createMaterializedViewStmt.getMVColumnItemList();
+            Assert.assertEquals(5, mvColumns.size());
+            MVColumnItem mvColumn0 = mvColumns.get(0);
+            Assert.assertTrue(mvColumn0.isKey());
+            Assert.assertFalse(mvColumn0.isAggregationTypeImplicit());
+            Assert.assertEquals(columnName1, mvColumn0.getName());
+            Assert.assertEquals(null, mvColumn0.getAggregationType());
+            MVColumnItem mvColumn1 = mvColumns.get(1);
+            Assert.assertTrue(mvColumn1.isKey());
+            Assert.assertFalse(mvColumn1.isAggregationTypeImplicit());
+            Assert.assertEquals(columnName2, mvColumn1.getName());
+            Assert.assertEquals(null, mvColumn1.getAggregationType());
+            MVColumnItem mvColumn2 = mvColumns.get(2);
+            Assert.assertTrue(mvColumn2.isKey());
+            Assert.assertFalse(mvColumn2.isAggregationTypeImplicit());
+            Assert.assertEquals(columnName3, mvColumn2.getName());
+            Assert.assertEquals(null, mvColumn2.getAggregationType());
+            MVColumnItem mvColumn3 = mvColumns.get(3);
+            Assert.assertTrue(mvColumn3.isKey());
+            Assert.assertFalse(mvColumn3.isAggregationTypeImplicit());
+            Assert.assertEquals(columnName4, mvColumn3.getName());
+            Assert.assertEquals(null, mvColumn3.getAggregationType());
+            MVColumnItem mvColumn4 = mvColumns.get(4);
+            Assert.assertFalse(mvColumn4.isKey());
+            Assert.assertFalse(mvColumn4.isAggregationTypeImplicit());
+            Assert.assertEquals(columnName5, mvColumn4.getName());
+            Assert.assertEquals(AggregateType.SUM, mvColumn4.getAggregationType());
+        } catch (UserException e) {
+            Assert.fail(e.getMessage());
+        }
+    }
+
+    @Test
+    public void testMVColumnsWithoutOrderbyWithoutAggregation(@Injectable SlotRef slotRef1,
+                                            @Injectable SlotRef slotRef2,
+                                            @Injectable SlotRef slotRef3,
+                                            @Injectable SlotRef slotRef4,
+                                            @Injectable TableRef tableRef,
+                                            @Injectable SelectStmt selectStmt) throws UserException {
+        SelectList selectList = new SelectList();
+        SelectListItem selectListItem1 = new SelectListItem(slotRef1, null);
+        selectList.addItem(selectListItem1);
+        SelectListItem selectListItem2 = new SelectListItem(slotRef2, null);
+        selectList.addItem(selectListItem2);
+        SelectListItem selectListItem3 = new SelectListItem(slotRef3, null);
+        selectList.addItem(selectListItem3);
+        SelectListItem selectListItem4 = new SelectListItem(slotRef4, null);
+        selectList.addItem(selectListItem4);
+
+        final String columnName1 = "k1";
+        final String columnName2 = "k2";
+        final String columnName3 = "k3";
+        final String columnName4 = "v1";
+        new Expectations() {
+            {
+                analyzer.getClusterName();
+                result = "default";
+                selectStmt.getSelectList();
+                result = selectList;
+                selectStmt.getTableRefs();
+                result = Lists.newArrayList(tableRef);
+                selectStmt.getWhereClause();
+                result = null;
+                selectStmt.getHavingPred();
+                result = null;
+                selectStmt.getOrderByElements();
+                result = null;
+                selectStmt.getLimit();
+                result = -1;
+                selectStmt.analyze(analyzer);
+                slotRef1.getColumnName();
+                result = columnName1;
+                slotRef2.getColumnName();
+                result = columnName2;
+                slotRef3.getColumnName();
+                result = columnName3;
+                slotRef4.getColumnName();
+                result = columnName4;
                 selectStmt.getResultExprs();
-                result = Lists.newArrayList(slotRef1, slotRef2, slotRef3, slotRef4, functionCallExpr);
+                result = Lists.newArrayList(slotRef1, slotRef2, slotRef3, slotRef4);
                 slotRef1.getType().getStorageLayoutBytes();
                 result = 35;
                 slotRef2.getType().getStorageLayoutBytes();
@@ -377,11 +533,11 @@ public class AddMaterializedViewClauseTest {
         };
 
 
-        AddMaterializedViewClause addMaterializedViewClause = new AddMaterializedViewClause("test", selectStmt, null);
+        CreateMaterializedViewStmt createMaterializedViewStmt = new CreateMaterializedViewStmt("test", selectStmt, null);
         try {
-            addMaterializedViewClause.analyze(analyzer);
-            List<MVColumnItem> mvColumns = addMaterializedViewClause.getMVColumnItemList();
-            Assert.assertEquals(5, mvColumns.size());
+            createMaterializedViewStmt.analyze(analyzer);
+            List<MVColumnItem> mvColumns = createMaterializedViewStmt.getMVColumnItemList();
+            Assert.assertEquals(4, mvColumns.size());
             MVColumnItem mvColumn0 = mvColumns.get(0);
             Assert.assertTrue(mvColumn0.isKey());
             Assert.assertFalse(mvColumn0.isAggregationTypeImplicit());
@@ -402,11 +558,6 @@ public class AddMaterializedViewClauseTest {
             Assert.assertTrue(mvColumn3.isAggregationTypeImplicit());
             Assert.assertEquals(columnName4, mvColumn3.getName());
             Assert.assertEquals(AggregateType.NONE, mvColumn3.getAggregationType());
-            MVColumnItem mvColumn4 = mvColumns.get(4);
-            Assert.assertFalse(mvColumn4.isKey());
-            Assert.assertFalse(mvColumn4.isAggregationTypeImplicit());
-            Assert.assertEquals(columnName5, mvColumn4.getName());
-            Assert.assertEquals(AggregateType.SUM, mvColumn4.getAggregationType());
         } catch (UserException e) {
             Assert.fail(e.getMessage());
         }
@@ -427,12 +578,15 @@ public class AddMaterializedViewClauseTest {
         SelectListItem selectListItem3 = new SelectListItem(functionCallExpr, null);
         selectList.addItem(selectListItem3);
         OrderByElement orderByElement1 = new OrderByElement(slotRef1, false, false);
-        ArrayList<OrderByElement> orderByElementList = Lists.newArrayList(orderByElement1);
+        OrderByElement orderByElement2 = new OrderByElement(slotRef2, false, false);
+        ArrayList<OrderByElement> orderByElementList = Lists.newArrayList(orderByElement1, orderByElement2);
         final String columnName1 = "k1";
         final String columnName2 = "v1";
         final String columnName3 = "sum_v2";
         new Expectations() {
             {
+                analyzer.getClusterName();
+                result = "default";
                 selectStmt.getSelectList();
                 result = selectList;
                 selectStmt.getTableRefs();
@@ -461,10 +615,10 @@ public class AddMaterializedViewClauseTest {
             }
         };
 
-        AddMaterializedViewClause addMaterializedViewClause = new AddMaterializedViewClause("test", selectStmt, null);
+        CreateMaterializedViewStmt createMaterializedViewStmt = new CreateMaterializedViewStmt("test", selectStmt, null);
         try {
-            addMaterializedViewClause.analyze(analyzer);
-            List<MVColumnItem> mvColumns = addMaterializedViewClause.getMVColumnItemList();
+            createMaterializedViewStmt.analyze(analyzer);
+            List<MVColumnItem> mvColumns = createMaterializedViewStmt.getMVColumnItemList();
             Assert.assertEquals(3, mvColumns.size());
             MVColumnItem mvColumn0 = mvColumns.get(0);
             Assert.assertTrue(mvColumn0.isKey());
@@ -472,10 +626,10 @@ public class AddMaterializedViewClauseTest {
             Assert.assertEquals(columnName1, mvColumn0.getName());
             Assert.assertEquals(null, mvColumn0.getAggregationType());
             MVColumnItem mvColumn1 = mvColumns.get(1);
-            Assert.assertFalse(mvColumn1.isKey());
-            Assert.assertTrue(mvColumn1.isAggregationTypeImplicit());
+            Assert.assertTrue(mvColumn1.isKey());
+            Assert.assertFalse(mvColumn1.isAggregationTypeImplicit());
             Assert.assertEquals(columnName2, mvColumn1.getName());
-            Assert.assertEquals(AggregateType.NONE, mvColumn1.getAggregationType());
+            Assert.assertEquals(null, mvColumn1.getAggregationType());
             MVColumnItem mvColumn2 = mvColumns.get(2);
             Assert.assertFalse(mvColumn2.isKey());
             Assert.assertFalse(mvColumn2.isAggregationTypeImplicit());

--- a/fe/src/test/java/org/apache/doris/backup/CatalogMocker.java
+++ b/fe/src/test/java/org/apache/doris/backup/CatalogMocker.java
@@ -17,7 +17,7 @@
 
 package org.apache.doris.backup;
 
-import org.apache.doris.alter.RollupHandler;
+import org.apache.doris.alter.MaterializedViewHandler;
 import org.apache.doris.alter.SchemaChangeHandler;
 import org.apache.doris.analysis.PartitionValue;
 import org.apache.doris.catalog.AggregateType;
@@ -392,7 +392,7 @@ public class CatalogMocker {
             EasyMock.expect(catalog.getDbNames()).andReturn(Lists.newArrayList(TEST_DB_NAME)).anyTimes();
             EasyMock.expect(catalog.getLoadInstance()).andReturn(new Load()).anyTimes();
             EasyMock.expect(catalog.getSchemaChangeHandler()).andReturn(new SchemaChangeHandler()).anyTimes();
-            EasyMock.expect(catalog.getRollupHandler()).andReturn(new RollupHandler()).anyTimes();
+            EasyMock.expect(catalog.getRollupHandler()).andReturn(new MaterializedViewHandler()).anyTimes();
             EasyMock.expect(catalog.getEditLog()).andReturn(EasyMock.createMock(EditLog.class)).anyTimes();
             catalog.changeDb(EasyMock.isA(ConnectContext.class), EasyMock.eq(WRONG_DB));
             EasyMock.expectLastCall().andThrow(new DdlException("failed.")).anyTimes();

--- a/fe/src/test/java/org/apache/doris/http/DorisHttpTestCase.java
+++ b/fe/src/test/java/org/apache/doris/http/DorisHttpTestCase.java
@@ -17,8 +17,7 @@
 
 package org.apache.doris.http;
 
-
-import org.apache.doris.alter.RollupHandler;
+import org.apache.doris.alter.MaterializedViewHandler;
 import org.apache.doris.alter.SchemaChangeHandler;
 import org.apache.doris.catalog.Catalog;
 import org.apache.doris.catalog.Column;
@@ -208,7 +207,7 @@ abstract public class DorisHttpTestCase {
             EasyMock.expect(catalog.getDbNames()).andReturn(Lists.newArrayList("default_cluster:testDb")).anyTimes();
             EasyMock.expect(catalog.getLoadInstance()).andReturn(new Load()).anyTimes();
             EasyMock.expect(catalog.getSchemaChangeHandler()).andReturn(new SchemaChangeHandler()).anyTimes();
-            EasyMock.expect(catalog.getRollupHandler()).andReturn(new RollupHandler()).anyTimes();
+            EasyMock.expect(catalog.getRollupHandler()).andReturn(new MaterializedViewHandler()).anyTimes();
             EasyMock.expect(catalog.getEditLog()).andReturn(EasyMock.createMock(EditLog.class)).anyTimes();
             EasyMock.expect(catalog.getClusterDbNames("default_cluster")).andReturn(Lists.newArrayList("default_cluster:testDb")).anyTimes();
             catalog.changeDb(EasyMock.isA(ConnectContext.class), EasyMock.eq("blockDb"));


### PR DESCRIPTION
This commit support to create materiliazed view.
The syntax of stmt is following:
ALTER TABLE [Table name] ADD Materialized View [MV name] AS
  SELECT select_expr[, select_expr ...]
  FROM [Base table name]
  GROUP BY column_name[, column_name ...]
  ORDER BY column_name[, column_name ...]

The AddMaterializedViewClause is used to check the semantic of stmt in the first step.
Now, the where, having, limit clause is forbidden in ADD MATERIALIZED VIEW.
Also the aggregation function is restricted in SUM/MIN/MAX.

The second step is to validate stmt according to metadata of base table.
For example, the aggregate type of mv column must be same as the aggregate type of base column in aggregate table.

The last step is to prepare index of mv and add this new mvJob in Handler.
The handler will asynchronous process this new mvJob.

ISSUE #2101