### PR TITLE
Add 'IndexKeysType' field in 'Desc all table stmt'

### DIFF
--- a/fe/src/main/java/org/apache/doris/analysis/DescribeStmt.java
+++ b/fe/src/main/java/org/apache/doris/analysis/DescribeStmt.java
@@ -20,6 +20,7 @@ package org.apache.doris.analysis;
 import org.apache.doris.catalog.Catalog;
 import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.Database;
+import org.apache.doris.catalog.MaterializedIndexMeta;
 import org.apache.doris.catalog.MysqlTable;
 import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.catalog.ScalarType;
@@ -52,6 +53,7 @@ public class DescribeStmt extends ShowStmt {
     private static final ShowResultSetMetaData DESC_OLAP_TABLE_ALL_META_DATA =
             ShowResultSetMetaData.builder()
                     .addColumn(new Column("IndexName", ScalarType.createVarchar(20)))
+                    .addColumn(new Column("IndexKeysType", ScalarType.createVarchar(20)))
                     .addColumn(new Column("Field", ScalarType.createVarchar(20)))
                     .addColumn(new Column("Type", ScalarType.createVarchar(20)))
                     .addColumn(new Column("Null", ScalarType.createVarchar(10)))
@@ -149,6 +151,7 @@ public class DescribeStmt extends ShowStmt {
                         long indexId = indices.get(i);
                         List<Column> columns = indexIdToSchema.get(indexId);
                         String indexName = olapTable.getIndexNameById(indexId);
+                        MaterializedIndexMeta indexMeta = olapTable.getIndexMetaByIndexId(indexId);
                         for (int j = 0; j < columns.size(); ++j) {
                             Column column = columns.get(j);
 
@@ -163,6 +166,7 @@ public class DescribeStmt extends ShowStmt {
                             String extraStr = StringUtils.join(extras, ",");
 
                             List<String> row = Arrays.asList("",
+                                                             "",
                                                              column.getName(),
                                                              column.getOriginType().toString(),
                                                              column.isAllowNull() ? "Yes" : "No",
@@ -173,6 +177,7 @@ public class DescribeStmt extends ShowStmt {
 
                             if (j == 0) {
                                 row.set(0, indexName);
+                                row.set(1, indexMeta.getKeysType().name());
                             }
 
                             totalRows.add(row);

--- a/fe/src/test/java/org/apache/doris/analysis/DescribeStmtTest.java
+++ b/fe/src/test/java/org/apache/doris/analysis/DescribeStmtTest.java
@@ -65,7 +65,7 @@ public class DescribeStmtTest {
 
     @Ignore
     @Test
-    public void testNormal() throws AnalysisException, UserException {
+    public void testNormal() throws UserException {
         DescribeStmt stmt = new DescribeStmt(new TableName("", "testTbl"), false);
         stmt.analyze(analyzer);
         Assert.assertEquals("DESCRIBE `testCluster:testDb.testTbl`", stmt.toString());
@@ -75,11 +75,12 @@ public class DescribeStmtTest {
     }
 
     @Test
-    public void testAllNormal() throws AnalysisException, UserException {
+    public void testAllNormal() throws UserException {
         DescribeStmt stmt = new DescribeStmt(new TableName("", "testTbl"), true);
         stmt.analyze(analyzer);
         Assert.assertEquals("DESCRIBE `testCluster:testDb.testTbl` ALL", stmt.toString());
-        Assert.assertEquals(7, stmt.getMetaData().getColumnCount());
+        Assert.assertEquals(8, stmt.getMetaData().getColumnCount());
+        Assert.assertEquals("IndexKeysType", stmt.getMetaData().getColumn(1).getName());
         Assert.assertEquals("testCluster:testDb", stmt.getDb());
         Assert.assertEquals("testTbl", stmt.getTableName());
     }


### PR DESCRIPTION
After doris support aggregation materialized view on duplicate table, desc stmt of metadata is confused in sometimes.
The reason is that there is no grouping information in desc stmt of metadata.

For example:
There are two materialized view as following.
    1. create materialized view k1_k2 as select k1, k2 from table;
    2. create materialzied view deduplicated_k1_k2 as select k1, k2 from table group by k1, k2;
Before this commit, the metatdata in desc stmt is the same.

   ```
    +-----------------------+-------+----------+------+-------+---------+-------+
    | IndexName             | Field | Type     | Null | Key   | Default | Extra |
    +-----------------------+-------+----------+------+-------+---------+-------+
    | k1_k2                 | k1    | TINYINT  | Yes  | true  | N/A     |       |
    |                       | k2    | SMALLINT | Yes  | true  | N/A     |       |
    | deduplicated_k1_k2    | k1    | TINYINT  | Yes  | true  | N/A     |       |
    |                       | k2    | SMALLINT | Yes  | true  | N/A     |       |
    +-----------------------+-------+----------+------+-------+---------+-------+
   ```

So, we need to show the KeysType of materialized view in desc stmt.
Now, the desc stmt of all mvs is changed as following:

    ```
    +-----------------------+---------------+-------+----------+------+-------+---------+-------+
    | IndexName             | IndexKeysType | Field | Type     | Null | Key   | Default | Extra |
    +-----------------------+---------------+-------+----------+------+-------+---------+-------+
    | k1_k2                 | DUP_KEYS      | k1    | TINYINT  | Yes  | true  | N/A     |       |
    |                       |               | k2    | SMALLINT | Yes  | true  | N/A     |       |
    | deduplicated_k1_k2    | AGG_KEYS      | k1    | TINYINT  | Yes  | true  | N/A     |       |
    |                       |               | k2    | SMALLINT | Yes  | true  | N/A     |       |
    +-----------------------+---------------+-------+----------+------+-------+---------+-------+
    ```