### PR TITLE
[Bug] Fix bug that ConcurrentModificationException thrown

### DIFF
--- a/fe/src/main/java/org/apache/doris/catalog/Catalog.java
+++ b/fe/src/main/java/org/apache/doris/catalog/Catalog.java
@@ -4516,7 +4516,7 @@ public class Catalog {
                     for (Partition partition : olapTable.getAllPartitions()) {
                         long partitionId = partition.getId();
                         DataProperty dataProperty = partitionInfo.getDataProperty(partition.getId());
-                        Preconditions.checkNotNull(dataProperty);
+                        Preconditions.checkNotNull(dataProperty, partition.getName() + ", pId:" + partitionId + ", db: " + dbId + ", tbl: " + tableId);
                         if (dataProperty.getStorageMedium() == TStorageMedium.SSD
                                 && dataProperty.getCooldownTimeMs() < currentTimeMs) {
                             // expire. change to HDD.

--- a/fe/src/main/java/org/apache/doris/catalog/PartitionInfo.java
+++ b/fe/src/main/java/org/apache/doris/catalog/PartitionInfo.java
@@ -76,6 +76,9 @@ public class PartitionInfo implements Writable {
     }
 
     public short getReplicationNum(long partitionId) {
+        if (!idToReplicationNum.containsKey(partitionId)) {
+            LOG.debug("failed to get replica num for partition: {}", partitionId);
+        }
         return idToReplicationNum.get(partitionId);
     }
 

--- a/fe/src/main/java/org/apache/doris/catalog/TempPartitions.java
+++ b/fe/src/main/java/org/apache/doris/catalog/TempPartitions.java
@@ -26,6 +26,7 @@ import org.apache.doris.persist.gson.GsonUtils;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
 import com.google.gson.annotations.SerializedName;
 
 import java.io.DataInput;
@@ -33,6 +34,7 @@ import java.io.DataOutput;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 // This class saved all temp partitions of a table.
 // temp partition is used to implement the overwrite load.
@@ -108,7 +110,8 @@ public class TempPartitions implements Writable, GsonPostProcessable {
 
     // drop all temp partitions
     public void dropAll() {
-        for (String partName : nameToPartition.keySet()) {
+        Set<String> partNames = Sets.newHashSet(nameToPartition.keySet());
+        for (String partName : partNames) {
             dropPartition(partName, true);
         }
     }

--- a/fe/src/main/java/org/apache/doris/cluster/Cluster.java
+++ b/fe/src/main/java/org/apache/doris/cluster/Cluster.java
@@ -17,12 +17,12 @@
 
 package org.apache.doris.cluster;
 
-import com.google.common.base.Preconditions;
 import org.apache.doris.catalog.InfoSchemaDb;
 import org.apache.doris.common.io.Text;
 import org.apache.doris.common.io.Writable;
 import org.apache.doris.persist.LinkDbInfo;
 
+import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 


### PR DESCRIPTION
Fix: #3588
When truncate the table, a ConcurrentModificationException may thrown when there
are temp partitions in this table.

NOTICE(#3622 ):
This is a "revert of revert pull request".
This pr is mainly used to synthesize the PRs whose commits were
scattered and submitted due to the wrong merge method into a complete single commit.