### PR TITLE
Fix the missing sync in SegmentWriter

### DIFF
--- a/be/src/olap/rowset/segment_v2/segment_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_writer.cpp
@@ -71,7 +71,7 @@ Status SegmentWriter::init(uint32_t write_mbytes_per_sec) {
             if ((column.aggregation() == OLAP_FIELD_AGGREGATION_REPLACE
                     || column.aggregation() == OLAP_FIELD_AGGREGATION_REPLACE_IF_NOT_NULL)
                     && !_opts.whether_to_filter_value) {
-                // if the column's Aggregation type is OLAP_FIELD_AGGREGATION_REPLACE or 
+                // if the column's Aggregation type is OLAP_FIELD_AGGREGATION_REPLACE or
                 // OLAP_FIELD_AGGREGATION_REPLACE_IF_NOT_NULL and the segment is not in base rowset,
                 // do not write the bloom filter index because it is useless
                 opts.need_bloom_filter = false;
@@ -129,6 +129,7 @@ Status SegmentWriter::finalize(uint64_t* segment_file_size, uint64_t* index_size
     RETURN_IF_ERROR(_write_short_key_index());
     *index_size = _output_file->size() - index_offset;
     RETURN_IF_ERROR(_write_footer());
+    RETURN_IF_ERROR(_output_file->sync());
     *segment_file_size = _output_file->size();
     return Status::OK();
 }
@@ -186,7 +187,7 @@ Status SegmentWriter::_write_short_key_index() {
 
 Status SegmentWriter::_write_footer() {
     _footer.set_num_rows(_row_count);
-    // collect all 
+    // collect all
     for (int i = 0; i < _column_writers.size(); ++i) {
         _column_writers[i]->write_meta(_footer.mutable_columns(i));
     }


### PR DESCRIPTION
In the default configuration, `WritableFile` does not sync when close file.
We need to do it manually to ensure durability.