### PR TITLE
[Bug] Serialize storage format in rollup job

### DIFF
--- a/fe/src/main/java/org/apache/doris/alter/RollupJobV2.java
+++ b/fe/src/main/java/org/apache/doris/alter/RollupJobV2.java
@@ -89,13 +89,14 @@ public class RollupJobV2 extends AlterJobV2 {
     private KeysType rollupKeysType;
     private short rollupShortKeyColumnCount;
 
+    // optional
+    private TStorageFormat storageFormat = TStorageFormat.DEFAULT;
+
     // The rollup job will wait all transactions before this txn id finished, then send the rollup tasks.
     protected long watershedTxnId = -1;
 
     // save all create rollup tasks
     private AgentBatchTask rollupBatchTask = new AgentBatchTask();
-
-    private TStorageFormat storageFormat = TStorageFormat.DEFAULT;
 
     public RollupJobV2(long jobId, long dbId, long tableId, String tableName, long timeoutMs,
             long baseIndexId, long rollupIndexId, String baseIndexName, String rollupIndexName,

--- a/fe/src/main/java/org/apache/doris/common/FeMetaVersion.java
+++ b/fe/src/main/java/org/apache/doris/common/FeMetaVersion.java
@@ -179,6 +179,8 @@ public final class FeMetaVersion {
     public static final int VERSION_83 = 83;
     // add storage format in schema change job
     public static final int VERSION_84 = 84;
+    // add storage format in rollup job
+    public static final int VERSION_85 = 85;
     // note: when increment meta version, should assign the latest version to VERSION_CURRENT
-    public static final int VERSION_CURRENT = VERSION_84;
+    public static final int VERSION_CURRENT = VERSION_85;
 }


### PR DESCRIPTION
The segment v2 rollup job should set the storage format v2 and serialize it.
If it is not serialized, the rollup of segment v2 may use the error format 'segment v1'.

Change-Id: I2cf3fd5fe3dc93a29ebdda46004e6c5e8a16b89f