### PR TITLE
Forbidden correlated having clause

### DIFF
--- a/fe/src/main/java/org/apache/doris/analysis/QueryStmt.java
+++ b/fe/src/main/java/org/apache/doris/analysis/QueryStmt.java
@@ -437,6 +437,8 @@ public abstract class QueryStmt extends StatementBase {
      */
     public abstract void collectTableRefs(List<TableRef> tblRefs);
 
+    abstract List<TupleId> collectTupleIds();
+
     public ArrayList<OrderByElement> getOrderByElements() {
         return orderByElements;
     }

--- a/fe/src/main/java/org/apache/doris/analysis/SetOperationStmt.java
+++ b/fe/src/main/java/org/apache/doris/analysis/SetOperationStmt.java
@@ -542,6 +542,13 @@ public class SetOperationStmt extends QueryStmt {
     }
 
     @Override
+    public List<TupleId> collectTupleIds() {
+        List<TupleId> result = Lists.newArrayList();
+        for (SetOperand op: operands) result.addAll(op.getQueryStmt().collectTupleIds());
+        return result;
+    }
+
+    @Override
     public String toSql() {
         if (toSqlString != null) {
             return toSqlString;

--- a/fe/src/main/java/org/apache/doris/analysis/StmtRewriter.java
+++ b/fe/src/main/java/org/apache/doris/analysis/StmtRewriter.java
@@ -161,7 +161,7 @@ public class StmtRewriter {
         Preconditions.checkState(havingClause != null);
         Preconditions.checkState(havingClause.getSubquery() != null);
         List<OrderByElement> orderByElements = stmt.getOrderByElementsAfterAnalyzed();
-        long limit = stmt.getLimit();
+        LimitElement limitElement = new LimitElement(stmt.getOffset(), stmt.getLimit());
         TableAliasGenerator tableAliasGenerator = stmt.getTableAliasGenerator();
 
         /*
@@ -260,7 +260,7 @@ public class StmtRewriter {
         newTableRefList.add(inlineViewRef);
         FromClause newFromClause = new FromClause(newTableRefList);
         SelectStmt result = new SelectStmt(newSelectList, newFromClause, newWherePredicate, null, null,
-                newOrderByElements, new LimitElement(limit));
+                newOrderByElements, limitElement);
         result.setTableAliasGenerator(tableAliasGenerator);
         try {
             result.analyze(analyzer);
@@ -514,7 +514,7 @@ public class StmtRewriter {
                     && ((BinaryPredicate) conjunct).getOp() == BinaryPredicate.Operator.EQ) {
                 return;
             }
-            throw new AnalysisException("scalar subquery's unCorrelatedPredicates's operator must be EQ");
+            throw new AnalysisException("scalar subquery's correlatedPredicates's operator must be EQ");
         }
     }
 

--- a/fe/src/main/java/org/apache/doris/analysis/Subquery.java
+++ b/fe/src/main/java/org/apache/doris/analysis/Subquery.java
@@ -158,6 +158,17 @@ public class Subquery extends Expr {
         return new StructType(structFields);
     }
 
+    @Override
+    public boolean isCorrelatedPredicate(List<TupleId> tupleIdList) {
+        List<TupleId> tupleIdFromSubquery = stmt.collectTupleIds();
+        for (TupleId tupleId : tupleIdList) {
+            if (tupleIdFromSubquery.contains(tupleId)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     /**
      * Returns true if the toSql() of the Subqueries is identical. May return false for
      * equivalent statements even due to minor syntactic differences like parenthesis.

--- a/fe/src/main/java/org/apache/doris/catalog/View.java
+++ b/fe/src/main/java/org/apache/doris/catalog/View.java
@@ -157,7 +157,7 @@ public class View extends Table {
             node = (ParseNode) SqlParserUtils.getFirstStmt(parser);
         } catch (Exception e) {
             LOG.info("stmt is {}", inlineViewDef);
-            LOG.info("exception because: {}", e);
+            LOG.info("exception because: ", e);
             LOG.info("msg is {}", inlineViewDef);
             // Do not pass e as the exception cause because it might reveal the existence
             // of tables that the user triggering this load may not have privileges on.

--- a/fe/src/test/java/org/apache/doris/analysis/SelectStmtTest.java
+++ b/fe/src/test/java/org/apache/doris/analysis/SelectStmtTest.java
@@ -19,10 +19,9 @@ package org.apache.doris.analysis;
 
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.qe.ConnectContext;
-import org.apache.doris.rewrite.ExprRewriter;
-import org.apache.doris.thrift.TPrimitiveType;
 import org.apache.doris.utframe.DorisAssert;
 import org.apache.doris.utframe.UtFrameUtils;
+
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -30,7 +29,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import java.io.IOException;
 import java.util.UUID;
 
 public class SelectStmtTest {
@@ -50,9 +48,11 @@ public class SelectStmtTest {
         UtFrameUtils.createMinDorisCluster(runningDir);
         String createTblStmtStr = "create table db1.tbl1(k1 varchar(32), k2 varchar(32), k3 varchar(32), k4 int) "
                 + "AGGREGATE KEY(k1, k2,k3,k4) distributed by hash(k1) buckets 3 properties('replication_num' = '1');";
+        String createBaseAllStmtStr = "create table db1.baseall(k1 int) distributed by hash(k1) "
+                + "buckets 3 properties('replication_num' = '1');";
         dorisAssert = new DorisAssert();
         dorisAssert.withDatabase("db1").useDatabase("db1");
-        dorisAssert.withTable(createTblStmtStr);
+        dorisAssert.withTable(createTblStmtStr).withTable(createBaseAllStmtStr);
     }
 
     @Test
@@ -282,5 +282,17 @@ public class SelectStmtTest {
         stmt8.rewriteExprs(new Analyzer(ctx.getCatalog(), ctx).getExprRewriter());
         Assert.assertTrue(stmt8.toSql().contains("((`t2`.`k1` IS NOT NULL) AND (`t1`.`k1` IS NOT NULL))" +
                 " AND (`t1`.`k1` IS NOT NULL)"));
+    }
+
+    @Test
+    public void testForbiddenCorrelatedSubqueryInHavingClause() throws Exception {
+        String sql = "SELECT k1 FROM baseall GROUP BY k1 HAVING EXISTS(SELECT k4 FROM tbl1 GROUP BY k4 HAVING SUM"
+                + "(baseall.k1) = k4);";
+        try {
+            dorisAssert.query(sql).explainQuery();
+            Assert.fail("The correlated subquery in having clause should be forbidden.");
+        } catch (AnalysisException e) {
+            System.out.println(e.getMessage());
+        }
     }
 }


### PR DESCRIPTION
Fixed #3377

The correlated slot ref should be bound by the agg tuple of outer query.
However, the correlated having clause should not be analyzed correctly so the result is incorrect.
For example: 
```
SELECT k1 FROM test GROUP BY k1 HAVING EXISTS(SELECT k1 FROM baseall GROUP BY k1 HAVING SUM(test.k1) = k1);
```
The correlated predicate is not executed.

The limit offset should be rewritten also when there is subquery in having clause.
For example: 
```
select k1, count(*) cnt from test group by k1 having k1 in (select k1 from baseall order by k1 limit 2) order by k1 limit 5 offset 3;
```
The new stmt should has a limit element with offset.

The view which has subquery in having clause should not be created.
The reason is that the toSql function of query stmt is incorrect when there is subquery in having clause.
So the view def sql is incorrect and could not pass the sql parser.
Now, the view def sql use the original sql directly to fix this error.

Change-Id: If24206a8dee94013225fe7fdd30ab1fb034de34f