### PR TITLE
Ignore broken disks when BE starts up

### DIFF
--- a/be/src/olap/data_dir.h
+++ b/be/src/olap/data_dir.h
@@ -159,8 +159,6 @@ private:
     TStorageMedium::type _storage_medium;
     bool _is_used;
 
-    uint32_t _rand_seed;
-
     std::string _file_system;
     TabletManager* _tablet_manager;
     TxnManager* _txn_manager;
@@ -173,11 +171,7 @@ private:
     uint64_t _current_shard;
     std::set<TabletInfo> _tablet_set;
 
-    static const size_t TEST_FILE_BUF_SIZE = 4096;
-    static const size_t DIRECT_IO_ALIGNMENT = 512;
     static const uint32_t MAX_SHARD_NUM = 1024;
-    char* _test_file_read_buf;
-    char* _test_file_write_buf;
 
     OlapMeta* _meta = nullptr;
     RowsetIdGenerator* _id_generator = nullptr;

--- a/be/src/olap/utils.h
+++ b/be/src/olap/utils.h
@@ -227,6 +227,10 @@ OLAPStatus copy_file(const std::string& src, const std::string& dest);
 
 OLAPStatus copy_dir(const std::string &src_dir, const std::string &dst_dir);
 
+bool check_datapath_rw(const std::string& path);
+
+OLAPStatus read_write_test_file(const std::string& test_file_path);
+
 //转换两个list
 template<typename T1, typename T2>
 void static_cast_assign_vector(std::vector<T1>* v1, const std::vector<T2>& v2) {

--- a/be/src/service/doris_main.cpp
+++ b/be/src/service/doris_main.cpp
@@ -143,6 +143,25 @@ int main(int argc, char** argv) {
         LOG(FATAL) << "parse config storage path failed, path=" << doris::config::storage_root_path;
         exit(-1);
     }
+    auto it = paths.begin();
+    for (;it != paths.end();) {
+        if (!doris::check_datapath_rw(it->path)) {
+            if (doris::config::ignore_broken_disk) {
+                LOG(WARNING) << "read write test file failed, path=" << it->path;
+                it = paths.erase(it);
+            } else {
+                LOG(FATAL) << "read write test file failed, path=" << it->path;
+                exit(-1);
+            }
+        } else {
+            ++it;
+        }
+    }
+
+    if (paths.empty()) {
+        LOG(FATAL) << "All disks are broken, exit.";
+        exit(-1);
+    }
 
     // initilize libcurl here to avoid concurrent initialization
     auto curl_ret = curl_global_init(CURL_GLOBAL_ALL);

--- a/docs/en/administrator-guide/config/be_config.md
+++ b/docs/en/administrator-guide/config/be_config.md
@@ -188,6 +188,19 @@ Since this is a brpc configuration, users can also modify this parameter directl
 ### `ignore_broken_disk`
 
 ### `ignore_load_tablet_failure`
+When BE starts, it will check all the paths under the `storage_root_path` in  configuration.
+
+- `ignore_broken_disk=true`
+
+  If the path does not exist or the file under the path cannot be read or written (broken disk), it will be ignored. If there are any other available paths, the startup will not be interrupted.
+
+- `ignore_broken_disk=false`
+
+  If the path does not exist or the file under the path cannot be read or written (bad disk), the startup will fail and exit.
+
+The default value is `false`.
+
+### inc_rowset_expired_sec
 
 * Type: boolean
 * Description: Whether to continue to start be when load tablet from header failed.

--- a/docs/zh-CN/administrator-guide/config/be_config.md
+++ b/docs/zh-CN/administrator-guide/config/be_config.md
@@ -185,6 +185,18 @@ under the License.
 
 ### `ignore_broken_disk`
 
+​	当BE启动时，会检查``storage_root_path`` 配置下的所有路径。
+
+ - `ignore_broken_disk=true`
+
+   如果路径不存在或路径下无法进行读写文件(坏盘)，将忽略此路径，如果有其他可用路径则不中断启动。
+
+ - `ignore_broken_disk=false`
+
+   如果路径不存在或路径下无法进行读写文件(坏盘)，将中断启动失败退出。
+
+​    默认为false
+
 ### `inc_rowset_expired_sec`
 
 ### `index_stream_cache_capacity`


### PR DESCRIPTION
Ignore **broken disks** from storage_root_path:

- add read and write check for each dir in storage_root_path and ignore broken disks.
- add AutoDeallocator.h to manage the lifecycle of allocated data by malloc or posix_memalign.
- rewrite DataDir::_read_and_write_test_file function.