### PR TITLE
Fix backup job block at UPLOAD_INFO phase

### DIFF
--- a/fe/src/main/java/org/apache/doris/backup/Repository.java
+++ b/fe/src/main/java/org/apache/doris/backup/Repository.java
@@ -372,10 +372,16 @@ public class Repository implements Writable {
         }
         Preconditions.checkState(!Strings.isNullOrEmpty(md5sum));
         String tmpRemotePath = assembleFileNameWithSuffix(remoteFilePath, SUFFIX_TMP_FILE);
-        LOG.debug("get md5sum of file: {}. tmp remote path: {}", localFilePath, tmpRemotePath);
+        String finalRemotePath = assembleFileNameWithSuffix(remoteFilePath, md5sum);
+        LOG.debug("get md5sum of file: {}. tmp remote path: {}. final remote path: {}", localFilePath, tmpRemotePath, finalRemotePath);
 
         // this may be a retry, so we should first delete remote file
         Status st = storage.delete(tmpRemotePath);
+        if (!st.ok()) {
+            return st;
+        }
+
+        st = storage.delete(finalRemotePath);
         if (!st.ok()) {
             return st;
         }
@@ -387,7 +393,6 @@ public class Repository implements Writable {
         }
 
         // rename tmp file with checksum named file
-        String finalRemotePath = assembleFileNameWithSuffix(remoteFilePath, md5sum);
         st = storage.rename(tmpRemotePath, finalRemotePath);
         if (!st.ok()) {
             return st;


### PR DESCRIPTION
There is a case where the META upload succeeded but the upload INFO failed, in which case the UPLOAD_INFO task will try again, but the META file has succeeded and filename.part has been renamed to filename.md5sum. The retry task will keep failing with rename and cannot complete the backup job. Therefore, the file.md5sum file needs to be deleted in advance

Fix #3001 