### PR TITLE
[Plugin] Create the FE plugin dir if missing

### DIFF
--- a/fe/src/main/java/org/apache/doris/catalog/Catalog.java
+++ b/fe/src/main/java/org/apache/doris/catalog/Catalog.java
@@ -52,7 +52,6 @@ import org.apache.doris.analysis.CreateUserStmt;
 import org.apache.doris.analysis.CreateViewStmt;
 import org.apache.doris.analysis.DecommissionBackendClause;
 import org.apache.doris.analysis.DistributionDesc;
-import org.apache.doris.catalog.MaterializedIndex.IndexExtState;
 import org.apache.doris.analysis.DropClusterStmt;
 import org.apache.doris.analysis.DropDbStmt;
 import org.apache.doris.analysis.DropFunctionStmt;
@@ -86,6 +85,7 @@ import org.apache.doris.backup.BackupHandler;
 import org.apache.doris.catalog.ColocateTableIndex.GroupId;
 import org.apache.doris.catalog.Database.DbState;
 import org.apache.doris.catalog.DistributionInfo.DistributionInfoType;
+import org.apache.doris.catalog.MaterializedIndex.IndexExtState;
 import org.apache.doris.catalog.MaterializedIndex.IndexState;
 import org.apache.doris.catalog.OlapTable.OlapTableState;
 import org.apache.doris.catalog.Replica.ReplicaState;
@@ -701,6 +701,9 @@ public class Catalog {
             LOG.error("Invalid edit log type: {}", Config.edit_log_type);
             System.exit(-1);
         }
+
+        // init plugin manager
+        pluginMgr.init();
 
         // 2. get cluster id and role (Observer or Follower)
         getClusterIdAndRole();

--- a/fe/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/src/main/java/org/apache/doris/common/Config.java
@@ -108,7 +108,7 @@ public class Config extends ConfigBase {
      */
     @ConfField public static String plugin_dir = System.getenv("DORIS_HOME") + "/plugins";
 
-    @ConfField
+    @ConfField(mutable = true, masterOnly = true)
     public static boolean plugin_enable = false;
 
     /*

--- a/fe_plugins/pom.xml
+++ b/fe_plugins/pom.xml
@@ -8,11 +8,36 @@
     <version>1.0-SNAPSHOT</version>
     <modules>
         <module>auditdemo</module>
-  </modules>
+    </modules>
 
     <properties>
         <doris.home>${basedir}/../../</doris.home>
     </properties>
+    <profiles>
+        <!-- for custom internal repository -->
+        <profile>
+            <id>custom-env</id>
+            <activation>
+                <property>
+                    <name>env.CUSTOM_MAVEN_REPO</name>
+                </property>
+            </activation>
+
+            <repositories>
+                <repository>
+                    <id>custom-nexus</id>
+                    <url>${env.CUSTOM_MAVEN_REPO}</url>
+                </repository>
+            </repositories>
+
+            <pluginRepositories>
+                <pluginRepository>
+                    <id>custom-nexus</id>
+                    <url>${env.CUSTOM_MAVEN_REPO}</url>
+                </pluginRepository>
+            </pluginRepositories>
+        </profile>
+    </profiles>
 
     <dependencyManagement>
         <dependencies>


### PR DESCRIPTION
The FE plugin dir should be created when initializing.
Also modify the pom.xml in `fe_plugins` dir to make it able to use custom maven setting.