### PR TITLE
(#3319) support java version hyperloglog

### DIFF
--- a/be/test/olap/hll_test.cpp
+++ b/be/test/olap/hll_test.cpp
@@ -32,7 +32,7 @@ public:
 static uint64_t hash(uint64_t value) {
     return HashUtil::murmur_hash64A(&value, 8, 0);
 }
-
+//  keep logic same with java version in fe when you change hll_test.cpp,see HllTest.java
 TEST_F(TestHll, Normal) {
     uint8_t buf[HLL_REGISTERS_COUNT + 1];
 

--- a/fe/src/main/java/org/apache/doris/load/loadv2/Hll.java
+++ b/fe/src/main/java/org/apache/doris/load/loadv2/Hll.java
@@ -1,0 +1,400 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.load.loadv2;
+
+import org.apache.commons.codec.binary.StringUtils;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import java.math.BigInteger;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ *  mainly used for Spark Load process to produce hll
+ *  Try to keep consistent with be's C++ hll
+ *  Whether method estimateCardinality can keep consistent with is a question to be studied
+ *
+ * use example:
+ *  Hll hll = new hll();
+ *  Hll.updateWithHash(value);
+ *
+ */
+public class Hll {
+
+    public static final byte HLL_DATA_EMPTY = 0;
+    public static final byte HLL_DATA_EXPLICIT = 1;
+    public static final byte HLL_DATA_SPARSE = 2;
+    public static final byte HLL_DATA_FULL = 3;
+
+    public static final int HLL_COLUMN_PRECISION = 14;
+    public static final int HLL_ZERO_COUNT_BITS = (64 - HLL_COLUMN_PRECISION);
+    public static final int HLL_EXPLICLIT_INT64_NUM = 160;
+    public static final int HLL_SPARSE_THRESHOLD = 4096;
+    public static final int HLL_REGISTERS_COUNT = 16 * 1024;
+
+    private int type;
+    private Set<Long> hashSet;
+    private byte[] registers;
+
+    public Hll() {
+        this.hashSet = new HashSet<>();
+        this.type = HLL_DATA_EMPTY;
+        this.registers = new byte[HLL_REGISTERS_COUNT];
+    }
+
+    private void convertExplicitToRegister() {
+        assert this.type == HLL_DATA_EXPLICIT;
+        registers = new byte[HLL_REGISTERS_COUNT];
+        for (Long value : hashSet) {
+            updateRegisters(value);
+        }
+        hashSet.clear();
+    }
+
+    private void updateRegisters(long hashValue) {
+        int idx;
+        // hash value less than zero means we get a unsigned long
+        // so need to transfer to BigInter to mod
+        if (hashValue < 0) {
+            BigInteger unint64HashValue = new BigInteger(Long.toUnsignedString(hashValue));
+            unint64HashValue = unint64HashValue.mod(new BigInteger(Long.toUnsignedString(HLL_REGISTERS_COUNT)));
+            idx = unint64HashValue.intValue();
+        } else {
+            idx = (int) (hashValue % HLL_REGISTERS_COUNT);
+        }
+
+        hashValue >>>= HLL_COLUMN_PRECISION;
+        hashValue |= (1l << HLL_ZERO_COUNT_BITS);
+        byte firstOneBit = (byte) (getLongTailZeroNum(hashValue) + 1);
+        registers[idx] = registers[idx] > firstOneBit ? registers[idx] : firstOneBit ;
+    }
+
+    private void mergeRegisters(byte[] other) {
+        for (int i = 0; i < HLL_REGISTERS_COUNT; i++) {
+            this.registers[i] = this.registers[i] > other[i] ? this.registers[i] : other[i];
+        }
+    }
+
+    public static byte getLongTailZeroNum(long hashValue) {
+        if (hashValue == 0) {
+            return 0;
+        }
+        long value = 1l;
+        byte idx = 0;
+        for (;; idx++) {
+            if ((value & hashValue) != 0) {
+                return idx;
+            }
+            value = value << 1;
+            if (idx == 62) {
+                break;
+            }
+        }
+        return idx;
+    }
+
+    public void updateWithHash(Object value) {
+        byte[] v = StringUtils.getBytesUtf8(String.valueOf(value));
+        update(hash64(v, v.length, SEED));
+    }
+
+    public void update(long hashValue) {
+        switch (this.type) {
+            case HLL_DATA_EMPTY:
+                hashSet.add(hashValue);
+                type = HLL_DATA_EXPLICIT;
+                break;
+            case HLL_DATA_EXPLICIT:
+                if (hashSet.size() < HLL_EXPLICLIT_INT64_NUM) {
+                    hashSet.add(hashValue);
+                    break;
+                }
+                convertExplicitToRegister();
+                type = HLL_DATA_FULL;
+                break;
+            case HLL_DATA_SPARSE:
+            case HLL_DATA_FULL:
+                updateRegisters(hashValue);
+                break;
+        }
+    }
+
+    public void merge(Hll other) {
+        if (other.type == HLL_DATA_EMPTY) {
+            return;
+        }
+        switch (this.type) {
+            case HLL_DATA_EMPTY:
+                this.type = other.type;
+                switch (other.type) {
+                    case HLL_DATA_EXPLICIT:
+                        this.hashSet = other.hashSet;
+                        break;
+                    case HLL_DATA_SPARSE:
+                    case HLL_DATA_FULL:
+                        this.registers = new byte[HLL_REGISTERS_COUNT];
+                        System.arraycopy(other.registers, 0, this.registers, 0, HLL_REGISTERS_COUNT);
+                        break;
+                }
+                break;
+            case HLL_DATA_EXPLICIT:
+                switch (other.type) {
+                    case HLL_DATA_EXPLICIT:
+                        this.hashSet.addAll(other.hashSet);
+                        this.type = HLL_DATA_EXPLICIT;
+                        if (this.hashSet.size() > HLL_EXPLICLIT_INT64_NUM) {
+                            convertExplicitToRegister();
+                            this.type = HLL_DATA_FULL;
+                        }
+                        break;
+                    case HLL_DATA_SPARSE:
+                    case HLL_DATA_FULL:
+                        convertExplicitToRegister();
+                        mergeRegisters(other.registers);
+                        this.type = HLL_DATA_FULL;
+                        break;
+                }
+                break;
+            case HLL_DATA_SPARSE:
+            case HLL_DATA_FULL:
+                switch (other.type) {
+                    case HLL_DATA_EXPLICIT:
+                        for (long value : other.hashSet) {
+                            update(value);
+                        }
+                        break;
+                    case HLL_DATA_SPARSE:
+                    case HLL_DATA_FULL:
+                        mergeRegisters(other.registers);
+                        break;
+                }
+                break;
+        }
+    }
+
+    public void serialize(DataOutput output) throws IOException {
+        switch (type) {
+            case HLL_DATA_EMPTY:
+                output.writeByte(type);
+                break;
+            case HLL_DATA_EXPLICIT:
+                output.writeByte(type);
+                output.writeByte(hashSet.size());
+                for (long value : hashSet) {
+                    output.writeLong(value);
+                }
+                break;
+            case HLL_DATA_SPARSE:
+            case HLL_DATA_FULL:
+                int nonZeroRegisterNum = 0;
+                for (int i = 0; i < HLL_REGISTERS_COUNT; i++) {
+                    if (registers[i] != 0) {
+                        nonZeroRegisterNum++;
+                    }
+                }
+                if (nonZeroRegisterNum > HLL_SPARSE_THRESHOLD) {
+                    output.writeByte(HLL_DATA_FULL);
+                    for (byte value : registers) {
+                        output.writeByte(value);
+                    }
+                } else {
+                    output.writeByte(HLL_DATA_SPARSE);
+                    output.writeInt(nonZeroRegisterNum);
+                    for (int i = 0; i < HLL_REGISTERS_COUNT; i++) {
+                        if (registers[i] != 0) {
+                            output.writeShort(i);
+                            output.writeByte(registers[i]);
+                        }
+                    }
+                }
+                break;
+        }
+    }
+
+    public boolean deserialize(DataInput input) throws IOException {
+        assert type == HLL_DATA_EMPTY;
+
+        if (input == null) {
+            return false;
+        }
+
+        this.type = input.readByte();
+        switch (this.type) {
+            case HLL_DATA_EMPTY:
+                break;
+            case HLL_DATA_EXPLICIT:
+                int hashSetSize = input.readUnsignedByte();
+                for (int i = 0; i < hashSetSize; i++) {
+                    update(input.readLong());
+                }
+                assert this.type == HLL_DATA_EXPLICIT;
+                break;
+            case HLL_DATA_SPARSE:
+                int sparseDataSize = input.readInt();
+                this.registers = new byte[HLL_REGISTERS_COUNT];
+                for (int i = 0; i < sparseDataSize; i++) {
+                    int idx = input.readShort();
+                    byte value = input.readByte();
+                    registers[idx] = value;
+                }
+                break;
+            case HLL_DATA_FULL:
+                for (int i = 0; i < HLL_REGISTERS_COUNT; i++) {
+                    registers[i] = input.readByte();
+                }
+                break;
+            default:
+                return false;
+        }
+
+        return true;
+    }
+
+    // use strictfp to force java follow IEEE 754 to deal float point strictly
+    // This method can not keep consistent with C++ implement completely
+    // Though C++ follow IEEE 754 to deal with float-point , but OS architecture,compile option may affect the real calculation.
+    public strictfp long estimateCardinality() {
+        if (type == HLL_DATA_EMPTY) {
+            return 0;
+        }
+        if (type == HLL_DATA_EXPLICIT) {
+            return hashSet.size();
+        }
+
+        int numStreams = HLL_REGISTERS_COUNT;
+        float alpha = 0;
+
+        if (numStreams == 16) {
+            alpha = 0.673f;
+        } else if (numStreams == 32) {
+            alpha = 0.697f;
+        } else if (numStreams == 64) {
+            alpha = 0.709f;
+        } else {
+            alpha = 0.7213f / (1 + 1.079f / numStreams);
+        }
+
+        float harmonicMean = 0;
+        int numZeroRegisters = 0;
+
+        for (int i = 0; i < HLL_REGISTERS_COUNT; i++) {
+            harmonicMean += Math.pow(2.0f, -registers[i]);
+
+            if (registers[i] == 0) {
+                numZeroRegisters++;
+            }
+        }
+
+        harmonicMean = 1.0f / harmonicMean;
+        double estimate = alpha * numStreams * numStreams * harmonicMean;
+
+        if (estimate <= numStreams * 2.5 && numZeroRegisters != 0) {
+            estimate = numStreams * Math.log(((float)numStreams) / ((float)numZeroRegisters));
+        } else if (numStreams == 16384 && estimate < 72000) {
+            double bias = 5.9119 * 1.0e-18 * (estimate * estimate * estimate * estimate)
+                    - 1.4253 * 1.0e-12 * (estimate * estimate * estimate) +
+                    1.2940 * 1.0e-7 * (estimate * estimate)
+                    - 5.2921 * 1.0e-3 * estimate +
+                    83.3216;
+            estimate -= estimate * (bias / 100);
+        }
+
+        return (long)(estimate + 0.5);
+    }
+
+    public int maxSerializedSize () {
+        switch (type) {
+            case HLL_DATA_EMPTY:
+            default:
+                return 1;
+            case HLL_DATA_EXPLICIT:
+                return 2 + hashSet.size() * 8;
+            case HLL_DATA_SPARSE:
+            case HLL_DATA_FULL:
+                return 1 + HLL_REGISTERS_COUNT;
+        }
+    }
+
+    public static final long M64 = 0xc6a4a7935bd1e995L;
+    public static final int R64 = 47;
+    public static final int SEED = 0xadc83b19;
+
+
+    private static long getLittleEndianLong(final byte[] data, final int index) {
+        return (((long) data[index    ] & 0xff)      ) |
+                (((long) data[index + 1] & 0xff) <<  8) |
+                (((long) data[index + 2] & 0xff) << 16) |
+                (((long) data[index + 3] & 0xff) << 24) |
+                (((long) data[index + 4] & 0xff) << 32) |
+                (((long) data[index + 5] & 0xff) << 40) |
+                (((long) data[index + 6] & 0xff) << 48) |
+                (((long) data[index + 7] & 0xff) << 56);
+    }
+
+    public static long hash64(final byte[] data, final int length, final int seed) {
+        long h = (seed & 0xffffffffL) ^ (length * M64);
+        final int nblocks = length >> 3;
+
+        // body
+        for (int i = 0; i < nblocks; i++) {
+            final int index = (i << 3);
+            long k = getLittleEndianLong(data, index);
+
+            k *= M64;
+            k ^= k >>> R64;
+            k *= M64;
+
+            h ^= k;
+            h *= M64;
+        }
+
+        final int index = (nblocks << 3);
+        switch (length - index) {
+            case 7:
+                h ^= ((long) data[index + 6] & 0xff) << 48;
+            case 6:
+                h ^= ((long) data[index + 5] & 0xff) << 40;
+            case 5:
+                h ^= ((long) data[index + 4] & 0xff) << 32;
+            case 4:
+                h ^= ((long) data[index + 3] & 0xff) << 24;
+            case 3:
+                h ^= ((long) data[index + 2] & 0xff) << 16;
+            case 2:
+                h ^= ((long) data[index + 1] & 0xff) << 8;
+            case 1:
+                h ^= ((long) data[index] & 0xff);
+                h *= M64;
+        }
+
+        h ^= h >>> R64;
+        h *= M64;
+        h ^= h >>> R64;
+
+        return h;
+    }
+
+    // just for ut
+    public int getType() {
+        return type;
+    }
+
+
+}

--- a/fe/src/test/java/org/apache/doris/load/loadv2/HllTest.java
+++ b/fe/src/test/java/org/apache/doris/load/loadv2/HllTest.java
@@ -1,0 +1,169 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.load.loadv2;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutput;
+import java.io.DataOutputStream;
+import java.io.IOException;
+
+import static org.apache.doris.load.loadv2.Hll.*;
+
+public class HllTest {
+
+    @Test
+    public void testFindFirstNonZeroBitPosition() {
+        Assert.assertTrue(getLongTailZeroNum(0) == 0);
+        Assert.assertTrue(getLongTailZeroNum(1) == 0);
+        Assert.assertTrue(getLongTailZeroNum(1l << 30) == 30);
+        Assert.assertTrue(getLongTailZeroNum(1l << 62) == 62);
+    }
+
+    @Test
+    public void HllBasicTest() throws IOException {
+        // test empty
+        Hll emptyHll = new Hll();
+
+        Assert.assertTrue(emptyHll.getType() == HLL_DATA_EMPTY);
+        Assert.assertTrue(emptyHll.estimateCardinality() == 0);
+
+        ByteArrayOutputStream emptyOutputStream = new ByteArrayOutputStream();
+        DataOutput output = new DataOutputStream(emptyOutputStream);
+        emptyHll.serialize(output);
+        DataInputStream emptyInputStream = new DataInputStream(new ByteArrayInputStream(emptyOutputStream.toByteArray()));
+        Hll deserializedEmptyHll = new Hll();
+        deserializedEmptyHll.deserialize(emptyInputStream);
+        Assert.assertTrue(deserializedEmptyHll.getType() == HLL_DATA_EMPTY);
+
+        // test explicit
+        Hll explicitHll = new Hll();
+        for (int i = 0; i < HLL_EXPLICLIT_INT64_NUM; i++) {
+            explicitHll.updateWithHash(i);
+        }
+        Assert.assertTrue(explicitHll.getType() == HLL_DATA_EXPLICIT);
+        Assert.assertTrue(explicitHll.estimateCardinality() == HLL_EXPLICLIT_INT64_NUM);
+
+        ByteArrayOutputStream explicitOutputStream = new ByteArrayOutputStream();
+        DataOutput explicitOutput = new DataOutputStream(explicitOutputStream);
+        explicitHll.serialize(explicitOutput);
+        DataInputStream explicitInputStream = new DataInputStream(new ByteArrayInputStream(explicitOutputStream.toByteArray()));
+        Hll deserializedExplicitHll = new Hll();
+        deserializedExplicitHll.deserialize(explicitInputStream);
+        Assert.assertTrue(deserializedExplicitHll.getType() == HLL_DATA_EXPLICIT);
+
+        // test sparse
+        Hll sparseHll = new Hll();
+        for (int i = 0; i < HLL_SPARSE_THRESHOLD; i++) {
+            sparseHll.updateWithHash(i);
+        }
+        Assert.assertTrue(sparseHll.getType() == HLL_DATA_FULL);
+        // 2% error rate
+        Assert.assertTrue(sparseHll.estimateCardinality() > HLL_SPARSE_THRESHOLD * (1 - 0.02) &&
+                sparseHll.estimateCardinality() < HLL_SPARSE_THRESHOLD * (1 + 0.02));
+
+        ByteArrayOutputStream sparseOutputStream = new ByteArrayOutputStream();
+        DataOutput sparseOutput = new DataOutputStream(sparseOutputStream);
+        sparseHll.serialize(sparseOutput);
+        DataInputStream sparseInputStream = new DataInputStream(new ByteArrayInputStream(sparseOutputStream.toByteArray()));
+        Hll deserializedSparseHll = new Hll();
+        deserializedSparseHll.deserialize(sparseInputStream);
+        Assert.assertTrue(deserializedSparseHll.getType() == HLL_DATA_SPARSE);
+        Assert.assertTrue(sparseHll.estimateCardinality() == deserializedSparseHll.estimateCardinality());
+
+
+        // test full
+        Hll fullHll = new Hll();
+        for (int i = 1; i <= Short.MAX_VALUE; i++) {
+            fullHll.updateWithHash(i);
+        }
+        Assert.assertTrue(fullHll.getType() == HLL_DATA_FULL);
+        // the result 32748 is consistent with C++ 's implementation
+        Assert.assertTrue(fullHll.estimateCardinality() == 32748);
+        // 2% error rate
+        Assert.assertTrue(fullHll.estimateCardinality() > Short.MAX_VALUE * (1 - 0.02) &&
+                fullHll.estimateCardinality() < Short.MAX_VALUE * (1 + 0.02));
+
+        ByteArrayOutputStream fullHllOutputStream = new ByteArrayOutputStream();
+        DataOutput fullHllOutput = new DataOutputStream(fullHllOutputStream);
+        fullHll.serialize(fullHllOutput);
+        DataInputStream fullHllInputStream = new DataInputStream(new ByteArrayInputStream(fullHllOutputStream.toByteArray()));
+        Hll deserializedFullHll = new Hll();
+        deserializedFullHll.deserialize(fullHllInputStream);
+        Assert.assertTrue(deserializedFullHll.getType() == HLL_DATA_FULL);
+        Assert.assertTrue(deserializedFullHll.estimateCardinality() == fullHll.estimateCardinality());
+
+    }
+
+    @Test
+    public void testMerge() {
+        Hll emptyHll = new Hll();
+
+        Hll explicitHll = new Hll();
+        for (int i = 0 ;i < 100; i++) {
+            explicitHll.updateWithHash(i);
+        }
+
+        Hll fullHll = new Hll();
+        for (int i = 0; i < Short.MAX_VALUE; i++) {
+            fullHll.updateWithHash(i);
+        }
+
+        // empty to empty
+        Hll emptyHll1 = new Hll();
+        emptyHll1.merge(emptyHll);
+        Assert.assertTrue(emptyHll1.getType() == HLL_DATA_EMPTY);
+        Assert.assertTrue(emptyHll1.estimateCardinality() == 0);
+
+        // empty to explicit
+        Hll emptyHll3 = new Hll();
+        emptyHll3.merge(explicitHll);
+        Assert.assertTrue(emptyHll3.getType() == HLL_DATA_EXPLICIT);
+        Assert.assertTrue(emptyHll3.estimateCardinality() == explicitHll.estimateCardinality());
+
+        // empty to full
+        Hll emptyHll2 = new Hll();
+        emptyHll2.merge(fullHll);
+        Assert.assertTrue(emptyHll2.getType() == HLL_DATA_FULL);
+        Assert.assertTrue(emptyHll2.estimateCardinality() == fullHll.estimateCardinality());
+
+        // explicit to full
+        Hll explicitHll2 = new Hll();
+        for (int i = 0 ;i < 100; i++) {
+            explicitHll2.updateWithHash(i + Short.MAX_VALUE);
+        }
+        explicitHll2.merge(fullHll);
+        Assert.assertTrue(explicitHll2.getType() == HLL_DATA_FULL);
+        Assert.assertTrue(explicitHll2.estimateCardinality() > fullHll.estimateCardinality());
+
+        // full to full
+        Hll fullHll2 = new Hll();
+        for (int i = 0; i < Short.MAX_VALUE; i++) {
+            fullHll2.updateWithHash(i + Short.MAX_VALUE);
+        }
+        fullHll2.merge(fullHll);
+        Assert.assertTrue(fullHll2.getType() == HLL_DATA_FULL);
+        Assert.assertTrue(fullHll2.estimateCardinality() > fullHll.estimateCardinality());
+    }
+
+
+}


### PR DESCRIPTION
#3319
mainly used for Spark Load process to calculate approximate deduplication value and then serialize to parquet file.
Try to keep the same calculation semantic with be's C++ version

#3433