### PR TITLE
Add `sync_dir` interface to Env

### DIFF
--- a/be/src/common/status.h
+++ b/be/src/common/status.h
@@ -128,15 +128,15 @@ public:
     }
 
     bool ok() const { return _state == nullptr; }
+
     bool is_cancelled() const { return code() == TStatusCode::CANCELLED; }
     bool is_mem_limit_exceeded() const { return code() == TStatusCode::MEM_LIMIT_EXCEEDED; }
     bool is_thrift_rpc_error() const { return code() == TStatusCode::THRIFT_RPC_ERROR; }
-
     bool is_end_of_file() const { return code() == TStatusCode::END_OF_FILE; }
-
     bool is_not_found() const { return code() == TStatusCode::NOT_FOUND; }
-    
+    bool is_already_exist() const { return code() == TStatusCode::ALREADY_EXIST; }
     bool is_io_error() const {return code() == TStatusCode::IO_ERROR; }
+
     // Convert into TStatus. Call this if 'status_container' contains an optional
     // TStatus field named 'status'. This also sets __isset.status.
     template <typename T>


### PR DESCRIPTION
when we need to ensure that **a newly-created file** is fully
synchronized back to disk, we should call `fsync()` on the parent
directory—that is, the directory containing the newly-created file.
That is to say, In this situation, we should call `fsync()` on
both the newly-created file and its parent directory.

Unfortunately, currently in Doris, in any scenario, directories
are not fsynced.

This patch adds `sync_dir()` interface first, laying the goundwork
for future fixes.

This patch also remove unneeded private method `dir_exists()`.