### PR TITLE
[Enhancement] Improve the performance of query with IN predicate 

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -189,6 +189,10 @@ namespace config {
     CONF_mInt32(doris_scanner_row_num, "16384");
     // number of max scan keys
     CONF_mInt32(doris_max_scan_key_num, "1024");
+    // the max number of push down values of In-Predicate.
+    // if the num children of In-Predicate larger than this,
+    // InPredicate will not push down to olap engine.
+    CONF_mInt32(max_pushdown_in_pred_element_num, "1024");
     // return_row / total_row
     CONF_mInt32(doris_max_pushdown_conjuncts_return_rate, "90");
     // (Advanced) Maximum size of per-query receive-side buffer

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -189,10 +189,9 @@ namespace config {
     CONF_mInt32(doris_scanner_row_num, "16384");
     // number of max scan keys
     CONF_mInt32(doris_max_scan_key_num, "1024");
-    // the max number of push down values of In-Predicate.
-    // if the num children of In-Predicate larger than this,
-    // InPredicate will not push down to olap engine.
-    CONF_mInt32(max_pushdown_in_pred_element_num, "1024");
+    // the max number of push down values of a single column.
+    // if exceed, no conditions will be pushed down for that column.
+    CONF_mInt32(max_pushdown_conditions_per_column, "1024");
     // return_row / total_row
     CONF_mInt32(doris_max_pushdown_conjuncts_return_rate, "90");
     // (Advanced) Maximum size of per-query receive-side buffer

--- a/be/src/exec/olap_common.h
+++ b/be/src/exec/olap_common.h
@@ -186,7 +186,7 @@ public:
         _is_convertible(true) {}
 
     template<class T>
-    Status extend_scan_key(ColumnValueRange<T>& range);
+    Status extend_scan_key(ColumnValueRange<T>& range, int32_t max_scan_key_num);
 
     Status get_key_range(std::vector<std::unique_ptr<OlapScanRange>>* key_range);
 
@@ -615,7 +615,7 @@ bool ColumnValueRange<T>::has_intersection(ColumnValueRange<T>& range) {
 }
 
 template<class T>
-Status OlapScanKeys::extend_scan_key(ColumnValueRange<T>& range) {
+Status OlapScanKeys::extend_scan_key(ColumnValueRange<T>& range, int32_t max_scan_key_num) {
     using namespace std;
     typedef typename set<T>::const_iterator const_iterator_type;
 
@@ -636,8 +636,8 @@ Status OlapScanKeys::extend_scan_key(ColumnValueRange<T>& range) {
     bool has_converted = false;
 
     if (range.is_fixed_value_range()) {
-        if ((_begin_scan_keys.empty() && range.get_fixed_value_size() > config::doris_max_scan_key_num)
-                || range.get_fixed_value_size() * _begin_scan_keys.size() > config::doris_max_scan_key_num) {
+        if ((_begin_scan_keys.empty() && range.get_fixed_value_size() > max_scan_key_num)
+                || range.get_fixed_value_size() * _begin_scan_keys.size() > max_scan_key_num) {
             if (range.is_range_value_convertible()) {
                 range.convert_to_range_value();
             } else {
@@ -647,7 +647,7 @@ Status OlapScanKeys::extend_scan_key(ColumnValueRange<T>& range) {
     } else {
         if (range.is_fixed_value_convertible() && _is_convertible) {
             if (_begin_scan_keys.empty()) {
-                if (range.get_convertible_fixed_value_size() < config::doris_max_scan_key_num) {
+                if (range.get_convertible_fixed_value_size() < max_scan_key_num) {
                     if (range.is_low_value_mininum() && range.is_high_value_maximum()) {
                         has_converted = true;
                     }
@@ -656,7 +656,7 @@ Status OlapScanKeys::extend_scan_key(ColumnValueRange<T>& range) {
                 }
             } else {
                 if (range.get_convertible_fixed_value_size() * _begin_scan_keys.size()
-                        < config::doris_max_scan_key_num) {
+                        < max_scan_key_num) {
                     if (range.is_low_value_mininum() && range.is_high_value_maximum()) {
                         has_converted = true;
                     }

--- a/be/src/exec/olap_scan_node.cpp
+++ b/be/src/exec/olap_scan_node.cpp
@@ -885,10 +885,10 @@ Status OlapScanNode::normalize_in_and_eq_predicate(SlotDescriptor* slot, ColumnV
                 // begin to push condition value into ColumnValueRange
                 // clear the ColumnValueRange before adding new fixed values.
                 // because for AND compound predicates, it can overwrite previous conditions
+                range->clear();
                 switch (slot->type().type) {
                     case TYPE_TINYINT: {
                         int32_t v = *reinterpret_cast<int8_t*>(value);
-                        range->clear();
                         range->add_fixed_value(*reinterpret_cast<T*>(&v));
                         break;
                     }
@@ -896,7 +896,6 @@ Status OlapScanNode::normalize_in_and_eq_predicate(SlotDescriptor* slot, ColumnV
                         DateTimeValue date_value =
                             *reinterpret_cast<DateTimeValue*>(value);
                         date_value.cast_to_date();
-                        range->clear();
                         range->add_fixed_value(*reinterpret_cast<T*>(&date_value));
                         break;
                     }
@@ -910,13 +909,11 @@ Status OlapScanNode::normalize_in_and_eq_predicate(SlotDescriptor* slot, ColumnV
                     case TYPE_INT:
                     case TYPE_BIGINT:
                     case TYPE_LARGEINT: {
-                        range->clear();
                         range->add_fixed_value(*reinterpret_cast<T*>(value));
                         break;
                     }
                     case TYPE_BOOLEAN: {
                         bool v = *reinterpret_cast<bool*>(value);
-                        range->clear();
                         range->add_fixed_value(*reinterpret_cast<T*>(&v));
                         break;
                     }

--- a/be/src/exec/olap_scan_node.cpp
+++ b/be/src/exec/olap_scan_node.cpp
@@ -387,6 +387,8 @@ Status OlapScanNode::start_scan(RuntimeState* state) {
 Status OlapScanNode::normalize_conjuncts() {
     std::vector<SlotDescriptor*> slots = _tuple_desc->slots();
 
+    LOG(INFO) << "cmy get slot size: " << slots.size();
+
     for (int slot_idx = 0; slot_idx < slots.size(); ++slot_idx) {
         switch (slots[slot_idx]->type().type) {
             // TYPE_TINYINT use int32_t to present
@@ -860,6 +862,7 @@ Status OlapScanNode::normalize_in_and_eq_predicate(SlotDescriptor* slot, ColumnV
                     switch (slot->type().type) {
                     case TYPE_TINYINT: {
                         int32_t v = *reinterpret_cast<int8_t*>(value);
+                        range->clear();
                         range->add_fixed_value(*reinterpret_cast<T*>(&v));
                         break;
                     }
@@ -867,6 +870,7 @@ Status OlapScanNode::normalize_in_and_eq_predicate(SlotDescriptor* slot, ColumnV
                         DateTimeValue date_value =
                             *reinterpret_cast<DateTimeValue*>(value);
                         date_value.cast_to_date();
+                        range->clear();
                         range->add_fixed_value(*reinterpret_cast<T*>(&date_value));
                         break;
                     }
@@ -880,11 +884,13 @@ Status OlapScanNode::normalize_in_and_eq_predicate(SlotDescriptor* slot, ColumnV
                     case TYPE_INT:
                     case TYPE_BIGINT:
                     case TYPE_LARGEINT: {
+                        range->clear();
                         range->add_fixed_value(*reinterpret_cast<T*>(value));
                         break;
                     }
                     case TYPE_BOOLEAN: {
                         bool v = *reinterpret_cast<bool*>(value);
+                        range->clear();
                         range->add_fixed_value(*reinterpret_cast<T*>(&v));
                         break;
                     }
@@ -898,6 +904,7 @@ Status OlapScanNode::normalize_in_and_eq_predicate(SlotDescriptor* slot, ColumnV
             }
         }
     }
+    LOG(INFO) << "cmy get get_fixed_value_size(): " << range->get_fixed_value_size();
 
     return Status::OK();
 }

--- a/be/src/exec/olap_scan_node.cpp
+++ b/be/src/exec/olap_scan_node.cpp
@@ -717,7 +717,7 @@ Status OlapScanNode::normalize_predicate(ColumnValueRange<T>& range, SlotDescrip
     RETURN_IF_ERROR(normalize_in_and_eq_predicate(slot, &range));
 
     // 2. Normalize BinaryPredicate , add to ColumnValueRange
-    RETURN_IF_ERROR(normalize_binary_predicate(slot, &range));
+    RETURN_IF_ERROR(normalize_noneq_binary_predicate(slot, &range));
 
     // 3. Add range to Column->ColumnValueRange map
     _column_value_ranges[slot->col_name()] = range;
@@ -983,7 +983,7 @@ void OlapScanNode::construct_is_null_pred_in_where_pred(Expr* expr, SlotDescript
 }
 
 template<class T>
-Status OlapScanNode::normalize_binary_predicate(SlotDescriptor* slot, ColumnValueRange<T>* range) {
+Status OlapScanNode::normalize_noneq_binary_predicate(SlotDescriptor* slot, ColumnValueRange<T>* range) {
     for (int conj_idx = 0; conj_idx < _conjunct_ctxs.size(); ++conj_idx) {
         Expr *root_expr =  _conjunct_ctxs[conj_idx]->root();
         if (TExprNodeType::BINARY_PRED != root_expr->node_type()

--- a/be/src/exec/olap_scan_node.h
+++ b/be/src/exec/olap_scan_node.h
@@ -254,9 +254,9 @@ private:
     // into OlapEngine.
     // If conditions in InPredicate is larger than this, all conditions in
     // InPredicate will not be pushed to the OlapEngine.
-    // it will set as BE's config `max_pushdown_in_pred_element_num`,
+    // it will set as BE's config `max_pushdown_conditions_per_column`,
     // or be overwritten by value in TQueryOptions
-    int32_t _max_pushdown_in_pred_element_num = 1024;
+    int32_t _max_pushdown_conditions_per_column = 1024;
 
     // Counters
     RuntimeProfile::Counter* _io_timer = nullptr;

--- a/be/src/exec/olap_scan_node.h
+++ b/be/src/exec/olap_scan_node.h
@@ -149,7 +149,7 @@ protected:
     Status normalize_in_and_eq_predicate(SlotDescriptor* slot, ColumnValueRange<T>* range);
 
     template<class T>
-    Status normalize_binary_predicate(SlotDescriptor* slot, ColumnValueRange<T>* range);
+    Status normalize_noneq_binary_predicate(SlotDescriptor* slot, ColumnValueRange<T>* range);
 
     void transfer_thread(RuntimeState* state);
     void scanner_thread(OlapScanner* scanner);

--- a/be/src/exec/olap_scan_node.h
+++ b/be/src/exec/olap_scan_node.h
@@ -84,13 +84,16 @@ protected:
 
     class ExtendScanKeyVisitor : public boost::static_visitor<Status> {
     public:
-        ExtendScanKeyVisitor(OlapScanKeys& scan_keys) : _scan_keys(scan_keys) { }
+        ExtendScanKeyVisitor(OlapScanKeys& scan_keys, int32_t max_scan_key_num)
+            : _scan_keys(scan_keys),
+              _max_scan_key_num(max_scan_key_num) { }
         template<class T>
         Status operator()(T& v) {
-            return _scan_keys.extend_scan_key(v);
+            return _scan_keys.extend_scan_key(v, _max_scan_key_num);
         }
     private:
         OlapScanKeys& _scan_keys;
+        int32_t _max_scan_key_num;
     };
 
     typedef boost::variant<std::list<std::string>> string_list;
@@ -143,7 +146,7 @@ protected:
     Status normalize_predicate(ColumnValueRange<T>& range, SlotDescriptor* slot);
 
     template<class T>
-    Status normalize_in_predicate(SlotDescriptor* slot, ColumnValueRange<T>* range);
+    Status normalize_in_and_eq_predicate(SlotDescriptor* slot, ColumnValueRange<T>* range);
 
     template<class T>
     Status normalize_binary_predicate(SlotDescriptor* slot, ColumnValueRange<T>* range);
@@ -243,6 +246,18 @@ private:
 
     bool _need_agg_finalize = true;
 
+    // the max num of scan keys of this scan request.
+    // it will set as BE's config `doris_max_scan_key_num`,
+    // or be overwritten by value in TQueryOptions
+    int32_t _max_scan_key_num = 1024;
+    // The max number of conditions in InPredicate  that can be pushed down
+    // into OlapEngine.
+    // If conditions in InPredicate is larger than this, all conditions in
+    // InPredicate will not be pushed to the OlapEngine.
+    // it will set as BE's config `max_pushdown_in_pred_element_num`,
+    // or be overwritten by value in TQueryOptions
+    int32_t _max_pushdown_in_pred_element_num = 1024;
+
     // Counters
     RuntimeProfile::Counter* _io_timer = nullptr;
     RuntimeProfile::Counter* _read_compressed_counter = nullptr;
@@ -277,6 +292,8 @@ private:
     RuntimeProfile::Counter* _bitmap_index_filter_counter = nullptr;
     // time fro bitmap inverted index read and filter
     RuntimeProfile::Counter* _bitmap_index_filter_timer = nullptr;
+    // number of created olap scanners
+    RuntimeProfile::Counter* _num_scanners = nullptr;
 };
 
 } // namespace doris

--- a/docs/en/administrator-guide/config/be_config.md
+++ b/docs/en/administrator-guide/config/be_config.md
@@ -129,6 +129,12 @@ Since this is a brpc configuration, users can also modify this parameter directl
 
 ### `doris_max_scan_key_num`
 
+* Type: int
+* Description: Used to limit the maximum number of scan keys that a scan node can split in a query request. When a conditional query request reaches the scan node, the scan node will try to split the conditions related to the key column in the query condition into multiple scan key ranges. After that, these scan key ranges will be assigned to multiple scanner threads for data scanning. A larger value usually means that more scanner threads can be used to increase the parallelism of the scanning operation. However, in high concurrency scenarios, too many threads may bring greater scheduling overhead and system load, and will slow down the query response speed. An empirical value is 50. This configuration can be configured separately at the session level. For details, please refer to the description of `max_scan_key_num` in [Variables](../variables.md).
+* Default value: 1024
+
+When the concurrency cannot be improved in high concurrency scenarios, try to reduce this value and observe the impact.
+
 ### `doris_scan_range_row_count`
 
 ### `doris_scanner_queue_size`
@@ -241,6 +247,20 @@ Indicates how many tablets in this data directory failed to load. At the same ti
 ### `max_memory_sink_batch_count`
 
 ### `max_percentage_of_error_disk`
+
+### `max_pushdown_conditions_per_column`
+
+* Type: int
+* Description: Used to limit the maximum number of conditions that can be pushed down to the storage engine for a single column in a query request. During the execution of the query plan, the filter conditions on some columns can be pushed down to the storage engine, so that the index information in the storage engine can be used for data filtering, reducing the amount of data that needs to be scanned by the query. Such as equivalent conditions, conditions in IN predicates, etc. In most cases, this parameter only affects queries containing IN predicates. Such as `WHERE colA IN (1,2,3,4, ...)`. A larger number means that more conditions in the IN predicate can be pushed to the storage engine, but too many conditions may cause an increase in random reads, and in some cases may reduce query efficiency. This configuration can be individually configured for session level. For details, please refer to the description of `max_pushdown_conditions_per_column` in [Variables](../ variables.md).
+* Default value: 1024
+
+* Example
+
+    The table structure is `id INT, col2 INT, col3 varchar (32), ...`.
+
+    The query is `... WHERE id IN (v1, v2, v3, ...)`
+
+    If the number of conditions in the IN predicate exceeds the configuration, try to increase the configuration value and observe whether the query response has improved.
 
 ### `max_runnings_transactions_per_txn_map`
 

--- a/docs/en/administrator-guide/variables.md
+++ b/docs/en/administrator-guide/variables.md
@@ -235,6 +235,14 @@ SET forward_to_master = concat('tr', 'u', 'e');
 
     Used for compatible JDBC connection pool C3P0. No practical effect.
     
+* `max_pushdown_conditions_per_column`
+
+    For the specific meaning of this variable, please refer to the description of `max_pushdown_conditions_per_column` in [BE Configuration](./config/be_config.md). This variable is set to -1 by default, which means that the configuration value in `be.conf` is used. If the setting is greater than 0, the query in the current session will use the variable value, and ignore the configuration value in `be.conf`.
+
+* `max_scan_key_num`
+
+    For the specific meaning of this variable, please refer to the description of `doris_max_scan_key_num` in [BE Configuration](./config/be_config.md). This variable is set to -1 by default, which means that the configuration value in `be.conf` is used. If the setting is greater than 0, the query in the current session will use the variable value, and ignore the configuration value in `be.conf`.
+
 * `net_buffer_length`
 
     Used for compatibility with MySQL clients. No practical effect.

--- a/docs/zh-CN/administrator-guide/variables.md
+++ b/docs/zh-CN/administrator-guide/variables.md
@@ -234,6 +234,14 @@ SET forward_to_master = concat('tr', 'u', 'e');
 
     用于兼容 JDBC 连接池 C3P0。 无实际作用。
     
+* `max_pushdown_conditions_per_column`
+
+    该变量的具体含义请参阅 [BE 配置项](./config/be_config.md) 中 `max_pushdown_conditions_per_column` 的说明。该变量默认置为 -1，表示使用 `be.conf` 中的配置值。如果设置大于 0，则当前会话中的查询会使用该变量值，而忽略 `be.conf` 中的配置值。
+
+* `max_scan_key_num`
+
+    该变量的具体含义请参阅 [BE 配置项](./config/be_config.md) 中 `doris_max_scan_key_num` 的说明。该变量默认置为 -1，表示使用 `be.conf` 中的配置值。如果设置大于 0，则当前会话中的查询会使用该变量值，而忽略 `be.conf` 中的配置值。
+    
 * `net_buffer_length`
 
     用于兼容 MySQL 客户端。无实际作用。

--- a/fe/src/main/java/org/apache/doris/qe/ConnectProcessor.java
+++ b/fe/src/main/java/org/apache/doris/qe/ConnectProcessor.java
@@ -46,6 +46,7 @@ import org.apache.doris.proto.PQueryStatistics;
 import org.apache.doris.service.FrontendOptions;
 import org.apache.doris.thrift.TMasterOpRequest;
 import org.apache.doris.thrift.TMasterOpResult;
+import org.apache.doris.thrift.TQueryOptions;
 
 import com.google.common.base.Strings;
 
@@ -383,12 +384,6 @@ public class ConnectProcessor {
         if (request.isSetResourceInfo()) {
             ctx.getSessionVariable().setResourceGroup(request.getResourceInfo().getGroup());
         }
-        if (request.isSetExecMemLimit()) {
-            ctx.getSessionVariable().setMaxExecMemByte(request.getExecMemLimit());
-        }
-        if (request.isSetQueryTimeout()) {
-            ctx.getSessionVariable().setQueryTimeoutS(request.getQueryTimeout());
-        }
         if (request.isSetUser_ip()) {
             ctx.setRemoteIP(request.getUser_ip());
         }
@@ -401,9 +396,6 @@ public class ConnectProcessor {
         if (request.isSetSqlMode()) {
             ctx.getSessionVariable().setSqlMode(request.sqlMode);
         }
-        if (request.isSetLoadMemLimit()) {
-            ctx.getSessionVariable().setLoadMemLimit(request.loadMemLimit);
-        }
         if (request.isSetEnableStrictMode()) {
             ctx.getSessionVariable().setEnableInsertStrict(request.enableStrictMode);
         }
@@ -411,6 +403,38 @@ public class ConnectProcessor {
             UserIdentity currentUserIdentity = UserIdentity.fromThrift(request.getCurrent_user_ident());
             ctx.setCurrentUserIdentity(currentUserIdentity);
         }
+
+        if (request.isSetQuery_options()) {
+            TQueryOptions queryOptions = request.getQuery_options();
+            if (queryOptions.isSetMem_limit()) {
+                ctx.getSessionVariable().setMaxExecMemByte(queryOptions.getMem_limit());
+            }
+            if (queryOptions.isSetQuery_timeout()) {
+                ctx.getSessionVariable().setQueryTimeoutS(queryOptions.getQuery_timeout());
+            }
+            if (queryOptions.isSetLoad_mem_limit()) {
+                ctx.getSessionVariable().setLoadMemLimit(queryOptions.getLoad_mem_limit());
+            }
+            if (queryOptions.isSetMax_scan_key_num()) {
+                ctx.getSessionVariable().setMaxScanKeyNum(queryOptions.getMax_scan_key_num());
+            }
+            if (queryOptions.isSetMax_pushdown_conditions_per_column()) {
+                ctx.getSessionVariable().setMaxPushdownConditionsPerColumn(
+                        queryOptions.getMax_pushdown_conditions_per_column());
+            }
+        } else {
+            // for compatibility, all following variables are moved to TQueryOptions.
+            if (request.isSetExecMemLimit()) {
+                ctx.getSessionVariable().setMaxExecMemByte(request.getExecMemLimit());
+            }
+            if (request.isSetQueryTimeout()) {
+                ctx.getSessionVariable().setQueryTimeoutS(request.getQueryTimeout());
+            }
+            if (request.isSetLoadMemLimit()) {
+                ctx.getSessionVariable().setLoadMemLimit(request.loadMemLimit);
+            }
+        }
+
         ctx.setThreadLocalInfo();
 
         if (ctx.getCurrentUserIdentity() == null) {

--- a/fe/src/main/java/org/apache/doris/qe/MasterOpExecutor.java
+++ b/fe/src/main/java/org/apache/doris/qe/MasterOpExecutor.java
@@ -23,6 +23,7 @@ import org.apache.doris.thrift.FrontendService;
 import org.apache.doris.thrift.TMasterOpRequest;
 import org.apache.doris.thrift.TMasterOpResult;
 import org.apache.doris.thrift.TNetworkAddress;
+import org.apache.doris.thrift.TQueryOptions;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -79,14 +80,17 @@ public class MasterOpExecutor {
         params.setDb(ctx.getDatabase());
         params.setSqlMode(ctx.getSessionVariable().getSqlMode());
         params.setResourceInfo(ctx.toResourceCtx());
-        params.setExecMemLimit(ctx.getSessionVariable().getMaxExecMemByte());
-        params.setQueryTimeout(ctx.getSessionVariable().getQueryTimeoutS());
         params.setUser_ip(ctx.getRemoteIP());
         params.setTime_zone(ctx.getSessionVariable().getTimeZone());
         params.setStmt_id(ctx.getStmtId());
-        params.setLoadMemLimit(ctx.getSessionVariable().getLoadMemLimit());
         params.setEnableStrictMode(ctx.getSessionVariable().getEnableInsertStrict());
         params.setCurrent_user_ident(ctx.getCurrentUserIdentity().toThrift());
+
+        TQueryOptions queryOptions = new TQueryOptions();
+        queryOptions.setMem_limit(ctx.getSessionVariable().getMaxExecMemByte());
+        queryOptions.setQuery_timeout(ctx.getSessionVariable().getQueryTimeoutS());
+        queryOptions.setLoad_mem_limit(ctx.getSessionVariable().getLoadMemLimit());
+        params.setQuery_options(queryOptions);
 
         LOG.info("Forward statement {} to Master {}", ctx.getStmtId(), thriftAddress);
 

--- a/fe/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -501,8 +501,12 @@ public class SessionVariable implements Serializable, Writable {
         tResult.setDisable_stream_preaggregations(disableStreamPreaggregations);
         tResult.setLoad_mem_limit(loadMemLimit);
 
-        tResult.setMax_scan_key_num(maxScanKeyNum);
-        tResult.setMax_pushdown_conditions_per_column(maxPushdownConditionsPerColumn);
+        if (maxScanKeyNum > -1) {
+            tResult.setMax_scan_key_num(maxScanKeyNum);
+        }
+        if (maxPushdownConditionsPerColumn > -1) {
+            tResult.setMax_pushdown_conditions_per_column(maxPushdownConditionsPerColumn);
+        }
         return tResult;
     }
 

--- a/fe/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -96,6 +96,10 @@ public class SessionVariable implements Serializable, Writable {
     public static final String STORAGE_ENGINE = "storage_engine";
     public static final String DIV_PRECISION_INCREMENT = "div_precision_increment";
 
+    // see comment of `doris_max_scan_key_num` and `max_pushdown_conditions_per_column` in BE config
+    public static final String MAX_SCAN_KEY_NUM = "max_scan_key_num";
+    public static final String MAX_PUSHDOWN_CONDITIONS_PER_COLUMN = "max_pushdown_conditions_per_column";
+
     // max memory used on every backend.
     @VariableMgr.VarAttr(name = EXEC_MEM_LIMIT)
     public long maxExecMemByte = 2147483648L;
@@ -241,6 +245,12 @@ public class SessionVariable implements Serializable, Writable {
     private String storageEngine = "olap";
     @VariableMgr.VarAttr(name = DIV_PRECISION_INCREMENT)
     private int divPrecisionIncrement = 4;
+
+    // -1 means unset, BE will use its config value
+    @VariableMgr.VarAttr(name = MAX_SCAN_KEY_NUM)
+    private int maxScanKeyNum = -1;
+    @VariableMgr.VarAttr(name = MAX_PUSHDOWN_CONDITIONS_PER_COLUMN)
+    private int maxPushdownConditionsPerColumn = -1;
 
     public long getMaxExecMemByte() {
         return maxExecMemByte;
@@ -455,6 +465,22 @@ public class SessionVariable implements Serializable, Writable {
         return defaultRowsetType;
     }
 
+    public int getMaxScanKeyNum() {
+        return maxScanKeyNum;
+    }
+
+    public void setMaxScanKeyNum(int maxScanKeyNum) {
+        this.maxScanKeyNum = maxScanKeyNum;
+    }
+
+    public int getMaxPushdownConditionsPerColumn() {
+        return maxPushdownConditionsPerColumn;
+    }
+
+    public void setMaxPushdownConditionsPerColumn(int maxPushdownConditionsPerColumn) {
+        this.maxPushdownConditionsPerColumn = maxPushdownConditionsPerColumn;
+    }
+
     // Serialize to thrift object
     // used for rest api
     public TQueryOptions toThrift() {
@@ -474,6 +500,9 @@ public class SessionVariable implements Serializable, Writable {
         tResult.setBatch_size(batchSize);
         tResult.setDisable_stream_preaggregations(disableStreamPreaggregations);
         tResult.setLoad_mem_limit(loadMemLimit);
+
+        tResult.setMax_scan_key_num(maxScanKeyNum);
+        tResult.setMax_pushdown_conditions_per_column(maxPushdownConditionsPerColumn);
         return tResult;
     }
 

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -413,17 +413,18 @@ struct TMasterOpRequest {
     3: required string sql 
     4: optional Types.TResourceInfo resourceInfo
     5: optional string cluster
-    6: optional i64 execMemLimit
-    7: optional i32 queryTimeout
+    6: optional i64 execMemLimit // deprecated, move into query_options
+    7: optional i32 queryTimeout // deprecated, move into query_options
     8: optional string user_ip
     9: optional string time_zone
     10: optional i64 stmt_id
     11: optional i64 sqlMode
-    12: optional i64 loadMemLimit
+    12: optional i64 loadMemLimit // deprecated, move into query_options
     13: optional bool enableStrictMode
     // this can replace the "user" field
     14: optional Types.TUserIdentity current_user_ident
     15: optional i32 stmtIdx  // the idx of the sql in multi statements
+    16: optional PaloInternalService.TQueryOptions query_options
 }
 
 struct TColumnDefinition {

--- a/gensrc/thrift/PaloInternalService.thrift
+++ b/gensrc/thrift/PaloInternalService.thrift
@@ -133,9 +133,9 @@ struct TQueryOptions {
   // see BE config `doris_max_scan_key_num` for details
   // if set, this will overwrite the BE config.
   29: optional i32 max_scan_key_num;
-  // see BE config `max_pushdown_in_pred_element_num` for details
+  // see BE config `max_pushdown_conditions_per_column` for details
   // if set, this will overwrite the BE config.
-  30: optional i32 max_pushdown_in_pred_element_num
+  30: optional i32 max_pushdown_conditions_per_column
 }
     
 

--- a/gensrc/thrift/PaloInternalService.thrift
+++ b/gensrc/thrift/PaloInternalService.thrift
@@ -130,7 +130,14 @@ struct TQueryOptions {
   // if this is a query option for LOAD, load_mem_limit should be set to limit the mem comsuption
   // of load channel.
   28: optional i64 load_mem_limit = 0;
+  // see BE config `doris_max_scan_key_num` for details
+  // if set, this will overwrite the BE config.
+  29: optional i32 max_scan_key_num;
+  // see BE config `max_pushdown_in_pred_element_num` for details
+  // if set, this will overwrite the BE config.
+  30: optional i32 max_pushdown_in_pred_element_num
 }
+    
 
 // A scan range plus the parameters needed to execute that scan.
 struct TScanRangeParams {


### PR DESCRIPTION
Fix: #3693

This CL mainly changes:
1. Add a new BE config `max_pushdown_conditions_per_column` to limit the number of conditions of a single column that can be pushed down to storage engine.

2. Add 2 new session variables `max_scan_key_num` and `doris_max_scan_key_num` which can set in session level and overwrite the config value in BE.