### PR TITLE
Ignore the null type when getCmpType

### DIFF
--- a/fe/src/main/java/org/apache/doris/catalog/Type.java
+++ b/fe/src/main/java/org/apache/doris/catalog/Type.java
@@ -943,9 +943,15 @@ public abstract class Type {
     }
 
     public static Type getCmpType(Type t1, Type t2) {
+        if (t1.getPrimitiveType() == PrimitiveType.NULL_TYPE) {
+            return t2;
+        }
+        if (t2.getPrimitiveType() == PrimitiveType.NULL_TYPE) {
+            return t1;
+        }
+
         PrimitiveType t1ResultType = t1.getResultType().getPrimitiveType();
         PrimitiveType t2ResultType = t2.getResultType().getPrimitiveType();
-
         // Following logical is compatible with MySQL.
         if ((t1ResultType == PrimitiveType.VARCHAR && t2ResultType == PrimitiveType.VARCHAR)) {
             return Type.VARCHAR; 


### PR DESCRIPTION
In previous versions, if the children of the IN predicate included NULL, all child types would be converted to DOUBLE for calculation.
For example:
select * from t1 where k1 in ('TABLE', NULL);
But children like varchar cannot be converted to double, so the query cannot be executed.
The error is "TABLE is not a number"

The current version, if null exists in the child, it will not enter the calculation of compatibility type.
For the above query, the compatibility type is varchar, so the 'TABLE' is not converted to double, and the query could be executed.

Also, for JDBC. It will convert 'show tables;' to :
```
SELECT
TABLE_SCHEMA AS TABLE_CAT, NULL AS TABLE_SCHEM, TABLE_NAME,
 CASE WHEN TABLE_TYPE='BASE TABLE'
 THEN CASE WHEN TABLE_SCHEMA = 'mysql' OR TABLE_SCHEMA = 'performance_schema'
 THEN 'SYSTEM TABLE' ELSE 'TABLE'END WHEN TABLE_TYPE='TEMPORARY'
 THEN 'LOCAL_TEMPORARY' ELSE TABLE_TYPE END AS TABLE_TYPE, TABLE_COMMENT AS REMARKS, NULL AS TYPE_CAT, NULL AS TYPE_SCHEM, NULL AS TYPE_NAME, NULL AS SELF_REFERENCING_COL_NAME, NULL AS REF_GENERATION
 FROM INFORMATION_SCHEMA.TABLES
 WHERE TABLE_SCHEMA LIKE 'test_db'
 AND TABLE_NAME LIKE '%'
 HAVING TABLE_TYPE IN ('TABLE','VIEW',null,null,null)
 ORDER BY TABLE_TYPE, TABLE_SCHEMA, TABLE_NAME
```
In previous version, Doris could not return the correct tables to JDBC. It will thrown the error "'TABLE' is not a number".
After this commit, #2729 is fixed. Doris could return the tables schema by JDBC.