### PR TITLE
fix small typo of metadata maintenance docs

### DIFF
--- a/docs/documentation/cn/administrator-guide/operation/metadata-operation.md
+++ b/docs/documentation/cn/administrator-guide/operation/metadata-operation.md
@@ -258,7 +258,7 @@ FE 目前有以下几个端口
 1. 集群停止所有 Load,Create,Alter 操作
 2. 执行以下命令，从 Master FE 内存中 dump 出元数据：(下面称为 image_mem)
 ```
-curl -u $root_user:$password http://$master_hostname:8410/dump
+curl -u $root_user:$password http://$master_hostname:8030/dump
 ```
 3. 用 image_mem 文件替换掉 OBSERVER FE 节点上`meta_dir/image`目录下的 image 文件，重启 OBSERVER FE 节点，
 验证 image_mem 文件的完整性和正确性（可以在 FE Web 页面查看 DB 和 Table 的元数据是否正常，查看fe.log 是否有异常，是否在正常 replayed journal）

--- a/docs/documentation/en/administrator-guide/operation/metadata-operation_EN.md
+++ b/docs/documentation/en/administrator-guide/operation/metadata-operation_EN.md
@@ -258,7 +258,7 @@ In some extreme cases, the image file on the disk may be damaged, but the metada
 
 2. Execute the following command to dump metadata from the Master FE memory: (hereafter called image_mem)
 ```
-curl -u $root_user:$password http://$master_hostname:8410/dump
+curl -u $root_user:$password http://$master_hostname:8030/dump
 ```
 3. Replace the image file in the `meta_dir/image` directory on the OBSERVER FE node with the image_mem file, restart the OBSERVER FE node, and verify the integrity and correctness of the image_mem file. You can check whether the DB and Table metadata are normal on the FE Web page, whether there is an exception in `fe.log`, whether it is in a normal replayed jour.
 


### PR DESCRIPTION
The default port of fe http server is 8030.
The instance of [recover metadata from FE memory] using the port 8410 in the curl.
It will misleading users.
