### PR TITLE
[Bug] Fix bug that DbTxnMgr does not create for db in CatalogRecycleBin

### DIFF
--- a/fe/src/main/java/org/apache/doris/catalog/Catalog.java
+++ b/fe/src/main/java/org/apache/doris/catalog/Catalog.java
@@ -1803,10 +1803,15 @@ public class Catalog {
 
     public long loadRecycleBin(DataInputStream dis, long checksum) throws IOException {
         if (Catalog.getCurrentCatalogJournalVersion() >= FeMetaVersion.VERSION_10) {
-            Catalog.getCurrentRecycleBin().readFields(dis);
+            recycleBin.readFields(dis);
             if (!isCheckpointThread()) {
                 // add tablet in Recycle bin to TabletInvertedIndex
-                Catalog.getCurrentRecycleBin().addTabletToInvertedIndex();
+                recycleBin.addTabletToInvertedIndex();
+            }
+            // create DatabaseTransactionMgr for db in recycle bin.
+            // these dbs do not exist in `idToDb` of the catalog.
+            for (Long dbId : recycleBin.getAllDbIds()) {
+                globalTransactionMgr.addDatabaseTransactionMgr(dbId);
             }
         }
         return checksum;

--- a/fe/src/main/java/org/apache/doris/catalog/CatalogRecycleBin.java
+++ b/fe/src/main/java/org/apache/doris/catalog/CatalogRecycleBin.java
@@ -174,7 +174,7 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
                 idToRecycleTime.remove(entry.getKey());
 
                 // remove database transaction manager
-                Catalog.getInstance().getGlobalTransactionMgr().removeDatabaseTransactionMgr(db.getId());
+                Catalog.getCurrentCatalog().getGlobalTransactionMgr().removeDatabaseTransactionMgr(db.getId());
 
                 LOG.info("erase database[{}] name: {}", db.getId(), dbName);
             }

--- a/fe/src/main/java/org/apache/doris/catalog/CatalogRecycleBin.java
+++ b/fe/src/main/java/org/apache/doris/catalog/CatalogRecycleBin.java
@@ -173,6 +173,9 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
                 iterator.remove();
                 idToRecycleTime.remove(entry.getKey());
 
+                // remove database transaction manager
+                Catalog.getInstance().getGlobalTransactionMgr().removeDatabaseTransactionMgr(db.getId());
+
                 LOG.info("erase database[{}] name: {}", db.getId(), dbName);
             }
         }

--- a/fe/src/main/java/org/apache/doris/catalog/CatalogRecycleBin.java
+++ b/fe/src/main/java/org/apache/doris/catalog/CatalogRecycleBin.java
@@ -36,6 +36,7 @@ import org.apache.doris.task.DropReplicaTask;
 import org.apache.doris.thrift.TStorageMedium;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Range;
 import com.google.common.collect.Sets;
@@ -886,5 +887,10 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
                 isInMemory = in.readBoolean();
             }
         }
+    }
+    
+    // currently only used when loading image. So no synchronized protected.
+    public List<Long> getAllDbIds() {
+        return Lists.newArrayList(idToDatabase.keySet());
     }
 }

--- a/fe/src/main/java/org/apache/doris/qe/AuditEventProcessor.java
+++ b/fe/src/main/java/org/apache/doris/qe/AuditEventProcessor.java
@@ -56,6 +56,7 @@ public class AuditEventProcessor {
 
     public void start() {
         workerThread = new Thread(new Worker(), "AuditEventProcessor");
+        workerThread.setDaemon(true);
         workerThread.start();
     }
 


### PR DESCRIPTION
Fix #3589
The reason is that:
When load meta from image, we will create `DatabaseTransactionMgr` for each database
loaded from `loadDb()` method. But we forget to create `DatabaseTransactionMgr` for 
database in the catalog recycle bin.