### PR TITLE
[Bug] Fix bug that double unregister the resource pool in runtime state

### DIFF
--- a/be/src/runtime/plan_fragment_executor.cpp
+++ b/be/src/runtime/plan_fragment_executor.cpp
@@ -553,16 +553,14 @@ void PlanFragmentExecutor::close() {
             }
         }
 
-        _exec_env->thread_mgr()->unregister_pool(_runtime_state->resource_pool());
-
         {
             std::stringstream ss;
-	    // Compute the _local_time_percent before pretty_print the runtime_profile
-	    // Before add this operation, the print out like that:
-	    // UNION_NODE (id=0):(Active: 56.720us, non-child: 00.00%)
-	    // After add thie operation, the print out like that:
-	    // UNION_NODE (id=0):(Active: 56.720us, non-child: 82.53%)
-	    // We can easily know the exec node excute time without child time consumed.
+            // Compute the _local_time_percent before pretty_print the runtime_profile
+            // Before add this operation, the print out like that:
+            // UNION_NODE (id=0):(Active: 56.720us, non-child: 00.00%)
+            // After add thie operation, the print out like that:
+            // UNION_NODE (id=0):(Active: 56.720us, non-child: 82.53%)
+            // We can easily know the exec node excute time without child time consumed.
             _runtime_state->runtime_profile()->compute_time_in_profile();
             _runtime_state->runtime_profile()->pretty_print(&ss);
             LOG(INFO) << ss.str();


### PR DESCRIPTION
The resource pool in runtime state will be automatically unregistered
when deconstructing the RuntimeState. So no need to unregister it when
closing the plan fragment executor.

Fix: #3457 