### PR TITLE
[SQL]When compare StringLiteral and Numerical, cast them to Numerical type

### DIFF
--- a/fe/src/main/java/org/apache/doris/analysis/BinaryPredicate.java
+++ b/fe/src/main/java/org/apache/doris/analysis/BinaryPredicate.java
@@ -101,8 +101,9 @@ public class BinaryPredicate extends Predicate implements Writable {
                     return LE;
                 case EQ_FOR_NULL:
                     return this;
+                default:
+                    return null;
             }
-            return null;
         }
 
         public Operator converse() {

--- a/fe/src/main/java/org/apache/doris/analysis/BinaryPredicate.java
+++ b/fe/src/main/java/org/apache/doris/analysis/BinaryPredicate.java
@@ -263,15 +263,9 @@ public class BinaryPredicate extends Predicate implements Writable {
 
     private boolean canCompareDate(PrimitiveType t1, PrimitiveType t2) {
         if (t1.isDateType()) {
-            if (t2.isDateType() || t2.isStringType()) {
-                return true;
-            }
-            return false;
+            return t2.isDateType() || t2.isStringType();
         } else if (t2.isDateType()) {
-            if (t1.isStringType()) {
-                return true;
-            }
-            return false;
+            return t1.isStringType();
         } else {
             return false;
         }
@@ -304,6 +298,10 @@ public class BinaryPredicate extends Predicate implements Writable {
         if ((t1 == PrimitiveType.BIGINT || t1 == PrimitiveType.LARGEINT)
                 && (t2 == PrimitiveType.BIGINT || t2 == PrimitiveType.LARGEINT)) {
             return Type.LARGEINT;
+        }
+
+        if ((t1.isNumericType() && t2.isStringType()) || (t1.isStringType() && t2.isNumericType())) {
+            return t1.isNumericType() ? Type.fromPrimitiveType(t1) : Type.fromPrimitiveType(t2);
         }
 
         return Type.DOUBLE;

--- a/fe/src/main/java/org/apache/doris/analysis/ExistsPredicate.java
+++ b/fe/src/main/java/org/apache/doris/analysis/ExistsPredicate.java
@@ -58,6 +58,7 @@ public class ExistsPredicate extends Predicate {
     @Override
     public Expr clone() { return new ExistsPredicate(this); }
 
+    @Override
     public String toSqlImpl() {
         StringBuilder strBuilder = new StringBuilder();
         if (notExists) {

--- a/fe/src/main/java/org/apache/doris/analysis/Expr.java
+++ b/fe/src/main/java/org/apache/doris/analysis/Expr.java
@@ -1220,7 +1220,7 @@ abstract public class Expr extends TreeNode<Expr> implements ParseNode, Cloneabl
         // TODO(zc): use implicit cast
         if (!Type.canCastTo(this.type, targetType)) {
             throw new AnalysisException("type not match, originType=" + this.type
-                    + ", targeType=" + targetType);
+                    + ", targetType=" + targetType);
 
         }
         return uncheckedCastTo(targetType);

--- a/fe/src/main/java/org/apache/doris/analysis/Expr.java
+++ b/fe/src/main/java/org/apache/doris/analysis/Expr.java
@@ -343,6 +343,7 @@ abstract public class Expr extends TreeNode<Expr> implements ParseNode, Cloneabl
      * Perform semantic analysis of node and all of its children.
      * Throws exception if any errors found.
      */
+    @Override
     public final void analyze(Analyzer analyzer) throws AnalysisException {
         if (isAnalyzed()) return;
 
@@ -660,7 +661,7 @@ abstract public class Expr extends TreeNode<Expr> implements ParseNode, Cloneabl
         if (exprs == null) {
             return null;
         }
-        ArrayList<Expr> result = new ArrayList<Expr>();
+        ArrayList<Expr> result = new ArrayList<>();
         for (Expr e: exprs) {
             result.add(e.trySubstitute(smap, analyzer, preserveRootTypes));
         }
@@ -820,6 +821,7 @@ abstract public class Expr extends TreeNode<Expr> implements ParseNode, Cloneabl
         }
     }
 
+    @Override
     public String toSql() {
         return (printSqlInParens) ? "(" + toSqlImpl() + ")" : toSqlImpl();
     }

--- a/fe/src/main/java/org/apache/doris/analysis/FunctionCallExpr.java
+++ b/fe/src/main/java/org/apache/doris/analysis/FunctionCallExpr.java
@@ -73,6 +73,7 @@ public class FunctionCallExpr extends Expr {
         isAnalyticFnCall = v;
     }
 
+    @Override
     public Function getFn() {
         return fn;
     }

--- a/fe/src/main/java/org/apache/doris/catalog/ScalarFunction.java
+++ b/fe/src/main/java/org/apache/doris/catalog/ScalarFunction.java
@@ -136,8 +136,8 @@ public class ScalarFunction extends Function {
         String beFn = name;
         boolean usesDecimal = false;
         boolean usesDecimalV2 = false;
-        for (int i = 0; i < argTypes.size(); ++i) {
-            switch (argTypes.get(i).getPrimitiveType()) {
+        for (Type argType : argTypes) {
+            switch (argType.getPrimitiveType()) {
                 case BOOLEAN:
                     beFn += "_boolean_val";
                     break;
@@ -182,7 +182,7 @@ public class ScalarFunction extends Function {
                     usesDecimalV2 = true;
                     break;
                 default:
-                    Preconditions.checkState(false, "Argument type not supported: " + argTypes.get(i));
+                    Preconditions.checkState(false, "Argument type not supported: " + argType);
             }
         }
         String beClass = usesDecimal ? "DecimalOperators" : "Operators";
@@ -224,7 +224,7 @@ public class ScalarFunction extends Function {
     public static ScalarFunction createBuiltinSearchDesc(
             String name, Type[] argTypes, boolean hasVarArgs) {
         ArrayList<Type> fnArgs =
-                (argTypes == null) ? new ArrayList<Type>() : Lists.newArrayList(argTypes);
+                (argTypes == null) ? new ArrayList<>() : Lists.newArrayList(argTypes);
         ScalarFunction fn = new ScalarFunction(
                 new FunctionName(name), fnArgs, Type.INVALID, hasVarArgs);
         fn.setBinaryType(TFunctionBinaryType.BUILTIN);
@@ -257,10 +257,10 @@ public class ScalarFunction extends Function {
     public String toSql(boolean ifNotExists) {
         StringBuilder sb = new StringBuilder("CREATE FUNCTION ");
         if (ifNotExists) sb.append("IF NOT EXISTS ");
-        sb.append(dbName() + "." + signatureString() + "\n")
-                .append(" RETURNS " + getReturnType() + "\n")
-                .append(" LOCATION '" + getLocation() + "'\n")
-                .append(" SYMBOL='" + getSymbolName() + "'\n");
+        sb.append(dbName()).append(".").append(signatureString()).append("\n").append(" RETURNS ")
+                .append(getReturnType()).append("\n").append(" LOCATION '")
+                .append(getLocation()).append("'\n").append(" SYMBOL='")
+                .append(getSymbolName()).append("'\n");
         return sb.toString();
     }
 
@@ -290,6 +290,7 @@ public class ScalarFunction extends Function {
         writeOptionString(output, closeFnSymbol);
     }
 
+    @Override
     public void readFields(DataInput input) throws IOException {
         super.readFields(input);
         symbolName = Text.readString(input);

--- a/fe/src/test/java/org/apache/doris/planner/QueryPlanTest.java
+++ b/fe/src/test/java/org/apache/doris/planner/QueryPlanTest.java
@@ -387,7 +387,7 @@ public class QueryPlanTest {
 
         testBitmapQueryPlan(
                 "select count(*) from test.bitmap_table where id2 = 1;",
-                "type not match, originType=BITMAP, targeType=DOUBLE"
+                "type not match, originType=BITMAP, targetType=DOUBLE"
         );
 
     }
@@ -446,7 +446,7 @@ public class QueryPlanTest {
 
         testHLLQueryPlan(
                 "select count(*) from test.hll_table where id2 = 1",
-                "type not match, originType=HLL, targeType=DOUBLE"
+                "type not match, originType=HLL, targetType=DOUBLE"
         );
     }
 

--- a/fe/src/test/java/org/apache/doris/planner/QueryPlanTest.java
+++ b/fe/src/test/java/org/apache/doris/planner/QueryPlanTest.java
@@ -387,7 +387,7 @@ public class QueryPlanTest {
 
         testBitmapQueryPlan(
                 "select count(*) from test.bitmap_table where id2 = 1;",
-                "type not match, originType=BITMAP, targetType=DOUBLE"
+                "type not match, originType=BITMAP, targetType=BIGINT"
         );
 
     }
@@ -446,7 +446,7 @@ public class QueryPlanTest {
 
         testHLLQueryPlan(
                 "select count(*) from test.hll_table where id2 = 1",
-                "type not match, originType=HLL, targetType=DOUBLE"
+                "type not match, originType=HLL, targetType=BIGINT"
         );
     }
 
@@ -740,7 +740,7 @@ public class QueryPlanTest {
                 + "case when date_format(now(),'%H%i')  < 123 then 1 else 0 end as col "
                 + "from test.test1 "
                 + "where time = case when date_format(now(),'%H%i')  < 123 then date_format(date_sub(now(),2),'%Y%m%d') else date_format(date_sub(now(),1),'%Y%m%d') end";
-        Assert.assertTrue(!StringUtils.containsIgnoreCase(UtFrameUtils.getSQLPlanOrErrorMsg(connectContext, "explain " + caseWhenSql), "CASE WHEN"));
+        Assert.assertFalse(StringUtils.containsIgnoreCase(UtFrameUtils.getSQLPlanOrErrorMsg(connectContext, "explain " + caseWhenSql), "CASE WHEN"));
 
         // test 1: case when then
         // 1.1 multi when in on `case when` and can be converted to constants

--- a/fe/src/test/java/org/apache/doris/planner/QueryPlanTest.java
+++ b/fe/src/test/java/org/apache/doris/planner/QueryPlanTest.java
@@ -48,7 +48,7 @@ public class QueryPlanTest {
     private static String runningDir = "fe/mocked/QueryPlanTest/" + UUID.randomUUID().toString() + "/";
 
     private static ConnectContext connectContext;
-
+    
     @BeforeClass
     public static void beforeClass() throws Exception {
         UtFrameUtils.createMinDorisCluster(runningDir);
@@ -856,5 +856,9 @@ public class QueryPlanTest {
         String explainString2 = UtFrameUtils.getSQLPlanOrErrorMsg(connectContext, queryStr2);
         // origin behavior is PREDICATES: `olap_date` = 2.0200217E7
         Assert.assertTrue(explainString2.contains("PREDICATES: `olap_date` = 20200217"));
+
+        String queryStr3 = "explain SELECT count(*) FROM test.binary_predicate_test WHERE olap_date = '20200217a'";
+        String explainString3 = UtFrameUtils.getSQLPlanOrErrorMsg(connectContext, queryStr3);
+        Assert.assertEquals(explainString3, "errCode = 2, detailMessage = Invalid number format: 20200217a");
     }
 }


### PR DESCRIPTION
When compare StringLiteral and Numerical type, Doris will convert them both to Double Type, which will lead some unexpected behavior. For example: `select 2882303761517473127 = "2882303761517473267";` will be true.
