### PR TITLE
Fix bug that _min_percentage_of_error_disk was not initialized

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -204,7 +204,7 @@ namespace config {
     CONF_Int32(unused_rowset_monitor_interval, "30");
     CONF_String(storage_root_path, "${DORIS_HOME}/storage");
     // BE process will exit if the percentage of error disk reach this value.
-    CONF_Int32(max_percentage_of_error_disk, "50");
+    CONF_Int32(max_percentage_of_error_disk, "0");
     CONF_Int32(default_num_rows_per_data_block, "1024");
     CONF_Int32(default_num_rows_per_column_file_block, "1024");
     CONF_Int32(max_tablet_num_per_shard, "1024");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -203,7 +203,8 @@ namespace config {
     CONF_Int32(disk_stat_monitor_interval, "5");
     CONF_Int32(unused_rowset_monitor_interval, "30");
     CONF_String(storage_root_path, "${DORIS_HOME}/storage");
-    CONF_Int32(min_percentage_of_error_disk, "50");
+    // BE process will exit if the percentage of error disk reach this value.
+    CONF_Int32(max_percentage_of_error_disk, "50");
     CONF_Int32(default_num_rows_per_data_block, "1024");
     CONF_Int32(default_num_rows_per_column_file_block, "1024");
     CONF_Int32(max_tablet_num_per_shard, "1024");

--- a/be/src/olap/storage_engine.cpp
+++ b/be/src/olap/storage_engine.cpp
@@ -101,6 +101,7 @@ Status StorageEngine::open(const EngineOptions& options, StorageEngine** engine_
         return Status::InternalError("open engine failed");
     }
     *engine_ptr = engine.release();
+    LOG(INFO) << "success to init storage engine.";
     return Status::OK();
 }
 
@@ -149,7 +150,7 @@ OLAPStatus StorageEngine::open() {
     // init store_map
     for (auto& path : _options.store_paths) {
         DataDir* store = new DataDir(path.path, path.capacity_bytes, path.storage_medium,
-                _tablet_manager.get(), _txn_manager.get());
+                                     _tablet_manager.get(), _txn_manager.get());
         auto st = store->init();
         if (!st.ok()) {
             LOG(WARNING) << "Store load failed, path=" << path.path;
@@ -158,37 +159,21 @@ OLAPStatus StorageEngine::open() {
         _store_map.emplace(path.path, store);
     }
     _effective_cluster_id = config::cluster_id;
-    auto res = _check_all_root_path_cluster_id();
-    if (res != OLAP_SUCCESS) {
-        LOG(WARNING) << "fail to check cluster info. res=" << res;
-        return res;
-    }
+    RETURN_NOT_OK_LOG(_check_all_root_path_cluster_id(), "fail to check cluster info.");
 
     _update_storage_medium_type_count();
 
     RETURN_NOT_OK(_check_file_descriptor_number());
 
     auto cache = new_lru_cache(config::file_descriptor_cache_capacity);
-    if (cache == nullptr) {
-        LOG(WARNING) << "failed to init file descriptor LRUCache";
-        _tablet_manager->clear();
-        return OLAP_ERR_INIT_FAILED;
-    }
     FileHandler::set_fd_cache(cache);
 
-    // 初始化LRUCache
-    // cache大小可通过配置文件配置
     _index_stream_lru_cache = new_lru_cache(config::index_stream_cache_capacity);
-    if (_index_stream_lru_cache == NULL) {
-        LOG(WARNING) << "failed to init index stream LRUCache";
-        _tablet_manager->clear();
-        return OLAP_ERR_INIT_FAILED;
-    }
 
-    auto dirs = get_stores();
+    auto dirs = get_stores<false>();
     load_data_dirs(dirs);
 
-    _memtable_flush_executor = new MemTableFlushExecutor();
+    _memtable_flush_executor.reset(new MemTableFlushExecutor());
     _memtable_flush_executor->init(dirs);
 
     _parse_default_rowset_type();
@@ -266,13 +251,13 @@ std::vector<DataDir*> StorageEngine::get_stores() {
 template std::vector<DataDir*> StorageEngine::get_stores<false>();
 template std::vector<DataDir*> StorageEngine::get_stores<true>();
 
-OLAPStatus StorageEngine::get_all_data_dir_info(vector<DataDirInfo>* data_dir_infos, bool need_update) {
+OLAPStatus StorageEngine::get_all_data_dir_info(vector<DataDirInfo>* data_dir_infos,
+                                                bool need_update) {
     OLAPStatus res = OLAP_SUCCESS;
     data_dir_infos->clear();
 
     MonotonicStopWatch timer;
     timer.start();
-    int tablet_counter = 0;
 
     // 1. update avaiable capacity of each data dir
     // get all root path info and construct a path map.
@@ -289,6 +274,7 @@ OLAPStatus StorageEngine::get_all_data_dir_info(vector<DataDirInfo>* data_dir_in
     }
 
     // 2. get total tablets' size of each data dir
+    int tablet_counter = 0;
     _tablet_manager->update_root_path_info(&path_map, &tablet_counter);
 
     // add path info to data_dir_infos
@@ -327,8 +313,9 @@ void StorageEngine::start_disk_stat_monitor() {
     }
 }
 
-bool StorageEngine::_used_disk_not_enough(uint32_t unused_num, uint32_t total_num) {
-    return ((total_num == 0) || (unused_num * 100 / total_num > _min_percentage_of_error_disk));
+bool StorageEngine::_too_many_disks_are_broken(uint32_t unused_num, uint32_t total_num) {
+    return ((total_num == 0)
+            || (unused_num * 100 / total_num > config::max_percentage_of_error_disk));
 }
 
 // TODO(lingbin): Should be in EnvPosix?
@@ -437,10 +424,11 @@ void StorageEngine::_delete_tablets_on_unused_root_path() {
         ++unused_root_path_num;
     }
 
-    if (_used_disk_not_enough(unused_root_path_num, total_root_path_num)) {
-        LOG(FATAL) << "engine stop running, because more than " << _min_percentage_of_error_disk
-                   << " disks error. total_disks=" << total_root_path_num
-                   << ", error_disks=" << unused_root_path_num;
+    if (_too_many_disks_are_broken(unused_root_path_num, total_root_path_num)) {
+        LOG(FATAL) << "meet too many error disk, process exit. "
+                   << "max_ratio_allowed=" << config::max_percentage_of_error_disk << "%"
+                   << ", error_disk_count=" << unused_root_path_num
+                   << ", total_disk_count=" << total_root_path_num;
         exit(0);
     }
 
@@ -456,14 +444,13 @@ OLAPStatus StorageEngine::clear() {
     delete FileHandler::get_fd_cache();
     FileHandler::set_fd_cache(nullptr);
     SAFE_DELETE(_index_stream_lru_cache);
+
     std::lock_guard<std::mutex> l(_store_lock);
     for (auto& store_pair : _store_map) {
         delete store_pair.second;
         store_pair.second = nullptr;
     }
     _store_map.clear();
-
-    delete _memtable_flush_executor;
 
     return OLAP_SUCCESS;
 }
@@ -508,7 +495,8 @@ void StorageEngine::start_clean_fd_cache() {
 }
 
 void StorageEngine::perform_cumulative_compaction(DataDir* data_dir) {
-    TabletSharedPtr best_tablet = _tablet_manager->find_best_tablet_to_compaction(CompactionType::CUMULATIVE_COMPACTION, data_dir);
+    TabletSharedPtr best_tablet = _tablet_manager->find_best_tablet_to_compaction(
+            CompactionType::CUMULATIVE_COMPACTION, data_dir);
     if (best_tablet == nullptr) {
         return;
     }
@@ -522,8 +510,7 @@ void StorageEngine::perform_cumulative_compaction(DataDir* data_dir) {
         if (res != OLAP_ERR_CUMULATIVE_NO_SUITABLE_VERSIONS) {
             DorisMetrics::cumulative_compaction_request_failed.increment(1);
             LOG(WARNING) << "failed to do cumulative compaction. res=" << res
-                        << ", table=" << best_tablet->full_name()
-                        << ", res=" << res;
+                        << ", table=" << best_tablet->full_name();
         }
         return;
     }
@@ -531,7 +518,8 @@ void StorageEngine::perform_cumulative_compaction(DataDir* data_dir) {
 }
 
 void StorageEngine::perform_base_compaction(DataDir* data_dir) {
-    TabletSharedPtr best_tablet = _tablet_manager->find_best_tablet_to_compaction(CompactionType::BASE_COMPACTION, data_dir);
+    TabletSharedPtr best_tablet = _tablet_manager->find_best_tablet_to_compaction(
+            CompactionType::BASE_COMPACTION, data_dir);
     if (best_tablet == nullptr) {
         return;
     }
@@ -563,11 +551,8 @@ OLAPStatus StorageEngine::start_trash_sweep(double* usage) {
     const int32_t trash_expire = config::trash_file_expire_time_sec;
     const double guard_space = config::storage_flood_stage_usage_percent / 100.0;
     std::vector<DataDirInfo> data_dir_infos;
-    res = get_all_data_dir_info(&data_dir_infos, false);
-    if (res != OLAP_SUCCESS) {
-        LOG(WARNING) << "failed to get root path stat info when sweep trash.";
-        return res;
-    }
+    RETURN_NOT_OK_LOG(get_all_data_dir_info(&data_dir_infos, false),
+                      "failed to get root path stat info when sweep trash.")
 
     time_t now = time(nullptr); //获取UTC时间
     tm local_tm_now;
@@ -582,8 +567,7 @@ OLAPStatus StorageEngine::start_trash_sweep(double* usage) {
             continue;
         }
 
-        double curr_usage = (info.capacity - info.available)
-                / (double) info.capacity;
+        double curr_usage = (double) (info.capacity - info.available) / info.capacity;
         *usage = *usage > curr_usage ? *usage : curr_usage;
 
         OLAPStatus curr_res = OLAP_SUCCESS;

--- a/be/src/olap/storage_engine.h
+++ b/be/src/olap/storage_engine.h
@@ -61,7 +61,6 @@ class Tablet;
 // allocation/deallocation must be done outside.
 class StorageEngine {
 public:
-    StorageEngine() { }
     StorageEngine(const EngineOptions& options);
     ~StorageEngine();
 
@@ -153,8 +152,7 @@ public:
     // @param [in] root_path specify root path of new tablet
     // @param [in] request specify new tablet info
     // @return OLAP_SUCCESS if load tablet success
-    OLAPStatus load_header(
-        const std::string& shard_path, const TCloneReq& request);
+    OLAPStatus load_header(const std::string& shard_path, const TCloneReq& request);
 
     // call this if you want to trigger a disk and tablet report
     void report_notify(bool is_all) {
@@ -175,6 +173,7 @@ public:
 
     TabletManager* tablet_manager() { return _tablet_manager.get(); }
     TxnManager* txn_manager() { return _txn_manager.get(); }
+    MemTableFlushExecutor* memtable_flush_executor() { return _memtable_flush_executor.get(); }
 
     bool check_rowset_id_in_unused_rowsets(const RowsetId& rowset_id);
 
@@ -183,11 +182,13 @@ public:
 
     RowsetId next_rowset_id() { return _rowset_id_generator->next_id(); };
 
-    bool rowset_id_in_use(const RowsetId& rowset_id) { return _rowset_id_generator->id_in_use(rowset_id); };
+    bool rowset_id_in_use(const RowsetId& rowset_id) {
+        return _rowset_id_generator->id_in_use(rowset_id);
+    }
 
-    void release_rowset_id(const RowsetId& rowset_id) { return _rowset_id_generator->release_id(rowset_id); };
-
-    MemTableFlushExecutor* memtable_flush_executor() { return _memtable_flush_executor; }
+    void release_rowset_id(const RowsetId& rowset_id) {
+        return _rowset_id_generator->release_id(rowset_id);
+    }
 
     RowsetTypePB default_rowset_type() const {
         if (_heartbeat_flags != nullptr && _heartbeat_flags->is_set_default_rowset_type_to_beta()) {
@@ -208,12 +209,10 @@ public:
     }
 
 private:
-
+    OLAPStatus _start_bg_worker();
     OLAPStatus _check_file_descriptor_number();
 
     OLAPStatus _check_all_root_path_cluster_id();
-
-    bool _used_disk_not_enough(uint32_t unused_num, uint32_t total_num);
 
     OLAPStatus _config_root_path_unused_flag_file(
             const std::string& root_path,
@@ -225,7 +224,7 @@ private:
 
     OLAPStatus _judge_and_update_effective_cluster_id(int32_t cluster_id);
 
-    OLAPStatus _start_bg_worker();
+    bool _too_many_disks_are_broken(uint32_t unused_num, uint32_t total_num);
 
     void _clean_unused_txns();
 
@@ -304,8 +303,6 @@ private:
     bool _is_all_cluster_id_exist;
     bool _is_drop_tables;
 
-    // 错误磁盘所在百分比，超过设定的值，则engine需要退出运行
-    uint32_t _min_percentage_of_error_disk;
     Cache* _file_descriptor_lru_cache;
     Cache* _index_stream_lru_cache;
 
@@ -355,7 +352,7 @@ private:
 
     std::unique_ptr<RowsetIdGenerator> _rowset_id_generator;
 
-    MemTableFlushExecutor* _memtable_flush_executor;
+    std::unique_ptr<MemTableFlushExecutor> _memtable_flush_executor;
 
     // default rowset type for load
     // used to decide the type of new loaded data

--- a/be/src/olap/storage_engine.h
+++ b/be/src/olap/storage_engine.h
@@ -224,8 +224,6 @@ private:
 
     OLAPStatus _judge_and_update_effective_cluster_id(int32_t cluster_id);
 
-    bool _too_many_disks_are_broken(uint32_t unused_num, uint32_t total_num);
-
     void _clean_unused_txns();
 
     void _clean_unused_rowset_metas();


### PR DESCRIPTION
In `StorageEngine`, the member `_min_percentage_of_error_disk` was not
initialized (so it defaults to 0), which causes the process to exit
whenever one disk fails.

What we expect is that exit the process only when the number of
failed disks reach a certain percentage.

Also, this variable should mean the maximum percentage of
error disks allowed, not the minimum, so change the configuration
name to `max_percentage_of_error_disk`