### PR TITLE
Add .clang-format and docs

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,91 @@
+---
+Language:        Cpp
+# BasedOnStyle:  Google
+AccessModifierOffset: -4
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+#AlignConsecutiveMacros: true # ver >= 9
+AlignEscapedNewlinesLeft: true
+AlignOperands:   true
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: true
+AllowShortLoopsOnASingleLine: true
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: true
+AlwaysBreakTemplateDeclarations: true
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:
+  AfterClass:      false
+  AfterControlStatement: false
+  AfterEnum:       false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  BeforeCatch:     false
+  BeforeElse:      false
+  IndentBraces:    false
+BreakBeforeBinaryOperators: NonAssignment
+BreakBeforeBraces: Attach
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializers: AfterColon # ver >= 8
+ColumnLimit:     100
+CommentPragmas:  '^ IWYU pragma:'
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: false
+ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH ]
+IncludeCategories:
+  - Regex:           '^<.*\.h>'
+    Priority:        1
+  - Regex:           '^<.*'
+    Priority:        2
+  - Regex:           '.*'
+    Priority:        3
+IndentCaseLabels: true
+IndentWidth:     4
+IndentWrappedFunctionNames: false
+KeepEmptyLinesAtTheStartOfBlocks: false
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: false
+PenaltyBreakBeforeFirstCallParameter: 1
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 200
+PointerAlignment: Left
+ReflowComments:  false
+SortIncludes:    false
+SortUsingDeclarations: false
+SpaceAfterCStyleCast: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 2
+SpacesInAngles:  false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Auto
+TabWidth:        8
+UseTab:          Never
+...

--- a/.clang-format
+++ b/.clang-format
@@ -86,6 +86,6 @@ SpacesInCStyleCastParentheses: false
 SpacesInParentheses: false
 SpacesInSquareBrackets: false
 Standard:        Auto
-TabWidth:        8
+TabWidth:        4
 UseTab:          Never
 ...

--- a/docs/documentation/cn/developer-guide/format-code.md
+++ b/docs/documentation/cn/developer-guide/format-code.md
@@ -1,0 +1,66 @@
+<!-- 
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# 代码格式化
+为了自动格式化代码，推荐使用clang-format进行代码格式化。
+
+## 代码风格定制
+Doris的代码风格在Google Style的基础上稍有改动，定制为.clang-format文件，位于Doris根目录。
+
+目前，.clang-format配置文件适配clang-format-8.0.1以上的版本。
+
+## 环境准备
+需要下载安装clang-format，也可使用IDE或Editor提供的clang-format插件，下面分别介绍。
+
+### 下载安装clang-format
+Ubuntu: `apt-get install clang-format` 
+
+当前版本为10.0，也可指定旧版本，例如: `apt-get install clang-format-9`
+
+Centos 7: 
+
+centos yum安装的clang-format版本过老，支持的StyleOption太少，建议源码编译10.0版本。
+
+### clang-format插件
+Clion IDE可使用插件"ClangFormat"，`File->Setting->Plugins`搜索下载。但版本无法和
+clang-format程序的版本匹配，从支持的StyleOption上看，应该是低于clang-format-9.0。
+
+## 使用方式
+
+### 命令行运行
+`clang-format --style=file -i $File$` 
+
+`--sytle=file`就会自动找到.clang-format文件，根据文件Option配置来格式化代码。
+
+批量文件clang-format时，需注意过滤不应该格式化的文件。例如，只格式化*.h/*.cpp，并排除某些文件夹：
+
+`find . -type f -not \( -wholename ./env/* \) -regextype posix-egrep -regex
+ ".*\.(cpp|h)" | xargs clang-format -i -style=file`
+
+### 在IDE或Editor中使用clang-format
+#### Clion
+Clion如果使用插件，点击`Reformat Code`即可。
+#### VS Code
+VS Code需安装扩展程序Clang-Format，但需要自行提供clang-format执行程序的位置。
+
+```
+"clang-format.executable":  "$clang-format path$",
+"clang-format.style": "file"
+```
+然后，点击`Format Document`即可。

--- a/docs/documentation/en/developer-guide/format-code.md
+++ b/docs/documentation/en/developer-guide/format-code.md
@@ -1,0 +1,78 @@
+<!-- 
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Format Code
+To automatically format the code, clang-format is a good choice.
+
+## Code Style
+Doris Code Style is based on Google's, makes a few changes. The customized .clang-format
+file is in the root dir of Doris.
+Now, .clang-format file only works on clang-format-8.0.1+.
+
+## Preparing
+You should install clang-format, or you can use clang-format plugins which support by IDEs or Editors.
+
+### Install clang-format
+Ubuntu: `apt-get install clang-format` 
+
+The current release is 10.0, you can specify old version, e.g.
+ 
+ `apt-get install clang-format-9`
+
+Centos 7: 
+
+The version of clang-format installed by yum is too old. Compiling clang from source
+is recommended.
+
+### Clang-format plugins
+Clion IDE supports the plugin "ClangFormat", you can search in `File->Setting->Plugins`
+ and download it.
+But the version is not match with clang-format. Judging from the options supported, 
+the version is lower than clang-format-9.0.
+
+## Usage
+
+### CMD
+`clang-format --style=file -i $File$` 
+
+When using `-style=file`, clang-format for each input file will try to find the 
+.clang-format file located in the closest parent directory of the input file. 
+When the standard input is used, the search is started from the current directory.
+
+Note: filter out the files which should not be formatted, when batch clang-formating
+ files. 
+ 
+ A example of how to filter \*.h/\*.cpp and exclude some dirs:
+ 
+`find . -type f -not \( -wholename ./env/* \) -regextype posix-egrep -regex
+ ".*\.(cpp|h)" | xargs clang-format -i -style=file`
+
+### Using clang-format in IDEs or Editors
+#### Clion
+If using the plugin 'ClangFormat' in Clion, choose `Reformat Code` or press the keyboard 
+shortcut.
+#### VS Code
+VS Code needs install the extension 'Clang-Format', and specify the executable path of 
+clang-format in settings.
+
+```
+"clang-format.executable":  "$clang-format path$",
+"clang-format.style": "file"
+```
+Then, choose `Format Document`.


### PR DESCRIPTION
#2272 
The problem of inconsistence style in Doris code is too big, it's hard to minimize modification when reformatting code.
So here, our aim is to make the style rules, tune the config in .clang-format.

Note: I choose clang-format-8.0+ to support richer  sytle options.