### PR TITLE
fix estimate_segment_size problem #2643

### DIFF
--- a/be/src/olap/rowset/segment_v2/column_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/column_writer.cpp
@@ -78,7 +78,8 @@ ColumnWriter::ColumnWriter(const ColumnWriterOptions& opts,
         : _opts(opts),
         _is_nullable(is_nullable),
         _output_file(output_file),
-        _field(std::move(field)) {
+        _field(std::move(field)),
+        _data_size(0) {
 }
 
 ColumnWriter::~ColumnWriter() {
@@ -208,14 +209,7 @@ Status ColumnWriter::append_nullable(
 }
 
 uint64_t ColumnWriter::estimate_buffer_size() {
-    uint64_t size = 0;
-    Page* page = _pages.head;
-    while (page != nullptr) {
-        for (auto& data_slice : page->data) {
-            size += data_slice.slice().size;
-        }
-        page = page->next;
-    }
+    uint64_t size = _data_size;
     size += _page_builder->size();
     if (_is_nullable) {
         size += _null_bitmap_builder->size();

--- a/be/src/olap/rowset/segment_v2/column_writer.h
+++ b/be/src/olap/rowset/segment_v2/column_writer.h
@@ -171,6 +171,7 @@ private:
     PagePointer _ordinal_index_pp;
     PagePointer _zone_map_pp;
     PagePointer _dict_page_pp;
+    // the total data size of page list
     uint64_t _data_size;
     uint64_t _written_size = 0;
 };

--- a/be/src/olap/rowset/segment_v2/column_writer.h
+++ b/be/src/olap/rowset/segment_v2/column_writer.h
@@ -132,6 +132,9 @@ private:
         if (_pages.head == nullptr) {
             _pages.head = page;
         }
+        for (auto& data_slice : page->data) {
+            _data_size += data_slice.slice().size;
+        }
     }
 
     Status _append_data(const uint8_t** ptr, size_t num_rows);
@@ -168,6 +171,7 @@ private:
     PagePointer _ordinal_index_pp;
     PagePointer _zone_map_pp;
     PagePointer _dict_page_pp;
+    uint64_t _data_size;
     uint64_t _written_size = 0;
 };
 


### PR DESCRIPTION
optimize estimate_segment_size realization to resolve the issue #2643. The problem lies in that the column writer has to iterate all pages and bloom filter pages to get data size, which is costly.