### PR TITLE
[BUG] Fix cast result expr bug

### DIFF
--- a/fe/src/main/java/org/apache/doris/analysis/StatementBase.java
+++ b/fe/src/main/java/org/apache/doris/analysis/StatementBase.java
@@ -124,6 +124,9 @@ public abstract class StatementBase implements ParseNode {
         Preconditions.checkNotNull(resultExprs);
         Preconditions.checkState(resultExprs.size() == types.size());
         for (int i = 0; i < types.size(); ++i) {
+            if (resultExprs.get(i).getType().isDateType() && types.get(i).isDateType()) {
+                continue;                               
+            }
             if (!resultExprs.get(i).getType().equals(types.get(i))) {
                 resultExprs.set(i, resultExprs.get(i).castTo(types.get(i)));
             }

--- a/fe/src/main/java/org/apache/doris/analysis/StatementBase.java
+++ b/fe/src/main/java/org/apache/doris/analysis/StatementBase.java
@@ -124,6 +124,9 @@ public abstract class StatementBase implements ParseNode {
         Preconditions.checkNotNull(resultExprs);
         Preconditions.checkState(resultExprs.size() == types.size());
         for (int i = 0; i < types.size(); ++i) {
+            //The specific type of the date type is determined by the 
+            //actual type of the return value, not by the function return value type in FE Function
+            //such as the result of str_to_date may be either DATE or DATETIME
             if (resultExprs.get(i).getType().isDateType() && types.get(i).isDateType()) {
                 continue;                               
             }

--- a/fe/src/test/java/org/apache/doris/planner/QueryPlanTest.java
+++ b/fe/src/test/java/org/apache/doris/planner/QueryPlanTest.java
@@ -17,10 +17,11 @@
 
 package org.apache.doris.planner;
 
-
 import org.apache.doris.analysis.CreateDbStmt;
 import org.apache.doris.analysis.CreateTableStmt;
 import org.apache.doris.analysis.DropDbStmt;
+import org.apache.doris.analysis.Expr;
+import org.apache.doris.analysis.SelectStmt;
 import org.apache.doris.analysis.ShowCreateDbStmt;
 import org.apache.doris.analysis.StatementBase;
 import org.apache.doris.catalog.Catalog;
@@ -445,4 +446,17 @@ public class QueryPlanTest {
         Assert.assertEquals(showCreateDbStmt.toSql(), showCreateSchemaStmt.toSql());
     }
 
+    @Test
+    public void testDateTypeCastSyntax() throws Exception {
+        String castSql = "select * from test.baseall where k11 < cast('2020-03-26' as date)";
+        SelectStmt selectStmt =
+                (SelectStmt) UtFrameUtils.parseAndAnalyzeStmt(castSql, connectContext);
+        Expr rightExpr = selectStmt.getWhereClause().getChildren().get(1);
+        Assert.assertTrue(rightExpr.getType().equals(Type.DATETIME));
+
+        String castSql2 = "select str_to_date('11/09/2011', '%m/%d/%Y');";
+        String explainString = UtFrameUtils.getSQLPlanOrErrorMsg(connectContext, "explain " + castSql2);
+        Assert.assertTrue(explainString.contains("2011-11-09"));
+        Assert.assertFalse(explainString.contains("2011-11-09 00:00:00"));
+    }
 }


### PR DESCRIPTION
For #3275 

When the result type is a date type, the result expr type should not be cast
Because in the fe function, the specific type of the date type is determined by the actual type of the return value, not by the function return value type