### PR TITLE
Support non-correlated subquery in having clause

### DIFF
--- a/fe/src/main/java/org/apache/doris/analysis/ArithmeticExpr.java
+++ b/fe/src/main/java/org/apache/doris/analysis/ArithmeticExpr.java
@@ -232,7 +232,7 @@ public class ArithmeticExpr extends Expr {
         }
 
         analyzeSubqueryInChildren();
-        // if children has subquery, it will be written and reanalyzed in the future.
+        // if children has subquery, it will be rewritten and reanalyzed in the future.
         if (contains(Subquery.class)) {
             return;
         }

--- a/fe/src/main/java/org/apache/doris/analysis/ArithmeticExpr.java
+++ b/fe/src/main/java/org/apache/doris/analysis/ArithmeticExpr.java
@@ -17,9 +17,6 @@
 
 package org.apache.doris.analysis;
 
-import java.util.List;
-import java.util.Objects;
-
 import org.apache.doris.catalog.Function;
 import org.apache.doris.catalog.FunctionSet;
 import org.apache.doris.catalog.PrimitiveType;
@@ -29,11 +26,15 @@ import org.apache.doris.common.AnalysisException;
 import org.apache.doris.thrift.TExprNode;
 import org.apache.doris.thrift.TExprNodeType;
 import org.apache.doris.thrift.TExprOpcode;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.List;
+import java.util.Objects;
 
 public class ArithmeticExpr extends Expr {
     private static final Logger LOG = LogManager.getLogger(ArithmeticExpr.class);
@@ -216,7 +217,6 @@ public class ArithmeticExpr extends Expr {
 
     @Override
     public void analyzeImpl(Analyzer analyzer) throws AnalysisException {
-
         // bitnot is the only unary op, deal with it here
         if (op == Operator.BITNOT) {
             type = Type.BIGINT;
@@ -228,6 +228,12 @@ public class ArithmeticExpr extends Expr {
             if (fn == null) {
                 Preconditions.checkState(false, String.format("No match for op with operand types", toSql()));
             }
+            return;
+        }
+
+        analyzeSubqueryInChildren();
+        // if children has subquery, it will be written and reanalyzed in the future.
+        if (contains(Subquery.class)) {
             return;
         }
 
@@ -272,6 +278,31 @@ public class ArithmeticExpr extends Expr {
         if (fn == null) {
             Preconditions.checkState(false, String.format(
                     "No match for '%s' with operand types %s and %s", toSql(), t1, t2));
+        }
+    }
+
+    public void analyzeSubqueryInChildren() throws AnalysisException {
+        for (Expr child : children) {
+            if (child instanceof Subquery) {
+                Subquery subquery = (Subquery) child;
+                if (!subquery.returnsScalarColumn()) {
+                    String msg = "Subquery of arithmetic expr must return a single column: " + child.toSql();
+                    throw new AnalysisException(msg);
+                }
+                /**
+                 * Situation: The expr is a binary predicate and the type of subquery is not scalar type.
+                 * Add assert: The stmt of subquery is added an assert condition (return error if row count > 1).
+                 * Input params:
+                 *     expr: 0.9*(select k1 from t2)
+                 *     subquery stmt: select k1 from t2
+                 * Output params:
+                 *     new expr: 0.9 * (select k1 from t2 (assert row count: return error if row count > 1 ))
+                 *     subquery stmt: select k1 from t2 (assert row count: return error if row count > 1 )
+                 */
+                if (!subquery.getType().isScalarType()) {
+                    subquery.getStatement().setAssertNumRowsElement(1);
+                }
+            }
         }
     }
 

--- a/fe/src/main/java/org/apache/doris/analysis/BinaryPredicate.java
+++ b/fe/src/main/java/org/apache/doris/analysis/BinaryPredicate.java
@@ -17,11 +17,6 @@
 
 package org.apache.doris.analysis;
 
-import java.io.DataInput;
-import java.io.DataOutput;
-import java.io.IOException;
-import java.util.Objects;
-
 import org.apache.doris.catalog.Function;
 import org.apache.doris.catalog.FunctionSet;
 import org.apache.doris.catalog.PrimitiveType;
@@ -35,11 +30,17 @@ import org.apache.doris.common.io.Writable;
 import org.apache.doris.thrift.TExprNode;
 import org.apache.doris.thrift.TExprNodeType;
 import org.apache.doris.thrift.TExprOpcode;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import java.util.Objects;
 
 /**
  * Most predicates with two operands..
@@ -313,9 +314,25 @@ public class BinaryPredicate extends Predicate implements Writable {
         super.analyzeImpl(analyzer);
 
         for (Expr expr : children) {
-            if (expr instanceof Subquery && !((Subquery) expr).returnsScalarColumn()) {
-                String msg = "Subquery of binary predicate must return a single column: " + expr.toSql();
-                throw new AnalysisException(msg);
+            if (expr instanceof Subquery) {
+                Subquery subquery = (Subquery) expr;
+                if (!subquery.returnsScalarColumn()) {
+                    String msg = "Subquery of binary predicate must return a single column: " + expr.toSql();
+                    throw new AnalysisException(msg);
+                }
+                /**
+                 * Situation: The expr is a binary predicate and the type of subquery is not scalar type.
+                 * Add assert: The stmt of subquery is added an assert condition (return error if row count > 1).
+                 * Input params:
+                 *     expr: k1=(select k1 from t2)
+                 *     subquery stmt: select k1 from t2
+                 * Output params:
+                 *     new expr: k1 = (select k1 from t2 (assert row count: return error if row count > 1 ))
+                 *     subquery stmt: select k1 from t2 (assert row count: return error if row count > 1 )
+                 */
+                if (!subquery.getType().isScalarType()) {
+                    subquery.getStatement().setAssertNumRowsElement(1);
+                }
             }
         }
 

--- a/fe/src/main/java/org/apache/doris/analysis/BinaryPredicate.java
+++ b/fe/src/main/java/org/apache/doris/analysis/BinaryPredicate.java
@@ -336,7 +336,7 @@ public class BinaryPredicate extends Predicate implements Writable {
             }
         }
 
-        // if children has subquery, it will be written and reanalyzed in the future.
+        // if children has subquery, it will be rewritten and reanalyzed in the future.
         if (contains(Subquery.class)) {
             return;
         }
@@ -575,4 +575,3 @@ public class BinaryPredicate extends Predicate implements Writable {
         return 31 * super.hashCode() + Objects.hashCode(op);
     }
 }
-

--- a/fe/src/main/java/org/apache/doris/analysis/BinaryPredicate.java
+++ b/fe/src/main/java/org/apache/doris/analysis/BinaryPredicate.java
@@ -337,7 +337,7 @@ public class BinaryPredicate extends Predicate implements Writable {
         }
 
         // if children has subquery, it will be written and reanalyzed in the future.
-        if (children.get(0) instanceof Subquery || children.get(1) instanceof Subquery) {
+        if (contains(Subquery.class)) {
             return;
         }
 

--- a/fe/src/main/java/org/apache/doris/analysis/Expr.java
+++ b/fe/src/main/java/org/apache/doris/analysis/Expr.java
@@ -1463,7 +1463,7 @@ abstract public class Expr extends TreeNode<Expr> implements ParseNode, Cloneabl
     }
 
     public boolean isCorrelatedPredicate(List<TupleId> tupleIdList) {
-        if ((this instanceof BinaryPredicate || this instanceof SlotRef) && !this.isBoundByTupleIds(tupleIdList)) {
+        if (this instanceof SlotRef && !this.isBoundByTupleIds(tupleIdList)) {
             return true;
         }
         for (Expr child : this.getChildren()) {

--- a/fe/src/main/java/org/apache/doris/analysis/Expr.java
+++ b/fe/src/main/java/org/apache/doris/analysis/Expr.java
@@ -1462,6 +1462,18 @@ abstract public class Expr extends TreeNode<Expr> implements ParseNode, Cloneabl
         return subqueries.get(0);
     }
 
+    public boolean isCorrelatedPredicate(List<TupleId> tupleIdList) {
+        if ((this instanceof BinaryPredicate || this instanceof SlotRef) && !this.isBoundByTupleIds(tupleIdList)) {
+            return true;
+        }
+        for (Expr child : this.getChildren()) {
+            if (child.isCorrelatedPredicate(tupleIdList)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     @Override
     public void write(DataOutput out) throws IOException {
         throw new IOException("Not implemented serializable ");

--- a/fe/src/main/java/org/apache/doris/analysis/InlineViewRef.java
+++ b/fe/src/main/java/org/apache/doris/analysis/InlineViewRef.java
@@ -58,7 +58,7 @@ public class InlineViewRef extends TableRef {
     // BEGIN: Members that need to be reset()
 
     // The select or union statement of the inline view
-    private final QueryStmt queryStmt;
+    private QueryStmt queryStmt;
 
     // queryStmt has its own analysis context
     private Analyzer inlineViewAnalyzer;
@@ -395,6 +395,10 @@ public class InlineViewRef extends TableRef {
 
     public QueryStmt getViewStmt() {
         return queryStmt;
+    }
+
+    public void setViewStmt(QueryStmt queryStmt) {
+        this.queryStmt = queryStmt;
     }
 
     public Analyzer getAnalyzer() {

--- a/fe/src/main/java/org/apache/doris/analysis/InsertStmt.java
+++ b/fe/src/main/java/org/apache/doris/analysis/InsertStmt.java
@@ -89,7 +89,7 @@ public class InsertStmt extends DdlStmt {
     // parsed from targetPartitionNames. empty means no partition specified
     private List<Long> targetPartitionIds = Lists.newArrayList();
     private final List<String> targetColumnNames;
-    private final QueryStmt queryStmt;
+    private QueryStmt queryStmt;
     private final List<String> planHints;
     private Boolean isRepartition;
     private boolean isStreaming = false;
@@ -202,6 +202,10 @@ public class InsertStmt extends DdlStmt {
 
     public QueryStmt getQueryStmt() {
         return queryStmt;
+    }
+
+    public void setQueryStmt(QueryStmt queryStmt) {
+        this.queryStmt = queryStmt;
     }
 
 

--- a/fe/src/main/java/org/apache/doris/analysis/OrderByElement.java
+++ b/fe/src/main/java/org/apache/doris/analysis/OrderByElement.java
@@ -129,6 +129,12 @@ public class OrderByElement {
 
         return strBuilder.toString();
     }
+
+    @Override
+    public String toString() {
+        return toSql();
+    }
+
     @Override
     public boolean equals(Object obj) {
         if (obj == null) {

--- a/fe/src/main/java/org/apache/doris/analysis/QueryStmt.java
+++ b/fe/src/main/java/org/apache/doris/analysis/QueryStmt.java
@@ -100,6 +100,11 @@ public abstract class QueryStmt extends StatementBase {
     // used by hll
     protected boolean fromInsert = false;
 
+    // order by elements which has been analyzed
+    // For example: select k1 a from t order by a;
+    // this parameter: order by t.k1
+    protected List<OrderByElement> orderByElementsAfterAnalyzed;
+
     /////////////////////////////////////////
     // END: Members that need to be reset()
 
@@ -225,6 +230,14 @@ public abstract class QueryStmt extends StatementBase {
             nullsFirstParams.add(orderByElement.getNullsFirstParam());
         }
         substituteOrdinalsAliases(orderingExprs, "ORDER BY", analyzer);
+
+        // save the order by element after analyzed
+        orderByElementsAfterAnalyzed = Lists.newArrayList();
+        for (int i = 0; i < orderByElements.size(); i++) {
+            OrderByElement orderByElement = new OrderByElement(orderingExprs.get(i), isAscOrder.get(i),
+                    nullsFirstParams.get(i));
+            orderByElementsAfterAnalyzed.add(orderByElement);
+        }
 
         if (!analyzer.isRootAnalyzer() && hasOffset() && !hasLimit()) {
             throw new AnalysisException("Order-by with offset without limit not supported" +
@@ -392,6 +405,10 @@ public abstract class QueryStmt extends StatementBase {
         return orderByElements;
     }
 
+    public List<OrderByElement> getOrderByElementsAfterAnalyzed() {
+        return orderByElementsAfterAnalyzed;
+    }
+
     public void removeOrderByElements() {
         orderByElements = null;
     }
@@ -529,6 +546,7 @@ public abstract class QueryStmt extends StatementBase {
         baseTblResultExprs.clear();
         aliasSMap.clear();
         ambiguousAliasList.clear();
+        orderByElementsAfterAnalyzed = null;
         sortInfo = null;
         evaluateOrderBy = false;
         fromInsert = false;

--- a/fe/src/main/java/org/apache/doris/analysis/QueryStmt.java
+++ b/fe/src/main/java/org/apache/doris/analysis/QueryStmt.java
@@ -494,6 +494,8 @@ public abstract class QueryStmt extends StatementBase {
         return withClause_ != null ? withClause_.clone() : null;
     }
 
+    public abstract boolean containsCorrelatedPredicate();
+
     /**
      * C'tor for cloning.
      */

--- a/fe/src/main/java/org/apache/doris/analysis/QueryStmt.java
+++ b/fe/src/main/java/org/apache/doris/analysis/QueryStmt.java
@@ -515,8 +515,6 @@ public abstract class QueryStmt extends StatementBase {
         return withClause_ != null ? withClause_.clone() : null;
     }
 
-    public abstract boolean containsCorrelatedPredicate();
-
     /**
      * C'tor for cloning.
      */

--- a/fe/src/main/java/org/apache/doris/analysis/QueryStmt.java
+++ b/fe/src/main/java/org/apache/doris/analysis/QueryStmt.java
@@ -415,6 +415,10 @@ public abstract class QueryStmt extends StatementBase {
         limitElement = new LimitElement(newLimit);
     }
 
+    public void removeLimitElement() {
+        limitElement = LimitElement.NO_LIMIT;
+    }
+
     public long getOffset() {
         return limitElement.getOffset();
     }

--- a/fe/src/main/java/org/apache/doris/analysis/SelectStmt.java
+++ b/fe/src/main/java/org/apache/doris/analysis/SelectStmt.java
@@ -97,7 +97,7 @@ public class SelectStmt extends QueryStmt {
 
     // having clause which has been analyzed
     // For example: select k1, sum(k2) a from t group by k1 having a>1;
-    // this parameter: having sum(t.k2) > 1
+    // this parameter: sum(t.k2) > 1
     private Expr havingClauseAfterAnaylzed;
 
     // END: Members that need to be reset()
@@ -877,7 +877,7 @@ public class SelectStmt extends QueryStmt {
              * having predicate: table.k1 > 1
              */
             /*
-             * TODO(ml): support substitute outer column in subquery
+             * TODO(ml): support substitute outer column in correlated subquery
              * For example: select k1 key, sum(k1) sum_k1 from table a group by k1
              *              having k1 >
              *                     (select min(k1) from table b where a.key=b.k2);
@@ -1474,22 +1474,6 @@ public class SelectStmt extends QueryStmt {
         }
         // In all other cases, return false.
         return false;
-    }
-
-    @Override
-    public boolean containsCorrelatedPredicate() {
-        // check inline view
-        for (TableRef tableRef : fromClause_.getTableRefs()) {
-            if (tableRef instanceof InlineViewRef) {
-                if (((InlineViewRef) tableRef).getViewStmt().containsCorrelatedPredicate()) {
-                    return true;
-                }
-            }
-        }
-        if (whereClause == null) {
-            return false;
-        }
-        return whereClause.isCorrelatedPredicate(getTableRefIds());
     }
 
     @Override

--- a/fe/src/main/java/org/apache/doris/analysis/SetOperationStmt.java
+++ b/fe/src/main/java/org/apache/doris/analysis/SetOperationStmt.java
@@ -22,11 +22,11 @@ import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.UserException;
 import org.apache.doris.rewrite.ExprRewriter;
 
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
-
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -616,6 +616,16 @@ public class SetOperationStmt extends QueryStmt {
         }
     }
 
+    @Override
+    public boolean containsCorrelatedPredicate() {
+        for (SetOperand setOperand : operands) {
+            if (setOperand.getQueryStmt().containsCorrelatedPredicate()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     /**
      * Represents an operand to a SetOperand. It consists of a query statement and its left
      * all/distinct qualifier (null for the first operand).
@@ -631,7 +641,7 @@ public class SetOperationStmt extends QueryStmt {
         // ///////////////////////////////////////
         // BEGIN: Members that need to be reset()
 
-        private final QueryStmt queryStmt;
+        private QueryStmt queryStmt;
 
         // Analyzer used for this operand. Set in analyze().
         // We must preserve the conjuncts registered in the analyzer for partition pruning.
@@ -699,6 +709,9 @@ public class SetOperationStmt extends QueryStmt {
 
         public void setOperation(Operation operation) {
             this.operation =operation;
+        }
+        public void setQueryStmt(QueryStmt queryStmt) {
+            this.queryStmt = queryStmt;
         }
         public Analyzer getAnalyzer() { return analyzer; }
         public ExprSubstitutionMap getSmap() { return smap_; }

--- a/fe/src/main/java/org/apache/doris/analysis/SetOperationStmt.java
+++ b/fe/src/main/java/org/apache/doris/analysis/SetOperationStmt.java
@@ -616,16 +616,6 @@ public class SetOperationStmt extends QueryStmt {
         }
     }
 
-    @Override
-    public boolean containsCorrelatedPredicate() {
-        for (SetOperand setOperand : operands) {
-            if (setOperand.getQueryStmt().containsCorrelatedPredicate()) {
-                return true;
-            }
-        }
-        return false;
-    }
-
     /**
      * Represents an operand to a SetOperand. It consists of a query statement and its left
      * all/distinct qualifier (null for the first operand).

--- a/fe/src/main/java/org/apache/doris/analysis/StmtRewriter.java
+++ b/fe/src/main/java/org/apache/doris/analysis/StmtRewriter.java
@@ -186,10 +186,13 @@ public class StmtRewriter {
         inlineViewQuery.removeOrderByElements();
         inlineViewQuery.removeLimitElement();
         // add missing aggregation columns
-        inlineViewQuery.setSelectList(addMissingAggregationColumns(selectList, aggregateExprs));
+        SelectList selectListOfInlineViewQuery = addMissingAggregationColumns(selectList, aggregateExprs);
+        inlineViewQuery.setSelectList(selectListOfInlineViewQuery);
         // add a new alias for all of columns in subquery
         List<String> colAliasOfInlineView = Lists.newArrayList();
-        for (int i = 0; i < inlineViewQuery.getSelectList().getItems().size(); ++i) {
+        List<Expr> leftExprList = Lists.newArrayList();
+        for (int i = 0; i < selectListOfInlineViewQuery.getItems().size(); ++i) {
+            leftExprList.add(selectListOfInlineViewQuery.getItems().get(i).getExpr());
             colAliasOfInlineView.add(inlineViewQuery.getColumnAliasGenerator().getNextAlias());
         }
         InlineViewRef inlineViewRef = new InlineViewRef(tableAliasGenerator.getNextAlias(), inlineViewQuery,
@@ -223,7 +226,7 @@ public class StmtRewriter {
         ExprSubstitutionMap smap = new ExprSubstitutionMap();
         List<SelectListItem> inlineViewItems = inlineViewQuery.getSelectList().getItems();
         for (int i = 0; i < inlineViewItems.size(); i++) {
-            Expr leftExpr = inlineViewItems.get(i).getExpr();
+            Expr leftExpr = leftExprList.get(i);
             Expr rightExpr = new SlotRef(inlineViewRef.getAliasAsName(), colAliasOfInlineView.get(i));
             rightExpr.analyze(analyzer);
             smap.put(leftExpr, rightExpr);

--- a/fe/src/main/java/org/apache/doris/analysis/StmtRewriter.java
+++ b/fe/src/main/java/org/apache/doris/analysis/StmtRewriter.java
@@ -252,20 +252,6 @@ public class StmtRewriter {
 
 
     /**
-     * Situation: The expr is a binary predicate and the type of subquery is not scalar type.
-     * Rewrite: The stmt of inline view is added an assert condition (return error if row count > 1).
-     * Input params:
-     *     expr: k1=(select k1 from t2)
-     *     origin inline view: (select k1 $a from t2) $b
-     *     stmt: select * from t1 where k1=(select k1 from t2);
-     * Output params:
-     *     rewritten inline view: (select k1 $a from t2 (assert row count: return error if row count > 1)) $b
-     */
-    private static void rewriteBinaryPredicateWithSubquery(InlineViewRef inlineViewRef) {
-        inlineViewRef.getViewStmt().setAssertNumRowsElement(1);
-    }
-
-    /**
      * Replace an ExistsPredicate that contains a subquery with a BoolLiteral if we
      * can determine its result without evaluating it. Return null if the result of the
      * ExistsPredicate can only be determined at run-time.
@@ -401,10 +387,6 @@ public class StmtRewriter {
             // For uncorrelated subqueries, we limit the number of rows returned by the
             // subquery.
             subqueryStmt.setLimit(1);
-        }
-
-        if (expr instanceof BinaryPredicate && !expr.getSubquery().getType().isScalarType()) {
-            rewriteBinaryPredicateWithSubquery(inlineView);
         }
 
         // Analyzing the inline view trigger reanalysis of the subquery's select statement.

--- a/fe/src/main/java/org/apache/doris/analysis/StmtRewriter.java
+++ b/fe/src/main/java/org/apache/doris/analysis/StmtRewriter.java
@@ -219,7 +219,7 @@ public class StmtRewriter {
         ArrayList<OrderByElement> newOrderByElements = null;
         if (orderByElements != null) {
             newOrderByElements = OrderByElement.substitute(orderByElements, smap, analyzer);
-            LOG.debug("Order by is changed to " + Joiner.on(",").join(newOrderByElements);
+            LOG.debug("Order by is changed to " + Joiner.on(",").join(newOrderByElements));
         }
 
         // construct rewritten query

--- a/fe/src/main/java/org/apache/doris/analysis/StmtRewriter.java
+++ b/fe/src/main/java/org/apache/doris/analysis/StmtRewriter.java
@@ -228,7 +228,6 @@ public class StmtRewriter {
             rightExpr.analyze(analyzer);
             smap.put(leftExpr, rightExpr);
         }
-        havingClause.reset();
         Expr newWherePredicate = havingClause.substitute(smap, analyzer, false);
         LOG.debug("Having predicate is changed to " + newWherePredicate.toSql());
         ArrayList<OrderByElement> newOrderByElements = null;

--- a/fe/src/main/java/org/apache/doris/analysis/StmtRewriter.java
+++ b/fe/src/main/java/org/apache/doris/analysis/StmtRewriter.java
@@ -245,7 +245,7 @@ public class StmtRewriter {
         for (SelectListItem item : selectList.getItems()) {
             SelectListItem newItem = new SelectListItem(item.getExpr().substitute(smap), item.getAlias());
             newSelectItems.add(newItem);
-            LOG.debug("New select item is changed to "+ newItem.toString());
+            LOG.debug("New select item is changed to "+ newItem.toSql());
         }
         SelectList newSelectList = new SelectList(newSelectItems, selectList.isDistinct());
 
@@ -281,9 +281,10 @@ public class StmtRewriter {
         SelectList result = selectList.clone();
         for (FunctionCallExpr functionCallExpr : aggregateExprs) {
             boolean columnExists = false;
-            for (SelectListItem selectListItem : result.getItems()) {
+            for (SelectListItem selectListItem : selectList.getItems()) {
                 if (selectListItem.getExpr().equals(functionCallExpr)) {
                     columnExists = true;
+                    break;
                 }
             }
             if (!columnExists) {

--- a/fe/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -439,7 +439,7 @@ public class StmtExecutor {
                     parsedStmt.rewriteExprs(rewriter);
                     reAnalyze = rewriter.changed();
                     if (analyzer.containSubquery()) {
-                        StmtRewriter.rewrite(analyzer, parsedStmt);
+                        parsedStmt = StmtRewriter.rewrite(analyzer, parsedStmt);
                         reAnalyze = true;
                     }
                     if (reAnalyze) {

--- a/fe/src/test/java/org/apache/doris/analysis/BinaryPredicateTest.java
+++ b/fe/src/test/java/org/apache/doris/analysis/BinaryPredicateTest.java
@@ -17,9 +17,13 @@
 
 package org.apache.doris.analysis;
 
+import org.apache.doris.catalog.Type;
 import org.apache.doris.common.AnalysisException;
 
 import org.apache.doris.common.jmockit.Deencapsulation;
+
+import com.google.common.collect.Lists;
+
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -52,12 +56,16 @@ public class BinaryPredicateTest {
 
     @Test
     public void testSingleColumnSubquery(@Injectable Expr child0,
-                                         @Injectable Subquery child1) {
+                                         @Injectable QueryStmt subquery,
+            @Injectable SlotRef slotRef) {
+        Subquery child1 = new Subquery(subquery);
         BinaryPredicate binaryPredicate = new BinaryPredicate(BinaryPredicate.Operator.EQ, child0, child1);
         new Expectations() {
             {
-                child1.returnsScalarColumn();
-                result = true;
+                subquery.getResultExprs();
+                result = Lists.newArrayList(slotRef);
+                slotRef.getType();
+                result = Type.INT;
             }
         };
 

--- a/fe/src/test/java/org/apache/doris/analysis/StmtRewriterTest.java
+++ b/fe/src/test/java/org/apache/doris/analysis/StmtRewriterTest.java
@@ -1,0 +1,55 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.analysis;
+
+import org.apache.doris.common.FeConstants;
+import org.apache.doris.utframe.DorisAssert;
+import org.apache.doris.utframe.UtFrameUtils;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.UUID;
+
+public class StmtRewriterTest {
+
+    private static String baseDir = "fe";
+    private static String runningDir = baseDir + "/mocked/StmtRewriterTest/"
+            + UUID.randomUUID().toString() + "/";
+    private static final String TABLE_NAME = "table1";
+    private static final String DB_NAME = "db1";
+    private static DorisAssert dorisAssert;
+
+    @BeforeClass
+    public void beforeClass() throws Exception{
+        FeConstants.runningUnitTest = true;
+        UtFrameUtils.createMinDorisCluster(runningDir);
+        dorisAssert = new DorisAssert();
+        dorisAssert.withDatabase(DB_NAME).useDatabase(DB_NAME);
+        String createTableSQL = "create table " + DB_NAME + "." + TABLE_NAME + " (empid int, name varchar, "
+                + "deptno int, salary int, commission int) partition by range (empid) "
+                + "(partition p1 values less than MAXVALUE) "
+                + "distributed by hash(empid) buckets 3 properties('replication_num' = '1');";
+        dorisAssert.withTable(createTableSQL);
+    }
+
+    @Test
+    public void testRewriteHavingClauseSubqueries() {
+
+    }
+}


### PR DESCRIPTION
This commit support the non-correlated subquery in having clause.
For example:
select k1, sum(k2) from table group by k1 having sum(k2) > (select avg(k1) from table)

Also the non-scalar subquery is supported in Doris.
For example:
select k1, sum(k2) from table group by k1 having sum(k2) > (select avg(k1) from table group by k2)
Doris will check the result row numbers of subquery in executing.
If more then one row returned by subquery, the query will throw exception.

The implement method:
The entire outer query is regarded as inline view of new query.
The subquery in having clause is changed to the where predicate in this new query.

After this commit, tpc-ds 23,24,44 are supported.

This commit also support the subquery in ArithmeticExpr.
For example:
select k1  from table where k1=0.9*(select k1 from t);