### PR TITLE
Rewritten subquery in having clause

### DIFF
--- a/fe/src/main/java/org/apache/doris/analysis/SelectStmt.java
+++ b/fe/src/main/java/org/apache/doris/analysis/SelectStmt.java
@@ -1228,17 +1228,19 @@ public class SelectStmt extends QueryStmt {
         for (TableRef ref : fromClause_) {
             ref.rewriteExprs(rewriter, analyzer);
         }
+        // Also rewrite exprs in the statements of subqueries.
+        List<Subquery> subqueryExprs = Lists.newArrayList();
         if (whereClause != null) {
             whereClause = rewriter.rewrite(whereClause, analyzer);
-            // Also rewrite exprs in the statements of subqueries.
-            List<Subquery> subqueryExprs = Lists.newArrayList();
             whereClause.collect(Subquery.class, subqueryExprs);
-            for (Subquery s : subqueryExprs) {
-                s.getStatement().rewriteExprs(rewriter);
-            }
+
         }
         if (havingClause != null) {
             havingClause = rewriter.rewrite(havingClause, analyzer);
+            havingClauseAfterAnaylzed.collect(Subquery.class, subqueryExprs);
+        }
+        for (Subquery subquery : subqueryExprs) {
+            subquery.getStatement().rewriteExprs(rewriter);
         }
         if (groupByClause != null) {
             ArrayList<Expr> groupingExprs = groupByClause.getGroupingExprs();

--- a/fe/src/test/java/org/apache/doris/analysis/StmtRewriterTest.java
+++ b/fe/src/test/java/org/apache/doris/analysis/StmtRewriterTest.java
@@ -596,6 +596,18 @@ public class StmtRewriterTest {
                 "order by: <slot 10> ASC", "OUTPUT EXPRS:<slot 11> | <slot 10>", "limit: 100");
     }
 
+    /**
+     * ISSUE-3205
+     */
+    @Test
+    public void testRewriteHavingClauseWithBetweenAndInSubquery() throws Exception {
+        String subquery = "select avg(salary) from " + TABLE_NAME + " where empid between 1 and 2";
+        String query = "select empid a, sum(salary) b from " + TABLE_NAME + " group by a having b > (" +
+                subquery + ");";
+        dorisAssert.query(query).explainContains(
+                "CROSS JOIN", "predicates: <slot 3> > <slot 9>", "`empid` >= 1, `empid` <= 2");
+    }
+
     @AfterClass
     public static void afterClass() throws Exception {
         UtFrameUtils.cleanDorisFeDir(baseDir);


### PR DESCRIPTION
The subquery in having clause should be rewritten too.
If not, ExprRewriteRule will not be apply in subquery.
For example:
select k1, sum (k2) from table group by k1 having sum(k2) > (select t1 from table2 where t1 between 1 and 2);
```t1 between 1 and 2``` should be rewritten to ```t1 >=1 and t1<=2```.

Fixed #3205. TPC-DS 14 will be passed after this commit.