### PR TITLE
[Doris On ES] Pushdown some  castexpr predicate to ES

### DIFF
--- a/be/src/exec/es/es_predicate.cpp
+++ b/be/src/exec/es/es_predicate.cpp
@@ -235,20 +235,14 @@ Status EsPredicate::build_disjuncts_list(const Expr* conjunct) {
         if (TExprNodeType::SLOT_REF == conjunct->get_child(0)->node_type()
             || TExprNodeType::CAST_EXPR == conjunct->get_child(0)->node_type()) {
             expr = conjunct->get_child(1);
-            slot_ref = (SlotRef*)(conjunct->get_child(0));
             // process cast expr, such as:
             // k (float) > 2.0, k(int) > 3.2
-            if (TExprNodeType::CAST_EXPR == conjunct->get_child(0)->node_type()) {
-                slot_ref = (SlotRef*)(conjunct->get_child(0)->get_child(0));
-            }
+            slot_ref = (SlotRef*)Expr::expr_without_cast(conjunct->get_child(0));
             op = conjunct->op();
         } else if (TExprNodeType::SLOT_REF == conjunct->get_child(1)->node_type()
             || TExprNodeType::CAST_EXPR == conjunct->get_child(1)->node_type()) {
             expr = conjunct->get_child(0);
-            slot_ref = (SlotRef*)(conjunct->get_child(1));
-            if (TExprNodeType::CAST_EXPR == conjunct->get_child(1)->node_type()) {
-                slot_ref = (SlotRef*)(conjunct->get_child(1)->get_child(0));
-            }
+            slot_ref = (SlotRef*)Expr::expr_without_cast(conjunct->get_child(1));
             op = conjunct->op();
         } else {
             return Status::InternalError("build disjuncts failed: no SLOT_REF child");

--- a/be/src/exec/es/es_predicate.cpp
+++ b/be/src/exec/es/es_predicate.cpp
@@ -230,14 +230,25 @@ Status EsPredicate::build_disjuncts_list(const Expr* conjunct) {
         // doris on es should ignore this doris native cast transformation, we push down this `cast` to elasticsearch
         // conjunct->get_child(0)->node_type() return CAST_EXPR
         // conjunct->get_child(1)->node_type()return FLOAT_LITERAL
-        // conjunct->op() return  EQ
-        if (TExprNodeType::SLOT_REF == conjunct->get_child(0)->node_type()) {
+        // the left child is literal and right child is SlotRef maybe not happend, but here we just process
+        // this situation regardless of the rewrite logic from the FE's Query Engine
+        if (TExprNodeType::SLOT_REF == conjunct->get_child(0)->node_type()
+            || TExprNodeType::CAST_EXPR == conjunct->get_child(0)->node_type()) {
             expr = conjunct->get_child(1);
             slot_ref = (SlotRef*)(conjunct->get_child(0));
+            // process cast expr, such as:
+            // k (float) > 2.0, k(int) > 3.2
+            if (TExprNodeType::CAST_EXPR == conjunct->get_child(0)->node_type()) {
+                slot_ref = (SlotRef*)(conjunct->get_child(0)->get_child(0));
+            }
             op = conjunct->op();
-        } else if (TExprNodeType::SLOT_REF == conjunct->get_child(1)->node_type()) {
+        } else if (TExprNodeType::SLOT_REF == conjunct->get_child(1)->node_type()
+            || TExprNodeType::CAST_EXPR == conjunct->get_child(1)->node_type()) {
             expr = conjunct->get_child(0);
             slot_ref = (SlotRef*)(conjunct->get_child(1));
+            if (TExprNodeType::CAST_EXPR == conjunct->get_child(1)->node_type()) {
+                slot_ref = (SlotRef*)(conjunct->get_child(1)->get_child(0));
+            }
             op = conjunct->op();
         } else {
             return Status::InternalError("build disjuncts failed: no SLOT_REF child");


### PR DESCRIPTION
Process castexpr, such as: k (float) > 2.0, k(int) > 3.2, Doris On Es should ignore this doris native cast transformation for every row's col value, we push down this `cast semantic` to Elasticsearch.  

I believe in this `predicate` situation, would decrease the mount of data for transmission。

k1 is float:

````
k1 >= 5
````

push-down filter:

```
{"range":{"k1":{"gte":"5.000000"}}}
```
k2 is int :

```
k2 > 3.2
```

push-down filter:

```
{"range":{"k2":{"gte":"3.2"}}}
```
