### PR TITLE
[Meta Serialization] Support GSON serialization for class "Type"

### DIFF
--- a/fe/src/main/java/org/apache/doris/catalog/ArrayType.java
+++ b/fe/src/main/java/org/apache/doris/catalog/ArrayType.java
@@ -20,6 +20,7 @@ package org.apache.doris.catalog;
 import org.apache.doris.thrift.TTypeDesc;
 import org.apache.doris.thrift.TTypeNode;
 import org.apache.doris.thrift.TTypeNodeType;
+
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 
@@ -30,6 +31,7 @@ public class ArrayType extends Type {
     private final Type itemType;
 
     public ArrayType(Type itemType) {
+        super(ArrayType.class.getSimpleName());
         this.itemType = itemType;
     }
 

--- a/fe/src/main/java/org/apache/doris/catalog/ArrayType.java
+++ b/fe/src/main/java/org/apache/doris/catalog/ArrayType.java
@@ -31,7 +31,6 @@ public class ArrayType extends Type {
     private final Type itemType;
 
     public ArrayType(Type itemType) {
-        super(ArrayType.class.getSimpleName());
         this.itemType = itemType;
     }
 

--- a/fe/src/main/java/org/apache/doris/catalog/Column.java
+++ b/fe/src/main/java/org/apache/doris/catalog/Column.java
@@ -27,6 +27,7 @@ import org.apache.doris.thrift.TColumn;
 import org.apache.doris.thrift.TColumnType;
 
 import com.google.common.base.Strings;
+import com.google.gson.annotations.SerializedName;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -40,22 +41,30 @@ import java.io.IOException;
  */
 public class Column implements Writable {
     private static final Logger LOG = LogManager.getLogger(Column.class);
+    @SerializedName(value = "name")
     private String name;
+    @SerializedName(value = "type")
     private Type type;
     // column is key: aggregate type is null
     // column is not key and has no aggregate type: aggregate type is none
     // column is not key and has aggregate type: aggregate type is name of aggregate function.
+    @SerializedName(value = "aggregationType")
     private AggregateType aggregationType;
 
     // if isAggregationTypeImplicit is true, the actual aggregation type will not be shown in show create table
     // the key type of table is duplicate or unique: the isAggregationTypeImplicit of value columns are true
     // other cases: the isAggregationTypeImplicit is false
+    @SerializedName(value = "isAggregationTypeImplicit")
     private boolean isAggregationTypeImplicit;
+    @SerializedName(value = "isKey")
     private boolean isKey;
+    @SerializedName(value = "isAllowNull")
     private boolean isAllowNull;
+    @SerializedName(value = "defaultValue")
     private String defaultValue;
+    @SerializedName(value = "comment")
     private String comment;
-
+    @SerializedName(value = "stats")
     private ColumnStats stats;     // cardinality and selectivity etc.
 
     public Column() {

--- a/fe/src/main/java/org/apache/doris/catalog/ColumnStats.java
+++ b/fe/src/main/java/org/apache/doris/catalog/ColumnStats.java
@@ -20,13 +20,13 @@ package org.apache.doris.catalog;
 import org.apache.doris.analysis.Expr;
 import org.apache.doris.analysis.SlotRef;
 import org.apache.doris.common.io.Writable;
-import org.apache.doris.catalog.PrimitiveType;
 
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
+import com.google.gson.annotations.SerializedName;
 
-import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.io.DataInput;
 import java.io.DataOutput;
@@ -38,9 +38,13 @@ import java.io.IOException;
 public class ColumnStats implements Writable {
     private final static Logger LOG = LogManager.getLogger(ColumnStats.class);
 
+    @SerializedName(value = "avgSerializedSize")
     private float avgSerializedSize;  // in bytes; includes serialization overhead
+    @SerializedName(value = "maxSize")
     private long  maxSize;  // in bytes
+    @SerializedName(value = "numDistinctValues")
     private long  numDistinctValues;
+    @SerializedName(value = "numNulls")
     private long  numNulls;
 
     /**

--- a/fe/src/main/java/org/apache/doris/catalog/MapType.java
+++ b/fe/src/main/java/org/apache/doris/catalog/MapType.java
@@ -32,7 +32,6 @@ public class MapType extends Type {
     private final Type valueType;
 
     public MapType(Type keyType, Type valueType) {
-        super(MapType.class.getSimpleName());
         Preconditions.checkNotNull(keyType);
         Preconditions.checkNotNull(valueType);
         this.keyType = keyType;

--- a/fe/src/main/java/org/apache/doris/catalog/MapType.java
+++ b/fe/src/main/java/org/apache/doris/catalog/MapType.java
@@ -20,6 +20,7 @@ package org.apache.doris.catalog;
 import org.apache.doris.thrift.TTypeDesc;
 import org.apache.doris.thrift.TTypeNode;
 import org.apache.doris.thrift.TTypeNodeType;
+
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 
@@ -31,6 +32,7 @@ public class MapType extends Type {
     private final Type valueType;
 
     public MapType(Type keyType, Type valueType) {
+        super(MapType.class.getSimpleName());
         Preconditions.checkNotNull(keyType);
         Preconditions.checkNotNull(valueType);
         this.keyType = keyType;

--- a/fe/src/main/java/org/apache/doris/catalog/ScalarType.java
+++ b/fe/src/main/java/org/apache/doris/catalog/ScalarType.java
@@ -77,6 +77,7 @@ public class ScalarType extends Type {
     private int scale;
 
     protected ScalarType(PrimitiveType type) {
+        super(ScalarType.class.getSimpleName());
         this.type = type;
     }
 

--- a/fe/src/main/java/org/apache/doris/catalog/ScalarType.java
+++ b/fe/src/main/java/org/apache/doris/catalog/ScalarType.java
@@ -25,6 +25,7 @@ import org.apache.doris.thrift.TTypeNodeType;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
+import com.google.gson.annotations.SerializedName;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -62,9 +63,11 @@ public class ScalarType extends Type {
     public static final int MAX_PRECISION = 38;
     public static final int MAX_SCALE = MAX_PRECISION;
 
+    @SerializedName(value = "type")
     private final PrimitiveType type;
 
     // Only used for type CHAR.
+    @SerializedName(value = "len")
     private int len = -1;
     private boolean isAssignedStrLenInColDefinition = false;
 
@@ -73,7 +76,9 @@ public class ScalarType extends Type {
     // It is invalid to have one by -1 and not the other.
     // TODO: we could use that to store DECIMAL(8,*), indicating a decimal
     // with 8 digits of precision and any valid ([0-8]) scale.
+    @SerializedName(value = "precision")
     private int precision;
+    @SerializedName(value = "scale")
     private int scale;
 
     protected ScalarType(PrimitiveType type) {

--- a/fe/src/main/java/org/apache/doris/catalog/ScalarType.java
+++ b/fe/src/main/java/org/apache/doris/catalog/ScalarType.java
@@ -82,7 +82,6 @@ public class ScalarType extends Type {
     private int scale;
 
     protected ScalarType(PrimitiveType type) {
-        super(ScalarType.class.getSimpleName());
         this.type = type;
     }
 

--- a/fe/src/main/java/org/apache/doris/catalog/StructType.java
+++ b/fe/src/main/java/org/apache/doris/catalog/StructType.java
@@ -39,7 +39,6 @@ public class StructType extends Type {
     private final ArrayList<StructField> fields;
 
     public StructType(ArrayList<StructField> fields) {
-        super(StructType.class.getSimpleName());
         Preconditions.checkNotNull(fields);
         this.fields = fields;
         for (int i = 0; i < this.fields.size(); ++i) {
@@ -49,7 +48,6 @@ public class StructType extends Type {
     }
 
     public StructType() {
-        super(StructType.class.getSimpleName());
         fields = Lists.newArrayList();
     }
 

--- a/fe/src/main/java/org/apache/doris/catalog/StructType.java
+++ b/fe/src/main/java/org/apache/doris/catalog/StructType.java
@@ -17,18 +17,19 @@
 
 package org.apache.doris.catalog;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-
 import org.apache.doris.thrift.TStructField;
 import org.apache.doris.thrift.TTypeDesc;
 import org.apache.doris.thrift.TTypeNode;
 import org.apache.doris.thrift.TTypeNodeType;
+
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+
+import java.util.ArrayList;
+import java.util.HashMap;
 
 /**
  * Describes a STRUCT type. STRUCT types have a list of named struct fields.
@@ -38,6 +39,7 @@ public class StructType extends Type {
     private final ArrayList<StructField> fields;
 
     public StructType(ArrayList<StructField> fields) {
+        super(StructType.class.getSimpleName());
         Preconditions.checkNotNull(fields);
         this.fields = fields;
         for (int i = 0; i < this.fields.size(); ++i) {
@@ -47,6 +49,7 @@ public class StructType extends Type {
     }
 
     public StructType() {
+        super(StructType.class.getSimpleName());
         fields = Lists.newArrayList();
     }
 

--- a/fe/src/main/java/org/apache/doris/catalog/Type.java
+++ b/fe/src/main/java/org/apache/doris/catalog/Type.java
@@ -28,7 +28,6 @@ import org.apache.doris.thrift.TTypeNodeType;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
-import com.google.gson.annotations.SerializedName;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -83,10 +82,6 @@ public abstract class Type {
     private static ArrayList<ScalarType> numericTypes;
     private static ArrayList<ScalarType> supportedTypes;
 
-    // this is used for Gson derived class serialization
-    @SerializedName(value = "clazz")
-    protected String clazz;
-
     static {
         integerTypes = Lists.newArrayList();
         integerTypes.add(TINYINT);
@@ -135,10 +130,6 @@ public abstract class Type {
     }
     public static ArrayList<ScalarType> getSupportedTypes() {
         return supportedTypes;
-    }
-
-    protected Type(String clazz) {
-        this.clazz = clazz;
     }
 
     /**

--- a/fe/src/main/java/org/apache/doris/catalog/Type.java
+++ b/fe/src/main/java/org/apache/doris/catalog/Type.java
@@ -82,6 +82,9 @@ public abstract class Type {
     private static ArrayList<ScalarType> numericTypes;
     private static ArrayList<ScalarType> supportedTypes;
 
+    // this is used for Gson derived class serialization
+    protected String clazz;
+
     static {
         integerTypes = Lists.newArrayList();
         integerTypes.add(TINYINT);
@@ -130,6 +133,10 @@ public abstract class Type {
     }
     public static ArrayList<ScalarType> getSupportedTypes() {
         return supportedTypes;
+    }
+
+    protected Type(String clazz) {
+        this.clazz = clazz;
     }
 
     /**

--- a/fe/src/main/java/org/apache/doris/catalog/Type.java
+++ b/fe/src/main/java/org/apache/doris/catalog/Type.java
@@ -28,6 +28,7 @@ import org.apache.doris.thrift.TTypeNodeType;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
+import com.google.gson.annotations.SerializedName;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -83,6 +84,7 @@ public abstract class Type {
     private static ArrayList<ScalarType> supportedTypes;
 
     // this is used for Gson derived class serialization
+    @SerializedName(value = "clazz")
     protected String clazz;
 
     static {

--- a/fe/src/main/java/org/apache/doris/persist/gson/GsonUtils.java
+++ b/fe/src/main/java/org/apache/doris/persist/gson/GsonUtils.java
@@ -17,6 +17,8 @@
 
 package org.apache.doris.persist.gson;
 
+import org.apache.doris.catalog.ScalarType;
+
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.HashBasedTable;
@@ -271,4 +273,10 @@ public class GsonUtils {
             return map;
         }
     }
+
+    private static RuntimeTypeAdapterFactory<org.apache.doris.catalog.Type> columnTypeAdapterFactory = RuntimeTypeAdapterFactory
+            // the "clazz" here is the name of "clazz" field in Type class.
+            .of(org.apache.doris.catalog.Type.class, "clazz")
+            // TODO: register other sub type after Doris support more types.
+            .registerSubtype(ScalarType.class, ScalarType.class.getSimpleName());
 }

--- a/fe/src/main/java/org/apache/doris/persist/gson/GsonUtils.java
+++ b/fe/src/main/java/org/apache/doris/persist/gson/GsonUtils.java
@@ -66,13 +66,21 @@ import java.util.Map;
  */
 public class GsonUtils {
 
+    // runtime adapter for class "Type"
+    private static RuntimeTypeAdapterFactory<org.apache.doris.catalog.Type> columnTypeAdapterFactory = RuntimeTypeAdapterFactory
+            // the "clazz" here is the name of "clazz" field in Type class.
+            .of(org.apache.doris.catalog.Type.class, "clazz")
+            // TODO: register other sub type after Doris support more types.
+            .registerSubtype(ScalarType.class, ScalarType.class.getSimpleName());
+
     // the builder of GSON instance.
     // Add any other adapters if necessary.
     private static final GsonBuilder GSON_BUILDER = new GsonBuilder()
             .addSerializationExclusionStrategy(new HiddenAnnotationExclusionStrategy())
             .enableComplexMapKeySerialization()
             .registerTypeHierarchyAdapter(Table.class, new GuavaTableAdapter())
-            .registerTypeHierarchyAdapter(Multimap.class, new GuavaMultimapAdapter());
+            .registerTypeHierarchyAdapter(Multimap.class, new GuavaMultimapAdapter())
+            .registerTypeAdapterFactory(columnTypeAdapterFactory);
 
     // this instance is thread-safe.
     public static final Gson GSON = GSON_BUILDER.create();
@@ -273,10 +281,4 @@ public class GsonUtils {
             return map;
         }
     }
-
-    private static RuntimeTypeAdapterFactory<org.apache.doris.catalog.Type> columnTypeAdapterFactory = RuntimeTypeAdapterFactory
-            // the "clazz" here is the name of "clazz" field in Type class.
-            .of(org.apache.doris.catalog.Type.class, "clazz")
-            // TODO: register other sub type after Doris support more types.
-            .registerSubtype(ScalarType.class, ScalarType.class.getSimpleName());
 }

--- a/fe/src/main/java/org/apache/doris/persist/gson/GsonUtils.java
+++ b/fe/src/main/java/org/apache/doris/persist/gson/GsonUtils.java
@@ -68,7 +68,6 @@ public class GsonUtils {
 
     // runtime adapter for class "Type"
     private static RuntimeTypeAdapterFactory<org.apache.doris.catalog.Type> columnTypeAdapterFactory = RuntimeTypeAdapterFactory
-            // the "clazz" here is the name of "clazz" field in Type class.
             .of(org.apache.doris.catalog.Type.class, "clazz")
             // TODO: register other sub type after Doris support more types.
             .registerSubtype(ScalarType.class, ScalarType.class.getSimpleName());

--- a/fe/src/main/java/org/apache/doris/persist/gson/RuntimeTypeAdapterFactory.java
+++ b/fe/src/main/java/org/apache/doris/persist/gson/RuntimeTypeAdapterFactory.java
@@ -252,7 +252,7 @@ public final class RuntimeTypeAdapterFactory<T> implements TypeAdapterFactory {
     }
 
     public <R> TypeAdapter<R> create(Gson gson, TypeToken<R> type) {
-        if (type.getRawType() != baseType) {
+        if (type.getRawType() != baseType && !subtypeToLabel.containsKey(type.getRawType())) {
             return null;
         }
 

--- a/fe/src/test/java/org/apache/doris/catalog/ColumnGsonSerializationTest.java
+++ b/fe/src/test/java/org/apache/doris/catalog/ColumnGsonSerializationTest.java
@@ -1,0 +1,123 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.catalog;
+
+import org.apache.doris.common.AnalysisException;
+import org.apache.doris.common.io.Text;
+import org.apache.doris.common.io.Writable;
+import org.apache.doris.persist.gson.GsonUtils;
+
+import com.google.common.collect.Lists;
+import com.google.gson.annotations.SerializedName;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.DataInput;
+import java.io.DataInputStream;
+import java.io.DataOutput;
+import java.io.DataOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.List;
+
+public class ColumnGsonSerializationTest {
+
+    private static String fileName = "./ColumnGsonSerializationTest";
+
+    @After
+    public void tearDown() {
+        File file = new File(fileName);
+        file.delete();
+    }
+
+    public static class ColumnList implements Writable {
+        @SerializedName(value = "columns")
+        public List<Column> columns = Lists.newArrayList();
+
+        @Override
+        public void write(DataOutput out) throws IOException {
+            String json = GsonUtils.GSON.toJson(this);
+            Text.writeString(out, json);
+        }
+
+        public static ColumnList read(DataInput in) throws IOException {
+            String json = Text.readString(in);
+            return GsonUtils.GSON.fromJson(json, ColumnList.class);
+        }
+    }
+
+    @Test
+    public void testSerializeColumn() throws IOException, AnalysisException {
+        // 1. Write objects to file
+        File file = new File(fileName);
+        file.createNewFile();
+        DataOutputStream out = new DataOutputStream(new FileOutputStream(file));
+
+        Column c1 = new Column("c1", Type.fromPrimitiveType(PrimitiveType.BIGINT), true, null, true, "1", "abc");
+
+        String c1Json = GsonUtils.GSON.toJson(c1);
+        Text.writeString(out, c1Json);
+        out.flush();
+        out.close();
+
+        // 2. Read objects from file
+        DataInputStream in = new DataInputStream(new FileInputStream(file));
+
+        String readJson = Text.readString(in);
+        Column readC1 = GsonUtils.GSON.fromJson(readJson, Column.class);
+
+        Assert.assertEquals(c1, readC1);
+    }
+    
+    @Test
+    public void testSerializeColumnList() throws IOException, AnalysisException {
+        // 1. Write objects to file
+        File file = new File(fileName);
+        file.createNewFile();
+        DataOutputStream out = new DataOutputStream(new FileOutputStream(file));
+
+        Column c1 = new Column("c1", Type.fromPrimitiveType(PrimitiveType.BIGINT), true, null, true, "1", "abc");
+        Column c2 = new Column("c2", ScalarType.createType(PrimitiveType.VARCHAR, 32, -1, -1), true, null, true, "cmy", "");
+        Column c3 = new Column("c3", ScalarType.createDecimalV2Type(27, 9), false, AggregateType.SUM, false, "1.1", "decimalv2");
+
+        ColumnList columnList = new ColumnList();
+        columnList.columns.add(c1);
+        columnList.columns.add(c2);
+        columnList.columns.add(c3);
+
+        columnList.write(out);
+        out.flush();
+        out.close();
+
+        // 2. Read objects from file
+        DataInputStream in = new DataInputStream(new FileInputStream(file));
+
+        ColumnList readList = ColumnList.read(in);
+        List<Column> columns = readList.columns;
+
+        Assert.assertEquals(3, columns.size());
+        Assert.assertEquals(c1, columns.get(0));
+        Assert.assertEquals(c2, columns.get(1));
+        Assert.assertEquals(c3, columns.get(2));
+    }
+
+}

--- a/fe/src/test/java/org/apache/doris/persist/gson/GsonDerivedClassSerializationTest.java
+++ b/fe/src/test/java/org/apache/doris/persist/gson/GsonDerivedClassSerializationTest.java
@@ -34,10 +34,6 @@ import java.util.Map;
  * register 2 derived classes to the factory. And then register the factory
  * to the GsonBuilder to create GSON instance.
  * 
- * Notice that there is a special field "clazz" in ParentClass. This field is used
- * to help the RuntimeTypeAdapterFactory to distinguish the kind of derived class.
- * This field's name should be specified when creating the RuntimeTypeAdapterFactory.
- * 
  */
 public class GsonDerivedClassSerializationTest {
     private static String fileName = "./GsonDerivedClassSerializationTest";
@@ -51,12 +47,10 @@ public class GsonDerivedClassSerializationTest {
     public static class ParentClass implements Writable {
         @SerializedName(value = "flag")
         public int flag = 0;
-        @SerializedName(value = "clazz")
-        public String clazz; // a specified field to save the type of derived classed
 
         public ParentClass(int flag, String clazz) {
             this.flag = flag;
-            this.clazz = clazz;
+            // this.clazz = clazz;
         }
 
         @Override
@@ -96,10 +90,32 @@ public class GsonDerivedClassSerializationTest {
         }
     }
 
+    public static class WrapperClass implements Writable {
+        @SerializedName(value = "tag")
+        public ParentClass clz;
+
+        public WrapperClass() {
+            clz = new ChildClassA(1, "child1");
+        }
+
+        @Override
+        public void write(DataOutput out) throws IOException {
+            String json = TEST_GSON.toJson(this);
+            System.out.println("write: " + json);
+            Text.writeString(out, json);
+        }
+
+        public static WrapperClass read(DataInput in) throws IOException {
+            String json = Text.readString(in);
+            System.out.println("read: " + json);
+            return TEST_GSON.fromJson(json, WrapperClass.class);
+        }
+    }
+
     private static RuntimeTypeAdapterFactory<ParentClass> runtimeTypeAdapterFactory = RuntimeTypeAdapterFactory
-            // the "clazz" here is the name of "clazz" field in ParentClass.
+            // the "clazz" is a custom defined name
             .of(ParentClass.class, "clazz")
-            // register 2 derived classes, the second parameter must be same to the value of field "clazz"
+            // register 2 derived classes, the second parameter will be the value of "clazz"
             .registerSubtype(ChildClassA.class, ChildClassA.class.getSimpleName())
             .registerSubtype(ChildClassB.class, ChildClassB.class.getSimpleName());
 
@@ -150,6 +166,24 @@ public class GsonDerivedClassSerializationTest {
         Assert.assertEquals(2, ((ChildClassB) parentClass).mapB.size());
         Assert.assertEquals("B1", ((ChildClassB) parentClass).mapB.get(1L));
         Assert.assertEquals("B2", ((ChildClassB) parentClass).mapB.get(2L));
+    }
+
+    @Test
+    public void testWrapperClass() throws IOException {
+        // 1. Write objects to file
+        File file = new File(fileName);
+        file.createNewFile();
+        DataOutputStream out = new DataOutputStream(new FileOutputStream(file));
+
+        WrapperClass wrapperClass = new WrapperClass();
+        wrapperClass.write(out);
+        out.flush();
+        out.close();
+
+        // 2. Read objects from file
+        DataInputStream in = new DataInputStream(new FileInputStream(file));
+        WrapperClass readWrapperClass = WrapperClass.read(in);
+        Assert.assertEquals(1, ((ChildClassA) readWrapperClass.clz).flag);
     }
 
 }

--- a/fe/src/test/java/org/apache/doris/persist/gson/GsonDerivedClassSerializationTest.java
+++ b/fe/src/test/java/org/apache/doris/persist/gson/GsonDerivedClassSerializationTest.java
@@ -50,7 +50,6 @@ public class GsonDerivedClassSerializationTest {
 
         public ParentClass(int flag, String clazz) {
             this.flag = flag;
-            // this.clazz = clazz;
         }
 
         @Override


### PR DESCRIPTION
"Type" is a abstract class, it has 4 sub classes:
1. ScalarType
2. ArrayType
3. MapType
4. StructType

This CL only support `ScalarType`. Other types can be added later.

ISSUE #2708