### PR TITLE
[Bug] Missing `in memory` property for old version of partition info

### DIFF
--- a/fe/src/main/cup/sql_parser.cup
+++ b/fe/src/main/cup/sql_parser.cup
@@ -1721,7 +1721,7 @@ opt_engine ::=
 
 opt_key_value_map ::=
     {:
-    RESULT = null;
+    RESULT = Maps.newHashMap();
     :}
     | LPAREN key_value_map:map RPAREN
     {:

--- a/fe/src/main/java/org/apache/doris/catalog/PartitionInfo.java
+++ b/fe/src/main/java/org/apache/doris/catalog/PartitionInfo.java
@@ -151,6 +151,9 @@ public class PartitionInfo implements Writable {
             idToReplicationNum.put(partitionId, replicationNum);
             if (Catalog.getCurrentCatalogJournalVersion() >= FeMetaVersion.VERSION_72) {
                 idToInMemory.put(partitionId, in.readBoolean());
+            } else {
+                // for compatibility, default is false
+                idToInMemory.put(partitionId, false);
             }
         }
     }


### PR DESCRIPTION
This bug is introduced by PR #2846 