### PR TITLE
[compaction] Update cumulative point calculate algorithm

### DIFF
--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -68,7 +68,7 @@ Tablet::Tablet(TabletMetaSharedPtr tablet_meta, DataDir* data_dir) :
         _last_base_compaction_failure_millis(0),
         _last_cumu_compaction_success_millis(0),
         _last_base_compaction_success_millis(0),
-        _cumulative_point(tablet_meta->cumulative_layer_point()) {
+        _cumulative_point(kInvalidCumulativePoint) {
     _gen_tablet_path();
     _rs_graph.construct_rowset_graph(_tablet_meta->all_rs_metas());
 }

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -68,7 +68,7 @@ Tablet::Tablet(TabletMetaSharedPtr tablet_meta, DataDir* data_dir) :
         _last_base_compaction_failure_millis(0),
         _last_cumu_compaction_success_millis(0),
         _last_base_compaction_success_millis(0),
-        _cumulative_point(kInvalidCumulativePoint) {
+        _cumulative_point(tablet_meta->cumulative_layer_point()) {
     _gen_tablet_path();
     _rs_graph.construct_rowset_graph(_tablet_meta->all_rs_metas());
 }
@@ -683,16 +683,8 @@ void Tablet::calculate_cumulative_point() {
             // There is a hole, do not continue
             break;
         }
-        // break the loop if segments in this rowset is overlapping, or overlap flag is NOT NONOVERLAPPING
-        // even if is_segments_overlapping() return false, the overlap flag may be OVERLAPPING.
-        // eg: tablet with versions(rowsets):
-        //      [0-1] NONOVERLAPPING
-        //      [2-2] OVERLAPPING
-        // [2-2]'s overlap flag is OVERLAPPING because it is newly written by the delta writer.
-        // but is has only one segment, so is_segments_overlapping() will return false.
-        // but we should not continue increasing the cumulative point, because we need
-        // the compaction process to change the overlap flag from OVERLAPPING to NONOVERLAPPING.
-        if (rs->is_segments_overlapping() || rs->segments_overlap() != NONOVERLAPPING) {
+        // break the loop if segments in this rowset is overlapping, or is a singleton.
+        if (rs->is_segments_overlapping() || rs->is_singleton_delta()) {
             _cumulative_point = rs->version().first;
             break;
         }

--- a/be/src/olap/tablet.h
+++ b/be/src/olap/tablet.h
@@ -309,6 +309,7 @@ inline const int64_t Tablet::cumulative_layer_point() const {
 
 inline void Tablet::set_cumulative_layer_point(int64_t new_point) {
     _cumulative_point = new_point;
+    _tablet_meta->set_cumulative_layer_point(new_point);
 }
 
 

--- a/be/src/olap/tablet.h
+++ b/be/src/olap/tablet.h
@@ -309,7 +309,6 @@ inline const int64_t Tablet::cumulative_layer_point() const {
 
 inline void Tablet::set_cumulative_layer_point(int64_t new_point) {
     _cumulative_point = new_point;
-    _tablet_meta->set_cumulative_layer_point(new_point);
 }
 
 


### PR DESCRIPTION
Ref https://github.com/apache/incubator-doris/issues/3687
Current cumulative point calculate algorithm may skip singleton version
rowset when the rowset has only one segment and with NONOVERLAPPING flag.
When a tablet is new created and cumulate many singleton version rowsets,
cumulative point will be calculated as the max version + 1, and then
cumulative compaction couldn't pick any rowsets and compaction failed, and
will lead the next base compaction on this tablet with all rowsets, which
can also cause memory consume problem, suppose there are thousands of rowsets.

All singleton version rowsets must be newly wrote by delta writer and hasn't
do any compaction, we should place cumulative point before any of these rowsets.