### PR TITLE
Fix cast date type return wrong result

### DIFF
--- a/fe/src/main/java/org/apache/doris/analysis/DateLiteral.java
+++ b/fe/src/main/java/org/apache/doris/analysis/DateLiteral.java
@@ -319,7 +319,14 @@ public class DateLiteral extends LiteralExpr {
 
     @Override
     protected Expr uncheckedCastTo(Type targetType) throws AnalysisException {
-        if (targetType.equals(this.type)) {
+        if (targetType.isDateType()) {
+            if (targetType.equals(Type.DATE)) {
+                this.castToDate();                            
+            } else if (targetType.equals(Type.DATETIME)) {
+                this.type = Type.DATETIME;                            
+            } else {
+                throw new AnalysisException("Error date literal type : " + type);
+            }
             return this;
         } else if (targetType.isStringType()) {
             return new StringLiteral(getStringValue());

--- a/fe/src/main/java/org/apache/doris/analysis/DateLiteral.java
+++ b/fe/src/main/java/org/apache/doris/analysis/DateLiteral.java
@@ -319,7 +319,7 @@ public class DateLiteral extends LiteralExpr {
 
     @Override
     protected Expr uncheckedCastTo(Type targetType) throws AnalysisException {
-        if (targetType.isDateType()) {
+        if (targetType.equals(this.type)) {
             return this;
         } else if (targetType.isStringType()) {
             return new StringLiteral(getStringValue());

--- a/fe/src/test/java/org/apache/doris/analysis/DateLiteralTest.java
+++ b/fe/src/test/java/org/apache/doris/analysis/DateLiteralTest.java
@@ -55,4 +55,23 @@ public class DateLiteralTest {
         }
         Assert.assertFalse(hasException);
     }
+
+    @Test
+    public void uncheckedCastTo() {
+        boolean hasException = false;
+        try {
+            DateLiteral literal = new DateLiteral("1997-10-07", Type.DATE);
+            Expr castToExpr = literal.uncheckedCastTo(Type.DATETIME);
+            Assert.assertTrue(castToExpr instanceof CastExpr);
+            Assert.assertEquals(((CastExpr) castToExpr).type, Type.DATETIME);
+
+            DateLiteral literal2 = new DateLiteral("1997-10-07 12:23:23", Type.DATETIME);
+            Expr castToExpr2 = literal2.uncheckedCastTo(Type.DATETIME);
+            Assert.assertTrue(castToExpr2 instanceof DateLiteral);
+        } catch (AnalysisException e) {
+            e.printStackTrace();
+            hasException = true;
+        }
+        Assert.assertFalse(hasException);
+    }
 }

--- a/fe/src/test/java/org/apache/doris/analysis/DateLiteralTest.java
+++ b/fe/src/test/java/org/apache/doris/analysis/DateLiteralTest.java
@@ -62,8 +62,8 @@ public class DateLiteralTest {
         try {
             DateLiteral literal = new DateLiteral("1997-10-07", Type.DATE);
             Expr castToExpr = literal.uncheckedCastTo(Type.DATETIME);
-            Assert.assertTrue(castToExpr instanceof CastExpr);
-            Assert.assertEquals(((CastExpr) castToExpr).type, Type.DATETIME);
+            Assert.assertTrue(castToExpr instanceof DateLiteral);
+            Assert.assertEquals(castToExpr.type, Type.DATETIME);
 
             DateLiteral literal2 = new DateLiteral("1997-10-07 12:23:23", Type.DATETIME);
             Expr castToExpr2 = literal2.uncheckedCastTo(Type.DATETIME);


### PR DESCRIPTION
For #3213 
We have multiple date type, and we also need to cast between different date types.
 If not cast, it will cause problems when binarypredicate
