### PR TITLE
Support correlated non-scalar subquery

### DIFF
--- a/fe/src/main/java/org/apache/doris/analysis/Expr.java
+++ b/fe/src/main/java/org/apache/doris/analysis/Expr.java
@@ -124,24 +124,6 @@ abstract public class Expr extends TreeNode<Expr> implements ParseNode, Cloneabl
             };
     */
 
-    // Returns true if an Expr is a builtin aggregate function.
-    public final static com.google.common.base.Predicate<Expr> IS_BUILTIN_AGG_FN =
-            new com.google.common.base.Predicate<Expr>() {
-                @Override
-                public boolean apply(Expr arg) {
-                    if (arg instanceof FunctionCallExpr) {
-                        String fnName = ((FunctionCallExpr)arg).getFnName().getFunction();
-                        return  (fnName.equalsIgnoreCase("sum")
-                                || fnName.equalsIgnoreCase("max")
-                                || fnName.equalsIgnoreCase("min")
-                                || fnName.equalsIgnoreCase("avg")
-                                || fnName.equalsIgnoreCase("count"));
-                    } else {
-                        return false;
-                    }
-                }
-            };
-
     public final static com.google.common.base.Predicate<Expr> IS_TRUE_LITERAL =
             new com.google.common.base.Predicate<Expr>() {
                 @Override

--- a/fe/src/main/java/org/apache/doris/analysis/StmtRewriter.java
+++ b/fe/src/main/java/org/apache/doris/analysis/StmtRewriter.java
@@ -907,10 +907,6 @@ public class StmtRewriter {
         ExprSubstitutionMap smap = new ExprSubstitutionMap();
         SelectListItem item =
                 ((SelectStmt) inlineView.getViewStmt()).getSelectList().getItems().get(0);
-        if (isCorrelated && !item.getExpr().contains(Expr.IS_BUILTIN_AGG_FN)) {
-            throw new AnalysisException("UDAs are not supported in the select list of "
-                    + "correlated subqueries: " + subquery.toSql());
-        }
         if (isCorrelated && item.getExpr().contains(Expr.NON_NULL_EMPTY_AGG)) {
             // TODO: Add support for multiple agg functions that return non-null on an
             // empty input, by wrapping them with zeroifnull functions before the inline


### PR DESCRIPTION
The first item of non-scalar subquery could be non-aggregation function such as column k1.
This commit remove this prohibit.

#2420