### PR TITLE
fix mismatched tags

### DIFF
--- a/be/src/env/env.h
+++ b/be/src/env/env.h
@@ -21,9 +21,9 @@ class RandomAccessFile;
 class RandomRWFile;
 class WritableFile;
 class SequentialFile;
-class WritableFileOptions;
-class RandomAccessFileOptions;
-class RandomRWFileOptions;
+struct WritableFileOptions;
+struct RandomAccessFileOptions;
+struct RandomRWFileOptions;
 
 class Env {
 public:


### PR DESCRIPTION
`RandomAccessFileOptions`, `WritableFileOptions`, `RandomRWFileOptions`
defined as a struct but previously declared as a class; this is valid,
but will result in compile warning or error under clang compiler