### PR TITLE
[Memory Engine] Add TabletType to PartitionInfo and TabletMeta

### DIFF
--- a/be/src/olap/base_tablet.h
+++ b/be/src/olap/base_tablet.h
@@ -43,6 +43,7 @@ public:
     // Property encapsulated in TabletMeta
     inline const TabletMetaSharedPtr tablet_meta();
 
+    inline bool is_memory() const;
     inline TabletUid tablet_uid() const;
     inline int64_t table_id() const;
     // Returns a string can be used to uniquely identify a tablet.
@@ -82,6 +83,10 @@ inline string BaseTablet::tablet_path() const {
 
 inline const TabletMetaSharedPtr BaseTablet::tablet_meta() {
     return _tablet_meta;
+}
+
+inline bool BaseTablet::is_memory() const {
+    return _tablet_meta->tablet_type() == TabletTypePB::TABLET_TYPE_MEMORY;
 }
 
 inline TabletUid BaseTablet::tablet_uid() const {

--- a/be/src/olap/tablet_meta.cpp
+++ b/be/src/olap/tablet_meta.cpp
@@ -58,19 +58,6 @@ OLAPStatus AlterTabletTask::set_alter_state(AlterTabletState alter_state) {
     return OLAP_SUCCESS;
 }
 
-OLAPStatus TabletMeta::create(int64_t table_id, int64_t partition_id,
-                              int64_t tablet_id, int32_t schema_hash,
-                              uint64_t shard_id, const TTabletSchema& tablet_schema,
-                              uint32_t next_unique_id,
-                              const unordered_map<uint32_t, uint32_t>& col_ordinal_to_unique_id,
-                              TabletMetaSharedPtr* tablet_meta, TabletUid& tablet_uid) {
-    tablet_meta->reset(new TabletMeta(table_id, partition_id,
-                                      tablet_id, schema_hash,
-                                      shard_id, tablet_schema,
-                                      next_unique_id, col_ordinal_to_unique_id, tablet_uid));
-    return OLAP_SUCCESS;
-}
-
 OLAPStatus TabletMeta::create(const TCreateTabletReq& request, const TabletUid& tablet_uid,
                               uint64_t shard_id, uint32_t next_unique_id,
                               const unordered_map<uint32_t, uint32_t>& col_ordinal_to_unique_id,
@@ -78,7 +65,8 @@ OLAPStatus TabletMeta::create(const TCreateTabletReq& request, const TabletUid& 
     tablet_meta->reset(new TabletMeta(request.table_id, request.partition_id,
                                       request.tablet_id, request.tablet_schema.schema_hash,
                                       shard_id, request.tablet_schema,
-                                      next_unique_id, col_ordinal_to_unique_id, tablet_uid));
+                                      next_unique_id, col_ordinal_to_unique_id, tablet_uid,
+                                      request.tablet_type));
     return OLAP_SUCCESS;
 }
 
@@ -89,7 +77,7 @@ TabletMeta::TabletMeta(int64_t table_id, int64_t partition_id,
                        uint64_t shard_id, const TTabletSchema& tablet_schema,
                        uint32_t next_unique_id,
                        const std::unordered_map<uint32_t, uint32_t>& col_ordinal_to_unique_id,
-                       TabletUid tablet_uid) : _tablet_uid(0, 0),
+                       TabletUid tablet_uid, TTabletType::type tabletType) : _tablet_uid(0, 0),
                        _preferred_rowset_type(ALPHA_ROWSET) {
     TabletMetaPB tablet_meta_pb;
     tablet_meta_pb.set_table_id(table_id);
@@ -101,6 +89,8 @@ TabletMeta::TabletMeta(int64_t table_id, int64_t partition_id,
     tablet_meta_pb.set_cumulative_layer_point(-1);
     tablet_meta_pb.set_tablet_state(PB_RUNNING);
     *(tablet_meta_pb.mutable_tablet_uid()) = tablet_uid.to_proto();
+    tablet_meta_pb.set_tablet_type(tabletType == TTabletType::TABLET_TYPE_MEMORY ?
+            TabletTypePB::TABLET_TYPE_DISK : TabletTypePB::TABLET_TYPE_MEMORY);
     TabletSchemaPB* schema = tablet_meta_pb.mutable_schema();
     schema->set_num_short_key_columns(tablet_schema.short_key_column_count);
     schema->set_num_rows_per_row_block(config::default_num_rows_per_column_file_block);
@@ -317,7 +307,7 @@ OLAPStatus TabletMeta::serialize(string* meta_binary) {
         LOG(FATAL) << "deserialize from previous serialize result failed " << full_name();
     }
     return OLAP_SUCCESS;
-};
+}
 
 OLAPStatus TabletMeta::deserialize(const string& meta_binary) {
     TabletMetaPB tablet_meta_pb;
@@ -339,6 +329,7 @@ void TabletMeta::init_from_pb(const TabletMetaPB& tablet_meta_pb) {
     _creation_time = tablet_meta_pb.creation_time();
     _cumulative_layer_point = tablet_meta_pb.cumulative_layer_point();
     _tablet_uid = TabletUid(tablet_meta_pb.tablet_uid());
+    _tablet_type = tablet_meta_pb.tablet_type();
 
     // init _tablet_state
     switch (tablet_meta_pb.tablet_state()) {
@@ -405,6 +396,7 @@ void TabletMeta::to_meta_pb(TabletMetaPB* tablet_meta_pb) {
     tablet_meta_pb->set_creation_time(creation_time());
     tablet_meta_pb->set_cumulative_layer_point(cumulative_layer_point());
     *(tablet_meta_pb->mutable_tablet_uid()) = tablet_uid().to_proto();
+    tablet_meta_pb->set_tablet_type(_tablet_type);
     switch (tablet_state()) {
         case TABLET_NOTREADY:
             tablet_meta_pb->set_tablet_state(PB_NOTREADY);

--- a/be/src/olap/tablet_meta.cpp
+++ b/be/src/olap/tablet_meta.cpp
@@ -66,7 +66,8 @@ OLAPStatus TabletMeta::create(const TCreateTabletReq& request, const TabletUid& 
                                       request.tablet_id, request.tablet_schema.schema_hash,
                                       shard_id, request.tablet_schema,
                                       next_unique_id, col_ordinal_to_unique_id, tablet_uid,
-                                      request.tablet_type));
+                                      request.__isset.tablet_type ?
+                                              request.tablet_type : TTabletType::TABLET_TYPE_DISK));
     return OLAP_SUCCESS;
 }
 
@@ -329,7 +330,11 @@ void TabletMeta::init_from_pb(const TabletMetaPB& tablet_meta_pb) {
     _creation_time = tablet_meta_pb.creation_time();
     _cumulative_layer_point = tablet_meta_pb.cumulative_layer_point();
     _tablet_uid = TabletUid(tablet_meta_pb.tablet_uid());
-    _tablet_type = tablet_meta_pb.tablet_type();
+    if (tablet_meta_pb.has_tablet_type()) {
+        _tablet_type = tablet_meta_pb.tablet_type();
+    } else {
+        _tablet_type = TabletTypePB::TABLET_TYPE_DISK;
+    }
 
     // init _tablet_state
     switch (tablet_meta_pb.tablet_state()) {

--- a/be/src/olap/tablet_meta.h
+++ b/be/src/olap/tablet_meta.h
@@ -98,13 +98,6 @@ typedef std::shared_ptr<AlterTabletTask> AlterTabletTaskSharedPtr;
 // The concurrency control is handled in Tablet Class, not in this class.
 class TabletMeta {
 public:
-    static OLAPStatus create(int64_t table_id, int64_t partition_id,
-                             int64_t tablet_id, int32_t schema_hash,
-                             uint64_t shard_id, const TTabletSchema& tablet_schema,
-                             uint32_t next_unique_id,
-                             const std::unordered_map<uint32_t, uint32_t>& col_ordinal_to_unique_id,
-                             TabletMetaSharedPtr* tablet_meta, TabletUid& tablet_uid);
-
     static OLAPStatus create(const TCreateTabletReq& request, const TabletUid& tablet_uid,
                              uint64_t shard_id, uint32_t next_unique_id,
                              const std::unordered_map<uint32_t, uint32_t>& col_ordinal_to_unique_id,
@@ -116,7 +109,7 @@ public:
                uint64_t shard_id, const TTabletSchema& tablet_schema,
                uint32_t next_unique_id,
                const std::unordered_map<uint32_t, uint32_t>& col_ordinal_to_unique_id,
-               TabletUid tablet_uid);
+               TabletUid tablet_uid, TTabletType::type tabletType);
 
     // Function create_from_file is used to be compatible with previous tablet_meta.
     // Previous tablet_meta is a physical file in tablet dir, which is not stored in rocksdb.
@@ -135,6 +128,7 @@ public:
     void to_meta_pb(TabletMetaPB* tablet_meta_pb);
     void to_json(std::string* json_string, json2pb::Pb2JsonOptions& options);
 
+    inline TabletTypePB tablet_type() const { return _tablet_type; }
     inline TabletUid tablet_uid() const;
     inline int64_t table_id() const;
     inline int64_t partition_id() const;
@@ -211,6 +205,7 @@ private:
     int64_t _creation_time = 0;
     int64_t _cumulative_layer_point = 0;
     TabletUid _tablet_uid;
+    TabletTypePB _tablet_type = TabletTypePB::TABLET_TYPE_DISK;
 
     TabletState _tablet_state = TABLET_NOTREADY;
     TabletSchema _schema;

--- a/be/test/olap/test_data/header.txt
+++ b/be/test/olap/test_data/header.txt
@@ -187,5 +187,6 @@
     "tablet_uid": {
         "hi": 10,
         "lo": 10
-    }
+    },
+    "tablet_type": "TABLET_TYPE_DISK"
 }

--- a/fe/src/main/java/org/apache/doris/alter/RollupJobV2.java
+++ b/fe/src/main/java/org/apache/doris/alter/RollupJobV2.java
@@ -47,6 +47,7 @@ import org.apache.doris.thrift.TStorageFormat;
 import org.apache.doris.thrift.TStorageMedium;
 import org.apache.doris.thrift.TStorageType;
 import org.apache.doris.thrift.TTaskType;
+import org.apache.doris.thrift.TTabletType;
 
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
@@ -179,6 +180,7 @@ public class RollupJobV2 extends AlterJobV2 {
                     continue;
                 }
                 TStorageMedium storageMedium = tbl.getPartitionInfo().getDataProperty(partitionId).getStorageMedium();
+                TTabletType tabletType = tbl.getPartitionInfo().getTabletType(partitionId);
                 MaterializedIndex rollupIndex = entry.getValue();
 
                 Map<Long, Long> tabletIdMap = this.partitionIdToBaseRollupTabletIdMap.get(partitionId);
@@ -198,7 +200,8 @@ public class RollupJobV2 extends AlterJobV2 {
                                 rollupKeysType, TStorageType.COLUMN, storageMedium,
                                 rollupSchema, tbl.getCopiedBfColumns(), tbl.getBfFpp(), countDownLatch,
                                 tbl.getCopiedIndexes(),
-                                tbl.isInMemory());
+                                tbl.isInMemory(),
+                                tabletType);
                         createReplicaTask.setBaseTablet(tabletIdMap.get(rollupTabletId), baseSchemaHash);
                         if (this.storageFormat != null) {
                             createReplicaTask.setStorageFormat(this.storageFormat);

--- a/fe/src/main/java/org/apache/doris/alter/SchemaChangeJobV2.java
+++ b/fe/src/main/java/org/apache/doris/alter/SchemaChangeJobV2.java
@@ -240,7 +240,8 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
                                     Partition.PARTITION_INIT_VERSION, Partition.PARTITION_INIT_VERSION_HASH,
                                     tbl.getKeysType(), TStorageType.COLUMN, storageMedium,
                                     shadowSchema, bfColumns, bfFpp, countDownLatch, indexes,
-                                    tbl.isInMemory());
+                                    tbl.isInMemory(),
+                                    tbl.getPartitionInfo().getTabletType(partitionId));
                             createReplicaTask.setBaseTablet(partitionIndexTabletMap.get(partitionId, shadowIdxId).get(shadowTabletId), originSchemaHash);
                             if (this.storageFormat != null) {
                                 createReplicaTask.setStorageFormat(this.storageFormat);

--- a/fe/src/main/java/org/apache/doris/analysis/ModifyTablePropertiesClause.java
+++ b/fe/src/main/java/org/apache/doris/analysis/ModifyTablePropertiesClause.java
@@ -86,6 +86,8 @@ public class ModifyTablePropertiesClause extends AlterTableClause {
         } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_INMEMORY)) {
             this.needTableStable = false;
             this.opType = AlterOpType.MODIFY_TABLE_PROPERTY_SYNC;
+        } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_TABLET_TYPE)) {
+            throw new AnalysisException("Alter tablet type not supported");
         } else {
             throw new AnalysisException("Unknown table property: " + properties.keySet());
         }

--- a/fe/src/main/java/org/apache/doris/analysis/SingleRangePartitionDesc.java
+++ b/fe/src/main/java/org/apache/doris/analysis/SingleRangePartitionDesc.java
@@ -29,6 +29,7 @@ import org.apache.doris.common.util.PropertyAnalyzer;
 import com.google.common.base.Joiner;
 import com.google.common.base.Joiner.MapJoiner;
 import com.google.common.base.Preconditions;
+import org.apache.doris.thrift.TTabletType;
 
 import java.util.Map;
 
@@ -44,6 +45,7 @@ public class SingleRangePartitionDesc {
     private DataProperty partitionDataProperty;
     private Short replicationNum;
     private boolean isInMemory = false;
+    private TTabletType tabletType = TTabletType.TABLET_TYPE_DISK;
     private Pair<Long, Long> versionInfo;
 
     public SingleRangePartitionDesc(boolean ifNotExists, String partName, PartitionKeyDesc partitionKeyDesc,
@@ -84,6 +86,8 @@ public class SingleRangePartitionDesc {
         return isInMemory;
     }
 
+    public TTabletType getTabletType() { return tabletType; }
+
     public Pair<Long, Long> getVersionInfo() {
         return versionInfo;
     }
@@ -121,6 +125,8 @@ public class SingleRangePartitionDesc {
 
         // analyze in memory
         isInMemory = PropertyAnalyzer.analyzeBooleanProp(properties, PropertyAnalyzer.PROPERTIES_INMEMORY, false);
+
+        tabletType = PropertyAnalyzer.analyzeTabletType(properties);
 
         if (otherProperties == null) {
             // check unknown properties

--- a/fe/src/main/java/org/apache/doris/backup/RestoreJob.java
+++ b/fe/src/main/java/org/apache/doris/backup/RestoreJob.java
@@ -781,7 +781,8 @@ public class RestoreJob extends AbstractJob {
                             TStorageMedium.HDD /* all restored replicas will be saved to HDD */,
                             indexMeta.getSchema(), bfColumns, bfFpp, null,
                             localTbl.getCopiedIndexes(),
-                            localTbl.isInMemory());
+                            localTbl.isInMemory(),
+                            localTbl.getPartitionInfo().getTabletType(restorePart.getId()));
                     task.setInRestoreMode(true);
                     batchTask.addTask(task);
                 }

--- a/fe/src/main/java/org/apache/doris/catalog/Catalog.java
+++ b/fe/src/main/java/org/apache/doris/catalog/Catalog.java
@@ -203,6 +203,8 @@ import org.apache.doris.thrift.TStorageFormat;
 import org.apache.doris.thrift.TStorageMedium;
 import org.apache.doris.thrift.TStorageType;
 import org.apache.doris.thrift.TTaskType;
+import org.apache.doris.thrift.TTabletType;
+
 import org.apache.doris.transaction.GlobalTransactionMgr;
 import org.apache.doris.transaction.PublishVersionDaemon;
 
@@ -3105,7 +3107,9 @@ public class Catalog {
                     bfColumns, olapTable.getBfFpp(),
                     tabletIdSet, olapTable.getCopiedIndexes(),
                     singlePartitionDesc.isInMemory(),
-                    olapTable.getStorageFormat());
+                    olapTable.getStorageFormat(),
+                    singlePartitionDesc.getTabletType()
+                    );
 
             // check again
             db.writeLock();
@@ -3352,6 +3356,14 @@ public class Catalog {
         boolean isInMemory = PropertyAnalyzer.analyzeBooleanProp(properties,
                 PropertyAnalyzer.PROPERTIES_INMEMORY, partitionInfo.getIsInMemory(partition.getId()));
 
+        // 4. tablet type
+        TTabletType tabletType = TTabletType.TABLET_TYPE_DISK;
+        try {
+            tabletType = PropertyAnalyzer.analyzeTabletType(properties);
+        } catch (AnalysisException e) {
+            throw new DdlException(e.getMessage());
+        }
+
         // check if has other undefined properties
         if (properties != null && !properties.isEmpty()) {
             MapJoiner mapJoiner = Joiner.on(", ").withKeyValueSeparator(" = ");
@@ -3378,6 +3390,14 @@ public class Catalog {
             partitionInfo.setIsInMemory(partition.getId(), isInMemory);
             LOG.debug("modify partition[{}-{}-{}] in memory to {}", db.getId(), olapTable.getId(), partitionName,
                     isInMemory);
+        }
+
+        // tablet type
+        // TODO: serialize to edit log
+        if (tabletType != partitionInfo.getTabletType(partition.getId())) {
+            partitionInfo.setTabletType(partition.getId(), tabletType);
+            LOG.debug("modify partition[{}-{}-{}] tablet type to {}", db.getId(), olapTable.getId(), partitionName,
+                    tabletType);
         }
 
         // log
@@ -3417,7 +3437,8 @@ public class Catalog {
                                                  Set<Long> tabletIdSet,
                                                  List<Index> indexes,
                                                  boolean isInMemory,
-                                                 TStorageFormat storageFormat) throws DdlException {
+                                                 TStorageFormat storageFormat,
+                                                 TTabletType tabletType) throws DdlException {
         // create base index first.
         Preconditions.checkArgument(baseIndexId != -1);
         MaterializedIndex baseIndex = new MaterializedIndex(baseIndexId, IndexState.NORMAL);
@@ -3481,7 +3502,8 @@ public class Catalog {
                             schema, bfColumns, bfFpp,
                             countDownLatch,
                             indexes,
-                            isInMemory);
+                            isInMemory,
+                            tabletType);
                     task.setStorageFormat(storageFormat);
                     batchTask.addTask(task);
                     // add to AgentTaskQueue for handling finish report.
@@ -3629,6 +3651,13 @@ public class Catalog {
         boolean isInMemory = PropertyAnalyzer.analyzeBooleanProp(properties, PropertyAnalyzer.PROPERTIES_INMEMORY, false);
         olapTable.setIsInMemory(isInMemory);
 
+        TTabletType tabletType = TTabletType.TABLET_TYPE_DISK;
+        try {
+            tabletType = PropertyAnalyzer.analyzeTabletType(properties);
+        } catch (AnalysisException e) {
+            throw new DdlException(e.getMessage());
+        }
+
         if (partitionInfo.getType() == PartitionType.UNPARTITIONED) {
             // if this is an unpartitioned table, we should analyze data property and replication num here.
             // if this is a partitioned table, there properties are already analyzed in RangePartitionDesc analyze phase.
@@ -3646,6 +3675,7 @@ public class Catalog {
             partitionInfo.setDataProperty(partitionId, dataProperty);
             partitionInfo.setReplicationNum(partitionId, replicationNum);
             partitionInfo.setIsInMemory(partitionId, isInMemory);
+            partitionInfo.setTabletType(partitionId, tabletType);
         }
 
         // check colocation properties
@@ -3752,7 +3782,7 @@ public class Catalog {
                         partitionInfo.getReplicationNum(partitionId),
                         versionInfo, bfColumns, bfFpp,
                         tabletIdSet, olapTable.getCopiedIndexes(),
-                        isInMemory, storageFormat);
+                        isInMemory, storageFormat, tabletType);
                 olapTable.addPartition(partition);
             } else if (partitionInfo.getType() == PartitionType.RANGE) {
                 try {
@@ -3781,7 +3811,8 @@ public class Catalog {
                             partitionInfo.getReplicationNum(entry.getValue()),
                             versionInfo, bfColumns, bfFpp,
                             tabletIdSet, olapTable.getCopiedIndexes(),
-                            isInMemory, storageFormat);
+                            isInMemory, storageFormat,
+                            rangePartitionInfo.getTabletType(entry.getValue()));
                     olapTable.addPartition(partition);
                 }
             } else {
@@ -6248,7 +6279,8 @@ public class Catalog {
                         tabletIdSet,
                         copiedTbl.getCopiedIndexes(),
                         copiedTbl.isInMemory(),
-                        copiedTbl.getStorageFormat());
+                        copiedTbl.getStorageFormat(),
+                        copiedTbl.getPartitionInfo().getTabletType(oldPartitionId));
                 newPartitions.add(newPartition);
             }
         } catch (DdlException e) {

--- a/fe/src/main/java/org/apache/doris/catalog/PartitionInfo.java
+++ b/fe/src/main/java/org/apache/doris/catalog/PartitionInfo.java
@@ -24,6 +24,7 @@ import org.apache.doris.common.io.Writable;
 import com.google.common.base.Preconditions;
 
 import org.apache.doris.thrift.TStorageMedium;
+import org.apache.doris.thrift.TTabletType;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -50,10 +51,16 @@ public class PartitionInfo implements Writable {
 
     protected Map<Long, Boolean> idToInMemory;
 
+    // partition id -> tablet type
+    // Note: currently it's only used for testing, it may change/add more meta field later,
+    // so we defer adding meta serialization until memory engine feature is more complete.
+    protected Map<Long, TTabletType> idToTabletType;
+
     public PartitionInfo() {
         this.idToDataProperty = new HashMap<>();
         this.idToReplicationNum = new HashMap<>();
         this.idToInMemory = new HashMap<>();
+        this.idToTabletType = new HashMap<>();
     }
 
     public PartitionInfo(PartitionType type) {
@@ -61,6 +68,7 @@ public class PartitionInfo implements Writable {
         this.idToDataProperty = new HashMap<>();
         this.idToReplicationNum = new HashMap<>();
         this.idToInMemory = new HashMap<>();
+        this.idToTabletType = new HashMap<>();
     }
 
     public PartitionType getType() {
@@ -92,6 +100,17 @@ public class PartitionInfo implements Writable {
 
     public void setIsInMemory(long partitionId, boolean isInMemory) {
         idToInMemory.put(partitionId, isInMemory);
+    }
+
+    public TTabletType getTabletType(long partitionId) {
+        if (!idToTabletType.containsKey(partitionId)) {
+            return TTabletType.TABLET_TYPE_DISK;
+        }
+        return idToTabletType.get(partitionId);
+    }
+
+    public void setTabletType(long partitionId, TTabletType tabletType) {
+        idToTabletType.put(partitionId, tabletType);
     }
 
     public void dropPartition(long partitionId) {

--- a/fe/src/main/java/org/apache/doris/common/util/PropertyAnalyzer.java
+++ b/fe/src/main/java/org/apache/doris/common/util/PropertyAnalyzer.java
@@ -237,7 +237,7 @@ public class PropertyAnalyzer {
     }
 
     public static TTabletType analyzeTabletType(Map<String, String> properties) throws AnalysisException {
-        // default is COLUMN
+        // default is TABLET_TYPE_DISK
         TTabletType tTabletType = TTabletType.TABLET_TYPE_DISK;
         if (properties != null && properties.containsKey(PROPERTIES_TABLET_TYPE)) {
             String tabletType = properties.get(PROPERTIES_TABLET_TYPE);

--- a/fe/src/main/java/org/apache/doris/common/util/PropertyAnalyzer.java
+++ b/fe/src/main/java/org/apache/doris/common/util/PropertyAnalyzer.java
@@ -35,6 +35,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.Sets;
 
+import org.apache.doris.thrift.TTabletType;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -78,6 +79,8 @@ public class PropertyAnalyzer {
     public static final String PROPERTIES_STORAGE_FORMAT = "storage_format";
 
     public static final String PROPERTIES_INMEMORY = "in_memory";
+
+    public static final String PROPERTIES_TABLET_TYPE = "tablet_type";
 
     public static final String PROPERTIES_STRICT_RANGE = "strict_range";
     public static final String PROPERTIES_USE_TEMP_PARTITION_NAME = "use_temp_partition_name";
@@ -231,6 +234,23 @@ public class PropertyAnalyzer {
         }
 
         return tStorageType;
+    }
+
+    public static TTabletType analyzeTabletType(Map<String, String> properties) throws AnalysisException {
+        // default is COLUMN
+        TTabletType tTabletType = TTabletType.TABLET_TYPE_DISK;
+        if (properties != null && properties.containsKey(PROPERTIES_TABLET_TYPE)) {
+            String tabletType = properties.get(PROPERTIES_TABLET_TYPE);
+            if (tabletType.equalsIgnoreCase("memory")) {
+                tTabletType = TTabletType.TABLET_TYPE_MEMORY;
+            } else if (tabletType.equalsIgnoreCase("disk")) {
+                tTabletType = TTabletType.TABLET_TYPE_DISK;
+            } else {
+                throw new AnalysisException(("Invalid tablet type"));
+            }
+            properties.remove(PROPERTIES_TABLET_TYPE);
+        }
+        return tTabletType;
     }
 
     public static Pair<Long, Long> analyzeVersionInfo(Map<String, String> properties) throws AnalysisException {

--- a/fe/src/main/java/org/apache/doris/master/ReportHandler.java
+++ b/fe/src/main/java/org/apache/doris/master/ReportHandler.java
@@ -574,7 +574,8 @@ public class ReportHandler extends Daemon {
                                             TStorageType.COLUMN,
                                             TStorageMedium.HDD, indexMeta.getSchema(), bfColumns, bfFpp, null,
                                             olapTable.getCopiedIndexes(),
-                                            olapTable.isInMemory());
+                                            olapTable.isInMemory(),
+                                            olapTable.getPartitionInfo().getTabletType(partitionId));
                                     createReplicaBatchTask.addTask(createReplicaTask);
                                 } else {
                                     // just set this replica as bad

--- a/fe/src/main/java/org/apache/doris/task/CreateReplicaTask.java
+++ b/fe/src/main/java/org/apache/doris/task/CreateReplicaTask.java
@@ -30,6 +30,7 @@ import org.apache.doris.thrift.TStatusCode;
 import org.apache.doris.thrift.TStorageMedium;
 import org.apache.doris.thrift.TStorageType;
 import org.apache.doris.thrift.TTabletSchema;
+import org.apache.doris.thrift.TTabletType;
 import org.apache.doris.thrift.TTaskType;
 import org.apache.doris.thrift.TStorageFormat;
 
@@ -65,6 +66,8 @@ public class CreateReplicaTask extends AgentTask {
 
     private boolean isInMemory;
 
+    private TTabletType tabletType;
+
     // used for synchronous process
     private MarkedCountDownLatch<Long, Long> latch;
 
@@ -82,7 +85,8 @@ public class CreateReplicaTask extends AgentTask {
                              TStorageMedium storageMedium, List<Column> columns,
                              Set<String> bfColumns, double bfFpp, MarkedCountDownLatch<Long, Long> latch,
                              List<Index> indexes,
-                             boolean isInMemory) {
+                             boolean isInMemory,
+                             TTabletType tabletType) {
         super(null, backendId, TTaskType.CREATE, dbId, tableId, partitionId, indexId, tabletId);
 
         this.shortKeyColumnCount = shortKeyColumnCount;
@@ -104,6 +108,7 @@ public class CreateReplicaTask extends AgentTask {
         this.latch = latch;
 
         this.isInMemory = isInMemory;
+        this.tabletType = tabletType;
     }
     
     public void countDownLatch(long backendId, long tabletId) {
@@ -200,6 +205,7 @@ public class CreateReplicaTask extends AgentTask {
             createTabletReq.setStorage_format(storageFormat);
         }
 
+        createTabletReq.setTablet_type(tabletType);
         return createTabletReq;
     }
 }

--- a/fe/src/test/java/org/apache/doris/common/util/UnitTestUtil.java
+++ b/fe/src/test/java/org/apache/doris/common/util/UnitTestUtil.java
@@ -47,6 +47,7 @@ import org.apache.doris.thrift.TStorageType;
 
 import com.google.common.collect.Maps;
 
+import org.apache.doris.thrift.TTabletType;
 import org.junit.Assert;
 
 import java.lang.reflect.Method;
@@ -111,6 +112,7 @@ public class UnitTestUtil {
         partitionInfo.setDataProperty(partitionId, DataProperty.DEFAULT_DATA_PROPERTY);
         partitionInfo.setReplicationNum(partitionId, (short) 3);
         partitionInfo.setIsInMemory(partitionId, false);
+        partitionInfo.setTabletType(partitionId, TTabletType.TABLET_TYPE_DISK);
         OlapTable table = new OlapTable(tableId, TABLE_NAME, columns,
                                         KeysType.AGG_KEYS, partitionInfo, distributionInfo);
         Deencapsulation.setField(table, "baseIndexId", indexId);

--- a/fe/src/test/java/org/apache/doris/task/AgentTaskTest.java
+++ b/fe/src/test/java/org/apache/doris/task/AgentTaskTest.java
@@ -113,7 +113,7 @@ public class AgentTaskTest {
                                                   version, versionHash, KeysType.AGG_KEYS,
                                                   storageType, TStorageMedium.SSD,
                                                   columns, null, 0, latch, null,
-                                                  false);
+                                                  false, TTabletType.TABLET_TYPE_DISK);
 
         // drop
         dropTask = new DropReplicaTask(backendId1, tabletId1, schemaHash1);

--- a/fe/src/test/java/org/apache/doris/task/AgentTaskTest.java
+++ b/fe/src/test/java/org/apache/doris/task/AgentTaskTest.java
@@ -33,6 +33,7 @@ import org.apache.doris.thrift.TPriority;
 import org.apache.doris.thrift.TPushType;
 import org.apache.doris.thrift.TStorageMedium;
 import org.apache.doris.thrift.TStorageType;
+import org.apache.doris.thrift.TTabletType;
 import org.apache.doris.thrift.TTaskType;
 
 import com.google.common.collect.Range;

--- a/gensrc/proto/olap_file.proto
+++ b/gensrc/proto/olap_file.proto
@@ -271,6 +271,11 @@ enum TabletStatePB {
     PB_SHUTDOWN = 4;
 }
 
+enum TabletTypePB {
+    TABLET_TYPE_DISK = 0;
+    TABLET_TYPE_MEMORY = 1;
+}
+
 message TabletMetaPB {
     optional int64 table_id = 1;    // ?
     optional int64 partition_id = 2;    // ?
@@ -292,6 +297,7 @@ message TabletMetaPB {
     optional PUniqueId tablet_uid = 14;
     optional int64 end_rowset_id = 15;
     optional RowsetTypePB preferred_rowset_type = 16;
+    optional TabletTypePB tablet_type = 17;
 }
 
 message OLAPIndexHeaderMessage {

--- a/gensrc/thrift/AgentService.thrift
+++ b/gensrc/thrift/AgentService.thrift
@@ -55,6 +55,11 @@ enum TStorageFormat {
     V2
 }
 
+enum TTabletType {
+    TABLET_TYPE_DISK = 0,
+    TABLET_TYPE_MEMORY = 1
+}
+
 struct TCreateTabletReq {
     1: required Types.TTabletId tablet_id
     2: required TTabletSchema tablet_schema
@@ -74,6 +79,7 @@ struct TCreateTabletReq {
     // indicate whether this tablet is a compute storage split mode, we call it "eco mode"
     12: optional bool is_eco_mode
     13: optional TStorageFormat storage_format
+    14: optional TTabletType tablet_type
 }
 
 struct TDropTabletReq {


### PR DESCRIPTION
This CL add TabletType to TabletMeta and PartitionInfo, it also adds a create table property "tablet_type" : "disk/memory" for user to specify tablet type. This is a temporary entry point for testing only, it may change in the future, so this field does not persist to FE PartitionInfo(need to upgrade meta version).

Resolves #3442 