### PR TITLE
[Bug] Fix constant In Predicate result error

### DIFF
--- a/fe/src/main/java/org/apache/doris/analysis/InPredicate.java
+++ b/fe/src/main/java/org/apache/doris/analysis/InPredicate.java
@@ -54,6 +54,8 @@ public class InPredicate extends Predicate {
     private static final String IN = "in";
     private static final String NOT_IN = "not_in";
 
+    private static final NullLiteral NULL_LITERAL = new NullLiteral();
+
     public static void initBuiltins(FunctionSet functionSet) {
         for (Type t: Type.getSupportedTypes()) {
             if (t.isNull()) continue;
@@ -262,15 +264,17 @@ public class InPredicate extends Predicate {
         }
 
         List<Expr> inListChildren = children.subList(1, children.size());
-        if (inListChildren.contains(leftChildValue)) {
-            return new BoolLiteral(true);
-        } else {
-            final NullLiteral nullLiteral = new NullLiteral();
-            if (inListChildren.contains(nullLiteral)) {
-                return nullLiteral;
-            }
-            return new BoolLiteral(false);
+        boolean containsLeftChild = inListChildren.contains(leftChildValue);
+
+        // See QueryPlanTest.java testConstantInPredicate() for examples.
+        // This logic should be same as logic in in_predicate.cpp: get_boolean_val()
+        if (containsLeftChild) {
+            return new BoolLiteral(!isNotIn);
         }
+        if (inListChildren.contains(NULL_LITERAL)) {
+            return new NullLiteral();
+        }
+        return new BoolLiteral(isNotIn);
     }
 
     @Override

--- a/fe/src/test/java/org/apache/doris/planner/ConstantExpressTest.java
+++ b/fe/src/test/java/org/apache/doris/planner/ConstantExpressTest.java
@@ -19,6 +19,7 @@ package org.apache.doris.planner;
 
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.utframe.UtFrameUtils;
+
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -157,5 +158,59 @@ public class ConstantExpressTest {
         testConstantExpressResult(
                 "select 1 = 1",
                 "TRUE");
+    }
+
+    @Test
+    public void testConstantInPredicate() throws Exception {
+        connectContext.setDatabase("default_cluster:test");
+        // for constant NOT IN PREDICATE
+        String sql = "select 1 not in (1, 2);";
+        String explainString = UtFrameUtils.getSQLPlanOrErrorMsg(connectContext, "explain " + sql);
+        Assert.assertTrue(explainString.contains("FALSE"));
+
+        sql = "select 1 not in (2, 3);";
+        explainString = UtFrameUtils.getSQLPlanOrErrorMsg(connectContext, "explain " + sql);
+        Assert.assertTrue(explainString.contains("TRUE"));
+
+        sql = "select 1 not in (2, null);";
+        explainString = UtFrameUtils.getSQLPlanOrErrorMsg(connectContext, "explain " + sql);
+        Assert.assertTrue(explainString.contains("NULL"));
+
+        sql = "select 1 not in (1, 2, null);";
+        explainString = UtFrameUtils.getSQLPlanOrErrorMsg(connectContext, "explain " + sql);
+        Assert.assertTrue(explainString.contains("FALSE"));
+
+        sql = "select null not in (1, 2);";
+        explainString = UtFrameUtils.getSQLPlanOrErrorMsg(connectContext, "explain " + sql);
+        Assert.assertTrue(explainString.contains("NULL"));
+
+        sql = "select null not in (null);";
+        explainString = UtFrameUtils.getSQLPlanOrErrorMsg(connectContext, "explain " + sql);
+        Assert.assertTrue(explainString.contains("NULL"));
+
+        // for constant IN PREDICATE
+        sql = "select 1 in (1, 2);";
+        explainString = UtFrameUtils.getSQLPlanOrErrorMsg(connectContext, "explain " + sql);
+        Assert.assertTrue(explainString.contains("TRUE"));
+
+        sql = "select 1 in (2, 3);";
+        explainString = UtFrameUtils.getSQLPlanOrErrorMsg(connectContext, "explain " + sql);
+        Assert.assertTrue(explainString.contains("FALSE"));
+
+        sql = "select 1 in (1, 2, NULL);";
+        explainString = UtFrameUtils.getSQLPlanOrErrorMsg(connectContext, "explain " + sql);
+        Assert.assertTrue(explainString.contains("TRUE"));
+
+        sql = "select 1 in (2, NULL);";
+        explainString = UtFrameUtils.getSQLPlanOrErrorMsg(connectContext, "explain " + sql);
+        Assert.assertTrue(explainString.contains("NULL"));
+
+        sql = "select null in (2);";
+        explainString = UtFrameUtils.getSQLPlanOrErrorMsg(connectContext, "explain " + sql);
+        Assert.assertTrue(explainString.contains("NULL"));
+
+        sql = "select null in (null);";
+        explainString = UtFrameUtils.getSQLPlanOrErrorMsg(connectContext, "explain " + sql);
+        Assert.assertTrue(explainString.contains("NULL"));
     }
 }

--- a/fe/src/test/java/org/apache/doris/planner/QueryPlanTest.java
+++ b/fe/src/test/java/org/apache/doris/planner/QueryPlanTest.java
@@ -825,6 +825,4 @@ public class QueryPlanTest {
         Assert.assertTrue(explainString.contains("CROSS JOIN"));
         Assert.assertTrue(!explainString.contains("PREDICATES"));
     }
-
-
 }


### PR DESCRIPTION
`select 1 not in (2, NULL, 1);` should return `0`

Fix: #3510 