### PR TITLE
[Bug] Fix bug that NPE when get table's storage format

### DIFF
--- a/fe/src/main/java/org/apache/doris/alter/SchemaChangeHandler.java
+++ b/fe/src/main/java/org/apache/doris/alter/SchemaChangeHandler.java
@@ -945,7 +945,7 @@ public class SchemaChangeHandler extends AlterHandler {
             } else if (hasIndexChange) {
                 needAlter = true;
             } else if (storageFormat == TStorageFormat.V2) {
-                if (olapTable.getTableProperty().getStorageFormat() != TStorageFormat.V2) {
+                if (olapTable.getStorageFormat() != TStorageFormat.V2) {
                     needAlter = true;
                 }
             }

--- a/fe/src/main/java/org/apache/doris/catalog/Catalog.java
+++ b/fe/src/main/java/org/apache/doris/catalog/Catalog.java
@@ -3072,7 +3072,7 @@ public class Catalog {
                     bfColumns, olapTable.getBfFpp(),
                     tabletIdSet, olapTable.getCopiedIndexes(),
                     singlePartitionDesc.isInMemory(),
-                    olapTable.getTableProperty().getStorageFormat());
+                    olapTable.getStorageFormat());
 
             // check again
             db.writeLock();
@@ -6215,7 +6215,7 @@ public class Catalog {
                         tabletIdSet,
                         copiedTbl.getCopiedIndexes(),
                         copiedTbl.isInMemory(),
-                        copiedTbl.getTableProperty().getStorageFormat());
+                        copiedTbl.getStorageFormat());
                 newPartitions.add(newPartition);
             }
         } catch (DdlException e) {


### PR DESCRIPTION
the OlapTable's tableProperty field may be null, we should handle it carefully.

This is error-prone, I will try to refactor it later.

Fix #3400