### PR TITLE
Fix disks_total_capacity metric bug

### DIFF
--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -1112,13 +1112,13 @@ void* TaskWorkerPool::_report_disk_state_worker_thread_callback(void* arg_this) 
             disk.__set_root_path(root_path_info.path);
             disk.__set_path_hash(root_path_info.path_hash);
             disk.__set_storage_medium(root_path_info.storage_medium);
-            disk.__set_disk_total_capacity(static_cast<double>(root_path_info.capacity));
+            disk.__set_disk_total_capacity(static_cast<double>(root_path_info.disk_capacity));
             disk.__set_data_used_capacity(static_cast<double>(root_path_info.data_used_capacity));
             disk.__set_disk_available_capacity(static_cast<double>(root_path_info.available));
             disk.__set_used(root_path_info.is_used);
             disks[root_path_info.path] = disk;
 
-            DorisMetrics::disks_total_capacity.set_metric(root_path_info.path, root_path_info.capacity);
+            DorisMetrics::disks_total_capacity.set_metric(root_path_info.path, root_path_info.disk_capacity);
             DorisMetrics::disks_avail_capacity.set_metric(root_path_info.path, root_path_info.available);
             DorisMetrics::disks_data_used_capacity.set_metric(root_path_info.path, root_path_info.data_used_capacity);
             DorisMetrics::disks_state.set_metric(root_path_info.path, root_path_info.is_used ? 1L : 0L);

--- a/be/src/olap/data_dir.h
+++ b/be/src/olap/data_dir.h
@@ -60,7 +60,7 @@ public:
         DataDirInfo info;
         info.path = _path;
         info.path_hash = _path_hash;
-        info.capacity = _capacity_bytes;
+        info.disk_capacity = _disk_capacity_bytes;
         info.available = _available_bytes;
         info.is_used = _is_used;
         info.storage_medium = _storage_medium;
@@ -155,8 +155,8 @@ private:
     size_t _path_hash;
     // user specified capacity
     int64_t _capacity_bytes;
-    // the actual avaiable capacity of the disk of this data dir
-    // NOTICE that _available_byte smay be larger than _capacity_bytes, if capacity is set
+    // the actual available capacity of the disk of this data dir
+    // NOTICE that _available_bytes may be larger than _capacity_bytes, if capacity is set
     // by user, not the disk's actual capacity
     int64_t _available_bytes;
     // the actual capacity of the disk of this data dir

--- a/be/src/olap/olap_common.h
+++ b/be/src/olap/olap_common.h
@@ -56,14 +56,15 @@ enum CompactionType {
 
 struct DataDirInfo {
     DataDirInfo():
-            capacity(1),
+            path_hash(0),
+            disk_capacity(1),
             available(0),
             data_used_capacity(0),
             is_used(false) { }
 
     std::string path;
     size_t path_hash;
-    int64_t capacity;                  // 总空间，单位字节
+    int64_t disk_capacity;             // actual disk capacity
     int64_t available;                 // 可用空间，单位字节
     int64_t data_used_capacity;
     bool is_used;                       // 是否可用标识

--- a/be/src/olap/storage_engine.cpp
+++ b/be/src/olap/storage_engine.cpp
@@ -257,7 +257,7 @@ OLAPStatus StorageEngine::get_all_data_dir_info(vector<DataDirInfo>* data_dir_in
     MonotonicStopWatch timer;
     timer.start();
 
-    // 1. update avaiable capacity of each data dir
+    // 1. update available capacity of each data dir
     // get all root path info and construct a path map.
     // path -> DataDirInfo
     std::map<std::string, DataDirInfo> path_map;
@@ -553,7 +553,7 @@ OLAPStatus StorageEngine::_start_trash_sweep(double* usage) {
             continue;
         }
 
-        double curr_usage = (double) (info.capacity - info.available) / info.capacity;
+        double curr_usage = (double) (info.disk_capacity - info.available) / info.disk_capacity;
         *usage = *usage > curr_usage ? *usage : curr_usage;
 
         OLAPStatus curr_res = OLAP_SUCCESS;


### PR DESCRIPTION
Now disks_total_capacity metric is a user specified capacity, but
disks_avail_capacity is the disk's actual available capacity, so
disks_total_capacity may be less than disks_avail_capacity, and
UsedPct on FE may be a negative number as a result.
We'd better to use disk actual capacity for disks_total_capacity metric.