### PR TITLE
[Bug] restore tablet action not working because tablet status is shutdown

### DIFF
--- a/be/src/http/action/restore_tablet_action.cpp
+++ b/be/src/http/action/restore_tablet_action.cpp
@@ -117,7 +117,7 @@ Status RestoreTabletAction::_reload_tablet(const std::string& key, const std::st
     clone_req.__set_tablet_id(tablet_id);
     clone_req.__set_schema_hash(schema_hash);
     OLAPStatus res = OLAPStatus::OLAP_SUCCESS;
-    res = _exec_env->storage_engine()->load_header(shard_path, clone_req);
+    res = _exec_env->storage_engine()->load_header(shard_path, clone_req, /*restore=*/true);
     if (res != OLAPStatus::OLAP_SUCCESS) {
         LOG(WARNING) << "load header failed. status: " << res << ", signature: " << tablet_id;
         // remove tablet data path in data path

--- a/be/src/olap/storage_engine.cpp
+++ b/be/src/olap/storage_engine.cpp
@@ -824,7 +824,8 @@ OLAPStatus StorageEngine::obtain_shard_path(
 
 OLAPStatus StorageEngine::load_header(
         const string& shard_path,
-        const TCloneReq& request) {
+        const TCloneReq& request,
+        bool restore) {
     LOG(INFO) << "begin to process load headers."
               << "tablet_id=" << request.tablet_id
               << ", schema_hash=" << request.schema_hash;
@@ -864,7 +865,7 @@ OLAPStatus StorageEngine::load_header(
     res = _tablet_manager->load_tablet_from_dir(
             store,
             request.tablet_id, request.schema_hash,
-            schema_hash_path_stream.str(), false);
+            schema_hash_path_stream.str(), false, restore);
     if (res != OLAP_SUCCESS) {
         LOG(WARNING) << "fail to process load headers. res=" << res;
         return res;

--- a/be/src/olap/storage_engine.h
+++ b/be/src/olap/storage_engine.h
@@ -131,7 +131,7 @@ public:
     // @param [in] request specify new tablet info
     // @param [in] restore whether we're restoring a tablet from trash
     // @return OLAP_SUCCESS if load tablet success
-    OLAPStatus load_header(const std::string& shard_path, const TCloneReq& request, bool restore);
+    OLAPStatus load_header(const std::string& shard_path, const TCloneReq& request, bool restore = false);
 
     // To trigger a disk-stat and tablet report
     void trigger_report() {

--- a/be/src/olap/storage_engine.h
+++ b/be/src/olap/storage_engine.h
@@ -129,8 +129,9 @@ public:
     //
     // @param [in] root_path specify root path of new tablet
     // @param [in] request specify new tablet info
+    // @param [in] restore whether we're restoring a tablet from trash
     // @return OLAP_SUCCESS if load tablet success
-    OLAPStatus load_header(const std::string& shard_path, const TCloneReq& request);
+    OLAPStatus load_header(const std::string& shard_path, const TCloneReq& request, bool restore);
 
     // To trigger a disk-stat and tablet report
     void trigger_report() {

--- a/be/src/olap/tablet_manager.h
+++ b/be/src/olap/tablet_manager.h
@@ -96,15 +96,20 @@ public:
     void get_tablet_stat(TTabletStatResult* result);
 
     // parse tablet header msg to generate tablet object
+    // - restore: whether the request is from restore tablet action,
+    //   where we should change tablet status from shutdown back to running
     OLAPStatus load_tablet_from_meta(DataDir* data_dir, TTabletId tablet_id,
                                      TSchemaHash schema_hash, const std::string& header,
-                                     bool update_meta, bool force = false);
+                                     bool update_meta,
+                                     bool force = false,
+                                     bool restore = false);
 
     OLAPStatus load_tablet_from_dir(DataDir* data_dir,
                                     TTabletId tablet_id,
                                     SchemaHash schema_hash,
                                     const std::string& schema_hash_path,
-                                    bool force = false);
+                                    bool force = false,
+                                    bool restore = false);
 
     void release_schema_change_lock(TTabletId tablet_id);
 


### PR DESCRIPTION
Fixes #3550 

When restoring tablet, its status should be changed from SHUTDOWN back to RUNNING.