### PR TITLE
Improve comparison and printing of Version

### DIFF
--- a/be/src/olap/data_dir.h
+++ b/be/src/olap/data_dir.h
@@ -25,11 +25,17 @@
 
 #include "common/status.h"
 #include "gen_cpp/Types_types.h"
+#include "gen_cpp/olap_file.pb.h"
 #include "olap/olap_common.h"
-#include "olap/storage_engine.h"
 #include "olap/rowset/rowset_id_generator.h"
+#include "olap/utils.h"
 
 namespace doris {
+
+class Tablet;
+class TabletManager;
+class TabletMeta;
+class TxnManager;
 
 // A DataDir used to manange data in same path.
 // Now, After DataDir was created, it will never be deleted for easy implementation.
@@ -68,7 +74,6 @@ public:
     void health_check();
 
     OLAPStatus get_shard(uint64_t* shard);
-
 
     OlapMeta* get_meta() { return _meta; }
 

--- a/be/src/olap/memtable.cpp
+++ b/be/src/olap/memtable.cpp
@@ -25,6 +25,7 @@
 #include "olap/schema.h"
 #include "runtime/tuple.h"
 #include "util/debug_util.h"
+#include "util/doris_metrics.h"
 
 namespace doris {
 
@@ -51,8 +52,7 @@ MemTable::~MemTable() {
     delete _skip_list;
 }
 
-MemTable::RowCursorComparator::RowCursorComparator(const Schema* schema)
-    : _schema(schema) {}
+MemTable::RowCursorComparator::RowCursorComparator(const Schema* schema) : _schema(schema) {}
 
 int MemTable::RowCursorComparator::operator()(const char* left, const char* right) const {
     ContiguousRow lhs_row(_schema, left);

--- a/be/src/olap/olap_common.h
+++ b/be/src/olap/olap_common.h
@@ -71,10 +71,7 @@ struct DataDirInfo {
 };
 
 struct TabletInfo {
-    TabletInfo(
-            TTabletId in_tablet_id,
-            TSchemaHash in_schema_hash,
-            UniqueId in_uid) :
+    TabletInfo(TTabletId in_tablet_id, TSchemaHash in_schema_hash, UniqueId in_uid) :
             tablet_id(in_tablet_id),
             schema_hash(in_schema_hash),
             tablet_uid(in_uid) {}
@@ -189,8 +186,9 @@ struct Version {
     int64_t second;
 
     Version(int64_t first_, int64_t second_) : first(first_), second(second_) {}
-
     Version() : first(0), second(0) {}
+
+    friend std::ostream& operator<<(std::ostream& os, const Version& version);
 
     bool operator!=(const Version& rhs) const {
         return first != rhs.first || second != rhs.second;
@@ -199,9 +197,17 @@ struct Version {
     bool operator==(const Version& rhs) const {
         return first == rhs.first && second == rhs.second;
     }
+
+    bool contains(const Version& other) const {
+        return first <= other.first && second >= other.first;
+    }
 };
 
 typedef std::vector<Version> Versions;
+
+inline std::ostream& operator<<(std::ostream& os, const Version& version) {
+    return os << "["<< version.first << "-" << version.second << "]";
+}
 
 // used for hash-struct of hash_map<Version, Rowset*>.
 struct HashOfVersion {
@@ -341,7 +347,6 @@ struct RowsetId {
         out << rowset_id.to_string();
         return out;
     }
-
 };
 
 }  // namespace doris

--- a/be/src/olap/olap_common.h
+++ b/be/src/olap/olap_common.h
@@ -199,7 +199,7 @@ struct Version {
     }
 
     bool contains(const Version& other) const {
-        return first <= other.first && second >= other.first;
+        return first <= other.first && second >= other.second;
     }
 };
 

--- a/be/src/olap/olap_define.h
+++ b/be/src/olap/olap_define.h
@@ -37,7 +37,7 @@ static const uint32_t OLAP_DEFAULT_MAX_UNPACKED_ROW_BLOCK_SIZE = 1024 * 1024 * 1
 // 列存储文件的块大小,由于可能会被全部载入内存,所以需要严格控制大小, 这里定义为256MB
 static const uint32_t OLAP_MAX_COLUMN_SEGMENT_FILE_SIZE = 268435456;
 // 列存储文件大小的伸缩性
-static const float OLAP_COLUMN_FILE_SEGMENT_SIZE_SCALE = 0.9f;
+static const double OLAP_COLUMN_FILE_SEGMENT_SIZE_SCALE = 0.9;
 // 在列存储文件中, 数据分块压缩, 每个块的默认压缩前的大小
 static const uint32_t OLAP_DEFAULT_COLUMN_STREAM_BUFFER_SIZE = 10 * 1024;
 // 在列存储文件中, 对字符串使用字典编码的字典大小门限
@@ -246,9 +246,9 @@ enum OLAPStatus {
     OLAP_ERR_PUSH_INPUT_DATA_ERROR = -910,
     OLAP_ERR_PUSH_TRANSACTION_ALREADY_EXIST = -911,
     // only support realtime push api, batch process is deprecated and is removed
-    OLAP_ERR_PUSH_BATCH_PROCESS_REMOVED = -912, 
-    OLAP_ERR_PUSH_COMMIT_ROWSET = -913, 
-    OLAP_ERR_PUSH_ROWSET_NOT_FOUND = -914, 
+    OLAP_ERR_PUSH_BATCH_PROCESS_REMOVED = -912,
+    OLAP_ERR_PUSH_COMMIT_ROWSET = -913,
+    OLAP_ERR_PUSH_ROWSET_NOT_FOUND = -914,
 
     // SegmentGroup
     // [-1000, -1100)

--- a/be/src/olap/rowset/beta_rowset.h
+++ b/be/src/olap/rowset/beta_rowset.h
@@ -22,15 +22,16 @@
 #include "olap/olap_define.h"
 #include "olap/rowset/rowset.h"
 #include "olap/rowset/rowset_meta.h"
+#include "olap/rowset/rowset_reader.h"
 #include "olap/rowset/segment_v2/segment.h"
-#include "olap/data_dir.h"
 
 namespace doris {
 
-class BetaRowset;
-using BetaRowsetSharedPtr = std::shared_ptr<BetaRowset>;
 class BetaRowsetReader;
 class RowsetFactory;
+
+class BetaRowset;
+using BetaRowsetSharedPtr = std::shared_ptr<BetaRowset>;
 
 class BetaRowset : public Rowset {
 public:
@@ -60,8 +61,6 @@ public:
     bool check_path(const std::string& path) override;
 
 protected:
-    friend class RowsetFactory;
-
     BetaRowset(const TabletSchema* schema,
                std::string rowset_path,
                RowsetMetaSharedPtr rowset_meta);
@@ -74,6 +73,7 @@ protected:
     void do_close() override;
 
 private:
+    friend class RowsetFactory;
     friend class BetaRowsetReader;
     std::vector<segment_v2::SegmentSharedPtr> _segments;
 };

--- a/be/src/olap/rowset/beta_rowset_reader.cpp
+++ b/be/src/olap/rowset/beta_rowset_reader.cpp
@@ -23,6 +23,7 @@
 #include "olap/row_cursor.h"
 #include "olap/rowset/segment_v2/segment_iterator.h"
 #include "olap/schema.h"
+#include "olap/delete_handler.h"
 
 namespace doris {
 

--- a/be/src/olap/rowset/rowset.h
+++ b/be/src/olap/rowset/rowset.h
@@ -218,7 +218,7 @@ public:
     }
 
     bool contains_version(Version version) {
-        return rowset_meta()->version().first <= version.first && rowset_meta()->version().second >= version.second;
+        return rowset_meta()->version().contains(version);
     }
 
     static bool comparator(const RowsetSharedPtr& left, const RowsetSharedPtr& right) {

--- a/be/src/olap/rowset/rowset_converter.h
+++ b/be/src/olap/rowset/rowset_converter.h
@@ -25,6 +25,7 @@
 #include "olap/rowset/alpha_rowset_writer.h"
 #include "olap/rowset/beta_rowset.h"
 #include "olap/rowset/beta_rowset_reader.h"
+#include "olap/tablet_meta.h"
 
 namespace doris {
 

--- a/be/src/olap/rowset/rowset_meta.h
+++ b/be/src/olap/rowset/rowset_meta.h
@@ -77,7 +77,7 @@ public:
         return _rowset_id;
     }
 
-    void set_rowset_id(RowsetId rowset_id) {
+    void set_rowset_id(const RowsetId& rowset_id) {
         // rowset id is a required field, just set it to 0
         _rowset_meta_pb.set_rowset_id(0);
         _rowset_id = rowset_id;
@@ -133,8 +133,7 @@ public:
     }
 
     Version version() const {
-        return { _rowset_meta_pb.start_version(),
-                 _rowset_meta_pb.end_version() };  
+        return { _rowset_meta_pb.start_version(), _rowset_meta_pb.end_version() };
     }
 
     void set_version(Version version) {
@@ -154,7 +153,7 @@ public:
     void set_start_version(int64_t start_version) {
         _rowset_meta_pb.set_start_version(start_version);
     }
-    
+
     int64_t end_version() const {
         return _rowset_meta_pb.end_version();
     }
@@ -162,7 +161,7 @@ public:
     void set_end_version(int64_t end_version) {
         _rowset_meta_pb.set_end_version(end_version);
     }
-    
+
     VersionHash version_hash() const {
         return _rowset_meta_pb.version_hash();
     }
@@ -381,7 +380,7 @@ private:
             // ATTN(cmy): the num segments should be read from rowset meta pb.
             // But the previous code error caused this value not to be set in some cases.
             // So when init the rowset meta and find that the num_segments is 0(not set),
-            // we will try to calculate the num segmengts from AlphaRowsetExtraMetaPB, 
+            // we will try to calculate the num segmengts from AlphaRowsetExtraMetaPB,
             // and then set the num_segments field.
             // This should only happen in some rowsets converted from old version.
             // and for all newly created rowsets, the num_segments field must be set.

--- a/be/src/olap/rowset/rowset_writer.h
+++ b/be/src/olap/rowset/rowset_writer.h
@@ -28,7 +28,6 @@ namespace doris {
 
 class ContiguousRow;
 class RowCursor;
-class RowsetWriter;
 
 class RowsetWriter {
 public:

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -255,7 +255,7 @@ OLAPStatus Tablet::add_rowset(RowsetSharedPtr rowset, bool need_persist) {
     // yiguolei: temp code, should remove the rowset contains by this rowset
     // but it should be removed in multi path version
     for (auto& it : _rs_version_map) {
-        if (it.first.contains(rowset->version()) && it.first != rowset->version()) {
+        if (rowset->version().contains(it.first) && rowset->version() != it.first) {
             if (it.second == nullptr) {
                 LOG(FATAL) << "there exist a version=" << it.first
                            << " contains the input rs with version=" << rowset->version()

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -29,7 +29,6 @@
 #include <rapidjson/prettywriter.h>
 #include <rapidjson/stringbuffer.h>
 
-#include "olap/data_dir.h"
 #include "olap/olap_common.h"
 #include "olap/olap_define.h"
 #include "olap/storage_engine.h"
@@ -38,7 +37,7 @@
 #include "olap/rowset/rowset_meta_manager.h"
 #include "olap/rowset/rowset_factory.h"
 #include "olap/tablet_meta_manager.h"
-#include "olap/utils.h"
+#include "util/path_util.h"
 #include "util/time.h"
 
 namespace doris {
@@ -61,31 +60,29 @@ TabletSharedPtr Tablet::create_tablet_from_meta(
     return tablet;
 }
 
-Tablet::Tablet(TabletMetaSharedPtr tablet_meta, DataDir* data_dir)
-  : _state(tablet_meta->tablet_state()),
-    _tablet_meta(tablet_meta),
-    _schema(tablet_meta->tablet_schema()),
-    _data_dir(data_dir),
-    _is_bad(false),
-    _last_cumu_compaction_failure_millis(0),
-    _last_base_compaction_failure_millis(0),
-    _last_cumu_compaction_success_millis(0),
-    _last_base_compaction_success_millis(0) {
+void Tablet::_gen_tablet_path() {
+    std::string path = _data_dir->path() + DATA_PREFIX;
+    path = path_util::join_path_segments(path, std::to_string(_tablet_meta->shard_id()));
+    path = path_util::join_path_segments(path, std::to_string(_tablet_meta->tablet_id()));
+    path = path_util::join_path_segments(path, std::to_string(_tablet_meta->schema_hash()));
+    _tablet_path = path;
+}
 
-    _tablet_path.append(_data_dir->path());
-    _tablet_path.append(DATA_PREFIX);
-    _tablet_path.append("/");
-    _tablet_path.append(std::to_string(_tablet_meta->shard_id()));
-    _tablet_path.append("/");
-    _tablet_path.append(std::to_string(_tablet_meta->tablet_id()));
-    _tablet_path.append("/");
-    _tablet_path.append(std::to_string(_tablet_meta->schema_hash()));
-
+Tablet::Tablet(TabletMetaSharedPtr tablet_meta, DataDir* data_dir) :
+        _state(tablet_meta->tablet_state()),
+        _tablet_meta(tablet_meta),
+        _schema(tablet_meta->tablet_schema()),
+        _data_dir(data_dir),
+        _is_bad(false),
+        _last_cumu_compaction_failure_millis(0),
+        _last_base_compaction_failure_millis(0),
+        _last_cumu_compaction_success_millis(0),
+        _last_base_compaction_success_millis(0) {
+    _gen_tablet_path();
     _rs_graph.construct_rowset_graph(_tablet_meta->all_rs_metas());
 }
 
 Tablet::~Tablet() {
-    WriteLock wrlock(&_meta_lock);
     _rs_version_map.clear();
     _inc_rs_version_map.clear();
 }
@@ -95,14 +92,14 @@ OLAPStatus Tablet::_init_once_action() {
     VLOG(3) << "begin to load tablet. tablet=" << full_name()
             << ", version_size=" << _tablet_meta->version_count();
     for (auto& rs_meta :  _tablet_meta->all_rs_metas()) {
-        Version version = { rs_meta->start_version(), rs_meta->end_version() };
+        Version version = rs_meta->version();
         RowsetSharedPtr rowset;
         res = RowsetFactory::create_rowset(&_schema, _tablet_path, rs_meta, &rowset);
         if (res != OLAP_SUCCESS) {
-            LOG(WARNING) << "fail to init rowset. tablet_id:" << tablet_id()
-                         << ", schema_hash:" << schema_hash()
-                         << ", version=" << version.first << "-" << version.second
-                         << ", res:" << res;
+            LOG(WARNING) << "fail to init rowset. tablet_id=" << tablet_id()
+                         << ", schema_hash=" << schema_hash()
+                         << ", version=" << version
+                         << ", res=" << res;
             return res;
         }
         _rs_version_map[version] = std::move(rowset);
@@ -110,14 +107,14 @@ OLAPStatus Tablet::_init_once_action() {
 
     // init incremental rowset
     for (auto& inc_rs_meta : _tablet_meta->all_inc_rs_metas()) {
-        Version version = { inc_rs_meta->start_version(), inc_rs_meta->end_version() };
+        Version version = inc_rs_meta->version();
         RowsetSharedPtr rowset = get_rowset_by_version(version);
         if (rowset == nullptr) {
             res = RowsetFactory::create_rowset(&_schema, _tablet_path, inc_rs_meta, &rowset);
             if (res != OLAP_SUCCESS) {
                 LOG(WARNING) << "fail to init incremental rowset. tablet_id:" << tablet_id()
                              << ", schema_hash:" << schema_hash()
-                             << ", version=" << version.first << "-" << version.second
+                             << ", version=" << version
                              << ", res:" << res;
                 return res;
             }
@@ -126,24 +123,11 @@ OLAPStatus Tablet::_init_once_action() {
     }
 
     _cumulative_point = -1;
-
     return res;
 }
 
 OLAPStatus Tablet::init() {
     return _init_once.call([this] { return _init_once_action(); });
-}
-
-bool Tablet::is_used() {
-    return !_is_bad && _data_dir->is_used();
-}
-
-TabletUid Tablet::tablet_uid() {
-    return _tablet_meta->tablet_uid();
-}
-
-string Tablet::tablet_path() const {
-    return _tablet_path;
 }
 
 OLAPStatus Tablet::set_tablet_state(TabletState state) {
@@ -161,9 +145,11 @@ OLAPStatus Tablet::set_tablet_state(TabletState state) {
 OLAPStatus Tablet::save_meta() {
     OLAPStatus res = _tablet_meta->save_meta(_data_dir);
     if (res != OLAP_SUCCESS) {
-       LOG(FATAL) << "fail to save tablet_meta. res=" << res
-                    << ", root=" << _data_dir->path();
+       LOG(FATAL) << "fail to save tablet_meta. res=" << res << ", root=" << _data_dir->path();
     }
+    // TODO(lingbin): Why we refetch schema again? should leave a comment to tell everyone why.
+    // seems that in schema-change task where schema will change, this method will be called.
+    // Maybe we should add a param named need_update_schema to this method.
     _schema = _tablet_meta->tablet_schema();
 
     return res;
@@ -185,15 +171,17 @@ OLAPStatus Tablet::revise_tablet_meta(
         for (const Version& version : versions_to_delete) {
             res = new_tablet_meta->delete_rs_meta_by_version(version, nullptr);
             if (res != OLAP_SUCCESS) {
-                LOG(WARNING) << "failed to delete version from new local tablet meta. tablet=" << full_name()
-                             << ", version=" << version.first << "-" << version.second;
+                // TODO(lingbin): should we stop and return an non-ok status?
+                // Actually, this func always return Status::OK
+                LOG(WARNING) << "failed to delete version from new local tablet meta. tablet="
+                        << full_name() << ", version=" << version;
                 break;
             }
             if (new_tablet_meta->version_for_delete_predicate(version)) {
                 new_tablet_meta->remove_delete_predicate_by_version(version);
             }
-            LOG(INFO) << "delete version from new local tablet_meta when clone. [table='" << full_name()
-                      << "', version=" << version.first << "-" << version.second << "]";
+            LOG(INFO) << "delete version from new local tablet_meta when clone. [table="
+                    << full_name() << ", version=" << version << "]";
         }
 
         if (res != OLAP_SUCCESS) {
@@ -248,22 +236,17 @@ OLAPStatus Tablet::revise_tablet_meta(
     return res;
 }
 
-OLAPStatus Tablet::register_tablet_into_dir() {
-    return _data_dir->register_tablet(this);
-}
-
-OLAPStatus Tablet::deregister_tablet_from_dir() {
-    return _data_dir->deregister_tablet(this);
-}
-
 OLAPStatus Tablet::add_rowset(RowsetSharedPtr rowset, bool need_persist) {
+    DCHECK(rowset != nullptr);
     WriteLock wrlock(&_meta_lock);
-    // if the rowset already exist, should not return version already exist
-    // should return OLAP_SUCCESS
-    if (contains_rowset(rowset->rowset_id())) {
+    // If the rowset already exist, just return directly.  The rowset_id is an unique-id,
+    // we can use it to check this situation.
+    if (_contains_rowset(rowset->rowset_id())) {
         return OLAP_SUCCESS;
     }
-    RETURN_NOT_OK(_check_added_rowset(rowset));
+    // Otherwise, the version shoud be not contained in any existing rowset.
+    RETURN_NOT_OK(_contains_version(rowset->version()));
+
     RETURN_NOT_OK(_tablet_meta->add_rs_meta(rowset->rowset_meta()));
     _rs_version_map[rowset->version()] = rowset;
     RETURN_NOT_OK(_rs_graph.add_version_to_graph(rowset->version()));
@@ -272,16 +255,11 @@ OLAPStatus Tablet::add_rowset(RowsetSharedPtr rowset, bool need_persist) {
     // yiguolei: temp code, should remove the rowset contains by this rowset
     // but it should be removed in multi path version
     for (auto& it : _rs_version_map) {
-        if ((it.first.first >= rowset->start_version() && it.first.second < rowset->end_version())
-            || (it.first.first > rowset->start_version() && it.first.second <= rowset->end_version())) {
+        if (it.first.contains(rowset->version()) && it.first != rowset->version()) {
             if (it.second == nullptr) {
-                LOG(FATAL) << "there exist a version "
-                           << " start_version=" << it.first.first
-                           << " end_version=" << it.first.second
-                           << " contains the input rs with version "
-                           << " start_version=" << rowset->start_version()
-                           << " end_version=" << rowset->end_version()
-                           << " but the related rs is null";
+                LOG(FATAL) << "there exist a version=" << it.first
+                           << " contains the input rs with version=" << rowset->version()
+                           << ", but the related rs is null";
                 return OLAP_ERR_PUSH_ROWSET_NOT_FOUND;
             } else {
                 rowsets_to_delete.push_back(it.second);
@@ -293,8 +271,8 @@ OLAPStatus Tablet::add_rowset(RowsetSharedPtr rowset, bool need_persist) {
     if (need_persist) {
         RowsetMetaPB rowset_meta_pb;
         rowset->rowset_meta()->to_rowset_pb(&rowset_meta_pb);
-        OLAPStatus res = RowsetMetaManager::save(data_dir()->get_meta(), tablet_uid(), 
-            rowset->rowset_id(), rowset_meta_pb);
+        OLAPStatus res = RowsetMetaManager::save(data_dir()->get_meta(), tablet_uid(),
+                                                 rowset->rowset_id(), rowset_meta_pb);
         if (res != OLAP_SUCCESS) {
             LOG(FATAL) << "failed to save rowset to local meta store" << rowset->rowset_id();
         }
@@ -327,11 +305,10 @@ OLAPStatus Tablet::modify_rowsets(const vector<RowsetSharedPtr>& to_add,
     }
 
     _rs_graph.reconstruct_rowset_graph(_tablet_meta->all_rs_metas());
-
     return OLAP_SUCCESS;
 }
 
-// snapshot manager may call this api to check if version exists, so that 
+// snapshot manager may call this api to check if version exists, so that
 // the version maybe not exist
 const RowsetSharedPtr Tablet::get_rowset_by_version(const Version& version) const {
     auto iter = _rs_version_map.find(version);
@@ -345,53 +322,39 @@ const RowsetSharedPtr Tablet::get_rowset_by_version(const Version& version) cons
 }
 
 // This function only be called by SnapshotManager to perform incremental clone.
-// Interal data structure will be protected in SnapSshotManager.
-// There is no necessity to add lock in this place.
+// It will be called under protected of _metalock(SnapshotManager will fetch it manually),
+// so it is no need to lock here.
 const RowsetSharedPtr Tablet::get_inc_rowset_by_version(const Version& version) const {
     auto iter = _inc_rs_version_map.find(version);
     if (iter == _inc_rs_version_map.end()) {
-        LOG(INFO) << "no rowset for version:" << version.first << "-" << version.second
-                  << ", tablet: " << full_name();
+        LOG(INFO) << "no rowset for version:" << version << ", tablet: " << full_name();
         return nullptr;
     }
     RowsetSharedPtr rowset = iter->second;
     return rowset;
 }
 
-size_t Tablet::get_rowset_size_by_version(const Version& version) {
-    DCHECK(_rs_version_map.find(version) != _rs_version_map.end())
-            << "invalid version:" << version.first << "-" << version.second;
-    auto iter = _rs_version_map.find(version);
-    if (iter == _rs_version_map.end()) {
-        LOG(WARNING) << "no rowset for version:" << version.first << "-" << version.second
-                << ", tablet: " << full_name();
-        return -1;
-    }
-    RowsetSharedPtr rowset = iter->second;
-    return rowset->data_disk_size();
-}
-
+// Already under _meta_lock
 const RowsetSharedPtr Tablet::rowset_with_max_version() const {
     Version max_version = _tablet_meta->max_version();
     if (max_version.first == -1) {
         return nullptr;
     }
+
     DCHECK(_rs_version_map.find(max_version) != _rs_version_map.end())
-            << "invalid version:" << max_version.first << "-" << max_version.second;
+            << "invalid version:" << max_version;
     auto iter = _rs_version_map.find(max_version);
     if (iter == _rs_version_map.end()) {
-        LOG(WARNING) << "no rowset for version:" << max_version.first << "-" << max_version.second;
+        LOG(WARNING) << "no rowset for version:" << max_version;
         return nullptr;
     }
     RowsetSharedPtr rowset = iter->second;
     return rowset;
 }
 
-RowsetSharedPtr Tablet::rowset_with_largest_size() {
+RowsetSharedPtr Tablet::_rowset_with_largest_size() {
     RowsetSharedPtr largest_rowset = nullptr;
     for (auto& it : _rs_version_map) {
-        // use segment_group of base file as target segment_group when base is not empty,
-        // or try to find the biggest segment_group.
         if (it.second->empty() || it.second->zero_num_rows()) {
             continue;
         }
@@ -404,14 +367,15 @@ RowsetSharedPtr Tablet::rowset_with_largest_size() {
     return largest_rowset;
 }
 
-// add inc rowset should not persist tablet meta, because the 
+// add inc rowset should not persist tablet meta, because it will be persisted when publish txn.
 OLAPStatus Tablet::add_inc_rowset(const RowsetSharedPtr& rowset) {
+    DCHECK(rowset != nullptr);
     WriteLock wrlock(&_meta_lock);
-    if (contains_rowset(rowset->rowset_id())) {
+    if (_contains_rowset(rowset->rowset_id())) {
         return OLAP_SUCCESS;
     }
-    // check if the rowset id is valid
-    RETURN_NOT_OK(_check_added_rowset(rowset));
+    RETURN_NOT_OK(_contains_version(rowset->version()));
+
     RETURN_NOT_OK(_tablet_meta->add_rs_meta(rowset->rowset_meta()));
     _rs_version_map[rowset->version()] = rowset;
     _inc_rs_version_map[rowset->version()] = rowset;
@@ -421,33 +385,20 @@ OLAPStatus Tablet::add_inc_rowset(const RowsetSharedPtr& rowset) {
     return OLAP_SUCCESS;
 }
 
-bool Tablet::has_expired_inc_rowset() {
-    bool exist = false;
-    time_t now = time(NULL);
-    ReadLock rdlock(&_meta_lock);
-    for (auto& rs_meta : _tablet_meta->all_inc_rs_metas()) {
-        double diff = difftime(now, rs_meta->creation_time());
-        if (diff >= config::inc_rowset_expired_sec) {
-            exist = true;
-            break;
-        }
-    }
-    return exist;
-}
-
-void Tablet::delete_inc_rowset_by_version(const Version& version,
-                                          const VersionHash& version_hash) {
+void Tablet::_delete_inc_rowset_by_version(const Version& version,
+                                           const VersionHash& version_hash) {
     // delete incremental rowset from map
     auto it = _inc_rs_version_map.find(version);
     if (it != _inc_rs_version_map.end()) {
         _inc_rs_version_map.erase(it);
     }
     RowsetMetaSharedPtr rowset_meta = _tablet_meta->acquire_inc_rs_meta_by_version(version);
-    if (rowset_meta == nullptr) { return; }
+    if (rowset_meta == nullptr) {
+        return;
+    }
 
     _tablet_meta->delete_inc_rs_meta_by_version(version);
-    VLOG(3) << "delete incremental rowset. tablet=" << full_name() << ", "
-            << "version=" << version.first << "-" << version.second;
+    VLOG(3) << "delete incremental rowset. tablet=" << full_name() << ", version=" << version;
 }
 
 void Tablet::delete_expired_inc_rowsets() {
@@ -455,22 +406,25 @@ void Tablet::delete_expired_inc_rowsets() {
     vector<pair<Version, VersionHash>> expired_versions;
     WriteLock wrlock(&_meta_lock);
     for (auto& rs_meta : _tablet_meta->all_inc_rs_metas()) {
-        double diff = difftime(now, rs_meta->creation_time());
+        double diff = ::difftime(now, rs_meta->creation_time());
         if (diff >= config::inc_rowset_expired_sec) {
-            Version version(rs_meta->start_version(), rs_meta->end_version());
+            Version version(rs_meta->version());
             expired_versions.push_back(std::make_pair(version, rs_meta->version_hash()));
-            VLOG(3) << "find expire incremental rowset. tablet=" << full_name() << ", "
-                    << "version=" << rs_meta->start_version() << "-" << rs_meta->end_version() << ", "
-                    << "exist_sec=" << diff;
+            VLOG(3) << "find expire incremental rowset. tablet=" << full_name()
+                    << ", version=" << version
+                    << ", version_hash=" << rs_meta->version_hash()
+                    << ", exist_sec=" << diff;
         }
     }
 
-    if (expired_versions.empty()) { return; }
+    if (expired_versions.empty()) {
+        return;
+    }
 
     for (auto& pair: expired_versions) {
-        delete_inc_rowset_by_version(pair.first, pair.second);
-        VLOG(3) << "delete expire incremental data. tablet=" << full_name() << ", "
-                << "version=" << pair.first.first << "-" << pair.first.second;
+        _delete_inc_rowset_by_version(pair.first, pair.second);
+        VLOG(3) << "delete expire incremental data. tablet=" << full_name()
+                << ", version=" << pair.first;
     }
 
     if (save_meta() != OLAP_SUCCESS) {
@@ -479,22 +433,19 @@ void Tablet::delete_expired_inc_rowsets() {
     }
 }
 
-OLAPStatus Tablet::capture_consistent_versions(
-                        const Version& spec_version, vector<Version>* version_path) const {
+OLAPStatus Tablet::capture_consistent_versions(const Version& spec_version,
+                                               vector<Version>* version_path) const {
     OLAPStatus status = _rs_graph.capture_consistent_versions(spec_version, version_path);
     if (status != OLAP_SUCCESS) {
         std::vector<Version> missed_versions;
-        calc_missed_versions_unlock(spec_version.second, &missed_versions);
+        calc_missed_versions_unlocked(spec_version.second, &missed_versions);
         if (missed_versions.empty()) {
             LOG(WARNING) << "tablet:" << full_name()
-                         << ", version already has been merged. "
-                         << "spec_version: " << spec_version.first
-                         << "-" << spec_version.second;
+                         << ", version already has been merged. spec_version: " << spec_version;
             status = OLAP_ERR_VERSION_ALREADY_MERGED;
         } else {
             LOG(WARNING) << "status:" << status << ", tablet:" << full_name()
-                         << ", missed version for version:"
-                         << spec_version.first << "-" << spec_version.second;
+                         << ", missed version for version:" << spec_version;
             _print_missed_versions(missed_versions);
         }
         return status;
@@ -508,11 +459,10 @@ OLAPStatus Tablet::check_version_integrity(const Version& version) {
     return capture_consistent_versions(version, &span_versions);
 }
 
-// if any rowset contains the version's data, it means the version
-// already exist
+// If any rowset contains the specific version, it means the version already exist
 bool Tablet::check_version_exist(const Version& version) const {
     for (auto& it : _rs_version_map) {
-        if (it.first.first <= version.first && it.first.second >= version.second) {
+        if (it.first.contains(version)) {
             return true;
         }
     }
@@ -532,21 +482,20 @@ OLAPStatus Tablet::capture_consistent_rowsets(const Version& spec_version,
                                               vector<RowsetSharedPtr>* rowsets) const {
     vector<Version> version_path;
     RETURN_NOT_OK(capture_consistent_versions(spec_version, &version_path));
-    RETURN_NOT_OK(capture_consistent_rowsets(version_path, rowsets));
+    RETURN_NOT_OK(_capture_consistent_rowsets_unlocked(version_path, rowsets));
     return OLAP_SUCCESS;
 }
 
-OLAPStatus Tablet::capture_consistent_rowsets(const vector<Version>& version_path,
-                                              vector<RowsetSharedPtr>* rowsets) const {
+OLAPStatus Tablet::_capture_consistent_rowsets_unlocked(const vector<Version>& version_path,
+                                                        vector<RowsetSharedPtr>* rowsets) const {
     DCHECK(rowsets != nullptr && rowsets->empty());
     for (auto& version : version_path) {
         auto it = _rs_version_map.find(version);
         if (it == _rs_version_map.end()) {
             LOG(WARNING) << "fail to find Rowset for version. tablet=" << full_name()
-                         << ", version='" << version.first << "-" << version.second;
+                         << ", version='" << version;
             return OLAP_ERR_CAPTURE_ROWSET_ERROR;
         }
-
         rowsets->push_back(it->second);
     }
     return OLAP_SUCCESS;
@@ -581,7 +530,8 @@ OLAPStatus Tablet::capture_rs_readers(const vector<Version>& version_path,
     return OLAP_SUCCESS;
 }
 
-OLAPStatus Tablet::add_delete_predicate(const DeletePredicatePB& delete_predicate, int64_t version) {
+OLAPStatus Tablet::add_delete_predicate(
+        const DeletePredicatePB& delete_predicate, int64_t version) {
     return _tablet_meta->add_delete_predicate(delete_predicate, version);
 }
 
@@ -594,15 +544,14 @@ bool Tablet::version_for_load_deletion(const Version& version) {
     return rowset->delete_flag();
 }
 
-
 AlterTabletTaskSharedPtr Tablet::alter_task() {
     return _tablet_meta->alter_task();
 }
 
 OLAPStatus Tablet::add_alter_task(int64_t related_tablet_id,
-                            int32_t related_schema_hash,
-                            const vector<Version>& versions_to_alter,
-                            const AlterTabletType alter_type) {
+                                  int32_t related_schema_hash,
+                                  const vector<Version>& versions_to_alter,
+                                  const AlterTabletType alter_type) {
     AlterTabletTask alter_task;
     alter_task.set_alter_state(ALTER_RUNNING);
     alter_task.set_related_tablet_id(related_tablet_id);
@@ -624,29 +573,6 @@ OLAPStatus Tablet::delete_alter_task() {
 
 OLAPStatus Tablet::set_alter_state(AlterTabletState state) {
     return _tablet_meta->set_alter_state(state);
-}
-
-OLAPStatus Tablet::protected_delete_alter_task() {
-    WriteLock wrlock(&_meta_lock);
-    OLAPStatus res = delete_alter_task();
-    if (res != OLAP_SUCCESS) {
-        LOG(WARNING) << "fail to delete alter task from table. res=" << res
-                        << ", full_name=" << full_name();
-        return res;
-    }
-
-    res = save_meta();
-    if (res != OLAP_SUCCESS) {
-        LOG(WARNING) << "fail to save tablet header. res=" << res
-                     << ", full_name=" << full_name();
-        return res;
-    }
-    return res;
-}
-
-void Tablet::set_io_error() {
-    OLAP_LOG_WARNING("io error occur.[tablet_full_name='%s', root_path_name='%s']",
-                     full_name().c_str());
 }
 
 OLAPStatus Tablet::recover_tablet_until_specfic_version(const int64_t& spec_version,
@@ -682,6 +608,7 @@ const uint32_t Tablet::calc_cumulative_compaction_score() const {
             base_rowset_exist = true;
         }
         if (rs_meta->start_version() < point) {
+            // all_rs_metas() is not sorted, so we use _continue_ other than _break_ here.
             continue;
         }
 
@@ -701,6 +628,7 @@ const uint32_t Tablet::calc_base_compaction_score() const {
             base_rowset_exist = true;
         }
         if (rs_meta->start_version() >= point) {
+            // all_rs_metas() is not sorted, so we use _continue_ other than _break_ here.
             continue;
         }
 
@@ -723,14 +651,17 @@ void Tablet::compute_version_hash_from_rowsets(
 }
 
 
-void Tablet::calc_missed_versions(int64_t spec_version,
-                                  vector<Version>* missed_versions) {
+void Tablet::calc_missed_versions(int64_t spec_version, vector<Version>* missed_versions) {
     ReadLock rdlock(&_meta_lock);
-    calc_missed_versions_unlock(spec_version, missed_versions);
+    calc_missed_versions_unlocked(spec_version, missed_versions);
 }
 
-void Tablet::calc_missed_versions_unlock(int64_t spec_version,
-                                  vector<Version>* missed_versions) const {
+// TODO(lingbin): there may be a bug here, should check it.
+// for example:
+//     [0-4][5-5][8-8][9-9]
+// if spec_version = 6, we still return {6, 7} other than {7}
+void Tablet::calc_missed_versions_unlocked(int64_t spec_version,
+                                           vector<Version>* missed_versions) const {
     DCHECK(spec_version > 0) << "invalid spec_version: " << spec_version;
     std::list<Version> existing_versions;
     for (auto& rs : _tablet_meta->all_rs_metas()) {
@@ -743,7 +674,7 @@ void Tablet::calc_missed_versions_unlock(int64_t spec_version,
         return a.first < b.first;
     });
 
-    // find the missing version until spec_version
+    // From the first version(=0),  find the missing version until spec_version
     int64_t last_version = -1;
     for (const Version& version : existing_versions) {
         if (version.first > last_version + 1) {
@@ -752,7 +683,7 @@ void Tablet::calc_missed_versions_unlock(int64_t spec_version,
             }
         }
         last_version = version.second;
-        if (spec_version <= last_version) {
+        if (last_version >= spec_version) {
             break;
         }
     }
@@ -761,12 +692,14 @@ void Tablet::calc_missed_versions_unlock(int64_t spec_version,
     }
 }
 
-OLAPStatus Tablet::max_continuous_version_from_begining(Version* version, VersionHash* v_hash) {
+OLAPStatus Tablet::max_continuous_version_from_begining(Version* version,
+                                                        VersionHash* v_hash) {
     ReadLock rdlock(&_meta_lock);
-    return _max_continuous_version_from_begining(version, v_hash);
+    return _max_continuous_version_from_begining_unlocked(version, v_hash);
 }
 
-OLAPStatus Tablet::_max_continuous_version_from_begining(Version* version, VersionHash* v_hash) {
+OLAPStatus Tablet::_max_continuous_version_from_begining_unlocked(Version* version,
+                                                                  VersionHash* v_hash) const {
     vector<pair<Version, VersionHash>> existing_versions;
     for (auto& rs : _tablet_meta->all_rs_metas()) {
         existing_versions.emplace_back(rs->version() , rs->version_hash());
@@ -779,7 +712,7 @@ OLAPStatus Tablet::_max_continuous_version_from_begining(Version* version, Versi
                  // simple because 2 versions are certainly not overlapping
                  return left.first.first < right.first.first;
               });
-    Version max_continuous_version = { -1, 0 };
+    Version max_continuous_version = {-1, 0};
     VersionHash max_continuous_version_hash = 0;
     for (int i = 0; i < existing_versions.size(); ++i) {
         if (existing_versions[i].first.first > max_continuous_version.second + 1) {
@@ -795,16 +728,16 @@ OLAPStatus Tablet::_max_continuous_version_from_begining(Version* version, Versi
 
 OLAPStatus Tablet::calculate_cumulative_point() {
     WriteLock wrlock(&_meta_lock);
-    if (_cumulative_point != -1)  {
+    if (_cumulative_point != -1) {
         return OLAP_SUCCESS;
     }
-    
+
     std::list<RowsetMetaSharedPtr> existing_rss;
     for (auto& rs : _tablet_meta->all_rs_metas()) {
         existing_rss.emplace_back(rs);
     }
 
-    // sort the existing rowset by version in ascending order
+    // sort the existing rowsets by version in ascending order
     existing_rss.sort([](const RowsetMetaSharedPtr& a, const RowsetMetaSharedPtr& b) {
         // simple because 2 versions are certainly not overlapping
         return a->version().first < b->version().first;
@@ -813,6 +746,7 @@ OLAPStatus Tablet::calculate_cumulative_point() {
     int64_t prev_version = -1;
     for (const RowsetMetaSharedPtr& rs : existing_rss) {
         if (rs->version().first > prev_version + 1) {
+            // There is a hole, do not continue
             break;
         }
         if (rs->is_segments_overlapping()) {
@@ -826,12 +760,11 @@ OLAPStatus Tablet::calculate_cumulative_point() {
     return OLAP_SUCCESS;
 }
 
-OLAPStatus Tablet::split_range(
-        const OlapTuple& start_key_strings,
-        const OlapTuple& end_key_strings,
-        uint64_t request_block_row_count,
-        vector<OlapTuple>* ranges) {
-    if (ranges == NULL) {
+OLAPStatus Tablet::split_range(const OlapTuple& start_key_strings,
+                               const OlapTuple& end_key_strings,
+                               uint64_t request_block_row_count,
+                               vector<OlapTuple>* ranges) {
+    if (ranges == nullptr) {
         LOG(WARNING) << "parameter end_row is null.";
         return OLAP_ERR_INPUT_PARAMETER_ERROR;
     }
@@ -881,8 +814,8 @@ OLAPStatus Tablet::split_range(
         end_key.build_max_key();
     }
 
-    ReadLock rdlock(get_header_lock_ptr());
-    RowsetSharedPtr rowset = rowset_with_largest_size();
+    ReadLock rdlock(&_meta_lock);
+    RowsetSharedPtr rowset = _rowset_with_largest_size();
 
     // 如果找不到合适的rowset，就直接返回startkey，endkey
     if (rowset == nullptr) {
@@ -895,6 +828,7 @@ OLAPStatus Tablet::split_range(
     return rowset->split_range(start_key, end_key, request_block_row_count, ranges);
 }
 
+// NOTE: only used when create_table, so it is sure that there is no concurrent reader and writer.
 void Tablet::delete_all_files() {
     // Release resources like memory and disk space.
     // we have to call list_versions first, or else error occurs when
@@ -915,9 +849,7 @@ bool Tablet::check_path(const std::string& path_to_check) {
     if (path_to_check == _tablet_path) {
         return true;
     }
-    boost::filesystem::path tablet_schema_hash_path(_tablet_path);
-    boost::filesystem::path tablet_id_path = tablet_schema_hash_path.parent_path();
-    std::string tablet_id_dir = tablet_id_path.string();
+    std::string tablet_id_dir = path_util::dir_name(_tablet_path);
     if (path_to_check == tablet_id_dir) {
         return true;
     }
@@ -936,11 +868,11 @@ bool Tablet::check_path(const std::string& path_to_check) {
     return false;
 }
 
-// check rowset id in tablet meta and in rowset meta atomicly
+// check rowset id in tablet-meta and in rowset-meta atomicly
 // for example, during publish version stage, it will first add rowset meta to tablet meta and then
 // remove it from rowset meta manager. If we check tablet meta first and then check rowset meta using 2 step unlocked
 // the sequence maybe: 1. check in tablet meta [return false]  2. add to tablet meta  3. remove from rowset meta manager
-// 4. check in rowset meta manager return false. so that the rowset maybe checked return false it means it is useless and 
+// 4. check in rowset meta manager return false. so that the rowset maybe checked return false it means it is useless and
 // will be treated as a garbage.
 bool Tablet::check_rowset_id(const RowsetId& rowset_id) {
     ReadLock rdlock(&_meta_lock);
@@ -968,28 +900,23 @@ void Tablet::_print_missed_versions(const std::vector<Version>& missed_versions)
     ss << full_name() << " has "<< missed_versions.size() << " missed version:";
     // print at most 10 version
     for (int i = 0; i < 10 && i < missed_versions.size(); ++i) {
-        ss << missed_versions[i].first << "-" << missed_versions[i].second << ",";
+        ss << missed_versions[i] << ",";
     }
     LOG(WARNING) << ss.str();
 }
 
-OLAPStatus Tablet::_check_added_rowset(const RowsetSharedPtr& rowset) {
-    if (rowset == nullptr) {
-        return OLAP_ERR_ROWSET_INVALID;
-    }
-
+OLAPStatus Tablet::_contains_version(const Version& version) {
     // check if there exist a rowset contains the added rowset
     for (auto& it : _rs_version_map) {
-        if (it.first.first <= rowset->start_version() 
-            && it.first.second >= rowset->end_version()) {
+        if (it.first.contains(version)) {
+            // TODO(lingbin): Is this check unnecessary?
+            // because the value type is std::shared_ptr, when will it be nullptr?
+            // In addition, in this class, there are many places that do not make this judgment
+            // when access _rs_version_map's value.
             if (it.second == nullptr) {
-                LOG(FATAL) << "there exist a version "
-                           << " start_version=" << it.first.first
-                           << " end_version=" << it.first.second
-                           << " contains the input rs with version "
-                           << " start_version=" << rowset->start_version()
-                           << " end_version=" << rowset->end_version()
-                           << " but the related rs is null";
+                LOG(FATAL) << "there exist a version=" << it.first
+                           << " contains the input rs with version=" <<  version
+                           << ", but the related rs is null";
                 return OLAP_ERR_PUSH_ROWSET_NOT_FOUND;
             } else {
                 return OLAP_ERR_PUSH_VERSION_ALREADY_EXIST;
@@ -1008,7 +935,8 @@ TabletInfo Tablet::get_tablet_info() {
     return TabletInfo(tablet_id(), schema_hash(), tablet_uid());
 }
 
-void Tablet::pick_candicate_rowsets_to_cumulative_compaction(std::vector<RowsetSharedPtr>* candidate_rowsets) {
+void Tablet::pick_candicate_rowsets_to_cumulative_compaction(
+        vector<RowsetSharedPtr>* candidate_rowsets) {
     ReadLock rdlock(&_meta_lock);
     for (auto& it : _rs_version_map) {
         if (it.first.first >= _cumulative_point) {
@@ -1017,7 +945,7 @@ void Tablet::pick_candicate_rowsets_to_cumulative_compaction(std::vector<RowsetS
     }
 }
 
-void Tablet::pick_candicate_rowsets_to_base_compaction(std::vector<RowsetSharedPtr>* candidate_rowsets) {
+void Tablet::pick_candicate_rowsets_to_base_compaction(vector<RowsetSharedPtr>* candidate_rowsets) {
     ReadLock rdlock(&_meta_lock);
     for (auto& it : _rs_version_map) {
         if (it.first.first < _cumulative_point) {
@@ -1026,6 +954,7 @@ void Tablet::pick_candicate_rowsets_to_base_compaction(std::vector<RowsetSharedP
     }
 }
 
+// For http compaction action
 OLAPStatus Tablet::get_compaction_status(std::string* json_result) {
     rapidjson::Document root;
     root.SetObject();
@@ -1065,12 +994,12 @@ OLAPStatus Tablet::get_compaction_status(std::string* json_result) {
     rapidjson::Document versions_arr;
     versions_arr.SetArray();
     for (int i = 0; i < rowsets.size(); ++i) {
-        const Version& ver = rowsets[i]->version(); 
+        const Version& ver = rowsets[i]->version();
         rapidjson::Value value;
         std::string version_str = strings::Substitute("[$0-$1] $2 $3 $4",
             ver.first, ver.second, rowsets[i]->num_segments(), (delete_flags[i] ? "DELETE" : "DATA"),
             SegmentsOverlapPB_Name(rowsets[i]->rowset_meta()->segments_overlap()));
-        value.SetString(version_str.c_str(), version_str.length(), versions_arr.GetAllocator()); 
+        value.SetString(version_str.c_str(), version_str.length(), versions_arr.GetAllocator());
         versions_arr.PushBack(value, versions_arr.GetAllocator());
     }
     root.AddMember("rowsets", versions_arr, root.GetAllocator());
@@ -1093,7 +1022,7 @@ OLAPStatus Tablet::do_tablet_meta_checkpoint() {
         && _newly_created_rowset_num < config::tablet_meta_checkpoint_min_new_rowsets_num) {
         return OLAP_SUCCESS;
     }
-    // hold read lock not write lock, because it will not modify meta structure
+    // hold read-lock other than write-lock, because it will not modify meta structure
     ReadLock rdlock(&_meta_lock);
     if (tablet_state() != TABLET_RUNNING) {
         LOG(INFO) << "tablet is under state=" << tablet_state()
@@ -1110,7 +1039,8 @@ OLAPStatus Tablet::do_tablet_meta_checkpoint() {
         if(rs_meta->is_remove_from_rowset_meta()) {
             continue;
         }
-        if (RowsetMetaManager::check_rowset_meta(_data_dir->get_meta(), tablet_uid(), rs_meta->rowset_id())) {
+        if (RowsetMetaManager::check_rowset_meta(
+                    _data_dir->get_meta(), tablet_uid(), rs_meta->rowset_id())) {
             RowsetMetaManager::remove(_data_dir->get_meta(), tablet_uid(), rs_meta->rowset_id());
             LOG(INFO) << "remove rowset id from meta store because it is already persistent with tablet meta"
                        << ", rowset_id=" << rs_meta->rowset_id();
@@ -1149,7 +1079,7 @@ bool Tablet::rowset_meta_is_useful(RowsetMetaSharedPtr rowset_meta) {
     }
 }
 
-bool Tablet::contains_rowset(const RowsetId rowset_id) {
+bool Tablet::_contains_rowset(const RowsetId rowset_id) {
     for (auto& version_rowset : _rs_version_map) {
         if (version_rowset.second->rowset_id() == rowset_id) {
             return true;
@@ -1171,18 +1101,23 @@ void Tablet::build_tablet_report_info(TTabletInfo* tablet_info) {
     tablet_info->data_size = _tablet_meta->tablet_footprint();
     Version version = { -1, 0 };
     VersionHash v_hash = 0;
-    _max_continuous_version_from_begining(&version, &v_hash);
+    _max_continuous_version_from_begining_unlocked(&version, &v_hash);
     auto max_rowset = rowset_with_max_version();
     if (max_rowset != nullptr) {
         if (max_rowset->version() != version) {
             tablet_info->__set_version_miss(true);
         }
     } else {
-        // if the tablet is in running state, it is not under schema change
-        // and could not get rowset, it is bad should clone it
+        // If the tablet is in running state, it must not be doing schema-change. so if we can not
+        // access its rowsets, it means that the tablet is bad and needs to be reported to the FE
+        // for subsequent repairs (through the cloning task)
         if (tablet_state() == TABLET_RUNNING) {
             tablet_info->__set_used(false);
         }
+        // For other states, FE knows that the tablet is in a certain change process, so here
+        // still sets the state to normal when reporting. Note that every task has an timeout,
+        // so if the task corresponding to this change hangs, when the task timeout, FE will know
+        // and perform state modification operations.
     }
     tablet_info->version = version.second;
     tablet_info->version_hash = v_hash;
@@ -1196,6 +1131,7 @@ void Tablet::build_tablet_report_info(TTabletInfo* tablet_info) {
 // should use this method to get a copy of current tablet meta
 // there are some rowset meta in local meta store and in in-memory tablet meta
 // but not in tablet meta in local meta store
+// TODO(lingbin): do we need _meta_lock?
 OLAPStatus Tablet::generate_tablet_meta_copy(TabletMetaSharedPtr new_tablet_meta) {
     TabletMetaPB tablet_meta_pb;
     RETURN_NOT_OK(_tablet_meta->to_meta_pb(&tablet_meta_pb));

--- a/be/src/olap/tablet_meta.h
+++ b/be/src/olap/tablet_meta.h
@@ -42,7 +42,7 @@ namespace doris {
 //
 //   NOTREADY -> RUNNING -> TOMBSTONED -> STOPPED -> SHUTDOWN
 //      |           |            |          ^^^
-//      |           |            +----------+||
+//      |           |            +----------++|
 //      |           +------------------------+|
 //      +-------------------------------------+
 
@@ -111,7 +111,7 @@ public:
                int64_t tablet_id, int32_t schema_hash,
                uint64_t shard_id, const TTabletSchema& tablet_schema,
                uint32_t next_unique_id,
-               const std::unordered_map<uint32_t, uint32_t>& col_ordinal_to_unique_id, 
+               const std::unordered_map<uint32_t, uint32_t>& col_ordinal_to_unique_id,
                TabletUid tablet_uid);
 
     // Function create_from_file is used to be compatible with previous tablet_meta.
@@ -130,7 +130,7 @@ public:
     OLAPStatus to_meta_pb(TabletMetaPB* tablet_meta_pb);
     OLAPStatus to_json(std::string* json_string, json2pb::Pb2JsonOptions& options);
 
-    const TabletUid tablet_uid();
+    inline const TabletUid tablet_uid() const;
     inline const int64_t table_id() const;
     inline const int64_t partition_id() const;
     inline const int64_t tablet_id() const;
@@ -215,6 +215,10 @@ private:
 
     RWMutex _meta_lock;
 };
+
+inline const TabletUid TabletMeta::tablet_uid() const {
+    return _tablet_uid;
+}
 
 inline const int64_t TabletMeta::table_id() const {
     return _table_id;

--- a/be/src/olap/task/engine_publish_version_task.cpp
+++ b/be/src/olap/task/engine_publish_version_task.cpp
@@ -25,27 +25,23 @@ namespace doris {
 
 using std::map;
 
-EnginePublishVersionTask::EnginePublishVersionTask(TPublishVersionRequest& publish_version_req, 
-                                                   vector<TTabletId>* error_tablet_ids)
-    : _publish_version_req(publish_version_req), 
-      _error_tablet_ids(error_tablet_ids) {}
+EnginePublishVersionTask::EnginePublishVersionTask(TPublishVersionRequest& publish_version_req,
+                                                   vector<TTabletId>* error_tablet_ids) :
+        _publish_version_req(publish_version_req),
+        _error_tablet_ids(error_tablet_ids) {}
 
 OLAPStatus EnginePublishVersionTask::finish() {
-    LOG(INFO) << "begin to process publish version. transaction_id="
-              << _publish_version_req.transaction_id;
-
-    int64_t transaction_id = _publish_version_req.transaction_id;
     OLAPStatus res = OLAP_SUCCESS;
+    int64_t transaction_id = _publish_version_req.transaction_id;
+    LOG(INFO) << "begin to process publish version. transaction_id=" << transaction_id;
 
     // each partition
-    for (auto& partitionVersionInfo
-         : _publish_version_req.partition_version_infos) {
-
-        int64_t partition_id = partitionVersionInfo.partition_id;
+    for (auto& par_ver_info : _publish_version_req.partition_version_infos) {
+        int64_t partition_id = par_ver_info.partition_id;
         // get all partition related tablets and check whether the tablet have the related version
         std::set<TabletInfo> partition_related_tablet_infos;
-        StorageEngine::instance()->tablet_manager()->get_partition_related_tablets(partition_id, 
-            &partition_related_tablet_infos);
+        StorageEngine::instance()->tablet_manager()->get_partition_related_tablets(
+                partition_id, &partition_related_tablet_infos);
         if (_publish_version_req.strict_mode && partition_related_tablet_infos.empty()) {
             LOG(INFO) << "could not find related tablet for partition " << partition_id
                       << ", skip publish version";
@@ -53,10 +49,11 @@ OLAPStatus EnginePublishVersionTask::finish() {
         }
 
         map<TabletInfo, RowsetSharedPtr> tablet_related_rs;
-        StorageEngine::instance()->txn_manager()->get_txn_related_tablets(transaction_id, partition_id, &tablet_related_rs);
+        StorageEngine::instance()->txn_manager()->get_txn_related_tablets(
+                transaction_id, partition_id, &tablet_related_rs);
 
-        Version version(partitionVersionInfo.version, partitionVersionInfo.version);
-        VersionHash version_hash = partitionVersionInfo.version_hash;
+        Version version(par_ver_info.version, par_ver_info.version);
+        VersionHash version_hash = par_ver_info.version_hash;
 
         // each tablet
         for (auto& tablet_rs : tablet_related_rs) {
@@ -79,9 +76,8 @@ OLAPStatus EnginePublishVersionTask::finish() {
                 res = OLAP_ERR_PUSH_ROWSET_NOT_FOUND;
                 continue;
             }
-            TabletSharedPtr tablet = StorageEngine::instance()->tablet_manager()->get_tablet(tablet_info.tablet_id, 
-                tablet_info.schema_hash, tablet_info.tablet_uid);
-
+            TabletSharedPtr tablet = StorageEngine::instance()->tablet_manager()->get_tablet(
+                    tablet_info.tablet_id, tablet_info.schema_hash, tablet_info.tablet_uid);
             if (tablet == nullptr) {
                 LOG(WARNING) << "can't get tablet when publish version. tablet_id=" << tablet_info.tablet_id
                              << " schema_hash=" << tablet_info.schema_hash;
@@ -90,24 +86,26 @@ OLAPStatus EnginePublishVersionTask::finish() {
                 continue;
             }
 
-            publish_status = StorageEngine::instance()->txn_manager()->publish_txn(partition_id, tablet, 
-                transaction_id, version, version_hash);
-            
+            publish_status = StorageEngine::instance()->txn_manager()->publish_txn(
+                    partition_id, tablet, transaction_id, version, version_hash);
             if (publish_status != OLAP_SUCCESS) {
-                LOG(WARNING) << "failed to publish for rowset_id:" << rowset->rowset_id()
-                             << "tablet id: " << tablet_info.tablet_id
-                             << "txn id:" << transaction_id;
+                LOG(WARNING) << "failed to publish version. rowset_id=" << rowset->rowset_id()
+                             << ", tablet_id=" << tablet_info.tablet_id
+                             << ", txn_id=" << transaction_id;
                 _error_tablet_ids->push_back(tablet_info.tablet_id);
                 res = publish_status;
                 continue;
             }
+
             // add visible rowset to tablet
             publish_status = tablet->add_inc_rowset(rowset);
-            if (publish_status != OLAP_SUCCESS && publish_status != OLAP_ERR_PUSH_VERSION_ALREADY_EXIST) {
-                LOG(WARNING) << "add visible rowset to tablet failed rowset_id:" << rowset->rowset_id()
-                             << "tablet id: " << tablet_info.tablet_id
-                             << "txn id:" << transaction_id
-                             << "res:" << publish_status;
+            if (publish_status != OLAP_SUCCESS
+                    && publish_status != OLAP_ERR_PUSH_VERSION_ALREADY_EXIST) {
+                LOG(WARNING) << "fail to add visible rowset to tablet. rowset_id="
+                             << rowset->rowset_id()
+                             << ", tablet_id=" << tablet_info.tablet_id
+                             << ", txn_id=" << transaction_id
+                             << ", res=" << publish_status;
                 _error_tablet_ids->push_back(tablet_info.tablet_id);
                 res = publish_status;
                 continue;
@@ -125,7 +123,7 @@ OLAPStatus EnginePublishVersionTask::finish() {
                 break;
             }
             TabletSharedPtr tablet = StorageEngine::instance()->tablet_manager()->get_tablet(
-                tablet_info.tablet_id, tablet_info.schema_hash);
+                    tablet_info.tablet_id, tablet_info.schema_hash);
             if (tablet == nullptr) {
                 _error_tablet_ids->push_back(tablet_info.tablet_id);
             } else {

--- a/be/src/olap/task/engine_publish_version_task.h
+++ b/be/src/olap/task/engine_publish_version_task.h
@@ -24,20 +24,20 @@
 
 namespace doris {
 
-// base class for storage engine
-// add "Engine" as task prefix to prevent duplicate name with agent task
 class EnginePublishVersionTask : public EngineTask {
-
 public:
-    EnginePublishVersionTask(TPublishVersionRequest& publish_version_req, vector<TTabletId>* error_tablet_ids);
+    EnginePublishVersionTask(TPublishVersionRequest& publish_version_req,
+                             vector<TTabletId>* error_tablet_ids);
     ~EnginePublishVersionTask() {}
 
-    virtual OLAPStatus finish();
+    virtual OLAPStatus finish() override;
 
 private:
     const TPublishVersionRequest& _publish_version_req;
     vector<TTabletId>* _error_tablet_ids;
-}; // EnginePublishVersionTask
+};
 
 } // doris
-#endif //DORIS_BE_SRC_OLAP_TASK_ENGINE_PUBLISH_VERSION_TASK_H
+
+#endif // DORIS_BE_SRC_OLAP_TASK_ENGINE_PUBLISH_VERSION_TASK_H
+

--- a/be/src/olap/task/engine_task.h
+++ b/be/src/olap/task/engine_task.h
@@ -30,15 +30,14 @@ namespace doris {
 // base class for storage engine
 // add "Engine" as task prefix to prevent duplicate name with agent task
 class EngineTask {
-
 public:
-    // use agent_status not olap_status, because the task is very close to engine
+    // use olap_status not agent_status, because the task is very close to engine
     virtual OLAPStatus prepare() { return OLAP_SUCCESS; }
     virtual OLAPStatus execute() { return OLAP_SUCCESS; }
     virtual OLAPStatus finish() { return OLAP_SUCCESS; }
     virtual OLAPStatus cancel() { return OLAP_SUCCESS; }
-    virtual void get_related_tablets(vector<TabletInfo>* tablet_infos) {}
-}; // EngineTask
+    virtual void get_related_tablets(std::vector<TabletInfo>* tablet_infos) {}
+};
 
-} // doris
+} // end namespace doris
 #endif //DORIS_BE_SRC_OLAP_TASK_ENGINE_TASK_H

--- a/be/test/olap/olap_snapshot_converter_test.cpp
+++ b/be/test/olap/olap_snapshot_converter_test.cpp
@@ -28,6 +28,7 @@
 #include "olap/rowset/rowset_meta_manager.h"
 #include "olap/rowset/alpha_rowset.h"
 #include "olap/rowset/alpha_rowset_meta.h"
+#include "olap/storage_engine.h"
 #include "olap/txn_manager.h"
 #include <boost/algorithm/string.hpp>
 #include "boost/filesystem.hpp"
@@ -69,14 +70,14 @@ public:
         _data_dir = new DataDir(_engine_data_path, 1000000000);
         _data_dir->init();
         _meta_path = "./meta";
-        string tmp_data_path = _engine_data_path + "/data"; 
+        string tmp_data_path = _engine_data_path + "/data";
         if (boost::filesystem::exists(tmp_data_path)) {
             boost::filesystem::remove_all(tmp_data_path);
         }
         copy_dir(test_engine_data_path, tmp_data_path);
         _tablet_id = 15007;
         _schema_hash = 368169781;
-        _tablet_data_path = tmp_data_path 
+        _tablet_data_path = tmp_data_path
                 + "/" + std::to_string(0)
                 + "/" + std::to_string(_tablet_id)
                 + "/" + std::to_string(_schema_hash);
@@ -130,7 +131,7 @@ TEST_F(OlapSnapshotConverterTest, ToNewAndToOldSnapshot) {
     OlapSnapshotConverter converter;
     TabletMetaPB tablet_meta_pb;
     vector<RowsetMetaPB> pending_rowsets;
-    OLAPStatus status = converter.to_new_snapshot(header_msg, _tablet_data_path, _tablet_data_path, 
+    OLAPStatus status = converter.to_new_snapshot(header_msg, _tablet_data_path, _tablet_data_path,
         &tablet_meta_pb, &pending_rowsets, true);
     ASSERT_TRUE(status == OLAP_SUCCESS);
 
@@ -183,7 +184,7 @@ TEST_F(OlapSnapshotConverterTest, ToNewAndToOldSnapshot) {
         AlphaRowset rowset(&tablet_schema, data_path_prefix, alpha_rowset_meta);
         ASSERT_TRUE(rowset.init() == OLAP_SUCCESS);
         ASSERT_TRUE(rowset.load() == OLAP_SUCCESS);
-        AlphaRowset tmp_rowset(&tablet_schema, data_path_prefix + "/incremental_delta", 
+        AlphaRowset tmp_rowset(&tablet_schema, data_path_prefix + "/incremental_delta",
             alpha_rowset_meta);
         ASSERT_TRUE(tmp_rowset.init() == OLAP_SUCCESS);
         std::vector<std::string> old_files;
@@ -217,7 +218,7 @@ TEST_F(OlapSnapshotConverterTest, ToNewAndToOldSnapshot) {
 
     // old files are removed, then convert new snapshot to old snapshot
     OLAPHeaderMessage old_header_msg;
-    status = converter.to_old_snapshot(tablet_meta_pb, _tablet_data_path, 
+    status = converter.to_old_snapshot(tablet_meta_pb, _tablet_data_path,
         _tablet_data_path, &old_header_msg);
     ASSERT_TRUE(status == OLAP_SUCCESS);
     for (auto& pdelta : header_msg.delta()) {

--- a/be/test/olap/tablet_mgr_test.cpp
+++ b/be/test/olap/tablet_mgr_test.cpp
@@ -25,6 +25,7 @@
 #include "olap/rowset/rowset_meta_manager.h"
 #include "olap/rowset/alpha_rowset.h"
 #include "olap/rowset/alpha_rowset_meta.h"
+#include "olap/storage_engine.h"
 #include "olap/tablet_meta_manager.h"
 #include "olap/txn_manager.h"
 #include "boost/filesystem.hpp"
@@ -66,14 +67,14 @@ public:
 
         _data_dir = new DataDir(_engine_data_path, 1000000000);
         _data_dir->init();
-        string tmp_data_path = _engine_data_path + "/data"; 
+        string tmp_data_path = _engine_data_path + "/data";
         if (boost::filesystem::exists(tmp_data_path)) {
             boost::filesystem::remove_all(tmp_data_path);
         }
         copy_dir(test_engine_data_path, tmp_data_path);
         _tablet_id = 15007;
         _schema_hash = 368169781;
-        _tablet_data_path = tmp_data_path 
+        _tablet_data_path = tmp_data_path
                 + "/" + std::to_string(0)
                 + "/" + std::to_string(_tablet_id)
                 + "/" + std::to_string(_schema_hash);

--- a/be/test/olap/txn_manager_test.cpp
+++ b/be/test/olap/txn_manager_test.cpp
@@ -26,6 +26,7 @@
 #include "olap/rowset/rowset_factory.h"
 #include "olap/rowset/rowset_meta_manager.h"
 #include "olap/rowset/alpha_rowset_meta.h"
+#include "olap/storage_engine.h"
 #include "olap/txn_manager.h"
 #include "boost/filesystem.hpp"
 #include "json2pb/json_to_pb.h"
@@ -93,7 +94,7 @@ public:
 
     virtual void SetUp() {
         config::max_runnings_transactions = 1000;
-        
+
         std::vector<StorePath> paths;
         paths.emplace_back("_engine_data_path", -1);
         EngineOptions options;
@@ -175,7 +176,7 @@ private:
 };
 
 TEST_F(TxnManagerTest, PrepareNewTxn) {
-    OLAPStatus status = _txn_mgr.prepare_txn(partition_id, transaction_id, 
+    OLAPStatus status = _txn_mgr.prepare_txn(partition_id, transaction_id,
         tablet_id, schema_hash, _tablet_uid, load_id);
     ASSERT_TRUE(status == OLAP_SUCCESS);
 }
@@ -184,9 +185,9 @@ TEST_F(TxnManagerTest, PrepareNewTxn) {
 // 2. commit txn
 // 3. should be success
 TEST_F(TxnManagerTest, CommitTxnWithPrepare) {
-    OLAPStatus status = _txn_mgr.prepare_txn(partition_id, transaction_id, 
+    OLAPStatus status = _txn_mgr.prepare_txn(partition_id, transaction_id,
         tablet_id, schema_hash, _tablet_uid, load_id);
-    _txn_mgr.commit_txn(_meta, partition_id, transaction_id, 
+    _txn_mgr.commit_txn(_meta, partition_id, transaction_id,
         tablet_id, schema_hash, _tablet_uid, load_id, _alpha_rowset, false);
     ASSERT_TRUE(status == OLAP_SUCCESS);
     RowsetMetaSharedPtr rowset_meta(new AlphaRowsetMeta());
@@ -198,7 +199,7 @@ TEST_F(TxnManagerTest, CommitTxnWithPrepare) {
 // 1. commit without prepare
 // 2. should success
 TEST_F(TxnManagerTest, CommitTxnWithNoPrepare) {
-    OLAPStatus status = _txn_mgr.commit_txn(_meta, partition_id, transaction_id, 
+    OLAPStatus status = _txn_mgr.commit_txn(_meta, partition_id, transaction_id,
         tablet_id, schema_hash, _tablet_uid, load_id, _alpha_rowset, false);
     ASSERT_TRUE(status == OLAP_SUCCESS);
 }
@@ -206,10 +207,10 @@ TEST_F(TxnManagerTest, CommitTxnWithNoPrepare) {
 // 1. commit twice with different rowset id
 // 2. should failed
 TEST_F(TxnManagerTest, CommitTxnTwiceWithDiffRowsetId) {
-    OLAPStatus status = _txn_mgr.commit_txn(_meta, partition_id, transaction_id, 
+    OLAPStatus status = _txn_mgr.commit_txn(_meta, partition_id, transaction_id,
         tablet_id, schema_hash, _tablet_uid, load_id, _alpha_rowset, false);
     ASSERT_TRUE(status == OLAP_SUCCESS);
-    status = _txn_mgr.commit_txn(_meta, partition_id, transaction_id, 
+    status = _txn_mgr.commit_txn(_meta, partition_id, transaction_id,
         tablet_id, schema_hash, _tablet_uid, load_id, _alpha_rowset_diff_id, false);
     ASSERT_TRUE(status != OLAP_SUCCESS);
 }
@@ -217,30 +218,30 @@ TEST_F(TxnManagerTest, CommitTxnTwiceWithDiffRowsetId) {
 // 1. commit twice with same rowset id
 // 2. should success
 TEST_F(TxnManagerTest, CommitTxnTwiceWithSameRowsetId) {
-    OLAPStatus status = _txn_mgr.commit_txn(_meta, partition_id, transaction_id, 
+    OLAPStatus status = _txn_mgr.commit_txn(_meta, partition_id, transaction_id,
         tablet_id, schema_hash, _tablet_uid, load_id, _alpha_rowset, false);
     ASSERT_TRUE(status == OLAP_SUCCESS);
-    status = _txn_mgr.commit_txn(_meta, partition_id, transaction_id, 
+    status = _txn_mgr.commit_txn(_meta, partition_id, transaction_id,
         tablet_id, schema_hash, _tablet_uid, load_id, _alpha_rowset_same_id, false);
     ASSERT_TRUE(status == OLAP_SUCCESS);
 }
 
 // 1. prepare twice should be success
 TEST_F(TxnManagerTest, PrepareNewTxnTwice) {
-    OLAPStatus status = _txn_mgr.prepare_txn(partition_id, transaction_id, 
+    OLAPStatus status = _txn_mgr.prepare_txn(partition_id, transaction_id,
         tablet_id, schema_hash, _tablet_uid, load_id);
     ASSERT_TRUE(status == OLAP_SUCCESS);
-    status = _txn_mgr.prepare_txn(partition_id, transaction_id, 
+    status = _txn_mgr.prepare_txn(partition_id, transaction_id,
         tablet_id, schema_hash, _tablet_uid, load_id);
     ASSERT_TRUE(status == OLAP_SUCCESS);
 }
 
 // 1. txn could be rollbacked if it is not committed
 TEST_F(TxnManagerTest, RollbackNotCommittedTxn) {
-    OLAPStatus status = _txn_mgr.prepare_txn(partition_id, transaction_id, 
+    OLAPStatus status = _txn_mgr.prepare_txn(partition_id, transaction_id,
         tablet_id, schema_hash, _tablet_uid, load_id);
     ASSERT_TRUE(status == OLAP_SUCCESS);
-    status = _txn_mgr.rollback_txn(partition_id, transaction_id, 
+    status = _txn_mgr.rollback_txn(partition_id, transaction_id,
         tablet_id, schema_hash, _tablet_uid);
     ASSERT_TRUE(status == OLAP_SUCCESS);
     RowsetMetaSharedPtr rowset_meta(new AlphaRowsetMeta());
@@ -250,10 +251,10 @@ TEST_F(TxnManagerTest, RollbackNotCommittedTxn) {
 
 // 1. txn could not be rollbacked if it is committed
 TEST_F(TxnManagerTest, RollbackCommittedTxn) {
-    OLAPStatus status = _txn_mgr.commit_txn(_meta, partition_id, transaction_id, 
+    OLAPStatus status = _txn_mgr.commit_txn(_meta, partition_id, transaction_id,
         tablet_id, schema_hash, _tablet_uid, load_id, _alpha_rowset, false);
     ASSERT_TRUE(status == OLAP_SUCCESS);
-    status = _txn_mgr.rollback_txn(partition_id, transaction_id, 
+    status = _txn_mgr.rollback_txn(partition_id, transaction_id,
         tablet_id, schema_hash, _tablet_uid);
     ASSERT_FALSE(status == OLAP_SUCCESS);
     RowsetMetaSharedPtr rowset_meta(new AlphaRowsetMeta());
@@ -264,12 +265,12 @@ TEST_F(TxnManagerTest, RollbackCommittedTxn) {
 
 // 1. publish version success
 TEST_F(TxnManagerTest, PublishVersionSuccessful) {
-    OLAPStatus status = _txn_mgr.commit_txn(_meta, partition_id, transaction_id, 
+    OLAPStatus status = _txn_mgr.commit_txn(_meta, partition_id, transaction_id,
         tablet_id, schema_hash, _tablet_uid, load_id, _alpha_rowset, false);
     ASSERT_TRUE(status == OLAP_SUCCESS);
     Version new_version(10,11);
     VersionHash new_versionhash = 123;
-    status = _txn_mgr.publish_txn(_meta, partition_id, transaction_id, 
+    status = _txn_mgr.publish_txn(_meta, partition_id, transaction_id,
         tablet_id, schema_hash, _tablet_uid, new_version, new_versionhash);
     ASSERT_TRUE(status == OLAP_SUCCESS);
 
@@ -285,28 +286,28 @@ TEST_F(TxnManagerTest, PublishVersionSuccessful) {
 TEST_F(TxnManagerTest, PublishNotExistedTxn) {
     Version new_version(10,11);
     VersionHash new_versionhash = 123;
-    OLAPStatus status = _txn_mgr.publish_txn(_meta, partition_id, transaction_id, 
+    OLAPStatus status = _txn_mgr.publish_txn(_meta, partition_id, transaction_id,
         tablet_id, schema_hash, _tablet_uid, new_version, new_versionhash);
     ASSERT_TRUE(status != OLAP_SUCCESS);
 }
 
 TEST_F(TxnManagerTest, DeletePreparedTxn) {
-    OLAPStatus status = _txn_mgr.prepare_txn(partition_id, transaction_id, 
+    OLAPStatus status = _txn_mgr.prepare_txn(partition_id, transaction_id,
         tablet_id, schema_hash, _tablet_uid, load_id);
     ASSERT_TRUE(status == OLAP_SUCCESS);
-    status = _txn_mgr.delete_txn(_meta, partition_id, transaction_id, 
+    status = _txn_mgr.delete_txn(_meta, partition_id, transaction_id,
         tablet_id, schema_hash, _tablet_uid);
     ASSERT_TRUE(status == OLAP_SUCCESS);
 }
 
 TEST_F(TxnManagerTest, DeleteCommittedTxn) {
-    OLAPStatus status = _txn_mgr.commit_txn(_meta, partition_id, transaction_id, 
+    OLAPStatus status = _txn_mgr.commit_txn(_meta, partition_id, transaction_id,
         tablet_id, schema_hash, _tablet_uid, load_id, _alpha_rowset, false);
     ASSERT_TRUE(status == OLAP_SUCCESS);
     RowsetMetaSharedPtr rowset_meta(new AlphaRowsetMeta());
     status = RowsetMetaManager::get_rowset_meta(_meta, _tablet_uid, _alpha_rowset->rowset_id(), rowset_meta);
     ASSERT_TRUE(status == OLAP_SUCCESS);
-    status = _txn_mgr.delete_txn(_meta, partition_id, transaction_id, 
+    status = _txn_mgr.delete_txn(_meta, partition_id, transaction_id,
         tablet_id, schema_hash, _tablet_uid);
     ASSERT_TRUE(status == OLAP_SUCCESS);
     RowsetMetaSharedPtr rowset_meta2(new AlphaRowsetMeta());


### PR DESCRIPTION
There are two members in `Version`:` first` and `second`.
There are many places where we need to print one `Version` object  and
compare two `Version` objects, but in the current code, these two members
are accessed directly, which makes the code very tedious.

This patch mainly do:
1. Adds overloaded methods for `operator<<()` for `Version`, so
   we can directly print a Version object;
2. Adds the `cantains()` method to determine whether it is an containment
   relationship;
3. Uses `operator==()` to determine if two `Version` objects are equal.

Because there are too many places need to be modified, there are still some
naked codes left, which will be modified later.

This patch also removes some necessary header file references.

No functional changes in this patch.