### PR TITLE
User ThreadPoolManager to create threadPool and add some prothemus metric about pool

### DIFF
--- a/fe/src/main/java/org/apache/doris/PaloFe.java
+++ b/fe/src/main/java/org/apache/doris/PaloFe.java
@@ -21,6 +21,7 @@ import org.apache.doris.catalog.Catalog;
 import org.apache.doris.common.CommandLineOptions;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.Log4jConfig;
+import org.apache.doris.common.ThreadPoolManager;
 import org.apache.doris.common.Version;
 import org.apache.doris.common.util.JdkUtils;
 import org.apache.doris.http.HttpServer;
@@ -118,6 +119,8 @@ public class PaloFe {
             feServer.start();
             httpServer.start();
             qeService.start();
+
+            ThreadPoolManager.registerAllThreadPoolMetric();
 
             while (true) {
                 Thread.sleep(2000);

--- a/fe/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/src/main/java/org/apache/doris/common/Config.java
@@ -354,6 +354,12 @@ public class Config extends ConfigBase {
      */
     @ConfField public static int publish_version_interval_ms = 10;
 
+
+    /*
+     * The thrift server max worker threads
+     */
+    @ConfField public static int thrift_server_max_worker_threads = 4096;
+
     /*
      * Maximal wait seconds for straggler node in load
      * eg.

--- a/fe/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/src/main/java/org/apache/doris/common/Config.java
@@ -205,6 +205,24 @@ public class Config extends ConfigBase {
     public static int bdbje_lock_timeout_second = 1;
 
     /*
+     * num of thread to handle heartbeat events in heartbeat_mgr.
+     */
+    @ConfField(masterOnly = true)
+    public static int heartbeat_mgr_threads_num = 8;
+
+     /*
+     * blocking queue size to store heartbeat task in heartbeat_mgr.
+     */
+    @ConfField(masterOnly = true)
+    public static int heartbeat_mgr_blocking_queue_size = 1024;
+
+    /*
+    * max num of thread to handle agent task in agent task thread-pool.
+    */
+    @ConfField(masterOnly = true)
+    public static int max_agent_task_threads_num = 4096;
+
+    /*
      * the max txn number which bdbje can rollback when trying to rejoin the group
      */
     @ConfField public static int txn_rollback_limit = 100;
@@ -289,6 +307,12 @@ public class Config extends ConfigBase {
      * num of thread to handle io events in mysql.
      */
     @ConfField public static int mysql_service_io_threads_num = 4;
+
+    /*
+     * max num of thread to handle task in mysql.
+     */
+    @ConfField public static int max_mysql_service_task_threads_num = 4096;
+
     /*
      * Cluster name will be shown as the title of web page
      */
@@ -635,6 +659,11 @@ public class Config extends ConfigBase {
      * Maximal number of connections per user, per FE.
      */
     @ConfField public static int max_conn_per_user = 100;
+
+    /*
+     * Maximal number of thread in connection-scheduler-pool.
+     */
+    @ConfField public static int max_connection_scheduler_threads_num = 4096;
 
     /*
     * The memory_limit for colocote join PlanFragment instance =

--- a/fe/src/main/java/org/apache/doris/common/ThreadPoolManager.java
+++ b/fe/src/main/java/org/apache/doris/common/ThreadPoolManager.java
@@ -18,11 +18,11 @@
 package org.apache.doris.common;
 
 
+import com.google.common.collect.Maps;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -35,7 +35,7 @@ import java.util.concurrent.TimeUnit;
 
 public class ThreadPoolManager {
 
-    private static Map<String, ThreadPoolExecutor> nameToThreadPoolMap = new HashMap<>();
+    private static Map<String, ThreadPoolExecutor> nameToThreadPoolMap = Maps.newConcurrentMap();
 
 
     public static Map<String, ThreadPoolExecutor> getNameToThreadPoolMap() {

--- a/fe/src/main/java/org/apache/doris/common/ThreadPoolManager.java
+++ b/fe/src/main/java/org/apache/doris/common/ThreadPoolManager.java
@@ -37,7 +37,7 @@ import java.util.concurrent.TimeUnit;
 /**
  * ThreadPoolManager is a helper class for construct daemon thread pool with limit thread and memory resource.
  * thread names in thread pool are formatted as poolName-ID, where ID is a unique, sequentially assigned integer.
- * it provide three function to construct thread pool now.
+ * it provide three functions to construct thread pool now.
  *
  * 1. newDaemonCacheThreadPool
  *    Wrapper over newCachedThreadPool with additional maxNumThread limit.
@@ -46,8 +46,8 @@ import java.util.concurrent.TimeUnit;
  * 3. newDaemonThreadPool
  *    Wrapper over ThreadPoolExecutor, user can use it to construct thread pool more flexibly.
  *
- *  All thread pool constructed by ThreadPoolManager will be added to the nameToThreadPool,
- *  so the pool name in the fe must be unique.
+ *  All thread pool constructed by ThreadPoolManager will be added to the nameToThreadPoolMap,
+ *  so the thread pool name in fe must be unique.
  *  when all thread pools are constructed, ThreadPoolManager will register some metrics of all thread pool to MetricRepo,
  *  so we can know the runtime state for all thread pool by prometheus metrics
  */

--- a/fe/src/main/java/org/apache/doris/common/ThreadPoolManager.java
+++ b/fe/src/main/java/org/apache/doris/common/ThreadPoolManager.java
@@ -1,0 +1,113 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.common;
+
+
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.RejectedExecutionHandler;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+
+public class ThreadPoolManager {
+
+    public static Map<String, ExecutorService> nameToThreadPoolMap = new HashMap<>();
+
+    public static ExecutorService newDaemonCacheThreadPool(int maxNumThread, String poolName) {
+        return newDaemonThreadPool(0, maxNumThread, 60L, TimeUnit.SECONDS, new SynchronousQueue(), new LogDiscardPolicy(poolName), poolName);
+    }
+
+    public static ExecutorService newDaemonFixedThreadPool(int numThread, int queueSize, String poolName) {
+       return newDaemonThreadPool(numThread, numThread, 60L ,TimeUnit.SECONDS, new LinkedBlockingQueue<>(queueSize),
+               new BlockedPolicy(poolName, 60), poolName);
+    }
+
+    public static ExecutorService newDaemonThreadPool(int corePoolSize,
+                                               int maximumPoolSize,
+                                               long keepAliveTime,
+                                               TimeUnit unit,
+                                               BlockingQueue<Runnable> workQueue,
+                                               RejectedExecutionHandler handler,
+                                               String poolName) {
+        ThreadFactory threadFactory = namedThreadFactory(poolName);
+        return new ThreadPoolExecutor(corePoolSize, maximumPoolSize, keepAliveTime, unit, workQueue, threadFactory, handler);
+    }
+
+    /**
+     * Create a thread factory that names threads with a prefix and also sets the threads to daemon.
+     */
+    private static ThreadFactory namedThreadFactory(String poolName) {
+        return new ThreadFactoryBuilder().setDaemon(true).setNameFormat(poolName + "-%d").build();
+    }
+
+    /**
+     * A handler for rejected task that discards and log it, used for cached thread pool
+     */
+    static class LogDiscardPolicy implements RejectedExecutionHandler {
+
+        private static final Logger LOG = LogManager.getLogger(LogDiscardPolicy.class);
+
+        private String threadPoolName;
+
+        public LogDiscardPolicy(String threadPoolName) {
+            this.threadPoolName = threadPoolName;
+        }
+
+        @Override
+        public void rejectedExecution(Runnable r, ThreadPoolExecutor executor) {
+           LOG.warn("Task " + r.toString() + " rejected from " + threadPoolName + " " + executor.toString());
+        }
+    }
+
+    /**
+     * A handler for rejected task that try to be blocked until the pool enqueue task succeed or timeout, used for fixed thread pool
+     */
+    static class BlockedPolicy implements RejectedExecutionHandler {
+
+        private static final Logger LOG = LogManager.getLogger(LogDiscardPolicy.class);
+
+        private String threadPoolName;
+
+        private int timeoutSeconds;
+
+        public BlockedPolicy(String threadPoolName, int timeoutSeconds) {
+            this.threadPoolName = threadPoolName;
+            this.timeoutSeconds = timeoutSeconds;
+        }
+
+        @Override
+        public void rejectedExecution(Runnable r, ThreadPoolExecutor executor) {
+            try {
+                executor.getQueue().offer(r, timeoutSeconds, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                LOG.warn("Task " + r.toString() + " wait to enqueue in " + threadPoolName + " " + executor.toString() + " failed");
+            }
+        }
+    }
+}
+

--- a/fe/src/main/java/org/apache/doris/common/ThreadPoolManager.java
+++ b/fe/src/main/java/org/apache/doris/common/ThreadPoolManager.java
@@ -58,7 +58,7 @@ public class ThreadPoolManager {
 
     private static String[] poolMerticTypes = {"pool_size", "active_thread_num", "task_in_queue"};
 
-    private final static Long KEEP_ALIVE_TIME = 60L;
+    private final static long KEEP_ALIVE_TIME = 60L;
 
     public static void registerAllThreadPoolMetric() {
         for (Map.Entry<String, ThreadPoolExecutor> entry : nameToThreadPoolMap.entrySet()) {

--- a/fe/src/main/java/org/apache/doris/common/ThreadPoolManager.java
+++ b/fe/src/main/java/org/apache/doris/common/ThreadPoolManager.java
@@ -25,7 +25,6 @@ import org.apache.logging.log4j.Logger;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.RejectedExecutionHandler;
 import java.util.concurrent.SynchronousQueue;
@@ -36,18 +35,27 @@ import java.util.concurrent.TimeUnit;
 
 public class ThreadPoolManager {
 
-    public static Map<String, ExecutorService> nameToThreadPoolMap = new HashMap<>();
+    private static Map<String, ThreadPoolExecutor> nameToThreadPoolMap = new HashMap<>();
 
-    public static ExecutorService newDaemonCacheThreadPool(int maxNumThread, String poolName) {
+
+    public static Map<String, ThreadPoolExecutor> getNameToThreadPoolMap() {
+        return nameToThreadPoolMap;
+    }
+
+    public static void registerThreadPoolMetric(String poolName, ThreadPoolExecutor threadPool) {
+        nameToThreadPoolMap.put(poolName, threadPool);
+    }
+
+    public static ThreadPoolExecutor newDaemonCacheThreadPool(int maxNumThread, String poolName) {
         return newDaemonThreadPool(0, maxNumThread, 60L, TimeUnit.SECONDS, new SynchronousQueue(), new LogDiscardPolicy(poolName), poolName);
     }
 
-    public static ExecutorService newDaemonFixedThreadPool(int numThread, int queueSize, String poolName) {
+    public static ThreadPoolExecutor newDaemonFixedThreadPool(int numThread, int queueSize, String poolName) {
        return newDaemonThreadPool(numThread, numThread, 60L ,TimeUnit.SECONDS, new LinkedBlockingQueue<>(queueSize),
                new BlockedPolicy(poolName, 60), poolName);
     }
 
-    public static ExecutorService newDaemonThreadPool(int corePoolSize,
+    public static ThreadPoolExecutor newDaemonThreadPool(int corePoolSize,
                                                int maximumPoolSize,
                                                long keepAliveTime,
                                                TimeUnit unit,

--- a/fe/src/main/java/org/apache/doris/common/ThreadPoolManager.java
+++ b/fe/src/main/java/org/apache/doris/common/ThreadPoolManager.java
@@ -58,6 +58,8 @@ public class ThreadPoolManager {
 
     private static String[] poolMerticTypes = {"pool_size", "active_thread_num", "task_in_queue"};
 
+    private final static Long KEEP_ALIVE_TIME = 60L;
+
     public static void registerAllThreadPoolMetric() {
         for (Map.Entry<String, ThreadPoolExecutor> entry : nameToThreadPoolMap.entrySet()) {
             registerThreadPoolMetric(entry.getKey(), entry.getValue());
@@ -89,11 +91,11 @@ public class ThreadPoolManager {
     }
 
     public static ThreadPoolExecutor newDaemonCacheThreadPool(int maxNumThread, String poolName) {
-        return newDaemonThreadPool(0, maxNumThread, 60L, TimeUnit.SECONDS, new SynchronousQueue(), new LogDiscardPolicy(poolName), poolName);
+        return newDaemonThreadPool(0, maxNumThread, KEEP_ALIVE_TIME, TimeUnit.SECONDS, new SynchronousQueue(), new LogDiscardPolicy(poolName), poolName);
     }
 
     public static ThreadPoolExecutor newDaemonFixedThreadPool(int numThread, int queueSize, String poolName) {
-       return newDaemonThreadPool(numThread, numThread, 60L ,TimeUnit.SECONDS, new LinkedBlockingQueue<>(queueSize),
+       return newDaemonThreadPool(numThread, numThread, KEEP_ALIVE_TIME ,TimeUnit.SECONDS, new LinkedBlockingQueue<>(queueSize),
                new BlockedPolicy(poolName, 60), poolName);
     }
 

--- a/fe/src/main/java/org/apache/doris/common/ThriftServer.java
+++ b/fe/src/main/java/org/apache/doris/common/ThriftServer.java
@@ -68,7 +68,6 @@ public class ThriftServer {
           new TThreadedSelectorServer.Args(new TNonblockingServerSocket(port)).protocolFactory(
             new TBinaryProtocol.Factory()).processor(processor);
         ThreadPoolExecutor threadPoolExecutor = ThreadPoolManager.newDaemonCacheThreadPool(Config.thrift_server_max_worker_threads, "thrift-server-pool");
-        ThreadPoolManager.registerThreadPoolMetric("thrift-server-pool", threadPoolExecutor);
         args.executorService(threadPoolExecutor);
         server = new TThreadedSelectorServer(args);
     }
@@ -83,7 +82,6 @@ public class ThriftServer {
           new TThreadPoolServer.Args(new TServerSocket(socketTransportArgs)).protocolFactory(
             new TBinaryProtocol.Factory()).processor(processor);
         ThreadPoolExecutor threadPoolExecutor = ThreadPoolManager.newDaemonCacheThreadPool(Config.thrift_server_max_worker_threads, "thrift-server-pool");
-        ThreadPoolManager.registerThreadPoolMetric("thrift-server-pool", threadPoolExecutor);
         serverArgs.executorService(threadPoolExecutor);
         server = new TThreadPoolServer(serverArgs);
     }

--- a/fe/src/main/java/org/apache/doris/common/ThriftServer.java
+++ b/fe/src/main/java/org/apache/doris/common/ThriftServer.java
@@ -36,6 +36,7 @@ import org.apache.thrift.transport.TTransportException;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.Set;
+import java.util.concurrent.ThreadPoolExecutor;
 
 public class ThriftServer {
     private static final Logger LOG = LogManager.getLogger(ThriftServer.class);
@@ -66,6 +67,9 @@ public class ThriftServer {
         TThreadedSelectorServer.Args args =
           new TThreadedSelectorServer.Args(new TNonblockingServerSocket(port)).protocolFactory(
             new TBinaryProtocol.Factory()).processor(processor);
+        ThreadPoolExecutor threadPoolExecutor = ThreadPoolManager.newDaemonCacheThreadPool(Config.thrift_server_max_worker_threads, "thrift-server-pool");
+        ThreadPoolManager.registerThreadPoolMetric("thrift-server-pool", threadPoolExecutor);
+        args.executorService(threadPoolExecutor);
         server = new TThreadedSelectorServer(args);
     }
 
@@ -78,6 +82,9 @@ public class ThriftServer {
         TThreadPoolServer.Args serverArgs =
           new TThreadPoolServer.Args(new TServerSocket(socketTransportArgs)).protocolFactory(
             new TBinaryProtocol.Factory()).processor(processor);
+        ThreadPoolExecutor threadPoolExecutor = ThreadPoolManager.newDaemonCacheThreadPool(Config.thrift_server_max_worker_threads, "thrift-server-pool");
+        ThreadPoolManager.registerThreadPoolMetric("thrift-server-pool", threadPoolExecutor);
+        serverArgs.executorService(threadPoolExecutor);
         server = new TThreadPoolServer(serverArgs);
     }
 

--- a/fe/src/main/java/org/apache/doris/common/publish/ClusterStatePublisher.java
+++ b/fe/src/main/java/org/apache/doris/common/publish/ClusterStatePublisher.java
@@ -35,6 +35,7 @@ import org.apache.thrift.TException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ThreadPoolExecutor;
 
 // This class intend to publish the state of cluster to backends.
 public class ClusterStatePublisher {
@@ -48,6 +49,7 @@ public class ClusterStatePublisher {
     // Use public for unit test easily.
     public ClusterStatePublisher(SystemInfoService clusterInfoService) {
         this.clusterInfoService = clusterInfoService;
+        ThreadPoolManager.registerThreadPoolMetric("cluster-state-publisher", (ThreadPoolExecutor) executor);
     }
 
     // Fuck singleton.

--- a/fe/src/main/java/org/apache/doris/common/publish/ClusterStatePublisher.java
+++ b/fe/src/main/java/org/apache/doris/common/publish/ClusterStatePublisher.java
@@ -35,21 +35,19 @@ import org.apache.thrift.TException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.ThreadPoolExecutor;
 
 // This class intend to publish the state of cluster to backends.
 public class ClusterStatePublisher {
     private static final Logger LOG = LogManager.getLogger(ClusterStatePublisher.class);
     private static ClusterStatePublisher INSTANCE;
 
-    private ExecutorService executor = ThreadPoolManager.newDaemonFixedThreadPool(16, 256, "cluster-state-publisher");
+    private ExecutorService executor = ThreadPoolManager.newDaemonFixedThreadPool(5, 256, "cluster-state-publisher");
 
     private SystemInfoService clusterInfoService;
 
     // Use public for unit test easily.
     public ClusterStatePublisher(SystemInfoService clusterInfoService) {
         this.clusterInfoService = clusterInfoService;
-        ThreadPoolManager.registerThreadPoolMetric("cluster-state-publisher", (ThreadPoolExecutor) executor);
     }
 
     // Fuck singleton.

--- a/fe/src/main/java/org/apache/doris/common/publish/ClusterStatePublisher.java
+++ b/fe/src/main/java/org/apache/doris/common/publish/ClusterStatePublisher.java
@@ -19,6 +19,7 @@ package org.apache.doris.common.publish;
 
 import org.apache.doris.catalog.Catalog;
 import org.apache.doris.common.ClientPool;
+import org.apache.doris.common.ThreadPoolManager;
 import org.apache.doris.system.Backend;
 import org.apache.doris.system.SystemInfoService;
 import org.apache.doris.thrift.BackendService;
@@ -34,14 +35,13 @@ import org.apache.thrift.TException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 
 // This class intend to publish the state of cluster to backends.
 public class ClusterStatePublisher {
     private static final Logger LOG = LogManager.getLogger(ClusterStatePublisher.class);
     private static ClusterStatePublisher INSTANCE;
 
-    private ExecutorService executor = Executors.newFixedThreadPool(5);
+    private ExecutorService executor = ThreadPoolManager.newDaemonFixedThreadPool(16, 256, "cluster-state-publisher");
 
     private SystemInfoService clusterInfoService;
 

--- a/fe/src/main/java/org/apache/doris/metric/MetricRepo.java
+++ b/fe/src/main/java/org/apache/doris/metric/MetricRepo.java
@@ -22,6 +22,7 @@ import org.apache.doris.alter.AlterJob.JobType;
 import org.apache.doris.catalog.Catalog;
 import org.apache.doris.catalog.TabletInvertedIndex;
 import org.apache.doris.common.Config;
+import org.apache.doris.common.ThreadPoolManager;
 import org.apache.doris.load.EtlJobType;
 import org.apache.doris.load.loadv2.JobState;
 import org.apache.doris.load.loadv2.LoadManager;
@@ -42,6 +43,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.SortedMap;
 import java.util.Timer;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 public final class MetricRepo {
@@ -137,6 +139,33 @@ public final class MetricRepo {
                 .addLabel(new MetricLabel("type", jobType.name()))
                 .addLabel(new MetricLabel("state", "running"));
             PALO_METRIC_REGISTER.addPaloMetrics(gauge);
+        }
+
+        // thread pool
+        Map<String, ThreadPoolExecutor> poolNameToThreadPoolExecutor = ThreadPoolManager.getNameToThreadPoolMap();
+        String[] poolMerticTypes = {"pool_size", "active_thread_num", "task_in_queue"};
+        for (Map.Entry<String, ThreadPoolExecutor> pool : poolNameToThreadPoolExecutor.entrySet()) {
+            for (String poolMetricType : poolMerticTypes) {
+                GaugeMetric<Integer> gauge = new GaugeMetric<Integer>("thread_pool",
+                        "thread_pool statistics") {
+                    @Override
+                    public Integer getValue() {
+                        switch (poolMetricType) {
+                            case "pool_size":
+                                return pool.getValue().getPoolSize();
+                            case "active_thread_num":
+                                return pool.getValue().getActiveCount();
+                            case "task_in_queue":
+                                return pool.getValue().getQueue().size();
+                            default:
+                                return 0;
+                        }
+                    }
+                };
+                gauge.addLabel(new MetricLabel("name", pool.getKey()))
+                        .addLabel(new MetricLabel("type", poolMetricType));
+                PALO_METRIC_REGISTER.addPaloMetrics(gauge);
+            }
         }
 
         // capacity

--- a/fe/src/main/java/org/apache/doris/mysql/nio/NMysqlServer.java
+++ b/fe/src/main/java/org/apache/doris/mysql/nio/NMysqlServer.java
@@ -32,6 +32,7 @@ import org.xnio.channels.AcceptingChannel;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ThreadPoolExecutor;
 
 /**
  * mysql protocol implementation based on nio.
@@ -46,7 +47,7 @@ public class NMysqlServer extends MysqlServer {
     private AcceptingChannel<StreamConnection> server;
 
     // default task service.
-    private ExecutorService taskService = ThreadPoolManager.newDaemonCacheThreadPool(Config.max_mysql_service_task_threads_num, "doris-mysql-nio TASK");
+    private ExecutorService taskService = ThreadPoolManager.newDaemonCacheThreadPool(Config.max_mysql_service_task_threads_num, "doris-mysql-nio-pool");
 
     public NMysqlServer(int port, ConnectScheduler connectScheduler) {
         this.port = port;
@@ -56,6 +57,7 @@ public class NMysqlServer extends MysqlServer {
                 .setExternalExecutorService(taskService).build();
         // connectScheduler only used for idle check.
         this.acceptListener = new AcceptListener(connectScheduler);
+        ThreadPoolManager.registerThreadPoolMetric("doris-mysql-nio-pool", (ThreadPoolExecutor) taskService);
     }
 
     // start MySQL protocol service

--- a/fe/src/main/java/org/apache/doris/mysql/nio/NMysqlServer.java
+++ b/fe/src/main/java/org/apache/doris/mysql/nio/NMysqlServer.java
@@ -32,7 +32,6 @@ import org.xnio.channels.AcceptingChannel;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.ThreadPoolExecutor;
 
 /**
  * mysql protocol implementation based on nio.
@@ -57,7 +56,6 @@ public class NMysqlServer extends MysqlServer {
                 .setExternalExecutorService(taskService).build();
         // connectScheduler only used for idle check.
         this.acceptListener = new AcceptListener(connectScheduler);
-        ThreadPoolManager.registerThreadPoolMetric("doris-mysql-nio-pool", (ThreadPoolExecutor) taskService);
     }
 
     // start MySQL protocol service

--- a/fe/src/main/java/org/apache/doris/mysql/nio/NMysqlServer.java
+++ b/fe/src/main/java/org/apache/doris/mysql/nio/NMysqlServer.java
@@ -16,8 +16,8 @@
 // under the License.
 package org.apache.doris.mysql.nio;
 
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.apache.doris.common.Config;
+import org.apache.doris.common.ThreadPoolManager;
 import org.apache.doris.mysql.MysqlServer;
 import org.apache.doris.qe.ConnectScheduler;
 import org.apache.logging.log4j.LogManager;
@@ -32,7 +32,6 @@ import org.xnio.channels.AcceptingChannel;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 
 /**
  * mysql protocol implementation based on nio.
@@ -47,7 +46,7 @@ public class NMysqlServer extends MysqlServer {
     private AcceptingChannel<StreamConnection> server;
 
     // default task service.
-    private ExecutorService taskService = Executors.newCachedThreadPool((new ThreadFactoryBuilder().setDaemon(false).setNameFormat("doris-mysql-nio TASK").build()));
+    private ExecutorService taskService = ThreadPoolManager.newDaemonCacheThreadPool(Config.max_mysql_service_task_threads_num, "doris-mysql-nio TASK");
 
     public NMysqlServer(int port, ConnectScheduler connectScheduler) {
         this.port = port;

--- a/fe/src/main/java/org/apache/doris/qe/ConnectScheduler.java
+++ b/fe/src/main/java/org/apache/doris/qe/ConnectScheduler.java
@@ -18,6 +18,8 @@
 package org.apache.doris.qe;
 
 import org.apache.doris.catalog.Catalog;
+import org.apache.doris.common.Config;
+import org.apache.doris.common.ThreadPoolManager;
 import org.apache.doris.mysql.MysqlProto;
 import org.apache.doris.mysql.nio.NConnectContext;
 import org.apache.doris.mysql.privilege.PrivPredicate;
@@ -33,7 +35,6 @@ import java.util.Map;
 import java.util.Timer;
 import java.util.TimerTask;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
 
 // 查询请求的调度器
@@ -46,7 +47,7 @@ public class ConnectScheduler {
     private AtomicInteger nextConnectionId;
     private Map<Long, ConnectContext> connectionMap = Maps.newHashMap();
     private Map<String, AtomicInteger> connByUser = Maps.newHashMap();
-    private ExecutorService executor = Executors.newCachedThreadPool();
+    private ExecutorService executor = ThreadPoolManager.newDaemonCacheThreadPool(Config.max_connection_scheduler_threads_num, "connect-scheduler-pool");
 
     // Use a thread to check whether connection is timeout. Because
     // 1. If use a scheduler, the task maybe a huge number when query is messy.

--- a/fe/src/main/java/org/apache/doris/qe/ConnectScheduler.java
+++ b/fe/src/main/java/org/apache/doris/qe/ConnectScheduler.java
@@ -35,6 +35,7 @@ import java.util.Map;
 import java.util.Timer;
 import java.util.TimerTask;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.atomic.AtomicInteger;
 
 // 查询请求的调度器
@@ -61,6 +62,7 @@ public class ConnectScheduler {
         nextConnectionId = new AtomicInteger(0);
         checkTimer = new Timer("ConnectScheduler Check Timer", true);
         checkTimer.scheduleAtFixedRate(new TimeoutChecker(), 0, 1000);
+        ThreadPoolManager.registerThreadPoolMetric("connect-scheduler-pool", (ThreadPoolExecutor) executor);
     }
 
     private class TimeoutChecker extends TimerTask {

--- a/fe/src/main/java/org/apache/doris/qe/ConnectScheduler.java
+++ b/fe/src/main/java/org/apache/doris/qe/ConnectScheduler.java
@@ -35,7 +35,6 @@ import java.util.Map;
 import java.util.Timer;
 import java.util.TimerTask;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.atomic.AtomicInteger;
 
 // 查询请求的调度器
@@ -62,7 +61,6 @@ public class ConnectScheduler {
         nextConnectionId = new AtomicInteger(0);
         checkTimer = new Timer("ConnectScheduler Check Timer", true);
         checkTimer.scheduleAtFixedRate(new TimeoutChecker(), 0, 1000);
-        ThreadPoolManager.registerThreadPoolMetric("connect-scheduler-pool", (ThreadPoolExecutor) executor);
     }
 
     private class TimeoutChecker extends TimerTask {

--- a/fe/src/main/java/org/apache/doris/system/HeartbeatMgr.java
+++ b/fe/src/main/java/org/apache/doris/system/HeartbeatMgr.java
@@ -22,6 +22,7 @@ import org.apache.doris.catalog.FsBroker;
 import org.apache.doris.common.ClientPool;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.FeConstants;
+import org.apache.doris.common.ThreadPoolManager;
 import org.apache.doris.common.util.MasterDaemon;
 import org.apache.doris.common.util.Util;
 import org.apache.doris.http.rest.BootstrapFinishAction;
@@ -53,7 +54,6 @@ import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -73,7 +73,8 @@ public class HeartbeatMgr extends MasterDaemon {
     public HeartbeatMgr(SystemInfoService nodeMgr) {
         super("heartbeat mgr", FeConstants.heartbeat_interval_second * 1000);
         this.nodeMgr = nodeMgr;
-        this.executor = Executors.newCachedThreadPool();
+        this.executor = ThreadPoolManager.newDaemonFixedThreadPool(Config.heartbeat_mgr_threads_num,
+                Config.heartbeat_mgr_blocking_queue_size, "heartbeat-mgr-pool");
         this.heartbeatFlags = new HeartbeatFlags();
     }
 

--- a/fe/src/main/java/org/apache/doris/system/HeartbeatMgr.java
+++ b/fe/src/main/java/org/apache/doris/system/HeartbeatMgr.java
@@ -55,7 +55,6 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
-import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
@@ -76,7 +75,6 @@ public class HeartbeatMgr extends MasterDaemon {
         this.nodeMgr = nodeMgr;
         this.executor = ThreadPoolManager.newDaemonFixedThreadPool(Config.heartbeat_mgr_threads_num,
                 Config.heartbeat_mgr_blocking_queue_size, "heartbeat-mgr-pool");
-        ThreadPoolManager.registerThreadPoolMetric("heartbeat-mgr-pool", (ThreadPoolExecutor) executor);
         this.heartbeatFlags = new HeartbeatFlags();
     }
 

--- a/fe/src/main/java/org/apache/doris/system/HeartbeatMgr.java
+++ b/fe/src/main/java/org/apache/doris/system/HeartbeatMgr.java
@@ -55,6 +55,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
@@ -75,6 +76,7 @@ public class HeartbeatMgr extends MasterDaemon {
         this.nodeMgr = nodeMgr;
         this.executor = ThreadPoolManager.newDaemonFixedThreadPool(Config.heartbeat_mgr_threads_num,
                 Config.heartbeat_mgr_blocking_queue_size, "heartbeat-mgr-pool");
+        ThreadPoolManager.registerThreadPoolMetric("heartbeat-mgr-pool", (ThreadPoolExecutor) executor);
         this.heartbeatFlags = new HeartbeatFlags();
     }
 

--- a/fe/src/main/java/org/apache/doris/task/AgentTaskExecutor.java
+++ b/fe/src/main/java/org/apache/doris/task/AgentTaskExecutor.java
@@ -17,11 +17,14 @@
 
 package org.apache.doris.task;
 
+import org.apache.doris.common.Config;
+import org.apache.doris.common.ThreadPoolManager;
+
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 
 public class AgentTaskExecutor {
-    private static final ExecutorService EXECUTOR = Executors.newCachedThreadPool();
+
+    private static final ExecutorService EXECUTOR = ThreadPoolManager.newDaemonCacheThreadPool(Config.max_agent_task_threads_num, "agent-task-pool");
 
     public AgentTaskExecutor() {
     }

--- a/fe/src/main/java/org/apache/doris/task/AgentTaskExecutor.java
+++ b/fe/src/main/java/org/apache/doris/task/AgentTaskExecutor.java
@@ -21,14 +21,13 @@ import org.apache.doris.common.Config;
 import org.apache.doris.common.ThreadPoolManager;
 
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.ThreadPoolExecutor;
 
 public class AgentTaskExecutor {
 
     private static final ExecutorService EXECUTOR = ThreadPoolManager.newDaemonCacheThreadPool(Config.max_agent_task_threads_num, "agent-task-pool");
 
     public AgentTaskExecutor() {
-        ThreadPoolManager.registerThreadPoolMetric("agent-task-pool", (ThreadPoolExecutor) EXECUTOR);
+
     }
     
     public static void submit(AgentBatchTask task) {

--- a/fe/src/main/java/org/apache/doris/task/AgentTaskExecutor.java
+++ b/fe/src/main/java/org/apache/doris/task/AgentTaskExecutor.java
@@ -21,12 +21,14 @@ import org.apache.doris.common.Config;
 import org.apache.doris.common.ThreadPoolManager;
 
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ThreadPoolExecutor;
 
 public class AgentTaskExecutor {
 
     private static final ExecutorService EXECUTOR = ThreadPoolManager.newDaemonCacheThreadPool(Config.max_agent_task_threads_num, "agent-task-pool");
 
     public AgentTaskExecutor() {
+        ThreadPoolManager.registerThreadPoolMetric("agent-task-pool", (ThreadPoolExecutor) EXECUTOR);
     }
     
     public static void submit(AgentBatchTask task) {

--- a/fe/src/main/java/org/apache/doris/task/PullLoadJobMgr.java
+++ b/fe/src/main/java/org/apache/doris/task/PullLoadJobMgr.java
@@ -18,6 +18,7 @@
 package org.apache.doris.task;
 
 import org.apache.doris.common.Status;
+import org.apache.doris.common.ThreadPoolManager;
 import org.apache.doris.common.UserException;
 import org.apache.doris.thrift.TStatusCode;
 
@@ -30,7 +31,6 @@ import org.apache.logging.log4j.Logger;
 import java.util.Map;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.locks.ReentrantLock;
 
 @Deprecated
@@ -42,11 +42,12 @@ public class PullLoadJobMgr {
     private final Map<Long, PullLoadJob> idToJobs = Maps.newHashMap();
 
     private final BlockingQueue<PullLoadTask> pendingTasks = Queues.newLinkedBlockingQueue();
-    private ExecutorService executorService = Executors.newCachedThreadPool();
+    private ExecutorService executorService;
 
     private int concurrency = 10;
 
     public PullLoadJobMgr() {
+        executorService = ThreadPoolManager.newDaemonCacheThreadPool(concurrency, "pull-load-job-mgr");
     }
 
     /**

--- a/fe/src/main/java/org/apache/doris/task/PullLoadJobMgr.java
+++ b/fe/src/main/java/org/apache/doris/task/PullLoadJobMgr.java
@@ -31,7 +31,6 @@ import org.apache.logging.log4j.Logger;
 import java.util.Map;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.locks.ReentrantLock;
 
 @Deprecated
@@ -49,7 +48,6 @@ public class PullLoadJobMgr {
 
     public PullLoadJobMgr() {
         executorService = ThreadPoolManager.newDaemonCacheThreadPool(concurrency, "pull-load-job-mgr");
-        ThreadPoolManager.registerThreadPoolMetric("pull-load-job-mgr", (ThreadPoolExecutor) executorService);
     }
 
     /**

--- a/fe/src/main/java/org/apache/doris/task/PullLoadJobMgr.java
+++ b/fe/src/main/java/org/apache/doris/task/PullLoadJobMgr.java
@@ -31,6 +31,7 @@ import org.apache.logging.log4j.Logger;
 import java.util.Map;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.locks.ReentrantLock;
 
 @Deprecated
@@ -48,6 +49,7 @@ public class PullLoadJobMgr {
 
     public PullLoadJobMgr() {
         executorService = ThreadPoolManager.newDaemonCacheThreadPool(concurrency, "pull-load-job-mgr");
+        ThreadPoolManager.registerThreadPoolMetric("pull-load-job-mgr", (ThreadPoolExecutor) executorService);
     }
 
     /**

--- a/fe/src/test/java/org/apache/doris/common/ThreadPoolManagerTest.java
+++ b/fe/src/test/java/org/apache/doris/common/ThreadPoolManagerTest.java
@@ -17,11 +17,13 @@
 
 package org.apache.doris.common;
 
+import org.apache.doris.metric.Metric;
+import org.apache.doris.metric.MetricRepo;
 import org.junit.Assert;
 import org.junit.Test;
 
-import java.util.Map;
 import java.util.concurrent.ThreadPoolExecutor;
+import java.util.List;
 
 public class ThreadPoolManagerTest {
 
@@ -30,10 +32,13 @@ public class ThreadPoolManagerTest {
         ThreadPoolExecutor testCachedPool = ThreadPoolManager.newDaemonCacheThreadPool(2, "test_cache_pool");
         ThreadPoolExecutor testFixedThreaddPool = ThreadPoolManager.newDaemonFixedThreadPool(2, 2,
                 "test_fixed_thread_pool");
+
         ThreadPoolManager.registerThreadPoolMetric("test_cache_pool", testCachedPool);
         ThreadPoolManager.registerThreadPoolMetric("test_fixed_thread_pool", testFixedThreaddPool);
-        Map<String, ThreadPoolExecutor> threadPoolExecutorMap = ThreadPoolManager.getNameToThreadPoolMap();
-        Assert.assertEquals(2, threadPoolExecutorMap.size());
+
+        List<Metric> metricList = MetricRepo.getMetricsByName("thread_pool");
+
+        Assert.assertEquals(6, metricList.size());
         Assert.assertEquals(ThreadPoolManager.LogDiscardPolicy.class, testCachedPool.getRejectedExecutionHandler().getClass());
         Assert.assertEquals(ThreadPoolManager.BlockedPolicy.class, testFixedThreaddPool.getRejectedExecutionHandler().getClass());
 
@@ -75,6 +80,7 @@ public class ThreadPoolManagerTest {
         Assert.assertEquals(0, testFixedThreaddPool.getActiveCount());
         Assert.assertEquals(0, testFixedThreaddPool.getQueue().size());
         Assert.assertEquals(4, testFixedThreaddPool.getCompletedTaskCount());
+
 
     }
 }

--- a/fe/src/test/java/org/apache/doris/common/ThreadPoolManagerTest.java
+++ b/fe/src/test/java/org/apache/doris/common/ThreadPoolManagerTest.java
@@ -1,7 +1,80 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package org.apache.doris.common;
 
-/**
- * Created by mi on 20-4-22.
- */
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Map;
+import java.util.concurrent.ThreadPoolExecutor;
+
 public class ThreadPoolManagerTest {
+
+    @Test
+    public void testNormal() throws InterruptedException {
+        ThreadPoolExecutor testCachedPool = ThreadPoolManager.newDaemonCacheThreadPool(2, "test_cache_pool");
+        ThreadPoolExecutor testFixedThreaddPool = ThreadPoolManager.newDaemonFixedThreadPool(2, 2,
+                "test_fixed_thread_pool");
+        ThreadPoolManager.registerThreadPoolMetric("test_cache_pool", testCachedPool);
+        ThreadPoolManager.registerThreadPoolMetric("test_fixed_thread_pool", testFixedThreaddPool);
+        Map<String, ThreadPoolExecutor> threadPoolExecutorMap = ThreadPoolManager.getNameToThreadPoolMap();
+        Assert.assertEquals(2, threadPoolExecutorMap.size());
+        Assert.assertEquals(ThreadPoolManager.LogDiscardPolicy.class, testCachedPool.getRejectedExecutionHandler().getClass());
+        Assert.assertEquals(ThreadPoolManager.BlockedPolicy.class, testFixedThreaddPool.getRejectedExecutionHandler().getClass());
+
+        Runnable task = () -> {
+            try {
+                Thread.sleep(500);
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        };
+        for (int i = 0; i < 4; i++) {
+            testCachedPool.submit(task);
+        }
+
+        Assert.assertEquals(2, testCachedPool.getPoolSize());
+        Assert.assertEquals(2, testCachedPool.getActiveCount());
+        Assert.assertEquals(0, testCachedPool.getQueue().size());
+        Assert.assertEquals(0, testCachedPool.getCompletedTaskCount());
+
+        Thread.sleep(500);
+
+        Assert.assertEquals(2, testCachedPool.getPoolSize());
+        Assert.assertEquals(0, testCachedPool.getActiveCount());
+        Assert.assertEquals(0, testCachedPool.getQueue().size());
+        Assert.assertEquals(2, testCachedPool.getCompletedTaskCount());
+
+        for (int i = 0; i < 4; i++) {
+            testFixedThreaddPool.submit(task);
+        }
+
+        Assert.assertEquals(2, testFixedThreaddPool.getPoolSize());
+        Assert.assertEquals(2, testFixedThreaddPool.getActiveCount());
+        Assert.assertEquals(2, testFixedThreaddPool.getQueue().size());
+        Assert.assertEquals(0, testFixedThreaddPool.getCompletedTaskCount());
+
+        Thread.sleep(2000);
+
+        Assert.assertEquals(2, testFixedThreaddPool.getPoolSize());
+        Assert.assertEquals(0, testFixedThreaddPool.getActiveCount());
+        Assert.assertEquals(0, testFixedThreaddPool.getQueue().size());
+        Assert.assertEquals(4, testFixedThreaddPool.getCompletedTaskCount());
+
+    }
 }

--- a/fe/src/test/java/org/apache/doris/common/ThreadPoolManagerTest.java
+++ b/fe/src/test/java/org/apache/doris/common/ThreadPoolManagerTest.java
@@ -1,0 +1,7 @@
+package org.apache.doris.common;
+
+/**
+ * Created by mi on 20-4-22.
+ */
+public class ThreadPoolManagerTest {
+}

--- a/fe/src/test/java/org/apache/doris/load/routineload/RoutineLoadSchedulerTest.java
+++ b/fe/src/test/java/org/apache/doris/load/routineload/RoutineLoadSchedulerTest.java
@@ -23,6 +23,7 @@ import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.common.DdlException;
 import org.apache.doris.common.LoadException;
 import org.apache.doris.common.MetaNotFoundException;
+import org.apache.doris.common.ThreadPoolManager;
 import org.apache.doris.common.jmockit.Deencapsulation;
 import org.apache.doris.load.RoutineLoadDesc;
 import org.apache.doris.planner.StreamLoadPlanner;
@@ -164,7 +165,7 @@ public class RoutineLoadSchedulerTest {
         RoutineLoadTaskScheduler routineLoadTaskScheduler = new RoutineLoadTaskScheduler();
         routineLoadTaskScheduler.setInterval(5000);
 
-        ExecutorService executorService = Executors.newFixedThreadPool(2);
+        ExecutorService executorService = ThreadPoolManager.newDaemonFixedThreadPool(2, 2, "routine-load-task-scheduler");
         executorService.submit(routineLoadScheduler);
         executorService.submit(routineLoadTaskScheduler);
 


### PR DESCRIPTION
This PR to to resolve the problem that the usage of CachedPool or FixedThreadPool which not limit thread num or blocked task num  may cause jvm process crashed due to too much thread or oom, we must construct threadpool explicitly, and know the runtime state about threadpool. 