### PR TITLE
Write delete predicate into RowsetMeta upon upgrade from Doris-0.10 to Doris-0.11

### DIFF
--- a/be/src/olap/olap_snapshot_converter.cpp
+++ b/be/src/olap/olap_snapshot_converter.cpp
@@ -144,12 +144,13 @@ OLAPStatus OlapSnapshotConverter::to_tablet_meta_pb(const OLAPHeaderMessage& ola
         // PDelta is not corresponding with RowsetMeta in DeletePredicate
         // Add delete predicate to PDelta from OLAPHeaderMessage.
         // Only after this, convert from PDelta to RowsetMeta is valid.
-        for (auto& del_pred : delete_conditions) {
-            if (temp_delta.start_version() == temp_delta.end_version()
-                && temp_delta.start_version() == del_pred.version()) {
+        if (temp_delta.start_version() == temp_delta.end_version()) {
+            for (auto& del_pred : delete_conditions) {
+                if (temp_delta.start_version() == del_pred.version()) {
                     DeletePredicatePB* delete_condition = temp_delta.mutable_delete_condition();
                     *delete_condition = del_pred;
                 }
+            }
         }
         convert_to_rowset_meta(temp_delta, next_id, olap_header.tablet_id(), olap_header.schema_hash(), rowset_meta);
         Version rowset_version = { temp_delta.start_version(), temp_delta.end_version() };
@@ -168,12 +169,13 @@ OLAPStatus OlapSnapshotConverter::to_tablet_meta_pb(const OLAPHeaderMessage& ola
         RowsetId next_id = StorageEngine::instance()->next_rowset_id();
         RowsetMetaPB* rowset_meta = tablet_meta_pb->add_inc_rs_metas();
         PDelta temp_inc_delta = inc_delta;
-        for (auto& del_pred : delete_conditions) {
-            if (temp_inc_delta.start_version() == temp_inc_delta.end_version()
-                && temp_inc_delta.start_version() == del_pred.version()) {
+        if (temp_inc_delta.start_version() == temp_inc_delta.end_version()) {
+            for (auto& del_pred : delete_conditions) {
+                if (temp_inc_delta.start_version() == del_pred.version()) {
                     DeletePredicatePB* delete_condition = temp_inc_delta.mutable_delete_condition();
                     *delete_condition = del_pred;
                 }
+            }
         }
         convert_to_rowset_meta(temp_inc_delta, next_id, olap_header.tablet_id(), olap_header.schema_hash(), rowset_meta);
     }

--- a/be/src/olap/olap_snapshot_converter.h
+++ b/be/src/olap/olap_snapshot_converter.h
@@ -47,7 +47,7 @@ public:
     // convert olap header to tablet meta pb, convert delta to rowsetmetapb
     // pending delta is not in tablet meta any more, so that convert pending delta to rowset and add it to pending rowsets
     // as a return value
-    OLAPStatus to_tablet_meta_pb(const OLAPHeaderMessage& olap_header, TabletMetaPB* tablet_meta_pb, 
+    OLAPStatus to_tablet_meta_pb(const OLAPHeaderMessage& olap_header, TabletMetaPB* tablet_meta_pb,
                                  vector<RowsetMetaPB>* pending_rowsets);
 
     OLAPStatus convert_to_pdelta(const RowsetMetaPB& rowset_meta_pb, PDelta* delta);
@@ -67,8 +67,8 @@ public:
     OLAPStatus to_alter_tablet_pb(const SchemaChangeStatusMessage& schema_change_msg, AlterTabletPB* alter_tablet_pb);
 
     // from olap header to tablet meta
-    OLAPStatus to_new_snapshot(const OLAPHeaderMessage& olap_header, const string& old_data_path_prefix, 
-        const string& new_data_path_prefix, TabletMetaPB* tablet_meta_pb,
+    OLAPStatus to_new_snapshot(const OLAPHeaderMessage& olap_header, const string& old_data_path_prefix,
+        const string& new_data_path_prefix, TabletMetaPB* tablet_meta_pb, 
         vector<RowsetMetaPB>* pending_rowsets, bool is_startup);
 
     // from tablet meta to olap header

--- a/be/src/olap/task/engine_clone_task.cpp
+++ b/be/src/olap/task/engine_clone_task.cpp
@@ -602,8 +602,8 @@ OLAPStatus EngineCloneTask::_convert_to_new_snapshot(const string& clone_dir, in
     OlapSnapshotConverter converter;
     TabletMetaPB tablet_meta_pb;
     vector<RowsetMetaPB> pending_rowsets;
-    res = converter.to_new_snapshot(olap_header_msg, clone_dir, clone_dir, &tablet_meta_pb,
-        &pending_rowsets, false);
+    res = converter.to_new_snapshot(olap_header_msg, clone_dir, clone_dir,
+                                    &tablet_meta_pb, &pending_rowsets, false);
     if (res != OLAP_SUCCESS) {
         LOG(WARNING) << "fail to convert snapshot to new format. dir='" << clone_dir;
         return res;


### PR DESCRIPTION
If delete predicate exists in meta in Doris-0.10, all of this predicates should
be remained. There is an confused place in Doris-0.10. The delete predicate
only exists in OLAPHeaderMessage and PPendingDelta, not in PDelta.
This trick results this bug.