### PR TITLE
fix compile error in ubuntu 18.10

### DIFF
--- a/thirdparty/download-thirdparty.sh
+++ b/thirdparty/download-thirdparty.sh
@@ -279,6 +279,14 @@ if test "x$PATCH_COMPILER_RT" == "xtrue"; then
     echo "Finished patching $COMPILER_RT_SOURCE"
 fi
 
+cd $TP_SOURCE_DIR/$COMPILER_RT_SOURCE
+if [ ! -f $PATCHED_MARK ]; then
+    patch -p0 < $TP_PATCH_DIR/compiler-rt_libc.patch
+    touch $PATCHED_MARK
+fi
+cd -
+echo "Finished patching $COMPILER_RT_SOURCE"
+
 # patch to llvm to support aarch64 platform
 cd $TP_SOURCE_DIR/$LLVM_SOURCE
 if [ ! -f $PATCHED_MARK ]; then

--- a/thirdparty/patches/compiler-rt_libc.patch
+++ b/thirdparty/patches/compiler-rt_libc.patch
@@ -1,0 +1,31 @@
+--- lib/sanitizer_common/sanitizer_platform_limits_posix.cc
++++ lib/sanitizer_common/sanitizer_platform_limits_posix.cc
+@@ -159,7 +159,6 @@
+ # include <sys/procfs.h>
+ #endif
+ #include <sys/user.h>
+-#include <sys/ustat.h>
+ #include <linux/cyclades.h>
+ #include <linux/if_eql.h>
+ #include <linux/if_plip.h>
+@@ -252,7 +251,19 @@
+ #endif // SANITIZER_LINUX || SANITIZER_FREEBSD
+ 
+ #if SANITIZER_LINUX && !SANITIZER_ANDROID
+-  unsigned struct_ustat_sz = sizeof(struct ustat);
++  // Use pre-computed size of struct ustat to avoid <sys/ustat.h> which
++  // has been removed from glibc 2.28.
++#if defined(__aarch64__) || defined(__s390x__) || defined (__mips64) \
++  || defined(__powerpc64__) || defined(__arch64__) || defined(__sparcv9) \
++  || defined(__x86_64__)
++#define SIZEOF_STRUCT_USTAT 32
++#elif defined(__arm__) || defined(__i386__) || defined(__mips__) \
++  || defined(__powerpc__) || defined(__s390__)
++#define SIZEOF_STRUCT_USTAT 20
++#else
++#error Unknown size of struct ustat
++#endif
++  unsigned struct_ustat_sz = SIZEOF_STRUCT_USTAT;
+   unsigned struct_rlimit64_sz = sizeof(struct rlimit64);
+   unsigned struct_statvfs64_sz = sizeof(struct statvfs64);
+ #endif // SANITIZER_LINUX && !SANITIZER_ANDROID


### PR DESCRIPTION
fix a complie error in ubuntu 18.10 due to the `sys/ustat.h` was removed in glibc