### PR TITLE
fix a daily test fail

### DIFF
--- a/be/src/runtime/raw_value.cpp
+++ b/be/src/runtime/raw_value.cpp
@@ -216,7 +216,10 @@ void RawValue::print_value(const void* value, const TypeDescriptor& type, int sc
         str->swap(tmp);
         return;
     }
-
+    case TYPE_NULL: {
+        *str = "NULL";
+        return;
+    }
     default:
         print_value(value, type, scale, &out);
     }

--- a/fe/src/main/java/org/apache/doris/analysis/CastExpr.java
+++ b/fe/src/main/java/org/apache/doris/analysis/CastExpr.java
@@ -103,12 +103,12 @@ public class CastExpr extends Expr {
                 if (fromType.isStringType() && toType.isBoolean()) {
                     continue;
                 }
-                // Disable casting from boolean to decimal
+                // Disable casting from boolean to decimal or datetime or date
                 if (fromType.isBoolean() &&
-                        (toType == Type.DECIMAL || toType == Type.DECIMALV2)) {
+                        (toType == Type.DECIMAL || toType == Type.DECIMALV2 ||
+                                toType == Type.DATETIME || toType == Type.DATE)) {
                     continue;
                 }
-
                 // Disable no-op casts
                 if (fromType.equals(toType)) {
                     continue;

--- a/fe/src/main/java/org/apache/doris/analysis/SetOperationStmt.java
+++ b/fe/src/main/java/org/apache/doris/analysis/SetOperationStmt.java
@@ -188,6 +188,11 @@ public class SetOperationStmt extends QueryStmt {
         super.analyze(analyzer);
         Preconditions.checkState(operands.size() > 0);
 
+        // the first operand's operation usually null
+        if (operands.get(0).operation == null && operands.size() > 1) {
+            operands.get(0).setOperation(operands.get(1).getOperation());
+        }
+
         // Propagates DISTINCT from left to right,
         propagateDistinct();
 
@@ -649,7 +654,9 @@ public class SetOperationStmt extends QueryStmt {
             if (isAnalyzed()) {
                 return;
             }
-            if (queryStmt instanceof SelectStmt && ((SelectStmt) queryStmt).fromClause_.isEmpty()) {
+            // union statement support const expr, so not need to rewrite
+            if (operation != Operation.UNION && queryStmt instanceof SelectStmt
+                    && ((SelectStmt) queryStmt).fromClause_.isEmpty()) {
                 // rewrite select 1 to select * from (select 1) __DORIS_DUAL__ , because when using select 1 it will be
                 // transformed to a union node, select 1 is a literal, it doesn't have a tuple but will produce a slot,
                 // this will cause be core dump


### PR DESCRIPTION
fix a bug of  const union query like  `select null union select null`, this because the type of SlotDescriptor  when claus is  `select null ` is null ,this will  cause be core dump, and fe find wrong cast function
this is the reason of  test fail  stream_test_insert.test_insert_union
