### PR TITLE
Support bitmap_intersect

### DIFF
--- a/be/src/exprs/bitmap_function.cpp
+++ b/be/src/exprs/bitmap_function.cpp
@@ -302,8 +302,8 @@ void BitmapFunctions::bitmap_union(FunctionContext* ctx, const StringVal& src, S
     }
 }
 
-// this is the read init function for bitmap_intersect
-void BitmapFunctions::bitmap_intersect_init_real(FunctionContext* ctx, StringVal* dst) {
+// the dst value could be null
+void BitmapFunctions::nullable_bitmap_init(FunctionContext* ctx, StringVal* dst) {
     dst->is_null = true;
 }
 
@@ -369,14 +369,13 @@ StringVal BitmapFunctions::bitmap_hash(doris_udf::FunctionContext* ctx, const do
 
 StringVal BitmapFunctions::bitmap_serialize(FunctionContext* ctx, const StringVal& src) {
     if (src.is_null) {
-        BitmapValue src_bitmap;
-        return serialize(ctx, &src_bitmap);
-    } else {
-        auto src_bitmap = reinterpret_cast<BitmapValue*>(src.ptr);
-        StringVal result = serialize(ctx, src_bitmap);
-        delete src_bitmap;
-        return result;
+        return src;
     }
+
+    auto src_bitmap = reinterpret_cast<BitmapValue*>(src.ptr);
+    StringVal result = serialize(ctx, src_bitmap);
+    delete src_bitmap;
+    return result;
 }
 
 // This is a init function for intersect_count not for bitmap_intersect.

--- a/be/src/exprs/bitmap_function.cpp
+++ b/be/src/exprs/bitmap_function.cpp
@@ -302,7 +302,8 @@ void BitmapFunctions::bitmap_union(FunctionContext* ctx, const StringVal& src, S
     }
 }
 
-void BitmapFunctions::bitmap_intersect_init(FunctionContext* ctx, StringVal* dst) {
+// this is the read init function for bitmap_intersect
+void BitmapFunctions::bitmap_intersect_init_real(FunctionContext* ctx, StringVal* dst) {
     dst->is_null = true;
 }
 
@@ -378,8 +379,9 @@ StringVal BitmapFunctions::bitmap_serialize(FunctionContext* ctx, const StringVa
     }
 }
 
+// This is a init function for intersect_count not for bitmap_intersect.
 template<typename T, typename ValType>
-void BitmapFunctions::intersect_count_init(FunctionContext* ctx, StringVal* dst) {
+void BitmapFunctions::bitmap_intersect_init(FunctionContext* ctx, StringVal* dst) {
     dst->is_null = false;
     dst->len = sizeof(BitmapIntersect<T>);
     auto intersect = new BitmapIntersect<T>();
@@ -539,25 +541,26 @@ template void BitmapFunctions::bitmap_update_int<IntVal>(
 template void BitmapFunctions::bitmap_update_int<BigIntVal>(
         FunctionContext* ctx, const BigIntVal& src, StringVal* dst);
 
-template void BitmapFunctions::intersect_count_init<int8_t, TinyIntVal>(
+// this is init function for intersect_count not for bitmap_intersect
+template void BitmapFunctions::bitmap_intersect_init<int8_t, TinyIntVal>(
     FunctionContext* ctx, StringVal* dst);
-template void BitmapFunctions::intersect_count_init<int16_t, SmallIntVal>(
+template void BitmapFunctions::bitmap_intersect_init<int16_t, SmallIntVal>(
     FunctionContext* ctx, StringVal* dst);
-template void BitmapFunctions::intersect_count_init<int32_t, IntVal>(
+template void BitmapFunctions::bitmap_intersect_init<int32_t, IntVal>(
     FunctionContext* ctx, StringVal* dst);
-template void BitmapFunctions::intersect_count_init<int64_t, BigIntVal>(
+template void BitmapFunctions::bitmap_intersect_init<int64_t, BigIntVal>(
     FunctionContext* ctx, StringVal* dst);
-template void BitmapFunctions::intersect_count_init<__int128, LargeIntVal>(
+template void BitmapFunctions::bitmap_intersect_init<__int128, LargeIntVal>(
     FunctionContext* ctx, StringVal* dst);
-template void BitmapFunctions::intersect_count_init<float, FloatVal>(
+template void BitmapFunctions::bitmap_intersect_init<float, FloatVal>(
     FunctionContext* ctx, StringVal* dst);
-template void BitmapFunctions::intersect_count_init<double, DoubleVal>(
+template void BitmapFunctions::bitmap_intersect_init<double, DoubleVal>(
     FunctionContext* ctx, StringVal* dst);
-template void BitmapFunctions::intersect_count_init<DateTimeValue, DateTimeVal>(
+template void BitmapFunctions::bitmap_intersect_init<DateTimeValue, DateTimeVal>(
     FunctionContext* ctx, StringVal* dst);
-template void BitmapFunctions::intersect_count_init<DecimalV2Value, DecimalV2Val>(
+template void BitmapFunctions::bitmap_intersect_init<DecimalV2Value, DecimalV2Val>(
     FunctionContext* ctx, StringVal* dst);
-template void BitmapFunctions::intersect_count_init<StringValue, StringVal>(
+template void BitmapFunctions::bitmap_intersect_init<StringValue, StringVal>(
     FunctionContext* ctx, StringVal* dst);
 
 

--- a/be/src/exprs/bitmap_function.cpp
+++ b/be/src/exprs/bitmap_function.cpp
@@ -302,6 +302,30 @@ void BitmapFunctions::bitmap_union(FunctionContext* ctx, const StringVal& src, S
     }
 }
 
+void BitmapFunctions::bitmap_intersect_init(FunctionContext* ctx, StringVal* dst) {
+    dst->is_null = true;
+}
+
+void BitmapFunctions::bitmap_intersect(FunctionContext* ctx, const StringVal& src, StringVal* dst) {
+    if (src.is_null) {
+        return;
+    }
+    // if dst is null, the src input is the first value
+    if (dst->is_null) {
+        dst->is_null = false;
+        dst->len = sizeof(BitmapValue);
+        dst->ptr = (uint8_t*)new BitmapValue((char*) src.ptr);
+        return;
+    }
+    auto dst_bitmap = reinterpret_cast<BitmapValue*>(dst->ptr);
+    // zero size means the src input is a agg object
+    if (src.len == 0) {
+        (*dst_bitmap) &= *reinterpret_cast<BitmapValue*>(src.ptr);
+    } else {
+        (*dst_bitmap) &= BitmapValue((char*) src.ptr);
+    }
+}
+
 BigIntVal BitmapFunctions::bitmap_count(FunctionContext* ctx, const StringVal& src) {
     if (src.is_null) {
         return 0;
@@ -343,14 +367,19 @@ StringVal BitmapFunctions::bitmap_hash(doris_udf::FunctionContext* ctx, const do
 }
 
 StringVal BitmapFunctions::bitmap_serialize(FunctionContext* ctx, const StringVal& src) {
-    auto src_bitmap = reinterpret_cast<BitmapValue*>(src.ptr);
-    StringVal result = serialize(ctx, src_bitmap);
-    delete src_bitmap;
-    return result;
+    if (src.is_null) {
+        BitmapValue src_bitmap;
+        return serialize(ctx, &src_bitmap);
+    } else {
+        auto src_bitmap = reinterpret_cast<BitmapValue*>(src.ptr);
+        StringVal result = serialize(ctx, src_bitmap);
+        delete src_bitmap;
+        return result;
+    }
 }
 
 template<typename T, typename ValType>
-void BitmapFunctions::bitmap_intersect_init(FunctionContext* ctx, StringVal* dst) {
+void BitmapFunctions::intersect_count_init(FunctionContext* ctx, StringVal* dst) {
     dst->is_null = false;
     dst->len = sizeof(BitmapIntersect<T>);
     auto intersect = new BitmapIntersect<T>();
@@ -510,25 +539,25 @@ template void BitmapFunctions::bitmap_update_int<IntVal>(
 template void BitmapFunctions::bitmap_update_int<BigIntVal>(
         FunctionContext* ctx, const BigIntVal& src, StringVal* dst);
 
-template void BitmapFunctions::bitmap_intersect_init<int8_t, TinyIntVal>(
+template void BitmapFunctions::intersect_count_init<int8_t, TinyIntVal>(
     FunctionContext* ctx, StringVal* dst);
-template void BitmapFunctions::bitmap_intersect_init<int16_t, SmallIntVal>(
+template void BitmapFunctions::intersect_count_init<int16_t, SmallIntVal>(
     FunctionContext* ctx, StringVal* dst);
-template void BitmapFunctions::bitmap_intersect_init<int32_t, IntVal>(
+template void BitmapFunctions::intersect_count_init<int32_t, IntVal>(
     FunctionContext* ctx, StringVal* dst);
-template void BitmapFunctions::bitmap_intersect_init<int64_t, BigIntVal>(
+template void BitmapFunctions::intersect_count_init<int64_t, BigIntVal>(
     FunctionContext* ctx, StringVal* dst);
-template void BitmapFunctions::bitmap_intersect_init<__int128, LargeIntVal>(
+template void BitmapFunctions::intersect_count_init<__int128, LargeIntVal>(
     FunctionContext* ctx, StringVal* dst);
-template void BitmapFunctions::bitmap_intersect_init<float, FloatVal>(
+template void BitmapFunctions::intersect_count_init<float, FloatVal>(
     FunctionContext* ctx, StringVal* dst);
-template void BitmapFunctions::bitmap_intersect_init<double, DoubleVal>(
+template void BitmapFunctions::intersect_count_init<double, DoubleVal>(
     FunctionContext* ctx, StringVal* dst);
-template void BitmapFunctions::bitmap_intersect_init<DateTimeValue, DateTimeVal>(
+template void BitmapFunctions::intersect_count_init<DateTimeValue, DateTimeVal>(
     FunctionContext* ctx, StringVal* dst);
-template void BitmapFunctions::bitmap_intersect_init<DecimalV2Value, DecimalV2Val>(
+template void BitmapFunctions::intersect_count_init<DecimalV2Value, DecimalV2Val>(
     FunctionContext* ctx, StringVal* dst);
-template void BitmapFunctions::bitmap_intersect_init<StringValue, StringVal>(
+template void BitmapFunctions::intersect_count_init<StringValue, StringVal>(
     FunctionContext* ctx, StringVal* dst);
 
 

--- a/be/src/exprs/bitmap_function.h
+++ b/be/src/exprs/bitmap_function.h
@@ -51,7 +51,8 @@ public:
     static BigIntVal bitmap_get_value(FunctionContext* ctx, const StringVal& src);
 
     static void bitmap_union(FunctionContext* ctx, const StringVal& src, StringVal* dst);
-    static void bitmap_intersect_init(FunctionContext* ctx, StringVal* dst);
+    // this is init function for bitmap_intersect
+    static void bitmap_intersect_init_real(FunctionContext* ctx, StringVal* dst);
     static void bitmap_intersect(FunctionContext* ctx, const StringVal& src, StringVal* dst);
     static BigIntVal bitmap_count(FunctionContext* ctx, const StringVal& src);
 
@@ -72,7 +73,8 @@ public:
 
     // intersect count
     template<typename T, typename ValType>
-    static void intersect_count_init(FunctionContext* ctx, StringVal* dst);
+    // this is init function for intersect_count not for bitmap_intersect
+    static void bitmap_intersect_init(FunctionContext* ctx, StringVal* dst);
     template<typename T, typename ValType>
     static void bitmap_intersect_update(FunctionContext* ctx, const StringVal& src, const ValType& key,
                                         int num_key, const ValType* keys, const StringVal* dst);

--- a/be/src/exprs/bitmap_function.h
+++ b/be/src/exprs/bitmap_function.h
@@ -51,6 +51,8 @@ public:
     static BigIntVal bitmap_get_value(FunctionContext* ctx, const StringVal& src);
 
     static void bitmap_union(FunctionContext* ctx, const StringVal& src, StringVal* dst);
+    static void bitmap_intersect_init(FunctionContext* ctx, StringVal* dst);
+    static void bitmap_intersect(FunctionContext* ctx, const StringVal& src, StringVal* dst);
     static BigIntVal bitmap_count(FunctionContext* ctx, const StringVal& src);
 
     static StringVal bitmap_serialize(FunctionContext* ctx, const StringVal& src);
@@ -68,9 +70,9 @@ public:
     static BooleanVal bitmap_contains(FunctionContext* ctx, const StringVal& src, const BigIntVal& input);
     static BooleanVal bitmap_has_any(FunctionContext* ctx, const StringVal& lhs, const StringVal& rhs);
 
-    // bitmap_intersect
+    // intersect count
     template<typename T, typename ValType>
-    static void bitmap_intersect_init(FunctionContext* ctx, StringVal* dst);
+    static void intersect_count_init(FunctionContext* ctx, StringVal* dst);
     template<typename T, typename ValType>
     static void bitmap_intersect_update(FunctionContext* ctx, const StringVal& src, const ValType& key,
                                         int num_key, const ValType* keys, const StringVal* dst);

--- a/be/src/exprs/bitmap_function.h
+++ b/be/src/exprs/bitmap_function.h
@@ -51,8 +51,8 @@ public:
     static BigIntVal bitmap_get_value(FunctionContext* ctx, const StringVal& src);
 
     static void bitmap_union(FunctionContext* ctx, const StringVal& src, StringVal* dst);
-    // this is init function for bitmap_intersect
-    static void bitmap_intersect_init_real(FunctionContext* ctx, StringVal* dst);
+    // the dst value could be null
+    static void nullable_bitmap_init(FunctionContext* ctx, StringVal* dst);
     static void bitmap_intersect(FunctionContext* ctx, const StringVal& src, StringVal* dst);
     static BigIntVal bitmap_count(FunctionContext* ctx, const StringVal& src);
 

--- a/be/src/util/bitmap_value.h
+++ b/be/src/util/bitmap_value.h
@@ -1235,7 +1235,7 @@ private:
     enum BitmapDataType {
         EMPTY = 0,
         SINGLE = 1, // single element
-        BITMAP = 2// more than one elements
+        BITMAP = 2 // more than one elements
     };
     uint64_t _sv = 0; // store the single value when _type == SINGLE
     detail::Roaring64Map _bitmap; // used when _type == BITMAP

--- a/be/src/util/bitmap_value.h
+++ b/be/src/util/bitmap_value.h
@@ -1235,7 +1235,7 @@ private:
     enum BitmapDataType {
         EMPTY = 0,
         SINGLE = 1, // single element
-        BITMAP = 2 // more than one elements
+        BITMAP = 2// more than one elements
     };
     uint64_t _sv = 0; // store the single value when _type == SINGLE
     detail::Roaring64Map _bitmap; // used when _type == BITMAP

--- a/be/test/exprs/bitmap_function_test.cpp
+++ b/be/test/exprs/bitmap_function_test.cpp
@@ -172,6 +172,37 @@ TEST_F(BitmapFunctionsTest, bitmap_union) {
     ASSERT_EQ(expected, result);
 }
 
+TEST_F(BitmapFunctionsTest, bitmap_intersect) {
+    StringVal dst;
+    BitmapFunctions::bitmap_intersect_init(ctx, &dst);
+
+    BitmapValue bitmap1(1);
+    bitmap1.add(2);
+    bitmap1.add(3);
+    StringVal src1 = convert_bitmap_to_string(ctx, bitmap1);
+    BitmapFunctions::bitmap_intersect(ctx, src1, &dst);
+
+    BitmapValue bitmap2(1);
+    bitmap2.add(2);
+    StringVal src2 = convert_bitmap_to_string(ctx, bitmap2);
+    BitmapFunctions::bitmap_intersect(ctx, src2, &dst);
+
+    StringVal serialized = BitmapFunctions::bitmap_serialize(ctx, dst);
+    BigIntVal result = BitmapFunctions::bitmap_count(ctx, serialized);
+    BigIntVal expected(2);
+    ASSERT_EQ(expected, result);    
+}
+
+TEST_F(BitmapFunctionsTest, bitmap_intersect_empty) {
+    StringVal dst;
+    BitmapFunctions::bitmap_intersect_init(ctx, &dst);
+
+    StringVal serialized = BitmapFunctions::bitmap_serialize(ctx, dst);
+    BigIntVal result = BitmapFunctions::bitmap_count(ctx, serialized);
+    BigIntVal expected(0);
+    ASSERT_EQ(expected, result);    
+}
+
 TEST_F(BitmapFunctionsTest, bitmap_count) {
     BitmapValue bitmap(1024);
     bitmap.add(1);
@@ -198,7 +229,7 @@ void test_bitmap_intersect(FunctionContext* ctx, ValType key1, ValType key2) {
     ctx->impl()->set_constant_args(const_vals);
 
     StringVal dst;
-    BitmapFunctions::bitmap_intersect_init<ValueType, ValType>(ctx, &dst);
+    BitmapFunctions::intersect_count_init<ValueType, ValType>(ctx, &dst);
 
     BitmapValue bitmap1({1024, 1025, 1026});
     StringVal src1 = convert_bitmap_to_string(ctx, bitmap1);
@@ -226,7 +257,7 @@ void test_bitmap_intersect(FunctionContext* ctx, ValType key1, ValType key2) {
     ASSERT_EQ(1, intersect2_serde.intersect_count());
 
     StringVal dst2;
-    BitmapFunctions::bitmap_intersect_init<ValueType, ValType>(ctx, &dst2);
+    BitmapFunctions::intersect_count_init<ValueType, ValType>(ctx, &dst2);
     BitmapFunctions::bitmap_intersect_merge<ValueType>(ctx, intersect1, &dst2);
     BigIntVal result = BitmapFunctions::bitmap_intersect_finalize<ValueType>(ctx, dst2);
     BigIntVal expected_count(1);

--- a/be/test/exprs/bitmap_function_test.cpp
+++ b/be/test/exprs/bitmap_function_test.cpp
@@ -172,9 +172,10 @@ TEST_F(BitmapFunctionsTest, bitmap_union) {
     ASSERT_EQ(expected, result);
 }
 
+// test bitmap_intersect
 TEST_F(BitmapFunctionsTest, bitmap_intersect) {
     StringVal dst;
-    BitmapFunctions::bitmap_intersect_init(ctx, &dst);
+    BitmapFunctions::bitmap_intersect_init_real(ctx, &dst);
 
     BitmapValue bitmap1(1);
     bitmap1.add(2);
@@ -193,9 +194,10 @@ TEST_F(BitmapFunctionsTest, bitmap_intersect) {
     ASSERT_EQ(expected, result);    
 }
 
+// test bitmap_intersect with null dst
 TEST_F(BitmapFunctionsTest, bitmap_intersect_empty) {
     StringVal dst;
-    BitmapFunctions::bitmap_intersect_init(ctx, &dst);
+    BitmapFunctions::bitmap_intersect_init_real(ctx, &dst);
 
     StringVal serialized = BitmapFunctions::bitmap_serialize(ctx, dst);
     BigIntVal result = BitmapFunctions::bitmap_count(ctx, serialized);
@@ -217,6 +219,7 @@ TEST_F(BitmapFunctionsTest, bitmap_count) {
     ASSERT_EQ(BigIntVal(0), null_bitmap);
 }
 
+// test intersect_count
 template<typename ValType, typename ValueType>
 void test_bitmap_intersect(FunctionContext* ctx, ValType key1, ValType key2) {
     StringVal bitmap_column("placeholder");
@@ -229,7 +232,7 @@ void test_bitmap_intersect(FunctionContext* ctx, ValType key1, ValType key2) {
     ctx->impl()->set_constant_args(const_vals);
 
     StringVal dst;
-    BitmapFunctions::intersect_count_init<ValueType, ValType>(ctx, &dst);
+    BitmapFunctions::bitmap_intersect_init<ValueType, ValType>(ctx, &dst);
 
     BitmapValue bitmap1({1024, 1025, 1026});
     StringVal src1 = convert_bitmap_to_string(ctx, bitmap1);
@@ -257,7 +260,7 @@ void test_bitmap_intersect(FunctionContext* ctx, ValType key1, ValType key2) {
     ASSERT_EQ(1, intersect2_serde.intersect_count());
 
     StringVal dst2;
-    BitmapFunctions::intersect_count_init<ValueType, ValType>(ctx, &dst2);
+    BitmapFunctions::bitmap_intersect_init<ValueType, ValType>(ctx, &dst2);
     BitmapFunctions::bitmap_intersect_merge<ValueType>(ctx, intersect1, &dst2);
     BigIntVal result = BitmapFunctions::bitmap_intersect_finalize<ValueType>(ctx, dst2);
     BigIntVal expected_count(1);

--- a/docs/.vuepress/sidebar/en.js
+++ b/docs/.vuepress/sidebar/en.js
@@ -257,6 +257,8 @@ module.exports = [
               "bitmap_or",
               "bitmap_to_string",
               "to_bitmap",
+              "bitmap_intersect",
+              "bitmap_union",
             ],
           },
           {

--- a/docs/.vuepress/sidebar/zh-CN.js
+++ b/docs/.vuepress/sidebar/zh-CN.js
@@ -269,6 +269,8 @@ module.exports = [
               "bitmap_or",
               "bitmap_to_string",
               "to_bitmap",
+              "bitmap_intersect",
+              "bitmap_union",
             ],
           },
           {

--- a/docs/en/sql-reference/sql-functions/bitmap-functions/bitmap_intersect.md
+++ b/docs/en/sql-reference/sql-functions/bitmap-functions/bitmap_intersect.md
@@ -1,0 +1,54 @@
+---
+{
+    "title": "bitmap_intersect",
+    "language": "en"
+}
+---
+
+<!-- 
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# bitmap_intersect
+## description
+
+Aggregation function, used to calculate the bitmap intersection after grouping. Common usage scenarios such as: calculating user retention rate.
+
+### Syntax
+
+`BITMAP BITMAP_INTERSECT(BITMAP value)`
+
+Enter a set of bitmap values, find the intersection of the set of bitmap values, and return.
+
+## example
+
+```
+Find the intersection of users for each tag
+mysql> select tag, bitmap_intersect(user_id) from table group by tag;
+```
+
+Used in combination with the bitmap_to_string function to obtain the specific data of the intersection
+
+```
+Who are the intersection users of each tag
+mysql> select tag, bitmap_to_string(bitmap_intersect(user_id)) from table group by tag;
+```
+
+## keyword
+
+    BITMAP_INTERSECT, BITMAP

--- a/docs/en/sql-reference/sql-functions/bitmap-functions/bitmap_intersect.md
+++ b/docs/en/sql-reference/sql-functions/bitmap-functions/bitmap_intersect.md
@@ -37,16 +37,23 @@ Enter a set of bitmap values, find the intersection of the set of bitmap values,
 
 ## example
 
+Table schema
+
 ```
-Find the intersection of users for each tag
-mysql> select tag, bitmap_intersect(user_id) from table group by tag;
+KeysType: AGG_KEY
+Columns: tag varchar, date datetime, user_id bitmap bitmap_union
+```
+
+```
+Find the retention of users between 2020-05-18 and 2020-05-19 under different tags.
+mysql> select tag, bitmap_intersect(user_id) from (select tag, date, bitmap_union(user_id) user_id from table where date in ('2020-05-18', '2020-05-19') group by tag, date) a group by tag;
 ```
 
 Used in combination with the bitmap_to_string function to obtain the specific data of the intersection
 
 ```
-Who are the intersection users of each tag
-mysql> select tag, bitmap_to_string(bitmap_intersect(user_id)) from table group by tag;
+Who are the users retained under different tags between 2020-05-18 and 2020-05-19?
+mysql> select tag, bitmap_to_string(bitmap_intersect(user_id)) from (select tag, date, bitmap_union(user_id) user_id from table where date in ('2020-05-18', '2020-05-19') group by tag, date) a group by tag;
 ```
 
 ## keyword

--- a/docs/en/sql-reference/sql-functions/bitmap-functions/bitmap_union.md
+++ b/docs/en/sql-reference/sql-functions/bitmap-functions/bitmap_union.md
@@ -1,0 +1,58 @@
+---
+{
+    "title": "bitmap_union",
+    "language": "en"
+}
+---
+
+<!-- 
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# bitmap_union
+## description
+
+Aggregate function, used to calculate the grouped bitmap union. Common usage scenarios such as: calculating PV, UV.
+
+### Syntax
+
+`BITMAP BITMAP_UNION(BITMAP value)`
+
+Enter a set of bitmap values, find the union of this set of bitmap values, and return.
+
+## example
+
+```
+mysql> select page_id, bitmap_union(user_id) from table group by page_id;
+```
+
+Combined with the bitmap_count function, the PV data of the web page can be obtained
+
+```
+mysql> select page_id, bitmap_count(bitmap_union(user_id)) from table group by page_id;
+```
+
+When the user_id field is int, the above query semantics is equivalent to
+
+```
+mysql> select page_id, count(distinct user_id) from table group by page_id;
+```
+
+## keyword
+
+    BITMAP_UNION, BITMAP

--- a/docs/zh-CN/sql-reference/sql-functions/bitmap-functions/bitmap_intersect.md
+++ b/docs/zh-CN/sql-reference/sql-functions/bitmap-functions/bitmap_intersect.md
@@ -1,0 +1,54 @@
+---
+{
+    "title": "bitmap_intersect",
+    "language": "zh-CN"
+}
+---
+
+<!-- 
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# bitmap_intersect
+## description
+
+聚合函数，用于计算分组后的 bitmap 交集。常见使用场景如：计算用户留存率。
+
+### Syntax
+
+`BITMAP BITMAP_INTERSECT(BITMAP value)`
+
+输入一组 bitmap 值，求这一组 bitmap 值的交集，并返回。
+
+## example
+
+```
+求每个 tag 的 用户交集
+mysql> select tag, bitmap_intersect(user_id) from table group by tag;
+```
+
+和 bitmap_to_string 函数组合使用可以获取交集的具体数据
+
+```
+求每个 tag 的 交集用户是哪些
+mysql> select tag, bitmap_to_string(bitmap_intersect(user_id)) from table group by tag;
+```
+
+## keyword
+
+    BITMAP_INTERSECT, BITMAP

--- a/docs/zh-CN/sql-reference/sql-functions/bitmap-functions/bitmap_intersect.md
+++ b/docs/zh-CN/sql-reference/sql-functions/bitmap-functions/bitmap_intersect.md
@@ -37,16 +37,24 @@ under the License.
 
 ## example
 
+表结构
+
 ```
-求每个 tag 的 用户交集
-mysql> select tag, bitmap_intersect(user_id) from table group by tag;
+KeysType: AGG_KEY
+Columns: tag varchar, date datetime, user_id bitmap bitmap_union
+
+```
+
+```
+求今天和昨天不同 tag 下的用户留存
+mysql> select tag, bitmap_intersect(user_id) from (select tag, date, bitmap_union(user_id) user_id from table where date in ('2020-05-18', '2020-05-19') group by tag, date) a group by tag;
 ```
 
 和 bitmap_to_string 函数组合使用可以获取交集的具体数据
 
 ```
-求每个 tag 的 交集用户是哪些
-mysql> select tag, bitmap_to_string(bitmap_intersect(user_id)) from table group by tag;
+求今天和昨天不同 tag 下留存的用户都是哪些
+mysql> select tag, bitmap_to_string(bitmap_intersect(user_id)) from (select tag, date, bitmap_union(user_id) user_id from table where date in ('2020-05-18', '2020-05-19') group by tag, date) a group by tag;
 ```
 
 ## keyword

--- a/docs/zh-CN/sql-reference/sql-functions/bitmap-functions/bitmap_union.md
+++ b/docs/zh-CN/sql-reference/sql-functions/bitmap-functions/bitmap_union.md
@@ -1,0 +1,58 @@
+---
+{
+    "title": "bitmap_union",
+    "language": "zh-CN"
+}
+---
+
+<!-- 
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# bitmap_union
+## description
+
+聚合函数，用于计算分组后的 bitmap 并集。常见使用场景如：计算PV，UV。
+
+### Syntax
+
+`BITMAP BITMAP_UNION(BITMAP value)`
+
+输入一组 bitmap 值，求这一组 bitmap 值的并集，并返回。
+
+## example
+
+```
+mysql> select page_id, bitmap_union(user_id) from table group by page_id;
+```
+
+和 bitmap_count 函数组合使用可以求得网页的 PV 数据
+
+```
+mysql> select page_id, bitmap_count(bitmap_union(user_id)) from table group by page_id;
+```
+
+当 user_id 字段为 int 时，上面查询语义等同于
+
+```
+mysql> select page_id, count(distinct user_id) from table group by page_id;
+```
+
+## keyword
+
+    BITMAP_UNION, BITMAP

--- a/fe/src/main/java/org/apache/doris/analysis/FunctionCallExpr.java
+++ b/fe/src/main/java/org/apache/doris/analysis/FunctionCallExpr.java
@@ -407,7 +407,8 @@ public class FunctionCallExpr extends Expr {
 
         if (fnName.getFunction().equalsIgnoreCase(FunctionSet.BITMAP_COUNT)
                 || fnName.getFunction().equalsIgnoreCase(FunctionSet.BITMAP_UNION)
-                || fnName.getFunction().equalsIgnoreCase(FunctionSet.BITMAP_UNION_COUNT)) {
+                || fnName.getFunction().equalsIgnoreCase(FunctionSet.BITMAP_UNION_COUNT)
+                || fnName.getFunction().equalsIgnoreCase(FunctionSet.BITMAP_INTERSECT)) {
             if (children.size() != 1) {
                 throw new AnalysisException(fnName + " function could only have one child");
             }

--- a/fe/src/main/java/org/apache/doris/catalog/FunctionSet.java
+++ b/fe/src/main/java/org/apache/doris/catalog/FunctionSet.java
@@ -1170,7 +1170,7 @@ public class FunctionSet {
         // TODO(ml): supply function symbol
         addBuiltin(AggregateFunction.createBuiltin(BITMAP_INTERSECT, Lists.newArrayList(Type.BITMAP),
                 Type.BITMAP, Type.VARCHAR,
-                "_ZN5doris15BitmapFunctions26bitmap_intersect_init_realEPN9doris_udf15FunctionContextEPNS1_9StringValE",
+                "_ZN5doris15BitmapFunctions20nullable_bitmap_initEPN9doris_udf15FunctionContextEPNS1_9StringValE",
                 "_ZN5doris15BitmapFunctions16bitmap_intersectEPN9doris_udf15FunctionContextERKNS1_9StringValEPS4_",
                 "_ZN5doris15BitmapFunctions16bitmap_intersectEPN9doris_udf15FunctionContextERKNS1_9StringValEPS4_",
                 "_ZN5doris15BitmapFunctions16bitmap_serializeEPN9doris_udf15FunctionContextERKNS1_9StringValE",

--- a/fe/src/main/java/org/apache/doris/catalog/FunctionSet.java
+++ b/fe/src/main/java/org/apache/doris/catalog/FunctionSet.java
@@ -540,6 +540,7 @@ public class FunctionSet {
     public static final String BITMAP_UNION_INT = "bitmap_union_int";
     public static final String BITMAP_COUNT = "bitmap_count";
     public static final String INTERSECT_COUNT = "intersect_count";
+    public static final String BITMAP_INTERSECT = "bitmap_intersect";
 
     private static final Map<Type, String> BITMAP_UNION_INT_SYMBOL =
             ImmutableMap.<Type, String>builder()
@@ -554,29 +555,29 @@ public class FunctionSet {
     private static final Map<Type, String> BITMAP_INTERSECT_INIT_SYMBOL =
             ImmutableMap.<Type, String>builder()
                     .put(Type.TINYINT,
-                            "_ZN5doris15BitmapFunctions21bitmap_intersect_initIaN9doris_udf10TinyIntValEEEvPNS2_15FunctionContextEPNS2_9StringValE")
+                            "_ZN5doris15BitmapFunctions20intersect_count_initIaN9doris_udf10TinyIntValEEEvPNS2_15FunctionContextEPNS2_9StringValE")
                     .put(Type.SMALLINT,
-                            "_ZN5doris15BitmapFunctions21bitmap_intersect_initIsN9doris_udf11SmallIntValEEEvPNS2_15FunctionContextEPNS2_9StringValE")
+                            "_ZN5doris15BitmapFunctions20intersect_count_initIsN9doris_udf11SmallIntValEEEvPNS2_15FunctionContextEPNS2_9StringValE")
                     .put(Type.INT,
-                            "_ZN5doris15BitmapFunctions21bitmap_intersect_initIiN9doris_udf6IntValEEEvPNS2_15FunctionContextEPNS2_9StringValE")
+                            "_ZN5doris15BitmapFunctions20intersect_count_initIiN9doris_udf6IntValEEEvPNS2_15FunctionContextEPNS2_9StringValE")
                     .put(Type.BIGINT,
-                            "_ZN5doris15BitmapFunctions21bitmap_intersect_initIlN9doris_udf9BigIntValEEEvPNS2_15FunctionContextEPNS2_9StringValE")
+                            "_ZN5doris15BitmapFunctions20intersect_count_initIlN9doris_udf9BigIntValEEEvPNS2_15FunctionContextEPNS2_9StringValE")
                     .put(Type.LARGEINT,
-                            "_ZN5doris15BitmapFunctions21bitmap_intersect_initInN9doris_udf11LargeIntValEEEvPNS2_15FunctionContextEPNS2_9StringValE")
+                            "_ZN5doris15BitmapFunctions20intersect_count_initInN9doris_udf11LargeIntValEEEvPNS2_15FunctionContextEPNS2_9StringValE")
                     .put(Type.FLOAT,
-                            "_ZN5doris15BitmapFunctions21bitmap_intersect_initIfN9doris_udf8FloatValEEEvPNS2_15FunctionContextEPNS2_9StringValE")
+                            "_ZN5doris15BitmapFunctions20intersect_count_initIfN9doris_udf8FloatValEEEvPNS2_15FunctionContextEPNS2_9StringValE")
                     .put(Type.DOUBLE,
-                            "_ZN5doris15BitmapFunctions21bitmap_intersect_initIdN9doris_udf9DoubleValEEEvPNS2_15FunctionContextEPNS2_9StringValE")
+                            "_ZN5doris15BitmapFunctions20intersect_count_initIdN9doris_udf9DoubleValEEEvPNS2_15FunctionContextEPNS2_9StringValE")
                     .put(Type.DATE,
-                            "_ZN5doris15BitmapFunctions21bitmap_intersect_initINS_13DateTimeValueEN9doris_udf11DateTimeValEEEvPNS3_15FunctionContextEPNS3_9StringValE")
+                            "_ZN5doris15BitmapFunctions20intersect_count_initINS_13DateTimeValueEN9doris_udf11DateTimeValEEEvPNS3_15FunctionContextEPNS3_9StringValE")
                     .put(Type.DATETIME,
-                            "_ZN5doris15BitmapFunctions21bitmap_intersect_initINS_13DateTimeValueEN9doris_udf11DateTimeValEEEvPNS3_15FunctionContextEPNS3_9StringValE")
+                            "_ZN5doris15BitmapFunctions20intersect_count_initINS_13DateTimeValueEN9doris_udf11DateTimeValEEEvPNS3_15FunctionContextEPNS3_9StringValE")
                     .put(Type.DECIMALV2,
-                            "_ZN5doris15BitmapFunctions21bitmap_intersect_initINS_14DecimalV2ValueEN9doris_udf12DecimalV2ValEEEvPNS3_15FunctionContextEPNS3_9StringValE")
+                            "_ZN5doris15BitmapFunctions20intersect_count_initINS_14DecimalV2ValueEN9doris_udf12DecimalV2ValEEEvPNS3_15FunctionContextEPNS3_9StringValE")
                     .put(Type.CHAR,
-                            "_ZN5doris15BitmapFunctions21bitmap_intersect_initINS_11StringValueEN9doris_udf9StringValEEEvPNS3_15FunctionContextEPS4_")
+                            "_ZN5doris15BitmapFunctions20intersect_count_initINS_11StringValueEN9doris_udf9StringValEEEvPNS3_15FunctionContextEPS4_")
                     .put(Type.VARCHAR,
-                            "_ZN5doris15BitmapFunctions21bitmap_intersect_initINS_11StringValueEN9doris_udf9StringValEEEvPNS3_15FunctionContextEPS4_")
+                            "_ZN5doris15BitmapFunctions20intersect_count_initINS_11StringValueEN9doris_udf9StringValEEEvPNS3_15FunctionContextEPS4_")
                     .build();
 
     private static final Map<Type, String> BITMAP_INTERSECT_UPDATE_SYMBOL =
@@ -1144,6 +1145,7 @@ public class FunctionSet {
                     null, false, true, false));
         }
 
+        // bitmap
         addBuiltin(AggregateFunction.createBuiltin(BITMAP_UNION, Lists.newArrayList(Type.BITMAP),
                 Type.BITMAP,
                 Type.VARCHAR,
@@ -1165,6 +1167,15 @@ public class FunctionSet {
                 null,
                 "_ZN5doris15BitmapFunctions15bitmap_finalizeEPN9doris_udf15FunctionContextERKNS1_9StringValE",
                 true, true, true));
+        // TODO(ml): supply function symbol
+        addBuiltin(AggregateFunction.createBuiltin(BITMAP_INTERSECT, Lists.newArrayList(Type.BITMAP),
+                Type.BITMAP, Type.VARCHAR,
+                "_ZN5doris15BitmapFunctions21bitmap_intersect_initEPN9doris_udf15FunctionContextEPNS1_9StringValE",
+                "_ZN5doris15BitmapFunctions16bitmap_intersectEPN9doris_udf15FunctionContextERKNS1_9StringValEPS4_",
+                "_ZN5doris15BitmapFunctions16bitmap_intersectEPN9doris_udf15FunctionContextERKNS1_9StringValEPS4_",
+                "_ZN5doris15BitmapFunctions16bitmap_serializeEPN9doris_udf15FunctionContextERKNS1_9StringValE",
+                "_ZN5doris15BitmapFunctions16bitmap_serializeEPN9doris_udf15FunctionContextERKNS1_9StringValE",
+                true, false, true));
 
         //PercentileApprox
         addBuiltin(AggregateFunction.createBuiltin("percentile_approx",

--- a/fe/src/main/java/org/apache/doris/catalog/FunctionSet.java
+++ b/fe/src/main/java/org/apache/doris/catalog/FunctionSet.java
@@ -555,29 +555,29 @@ public class FunctionSet {
     private static final Map<Type, String> BITMAP_INTERSECT_INIT_SYMBOL =
             ImmutableMap.<Type, String>builder()
                     .put(Type.TINYINT,
-                            "_ZN5doris15BitmapFunctions20intersect_count_initIaN9doris_udf10TinyIntValEEEvPNS2_15FunctionContextEPNS2_9StringValE")
+                            "_ZN5doris15BitmapFunctions21bitmap_intersect_initIaN9doris_udf10TinyIntValEEEvPNS2_15FunctionContextEPNS2_9StringValE")
                     .put(Type.SMALLINT,
-                            "_ZN5doris15BitmapFunctions20intersect_count_initIsN9doris_udf11SmallIntValEEEvPNS2_15FunctionContextEPNS2_9StringValE")
+                            "_ZN5doris15BitmapFunctions21bitmap_intersect_initIsN9doris_udf11SmallIntValEEEvPNS2_15FunctionContextEPNS2_9StringValE")
                     .put(Type.INT,
-                            "_ZN5doris15BitmapFunctions20intersect_count_initIiN9doris_udf6IntValEEEvPNS2_15FunctionContextEPNS2_9StringValE")
+                            "_ZN5doris15BitmapFunctions21bitmap_intersect_initIiN9doris_udf6IntValEEEvPNS2_15FunctionContextEPNS2_9StringValE")
                     .put(Type.BIGINT,
-                            "_ZN5doris15BitmapFunctions20intersect_count_initIlN9doris_udf9BigIntValEEEvPNS2_15FunctionContextEPNS2_9StringValE")
+                            "_ZN5doris15BitmapFunctions21bitmap_intersect_initIlN9doris_udf9BigIntValEEEvPNS2_15FunctionContextEPNS2_9StringValE")
                     .put(Type.LARGEINT,
-                            "_ZN5doris15BitmapFunctions20intersect_count_initInN9doris_udf11LargeIntValEEEvPNS2_15FunctionContextEPNS2_9StringValE")
+                            "_ZN5doris15BitmapFunctions21bitmap_intersect_initInN9doris_udf11LargeIntValEEEvPNS2_15FunctionContextEPNS2_9StringValE")
                     .put(Type.FLOAT,
-                            "_ZN5doris15BitmapFunctions20intersect_count_initIfN9doris_udf8FloatValEEEvPNS2_15FunctionContextEPNS2_9StringValE")
+                            "_ZN5doris15BitmapFunctions21bitmap_intersect_initIfN9doris_udf8FloatValEEEvPNS2_15FunctionContextEPNS2_9StringValE")
                     .put(Type.DOUBLE,
-                            "_ZN5doris15BitmapFunctions20intersect_count_initIdN9doris_udf9DoubleValEEEvPNS2_15FunctionContextEPNS2_9StringValE")
+                            "_ZN5doris15BitmapFunctions21bitmap_intersect_initIdN9doris_udf9DoubleValEEEvPNS2_15FunctionContextEPNS2_9StringValE")
                     .put(Type.DATE,
-                            "_ZN5doris15BitmapFunctions20intersect_count_initINS_13DateTimeValueEN9doris_udf11DateTimeValEEEvPNS3_15FunctionContextEPNS3_9StringValE")
+                            "_ZN5doris15BitmapFunctions21bitmap_intersect_initINS_13DateTimeValueEN9doris_udf11DateTimeValEEEvPNS3_15FunctionContextEPNS3_9StringValE")
                     .put(Type.DATETIME,
-                            "_ZN5doris15BitmapFunctions20intersect_count_initINS_13DateTimeValueEN9doris_udf11DateTimeValEEEvPNS3_15FunctionContextEPNS3_9StringValE")
+                            "_ZN5doris15BitmapFunctions21bitmap_intersect_initINS_13DateTimeValueEN9doris_udf11DateTimeValEEEvPNS3_15FunctionContextEPNS3_9StringValE")
                     .put(Type.DECIMALV2,
-                            "_ZN5doris15BitmapFunctions20intersect_count_initINS_14DecimalV2ValueEN9doris_udf12DecimalV2ValEEEvPNS3_15FunctionContextEPNS3_9StringValE")
+                            "_ZN5doris15BitmapFunctions21bitmap_intersect_initINS_14DecimalV2ValueEN9doris_udf12DecimalV2ValEEEvPNS3_15FunctionContextEPNS3_9StringValE")
                     .put(Type.CHAR,
-                            "_ZN5doris15BitmapFunctions20intersect_count_initINS_11StringValueEN9doris_udf9StringValEEEvPNS3_15FunctionContextEPS4_")
+                            "_ZN5doris15BitmapFunctions21bitmap_intersect_initINS_11StringValueEN9doris_udf9StringValEEEvPNS3_15FunctionContextEPS4_")
                     .put(Type.VARCHAR,
-                            "_ZN5doris15BitmapFunctions20intersect_count_initINS_11StringValueEN9doris_udf9StringValEEEvPNS3_15FunctionContextEPS4_")
+                            "_ZN5doris15BitmapFunctions21bitmap_intersect_initINS_11StringValueEN9doris_udf9StringValEEEvPNS3_15FunctionContextEPS4_")
                     .build();
 
     private static final Map<Type, String> BITMAP_INTERSECT_UPDATE_SYMBOL =
@@ -1170,7 +1170,7 @@ public class FunctionSet {
         // TODO(ml): supply function symbol
         addBuiltin(AggregateFunction.createBuiltin(BITMAP_INTERSECT, Lists.newArrayList(Type.BITMAP),
                 Type.BITMAP, Type.VARCHAR,
-                "_ZN5doris15BitmapFunctions21bitmap_intersect_initEPN9doris_udf15FunctionContextEPNS1_9StringValE",
+                "_ZN5doris15BitmapFunctions26bitmap_intersect_init_realEPN9doris_udf15FunctionContextEPNS1_9StringValE",
                 "_ZN5doris15BitmapFunctions16bitmap_intersectEPN9doris_udf15FunctionContextERKNS1_9StringValEPS4_",
                 "_ZN5doris15BitmapFunctions16bitmap_intersectEPN9doris_udf15FunctionContextERKNS1_9StringValEPS4_",
                 "_ZN5doris15BitmapFunctions16bitmap_serializeEPN9doris_udf15FunctionContextERKNS1_9StringValE",


### PR DESCRIPTION
Support aggregate function Bitmap Intersect, it is mainly used to take intersection of grouped data.
The function 'bitmap_intersect(expr)' calculates the intersection of bitmap columns and returns a bitmap object.
The defination is following:
FunctionName: bitmap_intersect,
InputType: bitmap,
OutputType: bitmap

The scenario is as follows:
Query which users satisfy the three tags a, b, and c at the same time.

```
select bitmap_to_string(bitmap_intersect(user_id)) from
(
    select bitmap_union(user_id) user_id from bitmap_intersect_test
    where tag in ('a', 'b', 'c')
    group by tag
) a
```
Closed #3552.

Change-Id: I0d50c9bb6827f7319c4d854f621412343a3ece24