### PR TITLE
Support simple transitivity on join predicate pushdown

### DIFF
--- a/fe/src/main/java/org/apache/doris/analysis/Analyzer.java
+++ b/fe/src/main/java/org/apache/doris/analysis/Analyzer.java
@@ -433,6 +433,10 @@ public class Analyzer {
         return result;
     }
 
+    public List<TupleId> getAllTupleIds() {
+        return new ArrayList<>(tableRefMap_.keySet());
+    }
+
     /**
      * Resolves the given TableRef into a concrete BaseTableRef, ViewRef or
      * CollectionTableRef. Returns the new resolved table ref or the given table
@@ -944,6 +948,29 @@ public class Analyzer {
                     && !globalState.assignedConjuncts.contains(e.getId())
                     && ((inclOjConjuncts && !e.isConstant())
                     || !globalState.ojClauseByConjunct.containsKey(e.getId()))) {
+                result.add(e);
+            }
+        }
+        return result;
+    }
+
+
+    /**
+     * Return all registered conjuncts that are fully bound by
+     * given list of tuple ids, the eqJoinConjuncts and inclOjConjuncts is excluded.
+     */
+    public List<Expr> getConjuncts(List<TupleId> tupleIds) {
+        List<Expr> result = Lists.newArrayList();
+        List<ExprId> eqJoinConjunctIds = Lists.newArrayList();
+        for (List<ExprId> conjuncts : globalState.eqJoinConjuncts.values()) {
+            eqJoinConjunctIds.addAll(conjuncts);
+        }
+        for (Expr e : globalState.conjuncts.values()) {
+            if (e.isBoundByTupleIds(tupleIds)
+                    && !e.isAuxExpr()
+                    && !eqJoinConjunctIds.contains(e.getId())
+                    && !globalState.ojClauseByConjunct.containsKey(e.getId())
+                    && canEvalPredicate(tupleIds, e)) {
                 result.add(e);
             }
         }

--- a/fe/src/main/java/org/apache/doris/analysis/InPredicate.java
+++ b/fe/src/main/java/org/apache/doris/analysis/InPredicate.java
@@ -125,6 +125,10 @@ public class InPredicate extends Predicate {
           !isNotIn);
     }
 
+    public List<Expr> getListChildren() {
+        return  children.subList(1, children.size());
+    }
+
     public boolean isNotIn() {
         return isNotIn;
     }

--- a/fe/src/main/java/org/apache/doris/planner/SingleNodePlanner.java
+++ b/fe/src/main/java/org/apache/doris/planner/SingleNodePlanner.java
@@ -72,8 +72,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
-import static org.apache.doris.analysis.Predicate.canPushDownPredicate;
-
 /**
  * Constructs a non-executable single-node plan from an analyzed parse tree.
  * The single-node plan does not contain data exchanges or data-reduction optimizations
@@ -1360,7 +1358,7 @@ public class SingleNodePlanner {
                     List<Expr> allConjuncts = analyzer.getConjuncts(analyzer.getAllTupleIds());
                     allConjuncts.removeAll(conjuncts);
                     for (Expr conjunct: allConjuncts) {
-                        if (canPushDownPredicate(conjunct)) {
+                        if (org.apache.doris.analysis.Predicate.canPushDownPredicate(conjunct)) {
                             for (Expr eqJoinPredicate : eqJoinPredicates) {
                                 // we can ensure slot is left node, because NormalizeBinaryPredicatesRule
                                 SlotRef otherSlot = conjunct.getChild(0).unwrapSlotRef();
@@ -1384,7 +1382,7 @@ public class SingleNodePlanner {
                     }
                 }
 
-                LOG.info("pushDownConjuncts: " + pushDownConjuncts);
+                LOG.debug("pushDownConjuncts: {}", pushDownConjuncts);
                 conjuncts.addAll(pushDownConjuncts);
             }
 
@@ -1414,6 +1412,8 @@ public class SingleNodePlanner {
         return scanNode;
     }
 
+    // Rewrite the oldPredicate with new leftChild
+    // For example: oldPredicate is t1.id = 1, leftChild is t2.id, will return t2.id = 1
     private Expr rewritePredicate(Analyzer analyzer, Expr oldPredicate, Expr leftChild) {
         if (oldPredicate instanceof BinaryPredicate) {
             BinaryPredicate oldBP = (BinaryPredicate) oldPredicate;

--- a/fe/src/test/java/org/apache/doris/planner/QueryPlanTest.java
+++ b/fe/src/test/java/org/apache/doris/planner/QueryPlanTest.java
@@ -98,6 +98,32 @@ public class QueryPlanTest {
                 " \"replication_num\" = \"1\"\n" +
                 ");");
 
+        createTable("CREATE TABLE test.join1 (\n" +
+                "  `dt` int(11) COMMENT \"\",\n" +
+                "  `id` int(11) COMMENT \"\",\n" +
+                "  `value` varchar(8) COMMENT \"\"\n" +
+                ") ENGINE=OLAP\n" +
+                "DUPLICATE KEY(`dt`, `id`)\n" +
+                "PARTITION BY RANGE(`dt`)\n" +
+                "(PARTITION p1 VALUES LESS THAN (\"10\"))\n" +
+                "DISTRIBUTED BY HASH(`id`) BUCKETS 10\n" +
+                "PROPERTIES (\n" +
+                "  \"replication_num\" = \"1\"\n" +
+                ");");
+
+        createTable("CREATE TABLE test.join2 (\n" +
+                "  `dt` int(11) COMMENT \"\",\n" +
+                "  `id` int(11) COMMENT \"\",\n" +
+                "  `value` varchar(8) COMMENT \"\"\n" +
+                ") ENGINE=OLAP\n" +
+                "DUPLICATE KEY(`dt`, `id`)\n" +
+                "PARTITION BY RANGE(`dt`)\n" +
+                "(PARTITION p1 VALUES LESS THAN (\"10\"))\n" +
+                "DISTRIBUTED BY HASH(`id`) BUCKETS 10\n" +
+                "PROPERTIES (\n" +
+                "  \"replication_num\" = \"1\"\n" +
+                ");");
+
         createTable("CREATE TABLE test.bitmap_table_2 (\n" +
                 "  `id` int(11) NULL COMMENT \"\",\n" +
                 "  `id2` bitmap bitmap_union NULL\n" +
@@ -503,5 +529,105 @@ public class QueryPlanTest {
         LoadStmt loadStmt = (LoadStmt) UtFrameUtils.parseAndAnalyzeStmt(loadStr, connectContext);
         Catalog.getCurrentCatalog().getLoadManager().createLoadJobV1FromStmt(loadStmt, EtlJobType.HADOOP,
                 System.currentTimeMillis());
+    }
+
+    @Test
+    public void  testJoinPredicateTransitivity() throws Exception {
+        connectContext.setDatabase("default_cluster:test");
+
+        // test left join : left table where binary predicate
+        String sql = "select join1.id\n" +
+                "from join1\n" +
+                "left join join2 on join1.id = join2.id\n" +
+                "where join1.id > 1;";
+        String explainString = UtFrameUtils.getSQLPlanOrErrorMsg(connectContext, "explain " + sql);
+        System.out.println(explainString);
+        Assert.assertTrue(explainString.contains("PREDICATES: `join2`.`id` > 1"));
+        Assert.assertTrue(explainString.contains("PREDICATES: `join1`.`id` > 1"));
+
+        // test left join: left table where in predicate
+        sql = "select join1.id\n" +
+                "from join1\n" +
+                "left join join2 on join1.id = join2.id\n" +
+                "where join1.id in (2);";
+        explainString = UtFrameUtils.getSQLPlanOrErrorMsg(connectContext, "explain " + sql);
+        System.out.println(explainString);
+        Assert.assertTrue(explainString.contains("PREDICATES: `join2`.`id` IN (2)"));
+        Assert.assertTrue(explainString.contains("PREDICATES: `join1`.`id` IN (2)"));
+
+        // test left join: left table where between predicate
+        sql = "select join1.id\n" +
+                "from join1\n" +
+                "left join join2 on join1.id = join2.id\n" +
+                "where join1.id BETWEEN 1 AND 2;";
+        explainString = UtFrameUtils.getSQLPlanOrErrorMsg(connectContext, "explain " + sql);
+        System.out.println(explainString);
+        Assert.assertTrue(explainString.contains("PREDICATES: `join1`.`id` >= 1, `join1`.`id` <= 2"));
+        Assert.assertTrue(explainString.contains("PREDICATES: `join2`.`id` >= 1, `join2`.`id` <= 2"));
+
+        // test left join: left table join predicate, left table couldn't push down
+        sql = "select *\n from join1\n" +
+                "left join join2 on join1.id = join2.id\n" +
+                "and join1.id > 1;";
+        explainString = UtFrameUtils.getSQLPlanOrErrorMsg(connectContext, "explain " + sql);
+        System.out.println(explainString);
+        Assert.assertTrue(explainString.contains("other join predicates: `join1`.`id` > 1"));
+        Assert.assertFalse(explainString.contains("PREDICATES: `join1`.`id` > 1"));
+
+        // test left join: right table where predicate.
+        // If we eliminate outer join, we could push predicate down to join1 and join2.
+        // Currently, we push predicate to join1 and keep join predicate for join2
+        sql = "select *\n from join1\n" +
+                "left join join2 on join1.id = join2.id\n" +
+                "where join2.id > 1;";
+        explainString = UtFrameUtils.getSQLPlanOrErrorMsg(connectContext, "explain " + sql);
+        System.out.println(explainString);
+        Assert.assertTrue(explainString.contains("PREDICATES: `join1`.`id` > 1"));
+        Assert.assertFalse(explainString.contains("other join predicates: `join2`.`id` > 1"));
+
+        // test left join: right table join predicate, only push down right table
+        sql = "select *\n from join1\n" +
+                "left join join2 on join1.id = join2.id\n" +
+                "and join2.id > 1;";
+        explainString = UtFrameUtils.getSQLPlanOrErrorMsg(connectContext, "explain " + sql);
+        System.out.println(explainString);
+        Assert.assertTrue(explainString.contains("PREDICATES: `join2`.`id` > 1"));
+        Assert.assertFalse(explainString.contains("PREDICATES: `join1`.`id` > 1"));
+
+        // test inner join: left table where predicate, both push down left table and right table
+        sql = "select *\n from join1\n" +
+                "join join2 on join1.id = join2.id\n" +
+                "where join1.id > 1;";
+        explainString = UtFrameUtils.getSQLPlanOrErrorMsg(connectContext, "explain " + sql);
+        System.out.println(explainString);
+        Assert.assertTrue(explainString.contains("PREDICATES: `join1`.`id` > 1"));
+        Assert.assertTrue(explainString.contains("PREDICATES: `join2`.`id` > 1"));
+
+        // test inner join: left table join predicate, both push down left table and right table
+        sql = "select *\n from join1\n" +
+                "join join2 on join1.id = join2.id\n" +
+                "and join1.id > 1;";
+        explainString = UtFrameUtils.getSQLPlanOrErrorMsg(connectContext, "explain " + sql);
+        System.out.println(explainString);
+        Assert.assertTrue(explainString.contains("PREDICATES: `join1`.`id` > 1"));
+        Assert.assertTrue(explainString.contains("PREDICATES: `join2`.`id` > 1"));
+
+        // test inner join: right table where predicate, both push down left table and right table
+        sql = "select *\n from join1\n" +
+                "join join2 on join1.id = join2.id\n" +
+                "where join2.id > 1;";
+        explainString = UtFrameUtils.getSQLPlanOrErrorMsg(connectContext, "explain " + sql);
+        System.out.println(explainString);
+        Assert.assertTrue(explainString.contains("PREDICATES: `join1`.`id` > 1"));
+        Assert.assertTrue(explainString.contains("PREDICATES: `join2`.`id` > 1"));
+
+        // test inner join: right table join predicate, both push down left table and right table
+        sql = "select *\n from join1\n" +
+                "join join2 on join1.id = join2.id\n" +
+                "and join2.id > 1;";
+        explainString = UtFrameUtils.getSQLPlanOrErrorMsg(connectContext, "explain " + sql);
+        System.out.println(explainString);
+        Assert.assertTrue(explainString.contains("PREDICATES: `join1`.`id` > 1"));
+        Assert.assertTrue(explainString.contains("PREDICATES: `join2`.`id` > 1"));
     }
 }


### PR DESCRIPTION
For #3452 

Current implement is very simply and conservative, because our query planner is error-prone.

After we implement the new query planner, we could do this work by `Predicate Equivalence Class` and `PredicatePushDown` rule like presto. 