### PR TITLE
Fixed the move-assigment of `Status`

### DIFF
--- a/be/src/common/status.cpp
+++ b/be/src/common/status.cpp
@@ -4,12 +4,13 @@
 
 #include "common/status.h"
 
-#include "gutil/strings/fastmem.h" // for memcpy_inlined
+#include "gutil/strings/fastmem.h"    // for memcpy_inlined
+#include "gutil/strings/substitute.h" // for strings::Substitute
 
 namespace doris {
 
-inline const char* assemble_state(
-        TStatusCode::type code, const Slice& msg, int16_t precise_code, const Slice& msg2) {
+inline const char* assemble_state(TStatusCode::type code, const Slice& msg,
+                                  int16_t posix_code, const Slice& msg2) {
     DCHECK(code != TStatusCode::OK);
 
     const uint32_t len1 = msg.size;
@@ -18,7 +19,7 @@ inline const char* assemble_state(
     auto result = new char[size + 7];
     memcpy(result, &size, sizeof(size));
     result[4] = static_cast<char>(code);
-    memcpy(result + 5, &precise_code, sizeof(precise_code));
+    memcpy(result + 5, &posix_code, sizeof(posix_code));
     memcpy(result + 7, msg.data, len1);
     if (len2 > 0) {
         result[7 + len1] = ':';
@@ -28,7 +29,7 @@ inline const char* assemble_state(
     return result;
 }
 
-const char* Status::copy_state(const char* state) {
+const char* Status::_copy_state(const char* state) {
     uint32_t size;
     strings::memcpy_inlined(&size, state, sizeof(size));
     auto result = new char[size + 7];
@@ -39,9 +40,9 @@ const char* Status::copy_state(const char* state) {
 Status::Status(const TStatus& s) : _state(nullptr) {
     if (s.status_code != TStatusCode::OK) {
         if (s.error_msgs.empty()) {
-            _state = assemble_state(s.status_code, Slice(), 1, Slice());
+            _state = assemble_state(s.status_code, Slice(), -1, Slice());
         } else {
-            _state = assemble_state(s.status_code, s.error_msgs[0], 1, Slice());
+            _state = assemble_state(s.status_code, s.error_msgs[0], -1, Slice());
         }
     }
 }
@@ -50,18 +51,20 @@ Status::Status(const PStatus& s) : _state(nullptr) {
     TStatusCode::type code = (TStatusCode::type)s.status_code();
     if (code != TStatusCode::OK) {
         if (s.error_msgs_size() == 0) {
-            _state = assemble_state(code, Slice(), 1, Slice());
+            _state = assemble_state(code, Slice(), -1, Slice());
         } else {
-            _state = assemble_state(code, s.error_msgs(0), 1, Slice());
+            _state = assemble_state(code, s.error_msgs(0), -1, Slice());
         }
     }
 }
 
-Status::Status(TStatusCode::type code, const Slice& msg, int16_t precise_code, const Slice& msg2)
-        : _state(assemble_state(code, msg, precise_code, msg2)) {
+Status::Status(TStatusCode::type code, const Slice& msg,
+               int16_t posix_code, const Slice& msg2) :
+        _state(assemble_state(code, msg, posix_code, msg2)) {
 }
 
 void Status::to_thrift(TStatus* s) const {
+    DCHECK_NOTNULL(s);
     s->error_msgs.clear();
     if (_state == nullptr) {
         s->status_code = TStatusCode::OK;
@@ -74,6 +77,7 @@ void Status::to_thrift(TStatus* s) const {
 }
 
 void Status::to_protobuf(PStatus* s) const {
+    DCHECK_NOTNULL(s);
     s->clear_error_msgs();
     if (_state == nullptr) {
         s->set_status_code((int)TStatusCode::OK);
@@ -143,11 +147,8 @@ std::string Status::code_as_string() const {
         return "Configuration error";
     case TStatusCode::INCOMPLETE:
         return "Incomplete";
-    default: {
-        char tmp[30];
-        snprintf(tmp, sizeof(tmp), "Unknown code(%d): ", static_cast<int>(code()));
-        return tmp;
-    }
+    default:
+        return strings::Substitute("Unknown code($0)", code());
     }
     return std::string();
 }
@@ -161,7 +162,7 @@ std::string Status::to_string() const {
     result.append(": ");
     Slice msg = message();
     result.append(reinterpret_cast<const char*>(msg.data), msg.size);
-    int16_t posix = precise_code();
+    int16_t posix = posix_code();
     if (posix != 1) {
         char buf[64];
         snprintf(buf, sizeof(buf), " (error %d)", posix);
@@ -184,14 +185,14 @@ Status Status::clone_and_prepend(const Slice& msg) const {
     if (ok()) {
         return *this;
     }
-    return Status(code(), msg, precise_code(), message());
+    return Status(code(), msg, posix_code(), message());
 }
 
 Status Status::clone_and_append(const Slice& msg) const {
     if (ok()) {
         return *this;
     }
-    return Status(code(), message(), precise_code(), msg);
+    return Status(code(), message(), posix_code(), msg);
 }
 
 }

--- a/be/src/common/status.cpp
+++ b/be/src/common/status.cpp
@@ -163,7 +163,7 @@ std::string Status::to_string() const {
     Slice msg = message();
     result.append(reinterpret_cast<const char*>(msg.data), msg.size);
     int16_t posix = posix_code();
-    if (posix != 1) {
+    if (posix != -1) {
         char buf[64];
         snprintf(buf, sizeof(buf), " (error %d)", posix);
         result.append(buf);

--- a/be/src/common/status.cpp
+++ b/be/src/common/status.cpp
@@ -40,9 +40,9 @@ const char* Status::_copy_state(const char* state) {
 Status::Status(const TStatus& s) : _state(nullptr) {
     if (s.status_code != TStatusCode::OK) {
         if (s.error_msgs.empty()) {
-            _state = assemble_state(s.status_code, Slice(), -1, Slice());
+            _state = assemble_state(s.status_code, Slice(), 1, Slice());
         } else {
-            _state = assemble_state(s.status_code, s.error_msgs[0], -1, Slice());
+            _state = assemble_state(s.status_code, s.error_msgs[0], 1, Slice());
         }
     }
 }
@@ -51,9 +51,9 @@ Status::Status(const PStatus& s) : _state(nullptr) {
     TStatusCode::type code = (TStatusCode::type)s.status_code();
     if (code != TStatusCode::OK) {
         if (s.error_msgs_size() == 0) {
-            _state = assemble_state(code, Slice(), -1, Slice());
+            _state = assemble_state(code, Slice(), 1, Slice());
         } else {
-            _state = assemble_state(code, s.error_msgs(0), -1, Slice());
+            _state = assemble_state(code, s.error_msgs(0), 1, Slice());
         }
     }
 }
@@ -163,7 +163,7 @@ std::string Status::to_string() const {
     Slice msg = message();
     result.append(reinterpret_cast<const char*>(msg.data), msg.size);
     int16_t posix = precise_code();
-    if (posix != -1) {
+    if (posix != 1) {
         char buf[64];
         snprintf(buf, sizeof(buf), " (error %d)", posix);
         result.append(buf);

--- a/be/src/common/status.h
+++ b/be/src/common/status.h
@@ -17,13 +17,13 @@ namespace doris {
 
 class Status {
 public:
-    Status(): _state(nullptr) {}
+    Status() : _state(nullptr) { }
     ~Status() noexcept { delete[] _state; }
 
-    // copy c'tor makes copy of error detail so Status can be returned by value
-    Status(const Status& s)
-            : _state(s._state == nullptr ? nullptr : copy_state(s._state))  {
-    }
+    // Here _state == nullptr(Status::OK) is the most common case, so use this as
+    // a fast path. This check can avoid one function call in most cases, because
+    // _copy_state() is not an inline function.
+    Status(const Status& s) : _state(s._state == nullptr ? nullptr : _copy_state(s._state))  { }
 
     // same as copy c'tor
     Status& operator=(const Status& s) {
@@ -31,154 +31,162 @@ public:
         // and the common case where both s and *this are OK.
         if (_state != s._state) {
             delete[] _state;
-            _state = (s._state == nullptr) ? nullptr : copy_state(s._state);
+            _state = (s._state == nullptr) ? nullptr : _copy_state(s._state);
         }
         return *this;
     }
 
-    // move c'tor
     Status(Status&& s) noexcept : _state(s._state) {
         s._state = nullptr;
     }
 
-    // move assign
     Status& operator=(Status&& s) noexcept {
-        std::swap(_state, s._state);
+        if (_state != s._state) {
+            delete[] _state;
+            _state = s._state;
+            s._state = nullptr;
+        }
         return *this;
     }
 
-    // "Copy" c'tor from TStatus.
-    Status(const TStatus& status);
-
+    Status(const TStatus& t_status);
     Status(const PStatus& pstatus);
 
     static Status OK() { return Status(); }
-
-    static Status PublishTimeout(const Slice& msg, int16_t precise_code = 1, const Slice& msg2 = Slice()) {
-        return Status(TStatusCode::PUBLISH_TIMEOUT, msg, precise_code, msg2);
-    }
-    static Status MemoryAllocFailed(const Slice& msg, int16_t precise_code = 1, const Slice& msg2 = Slice()) {
-        return Status(TStatusCode::MEM_ALLOC_FAILED, msg, precise_code, msg2);
-    }
-    static Status BufferAllocFailed(const Slice& msg, int16_t precise_code = 1, const Slice& msg2 = Slice()) {
-        return Status(TStatusCode::BUFFER_ALLOCATION_FAILED, msg, precise_code, msg2);
-    }
-    static Status InvalidArgument(const Slice& msg, int16_t precise_code = 1, const Slice& msg2 = Slice()) {
-        return Status(TStatusCode::INVALID_ARGUMENT, msg, precise_code, msg2);
-    }
-    static Status MinimumReservationUnavailable(const Slice& msg, int16_t precise_code = 1, const Slice& msg2 = Slice()) {
-        return Status(TStatusCode::MINIMUM_RESERVATION_UNAVAILABLE, msg, precise_code, msg2);
-    }
-    static Status Corruption(const Slice& msg, int16_t precise_code = 1, const Slice& msg2 = Slice()) {
-        return Status(TStatusCode::CORRUPTION, msg, precise_code, msg2);
-    }
-    static Status IOError(const Slice& msg,
-                               int16_t precise_code = 1,
-                               const Slice& msg2 = Slice()) {
-        return Status(TStatusCode::IO_ERROR, msg, precise_code, msg2);
-    }
-    static Status NotFound(const Slice& msg,
-                               int16_t precise_code = 1,
-                               const Slice& msg2 = Slice()) {
-        return Status(TStatusCode::NOT_FOUND, msg, precise_code, msg2);
-    }
-    static Status AlreadyExist(const Slice& msg,
-                               int16_t precise_code = 1,
-                               const Slice& msg2 = Slice()) {
-        return Status(TStatusCode::ALREADY_EXIST, msg, precise_code, msg2);
+    static Status Cancelled(const Slice& msg,
+                            int16_t posix_code = -1,
+                            const Slice& msg2 = Slice()) {
+        return Status(TStatusCode::CANCELLED, msg, posix_code, msg2);
     }
     static Status NotSupported(const Slice& msg,
-                               int16_t precise_code = 1,
+                               int16_t posix_code = -1,
                                const Slice& msg2 = Slice()) {
-        return Status(TStatusCode::NOT_IMPLEMENTED_ERROR, msg, precise_code, msg2);
-    }
-    static Status EndOfFile(const Slice& msg,
-                            int16_t precise_code = 1,
-                            const Slice& msg2 = Slice()) {
-        return Status(TStatusCode::END_OF_FILE, msg, precise_code, msg2);
-    }
-    static Status InternalError(const Slice& msg,
-                               int16_t precise_code = 1,
-                               const Slice& msg2 = Slice()) {
-        return Status(TStatusCode::INTERNAL_ERROR, msg, precise_code, msg2);
+        return Status(TStatusCode::NOT_IMPLEMENTED_ERROR, msg, posix_code, msg2);
     }
     static Status RuntimeError(const Slice& msg,
-                               int16_t precise_code = 1,
+                               int16_t posix_code = -1,
                                const Slice& msg2 = Slice()) {
-        return Status(TStatusCode::RUNTIME_ERROR, msg, precise_code, msg2);
+        return Status(TStatusCode::RUNTIME_ERROR, msg, posix_code, msg2);
     }
-    static Status Cancelled(const Slice& msg, int16_t precise_code = 1, const Slice& msg2 = Slice()) {
-        return Status(TStatusCode::CANCELLED, msg, precise_code, msg2);
+    static Status MemoryLimitExceeded(const Slice& msg,
+                                      int16_t posix_code = -1,
+                                      const Slice& msg2 = Slice()) {
+        return Status(TStatusCode::MEM_LIMIT_EXCEEDED, msg, posix_code, msg2);
     }
-
-    static Status MemoryLimitExceeded(const Slice& msg, int16_t precise_code = 1, const Slice& msg2 = Slice()) {
-        return Status(TStatusCode::MEM_LIMIT_EXCEEDED, msg, precise_code, msg2);
+    static Status InternalError(const Slice& msg,
+                               int16_t posix_code = -1,
+                               const Slice& msg2 = Slice()) {
+        return Status(TStatusCode::INTERNAL_ERROR, msg, posix_code, msg2);
     }
-
-    static Status ThriftRpcError(const Slice& msg, int16_t precise_code = 1, const Slice& msg2 = Slice()) {
-        return Status(TStatusCode::THRIFT_RPC_ERROR, msg, precise_code, msg2);
+    static Status ThriftRpcError(const Slice& msg,
+                                 int16_t posix_code = -1,
+                                 const Slice& msg2 = Slice()) {
+        return Status(TStatusCode::THRIFT_RPC_ERROR, msg, posix_code, msg2);
     }
-
-    static Status TimedOut(const Slice& msg, int16_t precise_code = 1, const Slice& msg2 = Slice()) {
-        return Status(TStatusCode::TIMEOUT, msg, precise_code, msg2);
+    static Status TimedOut(const Slice& msg,
+                           int16_t posix_code = -1,
+                           const Slice& msg2 = Slice()) {
+        return Status(TStatusCode::TIMEOUT, msg, posix_code, msg2);
     }
-
-    static Status TooManyTasks(const Slice& msg, int16_t precise_code = 1, const Slice& msg2 = Slice()) {
-        return Status(TStatusCode::TOO_MANY_TASKS, msg, precise_code, msg2);
+    static Status MemoryAllocFailed(const Slice& msg,
+                                    int16_t posix_code = -1,
+                                    const Slice& msg2 = Slice()) {
+        return Status(TStatusCode::MEM_ALLOC_FAILED, msg, posix_code, msg2);
     }
-    static Status ServiceUnavailable(const Slice& msg,
-                                     int16_t precise_code = -1,
-                                     const Slice& msg2 = Slice()) {
-        return Status(TStatusCode::SERVICE_UNAVAILABLE, msg, precise_code, msg2);
+    static Status BufferAllocFailed(const Slice& msg,
+                                    int16_t posix_code = -1,
+                                    const Slice& msg2 = Slice()) {
+        return Status(TStatusCode::BUFFER_ALLOCATION_FAILED, msg, posix_code, msg2);
     }
-    static Status Uninitialized(const Slice& msg,
-                                int16_t precise_code = -1,
-                                const Slice& msg2 = Slice()) {
-        return Status(TStatusCode::UNINITIALIZED, msg, precise_code, msg2);
+    static Status MinimumReservationUnavailable(const Slice& msg,
+                                                int16_t posix_code = -1,
+                                                const Slice& msg2 = Slice()) {
+        return Status(TStatusCode::MINIMUM_RESERVATION_UNAVAILABLE, msg, posix_code, msg2);
+    }
+    static Status PublishTimeout(const Slice& msg,
+                                 int16_t posix_code = 1,
+                                 const Slice& msg2 = Slice()) {
+        return Status(TStatusCode::PUBLISH_TIMEOUT, msg, posix_code, msg2);
+    }
+    static Status TooManyTasks(const Slice& msg,
+                               int16_t posix_code = -1,
+                               const Slice& msg2 = Slice()) {
+        return Status(TStatusCode::TOO_MANY_TASKS, msg, posix_code, msg2);
+    }
+    static Status EndOfFile(const Slice& msg,
+                            int16_t posix_code = -1,
+                            const Slice& msg2 = Slice()) {
+        return Status(TStatusCode::END_OF_FILE, msg, posix_code, msg2);
+    }
+    static Status NotFound(const Slice& msg,
+                           int16_t posix_code = -1,
+                           const Slice& msg2 = Slice()) {
+        return Status(TStatusCode::NOT_FOUND, msg, posix_code, msg2);
+    }
+    static Status Corruption(const Slice& msg,
+                             int16_t posix_code = -1,
+                             const Slice& msg2 = Slice()) {
+        return Status(TStatusCode::CORRUPTION, msg, posix_code, msg2);
+    }
+    static Status InvalidArgument(const Slice& msg,
+                                  int16_t posix_code = -1,
+                                  const Slice& msg2 = Slice()) {
+        return Status(TStatusCode::INVALID_ARGUMENT, msg, posix_code, msg2);
+    }
+    static Status IOError(const Slice& msg,
+                          int16_t posix_code = -1,
+                          const Slice& msg2 = Slice()) {
+        return Status(TStatusCode::IO_ERROR, msg, posix_code, msg2);
+    }
+    static Status AlreadyExist(const Slice& msg,
+                               int16_t posix_code = -1,
+                               const Slice& msg2 = Slice()) {
+        return Status(TStatusCode::ALREADY_EXIST, msg, posix_code, msg2);
     }
     static Status Aborted(const Slice& msg,
-                          int16_t precise_code = -1,
+                          int16_t posix_code = -1,
                           const Slice& msg2 = Slice()) {
-        return Status(TStatusCode::ABORTED, msg, precise_code, msg2);
+        return Status(TStatusCode::ABORTED, msg, posix_code, msg2);
+    }
+    static Status ServiceUnavailable(const Slice& msg,
+                                     int16_t posix_code = -1,
+                                     const Slice& msg2 = Slice()) {
+        return Status(TStatusCode::SERVICE_UNAVAILABLE, msg, posix_code, msg2);
+    }
+    static Status Uninitialized(const Slice& msg,
+                                int16_t posix_code = -1,
+                                const Slice& msg2 = Slice()) {
+        return Status(TStatusCode::UNINITIALIZED, msg, posix_code, msg2);
     }
 
     bool ok() const { return _state == nullptr; }
-
     bool is_cancelled() const { return code() == TStatusCode::CANCELLED; }
     bool is_mem_limit_exceeded() const { return code() == TStatusCode::MEM_LIMIT_EXCEEDED; }
     bool is_thrift_rpc_error() const { return code() == TStatusCode::THRIFT_RPC_ERROR; }
     bool is_end_of_file() const { return code() == TStatusCode::END_OF_FILE; }
     bool is_not_found() const { return code() == TStatusCode::NOT_FOUND; }
-    bool is_already_exist() const { return code() == TStatusCode::ALREADY_EXIST; }
-    bool is_io_error() const {return code() == TStatusCode::IO_ERROR; }
-
-    /// @return @c true iff the status indicates Uninitialized.
-    bool is_uninitialized() const { return code() == TStatusCode::UNINITIALIZED; }
-
-    // @return @c true iff the status indicates an Aborted error.
-    bool is_aborted() const { return code() == TStatusCode::ABORTED; }
-
-    /// @return @c true iff the status indicates an InvalidArgument error.
     bool is_invalid_argument() const { return code() == TStatusCode::INVALID_ARGUMENT; }
-
-    // @return @c true iff the status indicates ServiceUnavailable.
+    bool is_io_error() const {return code() == TStatusCode::IO_ERROR; }
+    bool is_already_exist() const { return code() == TStatusCode::ALREADY_EXIST; }
+    bool is_aborted() const { return code() == TStatusCode::ABORTED; }
     bool is_service_unavailable() const { return code() == TStatusCode::SERVICE_UNAVAILABLE; }
+    bool is_uninitialized() const { return code() == TStatusCode::UNINITIALIZED; }
 
     // Convert into TStatus. Call this if 'status_container' contains an optional
     // TStatus field named 'status'. This also sets __isset.status.
+    // NOTE: If the 'status' is required in Thrift Struct, this method can not
+    // be used(use `to_thrift()` instead).
     template <typename T>
     void set_t_status(T* status_container) const {
         to_thrift(&status_container->status);
         status_container->__isset.status = true;
     }
 
-    // Convert into TStatus.
     void to_thrift(TStatus* status) const;
     void to_protobuf(PStatus* status) const;
 
     std::string get_error_msg() const {
-        auto msg = message();
-        return std::string(msg.data, msg.size);
+        return message().to_string();
     }
 
     /// @return A string representation of this status suitable for printing.
@@ -203,13 +211,13 @@ public:
         return _state == nullptr ? TStatusCode::OK : static_cast<TStatusCode::type>(_state[4]);
     }
 
-    int16_t precise_code() const {
+    int16_t posix_code() const {
         if (_state == nullptr) {
             return 0;
         }
-        int16_t precise_code;
-        memcpy(&precise_code, _state + 5, sizeof(precise_code));
-        return precise_code;
+        int16_t posix_code;
+        memcpy(&posix_code, _state + 5, sizeof(posix_code));
+        return posix_code;
     }
 
     /// Clone this status and add the specified prefix to the message.
@@ -233,64 +241,57 @@ public:
     Status clone_and_append(const Slice& msg) const;
 
 private:
-    const char* copy_state(const char* state);
+    const char* _copy_state(const char* state);
 
-    Status(TStatusCode::type code, const Slice& msg, int16_t precise_code, const Slice& msg2);
+    Status(TStatusCode::type code, const Slice& msg, int16_t posix_code, const Slice& msg2);
 
 private:
     // OK status has a nullptr _state.  Otherwise, _state is a new[] array
     // of the following form:
     //    _state[0..3] == length of message
     //    _state[4]    == code
-    //    _state[5..6] == precise_code
+    //    _state[5..6] == posix_code
     //    _state[7..]  == message
     const char* _state;
 };
 
 // some generally useful macros
-#define RETURN_IF_ERROR(stmt) \
-    do { \
+#define RETURN_IF_ERROR(stmt)            \
+    do {                                 \
         const Status& _status_ = (stmt); \
-        if (UNLIKELY(!_status_.ok())) { \
-            return _status_; \
-        } \
+        if (UNLIKELY(!_status_.ok())) {  \
+            return _status_;             \
+        }                                \
     } while (false)
 
-#define RETURN_IF_STATUS_ERROR(status, stmt) \
-    do { \
-        status = (stmt); \
-        if (UNLIKELY(!status.ok())) { \
-            return; \
-        } \
-    } while (false)
-
-#define EXIT_IF_ERROR(stmt) \
-    do { \
-        const Status& _status_ = (stmt); \
-        if (UNLIKELY(!_status_.ok())) { \
-            string msg = _status_.get_error_msg(); \
-            LOG(ERROR) << msg;            \
-            exit(1); \
-        } \
+#define EXIT_IF_ERROR(stmt)                         \
+    do {                                            \
+        const Status& _status_ = (stmt);            \
+        if (UNLIKELY(!_status_.ok())) {             \
+            string msg = _status_.to_string();      \
+            LOG(ERROR) << msg;                      \
+            exit(1);                                \
+        }                                           \
     } while (false)
 
 /// @brief Emit a warning if @c to_call returns a bad status.
-#define WARN_IF_ERROR(to_call, warning_prefix) \
-    do { \
-        const Status& _s = (to_call);  \
-        if (UNLIKELY(!_s.ok())) { \
-            LOG(WARNING) << (warning_prefix) << ": " << _s.to_string();  \
-        } \
-    } while (0);
+#define WARN_IF_ERROR(to_call, warning_prefix)                          \
+    do {                                                                \
+        const Status& _s = (to_call);                                   \
+        if (UNLIKELY(!_s.ok())) {                                       \
+            LOG(WARNING) << (warning_prefix) << ": " << _s.to_string(); \
+        }                                                               \
+    } while (false);
 
-#define RETURN_WITH_WARN_IF_ERROR(stmt, ret_code, warning_prefix) \
-    do {    \
-        const Status& _s = (stmt);  \
-        if (UNLIKELY(!_s.ok())) {   \
+#define RETURN_WITH_WARN_IF_ERROR(stmt, ret_code, warning_prefix)              \
+    do {                                                                       \
+        const Status& _s = (stmt);                                             \
+        if (UNLIKELY(!_s.ok())) {                                              \
             LOG(WARNING) << (warning_prefix) << ", error: " << _s.to_string(); \
-            return ret_code;    \
-        }   \
-    } while (0);
-}
+            return ret_code;                                                   \
+        }                                                                      \
+    } while (false);
+
+} // end namespace doris
 
 #define WARN_UNUSED_RESULT __attribute__((warn_unused_result))

--- a/be/src/common/status.h
+++ b/be/src/common/status.h
@@ -54,52 +54,52 @@ public:
 
     static Status OK() { return Status(); }
     static Status Cancelled(const Slice& msg,
-                            int16_t precise_code = -1,
+                            int16_t precise_code = 1,
                             const Slice& msg2 = Slice()) {
         return Status(TStatusCode::CANCELLED, msg, precise_code, msg2);
     }
     static Status NotSupported(const Slice& msg,
-                               int16_t precise_code = -1,
+                               int16_t precise_code = 1,
                                const Slice& msg2 = Slice()) {
         return Status(TStatusCode::NOT_IMPLEMENTED_ERROR, msg, precise_code, msg2);
     }
     static Status RuntimeError(const Slice& msg,
-                               int16_t precise_code = -1,
+                               int16_t precise_code = 1,
                                const Slice& msg2 = Slice()) {
         return Status(TStatusCode::RUNTIME_ERROR, msg, precise_code, msg2);
     }
     static Status MemoryLimitExceeded(const Slice& msg,
-                                      int16_t precise_code = -1,
+                                      int16_t precise_code = 1,
                                       const Slice& msg2 = Slice()) {
         return Status(TStatusCode::MEM_LIMIT_EXCEEDED, msg, precise_code, msg2);
     }
     static Status InternalError(const Slice& msg,
-                               int16_t precise_code = -1,
+                               int16_t precise_code = 1,
                                const Slice& msg2 = Slice()) {
         return Status(TStatusCode::INTERNAL_ERROR, msg, precise_code, msg2);
     }
     static Status ThriftRpcError(const Slice& msg,
-                                 int16_t precise_code = -1,
+                                 int16_t precise_code = 1,
                                  const Slice& msg2 = Slice()) {
         return Status(TStatusCode::THRIFT_RPC_ERROR, msg, precise_code, msg2);
     }
     static Status TimedOut(const Slice& msg,
-                           int16_t precise_code = -1,
+                           int16_t precise_code = 1,
                            const Slice& msg2 = Slice()) {
         return Status(TStatusCode::TIMEOUT, msg, precise_code, msg2);
     }
     static Status MemoryAllocFailed(const Slice& msg,
-                                    int16_t precise_code = -1,
+                                    int16_t precise_code = 1,
                                     const Slice& msg2 = Slice()) {
         return Status(TStatusCode::MEM_ALLOC_FAILED, msg, precise_code, msg2);
     }
     static Status BufferAllocFailed(const Slice& msg,
-                                    int16_t precise_code = -1,
+                                    int16_t precise_code = 1,
                                     const Slice& msg2 = Slice()) {
         return Status(TStatusCode::BUFFER_ALLOCATION_FAILED, msg, precise_code, msg2);
     }
     static Status MinimumReservationUnavailable(const Slice& msg,
-                                                int16_t precise_code = -1,
+                                                int16_t precise_code = 1,
                                                 const Slice& msg2 = Slice()) {
         return Status(TStatusCode::MINIMUM_RESERVATION_UNAVAILABLE, msg, precise_code, msg2);
     }
@@ -109,52 +109,52 @@ public:
         return Status(TStatusCode::PUBLISH_TIMEOUT, msg, precise_code, msg2);
     }
     static Status TooManyTasks(const Slice& msg,
-                               int16_t precise_code = -1,
+                               int16_t precise_code = 1,
                                const Slice& msg2 = Slice()) {
         return Status(TStatusCode::TOO_MANY_TASKS, msg, precise_code, msg2);
     }
     static Status EndOfFile(const Slice& msg,
-                            int16_t precise_code = -1,
+                            int16_t precise_code = 1,
                             const Slice& msg2 = Slice()) {
         return Status(TStatusCode::END_OF_FILE, msg, precise_code, msg2);
     }
     static Status NotFound(const Slice& msg,
-                           int16_t precise_code = -1,
+                           int16_t precise_code = 1,
                            const Slice& msg2 = Slice()) {
         return Status(TStatusCode::NOT_FOUND, msg, precise_code, msg2);
     }
     static Status Corruption(const Slice& msg,
-                             int16_t precise_code = -1,
+                             int16_t precise_code = 1,
                              const Slice& msg2 = Slice()) {
         return Status(TStatusCode::CORRUPTION, msg, precise_code, msg2);
     }
     static Status InvalidArgument(const Slice& msg,
-                                  int16_t precise_code = -1,
+                                  int16_t precise_code = 1,
                                   const Slice& msg2 = Slice()) {
         return Status(TStatusCode::INVALID_ARGUMENT, msg, precise_code, msg2);
     }
     static Status IOError(const Slice& msg,
-                          int16_t precise_code = -1,
+                          int16_t precise_code = 1,
                           const Slice& msg2 = Slice()) {
         return Status(TStatusCode::IO_ERROR, msg, precise_code, msg2);
     }
     static Status AlreadyExist(const Slice& msg,
-                               int16_t precise_code = -1,
+                               int16_t precise_code = 1,
                                const Slice& msg2 = Slice()) {
         return Status(TStatusCode::ALREADY_EXIST, msg, precise_code, msg2);
     }
     static Status Aborted(const Slice& msg,
-                          int16_t precise_code = -1,
+                          int16_t precise_code = 1,
                           const Slice& msg2 = Slice()) {
         return Status(TStatusCode::ABORTED, msg, precise_code, msg2);
     }
     static Status ServiceUnavailable(const Slice& msg,
-                                     int16_t precise_code = -1,
+                                     int16_t precise_code = 1,
                                      const Slice& msg2 = Slice()) {
         return Status(TStatusCode::SERVICE_UNAVAILABLE, msg, precise_code, msg2);
     }
     static Status Uninitialized(const Slice& msg,
-                                int16_t precise_code = -1,
+                                int16_t precise_code = 1,
                                 const Slice& msg2 = Slice()) {
         return Status(TStatusCode::UNINITIALIZED, msg, precise_code, msg2);
     }
@@ -256,40 +256,40 @@ private:
 };
 
 // some generally useful macros
-#define RETURN_IF_ERROR(stmt)            \
-    do {                                 \
+#define RETURN_IF_ERROR(stmt) \
+    do { \
         const Status& _status_ = (stmt); \
-        if (UNLIKELY(!_status_.ok())) {  \
-            return _status_;             \
-        }                                \
+        if (UNLIKELY(!_status_.ok())) { \
+            return _status_; \
+        } \
     } while (false)
 
-#define EXIT_IF_ERROR(stmt)                         \
-    do {                                            \
-        const Status& _status_ = (stmt);            \
-        if (UNLIKELY(!_status_.ok())) {             \
-            string msg = _status_.to_string();      \
-            LOG(ERROR) << msg;                      \
-            exit(1);                                \
-        }                                           \
+#define EXIT_IF_ERROR(stmt) \
+    do { \
+        const Status& _status_ = (stmt); \
+        if (UNLIKELY(!_status_.ok())) { \
+            string msg = _status_.to_string(); \
+            LOG(ERROR) << msg; \
+            exit(1); \
+        } \
     } while (false)
 
 /// @brief Emit a warning if @c to_call returns a bad status.
-#define WARN_IF_ERROR(to_call, warning_prefix)                          \
-    do {                                                                \
-        const Status& _s = (to_call);                                   \
-        if (UNLIKELY(!_s.ok())) {                                       \
+#define WARN_IF_ERROR(to_call, warning_prefix) \
+    do { \
+        const Status& _s = (to_call); \
+        if (UNLIKELY(!_s.ok())) { \
             LOG(WARNING) << (warning_prefix) << ": " << _s.to_string(); \
-        }                                                               \
+        } \
     } while (false);
 
-#define RETURN_WITH_WARN_IF_ERROR(stmt, ret_code, warning_prefix)              \
-    do {                                                                       \
-        const Status& _s = (stmt);                                             \
-        if (UNLIKELY(!_s.ok())) {                                              \
+#define RETURN_WITH_WARN_IF_ERROR(stmt, ret_code, warning_prefix) \
+    do { \
+        const Status& _s = (stmt); \
+        if (UNLIKELY(!_s.ok())) { \
             LOG(WARNING) << (warning_prefix) << ", error: " << _s.to_string(); \
-            return ret_code;                                                   \
-        }                                                                      \
+            return ret_code; \
+        } \
     } while (false);
 
 } // end namespace doris

--- a/be/src/common/status.h
+++ b/be/src/common/status.h
@@ -54,109 +54,109 @@ public:
 
     static Status OK() { return Status(); }
     static Status Cancelled(const Slice& msg,
-                            int16_t posix_code = -1,
+                            int16_t precise_code = -1,
                             const Slice& msg2 = Slice()) {
-        return Status(TStatusCode::CANCELLED, msg, posix_code, msg2);
+        return Status(TStatusCode::CANCELLED, msg, precise_code, msg2);
     }
     static Status NotSupported(const Slice& msg,
-                               int16_t posix_code = -1,
+                               int16_t precise_code = -1,
                                const Slice& msg2 = Slice()) {
-        return Status(TStatusCode::NOT_IMPLEMENTED_ERROR, msg, posix_code, msg2);
+        return Status(TStatusCode::NOT_IMPLEMENTED_ERROR, msg, precise_code, msg2);
     }
     static Status RuntimeError(const Slice& msg,
-                               int16_t posix_code = -1,
+                               int16_t precise_code = -1,
                                const Slice& msg2 = Slice()) {
-        return Status(TStatusCode::RUNTIME_ERROR, msg, posix_code, msg2);
+        return Status(TStatusCode::RUNTIME_ERROR, msg, precise_code, msg2);
     }
     static Status MemoryLimitExceeded(const Slice& msg,
-                                      int16_t posix_code = -1,
+                                      int16_t precise_code = -1,
                                       const Slice& msg2 = Slice()) {
-        return Status(TStatusCode::MEM_LIMIT_EXCEEDED, msg, posix_code, msg2);
+        return Status(TStatusCode::MEM_LIMIT_EXCEEDED, msg, precise_code, msg2);
     }
     static Status InternalError(const Slice& msg,
-                               int16_t posix_code = -1,
+                               int16_t precise_code = -1,
                                const Slice& msg2 = Slice()) {
-        return Status(TStatusCode::INTERNAL_ERROR, msg, posix_code, msg2);
+        return Status(TStatusCode::INTERNAL_ERROR, msg, precise_code, msg2);
     }
     static Status ThriftRpcError(const Slice& msg,
-                                 int16_t posix_code = -1,
+                                 int16_t precise_code = -1,
                                  const Slice& msg2 = Slice()) {
-        return Status(TStatusCode::THRIFT_RPC_ERROR, msg, posix_code, msg2);
+        return Status(TStatusCode::THRIFT_RPC_ERROR, msg, precise_code, msg2);
     }
     static Status TimedOut(const Slice& msg,
-                           int16_t posix_code = -1,
+                           int16_t precise_code = -1,
                            const Slice& msg2 = Slice()) {
-        return Status(TStatusCode::TIMEOUT, msg, posix_code, msg2);
+        return Status(TStatusCode::TIMEOUT, msg, precise_code, msg2);
     }
     static Status MemoryAllocFailed(const Slice& msg,
-                                    int16_t posix_code = -1,
+                                    int16_t precise_code = -1,
                                     const Slice& msg2 = Slice()) {
-        return Status(TStatusCode::MEM_ALLOC_FAILED, msg, posix_code, msg2);
+        return Status(TStatusCode::MEM_ALLOC_FAILED, msg, precise_code, msg2);
     }
     static Status BufferAllocFailed(const Slice& msg,
-                                    int16_t posix_code = -1,
+                                    int16_t precise_code = -1,
                                     const Slice& msg2 = Slice()) {
-        return Status(TStatusCode::BUFFER_ALLOCATION_FAILED, msg, posix_code, msg2);
+        return Status(TStatusCode::BUFFER_ALLOCATION_FAILED, msg, precise_code, msg2);
     }
     static Status MinimumReservationUnavailable(const Slice& msg,
-                                                int16_t posix_code = -1,
+                                                int16_t precise_code = -1,
                                                 const Slice& msg2 = Slice()) {
-        return Status(TStatusCode::MINIMUM_RESERVATION_UNAVAILABLE, msg, posix_code, msg2);
+        return Status(TStatusCode::MINIMUM_RESERVATION_UNAVAILABLE, msg, precise_code, msg2);
     }
     static Status PublishTimeout(const Slice& msg,
-                                 int16_t posix_code = 1,
+                                 int16_t precise_code = 1,
                                  const Slice& msg2 = Slice()) {
-        return Status(TStatusCode::PUBLISH_TIMEOUT, msg, posix_code, msg2);
+        return Status(TStatusCode::PUBLISH_TIMEOUT, msg, precise_code, msg2);
     }
     static Status TooManyTasks(const Slice& msg,
-                               int16_t posix_code = -1,
+                               int16_t precise_code = -1,
                                const Slice& msg2 = Slice()) {
-        return Status(TStatusCode::TOO_MANY_TASKS, msg, posix_code, msg2);
+        return Status(TStatusCode::TOO_MANY_TASKS, msg, precise_code, msg2);
     }
     static Status EndOfFile(const Slice& msg,
-                            int16_t posix_code = -1,
+                            int16_t precise_code = -1,
                             const Slice& msg2 = Slice()) {
-        return Status(TStatusCode::END_OF_FILE, msg, posix_code, msg2);
+        return Status(TStatusCode::END_OF_FILE, msg, precise_code, msg2);
     }
     static Status NotFound(const Slice& msg,
-                           int16_t posix_code = -1,
+                           int16_t precise_code = -1,
                            const Slice& msg2 = Slice()) {
-        return Status(TStatusCode::NOT_FOUND, msg, posix_code, msg2);
+        return Status(TStatusCode::NOT_FOUND, msg, precise_code, msg2);
     }
     static Status Corruption(const Slice& msg,
-                             int16_t posix_code = -1,
+                             int16_t precise_code = -1,
                              const Slice& msg2 = Slice()) {
-        return Status(TStatusCode::CORRUPTION, msg, posix_code, msg2);
+        return Status(TStatusCode::CORRUPTION, msg, precise_code, msg2);
     }
     static Status InvalidArgument(const Slice& msg,
-                                  int16_t posix_code = -1,
+                                  int16_t precise_code = -1,
                                   const Slice& msg2 = Slice()) {
-        return Status(TStatusCode::INVALID_ARGUMENT, msg, posix_code, msg2);
+        return Status(TStatusCode::INVALID_ARGUMENT, msg, precise_code, msg2);
     }
     static Status IOError(const Slice& msg,
-                          int16_t posix_code = -1,
+                          int16_t precise_code = -1,
                           const Slice& msg2 = Slice()) {
-        return Status(TStatusCode::IO_ERROR, msg, posix_code, msg2);
+        return Status(TStatusCode::IO_ERROR, msg, precise_code, msg2);
     }
     static Status AlreadyExist(const Slice& msg,
-                               int16_t posix_code = -1,
+                               int16_t precise_code = -1,
                                const Slice& msg2 = Slice()) {
-        return Status(TStatusCode::ALREADY_EXIST, msg, posix_code, msg2);
+        return Status(TStatusCode::ALREADY_EXIST, msg, precise_code, msg2);
     }
     static Status Aborted(const Slice& msg,
-                          int16_t posix_code = -1,
+                          int16_t precise_code = -1,
                           const Slice& msg2 = Slice()) {
-        return Status(TStatusCode::ABORTED, msg, posix_code, msg2);
+        return Status(TStatusCode::ABORTED, msg, precise_code, msg2);
     }
     static Status ServiceUnavailable(const Slice& msg,
-                                     int16_t posix_code = -1,
+                                     int16_t precise_code = -1,
                                      const Slice& msg2 = Slice()) {
-        return Status(TStatusCode::SERVICE_UNAVAILABLE, msg, posix_code, msg2);
+        return Status(TStatusCode::SERVICE_UNAVAILABLE, msg, precise_code, msg2);
     }
     static Status Uninitialized(const Slice& msg,
-                                int16_t posix_code = -1,
+                                int16_t precise_code = -1,
                                 const Slice& msg2 = Slice()) {
-        return Status(TStatusCode::UNINITIALIZED, msg, posix_code, msg2);
+        return Status(TStatusCode::UNINITIALIZED, msg, precise_code, msg2);
     }
 
     bool ok() const { return _state == nullptr; }
@@ -211,13 +211,13 @@ public:
         return _state == nullptr ? TStatusCode::OK : static_cast<TStatusCode::type>(_state[4]);
     }
 
-    int16_t posix_code() const {
+    int16_t precise_code() const {
         if (_state == nullptr) {
             return 0;
         }
-        int16_t posix_code;
-        memcpy(&posix_code, _state + 5, sizeof(posix_code));
-        return posix_code;
+        int16_t precise_code;
+        memcpy(&precise_code, _state + 5, sizeof(precise_code));
+        return precise_code;
     }
 
     /// Clone this status and add the specified prefix to the message.
@@ -243,14 +243,14 @@ public:
 private:
     const char* _copy_state(const char* state);
 
-    Status(TStatusCode::type code, const Slice& msg, int16_t posix_code, const Slice& msg2);
+    Status(TStatusCode::type code, const Slice& msg, int16_t precise_code, const Slice& msg2);
 
 private:
     // OK status has a nullptr _state.  Otherwise, _state is a new[] array
     // of the following form:
     //    _state[0..3] == length of message
     //    _state[4]    == code
-    //    _state[5..6] == posix_code
+    //    _state[5..6] == precise_code
     //    _state[7..]  == message
     const char* _state;
 };


### PR DESCRIPTION
For `dst = std::move(src)`, we should clear the `_state` of `dst` object.

And like move-constructor, i.e., `Status(Status&&)`, we need to clear 
the state of `src`, which means, the `src` should be `Status::OK`
after the move-assigment.

But in the current implementation, after move-assignment, `dst` will 
get the `_state` of `src`(because it use an `std::swap()` simply).
 
This patch also has two other changes:
1. Removed unused macros: `RETURN_IF_STATUS_ERROR`
2. Adjusted the order of function declarations, using the same
   order as the type of `TStatusCode`, which is more clear.