### PR TITLE
Allow user to set thrift_client_timeout_ms config for thrift server

### DIFF
--- a/docs/en/administrator-guide/config/fe_config.md
+++ b/docs/en/administrator-guide/config/fe_config.md
@@ -547,6 +547,12 @@ Generally it is not recommended to increase this configuration value. An excessi
 
 ### `thrift_backlog_num`
 
+### `thrift_client_timeout_ms`
+
+The connection timeout and socket timeout config for thrift server.
+   
+The value for thrift_client_timeout_ms is set to be larger than zero to prevent some hang up problems in java.net.SocketInputStream.socketRead0.
+
 ### `thrift_server_max_worker_threads`
 
 ### `time_zone`

--- a/docs/zh-CN/administrator-guide/config/fe_config.md
+++ b/docs/zh-CN/administrator-guide/config/fe_config.md
@@ -547,6 +547,12 @@ current running txns on db xxx is xx, larger than limit xx
 
 ### `thrift_backlog_num`
 
+### `thrift_client_timeout_ms`
+
+这是 thrift 服务端的关于连接超时和socket读取数据超时的配置。
+   
+thrift_client_timeout_ms 的值被设置为大于0来避免线程卡在java.net.SocketInputStream.socketRead0的问题.
+
 ### `thrift_server_max_worker_threads`
 
 ### `time_zone`

--- a/fe/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/src/main/java/org/apache/doris/common/Config.java
@@ -283,7 +283,7 @@ public class Config extends ConfigBase {
     @ConfField public static int http_backlog_num = 1024;
 
     /*
-     * The connection timeout and socket timeout setting for thrift server
+     * The connection timeout and socket timeout config for thrift server
      * The value for thrift_client_timeout_ms is set to be larger than zero to prevent
      * some hang up problems in java.net.SocketInputStream.socketRead0
      */

--- a/fe/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/src/main/java/org/apache/doris/common/Config.java
@@ -283,6 +283,13 @@ public class Config extends ConfigBase {
     @ConfField public static int http_backlog_num = 1024;
 
     /*
+     * The connection timeout and socket timeout setting for thrift server
+     * The value for thrift_client_timeout_ms is set to be larger than zero to prevent
+     * some hang up problems in java.net.SocketInputStream.socketRead0
+     */
+    @ConfField public static int thrift_client_timeout_ms = 30000;
+
+    /*
      * The backlog_num for thrift server
      * When you enlarge this backlog_num, you should ensure it's value larger than
      * the linux /proc/sys/net/core/somaxconn config

--- a/fe/src/main/java/org/apache/doris/common/ThriftServer.java
+++ b/fe/src/main/java/org/apache/doris/common/ThriftServer.java
@@ -75,7 +75,7 @@ public class ThriftServer {
     private void createThreadPoolServer() throws TTransportException {
         TServerSocket.ServerSocketTransportArgs socketTransportArgs = new TServerSocket.ServerSocketTransportArgs()
             .bindAddr(new InetSocketAddress(port))
-            .clientTimeout(0)
+            .clientTimeout(Config.thrift_client_timeout_ms)
             .backlog(Config.thrift_backlog_num);
 
         TThreadPoolServer.Args serverArgs =


### PR DESCRIPTION
 The value for thrift_client_timeout_ms should set to be larger than zero to prevent
 some hang up problems in java.net.SocketInputStream.socketRead0