### PR TITLE
[Bug] NPE when using unknown function in broker load process

### DIFF
--- a/fe/src/main/java/org/apache/doris/analysis/FunctionCallExpr.java
+++ b/fe/src/main/java/org/apache/doris/analysis/FunctionCallExpr.java
@@ -558,7 +558,8 @@ public class FunctionCallExpr extends Expr {
             // find user defined functions
             if (fn == null) {
                 if (!analyzer.isUDFAllowed()) {
-                    throw new AnalysisException("Does not support non-builtin functions: " + fnName);
+                    throw new AnalysisException(
+                            "Does not support non-builtin functions, or function does not exist: " + this.toSqlImpl());
                 }
 
                 String dbName = fnName.analyzeDb(analyzer);
@@ -579,7 +580,7 @@ public class FunctionCallExpr extends Expr {
         }
 
         if (fn == null) {
-            LOG.warn("fn {} not exists", fnName.getFunction());
+            LOG.warn("fn {} not exists", this.toSqlImpl());
             throw new AnalysisException(getFunctionNotFoundError(collectChildReturnTypes()));
         }
 

--- a/fe/src/main/java/org/apache/doris/planner/BrokerScanNode.java
+++ b/fe/src/main/java/org/apache/doris/planner/BrokerScanNode.java
@@ -163,11 +163,7 @@ public class BrokerScanNode extends LoadScanNode {
             ParamCreateContext context = new ParamCreateContext();
             context.fileGroup = fileGroup;
             context.timezone = analyzer.getTimezone();
-            try {
-                initParams(context);
-            } catch (AnalysisException e) {
-                throw new UserException(e.getMessage());
-            }
+            initParams(context);
             paramCreateContexts.add(context);
         }
     }


### PR DESCRIPTION
This CL fix the bug described in issue #3224 by

1. Forbid UDF in broker load process
2. Improving the function checking logic to avoid NPE when trying to
   get default database from ConnectionContext.