### PR TITLE
[Doris On ES]fix bug of like not translate correcttly

### DIFF
--- a/be/src/exec/es/es_query_builder.cpp
+++ b/be/src/exec/es/es_query_builder.cpp
@@ -113,12 +113,17 @@ WildCardQueryBuilder::WildCardQueryBuilder(const ExtLikePredicate& like_predicat
     // example of translation :
     //      abc_123  ===> abc?123
     //      abc%ykz  ===> abc*123
+    //      %abc123  ===> *abc123
+    //      _abc123  ===> ?abc123
+    //      \\_abc1  ===> \\_abc1
     //      abc\\_123 ===> abc\\_123
     //      abc\\%123 ===> abc\\%123
     // NOTE. user must input sql like 'abc\\_123' or 'abc\\%ykz'
     for (int i = 0; i< _like_value.size(); i++) {
-        if ((_like_value[i] == '_' || _like_value[i]== '%') && i > 0) {
-                if (_like_value[i-1] != '\\' ) {
+        if (_like_value[i] == '_' || _like_value[i] == '%') {
+                if (i == 0) {
+                    _like_value[i] = (_like_value[i] == '_') ? '?' : '*';
+                } else if (_like_value[i - 1] != '\\' ) {
                     _like_value[i] = (_like_value[i] == '_') ? '?' : '*';
                 }
         }


### PR DESCRIPTION
case is desc in #3576

Why this case happened
In current implement, translation into dsl only if it is not the first charactor.
Thus, when sql is write like '%abc', translation would not run.

How fixed

Now, translation will trigger with charactor '?' or '*'
if it is the first charactor, translate directly
else, check the preceding char is escaped or not to determin translation or not