### PR TITLE
[Bug] Fix bug that coalesce() function return null when there is constant value in parameter.

### DIFF
--- a/gensrc/script/doris_builtins_functions.py
+++ b/gensrc/script/doris_builtins_functions.py
@@ -732,7 +732,8 @@ non_null_result_with_null_param_functions = [
     'hll_hash',
     'concat_ws',
     'ifnull',
-    'null_or_empty'
+    'null_or_empty',
+    'coalesce'
 ]
 
 invisible_functions = [


### PR DESCRIPTION
`select coalesce(1, null);`

RETURNS:    NULL
EXPECTED:   1