### PR TITLE
[ut] fix the  test case of SegmentReaderWriterTest::TestBitmapPredicate

### DIFF
--- a/be/src/olap/tablet_schema.cpp
+++ b/be/src/olap/tablet_schema.cpp
@@ -253,7 +253,8 @@ uint32_t TabletColumn::get_field_length_by_type(TPrimitiveType::type type, uint3
     }
 }
 
-TabletColumn::TabletColumn() {}
+TabletColumn::TabletColumn() :
+    _aggregation(OLAP_FIELD_AGGREGATION_NONE) {}
 
 TabletColumn::TabletColumn(FieldAggregationMethod agg, FieldType type) {
     _aggregation = agg;

--- a/be/test/olap/tablet_schema_helper.h
+++ b/be/test/olap/tablet_schema_helper.h
@@ -31,7 +31,6 @@ TabletColumn create_int_key(int32_t id, bool is_nullable = true,
     column._col_name = std::to_string(id);
     column._type = OLAP_FIELD_TYPE_INT;
     column._is_key = true;
-    column._aggregation = OLAP_FIELD_AGGREGATION_NONE;
     column._is_nullable = is_nullable;
     column._length = 4;
     column._index_length = 4;

--- a/be/test/olap/tablet_schema_helper.h
+++ b/be/test/olap/tablet_schema_helper.h
@@ -31,6 +31,7 @@ TabletColumn create_int_key(int32_t id, bool is_nullable = true,
     column._col_name = std::to_string(id);
     column._type = OLAP_FIELD_TYPE_INT;
     column._is_key = true;
+    column._aggregation = OLAP_FIELD_AGGREGATION_NONE;
     column._is_nullable = is_nullable;
     column._length = 4;
     column._index_length = 4;


### PR DESCRIPTION
function create_int_key() will create a TableColumn instance with data memger: _aggregation=(random value)

if _aggregation==OLAP_FIELD_AGGREGATION_REPLACE SegmentWriter::init() will set opts.need_bitmap_index = false;

so the test case TEST_F(SegmentReaderWriterTest, TestBitmapPredicate)  of olap/rowset/segment_v2/segment_test.cpp will exec failed if the_aggregation of TableColumn == OLAP_FIELD_AGGREGATION_REPLACE.

```
TEST_F(SegmentReaderWriterTest, TestBitmapPredicate) {
    TabletSchema tablet_schema = create_schemate({
        create_int_key(1, true, false, true),
        create_int_key(2, true, false, true),
        create_int_value(3),
        create_int_value(4)});
       ...
      ASSERT_TRUE(segment->footer().columns(0).has_bitmap_index());
      ...
}
```