### PR TITLE
Fix bug for show tables from unknown database doesn't throw error

### DIFF
--- a/fe/src/main/java/org/apache/doris/qe/ShowExecutor.java
+++ b/fe/src/main/java/org/apache/doris/qe/ShowExecutor.java
@@ -456,6 +456,8 @@ public class ShowExecutor {
                     rows.add(Lists.newArrayList(entry.getKey()));
                 }
             }
+        } else {
+            ErrorReport.reportAnalysisException(ErrorCode.ERR_BAD_DB_ERROR, showTableStmt.getDb());
         }
         resultSet = new ShowResultSet(showTableStmt.getMetaData(), rows);
     }

--- a/fe/src/test/java/org/apache/doris/qe/ShowExecutorTest.java
+++ b/fe/src/test/java/org/apache/doris/qe/ShowExecutorTest.java
@@ -214,12 +214,12 @@ public class ShowExecutorTest {
     }
 
     @Test
-    public void testShowTableEmpty() throws AnalysisException {
+    public void testShowTableFromUnknownDatabase() throws AnalysisException {
         ShowTableStmt stmt = new ShowTableStmt("testCluster:emptyDb", false, null);
         ShowExecutor executor = new ShowExecutor(ctx, stmt);
-        ShowResultSet resultSet = executor.execute();
-
-        Assert.assertFalse(resultSet.next());
+        expectedEx.expect(AnalysisException.class);
+        expectedEx.expectMessage("Unknown database 'testCluster:emptyDb'");
+        executor.execute();
     }
 
     @Test


### PR DESCRIPTION
when show tables from unknown database, the unknown database error should be thrown up