### PR TITLE
[Alter View] Fix bug that alter view operation lost when replaying from image

### DIFF
--- a/fe/src/main/java/org/apache/doris/alter/Alter.java
+++ b/fe/src/main/java/org/apache/doris/alter/Alter.java
@@ -125,7 +125,6 @@ public class Alter {
         } finally {
             db.writeUnlock();
         }
-
     }
 
     public void processAlterTable(AlterTableStmt stmt) throws UserException {
@@ -380,7 +379,7 @@ public class Alter {
         String inlineViewDef = alterViewInfo.getInlineViewDef();
         List<Column> newFullSchema = alterViewInfo.getNewFullSchema();
 
-        Database db = Catalog.getInstance().getDb(dbId);
+        Database db = Catalog.getCurrentCatalog().getDb(dbId);
         db.writeLock();
         try {
             View view = (View) db.getTable(tableId);


### PR DESCRIPTION
When "replay" something, we should use Catalog.getCurrentCatalog() instead
of Catalog.getInstance(), otherwise, we may get wrong Catalog instance.