### PR TITLE
[Bug] Fix bug that index name in MaterializedViewMeta is not changed after schema change

### DIFF
--- a/env.sh
+++ b/env.sh
@@ -99,4 +99,3 @@ if ! ${CMAKE_CMD} --version; then
     exit 1
 fi
 export CMAKE_CMD
-

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -38,6 +38,7 @@ under the License.
         <maven.compiler.target>1.8</maven.compiler.target>
         <jprotobuf.version>2.2.11</jprotobuf.version>
         <skip.plugin>false</skip.plugin>
+        <fe_ut_parallel>${env.FE_UT_PARALLEL}</fe_ut_parallel>
     </properties>
 
     <profiles>
@@ -608,7 +609,7 @@ under the License.
                 <version>2.22.2</version>
                 <configuration>
                     <!-->set larger, eg, 3, to reduce the time or running FE unit tests<-->
-                    <forkCount>1</forkCount>
+                    <forkCount>${fe_ut_parallel}</forkCount>
                     <!-->not reuse forked jvm, so that each unit test will run in separate jvm. to avoid singleton confict<-->
                     <reuseForks>false</reuseForks>
                     <argLine>

--- a/fe/src/main/cup/sql_parser.cup
+++ b/fe/src/main/cup/sql_parser.cup
@@ -28,7 +28,6 @@ import org.apache.doris.analysis.SetOperationStmt.Operation;
 import org.apache.doris.analysis.SetOperationStmt.SetOperand;
 import org.apache.doris.catalog.AccessPrivilege;
 import org.apache.doris.catalog.AggregateType;
-import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.KeysType;
 import org.apache.doris.catalog.PrimitiveType;
 import org.apache.doris.catalog.ScalarType;
@@ -1527,6 +1526,7 @@ recover_stmt ::=
     ;
 
 opt_agg_type ::=
+    /* not set */
     {: RESULT = null; :}
     | KW_SUM
     {:

--- a/fe/src/main/java/org/apache/doris/alter/SchemaChangeHandler.java
+++ b/fe/src/main/java/org/apache/doris/alter/SchemaChangeHandler.java
@@ -1076,7 +1076,7 @@ public class SchemaChangeHandler extends AlterHandler {
             while (currentSchemaHash == newSchemaHash) {
                 newSchemaHash = Util.generateSchemaHash();
             }
-            String newIndexName = SHADOW_NAME_PRFIX + currentIndexMeta.getIndexName();
+            String newIndexName = SHADOW_NAME_PRFIX + olapTable.getIndexNameById(originIndexId);
             short newShortKeyColumnCount = indexIdToShortKeyColumnCount.get(originIndexId);
             long shadowIndexId = catalog.getNextId();
 

--- a/fe/src/main/java/org/apache/doris/analysis/ColumnDef.java
+++ b/fe/src/main/java/org/apache/doris/analysis/ColumnDef.java
@@ -106,7 +106,7 @@ public class ColumnDef {
     public String getDefaultValue() { return defaultValue.value; }
     public String getName() { return name; }
     public AggregateType getAggregateType() { return aggregateType; }
-    public void setAggregateType(AggregateType aggregateType, boolean xxx) { this.aggregateType = aggregateType; }
+    public void setAggregateType(AggregateType aggregateType) { this.aggregateType = aggregateType; }
     public boolean isKey() { return isKey; }
     public void setIsKey(boolean isKey) { this.isKey = isKey; }
     public TypeDef getTypeDef() { return typeDef; }

--- a/fe/src/main/java/org/apache/doris/analysis/CreateTableStmt.java
+++ b/fe/src/main/java/org/apache/doris/analysis/CreateTableStmt.java
@@ -304,7 +304,7 @@ public class CreateTableStmt extends DdlStmt {
                         type = AggregateType.NONE;
                     }
                     for (int i = keysDesc.keysColumnSize(); i < columnDefs.size(); ++i) {
-                        columnDefs.get(i).setAggregateType(type, true);
+                        columnDefs.get(i).setAggregateType(type);
                     }
                 }
             }

--- a/fe/src/main/java/org/apache/doris/catalog/Catalog.java
+++ b/fe/src/main/java/org/apache/doris/catalog/Catalog.java
@@ -4121,7 +4121,7 @@ public class Catalog {
                 }
                 MaterializedIndexMeta materializedIndexMeta = entry.getValue();
                 sb = new StringBuilder();
-                String indexName = materializedIndexMeta.getIndexName();
+                String indexName = olapTable.getIndexNameById(entry.getKey());
                 sb.append("ALTER TABLE ").append(table.getName()).append(" ADD ROLLUP ").append(indexName);
                 sb.append("(");
 

--- a/fe/src/main/java/org/apache/doris/catalog/Column.java
+++ b/fe/src/main/java/org/apache/doris/catalog/Column.java
@@ -255,7 +255,9 @@ public class Column implements Writable {
             throw new DdlException("Can not change " + getDataType() + " to " + other.getDataType());
         }
 
-        if (this.aggregationType != other.aggregationType) {
+        if (this.aggregationType != other.aggregationType
+                && !(this.aggregationType == null && other.aggregationType == AggregateType.NONE)
+                && !(this.aggregationType == AggregateType.NONE && other.aggregationType == null)) {
             throw new DdlException("Can not change aggregation type");
         }
 

--- a/fe/src/main/java/org/apache/doris/catalog/Column.java
+++ b/fe/src/main/java/org/apache/doris/catalog/Column.java
@@ -255,9 +255,7 @@ public class Column implements Writable {
             throw new DdlException("Can not change " + getDataType() + " to " + other.getDataType());
         }
 
-        if (this.aggregationType != other.aggregationType
-                && !(this.aggregationType == null && other.aggregationType == AggregateType.NONE)
-                && !(this.aggregationType == AggregateType.NONE && other.aggregationType == null)) {
+        if (this.aggregationType != other.aggregationType) {
             throw new DdlException("Can not change aggregation type");
         }
 

--- a/fe/src/main/java/org/apache/doris/catalog/MaterializedIndexMeta.java
+++ b/fe/src/main/java/org/apache/doris/catalog/MaterializedIndexMeta.java
@@ -34,8 +34,6 @@ import java.util.List;
 public class MaterializedIndexMeta implements Writable {
     @SerializedName(value = "indexId")
     private long indexId;
-    @SerializedName(value = "indexName")
-    private String indexName;
     @SerializedName(value = "schema")
     private List<Column> schema = Lists.newArrayList();
     @SerializedName(value = "schemaVersion")
@@ -49,11 +47,9 @@ public class MaterializedIndexMeta implements Writable {
     @SerializedName(value = "keysType")
     private KeysType keysType;
 
-    public MaterializedIndexMeta(long indexId, String indexName, List<Column> schema, int schemaVersion, int
+    public MaterializedIndexMeta(long indexId, List<Column> schema, int schemaVersion, int
             schemaHash, short shortKeyColumnCount, TStorageType storageType, KeysType keysType) {
         this.indexId = indexId;
-        Preconditions.checkState(indexName != null);
-        this.indexName = indexName;
         Preconditions.checkState(schema != null);
         Preconditions.checkState(schema.size() != 0);
         this.schema = schema;
@@ -68,10 +64,6 @@ public class MaterializedIndexMeta implements Writable {
 
     public long getIndexId() {
         return indexId;
-    }
-
-    public String getIndexName() {
-        return indexName;
     }
 
     public KeysType getKeysType() {
@@ -109,9 +101,6 @@ public class MaterializedIndexMeta implements Writable {
         }
         MaterializedIndexMeta indexMeta = (MaterializedIndexMeta) obj;
         if (indexMeta.indexId != this.indexId) {
-            return false;
-        }
-        if (!indexMeta.indexName.equals(this.indexName)) {
             return false;
         }
         if (indexMeta.schema.size() != this.schema.size() || !indexMeta.schema.containsAll(this.schema)) {

--- a/fe/src/main/java/org/apache/doris/common/proc/IndexInfoProcDir.java
+++ b/fe/src/main/java/org/apache/doris/common/proc/IndexInfoProcDir.java
@@ -84,7 +84,7 @@ public class IndexInfoProcDir implements ProcDirInterface {
                     builder.append(Joiner.on(", ").join(columnNames)).append(")");
 
                     result.addRow(Lists.newArrayList(String.valueOf(indexId),
-                            indexMeta.getIndexName(),
+                            olapTable.getIndexNameById(indexId),
                             String.valueOf(indexMeta.getSchemaVersion()),
                             String.valueOf(indexMeta.getSchemaHash()),
                             String.valueOf(indexMeta.getShortKeyColumnCount()),

--- a/fe/src/main/java/org/apache/doris/http/rest/StorageTypeCheckAction.java
+++ b/fe/src/main/java/org/apache/doris/http/rest/StorageTypeCheckAction.java
@@ -80,7 +80,7 @@ public class StorageTypeCheckAction extends RestBaseAction {
                 for (Map.Entry<Long, MaterializedIndexMeta> entry : olapTbl.getIndexIdToMeta().entrySet()) {
                     MaterializedIndexMeta indexMeta = entry.getValue();
                     if (indexMeta.getStorageType() == TStorageType.ROW) {
-                        indexObj.put(indexMeta.getIndexName(), indexMeta.getStorageType().name());
+                        indexObj.put(olapTbl.getIndexNameById(entry.getKey()), indexMeta.getStorageType().name());
                     }
                 }
                 root.put(tbl.getName(), indexObj);

--- a/fe/src/main/java/org/apache/doris/load/routineload/RoutineLoadJob.java
+++ b/fe/src/main/java/org/apache/doris/load/routineload/RoutineLoadJob.java
@@ -128,7 +128,8 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback impl
         NEED_SCHEDULE,
         RUNNING,
         PAUSED,
-        STOPPED, CANCELLED;
+        STOPPED,
+        CANCELLED;
 
         public boolean isFinalState() {
             return this == STOPPED || this == CANCELLED;

--- a/fe/src/main/java/org/apache/doris/load/routineload/RoutineLoadTaskScheduler.java
+++ b/fe/src/main/java/org/apache/doris/load/routineload/RoutineLoadTaskScheduler.java
@@ -174,7 +174,7 @@ public class RoutineLoadTaskScheduler extends MasterDaemon {
             // set BE id to -1 to release the BE slot
             routineLoadTaskInfo.setBeId(-1);
             routineLoadManager.getJob(routineLoadTaskInfo.getJobId())
-                    .updateState(JobState.STOPPED,
+                    .updateState(JobState.CANCELLED,
                             new ErrorReason(InternalErrorCode.META_NOT_FOUND_ERR, "meta not found: " + e.getMessage()),
                             false);
             throw e;

--- a/fe/src/test/java/org/apache/doris/analysis/CreateMaterializedViewStmtTest.java
+++ b/fe/src/test/java/org/apache/doris/analysis/CreateMaterializedViewStmtTest.java
@@ -18,7 +18,6 @@
 package org.apache.doris.analysis;
 
 import org.apache.doris.catalog.AggregateType;
-import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.KeysType;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.UserException;
@@ -33,8 +32,6 @@ import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.List;
-
-import javax.validation.constraints.AssertTrue;
 
 import mockit.Expectations;
 import mockit.Injectable;
@@ -195,8 +192,6 @@ public class CreateMaterializedViewStmtTest {
                 result = havingClause;
                 slotRef.getColumnName();
                 result = "k1";
-                selectStmt.getGroupByClause();
-                result = null;
             }
         };
         CreateMaterializedViewStmt createMaterializedViewStmt = new CreateMaterializedViewStmt("test", selectStmt, null);
@@ -241,8 +236,6 @@ public class CreateMaterializedViewStmtTest {
                 result = "k1";
                 slotRef2.getColumnName();
                 result = "k2";
-                selectStmt.getGroupByClause();
-                result = null;
             }
         };
         CreateMaterializedViewStmt createMaterializedViewStmt = new CreateMaterializedViewStmt("test", selectStmt, null);
@@ -297,8 +290,6 @@ public class CreateMaterializedViewStmtTest {
                 result = Lists.newArrayList(slotRef2);
                 functionCallExpr.getChild(0);
                 result = slotRef2;
-                selectStmt.getGroupByClause();
-                result = groupByClause;
             }
         };
         CreateMaterializedViewStmt createMaterializedViewStmt = new CreateMaterializedViewStmt("test", selectStmt, null);
@@ -396,8 +387,6 @@ public class CreateMaterializedViewStmtTest {
                 result = Lists.newArrayList(slotRef1);
                 functionCallExpr.getChild(0);
                 result = functionChild0;
-                selectStmt.getGroupByClause();
-                result = groupByClause;
             }
         };
         CreateMaterializedViewStmt createMaterializedViewStmt = new CreateMaterializedViewStmt("test", selectStmt, null);
@@ -474,8 +463,6 @@ public class CreateMaterializedViewStmtTest {
                 result = columnName4;
                 functionChild0.getColumnName();
                 result = columnName5;
-                selectStmt.getGroupByClause();
-                result = groupByClause;
             }
         };
 
@@ -569,7 +556,7 @@ public class CreateMaterializedViewStmtTest {
                 result = 3;
                 slotRef4.getType().getStorageLayoutBytes();
                 result = 4;
-                selectStmt.getGroupByClause();
+                selectStmt.getAggInfo(); // return null, so that the mv can be a duplicate mv
                 result = null;
             }
         };
@@ -658,8 +645,6 @@ public class CreateMaterializedViewStmtTest {
                 result = columnName2;
                 functionChild0.getColumnName();
                 result = columnName3;
-                selectStmt.getGroupByClause();
-                result = groupByClause;
             }
         };
 
@@ -714,8 +699,6 @@ public class CreateMaterializedViewStmtTest {
                 result = null;
                 slotRef1.getColumnName();
                 result = columnName1;
-                selectStmt.getGroupByClause();
-                result = groupByClause;
                 selectStmt.getHavingPred();
                 result = null;
                 selectStmt.getLimit();
@@ -736,3 +719,4 @@ public class CreateMaterializedViewStmtTest {
 
     }
 }
+

--- a/fe/src/test/java/org/apache/doris/catalog/MaterializedIndexMetaTest.java
+++ b/fe/src/test/java/org/apache/doris/catalog/MaterializedIndexMetaTest.java
@@ -51,10 +51,22 @@ public class MaterializedIndexMetaTest {
         DataOutputStream out = new DataOutputStream(new FileOutputStream(file));
 
         List<Column> schema = Lists.newArrayList();
-        Column column = new Column("k1", Type.INT, true, null, true, "1", "");
-        schema.add(column);
+        schema.add(new Column("k1", Type.TINYINT, true, null, true, "1", "abc"));
+        schema.add(new Column("k2", Type.SMALLINT, true, null, true, "1", "debug"));
+        schema.add(new Column("k3", Type.INT, true, null, true, "1", ""));
+        schema.add(new Column("k4", Type.BIGINT, true, null, true, "1", "**"));
+        schema.add(new Column("k5", Type.LARGEINT, true, null, true, null, ""));
+        schema.add(new Column("k6", Type.DOUBLE, true, null, true, "1.1", ""));
+        schema.add(new Column("k7", Type.FLOAT, true, null, true, "1", ""));
+        schema.add(new Column("k8", Type.DATE, true, null, true, "1", ""));
+        schema.add(new Column("k9", Type.DATETIME, true, null, true, "1", ""));
+        schema.add(new Column("k10", Type.VARCHAR, true, null, true, "1", ""));
+        schema.add(new Column("k11", Type.DECIMALV2, true, null, true, "1", ""));
+        schema.add(new Column("k12", Type.INT, true, null, true, "1", ""));
+        schema.add(new Column("v1", Type.INT, true, AggregateType.SUM, true, "1", ""));
+        schema.add(new Column("v1", Type.VARCHAR, true, AggregateType.REPLACE, true, "1", ""));
         short shortKeyColumnCount = 1;
-        MaterializedIndexMeta indexMeta = new MaterializedIndexMeta(1, "test", schema, 1, 1, shortKeyColumnCount,
+        MaterializedIndexMeta indexMeta = new MaterializedIndexMeta(1, schema, 1, 1, shortKeyColumnCount,
                 TStorageType.COLUMN, KeysType.DUP_KEYS);
         indexMeta.write(out);
         out.flush();

--- a/run-fe-ut.sh
+++ b/run-fe-ut.sh
@@ -85,6 +85,12 @@ echo "******************************"
 cd ${DORIS_HOME}/fe/
 mkdir -p build/compile
 
+if [ -z "${FE_UT_PARALLEL}" ]; then
+    # the default fe unit test parallel is 1
+    export FE_UT_PARALLEL=1
+fi
+echo "Unit test parallel is: $FE_UT_PARALLEL"
+
 if [ ${COVERAGE} -eq 1 ]; then
     echo "Run coverage statistic"
     ant cover-test


### PR DESCRIPTION
The index name in MaterializedViewMeta is still with `__doris_shadow` prefix
after schema change finished.

In this CL, I just remove the index name field in MaterializedViewMeta,
so that it would makes managing change of names less error-prone.

This bug is introduced by PR: #3036 