### PR TITLE
Reformat BE code 1/7

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -2,11 +2,18 @@
 Language: Cpp
 BasedOnStyle: Google
 AccessModifierOffset: -4
+AlignEscapedNewlines: DontAlign
+AlignOperands: false
+AlignTrailingComments: false
 AllowShortFunctionsOnASingleLine: Inline
-ColumnLimit: 100
+AlwaysBreakBeforeMultilineStrings: false
+BreakBeforeBinaryOperators: NonAssignment
+BreakConstructorInitializers: AfterColon
+ColumnLimit: 0
 ConstructorInitializerIndentWidth: 8 # double of IndentWidth
 ContinuationIndentWidth: 8 # double of IndentWidth
 DerivePointerAlignment: false # always use PointerAlignment
+IncludeBlocks: Preserve # sort each #include block separately
 IndentCaseLabels: false
 IndentWidth: 4
 PointerAlignment: Left

--- a/be/src/agent/agent_server.h
+++ b/be/src/agent/agent_server.h
@@ -18,7 +18,6 @@
 #ifndef DORIS_BE_SRC_AGENT_AGENT_SERVER_H
 #define DORIS_BE_SRC_AGENT_AGENT_SERVER_H
 
-#include "thrift/transport/TTransportUtils.h"
 #include "agent/status.h"
 #include "agent/task_worker_pool.h"
 #include "agent/topic_subscriber.h"
@@ -28,6 +27,7 @@
 #include "olap/olap_define.h"
 #include "olap/utils.h"
 #include "runtime/exec_env.h"
+#include "thrift/transport/TTransportUtils.h"
 
 namespace doris {
 
@@ -37,7 +37,7 @@ public:
     ~AgentServer();
 
     // Receive agent task from dm
-    // 
+    //
     // Input parameters:
     // * tasks: The list of agent tasks
     //
@@ -47,7 +47,7 @@ public:
     void submit_tasks(
             TAgentResult& return_value,
             const std::vector<TAgentTaskRequest>& tasks);
-    
+
     // Make a snapshot for a local tablet
     //
     // Input parameters:
@@ -74,19 +74,19 @@ public:
     // Publish state to agent
     //
     // Input parameters:
-    //   request:  
-    void publish_cluster_state(TAgentResult& return_value, 
+    //   request:
+    void publish_cluster_state(TAgentResult& return_value,
                                const TAgentPublishRequest& request);
 
     // Master call this rpc to submit a etl task
-    void submit_etl_task(TAgentResult& return_value, 
+    void submit_etl_task(TAgentResult& return_value,
                          const TMiniLoadEtlTaskRequest& request);
 
     // Master call this rpc to fetch status of elt task
     void get_etl_status(TMiniLoadEtlStatusResult& return_value,
                         const TMiniLoadEtlStatusRequest& request);
 
-    void delete_etl_files(TAgentResult& result, 
+    void delete_etl_files(TAgentResult& result,
                           const TDeleteEtlFilesRequest& request);
 
 private:
@@ -115,8 +115,8 @@ private:
     TaskWorkerPool* _update_tablet_meta_info_workers;
 
     DISALLOW_COPY_AND_ASSIGN(AgentServer);
-    
-    TopicSubscriber* _topic_subscriber;   
-};  // class AgentServer
-}  // namespace doris
-#endif  // DORIS_BE_SRC_AGENT_AGENT_SERVER_H
+
+    TopicSubscriber* _topic_subscriber;
+}; // class AgentServer
+} // namespace doris
+#endif // DORIS_BE_SRC_AGENT_AGENT_SERVER_H

--- a/be/src/agent/cgroups_mgr.cpp
+++ b/be/src/agent/cgroups_mgr.cpp
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+// clang-format off
 #include "agent/cgroups_mgr.h"
 #include <fstream>
 #include <future>
@@ -503,3 +504,4 @@ bool CgroupsMgr::is_file_exist(const std::string& file_path) {
 }
 
 } // namespace doris
+// clang-format on

--- a/be/src/agent/cgroups_mgr.h
+++ b/be/src/agent/cgroups_mgr.h
@@ -18,11 +18,11 @@
 #ifndef DORIS_BE_SRC_AGENT_CGROUPS_MGR_H
 #define DORIS_BE_SRC_AGENT_CGROUPS_MGR_H
 
+#include <sys/types.h>
 #include <cstdint>
 #include <map>
 #include <mutex>
 #include <string>
-#include <sys/types.h>
 #include "agent/status.h"
 #include "gen_cpp/MasterService_types.h"
 
@@ -40,11 +40,11 @@ public:
 
     // Compare the old user resource and new user resource to find deleted user
     // then delete nonexisting cgroups, create new user cgroups, update all user cgroups
-    AgentStatus update_local_cgroups(const TFetchResourceResult&  new_fetched_resource);
-    
+    AgentStatus update_local_cgroups(const TFetchResourceResult& new_fetched_resource);
+
     // Delete all existing cgroups under root path
     AgentStatus init_cgroups();
-    
+
     // Modify cgroup resource shares under cgroups_root_path.
     // Create related cgroups if it not exist.
     //
@@ -53,14 +53,14 @@ public:
     //
     //   user_share: a mapping for shares for different resource like (cpu.share, 100)
     //               mapping key is resource file name in cgroup; value is share weight
-    //   
+    //
     //   level_share: a mapping for shares for different levels under the user.
     //               mapping key is level name; value is level's share. Currently, different resource using the same share.
-    AgentStatus modify_user_cgroups(const std::string& user_name, 
-                                    const std::map<std::string, int32_t>& user_share, 
+    AgentStatus modify_user_cgroups(const std::string& user_name,
+                                    const std::map<std::string, int32_t>& user_share,
                                     const std::map<std::string, int32_t>& level_share);
 
-    static void apply_cgroup(const std::string& user_name, 
+    static void apply_cgroup(const std::string& user_name,
                              const std::string& level);
 
     static void apply_system_cgroup() {
@@ -71,7 +71,7 @@ public:
     //
     // Input parameters:
     //   user_name&level: the user name and level used to find the cgroup
-    AgentStatus assign_to_cgroups(const std::string& user_name, 
+    AgentStatus assign_to_cgroups(const std::string& user_name,
                                   const std::string& level);
 
     // Assign the thread identified by thread id to the cgroup identified by user name and level
@@ -79,8 +79,8 @@ public:
     // Input parameters:
     //   thread_id: the unique id for the thread
     //   user_name&level: the user name and level used to find the cgroup
-    AgentStatus assign_thread_to_cgroups(int64_t thread_id, 
-                                         const std::string& user_name, 
+    AgentStatus assign_thread_to_cgroups(int64_t thread_id,
+                                         const std::string& user_name,
                                          const std::string& level);
 
     // Delete the user's cgroups and its sub level cgroups using DropCgroups
@@ -88,7 +88,7 @@ public:
     //   user name: user name to be deleted
     AgentStatus delete_user_cgroups(const std::string& user_name);
     // Delete a cgroup
-    // If there are active tasks in this cgroups, they will be relocated 
+    // If there are active tasks in this cgroups, they will be relocated
     // to root cgroups.
     // If there are sub cgroups, it will return error.
     // Input parameters:
@@ -107,14 +107,14 @@ public:
     }
 
     // set the disk throttle for the user by getting resource value from the map and echo it to the cgroups.
-    // currently, both the user and groups under the user are set to the same value 
+    // currently, both the user and groups under the user are set to the same value
     // because throttle does not support hierachy.
     // Input parameters:
     //  user_name: name for the user
     //  resource_share: resource value get from fe
-    void _config_user_disk_throttle(std::string user_name, 
+    void _config_user_disk_throttle(std::string user_name,
                                     const std::map<TResourceType::type, int32_t>& resource_share);
-    
+
     // get user resource share value from the map
     int64_t _get_resource_value(const TResourceType::type resource_type,
                                 const std::map<TResourceType::type, int32_t>& resource_share);
@@ -132,21 +132,21 @@ public:
     //  ssd_write_mbps: write bps number for ssd disk, using mb not byte or kb.
     AgentStatus _config_disk_throttle(std::string user_name,
                                       std::string level,
-                                      int64_t hdd_read_iops, 
+                                      int64_t hdd_read_iops,
                                       int64_t hdd_write_iops,
-                                      int64_t hdd_read_mbps, 
-                                      int64_t hdd_write_mbps, 
-                                      int64_t ssd_read_iops, 
-                                      int64_t ssd_write_iops, 
-                                      int64_t ssd_read_mbps, 
+                                      int64_t hdd_read_mbps,
+                                      int64_t hdd_write_mbps,
+                                      int64_t ssd_read_iops,
+                                      int64_t ssd_write_iops,
+                                      int64_t ssd_read_mbps,
                                       int64_t ssd_write_mbps);
-    
+
     // echo command in string stream to the cgroup file
     // Input parameters:
     //  ctrl_cmd: stringstream that contains the string to echo
     //  cgroups_path: target cgroup file path
     void _echo_cmd_to_cgroup(std::stringstream& ctrl_cmd, std::string& cgroups_path);
-    
+
     // check if the path exists and it is a directory
     // Input parameters:
     //   file_path: path to the file
@@ -165,6 +165,7 @@ public:
 public:
     const static std::string _s_system_user;
     const static std::string _s_system_group;
+
 private:
     ExecEnv* _exec_env;
     std::string _root_cgroups_path;
@@ -173,11 +174,11 @@ private:
     std::string _default_user_name = "default";
     std::string _default_level = "normal";
     int64_t _cur_version;
-    std::set<std::string>  _local_users;
-    std::mutex _update_cgroups_mtx;    
+    std::set<std::string> _local_users;
+    std::mutex _update_cgroups_mtx;
 
     // A static mapping from fe's resource type to cgroups file
-    static std::map<TResourceType::type, std::string> _s_resource_cgroups; 
+    static std::map<TResourceType::type, std::string> _s_resource_cgroups;
 };
-}
+} // namespace doris
 #endif

--- a/be/src/agent/heartbeat_server.cpp
+++ b/be/src/agent/heartbeat_server.cpp
@@ -19,17 +19,17 @@
 #include <ctime>
 #include <fstream>
 
-#include <boost/filesystem.hpp>
 #include <thrift/TProcessor.h>
+#include <boost/filesystem.hpp>
 
 #include "common/status.h"
 #include "gen_cpp/HeartbeatService.h"
 #include "gen_cpp/Status_types.h"
 #include "olap/storage_engine.h"
 #include "olap/utils.h"
+#include "runtime/heartbeat_flags.h"
 #include "service/backend_options.h"
 #include "util/thrift_server.h"
-#include "runtime/heartbeat_flags.h"
 
 using std::fstream;
 using std::nothrow;
@@ -52,13 +52,12 @@ void HeartbeatServer::init_cluster_id() {
 void HeartbeatServer::heartbeat(
         THeartbeatResult& heartbeat_result,
         const TMasterInfo& master_info) {
-
     //print heartbeat in every minute
     LOG_EVERY_N(INFO, 12) << "get heartbeat from FE."
-        << "host:" << master_info.network_address.hostname
-        << ", port:" << master_info.network_address.port
-        << ", cluster id:" << master_info.cluster_id
-        << ", counter:" << google::COUNTER;
+                          << "host:" << master_info.network_address.hostname
+                          << ", port:" << master_info.network_address.port
+                          << ", cluster id:" << master_info.cluster_id
+                          << ", counter:" << google::COUNTER;
 
     // do heartbeat
     Status st = _heartbeat(master_info);
@@ -74,13 +73,12 @@ void HeartbeatServer::heartbeat(
 
 Status HeartbeatServer::_heartbeat(
         const TMasterInfo& master_info) {
-    
     std::lock_guard<std::mutex> lk(_hb_mtx);
 
     if (master_info.__isset.backend_ip) {
         if (master_info.backend_ip != BackendOptions::get_localhost()) {
             LOG(WARNING) << "backend ip saved in master does not equal to backend local ip"
-                    << master_info.backend_ip << " vs. " << BackendOptions::get_localhost();
+                         << master_info.backend_ip << " vs. " << BackendOptions::get_localhost();
             std::stringstream ss;
             ss << "actual backend local ip: " << BackendOptions::get_localhost();
             return Status::InternalError(ss.str());
@@ -109,7 +107,7 @@ Status HeartbeatServer::_heartbeat(
 
     bool need_report = false;
     if (_master_info->network_address.hostname != master_info.network_address.hostname
-            || _master_info->network_address.port != master_info.network_address.port) {
+        || _master_info->network_address.port != master_info.network_address.port) {
         if (master_info.epoch > _epoch) {
             _master_info->network_address.hostname = master_info.network_address.hostname;
             _master_info->network_address.port = master_info.network_address.port;
@@ -120,7 +118,7 @@ Status HeartbeatServer::_heartbeat(
         } else {
             LOG(WARNING) << "epoch is not greater than local. ignore heartbeat. host: "
                          << _master_info->network_address.hostname
-                         << " port: " <<  _master_info->network_address.port
+                         << " port: " << _master_info->network_address.port
                          << " local epoch: " << _epoch << " received epoch: " << master_info.epoch;
             return Status::InternalError("epoch is not greater than local. ignore heartbeat.");
         }
@@ -185,4 +183,4 @@ AgentStatus create_heartbeat_server(
             worker_thread_num);
     return DORIS_SUCCESS;
 }
-}  // namesapce doris
+} // namespace doris

--- a/be/src/agent/heartbeat_server.h
+++ b/be/src/agent/heartbeat_server.h
@@ -38,7 +38,7 @@ class ThriftServer;
 class HeartbeatServer : public HeartbeatServiceIf {
 public:
     explicit HeartbeatServer(TMasterInfo* master_info);
-    virtual ~HeartbeatServer() {};
+    virtual ~HeartbeatServer(){};
 
     virtual void init_cluster_id();
 
@@ -53,7 +53,7 @@ public:
 
 private:
     Status _heartbeat(
-        const TMasterInfo& master_info);
+            const TMasterInfo& master_info);
 
     StorageEngine* _olap_engine;
 
@@ -63,7 +63,7 @@ private:
     int64_t _epoch;
 
     DISALLOW_COPY_AND_ASSIGN(HeartbeatServer);
-};  // class HeartBeatServer
+}; // class HeartBeatServer
 
 AgentStatus create_heartbeat_server(
         ExecEnv* exec_env,
@@ -71,5 +71,5 @@ AgentStatus create_heartbeat_server(
         ThriftServer** heart_beat_server,
         uint32_t worker_thread_num,
         TMasterInfo* local_master_info);
-}  // namespace doris
-#endif  // DORIS_BE_SRC_AGENT_HEARTBEAT_SERVER_H
+} // namespace doris
+#endif // DORIS_BE_SRC_AGENT_HEARTBEAT_SERVER_H

--- a/be/src/agent/pusher.cpp
+++ b/be/src/agent/pusher.cpp
@@ -23,9 +23,9 @@
 #include <iostream>
 #include <sstream>
 #include <string>
+#include "agent/cgroups_mgr.h"
 #include "boost/filesystem.hpp"
 #include "boost/lexical_cast.hpp"
-#include "agent/cgroups_mgr.h"
 #include "gen_cpp/AgentService_types.h"
 #include "http/http_client.h"
 #include "olap/olap_common.h"
@@ -130,13 +130,13 @@ AgentStatus Pusher::process(vector<TTabletInfo>* tablet_infos) {
             estimate_time_out = config::download_low_speed_time;
         }
         bool is_timeout = false;
-        auto download_cb = [this, estimate_time_out, file_size, &is_timeout] (HttpClient* client) {
+        auto download_cb = [this, estimate_time_out, file_size, &is_timeout](HttpClient* client) {
             // Check timeout and set timeout
             time_t now = time(NULL);
             if (_push_req.timeout > 0 && _push_req.timeout < now) {
                 // return status to break this callback
                 VLOG(3) << "check time out. time_out:" << _push_req.timeout
-                    << ", now:" << now;
+                        << ", now:" << now;
                 is_timeout = true;
                 return Status::OK();
             }
@@ -159,7 +159,7 @@ AgentStatus Pusher::process(vector<TTabletInfo>* tablet_infos) {
                 uint64_t local_file_size = boost::filesystem::file_size(_local_file_path);
                 if (file_size != local_file_size) {
                     LOG(WARNING) << "download_file size error. file_size=" << file_size
-                        << ", local_file_size=" << local_file_size;
+                                 << ", local_file_size=" << local_file_size;
                     return Status::InternalError("downloaded file's size isn't right");
                 }
             }
@@ -167,7 +167,7 @@ AgentStatus Pusher::process(vector<TTabletInfo>* tablet_infos) {
             _push_req.http_file_path = _local_file_path;
             return Status::OK();
         };
-        
+
         MonotonicStopWatch stopwatch;
         stopwatch.start();
         auto st = HttpClient::execute_with_retry(MAX_RETRY, 1, download_cb);
@@ -178,18 +178,18 @@ AgentStatus Pusher::process(vector<TTabletInfo>* tablet_infos) {
         if (st.ok() && !is_timeout) {
             double rate = -1.0;
             if (_push_req.__isset.http_file_size) {
-                rate = (double) _push_req.http_file_size / (cost / 1000 / 1000 / 1000) / 1024;
+                rate = (double)_push_req.http_file_size / (cost / 1000 / 1000 / 1000) / 1024;
             }
             LOG(INFO) << "down load file success. local_file=" << _local_file_path
-                << ", remote_file=" << _remote_file_path
-                << ", tablet_id" << _push_req.tablet_id
-                << ", cost=" << cost / 1000 << "us, file_size" << _push_req.http_file_size
-                << ", download rage:" << rate << "KB/s";
+                      << ", remote_file=" << _remote_file_path
+                      << ", tablet_id" << _push_req.tablet_id
+                      << ", cost=" << cost / 1000 << "us, file_size" << _push_req.http_file_size
+                      << ", download rage:" << rate << "KB/s";
         } else {
             LOG(WARNING) << "down load file failed. remote_file=" << _remote_file_path
-                << ", tablet=" << _push_req.tablet_id
-                << ", cost=" << cost / 1000
-                << "us, errmsg=" << st.get_error_msg() << ", is_timeout=" << is_timeout;
+                         << ", tablet=" << _push_req.tablet_id
+                         << ", cost=" << cost / 1000
+                         << "us, errmsg=" << st.get_error_msg() << ", is_timeout=" << is_timeout;
             status = DORIS_ERROR;
         }
     }

--- a/be/src/agent/status.h
+++ b/be/src/agent/status.h
@@ -43,5 +43,5 @@ enum AgentStatus {
     DORIS_INTERNAL_ERROR = -902,
     DORIS_DISK_REACH_CAPACITY_LIMIT = -903,
 };
-}  // namespace doris
-#endif  // DORIS_BE_SRC_AGENT_STATUS_H
+} // namespace doris
+#endif // DORIS_BE_SRC_AGENT_STATUS_H

--- a/be/src/agent/task_worker_pool.h
+++ b/be/src/agent/task_worker_pool.h
@@ -86,7 +86,7 @@ private:
     void _spawn_callback_worker_thread(CALLBACK_FUNCTION callback_func);
     void _finish_task(const TFinishTaskRequest& finish_task_request);
     uint32_t _get_next_task_index(int32_t thread_count, std::deque<TAgentTaskRequest>& tasks,
-            TPriority::type priority);
+                                  TPriority::type priority);
 
     static void* _create_tablet_worker_thread_callback(void* arg_this);
     static void* _drop_tablet_worker_thread_callback(void* arg_this);
@@ -152,6 +152,6 @@ private:
     static std::map<TTaskType::type, std::set<int64_t>> _s_task_signatures;
 
     DISALLOW_COPY_AND_ASSIGN(TaskWorkerPool);
-};  // class TaskWorkerPool
-}  // namespace doris
-#endif  // DORIS_BE_SRC_TASK_WORKER_POOL_H
+}; // class TaskWorkerPool
+} // namespace doris
+#endif // DORIS_BE_SRC_TASK_WORKER_POOL_H

--- a/be/src/agent/topic_listener.h
+++ b/be/src/agent/topic_listener.h
@@ -21,19 +21,17 @@
 #include "gen_cpp/AgentService_types.h"
 
 namespace doris {
-  
-class TopicListener {
 
+class TopicListener {
 public:
-    
-    virtual ~TopicListener(){}
+    virtual ~TopicListener() {}
     // Deal with a single update
     //
     // Input parameters:
     //   protocol version: the version for the protocol, listeners should deal with the msg according to the protocol
     //   topic_update: single update
-    virtual void handle_update(const TAgentServiceVersion::type& protocol_version, 
+    virtual void handle_update(const TAgentServiceVersion::type& protocol_version,
                                const TTopicUpdate& topic_update) = 0;
 };
-}
+} // namespace doris
 #endif

--- a/be/src/agent/topic_subscriber.cpp
+++ b/be/src/agent/topic_subscriber.cpp
@@ -25,8 +25,7 @@ TopicSubscriber::TopicSubscriber() {
 
 TopicSubscriber::~TopicSubscriber() {
     // Delete all listeners in the register
-    std::map<TTopicType::type, std::vector<TopicListener*>>::iterator it 
-        = _registed_listeners.begin();
+    std::map<TTopicType::type, std::vector<TopicListener*>>::iterator it = _registed_listeners.begin();
     for (; it != _registed_listeners.end(); ++it) {
         std::vector<TopicListener*>& listeners = it->second;
         std::vector<TopicListener*>::iterator listener_it = listeners.begin();
@@ -53,9 +52,8 @@ void TopicSubscriber::handle_updates(const TAgentPublishRequest& agent_publish_r
         std::vector<TopicListener*>::iterator listener_it = listeners.begin();
         // Send the update to all listeners with protocol version.
         for (; listener_it != listeners.end(); ++listener_it) {
-            (*listener_it)->handle_update(agent_publish_request.protocol_version, 
-                                          *topic_update_it); 
-        }    
+            (*listener_it)->handle_update(agent_publish_request.protocol_version, *topic_update_it);
+        }
     }
 }
 } // namespace doris

--- a/be/src/agent/topic_subscriber.h
+++ b/be/src/agent/topic_subscriber.h
@@ -18,17 +18,15 @@
 #ifndef DORIS_BE_SRC_AGENT_TOPIC_SUBSCRIBER_H
 #define DORIS_BE_SRC_AGENT_TOPIC_SUBSCRIBER_H
 
-#include <map>
 #include <boost/thread.hpp>
+#include <map>
 #include "agent/topic_listener.h"
 #include "gen_cpp/AgentService_types.h"
 
 namespace doris {
 
 class TopicSubscriber {
-
 public:
-    
     TopicSubscriber();
     ~TopicSubscriber();
     // Put the topic type and listener to the map

--- a/be/src/agent/user_resource_listener.cpp
+++ b/be/src/agent/user_resource_listener.cpp
@@ -16,13 +16,13 @@
 // under the License.
 
 #include "agent/user_resource_listener.h"
-#include <map>
-#include <future>
-#include <thrift/Thrift.h>
-#include <thrift/transport/TSocket.h>
-#include <thrift/transport/TBufferTransports.h>
-#include <thrift/protocol/TBinaryProtocol.h>
 #include <thrift/TApplicationException.h>
+#include <thrift/Thrift.h>
+#include <thrift/protocol/TBinaryProtocol.h>
+#include <thrift/transport/TBufferTransports.h>
+#include <thrift/transport/TSocket.h>
+#include <future>
+#include <map>
 #include "common/logging.h"
 #include "gen_cpp/FrontendService.h"
 #include "runtime/client_cache.h"
@@ -30,30 +30,30 @@
 namespace doris {
 
 using std::string;
-using apache::thrift::TException; 
+using apache::thrift::TException;
 using apache::thrift::transport::TTransportException;
 
 // Initialize the resource to cgroups file mapping
 // TRESOURCE_IOPS  not mapped
 
-UserResourceListener::UserResourceListener(ExecEnv* exec_env, 
-                                           const TMasterInfo& master_info) 
-    : _master_info(master_info), 
-      _exec_env(exec_env),
-      _cgroups_mgr(*(exec_env->cgroups_mgr())) {
+UserResourceListener::UserResourceListener(ExecEnv* exec_env,
+                                           const TMasterInfo& master_info) :
+        _master_info(master_info),
+        _exec_env(exec_env),
+        _cgroups_mgr(*(exec_env->cgroups_mgr())) {
 }
 
 UserResourceListener::~UserResourceListener() {
 }
 
-void UserResourceListener::handle_update(const TAgentServiceVersion::type& protocol_version, 
+void UserResourceListener::handle_update(const TAgentServiceVersion::type& protocol_version,
                                          const TTopicUpdate& topic_update) {
-    std::vector<TTopicItem>  updates = topic_update.updates;
+    std::vector<TTopicItem> updates = topic_update.updates;
     if (updates.size() > 0) {
         int64_t new_version = updates[0].int_value;
         // Async call to update users resource method
-        std::async(std::launch::async, 
-                   &UserResourceListener::update_users_resource, 
+        std::async(std::launch::async,
+                   &UserResourceListener::update_users_resource,
                    this, new_version);
     }
 }
@@ -64,16 +64,16 @@ void UserResourceListener::update_users_resource(int64_t new_version) {
     }
     // Call fe to get latest user resource
     Status master_status;
-    // using 500ms as default timeout value    
+    // using 500ms as default timeout value
     FrontendServiceConnection client(_exec_env->frontend_client_cache(),
-                                   _master_info.network_address,
-                                   config::thrift_rpc_timeout_ms, 
-                                   &master_status);
+                                     _master_info.network_address,
+                                     config::thrift_rpc_timeout_ms,
+                                     &master_status);
     TFetchResourceResult new_fetched_resource;
-    if (!master_status.ok()) { 
-        LOG(ERROR) << "Get frontend client failed, with address:" 
-            << _master_info.network_address.hostname << ":" 
-            << _master_info.network_address.port;
+    if (!master_status.ok()) {
+        LOG(ERROR) << "Get frontend client failed, with address:"
+                   << _master_info.network_address.hostname << ":"
+                   << _master_info.network_address.port;
         return;
     }
     try {
@@ -83,24 +83,24 @@ void UserResourceListener::update_users_resource(int64_t new_version) {
             // reopen the client and set timeout to 500ms
             master_status = client.reopen(config::thrift_rpc_timeout_ms);
 
-            if (!master_status.ok()) { 
-                LOG(WARNING) << "Reopen to get frontend client failed, with address:" 
-                    << _master_info.network_address.hostname << ":" 
-                    << _master_info.network_address.port;
+            if (!master_status.ok()) {
+                LOG(WARNING) << "Reopen to get frontend client failed, with address:"
+                             << _master_info.network_address.hostname << ":"
+                             << _master_info.network_address.port;
                 return;
             }
             LOG(WARNING) << "fetchResource from frontend failed, retry!";
             client->fetchResource(new_fetched_resource);
         }
-    } catch (TException& e) { 
+    } catch (TException& e) {
         // Already try twice, log here
         client.reopen(config::thrift_rpc_timeout_ms);
-        LOG(WARNING) << "retry to fetchResource from  " 
-            << _master_info.network_address.hostname << ":" 
-            << _master_info.network_address.port << " failed:\n" 
-            << e.what();
+        LOG(WARNING) << "retry to fetchResource from  "
+                     << _master_info.network_address.hostname << ":"
+                     << _master_info.network_address.port << " failed:\n"
+                     << e.what();
         return;
     }
-    _cgroups_mgr.update_local_cgroups(new_fetched_resource); 
+    _cgroups_mgr.update_local_cgroups(new_fetched_resource);
 }
-}
+} // namespace doris

--- a/be/src/agent/user_resource_listener.h
+++ b/be/src/agent/user_resource_listener.h
@@ -15,15 +15,15 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#ifndef DORIS_BE_SRC_AGENT_USER_RESOURCE_LISTENER_H 
+#ifndef DORIS_BE_SRC_AGENT_USER_RESOURCE_LISTENER_H
 #define DORIS_BE_SRC_AGENT_USER_RESOURCE_LISTENER_H
 
 #include <string>
-#include "agent/topic_listener.h"
 #include "agent/cgroups_mgr.h"
+#include "agent/topic_listener.h"
 #include "gen_cpp/AgentService_types.h"
-#include "gen_cpp/MasterService_types.h"
 #include "gen_cpp/HeartbeatService_types.h"
+#include "gen_cpp/MasterService_types.h"
 #include "runtime/exec_env.h"
 
 namespace doris {
@@ -31,22 +31,22 @@ namespace doris {
 class ExecEnv;
 
 class UserResourceListener : public TopicListener {
-
 public:
     ~UserResourceListener();
     // Input parameters:
     //   root_cgroups_path: root cgroups allocated by admin to doris
     UserResourceListener(ExecEnv* exec_env, const TMasterInfo& master_info);
     // This method should be async
-    virtual void handle_update(const TAgentServiceVersion::type& protocol_version, 
+    virtual void handle_update(const TAgentServiceVersion::type& protocol_version,
                                const TTopicUpdate& topic_update);
+
 private:
     const TMasterInfo& _master_info;
     ExecEnv* _exec_env;
-    CgroupsMgr& _cgroups_mgr;  
+    CgroupsMgr& _cgroups_mgr;
     // Call cgroups mgr to update user's cgroups resource share
     // Also refresh local user resource's cache
     void update_users_resource(int64_t new_version);
-}; 
-}
+};
+} // namespace doris
 #endif

--- a/be/src/agent/utils.cpp
+++ b/be/src/agent/utils.cpp
@@ -17,31 +17,31 @@
 
 #include "agent/utils.h"
 #include <arpa/inet.h>
-#include <cstdio>
 #include <errno.h>
-#include <fstream>
-#include <iostream>
 #include <netdb.h>
 #include <netinet/in.h>
-#include <sstream>
 #include <sys/socket.h>
 #include <sys/wait.h>
 #include <unistd.h>
+#include <cstdio>
+#include <fstream>
+#include <iostream>
+#include <sstream>
 
-#include <boost/filesystem.hpp>
-#include <thrift/Thrift.h>
-#include <thrift/transport/TSocket.h>
-#include <thrift/transport/TTransportException.h>
-#include <thrift/transport/TTransportUtils.h>
 #include <rapidjson/document.h>
 #include <rapidjson/rapidjson.h>
 #include <rapidjson/stringbuffer.h>
 #include <rapidjson/writer.h>
+#include <thrift/Thrift.h>
+#include <thrift/transport/TSocket.h>
+#include <thrift/transport/TTransportException.h>
+#include <thrift/transport/TTransportUtils.h>
+#include <boost/filesystem.hpp>
 
 #include "common/status.h"
 #include "gen_cpp/AgentService_types.h"
-#include "gen_cpp/HeartbeatService_types.h"
 #include "gen_cpp/FrontendService.h"
+#include "gen_cpp/HeartbeatService_types.h"
 #include "gen_cpp/Status_types.h"
 #include "olap/utils.h"
 #include "runtime/exec_env.h"
@@ -148,7 +148,7 @@ AgentStatus MasterServerClient::report(const TReportRequest& request, TMasterRes
                                      _master_info.network_address.port,
                                      client_status.code());
                     return DORIS_ERROR;
-                }   
+                }
 
                 client->report(*result, request);
             } else {
@@ -156,12 +156,12 @@ AgentStatus MasterServerClient::report(const TReportRequest& request, TMasterRes
                 // actually we don't care what FE returns.
                 OLAP_LOG_WARNING("master client, report failed: %s", e.what());
                 return DORIS_ERROR;
-            }   
-        }   
+            }
+        }
     } catch (TException& e) {
         client.reopen(config::thrift_rpc_timeout_ms);
         LOG(WARNING) << "master client. finish report failed. host: " << _master_info.network_address.hostname
-                    << ". port: " << _master_info.network_address.port << ". code: " << client_status.code();
+                     << ". port: " << _master_info.network_address.port << ". code: " << client_status.code();
         return DORIS_ERROR;
     }
 
@@ -260,7 +260,7 @@ bool AgentUtils::exec_cmd(const string& command, string* errmsg) {
     string cmd = command + " 2>&1";
 
     // Execute command.
-    FILE *fp = popen(cmd.c_str(), "r");
+    FILE* fp = popen(cmd.c_str(), "r");
     if (fp == NULL) {
         stringstream err_stream;
         err_stream << "popen failed. " << strerror(errno) << ", with errno: " << errno << ".\n";
@@ -277,7 +277,7 @@ bool AgentUtils::exec_cmd(const string& command, string* errmsg) {
     // Waits for the associated process to terminate and returns.
     rc = pclose(fp);
     if (rc == -1) {
-        if (errno==ECHILD) {
+        if (errno == ECHILD) {
             *errmsg += "pclose cannot obtain the child status.\n";
         } else {
             stringstream err_stream;
@@ -291,7 +291,7 @@ bool AgentUtils::exec_cmd(const string& command, string* errmsg) {
     // Get return code of command.
     int32_t status_child = WEXITSTATUS(rc);
     if (status_child == 0) {
-       return true;
+        return true;
     } else {
         return false;
     }
@@ -299,11 +299,11 @@ bool AgentUtils::exec_cmd(const string& command, string* errmsg) {
 
 bool AgentUtils::write_json_to_file(const map<string, string>& info, const string& path) {
     rapidjson::Document json_info(rapidjson::kObjectType);
-    for (auto &it : info) {
+    for (auto& it : info) {
         json_info.AddMember(
-            rapidjson::Value(it.first.c_str(), json_info.GetAllocator()).Move(),
-            rapidjson::Value(it.second.c_str(), json_info.GetAllocator()).Move(), 
-            json_info.GetAllocator());
+                rapidjson::Value(it.first.c_str(), json_info.GetAllocator()).Move(),
+                rapidjson::Value(it.second.c_str(), json_info.GetAllocator()).Move(),
+                json_info.GetAllocator());
     }
     rapidjson::StringBuffer json_info_str;
     rapidjson::Writer<rapidjson::StringBuffer> writer(json_info_str);
@@ -314,8 +314,8 @@ bool AgentUtils::write_json_to_file(const map<string, string>& info, const strin
     }
     fp << json_info_str.GetString() << std::endl;
     fp.close();
-    
-    return true; 
-} 
 
-}  // namespace doris
+    return true;
+}
+
+} // namespace doris

--- a/be/src/agent/utils.h
+++ b/be/src/agent/utils.h
@@ -20,25 +20,25 @@
 
 #include <pthread.h>
 #include <memory>
-#include "thrift/transport/TSocket.h"
-#include "thrift/transport/TTransportUtils.h"
 #include "agent/status.h"
+#include "gen_cpp/AgentService_types.h"
 #include "gen_cpp/BackendService.h"
 #include "gen_cpp/FrontendService.h"
-#include "gen_cpp/AgentService_types.h"
 #include "gen_cpp/HeartbeatService_types.h"
 #include "gen_cpp/Status_types.h"
 #include "gen_cpp/Types_types.h"
 #include "olap/olap_define.h"
 #include "runtime/client_cache.h"
+#include "thrift/transport/TSocket.h"
+#include "thrift/transport/TTransportUtils.h"
 
 namespace doris {
 
 class MasterServerClient {
 public:
     MasterServerClient(const TMasterInfo& master_info, FrontendServiceClientCache* client_cache);
-    virtual ~MasterServerClient() {};
-    
+    virtual ~MasterServerClient(){};
+
     // Reprot finished task to the master server
     //
     // Input parameters:
@@ -47,7 +47,7 @@ public:
     // Output parameters:
     // * result: The result of report task
     virtual AgentStatus finish_task(const TFinishTaskRequest& request, TMasterResult* result);
-    
+
     // Report tasks/olap tablet/disk state to the master server
     //
     // Input parameters:
@@ -62,12 +62,12 @@ private:
 
     FrontendServiceClientCache* _client_cache;
     DISALLOW_COPY_AND_ASSIGN(MasterServerClient);
-};  // class MasterServerClient
+}; // class MasterServerClient
 
 class AgentUtils {
 public:
-    AgentUtils() {};
-    virtual ~AgentUtils() {};
+    AgentUtils(){};
+    virtual ~AgentUtils(){};
 
     // Use rsync synchronize folder from remote agent to local folder
     //
@@ -99,7 +99,7 @@ public:
 
 private:
     DISALLOW_COPY_AND_ASSIGN(AgentUtils);
-};  // class AgentUtils
+}; // class AgentUtils
 
-}  // namespace doris
-#endif  // DORIS_BE_SRC_AGENT_UTILS_H
+} // namespace doris
+#endif // DORIS_BE_SRC_AGENT_UTILS_H

--- a/be/src/codegen/codegen_anyval.cpp
+++ b/be/src/codegen/codegen_anyval.cpp
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+// clang-format off
 #include "codegen/codegen_anyval.h"
 
 #include "runtime/multi_precision.h"
@@ -705,4 +706,4 @@ CodegenAnyVal CodegenAnyVal::get_non_null_val(
 }
 
 }
-
+// clang-format on

--- a/be/src/codegen/codegen_anyval.h
+++ b/be/src/codegen/codegen_anyval.h
@@ -23,7 +23,7 @@
 namespace llvm {
 class Type;
 class Value;
-}
+} // namespace llvm
 
 namespace doris {
 
@@ -81,27 +81,27 @@ public:
     /// 'name' optionally specifies the name of the returned value.
     static llvm::Value* create_call(
             LlvmCodeGen* cg, LlvmCodeGen::LlvmBuilder* builder,
-            llvm::Function* fn, llvm::ArrayRef<llvm::Value*> args, 
+            llvm::Function* fn, llvm::ArrayRef<llvm::Value*> args,
             const char* name,
             llvm::Value* result_ptr);
 
     static llvm::Value* create_call(
             LlvmCodeGen* cg, LlvmCodeGen::LlvmBuilder* builder,
-            llvm::Function* fn, llvm::ArrayRef<llvm::Value*> args, 
+            llvm::Function* fn, llvm::ArrayRef<llvm::Value*> args,
             const char* name) {
         return create_call(cg, builder, fn, args, name, NULL);
     }
 
     /// Same as above but wraps the result in a CodegenAnyVal.
     static CodegenAnyVal create_call_wrapped(LlvmCodeGen* cg,
-            LlvmCodeGen::LlvmBuilder* builder, const TypeDescriptor& type, llvm::Function* fn,
-            llvm::ArrayRef<llvm::Value*> args, const char* name,
-            llvm::Value* result_ptr);
+                                             LlvmCodeGen::LlvmBuilder* builder, const TypeDescriptor& type, llvm::Function* fn,
+                                             llvm::ArrayRef<llvm::Value*> args, const char* name,
+                                             llvm::Value* result_ptr);
 
     /// Same as above but wraps the result in a CodegenAnyVal.
     static CodegenAnyVal create_call_wrapped(LlvmCodeGen* cg,
-            LlvmCodeGen::LlvmBuilder* builder, const TypeDescriptor& type, llvm::Function* fn,
-            llvm::ArrayRef<llvm::Value*> args, const char* name) {
+                                             LlvmCodeGen::LlvmBuilder* builder, const TypeDescriptor& type, llvm::Function* fn,
+                                             llvm::ArrayRef<llvm::Value*> args, const char* name) {
         return create_call_wrapped(cg, builder, type, fn, args, name, NULL);
     }
 
@@ -135,11 +135,11 @@ public:
     /// This returns a CodegenAnyVal, rather than the unwrapped Value*, because the actual
     /// value still needs to be set.
     static CodegenAnyVal get_non_null_val(
-        LlvmCodeGen* codegen, LlvmCodeGen::LlvmBuilder* builder, 
-        const TypeDescriptor& type, const char* name);
+            LlvmCodeGen* codegen, LlvmCodeGen::LlvmBuilder* builder,
+            const TypeDescriptor& type, const char* name);
 
     static CodegenAnyVal get_non_null_val(
-            LlvmCodeGen* codegen, LlvmCodeGen::LlvmBuilder* builder, 
+            LlvmCodeGen* codegen, LlvmCodeGen::LlvmBuilder* builder,
             const TypeDescriptor& type) {
         return get_non_null_val(codegen, builder, type, "");
     }
@@ -160,7 +160,7 @@ public:
     CodegenAnyVal(LlvmCodeGen* codegen, LlvmCodeGen::LlvmBuilder* builder,
                   const TypeDescriptor& type, llvm::Value* value = NULL, const char* name = "");
 
-    ~CodegenAnyVal() { }
+    ~CodegenAnyVal() {}
 
     /// Returns the current type-lowered value.
     llvm::Value* value() { return _value; }
@@ -193,7 +193,7 @@ public:
 
     /// Getters for StringVals.
     llvm::Value* get_ptr();
-    llvm::Value *get_len();
+    llvm::Value* get_len();
 
     /// Setters for StringVals.
     void set_ptr(llvm::Value* ptr);
@@ -235,13 +235,13 @@ public:
     /// RawValue::Compare()). This and 'other' must be non-null. Return value is < 0 if
     /// this < 'other', 0 if this == 'other', > 0 if this > 'other'.
     llvm::Value* compare(CodegenAnyVal* other, const char* name);
-    llvm::Value* compare(CodegenAnyVal* other) { 
+    llvm::Value* compare(CodegenAnyVal* other) {
         return compare(other, "result");
     }
 
     /// Ctor for created an uninitialized CodegenAnYVal that can be assigned to later.
-    CodegenAnyVal() : 
-        _type(INVALID_TYPE), _value(NULL), _name(NULL), _codegen(NULL), _builder(NULL) { 
+    CodegenAnyVal() :
+            _type(INVALID_TYPE), _value(NULL), _name(NULL), _codegen(NULL), _builder(NULL) {
     }
 
 private:
@@ -260,12 +260,11 @@ private:
         return get_high_bits(num_bits, v, "");
     }
 
-
     /// Helper function for setting the top (most significant) half of a 'dst' to 'src'.
     /// 'src' must have width <= 'num_bits' and 'dst' must have width = 'num_bits' * 2.
     /// Both 'dst' and 'src' should be integer types.
     llvm::Value* set_high_bits(
-        int num_bits, llvm::Value* src, llvm::Value* dst, const char* name);
+            int num_bits, llvm::Value* src, llvm::Value* dst, const char* name);
 
     llvm::Value* set_high_bits(
             int num_bits, llvm::Value* src, llvm::Value* dst) {
@@ -273,7 +272,6 @@ private:
     }
 };
 
-}
+} // namespace doris
 
 #endif
-

--- a/be/src/codegen/codegen_anyval_ir.cpp
+++ b/be/src/codegen/codegen_anyval_ir.cpp
@@ -17,9 +17,9 @@
 
 #ifdef IR_COMPILE
 
-#include "runtime/string_value.hpp"
 #include "runtime/datetime_value.h"
 #include "runtime/decimal_value.h"
+#include "runtime/string_value.hpp"
 #include "udf/udf.h"
 
 namespace doris {
@@ -55,7 +55,7 @@ bool decimal_value_eq(const DecimalVal& x, const DecimalValue& y) {
     DecimalValue tv = DecimalValue::from_decimal_val(x);
     return tv == y;
 }
-}
+} // namespace doris
 #else
 #error "This file should only be used for cross compiling to IR."
 #endif

--- a/be/src/codegen/doris_ir.cpp
+++ b/be/src/codegen/doris_ir.cpp
@@ -38,4 +38,3 @@ struct __float128;
 #else
 #error "This file should only be used for cross compiling to IR."
 #endif
-

--- a/be/src/codegen/llvm_codegen.h
+++ b/be/src/codegen/llvm_codegen.h
@@ -18,26 +18,26 @@
 #ifndef DORIS_BE_SRC_QUERY_CODEGEN_LLVM_CODEGEN_H
 #define DORIS_BE_SRC_QUERY_CODEGEN_LLVM_CODEGEN_H
 
+#include <boost/scoped_ptr.hpp>
+#include <boost/thread/mutex.hpp>
 #include <map>
 #include <string>
 #include <vector>
-#include <boost/scoped_ptr.hpp>
-#include <boost/thread/mutex.hpp>
 
+#include <llvm/Analysis/Verifier.h>
 #include <llvm/IR/DerivedTypes.h>
-#include <llvm/IR/Intrinsics.h>
 #include <llvm/IR/IRBuilder.h>
+#include <llvm/IR/Intrinsics.h>
 #include <llvm/IR/LLVMContext.h>
 #include <llvm/IR/Module.h>
-#include <llvm/Analysis/Verifier.h>
-#include <llvm/Support/raw_ostream.h>
 #include <llvm/Support/MemoryBuffer.h>
+#include <llvm/Support/raw_ostream.h>
 
 #include "common/status.h"
-#include "runtime/primitive_type.h"
-#include "exprs/expr.h"
-#include "util/runtime_profile.h"
 #include "doris_ir/doris_ir_functions.h"
+#include "exprs/expr.h"
+#include "runtime/primitive_type.h"
+#include "util/runtime_profile.h"
 
 // Forward declare all llvm classes to avoid namespace pollution.
 namespace llvm {
@@ -57,12 +57,12 @@ class TargetData;
 class Type;
 class Value;
 
-template<bool B, typename T, typename I>
+template <bool B, typename T, typename I>
 class IRBuilder;
 
-template<bool preserveName>
+template <bool preserveName>
 class IRBuilderDefaultInserter;
-}
+} // namespace llvm
 
 namespace doris {
 
@@ -120,7 +120,7 @@ public:
     // Loads and parses the precompiled doris IR module
     // codegen will contain the created object on success.
     static Status load_doris_ir(
-        ObjectPool*, const std::string& id, boost::scoped_ptr<LlvmCodeGen>* codegen);
+            ObjectPool*, const std::string& id, boost::scoped_ptr<LlvmCodeGen>* codegen);
 
     // Removes all jit compiled dynamically linked functions from the process.
     ~LlvmCodeGen();
@@ -183,7 +183,7 @@ public:
         // values (params[0] is the first arg, etc).
         // In that case, params should be preallocated to be number of arguments
         llvm::Function* generate_prototype(LlvmBuilder* builder = NULL,
-                                          llvm::Value** params = NULL);
+                                           llvm::Value** params = NULL);
 
     private:
         friend class LlvmCodeGen;
@@ -198,7 +198,7 @@ public:
     /// C-style array (e.g. i32*) or an IR array (e.g. [10 x i32]). This function does not
     /// do bounds checking.
     llvm::Value* codegen_array_at(
-        LlvmBuilder*, llvm::Value* array, int idx, const char* name);
+            LlvmBuilder*, llvm::Value* array, int idx, const char* name);
 
     /// Return a pointer type to 'type'
     llvm::PointerType* get_ptr_type(llvm::Type* type);
@@ -296,7 +296,7 @@ public:
     // body with the codegened version.  The codegened bodies differ from instance
     // to instance since they are specific to the node's tuple desc.
     llvm::Function* replace_call_sites(llvm::Function* caller, bool update_in_place,
-                                     llvm::Function* new_fn, const std::string& target_name, int* num_replaced);
+                                       llvm::Function* new_fn, const std::string& target_name, int* num_replaced);
 
     /// Returns a copy of fn. The copy is added to the module.
     llvm::Function* clone_function(llvm::Function* fn);
@@ -361,7 +361,7 @@ public:
     void codegen_debug_trace(LlvmBuilder* builder, const char* message);
 
     /// Returns the string representation of a llvm::Value* or llvm::Type*
-    template <typename T> 
+    template <typename T>
     static std::string print(T* value_or_type) {
         std::string str;
         llvm::raw_string_ostream stream(str);
@@ -392,7 +392,7 @@ public:
     // to the caller.
     llvm::AllocaInst* create_entry_block_alloca(llvm::Function* f, const NamedVariable& var);
     llvm::AllocaInst* create_entry_block_alloca(
-        const LlvmBuilder& builder, llvm::Type* type, const char* name);
+            const LlvmBuilder& builder, llvm::Type* type, const char* name);
 
     // Utility to create two blocks in 'fn' for if/else codegen.  if_block and else_block
     // are return parameters.  insert_before is optional and if set, the two blocks
@@ -400,9 +400,9 @@ public:
     // of 'fn'.  Being able to place blocks is useful for debugging so the IR has a
     // better looking control flow.
     void create_if_else_blocks(llvm::Function* fn, const std::string& if_name,
-                            const std::string& else_name,
-                            llvm::BasicBlock** if_block, llvm::BasicBlock** else_block,
-                            llvm::BasicBlock* insert_before = NULL);
+                               const std::string& else_name,
+                               llvm::BasicBlock** if_block, llvm::BasicBlock** else_block,
+                               llvm::BasicBlock* insert_before = NULL);
 
     // Returns offset into scratch buffer: offset points to area of size 'byte_size'
     // Called by expr generation to request scratch buffer.  This is used for struct
@@ -472,8 +472,8 @@ public:
         return _void_type;
     }
 
-    llvm::Type* i128_type() { 
-        return llvm::Type::getIntNTy(context(), 128); 
+    llvm::Type* i128_type() {
+        return llvm::Type::getIntNTy(context(), 128);
     }
 
     // Fills 'functions' with all the functions that are defined in the module.
@@ -510,12 +510,12 @@ private:
     // codegen object.  This is used by tests to load custom modules.
     // codegen will contain the created object on success.
     static Status load_from_file(ObjectPool*, const std::string& file,
-                               boost::scoped_ptr<LlvmCodeGen>* codegen);
+                                 boost::scoped_ptr<LlvmCodeGen>* codegen);
 
     /// Load a pre-compiled IR module from module_ir.  This creates a top level codegen
     /// object.  codegen will contain the created object on success.
     static Status load_from_memory(ObjectPool* pool, llvm::MemoryBuffer* module_ir,
-                                   const std::string& module_name, const std::string& id, 
+                                   const std::string& module_name, const std::string& id,
                                    boost::scoped_ptr<LlvmCodeGen>* codegen);
 
     /// Loads an LLVM module. 'module_ir' should be a reference to a memory buffer containing
@@ -624,18 +624,17 @@ private:
     std::vector<std::string> _debug_strings;
 
     // llvm representation of a few common types.  Owned by context.
-    llvm::PointerType* _ptr_type;     // int8_t*
-    llvm::Type* _void_type;           // void
-    llvm::Type* _string_val_type;     // StringVal
-    llvm::Type* _decimal_val_type;    // StringVal
-    llvm::Type* _datetime_val_type;   // DateTimeValue
+    llvm::PointerType* _ptr_type; // int8_t*
+    llvm::Type* _void_type; // void
+    llvm::Type* _string_val_type; // StringVal
+    llvm::Type* _decimal_val_type; // StringVal
+    llvm::Type* _datetime_val_type; // DateTimeValue
 
     // llvm constants to help with code gen verbosity
     llvm::Value* _true_value;
     llvm::Value* _false_value;
 };
 
-}
+} // namespace doris
 
 #endif
-

--- a/be/src/codegen/llvm_codegen_test.cpp
+++ b/be/src/codegen/llvm_codegen_test.cpp
@@ -15,9 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include <string>
 #include <gtest/gtest.h>
 #include <boost/thread/thread.hpp>
+#include <string>
 
 #include "codegen/llvm-codegen.h"
 #include "runtime/raw-value.h"
@@ -57,7 +57,7 @@ private:
 
     // Wrapper to call private test-only methods on LlvmCodeGen object
     static Status load_from_file(ObjectPool* pool, const string& filename,
-                               scoped_ptr<LlvmCodeGen>* codegen) {
+                                 scoped_ptr<LlvmCodeGen>* codegen) {
         return LlvmCodeGen::load_from_file(pool, filename, codegen);
     }
 
@@ -130,7 +130,7 @@ Function* CodegenInnerLoop(LlvmCodeGen* codegen, int64_t* jitted_counter, int de
     // Store &jitted_counter as a constant.
     Value* const_delta = ConstantInt::get(context, APInt(64, delta));
     Value* counter_ptr = codegen->cast_ptr_to_llvm_ptr(codegen->get_ptr_type(TYPE_BIGINT),
-                         jitted_counter);
+                                                       jitted_counter);
     Value* loaded_counter = builder.CreateLoad(counter_ptr);
     Value* incremented_value = builder.CreateAdd(loaded_counter, const_delta);
     builder.CreateStore(incremented_value, counter_ptr);
@@ -202,7 +202,7 @@ TEST_F(LlvmCodeGenTest, ReplaceFnCall) {
     // jitted one
     int num_replaced;
     Function* jitted_loop = codegen->replace_call_sites(
-                                loop, false, jitted_loop_call, loop_call_name, &num_replaced);
+            loop, false, jitted_loop_call, loop_call_name, &num_replaced);
     EXPECT_EQ(num_replaced, 1);
     EXPECT_TRUE(codegen->verify_function(jitted_loop));
 
@@ -221,7 +221,7 @@ TEST_F(LlvmCodeGenTest, ReplaceFnCall) {
     // Part5: Generate a new inner loop function and a new loop function in place
     Function* jitted_loop_call2 = CodegenInnerLoop(codegen.get(), &jitted_counter, -2);
     Function* jitted_loop2 = codegen->replace_call_sites(loop, true, jitted_loop_call2,
-                             loop_call_name, &num_replaced);
+                                                         loop_call_name, &num_replaced);
     EXPECT_EQ(num_replaced, 1);
     EXPECT_TRUE(codegen->verify_function(jitted_loop2));
 
@@ -268,7 +268,7 @@ Function* CodegenStringTest(LlvmCodeGen* codegen) {
     // strval->ptr[0] = 'A'
     Value* str_ptr = builder.CreateStructGEP(str, 0, "str_ptr");
     Value* ptr = builder.CreateLoad(str_ptr, "ptr");
-    Value* first_char_offset[] = { codegen->get_int_constant(TYPE_INT, 0) };
+    Value* first_char_offset[] = {codegen->get_int_constant(TYPE_INT, 0)};
     Value* first_char_ptr = builder.CreateGEP(ptr, first_char_offset, "first_char_ptr");
     builder.CreateStore(codegen->get_int_constant(TYPE_TINYINT, 'A'), first_char_ptr);
 
@@ -321,8 +321,8 @@ TEST_F(LlvmCodeGenTest, StringValue) {
 
     // Validate padding bytes are unchanged
     int32_t* bytes = reinterpret_cast<int32_t*>(&str_val);
-    EXPECT_EQ(1, bytes[2]);   // str_val.len
-    EXPECT_EQ(0, bytes[3]);   // padding
+    EXPECT_EQ(1, bytes[2]); // str_val.len
+    EXPECT_EQ(0, bytes[3]); // padding
 }
 
 // Test calling memcpy intrinsic
@@ -379,9 +379,9 @@ TEST_F(LlvmCodeGenTest, HashTest) {
     bool restore_sse_support = false;
 
     Value* llvm_data1 = codegen->cast_ptr_to_llvm_ptr(codegen->ptr_type(),
-                        const_cast<char*>(data1));
+                                                      const_cast<char*>(data1));
     Value* llvm_data2 = codegen->cast_ptr_to_llvm_ptr(codegen->ptr_type(),
-                        const_cast<char*>(data2));
+                                                      const_cast<char*>(data2));
     Value* llvm_len1 = codegen->get_int_constant(TYPE_INT, strlen(data1));
     Value* llvm_len2 = codegen->get_int_constant(TYPE_INT, strlen(data2));
 
@@ -442,7 +442,7 @@ TEST_F(LlvmCodeGenTest, HashTest) {
     CpuInfo::EnableFeature(CpuInfo::SSE4_2, restore_sse_support);
 }
 
-}
+} // namespace doris
 
 int main(int argc, char** argv) {
     doris::CpuInfo::Init();
@@ -452,4 +452,3 @@ int main(int argc, char** argv) {
     doris::LlvmCodeGen::initialize_llvm();
     return RUN_ALL_TESTS();
 }
-

--- a/be/src/codegen/subexpr_elimination.cpp
+++ b/be/src/codegen/subexpr_elimination.cpp
@@ -21,24 +21,24 @@
 #include <iostream>
 #include <sstream>
 
-#include <boost/thread/mutex.hpp>
 #include <llvm/Analysis/Dominators.h>
-#include <llvm/Analysis/Passes.h>
 #include <llvm/Analysis/InstructionSimplify.h>
-#include <llvm/Support/DynamicLibrary.h>
+#include <llvm/Analysis/Passes.h>
 #include <llvm/IRReader/IRReader.h>
-#include <llvm/Support/MemoryBuffer.h>
+#include <llvm/Support/DynamicLibrary.h>
 #include <llvm/Support/InstIterator.h>
+#include <llvm/Support/MemoryBuffer.h>
 #include <llvm/Support/NoFolder.h>
 #include <llvm/Support/TargetSelect.h>
 #include <llvm/Support/raw_ostream.h>
 #include <llvm/Support/system_error.h>
-#include "llvm/Transforms/IPO.h"
 #include <llvm/Transforms/Scalar.h>
 #include <llvm/Transforms/Utils/SSAUpdater.h>
+#include <boost/thread/mutex.hpp>
+#include "llvm/Transforms/IPO.h"
 
-#include "common/logging.h"
 #include "codegen/subexpr_elimination.h"
+#include "common/logging.h"
 #include "doris_ir/doris_ir_names.h"
 #include "util/cpu_info.h"
 #include "util/path_builder.h"
@@ -53,7 +53,8 @@ using llvm::Value;
 using llvm::DominatorTree;
 namespace doris {
 
-SubExprElimination::SubExprElimination(LlvmCodeGen* codegen) : _codegen(codegen) {
+SubExprElimination::SubExprElimination(LlvmCodeGen* codegen) :
+        _codegen(codegen) {
 }
 
 // Before running the standard llvm optimization passes, first remove redundant calls
@@ -166,8 +167,7 @@ bool SubExprElimination::run(Function* fn) {
 
         CallInst* call_instr = reinterpret_cast<CallInst*>(instr);
         Function* called_fn = call_instr->getCalledFunction();
-        if (_codegen->_registered_exprs.find(called_fn) == 
-                _codegen->_registered_exprs.end()) {
+        if (_codegen->_registered_exprs.find(called_fn) == _codegen->_registered_exprs.end()) {
             continue;
         }
 
@@ -225,4 +225,4 @@ bool SubExprElimination::run(Function* fn) {
     return true;
 }
 
-}
+} // namespace doris

--- a/be/src/codegen/subexpr_elimination.h
+++ b/be/src/codegen/subexpr_elimination.h
@@ -18,8 +18,8 @@
 #ifndef DORIS_BE_SRC_QUERY_CODEGEN_SUBEXPR_ELIMINATION_H
 #define DORIS_BE_SRC_QUERY_CODEGEN_SUBEXPR_ELIMINATION_H
 
-#include "common/status.h"
 #include "codegen/llvm_codegen.h"
+#include "common/status.h"
 
 namespace doris {
 
@@ -28,7 +28,7 @@ namespace doris {
 class SubExprElimination {
 public:
     SubExprElimination(LlvmCodeGen* codegen);
-    ~SubExprElimination() { }
+    ~SubExprElimination() {}
 
     // Perform subexpr elimination on function.
     bool run(llvm::Function* function);
@@ -38,7 +38,6 @@ private:
     LlvmCodeGen* _codegen;
 };
 
-}
+} // namespace doris
 
 #endif
-

--- a/be/src/common/atomic.h
+++ b/be/src/common/atomic.h
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+// clang-format off
 #ifndef DORIS_BE_SRC_COMMON_ATOMIC_H
 #define DORIS_BE_SRC_COMMON_ATOMIC_H
 
@@ -208,3 +209,4 @@ private:
 } // end namespace doris
 
 #endif // DORIS_BE_SRC_COMMON_ATOMIC_H
+// clang-format on

--- a/be/src/common/compiler_util.h
+++ b/be/src/common/compiler_util.h
@@ -44,7 +44,6 @@
 /// decision, e.g. not inlining a small function on a hot path.
 #define ALWAYS_INLINE __attribute__((always_inline))
 
-#define ALIGN_CACHE_LINE __attribute__ ((aligned (CACHE_LINE_SIZE)))
+#define ALIGN_CACHE_LINE __attribute__((aligned(CACHE_LINE_SIZE)))
 
 #endif
-

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+// clang-format off
 #ifndef DORIS_BE_SRC_COMMON_CONFIG_H
 #define DORIS_BE_SRC_COMMON_CONFIG_H
 
@@ -510,3 +511,4 @@ namespace config {
 } // namespace doris
 
 #endif // DORIS_BE_SRC_COMMON_CONFIG_H
+// clang-format on

--- a/be/src/common/configbase.cpp
+++ b/be/src/common/configbase.cpp
@@ -22,9 +22,9 @@
 #include <iostream>
 #include <sstream>
 
-#define __IN_CONFIGBASE_CPP__ 
+#define __IN_CONFIGBASE_CPP__
 #include "common/config.h"
-#undef  __IN_CONFIGBASE_CPP__
+#undef __IN_CONFIGBASE_CPP__
 
 namespace doris {
 namespace config {
@@ -44,7 +44,7 @@ bool Properties::load(const char* filename) {
     // open the conf file
     std::ifstream input(filename);
     if (!input.is_open()) {
-        std::cerr <<  "config::load() failed to open the file:" << filename << std::endl;
+        std::cerr << "config::load() failed to open the file:" << filename << std::endl;
         return false;
     }
 
@@ -62,14 +62,14 @@ bool Properties::load(const char* filename) {
 
         // ignore comments
         if (line.empty() || line[0] == '#') {
-            continue; 
+            continue;
         }
 
         // read key and value
         splitkv(line, key, value);
         trim(key);
         trim(value);
-        
+
         // insert into propmap
         propmap[key] = value;
     }
@@ -83,9 +83,9 @@ bool Properties::load(const char* filename) {
 template <typename T>
 bool Properties::get(const char* key, const char* defstr, T& retval) const {
     std::map<std::string, std::string>::const_iterator it = propmap.find(std::string(key));
-    std::string valstr = it != propmap.end() ? it->second: std::string(defstr);
+    std::string valstr = it != propmap.end() ? it->second : std::string(defstr);
     trim(valstr);
-    if (!replaceenv(valstr)) { 
+    if (!replaceenv(valstr)) {
         return false;
     }
     return strtox(valstr, retval);
@@ -110,7 +110,7 @@ const std::map<std::string, std::string>& Properties::getmap() const {
 }
 
 // trim string
-std::string& Properties::trim(std::string& s)  {
+std::string& Properties::trim(std::string& s) {
     // rtrim
     s.erase(std::find_if(s.rbegin(), s.rend(), std::not1(std::ptr_fun<int, int>(std::isspace))).base(), s.end());
     // ltrim
@@ -138,7 +138,7 @@ bool Properties::replaceenv(std::string& s) {
     std::size_t start = 0;
     while ((start = s.find("${", pos)) != std::string::npos) {
         std::size_t end = s.find("}", start + 2);
-        if (end == std::string::npos) { 
+        if (end == std::string::npos) {
             return false;
         }
         std::string envkey = s.substr(start + 2, end - start - 2);
@@ -164,9 +164,9 @@ bool Properties::strtox(const std::string& valstr, bool& retval) {
     return true;
 }
 
-template<typename T>
+template <typename T>
 bool Properties::strtointeger(const std::string& valstr, T& retval) {
-    if (valstr.length() == 0)  { 
+    if (valstr.length() == 0) {
         return false; // empty-string is only allowed for string type.
     }
     char* end;
@@ -174,7 +174,7 @@ bool Properties::strtointeger(const std::string& valstr, T& retval) {
     const char* valcstr = valstr.c_str();
     int64_t ret64 = strtoll(valcstr, &end, 10);
     if (errno || end != valcstr + strlen(valcstr)) {
-        return false;  // bad parse
+        return false; // bad parse
     }
     retval = static_cast<T>(ret64);
     if (retval != ret64) {
@@ -196,15 +196,15 @@ bool Properties::strtox(const std::string& valstr, int64_t& retval) {
 }
 
 bool Properties::strtox(const std::string& valstr, double& retval) {
-    if (valstr.length() == 0)  {
+    if (valstr.length() == 0) {
         return false; // empty-string is only allowed for string type.
     }
     char* end = NULL;
     errno = 0;
     const char* valcstr = valstr.c_str();
     retval = strtod(valcstr, &end);
-    if (errno || end != valcstr + strlen(valcstr))  {
-        return false;  // bad parse
+    if (errno || end != valcstr + strlen(valcstr)) {
+        return false; // bad parse
     }
     return true;
 }
@@ -214,8 +214,8 @@ bool Properties::strtox(const std::string& valstr, std::string& retval) {
     return true;
 }
 
-template<typename T>
-std::ostream& operator<< (std::ostream& out, const std::vector<T>& v) {
+template <typename T>
+std::ostream& operator<<(std::ostream& out, const std::vector<T>& v) {
     size_t last = v.size() - 1;
     for (size_t i = 0; i < v.size(); ++i) {
         out << v[i];
@@ -226,24 +226,24 @@ std::ostream& operator<< (std::ostream& out, const std::vector<T>& v) {
     return out;
 }
 
-#define SET_FIELD(FIELD, TYPE, FILL_CONFMAP)\
-        if (strcmp((FIELD).type, #TYPE) == 0) {\
-            if (!props.get((FIELD).name, (FIELD).defval, *reinterpret_cast<TYPE*>((FIELD).storage))) {\
-                std::cerr << "config field error: " << (FIELD).name << std::endl;\
-                return false;\
-            }\
-            if (FILL_CONFMAP) {\
-                std::ostringstream oss;\
-                oss << (*reinterpret_cast<TYPE*>((FIELD).storage));\
-                (*confmap)[(FIELD).name] = oss.str();\
-            }\
-            continue;\
-        }
+#define SET_FIELD(FIELD, TYPE, FILL_CONFMAP) \
+    if (strcmp((FIELD).type, #TYPE) == 0) { \
+        if (!props.get((FIELD).name, (FIELD).defval, *reinterpret_cast<TYPE*>((FIELD).storage))) { \
+            std::cerr << "config field error: " << (FIELD).name << std::endl; \
+            return false; \
+        } \
+        if (FILL_CONFMAP) { \
+            std::ostringstream oss; \
+            oss << (*reinterpret_cast<TYPE*>((FIELD).storage)); \
+            (*confmap)[(FIELD).name] = oss.str(); \
+        } \
+        continue; \
+    }
 
 // init conf fields
 bool init(const char* filename, bool fillconfmap) {
     // load properties file
-    if (!props.load(filename)) { 
+    if (!props.load(filename)) {
         return false;
     }
     // fill confmap ?
@@ -252,8 +252,8 @@ bool init(const char* filename, bool fillconfmap) {
     }
 
     // set conf fields
-    for (std::list<Register::Field>::iterator it = Register::_s_fieldlist->begin(); 
-        it != Register::_s_fieldlist->end(); ++it) {
+    for (std::list<Register::Field>::iterator it = Register::_s_fieldlist->begin();
+         it != Register::_s_fieldlist->end(); ++it) {
         SET_FIELD(*it, bool, fillconfmap);
         SET_FIELD(*it, int16_t, fillconfmap);
         SET_FIELD(*it, int32_t, fillconfmap);

--- a/be/src/common/configbase.h
+++ b/be/src/common/configbase.h
@@ -53,6 +53,7 @@ public:
     }
 }; 
 
+// clang-format off
 #define DEFINE_FIELD(FIELD_TYPE, FIELD_NAME, FIELD_DEFAULT)\
     FIELD_TYPE FIELD_NAME;\
     static Register reg_##FIELD_NAME(#FIELD_TYPE, #FIELD_NAME, &FIELD_NAME, FIELD_DEFAULT);
@@ -86,6 +87,7 @@ public:
 #define CONF_Doubles(name, defaultstr)      DECLARE_FIELD(std::vector<double>, name)
 #define CONF_Strings(name, defaultstr)      DECLARE_FIELD(std::vector<std::string>, name)
 #endif
+// clang-format on
 
 class Properties {
 public:

--- a/be/src/common/configbase.h
+++ b/be/src/common/configbase.h
@@ -34,10 +34,10 @@ public:
         void* storage;
         const char* defval;
         Field(const char* ftype, const char* fname, void* fstorage, const char* fdefval) :
-            type(ftype), 
-            name(fname),
-            storage(fstorage),
-            defval(fdefval) {}
+                type(ftype),
+                name(fname),
+                storage(fstorage),
+                defval(fdefval) {}
     };
 
 public:
@@ -51,7 +51,7 @@ public:
         Field field(ftype, fname, fstorage, fdefval);
         _s_fieldlist->push_back(field);
     }
-}; 
+};
 
 // clang-format off
 #define DEFINE_FIELD(FIELD_TYPE, FIELD_NAME, FIELD_DEFAULT)\
@@ -92,14 +92,14 @@ public:
 class Properties {
 public:
     bool load(const char* filename);
-    template<typename T> 
+    template <typename T>
     bool get(const char* key, const char* defstr, T& retval) const;
     const std::map<std::string, std::string>& getmap() const;
 
 private:
-    template <typename T> 
+    template <typename T>
     static bool strtox(const std::string& valstr, std::vector<T>& retval);
-    template<typename T> 
+    template <typename T>
     static bool strtointeger(const std::string& valstr, T& retval);
     static bool strtox(const std::string& valstr, bool& retval);
     static bool strtox(const std::string& valstr, int16_t& retval);

--- a/be/src/common/daemon.cpp
+++ b/be/src/common/daemon.cpp
@@ -21,45 +21,45 @@
 #include <gperftools/malloc_extension.h>
 
 #include "common/config.h"
+#include "exprs/bitmap_function.h"
+#include "exprs/cast_functions.h"
+#include "exprs/compound_predicate.h"
+#include "exprs/decimal_operators.h"
+#include "exprs/decimalv2_operators.h"
+#include "exprs/encryption_functions.h"
+#include "exprs/es_functions.h"
+#include "exprs/grouping_sets_functions.h"
+#include "exprs/hash_functions.h"
+#include "exprs/hll_function.h"
+#include "exprs/hll_hash_function.h"
+#include "exprs/is_null_predicate.h"
+#include "exprs/json_functions.h"
+#include "exprs/like_predicate.h"
+#include "exprs/math_functions.h"
+#include "exprs/new_in_predicate.h"
+#include "exprs/operators.h"
+#include "exprs/string_functions.h"
+#include "exprs/time_operators.h"
+#include "exprs/timestamp_functions.h"
+#include "exprs/timezone_db.h"
+#include "exprs/utility_functions.h"
+#include "geo/geo_functions.h"
+#include "olap/options.h"
+#include "runtime/bufferpool/buffer_pool.h"
+#include "runtime/exec_env.h"
+#include "runtime/mem_tracker.h"
+#include "runtime/memory/chunk_allocator.h"
+#include "runtime/user_function_cache.h"
 #include "util/cpu_info.h"
 #include "util/debug_util.h"
 #include "util/disk_info.h"
+#include "util/doris_metrics.h"
 #include "util/logging.h"
 #include "util/mem_info.h"
 #include "util/network_util.h"
-#include "util/thrift_util.h"
-#include "util/doris_metrics.h"
-#include "runtime/bufferpool/buffer_pool.h"
-#include "runtime/exec_env.h"
-#include "runtime/memory/chunk_allocator.h"
-#include "runtime/mem_tracker.h"
-#include "runtime/user_function_cache.h"
-#include "exprs/operators.h"
-#include "exprs/is_null_predicate.h"
-#include "exprs/like_predicate.h"
-#include "exprs/compound_predicate.h"
-#include "exprs/new_in_predicate.h"
-#include "exprs/string_functions.h"
-#include "exprs/cast_functions.h"
-#include "exprs/math_functions.h"
-#include "exprs/encryption_functions.h"
-#include "exprs/es_functions.h"
-#include "exprs/hash_functions.h"
-#include "exprs/timestamp_functions.h"
-#include "exprs/decimal_operators.h"
-#include "exprs/decimalv2_operators.h"
-#include "exprs/time_operators.h"
-#include "exprs/utility_functions.h"
-#include "exprs/json_functions.h"
-#include "exprs/hll_hash_function.h"
-#include "exprs/grouping_sets_functions.h"
-#include "exprs/timezone_db.h"
-#include "exprs/bitmap_function.h"
-#include "exprs/hll_function.h"
-#include "geo/geo_functions.h"
-#include "olap/options.h"
-#include "util/time.h"
 #include "util/system_metrics.h"
+#include "util/thrift_util.h"
+#include "util/time.h"
 
 namespace doris {
 
@@ -106,8 +106,7 @@ void* memory_maintenance_thread(void* dummy) {
             // so on a system with queries executing it will be refreshed frequently. However
             // if the system is idle, we need to refresh the tracker occasionally since
             // untracked memory may be allocated or freed, e.g. by background threads.
-            if (env->process_mem_tracker() != nullptr &&
-                     !env->process_mem_tracker()->is_consumption_metric_null()) {
+            if (env->process_mem_tracker() != nullptr && !env->process_mem_tracker()->is_consumption_metric_null()) {
                 env->process_mem_tracker()->RefreshConsumptionFromMetric();
             }
         }
@@ -151,19 +150,19 @@ void* calculate_metrics(void* dummy) {
             int64_t current_push_bytes = DorisMetrics::push_request_write_bytes.value();
             int64_t pps = (current_push_bytes - lst_push_bytes) / (interval + 1);
             DorisMetrics::push_request_write_bytes_per_second.set_value(
-                pps < 0 ? 0 : pps);
+                    pps < 0 ? 0 : pps);
             lst_push_bytes = current_push_bytes;
 
             // 2. query bytes per second
             int64_t current_query_bytes = DorisMetrics::query_scan_bytes.value();
             int64_t qps = (current_query_bytes - lst_query_bytes) / (interval + 1);
             DorisMetrics::query_scan_bytes_per_second.set_value(
-                qps < 0 ? 0 : qps);
+                    qps < 0 ? 0 : qps);
             lst_query_bytes = current_query_bytes;
 
             // 3. max disk io util
             DorisMetrics::max_disk_io_util_percent.set_value(
-                DorisMetrics::system_metrics()->get_max_io_util(lst_disks_io_time, 15));
+                    DorisMetrics::system_metrics()->get_max_io_util(lst_disks_io_time, 15));
             // update lst map
             DorisMetrics::system_metrics()->get_disks_io_time(&lst_disks_io_time);
 
@@ -171,7 +170,7 @@ void* calculate_metrics(void* dummy) {
             int64_t max_send = 0;
             int64_t max_receive = 0;
             DorisMetrics::system_metrics()->get_max_net_traffic(
-                lst_net_send_bytes, lst_net_receive_bytes, 15, &max_send, &max_receive);
+                    lst_net_send_bytes, lst_net_receive_bytes, 15, &max_send, &max_receive);
             DorisMetrics::max_network_send_bytes_rate.set_value(max_send);
             DorisMetrics::max_network_receive_bytes_rate.set_value(max_receive);
             // update lst map
@@ -205,7 +204,7 @@ static void init_doris_metrics(const std::vector<StorePath>& store_paths) {
         }
     }
     DorisMetrics::instance()->initialize(
-        "doris_be", paths, init_system_metrics, disk_devices, network_interfaces);
+            "doris_be", paths, init_system_metrics, disk_devices, network_interfaces);
 
     if (config::enable_metric_calculator) {
         pthread_t calculator_pid;
@@ -217,7 +216,7 @@ void sigterm_handler(int signo) {
     k_doris_exit = true;
 }
 
-int install_signal(int signo, void(*handler)(int)) {
+int install_signal(int signo, void (*handler)(int)) {
     struct sigaction sa;
     memset(&sa, 0, sizeof(struct sigaction));
     sa.sa_handler = handler;
@@ -226,8 +225,8 @@ int install_signal(int signo, void(*handler)(int)) {
     if (ret != 0) {
         char buf[64];
         LOG(ERROR) << "install signal failed, signo=" << signo
-            << ", errno=" << errno
-            << ", errmsg=" << strerror_r(errno, buf, sizeof(buf));
+                   << ", errno=" << errno
+                   << ", errmsg=" << strerror_r(errno, buf, sizeof(buf));
     }
     return ret;
 }
@@ -295,4 +294,4 @@ void init_daemon(int argc, char** argv, const std::vector<StorePath>& paths) {
     ChunkAllocator::init_instance(config::chunk_reserved_bytes_limit);
 }
 
-}
+} // namespace doris

--- a/be/src/common/daemon.h
+++ b/be/src/common/daemon.h
@@ -29,6 +29,6 @@ class StorePath;
 // performed until after this method returns.
 void init_daemon(int argc, char** argv, const std::vector<StorePath>& paths);
 
-}
+} // namespace doris
 
 #endif

--- a/be/src/common/global_types.h
+++ b/be/src/common/global_types.h
@@ -28,6 +28,6 @@ typedef int SlotId;
 typedef int TableId;
 typedef int PlanNodeId;
 
-};
+}; // namespace doris
 
 #endif

--- a/be/src/common/hdfs.h
+++ b/be/src/common/hdfs.h
@@ -29,4 +29,3 @@ typedef void* hdfsFile;
 #endif
 
 #endif
-

--- a/be/src/common/logconfig.cpp
+++ b/be/src/common/logconfig.cpp
@@ -15,13 +15,13 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include <iostream>
-#include <cerrno>
-#include <cstring>
-#include <cstdlib>
-#include <mutex>
 #include <glog/logging.h>
 #include <glog/vlog_is_on.h>
+#include <cerrno>
+#include <cstdlib>
+#include <cstring>
+#include <iostream>
+#include <mutex>
 #include "common/config.h"
 
 namespace doris {
@@ -30,8 +30,7 @@ static bool logging_initialized = false;
 
 static std::mutex logging_mutex;
 
-static bool iequals(const std::string& a, const std::string& b)
-{
+static bool iequals(const std::string& a, const std::string& b) {
     unsigned int sz = a.size();
     if (b.size() != sz) {
         return false;
@@ -42,10 +41,9 @@ static bool iequals(const std::string& a, const std::string& b)
         }
     }
     return true;
-}       
+}
 
 bool init_glog(const char* basename, bool install_signal_handler) {
-
     std::lock_guard<std::mutex> logging_lock(logging_mutex);
 
     if (logging_initialized) {
@@ -63,10 +61,10 @@ bool init_glog(const char* basename, bool install_signal_handler) {
     // 0 means buffer INFO only
     FLAGS_logbuflevel = 0;
     // buffer log messages for at most this many seconds
-    FLAGS_logbufsecs = 30;  
+    FLAGS_logbufsecs = 30;
     // set roll num
     FLAGS_log_filenum_quota = config::sys_log_roll_num;
-    
+
     // set log level
     std::string& loglevel = config::sys_log_level;
     if (iequals(loglevel, "INFO")) {
@@ -104,7 +102,7 @@ bool init_glog(const char* basename, bool install_signal_handler) {
     } else if (rollmode.substr(0, sizeflag.length()).compare(sizeflag) == 0) {
         FLAGS_log_split_method = "size";
         std::string sizestr = rollmode.substr(sizeflag.size(), rollmode.size() - sizeflag.size());
-        if (sizestr.size() != 0)  {
+        if (sizestr.size() != 0) {
             char* end = NULL;
             errno = 0;
             const char* sizecstr = sizestr.c_str();
@@ -138,9 +136,8 @@ bool init_glog(const char* basename, bool install_signal_handler) {
     google::InitGoogleLogging(basename);
 
     logging_initialized = true;
- 
-    return true;
 
+    return true;
 }
 
 void shutdown_logging() {

--- a/be/src/common/logging.h
+++ b/be/src/common/logging.h
@@ -23,16 +23,25 @@
 // issues when we try to dynamically link the codegen'd functions.
 #ifdef IR_COMPILE
 #include <iostream>
-#define DCHECK(condition) while (false) std::cout
-#define DCHECK_EQ(a, b) while(false) std::cout
-#define DCHECK_NE(a, b) while(false) std::cout
-#define DCHECK_GT(a, b) while(false) std::cout
-#define DCHECK_LT(a, b) while(false) std::cout
-#define DCHECK_GE(a, b) while(false) std::cout
-#define DCHECK_LE(a, b) while(false) std::cout
+#define DCHECK(condition) \
+    while (false) std::cout
+#define DCHECK_EQ(a, b) \
+    while (false) std::cout
+#define DCHECK_NE(a, b) \
+    while (false) std::cout
+#define DCHECK_GT(a, b) \
+    while (false) std::cout
+#define DCHECK_LT(a, b) \
+    while (false) std::cout
+#define DCHECK_GE(a, b) \
+    while (false) std::cout
+#define DCHECK_LE(a, b) \
+    while (false) std::cout
 // Similar to how glog defines DCHECK for release.
-#define LOG(level) while (false) std::cout
-#define VLOG(level) while (false) std::cout
+#define LOG(level) \
+    while (false) std::cout
+#define VLOG(level) \
+    while (false) std::cout
 #else
 // GLOG defines this based on the system but doesn't check if it's already
 // been defined.  undef it first to avoid warnings.
@@ -41,19 +50,19 @@
 #undef _XOPEN_SOURCE
 // This is including a glog internal file.  We want this to expose the
 // function to get the stack trace.
-#include <glog/logging.h>
 #include <common/config.h>
+#include <glog/logging.h>
 #undef MutexLock
 #endif
 
 // Define VLOG levels.  We want display per-row info less than per-file which
 // is less than per-query.  For now per-connection is the same as per-query.
 #define VLOG_CONNECTION VLOG(1)
-#define VLOG_RPC        VLOG(8)
-#define VLOG_QUERY      VLOG(1)
-#define VLOG_FILE       VLOG(2)
-#define VLOG_ROW        VLOG(10)
-#define VLOG_PROGRESS   VLOG(2)
+#define VLOG_RPC VLOG(8)
+#define VLOG_QUERY VLOG(1)
+#define VLOG_FILE VLOG(2)
+#define VLOG_ROW VLOG(10)
+#define VLOG_PROGRESS VLOG(2)
 
 #define VLOG_CONNECTION_IS_ON VLOG_IS_ON(1)
 #define VLOG_RPC_IS_ON VLOG_IS_ON(2)

--- a/be/src/common/names.h
+++ b/be/src/common/names.h
@@ -77,13 +77,11 @@ using std::setfill;
 using std::setw;
 #endif
 
-
 #ifdef _GLIBCXX_FSTREAM
 using std::fstream;
 using std::ifstream;
 using std::ofstream;
 #endif
-
 
 #ifdef _GLIBCXX_SSTREAM
 using std::stringstream;
@@ -133,14 +131,13 @@ using boost::lexical_cast;
 using boost::shared_mutex;
 #endif
 
-
 /// In older versions of boost, when including mutex.hpp, it would include locks.hpp that
 /// would in turn provide lock_guard<>. In more recent versions, including mutex.hpp would
 /// include lock_types.hpp that does not provide lock_guard<>. This check verifies if boost
 /// locks have been included and makes sure to only include lock_guard if the provided lock
 /// implementations were not included using lock_types.hpp (for older boost versions) or if
 /// lock_guard.hpp was explicitly included.
-#if (defined(BOOST_THREAD_LOCKS_HPP) && BOOST_VERSION < 105300)  || defined(BOOST_THREAD_LOCK_GUARD_HPP)
+#if (defined(BOOST_THREAD_LOCKS_HPP) && BOOST_VERSION < 105300) || defined(BOOST_THREAD_LOCK_GUARD_HPP)
 using boost::lock_guard;
 #endif
 

--- a/be/src/common/object_pool.h
+++ b/be/src/common/object_pool.h
@@ -18,9 +18,9 @@
 #ifndef DORIS_BE_SRC_COMMON_COMMON_OBJECT_POOL_H
 #define DORIS_BE_SRC_COMMON_COMMON_OBJECT_POOL_H
 
-#include <vector>
-#include <boost/thread/mutex.hpp>
 #include <boost/thread/locks.hpp>
+#include <boost/thread/mutex.hpp>
+#include <vector>
 
 #include "util/spinlock.h"
 
@@ -31,7 +31,8 @@ namespace doris {
 // Thread-safe.
 class ObjectPool {
 public:
-    ObjectPool(): _objects() {}
+    ObjectPool() :
+            _objects() {}
 
     ~ObjectPool() {
         clear();
@@ -70,7 +71,8 @@ private:
 
     template <class T>
     struct SpecificElement : GenericElement {
-        SpecificElement(T* t): t(t) {}
+        SpecificElement(T* t) :
+                t(t) {}
         ~SpecificElement() {
             delete t;
         }
@@ -83,6 +85,6 @@ private:
     SpinLock _lock;
 };
 
-}
+} // namespace doris
 
 #endif

--- a/be/src/common/resource_tls.cpp
+++ b/be/src/common/resource_tls.cpp
@@ -64,4 +64,4 @@ int ResourceTls::set_resource_tls(TResourceInfo* info) {
     return ret;
 }
 
-}
+} // namespace doris

--- a/be/src/common/resource_tls.h
+++ b/be/src/common/resource_tls.h
@@ -28,6 +28,6 @@ public:
     static int set_resource_tls(TResourceInfo*);
 };
 
-}
+} // namespace doris
 
 #endif

--- a/be/src/common/status.cpp
+++ b/be/src/common/status.cpp
@@ -36,7 +36,8 @@ const char* Status::copy_state(const char* state) {
     return result;
 }
 
-Status::Status(const TStatus& s) : _state(nullptr) {
+Status::Status(const TStatus& s) :
+        _state(nullptr) {
     if (s.status_code != TStatusCode::OK) {
         if (s.error_msgs.empty()) {
             _state = assemble_state(s.status_code, Slice(), 1, Slice());
@@ -46,7 +47,8 @@ Status::Status(const TStatus& s) : _state(nullptr) {
     }
 }
 
-Status::Status(const PStatus& s) : _state(nullptr) {
+Status::Status(const PStatus& s) :
+        _state(nullptr) {
     TStatusCode::type code = (TStatusCode::type)s.status_code();
     if (code != TStatusCode::OK) {
         if (s.error_msgs_size() == 0) {
@@ -57,8 +59,8 @@ Status::Status(const PStatus& s) : _state(nullptr) {
     }
 }
 
-Status::Status(TStatusCode::type code, const Slice& msg, int16_t precise_code, const Slice& msg2)
-        : _state(assemble_state(code, msg, precise_code, msg2)) {
+Status::Status(TStatusCode::type code, const Slice& msg, int16_t precise_code, const Slice& msg2) :
+        _state(assemble_state(code, msg, precise_code, msg2)) {
 }
 
 void Status::to_thrift(TStatus* s) const {
@@ -194,4 +196,4 @@ Status Status::clone_and_append(const Slice& msg) const {
     return Status(code(), message(), precise_code(), msg);
 }
 
-}
+} // namespace doris

--- a/be/src/common/status.h
+++ b/be/src/common/status.h
@@ -7,9 +7,9 @@
 #include <string>
 #include <vector>
 
-#include "common/logging.h"
 #include "common/compiler_util.h"
-#include "gen_cpp/Status_types.h"  // for TStatus
+#include "common/logging.h"
+#include "gen_cpp/Status_types.h" // for TStatus
 #include "gen_cpp/status.pb.h" // for PStatus
 #include "util/slice.h" // for Slice
 
@@ -17,12 +17,13 @@ namespace doris {
 
 class Status {
 public:
-    Status(): _state(nullptr) {}
+    Status() :
+            _state(nullptr) {}
     ~Status() noexcept { delete[] _state; }
 
     // copy c'tor makes copy of error detail so Status can be returned by value
-    Status(const Status& s)
-            : _state(s._state == nullptr ? nullptr : copy_state(s._state))  {
+    Status(const Status& s) :
+            _state(s._state == nullptr ? nullptr : copy_state(s._state)) {
     }
 
     // same as copy c'tor
@@ -37,7 +38,8 @@ public:
     }
 
     // move c'tor
-    Status(Status&& s) noexcept : _state(s._state) {
+    Status(Status&& s) noexcept :
+            _state(s._state) {
         s._state = nullptr;
     }
 
@@ -73,13 +75,13 @@ public:
         return Status(TStatusCode::CORRUPTION, msg, precise_code, msg2);
     }
     static Status IOError(const Slice& msg,
-                               int16_t precise_code = 1,
-                               const Slice& msg2 = Slice()) {
+                          int16_t precise_code = 1,
+                          const Slice& msg2 = Slice()) {
         return Status(TStatusCode::IO_ERROR, msg, precise_code, msg2);
     }
     static Status NotFound(const Slice& msg,
-                               int16_t precise_code = 1,
-                               const Slice& msg2 = Slice()) {
+                           int16_t precise_code = 1,
+                           const Slice& msg2 = Slice()) {
         return Status(TStatusCode::NOT_FOUND, msg, precise_code, msg2);
     }
     static Status AlreadyExist(const Slice& msg,
@@ -98,8 +100,8 @@ public:
         return Status(TStatusCode::END_OF_FILE, msg, precise_code, msg2);
     }
     static Status InternalError(const Slice& msg,
-                               int16_t precise_code = 1,
-                               const Slice& msg2 = Slice()) {
+                                int16_t precise_code = 1,
+                                const Slice& msg2 = Slice()) {
         return Status(TStatusCode::INTERNAL_ERROR, msg, precise_code, msg2);
     }
     static Status RuntimeError(const Slice& msg,
@@ -135,8 +137,8 @@ public:
     bool is_end_of_file() const { return code() == TStatusCode::END_OF_FILE; }
 
     bool is_not_found() const { return code() == TStatusCode::NOT_FOUND; }
-    
-    bool is_io_error() const {return code() == TStatusCode::IO_ERROR; }
+
+    bool is_io_error() const { return code() == TStatusCode::IO_ERROR; }
     // Convert into TStatus. Call this if 'status_container' contains an optional
     // TStatus field named 'status'. This also sets __isset.status.
     template <typename T>
@@ -242,7 +244,7 @@ private:
         const Status& _status_ = (stmt); \
         if (UNLIKELY(!_status_.ok())) { \
             string msg = _status_.get_error_msg(); \
-            LOG(ERROR) << msg;            \
+            LOG(ERROR) << msg; \
             exit(1); \
         } \
     } while (false)
@@ -250,20 +252,20 @@ private:
 /// @brief Emit a warning if @c to_call returns a bad status.
 #define WARN_IF_ERROR(to_call, warning_prefix) \
     do { \
-        const Status& _s = (to_call);  \
+        const Status& _s = (to_call); \
         if (UNLIKELY(!_s.ok())) { \
-            LOG(WARNING) << (warning_prefix) << ": " << _s.to_string();  \
+            LOG(WARNING) << (warning_prefix) << ": " << _s.to_string(); \
         } \
     } while (0);
 
 #define RETURN_WITH_WARN_IF_ERROR(stmt, ret_code, warning_prefix) \
-    do {    \
-        const Status& _s = (stmt);  \
-        if (UNLIKELY(!_s.ok())) {   \
+    do { \
+        const Status& _s = (stmt); \
+        if (UNLIKELY(!_s.ok())) { \
             LOG(WARNING) << (warning_prefix) << ", error: " << _s.to_string(); \
-            return ret_code;    \
-        }   \
+            return ret_code; \
+        } \
     } while (0);
-}
+} // namespace doris
 
 #define WARN_UNUSED_RESULT __attribute__((warn_unused_result))

--- a/be/src/common/utils.h
+++ b/be/src/common/utils.h
@@ -30,7 +30,7 @@ struct AuthInfo {
     int64_t auth_code = -1;
 };
 
-template<class T>
+template <class T>
 void set_request_auth(T* req, const AuthInfo& auth) {
     if (auth.auth_code != -1) {
         // if auth_code is set, no need to set other info
@@ -49,4 +49,4 @@ void set_request_auth(T* req, const AuthInfo& auth) {
     }
 }
 
-}
+} // namespace doris

--- a/be/src/env/env.h
+++ b/be/src/env/env.h
@@ -9,8 +9,8 @@
 
 #pragma once
 
-#include <string>
 #include <memory>
+#include <string>
 
 #include "common/status.h"
 #include "util/slice.h"
@@ -42,8 +42,8 @@ public:
         MUST_EXIST
     };
 
-    Env() { }
-    virtual ~Env() { }
+    Env() {}
+    virtual ~Env() {}
 
     // Return a default environment suitable for the current operating
     // system.  Sophisticated users may wish to provide their own Env
@@ -82,7 +82,6 @@ public:
     // The returned file will only be accessed by one thread at a time.
     virtual Status new_writable_file(const std::string& fname,
                                      std::unique_ptr<WritableFile>* result) = 0;
-
 
     // Like the previous new_writable_file, but allows options to be
     // specified.
@@ -165,7 +164,7 @@ public:
 
     // Store the last modification time of fname in *file_mtime.
     virtual Status get_file_modified_time(const std::string& fname,
-                                              uint64_t* file_mtime) = 0;
+                                          uint64_t* file_mtime) = 0;
     // Rename file src to target.
     virtual Status rename_file(const std::string& src,
                                const std::string& target) = 0;
@@ -178,7 +177,7 @@ public:
 };
 
 struct RandomAccessFileOptions {
-    RandomAccessFileOptions() { }
+    RandomAccessFileOptions() {}
 };
 
 // Creation-time options for WritableFile
@@ -200,8 +199,8 @@ struct RandomRWFileOptions {
 // A file abstraction for reading sequentially through a file
 class SequentialFile {
 public:
-    SequentialFile() { }
-    virtual ~SequentialFile() { }
+    SequentialFile() {}
+    virtual ~SequentialFile() {}
 
     // Read up to "result.size" bytes from the file.
     // Sets "result.data" to the data that was read.
@@ -227,8 +226,8 @@ public:
 
 class RandomAccessFile {
 public:
-    RandomAccessFile() { }
-    virtual ~RandomAccessFile() { }
+    RandomAccessFile() {}
+    virtual ~RandomAccessFile() {}
 
     // Read "result.size" bytes from the file starting at "offset".
     // Copies the resulting data into "result.data".
@@ -272,8 +271,8 @@ public:
         FLUSH_ASYNC
     };
 
-    WritableFile() { }
-    virtual ~WritableFile() { }
+    WritableFile() {}
+    virtual ~WritableFile() {}
 
     // Append data to the end of the file
     // Note: A WritableFile object must support either Append or
@@ -323,7 +322,7 @@ public:
         FLUSH_ASYNC
     };
     RandomRWFile() {}
-    virtual ~RandomRWFile() { }
+    virtual ~RandomRWFile() {}
 
     virtual Status read_at(uint64_t offset, const Slice& result) const = 0;
 
@@ -343,4 +342,4 @@ public:
     virtual const std::string& filename() const = 0;
 };
 
-}
+} // namespace doris


### PR DESCRIPTION
Part of #2790 

This PR reformat "agent codegen common env" modules with the following command

```
$ find be/src/agent be/src/codegen be/src/common be/src/env -type f \( -name \*.h -or -name \*.hpp -or -name \*.cpp -or -iname \*.cc \) | xargs clang-format -i -style=file
```

I have disabled clang-format on full or part of the following files in order to minimize diff size.
```
be/src/agent/agent_server.cpp
be/src/agent/cgroups_mgr.cpp
be/src/codegen/codegen_anyval.cpp
be/src/common/config.h
be/src/common/configbase.h
be/src/common/logging.h
```
