### PR TITLE
[ut] disable backgrounp scan context gc to speed up unit test

### DIFF
--- a/be/src/runtime/external_scan_context_mgr.cpp
+++ b/be/src/runtime/external_scan_context_mgr.cpp
@@ -92,6 +92,7 @@ Status ExternalScanContextMgr::clear_scan_context(const std::string& context_id)
 }
 
 void ExternalScanContextMgr::gc_expired_context() {
+#ifndef BE_TEST
     while (!_is_stop) {
         std::this_thread::sleep_for(std::chrono::seconds(doris::config::scan_context_gc_interval_min * 60));
         time_t current_time = time(NULL);
@@ -125,5 +126,6 @@ void ExternalScanContextMgr::gc_expired_context() {
             _exec_env->result_queue_mgr()->cancel(expired_context->fragment_instance_id);
         }
     }
+#endif
 }
 }

--- a/be/test/runtime/external_scan_context_mgr_test.cpp
+++ b/be/test/runtime/external_scan_context_mgr_test.cpp
@@ -110,8 +110,6 @@ int main(int argc, char** argv) {
         return -1;
     }
 
-    doris::config::scan_context_gc_interval_min = 1;
-    // doris::init_glog("be-test");
     ::testing::InitGoogleTest(&argc, argv);
     doris::CpuInfo::init();
     return RUN_ALL_TESTS();


### PR DESCRIPTION
Each test case in ExternalScanContextMgrTest may cost 1 minitue
which is too long, we'd better disable backgrounp scan context
gc to speed up unit test.