### PR TITLE
[Fix]SlotRef.tosql() is the same as the SQL returned by different sql

### DIFF
--- a/fe/src/main/java/org/apache/doris/analysis/SlotRef.java
+++ b/fe/src/main/java/org/apache/doris/analysis/SlotRef.java
@@ -163,9 +163,12 @@ public class SlotRef extends Expr {
         } else if (label != null) {
             return label + sb.toString();
         } else if (desc.getSourceExprs() != null) {
+            if (desc.getId().asInt() != 1) {
+                sb.append("<slot " + Integer.toString(desc.getId().asInt()) + ">");
+            }
             for (Expr expr : desc.getSourceExprs()) {
-                sb.append(expr.toSql());
                 sb.append(" ");
+                sb.append(expr.toSql());
             }
             return sb.toString();
         } else {

--- a/fe/src/main/java/org/apache/doris/analysis/SlotRef.java
+++ b/fe/src/main/java/org/apache/doris/analysis/SlotRef.java
@@ -162,6 +162,12 @@ public class SlotRef extends Expr {
             return tblName.toSql() + "." + label + sb.toString();
         } else if (label != null) {
             return label + sb.toString();
+        } else if (desc.getSourceExprs() != null) {
+            for (Expr expr : desc.getSourceExprs()) {
+                sb.append(expr.toSql());
+                sb.append(" ");
+            }
+            return sb.toString();
         } else {
             return "<slot " + Integer.toString(desc.getId().asInt()) + ">" + sb.toString();
         }


### PR DESCRIPTION
- Describe the bug

select distinct ss_sold_date_sk as sk from store_sales order by sk limit 100;
select distinct ss_item_sk as sk from store_sales order by sk limit 100;
Invoke FE SelectStmt.toSql()，return the same result：
SELECT DISTINCT <slot 2> AS `sk` FROM `default_cluster:tpcds`.`store_sales` ORDER BY `sk` ASC LIMIT 100

Because label in SlotRef corresponding to distinct function is null, SQL is output in the form of slot + number. When label is null, desc.getsourceexprs() is obtained to get the column name

- Modified effect

SQL1：SELECT DISTINCT <slot 2>  `ss_sold_date_sk` AS `sk` FROM `default_cluster:tpcds`.`store_sales` ORDER BY `sk` ASC LIMIT 100

SQL2：SELECT DISTINCT <slot 2>  `ss_item_sk` AS `sk` FROM `default_cluster:tpcds`.`store_sales` ORDER BY `sk` ASC LIMIT 100

#3555 