### PR TITLE
Support bitmap index for more type

### DIFF
--- a/be/src/exec/olap_common.h
+++ b/be/src/exec/olap_common.h
@@ -257,7 +257,8 @@ typedef boost::variant <
         ColumnValueRange<StringValue>,
         ColumnValueRange<DateTimeValue>,
         ColumnValueRange<DecimalValue>,
-        ColumnValueRange<DecimalV2Value> > ColumnValueRangeType;
+        ColumnValueRange<DecimalV2Value>,
+        ColumnValueRange<bool> > ColumnValueRangeType;
 
 template<class T>
 ColumnValueRange<T>::ColumnValueRange() : _column_type(INVALID_TYPE) {

--- a/be/src/olap/comparison_predicate.cpp
+++ b/be/src/olap/comparison_predicate.cpp
@@ -236,6 +236,7 @@ COMPARISON_PRED_BITMAP_EVALUATE(GreaterEqualPredicate, >=)
     template CLASS<StringValue>::CLASS(uint32_t column_id, const StringValue& value); \
     template CLASS<uint24_t>::CLASS(uint32_t column_id, const uint24_t& value); \
     template CLASS<uint64_t>::CLASS(uint32_t column_id, const uint64_t& value); \
+    template CLASS<bool>::CLASS(uint32_t column_id, const bool& value); \
 
 COMPARISON_PRED_CONSTRUCTOR_DECLARATION(EqualPredicate)
 COMPARISON_PRED_CONSTRUCTOR_DECLARATION(NotEqualPredicate)
@@ -256,6 +257,7 @@ COMPARISON_PRED_CONSTRUCTOR_DECLARATION(GreaterEqualPredicate)
     template void CLASS<StringValue>::evaluate(VectorizedRowBatch* batch) const; \
     template void CLASS<uint24_t>::evaluate(VectorizedRowBatch* batch) const; \
     template void CLASS<uint64_t>::evaluate(VectorizedRowBatch* batch) const; \
+    template void CLASS<bool>::evaluate(VectorizedRowBatch* batch) const; \
 
 COMPARISON_PRED_EVALUATE_DECLARATION(EqualPredicate)
 COMPARISON_PRED_EVALUATE_DECLARATION(NotEqualPredicate)
@@ -276,6 +278,7 @@ COMPARISON_PRED_EVALUATE_DECLARATION(GreaterEqualPredicate)
     template void CLASS<StringValue>::evaluate(ColumnBlock* block, uint16_t* sel, uint16_t* size) const; \
     template void CLASS<uint24_t>::evaluate(ColumnBlock* block, uint16_t* sel, uint16_t* size) const; \
     template void CLASS<uint64_t>::evaluate(ColumnBlock* block, uint16_t* sel, uint16_t* size) const; \
+    template void CLASS<bool>::evaluate(ColumnBlock* block, uint16_t* sel, uint16_t* size) const; \
 
 COMPARISON_PRED_COLUMN_BLOCK_EVALUATE_DECLARATION(EqualPredicate)
 COMPARISON_PRED_COLUMN_BLOCK_EVALUATE_DECLARATION(NotEqualPredicate)
@@ -296,6 +299,7 @@ COMPARISON_PRED_COLUMN_BLOCK_EVALUATE_DECLARATION(GreaterEqualPredicate)
     template Status CLASS<StringValue>::evaluate(const Schema& schema, const vector<BitmapIndexIterator*>& iterators, uint32_t num_rows, Roaring* bitmap) const; \
     template Status CLASS<uint24_t>::evaluate(const Schema& schema, const vector<BitmapIndexIterator*>& iterators, uint32_t num_rows, Roaring* bitmap) const; \
     template Status CLASS<uint64_t>::evaluate(const Schema& schema, const vector<BitmapIndexIterator*>& iterators, uint32_t num_rows, Roaring* bitmap) const; \
+    template Status CLASS<bool>::evaluate(const Schema& schema, const vector<BitmapIndexIterator*>& iterators, uint32_t num_rows, Roaring* bitmap) const; \
 
 COMPARISON_PRED_BITMAP_EVALUATE_DECLARATION(EqualPredicate)
 COMPARISON_PRED_BITMAP_EVALUATE_DECLARATION(NotEqualPredicate)

--- a/be/src/olap/reader.cpp
+++ b/be/src/olap/reader.cpp
@@ -844,6 +844,13 @@ ColumnPredicate* Reader::_new_##NAME##_pred(const TabletColumn& column, int inde
             predicate = new PREDICATE<uint64_t>(index, value); \
             break; \
         } \
+        case OLAP_FIELD_TYPE_BOOL: { \
+            std::stringstream ss(cond); \
+            bool value = false; \
+            ss >> value; \
+            predicate = new PREDICATE<bool>(index, value); \
+            break; \
+        } \
         default: break; \
     } \
  \
@@ -991,6 +998,7 @@ ColumnPredicate* Reader::_parse_to_predicate(const TCondition& condition) {
                 predicate = new InListPredicate<uint64_t>(index, std::move(values));
                 break;
             }
+            // OLAP_FIELD_TYPE_BOOL is not valid in this case.
             default: break;
         }
     } else if (condition.condition_op == "is") {

--- a/be/src/olap/rowset/segment_v2/bitmap_index_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/bitmap_index_writer.cpp
@@ -186,7 +186,7 @@ private:
 
 } // namespace
 
-// TODO currently we don't support bitmap index for float/double/date/datetime/decimal/hll
+// TODO currently we don't support bitmap index for bool/float/double/date/datetime/decimal
 Status BitmapIndexWriter::create(const TypeInfo* typeinfo, std::unique_ptr<BitmapIndexWriter>* res) {
     FieldType type = typeinfo->type();
     switch (type) {
@@ -210,6 +210,15 @@ Status BitmapIndexWriter::create(const TypeInfo* typeinfo, std::unique_ptr<Bitma
             break;
         case OLAP_FIELD_TYPE_VARCHAR:
             res->reset(new BitmapIndexWriterImpl<OLAP_FIELD_TYPE_VARCHAR>(typeinfo));
+            break;
+        case OLAP_FIELD_TYPE_DATE:
+            res->reset(new BitmapIndexWriterImpl<OLAP_FIELD_TYPE_DATE>(typeinfo));
+            break;
+        case OLAP_FIELD_TYPE_DATETIME:
+            res->reset(new BitmapIndexWriterImpl<OLAP_FIELD_TYPE_DATETIME>(typeinfo));
+            break;
+        case OLAP_FIELD_TYPE_LARGEINT:
+            res->reset(new BitmapIndexWriterImpl<OLAP_FIELD_TYPE_LARGEINT>(typeinfo));
             break;
         default:
             return Status::NotSupported("unsupported type for bitmap index: " + std::to_string(type));

--- a/be/src/olap/rowset/segment_v2/bitmap_index_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/bitmap_index_writer.cpp
@@ -186,7 +186,6 @@ private:
 
 } // namespace
 
-// TODO currently we don't support bitmap index for bool/float/double/date/datetime/decimal
 Status BitmapIndexWriter::create(const TypeInfo* typeinfo, std::unique_ptr<BitmapIndexWriter>* res) {
     FieldType type = typeinfo->type();
     switch (type) {
@@ -219,6 +218,18 @@ Status BitmapIndexWriter::create(const TypeInfo* typeinfo, std::unique_ptr<Bitma
             break;
         case OLAP_FIELD_TYPE_LARGEINT:
             res->reset(new BitmapIndexWriterImpl<OLAP_FIELD_TYPE_LARGEINT>(typeinfo));
+            break;
+        case OLAP_FIELD_TYPE_FLOAT:
+            res->reset(new BitmapIndexWriterImpl<OLAP_FIELD_TYPE_FLOAT>(typeinfo));
+            break;
+        case OLAP_FIELD_TYPE_DOUBLE:
+            res->reset(new BitmapIndexWriterImpl<OLAP_FIELD_TYPE_DOUBLE>(typeinfo));
+            break;
+        case OLAP_FIELD_TYPE_DECIMAL:
+            res->reset(new BitmapIndexWriterImpl<OLAP_FIELD_TYPE_DECIMAL>(typeinfo));
+            break;
+        case OLAP_FIELD_TYPE_BOOL:
+            res->reset(new BitmapIndexWriterImpl<OLAP_FIELD_TYPE_BOOL>(typeinfo));
             break;
         default:
             return Status::NotSupported("unsupported type for bitmap index: " + std::to_string(type));

--- a/be/src/olap/rowset/segment_v2/bitmap_index_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/bitmap_index_writer.cpp
@@ -219,12 +219,6 @@ Status BitmapIndexWriter::create(const TypeInfo* typeinfo, std::unique_ptr<Bitma
         case OLAP_FIELD_TYPE_LARGEINT:
             res->reset(new BitmapIndexWriterImpl<OLAP_FIELD_TYPE_LARGEINT>(typeinfo));
             break;
-        case OLAP_FIELD_TYPE_FLOAT:
-            res->reset(new BitmapIndexWriterImpl<OLAP_FIELD_TYPE_FLOAT>(typeinfo));
-            break;
-        case OLAP_FIELD_TYPE_DOUBLE:
-            res->reset(new BitmapIndexWriterImpl<OLAP_FIELD_TYPE_DOUBLE>(typeinfo));
-            break;
         case OLAP_FIELD_TYPE_DECIMAL:
             res->reset(new BitmapIndexWriterImpl<OLAP_FIELD_TYPE_DECIMAL>(typeinfo));
             break;

--- a/be/src/olap/rowset/segment_v2/encoding_info.cpp
+++ b/be/src/olap/rowset/segment_v2/encoding_info.cpp
@@ -211,9 +211,11 @@ EncodingInfoResolver::EncodingInfoResolver() {
 
     _add_map<OLAP_FIELD_TYPE_FLOAT, BIT_SHUFFLE>();
     _add_map<OLAP_FIELD_TYPE_FLOAT, PLAIN_ENCODING>();
+    _add_map<OLAP_FIELD_TYPE_FLOAT, BIT_SHUFFLE, true>();
 
     _add_map<OLAP_FIELD_TYPE_DOUBLE, BIT_SHUFFLE>();
     _add_map<OLAP_FIELD_TYPE_DOUBLE, PLAIN_ENCODING>();
+    _add_map<OLAP_FIELD_TYPE_DOUBLE, BIT_SHUFFLE, true>();
 
     _add_map<OLAP_FIELD_TYPE_CHAR, DICT_ENCODING>();
     _add_map<OLAP_FIELD_TYPE_CHAR, PLAIN_ENCODING>();
@@ -226,6 +228,7 @@ EncodingInfoResolver::EncodingInfoResolver() {
     _add_map<OLAP_FIELD_TYPE_BOOL, RLE>();
     _add_map<OLAP_FIELD_TYPE_BOOL, BIT_SHUFFLE>();
     _add_map<OLAP_FIELD_TYPE_BOOL, PLAIN_ENCODING>();
+    _add_map<OLAP_FIELD_TYPE_BOOL, PLAIN_ENCODING, true>();
 
     _add_map<OLAP_FIELD_TYPE_DATE, BIT_SHUFFLE>();
     _add_map<OLAP_FIELD_TYPE_DATE, PLAIN_ENCODING>();
@@ -237,6 +240,7 @@ EncodingInfoResolver::EncodingInfoResolver() {
 
     _add_map<OLAP_FIELD_TYPE_DECIMAL, BIT_SHUFFLE>();
     _add_map<OLAP_FIELD_TYPE_DECIMAL, PLAIN_ENCODING>();
+    _add_map<OLAP_FIELD_TYPE_DECIMAL, BIT_SHUFFLE, true>();
 
     _add_map<OLAP_FIELD_TYPE_HLL, PLAIN_ENCODING>();
 

--- a/be/src/olap/rowset/segment_v2/encoding_info.cpp
+++ b/be/src/olap/rowset/segment_v2/encoding_info.cpp
@@ -104,6 +104,18 @@ struct TypeEncodingTraits<type, DICT_ENCODING, Slice> {
     }
 };
 
+template<>
+struct TypeEncodingTraits<OLAP_FIELD_TYPE_DATE, FOR_ENCODING, typename CppTypeTraits<OLAP_FIELD_TYPE_DATE>::CppType> {
+    static Status create_page_builder(const PageBuilderOptions& opts, PageBuilder** builder) {
+        *builder = new FrameOfReferencePageBuilder<OLAP_FIELD_TYPE_DATE>(opts);
+        return Status::OK();
+    }
+    static Status create_page_decoder(const Slice& data, const PageDecoderOptions& opts, PageDecoder** decoder) {
+        *decoder = new FrameOfReferencePageDecoder<OLAP_FIELD_TYPE_DATE>(data, opts);
+        return Status::OK();
+    }
+};
+
 template<FieldType type, typename CppType>
 struct TypeEncodingTraits<type, FOR_ENCODING, CppType,
                           typename std::enable_if<std::is_integral<CppType>::value>::type> {
@@ -180,38 +192,54 @@ EncodingInfoResolver::EncodingInfoResolver() {
     _add_map<OLAP_FIELD_TYPE_TINYINT, BIT_SHUFFLE>();
     _add_map<OLAP_FIELD_TYPE_TINYINT, FOR_ENCODING, true>();
     _add_map<OLAP_FIELD_TYPE_TINYINT, PLAIN_ENCODING>();
+
     _add_map<OLAP_FIELD_TYPE_SMALLINT, BIT_SHUFFLE>();
     _add_map<OLAP_FIELD_TYPE_SMALLINT, FOR_ENCODING, true>();
     _add_map<OLAP_FIELD_TYPE_SMALLINT, PLAIN_ENCODING>();
+
     _add_map<OLAP_FIELD_TYPE_INT, BIT_SHUFFLE>();
     _add_map<OLAP_FIELD_TYPE_INT, FOR_ENCODING, true>();
     _add_map<OLAP_FIELD_TYPE_INT, PLAIN_ENCODING>();
+
     _add_map<OLAP_FIELD_TYPE_BIGINT, BIT_SHUFFLE>();
     _add_map<OLAP_FIELD_TYPE_BIGINT, FOR_ENCODING, true>();
     _add_map<OLAP_FIELD_TYPE_BIGINT, PLAIN_ENCODING>();
+
     _add_map<OLAP_FIELD_TYPE_LARGEINT, BIT_SHUFFLE>();
     _add_map<OLAP_FIELD_TYPE_LARGEINT, PLAIN_ENCODING>();
+    _add_map<OLAP_FIELD_TYPE_LARGEINT, FOR_ENCODING, true>();
+
     _add_map<OLAP_FIELD_TYPE_FLOAT, BIT_SHUFFLE>();
     _add_map<OLAP_FIELD_TYPE_FLOAT, PLAIN_ENCODING>();
+
     _add_map<OLAP_FIELD_TYPE_DOUBLE, BIT_SHUFFLE>();
     _add_map<OLAP_FIELD_TYPE_DOUBLE, PLAIN_ENCODING>();
+
     _add_map<OLAP_FIELD_TYPE_CHAR, DICT_ENCODING>();
     _add_map<OLAP_FIELD_TYPE_CHAR, PLAIN_ENCODING>();
     _add_map<OLAP_FIELD_TYPE_CHAR, PREFIX_ENCODING, true>();
+
     _add_map<OLAP_FIELD_TYPE_VARCHAR, DICT_ENCODING>();
     _add_map<OLAP_FIELD_TYPE_VARCHAR, PLAIN_ENCODING>();
     _add_map<OLAP_FIELD_TYPE_VARCHAR, PREFIX_ENCODING, true>();
-    _add_map<OLAP_FIELD_TYPE_HLL, PLAIN_ENCODING>();
+
     _add_map<OLAP_FIELD_TYPE_BOOL, RLE>();
     _add_map<OLAP_FIELD_TYPE_BOOL, BIT_SHUFFLE>();
     _add_map<OLAP_FIELD_TYPE_BOOL, PLAIN_ENCODING>();
+
     _add_map<OLAP_FIELD_TYPE_DATE, BIT_SHUFFLE>();
     _add_map<OLAP_FIELD_TYPE_DATE, PLAIN_ENCODING>();
+    _add_map<OLAP_FIELD_TYPE_DATE, FOR_ENCODING, true>();
+
     _add_map<OLAP_FIELD_TYPE_DATETIME, BIT_SHUFFLE>();
     _add_map<OLAP_FIELD_TYPE_DATETIME, PLAIN_ENCODING>();
+    _add_map<OLAP_FIELD_TYPE_DATETIME, FOR_ENCODING, true>();
+
     _add_map<OLAP_FIELD_TYPE_DECIMAL, BIT_SHUFFLE>();
     _add_map<OLAP_FIELD_TYPE_DECIMAL, PLAIN_ENCODING>();
+
     _add_map<OLAP_FIELD_TYPE_HLL, PLAIN_ENCODING>();
+
     _add_map<OLAP_FIELD_TYPE_OBJECT, PLAIN_ENCODING>();
 }
 

--- a/be/src/olap/rowset/segment_v2/encoding_info.cpp
+++ b/be/src/olap/rowset/segment_v2/encoding_info.cpp
@@ -211,11 +211,9 @@ EncodingInfoResolver::EncodingInfoResolver() {
 
     _add_map<OLAP_FIELD_TYPE_FLOAT, BIT_SHUFFLE>();
     _add_map<OLAP_FIELD_TYPE_FLOAT, PLAIN_ENCODING>();
-    _add_map<OLAP_FIELD_TYPE_FLOAT, BIT_SHUFFLE, true>();
 
     _add_map<OLAP_FIELD_TYPE_DOUBLE, BIT_SHUFFLE>();
     _add_map<OLAP_FIELD_TYPE_DOUBLE, PLAIN_ENCODING>();
-    _add_map<OLAP_FIELD_TYPE_DOUBLE, BIT_SHUFFLE, true>();
 
     _add_map<OLAP_FIELD_TYPE_CHAR, DICT_ENCODING>();
     _add_map<OLAP_FIELD_TYPE_CHAR, PLAIN_ENCODING>();

--- a/be/src/olap/uint24.h
+++ b/be/src/olap/uint24.h
@@ -49,8 +49,32 @@ public:
         return *this;
     }
 
+    uint24_t& operator=(const uint128_t& value) {
+        data[0] = static_cast<uint8_t>(value);
+        data[1] = static_cast<uint8_t>(value >> 8);
+        data[2] = static_cast<uint8_t>(value >> 16);
+        return *this;
+    }
+
+    uint24_t& operator=(const uint64_t& value) {
+        data[0] = static_cast<uint8_t>(value);
+        data[1] = static_cast<uint8_t>(value >> 8);
+        data[2] = static_cast<uint8_t>(value >> 16);
+        return *this;
+    }
+
     uint24_t& operator+=(const uint24_t& value) {
         *this = static_cast<int>(*this) + static_cast<int>(value);
+        return *this;
+    }
+
+    uint24_t& operator>>=(const int& bits) {
+        *this = static_cast<uint>(*this) >> bits;
+        return *this;
+    }
+
+    uint24_t& operator|=(const uint24_t& value) {
+        *this = static_cast<int>(*this) | static_cast<int>(value);
         return *this;
     }
 

--- a/be/src/util/coding.h
+++ b/be/src/util/coding.h
@@ -55,11 +55,11 @@ inline void encode_fixed64_le(uint8_t* buf, uint64_t val) {
 
 inline void encode_fixed128_le(uint8_t* buf, uint128_t val) {
 #if __BYTE_ORDER == __LITTLE_ENDIAN
-        memcpy(buf, &val, sizeof(val));
-    #else
+    memcpy(buf, &val, sizeof(val));
+#else
     uint128_t res = gbswap_128(val);
     memcpy(buf, &res, sizeof(res));
-    #endif
+#endif
 }
 
 inline uint8_t decode_fixed8(const uint8_t* buf) {

--- a/be/src/util/coding.h
+++ b/be/src/util/coding.h
@@ -11,6 +11,8 @@
 
 #include <string>
 
+#include "olap/olap_common.h"
+
 #include "gutil/endian.h"
 #include "util/slice.h"
 
@@ -51,6 +53,15 @@ inline void encode_fixed64_le(uint8_t* buf, uint64_t val) {
 #endif
 }
 
+inline void encode_fixed128_le(uint8_t* buf, uint128_t val) {
+    #if __BYTE_ORDER == __LITTLE_ENDIAN
+        memcpy(buf, &val, sizeof(val));
+    #else
+    uint128_t res = gbswap_128(val);
+    memcpy(buf, &res, sizeof(res));
+    #endif
+}
+
 inline uint8_t decode_fixed8(const uint8_t* buf) {
     return *buf;
 }
@@ -85,6 +96,16 @@ inline uint64_t decode_fixed64_le(const uint8_t* buf) {
 #endif
 }
 
+inline uint128_t decode_fixed128_le(const uint8_t* buf) {
+    uint128_t res;
+    memcpy(&res, buf, sizeof(res));
+#if __BYTE_ORDER == __LITTLE_ENDIAN
+    return res;
+#else
+    return gbswap_128(res);
+#endif
+}
+
 template<typename T>
 inline void put_fixed32_le(T* dst, uint32_t val) {
     uint8_t buf[sizeof(val)];
@@ -107,6 +128,13 @@ inline int varint_length(uint64_t v) {
         len++;
     }
     return len;
+}
+
+template<typename T>
+inline void put_fixed128_le(T* dst, uint128_t val) {
+    uint8_t buf[sizeof(val)];
+    encode_fixed128_le(buf, val);
+    dst->append((char*)buf, sizeof(buf));
 }
 
 extern uint8_t* encode_varint32(uint8_t* dst, uint32_t value);

--- a/be/src/util/coding.h
+++ b/be/src/util/coding.h
@@ -54,7 +54,7 @@ inline void encode_fixed64_le(uint8_t* buf, uint64_t val) {
 }
 
 inline void encode_fixed128_le(uint8_t* buf, uint128_t val) {
-    #if __BYTE_ORDER == __LITTLE_ENDIAN
+#if __BYTE_ORDER == __LITTLE_ENDIAN
         memcpy(buf, &val, sizeof(val));
     #else
     uint128_t res = gbswap_128(val);

--- a/be/src/util/frame_of_reference_coding.cpp
+++ b/be/src/util/frame_of_reference_coding.cpp
@@ -33,7 +33,7 @@ static inline uint8_t bits_less_than_64(const uint64_t v) {
 static inline uint8_t bits_may_more_than_64(const uint128_t v) {
     uint64_t hi = v >> 64;
     uint64_t lo = v;
-    int z[3]={
+    int z[3] = {
             __builtin_clzll(hi),
             __builtin_clzll(lo) + 64,
             128

--- a/be/src/util/frame_of_reference_coding.cpp
+++ b/be/src/util/frame_of_reference_coding.cpp
@@ -38,7 +38,7 @@ static inline uint8_t bits_may_more_than_64(const uint128_t v) {
             __builtin_clzll(lo) + 64,
             128
     };
-    int idx = !hi + ((!lo)&(!hi));
+    int idx = !hi + ((!lo) & (!hi));
     return 128 - z[idx];
 }
 

--- a/be/test/olap/rowset/segment_v2/frame_of_reference_page_test.cpp
+++ b/be/test/olap/rowset/segment_v2/frame_of_reference_page_test.cpp
@@ -28,29 +28,7 @@
 
 using doris::segment_v2::PageBuilderOptions;
 using doris::segment_v2::PageDecoderOptions;
-std::ostream& operator<<( std::ostream& dest, doris::int128_t value) {
-    std::ostream::sentry s( dest );
-    if ( s ) {
-        __uint128_t tmp = value < 0 ? -value : value;
-        char buffer[ 128 ];
-        char* d = std::end( buffer );
-        do
-        {
-            -- d;
-            *d = "0123456789"[ tmp % 10 ];
-            tmp /= 10;
-        } while ( tmp != 0 );
-        if ( value < 0 ) {
-            -- d;
-            *d = '-';
-        }
-        int len = std::end( buffer ) - d;
-        if ( dest.rdbuf()->sputn( d, len ) != len ) {
-            dest.setstate( std::ios_base::badbit );
-        }
-    }
-    return dest;
-}
+using doris::operator<<;
 
 namespace doris {
 class FrameOfReferencePageTest : public testing::Test {

--- a/be/test/olap/rowset/segment_v2/frame_of_reference_page_test.cpp
+++ b/be/test/olap/rowset/segment_v2/frame_of_reference_page_test.cpp
@@ -56,7 +56,7 @@ public:
         for_page_builder.add(reinterpret_cast<const uint8_t *>(src), &size);
         OwnedSlice s = for_page_builder.finish();
         ASSERT_EQ(size, for_page_builder.count());
-        LOG(INFO) << "FrameOfReference Encoded size for 10k values: " << s.slice().size
+        LOG(INFO) << "FrameOfReference Encoded size for " << size << " values: " << s.slice().size
                   << ", original size:" << size * sizeof(CppType);
 
         PageDecoderOptions decoder_options;
@@ -148,7 +148,7 @@ TEST_F(FrameOfReferencePageTest, TestInt64BlockEncoderSequence) {
 }
 
 TEST_F(FrameOfReferencePageTest, TestInt24BlockEncoderSequence) {
-    const uint32_t size = 1000;
+    const uint32_t size = 1311;
 
     std::unique_ptr<uint24_t[]> ints(new uint24_t[size]);
     // to guarantee the last value is 0xFFFFFF
@@ -173,6 +173,26 @@ TEST_F(FrameOfReferencePageTest, TestInt128BlockEncoderSequence) {
 
     test_encode_decode_page_template<OLAP_FIELD_TYPE_LARGEINT, segment_v2::FrameOfReferencePageBuilder<OLAP_FIELD_TYPE_LARGEINT>,
             segment_v2::FrameOfReferencePageDecoder<OLAP_FIELD_TYPE_LARGEINT> >(ints.get(), size);
+}
+
+TEST_F(FrameOfReferencePageTest, TestInt24BlockEncoderMinMax) {
+
+    std::unique_ptr<uint24_t[]> ints(new uint24_t[2]);
+    ints.get()[0] = 0;
+    ints.get()[1] = 0xFFFFFF;
+
+    test_encode_decode_page_template<OLAP_FIELD_TYPE_DATE, segment_v2::FrameOfReferencePageBuilder<OLAP_FIELD_TYPE_DATE>,
+        segment_v2::FrameOfReferencePageDecoder<OLAP_FIELD_TYPE_DATE> >(ints.get(), 2);
+}
+
+TEST_F(FrameOfReferencePageTest, TestInt128BlockEncoderMinMax) {
+
+    std::unique_ptr<int128_t[]> ints(new int128_t[2]);
+    ints.get()[0] = numeric_limits<int128_t>::min();
+    ints.get()[1] = numeric_limits<int128_t>::max();
+
+    test_encode_decode_page_template<OLAP_FIELD_TYPE_LARGEINT, segment_v2::FrameOfReferencePageBuilder<OLAP_FIELD_TYPE_LARGEINT>,
+        segment_v2::FrameOfReferencePageDecoder<OLAP_FIELD_TYPE_LARGEINT> >(ints.get(), 2);
 }
 
 TEST_F(FrameOfReferencePageTest, TestInt32SequenceBlockEncoderSize) {

--- a/be/test/olap/rowset/segment_v2/frame_of_reference_page_test.cpp
+++ b/be/test/olap/rowset/segment_v2/frame_of_reference_page_test.cpp
@@ -246,6 +246,32 @@ TEST_F(FrameOfReferencePageTest, TestInt32NormalBlockEncoderSize) {
     ASSERT_EQ(123, s.slice().size);
 }
 
+TEST_F(FrameOfReferencePageTest, TestFindBitsOfInt) {
+    int8_t bits_3 = 0x06;
+    ASSERT_EQ(3, bits(bits_3));
+
+    uint8_t bits_4 = 0x0F;
+    ASSERT_EQ(4, bits(bits_4));
+
+    int32_t bits_17 = 0x000100FF;
+    ASSERT_EQ(17, bits(bits_17));
+
+    int64_t bits_33 = 0x00000001FFFFFFFF;
+    ASSERT_EQ(33, bits(bits_33));
+
+    int128_t bits_0 = 0;
+    ASSERT_EQ(0, bits(bits_0));
+
+    int128_t bits_127 = numeric_limits<int128_t>::max();
+    ASSERT_EQ(127, bits(bits_127));
+
+    uint128_t bits_128 = numeric_limits<uint128_t>::max();
+    ASSERT_EQ(128, bits(bits_128));
+
+    int128_t bits_65 = ((int128_t)1) << 64;
+    ASSERT_EQ(65, bits(bits_65));
+}
+
 }
 
 int main(int argc, char** argv) {

--- a/be/test/olap/rowset/segment_v2/plain_page_test.cpp
+++ b/be/test/olap/rowset/segment_v2/plain_page_test.cpp
@@ -112,6 +112,59 @@ public:
             EXPECT_EQ(decoded[seek_off], ret);
        }
     }
+
+    template <FieldType Type, class PageBuilderType, class PageDecoderType>
+    void test_seek_at_or_after_value_template(typename TypeTraits<Type>::CppType* src,
+            size_t size, typename TypeTraits<Type>::CppType* small_than_smallest,
+            typename TypeTraits<Type>::CppType* bigger_than_biggest) {
+        typedef typename TypeTraits<Type>::CppType CppType;
+
+        PageBuilderOptions options;
+        options.data_page_size = 256 * 1024;
+        PageBuilderType page_builder(options);
+
+        page_builder.add(reinterpret_cast<const uint8_t *>(src), &size);
+        OwnedSlice s = page_builder.finish();
+
+        PageDecoderOptions decoder_options;
+        PageDecoderType page_decoder(s.slice(), decoder_options);
+        Status status = page_decoder.init();
+
+        ASSERT_TRUE(status.ok());
+        ASSERT_EQ(0, page_decoder.current_index());
+
+        size_t index = random() % size;
+        CppType seek_value = src[index];
+        bool exact_match;
+        status = page_decoder.seek_at_or_after_value(&seek_value, &exact_match);
+        EXPECT_EQ(index, page_decoder.current_index());
+        ASSERT_TRUE(status.ok());
+        ASSERT_TRUE(exact_match);
+
+        CppType last_value = src[size - 1];
+        status = page_decoder.seek_at_or_after_value(&last_value, &exact_match);
+        EXPECT_EQ(size - 1, page_decoder.current_index());
+        ASSERT_TRUE(status.ok());
+        ASSERT_TRUE(exact_match);
+
+        CppType first_value = src[0];
+        status = page_decoder.seek_at_or_after_value(&first_value, &exact_match);
+        EXPECT_EQ(0, page_decoder.current_index());
+        ASSERT_TRUE(status.ok());
+        ASSERT_TRUE(exact_match);
+
+        if (small_than_smallest != nullptr) {
+            status = page_decoder.seek_at_or_after_value(small_than_smallest, &exact_match);
+            EXPECT_EQ(0, page_decoder.current_index());
+            ASSERT_TRUE(status.ok());
+            ASSERT_FALSE(exact_match);
+        }
+
+        if (bigger_than_biggest != nullptr) {
+            status = page_decoder.seek_at_or_after_value(bigger_than_biggest, &exact_match);
+            EXPECT_EQ(status.code(), TStatusCode::NOT_FOUND);
+        }
+    }
 };
 
 TEST_F(PlainPageTest, TestInt32PlainPageRandom) {
@@ -125,6 +178,19 @@ TEST_F(PlainPageTest, TestInt32PlainPageRandom) {
         segment_v2::PlainPageDecoder<OLAP_FIELD_TYPE_INT> >(ints.get(), size);
 }
 
+TEST_F(PlainPageTest, TestInt32PlainPageSeekValue) {
+    const uint32_t size = 1000;
+    std::unique_ptr<int32_t[]> ints(new int32_t[size]);
+    for (int i = 0; i < size; i++) {
+        ints.get()[i] = i + 100;
+    }
+    int32_t small_than_smallest = 99;
+    int32_t bigger_than_biggest = 1111;
+
+    test_seek_at_or_after_value_template<OLAP_FIELD_TYPE_INT, segment_v2::PlainPageBuilder<OLAP_FIELD_TYPE_INT>,
+        segment_v2::PlainPageDecoder<OLAP_FIELD_TYPE_INT> >(ints.get(), size, &small_than_smallest, &bigger_than_biggest);
+}
+
 TEST_F(PlainPageTest, TestInt64PlainPageRandom) {
     const uint32_t size = 10000;            
     std::unique_ptr<int64_t[]> ints(new int64_t[size]);
@@ -134,6 +200,19 @@ TEST_F(PlainPageTest, TestInt64PlainPageRandom) {
 
     test_encode_decode_page_template<OLAP_FIELD_TYPE_BIGINT, segment_v2::PlainPageBuilder<OLAP_FIELD_TYPE_BIGINT>,
         segment_v2::PlainPageDecoder<OLAP_FIELD_TYPE_BIGINT> >(ints.get(), size);                            
+}
+
+TEST_F(PlainPageTest, TestInt64PlainPageSeekValue) {
+    const uint32_t size = 1000;
+    std::unique_ptr<int64_t[]> ints(new int64_t[size]);
+    for (int i = 0; i < size; i++) {
+        ints.get()[i] = i + 100;
+    }
+    int64_t small_than_smallest = 99;
+    int64_t bigger_than_biggest = 1111;
+
+    test_seek_at_or_after_value_template<OLAP_FIELD_TYPE_BIGINT, segment_v2::PlainPageBuilder<OLAP_FIELD_TYPE_BIGINT>,
+        segment_v2::PlainPageDecoder<OLAP_FIELD_TYPE_BIGINT> >(ints.get(), size, &small_than_smallest, &bigger_than_biggest);
 }
 
 TEST_F(PlainPageTest, TestPlainFloatBlockEncoderRandom) {
@@ -208,6 +287,23 @@ TEST_F(PlainPageTest, TestInt32PageEncoderSequence) {
     
     test_encode_decode_page_template<OLAP_FIELD_TYPE_INT, segment_v2::PlainPageBuilder<OLAP_FIELD_TYPE_INT>,
         segment_v2::PlainPageDecoder<OLAP_FIELD_TYPE_INT> >(ints.get(), size);
+}
+
+TEST_F(PlainPageTest, TestBoolPlainPageSeekValue) {
+    std::unique_ptr<bool[]> bools(new bool[2]);
+    bools.get()[0] = false;
+    bools.get()[1] = true;
+
+    test_seek_at_or_after_value_template<OLAP_FIELD_TYPE_BOOL, segment_v2::PlainPageBuilder<OLAP_FIELD_TYPE_BOOL>,
+        segment_v2::PlainPageDecoder<OLAP_FIELD_TYPE_BOOL> >(bools.get(), 2, nullptr, nullptr);
+
+    bool t = true;
+    test_seek_at_or_after_value_template<OLAP_FIELD_TYPE_BOOL, segment_v2::PlainPageBuilder<OLAP_FIELD_TYPE_BOOL>,
+        segment_v2::PlainPageDecoder<OLAP_FIELD_TYPE_BOOL> >(bools.get(), 1, nullptr, &t);
+
+    t = false;
+    test_seek_at_or_after_value_template<OLAP_FIELD_TYPE_BOOL, segment_v2::PlainPageBuilder<OLAP_FIELD_TYPE_BOOL>,
+        segment_v2::PlainPageDecoder<OLAP_FIELD_TYPE_BOOL> >(&bools.get()[1], 1, &t, nullptr);
 }
 
 }


### PR DESCRIPTION
For #2589

1. date(uint24_t)/datetime(int64_t)/largeint(int128_t) use frame of reference code as dict.
2. decimal(decimal12_t) also uses frame of reference code as dict.
3. float/double use bitshuffle code as dict.