### PR TITLE
Restructure storage type to support complex types expending

### DIFF
--- a/be/src/olap/CMakeLists.txt
+++ b/be/src/olap/CMakeLists.txt
@@ -112,4 +112,5 @@ add_library(Olap STATIC
     task/engine_publish_version_task.cpp
     task/engine_alter_tablet_task.cpp
     olap_snapshot_converter.cpp
+    collection.h column_vector.h column_vector.cpp
 )

--- a/be/src/olap/CMakeLists.txt
+++ b/be/src/olap/CMakeLists.txt
@@ -112,5 +112,7 @@ add_library(Olap STATIC
     task/engine_publish_version_task.cpp
     task/engine_alter_tablet_task.cpp
     olap_snapshot_converter.cpp
-    collection.h column_vector.h column_vector.cpp
+    collection.h
+    column_vector.h
+    column_vector.cpp
 )

--- a/be/src/olap/aggregate_func.h
+++ b/be/src/olap/aggregate_func.h
@@ -95,7 +95,8 @@ struct BaseAggregateFuncs {
             return;
         }
 
-        const TypeInfo* _type_info = get_type_info(field_type);
+        // TODO: support complex type.
+        const TypeInfo* _type_info = get_scalar_type_info(field_type);
         _type_info->deep_copy(dst->mutable_cell_ptr(), src, mem_pool);
     }
 

--- a/be/src/olap/collection.h
+++ b/be/src/olap/collection.h
@@ -1,0 +1,54 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <iostream>
+
+namespace doris {
+
+// cpp type for LIST
+struct collection {
+    size_t length;
+    // null bitmap
+    bool* null_signs;
+    // 子元素数据数据
+    void* data;
+
+    collection(size_t length ) : length(length), null_signs(nullptr), data(nullptr) {}
+
+    collection(void* data, size_t length ) : length(length), null_signs(nullptr), data(data) {}
+
+    collection(void* data, size_t length, bool* null_signs)
+    : length(length), null_signs(null_signs), data(data) {}
+
+    collection(collection& value) {
+        length = value.length;
+        null_signs = value.null_signs;
+        data = value.data;
+    }
+
+    bool operator==(const collection& y) const ;
+    bool operator!=(const collection& value) const ;
+    bool operator<(const collection& value) const ;
+    bool operator<=(const collection& value) const ;
+    bool operator>(const collection& value) const ;
+    bool operator>=(const collection& value) const;
+    int32_t cmp(const collection& other) const;
+};
+
+}  // namespace doris

--- a/be/src/olap/collection.h
+++ b/be/src/olap/collection.h
@@ -26,7 +26,7 @@ struct collection {
     size_t length;
     // null bitmap
     bool* null_signs;
-    // 子元素数据数据
+    // child column data
     void* data;
 
     collection(size_t length ) : length(length), null_signs(nullptr), data(nullptr) {}
@@ -42,13 +42,6 @@ struct collection {
         data = value.data;
     }
 
-    bool operator==(const collection& y) const ;
-    bool operator!=(const collection& value) const ;
-    bool operator<(const collection& value) const ;
-    bool operator<=(const collection& value) const ;
-    bool operator>(const collection& value) const ;
-    bool operator>=(const collection& value) const;
-    int32_t cmp(const collection& other) const;
 };
 
 }  // namespace doris

--- a/be/src/olap/column_block.h
+++ b/be/src/olap/column_block.h
@@ -19,6 +19,7 @@
 
 #include <cstdint>
 
+#include "olap/column_vector.h"
 #include "olap/types.h"
 #include "util/bitmap.h"
 
@@ -26,36 +27,37 @@ namespace doris {
 
 class MemPool;
 class TypeInfo;
-class ColumnBlockCell;
+struct ColumnBlockCell;
 
 // Block of data belong to a single column.
 // It doesn't own any data, user should keep the life of input data.
 class ColumnBlock {
 public:
-    ColumnBlock(const TypeInfo* type_info, uint8_t* data, uint8_t* null_bitmap,
-                size_t nrows, MemPool* pool)
-        : _type_info(type_info), _data(data), _null_bitmap(null_bitmap),
-          _nrows(nrows), _delete_state(DEL_NOT_SATISFIED), _pool(pool) { }
+    ColumnBlock(ColumnVectorBatch* batch, MemPool* pool)
+        : _batch(batch), _delete_state(DEL_NOT_SATISFIED), _pool(pool) { }
 
-    const TypeInfo* type_info() const { return _type_info; }
-    uint8_t* data() const { return _data; }
-    uint8_t* null_bitmap() const { return _null_bitmap; }
-    bool is_nullable() const { return _null_bitmap != nullptr; }
+    const TypeInfo* type_info() const { return _batch->type_info(); }
+    uint8_t* data() const { return _batch->data(); }
+    bool is_nullable() const { return _batch->is_nullable(); }
     MemPool* pool() const { return _pool; }
-    const uint8_t* cell_ptr(size_t idx) const { return _data + idx * _type_info->size(); }
-    uint8_t* mutable_cell_ptr(size_t idx) const { return _data + idx * _type_info->size(); }
+    const uint8_t* cell_ptr(size_t idx) const { return _batch->cell_ptr(idx); }
+    uint8_t* mutable_cell_ptr(size_t idx) const { return _batch->mutable_cell_ptr(idx); }
     bool is_null(size_t idx) const {
-        return is_nullable() && BitmapTest(_null_bitmap, idx);
+        return _batch->is_null_at(idx);
     }
     void set_is_null(size_t idx, bool is_null) const {
-        if (is_nullable()) {
-            BitmapChange(_null_bitmap, idx, is_null);
-        }
+        _batch->set_is_null(idx, is_null);
     }
+
+    void set_null_bits(size_t offset, size_t num_rows, bool val) const {
+        _batch->set_null_bits(offset, num_rows, val);
+    }
+
+    ColumnVectorBatch* vector_batch() const { return _batch; }
 
     ColumnBlockCell cell(size_t idx) const;
 
-    size_t nrows() const { return _nrows; }
+    size_t nrows() const { return _batch->get_capacity(); }
 
     void set_delete_state(DelCondSatisfied delete_state) {
         _delete_state = delete_state;
@@ -64,10 +66,7 @@ public:
     DelCondSatisfied delete_state() const { return _delete_state; }
 
 private:
-    const TypeInfo* _type_info;
-    uint8_t* _data;
-    uint8_t* _null_bitmap;
-    size_t _nrows;
+    ColumnVectorBatch* _batch;
     DelCondSatisfied _delete_state;
     MemPool* _pool;
 };
@@ -101,10 +100,12 @@ public:
     const TypeInfo* type_info() const { return _block->type_info(); }
     MemPool* pool() const { return _block->pool(); }
     void set_null_bits(size_t num_rows, bool val) {
-        BitmapChangeBits(_block->null_bitmap(), _row_offset, num_rows, val);
+        _block->set_null_bits(_row_offset, num_rows, val);
     }
     bool is_nullable() const { return _block->is_nullable(); }
     uint8_t* data() const { return _block->mutable_cell_ptr(_row_offset); }
+    size_t current_offset() { return _row_offset; }
+
 private:
     ColumnBlock* _block;
     size_t _row_offset;

--- a/be/src/olap/column_vector.cpp
+++ b/be/src/olap/column_vector.cpp
@@ -1,0 +1,162 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "column_vector.h"
+
+namespace doris {
+
+ColumnVectorBatch::~ColumnVectorBatch() {
+    SAFE_DELETE_ARRAY(_null_signs);
+}
+
+Status ColumnVectorBatch::resize(size_t new_cap) {
+    if (_nullable) {
+        resize_buff(_capacity, new_cap, reinterpret_cast<uint8_t**>(&_null_signs));
+    }
+    _capacity = new_cap;
+    return Status::OK();
+}
+
+Status ColumnVectorBatch::resize_buff(size_t copy_bytes, size_t new_cap, uint8_t** _buf_ptr) {
+    const uint8_t* old_buf = *_buf_ptr;
+    if (old_buf) {
+        *_buf_ptr = new uint8_t[new_cap];
+        memcpy(*_buf_ptr, old_buf, copy_bytes);
+        delete[] old_buf;
+    } else {
+        *_buf_ptr = new uint8_t[new_cap];
+    }
+    return Status::OK();
+}
+
+bool ColumnVectorBatch::is_null_at(size_t row_idx) const {
+    return _nullable && _null_signs[row_idx];
+}
+
+void ColumnVectorBatch::set_is_null(size_t idx, bool is_null) const {
+    if (_nullable) {
+        _null_signs[idx] = is_null;
+    }
+}
+
+Status ColumnVectorBatch::create(size_t init_capacity,
+        bool is_nullable,
+        const TypeInfo* type_info,
+        std::unique_ptr<ColumnVectorBatch>* column_vector_batch) {
+    if (is_scalar_type(type_info->type())) {
+        std::unique_ptr<ColumnVectorBatch> local(
+                new ScalarColumnVectorBatch(type_info, is_nullable, init_capacity));
+        *column_vector_batch = std::move(local);
+        return Status::OK();
+    } else {
+        switch (type_info->type()) {
+        case FieldType::OLAP_FIELD_TYPE_LIST: {
+            std::unique_ptr<ColumnVectorBatch> local(new ListColumnVectorBatch(type_info, is_nullable, init_capacity));
+            *column_vector_batch = std::move(local);
+            return Status::OK();
+        }
+        default:
+            return Status::NotSupported("unsupported type for ColumnVectorBatch: " + std::to_string(type_info->type()));
+        }
+    }
+}
+
+ScalarColumnVectorBatch::ScalarColumnVectorBatch(const TypeInfo* type_info, bool is_nullable, size_t init_capacity)
+: ColumnVectorBatch(type_info, is_nullable) {
+    resize(init_capacity);
+}
+ScalarColumnVectorBatch::~ScalarColumnVectorBatch() {
+    SAFE_DELETE_ARRAY(_data);
+    ColumnVectorBatch::~ColumnVectorBatch();
+}
+
+Status ScalarColumnVectorBatch::resize(size_t new_cap) {
+    if (get_capacity() < new_cap) { // before first init, _capacity is 0.
+        size_t type_size = type_info()->size();
+        auto copy_bytes = get_capacity() * type_size;
+        size_t new_data_size = new_cap * type_size;
+        resize_buff(copy_bytes, new_data_size, &_data);
+        return ColumnVectorBatch::resize(new_cap);
+    }
+    return Status::OK();
+}
+
+uint8_t* ScalarColumnVectorBatch::data() const { return _data; };
+
+const uint8_t* ScalarColumnVectorBatch::cell_ptr(size_t idx) const { return _data + idx * type_info()->size(); };
+
+uint8_t* ScalarColumnVectorBatch::mutable_cell_ptr(size_t idx) const { return _data + idx * type_info()->size(); };
+
+
+ListColumnVectorBatch::ListColumnVectorBatch(const TypeInfo* type_info, bool is_nullable, size_t init_capacity)
+: ColumnVectorBatch(type_info, is_nullable) {
+    const auto* list_type_info = reinterpret_cast<const ListTypeInfo*>(type_info);
+    ColumnVectorBatch::create(init_capacity * 2, true, list_type_info->item_type_info(), &_elements);
+    resize(init_capacity);
+}
+
+ListColumnVectorBatch::~ListColumnVectorBatch() {
+    SAFE_DELETE_ARRAY(_data);
+    SAFE_DELETE_ARRAY(_data_offsets);
+    ColumnVectorBatch::~ColumnVectorBatch();
+}
+
+Status ListColumnVectorBatch::resize(size_t new_cap) {
+    if (get_capacity() < new_cap) {
+        size_t collection_type_size = sizeof(collection);
+        size_t copy_bytes = get_capacity() * collection_type_size;
+        size_t new_data_size = new_cap * collection_type_size;
+        RETURN_IF_ERROR(resize_buff(copy_bytes, new_data_size, reinterpret_cast<uint8_t**>(&_data)));
+
+        size_t offset_type_size = sizeof(size_t);
+        size_t offset_copy_bytes = (get_capacity() + 1) * offset_type_size;
+        size_t new_offset_size = (new_cap + 1) * offset_type_size;
+        RETURN_IF_ERROR(resize_buff(offset_copy_bytes, new_offset_size, reinterpret_cast<uint8_t**>(&_item_offsets)));
+
+        RETURN_IF_ERROR(ColumnVectorBatch::resize(new_cap));
+    }
+    return Status::OK();
+}
+
+uint8_t* ListColumnVectorBatch::data() const { return reinterpret_cast<uint8*>(_data); }
+
+const uint8_t* ListColumnVectorBatch::cell_ptr(size_t idx) const { return reinterpret_cast<uint8*>(_data + idx); }
+
+uint8_t* ListColumnVectorBatch::mutable_cell_ptr(size_t idx) const { return reinterpret_cast<uint8*>(_data + idx); }
+
+size_t ListColumnVectorBatch::item_offset(size_t idx) const { return _item_offsets[idx]; }
+
+void ListColumnVectorBatch::put_item_ordinal(segment_v2::ordinal_t* ordinals, size_t start_idx, size_t size) {
+    size_t first_offset = _item_offsets[start_idx];
+    segment_v2::ordinal_t first_ordinal = ordinals[0];
+    size_t i = 0;
+    while (++i < size) {
+        _item_offsets[start_idx + i] = first_offset + (ordinals[i] - first_ordinal);
+    }
+}
+
+void ListColumnVectorBatch::transform_offsets_and_elements_to_data(size_t start_idx, size_t end_idx) {
+    for (size_t idx = start_idx; idx < end_idx; ++idx) {
+        if (!is_null_at(idx)) {
+            _data[idx] = collection(_elements->mutable_cell_ptr(_item_offsets[idx]),
+            _item_offsets[idx + 1] - _item_offsets[idx],
+            _elements->get_null_signs(_item_offsets[idx]));
+        }
+    }
+}
+
+} // namespace doris end

--- a/be/src/olap/column_vector.h
+++ b/be/src/olap/column_vector.h
@@ -1,0 +1,147 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include "common/status.h"
+#include "olap/olap_common.h"
+#include "olap/rowset/segment_v2/common.h" // for ordinal_t
+#include "olap/row_block.h"
+#include "olap/row_cursor.h"
+#include "olap/types.h"
+#include "util/bitmap.h"
+
+namespace doris {
+
+// struct that contains column data(null bitmap), data array in sub class.
+struct ColumnVectorBatch {
+public:
+    explicit ColumnVectorBatch(const TypeInfo* type_info, bool is_nullable)
+    : _type_info(type_info), _capacity(0), _nullable(is_nullable) {}
+
+    ~ColumnVectorBatch();
+
+    const TypeInfo* type_info() const { return _type_info; }
+
+    size_t get_capacity() { return _capacity; }
+
+    inline bool is_nullable() {return _nullable; }
+
+    inline bool is_null_at(size_t row_idx) const;
+
+    inline void set_is_null(size_t idx, bool is_null) const;
+
+    inline void set_null_bits(size_t offset, size_t num_rows, bool val) const {
+        for (size_t i = 0; i < num_rows; ++i) {
+            set_is_null(offset + i, val);
+        }
+    }
+
+    inline bool* get_null_signs(size_t idx) { return _null_signs + idx; }
+
+
+    /**
+     * Change the number of slots to at least the given capacity.
+     * This function is not recursive into subtypes.
+     * Tips: This function will change `_capacity` attribute.
+     */
+    virtual Status resize(size_t new_cap);
+
+    // Get the start of the data.
+    virtual uint8_t* data() const = 0;
+
+    // Get the idx's cell_ptr
+    virtual const uint8_t* cell_ptr(size_t idx) const = 0;
+
+    // Get thr idx's cell_ptr for write
+    virtual uint8_t* mutable_cell_ptr(size_t idx) const = 0;
+
+
+    static Status create(size_t init_capacity,
+                         bool is_nullable,
+                         const TypeInfo* type_info,
+                         std::unique_ptr<ColumnVectorBatch>* column_vector_batch);
+
+protected:
+    static Status resize_buff(size_t old_cap, size_t new_cap, uint8_t** _buf);
+
+private:
+    const TypeInfo* _type_info;
+    size_t _capacity;
+    const bool _nullable;
+    bool* _null_signs = nullptr;
+};
+
+struct ScalarColumnVectorBatch : public ColumnVectorBatch {
+public:
+    explicit ScalarColumnVectorBatch(const TypeInfo* type_info, bool is_nullable, size_t init_capacity);
+
+    ~ScalarColumnVectorBatch();
+
+    Status resize(size_t new_cap) override;
+
+    // Get the start of the data.
+    uint8_t* data() const override;
+
+    // Get the idx's cell_ptr
+    const uint8_t* cell_ptr(size_t idx) const override;
+
+    // Get thr idx's cell_ptr for write
+    uint8_t* mutable_cell_ptr(size_t idx) const override;
+
+private:
+    uint8_t* _data = nullptr;
+};
+
+struct ListColumnVectorBatch : public ColumnVectorBatch {
+public:
+    explicit ListColumnVectorBatch(const TypeInfo* type_info, bool is_nullable, size_t init_capacity);
+    ~ListColumnVectorBatch();
+    Status resize(size_t new_cap) override;
+
+    ColumnVectorBatch* get_elements() const { return _elements.get(); }
+
+    // Get the start of the data.
+    uint8_t* data() const override;
+
+    // Get the idx's cell_ptr
+    const uint8_t* cell_ptr(size_t idx) const override;
+
+    // Get thr idx's cell_ptr for write
+    uint8_t* mutable_cell_ptr(size_t idx) const override;
+
+    size_t item_offset(size_t idx) const;
+
+    // 将size个ordinals放入_item_offsets，从start_idx开始覆盖
+    // _item_offsets: 0 3 5 9, ordinals: 100 105 111, size: 3, satart_idx:3
+    // --> _item_offsets: 0 3 5 (9 + 100 - 100) (9 + 105 - 100) (9 + 111 - 100)
+    // 即 _item_offsets变成 0 3 5 9 14 20
+    void put_item_ordinal(segment_v2::ordinal_t* ordinals, size_t start_idx, size_t size);
+
+    // 将_item_offsets从start_idx到end_idx的部分转化成data
+    void transform_offsets_and_elements_to_data(size_t start_idx, size_t end_idx);
+
+private:
+    collection* _data = nullptr;
+
+    std::unique_ptr<ColumnVectorBatch> _elements;
+
+    // 用于存储每个数据在_elements中的位置
+    size_t* _item_offsets;
+};
+
+} // namespace doris end

--- a/be/src/olap/field.h
+++ b/be/src/olap/field.h
@@ -41,7 +41,7 @@ namespace doris {
 class Field {
 public:
     explicit Field(const TabletColumn& column)
-        : _type_info(get_type_info(column.type())),
+        : _type_info(get_type_info(&column)),
         _key_coder(get_key_coder(column.type())),
         _index_size(column.index_length()),
         _is_nullable(column.is_nullable()),

--- a/be/src/olap/row_block2.cpp
+++ b/be/src/olap/row_block2.cpp
@@ -29,30 +29,21 @@ namespace doris {
 RowBlockV2::RowBlockV2(const Schema& schema, uint16_t capacity)
     : _schema(schema),
       _capacity(capacity),
-      _column_datas(_schema.num_columns(), nullptr),
-      _column_null_bitmaps(_schema.num_columns(), nullptr),
+      _column_vector_batches(_schema.num_columns()),
       _pool(new MemPool(&_tracker)),
       _selection_vector(nullptr) {
-    auto bitmap_size = BitmapSize(capacity);
     for (auto cid : _schema.column_ids()) {
-        size_t data_size = _schema.column(cid)->type_info()->size() * _capacity;
-        _column_datas[cid] = new uint8_t[data_size];
-
-        if (_schema.column(cid)->is_nullable()) {
-            _column_null_bitmaps[cid] = new uint8_t[bitmap_size];;
-        }
+        ColumnVectorBatch::create(
+                _capacity,
+                _schema.column(cid)->is_nullable(),
+                _schema.column(cid)->type_info(),
+                &_column_vector_batches[cid]);
     }
     _selection_vector = new uint16_t[_capacity];
     clear();
 }
 
 RowBlockV2::~RowBlockV2() {
-    for (auto data : _column_datas) {
-        delete[] data;
-    }
-    for (auto null_bitmap : _column_null_bitmaps) {
-        delete[] null_bitmap;
-    }
     delete[] _selection_vector;
 }
 
@@ -63,7 +54,7 @@ Status RowBlockV2::convert_to_row_block(RowCursor* helper, RowBlock* dst) {
             for (uint16_t i = 0; i < _selected_size; ++i) {
                 uint16_t row_idx = _selection_vector[i];
                 dst->get_row(i, helper);
-                bool is_null = BitmapTest(_column_null_bitmaps[cid], row_idx);
+                bool is_null = column_block(cid).is_null(row_idx);
                 if (is_null) {
                     helper->set_null(cid);
                 } else {

--- a/be/src/olap/row_block2.h
+++ b/be/src/olap/row_block2.h
@@ -74,10 +74,8 @@ public:
     // low-level API to access memory for each column block(including data array and nullmap).
     // `cid` must be one of `schema()->column_ids()`.
     ColumnBlock column_block(ColumnId cid) const {
-        const TypeInfo* type_info = _schema.column(cid)->type_info();
-        uint8_t* data = _column_datas[cid];
-        uint8_t* null_bitmap = _column_null_bitmaps[cid];
-        return ColumnBlock(type_info, data, null_bitmap, _capacity, _pool.get());
+        ColumnVectorBatch* batch = _column_vector_batches[cid].get();
+        return {batch, _pool.get()};
     }
 
     // low-level API to access the underlying memory for row at `row_idx`.
@@ -113,14 +111,10 @@ public:
 private:
     Schema _schema;
     size_t _capacity;
-    // keeps fixed-size (field_size x capacity) data vector for each column,
-    // _column_datas[cid] == null if cid is not in `_schema`.
+    // _column_vector_batches[cid] == null if cid is not in `_schema`.
     // memory are not allocated from `_pool` because we don't wan't to reallocate them in clear()
-    std::vector<uint8_t*> _column_datas;
-    // keeps null bitmap for each column,
-    // _column_null_bitmaps[cid] == null if cid is not in `_schema` or the column is not null.
-    // memory are not allocated from `_pool` because we don't wan't to reallocate them in clear()
-    std::vector<uint8_t*> _column_null_bitmaps;
+    std::vector<std::unique_ptr<ColumnVectorBatch>> _column_vector_batches;
+
     size_t _num_rows;
     // manages the memory for slice's data
     MemTracker _tracker;

--- a/be/src/olap/rowset/segment_v2/binary_dict_page.cpp
+++ b/be/src/olap/rowset/segment_v2/binary_dict_page.cpp
@@ -196,6 +196,11 @@ Status BinaryDictPageDecoder::init() {
     _encoding_type = static_cast<EncodingTypePB>(type);
     _data.remove_prefix(BINARY_DICT_PAGE_HEADER_SIZE);
     if (_encoding_type == DICT_ENCODING) {
+        ColumnVectorBatch::create(
+                1024,
+                false,
+                get_scalar_type_info(OLAP_FIELD_TYPE_INT),
+                &_batch);
         _data_page_decoder.reset(new BitShufflePageDecoder<OLAP_FIELD_TYPE_INT>(_data, _options));
     } else if (_encoding_type == PLAIN_ENCODING) {
         DCHECK_EQ(_encoding_type, PLAIN_ENCODING);
@@ -234,17 +239,17 @@ Status BinaryDictPageDecoder::next_batch(size_t* n, ColumnBlockView* dst) {
         return Status::OK();
     }
     Slice* out = reinterpret_cast<Slice*>(dst->data());
-    _code_buf.resize((*n) * sizeof(int32_t));
+    _batch->resize(*n);
 
     // copy the codewords into a temporary buffer first
     // And then copy the strings corresponding to the codewords to the destination buffer
-    TypeInfo *type_info = get_type_info(OLAP_FIELD_TYPE_INT);
-    // the data in page is not null
-    ColumnBlock column_block(type_info, _code_buf.data(), nullptr, *n, dst->column_block()->pool());
+    TypeInfo *type_info = get_scalar_type_info(OLAP_FIELD_TYPE_INT);
+
+    ColumnBlock column_block(_batch.get(), dst->column_block()->pool());
     ColumnBlockView tmp_block_view(&column_block);
     RETURN_IF_ERROR(_data_page_decoder->next_batch(n, &tmp_block_view));
     for (int i = 0; i < *n; ++i) {
-        int32_t codeword = *reinterpret_cast<int32_t*>(&_code_buf[i * sizeof(int32_t)]);
+        int32_t codeword = *reinterpret_cast<const int32_t*>(column_block.cell_ptr(i));
         // get the string from the dict decoder
         Slice element = _dict_decoder->string_at_index(codeword);
         if (element.size > 0) {

--- a/be/src/olap/rowset/segment_v2/binary_dict_page.h
+++ b/be/src/olap/rowset/segment_v2/binary_dict_page.h
@@ -28,6 +28,7 @@
 #include "olap/rowset/segment_v2/options.h"
 #include "olap/rowset/segment_v2/common.h"
 #include "olap/column_block.h"
+#include "olap/column_vector.h"
 #include "runtime/mem_pool.h"
 #include "runtime/mem_tracker.h"
 #include "gen_cpp/segment_v2.pb.h"
@@ -126,7 +127,8 @@ private:
     const BinaryPlainPageDecoder* _dict_decoder = nullptr;
     bool _parsed;
     EncodingTypePB _encoding_type;
-    faststring _code_buf;
+    // use as data buf.
+    std::unique_ptr<ColumnVectorBatch> _batch;
 };
 
 } // namespace segment_v2

--- a/be/src/olap/rowset/segment_v2/bitmap_index_reader.cpp
+++ b/be/src/olap/rowset/segment_v2/bitmap_index_reader.cpp
@@ -48,17 +48,18 @@ Status BitmapIndexIterator::seek_dictionary(const void* value, bool* exact_match
 Status BitmapIndexIterator::read_bitmap(rowid_t ordinal, Roaring* result) {
     DCHECK(0 <= ordinal && ordinal < _reader->bitmap_nums());
 
-    Slice value;
-    uint8_t nullmap;
     size_t num_to_read = 1;
-    ColumnBlock block(_reader->type_info(), (uint8_t*) &value, &nullmap, num_to_read, _pool.get());
+    std::unique_ptr<ColumnVectorBatch> cvb;
+    ColumnVectorBatch::create(num_to_read, true, _reader->type_info(), &cvb);
+    ColumnBlock block(cvb.get(), _pool.get());
     ColumnBlockView column_block_view(&block);
 
     RETURN_IF_ERROR(_bitmap_column_iter.seek_to_ordinal(ordinal));
     size_t num_read = num_to_read;
     RETURN_IF_ERROR(_bitmap_column_iter.next_batch(&num_read, &column_block_view));
     DCHECK(num_to_read == num_read);
-    *result = Roaring::read(value.data, false);
+
+    *result = Roaring::read(reinterpret_cast<const Slice*>(block.data())->data, false);
     _pool->clear();
     return Status::OK();
 }

--- a/be/src/olap/rowset/segment_v2/bitmap_index_reader.h
+++ b/be/src/olap/rowset/segment_v2/bitmap_index_reader.h
@@ -44,7 +44,7 @@ public:
                                const BitmapIndexColumnPB& bitmap_index_meta)
         : _file_name(file_name),
           _bitmap_index_meta(bitmap_index_meta){
-        _typeinfo = get_type_info(OLAP_FIELD_TYPE_VARCHAR);
+        _typeinfo = get_scalar_type_info(OLAP_FIELD_TYPE_VARCHAR);
     }
 
     Status load(bool cache_in_memory);

--- a/be/src/olap/rowset/segment_v2/bitmap_index_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/bitmap_index_writer.cpp
@@ -138,7 +138,7 @@ public:
                 bitmap_sizes.push_back(bitmap_size);
             }
 
-            const TypeInfo* bitmap_typeinfo = get_type_info(OLAP_FIELD_TYPE_OBJECT);
+            const TypeInfo* bitmap_typeinfo = get_scalar_type_info(OLAP_FIELD_TYPE_OBJECT);
 
             IndexedColumnWriterOptions options;
             options.write_ordinal_index = true;

--- a/be/src/olap/rowset/segment_v2/bitshuffle_page.h
+++ b/be/src/olap/rowset/segment_v2/bitshuffle_page.h
@@ -334,6 +334,10 @@ public:
     }
 
     Status next_batch(size_t* n, ColumnBlockView* dst) override {
+        RETURN_IF_ERROR(next_batch(n, dst, true));
+    }
+
+    Status next_batch(size_t* n, ColumnBlockView* dst, bool forward_index)  {
         DCHECK(_parsed);
         if (PREDICT_FALSE(*n == 0 || _cur_index >= _num_elements)) {
             *n = 0;
@@ -343,9 +347,15 @@ public:
         size_t max_fetch = std::min(*n, static_cast<size_t>(_num_elements - _cur_index));
         _copy_next_values(max_fetch, dst->data());
         *n = max_fetch;
-        _cur_index += max_fetch;
+        if (forward_index) {
+            _cur_index += max_fetch;
+        }
 
         return Status::OK();
+    }
+
+    Status peek_next_batch(size_t *n, ColumnBlockView* dst) override {
+        RETURN_IF_ERROR(next_batch(n, dst, false));
     }
 
     size_t count() const override {

--- a/be/src/olap/rowset/segment_v2/bloom_filter_index_reader.cpp
+++ b/be/src/olap/rowset/segment_v2/bloom_filter_index_reader.cpp
@@ -37,10 +37,10 @@ Status BloomFilterIndexReader::new_iterator(std::unique_ptr<BloomFilterIndexIter
 }
 
 Status BloomFilterIndexIterator::read_bloom_filter(rowid_t ordinal, std::unique_ptr<BloomFilter>* bf) {
-    Slice value;
-    uint8_t nullmap = 0;
     size_t num_to_read = 1;
-    ColumnBlock block(_reader->type_info(), (uint8_t*)&value, &nullmap, num_to_read, _pool.get());
+    std::unique_ptr<ColumnVectorBatch> cvb;
+    ColumnVectorBatch::create(num_to_read, true, _reader->type_info(), &cvb);
+    ColumnBlock block(cvb.get(), _pool.get());
     ColumnBlockView column_block_view(&block);
 
     RETURN_IF_ERROR(_bloom_filter_iter.seek_to_ordinal(ordinal));
@@ -49,7 +49,8 @@ Status BloomFilterIndexIterator::read_bloom_filter(rowid_t ordinal, std::unique_
     DCHECK(num_to_read == num_read);
     // construct bloom filter
     BloomFilter::create(_reader->_bloom_filter_index_meta.algorithm(), bf);
-    RETURN_IF_ERROR((*bf)->init(value.data, value.size, _reader->_bloom_filter_index_meta.hash_strategy()));
+    const Slice* value_ptr = reinterpret_cast<const Slice*>(block.data());
+    RETURN_IF_ERROR((*bf)->init(value_ptr->data, value_ptr->size, _reader->_bloom_filter_index_meta.hash_strategy()));
     _pool->clear();
     return Status::OK();
 }

--- a/be/src/olap/rowset/segment_v2/bloom_filter_index_reader.h
+++ b/be/src/olap/rowset/segment_v2/bloom_filter_index_reader.h
@@ -47,7 +47,7 @@ public:
                                const BloomFilterIndexPB& bloom_filter_index_meta)
         : _file_name(file_name),
           _bloom_filter_index_meta(bloom_filter_index_meta) {
-        _typeinfo = get_type_info(OLAP_FIELD_TYPE_VARCHAR);
+        _typeinfo = get_scalar_type_info(OLAP_FIELD_TYPE_VARCHAR);
     }
 
     Status load(bool cache_in_memory);

--- a/be/src/olap/rowset/segment_v2/bloom_filter_index_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/bloom_filter_index_writer.cpp
@@ -112,7 +112,7 @@ public:
         meta->set_algorithm(BLOCK_BLOOM_FILTER);
 
         // write bloom filters
-        const TypeInfo* bf_typeinfo = get_type_info(OLAP_FIELD_TYPE_VARCHAR);
+        const TypeInfo* bf_typeinfo = get_scalar_type_info(OLAP_FIELD_TYPE_VARCHAR);
         IndexedColumnWriterOptions options;
         options.write_ordinal_index = true;
         options.write_value_index = false;

--- a/be/src/olap/rowset/segment_v2/column_reader.cpp
+++ b/be/src/olap/rowset/segment_v2/column_reader.cpp
@@ -47,18 +47,40 @@ Status ColumnReader::create(const ColumnReaderOptions& opts,
                             uint64_t num_rows,
                             const std::string& file_name,
                             std::unique_ptr<ColumnReader>* reader) {
-    std::unique_ptr<ColumnReader> reader_local(
-        new ColumnReader(opts, meta, num_rows, file_name));
-    RETURN_IF_ERROR(reader_local->init());
-    *reader = std::move(reader_local);
-    return Status::OK();
+    if (is_scalar_type((FieldType)meta.type())) {
+        std::unique_ptr<ColumnReader> reader_local(
+                new ColumnReader(opts, meta, num_rows, file_name));
+        RETURN_IF_ERROR(reader_local->init());
+        *reader = std::move(reader_local);
+        return Status::OK();
+    } else {
+        FieldType type = (FieldType)meta.type();
+        switch(type) {
+            case FieldType::OLAP_FIELD_TYPE_LIST: {
+                std::unique_ptr<ColumnReader> item_reader;
+                DCHECK(meta.children_columns_size() == 1);
+                RETURN_IF_ERROR(ColumnReader::create(opts,
+                                                           meta.children_columns(0),
+                                                           meta.children_columns(0).orinal(),
+                                                           file_name,
+                                                           &item_reader));
+                std::unique_ptr<ColumnReader> reader_local(
+                        new ListColumnReader(opts, meta, num_rows, file_name, std::move(item_reader)));
+                RETURN_IF_ERROR(reader_local->init());
+                *reader = std::move(reader_local);
+                return Status::OK();
+            }
+            default:
+                return Status::NotSupported("unsupported type for ColumnReader: " + std::to_string(type));
+        }
+    }
 }
 
 ColumnReader::ColumnReader(const ColumnReaderOptions& opts,
                            const ColumnMetaPB& meta,
                            uint64_t num_rows,
                            const std::string& file_name)
-        : _opts(opts), _meta(meta), _num_rows(num_rows), _file_name(file_name) {
+        :_meta(meta), _opts(opts),_num_rows(num_rows), _file_name(file_name) {
 }
 
 ColumnReader::~ColumnReader() = default;
@@ -336,12 +358,114 @@ Status ColumnReader::seek_at_or_before(rowid_t rowid, OrdinalPageIndexIterator* 
     return Status::OK();
 }
 
+////////////////////////////////////////////////////////////////////////////////
+
+Status ListColumnReader::new_iterator(ColumnIterator** iterator) {
+    ColumnIterator* item_iterator;
+    _item_reader->new_iterator(&item_iterator);
+    *iterator = new ListFileColumnIterator(this, item_iterator);
+    return Status::OK();
+}
+
+Status ListColumnReader::init() {
+    _type_info = get_type_info(&_meta);
+    if (_type_info == nullptr) {
+        return Status::NotSupported(Substitute("generate typeinfo fail, _meta=$0, _meta.children size=$1",
+                _meta.type(), _meta.children_columns_size()));
+    }
+    TypeInfo* bigint_type_info = get_scalar_type_info(FieldType::OLAP_FIELD_TYPE_BIGINT);
+    RETURN_IF_ERROR(EncodingInfo::get(bigint_type_info, _meta.encoding(), &_encoding_info));
+    RETURN_IF_ERROR(get_block_compression_codec(_meta.compression(), &_compress_codec));
+
+
+    RETURN_IF_ERROR(_item_reader->init());
+    return Status::OK();
+}
+
+ListFileColumnIterator::ListFileColumnIterator(ColumnReader* offset_reader, ColumnIterator* item_reader)
+: FileColumnIterator(offset_reader) {
+    _item_iterator.reset(item_reader);
+}
+
+Status ListFileColumnIterator::init(const ColumnIteratorOptions& opts) {
+    RETURN_IF_ERROR(FileColumnIterator::init(opts));
+    TypeInfo* bigint_type_info = get_scalar_type_info(FieldType::OLAP_FIELD_TYPE_BIGINT);
+    RETURN_IF_ERROR(ColumnVectorBatch::create(1024, true, bigint_type_info, &_offset_batch));
+    RETURN_IF_ERROR(_item_iterator->init(opts));
+}
+
+// every invoke this method, _offset_batch will be cover, so this method is not thread safe.
+Status ListFileColumnIterator::next_batch(size_t* n, ColumnBlockView* dst) {
+    // 1. read offsets into  _offset_batch;
+    _offset_batch->resize(*n + 1);
+    ColumnBlock ordinal_block(_offset_batch.get(), nullptr);
+    ColumnBlockView ordinal_view(&ordinal_block);
+    RETURN_IF_ERROR(FileColumnIterator::next_batch(n, &ordinal_view));
+
+    if (*n == 0) {
+        return Status::OK();
+    }
+
+    // 2. 读取最后一个ordinal
+    if (_page->has_remaining()) { // last_ordinal in page.
+        size_t i = 1;
+        _page->data_decoder->peek_next_batch(&i, &ordinal_view);
+        DCHECK(i == 1);
+    } else {
+        // TODO llj,read next ordinal in _page's footer
+    }
+    ordinal_view.set_null_bits(1, false);
+    ordinal_view.advance(1);
+
+    // 3. 对于nullable的数据，修补ordinal_block中的空洞: 0 N N 3 N 5 -> 0 3 3 3 5 5
+    if (_reader->is_nullable()) {
+        size_t j = *n + 1;
+        ordinal_t pre = *(reinterpret_cast<ordinal_t*>(ordinal_block.cell(j).mutable_cell_ptr()));
+        while(--j >= 0) {
+            ColumnBlockCell cell = ordinal_block.cell(j);
+            if (cell.is_null()) {
+                *(reinterpret_cast<ordinal_t*>(cell.mutable_cell_ptr())) = pre;
+            }
+        }
+    }
+
+    // 4. 读子列数据并拼装collection
+    ColumnBlock* collection_block = dst->column_block();
+    ListColumnVectorBatch* collection_batch =
+            reinterpret_cast<ListColumnVectorBatch*>(collection_block->vector_batch());
+    size_t start_offset = dst->current_offset();
+    size_t end_offset = start_offset + *n;
+    ordinal_t* ordinals = reinterpret_cast<ordinal_t *>(ordinal_block.data());
+    collection_batch->put_item_ordinal(ordinals, start_offset, *n + 1);
+
+    size_t size_to_read = ordinals[*n] - ordinals[0];
+    if (size_to_read > 0) {
+        _item_iterator->seek_to_ordinal(ordinals[0]);
+        ColumnVectorBatch* item_vector_batch = collection_batch->get_elements();
+        item_vector_batch->resize(collection_batch->item_offset(end_offset));
+        ColumnBlock item_block = ColumnBlock(item_vector_batch, dst->pool());
+        ColumnBlockView item_view = ColumnBlockView(&item_block, collection_batch->item_offset(start_offset));
+        size_t real_read = size_to_read;
+        RETURN_IF_ERROR(_item_iterator->next_batch(&real_read, &item_view));
+        DCHECK(size_to_read == real_read);
+    }
+    collection_batch->transform_offsets_and_elements_to_data(start_offset, end_offset);
+
+    dst->advance(*n);
+    return Status::OK();
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
 FileColumnIterator::FileColumnIterator(ColumnReader* reader) : _reader(reader) {
 }
 
 FileColumnIterator::~FileColumnIterator() = default;
 
 Status FileColumnIterator::seek_to_first() {
+    if (_current_rowid == 0) { // need not to seek
+        return Status::OK();
+    }
     RETURN_IF_ERROR(_reader->seek_to_first(&_page_iter));
 
     _page.reset(new ParsedPage());
@@ -354,6 +478,9 @@ Status FileColumnIterator::seek_to_first() {
 }
 
 Status FileColumnIterator::seek_to_ordinal(rowid_t rid) {
+    if (_current_rowid == rid) { // need not to seek
+        return Status::OK();
+    }
     // if current page contains this row, we don't need to seek
     if (_page == nullptr || !_page->contains(rid)) {
         RETURN_IF_ERROR(_reader->seek_at_or_before(rid, &_page_iter));
@@ -562,27 +689,30 @@ Status DefaultValueColumnIterator::init(const ColumnIteratorOptions& opts) {
             DCHECK(_is_nullable);
             _is_default_value_null = true;
         } else {
-            TypeInfo* type_info = get_type_info(_type);
-            _type_size = type_info->size();
+//            TypeInfo* type_info = get_type_info(_type);
+            _type_size = _type_info->size();
             _mem_value = reinterpret_cast<void*>(_pool->allocate(_type_size));
             OLAPStatus s = OLAP_SUCCESS;
-            if (_type == OLAP_FIELD_TYPE_CHAR) {
+            if (_type_info->type() == OLAP_FIELD_TYPE_CHAR) {
                 int32_t length = _schema_length;
                 char* string_buffer = reinterpret_cast<char*>(_pool->allocate(length));
                 memset(string_buffer, 0, length);
                 memory_copy(string_buffer, _default_value.c_str(), _default_value.length());
                 ((Slice*)_mem_value)->size = length;
                 ((Slice*)_mem_value)->data = string_buffer;
-            } else if ( _type == OLAP_FIELD_TYPE_VARCHAR ||
-                _type == OLAP_FIELD_TYPE_HLL ||
-                _type == OLAP_FIELD_TYPE_OBJECT ) {
+            } else if (_type_info->type() == OLAP_FIELD_TYPE_VARCHAR ||
+                _type_info->type() == OLAP_FIELD_TYPE_HLL ||
+                _type_info->type() == OLAP_FIELD_TYPE_OBJECT ) {
                 int32_t length = _default_value.length();
                 char* string_buffer = reinterpret_cast<char*>(_pool->allocate(length));
                 memory_copy(string_buffer, _default_value.c_str(), length);
                 ((Slice*)_mem_value)->size = length;
                 ((Slice*)_mem_value)->data = string_buffer;
+            } else if (_type_info->type() == OLAP_FIELD_TYPE_LIST) {
+                // TODO llj FOR LIST DEFAULT VALUE
+                ((collection*)_mem_value)->length = 0;
             } else {
-                s = type_info->from_string(_mem_value, _default_value);
+                s = _type_info->from_string(_mem_value, _default_value);
             }
             if (s != OLAP_SUCCESS) {
                 return Status::InternalError(

--- a/be/src/olap/rowset/segment_v2/common.h
+++ b/be/src/olap/rowset/segment_v2/common.h
@@ -26,6 +26,7 @@ namespace doris {
 namespace segment_v2 {
 
 using rowid_t = uint32_t;
+using ordinal_t = uint64_t;
 
 } // namespace segment_v2
 } // namespace doris

--- a/be/src/olap/rowset/segment_v2/frame_of_reference_page.h
+++ b/be/src/olap/rowset/segment_v2/frame_of_reference_page.h
@@ -153,6 +153,10 @@ public:
     }
 
     Status next_batch(size_t* n, ColumnBlockView* dst) override {
+        RETURN_IF_ERROR(next_batch(n, dst, true));
+    }
+
+    Status next_batch(size_t* n, ColumnBlockView* dst, bool forward_index) {
         DCHECK(_parsed) << "Must call init() firstly";
         if (PREDICT_FALSE(*n == 0 || _cur_index >= _num_elements)) {
             *n = 0;
@@ -162,9 +166,15 @@ public:
         size_t to_fetch = std::min(*n, static_cast<size_t>(_num_elements - _cur_index));
         uint8_t* data_ptr = dst->data();
         _decoder->get_batch(reinterpret_cast<CppType*>(data_ptr), to_fetch);
-        _cur_index += to_fetch;
+        if (forward_index) {
+            _cur_index += to_fetch;
+        }
         *n = to_fetch;
         return Status::OK();
+    }
+
+    Status peek_next_batch(size_t *n, ColumnBlockView* dst) override {
+        RETURN_IF_ERROR(next_batch(n, dst, false));
     }
 
     size_t count() const override {

--- a/be/src/olap/rowset/segment_v2/indexed_column_reader.cpp
+++ b/be/src/olap/rowset/segment_v2/indexed_column_reader.cpp
@@ -35,7 +35,8 @@ namespace segment_v2 {
 using strings::Substitute;
 
 Status IndexedColumnReader::load() {
-    _type_info = get_type_info((FieldType)_meta.data_type());
+    // IndexColumn just support scalar type.
+    _type_info = get_scalar_type_info((FieldType)_meta.data_type());
     if (_type_info == nullptr) {
         return Status::NotSupported(Substitute("unsupported typeinfo, type=$0", _meta.data_type()));
     }

--- a/be/src/olap/rowset/segment_v2/page_decoder.h
+++ b/be/src/olap/rowset/segment_v2/page_decoder.h
@@ -82,6 +82,11 @@ public:
     // allocated in the column_vector_view's mem_pool.
     virtual Status next_batch(size_t* n, ColumnBlockView* dst) = 0;
 
+    // Same as `next_batch` except for not adding index
+    virtual Status peek_next_batch(size_t *n, ColumnBlockView* dst) {
+        return Status::NotSupported("peek_next_batch");
+    }
+
     // Return the number of elements in this page.
     virtual size_t count() const = 0;
 

--- a/be/src/olap/rowset/segment_v2/plain_page.h
+++ b/be/src/olap/rowset/segment_v2/plain_page.h
@@ -195,7 +195,11 @@ public:
         return Status::OK();
     }
 
-    Status next_batch(size_t *n, ColumnBlockView *dst) override {
+    Status next_batch(size_t* n, ColumnBlockView* dst) override {
+        RETURN_IF_ERROR(next_batch(n, dst, true));
+    }
+
+    Status next_batch(size_t *n, ColumnBlockView *dst, bool forward_index) override {
         DCHECK(_parsed);
 
         if (PREDICT_FALSE(*n == 0 || _cur_idx >= _num_elems)) {
@@ -207,9 +211,15 @@ public:
         memcpy(dst->data(),
                &_data[PLAIN_PAGE_HEADER_SIZE + _cur_idx * SIZE_OF_TYPE],
                max_fetch * SIZE_OF_TYPE);
-        _cur_idx += max_fetch;
+        if (forward_index) {
+            _cur_idx += max_fetch;
+        }
         *n = max_fetch;
         return Status::OK();
+    }
+
+    Status peek_next_batch(size_t *n, ColumnBlockView* dst) override {
+        return next_batch(n, dst, false);
     }
 
     size_t count() const override {

--- a/be/src/olap/rowset/segment_v2/segment.cpp
+++ b/be/src/olap/rowset/segment_v2/segment.cpp
@@ -83,7 +83,8 @@ Status Segment::new_iterator(const Schema& schema,
                 return Status::OK();
             }
             // TODO Logic here and the similar logic in ColumnReader::_get_filtered_pages should be unified.
-            TypeInfo* type_info = get_type_info((FieldType)c_meta.type());
+            // Now just scalar type has zone map.
+            TypeInfo* type_info = get_scalar_type_info((FieldType)c_meta.type());
             if (type_info == nullptr) {
                 return Status::NotSupported(Substitute("unsupported typeinfo, type=$0", c_meta.type()));
             }
@@ -210,11 +211,12 @@ Status Segment::new_column_iterator(uint32_t cid, ColumnIterator** iter) {
         if (!tablet_column.has_default_value() && !tablet_column.is_nullable()) {
             return Status::InternalError("invalid nonexistent column without default value.");
         }
+        TypeInfo* type_info = get_type_info(&tablet_column);
         std::unique_ptr<DefaultValueColumnIterator> default_value_iter(
                 new DefaultValueColumnIterator(tablet_column.has_default_value(),
                 tablet_column.default_value(),
                 tablet_column.is_nullable(),
-                tablet_column.type(),
+                type_info,
                 tablet_column.length()));
         ColumnIteratorOptions iter_opts;
         RETURN_IF_ERROR(default_value_iter->init(iter_opts));

--- a/be/src/olap/tablet_schema.h
+++ b/be/src/olap/tablet_schema.h
@@ -51,6 +51,26 @@ public:
     FieldAggregationMethod aggregation() const { return _aggregation; }
     int precision() const { return _precision; }
     int frac() const { return _frac; }
+    /**
+     * Add a sub column.
+     */
+    OLAPStatus add_sub_column(std::unique_ptr<TabletColumn> tablet_column);
+
+    OLAPStatus add_struct_field(const std::string& field_name, std::unique_ptr<TabletColumn> tablet_column) {
+        RETURN_NOT_OK(add_sub_column(std::move(tablet_column)));
+        _field_names.push_back(field_name);
+        return OLAP_SUCCESS;
+    }
+    uint32_t get_subtype_count() const {
+        return _sub_column_count;
+    }
+    const TabletColumn* get_sub_column(uint32_t i) const {
+        return _sub_columns[i].get();
+    }
+
+    const std::string& get_field_name(uint32_t i) {
+        return _field_names[i];
+    }
 
     static std::string get_string_by_field_type(FieldType type);
     static std::string get_string_by_aggregation_type(FieldAggregationMethod aggregation_type);
@@ -83,6 +103,12 @@ private:
     std::string _referenced_column;
 
     bool _has_bitmap_index = false;
+
+    TabletColumn* _parent = nullptr;
+    std::vector<std::unique_ptr<TabletColumn>> _sub_columns;
+    std::vector<std::string> _field_names;
+    uint32_t _sub_column_count = 0;
+
 };
 
 class TabletSchema {

--- a/be/src/olap/types.cpp
+++ b/be/src/olap/types.cpp
@@ -22,7 +22,7 @@ namespace doris {
 void (*FieldTypeTraits<OLAP_FIELD_TYPE_CHAR>::set_to_max)(void*) = nullptr;
 
 template<typename TypeTraitsClass>
-TypeInfo::TypeInfo(TypeTraitsClass t)
+ScalarTypeInfo::ScalarTypeInfo(TypeTraitsClass t)
       : _equal(TypeTraitsClass::equal),
         _cmp(TypeTraitsClass::cmp),
         _shallow_copy(TypeTraitsClass::shallow_copy),
@@ -39,30 +39,30 @@ TypeInfo::TypeInfo(TypeTraitsClass t)
         _field_type(TypeTraitsClass::type) {
 }
 
-class TypeInfoResolver {
-    DECLARE_SINGLETON(TypeInfoResolver);
+class ScalarTypeInfoResolver {
+    DECLARE_SINGLETON(ScalarTypeInfoResolver);
 public:
     TypeInfo* get_type_info(const FieldType t) {
-        auto pair = _mapping.find(t);
-        DCHECK(pair != _mapping.end()) << "Bad field type: " << t;
+        auto pair = _scalar_type_mapping.find(t);
+        DCHECK(pair != _scalar_type_mapping.end()) << "Bad field type: " << t;
         return pair->second.get();
     }
 
 private:
     template<FieldType field_type> void add_mapping() {
         TypeTraits<field_type> traits;
-        _mapping.emplace(field_type,
-                 std::shared_ptr<TypeInfo>(new TypeInfo(traits)));
+        _scalar_type_mapping.emplace(field_type,
+                 std::shared_ptr<TypeInfo>(new ScalarTypeInfo(traits)));
     }
 
     std::unordered_map<FieldType,
         std::shared_ptr<TypeInfo>,
-        std::hash<size_t>> _mapping;
+        std::hash<size_t>> _scalar_type_mapping;
 
-    DISALLOW_COPY_AND_ASSIGN(TypeInfoResolver);
+    DISALLOW_COPY_AND_ASSIGN(ScalarTypeInfoResolver);
 };
 
-TypeInfoResolver::TypeInfoResolver() {
+ScalarTypeInfoResolver::ScalarTypeInfoResolver() {
     add_mapping<OLAP_FIELD_TYPE_TINYINT>();
     add_mapping<OLAP_FIELD_TYPE_SMALLINT>();
     add_mapping<OLAP_FIELD_TYPE_INT>();
@@ -81,10 +81,93 @@ TypeInfoResolver::TypeInfoResolver() {
     add_mapping<OLAP_FIELD_TYPE_OBJECT>();
 }
 
-TypeInfoResolver::~TypeInfoResolver() {}
+ScalarTypeInfoResolver::~ScalarTypeInfoResolver() {}
 
+bool is_scalar_type(FieldType field_type) {
+    switch (field_type) {
+    case OLAP_FIELD_TYPE_STRUCT:
+    case OLAP_FIELD_TYPE_LIST:
+    case OLAP_FIELD_TYPE_MAP:
+        return false;
+    default: return false;
+    }
+}
+
+TypeInfo* get_scalar_type_info(FieldType field_type) {
+    return ScalarTypeInfoResolver::instance()->get_type_info(field_type);
+}
+
+
+class ListTypeInfoResolver {
+    DECLARE_SINGLETON(ListTypeInfoResolver);
+
+public:
+    TypeInfo* get_type_info(const FieldType t) {
+        auto pair = _type_mapping.find(t);
+        DCHECK(pair != _type_mapping.end()) << "Bad field type: list<" << t << ">";
+        return pair->second.get();
+    }
+private:
+    void add_mapping(FieldType field_type) {
+        _type_mapping.emplace(field_type, std::shared_ptr<TypeInfo>(new ListTypeInfo(get_scalar_type_info(field_type))));
+    }
+
+    // item_type_info -> list_type_info
+    std::unordered_map<FieldType, std::shared_ptr<TypeInfo>, std::hash<size_t>> _type_mapping;
+};
+ListTypeInfoResolver::ListTypeInfoResolver() {
+    add_mapping(OLAP_FIELD_TYPE_TINYINT);
+    add_mapping(OLAP_FIELD_TYPE_SMALLINT);
+    add_mapping(OLAP_FIELD_TYPE_INT);
+    add_mapping(OLAP_FIELD_TYPE_UNSIGNED_INT);
+    add_mapping(OLAP_FIELD_TYPE_BOOL);
+    add_mapping(OLAP_FIELD_TYPE_BIGINT);
+    add_mapping(OLAP_FIELD_TYPE_LARGEINT);
+    add_mapping(OLAP_FIELD_TYPE_FLOAT);
+    add_mapping(OLAP_FIELD_TYPE_DOUBLE);
+    add_mapping(OLAP_FIELD_TYPE_DECIMAL);
+    add_mapping(OLAP_FIELD_TYPE_DATE);
+    add_mapping(OLAP_FIELD_TYPE_DATETIME);
+    add_mapping(OLAP_FIELD_TYPE_CHAR);
+    add_mapping(OLAP_FIELD_TYPE_VARCHAR);
+}
+
+// equal to get_scalar_type_info
 TypeInfo* get_type_info(FieldType field_type) {
-    return TypeInfoResolver::instance()->get_type_info(field_type);
+    return get_scalar_type_info(field_type);
+}
+
+TypeInfo* get_type_info(segment_v2::ColumnMetaPB* column_meta_pb) {
+    FieldType type = (FieldType)column_meta_pb->type();
+    if (is_scalar_type(type)) {
+        return get_scalar_type_info(type);
+    } else {
+        switch (type) {
+            case OLAP_FIELD_TYPE_LIST: {
+                DCHECK(column_meta_pb->children_columns_size() == 1) << "more than 1 child type.";
+                FieldType child_type = (FieldType)column_meta_pb->children_columns(0).type();
+                return ListTypeInfoResolver::instance()->get_type_info(child_type);
+            }
+            default:
+                DCHECK(false) << "Bad field type: " << type;
+                return nullptr;
+        }
+    }
+}
+
+TypeInfo* get_type_info(const TabletColumn* col) {
+    if (is_scalar_type(col->type())) {
+        return get_scalar_type_info(col->type());
+    } else {
+        switch (col->type()) {
+        case OLAP_FIELD_TYPE_LIST:
+            DCHECK(col->get_subtype_count() == 1) << "more than 1 child type.";
+            return ListTypeInfoResolver::instance()->get_type_info(col->get_sub_column(0)->type());
+        default:
+            DCHECK(false) << "Bad field type: " << col->type();
+            return nullptr;
+        }
+    }
 }
 
 } // namespace doris

--- a/be/test/olap/rowset/segment_v2/binary_dict_page_test.cpp
+++ b/be/test/olap/rowset/segment_v2/binary_dict_page_test.cpp
@@ -82,13 +82,15 @@ public:
         //check values
         MemTracker tracker;
         MemPool pool(&tracker);
-        TypeInfo* type_info = get_type_info(OLAP_FIELD_TYPE_VARCHAR);
+        TypeInfo* type_info = get_scalar_type_info(OLAP_FIELD_TYPE_VARCHAR);
         size_t size = slices.size();
-        Slice* values = reinterpret_cast<Slice*>(pool.allocate(size * sizeof(Slice)));
-        ColumnBlock column_block(type_info, (uint8_t*)values, nullptr, size, &pool);
+        std::unique_ptr<ColumnVectorBatch> cvb;
+        ColumnVectorBatch::create(size, false, type_info, &cvb);
+        ColumnBlock column_block(cvb.get(), &pool);
         ColumnBlockView block_view(&column_block);
 
         status = page_decoder.next_batch(&size, &block_view);
+        Slice* values = reinterpret_cast<Slice*>(column_block.data());
         ASSERT_TRUE(status.ok());
         ASSERT_EQ(slices.size(), size);
         ASSERT_EQ("Individual", values[0].to_string());
@@ -172,10 +174,12 @@ public:
             //check values
             MemTracker tracker;
             MemPool pool(&tracker);
-            TypeInfo* type_info = get_type_info(OLAP_FIELD_TYPE_VARCHAR);
-            Slice* values = reinterpret_cast<Slice*>(pool.allocate(sizeof(Slice)));
-            ColumnBlock column_block(type_info, (uint8_t*)values, nullptr, 1, &pool);
+            TypeInfo* type_info = get_scalar_type_info(OLAP_FIELD_TYPE_VARCHAR);
+            std::unique_ptr<ColumnVectorBatch> cvb;
+            ColumnVectorBatch::create(1, false, type_info, &cvb);
+            ColumnBlock column_block(cvb.get(), &pool);
             ColumnBlockView block_view(&column_block);
+            Slice* values = reinterpret_cast<Slice*>(column_block.data());
 
             size_t num = 1;
             size_t pos = random() % (page_start_ids[slice_index + 1] - page_start_ids[slice_index]);

--- a/be/test/olap/rowset/segment_v2/binary_plain_page_test.cpp
+++ b/be/test/olap/rowset/segment_v2/binary_plain_page_test.cpp
@@ -74,12 +74,13 @@ public:
         MemTracker tracker;
         MemPool pool(&tracker);
         size_t size = 3;
-        Slice* values = reinterpret_cast<Slice*>(pool.allocate(size * sizeof(Slice)));
-        uint8_t* null_bitmap = reinterpret_cast<uint8_t*>(pool.allocate(BitmapSize(size)));
-        ColumnBlock block(get_type_info(OLAP_FIELD_TYPE_VARCHAR), (uint8_t*)values, null_bitmap, size, &pool);
+        std::unique_ptr<ColumnVectorBatch> cvb;
+        ColumnVectorBatch::create(size, true, get_scalar_type_info(OLAP_FIELD_TYPE_VARCHAR), &cvb);
+        ColumnBlock block(cvb.get(), &pool);
         ColumnBlockView column_block_view(&block);
 
         status = page_decoder.next_batch(&size, &column_block_view);
+        Slice* values = reinterpret_cast<Slice*>(block.data());
         ASSERT_TRUE(status.ok());
 
         Slice* value = reinterpret_cast<Slice*>(values);
@@ -88,13 +89,15 @@ public:
         ASSERT_EQ (",", value[1].to_string());
         ASSERT_EQ ("Doris", value[2].to_string());
         
-        Slice* values2 = reinterpret_cast<Slice*>(pool.allocate(size * sizeof(Slice)));
-        ColumnBlock block2(get_type_info(OLAP_FIELD_TYPE_VARCHAR), (uint8_t*)values2, null_bitmap, 1, &pool);
+        std::unique_ptr<ColumnVectorBatch> cvb2;
+        ColumnVectorBatch::create(1, true, get_scalar_type_info(OLAP_FIELD_TYPE_VARCHAR), &cvb2);
+        ColumnBlock block2(cvb2.get(), &pool);
         ColumnBlockView column_block_view2(&block2);
 
         size_t fetch_num = 1;
         page_decoder.seek_to_position_in_page(2);
         status = page_decoder.next_batch(&fetch_num, &column_block_view2);
+        Slice* values2 = reinterpret_cast<Slice*>(block2.data());
         ASSERT_TRUE(status.ok());
         Slice* value2 = reinterpret_cast<Slice*>(values2);
         ASSERT_EQ (1, fetch_num);

--- a/be/test/olap/rowset/segment_v2/binary_prefix_page_test.cpp
+++ b/be/test/olap/rowset/segment_v2/binary_prefix_page_test.cpp
@@ -75,26 +75,30 @@ class BinaryPrefixPageTest : public testing::Test {
         //check values
         MemTracker tracker;
         MemPool pool(&tracker);
-        TypeInfo* type_info = get_type_info(OLAP_FIELD_TYPE_VARCHAR);
+        TypeInfo* type_info = get_scalar_type_info(OLAP_FIELD_TYPE_VARCHAR);
         size_t size = slices.size();
-        Slice* values = reinterpret_cast<Slice*>(pool.allocate(size * sizeof(Slice)));
-        ColumnBlock column_block(type_info, (uint8_t*)values, nullptr, size, &pool);
+        std::unique_ptr<ColumnVectorBatch> cvb;
+        ColumnVectorBatch::create(size, false, type_info, &cvb);
+        ColumnBlock column_block(cvb.get(), &pool);
         ColumnBlockView block_view(&column_block);
 
         ret = page_decoder->next_batch(&size, &block_view);
+        Slice* values = reinterpret_cast<Slice*>(column_block.data());
         ASSERT_TRUE(ret.ok());
         ASSERT_EQ(slices.size(), size);
         for (int i = 1000; i < 1038; ++i) {
             ASSERT_EQ(std::to_string(i), values[i - 1000].to_string());
         }
 
-        values = reinterpret_cast<Slice*>(pool.allocate(size * sizeof(Slice)));
-        ColumnBlock column_block2(type_info, (uint8_t*)values, nullptr, size, &pool);
+        std::unique_ptr<ColumnVectorBatch> cvb2;
+        ColumnVectorBatch::create(size, false, type_info, &cvb2);
+        ColumnBlock column_block2(cvb2.get(), &pool);
         ColumnBlockView block_view2(&column_block2);
         ret = page_decoder->seek_to_position_in_page(15);
         ASSERT_TRUE(ret.ok());
 
         ret = page_decoder->next_batch(&size, &block_view2);
+        values = reinterpret_cast<Slice*>(column_block2.data());
         ASSERT_TRUE(ret.ok());
         ASSERT_EQ(23, size);
         for (int i = 1015; i < 1038; ++i) {
@@ -146,14 +150,6 @@ class BinaryPrefixPageTest : public testing::Test {
             new BinaryPrefixPageDecoder(dict_slice.slice(), dict_decoder_options));
         ret = page_decoder->init();
         ASSERT_TRUE(ret.ok());
-
-        MemTracker tracker;
-        MemPool pool(&tracker);
-        TypeInfo* type_info = get_type_info(OLAP_FIELD_TYPE_VARCHAR);
-        size_t size = slices.size();
-        Slice* values = reinterpret_cast<Slice*>(pool.allocate(size * sizeof(Slice)));
-        ColumnBlock column_block(type_info, (uint8_t*)values, nullptr, size, &pool);
-        ColumnBlockView block_view(&column_block);
 
         Slice slice("c");
         bool exact_match;

--- a/be/test/olap/rowset/segment_v2/bloom_filter_index_reader_writer_test.cpp
+++ b/be/test/olap/rowset/segment_v2/bloom_filter_index_reader_writer_test.cpp
@@ -47,7 +47,7 @@ template<FieldType type>
 void write_bloom_filter_index_file(const std::string& file_name, const void* values,
                       size_t value_count, size_t null_count,
                       BloomFilterIndexPB* bloom_filter_index_meta) {
-    const TypeInfo* type_info = get_type_info(type);
+    const TypeInfo* type_info = get_scalar_type_info(type);
     using CppType = typename CppTypeTraits<type>::CppType;
     FileUtils::create_dir(dname);
     std::string fname = dname + "/" + file_name;

--- a/be/test/olap/rowset/segment_v2/column_reader_writer_test.cpp
+++ b/be/test/olap/rowset/segment_v2/column_reader_writer_test.cpp
@@ -67,7 +67,7 @@ template<FieldType type, EncodingTypePB encoding>
 void test_nullable_data(uint8_t* src_data, uint8_t* src_is_null, int num_rows, string test_name) {
     using Type = typename TypeTraits<type>::CppType;
     Type* src = (Type*)src_data;
-    const TypeInfo* type_info = get_type_info(type);
+    const TypeInfo* type_info = get_scalar_type_info(type);
 
     ColumnMetaPB meta;
 
@@ -90,26 +90,27 @@ void test_nullable_data(uint8_t* src_data, uint8_t* src_is_null, int num_rows, s
             column = create_char_key(1);
         }
         std::unique_ptr<Field> field(FieldFactory::create(column));
-        ColumnWriter writer(writer_opts, std::move(field), true, wfile.get());
-        st = writer.init();
+        std::unique_ptr<ColumnWriter> writer;
+        ColumnWriter::create(writer_opts, std::move(field), true, wfile.get(), &writer);
+        st = writer->init();
         ASSERT_TRUE(st.ok()) << st.to_string();
 
         for (int i = 0; i < num_rows; ++i) {
-            st = writer.append(BitmapTest(src_is_null, i), src + i);
+            st = writer->append(BitmapTest(src_is_null, i), src + i);
             ASSERT_TRUE(st.ok());
         }
 
-        st = writer.finish();
+        st = writer->finish();
         ASSERT_TRUE(st.ok());
 
-        st = writer.write_data();
+        st = writer->write_data();
         ASSERT_TRUE(st.ok());
-        st = writer.write_ordinal_index();
+        st = writer->write_ordinal_index();
         ASSERT_TRUE(st.ok());
-        st = writer.write_zone_map();
+        st = writer->write_zone_map();
         ASSERT_TRUE(st.ok());
 
-        writer.write_meta(&meta);
+        writer->write_meta(&meta);
         ASSERT_TRUE(meta.has_zone_map_page());
 
         // close the file
@@ -142,10 +143,9 @@ void test_nullable_data(uint8_t* src_data, uint8_t* src_is_null, int num_rows, s
 
             MemTracker tracker;
             MemPool pool(&tracker);
-            Type vals[1024];
-            Type* vals_ = vals;
-            uint8_t is_null[1024];
-            ColumnBlock col(type_info, (uint8_t*)vals, is_null, 1024, &pool);
+            std::unique_ptr<ColumnVectorBatch> cvb;
+            ColumnVectorBatch::create(1024, true, type_info, &cvb);
+            ColumnBlock col(cvb.get(), &pool);
 
             int idx = 0;
             while (true) {
@@ -154,15 +154,14 @@ void test_nullable_data(uint8_t* src_data, uint8_t* src_is_null, int num_rows, s
                 st = iter->next_batch(&rows_read, &dst);
                 ASSERT_TRUE(st.ok());
                 for (int j = 0; j < rows_read; ++j) {
-                    ASSERT_EQ(BitmapTest(src_is_null, idx), BitmapTest(is_null, j));
-                    if (!BitmapTest(is_null, j)) {
+                    ASSERT_EQ(BitmapTest(src_is_null, idx), col.is_null(j));
+                    if (!col.is_null(j)) {
                         if (type == OLAP_FIELD_TYPE_VARCHAR || type == OLAP_FIELD_TYPE_CHAR) {
                             Slice* src_slice = (Slice*)src_data;
-                            Slice* dst_slice = (Slice*)vals_;
                             ASSERT_EQ(src_slice[idx].to_string(),
-                                      dst_slice[j].to_string()) << "j:" << j;
+                                    reinterpret_cast<const Slice*>(col.cell_ptr(j))->to_string()) << "j:" << j;
                         } else {
-                            ASSERT_EQ(src[idx], vals[j]);
+                            ASSERT_EQ(src[idx], *reinterpret_cast<const Type*>(col.cell_ptr(j)));
                         }
                     }
                     idx++;
@@ -176,9 +175,9 @@ void test_nullable_data(uint8_t* src_data, uint8_t* src_is_null, int num_rows, s
         {
             MemTracker tracker;
             MemPool pool(&tracker);
-            Type vals[1024];
-            uint8_t is_null[1024];
-            ColumnBlock col(type_info, (uint8_t*)vals, is_null, 1024, &pool);
+            std::unique_ptr<ColumnVectorBatch> cvb;
+            ColumnVectorBatch::create(1024, true, type_info, &cvb);
+            ColumnBlock col(cvb.get(), &pool);
 
             for (int rowid = 0; rowid < num_rows; rowid += 4025) {
                 st = iter->seek_to_ordinal(rowid);
@@ -194,10 +193,10 @@ void test_nullable_data(uint8_t* src_data, uint8_t* src_is_null, int num_rows, s
                     if (!BitmapTest(is_null, j)) {
                         if (type == OLAP_FIELD_TYPE_VARCHAR || type == OLAP_FIELD_TYPE_CHAR) {
                             Slice* src_slice = (Slice*)src_data;
-                            Slice* dst_slice = (Slice*)vals;
-                            ASSERT_EQ(src_slice[idx].to_string(), dst_slice[j].to_string());
+                            ASSERT_EQ(src_slice[idx].to_string(),
+                                    reinterpret_cast<const Slice*>(col.cell_ptr(j))->to_string());
                         } else {
-                            ASSERT_EQ(src[idx], vals[j]);
+                            ASSERT_EQ(src[idx], *reinterpret_cast<const Type*>(col.cell_ptr(j)));
                         }
                     }
                     idx++;
@@ -210,82 +209,82 @@ void test_nullable_data(uint8_t* src_data, uint8_t* src_is_null, int num_rows, s
 }
 
 template<FieldType type>
-void test_read_default_value(string value, void* result) {
-    using Type = typename TypeTraits<type>::CppType;
-    const TypeInfo* type_info = get_type_info(type);
-    // read and check
-    {
-        TabletColumn tablet_column = create_with_default_value<type>(value);
-        DefaultValueColumnIterator iter(tablet_column.has_default_value(),
-                                        tablet_column.default_value(),
-                                        tablet_column.is_nullable(),
-                                        tablet_column.type(),
-                                        tablet_column.length());
-        ColumnIteratorOptions iter_opts;
-        auto st = iter.init(iter_opts);
-        ASSERT_TRUE(st.ok());
-        // sequence read
+void test_read_default_value(std::string value, void* result) {
+        using Type = typename TypeTraits<type>::CppType;
+        const TypeInfo* type_info = get_scalar_type_info(type);
+        // read and check
         {
-            st = iter.seek_to_first();
-            ASSERT_TRUE(st.ok()) << st.to_string();
-
-            MemTracker tracker;
-            MemPool pool(&tracker);
-            Type vals[1024];
-            Type* vals_ = vals;
-            uint8_t is_null[1024];
-            ColumnBlock col(type_info, (uint8_t*)vals, is_null, 1024, &pool);
-
-            int idx = 0;
-            size_t rows_read = 1024;
-            ColumnBlockView dst(&col);
-            st = iter.next_batch(&rows_read, &dst);
+            TabletColumn tablet_column = create_with_default_value<type>(value);
+            TypeInfo* t = get_type_info(&tablet_column);
+            DefaultValueColumnIterator iter(tablet_column.has_default_value(),
+                                                   tablet_column.default_value(),
+                                                   tablet_column.is_nullable(),
+                                                   t,
+                                                   tablet_column.length());
+            ColumnIteratorOptions iter_opts;
+            auto st = iter.init(iter_opts);
             ASSERT_TRUE(st.ok());
-            for (int j = 0; j < rows_read; ++j) {
-                if (type == OLAP_FIELD_TYPE_CHAR) {
-                    Slice* dst_slice = (Slice*)vals_;
-                    ASSERT_EQ(*(string*)result, dst_slice[j].to_string()) << "j:" << j;
-                } else if (type == OLAP_FIELD_TYPE_VARCHAR
-                        || type == OLAP_FIELD_TYPE_HLL
-                        || type == OLAP_FIELD_TYPE_OBJECT) {
-                    Slice* dst_slice = (Slice*)vals_;
-                    ASSERT_EQ(value, dst_slice[j].to_string()) << "j:" << j;
-                } else {
-                    ASSERT_EQ(*(Type*)result, vals[j]);
-                }
-                idx++;
-            }
-        }
+            // sequence read
+            {
+                st = iter.seek_to_first();
+                ASSERT_TRUE(st.ok()) << st.to_string();
 
-        {
-            MemTracker tracker;
-            MemPool pool(&tracker);
-            Type vals[1024];
-            uint8_t is_null[1024];
-            ColumnBlock col(type_info, (uint8_t*)vals, is_null, 1024, &pool);
+                MemTracker tracker;
+                MemPool pool(&tracker);
+                std::unique_ptr<ColumnVectorBatch> cvb;
+                ColumnVectorBatch::create(1024, true, type_info, &cvb);
+                ColumnBlock col(cvb.get(), &pool);
 
-            for (int rowid = 0; rowid < 2048; rowid += 128) {
-                st = iter.seek_to_ordinal(rowid);
-                ASSERT_TRUE(st.ok());
-
-                int idx = rowid;
+                int idx = 0;
                 size_t rows_read = 1024;
                 ColumnBlockView dst(&col);
                 st = iter.next_batch(&rows_read, &dst);
                 ASSERT_TRUE(st.ok());
                 for (int j = 0; j < rows_read; ++j) {
                     if (type == OLAP_FIELD_TYPE_CHAR) {
-                        Slice* dst_slice = (Slice*)vals;
-                        ASSERT_EQ(*(string*)result, dst_slice[j].to_string()) << "j:" << j;
+                        ASSERT_EQ(*(std::string*)result,
+                                reinterpret_cast<const Slice*>(col.cell_ptr(j))->to_string()) << "j:" << j;
                     } else if (type == OLAP_FIELD_TYPE_VARCHAR
                             || type == OLAP_FIELD_TYPE_HLL
                             || type == OLAP_FIELD_TYPE_OBJECT) {
-                        Slice* dst_slice = (Slice*)vals;
-                        ASSERT_EQ(value, dst_slice[j].to_string());
+                        ASSERT_EQ(value,
+                                reinterpret_cast<const Slice*>(col.cell_ptr(j))->to_string()) << "j:" << j;
                     } else {
-                        ASSERT_EQ(*(Type*)result, vals[j]);
+                        ASSERT_EQ(*(Type*)result, *reinterpret_cast<const Type*>(col.cell_ptr(j)));
                     }
                     idx++;
+                }
+            }
+
+            {
+                MemTracker tracker;
+                MemPool pool(&tracker);
+                std::unique_ptr<ColumnVectorBatch> cvb;
+                ColumnVectorBatch::create(1024, true, type_info, &cvb);
+                ColumnBlock col(cvb.get(), &pool);
+
+                for (int rowid = 0; rowid < 2048; rowid += 128) {
+                    st = iter.seek_to_ordinal(rowid);
+                    ASSERT_TRUE(st.ok());
+
+                    int idx = rowid; // ??
+                    size_t rows_read = 1024;
+                    ColumnBlockView dst(&col);
+                    st = iter.next_batch(&rows_read, &dst);
+                    ASSERT_TRUE(st.ok());
+                    for (int j = 0; j < rows_read; ++j) {
+                        if (type == OLAP_FIELD_TYPE_CHAR) {
+                            ASSERT_EQ(*(std::string*)result,
+                                    reinterpret_cast<const Slice*>(col.cell_ptr(j))->to_string()) << "j:" << j;
+                        } else if (type == OLAP_FIELD_TYPE_VARCHAR
+                           || type == OLAP_FIELD_TYPE_HLL
+                           || type == OLAP_FIELD_TYPE_OBJECT) {
+                            ASSERT_EQ(value, reinterpret_cast<const Slice*>(col.cell_ptr(j))->to_string());
+                        } else {
+                            ASSERT_EQ(*(Type*)result, *reinterpret_cast<const Type*>(col.cell_ptr(j)));
+                        }
+                        idx++;
+                    }
                 }
             }
         }

--- a/be/test/olap/rowset/segment_v2/encoding_info_test.cpp
+++ b/be/test/olap/rowset/segment_v2/encoding_info_test.cpp
@@ -35,7 +35,7 @@ public:
 };
 
 TEST_F(EncodingInfoTest, normal) {
-    auto type_info = get_type_info(OLAP_FIELD_TYPE_BIGINT);
+    auto type_info = get_scalar_type_info(OLAP_FIELD_TYPE_BIGINT);
     const EncodingInfo* encoding_info = nullptr;
     auto status = EncodingInfo::get(type_info, PLAIN_ENCODING, &encoding_info);
     ASSERT_TRUE(status.ok());
@@ -43,7 +43,7 @@ TEST_F(EncodingInfoTest, normal) {
 }
 
 TEST_F(EncodingInfoTest, no_encoding) {
-    auto type_info = get_type_info(OLAP_FIELD_TYPE_BIGINT);
+    auto type_info = get_scalar_type_info(OLAP_FIELD_TYPE_BIGINT);
     const EncodingInfo* encoding_info = nullptr;
     auto status = EncodingInfo::get(type_info, DICT_ENCODING, &encoding_info);
     ASSERT_FALSE(status.ok());

--- a/be/test/olap/rowset/segment_v2/index_column_reader_writer_test.cpp
+++ b/be/test/olap/rowset/segment_v2/index_column_reader_writer_test.cpp
@@ -49,7 +49,7 @@ template<FieldType type>
 void wirte_index_file(std::string& file_name, const void* values,
                       size_t value_count, size_t null_count,
                       BitmapIndexColumnPB* bitmap_index_meta) {
-    const TypeInfo* type_info = get_type_info(type);
+    const TypeInfo* type_info = get_scalar_type_info(type);
     FileUtils::create_dir(dname);
     std::string fname = dname + "/" + file_name;
     {

--- a/be/test/olap/rowset/segment_v2/rle_page_test.cpp
+++ b/be/test/olap/rowset/segment_v2/rle_page_test.cpp
@@ -36,16 +36,18 @@ public:
     virtual ~RlePageTest() { }
 
     template<FieldType type, class PageDecoderType>
-    void copy_one(PageDecoderType* decoder, typename TypeTraits<type>::CppType* ret) {
+    void copy_one(PageDecoderType* decoder, typename TypeTraits<type>::CppType** ret) {
         MemTracker tracker;
         MemPool pool(&tracker);
-        uint8_t null_bitmap = 0;
-        ColumnBlock block(get_type_info(type), (uint8_t*)ret, &null_bitmap, 1, &pool);
+        std::unique_ptr<ColumnVectorBatch> cvb;
+        ColumnVectorBatch::create(1, true, get_scalar_type_info(type), &cvb);
+        ColumnBlock block(cvb.get(), &pool);
         ColumnBlockView column_block_view(&block);
 
         size_t n = 1;
         decoder->next_batch(&n, &column_block_view);
         ASSERT_EQ(1, n);
+        *ret = block.cell_ptr(1);
     }
 
     template <FieldType Type, class PageBuilderType, class PageDecoderType>
@@ -76,15 +78,16 @@ public:
 
         MemTracker tracker;
         MemPool pool(&tracker);
-        CppType* values = reinterpret_cast<CppType*>(pool.allocate(size * sizeof(CppType)));
-        uint8_t* null_bitmap = reinterpret_cast<uint8_t*>(pool.allocate(BitmapSize(size)));
-        ColumnBlock block(get_type_info(Type), (uint8_t*)values, null_bitmap, size, &pool);
+        std::unique_ptr<ColumnVectorBatch> cvb;
+        ColumnVectorBatch::create(size, true, get_scalar_type_info(Type), &cvb);
+        ColumnBlock block(cvb.get(), &pool);
         ColumnBlockView column_block_view(&block);
         size_t size_to_fetch = size;
         status = rle_page_decoder.next_batch(&size_to_fetch, &column_block_view);
         ASSERT_TRUE(status.ok());
         ASSERT_EQ(size, size_to_fetch);
 
+        CppType* values = reinterpret_cast<CppType*>(block.data());
         for (uint i = 0; i < size; i++) {
             if (src[i] != values[i]) {
                 FAIL() << "Fail at index " << i <<
@@ -97,9 +100,9 @@ public:
             int seek_off = random() % size;
             rle_page_decoder.seek_to_position_in_page(seek_off);
             EXPECT_EQ((int32_t )(seek_off), rle_page_decoder.current_index());
-            CppType ret;
+            CppType* ret;
             copy_one<Type, PageDecoderType>(&rle_page_decoder, &ret);
-            EXPECT_EQ(values[seek_off], ret);
+            EXPECT_EQ(values[seek_off], *ret);
         }
     }
 };

--- a/be/test/olap/rowset/segment_v2/segment_test.cpp
+++ b/be/test/olap/rowset/segment_v2/segment_test.cpp
@@ -164,7 +164,7 @@ TEST_F(SegmentReaderWriterTest, normal) {
                     auto column_block = block.column_block(j);
                     for (int i = 0; i < rows_read; ++i) {
                         int rid = rowid + i;
-                        ASSERT_FALSE(BitmapTest(column_block.null_bitmap(), i));
+                        ASSERT_FALSE(column_block.is_null(i));
                         ASSERT_EQ(rid * 10 + cid, *(int*)column_block.cell_ptr(i));
                     }
                 }
@@ -476,7 +476,7 @@ TEST_F(SegmentReaderWriterTest, TestIndex) {
                     auto column_block = block.column_block(j);
                     for (int i = 0; i < rows_read; ++i) {
                         int rid = rowid + i;
-                        ASSERT_FALSE(BitmapTest(column_block.null_bitmap(), i));
+                        ASSERT_FALSE(column_block.is_null(i));
                         ASSERT_EQ(rid * 10 + cid, *(int*)column_block.cell_ptr(i)) << "rid:" << rid << ", i:" << i;
                     }
                 }
@@ -535,7 +535,7 @@ TEST_F(SegmentReaderWriterTest, TestIndex) {
                     auto column_block = block.column_block(j);
                     for (int i = 0; i < rows_read; ++i) {
                         int rid = rowid + i;
-                        ASSERT_FALSE(BitmapTest(column_block.null_bitmap(), i));
+                        ASSERT_FALSE(column_block.is_null(i));
                         ASSERT_EQ(rid * 10 + cid, *(int*)column_block.cell_ptr(i)) << "rid:" << rid << ", i:" << i;
                     }
                 }
@@ -668,9 +668,9 @@ TEST_F(SegmentReaderWriterTest, TestDefaultValueColumn) {
                     for (int i = 0; i < rows_read; ++i) {
                         int rid = rowid + i;
                         if (cid == 4) {
-                            ASSERT_TRUE(BitmapTest(column_block.null_bitmap(), i));
+                            ASSERT_TRUE(column_block.is_null(i));
                         } else {
-                            ASSERT_FALSE(BitmapTest(column_block.null_bitmap(), i));
+                            ASSERT_FALSE(column_block.is_null(i));
                             ASSERT_EQ(rid * 10 + cid, *(int*)column_block.cell_ptr(i));
                         }
                     }
@@ -716,10 +716,10 @@ TEST_F(SegmentReaderWriterTest, TestDefaultValueColumn) {
                     for (int i = 0; i < rows_read; ++i) {
                         int rid = rowid + i;
                         if (cid == 4) {
-                            ASSERT_FALSE(BitmapTest(column_block.null_bitmap(), i));
+                            ASSERT_FALSE(column_block.is_null(i));
                             ASSERT_EQ(10086, *(int*)column_block.cell_ptr(i));
                         } else {
-                            ASSERT_FALSE(BitmapTest(column_block.null_bitmap(), i));
+                            ASSERT_FALSE(column_block.is_null(i));
                             ASSERT_EQ(rid * 10 + cid, *(int*)column_block.cell_ptr(i));
                         }
                     }
@@ -814,7 +814,7 @@ TEST_F(SegmentReaderWriterTest, TestStringDict) {
                     auto column_block = block.column_block(j);
                     for (int i = 0; i < rows_read; ++i) {
                         int rid = rowid + i;
-                        ASSERT_FALSE(BitmapTest(column_block.null_bitmap(), i));
+                        ASSERT_FALSE(column_block.is_null(i));
                         const Slice* actual = reinterpret_cast<const Slice*>(column_block.cell_ptr(i));
 
                         Slice expect;
@@ -916,7 +916,7 @@ TEST_F(SegmentReaderWriterTest, TestStringDict) {
                     auto column_block = block.column_block(j);
                     for (int i = 0; i < rows_read; ++i) {
                         int rid = rowid + i;
-                        ASSERT_FALSE(BitmapTest(column_block.null_bitmap(), i));
+                        ASSERT_FALSE(column_block.is_null(i));
 
                         const Slice* actual = reinterpret_cast<const Slice*>(column_block.cell_ptr(i));
                         Slice expect;

--- a/be/test/olap/schema_change_test.cpp
+++ b/be/test/olap/schema_change_test.cpp
@@ -289,7 +289,7 @@ public:
             ASSERT_TRUE(dst_str.compare(0, value.size(), value) == 0);
         }
 
-        TypeInfo* tp = get_type_info(OLAP_FIELD_TYPE_HLL);
+        TypeInfo* tp = get_scalar_type_info(OLAP_FIELD_TYPE_HLL);
         st = read_row.convert_from(0, read_row.cell_ptr(0), tp, _mem_pool.get());
         ASSERT_EQ(st, OLAP_ERR_INVALID_SCHEMA);
     }
@@ -366,7 +366,7 @@ TEST_F(TestColumn, ConvertFloatToDouble) {
     ASSERT_TRUE(v2 == 1.234);
     
     //test not support type
-    TypeInfo* tp = get_type_info(OLAP_FIELD_TYPE_HLL);
+    TypeInfo* tp = get_scalar_type_info(OLAP_FIELD_TYPE_HLL);
     OLAPStatus st = read_row.convert_from(0, data, tp, _mem_pool.get());
     ASSERT_TRUE( st == OLAP_ERR_INVALID_SCHEMA);
 }

--- a/be/test/olap/storage_types_test.cpp
+++ b/be/test/olap/storage_types_test.cpp
@@ -35,7 +35,7 @@ public:
 
 template<FieldType field_type>
 void common_test(typename TypeTraits<field_type>::CppType src_val) {
-    TypeInfo* type = get_type_info(field_type);
+    TypeInfo* type = get_scalar_type_info(field_type);
 
     ASSERT_EQ(field_type, type->type());
     ASSERT_EQ(sizeof(src_val), type->size());

--- a/gensrc/proto/olap_file.proto
+++ b/gensrc/proto/olap_file.proto
@@ -265,6 +265,8 @@ message ColumnPB {
     optional int32 referenced_column_id = 13; //   
     optional string referenced_column = 14; // ColumnMessage.referenced_column?
     optional bool has_bitmap_index = 15 [default=false]; // ColumnMessage.has_bitmap_index
+    repeated ColumnPB children_columns = 16;
+    repeated string children_column_names = 17;
 
 }
 

--- a/gensrc/proto/segment_v2.proto
+++ b/gensrc/proto/segment_v2.proto
@@ -105,6 +105,12 @@ message ColumnMetaPB {
     // bloom filter index
     optional BloomFilterIndexPB bloom_filter_index = 13;
 
+    repeated ColumnMetaPB children_columns = 14;
+    repeated string children_clolumn_names = 15;
+
+    // required
+    optional uint64 orinal = 16;
+
     // // bloom filter pages for bloom filter column
     // repeated PagePointerPB bloom_filter_pages = 3;
 


### PR DESCRIPTION
For #2885
1. Change type to tree structure.
2. Add List type.

This PR is not ready to be review because there are still a problem to be resolved in this PR:
1. `collection` has no type information, so method like `cmp` can't be implemented.
2. #2953 must be closed first. 