### PR TITLE
[Decommission] Support NOT dropping BE after decommission

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -90,7 +90,7 @@ module.exports = {
         sidebar: convertSidebar(require('./sidebar/en.js'), '/en/')
       },
       '/zh-CN/': {
-        selectText: '选择语言',
+        selectText: 'Languages',
         label: '简体中文',
         editLinkText: '在 GitHub 上编辑此页',
         nav: [

--- a/docs/.vuepress/sidebar/en.js
+++ b/docs/.vuepress/sidebar/en.js
@@ -95,8 +95,11 @@ module.exports = [
       {
         title: "Configuration",
         directoryPath: "config/",
-        children: ["fe_config"],
-        sidebarDepth: 1,
+        children: [
+          "fe_config",
+          "be_config",
+        ],
+        sidebarDepth: 2,
       },
       "backup-restore",
       "broker",

--- a/docs/.vuepress/sidebar/en.js
+++ b/docs/.vuepress/sidebar/en.js
@@ -99,7 +99,7 @@ module.exports = [
           "fe_config",
           "be_config",
         ],
-        sidebarDepth: 2,
+        sidebarDepth: 1,
       },
       "backup-restore",
       "broker",

--- a/docs/.vuepress/sidebar/zh-CN.js
+++ b/docs/.vuepress/sidebar/zh-CN.js
@@ -103,8 +103,11 @@ module.exports = [
       {
         title: "配置文件",
         directoryPath: "config/",
-        children: ["fe_config"],
-        sidebarDepth: 1,
+        children: [
+          "fe_config",
+          "be_config",
+        ],
+        sidebarDepth: 2,
       },
       "backup-restore",
       "broker",

--- a/docs/.vuepress/sidebar/zh-CN.js
+++ b/docs/.vuepress/sidebar/zh-CN.js
@@ -107,7 +107,7 @@ module.exports = [
           "fe_config",
           "be_config",
         ],
-        sidebarDepth: 2,
+        sidebarDepth: 1,
       },
       "backup-restore",
       "broker",

--- a/docs/en/administrator-guide/config/be_config.md
+++ b/docs/en/administrator-guide/config/be_config.md
@@ -1,0 +1,392 @@
+---
+{
+    "title": "BE Configuration",
+    "language": "zh-CN"
+}
+---
+
+<!-- 
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<!-- Please sort the configuration alphabetically -->
+
+# BE Configuration
+
+This document mainly introduces the relevant configuration items of BE.
+
+## View configuration items
+(TODO)
+
+## Set configuration items
+(TODO)
+
+## Examples
+(TODO)
+
+## Configurations
+
+### alter_tablet_worker_count
+
+### base_compaction_check_interval_seconds
+
+### base_compaction_interval_seconds_since_last_operation
+
+### base_compaction_num_cumulative_deltas
+
+### base_compaction_num_threads_per_disk
+
+### base_compaction_write_mbytes_per_sec
+
+### base_cumulative_delta_ratio
+
+### be_port
+
+### be_service_threads
+
+### brpc_max_body_size
+
+This configuration is mainly used to modify the parameter `max_body_size` of brpc.
+
+Sometimes the query fails and an error message of `body_size is too large` will appear in the BE log. This may happen when the SQL mode is "multi distinct + no group by + more than 1T of data".
+
+This error indicates that the packet size of brpc exceeds the configured value. At this time, you can avoid this error by increasing the configuration.
+
+Since this is a brpc configuration, users can also modify this parameter directly during operation. Modify by visiting `http://be_host:brpc_port/flags`.
+
+### brpc_port
+
+### buffer_pool_clean_pages_limit
+
+### buffer_pool_limit
+
+### check_consistency_worker_count
+
+### chunk_reserved_bytes_limit
+
+### clear_transaction_task_worker_count
+
+### clone_worker_count
+
+### cluster_id
+
+### column_dictionary_key_ratio_threshold
+
+### column_dictionary_key_size_threshold
+
+### compress_rowbatches
+
+### create_tablet_worker_count
+
+### cumulative_compaction_budgeted_bytes
+
+### cumulative_compaction_check_interval_seconds
+
+### cumulative_compaction_num_threads_per_disk
+
+### cumulative_compaction_skip_window_seconds
+
+### default_num_rows_per_column_file_block
+
+### default_query_options
+
+### default_rowset_type
+
+### delete_worker_count
+
+### disable_mem_pools
+
+### disable_storage_page_cache
+
+### disk_stat_monitor_interval
+
+### doris_cgroups
+
+### doris_max_pushdown_conjuncts_return_rate
+
+### doris_max_scan_key_num
+
+### doris_scan_range_row_count
+
+### doris_scanner_queue_size
+
+### doris_scanner_row_num
+
+### doris_scanner_thread_pool_queue_size
+
+### doris_scanner_thread_pool_thread_num
+
+### download_low_speed_limit_kbps
+
+### download_low_speed_time
+
+### download_worker_count
+
+### drop_tablet_worker_count
+
+### enable_metric_calculator
+
+### enable_partitioned_aggregation
+
+### enable_prefetch
+
+### enable_quadratic_probing
+
+### enable_system_metrics
+
+### enable_token_check
+
+### es_http_timeout_ms
+
+### es_scroll_keepalive
+
+### etl_thread_pool_queue_size
+
+### etl_thread_pool_size
+
+### exchg_node_buffer_size_bytes
+
+### file_descriptor_cache_capacity
+
+### file_descriptor_cache_clean_interval
+
+### flush_thread_num_per_store
+
+### force_recovery
+
+### fragment_pool_queue_size
+
+### fragment_pool_thread_num
+
+### heartbeat_service_port
+
+### heartbeat_service_thread_count
+
+### ignore_broken_disk
+
+### inc_rowset_expired_sec
+
+### index_stream_cache_capacity
+
+### load_data_reserve_hours
+
+### load_error_log_reserve_hours
+
+### load_process_max_memory_limit_bytes
+
+### load_process_max_memory_limit_percent
+
+### local_library_dir
+
+### log_buffer_level
+
+### madvise_huge_pages
+
+### make_snapshot_worker_count
+
+### max_client_cache_size_per_host
+
+### max_compaction_concurrency
+
+### max_consumer_num_per_group
+
+### max_cumulative_compaction_num_singleton_deltas
+
+### max_download_speed_kbps
+
+### max_free_io_buffers
+
+### max_garbage_sweep_interval
+
+### max_memory_sink_batch_count
+
+### max_percentage_of_error_disk
+
+### max_runnings_transactions_per_txn_map
+
+### max_tablet_num_per_shard
+
+### mem_limit
+
+### memory_limitation_per_thread_for_schema_change
+
+### memory_maintenance_sleep_time_s
+
+### memory_max_alignment
+
+### min_buffer_size
+
+### min_compaction_failure_interval_sec
+
+### min_cumulative_compaction_num_singleton_deltas
+
+### min_file_descriptor_number
+
+### min_garbage_sweep_interval
+
+### mmap_buffers
+
+### num_cores
+
+### num_disks
+
+### num_threads_per_core
+
+### num_threads_per_disk
+
+### number_tablet_writer_threads
+
+### path_gc_check
+
+### path_gc_check_interval_second
+
+### path_gc_check_step
+
+### path_gc_check_step_interval_ms
+
+### path_scan_interval_second
+
+### pending_data_expire_time_sec
+
+### periodic_counter_update_period_ms
+
+### plugin_path
+
+### port
+
+### pprof_profile_dir
+
+### priority_networks
+
+### priority_queue_remaining_tasks_increased_frequency
+
+### publish_version_worker_count
+
+### pull_load_task_dir
+
+### push_worker_count_high_priority
+
+### push_worker_count_normal_priority
+
+### push_write_mbytes_per_sec
+
+### query_scratch_dirs
+
+### read_size
+
+### release_snapshot_worker_count
+
+### report_disk_state_interval_seconds
+
+### report_tablet_interval_seconds
+
+### report_task_interval_seconds
+
+### result_buffer_cancelled_interval_time
+
+### routine_load_thread_pool_size
+
+### row_nums_check
+
+### scan_context_gc_interval_min
+
+### scratch_dirs
+
+### serialize_batch
+
+### sleep_five_seconds
+
+### sleep_one_second
+
+### small_file_dir
+
+### snapshot_expire_time_sec
+
+### sorter_block_size
+
+### status_report_interval
+
+### storage_flood_stage_left_capacity_bytes
+
+### storage_flood_stage_usage_percent
+
+### storage_medium_migrate_count
+
+### storage_page_cache_limit
+
+### storage_root_path
+
+### streaming_load_max_mb
+
+### streaming_load_rpc_max_alive_time_sec
+
+### sync_tablet_meta
+
+### sys_log_dir
+
+### sys_log_level
+
+### sys_log_roll_mode
+
+### sys_log_roll_num
+
+### sys_log_verbose_level
+
+### sys_log_verbose_modules
+
+### tablet_map_shard_size
+
+### tablet_meta_checkpoint_min_interval_secs
+
+### tablet_meta_checkpoint_min_new_rowsets_num
+
+### tablet_stat_cache_update_interval_second
+
+### tablet_writer_open_rpc_timeout_sec
+
+### tc_free_memory_rate
+
+### tc_use_memory_min
+
+### thrift_connect_timeout_seconds
+
+### thrift_rpc_timeout_ms
+
+### trash_file_expire_time_sec
+
+### txn_commit_rpc_timeout_ms
+
+### txn_map_shard_size
+
+### txn_shard_size
+
+### unused_rowset_monitor_interval
+
+### upload_worker_count
+
+### use_mmap_allocate_chunk
+
+### user_function_dir
+
+### web_log_bytes
+
+### webserver_num_workers
+
+### webserver_port
+
+### write_buffer_size

--- a/docs/en/administrator-guide/config/be_config.md
+++ b/docs/en/administrator-guide/config/be_config.md
@@ -1,7 +1,7 @@
 ---
 {
     "title": "BE Configuration",
-    "language": "zh-CN"
+    "language": "en"
 }
 ---
 

--- a/docs/en/administrator-guide/config/fe_config.md
+++ b/docs/en/administrator-guide/config/fe_config.md
@@ -1,7 +1,7 @@
 ---
 {
     "title": "FE Configuration",
-    "language": "zh-CN"
+    "language": "en"
 }
 ---
 

--- a/docs/en/administrator-guide/config/fe_config.md
+++ b/docs/en/administrator-guide/config/fe_config.md
@@ -110,135 +110,135 @@ There are two ways to configure FE configuration items:
 
 ## Configurations
 
-### alter_table_timeout_second
+### `alter_table_timeout_second`
 
-### async_load_task_pool_size
+### `async_load_task_pool_size`
 
-### audit_log_delete_age
+### `audit_log_delete_age`
 
-### audit_log_dir
+### `audit_log_dir`
 
-### audit_log_modules
+### `audit_log_modules`
 
-### audit_log_roll_interval
+### `audit_log_roll_interval`
 
-### audit_log_roll_mode
+### `audit_log_roll_mode`
 
-### audit_log_roll_num
+### `audit_log_roll_num`
 
-### auth_token
+### `auth_token`
 
-### autocommit
+### `autocommit`
 
-### auto_increment_increment
+### `auto_increment_increment`
 
-### backup_job_default_timeout_ms
+### `backup_job_default_timeout_ms`
 
-### backup_plugin_path
+### `backup_plugin_path`
 
-### balance_load_score_threshold
+### `balance_load_score_threshold`
 
-### batch_size
+### `batch_size`
 
-### bdbje_heartbeat_timeout_second
+### `bdbje_heartbeat_timeout_second`
 
-### bdbje_lock_timeout_second
+### `bdbje_lock_timeout_second`
 
-### broker_load_default_timeout_second
+### `broker_load_default_timeout_second`
 
-### brpc_idle_wait_max_time
+### `brpc_idle_wait_max_time`
 
-### brpc_number_of_concurrent_requests_processed
+### `brpc_number_of_concurrent_requests_processed`
 
-### capacity_used_percent_high_water
+### `capacity_used_percent_high_water`
 
-### catalog_trash_expire_second
+### `catalog_trash_expire_second`
 
-### catalog_try_lock_timeout_ms
+### `catalog_try_lock_timeout_ms`
 
-### character_set_client
+### `character_set_client`
 
-### character_set_connection
+### `character_set_connection`
 
-### character_set_results
+### `character_set_results`
 
-### character_set_server
+### `character_set_server`
 
-### check_consistency_default_timeout_second
+### `check_consistency_default_timeout_second`
 
-### check_java_version
+### `check_java_version`
 
-### clone_capacity_balance_threshold
+### `clone_capacity_balance_threshold`
 
-### clone_checker_interval_second
+### `clone_checker_interval_second`
 
-### clone_distribution_balance_threshold
+### `clone_distribution_balance_threshold`
 
-### clone_high_priority_delay_second
+### `clone_high_priority_delay_second`
 
-### clone_job_timeout_second
+### `clone_job_timeout_second`
 
-### clone_low_priority_delay_second
+### `clone_low_priority_delay_second`
 
-### clone_max_job_num
+### `clone_max_job_num`
 
-### clone_normal_priority_delay_second
+### `clone_normal_priority_delay_second`
 
-### cluster_id
+### `cluster_id`
 
-### cluster_name
+### `cluster_name`
 
-### codegen_level
+### `codegen_level`
 
-### collation_connection
+### `collation_connection`
 
-### collation_database
+### `collation_database`
 
-### collation_server
+### `collation_server`
 
-### consistency_check_end_time
+### `consistency_check_end_time`
 
-### consistency_check_start_time
+### `consistency_check_start_time`
 
-### default_rowset_type
+### `default_rowset_type`
 
-### default_storage_medium
+### `default_storage_medium`
 
-### delete_thread_num
+### `delete_thread_num`
 
-### desired_max_waiting_jobs
+### `desired_max_waiting_jobs`
 
-### disable_balance
+### `disable_balance`
 
-### disable_cluster_feature
+### `disable_cluster_feature`
 
-### disable_colocate_balance
+### `disable_colocate_balance`
 
-### disable_colocate_join
+### `disable_colocate_join`
 
-### disable_colocate_join
+### `disable_colocate_join`
 
-### disable_colocate_relocate
+### `disable_colocate_relocate`
 
-### disable_hadoop_load
+### `disable_hadoop_load`
 
-### disable_load_job
+### `disable_load_job`
 
-### disable_streaming_preaggregations
+### `disable_streaming_preaggregations`
 
-### div_precision_increment
+### `div_precision_increment`
 
-### dpp_bytes_per_reduce
+### `dpp_bytes_per_reduce`
 
-### dpp_config_str
+### `dpp_config_str`
 
-### dpp_default_cluster
+### `dpp_default_cluster`
 
-### dpp_default_config_str
+### `dpp_default_config_str`
 
-### dpp_hadoop_client_path
+### `dpp_hadoop_client_path`
 
-### drop_backend_after_decommission
+### `drop_backend_after_decommission`
 
 This configuration is used to control whether the system drops the BE after successfully decommissioning the BE. If true, the BE node will be deleted after the BE is successfully offline. If false, after the BE successfully goes offline, the BE will remain in the DECOMMISSION state, but will not be dropped.
 
@@ -249,151 +249,151 @@ This configuration can play a role in certain scenarios. Assume that the initial
 3. After the decommission operation is completed, the BE will not be dropped. At this time, cancel the decommission status of the BE. Then the data will start to balance from other BE nodes back to this node. At this time, the data will be evenly distributed to all disks of the BE.
 4. Perform steps 2 and 3 for all BE nodes in sequence, and finally achieve the purpose of disk balancing for all nodes.
 
-### dynamic_partition_check_interval_seconds
+### `dynamic_partition_check_interval_seconds`
 
-### dynamic_partition_enable
+### `dynamic_partition_enable`
 
-### edit_log_port
+### `edit_log_port`
 
-### edit_log_roll_num
+### `edit_log_roll_num`
 
-### edit_log_type
+### `edit_log_type`
 
-### enable_auth_check
+### `enable_auth_check`
 
-### enable_deploy_manager
+### `enable_deploy_manager`
 
-### enable_insert_strict
+### `enable_insert_strict`
 
-### enable_local_replica_selection
+### `enable_local_replica_selection`
 
-### enable_materialized_view
+### `enable_materialized_view`
 
-### enable_metric_calculator
+### `enable_metric_calculator`
 
-### enable_spilling
+### `enable_spilling`
 
-### enable_token_check
+### `enable_token_check`
 
-### es_state_sync_interval_second
+### `es_state_sync_interval_second`
 
-### event_scheduler
+### `event_scheduler`
 
-### exec_mem_limit
+### `exec_mem_limit`
 
-### export_checker_interval_second
+### `export_checker_interval_second`
 
-### export_running_job_num_limit
+### `export_running_job_num_limit`
 
-### export_tablet_num_per_task
+### `export_tablet_num_per_task`
 
-### export_task_default_timeout_second
+### `export_task_default_timeout_second`
 
-### expr_children_limit
+### `expr_children_limit`
 
-### expr_depth_limit
+### `expr_depth_limit`
 
-### force_do_metadata_checkpoint
+### `force_do_metadata_checkpoint`
 
-### forward_to_master
+### `forward_to_master`
 
-### frontend_address
+### `frontend_address`
 
-### hadoop_load_default_timeout_second
+### `hadoop_load_default_timeout_second`
 
-### heartbeat_mgr_blocking_queue_size
+### `heartbeat_mgr_blocking_queue_size`
 
-### heartbeat_mgr_threads_num
+### `heartbeat_mgr_threads_num`
 
-### history_job_keep_max_second
+### `history_job_keep_max_second`
 
-### http_backlog_num
+### `http_backlog_num`
 
-### http_port
+### `http_port`
 
-### ignore_meta_check
+### `ignore_meta_check`
 
-### init_connect
+### `init_connect`
 
-### insert_load_default_timeout_second
+### `insert_load_default_timeout_second`
 
-### interactive_timeout
+### `interactive_timeout`
 
-### is_report_success
+### `is_report_success`
 
-### label_clean_interval_second
+### `label_clean_interval_second`
 
-### label_keep_max_second
+### `label_keep_max_second`
 
-### language
+### `language`
 
-### license
+### `license`
 
-### load_checker_interval_second
+### `load_checker_interval_second`
 
-### load_etl_thread_num_high_priority
+### `load_etl_thread_num_high_priority`
 
-### load_etl_thread_num_normal_priority
+### `load_etl_thread_num_normal_priority`
 
-### load_input_size_limit_gb
+### `load_input_size_limit_gb`
 
-### load_mem_limit
+### `load_mem_limit`
 
-### load_pending_thread_num_high_priority
+### `load_pending_thread_num_high_priority`
 
-### load_pending_thread_num_normal_priority
+### `load_pending_thread_num_normal_priority`
 
-### load_running_job_num_limit
+### `load_running_job_num_limit`
 
-### load_straggler_wait_second
+### `load_straggler_wait_second`
 
-### locale
+### `locale`
 
-### log_roll_size_mb
+### `log_roll_size_mb`
 
-### lower_case_table_names
+### `lower_case_table_names`
 
-### master_sync_policy
+### `master_sync_policy`
 
-### max_agent_task_threads_num
+### `max_agent_task_threads_num`
 
-### max_allowed_packet
+### `max_allowed_packet`
 
-### max_backend_down_time_second
+### `max_backend_down_time_second`
 
-### max_balancing_tablets
+### `max_balancing_tablets`
 
-### max_bdbje_clock_delta_ms
+### `max_bdbje_clock_delta_ms`
 
-### max_broker_concurrency
+### `max_broker_concurrency`
 
-### max_bytes_per_broker_scanner
+### `max_bytes_per_broker_scanner`
 
-### max_connection_scheduler_threads_num
+### `max_connection_scheduler_threads_num`
 
-### max_conn_per_user
+### `max_conn_per_user`
 
-### max_create_table_timeout_second
+### `max_create_table_timeout_second`
 
-### max_distribution_pruner_recursion_depth
+### `max_distribution_pruner_recursion_depth`
 
-### max_layout_length_per_row
+### `max_layout_length_per_row`
 
-### max_load_timeout_second
+### `max_load_timeout_second`
 
-### max_mysql_service_task_threads_num
+### `max_mysql_service_task_threads_num`
 
-### max_query_retry_time
+### `max_query_retry_time`
 
-### max_routine_load_job_num
+### `max_routine_load_job_num`
 
-### max_routine_load_task_concurrent_num
+### `max_routine_load_task_concurrent_num`
 
-### max_routine_load_task_num_per_be
+### `max_routine_load_task_num_per_be`
 
-### max_running_rollup_job_num_per_table
+### `max_running_rollup_job_num_per_table`
 
-### max_running_txn_num_per_db
+### `max_running_txn_num_per_db`
 
 This configuration is mainly used to control the number of concurrent load jobs of the same database.
 
@@ -407,171 +407,171 @@ When this error is encountered, it means that the load jobs currently running in
 
 Generally it is not recommended to increase this configuration value. An excessively high number of concurrency may cause excessive system load.
 
-### max_scheduling_tablets
+### `max_scheduling_tablets`
 
-### max_small_file_number
+### `max_small_file_number`
 
-### max_small_file_size_bytes
+### `max_small_file_size_bytes`
 
-### max_tolerable_backend_down_num
+### `max_tolerable_backend_down_num`
 
-### max_unfinished_load_job
+### `max_unfinished_load_job`
 
-### metadata_checkopoint_memory_threshold
+### `metadata_checkopoint_memory_threshold`
 
-### metadata_failure_recovery
+### `metadata_failure_recovery`
 
-### meta_delay_toleration_second
+### `meta_delay_toleration_second`
 
-### meta_dir
+### `meta_dir`
 
-### meta_publish_timeout_ms
+### `meta_publish_timeout_ms`
 
-### min_bytes_per_broker_scanner
+### `min_bytes_per_broker_scanner`
 
-### mini_load_default_timeout_second
+### `mini_load_default_timeout_second`
 
-### min_load_timeout_second
+### `min_load_timeout_second`
 
-### mysql_service_io_threads_num
+### `mysql_service_io_threads_num`
 
-### mysql_service_nio_enabled
+### `mysql_service_nio_enabled`
 
-### net_buffer_length
+### `net_buffer_length`
 
-### net_read_timeout
+### `net_read_timeout`
 
-### net_write_timeout
+### `net_write_timeout`
 
-### parallel_exchange_instance_num
+### `parallel_exchange_instance_num`
 
-### parallel_fragment_exec_instance_num
+### `parallel_fragment_exec_instance_num`
 
-### period_of_auto_resume_min
+### `period_of_auto_resume_min`
 
-### plugin_dir
+### `plugin_dir`
 
-### plugin_enable
+### `plugin_enable`
 
-### priority_networks
+### `priority_networks`
 
-### proxy_auth_enable
+### `proxy_auth_enable`
 
-### proxy_auth_magic_prefix
+### `proxy_auth_magic_prefix`
 
-### publish_version_interval_ms
+### `publish_version_interval_ms`
 
-### publish_version_timeout_second
+### `publish_version_timeout_second`
 
-### qe_max_connection
+### `qe_max_connection`
 
-### qe_slow_log_ms
+### `qe_slow_log_ms`
 
-### query_cache_size
+### `query_cache_size`
 
-### query_cache_type
+### `query_cache_type`
 
-### query_colocate_join_memory_limit_penalty_factor
+### `query_colocate_join_memory_limit_penalty_factor`
 
-### query_port
+### `query_port`
 
-### query_timeout
+### `query_timeout`
 
-### remote_fragment_exec_timeout_ms
+### `remote_fragment_exec_timeout_ms`
 
-### replica_ack_policy
+### `replica_ack_policy`
 
-### replica_delay_recovery_second
+### `replica_delay_recovery_second`
 
-### replica_sync_policy
+### `replica_sync_policy`
 
-### report_queue_size
+### `report_queue_size`
 
-### resource_group
+### `resource_group`
 
-### rewrite_count_distinct_to_bitmap_hll
+### `rewrite_count_distinct_to_bitmap_hll`
 
-### rpc_port
+### `rpc_port`
 
-### schedule_slot_num_per_path
+### `schedule_slot_num_per_path`
 
-### small_file_dir
+### `small_file_dir`
 
-### SQL_AUTO_IS_NULL
+### `SQL_AUTO_IS_NULL`
 
-### sql_mode
+### `sql_mode`
 
-### sql_safe_updates
+### `sql_safe_updates`
 
-### sql_select_limit
+### `sql_select_limit`
 
-### storage_cooldown_second
+### `storage_cooldown_second`
 
-### storage_engine
+### `storage_engine`
 
-### storage_flood_stage_left_capacity_bytes
+### `storage_flood_stage_left_capacity_bytes`
 
-### storage_flood_stage_usage_percent
+### `storage_flood_stage_usage_percent`
 
-### storage_high_watermark_usage_percent
+### `storage_high_watermark_usage_percent`
 
-### storage_min_left_capacity_bytes
+### `storage_min_left_capacity_bytes`
 
-### stream_load_default_timeout_second
+### `stream_load_default_timeout_second`
 
-### sys_log_delete_age
+### `sys_log_delete_age`
 
-### sys_log_dir
+### `sys_log_dir`
 
-### sys_log_level
+### `sys_log_level`
 
-### sys_log_roll_interval
+### `sys_log_roll_interval`
 
-### sys_log_roll_mode
+### `sys_log_roll_mode`
 
-### sys_log_roll_num
+### `sys_log_roll_num`
 
-### sys_log_verbose_modules
+### `sys_log_verbose_modules`
 
-### system_time_zone
+### `system_time_zone`
 
-### tablet_create_timeout_second
+### `tablet_create_timeout_second`
 
-### tablet_delete_timeout_second
+### `tablet_delete_timeout_second`
 
-### tablet_repair_delay_factor_second
+### `tablet_repair_delay_factor_second`
 
-### tablet_stat_update_interval_second
+### `tablet_stat_update_interval_second`
 
-### test_materialized_view
+### `test_materialized_view`
 
-### thrift_backlog_num
+### `thrift_backlog_num`
 
-### thrift_server_max_worker_threads
+### `thrift_server_max_worker_threads`
 
-### time_zone
+### `time_zone`
 
-### tmp_dir
+### `tmp_dir`
 
-### transaction_clean_interval_second
+### `transaction_clean_interval_second`
 
-### tx_isolation
+### `tx_isolation`
 
-### txn_rollback_limit
+### `txn_rollback_limit`
 
-### use_new_tablet_scheduler
+### `use_new_tablet_scheduler`
 
-### use_v2_rollup
+### `use_v2_rollup`
 
-### using_old_load_usage_pattern
+### `using_old_load_usage_pattern`
 
-### Variable Info
+### `Variable Info`
 
-### version
+### `version`
 
-### version_comment
+### `version_comment`
 
-### wait_timeout
+### `wait_timeout`
 
-### with_k8s_certs
+### `with_k8s_certs`
 

--- a/docs/en/administrator-guide/config/fe_config.md
+++ b/docs/en/administrator-guide/config/fe_config.md
@@ -1,7 +1,7 @@
 ---
 {
-    "title": "Configuration",
-    "language": "en"
+    "title": "FE Configuration",
+    "language": "zh-CN"
 }
 ---
 
@@ -24,18 +24,554 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-# Configuration
+<!-- Please sort the configuration alphabetically -->
 
-## brpc_max_body_size
+# FE Configuration
 
-  This configuration is mainly used to modify the parameter max_body_size of brpc. The default configuration is 64M. It usually occurs in multi distinct + no group by + exceeds 1t data. In particular, if you find that the query is stuck, and be appears the word "body size is too large" in log.
+This document mainly introduces the relevant configuration items of FE.
 
-  Because this is a brpc configuration, users can also directly modify this parameter on-the-fly by visiting ```http://host:brpc_port/flags```
+## View configuration items
 
-## max_running_txn_num_per_db
+There are two ways to view the configuration items of FE:
 
-   This configuration is mainly used to control the number of concurrent load job in the same db. The default configuration is 100. When the number of concurrent load job exceeds the configured value, the load which is synchronously executed will fail, such as stream load. The load which is asynchronously will always be in a pending state such as broker load.
+1. FE web page
 
-   It is generally not recommended to change this property. If the current load concurrency exceeds this value, you need to first check if a single load job is too slow, or if there are too many small files, there is no problem of load after merging those small files.
+    Open the FE web page `http://fe_host:fe_http_port/variable` in the browser. You can see the currently effective FE configuration items in `Configure Info`.
+    
+2. View by command
 
-   Error information such as: current running txns on db xxx is xx, larger than limit xx. The above info is related by this property.
+    After the FE is started, you can view the configuration items of the FE in the MySQL client with the following command:
+
+    `ADMIN SHOW FRONTEND CONFIG;`
+
+    The meanings of the columns in the results are as follows:
+
+    * Key: the name of the configuration item.
+    * Value: The value of the current configuration item.
+    * Type: The configuration item value type, such as integer or string.
+    * IsMutable: whether it can be dynamically configured. If true, the configuration item can be dynamically configured at runtime. If false, it means that the configuration item can only be configured in `fe.conf` and takes effect after restarting FE.
+    * MasterOnly: Whether it is a unique configuration item of Master FE node. If it is true, it means that the configuration item is meaningful only at the Master FE node, and is meaningless to other types of FE nodes. If false, it means that the configuration item is meaningful in all types of FE nodes.
+    * Comment: The description of the configuration item.
+
+## Set configuration items
+
+There are two ways to configure FE configuration items:
+
+1. Static configuration
+
+    Add and set configuration items in the `conf/fe.conf` file. The configuration items in `fe.conf` will be read when the FE process starts. Configuration items not in `fe.conf` will use default values.
+    
+2. Dynamic configuration
+
+    After the FE starts, you can set the configuration items dynamically through the following commands. This command requires administrator priviledge.
+
+    `ADMIN SET FRONTEND CONFIG (" fe_config_name "=" fe_config_value ");`
+
+    Not all configuration items support dynamic configuration. You can check whether the dynamic configuration is supported by the `IsMutable` column in the` ADMIN SHOW FRONTEND CONFIG; `command result.
+
+    If the configuration item of `MasterOnly` is modified, the command will be directly forwarded to the Master FE and only the corresponding configuration item in the Master FE will be modified.
+
+    **Configuration items modified in this way will become invalid after the FE process restarts.**
+
+    For more help on this command, you can view it through the `HELP ADMIN SET CONFIG;` command.
+
+## Examples
+
+1. Modify `async_load_task_pool_size`
+
+    Through `ADMIN SHOW FRONTEND CONFIG;` you can see that this configuration item cannot be dynamically configured (`IsMutable` is false). You need to add in `fe.conf`:
+
+    `async_load_task_pool_size = 20`
+
+    Then restart the FE process to take effect the configuration.
+    
+2. Modify `dynamic_partition_enable`
+
+    Through `ADMIN SHOW FRONTEND CONFIG;` you can see that the configuration item can be dynamically configured (`IsMutable` is true). And it is the unique configuration of Master FE. Then first we can connect to any FE and execute the following command to modify the configuration:
+
+    ```
+    ADMIN SET FRONTEND CONFIG ("dynamic_partition_enable" = "true"); `
+    ```
+
+    Afterwards, you can view the modified value with the following command:
+
+    ```
+    set forward_to_master = true;
+    ADMIN SHOW FRONTEND CONFIG;
+    ```
+    
+    After modification in the above manner, if the Master FE restarts or a Master election is performed, the configuration will be invalid. You can add the configuration item directly in `fe.conf` and restart the FE to make the configuration item permanent.
+
+3. Modify `max_distribution_pruner_recursion_depth`
+
+    Through `ADMIN SHOW FRONTEND CONFIG;` you can see that the configuration item can be dynamically configured (`IsMutable` is true). It is not unique to Master FE.
+
+    Similarly, we can modify the configuration by dynamically modifying the configuration command. Because this configuration is not unique to the Master FE, user need to connect to different FEs separately to modify the configuration dynamically, so that all FEs use the modified configuration values.
+
+## Configurations
+
+### alter_table_timeout_second
+
+### async_load_task_pool_size
+
+### audit_log_delete_age
+
+### audit_log_dir
+
+### audit_log_modules
+
+### audit_log_roll_interval
+
+### audit_log_roll_mode
+
+### audit_log_roll_num
+
+### auth_token
+
+### autocommit
+
+### auto_increment_increment
+
+### backup_job_default_timeout_ms
+
+### backup_plugin_path
+
+### balance_load_score_threshold
+
+### batch_size
+
+### bdbje_heartbeat_timeout_second
+
+### bdbje_lock_timeout_second
+
+### broker_load_default_timeout_second
+
+### brpc_idle_wait_max_time
+
+### brpc_number_of_concurrent_requests_processed
+
+### capacity_used_percent_high_water
+
+### catalog_trash_expire_second
+
+### catalog_try_lock_timeout_ms
+
+### character_set_client
+
+### character_set_connection
+
+### character_set_results
+
+### character_set_server
+
+### check_consistency_default_timeout_second
+
+### check_java_version
+
+### clone_capacity_balance_threshold
+
+### clone_checker_interval_second
+
+### clone_distribution_balance_threshold
+
+### clone_high_priority_delay_second
+
+### clone_job_timeout_second
+
+### clone_low_priority_delay_second
+
+### clone_max_job_num
+
+### clone_normal_priority_delay_second
+
+### cluster_id
+
+### cluster_name
+
+### codegen_level
+
+### collation_connection
+
+### collation_database
+
+### collation_server
+
+### consistency_check_end_time
+
+### consistency_check_start_time
+
+### default_rowset_type
+
+### default_storage_medium
+
+### delete_thread_num
+
+### desired_max_waiting_jobs
+
+### disable_balance
+
+### disable_cluster_feature
+
+### disable_colocate_balance
+
+### disable_colocate_join
+
+### disable_colocate_join
+
+### disable_colocate_relocate
+
+### disable_hadoop_load
+
+### disable_load_job
+
+### disable_streaming_preaggregations
+
+### div_precision_increment
+
+### dpp_bytes_per_reduce
+
+### dpp_config_str
+
+### dpp_default_cluster
+
+### dpp_default_config_str
+
+### dpp_hadoop_client_path
+
+### drop_backend_after_decommission
+
+This configuration is used to control whether the system drops the BE after successfully decommissioning the BE. If true, the BE node will be deleted after the BE is successfully offline. If false, after the BE successfully goes offline, the BE will remain in the DECOMMISSION state, but will not be dropped.
+
+This configuration can play a role in certain scenarios. Assume that the initial state of a Doris cluster is one disk per BE node. After running for a period of time, the system has been vertically expanded, that is, each BE node adds 2 new disks. Because Doris currently does not support data balancing among the disks within the BE, the data volume of the initial disk may always be much higher than the data volume of the newly added disk. At this time, we can perform manual inter-disk balancing by the following operations:
+
+1. Set the configuration item to false.
+2. Perform a decommission operation on a certain BE node. This operation will migrate all data on the BE to other nodes.
+3. After the decommission operation is completed, the BE will not be dropped. At this time, cancel the decommission status of the BE. Then the data will start to balance from other BE nodes back to this node. At this time, the data will be evenly distributed to all disks of the BE.
+4. Perform steps 2 and 3 for all BE nodes in sequence, and finally achieve the purpose of disk balancing for all nodes.
+
+### dynamic_partition_check_interval_seconds
+
+### dynamic_partition_enable
+
+### edit_log_port
+
+### edit_log_roll_num
+
+### edit_log_type
+
+### enable_auth_check
+
+### enable_deploy_manager
+
+### enable_insert_strict
+
+### enable_local_replica_selection
+
+### enable_materialized_view
+
+### enable_metric_calculator
+
+### enable_spilling
+
+### enable_token_check
+
+### es_state_sync_interval_second
+
+### event_scheduler
+
+### exec_mem_limit
+
+### export_checker_interval_second
+
+### export_running_job_num_limit
+
+### export_tablet_num_per_task
+
+### export_task_default_timeout_second
+
+### expr_children_limit
+
+### expr_depth_limit
+
+### force_do_metadata_checkpoint
+
+### forward_to_master
+
+### frontend_address
+
+### hadoop_load_default_timeout_second
+
+### heartbeat_mgr_blocking_queue_size
+
+### heartbeat_mgr_threads_num
+
+### history_job_keep_max_second
+
+### http_backlog_num
+
+### http_port
+
+### ignore_meta_check
+
+### init_connect
+
+### insert_load_default_timeout_second
+
+### interactive_timeout
+
+### is_report_success
+
+### label_clean_interval_second
+
+### label_keep_max_second
+
+### language
+
+### license
+
+### load_checker_interval_second
+
+### load_etl_thread_num_high_priority
+
+### load_etl_thread_num_normal_priority
+
+### load_input_size_limit_gb
+
+### load_mem_limit
+
+### load_pending_thread_num_high_priority
+
+### load_pending_thread_num_normal_priority
+
+### load_running_job_num_limit
+
+### load_straggler_wait_second
+
+### locale
+
+### log_roll_size_mb
+
+### lower_case_table_names
+
+### master_sync_policy
+
+### max_agent_task_threads_num
+
+### max_allowed_packet
+
+### max_backend_down_time_second
+
+### max_balancing_tablets
+
+### max_bdbje_clock_delta_ms
+
+### max_broker_concurrency
+
+### max_bytes_per_broker_scanner
+
+### max_connection_scheduler_threads_num
+
+### max_conn_per_user
+
+### max_create_table_timeout_second
+
+### max_distribution_pruner_recursion_depth
+
+### max_layout_length_per_row
+
+### max_load_timeout_second
+
+### max_mysql_service_task_threads_num
+
+### max_query_retry_time
+
+### max_routine_load_job_num
+
+### max_routine_load_task_concurrent_num
+
+### max_routine_load_task_num_per_be
+
+### max_running_rollup_job_num_per_table
+
+### max_running_txn_num_per_db
+
+This configuration is mainly used to control the number of concurrent load jobs of the same database.
+
+When there are too many load jobs running in the cluster, the newly submitted load jobs may report errors:
+
+```
+current running txns on db xxx is xx, larger than limit xx
+```
+
+When this error is encountered, it means that the load jobs currently running in the cluster exceeds the configuration value. At this time, it is recommended to wait on the business side and retry the load jobs.
+
+Generally it is not recommended to increase this configuration value. An excessively high number of concurrency may cause excessive system load.
+
+### max_scheduling_tablets
+
+### max_small_file_number
+
+### max_small_file_size_bytes
+
+### max_tolerable_backend_down_num
+
+### max_unfinished_load_job
+
+### metadata_checkopoint_memory_threshold
+
+### metadata_failure_recovery
+
+### meta_delay_toleration_second
+
+### meta_dir
+
+### meta_publish_timeout_ms
+
+### min_bytes_per_broker_scanner
+
+### mini_load_default_timeout_second
+
+### min_load_timeout_second
+
+### mysql_service_io_threads_num
+
+### mysql_service_nio_enabled
+
+### net_buffer_length
+
+### net_read_timeout
+
+### net_write_timeout
+
+### parallel_exchange_instance_num
+
+### parallel_fragment_exec_instance_num
+
+### period_of_auto_resume_min
+
+### plugin_dir
+
+### plugin_enable
+
+### priority_networks
+
+### proxy_auth_enable
+
+### proxy_auth_magic_prefix
+
+### publish_version_interval_ms
+
+### publish_version_timeout_second
+
+### qe_max_connection
+
+### qe_slow_log_ms
+
+### query_cache_size
+
+### query_cache_type
+
+### query_colocate_join_memory_limit_penalty_factor
+
+### query_port
+
+### query_timeout
+
+### remote_fragment_exec_timeout_ms
+
+### replica_ack_policy
+
+### replica_delay_recovery_second
+
+### replica_sync_policy
+
+### report_queue_size
+
+### resource_group
+
+### rewrite_count_distinct_to_bitmap_hll
+
+### rpc_port
+
+### schedule_slot_num_per_path
+
+### small_file_dir
+
+### SQL_AUTO_IS_NULL
+
+### sql_mode
+
+### sql_safe_updates
+
+### sql_select_limit
+
+### storage_cooldown_second
+
+### storage_engine
+
+### storage_flood_stage_left_capacity_bytes
+
+### storage_flood_stage_usage_percent
+
+### storage_high_watermark_usage_percent
+
+### storage_min_left_capacity_bytes
+
+### stream_load_default_timeout_second
+
+### sys_log_delete_age
+
+### sys_log_dir
+
+### sys_log_level
+
+### sys_log_roll_interval
+
+### sys_log_roll_mode
+
+### sys_log_roll_num
+
+### sys_log_verbose_modules
+
+### system_time_zone
+
+### tablet_create_timeout_second
+
+### tablet_delete_timeout_second
+
+### tablet_repair_delay_factor_second
+
+### tablet_stat_update_interval_second
+
+### test_materialized_view
+
+### thrift_backlog_num
+
+### thrift_server_max_worker_threads
+
+### time_zone
+
+### tmp_dir
+
+### transaction_clean_interval_second
+
+### tx_isolation
+
+### txn_rollback_limit
+
+### use_new_tablet_scheduler
+
+### use_v2_rollup
+
+### using_old_load_usage_pattern
+
+### Variable Info
+
+### version
+
+### version_comment
+
+### wait_timeout
+
+### with_k8s_certs
+

--- a/docs/zh-CN/administrator-guide/config/be_config.md
+++ b/docs/zh-CN/administrator-guide/config/be_config.md
@@ -1,0 +1,390 @@
+---
+{
+    "title": "BE 配置项",
+    "language": "zh-CN"
+}
+---
+
+<!-- 
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<!-- Please sort the configuration alphabetically -->
+
+# BE 配置项
+
+该文档主要介绍 BE 的相关配置项。
+
+## 查看配置项
+（TODO）
+
+## 设置配置项
+（TODO）
+
+## 应用举例
+（TODO）
+
+## 配置项列表
+
+### alter_tablet_worker_count
+
+### base_compaction_check_interval_seconds
+
+### base_compaction_interval_seconds_since_last_operation
+
+### base_compaction_num_cumulative_deltas
+
+### base_compaction_num_threads_per_disk
+
+### base_compaction_write_mbytes_per_sec
+
+### base_cumulative_delta_ratio
+
+### be_port
+
+### be_service_threads
+
+### brpc_max_body_size
+
+这个配置主要用来修改 brpc 的参数 `max_body_size`。
+
+有时查询失败，在 BE 日志中会出现 `body_size is too large` 的错误信息。这可能发生在 SQL 模式为 multi distinct + 无 group by + 超过1T 数据量的情况下。这个错误表示 brpc 的包大小超过了配置值。此时可以通过调大该配置避免这个错误。
+
+由于这是一个 brpc 的配置，用户也可以在运行中直接修改该参数。通过访问 `http://be_host:brpc_port/flags` 修改。
+
+### brpc_port
+
+### buffer_pool_clean_pages_limit
+
+### buffer_pool_limit
+
+### check_consistency_worker_count
+
+### chunk_reserved_bytes_limit
+
+### clear_transaction_task_worker_count
+
+### clone_worker_count
+
+### cluster_id
+
+### column_dictionary_key_ratio_threshold
+
+### column_dictionary_key_size_threshold
+
+### compress_rowbatches
+
+### create_tablet_worker_count
+
+### cumulative_compaction_budgeted_bytes
+
+### cumulative_compaction_check_interval_seconds
+
+### cumulative_compaction_num_threads_per_disk
+
+### cumulative_compaction_skip_window_seconds
+
+### default_num_rows_per_column_file_block
+
+### default_query_options
+
+### default_rowset_type
+
+### delete_worker_count
+
+### disable_mem_pools
+
+### disable_storage_page_cache
+
+### disk_stat_monitor_interval
+
+### doris_cgroups
+
+### doris_max_pushdown_conjuncts_return_rate
+
+### doris_max_scan_key_num
+
+### doris_scan_range_row_count
+
+### doris_scanner_queue_size
+
+### doris_scanner_row_num
+
+### doris_scanner_thread_pool_queue_size
+
+### doris_scanner_thread_pool_thread_num
+
+### download_low_speed_limit_kbps
+
+### download_low_speed_time
+
+### download_worker_count
+
+### drop_tablet_worker_count
+
+### enable_metric_calculator
+
+### enable_partitioned_aggregation
+
+### enable_prefetch
+
+### enable_quadratic_probing
+
+### enable_system_metrics
+
+### enable_token_check
+
+### es_http_timeout_ms
+
+### es_scroll_keepalive
+
+### etl_thread_pool_queue_size
+
+### etl_thread_pool_size
+
+### exchg_node_buffer_size_bytes
+
+### file_descriptor_cache_capacity
+
+### file_descriptor_cache_clean_interval
+
+### flush_thread_num_per_store
+
+### force_recovery
+
+### fragment_pool_queue_size
+
+### fragment_pool_thread_num
+
+### heartbeat_service_port
+
+### heartbeat_service_thread_count
+
+### ignore_broken_disk
+
+### inc_rowset_expired_sec
+
+### index_stream_cache_capacity
+
+### load_data_reserve_hours
+
+### load_error_log_reserve_hours
+
+### load_process_max_memory_limit_bytes
+
+### load_process_max_memory_limit_percent
+
+### local_library_dir
+
+### log_buffer_level
+
+### madvise_huge_pages
+
+### make_snapshot_worker_count
+
+### max_client_cache_size_per_host
+
+### max_compaction_concurrency
+
+### max_consumer_num_per_group
+
+### max_cumulative_compaction_num_singleton_deltas
+
+### max_download_speed_kbps
+
+### max_free_io_buffers
+
+### max_garbage_sweep_interval
+
+### max_memory_sink_batch_count
+
+### max_percentage_of_error_disk
+
+### max_runnings_transactions_per_txn_map
+
+### max_tablet_num_per_shard
+
+### mem_limit
+
+### memory_limitation_per_thread_for_schema_change
+
+### memory_maintenance_sleep_time_s
+
+### memory_max_alignment
+
+### min_buffer_size
+
+### min_compaction_failure_interval_sec
+
+### min_cumulative_compaction_num_singleton_deltas
+
+### min_file_descriptor_number
+
+### min_garbage_sweep_interval
+
+### mmap_buffers
+
+### num_cores
+
+### num_disks
+
+### num_threads_per_core
+
+### num_threads_per_disk
+
+### number_tablet_writer_threads
+
+### path_gc_check
+
+### path_gc_check_interval_second
+
+### path_gc_check_step
+
+### path_gc_check_step_interval_ms
+
+### path_scan_interval_second
+
+### pending_data_expire_time_sec
+
+### periodic_counter_update_period_ms
+
+### plugin_path
+
+### port
+
+### pprof_profile_dir
+
+### priority_networks
+
+### priority_queue_remaining_tasks_increased_frequency
+
+### publish_version_worker_count
+
+### pull_load_task_dir
+
+### push_worker_count_high_priority
+
+### push_worker_count_normal_priority
+
+### push_write_mbytes_per_sec
+
+### query_scratch_dirs
+
+### read_size
+
+### release_snapshot_worker_count
+
+### report_disk_state_interval_seconds
+
+### report_tablet_interval_seconds
+
+### report_task_interval_seconds
+
+### result_buffer_cancelled_interval_time
+
+### routine_load_thread_pool_size
+
+### row_nums_check
+
+### scan_context_gc_interval_min
+
+### scratch_dirs
+
+### serialize_batch
+
+### sleep_five_seconds
+
+### sleep_one_second
+
+### small_file_dir
+
+### snapshot_expire_time_sec
+
+### sorter_block_size
+
+### status_report_interval
+
+### storage_flood_stage_left_capacity_bytes
+
+### storage_flood_stage_usage_percent
+
+### storage_medium_migrate_count
+
+### storage_page_cache_limit
+
+### storage_root_path
+
+### streaming_load_max_mb
+
+### streaming_load_rpc_max_alive_time_sec
+
+### sync_tablet_meta
+
+### sys_log_dir
+
+### sys_log_level
+
+### sys_log_roll_mode
+
+### sys_log_roll_num
+
+### sys_log_verbose_level
+
+### sys_log_verbose_modules
+
+### tablet_map_shard_size
+
+### tablet_meta_checkpoint_min_interval_secs
+
+### tablet_meta_checkpoint_min_new_rowsets_num
+
+### tablet_stat_cache_update_interval_second
+
+### tablet_writer_open_rpc_timeout_sec
+
+### tc_free_memory_rate
+
+### tc_use_memory_min
+
+### thrift_connect_timeout_seconds
+
+### thrift_rpc_timeout_ms
+
+### trash_file_expire_time_sec
+
+### txn_commit_rpc_timeout_ms
+
+### txn_map_shard_size
+
+### txn_shard_size
+
+### unused_rowset_monitor_interval
+
+### upload_worker_count
+
+### use_mmap_allocate_chunk
+
+### user_function_dir
+
+### web_log_bytes
+
+### webserver_num_workers
+
+### webserver_port
+
+### write_buffer_size

--- a/docs/zh-CN/administrator-guide/config/be_config.md
+++ b/docs/zh-CN/administrator-guide/config/be_config.md
@@ -41,25 +41,25 @@ under the License.
 
 ## 配置项列表
 
-### alter_tablet_worker_count
+### `alter_tablet_worker_count`
 
-### base_compaction_check_interval_seconds
+### `base_compaction_check_interval_seconds`
 
-### base_compaction_interval_seconds_since_last_operation
+### `base_compaction_interval_seconds_since_last_operation`
 
-### base_compaction_num_cumulative_deltas
+### `base_compaction_num_cumulative_deltas`
 
-### base_compaction_num_threads_per_disk
+### `base_compaction_num_threads_per_disk`
 
-### base_compaction_write_mbytes_per_sec
+### `base_compaction_write_mbytes_per_sec`
 
-### base_cumulative_delta_ratio
+### `base_cumulative_delta_ratio`
 
-### be_port
+### `be_port`
 
-### be_service_threads
+### `be_service_threads`
 
-### brpc_max_body_size
+### `brpc_max_body_size`
 
 这个配置主要用来修改 brpc 的参数 `max_body_size`。
 
@@ -67,324 +67,324 @@ under the License.
 
 由于这是一个 brpc 的配置，用户也可以在运行中直接修改该参数。通过访问 `http://be_host:brpc_port/flags` 修改。
 
-### brpc_port
+### `brpc_port`
 
-### buffer_pool_clean_pages_limit
+### `buffer_pool_clean_pages_limit`
 
-### buffer_pool_limit
+### `buffer_pool_limit`
 
-### check_consistency_worker_count
+### `check_consistency_worker_count`
 
-### chunk_reserved_bytes_limit
+### `chunk_reserved_bytes_limit`
 
-### clear_transaction_task_worker_count
+### `clear_transaction_task_worker_count`
 
-### clone_worker_count
+### `clone_worker_count`
 
-### cluster_id
+### `cluster_id`
 
-### column_dictionary_key_ratio_threshold
+### `column_dictionary_key_ratio_threshold`
 
-### column_dictionary_key_size_threshold
+### `column_dictionary_key_size_threshold`
 
-### compress_rowbatches
+### `compress_rowbatches`
 
-### create_tablet_worker_count
+### `create_tablet_worker_count`
 
-### cumulative_compaction_budgeted_bytes
+### `cumulative_compaction_budgeted_bytes`
 
-### cumulative_compaction_check_interval_seconds
+### `cumulative_compaction_check_interval_seconds`
 
-### cumulative_compaction_num_threads_per_disk
+### `cumulative_compaction_num_threads_per_disk`
 
-### cumulative_compaction_skip_window_seconds
+### `cumulative_compaction_skip_window_seconds`
 
-### default_num_rows_per_column_file_block
+### `default_num_rows_per_column_file_block`
 
-### default_query_options
+### `default_query_options`
 
-### default_rowset_type
+### `default_rowset_type`
 
-### delete_worker_count
+### `delete_worker_count`
 
-### disable_mem_pools
+### `disable_mem_pools`
 
-### disable_storage_page_cache
+### `disable_storage_page_cache`
 
-### disk_stat_monitor_interval
+### `disk_stat_monitor_interval`
 
-### doris_cgroups
+### `doris_cgroups`
 
-### doris_max_pushdown_conjuncts_return_rate
+### `doris_max_pushdown_conjuncts_return_rate`
 
-### doris_max_scan_key_num
+### `doris_max_scan_key_num`
 
-### doris_scan_range_row_count
+### `doris_scan_range_row_count`
 
-### doris_scanner_queue_size
+### `doris_scanner_queue_size`
 
-### doris_scanner_row_num
+### `doris_scanner_row_num`
 
-### doris_scanner_thread_pool_queue_size
+### `doris_scanner_thread_pool_queue_size`
 
-### doris_scanner_thread_pool_thread_num
+### `doris_scanner_thread_pool_thread_num`
 
-### download_low_speed_limit_kbps
+### `download_low_speed_limit_kbps`
 
-### download_low_speed_time
+### `download_low_speed_time`
 
-### download_worker_count
+### `download_worker_count`
 
-### drop_tablet_worker_count
+### `drop_tablet_worker_count`
 
-### enable_metric_calculator
+### `enable_metric_calculator`
 
-### enable_partitioned_aggregation
+### `enable_partitioned_aggregation`
 
-### enable_prefetch
+### `enable_prefetch`
 
-### enable_quadratic_probing
+### `enable_quadratic_probing`
 
-### enable_system_metrics
+### `enable_system_metrics`
 
-### enable_token_check
+### `enable_token_check`
 
-### es_http_timeout_ms
+### `es_http_timeout_ms`
 
-### es_scroll_keepalive
+### `es_scroll_keepalive`
 
-### etl_thread_pool_queue_size
+### `etl_thread_pool_queue_size`
 
-### etl_thread_pool_size
+### `etl_thread_pool_size`
 
-### exchg_node_buffer_size_bytes
+### `exchg_node_buffer_size_bytes`
 
-### file_descriptor_cache_capacity
+### `file_descriptor_cache_capacity`
 
-### file_descriptor_cache_clean_interval
+### `file_descriptor_cache_clean_interval`
 
-### flush_thread_num_per_store
+### `flush_thread_num_per_store`
 
-### force_recovery
+### `force_recovery`
 
-### fragment_pool_queue_size
+### `fragment_pool_queue_size`
 
-### fragment_pool_thread_num
+### `fragment_pool_thread_num`
 
-### heartbeat_service_port
+### `heartbeat_service_port`
 
-### heartbeat_service_thread_count
+### `heartbeat_service_thread_count`
 
-### ignore_broken_disk
+### `ignore_broken_disk`
 
-### inc_rowset_expired_sec
+### `inc_rowset_expired_sec`
 
-### index_stream_cache_capacity
+### `index_stream_cache_capacity`
 
-### load_data_reserve_hours
+### `load_data_reserve_hours`
 
-### load_error_log_reserve_hours
+### `load_error_log_reserve_hours`
 
-### load_process_max_memory_limit_bytes
+### `load_process_max_memory_limit_bytes`
 
-### load_process_max_memory_limit_percent
+### `load_process_max_memory_limit_percent`
 
-### local_library_dir
+### `local_library_dir`
 
-### log_buffer_level
+### `log_buffer_level`
 
-### madvise_huge_pages
+### `madvise_huge_pages`
 
-### make_snapshot_worker_count
+### `make_snapshot_worker_count`
 
-### max_client_cache_size_per_host
+### `max_client_cache_size_per_host`
 
-### max_compaction_concurrency
+### `max_compaction_concurrency`
 
-### max_consumer_num_per_group
+### `max_consumer_num_per_group`
 
-### max_cumulative_compaction_num_singleton_deltas
+### `max_cumulative_compaction_num_singleton_deltas`
 
-### max_download_speed_kbps
+### `max_download_speed_kbps`
 
-### max_free_io_buffers
+### `max_free_io_buffers`
 
-### max_garbage_sweep_interval
+### `max_garbage_sweep_interval`
 
-### max_memory_sink_batch_count
+### `max_memory_sink_batch_count`
 
-### max_percentage_of_error_disk
+### `max_percentage_of_error_disk`
 
-### max_runnings_transactions_per_txn_map
+### `max_runnings_transactions_per_txn_map`
 
-### max_tablet_num_per_shard
+### `max_tablet_num_per_shard`
 
-### mem_limit
+### `mem_limit`
 
-### memory_limitation_per_thread_for_schema_change
+### `memory_limitation_per_thread_for_schema_change`
 
-### memory_maintenance_sleep_time_s
+### `memory_maintenance_sleep_time_s`
 
-### memory_max_alignment
+### `memory_max_alignment`
 
-### min_buffer_size
+### `min_buffer_size`
 
-### min_compaction_failure_interval_sec
+### `min_compaction_failure_interval_sec`
 
-### min_cumulative_compaction_num_singleton_deltas
+### `min_cumulative_compaction_num_singleton_deltas`
 
-### min_file_descriptor_number
+### `min_file_descriptor_number`
 
-### min_garbage_sweep_interval
+### `min_garbage_sweep_interval`
 
-### mmap_buffers
+### `mmap_buffers`
 
-### num_cores
+### `num_cores`
 
-### num_disks
+### `num_disks`
 
-### num_threads_per_core
+### `num_threads_per_core`
 
-### num_threads_per_disk
+### `num_threads_per_disk`
 
-### number_tablet_writer_threads
+### `number_tablet_writer_threads`
 
-### path_gc_check
+### `path_gc_check`
 
-### path_gc_check_interval_second
+### `path_gc_check_interval_second`
 
-### path_gc_check_step
+### `path_gc_check_step`
 
-### path_gc_check_step_interval_ms
+### `path_gc_check_step_interval_ms`
 
-### path_scan_interval_second
+### `path_scan_interval_second`
 
-### pending_data_expire_time_sec
+### `pending_data_expire_time_sec`
 
-### periodic_counter_update_period_ms
+### `periodic_counter_update_period_ms`
 
-### plugin_path
+### `plugin_path`
 
-### port
+### `port`
 
-### pprof_profile_dir
+### `pprof_profile_dir`
 
-### priority_networks
+### `priority_networks`
 
-### priority_queue_remaining_tasks_increased_frequency
+### `priority_queue_remaining_tasks_increased_frequency`
 
-### publish_version_worker_count
+### `publish_version_worker_count`
 
-### pull_load_task_dir
+### `pull_load_task_dir`
 
-### push_worker_count_high_priority
+### `push_worker_count_high_priority`
 
-### push_worker_count_normal_priority
+### `push_worker_count_normal_priority`
 
-### push_write_mbytes_per_sec
+### `push_write_mbytes_per_sec`
 
-### query_scratch_dirs
+### `query_scratch_dirs`
 
-### read_size
+### `read_size`
 
-### release_snapshot_worker_count
+### `release_snapshot_worker_count`
 
-### report_disk_state_interval_seconds
+### `report_disk_state_interval_seconds`
 
-### report_tablet_interval_seconds
+### `report_tablet_interval_seconds`
 
-### report_task_interval_seconds
+### `report_task_interval_seconds`
 
-### result_buffer_cancelled_interval_time
+### `result_buffer_cancelled_interval_time`
 
-### routine_load_thread_pool_size
+### `routine_load_thread_pool_size`
 
-### row_nums_check
+### `row_nums_check`
 
-### scan_context_gc_interval_min
+### `scan_context_gc_interval_min`
 
-### scratch_dirs
+### `scratch_dirs`
 
-### serialize_batch
+### `serialize_batch`
 
-### sleep_five_seconds
+### `sleep_five_seconds`
 
-### sleep_one_second
+### `sleep_one_second`
 
-### small_file_dir
+### `small_file_dir`
 
-### snapshot_expire_time_sec
+### `snapshot_expire_time_sec`
 
-### sorter_block_size
+### `sorter_block_size`
 
-### status_report_interval
+### `status_report_interval`
 
-### storage_flood_stage_left_capacity_bytes
+### `storage_flood_stage_left_capacity_bytes`
 
-### storage_flood_stage_usage_percent
+### `storage_flood_stage_usage_percent`
 
-### storage_medium_migrate_count
+### `storage_medium_migrate_count`
 
-### storage_page_cache_limit
+### `storage_page_cache_limit`
 
-### storage_root_path
+### `storage_root_path`
 
-### streaming_load_max_mb
+### `streaming_load_max_mb`
 
-### streaming_load_rpc_max_alive_time_sec
+### `streaming_load_rpc_max_alive_time_sec`
 
-### sync_tablet_meta
+### `sync_tablet_meta`
 
-### sys_log_dir
+### `sys_log_dir`
 
-### sys_log_level
+### `sys_log_level`
 
-### sys_log_roll_mode
+### `sys_log_roll_mode`
 
-### sys_log_roll_num
+### `sys_log_roll_num`
 
-### sys_log_verbose_level
+### `sys_log_verbose_level`
 
-### sys_log_verbose_modules
+### `sys_log_verbose_modules`
 
-### tablet_map_shard_size
+### `tablet_map_shard_size`
 
-### tablet_meta_checkpoint_min_interval_secs
+### `tablet_meta_checkpoint_min_interval_secs`
 
-### tablet_meta_checkpoint_min_new_rowsets_num
+### `tablet_meta_checkpoint_min_new_rowsets_num`
 
-### tablet_stat_cache_update_interval_second
+### `tablet_stat_cache_update_interval_second`
 
-### tablet_writer_open_rpc_timeout_sec
+### `tablet_writer_open_rpc_timeout_sec`
 
-### tc_free_memory_rate
+### `tc_free_memory_rate`
 
-### tc_use_memory_min
+### `tc_use_memory_min`
 
-### thrift_connect_timeout_seconds
+### `thrift_connect_timeout_seconds`
 
-### thrift_rpc_timeout_ms
+### `thrift_rpc_timeout_ms`
 
-### trash_file_expire_time_sec
+### `trash_file_expire_time_sec`
 
-### txn_commit_rpc_timeout_ms
+### `txn_commit_rpc_timeout_ms`
 
-### txn_map_shard_size
+### `txn_map_shard_size`
 
-### txn_shard_size
+### `txn_shard_size`
 
-### unused_rowset_monitor_interval
+### `unused_rowset_monitor_interval`
 
-### upload_worker_count
+### `upload_worker_count`
 
-### use_mmap_allocate_chunk
+### `use_mmap_allocate_chunk`
 
-### user_function_dir
+### `user_function_dir`
 
-### web_log_bytes
+### `web_log_bytes`
 
-### webserver_num_workers
+### `webserver_num_workers`
 
-### webserver_port
+### `webserver_port`
 
-### write_buffer_size
+### `write_buffer_size`

--- a/docs/zh-CN/administrator-guide/config/fe_config.md
+++ b/docs/zh-CN/administrator-guide/config/fe_config.md
@@ -1,6 +1,6 @@
 ---
 {
-    "title": "基本配置",
+    "title": "FE 配置项",
     "language": "zh-CN"
 }
 ---
@@ -24,18 +24,554 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-# 基本配置
+<!-- Please sort the configuration alphabetically -->
 
-## brpc_max_body_size
+# FE 配置项
 
-  这个配置主要用来修改 brpc 的参数 max_body_size ，默认配置是 64M。一般发生在 multi distinct + 无 group by + 超过1T 数据量的情况下。尤其如果发现查询卡死，且 BE 出现类似 body_size is too large 的字样。
+该文档主要介绍 FE 的相关配置项。
 
-  由于这是一个 brpc 的配置，用户也可以在运行中直接修改该参数。通过访问 http://host:brpc_port/flags 修改。
+## 查看配置项
 
-## max_running_txn_num_per_db
+FE 的配置项有两种方式进行查看：
 
-  这个配置主要是用来控制同一个 db 的并发导入个数的，默认配置是100。当导入的并发执行的个数超过这个配置的值的时候，同步执行的导入就会失败比如 stream load。异步执行的导入就会一直处在 pending 状态比如 broker load。
+1. FE 前端页面查看
 
-  一般来说不推荐更改这个并发数。如果当前导入并发超过这个值，则需要先检查是否单个导入任务过慢，或者小文件太多没有合并后导入的问题。
+    在浏览器中打开 FE 前端页面 `http://fe_host:fe_http_port/variable`。在 `Configure Info` 中可以看到当前生效的 FE 配置项。
+    
+2. 通过命令查看
 
-  报错信息比如：current running txns on db xxx is xx, larger than limit xx。就属于这类问题。
+    FE 启动后，可以在 MySQL 客户端中，通过以下命令查看 FE 的配置项：
+    
+    `ADMIN SHOW FRONTEND CONFIG;`
+    
+    结果中各列含义如下：
+    
+    * Key：配置项名称。
+    * Value：当前配置项的值。
+    * Type：配置项值类型，如果整型、字符串。
+    * IsMutable：是否可以动态配置。如果为 true，表示该配置项可以在运行时进行动态配置。如果false，则表示该配置项只能在 `fe.conf` 中配置并且重启 FE 后生效。
+    * MasterOnly：是否为 Master FE 节点独有的配置项。如果为 true，则表示该配置项仅在 Master FE 节点有意义，对其他类型的 FE 节点无意义。如果为 false，则表示该配置项在所有 FE 节点中均有意义。
+    * Comment：配置项的描述。
+
+## 设置配置项
+
+FE 的配置项有两种方式进行配置：
+
+1. 静态配置
+
+    在 `conf/fe.conf` 文件中添加和设置配置项。`fe.conf` 中的配置项会在 FE 进程启动时被读取。没有在 `fe.conf` 中的配置项将使用默认值。
+    
+2. 动态配置
+
+    FE 启动后，可以通过以下命令动态设置配置项。该命令需要管理员权限。
+    
+    `ADMIN SET FRONTEND CONFIG ("fe_config_name" = "fe_config_value");`
+    
+    不是所有配置项都支持动态配置。可以通过 `ADMIN SHOW FRONTEND CONFIG;` 命令结果中的 `IsMutable` 列查看是否支持动态配置。
+    
+    如果是修改 `MasterOnly` 的配置项，则该命令会直接转发给 Master FE 并且仅修改 Master FE 中对应的配置项。
+    
+    **通过该方式修改的配置项将在 FE 进程重启后失效。**
+    
+    更多该命令的帮助，可以通过 `HELP ADMIN SET CONFIG;` 命令查看。
+    
+## 应用举例
+
+1. 修改 `async_load_task_pool_size`
+
+    通过 `ADMIN SHOW FRONTEND CONFIG;` 可以查看到该配置项不能动态配置（`IsMutable` 为 false）。则需要在 `fe.conf` 中添加：
+    
+    `async_load_task_pool_size=20`
+    
+    之后重启 FE 进程以生效该配置。
+    
+2. 修改 `dynamic_partition_enable`
+
+    通过 `ADMIN SHOW FRONTEND CONFIG;` 可以查看到该配置项可以动态配置（`IsMutable` 为 true）。并且是 Master FE 独有配置。则首先我们可以连接到任意 FE，执行如下命令修改配置：
+    
+    ```
+    ADMIN SET FRONTEND CONFIG ("dynamic_partition_enable" = "true");`
+    ```
+
+    之后可以通过如下命令查看修改后的值：
+    
+    ```
+    set forward_to_master=true;
+    ADMIN SHOW FRONTEND CONFIG;
+    ```
+    
+    通过以上方式修改后，如果 Master FE 重启或进行了 Master 切换，则配置将失效。可以通过在 `fe.conf` 中直接添加配置项，并重启 FE 后，永久生效该配置项。
+
+3. 修改 `max_distribution_pruner_recursion_depth`
+
+    通过 `ADMIN SHOW FRONTEND CONFIG;` 可以查看到该配置项可以动态配置（`IsMutable` 为 true）。并且不是 Master FE 独有配置。
+    
+    同样，我们可以通过动态修改配置的命令修改该配置。因为该配置不是 Master FE 独有配置，所以需要单独连接到不同的 FE，进行动态修改配置的操作，这样才能保证所有 FE 都使用了修改后的配置值。
+
+## 配置项列表
+
+### alter_table_timeout_second
+
+### async_load_task_pool_size
+
+### audit_log_delete_age
+
+### audit_log_dir
+
+### audit_log_modules
+
+### audit_log_roll_interval
+
+### audit_log_roll_mode
+
+### audit_log_roll_num
+
+### auth_token
+
+### autocommit
+
+### auto_increment_increment
+
+### backup_job_default_timeout_ms
+
+### backup_plugin_path
+
+### balance_load_score_threshold
+
+### batch_size
+
+### bdbje_heartbeat_timeout_second
+
+### bdbje_lock_timeout_second
+
+### broker_load_default_timeout_second
+
+### brpc_idle_wait_max_time
+
+### brpc_number_of_concurrent_requests_processed
+
+### capacity_used_percent_high_water
+
+### catalog_trash_expire_second
+
+### catalog_try_lock_timeout_ms
+
+### character_set_client
+
+### character_set_connection
+
+### character_set_results
+
+### character_set_server
+
+### check_consistency_default_timeout_second
+
+### check_java_version
+
+### clone_capacity_balance_threshold
+
+### clone_checker_interval_second
+
+### clone_distribution_balance_threshold
+
+### clone_high_priority_delay_second
+
+### clone_job_timeout_second
+
+### clone_low_priority_delay_second
+
+### clone_max_job_num
+
+### clone_normal_priority_delay_second
+
+### cluster_id
+
+### cluster_name
+
+### codegen_level
+
+### collation_connection
+
+### collation_database
+
+### collation_server
+
+### consistency_check_end_time
+
+### consistency_check_start_time
+
+### default_rowset_type
+
+### default_storage_medium
+
+### delete_thread_num
+
+### desired_max_waiting_jobs
+
+### disable_balance
+
+### disable_cluster_feature
+
+### disable_colocate_balance
+
+### disable_colocate_join
+
+### disable_colocate_join
+
+### disable_colocate_relocate
+
+### disable_hadoop_load
+
+### disable_load_job
+
+### disable_streaming_preaggregations
+
+### div_precision_increment
+
+### dpp_bytes_per_reduce
+
+### dpp_config_str
+
+### dpp_default_cluster
+
+### dpp_default_config_str
+
+### dpp_hadoop_client_path
+
+### drop_backend_after_decommission
+
+该配置用于控制系统在成功下线（Decommission） BE 后，是否 Drop 该 BE。如果为 true，则在 BE 成功下线后，会删除掉该BE节点。如果为 false，则在 BE 成功下线后，该 BE 会一直处于 DECOMMISSION 状态，但不会被删除。
+
+该配置在某些场景下可以发挥作用。假设一个 Doris 集群的初始状态为每个 BE 节点有一块磁盘。运行一段时间后，系统进行了纵向扩容，即每个 BE 节点新增2块磁盘。因为 Doris 当前还不支持 BE 内部各磁盘间的数据均衡，所以会导致初始磁盘的数据量可能一直远高于新增磁盘的数据量。此时我们可以通过以下操作进行人工的磁盘间均衡：
+
+1. 将该配置项置为 false。
+2. 对某一个 BE 节点，执行 decommission 操作，该操作会将该 BE 上的数据全部迁移到其他节点中。
+3. decommission 操作完成后，该 BE 不会被删除。此时，取消掉该 BE 的 decommission 状态。则数据会开始从其他 BE 节点均衡回这个节点。此时，数据将会均匀的分布到该 BE 的所有磁盘上。
+4. 对所有 BE 节点依次执行 2，3 两个步骤，最终达到所有节点磁盘均衡的目的。
+
+### dynamic_partition_check_interval_seconds
+
+### dynamic_partition_enable
+
+### edit_log_port
+
+### edit_log_roll_num
+
+### edit_log_type
+
+### enable_auth_check
+
+### enable_deploy_manager
+
+### enable_insert_strict
+
+### enable_local_replica_selection
+
+### enable_materialized_view
+
+### enable_metric_calculator
+
+### enable_spilling
+
+### enable_token_check
+
+### es_state_sync_interval_second
+
+### event_scheduler
+
+### exec_mem_limit
+
+### export_checker_interval_second
+
+### export_running_job_num_limit
+
+### export_tablet_num_per_task
+
+### export_task_default_timeout_second
+
+### expr_children_limit
+
+### expr_depth_limit
+
+### force_do_metadata_checkpoint
+
+### forward_to_master
+
+### frontend_address
+
+### hadoop_load_default_timeout_second
+
+### heartbeat_mgr_blocking_queue_size
+
+### heartbeat_mgr_threads_num
+
+### history_job_keep_max_second
+
+### http_backlog_num
+
+### http_port
+
+### ignore_meta_check
+
+### init_connect
+
+### insert_load_default_timeout_second
+
+### interactive_timeout
+
+### is_report_success
+
+### label_clean_interval_second
+
+### label_keep_max_second
+
+### language
+
+### license
+
+### load_checker_interval_second
+
+### load_etl_thread_num_high_priority
+
+### load_etl_thread_num_normal_priority
+
+### load_input_size_limit_gb
+
+### load_mem_limit
+
+### load_pending_thread_num_high_priority
+
+### load_pending_thread_num_normal_priority
+
+### load_running_job_num_limit
+
+### load_straggler_wait_second
+
+### locale
+
+### log_roll_size_mb
+
+### lower_case_table_names
+
+### master_sync_policy
+
+### max_agent_task_threads_num
+
+### max_allowed_packet
+
+### max_backend_down_time_second
+
+### max_balancing_tablets
+
+### max_bdbje_clock_delta_ms
+
+### max_broker_concurrency
+
+### max_bytes_per_broker_scanner
+
+### max_connection_scheduler_threads_num
+
+### max_conn_per_user
+
+### max_create_table_timeout_second
+
+### max_distribution_pruner_recursion_depth
+
+### max_layout_length_per_row
+
+### max_load_timeout_second
+
+### max_mysql_service_task_threads_num
+
+### max_query_retry_time
+
+### max_routine_load_job_num
+
+### max_routine_load_task_concurrent_num
+
+### max_routine_load_task_num_per_be
+
+### max_running_rollup_job_num_per_table
+
+### max_running_txn_num_per_db
+
+这个配置主要是用来控制同一个 db 的并发导入个数的。
+
+当集群中有过多的导入任务正在运行时，新提交的导入任务可能会报错：
+
+```
+current running txns on db xxx is xx, larger than limit xx
+```
+
+该遇到该错误时，说明当前集群内正在运行的导入任务超过了该配置值。此时建议在业务侧进行等待并重试导入任务。
+
+一般来说不推荐增大这个配置值。过高的并发数可能导致系统负载过大。
+
+### max_scheduling_tablets
+
+### max_small_file_number
+
+### max_small_file_size_bytes
+
+### max_tolerable_backend_down_num
+
+### max_unfinished_load_job
+
+### metadata_checkopoint_memory_threshold
+
+### metadata_failure_recovery
+
+### meta_delay_toleration_second
+
+### meta_dir
+
+### meta_publish_timeout_ms
+
+### min_bytes_per_broker_scanner
+
+### mini_load_default_timeout_second
+
+### min_load_timeout_second
+
+### mysql_service_io_threads_num
+
+### mysql_service_nio_enabled
+
+### net_buffer_length
+
+### net_read_timeout
+
+### net_write_timeout
+
+### parallel_exchange_instance_num
+
+### parallel_fragment_exec_instance_num
+
+### period_of_auto_resume_min
+
+### plugin_dir
+
+### plugin_enable
+
+### priority_networks
+
+### proxy_auth_enable
+
+### proxy_auth_magic_prefix
+
+### publish_version_interval_ms
+
+### publish_version_timeout_second
+
+### qe_max_connection
+
+### qe_slow_log_ms
+
+### query_cache_size
+
+### query_cache_type
+
+### query_colocate_join_memory_limit_penalty_factor
+
+### query_port
+
+### query_timeout
+
+### remote_fragment_exec_timeout_ms
+
+### replica_ack_policy
+
+### replica_delay_recovery_second
+
+### replica_sync_policy
+
+### report_queue_size
+
+### resource_group
+
+### rewrite_count_distinct_to_bitmap_hll
+
+### rpc_port
+
+### schedule_slot_num_per_path
+
+### small_file_dir
+
+### SQL_AUTO_IS_NULL
+
+### sql_mode
+
+### sql_safe_updates
+
+### sql_select_limit
+
+### storage_cooldown_second
+
+### storage_engine
+
+### storage_flood_stage_left_capacity_bytes
+
+### storage_flood_stage_usage_percent
+
+### storage_high_watermark_usage_percent
+
+### storage_min_left_capacity_bytes
+
+### stream_load_default_timeout_second
+
+### sys_log_delete_age
+
+### sys_log_dir
+
+### sys_log_level
+
+### sys_log_roll_interval
+
+### sys_log_roll_mode
+
+### sys_log_roll_num
+
+### sys_log_verbose_modules
+
+### system_time_zone
+
+### tablet_create_timeout_second
+
+### tablet_delete_timeout_second
+
+### tablet_repair_delay_factor_second
+
+### tablet_stat_update_interval_second
+
+### test_materialized_view
+
+### thrift_backlog_num
+
+### thrift_server_max_worker_threads
+
+### time_zone
+
+### tmp_dir
+
+### transaction_clean_interval_second
+
+### tx_isolation
+
+### txn_rollback_limit
+
+### use_new_tablet_scheduler
+
+### use_v2_rollup
+
+### using_old_load_usage_pattern
+
+### Variable Info
+
+### version
+
+### version_comment
+
+### wait_timeout
+
+### with_k8s_certs
+

--- a/docs/zh-CN/administrator-guide/config/fe_config.md
+++ b/docs/zh-CN/administrator-guide/config/fe_config.md
@@ -110,135 +110,135 @@ FE 的配置项有两种方式进行配置：
 
 ## 配置项列表
 
-### alter_table_timeout_second
+### `alter_table_timeout_second`
 
-### async_load_task_pool_size
+### `async_load_task_pool_size`
 
-### audit_log_delete_age
+### `audit_log_delete_age`
 
-### audit_log_dir
+### `audit_log_dir`
 
-### audit_log_modules
+### `audit_log_modules`
 
-### audit_log_roll_interval
+### `audit_log_roll_interval`
 
-### audit_log_roll_mode
+### `audit_log_roll_mode`
 
-### audit_log_roll_num
+### `audit_log_roll_num`
 
-### auth_token
+### `auth_token`
 
-### autocommit
+### `autocommit`
 
-### auto_increment_increment
+### `auto_increment_increment`
 
-### backup_job_default_timeout_ms
+### `backup_job_default_timeout_ms`
 
-### backup_plugin_path
+### `backup_plugin_path`
 
-### balance_load_score_threshold
+### `balance_load_score_threshold`
 
-### batch_size
+### `batch_size`
 
-### bdbje_heartbeat_timeout_second
+### `bdbje_heartbeat_timeout_second`
 
-### bdbje_lock_timeout_second
+### `bdbje_lock_timeout_second`
 
-### broker_load_default_timeout_second
+### `broker_load_default_timeout_second`
 
-### brpc_idle_wait_max_time
+### `brpc_idle_wait_max_time`
 
-### brpc_number_of_concurrent_requests_processed
+### `brpc_number_of_concurrent_requests_processed`
 
-### capacity_used_percent_high_water
+### `capacity_used_percent_high_water`
 
-### catalog_trash_expire_second
+### `catalog_trash_expire_second`
 
-### catalog_try_lock_timeout_ms
+### `catalog_try_lock_timeout_ms`
 
-### character_set_client
+### `character_set_client`
 
-### character_set_connection
+### `character_set_connection`
 
-### character_set_results
+### `character_set_results`
 
-### character_set_server
+### `character_set_server`
 
-### check_consistency_default_timeout_second
+### `check_consistency_default_timeout_second`
 
-### check_java_version
+### `check_java_version`
 
-### clone_capacity_balance_threshold
+### `clone_capacity_balance_threshold`
 
-### clone_checker_interval_second
+### `clone_checker_interval_second`
 
-### clone_distribution_balance_threshold
+### `clone_distribution_balance_threshold`
 
-### clone_high_priority_delay_second
+### `clone_high_priority_delay_second`
 
-### clone_job_timeout_second
+### `clone_job_timeout_second`
 
-### clone_low_priority_delay_second
+### `clone_low_priority_delay_second`
 
-### clone_max_job_num
+### `clone_max_job_num`
 
-### clone_normal_priority_delay_second
+### `clone_normal_priority_delay_second`
 
-### cluster_id
+### `cluster_id`
 
-### cluster_name
+### `cluster_name`
 
-### codegen_level
+### `codegen_level`
 
-### collation_connection
+### `collation_connection`
 
-### collation_database
+### `collation_database`
 
-### collation_server
+### `collation_server`
 
-### consistency_check_end_time
+### `consistency_check_end_time`
 
-### consistency_check_start_time
+### `consistency_check_start_time`
 
-### default_rowset_type
+### `default_rowset_type`
 
-### default_storage_medium
+### `default_storage_medium`
 
-### delete_thread_num
+### `delete_thread_num`
 
-### desired_max_waiting_jobs
+### `desired_max_waiting_jobs`
 
-### disable_balance
+### `disable_balance`
 
-### disable_cluster_feature
+### `disable_cluster_feature`
 
-### disable_colocate_balance
+### `disable_colocate_balance`
 
-### disable_colocate_join
+### `disable_colocate_join`
 
-### disable_colocate_join
+### `disable_colocate_join`
 
-### disable_colocate_relocate
+### `disable_colocate_relocate`
 
-### disable_hadoop_load
+### `disable_hadoop_load`
 
-### disable_load_job
+### `disable_load_job`
 
-### disable_streaming_preaggregations
+### `disable_streaming_preaggregations`
 
-### div_precision_increment
+### `div_precision_increment`
 
-### dpp_bytes_per_reduce
+### `dpp_bytes_per_reduce`
 
-### dpp_config_str
+### `dpp_config_str`
 
-### dpp_default_cluster
+### `dpp_default_cluster`
 
-### dpp_default_config_str
+### `dpp_default_config_str`
 
-### dpp_hadoop_client_path
+### `dpp_hadoop_client_path`
 
-### drop_backend_after_decommission
+### `drop_backend_after_decommission`
 
 该配置用于控制系统在成功下线（Decommission） BE 后，是否 Drop 该 BE。如果为 true，则在 BE 成功下线后，会删除掉该BE节点。如果为 false，则在 BE 成功下线后，该 BE 会一直处于 DECOMMISSION 状态，但不会被删除。
 
@@ -249,151 +249,151 @@ FE 的配置项有两种方式进行配置：
 3. decommission 操作完成后，该 BE 不会被删除。此时，取消掉该 BE 的 decommission 状态。则数据会开始从其他 BE 节点均衡回这个节点。此时，数据将会均匀的分布到该 BE 的所有磁盘上。
 4. 对所有 BE 节点依次执行 2，3 两个步骤，最终达到所有节点磁盘均衡的目的。
 
-### dynamic_partition_check_interval_seconds
+### `dynamic_partition_check_interval_seconds`
 
-### dynamic_partition_enable
+### `dynamic_partition_enable`
 
-### edit_log_port
+### `edit_log_port`
 
-### edit_log_roll_num
+### `edit_log_roll_num`
 
-### edit_log_type
+### `edit_log_type`
 
-### enable_auth_check
+### `enable_auth_check`
 
-### enable_deploy_manager
+### `enable_deploy_manager`
 
-### enable_insert_strict
+### `enable_insert_strict`
 
-### enable_local_replica_selection
+### `enable_local_replica_selection`
 
-### enable_materialized_view
+### `enable_materialized_view`
 
-### enable_metric_calculator
+### `enable_metric_calculator`
 
-### enable_spilling
+### `enable_spilling`
 
-### enable_token_check
+### `enable_token_check`
 
-### es_state_sync_interval_second
+### `es_state_sync_interval_second`
 
-### event_scheduler
+### `event_scheduler`
 
-### exec_mem_limit
+### `exec_mem_limit`
 
-### export_checker_interval_second
+### `export_checker_interval_second`
 
-### export_running_job_num_limit
+### `export_running_job_num_limit`
 
-### export_tablet_num_per_task
+### `export_tablet_num_per_task`
 
-### export_task_default_timeout_second
+### `export_task_default_timeout_second`
 
-### expr_children_limit
+### `expr_children_limit`
 
-### expr_depth_limit
+### `expr_depth_limit`
 
-### force_do_metadata_checkpoint
+### `force_do_metadata_checkpoint`
 
-### forward_to_master
+### `forward_to_master`
 
-### frontend_address
+### `frontend_address`
 
-### hadoop_load_default_timeout_second
+### `hadoop_load_default_timeout_second`
 
-### heartbeat_mgr_blocking_queue_size
+### `heartbeat_mgr_blocking_queue_size`
 
-### heartbeat_mgr_threads_num
+### `heartbeat_mgr_threads_num`
 
-### history_job_keep_max_second
+### `history_job_keep_max_second`
 
-### http_backlog_num
+### `http_backlog_num`
 
-### http_port
+### `http_port`
 
-### ignore_meta_check
+### `ignore_meta_check`
 
-### init_connect
+### `init_connect`
 
-### insert_load_default_timeout_second
+### `insert_load_default_timeout_second`
 
-### interactive_timeout
+### `interactive_timeout`
 
-### is_report_success
+### `is_report_success`
 
-### label_clean_interval_second
+### `label_clean_interval_second`
 
-### label_keep_max_second
+### `label_keep_max_second`
 
-### language
+### `language`
 
-### license
+### `license`
 
-### load_checker_interval_second
+### `load_checker_interval_second`
 
-### load_etl_thread_num_high_priority
+### `load_etl_thread_num_high_priority`
 
-### load_etl_thread_num_normal_priority
+### `load_etl_thread_num_normal_priority`
 
-### load_input_size_limit_gb
+### `load_input_size_limit_gb`
 
-### load_mem_limit
+### `load_mem_limit`
 
-### load_pending_thread_num_high_priority
+### `load_pending_thread_num_high_priority`
 
-### load_pending_thread_num_normal_priority
+### `load_pending_thread_num_normal_priority`
 
-### load_running_job_num_limit
+### `load_running_job_num_limit`
 
-### load_straggler_wait_second
+### `load_straggler_wait_second`
 
-### locale
+### `locale`
 
-### log_roll_size_mb
+### `log_roll_size_mb`
 
-### lower_case_table_names
+### `lower_case_table_names`
 
-### master_sync_policy
+### `master_sync_policy`
 
-### max_agent_task_threads_num
+### `max_agent_task_threads_num`
 
-### max_allowed_packet
+### `max_allowed_packet`
 
-### max_backend_down_time_second
+### `max_backend_down_time_second`
 
-### max_balancing_tablets
+### `max_balancing_tablets`
 
-### max_bdbje_clock_delta_ms
+### `max_bdbje_clock_delta_ms`
 
-### max_broker_concurrency
+### `max_broker_concurrency`
 
-### max_bytes_per_broker_scanner
+### `max_bytes_per_broker_scanner`
 
-### max_connection_scheduler_threads_num
+### `max_connection_scheduler_threads_num`
 
-### max_conn_per_user
+### `max_conn_per_user`
 
-### max_create_table_timeout_second
+### `max_create_table_timeout_second`
 
-### max_distribution_pruner_recursion_depth
+### `max_distribution_pruner_recursion_depth`
 
-### max_layout_length_per_row
+### `max_layout_length_per_row`
 
-### max_load_timeout_second
+### `max_load_timeout_second`
 
-### max_mysql_service_task_threads_num
+### `max_mysql_service_task_threads_num`
 
-### max_query_retry_time
+### `max_query_retry_time`
 
-### max_routine_load_job_num
+### `max_routine_load_job_num`
 
-### max_routine_load_task_concurrent_num
+### `max_routine_load_task_concurrent_num`
 
-### max_routine_load_task_num_per_be
+### `max_routine_load_task_num_per_be`
 
-### max_running_rollup_job_num_per_table
+### `max_running_rollup_job_num_per_table`
 
-### max_running_txn_num_per_db
+### `max_running_txn_num_per_db`
 
 这个配置主要是用来控制同一个 db 的并发导入个数的。
 
@@ -407,171 +407,171 @@ current running txns on db xxx is xx, larger than limit xx
 
 一般来说不推荐增大这个配置值。过高的并发数可能导致系统负载过大。
 
-### max_scheduling_tablets
+### `max_scheduling_tablets`
 
-### max_small_file_number
+### `max_small_file_number`
 
-### max_small_file_size_bytes
+### `max_small_file_size_bytes`
 
-### max_tolerable_backend_down_num
+### `max_tolerable_backend_down_num`
 
-### max_unfinished_load_job
+### `max_unfinished_load_job`
 
-### metadata_checkopoint_memory_threshold
+### `metadata_checkopoint_memory_threshold`
 
-### metadata_failure_recovery
+### `metadata_failure_recovery`
 
-### meta_delay_toleration_second
+### `meta_delay_toleration_second`
 
-### meta_dir
+### `meta_dir`
 
-### meta_publish_timeout_ms
+### `meta_publish_timeout_ms`
 
-### min_bytes_per_broker_scanner
+### `min_bytes_per_broker_scanner`
 
-### mini_load_default_timeout_second
+### `mini_load_default_timeout_second`
 
-### min_load_timeout_second
+### `min_load_timeout_second`
 
-### mysql_service_io_threads_num
+### `mysql_service_io_threads_num`
 
-### mysql_service_nio_enabled
+### `mysql_service_nio_enabled`
 
-### net_buffer_length
+### `net_buffer_length`
 
-### net_read_timeout
+### `net_read_timeout`
 
-### net_write_timeout
+### `net_write_timeout`
 
-### parallel_exchange_instance_num
+### `parallel_exchange_instance_num`
 
-### parallel_fragment_exec_instance_num
+### `parallel_fragment_exec_instance_num`
 
-### period_of_auto_resume_min
+### `period_of_auto_resume_min`
 
-### plugin_dir
+### `plugin_dir`
 
-### plugin_enable
+### `plugin_enable`
 
-### priority_networks
+### `priority_networks`
 
-### proxy_auth_enable
+### `proxy_auth_enable`
 
-### proxy_auth_magic_prefix
+### `proxy_auth_magic_prefix`
 
-### publish_version_interval_ms
+### `publish_version_interval_ms`
 
-### publish_version_timeout_second
+### `publish_version_timeout_second`
 
-### qe_max_connection
+### `qe_max_connection`
 
-### qe_slow_log_ms
+### `qe_slow_log_ms`
 
-### query_cache_size
+### `query_cache_size`
 
-### query_cache_type
+### `query_cache_type`
 
-### query_colocate_join_memory_limit_penalty_factor
+### `query_colocate_join_memory_limit_penalty_factor`
 
-### query_port
+### `query_port`
 
-### query_timeout
+### `query_timeout`
 
-### remote_fragment_exec_timeout_ms
+### `remote_fragment_exec_timeout_ms`
 
-### replica_ack_policy
+### `replica_ack_policy`
 
-### replica_delay_recovery_second
+### `replica_delay_recovery_second`
 
-### replica_sync_policy
+### `replica_sync_policy`
 
-### report_queue_size
+### `report_queue_size`
 
-### resource_group
+### `resource_group`
 
-### rewrite_count_distinct_to_bitmap_hll
+### `rewrite_count_distinct_to_bitmap_hll`
 
-### rpc_port
+### `rpc_port`
 
-### schedule_slot_num_per_path
+### `schedule_slot_num_per_path`
 
-### small_file_dir
+### `small_file_dir`
 
-### SQL_AUTO_IS_NULL
+### `SQL_AUTO_IS_NULL`
 
-### sql_mode
+### `sql_mode`
 
-### sql_safe_updates
+### `sql_safe_updates`
 
-### sql_select_limit
+### `sql_select_limit`
 
-### storage_cooldown_second
+### `storage_cooldown_second`
 
-### storage_engine
+### `storage_engine`
 
-### storage_flood_stage_left_capacity_bytes
+### `storage_flood_stage_left_capacity_bytes`
 
-### storage_flood_stage_usage_percent
+### `storage_flood_stage_usage_percent`
 
-### storage_high_watermark_usage_percent
+### `storage_high_watermark_usage_percent`
 
-### storage_min_left_capacity_bytes
+### `storage_min_left_capacity_bytes`
 
-### stream_load_default_timeout_second
+### `stream_load_default_timeout_second`
 
-### sys_log_delete_age
+### `sys_log_delete_age`
 
-### sys_log_dir
+### `sys_log_dir`
 
-### sys_log_level
+### `sys_log_level`
 
-### sys_log_roll_interval
+### `sys_log_roll_interval`
 
-### sys_log_roll_mode
+### `sys_log_roll_mode`
 
-### sys_log_roll_num
+### `sys_log_roll_num`
 
-### sys_log_verbose_modules
+### `sys_log_verbose_modules`
 
-### system_time_zone
+### `system_time_zone`
 
-### tablet_create_timeout_second
+### `tablet_create_timeout_second`
 
-### tablet_delete_timeout_second
+### `tablet_delete_timeout_second`
 
-### tablet_repair_delay_factor_second
+### `tablet_repair_delay_factor_second`
 
-### tablet_stat_update_interval_second
+### `tablet_stat_update_interval_second`
 
-### test_materialized_view
+### `test_materialized_view`
 
-### thrift_backlog_num
+### `thrift_backlog_num`
 
-### thrift_server_max_worker_threads
+### `thrift_server_max_worker_threads`
 
-### time_zone
+### `time_zone`
 
-### tmp_dir
+### `tmp_dir`
 
-### transaction_clean_interval_second
+### `transaction_clean_interval_second`
 
-### tx_isolation
+### `tx_isolation`
 
-### txn_rollback_limit
+### `txn_rollback_limit`
 
-### use_new_tablet_scheduler
+### `use_new_tablet_scheduler`
 
-### use_v2_rollup
+### `use_v2_rollup`
 
-### using_old_load_usage_pattern
+### `using_old_load_usage_pattern`
 
-### Variable Info
+### `Variable Info`
 
-### version
+### `version`
 
-### version_comment
+### `version_comment`
 
-### wait_timeout
+### `wait_timeout`
 
-### with_k8s_certs
+### `with_k8s_certs`
 

--- a/fe/src/main/java/org/apache/doris/alter/SystemHandler.java
+++ b/fe/src/main/java/org/apache/doris/alter/SystemHandler.java
@@ -102,7 +102,7 @@ public class SystemHandler extends AlterHandler {
             }
 
             List<Long> backendTabletIds = invertedIndex.getTabletIdsByBackendId(beId);
-            if (backendTabletIds.isEmpty()) {
+            if (backendTabletIds.isEmpty() && Config.drop_backend_after_decommission) {
                 try {
                     systemInfoService.dropBackend(beId);
                     LOG.info("no tablet on decommission backend {}, drop it", beId);

--- a/fe/src/main/java/org/apache/doris/analysis/DecommissionBackendClause.java
+++ b/fe/src/main/java/org/apache/doris/analysis/DecommissionBackendClause.java
@@ -17,9 +17,9 @@
 
 package org.apache.doris.analysis;
 
-import java.util.List;
-
 import org.apache.doris.alter.DecommissionBackendJob.DecommissionType;
+
+import java.util.List;
 
 public class DecommissionBackendClause extends BackendClause {
 
@@ -41,10 +41,6 @@ public class DecommissionBackendClause extends BackendClause {
             }
         }
         return sb.toString();
-    }
-
-    public DecommissionType getType() {
-        return type;
     }
 
     public void setType(DecommissionType type) {

--- a/fe/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/src/main/java/org/apache/doris/common/Config.java
@@ -1067,5 +1067,11 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true, masterOnly = true)
     public static int period_of_auto_resume_min = 5;
 
+    /*
+     * If set to true, the backend will be automatically dropped after finishing decommission.
+     * If set to false, the backend will not be dropped and remaining in DECOMMISSION state.
+     */
+    @ConfField(mutable = true, masterOnly = true)
+    public static boolean drop_backend_after_decommission = false;
 }
 

--- a/fe/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/src/main/java/org/apache/doris/common/Config.java
@@ -1072,6 +1072,6 @@ public class Config extends ConfigBase {
      * If set to false, the backend will not be dropped and remaining in DECOMMISSION state.
      */
     @ConfField(mutable = true, masterOnly = true)
-    public static boolean drop_backend_after_decommission = false;
+    public static boolean drop_backend_after_decommission = true;
 }
 


### PR DESCRIPTION
Add a new config `drop_backend_after_decommission` in FE. if this config
is false, the BE will not be dropped after finishing decommission operation.

This new config is try to solve the problem described in ISSUE: #3460 .

TODO:
This method will generate a lot of data migration, so it is only a temporary solution.
After that, we should try to solve the problem of data balancing within the BE.

This CL also add the documents of FE and BE configuration.
These documents are incomplete and can be added later.