### PR TITLE
[V2 Format] encoding of ColumnMetaPB should not be DEFAULT_ENCODING

### DIFF
--- a/be/src/olap/rowset/segment_v2/column_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/column_writer.cpp
@@ -258,7 +258,10 @@ Status ColumnWriter::write_bitmap_index() {
 
 void ColumnWriter::write_meta(ColumnMetaPB* meta) {
     meta->set_type(_field->type());
-    meta->set_encoding(_opts.encoding_type);
+    meta->set_encoding(_encoding_info->encoding());
+    // should store more concrete encoding type instead of DEFAULT_ENCODING
+    // because the default encoding of a data type can be changed in the future
+    DCHECK_NE(meta->encoding(), DEFAULT_ENCODING);
     meta->set_compression(_opts.compression_type);
     meta->set_is_nullable(_is_nullable);
     _ordinal_index_pp.to_proto(meta->mutable_ordinal_index_page());


### PR DESCRIPTION
Fixes #2450 

Currently all columns use DEFAULT_ENCODING as ColumnMetaPB.encoding. However we may change the default encoding type for a data type in the future, therefore concrete encoding type such as PLAIN_ENCODING/BIT_SHUFFLE should be stored in column meta in order to support encoding evolution.