### PR TITLE
Fix the core of get_next in exchange node

### DIFF
--- a/be/src/exec/exchange_node.h
+++ b/be/src/exec/exchange_node.h
@@ -85,7 +85,7 @@ private:
     // Only valid if _is_merging is false. (If _is_merging is true, GetNext() is
     // delegated to the receiver). Owned by the stream receiver.
     // boost::scoped_ptr<RowBatch> _input_batch;
-    RowBatch* _input_batch = NULL;
+    RowBatch* _input_batch = nullptr;
 
     // Next row to copy from _input_batch. For non-merging exchanges, _input_batch
     // is retrieved directly from the sender queue in the stream recvr, and rows from
@@ -119,4 +119,3 @@ private:
 };
 
 #endif
-

--- a/be/src/exec/exchange_node.h
+++ b/be/src/exec/exchange_node.h
@@ -85,7 +85,7 @@ private:
     // Only valid if _is_merging is false. (If _is_merging is true, GetNext() is
     // delegated to the receiver). Owned by the stream receiver.
     // boost::scoped_ptr<RowBatch> _input_batch;
-    RowBatch* _input_batch;
+    RowBatch* _input_batch = NULL;
 
     // Next row to copy from _input_batch. For non-merging exchanges, _input_batch
     // is retrieved directly from the sender queue in the stream recvr, and rows from


### PR DESCRIPTION
The _input_batch hasn't been initialized in exchange node.
The undefined behavior will cause that the BE wants to get the capacity of input_batch before BE initialize it.
The issue is #2504