### PR TITLE
[FIX] fix a sqlparser conflict by KW_PROPERTIES

### DIFF
--- a/fe/src/main/cup/sql_parser.cup
+++ b/fe/src/main/cup/sql_parser.cup
@@ -451,6 +451,7 @@ precedence left BITAND, BITOR, BITXOR;
 precedence left KW_PIPE;
 precedence left BITNOT;
 precedence left KW_ORDER, KW_BY, KW_LIMIT;
+precedence right KW_PROPERTIES;
 precedence left LPAREN, RPAREN;
 // Support chaining of timestamp arithmetic exprs.
 precedence left KW_INTERVAL;


### PR DESCRIPTION
fix a sqlparser conflict by KW_PROPERTIES, now change KW_PROPERTIES's precedence to right, so it must use like PROPERTIES()