### PR TITLE
Fix backup job block at SNAPSHOTING phase

### DIFF
--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -1360,7 +1360,8 @@ void* TaskWorkerPool::_make_snapshot_thread_callback(void* arg_this) {
         OLAPStatus make_snapshot_status = SnapshotManager::instance()->make_snapshot(
                 snapshot_request, &snapshot_path);
         if (make_snapshot_status != OLAP_SUCCESS) {
-            status_code = TStatusCode::RUNTIME_ERROR;
+            status_code = make_snapshot_status == OLAP_ERR_VERSION_ALREADY_MERGED ? TStatusCode::OLAP_ERR_VERSION_ALREADY_MERGED :
+                    TStatusCode::RUNTIME_ERROR;
             OLAP_LOG_WARNING("make_snapshot failed. tablet_id: %ld, schema_hash: %ld, version: %d,"
                              "version_hash: %ld, status: %d",
                              snapshot_request.tablet_id, snapshot_request.schema_hash,

--- a/fe/src/main/java/org/apache/doris/backup/BackupJob.java
+++ b/fe/src/main/java/org/apache/doris/backup/BackupJob.java
@@ -146,9 +146,8 @@ public class BackupJob extends AbstractJob {
         if (request.getTask_status().getStatus_code() != TStatusCode.OK) {
             taskErrMsg.put(task.getSignature(), Joiner.on(",").join(request.getTask_status().getError_msgs()));
             // status -230 means OLAP_ERR_VERSION_ALREADY_MERGED in BE OLAPStatus
-            if (request.getTask_status().isSetError_msgs() &&
-                    request.getTask_status().getError_msgs().get(0).equals("make_snapshot failed. status: -230")) {
-                status = new Status(ErrCode.COMMON_ERROR, "make_snapshot failed");
+            if (request.getTask_status().getStatus_code() == TStatusCode.OLAP_ERR_VERSION_ALREADY_MERGED) {
+                status = new Status(ErrCode.OLAP_VERSION_ALREADY_MERGED, "make snapshot failed, version already merged");
                 cancelInternal();
             }
             return false;

--- a/fe/src/main/java/org/apache/doris/backup/BackupJob.java
+++ b/fe/src/main/java/org/apache/doris/backup/BackupJob.java
@@ -145,7 +145,8 @@ public class BackupJob extends AbstractJob {
         
         if (request.getTask_status().getStatus_code() != TStatusCode.OK) {
             taskErrMsg.put(task.getSignature(), Joiner.on(",").join(request.getTask_status().getError_msgs()));
-            // status -230 means OLAP_ERR_VERSION_ALREADY_MERGED in BE OLAPStatus
+            // snapshot task could not finish if status_code is OLAP_ERR_VERSION_ALREADY_MERGED,
+            // so cancel this job
             if (request.getTask_status().getStatus_code() == TStatusCode.OLAP_ERR_VERSION_ALREADY_MERGED) {
                 status = new Status(ErrCode.OLAP_VERSION_ALREADY_MERGED, "make snapshot failed, version already merged");
                 cancelInternal();

--- a/fe/src/main/java/org/apache/doris/backup/BackupJob.java
+++ b/fe/src/main/java/org/apache/doris/backup/BackupJob.java
@@ -145,6 +145,12 @@ public class BackupJob extends AbstractJob {
         
         if (request.getTask_status().getStatus_code() != TStatusCode.OK) {
             taskErrMsg.put(task.getSignature(), Joiner.on(",").join(request.getTask_status().getError_msgs()));
+            // status -230 means OLAP_ERR_VERSION_ALREADY_MERGED in BE OLAPStatus
+            if (request.getTask_status().isSetError_msgs() &&
+                    request.getTask_status().getError_msgs().get(0).equals("make_snapshot failed. status: -230")) {
+                status = new Status(ErrCode.COMMON_ERROR, "make_snapshot failed");
+                cancelInternal();
+            }
             return false;
         }
 

--- a/fe/src/main/java/org/apache/doris/backup/Status.java
+++ b/fe/src/main/java/org/apache/doris/backup/Status.java
@@ -27,7 +27,8 @@ public class Status {
         IS_FILE,
         TIMEOUT,
         BAD_CONNECTION,
-        COMMON_ERROR
+        COMMON_ERROR,
+        OLAP_VERSION_ALREADY_MERGED
     }
 
     private ErrCode errCode;

--- a/gensrc/thrift/Status.thrift
+++ b/gensrc/thrift/Status.thrift
@@ -72,7 +72,8 @@ enum TStatusCode {
     SERVICE_UNAVAILABLE = 41,
     UNINITIALIZED       = 42,
     CONFIGURATION_ERROR = 43,
-    INCOMPLETE          = 44
+    INCOMPLETE          = 44,
+    OLAP_ERR_VERSION_ALREADY_MERGED = 45
 }
 
 struct TStatus {


### PR DESCRIPTION
This bug occurred when BE make snapshot, the version required by fe had been merged into the cumulative version, so the snapshot task could not complete the task even if it retried. In order to solve this problem, the BackupJob could be set to CANCELLED, and the user could continue to retry the job

Fix #3057 