### PR TITLE
Fix bug of memory limit when group by varchar columns.

### DIFF
--- a/be/src/exec/partitioned_aggregation_node_ir.cc
+++ b/be/src/exec/partitioned_aggregation_node_ir.cc
@@ -56,6 +56,7 @@ Status PartitionedAggregationNode::ProcessBatch(RowBatch* batch,
       RETURN_IF_ERROR(ProcessRow<AGGREGATED_ROWS>(batch_iter.get(), ht_ctx));
       expr_vals_cache->NextRow();
     }
+    ht_ctx->expr_results_pool_->clear();
     DCHECK(expr_vals_cache->AtEnd());
   }
   return Status::OK();
@@ -199,6 +200,7 @@ Status PartitionedAggregationNode::ProcessBatchStreaming(bool needs_serialize,
       DCHECK(process_batch_status_.ok());
       expr_vals_cache->NextRow();
     }
+    ht_ctx->expr_results_pool_->clear();
     DCHECK(expr_vals_cache->AtEnd());
   }
   if (needs_serialize) {

--- a/be/src/exec/partitioned_hash_table.h
+++ b/be/src/exec/partitioned_hash_table.h
@@ -358,6 +358,7 @@ class PartitionedHashTableCtx {
   ExprValuesCache* ALWAYS_INLINE expr_values_cache() { return &expr_values_cache_; }
 
  private:
+  friend class PartitionedAggregationNode;
   friend class PartitionedHashTable;
   friend class HashTableTest_HashEmpty_Test;
 


### PR DESCRIPTION
select date_format(k10, '%Y%m%d') as myk10 from baseall group by myk10;
The date_format function in query above will be stored in MemPool during
the query execution. If the query handles millions of rows, it will
consume much memory. Should clear the MemPool at interval.