### PR TITLE
[Bug][AuditPlugin] Fix bug that length of query stmt in audit should less than limit.

### DIFF
--- a/fe_plugins/auditloader/src/main/java/org/apache/doris/plugin/audit/AuditLoaderPlugin.java
+++ b/fe_plugins/auditloader/src/main/java/org/apache/doris/plugin/audit/AuditLoaderPlugin.java
@@ -62,6 +62,9 @@ public class AuditLoaderPlugin extends Plugin implements AuditPlugin {
     private volatile boolean isClosed = false;
     private volatile boolean isInit = false;
 
+    // the max stmt length to be loaded in audit table.
+    private static final long MAX_STMT_LENGTH = 2000;
+
     @Override
     public void init(PluginInfo info, PluginContext ctx) throws PluginException {
         super.init(info, ctx);
@@ -144,7 +147,7 @@ public class AuditLoaderPlugin extends Plugin implements AuditPlugin {
         auditBuffer.append(event.feIp).append("\t");
         // trim the query to avoid too long
         // use `getBytes().length` to get real byte length
-        int maxLen = Math.min(2000, event.stmt.getBytes().length);
+        int maxLen = Math.min(MAX_STMT_LENGTH, event.stmt.getBytes().length);
         String stmt = new String(event.stmt.getBytes(), 0, maxLen).replace("\t", " ");
         LOG.debug("receive audit event with stmt: {}", stmt);
         auditBuffer.append(stmt).append("\n");

--- a/fe_plugins/auditloader/src/main/java/org/apache/doris/plugin/audit/AuditLoaderPlugin.java
+++ b/fe_plugins/auditloader/src/main/java/org/apache/doris/plugin/audit/AuditLoaderPlugin.java
@@ -63,7 +63,7 @@ public class AuditLoaderPlugin extends Plugin implements AuditPlugin {
     private volatile boolean isInit = false;
 
     // the max stmt length to be loaded in audit table.
-    private static final long MAX_STMT_LENGTH = 2000;
+    private static final int MAX_STMT_LENGTH = 2000;
 
     @Override
     public void init(PluginInfo info, PluginContext ctx) throws PluginException {

--- a/fe_plugins/auditloader/src/main/java/org/apache/doris/plugin/audit/AuditLoaderPlugin.java
+++ b/fe_plugins/auditloader/src/main/java/org/apache/doris/plugin/audit/AuditLoaderPlugin.java
@@ -143,8 +143,9 @@ public class AuditLoaderPlugin extends Plugin implements AuditPlugin {
         auditBuffer.append(event.isQuery ? 1 : 0).append("\t");
         auditBuffer.append(event.feIp).append("\t");
         // trim the query to avoid too long
-        int maxLen = Math.min(2048, event.stmt.length());
-        String stmt = event.stmt.substring(0, maxLen).replace("\t", " ");
+        // use `getBytes().length` to get real byte length
+        int maxLen = Math.min(2000, event.stmt.getBytes().length);
+        String stmt = new String(event.stmt.getBytes(), 0, maxLen).replace("\t", " ");
         LOG.debug("receive audit event with stmt: {}", stmt);
         auditBuffer.append(stmt).append("\n");
     }

--- a/fe_plugins/auditloader/src/main/java/org/apache/doris/plugin/audit/DorisStreamLoader.java
+++ b/fe_plugins/auditloader/src/main/java/org/apache/doris/plugin/audit/DorisStreamLoader.java
@@ -87,7 +87,7 @@ public class DorisStreamLoader {
         conn.addRequestProperty("Content-Type", "text/plain; charset=UTF-8");
 
         conn.addRequestProperty("label", label);
-        conn.addRequestProperty("max_fiter_ratio", "1.0");
+        conn.addRequestProperty("max_filter_ratio", "1.0");
         conn.addRequestProperty("columns", "query_id, time, client_ip, user, db, state, query_time, scan_bytes, scan_rows, return_rows, stmt_id, is_query, frontend_ip, stmt");
 
         conn.setDoOutput(true);


### PR DESCRIPTION
Use `String.getBytes().length` instead of `String.length()` to get the real byte length of a string.
Fix: #3443 

Also fix the typo of `max_filter_ratio` in audit log plugin.