### PR TITLE
[FIX] fix binaryPredicte's equals function ignore op

### DIFF
--- a/fe/src/main/java/org/apache/doris/analysis/BinaryPredicate.java
+++ b/fe/src/main/java/org/apache/doris/analysis/BinaryPredicate.java
@@ -226,7 +226,7 @@ public class BinaryPredicate extends Predicate implements Writable {
         if (!super.equals(obj)) {
             return false;
         }
-        return this.op.equals(((BinaryPredicate) obj).getOp());
+        return ((BinaryPredicate) obj).opcode == this.opcode;
     }
 
     @Override

--- a/fe/src/main/java/org/apache/doris/analysis/BinaryPredicate.java
+++ b/fe/src/main/java/org/apache/doris/analysis/BinaryPredicate.java
@@ -226,7 +226,7 @@ public class BinaryPredicate extends Predicate implements Writable {
         if (!super.equals(obj)) {
             return false;
         }
-        return ((BinaryPredicate) obj).opcode == this.opcode && op.equals(((BinaryPredicate) obj).getOp());
+        return this.op.equals(((BinaryPredicate) obj).getOp());
     }
 
     @Override

--- a/fe/src/main/java/org/apache/doris/analysis/BinaryPredicate.java
+++ b/fe/src/main/java/org/apache/doris/analysis/BinaryPredicate.java
@@ -147,6 +147,7 @@ public class BinaryPredicate extends Predicate implements Writable {
     public BinaryPredicate(Operator op, Expr e1, Expr e2) {
         super();
         this.op = op;
+        this.opcode = op.opcode;
         Preconditions.checkNotNull(e1);
         children.add(e1);
         Preconditions.checkNotNull(e2);
@@ -225,7 +226,7 @@ public class BinaryPredicate extends Predicate implements Writable {
         if (!super.equals(obj)) {
             return false;
         }
-        return ((BinaryPredicate) obj).opcode == this.opcode;
+        return ((BinaryPredicate) obj).opcode == this.opcode && op.equals(((BinaryPredicate) obj).getOp());
     }
 
     @Override

--- a/fe/src/main/java/org/apache/doris/analysis/SelectStmt.java
+++ b/fe/src/main/java/org/apache/doris/analysis/SelectStmt.java
@@ -437,6 +437,8 @@ public class SelectStmt extends QueryStmt {
         }
 
         if (whereClause != null) {
+            // do this before whereClause.analyze , some expr is not analyzed, this may cause some
+            // function not work as expected such as equals;
             whereClauseRewrite();
             if (checkGroupingFn(whereClause)) {
                 throw new AnalysisException("grouping operations are not allowed in WHERE.");

--- a/fe/src/main/java/org/apache/doris/analysis/SelectStmt.java
+++ b/fe/src/main/java/org/apache/doris/analysis/SelectStmt.java
@@ -608,7 +608,7 @@ public class SelectStmt extends QueryStmt {
         if (clearExprs.size() == 1) {
             return makeCompound(clearExprs.get(0), CompoundPredicate.Operator.AND);
         }
-        // 2. find duplcate cross the clause
+        // 2. find duplicate cross the clause
         List<Expr> cloneExprs = new ArrayList<>(clearExprs.get(0));
         for (int i = 1; i < clearExprs.size(); ++i) {
             cloneExprs.retainAll(clearExprs.get(i));

--- a/fe/src/test/java/org/apache/doris/analysis/SelectStmtTest.java
+++ b/fe/src/test/java/org/apache/doris/analysis/SelectStmtTest.java
@@ -301,6 +301,12 @@ public class SelectStmtTest {
         stmt8.rewriteExprs(new Analyzer(ctx.getCatalog(), ctx).getExprRewriter());
         Assert.assertTrue(stmt8.toSql().contains("((`t2`.`k1` IS NOT NULL) AND (`t1`.`k1` IS NOT NULL))" +
                 " AND (`t1`.`k1` IS NOT NULL)"));
+
+        String sql9 = "select * from db1.tbl1 where (k1='shutdown' and k4<1) or (k1='switchOff' and k4>=1)";
+        SelectStmt stmt9 = (SelectStmt) UtFrameUtils.parseAndAnalyzeStmt(sql9, ctx);
+        stmt9.rewriteExprs(new Analyzer(ctx.getCatalog(), ctx).getExprRewriter());
+        Assert.assertTrue(stmt9.toSql().contains("((`k1` = 'shutdown') AND (`k4` < 1))" +
+                " OR ((`k1` = 'switchOff') AND (`k4` >= 1))"));
     }
 
     @Test


### PR DESCRIPTION
BinaryPredicte's equals funtion compare by opccode ,
but the opcode is never inited, 
so it will return true if this child is same,  for example `a>1` and `a<1` are equal
Fixes #3756