### PR TITLE
[Compaction] Avoid unnecessary compaction

### DIFF
--- a/be/src/olap/cumulative_compaction.cpp
+++ b/be/src/olap/cumulative_compaction.cpp
@@ -130,24 +130,36 @@ OLAPStatus CumulativeCompaction::pick_rowsets_to_compact() {
         // the cumulative point after waiting for a long time, to ensure that the base compaction can continue.
 
         // check both last success time of base and cumulative compaction
-        int64_t interval_threshold = config::base_compaction_interval_seconds_since_last_operation * 1000;
         int64_t now = UnixMillis();
-        int64_t cumu_interval = now - _tablet->last_cumu_compaction_success_time();
-        int64_t base_interval = now - _tablet->last_base_compaction_success_time();
-        if (cumu_interval > interval_threshold && base_interval > interval_threshold) {
-            // before increasing cumulative point, we should make sure all rowsets are non-overlapping.
-            // if at least one rowset is overlapping, we should compact them first.
-            CHECK(candidate_rowsets.size() == transient_rowsets.size())
-                << "tablet: " << _tablet->full_name() << ", "<<  candidate_rowsets.size() << " vs. " << transient_rowsets.size();
-            for (auto& rs : candidate_rowsets) {
-                if (rs->rowset_meta()->is_segments_overlapping()) {
-                    _input_rowsets = candidate_rowsets;
-                    return OLAP_SUCCESS;
+        int64_t last_cumu = _tablet->last_cumu_compaction_success_time();
+        int64_t last_base = _tablet->last_base_compaction_success_time();
+        if (last_cumu != 0 || last_base != 0) {
+            int64_t interval_threshold = config::base_compaction_interval_seconds_since_last_operation * 1000;
+            int64_t cumu_interval = now - last_cumu;
+            int64_t base_interval = now - last_base;
+            if (cumu_interval > interval_threshold && base_interval > interval_threshold) {
+                // before increasing cumulative point, we should make sure all rowsets are non-overlapping.
+                // if at least one rowset is overlapping, we should compact them first.
+                CHECK(candidate_rowsets.size() == transient_rowsets.size())
+                    << "tablet: " << _tablet->full_name() << ", "<<  candidate_rowsets.size() << " vs. " << transient_rowsets.size();
+                for (auto& rs : candidate_rowsets) {
+                    if (rs->rowset_meta()->is_segments_overlapping()) {
+                        _input_rowsets = candidate_rowsets;
+                        return OLAP_SUCCESS;
+                    }
                 }
+
+                // all candicate rowsets are non-overlapping, increase the cumulative point
+                _tablet->set_cumulative_layer_point(candidate_rowsets.back()->start_version() + 1);
+        } else {
+            // init the compaction success time for first time
+            if (last_cumu == 0) {
+                _tablet->set_last_cumu_compaction_success_time(now);
             }
 
-            // all candicate rowsets are non-overlapping, increase the cumulative point
-            _tablet->set_cumulative_layer_point(candidate_rowsets.back()->start_version() + 1);
+            if (last_base == 0) {
+                _tablet->set_last_base_compaction_success_time(now);
+            }
         }
 
         return OLAP_ERR_CUMULATIVE_NO_SUITABLE_VERSIONS;

--- a/be/src/olap/cumulative_compaction.cpp
+++ b/be/src/olap/cumulative_compaction.cpp
@@ -151,6 +151,7 @@ OLAPStatus CumulativeCompaction::pick_rowsets_to_compact() {
 
                 // all candicate rowsets are non-overlapping, increase the cumulative point
                 _tablet->set_cumulative_layer_point(candidate_rowsets.back()->start_version() + 1);
+            }
         } else {
             // init the compaction success time for first time
             if (last_cumu == 0) {


### PR DESCRIPTION
It is not necessary to perform compaction in the following cases

1. A tablet has only 2 rowsets, the versions are [0-1] and [2-x]. In this case, 
there is no need to perform base compaction because the [0-1] version is an empty version.

    Some tables will be partitioned by day, and then each partition will only load one batch of data
 each day, so a large number of tablets with rowsets [0-1][2-2] will appear. And these tablets
 do not need to be base compaction.

2. The initial value of the `last successful execution time of compaction` is 0, 
which causes the first time to determine the time interval from the
 last successful execution time of compaction, which always meets the 
conditions to trigger cumulative compaction.

ISSUE: #2838 