### PR TITLE
Add env-util class

### DIFF
--- a/be/src/env/CMakeLists.txt
+++ b/be/src/env/CMakeLists.txt
@@ -23,4 +23,5 @@ set(EXECUTABLE_OUTPUT_PATH "${BUILD_DIR}/src/env")
   
 add_library(Env STATIC
     env_posix.cpp
+    env_util.cpp
 )

--- a/be/src/env/env_util.cpp
+++ b/be/src/env/env_util.cpp
@@ -1,0 +1,50 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "env/env_util.h"
+
+#include "env/env.h"
+
+using std::shared_ptr;
+using std::string;
+using std::unique_ptr;
+
+namespace doris {
+namespace env_util {
+
+Status open_file_for_write(Env* env, const string& path, shared_ptr<WritableFile>* file) {
+    return open_file_for_write(WritableFileOptions(), env, path, file);
+}
+
+Status open_file_for_write(const WritableFileOptions& opts,
+                           Env *env, const string &path,
+                           shared_ptr<WritableFile> *file) {
+    unique_ptr<WritableFile> w;
+    RETURN_IF_ERROR(env->new_writable_file(opts, path, &w));
+    file->reset(w.release());
+    return Status::OK();
+}
+
+Status open_file_for_random(Env *env, const string &path, shared_ptr<RandomAccessFile> *file) {
+    unique_ptr<RandomAccessFile> r;
+    RETURN_IF_ERROR(env->new_random_access_file(path, &r));
+    file->reset(r.release());
+    return Status::OK();
+}
+
+} // namespace env_util
+} // namespace doris

--- a/be/src/env/env_util.h
+++ b/be/src/env/env_util.h
@@ -1,0 +1,43 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+#pragma once
+
+#include <memory>
+#include <string>
+
+#include "common/status.h"
+
+namespace doris {
+
+class Env;
+class RandomAccessFile;
+class WritableFile;
+struct WritableFileOptions;
+
+namespace env_util {
+
+Status open_file_for_write(Env *env, const std::string& path, std::shared_ptr<WritableFile> *file);
+
+Status open_file_for_write(const WritableFileOptions& opts, Env *env,
+                           const std::string& path, std::shared_ptr<WritableFile> *file);
+
+Status open_file_for_random(Env *env, const std::string& path,
+                            std::shared_ptr<RandomAccessFile> *file);
+
+} // namespace env_util
+} // namespace doris
+


### PR DESCRIPTION
The code submitted later will use this utility class.

Currently only factory methods for various file types are provided.
In the future, tool methods that are common to all Env types can
be added here.