### PR TITLE
Replace PowerMock/EasyMock by Jmockit (2/4)

### DIFF
--- a/fe/src/test/java/org/apache/doris/analysis/CreateTableStmtTest.java
+++ b/fe/src/test/java/org/apache/doris/analysis/CreateTableStmtTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.analysis;
 
+import mockit.Expectations;
 import org.apache.doris.catalog.KeysType;
 import org.apache.doris.catalog.PrimitiveType;
 import org.apache.doris.catalog.ScalarType;
@@ -28,7 +29,6 @@ import org.apache.doris.qe.ConnectContext;
 
 import com.google.common.collect.Lists;
 
-import org.easymock.EasyMock;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -111,16 +111,23 @@ public class CreateTableStmtTest {
     }
     
     @Test(expected = AnalysisException.class)
-    public void testNoDb() throws UserException, AnalysisException {
+    public void testNoDb(@Mocked Analyzer noDbAnalyzer) throws UserException, AnalysisException {
         // make defalut db return empty;
-        analyzer = EasyMock.createMock(Analyzer.class);
-        EasyMock.expect(analyzer.getDefaultDb()).andReturn("").anyTimes();
-        EasyMock.expect(analyzer.getClusterName()).andReturn("cluster").anyTimes();
-        EasyMock.replay(analyzer);
+        new Expectations() {
+            {
+                noDbAnalyzer.getDefaultDb();
+                minTimes = 0;
+                result = "";
+
+                noDbAnalyzer.getClusterName();
+                minTimes = 0;
+                result = "cluster";
+            }
+        };
         CreateTableStmt stmt = new CreateTableStmt(false, false, tblNameNoDb, cols, "olap",
                 new KeysDesc(KeysType.AGG_KEYS, colsName), null,
                 new RandomDistributionDesc(10), null, null, "");
-        stmt.analyze(analyzer);
+        stmt.analyze(noDbAnalyzer);
     }
     
     @Test(expected = AnalysisException.class)

--- a/fe/src/test/java/org/apache/doris/analysis/ShowPartitionsStmtTest.java
+++ b/fe/src/test/java/org/apache/doris/analysis/ShowPartitionsStmtTest.java
@@ -7,17 +7,11 @@ import org.apache.doris.catalog.FakeCatalog;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.UserException;
 import org.apache.doris.system.SystemInfoService;
-import org.easymock.EasyMock;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-import org.junit.runner.RunWith;
-import org.powermock.api.easymock.PowerMock;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.util.Arrays;
 

--- a/fe/src/test/java/org/apache/doris/catalog/ColumnTest.java
+++ b/fe/src/test/java/org/apache/doris/catalog/ColumnTest.java
@@ -20,15 +20,10 @@ package org.apache.doris.catalog;
 import org.apache.doris.common.DdlException;
 import org.apache.doris.common.FeConstants;
 
-import org.easymock.EasyMock;
+import org.apache.doris.common.jmockit.Deencapsulation;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.powermock.api.easymock.PowerMock;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
@@ -36,21 +31,19 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 
-@RunWith(PowerMockRunner.class)
-@PowerMockIgnore({ "org.apache.log4j.*", "javax.management.*" })
-@PrepareForTest(Catalog.class)
 public class ColumnTest {
     
     private Catalog catalog;
 
+    private FakeCatalog fakeCatalog;
+
     @Before
     public void setUp() {
-        catalog = EasyMock.createMock(Catalog.class);
+        fakeCatalog = new FakeCatalog();
+        catalog = Deencapsulation.newInstance(Catalog.class);
 
-        PowerMock.mockStatic(Catalog.class);
-        EasyMock.expect(Catalog.getInstance()).andReturn(catalog).anyTimes();
-        EasyMock.expect(Catalog.getCurrentCatalogJournalVersion()).andReturn(FeConstants.meta_version).anyTimes();
-        PowerMock.replay(Catalog.class);
+        FakeCatalog.setCatalog(catalog);
+        FakeCatalog.setMetaVersion(FeConstants.meta_version);
     }
 
     @Test

--- a/fe/src/test/java/org/apache/doris/catalog/ColumnTypeTest.java
+++ b/fe/src/test/java/org/apache/doris/catalog/ColumnTypeTest.java
@@ -27,25 +27,16 @@ import org.apache.doris.analysis.TypeDef;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.FeConstants;
 
-import org.easymock.EasyMock;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.powermock.api.easymock.PowerMock;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
-@RunWith(PowerMockRunner.class)
-@PowerMockIgnore({ "org.apache.log4j.*", "javax.management.*" })
-@PrepareForTest(Catalog.class)
 public class ColumnTypeTest {
+    private FakeCatalog fakeCatalog;
     @Before
     public void setUp() {
-        PowerMock.mockStatic(Catalog.class);
-        EasyMock.expect(Catalog.getCurrentCatalogJournalVersion()).andReturn(FeConstants.meta_version).anyTimes();
-        PowerMock.replay(Catalog.class);
+        fakeCatalog = new FakeCatalog();
+        FakeCatalog.setMetaVersion(FeConstants.meta_version);
     }
 
     @Test

--- a/fe/src/test/java/org/apache/doris/catalog/MysqlTableTest.java
+++ b/fe/src/test/java/org/apache/doris/catalog/MysqlTableTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.catalog;
 
+import mockit.Mocked;
 import org.apache.doris.common.DdlException;
 import org.apache.doris.common.FeConstants;
 
@@ -24,15 +25,9 @@ import com.google.common.base.Predicate;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 
-import org.easymock.EasyMock;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.powermock.api.easymock.PowerMock;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.io.BufferedInputStream;
 import java.io.DataInputStream;
@@ -44,14 +39,14 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
-@RunWith(PowerMockRunner.class)
-@PowerMockIgnore({ "org.apache.log4j.*", "javax.management.*" })
-@PrepareForTest(Catalog.class)
 public class MysqlTableTest {
     private List<Column> columns;
     private Map<String, String> properties;
 
+    @Mocked
     private Catalog catalog;
+
+    private FakeCatalog fakeCatalog;
 
     @Before
     public void setUp() {
@@ -68,11 +63,9 @@ public class MysqlTableTest {
         properties.put("database", "db");
         properties.put("table", "tbl");
 
-        catalog = EasyMock.createMock(Catalog.class);
-        PowerMock.mockStatic(Catalog.class);
-        EasyMock.expect(Catalog.getInstance()).andReturn(catalog).anyTimes();
-        EasyMock.expect(Catalog.getCurrentCatalogJournalVersion()).andReturn(FeConstants.meta_version).anyTimes();
-        PowerMock.replay(Catalog.class);
+        fakeCatalog = new FakeCatalog();
+        FakeCatalog.setCatalog(catalog);
+        FakeCatalog.setMetaVersion(FeConstants.meta_version);
     }
 
     @Test

--- a/fe/src/test/java/org/apache/doris/catalog/PartitionKeyTest.java
+++ b/fe/src/test/java/org/apache/doris/catalog/PartitionKeyTest.java
@@ -31,19 +31,10 @@ import java.util.List;
 import java.util.TimeZone;
 
 import org.apache.doris.common.FeConstants;
-import org.easymock.EasyMock;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.powermock.api.easymock.PowerMock;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
-@RunWith(PowerMockRunner.class)
-@PowerMockIgnore({ "org.apache.log4j.*", "javax.management.*"  })
-@PrepareForTest(Catalog.class)
 public class PartitionKeyTest {
 
     private static List<Column> allColumns;
@@ -159,11 +150,8 @@ public class PartitionKeyTest {
 
     @Test
     public void testSerialization() throws Exception {
-        catalog = EasyMock.createMock(Catalog.class);
-        PowerMock.mockStatic(Catalog.class);
-        EasyMock.expect(Catalog.getInstance()).andReturn(catalog).anyTimes();
-        EasyMock.expect(Catalog.getCurrentCatalogJournalVersion()).andReturn(FeConstants.meta_version).anyTimes();
-        PowerMock.replay(Catalog.class);
+        FakeCatalog fakeCatalog = new FakeCatalog();
+        FakeCatalog.setMetaVersion(FeConstants.meta_version);
 
         // 1. Write objects to file
         File file = new File("./keyRangePartition");

--- a/fe/src/test/java/org/apache/doris/catalog/TableTest.java
+++ b/fe/src/test/java/org/apache/doris/catalog/TableTest.java
@@ -27,31 +27,23 @@ import java.io.FileOutputStream;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.easymock.EasyMock;
+import org.apache.doris.common.jmockit.Deencapsulation;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.powermock.api.easymock.PowerMock;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
-@RunWith(PowerMockRunner.class)
-@PowerMockIgnore({ "org.apache.log4j.*", "javax.management.*" })
-@PrepareForTest(Catalog.class)
 public class TableTest {
+    private FakeCatalog fakeCatalog;
 
     private Catalog catalog;
 
     @Before
     public void setUp() {
-        catalog = EasyMock.createMock(Catalog.class);
+        fakeCatalog = new FakeCatalog();
+        catalog = Deencapsulation.newInstance(Catalog.class);
 
-        PowerMock.mockStatic(Catalog.class);
-        EasyMock.expect(Catalog.getInstance()).andReturn(catalog).anyTimes();
-        EasyMock.expect(Catalog.getCurrentCatalogJournalVersion()).andReturn(FeConstants.meta_version).anyTimes();
-        PowerMock.replay(Catalog.class);
+        FakeCatalog.setCatalog(catalog);
+        FakeCatalog.setMetaVersion(FeConstants.meta_version);
     }
 
     @Test

--- a/fe/src/test/java/org/apache/doris/catalog/UserPropertyTest.java
+++ b/fe/src/test/java/org/apache/doris/catalog/UserPropertyTest.java
@@ -25,14 +25,8 @@ import org.apache.doris.mysql.privilege.UserProperty;
 
 import com.google.common.collect.Lists;
 
-import org.easymock.EasyMock;
 import org.junit.Assert;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.powermock.api.easymock.PowerMock;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -41,16 +35,13 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 import java.util.List;
 
-@RunWith(PowerMockRunner.class)
-@PowerMockIgnore({ "org.apache.log4j.*", "javax.management.*" })
-@PrepareForTest({ Catalog.class })
 public class UserPropertyTest {
+    private FakeCatalog fakeCatalog;
     @Test
     public void testNormal() throws IOException, DdlException {
         // mock catalog
-        PowerMock.mockStatic(Catalog.class);
-        EasyMock.expect(Catalog.getCurrentCatalogJournalVersion()).andReturn(FeConstants.meta_version).anyTimes();
-        PowerMock.replay(Catalog.class);
+        fakeCatalog = new FakeCatalog();
+        FakeCatalog.setMetaVersion(FeConstants.meta_version);
 
         UserProperty property = new UserProperty("root");
         property.getResource().updateGroupShare("low", 991);

--- a/fe/src/test/java/org/apache/doris/cluster/SystemInfoServiceTest.java
+++ b/fe/src/test/java/org/apache/doris/cluster/SystemInfoServiceTest.java
@@ -19,7 +19,6 @@ package org.apache.doris.cluster;
 
 import mockit.Expectations;
 import mockit.Mocked;
-import org.apache.doris.analysis.AccessTestUtil;
 import org.apache.doris.analysis.AddBackendClause;
 import org.apache.doris.analysis.Analyzer;
 import org.apache.doris.analysis.DropBackendClause;
@@ -36,15 +35,9 @@ import org.apache.doris.system.SystemInfoService;
 
 import com.google.common.collect.Lists;
 
-import org.easymock.EasyMock;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.powermock.api.easymock.PowerMock;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.io.BufferedInputStream;
 import java.io.DataInputStream;

--- a/fe/src/test/java/org/apache/doris/common/proc/BackendProcNodeTest.java
+++ b/fe/src/test/java/org/apache/doris/common/proc/BackendProcNodeTest.java
@@ -17,6 +17,8 @@
 
 package org.apache.doris.common.proc;
 
+import mockit.Expectations;
+import mockit.Mocked;
 import org.apache.doris.catalog.Catalog;
 import org.apache.doris.catalog.DiskInfo;
 import org.apache.doris.common.AnalysisException;
@@ -27,48 +29,50 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 
-import org.easymock.EasyMock;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.powermock.api.easymock.PowerMock;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.util.Map;
 
-@RunWith(PowerMockRunner.class)
-@PowerMockIgnore({ "org.apache.log4j.*", "javax.management.*" })
-@PrepareForTest(Catalog.class)
 public class BackendProcNodeTest {
     private Backend b1;
+    @Mocked
     private Catalog catalog;
+    @Mocked
     private EditLog editLog;
 
     @Before
     public void setUp() {
-        editLog = EasyMock.createMock(EditLog.class);
-        editLog.logAddBackend(EasyMock.anyObject(Backend.class));
-        EasyMock.expectLastCall().anyTimes();
-        editLog.logDropBackend(EasyMock.anyObject(Backend.class));
-        EasyMock.expectLastCall().anyTimes();
-        editLog.logBackendStateChange(EasyMock.anyObject(Backend.class));
-        EasyMock.expectLastCall().anyTimes();
-        EasyMock.replay(editLog);
+        new Expectations() {
+            {
+                editLog.logAddBackend((Backend) any);
+                minTimes = 0;
 
-        catalog = EasyMock.createMock(Catalog.class);
-        EasyMock.expect(catalog.getNextId()).andReturn(10000L).anyTimes();
-        EasyMock.expect(catalog.getEditLog()).andReturn(editLog).anyTimes();
-        catalog.clear();
-        EasyMock.expectLastCall().anyTimes();
-        EasyMock.replay(catalog);
+                editLog.logDropBackend((Backend) any);
+                minTimes = 0;
 
-        PowerMock.mockStatic(Catalog.class);
-        EasyMock.expect(Catalog.getInstance()).andReturn(catalog).anyTimes();
-        PowerMock.replay(Catalog.class);
+                editLog.logBackendStateChange((Backend) any);
+                minTimes = 0;
+
+                catalog.getNextId();
+                minTimes = 0;
+                result = 10000L;
+
+                catalog.getEditLog();
+                minTimes = 0;
+                result = editLog;
+            }
+        };
+
+        new Expectations(catalog) {
+            {
+                Catalog.getInstance();
+                minTimes = 0;
+                result = catalog;
+            }
+        };
 
         b1 = new Backend(1000, "host1", 10000);
         b1.updateOnce(10001, 10003, 10005);

--- a/fe/src/test/java/org/apache/doris/common/util/TimeUtilsTest.java
+++ b/fe/src/test/java/org/apache/doris/common/util/TimeUtilsTest.java
@@ -23,6 +23,7 @@ import org.apache.doris.catalog.ScalarType;
 import org.apache.doris.common.AnalysisException;
 
 import org.apache.doris.common.DdlException;
+import org.apache.doris.qe.VariableMgr;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -123,6 +124,7 @@ public class TimeUtilsTest {
 
     @Test
     public void testDateTrans() throws AnalysisException {
+        VariableMgr variableMgr = new VariableMgr();
         Assert.assertEquals("N/A", TimeUtils.longToTimeString(-2));
 
         long timestamp = 1426125600000L;

--- a/fe/src/test/java/org/apache/doris/common/util/TimeUtilsTest.java
+++ b/fe/src/test/java/org/apache/doris/common/util/TimeUtilsTest.java
@@ -17,13 +17,15 @@
 
 package org.apache.doris.common.util;
 
+import mockit.Expectations;
+import mockit.Mocked;
 import org.apache.doris.analysis.DateLiteral;
 import org.apache.doris.catalog.PrimitiveType;
 import org.apache.doris.catalog.ScalarType;
 import org.apache.doris.common.AnalysisException;
 
 import org.apache.doris.common.DdlException;
-import org.apache.doris.qe.VariableMgr;
+import org.apache.doris.qe.ConnectContext;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -123,8 +125,14 @@ public class TimeUtilsTest {
     }
 
     @Test
-    public void testDateTrans() throws AnalysisException {
-        VariableMgr variableMgr = new VariableMgr();
+    public void testDateTrans(@Mocked ConnectContext ctx) throws AnalysisException {
+        new Expectations(ctx) {
+            {
+                ConnectContext.get();
+                minTimes = 0;
+                result = new ConnectContext(null);
+            }
+        };
         Assert.assertEquals("N/A", TimeUtils.longToTimeString(-2));
 
         long timestamp = 1426125600000L;

--- a/fe/src/test/java/org/apache/doris/common/util/TimeUtilsTest.java
+++ b/fe/src/test/java/org/apache/doris/common/util/TimeUtilsTest.java
@@ -17,8 +17,7 @@
 
 package org.apache.doris.common.util;
 
-import mockit.Expectations;
-import mockit.Mocked;
+import mockit.MockUp;
 import org.apache.doris.analysis.DateLiteral;
 import org.apache.doris.catalog.PrimitiveType;
 import org.apache.doris.catalog.ScalarType;
@@ -26,13 +25,31 @@ import org.apache.doris.common.AnalysisException;
 
 import org.apache.doris.common.DdlException;
 import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.qe.SessionVariable;
+import org.apache.doris.qe.VariableMgr;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.util.LinkedList;
 import java.util.List;
 
 public class TimeUtilsTest {
+
+    @Before
+    public void setUp() {
+        new MockUp<VariableMgr>() {
+            SessionVariable newSessionVariable() {
+                return new SessionVariable();
+            }
+        };
+
+        new MockUp<ConnectContext>() {
+            ConnectContext get() {
+                return new ConnectContext(null);
+            }
+        };
+    }
 
     @Test
     public void testNormal() {
@@ -125,14 +142,7 @@ public class TimeUtilsTest {
     }
 
     @Test
-    public void testDateTrans(@Mocked ConnectContext ctx) throws AnalysisException {
-        new Expectations(ctx) {
-            {
-                ConnectContext.get();
-                minTimes = 0;
-                result = new ConnectContext(null);
-            }
-        };
+    public void testDateTrans() throws AnalysisException {
         Assert.assertEquals("N/A", TimeUtils.longToTimeString(-2));
 
         long timestamp = 1426125600000L;

--- a/fe/src/test/java/org/apache/doris/common/util/TimeUtilsTest.java
+++ b/fe/src/test/java/org/apache/doris/common/util/TimeUtilsTest.java
@@ -17,36 +17,36 @@
 
 package org.apache.doris.common.util;
 
-import mockit.MockUp;
+import mockit.Expectations;
+import mockit.Mocked;
 import org.apache.doris.analysis.DateLiteral;
 import org.apache.doris.catalog.PrimitiveType;
 import org.apache.doris.catalog.ScalarType;
 import org.apache.doris.common.AnalysisException;
 
 import org.apache.doris.common.DdlException;
-import org.apache.doris.qe.ConnectContext;
-import org.apache.doris.qe.SessionVariable;
-import org.apache.doris.qe.VariableMgr;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.time.ZoneId;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.TimeZone;
 
 public class TimeUtilsTest {
 
+    @Mocked
+    TimeUtils timeUtils;
+
     @Before
     public void setUp() {
-        new MockUp<VariableMgr>() {
-            SessionVariable newSessionVariable() {
-                return new SessionVariable();
-            }
-        };
-
-        new MockUp<ConnectContext>() {
-            ConnectContext get() {
-                return new ConnectContext(null);
+        TimeZone tz = TimeZone.getTimeZone(ZoneId.of("Asia/Shanghai"));
+        new Expectations(timeUtils) {
+            {
+                TimeUtils.getTimeZone();
+                minTimes = 0;
+                result = tz;
             }
         };
     }

--- a/fe/src/test/java/org/apache/doris/load/LoadCheckerTest.java
+++ b/fe/src/test/java/org/apache/doris/load/LoadCheckerTest.java
@@ -104,6 +104,9 @@ public class LoadCheckerTest {
                 result = catalog;
             }
         };
+
+        AgentTaskQueue.clearAllTasks();
+        Assert.assertEquals(0, AgentTaskQueue.getTaskNum());
     }
 
     @After

--- a/fe/src/test/java/org/apache/doris/load/LoadJobTest.java
+++ b/fe/src/test/java/org/apache/doris/load/LoadJobTest.java
@@ -22,7 +22,7 @@ import org.apache.doris.analysis.BinaryPredicate.Operator;
 import org.apache.doris.analysis.Predicate;
 import org.apache.doris.analysis.SlotRef;
 import org.apache.doris.analysis.StringLiteral;
-import org.apache.doris.catalog.Catalog;
+import org.apache.doris.catalog.FakeCatalog;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.FeConstants;
 import org.apache.doris.common.util.UnitTestUtil;
@@ -30,16 +30,10 @@ import org.apache.doris.load.LoadJob.JobState;
 import org.apache.doris.metric.MetricRepo;
 import org.apache.doris.persist.ReplicaPersistInfo;
 
-import org.easymock.EasyMock;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.powermock.api.easymock.PowerMock;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
@@ -51,9 +45,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-@RunWith(PowerMockRunner.class)
-@PowerMockIgnore({ "org.apache.log4j.*", "javax.management.*" })
-@PrepareForTest({Catalog.class})
 public class LoadJobTest {
 
     @BeforeClass
@@ -144,9 +135,8 @@ public class LoadJobTest {
     @Test
     public void testSerialization() throws Exception {
         // mock meta version
-        PowerMock.mockStatic(Catalog.class);
-        EasyMock.expect(Catalog.getCurrentCatalogJournalVersion()).andReturn(FeConstants.meta_version).anyTimes();
-        PowerMock.replay(Catalog.class);
+        FakeCatalog fakeCatalog = new FakeCatalog();
+        FakeCatalog.setMetaVersion(FeConstants.meta_version);
 
         File file = new File("./loadJobTest" + System.currentTimeMillis());
         file.createNewFile();

--- a/fe/src/test/java/org/apache/doris/load/TabletLoadInfoTest.java
+++ b/fe/src/test/java/org/apache/doris/load/TabletLoadInfoTest.java
@@ -17,17 +17,11 @@
 
 package org.apache.doris.load;
 
-import org.apache.doris.catalog.Catalog;
+import org.apache.doris.catalog.FakeCatalog;
 import org.apache.doris.common.FeConstants;
 
-import org.easymock.EasyMock;
 import org.junit.Assert;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.powermock.api.easymock.PowerMock;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
@@ -35,17 +29,13 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 
-@RunWith(PowerMockRunner.class)
-@PowerMockIgnore({ "org.apache.log4j.*", "javax.management.*" })
-@PrepareForTest({ Catalog.class })
 public class TabletLoadInfoTest {
-
+    private FakeCatalog fakeCatalog;
     @Test
     public void testSerialization() throws Exception {
         // mock catalog
-        PowerMock.mockStatic(Catalog.class);
-        EasyMock.expect(Catalog.getCurrentCatalogJournalVersion()).andReturn(FeConstants.meta_version).anyTimes();
-        PowerMock.replay(Catalog.class);
+        fakeCatalog = new FakeCatalog();
+        FakeCatalog.setMetaVersion(FeConstants.meta_version);
 
         // test
         File file = new File("./tabletLoadInfoTest");

--- a/fe/src/test/java/org/apache/doris/persist/CreateTableInfoTest.java
+++ b/fe/src/test/java/org/apache/doris/persist/CreateTableInfoTest.java
@@ -25,21 +25,16 @@ import java.io.FileOutputStream;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.doris.catalog.FakeCatalog;
 import org.apache.doris.catalog.ScalarType;
-import org.easymock.EasyMock;
+import org.apache.doris.common.jmockit.Deencapsulation;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.powermock.api.easymock.PowerMock;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 import org.apache.doris.catalog.AggregateType;
 import org.apache.doris.catalog.Catalog;
 import org.apache.doris.catalog.Column;
-import org.apache.doris.catalog.ScalarType;
 import org.apache.doris.catalog.KeysType;
 import org.apache.doris.catalog.MaterializedIndex;
 import org.apache.doris.catalog.OlapTable;
@@ -50,20 +45,18 @@ import org.apache.doris.catalog.SinglePartitionInfo;
 import org.apache.doris.catalog.MaterializedIndex.IndexState;
 import org.apache.doris.common.FeConstants;
 
-@RunWith(PowerMockRunner.class)
-@PowerMockIgnore({ "org.apache.log4j.*", "javax.management.*" })
-@PrepareForTest(Catalog.class)
 public class CreateTableInfoTest {
     private Catalog catalog;
 
+    private FakeCatalog fakeCatalog;
+
     @Before
     public void setUp() {
-        catalog = EasyMock.createMock(Catalog.class);
+        fakeCatalog = new FakeCatalog();
+        catalog = Deencapsulation.newInstance(Catalog.class);
 
-        PowerMock.mockStatic(Catalog.class);
-        EasyMock.expect(Catalog.getInstance()).andReturn(catalog).anyTimes();
-        EasyMock.expect(Catalog.getCurrentCatalogJournalVersion()).andReturn(FeConstants.meta_version).anyTimes();
-        PowerMock.replay(Catalog.class);
+        FakeCatalog.setCatalog(catalog);
+        FakeCatalog.setMetaVersion(FeConstants.meta_version);
     }
 
     @Test

--- a/fe/src/test/java/org/apache/doris/qe/ConnectContextTest.java
+++ b/fe/src/test/java/org/apache/doris/qe/ConnectContextTest.java
@@ -171,6 +171,9 @@ public class ConnectContextTest {
         Assert.assertTrue(ctx.isKilled());
         ctx.kill(false);
         Assert.assertTrue(ctx.isKilled());
+
+        // clean up
+        ctx.cleanup();
     }
 
     @Test
@@ -192,6 +195,9 @@ public class ConnectContextTest {
         // Kill
         ctx.kill(true);
         Assert.assertTrue(ctx.isKilled());
+
+        // clean up
+        ctx.cleanup();
     }
 
     @Test

--- a/fe/src/test/java/org/apache/doris/qe/ConnectSchedulerTest.java
+++ b/fe/src/test/java/org/apache/doris/qe/ConnectSchedulerTest.java
@@ -24,20 +24,12 @@ import org.apache.doris.analysis.AccessTestUtil;
 import org.apache.doris.mysql.MysqlChannel;
 import org.apache.doris.mysql.MysqlProto;
 
-import org.easymock.EasyMock;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.powermock.api.easymock.PowerMock;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
-import java.nio.ByteBuffer;
 import java.nio.channels.SocketChannel;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -117,7 +109,7 @@ public class ConnectSchedulerTest {
 
         ConnectScheduler scheduler = new ConnectScheduler(10);
 
-        ConnectContext context = new ConnectContext(EasyMock.createMock(SocketChannel.class));
+        ConnectContext context = new ConnectContext(socketChannel);
         context.setCatalog(AccessTestUtil.fetchAdminCatalog());
         context.setQualifiedUser("root");
         Assert.assertTrue(scheduler.submit(context));
@@ -136,7 +128,7 @@ public class ConnectSchedulerTest {
     @Test
     public void testSubmitTooMany() throws InterruptedException {
         ConnectScheduler scheduler = new ConnectScheduler(0);
-        ConnectContext context = new ConnectContext(EasyMock.createMock(SocketChannel.class));
+        ConnectContext context = new ConnectContext(socketChannel);
         Assert.assertTrue(scheduler.submit(context));
     }
 }

--- a/fe/src/test/java/org/apache/doris/qe/CoordinatorTest.java
+++ b/fe/src/test/java/org/apache/doris/qe/CoordinatorTest.java
@@ -17,6 +17,8 @@
 
 package org.apache.doris.qe;
 
+import mockit.Expectations;
+import mockit.Mocked;
 import org.apache.doris.analysis.Analyzer;
 import org.apache.doris.analysis.TupleDescriptor;
 import org.apache.doris.analysis.TupleId;
@@ -41,14 +43,8 @@ import org.apache.doris.thrift.TUniqueId;
 
 import com.google.common.collect.ImmutableMap;
 
-import org.easymock.EasyMock;
 import org.junit.Assert;
 import org.junit.BeforeClass;
-import org.junit.runner.RunWith;
-import org.powermock.api.easymock.PowerMock;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
@@ -58,17 +54,18 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-@RunWith(PowerMockRunner.class)
-@PowerMockIgnore({"org.apache.log4j.*", "javax.management.*"})
-@PrepareForTest({ Catalog.class, FrontendOptions.class })
 public class CoordinatorTest extends Coordinator {
     static Planner planner = new Planner();
     static ConnectContext context = new ConnectContext(null);
     static {
         context.setQueryId(new TUniqueId(1, 2));
     }
+    @Mocked
     static Catalog catalog;
+    @Mocked
     static EditLog editLog;
+    @Mocked
+    static FrontendOptions frontendOptions;
     static Analyzer analyzer = new Analyzer(catalog, null);
     static Backend backendA;
     static Backend backendB;
@@ -86,27 +83,42 @@ public class CoordinatorTest extends Coordinator {
             InvocationTargetException, NoSuchFieldException,
             SecurityException, NoSuchMethodException {
         coor = new Coordinator(context, analyzer, planner);
+        new Expectations() {
+            {
+                editLog.logAddBackend((Backend) any);
+                minTimes = 0;
 
-        editLog = EasyMock.createMock(EditLog.class);
-        editLog.logAddBackend(EasyMock.anyObject(Backend.class));
-        EasyMock.expectLastCall().anyTimes();
-        editLog.logDropBackend(EasyMock.anyObject(Backend.class));
-        EasyMock.expectLastCall().anyTimes();
-        editLog.logBackendStateChange(EasyMock.anyObject(Backend.class));
-        EasyMock.expectLastCall().anyTimes();
-        EasyMock.replay(editLog);
+                editLog.logDropBackend((Backend) any);
+                minTimes = 0;
 
-        catalog = EasyMock.createMock(Catalog.class);
-        EasyMock.expect(catalog.getEditLog()).andReturn(editLog).anyTimes();
-        EasyMock.replay(catalog);
+                editLog.logBackendStateChange((Backend) any);
+                minTimes = 0;
 
-        PowerMock.mockStatic(Catalog.class);
-        EasyMock.expect(Catalog.getInstance()).andReturn(catalog).anyTimes();
-        PowerMock.replay(Catalog.class);
+                catalog.getEditLog();
+                minTimes = 0;
+                result = editLog;
+            }
+        };
 
-        PowerMock.mockStatic(FrontendOptions.class);
-        EasyMock.expect(FrontendOptions.getLocalHostAddress()).andReturn("127.0.0.1").anyTimes();
-        PowerMock.replay(FrontendOptions.class);
+        new Expectations(catalog) {
+            {
+                Catalog.getInstance();
+                minTimes = 0;
+                result = catalog;
+
+                Catalog.getCurrentCatalogJournalVersion();
+                minTimes = 0;
+                result = FeConstants.meta_version;
+            }
+        };
+
+        new Expectations(frontendOptions) {
+            {
+                FrontendOptions.getLocalHostAddress();
+                minTimes = 0;
+                result = "127.0.0.1";
+            }
+        };
 
         FeConstants.heartbeat_interval_second = Integer.MAX_VALUE;
         backendA = new Backend(0, "machineA", 0);

--- a/fe/src/test/java/org/apache/doris/qe/ShowResultSetTest.java
+++ b/fe/src/test/java/org/apache/doris/qe/ShowResultSetTest.java
@@ -18,16 +18,17 @@
 package org.apache.doris.qe;
 
 import com.google.common.collect.Lists;
+import mockit.Mocked;
 import org.junit.Assert;
-import org.easymock.EasyMock;
 import org.junit.Test;
 
 import java.util.List;
 
 public class ShowResultSetTest {
+    @Mocked
+    ShowResultSetMetaData metaData;
     @Test
     public void testNormal() {
-        ShowResultSetMetaData metaData = EasyMock.createMock(ShowResultSetMetaData.class);
         List<List<String>> rows = Lists.newArrayList();
 
         rows.add(Lists.newArrayList("col1-0", "col2-0"));
@@ -45,7 +46,6 @@ public class ShowResultSetTest {
 
     @Test(expected = IndexOutOfBoundsException.class)
     public void testOutOfBound() {
-        ShowResultSetMetaData metaData = EasyMock.createMock(ShowResultSetMetaData.class);
         List<List<String>> rows = Lists.newArrayList();
 
         rows.add(Lists.newArrayList("col1-0", "col2-0"));
@@ -57,7 +57,6 @@ public class ShowResultSetTest {
 
     @Test(expected = NumberFormatException.class)
     public void testBadNumber() {
-        ShowResultSetMetaData metaData = EasyMock.createMock(ShowResultSetMetaData.class);
         List<List<String>> rows = Lists.newArrayList();
 
         rows.add(Lists.newArrayList(" 123", "456"));

--- a/fe/src/test/java/org/apache/doris/qe/VariableMgrTest.java
+++ b/fe/src/test/java/org/apache/doris/qe/VariableMgrTest.java
@@ -17,6 +17,8 @@
 
 package org.apache.doris.qe;
 
+import mockit.Expectations;
+import mockit.Mocked;
 import org.apache.doris.analysis.IntLiteral;
 import org.apache.doris.analysis.SetType;
 import org.apache.doris.analysis.SetVar;
@@ -27,42 +29,41 @@ import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.DdlException;
 import org.apache.doris.persist.EditLog;
 
-import org.easymock.EasyMock;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.powermock.api.easymock.PowerMock;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.List;
 
-@RunWith(PowerMockRunner.class)
-@PowerMockIgnore({ "org.apache.log4j.*", "javax.management.*" })
-@PrepareForTest({ Catalog.class })
 public class VariableMgrTest {
     private static final Logger LOG = LoggerFactory.getLogger(VariableMgrTest.class);
+    @Mocked
     private Catalog catalog;
+    @Mocked
+    private EditLog editLog;
 
     @Before
     public void setUp() {
-        catalog = EasyMock.createNiceMock(Catalog.class);
-        // mock editLog
-        EditLog editLog = EasyMock.createMock(EditLog.class);
-        EasyMock.expect(catalog.getEditLog()).andReturn(editLog).anyTimes();
-        editLog.logGlobalVariable(EasyMock.anyObject(SessionVariable.class));
-        EasyMock.expectLastCall().anyTimes();
-        EasyMock.replay(editLog);
-        // mock static getInstance
-        PowerMock.mockStatic(Catalog.class);
-        EasyMock.expect(Catalog.getInstance()).andReturn(catalog).anyTimes();
-        PowerMock.replay(Catalog.class);
+        new Expectations() {
+            {
+                catalog.getEditLog();
+                minTimes = 0;
+                result = editLog;
 
-        EasyMock.replay(catalog);
+                editLog.logGlobalVariable((SessionVariable) any);
+                minTimes = 0;
+            }
+        };
+
+        new Expectations(catalog) {
+            {
+                Catalog.getInstance();
+                minTimes = 0;
+                result = catalog;
+            }
+        };
     }
 
     @Test

--- a/fe/src/test/java/org/apache/doris/rewrite/FEFunctionsTest.java
+++ b/fe/src/test/java/org/apache/doris/rewrite/FEFunctionsTest.java
@@ -19,7 +19,9 @@ package org.apache.doris.rewrite;
 
 import static org.junit.Assert.fail;
 
+import mockit.Expectations;
 import mockit.MockUp;
+import mockit.Mocked;
 import org.apache.doris.analysis.DateLiteral;
 import org.apache.doris.analysis.DecimalLiteral;
 import org.apache.doris.analysis.FloatLiteral;
@@ -29,33 +31,33 @@ import org.apache.doris.analysis.StringLiteral;
 import org.apache.doris.catalog.Type;
 import org.apache.doris.common.AnalysisException;
 
-import org.apache.doris.qe.ConnectContext;
-import org.apache.doris.qe.SessionVariable;
-import org.apache.doris.qe.VariableMgr;
+import org.apache.doris.common.util.TimeUtils;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import java.time.ZoneId;
 import java.util.Locale;
+import java.util.TimeZone;
 
 public class FEFunctionsTest {
+
+    @Mocked
+    TimeUtils timeUtils;
 
     @Rule
     public ExpectedException expectedEx = ExpectedException.none();
 
     @Before
     public void setUp() {
-        new MockUp<VariableMgr>() {
-            SessionVariable newSessionVariable() {
-                return new SessionVariable();
-            }
-        };
-
-        new MockUp<ConnectContext>() {
-            ConnectContext get() {
-                return new ConnectContext(null);
+        TimeZone tz = TimeZone.getTimeZone(ZoneId.of("Asia/Shanghai"));
+        new Expectations(timeUtils) {
+            {
+                TimeUtils.getTimeZone();
+                minTimes = 0;
+                result = tz;
             }
         };
     }

--- a/fe/src/test/java/org/apache/doris/rewrite/FEFunctionsTest.java
+++ b/fe/src/test/java/org/apache/doris/rewrite/FEFunctionsTest.java
@@ -19,8 +19,7 @@ package org.apache.doris.rewrite;
 
 import static org.junit.Assert.fail;
 
-import mockit.Expectations;
-import mockit.Mocked;
+import mockit.MockUp;
 import org.apache.doris.analysis.DateLiteral;
 import org.apache.doris.analysis.DecimalLiteral;
 import org.apache.doris.analysis.FloatLiteral;
@@ -31,7 +30,10 @@ import org.apache.doris.catalog.Type;
 import org.apache.doris.common.AnalysisException;
 
 import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.qe.SessionVariable;
+import org.apache.doris.qe.VariableMgr;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -43,15 +45,23 @@ public class FEFunctionsTest {
     @Rule
     public ExpectedException expectedEx = ExpectedException.none();
 
-    @Test
-    public void unixtimestampTest(@Mocked ConnectContext ctx) {
-        new Expectations(ctx) {
-            {
-                ConnectContext.get();
-                minTimes = 0;
-                result = new ConnectContext(null);
+    @Before
+    public void setUp() {
+        new MockUp<VariableMgr>() {
+            SessionVariable newSessionVariable() {
+                return new SessionVariable();
             }
         };
+
+        new MockUp<ConnectContext>() {
+            ConnectContext get() {
+                return new ConnectContext(null);
+            }
+        };
+    }
+
+    @Test
+    public void unixtimestampTest() {
         try {
             IntLiteral timestamp = FEFunctions.unixTimestamp(new DateLiteral("2018-01-01", Type.DATE));
             Assert.assertEquals(1514736000, timestamp.getValue());
@@ -117,14 +127,7 @@ public class FEFunctionsTest {
     }
     
     @Test
-    public void fromUnixTimeTest(@Mocked ConnectContext ctx) throws AnalysisException {
-        new Expectations(ctx) {
-            {
-                ConnectContext.get();
-                minTimes = 0;
-                result = new ConnectContext(null);
-            }
-        };
+    public void fromUnixTimeTest() throws AnalysisException {
         StringLiteral actualResult = FEFunctions.fromUnixTime(new IntLiteral(100000));
         StringLiteral expectedResult = new StringLiteral("1970-01-02 11:46:40");
         Assert.assertEquals(expectedResult, actualResult);
@@ -527,14 +530,7 @@ public class FEFunctionsTest {
     }
 
     @Test
-    public void timeDiffTest(@Mocked ConnectContext ctx) throws AnalysisException {
-        new Expectations(ctx) {
-            {
-                ConnectContext.get();
-                minTimes = 0;
-                result = new ConnectContext(null);
-            }
-        };
+    public void timeDiffTest() throws AnalysisException {
         DateLiteral d1 = new DateLiteral("1019-02-28 00:00:00", Type.DATETIME);
         DateLiteral d2 = new DateLiteral("2019-02-28 00:00:00", Type.DATETIME);
         DateLiteral d3 = new DateLiteral("2019-03-28 00:00:00", Type.DATETIME);

--- a/fe/src/test/java/org/apache/doris/rewrite/FEFunctionsTest.java
+++ b/fe/src/test/java/org/apache/doris/rewrite/FEFunctionsTest.java
@@ -28,6 +28,7 @@ import org.apache.doris.analysis.StringLiteral;
 import org.apache.doris.catalog.Type;
 import org.apache.doris.common.AnalysisException;
 
+import org.apache.doris.qe.VariableMgr;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -42,6 +43,7 @@ public class FEFunctionsTest {
 
     @Test
     public void unixtimestampTest() {
+        VariableMgr variableMgr = new VariableMgr();
         try {
             IntLiteral timestamp = FEFunctions.unixTimestamp(new DateLiteral("2018-01-01", Type.DATE));
             Assert.assertEquals(1514736000, timestamp.getValue());
@@ -108,6 +110,7 @@ public class FEFunctionsTest {
     
     @Test
     public void fromUnixTimeTest() throws AnalysisException {
+        VariableMgr variableMgr = new VariableMgr();
         StringLiteral actualResult = FEFunctions.fromUnixTime(new IntLiteral(100000));
         StringLiteral expectedResult = new StringLiteral("1970-01-02 11:46:40");
         Assert.assertEquals(expectedResult, actualResult);
@@ -511,6 +514,7 @@ public class FEFunctionsTest {
 
     @Test
     public void timeDiffTest() throws AnalysisException {
+        VariableMgr variableMgr = new VariableMgr();
         DateLiteral d1 = new DateLiteral("1019-02-28 00:00:00", Type.DATETIME);
         DateLiteral d2 = new DateLiteral("2019-02-28 00:00:00", Type.DATETIME);
         DateLiteral d3 = new DateLiteral("2019-03-28 00:00:00", Type.DATETIME);

--- a/fe/src/test/java/org/apache/doris/rewrite/FEFunctionsTest.java
+++ b/fe/src/test/java/org/apache/doris/rewrite/FEFunctionsTest.java
@@ -19,6 +19,8 @@ package org.apache.doris.rewrite;
 
 import static org.junit.Assert.fail;
 
+import mockit.Expectations;
+import mockit.Mocked;
 import org.apache.doris.analysis.DateLiteral;
 import org.apache.doris.analysis.DecimalLiteral;
 import org.apache.doris.analysis.FloatLiteral;
@@ -28,7 +30,7 @@ import org.apache.doris.analysis.StringLiteral;
 import org.apache.doris.catalog.Type;
 import org.apache.doris.common.AnalysisException;
 
-import org.apache.doris.qe.VariableMgr;
+import org.apache.doris.qe.ConnectContext;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -42,8 +44,14 @@ public class FEFunctionsTest {
     public ExpectedException expectedEx = ExpectedException.none();
 
     @Test
-    public void unixtimestampTest() {
-        VariableMgr variableMgr = new VariableMgr();
+    public void unixtimestampTest(@Mocked ConnectContext ctx) {
+        new Expectations(ctx) {
+            {
+                ConnectContext.get();
+                minTimes = 0;
+                result = new ConnectContext(null);
+            }
+        };
         try {
             IntLiteral timestamp = FEFunctions.unixTimestamp(new DateLiteral("2018-01-01", Type.DATE));
             Assert.assertEquals(1514736000, timestamp.getValue());
@@ -109,8 +117,14 @@ public class FEFunctionsTest {
     }
     
     @Test
-    public void fromUnixTimeTest() throws AnalysisException {
-        VariableMgr variableMgr = new VariableMgr();
+    public void fromUnixTimeTest(@Mocked ConnectContext ctx) throws AnalysisException {
+        new Expectations(ctx) {
+            {
+                ConnectContext.get();
+                minTimes = 0;
+                result = new ConnectContext(null);
+            }
+        };
         StringLiteral actualResult = FEFunctions.fromUnixTime(new IntLiteral(100000));
         StringLiteral expectedResult = new StringLiteral("1970-01-02 11:46:40");
         Assert.assertEquals(expectedResult, actualResult);
@@ -513,8 +527,14 @@ public class FEFunctionsTest {
     }
 
     @Test
-    public void timeDiffTest() throws AnalysisException {
-        VariableMgr variableMgr = new VariableMgr();
+    public void timeDiffTest(@Mocked ConnectContext ctx) throws AnalysisException {
+        new Expectations(ctx) {
+            {
+                ConnectContext.get();
+                minTimes = 0;
+                result = new ConnectContext(null);
+            }
+        };
         DateLiteral d1 = new DateLiteral("1019-02-28 00:00:00", Type.DATETIME);
         DateLiteral d2 = new DateLiteral("2019-02-28 00:00:00", Type.DATETIME);
         DateLiteral d3 = new DateLiteral("2019-03-28 00:00:00", Type.DATETIME);


### PR DESCRIPTION
#2263

This commit replaces the PowerMock/EasyMock in our unit tests. (But not all)