### PR TITLE
[Config] allow user to config BRPC socket_max_unwritten_bytes

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -488,8 +488,10 @@ namespace config {
     // Valid configs: ALPHA, BETA
     CONF_String(default_rowset_type, "ALPHA");
 
-    // brpc config, 200M
+    // Maximum size of a single message body in all protocols
     CONF_Int64(brpc_max_body_size, "209715200")
+    // Max unwritten bytes in each socket, if the limit is reached, Socket.Write fails with EOVERCROWDED
+    CONF_Int64(brpc_socket_max_unwritten_bytes, "67108864")
 
     // max number of txns for every txn_partition_map in txn manager
     // this is a self protection to avoid too many txns saving in manager

--- a/be/src/service/brpc_service.cpp
+++ b/be/src/service/brpc_service.cpp
@@ -27,6 +27,7 @@
 namespace brpc {
 
 DECLARE_uint64(max_body_size);
+DECLARE_int64(socket_max_unwritten_bytes);
 
 }
 
@@ -37,6 +38,7 @@ BRpcService::BRpcService(ExecEnv* exec_env)
         _server(new brpc::Server()) {
     // Set config
     brpc::FLAGS_max_body_size = config::brpc_max_body_size;
+    brpc::FLAGS_socket_max_unwritten_bytes = config::brpc_socket_max_unwritten_bytes;
 }
 
 BRpcService::~BRpcService() {

--- a/docs/en/administrator-guide/config/be_config.md
+++ b/docs/en/administrator-guide/config/be_config.md
@@ -69,6 +69,14 @@ This error indicates that the packet size of brpc exceeds the configured value. 
 
 Since this is a brpc configuration, users can also modify this parameter directly during operation. Modify by visiting `http://be_host:brpc_port/flags`.
 
+### `brpc_socket_max_unwritten_bytes`
+
+This configuration is mainly used to modify the parameter `socket_max_unwritten_bytes` of brpc.
+
+Sometimes the query fails and an error message of `The server is overcrowded` will appear in the BE log. This means there are too many messages to buffer at the sender side, which may happen when the SQL needs to send large bitmap value. You can avoid this error by increasing the configuration.
+
+Since this is a brpc configuration, users can also modify this parameter directly during operation. Modify by visiting `http://be_host:brpc_port/flags`.
+
 ### brpc_port
 
 ### buffer_pool_clean_pages_limit

--- a/docs/zh-CN/administrator-guide/config/be_config.md
+++ b/docs/zh-CN/administrator-guide/config/be_config.md
@@ -67,6 +67,14 @@ under the License.
 
 由于这是一个 brpc 的配置，用户也可以在运行中直接修改该参数。通过访问 `http://be_host:brpc_port/flags` 修改。
 
+### `brpc_socket_max_unwritten_bytes`
+
+这个配置主要用来修改 brpc  的参数 `socket_max_unwritten_bytes`。
+
+有时查询失败，BE 日志中会出现 `The server is overcrowded` 的错误信息，表示连接上有过多的未发送数据。当查询需要发送较大的bitmap字段时，可能会遇到该问题，此时可能通过调大该配置避免该错误。
+
+由于这是一个 brpc 的配置，用户也可以在运行中直接修改该参数。通过访问 `http://be_host:brpc_port/flags` 修改。
+
 ### `brpc_port`
 
 ### `buffer_pool_clean_pages_limit`


### PR DESCRIPTION
Fixes #3487 

We have some queries failed with the following logs

```
W0429 15:19:08.580521 38042 data_stream_sender.cpp:136] failed to send brpc batch, error=The server is overcrowded, error_text=[E1011]The server is overcrowded @xx.xx.xx.xx:8060 [R1][E1011]The server is overcrowded @10.16.212.49:8060 [R2][E1011]The server is overcrowded @xx.xx.xx.xx:8060 [R3][E1011]The server is overcrowded @xx.xx.xx.xx:8060
```

The reason is that the query needs to shuffle some large batches (with big value like HLL or bitmap), and the default limit for BRPC socket_max_unwritten_bytes (64MB) is exceeded.

I think we should allow user to config that parameter, just like 'brpc_max_body_size'.