### PR TITLE
unregister fragment mem tracker in close()

### DIFF
--- a/be/src/runtime/plan_fragment_executor.cpp
+++ b/be/src/runtime/plan_fragment_executor.cpp
@@ -65,6 +65,12 @@ PlanFragmentExecutor::~PlanFragmentExecutor() {
     // }
     // at this point, the report thread should have been stopped
     DCHECK(!_report_thread_active);
+
+    // fragment mem tracker needs unregister
+    if (_mem_tracker.get() != nullptr) {
+        _mem_tracker->unregister_from_parent();
+        _mem_tracker->close();
+    }
 }
 
 Status PlanFragmentExecutor::prepare(const TExecPlanFragmentParams& request) {
@@ -556,12 +562,10 @@ void PlanFragmentExecutor::close() {
         }
     }
      
-    // fragment mem tracker needs unregister
+    // _mem_tracker init failed
     if (_mem_tracker.get() != nullptr) {
-        _mem_tracker->unregister_from_parent();
-        _mem_tracker->close();
+        _mem_tracker->release(_mem_tracker->consumption());
     }
-    _mem_tracker.reset();
     _closed = true;
 }
 

--- a/be/src/runtime/plan_fragment_executor.cpp
+++ b/be/src/runtime/plan_fragment_executor.cpp
@@ -556,10 +556,12 @@ void PlanFragmentExecutor::close() {
         }
     }
      
-    // _mem_tracker init failed
+    // fragment mem tracker needs unregister
     if (_mem_tracker.get() != nullptr) {
-        _mem_tracker->release(_mem_tracker->consumption());
+        _mem_tracker->unregister_from_parent();
+        _mem_tracker->close();
     }
+    _mem_tracker.reset();
     _closed = true;
 }
 

--- a/be/src/runtime/plan_fragment_executor.cpp
+++ b/be/src/runtime/plan_fragment_executor.cpp
@@ -69,7 +69,6 @@ PlanFragmentExecutor::~PlanFragmentExecutor() {
     // fragment mem tracker needs unregister
     if (_mem_tracker.get() != nullptr) {
         _mem_tracker->unregister_from_parent();
-        _mem_tracker->close();
     }
 }
 


### PR DESCRIPTION
ref https://github.com/apache/incubator-doris/issues/3273

P.S.
https://github.com/apache/incubator-doris/blob/614a76beeac73821c78903c46e7a703b7956796b/be/src/runtime/plan_fragment_executor.cpp#L559-L562
I think this piece of code is useless.
This `_mem_tracker` in `PlanFragmentExecutor` is set as fragment_mem_tracker of `RuntimeState`.

**direct use**
We use it in these code, when rowbatch reset, mem tracker's consumption will be released.
https://github.com/apache/incubator-doris/blob/7eab12a40e5a20959c13eba99697c171d1461e0b/be/src/exec/olap_rewrite_node.cpp#L57-L58
https://github.com/apache/incubator-doris/blob/839ec45197fb4559c4946bf0fa4ce3b6805b4248/be/src/exec/olap_scan_node.cpp#L1217-L1218

**other usage** 
e.g.
https://github.com/apache/incubator-doris/blob/6c33f805449d9a7bc8809a575407acfa87bb061e/be/src/exec/olap_scanner.cpp#L245
won't consume the fragment mem tracker. We don't need to worry about the fragment mem tracker consumption is not zero when we want to destroy it.

Or we can add a consumption check before we close the mem tracker?