### PR TITLE
Fix the error selectedIndexId when keysType of table is UNIQUE

### DIFF
--- a/fe/src/main/java/org/apache/doris/planner/MaterializedViewSelector.java
+++ b/fe/src/main/java/org/apache/doris/planner/MaterializedViewSelector.java
@@ -131,7 +131,8 @@ public class MaterializedViewSelector {
         // Step5: columns required to compute output expr are available in the view output
         checkOutputColumns(columnNamesInQueryOutput.get(tableName), candidateIndexIdToMeta);
         // Step6: if table type is aggregate and the candidateIndexIdToSchema is empty,
-        if (table.getKeysType() == KeysType.AGG_KEYS && candidateIndexIdToMeta.size() == 0) {
+        if ((table.getKeysType() == KeysType.AGG_KEYS || table.getKeysType() == KeysType.UNIQUE_KEYS)
+                && candidateIndexIdToMeta.size() == 0) {
             // the base index will be added in the candidateIndexIdToSchema.
             /**
              * In Doris, it is allowed that the aggregate table should be scanned directly

--- a/fe/src/test/java/org/apache/doris/planner/MaterializedViewFunctionTest.java
+++ b/fe/src/test/java/org/apache/doris/planner/MaterializedViewFunctionTest.java
@@ -624,4 +624,18 @@ public class MaterializedViewFunctionTest {
         dorisAssert.withMaterializedView(createK1K2MV).query(query).explainWithout("k1_k2");
         dorisAssert.dropTable(TEST_TABLE_NAME);
     }
+
+    @Test
+    public void testUniqueTableInQuery() throws Exception {
+        String uniqueTable = "CREATE TABLE " + TEST_TABLE_NAME + " (k1 int, v1 int) UNIQUE KEY (k1) "
+                + "DISTRIBUTED BY HASH(k1) BUCKETS 3 PROPERTIES ('replication_num' = '1');";
+        dorisAssert.withTable(uniqueTable);
+        String createK1K2MV = "create materialized view only_k1 as select k1 from " + TEST_TABLE_NAME + " group by "
+                + "k1;";
+        String query = "select * from " + TEST_TABLE_NAME + ";";
+        dorisAssert.withMaterializedView(createK1K2MV).query(query).explainContains(TEST_TABLE_NAME);
+        dorisAssert.dropTable(TEST_TABLE_NAME);
+
+
+    }
 }


### PR DESCRIPTION
The unique table also should be compensated candidate index.
The reason is the same as the agg table type.

Fixed #3771.
Change-Id: Ic04b0360a0b178cb0b6ee635e56f48852092ec09