### PR TITLE
[Segment V2] add UT for lazy materialization

### DIFF
--- a/be/src/olap/iterators.h
+++ b/be/src/olap/iterators.h
@@ -77,7 +77,7 @@ public:
     // to unify Conditions and ColumnPredicate
     const std::vector<ColumnPredicate*>* column_predicates = nullptr;
 
-    // reader statistics
+    // REQUIRED (null is not allowed)
     OlapReaderStatistics* stats = nullptr;
 };
 
@@ -102,6 +102,9 @@ public:
 
     // return schema for this Iterator
     virtual const Schema& schema() const = 0;
+
+    // Only used by UT. Whether lazy-materialization-read is used by this iterator or not.
+    virtual bool is_lazy_materialization_read() const { return false; }
 };
 
 }

--- a/be/src/olap/row_block2.cpp
+++ b/be/src/olap/row_block2.cpp
@@ -93,15 +93,16 @@ Status RowBlockV2::convert_to_row_block(RowCursor* helper, RowBlock* dst) {
 std::string RowBlockRow::debug_string() const {
     std::stringstream ss;
     ss << "[";
-    for (int i = 0; i < _block->schema()->num_columns(); ++i) {
+    for (int i = 0; i < _block->schema()->num_column_ids(); ++i) {
         if (i != 0) {
             ss << ",";
         }
-        auto col_schema = _block->schema()->column(i);
-        if (col_schema->is_nullable() && is_null(i)) {
+        ColumnId cid = _block->schema()->column_ids()[i];
+        auto col_schema = _block->schema()->column(cid);
+        if (col_schema->is_nullable() && is_null(cid)) {
             ss << "NULL";
         } else {
-            ss << col_schema->type_info()->to_string(cell_ptr(i));
+            ss << col_schema->type_info()->to_string(cell_ptr(cid));
         }
     }
     ss << "]";

--- a/be/src/olap/row_block2.h
+++ b/be/src/olap/row_block2.h
@@ -45,7 +45,9 @@ public:
 
     // update number of rows contained in this block
     void set_num_rows(size_t num_rows) { _num_rows = num_rows; }
-    // return number of rows contained in this block
+    // low-level API to get the number of rows contained in this block.
+    // note that some rows may have been un-selected by selection_vector(),
+    // client should use selected_size() to get the actual number of selected rows.
     size_t num_rows() const { return _num_rows; }
     // return the maximum number of rows that can be contained in this block.
     // invariant: 0 <= num_rows() <= capacity()
@@ -68,7 +70,7 @@ public:
     // convert RowBlockV2 to RowBlock
     Status convert_to_row_block(RowCursor* helper, RowBlock* dst);
 
-    // Get the column block for one of the columns in this row block.
+    // low-level API to access memory for each column block(including data array and nullmap).
     // `cid` must be one of `schema()->column_ids()`.
     ColumnBlock column_block(ColumnId cid) const {
         const TypeInfo* type_info = _schema.column(cid)->type_info();
@@ -77,6 +79,9 @@ public:
         return ColumnBlock(type_info, data, null_bitmap, _capacity, _pool.get());
     }
 
+    // low-level API to access the underlying memory for row at `row_idx`.
+    // client should use selection_vector() to iterate over row index of selected rows.
+    // TODO(gdy) DO NOT expose raw rows which may be un-selected to clients
     RowBlockRow row(size_t row_idx) const;
 
     const Schema* schema() const { return &_schema; }

--- a/be/src/olap/rowset/segment_v2/segment.cpp
+++ b/be/src/olap/rowset/segment_v2/segment.cpp
@@ -60,11 +60,10 @@ Status Segment::_open() {
     return Status::OK();
 }
 
-Status Segment::new_iterator(
-        const Schema& schema,
-        const StorageReadOptions& read_options,
-        std::unique_ptr<RowwiseIterator>* iter) {
-
+Status Segment::new_iterator(const Schema& schema,
+                             const StorageReadOptions& read_options,
+                             std::unique_ptr<RowwiseIterator>* iter) {
+    DCHECK_NOTNULL(read_options.stats);
     // trying to prune the current segment by segment-level zone map
     if (read_options.conditions != nullptr) {
         for (auto& column_condition : read_options.conditions->columns()) {

--- a/be/src/olap/rowset/segment_v2/segment.h
+++ b/be/src/olap/rowset/segment_v2/segment.h
@@ -105,6 +105,11 @@ public:
         return _sk_index_decoder->num_items() - 1;
     }
 
+    // only used by UT
+    const SegmentFooterPB& footer() const {
+        return _footer;
+    }
+
 private:
     DISALLOW_COPY_AND_ASSIGN(Segment);
     Segment(std::string fname, uint32_t segment_id, const TabletSchema* tablet_schema);

--- a/be/src/olap/rowset/segment_v2/segment_iterator.h
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.h
@@ -50,6 +50,7 @@ public:
     Status init(const StorageReadOptions& opts) override;
     Status next_batch(RowBlockV2* row_block) override;
     const Schema& schema() const override { return _schema; }
+    bool is_lazy_materialization_read() const override { return _lazy_materialization_read; }
 private:
     Status _init();
 
@@ -69,8 +70,6 @@ private:
     Status _apply_bitmap_index();
 
     void _init_lazy_materialization();
-
-    Status _next_batch(RowBlockV2* block, size_t row_offset, size_t* rows_read);
 
     uint32_t segment_id() const { return _segment->id(); }
     uint32_t num_rows() const { return _segment->num_rows(); }

--- a/be/test/olap/rowset/segment_v2/segment_test.cpp
+++ b/be/test/olap/rowset/segment_v2/segment_test.cpp
@@ -19,11 +19,13 @@
 #include "olap/rowset/segment_v2/segment_writer.h"
 #include "olap/rowset/segment_v2/segment_iterator.h"
 
+#include <functional>
 #include <gtest/gtest.h>
 #include <iostream>
 #include <boost/filesystem.hpp>
 
 #include "common/logging.h"
+#include "gutil/strings/substitute.h"
 #include "olap/comparison_predicate.h"
 #include "olap/in_list_predicate.h"
 #include "olap/olap_common.h"
@@ -40,67 +42,102 @@
 namespace doris {
 namespace segment_v2 {
 
-class SegmentReaderWriterTest : public testing::Test {
-public:
-    SegmentReaderWriterTest() { }
-    virtual ~SegmentReaderWriterTest() {
+using std::string;
+using std::shared_ptr;
+using std::unique_ptr;
+using std::vector;
+
+using ValueGenerator = std::function<void(size_t rid, int cid, int block_id, RowCursorCell& cell)>;
+
+// 0,  1,  2,  3
+// 10, 11, 12, 13
+// 20, 21, 22, 23
+static void DefaultIntGenerator(size_t rid, int cid, int block_id, RowCursorCell& cell) {
+    cell.set_not_null();
+    *(int*)cell.mutable_cell_ptr() = rid * 10 + cid;
+}
+
+class SegmentReaderWriterTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        if (FileUtils::check_exist(kSegmentDir)) {
+            ASSERT_TRUE(FileUtils::remove_all(kSegmentDir).ok());
+        }
+        ASSERT_TRUE(FileUtils::create_dir(kSegmentDir).ok());
     }
+
+    void TearDown() override {
+        if (FileUtils::check_exist(kSegmentDir)) {
+            ASSERT_TRUE(FileUtils::remove_all(kSegmentDir).ok());
+        }
+    }
+
+    TabletSchema create_schema(const vector<TabletColumn>& columns, int num_short_key_columns = -1) {
+        TabletSchema res;
+        int num_key_columns = 0;
+        for (auto& col : columns) {
+            if (col.is_key()) {
+                num_key_columns++;
+            }
+            res._cols.push_back(col);
+        }
+        res._num_columns = columns.size();
+        res._num_key_columns = num_key_columns;
+        res._num_short_key_columns = num_short_key_columns != -1 ? num_short_key_columns : num_key_columns;
+        return res;
+    }
+
+    void build_segment(SegmentWriterOptions opts,
+                       const TabletSchema& build_schema,
+                       const TabletSchema& query_schema,
+                       size_t nrows, const ValueGenerator& generator,
+                       shared_ptr<Segment>* res) {
+        static int seg_id = 0;
+        // must use unique filename for each segment, otherwise page cache kicks in and produces
+        // the wrong answer (it use (filename,offset) as cache key)
+        string filename = strings::Substitute("$0/seg_$1.dat", kSegmentDir, seg_id++);
+        SegmentWriter writer(filename, 0, &build_schema, opts);
+        auto st = writer.init(10);
+        ASSERT_TRUE(st.ok());
+
+        RowCursor row;
+        auto olap_st = row.init(build_schema);
+        ASSERT_EQ(OLAP_SUCCESS, olap_st);
+
+        for (size_t rid = 0; rid < nrows; ++rid) {
+            for (int cid = 0; cid < build_schema.num_columns(); ++cid) {
+                int row_block_id = rid / opts.num_rows_per_block;
+                RowCursorCell cell = row.cell(cid);
+                generator(rid, cid, row_block_id, cell);
+            }
+            ASSERT_TRUE(writer.append_row(row).ok());
+        }
+
+        uint64_t file_size, index_size;
+        st = writer.finalize(&file_size, &index_size);
+        ASSERT_TRUE(st.ok());
+
+        st = Segment::open(filename, 0, &query_schema, res);
+        ASSERT_TRUE(st.ok());
+        ASSERT_EQ(nrows, (*res)->num_rows());
+    }
+private:
+    const string kSegmentDir = "./ut_dir/segment_test";
 };
 
 TEST_F(SegmentReaderWriterTest, normal) {
-
-    size_t num_rows_per_block = 10;
-
-    std::shared_ptr<TabletSchema> tablet_schema(new TabletSchema());
-    tablet_schema->_num_columns = 4;
-    tablet_schema->_num_key_columns = 3;
-    tablet_schema->_num_short_key_columns = 2;
-    tablet_schema->_num_rows_per_row_block = num_rows_per_block;
-    tablet_schema->_cols.push_back(create_int_key(1));
-    tablet_schema->_cols.push_back(create_int_key(2));
-    tablet_schema->_cols.push_back(create_int_key(3));
-    tablet_schema->_cols.push_back(create_int_value(4));
-
-    // segment write
-    std::string dname = "./ut_dir/segment_test";
-    FileUtils::create_dir(dname);
+    TabletSchema tablet_schema = create_schema({
+        create_int_key(1), create_int_key(2), create_int_value(3), create_int_value(4)});
 
     SegmentWriterOptions opts;
-    opts.num_rows_per_block = num_rows_per_block;
+    opts.num_rows_per_block = 10;
 
-    std::string fname = dname + "/int_case";
-    SegmentWriter writer(fname, 0, tablet_schema.get(), opts);
-    auto st = writer.init(10);
-    ASSERT_TRUE(st.ok());
+    shared_ptr<Segment> segment;
+    build_segment(opts, tablet_schema, tablet_schema, 4096, DefaultIntGenerator, &segment);
 
-    RowCursor row;
-    auto olap_st = row.init(*tablet_schema);
-    ASSERT_EQ(OLAP_SUCCESS, olap_st);
-
-    // 0, 1, 2, 3
-    // 10, 11, 12, 13
-    // 20, 21, 22, 23
-    for (int i = 0; i < 4096; ++i) {
-        for (int j = 0; j < 4; ++j) {
-            auto cell = row.cell(j);
-            cell.set_not_null();
-            *(int*)cell.mutable_cell_ptr() = i * 10 + j;
-        }
-        writer.append_row(row);
-    }
-
-    uint64_t file_size = 0;
-    uint64_t index_size;
-    st = writer.finalize(&file_size, &index_size);
-    ASSERT_TRUE(st.ok());
     // reader
     {
-        std::shared_ptr<Segment> segment;
-        st = Segment::open(fname, 0, tablet_schema.get(), &segment);
-        LOG(INFO) << "segment open, msg=" << st.to_string();
-        ASSERT_TRUE(st.ok());
-        ASSERT_EQ(4096, segment->num_rows());
-        Schema schema(*tablet_schema);
+        Schema schema(tablet_schema);
         OlapReaderStatistics stats;
         // scan all rows
         {
@@ -117,8 +154,7 @@ TEST_F(SegmentReaderWriterTest, normal) {
             while (left > 0)  {
                 int rows_read = left > 1024 ? 1024 : left;
                 block.clear();
-                st = iter->next_batch(&block);
-                ASSERT_TRUE(st.ok());
+                ASSERT_TRUE(iter->next_batch(&block).ok());
                 ASSERT_EQ(DEL_NOT_SATISFIED, block.delete_state());
                 ASSERT_EQ(rows_read, block.num_rows());
                 left -= rows_read;
@@ -139,7 +175,7 @@ TEST_F(SegmentReaderWriterTest, normal) {
         {
             // lower bound
             std::unique_ptr<RowCursor> lower_bound(new RowCursor());
-            lower_bound->init(*tablet_schema, 2);
+            lower_bound->init(tablet_schema, 2);
             {
                 auto cell = lower_bound->cell(0);
                 cell.set_not_null();
@@ -153,7 +189,7 @@ TEST_F(SegmentReaderWriterTest, normal) {
 
             // upper bound
             std::unique_ptr<RowCursor> upper_bound(new RowCursor());
-            upper_bound->init(*tablet_schema, 1);
+            upper_bound->init(tablet_schema, 1);
             {
                 auto cell = upper_bound->cell(0);
                 cell.set_not_null();
@@ -167,9 +203,8 @@ TEST_F(SegmentReaderWriterTest, normal) {
             segment->new_iterator(schema, read_opts, &iter);
 
             RowBlockV2 block(schema, 100);
-            st = iter->next_batch(&block);
+            ASSERT_TRUE(iter->next_batch(&block).ok());
             ASSERT_EQ(DEL_NOT_SATISFIED, block.delete_state());
-            ASSERT_TRUE(st.ok());
             ASSERT_EQ(11, block.num_rows());
             auto column_block = block.column_block(0);
             for (int i = 0; i < 11; ++i) {
@@ -180,7 +215,7 @@ TEST_F(SegmentReaderWriterTest, normal) {
         {
             // lower bound
             std::unique_ptr<RowCursor> lower_bound(new RowCursor());
-            lower_bound->init(*tablet_schema, 1);
+            lower_bound->init(tablet_schema, 1);
             {
                 auto cell = lower_bound->cell(0);
                 cell.set_not_null();
@@ -194,15 +229,14 @@ TEST_F(SegmentReaderWriterTest, normal) {
             segment->new_iterator(schema, read_opts, &iter);
 
             RowBlockV2 block(schema, 100);
-            st = iter->next_batch(&block);
-            ASSERT_TRUE(st.is_end_of_file());
+            ASSERT_TRUE(iter->next_batch(&block).is_end_of_file());
             ASSERT_EQ(0, block.num_rows());
         }
         // test seek, key (-2, -1)
         {
             // lower bound
             std::unique_ptr<RowCursor> lower_bound(new RowCursor());
-            lower_bound->init(*tablet_schema, 1);
+            lower_bound->init(tablet_schema, 1);
             {
                 auto cell = lower_bound->cell(0);
                 cell.set_not_null();
@@ -210,7 +244,7 @@ TEST_F(SegmentReaderWriterTest, normal) {
             }
 
             std::unique_ptr<RowCursor> upper_bound(new RowCursor());
-            upper_bound->init(*tablet_schema, 1);
+            upper_bound->init(tablet_schema, 1);
             {
                 auto cell = upper_bound->cell(0);
                 cell.set_not_null();
@@ -224,75 +258,162 @@ TEST_F(SegmentReaderWriterTest, normal) {
             segment->new_iterator(schema, read_opts, &iter);
 
             RowBlockV2 block(schema, 100);
-            st = iter->next_batch(&block);
-            ASSERT_TRUE(st.is_end_of_file());
+            ASSERT_TRUE(iter->next_batch(&block).is_end_of_file());
             ASSERT_EQ(0, block.num_rows());
         }
     }
-    FileUtils::remove_all(dname);
+}
+
+TEST_F(SegmentReaderWriterTest, LazyMaterialization) {
+    TabletSchema tablet_schema = create_schema({ create_int_key(1), create_int_value(2) });
+    ValueGenerator data_gen = [](size_t rid, int cid, int block_id, RowCursorCell& cell) {
+        cell.set_not_null();
+        if (cid == 0) {
+            *(int*) (cell.mutable_cell_ptr()) = rid;
+        } else if (cid == 1) {
+            *(int*) (cell.mutable_cell_ptr()) = rid * 10;
+        }
+    };
+
+    {
+        shared_ptr<Segment> segment;
+        build_segment(SegmentWriterOptions(), tablet_schema, tablet_schema, 100, data_gen, &segment);
+        {
+            // lazy enabled when predicate is subset of returned columns:
+            // select c1, c2 where c2 = 30;
+            Schema read_schema(tablet_schema);
+            unique_ptr<ColumnPredicate> predicate(new EqualPredicate<int32_t>(1, 30));
+            const vector<ColumnPredicate*> predicates = {predicate.get()};
+
+            OlapReaderStatistics stats;
+            StorageReadOptions read_opts;
+            read_opts.column_predicates = &predicates;
+            read_opts.stats = &stats;
+
+            unique_ptr<RowwiseIterator> iter;
+            ASSERT_TRUE(segment->new_iterator(read_schema, read_opts, &iter).ok());
+
+            RowBlockV2 block(read_schema, 1024);
+            ASSERT_TRUE(iter->next_batch(&block).ok());
+            ASSERT_TRUE(iter->is_lazy_materialization_read());
+            ASSERT_EQ(1, block.selected_size());
+            ASSERT_EQ(99, stats.rows_vec_cond_filtered);
+            auto row = block.row(block.selection_vector()[0]);
+            ASSERT_EQ("[3,30]", row.debug_string());
+        }
+        {
+            // lazy disabled when all return columns have predicates:
+            // select c1, c2 where c1 = 10 and c2 = 100;
+            Schema read_schema(tablet_schema);
+            unique_ptr<ColumnPredicate> p0(new EqualPredicate<int32_t>(0, 10));
+            unique_ptr<ColumnPredicate> p1(new EqualPredicate<int32_t>(1, 100));
+            const vector<ColumnPredicate*> predicates = {p0.get(), p1.get()};
+
+            OlapReaderStatistics stats;
+            StorageReadOptions read_opts;
+            read_opts.column_predicates = &predicates;
+            read_opts.stats = &stats;
+
+            unique_ptr<RowwiseIterator> iter;
+            ASSERT_TRUE(segment->new_iterator(read_schema, read_opts, &iter).ok());
+
+            RowBlockV2 block(read_schema, 1024);
+            ASSERT_TRUE(iter->next_batch(&block).ok());
+            ASSERT_FALSE(iter->is_lazy_materialization_read());
+            ASSERT_EQ(1, block.selected_size());
+            ASSERT_EQ(99, stats.rows_vec_cond_filtered);
+            auto row = block.row(block.selection_vector()[0]);
+            ASSERT_EQ("[10,100]", row.debug_string());
+        }
+        {
+            // lazy disabled when no predicate:
+            // select c2
+            vector<ColumnId> read_cols = {1};
+            Schema read_schema(tablet_schema.columns(), read_cols);
+            OlapReaderStatistics stats;
+            StorageReadOptions read_opts;
+            read_opts.stats = &stats;
+
+            unique_ptr<RowwiseIterator> iter;
+            ASSERT_TRUE(segment->new_iterator(read_schema, read_opts, &iter).ok());
+
+            RowBlockV2 block(read_schema, 1024);
+            ASSERT_TRUE(iter->next_batch(&block).ok());
+            ASSERT_FALSE(iter->is_lazy_materialization_read());
+            ASSERT_EQ(100, block.selected_size());
+            for (int i = 0; i < block.selected_size(); ++i) {
+                auto row = block.row(block.selection_vector()[i]);
+                ASSERT_EQ(strings::Substitute("[$0]", i * 10), row.debug_string());
+            }
+        }
+    }
+
+    {
+        shared_ptr<Segment> segment;
+        SegmentWriterOptions write_opts;
+        write_opts.need_bitmap_index = true; // c2 with bitmap index
+        build_segment(write_opts, tablet_schema, tablet_schema, 100, data_gen, &segment);
+        ASSERT_TRUE(segment->footer().columns(1).has_bitmap_index());
+        {
+            // lazy disabled when all predicates are removed by bitmap index:
+            // select c1, c2 where c2 = 30;
+            Schema read_schema(tablet_schema);
+            unique_ptr<ColumnPredicate> predicate(new EqualPredicate<int32_t>(1, 200));
+            const vector<ColumnPredicate*> predicates = { predicate.get() };
+
+            OlapReaderStatistics stats;
+            StorageReadOptions read_opts;
+            read_opts.column_predicates = &predicates;
+            read_opts.stats = &stats;
+
+            unique_ptr<RowwiseIterator> iter;
+            ASSERT_TRUE(segment->new_iterator(read_schema, read_opts, &iter).ok());
+
+            RowBlockV2 block(read_schema, 1024);
+            ASSERT_TRUE(iter->next_batch(&block).ok());
+            ASSERT_FALSE(iter->is_lazy_materialization_read());
+            ASSERT_EQ(1, block.selected_size());
+            ASSERT_EQ(99, stats.bitmap_index_filter_count);
+            ASSERT_EQ(0, stats.rows_vec_cond_filtered);
+            auto row = block.row(block.selection_vector()[0]);
+            ASSERT_EQ("[20,200]", row.debug_string());
+        }
+    }
 }
 
 TEST_F(SegmentReaderWriterTest, TestIndex) {
-    size_t num_rows_per_block = 10;
-
-    std::shared_ptr<TabletSchema> tablet_schema(new TabletSchema());
-    tablet_schema->_num_columns = 4;
-    tablet_schema->_num_key_columns = 3;
-    tablet_schema->_num_short_key_columns = 2;
-    tablet_schema->_num_rows_per_row_block = num_rows_per_block;
-    tablet_schema->_cols.push_back(create_int_key(1));
-    tablet_schema->_cols.push_back(create_int_key(2, true, true));
-    tablet_schema->_cols.push_back(create_int_key(3));
-    tablet_schema->_cols.push_back(create_int_value(4));
-
-    // segment write
-    std::string dname = "./ut_dir/segment_test";
-    FileUtils::create_dir(dname);
+    TabletSchema tablet_schema = create_schema({
+        create_int_key(1),
+        create_int_key(2, true, true),
+        create_int_key(3),
+        create_int_value(4)});
 
     SegmentWriterOptions opts;
-    opts.num_rows_per_block = num_rows_per_block;
+    opts.num_rows_per_block = 10;
 
-    std::string fname = dname + "/int_case2";
-    SegmentWriter writer(fname, 0, tablet_schema.get(), opts);
-    auto st = writer.init(10);
-    ASSERT_TRUE(st.ok());
-
-    RowCursor row;
-    auto olap_st = row.init(*tablet_schema);
-    ASSERT_EQ(OLAP_SUCCESS, olap_st);
-
+    std::shared_ptr<Segment> segment;
     // 0, 1, 2, 3
     // 10, 11, 12, 13
     // 20, 21, 22, 23
-    //
+    // ...
     // 64k int will generate 4 pages
-    for (int i = 0; i < 64 * 1024; ++i) {
-        for (int j = 0; j < 4; ++j) {
-            auto cell = row.cell(j);
+    build_segment(opts, tablet_schema, tablet_schema, 64 * 1024,
+        [](size_t rid, int cid, int block_id, RowCursorCell& cell) {
             cell.set_not_null();
-            if (i >= 16 * 1024 && i < 32 * 1024) {
+            if (rid >= 16 * 1024 && rid < 32 * 1024) {
                 // make second page all rows equal
-                *(int*)cell.mutable_cell_ptr() = 164000 + j;
+                *(int*)cell.mutable_cell_ptr() = 164000 + cid;
 
             } else {
-                *(int*)cell.mutable_cell_ptr() = i * 10 + j;
+                *(int*)cell.mutable_cell_ptr() = rid * 10 + cid;
             }
-        }
-        writer.append_row(row);
-    }
-
-    uint64_t file_size = 0;
-    uint64_t index_size;
-    st = writer.finalize(&file_size, &index_size);
-    ASSERT_TRUE(st.ok());
+        },
+        &segment
+    );
 
     // reader with condition
     {
-        std::shared_ptr<Segment> segment;
-        st = Segment::open(fname, 0, tablet_schema.get(), &segment);
-        ASSERT_TRUE(st.ok());
-        ASSERT_EQ(64 * 1024, segment->num_rows());
-        Schema schema(*tablet_schema);
+        Schema schema(tablet_schema);
         OlapReaderStatistics stats;
         // test empty segment iterator
         {
@@ -303,7 +424,7 @@ TEST_F(SegmentReaderWriterTest, TestIndex) {
             std::vector<std::string> vals = {"2"};
             condition.__set_condition_values(vals);
             std::shared_ptr<Conditions> conditions(new Conditions());
-            conditions->set_tablet_schema(tablet_schema.get());
+            conditions->set_tablet_schema(&tablet_schema);
             conditions->append_condition(condition);
 
             StorageReadOptions read_opts;
@@ -315,8 +436,7 @@ TEST_F(SegmentReaderWriterTest, TestIndex) {
 
             RowBlockV2 block(schema, 1);
 
-            st = iter->next_batch(&block);
-            ASSERT_TRUE(st.is_end_of_file());
+            ASSERT_TRUE(iter->next_batch(&block).is_end_of_file());
             ASSERT_EQ(0, block.num_rows());
         }
         // scan all rows
@@ -327,7 +447,7 @@ TEST_F(SegmentReaderWriterTest, TestIndex) {
             std::vector<std::string> vals = {"100"};
             condition.__set_condition_values(vals);
             std::shared_ptr<Conditions> conditions(new Conditions());
-            conditions->set_tablet_schema(tablet_schema.get());
+            conditions->set_tablet_schema(&tablet_schema);
             conditions->append_condition(condition);
 
             StorageReadOptions read_opts;
@@ -346,8 +466,7 @@ TEST_F(SegmentReaderWriterTest, TestIndex) {
             while (left > 0)  {
                 int rows_read = left > 1024 ? 1024 : left;
                 block.clear();
-                st = iter->next_batch(&block);
-                ASSERT_TRUE(st.ok());
+                ASSERT_TRUE(iter->next_batch(&block).ok());
                 ASSERT_EQ(DEL_NOT_SATISFIED, block.delete_state());
                 ASSERT_EQ(rows_read, block.num_rows());
                 left -= rows_read;
@@ -364,8 +483,7 @@ TEST_F(SegmentReaderWriterTest, TestIndex) {
                 rowid += rows_read;
             }
             ASSERT_EQ(16 * 1024, rowid);
-            st = iter->next_batch(&block);
-            ASSERT_TRUE(st.is_end_of_file());
+            ASSERT_TRUE(iter->next_batch(&block).is_end_of_file());
             ASSERT_EQ(0, block.num_rows());
         }
         // test zone map with query predicate an delete predicate
@@ -377,7 +495,7 @@ TEST_F(SegmentReaderWriterTest, TestIndex) {
             std::vector<std::string> vals = {"165000"};
             condition.__set_condition_values(vals);
             std::shared_ptr<Conditions> conditions(new Conditions());
-            conditions->set_tablet_schema(tablet_schema.get());
+            conditions->set_tablet_schema(&tablet_schema);
             conditions->append_condition(condition);
 
             // the second page read will be pruned by the following delete predicate
@@ -387,7 +505,7 @@ TEST_F(SegmentReaderWriterTest, TestIndex) {
             std::vector<std::string> vals2 = {"164001"};
             delete_condition.__set_condition_values(vals2);
             std::shared_ptr<Conditions> delete_conditions(new Conditions());
-            delete_conditions->set_tablet_schema(tablet_schema.get());
+            delete_conditions->set_tablet_schema(&tablet_schema);
             delete_conditions->append_condition(delete_condition);
 
             StorageReadOptions read_opts;
@@ -407,8 +525,7 @@ TEST_F(SegmentReaderWriterTest, TestIndex) {
             while (left > 0)  {
                 int rows_read = left > 1024 ? 1024 : left;
                 block.clear();
-                st = iter->next_batch(&block);
-                ASSERT_TRUE(st.ok());
+                ASSERT_TRUE(iter->next_batch(&block).ok());
                 ASSERT_EQ(rows_read, block.num_rows());
                 ASSERT_EQ(DEL_NOT_SATISFIED, block.delete_state());
                 left -= rows_read;
@@ -425,8 +542,7 @@ TEST_F(SegmentReaderWriterTest, TestIndex) {
                 rowid += rows_read;
             }
             ASSERT_EQ(16 * 1024, rowid);
-            st = iter->next_batch(&block);
-            ASSERT_TRUE(st.is_end_of_file());
+            ASSERT_TRUE(iter->next_batch(&block).is_end_of_file());
             ASSERT_EQ(0, block.num_rows());
         }
         // test bloom filter
@@ -440,19 +556,17 @@ TEST_F(SegmentReaderWriterTest, TestIndex) {
             std::vector<std::string> vals = {"102"};
             condition.__set_condition_values(vals);
             std::shared_ptr<Conditions> conditions(new Conditions());
-            conditions->set_tablet_schema(tablet_schema.get());
+            conditions->set_tablet_schema(&tablet_schema);
             conditions->append_condition(condition);
             read_opts.conditions = conditions.get();
             std::unique_ptr<RowwiseIterator> iter;
             segment->new_iterator(schema, read_opts, &iter);
 
             RowBlockV2 block(schema, 1024);
-            st = iter->next_batch(&block);
-            ASSERT_TRUE(st.is_end_of_file()) << "status:" << st.to_string();
+            ASSERT_TRUE(iter->next_batch(&block).is_end_of_file());
             ASSERT_EQ(0, block.num_rows());
         }
     }
-    FileUtils::remove_all(dname);
 }
 
 TEST_F(SegmentReaderWriterTest, estimate_segment_size) {
@@ -514,70 +628,19 @@ TEST_F(SegmentReaderWriterTest, estimate_segment_size) {
 }
 
 TEST_F(SegmentReaderWriterTest, TestDefaultValueColumn) {
-    size_t num_rows_per_block = 10;
-
-    std::shared_ptr<TabletSchema> tablet_schema(new TabletSchema());
-    tablet_schema->_num_columns = 4;
-    tablet_schema->_num_key_columns = 3;
-    tablet_schema->_num_short_key_columns = 2;
-    tablet_schema->_num_rows_per_row_block = num_rows_per_block;
-    tablet_schema->_cols.push_back(create_int_key(1));
-    tablet_schema->_cols.push_back(create_int_key(2));
-    tablet_schema->_cols.push_back(create_int_key(3));
-    tablet_schema->_cols.push_back(create_int_value(4));
-
-    // segment write
-    std::string dname = "./ut_dir/segment_test";
-    FileUtils::create_dir(dname);
-
-    SegmentWriterOptions opts;
-    opts.num_rows_per_block = num_rows_per_block;
-
-    std::string fname = dname + "/int_case";
-    SegmentWriter writer(fname, 0, tablet_schema.get(), opts);
-    auto st = writer.init(10);
-    ASSERT_TRUE(st.ok());
-
-    RowCursor row;
-    auto olap_st = row.init(*tablet_schema);
-    ASSERT_EQ(OLAP_SUCCESS, olap_st);
-
-    // 0, 1, 2, 3
-    // 10, 11, 12, 13
-    // 20, 21, 22, 23
-    for (int i = 0; i < 4096; ++i) {
-        for (int j = 0; j < 4; ++j) {
-            auto cell = row.cell(j);
-            cell.set_not_null();
-            *(int*)cell.mutable_cell_ptr() = i * 10 + j;
-        }
-        writer.append_row(row);
-    }
-
-    uint64_t file_size = 0;
-    uint64_t index_size;
-    st = writer.finalize(&file_size, &index_size);
-    ASSERT_TRUE(st.ok());
+    vector<TabletColumn> columns = { create_int_key(1), create_int_key(2), create_int_value(3), create_int_value(4) };
+    TabletSchema build_schema = create_schema(columns);
 
     // add a column with null default value
     {
-        std::shared_ptr<TabletSchema> new_tablet_schema_1(new TabletSchema());
-        new_tablet_schema_1->_num_columns = 5;
-        new_tablet_schema_1->_num_key_columns = 3;
-        new_tablet_schema_1->_num_short_key_columns = 2;
-        new_tablet_schema_1->_num_rows_per_row_block = num_rows_per_block;
-        new_tablet_schema_1->_cols.push_back(create_int_key(1));
-        new_tablet_schema_1->_cols.push_back(create_int_key(2));
-        new_tablet_schema_1->_cols.push_back(create_int_key(3));
-        new_tablet_schema_1->_cols.push_back(create_int_value(4));
-        new_tablet_schema_1->_cols.push_back(
-            create_int_value(5, OLAP_FIELD_AGGREGATION_SUM, true, "NULL"));
+        vector<TabletColumn> read_columns = columns;
+        read_columns.push_back(create_int_value(5, OLAP_FIELD_AGGREGATION_SUM, true, "NULL"));
+        TabletSchema query_schema = create_schema(read_columns);
 
         std::shared_ptr<Segment> segment;
-        st = Segment::open(fname, 0, new_tablet_schema_1.get(), &segment);
-        ASSERT_TRUE(st.ok());
-        ASSERT_EQ(4096, segment->num_rows());
-        Schema schema(*new_tablet_schema_1);
+        build_segment(SegmentWriterOptions(), build_schema, query_schema, 4096, DefaultIntGenerator, &segment);
+
+        Schema schema(query_schema);
         OlapReaderStatistics stats;
         // scan all rows
         {
@@ -594,8 +657,7 @@ TEST_F(SegmentReaderWriterTest, TestDefaultValueColumn) {
             while (left > 0) {
                 int rows_read = left > 1024 ? 1024 : left;
                 block.clear();
-                st = iter->next_batch(&block);
-                ASSERT_TRUE(st.ok());
+                ASSERT_TRUE(iter->next_batch(&block).ok());
                 ASSERT_EQ(DEL_NOT_SATISFIED, block.delete_state());
                 ASSERT_EQ(rows_read, block.num_rows());
                 left -= rows_read;
@@ -620,22 +682,14 @@ TEST_F(SegmentReaderWriterTest, TestDefaultValueColumn) {
 
     // add a column with non-null default value
     {
-        std::shared_ptr<TabletSchema> new_tablet_schema_1(new TabletSchema());
-        new_tablet_schema_1->_num_columns = 5;
-        new_tablet_schema_1->_num_key_columns = 3;
-        new_tablet_schema_1->_num_short_key_columns = 2;
-        new_tablet_schema_1->_num_rows_per_row_block = num_rows_per_block;
-        new_tablet_schema_1->_cols.push_back(create_int_key(1));
-        new_tablet_schema_1->_cols.push_back(create_int_key(2));
-        new_tablet_schema_1->_cols.push_back(create_int_key(3));
-        new_tablet_schema_1->_cols.push_back(create_int_value(4));
-        new_tablet_schema_1->_cols.push_back(create_int_value(5, OLAP_FIELD_AGGREGATION_SUM, true, "10086"));
+        vector<TabletColumn> read_columns = columns;
+        read_columns.push_back(create_int_value(5, OLAP_FIELD_AGGREGATION_SUM, true, "10086"));
+        TabletSchema query_schema = create_schema(read_columns);
 
         std::shared_ptr<Segment> segment;
-        st = Segment::open(fname, 0, new_tablet_schema_1.get(), &segment);
-        ASSERT_TRUE(st.ok());
-        ASSERT_EQ(4096, segment->num_rows());
-        Schema schema(*new_tablet_schema_1);
+        build_segment(SegmentWriterOptions(), build_schema, query_schema, 4096, DefaultIntGenerator, &segment);
+
+        Schema schema(query_schema);
         OlapReaderStatistics stats;
         // scan all rows
         {
@@ -652,8 +706,7 @@ TEST_F(SegmentReaderWriterTest, TestDefaultValueColumn) {
             while (left > 0) {
                 int rows_read = left > 1024 ? 1024 : left;
                 block.clear();
-                st = iter->next_batch(&block);
-                ASSERT_TRUE(st.ok());
+                ASSERT_TRUE(iter->next_batch(&block).ok());
                 ASSERT_EQ(rows_read, block.num_rows());
                 left -= rows_read;
 
@@ -910,61 +963,19 @@ TEST_F(SegmentReaderWriterTest, TestStringDict) {
 }
 
 TEST_F(SegmentReaderWriterTest, TestBitmapPredicate) {
-    size_t num_rows_per_block = 10;
-    MemTracker tracker;
-    MemPool pool(&tracker);
-
-    std::shared_ptr<TabletSchema> tablet_schema(new TabletSchema());
-    tablet_schema->_num_columns = 4;
-    tablet_schema->_num_key_columns = 2;
-    tablet_schema->_num_short_key_columns = 1;
-    tablet_schema->_num_rows_per_row_block = num_rows_per_block;
-    tablet_schema->_cols.push_back(create_int_key(1));
-    tablet_schema->_cols.push_back(create_int_key(2));
-    tablet_schema->_cols.push_back(create_int_value(3));
-    tablet_schema->_cols.push_back(create_int_value(4));
-
-    //    segment write
-    std::string dname = "./ut_dir/segment_test";
-    FileUtils::create_dir(dname);
+    TabletSchema tablet_schema = create_schema({
+        create_int_key(1), create_int_key(2), create_int_value(3), create_int_value(4)});
 
     SegmentWriterOptions opts;
-    opts.num_rows_per_block = num_rows_per_block;
-    opts.need_bitmap_index = true;
+    opts.need_bitmap_index = true; // produce bitmap index for value columns 2 and 3
 
-    std::string fname = dname + "/bitmap_predicate";
-
-    SegmentWriter writer(fname, 0, tablet_schema.get(), opts);
-    auto st = writer.init(10);
-    ASSERT_TRUE(st.ok());
-
-    RowCursor row;
-    auto olap_st = row.init(*tablet_schema);
-    ASSERT_EQ(OLAP_SUCCESS, olap_st);
-
-    // 0, 1, 2, 3
-    // 10, 11, 12, 13
-    // 20, 21, 22, 23
-    for (int i = 0; i < 4096; ++i) {
-        for (int j = 0; j < 4; ++j) {
-            auto cell = row.cell(j);
-            cell.set_not_null();
-            *(int*)cell.mutable_cell_ptr() = i * 10 + j;
-        }
-        writer.append_row(row);
-    }
-
-    uint64_t file_size = 0;
-    uint64_t index_size;
-    st = writer.finalize(&file_size, &index_size);
-    ASSERT_TRUE(st.ok());
+    shared_ptr<Segment> segment;
+    build_segment(opts, tablet_schema, tablet_schema, 4096, DefaultIntGenerator, &segment);
+    ASSERT_TRUE(segment->footer().columns(2).has_bitmap_index());
+    ASSERT_TRUE(segment->footer().columns(3).has_bitmap_index());
 
     {
-        std::shared_ptr<Segment> segment;
-        st = segment->open(fname, 0, tablet_schema.get(), &segment);
-        ASSERT_TRUE(st.ok());
-        ASSERT_EQ(4096, segment->num_rows());
-        Schema schema(*tablet_schema);
+        Schema schema(tablet_schema);
 
         // test where v1=12
         {
@@ -981,8 +992,7 @@ TEST_F(SegmentReaderWriterTest, TestBitmapPredicate) {
             segment->new_iterator(schema, read_opts, &iter);
 
             RowBlockV2 block(schema, 1024);
-            st = iter->next_batch(&block);
-            ASSERT_TRUE(st.ok());
+            ASSERT_TRUE(iter->next_batch(&block).ok());
             ASSERT_EQ(block.num_rows(), 1);
             ASSERT_EQ(read_opts.stats->raw_rows_read, 1);
         }
@@ -1004,8 +1014,7 @@ TEST_F(SegmentReaderWriterTest, TestBitmapPredicate) {
             segment->new_iterator(schema, read_opts, &iter);
 
             RowBlockV2 block(schema, 1024);
-            st = iter->next_batch(&block);
-            ASSERT_TRUE(st.ok());
+            ASSERT_TRUE(iter->next_batch(&block).ok());
             ASSERT_EQ(block.num_rows(), 1);
             ASSERT_EQ(read_opts.stats->raw_rows_read, 1);
         }
@@ -1027,9 +1036,8 @@ TEST_F(SegmentReaderWriterTest, TestBitmapPredicate) {
             segment->new_iterator(schema, read_opts, &iter);
 
             RowBlockV2 block(schema, 1024);
-            st = iter->next_batch(&block);
+            ASSERT_FALSE(iter->next_batch(&block).ok());
             ASSERT_EQ(read_opts.stats->raw_rows_read, 0);
-            ASSERT_FALSE(st.ok());
         }
 
         // test where v1 in (12,22,1)
@@ -1051,9 +1059,8 @@ TEST_F(SegmentReaderWriterTest, TestBitmapPredicate) {
             segment->new_iterator(schema, read_opts, &iter);
 
             RowBlockV2 block(schema, 1024);
-            st = iter->next_batch(&block);
+            ASSERT_TRUE(iter->next_batch(&block).ok());
             ASSERT_EQ(read_opts.stats->raw_rows_read, 2);
-            ASSERT_TRUE(st.ok());
         }
 
         // test where v1 not in (12,22)
@@ -1075,6 +1082,7 @@ TEST_F(SegmentReaderWriterTest, TestBitmapPredicate) {
 
             RowBlockV2 block(schema, 1024);
 
+            Status st;
             do {
                 block.clear();
                 st = iter->next_batch(&block);
@@ -1082,104 +1090,27 @@ TEST_F(SegmentReaderWriterTest, TestBitmapPredicate) {
             ASSERT_EQ(read_opts.stats->raw_rows_read, 4094);
         }
     }
-
-    FileUtils::remove_all(dname);
 }
 
 TEST_F(SegmentReaderWriterTest, TestBloomFilterIndexUniqueModel) {
-    size_t num_rows_per_block = 10;
-
-    std::shared_ptr<TabletSchema> tablet_schema(new TabletSchema());
-    tablet_schema->_num_columns = 4;
-    tablet_schema->_num_key_columns = 3;
-    tablet_schema->_num_short_key_columns = 2;
-    tablet_schema->_num_rows_per_row_block = num_rows_per_block;
-    tablet_schema->_cols.push_back(create_int_key(1));
-    tablet_schema->_cols.push_back(create_int_key(2));
-    tablet_schema->_cols.push_back(create_int_key(3));
-    tablet_schema->_cols.push_back(create_int_value(4, OLAP_FIELD_AGGREGATION_REPLACE, true, "", true));
-
-    // segment write
-    std::string dname = "./ut_dir/segment_test";
-    FileUtils::create_dir(dname);
+    TabletSchema schema = create_schema({
+        create_int_key(1), create_int_key(2), create_int_key(3),
+        create_int_value(4, OLAP_FIELD_AGGREGATION_REPLACE, true, "", true)
+    });
 
     // for not base segment
-    SegmentWriterOptions opts;
-    opts.num_rows_per_block = num_rows_per_block;
-
-    std::string fname = dname + "/bf_in_unique_model_not_base";
-    SegmentWriter writer(fname, 0, tablet_schema.get(), opts);
-    auto st = writer.init(10);
-    ASSERT_TRUE(st.ok());
-
-    RowCursor row;
-    auto olap_st = row.init(*tablet_schema);
-    ASSERT_EQ(OLAP_SUCCESS, olap_st);
-
-    // 0, 1, 2, 3
-    // 10, 11, 12, 13
-    // 20, 21, 22, 23
-    //
-    // 64k int will generate 4 pages
-    for (int i = 0; i < 64 * 1024; ++i) {
-        for (int j = 0; j < 4; ++j) {
-            auto cell = row.cell(j);
-            cell.set_not_null();
-            if (i >= 16 * 1024 && i < 32 * 1024) {
-                // make second page all rows equal
-                *(int*)cell.mutable_cell_ptr() = 164000 + j;
-
-            } else {
-                *(int*)cell.mutable_cell_ptr() = i * 10 + j;
-            }
-        }
-        writer.append_row(row);
-    }
-
-    uint64_t file_size = 0;
-    uint64_t index_size;
-    st = writer.finalize(&file_size, &index_size);
-    ASSERT_TRUE(st.ok());
-    ASSERT_FALSE(writer.has_bf_index(3));
+    SegmentWriterOptions opts1;
+    opts1.whether_to_filter_value = false;
+    shared_ptr<Segment> seg1;
+    build_segment(opts1, schema, schema, 100, DefaultIntGenerator, &seg1);
+    ASSERT_FALSE(seg1->footer().columns(3).has_bloom_filter_index());
 
     // for base segment
-    // for not base segment
     SegmentWriterOptions opts2;
-    opts2.num_rows_per_block = num_rows_per_block;
     opts2.whether_to_filter_value = true;
-
-    std::string fname2 = dname + "/bf_in_unique_model_base";
-    SegmentWriter writer2(fname, 0, tablet_schema.get(), opts2);
-    st = writer2.init(10);
-    ASSERT_TRUE(st.ok());
-
-    RowCursor row2;
-    olap_st = row2.init(*tablet_schema);
-    ASSERT_EQ(OLAP_SUCCESS, olap_st);
-
-    // 0, 1, 2, 3
-    // 10, 11, 12, 13
-    // 20, 21, 22, 23
-    //
-    // 64k int will generate 4 pages
-    for (int i = 0; i < 64 * 1024; ++i) {
-        for (int j = 0; j < 4; ++j) {
-            auto cell = row2.cell(j);
-            cell.set_not_null();
-            if (i >= 16 * 1024 && i < 32 * 1024) {
-                // make second page all rows equal
-                *(int*)cell.mutable_cell_ptr() = 164000 + j;
-
-            } else {
-                *(int*)cell.mutable_cell_ptr() = i * 10 + j;
-            }
-        }
-        writer2.append_row(row2);
-    }
-
-    st = writer2.finalize(&file_size, &index_size);
-    ASSERT_TRUE(st.ok());
-    ASSERT_TRUE(writer2.has_bf_index(3));
+    shared_ptr<Segment> seg2;
+    build_segment(opts2, schema, schema, 100, DefaultIntGenerator, &seg2);
+    ASSERT_TRUE(seg2->footer().columns(3).has_bloom_filter_index());
 }
 
 }


### PR DESCRIPTION
This CL a follow-up of #2547 , with the following changes
- add UT for lazy materialization
- add several utility functions in segment_test to make it easier to add test cases
- optimize the performance when populating `SegmentIterator::_block_rowids`