### PR TITLE
[BugFix] Fix the bug let fe can show each fragment execute time percent

### DIFF
--- a/fe/src/main/java/org/apache/doris/common/util/RuntimeProfile.java
+++ b/fe/src/main/java/org/apache/doris/common/util/RuntimeProfile.java
@@ -316,6 +316,13 @@ public class RuntimeProfile {
         Pair<RuntimeProfile, Boolean> pair = Pair.create(child, true);
         this.childList.add(pair);
     }
+
+    // Because the profile of summary and child fragment is not a real parent-child relationship
+    // Each child profile needs to calculate the time proportion consumed by itself
+    public void computeTimeInChildProfile() {
+        childMap.values().stream().
+                forEach(child -> child.computeTimeInProfile());
+    }
     
     public void computeTimeInProfile() {
         computeTimeInProfile(this.counterTotalTime.getValue());

--- a/fe/src/main/java/org/apache/doris/qe/Coordinator.java
+++ b/fe/src/main/java/org/apache/doris/qe/Coordinator.java
@@ -1374,6 +1374,7 @@ public class Coordinator {
         }
 
         public synchronized void printProfile(StringBuilder builder) {
+            this.profile.computeTimeInProfile();
             this.profile.prettyPrint(builder, "");
         }
 

--- a/fe/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -335,6 +335,7 @@ public class StmtExecutor {
 
     private void writeProfile(long beginTimeInNanoSecond) {
         initProfile(beginTimeInNanoSecond);
+        profile.computeTimeInChildProfile();
         StringBuilder builder = new StringBuilder();
         profile.prettyPrint(builder, "");
         System.out.println(builder.toString());


### PR DESCRIPTION
like this：
          (Active: 14.133ms, non-child: 93.20%)

ISSUE: #3365