### PR TITLE
[Doris On ES] Support compound_and predicate push down to Elasticsearch

### DIFF
--- a/be/src/exec/es/es_predicate.h
+++ b/be/src/exec/es/es_predicate.h
@@ -86,9 +86,15 @@ struct ExtPredicate {
     TExprNodeType::type node_type;
 };
 
-// this used for placeholder for compound_and
-struct ExtCompAndPredicates : public ExtPredicate {
-    ExtCompAndPredicates(std::vector<EsPredicate*> conjuncts) : ExtPredicate(TExprNodeType::COMPOUND_PRED), op(TExprOpcode::COMPOUND_AND), conjuncts(conjuncts) {
+// this used for placeholder for compound_predicate
+// reserved for compound_not
+struct ExtCompPredicates : public ExtPredicate {
+    ExtCompPredicates(
+            TExprOpcode::type expr_op,
+            const std::vector<EsPredicate*>& es_predicates) : 
+            ExtPredicate(TExprNodeType::COMPOUND_PRED),
+            op(expr_op),
+            conjuncts(es_predicates) {
     }
 
     TExprOpcode::type op;

--- a/be/src/exec/es/es_predicate.h
+++ b/be/src/exec/es/es_predicate.h
@@ -34,6 +34,7 @@ namespace doris {
 class Status;
 class ExprContext;
 class ExtBinaryPredicate;
+class EsPredicate;
 
 class ExtLiteral {
 public:
@@ -83,6 +84,15 @@ struct ExtPredicate {
     }
 
     TExprNodeType::type node_type;
+};
+
+// this used for placeholder for compound_and
+struct ExtCompAndPredicates : public ExtPredicate {
+    ExtCompAndPredicates(std::vector<EsPredicate*> conjuncts) : ExtPredicate(TExprNodeType::COMPOUND_PRED), op(TExprOpcode::COMPOUND_AND), conjuncts(conjuncts) {
+    }
+
+    TExprOpcode::type op;
+    std::vector<EsPredicate*> conjuncts;
 };
 
 struct ExtBinaryPredicate : public ExtPredicate {
@@ -169,7 +179,7 @@ struct ExtFunction : public ExtPredicate {
 
 class EsPredicate {
 public:
-    EsPredicate(ExprContext* context, const TupleDescriptor* tuple_desc);
+    EsPredicate(ExprContext* context, const TupleDescriptor* tuple_desc, ObjectPool* pool);
     ~EsPredicate();
     const std::vector<ExtPredicate*>& get_predicate_list();
     Status build_disjuncts_list();
@@ -191,7 +201,10 @@ private:
     int _disjuncts_num;
     const TupleDescriptor* _tuple_desc;
     std::vector<ExtPredicate*> _disjuncts;
+    // used for compound_and
+    std::vector<ExtPredicate*> _conjuncts;
     Status _es_query_status;
+    ObjectPool *_pool;
 };
 
 }

--- a/be/src/exec/es/es_predicate.h
+++ b/be/src/exec/es/es_predicate.h
@@ -201,8 +201,6 @@ private:
     int _disjuncts_num;
     const TupleDescriptor* _tuple_desc;
     std::vector<ExtPredicate*> _disjuncts;
-    // used for compound_and
-    std::vector<ExtPredicate*> _conjuncts;
     Status _es_query_status;
     ObjectPool *_pool;
 };

--- a/be/src/exec/es/es_query_builder.cpp
+++ b/be/src/exec/es/es_query_builder.cpp
@@ -258,14 +258,17 @@ BooleanQueryBuilder::BooleanQueryBuilder(const std::vector<ExtPredicate*>& predi
                 break;
             }
             case TExprNodeType::COMPOUND_PRED: {
-                ExtCompAndPredicates* comp_and_predicate = (ExtCompAndPredicates *)predicate;
-                BooleanQueryBuilder* bool_query = new BooleanQueryBuilder();
-                for (auto es_predicate : comp_and_predicate->conjuncts) {
-                    vector<ExtPredicate*> or_predicates = es_predicate->get_predicate_list();
-                    BooleanQueryBuilder* inner_bool_query = new BooleanQueryBuilder(or_predicates);
-                    bool_query->must(inner_bool_query);
+                ExtCompPredicates* compound_predicates = (ExtCompPredicates *)predicate;
+                // reserved for compound_not
+                if (compound_predicates->op == TExprOpcode::COMPOUND_AND) {
+                    BooleanQueryBuilder* bool_query = new BooleanQueryBuilder();
+                    for (auto es_predicate : compound_predicates->conjuncts) {
+                        vector<ExtPredicate*> or_predicates = es_predicate->get_predicate_list();
+                        BooleanQueryBuilder* inner_bool_query = new BooleanQueryBuilder(or_predicates);
+                        bool_query->must(inner_bool_query);
+                    }
+                    _should_clauses.push_back(bool_query);
                 }
-                _should_clauses.push_back(bool_query);
                 break;
             }
             default:
@@ -371,15 +374,21 @@ void BooleanQueryBuilder::validate(const std::vector<EsPredicate*>& espredicates
                     break;
                 }
                 case TExprNodeType::COMPOUND_PRED: {
-                    ExtCompAndPredicates* compound_predicates = (ExtCompAndPredicates *)predicate;
-                    std::vector<bool> list;
-                    validate(compound_predicates->conjuncts, &list);
-                    for(int i = list.size() - 1; i >= 0; i--) {
-                        if(!list[i]) {
-                            flag = false;
-                            break;
+                    ExtCompPredicates* compound_predicates = (ExtCompPredicates *)predicate;
+                    if (compound_predicates->op == TExprOpcode::COMPOUND_AND) {
+                        std::vector<bool> list;
+                        validate(compound_predicates->conjuncts, &list);
+                        for(int i = list.size() - 1; i >= 0; i--) {
+                            if(!list[i]) {
+                                flag = false;
+                                break;
+                            }
                         }
+                    } else {
+                        // reserved for compound_not
+                        flag = false;
                     }
+                    break;
                 }
                 case TExprNodeType::LIKE_PRED:
                 case TExprNodeType::IS_NULL_PRED:

--- a/be/src/exec/es/es_query_builder.cpp
+++ b/be/src/exec/es/es_query_builder.cpp
@@ -258,8 +258,8 @@ BooleanQueryBuilder::BooleanQueryBuilder(const std::vector<ExtPredicate*>& predi
                 break;
             }
             case TExprNodeType::COMPOUND_PRED: {
-                ExtCompAndPredicates *comp_and_predicate = (ExtCompAndPredicates *)predicate;
-                BooleanQueryBuilder *bool_query = new BooleanQueryBuilder();
+                ExtCompAndPredicates* comp_and_predicate = (ExtCompAndPredicates *)predicate;
+                BooleanQueryBuilder* bool_query = new BooleanQueryBuilder();
                 for (auto es_predicate : comp_and_predicate->conjuncts) {
                     vector<ExtPredicate*> or_predicates = es_predicate->get_predicate_list();
                     BooleanQueryBuilder* inner_bool_query = new BooleanQueryBuilder(or_predicates);

--- a/be/src/exec/es_http_scan_node.cpp
+++ b/be/src/exec/es_http_scan_node.cpp
@@ -92,7 +92,7 @@ Status EsHttpScanNode::build_conjuncts_list() {
     Status status = Status::OK();
     for (int i = 0; i < _conjunct_ctxs.size(); ++i) {
         EsPredicate* predicate = _pool->add(
-                    new EsPredicate(_conjunct_ctxs[i], _tuple_desc));
+                    new EsPredicate(_conjunct_ctxs[i], _tuple_desc, _pool));
         status = predicate->build_disjuncts_list();
         if (status.ok()) {
             _predicates.push_back(predicate);

--- a/be/test/exec/es_predicate_test.cpp
+++ b/be/test/exec/es_predicate_test.cpp
@@ -146,7 +146,7 @@ TEST_F(EsPredicateTest, normal) {
     TupleDescriptor *tuple_desc = _desc_tbl->get_tuple_descriptor(0);
     std::vector<EsPredicate*> predicates;
     for (int i = 0; i < conjunct_ctxs.size(); ++i) {
-        EsPredicate* predicate = new EsPredicate(conjunct_ctxs[i], tuple_desc);
+        EsPredicate* predicate = new EsPredicate(conjunct_ctxs[i], tuple_desc, &_obj_pool);
         if (predicate->build_disjuncts_list().ok()) {
             predicates.push_back(predicate);
         }

--- a/be/test/exec/es_query_builder_test.cpp
+++ b/be/test/exec/es_query_builder_test.cpp
@@ -470,6 +470,83 @@ TEST_F(BooleanQueryBuilderTest, validate_partial) {
     std::vector<bool> expected1 = {true, true, false};
     ASSERT_TRUE(result1 == expected1);
 }
+
+// ( k >= "a" and (fv not in [8.0, 16.0]) or (content != "wyf") ) or content like "a%e%g_"
+
+TEST_F(BooleanQueryBuilderTest, validate_compound_and) {
+
+    std::string terms_in_field = "fv"; // fv not in [8.0, 16.0]
+    int terms_in_field_length = terms_in_field.length();
+    TypeDescriptor terms_in_col_type_desc = TypeDescriptor::create_varchar_type(terms_in_field_length);
+
+    char value_1[] = "8.0";
+    int value_1_length = (int)strlen(value_1);
+    StringValue string_value_1(value_1, value_1_length);
+    ExtLiteral term_literal_1(TYPE_VARCHAR, &string_value_1);
+
+    char value_2[] = "16.0";
+    int value_2_length = (int)strlen(value_2);
+    StringValue string_value_2(value_2, value_2_length);
+    ExtLiteral term_literal_2(TYPE_VARCHAR, &string_value_2);
+
+    std::vector<ExtLiteral> terms_values = {term_literal_1, term_literal_2};
+    ExtInPredicate* in_predicate = new ExtInPredicate(TExprNodeType::IN_PRED, true, terms_in_field, terms_in_col_type_desc, terms_values);
+
+    char term_str[] = "wyf";
+    int term_value_length = (int)strlen(term_str);
+    StringValue term_value(term_str, term_value_length);
+    ExtLiteral term_literal(TYPE_VARCHAR, &term_value);
+    TypeDescriptor term_type_desc = TypeDescriptor::create_varchar_type(term_value_length);
+    std::string term_field_name = "content";
+    ExtBinaryPredicate* term_ne_predicate = new ExtBinaryPredicate(TExprNodeType::BINARY_PRED, term_field_name, term_type_desc, TExprOpcode::NE, term_literal);
+
+    std::vector<ExtPredicate*> innner_or_content = {term_ne_predicate, in_predicate};
+
+    EsPredicate* innner_or_predicate = new EsPredicate(innner_or_content);
+
+    char range_value_str[] = "a"; // k >= "a"
+    int range_value_length = (int)strlen(range_value_str);
+    StringValue range_value(range_value_str, range_value_length);
+    ExtLiteral range_literal(TYPE_VARCHAR, &range_value);
+    TypeDescriptor range_type_desc = TypeDescriptor::create_varchar_type(range_value_length);
+    std::string range_field_name = "k";
+    ExtBinaryPredicate* range_predicate = new ExtBinaryPredicate(TExprNodeType::BINARY_PRED, range_field_name, range_type_desc, TExprOpcode::GE, range_literal);
+    std::vector<ExtPredicate*> range_predicates = {range_predicate};
+    EsPredicate* left_inner_or_predicate = new EsPredicate(range_predicates);
+
+    std::vector<EsPredicate*> ourter_left_predicates_1 = {left_inner_or_predicate, innner_or_predicate};
+
+    ExtCompPredicates* comp_predicate = new ExtCompPredicates(TExprOpcode::COMPOUND_AND, ourter_left_predicates_1);
+
+    char like_value[] = "a%e%g_";
+    int like_value_length = (int)strlen(like_value);
+    TypeDescriptor like_type_desc = TypeDescriptor::create_varchar_type(like_value_length);
+    StringValue like_term_value(like_value, like_value_length);
+    ExtLiteral like_literal(TYPE_VARCHAR, &like_term_value);
+    std::string like_field_name = "content";
+    ExtLikePredicate* like_predicate = new ExtLikePredicate(TExprNodeType::LIKE_PRED, like_field_name, like_type_desc, like_literal);
+
+    
+    std::vector<ExtPredicate*> or_predicate_vector = {comp_predicate, like_predicate};
+    EsPredicate* or_predicate = new EsPredicate(or_predicate_vector);
+
+    std::vector<EsPredicate*> or_predicates = {or_predicate};
+    std::vector<bool> result1;
+    BooleanQueryBuilder::validate(or_predicates, &result1);
+    std::vector<bool> expected1 = {true};
+    ASSERT_TRUE(result1 == expected1);
+
+    rapidjson::Document document;
+    rapidjson::Value compound_and_value(rapidjson::kObjectType);
+    compound_and_value.SetObject();
+    BooleanQueryBuilder::to_query(or_predicates, &document, &compound_and_value);
+    rapidjson::StringBuffer buffer;
+    rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
+    compound_and_value.Accept(writer);
+    std::string actual_bool_json = buffer.GetString();
+    std::string expected_json = "{\"bool\":{\"filter\":[{\"bool\":{\"should\":[{\"bool\":{\"filter\":[{\"bool\":{\"should\":[{\"range\":{\"k\":{\"gte\":\"a\"}}}]}},{\"bool\":{\"should\":[{\"bool\":{\"must_not\":[{\"term\":{\"content\":\"wyf\"}}]}},{\"bool\":{\"must_not\":[{\"terms\":{\"fv\":[\"8.0\",\"16.0\"]}}]}}]}}]}},{\"wildcard\":{\"content\":\"a*e*g?\"}}]}}]}}";
+    ASSERT_STREQ(expected_json.c_str(), actual_bool_json.c_str());
+}
 }
 
 int main(int argc, char* argv[]) {


### PR DESCRIPTION
Relate Issue: https://github.com/apache/incubator-doris/issues/3248


SQL:

```
select * from test where (k2 = 6 and k3 = 1) or (k2 = 2 and k3 =3 and k4 = 'beijing');
```

Output filter:

```
((#k2:[6 TO 6] #k3:[1 TO 1]) (#(#k2:[2 TO 2] #k3:[3 TO 3]) #k4:beijing))~1
```

SQL:

```
select * from test where (k2 = 6 or k3 = 7) or (k2 = 2 and k3 =3 and (k4 = 'beijing' or k4 = 'zhaochun'));
```
Output filter:

```
(k2:[6 TO 6] k3:[7 TO 7] (#(#k2:[2 TO 2] #k3:[3 TO 3]) #((k4:beijing k4:zhaochun)~1)))~1
```

SQL:

```
select * from test where (k2 = 6 or k3 = 7) or (k2 = 2 and abs(k3) =3 and (k4 = 'beijing' or k4 = 'zhaochun'));
```

Output filter (`abs` can not be pushed down to es, so doris on es would not process this scenario ):

```
match_all
```