### PR TITLE
[BUG] Make default result ordering of SHOW PARTITIONS be consist with 0.11

### DIFF
--- a/fe/src/main/java/org/apache/doris/catalog/OlapTable.java
+++ b/fe/src/main/java/org/apache/doris/catalog/OlapTable.java
@@ -1444,10 +1444,6 @@ public class OlapTable extends Table {
         tempPartitions.dropAll();
     }
 
-    public Collection<Partition> getAllTempPartitions() {
-        return tempPartitions.getAllPartitions();
-    }
-
     public boolean existTempPartitions() {
         return !tempPartitions.isEmpty();
     }

--- a/fe/src/test/java/org/apache/doris/catalog/TempPartitionTest.java
+++ b/fe/src/test/java/org/apache/doris/catalog/TempPartitionTest.java
@@ -578,7 +578,7 @@ public class TempPartitionTest {
 
         OlapTable readTbl = (OlapTable) Table.read(in);
         Assert.assertEquals(tbl.getId(), readTbl.getId());
-        Assert.assertEquals(tbl.getAllTempPartitions().size(), readTbl.getAllTempPartitions().size());
+        Assert.assertEquals(tbl.getTempPartitions().size(), readTbl.getTempPartitions().size());
         file.delete();
     }
 


### PR DESCRIPTION
Previously in 0.11, the results of SHOW PARTITIONS statement for range partitioned table is returned in ascending range order. #2828 changes the behavior to non-deterministic order, which may break some existing tools that relies on the ordering.

This CL makes the result ordering to be consist with 0.11