### PR TITLE
[Bug] Fix bug that descriptor table is not reset before planning next routine load task

### DIFF
--- a/fe/src/main/java/org/apache/doris/analysis/DescriptorTable.java
+++ b/fe/src/main/java/org/apache/doris/analysis/DescriptorTable.java
@@ -41,17 +41,15 @@ import java.util.List;
 public class DescriptorTable {
     private final static Logger LOG = LogManager.getLogger(DescriptorTable.class);
 
-    private final HashMap<TupleId, TupleDescriptor> tupleDescs;
+    private final HashMap<TupleId, TupleDescriptor> tupleDescs = new HashMap<TupleId, TupleDescriptor>();
     // List of referenced tables with no associated TupleDescriptor to ship to the BE.
     // For example, the output table of an insert query.
-    private final List<Table>                       referencedTables;
+    private final List<Table> referencedTables = new ArrayList<Table>();;
     private final IdGenerator<TupleId> tupleIdGenerator_ = TupleId.createGenerator();
     private final IdGenerator<SlotId> slotIdGenerator_ = SlotId.createGenerator();
     private final HashMap<SlotId, SlotDescriptor> slotDescs = Maps.newHashMap();
 
     public DescriptorTable() {
-        tupleDescs = new HashMap<TupleId, TupleDescriptor>();
-        referencedTables = new ArrayList<Table>();
     }
 
     public TupleDescriptor createTupleDescriptor() {

--- a/fe/src/main/java/org/apache/doris/planner/StreamLoadPlanner.java
+++ b/fe/src/main/java/org/apache/doris/planner/StreamLoadPlanner.java
@@ -77,19 +77,24 @@ public class StreamLoadPlanner {
         this.db = db;
         this.destTable = destTable;
         this.streamLoadTask = streamLoadTask;
-        analyzer = new Analyzer(Catalog.getInstance(), null);
+    }
+
+    private void resetAnalyzer() {
+        analyzer = new Analyzer(Catalog.getCurrentCatalog(), null);
         // TODO(cmy): currently we do not support UDF in stream load command.
         // Because there is no way to check the privilege of accessing UDF..
         analyzer.setUDFAllowed(false);
         descTable = analyzer.getDescTbl();
     }
 
+    // can only be called after "plan()", or it will return null
     public OlapTable getDestTable() {
         return destTable;
     }
 
     // create the plan. the plan's query id and load id are same, using the parameter 'loadId'
     public TExecPlanFragmentParams plan(TUniqueId loadId) throws UserException {
+        resetAnalyzer();
         // construct tuple descriptor, used for scanNode and dataSink
         TupleDescriptor tupleDesc = descTable.createTupleDescriptor("DstTableTuple");
         boolean negative = streamLoadTask.getNegative();


### PR DESCRIPTION
Before planning for next routine load task, the analyzer and descriptor table
in it should be reset. Otherwise, a lot of historical objects will
accumulate inside, causing memory leaks.
Fix: #3603

NOTICE(#3622):
This is a "revert of revert pull request".
This pr is mainly used to synthesize the PRs whose commits were
scattered and submitted due to the wrong merge method into a complete single commit.