### PR TITLE
create pprof_profile_dir before heap profiling

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -139,8 +139,6 @@ namespace config {
 
     // If non-zero, Doris will output memory usage every log_mem_usage_interval'th fragment completion.
     CONF_Int32(log_mem_usage_interval, "0");
-    // if non-empty, enable heap profiling and output to specified directory.
-    CONF_String(heap_profile_dir, "");
 
     // cgroups allocated for doris
     CONF_String(doris_cgroups, "");

--- a/be/src/http/action/pprof_actions.cpp
+++ b/be/src/http/action/pprof_actions.cpp
@@ -25,7 +25,6 @@
 #include <gperftools/heap-profiler.h>
 #include <gperftools/malloc_extension.h>
 #include <gperftools/profiler.h>
-#include <boost/filesystem.hpp>
 
 #include "common/config.h"
 #include "http/ev_http_server.h"
@@ -242,8 +241,9 @@ void SymbolAction::handle(HttpRequest* req) {
 }
 
 Status PprofActions::setup(ExecEnv* exec_env, EvHttpServer* http_server) {
-    if (!config::pprof_profile_dir.empty())
-        boost::filesystem::create_directories(config::pprof_profile_dir);
+    if (!config::pprof_profile_dir.empty()){
+        FileUtils::create_dir(config::pprof_profile_dir);
+    }
 
     http_server->register_handler(HttpMethod::GET, "/pprof/heap", new HeapAction());
     http_server->register_handler(HttpMethod::GET, "/pprof/growth", new GrowthAction());

--- a/be/src/http/action/pprof_actions.cpp
+++ b/be/src/http/action/pprof_actions.cpp
@@ -18,21 +18,22 @@
 #include "http/action/pprof_actions.h"
 
 #include <fstream>
-#include <sstream>
 #include <iostream>
 #include <mutex>
+#include <sstream>
 
-#include <gperftools/profiler.h>
 #include <gperftools/heap-profiler.h>
 #include <gperftools/malloc_extension.h>
+#include <gperftools/profiler.h>
+#include <boost/filesystem.hpp>
 
 #include "common/config.h"
+#include "http/ev_http_server.h"
+#include "http/http_channel.h"
 #include "http/http_handler.h"
+#include "http/http_headers.h"
 #include "http/http_request.h"
 #include "http/http_response.h"
-#include "http/http_channel.h"
-#include "http/http_headers.h"
-#include "http/ev_http_server.h"
 #include "runtime/exec_env.h"
 #include "util/bfd_parser.h"
 
@@ -40,17 +41,17 @@ namespace doris {
 
 // pprof default sample time in seconds.
 static const std::string SECOND_KEY = "seconds";
-static const int kPprofDefaultSampleSecs = 30; 
+static const int kPprofDefaultSampleSecs = 30;
 
 // Protect, only one thread can work
 static std::mutex kPprofActionMutex;
 
 class HeapAction : public HttpHandler {
 public:
-    HeapAction() { }
-    virtual ~HeapAction() { }
+    HeapAction() {}
+    virtual ~HeapAction() {}
 
-    virtual void handle(HttpRequest *req) override;
+    virtual void handle(HttpRequest* req) override;
 };
 
 void HeapAction::handle(HttpRequest* req) {
@@ -71,8 +72,8 @@ void HeapAction::handle(HttpRequest* req) {
 
     std::stringstream tmp_prof_file_name;
     // Build a temporary file name that is hopefully unique.
-    tmp_prof_file_name << config::pprof_profile_dir << "/heap_profile."
-        << getpid() << "." << rand();
+    tmp_prof_file_name << config::pprof_profile_dir << "/heap_profile." << getpid() << "."
+                       << rand();
 
     HeapProfilerStart(tmp_prof_file_name.str().c_str());
     // Sleep to allow for some samples to be collected.
@@ -88,10 +89,10 @@ void HeapAction::handle(HttpRequest* req) {
 
 class GrowthAction : public HttpHandler {
 public:
-    GrowthAction() { }
-    virtual ~GrowthAction() { }
+    GrowthAction() {}
+    virtual ~GrowthAction() {}
 
-    virtual void handle(HttpRequest *req) override;
+    virtual void handle(HttpRequest* req) override;
 };
 
 void GrowthAction::handle(HttpRequest* req) {
@@ -110,13 +111,13 @@ void GrowthAction::handle(HttpRequest* req) {
 
 class ProfileAction : public HttpHandler {
 public:
-    ProfileAction() { }
-    virtual ~ProfileAction() { }
+    ProfileAction() {}
+    virtual ~ProfileAction() {}
 
-    virtual void handle(HttpRequest *req) override;
+    virtual void handle(HttpRequest* req) override;
 };
 
-void ProfileAction::handle(HttpRequest *req) {
+void ProfileAction::handle(HttpRequest* req) {
 #if defined(ADDRESS_SANITIZER) || defined(LEAK_SANITIZER) || defined(THREAD_SANITIZER)
     std::string str = "CPU profiling is not available with address sanitizer builds.";
     HttpChannel::send_reply(req, str);
@@ -131,8 +132,8 @@ void ProfileAction::handle(HttpRequest *req) {
 
     std::ostringstream tmp_prof_file_name;
     // Build a temporary file name that is hopefully unique.
-    tmp_prof_file_name << config::pprof_profile_dir << "/doris_profile." 
-        << getpid() << "." << rand();
+    tmp_prof_file_name << config::pprof_profile_dir << "/doris_profile." << getpid() << "."
+                       << rand();
     ProfilerStart(tmp_prof_file_name.str().c_str());
     sleep(seconds);
     ProfilerStop();
@@ -154,26 +155,24 @@ void ProfileAction::handle(HttpRequest *req) {
 
 class PmuProfileAction : public HttpHandler {
 public:
-    PmuProfileAction() { }
-    virtual ~PmuProfileAction() { }
-    virtual void handle(HttpRequest *req) override {
-    }
+    PmuProfileAction() {}
+    virtual ~PmuProfileAction() {}
+    virtual void handle(HttpRequest* req) override {}
 };
 
 class ContentionAction : public HttpHandler {
 public:
-    ContentionAction() { }
-    virtual ~ContentionAction() { }
+    ContentionAction() {}
+    virtual ~ContentionAction() {}
 
-    virtual void handle(HttpRequest *req) override {
-    }
+    virtual void handle(HttpRequest* req) override {}
 };
 
 class CmdlineAction : public HttpHandler {
 public:
-    CmdlineAction() { }
-    virtual ~CmdlineAction() { }
-    virtual void handle(HttpRequest *req) override;
+    CmdlineAction() {}
+    virtual ~CmdlineAction() {}
+    virtual void handle(HttpRequest* req) override;
 };
 
 void CmdlineAction::handle(HttpRequest* req) {
@@ -194,10 +193,10 @@ void CmdlineAction::handle(HttpRequest* req) {
 
 class SymbolAction : public HttpHandler {
 public:
-    SymbolAction(BfdParser* parser) : _parser(parser) { }
-    virtual ~SymbolAction() { }
+    SymbolAction(BfdParser* parser) : _parser(parser) {}
+    virtual ~SymbolAction() {}
 
-    virtual void handle(HttpRequest *req) override;
+    virtual void handle(HttpRequest* req) override;
 
 private:
     BfdParser* _parser;
@@ -243,18 +242,15 @@ void SymbolAction::handle(HttpRequest* req) {
 }
 
 Status PprofActions::setup(ExecEnv* exec_env, EvHttpServer* http_server) {
-    http_server->register_handler(HttpMethod::GET, "/pprof/heap",
-                                  new HeapAction());
-    http_server->register_handler(HttpMethod::GET, "/pprof/growth",
-                                  new GrowthAction());
-    http_server->register_handler(HttpMethod::GET, "/pprof/profile",
-                                  new ProfileAction());
-    http_server->register_handler(HttpMethod::GET, "/pprof/pmuprofile",
-                                  new PmuProfileAction());
-    http_server->register_handler(HttpMethod::GET, "/pprof/contention",
-                                  new ContentionAction());
-    http_server->register_handler(HttpMethod::GET, "/pprof/cmdline",
-                                  new CmdlineAction());
+    if (!config::pprof_profile_dir.empty())
+        boost::filesystem::create_directories(config::pprof_profile_dir);
+
+    http_server->register_handler(HttpMethod::GET, "/pprof/heap", new HeapAction());
+    http_server->register_handler(HttpMethod::GET, "/pprof/growth", new GrowthAction());
+    http_server->register_handler(HttpMethod::GET, "/pprof/profile", new ProfileAction());
+    http_server->register_handler(HttpMethod::GET, "/pprof/pmuprofile", new PmuProfileAction());
+    http_server->register_handler(HttpMethod::GET, "/pprof/contention", new ContentionAction());
+    http_server->register_handler(HttpMethod::GET, "/pprof/cmdline", new CmdlineAction());
     auto action = new SymbolAction(exec_env->bfd_parser());
     http_server->register_handler(HttpMethod::GET, "/pprof/symbol", action);
     http_server->register_handler(HttpMethod::HEAD, "/pprof/symbol", action);
@@ -262,4 +258,4 @@ Status PprofActions::setup(ExecEnv* exec_env, EvHttpServer* http_server) {
     return Status::OK();
 }
 
-}
+} // namespace doris

--- a/be/src/http/action/pprof_actions.cpp
+++ b/be/src/http/action/pprof_actions.cpp
@@ -35,6 +35,7 @@
 #include "http/http_response.h"
 #include "runtime/exec_env.h"
 #include "util/bfd_parser.h"
+#include "util/file_utils.h"
 
 namespace doris {
 
@@ -241,7 +242,7 @@ void SymbolAction::handle(HttpRequest* req) {
 }
 
 Status PprofActions::setup(ExecEnv* exec_env, EvHttpServer* http_server) {
-    if (!config::pprof_profile_dir.empty()){
+    if (!config::pprof_profile_dir.empty()) {
         FileUtils::create_dir(config::pprof_profile_dir);
     }
 

--- a/be/src/service/backend_service.cpp
+++ b/be/src/service/backend_service.cpp
@@ -70,12 +70,6 @@ using apache::thrift::concurrency::PosixThreadFactory;
 BackendService::BackendService(ExecEnv* exec_env) :
         _exec_env(exec_env),
         _agent_server(new AgentServer(exec_env, *exec_env->master_info())) {
-#if !defined(ADDRESS_SANITIZER) && !defined(LEAK_SANITIZER) && !defined(THREAD_SANITIZER)
-    // tcmalloc and address sanitizer can not be used together
-    if (!config::heap_profile_dir.empty()) {
-        HeapProfilerStart(config::heap_profile_dir.c_str());
-    }
-#endif
     char buf[64];
     DateTimeValue value = DateTimeValue::local_time();
     value.to_string(buf);


### PR DESCRIPTION
only add create dir code(https://github.com/vagetablechicken/incubator-doris/commit/18ee0eb0867d3a7540d3538daa1b184dd64c5369#diff-2e6f5a32f0d05c704d7c66abf7e74ae3R246), contain too much clang-format diff

If `config::heap_profile_dir` is no use, I'd like to remove it in this pr.
https://github.com/apache/incubator-doris/blob/feef077520ba9dc843fa900febd43b8ed03c2b66/be/src/service/backend_service.cpp#L76

