### PR TITLE
Fix memory leak when compression fails in ColumnWriter

### DIFF
--- a/be/src/olap/rowset/segment_v2/column_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/column_writer.cpp
@@ -82,7 +82,7 @@ ColumnWriter::ColumnWriter(const ColumnWriterOptions& opts,
 }
 
 ColumnWriter::~ColumnWriter() {
-    // delete all page
+    // delete all pages
     Page* page = _pages.head;
     while (page != nullptr) {
         Page* next_page = page->next;
@@ -370,7 +370,7 @@ Status ColumnWriter::_finish_current_page() {
     if (_next_rowid == _last_first_rowid) {
         return Status::OK();
     }
-    Page* page = new Page();
+    std::unique_ptr<Page> page(new Page());
     page->first_rowid = _last_first_rowid;
     page->num_rows = _next_rowid - _last_first_rowid;
     faststring header;
@@ -420,7 +420,7 @@ Status ColumnWriter::_finish_current_page() {
     // update last first rowid
     _last_first_rowid = _next_rowid;
 
-    _push_back_page(page);
+    _push_back_page(page.release());
     if (_opts.need_zone_map) {
         RETURN_IF_ERROR(_column_zone_map_builder->flush());
     }

--- a/be/src/olap/rowset/segment_v2/column_writer.h
+++ b/be/src/olap/rowset/segment_v2/column_writer.h
@@ -67,7 +67,7 @@ public:
     ~ColumnWriter();
 
     Status init();
-    
+
     template<typename CellType>
     Status append(const CellType& cell) {
         if (_is_nullable) {
@@ -105,6 +105,7 @@ public:
     void write_meta(ColumnMetaPB* meta);
 
 private:
+    // All Pages will be organized into a linked list
     struct Page {
         int32_t first_rowid;
         int32_t num_rows;


### PR DESCRIPTION
#2605 

Only the Pages in the linked-list can be destructed in the
ColumnWriter dtor, but if we meet something wrong, we will
return directly, which causes a memory leak