### PR TITLE
Fix the error result when assert num rows node is used

### DIFF
--- a/be/src/exec/assert_num_rows_node.cpp
+++ b/be/src/exec/assert_num_rows_node.cpp
@@ -45,6 +45,7 @@ Status AssertNumRowsNode::prepare(RuntimeState* state) {
 Status AssertNumRowsNode::open(RuntimeState* state) {
     SCOPED_TIMER(_runtime_profile->total_time_counter());
     RETURN_IF_ERROR(ExecNode::open(state));
+    // ISSUE-3435
     RETURN_IF_ERROR(child(0)->open(state));
     return Status::OK();
 }

--- a/be/src/exec/assert_num_rows_node.cpp
+++ b/be/src/exec/assert_num_rows_node.cpp
@@ -45,6 +45,7 @@ Status AssertNumRowsNode::prepare(RuntimeState* state) {
 Status AssertNumRowsNode::open(RuntimeState* state) {
     SCOPED_TIMER(_runtime_profile->total_time_counter());
     RETURN_IF_ERROR(ExecNode::open(state));
+    RETURN_IF_ERROR(child(0)->open(state));
     return Status::OK();
 }
 


### PR DESCRIPTION
The child.open() function is not called before this commit.

If the assert num rows node has child which process data in open function, the assert num rows node will fetch no data from child. So the result will be empty(incorrect).

This error only appear in inner subquery which has a aggregation function.
For example:

`select * from table where k1=(select k1 from (select avg(k1) from table) a);`

The first level of subquery returns a non-scalar value, so the assert num rows node is needed.
The second level of subquery has a aggregation function, so the child of assert node is aggregate node.

However, if the open stage of the aggregate node is not called, the get next state of aggregate node will return empty set.
So the result is wrong.
Fixed #3435.

Change-Id: I45f3eda0fbd2e0723aa4185a2d8a3459135a2d37