### PR TITLE
[BugFix] fix travis build timeout (branch-0.12)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@
 language: node_js
 # nodejs版本
 node_js: 
-    - '8'
+    - '14'
 
 # Travis-CI Caching
 cache:


### PR DESCRIPTION
Upgrade node version to 14 to speed up the Vuepress building process.(#3650)