### PR TITLE
Fix invalid to_bitmap input lead to BE core

### DIFF
--- a/be/src/exprs/bitmap_function.cpp
+++ b/be/src/exprs/bitmap_function.cpp
@@ -304,8 +304,8 @@ StringVal BitmapFunctions::to_bitmap(doris_udf::FunctionContext* ctx, const dori
         uint32_t int_value = StringParser::string_to_unsigned_int<uint32_t>(reinterpret_cast<char*>(src.ptr), src.len, &parse_result);
         if (UNLIKELY(parse_result != StringParser::PARSE_SUCCESS)) {
             std::stringstream error_msg;
-            error_msg << "The to_bitmap function argument: " << std::string(reinterpret_cast<char*>(src.ptr), src.len)
-            << " type isn't integer family or exceed unsigned integer max value 4294967295";
+            error_msg << "The input: " << std::string(reinterpret_cast<char*>(src.ptr), src.len)
+            << " is not valid, to_bitmap only support int value from 0 to 4294967295 currently";
             ctx->set_error(error_msg.str().c_str());
             return StringVal::null();
         }

--- a/be/test/exprs/bitmap_function_test.cpp
+++ b/be/test/exprs/bitmap_function_test.cpp
@@ -98,7 +98,7 @@ TEST_F(BitmapFunctionsTest, to_bitmap_invalid_argument) {
     ASSERT_EQ(expected, result);
     ASSERT_TRUE(ctx->has_error());
 
-    std::string error_msg("The to_bitmap function argument: xxxxxx type isn't integer family or exceed unsigned integer max value 4294967295");
+    std::string error_msg("The input: xxxxxx is not valid, to_bitmap only support int value from 0 to 4294967295 currently");
     ASSERT_EQ(error_msg, ctx->error_msg());
 }
 
@@ -111,7 +111,7 @@ TEST_F(BitmapFunctionsTest, to_bitmap_out_of_range) {
 
     ASSERT_TRUE(ctx->has_error());
 
-    std::string error_msg("The to_bitmap function argument: 4294967296 type isn't integer family or exceed unsigned integer max value 4294967295");
+    std::string error_msg("The input: 4294967296 is not valid, to_bitmap only support int value from 0 to 4294967295 currently");
     ASSERT_EQ(error_msg, ctx->error_msg());
 }
 


### PR DESCRIPTION
For https://github.com/apache/incubator-doris/issues/2699 and https://github.com/apache/incubator-doris/issues/2678 and https://github.com/apache/incubator-doris/issues/2499

When there is a error for one row by insert into, we should ignore it, not fill in default value.

