### PR TITLE
[Compaction] Limit the max concurrency of running compaction tasks

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -235,7 +235,6 @@ namespace config {
     CONF_Int64(base_compaction_end_hour, "7");
     CONF_Int32(base_compaction_check_interval_seconds, "60");
     CONF_Int64(base_compaction_num_cumulative_deltas, "5");
-    CONF_Int32(base_compaction_num_threads, "1");
     CONF_Int32(base_compaction_num_threads_per_disk, "1");
     CONF_Double(base_cumulative_delta_ratio, "0.3");
     CONF_Int64(base_compaction_interval_seconds_since_last_operation, "86400");
@@ -245,7 +244,6 @@ namespace config {
     CONF_Int32(cumulative_compaction_check_interval_seconds, "10");
     CONF_Int64(min_cumulative_compaction_num_singleton_deltas, "5");
     CONF_Int64(max_cumulative_compaction_num_singleton_deltas, "1000");
-    CONF_Int32(cumulative_compaction_num_threads, "1");
     CONF_Int32(cumulative_compaction_num_threads_per_disk, "1");
     CONF_Int64(cumulative_compaction_budgeted_bytes, "104857600");
     CONF_Int32(cumulative_compaction_write_mbytes_per_sec, "100");
@@ -253,6 +251,13 @@ namespace config {
     // if compaction of a tablet failed, this tablet should not be chosen to
     // compaction until this interval passes.
     CONF_Int64(min_compaction_failure_interval_sec, "600") // 10 min
+    // Too many compaction tasks may run out of memory.
+    // This config is to limit the max concurrency of running compaction tasks.
+    // -1 means no limit, and the max concurrency will be:
+    //      C = (cumulative_compaction_num_threads_per_disk + base_compaction_num_threads_per_disk) * dir_num
+    // set it to larger than C will be set to equal to C.
+    // This config can be set to 0, which means to forbid any compaction, for some special cases.
+    CONF_Int32(max_compaction_concurrency, "-1");
 
     // Port to start debug webserver on
     CONF_Int32(webserver_port, "8040");

--- a/be/src/olap/compaction.cpp
+++ b/be/src/olap/compaction.cpp
@@ -35,6 +35,18 @@ Compaction::Compaction(TabletSharedPtr tablet)
 
 Compaction::~Compaction() {}
 
+OLAPStatus Compaction::init(int concurreny) {
+    _concurrency_sem.set_count(concurreny);
+    return OLAP_SUCCESS;
+}
+
+OLAPStatus Compaction::do_compaction() {
+    _concurrency_sem.wait();
+    OLAPStatus st = do_compaction_impl();
+    _concurrency_sem.signal();
+    return st;
+}
+
 OLAPStatus Compaction::do_compaction_impl() {
 
     LOG(INFO) << "start " << compaction_name() << ". tablet=" << _tablet->full_name();

--- a/be/src/olap/compaction.cpp
+++ b/be/src/olap/compaction.cpp
@@ -24,6 +24,8 @@ using std::vector;
 
 namespace doris {
 
+Semaphore Compaction::_concurrency_sem;
+
 Compaction::Compaction(TabletSharedPtr tablet)
     : _tablet(tablet),
       _input_rowsets_size(0),
@@ -33,7 +35,8 @@ Compaction::Compaction(TabletSharedPtr tablet)
 
 Compaction::~Compaction() {}
 
-OLAPStatus Compaction::do_compaction() {
+OLAPStatus Compaction::do_compaction_impl() {
+
     LOG(INFO) << "start " << compaction_name() << ". tablet=" << _tablet->full_name();
 
     OlapStopWatch watch;

--- a/be/src/olap/compaction.h
+++ b/be/src/olap/compaction.h
@@ -28,6 +28,7 @@
 #include "olap/tablet_meta.h"
 #include "olap/utils.h"
 #include "rowset/rowset_id_generator.h"
+#include "util/semaphore.hpp"
 
 namespace doris {
 
@@ -48,12 +49,22 @@ public:
 
     virtual OLAPStatus compact() = 0;
 
+    static void init(int concurreny) { _concurrency_sem.set_count(concurreny); }
+
 protected:
     virtual OLAPStatus pick_rowsets_to_compact() = 0;
     virtual std::string compaction_name() const = 0;
     virtual ReaderType compaction_type() const = 0;
 
-    OLAPStatus do_compaction();
+    OLAPStatus do_compaction() {
+        _concurrency_sem.wait();
+        OLAPStatus st = do_compation_impl();
+        _concurrency_sem.signal();
+        return st;
+    }
+
+    OLAPStatus do_compaction_impl();
+
     OLAPStatus modify_rowsets();
     OLAPStatus gc_unused_rowsets();
 
@@ -62,6 +73,9 @@ protected:
 
     OLAPStatus check_version_continuity(const std::vector<RowsetSharedPtr>& rowsets);
     OLAPStatus check_correctness(const Merger::Statistics& stats);
+
+    // semaphore used to limit the concurrency of running compaction tasks
+    static Semaphore _concurrency_sem;
 
 protected:
     TabletSharedPtr _tablet;

--- a/be/src/olap/compaction.h
+++ b/be/src/olap/compaction.h
@@ -49,20 +49,14 @@ public:
 
     virtual OLAPStatus compact() = 0;
 
-    static void init(int concurreny) { _concurrency_sem.set_count(concurreny); }
+    static OLAPStatus init(int concurreny);
 
 protected:
     virtual OLAPStatus pick_rowsets_to_compact() = 0;
     virtual std::string compaction_name() const = 0;
     virtual ReaderType compaction_type() const = 0;
 
-    OLAPStatus do_compaction() {
-        _concurrency_sem.wait();
-        OLAPStatus st = do_compation_impl();
-        _concurrency_sem.signal();
-        return st;
-    }
-
+    OLAPStatus do_compaction();
     OLAPStatus do_compaction_impl();
 
     OLAPStatus modify_rowsets();

--- a/be/src/olap/olap_server.cpp
+++ b/be/src/olap/olap_server.cpp
@@ -67,8 +67,10 @@ OLAPStatus StorageEngine::_start_bg_worker() {
     int32_t data_dir_num = data_dirs.size();
 
     // base and cumulative compaction threads
-    int32_t base_compaction_num_threads = config::base_compaction_num_threads_per_disk * data_dir_num;
-    int32_t cumulative_compaction_num_threads = config::cumulative_compaction_num_threads_per_disk * data_dir_num;
+    int32_t base_compaction_num_threads_per_disk = std::max<int32_t>(1, config::base_compaction_num_threads_per_disk);
+    int32_t cumulative_compaction_num_threads_per_disk = std::max<int32_t>(1, config::cumulative_compaction_num_threads_per_disk);
+    int32_t base_compaction_num_threads = base_compaction_num_threads_per_disk * data_dir_num;
+    int32_t cumulative_compaction_num_threads = cumulative_compaction_num_threads_per_disk * data_dir_num;
     // calc the max concurrency of compaction tasks
     int32_t max_compaction_concurrency = config::max_compaction_concurrency;
     if (max_compaction_concurrency < 0

--- a/be/src/olap/olap_server.cpp
+++ b/be/src/olap/olap_server.cpp
@@ -65,8 +65,18 @@ OLAPStatus StorageEngine::_start_bg_worker() {
         data_dirs.push_back(tmp_store.second);
     }
     int32_t data_dir_num = data_dirs.size();
-    // start be and ce threads for merge data
+
+    // base and cumulative compaction threads
     int32_t base_compaction_num_threads = config::base_compaction_num_threads_per_disk * data_dir_num;
+    int32_t cumulative_compaction_num_threads = config::cumulative_compaction_num_threads_per_disk * data_dir_num;
+    // calc the max concurrency of compaction tasks
+    int32_t max_compaction_concurrency = config::max_compaction_concurrency;
+    if (max_compaction_concurrency < 0
+        || max_compaction_concurrency > base_compaction_num_threads + cumulative_compaction_num_threads) {
+        max_compaction_concurrency = base_compaction_num_threads + cumulative_compaction_num_threads;
+    }
+    Compaction::init(max_compaction_concurrency);
+
     _base_compaction_threads.reserve(base_compaction_num_threads);
     for (uint32_t i = 0; i < base_compaction_num_threads; ++i) {
         _base_compaction_threads.emplace_back(
@@ -78,7 +88,6 @@ OLAPStatus StorageEngine::_start_bg_worker() {
         thread.detach();
     }
 
-    int32_t cumulative_compaction_num_threads = config::cumulative_compaction_num_threads_per_disk * data_dir_num;
     _cumulative_compaction_threads.reserve(cumulative_compaction_num_threads);
     for (uint32_t i = 0; i < cumulative_compaction_num_threads; ++i) {
         _cumulative_compaction_threads.emplace_back(
@@ -90,6 +99,7 @@ OLAPStatus StorageEngine::_start_bg_worker() {
         thread.detach();
     }
 
+    // tablet checkpoint thread
     for (auto data_dir : data_dirs) {
         _tablet_checkpoint_threads.emplace_back(
         [this, data_dir] {
@@ -100,6 +110,7 @@ OLAPStatus StorageEngine::_start_bg_worker() {
         thread.detach();
     }
 
+    // fd cache clean thread
     _fd_cache_clean_thread = std::thread(
         [this] {
             _fd_cache_clean_callback(nullptr);

--- a/be/src/olap/storage_engine.cpp
+++ b/be/src/olap/storage_engine.cpp
@@ -185,13 +185,6 @@ OLAPStatus StorageEngine::open() {
         return OLAP_ERR_INIT_FAILED;
     }
 
-    // 初始化CE调度器
-    int32_t cumulative_compaction_num_threads = config::cumulative_compaction_num_threads;
-    int32_t base_compaction_num_threads = config::base_compaction_num_threads;
-    uint32_t dir_size = _store_map.size();
-    _max_cumulative_compaction_task_per_disk = (cumulative_compaction_num_threads + dir_size - 1) / dir_size;
-    _max_base_compaction_task_per_disk = (base_compaction_num_threads + dir_size - 1) / dir_size;
-
     auto dirs = get_stores();
     load_data_dirs(dirs);
 

--- a/be/src/olap/storage_engine.h
+++ b/be/src/olap/storage_engine.h
@@ -310,8 +310,6 @@ private:
     uint32_t _min_percentage_of_error_disk;
     Cache* _file_descriptor_lru_cache;
     Cache* _index_stream_lru_cache;
-    uint32_t _max_base_compaction_task_per_disk;
-    uint32_t _max_cumulative_compaction_task_per_disk;
 
     Mutex _fs_task_mutex;
     file_system_task_count_t _fs_base_compaction_task_num_map;


### PR DESCRIPTION
Compaction task may sometimes consume much memory and results in OOM.
And currently, there is no good way to predict the mem consumption of
a compaction task, so I add a new BE config: max_compaction_concurrency
to limit the max concurrency of running compaction tasks manually.

The default value is -1, which means no limit. And the max value is:
`(base compaction thread num + cumulative compaction thread num) * num of data dir`

ISSUE #2633 