### PR TITLE
[Load] Add more info in SHOW LOAD result

### DIFF
--- a/be/src/agent/heartbeat_server.cpp
+++ b/be/src/agent/heartbeat_server.cpp
@@ -153,6 +153,10 @@ Status HeartbeatServer::_heartbeat(const TMasterInfo& master_info) {
         heartbeat_flags->update(master_info.heartbeat_flags);
     }
 
+    if (master_info.__isset.backend_id) {
+        _master_info->__set_backend_id(master_info.backend_id);
+    }
+
     if (need_report) {
         LOG(INFO) << "Master FE is changed or restarted. report tablet and disk info immediately";
         _olap_engine->trigger_report();

--- a/be/src/runtime/fragment_mgr.cpp
+++ b/be/src/runtime/fragment_mgr.cpp
@@ -37,6 +37,7 @@
 #include "util/url_coding.h"
 #include "runtime/client_cache.h"
 #include "runtime/descriptors.h"
+#include "gen_cpp/HeartbeatService.h"
 #include "gen_cpp/PaloInternalService_types.h"
 #include "gen_cpp/PlanNodes_types.h"
 #include "gen_cpp/Types_types.h"

--- a/be/src/runtime/fragment_mgr.cpp
+++ b/be/src/runtime/fragment_mgr.cpp
@@ -321,6 +321,10 @@ void FragmentExecState::coordinator_callback(
         params.__isset.error_log = (params.error_log.size() > 0);
     }
 
+    if (_exec_env->master_info()->__isset.backend_id) {
+        params.__set_backend_id(_exec_env->master_info()->backend_id);
+    }
+
     TReportExecStatusResult res;
     Status rpc_status;
 

--- a/docs/documentation/cn/administrator-guide/load-data/broker-load-manual.md
+++ b/docs/documentation/cn/administrator-guide/load-data/broker-load-manual.md
@@ -278,7 +278,7 @@ mysql> show load order by createtime desc limit 1\G
  LoadStartTime: 2019-07-27 11:46:44
 LoadFinishTime: 2019-07-27 11:50:16
            URL: http://192.168.1.1:8040/api/_load_error_log?file=__shard_4/error_log_insert_stmt_4bb00753932c491a-a6da6e2725415317_4bb00753932c491a_a6da6e2725415317
-    JobDetails: {"ScannedRows":28133395,"TaskNumber":1,"FileNumber":1,"FileSize":200000}
+    JobDetails: {"Unfinished backends":{"9c3441027ff948a0-8287923329a2b6a7":[10002]},"ScannedRows":2390016,"TaskNumber":1,"All backends":{"9c3441027ff948a0-8287923329a2b6a7":[10002]},"FileNumber":1,"FileSize":1073741824}
 ```
 
 下面主要介绍了查看导入命令返回结果集中参数意义：
@@ -357,9 +357,11 @@ LoadFinishTime: 2019-07-27 11:50:16
 
 + JobDetails
 
-    显示一些作业的详细运行状态。包括导入文件的个数、总大小（字节）、子任务个数、已处理的原始行数等。
+    显示一些作业的详细运行状态。包括导入文件的个数、总大小（字节）、子任务个数、已处理的原始行数，运行子任务的 BE 节点 Id，未完成的 BE 节点 Id。
 
-    ```{"ScannedRows":139264,"TaskNumber":1,"FileNumber":1,"FileSize":940754064}```
+    ```
+    {"Unfinished backends":{"9c3441027ff948a0-8287923329a2b6a7":[10002]},"ScannedRows":2390016,"TaskNumber":1,"All backends":{"9c3441027ff948a0-8287923329a2b6a7":[10002]},"FileNumber":1,"FileSize":1073741824}
+    ```
 
     其中已处理的原始行数，每 5 秒更新一次。该行数仅用于展示当前的进度，不代表最终实际的处理行数。实际处理行数以 EtlInfo 中显示的为准。
 

--- a/docs/documentation/en/administrator-guide/load-data/broker-load-manual_EN.md
+++ b/docs/documentation/en/administrator-guide/load-data/broker-load-manual_EN.md
@@ -270,7 +270,7 @@ mysql> show load order by createtime desc limit 1\G
  LoadStartTime: 2019-07-27 11:46:44
 LoadFinishTime: 2019-07-27 11:50:16
            URL: http://192.168.1.1:8040/api/_load_error_log?file=__shard_4/error_log_insert_stmt_4bb00753932c491a-a6da6e2725415317_4bb00753932c491a_a6da6e2725415317
-    JobDetails: {"ScannedRows":28133395,"TaskNumber":1,"FileNumber":1,"FileSize":200000}
+    JobDetails: {"Unfinished backends":{"9c3441027ff948a0-8287923329a2b6a7":[10002]},"ScannedRows":2390016,"TaskNumber":1,"All backends":{"9c3441027ff948a0-8287923329a2b6a7":[10002]},"FileNumber":1,"FileSize":1073741824}
 ```
 
 The following is mainly about the significance of viewing the parameters in the return result set of the import command:
@@ -343,6 +343,16 @@ The following is mainly about the significance of viewing the parameters in the 
 + URL
 
 	The error data sample of the import task can be obtained by accessing the URL address. When there is no error data in this import, the URL field is N/A.
+
++ JobDetails
+
+    Display some details of the running status of the job. Including file number, total file size(Bytes), num of sub tasks, scanned rows, related backend ids and unfinished backend ids.
+
+    ```
+    {"Unfinished backends":{"9c3441027ff948a0-8287923329a2b6a7":[10002]},"ScannedRows":2390016,"TaskNumber":1,"All backends":{"9c3441027ff948a0-8287923329a2b6a7":[10002]},"FileNumber":1,"FileSize":1073741824}
+    ```
+
+    This info will be updated every 5 seconds. the ScannedRows only for displaying the job progress, not indicate the real numbers.
 
 ### Cancel load
 

--- a/fe/src/main/java/org/apache/doris/load/loadv2/LoadJob.java
+++ b/fe/src/main/java/org/apache/doris/load/loadv2/LoadJob.java
@@ -33,6 +33,7 @@ import org.apache.doris.common.MetaNotFoundException;
 import org.apache.doris.common.UserException;
 import org.apache.doris.common.io.Text;
 import org.apache.doris.common.io.Writable;
+import org.apache.doris.common.util.DebugUtil;
 import org.apache.doris.common.util.LogBuilder;
 import org.apache.doris.common.util.LogKey;
 import org.apache.doris.common.util.TimeUtils;
@@ -138,30 +139,41 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
         // load task id -> fragment id -> rows count
         private Table<TUniqueId, TUniqueId, Long> counterTbl = HashBasedTable.create();
 
+        // load task id -> unfinished backend id list
+        private Map<TUniqueId, List<Long>> unfinishedBackendIds = Maps.newHashMap();
+        // load task id -> all backend id list
+        private Map<TUniqueId, List<Long>> allBackendIds = Maps.newHashMap();
+
         // number of file to be loaded
         public int fileNum = 0;
         public long totalFileSizeB = 0;
 
         // init the statistic of specified load task
-        public synchronized void initLoad(TUniqueId loadId, Set<TUniqueId> fragmentIds) {
+        public synchronized void initLoad(TUniqueId loadId, Set<TUniqueId> fragmentIds, List<Long> relatedBackendIds) {
             counterTbl.rowMap().remove(loadId);
             for (TUniqueId fragId : fragmentIds) {
                 counterTbl.put(loadId, fragId, 0L);
             }
+            allBackendIds.put(loadId, relatedBackendIds);
+            // need to get a copy of relatedBackendIds, so that when we modify the "relatedBackendIds" in
+            // allBackendIds, the list in unfinishedBackendIds will not be changed.
+            unfinishedBackendIds.put(loadId, Lists.newArrayList(relatedBackendIds));
         }
 
         public synchronized void removeLoad(TUniqueId loadId) {
             counterTbl.rowMap().remove(loadId);
+            unfinishedBackendIds.remove(loadId);
+            allBackendIds.remove(loadId);
         }
 
-        public synchronized void updateLoad(TUniqueId loadId, TUniqueId fragmentId, long rows) {
+        public synchronized void updateLoadProgress(long beId, TUniqueId loadId, TUniqueId fragmentId, long rows,
+                boolean isDone) {
             if (counterTbl.contains(loadId, fragmentId)) {
                 counterTbl.put(loadId, fragmentId, rows);
             }
-        }
-
-        public synchronized void clearAllLoads() {
-            counterTbl.clear();
+            if (isDone && unfinishedBackendIds.containsKey(loadId)) {
+                unfinishedBackendIds.get(loadId).remove(beId);
+            }
         }
 
         public synchronized String toJson() {
@@ -175,8 +187,19 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
             details.put("FileNumber", fileNum);
             details.put("FileSize", totalFileSizeB);
             details.put("TaskNumber", counterTbl.rowMap().size());
+            details.put("TaskNumber", counterTbl.rowMap().size());
+            details.put("Unfinished backends", getPrintableMap(unfinishedBackendIds));
+            details.put("All backends", getPrintableMap(allBackendIds));
             Gson gson = new Gson();
             return gson.toJson(details);
+        }
+
+        private Map<String, List<Long>> getPrintableMap(Map<TUniqueId, List<Long>> map) {
+            Map<String, List<Long>> newMap = Maps.newHashMap();
+            for (Map.Entry<TUniqueId, List<Long>> entry : map.entrySet()) {
+                newMap.put(DebugUtil.printId(entry.getKey()), entry.getValue());
+            }
+            return newMap;
         }
     }
 
@@ -254,12 +277,12 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
         return transactionId;
     }
 
-    public void initScannedRows(TUniqueId loadId, Set<TUniqueId> fragmentIds) {
-        loadStatistic.initLoad(loadId, fragmentIds);
+    public void initLoadProgress(TUniqueId loadId, Set<TUniqueId> fragmentIds, List<Long> relatedBackendIds) {
+        loadStatistic.initLoad(loadId, fragmentIds, relatedBackendIds);
     }
 
-    public void updateScannedRows(TUniqueId loadId, TUniqueId fragmentId, long scannedRows) {
-        loadStatistic.updateLoad(loadId, fragmentId, scannedRows);
+    public void updateProgess(Long beId, TUniqueId loadId, TUniqueId fragmentId, long scannedRows, boolean isDone) {
+        loadStatistic.updateLoadProgress(beId, loadId, fragmentId, scannedRows, isDone);
     }
 
     public void setLoadFileInfo(int fileNum, long fileSize) {

--- a/fe/src/main/java/org/apache/doris/load/loadv2/LoadJob.java
+++ b/fe/src/main/java/org/apache/doris/load/loadv2/LoadJob.java
@@ -166,13 +166,13 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
             allBackendIds.remove(loadId);
         }
 
-        public synchronized void updateLoadProgress(long beId, TUniqueId loadId, TUniqueId fragmentId, long rows,
-                boolean isDone) {
+        public synchronized void updateLoadProgress(long backendId, TUniqueId loadId, TUniqueId fragmentId,
+                long rows, boolean isDone) {
             if (counterTbl.contains(loadId, fragmentId)) {
                 counterTbl.put(loadId, fragmentId, rows);
             }
             if (isDone && unfinishedBackendIds.containsKey(loadId)) {
-                unfinishedBackendIds.get(loadId).remove(beId);
+                unfinishedBackendIds.get(loadId).remove(backendId);
             }
         }
 

--- a/fe/src/main/java/org/apache/doris/load/loadv2/LoadManager.java
+++ b/fe/src/main/java/org/apache/doris/load/loadv2/LoadManager.java
@@ -582,17 +582,19 @@ public class LoadManager implements Writable{
         return false;
     }
 
-    public void initJobScannedRows(Long jobId, TUniqueId loadId, Set<TUniqueId> fragmentIds) {
+    public void initJobProgress(Long jobId, TUniqueId loadId, Set<TUniqueId> fragmentIds,
+            List<Long> relatedBackendIds) {
         LoadJob job = idToLoadJob.get(jobId);
         if (job != null) {
-            job.initScannedRows(loadId, fragmentIds);
+            job.initLoadProgress(loadId, fragmentIds, relatedBackendIds);
         }
     }
 
-    public void updateJobScannedRows(Long jobId, TUniqueId loadId, TUniqueId fragmentId, long scannedRows) {
+    public void updateJobPrgress(Long jobId, Long beId, TUniqueId loadId, TUniqueId fragmentId,
+            long scannedRows, boolean isDone) {
         LoadJob job = idToLoadJob.get(jobId);
         if (job != null) {
-            job.updateScannedRows(loadId, fragmentId, scannedRows);
+            job.updateProgess(beId, loadId, fragmentId, scannedRows, isDone);
         }
     }
 

--- a/fe/src/main/java/org/apache/doris/system/HeartbeatMgr.java
+++ b/fe/src/main/java/org/apache/doris/system/HeartbeatMgr.java
@@ -225,6 +225,7 @@ public class HeartbeatMgr extends MasterDaemon {
                 copiedMasterInfo.setBackend_ip(backend.getHost());
                 long flags = heartbeatFlags.getHeartbeatFlags();
                 copiedMasterInfo.setHeartbeat_flags(flags);
+                copiedMasterInfo.setBackend_id(backendId);
                 THeartbeatResult result = client.heartbeat(copiedMasterInfo);
 
                 ok = true;

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -374,6 +374,8 @@ struct TReportExecStatusParams {
   14: optional list<Types.TTabletCommitInfo> commitInfos
 
   15: optional i64 loaded_rows
+
+  16: optional i64 backend_id
 }
 
 struct TFeResult {

--- a/gensrc/thrift/HeartbeatService.thrift
+++ b/gensrc/thrift/HeartbeatService.thrift
@@ -28,6 +28,7 @@ struct TMasterInfo {
     5: optional string backend_ip
     6: optional Types.TPort http_port
     7: optional i64 heartbeat_flags
+    8: optional i64 backend_id
 }
 
 struct TBackendInfo {


### PR DESCRIPTION
Fix #3390
This CL add more info in `JobDetails` column of `SHOW LOAD` result for Broker Load Job.

For example:
```
{
	"Unfinished backends": {
		"9c3441027ff948a0-8287923329a2b6a7": [10002]
	},
        "All backends": {
		"9c3441027ff948a0-8287923329a2b6a7": [10002, 10004, 10006]
	},
	"ScannedRows": 2390016,
	"TaskNumber": 1,
	"FileNumber": 1,
	"FileSize": 1073741824
}
```

2 newly added keys:

`Unfinished backends` indicates the BE which task on them are not finished.
`All backends` indicates the BE which this job has tasks on it.

One more thing, I pass the Backend Id along with the heartbeat msg from FE to BE, so that BE can
know the Id of themselves.