### PR TITLE
fix some flaw in format-code tutorial

### DIFF
--- a/docs/en/developer-guide/format-code.md
+++ b/docs/en/developer-guide/format-code.md
@@ -38,6 +38,8 @@ You should install clang-format, or you can use clang-format plugins which suppo
 ### Install clang-format
 Ubuntu: `apt-get install clang-format` 
 
+Mac: `brew install clang-format`
+
 The current release is 10.0, you can specify old version, e.g.
  
  `apt-get install clang-format-9`
@@ -58,17 +60,24 @@ the version is lower than clang-format-9.0.
 ### CMD
 `clang-format --style=file -i $File$` 
 
-When using `-style=file`, clang-format for each input file will try to find the 
-.clang-format file located in the closest parent directory of the input file. 
-When the standard input is used, the search is started from the current directory.
+`-style=file` Clang-format will try to find the .clang-format file located in the closest parent directory of the input file. When the standard input is used, the search is started from the current directory.
 
-Note: filter out the files which should not be formatted, when batch clang-formating
- files. 
+`--lines = m:n` Format a range of lines. Multiple ranges can be formatted by specifying several -lines arguments.
+
+`-i`input file
+
+Note: filter out the files which should not be formatted, when batch clang-formating files. 
  
  A example of how to filter \*.h/\*.cpp and exclude some dirs:
  
+ Centos
+
 `find . -type f -not \( -wholename ./env/* \) -regextype posix-egrep -regex
  ".*\.(cpp|h)" | xargs clang-format -i -style=file`
+ 
+ Mac
+ 
+ `find -E . -type f -not \( -wholename ./env/* \) -regex ".*\.(cpp|h)" | xargs clang-format -i --style=file`
 
 ### Using clang-format in IDEs or Editors
 #### Clion
@@ -78,8 +87,10 @@ shortcut.
 VS Code needs install the extension 'Clang-Format', and specify the executable path of 
 clang-format in settings.
 
+Open the vs code configuration page and search `clang_format`, fill the box as follows.
+
 ```
-"clang-format.executable":  "$clang-format path$",
-"clang-format.style": "file"
+"clang_format_path":  "$clang-format path$",
+"clang_format_style": "file"
 ```
-Then, choose `Format Document`.
+Then, right click the file and choose `Format Document`.

--- a/docs/zh-CN/developer-guide/format-code.md
+++ b/docs/zh-CN/developer-guide/format-code.md
@@ -40,6 +40,8 @@ Ubuntu: `apt-get install clang-format`
 
 当前版本为10.0，也可指定旧版本，例如: `apt-get install clang-format-9`
 
+Mac: `brew install clang-format`
+
 Centos 7: 
 
 centos yum安装的clang-format版本过老，支持的StyleOption太少，建议源码编译10.0版本。
@@ -55,10 +57,20 @@ clang-format程序的版本匹配，从支持的StyleOption上看，应该是低
 
 `--sytle=file`就会自动找到.clang-format文件，根据文件Option配置来格式化代码。
 
+`--lines=m:n`通过指定起始行和结束行修改文件的指定范围
+
+`-i`指定被格式化文件
+
 批量文件clang-format时，需注意过滤不应该格式化的文件。例如，只格式化*.h/*.cpp，并排除某些文件夹：
+
+ Centos
 
 `find . -type f -not \( -wholename ./env/* \) -regextype posix-egrep -regex
  ".*\.(cpp|h)" | xargs clang-format -i -style=file`
+ 
+ Mac
+ 
+ `find -E . -type f -not \( -wholename ./env/* \) -regex ".*\.(cpp|h)" | xargs clang-format -i --style=file`
 
 ### 在IDE或Editor中使用clang-format
 #### Clion
@@ -66,8 +78,11 @@ Clion如果使用插件，点击`Reformat Code`即可。
 #### VS Code
 VS Code需安装扩展程序Clang-Format，但需要自行提供clang-format执行程序的位置。
 
+打开VS Code配置页面，直接搜索"clang_format"，填上
+
 ```
-"clang-format.executable":  "$clang-format path$",
-"clang-format.style": "file"
+"clang_format_path":  "$clang-format path$",
+"clang_format_style": "file"
 ```
-然后，点击`Format Document`即可。
+
+然后，右键点击`Format Document`即可。


### PR DESCRIPTION
Fix some problems found when using MAC to refer to format-code tutorial.
This commit adds some details to the document in formate-code tutorial.