### PR TITLE
Fix table could not load data after restore

### DIFF
--- a/fe/src/main/java/org/apache/doris/catalog/OlapTable.java
+++ b/fe/src/main/java/org/apache/doris/catalog/OlapTable.java
@@ -993,15 +993,14 @@ public class OlapTable extends Table {
             LOG.warn("failed to copy olap table: " + getName());
             return null;
         }
-
-        // remove shadow index from copied table
-        List<MaterializedIndex> shadowIndex = copied.getPartitions().stream().findFirst().get().getMaterializedIndices(IndexExtState.SHADOW);
-        for (MaterializedIndex deleteIndex : shadowIndex) {
-            LOG.debug("copied table delete shadow index : {}", deleteIndex.getId());
-            copied.deleteIndexInfo(copied.getIndexNameById(deleteIndex.getId()));
-        }
-
+        
         if (resetState) {
+            // remove shadow index from copied table
+            List<MaterializedIndex> shadowIndex = copied.getPartitions().stream().findFirst().get().getMaterializedIndices(IndexExtState.SHADOW);
+            for (MaterializedIndex deleteIndex : shadowIndex) {
+                LOG.debug("copied table delete shadow index : {}", deleteIndex.getId());
+                copied.deleteIndexInfo(copied.getIndexNameById(deleteIndex.getId()));
+            }
             copied.setState(OlapTableState.NORMAL);
             for (Partition partition : copied.getPartitions()) {
                 // remove shadow index from partition

--- a/fe/src/main/java/org/apache/doris/catalog/OlapTable.java
+++ b/fe/src/main/java/org/apache/doris/catalog/OlapTable.java
@@ -997,30 +997,15 @@ public class OlapTable extends Table {
         // remove shadow index from copied table
         List<MaterializedIndex> shadowIndex = copied.getPartitions().stream().findFirst().get().getMaterializedIndices(IndexExtState.SHADOW);
         for (MaterializedIndex deleteIndex : shadowIndex) {
-            LOG.debug("table delete shadow index : {}", deleteIndex);
+            LOG.debug("copied table delete shadow index : {}", deleteIndex.getId());
             copied.deleteIndexInfo(copied.getIndexNameById(deleteIndex.getId()));
         }
-        /*
-        Map<Long, MaterializedIndexMeta> visibleIndex =  copied.getVisibleIndexIdToMeta();
-        Map<Long, String> shadowIndex = Maps.newHashMap();
-        for (Map.Entry<String, Long> entry : copied.getIndexNameToId().entrySet()) {
-            if (!visibleIndex.containsKey(entry.getValue())) {
-                shadowIndex.put(entry.getValue(), entry.getKey());
-            }
-        }
-
-        for (String index : shadowIndex.values()) {
-            LOG.debug("delete shadow index : {}", index);
-            copied.deleteIndexInfo(index);
-        }
-        */
 
         if (resetState) {
             copied.setState(OlapTableState.NORMAL);
             for (Partition partition : copied.getPartitions()) {
                 // remove shadow index from partition
                 for (MaterializedIndex deleteIndex : shadowIndex) {
-                    LOG.debug("partition delete shadow index : {}", deleteIndex);
                     partition.deleteRollupIndex(deleteIndex.getId());
                 }
                 partition.setState(PartitionState.NORMAL);


### PR DESCRIPTION
Backup job in BE only backup index which is visible, but the backup meta in FE contains the shadow index, after restore from this snapshot, the shadow index is visible to load process, and the tablets is not exist in BE, so load process would be cancelled.  we could fix this bug by remove the useless shadow index at backup process

Fix #3086