### PR TITLE
fix join hints not work when need table reorder

### DIFF
--- a/fe/src/main/java/org/apache/doris/analysis/SelectStmt.java
+++ b/fe/src/main/java/org/apache/doris/analysis/SelectStmt.java
@@ -610,15 +610,12 @@ public class SelectStmt extends QueryStmt {
         }
     }
 
-    // When a join statement with a join hint, the decorated part should be reordered as a whole,
-    // rather than individually.
     protected void reorderTable(Analyzer analyzer) throws AnalysisException {
-        List<Pair<List<TableRef>, Long>> candidates = Lists.newArrayList();
+        List<Pair<TableRef, Long>> candidates = Lists.newArrayList();
 
-        for (int i = 0; i < fromClause_.size(); ++i) {
-            List<TableRef> tableRefs = new ArrayList<>();
-            TableRef tblRef = fromClause_.get(i);
-            if (tblRef.getJoinOp() != JoinOperator.INNER_JOIN) {
+        // New pair of table ref and row count
+        for (TableRef tblRef : fromClause_) {
+            if (tblRef.getJoinOp() != JoinOperator.INNER_JOIN || tblRef.hasJoinHints()) {
                 // Unsupported reorder outer join
                 return;
             }
@@ -627,32 +624,14 @@ public class SelectStmt extends QueryStmt {
                 rowCount = ((OlapTable) (tblRef.getTable())).getRowCount();
                 LOG.debug("tableName={} rowCount={}", tblRef.getAlias(), rowCount);
             }
-            tableRefs.add(tblRef);
-            if (i < fromClause_.size() - 1) {
-                for (int j = i + 1; j < fromClause_.size(); ++j) {
-                    if (fromClause_.get(j).getJoinOp() != JoinOperator.INNER_JOIN) {
-                        // Unsupported reorder outer join
-                        return;
-                    }
-                    if (fromClause_.get(j).hasJoinHints()) {
-                        tableRefs.add(fromClause_.get(j));
-                        i++;
-                    } else {
-                        break;
-                    }
-                }
-            }
-            candidates.add(new Pair(tableRefs, rowCount));
+            candidates.add(new Pair(tblRef, rowCount));
         }
-
         // give InlineView row count
         long last = 0;
         for (int i = candidates.size() - 1; i >= 0; --i) {
-            Pair<List<TableRef>, Long> candidate = candidates.get(i);
-            for (TableRef tableRef : candidate.first) {
-                if (tableRef instanceof InlineViewRef) {
-                    candidate.second = last;
-                }
+            Pair<TableRef, Long> candidate = candidates.get(i);
+            if (candidate.first instanceof InlineViewRef) {
+                candidate.second = last;
             }
             last = candidate.second + 1;
         }
@@ -660,7 +639,7 @@ public class SelectStmt extends QueryStmt {
         // order oldRefList by row count
         Collections.sort(candidates, (a, b) -> b.second.compareTo(a.second));
 
-        for (Pair<List<TableRef>, Long> candidate : candidates) {
+        for (Pair<TableRef, Long> candidate : candidates) {
             if (reorderTable(analyzer, candidate.first)) {
                 // as long as one scheme success, we return this scheme immediately.
                 // in this scheme, candidate.first will be consider to be the big table in star schema.
@@ -671,13 +650,13 @@ public class SelectStmt extends QueryStmt {
 
         // can not get AST only with equal join, MayBe cross join can help
         fromClause_.clear();
-        for (Pair<List<TableRef>, Long> candidate : candidates) {
-            fromClause_.addAll(candidate.first);
+        for (Pair<TableRef, Long> candidate : candidates) {
+            fromClause_.add(candidate.first);
         }
     }
 
     // reorder select table
-    protected boolean reorderTable(Analyzer analyzer, List<TableRef> firstRefs)
+    protected boolean reorderTable(Analyzer analyzer, TableRef firstRef)
             throws AnalysisException {
         List<TableRef> tmpRefList = Lists.newArrayList();
         Map<TupleId, TableRef> tableRefMap = Maps.newHashMap();
@@ -690,13 +669,12 @@ public class SelectStmt extends QueryStmt {
         // clear tableRefList
         fromClause_.clear();
         // mark first table
+        fromClause_.add(firstRef);
+        tableRefMap.remove(firstRef.getId());
+
+        // reserve TupleId has been added successfully
         Set<TupleId> validTupleId = Sets.newHashSet();
-        fromClause_.addAll(firstRefs);
-        for (TableRef firstRef : firstRefs) {
-            tableRefMap.remove(firstRef.getId());
-            // reserve TupleId has been added successfully
-            validTupleId.add(firstRef.getId());
-        }
+        validTupleId.add(firstRef.getId());
         // find table
         int i = 0;
         while (i < fromClause_.size()) {
@@ -712,12 +690,7 @@ public class SelectStmt extends QueryStmt {
                 }
                 TableRef candidateTableRef = tableRefMap.get(tid);
                 if (candidateTableRef != null) {
-                    int idx = tmpRefList.indexOf(candidateTableRef);
-                    // if table has join hints ignore it
-                    if (candidateTableRef.hasJoinHints() ||
-                            idx != -1 && idx != tmpRefList.size() - 1 && tmpRefList.get(idx + 1).hasJoinHints()) {
-                        continue;
-                    }
+
                     // When sorting table according to the rows, you must ensure
                     // that all tables On-conjuncts referenced has been added or
                     // is being added.
@@ -736,14 +709,6 @@ public class SelectStmt extends QueryStmt {
                         fromClause_.add(candidateTableRef);
                         validTupleId.add(tid);
                         tableRefMap.remove(tid);
-                        for (int j = idx + 1; j < tmpRefList.size(); ++j) {
-                            if (tmpRefList.get(j).hasJoinHints()) {
-                                fromClause_.add(tmpRefList.get(j));
-                                validTupleId.add(tmpRefList.get(j).getId());
-                                tableRefMap.remove(tmpRefList.get(j).getId());
-                                i++;
-                            }
-                        }
                     }
                 }
             }

--- a/fe/src/main/java/org/apache/doris/analysis/SelectStmt.java
+++ b/fe/src/main/java/org/apache/doris/analysis/SelectStmt.java
@@ -610,7 +610,7 @@ public class SelectStmt extends QueryStmt {
         }
     }
 
-    // When a join statement with a join hit, the decorated part should be reordered as a whole,
+    // When a join statement with a join hint, the decorated part should be reordered as a whole,
     // rather than individually.
     protected void reorderTable(Analyzer analyzer) throws AnalysisException {
         List<Pair<List<TableRef>, Long>> candidates = Lists.newArrayList();
@@ -637,6 +637,8 @@ public class SelectStmt extends QueryStmt {
                     if (fromClause_.get(j).hasJoinHints()) {
                         tableRefs.add(fromClause_.get(j));
                         i++;
+                    } else {
+                        break;
                     }
                 }
             }

--- a/fe/src/main/java/org/apache/doris/analysis/TableRef.java
+++ b/fe/src/main/java/org/apache/doris/analysis/TableRef.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.analysis;
 
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.doris.catalog.Catalog;
 import org.apache.doris.catalog.Table;
 import org.apache.doris.common.AnalysisException;
@@ -301,7 +302,7 @@ public class TableRef implements ParseNode, Writable {
     }
 
     public boolean hasJoinHints() {
-        return joinHints != null && !joinHints.isEmpty();
+        return CollectionUtils.isNotEmpty(joinHints);
     }
 
     public void setJoinHints(ArrayList<String> hints) {

--- a/fe/src/main/java/org/apache/doris/analysis/TableRef.java
+++ b/fe/src/main/java/org/apache/doris/analysis/TableRef.java
@@ -296,6 +296,14 @@ public class TableRef implements ParseNode, Writable {
         this.leftTblRef = leftTblRef;
     }
 
+    public ArrayList<String> getJoinHints() {
+        return joinHints;
+    }
+
+    public boolean hasJoinHints() {
+        return joinHints != null && !joinHints.isEmpty();
+    }
+
     public void setJoinHints(ArrayList<String> hints) {
         this.joinHints = hints;
     }
@@ -338,11 +346,21 @@ public class TableRef implements ParseNode, Writable {
         }
         for (String hint : joinHints) {
             if (hint.toUpperCase().equals("BROADCAST")) {
+                if (joinOp == JoinOperator.RIGHT_OUTER_JOIN
+                        || joinOp == JoinOperator.FULL_OUTER_JOIN
+                        || joinOp == JoinOperator.RIGHT_SEMI_JOIN
+                        || joinOp == JoinOperator.RIGHT_ANTI_JOIN) {
+                    throw new AnalysisException(
+                            joinOp.toString() + " does not support BROADCAST.");
+                }
                 if (isPartitionJoin) {
                     throw new AnalysisException("Conflicting JOIN hint: " + hint);
                 }
                 isBroadcastJoin = true;
             } else if (hint.toUpperCase().equals("SHUFFLE")) {
+                if (joinOp == JoinOperator.CROSS_JOIN) {
+                    throw new AnalysisException("CROSS JOIN does not support SHUFFLE.");
+                }
                 if (isBroadcastJoin) {
                     throw new AnalysisException("Conflicting JOIN hint: " + hint);
                 }

--- a/fe/src/main/java/org/apache/doris/planner/CrossJoinNode.java
+++ b/fe/src/main/java/org/apache/doris/planner/CrossJoinNode.java
@@ -59,16 +59,16 @@ public class CrossJoinNode extends PlanNode {
 
     @Override
     public void computeStats(Analyzer analyzer) {
-        // super.computeStats(analyzer);
-        // if (getChild(0).cardinality_ == -1 || getChild(1).cardinality_ == -1) {
-        //   cardinality_ = -1;
-        // } else {
-        //   cardinality_ = getChild(0).cardinality_ * getChild(1).cardinality_;
-        //   if (computeSelectivity() != -1) {
-        //     cardinality_ = Math.round(((double) cardinality_) * computeSelectivity());
-        //   }
-        // }
-        // LOG.debug("stats CrossJoin: cardinality=" + Long.toString(cardinality_));
+         super.computeStats(analyzer);
+         if (getChild(0).cardinality == -1 || getChild(1).cardinality == -1) {
+           cardinality = -1;
+         } else {
+           cardinality = getChild(0).cardinality * getChild(1).cardinality;
+           if (computeSelectivity() != -1) {
+             cardinality = Math.round(((double) cardinality) * computeSelectivity());
+           }
+         }
+         LOG.debug("stats CrossJoin: cardinality=" + Long.toString(cardinality));
     }
 
     @Override

--- a/fe/src/main/java/org/apache/doris/planner/CrossJoinNode.java
+++ b/fe/src/main/java/org/apache/doris/planner/CrossJoinNode.java
@@ -68,7 +68,7 @@ public class CrossJoinNode extends PlanNode {
              cardinality = Math.round(((double) cardinality) * computeSelectivity());
            }
          }
-         LOG.debug("stats CrossJoin: cardinality=" + Long.toString(cardinality));
+         LOG.debug("stats CrossJoin: cardinality={}", Long.toString(cardinality));
     }
 
     @Override


### PR DESCRIPTION
1 fix join hints not work when need table reorder, this bug is described in #3187
2 fix cross join node does not implement `computeStats`, this will  cause brodcast join cost always 0 #3195