### PR TITLE
Remove unused LLVM related codes of directory:be/src/runtime (#2910)

### DIFF
--- a/be/src/exec/aggregation_node.cpp
+++ b/be/src/exec/aggregation_node.cpp
@@ -23,7 +23,6 @@
 #include <thrift/protocol/TDebugProtocol.h>
 #include <gperftools/profiler.h>
 
-#include "codegen/codegen_anyval.h"
 #include "exec/hash_table.hpp"
 #include "exprs/agg_fn_evaluator.h"
 #include "exprs/expr.h"

--- a/be/src/exec/exec_node.cpp
+++ b/be/src/exec/exec_node.cpp
@@ -21,7 +21,6 @@
 #include <thrift/protocol/TDebugProtocol.h>
 #include <unistd.h>
 
-#include "codegen/codegen_anyval.h"
 #include "common/object_pool.h"
 #include "common/status.h"
 #include "exprs/expr_context.h"

--- a/be/src/exec/hash_table.cpp
+++ b/be/src/exec/hash_table.cpp
@@ -17,8 +17,6 @@
 
 #include "exec/hash_table.hpp"
 
-#include "codegen/codegen_anyval.h"
-
 #include "exprs/expr.h"
 #include "runtime/raw_value.h"
 #include "runtime/string_value.hpp"

--- a/be/src/exec/new_partitioned_aggregation_node.cc
+++ b/be/src/exec/new_partitioned_aggregation_node.cc
@@ -22,7 +22,6 @@
 #include <set>
 #include <sstream>
 
-//#include "codegen/codegen_anyval.h"
 #include "exec/new_partitioned_hash_table.h"
 #include "exec/new_partitioned_hash_table.inline.h"
 #include "exprs/new_agg_fn_evaluator.h"

--- a/be/src/exprs/arithmetic_expr.cpp
+++ b/be/src/exprs/arithmetic_expr.cpp
@@ -17,7 +17,6 @@
 
 #include "exprs/arithmetic_expr.h"
 
-#include "codegen/codegen_anyval.h"
 #include "runtime/runtime_state.h"
 
 namespace doris {

--- a/be/src/exprs/binary_predicate.cpp
+++ b/be/src/exprs/binary_predicate.cpp
@@ -19,7 +19,6 @@
 
 #include <sstream>
 
-#include "codegen/codegen_anyval.h"
 #include "util/debug_util.h"
 #include "gen_cpp/Exprs_types.h"
 #include "runtime/runtime_state.h"

--- a/be/src/exprs/case_expr.cpp
+++ b/be/src/exprs/case_expr.cpp
@@ -17,7 +17,6 @@
 
 #include "exprs/case_expr.h"
 
-#include "codegen/codegen_anyval.h"
 #include "exprs/anyval_util.h"
 #include "runtime/runtime_state.h"
 #include "gen_cpp/Exprs_types.h"

--- a/be/src/exprs/cast_expr.cpp
+++ b/be/src/exprs/cast_expr.cpp
@@ -17,7 +17,6 @@
 
 #include "exprs/cast_expr.h"
 
-#include "codegen/codegen_anyval.h"
 #include "runtime/runtime_state.h"
 
 namespace doris {

--- a/be/src/exprs/compound_predicate.cpp
+++ b/be/src/exprs/compound_predicate.cpp
@@ -19,7 +19,6 @@
 
 #include <sstream>
 
-#include "codegen/codegen_anyval.h"
 #include "util/debug_util.h"
 #include "runtime/runtime_state.h"
 

--- a/be/src/exprs/expr.cpp
+++ b/be/src/exprs/expr.cpp
@@ -21,7 +21,6 @@
 #include <vector>
 #include <thrift/protocol/TDebugProtocol.h>
 
-#include "codegen/codegen_anyval.h"
 #include "common/object_pool.h"
 #include "common/status.h"
 #include "exprs/anyval_util.h"

--- a/be/src/exprs/literal.cpp
+++ b/be/src/exprs/literal.cpp
@@ -19,7 +19,6 @@
 
 #include <string>
 
-#include "codegen/codegen_anyval.h"
 #include "gen_cpp/Exprs_types.h"
 #include "util/string_parser.hpp"
 #include "runtime/runtime_state.h"

--- a/be/src/exprs/null_literal.cpp
+++ b/be/src/exprs/null_literal.cpp
@@ -17,7 +17,6 @@
 
 #include "null_literal.h"
 
-#include "codegen/codegen_anyval.h"
 #include "gen_cpp/Exprs_types.h"
 #include "runtime/runtime_state.h"
 

--- a/be/src/exprs/slot_ref.cpp
+++ b/be/src/exprs/slot_ref.cpp
@@ -19,7 +19,6 @@
 
 #include <sstream>
 
-#include "codegen/codegen_anyval.h"
 #include "gen_cpp/Exprs_types.h"
 #include "runtime/runtime_state.h"
 #include "util/types.h"

--- a/be/src/runtime/decimalv2_value.cpp
+++ b/be/src/runtime/decimalv2_value.cpp
@@ -24,8 +24,6 @@
 
 namespace doris {
 
-const char* DecimalV2Value::_s_llvm_class_name = "class.doris::DecimalV2Value";
-
 static inline int128_t abs(const int128_t& x) { return (x < 0) ? -x : x; }
 
 // x>=0 && y>=0

--- a/be/src/runtime/decimalv2_value.h
+++ b/be/src/runtime/decimalv2_value.h
@@ -319,9 +319,6 @@ public:
         return _value == 0;
     }
 
-    // For C++/IR interop, we need to be able to look up types by name.
-    static const char* _s_llvm_class_name;
-
 private:
 
     int128_t _value;

--- a/be/src/runtime/mem_pool.cpp
+++ b/be/src/runtime/mem_pool.cpp
@@ -34,7 +34,6 @@ namespace doris {
 const int MemPool::INITIAL_CHUNK_SIZE;
 const int MemPool::MAX_CHUNK_SIZE;
 
-const char* MemPool::LLVM_CLASS_NAME = "class.doris::MemPool";
 const int MemPool::DEFAULT_ALIGNMENT;
 uint32_t MemPool::k_zero_length_region_ alignas(std::max_align_t) = MEM_POOL_POISON;
 

--- a/be/src/runtime/mem_pool.h
+++ b/be/src/runtime/mem_pool.h
@@ -159,10 +159,6 @@ public:
 
     MemTracker* mem_tracker() { return mem_tracker_; }
 
-    /// TODO: make a macro for doing this
-    /// For C++/IR interop, we need to be able to look up types by name.
-    static const char* LLVM_CLASS_NAME;
-
     static const int DEFAULT_ALIGNMENT = 8;
 
 private:

--- a/be/src/runtime/plan_fragment_executor.h
+++ b/be/src/runtime/plan_fragment_executor.h
@@ -241,14 +241,6 @@ private:
     // sends a final report.
     void update_status(const Status& status);
 
-    /// Optimizes the code-generated functions in runtime_state_->llvm_codegen().
-    /// Must be called between plan_->Prepare() and plan_->Open().
-    /// This is somewhat time consuming so we don't want it to do it in
-    /// PlanFragmentExecutor()::Prepare() to allow starting plan fragments more
-    /// quickly and in parallel (in a deep plan tree, the fragments are started
-    /// in level order).
-    void optimize_llvm_module();
-
     // Executes open() logic and returns resulting status. Does not set _status.
     // If this plan fragment has no sink, open_internal() does nothing.
     // If this plan fragment has a sink and open_internal() returns without an

--- a/be/src/runtime/runtime_state.cpp
+++ b/be/src/runtime/runtime_state.cpp
@@ -22,7 +22,6 @@
 #include "common/logging.h"
 #include <boost/algorithm/string/join.hpp>
 
-#include "codegen/llvm_codegen.h"
 #include "common/object_pool.h"
 #include "common/status.h"
 #include "exec/exec_node.h"
@@ -196,12 +195,6 @@ Status RuntimeState::init(
     }
     _exec_env = exec_env;
 
-    if (!query_options.disable_codegen) {
-        RETURN_IF_ERROR(create_codegen());
-    } else {
-        _codegen.reset(NULL);
-    }
-
     if (_query_options.max_errors <= 0) {
         // TODO: fix linker error and uncomment this
         //_query_options.max_errors = config::max_errors;
@@ -307,14 +300,6 @@ Status RuntimeState::create_block_mgr() {
     RETURN_IF_ERROR(BufferedBlockMgr2::create(this, _query_mem_tracker.get(),
             runtime_profile(), _exec_env->tmp_file_mgr(),
             block_mgr_limit, _exec_env->disk_io_mgr()->max_read_buffer_size(), &_block_mgr2));
-    return Status::OK();
-}
-
-Status RuntimeState::create_codegen() {
-    RETURN_IF_ERROR(LlvmCodeGen::load_doris_ir(
-            _obj_pool.get(), print_id(fragment_instance_id()), &_codegen));
-    _codegen->enable_optimizations(true);
-    _profile.add_child(_codegen->runtime_profile(), true, NULL);
     return Status::OK();
 }
 
@@ -512,18 +497,6 @@ void RuntimeState::export_load_error(const std::string& err_msg) {
         // TODO(lingbin): think if should check return value?
         _error_hub->export_error(err);
     }
-}
-
-Status RuntimeState::get_codegen(LlvmCodeGen** codegen, bool initialize) {
-    if (_codegen.get() == NULL && initialize) {
-        RETURN_IF_ERROR(create_codegen());
-    }
-    *codegen = _codegen.get();
-    return Status::OK();
-}
-
-Status RuntimeState::get_codegen(LlvmCodeGen** codegen) {
-    return get_codegen(codegen, true);
 }
 
 // TODO chenhao , check scratch_limit, disable_spilling and file_group

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -46,7 +46,6 @@ class ObjectPool;
 class Status;
 class ExecEnv;
 class Expr;
-class LlvmCodeGen;
 class DateTimeValue;
 class MemTracker;
 class DataStreamRecvr;
@@ -186,12 +185,6 @@ public:
         return _root_node_id + 1;
     }
 
-    // Returns true if the codegen object has been created. Note that this may return false
-    // even when codegen is enabled if nothing has been codegen'd.
-    bool codegen_created() const {
-        return _codegen.get() != NULL;
-    }
-
     // Returns runtime state profile
     RuntimeProfile* runtime_profile() {
         return &_profile;
@@ -200,18 +193,6 @@ public:
     // Returns true if codegen is enabled for this query.
     bool codegen_enabled() const {
         return !_query_options.disable_codegen;
-    }
-
-    // Returns CodeGen object.  Returns NULL if codegen is disabled.
-    LlvmCodeGen* llvm_codegen() {
-        return _codegen.get();
-    }
-    // Returns CodeGen object.  Returns NULL if the codegen object has not been
-    // created. If codegen is enabled for the query, the codegen object will be
-    // created as part of the RuntimeState's initialization.
-    // Otherwise, it can be created by calling create_codegen().
-    LlvmCodeGen* codegen() {
-        return _codegen.get();
     }
 
     // Create a codegen object in _codegen. No-op if it has already been called.
@@ -272,12 +253,6 @@ public:
     // Append all _error_log[_unreported_error_idx+] to new_errors and set
     // _unreported_error_idx to _errors_log.size()
     void get_unreported_errors(std::vector<std::string>* new_errors);
-
-    // Returns _codegen in 'codegen'. If 'initialize' is true, _codegen will be created if
-    // it has not been initialized by a previous call already. If 'initialize' is false,
-    // 'codegen' will be set to NULL if _codegen has not been initialized.
-    Status get_codegen(LlvmCodeGen** codegen, bool initialize);
-    Status get_codegen(LlvmCodeGen** codegen);
 
     bool is_cancelled() const {
         return _is_cancelled;
@@ -554,7 +529,6 @@ private:
     TUniqueId _fragment_instance_id;
     TQueryOptions _query_options;
     ExecEnv* _exec_env;
-    boost::scoped_ptr<LlvmCodeGen> _codegen;
 
     // Thread resource management object for this fragment's execution.  The runtime
     // state is responsible for returning this pool to the thread mgr.

--- a/be/src/runtime/tuple.cpp
+++ b/be/src/runtime/tuple.cpp
@@ -29,8 +29,6 @@
 
 namespace doris {
 
-const char* Tuple::_s_llvm_class_name = "class.doris::Tuple";
-
 int64_t Tuple::total_byte_size(const TupleDescriptor& desc) const {
     int64_t result = desc.byte_size();
     if (!desc.has_varlen_slots()) {

--- a/be/src/runtime/tuple.h
+++ b/be/src/runtime/tuple.h
@@ -174,9 +174,6 @@ public:
         return reinterpret_cast<DecimalV2Value*>(reinterpret_cast<char*>(this) + offset);
     }
 
-    // For C++/IR interop, we need to be able to look up types by name.
-    static const char* _s_llvm_class_name;
-
     void* get_data() { return this; }
 
     std::string to_string(const TupleDescriptor& d) const;

--- a/be/src/runtime/tuple_row.cpp
+++ b/be/src/runtime/tuple_row.cpp
@@ -20,7 +20,6 @@
 #include <sstream>
 
 namespace doris {
-const char* TupleRow::_s_llvm_class_name = "class.doris::TupleRow";
 
 std::string TupleRow::to_string(const RowDescriptor& d) {
     std::stringstream out;

--- a/be/src/runtime/tuple_row.h
+++ b/be/src/runtime/tuple_row.h
@@ -111,10 +111,6 @@ public:
         return bytes;
     }
 
-    // TODO: make a macro for doing this
-    // For C++/IR interop, we need to be able to look up types by name.
-    static const char* _s_llvm_class_name;
-
     std::string to_string(const RowDescriptor& d);
 private:
     Tuple* _tuples[1];

--- a/be/test/runtime/data_stream_test.cpp
+++ b/be/test/runtime/data_stream_test.cpp
@@ -24,7 +24,6 @@
 #include <gtest/gtest.h>
 
 #include "common/status.h"
-#include "codegen/llvm_codegen.h"
 #include "exprs/slot_ref.h"
 #include "runtime/row_batch.h"
 #include "runtime/runtime_state.h"
@@ -712,7 +711,6 @@ int main(int argc, char** argv) {
     doris::CpuInfo::init();
     doris::DiskInfo::init();
     doris::MemInfo::init();
-    doris::LlvmCodeGen::initialize_llvm();
 
     return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
Remove unused LLVM related codes of directory (step 4):be/src/runtime (#2910)

there are many LLVM related codes in code base, but these codes are not really used.
The higher version of GCC is not compatible with the LLVM 3.4.2 version currently used by Doris.
The PR delete all LLVM related code of directory: be/src/runtime