### PR TITLE
[BUG] Fix a bug that ignore_broken_disk may not work

### DIFF
--- a/be/src/olap/options.cpp
+++ b/be/src/olap/options.cpp
@@ -134,15 +134,18 @@ OLAPStatus parse_conf_store_paths(const string& config_path, vector<StorePath>* 
     vector<string> path_vec = strings::Split(config_path, ";", strings::SkipWhitespace());
     for (auto& item : path_vec) {
         StorePath path;
-        RETURN_NOT_OK_LOG(parse_root_path(item, &path),
-                strings::Substitute("fail to parse store path. path=$0", item));
-        paths->emplace_back(std::move(path));
+        auto res = parse_root_path(item, &path);
+        if (res == OLAP_SUCCESS) {
+            paths->emplace_back(std::move(path));
+        } else {
+            LOG(WARNING) << "failed to parse store path " << item << ", res=" << res;
+        }
+
     }
-    if (paths->empty()) {
+    if (paths->empty() || (path_vec.size() != paths->size() && !config::ignore_broken_disk)) {
         LOG(WARNING) << "fail to parse storage_root_path config. value=[" << config_path << "]";
         return OLAP_ERR_INPUT_PARAMETER_ERROR;
     }
-
     return OLAP_SUCCESS;
 }
 

--- a/be/src/olap/options.cpp
+++ b/be/src/olap/options.cpp
@@ -19,6 +19,7 @@
 
 #include <algorithm>
 
+#include "common/config.h"
 #include "common/logging.h"
 #include "common/status.h"
 #include "env/env.h"

--- a/be/src/service/doris_main.cpp
+++ b/be/src/service/doris_main.cpp
@@ -137,26 +137,6 @@ int main(int argc, char** argv) {
         exit(-1);
     }
 
-    auto it = paths.begin();
-    for (; it != paths.end();) {
-        if (!doris::FileUtils::check_exist(it->path)) {
-            if (doris::config::ignore_broken_disk) {
-                LOG(WARNING) << "opendir failed, path=" << it->path;
-                it = paths.erase(it);
-            } else {
-                LOG(FATAL) << "opendir failed, path=" << it->path;
-                exit(-1);
-            }
-        } else {
-            ++it;
-        }
-    }
-
-    if (paths.empty()) {
-        LOG(FATAL) << "All disks are broken, exit.";
-        exit(-1);
-    }
-
     // initilize libcurl here to avoid concurrent initialization
     auto curl_ret = curl_global_init(CURL_GLOBAL_ALL);
     if (curl_ret != 0) {


### PR DESCRIPTION
Fixes #3484 

When BE sets `ignore_broken_disk` to true, it's expected that non-exist path in storage_root_path won't prevent BE from launching, but in 0.12 BE fails to launch in such scenario.

```
W0506 14:46:11.039953 17040 options.cpp:64] path can not be canonicalized. may be not exist. path=/data11/olap
W0506 14:46:11.040014 17040 options.cpp:141] failed to parse store path /data11/olap, res=-203
```
The reason is that #2861 adds a path existence check in `parse_root_path` which precedes the usage of `ignore_broken_disk` in the main method.