### PR TITLE
Disable Bitmap or Hll type in keys or in values with incorrect agg-type

### DIFF
--- a/fe/src/main/java/org/apache/doris/analysis/ColumnDef.java
+++ b/fe/src/main/java/org/apache/doris/analysis/ColumnDef.java
@@ -132,8 +132,8 @@ public class ColumnDef {
         Type type = typeDef.getType();
 
         // disable Bitmap Hll type in keys, values without aggregate function.
-        if ( type.isBitmapType() || type.isHllType() ){
-            if (isKey){
+        if (type.isBitmapType() || type.isHllType()) {
+            if (isKey) {
                 throw new AnalysisException("Key column can not set bitmap or hll type:" + name);
             }
             if (aggregateType == null) {

--- a/fe/src/main/java/org/apache/doris/analysis/ColumnDef.java
+++ b/fe/src/main/java/org/apache/doris/analysis/ColumnDef.java
@@ -131,6 +131,16 @@ public class ColumnDef {
 
         Type type = typeDef.getType();
 
+        // disable Bitmap Hll type in keys, values without aggregate function.
+        if ( type.isBitmapType() || type.isHllType() ){
+            if (isKey){
+                throw new AnalysisException("Key column can not set bitmap or hll type:" + name);
+            }
+            if (aggregateType == null) {
+                throw new AnalysisException("Bitmap and hll type have to use aggregate function" + name);
+            }
+        }
+
         // A column is a key column if and only if isKey is true.
         // aggregateType == null does not mean that this is a key column,
         // because when creating a UNIQUE KEY table, aggregateType is implicit.

--- a/fe/src/main/java/org/apache/doris/analysis/CreateTableStmt.java
+++ b/fe/src/main/java/org/apache/doris/analysis/CreateTableStmt.java
@@ -322,24 +322,12 @@ public class CreateTableStmt extends DdlStmt {
             columnDef.analyze(engineName.equals("olap"));
 
             if (columnDef.getType().isHllType()) {
-                if (columnDef.isKey()) {
-                    throw new AnalysisException("HLL can't be used as keys, " +
-                            "please specify the aggregation type HLL_UNION");
-                }
                 hasHll = true;
             }
 
-            if (columnDef.getType().isBitmapType()) {
-                if (columnDef.isKey()) {
-                    throw new AnalysisException("BITMAP can't be used as keys, ");
-                }
-            }
 
             if (columnDef.getAggregateType() == BITMAP_UNION) {
-                if (columnDef.isKey()) {
-                    throw new AnalysisException("Key column can't has the BITMAP_UNION aggregation type");
-                }
-                hasBitmap = true;
+                hasBitmap = columnDef.getType().isBitmapType();
             }
 
             if (!columnSet.add(columnDef.getName())) {

--- a/fe/src/main/java/org/apache/doris/catalog/AggregateType.java
+++ b/fe/src/main/java/org/apache/doris/catalog/AggregateType.java
@@ -85,11 +85,14 @@ public enum AggregateType {
         compatibilityMap.put(MAX, EnumSet.copyOf(primitiveTypeList));
 
         primitiveTypeList.clear();
-        compatibilityMap.put(REPLACE, EnumSet.allOf(PrimitiveType.class));
+        // all types except bitmap and hll.
+        EnumSet<PrimitiveType> exc_bitmap_hll = EnumSet.allOf(PrimitiveType.class);
+        exc_bitmap_hll.remove(PrimitiveType.BITMAP);
+        exc_bitmap_hll.remove(PrimitiveType.HLL);
+        compatibilityMap.put(REPLACE, EnumSet.copyOf(exc_bitmap_hll));
 
-        primitiveTypeList.clear();
-        compatibilityMap.put(REPLACE_IF_NOT_NULL, EnumSet.allOf(PrimitiveType.class));
-       
+        compatibilityMap.put(REPLACE_IF_NOT_NULL, EnumSet.copyOf(exc_bitmap_hll));
+
         primitiveTypeList.clear();
         primitiveTypeList.add(PrimitiveType.HLL);
         compatibilityMap.put(HLL_UNION, EnumSet.copyOf(primitiveTypeList));
@@ -97,8 +100,8 @@ public enum AggregateType {
         primitiveTypeList.clear();
         primitiveTypeList.add(PrimitiveType.BITMAP);
         compatibilityMap.put(BITMAP_UNION, EnumSet.copyOf(primitiveTypeList));
-    
-        compatibilityMap.put(NONE, EnumSet.allOf(PrimitiveType.class));
+
+        compatibilityMap.put(NONE, EnumSet.copyOf(exc_bitmap_hll));
     }
     private final String sqlName;
 


### PR DESCRIPTION
Bitmap and Hll type can not be used with incorrect aggregate functions, which will cause to BE crush.
Add some logical checks in FE's ColumnDef#analyze to avoid creating tables or changing schemas incorrectly.

- Keys never be bitmap or hll type
- values with bitmap or hll type have to be associated with bitmap_union or hll_union
