### PR TITLE
[Load] Add more metric to trace the time cost in stream load and make brpc_num_threads configurable

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -30,6 +30,9 @@ namespace config {
     // port for brpc
     CONF_Int32(brpc_port, "8060");
 
+    //the num of bthreads for brpc, the default value is set to -1, which means the num of bthreads is #cpu-cores
+    CONF_Int32(brpc_num_threads, "-1")
+
     // Declare a selection strategy for those servers have many ips.
     // Note that there should at most one ip match this list.
     // this is a list in semicolon-delimited format, in CIDR notation, e.g. 10.10.10.0/24

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -78,7 +78,7 @@ namespace config {
     // the count of thread to high priority batch load
     CONF_Int32(push_worker_count_high_priority, "3");
     // the count of thread to publish version
-    CONF_Int32(publish_version_worker_count, "2");
+    CONF_Int32(publish_version_worker_count, "8");
     // the count of thread to clear transaction task
     CONF_Int32(clear_transaction_task_worker_count, "1");
     // the count of thread to delete
@@ -150,7 +150,7 @@ namespace config {
     // the maximum number of bytes to display on the debug webserver's log page
     CONF_Int64(web_log_bytes, "1048576");
     // number of threads available to serve backend execution requests
-    CONF_Int32(be_service_threads, "64");
+    CONF_Int32(be_service_threads, "512");
     // key=value pair of default query options for Doris, separated by ','
     CONF_String(default_query_options, "");
 
@@ -284,7 +284,7 @@ namespace config {
     // Port to start debug webserver on
     CONF_Int32(webserver_port, "8040");
     // Number of webserver workers
-    CONF_Int32(webserver_num_workers, "5");
+    CONF_Int32(webserver_num_workers, "48");
     // Period to update rate counters and sampling counters in ms.
     CONF_mInt32(periodic_counter_update_period_ms, "500");
 

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -150,7 +150,7 @@ namespace config {
     // the maximum number of bytes to display on the debug webserver's log page
     CONF_Int64(web_log_bytes, "1048576");
     // number of threads available to serve backend execution requests
-    CONF_Int32(be_service_threads, "512");
+    CONF_Int32(be_service_threads, "64");
     // key=value pair of default query options for Doris, separated by ','
     CONF_String(default_query_options, "");
 

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -30,7 +30,7 @@ namespace config {
     // port for brpc
     CONF_Int32(brpc_port, "8060");
 
-    //the num of bthreads for brpc, the default value is set to -1, which means the num of bthreads is #cpu-cores
+    // the number of bthreads for brpc, the default value is set to -1, which means the number of bthreads is #cpu-cores
     CONF_Int32(brpc_num_threads, "-1")
 
     // Declare a selection strategy for those servers have many ips.

--- a/be/src/http/action/stream_load.cpp
+++ b/be/src/http/action/stream_load.cpp
@@ -156,9 +156,12 @@ Status StreamLoadAction::_handle(StreamLoadContext* ctx) {
 
     // wait stream load finish
     RETURN_IF_ERROR(ctx->future.get());
+    ctx->write_data_cost_nanos = MonotonicNanos() - ctx->start_write_data_nanos;
 
     // If put file succeess we need commit this load
+    int64_t commit_and_publish_start_time = MonotonicNanos();
     RETURN_IF_ERROR(_exec_env->stream_load_executor()->commit_txn(ctx));
+    ctx->commit_and_publish_txn_cost_nanos = MonotonicNanos() - commit_and_publish_start_time;
 
     return Status::OK();
 }
@@ -248,7 +251,9 @@ Status StreamLoadAction::_on_header(HttpRequest* http_req, StreamLoadContext* ct
     }
 
     // begin transaction
+    int64_t begin_txn_start_time = MonotonicNanos();
     RETURN_IF_ERROR(_exec_env->stream_load_executor()->begin_txn(ctx));
+    ctx->begin_txn_cost_nanos = MonotonicNanos() - begin_txn_start_time;
 
     // process put file
     return _process_put(http_req, ctx);
@@ -263,6 +268,7 @@ void StreamLoadAction::on_chunk_data(HttpRequest* req) {
     struct evhttp_request* ev_req = req->get_evhttp_request();
     auto evbuf = evhttp_request_get_input_buffer(ev_req);
 
+    int64_t start_read_data_time = MonotonicNanos();
     while (evbuffer_get_length(evbuf) > 0) {
         auto bb = ByteBuffer::allocate(4096);
         auto remove_bytes = evbuffer_remove(evbuf, bb->ptr, bb->capacity);
@@ -277,6 +283,7 @@ void StreamLoadAction::on_chunk_data(HttpRequest* req) {
         }
         ctx->receive_bytes += remove_bytes;
     }
+    ctx->read_data_cost_nanos += (MonotonicNanos() - start_read_data_time);
 }
 
 void StreamLoadAction::free_handler_ctx(void* param) {
@@ -388,11 +395,13 @@ Status StreamLoadAction::_process_put(HttpRequest* http_req, StreamLoadContext* 
         ctx->max_filter_ratio = strtod(http_req->header(HTTP_MAX_FILTER_RATIO).c_str(), nullptr);
     }
 
+    int64_t stream_load_put_start_time = MonotonicNanos();
     RETURN_IF_ERROR(ThriftRpcHelper::rpc<FrontendServiceClient>(
             master_addr.hostname, master_addr.port,
             [&request, ctx] (FrontendServiceConnection& client) {
                 client->streamLoadPut(ctx->put_result, request);
             }));
+    ctx->stream_load_put_cost_nanos = MonotonicNanos() - stream_load_put_start_time;
 #else
     ctx->put_result = k_stream_load_put_result;
 #endif
@@ -408,6 +417,8 @@ Status StreamLoadAction::_process_put(HttpRequest* http_req, StreamLoadContext* 
     if (!ctx->use_streaming) {
         return Status::OK();
     }
+
+    ctx->start_write_data_nanos = MonotonicNanos();
     return _exec_env->stream_load_executor()->execute_plan_fragment(ctx);
 }
 

--- a/be/src/http/action/stream_load.cpp
+++ b/be/src/http/action/stream_load.cpp
@@ -156,7 +156,6 @@ Status StreamLoadAction::_handle(StreamLoadContext* ctx) {
 
     // wait stream load finish
     RETURN_IF_ERROR(ctx->future.get());
-    ctx->write_data_cost_nanos = MonotonicNanos() - ctx->start_write_data_nanos;
 
     // If put file succeess we need commit this load
     int64_t commit_and_publish_start_time = MonotonicNanos();
@@ -418,7 +417,6 @@ Status StreamLoadAction::_process_put(HttpRequest* http_req, StreamLoadContext* 
         return Status::OK();
     }
 
-    ctx->start_write_data_nanos = MonotonicNanos();
     return _exec_env->stream_load_executor()->execute_plan_fragment(ctx);
 }
 

--- a/be/src/runtime/stream_load/stream_load_context.cpp
+++ b/be/src/runtime/stream_load/stream_load_context.cpp
@@ -70,6 +70,17 @@ std::string StreamLoadContext::to_json() const {
     writer.Int64(receive_bytes);
     writer.Key("LoadTimeMs");
     writer.Int64(load_cost_nanos / 1000000);
+    writer.Key("BeginTxnTimeMs");
+    writer.Int64(begin_txn_cost_nanos / 1000000);
+    writer.Key("StreamLoadPutMs");
+    writer.Int64(stream_load_put_cost_nanos / 1000000);
+    writer.Key("ReadDataTimeMs");
+    writer.Int64(read_data_cost_nanos / 1000000);
+    writer.Key("WriteDataTimeMs");
+    writer.Int(write_data_cost_nanos / 1000000);
+    writer.Key("CommitAndPublishTimeMs");
+    writer.Int64(commit_and_publish_txn_cost_nanos / 1000000);
+
     if (!error_url.empty()) {
         writer.Key("ErrorURL");
         writer.String(error_url.c_str());

--- a/be/src/runtime/stream_load/stream_load_context.cpp
+++ b/be/src/runtime/stream_load/stream_load_context.cpp
@@ -72,7 +72,7 @@ std::string StreamLoadContext::to_json() const {
     writer.Int64(load_cost_nanos / 1000000);
     writer.Key("BeginTxnTimeMs");
     writer.Int64(begin_txn_cost_nanos / 1000000);
-    writer.Key("StreamLoadPutMs");
+    writer.Key("StreamLoadPutTimeMs");
     writer.Int64(stream_load_put_cost_nanos / 1000000);
     writer.Key("ReadDataTimeMs");
     writer.Int64(read_data_cost_nanos / 1000000);

--- a/be/src/runtime/stream_load/stream_load_context.h
+++ b/be/src/runtime/stream_load/stream_load_context.h
@@ -171,7 +171,14 @@ public:
     int64_t number_unselected_rows = 0;
     int64_t loaded_bytes = 0;
     int64_t start_nanos = 0;
+    int64_t start_write_data_nanos = 0;
     int64_t load_cost_nanos = 0;
+    int64_t begin_txn_cost_nanos = 0;
+    int64_t stream_load_put_cost_nanos = 0;
+    int64_t commit_and_publish_txn_cost_nanos = 0;
+    int64_t read_data_cost_nanos = 0;
+    int64_t write_data_cost_nanos = 0;
+
     std::string error_url = "";
     // if label already be used, set existing job's status here
     // should be RUNNING or FINISHED

--- a/be/src/runtime/stream_load/stream_load_executor.cpp
+++ b/be/src/runtime/stream_load/stream_load_executor.cpp
@@ -47,6 +47,7 @@ Status StreamLoadExecutor::execute_plan_fragment(StreamLoadContext* ctx) {
 // submit this params
 #ifndef BE_TEST
     ctx->ref();
+    ctx->start_write_data_nanos = MonotonicNanos();
     LOG(INFO) << "begin to execute job. label=" << ctx->label << ", txn_id=" << ctx->txn_id
               << ", query_id=" << print_id(ctx->put_result.params.params.query_id);
     auto st = _exec_env->fragment_mgr()->exec_plan_fragment(
@@ -100,7 +101,9 @@ Status StreamLoadExecutor::execute_plan_fragment(StreamLoadContext* ctx) {
                         break;
                     }
                 }
+                ctx->write_data_cost_nanos = MonotonicNanos() - ctx->start_write_data_nanos;
                 ctx->promise.set_value(status);
+
                 if (ctx->unref()) {
                     delete ctx;
                 }

--- a/be/src/service/brpc_service.cpp
+++ b/be/src/service/brpc_service.cpp
@@ -52,6 +52,10 @@ Status BRpcService::start(int port) {
                         brpc::SERVER_OWNS_SERVICE);
     // start service
     brpc::ServerOptions options;
+    if (config::brpc_num_threads != -1) {
+        options.num_threads = config::brpc_num_threads;
+    }
+
     if (_server->Start(port, &options) != 0) {
         char buf[64];
         LOG(WARNING) << "start brpc failed, errno=" << errno

--- a/docs/en/administrator-guide/config/be_config.md
+++ b/docs/en/administrator-guide/config/be_config.md
@@ -81,7 +81,7 @@ Since this is a brpc configuration, users can also modify this parameter directl
 
 This configuration is mainly used to modify the num of bthreads for brpc. The default value is set to -1, which means the num of bthreads is #cpu-cores.
 
-User can set this configuration to a larger value to get better QPS performance.
+User can set this configuration to a larger value to get better QPS performance. For more information, please refer to `https://github.com/apache/incubator-brpc/blob/master/docs/cn/benchmark.md`
 
 ### `buffer_pool_clean_pages_limit`
 

--- a/docs/en/administrator-guide/config/be_config.md
+++ b/docs/en/administrator-guide/config/be_config.md
@@ -77,7 +77,11 @@ Sometimes the query fails and an error message of `The server is overcrowded` wi
 
 Since this is a brpc configuration, users can also modify this parameter directly during operation. Modify by visiting `http://be_host:brpc_port/flags`.
 
-### `brpc_port`
+### `brpc_num_threads`
+
+This configuration is mainly used to modify the num of bthreads for brpc. The default value is set to -1, which means the num of bthreads is #cpu-cores.
+
+User can set this configuration to a larger value to get better QPS performance.
 
 ### `buffer_pool_clean_pages_limit`
 

--- a/docs/en/administrator-guide/config/be_config.md
+++ b/docs/en/administrator-guide/config/be_config.md
@@ -79,7 +79,7 @@ Since this is a brpc configuration, users can also modify this parameter directl
 
 ### `brpc_num_threads`
 
-This configuration is mainly used to modify the num of bthreads for brpc. The default value is set to -1, which means the num of bthreads is #cpu-cores.
+This configuration is mainly used to modify the number of bthreads for brpc. The default value is set to -1, which means the number of bthreads is #cpu-cores.
 
 User can set this configuration to a larger value to get better QPS performance. For more information, please refer to `https://github.com/apache/incubator-brpc/blob/master/docs/cn/benchmark.md`
 

--- a/docs/en/administrator-guide/config/be_config.md
+++ b/docs/en/administrator-guide/config/be_config.md
@@ -83,6 +83,8 @@ This configuration is mainly used to modify the number of bthreads for brpc. The
 
 User can set this configuration to a larger value to get better QPS performance. For more information, please refer to `https://github.com/apache/incubator-brpc/blob/master/docs/cn/benchmark.md`
 
+### `brpc_port`
+
 ### `buffer_pool_clean_pages_limit`
 
 ### `buffer_pool_limit`

--- a/docs/en/administrator-guide/load-data/stream-load-manual.md
+++ b/docs/en/administrator-guide/load-data/stream-load-manual.md
@@ -162,6 +162,11 @@ Examples:
     "NumberUnselectedRows": 0,
     "LoadBytes": 40888898,
     "LoadTimeMs": 2144,
+    "BeginTxnTimeMs": 1,
+    "StreamLoadPutTimeMs": 2,
+    "ReadDataTimeMs": 325,
+    "WriteDataTimeMs": 1933,
+    "CommitAndPublishTimeMs": 106,
     "ErrorURL": "http://192.168.1.1:8042/api/_load_error_log?file=__shard_0/error_log_insert_stmt_db18266d4d9b4ee5-abb00ddd64bdf005_db18266d4d9b4ee5_abb00ddd64bdf005"
 }
 ```
@@ -199,6 +204,16 @@ The following main explanations are given for the Stream load import result para
 + LoadBytes: Number of bytes imported.
 
 + LoadTimeMs: Import completion time. Unit milliseconds.
+
++ BeginTxnTimeMs: The time cost for RPC to Fe to begin a transaction, Unit milliseconds.
+
++ StreamLoadPutTimeMs：The time cost for RPC to Fe to get a stream load plan, Unit milliseconds.
+  
++ ReadDataTimeMs：Read data time, Unit milliseconds.
+
++ WriteDataTimeMs：Write data time, Unit milliseconds.
+
++ CommitAndPublishTimeMs：The time cost for RPC to Fe to commit and publish a transaction, Unit milliseconds.
 
 + ErrorURL: If you have data quality problems, visit this URL to see specific error lines.
 

--- a/docs/zh-CN/administrator-guide/config/be_config.md
+++ b/docs/zh-CN/administrator-guide/config/be_config.md
@@ -79,7 +79,7 @@ under the License.
 
 该配置主要用来修改brpc中bthreads的数量. 该配置的默认值被设置为-1, 这意味着bthreads的数量将被设置为机器的cpu核数。
 
-用户可以将该配置的值调大来获取更好的QPS性能。
+用户可以将该配置的值调大来获取更好的QPS性能。更多的信息可以参考`https://github.com/apache/incubator-brpc/blob/master/docs/cn/benchmark.md`。
 
 ### `brpc_port`
 

--- a/docs/zh-CN/administrator-guide/config/be_config.md
+++ b/docs/zh-CN/administrator-guide/config/be_config.md
@@ -75,6 +75,12 @@ under the License.
 
 由于这是一个 brpc 的配置，用户也可以在运行中直接修改该参数。通过访问 `http://be_host:brpc_port/flags` 修改。
 
+### `brpc_num_threads`
+
+该配置主要用来修改brpc中bthreads的数量. 该配置的默认值被设置为-1, 这意味着bthreads的数量将被设置为机器的cpu核数。
+
+用户可以将该配置的值调大来获取更好的QPS性能。
+
 ### `brpc_port`
 
 ### `buffer_pool_clean_pages_limit`

--- a/docs/zh-CN/administrator-guide/load-data/stream-load-manual.md
+++ b/docs/zh-CN/administrator-guide/load-data/stream-load-manual.md
@@ -201,6 +201,11 @@ Stream load 由于使用的是 HTTP 协议，所以所有导入任务有关的�
     "NumberUnselectedRows": 0,
     "LoadBytes": 40888898,
     "LoadTimeMs": 2144,
+    "BeginTxnTimeMs": 1,
+    "StreamLoadPutTimeMs": 2,
+    "ReadDataTimeMs": 325,
+    "WriteDataTimeMs": 1933,
+    "CommitAndPublishTimeMs": 106,
     "ErrorURL": "http://192.168.1.1:8042/api/_load_error_log?file=__shard_0/error_log_insert_stmt_db18266d4d9b4ee5-abb00ddd64bdf005_db18266d4d9b4ee5_abb00ddd64bdf005"
 }
 ```
@@ -238,6 +243,16 @@ Stream load 由于使用的是 HTTP 协议，所以所有导入任务有关的�
 + LoadBytes：导入的字节数。
 
 + LoadTimeMs：导入完成时间。单位毫秒。
+
++ BeginTxnTimeMs：向Fe请求开始一个事务所花费的时间，单位毫秒。
+
++ StreamLoadPutTimeMs：向Fe请求获取导入数据执行计划所花费的时间，单位毫秒。
+  
++ ReadDataTimeMs：读取数据所花费的时间，单位毫秒。
+
++ WriteDataTimeMs：执行写入数据操作所花费的时间，单位毫秒。
+
++ CommitAndPublishTimeMs：向Fe请求提交并且发布事务所花费的时间，单位毫秒。
 
 + ErrorURL：如果有数据质量问题，通过访问这个 URL 查看具体错误行。
 


### PR DESCRIPTION
This PR mainly do three things:
1. Make brpc_num_threads configurable to get better performance for qps
2. Change some default config in be to make doris get better performance both in stream load and query
3. Add more metric to trace the time cost in stream load
