### PR TITLE
[Insert] Fix bug that insert meet unexpected "label already exists" exception

### DIFF
--- a/fe/src/main/java/org/apache/doris/analysis/InsertStmt.java
+++ b/fe/src/main/java/org/apache/doris/analysis/InsertStmt.java
@@ -246,6 +246,10 @@ public class InsertStmt extends DdlStmt {
         return db;
     }
 
+    public boolean isTransactionBegin() {
+        return isTransactionBegin;
+    }
+
     @Override
     public void analyze(Analyzer analyzer) throws UserException {
         super.analyze(analyzer);

--- a/fe/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/src/main/java/org/apache/doris/common/Config.java
@@ -794,7 +794,7 @@ public class Config extends ConfigBase {
      * You may reduce this number to void Avalanche disaster.
      */
     @ConfField(mutable = true)
-    public static int max_query_retry_time = 3;
+    public static int max_query_retry_time = 2;
 
     /*
      * The tryLock timeout configuration of catalog lock.


### PR DESCRIPTION
This CL will abort the transaction of an insert operation when encountering exception thrown in analysis phase.

ISSUE: #3102