### PR TITLE
[Bug]fix the crash of checksum task #3735

### DIFF
--- a/be/src/olap/row.h
+++ b/be/src/olap/row.h
@@ -59,6 +59,10 @@ bool equal_row(const std::vector<uint32_t>& ids,
 template<typename LhsRowType, typename RhsRowType>
 int compare_row(const LhsRowType& lhs, const RhsRowType& rhs) {
     for (uint32_t cid = 0; cid < lhs.schema()->num_key_columns(); ++cid) {
+        //because the num_column_ids include the column of double/float type
+        if (lhs.schema()->column(cid) == NULL) {
+            continue;
+        }
         auto res = lhs.schema()->column(cid)->compare_cell(lhs.cell(cid), rhs.cell(cid));
         if (res != 0) {
             return res;
@@ -76,6 +80,10 @@ template<typename LhsRowType, typename RhsRowType>
 int compare_row_key(const LhsRowType& lhs, const RhsRowType& rhs) {
     auto cmp_cids = std::min(lhs.schema()->num_column_ids(), rhs.schema()->num_column_ids());
     for (uint32_t cid = 0; cid < cmp_cids; ++cid) {
+        //because the num_column_ids include the column of double/float type
+        if (lhs.schema()->column(cid) == NULL) {
+            continue;
+        }
         auto res = lhs.schema()->column(cid)->compare_cell(lhs.cell(cid), rhs.cell(cid));
         if (res != 0) {
             return res;

--- a/be/src/olap/row.h
+++ b/be/src/olap/row.h
@@ -186,11 +186,10 @@ void agg_finalize_row(const std::vector<uint32_t>& ids, RowType* row, MemPool* m
 
 template<typename RowType>
 uint32_t hash_row(const RowType& row, uint32_t seed) {
-    FieldType type;
     for (uint32_t cid : row.schema()->column_ids()) {
-        type = row.schema()->column(cid)->type();
-        //The approximation of float/double in a certain precision range, the binary of byte is not
-        //a fixed value, so these two types are ignored in calculating hash code.
+        FieldType type = row.schema()->column(cid)->type();
+        // The approximation of float/double in a certain precision range, the binary of byte is not
+        // a fixed value, so these two types are ignored in calculating hash code.
         if (type == OLAP_FIELD_TYPE_FLOAT || type == OLAP_FIELD_TYPE_DOUBLE) {
             continue;
         }

--- a/be/src/olap/row.h
+++ b/be/src/olap/row.h
@@ -189,6 +189,8 @@ uint32_t hash_row(const RowType& row, uint32_t seed) {
     FieldType type;
     for (uint32_t cid : row.schema()->column_ids()) {
         type = row.schema()->column(cid)->type();
+        //The approximation of float/double in a certain precision range, the binary of byte is not
+        //a fixed value, so these two types are ignored in calculating hash code.
         if (type == OLAP_FIELD_TYPE_FLOAT || type == OLAP_FIELD_TYPE_DOUBLE) {
             continue;
         }

--- a/be/src/olap/task/engine_checksum_task.cpp
+++ b/be/src/olap/task/engine_checksum_task.cpp
@@ -103,7 +103,6 @@ OLAPStatus EngineChecksumTask::_compute_checksum() {
 
     bool eof = false;
     uint32_t row_checksum = 0;
-    uint32_t one_checksum;
     while (true) {
         OLAPStatus res = reader.next_row_with_aggregation(&row, mem_pool.get(), agg_object_pool.get(), &eof);
         if (res == OLAP_SUCCESS && eof) {
@@ -113,10 +112,8 @@ OLAPStatus EngineChecksumTask::_compute_checksum() {
             OLAP_LOG_WARNING("fail to read in reader. [res=%d]", res);
             return res;
         }
-        one_checksum = 0;
-        one_checksum = hash_row(row, one_checksum);
         // The value of checksum is independent of the sorting of data rows.
-        row_checksum = row_checksum ^ one_checksum;
+        row_checksum ^= hash_row(row, 0);
         // the memory allocate by mem pool has been copied,
         // so we should release memory immediately
         mem_pool->clear();


### PR DESCRIPTION
1. the table include key column of double/float type
2. when run checksum task, will use all of key columns to compare
3. schema.column(idx) of double/float type is NULL

#3735
