### PR TITLE
Alter replication number for table in one command

### DIFF
--- a/docs/documentation/cn/administrator-guide/index.rst
+++ b/docs/documentation/cn/administrator-guide/index.rst
@@ -7,6 +7,7 @@
 
     load-data/index
     alter-table/index
+    materialized-view/index
     http-actions/index
     operation/index
     config/index

--- a/docs/documentation/cn/administrator-guide/load-data/delete-manual.md
+++ b/docs/documentation/cn/administrator-guide/load-data/delete-manual.md
@@ -17,32 +17,30 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-#Delete
+# Delete
 
 Delete不同于其他导入方式，它是一个同步过程。和Insert into相似，所有的Delete操作在Doris中是一个独立的导入作业，一般Delete语句需要指定表和分区以及删除的条件来筛选要删除的数据，并将会同时删除base表和rollup表的数据。
 
-##语法
+## 语法
 
 主要的Delete语法如下：
 
 ```
 DELETE FROM table_name [PARTITION partition_name]
-        WHERE
-        column_name1 op value[ AND column_name2 op value ...];
+WHERE
+column_name1 op value[ AND column_name2 op value ...];
 ```
 
 示例1：
 
 ```
-DELETE FROM my_table PARTITION p1
-        WHERE k1 = 3;
+DELETE FROM my_table PARTITION p1 WHERE k1 = 3;
 ```
 
 示例2:
 
 ```
-DELETE FROM my_table PARTITION p1
-        WHERE k1 < 3 AND k2 = "abc";
+DELETE FROM my_table PARTITION p1 WHERE k1 < 3 AND k2 = "abc";
 ```
 
 下面介绍删除语句中使用到的参数：
@@ -64,7 +62,7 @@ DELETE FROM my_table PARTITION p1
 5.  如果指定表为RANGE分区表，则必须指定 `PARTITION`。如果是单分区表，可以不指定。
 6.  不同于Insert into命令，delete不能手动指定`label`，有关label的概念可以查看[Insert Into文档] (./insert-into-manual.md)
 
-##返回结果
+## 返回结果
 
 Delete命令是一个SQL命令，返回结果是同步的，分为以下几种：
 
@@ -74,8 +72,8 @@ Delete命令是一个SQL命令，返回结果是同步的，分为以下几种�
 	
 	```
 	mysql> delete from test_tbl PARTITION p1 where k1 = 1;
-Query OK, 0 rows affected (0.04 sec)
-{'label':'delete_e7830c72-eb14-4cb9-bbb6-eebd4511d251', 'status':'VISIBLE', 'txnId':'4005'}
+    Query OK, 0 rows affected (0.04 sec)
+    {'label':'delete_e7830c72-eb14-4cb9-bbb6-eebd4511d251', 'status':'VISIBLE', 'txnId':'4005'}
 	```
 	
 2. 提交成功，但未可见
@@ -84,11 +82,11 @@ Query OK, 0 rows affected (0.04 sec)
     
     ```
 	mysql> delete from test_tbl PARTITION p1 where k1 = 1;
-Query OK, 0 rows affected (0.04 sec)
-{'label':'delete_e7830c72-eb14-4cb9-bbb6-eebd4511d251', 'status':'VISIBLE', 'txnId':'4005', 'err':'delete job is committed but may be taking effect later' }
+    Query OK, 0 rows affected (0.04 sec)
+    {'label':'delete_e7830c72-eb14-4cb9-bbb6-eebd4511d251', 'status':'VISIBLE', 'txnId':'4005', 'err':'delete job is committed but may be taking effect later' }
 	```
 	
-      结果会同时返回一个json字符串：
+    结果会同时返回一个json字符串：
 	
     `affected rows`表示此次删除影响的行，由于Doris的删除目前是逻辑删除，因此对于这个值是恒为0。
     
@@ -106,7 +104,7 @@ Query OK, 0 rows affected (0.04 sec)
     
     ```
 	mysql> delete from test_tbl partition p1 where k1 > 80;
-ERROR 1064 (HY000): errCode = 2, detailMessage = {错误原因}
+    ERROR 1064 (HY000): errCode = 2, detailMessage = {错误原因}
 	```
 	
     示例：
@@ -115,7 +113,7 @@ ERROR 1064 (HY000): errCode = 2, detailMessage = {错误原因}
 
     ```
 	mysql> delete from test_tbl partition p1 where k1 > 80;
-ERROR 1064 (HY000): errCode = 2, detailMessage = failed to delete replicas from job: 4005, Unfinished replicas:10000=60000, 10001=60000, 10002=60000
+    ERROR 1064 (HY000): errCode = 2, detailMessage = failed to delete replicas from job: 4005, Unfinished replicas:10000=60000, 10001=60000, 10002=60000
 	```
 	
     **综上，对于Delete操作返回结果的正确处理逻辑为：**
@@ -127,9 +125,9 @@ ERROR 1064 (HY000): errCode = 2, detailMessage = failed to delete replicas from 
     	1. 如果`status`为`COMMITTED`，表示数据仍不可见，用户可以稍等一段时间再用`show delete`命令查看结果
     	2. 如果`status`为`VISIBLE`，表示数据删除成功。
 
-##可配置项
+## 可配置项
 
-###FE配置
+### FE配置
 
 **TIMEOUT配置**
 
@@ -153,11 +151,11 @@ ERROR 1064 (HY000): errCode = 2, detailMessage = failed to delete replicas from 
   
   因为delete本身是一个SQL命令，因此删除语句也会受session限制，timeout还受Session中的`query_timeout`值影响，可以通过`SET query_timeout = xxx`来增加超时时间，单位是秒。
   
-##查看历史记录
+## 查看历史记录
 	
 1. 用户可以通过show delete语句查看历史上已执行完成的删除记录
 
-	###语法
+	语法
 
 	```
 	SHOW DELETE [FROM db_name]

--- a/docs/documentation/cn/administrator-guide/load-data/index.rst
+++ b/docs/documentation/cn/administrator-guide/load-data/index.rst
@@ -10,3 +10,4 @@
     stream-load-manual.md
     routine-load-manual.md
     insert-into-manual.md
+    delete-manual.md

--- a/docs/documentation/cn/sql-reference/sql-statements/Data Definition/ALTER TABLE.md
+++ b/docs/documentation/cn/sql-reference/sql-statements/Data Definition/ALTER TABLE.md
@@ -166,7 +166,7 @@ under the License.
             1) index 中的所有列都要写出来
             2) value 列在 key 列之后
             
-    6. 修改table的属性，目前支持修改bloom filter列, colocate_with 属性和dynamic_partition属性
+    6. 修改table的属性，目前支持修改bloom filter列, colocate_with 属性和dynamic_partition属性，replication_num和default.replication_num属性
         语法：
             PROPERTIES ("key"="value")
         注意：
@@ -197,6 +197,15 @@ under the License.
             DROP INDEX index_name；
 
 ## example
+
+    [table]
+    1. 修改表的默认副本数量, 新建分区副本数量默认使用此值
+        ATLER TABLE example_db.my_table 
+        SET ("default.replication_num" = "2");
+        
+    2. 修改单分区表的实际副本数量(只限单分区表)
+        ALTER TABLE example_db.my_table
+        SET ("replication_num" = "3");
 
     [partition]
     1. 增加分区, 现有分区 [MIN, 2013-01-01)，增加分区 [2013-01-01, 2014-01-01)，使用默认分桶方式

--- a/docs/documentation/en/administrator-guide/load-data/index.rst
+++ b/docs/documentation/en/administrator-guide/load-data/index.rst
@@ -10,3 +10,4 @@ Load Data
     stream-load-manual_EN.md
     routine-load-manual_EN.md
     insert-into-manual_EN.md
+    delete-manual_EN.md

--- a/docs/documentation/en/sql-reference/sql-statements/Data Definition/ALTER TABLE_EN.md
+++ b/docs/documentation/en/sql-reference/sql-statements/Data Definition/ALTER TABLE_EN.md
@@ -167,7 +167,7 @@ under the License.
             1) All columns in index must be written
             2) value is listed after the key column
             
-    6. Modify the properties of the table, currently supports modifying the bloom filter column, the colocate_with attribute and the dynamic_partition attribute.
+    6. Modify the properties of the table, currently supports modifying the bloom filter column, the colocate_with attribute and the dynamic_partition attribute， the replication_num and default.replication_num.
         grammar:
             PROPERTIES ("key"="value")
         note:
@@ -199,6 +199,15 @@ under the License.
             DROP INDEX index_name；
 
 ## example
+
+    [table]
+    1. Modify the default number of replications of the table, which is used as default number of replications while creating new partition.
+        ATLER TABLE example_db.my_table 
+        SET ("default.replication_num" = "2");
+        
+    2. Modify the actual number of replications of a unpartitioned table (unpartitioned table only)
+        ALTER TABLE example_db.my_table
+        SET ("replication_num" = "3");
 
     [partition]
     1. Add partition, existing partition [MIN, 2013-01-01), add partition [2013-01-01, 2014-01-01), use default bucket mode

--- a/fe/src/main/java/org/apache/doris/alter/SchemaChangeHandler.java
+++ b/fe/src/main/java/org/apache/doris/alter/SchemaChangeHandler.java
@@ -1397,6 +1397,9 @@ public class SchemaChangeHandler extends AlterHandler {
                 } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_REPLICATION_NUM)) {
                     Catalog.getCurrentCatalog().modifyTableReplicationNum(db, olapTable, properties);
                     return;
+                } else if (properties.containsKey("default." + PropertyAnalyzer.PROPERTIES_REPLICATION_NUM)) {
+                    Catalog.getCurrentCatalog().modifyTableDefaultReplicationNum(db, olapTable, properties);
+                    return;
                 }
             }
 

--- a/fe/src/main/java/org/apache/doris/alter/SchemaChangeHandler.java
+++ b/fe/src/main/java/org/apache/doris/alter/SchemaChangeHandler.java
@@ -1394,11 +1394,12 @@ public class SchemaChangeHandler extends AlterHandler {
                 } else if (DynamicPartitionUtil.checkDynamicPartitionPropertiesExist(properties)) {
                     Catalog.getCurrentCatalog().modifyTableDynamicPartition(db, olapTable, properties);
                     return;
+                } else if (properties.containsKey("default." + PropertyAnalyzer.PROPERTIES_REPLICATION_NUM)) {
+                    Preconditions.checkNotNull(properties.get(PropertyAnalyzer.PROPERTIES_REPLICATION_NUM));
+                    Catalog.getCurrentCatalog().modifyTableDefaultReplicationNum(db, olapTable, properties);
+                    return;
                 } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_REPLICATION_NUM)) {
                     Catalog.getCurrentCatalog().modifyTableReplicationNum(db, olapTable, properties);
-                    return;
-                } else if (properties.containsKey("default." + PropertyAnalyzer.PROPERTIES_REPLICATION_NUM)) {
-                    Catalog.getCurrentCatalog().modifyTableDefaultReplicationNum(db, olapTable, properties);
                     return;
                 }
             }

--- a/fe/src/main/java/org/apache/doris/analysis/ModifyTablePropertiesClause.java
+++ b/fe/src/main/java/org/apache/doris/analysis/ModifyTablePropertiesClause.java
@@ -79,11 +79,10 @@ public class ModifyTablePropertiesClause extends AlterTableClause {
         } else if (DynamicPartitionUtil.checkDynamicPartitionPropertiesExist(properties)) {
             // do nothing, dynamic properties will be analyzed in SchemaChangeHandler.process
         } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_REPLICATION_NUM)) {
-            short replicationNum = PropertyAnalyzer.analyzeReplicationNum(properties, (short) -1);
-            properties.put(PropertyAnalyzer.PROPERTIES_REPLICATION_NUM, Short.toString(replicationNum));
+            PropertyAnalyzer.analyzeReplicationNum(properties, false);
         } else if (properties.containsKey("default." + PropertyAnalyzer.PROPERTIES_REPLICATION_NUM)) {
-            short defaultReplicationNum = PropertyAnalyzer.analyzeDefaultReplicationNum(properties, (short) -1);
-            properties.put("default." + PropertyAnalyzer.PROPERTIES_REPLICATION_NUM, Short.toString(defaultReplicationNum));
+            short defaultReplicationNum = PropertyAnalyzer.analyzeReplicationNum(properties, true);
+            properties.put(PropertyAnalyzer.PROPERTIES_REPLICATION_NUM, Short.toString(defaultReplicationNum));
         } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_INMEMORY)) {
             this.needTableStable = false;
             this.opType = AlterOpType.MODIFY_TABLE_PROPERTY_SYNC;

--- a/fe/src/main/java/org/apache/doris/analysis/ModifyTablePropertiesClause.java
+++ b/fe/src/main/java/org/apache/doris/analysis/ModifyTablePropertiesClause.java
@@ -79,14 +79,11 @@ public class ModifyTablePropertiesClause extends AlterTableClause {
         } else if (DynamicPartitionUtil.checkDynamicPartitionPropertiesExist(properties)) {
             // do nothing, dynamic properties will be analyzed in SchemaChangeHandler.process
         } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_REPLICATION_NUM)) {
-            String defaultReplicationNumName = "default." + PropertyAnalyzer.PROPERTIES_REPLICATION_NUM;
-            throw new AnalysisException("Please use " + defaultReplicationNumName +
-                    " instead of " + PropertyAnalyzer.PROPERTIES_REPLICATION_NUM + " config to escape misleading, this operation" +
-                    " doesn't support changing the replication_num of the table data");
+            short replicationNum = PropertyAnalyzer.analyzeReplicationNum(properties, (short) -1);
+            properties.put(PropertyAnalyzer.PROPERTIES_REPLICATION_NUM, Short.toString(replicationNum));
         } else if (properties.containsKey("default." + PropertyAnalyzer.PROPERTIES_REPLICATION_NUM)) {
-            String defaultReplicationNumName = "default." + PropertyAnalyzer.PROPERTIES_REPLICATION_NUM;
-            properties.put(PropertyAnalyzer.PROPERTIES_REPLICATION_NUM, properties.get(defaultReplicationNumName));
-            properties.remove(defaultReplicationNumName);
+            short defaultReplicationNum = PropertyAnalyzer.analyzeDefaultReplicationNum(properties, (short) -1);
+            properties.put("default." + PropertyAnalyzer.PROPERTIES_REPLICATION_NUM, Short.toString(defaultReplicationNum));
         } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_INMEMORY)) {
             this.needTableStable = false;
             this.opType = AlterOpType.MODIFY_TABLE_PROPERTY_SYNC;

--- a/fe/src/main/java/org/apache/doris/catalog/Catalog.java
+++ b/fe/src/main/java/org/apache/doris/catalog/Catalog.java
@@ -5198,8 +5198,11 @@ public class Catalog {
             tableProperty.modifyTableProperties(properties);
         }
         tableProperty.buildReplicationNum();
+        // log
         ModifyTablePropertyOperationLog info = new ModifyTablePropertyOperationLog(db.getId(), table.getId(), properties);
         editLog.logModifyReplicationNum(info);
+        LOG.debug("modify table[{}] replication num to {}", table.getName(),
+                properties.get(PropertyAnalyzer.PROPERTIES_REPLICATION_NUM));
     }
 
     // The caller need to hold the db write lock

--- a/fe/src/main/java/org/apache/doris/catalog/Catalog.java
+++ b/fe/src/main/java/org/apache/doris/catalog/Catalog.java
@@ -5161,7 +5161,7 @@ public class Catalog {
     }
 
     /**
-     * Set replication number for a table that only have one partition.
+     * Set replication number for unpartitioned table.
      * @param db
      * @param table
      * @param properties

--- a/fe/src/main/java/org/apache/doris/catalog/Catalog.java
+++ b/fe/src/main/java/org/apache/doris/catalog/Catalog.java
@@ -5160,6 +5160,13 @@ public class Catalog {
         editLog.logDynamicPartition(info);
     }
 
+    /**
+     * Set replication number for a table that only have one partition.
+     * @param db
+     * @param table
+     * @param properties
+     * @throws DdlException
+     */
     // The caller need to hold the db write lock
     public void modifyTableReplicationNum(Database db, OlapTable table, Map<String, String> properties) throws DdlException {
         Preconditions.checkArgument(db.isWriteLockHeldByCurrentThread());
@@ -5188,6 +5195,13 @@ public class Catalog {
                 replicationNum);
     }
 
+    /**
+     * Set default replication number for a specified table.
+     * You can see the default replication number by Show Create Table stmt.
+     * @param db
+     * @param table
+     * @param properties
+     */
     // The caller need to hold the db write lock
     public void modifyTableDefaultReplicationNum(Database db, OlapTable table, Map<String, String> properties) {
         Preconditions.checkArgument(db.isWriteLockHeldByCurrentThread());

--- a/fe/src/main/java/org/apache/doris/common/util/PropertyAnalyzer.java
+++ b/fe/src/main/java/org/apache/doris/common/util/PropertyAnalyzer.java
@@ -184,22 +184,16 @@ public class PropertyAnalyzer {
         return replicationNum;
     }
 
-    public static Short analyzeDefaultReplicationNum(Map<String, String> properties, short oldReplicationNum)
-            throws AnalysisException {
-        Short replicationNum = oldReplicationNum;
-        String defaultReplicationNumName = "default." + PropertyAnalyzer.PROPERTIES_REPLICATION_NUM;
-        if (properties != null && properties.containsKey(defaultReplicationNumName)) {
-            try {
-                replicationNum = Short.valueOf(properties.get(defaultReplicationNumName));
-            } catch (Exception e) {
-                throw new AnalysisException(e.getMessage());
-            }
-
-            if (replicationNum <= 0) {
-                throw new AnalysisException("Replication num should larger than 0. (suggested 3)");
-            }
-
-            properties.remove(PROPERTIES_REPLICATION_NUM);
+    public static Short analyzeReplicationNum(Map<String, String> properties, boolean isDefault) throws AnalysisException {
+        String key = "default.";
+        if (isDefault) {
+            key += PropertyAnalyzer.PROPERTIES_REPLICATION_NUM;
+        } else {
+            key = PropertyAnalyzer.PROPERTIES_REPLICATION_NUM;
+        }
+        short replicationNum = Short.valueOf(properties.get(key));
+        if (replicationNum <= 0) {
+            throw new AnalysisException("Replication num should larger than 0. (suggested 3)");
         }
         return replicationNum;
     }

--- a/fe/src/main/java/org/apache/doris/common/util/PropertyAnalyzer.java
+++ b/fe/src/main/java/org/apache/doris/common/util/PropertyAnalyzer.java
@@ -184,6 +184,26 @@ public class PropertyAnalyzer {
         return replicationNum;
     }
 
+    public static Short analyzeDefaultReplicationNum(Map<String, String> properties, short oldReplicationNum)
+            throws AnalysisException {
+        Short replicationNum = oldReplicationNum;
+        String defaultReplicationNumName = "default." + PropertyAnalyzer.PROPERTIES_REPLICATION_NUM;
+        if (properties != null && properties.containsKey(defaultReplicationNumName)) {
+            try {
+                replicationNum = Short.valueOf(properties.get(defaultReplicationNumName));
+            } catch (Exception e) {
+                throw new AnalysisException(e.getMessage());
+            }
+
+            if (replicationNum <= 0) {
+                throw new AnalysisException("Replication num should larger than 0. (suggested 3)");
+            }
+
+            properties.remove(PROPERTIES_REPLICATION_NUM);
+        }
+        return replicationNum;
+    }
+
     public static String analyzeColumnSeparator(Map<String, String> properties, String oldColumnSeparator) {
         String columnSeparator = oldColumnSeparator;
         if (properties != null && properties.containsKey(PROPERTIES_COLUMN_SEPARATOR)) {


### PR DESCRIPTION
#2299 #3389 
This cl add new command to set replication number of table in one time.

```
alter table test_tbl set ("replication_num" = "3");
```

It changes replication num of a table that have only one partition.

and

```
alter table test_tbl set ("default.replication_num" = "3");
```

It changes default replication num of the specified table.