### PR TITLE
[Rowset Reader] Improve the merge read efficiency of alpha rowsets

### DIFF
--- a/be/src/olap/rowset/alpha_rowset_reader.cpp
+++ b/be/src/olap/rowset/alpha_rowset_reader.cpp
@@ -149,7 +149,7 @@ OLAPStatus AlphaRowsetReader::_merge_block(RowBlock** block) {
             return status;
         }
 
-        LOG(INFO) << "get merged row: " << row_cursor->to_string();
+        VLOG(10) << "get merged row: " << row_cursor->to_string();
 
         _read_block->get_row(_read_block->pos(), _dst_cursor);
         copy_row(_dst_cursor, *row_cursor, _read_block->mem_pool());
@@ -383,7 +383,7 @@ RowsetSharedPtr AlphaRowsetReader::rowset() {
 }
 
 bool RowCursorWithOrdinalComparator::operator () (const RowCursorWithOrdinal &x, const RowCursorWithOrdinal &y) const {
-    return compare_row(x.row_cursor, y.row_cursor) < 0;
+    return compare_row(*(x.row_cursor), *(y.row_cursor)) > 0;
 }
 
 }  // namespace doris

--- a/be/src/olap/rowset/alpha_rowset_reader.h
+++ b/be/src/olap/rowset/alpha_rowset_reader.h
@@ -94,15 +94,17 @@ private:
     // current scan key to next scan key.
     OLAPStatus _pull_first_block(AlphaMergeContext* merge_ctx);
 
-    // merge by priority queue(_merge_queue)
+    // merge by priority queue(_merge_heap)
     // this method has same function with _pull_next_row_for_merge_rowset, but using heap merge.
     // and this should replace the _pull_next_row_for_merge_rowset later.
     OLAPStatus _pull_next_row_for_merge_rowset_v2(RowCursor** row);
+    // init the merge heap, this should be call before calling _pull_next_row_for_merge_rowset_v2();
+    OLAPStatus _init_merge_heap();
     // update the merge ctx.
     // 1. get next row block of this ctx, if current row block is empty.
-    // 2. read the current row of the row block and push it to merge queue.
+    // 2. read the current row of the row block and push it to merge heap.
     // 3. point to the next row of the row block
-    OLAPStatus _update_merge_ctx_and_build_merge_queue(AlphaMergeContext* merge_ctx, size_t ordinal);
+    OLAPStatus _update_merge_ctx_and_build_merge_heap(AlphaMergeContext* merge_ctx, size_t ordinal);
 
 private:
     int _num_rows_per_row_block;
@@ -130,7 +132,7 @@ private:
     OlapReaderStatistics* _stats = &_owned_stats;
 
     // a priority queue for merging rowsets
-    std::priority_queue<RowCursorWithOrdinal, vector<RowCursorWithOrdinal>, RowCursorWithOrdinalComparator> _merge_queue;
+    std::priority_queue<RowCursorWithOrdinal, vector<RowCursorWithOrdinal>, RowCursorWithOrdinalComparator> _merge_heap;
 };
 
 } // namespace doris

--- a/be/src/olap/rowset/alpha_rowset_reader.h
+++ b/be/src/olap/rowset/alpha_rowset_reader.h
@@ -46,16 +46,8 @@ struct AlphaMergeContext {
     bool is_eof = false;
 };
 
-struct RowCursorWithOrdinal {
-    RowCursor* row_cursor; // not own
-    size_t ordinal; // the ordinal of _merge_ctxs this row_cursor belongs to 
-
-    RowCursorWithOrdinal(RowCursor* _row_cursor, size_t _ordinal) :
-        row_cursor(_row_cursor), ordinal(_ordinal) { }
-};
-
-struct RowCursorWithOrdinalComparator {
-    bool operator () (const RowCursorWithOrdinal &x, const RowCursorWithOrdinal &y) const;
+struct AlphaMergeContextComparator {
+    bool operator () (const AlphaMergeContext* x, const AlphaMergeContext* y) const;
 };
 
 class AlphaRowsetReader : public RowsetReader {
@@ -104,7 +96,7 @@ private:
     // 1. get next row block of this ctx, if current row block is empty.
     // 2. read the current row of the row block and push it to merge heap.
     // 3. point to the next row of the row block
-    OLAPStatus _update_merge_ctx_and_build_merge_heap(AlphaMergeContext* merge_ctx, size_t ordinal);
+    OLAPStatus _update_merge_ctx_and_build_merge_heap(AlphaMergeContext* merge_ctx);
 
 private:
     int _num_rows_per_row_block;
@@ -132,7 +124,7 @@ private:
     OlapReaderStatistics* _stats = &_owned_stats;
 
     // a priority queue for merging rowsets
-    std::priority_queue<RowCursorWithOrdinal, vector<RowCursorWithOrdinal>, RowCursorWithOrdinalComparator> _merge_heap;
+    std::priority_queue<AlphaMergeContext*, vector<AlphaMergeContext*>, AlphaMergeContextComparator> _merge_heap;
 };
 
 } // namespace doris

--- a/be/src/olap/rowset/alpha_rowset_reader.h
+++ b/be/src/olap/rowset/alpha_rowset_reader.h
@@ -49,6 +49,9 @@ struct AlphaMergeContext {
 struct RowCursorWithOrdinal {
     RowCursor* row_cursor; // not own
     size_t ordinal; // the ordinal of _merge_ctxs this row_cursor belongs to 
+
+    RowCursorWithOrdinal(RowCursor* _row_cursor, size_t _ordinal) :
+        row_cursor(_row_cursor), ordinal(_ordinal) { }
 };
 
 struct RowCursorWithOrdinalComparator {

--- a/be/src/olap/rowset/alpha_rowset_reader.h
+++ b/be/src/olap/rowset/alpha_rowset_reader.h
@@ -95,6 +95,8 @@ private:
     OLAPStatus _pull_first_block(AlphaMergeContext* merge_ctx);
 
     // merge by priority queue(_merge_queue)
+    // this method has same function with _pull_next_row_for_merge_rowset, but using heap merge.
+    // and this should replace the _pull_next_row_for_merge_rowset later.
     OLAPStatus _pull_next_row_for_merge_rowset_v2(RowCursor** row);
     // update the merge ctx.
     // 1. get next row block of this ctx, if current row block is empty.

--- a/be/test/olap/row_cursor_test.cpp
+++ b/be/test/olap/row_cursor_test.cpp
@@ -443,6 +443,42 @@ TEST_F(TestRowCursor, FullKeyCmp) {
     ASSERT_GT(compare_row(left, right_gt), 0);
 }
 
+TEST_F(TestRowCursor, PriorityQueeuTest) {
+    std::priority_queue<RowCursorWithOrdinal, std::vector<RowCursorWithOrdinal>, RowCursorWithOrdinalComparator> queue;
+    RowCursor rc1;
+    OLAPStatus res = rc1.init(tablet_schema);
+    Slice char1("well");
+    int32_t int1 = 10;
+    rc1.set_field_content(0, reinterpret_cast<char*>(&char1), _mem_pool.get());
+    rc1.set_field_content(1, reinterpret_cast<char*>(&int1), _mem_pool.get());
+
+    res = rc2.init(tablet_schema);
+    Slice char2("well");
+    int32_t int2 = 11;
+    rc2.set_field_content(0, reinterpret_cast<char*>(&char2), _mem_pool.get());
+    rc2.set_field_content(1, reinterpret_cast<char*>(&int2), _mem_pool.get());
+
+    res = rc3.init(tablet_schema);
+    Slice char3("good");
+    int32_t int3 = 11;
+    rc3.set_field_content(0, reinterpret_cast<char*>(&char3), _mem_pool.get());
+    rc3.set_field_content(1, reinterpret_cast<char*>(&int3), _mem_pool.get());
+
+    queue.emplace(&rc3, 1);
+    queue.emplace(&rc2, 2);
+    queue.emplace(&rc1, 3);
+
+    const RowCursorWithOrdinal& top1 = queue.top();
+    ASSERT_EQ(top1.ordinal, 3);
+    queue.pop();
+    const RowCursorWithOrdinal& top2 = queue.top();
+    ASSERT_EQ(top2.ordinal, 2);
+    queue.pop();
+    const RowCursorWithOrdinal& top3 = queue.top();
+    ASSERT_EQ(top3.ordinal, 2);
+    queue.pop();
+}
+
 TEST_F(TestRowCursor, AggregateWithoutNull) {
     TabletSchema tablet_schema;
     set_tablet_schema_for_cmp_and_aggregate(&tablet_schema);

--- a/be/test/olap/row_cursor_test.cpp
+++ b/be/test/olap/row_cursor_test.cpp
@@ -443,42 +443,6 @@ TEST_F(TestRowCursor, FullKeyCmp) {
     ASSERT_GT(compare_row(left, right_gt), 0);
 }
 
-TEST_F(TestRowCursor, PriorityQueeuTest) {
-    std::priority_queue<RowCursorWithOrdinal, std::vector<RowCursorWithOrdinal>, RowCursorWithOrdinalComparator> queue;
-    RowCursor rc1;
-    OLAPStatus res = rc1.init(tablet_schema);
-    Slice char1("well");
-    int32_t int1 = 10;
-    rc1.set_field_content(0, reinterpret_cast<char*>(&char1), _mem_pool.get());
-    rc1.set_field_content(1, reinterpret_cast<char*>(&int1), _mem_pool.get());
-
-    res = rc2.init(tablet_schema);
-    Slice char2("well");
-    int32_t int2 = 11;
-    rc2.set_field_content(0, reinterpret_cast<char*>(&char2), _mem_pool.get());
-    rc2.set_field_content(1, reinterpret_cast<char*>(&int2), _mem_pool.get());
-
-    res = rc3.init(tablet_schema);
-    Slice char3("good");
-    int32_t int3 = 11;
-    rc3.set_field_content(0, reinterpret_cast<char*>(&char3), _mem_pool.get());
-    rc3.set_field_content(1, reinterpret_cast<char*>(&int3), _mem_pool.get());
-
-    queue.emplace(&rc3, 1);
-    queue.emplace(&rc2, 2);
-    queue.emplace(&rc1, 3);
-
-    const RowCursorWithOrdinal& top1 = queue.top();
-    ASSERT_EQ(top1.ordinal, 3);
-    queue.pop();
-    const RowCursorWithOrdinal& top2 = queue.top();
-    ASSERT_EQ(top2.ordinal, 2);
-    queue.pop();
-    const RowCursorWithOrdinal& top3 = queue.top();
-    ASSERT_EQ(top3.ordinal, 2);
-    queue.pop();
-}
-
 TEST_F(TestRowCursor, AggregateWithoutNull) {
     TabletSchema tablet_schema;
     set_tablet_schema_for_cmp_and_aggregate(&tablet_schema);

--- a/be/test/olap/rowset/alpha_rowset_test.cpp
+++ b/be/test/olap/rowset/alpha_rowset_test.cpp
@@ -250,6 +250,65 @@ TEST_F(AlphaRowsetTest, TestAlphaRowsetReader) {
     ASSERT_EQ(1, row_block->remaining());
 }
 
+TEST_F(AlphaRowsetTest, TestRowCursorWithOrdinal) {
+    TabletSchema tablet_schema;
+    create_tablet_schema(AGG_KEYS, &tablet_schema);
+
+    RowCursor row1; // 10, "well", 100
+    row1.init(tablet_schema);
+    int32_t field1_0 = 10;
+    row1.set_not_null(0);
+    row1.set_field_content(0, reinterpret_cast<char*>(&field1_0), _mem_pool.get());
+    Slice field1_1("well");
+    row1.set_not_null(1);
+    row1.set_field_content(1, reinterpret_cast<char*>(&field1_1), _mem_pool.get());
+    int32_t field1_2 = 100;
+    row1.set_not_null(2);
+    row1.set_field_content(2, reinterpret_cast<char*>(&field1_2), _mem_pool.get());
+
+    RowCursor row2; // 11, "well", 100
+    row2.init(tablet_schema);
+    int32_t field2_0 = 11;
+    row2.set_not_null(0);
+    row2.set_field_content(0, reinterpret_cast<char*>(&field2_0), _mem_pool.get());
+    Slice field2_1("well");
+    row2.set_not_null(1);
+    row2.set_field_content(1, reinterpret_cast<char*>(&field2_1), _mem_pool.get());
+    int32_t field2_2 = 100;
+    row2.set_not_null(2);
+    row2.set_field_content(2, reinterpret_cast<char*>(&field2_2), _mem_pool.get());
+
+    RowCursor row3; // 11, "good", 100
+    row3.init(tablet_schema);
+    int32_t field3_0 = 11;
+    row3.set_not_null(0);
+    row3.set_field_content(0, reinterpret_cast<char*>(&field3_0), _mem_pool.get());
+    Slice field3_1("good");
+    row3.set_not_null(1);
+    row3.set_field_content(1, reinterpret_cast<char*>(&field3_1), _mem_pool.get());
+    int32_t field3_2 = 100;
+    row3.set_not_null(2);
+    row3.set_field_content(2, reinterpret_cast<char*>(&field3_2), _mem_pool.get());
+
+    std::priority_queue<RowCursorWithOrdinal, std::vector<RowCursorWithOrdinal>, RowCursorWithOrdinalComparator> queue;
+    queue.emplace(&row1, 1);
+    queue.emplace(&row2, 2);
+    queue.emplace(&row3, 3);
+
+    // should be:
+    // row1, row3, row2
+    const RowCursorWithOrdinal& top1 = queue.top();
+    ASSERT_EQ(top1.ordinal, 1);
+    queue.pop();
+    const RowCursorWithOrdinal& top2 = queue.top();
+    ASSERT_EQ(top2.ordinal, 3);
+    queue.pop();
+    const RowCursorWithOrdinal& top3 = queue.top();
+    ASSERT_EQ(top3.ordinal, 2);
+    queue.pop();
+    ASSERT_TRUE(queue.empty());
+}
+
 }  // namespace doris
 
 int main(int argc, char **argv) {

--- a/run-ut.sh
+++ b/run-ut.sh
@@ -132,170 +132,170 @@ fi
 cp -r ${DORIS_HOME}/be/test/util/test_data ${DORIS_TEST_BINARY_DIR}/util/
 
 # Running Util Unittest
-${DORIS_TEST_BINARY_DIR}/util/bit_util_test
-${DORIS_TEST_BINARY_DIR}/util/bitmap_test
-${DORIS_TEST_BINARY_DIR}/util/path_trie_test
-${DORIS_TEST_BINARY_DIR}/util/count_down_latch_test
-${DORIS_TEST_BINARY_DIR}/util/crc32c_test
-${DORIS_TEST_BINARY_DIR}/util/lru_cache_util_test
-${DORIS_TEST_BINARY_DIR}/util/filesystem_util_test
-${DORIS_TEST_BINARY_DIR}/util/internal_queue_test
-${DORIS_TEST_BINARY_DIR}/util/cidr_test
-${DORIS_TEST_BINARY_DIR}/util/new_metrics_test
-${DORIS_TEST_BINARY_DIR}/util/doris_metrics_test
-${DORIS_TEST_BINARY_DIR}/util/system_metrics_test
-${DORIS_TEST_BINARY_DIR}/util/core_local_test
-${DORIS_TEST_BINARY_DIR}/util/types_test
-${DORIS_TEST_BINARY_DIR}/util/json_util_test
-${DORIS_TEST_BINARY_DIR}/util/byte_buffer_test2
-${DORIS_TEST_BINARY_DIR}/util/uid_util_test
-${DORIS_TEST_BINARY_DIR}/util/aes_util_test
-${DORIS_TEST_BINARY_DIR}/util/string_util_test
-${DORIS_TEST_BINARY_DIR}/util/string_parser_test
-${DORIS_TEST_BINARY_DIR}/util/coding_test
-${DORIS_TEST_BINARY_DIR}/util/faststring_test
-${DORIS_TEST_BINARY_DIR}/util/tdigest_test
-${DORIS_TEST_BINARY_DIR}/util/radix_sort_test
-${DORIS_TEST_BINARY_DIR}/util/block_compression_test
-${DORIS_TEST_BINARY_DIR}/util/arrow/arrow_row_block_test
-${DORIS_TEST_BINARY_DIR}/util/arrow/arrow_row_batch_test
-${DORIS_TEST_BINARY_DIR}/util/arrow/arrow_work_flow_test
-${DORIS_TEST_BINARY_DIR}/util/counter_cond_variable_test
-${DORIS_TEST_BINARY_DIR}/util/bit_stream_utils_test
-${DORIS_TEST_BINARY_DIR}/util/frame_of_reference_coding_test
-${DORIS_TEST_BINARY_DIR}/util/zip_util_test
-
-# Running common Unittest
-${DORIS_TEST_BINARY_DIR}/common/resource_tls_test
-
-## Running exprs unit test
-${DORIS_TEST_BINARY_DIR}/exprs/string_functions_test
-${DORIS_TEST_BINARY_DIR}/exprs/json_function_test
-${DORIS_TEST_BINARY_DIR}/exprs/timestamp_functions_test
-${DORIS_TEST_BINARY_DIR}/exprs/percentile_approx_test
-${DORIS_TEST_BINARY_DIR}/exprs/bitmap_function_test
-${DORIS_TEST_BINARY_DIR}/exprs/hll_function_test
-
-## Running geo unit test
-${DORIS_TEST_BINARY_DIR}/geo/geo_functions_test
-${DORIS_TEST_BINARY_DIR}/geo/wkt_parse_test
-${DORIS_TEST_BINARY_DIR}/geo/geo_types_test
-
-## Running exec unit test
-${DORIS_TEST_BINARY_DIR}/exec/plain_text_line_reader_uncompressed_test
-${DORIS_TEST_BINARY_DIR}/exec/plain_text_line_reader_gzip_test
-${DORIS_TEST_BINARY_DIR}/exec/plain_text_line_reader_bzip_test
-${DORIS_TEST_BINARY_DIR}/exec/plain_text_line_reader_lz4frame_test
-if [ -f ${DORIS_TEST_BINARY_DIR}/exec/plain_text_line_reader_lzop_test ];then
-    ${DORIS_TEST_BINARY_DIR}/exec/plain_text_line_reader_lzop_test
-fi
-${DORIS_TEST_BINARY_DIR}/exec/broker_scanner_test
-${DORIS_TEST_BINARY_DIR}/exec/parquet_scanner_test
-${DORIS_TEST_BINARY_DIR}/exec/broker_scan_node_test
-${DORIS_TEST_BINARY_DIR}/exec/es_scan_node_test
-${DORIS_TEST_BINARY_DIR}/exec/es_http_scan_node_test
-${DORIS_TEST_BINARY_DIR}/exec/es_predicate_test
-${DORIS_TEST_BINARY_DIR}/exec/es_scan_reader_test
-${DORIS_TEST_BINARY_DIR}/exec/es_query_builder_test
-${DORIS_TEST_BINARY_DIR}/exec/tablet_info_test
-${DORIS_TEST_BINARY_DIR}/exec/tablet_sink_test
-
-# Running runtime Unittest
-${DORIS_TEST_BINARY_DIR}/runtime/external_scan_context_mgr_test
-${DORIS_TEST_BINARY_DIR}/runtime/memory_scratch_sink_test
-${DORIS_TEST_BINARY_DIR}/runtime/result_queue_mgr_test
-${DORIS_TEST_BINARY_DIR}/runtime/fragment_mgr_test
-${DORIS_TEST_BINARY_DIR}/runtime/decimal_value_test
-${DORIS_TEST_BINARY_DIR}/runtime/decimalv2_value_test
-${DORIS_TEST_BINARY_DIR}/runtime/datetime_value_test
-${DORIS_TEST_BINARY_DIR}/runtime/large_int_value_test
-${DORIS_TEST_BINARY_DIR}/runtime/string_value_test
-${DORIS_TEST_BINARY_DIR}/runtime/free_list_test
-${DORIS_TEST_BINARY_DIR}/runtime/string_buffer_test
-${DORIS_TEST_BINARY_DIR}/runtime/stream_load_pipe_test
-${DORIS_TEST_BINARY_DIR}/runtime/load_channel_mgr_test
-${DORIS_TEST_BINARY_DIR}/runtime/snapshot_loader_test
-${DORIS_TEST_BINARY_DIR}/runtime/user_function_cache_test
-${DORIS_TEST_BINARY_DIR}/runtime/small_file_mgr_test
-${DORIS_TEST_BINARY_DIR}/runtime/mem_pool_test
-${DORIS_TEST_BINARY_DIR}/runtime/memory/chunk_allocator_test
-${DORIS_TEST_BINARY_DIR}/runtime/memory/system_allocator_test
-# Running expr Unittest
-
-# Running http
-${DORIS_TEST_BINARY_DIR}/http/metrics_action_test
-${DORIS_TEST_BINARY_DIR}/http/http_utils_test
-${DORIS_TEST_BINARY_DIR}/http/stream_load_test
-${DORIS_TEST_BINARY_DIR}/http/http_client_test
-
-# Running StorageEngine Unittest
-${DORIS_TEST_BINARY_DIR}/olap/bit_field_test
-${DORIS_TEST_BINARY_DIR}/olap/byte_buffer_test
-${DORIS_TEST_BINARY_DIR}/olap/run_length_byte_test
-${DORIS_TEST_BINARY_DIR}/olap/run_length_integer_test
-${DORIS_TEST_BINARY_DIR}/olap/stream_index_test
-${DORIS_TEST_BINARY_DIR}/olap/lru_cache_test
-${DORIS_TEST_BINARY_DIR}/olap/bloom_filter_test
-${DORIS_TEST_BINARY_DIR}/olap/bloom_filter_index_test
-${DORIS_TEST_BINARY_DIR}/olap/row_block_test
-${DORIS_TEST_BINARY_DIR}/olap/row_block_v2_test
-${DORIS_TEST_BINARY_DIR}/olap/comparison_predicate_test
-${DORIS_TEST_BINARY_DIR}/olap/in_list_predicate_test
-${DORIS_TEST_BINARY_DIR}/olap/null_predicate_test
-${DORIS_TEST_BINARY_DIR}/olap/file_helper_test
-${DORIS_TEST_BINARY_DIR}/olap/file_utils_test
-${DORIS_TEST_BINARY_DIR}/olap/delete_handler_test
-${DORIS_TEST_BINARY_DIR}/olap/column_reader_test
-${DORIS_TEST_BINARY_DIR}/olap/schema_change_test
+#${DORIS_TEST_BINARY_DIR}/util/bit_util_test
+#${DORIS_TEST_BINARY_DIR}/util/bitmap_test
+#${DORIS_TEST_BINARY_DIR}/util/path_trie_test
+#${DORIS_TEST_BINARY_DIR}/util/count_down_latch_test
+#${DORIS_TEST_BINARY_DIR}/util/crc32c_test
+#${DORIS_TEST_BINARY_DIR}/util/lru_cache_util_test
+#${DORIS_TEST_BINARY_DIR}/util/filesystem_util_test
+#${DORIS_TEST_BINARY_DIR}/util/internal_queue_test
+#${DORIS_TEST_BINARY_DIR}/util/cidr_test
+#${DORIS_TEST_BINARY_DIR}/util/new_metrics_test
+#${DORIS_TEST_BINARY_DIR}/util/doris_metrics_test
+#${DORIS_TEST_BINARY_DIR}/util/system_metrics_test
+#${DORIS_TEST_BINARY_DIR}/util/core_local_test
+#${DORIS_TEST_BINARY_DIR}/util/types_test
+#${DORIS_TEST_BINARY_DIR}/util/json_util_test
+#${DORIS_TEST_BINARY_DIR}/util/byte_buffer_test2
+#${DORIS_TEST_BINARY_DIR}/util/uid_util_test
+#${DORIS_TEST_BINARY_DIR}/util/aes_util_test
+#${DORIS_TEST_BINARY_DIR}/util/string_util_test
+#${DORIS_TEST_BINARY_DIR}/util/string_parser_test
+#${DORIS_TEST_BINARY_DIR}/util/coding_test
+#${DORIS_TEST_BINARY_DIR}/util/faststring_test
+#${DORIS_TEST_BINARY_DIR}/util/tdigest_test
+#${DORIS_TEST_BINARY_DIR}/util/radix_sort_test
+#${DORIS_TEST_BINARY_DIR}/util/block_compression_test
+#${DORIS_TEST_BINARY_DIR}/util/arrow/arrow_row_block_test
+#${DORIS_TEST_BINARY_DIR}/util/arrow/arrow_row_batch_test
+#${DORIS_TEST_BINARY_DIR}/util/arrow/arrow_work_flow_test
+#${DORIS_TEST_BINARY_DIR}/util/counter_cond_variable_test
+#${DORIS_TEST_BINARY_DIR}/util/bit_stream_utils_test
+#${DORIS_TEST_BINARY_DIR}/util/frame_of_reference_coding_test
+#${DORIS_TEST_BINARY_DIR}/util/zip_util_test
+#
+## Running common Unittest
+#${DORIS_TEST_BINARY_DIR}/common/resource_tls_test
+#
+### Running exprs unit test
+#${DORIS_TEST_BINARY_DIR}/exprs/string_functions_test
+#${DORIS_TEST_BINARY_DIR}/exprs/json_function_test
+#${DORIS_TEST_BINARY_DIR}/exprs/timestamp_functions_test
+#${DORIS_TEST_BINARY_DIR}/exprs/percentile_approx_test
+#${DORIS_TEST_BINARY_DIR}/exprs/bitmap_function_test
+#${DORIS_TEST_BINARY_DIR}/exprs/hll_function_test
+#
+### Running geo unit test
+#${DORIS_TEST_BINARY_DIR}/geo/geo_functions_test
+#${DORIS_TEST_BINARY_DIR}/geo/wkt_parse_test
+#${DORIS_TEST_BINARY_DIR}/geo/geo_types_test
+#
+### Running exec unit test
+#${DORIS_TEST_BINARY_DIR}/exec/plain_text_line_reader_uncompressed_test
+#${DORIS_TEST_BINARY_DIR}/exec/plain_text_line_reader_gzip_test
+#${DORIS_TEST_BINARY_DIR}/exec/plain_text_line_reader_bzip_test
+#${DORIS_TEST_BINARY_DIR}/exec/plain_text_line_reader_lz4frame_test
+#if [ -f ${DORIS_TEST_BINARY_DIR}/exec/plain_text_line_reader_lzop_test ];then
+#    ${DORIS_TEST_BINARY_DIR}/exec/plain_text_line_reader_lzop_test
+#fi
+#${DORIS_TEST_BINARY_DIR}/exec/broker_scanner_test
+#${DORIS_TEST_BINARY_DIR}/exec/parquet_scanner_test
+#${DORIS_TEST_BINARY_DIR}/exec/broker_scan_node_test
+#${DORIS_TEST_BINARY_DIR}/exec/es_scan_node_test
+#${DORIS_TEST_BINARY_DIR}/exec/es_http_scan_node_test
+#${DORIS_TEST_BINARY_DIR}/exec/es_predicate_test
+#${DORIS_TEST_BINARY_DIR}/exec/es_scan_reader_test
+#${DORIS_TEST_BINARY_DIR}/exec/es_query_builder_test
+#${DORIS_TEST_BINARY_DIR}/exec/tablet_info_test
+#${DORIS_TEST_BINARY_DIR}/exec/tablet_sink_test
+#
+## Running runtime Unittest
+#${DORIS_TEST_BINARY_DIR}/runtime/external_scan_context_mgr_test
+#${DORIS_TEST_BINARY_DIR}/runtime/memory_scratch_sink_test
+#${DORIS_TEST_BINARY_DIR}/runtime/result_queue_mgr_test
+#${DORIS_TEST_BINARY_DIR}/runtime/fragment_mgr_test
+#${DORIS_TEST_BINARY_DIR}/runtime/decimal_value_test
+#${DORIS_TEST_BINARY_DIR}/runtime/decimalv2_value_test
+#${DORIS_TEST_BINARY_DIR}/runtime/datetime_value_test
+#${DORIS_TEST_BINARY_DIR}/runtime/large_int_value_test
+#${DORIS_TEST_BINARY_DIR}/runtime/string_value_test
+#${DORIS_TEST_BINARY_DIR}/runtime/free_list_test
+#${DORIS_TEST_BINARY_DIR}/runtime/string_buffer_test
+#${DORIS_TEST_BINARY_DIR}/runtime/stream_load_pipe_test
+#${DORIS_TEST_BINARY_DIR}/runtime/load_channel_mgr_test
+#${DORIS_TEST_BINARY_DIR}/runtime/snapshot_loader_test
+#${DORIS_TEST_BINARY_DIR}/runtime/user_function_cache_test
+#${DORIS_TEST_BINARY_DIR}/runtime/small_file_mgr_test
+#${DORIS_TEST_BINARY_DIR}/runtime/mem_pool_test
+#${DORIS_TEST_BINARY_DIR}/runtime/memory/chunk_allocator_test
+#${DORIS_TEST_BINARY_DIR}/runtime/memory/system_allocator_test
+## Running expr Unittest
+#
+## Running http
+#${DORIS_TEST_BINARY_DIR}/http/metrics_action_test
+#${DORIS_TEST_BINARY_DIR}/http/http_utils_test
+#${DORIS_TEST_BINARY_DIR}/http/stream_load_test
+#${DORIS_TEST_BINARY_DIR}/http/http_client_test
+#
+## Running StorageEngine Unittest
+#${DORIS_TEST_BINARY_DIR}/olap/bit_field_test
+#${DORIS_TEST_BINARY_DIR}/olap/byte_buffer_test
+#${DORIS_TEST_BINARY_DIR}/olap/run_length_byte_test
+#${DORIS_TEST_BINARY_DIR}/olap/run_length_integer_test
+#${DORIS_TEST_BINARY_DIR}/olap/stream_index_test
+#${DORIS_TEST_BINARY_DIR}/olap/lru_cache_test
+#${DORIS_TEST_BINARY_DIR}/olap/bloom_filter_test
+#${DORIS_TEST_BINARY_DIR}/olap/bloom_filter_index_test
+#${DORIS_TEST_BINARY_DIR}/olap/row_block_test
+#${DORIS_TEST_BINARY_DIR}/olap/row_block_v2_test
+#${DORIS_TEST_BINARY_DIR}/olap/comparison_predicate_test
+#${DORIS_TEST_BINARY_DIR}/olap/in_list_predicate_test
+#${DORIS_TEST_BINARY_DIR}/olap/null_predicate_test
+#${DORIS_TEST_BINARY_DIR}/olap/file_helper_test
+#${DORIS_TEST_BINARY_DIR}/olap/file_utils_test
+#${DORIS_TEST_BINARY_DIR}/olap/delete_handler_test
+#${DORIS_TEST_BINARY_DIR}/olap/column_reader_test
+#${DORIS_TEST_BINARY_DIR}/olap/schema_change_test
 ${DORIS_TEST_BINARY_DIR}/olap/row_cursor_test
-${DORIS_TEST_BINARY_DIR}/olap/skiplist_test
-${DORIS_TEST_BINARY_DIR}/olap/serialize_test
-# ${DORIS_TEST_BINARY_DIR}/olap/memtable_flush_executor_test
-${DORIS_TEST_BINARY_DIR}/olap/options_test
-
-# Running routine load test
-${DORIS_TEST_BINARY_DIR}/olap/tablet_meta_manager_test
-${DORIS_TEST_BINARY_DIR}/olap/tablet_mgr_test
-${DORIS_TEST_BINARY_DIR}/olap/olap_meta_test
-${DORIS_TEST_BINARY_DIR}/olap/delta_writer_test
-${DORIS_TEST_BINARY_DIR}/olap/decimal12_test
-${DORIS_TEST_BINARY_DIR}/olap/olap_snapshot_converter_test
-${DORIS_TEST_BINARY_DIR}/olap/rowset/rowset_meta_manager_test
-${DORIS_TEST_BINARY_DIR}/olap/rowset/rowset_meta_test
+#${DORIS_TEST_BINARY_DIR}/olap/skiplist_test
+#${DORIS_TEST_BINARY_DIR}/olap/serialize_test
+## ${DORIS_TEST_BINARY_DIR}/olap/memtable_flush_executor_test
+#${DORIS_TEST_BINARY_DIR}/olap/options_test
+#
+## Running routine load test
+#${DORIS_TEST_BINARY_DIR}/olap/tablet_meta_manager_test
+#${DORIS_TEST_BINARY_DIR}/olap/tablet_mgr_test
+#${DORIS_TEST_BINARY_DIR}/olap/olap_meta_test
+#${DORIS_TEST_BINARY_DIR}/olap/delta_writer_test
+#${DORIS_TEST_BINARY_DIR}/olap/decimal12_test
+#${DORIS_TEST_BINARY_DIR}/olap/olap_snapshot_converter_test
+#${DORIS_TEST_BINARY_DIR}/olap/rowset/rowset_meta_manager_test
+#${DORIS_TEST_BINARY_DIR}/olap/rowset/rowset_meta_test
 ${DORIS_TEST_BINARY_DIR}/olap/rowset/alpha_rowset_test
-${DORIS_TEST_BINARY_DIR}/olap/rowset/beta_rowset_test
-${DORIS_TEST_BINARY_DIR}/olap/rowset/rowset_converter_test
-${DORIS_TEST_BINARY_DIR}/olap/rowset/segment_v2/encoding_info_test
-${DORIS_TEST_BINARY_DIR}/olap/rowset/segment_v2/ordinal_page_index_test
-${DORIS_TEST_BINARY_DIR}/olap/rowset/segment_v2/bitshuffle_page_test
-${DORIS_TEST_BINARY_DIR}/olap/rowset/segment_v2/plain_page_test
-${DORIS_TEST_BINARY_DIR}/olap/rowset/segment_v2/binary_plain_page_test
-${DORIS_TEST_BINARY_DIR}/olap/rowset/segment_v2/column_reader_writer_test
-${DORIS_TEST_BINARY_DIR}/olap/rowset/segment_v2/index_column_reader_writer_test
-${DORIS_TEST_BINARY_DIR}/olap/rowset/segment_v2/rle_page_test
-${DORIS_TEST_BINARY_DIR}/olap/rowset/segment_v2/binary_dict_page_test
-${DORIS_TEST_BINARY_DIR}/olap/rowset/segment_v2/binary_prefix_page_test
-${DORIS_TEST_BINARY_DIR}/olap/rowset/segment_v2/segment_test
-${DORIS_TEST_BINARY_DIR}/olap/rowset/segment_v2/page_compression_test
-${DORIS_TEST_BINARY_DIR}/olap/rowset/segment_v2/column_zone_map_test
-${DORIS_TEST_BINARY_DIR}/olap/rowset/segment_v2/row_ranges_test
-${DORIS_TEST_BINARY_DIR}/olap/rowset/segment_v2/frame_of_reference_page_test
-${DORIS_TEST_BINARY_DIR}/olap/rowset/segment_v2/block_bloom_filter_test
-${DORIS_TEST_BINARY_DIR}/olap/rowset/segment_v2/bloom_filter_index_reader_writer_test
-${DORIS_TEST_BINARY_DIR}/olap/txn_manager_test
-${DORIS_TEST_BINARY_DIR}/olap/storage_types_test
-${DORIS_TEST_BINARY_DIR}/olap/generic_iterators_test
-${DORIS_TEST_BINARY_DIR}/olap/aggregate_func_test
-${DORIS_TEST_BINARY_DIR}/olap/short_key_index_test
-${DORIS_TEST_BINARY_DIR}/olap/key_coder_test
-${DORIS_TEST_BINARY_DIR}/olap/page_cache_test
-${DORIS_TEST_BINARY_DIR}/olap/hll_test
-${DORIS_TEST_BINARY_DIR}/olap/selection_vector_test
-
-# Running routine load test
-${DORIS_TEST_BINARY_DIR}/runtime/kafka_consumer_pipe_test
-${DORIS_TEST_BINARY_DIR}/runtime/routine_load_task_executor_test
-${DORIS_TEST_BINARY_DIR}/runtime/heartbeat_flags_test
+#${DORIS_TEST_BINARY_DIR}/olap/rowset/beta_rowset_test
+#${DORIS_TEST_BINARY_DIR}/olap/rowset/rowset_converter_test
+#${DORIS_TEST_BINARY_DIR}/olap/rowset/segment_v2/encoding_info_test
+#${DORIS_TEST_BINARY_DIR}/olap/rowset/segment_v2/ordinal_page_index_test
+#${DORIS_TEST_BINARY_DIR}/olap/rowset/segment_v2/bitshuffle_page_test
+#${DORIS_TEST_BINARY_DIR}/olap/rowset/segment_v2/plain_page_test
+#${DORIS_TEST_BINARY_DIR}/olap/rowset/segment_v2/binary_plain_page_test
+#${DORIS_TEST_BINARY_DIR}/olap/rowset/segment_v2/column_reader_writer_test
+#${DORIS_TEST_BINARY_DIR}/olap/rowset/segment_v2/index_column_reader_writer_test
+#${DORIS_TEST_BINARY_DIR}/olap/rowset/segment_v2/rle_page_test
+#${DORIS_TEST_BINARY_DIR}/olap/rowset/segment_v2/binary_dict_page_test
+#${DORIS_TEST_BINARY_DIR}/olap/rowset/segment_v2/binary_prefix_page_test
+#${DORIS_TEST_BINARY_DIR}/olap/rowset/segment_v2/segment_test
+#${DORIS_TEST_BINARY_DIR}/olap/rowset/segment_v2/page_compression_test
+#${DORIS_TEST_BINARY_DIR}/olap/rowset/segment_v2/column_zone_map_test
+#${DORIS_TEST_BINARY_DIR}/olap/rowset/segment_v2/row_ranges_test
+#${DORIS_TEST_BINARY_DIR}/olap/rowset/segment_v2/frame_of_reference_page_test
+#${DORIS_TEST_BINARY_DIR}/olap/rowset/segment_v2/block_bloom_filter_test
+#${DORIS_TEST_BINARY_DIR}/olap/rowset/segment_v2/bloom_filter_index_reader_writer_test
+#${DORIS_TEST_BINARY_DIR}/olap/txn_manager_test
+#${DORIS_TEST_BINARY_DIR}/olap/storage_types_test
+#${DORIS_TEST_BINARY_DIR}/olap/generic_iterators_test
+#${DORIS_TEST_BINARY_DIR}/olap/aggregate_func_test
+#${DORIS_TEST_BINARY_DIR}/olap/short_key_index_test
+#${DORIS_TEST_BINARY_DIR}/olap/key_coder_test
+#${DORIS_TEST_BINARY_DIR}/olap/page_cache_test
+#${DORIS_TEST_BINARY_DIR}/olap/hll_test
+#${DORIS_TEST_BINARY_DIR}/olap/selection_vector_test
+#
+## Running routine load test
+#${DORIS_TEST_BINARY_DIR}/runtime/kafka_consumer_pipe_test
+#${DORIS_TEST_BINARY_DIR}/runtime/routine_load_task_executor_test
+#${DORIS_TEST_BINARY_DIR}/runtime/heartbeat_flags_test
 
 # Running agent unittest
 # Prepare agent testdata

--- a/run-ut.sh
+++ b/run-ut.sh
@@ -132,170 +132,170 @@ fi
 cp -r ${DORIS_HOME}/be/test/util/test_data ${DORIS_TEST_BINARY_DIR}/util/
 
 # Running Util Unittest
-#${DORIS_TEST_BINARY_DIR}/util/bit_util_test
-#${DORIS_TEST_BINARY_DIR}/util/bitmap_test
-#${DORIS_TEST_BINARY_DIR}/util/path_trie_test
-#${DORIS_TEST_BINARY_DIR}/util/count_down_latch_test
-#${DORIS_TEST_BINARY_DIR}/util/crc32c_test
-#${DORIS_TEST_BINARY_DIR}/util/lru_cache_util_test
-#${DORIS_TEST_BINARY_DIR}/util/filesystem_util_test
-#${DORIS_TEST_BINARY_DIR}/util/internal_queue_test
-#${DORIS_TEST_BINARY_DIR}/util/cidr_test
-#${DORIS_TEST_BINARY_DIR}/util/new_metrics_test
-#${DORIS_TEST_BINARY_DIR}/util/doris_metrics_test
-#${DORIS_TEST_BINARY_DIR}/util/system_metrics_test
-#${DORIS_TEST_BINARY_DIR}/util/core_local_test
-#${DORIS_TEST_BINARY_DIR}/util/types_test
-#${DORIS_TEST_BINARY_DIR}/util/json_util_test
-#${DORIS_TEST_BINARY_DIR}/util/byte_buffer_test2
-#${DORIS_TEST_BINARY_DIR}/util/uid_util_test
-#${DORIS_TEST_BINARY_DIR}/util/aes_util_test
-#${DORIS_TEST_BINARY_DIR}/util/string_util_test
-#${DORIS_TEST_BINARY_DIR}/util/string_parser_test
-#${DORIS_TEST_BINARY_DIR}/util/coding_test
-#${DORIS_TEST_BINARY_DIR}/util/faststring_test
-#${DORIS_TEST_BINARY_DIR}/util/tdigest_test
-#${DORIS_TEST_BINARY_DIR}/util/radix_sort_test
-#${DORIS_TEST_BINARY_DIR}/util/block_compression_test
-#${DORIS_TEST_BINARY_DIR}/util/arrow/arrow_row_block_test
-#${DORIS_TEST_BINARY_DIR}/util/arrow/arrow_row_batch_test
-#${DORIS_TEST_BINARY_DIR}/util/arrow/arrow_work_flow_test
-#${DORIS_TEST_BINARY_DIR}/util/counter_cond_variable_test
-#${DORIS_TEST_BINARY_DIR}/util/bit_stream_utils_test
-#${DORIS_TEST_BINARY_DIR}/util/frame_of_reference_coding_test
-#${DORIS_TEST_BINARY_DIR}/util/zip_util_test
-#
-## Running common Unittest
-#${DORIS_TEST_BINARY_DIR}/common/resource_tls_test
-#
-### Running exprs unit test
-#${DORIS_TEST_BINARY_DIR}/exprs/string_functions_test
-#${DORIS_TEST_BINARY_DIR}/exprs/json_function_test
-#${DORIS_TEST_BINARY_DIR}/exprs/timestamp_functions_test
-#${DORIS_TEST_BINARY_DIR}/exprs/percentile_approx_test
-#${DORIS_TEST_BINARY_DIR}/exprs/bitmap_function_test
-#${DORIS_TEST_BINARY_DIR}/exprs/hll_function_test
-#
-### Running geo unit test
-#${DORIS_TEST_BINARY_DIR}/geo/geo_functions_test
-#${DORIS_TEST_BINARY_DIR}/geo/wkt_parse_test
-#${DORIS_TEST_BINARY_DIR}/geo/geo_types_test
-#
-### Running exec unit test
-#${DORIS_TEST_BINARY_DIR}/exec/plain_text_line_reader_uncompressed_test
-#${DORIS_TEST_BINARY_DIR}/exec/plain_text_line_reader_gzip_test
-#${DORIS_TEST_BINARY_DIR}/exec/plain_text_line_reader_bzip_test
-#${DORIS_TEST_BINARY_DIR}/exec/plain_text_line_reader_lz4frame_test
-#if [ -f ${DORIS_TEST_BINARY_DIR}/exec/plain_text_line_reader_lzop_test ];then
-#    ${DORIS_TEST_BINARY_DIR}/exec/plain_text_line_reader_lzop_test
-#fi
-#${DORIS_TEST_BINARY_DIR}/exec/broker_scanner_test
-#${DORIS_TEST_BINARY_DIR}/exec/parquet_scanner_test
-#${DORIS_TEST_BINARY_DIR}/exec/broker_scan_node_test
-#${DORIS_TEST_BINARY_DIR}/exec/es_scan_node_test
-#${DORIS_TEST_BINARY_DIR}/exec/es_http_scan_node_test
-#${DORIS_TEST_BINARY_DIR}/exec/es_predicate_test
-#${DORIS_TEST_BINARY_DIR}/exec/es_scan_reader_test
-#${DORIS_TEST_BINARY_DIR}/exec/es_query_builder_test
-#${DORIS_TEST_BINARY_DIR}/exec/tablet_info_test
-#${DORIS_TEST_BINARY_DIR}/exec/tablet_sink_test
-#
-## Running runtime Unittest
-#${DORIS_TEST_BINARY_DIR}/runtime/external_scan_context_mgr_test
-#${DORIS_TEST_BINARY_DIR}/runtime/memory_scratch_sink_test
-#${DORIS_TEST_BINARY_DIR}/runtime/result_queue_mgr_test
-#${DORIS_TEST_BINARY_DIR}/runtime/fragment_mgr_test
-#${DORIS_TEST_BINARY_DIR}/runtime/decimal_value_test
-#${DORIS_TEST_BINARY_DIR}/runtime/decimalv2_value_test
-#${DORIS_TEST_BINARY_DIR}/runtime/datetime_value_test
-#${DORIS_TEST_BINARY_DIR}/runtime/large_int_value_test
-#${DORIS_TEST_BINARY_DIR}/runtime/string_value_test
-#${DORIS_TEST_BINARY_DIR}/runtime/free_list_test
-#${DORIS_TEST_BINARY_DIR}/runtime/string_buffer_test
-#${DORIS_TEST_BINARY_DIR}/runtime/stream_load_pipe_test
-#${DORIS_TEST_BINARY_DIR}/runtime/load_channel_mgr_test
-#${DORIS_TEST_BINARY_DIR}/runtime/snapshot_loader_test
-#${DORIS_TEST_BINARY_DIR}/runtime/user_function_cache_test
-#${DORIS_TEST_BINARY_DIR}/runtime/small_file_mgr_test
-#${DORIS_TEST_BINARY_DIR}/runtime/mem_pool_test
-#${DORIS_TEST_BINARY_DIR}/runtime/memory/chunk_allocator_test
-#${DORIS_TEST_BINARY_DIR}/runtime/memory/system_allocator_test
-## Running expr Unittest
-#
-## Running http
-#${DORIS_TEST_BINARY_DIR}/http/metrics_action_test
-#${DORIS_TEST_BINARY_DIR}/http/http_utils_test
-#${DORIS_TEST_BINARY_DIR}/http/stream_load_test
-#${DORIS_TEST_BINARY_DIR}/http/http_client_test
-#
-## Running StorageEngine Unittest
-#${DORIS_TEST_BINARY_DIR}/olap/bit_field_test
-#${DORIS_TEST_BINARY_DIR}/olap/byte_buffer_test
-#${DORIS_TEST_BINARY_DIR}/olap/run_length_byte_test
-#${DORIS_TEST_BINARY_DIR}/olap/run_length_integer_test
-#${DORIS_TEST_BINARY_DIR}/olap/stream_index_test
-#${DORIS_TEST_BINARY_DIR}/olap/lru_cache_test
-#${DORIS_TEST_BINARY_DIR}/olap/bloom_filter_test
-#${DORIS_TEST_BINARY_DIR}/olap/bloom_filter_index_test
-#${DORIS_TEST_BINARY_DIR}/olap/row_block_test
-#${DORIS_TEST_BINARY_DIR}/olap/row_block_v2_test
-#${DORIS_TEST_BINARY_DIR}/olap/comparison_predicate_test
-#${DORIS_TEST_BINARY_DIR}/olap/in_list_predicate_test
-#${DORIS_TEST_BINARY_DIR}/olap/null_predicate_test
-#${DORIS_TEST_BINARY_DIR}/olap/file_helper_test
-#${DORIS_TEST_BINARY_DIR}/olap/file_utils_test
-#${DORIS_TEST_BINARY_DIR}/olap/delete_handler_test
-#${DORIS_TEST_BINARY_DIR}/olap/column_reader_test
-#${DORIS_TEST_BINARY_DIR}/olap/schema_change_test
+${DORIS_TEST_BINARY_DIR}/util/bit_util_test
+${DORIS_TEST_BINARY_DIR}/util/bitmap_test
+${DORIS_TEST_BINARY_DIR}/util/path_trie_test
+${DORIS_TEST_BINARY_DIR}/util/count_down_latch_test
+${DORIS_TEST_BINARY_DIR}/util/crc32c_test
+${DORIS_TEST_BINARY_DIR}/util/lru_cache_util_test
+${DORIS_TEST_BINARY_DIR}/util/filesystem_util_test
+${DORIS_TEST_BINARY_DIR}/util/internal_queue_test
+${DORIS_TEST_BINARY_DIR}/util/cidr_test
+${DORIS_TEST_BINARY_DIR}/util/new_metrics_test
+${DORIS_TEST_BINARY_DIR}/util/doris_metrics_test
+${DORIS_TEST_BINARY_DIR}/util/system_metrics_test
+${DORIS_TEST_BINARY_DIR}/util/core_local_test
+${DORIS_TEST_BINARY_DIR}/util/types_test
+${DORIS_TEST_BINARY_DIR}/util/json_util_test
+${DORIS_TEST_BINARY_DIR}/util/byte_buffer_test2
+${DORIS_TEST_BINARY_DIR}/util/uid_util_test
+${DORIS_TEST_BINARY_DIR}/util/aes_util_test
+${DORIS_TEST_BINARY_DIR}/util/string_util_test
+${DORIS_TEST_BINARY_DIR}/util/string_parser_test
+${DORIS_TEST_BINARY_DIR}/util/coding_test
+${DORIS_TEST_BINARY_DIR}/util/faststring_test
+${DORIS_TEST_BINARY_DIR}/util/tdigest_test
+${DORIS_TEST_BINARY_DIR}/util/radix_sort_test
+${DORIS_TEST_BINARY_DIR}/util/block_compression_test
+${DORIS_TEST_BINARY_DIR}/util/arrow/arrow_row_block_test
+${DORIS_TEST_BINARY_DIR}/util/arrow/arrow_row_batch_test
+${DORIS_TEST_BINARY_DIR}/util/arrow/arrow_work_flow_test
+${DORIS_TEST_BINARY_DIR}/util/counter_cond_variable_test
+${DORIS_TEST_BINARY_DIR}/util/bit_stream_utils_test
+${DORIS_TEST_BINARY_DIR}/util/frame_of_reference_coding_test
+${DORIS_TEST_BINARY_DIR}/util/zip_util_test
+
+# Running common Unittest
+${DORIS_TEST_BINARY_DIR}/common/resource_tls_test
+
+## Running exprs unit test
+${DORIS_TEST_BINARY_DIR}/exprs/string_functions_test
+${DORIS_TEST_BINARY_DIR}/exprs/json_function_test
+${DORIS_TEST_BINARY_DIR}/exprs/timestamp_functions_test
+${DORIS_TEST_BINARY_DIR}/exprs/percentile_approx_test
+${DORIS_TEST_BINARY_DIR}/exprs/bitmap_function_test
+${DORIS_TEST_BINARY_DIR}/exprs/hll_function_test
+
+## Running geo unit test
+${DORIS_TEST_BINARY_DIR}/geo/geo_functions_test
+${DORIS_TEST_BINARY_DIR}/geo/wkt_parse_test
+${DORIS_TEST_BINARY_DIR}/geo/geo_types_test
+
+## Running exec unit test
+${DORIS_TEST_BINARY_DIR}/exec/plain_text_line_reader_uncompressed_test
+${DORIS_TEST_BINARY_DIR}/exec/plain_text_line_reader_gzip_test
+${DORIS_TEST_BINARY_DIR}/exec/plain_text_line_reader_bzip_test
+${DORIS_TEST_BINARY_DIR}/exec/plain_text_line_reader_lz4frame_test
+if [ -f ${DORIS_TEST_BINARY_DIR}/exec/plain_text_line_reader_lzop_test ];then
+    ${DORIS_TEST_BINARY_DIR}/exec/plain_text_line_reader_lzop_test
+fi
+${DORIS_TEST_BINARY_DIR}/exec/broker_scanner_test
+${DORIS_TEST_BINARY_DIR}/exec/parquet_scanner_test
+${DORIS_TEST_BINARY_DIR}/exec/broker_scan_node_test
+${DORIS_TEST_BINARY_DIR}/exec/es_scan_node_test
+${DORIS_TEST_BINARY_DIR}/exec/es_http_scan_node_test
+${DORIS_TEST_BINARY_DIR}/exec/es_predicate_test
+${DORIS_TEST_BINARY_DIR}/exec/es_scan_reader_test
+${DORIS_TEST_BINARY_DIR}/exec/es_query_builder_test
+${DORIS_TEST_BINARY_DIR}/exec/tablet_info_test
+${DORIS_TEST_BINARY_DIR}/exec/tablet_sink_test
+
+# Running runtime Unittest
+${DORIS_TEST_BINARY_DIR}/runtime/external_scan_context_mgr_test
+${DORIS_TEST_BINARY_DIR}/runtime/memory_scratch_sink_test
+${DORIS_TEST_BINARY_DIR}/runtime/result_queue_mgr_test
+${DORIS_TEST_BINARY_DIR}/runtime/fragment_mgr_test
+${DORIS_TEST_BINARY_DIR}/runtime/decimal_value_test
+${DORIS_TEST_BINARY_DIR}/runtime/decimalv2_value_test
+${DORIS_TEST_BINARY_DIR}/runtime/datetime_value_test
+${DORIS_TEST_BINARY_DIR}/runtime/large_int_value_test
+${DORIS_TEST_BINARY_DIR}/runtime/string_value_test
+${DORIS_TEST_BINARY_DIR}/runtime/free_list_test
+${DORIS_TEST_BINARY_DIR}/runtime/string_buffer_test
+${DORIS_TEST_BINARY_DIR}/runtime/stream_load_pipe_test
+${DORIS_TEST_BINARY_DIR}/runtime/load_channel_mgr_test
+${DORIS_TEST_BINARY_DIR}/runtime/snapshot_loader_test
+${DORIS_TEST_BINARY_DIR}/runtime/user_function_cache_test
+${DORIS_TEST_BINARY_DIR}/runtime/small_file_mgr_test
+${DORIS_TEST_BINARY_DIR}/runtime/mem_pool_test
+${DORIS_TEST_BINARY_DIR}/runtime/memory/chunk_allocator_test
+${DORIS_TEST_BINARY_DIR}/runtime/memory/system_allocator_test
+# Running expr Unittest
+
+# Running http
+${DORIS_TEST_BINARY_DIR}/http/metrics_action_test
+${DORIS_TEST_BINARY_DIR}/http/http_utils_test
+${DORIS_TEST_BINARY_DIR}/http/stream_load_test
+${DORIS_TEST_BINARY_DIR}/http/http_client_test
+
+# Running StorageEngine Unittest
+${DORIS_TEST_BINARY_DIR}/olap/bit_field_test
+${DORIS_TEST_BINARY_DIR}/olap/byte_buffer_test
+${DORIS_TEST_BINARY_DIR}/olap/run_length_byte_test
+${DORIS_TEST_BINARY_DIR}/olap/run_length_integer_test
+${DORIS_TEST_BINARY_DIR}/olap/stream_index_test
+${DORIS_TEST_BINARY_DIR}/olap/lru_cache_test
+${DORIS_TEST_BINARY_DIR}/olap/bloom_filter_test
+${DORIS_TEST_BINARY_DIR}/olap/bloom_filter_index_test
+${DORIS_TEST_BINARY_DIR}/olap/row_block_test
+${DORIS_TEST_BINARY_DIR}/olap/row_block_v2_test
+${DORIS_TEST_BINARY_DIR}/olap/comparison_predicate_test
+${DORIS_TEST_BINARY_DIR}/olap/in_list_predicate_test
+${DORIS_TEST_BINARY_DIR}/olap/null_predicate_test
+${DORIS_TEST_BINARY_DIR}/olap/file_helper_test
+${DORIS_TEST_BINARY_DIR}/olap/file_utils_test
+${DORIS_TEST_BINARY_DIR}/olap/delete_handler_test
+${DORIS_TEST_BINARY_DIR}/olap/column_reader_test
+${DORIS_TEST_BINARY_DIR}/olap/schema_change_test
 ${DORIS_TEST_BINARY_DIR}/olap/row_cursor_test
-#${DORIS_TEST_BINARY_DIR}/olap/skiplist_test
-#${DORIS_TEST_BINARY_DIR}/olap/serialize_test
-## ${DORIS_TEST_BINARY_DIR}/olap/memtable_flush_executor_test
-#${DORIS_TEST_BINARY_DIR}/olap/options_test
-#
-## Running routine load test
-#${DORIS_TEST_BINARY_DIR}/olap/tablet_meta_manager_test
-#${DORIS_TEST_BINARY_DIR}/olap/tablet_mgr_test
-#${DORIS_TEST_BINARY_DIR}/olap/olap_meta_test
-#${DORIS_TEST_BINARY_DIR}/olap/delta_writer_test
-#${DORIS_TEST_BINARY_DIR}/olap/decimal12_test
-#${DORIS_TEST_BINARY_DIR}/olap/olap_snapshot_converter_test
-#${DORIS_TEST_BINARY_DIR}/olap/rowset/rowset_meta_manager_test
-#${DORIS_TEST_BINARY_DIR}/olap/rowset/rowset_meta_test
+${DORIS_TEST_BINARY_DIR}/olap/skiplist_test
+${DORIS_TEST_BINARY_DIR}/olap/serialize_test
+# ${DORIS_TEST_BINARY_DIR}/olap/memtable_flush_executor_test
+${DORIS_TEST_BINARY_DIR}/olap/options_test
+
+# Running segment v2 test
+${DORIS_TEST_BINARY_DIR}/olap/tablet_meta_manager_test
+${DORIS_TEST_BINARY_DIR}/olap/tablet_mgr_test
+${DORIS_TEST_BINARY_DIR}/olap/olap_meta_test
+${DORIS_TEST_BINARY_DIR}/olap/delta_writer_test
+${DORIS_TEST_BINARY_DIR}/olap/decimal12_test
+${DORIS_TEST_BINARY_DIR}/olap/olap_snapshot_converter_test
+${DORIS_TEST_BINARY_DIR}/olap/rowset/rowset_meta_manager_test
+${DORIS_TEST_BINARY_DIR}/olap/rowset/rowset_meta_test
 ${DORIS_TEST_BINARY_DIR}/olap/rowset/alpha_rowset_test
-#${DORIS_TEST_BINARY_DIR}/olap/rowset/beta_rowset_test
-#${DORIS_TEST_BINARY_DIR}/olap/rowset/rowset_converter_test
-#${DORIS_TEST_BINARY_DIR}/olap/rowset/segment_v2/encoding_info_test
-#${DORIS_TEST_BINARY_DIR}/olap/rowset/segment_v2/ordinal_page_index_test
-#${DORIS_TEST_BINARY_DIR}/olap/rowset/segment_v2/bitshuffle_page_test
-#${DORIS_TEST_BINARY_DIR}/olap/rowset/segment_v2/plain_page_test
-#${DORIS_TEST_BINARY_DIR}/olap/rowset/segment_v2/binary_plain_page_test
-#${DORIS_TEST_BINARY_DIR}/olap/rowset/segment_v2/column_reader_writer_test
-#${DORIS_TEST_BINARY_DIR}/olap/rowset/segment_v2/index_column_reader_writer_test
-#${DORIS_TEST_BINARY_DIR}/olap/rowset/segment_v2/rle_page_test
-#${DORIS_TEST_BINARY_DIR}/olap/rowset/segment_v2/binary_dict_page_test
-#${DORIS_TEST_BINARY_DIR}/olap/rowset/segment_v2/binary_prefix_page_test
-#${DORIS_TEST_BINARY_DIR}/olap/rowset/segment_v2/segment_test
-#${DORIS_TEST_BINARY_DIR}/olap/rowset/segment_v2/page_compression_test
-#${DORIS_TEST_BINARY_DIR}/olap/rowset/segment_v2/column_zone_map_test
-#${DORIS_TEST_BINARY_DIR}/olap/rowset/segment_v2/row_ranges_test
-#${DORIS_TEST_BINARY_DIR}/olap/rowset/segment_v2/frame_of_reference_page_test
-#${DORIS_TEST_BINARY_DIR}/olap/rowset/segment_v2/block_bloom_filter_test
-#${DORIS_TEST_BINARY_DIR}/olap/rowset/segment_v2/bloom_filter_index_reader_writer_test
-#${DORIS_TEST_BINARY_DIR}/olap/txn_manager_test
-#${DORIS_TEST_BINARY_DIR}/olap/storage_types_test
-#${DORIS_TEST_BINARY_DIR}/olap/generic_iterators_test
-#${DORIS_TEST_BINARY_DIR}/olap/aggregate_func_test
-#${DORIS_TEST_BINARY_DIR}/olap/short_key_index_test
-#${DORIS_TEST_BINARY_DIR}/olap/key_coder_test
-#${DORIS_TEST_BINARY_DIR}/olap/page_cache_test
-#${DORIS_TEST_BINARY_DIR}/olap/hll_test
-#${DORIS_TEST_BINARY_DIR}/olap/selection_vector_test
-#
-## Running routine load test
-#${DORIS_TEST_BINARY_DIR}/runtime/kafka_consumer_pipe_test
-#${DORIS_TEST_BINARY_DIR}/runtime/routine_load_task_executor_test
-#${DORIS_TEST_BINARY_DIR}/runtime/heartbeat_flags_test
+${DORIS_TEST_BINARY_DIR}/olap/rowset/beta_rowset_test
+${DORIS_TEST_BINARY_DIR}/olap/rowset/rowset_converter_test
+${DORIS_TEST_BINARY_DIR}/olap/rowset/segment_v2/encoding_info_test
+${DORIS_TEST_BINARY_DIR}/olap/rowset/segment_v2/ordinal_page_index_test
+${DORIS_TEST_BINARY_DIR}/olap/rowset/segment_v2/bitshuffle_page_test
+${DORIS_TEST_BINARY_DIR}/olap/rowset/segment_v2/plain_page_test
+${DORIS_TEST_BINARY_DIR}/olap/rowset/segment_v2/binary_plain_page_test
+${DORIS_TEST_BINARY_DIR}/olap/rowset/segment_v2/column_reader_writer_test
+${DORIS_TEST_BINARY_DIR}/olap/rowset/segment_v2/index_column_reader_writer_test
+${DORIS_TEST_BINARY_DIR}/olap/rowset/segment_v2/rle_page_test
+${DORIS_TEST_BINARY_DIR}/olap/rowset/segment_v2/binary_dict_page_test
+${DORIS_TEST_BINARY_DIR}/olap/rowset/segment_v2/binary_prefix_page_test
+${DORIS_TEST_BINARY_DIR}/olap/rowset/segment_v2/segment_test
+${DORIS_TEST_BINARY_DIR}/olap/rowset/segment_v2/page_compression_test
+${DORIS_TEST_BINARY_DIR}/olap/rowset/segment_v2/column_zone_map_test
+${DORIS_TEST_BINARY_DIR}/olap/rowset/segment_v2/row_ranges_test
+${DORIS_TEST_BINARY_DIR}/olap/rowset/segment_v2/frame_of_reference_page_test
+${DORIS_TEST_BINARY_DIR}/olap/rowset/segment_v2/block_bloom_filter_test
+${DORIS_TEST_BINARY_DIR}/olap/rowset/segment_v2/bloom_filter_index_reader_writer_test
+${DORIS_TEST_BINARY_DIR}/olap/txn_manager_test
+${DORIS_TEST_BINARY_DIR}/olap/storage_types_test
+${DORIS_TEST_BINARY_DIR}/olap/generic_iterators_test
+${DORIS_TEST_BINARY_DIR}/olap/aggregate_func_test
+${DORIS_TEST_BINARY_DIR}/olap/short_key_index_test
+${DORIS_TEST_BINARY_DIR}/olap/key_coder_test
+${DORIS_TEST_BINARY_DIR}/olap/page_cache_test
+${DORIS_TEST_BINARY_DIR}/olap/hll_test
+${DORIS_TEST_BINARY_DIR}/olap/selection_vector_test
+
+# Running routine load test
+${DORIS_TEST_BINARY_DIR}/runtime/kafka_consumer_pipe_test
+${DORIS_TEST_BINARY_DIR}/runtime/routine_load_task_executor_test
+${DORIS_TEST_BINARY_DIR}/runtime/heartbeat_flags_test
 
 # Running agent unittest
 # Prepare agent testdata


### PR DESCRIPTION
When merge reads from one rowset with multi overlapping segments, 
I introduce a priority queue(A Minimum heap data structure) for multipath merge sort, 
to replace the old N*M time complexity algorithm.

This can significantly improve the read efficiency when merging large number of 
overlapping data.

In mytest:
1. Compaction with 187 segments reduce time from 75 seconds to 42 seconds
2. Compaction with 3574 segments cost 43 seconds, and with old version, I kill the 
process after waiting more than 10 minutes...

This CL only change the reads of alpha rowset. Beta rowset will be changed in another CL.

ISSUE: #2631 