### PR TITLE
[Bug] Use equals() method to judge whether "type" are equal

### DIFF
--- a/fe/src/main/java/org/apache/doris/analysis/Analyzer.java
+++ b/fe/src/main/java/org/apache/doris/analysis/Analyzer.java
@@ -1412,7 +1412,7 @@ public class Analyzer {
             // TODO(zc)
             compatibleType = Type.getCmpType(compatibleType, exprs.get(i).getType());
         }
-        if (compatibleType == Type.VARCHAR) {
+        if (compatibleType.equals(Type.VARCHAR)) {
             if (exprs.get(0).getType().isDateType()) {
                 compatibleType = Type.DATETIME;
             }

--- a/fe/src/main/java/org/apache/doris/analysis/CastExpr.java
+++ b/fe/src/main/java/org/apache/doris/analysis/CastExpr.java
@@ -105,8 +105,8 @@ public class CastExpr extends Expr {
                 }
                 // Disable casting from boolean to decimal or datetime or date
                 if (fromType.isBoolean() &&
-                        (toType == Type.DECIMAL || toType == Type.DECIMALV2 ||
-                                toType == Type.DATETIME || toType == Type.DATE)) {
+                        (toType.equals(Type.DECIMAL) || toType.equals(Type.DECIMALV2) ||
+                                toType.equals(Type.DATETIME) || toType.equals(Type.DATE))) {
                     continue;
                 }
                 // Disable no-op casts

--- a/fe/src/main/java/org/apache/doris/analysis/ColumnDef.java
+++ b/fe/src/main/java/org/apache/doris/analysis/ColumnDef.java
@@ -205,7 +205,7 @@ public class ColumnDef {
                 break;
             case FLOAT:
                 FloatLiteral floatLiteral = new FloatLiteral(defaultValue);
-                if (floatLiteral.getType() == Type.DOUBLE) {
+                if (floatLiteral.getType().equals(Type.DOUBLE)) {
                     throw new AnalysisException("Default value will loose precision: " + defaultValue);
                 }
             case DOUBLE:

--- a/fe/src/main/java/org/apache/doris/analysis/DateLiteral.java
+++ b/fe/src/main/java/org/apache/doris/analysis/DateLiteral.java
@@ -17,15 +17,6 @@
 
 package org.apache.doris.analysis;
 
-import java.io.DataInput;
-import java.io.DataOutput;
-import java.io.IOException;
-import java.nio.ByteBuffer;
-import java.util.Date;
-import java.util.Objects;
-import java.util.TimeZone;
-import java.util.regex.Pattern;
-
 import org.apache.doris.catalog.Catalog;
 import org.apache.doris.catalog.PrimitiveType;
 import org.apache.doris.catalog.Type;
@@ -35,6 +26,9 @@ import org.apache.doris.common.util.TimeUtils;
 import org.apache.doris.thrift.TDateLiteral;
 import org.apache.doris.thrift.TExprNode;
 import org.apache.doris.thrift.TExprNodeType;
+
+import com.google.common.base.Preconditions;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.joda.time.DateTime;
@@ -43,7 +37,14 @@ import org.joda.time.LocalDateTime;
 import org.joda.time.format.DateTimeFormatter;
 import org.joda.time.format.DateTimeFormatterBuilder;
 
-import com.google.common.base.Preconditions;
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Date;
+import java.util.Objects;
+import java.util.TimeZone;
+import java.util.regex.Pattern;
 
 public class DateLiteral extends LiteralExpr {
     private static final Logger LOG = LogManager.getLogger(DateLiteral.class);
@@ -131,7 +132,7 @@ public class DateLiteral extends LiteralExpr {
         hour = dt.getHourOfDay();
         minute = dt.getMinuteOfHour();
         second = dt.getSecondOfMinute();
-        if (type == Type.DATE) {
+        if (type.equals(Type.DATE)) {
             hour = 0;
             minute = 0;
             second = 0;
@@ -191,7 +192,7 @@ public class DateLiteral extends LiteralExpr {
         try {
             Preconditions.checkArgument(type.isDateType());
             LocalDateTime dateTime;
-            if (type == Type.DATE) {
+            if (type.equals(Type.DATE)) {
                 if (s.split("-")[0].length() == 2) {
                     dateTime = DATE_FORMATTER_TWO_DIGIT.parseLocalDateTime(s);
                 } else {
@@ -247,9 +248,9 @@ public class DateLiteral extends LiteralExpr {
 
     @Override
     public Object getRealValue() {
-        if (type == Type.DATE) {
+        if (type.equals(Type.DATE)) {
             return year * 16 * 32L + month * 32 + day;
-        } else if (type == Type.DATETIME) {
+        } else if (type.equals(Type.DATETIME)) {
             return (year * 10000 + month * 100 + day) * 1000000L + hour * 10000 + minute * 100 + second;
         } else {
             Preconditions.checkState(false, "invalid date type: " + type);
@@ -355,9 +356,9 @@ public class DateLiteral extends LiteralExpr {
     public void write(DataOutput out) throws IOException {
         super.write(out);
         //set flag bit in meta, 0 is DATETIME and 1 is DATE
-        if (this.type == Type.DATETIME) {
+        if (this.type.equals(Type.DATETIME)) {
             out.writeShort(DateLiteralType.DATETIME.value());
-        } else if (this.type == Type.DATE) {
+        } else if (this.type.equals(Type.DATE)) {
             out.writeShort(DateLiteralType.DATE.value());
         } else {
             throw new IOException("Error date literal type : " + type);
@@ -439,7 +440,7 @@ public class DateLiteral extends LiteralExpr {
     //Return the date stored in the dateliteral as pattern format.
     //eg : "%Y-%m-%d" or "%Y-%m-%d %H:%i:%s"
     public String dateFormat(String pattern) throws AnalysisException {
-        if (type == Type.DATE) {
+        if (type.equals(Type.DATE)) {
             return DATE_FORMATTER.parseLocalDateTime(getStringValue())
                     .toString(formatBuilder(pattern).toFormatter());
         } else {
@@ -559,9 +560,9 @@ public class DateLiteral extends LiteralExpr {
     }
 
     public LocalDateTime getTimeFormatter() throws AnalysisException {
-        if (type == Type.DATE) {
+        if (type.equals(Type.DATE)) {
             return DATE_FORMATTER.parseLocalDateTime(getStringValue());                        
-        } else if (type == Type.DATETIME) {
+        } else if (type.equals(Type.DATETIME)) {
             return DATE_TIME_FORMATTER.parseLocalDateTime(getStringValue());
         } else {
             throw new AnalysisException("Not support date literal type");

--- a/fe/src/main/java/org/apache/doris/analysis/DateLiteral.java
+++ b/fe/src/main/java/org/apache/doris/analysis/DateLiteral.java
@@ -102,7 +102,7 @@ public class DateLiteral extends LiteralExpr {
     public DateLiteral(Type type, boolean isMax) throws AnalysisException {
         super();
         this.type = type;
-        if (type == Type.DATE) {
+        if (type.equals(Type.DATE)) {
             if (isMax) {
                 copy(MAX_DATE);
             } else {

--- a/fe/src/main/java/org/apache/doris/analysis/Expr.java
+++ b/fe/src/main/java/org/apache/doris/analysis/Expr.java
@@ -1441,7 +1441,7 @@ abstract public class Expr extends TreeNode<Expr> implements ParseNode, Cloneabl
      * Negates a boolean Expr.
      */
     public Expr negate() {
-        Preconditions.checkState(type == Type.BOOLEAN);
+        Preconditions.checkState(type.equals(Type.BOOLEAN));
         return new CompoundPredicate(CompoundPredicate.Operator.NOT, this, null);
     }
 

--- a/fe/src/main/java/org/apache/doris/analysis/InPredicate.java
+++ b/fe/src/main/java/org/apache/doris/analysis/InPredicate.java
@@ -147,7 +147,7 @@ public class InPredicate extends Predicate {
 //       OpcodeRegistry.BuiltinFunction match = OpcodeRegistry.instance().getFunctionInfo(
 //               FunctionOperator.FILTER_IN, true, true, type);
 //       Preconditions.checkState(match != null);
-//       Preconditions.checkState(match.getReturnType() == Type.BOOLEAN);
+//       Preconditions.checkState(match.getReturnType().equals(Type.BOOLEAN));
 //       this.vectorOpcode = match.opcode;
 //       LOG.info(debugString() + " opcode: " + vectorOpcode);
    }

--- a/fe/src/main/java/org/apache/doris/analysis/LargeIntLiteral.java
+++ b/fe/src/main/java/org/apache/doris/analysis/LargeIntLiteral.java
@@ -17,15 +17,6 @@
 
 package org.apache.doris.analysis;
 
-import java.io.DataInput;
-import java.io.DataOutput;
-import java.io.IOException;
-import java.math.BigDecimal;
-import java.math.BigInteger;
-import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
-import java.util.Objects;
-
 import org.apache.doris.catalog.PrimitiveType;
 import org.apache.doris.catalog.Type;
 import org.apache.doris.common.AnalysisException;
@@ -34,8 +25,18 @@ import org.apache.doris.common.io.Text;
 import org.apache.doris.thrift.TExprNode;
 import org.apache.doris.thrift.TExprNodeType;
 import org.apache.doris.thrift.TLargeIntLiteral;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.Objects;
 
 // large int for the num that native types can not
 public class LargeIntLiteral extends LiteralExpr {
@@ -149,7 +150,7 @@ public class LargeIntLiteral extends LiteralExpr {
         if (expr == MaxLiteral.MAX_VALUE) {
             return -1;
         }
-        if (expr.type == Type.LARGEINT) {
+        if (expr.type.equals(Type.LARGEINT)) {
             return value.compareTo(((LargeIntLiteral) expr).value);
         } else {
             BigInteger intValue = new BigInteger(((IntLiteral) expr).getStringValue());

--- a/fe/src/main/java/org/apache/doris/analysis/SlotRef.java
+++ b/fe/src/main/java/org/apache/doris/analysis/SlotRef.java
@@ -72,7 +72,7 @@ public class SlotRef extends Expr {
         this.type = desc.getType();
         // TODO(zc): label is meaningful
         this.label = null;
-        if (this.type == Type.CHAR) {
+        if (this.type.equals(Type.CHAR)) {
             this.type = Type.VARCHAR;
         }
         analysisDone();
@@ -124,7 +124,7 @@ public class SlotRef extends Expr {
     public void analyzeImpl(Analyzer analyzer) throws AnalysisException {
         desc = analyzer.registerColumnRef(tblName, col);
         type = desc.getType();
-        if (this.type == Type.CHAR) {
+        if (this.type.equals(Type.CHAR)) {
             this.type = Type.VARCHAR;
         }
         if (!type.isSupported()) {
@@ -132,7 +132,7 @@ public class SlotRef extends Expr {
                     "Unsupported type '" + type.toString() + "' in '" + toSql() + "'.");
         }
         numDistinctValues = desc.getStats().getNumDistinctValues();
-        if (type == Type.BOOLEAN) {
+        if (type.equals(Type.BOOLEAN)) {
             selectivity = DEFAULT_SELECTIVITY;
         }
     }

--- a/fe/src/main/java/org/apache/doris/catalog/FunctionSet.java
+++ b/fe/src/main/java/org/apache/doris/catalog/FunctionSet.java
@@ -860,7 +860,7 @@ public class FunctionSet {
                     null, false, true, true));
 
             // count in multi distinct
-            if (t == Type.CHAR || t == Type.VARCHAR) {
+            if (t.equals(Type.CHAR) || t.equals(Type.VARCHAR)) {
                addBuiltin(AggregateFunction.createBuiltin("multi_distinct_count", Lists.newArrayList(t),
                     Type.BIGINT,
                     Type.VARCHAR,
@@ -872,8 +872,8 @@ public class FunctionSet {
                     null,
                     prefix + "30count_distinct_string_finalizeEPN9doris_udf15FunctionContextERKNS1_9StringValE",
                     false, true, true));
-            } else if (t == Type.TINYINT || t == Type.SMALLINT || t == Type.INT
-                || t == Type.BIGINT || t == Type.LARGEINT || t == Type.DOUBLE) {
+            } else if (t.equals(Type.TINYINT) || t.equals(Type.SMALLINT) || t.equals(Type.INT)
+                    || t.equals(Type.BIGINT) || t.equals(Type.LARGEINT) || t.equals(Type.DOUBLE)) {
                addBuiltin(AggregateFunction.createBuiltin("multi_distinct_count", Lists.newArrayList(t),
                     Type.BIGINT,
                     Type.VARCHAR,
@@ -885,7 +885,7 @@ public class FunctionSet {
                     null,
                     prefix + MULTI_DISTINCT_COUNT_FINALIZE_SYMBOL.get(t),
                     false, true, true));
-            } else if (t == Type.DATE || t == Type.DATETIME) {
+            } else if (t.equals(Type.DATE) || t.equals(Type.DATETIME)) {
                addBuiltin(AggregateFunction.createBuiltin("multi_distinct_count", Lists.newArrayList(t),
                     Type.BIGINT,
                     Type.VARCHAR,
@@ -897,7 +897,7 @@ public class FunctionSet {
                     null,
                     prefix + "28count_distinct_date_finalizeEPN9doris_udf15FunctionContextERKNS1_9StringValE",
                     false, true, true));
-            } else if (t == Type.DECIMAL) {
+            } else if (t.equals(Type.DECIMAL)) {
                addBuiltin(AggregateFunction.createBuiltin("multi_distinct_count", Lists.newArrayList(t),
                     Type.BIGINT,
                     Type.VARCHAR,
@@ -909,7 +909,7 @@ public class FunctionSet {
                     null,
                     prefix + "31count_distinct_decimal_finalizeEPN9doris_udf15FunctionContextERKNS1_9StringValE",
                     false, true, true));
-            } else if (t == Type.DECIMALV2) {
+            } else if (t.equals(Type.DECIMALV2)) {
                addBuiltin(AggregateFunction.createBuiltin("multi_distinct_count", Lists.newArrayList(t),
                     Type.BIGINT,
                     Type.VARCHAR,
@@ -924,7 +924,7 @@ public class FunctionSet {
             }
 
             // sum in multi distinct
-            if (t == Type.BIGINT || t == Type.LARGEINT || t == Type.DOUBLE) {
+            if (t.equals(Type.BIGINT) || t.equals(Type.LARGEINT) || t.equals(Type.DOUBLE)) {
                 addBuiltin(AggregateFunction.createBuiltin("multi_distinct_sum", Lists.newArrayList(t),
                     t,
                     Type.VARCHAR,
@@ -936,7 +936,7 @@ public class FunctionSet {
                     null,
                     prefix + MULTI_DISTINCT_SUM_FINALIZE_SYMBOL.get(t),
                     false, true, true));
-            }  else if (t == Type.DECIMAL) {
+            } else if (t.equals(Type.DECIMAL)) {
                addBuiltin(AggregateFunction.createBuiltin("multi_distinct_sum", Lists.newArrayList(t),
                     MULTI_DISTINCT_SUM_RETURN_TYPE.get(t),
                     Type.VARCHAR,
@@ -948,7 +948,7 @@ public class FunctionSet {
                     null,
                     prefix + "29sum_distinct_decimal_finalizeEPN9doris_udf15FunctionContextERKNS1_9StringValE",
                     false, true, true));
-            }  else if (t == Type.DECIMALV2) {
+            } else if (t.equals(Type.DECIMALV2)) {
                addBuiltin(AggregateFunction.createBuiltin("multi_distinct_sum", Lists.newArrayList(t),
                     MULTI_DISTINCT_SUM_RETURN_TYPE.get(t),
                     Type.VARCHAR,
@@ -1302,16 +1302,16 @@ public class FunctionSet {
                     t.isStringType() ? initNullString : initNull,
                     prefix + FIRST_VALUE_UPDATE_SYMBOL.get(t),
                     null,
-                    t == Type.VARCHAR ? stringValGetValue : null,
-                    t == Type.VARCHAR ? stringValSerializeOrFinalize : null));
+                    t.equals(Type.VARCHAR) ? stringValGetValue : null,
+                    t.equals(Type.VARCHAR) ? stringValSerializeOrFinalize : null));
             // Implements FIRST_VALUE for some windows that require rewrites during planning.
             addBuiltin(AggregateFunction.createAnalyticBuiltin(
                     "first_value_rewrite", Lists.newArrayList(t, Type.BIGINT), t, t,
                     t.isStringType() ? initNullString : initNull,
                     prefix + FIRST_VALUE_REWRITE_UPDATE_SYMBOL.get(t),
                     null,
-                    t == Type.VARCHAR ? stringValGetValue : null,
-                    t == Type.VARCHAR ? stringValSerializeOrFinalize : null,
+                    t.equals(Type.VARCHAR) ? stringValGetValue : null,
+                    t.equals(Type.VARCHAR) ? stringValSerializeOrFinalize : null,
                     false));
 
             addBuiltin(AggregateFunction.createAnalyticBuiltin(
@@ -1319,8 +1319,8 @@ public class FunctionSet {
                     t.isStringType() ? initNullString : initNull,
                     prefix + LAST_VALUE_UPDATE_SYMBOL.get(t),
                     prefix + LAST_VALUE_REMOVE_SYMBOL.get(t),
-                    t == Type.VARCHAR ? stringValGetValue : null,
-                    t == Type.VARCHAR ? stringValSerializeOrFinalize : null));
+                    t.equals(Type.VARCHAR) ? stringValGetValue : null,
+                    t.equals(Type.VARCHAR) ? stringValSerializeOrFinalize : null));
 
             addBuiltin(AggregateFunction.createAnalyticBuiltin(
                     "lag", Lists.newArrayList(t, Type.BIGINT, t), t, t,

--- a/fe/src/main/java/org/apache/doris/mysql/MysqlChannel.java
+++ b/fe/src/main/java/org/apache/doris/mysql/MysqlChannel.java
@@ -82,7 +82,7 @@ public class MysqlChannel {
                     remoteIp = channel.getRemoteAddress().toString();
                 }
             } catch (Exception e) {
-                  LOG.warn("get remote host string failed: " + e.toString());
+                LOG.warn("get remote host string failed: ", e);
             }
         }
     }

--- a/fe/src/main/java/org/apache/doris/planner/PlanNode.java
+++ b/fe/src/main/java/org/apache/doris/planner/PlanNode.java
@@ -300,8 +300,7 @@ abstract public class PlanNode extends TreeNode<PlanNode> {
      * The root node header line will be prefixed by rootPrefix and the remaining plan
      * output will be prefixed by prefix.
      */
-    protected final String getExplainString(String rootPrefix, String prefix,
-      TExplainLevel detailLevel) {
+    protected final String getExplainString(String rootPrefix, String prefix, TExplainLevel detailLevel) {
         StringBuilder expBuilder = new StringBuilder();
         String detailPrefix = prefix;
         boolean traverseChildren = children != null

--- a/fe/src/test/java/org/apache/doris/plugin/PluginMgrTest.java
+++ b/fe/src/test/java/org/apache/doris/plugin/PluginMgrTest.java
@@ -70,6 +70,7 @@ public class PluginMgrTest {
     @Test
     public void testInstallPluginZip() {
         try {
+            // path "target/audit_plugin_demo" is where we are going to install the plugin
             assertFalse(Files.exists(PluginTestUtil.getTestPath("target/audit_plugin_demo")));
             assertFalse(Files.exists(PluginTestUtil.getTestPath("target/audit_plugin_demo/auditdemo.jar")));
 
@@ -112,20 +113,17 @@ public class PluginMgrTest {
     @Test
     public void testInstallPluginLocal() {
         try {
+            // path "target/audit_plugin_demo" is where we are going to install the plugin
             assertFalse(Files.exists(PluginTestUtil.getTestPath("target/audit_plugin_demo")));
             assertFalse(Files.exists(PluginTestUtil.getTestPath("target/audit_plugin_demo/auditdemo.jar")));
-            assertFalse(Files.exists(PluginTestUtil.getTestPath("test_plugin")));
 
-            FileUtils.copyDirectory(PluginTestUtil.getTestPath("test_local_plugin").toFile(),
-                    PluginTestUtil.getTestPath("test_plugin").toFile());
-
-            InstallPluginStmt stmt = new InstallPluginStmt(PluginTestUtil.getTestPathString("test_plugin"));
+            InstallPluginStmt stmt = new InstallPluginStmt(PluginTestUtil.getTestPathString("test_local_plugin"));
             Catalog.getCurrentCatalog().installPlugin(stmt);
 
             PluginMgr pluginMgr = Catalog.getCurrentPluginMgr();
 
-            assertFalse(Files.exists(PluginTestUtil.getTestPath("test_plugin")));
-            assertFalse(Files.exists(PluginTestUtil.getTestPath("test_plugin/auditdemo.jar")));
+            assertTrue(Files.exists(PluginTestUtil.getTestPath("test_local_plugin")));
+            assertTrue(Files.exists(PluginTestUtil.getTestPath("test_local_plugin/auditdemo.jar")));
 
             Plugin p = pluginMgr.getActivePlugin("audit_plugin_demo", PluginInfo.PluginType.AUDIT);
 

--- a/fe/src/test/java/org/apache/doris/qe/ConnectSchedulerTest.java
+++ b/fe/src/test/java/org/apache/doris/qe/ConnectSchedulerTest.java
@@ -17,9 +17,6 @@
 
 package org.apache.doris.qe;
 
-import mockit.Delegate;
-import mockit.Expectations;
-import mockit.Mocked;
 import org.apache.doris.analysis.AccessTestUtil;
 import org.apache.doris.mysql.MysqlChannel;
 import org.apache.doris.mysql.MysqlProto;
@@ -32,6 +29,10 @@ import org.slf4j.LoggerFactory;
 
 import java.nio.channels.SocketChannel;
 import java.util.concurrent.atomic.AtomicLong;
+
+import mockit.Delegate;
+import mockit.Expectations;
+import mockit.Mocked;
 
 public class ConnectSchedulerTest {
     private static final Logger LOG = LoggerFactory.getLogger(ConnectScheduler.class);

--- a/fe/src/test/java/org/apache/doris/utframe/MockedBackendFactory.java
+++ b/fe/src/test/java/org/apache/doris/utframe/MockedBackendFactory.java
@@ -166,7 +166,7 @@ public class MockedBackendFactory {
                         try {
                             TAgentTaskRequest request = taskQueue.take();
                             System.out.println("get agent task request. type: " + request.getTask_type()
-                                    + ", signature: " + request.getSignature());
+                                    + ", signature: " + request.getSignature() + ", fe addr: " + backend.getFeAddress());
                             TFinishTaskRequest finishTaskRequest = new TFinishTaskRequest(tBackend,
                                     request.getTask_type(), request.getSignature(), new TStatus(TStatusCode.OK));
                             finishTaskRequest.setReport_version(++reportVersion);


### PR DESCRIPTION
I don't why, but I found that sometimes when I use "==" to judge the equality of type,
it return false, even if the types are exactly same.

ISSUE: #3309 

This CL only changes `==` to `equals()` to solve the problem, but the reason is still unknown.