### PR TITLE
(#3464) fix Query failed when fact table has no data in join case

### DIFF
--- a/fe/src/main/java/org/apache/doris/planner/DistributedPlanner.java
+++ b/fe/src/main/java/org/apache/doris/planner/DistributedPlanner.java
@@ -335,14 +335,13 @@ public class DistributedPlanner {
         // - and we're not doing a full or right outer join (those require the left-hand
         //   side to be partitioned for correctness)
         // - and the expected size of the hash tbl doesn't exceed perNodeMemLimit
-        // we do a "<=" comparison of the costs so that we default to broadcast joins if
-        // we're unable to estimate the cost
+        // we set partition join as default when broadcast join cost equals partition join cost
         if (node.getJoinOp() != JoinOperator.RIGHT_OUTER_JOIN
                 && node.getJoinOp() != JoinOperator.FULL_OUTER_JOIN
                 && (perNodeMemLimit == 0 || Math.round(
                 (double) rhsDataSize * PlannerContext.HASH_TBL_SPACE_OVERHEAD) <= perNodeMemLimit)
                 && (node.getInnerRef().isBroadcastJoin() || (!node.getInnerRef().isPartitionJoin()
-                && broadcastCost <= partitionCost))) {
+                && broadcastCost < partitionCost))) {
             doBroadcast = true;
         } else {
             doBroadcast = false;

--- a/fe/src/main/java/org/apache/doris/planner/OlapScanNode.java
+++ b/fe/src/main/java/org/apache/doris/planner/OlapScanNode.java
@@ -271,6 +271,10 @@ public class OlapScanNode extends ScanNode {
             }
             numNodes = scanBackendIds.size();
         }
+        // even current node scan has no data,at least on backend will be assigned when the fragment actually execute
+        numNodes = numNodes <= 0 ? 1 : numNodes;
+        // when node scan has no data, cardinality should be 0 instead of a invalid value after computeStats()
+        cardinality = cardinality == -1 ? 0 : cardinality;
     }
 
     private Collection<Long> partitionPrune(RangePartitionInfo partitionInfo, PartitionNames partitionNames) throws AnalysisException {

--- a/fe/src/main/java/org/apache/doris/qe/Coordinator.java
+++ b/fe/src/main/java/org/apache/doris/qe/Coordinator.java
@@ -912,10 +912,8 @@ public class Coordinator {
             if (!(leftMostNode instanceof ScanNode)) {
                 // (Case B)
                 // there is no leftmost scan; we assign the same hosts as those of our
-                // leftmost input fragment (so that a partitioned aggregation
-                // fragment runs on the hosts that provide the input data)
+                //  input fragment which has a higher instance_number
 
-                // find a input fragment which has a higher parallelism
                 int inputFragmentIndex = 0;
                 int maxParallelism = 0;
                 for (int j = 0; j < fragment.getChildren().size(); j++) {


### PR DESCRIPTION
#3464

major work
1.  Correct the value of ```numNodes``` and ```cardinality``` when ```OlapTableScan``` computeStats so that the ``` broadcast cost``` and ```paritition join cost ``` can be calculated correctly.
2. Find a input fragment with higher parallelism for shuffle fragment to assign backend