### PR TITLE
Del some useless code and impove the performance of sort

### DIFF
--- a/be/src/exec/CMakeLists.txt
+++ b/be/src/exec/CMakeLists.txt
@@ -49,7 +49,6 @@ set(EXEC_FILES
     text_converter.cpp
     topn_node.cpp
     sort_exec_exprs.cpp
-    sort_node.cpp
     olap_rewrite_node.cpp
     olap_scan_node.cpp
     olap_scanner.cpp

--- a/be/src/exec/exec_node.cpp
+++ b/be/src/exec/exec_node.cpp
@@ -45,7 +45,6 @@
 #include "exec/repeat_node.h"
 #include "exec/schema_scan_node.h"
 #include "exec/select_node.h"
-#include "exec/sort_node.h"
 #include "exec/spill_sort_node.h"
 #include "exec/topn_node.h"
 #include "exec/union_node.h"


### PR DESCRIPTION
1. Delete the code of Sort Node we do not use now.
2. Optimize the quick sort by find_the_median and try to reduce recursion level of quick sort.

I have tested 50 million pieces of data sort.   ordered, disordered and reversed order 
there is improved by about 10%