### PR TITLE
[Bug] Fix bug that SHOW DELETE not return Delete job info

### DIFF
--- a/fe/src/main/java/org/apache/doris/common/MarkedCountDownLatch.java
+++ b/fe/src/main/java/org/apache/doris/common/MarkedCountDownLatch.java
@@ -56,11 +56,13 @@ public class MarkedCountDownLatch<K, V> extends CountDownLatch {
     }
 
     public synchronized void countDownToZero(Status status) {
-        while(getCount() > 0) {
-            super.countDown();
-        }
+        // update status first before countDown.
+        // so that the waiting thread will get the correct status.
         if (st.ok()) {
             st = status;
+        }
+        while(getCount() > 0) {
+            super.countDown();
         }
     }
 }

--- a/fe/src/main/java/org/apache/doris/load/DeleteJob.java
+++ b/fe/src/main/java/org/apache/doris/load/DeleteJob.java
@@ -22,6 +22,7 @@ import org.apache.doris.catalog.Database;
 import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.catalog.Replica;
 import org.apache.doris.common.Config;
+import org.apache.doris.common.FeConstants;
 import org.apache.doris.common.MetaNotFoundException;
 import org.apache.doris.common.UserException;
 import org.apache.doris.task.PushTask;
@@ -190,6 +191,10 @@ public class DeleteJob extends AbstractTxnStateChangeCallback {
     }
 
     public long getTimeoutMs() {
+        if (FeConstants.runningUnitTest) {
+            // for making unit test run fast
+            return 1000;
+        }
         // timeout is between 30 seconds to 5 min
         long timeout = Math.max(totalTablets.size() * Config.tablet_delete_timeout_second * 1000L, 30000L);
         return Math.min(timeout, Config.load_straggler_wait_second * 1000L);

--- a/fe/src/main/java/org/apache/doris/load/DeleteJob.java
+++ b/fe/src/main/java/org/apache/doris/load/DeleteJob.java
@@ -17,17 +17,20 @@
 
 package org.apache.doris.load;
 
-import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
 import org.apache.doris.catalog.Catalog;
 import org.apache.doris.catalog.Database;
 import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.catalog.Replica;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.MetaNotFoundException;
+import org.apache.doris.common.UserException;
 import org.apache.doris.task.PushTask;
 import org.apache.doris.transaction.AbstractTxnStateChangeCallback;
 import org.apache.doris.transaction.TransactionState;
+
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -163,6 +166,13 @@ public class DeleteJob extends AbstractTxnStateChangeCallback {
         }
         executeFinish();
         Catalog.getCurrentCatalog().getEditLog().logFinishDelete(deleteInfo);
+    }
+
+    @Override
+    public void afterAborted(TransactionState txnState, boolean txnOperated, String txnStatusChangeReason)
+            throws UserException {
+        // just to clean the callback
+        Catalog.getCurrentGlobalTransactionMgr().getCallbackFactory().removeCallback(getId());
     }
 
     public void executeFinish() {

--- a/fe/src/main/java/org/apache/doris/transaction/TxnStateCallbackFactory.java
+++ b/fe/src/main/java/org/apache/doris/transaction/TxnStateCallbackFactory.java
@@ -35,13 +35,15 @@ public class TxnStateCallbackFactory {
             return false;
         }
         callbacks.put(callback.getId(), callback);
-        LOG.info("add callback of txn state : {}", callback.getId());
+        LOG.info("add callback of txn state : {}. current callback size: {}",
+                callback.getId(), callbacks.size());
         return true;
     }
 
     public synchronized void removeCallback(long id) {
         if (callbacks.remove(id) != null) {
-            LOG.info("remove callback of txn state : {}", id);
+            LOG.info("remove callback of txn state : {}. current callback size: {}",
+                    id, callbacks.size());
         }
     }
 


### PR DESCRIPTION
Fix: #3514 
The callback added to the CallbackFactory should not be removed until the
transaction is aborted or visible. Otherwise, some callback method may failed
to be called.