### PR TITLE
Revert "Remove deep copy when doing hash table EvalRow (#3171)"

### DIFF
--- a/be/src/exec/partitioned_hash_table.cc
+++ b/be/src/exec/partitioned_hash_table.cc
@@ -235,7 +235,7 @@ bool PartitionedHashTableCtx::EvalRow(TupleRow* row, const vector<ExprContext*>&
       expr_values_null[i] = false;
       DCHECK_LE(build_exprs_[i]->type().get_slot_size(),
           sizeof(NULL_VALUE));
-      RawValue::write(val, loc, build_exprs_[i]->type(), nullptr);
+      RawValue::write(val, loc, build_exprs_[i]->type(), expr_results_pool_);
     }
   }
   return has_null;


### PR DESCRIPTION
This reverts commit dd8d748c55fd6a4e95f7e692f8958a66dfdd9c18.