### PR TITLE
[Bug] `isQuery` field should be reset at the beginning of query execution

### DIFF
--- a/docs/documentation/cn/administrator-guide/segment-v2-usage.md
+++ b/docs/documentation/cn/administrator-guide/segment-v2-usage.md
@@ -62,7 +62,7 @@ V2 格式的表可以支持以下新的特性：
     
     ```
     ## 创建 V2 格式的 Rollup
-    
+
     ALTER TABLE table_name ADD ROLLUP table_name (columns) PROPERTIES ("storage_format" = "v2");
     ```
 

--- a/fe/src/main/java/org/apache/doris/catalog/Catalog.java
+++ b/fe/src/main/java/org/apache/doris/catalog/Catalog.java
@@ -3971,7 +3971,7 @@ public class Catalog {
 
             // storage type
             sb.append(",\n\"").append(PropertyAnalyzer.PROPERTIES_STORAGE_FORMAT).append("\" = \"");
-            sb.append(olapTable.getTableProperty().getStorageFormat()).append("\"");
+            sb.append(olapTable.getStorageFormat()).append("\"");
 
             sb.append("\n)");
         } else if (table.getType() == TableType.MYSQL) {

--- a/fe/src/main/java/org/apache/doris/catalog/DomainResolver.java
+++ b/fe/src/main/java/org/apache/doris/catalog/DomainResolver.java
@@ -55,13 +55,13 @@ public class DomainResolver extends MasterDaemon {
     // 'public' for test
     @Override
     public void runAfterCatalogReady() {
-        // domain name -> set of user names
-        Map<String, Set<String>> domainMap = Maps.newHashMap();
-        auth.getDomainMap(domainMap);
+        // domain names
+        Set<String> allDomains = Sets.newHashSet();
+        auth.getAllDomains(allDomains);
         
         // resolve domain name
         Map<String, Set<String>> resolvedIPsMap = Maps.newHashMap();
-        for (String domain : domainMap.keySet()) {
+        for (String domain : allDomains) {
             LOG.debug("begin to resolve domain: {}", domain);
             Set<String> resolvedIPs = Sets.newHashSet();
             if (!resolveWithBNS(domain, resolvedIPs) && !resolveWithDNS(domain, resolvedIPs)) {

--- a/fe/src/main/java/org/apache/doris/catalog/OlapTable.java
+++ b/fe/src/main/java/org/apache/doris/catalog/OlapTable.java
@@ -1470,4 +1470,11 @@ public class OlapTable extends Table {
         tableProperty.modifyTableProperties(PropertyAnalyzer.PROPERTIES_STORAGE_FORMAT, storageFormat.name());
         tableProperty.buildStorageFormat();
     }
+
+    public TStorageFormat getStorageFormat() {
+        if (tableProperty == null) {
+            return TStorageFormat.DEFAULT;
+        }
+        return tableProperty.getStorageFormat();
+    }
 }

--- a/fe/src/main/java/org/apache/doris/mysql/privilege/PaloAuth.java
+++ b/fe/src/main/java/org/apache/doris/mysql/privilege/PaloAuth.java
@@ -851,10 +851,10 @@ public class PaloAuth implements Writable {
         }
     }
 
-    public void getDomainMap(Map<String, Set<String>> domainMap) {
+    public void getAllDomains(Set<String> allDomains) {
         readLock();
         try {
-            propertyMgr.getDomainMap(domainMap);
+            propertyMgr.getAllDomains(allDomains);
         } finally {
             readUnlock();
         }

--- a/fe/src/main/java/org/apache/doris/mysql/privilege/UserPropertyMgr.java
+++ b/fe/src/main/java/org/apache/doris/mysql/privilege/UserPropertyMgr.java
@@ -28,7 +28,6 @@ import org.apache.doris.thrift.TFetchResourceResult;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -181,22 +180,11 @@ public class UserPropertyMgr implements Writable {
     }
 
     // return a map from domain name -> set of user names
-    public void getDomainMap(Map<String, Set<String>> domainMap) {
+    public void getAllDomains(Set<String> allDomains) {
         LOG.debug("get property map: {}", propertyMap);
         for (Map.Entry<String, UserProperty> entry : propertyMap.entrySet()) {
             Set<String> domains = entry.getValue().getWhiteList().getAllDomains();
-            if (domains.isEmpty()) {
-                continue;
-            }
-
-            for (String domain : domains) {
-                Set<String> usernames = domainMap.get(domain);
-                if (usernames == null) {
-                    usernames = Sets.newHashSet();
-                    domainMap.put(domain, usernames);
-                }
-                usernames.add(entry.getKey());
-            }
+            allDomains.addAll(domains);
         }
     }
 

--- a/fe/src/main/java/org/apache/doris/mysql/privilege/WhiteList.java
+++ b/fe/src/main/java/org/apache/doris/mysql/privilege/WhiteList.java
@@ -68,10 +68,15 @@ public class WhiteList implements Writable {
     // it will only modify password entry of these resolved IPs. All other privileges are binded
     // to the domain, so no need to modify.
     public void addUserPrivEntriesByResovledIPs(String user, Map<String, Set<String>> resolvedIPsMap) {
+        // the parameter "resolvedIPsMap" contains all resolved domains.
+        // "newResolvedIPsMap" will only save the domains contained in this white list.
+        Map<String, Set<String>> newResolvedIPsMap = Maps.newHashMap();
         for (Map.Entry<String, Set<String>> entry : resolvedIPsMap.entrySet()) {
             if (!containsDomain(entry.getKey())) {
                 continue;
             }
+
+            newResolvedIPsMap.put(entry.getKey(), entry.getValue());
 
             // this user ident will be saved along with each resolved "IP" user ident, so that when checking
             // password, this "domain" user ident will be returned as "current user".
@@ -93,7 +98,7 @@ public class WhiteList implements Writable {
         }
 
         // set new resolved IPs
-        this.resolvedIPsMap = resolvedIPsMap;
+        this.resolvedIPsMap = newResolvedIPsMap;
     }
 
     public Map<String, Set<String>> getResolvedIPs() {

--- a/fe/src/main/java/org/apache/doris/qe/QueryState.java
+++ b/fe/src/main/java/org/apache/doris/qe/QueryState.java
@@ -56,6 +56,7 @@ public class QueryState {
         errorCode = null;
         infoMessage = null;
         serverStatus = 0;
+        isQuery = false;
     }
 
     public MysqlStateType getStateType() {


### PR DESCRIPTION
If not reset, all queries comes from same session will have save `isQuery` field value.
This bug will cause all entries in `fe.audit.log` has same `IsQuery=true`.

This CL also fix another bug:
The resolved IPs of domain of a user should not appear in other user's white list. Fix #3380 