### PR TITLE
[ASAN] Fix some address problems detected by ASAN

### DIFF
--- a/be/src/http/ev_http_server.cpp
+++ b/be/src/http/ev_http_server.cpp
@@ -124,6 +124,7 @@ Status EvHttpServer::start() {
 }
 
 void EvHttpServer::stop() {
+    close(_server_fd);
 }
 
 void EvHttpServer::join() {

--- a/be/src/runtime/runtime_state.cpp
+++ b/be/src/runtime/runtime_state.cpp
@@ -105,6 +105,7 @@ RuntimeState::RuntimeState(const TQueryGlobals& query_globals)
       _data_stream_recvrs_pool(new ObjectPool()),
       _unreported_error_idx(0),
       _profile(_obj_pool.get(), "<unnamed>"),
+      _is_cancelled(false),
       _per_fragment_instance_idx(0) {
     _query_options.batch_size = DEFAULT_BATCH_SIZE;
     if (query_globals.__isset.time_zone) {
@@ -151,7 +152,7 @@ RuntimeState::~RuntimeState() {
         _buffer_reservation->Close();
     }
 
-    if (_exec_env != nullptr) {
+    if (_exec_env != nullptr && _exec_env->thread_mgr() != nullptr) {
         _exec_env->thread_mgr()->unregister_pool(_resource_pool);
     }
 

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -528,7 +528,7 @@ private:
     TUniqueId _query_id;
     TUniqueId _fragment_instance_id;
     TQueryOptions _query_options;
-    ExecEnv* _exec_env;
+    ExecEnv* _exec_env = nullptr;
 
     // Thread resource management object for this fragment's execution.  The runtime
     // state is responsible for returning this pool to the thread mgr.
@@ -599,7 +599,7 @@ private:
     int64_t _normal_row_number;
     int64_t _error_row_number;
     std::string _error_log_file_path;
-    std::ofstream* _error_log_file; // error file path, absolute path
+    std::ofstream* _error_log_file = nullptr; // error file path, absolute path
     std::unique_ptr<LoadErrorHub> _error_hub;
     std::vector<TTabletCommitInfo> _tablet_commit_infos;
 

--- a/be/src/util/debug/leakcheck_disabler.h
+++ b/be/src/util/debug/leakcheck_disabler.h
@@ -31,7 +31,7 @@ class ScopedLeakCheckDisabler {
 
  private:
 
-#ifdef LEAK_SANITIZER
+#if defined(ADDRESS_SANITIZER) || defined(LEAK_SANITIZER)
   ScopedLSANDisabler lsan_disabler;
 #endif
 

--- a/be/src/util/dynamic_util.cpp
+++ b/be/src/util/dynamic_util.cpp
@@ -52,7 +52,7 @@ Status dynamic_open(const char* library, void** handle) {
 void dynamic_close(void* handle) {
 // There is an issue of LSAN can't deal well with dlclose(), so we disable LSAN here, more details:
 // https://github.com/google/sanitizers/issues/89
-#ifndef LEAK_SANITIZER
+#if !defined(ADDRESS_SANITIZER) && !defined(LEAK_SANITIZER)
    dlclose(handle);
 #endif
 }

--- a/be/src/util/mem_util.hpp
+++ b/be/src/util/mem_util.hpp
@@ -50,6 +50,8 @@ template<> inline void fixed_size_memory_copy<8>(void* dst, const void* src) {
 }
 
 inline void memory_copy(void* dst, const void* src, size_t size) {
+// Function fixed_size_memory_copy will report a stack-use-after-scope error in ASAN mode.
+#if !defined(ADDRESS_SANITIZER)
     static const void* addrs[] = {
         &&B0, &&B1, &&B2, &&B3, &&B4, &&B5, &&B6, 
         &&B7, &&B8, &&B9, &&B10, &&B11, &&B12, &&B13,
@@ -615,6 +617,7 @@ B254:
 B255:
         return fixed_size_memory_copy<255>(dst, src);
     }
+#endif
 
     memcpy(dst, src, size);
     return;

--- a/be/src/util/path_util.cpp
+++ b/be/src/util/path_util.cpp
@@ -70,13 +70,19 @@ vector<string> split_path(const string& path) {
     return segments;
 }
 
+struct FreeDeleter {
+    inline void operator()(void* ptr) const {
+        free(ptr);
+    }
+};
+
 string dir_name(const string& path) {
-    std::unique_ptr<char[]> path_copy(strdup(path.c_str()));
+    std::unique_ptr<char[], FreeDeleter> path_copy(strdup(path.c_str()));
     return dirname(path_copy.get());
 }
 
 string base_name(const string& path) {
-    std::unique_ptr<char[]> path_copy(strdup(path.c_str()));
+    std::unique_ptr<char[], FreeDeleter> path_copy(strdup(path.c_str()));
     return basename(path_copy.get());
 }
 

--- a/be/src/util/path_util.cpp
+++ b/be/src/util/path_util.cpp
@@ -70,20 +70,14 @@ vector<string> split_path(const string& path) {
     return segments;
 }
 
-struct FreeDeleter {
-    inline void operator()(void* ptr) const {
-        free(ptr);
-    }
-};
-
 string dir_name(const string& path) {
-    std::unique_ptr<char[], FreeDeleter> path_copy(strdup(path.c_str()));
-    return dirname(path_copy.get());
+    std::vector<char> path_copy(path.c_str(), path.c_str() + path.size() + 1);
+    return dirname(&path_copy[0]);
 }
 
 string base_name(const string& path) {
-    std::unique_ptr<char[], FreeDeleter> path_copy(strdup(path.c_str()));
-    return basename(path_copy.get());
+    std::vector<char> path_copy(path.c_str(), path.c_str() + path.size() + 1);
+    return basename(&path_copy[0]);
 }
 
 string file_extension(const string& path) {

--- a/be/src/util/url_coding.cpp
+++ b/be/src/util/url_coding.cpp
@@ -91,7 +91,8 @@ bool url_decode(const std::string& in, std::string* out) {
 static void encode_base64_internal(const std::string& in, std::string* out,
                                    const unsigned char* basis, bool padding) {
     size_t len = in.size();
-    std::unique_ptr<unsigned char[]> buf(new unsigned char[len]);
+    // Every 3 source bytes will be encoded into 4 bytes.
+    std::unique_ptr<unsigned char[]> buf(new unsigned char[(((len + 2) / 3) * 4)]);
     const unsigned char* s = reinterpret_cast<const unsigned char*>(in.data());
     unsigned char* d = buf.get();
     while (len > 2) {

--- a/be/test/agent/utils_test.cpp
+++ b/be/test/agent/utils_test.cpp
@@ -30,9 +30,9 @@ using std::string;
 namespace doris {
 
 TEST(AgentUtilsTest, Test) {
-    const char* host_name = BackendOptions::get_localhost().c_str();
-    int cnt = std::count(host_name, host_name + 17, '.');
-    EXPECT_EQ(3, cnt);
+    std::string host_name = BackendOptions::get_localhost();
+    int cnt = std::count(host_name.begin(), host_name.end(), '.');
+    ASSERT_EQ(3, cnt);
 }
 
 }  // namespace doris

--- a/be/test/exec/broker_scan_node_test.cpp
+++ b/be/test/exec/broker_scan_node_test.cpp
@@ -314,7 +314,7 @@ void BrokerScanNodeTest::init_desc_table() {
         // TTupleDescriptor source
         TTupleDescriptor t_tuple_desc;
         t_tuple_desc.id = 1;
-        t_tuple_desc.byteSize = 60;
+        t_tuple_desc.byteSize = 64;
         t_tuple_desc.numNullBytes = 0;
         t_tuple_desc.tableId = 0;
         t_tuple_desc.__isset.tableId = true;

--- a/be/test/exec/tablet_sink_test.cpp
+++ b/be/test/exec/tablet_sink_test.cpp
@@ -415,7 +415,7 @@ TEST_F(OlapTableSinkTest, normal) {
         *reinterpret_cast<int*>(tuple->get_slot(4)) = 14;
         *reinterpret_cast<int64_t*>(tuple->get_slot(8)) = 50;
         StringValue* str_val = reinterpret_cast<StringValue*>(tuple->get_slot(16));
-        str_val->ptr = reinterpret_cast<char*>(batch.tuple_data_pool()->allocate(10));
+        str_val->ptr = reinterpret_cast<char*>(batch.tuple_data_pool()->allocate(16));
         str_val->len = 15;
         memcpy(str_val->ptr, "abcde1234567890", str_val->len);
 

--- a/be/test/exprs/timestamp_functions_test.cpp
+++ b/be/test/exprs/timestamp_functions_test.cpp
@@ -47,14 +47,16 @@ public:
         utils = new FunctionUtils(state);
         ctx = utils->get_fn_ctx();
     }
+
     void TearDown() {
         delete state;
         delete utils;
     }
+
 private:
-    RuntimeState* state;
-    FunctionUtils* utils;
-    FunctionContext* ctx;
+    RuntimeState* state = nullptr;
+    FunctionUtils* utils = nullptr;
+    FunctionContext* ctx = nullptr;
 };
 
 TEST_F(TimestampFunctionsTest, day_of_week_test) {

--- a/be/test/geo/wkt_parse_test.cpp
+++ b/be/test/geo/wkt_parse_test.cpp
@@ -39,6 +39,7 @@ TEST_F(WktParseTest, normal) {
     ASSERT_EQ(GEO_PARSE_OK, status);
     ASSERT_NE(nullptr, shape);
     LOG(INFO) << "parse result: " << shape->to_string();
+    delete shape;
 }
 
 TEST_F(WktParseTest, invalid_wkt) {

--- a/be/test/olap/in_list_predicate_test.cpp
+++ b/be/test/olap/in_list_predicate_test.cpp
@@ -441,8 +441,8 @@ TEST_F(TestInListPredicate, CHAR_COLUMN) {
     StringValue* col_data = reinterpret_cast<StringValue*>(_mem_pool->allocate(size * sizeof(StringValue)));
     col_vector->set_col_data(col_data);
     
-    char* string_buffer = reinterpret_cast<char*>(_mem_pool->allocate(50));
-    memset(string_buffer, 0, 50);
+    char* string_buffer = reinterpret_cast<char*>(_mem_pool->allocate(60));
+    memset(string_buffer, 0, 60);
     for (int i = 0; i < size; ++i) {
         for (int j = 0; j <= 5; ++j) {
             string_buffer[j] = 'a' + i;
@@ -484,8 +484,8 @@ TEST_F(TestInListPredicate, CHAR_COLUMN) {
     bool* is_null = reinterpret_cast<bool*>(_mem_pool->allocate(size));  
     memset(is_null, 0, size);
     col_vector->set_is_null(is_null);
-    string_buffer = reinterpret_cast<char*>(_mem_pool->allocate(50));
-    memset(string_buffer, 0, 50);
+    string_buffer = reinterpret_cast<char*>(_mem_pool->allocate(60));
+    memset(string_buffer, 0, 60);
     for (int i = 0; i < size; ++i) {
         if (i % 2 == 0) {
             is_null[i] = true;

--- a/be/test/olap/key_coder_test.cpp
+++ b/be/test/olap/key_coder_test.cpp
@@ -233,7 +233,8 @@ TEST_F(KeyCoderTest, test_char) {
         auto st = key_coder->decode_ascending(&encoded_key, 10, (uint8_t*)&check_slice, &_pool);
         ASSERT_TRUE(st.ok());
 
-        ASSERT_STREQ("1234567890", check_slice.data);
+        ASSERT_EQ(10, check_slice.size);
+        ASSERT_EQ(strncmp("1234567890", check_slice.data, 10), 0);
     }
 
     {
@@ -245,7 +246,8 @@ TEST_F(KeyCoderTest, test_char) {
         auto st = key_coder->decode_ascending(&encoded_key, 5, (uint8_t*)&check_slice, &_pool);
         ASSERT_TRUE(st.ok());
 
-        ASSERT_STREQ("12345", check_slice.data);
+        ASSERT_EQ(5, check_slice.size);
+        ASSERT_EQ(strncmp("12345", check_slice.data, 5), 0);
     }
 }
 
@@ -264,7 +266,8 @@ TEST_F(KeyCoderTest, test_varchar) {
         auto st = key_coder->decode_ascending(&encoded_key, 15, (uint8_t*)&check_slice, &_pool);
         ASSERT_TRUE(st.ok());
 
-        ASSERT_STREQ("1234567890", check_slice.data);
+        ASSERT_EQ(10, check_slice.size);
+        ASSERT_EQ(strncmp("1234567890", check_slice.data, 10), 0);
     }
 
     {
@@ -276,7 +279,8 @@ TEST_F(KeyCoderTest, test_varchar) {
         auto st = key_coder->decode_ascending(&encoded_key, 5, (uint8_t*)&check_slice, &_pool);
         ASSERT_TRUE(st.ok());
 
-        ASSERT_STREQ("12345", check_slice.data);
+        ASSERT_EQ(5, check_slice.size);
+        ASSERT_EQ(strncmp("12345", check_slice.data, 5), 0);
     }
 }
 

--- a/be/test/olap/rowset/rowset_converter_test.cpp
+++ b/be/test/olap/rowset/rowset_converter_test.cpp
@@ -207,10 +207,13 @@ void RowsetConverterTest::process(RowsetTypePB src_type, RowsetTypePB dst_type) 
     OLAPStatus res = row.init(tablet_schema);
     ASSERT_EQ(OLAP_SUCCESS, res);
 
+    std::vector<std::string> test_data;
     for (int i = 0; i < 1024; ++i) {
+        test_data.push_back("well" + std::to_string(i));
+
         int32_t field_0 = i;
         row.set_field_content(0, reinterpret_cast<char*>(&field_0), _mem_pool.get());
-        Slice field_1("well" + std::to_string(i));
+        Slice field_1(test_data[i]);
         row.set_field_content(1, reinterpret_cast<char*>(&field_1), _mem_pool.get());
         int32_t field_2 = 10000 + i;
         row.set_field_content(2, reinterpret_cast<char*>(&field_2), _mem_pool.get());

--- a/be/test/olap/rowset/segment_v2/binary_dict_page_test.cpp
+++ b/be/test/olap/rowset/segment_v2/binary_dict_page_test.cpp
@@ -217,7 +217,7 @@ TEST_F(BinaryDictPageTest, TestEncodingRatio) {
         src_strings.emplace_back(line);
     }
     for (int i = 0; i < 10000; ++i) {
-        for (auto src_string : src_strings) {
+        for (const auto& src_string : src_strings) {
             slices.push_back(src_string);
         }
     }

--- a/be/test/olap/rowset/segment_v2/binary_prefix_page_test.cpp
+++ b/be/test/olap/rowset/segment_v2/binary_prefix_page_test.cpp
@@ -37,12 +37,11 @@ class BinaryPrefixPageTest : public testing::Test {
     void test_encode_and_decode() {
         std::vector<std::string> test_data;
         for (int i = 1000; i < 1038; ++i) {
-            test_data.push_back(std::to_string(i));
+            test_data.emplace_back(std::to_string(i));
         }
         std::vector<Slice> slices;
-        for (int i = 0; i < test_data.size(); ++i) {
-            Slice s(test_data[i]);
-            slices.emplace_back(s);
+        for (const auto& data : test_data) {
+            slices.emplace_back(Slice(data));
         }
         // encode
         PageBuilderOptions options;
@@ -101,22 +100,22 @@ class BinaryPrefixPageTest : public testing::Test {
             ASSERT_EQ(std::to_string(i), values[i - 1015].to_string());
         }
 
-        Slice v1 = Slice(std::to_string(1039));
+        Slice v1 = Slice("1039");
         bool exact_match;
         ret = page_decoder->seek_at_or_after_value(&v1, &exact_match);
         ASSERT_TRUE(ret.is_not_found());
 
-        Slice v2 = Slice(std::to_string(1000));
+        Slice v2 = Slice("1000");
         ret = page_decoder->seek_at_or_after_value(&v2, &exact_match);
         ASSERT_TRUE(ret.ok());
         ASSERT_TRUE(exact_match);
 
-        Slice v3 = Slice(std::to_string(1037));
+        Slice v3 = Slice("1037");
         ret = page_decoder->seek_at_or_after_value(&v3, &exact_match);
         ASSERT_TRUE(ret.ok());
         ASSERT_TRUE(exact_match);
 
-        Slice v4 = Slice(std::to_string(100));
+        Slice v4 = Slice("100");
         ret = page_decoder->seek_at_or_after_value(&v4, &exact_match);
         ASSERT_TRUE(ret.ok());
         ASSERT_TRUE(!exact_match);

--- a/be/test/olap/rowset/segment_v2/bitmap_index_test.cpp
+++ b/be/test/olap/rowset/segment_v2/bitmap_index_test.cpp
@@ -136,7 +136,7 @@ TEST_F(BitmapIndexTest, test_invert) {
         delete reader;
         delete iter;
     }
-    delete val;
+    delete[] val;
 }
 
 TEST_F(BitmapIndexTest, test_invert_2) {
@@ -174,7 +174,7 @@ TEST_F(BitmapIndexTest, test_invert_2) {
         delete reader;
         delete iter;
     }
-    delete val;
+    delete[] val;
 }
 
 TEST_F(BitmapIndexTest, test_multi_pages) {
@@ -206,7 +206,7 @@ TEST_F(BitmapIndexTest, test_multi_pages) {
         delete reader;
         delete iter;
     }
-    delete val;
+    delete[] val;
 }
 
 TEST_F(BitmapIndexTest, test_null) {
@@ -231,7 +231,7 @@ TEST_F(BitmapIndexTest, test_null) {
         delete reader;
         delete iter;
     }
-    delete val;
+    delete[] val;
 }
 
 }

--- a/be/test/olap/schema_change_test.cpp
+++ b/be/test/olap/schema_change_test.cpp
@@ -318,7 +318,7 @@ public:
     std::vector<StorageByteBuffer*> _second_buffers;
     std::vector<StorageByteBuffer*> _dictionary_buffers;
     std::vector<StorageByteBuffer*> _length_buffers;
-    StorageByteBuffer* _shared_buffer;
+    StorageByteBuffer* _shared_buffer = nullptr;
     std::map<StreamName, ReadOnlyFileStream *> _map_in_streams;
     FileHandler helper;
     OlapReaderStatistics _stats;

--- a/be/test/plugin/plugin_zip_test.cpp
+++ b/be/test/plugin/plugin_zip_test.cpp
@@ -80,7 +80,6 @@ public:
         _server->start();
         
         std::cout << "the path: " << _path << std::endl;
-
     }
 
     ~PluginZipTest() {
@@ -122,13 +121,9 @@ TEST_F(PluginZipTest, http_normal) {
 
     //    ASSERT_TRUE(zip.extract(_path + "/plugin_test/target/", "test").ok());
     Status st = (zip.extract(_path + "/plugin_test/target/", "test"));
-
-    std::cout << st.to_string() << std::endl;
-    
-    
+    ASSERT_TRUE(st.ok()) << st.to_string();
     ASSERT_TRUE(FileUtils::check_exist(_path + "/plugin_test/target/test"));
     ASSERT_TRUE(FileUtils::check_exist(_path + "/plugin_test/target/test/test.txt"));
-
 
     std::unique_ptr<RandomAccessFile> file;
     Env::Default()->new_random_access_file(_path + "/plugin_test/target/test/test.txt", &file);
@@ -150,6 +145,9 @@ TEST_F(PluginZipTest, http_normal) {
 }
 
 TEST_F(PluginZipTest, already_install) {
+    // This test case will finish very soon, sleep 1 second to ensure that EvHttpServer worker has started
+    // before this unit test case finished, or there may cause an ASAN error.
+    sleep(1);
     FileUtils::remove_all(_path + "/plugin_test/target");
 
     PluginZip zip("http://127.0.0.1:29191/test.zip");

--- a/be/test/runtime/memory_scratch_sink_test.cpp
+++ b/be/test/runtime/memory_scratch_sink_test.cpp
@@ -67,7 +67,6 @@ public:
 
     ~MemoryScratchSinkTest() {
         delete _state;
-        delete _row_desc;
         delete _mem_tracker;
         delete _exec_env->_result_queue_mgr;
         delete _exec_env->_thread_mgr;

--- a/be/test/util/aes_util_test.cpp
+++ b/be/test/util/aes_util_test.cpp
@@ -37,12 +37,12 @@ private:
 
 void do_aes_test(const std::string& source, const std::string& key) {
     int cipher_len = source.length() + 16;
-    std::unique_ptr<unsigned char> dest(new unsigned char[cipher_len]);
+    std::unique_ptr<unsigned char[]> dest(new unsigned char[cipher_len]);
     int ret_code = AesUtil::encrypt(AES_128_ECB, (unsigned char *)source.c_str(), source.length(),
             (unsigned char *)key.c_str(), key.length(), NULL, true, dest.get());
     ASSERT_TRUE(ret_code > 0);
     int encrypted_length = ret_code;
-    std::unique_ptr<char> decrypted(new char[source.length()]);
+    std::unique_ptr<char[]> decrypted(new char[cipher_len]);
     ret_code = AesUtil::decrypt(AES_128_ECB, dest.get(), encrypted_length, 
             (unsigned char *)key.c_str(), key.length(), NULL, true, (unsigned char *)decrypted.get());
     ASSERT_TRUE(ret_code > 0);
@@ -63,18 +63,18 @@ TEST_F(AesUtilTest, aes_test_by_case) {
     std::string case_2 = "nP/db4j4yqMjXv/pItaOVA=="; // base64 for encrypted "doris test"
     std::string source_2 = "doris test";
 
-    std::unique_ptr<char> encrypt_1(new char[case_1.length()]);
+    std::unique_ptr<char[]> encrypt_1(new char[case_1.length()]);
     int length_1 = base64_decode2(case_1.c_str(), case_1.length(), encrypt_1.get());
-    std::unique_ptr<char> decrypted_1(new char[case_1.length()]);
+    std::unique_ptr<char[]> decrypted_1(new char[case_1.length()]);
     int ret_code = AesUtil::decrypt(AES_128_ECB, (unsigned char *)encrypt_1.get(), length_1,
             (unsigned char *)_aes_key.c_str(), _aes_key.length(), NULL, true, (unsigned char *)decrypted_1.get());
     ASSERT_TRUE(ret_code > 0);
     std::string decrypted_content_1(decrypted_1.get(), ret_code);
     ASSERT_EQ(source_1, decrypted_content_1);
 
-    std::unique_ptr<char> encrypt_2(new char[case_2.length()]);
+    std::unique_ptr<char[]> encrypt_2(new char[case_2.length()]);
     int length_2 = base64_decode2(case_2.c_str(), case_2.length(), encrypt_2.get());
-    std::unique_ptr<char> decrypted_2(new char[case_2.length()]);
+    std::unique_ptr<char[]> decrypted_2(new char[case_2.length()]);
     ret_code = AesUtil::decrypt(AES_128_ECB, (unsigned char *)encrypt_2.get(), length_2,
             (unsigned char *)_aes_key.c_str(), _aes_key.length(), NULL, true, (unsigned char *)decrypted_2.get());
     ASSERT_TRUE(ret_code > 0);

--- a/be/test/util/zip_util_test.cpp
+++ b/be/test/util/zip_util_test.cpp
@@ -39,7 +39,8 @@ TEST(ZipUtilTest, basic) {
     FileUtils::remove_all(path + "/test_data/target");
 
     ZipFile zf = ZipFile(path + "/test_data/zip_normal.zip");
-    ASSERT_TRUE(zf.extract(path + "/test_data", "target").ok());
+    auto st = zf.extract(path + "/test_data", "target");
+    ASSERT_TRUE(st.ok()) << st.to_string();
     ASSERT_TRUE(FileUtils::check_exist(path + "/test_data/target/zip_normal_data"));
     ASSERT_FALSE(FileUtils::is_dir(path + "/test_data/target/zip_normal_data"));
 


### PR DESCRIPTION
LSAN detected errors have been fixed by a prior pathch (#3326), but
there are still some ASAN detected errors.
This patch try to fix these errors to make Doris BE more robustness.
And then we can add CI run in LSAN/ASAN mode to detect memory errors
as early as possible.