### PR TITLE
[Bug] Set the 404 error for QueryProfile HttpRequest when query_id not set

### DIFF
--- a/fe/src/main/java/org/apache/doris/common/util/ProfileManager.java
+++ b/fe/src/main/java/org/apache/doris/common/util/ProfileManager.java
@@ -155,7 +155,7 @@ public class ProfileManager {
         try {
             ProfileElement element = profileMap.get(queryID);
             if (element == null) {
-                return new String("query id " + queryID + " not found." );
+                return null;
             }
             
             return element.profileContent;

--- a/fe/src/main/java/org/apache/doris/http/action/QueryProfileAction.java
+++ b/fe/src/main/java/org/apache/doris/http/action/QueryProfileAction.java
@@ -26,6 +26,7 @@ import org.apache.doris.http.IllegalArgException;
 import com.google.common.base.Strings;
 
 import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpResponseStatus;
 
 public class QueryProfileAction extends WebBaseAction {
 
@@ -47,14 +48,18 @@ public class QueryProfileAction extends WebBaseAction {
         }
         
         String queryProfileStr = ProfileManager.getInstance().getProfile(queryId);
-        appendQueryPrifile(response.getContent(), queryProfileStr);
-        
-        getPageFooter(response.getContent());
-        
-        writeResponse(request, response);
+        if (queryProfileStr != null) {
+            appendQueryProfile(response.getContent(), queryProfileStr);
+            getPageFooter(response.getContent());
+            writeResponse(request, response);
+        } else {
+            appendQueryProfile(response.getContent(), "query id " + queryId + " not found.");
+            getPageFooter(response.getContent());
+            writeResponse(request, response, HttpResponseStatus.NOT_FOUND);
+        }
     }
     
-    private void appendQueryPrifile(StringBuilder buffer, String queryProfileStr) {
+    private void appendQueryProfile(StringBuilder buffer, String queryProfileStr) {
         buffer.append("<pre>");
         buffer.append(queryProfileStr);
         buffer.append("</pre>");


### PR DESCRIPTION
Doris can get query profile by HttpRequest 
```
http://fe_host:web_port/query_profile?query_id=123456
```
Now, if query_id is not found, the 404 error is not set  in HttpHeader.