### PR TITLE
Return NullLiteral in castTo method instead of throwing a exception

### DIFF
--- a/fe/src/main/java/org/apache/doris/analysis/CastExpr.java
+++ b/fe/src/main/java/org/apache/doris/analysis/CastExpr.java
@@ -271,8 +271,8 @@ public class CastExpr extends Expr {
     }
 
     private Expr castTo(LiteralExpr value) throws AnalysisException {
-        Preconditions.checkArgument(!(value instanceof NullLiteral)
-            && !type.isNull());
+//        Preconditions.checkArgument(!(value instanceof NullLiteral)
+//            && !type.isNull());
         if (type.isIntegerType()) {
             return new IntLiteral(value.getLongValue(), type);
         } else if (type.isLargeIntType()) {

--- a/fe/src/main/java/org/apache/doris/analysis/CastExpr.java
+++ b/fe/src/main/java/org/apache/doris/analysis/CastExpr.java
@@ -271,9 +271,9 @@ public class CastExpr extends Expr {
     }
 
     private Expr castTo(LiteralExpr value) throws AnalysisException {
-//        Preconditions.checkArgument(!(value instanceof NullLiteral)
-//            && !type.isNull());
-        if (type.isIntegerType()) {
+        if (value instanceof NullLiteral) {
+            return value;
+        } else if (type.isIntegerType()) {
             return new IntLiteral(value.getLongValue(), type);
         } else if (type.isLargeIntType()) {
             return new LargeIntLiteral(value.getStringValue());

--- a/fe/src/main/java/org/apache/doris/analysis/Expr.java
+++ b/fe/src/main/java/org/apache/doris/analysis/Expr.java
@@ -170,6 +170,12 @@ abstract public class Expr extends TreeNode<Expr> implements ParseNode, Cloneabl
                 public boolean apply(Expr arg) { return arg instanceof BinaryPredicate; }
             };
 
+    public static final com.google.common.base.Predicate<Expr> IS_NULL_LITERAL =
+            new com.google.common.base.Predicate<Expr>() {
+                @Override
+                public boolean apply(Expr arg) { return arg instanceof NullLiteral; }
+            };
+
     /* TODO(zc)
     public final static com.google.common.base.Predicate<Expr>
             IS_NONDETERMINISTIC_BUILTIN_FN_PREDICATE =


### PR DESCRIPTION
Issue
#2399 
#2396 (2.2)
We used to use **Precondition** to throw an exception when encounter a NullLiteral in castTo method. So if the child of CastExpr is NullLiteral, then this CastExpr will throw an exception when invoking the castTo method.
And this may make the user not get the desired result.
For example, we get an unexpected exception in query: (In sql mode `PIPES_AS_CONCAT_MODE`)
`select (1 || 'a' > 0) + 1;`
which should return a result 'Null'.