### PR TITLE
Add multi-thread ver olaptablesink for LOAD

### DIFF
--- a/be/src/exec/tablet_sink.h
+++ b/be/src/exec/tablet_sink.h
@@ -199,6 +199,9 @@ private:
     std::unordered_map<int64_t, AddBatchCounter> _add_batch_counter_map;
 };
 
+// RowBuffer is used for multi-thread version of OlapTableSink, it's single-productor/single-consumer.
+// In multi-thread version, OlapTableSink will create multi RowBuffers, and create the same number threads to exec RowBuffer::consume_process.
+// Only one thread(OlapTableSink::send) exec push op, use modular hashing(node_id%buffer_num) to specify the buffer for which the row should be pushed into.
 class RowBuffer {
 public:
     RowBuffer(TupleDescriptor* tuple_desc, int64_t byte_limit, int64_t size_limit)

--- a/docs/documentation/cn/sql-reference/sql-statements/Data Manipulation/BROKER LOAD.md
+++ b/docs/documentation/cn/sql-reference/sql-statements/Data Manipulation/BROKER LOAD.md
@@ -158,7 +158,7 @@ under the License.
         strict mode：     是否对数据进行严格限制。默认为 false。
         timezone:         指定某些受时区影响的函数的时区，如 strftime/alignment_timestamp/from_unixtime 等等，具体请查阅 [时区] 文档。如果不指定，则使用 "Asia/Shanghai" 时区。
 
-        *针对数据量较大的BROKER LOAD，可以使用多线程模式提高导入速度，通过设置如下参数：
+        \*针对数据量较大的BROKER LOAD，可以使用多线程模式提高导入速度，通过设置如下参数：
         buffer_num:         多线程模式使用的buffer数目和线程数目
         mem_limit_per_buf:  每个buffer可以使用的最大内存
         size_limit_per_buf: 每个buffer可容纳的数据条数

--- a/docs/documentation/en/sql-reference/sql-statements/Data Manipulation/BROKER LOAD_EN.md
+++ b/docs/documentation/en/sql-reference/sql-statements/Data Manipulation/BROKER LOAD_EN.md
@@ -171,7 +171,7 @@ under the License.
 
         timezone: Specify time zones for functions affected by time zones, such as strftime/alignment_timestamp/from_unixtime, etc. See the documentation for details. If not specified, use the "Asia/Shanghai" time zone.
 
-        *If BROKER LOAD data is large, we can use multi-thread mode to improve load speed. You can specify the following parameters:
+        \*If BROKER LOAD data is large, we can use multi-thread mode to improve load speed. You can specify the following parameters:
         buffer_num:         number of buffers in multi-thread, the same number of threads
         mem_limit_per_buf:  the memory limit of one buffer
         size_limit_per_buf: the max number of rows in one buffer

--- a/fe/src/main/java/org/apache/doris/analysis/LoadStmt.java
+++ b/fe/src/main/java/org/apache/doris/analysis/LoadStmt.java
@@ -62,6 +62,10 @@ public class LoadStmt extends DdlStmt {
     private static final String VERSION = "version";
     public static final String STRICT_MODE = "strict_mode";
     public static final String TIMEZONE = "timezone";
+
+    public static final String BUFFER_NUM = "buffer_num";
+    public static final String MEM_LIMIT_PER_BUF = "mem_limit_per_buf";
+    public static final String SIZE_LIMIT_PER_BUF = "size_limit_per_buf";
     
     // for load data from Baidu Object Store(BOS)
     public static final String BOS_ENDPOINT = "bos_endpoint";
@@ -95,6 +99,9 @@ public class LoadStmt extends DdlStmt {
             .add(STRICT_MODE)
             .add(VERSION)
             .add(TIMEZONE)
+            .add(BUFFER_NUM)
+            .add(MEM_LIMIT_PER_BUF)
+            .add(SIZE_LIMIT_PER_BUF)
             .build();
     
     public LoadStmt(LabelName label, List<DataDescription> dataDescriptions,

--- a/fe/src/main/java/org/apache/doris/load/loadv2/BrokerLoadJob.java
+++ b/fe/src/main/java/org/apache/doris/load/loadv2/BrokerLoadJob.java
@@ -183,7 +183,7 @@ public class BrokerLoadJob extends LoadJob {
     }
 
     @Override
-    public Set<String> getTableNames() throws MetaNotFoundException{
+    public Set<String> getTableNames() throws MetaNotFoundException {
         Set<String> result = Sets.newHashSet();
         Database database = Catalog.getCurrentCatalog().getDb(dbId);
         if (database == null) {
@@ -377,6 +377,9 @@ public class BrokerLoadJob extends LoadJob {
                 LoadLoadingTask task = new LoadLoadingTask(db, table, brokerDesc,
                         brokerFileGroups, getDeadlineMs(), execMemLimit,
                         strictMode, transactionId, this, timezone, timeoutSecond);
+                if (bufferNum > 0) {
+                    task.useMultiThreadSink(bufferNum, memLimitPerBuf, sizeLimitPerBuf);
+                }
                 UUID uuid = UUID.randomUUID();
                 TUniqueId loadId = new TUniqueId(uuid.getMostSignificantBits(), uuid.getLeastSignificantBits());
                 task.init(loadId, attachment.getFileStatusByTable(aggKey), attachment.getFileNumByTable(aggKey));
@@ -558,5 +561,4 @@ public class BrokerLoadJob extends LoadJob {
             sessionVariables.put(SessionVariable.SQL_MODE, String.valueOf(SqlModeHelper.MODE_DEFAULT));
         }
     }
-
 }

--- a/fe/src/main/java/org/apache/doris/load/loadv2/LoadJob.java
+++ b/fe/src/main/java/org/apache/doris/load/loadv2/LoadJob.java
@@ -17,20 +17,6 @@
 
 package org.apache.doris.load.loadv2;
 
-import com.google.common.base.Joiner;
-import com.google.common.collect.HashBasedTable;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
-import com.google.common.collect.Table;
-import com.google.gson.Gson;
-import java.io.DataInput;
-import java.io.DataOutput;
-import java.io.IOException;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
 import org.apache.doris.analysis.LoadStmt;
 import org.apache.doris.catalog.AuthorizationInfo;
 import org.apache.doris.catalog.Catalog;
@@ -67,8 +53,25 @@ import org.apache.doris.transaction.AbstractTxnStateChangeCallback;
 import org.apache.doris.transaction.BeginTransactionException;
 import org.apache.doris.transaction.TransactionException;
 import org.apache.doris.transaction.TransactionState;
+
+import com.google.common.base.Joiner;
+import com.google.common.collect.HashBasedTable;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import com.google.common.collect.Table;
+import com.google.gson.Gson;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 public abstract class LoadJob extends AbstractTxnStateChangeCallback implements LoadTaskCallback, Writable {
     private static final Logger LOG = LogManager.getLogger(LoadJob.class);

--- a/fe/src/main/java/org/apache/doris/load/loadv2/LoadLoadingTask.java
+++ b/fe/src/main/java/org/apache/doris/load/loadv2/LoadLoadingTask.java
@@ -60,6 +60,9 @@ public class LoadLoadingTask extends LoadTask {
     private final String timezone;
     // timeout of load job, in seconds
     private final long timeoutS;
+    private int bufferNum = 0;
+    private long memLimitPerBuf = 0;
+    private long sizeLimitPerBuf = 0;
 
     private LoadingTaskPlanner planner;
 
@@ -83,9 +86,16 @@ public class LoadLoadingTask extends LoadTask {
         this.timeoutS = timeoutS;
     }
 
+    public void useMultiThreadSink(int bufferNum, long memLimitPerBuf, long sizeLimitPerBuf) {
+        this.bufferNum = bufferNum;
+        this.memLimitPerBuf = memLimitPerBuf;
+        this.sizeLimitPerBuf = sizeLimitPerBuf;
+    }
+
     public void init(TUniqueId loadId, List<List<TBrokerFileStatus>> fileStatusList, int fileNum) throws UserException {
         this.loadId = loadId;
-        planner = new LoadingTaskPlanner(callback.getCallbackId(), txnId, db.getId(), table, brokerDesc, fileGroups, strictMode, timezone, this.timeoutS);
+        planner = new LoadingTaskPlanner(callback.getCallbackId(), txnId, db.getId(), table, brokerDesc, fileGroups, strictMode,
+            timezone, this.timeoutS, bufferNum, memLimitPerBuf, sizeLimitPerBuf);
         planner.plan(loadId, fileStatusList, fileNum);
     }
 

--- a/fe/src/main/java/org/apache/doris/planner/OlapTableSink.java
+++ b/fe/src/main/java/org/apache/doris/planner/OlapTableSink.java
@@ -109,10 +109,12 @@ public class OlapTableSink extends DataSink {
 
         if (bufferNum > 0) {
             tSink.setBuffer_num(bufferNum);
-            if (memLimitPerBuf > 0)
+            if (memLimitPerBuf > 0) {
                 tSink.setMem_limit_per_buf(memLimitPerBuf);
-            if (sizeLimitPerBuf > 0)
+            }
+            if (sizeLimitPerBuf > 0) {
                 tSink.setSize_limit_per_buf(sizeLimitPerBuf);
+            }
         }
 
         tDataSink = new TDataSink(TDataSinkType.DATA_SPLIT_SINK);

--- a/gensrc/thrift/DataSinks.thrift
+++ b/gensrc/thrift/DataSinks.thrift
@@ -105,9 +105,9 @@ struct TOlapTableSink {
     12: required Descriptors.TOlapTableLocationParam location
     13: required Descriptors.TPaloNodesInfo nodes_info
     14: optional i64 load_channel_timeout_s // the timeout of load channels in second
-    15: optional i32 buffer_num
-    16: optional i64 mem_limit_per_buf
-    17: optional i64 size_limit_per_buf
+    15: optional i32 buffer_num // number of buffers in multi-thread version of OlapTableSink, the same number of threads
+    16: optional i64 mem_limit_per_buf // if memory limit exceeded, block the buffer push
+    17: optional i64 size_limit_per_buf // if buffer queue is full, block the buffer push
 }
 
 struct TDataSink {

--- a/gensrc/thrift/DataSinks.thrift
+++ b/gensrc/thrift/DataSinks.thrift
@@ -105,6 +105,9 @@ struct TOlapTableSink {
     12: required Descriptors.TOlapTableLocationParam location
     13: required Descriptors.TPaloNodesInfo nodes_info
     14: optional i64 load_channel_timeout_s // the timeout of load channels in second
+    15: optional i32 buffer_num
+    16: optional i64 mem_limit_per_buf
+    17: optional i64 size_limit_per_buf
 }
 
 struct TDataSink {


### PR DESCRIPTION
Ref https://github.com/apache/incubator-doris/issues/2780#issuecomment-588156273
So we can use 
```
LOAD LABEL ...
        PROPERTIES 
        ( 
        "buffer_num"="5", 
        "mem_limit_per_buf"="5368709120", 
        "size_limit_per_buf"="62914560"
        );
```
to use multi-thread version olaptablesink,  to accelerate the time-consuming load.
If we don't set buffer_num or set it to 0, use the origin version(single-thread).

- [x] add configuration references

- [x] add doc