### PR TITLE
[Bug][FsBroker] NPE throw when username is empty

### DIFF
--- a/fs_brokers/apache_hdfs_broker/src/main/java/org/apache/doris/broker/hdfs/FileSystemManager.java
+++ b/fs_brokers/apache_hdfs_broker/src/main/java/org/apache/doris/broker/hdfs/FileSystemManager.java
@@ -335,7 +335,7 @@ public class FileSystemManager {
                 conf.set(FS_HDFS_IMPL_DISABLE_CACHE, "true");
                 FileSystem dfsFileSystem = null;
                 if (authentication.equals(AUTHENTICATION_SIMPLE) &&
-                    properties.containsKey(USER_NAME_KEY)) {
+                    properties.containsKey(USER_NAME_KEY) && !Strings.isNullOrEmpty(username)) {
                     // Use the specified 'username' as the login name
                     UserGroupInformation ugi = UserGroupInformation.createRemoteUser(username);
                     dfsFileSystem = ugi.doAs(new PrivilegedExceptionAction<FileSystem>() {


### PR DESCRIPTION
When using Broker with an empty username, a NPE is thrown, which is
not expected.

Fix: #3730