### PR TITLE
[Bug][Privilege] Missing current user identity when forwarding request to Master FE

### DIFF
--- a/fe/src/main/java/org/apache/doris/qe/ConnectProcessor.java
+++ b/fe/src/main/java/org/apache/doris/qe/ConnectProcessor.java
@@ -18,6 +18,7 @@
 package org.apache.doris.qe;
 
 import org.apache.doris.analysis.StatementBase;
+import org.apache.doris.analysis.UserIdentity;
 import org.apache.doris.catalog.Catalog;
 import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.Database;
@@ -351,8 +352,22 @@ public class ConnectProcessor {
         if (request.isSetEnableStrictMode()) {
             ctx.getSessionVariable().setEnableInsertStrict(request.enableStrictMode);
         }
-
+        if (request.isSetCurrent_user_ident()) {
+            UserIdentity currentUserIdentity = UserIdentity.fromThrift(request.getCurrent_user_ident());
+            ctx.setCurrentUserIdentity(currentUserIdentity);
+        }
         ctx.setThreadLocalInfo();
+
+        if (ctx.getCurrentUserIdentity() == null) {
+            // if we upgrade Master FE first, the request from old FE does not set "current_user_ident".
+            // so ctx.getCurrentUserIdentity() will get null, and causing NullPointerException after using it.
+            // return error directly.
+            TMasterOpResult result = new TMasterOpResult();
+            ctx.getState().setError("Palo process failed");
+            result.setMaxJournalId(Catalog.getInstance().getMaxJournalId().longValue());
+            result.setPacket(getResultPacket());
+            return result;
+        }
 
         StmtExecutor executor = null;
         try {

--- a/fe/src/main/java/org/apache/doris/qe/ConnectProcessor.java
+++ b/fe/src/main/java/org/apache/doris/qe/ConnectProcessor.java
@@ -363,7 +363,7 @@ public class ConnectProcessor {
             // so ctx.getCurrentUserIdentity() will get null, and causing NullPointerException after using it.
             // return error directly.
             TMasterOpResult result = new TMasterOpResult();
-            ctx.getState().setError("Palo process failed");
+            ctx.getState().setError("Missing current user identity. You need to upgrade this Frontend to the same version as Master Frontend.");
             result.setMaxJournalId(Catalog.getInstance().getMaxJournalId().longValue());
             result.setPacket(getResultPacket());
             return result;
@@ -376,7 +376,7 @@ public class ConnectProcessor {
         } catch (IOException e) {
             // Client failed.
             LOG.warn("Process one query failed because IOException: ", e);
-            ctx.getState().setError("Palo process failed");
+            ctx.getState().setError("Doris process failed: " + e.getMessage());
         } catch (Throwable e) {
             // Catch all throwable.
             // If reach here, maybe palo bug.

--- a/fe/src/main/java/org/apache/doris/qe/MasterOpExecutor.java
+++ b/fe/src/main/java/org/apache/doris/qe/MasterOpExecutor.java
@@ -85,6 +85,7 @@ public class MasterOpExecutor {
         params.setStmt_id(ctx.getStmtId());
         params.setLoadMemLimit(ctx.getSessionVariable().getLoadMemLimit());
         params.setEnableStrictMode(ctx.getSessionVariable().getEnableInsertStrict());
+        params.setCurrent_user_ident(ctx.getCurrentUserIdentity().toThrift());
 
         LOG.info("Forward statement {} to Master {}", ctx.getStmtId(), thriftAddress);
 

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -419,6 +419,8 @@ struct TMasterOpRequest {
     11: optional i64 sqlMode
     12: optional i64 loadMemLimit
     13: optional bool enableStrictMode
+    // this can replace the "user" field
+    14: optional Types.TUserIdentity current_user_ident
 }
 
 struct TColumnDefinition {


### PR DESCRIPTION
The current user identity should be passed to Master FE in forward request.

ISSUE #2442 