### PR TITLE
[Alter Table] No need to check whether table is stable when doing some kinds of alter operation

### DIFF
--- a/be/src/olap/task/engine_clone_task.cpp
+++ b/be/src/olap/task/engine_clone_task.cpp
@@ -519,6 +519,9 @@ Status EngineCloneTask::_download_files(
 
         std::string local_file_path = local_path + file_name;
 
+        LOG(INFO) << "clone begin to download file from: " << remote_file_url << " to: "
+            << local_file_path << ". size(B): " << file_size << ", timeout(s): " << estimate_timeout;
+
         auto download_cb = [&remote_file_url,
              estimate_timeout,
              &local_file_path,

--- a/be/src/runtime/routine_load/routine_load_task_executor.cpp
+++ b/be/src/runtime/routine_load/routine_load_task_executor.cpp
@@ -165,7 +165,7 @@ void RoutineLoadTaskExecutor::exec_task(
 #define HANDLE_ERROR(stmt, err_msg) \
     do { \
         Status _status_ = (stmt); \
-        if (UNLIKELY(!_status_.ok())) { \
+        if (UNLIKELY(!_status_.ok() && _status_.code() != TStatusCode::PUBLISH_TIMEOUT)) { \
             err_handler(ctx, _status_, err_msg); \
             cb(ctx); \
             return; \

--- a/fe/src/main/java/org/apache/doris/alter/Alter.java
+++ b/fe/src/main/java/org/apache/doris/alter/Alter.java
@@ -229,7 +229,7 @@ public class Alter {
                 throw new DdlException("Table[" + table.getName() + "]'s state is not NORMAL. Do not allow doing ALTER ops");
             }
             
-            if ((hasSchemaChange || hasModifyProp || hasAddMaterializedView) && needTableStable) {
+            if (needTableStable) {
                 // check if all tablets are healthy, and no tablet is in tablet scheduler
                 boolean isStable = olapTable.isStable(Catalog.getCurrentSystemInfo(),
                         Catalog.getCurrentCatalog().getTabletScheduler(),
@@ -244,7 +244,7 @@ public class Alter {
 
             if (hasSchemaChange || hasModifyProp) {
                 // if modify storage type to v2, do schema change to convert all related tablets to segment v2 format
-                schemaChangeHandler.process((List<AlterClause>) alterClauses, clusterName, db, olapTable);
+                schemaChangeHandler.process(alterClauses, clusterName, db, olapTable);
             } else if (hasAddMaterializedView || hasDropRollup) {
                 materializedViewHandler.process(alterClauses, clusterName, db, olapTable);
             } else if (hasPartition) {

--- a/fe/src/main/java/org/apache/doris/alter/Alter.java
+++ b/fe/src/main/java/org/apache/doris/alter/Alter.java
@@ -23,6 +23,7 @@ import org.apache.doris.analysis.AddPartitionClause;
 import org.apache.doris.analysis.AddRollupClause;
 import org.apache.doris.analysis.AlterClause;
 import org.apache.doris.analysis.AlterSystemStmt;
+import org.apache.doris.analysis.AlterTableClause;
 import org.apache.doris.analysis.AlterTableStmt;
 import org.apache.doris.analysis.AlterViewStmt;
 import org.apache.doris.analysis.ColumnRenameClause;
@@ -167,7 +168,7 @@ public class Alter {
         boolean needTableStable = false;
         for (AlterClause alterClause : alterClauses) {
             if (!needTableStable) {
-                needTableStable = alterClause.isNeedTableStable();
+                needTableStable = ((AlterTableClause) alterClause).isNeedTableStable();
             }
             if ((alterClause instanceof AddColumnClause
                     || alterClause instanceof AddColumnsClause
@@ -243,7 +244,7 @@ public class Alter {
 
             if (hasSchemaChange || hasModifyProp) {
                 // if modify storage type to v2, do schema change to convert all related tablets to segment v2 format
-                schemaChangeHandler.process(alterClauses, clusterName, db, olapTable);
+                schemaChangeHandler.process((List<AlterClause>) alterClauses, clusterName, db, olapTable);
             } else if (hasAddMaterializedView || hasDropRollup) {
                 materializedViewHandler.process(alterClauses, clusterName, db, olapTable);
             } else if (hasPartition) {

--- a/fe/src/main/java/org/apache/doris/alter/SchemaChangeHandler.java
+++ b/fe/src/main/java/org/apache/doris/alter/SchemaChangeHandler.java
@@ -65,8 +65,8 @@ import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.task.AgentBatchTask;
 import org.apache.doris.task.AgentTaskExecutor;
 import org.apache.doris.task.ClearAlterTask;
-import org.apache.doris.thrift.TStorageMedium;
 import org.apache.doris.thrift.TStorageFormat;
+import org.apache.doris.thrift.TStorageMedium;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;

--- a/fe/src/main/java/org/apache/doris/analysis/AddColumnClause.java
+++ b/fe/src/main/java/org/apache/doris/analysis/AddColumnClause.java
@@ -58,6 +58,7 @@ public class AddColumnClause extends AlterClause {
         this.colPos = colPos;
         this.rollupName = rollupName;
         this.properties = properties;
+        this.needTableStable = true;
     }
 
     @Override

--- a/fe/src/main/java/org/apache/doris/analysis/AddColumnClause.java
+++ b/fe/src/main/java/org/apache/doris/analysis/AddColumnClause.java
@@ -30,7 +30,7 @@ import org.apache.logging.log4j.Logger;
 import java.util.Map;
 
 // clause which is used to add one column to
-public class AddColumnClause extends AlterClause {
+public class AddColumnClause extends AlterTableClause {
     private static final Logger LOG = LogManager.getLogger(AddColumnClause.class);
     private ColumnDef columnDef;
     // Column position
@@ -58,7 +58,6 @@ public class AddColumnClause extends AlterClause {
         this.colPos = colPos;
         this.rollupName = rollupName;
         this.properties = properties;
-        this.needTableStable = true;
     }
 
     @Override

--- a/fe/src/main/java/org/apache/doris/analysis/AddColumnsClause.java
+++ b/fe/src/main/java/org/apache/doris/analysis/AddColumnsClause.java
@@ -29,7 +29,7 @@ import java.util.List;
 import java.util.Map;
 
 // add some columns to one index.
-public class AddColumnsClause extends AlterClause {
+public class AddColumnsClause extends AlterTableClause {
     private List<ColumnDef> columnDefs;
     private String rollupName;
 
@@ -49,7 +49,6 @@ public class AddColumnsClause extends AlterClause {
         this.columnDefs = columnDefs;
         this.rollupName = rollupName;
         this.properties = properties;
-        this.needTableStable = true;
     }
 
     @Override

--- a/fe/src/main/java/org/apache/doris/analysis/AddColumnsClause.java
+++ b/fe/src/main/java/org/apache/doris/analysis/AddColumnsClause.java
@@ -49,6 +49,7 @@ public class AddColumnsClause extends AlterClause {
         this.columnDefs = columnDefs;
         this.rollupName = rollupName;
         this.properties = properties;
+        this.needTableStable = true;
     }
 
     @Override

--- a/fe/src/main/java/org/apache/doris/analysis/AddPartitionClause.java
+++ b/fe/src/main/java/org/apache/doris/analysis/AddPartitionClause.java
@@ -22,7 +22,7 @@ import org.apache.doris.common.AnalysisException;
 import java.util.Map;
 
 // clause which is used to add partition
-public class AddPartitionClause extends AlterClause {
+public class AddPartitionClause extends AlterTableClause {
 
     private SingleRangePartitionDesc partitionDesc;
     private DistributionDesc distributionDesc;
@@ -42,6 +42,7 @@ public class AddPartitionClause extends AlterClause {
         this.partitionDesc = partitionDesc;
         this.distributionDesc = distributionDesc;
         this.properties = properties;
+        this.needTableStable = false;
     }
 
     @Override

--- a/fe/src/main/java/org/apache/doris/analysis/AddRollupClause.java
+++ b/fe/src/main/java/org/apache/doris/analysis/AddRollupClause.java
@@ -72,6 +72,7 @@ public class AddRollupClause extends AlterClause {
         this.dupKeys = dupKeys;
         this.baseRollupName = baseRollupName;
         this.properties = properties;
+        this.needTableStable = true;
     }
 
     @Override

--- a/fe/src/main/java/org/apache/doris/analysis/AddRollupClause.java
+++ b/fe/src/main/java/org/apache/doris/analysis/AddRollupClause.java
@@ -35,7 +35,7 @@ import java.util.Set;
 // syntax:
 //      ALTER TABLE table_name
 //          ADD ROLLUP rollup_name (column, ..) FROM base_rollup
-public class AddRollupClause extends AlterClause {
+public class AddRollupClause extends AlterTableClause {
     private String rollupName;
     private List<String> columnNames;
     private String baseRollupName;
@@ -72,7 +72,6 @@ public class AddRollupClause extends AlterClause {
         this.dupKeys = dupKeys;
         this.baseRollupName = baseRollupName;
         this.properties = properties;
-        this.needTableStable = true;
     }
 
     @Override

--- a/fe/src/main/java/org/apache/doris/analysis/AlterClause.java
+++ b/fe/src/main/java/org/apache/doris/analysis/AlterClause.java
@@ -23,6 +23,12 @@ import java.util.Map;
 
 // Alter table clause.
 public abstract class AlterClause implements ParseNode {
+    // if set to true, the corresponding table should be stable before processing this operation on it.
+    protected boolean needTableStable = false;
+
+    public boolean isNeedTableStable() {
+        return needTableStable;
+    }
 
     public Map<String, String> getProperties() {
         throw new NotImplementedException();

--- a/fe/src/main/java/org/apache/doris/analysis/AlterTableClause.java
+++ b/fe/src/main/java/org/apache/doris/analysis/AlterTableClause.java
@@ -17,14 +17,12 @@
 
 package org.apache.doris.analysis;
 
-import org.apache.commons.lang.NotImplementedException;
+// alter table clause
+public abstract class AlterTableClause extends AlterClause {
+    // if set to true, the corresponding table should be stable before processing this operation on it.
+    protected boolean needTableStable = true;
 
-import java.util.Map;
-
-// Alter clause.
-public abstract class AlterClause implements ParseNode {
-
-    public Map<String, String> getProperties() {
-        throw new NotImplementedException();
+    public boolean isNeedTableStable() {
+        return needTableStable;
     }
 }

--- a/fe/src/main/java/org/apache/doris/analysis/ColumnRenameClause.java
+++ b/fe/src/main/java/org/apache/doris/analysis/ColumnRenameClause.java
@@ -24,14 +24,15 @@ import com.google.common.base.Strings;
 
 import java.util.Map;
 
-// rename table
-public class ColumnRenameClause extends AlterClause {
+// rename column
+public class ColumnRenameClause extends AlterTableClause {
     private String colName;
     private String newColName;
 
     public ColumnRenameClause(String colName, String newColName) {
         this.colName = colName;
         this.newColName = newColName;
+        this.needTableStable = false;
     }
 
     public String getColName() {

--- a/fe/src/main/java/org/apache/doris/analysis/DropColumnClause.java
+++ b/fe/src/main/java/org/apache/doris/analysis/DropColumnClause.java
@@ -26,7 +26,7 @@ import com.google.common.base.Strings;
 import java.util.Map;
 
 // Drop one column
-public class DropColumnClause extends AlterClause {
+public class DropColumnClause extends AlterTableClause {
     private String colName;
     private String rollupName;
 
@@ -44,7 +44,6 @@ public class DropColumnClause extends AlterClause {
         this.colName = colName;
         this.rollupName = rollupName;
         this.properties = properties;
-        this.needTableStable = true;
     }
 
     @Override

--- a/fe/src/main/java/org/apache/doris/analysis/DropColumnClause.java
+++ b/fe/src/main/java/org/apache/doris/analysis/DropColumnClause.java
@@ -44,6 +44,7 @@ public class DropColumnClause extends AlterClause {
         this.colName = colName;
         this.rollupName = rollupName;
         this.properties = properties;
+        this.needTableStable = true;
     }
 
     @Override

--- a/fe/src/main/java/org/apache/doris/analysis/DropPartitionClause.java
+++ b/fe/src/main/java/org/apache/doris/analysis/DropPartitionClause.java
@@ -26,13 +26,14 @@ import com.google.common.base.Strings;
 import java.util.Map;
 
 // clause which is used to add one column to
-public class DropPartitionClause extends AlterClause {
+public class DropPartitionClause extends AlterTableClause {
     private boolean ifExists;
     private String partitionName;
 
     public DropPartitionClause(boolean ifExists, String partitionName) {
         this.ifExists = ifExists;
         this.partitionName = partitionName;
+        this.needTableStable = false;
     }
 
     public boolean isSetIfExists() {

--- a/fe/src/main/java/org/apache/doris/analysis/DropRollupClause.java
+++ b/fe/src/main/java/org/apache/doris/analysis/DropRollupClause.java
@@ -24,13 +24,14 @@ import com.google.common.base.Strings;
 import java.util.Map;
 
 // Delete one rollup from table
-public class DropRollupClause extends AlterClause {
+public class DropRollupClause extends AlterTableClause {
     private final String rollupName;
     private Map<String, String> properties;
 
     public DropRollupClause(String rollupName, Map<String, String> properties) {
         this.rollupName = rollupName;
         this.properties = properties;
+        this.needTableStable = false;
     }
 
     @Override

--- a/fe/src/main/java/org/apache/doris/analysis/ModifyColumnClause.java
+++ b/fe/src/main/java/org/apache/doris/analysis/ModifyColumnClause.java
@@ -25,7 +25,7 @@ import com.google.common.base.Strings;
 import java.util.Map;
 
 // modify one column
-public class ModifyColumnClause extends AlterClause {
+public class ModifyColumnClause extends AlterTableClause {
     private ColumnDef columnDef;
     private ColumnPosition colPos;
     // which rollup is to be modify, if rollup is null, modify base table.
@@ -52,7 +52,6 @@ public class ModifyColumnClause extends AlterClause {
         this.colPos = colPos;
         this.rollupName = rollup;
         this.properties = properties;
-        this.needTableStable = true;
     }
 
     @Override

--- a/fe/src/main/java/org/apache/doris/analysis/ModifyColumnClause.java
+++ b/fe/src/main/java/org/apache/doris/analysis/ModifyColumnClause.java
@@ -52,6 +52,7 @@ public class ModifyColumnClause extends AlterClause {
         this.colPos = colPos;
         this.rollupName = rollup;
         this.properties = properties;
+        this.needTableStable = true;
     }
 
     @Override

--- a/fe/src/main/java/org/apache/doris/analysis/ModifyPartitionClause.java
+++ b/fe/src/main/java/org/apache/doris/analysis/ModifyPartitionClause.java
@@ -25,7 +25,7 @@ import com.google.common.base.Strings;
 import java.util.Map;
 
 // clause which is used to modify partition properties
-public class ModifyPartitionClause extends AlterClause {
+public class ModifyPartitionClause extends AlterTableClause {
 
     private String partitionName;
     private Map<String, String> properties;
@@ -37,6 +37,12 @@ public class ModifyPartitionClause extends AlterClause {
     public ModifyPartitionClause(String partitionName, Map<String, String> properties) {
         this.partitionName = partitionName;
         this.properties = properties;
+        // ATTN: currently, modify partition only allow 2 kinds of operations:
+        // 1. modify replication num
+        // 2. modify data property
+        // And these 2 operations does not require table to be stable.
+        // If other kinds of operations be added later, "needTableStable" may be changed.
+        this.needTableStable = false;
     }
 
     @Override

--- a/fe/src/main/java/org/apache/doris/analysis/ModifyTablePropertiesClause.java
+++ b/fe/src/main/java/org/apache/doris/analysis/ModifyTablePropertiesClause.java
@@ -25,7 +25,7 @@ import org.apache.doris.common.util.PropertyAnalyzer;
 import java.util.Map;
 
 // clause which is used to modify table properties
-public class ModifyTablePropertiesClause extends AlterClause {
+public class ModifyTablePropertiesClause extends AlterTableClause {
 
     private Map<String, String> properties;
 
@@ -47,31 +47,30 @@ public class ModifyTablePropertiesClause extends AlterClause {
             if (Config.disable_colocate_join) {
                 throw new AnalysisException("Colocate table is disabled by Admin");
             }
-            this.needTableStable = true;
+            this.needTableStable = false;
         } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_STORAGE_TYPE)) {
             if (!properties.get(PropertyAnalyzer.PROPERTIES_STORAGE_TYPE).equalsIgnoreCase("column")) {
                 throw new AnalysisException("Can only change storage type to COLUMN");
             }
-            this.needTableStable = true;
         } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_DISTRIBUTION_TYPE)) {
             if (!properties.get(PropertyAnalyzer.PROPERTIES_DISTRIBUTION_TYPE).equalsIgnoreCase("hash")) {
                 throw new AnalysisException("Can only change distribution type to HASH");
             }
+            this.needTableStable = false;
         } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_SEND_CLEAR_ALTER_TASK)) {
             if (!properties.get(PropertyAnalyzer.PROPERTIES_SEND_CLEAR_ALTER_TASK).equalsIgnoreCase("true")) {
                 throw new AnalysisException(
                         "Property " + PropertyAnalyzer.PROPERTIES_SEND_CLEAR_ALTER_TASK + " should be set to true");
             }
+            this.needTableStable = false;
         } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_BF_COLUMNS)
                 || properties.containsKey(PropertyAnalyzer.PROPERTIES_BF_FPP)) {
             // do nothing, these 2 properties will be analyzed when creating alter job
-            this.needTableStable = true;
         } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_STORAGE_FORMAT)) {
             if (!properties.get(PropertyAnalyzer.PROPERTIES_STORAGE_FORMAT).equalsIgnoreCase("v2")) {
                 throw new AnalysisException(
                         "Property " + PropertyAnalyzer.PROPERTIES_STORAGE_FORMAT + " should be v2");
             }
-            this.needTableStable = true;
         } else {
             throw new AnalysisException("Unknown table property: " + properties.keySet());
         }

--- a/fe/src/main/java/org/apache/doris/analysis/ModifyTablePropertiesClause.java
+++ b/fe/src/main/java/org/apache/doris/analysis/ModifyTablePropertiesClause.java
@@ -47,10 +47,12 @@ public class ModifyTablePropertiesClause extends AlterClause {
             if (Config.disable_colocate_join) {
                 throw new AnalysisException("Colocate table is disabled by Admin");
             }
+            this.needTableStable = true;
         } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_STORAGE_TYPE)) {
             if (!properties.get(PropertyAnalyzer.PROPERTIES_STORAGE_TYPE).equalsIgnoreCase("column")) {
                 throw new AnalysisException("Can only change storage type to COLUMN");
             }
+            this.needTableStable = true;
         } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_DISTRIBUTION_TYPE)) {
             if (!properties.get(PropertyAnalyzer.PROPERTIES_DISTRIBUTION_TYPE).equalsIgnoreCase("hash")) {
                 throw new AnalysisException("Can only change distribution type to HASH");
@@ -63,11 +65,13 @@ public class ModifyTablePropertiesClause extends AlterClause {
         } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_BF_COLUMNS)
                 || properties.containsKey(PropertyAnalyzer.PROPERTIES_BF_FPP)) {
             // do nothing, these 2 properties will be analyzed when creating alter job
+            this.needTableStable = true;
         } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_STORAGE_FORMAT)) {
             if (!properties.get(PropertyAnalyzer.PROPERTIES_STORAGE_FORMAT).equalsIgnoreCase("v2")) {
                 throw new AnalysisException(
                         "Property " + PropertyAnalyzer.PROPERTIES_STORAGE_FORMAT + " should be v2");
             }
+            this.needTableStable = true;
         } else {
             throw new AnalysisException("Unknown table property: " + properties.keySet());
         }

--- a/fe/src/main/java/org/apache/doris/analysis/PartitionRenameClause.java
+++ b/fe/src/main/java/org/apache/doris/analysis/PartitionRenameClause.java
@@ -25,13 +25,14 @@ import com.google.common.base.Strings;
 import java.util.Map;
 
 // rename table
-public class PartitionRenameClause extends AlterClause {
+public class PartitionRenameClause extends AlterTableClause {
     private String partitionName;
     private String newPartitionName;
 
     public PartitionRenameClause(String partitionName, String newPartitionName) {
         this.partitionName = partitionName;
         this.newPartitionName = newPartitionName;
+        this.needTableStable = false;
     }
 
     public String getPartitionName() {

--- a/fe/src/main/java/org/apache/doris/analysis/ReorderColumnsClause.java
+++ b/fe/src/main/java/org/apache/doris/analysis/ReorderColumnsClause.java
@@ -43,6 +43,7 @@ public class ReorderColumnsClause extends AlterClause {
         this.columnsByPos = cols;
         this.rollupName = rollup;
         this.properties = properties;
+        this.needTableStable = true;
     }
 
     @Override

--- a/fe/src/main/java/org/apache/doris/analysis/ReorderColumnsClause.java
+++ b/fe/src/main/java/org/apache/doris/analysis/ReorderColumnsClause.java
@@ -25,7 +25,7 @@ import java.util.List;
 import java.util.Map;
 
 // reorder column
-public class ReorderColumnsClause extends AlterClause {
+public class ReorderColumnsClause extends AlterTableClause {
     private List<String> columnsByPos;
     private String rollupName;
 
@@ -43,7 +43,6 @@ public class ReorderColumnsClause extends AlterClause {
         this.columnsByPos = cols;
         this.rollupName = rollup;
         this.properties = properties;
-        this.needTableStable = true;
     }
 
     @Override

--- a/fe/src/main/java/org/apache/doris/analysis/RollupRenameClause.java
+++ b/fe/src/main/java/org/apache/doris/analysis/RollupRenameClause.java
@@ -25,13 +25,14 @@ import com.google.common.base.Strings;
 import java.util.Map;
 
 // rename table
-public class RollupRenameClause extends AlterClause {
+public class RollupRenameClause extends AlterTableClause {
     private String rollupName;
     private String newRollupName;
 
     public RollupRenameClause(String rollupName, String newRollupName) {
         this.rollupName = rollupName;
         this.newRollupName = newRollupName;
+        this.needTableStable = false;
     }
 
     public String getRollupName() {

--- a/fe/src/main/java/org/apache/doris/analysis/TableRenameClause.java
+++ b/fe/src/main/java/org/apache/doris/analysis/TableRenameClause.java
@@ -25,11 +25,12 @@ import com.google.common.base.Strings;
 import java.util.Map;
 
 // rename table
-public class TableRenameClause extends AlterClause {
+public class TableRenameClause extends AlterTableClause {
     private String newTableName;
 
     public TableRenameClause(String newTableName) {
         this.newTableName = newTableName;
+        this.needTableStable = false;
     }
 
     public String getNewTableName() {

--- a/fe/src/main/java/org/apache/doris/clone/TabletScheduler.java
+++ b/fe/src/main/java/org/apache/doris/clone/TabletScheduler.java
@@ -879,6 +879,8 @@ public class TabletScheduler extends MasterDaemon {
             long nextTxnId = Catalog.getCurrentGlobalTransactionMgr().getTransactionIDGenerator().getNextTransactionId();
             replica.setWatermarkTxnId(nextTxnId);
             replica.setState(ReplicaState.DECOMMISSION);
+            // set priority to normal because it may wait for a long time. Remain it as VERY_HIGH may block other task.
+            tabletCtx.setOrigPriority(Priority.NORMAL);
             throw new SchedException(Status.SCHEDULE_FAILED, "set watermark txn " + nextTxnId);
         } else if (replica.getState() == ReplicaState.DECOMMISSION && replica.getWatermarkTxnId() != -1) {
             long watermarkTxnId = replica.getWatermarkTxnId();


### PR DESCRIPTION
Not all alter table operation require table to be stable. Such as rename, modify meta data.
ISSUE #2616 

And also optimize the routine load logic so that it won't rollback a already committed transaction.
ISSUE #2527