### PR TITLE
Fix some function DATE type priority

### DIFF
--- a/fe/src/main/java/org/apache/doris/rewrite/FEFunctions.java
+++ b/fe/src/main/java/org/apache/doris/rewrite/FEFunctions.java
@@ -214,21 +214,6 @@ public class FEFunctions {
      ------------------------------------------------------------------------------
      */
 
-
-    /**
-     * Cast
-     */
-
-    @FEFunction(name = "casttoint", argTypes = { "VARCHAR"}, returnType = "INT")
-    public static IntLiteral castToInt(StringLiteral expr) throws AnalysisException {
-        return new IntLiteral(expr.getLongValue(), Type.INT);
-    }
-
-
-    /**
-     ------------------------------------------------------------------------------
-     */
-
     /**
      * Math function
      */

--- a/fe/src/test/java/org/apache/doris/rewrite/FEFunctionsTest.java
+++ b/fe/src/test/java/org/apache/doris/rewrite/FEFunctionsTest.java
@@ -290,17 +290,6 @@ public class FEFunctionsTest {
     }
 
     @Test
-    public void castToIntTest() throws AnalysisException {
-        IntLiteral actualResult =  FEFunctions.castToInt(new StringLiteral("2019"));
-        IntLiteral expectedResult = new IntLiteral(2019);
-        Assert.assertEquals(expectedResult, actualResult);
-
-        actualResult = FEFunctions.castToInt(new StringLiteral("-1970"));
-        expectedResult = new IntLiteral(-1970);
-        Assert.assertEquals(expectedResult, actualResult);
-    }
-
-    @Test
     public void floorTest() throws AnalysisException {
         IntLiteral actualResult = FEFunctions.floor(new FloatLiteral(3.3));
         IntLiteral expectedResult = new IntLiteral(3);

--- a/fe/src/test/java/org/apache/doris/utframe/ConstantExpressTest.java
+++ b/fe/src/test/java/org/apache/doris/utframe/ConstantExpressTest.java
@@ -1,0 +1,151 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.utframe;
+
+import org.apache.doris.qe.ConnectContext;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.UUID;
+
+public class ConstantExpressTest {
+    // use a unique dir so that it won't be conflict with other unit test which
+    // may also start a Mocked Frontend
+    private static String runningDir = "fe/mocked/ConstantExpressTest/" + UUID.randomUUID().toString() + "/";
+
+    private static ConnectContext connectContext;
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        UtFrameUtils.startFEServer(runningDir);
+        connectContext = UtFrameUtils.createDefaultCtx();
+    }
+
+    private static void testConstantExpressResult(String sql, String result) throws Exception {
+        String explainString = UtFrameUtils.getSQLPlanOrErrorMsg(connectContext, "explain " + sql);
+        System.out.println(explainString);
+        Assert.assertTrue(explainString.contains("constant exprs: "+result));
+    }
+
+    @Test
+    public void testDate() throws Exception {
+        testConstantExpressResult(
+                "select date_format('2020-02-19 16:01:12','%H%i');",
+                "'1601'");
+
+        testConstantExpressResult(
+                "select date_format('2020-02-19 16:01:12','%Y%m%d');",
+                "'20200219'");
+
+        testConstantExpressResult(
+                "select date_format(date_sub('2018-07-24 07:16:19',1),'yyyyMMdd');",
+                "'20180723'");
+
+        testConstantExpressResult(
+                "select year('2018-07-24')*12 + month('2018-07-24');",
+                "24223");
+
+        testConstantExpressResult(
+                "select date_format('2018-08-08 07:16:19', 'yyyyMMdd');",
+                "'20180808'");
+
+        testConstantExpressResult(
+                "select date_format('2018-08-08 07:16:19', 'yyyy-MM-dd HH:mm:ss');",
+                "'2018-08-08 07:16:19'");
+
+        testConstantExpressResult(
+                "select datediff('2018-08-08','1970-01-01');",
+                "17751");
+
+        testConstantExpressResult(
+                "select date_add('2018-08-08', 1);",
+                "'2018-08-09 00:00:00'");
+
+        testConstantExpressResult(
+                "select date_add('2018-08-08', -1);",
+                "'2018-08-07 00:00:00'");
+
+        testConstantExpressResult(
+                "select date_sub('2018-08-08 07:16:19',1);",
+                "'2018-08-07 07:16:19'");
+
+        testConstantExpressResult(
+                "select year('2018-07-24');",
+                "2018");
+
+        testConstantExpressResult(
+                "select month('2018-07-24');",
+                "7");
+
+        testConstantExpressResult(
+                "select day('2018-07-24');",
+                "24");
+
+        testConstantExpressResult(
+                "select UNIX_TIMESTAMP(\"1970-01-01 08:00:01\");",
+                "1");
+    }
+
+    @Test
+    public void testCast() throws Exception {
+        testConstantExpressResult(
+                "select cast ('1' as int) ;",
+                "1");
+
+        testConstantExpressResult(
+                "select cast ('2020-01-20' as date);",
+                "'2020-01-20'");
+    }
+
+    @Test
+    public void testArithmetic() throws Exception {
+        testConstantExpressResult(
+                "select 1 + 10;",
+                "11");
+
+        testConstantExpressResult(
+                "select 1 - 10;",
+                "-9");
+
+        testConstantExpressResult(
+                "select 1 * 10.0;",
+                "10.0");
+
+        testConstantExpressResult(
+                "select 1 / 10.0;",
+                "0.1");
+    }
+
+    @Test
+    public void testMath() throws Exception {
+        testConstantExpressResult(
+                "select floor(2.3);",
+                "2");
+    }
+
+    @Test
+    public void testPredicate() throws Exception {
+        testConstantExpressResult(
+                "select 1 > 2",
+                "FALSE");
+
+        testConstantExpressResult(
+                "select 1 = 1",
+                "TRUE");
+    }
+}

--- a/gensrc/script/doris_builtins_functions.py
+++ b/gensrc/script/doris_builtins_functions.py
@@ -102,9 +102,9 @@ visible_functions = [
     # Timestamp functions
     [['unix_timestamp'], 'INT', [],
         '_ZN5doris18TimestampFunctions7to_unixEPN9doris_udf15FunctionContextE'],
-    [['unix_timestamp'], 'INT', ['DATE'],
-        '_ZN5doris18TimestampFunctions7to_unixEPN9doris_udf15FunctionContextERKNS1_11DateTimeValE'],
     [['unix_timestamp'], 'INT', ['DATETIME'],
+        '_ZN5doris18TimestampFunctions7to_unixEPN9doris_udf15FunctionContextERKNS1_11DateTimeValE'],
+    [['unix_timestamp'], 'INT', ['DATE'],
         '_ZN5doris18TimestampFunctions7to_unixEPN9doris_udf15FunctionContextERKNS1_11DateTimeValE'],
     [['unix_timestamp'], 'INT', ['VARCHAR', 'VARCHAR'],
         '_ZN5doris18TimestampFunctions7to_unixEPN9doris_udf15FunctionContextERKNS1_9StringValES6_'],
@@ -212,10 +212,10 @@ visible_functions = [
     [['str_to_date'], 'DATETIME', ['VARCHAR', 'VARCHAR'],
         '_ZN5doris18TimestampFunctions11str_to_dateEPN9doris_udf'
         '15FunctionContextERKNS1_9StringValES6_'],
-    [['date_format'], 'VARCHAR', ['DATE', 'VARCHAR'],
+    [['date_format'], 'VARCHAR', ['DATETIME', 'VARCHAR'],
         '_ZN5doris18TimestampFunctions11date_formatEPN9doris_udf'
         '15FunctionContextERKNS1_11DateTimeValERKNS1_9StringValE'],
-    [['date_format'], 'VARCHAR', ['DATETIME', 'VARCHAR'],
+    [['date_format'], 'VARCHAR', ['DATE', 'VARCHAR'],
         '_ZN5doris18TimestampFunctions11date_formatEPN9doris_udf'
         '15FunctionContextERKNS1_11DateTimeValERKNS1_9StringValE'],
     [['date', 'to_date'], 'DATE', ['DATETIME'],
@@ -443,8 +443,8 @@ visible_functions = [
     [['if'], 'LARGEINT', ['BOOLEAN', 'LARGEINT', 'LARGEINT'], ''],
     [['if'], 'FLOAT', ['BOOLEAN', 'FLOAT', 'FLOAT'], ''],
     [['if'], 'DOUBLE', ['BOOLEAN', 'DOUBLE', 'DOUBLE'], ''],
-    [['if'], 'DATE', ['BOOLEAN', 'DATE', 'DATE'], ''],
     [['if'], 'DATETIME', ['BOOLEAN', 'DATETIME', 'DATETIME'], ''],
+    [['if'], 'DATE', ['BOOLEAN', 'DATE', 'DATE'], ''],
     [['if'], 'DECIMAL', ['BOOLEAN', 'DECIMAL', 'DECIMAL'], ''],
     [['if'], 'DECIMALV2', ['BOOLEAN', 'DECIMALV2', 'DECIMALV2'], ''],
     # The priority of varchar should be lower than decimal in IS_SUPERTYPE_OF mode.
@@ -458,8 +458,8 @@ visible_functions = [
     [['nullif'], 'LARGEINT', ['LARGEINT', 'LARGEINT'], ''],
     [['nullif'], 'FLOAT', ['FLOAT', 'FLOAT'], ''],
     [['nullif'], 'DOUBLE', ['DOUBLE', 'DOUBLE'], ''],
-    [['nullif'], 'DATE', ['DATE', 'DATE'], ''],
     [['nullif'], 'DATETIME', ['DATETIME', 'DATETIME'], ''],
+    [['nullif'], 'DATE', ['DATE', 'DATE'], ''],
     [['nullif'], 'DECIMAL', ['DECIMAL', 'DECIMAL'], ''],
     [['nullif'], 'DECIMALV2', ['DECIMALV2', 'DECIMALV2'], ''],
     # The priority of varchar should be lower than decimal in IS_SUPERTYPE_OF mode.
@@ -488,8 +488,8 @@ visible_functions = [
     [['coalesce'], 'LARGEINT', ['LARGEINT', '...'], ''],
     [['coalesce'], 'FLOAT', ['FLOAT', '...'], ''],
     [['coalesce'], 'DOUBLE', ['DOUBLE', '...'], ''],
-    [['coalesce'], 'DATE', ['DATE', '...'], ''],
     [['coalesce'], 'DATETIME', ['DATETIME', '...'], ''],
+    [['coalesce'], 'DATE', ['DATE', '...'], ''],
     [['coalesce'], 'DECIMAL', ['DECIMAL', '...'], ''],
     [['coalesce'], 'DECIMALV2', ['DECIMALV2', '...'], ''],
     # The priority of varchar should be lower than decimal in IS_SUPERTYPE_OF mode.


### PR DESCRIPTION
1. Fix the bug introduced by https://github.com/apache/incubator-doris/pull/2947.  
The following sql result is 0000, which is wrong. The result should be 1601
```
select date_format('2020-02-19 16:01:12','%H%i');
```

2. Add constant Express plan test, ensure the FE constant Express compute result is right.

3. Remove the `castToInt ` function in `FEFunctions`, which is duplicated with `CastExpr::getResultValue`

4. Implement `getNodeExplainString` method for `UnionNode`