### PR TITLE
Fix UT ThreadPoolManagerTest failure

### DIFF
--- a/fe/src/test/java/org/apache/doris/common/ThreadPoolManagerTest.java
+++ b/fe/src/test/java/org/apache/doris/common/ThreadPoolManagerTest.java
@@ -58,7 +58,7 @@ public class ThreadPoolManagerTest {
         Assert.assertEquals(0, testCachedPool.getQueue().size());
         Assert.assertEquals(0, testCachedPool.getCompletedTaskCount());
 
-        Thread.sleep(500);
+        Thread.sleep(700);
 
         Assert.assertEquals(2, testCachedPool.getPoolSize());
         Assert.assertEquals(0, testCachedPool.getActiveCount());


### PR DESCRIPTION
```
java.lang.AssertionError: expected:<0> but was:<1>
	at org.apache.doris.common.ThreadPoolManagerTest.testNormal(ThreadPoolManagerTest.java:64)
-
```