### PR TITLE
[Thirdparty] Upgrade Google Guava lib to 29.0-jre

### DIFF
--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -164,7 +164,7 @@ under the License.
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>15.0</version>
+            <version>29.0-jre</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-core -->

--- a/fe/src/main/java/org/apache/doris/analysis/AggregateInfo.java
+++ b/fe/src/main/java/org/apache/doris/analysis/AggregateInfo.java
@@ -21,7 +21,7 @@ import org.apache.doris.common.AnalysisException;
 import org.apache.doris.planner.DataPartition;
 import org.apache.doris.thrift.TPartitionType;
 
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 
@@ -767,7 +767,7 @@ public final class AggregateInfo extends AggregateInfoBase {
 
     public String debugString() {
         StringBuilder out = new StringBuilder(super.debugString());
-        out.append(Objects.toStringHelper(this)
+        out.append(MoreObjects.toStringHelper(this)
                 .add("phase", aggPhase_)
                 .add("intermediate_smap", intermediateTupleSmap_.debugString())
                 .add("output_smap", outputTupleSmap_.debugString())

--- a/fe/src/main/java/org/apache/doris/analysis/AggregateInfoBase.java
+++ b/fe/src/main/java/org/apache/doris/analysis/AggregateInfoBase.java
@@ -17,18 +17,19 @@
 
 package org.apache.doris.analysis;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import org.apache.doris.catalog.AggregateFunction;
 import org.apache.doris.catalog.FunctionSet;
 import org.apache.doris.catalog.Type;
+
+import com.google.common.base.MoreObjects;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.base.Objects;
-import com.google.common.base.Preconditions;
-import com.google.common.collect.Lists;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Base class for AggregateInfo and AnalyticInfo containing the intermediate and output
@@ -213,7 +214,7 @@ public abstract class AggregateInfoBase {
 
     public String debugString() {
         StringBuilder out = new StringBuilder();
-        out.append(Objects.toStringHelper(this)
+        out.append(MoreObjects.toStringHelper(this)
                 .add("grouping_exprs", Expr.debugString(groupingExprs_))
                 .add("aggregate_exprs", Expr.debugString(aggregateExprs_))
                 .add("intermediate_tuple", (intermediateTupleDesc_ == null)

--- a/fe/src/main/java/org/apache/doris/analysis/AnalyticExpr.java
+++ b/fe/src/main/java/org/apache/doris/analysis/AnalyticExpr.java
@@ -28,7 +28,7 @@ import org.apache.doris.common.TreeNode;
 import org.apache.doris.thrift.TExprNode;
 
 import com.google.common.base.Joiner;
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 
@@ -177,7 +177,7 @@ public class AnalyticExpr extends Expr {
 
     @Override
     public String debugString() {
-        return Objects.toStringHelper(this)
+        return MoreObjects.toStringHelper(this)
                .add("fn", getFnCall())
                .add("window", window)
                .addValue(super.debugString())

--- a/fe/src/main/java/org/apache/doris/analysis/AnalyticInfo.java
+++ b/fe/src/main/java/org/apache/doris/analysis/AnalyticInfo.java
@@ -19,7 +19,7 @@ package org.apache.doris.analysis;
 
 import org.apache.doris.catalog.Type;
 
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 
@@ -173,7 +173,7 @@ public final class AnalyticInfo extends AggregateInfoBase {
     @Override
     public String debugString() {
         StringBuilder out = new StringBuilder(super.debugString());
-        out.append(Objects.toStringHelper(this)
+        out.append(MoreObjects.toStringHelper(this)
                 .add("analytic_exprs", Expr.debugString(analyticExprs_))
                 .add("smap", analyticTupleSmap_.debugString())
                 .toString());

--- a/fe/src/main/java/org/apache/doris/analysis/Expr.java
+++ b/fe/src/main/java/org/apache/doris/analysis/Expr.java
@@ -30,6 +30,7 @@ import org.apache.doris.thrift.TExprNode;
 import org.apache.doris.thrift.TExprOpcode;
 
 import com.google.common.base.Joiner;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
@@ -1301,7 +1302,7 @@ abstract public class Expr extends TreeNode<Expr> implements ParseNode, Cloneabl
 
     @Override
     public String toString() {
-        return Objects.toStringHelper(this.getClass()).add("id", id).add("type", type).add("sel",
+        return MoreObjects.toStringHelper(this.getClass()).add("id", id).add("type", type).add("sel",
           selectivity).add("#distinct", numDistinctValues).add("scale", outputScale).toString();
     }
 

--- a/fe/src/main/java/org/apache/doris/analysis/FunctionCallExpr.java
+++ b/fe/src/main/java/org/apache/doris/analysis/FunctionCallExpr.java
@@ -34,6 +34,7 @@ import org.apache.doris.thrift.TExprNode;
 import org.apache.doris.thrift.TExprNodeType;
 
 import com.google.common.base.Joiner;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
@@ -194,7 +195,7 @@ public class FunctionCallExpr extends Expr {
 
     @Override
     public String debugString() {
-        return Objects.toStringHelper(this)/*.add("op", aggOp)*/.add("name", fnName).add("isStar",
+        return MoreObjects.toStringHelper(this)/*.add("op", aggOp)*/.add("name", fnName).add("isStar",
                 fnParams.isStar()).add("isDistinct", fnParams.isDistinct()).addValue(
                 super.debugString()).toString();
     }

--- a/fe/src/main/java/org/apache/doris/analysis/SlotDescriptor.java
+++ b/fe/src/main/java/org/apache/doris/analysis/SlotDescriptor.java
@@ -22,7 +22,7 @@ import org.apache.doris.catalog.ColumnStats;
 import org.apache.doris.catalog.Type;
 import org.apache.doris.thrift.TSlotDescriptor;
 
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 
@@ -257,7 +257,7 @@ public class SlotDescriptor {
         String colStr = (column == null ? "null" : column.getName());
         String typeStr = (type == null ? "null" : type.toString());
         String parentTupleId = (parent == null) ? "null" : parent.getId().toString();
-        return Objects.toStringHelper(this).add("id", id.asInt()).add("parent", parentTupleId)
+        return MoreObjects.toStringHelper(this).add("id", id.asInt()).add("parent", parentTupleId)
                 .add("col", colStr).add("type", typeStr).add("materialized", isMaterialized)
                 .add("byteSize", byteSize).add("byteOffset", byteOffset)
                 .add("nullIndicatorByte", nullIndicatorByte)

--- a/fe/src/main/java/org/apache/doris/analysis/SlotRef.java
+++ b/fe/src/main/java/org/apache/doris/analysis/SlotRef.java
@@ -25,8 +25,8 @@ import org.apache.doris.thrift.TExprNode;
 import org.apache.doris.thrift.TExprNodeType;
 import org.apache.doris.thrift.TSlotRef;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
-import com.google.common.base.Objects.ToStringHelper;
 import com.google.common.base.Preconditions;
 
 import org.apache.logging.log4j.LogManager;
@@ -139,7 +139,7 @@ public class SlotRef extends Expr {
 
     @Override
     public String debugString() {
-        ToStringHelper helper = Objects.toStringHelper(this);
+        MoreObjects.ToStringHelper helper = MoreObjects.toStringHelper(this);
         helper.add("slotDesc", desc != null ? desc.debugString() : "null");
         helper.add("col", col);
         helper.add("label", label);

--- a/fe/src/main/java/org/apache/doris/analysis/TupleDescriptor.java
+++ b/fe/src/main/java/org/apache/doris/analysis/TupleDescriptor.java
@@ -23,7 +23,7 @@ import org.apache.doris.catalog.Table;
 import org.apache.doris.thrift.TTupleDescriptor;
 
 import com.google.common.base.Joiner;
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 
@@ -291,7 +291,7 @@ public class TupleDescriptor {
         for (SlotDescriptor slot : slots) {
             slotStrings.add(slot.debugString());
         }
-        return Objects.toStringHelper(this).add("id", id.asInt()).add("tbl", tblStr).add("byte_size", byteSize)
+        return MoreObjects.toStringHelper(this).add("id", id.asInt()).add("tbl", tblStr).add("byte_size", byteSize)
                    .add("is_materialized", isMaterialized).add("slots", "[" + Joiner.on(", ").join(slotStrings) + "]")
                    .toString();
     }
@@ -304,7 +304,7 @@ public class TupleDescriptor {
         for (SlotDescriptor slot : slots) {
             slotStrings.add(slot.debugString());
         }
-        return Objects.toStringHelper(this)
+        return MoreObjects.toStringHelper(this)
                 .add("id", id.asInt())
                 .add("name", debugName)
                 .add("tbl", tblStr)

--- a/fe/src/main/java/org/apache/doris/catalog/ColumnStats.java
+++ b/fe/src/main/java/org/apache/doris/catalog/ColumnStats.java
@@ -17,12 +17,11 @@
 
 package org.apache.doris.catalog;
 
-import com.google.gson.annotations.SerializedName;
 import org.apache.doris.analysis.Expr;
 import org.apache.doris.analysis.SlotRef;
 import org.apache.doris.common.io.Writable;
 
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
 import com.google.gson.annotations.SerializedName;
 
@@ -116,7 +115,7 @@ public class ColumnStats implements Writable {
 
     @Override
     public String toString() {
-        return Objects.toStringHelper(this.getClass()).add("avgSerializedSize",
+        return MoreObjects.toStringHelper(this.getClass()).add("avgSerializedSize",
           avgSerializedSize).add("maxSize", maxSize).add("numDistinct", numDistinctValues).add(
           "numNulls", numNulls).toString();
     }

--- a/fe/src/main/java/org/apache/doris/load/LoadErrorHub.java
+++ b/fe/src/main/java/org/apache/doris/load/LoadErrorHub.java
@@ -22,7 +22,8 @@ import org.apache.doris.common.io.Writable;
 import org.apache.doris.thrift.TErrorHubType;
 import org.apache.doris.thrift.TLoadErrorHubInfo;
 
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
+import com.google.common.base.MoreObjects.ToStringHelper;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -109,7 +110,7 @@ public abstract class LoadErrorHub {
         }
 
         public String toString() {
-            Objects.ToStringHelper helper = Objects.toStringHelper(this);
+            ToStringHelper helper = MoreObjects.toStringHelper(this);
             helper.add("type", type.toString());
             switch (type) {
                 case MYSQL_TYPE:

--- a/fe/src/main/java/org/apache/doris/planner/AggregationNode.java
+++ b/fe/src/main/java/org/apache/doris/planner/AggregationNode.java
@@ -17,9 +17,6 @@
 
 package org.apache.doris.planner;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import org.apache.doris.analysis.AggregateInfo;
 import org.apache.doris.analysis.Analyzer;
 import org.apache.doris.analysis.Expr;
@@ -31,12 +28,16 @@ import org.apache.doris.thrift.TExplainLevel;
 import org.apache.doris.thrift.TExpr;
 import org.apache.doris.thrift.TPlanNode;
 import org.apache.doris.thrift.TPlanNodeType;
+
+import com.google.common.base.MoreObjects;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import com.google.common.base.Objects;
-import com.google.common.base.Preconditions;
-import com.google.common.collect.Lists;
+import java.util.ArrayList;
+import java.util.List;
 
 //import org.apache.doris.thrift.TAggregateFunctionCall;
 
@@ -222,7 +223,7 @@ public class AggregationNode extends PlanNode {
 
     @Override
     protected String debugString() {
-        return Objects.toStringHelper(this).add("aggInfo", aggInfo.debugString()).addValue(
+        return MoreObjects.toStringHelper(this).add("aggInfo", aggInfo.debugString()).addValue(
           super.debugString()).toString();
     }
 

--- a/fe/src/main/java/org/apache/doris/planner/AnalyticEvalNode.java
+++ b/fe/src/main/java/org/apache/doris/planner/AnalyticEvalNode.java
@@ -17,11 +17,6 @@
 
 package org.apache.doris.planner;
 
-import java.util.List;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import org.apache.doris.analysis.AnalyticWindow;
 import org.apache.doris.analysis.Analyzer;
 import org.apache.doris.analysis.Expr;
@@ -34,11 +29,17 @@ import org.apache.doris.thrift.TExplainLevel;
 import org.apache.doris.thrift.TPlanNode;
 import org.apache.doris.thrift.TPlanNodeType;
 import org.apache.doris.thrift.TQueryOptions;
+
 import com.google.common.base.Joiner;
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
 
 /**
  * Computation of analytic exprs.
@@ -148,7 +149,7 @@ public class AnalyticEvalNode extends PlanNode {
             orderByElementStrs.add(element.toSql());
         }
 
-        return Objects.toStringHelper(this)
+        return MoreObjects.toStringHelper(this)
                .add("analyticFnCalls", Expr.debugString(analyticFnCalls))
                .add("partitionExprs", Expr.debugString(partitionExprs))
                .add("subtitutedPartitionExprs", Expr.debugString(substitutedPartitionExprs))

--- a/fe/src/main/java/org/apache/doris/planner/CrossJoinNode.java
+++ b/fe/src/main/java/org/apache/doris/planner/CrossJoinNode.java
@@ -22,9 +22,11 @@ import org.apache.doris.analysis.TableRef;
 import org.apache.doris.thrift.TExplainLevel;
 import org.apache.doris.thrift.TPlanNode;
 import org.apache.doris.thrift.TPlanNodeType;
-import com.google.common.base.Objects;
-import org.apache.logging.log4j.Logger;
+
+import com.google.common.base.MoreObjects;
+
 import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Cross join between left child and right child.
@@ -73,7 +75,7 @@ public class CrossJoinNode extends PlanNode {
 
     @Override
     protected String debugString() {
-        return Objects.toStringHelper(this).addValue(super.debugString()).toString();
+        return MoreObjects.toStringHelper(this).addValue(super.debugString()).toString();
     }
 
     @Override

--- a/fe/src/main/java/org/apache/doris/planner/CsvScanNode.java
+++ b/fe/src/main/java/org/apache/doris/planner/CsvScanNode.java
@@ -17,35 +17,36 @@
 
 package org.apache.doris.planner;
 
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
 import org.apache.doris.analysis.Analyzer;
 import org.apache.doris.analysis.TupleDescriptor;
 import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.OlapTable;
-import org.apache.doris.common.UserException;
 import org.apache.doris.common.Pair;
+import org.apache.doris.common.UserException;
 import org.apache.doris.load.LoadJob;
 import org.apache.doris.load.PartitionLoadInfo;
 import org.apache.doris.load.Source;
 import org.apache.doris.load.TableLoadInfo;
-import org.apache.doris.thrift.TMiniLoadEtlFunction;
 import org.apache.doris.thrift.TColumnType;
 import org.apache.doris.thrift.TCsvScanNode;
+import org.apache.doris.thrift.TMiniLoadEtlFunction;
 import org.apache.doris.thrift.TPlanNode;
 import org.apache.doris.thrift.TPlanNodeType;
 import org.apache.doris.thrift.TScanRangeLocations;
-import com.google.common.base.Objects;
-import com.google.common.base.Objects.ToStringHelper;
+
+import com.google.common.base.MoreObjects;
+import com.google.common.base.MoreObjects.ToStringHelper;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
 
 public class CsvScanNode extends ScanNode {
     private static final Logger LOG = LogManager.getLogger(CsvScanNode.class);
@@ -186,7 +187,7 @@ public class CsvScanNode extends ScanNode {
 
     @Override
     protected String debugString() {
-        ToStringHelper helper = Objects.toStringHelper(this);
+        ToStringHelper helper = MoreObjects.toStringHelper(this);
         return helper.addValue(super.debugString()).toString();
     }
 

--- a/fe/src/main/java/org/apache/doris/planner/ExchangeNode.java
+++ b/fe/src/main/java/org/apache/doris/planner/ExchangeNode.java
@@ -27,8 +27,8 @@ import org.apache.doris.thrift.TPlanNode;
 import org.apache.doris.thrift.TPlanNodeType;
 import org.apache.doris.thrift.TSortInfo;
 
-import com.google.common.base.Objects;
-import com.google.common.base.Objects.ToStringHelper;
+import com.google.common.base.MoreObjects;
+import com.google.common.base.MoreObjects.ToStringHelper;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 
@@ -122,7 +122,7 @@ public class ExchangeNode extends PlanNode {
 
     @Override
     protected String debugString() {
-        ToStringHelper helper = Objects.toStringHelper(this);
+        ToStringHelper helper = MoreObjects.toStringHelper(this);
         helper.addValue(super.debugString());
         helper.add("offset", offset);
         return helper.toString();

--- a/fe/src/main/java/org/apache/doris/planner/HashJoinNode.java
+++ b/fe/src/main/java/org/apache/doris/planner/HashJoinNode.java
@@ -34,7 +34,7 @@ import org.apache.doris.thrift.THashJoinNode;
 import org.apache.doris.thrift.TPlanNode;
 import org.apache.doris.thrift.TPlanNodeType;
 
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 
@@ -220,12 +220,12 @@ public class HashJoinNode extends PlanNode {
 
     @Override
     protected String debugString() {
-        return Objects.toStringHelper(this).add("eqJoinConjuncts",
+        return MoreObjects.toStringHelper(this).add("eqJoinConjuncts",
           eqJoinConjunctsDebugString()).addValue(super.debugString()).toString();
     }
 
     private String eqJoinConjunctsDebugString() {
-        Objects.ToStringHelper helper = Objects.toStringHelper(this);
+        MoreObjects.ToStringHelper helper = MoreObjects.toStringHelper(this);
         for (BinaryPredicate expr : eqJoinConjuncts) {
             helper.add("lhs", expr.getChild(0)).add("rhs", expr.getChild(1));
         }

--- a/fe/src/main/java/org/apache/doris/planner/MergeJoinNode.java
+++ b/fe/src/main/java/org/apache/doris/planner/MergeJoinNode.java
@@ -26,10 +26,12 @@ import org.apache.doris.thrift.TExplainLevel;
 import org.apache.doris.thrift.TMergeJoinNode;
 import org.apache.doris.thrift.TPlanNode;
 import org.apache.doris.thrift.TPlanNodeType;
-import com.google.common.base.Objects;
+
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
-import org.apache.logging.log4j.Logger;
+
 import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.List;
 
@@ -82,12 +84,12 @@ public class MergeJoinNode extends PlanNode {
 
     @Override
     protected String debugString() {
-        return Objects.toStringHelper(this).add("cmpConjuncts", cmpConjunctsDebugString()).addValue(
+        return MoreObjects.toStringHelper(this).add("cmpConjuncts", cmpConjunctsDebugString()).addValue(
           super.debugString()).toString();
     }
 
     private String cmpConjunctsDebugString() {
-        Objects.ToStringHelper helper = Objects.toStringHelper(this);
+        MoreObjects.ToStringHelper helper = MoreObjects.toStringHelper(this);
         for (Pair<Expr, Expr> entry : cmpConjuncts) {
             helper.add("lhs", entry.first).add("rhs", entry.second);
         }

--- a/fe/src/main/java/org/apache/doris/planner/MysqlScanNode.java
+++ b/fe/src/main/java/org/apache/doris/planner/MysqlScanNode.java
@@ -33,8 +33,7 @@ import org.apache.doris.thrift.TPlanNodeType;
 import org.apache.doris.thrift.TScanRangeLocations;
 
 import com.google.common.base.Joiner;
-import com.google.common.base.Objects;
-import com.google.common.base.Objects.ToStringHelper;
+import com.google.common.base.MoreObjects;
 import com.google.common.collect.Lists;
 
 import org.apache.logging.log4j.LogManager;
@@ -63,7 +62,7 @@ public class MysqlScanNode extends ScanNode {
 
     @Override
     protected String debugString() {
-        ToStringHelper helper = Objects.toStringHelper(this);
+        MoreObjects.ToStringHelper helper = MoreObjects.toStringHelper(this);
         return helper.addValue(super.debugString()).toString();
     }
 

--- a/fe/src/main/java/org/apache/doris/planner/OlapScanNode.java
+++ b/fe/src/main/java/org/apache/doris/planner/OlapScanNode.java
@@ -64,7 +64,6 @@ import org.apache.doris.thrift.TScanRangeLocations;
 
 import com.google.common.base.Joiner;
 import com.google.common.base.MoreObjects;
-import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Lists;

--- a/fe/src/main/java/org/apache/doris/planner/OlapScanNode.java
+++ b/fe/src/main/java/org/apache/doris/planner/OlapScanNode.java
@@ -63,8 +63,8 @@ import org.apache.doris.thrift.TScanRangeLocation;
 import org.apache.doris.thrift.TScanRangeLocations;
 
 import com.google.common.base.Joiner;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
-import com.google.common.base.Objects.ToStringHelper;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Lists;
@@ -241,7 +241,7 @@ public class OlapScanNode extends ScanNode {
 
     @Override
     protected String debugString() {
-        ToStringHelper helper = Objects.toStringHelper(this);
+        MoreObjects.ToStringHelper helper = MoreObjects.toStringHelper(this);
         helper.addValue(super.debugString());
         helper.addValue("olapTable=" + olapTable.getName());
         return helper.toString();

--- a/fe/src/main/java/org/apache/doris/planner/RepeatNode.java
+++ b/fe/src/main/java/org/apache/doris/planner/RepeatNode.java
@@ -33,7 +33,7 @@ import org.apache.doris.thrift.TPlanNode;
 import org.apache.doris.thrift.TPlanNodeType;
 import org.apache.doris.thrift.TRepeatNode;
 
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
 
 import org.apache.commons.collections.CollectionUtils;
@@ -177,7 +177,7 @@ public class RepeatNode extends PlanNode {
 
     @Override
     protected String debugString() {
-        return Objects.toStringHelper(this).add("Repeat", repeatSlotIdList.size()).addValue(
+        return MoreObjects.toStringHelper(this).add("Repeat", repeatSlotIdList.size()).addValue(
                 super.debugString()).toString();
     }
 

--- a/fe/src/main/java/org/apache/doris/planner/ScanNode.java
+++ b/fe/src/main/java/org/apache/doris/planner/ScanNode.java
@@ -25,7 +25,7 @@ import org.apache.doris.common.UserException;
 import org.apache.doris.thrift.TNetworkAddress;
 import org.apache.doris.thrift.TScanRangeLocations;
 
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 
 import java.util.List;
 import java.util.Map;
@@ -88,7 +88,7 @@ abstract public class ScanNode extends PlanNode {
 
     @Override
     public String toString() {
-        return Objects.toStringHelper(this).add("tid", desc.getId().asInt()).add("tblName",
+        return MoreObjects.toStringHelper(this).add("tid", desc.getId().asInt()).add("tblName",
                 desc.getTable().getName()).add("keyRanges", "").addValue(
                 super.debugString()).toString();
     }

--- a/fe/src/main/java/org/apache/doris/planner/SchemaScanNode.java
+++ b/fe/src/main/java/org/apache/doris/planner/SchemaScanNode.java
@@ -30,8 +30,7 @@ import org.apache.doris.thrift.TScanRangeLocations;
 import org.apache.doris.thrift.TSchemaScanNode;
 import org.apache.doris.thrift.TUserIdentity;
 
-import com.google.common.base.Objects;
-import com.google.common.base.Objects.ToStringHelper;
+import com.google.common.base.MoreObjects;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -63,7 +62,7 @@ public class SchemaScanNode extends ScanNode {
 
     @Override
     protected String debugString() {
-        ToStringHelper helper = Objects.toStringHelper(this);
+        MoreObjects.ToStringHelper helper = MoreObjects.toStringHelper(this);
         return helper.addValue(super.debugString()).toString();
     }
 

--- a/fe/src/main/java/org/apache/doris/planner/SortNode.java
+++ b/fe/src/main/java/org/apache/doris/planner/SortNode.java
@@ -32,12 +32,12 @@ import org.apache.doris.thrift.TSortInfo;
 import org.apache.doris.thrift.TSortNode;
 
 import com.google.common.base.Joiner;
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 
-import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.Iterator;
 import java.util.List;
@@ -141,7 +141,7 @@ public class SortNode extends PlanNode {
         for (Boolean isAsc : info.getIsAscOrder()) {
             strings.add(isAsc ? "a" : "d");
         }
-        return Objects.toStringHelper(this).add("ordering_exprs",
+        return MoreObjects.toStringHelper(this).add("ordering_exprs",
           Expr.debugString(info.getOrderingExprs())).add("is_asc",
           "[" + Joiner.on(" ").join(strings) + "]").addValue(super.debugString()).toString();
     }


### PR DESCRIPTION
Fix #3403
The new version of Guava has move the `toStringHelper` from `Object` to `MoreObject`.
This CL has passed our test environment, and looks running well.
