### PR TITLE
[Bug] Fix bug that the file_block_mgr object was incorrectly destructed

### DIFF
--- a/be/src/olap/rowset/beta_rowset_writer.cpp
+++ b/be/src/olap/rowset/beta_rowset_writer.cpp
@@ -23,6 +23,7 @@
 #include "common/logging.h"
 #include "env/env.h"
 #include "gutil/strings/substitute.h"
+#include "olap/fs/fs_util.h"
 #include "olap/olap_define.h"
 #include "olap/rowset/beta_rowset.h"
 #include "olap/rowset/rowset_factory.h"
@@ -179,10 +180,7 @@ OLAPStatus BetaRowsetWriter::_create_segment_writer() {
                                               _num_segment);
     // TODO(lingbin): should use a more general way to get BlockManager object
     // and tablets with the same type should share one BlockManager object;
-    fs::BlockManagerOptions bm_opts;
-    bm_opts.read_only = false;
-    // fs::BlockManager* block_mgr = fs::fs_util::file_block_mgr(Env::Default(), bm_opts);
-    fs::BlockManager* block_mgr = ExecEnv::GetInstance()->storage_engine()->file_block_manager();
+    fs::BlockManager* block_mgr = ExecEnv::GetInstance()->storage_engine()->block_manager();
 
     std::unique_ptr<fs::WritableBlock> wblock;
     fs::CreateBlockOptions opts({path});

--- a/be/src/olap/rowset/beta_rowset_writer.h
+++ b/be/src/olap/rowset/beta_rowset_writer.h
@@ -80,6 +80,8 @@ private:
     std::unique_ptr<segment_v2::SegmentWriter> _segment_writer;
     // TODO(lingbin): it is better to wrapper in a Batch?
     std::vector<std::unique_ptr<fs::WritableBlock>> _wblocks;
+    // TODO(cmy): 
+    std::unique_ptr<FileBlockManager> _file_block_manager;
 
     // counters and statistics maintained during data write
     int64_t _num_rows_written;

--- a/be/src/olap/rowset/beta_rowset_writer.h
+++ b/be/src/olap/rowset/beta_rowset_writer.h
@@ -80,8 +80,6 @@ private:
     std::unique_ptr<segment_v2::SegmentWriter> _segment_writer;
     // TODO(lingbin): it is better to wrapper in a Batch?
     std::vector<std::unique_ptr<fs::WritableBlock>> _wblocks;
-    // TODO(cmy): 
-    std::unique_ptr<FileBlockManager> _file_block_manager;
 
     // counters and statistics maintained during data write
     int64_t _num_rows_written;

--- a/be/src/olap/storage_engine.cpp
+++ b/be/src/olap/storage_engine.cpp
@@ -50,7 +50,7 @@
 #include "olap/rowset/column_data_writer.h"
 #include "olap/olap_snapshot_converter.h"
 #include "olap/rowset/unique_rowset_id_generator.h"
-#include "olap/fs/file_block_manager.h"
+#include "olap/fs/fs_util.h"
 #include "util/time.h"
 #include "util/doris_metrics.h"
 #include "util/pretty_printer.h"
@@ -116,7 +116,7 @@ StorageEngine::StorageEngine(const EngineOptions& options)
         _txn_manager(new TxnManager()),
         _rowset_id_generator(new UniqueRowsetIdGenerator(options.backend_uid)),
         _memtable_flush_executor(nullptr),
-        _file_block_manager(nullptr),
+        _block_manager(nullptr),
         _default_rowset_type(ALPHA_ROWSET),
         _compaction_rowset_type(ALPHA_ROWSET),
         _heartbeat_flags(nullptr) {
@@ -178,7 +178,7 @@ OLAPStatus StorageEngine::_open() {
 
     fs::BlockManagerOptions bm_opts;
     bm_opts.read_only = false;
-    _file_block_manager.reset(new FileBlockManager(Env::Default(), std::move(opts));
+    _block_manager.reset(fs::fs_util::file_block_mgr(Env::Default(), bm_opts));
 
     _parse_default_rowset_type();
 

--- a/be/src/olap/storage_engine.cpp
+++ b/be/src/olap/storage_engine.cpp
@@ -50,6 +50,7 @@
 #include "olap/rowset/column_data_writer.h"
 #include "olap/olap_snapshot_converter.h"
 #include "olap/rowset/unique_rowset_id_generator.h"
+#include "olap/fs/file_block_manager.h"
 #include "util/time.h"
 #include "util/doris_metrics.h"
 #include "util/pretty_printer.h"
@@ -115,6 +116,7 @@ StorageEngine::StorageEngine(const EngineOptions& options)
         _txn_manager(new TxnManager()),
         _rowset_id_generator(new UniqueRowsetIdGenerator(options.backend_uid)),
         _memtable_flush_executor(nullptr),
+        _file_block_manager(nullptr),
         _default_rowset_type(ALPHA_ROWSET),
         _compaction_rowset_type(ALPHA_ROWSET),
         _heartbeat_flags(nullptr) {
@@ -173,6 +175,10 @@ OLAPStatus StorageEngine::_open() {
 
     _memtable_flush_executor.reset(new MemTableFlushExecutor());
     _memtable_flush_executor->init(dirs);
+
+    fs::BlockManagerOptions bm_opts;
+    bm_opts.read_only = false;
+    _file_block_manager.reset(new FileBlockManager(Env::Default(), std::move(opts));
 
     _parse_default_rowset_type();
 

--- a/be/src/olap/storage_engine.h
+++ b/be/src/olap/storage_engine.h
@@ -46,13 +46,14 @@
 #include "olap/txn_manager.h"
 #include "olap/task/engine_task.h"
 #include "olap/rowset/rowset_id_generator.h"
+#include "olap/fs/fs_util.h"
 #include "runtime/heartbeat_flags.h"
 
 namespace doris {
 
 class DataDir;
 class EngineTask;
-class FileBlockManager;
+class BlockManager;
 class MemTableFlushExecutor;
 class Tablet;
 
@@ -164,7 +165,7 @@ public:
     TabletManager* tablet_manager() { return _tablet_manager.get(); }
     TxnManager* txn_manager() { return _txn_manager.get(); }
     MemTableFlushExecutor* memtable_flush_executor() { return _memtable_flush_executor.get(); }
-    FileBlockManager* file_block_manager() { return _file_block_manager.get(); }
+    fs::BlockManager* block_manager() { return _block_manager.get(); }
 
     bool check_rowset_id_in_unused_rowsets(const RowsetId& rowset_id);
 
@@ -335,7 +336,7 @@ private:
 
     std::unique_ptr<MemTableFlushExecutor> _memtable_flush_executor;
 
-    std::unique_lock<FileBlockManager> _file_block_manager;
+    std::unique_ptr<fs::BlockManager> _block_manager;
 
     // Used to control the migration from segment_v1 to segment_v2, can be deleted in futrue.
     // Type of new loaded data

--- a/be/src/olap/storage_engine.h
+++ b/be/src/olap/storage_engine.h
@@ -52,6 +52,7 @@ namespace doris {
 
 class DataDir;
 class EngineTask;
+class FileBlockManager;
 class MemTableFlushExecutor;
 class Tablet;
 
@@ -163,6 +164,7 @@ public:
     TabletManager* tablet_manager() { return _tablet_manager.get(); }
     TxnManager* txn_manager() { return _txn_manager.get(); }
     MemTableFlushExecutor* memtable_flush_executor() { return _memtable_flush_executor.get(); }
+    FileBlockManager* file_block_manager() { return _file_block_manager.get(); }
 
     bool check_rowset_id_in_unused_rowsets(const RowsetId& rowset_id);
 
@@ -332,6 +334,8 @@ private:
     std::unique_ptr<RowsetIdGenerator> _rowset_id_generator;
 
     std::unique_ptr<MemTableFlushExecutor> _memtable_flush_executor;
+
+    std::unique_lock<FileBlockManager> _file_block_manager;
 
     // Used to control the migration from segment_v1 to segment_v2, can be deleted in futrue.
     // Type of new loaded data

--- a/be/src/runtime/exec_env.h
+++ b/be/src/runtime/exec_env.h
@@ -53,6 +53,7 @@ class WebPageHandler;
 class StreamLoadExecutor;
 class RoutineLoadTaskExecutor;
 class SmallFileMgr;
+class FileBlockManager;
 
 class BackendServiceClient;
 class FrontendServiceClient;


### PR DESCRIPTION
During the use of the `block`, some methods in the block manager will be referenced.
So `file_block_mgr` should be a resident and globally unique object.

I put it in `StorageEngine`.

TODO: the `BlockManager`, `Env`  need to be reorganized. 