### PR TITLE
[bug] init be log file length when restart be

### DIFF
--- a/thirdparty/patches/glog-0.3.3-for-palo2.patch
+++ b/thirdparty/patches/glog-0.3.3-for-palo2.patch
@@ -298,7 +298,7 @@
 +      // Mark the file close-on-exec. We don't really care if this fails
 +      fcntl(fd, F_SETFD, FD_CLOEXEC);
 +#endif
-+      file_ = fdopen(fd, "ra"); // Read and append a FILE*.
++      file_ = fopen(filename, "a+"); // Read and append a FILE*.
 +      if (file_ == NULL) {      // Man, we're screwed!, try to create new log file
 +        close(fd);
 +      }


### PR DESCRIPTION
## issue
```
int fd = open(filename, O_WRONLY | O_CREAT /* | O_EXCL */ | O_APPEND, 0664); 
fdopen(fd, "ra") 
```
## view
```
*** Aborted at 1590044592 (unix time) try "date -d @1590044592" if you are using GNU date ***
PC: @     0x7f0fa14679ec __GI_fseek
*** SIGSEGV (@0x0) received by PID 79596 (TID 0x7f0fa22ed580) from PID 0; stack trace: ***
    @     0x7f0fa1429670 (unknown)
    @     0x7f0fa14679ec __GI_fseek
    @          0x23775e1 google::(anonymous namespace)::LogFileObject::Write()
    @          0x23730a4 google::LogMessage::SendToLog()
    @          0x23706d4 google::LogMessage::Flush()
    @          0x2370931 google::LogMessage::~LogMessage()
    @           0xdc3eb4 doris::init_daemon()
    @           0xc4eec7 main
    @     0x7f0fa1415b15 __libc_start_main
    @           0xda72d3 (unknown)
```

## fix 
use fopen