### PR TITLE
Fixbug: Invalid memory address in doris::memory_copy (#2919)

### DIFF
--- a/be/src/olap/schema_change.cpp
+++ b/be/src/olap/schema_change.cpp
@@ -335,7 +335,7 @@ bool RowBlockChanger::change_row_block(
                             p--;
                         }
                         slice->size = p + 1;
-                        write_helper.set_field_content(i, buf, mem_pool);
+                        write_helper.set_field_content(i, reinterpret_cast<char*>(&slice), mem_pool);
                     }
                 }
             } else if ((reftype == OLAP_FIELD_TYPE_FLOAT && newtype == OLAP_FIELD_TYPE_DOUBLE)


### PR DESCRIPTION
   When I change schema from char(20) to varchar(20), be will cause coredump.