### PR TITLE
[Bug]Use OlapTableSink::close to replace OlapTableSink::finalize method to avoid OOM

### DIFF
--- a/fe/src/main/java/org/apache/doris/analysis/InsertStmt.java
+++ b/fe/src/main/java/org/apache/doris/analysis/InsertStmt.java
@@ -713,9 +713,9 @@ public class InsertStmt extends DdlStmt {
         return dataSink;
     }
 
-    public void close() throws UserException {
+    public void complete() throws UserException {
         if (!isExplain() && targetTable instanceof OlapTable) {
-            ((OlapTableSink) dataSink).close();
+            ((OlapTableSink) dataSink).complete();
             // add table indexes to transaction state
             TransactionState txnState = Catalog.getCurrentGlobalTransactionMgr().getTransactionState(transactionId);
             if (txnState == null) {

--- a/fe/src/main/java/org/apache/doris/analysis/InsertStmt.java
+++ b/fe/src/main/java/org/apache/doris/analysis/InsertStmt.java
@@ -713,9 +713,9 @@ public class InsertStmt extends DdlStmt {
         return dataSink;
     }
 
-    public void finalize() throws UserException {
+    public void close() throws UserException {
         if (!isExplain() && targetTable instanceof OlapTable) {
-            ((OlapTableSink) dataSink).finalize();
+            ((OlapTableSink) dataSink).close();
             // add table indexes to transaction state
             TransactionState txnState = Catalog.getCurrentGlobalTransactionMgr().getTransactionState(transactionId);
             if (txnState == null) {

--- a/fe/src/main/java/org/apache/doris/load/loadv2/LoadingTaskPlanner.java
+++ b/fe/src/main/java/org/apache/doris/load/loadv2/LoadingTaskPlanner.java
@@ -128,7 +128,7 @@ public class LoadingTaskPlanner {
         List<Long> partitionIds = getAllPartitionIds();
         OlapTableSink olapTableSink = new OlapTableSink(table, tupleDesc, partitionIds);
         olapTableSink.init(loadId, txnId, dbId, timeoutS);
-        olapTableSink.finalize();
+        olapTableSink.close();
 
         // 3. Plan fragment
         PlanFragment sinkFragment = new PlanFragment(new PlanFragmentId(0), scanNode, DataPartition.RANDOM);

--- a/fe/src/main/java/org/apache/doris/load/loadv2/LoadingTaskPlanner.java
+++ b/fe/src/main/java/org/apache/doris/load/loadv2/LoadingTaskPlanner.java
@@ -128,7 +128,7 @@ public class LoadingTaskPlanner {
         List<Long> partitionIds = getAllPartitionIds();
         OlapTableSink olapTableSink = new OlapTableSink(table, tupleDesc, partitionIds);
         olapTableSink.init(loadId, txnId, dbId, timeoutS);
-        olapTableSink.close();
+        olapTableSink.complete();
 
         // 3. Plan fragment
         PlanFragment sinkFragment = new PlanFragment(new PlanFragmentId(0), scanNode, DataPartition.RANDOM);

--- a/fe/src/main/java/org/apache/doris/planner/OlapTableSink.java
+++ b/fe/src/main/java/org/apache/doris/planner/OlapTableSink.java
@@ -118,7 +118,7 @@ public class OlapTableSink extends DataSink {
     }
 
     // must called after tupleDescriptor is computed
-    public void close() throws UserException {
+    public void completeq() throws UserException {
         TOlapTableSink tSink = tDataSink.getOlap_table_sink();
 
         tSink.setTable_id(dstTable.getId());

--- a/fe/src/main/java/org/apache/doris/planner/OlapTableSink.java
+++ b/fe/src/main/java/org/apache/doris/planner/OlapTableSink.java
@@ -118,7 +118,7 @@ public class OlapTableSink extends DataSink {
     }
 
     // must called after tupleDescriptor is computed
-    public void completeq() throws UserException {
+    public void complete() throws UserException {
         TOlapTableSink tSink = tDataSink.getOlap_table_sink();
 
         tSink.setTable_id(dstTable.getId());

--- a/fe/src/main/java/org/apache/doris/planner/OlapTableSink.java
+++ b/fe/src/main/java/org/apache/doris/planner/OlapTableSink.java
@@ -118,7 +118,7 @@ public class OlapTableSink extends DataSink {
     }
 
     // must called after tupleDescriptor is computed
-    public void finalize() throws UserException {
+    public void close() throws UserException {
         TOlapTableSink tSink = tDataSink.getOlap_table_sink();
 
         tSink.setTable_id(dstTable.getId());

--- a/fe/src/main/java/org/apache/doris/planner/Planner.java
+++ b/fe/src/main/java/org/apache/doris/planner/Planner.java
@@ -180,7 +180,7 @@ public class Planner {
             InsertStmt insertStmt = (InsertStmt) statement;
             rootFragment = distributedPlanner.createInsertFragment(rootFragment, insertStmt, fragments);
             rootFragment.setSink(insertStmt.getDataSink());
-            insertStmt.close();
+            insertStmt.complete();
             ArrayList<Expr> exprs = ((InsertStmt) statement).getResultExprs();
             List<Expr> resExprs = Expr.substituteList(
                     exprs, rootFragment.getPlanRoot().getOutputSmap(), analyzer, true);

--- a/fe/src/main/java/org/apache/doris/planner/Planner.java
+++ b/fe/src/main/java/org/apache/doris/planner/Planner.java
@@ -180,7 +180,7 @@ public class Planner {
             InsertStmt insertStmt = (InsertStmt) statement;
             rootFragment = distributedPlanner.createInsertFragment(rootFragment, insertStmt, fragments);
             rootFragment.setSink(insertStmt.getDataSink());
-            insertStmt.finalize();
+            insertStmt.close();
             ArrayList<Expr> exprs = ((InsertStmt) statement).getResultExprs();
             List<Expr> resExprs = Expr.substituteList(
                     exprs, rootFragment.getPlanRoot().getOutputSmap(), analyzer, true);

--- a/fe/src/main/java/org/apache/doris/planner/StreamLoadPlanner.java
+++ b/fe/src/main/java/org/apache/doris/planner/StreamLoadPlanner.java
@@ -114,7 +114,7 @@ public class StreamLoadPlanner {
         List<Long> partitionIds = getAllPartitionIds();
         OlapTableSink olapTableSink = new OlapTableSink(destTable, tupleDesc, partitionIds);
         olapTableSink.init(loadId, streamLoadTask.getTxnId(), db.getId(), streamLoadTask.getTimeout());
-        olapTableSink.finalize();
+        olapTableSink.close();
 
         // for stream load, we only need one fragment, ScanNode -> DataSink.
         // OlapTableSink can dispatch data to corresponding node.

--- a/fe/src/main/java/org/apache/doris/planner/StreamLoadPlanner.java
+++ b/fe/src/main/java/org/apache/doris/planner/StreamLoadPlanner.java
@@ -114,7 +114,7 @@ public class StreamLoadPlanner {
         List<Long> partitionIds = getAllPartitionIds();
         OlapTableSink olapTableSink = new OlapTableSink(destTable, tupleDesc, partitionIds);
         olapTableSink.init(loadId, streamLoadTask.getTxnId(), db.getId(), streamLoadTask.getTimeout());
-        olapTableSink.close();
+        olapTableSink.complete();
 
         // for stream load, we only need one fragment, ScanNode -> DataSink.
         // OlapTableSink can dispatch data to corresponding node.

--- a/fe/src/test/java/org/apache/doris/planner/OlapTableSinkTest.java
+++ b/fe/src/test/java/org/apache/doris/planner/OlapTableSinkTest.java
@@ -99,7 +99,7 @@ public class OlapTableSinkTest {
 
         OlapTableSink sink = new OlapTableSink(dstTable, tuple, Lists.newArrayList());
         sink.init(new TUniqueId(1, 2), 3, 4, 1000);
-        sink.finalize();
+        sink.close();
         LOG.info("sink is {}", sink.toThrift());
         LOG.info("{}", sink.getExplainString("", TExplainLevel.NORMAL));
     }
@@ -130,7 +130,7 @@ public class OlapTableSinkTest {
         OlapTableSink sink = new OlapTableSink(dstTable, tuple, Lists.newArrayList(p1.getId()));
         sink.init(new TUniqueId(1, 2), 3, 4, 1000);
         try {
-            sink.finalize();
+            sink.close();
         } catch (UserException e) {
 
         }
@@ -152,7 +152,7 @@ public class OlapTableSinkTest {
 
         OlapTableSink sink = new OlapTableSink(dstTable, tuple, Lists.newArrayList(unknownPartId));
         sink.init(new TUniqueId(1, 2), 3, 4, 1000);
-        sink.finalize();
+        sink.close();
         LOG.info("sink is {}", sink.toThrift());
         LOG.info("{}", sink.getExplainString("", TExplainLevel.NORMAL));
     }
@@ -169,7 +169,7 @@ public class OlapTableSinkTest {
 
         OlapTableSink sink = new OlapTableSink(dstTable, tuple, Lists.newArrayList(1L));
         sink.init(new TUniqueId(1, 2), 3, 4, 1000);
-        sink.finalize();
+        sink.close();
         LOG.info("sink is {}", sink.toThrift());
         LOG.info("{}", sink.getExplainString("", TExplainLevel.NORMAL));
     }

--- a/fe/src/test/java/org/apache/doris/planner/OlapTableSinkTest.java
+++ b/fe/src/test/java/org/apache/doris/planner/OlapTableSinkTest.java
@@ -99,7 +99,7 @@ public class OlapTableSinkTest {
 
         OlapTableSink sink = new OlapTableSink(dstTable, tuple, Lists.newArrayList());
         sink.init(new TUniqueId(1, 2), 3, 4, 1000);
-        sink.close();
+        sink.complete();
         LOG.info("sink is {}", sink.toThrift());
         LOG.info("{}", sink.getExplainString("", TExplainLevel.NORMAL));
     }
@@ -130,7 +130,7 @@ public class OlapTableSinkTest {
         OlapTableSink sink = new OlapTableSink(dstTable, tuple, Lists.newArrayList(p1.getId()));
         sink.init(new TUniqueId(1, 2), 3, 4, 1000);
         try {
-            sink.close();
+            sink.complete();
         } catch (UserException e) {
 
         }
@@ -152,7 +152,7 @@ public class OlapTableSinkTest {
 
         OlapTableSink sink = new OlapTableSink(dstTable, tuple, Lists.newArrayList(unknownPartId));
         sink.init(new TUniqueId(1, 2), 3, 4, 1000);
-        sink.close();
+        sink.complete();
         LOG.info("sink is {}", sink.toThrift());
         LOG.info("{}", sink.getExplainString("", TExplainLevel.NORMAL));
     }
@@ -169,7 +169,7 @@ public class OlapTableSinkTest {
 
         OlapTableSink sink = new OlapTableSink(dstTable, tuple, Lists.newArrayList(1L));
         sink.init(new TUniqueId(1, 2), 3, 4, 1000);
-        sink.close();
+        sink.complete();
         LOG.info("sink is {}", sink.toThrift());
         LOG.info("{}", sink.getExplainString("", TExplainLevel.NORMAL));
     }


### PR DESCRIPTION
This CL mainly solve the problem that when recycle `OlapTableSink`
object, GC thread will not do it immediately because the class override
the `finalize` method, and it will cause OOM.