### PR TITLE
[Bug] Fix bug of Partition prune of constant in predicate

### DIFF
--- a/fe/src/main/java/org/apache/doris/catalog/Partition.java
+++ b/fe/src/main/java/org/apache/doris/catalog/Partition.java
@@ -20,6 +20,7 @@ package org.apache.doris.catalog;
 import org.apache.doris.catalog.DistributionInfo.DistributionInfoType;
 import org.apache.doris.catalog.MaterializedIndex.IndexExtState;
 import org.apache.doris.catalog.MaterializedIndex.IndexState;
+import org.apache.doris.common.FeConstants;
 import org.apache.doris.common.FeMetaVersion;
 import org.apache.doris.common.io.Text;
 import org.apache.doris.common.io.Writable;
@@ -285,7 +286,9 @@ public class Partition extends MetaObject implements Writable {
     }
 
     public boolean hasData() {
-        return !(visibleVersion == PARTITION_INIT_VERSION && visibleVersionHash == PARTITION_INIT_VERSION_HASH);
+        return !(visibleVersion == PARTITION_INIT_VERSION 
+                && visibleVersionHash == PARTITION_INIT_VERSION_HASH
+                && !FeConstants.runningUnitTest);
     }
 
     /*

--- a/fe/src/main/java/org/apache/doris/catalog/Partition.java
+++ b/fe/src/main/java/org/apache/doris/catalog/Partition.java
@@ -286,9 +286,9 @@ public class Partition extends MetaObject implements Writable {
     }
 
     public boolean hasData() {
-        return !(visibleVersion == PARTITION_INIT_VERSION 
-                && visibleVersionHash == PARTITION_INIT_VERSION_HASH
-                && !FeConstants.runningUnitTest);
+        return ((visibleVersion != PARTITION_INIT_VERSION)
+                || (visibleVersionHash != PARTITION_INIT_VERSION_HASH)
+                || FeConstants.runningUnitTest);
     }
 
     /*

--- a/fe/src/main/java/org/apache/doris/catalog/Partition.java
+++ b/fe/src/main/java/org/apache/doris/catalog/Partition.java
@@ -286,6 +286,9 @@ public class Partition extends MetaObject implements Writable {
     }
 
     public boolean hasData() {
+        // The fe unit test need to check the selected index id without any data.
+        // So if set FeConstants.runningUnitTest, we can ensure that the number of partitions is not empty,
+        // And the test case can continue to execute the logic of 'select best roll up'
         return ((visibleVersion != PARTITION_INIT_VERSION)
                 || (visibleVersionHash != PARTITION_INIT_VERSION_HASH)
                 || FeConstants.runningUnitTest);

--- a/fe/src/main/java/org/apache/doris/planner/OlapScanNode.java
+++ b/fe/src/main/java/org/apache/doris/planner/OlapScanNode.java
@@ -45,7 +45,6 @@ import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.ErrorReport;
-import org.apache.doris.common.FeConstants;
 import org.apache.doris.common.UserException;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.SessionVariable;
@@ -428,9 +427,7 @@ public class OlapScanNode extends ScanNode {
         selectedPartitionNum = selectedPartitionIds.size();
         LOG.debug("partition prune cost: {} ms, partitions: {}",
                   (System.currentTimeMillis() - start), selectedPartitionIds);
-        // The fe unit test need to check the selected index id without any data.
-        // So the step2 needs to be continued although selectedPartitionIds is 0.
-        if (selectedPartitionIds.size() == 0 && !FeConstants.runningUnitTest) {
+        if (selectedPartitionIds.size() == 0) {
             return;
         }
 

--- a/fe/src/main/java/org/apache/doris/planner/OlapScanNode.java
+++ b/fe/src/main/java/org/apache/doris/planner/OlapScanNode.java
@@ -408,10 +408,6 @@ public class OlapScanNode extends ScanNode {
         PartitionInfo partitionInfo = olapTable.getPartitionInfo();
         if (partitionInfo.getType() == PartitionType.RANGE) {
             selectedPartitionIds = partitionPrune((RangePartitionInfo) partitionInfo, partitionNames);
-            if (FeConstants.runningUnitTest) {
-                selectedPartitionNum = selectedPartitionIds.size();
-                return;
-            }
         } else {
             selectedPartitionIds = null;
         }

--- a/fe/src/main/java/org/apache/doris/planner/OlapScanNode.java
+++ b/fe/src/main/java/org/apache/doris/planner/OlapScanNode.java
@@ -408,6 +408,10 @@ public class OlapScanNode extends ScanNode {
         PartitionInfo partitionInfo = olapTable.getPartitionInfo();
         if (partitionInfo.getType() == PartitionType.RANGE) {
             selectedPartitionIds = partitionPrune((RangePartitionInfo) partitionInfo, partitionNames);
+            if (FeConstants.runningUnitTest) {
+                selectedPartitionNum = selectedPartitionIds.size();
+                return;
+            }
         } else {
             selectedPartitionIds = null;
         }

--- a/fe/src/main/java/org/apache/doris/planner/SingleNodePlanner.java
+++ b/fe/src/main/java/org/apache/doris/planner/SingleNodePlanner.java
@@ -928,6 +928,14 @@ public class SingleNodePlanner {
                 if (!inPredicate.isLiteralChildren() || inPredicate.isNotIn()) {
                     continue;
                 }
+                if ((inPredicate.getChild(0) instanceof LiteralExpr)
+                        || (inPredicate.getChild(0) instanceof CastExpr
+                                && inPredicate.getChild(0).getChild(0) instanceof LiteralExpr)) {
+                    // If child(0) of the in predicate is a constant expression,
+                    // then other children of in predicate should not be used as a condition for partition prune.
+                    // Such as "where  'Hi' in ('Hi', 'hello') and ... "
+                    continue;
+                }
                 if (null == partitionColumnFilter) {
                     partitionColumnFilter = new PartitionColumnFilter();
                 }

--- a/fe/src/main/java/org/apache/doris/planner/SingleNodePlanner.java
+++ b/fe/src/main/java/org/apache/doris/planner/SingleNodePlanner.java
@@ -928,9 +928,7 @@ public class SingleNodePlanner {
                 if (!inPredicate.isLiteralChildren() || inPredicate.isNotIn()) {
                     continue;
                 }
-                if ((inPredicate.getChild(0) instanceof LiteralExpr)
-                        || (inPredicate.getChild(0) instanceof CastExpr
-                                && inPredicate.getChild(0).getChild(0) instanceof LiteralExpr)) {
+                if (inPredicate.getChild(0).unwrapExpr(false) instanceof LiteralExpr) {
                     // If child(0) of the in predicate is a constant expression,
                     // then other children of in predicate should not be used as a condition for partition prune.
                     // Such as "where  'Hi' in ('Hi', 'hello') and ... "

--- a/fe/src/test/java/org/apache/doris/planner/QueryPlanTest.java
+++ b/fe/src/test/java/org/apache/doris/planner/QueryPlanTest.java
@@ -637,6 +637,7 @@ public class QueryPlanTest {
         FeConstants.runningUnitTest = true;
         String queryStr = "explain select * from (select 'aa' as kk1, sum(id) from test.join1 where dt = 9 group by kk1)tt where kk1 in ('aa');";
         String explainString = UtFrameUtils.getSQLPlanOrErrorMsg(connectContext, queryStr);
+        FeConstants.runningUnitTest = false;
         Assert.assertTrue(explainString.contains("partitions=1/1"));
     }
 }

--- a/fe/src/test/java/org/apache/doris/planner/QueryPlanTest.java
+++ b/fe/src/test/java/org/apache/doris/planner/QueryPlanTest.java
@@ -26,6 +26,7 @@ import org.apache.doris.analysis.SelectStmt;
 import org.apache.doris.analysis.ShowCreateDbStmt;
 import org.apache.doris.analysis.StatementBase;
 import org.apache.doris.catalog.Catalog;
+import org.apache.doris.common.FeConstants;
 import org.apache.doris.catalog.Type;
 import org.apache.doris.load.EtlJobType;
 import org.apache.doris.qe.ConnectContext;
@@ -629,5 +630,13 @@ public class QueryPlanTest {
         System.out.println(explainString);
         Assert.assertTrue(explainString.contains("PREDICATES: `join1`.`id` > 1"));
         Assert.assertTrue(explainString.contains("PREDICATES: `join2`.`id` > 1"));
+    }
+
+    @Test
+    public void testConstInParitionPrune() throws Exception {
+        FeConstants.runningUnitTest = true;
+        String queryStr = "explain select * from (select 'aa' as kk1, sum(id) from test.join1 where dt = 9 group by kk1)tt where kk1 in ('aa');";
+        String explainString = UtFrameUtils.getSQLPlanOrErrorMsg(connectContext, queryStr);
+        Assert.assertTrue(explainString.contains("partitions=1/1"));
     }
 }


### PR DESCRIPTION
**1. phenomenon：**

The following two statements are the same, but a query has results and the other query has no results

mysql> select * from (select '积极' as kk1, sum(k2) from table_range where k1 = '2013-01-01' group by kk1)tt where kk1 = '积极';        
+--------+-----------+
| kk1    | sum(`k2`) |
+--------+-----------+
| 积极 |         1 |
+--------+-----------+
1 row in set (0.01 sec)

mysql> select * from (select '积极' as kk1, sum(k2) from table_range where k1 = '2013-01-01' group by kk1)tt where kk1 in ('积极');     
Empty set (0.01 sec)


**2. reason：**

In partition prune, constant in predicate（‘积极’ in ‘积极’） is mistakenly considered to meet partition prune conditions, and mistakenly regarded as partition prune column. Then in partition prune , no partition is considered to meet the requirements, so it is planned to be 0 partition in query planning

@morningman 
