### PR TITLE
Fix one compile warning

### DIFF
--- a/be/src/olap/rowset/segment_v2/ordinal_page_index.cpp
+++ b/be/src/olap/rowset/segment_v2/ordinal_page_index.cpp
@@ -96,7 +96,7 @@ Status OrdinalIndexReader::load(bool use_page_cache, bool kept_in_memory) {
     _pages.resize(_num_pages);
     for (int i = 0; i < _num_pages; i++) {
         Slice key = reader.get_key(i);
-        ordinal_t ordinal;
+        ordinal_t ordinal = 0;
         RETURN_IF_ERROR(KeyCoderTraits<OLAP_FIELD_TYPE_UNSIGNED_BIGINT>::decode_ascending(
                 &key, sizeof(ordinal_t), (uint8_t*) &ordinal, nullptr));
 


### PR DESCRIPTION
```
be/src/olap/rowset/segment_v2/ordinal_page_index.cpp:103:22: warning: ‘ordinal’ may be used
uninitialized in this function [-Wmaybe-uninitialized]
    _ordinals[i] = ordinal;
```