### PR TITLE
[Doris On ES] Add field context for string field keyword type

### DIFF
--- a/be/src/exec/es/es_predicate.cpp
+++ b/be/src/exec/es/es_predicate.cpp
@@ -413,7 +413,7 @@ Status EsPredicate::build_disjuncts_list(const Expr* conjunct) {
             std::vector<EsPredicate*> conjuncts;
             for (int i = 0; i < conjunct->get_num_children(); ++i) {
                 EsPredicate *predicate = _pool->add(new EsPredicate(_context, _tuple_desc, _pool));
-                predicate->field_context(_field_context);
+                predicate->set_field_context(_field_context);
                 Status status = predicate->build_disjuncts_list(conjunct->children()[i]);
                 if (status.ok()) {
                     conjuncts.push_back(predicate);

--- a/be/src/exec/es/es_predicate.h
+++ b/be/src/exec/es/es_predicate.h
@@ -198,6 +198,10 @@ public:
         return _es_query_status;
     }
 
+    void field_context(const std::map<std::string, std::string>& field_context) {
+        _field_context = field_context;
+    }
+
 private:
     Status build_disjuncts_list(const Expr* conjunct);
     bool is_match_func(const Expr* conjunct);
@@ -209,6 +213,7 @@ private:
     std::vector<ExtPredicate*> _disjuncts;
     Status _es_query_status;
     ObjectPool *_pool;
+    std::map<std::string, std::string> _field_context;
 };
 
 }

--- a/be/src/exec/es/es_predicate.h
+++ b/be/src/exec/es/es_predicate.h
@@ -198,7 +198,7 @@ public:
         return _es_query_status;
     }
 
-    void field_context(const std::map<std::string, std::string>& field_context) {
+    void set_field_context(const std::map<std::string, std::string>& field_context) {
         _field_context = field_context;
     }
 

--- a/be/src/exec/es_http_scan_node.cpp
+++ b/be/src/exec/es_http_scan_node.cpp
@@ -97,7 +97,7 @@ Status EsHttpScanNode::build_conjuncts_list() {
     for (int i = 0; i < _conjunct_ctxs.size(); ++i) {
         EsPredicate* predicate = _pool->add(
                     new EsPredicate(_conjunct_ctxs[i], _tuple_desc, _pool));
-        predicate->field_context(_fields_context);
+        predicate->set_field_context(_fields_context);
         status = predicate->build_disjuncts_list();
         if (status.ok()) {
             _predicates.push_back(predicate);

--- a/be/src/exec/es_http_scan_node.cpp
+++ b/be/src/exec/es_http_scan_node.cpp
@@ -59,6 +59,10 @@ Status EsHttpScanNode::init(const TPlanNode& tnode, RuntimeState* state) {
     if (tnode.es_scan_node.__isset.docvalue_context) {
         _docvalue_context = tnode.es_scan_node.docvalue_context;
     }
+
+    if (tnode.es_scan_node.__isset.fields_context) {
+        _fields_context = tnode.es_scan_node.fields_context;
+    }
     return Status::OK();
 }
 
@@ -93,6 +97,7 @@ Status EsHttpScanNode::build_conjuncts_list() {
     for (int i = 0; i < _conjunct_ctxs.size(); ++i) {
         EsPredicate* predicate = _pool->add(
                     new EsPredicate(_conjunct_ctxs[i], _tuple_desc, _pool));
+        predicate->field_context(_fields_context);
         status = predicate->build_disjuncts_list();
         if (status.ok()) {
             _predicates.push_back(predicate);

--- a/be/src/exec/es_http_scan_node.h
+++ b/be/src/exec/es_http_scan_node.h
@@ -100,6 +100,7 @@ private:
     std::vector<std::promise<Status>> _scanners_status;
     std::map<std::string, std::string> _properties;
     std::map<std::string, std::string> _docvalue_context;
+    std::map<std::string, std::string> _fields_context;
     std::vector<TScanRangeParams> _scan_ranges;
     std::vector<std::string> _column_names;
 

--- a/fe/src/main/java/org/apache/doris/catalog/Catalog.java
+++ b/fe/src/main/java/org/apache/doris/catalog/Catalog.java
@@ -3997,8 +3997,9 @@ public class Catalog {
             sb.append("\"password\" = \"").append(hidePassword ? "" : esTable.getPasswd()).append("\",\n");
             sb.append("\"index\" = \"").append(esTable.getIndexName()).append("\",\n");
             sb.append("\"type\" = \"").append(esTable.getMappingType()).append("\",\n");
-            sb.append("\"transport\" = \"").append(esTable.getTransport()).append("\"\n");
-            sb.append("\"enable_docvalue_scan\" = \"").append(esTable.isDocValueScanEnable()).append("\"\n");
+            sb.append("\"transport\" = \"").append(esTable.getTransport()).append("\",\n");
+            sb.append("\"enable_docvalue_scan\" = \"").append(esTable.isDocValueScanEnable()).append("\",\n");
+            sb.append("\"enable_keyword_sniff\" = \"").append(esTable.isKeywordSniffEnable()).append("\"\n");
             sb.append(")");
         }
         sb.append(";");

--- a/fe/src/main/java/org/apache/doris/catalog/EsTable.java
+++ b/fe/src/main/java/org/apache/doris/catalog/EsTable.java
@@ -196,7 +196,7 @@ public class EsTable extends Table {
                         + " shoud be like 'true' or 'false'， value should be double quotation marks");
             }
         } else {
-            enableKeywordSniff = false;
+            enableKeywordSniff = true;
         }
 
         if (!Strings.isNullOrEmpty(properties.get(TYPE))

--- a/fe/src/main/java/org/apache/doris/catalog/EsTable.java
+++ b/fe/src/main/java/org/apache/doris/catalog/EsTable.java
@@ -56,6 +56,7 @@ public class EsTable extends Table {
     public static final String TRANSPORT_HTTP = "http";
     public static final String TRANSPORT_THRIFT = "thrift";
     public static final String DOC_VALUE_SCAN = "enable_docvalue_scan";
+    public static final String KEYWORD_SNIFF = "enable_keyword_sniff";
 
     private String hosts;
     private String[] seeds;
@@ -69,6 +70,7 @@ public class EsTable extends Table {
     private PartitionInfo partitionInfo;
     private EsTableState esTableState;
     private boolean enableDocValueScan = false;
+    private boolean enableKeywordSniff = true;
 
     public EsMajorVersion majorVersion = null;
 
@@ -93,6 +95,8 @@ public class EsTable extends Table {
     // use select city from table, if enable the docvalue, we will fetch the `city` field value from `city.raw`
     private Map<String, String> docValueContext = new HashMap<>();
 
+    private Map<String, String> fieldsContext = new HashMap<>();
+
     public EsTable() {
         super(TableType.ELASTICSEARCH);
     }
@@ -104,6 +108,13 @@ public class EsTable extends Table {
         validate(properties);
     }
 
+    public void addFetchField(String originName, String replaceName) {
+        fieldsContext.put(originName, replaceName);
+    }
+
+    public Map<String, String> fieldsContext() {
+        return fieldsContext;
+    }
 
     public void addDocValueField(String name, String fieldsName) {
         docValueContext.put(name, fieldsName);
@@ -115,6 +126,10 @@ public class EsTable extends Table {
 
     public boolean isDocValueScanEnable() {
         return enableDocValueScan;
+    }
+
+    public boolean isKeywordSniffEnable() {
+        return enableKeywordSniff;
     }
 
 
@@ -159,7 +174,7 @@ public class EsTable extends Table {
             }
         }
 
-        // Explicit setting for cluster version to avoid detecting version failure
+        // enable doc value scan for Elasticsearch
         if (properties.containsKey(DOC_VALUE_SCAN)) {
             try {
                 enableDocValueScan = Boolean.parseBoolean(properties.get(DOC_VALUE_SCAN).trim());
@@ -170,6 +185,18 @@ public class EsTable extends Table {
             }
         } else {
             enableDocValueScan = false;
+        }
+
+        if (properties.containsKey(KEYWORD_SNIFF)) {
+            try {
+                enableKeywordSniff = Boolean.parseBoolean(properties.get(KEYWORD_SNIFF).trim());
+            } catch (Exception e) {
+                throw new DdlException("fail to parse enable_keyword_sniff, enable_keyword_sniff= "
+                        + properties.get(VERSION).trim() + " ,`enable_keyword_sniff`"
+                        + " shoud be like 'true' or 'false'， value should be double quotation marks");
+            }
+        } else {
+            enableKeywordSniff = false;
         }
 
         if (!Strings.isNullOrEmpty(properties.get(TYPE))
@@ -194,6 +221,7 @@ public class EsTable extends Table {
             tableContext.put("majorVersion", majorVersion.toString());
         }
         tableContext.put("enableDocValueScan", String.valueOf(enableDocValueScan));
+        tableContext.put("enableKeywordSniff", String.valueOf(enableKeywordSniff));
     }
 
     public TTableDescriptor toThrift() {
@@ -278,6 +306,11 @@ public class EsTable extends Table {
             }
 
             enableDocValueScan = Boolean.parseBoolean(tableContext.get("enableDocValueScan"));
+            if (tableContext.containsKey("enableKeywordSniff")) {
+                enableKeywordSniff = Boolean.parseBoolean(tableContext.get("enableKeywordSniff"));
+            } else {
+                enableKeywordSniff = true;
+            }
 
             PartitionType partType = PartitionType.valueOf(Text.readString(in));
             if (partType == PartitionType.UNPARTITIONED) {
@@ -311,6 +344,7 @@ public class EsTable extends Table {
             tableContext.put("mappingType", mappingType);
             tableContext.put("transport", transport);
             tableContext.put("enableDocValueScan", "false");
+            tableContext.put(KEYWORD_SNIFF, "true");
         }
     }
 

--- a/fe/src/main/java/org/apache/doris/planner/EsScanNode.java
+++ b/fe/src/main/java/org/apache/doris/planner/EsScanNode.java
@@ -123,6 +123,9 @@ public class EsScanNode extends ScanNode {
         if (table.isDocValueScanEnable()) {
             esScanNode.setDocvalue_context(table.docValueContext());
         }
+        if (table.isKeywordSniffEnable() && table.fieldsContext().size() > 0) {
+            esScanNode.setFields_context(table.fieldsContext());
+        }
         msg.es_scan_node = esScanNode;
 
     }

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -222,6 +222,18 @@ struct TEsScanNode {
     // {"city": "city.raw"}
     // use select city from table, if enable the docvalue, we will fetch the `city` field value from `city.raw`
     3: optional map<string, string> docvalue_context
+    // used to indicate which string-type field predicate should used xxx.keyword etc.
+    // "k1": {
+    //    "type": "text",
+    //    "fields": {
+    //        "keyword": {
+    //            "type": "keyword",
+    //            "ignore_above": 256
+    //           }
+    //    }
+    // }
+    // k1 > 'abc' -> k1.keyword > 'abc'
+    4: optional map<string, string> fields_context
 }
 
 struct TMiniLoadEtlFunction {


### PR DESCRIPTION
https://github.com/apache/incubator-doris/issues/3304

This PR is just a transitional way，but it is better to move the predicates transformation from Doris BE to Doris BE, in this way, Doris BE is responsible for fetching data from ES.

 Add a  `enable_keyword_sniff ` configuration item in creating External Elasticsearch Table ，it default to true , would to sniff the `keyword` type on the `text analyzed` Field and return the `json_path` which substitute the origin col name.

```
CREATE EXTERNAL TABLE `test` (
  `k1` varchar(20) COMMENT "",
  `create_time` datetime COMMENT ""
) ENGINE=ELASTICSEARCH
PROPERTIES (
"hosts" = "http://10.74.167.16:8200",
"user" = "root",
"password" = "root",
"index" = "test",
"type" = "doc",
"enable_keyword_sniff" = "true"
);
```
note: `enable_keyword_sniff` default to  "true"

run this SQL：

```
select * from test where k1 = "wu yun feng"
```
 Output predicate DSL：

```
{"term":{"k1.keyword":"wu yun feng"}}
```
and in this PR, I remove the elasticsearch version detected logic for now this is useless, maybe future is needed.