### PR TITLE
Support sharding txn_map_lock into more small map locks to make good performance for txn manage task

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -505,6 +505,10 @@ namespace config {
     // this is a an enhancement for better performance to manage txn
     CONF_Int32(txn_map_shard_size, "128");
 
+    // txn_map_lock shard size, the value is 2^n, n=0,1,2,3,4
+    // this is a an enhancement for better performance to publish txn
+    CONF_Int32(txn_shard_size, "1024")
+
 } // namespace config
 
 } // namespace doris

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -491,15 +491,19 @@ namespace config {
     // brpc config, 200M
     CONF_Int64(brpc_max_body_size, "209715200")
 
-    // max number of txns in txn manager
+    // max number of txns for every txn_partition_map in txn manager
     // this is a self protection to avoid too many txns saving in manager
-    CONF_mInt64(max_runnings_transactions, "2000");
+    CONF_Int64(max_runnings_transactions_per_txn_map, "100");
 
     // tablet_map_lock shard size, the value is 2^n, n=0,1,2,3,4
     // this is a an enhancement for better performance to manage tablet
     CONF_Int32(tablet_map_shard_size, "1");
 
     CONF_String(plugin_path, "${DORIS_HOME}/plugin")
+
+    // txn_map_lock shard size, the value is 2^n, n=0,1,2,3,4
+    // this is a an enhancement for better performance to manage txn
+    CONF_Int32(txn_map_shard_size, "128");
 
 } // namespace config
 

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -493,7 +493,7 @@ namespace config {
 
     // max number of txns for every txn_partition_map in txn manager
     // this is a self protection to avoid too many txns saving in manager
-    CONF_Int64(max_runnings_transactions_per_txn_map, "100");
+    CONF_mInt64(max_runnings_transactions_per_txn_map, "100");
 
     // tablet_map_lock shard size, the value is 2^n, n=0,1,2,3,4
     // this is a an enhancement for better performance to manage tablet

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -505,7 +505,7 @@ namespace config {
     // this is a an enhancement for better performance to manage txn
     CONF_Int32(txn_map_shard_size, "128");
 
-    // txn_map_lock shard size, the value is 2^n, n=0,1,2,3,4
+    // txn_lock shard size, the value is 2^n, n=0,1,2,3,4
     // this is a an enhancement for better performance to publish txn
     CONF_Int32(txn_shard_size, "1024")
 

--- a/be/src/olap/storage_engine.cpp
+++ b/be/src/olap/storage_engine.cpp
@@ -114,7 +114,7 @@ StorageEngine::StorageEngine(const EngineOptions& options)
         _is_all_cluster_id_exist(true),
         _index_stream_lru_cache(NULL),
         _tablet_manager(new TabletManager(config::tablet_map_shard_size)),
-        _txn_manager(new TxnManager()),
+        _txn_manager(new TxnManager(config::txn_map_shard_size)),
         _rowset_id_generator(new UniqueRowsetIdGenerator(options.backend_uid)),
         _memtable_flush_executor(nullptr),
         _block_manager(nullptr),

--- a/be/src/olap/storage_engine.cpp
+++ b/be/src/olap/storage_engine.cpp
@@ -114,7 +114,7 @@ StorageEngine::StorageEngine(const EngineOptions& options)
         _is_all_cluster_id_exist(true),
         _index_stream_lru_cache(NULL),
         _tablet_manager(new TabletManager(config::tablet_map_shard_size)),
-        _txn_manager(new TxnManager(config::txn_map_shard_size)),
+        _txn_manager(new TxnManager(config::txn_map_shard_size, config::txn_shard_size)),
         _rowset_id_generator(new UniqueRowsetIdGenerator(options.backend_uid)),
         _memtable_flush_executor(nullptr),
         _block_manager(nullptr),

--- a/be/src/olap/tablet_manager.cpp
+++ b/be/src/olap/tablet_manager.cpp
@@ -70,6 +70,7 @@ TabletManager::TabletManager(int32_t tablet_map_lock_shard_size)
     : _tablet_map_lock_shard_size(tablet_map_lock_shard_size),
       _last_update_stat_ms(0) {
     DCHECK_GT(_tablet_map_lock_shard_size, 0);
+    DCHECK_EQ(_tablet_map_lock_shard_size & (tablet_map_lock_shard_size - 1), 0);
     _tablet_map_lock_array = new RWMutex[_tablet_map_lock_shard_size];
     _tablet_map_array = new tablet_map_t[_tablet_map_lock_shard_size];
 }

--- a/be/src/olap/tablet_manager.h
+++ b/be/src/olap/tablet_manager.h
@@ -193,7 +193,7 @@ private:
     // tablet_id -> TabletInstances
     typedef std::unordered_map<int64_t, TableInstances> tablet_map_t;
 
-    int32_t _tablet_map_lock_shard_size;
+    const int32_t _tablet_map_lock_shard_size;
     // _tablet_map_lock_array[i] protect _tablet_map_array[i], i=0,1,2...,and i < _tablet_map_lock_shard_size
     RWMutex *_tablet_map_lock_array;
     tablet_map_t *_tablet_map_array;

--- a/be/src/olap/txn_manager.cpp
+++ b/be/src/olap/txn_manager.cpp
@@ -70,10 +70,12 @@ using std::vector;
 
 namespace doris {
 
-TxnManager::TxnManager() {
-    for (int i = 0; i < _txn_lock_num; ++i) {
-        _txn_locks[i] = std::make_shared<RWMutex>();
-    }
+TxnManager::TxnManager(int32_t txn_map_shard_size)
+        : _txn_map_shard_size(txn_map_shard_size) {
+    DCHECK_GT(_txn_map_shard_size, 0);
+    _txn_map_locks = new RWMutex[_txn_map_shard_size];
+    _txn_tablet_maps = new std::map<TxnKey, std::map<TabletInfo, TabletTxnInfo>>[_txn_map_shard_size];
+    _txn_partition_maps = new std::unordered_map<int64_t, std::unordered_set<int64_t>>[_txn_map_shard_size];
 }
 
 OLAPStatus TxnManager::prepare_txn(TPartitionId partition_id, const TabletSharedPtr& tablet, TTransactionId transaction_id, 
@@ -113,10 +115,10 @@ OLAPStatus TxnManager::prepare_txn(
 
     pair<int64_t, int64_t> key(partition_id, transaction_id);
     TabletInfo tablet_info(tablet_id, schema_hash, tablet_uid);
-    WriteLock wrlock(_get_txn_lock(transaction_id));
-    WriteLock txn_wrlock(&_txn_map_lock);
-    auto it = _txn_tablet_map.find(key);
-    if (it != _txn_tablet_map.end()) {
+    WriteLock txn_wrlock(&_get_txn_map_lock(transaction_id));
+    txn_tablet_map_t& txn_tablet_map = _get_txn_tablet_map(transaction_id);
+    auto it = txn_tablet_map.find(key);
+    if (it != txn_tablet_map.end()) {
         auto load_itr = it->second.find(tablet_info);
         if (load_itr != it->second.end()) {
             // found load for txn,tablet
@@ -137,8 +139,9 @@ OLAPStatus TxnManager::prepare_txn(
 
     // check if there are too many transactions on running.
     // if yes, reject the request.
-    if (_txn_partition_map.size() > config::max_runnings_transactions) {
-        LOG(WARNING) << "too many transactions: " << _txn_tablet_map.size() << ", limit: " << config::max_runnings_transactions;
+    txn_partition_map_t& txn_partition_map = _get_txn_partition_map(transaction_id);
+    if (txn_partition_map.size() > config::max_runnings_transactions_per_txn_map) {
+        LOG(WARNING) << "too many transactions: " << txn_tablet_map.size() << ", limit: " << config::max_runnings_transactions_per_txn_map;
         return OLAP_ERR_TOO_MANY_TRANSACTIONS;
     }
 
@@ -146,7 +149,7 @@ OLAPStatus TxnManager::prepare_txn(
     // case 1: user start a new txn, rowset_ptr = null
     // case 2: loading txn from meta env
     TabletTxnInfo load_info(load_id, nullptr);
-    _txn_tablet_map[key][tablet_info] = load_info;
+    txn_tablet_map[key][tablet_info] = load_info;
     _insert_txn_partition_map_unlocked(transaction_id, partition_id);
 
     VLOG(3) << "add transaction to engine successfully."
@@ -175,12 +178,13 @@ OLAPStatus TxnManager::commit_txn(
                      << ", tablet: " << tablet_info.to_string();
         return OLAP_ERR_ROWSET_INVALID;
     }
-    WriteLock wrlock(_get_txn_lock(transaction_id));
+
     {
         // get tx
-        ReadLock rdlock(&_txn_map_lock);
-        auto it = _txn_tablet_map.find(key);
-        if (it != _txn_tablet_map.end()) {
+        ReadLock rdlock(&_get_txn_map_lock(transaction_id));
+        txn_tablet_map_t& txn_tablet_map = _get_txn_tablet_map(transaction_id);
+        auto it = txn_tablet_map.find(key);
+        if (it != txn_tablet_map.end()) {
             auto load_itr = it->second.find(tablet_info);
             if (load_itr != it->second.end()) {
                 // found load for txn,tablet
@@ -232,9 +236,10 @@ OLAPStatus TxnManager::commit_txn(
     }
 
     {
-        WriteLock wrlock(&_txn_map_lock);
+        WriteLock wrlock(&_get_txn_map_lock(transaction_id));
         TabletTxnInfo load_info(load_id, rowset_ptr);
-        _txn_tablet_map[key][tablet_info] = load_info;
+        txn_tablet_map_t& txn_tablet_map = _get_txn_tablet_map(transaction_id);
+        txn_tablet_map[key][tablet_info] = load_info;
         _insert_txn_partition_map_unlocked(transaction_id, partition_id);
         LOG(INFO) << "commit transaction to engine successfully."
                 << " partition_id: " << key.first
@@ -253,11 +258,11 @@ OLAPStatus TxnManager::publish_txn(OlapMeta* meta, TPartitionId partition_id, TT
     pair<int64_t, int64_t> key(partition_id, transaction_id);
     TabletInfo tablet_info(tablet_id, schema_hash, tablet_uid);
     RowsetSharedPtr rowset_ptr = nullptr;
-    WriteLock wrlock(_get_txn_lock(transaction_id));
     {
-        ReadLock rlock(&_txn_map_lock);
-        auto it = _txn_tablet_map.find(key);
-        if (it != _txn_tablet_map.end()) {
+        ReadLock rlock(&_get_txn_map_lock(transaction_id));
+        txn_tablet_map_t& txn_tablet_map = _get_txn_tablet_map(transaction_id);
+        auto it = txn_tablet_map.find(key);
+        if (it != txn_tablet_map.end()) {
             auto load_itr = it->second.find(tablet_info);
             if (load_itr != it->second.end()) {
                 // found load for txn,tablet
@@ -287,9 +292,10 @@ OLAPStatus TxnManager::publish_txn(OlapMeta* meta, TPartitionId partition_id, TT
         return OLAP_ERR_TRANSACTION_NOT_EXIST;
     }
     {
-        WriteLock wrlock(&_txn_map_lock);
-        auto it = _txn_tablet_map.find(key);
-        if (it != _txn_tablet_map.end()) {
+        WriteLock wrlock(&_get_txn_map_lock(transaction_id));
+        txn_tablet_map_t& txn_tablet_map = _get_txn_tablet_map(transaction_id);
+        auto it = txn_tablet_map.find(key);
+        if (it != txn_tablet_map.end()) {
             it->second.erase(tablet_info);
             LOG(INFO) << "publish txn successfully."
                       << " partition_id: " << key.first
@@ -297,7 +303,7 @@ OLAPStatus TxnManager::publish_txn(OlapMeta* meta, TPartitionId partition_id, TT
                       << ", tablet: " << tablet_info.to_string()
                       << ", rowsetid: " << rowset_ptr->rowset_id();
             if (it->second.empty()) {
-                _txn_tablet_map.erase(it);
+                txn_tablet_map.erase(it);
                 _clear_txn_partition_map_unlocked(transaction_id, partition_id);
             }
         }
@@ -313,10 +319,10 @@ OLAPStatus TxnManager::rollback_txn(TPartitionId partition_id, TTransactionId tr
                                     TTabletId tablet_id, SchemaHash schema_hash, TabletUid tablet_uid) {
     pair<int64_t, int64_t> key(partition_id, transaction_id);
     TabletInfo tablet_info(tablet_id, schema_hash, tablet_uid);
-    WriteLock wrlock(_get_txn_lock(transaction_id));
-    WriteLock txn_wrlock(&_txn_map_lock);
-    auto it = _txn_tablet_map.find(key);
-    if (it != _txn_tablet_map.end()) {
+    WriteLock wrlock(&_get_txn_map_lock(transaction_id));
+    txn_tablet_map_t& txn_tablet_map = _get_txn_tablet_map(transaction_id);
+    auto it = txn_tablet_map.find(key);
+    if (it != txn_tablet_map.end()) {
         auto load_itr = it->second.find(tablet_info);
         if (load_itr != it->second.end()) {
             // found load for txn,tablet
@@ -334,7 +340,7 @@ OLAPStatus TxnManager::rollback_txn(TPartitionId partition_id, TTransactionId tr
                   << ", transaction_id: " << key.second
                   << ", tablet: " << tablet_info.to_string();
         if (it->second.empty()) {
-            _txn_tablet_map.erase(it);
+            txn_tablet_map.erase(it);
             _clear_txn_partition_map_unlocked(transaction_id, partition_id);
         }
     }
@@ -347,10 +353,10 @@ OLAPStatus TxnManager::delete_txn(OlapMeta* meta, TPartitionId partition_id, TTr
                                   TTabletId tablet_id, SchemaHash schema_hash, TabletUid tablet_uid) {
     pair<int64_t, int64_t> key(partition_id, transaction_id);
     TabletInfo tablet_info(tablet_id, schema_hash, tablet_uid);
-    WriteLock wrlock(_get_txn_lock(transaction_id));
-    WriteLock txn_wrlock(&_txn_map_lock);
-    auto it = _txn_tablet_map.find(key);
-    if (it == _txn_tablet_map.end()) {
+    WriteLock txn_wrlock(&_get_txn_map_lock(transaction_id));
+    txn_tablet_map_t& txn_tablet_map = _get_txn_tablet_map(transaction_id);
+    auto it = txn_tablet_map.find(key);
+    if (it == txn_tablet_map.end()) {
         return OLAP_ERR_TRANSACTION_NOT_EXIST;
     }
     auto load_itr = it->second.find(tablet_info);
@@ -384,7 +390,7 @@ OLAPStatus TxnManager::delete_txn(OlapMeta* meta, TPartitionId partition_id, TTr
     }
     it->second.erase(tablet_info);
     if (it->second.empty()) {
-        _txn_tablet_map.erase(it);
+        txn_tablet_map.erase(it);
         _clear_txn_partition_map_unlocked(transaction_id, partition_id);
     }
     return OLAP_SUCCESS;
@@ -398,15 +404,18 @@ void TxnManager::get_tablet_related_txns(TTabletId tablet_id, SchemaHash schema_
     }
 
     TabletInfo tablet_info(tablet_id, schema_hash, tablet_uid);
-    ReadLock txn_rdlock(&_txn_map_lock);
-    for (auto& it : _txn_tablet_map) {
-        if (it.second.find(tablet_info) != it.second.end()) {
-            *partition_id = it.first.first;
-            transaction_ids->insert(it.first.second);
-            VLOG(3) << "find transaction on tablet."
-                    << "partition_id: " << it.first.first
-                    << ", transaction_id: " << it.first.second
-                    << ", tablet: " << tablet_info.to_string();
+    for (int32_t i = 0; i < _txn_map_shard_size; i++) {
+        ReadLock txn_rdlock(&_txn_map_locks[i]);
+        txn_tablet_map_t& txn_tablet_map = _txn_tablet_maps[i];
+        for (auto& it : txn_tablet_map) {
+            if (it.second.find(tablet_info) != it.second.end()) {
+                *partition_id = it.first.first;
+                transaction_ids->insert(it.first.second);
+                VLOG(3) << "find transaction on tablet."
+                        << "partition_id: " << it.first.first
+                        << ", transaction_id: " << it.first.second
+                        << ", tablet: " << tablet_info.to_string();
+            }
         }
     }
 }
@@ -415,33 +424,36 @@ void TxnManager::get_tablet_related_txns(TTabletId tablet_id, SchemaHash schema_
 // maybe lock error, because not get txn lock before remove from meta
 void TxnManager::force_rollback_tablet_related_txns(OlapMeta* meta, TTabletId tablet_id, SchemaHash schema_hash, TabletUid tablet_uid) {
     TabletInfo tablet_info(tablet_id, schema_hash, tablet_uid);
-    WriteLock txn_wrlock(&_txn_map_lock);
-    for (auto it = _txn_tablet_map.begin(); it != _txn_tablet_map.end();) {
-        auto load_itr = it->second.find(tablet_info);
-        if (load_itr != it->second.end()) {
-            TabletTxnInfo& load_info = load_itr->second;
-            if (load_info.rowset != nullptr && meta != nullptr) {
-                LOG(INFO) << " delete transaction from engine "
-                          << ", tablet: " << tablet_info.to_string()
-                          << ", rowset id: " << load_info.rowset->rowset_id();
-                RowsetMetaManager::remove(meta, tablet_uid,
-                                          load_info.rowset->rowset_id());
-            }
-            LOG(INFO) << "remove tablet related txn."
-                      << " partition_id: " << it->first.first
-                      << ", transaction_id: " << it->first.second
-                      << ", tablet: " << tablet_info.to_string() << ", rowset: "
-                      << (load_info.rowset != nullptr
+    for (int32_t i = 0; i < _txn_map_shard_size; i++) {
+        WriteLock txn_wrlock(&_txn_map_locks[i]);
+        txn_tablet_map_t& txn_tablet_map = _txn_tablet_maps[i];
+        for (auto it = txn_tablet_map.begin(); it != txn_tablet_map.end();) {
+            auto load_itr = it->second.find(tablet_info);
+            if (load_itr != it->second.end()) {
+                TabletTxnInfo& load_info = load_itr->second;
+                if (load_info.rowset != nullptr && meta != nullptr) {
+                    LOG(INFO) << " delete transaction from engine "
+                              << ", tablet: " << tablet_info.to_string()
+                              << ", rowset id: " << load_info.rowset->rowset_id();
+                    RowsetMetaManager::remove(meta, tablet_uid,
+                                              load_info.rowset->rowset_id());
+                }
+                LOG(INFO) << "remove tablet related txn."
+                          << " partition_id: " << it->first.first
+                          << ", transaction_id: " << it->first.second
+                          << ", tablet: " << tablet_info.to_string() << ", rowset: "
+                          << (load_info.rowset != nullptr
                               ? load_info.rowset->rowset_id().to_string()
                               : "0");
-            it->second.erase(tablet_info);
-        }
-        if (it->second.empty()) {
-            _clear_txn_partition_map_unlocked(it->first.second,
-                                              it->first.first);
-            it = _txn_tablet_map.erase(it);
-        } else {
-            ++it;
+                it->second.erase(tablet_info);
+            }
+            if (it->second.empty()) {
+                _clear_txn_partition_map_unlocked(it->first.second,
+                                                  it->first.first);
+                it = txn_tablet_map.erase(it);
+            } else {
+                ++it;
+            }
         }
     }
 }
@@ -451,10 +463,10 @@ void TxnManager::get_txn_related_tablets(const TTransactionId transaction_id,
                                          std::map<TabletInfo, RowsetSharedPtr>* tablet_infos) {
     // get tablets in this transaction
     pair<int64_t, int64_t> key(partition_id, transaction_id);
-    ReadLock rdlock(_get_txn_lock(transaction_id));
-    ReadLock txn_rdlock(&_txn_map_lock);
-    auto it = _txn_tablet_map.find(key);
-    if (it == _txn_tablet_map.end()) {
+    ReadLock txn_rdlock(&_get_txn_map_lock(transaction_id));
+    txn_tablet_map_t& txn_tablet_map = _get_txn_tablet_map(transaction_id);
+    auto it = txn_tablet_map.find(key);
+    if (it == txn_tablet_map.end()) {
         VLOG(3) << "could not find tablet for"
                 << " partition_id=" << partition_id 
                 << ", transaction_id=" << transaction_id;
@@ -472,10 +484,12 @@ void TxnManager::get_txn_related_tablets(const TTransactionId transaction_id,
 }
 
 void TxnManager::get_all_related_tablets(std::set<TabletInfo>* tablet_infos) {
-    ReadLock txn_rdlock(&_txn_map_lock);
-    for (auto& it : _txn_tablet_map) {
-        for (auto& tablet_load_it : it.second) {
-            tablet_infos->emplace(tablet_load_it.first);
+    for (int32_t i = 0; i < _txn_map_shard_size; i++) {
+        ReadLock txn_rdlock(&_txn_map_locks[i]);
+        for (auto& it : _txn_tablet_maps[i]) {
+            for (auto& tablet_load_it : it.second) {
+                tablet_infos->emplace(tablet_load_it.first);
+            }
         }
     }
 }                                
@@ -484,10 +498,10 @@ bool TxnManager::has_txn(TPartitionId partition_id, TTransactionId transaction_i
                          TTabletId tablet_id, SchemaHash schema_hash, TabletUid tablet_uid) {
     pair<int64_t, int64_t> key(partition_id, transaction_id);
     TabletInfo tablet_info(tablet_id, schema_hash, tablet_uid);
-    ReadLock rdlock(_get_txn_lock(transaction_id));
-    ReadLock txn_rdlock(&_txn_map_lock);
-    auto it = _txn_tablet_map.find(key);
-    bool found = it != _txn_tablet_map.end()
+    ReadLock txn_rdlock(&_get_txn_map_lock(transaction_id));
+    txn_tablet_map_t& txn_tablet_map = _get_txn_tablet_map(transaction_id);
+    auto it = txn_tablet_map.find(key);
+    bool found = it != txn_tablet_map.end()
                  && it->second.find(tablet_info) != it->second.end();
 
     return found;
@@ -496,18 +510,20 @@ bool TxnManager::has_txn(TPartitionId partition_id, TTransactionId transaction_i
 void TxnManager::build_expire_txn_map(std::map<TabletInfo, std::vector<int64_t>>* expire_txn_map) {
     int64_t now = UnixSeconds();
     // traverse the txn map, and get all expired txns
-    ReadLock txn_rdlock(&_txn_map_lock);
-    for (auto& it : _txn_tablet_map) {
-        auto txn_id = it.first.second;
-        for (auto& t_map : it.second) {
-            double diff = difftime(now, t_map.second.creation_time);
-            if (diff >= config::pending_data_expire_time_sec) {
-                (*expire_txn_map)[t_map.first].push_back(txn_id);
-                if (VLOG_IS_ON(3)) {
-                    VLOG(3) << "find expired txn."
-                            << " tablet=" << t_map.first.to_string()
-                            << " transaction_id=" << txn_id
-                            << " exist_sec=" << diff;
+    for (int32_t i = 0; i < _txn_map_shard_size; i++) {
+        ReadLock txn_rdlock(&_txn_map_locks[i]);
+        for (auto& it : _txn_tablet_maps[i]) {
+            auto txn_id = it.first.second;
+            for (auto& t_map : it.second) {
+                double diff = difftime(now, t_map.second.creation_time);
+                if (diff >= config::pending_data_expire_time_sec) {
+                    (*expire_txn_map)[t_map.first].push_back(txn_id);
+                    if (VLOG_IS_ON(3)) {
+                        VLOG(3) << "find expired txn."
+                                << " tablet=" << t_map.first.to_string()
+                                << " transaction_id=" << txn_id
+                                << " exist_sec=" << diff;
+                    }
                 }
             }
         }
@@ -515,9 +531,10 @@ void TxnManager::build_expire_txn_map(std::map<TabletInfo, std::vector<int64_t>>
 }
 
 void TxnManager::get_partition_ids(const TTransactionId transaction_id, std::vector<TPartitionId>* partition_ids) {
-    ReadLock txn_rdlock(&_txn_map_lock);
-    auto it = _txn_partition_map.find(transaction_id);
-    if (it != _txn_partition_map.end()) {
+    ReadLock txn_rdlock(&_get_txn_map_lock(transaction_id));
+    txn_partition_map_t& txn_partition_map = _get_txn_partition_map(transaction_id);
+    auto it = txn_partition_map.find(transaction_id);
+    if (it != txn_partition_map.end()) {
         for (int64_t partition_id : it->second) {
             partition_ids->push_back(partition_id);
         }
@@ -525,19 +542,21 @@ void TxnManager::get_partition_ids(const TTransactionId transaction_id, std::vec
 }
 
 void TxnManager::_insert_txn_partition_map_unlocked(int64_t transaction_id, int64_t partition_id) {
-    auto find = _txn_partition_map.find(transaction_id);
-    if (find == _txn_partition_map.end()) {
-        _txn_partition_map[transaction_id] = std::unordered_set<int64_t>();
+    txn_partition_map_t& txn_partition_map = _get_txn_partition_map(transaction_id);
+    auto find = txn_partition_map.find(transaction_id);
+    if (find == txn_partition_map.end()) {
+        txn_partition_map[transaction_id] = std::unordered_set<int64_t>();
     }
-    _txn_partition_map[transaction_id].insert(partition_id);
+    txn_partition_map[transaction_id].insert(partition_id);
 }
 
 void TxnManager::_clear_txn_partition_map_unlocked(int64_t transaction_id, int64_t partition_id) {
-    auto it = _txn_partition_map.find(transaction_id);
-    if (it != _txn_partition_map.end()) {
+    txn_partition_map_t& txn_partition_map = _get_txn_partition_map(transaction_id);
+    auto it = txn_partition_map.find(transaction_id);
+    if (it != txn_partition_map.end()) {
         it->second.erase(partition_id);
         if (it->second.empty()) {
-            _txn_partition_map.erase(it);
+            txn_partition_map.erase(it);
         }
     }
 }

--- a/be/src/olap/txn_manager.cpp
+++ b/be/src/olap/txn_manager.cpp
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include "olap/storage_engine.h"
+#include "txn_manager.h"
 
 #include <signal.h>
 
@@ -36,6 +36,7 @@
 #include "olap/base_compaction.h"
 #include "olap/cumulative_compaction.h"
 #include "olap/lru_cache.h"
+#include "olap/storage_engine.h"
 #include "olap/tablet_meta.h"
 #include "olap/tablet_meta_manager.h"
 #include "olap/push_handler.h"
@@ -73,6 +74,7 @@ namespace doris {
 TxnManager::TxnManager(int32_t txn_map_shard_size)
         : _txn_map_shard_size(txn_map_shard_size) {
     DCHECK_GT(_txn_map_shard_size, 0);
+    DCHECK_EQ(_txn_map_shard_size & (_txn_map_shard_size - 1), 0);
     _txn_map_locks = new RWMutex[_txn_map_shard_size];
     _txn_tablet_maps = new std::map<TxnKey, std::map<TabletInfo, TabletTxnInfo>>[_txn_map_shard_size];
     _txn_partition_maps = new std::unordered_map<int64_t, std::unordered_set<int64_t>>[_txn_map_shard_size];

--- a/be/src/olap/txn_manager.h
+++ b/be/src/olap/txn_manager.h
@@ -68,12 +68,13 @@ struct TabletTxnInfo {
 // txn manager is used to manage mapping between tablet and txns
 class TxnManager {
 public:
-    TxnManager(int32_t txn_map_shard_size);
+    TxnManager(int32_t txn_map_shard_size, int32_t txn_shard_size);
 
     ~TxnManager() {
         delete [] _txn_tablet_maps;
         delete [] _txn_partition_maps;
         delete [] _txn_map_locks;
+        delete [] _txn_mutex;
     }
 
     OLAPStatus prepare_txn(TPartitionId partition_id, const TabletSharedPtr& tablet, TTransactionId transaction_id, 
@@ -144,7 +145,23 @@ private:
 
     using TxnKey = std::pair<int64_t, int64_t>; // partition_id, transaction_id;
 
-    typedef std::map<TxnKey, std::map<TabletInfo, TabletTxnInfo>> txn_tablet_map_t;
+    // implement TxnKey hash function to support TxnKey as a key for unordered_map
+    struct TxnKeyHash {
+        template<typename T, typename U>
+        size_t operator()(const std::pair<T, U> &e) const {
+            return std::hash<T>()(e.first) ^ std::hash<U>()(e.second);
+        }
+    };
+
+    // implement TxnKey equal function to support TxnKey as a key for unordered_map
+    struct TxnKeyEqual {
+        template <class T, typename U>
+        bool operator()(const std::pair<T, U> &l, const std::pair<T, U> &r) const{
+            return l.first == r.first && l.second == r.second;
+        }
+    };
+
+    typedef std::unordered_map<TxnKey, std::map<TabletInfo, TabletTxnInfo>, TxnKeyHash, TxnKeyEqual> txn_tablet_map_t;
     typedef std::unordered_map<int64_t, std::unordered_set<int64_t>> txn_partition_map_t;
 
     inline RWMutex& _get_txn_map_lock(TTransactionId transactionId);
@@ -152,6 +169,8 @@ private:
     inline txn_tablet_map_t& _get_txn_tablet_map(TTransactionId transactionId);
 
     inline txn_partition_map_t& _get_txn_partition_map(TTransactionId transactionId);
+
+    inline Mutex& _get_txn_lock(TTransactionId transactionId);
 
     // insert or remove (transaction_id, partition_id) from _txn_partition_map
     // get _txn_map_lock before calling
@@ -161,27 +180,36 @@ private:
 private:
     const int32_t _txn_map_shard_size;
 
+    const int32_t _txn_shard_size;
+
     // _txn_map_locks[i] protect _txn_tablet_maps[i], i=0,1,2...,and i < _txn_map_shard_size
-    std::map<TxnKey, std::map<TabletInfo, TabletTxnInfo>> *_txn_tablet_maps;
+    txn_tablet_map_t *_txn_tablet_maps;
     // transaction_id -> corresponding partition ids
     // This is mainly for the clear txn task received from FE, which may only has transaction id,
     // so we need this map to find out which partitions are corresponding to a transaction id.
     // The _txn_partition_maps[i] should be constructed/deconstructed/modified alongside with '_txn_tablet_maps[i]'
-    std::unordered_map<int64_t, std::unordered_set<int64_t>> *_txn_partition_maps;
+    txn_partition_map_t *_txn_partition_maps;
 
     RWMutex *_txn_map_locks;
 
+    Mutex *_txn_mutex;
     DISALLOW_COPY_AND_ASSIGN(TxnManager);
 };  // TxnManager
 
 inline RWMutex& TxnManager::_get_txn_map_lock(TTransactionId transactionId) {
     return _txn_map_locks[transactionId & (_txn_map_shard_size - 1)];
 }
+
 inline TxnManager::txn_tablet_map_t& TxnManager::_get_txn_tablet_map(TTransactionId transactionId) {
     return _txn_tablet_maps[transactionId & (_txn_map_shard_size - 1)];
 }
+
 inline TxnManager::txn_partition_map_t& TxnManager::_get_txn_partition_map(TTransactionId transactionId) {
     return _txn_partition_maps[transactionId & (_txn_map_shard_size - 1)];
+}
+
+inline Mutex& TxnManager::_get_txn_lock(TTransactionId transactionId) {
+    return _txn_mutex[transactionId & (_txn_shard_size - 1)];
 }
 
 }

--- a/be/src/olap/txn_manager.h
+++ b/be/src/olap/txn_manager.h
@@ -64,15 +64,17 @@ struct TabletTxnInfo {
     TabletTxnInfo() {}
 };
 
+using TxnKey = std::pair<int64_t, int64_t>; // partition_id, transaction_id;
+
 // txn manager is used to manage mapping between tablet and txns
 class TxnManager {
 public:
-    TxnManager();
+    TxnManager(int32_t txn_map_shard_size);
 
     ~TxnManager() {
-        _txn_tablet_map.clear();
-        _txn_partition_map.clear();
-        _txn_locks.clear();
+        delete [] _txn_tablet_maps;
+        delete [] _txn_partition_maps;
+        delete [] _txn_map_locks;
     }
 
     OLAPStatus prepare_txn(TPartitionId partition_id, const TabletSharedPtr& tablet, TTransactionId transaction_id, 
@@ -140,9 +142,12 @@ public:
     void get_partition_ids(const TTransactionId transaction_id, std::vector<TPartitionId>* partition_ids);
     
 private:
-    RWMutex* _get_txn_lock(TTransactionId txn_id) {
-        return _txn_locks[txn_id % _txn_lock_num].get();
-    }
+
+    inline RWMutex& _get_txn_map_lock(TTransactionId transactionId);
+
+    inline std::map<TxnKey, std::map<TabletInfo, TabletTxnInfo>>& _get_txn_tablet_map(TTransactionId transactionId);
+
+    inline std::unordered_map<int64_t, std::unordered_set<int64_t>>& _get_txn_partition_map(TTransactionId transactionId);
 
     // insert or remove (transaction_id, partition_id) from _txn_partition_map
     // get _txn_map_lock before calling
@@ -150,20 +155,33 @@ private:
     void _clear_txn_partition_map_unlocked(int64_t transaction_id, int64_t partition_id);
 
 private:
-    RWMutex _txn_map_lock;
-    using TxnKey = std::pair<int64_t, int64_t>; // partition_id, transaction_id;
-    std::map<TxnKey, std::map<TabletInfo, TabletTxnInfo>> _txn_tablet_map;
+    int32_t _txn_map_shard_size;
+
+    typedef std::map<TxnKey, std::map<TabletInfo, TabletTxnInfo>> txn_tablet_map_t;
+    typedef std::unordered_map<int64_t, std::unordered_set<int64_t>> txn_partition_map_t;
+
+    // _txn_map_locks[i] protect _txn_tablet_maps[i], i=0,1,2...,and i < _txn_map_shard_size
+    std::map<TxnKey, std::map<TabletInfo, TabletTxnInfo>> *_txn_tablet_maps;
     // transaction_id -> corresponding partition ids
     // This is mainly for the clear txn task received from FE, which may only has transaction id,
     // so we need this map to find out which partitions are corresponding to a transaction id.
-    // This map should be constructed/deconstructed/modified alongside with '_txn_tablet_map'
-    std::unordered_map<int64_t, std::unordered_set<int64_t>> _txn_partition_map;
+    // The _txn_partition_maps[i] should be constructed/deconstructed/modified alongside with '_txn_tablet_maps[i]'
+    std::unordered_map<int64_t, std::unordered_set<int64_t>> *_txn_partition_maps;
 
-    const int32_t _txn_lock_num = 100;
-    std::map<int32_t, std::shared_ptr<RWMutex>> _txn_locks;
+    RWMutex *_txn_map_locks;
 
     DISALLOW_COPY_AND_ASSIGN(TxnManager);
 };  // TxnManager
+
+inline RWMutex& TxnManager::_get_txn_map_lock(TTransactionId transactionId) {
+    return _txn_map_locks[transactionId & (_txn_map_shard_size - 1)];
+}
+inline std::map<TxnKey, std::map<TabletInfo, TabletTxnInfo>>& TxnManager::_get_txn_tablet_map(TTransactionId transactionId) {
+    return _txn_tablet_maps[transactionId & (_txn_map_shard_size - 1)];
+}
+inline std::unordered_map<int64_t, std::unordered_set<int64_t>>& TxnManager::_get_txn_partition_map(TTransactionId transactionId) {
+    return _txn_partition_maps[transactionId & (_txn_map_shard_size - 1)];
+}
 
 }
 #endif // DORIS_BE_SRC_OLAP_TXN_MANAGER_H

--- a/be/test/olap/olap_snapshot_converter_test.cpp
+++ b/be/test/olap/olap_snapshot_converter_test.cpp
@@ -107,7 +107,6 @@ private:
     DataDir* _data_dir;
     OlapMeta* _meta;
     std::string _json_rowset_meta;
-    TxnManager _txn_mgr;
     std::string _engine_data_path;
     std::string _meta_path;
     int64_t _tablet_id;

--- a/be/test/olap/tablet_mgr_test.cpp
+++ b/be/test/olap/tablet_mgr_test.cpp
@@ -78,7 +78,7 @@ public:
                 + "/" + std::to_string(0)
                 + "/" + std::to_string(_tablet_id)
                 + "/" + std::to_string(_schema_hash);
-        _tablet_mgr = new TabletManager(1);
+        _tablet_mgr.reset(new TabletManager(1));
     }
 
     virtual void TearDown() {
@@ -86,18 +86,16 @@ public:
         if (boost::filesystem::exists(_engine_data_path)) {
             ASSERT_TRUE(boost::filesystem::remove_all(_engine_data_path));
         }
-        delete _tablet_mgr;
     }
 
 private:
     DataDir* _data_dir;
     std::string _json_rowset_meta;
-    TxnManager _txn_mgr;
     std::string _engine_data_path;
     int64_t _tablet_id;
     int32_t _schema_hash;
     string _tablet_data_path;
-    TabletManager* _tablet_mgr;
+    std::unique_ptr<TabletManager> _tablet_mgr;
 };
 
 TEST_F(TabletMgrTest, CreateTablet) {

--- a/be/test/olap/txn_manager_test.cpp
+++ b/be/test/olap/txn_manager_test.cpp
@@ -94,7 +94,7 @@ public:
 
     virtual void SetUp() {
         config::max_runnings_transactions_per_txn_map = 500;
-        _txn_mgr.reset(new TxnManager(64));
+        _txn_mgr.reset(new TxnManager(64, 1024));
         std::vector<StorePath> paths;
         paths.emplace_back("_engine_data_path", -1);
         EngineOptions options;

--- a/be/test/olap/txn_manager_test.cpp
+++ b/be/test/olap/txn_manager_test.cpp
@@ -93,8 +93,8 @@ public:
     }
 
     virtual void SetUp() {
-        config::max_runnings_transactions = 1000;
-
+        config::max_runnings_transactions_per_txn_map = 500;
+        _txn_mgr.reset(new TxnManager(64));
         std::vector<StorePath> paths;
         paths.emplace_back("_engine_data_path", -1);
         EngineOptions options;
@@ -162,7 +162,7 @@ public:
 private:
     OlapMeta* _meta;
     std::string _json_rowset_meta;
-    TxnManager _txn_mgr;
+    std::unique_ptr<TxnManager>  _txn_mgr;
     TPartitionId partition_id = 1123;
     TTransactionId transaction_id = 111;
     TTabletId tablet_id = 222;
@@ -176,7 +176,7 @@ private:
 };
 
 TEST_F(TxnManagerTest, PrepareNewTxn) {
-    OLAPStatus status = _txn_mgr.prepare_txn(partition_id, transaction_id,
+    OLAPStatus status = _txn_mgr->prepare_txn(partition_id, transaction_id,
         tablet_id, schema_hash, _tablet_uid, load_id);
     ASSERT_TRUE(status == OLAP_SUCCESS);
 }
@@ -185,9 +185,9 @@ TEST_F(TxnManagerTest, PrepareNewTxn) {
 // 2. commit txn
 // 3. should be success
 TEST_F(TxnManagerTest, CommitTxnWithPrepare) {
-    OLAPStatus status = _txn_mgr.prepare_txn(partition_id, transaction_id,
+    OLAPStatus status = _txn_mgr->prepare_txn(partition_id, transaction_id,
         tablet_id, schema_hash, _tablet_uid, load_id);
-    _txn_mgr.commit_txn(_meta, partition_id, transaction_id,
+    _txn_mgr->commit_txn(_meta, partition_id, transaction_id,
         tablet_id, schema_hash, _tablet_uid, load_id, _alpha_rowset, false);
     ASSERT_TRUE(status == OLAP_SUCCESS);
     RowsetMetaSharedPtr rowset_meta(new AlphaRowsetMeta());
@@ -199,7 +199,7 @@ TEST_F(TxnManagerTest, CommitTxnWithPrepare) {
 // 1. commit without prepare
 // 2. should success
 TEST_F(TxnManagerTest, CommitTxnWithNoPrepare) {
-    OLAPStatus status = _txn_mgr.commit_txn(_meta, partition_id, transaction_id,
+    OLAPStatus status = _txn_mgr->commit_txn(_meta, partition_id, transaction_id,
         tablet_id, schema_hash, _tablet_uid, load_id, _alpha_rowset, false);
     ASSERT_TRUE(status == OLAP_SUCCESS);
 }
@@ -207,10 +207,10 @@ TEST_F(TxnManagerTest, CommitTxnWithNoPrepare) {
 // 1. commit twice with different rowset id
 // 2. should failed
 TEST_F(TxnManagerTest, CommitTxnTwiceWithDiffRowsetId) {
-    OLAPStatus status = _txn_mgr.commit_txn(_meta, partition_id, transaction_id,
+    OLAPStatus status = _txn_mgr->commit_txn(_meta, partition_id, transaction_id,
         tablet_id, schema_hash, _tablet_uid, load_id, _alpha_rowset, false);
     ASSERT_TRUE(status == OLAP_SUCCESS);
-    status = _txn_mgr.commit_txn(_meta, partition_id, transaction_id,
+    status = _txn_mgr->commit_txn(_meta, partition_id, transaction_id,
         tablet_id, schema_hash, _tablet_uid, load_id, _alpha_rowset_diff_id, false);
     ASSERT_TRUE(status != OLAP_SUCCESS);
 }
@@ -218,30 +218,30 @@ TEST_F(TxnManagerTest, CommitTxnTwiceWithDiffRowsetId) {
 // 1. commit twice with same rowset id
 // 2. should success
 TEST_F(TxnManagerTest, CommitTxnTwiceWithSameRowsetId) {
-    OLAPStatus status = _txn_mgr.commit_txn(_meta, partition_id, transaction_id,
+    OLAPStatus status = _txn_mgr->commit_txn(_meta, partition_id, transaction_id,
         tablet_id, schema_hash, _tablet_uid, load_id, _alpha_rowset, false);
     ASSERT_TRUE(status == OLAP_SUCCESS);
-    status = _txn_mgr.commit_txn(_meta, partition_id, transaction_id,
+    status = _txn_mgr->commit_txn(_meta, partition_id, transaction_id,
         tablet_id, schema_hash, _tablet_uid, load_id, _alpha_rowset_same_id, false);
     ASSERT_TRUE(status == OLAP_SUCCESS);
 }
 
 // 1. prepare twice should be success
 TEST_F(TxnManagerTest, PrepareNewTxnTwice) {
-    OLAPStatus status = _txn_mgr.prepare_txn(partition_id, transaction_id,
+    OLAPStatus status = _txn_mgr->prepare_txn(partition_id, transaction_id,
         tablet_id, schema_hash, _tablet_uid, load_id);
     ASSERT_TRUE(status == OLAP_SUCCESS);
-    status = _txn_mgr.prepare_txn(partition_id, transaction_id,
+    status = _txn_mgr->prepare_txn(partition_id, transaction_id,
         tablet_id, schema_hash, _tablet_uid, load_id);
     ASSERT_TRUE(status == OLAP_SUCCESS);
 }
 
 // 1. txn could be rollbacked if it is not committed
 TEST_F(TxnManagerTest, RollbackNotCommittedTxn) {
-    OLAPStatus status = _txn_mgr.prepare_txn(partition_id, transaction_id,
+    OLAPStatus status = _txn_mgr->prepare_txn(partition_id, transaction_id,
         tablet_id, schema_hash, _tablet_uid, load_id);
     ASSERT_TRUE(status == OLAP_SUCCESS);
-    status = _txn_mgr.rollback_txn(partition_id, transaction_id,
+    status = _txn_mgr->rollback_txn(partition_id, transaction_id,
         tablet_id, schema_hash, _tablet_uid);
     ASSERT_TRUE(status == OLAP_SUCCESS);
     RowsetMetaSharedPtr rowset_meta(new AlphaRowsetMeta());
@@ -251,10 +251,10 @@ TEST_F(TxnManagerTest, RollbackNotCommittedTxn) {
 
 // 1. txn could not be rollbacked if it is committed
 TEST_F(TxnManagerTest, RollbackCommittedTxn) {
-    OLAPStatus status = _txn_mgr.commit_txn(_meta, partition_id, transaction_id,
+    OLAPStatus status = _txn_mgr->commit_txn(_meta, partition_id, transaction_id,
         tablet_id, schema_hash, _tablet_uid, load_id, _alpha_rowset, false);
     ASSERT_TRUE(status == OLAP_SUCCESS);
-    status = _txn_mgr.rollback_txn(partition_id, transaction_id,
+    status = _txn_mgr->rollback_txn(partition_id, transaction_id,
         tablet_id, schema_hash, _tablet_uid);
     ASSERT_FALSE(status == OLAP_SUCCESS);
     RowsetMetaSharedPtr rowset_meta(new AlphaRowsetMeta());
@@ -265,12 +265,12 @@ TEST_F(TxnManagerTest, RollbackCommittedTxn) {
 
 // 1. publish version success
 TEST_F(TxnManagerTest, PublishVersionSuccessful) {
-    OLAPStatus status = _txn_mgr.commit_txn(_meta, partition_id, transaction_id,
+    OLAPStatus status = _txn_mgr->commit_txn(_meta, partition_id, transaction_id,
         tablet_id, schema_hash, _tablet_uid, load_id, _alpha_rowset, false);
     ASSERT_TRUE(status == OLAP_SUCCESS);
     Version new_version(10,11);
     VersionHash new_versionhash = 123;
-    status = _txn_mgr.publish_txn(_meta, partition_id, transaction_id,
+    status = _txn_mgr->publish_txn(_meta, partition_id, transaction_id,
         tablet_id, schema_hash, _tablet_uid, new_version, new_versionhash);
     ASSERT_TRUE(status == OLAP_SUCCESS);
 
@@ -286,28 +286,28 @@ TEST_F(TxnManagerTest, PublishVersionSuccessful) {
 TEST_F(TxnManagerTest, PublishNotExistedTxn) {
     Version new_version(10,11);
     VersionHash new_versionhash = 123;
-    OLAPStatus status = _txn_mgr.publish_txn(_meta, partition_id, transaction_id,
+    OLAPStatus status = _txn_mgr->publish_txn(_meta, partition_id, transaction_id,
         tablet_id, schema_hash, _tablet_uid, new_version, new_versionhash);
     ASSERT_TRUE(status != OLAP_SUCCESS);
 }
 
 TEST_F(TxnManagerTest, DeletePreparedTxn) {
-    OLAPStatus status = _txn_mgr.prepare_txn(partition_id, transaction_id,
+    OLAPStatus status = _txn_mgr->prepare_txn(partition_id, transaction_id,
         tablet_id, schema_hash, _tablet_uid, load_id);
     ASSERT_TRUE(status == OLAP_SUCCESS);
-    status = _txn_mgr.delete_txn(_meta, partition_id, transaction_id,
+    status = _txn_mgr->delete_txn(_meta, partition_id, transaction_id,
         tablet_id, schema_hash, _tablet_uid);
     ASSERT_TRUE(status == OLAP_SUCCESS);
 }
 
 TEST_F(TxnManagerTest, DeleteCommittedTxn) {
-    OLAPStatus status = _txn_mgr.commit_txn(_meta, partition_id, transaction_id,
+    OLAPStatus status = _txn_mgr->commit_txn(_meta, partition_id, transaction_id,
         tablet_id, schema_hash, _tablet_uid, load_id, _alpha_rowset, false);
     ASSERT_TRUE(status == OLAP_SUCCESS);
     RowsetMetaSharedPtr rowset_meta(new AlphaRowsetMeta());
     status = RowsetMetaManager::get_rowset_meta(_meta, _tablet_uid, _alpha_rowset->rowset_id(), rowset_meta);
     ASSERT_TRUE(status == OLAP_SUCCESS);
-    status = _txn_mgr.delete_txn(_meta, partition_id, transaction_id,
+    status = _txn_mgr->delete_txn(_meta, partition_id, transaction_id,
         tablet_id, schema_hash, _tablet_uid);
     ASSERT_TRUE(status == OLAP_SUCCESS);
     RowsetMetaSharedPtr rowset_meta2(new AlphaRowsetMeta());


### PR DESCRIPTION
This PR is to enhance the peformance for txn manage task, when there are so many txn in doris be, the only one txn_map_lock and additional _txn_locks may cause poor performance, and now we remove the additional _txn_locks and split the txn_map_lock into many small locks.