### PR TITLE
[Bug] fix mixed used of counter

### DIFF
--- a/be/src/runtime/mysql_result_writer.cpp
+++ b/be/src/runtime/mysql_result_writer.cpp
@@ -229,7 +229,7 @@ Status MysqlResultWriter::append_row_batch(const RowBatch* batch) {
     }
 
     if (status.ok()) {
-        SCOPED_TIMER(_sent_rows_counter);
+        SCOPED_TIMER(_result_send_timer);
         // push this batch to back
         status = _sinker->add_batch(result);
 


### PR DESCRIPTION
MysqlResultWriter _sent_rows_counter and _result_send_timer are mixed used.
It will results core dump when checking counter->type().