### PR TITLE
[Tag system] Introduce ReplicaAllocation and Backend TagSet

### DIFF
--- a/fe/src/main/java/org/apache/doris/analysis/SingleRangePartitionDesc.java
+++ b/fe/src/main/java/org/apache/doris/analysis/SingleRangePartitionDesc.java
@@ -31,6 +31,7 @@ import org.apache.doris.system.SystemInfoService;
 import com.google.common.base.Joiner;
 import com.google.common.base.Joiner.MapJoiner;
 import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
 
 import java.util.Map;
 
@@ -138,12 +139,10 @@ public class SingleRangePartitionDesc {
             }
         }
 
-        if (ConnectContext.get() != null) {
+        if (ConnectContext.get() != null && !Strings.isNullOrEmpty(ConnectContext.get().getClusterName())) {
             // after introducing the replica allocation. we need the cluster info, so that we can convert
             // the "replicationNum" to "replicaAllocation"
             this.clusterName = ConnectContext.get().getClusterName();
-        } else {
-            this.clusterName = SystemInfoService.DEFAULT_CLUSTER;
         }
 
         this.isAnalyzed = true;

--- a/fe/src/main/java/org/apache/doris/analysis/SingleRangePartitionDesc.java
+++ b/fe/src/main/java/org/apache/doris/analysis/SingleRangePartitionDesc.java
@@ -142,6 +142,8 @@ public class SingleRangePartitionDesc {
             // after introducing the replica allocation. we need the cluster info, so that we can convert
             // the "replicationNum" to "replicaAllocation"
             this.clusterName = ConnectContext.get().getClusterName();
+        } else {
+            this.clusterName = SystemInfoService.DEFAULT_CLUSTER;
         }
 
         this.isAnalyzed = true;

--- a/fe/src/main/java/org/apache/doris/backup/RestoreJob.java
+++ b/fe/src/main/java/org/apache/doris/backup/RestoreJob.java
@@ -40,6 +40,7 @@ import org.apache.doris.catalog.PartitionType;
 import org.apache.doris.catalog.RangePartitionInfo;
 import org.apache.doris.catalog.Replica;
 import org.apache.doris.catalog.Replica.ReplicaState;
+import org.apache.doris.catalog.ReplicaAllocation;
 import org.apache.doris.catalog.Table;
 import org.apache.doris.catalog.Table.TableType;
 import org.apache.doris.catalog.Tablet;
@@ -724,8 +725,10 @@ public class RestoreJob extends AbstractJob {
                         long remotePartId = backupPartitionInfo.id;
                         Range<PartitionKey> remoteRange = remotePartitionInfo.getRange(remotePartId);
                         DataProperty remoteDataProperty = remotePartitionInfo.getDataProperty(remotePartId);
+                        ReplicaAllocation replicaAlloc = ReplicaAllocation.createDefault((short) restoreReplicationNum,
+                                db.getClusterName());
                         localPartitionInfo.addPartition(restoredPart.getId(), remoteRange,
-                                remoteDataProperty, (short) restoreReplicationNum);
+                                remoteDataProperty, replicaAlloc);
                         localTbl.addPartition(restoredPart);
                     }
 
@@ -931,8 +934,9 @@ public class RestoreJob extends AbstractJob {
                 long remotePartId = backupPartitionInfo.id;
                 Range<PartitionKey> remoteRange = remotePartitionInfo.getRange(remotePartId);
                 DataProperty remoteDataProperty = remotePartitionInfo.getDataProperty(remotePartId);
-                localPartitionInfo.addPartition(restorePart.getId(), remoteRange,
-                        remoteDataProperty, (short) restoreReplicationNum);
+                ReplicaAllocation replicaAlloc = ReplicaAllocation.createDefault((short) restoreReplicationNum,
+                        db.getClusterName());
+                localPartitionInfo.addPartition(restorePart.getId(), remoteRange, remoteDataProperty, replicaAlloc);
                 localTbl.addPartition(restorePart);
 
                 // modify tablet inverted index

--- a/fe/src/main/java/org/apache/doris/catalog/Catalog.java
+++ b/fe/src/main/java/org/apache/doris/catalog/Catalog.java
@@ -1139,6 +1139,9 @@ public class Catalog {
                 db.writeUnlock();
             }
         }
+
+        // tag for backend
+        systemInfo.convertToTagSystem();
     }
 
     // start all daemon threads only running on Master

--- a/fe/src/main/java/org/apache/doris/catalog/Catalog.java
+++ b/fe/src/main/java/org/apache/doris/catalog/Catalog.java
@@ -167,6 +167,7 @@ import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.JournalObservable;
 import org.apache.doris.qe.SessionVariable;
 import org.apache.doris.qe.VariableMgr;
+import org.apache.doris.resource.TagManager;
 import org.apache.doris.service.FrontendOptions;
 import org.apache.doris.system.Backend;
 import org.apache.doris.system.Backend.BackendState;
@@ -368,6 +369,8 @@ public class Catalog {
 
     private SmallFileMgr smallFileMgr;
 
+    private TagManager tagManager;
+
     public List<Frontend> getFrontends(FrontendNodeType nodeType) {
         if (nodeType == null) {
             // get all
@@ -489,6 +492,8 @@ public class Catalog {
         this.routineLoadTaskScheduler = new RoutineLoadTaskScheduler(routineLoadManager);
 
         this.smallFileMgr = new SmallFileMgr();
+
+        this.tagManager = new TagManager();
     }
 
     public static void destroyCheckpoint() {
@@ -4571,6 +4576,10 @@ public class Catalog {
 
     public SmallFileMgr getSmallFileMgr() {
         return this.smallFileMgr;
+    }
+
+    public TagManager getTagManager() {
+        return tagManager;
     }
 
     public long getReplayedJournalId() {

--- a/fe/src/main/java/org/apache/doris/catalog/ColocateGroupSchema.java
+++ b/fe/src/main/java/org/apache/doris/catalog/ColocateGroupSchema.java
@@ -96,10 +96,8 @@ public class ColocateGroupSchema implements Writable {
     }
 
     public void checkReplicationNum(PartitionInfo partitionInfo) throws DdlException {
-        for (Short repNum : partitionInfo.idToReplicationNum.values()) {
-            if (repNum != replicationNum) {
-                ErrorReport.reportDdlException(ErrorCode.ERR_COLOCATE_TABLE_MUST_HAS_SAME_REPLICATION_NUM, replicationNum);
-            }
+        if (!partitionInfo.isReplicaNumSameWith(replicationNum)) {
+            ErrorReport.reportDdlException(ErrorCode.ERR_COLOCATE_TABLE_MUST_HAS_SAME_REPLICATION_NUM, replicationNum);
         }
     }
 

--- a/fe/src/main/java/org/apache/doris/catalog/ColocateTableIndex.java
+++ b/fe/src/main/java/org/apache/doris/catalog/ColocateTableIndex.java
@@ -161,7 +161,7 @@ public class ColocateTableIndex implements Writable {
                 HashDistributionInfo distributionInfo = (HashDistributionInfo) tbl.getDefaultDistributionInfo();
                 ColocateGroupSchema groupSchema = new ColocateGroupSchema(groupId,
                         distributionInfo.getDistributionColumns(), distributionInfo.getBucketNum(),
-                        tbl.getPartitionInfo().idToReplicationNum.values().stream().findFirst().get());
+                        tbl.getPartitionInfo().getArbitraryReplicationNum());
                 group2Schema.put(groupId, groupSchema);
             }
             group2Tables.put(groupId, tbl.getId());
@@ -667,7 +667,7 @@ public class ColocateTableIndex implements Writable {
                         ColocateGroupSchema groupSchema = new ColocateGroupSchema(groupId,
                                 ((HashDistributionInfo)tbl.getDefaultDistributionInfo()).getDistributionColumns(), 
                                 tbl.getDefaultDistributionInfo().getBucketNum(),
-                                tbl.getPartitionInfo().idToReplicationNum.values().stream().findFirst().get());
+                                tbl.getPartitionInfo().getArbitraryReplicationNum());
                         group2Schema.put(groupId, groupSchema);
                         group2BackendsPerBucketSeq.put(groupId, tmpGroup2BackendsPerBucketSeq.get(groupId.grpId));
                     }

--- a/fe/src/main/java/org/apache/doris/catalog/Database.java
+++ b/fe/src/main/java/org/apache/doris/catalog/Database.java
@@ -270,6 +270,10 @@ public class Database extends MetaObject implements Writable {
                 if (table.getType() == TableType.ELASTICSEARCH) {
                     Catalog.getCurrentCatalog().getEsStateStore().registerTable((EsTable)table);
                 }
+
+                if (table.getType() == TableType.OLAP) {
+                    ((OlapTable) table).getPartitionInfo().convertToReplicaAllocation(getClusterName());
+                }
             }
             return result;
         } finally {

--- a/fe/src/main/java/org/apache/doris/catalog/OlapTable.java
+++ b/fe/src/main/java/org/apache/doris/catalog/OlapTable.java
@@ -323,15 +323,15 @@ public class OlapTable extends Table {
         }
 
         // reset partition info and idToPartition map
+        ReplicaAllocation replicaAlloc = ReplicaAllocation.createDefault((short) restoreReplicationNum,
+                db.getClusterName());
         if (partitionInfo.getType() == PartitionType.RANGE) {
             RangePartitionInfo rangePartitionInfo = (RangePartitionInfo) partitionInfo;
             for (Map.Entry<String, Long> entry : origPartNameToId.entrySet()) {
                 long newPartId = catalog.getNextId();
                 rangePartitionInfo.idToDataProperty.put(newPartId,
                                                         rangePartitionInfo.idToDataProperty.remove(entry.getValue()));
-                rangePartitionInfo.idToReplicationNum.remove(entry.getValue());
-                rangePartitionInfo.idToReplicationNum.put(newPartId,
-                                                          (short) restoreReplicationNum);
+                rangePartitionInfo.resetPartitionReplicaNum(entry.getValue(), newPartId, replicaAlloc);
                 rangePartitionInfo.getIdToRange().put(newPartId,
                                                       rangePartitionInfo.getIdToRange().remove(entry.getValue()));
 
@@ -342,8 +342,7 @@ public class OlapTable extends Table {
             long newPartId = catalog.getNextId();
             for (Map.Entry<String, Long> entry : origPartNameToId.entrySet()) {
                 partitionInfo.idToDataProperty.put(newPartId, partitionInfo.idToDataProperty.remove(entry.getValue()));
-                partitionInfo.idToReplicationNum.remove(entry.getValue());
-                partitionInfo.idToReplicationNum.put(newPartId, (short) restoreReplicationNum);
+                partitionInfo.resetPartitionReplicaNum(entry.getValue(), newPartId, replicaAlloc);
                 idToPartition.put(newPartId, idToPartition.remove(entry.getValue()));
             }
         }

--- a/fe/src/main/java/org/apache/doris/catalog/PartitionInfo.java
+++ b/fe/src/main/java/org/apache/doris/catalog/PartitionInfo.java
@@ -17,11 +17,15 @@
 
 package org.apache.doris.catalog;
 
+import org.apache.doris.common.DdlException;
 import org.apache.doris.common.io.Text;
 import org.apache.doris.common.io.Writable;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Maps;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.io.DataInput;
 import java.io.DataOutput;
@@ -33,6 +37,8 @@ import java.util.Map;
  * Repository of a partition's related infos
  */
 public class PartitionInfo implements Writable {
+    private static final Logger LOG = LogManager.getLogger(PartitionInfo.class);
+
     protected PartitionType type;
     // partition id -> data property
     protected Map<Long, DataProperty> idToDataProperty = Maps.newHashMap();
@@ -112,6 +118,18 @@ public class PartitionInfo implements Writable {
             setReplicationNum(partitionId, replicaAlloc);
         }
         idToReplicationNum.clear();
+    }
+
+    /*
+     * This method is only for checking whether the replica allocation converted successfully.
+     */
+    public void checkReplicaAllocation() throws DdlException {
+        if (!idToReplicationNum.isEmpty()) {
+            throw new DdlException("idToReplicationNum is not empty");
+        }
+        if (idToReplicaAllocation.size() != idToDataProperty.size()) {
+            throw new DdlException("idToReplicaAllocation size is incorrect");
+        }
     }
 
     @Override

--- a/fe/src/main/java/org/apache/doris/catalog/PartitionInfo.java
+++ b/fe/src/main/java/org/apache/doris/catalog/PartitionInfo.java
@@ -64,7 +64,7 @@ public class PartitionInfo implements Writable {
     }
 
     public short getReplicationNum(long partitionId) {
-        if (idToReplicaAllocation.containsKey(partitionId)) {
+        if (idToReplicationNum.containsKey(partitionId)) {
             return idToReplicationNum.get(partitionId);
         } else {
             return idToReplicaAllocation.get(partitionId).getReplicaNum();
@@ -120,7 +120,7 @@ public class PartitionInfo implements Writable {
         Preconditions.checkState(idToReplicationNum.isEmpty(), idToReplicaAllocation);
 
         Text.writeString(out, type.name());
-        Preconditions.checkState(idToDataProperty.size() == idToReplicationNum.size());
+        Preconditions.checkState(idToDataProperty.size() == idToReplicaAllocation.size());
         out.writeInt(idToDataProperty.size());
         for (Map.Entry<Long, DataProperty> entry : idToDataProperty.entrySet()) {
             out.writeLong(entry.getKey());

--- a/fe/src/main/java/org/apache/doris/catalog/PartitionInfo.java
+++ b/fe/src/main/java/org/apache/doris/catalog/PartitionInfo.java
@@ -167,7 +167,7 @@ public class PartitionInfo implements Writable {
                 idToDataProperty.put(partitionId, DataProperty.read(in));
             }
 
-            if (Catalog.getCurrentCatalogJournalVersion() <= FeMetaVersion.VERSION_70) {
+            if (Catalog.getCurrentCatalogJournalVersion() < FeMetaVersion.VERSION_70) {
                 short replicationNum = in.readShort();
                 idToReplicationNum.put(partitionId, replicationNum);
             } else {

--- a/fe/src/main/java/org/apache/doris/catalog/PartitionInfo.java
+++ b/fe/src/main/java/org/apache/doris/catalog/PartitionInfo.java
@@ -18,6 +18,7 @@
 package org.apache.doris.catalog;
 
 import org.apache.doris.common.DdlException;
+import org.apache.doris.common.FeMetaVersion;
 import org.apache.doris.common.io.Text;
 import org.apache.doris.common.io.Writable;
 
@@ -149,7 +150,6 @@ public class PartitionInfo implements Writable {
                 entry.getValue().write(out);
             }
 
-            // out.writeShort(idToReplicationNum.get(entry.getKey()));
             idToReplicaAllocation.get(entry.getKey()).write(out);
         }
     }
@@ -167,8 +167,13 @@ public class PartitionInfo implements Writable {
                 idToDataProperty.put(partitionId, DataProperty.read(in));
             }
 
-            short replicationNum = in.readShort();
-            idToReplicationNum.put(partitionId, replicationNum);
+            if (Catalog.getCurrentCatalogJournalVersion() <= FeMetaVersion.VERSION_70) {
+                short replicationNum = in.readShort();
+                idToReplicationNum.put(partitionId, replicationNum);
+            } else {
+                ReplicaAllocation replicaAlloc = ReplicaAllocation.read(in);
+                idToReplicaAllocation.put(partitionId, replicaAlloc);
+            }
         }
     }
 

--- a/fe/src/main/java/org/apache/doris/catalog/RangePartitionInfo.java
+++ b/fe/src/main/java/org/apache/doris/catalog/RangePartitionInfo.java
@@ -190,7 +190,9 @@ public class RangePartitionInfo extends PartitionInfo {
             throw new DdlException("Invalid key range: " + e.getMessage());
         }
         idToDataProperty.put(partitionId, desc.getPartitionDataProperty());
-        idToReplicationNum.put(partitionId, desc.getReplicationNum());
+        ReplicaAllocation replicaAlloc = ReplicaAllocation.createDefault(desc.getReplicationNum(),
+                desc.getClusterName());
+        idToReplicaAllocation.put(partitionId, replicaAlloc);
         return range;
     }
 

--- a/fe/src/main/java/org/apache/doris/catalog/RangePartitionInfo.java
+++ b/fe/src/main/java/org/apache/doris/catalog/RangePartitionInfo.java
@@ -85,8 +85,8 @@ public class RangePartitionInfo extends PartitionInfo {
     }
 
     public void addPartition(long partitionId, Range<PartitionKey> range, DataProperty dataProperty,
-            short replicationNum) {
-        addPartition(partitionId, dataProperty, replicationNum);
+            ReplicaAllocation replicaAlloc) {
+        addPartition(partitionId, dataProperty, replicaAlloc);
         idToRange.put(partitionId, range);
     }
 

--- a/fe/src/main/java/org/apache/doris/catalog/ReplicaAllocation.java
+++ b/fe/src/main/java/org/apache/doris/catalog/ReplicaAllocation.java
@@ -1,0 +1,120 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.catalog;
+
+import org.apache.doris.common.io.Text;
+import org.apache.doris.common.io.Writable;
+import org.apache.doris.persist.gson.GsonUtils;
+import org.apache.doris.resource.Tag;
+import org.apache.doris.resource.TagSet;
+import org.apache.doris.system.Backend;
+
+import com.google.common.collect.HashBasedTable;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Table;
+import com.google.gson.annotations.SerializedName;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import java.util.Map;
+
+/*
+ * This class represent the allocation of replicas.
+ * This class is not thread safe
+ */
+public class ReplicaAllocation implements Writable {
+    public enum AllocationType {
+        LOCAL, // replica is allocated on local Backend
+        REMOTE // replica is allocated on remote storage
+    }
+
+    @SerializedName(value = "typeToTag")
+    // allocation type -> (tags -> replication num)
+    private Table<AllocationType, TagSet, Short> typeToTag = HashBasedTable.create();
+
+    // return the default allocation with specified replication num
+    public static ReplicaAllocation createDefault(short replicaNum, String cluster) {
+        ReplicaAllocation replicaAlloc = new ReplicaAllocation();
+        TagSet tagSet = TagSet.copyFrom(Backend.DEFAULT_TAG_SET);
+        tagSet.substituteMerge(TagSet.create(Tag.createNoThrow(Tag.TYPE_LOCATION, cluster)));
+        replicaAlloc.setReplica(AllocationType.LOCAL, tagSet, replicaNum);
+        return replicaAlloc;
+    }
+
+    public ReplicaAllocation() {
+
+    }
+
+    public ReplicaAllocation(ReplicaAllocation other) {
+        typeToTag = HashBasedTable.create(other.typeToTag);
+    }
+
+    // set replication num by give allocation type and set of tags.
+    // it will overwrite existing entry
+    public void setReplica(AllocationType type, TagSet tagSet, short num) {
+        typeToTag.put(type, tagSet, num);
+    }
+
+    // return the total replica num of given allocation type
+    public short getReplicaNumByType(AllocationType type) {
+        if (!typeToTag.containsRow(type)) {
+            return 0;
+        }
+        return (short) typeToTag.row(type).values().stream().mapToInt(Short::valueOf).sum();
+    }
+
+    // return the total replica num
+    public short getReplicaNum() {
+        return (short) typeToTag.values().stream().mapToInt(Short::valueOf).sum();
+    }
+
+    // return a map of (tagset -> replication num).
+    // return a empty map if there is no such replica allocation type
+    public Map<TagSet, Short> getTagMapByType(AllocationType type) {
+        if (!typeToTag.containsRow(type)) {
+            return Maps.newHashMap();
+        }
+        return Maps.newHashMap(typeToTag.row(type));
+    }
+
+    // return true if 2 replica allocations are same
+    public boolean isSameAlloc(ReplicaAllocation allocation) {
+        return typeToTag.equals(allocation.typeToTag);
+    }
+
+    public static ReplicaAllocation read(DataInput in) throws IOException {
+        String json = Text.readString(in);
+        ReplicaAllocation allocation = GsonUtils.GSON.fromJson(json, ReplicaAllocation.class);
+        return allocation;
+    }
+
+
+    @Override
+    public void write(DataOutput out) throws IOException {
+        String json = GsonUtils.GSON.toJson(this);
+        Text.writeString(out, json);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        // TODO
+        return sb.toString();
+    }
+}

--- a/fe/src/main/java/org/apache/doris/common/FeMetaVersion.java
+++ b/fe/src/main/java/org/apache/doris/common/FeMetaVersion.java
@@ -149,6 +149,10 @@ public final class FeMetaVersion {
     public static final int VERSION_68 = 68;
     // modofy password checking logic
     public static final int VERSION_69 = 69;
+
+    // add replica allocation
+    public static final int VERSION_70 = 70;
+
     // note: when increment meta version, should assign the latest version to VERSION_CURRENT
-    public static final int VERSION_CURRENT = VERSION_69;
+    public static final int VERSION_CURRENT = VERSION_70;
 }

--- a/fe/src/main/java/org/apache/doris/common/proc/ProcService.java
+++ b/fe/src/main/java/org/apache/doris/common/proc/ProcService.java
@@ -50,6 +50,7 @@ public final class ProcService {
         root.register("cluster_balance", new ClusterBalanceProcDir());
         root.register("routine_loads", new RoutineLoadsProcDir());
         root.register("colocation_group", new ColocationGroupProcDir());
+        root.register("tags", new TagsProcNode(Catalog.getCurrentCatalog().getTagManager()));
     }
 
     // 通过指定的路径获得对应的PROC Node

--- a/fe/src/main/java/org/apache/doris/common/proc/TagsProcNode.java
+++ b/fe/src/main/java/org/apache/doris/common/proc/TagsProcNode.java
@@ -18,39 +18,36 @@
 package org.apache.doris.common.proc;
 
 import org.apache.doris.common.AnalysisException;
+import org.apache.doris.resource.TagManager;
 
-import com.google.common.collect.Lists;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
 
-import java.util.Map;
-import java.util.concurrent.ConcurrentSkipListMap;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
+public class TagsProcNode implements ProcNodeInterface {
+    private static final Logger LOG = LogManager.getLogger(TagsProcNode.class);
 
-// 通用PROC DIR类，可以进行注册，返回底层节点内容。
-// 非线程安全的，需要调用者考虑线程安全内容。
-public class BaseProcDir implements ProcDirInterface {
-    protected Map<String, ProcNodeInterface> nodeMap = new ConcurrentSkipListMap<>();;
+    public static final ImmutableList<String> TITLE_NAMES = new ImmutableList.Builder<String>()
+            .add("Tags").add("ResourceIds")
+            .build();
 
-    public BaseProcDir() {
-    }
+    private TagManager tagManager;
 
-    @Override
-    public boolean register(String name, ProcNodeInterface node) {
-        nodeMap.put(name, node);
-        return true;
-    }
-
-    @Override
-    public ProcNodeInterface lookup(String name) {
-        return nodeMap.get(name);
+    public TagsProcNode(TagManager tagManager) {
+        this.tagManager = tagManager;
     }
 
     @Override
     public ProcResult fetchResult() throws AnalysisException {
+        Preconditions.checkNotNull(tagManager);
+
         BaseProcResult result = new BaseProcResult();
-        result.setNames(Lists.newArrayList("name"));
-        for (String name : nodeMap.keySet()) {
-            result.addRow(Lists.newArrayList(name));
-        }
+        result.setNames(TITLE_NAMES);
+        result.setRows(tagManager.getShowInfos());
         return result;
     }
 }
+
+

--- a/fe/src/main/java/org/apache/doris/common/util/ListComparator.java
+++ b/fe/src/main/java/org/apache/doris/common/util/ListComparator.java
@@ -25,7 +25,7 @@ import java.util.List;
 /*
  * this class is for sorting list collections
  */
-public class ListComparator<T extends List<Comparable>> implements Comparator<T> {
+public class ListComparator<T extends List<? extends Comparable>> implements Comparator<T> {
 
     OrderByPair[] orderByPairs;
     boolean isDesc;

--- a/fe/src/main/java/org/apache/doris/external/EsStateStore.java
+++ b/fe/src/main/java/org/apache/doris/external/EsStateStore.java
@@ -296,8 +296,7 @@ public class EsStateStore extends MasterDaemon {
             long partitionId = 0;
             for (EsIndexState esIndexState : esIndexStates) {
                 Range<PartitionKey> range = ((RangePartitionInfo) partitionInfo).handleNewSinglePartitionDesc(
-                        esIndexState.getPartitionDesc(),
-                        partitionId);
+                        esIndexState.getPartitionDesc(), partitionId);
                 esTableState.addPartition(esIndexState.getIndexName(), partitionId);
                 esIndexState.setPartitionId(partitionId);
                 ++partitionId;

--- a/fe/src/main/java/org/apache/doris/http/HttpServer.java
+++ b/fe/src/main/java/org/apache/doris/http/HttpServer.java
@@ -49,6 +49,7 @@ import org.apache.doris.http.rest.GetSmallFileAction;
 import org.apache.doris.http.rest.GetStreamLoadState;
 import org.apache.doris.http.rest.HealthAction;
 import org.apache.doris.http.rest.LoadAction;
+import org.apache.doris.http.rest.MetaCheckAction;
 import org.apache.doris.http.rest.MetaReplayerCheckAction;
 import org.apache.doris.http.rest.MetricsAction;
 import org.apache.doris.http.rest.MigrationAction;
@@ -163,6 +164,7 @@ public class HttpServer {
         CheckAction.registerAction(controller, imageDir);
         DumpAction.registerAction(controller, imageDir);
         RoleAction.registerAction(controller, imageDir);
+        MetaCheckAction.registerAction(controller);
 
         // external usage
         TableRowCountAction.registerAction(controller);

--- a/fe/src/main/java/org/apache/doris/http/rest/MetaCheckAction.java
+++ b/fe/src/main/java/org/apache/doris/http/rest/MetaCheckAction.java
@@ -55,7 +55,7 @@ public class MetaCheckAction extends RestBaseAction {
     }
 
     public static void registerAction(ActionController controller) throws IllegalArgException {
-        controller.registerHandler(HttpMethod.GET, "/metacheck/", new MetricsAction(controller));
+        controller.registerHandler(HttpMethod.GET, "/metacheck/", new MetaCheckAction(controller));
     }
 
     @Override

--- a/fe/src/main/java/org/apache/doris/http/rest/MetaCheckAction.java
+++ b/fe/src/main/java/org/apache/doris/http/rest/MetaCheckAction.java
@@ -28,7 +28,8 @@ import org.apache.doris.http.ActionController;
 import org.apache.doris.http.BaseRequest;
 import org.apache.doris.http.BaseResponse;
 import org.apache.doris.http.IllegalArgException;
-import org.apache.doris.metric.MetricVisitor;
+import org.apache.doris.mysql.privilege.PrivPredicate;
+import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.system.Backend;
 import org.apache.doris.system.SystemInfoService;
 
@@ -60,8 +61,13 @@ public class MetaCheckAction extends RestBaseAction {
 
     @Override
     protected void executeWithoutPassword(BaseRequest request, BaseResponse response) {
+        if (Catalog.getCurrentCatalog().getAuth().checkGlobalPriv(ConnectContext.get(), PrivPredicate.ADMIN)) {
+            response.setContentType("text/plain");
+            response.getContent().append("Access denied. Need ADMIN privilege");
+            sendResult(request, response);
+        }
+
         String type = request.getSingleParameter(TYPE_PARAM);
-        MetricVisitor visitor = null;
         if (Strings.isNullOrEmpty(type)) {
             response.setContentType("text/plain");
             response.getContent().append("Missing type parameter");

--- a/fe/src/main/java/org/apache/doris/http/rest/MetaCheckAction.java
+++ b/fe/src/main/java/org/apache/doris/http/rest/MetaCheckAction.java
@@ -61,7 +61,7 @@ public class MetaCheckAction extends RestBaseAction {
 
     @Override
     protected void executeWithoutPassword(BaseRequest request, BaseResponse response) {
-        if (Catalog.getCurrentCatalog().getAuth().checkGlobalPriv(ConnectContext.get(), PrivPredicate.ADMIN)) {
+        if (!Catalog.getCurrentCatalog().getAuth().checkGlobalPriv(ConnectContext.get(), PrivPredicate.ADMIN)) {
             response.setContentType("text/plain");
             response.getContent().append("Access denied. Need ADMIN privilege");
             sendResult(request, response);

--- a/fe/src/main/java/org/apache/doris/http/rest/MetaCheckAction.java
+++ b/fe/src/main/java/org/apache/doris/http/rest/MetaCheckAction.java
@@ -1,0 +1,141 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.http.rest;
+
+import org.apache.doris.catalog.Catalog;
+import org.apache.doris.catalog.Database;
+import org.apache.doris.catalog.OlapTable;
+import org.apache.doris.catalog.PartitionInfo;
+import org.apache.doris.catalog.Table;
+import org.apache.doris.catalog.Table.TableType;
+import org.apache.doris.common.DdlException;
+import org.apache.doris.http.ActionController;
+import org.apache.doris.http.BaseRequest;
+import org.apache.doris.http.BaseResponse;
+import org.apache.doris.http.IllegalArgException;
+import org.apache.doris.metric.MetricVisitor;
+import org.apache.doris.system.Backend;
+import org.apache.doris.system.SystemInfoService;
+
+import com.google.common.base.Strings;
+import com.google.common.collect.Maps;
+import com.google.gson.Gson;
+
+import java.util.List;
+import java.util.Map;
+
+import io.netty.handler.codec.http.HttpMethod;
+
+/*
+ * This action is used to check metadata.
+ * It is usually used to check some metadata information, such as whether the metadata information is correct.
+ */
+public class MetaCheckAction extends RestBaseAction {
+
+    private static final String TYPE_PARAM = "type";
+    private static final String TYPE_REPLICA_ALLOCATION = "replica_allocation";
+
+    public MetaCheckAction(ActionController controller) {
+        super(controller);
+    }
+
+    public static void registerAction(ActionController controller) throws IllegalArgException {
+        controller.registerHandler(HttpMethod.GET, "/metacheck/", new MetricsAction(controller));
+    }
+
+    @Override
+    protected void executeWithoutPassword(BaseRequest request, BaseResponse response) {
+        String type = request.getSingleParameter(TYPE_PARAM);
+        MetricVisitor visitor = null;
+        if (Strings.isNullOrEmpty(type)) {
+            response.setContentType("text/plain");
+            response.getContent().append("Missing type parameter");
+            sendResult(request, response);
+        } else if (type.equalsIgnoreCase(TYPE_REPLICA_ALLOCATION)) {
+            checkReplicaAllocation(request, response);
+        } else {
+            response.setContentType("text/plain");
+            response.getContent().append("Unsupported type: " + type);
+            sendResult(request, response);
+        }
+    }
+
+    /*
+     * check the following metadata:
+     * 1. All olap table's partition info has been set replica allocation, and idToReplicationNum is empty
+     * 2. All backend's tag set has been set
+     */
+    private void checkReplicaAllocation(BaseRequest request, BaseResponse response) {
+        Gson gson = new Gson();
+        Map<String, Object> result = Maps.newHashMap();
+        result.put("status", "ok");
+        Map<String, String> partitionInfos = Maps.newHashMap();
+        Map<Long, String> backendInfos = Maps.newHashMap();
+
+        result.put("partition_info", partitionInfos);
+        result.put("backend", backendInfos);
+
+        // 1. check partition info
+        Catalog catalog = Catalog.getCheckpoint();
+        List<Long> dbIds = catalog.getDbIds();
+        for (Long dbId : dbIds) {
+            Database db = catalog.getDb(dbId);
+            if (db == null) {
+                continue;
+            }
+            db.readLock();
+            try {
+                for (Table table : db.getTables()) {
+                    if (table.getType() != TableType.OLAP) {
+                        continue;
+                    }
+                    PartitionInfo partitionInfo = ((OlapTable) table).getPartitionInfo();
+                    try {
+                        partitionInfo.checkReplicaAllocation();
+                    } catch (DdlException e) {
+                        result.put("status", "failed");
+                        partitionInfos.put(db.getFullName() + "." + table.getName(), e.getMessage());
+                    }
+                }
+            } finally {
+                db.readUnlock();
+            }
+        }
+
+        // 2. check backends
+        SystemInfoService infoService = Catalog.getCurrentSystemInfo();
+        List<Long> backendIds = infoService.getBackendIds(false);
+        for (Long beId : backendIds) {
+            Backend be = infoService.getBackend(beId);
+            if (be == null) {
+                continue;
+            }
+
+            try {
+                be.checkTagSetConverted();
+            } catch (DdlException e) {
+                result.put("status", "failed");
+                backendInfos.put(be.getId(), e.getMessage());
+            }
+        }
+
+        response.setContentType("application/json");
+        response.getContent().append(gson.toJson(result));
+        sendResult(request, response);
+    }
+}

--- a/fe/src/main/java/org/apache/doris/master/Checkpoint.java
+++ b/fe/src/main/java/org/apache/doris/master/Checkpoint.java
@@ -104,7 +104,7 @@ public class Checkpoint extends MasterDaemon {
                           checkPointVersion, catalog.getReplayedJournalId());
                 return;
             }
-            catalog.fixBugAfterMetadataReplayed(false);
+            catalog.metaConvertOrBugFixAfterMetadataReplayed(false);
 
             catalog.saveImage();
             replayedJournalId = catalog.getReplayedJournalId();

--- a/fe/src/main/java/org/apache/doris/resource/Resource.java
+++ b/fe/src/main/java/org/apache/doris/resource/Resource.java
@@ -32,6 +32,11 @@ public abstract class Resource {
     @SerializedName(value = "tagSet")
     protected TagSet tagSet;
 
+    public Resource(long id) {
+        this.id = id;
+        this.tagSet = TagSet.create();
+    }
+
     public Resource(long id, TagSet tagSet) {
         this.tagSet = tagSet;
     }

--- a/fe/src/main/java/org/apache/doris/resource/Tag.java
+++ b/fe/src/main/java/org/apache/doris/resource/Tag.java
@@ -22,6 +22,7 @@ import org.apache.doris.common.io.Text;
 import org.apache.doris.common.io.Writable;
 import org.apache.doris.persist.gson.GsonUtils;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
 import com.google.gson.annotations.SerializedName;
 
@@ -51,7 +52,7 @@ import java.util.Objects;
 public class Tag implements Writable {
 
     public static final String TYPE_ROLE = "role";
-    public static final String TYPE_FUNCATION = "function";
+    public static final String TYPE_FUNCTION = "function";
     public static final String TYPE_LOCATION = "location";
 
     public static final String VALUE_FRONTEND = "frontend";
@@ -63,7 +64,7 @@ public class Tag implements Writable {
     public static final String VALUE_DEFAULT_CLUSTER = "default_cluster";
 
     public static final ImmutableSet<String> RESERVED_TAG_TYPE = ImmutableSet.of(
-            TYPE_ROLE, TYPE_FUNCATION, TYPE_LOCATION);
+            TYPE_ROLE, TYPE_FUNCTION, TYPE_LOCATION);
     public static final ImmutableSet<String> RESERVED_TAG_VALUES = ImmutableSet.of(
             VALUE_FRONTEND, VALUE_BACKEND, VALUE_BROKER, VALUE_REMOTE_STORAGE, VALUE_STORE, VALUE_COMPUTATION,
             VALUE_DEFAULT_CLUSTER);
@@ -84,6 +85,15 @@ public class Tag implements Writable {
             throw new AnalysisException("Invalid tag format: " + type + ":" + value);
         }
         return new Tag(type, value);
+    }
+
+    public static Tag createNoThrow(String type, String value) {
+        try {
+            return Tag.create(type, value);
+        } catch (AnalysisException e) {
+            Preconditions.checkState(false, type + ":" + value);
+        }
+        return null;
     }
 
     @Override

--- a/fe/src/main/java/org/apache/doris/resource/TagManager.java
+++ b/fe/src/main/java/org/apache/doris/resource/TagManager.java
@@ -19,6 +19,7 @@ package org.apache.doris.resource;
 
 import org.apache.doris.common.io.Text;
 import org.apache.doris.common.io.Writable;
+import org.apache.doris.common.util.ListComparator;
 import org.apache.doris.persist.gson.GsonUtils;
 
 import com.google.common.base.Joiner;
@@ -31,6 +32,7 @@ import com.google.gson.annotations.SerializedName;
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -211,6 +213,9 @@ public class TagManager implements Writable {
         } finally {
             lock.readLock().unlock();
         }
+
+        ListComparator<List<? extends Comparable>> comparator = new ListComparator<List<? extends Comparable>>(0);
+        Collections.sort(infos, comparator);
         return infos;
     }
 

--- a/fe/src/main/java/org/apache/doris/resource/TagManager.java
+++ b/fe/src/main/java/org/apache/doris/resource/TagManager.java
@@ -21,7 +21,9 @@ import org.apache.doris.common.io.Text;
 import org.apache.doris.common.io.Writable;
 import org.apache.doris.persist.gson.GsonUtils;
 
+import com.google.common.base.Joiner;
 import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.google.gson.annotations.SerializedName;
@@ -29,6 +31,7 @@ import com.google.gson.annotations.SerializedName;
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
@@ -192,6 +195,23 @@ public class TagManager implements Writable {
                 tagIndex.put(tag, resourceId);
             }
         }
+    }
+
+    public List<List<String>> getShowInfos() {
+        List<List<String>> infos = Lists.newArrayList();
+        lock.readLock().lock();
+        try {
+            for (Tag tag : tagIndex.keySet()) {
+                Set<Long> resourceIds = tagIndex.get(tag);
+                List<String> info = Lists.newArrayList();
+                info.add(tag.toString());
+                info.add(Joiner.on(",").join(resourceIds));
+                infos.add(info);
+            }
+        } finally {
+            lock.readLock().unlock();
+        }
+        return infos;
     }
 
     @Override

--- a/fe/src/main/java/org/apache/doris/system/Backend.java
+++ b/fe/src/main/java/org/apache/doris/system/Backend.java
@@ -21,6 +21,7 @@ import org.apache.doris.alter.DecommissionBackendJob.DecommissionType;
 import org.apache.doris.catalog.Catalog;
 import org.apache.doris.catalog.DiskInfo;
 import org.apache.doris.catalog.DiskInfo.DiskState;
+import org.apache.doris.common.DdlException;
 import org.apache.doris.common.FeMetaVersion;
 import org.apache.doris.common.io.Text;
 import org.apache.doris.common.io.Writable;
@@ -661,6 +662,19 @@ public class Backend extends Resource implements Writable {
         if (!ownerClusterName.get().equals(SystemInfoService.DEFAULT_CLUSTER)) {
             Tag locationTag = Tag.createNoThrow(Tag.TYPE_LOCATION, ownerClusterName.get());
             this.tagSet.substituteMerge(TagSet.create(locationTag));
+        }
+    }
+
+    /*
+     * Only used for checking whether the tag system converted successfully
+     */
+    public void checkTagSetConverted() throws DdlException {
+        if (tagSet.isEmpty()) {
+            throw new DdlException("tag set is empty");
+        }
+
+        if (!tagSet.containsTag(Tag.createNoThrow(Tag.TYPE_LOCATION, ownerClusterName.get()))) {
+            throw new DdlException("tag set does not contain location with cluster: " + ownerClusterName.get());
         }
     }
 }

--- a/fe/src/main/java/org/apache/doris/system/Backend.java
+++ b/fe/src/main/java/org/apache/doris/system/Backend.java
@@ -24,6 +24,8 @@ import org.apache.doris.catalog.DiskInfo.DiskState;
 import org.apache.doris.common.FeMetaVersion;
 import org.apache.doris.common.io.Text;
 import org.apache.doris.common.io.Writable;
+import org.apache.doris.resource.Tag;
+import org.apache.doris.resource.TagSet;
 import org.apache.doris.system.HeartbeatResponse.HbStatus;
 import org.apache.doris.thrift.TDisk;
 
@@ -92,6 +94,17 @@ public class Backend implements Writable {
     // the max tablet compaction score of this backend.
     // this field is set by tablet report, and just for metric monitor, no need to persist.
     private AtomicLong tabletMaxCompactionScore = new AtomicLong(0);
+
+    // the default tag set of a backend.
+    // it also used for being compatible with cluster system
+    public static final TagSet DEFAULT_TAG_SET;
+    static {
+        Tag typeTag = Tag.createNoThrow(Tag.TYPE_ROLE, Tag.VALUE_FRONTEND);
+        Tag locationTag = Tag.createNoThrow(Tag.TYPE_LOCATION, Tag.VALUE_DEFAULT_CLUSTER);
+        Tag storageTag = Tag.createNoThrow(Tag.TYPE_FUNCTION, Tag.VALUE_STORE);
+        Tag computeTag = Tag.createNoThrow(Tag.TYPE_FUNCTION, Tag.VALUE_COMPUTATION);
+        DEFAULT_TAG_SET = TagSet.create(typeTag, locationTag, storageTag, computeTag);
+    }
 
     public Backend() {
         this.host = "";

--- a/fe/src/main/java/org/apache/doris/system/SystemInfoService.java
+++ b/fe/src/main/java/org/apache/doris/system/SystemInfoService.java
@@ -169,8 +169,10 @@ public class SystemInfoService {
 
         newBackend.convertToTagSystem();
 
+        Catalog.getCurrentCatalog().getTagManager().addResourceTags(newBackend.getId(), newBackend.getTagSet());
+
         // log
-        Catalog.getInstance().getEditLog().logAddBackend(newBackend);
+        Catalog.getCurrentCatalog().getEditLog().logAddBackend(newBackend);
         LOG.info("finished to add {} ", newBackend);
 
         // backends is changed, regenerated tablet number metrics
@@ -227,6 +229,9 @@ public class SystemInfoService {
         } else {
             LOG.error("Cluster " + droppedBackend.getOwnerClusterName() + " no exist.");
         }
+
+        Catalog.getCurrentCatalog().getTagManager().removeResource(droppedBackend.getId());
+
         // log
         Catalog.getInstance().getEditLog().logDropBackend(droppedBackend);
         LOG.info("finished to drop {}", droppedBackend);
@@ -1013,6 +1018,7 @@ public class SystemInfoService {
         }
 
         newBackend.convertToTagSystem();
+        Catalog.getCurrentCatalog().getTagManager().addResourceTags(newBackend.getId(), newBackend.getTagSet());
     }
 
     public void replayDropBackend(Backend backend) {
@@ -1036,6 +1042,7 @@ public class SystemInfoService {
         } else {
             LOG.error("Cluster " + backend.getOwnerClusterName() + " no exist.");
         }
+        Catalog.getCurrentCatalog().getTagManager().removeResource(backend.getId());
     }
 
     public void updateBackendState(Backend be) {

--- a/fe/src/main/java/org/apache/doris/system/SystemInfoService.java
+++ b/fe/src/main/java/org/apache/doris/system/SystemInfoService.java
@@ -167,6 +167,8 @@ public class SystemInfoService {
             // backend is free
         }
 
+        newBackend.convertToTagSystem();
+
         // log
         Catalog.getInstance().getEditLog().logAddBackend(newBackend);
         LOG.info("finished to add {} ", newBackend);
@@ -1009,6 +1011,8 @@ public class SystemInfoService {
                 // cluster is not created. Be in cluster will be updated in loadCluster.
             }
         }
+
+        newBackend.convertToTagSystem();
     }
 
     public void replayDropBackend(Backend backend) {
@@ -1148,6 +1152,12 @@ public class SystemInfoService {
         ImmutableMap<Long, DiskInfo> newPathInfos = ImmutableMap.copyOf(copiedPathInfos);
         pathHashToDishInfoRef.set(newPathInfos);
         LOG.debug("update path infos: {}", newPathInfos);
+    }
+
+    public void convertToTagSystem() {
+        for (Backend backend : idToBackendRef.get().values()) {
+            backend.convertToTagSystem();
+        }
     }
 }
 

--- a/fe/src/test/java/org/apache/doris/analysis/AccessTestUtil.java
+++ b/fe/src/test/java/org/apache/doris/analysis/AccessTestUtil.java
@@ -38,6 +38,7 @@ import org.apache.doris.mysql.privilege.PaloAuth;
 import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.persist.EditLog;
 import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.resource.TagManager;
 import org.apache.doris.system.SystemInfoService;
 
 import com.google.common.collect.Lists;
@@ -104,6 +105,8 @@ public class AccessTestUtil {
             EasyMock.expect(catalog.getRollupHandler()).andReturn(new MaterializedViewHandler()).anyTimes();
             EasyMock.expect(catalog.getEditLog()).andReturn(EasyMock.createMock(EditLog.class)).anyTimes();
             EasyMock.expect(catalog.getClusterDbNames("testCluster")).andReturn(Lists.newArrayList("testCluster:testDb")).anyTimes();
+            EasyMock.expect(catalog.getTagManager()).andReturn(new TagManager()).anyTimes();
+
             catalog.changeDb(EasyMock.isA(ConnectContext.class), EasyMock.eq("blockDb"));
             EasyMock.expectLastCall().andThrow(new DdlException("failed.")).anyTimes();
             catalog.changeDb(EasyMock.isA(ConnectContext.class), EasyMock.isA(String.class));

--- a/fe/src/test/java/org/apache/doris/analysis/DescribeStmtTest.java
+++ b/fe/src/test/java/org/apache/doris/analysis/DescribeStmtTest.java
@@ -39,7 +39,7 @@ public class DescribeStmtTest {
     private Analyzer analyzer;
     private Catalog catalog;
     private ConnectContext ctx;
-
+    
     @Before
     public void setUp() {
         ctx = new ConnectContext(null);
@@ -57,7 +57,6 @@ public class DescribeStmtTest {
         EasyMock.expect(Catalog.getCurrentCatalog()).andReturn(catalog).anyTimes();
         EasyMock.expect(Catalog.getCurrentSystemInfo()).andReturn(AccessTestUtil.fetchSystemInfoService()).anyTimes();
         PowerMock.replay(Catalog.class);
-
     }
 
     @Test

--- a/fe/src/test/java/org/apache/doris/backup/CatalogMocker.java
+++ b/fe/src/test/java/org/apache/doris/backup/CatalogMocker.java
@@ -40,6 +40,7 @@ import org.apache.doris.catalog.RandomDistributionInfo;
 import org.apache.doris.catalog.RangePartitionInfo;
 import org.apache.doris.catalog.Replica;
 import org.apache.doris.catalog.Replica.ReplicaState;
+import org.apache.doris.catalog.ReplicaAllocation;
 import org.apache.doris.catalog.ScalarType;
 import org.apache.doris.catalog.SinglePartitionInfo;
 import org.apache.doris.catalog.Tablet;
@@ -230,7 +231,8 @@ public class CatalogMocker {
         Partition partition =
                 new Partition(TEST_SINGLE_PARTITION_ID, TEST_SINGLE_PARTITION_NAME, baseIndex, distributionInfo);
         PartitionInfo partitionInfo = new SinglePartitionInfo();
-        partitionInfo.setReplicationNum(TEST_SINGLE_PARTITION_ID, (short) 3);
+        ReplicaAllocation replicaAlloc = ReplicaAllocation.createDefault((short) 3, "default_cluster");
+        partitionInfo.setReplicationNum(TEST_SINGLE_PARTITION_ID, replicaAlloc);
         DataProperty dataProperty = new DataProperty(TStorageMedium.HDD);
         partitionInfo.setDataProperty(TEST_SINGLE_PARTITION_ID, dataProperty);
         OlapTable olapTable = new OlapTable(TEST_TBL_ID, TEST_TBL_NAME, TEST_TBL_BASE_SCHEMA,
@@ -297,8 +299,10 @@ public class CatalogMocker {
         Range<PartitionKey> rangeP2 = Range.closedOpen(rangeP2Lower, rangeP2Upper);
         rangePartitionInfo.setRange(TEST_PARTITION2_ID, rangeP2);
 
-        rangePartitionInfo.setReplicationNum(TEST_PARTITION1_ID, (short) 3);
-        rangePartitionInfo.setReplicationNum(TEST_PARTITION2_ID, (short) 3);
+        ReplicaAllocation replicaAlloc1 = ReplicaAllocation.createDefault((short) 3, "default_cluster");
+        rangePartitionInfo.setReplicationNum(TEST_PARTITION1_ID, replicaAlloc1);
+        ReplicaAllocation replicaAlloc2 = ReplicaAllocation.createDefault((short) 3, "default_cluster");
+        rangePartitionInfo.setReplicationNum(TEST_PARTITION2_ID, replicaAlloc2);
         DataProperty dataPropertyP1 = new DataProperty(TStorageMedium.HDD);
         DataProperty dataPropertyP2 = new DataProperty(TStorageMedium.HDD);
         rangePartitionInfo.setDataProperty(TEST_PARTITION1_ID, dataPropertyP1);

--- a/fe/src/test/java/org/apache/doris/catalog/BackendTest.java
+++ b/fe/src/test/java/org/apache/doris/catalog/BackendTest.java
@@ -135,11 +135,13 @@ public class BackendTest {
         for (int count = 0; count < 100; ++count) {
             Backend backend = new Backend(count, "10.120.22.32" + count, 6000 + count);
             backend.updateOnce(7000 + count, 9000 + count, beRpcPort);
+            backend.convertToTagSystem();
             list1.add(backend);
         }
         for (int count = 100; count < 200; count++) {
             Backend backend = new Backend(count, "10.120.22.32" + count, 6000 + count);
             backend.updateOnce(7000 + count, 9000 + count, beRpcPort);
+            backend.convertToTagSystem();
             list1.add(backend);
         }
         for (Backend backend : list1) {
@@ -151,11 +153,11 @@ public class BackendTest {
         // 2. Read objects from file
         DataInputStream dis = new DataInputStream(new FileInputStream(file));
         for (int count = 0; count < 100; ++count) {
-            Backend backend = new Backend();
-            backend.readFields(dis);
+            Backend backend = Backend.read(dis);
             list2.add(backend);
             Assert.assertEquals(count, backend.getId());
             Assert.assertEquals("10.120.22.32" + count, backend.getHost());
+            Assert.assertEquals(Backend.DEFAULT_TAG_SET, backend.getTagSet());
         }
         
         for (int count = 100; count < 200; ++count) {
@@ -163,6 +165,7 @@ public class BackendTest {
             list2.add(backend);
             Assert.assertEquals(count, backend.getId());
             Assert.assertEquals("10.120.22.32" + count, backend.getHost());
+            Assert.assertEquals(Backend.DEFAULT_TAG_SET, backend.getTagSet());
         }
         
         for (int count = 0; count < 200; count++) {

--- a/fe/src/test/java/org/apache/doris/catalog/CatalogTestUtil.java
+++ b/fe/src/test/java/org/apache/doris/catalog/CatalogTestUtil.java
@@ -209,7 +209,8 @@ public class CatalogTestUtil {
         // table
         PartitionInfo partitionInfo = new SinglePartitionInfo();
         partitionInfo.setDataProperty(partitionId, DataProperty.DEFAULT_HDD_DATA_PROPERTY);
-        partitionInfo.setReplicationNum(partitionId, (short) 3);
+        ReplicaAllocation replicaAlloc = ReplicaAllocation.createDefault((short) 3, "default_cluster");
+        partitionInfo.setReplicationNum(partitionId, replicaAlloc);
         OlapTable table = new OlapTable(tableId, testTable1, columns, KeysType.AGG_KEYS, partitionInfo,
                 distributionInfo);
         table.addPartition(partition);

--- a/fe/src/test/java/org/apache/doris/catalog/CreateTableTest.java
+++ b/fe/src/test/java/org/apache/doris/catalog/CreateTableTest.java
@@ -24,6 +24,7 @@ import org.apache.doris.analysis.HashDistributionDesc;
 import org.apache.doris.analysis.KeysDesc;
 import org.apache.doris.analysis.TableName;
 import org.apache.doris.analysis.TypeDef;
+import org.apache.doris.analysis.UserIdentity;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.DdlException;
 import org.apache.doris.common.util.PropertyAnalyzer;
@@ -66,8 +67,7 @@ public class CreateTableTest {
     private Database db = new Database();
     private Analyzer analyzer;
 
-    @Injectable
-    ConnectContext connectContext;
+    ConnectContext ctx;
 
     @Rule
     public ExpectedException expectedEx = ExpectedException.none();
@@ -86,7 +86,9 @@ public class CreateTableTest {
         columnDefs.add(new ColumnDef("key1", new TypeDef(ScalarType.createType(PrimitiveType.INT))));
         columnDefs.add(new ColumnDef("key2", new TypeDef(ScalarType.createVarchar(10))));
 
-        analyzer = new Analyzer(catalog, connectContext);
+        analyzer = new Analyzer(catalog, ctx);
+
+        db.setClusterName(SystemInfoService.DEFAULT_CLUSTER);
 
         new Expectations(analyzer) {
             {
@@ -95,6 +97,13 @@ public class CreateTableTest {
                 result = clusterName;
             }
         };
+
+        ctx = new ConnectContext(null);
+        ctx.setQualifiedUser("root");
+        ctx.setRemoteIP("127.0.0.1");
+        ctx.setCurrentUserIdentity(UserIdentity.createAnalyzedUserIdentWithIp("root", "%"));
+        ctx.setCluster(SystemInfoService.DEFAULT_CLUSTER);
+        ctx.setThreadLocalInfo();
 
         dbTableName.analyze(analyzer);
     }

--- a/fe/src/test/java/org/apache/doris/catalog/ReplicaAllocationTest.java
+++ b/fe/src/test/java/org/apache/doris/catalog/ReplicaAllocationTest.java
@@ -62,7 +62,5 @@ public class ReplicaAllocationTest {
         tagMap = replicaAllocation.getTagMapByType(AllocationType.LOCAL);
         Assert.assertTrue(tagMap.containsKey(tagSet));
         Assert.assertEquals(3, (int) tagMap.get(tagSet));
-        
-        replicaAllocation.g
     }
 }

--- a/fe/src/test/java/org/apache/doris/catalog/ReplicaAllocationTest.java
+++ b/fe/src/test/java/org/apache/doris/catalog/ReplicaAllocationTest.java
@@ -1,0 +1,68 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.catalog;
+
+import org.apache.doris.catalog.ReplicaAllocation.AllocationType;
+import org.apache.doris.common.AnalysisException;
+import org.apache.doris.resource.Tag;
+import org.apache.doris.resource.TagSet;
+import org.apache.doris.system.Backend;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Map;
+
+/*
+ * Author: Chenmingyu
+ * Date: Dec 20, 2019
+ */
+
+public class ReplicaAllocationTest {
+
+    @Test
+    public void testDefault() {
+        ReplicaAllocation replicaAllocation = ReplicaAllocation.createDefault((short) 2, "default_cluster");
+        Assert.assertEquals(2, replicaAllocation.getReplicaNum());
+        Assert.assertEquals(2, replicaAllocation.getReplicaNumByType(AllocationType.LOCAL));
+        Map<TagSet, Short> tagMap = replicaAllocation.getTagMapByType(AllocationType.REMOTE);
+        Assert.assertTrue(tagMap.isEmpty());
+        tagMap = replicaAllocation.getTagMapByType(AllocationType.LOCAL);
+        Assert.assertTrue(tagMap.containsKey(Backend.DEFAULT_TAG_SET));
+        Assert.assertEquals(2, (int) tagMap.get(Backend.DEFAULT_TAG_SET));
+    }
+
+    @Test
+    public void testCustom() throws AnalysisException {
+        ReplicaAllocation replicaAllocation = new ReplicaAllocation();
+        TagSet tagSet = TagSet.create(Tag.create(Tag.TYPE_FUNCTION, Tag.VALUE_COMPUTATION),
+                Tag.create(Tag.TYPE_FUNCTION, Tag.VALUE_STORE),
+                Tag.create("custom", "tag1"));
+        replicaAllocation.setReplica(AllocationType.LOCAL, tagSet, (short) 3);
+
+        Assert.assertEquals(3, replicaAllocation.getReplicaNum());
+        Assert.assertEquals(3, replicaAllocation.getReplicaNumByType(AllocationType.LOCAL));
+        Map<TagSet, Short> tagMap = replicaAllocation.getTagMapByType(AllocationType.REMOTE);
+        Assert.assertTrue(tagMap.isEmpty());
+        tagMap = replicaAllocation.getTagMapByType(AllocationType.LOCAL);
+        Assert.assertTrue(tagMap.containsKey(tagSet));
+        Assert.assertEquals(3, (int) tagMap.get(tagSet));
+        
+        replicaAllocation.g
+    }
+}

--- a/fe/src/test/java/org/apache/doris/cluster/SystemInfoServiceTest.java
+++ b/fe/src/test/java/org/apache/doris/cluster/SystemInfoServiceTest.java
@@ -28,6 +28,7 @@ import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.DdlException;
 import org.apache.doris.common.FeConstants;
 import org.apache.doris.persist.EditLog;
+import org.apache.doris.resource.TagManager;
 import org.apache.doris.system.Backend;
 import org.apache.doris.system.SystemInfoService;
 
@@ -91,6 +92,7 @@ public class SystemInfoServiceTest {
         EasyMock.expect(catalog.getEditLog()).andReturn(editLog).anyTimes();
         EasyMock.expect(catalog.getDb(EasyMock.anyLong())).andReturn(db).anyTimes();
         EasyMock.expect(catalog.getCluster(EasyMock.anyString())).andReturn(new Cluster("cluster", 1)).anyTimes();
+        EasyMock.expect(catalog.getTagManager()).andReturn(new TagManager()).anyTimes();
 
         catalog.clear();
         EasyMock.expectLastCall().anyTimes();
@@ -100,6 +102,7 @@ public class SystemInfoServiceTest {
         systemInfoService = new SystemInfoService();
         invertedIndex = new TabletInvertedIndex();
         EasyMock.expect(Catalog.getInstance()).andReturn(catalog).anyTimes();
+        EasyMock.expect(Catalog.getCurrentCatalog()).andReturn(catalog).anyTimes();
         EasyMock.expect(Catalog.getCurrentSystemInfo()).andReturn(systemInfoService).anyTimes();
         EasyMock.expect(Catalog.getCurrentInvertedIndex()).andReturn(invertedIndex).anyTimes();
         EasyMock.expect(Catalog.getCurrentCatalogJournalVersion()).andReturn(FeConstants.meta_version).anyTimes();
@@ -166,19 +169,19 @@ public class SystemInfoServiceTest {
     @Test(expected = AnalysisException.class)
     public void validHostAndPortTest1() throws Exception {
         createHostAndPort(1);
-        systemInfoService.validateHostAndPort(hostPort);
+        SystemInfoService.validateHostAndPort(hostPort);
     }
 
     @Test(expected = AnalysisException.class)
     public void validHostAndPortTest3() throws Exception {
         createHostAndPort(3);
-        systemInfoService.validateHostAndPort(hostPort);
+        SystemInfoService.validateHostAndPort(hostPort);
     }
 
     @Test
     public void validHostAndPortTest4() throws Exception {
         createHostAndPort(4);
-        systemInfoService.validateHostAndPort(hostPort);
+        SystemInfoService.validateHostAndPort(hostPort);
     }
 
     @Test

--- a/fe/src/test/java/org/apache/doris/common/util/UnitTestUtil.java
+++ b/fe/src/test/java/org/apache/doris/common/util/UnitTestUtil.java
@@ -31,6 +31,7 @@ import org.apache.doris.catalog.PrimitiveType;
 import org.apache.doris.catalog.RandomDistributionInfo;
 import org.apache.doris.catalog.Replica;
 import org.apache.doris.catalog.Replica.ReplicaState;
+import org.apache.doris.catalog.ReplicaAllocation;
 import org.apache.doris.catalog.ScalarType;
 import org.apache.doris.catalog.SinglePartitionInfo;
 import org.apache.doris.catalog.Tablet;
@@ -108,7 +109,8 @@ public class UnitTestUtil {
         // table
         PartitionInfo partitionInfo = new SinglePartitionInfo();
         partitionInfo.setDataProperty(partitionId, DataProperty.DEFAULT_HDD_DATA_PROPERTY);
-        partitionInfo.setReplicationNum(partitionId, (short) 3);
+        ReplicaAllocation replicaAlloc = ReplicaAllocation.createDefault((short) 3, "default_cluster");
+        partitionInfo.setReplicationNum(partitionId, replicaAlloc);
         OlapTable table = new OlapTable(tableId, TABLE_NAME, columns,
                                         KeysType.AGG_KEYS, partitionInfo, distributionInfo);
         table.addPartition(partition);

--- a/fe/src/test/java/org/apache/doris/http/DorisHttpTestCase.java
+++ b/fe/src/test/java/org/apache/doris/http/DorisHttpTestCase.java
@@ -32,6 +32,7 @@ import org.apache.doris.catalog.PartitionInfo;
 import org.apache.doris.catalog.PrimitiveType;
 import org.apache.doris.catalog.RandomDistributionInfo;
 import org.apache.doris.catalog.Replica;
+import org.apache.doris.catalog.ReplicaAllocation;
 import org.apache.doris.catalog.SinglePartitionInfo;
 import org.apache.doris.catalog.Tablet;
 import org.apache.doris.catalog.TabletInvertedIndex;
@@ -47,10 +48,7 @@ import org.apache.doris.system.SystemInfoService;
 import org.apache.doris.thrift.TStorageMedium;
 
 import com.google.common.collect.Lists;
-import mockit.internal.startup.Startup;
-import okhttp3.Credentials;
-import okhttp3.MediaType;
-import okhttp3.OkHttpClient;
+
 import org.easymock.EasyMock;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -61,13 +59,18 @@ import org.powermock.api.easymock.PowerMock;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
+
 import junit.framework.AssertionFailedError;
+import okhttp3.Credentials;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
 
 @RunWith(PowerMockRunner.class)
 @PowerMockIgnore({"org.apache.log4j.*", "javax.management.*", "javax.net.ssl.*"})
@@ -154,7 +157,8 @@ abstract public class DorisHttpTestCase {
         // table
         PartitionInfo partitionInfo = new SinglePartitionInfo();
         partitionInfo.setDataProperty(testPartitionId, DataProperty.DEFAULT_HDD_DATA_PROPERTY);
-        partitionInfo.setReplicationNum(testPartitionId, (short) 3);
+        ReplicaAllocation replicaAlloc = ReplicaAllocation.createDefault((short) 3, "default_cluster");
+        partitionInfo.setReplicationNum(testPartitionId, replicaAlloc);
         OlapTable table = new OlapTable(testTableId, name, columns, KeysType.AGG_KEYS, partitionInfo,
                 distributionInfo);
         table.addPartition(partition);
@@ -171,7 +175,8 @@ abstract public class DorisHttpTestCase {
         columns.add(k2);
         PartitionInfo partitionInfo = new SinglePartitionInfo();
         partitionInfo.setDataProperty(testPartitionId + 100, DataProperty.DEFAULT_HDD_DATA_PROPERTY);
-        partitionInfo.setReplicationNum(testPartitionId + 100, (short) 3);
+        ReplicaAllocation replicaAlloc = ReplicaAllocation.createDefault((short) 3, "default_cluster");
+        partitionInfo.setReplicationNum(testPartitionId + 100, replicaAlloc);
         EsTable table = null;
         Map<String, String> props = new HashMap<>();
         props.put(EsTable.HOSTS, "http://node-1:8080");

--- a/fe/src/test/java/org/apache/doris/persist/gson/GsonSerializationTest.java
+++ b/fe/src/test/java/org/apache/doris/persist/gson/GsonSerializationTest.java
@@ -47,6 +47,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 
 /*
  * This unit test provides examples about how to make a class serializable.
@@ -73,11 +75,17 @@ public class GsonSerializationTest {
         public InnerClassA ignoreClassA2;
         @SerializedName(value = "flag")
         public int flag = 0;
+        @SerializedName(value = "atomicLong")
+        public AtomicLong atomicLong;
+        @SerializedName(value = "atomicBoolean")
+        public AtomicBoolean atomicBoolean;
 
         public OrigClassA(int flag) {
             this.flag = flag;
             classA1 = new InnerClassA(1);
             ignoreClassA2 = new InnerClassA(2);
+            atomicLong = new AtomicLong(flag);
+            atomicBoolean = new AtomicBoolean(false);
         }
 
         @Override
@@ -259,6 +267,8 @@ public class GsonSerializationTest {
         Assert.assertEquals(1, readClassA.flag);
         Assert.assertEquals(1, readClassA.classA1.flag);
         Assert.assertNull(readClassA.ignoreClassA2);
+        Assert.assertEquals(1, readClassA.atomicLong.get());
+        Assert.assertEquals(false, readClassA.atomicBoolean.get());
 
         Assert.assertEquals(Lists.newArrayList("string1", "string2"), readClassA.classA1.list1);
         Assert.assertTrue(readClassA.classA1.map1.containsKey(1L));

--- a/fe/src/test/java/org/apache/doris/planner/OlapTableSinkTest.java
+++ b/fe/src/test/java/org/apache/doris/planner/OlapTableSinkTest.java
@@ -30,6 +30,7 @@ import org.apache.doris.catalog.PartitionKey;
 import org.apache.doris.catalog.PartitionType;
 import org.apache.doris.catalog.PrimitiveType;
 import org.apache.doris.catalog.RangePartitionInfo;
+import org.apache.doris.catalog.ReplicaAllocation;
 import org.apache.doris.catalog.ScalarType;
 import org.apache.doris.catalog.SinglePartitionInfo;
 import org.apache.doris.catalog.Tablet;
@@ -87,7 +88,8 @@ public class OlapTableSinkTest {
     public void testSinglePartition() throws UserException {
         TupleDescriptor tuple = getTuple();
         SinglePartitionInfo partInfo = new SinglePartitionInfo();
-        partInfo.setReplicationNum(2, (short) 3);
+        ReplicaAllocation replicaAlloc = ReplicaAllocation.createDefault((short) 3, "default_cluster");
+        partInfo.setReplicationNum(2, replicaAlloc);
         MaterializedIndex index = new MaterializedIndex(2, MaterializedIndex.IndexState.NORMAL);
         HashDistributionInfo distInfo = new HashDistributionInfo(
                 2, Lists.newArrayList(new Column("k1", PrimitiveType.BIGINT)));


### PR DESCRIPTION
This CL introduces the `ReplicaAllocation` class.
`ReplicaAllocation` is used to identify the distribution information of the replica, and the
 distribution information is represented by a set of tags.
`ReplicaAllocation` is stored in `PartitionInfo` and replaces the previous `idToReplicationNum`
object. This conversion operation is performed when the FE replays the metadata.

At the same time, the `Backend` object will inherit from the `Resource` abstract class and
start to have the `TagSet` attribute. The `TagSet` attribute is currently generated by the cluster
 name of the Backend. This conversion operation is also performed when the FE replays the
 metadata.

To maintain compatibility and minimize the impact on existing metadata. We currently retain all
 cluster information. The new `ReplicaAllocation` and `TagSet` classes are only converted and
 stored. And also, the `idToReplicationNum` and `idToReplicaAllocation` coexist during the version 
0.12. All new operations will only modify the `idToReplicaAllocation`, and `idToReplicationNum` will
be converted to `idToReplicaAllocation`, eventually.

In version 0.13, `idToReplicationNum` will be removed.

We will start using `ReplicaAllocation` and `TagSet` in the next commit.

I added a proc `"/ tags"` to show all tags and the corresponding resource ids.
I also added an http action `/metacheck?type=replica_allocation` to check if the 
`ReplicaAllocation` and `TagSet` were converted correctly after the upgrade.

FeMetaVersion is updated to 70.

ISSUE #1723 