### PR TITLE
Remove resource_info related members from TaskWorkerPool

### DIFF
--- a/be/src/agent/task_worker_pool.h
+++ b/be/src/agent/task_worker_pool.h
@@ -81,7 +81,7 @@ public:
     virtual void submit_task(const TAgentTaskRequest& task);
 
 private:
-    bool _check_task_info(const TTaskType::type task_type, int64_t signature);
+    bool _register_task_info(const TTaskType::type task_type, int64_t signature);
     void _remove_task_info(const TTaskType::type task_type, int64_t signature);
     void _spawn_callback_worker_thread(CALLBACK_FUNCTION callback_func);
     void _finish_task(const TFinishTaskRequest& finish_task_request);

--- a/be/src/agent/task_worker_pool.h
+++ b/be/src/agent/task_worker_pool.h
@@ -19,20 +19,17 @@
 #define DORIS_BE_SRC_TASK_WORKER_POOL_H
 
 #include <atomic>
-#include <boost/date_time/posix_time/posix_time.hpp>
-#include <boost/thread/condition_variable.hpp>
-#include <boost/thread/mutex.hpp>
 #include <deque>
-#include <mutex>
+#include <memory>
 #include <utility>
 #include <vector>
+
 #include "agent/status.h"
 #include "agent/utils.h"
 #include "gen_cpp/AgentService_types.h"
 #include "gen_cpp/HeartbeatService_types.h"
 #include "olap/olap_define.h"
 #include "olap/storage_engine.h"
-#include "olap/utils.h"
 
 namespace doris {
 
@@ -84,10 +81,8 @@ public:
     virtual void submit_task(const TAgentTaskRequest& task);
 
 private:
-    bool _record_task_info(
-            const TTaskType::type task_type, int64_t signature, const std::string& user);
-    void _remove_task_info(
-            const TTaskType::type task_type, int64_t signature, const std::string& user);
+    bool _check_task_info(const TTaskType::type task_type, int64_t signature);
+    void _remove_task_info(const TTaskType::type task_type, int64_t signature);
     void _spawn_callback_worker_thread(CALLBACK_FUNCTION callback_func);
     void _finish_task(const TFinishTaskRequest& finish_task_request);
     uint32_t _get_next_task_index(int32_t thread_count, std::deque<TAgentTaskRequest>& tasks,
@@ -134,26 +129,27 @@ private:
             bool overwrite,
             std::vector<std::string>* error_msgs);
 
+    // Reference to the ExecEnv::_master_info
     const TMasterInfo& _master_info;
     TBackend _backend;
-    AgentUtils* _agent_utils;
-    MasterServerClient* _master_client;
+    std::unique_ptr<AgentUtils> _agent_utils;
+    std::unique_ptr<MasterServerClient> _master_client;
     ExecEnv* _env;
 
-    std::deque<TAgentTaskRequest> _tasks;
+    // Protect task queue
     Mutex _worker_thread_lock;
     Condition _worker_thread_condition_lock;
+    std::deque<TAgentTaskRequest> _tasks;
+
     uint32_t _worker_count;
     TaskWorkerType _task_worker_type;
     CALLBACK_FUNCTION _callback_function;
-    static std::atomic_ulong _s_report_version;
-    static std::map<TTaskType::type, std::set<int64_t>> _s_task_signatures;
-    static std::map<TTaskType::type, std::map<std::string, uint32_t>> _s_running_task_user_count;
-    static std::map<TTaskType::type, std::map<std::string, uint32_t>> _s_total_task_user_count;
-    static std::map<TTaskType::type, uint32_t> _s_total_task_count;
-    static Mutex _s_task_signatures_lock;
-    static Mutex _s_running_task_user_count_lock;
+
     static FrontendServiceClientCache _master_service_client_cache;
+    static std::atomic_ulong _s_report_version;
+
+    static Mutex _s_task_signatures_lock;
+    static std::map<TTaskType::type, std::set<int64_t>> _s_task_signatures;
 
     DISALLOW_COPY_AND_ASSIGN(TaskWorkerPool);
 };  // class TaskWorkerPool

--- a/gensrc/thrift/AgentService.thrift
+++ b/gensrc/thrift/AgentService.thrift
@@ -253,6 +253,7 @@ struct TAgentTaskRequest {
     8: optional TCloneReq clone_req
     9: optional TPushReq push_req
     10: optional TCancelDeleteDataReq cancel_delete_data_req //deprecated
+    // Deprecated
     11: optional Types.TResourceInfo resource_info
     12: optional TStorageMediumMigrateReq storage_medium_migrate_req
     13: optional TCheckConsistencyReq check_consistency_req


### PR DESCRIPTION
The `TResourceInfo` was used to help `cgruops` to isolate resources,
but it is no longer used.

In fact, the `TResourceInfo` information is no longer carried in
the requests from FE to BE.