### PR TITLE
Fix removing tablet bug from partition_map in TabletManager

### DIFF
--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -931,7 +931,7 @@ OLAPStatus Tablet::set_partition_id(int64_t partition_id) {
     return _tablet_meta->set_partition_id(partition_id);
 }
 
-TabletInfo Tablet::get_tablet_info() {
+TabletInfo Tablet::get_tablet_info() const {
     return TabletInfo(tablet_id(), schema_hash(), tablet_uid());
 }
 

--- a/be/src/olap/tablet.h
+++ b/be/src/olap/tablet.h
@@ -223,7 +223,7 @@ public:
 
     OLAPStatus set_partition_id(int64_t partition_id);
 
-    TabletInfo get_tablet_info();
+    TabletInfo get_tablet_info() const;
 
     void pick_candicate_rowsets_to_cumulative_compaction(std::vector<RowsetSharedPtr>* candidate_rowsets);
     void pick_candicate_rowsets_to_base_compaction(std::vector<RowsetSharedPtr>* candidate_rowsets);

--- a/be/src/olap/tablet_manager.h
+++ b/be/src/olap/tablet_manager.h
@@ -169,6 +169,8 @@ private:
 
     void _build_tablet_stat();
 
+    void _remove_tablet_from_partition_unlocked(const Tablet& tablet);
+
 private:
     // TODO(lingbin): should be TabletInstances?
     // should be removed after schema_hash be removed


### PR DESCRIPTION
When using an iterator of _tablet_map.tablet_arr(`std::list`) to remove
a tablet, we should first remove tablet from _partition_map to avoid
the iterator becoming invalid.