### PR TITLE
[Build]Make set target arch universal

### DIFF
--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -40,6 +40,7 @@ string(TOUPPER ${CMAKE_BUILD_TYPE} CMAKE_BUILD_TYPE)
 message(STATUS "Build type is ${CMAKE_BUILD_TYPE}")
 
 # set CMAKE_BUILD_TARGET_ARCH
+# use `lscpu | grep 'Architecture' | awk '{print $2}'` only support system which language is en_US.UTF-8
 execute_process(COMMAND bash "-c" "uname -m"
                 OUTPUT_VARIABLE
                 CMAKE_BUILD_TARGET_ARCH

--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -40,7 +40,7 @@ string(TOUPPER ${CMAKE_BUILD_TYPE} CMAKE_BUILD_TYPE)
 message(STATUS "Build type is ${CMAKE_BUILD_TYPE}")
 
 # set CMAKE_BUILD_TARGET_ARCH
-execute_process(COMMAND bash "-c" "lscpu | grep 'Architecture' | awk '{print $2}'"
+execute_process(COMMAND bash "-c" "uname -m"
                 OUTPUT_VARIABLE
                 CMAKE_BUILD_TARGET_ARCH
                 OUTPUT_STRIP_TRAILING_WHITESPACE)

--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -44,7 +44,7 @@ execute_process(COMMAND bash "-c" "uname -m"
                 OUTPUT_VARIABLE
                 CMAKE_BUILD_TARGET_ARCH
                 OUTPUT_STRIP_TRAILING_WHITESPACE)
-message(STATUS "Build target arch is ${CMAKE_BUILD_TARGET_ARCH}")
+message(STATUS "Build target arch is ${CMAKE_BUILD_TARGET_ARCH}.")
 
 # Set dirs
 set(BASE_DIR "${CMAKE_CURRENT_SOURCE_DIR}")

--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -44,7 +44,7 @@ execute_process(COMMAND bash "-c" "uname -m"
                 OUTPUT_VARIABLE
                 CMAKE_BUILD_TARGET_ARCH
                 OUTPUT_STRIP_TRAILING_WHITESPACE)
-message(STATUS "Build target arch is ${CMAKE_BUILD_TARGET_ARCH}.")
+message(STATUS "Build target arch is ${CMAKE_BUILD_TARGET_ARCH}")
 
 # Set dirs
 set(BASE_DIR "${CMAKE_CURRENT_SOURCE_DIR}")


### PR DESCRIPTION
There is a problem that if the compile computer language is not en, for example zh_CN.UTF-8, the variable CMAKE_BUILD_TARGET_ARCH will be empty.So use `uname -m` to set CMAKE_BUILD_TARGET_ARCH 