### PR TITLE
Support different keys type between mv and base table

### DIFF
--- a/fe/src/main/java/org/apache/doris/alter/MaterializedViewHandler.java
+++ b/fe/src/main/java/org/apache/doris/alter/MaterializedViewHandler.java
@@ -194,8 +194,8 @@ public class MaterializedViewHandler extends AlterHandler {
         List<Column> mvColumns = checkAndPrepareMaterializedView(addMVClause, olapTable);
 
         // Step2: create mv job
-        RollupJobV2 rollupJobV2 = createMaterializedViewJob(mvIndexName, baseIndexName, mvColumns,
-                addMVClause.getProperties(), olapTable, db, baseIndexId);
+        RollupJobV2 rollupJobV2 = createMaterializedViewJob(mvIndexName, baseIndexName, mvColumns, addMVClause
+                .getProperties(), olapTable, db, baseIndexId, addMVClause.getMVKeysType());
 
         addAlterJobV2(rollupJobV2);
 
@@ -260,7 +260,7 @@ public class MaterializedViewHandler extends AlterHandler {
 
                 // step 3 create rollup job
                 RollupJobV2 alterJobV2 = createMaterializedViewJob(rollupIndexName, baseIndexName, rollupSchema, addRollupClause.getProperties(),
-                        olapTable, db, baseIndexId);
+                        olapTable, db, baseIndexId, null);
 
                 rollupNameJobMap.put(addRollupClause.getRollupName(), alterJobV2);
                 logJobIdSet.add(alterJobV2.getJobId());
@@ -308,11 +308,13 @@ public class MaterializedViewHandler extends AlterHandler {
      * @throws AnalysisException
      */
     private RollupJobV2 createMaterializedViewJob(String mvName, String baseIndexName,
-                                           List<Column> mvColumns, Map<String, String> properties,
-                                           OlapTable olapTable, Database db, long baseIndexId)
+                                           List<Column> mvColumns, Map<String, String> properties, OlapTable
+            olapTable, Database db, long baseIndexId, KeysType mvKeysType)
             throws DdlException, AnalysisException {
-        // assign rollup index's key type, same as base index's
-        KeysType mvKeysType = olapTable.getKeysType();
+        if (mvKeysType == null) {
+            // assign rollup index's key type, same as base index's
+            mvKeysType = olapTable.getKeysType();
+        }
         // get rollup schema hash
         int mvSchemaHash = Util.schemaHash(0 /* init schema version */, mvColumns, olapTable.getCopiedBfColumns(),
                                            olapTable.getBfFpp());

--- a/fe/src/main/java/org/apache/doris/alter/MaterializedViewHandler.java
+++ b/fe/src/main/java/org/apache/doris/alter/MaterializedViewHandler.java
@@ -260,7 +260,7 @@ public class MaterializedViewHandler extends AlterHandler {
 
                 // step 3 create rollup job
                 RollupJobV2 alterJobV2 = createMaterializedViewJob(rollupIndexName, baseIndexName, rollupSchema, addRollupClause.getProperties(),
-                        olapTable, db, baseIndexId, null);
+                        olapTable, db, baseIndexId, olapTable.getKeysType());
 
                 rollupNameJobMap.put(addRollupClause.getRollupName(), alterJobV2);
                 logJobIdSet.add(alterJobV2.getJobId());

--- a/fe/src/main/java/org/apache/doris/alter/RollupJob.java
+++ b/fe/src/main/java/org/apache/doris/alter/RollupJob.java
@@ -20,6 +20,7 @@ package org.apache.doris.alter;
 import org.apache.doris.catalog.Catalog;
 import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.Database;
+import org.apache.doris.catalog.KeysType;
 import org.apache.doris.catalog.MaterializedIndex;
 import org.apache.doris.catalog.MaterializedIndex.IndexState;
 import org.apache.doris.catalog.OlapTable;
@@ -748,9 +749,8 @@ public class RollupJob extends AlterJob {
                 } // end for partitions
 
                 // set index's info
-                olapTable.setIndexSchemaInfo(rollupIndexId, rollupIndexName, rollupSchema, 0,
-                                             rollupSchemaHash, rollupShortKeyColumnCount);
-                olapTable.setStorageTypeToIndex(rollupIndexId, rollupStorageType);
+                olapTable.setIndexMeta(rollupIndexId, rollupIndexName, rollupSchema, 0, rollupSchemaHash,
+                        rollupShortKeyColumnCount, rollupStorageType, KeysType.fromThrift(rollupKeysType));
                 Preconditions.checkState(olapTable.getState() == OlapTableState.ROLLUP);
 
                 this.state = JobState.FINISHING;
@@ -883,9 +883,8 @@ public class RollupJob extends AlterJob {
                 }
             }
 
-            olapTable.setIndexSchemaInfo(rollupIndexId, rollupIndexName, rollupSchema, 0,
-                                         rollupSchemaHash, rollupShortKeyColumnCount);
-            olapTable.setStorageTypeToIndex(rollupIndexId, rollupStorageType);
+            olapTable.setIndexMeta(rollupIndexId, rollupIndexName, rollupSchema, 0, rollupSchemaHash,
+                    rollupShortKeyColumnCount, rollupStorageType, KeysType.fromThrift(rollupKeysType));
         } finally {
             db.writeUnlock();
         }

--- a/fe/src/main/java/org/apache/doris/alter/RollupJobV2.java
+++ b/fe/src/main/java/org/apache/doris/alter/RollupJobV2.java
@@ -281,9 +281,8 @@ public class RollupJobV2 extends AlterJobV2 {
             partition.createRollupIndex(rollupIndex);
         }
 
-        tbl.setIndexSchemaInfo(rollupIndexId, rollupIndexName, rollupSchema, 0 /* init schema version */,
-                rollupSchemaHash, rollupShortKeyColumnCount);
-        tbl.setStorageTypeToIndex(rollupIndexId, TStorageType.COLUMN);
+        tbl.setIndexMeta(rollupIndexId, rollupIndexName, rollupSchema, 0 /* init schema version */,
+                rollupSchemaHash, rollupShortKeyColumnCount,TStorageType.COLUMN, rollupKeysType);
     }
 
     /*

--- a/fe/src/main/java/org/apache/doris/alter/SchemaChangeJob.java
+++ b/fe/src/main/java/org/apache/doris/alter/SchemaChangeJob.java
@@ -844,12 +844,8 @@ public class SchemaChangeJob extends AlterJob {
                     int schemaVersion = changedIndexIdToSchemaVersion.get(indexId);
                     int schemaHash = changedIndexIdToSchemaHash.get(indexId);
                     short shortKeyColumnCount = changedIndexIdToShortKeyColumnCount.get(indexId);
-                    olapTable.setIndexSchemaInfo(indexId, null, entry.getValue(), schemaVersion, schemaHash,
-                                                 shortKeyColumnCount);
-
-                    if (newStorageType != null) {
-                        olapTable.setIndexStorageType(indexId, newStorageType);
-                    }
+                    olapTable.setIndexMeta(indexId, null, entry.getValue(), schemaVersion, schemaHash,
+                            shortKeyColumnCount, newStorageType, null);
                 }
 
                 // 3. update base schema if changed
@@ -1012,12 +1008,9 @@ public class SchemaChangeJob extends AlterJob {
                 int schemaVersion = getSchemaVersionByIndexId(indexId);
                 int schemaHash = getSchemaHashByIndexId(indexId);
                 short shortKeyColumnCount = getShortKeyColumnCountByIndexId(indexId);
-                olapTable.setIndexSchemaInfo(indexId, null, entry.getValue(), schemaVersion, schemaHash,
-                                             shortKeyColumnCount);
+                olapTable.setIndexMeta(indexId, null, entry.getValue(), schemaVersion, schemaHash,
+                        shortKeyColumnCount, newStorageType, null);
 
-                if (newStorageType != null) {
-                    olapTable.setIndexStorageType(indexId, newStorageType);
-                }
                 if (indexId == olapTable.getBaseIndexId()) {
                     olapTable.setNewFullSchema(entry.getValue());
                 }

--- a/fe/src/main/java/org/apache/doris/alter/SchemaChangeJobV2.java
+++ b/fe/src/main/java/org/apache/doris/alter/SchemaChangeJobV2.java
@@ -314,11 +314,10 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
         }
 
         for (long shadowIdxId : indexIdMap.keySet()) {
-            tbl.setIndexSchemaInfo(shadowIdxId, indexIdToName.get(shadowIdxId), indexSchemaMap.get(shadowIdxId),
+            tbl.setIndexMeta(shadowIdxId, indexIdToName.get(shadowIdxId), indexSchemaMap.get(shadowIdxId),
                     indexSchemaVersionAndHashMap.get(shadowIdxId).first,
                     indexSchemaVersionAndHashMap.get(shadowIdxId).second,
-                    indexShortKeyMap.get(shadowIdxId));
-            tbl.setStorageTypeToIndex(shadowIdxId, TStorageType.COLUMN);
+                    indexShortKeyMap.get(shadowIdxId), TStorageType.COLUMN, null);
         }
 
         tbl.rebuildFullSchema();

--- a/fe/src/main/java/org/apache/doris/analysis/CreateMaterializedViewStmt.java
+++ b/fe/src/main/java/org/apache/doris/analysis/CreateMaterializedViewStmt.java
@@ -109,14 +109,14 @@ public class CreateMaterializedViewStmt extends DdlStmt {
         FeNameFormat.checkTableName(mvName);
         // TODO(ml): The mv name in from clause should pass the analyze without error.
         selectStmt.analyze(analyzer);
+        if (selectStmt.getAggInfo() != null) {
+            mvKeysType = KeysType.AGG_KEYS;
+        }
         analyzeSelectClause();
         analyzeFromClause();
         if (selectStmt.getWhereClause() != null) {
             throw new AnalysisException("The where clause is not supported in add materialized view clause, expr:"
                                                 + selectStmt.getWhereClause().toSql());
-        }
-        if (selectStmt.getGroupByClause() != null) {
-            mvKeysType = KeysType.AGG_KEYS;
         }
         if (selectStmt.getHavingPred() != null) {
             throw new AnalysisException("The having clause is not supported in add materialized view clause, expr:"
@@ -189,7 +189,6 @@ public class CreateMaterializedViewStmt extends DdlStmt {
                                                         + "Error function: " + functionCallExpr.toSqlImpl());
                 }
                 meetAggregate = true;
-                mvKeysType = KeysType.AGG_KEYS;
                 // check duplicate value
                 String columnName = slotRef.getColumnName().toLowerCase();
                 if (mvKeyColumnNameSet.contains(columnName)) {

--- a/fe/src/main/java/org/apache/doris/catalog/Catalog.java
+++ b/fe/src/main/java/org/apache/doris/catalog/Catalog.java
@@ -2904,10 +2904,7 @@ public class Catalog {
         DistributionInfo distributionInfo = null;
         OlapTable olapTable = null;
 
-        Map<Long, List<Column>> indexIdToSchema = null;
-        Map<Long, Integer> indexIdToSchemaHash = null;
-        Map<Long, Short> indexIdToShortKeyColumnCount = null;
-        Map<Long, TStorageType> indexIdToStorageType = null;
+        Map<Long, MaterializedIndexMeta> indexIdToMeta;
         Set<String> bfColumns = null;
 
         String partitionName = singlePartitionDesc.getPartitionName();
@@ -3001,10 +2998,7 @@ public class Catalog {
                 groupSchema.checkReplicationNum(singlePartitionDesc.getReplicationNum());
             }
 
-            indexIdToShortKeyColumnCount = olapTable.getCopiedIndexIdToShortKeyColumnCount();
-            indexIdToSchemaHash = olapTable.getCopiedIndexIdToSchemaHash();
-            indexIdToStorageType = olapTable.getCopiedIndexIdToStorageType();
-            indexIdToSchema = olapTable.getCopiedIndexIdToSchema();
+            indexIdToMeta = olapTable.getCopiedIndexIdToMeta();
             bfColumns = olapTable.getCopiedBfColumns();
         } catch (AnalysisException e) {
             throw new DdlException(e.getMessage());
@@ -3014,10 +3008,7 @@ public class Catalog {
 
         Preconditions.checkNotNull(distributionInfo);
         Preconditions.checkNotNull(olapTable);
-        Preconditions.checkNotNull(indexIdToShortKeyColumnCount);
-        Preconditions.checkNotNull(indexIdToSchemaHash);
-        Preconditions.checkNotNull(indexIdToStorageType);
-        Preconditions.checkNotNull(indexIdToSchema);
+        Preconditions.checkNotNull(indexIdToMeta);
 
         // create partition outside db lock
         DataProperty dataProperty = singlePartitionDesc.getPartitionDataProperty();
@@ -3030,10 +3021,7 @@ public class Catalog {
                     olapTable.getId(),
                     olapTable.getBaseIndexId(),
                     partitionId, partitionName,
-                    indexIdToShortKeyColumnCount,
-                    indexIdToSchemaHash,
-                    indexIdToStorageType,
-                    indexIdToSchema,
+                    indexIdToMeta,
                     olapTable.getKeysType(),
                     distributionInfo,
                     dataProperty.getStorageMedium(),
@@ -3074,17 +3062,17 @@ public class Catalog {
                 // rollup index may be added or dropped during add partition operation.
                 // schema may be changed during add partition operation.
                 boolean metaChanged = false;
-                if (olapTable.getIndexNameToId().size() != indexIdToSchema.size()) {
+                if (olapTable.getIndexNameToId().size() != indexIdToMeta.size()) {
                     metaChanged = true;
                 } else {
                     // compare schemaHash
-                    for (Map.Entry<Long, Integer> entry : olapTable.getIndexIdToSchemaHash().entrySet()) {
+                    for (Map.Entry<Long, MaterializedIndexMeta> entry : olapTable.getIndexIdToMeta().entrySet()) {
                         long indexId = entry.getKey();
-                        if (!indexIdToSchemaHash.containsKey(indexId)) {
+                        if (!indexIdToMeta.containsKey(indexId)) {
                             metaChanged = true;
                             break;
                         }
-                        if (!indexIdToSchemaHash.get(indexId).equals(entry.getValue())) {
+                        if (indexIdToMeta.get(indexId).getSchemaHash() != entry.getValue().getSchemaHash()) {
                             metaChanged = true;
                             break;
                         }
@@ -3351,10 +3339,7 @@ public class Catalog {
 
     private Partition createPartitionWithIndices(String clusterName, long dbId, long tableId,
                                                  long baseIndexId, long partitionId, String partitionName,
-                                                 Map<Long, Short> indexIdToShortKeyColumnCount,
-                                                 Map<Long, Integer> indexIdToSchemaHash,
-                                                 Map<Long, TStorageType> indexIdToStorageType,
-                                                 Map<Long, List<Column>> indexIdToSchema,
+                                                 Map<Long, MaterializedIndexMeta> indexIdToMeta,
                                                  KeysType keysType,
                                                  DistributionInfo distributionInfo,
                                                  TStorageMedium storageMedium,
@@ -3377,7 +3362,7 @@ public class Catalog {
         indexMap.put(baseIndexId, baseIndex);
 
         // create rollup index if has
-        for (long indexId : indexIdToSchema.keySet()) {
+        for (long indexId : indexIdToMeta.keySet()) {
             if (indexId == baseIndexId) {
                 continue;
             }
@@ -3396,9 +3381,10 @@ public class Catalog {
         for (Map.Entry<Long, MaterializedIndex> entry : indexMap.entrySet()) {
             long indexId = entry.getKey();
             MaterializedIndex index = entry.getValue();
+            MaterializedIndexMeta indexMeta = indexIdToMeta.get(indexId);
 
             // create tablets
-            int schemaHash = indexIdToSchemaHash.get(indexId);
+            int schemaHash = indexMeta.getSchemaHash();
             TabletMeta tabletMeta = new TabletMeta(dbId, tableId, partitionId, indexId, schemaHash, storageMedium);
             createTablets(clusterName, index, ReplicaState.NORMAL, distributionInfo, version, versionHash,
                     replicationNum, tabletMeta, tabletIdSet);
@@ -3407,9 +3393,9 @@ public class Catalog {
             String errMsg = null;
 
             // add create replica task for olap
-            short shortKeyColumnCount = indexIdToShortKeyColumnCount.get(indexId);
-            TStorageType storageType = indexIdToStorageType.get(indexId);
-            List<Column> schema = indexIdToSchema.get(indexId);
+            short shortKeyColumnCount = indexMeta.getShortKeyColumnCount();
+            TStorageType storageType = indexMeta.getStorageType();
+            List<Column> schema = indexMeta.getSchema();
             int totalTaskNum = index.getTablets().size() * replicationNum;
             MarkedCountDownLatch<Long, Long> countDownLatch = new MarkedCountDownLatch<Long, Long>(totalTaskNum);
             AgentBatchTask batchTask = new AgentBatchTask();
@@ -3535,16 +3521,7 @@ public class Catalog {
 
         // set base index info to table
         // this should be done before create partition.
-        // get base index storage type. default is COLUMN
         Map<String, String> properties = stmt.getProperties();
-        TStorageType baseIndexStorageType = null;
-        try {
-            baseIndexStorageType = PropertyAnalyzer.analyzeStorageType(properties);
-        } catch (AnalysisException e) {
-            throw new DdlException(e.getMessage());
-        }
-        Preconditions.checkNotNull(baseIndexStorageType);
-        olapTable.setStorageTypeToIndex(baseIndexId, baseIndexStorageType);
 
         // analyze bloom filter columns
         Set<String> bfColumns = null;
@@ -3624,7 +3601,15 @@ public class Catalog {
             throw new DdlException(e.getMessage());
         }
 
-        // set index schema
+        // get base index storage type. default is COLUMN
+        TStorageType baseIndexStorageType = null;
+        try {
+            baseIndexStorageType = PropertyAnalyzer.analyzeStorageType(properties);
+        } catch (AnalysisException e) {
+            throw new DdlException(e.getMessage());
+        }
+        Preconditions.checkNotNull(baseIndexStorageType);
+        // set base index meta
         int schemaVersion = 0;
         try {
             schemaVersion = PropertyAnalyzer.analyzeSchemaVersion(properties);
@@ -3632,8 +3617,8 @@ public class Catalog {
             throw new DdlException(e.getMessage());
         }
         int schemaHash = Util.schemaHash(schemaVersion, baseSchema, bfColumns, bfFpp);
-        olapTable.setIndexSchemaInfo(baseIndexId, tableName, baseSchema, schemaVersion, schemaHash,
-                shortKeyColumnCount);
+        olapTable.setIndexMeta(baseIndexId, tableName, baseSchema, schemaVersion, schemaHash,
+                shortKeyColumnCount, baseIndexStorageType, keysType);
 
 
         for (AlterClause alterClause : stmt.getRollupAlterClauseList()) {
@@ -3641,15 +3626,7 @@ public class Catalog {
 
             Long baseRollupIndex = olapTable.getIndexIdByName(tableName);
 
-            // set rollup index schema to olap table
-            List<Column> rollupColumns = getRollupHandler().checkAndPrepareMaterializedView(addRollupClause, olapTable, baseRollupIndex, false);
-            short rollupShortKeyColumnCount = Catalog.calcShortKeyColumnCount(rollupColumns, alterClause.getProperties());
-            int rollupSchemaHash = Util.schemaHash(schemaVersion, rollupColumns, bfColumns, bfFpp);
-            long rollupIndexId = getCurrentCatalog().getNextId();
-            olapTable.setIndexSchemaInfo(rollupIndexId, addRollupClause.getRollupName(), rollupColumns, schemaVersion, rollupSchemaHash,
-                    rollupShortKeyColumnCount);
-
-            // set storage type for rollup index
+            // get storage type for rollup index
             TStorageType rollupIndexStorageType = null;
             try {
                 rollupIndexStorageType = PropertyAnalyzer.analyzeStorageType(addRollupClause.getProperties());
@@ -3657,7 +3634,14 @@ public class Catalog {
                 throw new DdlException(e.getMessage());
             }
             Preconditions.checkNotNull(rollupIndexStorageType);
-            olapTable.setStorageTypeToIndex(rollupIndexId, rollupIndexStorageType);
+            // set rollup index meta to olap table
+            List<Column> rollupColumns = getRollupHandler().checkAndPrepareMaterializedView(addRollupClause,
+                    olapTable, baseRollupIndex, false);
+            short rollupShortKeyColumnCount = Catalog.calcShortKeyColumnCount(rollupColumns, alterClause.getProperties());
+            int rollupSchemaHash = Util.schemaHash(schemaVersion, rollupColumns, bfColumns, bfFpp);
+            long rollupIndexId = getCurrentCatalog().getNextId();
+            olapTable.setIndexMeta(rollupIndexId, addRollupClause.getRollupName(), rollupColumns, schemaVersion,
+                    rollupSchemaHash, rollupShortKeyColumnCount, rollupIndexStorageType, keysType);
         }
 
         // analyze version info
@@ -3684,10 +3668,7 @@ public class Catalog {
                 Partition partition = createPartitionWithIndices(db.getClusterName(), db.getId(),
                         olapTable.getId(), olapTable.getBaseIndexId(),
                         partitionId, partitionName,
-                        olapTable.getIndexIdToShortKeyColumnCount(),
-                        olapTable.getIndexIdToSchemaHash(),
-                        olapTable.getIndexIdToStorageType(),
-                        olapTable.getIndexIdToSchema(),
+                        olapTable.getIndexIdToMeta(),
                         keysType,
                         distributionInfo,
                         partitionInfo.getDataProperty(partitionId).getStorageMedium(),
@@ -3717,10 +3698,7 @@ public class Catalog {
                     DataProperty dataProperty = rangePartitionInfo.getDataProperty(entry.getValue());
                     Partition partition = createPartitionWithIndices(db.getClusterName(), db.getId(), olapTable.getId(),
                             olapTable.getBaseIndexId(), entry.getValue(), entry.getKey(),
-                            olapTable.getIndexIdToShortKeyColumnCount(),
-                            olapTable.getIndexIdToSchemaHash(),
-                            olapTable.getIndexIdToStorageType(),
-                            olapTable.getIndexIdToSchema(),
+                            olapTable.getIndexIdToMeta(),
                             keysType, distributionInfo,
                             dataProperty.getStorageMedium(),
                             partitionInfo.getReplicationNum(entry.getValue()),
@@ -4139,19 +4117,21 @@ public class Catalog {
         // 3. rollup
         if (createRollupStmt != null && (table instanceof OlapTable)) {
             OlapTable olapTable = (OlapTable) table;
-            for (Map.Entry<Long, List<Column>> entry : olapTable.getIndexIdToSchema().entrySet()) {
+            for (Map.Entry<Long, MaterializedIndexMeta> entry : olapTable.getIndexIdToMeta().entrySet()) {
                 if (entry.getKey() == olapTable.getBaseIndexId()) {
                     continue;
                 }
+                MaterializedIndexMeta materializedIndexMeta = entry.getValue();
                 sb = new StringBuilder();
-                String indexName = olapTable.getIndexNameById(entry.getKey());
+                String indexName = materializedIndexMeta.getIndexName();
                 sb.append("ALTER TABLE ").append(table.getName()).append(" ADD ROLLUP ").append(indexName);
                 sb.append("(");
 
-                for (int i = 0; i < entry.getValue().size(); i++) {
-                    Column column = entry.getValue().get(i);
+                List<Column> indexSchema = materializedIndexMeta.getSchema();
+                for (int i = 0; i < indexSchema.size(); i++) {
+                    Column column = indexSchema.get(i);
                     sb.append(column.getName());
-                    if (i != entry.getValue().size() - 1) {
+                    if (i != indexSchema.size() - 1) {
                         sb.append(", ");
                     }
                 }
@@ -6225,10 +6205,7 @@ public class Catalog {
                 Partition newPartition = createPartitionWithIndices(db.getClusterName(),
                         db.getId(), copiedTbl.getId(), copiedTbl.getBaseIndexId(),
                         newPartitionId, entry.getKey(),
-                        copiedTbl.getIndexIdToShortKeyColumnCount(),
-                        copiedTbl.getIndexIdToSchemaHash(),
-                        copiedTbl.getIndexIdToStorageType(),
-                        copiedTbl.getIndexIdToSchema(),
+                        copiedTbl.getIndexIdToMeta(),
                         copiedTbl.getKeysType(),
                         copiedTbl.getDefaultDistributionInfo(),
                         copiedTbl.getPartitionInfo().getDataProperty(oldPartitionId).getStorageMedium(),

--- a/fe/src/main/java/org/apache/doris/catalog/KeysType.java
+++ b/fe/src/main/java/org/apache/doris/catalog/KeysType.java
@@ -50,6 +50,21 @@ public enum KeysType {
         }
     }
 
+    public static KeysType fromThrift(TKeysType tKeysType) {
+        switch (tKeysType) {
+            case PRIMARY_KEYS:
+                return KeysType.PRIMARY_KEYS;
+            case DUP_KEYS:
+                return KeysType.DUP_KEYS;
+            case UNIQUE_KEYS:
+                return KeysType.UNIQUE_KEYS;
+            case AGG_KEYS:
+                return KeysType.AGG_KEYS;
+            default:
+                return null;
+        }
+    }
+
     public String toSql() {
         switch (this) {
             case PRIMARY_KEYS:

--- a/fe/src/main/java/org/apache/doris/catalog/MaterializedIndexMeta.java
+++ b/fe/src/main/java/org/apache/doris/catalog/MaterializedIndexMeta.java
@@ -1,0 +1,129 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.catalog;
+
+import org.apache.doris.common.io.Text;
+import org.apache.doris.common.io.Writable;
+import org.apache.doris.thrift.TStorageType;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import java.util.List;
+
+public class MaterializedIndexMeta implements Writable {
+    private long indexId;
+    private String indexName;
+    private List<Column> schema = Lists.newArrayList();
+    private int schemaVersion;
+    private int schemaHash;
+    private short shortKeyColumnCount;
+    private TStorageType storageType;
+    private KeysType keysType;
+
+    public MaterializedIndexMeta(long indexId, String indexName, List<Column> schema, int schemaVersion, int
+            schemaHash, short shortKeyColumnCount, TStorageType storageType, KeysType keysType) {
+        this.indexId = indexId;
+        Preconditions.checkState(indexName != null);
+        this.indexName = indexName;
+        Preconditions.checkState(schema != null);
+        Preconditions.checkState(schema.size() != 0);
+        this.schema = schema;
+        this.schemaVersion = schemaVersion;
+        this.schemaHash = schemaHash;
+        this.shortKeyColumnCount = shortKeyColumnCount;
+        Preconditions.checkState(storageType != null);
+        this.storageType = storageType;
+        Preconditions.checkState(keysType != null);
+        this.keysType = keysType;
+    }
+
+    public long getIndexId() {
+        return indexId;
+    }
+
+    public String getIndexName() {
+        return indexName;
+    }
+
+    public KeysType getKeysType() {
+        return keysType;
+    }
+
+    public void setKeysType(KeysType keysType) {
+        this.keysType = keysType;
+    }
+
+    public TStorageType getStorageType() {
+        return storageType;
+    }
+
+    public List<Column> getSchema() {
+        return schema;
+    }
+
+    public int getSchemaHash() {
+        return schemaHash;
+    }
+
+    public short getShortKeyColumnCount() {
+        return shortKeyColumnCount;
+    }
+
+    public int getSchemaVersion() {
+        return schemaVersion;
+    }
+
+    @Override
+    public void write(DataOutput out) throws IOException {
+        out.writeLong(indexId);
+        Text.writeString(out, indexName);
+        out.writeInt(schema.size());
+        for (Column column : schema) {
+            column.write(out);
+        }
+        out.writeInt(schemaVersion);
+        out.writeInt(schemaHash);
+        out.writeShort(shortKeyColumnCount);
+        Text.writeString(out, storageType.name());
+        Text.writeString(out, keysType.name());
+    }
+
+    public static MaterializedIndexMeta read(DataInput in) throws IOException {
+        long indexId = in.readLong();
+        String indexName = Text.readString(in);
+        int schemaSize = in.readInt();
+        List<Column> schema = Lists.newArrayList();
+        for (int i = 0; i < schemaSize; i++) {
+            Column column = Column.read(in);
+            schema.add(column);
+        }
+        int schemaVersion = in.readInt();
+        int schemaHash = in.readInt();
+        short shortKeyColumnCount = in .readShort();
+        TStorageType storageType = TStorageType.valueOf(Text.readString(in));
+        KeysType keysType = KeysType.valueOf(Text.readString(in));
+        MaterializedIndexMeta indexMeta = new MaterializedIndexMeta(indexId, indexName, schema,
+                 schemaVersion, schemaHash, shortKeyColumnCount, storageType, keysType);
+        return indexMeta;
+    }
+
+}

--- a/fe/src/main/java/org/apache/doris/catalog/MaterializedIndexMeta.java
+++ b/fe/src/main/java/org/apache/doris/catalog/MaterializedIndexMeta.java
@@ -23,6 +23,7 @@ import org.apache.doris.thrift.TStorageType;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
+import com.google.gson.annotations.SerializedName;
 
 import java.io.DataInput;
 import java.io.DataOutput;
@@ -30,13 +31,21 @@ import java.io.IOException;
 import java.util.List;
 
 public class MaterializedIndexMeta implements Writable {
+    @SerializedName(value = "indexId")
     private long indexId;
+    @SerializedName(value = "indexName")
     private String indexName;
+    @SerializedName(value = "schema")
     private List<Column> schema = Lists.newArrayList();
+    @SerializedName(value = "schemaVersion")
     private int schemaVersion;
+    @SerializedName(value = "schemaHash")
     private int schemaHash;
+    @SerializedName(value = "shortKeyColumnCount")
     private short shortKeyColumnCount;
+    @SerializedName(value = "storageType")
     private TStorageType storageType;
+    @SerializedName(value = "keysType")
     private KeysType keysType;
 
     public MaterializedIndexMeta(long indexId, String indexName, List<Column> schema, int schemaVersion, int

--- a/fe/src/main/java/org/apache/doris/catalog/OlapTable.java
+++ b/fe/src/main/java/org/apache/doris/catalog/OlapTable.java
@@ -510,7 +510,6 @@ public class OlapTable extends Table {
     public TStorageType getStorageTypeByIndexId(Long indexId) {
         MaterializedIndexMeta indexMeta = indexIdToMeta.get(indexId);
         if (indexMeta == null) {
-            LOG.warn("There is no index meta by index id {}. Using column storage type instead.", indexId);
             return TStorageType.COLUMN;
         }
         return indexMeta.getStorageType();

--- a/fe/src/main/java/org/apache/doris/common/FeMetaVersion.java
+++ b/fe/src/main/java/org/apache/doris/common/FeMetaVersion.java
@@ -159,7 +159,8 @@ public final class FeMetaVersion {
     public static final int VERSION_73 = 73;
     // temp partitions
     public static final int VERSION_74 = 74;
-
+    // support materialized index meta while there is different keys type in different materialized index
+    public static final int VERSION_75 = 75;
     // note: when increment meta version, should assign the latest version to VERSION_CURRENT
-    public static final int VERSION_CURRENT = VERSION_74;
+    public static final int VERSION_CURRENT = VERSION_75;
 }

--- a/fe/src/main/java/org/apache/doris/common/proc/IndexInfoProcDir.java
+++ b/fe/src/main/java/org/apache/doris/common/proc/IndexInfoProcDir.java
@@ -19,11 +19,11 @@ package org.apache.doris.common.proc;
 
 import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.Database;
+import org.apache.doris.catalog.MaterializedIndexMeta;
 import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.catalog.Table;
 import org.apache.doris.catalog.Table.TableType;
 import org.apache.doris.common.AnalysisException;
-import org.apache.doris.thrift.TStorageType;
 
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
@@ -66,18 +66,10 @@ public class IndexInfoProcDir implements ProcDirInterface {
                 // indices order
                 List<Long> indices = Lists.newArrayList();
                 indices.add(olapTable.getBaseIndexId());
-                for (Long indexId : olapTable.getIndexIdToSchema().keySet()) {
-                    if (indexId != olapTable.getBaseIndexId()) {
-                        indices.add(indexId);
-                    }
-                }
+                indices.addAll(olapTable.getIndexIdListExceptBaseIndex());
 
                 for (long indexId : indices) {
-                    int schemaVersion = olapTable.getSchemaVersionByIndexId(indexId);
-                    int schemaHash = olapTable.getSchemaHashByIndexId(indexId);
-                    short shortKeyColumnCount = olapTable.getShortKeyColumnCountByIndexId(indexId);
-                    TStorageType storageType = olapTable.getStorageTypeByIndexId(indexId);
-                    String indexName = olapTable.getIndexNameById(indexId);
+                    MaterializedIndexMeta indexMeta = olapTable.getIndexIdToMeta().get(indexId);
 
                     String type = olapTable.getKeysType().name();
                     StringBuilder builder = new StringBuilder();
@@ -92,11 +84,11 @@ public class IndexInfoProcDir implements ProcDirInterface {
                     builder.append(Joiner.on(", ").join(columnNames)).append(")");
 
                     result.addRow(Lists.newArrayList(String.valueOf(indexId),
-                            indexName,
-                            String.valueOf(schemaVersion),
-                            String.valueOf(schemaHash),
-                            String.valueOf(shortKeyColumnCount),
-                            storageType.name(),
+                            indexMeta.getIndexName(),
+                            String.valueOf(indexMeta.getSchemaVersion()),
+                            String.valueOf(indexMeta.getSchemaHash()),
+                            String.valueOf(indexMeta.getShortKeyColumnCount()),
+                            indexMeta.getStorageType().name(),
                             builder.toString()));
                 }
             } else {

--- a/fe/src/main/java/org/apache/doris/http/rest/StorageTypeCheckAction.java
+++ b/fe/src/main/java/org/apache/doris/http/rest/StorageTypeCheckAction.java
@@ -18,6 +18,7 @@
 package org.apache.doris.http.rest;
 
 import org.apache.doris.catalog.Database;
+import org.apache.doris.catalog.MaterializedIndexMeta;
 import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.catalog.Table;
 import org.apache.doris.catalog.Table.TableType;
@@ -76,10 +77,10 @@ public class StorageTypeCheckAction extends RestBaseAction {
 
                 OlapTable olapTbl = (OlapTable) tbl;
                 JSONObject indexObj = new JSONObject();
-                for (Map.Entry<Long, TStorageType> entry : olapTbl.getIndexIdToStorageType().entrySet()) {
-                    if (entry.getValue() == TStorageType.ROW) {
-                        String idxName = olapTbl.getIndexNameById(entry.getKey());
-                        indexObj.put(idxName, entry.getValue().name());
+                for (Map.Entry<Long, MaterializedIndexMeta> entry : olapTbl.getIndexIdToMeta().entrySet()) {
+                    MaterializedIndexMeta indexMeta = entry.getValue();
+                    if (indexMeta.getStorageType() == TStorageType.ROW) {
+                        indexObj.put(indexMeta.getIndexName(), indexMeta.getStorageType().name());
                     }
                 }
                 root.put(tbl.getName(), indexObj);

--- a/fe/src/main/java/org/apache/doris/master/ReportHandler.java
+++ b/fe/src/main/java/org/apache/doris/master/ReportHandler.java
@@ -21,11 +21,10 @@ import com.google.common.collect.Sets;
 import org.apache.commons.lang3.tuple.ImmutableTriple;
 import org.apache.commons.lang3.tuple.Triple;
 import org.apache.doris.catalog.Catalog;
-import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.Database;
-import org.apache.doris.catalog.KeysType;
 import org.apache.doris.catalog.MaterializedIndex;
 import org.apache.doris.catalog.MaterializedIndex.IndexState;
+import org.apache.doris.catalog.MaterializedIndexMeta;
 import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.catalog.Partition;
 import org.apache.doris.catalog.Replica;
@@ -566,18 +565,15 @@ public class ReportHandler extends Daemon {
                                     LOG.warn("tablet {} has only one replica {} on backend {}"
                                             + "and it is lost. create an empty replica to recover it",
                                             tabletId, replica.getId(), backendId);
-                                    short shortKeyColumnCount = olapTable.getShortKeyColumnCountByIndexId(indexId);
-                                    int schemaHash = olapTable.getSchemaHashByIndexId(indexId);
-                                    KeysType keysType = olapTable.getKeysType();
-                                    List<Column> columns = olapTable.getSchemaByIndexId(indexId);
+                                    MaterializedIndexMeta indexMeta = olapTable.getIndexMetaByIndexId(indexId);
                                     Set<String> bfColumns = olapTable.getCopiedBfColumns();
                                     double bfFpp = olapTable.getBfFpp();
                                     CreateReplicaTask createReplicaTask = new CreateReplicaTask(backendId, dbId,
-                                            tableId, partitionId, indexId, tabletId, shortKeyColumnCount,
-                                            schemaHash, partition.getVisibleVersion(),
-                                            partition.getVisibleVersionHash(), keysType,
+                                            tableId, partitionId, indexId, tabletId, indexMeta.getShortKeyColumnCount(),
+                                            indexMeta.getSchemaHash(), partition.getVisibleVersion(),
+                                            partition.getVisibleVersionHash(), indexMeta.getKeysType(),
                                             TStorageType.COLUMN,
-                                            TStorageMedium.HDD, columns, bfColumns, bfFpp, null,
+                                            TStorageMedium.HDD, indexMeta.getSchema(), bfColumns, bfFpp, null,
                                             olapTable.getCopiedIndexes(),
                                             olapTable.isInMemory());
                                     createReplicaBatchTask.addTask(createReplicaTask);

--- a/fe/src/main/java/org/apache/doris/planner/MaterializedViewSelector.java
+++ b/fe/src/main/java/org/apache/doris/planner/MaterializedViewSelector.java
@@ -27,6 +27,7 @@ import org.apache.doris.analysis.SlotRef;
 import org.apache.doris.analysis.TableRef;
 import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.KeysType;
+import org.apache.doris.catalog.MaterializedIndexMeta;
 import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.catalog.Table;
 import org.apache.doris.common.UserException;
@@ -115,14 +116,14 @@ public class MaterializedViewSelector {
 
     private Map<Long, List<Column>> predicates(OlapScanNode scanNode) {
         // Step1: all of predicates is compensating predicates
-        Map<Long, List<Column>> candidateIndexIdToSchema = scanNode.getOlapTable().getVisibleIndexIdToSchema();
+        Map<Long, MaterializedIndexMeta> candidateIndexIdToSchema = scanNode.getOlapTable().getVisibleIndexIdToSchema();
         OlapTable table = scanNode.getOlapTable();
         Preconditions.checkState(table != null);
         String tableName = table.getName();
         // Step2: check all columns in compensating predicates are available in the view output
         checkCompensatingPredicates(columnNamesInPredicates.get(tableName), candidateIndexIdToSchema);
         // Step3: group by list in query is the subset of group by list in view or view contains no aggregation
-        checkGrouping(columnNamesInGrouping.get(tableName), candidateIndexIdToSchema, table.getKeysType());
+        checkGrouping(columnNamesInGrouping.get(tableName), candidateIndexIdToSchema);
         // Step4: aggregation functions are available in the view output
         checkAggregationFunction(aggregateColumnsInQuery.get(tableName), candidateIndexIdToSchema);
         // Step5: columns required to compute output expr are available in the view output
@@ -148,7 +149,11 @@ public class MaterializedViewSelector {
                             table);
             checkOutputColumns(columnNamesInQueryOutput.get(tableName), candidateIndexIdToSchema);
         }
-        return candidateIndexIdToSchema;
+        Map<Long, List<Column>> result = Maps.newHashMap();
+        for (Map.Entry<Long, MaterializedIndexMeta> entry : candidateIndexIdToSchema.entrySet()) {
+            result.put(entry.getKey(), entry.getValue().getSchema());
+        }
+        return result;
     }
 
     private long priorities(OlapScanNode scanNode, Map<Long, List<Column>> candidateIndexIdToSchema) {
@@ -217,8 +222,8 @@ public class MaterializedViewSelector {
                 selectedIndexId = indexId;
             } else if (rowCount == minRowCount) {
                 // check column number, select one minimum column number
-                int selectedColumnSize = olapTable.getIndexIdToSchema().get(selectedIndexId).size();
-                int currColumnSize = olapTable.getIndexIdToSchema().get(indexId).size();
+                int selectedColumnSize = olapTable.getSchemaByIndexId(selectedIndexId).size();
+                int currColumnSize = olapTable.getSchemaByIndexId(indexId).size();
                 if (currColumnSize < selectedColumnSize) {
                     selectedIndexId = indexId;
                 }
@@ -248,17 +253,17 @@ public class MaterializedViewSelector {
         return selectedIndexId;
     }
 
-    private void checkCompensatingPredicates(Set<String> columnsInPredicates,
-                                             Map<Long, List<Column>> candidateIndexIdToSchema) {
+    private void checkCompensatingPredicates(Set<String> columnsInPredicates, Map<Long, MaterializedIndexMeta>
+            candidateIndexIdToSchema) {
         // When the query statement does not contain any columns in predicates, all candidate index can pass this check
         if (columnsInPredicates == null) {
             return;
         }
-        Iterator<Map.Entry<Long, List<Column>>> iterator = candidateIndexIdToSchema.entrySet().iterator();
+        Iterator<Map.Entry<Long, MaterializedIndexMeta>> iterator = candidateIndexIdToSchema.entrySet().iterator();
         while (iterator.hasNext()) {
-            Map.Entry<Long, List<Column>> entry = iterator.next();
+            Map.Entry<Long, MaterializedIndexMeta> entry = iterator.next();
             Set<String> indexNonAggregatedColumnNames = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
-            entry.getValue().stream().filter(column -> !column.isAggregated())
+            entry.getValue().getSchema().stream().filter(column -> !column.isAggregated())
                     .forEach(column -> indexNonAggregatedColumnNames.add(column.getName()));
             if (!indexNonAggregatedColumnNames.containsAll(columnsInPredicates)) {
                 iterator.remove();
@@ -280,32 +285,34 @@ public class MaterializedViewSelector {
      * @param candidateIndexIdToSchema
      */
 
-    private void checkGrouping(Set<String> columnsInGrouping, Map<Long, List<Column>> candidateIndexIdToSchema,
-            KeysType keysType) {
-        Iterator<Map.Entry<Long, List<Column>>> iterator = candidateIndexIdToSchema.entrySet().iterator();
+    private void checkGrouping(Set<String> columnsInGrouping, Map<Long, MaterializedIndexMeta>
+            candidateIndexIdToSchema) {
+        Iterator<Map.Entry<Long, MaterializedIndexMeta>> iterator = candidateIndexIdToSchema.entrySet().iterator();
         while (iterator.hasNext()) {
-            Map.Entry<Long, List<Column>> entry = iterator.next();
+            Map.Entry<Long, MaterializedIndexMeta> entry = iterator.next();
             Set<String> indexNonAggregatedColumnNames = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
-            List<Column> candidateIndexSchema = entry.getValue();
+            MaterializedIndexMeta candidateIndexMeta = entry.getValue();
+            List<Column> candidateIndexSchema = candidateIndexMeta.getSchema();
             candidateIndexSchema.stream().filter(column -> !column.isAggregated())
                     .forEach(column -> indexNonAggregatedColumnNames.add(column.getName()));
             /*
-            If there is no aggregated column in duplicate table, the index will be SPJ.
+            If there is no aggregated column in duplicate index, the index will be SPJ.
             For example:
                 duplicate table (k1, k2, v1)
-                mv index (k1, v1)
+                duplicate mv index (k1, v1)
             When the candidate index is SPJ type, it passes the verification directly
 
-            If there is no aggregated column in aggregate index, the index will be deduplicate table.
+            If there is no aggregated column in aggregate index, the index will be deduplicate index.
             For example:
-                aggregate table (k1, k2, v1 sum)
-                mv index (k1, k2)
+                duplicate table (k1, k2, v1 sum)
+                aggregate mv index (k1, k2)
             This kind of index is SPJG which same as select k1, k2 from aggregate_table group by k1, k2.
             It also need to check the grouping column using following steps.
 
             ISSUE-3016, MaterializedViewFunctionTest: testDeduplicateQueryInAgg
              */
-            if (indexNonAggregatedColumnNames.size() == candidateIndexSchema.size() && keysType == KeysType.DUP_KEYS) {
+            if (indexNonAggregatedColumnNames.size() == candidateIndexSchema.size()
+                    && candidateIndexMeta.getKeysType() == KeysType.DUP_KEYS) {
                 continue;
             }
             // When the query is SPJ type but the candidate index is SPJG type, it will not pass directly.
@@ -327,13 +334,13 @@ public class MaterializedViewSelector {
                           + Joiner.on(",").join(candidateIndexIdToSchema.keySet()));
     }
 
-    private void checkAggregationFunction(Set<AggregatedColumn> aggregatedColumnsInQueryOutput,
-                                          Map<Long, List<Column>> candidateIndexIdToSchema) {
-        Iterator<Map.Entry<Long, List<Column>>> iterator = candidateIndexIdToSchema.entrySet().iterator();
+    private void checkAggregationFunction(Set<AggregatedColumn> aggregatedColumnsInQueryOutput, Map<Long,
+            MaterializedIndexMeta> candidateIndexIdToSchema) {
+        Iterator<Map.Entry<Long, MaterializedIndexMeta>> iterator = candidateIndexIdToSchema.entrySet().iterator();
         while (iterator.hasNext()) {
-            Map.Entry<Long, List<Column>> entry = iterator.next();
+            Map.Entry<Long, MaterializedIndexMeta> entry = iterator.next();
             List<AggregatedColumn> indexAggregatedColumns = Lists.newArrayList();
-            List<Column> candidateIndexSchema = entry.getValue();
+            List<Column> candidateIndexSchema = entry.getValue().getSchema();
             candidateIndexSchema.stream().filter(column -> column.isAggregated())
                     .forEach(column -> indexAggregatedColumns.add(
                             new AggregatedColumn(column.getName(), column.getAggregationType().name())));
@@ -363,16 +370,16 @@ public class MaterializedViewSelector {
                           + Joiner.on(",").join(candidateIndexIdToSchema.keySet()));
     }
 
-    private void checkOutputColumns(Set<String> columnNamesInQueryOutput,
-                                    Map<Long, List<Column>> candidateIndexIdToSchema) {
+    private void checkOutputColumns(Set<String> columnNamesInQueryOutput, Map<Long, MaterializedIndexMeta>
+            candidateIndexIdToSchema) {
         if (columnNamesInQueryOutput == null) {
             return;
         }
-        Iterator<Map.Entry<Long, List<Column>>> iterator = candidateIndexIdToSchema.entrySet().iterator();
+        Iterator<Map.Entry<Long, MaterializedIndexMeta>> iterator = candidateIndexIdToSchema.entrySet().iterator();
         while (iterator.hasNext()) {
-            Map.Entry<Long, List<Column>> entry = iterator.next();
+            Map.Entry<Long, MaterializedIndexMeta> entry = iterator.next();
             Set<String> indexColumnNames = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
-            List<Column> candidateIndexSchema = entry.getValue();
+            List<Column> candidateIndexSchema = entry.getValue().getSchema();
             candidateIndexSchema.stream().forEach(column -> indexColumnNames.add(column.getName()));
             // The aggregated columns in query output must be subset of the aggregated columns in view
             if (!indexColumnNames.containsAll(columnNamesInQueryOutput)) {
@@ -383,13 +390,13 @@ public class MaterializedViewSelector {
                           + Joiner.on(",").join(candidateIndexIdToSchema.keySet()));
     }
 
-    private void compensateCandidateIndex(Map<Long, List<Column>> candidateIndexIdToSchema,
-                                 Map<Long, List<Column>> allVisibleIndexes,
+    private void compensateCandidateIndex(Map<Long, MaterializedIndexMeta> candidateIndexIdToSchema, Map<Long,
+            MaterializedIndexMeta> allVisibleIndexes,
                                  OlapTable table) {
         isPreAggregation = false;
         reasonOfDisable = "The aggregate operator does not match";
         int keySizeOfBaseIndex = table.getKeyColumnsByIndexId(table.getBaseIndexId()).size();
-        for (Map.Entry<Long, List<Column>> index : allVisibleIndexes.entrySet()) {
+        for (Map.Entry<Long, MaterializedIndexMeta> index : allVisibleIndexes.entrySet()) {
             long mvIndexId = index.getKey();
             if (table.getKeyColumnsByIndexId(mvIndexId).size() == keySizeOfBaseIndex) {
                 candidateIndexIdToSchema.put(mvIndexId, index.getValue());

--- a/fe/src/main/java/org/apache/doris/planner/OlapTableSink.java
+++ b/fe/src/main/java/org/apache/doris/planner/OlapTableSink.java
@@ -25,6 +25,7 @@ import org.apache.doris.catalog.DistributionInfo;
 import org.apache.doris.catalog.HashDistributionInfo;
 import org.apache.doris.catalog.MaterializedIndex;
 import org.apache.doris.catalog.MaterializedIndex.IndexExtState;
+import org.apache.doris.catalog.MaterializedIndexMeta;
 import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.catalog.Partition;
 import org.apache.doris.catalog.PartitionKey;
@@ -170,11 +171,12 @@ public class OlapTableSink extends DataSink {
             schemaParam.addToSlot_descs(slotDesc.toThrift());
         }
 
-        for (Map.Entry<Long, List<Column>> pair : table.getIndexIdToSchema().entrySet()) {
+        for (Map.Entry<Long, MaterializedIndexMeta> pair : table.getIndexIdToMeta().entrySet()) {
+            MaterializedIndexMeta indexMeta = pair.getValue();
             List<String> columns = Lists.newArrayList();
-            columns.addAll(pair.getValue().stream().map(Column::getName).collect(Collectors.toList()));
+            columns.addAll(indexMeta.getSchema().stream().map(Column::getName).collect(Collectors.toList()));
             TOlapTableIndexSchema indexSchema = new TOlapTableIndexSchema(pair.getKey(), columns,
-                    table.getSchemaHashByIndexId(pair.getKey()));
+                    indexMeta.getSchemaHash());
             schemaParam.addToIndexes(indexSchema);
         }
         return schemaParam;

--- a/fe/src/main/java/org/apache/doris/planner/RollupSelector.java
+++ b/fe/src/main/java/org/apache/doris/planner/RollupSelector.java
@@ -84,8 +84,8 @@ public final class RollupSelector {
                 selectedIndexId = indexId;
             } else if (rowCount == minRowCount) {
                 // check column number, select one minimum column number
-                int selectedColumnSize = table.getIndexIdToSchema().get(selectedIndexId).size();
-                int currColumnSize = table.getIndexIdToSchema().get(indexId).size();
+                int selectedColumnSize = table.getSchemaByIndexId(selectedIndexId).size();
+                int currColumnSize = table.getSchemaByIndexId(indexId).size();
                 if (currColumnSize < selectedColumnSize) {
                     selectedIndexId = indexId;
                 }

--- a/fe/src/main/java/org/apache/doris/task/HadoopLoadPendingTask.java
+++ b/fe/src/main/java/org/apache/doris/task/HadoopLoadPendingTask.java
@@ -24,6 +24,7 @@ import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.DistributionInfo;
 import org.apache.doris.catalog.HashDistributionInfo;
 import org.apache.doris.catalog.KeysType;
+import org.apache.doris.catalog.MaterializedIndexMeta;
 import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.catalog.Partition;
 import org.apache.doris.catalog.PartitionInfo;
@@ -180,10 +181,11 @@ public class HadoopLoadPendingTask extends LoadPendingTask {
         Map<String, EtlIndex> etlIndices = Maps.newHashMap();
 
         TableLoadInfo tableLoadInfo = job.getTableLoadInfo(table.getId());
-        for (Entry<Long, List<Column>> entry : table.getIndexIdToSchema().entrySet()) {
+        for (Entry<Long, MaterializedIndexMeta> entry : table.getIndexIdToMeta().entrySet()) {
             long indexId = entry.getKey();
+            MaterializedIndexMeta indexMeta = entry.getValue();
 
-            List<Column> indexColumns = entry.getValue();
+            List<Column> indexColumns = indexMeta.getSchema();
 
             Partition partition = table.getPartition(partitionId);
             if (partition == null) {
@@ -196,7 +198,7 @@ public class HadoopLoadPendingTask extends LoadPendingTask {
             etlIndex.setIndexId(indexId);
 
             // schema hash
-            int schemaHash = table.getSchemaHashByIndexId(indexId);
+            int schemaHash = indexMeta.getSchemaHash();
             etlIndex.setSchemaHash(schemaHash);
             tableLoadInfo.addIndexSchemaHash(indexId, schemaHash);
 

--- a/fe/src/main/java/org/apache/doris/transaction/TransactionState.java
+++ b/fe/src/main/java/org/apache/doris/transaction/TransactionState.java
@@ -452,7 +452,7 @@ public class TransactionState implements Writable {
         }
         // always rewrite the index ids
         indexIds.clear();
-        for (Long indexId : table.getIndexIdToSchema().keySet()) {
+        for (Long indexId : table.getIndexIdToMeta().keySet()) {
             indexIds.add(indexId);
         }
     }

--- a/fe/src/test/java/org/apache/doris/analysis/AccessTestUtil.java
+++ b/fe/src/test/java/org/apache/doris/analysis/AccessTestUtil.java
@@ -40,6 +40,7 @@ import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.persist.EditLog;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.system.SystemInfoService;
+import org.apache.doris.thrift.TStorageType;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
@@ -98,9 +99,12 @@ public class AccessTestUtil {
             RandomDistributionInfo distributionInfo = new RandomDistributionInfo(10);
             Partition partition = new Partition(20000L, "testTbl", baseIndex, distributionInfo);
             List<Column> baseSchema = new LinkedList<Column>();
+            Column column = new Column();
+            baseSchema.add(column);
             OlapTable table = new OlapTable(30000, "testTbl", baseSchema,
                     KeysType.AGG_KEYS, new SinglePartitionInfo(), distributionInfo);
-            table.setIndexSchemaInfo(baseIndex.getId(), "testTbl", baseSchema, 0, 1, (short) 1);
+            table.setIndexMeta(baseIndex.getId(), "testTbl", baseSchema, 0, 1, (short) 1,
+                    TStorageType.COLUMN, KeysType.AGG_KEYS);
             table.addPartition(partition);
             table.setBaseIndexId(baseIndex.getId());
             db.createTable(table);

--- a/fe/src/test/java/org/apache/doris/backup/CatalogMocker.java
+++ b/fe/src/test/java/org/apache/doris/backup/CatalogMocker.java
@@ -17,7 +17,6 @@
 
 package org.apache.doris.backup;
 
-import mockit.Expectations;
 import org.apache.doris.analysis.PartitionValue;
 import org.apache.doris.catalog.AggregateType;
 import org.apache.doris.catalog.Catalog;
@@ -63,6 +62,8 @@ import com.google.common.collect.Range;
 
 import java.util.List;
 import java.util.Map;
+
+import mockit.Expectations;
 
 public class CatalogMocker {
     // user
@@ -255,8 +256,8 @@ public class CatalogMocker {
         tablet0.addReplica(replica1);
         tablet0.addReplica(replica2);
 
-        olapTable.setIndexSchemaInfo(TEST_TBL_ID, TEST_TBL_NAME, TEST_TBL_BASE_SCHEMA, 0, SCHEMA_HASH, (short) 1);
-        olapTable.setStorageTypeToIndex(TEST_TBL_ID, TStorageType.COLUMN);
+        olapTable.setIndexMeta(TEST_TBL_ID, TEST_TBL_NAME, TEST_TBL_BASE_SCHEMA, 0, SCHEMA_HASH, (short) 1,
+                TStorageType.COLUMN, KeysType.AGG_KEYS);
         olapTable.addPartition(partition);
         db.createTable(olapTable);
 
@@ -340,8 +341,8 @@ public class CatalogMocker {
         baseTabletP2.addReplica(replica8);
 
 
-        olapTable2.setIndexSchemaInfo(TEST_TBL2_ID, TEST_TBL2_NAME, TEST_TBL_BASE_SCHEMA, 0, SCHEMA_HASH, (short) 1);
-        olapTable2.setStorageTypeToIndex(TEST_TBL2_ID, TStorageType.COLUMN);
+        olapTable2.setIndexMeta(TEST_TBL2_ID, TEST_TBL2_NAME, TEST_TBL_BASE_SCHEMA, 0, SCHEMA_HASH, (short) 1,
+                TStorageType.COLUMN, KeysType.AGG_KEYS);
         olapTable2.addPartition(partition1);
         olapTable2.addPartition(partition2);
 
@@ -378,9 +379,8 @@ public class CatalogMocker {
 
         partition2.createRollupIndex(rollupIndexP2);
 
-        olapTable2.setIndexSchemaInfo(TEST_ROLLUP_ID, TEST_ROLLUP_NAME, TEST_ROLLUP_SCHEMA, 0, ROLLUP_SCHEMA_HASH,
-                                      (short) 1);
-        olapTable2.setStorageTypeToIndex(TEST_ROLLUP_ID, TStorageType.COLUMN);
+        olapTable2.setIndexMeta(TEST_ROLLUP_ID, TEST_ROLLUP_NAME, TEST_ROLLUP_SCHEMA, 0, ROLLUP_SCHEMA_HASH,
+                                      (short) 1, TStorageType.COLUMN, KeysType.AGG_KEYS);
         db.createTable(olapTable2);
 
         return db;

--- a/fe/src/test/java/org/apache/doris/catalog/CatalogTestUtil.java
+++ b/fe/src/test/java/org/apache/doris/catalog/CatalogTestUtil.java
@@ -29,6 +29,7 @@ import org.apache.doris.system.Backend;
 import org.apache.doris.system.SystemInfoService;
 import org.apache.doris.thrift.TDisk;
 import org.apache.doris.thrift.TStorageMedium;
+import org.apache.doris.thrift.TStorageType;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -218,7 +219,8 @@ public class CatalogTestUtil {
         OlapTable table = new OlapTable(tableId, testTable1, columns, KeysType.AGG_KEYS, partitionInfo,
                 distributionInfo);
         table.addPartition(partition);
-        table.setIndexSchemaInfo(indexId, testIndex1, columns, 0, testSchemaHash1, (short) 1);
+        table.setIndexMeta(indexId, testIndex1, columns, 0, testSchemaHash1, (short) 1,
+                TStorageType.COLUMN, KeysType.AGG_KEYS);
         table.setBaseIndexId(indexId);
         // db
         Database db = new Database(dbId, testDb1);

--- a/fe/src/test/java/org/apache/doris/catalog/DatabaseTest.java
+++ b/fe/src/test/java/org/apache/doris/catalog/DatabaseTest.java
@@ -157,9 +157,10 @@ public class DatabaseTest {
         // db2
         Database db2 = new Database(2, "db2");
         List<Column> columns = new ArrayList<Column>();
-        columns.add(new Column("column2", 
-                        ScalarType.createType(PrimitiveType.TINYINT), false, AggregateType.MIN, "", ""));
-        columns.add(new Column("column3", 
+        Column column2 = new Column("column2",
+                ScalarType.createType(PrimitiveType.TINYINT), false, AggregateType.MIN, "", "");
+        columns.add(column2);
+        columns.add(new Column("column3",
                         ScalarType.createType(PrimitiveType.SMALLINT), false, AggregateType.SUM, "", ""));
         columns.add(new Column("column4", 
                         ScalarType.createType(PrimitiveType.INT), false, AggregateType.REPLACE, "", ""));
@@ -178,13 +179,15 @@ public class DatabaseTest {
         Partition partition = new Partition(20000L, "table", index, new RandomDistributionInfo(10));
         OlapTable table = new OlapTable(1000, "table", columns, KeysType.AGG_KEYS,
                                         new SinglePartitionInfo(), new RandomDistributionInfo(10));
+        short shortKeyColumnCount = 1;
+        table.setIndexMeta(1000, "group1", columns, 1,1,shortKeyColumnCount,TStorageType.COLUMN, KeysType.AGG_KEYS);
+
         List<Column> column = Lists.newArrayList();
-        short schemaHash = 1;
-        table.setIndexSchemaInfo(new Long(1), "test", column, 1, 1, schemaHash);
+        column.add(column2);
+        table.setIndexMeta(new Long(1), "test", column, 1, 1, shortKeyColumnCount,
+                TStorageType.COLUMN, KeysType.AGG_KEYS);
+        table.setIndexMeta(new Long(1), "test", column, 1, 1, shortKeyColumnCount, TStorageType.COLUMN, KeysType.AGG_KEYS);
         Deencapsulation.setField(table, "baseIndexId", 1);
-        Map<Long, TStorageType> indexIdToStorageType = Maps.newHashMap();
-        indexIdToStorageType.put(new Long(1), TStorageType.COLUMN);
-        Deencapsulation.setField(table, "indexIdToStorageType", indexIdToStorageType);
         table.addPartition(partition);
         db2.createTable(table);
         db2.write(dos);

--- a/fe/src/test/java/org/apache/doris/catalog/MaterializedIndexMetaTest.java
+++ b/fe/src/test/java/org/apache/doris/catalog/MaterializedIndexMetaTest.java
@@ -1,0 +1,69 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.catalog;
+
+import org.apache.doris.thrift.TStorageType;
+
+import com.google.common.collect.Lists;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.List;
+
+public class MaterializedIndexMetaTest {
+
+    private static String fileName = "./MaterializedIndexMetaSerializeTest";
+
+    @After
+    public void tearDown() {
+        File file = new File(fileName);
+        file.delete();
+    }
+
+    @Test
+    public void testSerializeMaterializedIndexMeta() throws IOException {
+        // 1. Write objects to file
+        File file = new File(fileName);
+        file.createNewFile();
+        DataOutputStream out = new DataOutputStream(new FileOutputStream(file));
+
+        List<Column> schema = Lists.newArrayList();
+        Column column = new Column("k1", Type.INT, true, null, true, "1", "");
+        schema.add(column);
+        short shortKeyColumnCount = 1;
+        MaterializedIndexMeta indexMeta = new MaterializedIndexMeta(1, "test", schema, 1, 1, shortKeyColumnCount,
+                TStorageType.COLUMN, KeysType.DUP_KEYS);
+        indexMeta.write(out);
+        out.flush();
+        out.close();
+
+        // 2. Read objects from file
+        DataInputStream in = new DataInputStream(new FileInputStream(file));
+
+        MaterializedIndexMeta readIndexMeta = MaterializedIndexMeta.read(in);
+        Assert.assertEquals(indexMeta, readIndexMeta);
+    }
+}

--- a/fe/src/test/java/org/apache/doris/catalog/TempPartitionTest.java
+++ b/fe/src/test/java/org/apache/doris/catalog/TempPartitionTest.java
@@ -558,7 +558,7 @@ public class TempPartitionTest {
     
     private void testSerializeOlapTable(OlapTable tbl) throws IOException, AnalysisException {
         MetaContext metaContext = new MetaContext();
-        metaContext.setMetaVersion(FeMetaVersion.VERSION_74);
+        metaContext.setMetaVersion(FeMetaVersion.VERSION_75);
         metaContext.setThreadLocalInfo();
 
         // 1. Write objects to file

--- a/fe/src/test/java/org/apache/doris/common/util/UnitTestUtil.java
+++ b/fe/src/test/java/org/apache/doris/common/util/UnitTestUtil.java
@@ -115,8 +115,8 @@ public class UnitTestUtil {
                                         KeysType.AGG_KEYS, partitionInfo, distributionInfo);
         Deencapsulation.setField(table, "baseIndexId", indexId);
         table.addPartition(partition);
-        table.setIndexSchemaInfo(indexId, TABLE_NAME, columns, 0, SCHEMA_HASH, (short) 1);
-        table.setStorageTypeToIndex(indexId, TStorageType.COLUMN);
+        table.setIndexMeta(indexId, TABLE_NAME, columns, 0, SCHEMA_HASH, (short) 1, TStorageType.COLUMN,
+                KeysType.AGG_KEYS);
 
         // db
         Database db = new Database(dbId, DB_NAME);

--- a/fe/src/test/java/org/apache/doris/http/DorisHttpTestCase.java
+++ b/fe/src/test/java/org/apache/doris/http/DorisHttpTestCase.java
@@ -46,6 +46,7 @@ import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.system.Backend;
 import org.apache.doris.system.SystemInfoService;
 import org.apache.doris.thrift.TStorageMedium;
+import org.apache.doris.thrift.TStorageType;
 
 import com.google.common.collect.Lists;
 
@@ -154,7 +155,8 @@ abstract public class DorisHttpTestCase {
         OlapTable table = new OlapTable(testTableId, name, columns, KeysType.AGG_KEYS, partitionInfo,
                 distributionInfo);
         table.addPartition(partition);
-        table.setIndexSchemaInfo(testIndexId, "testIndex", columns, 0, testSchemaHash, (short) 1);
+        table.setIndexMeta(testIndexId, "testIndex", columns, 0, testSchemaHash, (short) 1, TStorageType.COLUMN,
+                KeysType.AGG_KEYS);
         table.setBaseIndexId(testIndexId);
         return table;
     }

--- a/fe/src/test/java/org/apache/doris/persist/CreateTableInfoTest.java
+++ b/fe/src/test/java/org/apache/doris/persist/CreateTableInfoTest.java
@@ -72,9 +72,10 @@ public class CreateTableInfoTest {
         DataOutputStream dos = new DataOutputStream(new FileOutputStream(file));
         
         List<Column> columns = new ArrayList<Column>();
-        columns.add(new Column("column2", 
-                        ScalarType.createType(PrimitiveType.TINYINT), false, AggregateType.MIN, "", ""));
-        columns.add(new Column("column3", 
+        Column column2 = new Column("column2",
+                ScalarType.createType(PrimitiveType.TINYINT), false, AggregateType.MIN, "", "");
+        columns.add(column2);
+        columns.add(new Column("column3",
                         ScalarType.createType(PrimitiveType.SMALLINT), false, AggregateType.SUM, "", ""));
         columns.add(new Column("column4", 
                         ScalarType.createType(PrimitiveType.INT), false, AggregateType.REPLACE, "", ""));
@@ -94,13 +95,14 @@ public class CreateTableInfoTest {
         Partition partition = new Partition(20000L, "table", index, distributionInfo);
         OlapTable table = new OlapTable(1000L, "table", columns, KeysType.AGG_KEYS, 
                                         new SinglePartitionInfo(), distributionInfo);
+        short shortKeyColumnCount = 1;
+        table.setIndexMeta(1000, "group1", columns, 1,1,shortKeyColumnCount,TStorageType.COLUMN, KeysType.AGG_KEYS);
+
         List<Column> column = Lists.newArrayList();
-        short schemaHash = 1;
-        table.setIndexSchemaInfo(new Long(1), "test", column, 1, 1, schemaHash);
-        Deencapsulation.setField(table, "baseIndexId", 1);
-        Map<Long, TStorageType> indexIdToStorageType = Maps.newHashMap();
-        indexIdToStorageType.put(new Long(1), TStorageType.COLUMN);
-        Deencapsulation.setField(table, "indexIdToStorageType", indexIdToStorageType);
+        column.add(column2);
+        table.setIndexMeta(new Long(1), "test", column, 1, 1, shortKeyColumnCount,
+                TStorageType.COLUMN, KeysType.AGG_KEYS);
+        Deencapsulation.setField(table, "baseIndexId", 1000);
         table.addPartition(partition);
         CreateTableInfo info = new CreateTableInfo("db1", table);
         info.write(dos);


### PR DESCRIPTION
Firstly, add materialized index meta in olap table

The materialized index meta include index name, schema, schemahash, keystype etc.
The information itself scattered in each map is encapsulated into MaterializedIndexMeta.

Also the keys type of index meta maybe not same as keys type of base index after materialized view enabled.

Secondly, support the deduplicate mv.
If there is group by or aggregation function in create mv stmt, the keys type of mv is agg.
At the same time, the keys type of base table is duplicate.
For example
Duplicate table (k1, k2, v1)
MV (k1, k2) group by k1, k2
It should be aggregated during executing mv.