### PR TITLE
remove unnecessary if condition

### DIFF
--- a/be/src/olap/rowset/segment_v2/segment_iterator.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.cpp
@@ -239,10 +239,7 @@ Status SegmentIterator::_get_row_ranges_from_conditions(RowRanges* condition_row
     for (auto& cid : cids) {
         // get row ranges by bf index of this column,
         RowRanges column_bf_row_ranges = RowRanges::create_single(num_rows());
-        CondColumn* column_cond = nullptr;
-        if (_opts.conditions != nullptr) {
-            column_cond = _opts.conditions->get_column(cid);
-        }
+        CondColumn* column_cond = _opts.conditions->get_column(cid);
         RETURN_IF_ERROR(
             _column_iterators[cid]->get_row_ranges_by_bloom_filter(
                 column_cond,


### PR DESCRIPTION
if `_opts.conditions`  is `nullptr`, the set `cids` would be empty.