### PR TITLE
Remove the function `count_distinct()`

### DIFF
--- a/fe/src/main/java/org/apache/doris/catalog/FunctionSet.java
+++ b/fe/src/main/java/org/apache/doris/catalog/FunctionSet.java
@@ -839,17 +839,6 @@ public class FunctionSet {
                     prefix + "12count_removeEPN9doris_udf15FunctionContextERKNS1_6AnyValEPNS1_9BigIntValE",
                     null, false, true, true));
 
-            // Count_distinct
-            addBuiltin(AggregateFunction.createBuiltin("count_distinct",
-                    Lists.newArrayList(t), Type.BIGINT, Type.BIGINT,
-                    prefix + "9init_zeroIN9doris_udf9BigIntValEEEvPNS2_15FunctionContextEPT_",
-                    prefix + "12count_updateEPN9doris_udf15FunctionContextERKNS1_6AnyValEPNS1_9BigIntValE",
-                    prefix + "11count_mergeEPN9doris_udf15FunctionContextERKNS1_9BigIntValEPS4_",
-                    null, null,
-                    prefix + "12count_removeEPN9doris_udf15FunctionContextERKNS1_6AnyValEPNS1_9BigIntValE",
-                    null, false, true, true));
-
-
             // count in multi distinct
             if (t == Type.CHAR || t == Type.VARCHAR) {
                addBuiltin(AggregateFunction.createBuiltin("multi_distinct_count", Lists.newArrayList(t),


### PR DESCRIPTION
ISSUE #1553 
This commit will remove function `count_distinct()`.

We already have function `multi_distinct_count` as an alternative to help us calculate "count distinct" of any type value.
Besides, the `count_distinct()` function is with the the same symbol as `count()` function, which fails to express the meaning.
So I suggest to remove `count_distinct()` function.