### PR TITLE
[Bug] Fix authorization missing when auditloader plugin redirect stream load bug

### DIFF
--- a/docs/documentation/cn/administrator-guide/alter-table/alter-table-temp-partition.md
+++ b/docs/documentation/cn/administrator-guide/alter-table/alter-table-temp-partition.md
@@ -163,7 +163,7 @@ PROPERTIES (
     ```
 
     ```
-    curl --location-trusted -u root: -H "label:123" -H "temporary_partition: tp1, tp2, ..." -T testData http://host:port/api/testDb/testTbl/_stream_load    
+    curl --location-trusted -u root: -H "label:123" -H "temporary_partitions: tp1, tp2, ..." -T testData http://host:port/api/testDb/testTbl/_stream_load    
     ```
 
     ```


### PR DESCRIPTION
HttpURLConnection can automatically redirect stream load to BE, but there is no authorization information in http request headers after redirect.
Maybe HttpURLConnection remove authorization info when do followredirect.
The solution is set the followRedirect property to false on the connection object and do the redirect request manually.
#3364 