### PR TITLE
Remove redunant call function _wait_in_flight_packet()

### DIFF
--- a/be/src/exec/tablet_sink.cpp
+++ b/be/src/exec/tablet_sink.cpp
@@ -155,7 +155,6 @@ Status NodeChannel::close(RuntimeState* state) {
 }
 
 Status NodeChannel::_close(RuntimeState* state) {
-    RETURN_IF_ERROR(_wait_in_flight_packet());
     return _send_cur_batch(true);
 }
 


### PR DESCRIPTION
The function `_wait_in_flight_packet` has been called in `_send_cur_batch`. No need to call twice.