### PR TITLE
[Bug] Fix bug that user plugin dir is removed after installing the plugin

### DIFF
--- a/fe/src/main/java/org/apache/doris/plugin/DynamicPluginLoader.java
+++ b/fe/src/main/java/org/apache/doris/plugin/DynamicPluginLoader.java
@@ -79,17 +79,17 @@ public class DynamicPluginLoader extends PluginLoader {
                 PluginZip zip = new PluginZip(source);
                 // generation a tmp dir to extract the zip
                 tmpTarget = Files.createTempDirectory(pluginDir, ".install_");
-                // for now, installPath point to the temp dir which contains all extracted files from zip file.
+                // for now, installPath point to the temp dir which contains
+                // all files extracted from zip or copied from user specified dir.
                 installPath = zip.extract(tmpTarget);
             }
             pluginInfo = PluginInfo.readFromProperties(installPath, source);
         } catch (Exception e) {
             if (tmpTarget != null) {
-                Files.delete(tmpTarget);
+                FileUtils.deleteQuietly(tmpTarget.toFile());
             }
             throw e;
         }
-
         return pluginInfo;
     }
 

--- a/fe/src/main/java/org/apache/doris/plugin/PluginZip.java
+++ b/fe/src/main/java/org/apache/doris/plugin/PluginZip.java
@@ -141,7 +141,8 @@ class PluginZip {
     }
 
     /**
-     * unzip the specified .zip file "zip" to the target path
+     * if `zipOrPath` is a zip file, unzip the specified .zip file to the targetPath.
+     * if `zipOrPath` is a dir, copy the dir and its content to targetPath.
      */
     Path extractZip(Path zip, Path targetPath) throws IOException, UserException {
         if (!Files.exists(zip)) {
@@ -149,7 +150,9 @@ class PluginZip {
         }
 
         if (Files.isDirectory(zip)) {
-            return zip;
+            // user install the plugin by dir/, so just copy the dir to the target path
+            FileUtils.copyDirectory(zip.toFile(), targetPath.toFile());
+            return targetPath;
         }
 
         try (ZipInputStream zipInput = new ZipInputStream(Files.newInputStream(zip))) {


### PR DESCRIPTION
When user install a FE plugin from a directory, the directory should not
be removed after installing.

ISSUE: #3301 