### PR TITLE
Support sharding tablet_map_lock into more small map locks to make good performance for tablet manage task

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -508,6 +508,10 @@ namespace config {
     // this is a self protection to avoid too many txns saving in manager
     CONF_Int64(max_runnings_transactions, "2000");
 
+    // tablet_map_lock shard size, the value is 2^n, n=0,1,2,3,4
+    // this is a an enhancement for better performance to manage tablet
+    CONF_Int32(tablet_map_shard_size, "1");
+
 } // namespace config
 
 } // namespace doris

--- a/be/src/olap/storage_engine.cpp
+++ b/be/src/olap/storage_engine.cpp
@@ -111,7 +111,7 @@ StorageEngine::StorageEngine(const EngineOptions& options)
         _effective_cluster_id(-1),
         _is_all_cluster_id_exist(true),
         _index_stream_lru_cache(NULL),
-        _tablet_manager(new TabletManager()),
+        _tablet_manager(new TabletManager(config::tablet_map_shard_size)),
         _txn_manager(new TxnManager()),
         _rowset_id_generator(new UniqueRowsetIdGenerator(options.backend_uid)),
         _memtable_flush_executor(nullptr),

--- a/be/src/olap/tablet_manager.h
+++ b/be/src/olap/tablet_manager.h
@@ -172,6 +172,8 @@ private:
 
     void _build_tablet_stat();
 
+    void _add_tablet_to_partition(const Tablet& tablet);
+
     void _remove_tablet_from_partition(const Tablet& tablet);
 
     inline RWMutex& _get_tablet_map_lock(TTabletId tabletId);
@@ -191,12 +193,14 @@ private:
     // tablet_id -> TabletInstances
     typedef std::unordered_map<int64_t, TableInstances> tablet_map_t;
 
-    // Protect _tablet_map, _partition_tablet_map, _shutdown_tablets
     int32_t _tablet_map_lock_shard_size;
+    // _tablet_map_lock_array[i] protect _tablet_map_array[i], i=0,1,2...,and i < _tablet_map_lock_shard_size
     RWMutex *_tablet_map_lock_array;
     tablet_map_t *_tablet_map_array;
 
+    // Protect _partition_tablet_map, should not be obtained before _tablet_map_lock to avoid dead lock
     RWMutex _partition_tablet_map_lock;
+    // Protect _shutdown_tablets, should not be obtained before _tablet_map_lock to avoid dead lock
     RWMutex _shutdown_tablets_lock;
     // partition_id => tablet_info
     std::map<int64_t, std::set<TabletInfo>> _partition_tablet_map;


### PR DESCRIPTION
This PR is to enhance the peformance for tablet manage task, when there are so many tablet in doris be, the only one tablet_map_lock may cause poor performance, and now we split it into many small locks.