### PR TITLE
Fix parquet arrow read batch bug

### DIFF
--- a/be/src/exec/parquet_reader.h
+++ b/be/src/exec/parquet_reader.h
@@ -103,6 +103,7 @@ private:
 
     int _rows_of_group; // rows in a group.
     int _current_line_of_group;
+    int _current_line_of_batch;
 };
 
 }


### PR DESCRIPTION
Fix parquet arrow read batch bug
#2811 

The original code was to determine the number of rows in the batch based on the number of rows in the parquet RowGroup.But now it's a batch take 65535 lines. So when parquet row greater than 65535，the number of batch don't match the number of rowgroup. The code using the field "_current_line_of_group" as a position of array can cause the data to be out of array cause be crash