### PR TITLE
Fix WARNING to WARN in fe.conf sys_log_level

### DIFF
--- a/conf/fe.conf
+++ b/conf/fe.conf
@@ -34,7 +34,7 @@ JAVA_OPTS_FOR_JDK_9="-Xmx4096m -XX:SurvivorRatio=8 -XX:MaxTenuringThreshold=7 -X
 ## the lowercase properties are read by main program.
 ##
 
-# INFO, WARNING, ERROR, FATAL
+# INFO, WARN, ERROR, FATAL
 sys_log_level = INFO
 
 # store metadata, create it if it is not exist.


### PR DESCRIPTION
When I used it, I changed it to WARING in the comments, and the log didn't work because there was no warning-level log in Java