### PR TITLE
Add a configuration to check consistency for repaired tablets.

### DIFF
--- a/fe/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/src/main/java/org/apache/doris/common/Config.java
@@ -614,6 +614,14 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true, masterOnly = true)
     public static long check_consistency_default_timeout_second = 600; // 10 min
 
+    /*
+     * Check consistency for current inconsistent tablets.
+     * This configuration can be used after you repair
+     * inconsistent tablets manually.
+     */
+    @ConfField(mutable = true, masterOnly = true)
+    public static boolean check_inconsistent_tablets = false;
+
     // Configurations for query engine
     /*
      * Maximal number of connections per FE.

--- a/fe/src/main/java/org/apache/doris/consistency/ConsistencyChecker.java
+++ b/fe/src/main/java/org/apache/doris/consistency/ConsistencyChecker.java
@@ -318,18 +318,24 @@ public class ConsistencyChecker extends MasterDaemon {
                                     }
 
                                     // check if version has already been checked
-                                    if (partition.getVisibleVersion() == tablet.getCheckedVersion()
-                                            && partition.getVisibleVersionHash() == tablet.getCheckedVersionHash()) {
-                                        if (tablet.isConsistent()) {
-                                            LOG.debug("tablet[{}]'s version[{}-{}] has been checked. ignore",
-                                                      chosenTabletId, tablet.getCheckedVersion(),
-                                                      tablet.getCheckedVersionHash());
+                                    if (Config.check_inconsistent_tablets) {
+                                        if (!tablet.isConsistent()) {
+                                            chosenTablets.add(chosenTabletId);
                                         }
                                     } else {
-                                        LOG.info("chose tablet[{}-{}-{}-{}-{}] to check consistency", db.getId(),
-                                                 table.getId(), partition.getId(), index.getId(), chosenTabletId);
+                                        if (partition.getVisibleVersion() == tablet.getCheckedVersion()
+                                                && partition.getVisibleVersionHash() == tablet.getCheckedVersionHash()) {
+                                            if (tablet.isConsistent()) {
+                                                LOG.debug("tablet[{}]'s version[{}-{}] has been checked. ignore",
+                                                        chosenTabletId, tablet.getCheckedVersion(),
+                                                        tablet.getCheckedVersionHash());
+                                            }
+                                        } else {
+                                            LOG.info("chose tablet[{}-{}-{}-{}-{}] to check consistency", db.getId(),
+                                                    table.getId(), partition.getId(), index.getId(), chosenTabletId);
 
-                                        chosenTablets.add(chosenTabletId);
+                                            chosenTablets.add(chosenTabletId);
+                                        }
                                     }
                                 } // end while tabletQueue
                             } // end while indexQueue


### PR DESCRIPTION
Doris may encounter consistency tablets because of code bug.
After repairing this tablets, we should trigger check consistency
again to update the consistent info in meta.