### PR TITLE
Optimize performance of TxnManager::build_expire_txn_map

### DIFF
--- a/be/src/olap/txn_manager.h
+++ b/be/src/olap/txn_manager.h
@@ -133,7 +133,7 @@ public:
 
     // get all expired txns and save tham in expire_txn_map.
     // This is currently called before reporting all tablet info, to avoid iterating txn map for every tablets.
-    void build_expire_txn_map(std::map<TabletInfo, std::set<int64_t>>* expire_txn_map);
+    void build_expire_txn_map(std::map<TabletInfo, std::vector<int64_t>>* expire_txn_map);
 
     void force_rollback_tablet_related_txns(OlapMeta* meta, TTabletId tablet_id, SchemaHash schema_hash, TabletUid tablet_uid);
 


### PR DESCRIPTION
It's not possible to insert duplicated transaction ids for a specific tablet, therefore we could use `map<TabletInfo, vector<int64_t>>` instead of `map<TabletInfo, set<int64_t>>` for expire_txn_map.