### PR TITLE
[Compaction] Fix the bug that cumulative point grows unreasonably

### DIFF
--- a/be/src/olap/cumulative_compaction.cpp
+++ b/be/src/olap/cumulative_compaction.cpp
@@ -97,7 +97,8 @@ OLAPStatus CumulativeCompaction::pick_rowsets_to_compact() {
             continue;
         }
 
-        if (num_overlapping_segments >= config::max_cumulative_compaction_num_singleton_deltas) {
+        if (num_overlapping_segments >= config::max_cumulative_compaction_num_singleton_deltas
+            && transient_rowsets.size() >= 2) {
             // the threshold of files to compacted one time
             break;
         }

--- a/docs/documentation/cn/administrator-guide/http-actions/compaction-action.md
+++ b/docs/documentation/cn/administrator-guide/http-actions/compaction-action.md
@@ -52,10 +52,10 @@ curl -X GET http://be_host:webserver_port/api/compaction/show?tablet_id=xxxx\&sc
     "last cumu success time": "2019-12-16 18:12:15.110",
     "last base success time": "2019-12-16 18:11:50.780",
     "versions": [
-        "[0-48] ",
-        "[49-49] ",
-        "[50-50] DELETE",
-        "[51-51] "
+        "[0-48] 10 ",
+        "[49-49] 2 ",
+        "[50-50] 0 DELETE",
+        "[51-51] 5 "
     ]
 }
 ```
@@ -65,7 +65,7 @@ curl -X GET http://be_host:webserver_port/api/compaction/show?tablet_id=xxxx\&sc
 * cumulative point：base 和 cumulative compaction 的版本分界线。在 point（不含）之前的版本由 base compaction 处理。point（含）之后的版本由 cumulative compaction 处理。
 * last cumulative failure time：上一次尝试 cumulative compaction 失败的时间。默认 10min 后才会再次尝试对该 tablet 做 cumulative compaction。
 * last base failure time：上一次尝试 base compaction 失败的时间。默认 10min 后才会再次尝试对该 tablet 做 base compaction。
-* versions：该 tablet 当前的数据版本集合。其中后 `DELETE` 后缀的表示 delete 版本。
+* versions：该 tablet 当前的数据版本集合。如 [0-48] 表示 0-48 版本。第二位数字表示该版本中 segment 的数量。`DELETE` 后缀的表示 delete 版本。
 
 ### 示例
 

--- a/docs/documentation/en/administrator-guide/http-actions/compaction-action_EN.md
+++ b/docs/documentation/en/administrator-guide/http-actions/compaction-action_EN.md
@@ -52,10 +52,10 @@ If the tablet exists, the result is returned in JSON format:
     "last cumu success time": "2019-12-16 18:12:15.110",
     "last base success time": "2019-12-16 18:11:50.780",
     "versions": [
-        "[0-48] ",
-        "[49-49] ",
-        "[50-50] DELETE",
-        "[51-51] "
+        "[0-48] 10 ",
+        "[49-49] 2 ",
+        "[50-50] 0 DELETE",
+        "[51-51] 5 "
     ]
 }
 ```
@@ -65,7 +65,7 @@ Explanation of results:
 * cumulative point: The version boundary between base and cumulative compaction. Versions before (excluding) points are handled by base compaction. Versions after (inclusive) are handled by cumulative compaction.
 * last cumulative failure time: The time when the last cumulative compaction failed. After 10 minutes by default, cumulative compaction is attempted on the this tablet again.
 * last base failure time: The time when the last base compaction failed. After 10 minutes by default, base compaction is attempted on the this tablet again.
-* versions: The current data version collection of this tablet. The `DELETE` suffix indicates the delete version.
+* versions: The current data version collection of this tablet. [0-48] means a rowset with version 0-48. The second number is the number of segments in a rowset. The `DELETE` suffix indicates the delete version.
 
 ### Examples
 


### PR DESCRIPTION
When there are to many segment in one rowset, which is larger than
BE config 'max_cumulative_compaction_num_singleton_deltas', the
cumulative compaction will not work and just increase the cumulative
point, because there is only once rowset being selected.

So when selecting rowset for cumulative compaction, we should meet 2
requirments before finishing the selection logic:

1. compaction score is larger than 'max_cumulative_compaction_num_singleton_deltas'
2. at least 2 rowsets are selected.

ISSUE #2474