### PR TITLE
Show BE version in 'show backends;'

### DIFF
--- a/be/src/agent/heartbeat_server.cpp
+++ b/be/src/agent/heartbeat_server.cpp
@@ -28,6 +28,7 @@
 #include "olap/storage_engine.h"
 #include "olap/utils.h"
 #include "service/backend_options.h"
+#include "util/debug_util.h"
 #include "util/thrift_server.h"
 #include "runtime/heartbeat_flags.h"
 
@@ -69,6 +70,7 @@ void HeartbeatServer::heartbeat(
         heartbeat_result.backend_info.__set_http_port(config::webserver_port);
         heartbeat_result.backend_info.__set_be_rpc_port(-1);
         heartbeat_result.backend_info.__set_brpc_port(config::brpc_port);
+        heartbeat_result.backend_info.__set_version(get_short_version());
     }
 }
 

--- a/be/src/util/debug_util.cpp
+++ b/be/src/util/debug_util.cpp
@@ -108,7 +108,7 @@ std::string get_build_version(bool compact) {
 }
 
 std::string get_short_version() {
-    static std::string short_version(std::string(PALO_BUILD_VERSION) + "-" + PALO_BUILD_SHORT_HASH);
+    static std::string short_version(std::string(DORIS_BUILD_VERSION) + "-" + DORIS_BUILD_SHORT_HASH);
     return short_version;
 }
 

--- a/be/src/util/debug_util.cpp
+++ b/be/src/util/debug_util.cpp
@@ -107,6 +107,11 @@ std::string get_build_version(bool compact) {
     return ss.str();
 }
 
+std::string get_short_version() {
+    static std::string short_version(std::string(PALO_BUILD_VERSION) + "-" + PALO_BUILD_SHORT_HASH);
+    return short_version;
+}
+
 std::string get_version_string(bool compact) {
     std::stringstream ss;
     ss << " version " << get_build_version(compact);

--- a/be/src/util/debug_util.h
+++ b/be/src/util/debug_util.h
@@ -45,6 +45,9 @@ std::string PrintTMetricKind(const TMetricKind::type& type);
 // This is used to set gflags build version
 std::string get_build_version(bool compact);
 
+// Returns a string "<product version number> (<short build hash>)"
+std::string get_short_version();
+
 // Returns "<program short name> version <GetBuildVersion(compact)>"
 std::string get_version_string(bool compact);
 

--- a/fe/src/main/java/org/apache/doris/common/proc/BackendsProcDir.java
+++ b/fe/src/main/java/org/apache/doris/common/proc/BackendsProcDir.java
@@ -48,11 +48,11 @@ public class BackendsProcDir implements ProcDirInterface {
     private static final Logger LOG = LogManager.getLogger(BackendsProcDir.class);
 
     public static final ImmutableList<String> TITLE_NAMES = new ImmutableList.Builder<String>()
-            .add("BackendId").add("Cluster").add("IP").add("HostName").add("Version").add("HeartbeatPort")
+            .add("BackendId").add("Cluster").add("IP").add("HostName").add("HeartbeatPort")
             .add("BePort").add("HttpPort").add("BrpcPort").add("LastStartTime").add("LastHeartbeat").add("Alive")
             .add("SystemDecommissioned").add("ClusterDecommissioned").add("TabletNum")
             .add("DataUsedCapacity").add("AvailCapacity").add("TotalCapacity").add("UsedPct")
-            .add("MaxDiskUsedPct").add("ErrMsg")
+            .add("MaxDiskUsedPct").add("ErrMsg").add("Version")
             .build();
 
     public static final int IP_INDEX = 2;
@@ -123,7 +123,6 @@ public class BackendsProcDir implements ProcDirInterface {
             backendInfo.add(backend.getHost());
             if (Strings.isNullOrEmpty(clusterName)) {
                 backendInfo.add(FrontendOptions.getHostnameByIp(backend.getHost()));
-                backendInfo.add(String.valueOf(backend.getVersion()));
                 backendInfo.add(String.valueOf(backend.getHeartbeatPort()));
                 backendInfo.add(String.valueOf(backend.getBePort()));
                 backendInfo.add(String.valueOf(backend.getHttpPort()));
@@ -170,6 +169,7 @@ public class BackendsProcDir implements ProcDirInterface {
             backendInfo.add(String.format("%.2f", backend.getMaxDiskUsedPct() * 100) + " %");
 
             backendInfo.add(backend.getHeartbeatErrMsg());
+            backendInfo.add(backend.getVersion());
 
             comparableBackendInfos.add(backendInfo);
         }

--- a/fe/src/main/java/org/apache/doris/common/proc/BackendsProcDir.java
+++ b/fe/src/main/java/org/apache/doris/common/proc/BackendsProcDir.java
@@ -48,7 +48,7 @@ public class BackendsProcDir implements ProcDirInterface {
     private static final Logger LOG = LogManager.getLogger(BackendsProcDir.class);
 
     public static final ImmutableList<String> TITLE_NAMES = new ImmutableList.Builder<String>()
-            .add("BackendId").add("Cluster").add("IP").add("HostName").add("HeartbeatPort")
+            .add("BackendId").add("Cluster").add("IP").add("HostName").add("Version").add("HeartbeatPort")
             .add("BePort").add("HttpPort").add("BrpcPort").add("LastStartTime").add("LastHeartbeat").add("Alive")
             .add("SystemDecommissioned").add("ClusterDecommissioned").add("TabletNum")
             .add("DataUsedCapacity").add("AvailCapacity").add("TotalCapacity").add("UsedPct")
@@ -123,6 +123,7 @@ public class BackendsProcDir implements ProcDirInterface {
             backendInfo.add(backend.getHost());
             if (Strings.isNullOrEmpty(clusterName)) {
                 backendInfo.add(FrontendOptions.getHostnameByIp(backend.getHost()));
+                backendInfo.add(String.valueOf(backend.getVersion()));
                 backendInfo.add(String.valueOf(backend.getHeartbeatPort()));
                 backendInfo.add(String.valueOf(backend.getBePort()));
                 backendInfo.add(String.valueOf(backend.getHttpPort()));

--- a/fe/src/main/java/org/apache/doris/system/Backend.java
+++ b/fe/src/main/java/org/apache/doris/system/Backend.java
@@ -61,6 +61,7 @@ public class Backend implements Writable {
 
     private long id;
     private String host;
+    private String version;
 
     private int heartbeatPort; // heartbeat
     private AtomicInteger bePort; // be
@@ -95,6 +96,7 @@ public class Backend implements Writable {
 
     public Backend() {
         this.host = "";
+        this.version = "";
         this.lastUpdateMs = new AtomicLong();
         this.lastStartTime = new AtomicLong();
         this.isAlive = new AtomicBoolean();
@@ -114,6 +116,7 @@ public class Backend implements Writable {
     public Backend(long id, String host, int heartbeatPort) {
         this.id = id;
         this.host = host;
+        this.version = "";
         this.heartbeatPort = heartbeatPort;
         this.bePort = new AtomicInteger(-1);
         this.httpPort = new AtomicInteger(-1);
@@ -136,6 +139,10 @@ public class Backend implements Writable {
 
     public String getHost() {
         return host;
+    }
+
+    public String getVersion() {
+        return version;
     }
 
     public int getBePort() {
@@ -573,6 +580,11 @@ public class Backend implements Writable {
     public boolean handleHbResponse(BackendHbResponse hbResponse) {
         boolean isChanged = false;
         if (hbResponse.getStatus() == HbStatus.OK) {
+            if (!this.version.equals(hbResponse.getVersion())) {
+                isChanged = true;
+                this.version = hbResponse.getVersion();
+            }
+
             if (this.bePort.get() != hbResponse.getBePort()) {
                 isChanged = true;
                 this.bePort.set(hbResponse.getBePort());

--- a/fe/src/main/java/org/apache/doris/system/BackendHbResponse.java
+++ b/fe/src/main/java/org/apache/doris/system/BackendHbResponse.java
@@ -31,12 +31,13 @@ public class BackendHbResponse extends HeartbeatResponse implements Writable {
     private int bePort;
     private int httpPort;
     private int brpcPort;
+    private String version = "";
 
     public BackendHbResponse() {
         super(HeartbeatResponse.Type.BACKEND);
     }
 
-    public BackendHbResponse(long beId, int bePort, int httpPort, int brpcPort, long hbTime) {
+    public BackendHbResponse(long beId, int bePort, int httpPort, int brpcPort, long hbTime, String version) {
         super(HeartbeatResponse.Type.BACKEND);
         this.beId = beId;
         this.status = HbStatus.OK;
@@ -44,6 +45,7 @@ public class BackendHbResponse extends HeartbeatResponse implements Writable {
         this.httpPort = httpPort;
         this.brpcPort = brpcPort;
         this.hbTime = hbTime;
+        this.version = version;
     }
 
     public BackendHbResponse(long beId, String errMsg) {
@@ -67,6 +69,10 @@ public class BackendHbResponse extends HeartbeatResponse implements Writable {
 
     public int getBrpcPort() {
         return brpcPort;
+    }
+
+    public String getVersion() {
+        return version;
     }
 
     public static BackendHbResponse read(DataInput in) throws IOException {

--- a/fe/src/main/java/org/apache/doris/system/HeartbeatMgr.java
+++ b/fe/src/main/java/org/apache/doris/system/HeartbeatMgr.java
@@ -233,8 +233,13 @@ public class HeartbeatMgr extends MasterDaemon {
                     if (tBackendInfo.isSetBrpc_port()) {
                         brpcPort = tBackendInfo.getBrpc_port();
                     }
+                    String version = "";
+                    if (tBackendInfo.isSetVersion()) {
+                        version = tBackendInfo.getVersion();
+                    }
+
                     // backend.updateOnce(bePort, httpPort, beRpcPort, brpcPort);
-                    return new BackendHbResponse(backendId, bePort, httpPort, brpcPort, System.currentTimeMillis());
+                    return new BackendHbResponse(backendId, bePort, httpPort, brpcPort, System.currentTimeMillis(), version);
                 } else {
                     return new BackendHbResponse(backendId, result.getStatus().getError_msgs().isEmpty() ? "Unknown error"
                             : result.getStatus().getError_msgs().get(0));

--- a/gensrc/script/gen_build_version.sh
+++ b/gensrc/script/gen_build_version.sh
@@ -54,6 +54,7 @@ fi
 cd ${DORIS_HOME}
 if [ -d .svn ]; then
     revision=`svn info | sed -n -e 's/Last Changed Rev: \(.*\)/\1/p'`
+    short_revision="${revision}"
     url=`svn info | sed -n -e 's/^URL: \(.*\)/\1/p'`
     if echo ${url} | grep '\/tags\/' > /dev/null
     then
@@ -61,15 +62,18 @@ if [ -d .svn ]; then
     fi
 elif [ -d .git ]; then
     revision=`git log -1 --pretty=format:"%H"`
+    short_revision=`git log -1 --pretty=format:"%h"`
     url="git://${hostname}${DORIS_HOME}"
 else
     revision="Unknown"
+    short_revision="${revision}"
     url="file://${DORIS_HOME}"
 fi
 
 cd ${cwd}
 
 build_hash="${url}@${revision}"
+build_short_hash="${short_revision}"
 build_time="${date}"
 build_info="${user}@${hostname}"
 
@@ -161,10 +165,11 @@ cat >"${GEN_CPP_DIR}/version.h" <<EOF
 
 namespace doris {
 
-#define DORIS_BUILD_VERSION "${build_version}"
-#define DORIS_BUILD_HASH    "${build_hash}"
-#define DORIS_BUILD_TIME    "${build_time}"
-#define DORIS_BUILD_INFO    "${build_info}"
+#define DORIS_BUILD_VERSION    "${build_version}"
+#define DORIS_BUILD_HASH       "${build_hash}"
+#define DORIS_BUILD_SHORT_HASH "${build_short_hash}"
+#define DORIS_BUILD_TIME       "${build_time}"
+#define DORIS_BUILD_INFO       "${build_info}"
 
 } // namespace doris
 

--- a/gensrc/thrift/HeartbeatService.thrift
+++ b/gensrc/thrift/HeartbeatService.thrift
@@ -35,6 +35,7 @@ struct TBackendInfo {
     2: required Types.TPort http_port
     3: optional Types.TPort be_rpc_port
     4: optional Types.TPort brpc_port
+    5: optional string version
 }
 
 struct THeartbeatResult {


### PR DESCRIPTION
In a large scale cluster, we may rolling upgrade BEs, this patch add a
column named 'Version' for command 'show backends;', as well as website
'/system?path=//backends', to provide a method to check whether there
is any BE missing upgraded.

ref issue https://github.com/apache/incubator-doris/issues/3006