### PR TITLE
Fix NPE when access follower Fe's web console

### DIFF
--- a/fe/src/main/java/org/apache/doris/http/action/WebBaseAction.java
+++ b/fe/src/main/java/org/apache/doris/http/action/WebBaseAction.java
@@ -162,6 +162,8 @@ public class WebBaseAction extends BaseAction {
             ctx.setQualifiedUser(authInfo.fullUserName);
             ctx.setRemoteIP(authInfo.remoteIp);
             ctx.setCurrentUserIdentity(currentUser);
+            ctx.setCatalog(Catalog.getCurrentCatalog());
+            ctx.setCluster(SystemInfoService.DEFAULT_CLUSTER);
             ctx.setThreadLocalInfo();
 
             return true;


### PR DESCRIPTION
This CL fixes the following NPE when access follower's web console
```
2020-03-19 14:54:24,174 WARN 84 [SystemAction.appendSystemInfo():93] Fail to forward.
java.lang.NullPointerException: null
        at org.apache.doris.qe.MasterOpExecutor.forward(MasterOpExecutor.java:63) ~[palo-fe.jar:?]
        at org.apache.doris.qe.MasterOpExecutor.execute(MasterOpExecutor.java:56) ~[palo-fe.jar:?]
        at org.apache.doris.http.action.SystemAction.appendSystemInfo(SystemAction.java:91) [palo-fe.jar:?]
        at org.apache.doris.http.action.SystemAction.executeGet(SystemAction.java:65) [palo-fe.jar:?]
        at org.apache.doris.http.action.WebBaseAction.execute(WebBaseAction.java:116) [palo-fe.jar:?]
        at org.apache.doris.http.BaseAction.handleRequest(BaseAction.java:89) [palo-fe.jar:?]
        at org.apache.doris.http.HttpServerHandler.channelRead(HttpServerHandler.java:73) [palo-fe.jar:?]
```

It's a follow-up of #3020 which forgets to set ConnectContext's catalog in `checkAuthWithCookie`.