### PR TITLE
Improve initialization flow of Schema

### DIFF
--- a/be/src/olap/row_block2.h
+++ b/be/src/olap/row_block2.h
@@ -33,6 +33,7 @@
 namespace doris {
 
 class MemPool;
+class RowBlockRow;
 class RowCursor;
 
 // This struct contains a block of rows, in which each column's data is stored

--- a/be/src/olap/schema.h
+++ b/be/src/olap/schema.h
@@ -29,56 +29,54 @@
 
 namespace doris {
 
-
-class RowBlockRow;
-
-// The class is used to represent row's format in memory.
-// One row contains some columns, within these columns there may be key columns which
-// must be the first few columns.
+// The class is used to represent row's format in memory.  Each row contains
+// multiple columns, some of which are key-columns (the rest are value-columns).
+// NOTE: If both key-columns and value-columns exist, then the key-columns
+// must be placed before value-columns.
 //
 // To compare two rows whose schemas are different, but they are from the same origin
-// we store all column schema maybe accessed here. And default access through column
-// id
+// we store all column schema maybe accessed here. And default access through column id
 class Schema {
 public:
-    Schema(const TabletSchema& schema) {
-        size_t num_key_columns = 0;
-        std::vector<ColumnId> col_ids(schema.num_columns());
-        std::vector<TabletColumn> columns(schema.num_columns());
+    Schema(const TabletSchema& tablet_schema) {
+        size_t num_columns = tablet_schema.num_columns();
+        std::vector<ColumnId> col_ids(num_columns);
+        std::vector<TabletColumn> columns;
+        columns.reserve(num_columns);
 
-        for (uint32_t cid = 0; cid < schema.num_columns(); ++cid) {
+        size_t num_key_columns = 0;
+        for (uint32_t cid = 0; cid < num_columns; ++cid) {
             col_ids[cid] = cid;
-            const TabletColumn& column = schema.column(cid);
-            columns[cid] = column;
+            const TabletColumn& column = tablet_schema.column(cid);
             if (column.is_key()) {
-                num_key_columns++;
+                ++num_key_columns;
             }
+            columns.push_back(column);
         }
 
-        init_field(columns, col_ids);
-        init(col_ids, num_key_columns);
+        _init(columns, col_ids, num_key_columns);
     }
 
+    // All the columns of one table may exist in the columns param, but col_ids is only a subset.
     Schema(const std::vector<TabletColumn>& columns, const std::vector<ColumnId>& col_ids) {
         size_t num_key_columns = 0;
-        for (const auto& i: columns) {
-            if (i.is_key()) {
-                num_key_columns++;
+        for (const auto& c: columns) {
+            if (c.is_key()) {
+                ++num_key_columns;
             }
         }
 
-        init_field(columns, col_ids);
-        init(col_ids, num_key_columns);
+        _init(columns, col_ids, num_key_columns);
     }
 
+    // Only for UT
     Schema(const std::vector<TabletColumn>& columns, size_t num_key_columns) {
         std::vector<ColumnId> col_ids(columns.size());
         for (uint32_t cid = 0; cid < columns.size(); ++cid) {
             col_ids[cid] = cid;
         }
 
-        init_field(columns, col_ids);
-        init(col_ids, num_key_columns);
+        _init(columns, col_ids, num_key_columns);
     }
 
     Schema(const std::vector<const Field*>& cols, size_t num_key_columns) {
@@ -87,14 +85,11 @@ public:
             col_ids[cid] = cid;
         }
 
-        init_field(cols, col_ids);
-        init(col_ids, num_key_columns);
+        _init(cols, col_ids, num_key_columns);
     }
 
     Schema(const Schema&);
     Schema& operator=(const Schema& other);
-
-    void copy_from(const Schema& other);
 
     ~Schema();
 
@@ -104,11 +99,15 @@ public:
     size_t num_key_columns() const {
         return _num_key_columns;
     }
+    size_t schema_size() const {
+        return _schema_size;
+    }
 
     size_t column_offset(ColumnId cid) const {
         return _col_offsets[cid];
     }
 
+    // TODO(lingbin): What is the difference between colun_size() and index_size()
     size_t column_size(ColumnId cid) const {
         return _cols[cid]->size();
     }
@@ -120,39 +119,36 @@ public:
     bool is_null(const char* row, int index) const {
         return *reinterpret_cast<const bool*>(row + _col_offsets[index]);
     }
-
     void set_is_null(void* row, uint32_t cid, bool is_null) const {
         *reinterpret_cast<bool*>((char*)row + _col_offsets[cid]) = is_null;
-    }
-
-    size_t schema_size() const {
-        return _schema_size;
     }
 
     size_t num_columns() const { return _cols.size(); }
     size_t num_column_ids() const { return _col_ids.size(); }
     const std::vector<ColumnId>& column_ids() const { return _col_ids; }
+
 private:
-    // all valid ColumnIds in this schema
+    void _init(const std::vector<TabletColumn>& cols,
+               const std::vector<ColumnId>& col_ids,
+               size_t num_key_columns);
+    void _init(const std::vector<const Field*>& cols,
+               const std::vector<ColumnId>& col_ids,
+               size_t num_key_columns);
+
+    void _copy_from(const Schema& other);
+
+    // NOTE: The ColumnId here represents the sequential index number (starting from 0) of
+    // a column in current row, not the unique id-identifier of each column
     std::vector<ColumnId> _col_ids;
-    // _cols[cid] is ony valid when cid is contained in `_col_ids`
+    // NOTE: Both _cols[cid] and _col_offsets[cid] can only be accessed when the cid is
+    // contained in _col_ids
     std::vector<Field*> _cols;
-    // _col_offsets[cid] is ony valid when cid is contained in `_col_ids`
+    // The value of each item indicates the starting offset of the corresponding column in
+    // current row. e.g. _col_offsets[idx] is the offset of _cols[idx] (idx must in _col_ids)
     std::vector<size_t> _col_offsets;
+
     size_t _num_key_columns;
     size_t _schema_size;
-
-    // init _cols member variable, must call before init method
-    void init_field(const std::vector<TabletColumn>& columns,
-                     const std::vector<ColumnId>& col_ids);
-
-    // init _cols member variable, must call before init method
-    void init_field(const std::vector<const Field*>& cols,
-                     const std::vector<ColumnId>& col_ids);
-
-    // init all member variables except _cols
-    void init(const std::vector<ColumnId>& col_ids,
-               size_t num_key_columns);
 };
 
 } // namespace doris


### PR DESCRIPTION
When constructing `Schema` objects, two similar `init()` functions
need to be called, and the call order is implicitly required, which
is easy to be misused. At the same time, some of the existing comments
are missing or out of date, which will cause some misleading.

This patch unifies the initialization logic of `Schema`.

No functional changes in this patch.