### PR TITLE
Solve the problem of mv selector when there is having clause in query

### DIFF
--- a/fe/src/main/java/org/apache/doris/analysis/TupleDescriptor.java
+++ b/fe/src/main/java/org/apache/doris/analysis/TupleDescriptor.java
@@ -261,7 +261,7 @@ public class TupleDescriptor {
 
     public void getTableNameToColumnNames(Map<String, Set<String>> tupleDescToColumnNames) {
         for (SlotDescriptor slotDescriptor : slots) {
-            if (slotDescriptor.isMaterialized() == false) {
+            if (!slotDescriptor.isMaterialized()) {
                 continue;
             }
             if (slotDescriptor.getColumn() != null) {

--- a/fe/src/main/java/org/apache/doris/analysis/TupleDescriptor.java
+++ b/fe/src/main/java/org/apache/doris/analysis/TupleDescriptor.java
@@ -32,6 +32,9 @@ import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
 
 public class TupleDescriptor {
     private static final Logger LOG = LogManager.getLogger(TupleDescriptor.class);
@@ -254,6 +257,31 @@ public class TupleDescriptor {
      */
     public void materializeSlots() {
         for (SlotDescriptor slot: slots) slot.setIsMaterialized(true);
+    }
+
+    public void getTableNameToColumnNames(Map<String, Set<String>> tupleDescToColumnNames) {
+        for (SlotDescriptor slotDescriptor : slots) {
+            if (slotDescriptor.isMaterialized() == false) {
+                continue;
+            }
+            if (slotDescriptor.getColumn() != null) {
+                TupleDescriptor parent = slotDescriptor.getParent();
+                Preconditions.checkState(parent != null);
+                Table table = parent.getTable();
+                Preconditions.checkState(table != null);
+                String tableName = table.getName();
+                Set<String> columnNames = tupleDescToColumnNames.get(tableName);
+                if (columnNames == null) {
+                    columnNames = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
+                    tupleDescToColumnNames.put(tableName, columnNames);
+                }
+                columnNames.add(slotDescriptor.getColumn().getName());
+            } else {
+                for (Expr expr : slotDescriptor.getSourceExprs()) {
+                    expr.getTableNameToColumnNames(tupleDescToColumnNames);
+                }
+            }
+        }
     }
 
     @Override

--- a/fe/src/main/java/org/apache/doris/planner/MaterializedViewSelector.java
+++ b/fe/src/main/java/org/apache/doris/planner/MaterializedViewSelector.java
@@ -25,6 +25,8 @@ import org.apache.doris.analysis.FunctionCallExpr;
 import org.apache.doris.analysis.SelectStmt;
 import org.apache.doris.analysis.SlotRef;
 import org.apache.doris.analysis.TableRef;
+import org.apache.doris.analysis.TupleDescriptor;
+import org.apache.doris.analysis.TupleId;
 import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.KeysType;
 import org.apache.doris.catalog.MaterializedIndexMeta;
@@ -42,6 +44,7 @@ import com.google.common.collect.Sets;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
@@ -474,8 +477,13 @@ public class MaterializedViewSelector {
         }
 
         // Step4: compute the output column
-        for (Expr resultExpr : selectStmt.getResultExprs()) {
-            resultExpr.getTableNameToColumnNames(columnNamesInQueryOutput);
+        // ISSUE-3174: all of columns which belong to top tuple should be considered in selector.
+        ArrayList<TupleId> topTupleIds = Lists.newArrayList();
+        selectStmt.getMaterializedTupleIds(topTupleIds);
+        for (TupleId tupleId : topTupleIds) {
+            TupleDescriptor tupleDescriptor = analyzer.getTupleDesc(tupleId);
+            tupleDescriptor.getTableNameToColumnNames(columnNamesInQueryOutput);
+
         }
     }
 

--- a/fe/src/test/java/org/apache/doris/planner/MaterializedViewSelectorTest.java
+++ b/fe/src/test/java/org/apache/doris/planner/MaterializedViewSelectorTest.java
@@ -108,18 +108,8 @@ public class MaterializedViewSelectorTest {
                 tableBColumn1.getTableName().getTbl();
                 result = "tableB";
 
-                selectStmt.getResultExprs();
-                result = Lists.newArrayList(tableAColumn1, tableAColumn2Sum, tableBColumn1Max);
-                tableAColumn2Desc.isMaterialized();
-                result = true;
-                tableAColumn2Desc.getColumn().getName();
-                result = "c2";
                 tableAColumn2Desc.getParent();
                 result = tableADesc;
-                tableBColumn1Desc.isMaterialized();
-                result = true;
-                tableBColumn1Desc.getColumn().getName();
-                result = "c1";
                 tableBColumn1Desc.getParent();
                 result = tableBDesc;
                 tableBDesc.getTable();
@@ -154,16 +144,6 @@ public class MaterializedViewSelectorTest {
         MaterializedViewSelector.AggregatedColumn aggregatedColumn2 = tableBAgggregatedColumns.iterator().next();
         Assert.assertEquals("c1", Deencapsulation.getField(aggregatedColumn2, "columnName"));
         Assert.assertTrue("MAX".equalsIgnoreCase(Deencapsulation.getField(aggregatedColumn2, "aggFunctionName")));
-        Map<String, Set<String>> columnNamesInQueryOutput =
-                Deencapsulation.getField(materializedViewSelector, "columnNamesInQueryOutput");
-        Assert.assertEquals(2, columnNamesInQueryOutput.size());
-        Set<String> tableAColumnNamesInQueryOutput = columnNamesInQueryOutput.get("tableA");
-        Assert.assertEquals(2, tableAColumnNamesInQueryOutput.size());
-        Assert.assertTrue(tableAColumnNamesInQueryOutput.contains("c1"));
-        Assert.assertTrue(tableAColumnNamesInQueryOutput.contains("c2"));
-        Set<String> tableBColumnNamesInQueryOutput = columnNamesInQueryOutput.get("tableB");
-        Assert.assertEquals(1, tableBColumnNamesInQueryOutput.size());
-        Assert.assertTrue(tableBColumnNamesInQueryOutput.contains("c1"));
     }
 
     @Test
@@ -195,8 +175,6 @@ public class MaterializedViewSelectorTest {
             {
                 selectStmt.getAggInfo();
                 result = null;
-                selectStmt.getResultExprs();
-                result = Lists.newArrayList();
                 indexMeta1.getSchema();
                 result = index1Columns;
                 indexMeta2.getSchema();
@@ -243,8 +221,6 @@ public class MaterializedViewSelectorTest {
             {
                 selectStmt.getAggInfo();
                 result = null;
-                selectStmt.getResultExprs();
-                result = Lists.newArrayList();
                 indexMeta1.getSchema();
                 result = index1Columns;
                 indexMeta1.getKeysType();
@@ -290,8 +266,6 @@ public class MaterializedViewSelectorTest {
             {
                 selectStmt.getAggInfo();
                 result = null;
-                selectStmt.getResultExprs();
-                result = Lists.newArrayList();
                 indexMeta1.getSchema();
                 result = index1Columns;
                 indexMeta2.getSchema();
@@ -340,8 +314,6 @@ public class MaterializedViewSelectorTest {
             {
                 selectStmt.getAggInfo();
                 result = null;
-                selectStmt.getResultExprs();
-                result = Lists.newArrayList();
                 indexMeta1.getSchema();
                 result = index1Columns;
                 indexMeta2.getSchema();
@@ -389,8 +361,6 @@ public class MaterializedViewSelectorTest {
             {
                 selectStmt.getAggInfo();
                 result = null;
-                selectStmt.getResultExprs();
-                result = Lists.newArrayList();
                 table.getBaseIndexId();
                 result = -1L;
                 table.getKeyColumnsByIndexId(-1L);
@@ -443,8 +413,6 @@ public class MaterializedViewSelectorTest {
             {
                 selectStmt.getAggInfo();
                 result = null;
-                selectStmt.getResultExprs();
-                result = Lists.newArrayList();
             }
         };
         Set<String> equivalenceColumns = Sets.newHashSet();


### PR DESCRIPTION
All of columns which belong to top of tupleIds in query shoud be considered in mv selecotr.
For example:
Select k1 from table group by k1 having sum(v1) >1;
The candidate index should contain k1 and v1 columns instread of only k1.
The rollup which only has k1 column should not be selected.
The issue #3174 describe in detail.