### PR TITLE
[Alter] Alter job got stuck because of table is untable

### DIFF
--- a/fe/src/main/java/org/apache/doris/alter/AlterJobV2.java
+++ b/fe/src/main/java/org/apache/doris/alter/AlterJobV2.java
@@ -17,6 +17,10 @@
 
 package org.apache.doris.alter;
 
+import org.apache.doris.catalog.Catalog;
+import org.apache.doris.catalog.Database;
+import org.apache.doris.catalog.OlapTable;
+import org.apache.doris.catalog.OlapTable.OlapTableState;
 import org.apache.doris.common.io.Text;
 import org.apache.doris.common.io.Writable;
 
@@ -157,6 +161,42 @@ public abstract class AlterJobV2 implements Writable {
     public final boolean cancel(String errMsg) {
         synchronized (this) {
             return cancelImpl(errMsg);
+        }
+    }
+
+    // should be call before executing the job.
+    // return false if table is not stable.
+    protected boolean checkTableStable(Database db) throws AlterCancelException {
+        OlapTable tbl = null;
+        boolean isStable = false;
+        db.readLock();
+        try {
+            tbl = (OlapTable) db.getTable(tableId);
+            if (tbl == null) {
+                throw new AlterCancelException("Table " + tableId + " does not exist");
+            }
+
+            isStable = tbl.isStable(Catalog.getCurrentSystemInfo(),
+                    Catalog.getCurrentCatalog().getTabletScheduler(), db.getClusterName());
+        } finally {
+            db.readUnlock();
+        }
+
+        db.writeLock();
+        try {
+            if (!isStable) {
+                errMsg = "table is unstable";
+                LOG.warn("wait table {} to be stable before doing {} job", tableId, type);
+                tbl.setState(OlapTableState.WAITING_STABLE);
+                return false;
+            } else {
+                // table is stable, set is to ROLLUP and begin altering.
+                LOG.info("table {} is stable, start {} job {}", tableId, type);
+                tbl.setState(type == JobType.ROLLUP ? OlapTableState.ROLLUP : OlapTableState.SCHEMA_CHANGE);
+                return true;
+            }
+        } finally {
+            db.writeUnlock();
         }
     }
 

--- a/fe/src/main/java/org/apache/doris/alter/RollupJobV2.java
+++ b/fe/src/main/java/org/apache/doris/alter/RollupJobV2.java
@@ -166,7 +166,7 @@ public class RollupJobV2 extends AlterJobV2 {
             }
         }
         MarkedCountDownLatch<Long, Long> countDownLatch = new MarkedCountDownLatch<Long, Long>(totalReplicaNum);
-        db.writeLock();
+        db.readLock();
         try {
             OlapTable tbl = (OlapTable) db.getTable(tableId);
             if (tbl == null) {
@@ -210,7 +210,7 @@ public class RollupJobV2 extends AlterJobV2 {
                 } // end for rollupTablets
             }
         } finally {
-            db.writeUnlock();
+            db.readUnlock();
         }
 
         if (!FeConstants.runningUnitTest) {

--- a/fe/src/main/java/org/apache/doris/alter/SchemaChangeJobV2.java
+++ b/fe/src/main/java/org/apache/doris/alter/SchemaChangeJobV2.java
@@ -189,7 +189,7 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
             }
         }
         MarkedCountDownLatch<Long, Long> countDownLatch = new MarkedCountDownLatch<>(totalReplicaNum);
-        db.writeLock();
+        db.readLock();
         try {
             OlapTable tbl = (OlapTable) db.getTable(tableId);
             if (tbl == null) {
@@ -238,7 +238,7 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
                 }
             }
         } finally {
-            db.writeUnlock();
+            db.readUnlock();
         }
 
         if (!FeConstants.runningUnitTest) {

--- a/fe/src/main/java/org/apache/doris/catalog/OlapTable.java
+++ b/fe/src/main/java/org/apache/doris/catalog/OlapTable.java
@@ -82,7 +82,14 @@ public class OlapTable extends Table {
         @Deprecated
         BACKUP,
         RESTORE,
-        RESTORE_WITH_LOAD
+        RESTORE_WITH_LOAD,
+        /*
+         * this state means table is under PENDING alter operation(SCHEMA_CHANGE or ROLLUP), and is not
+         * stable. The tablet scheduler will continue fixing the tablets of this table. And the state will
+         * change back to SCHEMA_CHANGE or ROLLUP after table is stable, and continue doing alter operation.
+         * This state is a in-memory state and no need to persist.
+         */
+        WAITING_STABLE
     }
 
     private OlapTableState state;

--- a/fe/src/main/java/org/apache/doris/clone/TabletScheduler.java
+++ b/fe/src/main/java/org/apache/doris/clone/TabletScheduler.java
@@ -509,9 +509,13 @@ public class TabletScheduler extends MasterDaemon {
             }
 
             if (statusPair.first != TabletStatus.VERSION_INCOMPLETE  
-                    && (partition.getState() != PartitionState.NORMAL || tableState != OlapTableState.NORMAL)) {
+                    && (partition.getState() != PartitionState.NORMAL || tableState != OlapTableState.NORMAL)
+                    && tableState != OlapTableState.WAITING_STABLE) {
                 // If table is under ALTER process(before FINISHING), do not allow to add or delete replica.
                 // VERSION_INCOMPLETE will repair the replica in place, which is allowed.
+                // The WAITING_STABLE state is an exception. This state indicates that the table is
+                // executing an alter job, but the alter job is in a PENDING state and is waiting for
+                // the table to become stable. In this case, we allow the tablet repair to proceed.
                 throw new SchedException(Status.UNRECOVERABLE,
                     "table is in alter process, but tablet status is " + statusPair.first.name());
             }


### PR DESCRIPTION
This CL solve the issue #3105 

I add a new temporary table state `WAITING_STABLE`. 

When an alter job is ready to start, it checks whether the table is stable. If it is not stable,
the table state is set to `WAITING_STABLE`. In this state, the tablet repair logic will continue to 
repair the tablet until the table becomes stable.

After that, the table state will be reset to SCHEMA_CHANGE/ROLLUP and alter operations will begin.

This is just a temporary state, it does not need to be persistent, and only the master FE can see this state.