### PR TITLE
Support read and write lock in table level to reduce lock competition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ docs/.temp
 docs/.vuepress/dist
 docs/node_modules
 docs/build
+docs/contents
 gensrc/build
 fe/fe-core/target
 thirdparty/src

--- a/fe/fe-core/src/main/java/org/apache/doris/alter/Alter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/Alter.java
@@ -290,7 +290,6 @@ public class Alter {
                 Catalog.getCurrentSystemInfo().checkClusterCapacity(clusterName);
                 db.checkQuota();
             }
-
             if (olapTable.getState() != OlapTableState.NORMAL) {
                 throw new DdlException(
                         "Table[" + table.getName() + "]'s state is not NORMAL. Do not allow doing ALTER ops");

--- a/fe/fe-core/src/main/java/org/apache/doris/alter/Alter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/Alter.java
@@ -227,6 +227,9 @@ public class Alter {
             ErrorReport.reportDdlException(ErrorCode.ERR_BAD_DB_ERROR, dbName);
         }
         Table table = db.getTable(tableName);
+        if (table == null) {
+            ErrorReport.reportDdlException(ErrorCode.ERR_BAD_TABLE_ERROR, tableName);
+        }
         List<AlterClause> alterClauses = Lists.newArrayList();
         // some operations will take long time to process, need to be done outside the table lock
         boolean needProcessOutsideTableLock = false;

--- a/fe/fe-core/src/main/java/org/apache/doris/alter/Alter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/Alter.java
@@ -363,10 +363,7 @@ public class Alter {
 
         String oldTblName = origTable.getName();
         String newTblName = clause.getTblName();
-        Table newTbl = db.getTable(newTblName);
-        if (newTbl == null || newTbl.getType() != TableType.OLAP) {
-            throw new DdlException("Table " + newTblName + " does not exist or is not OLAP table");
-        }
+        Table newTbl = db.getTableOrThrowException(newTblName, TableType.OLAP);
         OlapTable olapNewTbl = (OlapTable) newTbl;
 
         boolean swapTable = clause.isSwapTable();

--- a/fe/fe-core/src/main/java/org/apache/doris/alter/Alter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/Alter.java
@@ -359,15 +359,13 @@ public class Alter {
     // entry of processing replace table
     private void processReplaceTable(Database db, OlapTable origTable, List<AlterClause> alterClauses) throws UserException {
         ReplaceTableClause clause = (ReplaceTableClause) alterClauses.get(0);
-        Preconditions.checkState(db.isWriteLockHeldByCurrentThread());
+        Preconditions.checkState(origTable.isWriteLockHeldByCurrentThread());
 
         String oldTblName = origTable.getName();
         String newTblName = clause.getTblName();
         Table newTbl = db.getTableOrThrowException(newTblName, TableType.OLAP);
         OlapTable olapNewTbl = (OlapTable) newTbl;
-
         boolean swapTable = clause.isSwapTable();
-
         // First, we need to check whether the table to be operated on can be renamed
         olapNewTbl.checkAndSetName(oldTblName, true);
         if (swapTable) {

--- a/fe/fe-core/src/main/java/org/apache/doris/alter/AlterHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/AlterHandler.java
@@ -427,12 +427,13 @@ public abstract class AlterHandler extends MasterDaemon {
             throw new MetaNotFoundException("database " + task.getDbId() + " does not exist");
         }
 
-        db.writeLock();
+        OlapTable tbl = (OlapTable) db.getTable(task.getTableId());
+        if (tbl == null) {
+            throw new MetaNotFoundException("tbl " + task.getTableId() + " does not exist");
+        }
+
+        tbl.writeLock();
         try {
-            OlapTable tbl = (OlapTable) db.getTable(task.getTableId());
-            if (tbl == null) {
-                throw new MetaNotFoundException("tbl " + task.getTableId() + " does not exist");
-            }
             Partition partition = tbl.getPartition(task.getPartitionId());
             if (partition == null) {
                 throw new MetaNotFoundException("partition " + task.getPartitionId() + " does not exist");
@@ -478,7 +479,7 @@ public abstract class AlterHandler extends MasterDaemon {
             
             LOG.info("after handle alter task tablet: {}, replica: {}", task.getSignature(), replica);
         } finally {
-            db.writeUnlock();
+            tbl.writeUnlock();
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/alter/AlterHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/AlterHandler.java
@@ -410,11 +410,7 @@ public abstract class AlterHandler extends MasterDaemon {
             throw new MetaNotFoundException("database " + task.getDbId() + " does not exist");
         }
 
-        OlapTable tbl = (OlapTable) db.getTable(task.getTableId());
-        if (tbl == null) {
-            throw new MetaNotFoundException("tbl " + task.getTableId() + " does not exist");
-        }
-
+        OlapTable tbl = (OlapTable) db.getTableOrThrowException(task.getTableId(), Table.TableType.OLAP);
         tbl.writeLock();
         try {
             Partition partition = tbl.getPartition(task.getPartitionId());

--- a/fe/fe-core/src/main/java/org/apache/doris/alter/AlterJobV2.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/AlterJobV2.java
@@ -178,7 +178,7 @@ public abstract class AlterJobV2 implements Writable {
         }
     }
 
-    public final boolean cancel(String errMsg) {
+    public synchronized final boolean cancel(String errMsg) {
         return cancelImpl(errMsg);
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/alter/AlterJobV2.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/AlterJobV2.java
@@ -187,22 +187,12 @@ public abstract class AlterJobV2 implements Writable {
     * return false if table is not stable.
     */
     protected boolean checkTableStable(Database db) throws AlterCancelException {
-        OlapTable tbl = null;
-        boolean isStable = false;
-        db.readLock();
-        try {
-            tbl = (OlapTable) db.getTable(tableId);
-            if (tbl == null) {
-                throw new AlterCancelException("Table " + tableId + " does not exist");
-            }
+        OlapTable tbl = (OlapTable) db.getTable(tableId);
 
-            isStable = tbl.isStable(Catalog.getCurrentSystemInfo(),
+        boolean isStable = tbl.isStable(Catalog.getCurrentSystemInfo(),
                     Catalog.getCurrentCatalog().getTabletScheduler(), db.getClusterName());
-        } finally {
-            db.readUnlock();
-        }
 
-        db.writeLock();
+        tbl.writeLock();
         try {
             if (!isStable) {
                 errMsg = "table is unstable";
@@ -216,7 +206,7 @@ public abstract class AlterJobV2 implements Writable {
                 return true;
             }
         } finally {
-            db.writeUnlock();
+            tbl.writeUnlock();
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/alter/AlterJobV2.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/AlterJobV2.java
@@ -179,9 +179,7 @@ public abstract class AlterJobV2 implements Writable {
     }
 
     public final boolean cancel(String errMsg) {
-        synchronized (this) {
-            return cancelImpl(errMsg);
-        }
+        return cancelImpl(errMsg);
     }
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/alter/AlterJobV2.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/AlterJobV2.java
@@ -188,6 +188,9 @@ public abstract class AlterJobV2 implements Writable {
     */
     protected boolean checkTableStable(Database db) throws AlterCancelException {
         OlapTable tbl = (OlapTable) db.getTable(tableId);
+        if (tbl == null) {
+            throw new AlterCancelException("Table " + tableId + " does not exist");
+        }
 
         boolean isStable = tbl.isStable(Catalog.getCurrentSystemInfo(),
                     Catalog.getCurrentCatalog().getTabletScheduler(), db.getClusterName());

--- a/fe/fe-core/src/main/java/org/apache/doris/alter/MaterializedViewHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/MaterializedViewHandler.java
@@ -1128,18 +1128,13 @@ public class MaterializedViewHandler extends AlterHandler {
             unlock();
         }
 
-        db.readLock();
-        try {
-            for (AlterJob selectedJob : jobs) {
-                OlapTable olapTable = (OlapTable) db.getTable(selectedJob.getTableId());
-                if (olapTable == null) {
-                    continue;
-                }
 
-                selectedJob.getJobInfo(rollupJobInfos, olapTable);
+        for (AlterJob selectedJob : jobs) {
+            OlapTable olapTable = (OlapTable) db.getTable(selectedJob.getTableId());
+            if (olapTable == null) {
+                continue;
             }
-        } finally {
-            db.readUnlock();
+            selectedJob.getJobInfo(rollupJobInfos, olapTable);
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/alter/MaterializedViewHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/MaterializedViewHandler.java
@@ -287,7 +287,6 @@ public class MaterializedViewHandler extends AlterHandler {
         // ATTN: This order is not mandatory, because database lock will protect us,
         // but this order is more reasonable
         olapTable.setState(OlapTableState.ROLLUP);
-
         // 2 batch submit rollup job
         List<AlterJobV2> rollupJobV2List = new ArrayList<>(rollupNameJobMap.values());
         batchAddAlterJobV2(rollupJobV2List);
@@ -700,7 +699,7 @@ public class MaterializedViewHandler extends AlterHandler {
 
     public void processBatchDropRollup(List<AlterClause> dropRollupClauses, Database db, OlapTable olapTable)
             throws DdlException, MetaNotFoundException {
-        db.writeLock();
+        olapTable.writeLock();
         try {
             // check drop rollup index operation
             for (AlterClause alterClause : dropRollupClauses) {
@@ -726,13 +725,14 @@ public class MaterializedViewHandler extends AlterHandler {
             editLog.logBatchDropRollup(new BatchDropInfo(dbId, tableId, indexIdSet));
             LOG.info("finished drop rollup index[{}] in table[{}]", String.join("", rollupNameSet), olapTable.getName());
         } finally {
-            db.writeUnlock();
+            olapTable.writeUnlock();
         }
     }
 
     public void processDropMaterializedView(DropMaterializedViewStmt dropMaterializedViewStmt, Database db,
             OlapTable olapTable) throws DdlException, MetaNotFoundException {
-        Preconditions.checkState(db.isWriteLockHeldByCurrentThread());
+        Preconditions.checkState(olapTable.isWriteLockHeldByCurrentThread());
+        olapTable.writeLock();
         try {
             String mvName = dropMaterializedViewStmt.getMvName();
             // Step1: check drop mv index operation
@@ -807,13 +807,13 @@ public class MaterializedViewHandler extends AlterHandler {
 
     public void replayDropRollup(DropInfo dropInfo, Catalog catalog) {
         Database db = catalog.getDb(dropInfo.getDbId());
-        db.writeLock();
-        try {
-            long tableId = dropInfo.getTableId();
-            long rollupIndexId = dropInfo.getIndexId();
+        long tableId = dropInfo.getTableId();
+        long rollupIndexId = dropInfo.getIndexId();
 
-            TabletInvertedIndex invertedIndex = Catalog.getCurrentInvertedIndex();
-            OlapTable olapTable = (OlapTable) db.getTable(tableId);
+        TabletInvertedIndex invertedIndex = Catalog.getCurrentInvertedIndex();
+        OlapTable olapTable = (OlapTable) db.getTable(tableId);
+        olapTable.writeLock();
+        try {
             for (Partition partition : olapTable.getPartitions()) {
                 MaterializedIndex rollupIndex = partition.deleteRollupIndex(rollupIndexId);
 
@@ -828,7 +828,7 @@ public class MaterializedViewHandler extends AlterHandler {
             String rollupIndexName = olapTable.getIndexNameById(rollupIndexId);
             olapTable.deleteIndexInfo(rollupIndexName);
         } finally {
-            db.writeUnlock();
+            olapTable.writeUnlock();
         }
         LOG.info("replay drop rollup {}", dropInfo.getIndexId());
     }
@@ -863,15 +863,18 @@ public class MaterializedViewHandler extends AlterHandler {
                     dbId, tableId);
             return;
         }
-        db.writeLock();
+        OlapTable tbl = (OlapTable) db.getTable(tableId);
+        if (tbl == null) {
+            return;
+        }
+        tbl.writeLock();
         try {
-            OlapTable tbl = (OlapTable) db.getTable(tableId);
-            if (tbl == null || tbl.getState() == olapTableState) {
+            if (tbl.getState() == olapTableState) {
                 return;
             }
             tbl.setState(olapTableState);
         } finally {
-            db.writeUnlock();
+            tbl.writeUnlock();
         }
     }
 
@@ -1054,13 +1057,8 @@ public class MaterializedViewHandler extends AlterHandler {
                 continue;
             }
 
-            db.writeLock();
-            try {
-                OlapTable olapTable = (OlapTable) db.getTable(rollupJob.getTableId());
-                rollupJob.cancel(olapTable, "cancelled");
-            } finally {
-                db.writeUnlock();
-            }
+            OlapTable olapTable = (OlapTable) db.getTable(rollupJob.getTableId());
+            rollupJob.cancel(olapTable, "cancelled");
             jobDone(rollupJob);
         }
 
@@ -1174,16 +1172,16 @@ public class MaterializedViewHandler extends AlterHandler {
 
         AlterJob rollupJob = null;
         List<AlterJobV2> rollupJobV2List = new ArrayList<>();
-        db.writeLock();
+        Table table = db.getTable(tableName);
+        if (table == null) {
+            ErrorReport.reportDdlException(ErrorCode.ERR_BAD_TABLE_ERROR, tableName);
+        }
+        if (!(table instanceof OlapTable)) {
+            ErrorReport.reportDdlException(ErrorCode.ERR_NOT_OLAP_TABLE, tableName);
+        }
+        OlapTable olapTable = (OlapTable) table;
+        olapTable.writeLock();
         try {
-            Table table = db.getTable(tableName);
-            if (table == null) {
-                ErrorReport.reportDdlException(ErrorCode.ERR_BAD_TABLE_ERROR, tableName);
-            }
-            if (!(table instanceof OlapTable)) {
-                ErrorReport.reportDdlException(ErrorCode.ERR_NOT_OLAP_TABLE, tableName);
-            }
-            OlapTable olapTable = (OlapTable) table;
             if (olapTable.getState() != OlapTableState.ROLLUP) {
                 throw new DdlException("Table[" + tableName + "] is not under ROLLUP. "
                         + "Use 'ALTER TABLE DROP ROLLUP' if you want to.");
@@ -1211,7 +1209,7 @@ public class MaterializedViewHandler extends AlterHandler {
                 rollupJob.cancel(olapTable, "user cancelled");
             }
         } finally {
-            db.writeUnlock();
+            olapTable.writeUnlock();
         }
 
         // alter job v2's cancel must be called outside the database lock

--- a/fe/fe-core/src/main/java/org/apache/doris/alter/MaterializedViewHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/MaterializedViewHandler.java
@@ -1077,7 +1077,16 @@ public class MaterializedViewHandler extends AlterHandler {
             }
 
             OlapTable olapTable = (OlapTable) db.getTable(rollupJob.getTableId());
-            rollupJob.cancel(olapTable, "cancelled");
+            if (olapTable != null) {
+                olapTable.writeLock();
+            }
+            try {
+                rollupJob.cancel(olapTable, "cancelled");
+            } finally {
+                if (olapTable != null) {
+                    olapTable.writeUnlock();
+                }
+            }
             jobDone(rollupJob);
         }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/alter/MaterializedViewHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/MaterializedViewHandler.java
@@ -1173,6 +1173,7 @@ public class MaterializedViewHandler extends AlterHandler {
     @Override
     public void process(List<AlterClause> alterClauses, String clusterName, Database db, OlapTable olapTable)
             throws DdlException, AnalysisException, MetaNotFoundException {
+        Preconditions.checkState(olapTable.isWriteLockHeldByCurrentThread());
         Optional<AlterClause> alterClauseOptional = alterClauses.stream().findAny();
         if (alterClauseOptional.isPresent()) {
             if (alterClauseOptional.get() instanceof AddRollupClause) {

--- a/fe/fe-core/src/main/java/org/apache/doris/alter/MaterializedViewHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/MaterializedViewHandler.java
@@ -1160,7 +1160,13 @@ public class MaterializedViewHandler extends AlterHandler {
             if (olapTable == null) {
                 continue;
             }
-            selectedJob.getJobInfo(rollupJobInfos, olapTable);
+            olapTable.readLock();
+            try {
+                selectedJob.getJobInfo(rollupJobInfos, olapTable);
+            } finally {
+                olapTable.readUnlock();
+            }
+
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/alter/MaterializedViewHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/MaterializedViewHandler.java
@@ -734,6 +734,12 @@ public class MaterializedViewHandler extends AlterHandler {
         Preconditions.checkState(olapTable.isWriteLockHeldByCurrentThread());
         olapTable.writeLock();
         try {
+            // check table state
+            if (olapTable.getState() != OlapTableState.NORMAL) {
+                throw new DdlException("Table[" + olapTable.getName() + "]'s state is not NORMAL. "
+                        + "Do not allow doing DROP ops");
+            }
+
             String mvName = dropMaterializedViewStmt.getMvName();
             // Step1: check drop mv index operation
             checkDropMaterializedView(mvName, olapTable);

--- a/fe/fe-core/src/main/java/org/apache/doris/alter/RollupJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/RollupJob.java
@@ -499,20 +499,15 @@ public class RollupJob extends AlterJob {
 
         // set state
         if (olapTable != null) {
-            olapTable.writeLock();
-            try {
-                Preconditions.checkState(olapTable.getId() == tableId);
-                for (Partition partition : olapTable.getPartitions()) {
-                    if (partition.getState() == PartitionState.ROLLUP) {
-                        partition.setState(PartitionState.NORMAL);
-                    }
+            Preconditions.checkState(olapTable.getId() == tableId);
+            for (Partition partition : olapTable.getPartitions()) {
+                if (partition.getState() == PartitionState.ROLLUP) {
+                    partition.setState(PartitionState.NORMAL);
                 }
+            }
 
-                if (olapTable.getState() == OlapTableState.ROLLUP) {
-                    olapTable.setState(OlapTableState.NORMAL);
-                }
-            } finally {
-                olapTable.writeUnlock();
+            if (olapTable.getState() == OlapTableState.ROLLUP) {
+                olapTable.setState(OlapTableState.NORMAL);
             }
         }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/alter/RollupJobV2.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/RollupJobV2.java
@@ -34,6 +34,7 @@ import org.apache.doris.catalog.OlapTable.OlapTableState;
 import org.apache.doris.catalog.Partition;
 import org.apache.doris.catalog.Replica;
 import org.apache.doris.catalog.Replica.ReplicaState;
+import org.apache.doris.catalog.Table;
 import org.apache.doris.catalog.Tablet;
 import org.apache.doris.catalog.TabletInvertedIndex;
 import org.apache.doris.catalog.TabletMeta;
@@ -42,6 +43,7 @@ import org.apache.doris.common.Config;
 import org.apache.doris.common.FeConstants;
 import org.apache.doris.common.FeMetaVersion;
 import org.apache.doris.common.MarkedCountDownLatch;
+import org.apache.doris.common.MetaNotFoundException;
 import org.apache.doris.common.io.Text;
 import org.apache.doris.common.util.SqlParserUtils;
 import org.apache.doris.common.util.TimeUtils;
@@ -198,9 +200,11 @@ public class RollupJobV2 extends AlterJobV2 implements GsonPostProcessable {
             }
         }
         MarkedCountDownLatch<Long, Long> countDownLatch = new MarkedCountDownLatch<Long, Long>(totalReplicaNum);
-        OlapTable tbl = (OlapTable) db.getTable(tableId);
-        if (tbl == null) {
-            throw new AlterCancelException("Table " + tableId + " does not exist");
+        OlapTable tbl = null;
+        try {
+            tbl = (OlapTable) db.getTableOrThrowException(tableId, Table.TableType.OLAP);
+        } catch (MetaNotFoundException e) {
+            throw new AlterCancelException(e.getMessage());
         }
 
         tbl.readLock();
@@ -336,10 +340,13 @@ public class RollupJobV2 extends AlterJobV2 implements GsonPostProcessable {
             throw new AlterCancelException("Databasee " + dbId + " does not exist");
         }
 
-        OlapTable tbl = (OlapTable) db.getTable(tableId);
-        if (tbl == null) {
-            throw new AlterCancelException("Table " + tableId + " does not exist");
+        OlapTable tbl = null;
+        try {
+            tbl = (OlapTable) db.getTableOrThrowException(tableId, Table.TableType.OLAP);
+        } catch (MetaNotFoundException e) {
+            throw new AlterCancelException(e.getMessage());
         }
+
         tbl.readLock();
         try {
             Preconditions.checkState(tbl.getState() == OlapTableState.ROLLUP);
@@ -408,9 +415,11 @@ public class RollupJobV2 extends AlterJobV2 implements GsonPostProcessable {
             throw new AlterCancelException("Databasee " + dbId + " does not exist");
         }
 
-        OlapTable tbl = (OlapTable) db.getTable(tableId);
-        if (tbl == null) {
-            throw new AlterCancelException("Table " + tableId + " does not exist");
+        OlapTable tbl = null;
+        try {
+            tbl = (OlapTable) db.getTableOrThrowException(tableId, Table.TableType.OLAP);
+        } catch (MetaNotFoundException e) {
+            throw new AlterCancelException(e.getMessage());
         }
 
         if (!rollupBatchTask.isFinished()) {

--- a/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeHandler.java
@@ -1506,7 +1506,7 @@ public class SchemaChangeHandler extends AlterHandler {
             // has to remove here, because check is running every interval, it maybe finished but also in job list
             // some check will failed
             ((SchemaChangeJob) alterJob).deleteAllTableHistorySchema();
-            ((SchemaChangeJob) alterJob).finishJob();
+            alterJob.finishJob();
             jobDone(alterJob);
             Catalog.getCurrentCatalog().getEditLog().logFinishSchemaChange((SchemaChangeJob) alterJob);
         }
@@ -1572,7 +1572,13 @@ public class SchemaChangeHandler extends AlterHandler {
             if (olapTable == null) {
                 continue;
             }
-            selectedJob.getJobInfo(schemaChangeJobInfos, olapTable);
+            olapTable.readLock();
+            try {
+                selectedJob.getJobInfo(schemaChangeJobInfos, olapTable);
+            } finally {
+                olapTable.readUnlock();
+            }
+
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeHandler.java
@@ -1586,7 +1586,7 @@ public class SchemaChangeHandler extends AlterHandler {
     @Override
     public void process(List<AlterClause> alterClauses, String clusterName, Database db, OlapTable olapTable)
             throws UserException {
-
+        Preconditions.checkState(olapTable.isWriteLockHeldByCurrentThread());
         // index id -> index schema
         Map<Long, LinkedList<Column>> indexSchemaMap = new HashMap<>();
         for (Map.Entry<Long, List<Column>> entry : olapTable.getIndexIdToSchema(true).entrySet()) {

--- a/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeHandler.java
@@ -1770,22 +1770,8 @@ public class SchemaChangeHandler extends AlterHandler {
     public void updatePartitionsInMemoryMeta(Database db,
                                              String tableName,
                                              List<String> partitionNames,
-                                             Map<String, String> properties) throws DdlException {
-        OlapTable olapTable;
-        db.readLock();
-        try {
-            olapTable = (OlapTable)db.getTable(tableName);
-            for (String partitionName : partitionNames) {
-                Partition partition = olapTable.getPartition(partitionName);
-                if (partition == null) {
-                    throw new DdlException("Partition[" + partitionName + "] does not exist in " +
-                            "table[" + olapTable.getName() + "]");
-                }
-            }
-        } finally {
-            db.readUnlock();
-        }
-
+                                             Map<String, String> properties) throws DdlException, MetaNotFoundException {
+        OlapTable olapTable = (OlapTable) db.getTableOrThrowException(tableName, Table.TableType.OLAP);
         boolean isInMemory = Boolean.parseBoolean(properties.get(PropertyAnalyzer.PROPERTIES_INMEMORY));
         if (isInMemory == olapTable.isInMemory()) {
             return;

--- a/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeJob.java
@@ -1104,7 +1104,7 @@ public class SchemaChangeJob extends AlterJob {
 
     @Override
     public void getJobInfo(List<List<Comparable>> jobInfos, OlapTable tbl) {
-        // TODO
+        //TODO
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeJob.java
@@ -920,9 +920,6 @@ public class SchemaChangeJob extends AlterJob {
     @Override
     public void replayInitJob(Database db) {
         OlapTable olapTable = (OlapTable) db.getTable(tableId);
-        if (olapTable == null) {
-            return;
-        }
         olapTable.writeLock();
         try {
             // change the state of table/partition and replica, then add object to related List and Set
@@ -965,9 +962,6 @@ public class SchemaChangeJob extends AlterJob {
     @Override
     public void replayFinishing(Database db) {
         OlapTable olapTable = (OlapTable) db.getTable(tableId);
-        if (olapTable == null) {
-            return;
-        }
         olapTable.writeLock();
         try {
             // set the status to normal

--- a/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeJob.java
@@ -638,7 +638,7 @@ public class SchemaChangeJob extends AlterJob {
         }
 
         Catalog.getCurrentSystemInfo().updateBackendReportVersion(schemaChangeTask.getBackendId(),
-                                                                    reportVersion, dbId);
+                                                                    reportVersion, dbId, tableId);
         setReplicaFinished(indexId, replicaId);
 
         LOG.info("finish schema change replica[{}]. index[{}]. tablet[{}], backend[{}]",

--- a/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeJob.java
@@ -33,9 +33,11 @@ import org.apache.doris.catalog.Replica.ReplicaState;
 import org.apache.doris.catalog.Table;
 import org.apache.doris.catalog.Tablet;
 import org.apache.doris.common.Config;
+import org.apache.doris.common.FeConstants;
 import org.apache.doris.common.FeMetaVersion;
 import org.apache.doris.common.MetaNotFoundException;
 import org.apache.doris.common.io.Text;
+import org.apache.doris.common.util.TimeUtils;
 import org.apache.doris.persist.ReplicaPersistInfo;
 import org.apache.doris.persist.ReplicaPersistInfo.ReplicaOperationType;
 import org.apache.doris.task.AgentBatchTask;
@@ -66,6 +68,7 @@ import org.apache.logging.log4j.Logger;
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -1104,7 +1107,96 @@ public class SchemaChangeJob extends AlterJob {
 
     @Override
     public void getJobInfo(List<List<Comparable>> jobInfos, OlapTable tbl) {
-        //TODO
+        if (changedIndexIdToSchemaVersion == null) {
+            // for compatibility
+            if (state == JobState.FINISHED || state == JobState.CANCELLED) {
+                List<Comparable> jobInfo = new ArrayList<Comparable>();
+                jobInfo.add(tableId); // job id
+                jobInfo.add(tbl.getName()); // table name
+                jobInfo.add(TimeUtils.longToTimeString(createTime));
+                jobInfo.add(TimeUtils.longToTimeString(finishedTime));
+                jobInfo.add(FeConstants.null_string); // index name
+                jobInfo.add(FeConstants.null_string); // index id
+                jobInfo.add(FeConstants.null_string); // origin id
+                jobInfo.add(FeConstants.null_string); // schema version
+                jobInfo.add(-1); // transaction id
+                jobInfo.add(state.name()); // job state
+                jobInfo.add(cancelMsg);
+                jobInfo.add(FeConstants.null_string); // progress
+                jobInfo.add(Config.alter_table_timeout_second); // timeout
+                jobInfos.add(jobInfo);
+                return;
+            }
+
+            // in previous version, changedIndexIdToSchema is set to null
+            // when job is finished or cancelled.
+            // so if changedIndexIdToSchema == null, the job'state must be FINISHED or CANCELLED
+            return;
+        }
+
+        Map<Long, String> indexProgress = new HashMap<Long, String>();
+        Map<Long, String> indexState = new HashMap<Long, String>();
+
+        // calc progress and state for each table
+        for (Long indexId : changedIndexIdToSchemaVersion.keySet()) {
+            if (tbl.getIndexNameById(indexId) == null) {
+                // this index may be dropped, and this should be a FINISHED job, just use a dummy info to show
+                indexState.put(indexId, IndexState.NORMAL.name());
+                indexProgress.put(indexId, "100%");
+            } else {
+                int totalReplicaNum = 0;
+                int finishedReplicaNum = 0;
+                String idxState = IndexState.NORMAL.name();
+                for (Partition partition : tbl.getPartitions()) {
+                    MaterializedIndex index = partition.getIndex(indexId);
+                    if (state == JobState.RUNNING) {
+                        int tableReplicaNum = getTotalReplicaNumByIndexId(indexId);
+                        int tableFinishedReplicaNum = getFinishedReplicaNumByIndexId(indexId);
+                        Preconditions.checkState(!(tableReplicaNum == 0 && tableFinishedReplicaNum == -1));
+                        Preconditions.checkState(tableFinishedReplicaNum <= tableReplicaNum,
+                            tableFinishedReplicaNum + "/" + tableReplicaNum);
+                        totalReplicaNum += tableReplicaNum;
+                        finishedReplicaNum += tableFinishedReplicaNum;
+                    }
+
+                    if (index.getState() != IndexState.NORMAL) {
+                        idxState = index.getState().name();
+                    }
+                }
+
+                indexState.put(indexId, idxState);
+
+                if (Catalog.getCurrentCatalog().isMaster() && state == JobState.RUNNING && totalReplicaNum != 0) {
+                    indexProgress.put(indexId, (finishedReplicaNum * 100 / totalReplicaNum) + "%");
+                } else {
+                    indexProgress.put(indexId, "0%");
+                }
+            }
+        }
+
+        for (Long indexId : changedIndexIdToSchemaVersion.keySet()) {
+            List<Comparable> jobInfo = new ArrayList<Comparable>();
+
+            jobInfo.add(tableId);
+            jobInfo.add(tbl.getName());
+            jobInfo.add(TimeUtils.longToTimeString(createTime));
+            jobInfo.add(TimeUtils.longToTimeString(finishedTime));
+            jobInfo.add(tbl.getIndexNameById(indexId) == null ? FeConstants.null_string : tbl.getIndexNameById(indexId)); // index name
+            jobInfo.add(indexId);
+            jobInfo.add(indexId); // origin index id
+            // index schema version and schema hash
+            jobInfo.add(changedIndexIdToSchemaVersion.get(indexId) + ":" + changedIndexIdToSchemaHash.get(indexId));
+            jobInfo.add(transactionId);
+            jobInfo.add(state.name()); // job state
+            jobInfo.add(cancelMsg);
+            if (state == JobState.RUNNING) {
+                jobInfo.add(indexProgress.get(indexId) == null ? FeConstants.null_string : indexProgress.get(indexId)); // progress
+            } else {
+                jobInfo.add(FeConstants.null_string);
+            }
+            jobInfo.add(Config.alter_table_timeout_second);
+            jobInfos.add(jobInfo);
+        } // end for indexIds
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/DescribeStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/DescribeStmt.java
@@ -113,13 +113,14 @@ public class DescribeStmt extends ShowStmt {
         if (db == null) {
             ErrorReport.reportAnalysisException(ErrorCode.ERR_BAD_DB_ERROR, dbTableName.getDb());
         }
-        db.readLock();
-        try {
-            Table table = db.getTable(dbTableName.getTbl());
-            if (table == null) {
-                ErrorReport.reportAnalysisException(ErrorCode.ERR_BAD_TABLE_ERROR, dbTableName.getTbl());
-            }
 
+        Table table = db.getTable(dbTableName.getTbl());
+        if (table == null) {
+            ErrorReport.reportAnalysisException(ErrorCode.ERR_BAD_TABLE_ERROR, dbTableName.getTbl());
+        }
+
+        table.readLock();
+        try {
             if (!isAllTables) {
                 // show base table schema only
                 String procString = "/dbs/" + db.getId() + "/" + table.getId() + "/" + TableProcDir.INDEX_SCHEMA
@@ -220,7 +221,7 @@ public class DescribeStmt extends ShowStmt {
                 }
             }
         } finally {
-            db.readUnlock();
+            table.readUnlock();
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ExportStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ExportStmt.java
@@ -177,13 +177,13 @@ public class ExportStmt extends StatementBase {
             throw new AnalysisException("Db does not exist. name: " + tblName.getDb());
         }
 
-        db.readLock();
-        try {
-            Table table = db.getTable(tblName.getTbl());
-            if (table == null) {
-                throw new AnalysisException("Table[" + tblName.getTbl() + "] does not exist");
-            }
+        Table table = db.getTable(tblName.getTbl());
+        if (table == null) {
+            throw new AnalysisException("Table[" + tblName.getTbl() + "] does not exist");
+        }
 
+        table.readLock();
+        try {
             if (partitions == null) {
                 return;
             }
@@ -212,10 +212,8 @@ public class ExportStmt extends StatementBase {
                 }
             }
         } finally {
-            db.readUnlock();
+            table.readUnlock();
         }
-
-        return;
     }
 
     private static void checkPath(String path) throws AnalysisException {

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/QueryStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/QueryStmt.java
@@ -17,7 +17,7 @@
 
 package org.apache.doris.analysis;
 
-import org.apache.doris.catalog.Database;
+import org.apache.doris.catalog.Table;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.ErrorReport;
@@ -427,20 +427,20 @@ public abstract class QueryStmt extends StatementBase {
         return resultExprs.get((int) pos - 1).clone();
     }
 
-    public void getWithClauseDbs(Analyzer analyzer, Map<String, Database> dbs, Set<String> parentViewNameSet) throws AnalysisException {
+    public void getWithClauseTables(Analyzer analyzer, Map<Long, Table> tableMap, Set<String> parentViewNameSet) throws AnalysisException {
         if (withClause_ != null) {
-            withClause_.getDbs(analyzer, dbs, parentViewNameSet);
+            withClause_.getTables(analyzer, tableMap, parentViewNameSet);
         }
     }
 
-    // get database used by this query.
+    // get tables used by this query.
     // Set<String> parentViewNameSet contain parent stmt view name
     // to make sure query like "with tmp as (select * from db1.table1) " +
     //                "select a.siteid, b.citycode, a.siteid from (select siteid, citycode from tmp) a " +
     //                "left join (select siteid, citycode from tmp) b on a.siteid = b.siteid;";
     // tmp in child stmt "(select siteid, citycode from tmp)" do not contain with_Clause
     // so need to check is view name by parentViewNameSet. issue link: https://github.com/apache/incubator-doris/issues/4598
-    public abstract void getDbs(Analyzer analyzer, Map<String, Database> dbs, Set<String> parentViewNameSet) throws AnalysisException;
+    public abstract void getTables(Analyzer analyzer, Map<Long, Table> tables, Set<String> parentViewNameSet) throws AnalysisException;
 
     /**
      * UnionStmt and SelectStmt have different implementations.

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/SelectStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/SelectStmt.java
@@ -23,6 +23,7 @@ import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.Database;
 import org.apache.doris.catalog.FunctionSet;
 import org.apache.doris.catalog.OlapTable;
+import org.apache.doris.catalog.Table;
 import org.apache.doris.catalog.Table.TableType;
 import org.apache.doris.catalog.Type;
 import org.apache.doris.catalog.View;
@@ -60,6 +61,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.SortedMap;
 import java.util.UUID;
 
 /**
@@ -276,15 +278,16 @@ public class SelectStmt extends QueryStmt {
     }
 
     @Override
-    public void getDbs(Analyzer analyzer, Map<String, Database> dbs, Set<String> parentViewNameSet) throws AnalysisException {
-        getWithClauseDbs(analyzer, dbs, parentViewNameSet);
+    public void getTables(Analyzer analyzer, Map<Long, Table> tableMap, Set<String> parentViewNameSet) throws AnalysisException {
+        getWithClauseTables(analyzer, tableMap, parentViewNameSet);
         for (TableRef tblRef : fromClause_) {
             if (tblRef instanceof InlineViewRef) {
                 // Inline view reference
                 QueryStmt inlineStmt = ((InlineViewRef) tblRef).getViewStmt();
-                inlineStmt.getDbs(analyzer, dbs, parentViewNameSet);
+                inlineStmt.getTables(analyzer, tableMap, parentViewNameSet);
             } else {
                 String dbName = tblRef.getName().getDb();
+                String tableName = tblRef.getName().getTbl();
                 if (Strings.isNullOrEmpty(dbName)) {
                     dbName = analyzer.getDefaultDb();
                 } else {
@@ -296,23 +299,28 @@ public class SelectStmt extends QueryStmt {
                 if (Strings.isNullOrEmpty(dbName)) {
                     ErrorReport.reportAnalysisException(ErrorCode.ERR_NO_DB_ERROR);
                 }
-
+                if (Strings.isNullOrEmpty(tableName)) {
+                    ErrorReport.reportAnalysisException(ErrorCode.ERR_BAD_TABLE_ERROR);
+                }
                 Database db = analyzer.getCatalog().getDb(dbName);
                 if (db == null) {
                     ErrorReport.reportAnalysisException(ErrorCode.ERR_BAD_DB_ERROR, dbName);
                 }
+                Table table = db.getTable(tableName);
+                if (table == null) {
+                    ErrorReport.reportAnalysisException(ErrorCode.ERR_BAD_TABLE_ERROR, tableName);
+                }
 
                 // check auth
                 if (!Catalog.getCurrentCatalog().getAuth().checkTblPriv(ConnectContext.get(), dbName,
-                        tblRef.getName().getTbl(),
+                        tableName,
                         PrivPredicate.SELECT)) {
                     ErrorReport.reportAnalysisException(ErrorCode.ERR_TABLEACCESS_DENIED_ERROR, "SELECT",
                             ConnectContext.get().getQualifiedUser(),
                             ConnectContext.get().getRemoteIP(),
                             tblRef.getName().getTbl());
                 }
-
-                dbs.put(dbName, db);
+                tableMap.put(table.getId(), table);
             }
         }
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/SelectStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/SelectStmt.java
@@ -61,7 +61,6 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.SortedMap;
 import java.util.UUID;
 
 /**

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/SetOperationStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/SetOperationStmt.java
@@ -17,7 +17,7 @@
 
 package org.apache.doris.analysis;
 
-import org.apache.doris.catalog.Database;
+import org.apache.doris.catalog.Table;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.UserException;
 import org.apache.doris.rewrite.ExprRewriter;
@@ -172,10 +172,10 @@ public class SetOperationStmt extends QueryStmt {
     public List<Expr> getSetOpsResultExprs() { return setOpsResultExprs_; }
 
     @Override
-    public void getDbs(Analyzer analyzer, Map<String, Database> dbs, Set<String> parentViewNameSet) throws AnalysisException {
-        getWithClauseDbs(analyzer, dbs, parentViewNameSet);
+    public void getTables(Analyzer analyzer, Map<Long, Table> tableMap, Set<String> parentViewNameSet) throws AnalysisException {
+        getWithClauseTables(analyzer, tableMap, parentViewNameSet);
         for (SetOperand op : operands) {
-            op.getQueryStmt().getDbs(analyzer, dbs, parentViewNameSet);
+            op.getQueryStmt().getTables(analyzer, tableMap, parentViewNameSet);
         }
     }
 
@@ -184,7 +184,7 @@ public class SetOperationStmt extends QueryStmt {
      * set operands are set compatible, adding implicit casts if necessary.
      */
     @Override
-    public void analyze(Analyzer analyzer) throws AnalysisException, UserException {
+    public void analyze(Analyzer analyzer) throws UserException {
         if (isAnalyzed()) return;
         super.analyze(analyzer);
         Preconditions.checkState(operands.size() > 0);

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowDataStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowDataStmt.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.analysis;
 
+import com.google.common.collect.Lists;
 import org.apache.doris.catalog.Catalog;
 import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.Database;
@@ -41,7 +42,6 @@ import com.google.common.base.Strings;
 
 import java.util.Arrays;
 import java.util.Comparator;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.SortedSet;
@@ -73,8 +73,7 @@ public class ShowDataStmt extends ShowStmt {
     public ShowDataStmt(String dbName, String tableName) {
         this.dbName = dbName;
         this.tableName = tableName;
-
-        this.totalRows = new LinkedList<List<String>>();
+        this.totalRows = Lists.newArrayList();
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowDataStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowDataStmt.java
@@ -78,7 +78,7 @@ public class ShowDataStmt extends ShowStmt {
     }
 
     @Override
-    public void analyze(Analyzer analyzer) throws AnalysisException, UserException {
+    public void analyze(Analyzer analyzer) throws UserException {
         super.analyze(analyzer);
         if (Strings.isNullOrEmpty(dbName)) {
             dbName = analyzer.getDefaultDb();
@@ -181,16 +181,7 @@ public class ShowDataStmt extends ShowStmt {
                         tableName);
             }
 
-            Table table = db.getTable(tableName);
-            if (table == null) {
-                ErrorReport.reportAnalysisException(ErrorCode.ERR_BAD_TABLE_ERROR, tableName);
-            }
-
-            if (table.getType() != TableType.OLAP) {
-                ErrorReport.reportAnalysisException(ErrorCode.ERR_NOT_OLAP_TABLE, tableName);
-            }
-
-            OlapTable olapTable = (OlapTable) table;
+            OlapTable olapTable = (OlapTable) db.getTableOrThrowException(tableName, TableType.OLAP);
             int i = 0;
             long totalSize = 0;
             long totalReplicaCount = 0;

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/WithClause.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/WithClause.java
@@ -109,6 +109,7 @@ public class WithClause implements ParseNode {
     public void getTables(Analyzer analyzer, Map<Long, Table> tableMap, Set<String> parentViewNameSet) throws AnalysisException {
         for (View view : views_) {
             QueryStmt stmt = view.getQueryStmt();
+            parentViewNameSet.add(view.getName());
             stmt.getTables(analyzer, tableMap, parentViewNameSet);
         }
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/WithClause.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/WithClause.java
@@ -22,7 +22,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.doris.catalog.Database;
+import org.apache.doris.catalog.Table;
 import org.apache.doris.catalog.View;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.UserException;
@@ -106,11 +106,10 @@ public class WithClause implements ParseNode {
         for (View view: views_) view.getQueryStmt().reset();
     }
 
-    public void getDbs(Analyzer analyzer, Map<String, Database> dbs, Set<String> parentViewNameSet) throws AnalysisException {
+    public void getTables(Analyzer analyzer, Map<Long, Table> tableMap, Set<String> parentViewNameSet) throws AnalysisException {
         for (View view : views_) {
             QueryStmt stmt = view.getQueryStmt();
-            parentViewNameSet.add(view.getName());
-            stmt.getDbs(analyzer, dbs, parentViewNameSet);
+            stmt.getTables(analyzer, tableMap, parentViewNameSet);
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/backup/RestoreJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/backup/RestoreJob.java
@@ -1392,12 +1392,7 @@ public class RestoreJob extends AbstractJob {
                 } finally {
                     restoreTbl.writeUnlock();
                 }
-                db.writeLock();
-                try {
-                    db.dropTable(restoreTbl.getName());
-                } finally {
-                    db.writeUnlock();
-                }
+                db.dropTableWithLock(restoreTbl.getName());
             }
 
             // remove restored partitions

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Catalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Catalog.java
@@ -4747,7 +4747,7 @@ public class Catalog {
                 // use try lock to avoid blocking a long time.
                 // if block too long, backend report rpc will timeout.
                 if (!olapTable.tryWriteLock(Table.TRY_LOCK_TIMEOUT_MS, TimeUnit.MILLISECONDS)) {
-                    LOG.warn("try get db {} writelock but failed when checking backend storage medium", dbId);
+                    LOG.warn("try get table {} writelock but failed when checking backend storage medium", table.getName());
                     continue;
                 }
                 Preconditions.checkState(olapTable.isWriteLockHeldByCurrentThread());

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Catalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Catalog.java
@@ -5436,9 +5436,9 @@ public class Catalog {
                 properties.get(PropertyAnalyzer.PROPERTIES_REPLICATION_NUM));
     }
 
-    // The caller need to hold the db write lock
+    // The caller need to hold the table write lock
     public void modifyTableInMemoryMeta(Database db, OlapTable table, Map<String, String> properties) {
-        Preconditions.checkArgument(db.isWriteLockHeldByCurrentThread());
+        Preconditions.checkArgument(table.isWriteLockHeldByCurrentThread());
         TableProperty tableProperty = table.getTableProperty();
         if (tableProperty == null) {
             tableProperty = new TableProperty(properties);

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Catalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Catalog.java
@@ -5055,19 +5055,19 @@ public class Catalog {
      * used for handling AlterTableStmt (for client is the ALTER TABLE command).
      * including SchemaChangeHandler and RollupHandler
      */
-    public void alterTable(AlterTableStmt stmt) throws DdlException, UserException {
+    public void alterTable(AlterTableStmt stmt) throws UserException {
         this.alter.processAlterTable(stmt);
     }
 
     /**
      * used for handling AlterViewStmt (the ALTER VIEW command).
      */
-    public void alterView(AlterViewStmt stmt) throws DdlException, UserException {
+    public void alterView(AlterViewStmt stmt) throws UserException {
         this.alter.processAlterView(stmt, ConnectContext.get());
     }
 
     public void createMaterializedView(CreateMaterializedViewStmt stmt)
-            throws AnalysisException, DdlException {
+            throws AnalysisException, DdlException, MetaNotFoundException {
         this.alter.processCreateMaterializedView(stmt);
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Catalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Catalog.java
@@ -5413,7 +5413,7 @@ public class Catalog {
      */
     // The caller need to hold the db write lock
     public void modifyTableReplicationNum(Database db, OlapTable table, Map<String, String> properties) throws DdlException {
-        Preconditions.checkArgument(db.isWriteLockHeldByCurrentThread());
+        Preconditions.checkArgument(table.isWriteLockHeldByCurrentThread());
         String defaultReplicationNumName = "default."+ PropertyAnalyzer.PROPERTIES_REPLICATION_NUM;
         PartitionInfo partitionInfo = table.getPartitionInfo();
         if (partitionInfo.getType() == PartitionType.RANGE) {
@@ -5448,7 +5448,7 @@ public class Catalog {
      */
     // The caller need to hold the db write lock
     public void modifyTableDefaultReplicationNum(Database db, OlapTable table, Map<String, String> properties) {
-        Preconditions.checkArgument(db.isWriteLockHeldByCurrentThread());
+        Preconditions.checkArgument(table.isWriteLockHeldByCurrentThread());
         TableProperty tableProperty = table.getTableProperty();
         if (tableProperty == null) {
             tableProperty = new TableProperty(properties);

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Catalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Catalog.java
@@ -3414,9 +3414,6 @@ public class Catalog {
     public void replayDropPartition(DropPartitionInfo info) {
         Database db = this.getDb(info.getDbId());
         OlapTable olapTable = (OlapTable) db.getTable(info.getTableId());
-        if (olapTable == null) {
-            return;
-        }
         olapTable.writeLock();
         try {
             if (info.isTempPartition()) {
@@ -4301,9 +4298,6 @@ public class Catalog {
     public void replayAlterExteranlTableSchema(String dbName, String tableName, List<Column> newSchema) throws DdlException {
         Database db = this.fullNameToDb.get(dbName);
         Table table = db.getTable(tableName);
-        if (table == null) {
-            throw new DdlException("Do not contain proper table " + tableName + " in refresh table");
-        }
         table.writeLock();
         try {
             table.setNewFullSchema(newSchema);
@@ -4474,18 +4468,12 @@ public class Catalog {
     public void replayDropTable(Database db, long tableId, boolean isForceDrop) {
         Table table = db.getTable(tableId);
         // delete from db meta
-        if (table == null) {
-            return;
-        }
         db.writeLock();
+        table.writeLock();
         try {
-            table.writeLock();
-            try {
-                unprotectDropTable(db, table, isForceDrop);
-            } finally {
-                table.writeUnlock();
-            }
+            unprotectDropTable(db, table, isForceDrop);
         } finally {
+            table.writeUnlock();
             db.writeUnlock();
         }
     }
@@ -4545,9 +4533,6 @@ public class Catalog {
     public void replayAddReplica(ReplicaPersistInfo info) {
         Database db = getDb(info.getDbId());
         OlapTable olapTable = (OlapTable) db.getTable(info.getTableId());
-        if (olapTable == null) {
-            return;
-        }
         olapTable.writeLock();
         try {
             unprotectAddReplica(info);
@@ -4559,9 +4544,6 @@ public class Catalog {
     public void replayUpdateReplica(ReplicaPersistInfo info) {
         Database db = getDb(info.getDbId());
         OlapTable olapTable = (OlapTable) db.getTable(info.getTableId());
-        if (olapTable == null) {
-            return;
-        }
         olapTable.writeLock();
         try {
             unprotectUpdateReplica(info);
@@ -4582,9 +4564,6 @@ public class Catalog {
     public void replayDeleteReplica(ReplicaPersistInfo info) {
         Database db = getDb(info.getDbId());
         OlapTable tbl = (OlapTable) db.getTable(info.getTableId());
-        if (tbl == null) {
-            return;
-        }
         tbl.writeLock();
         try {
             unprotectDeleteReplica(info);

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Catalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Catalog.java
@@ -2043,7 +2043,7 @@ public class Catalog {
             if (!InfoSchemaDb.isInfoSchemaDb(dbName)) {
                 checksum ^= entry.getKey();
                 db.readLock();
-                List<Table> tableList = db.getOrderedTablesById();
+                List<Table> tableList = db.getTablesOnIdOrder();
                 for (Table table : tableList) {
                     table.readLock();
                 }
@@ -2764,17 +2764,12 @@ public class Catalog {
 
     public void unprotectDropDb(Database db, boolean isForeDrop) {
         for (Table table : db.getTables()) {
-<<<<<<< HEAD:fe/fe-core/src/main/java/org/apache/doris/catalog/Catalog.java
-            unprotectDropTable(db, table.getId(), isForeDrop);
-=======
             table.writeLock();
             try {
-                unprotectDropTable(db, table);
+                unprotectDropTable(db, table, isForeDrop);
             } finally {
                 table.writeUnlock();
             }
-
->>>>>>> use table lock to replace db lock:fe/src/main/java/org/apache/doris/catalog/Catalog.java
         }
     }
 
@@ -6349,7 +6344,7 @@ public class Catalog {
             // lock all dbs
             for (Database db : lockedDbMap.values()) {
                 db.readLock();
-                List<Table> tableList = db.getOrderedTablesById();
+                List<Table> tableList = db.getTablesOnIdOrder();
                 for (Table table : tableList) {
                     table.readLock();
                 }
@@ -6372,7 +6367,7 @@ public class Catalog {
             // unlock all
             load.readUnlock();
             for (Database db : lockedDbMap.values()) {
-                List<Table> tableList = db.getOrderedTablesById();
+                List<Table> tableList = db.getTablesOnIdOrder();
                 for (int i = tableList.size() - 1; i >= 0; i--) {
                     tableList.get(i).readUnlock();
                 }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Catalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Catalog.java
@@ -4308,7 +4308,16 @@ public class Catalog {
 
     public void replayAlterExteranlTableSchema(String dbName, String tableName, List<Column> newSchema) throws DdlException {
         Database db = this.fullNameToDb.get(dbName);
-        db.allterExternalTableSchemaWithLock(tableName, newSchema);
+        Table table = db.getTable(tableName);
+        if (table == null) {
+            throw new DdlException("Do not contain proper table " + tableName + " in refresh table");
+        }
+        table.writeLock();
+        try {
+            table.setNewFullSchema(newSchema);
+        } finally {
+            table.writeUnlock();
+        }
     }
 
     private void createTablets(String clusterName, MaterializedIndex index, ReplicaState replicaState,

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/CatalogRecycleBin.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/CatalogRecycleBin.java
@@ -551,7 +551,7 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
         LOG.info("recover partition[{}]", partitionId);
     }
 
-    // The caller should keep db write lock
+    // The caller should keep table write lock
     public synchronized void replayRecoverPartition(OlapTable table, long partitionId) {
         Iterator<Map.Entry<Long, RecyclePartitionInfo>> iterator = idToPartition.entrySet().iterator();
         while (iterator.hasNext()) {

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Database.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Database.java
@@ -422,13 +422,13 @@ public class Database extends MetaObject implements Writable {
      * @param tableType
      * @return
      */
-    public Table getTableOrThrowException(String tableName, TableType tableType) throws UserException {
+    public Table getTableOrThrowException(String tableName, TableType tableType) throws MetaNotFoundException {
         Table table = nameToTable.get(tableName);
         if(table == null) {
             throw new MetaNotFoundException("unknown table, table=" + tableName);
         }
         if (table.getType() != tableType) {
-            throw new UserException("table type is not " + tableType + ", table=" + tableName + "type=" + table.getClass());
+            throw new MetaNotFoundException("table type is not " + tableType + ", table=" + tableName + "type=" + table.getClass());
         }
         return table;
     }
@@ -449,13 +449,13 @@ public class Database extends MetaObject implements Writable {
      * @param tableType
      * @return
      */
-    public Table getTableOrThrowException(long tableId, TableType tableType) throws UserException {
+    public Table getTableOrThrowException(long tableId, TableType tableType) throws MetaNotFoundException {
         Table table = idToTable.get(tableId);
         if(table == null) {
             throw new MetaNotFoundException("unknown table, tableId=" + tableId);
         }
         if (table.getType() != tableType) {
-            throw new UserException("table type is not " + tableType + ", type=" + table.getClass());
+            throw new MetaNotFoundException("table type is not " + tableType + ", type=" + table.getClass());
         }
         return table;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Database.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Database.java
@@ -154,6 +154,10 @@ public class Database extends MetaObject implements Writable {
         }
     }
 
+    public boolean isWriteLockHeldByCurrentThread() {
+        return this.rwLock.writeLock().isHeldByCurrentThread();
+    }
+
     public long getId() {
         return id;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Database.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Database.java
@@ -328,19 +328,6 @@ public class Database extends MetaObject implements Writable {
         return result;
     }
 
-    public void dropTableWithLock(String tableName) {
-        writeLock();
-        try {
-            Table table = this.nameToTable.get(tableName);
-            if (table != null) {
-                this.nameToTable.remove(tableName);
-                this.idToTable.remove(table.getId());
-            }
-        } finally {
-            writeUnlock();
-        }
-    }
-
     public void dropTable(String tableName) {
         Table table = this.nameToTable.get(tableName);
         if (table != null) {

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Database.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Database.java
@@ -366,8 +366,9 @@ public class Database extends MetaObject implements Writable {
         for (Long tableId : tableIdList) {
             Table table = idToTable.get(tableId);
             if (table == null) {
-                throw new MetaNotFoundException("unknown table, table=" + tableId);
+                throw new MetaNotFoundException("unknown table, tableId=" + tableId);
             }
+            tableList.add(table);
         }
         if (tableList.size() > 1) {
             return tableList.stream().sorted(Comparator.comparing(Table::getId)).collect(Collectors.toList());
@@ -405,7 +406,7 @@ public class Database extends MetaObject implements Writable {
             throw new MetaNotFoundException("unknown table, table=" + tableName);
         }
         if (table.getType() != tableType) {
-            throw new MetaNotFoundException("table type is not " + tableType + ", table=" + tableName + "type=" + table.getClass());
+            throw new MetaNotFoundException("table type is not " + tableType + ", table=" + tableName + ", type=" + table.getClass());
         }
         return table;
     }
@@ -432,7 +433,7 @@ public class Database extends MetaObject implements Writable {
             throw new MetaNotFoundException("unknown table, tableId=" + tableId);
         }
         if (table.getType() != tableType) {
-            throw new MetaNotFoundException("table type is not " + tableType + ", type=" + table.getClass());
+            throw new MetaNotFoundException("table type is not " + tableType + ", tableId=" + tableId +", type=" + table.getClass());
         }
         return table;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Database.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Database.java
@@ -433,7 +433,7 @@ public class Database extends MetaObject implements Writable {
             throw new MetaNotFoundException("unknown table, tableId=" + tableId);
         }
         if (table.getType() != tableType) {
-            throw new MetaNotFoundException("table type is not " + tableType + ", tableId=" + tableId +", type=" + table.getClass());
+            throw new MetaNotFoundException("table type is not " + tableType + ", tableId=" + tableId + ", type=" + table.getClass());
         }
         return table;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Database.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Database.java
@@ -132,7 +132,7 @@ public class Database extends MetaObject implements Writable {
             return false;
         }
     }
-
+    
     public void readUnlock() {
         this.rwLock.readLock().unlock();
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Database.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Database.java
@@ -132,7 +132,7 @@ public class Database extends MetaObject implements Writable {
             return false;
         }
     }
-    
+
     public void readUnlock() {
         this.rwLock.readLock().unlock();
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Database.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Database.java
@@ -319,6 +319,19 @@ public class Database extends MetaObject implements Writable {
         return result;
     }
 
+    public void dropTableWithLock(String tableName) {
+        writeLock();
+        try {
+            Table table = this.nameToTable.get(tableName);
+            if (table != null) {
+                this.nameToTable.remove(tableName);
+                this.idToTable.remove(table.getId());
+            }
+        } finally {
+            writeUnlock();
+        }
+    }
+
     public void dropTable(String tableName) {
         Table table = this.nameToTable.get(tableName);
         if (table != null) {

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Database.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Database.java
@@ -124,15 +124,6 @@ public class Database extends MetaObject implements Writable {
         this.rwLock.readLock().lock();
     }
 
-    public boolean tryReadLock(long timeout, TimeUnit unit) {
-        try {
-            return this.rwLock.readLock().tryLock(timeout, unit);
-        } catch (InterruptedException e) {
-            LOG.warn("failed to try read lock at db[" + id + "]", e);
-            return false;
-        }
-    }
-
     public void readUnlock() {
         this.rwLock.readLock().unlock();
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Database.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Database.java
@@ -414,7 +414,7 @@ public class Database extends MetaObject implements Writable {
             throw new MetaNotFoundException("unknown table, table=" + tableName);
         }
         if (table.getType() != tableType) {
-            throw new UserException("table type is not " + tableType + ", type=" + table.getClass());
+            throw new UserException("table type is not " + tableType + ", table=" + tableName + "type=" + table.getClass());
         }
         return table;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Database.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Database.java
@@ -154,10 +154,6 @@ public class Database extends MetaObject implements Writable {
         }
     }
 
-    public boolean isWriteLockHeldByCurrentThread() {
-        return this.rwLock.writeLock().isHeldByCurrentThread();
-    }
-
     public long getId() {
         return id;
     }
@@ -311,20 +307,6 @@ public class Database extends MetaObject implements Writable {
                 }
             }
             return result;
-        } finally {
-            writeUnlock();
-        }
-    }
-
-    public void allterExternalTableSchemaWithLock(String tableName, List<Column> newSchema) throws DdlException{
-        writeLock();
-        try {
-            if (!nameToTable.containsKey(tableName)) {
-                throw new DdlException("Do not contain proper table " + tableName + " in refresh table");
-            } else {
-                Table table = nameToTable.get(tableName);
-                table.setNewFullSchema(newSchema);
-            }
         } finally {
             writeUnlock();
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Database.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Database.java
@@ -368,7 +368,7 @@ public class Database extends MetaObject implements Writable {
     }
 
     // tables must get read or write table in fixed order to escape potential dead lock
-    public List<Table> getOrderedTablesById() {
+    public List<Table> getTablesOnIdOrder() {
         return idToTable.values().stream()
                 .sorted(Comparator.comparing(Table::getId))
                 .collect(Collectors.toList());
@@ -384,10 +384,24 @@ public class Database extends MetaObject implements Writable {
         return views;
     }
 
+    public List<Table> getTablesOnIdOrderOrThrowException(List<Long> tableIdList) throws MetaNotFoundException {
+        List<Table> tableList = Lists.newArrayList();
+        for (Long tableId : tableIdList) {
+            Table table = idToTable.get(tableId);
+            if (table == null) {
+                throw new MetaNotFoundException("unknown table, table=" + tableId);
+            }
+        }
+        if (tableList.size() > 1) {
+            return tableList.stream().sorted(Comparator.comparing(Table::getId)).collect(Collectors.toList());
+        }
+        return tableList;
+    }
+
     public Set<String> getTableNamesWithLock() {
         readLock();
         try {
-            return new HashSet<String>(this.nameToTable.keySet());
+            return new HashSet<>(this.nameToTable.keySet());
         } finally {
             readUnlock();
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Database.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Database.java
@@ -367,7 +367,7 @@ public class Database extends MetaObject implements Writable {
         return new ArrayList<>(idToTable.values());
     }
 
-    // tables must get read or write table in fixed order to escape potential dead lock
+    // tables must get read or write table in fixed order to avoid potential dead lock
     public List<Table> getTablesOnIdOrder() {
         return idToTable.values().stream()
                 .sorted(Comparator.comparing(Table::getId))

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/InfoSchemaDb.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/InfoSchemaDb.java
@@ -50,11 +50,6 @@ public class InfoSchemaDb extends Database {
     }
 
     @Override
-    public void dropTableWithLock(String name) {
-        // Do nothing.
-    }
-
-    @Override
     public void dropTable(String name) {
         // Do nothing.
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/MetadataViewer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/MetadataViewer.java
@@ -55,14 +55,14 @@ public class MetadataViewer {
         if (db == null) {
             throw new DdlException("Database " + dbName + " does not exist");
         }
-        
-        db.readLock();
+
+        Table tbl = db.getTable(tblName);
+        if (tbl == null || tbl.getType() != TableType.OLAP) {
+            throw new DdlException("Table does not exist or is not OLAP table: " + tblName);
+        }
+
+        tbl.readLock();
         try {
-            Table tbl = db.getTable(tblName);
-            if (tbl == null || tbl.getType() != TableType.OLAP) {
-                throw new DdlException("Table does not exist or is not OLAP table: " + tblName);
-            }
-            
             OlapTable olapTable = (OlapTable) tbl;
             
             if (partitions.isEmpty()) {
@@ -146,7 +146,7 @@ public class MetadataViewer {
                 }
             }
         } finally {
-            db.readUnlock();
+            tbl.readUnlock();
         }
 
         return result;
@@ -181,12 +181,13 @@ public class MetadataViewer {
             throw new DdlException("Database " + dbName + " does not exist");
         }
 
-        db.readLock();
+        Table tbl = db.getTable(tblName);
+        if (tbl == null || tbl.getType() != TableType.OLAP) {
+            throw new DdlException("Table does not exist or is not OLAP table: " + tblName);
+        }
+
+        tbl.readLock();
         try {
-            Table tbl = db.getTable(tblName);
-            if (tbl == null || tbl.getType() != TableType.OLAP) {
-                throw new DdlException("Table does not exist or is not OLAP table: " + tblName);
-            }
 
             OlapTable olapTable = (OlapTable) tbl;
 
@@ -242,7 +243,7 @@ public class MetadataViewer {
             }
             
         } finally {
-            db.readUnlock();
+            tbl.readUnlock();
         }
 
         return result;

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
@@ -101,7 +101,7 @@ public class OlapTable extends Table {
         WAITING_STABLE
     }
 
-    private OlapTableState state;
+    private volatile OlapTableState state;
 
     // index id -> index meta
     private Map<Long, MaterializedIndexMeta> indexIdToMeta = Maps.newHashMap();

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Table.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Table.java
@@ -49,6 +49,10 @@ import java.util.stream.Collectors;
 public class Table extends MetaObject implements Writable {
     private static final Logger LOG = LogManager.getLogger(Table.class);
 
+    // empirical value.
+    // assume that the time a lock is held by thread is less then 100ms
+    public static final long TRY_LOCK_TIMEOUT_MS = 100L;
+
     public enum TableType {
         MYSQL,
         ODBC,

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Table.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Table.java
@@ -62,7 +62,7 @@ public class Table extends MetaObject implements Writable {
     }
 
     protected long id;
-    protected String name;
+    protected volatile String name;
     protected TableType type;
     protected long createTime;
     protected ReentrantReadWriteLock rwLock;

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/TabletStatMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/TabletStatMgr.java
@@ -86,14 +86,7 @@ public class TabletStatMgr extends MasterDaemon {
             if (db == null) {
                 continue;
             }
-            List<Table> tableList = null;
-            db.readLock();
-            try {
-                tableList = db.getTables();
-            } finally {
-                db.readUnlock();
-            }
-
+            List<Table> tableList = db.getTables();
             for (Table table : tableList) {
                 if (table.getType() != TableType.OLAP) {
                     continue;

--- a/fe/fe-core/src/main/java/org/apache/doris/clone/ColocateTableBalancer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/ColocateTableBalancer.java
@@ -251,8 +251,8 @@ public class ColocateTableBalancer extends MasterDaemon {
             } else {
                 colocateIndex.markGroupUnstable(groupId, true);
             }
-        }
-    } // end for groups
+        } // end for groups
+    }
 
     /*
      * The balance logic is as follow:
@@ -416,7 +416,7 @@ public class ColocateTableBalancer extends MasterDaemon {
     // change the backend id to backend host
     // return null if some of backends do not exist
     private List<List<String>> getHostsPerBucketSeq(List<List<Long>> backendsPerBucketSeq,
-            SystemInfoService infoService) {
+                                                    SystemInfoService infoService) {
         List<List<String>> hostsPerBucketSeq = Lists.newArrayList();
         for (List<Long> backendIds : backendsPerBucketSeq) {
             List<String> hosts = Lists.newArrayList();
@@ -434,7 +434,7 @@ public class ColocateTableBalancer extends MasterDaemon {
     }
 
     private List<Map.Entry<Long, Long>> getSortedBackendReplicaNumPairs(List<Long> allAvailBackendIds, Set<Long> unavailBackendIds,
-                ClusterLoadStatistic statistic, List<Long> flatBackendsPerBucketSeq) {
+                                                                        ClusterLoadStatistic statistic, List<Long> flatBackendsPerBucketSeq) {
         // backend id -> replica num, and sorted by replica num, descending.
         Map<Long, Long> backendToReplicaNum = flatBackendsPerBucketSeq.stream()
                 .collect(Collectors.groupingBy(Function.identity(), Collectors.counting()));

--- a/fe/fe-core/src/main/java/org/apache/doris/clone/ColocateTableBalancer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/ColocateTableBalancer.java
@@ -192,14 +192,13 @@ public class ColocateTableBalancer extends MasterDaemon {
             }
 
             boolean isGroupStable = true;
-            db.readLock();
-            try {
-                OUT: for (Long tableId : tableIds) {
-                    OlapTable olapTable = (OlapTable) db.getTable(tableId);
-                    if (olapTable == null || !colocateIndex.isColocateTable(olapTable.getId())) {
-                        continue;
-                    }
-
+            OUT: for (Long tableId : tableIds) {
+                OlapTable olapTable = (OlapTable) db.getTable(tableId);
+                if (olapTable == null || !colocateIndex.isColocateTable(olapTable.getId())) {
+                    continue;
+                }
+                olapTable.readLock();
+                try {
                     for (Partition partition : olapTable.getPartitions()) {
                         short replicationNum = olapTable.getPartitionInfo().getReplicationNum(partition.getId());
                         long visibleVersion = partition.getVisibleVersion();
@@ -241,19 +240,19 @@ public class ColocateTableBalancer extends MasterDaemon {
                             }
                         }
                     }
-                } // end for tables
-
-                // mark group as stable or unstable
-                if (isGroupStable) {
-                    colocateIndex.markGroupStable(groupId, true);
-                } else {
-                    colocateIndex.markGroupUnstable(groupId, true);
+                } finally {
+                    olapTable.readUnlock();
                 }
-            } finally {
-                db.readUnlock();
+            } // end for tables
+
+            // mark group as stable or unstable
+            if (isGroupStable) {
+                colocateIndex.markGroupStable(groupId, true);
+            } else {
+                colocateIndex.markGroupUnstable(groupId, true);
             }
-        } // end for groups
-    }
+        }
+    } // end for groups
 
     /*
      * The balance logic is as follow:

--- a/fe/fe-core/src/main/java/org/apache/doris/clone/TabletScheduler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/TabletScheduler.java
@@ -458,13 +458,12 @@ public class TabletScheduler extends MasterDaemon {
         }
 
         Pair<TabletStatus, TabletSchedCtx.Priority> statusPair;
-        db.writeLock();
+        OlapTable tbl = (OlapTable) db.getTable(tabletCtx.getTblId());
+        if (tbl == null) {
+            throw new SchedException(Status.UNRECOVERABLE, "tbl does not exist");
+        }
+        tbl.writeLock();
         try {
-            OlapTable tbl = (OlapTable) db.getTable(tabletCtx.getTblId());
-            if (tbl == null) {
-                throw new SchedException(Status.UNRECOVERABLE, "tbl does not exist");
-            }
-
             boolean isColocateTable = colocateTableIndex.isColocateTable(tbl.getId());
 
             OlapTableState tableState = tbl.getState();
@@ -553,7 +552,7 @@ public class TabletScheduler extends MasterDaemon {
 
             handleTabletByTypeAndStatus(statusPair.first, tabletCtx, batchTask);
         } finally {
-            db.writeUnlock();
+            tbl.writeUnlock();
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/common/proc/EsPartitionsProcDir.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/proc/EsPartitionsProcDir.java
@@ -62,7 +62,7 @@ public class EsPartitionsProcDir implements ProcDirInterface {
 
         // get info
         List<List<Comparable>> partitionInfos = new ArrayList<List<Comparable>>();
-        db.readLock();
+        esTable.readLock();
         try {
             RangePartitionInfo rangePartitionInfo = null;
             if (esTable.getPartitionInfo().getType() == PartitionType.RANGE) {
@@ -97,7 +97,7 @@ public class EsPartitionsProcDir implements ProcDirInterface {
                 partitionInfos.add(partitionInfo);
             }
         } finally {
-            db.readUnlock();
+            esTable.readUnlock();
         }
 
         // set result
@@ -121,13 +121,7 @@ public class EsPartitionsProcDir implements ProcDirInterface {
 
     @Override
     public ProcNodeInterface lookup(String indexName) throws AnalysisException {
-
-        db.readLock();
-        try {
-            return new EsShardProcDir(db, esTable, indexName);
-        } finally {
-            db.readUnlock();
-        }
+        return new EsShardProcDir(db, esTable, indexName);
     }
 
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/common/proc/EsShardProcDir.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/proc/EsShardProcDir.java
@@ -52,7 +52,7 @@ public class EsShardProcDir implements ProcDirInterface {
         Preconditions.checkNotNull(indexName);
 
         List<List<Comparable>> shardInfos = new ArrayList<List<Comparable>>();
-        db.readLock();
+        esTable.readLock();
         try {
             // get infos
             EsShardPartitions esShardPartitions = esTable.getEsTablePartitions().getEsShardPartitions(indexName);
@@ -75,7 +75,7 @@ public class EsShardProcDir implements ProcDirInterface {
                 }
             }
         } finally {
-            db.readUnlock();
+            esTable.readUnlock();
         }
 
         // sort by tabletId, replicaId

--- a/fe/fe-core/src/main/java/org/apache/doris/common/proc/IndexInfoProcDir.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/proc/IndexInfoProcDir.java
@@ -58,7 +58,7 @@ public class IndexInfoProcDir implements ProcDirInterface {
 
         BaseProcResult result = new BaseProcResult();
         result.setNames(TITLE_NAMES);
-        db.readLock();
+        table.readLock();
         try {
             if (table.getType() == TableType.OLAP) {
                 OlapTable olapTable = (OlapTable) table;
@@ -97,7 +97,7 @@ public class IndexInfoProcDir implements ProcDirInterface {
 
             return result;
         } finally {
-            db.readUnlock();
+            table.readUnlock();
         }
     }
 
@@ -118,7 +118,7 @@ public class IndexInfoProcDir implements ProcDirInterface {
             throw new AnalysisException("Invalid index id format: " + idxIdStr);
         }
 
-        db.readLock();
+        table.readLock();
         try {
             List<Column> schema = null;
             Set<String> bfColumns = null;
@@ -134,7 +134,7 @@ public class IndexInfoProcDir implements ProcDirInterface {
             }
             return new IndexSchemaProcNode(schema, bfColumns);
         } finally {
-            db.readUnlock();
+            table.readUnlock();
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/common/proc/IndicesProcDir.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/proc/IndicesProcDir.java
@@ -61,7 +61,7 @@ public class IndicesProcDir implements ProcDirInterface {
         BaseProcResult result = new BaseProcResult();
         // get info
         List<List<Comparable>> indexInfos = new ArrayList<List<Comparable>>();
-        db.readLock();
+        olapTable.readLock();
         try {
             result.setNames(TITLE_NAMES);
             for (MaterializedIndex materializedIndex : partition.getMaterializedIndices(IndexExtState.ALL)) {
@@ -75,7 +75,7 @@ public class IndicesProcDir implements ProcDirInterface {
             }
 
         } finally {
-            db.readUnlock();
+            olapTable.readUnlock();
         }
 
         // sort by index id
@@ -113,15 +113,15 @@ public class IndicesProcDir implements ProcDirInterface {
             throw new AnalysisException("Invalid index id format: " + indexIdStr);
         }
         
-        db.readLock();
+        olapTable.readLock();
         try {
             MaterializedIndex materializedIndex = partition.getIndex(indexId);
             if (materializedIndex == null) {
                 throw new AnalysisException("Index[" + indexId + "] does not exist.");
             }
-            return new TabletsProcDir(db, materializedIndex);
+            return new TabletsProcDir(olapTable, materializedIndex);
         } finally {
-            db.readUnlock();
+            olapTable.readUnlock();
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/common/proc/PartitionsProcDir.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/proc/PartitionsProcDir.java
@@ -207,7 +207,7 @@ public class PartitionsProcDir implements ProcDirInterface {
 
         // get info
         List<List<Comparable>> partitionInfos = new ArrayList<List<Comparable>>();
-        db.readLock();
+        olapTable.readLock();
         try {
             List<Long> partitionIds;
             PartitionInfo tblPartitionInfo = olapTable.getPartitionInfo();
@@ -288,7 +288,7 @@ public class PartitionsProcDir implements ProcDirInterface {
                 partitionInfos.add(partitionInfo);
             }
         } finally {
-            db.readUnlock();
+            olapTable.readUnlock();
         }
         return partitionInfos;
     }
@@ -313,7 +313,7 @@ public class PartitionsProcDir implements ProcDirInterface {
             throw new AnalysisException("Invalid partition id format: " + partitionIdStr);
         }
 
-        db.readLock();
+        olapTable.readLock();
         try {
             Partition partition = olapTable.getPartition(partitionId);
             if (partition == null) {
@@ -322,7 +322,7 @@ public class PartitionsProcDir implements ProcDirInterface {
 
             return new IndicesProcDir(db, olapTable, partition);
         } finally {
-            db.readUnlock();
+            olapTable.readUnlock();
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/common/proc/TablesProcDir.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/proc/TablesProcDir.java
@@ -86,14 +86,7 @@ public class TablesProcDir implements ProcDirInterface {
 
         // get info
         List<List<Comparable>> tableInfos = new ArrayList<List<Comparable>>();
-        List<Table> tableList = null;
-        db.readLock();
-        try {
-            tableList = db.getTables();
-        } finally {
-            db.readUnlock();
-        }
-
+        List<Table> tableList = db.getTables();
         for (Table table : tableList) {
             List<Comparable> tableInfo = new ArrayList<Comparable>();
             int partitionNum = 1;

--- a/fe/fe-core/src/main/java/org/apache/doris/common/proc/TabletsProcDir.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/proc/TabletsProcDir.java
@@ -18,9 +18,9 @@
 package org.apache.doris.common.proc;
 
 import org.apache.doris.catalog.Catalog;
-import org.apache.doris.catalog.Database;
 import org.apache.doris.catalog.MaterializedIndex;
 import org.apache.doris.catalog.Replica;
+import org.apache.doris.catalog.Table;
 import org.apache.doris.catalog.Tablet;
 import org.apache.doris.catalog.TabletInvertedIndex;
 import org.apache.doris.common.AnalysisException;
@@ -51,21 +51,21 @@ public class TabletsProcDir implements ProcDirInterface {
             .add("VersionCount").add("PathHash").add("MetaUrl").add("CompactionStatus")
             .build();
 
-    private Database db;
+    private Table table;
     private MaterializedIndex index;
 
-    public TabletsProcDir(Database db, MaterializedIndex index) {
-        this.db = db;
+    public TabletsProcDir(Table table, MaterializedIndex index) {
+        this.table = table;
         this.index = index;
     }
 
     public List<List<Comparable>> fetchComparableResult(long version, long backendId, Replica.ReplicaState state) {
-        Preconditions.checkNotNull(db);
+        Preconditions.checkNotNull(table);
         Preconditions.checkNotNull(index);
         ImmutableMap<Long, Backend> backendMap = Catalog.getCurrentSystemInfo().getIdToBackend();
 
         List<List<Comparable>> tabletInfos = new ArrayList<List<Comparable>>();
-        db.readLock();
+        table.readLock();
         try {
             // get infos
             for (Tablet tablet : index.getTablets()) {
@@ -143,7 +143,7 @@ public class TabletsProcDir implements ProcDirInterface {
                 }
             }
         } finally {
-            db.readUnlock();
+            table.readUnlock();
         }
         return tabletInfos;
     }
@@ -181,7 +181,7 @@ public class TabletsProcDir implements ProcDirInterface {
 
     @Override
     public ProcNodeInterface lookup(String tabletIdStr) throws AnalysisException {
-        Preconditions.checkNotNull(db);
+        Preconditions.checkNotNull(table);
         Preconditions.checkNotNull(index);
 
         long tabletId = -1L;

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/MetaLockUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/MetaLockUtils.java
@@ -23,6 +23,11 @@ import org.apache.doris.catalog.Table;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
+/**
+ * MetaLockUtils is a helper class to lock and unlock all meta object in a list.
+ * In order to escape dead lock, meta object in list should be sorted in ascending
+ * order by id first, and then MetaLockUtils can lock them.
+ */
 public class MetaLockUtils {
 
     public static void readLockDatabases(List<Database> databaseList) {

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/MetaLockUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/MetaLockUtils.java
@@ -31,65 +31,16 @@ public class MetaLockUtils {
         }
     }
 
-    public static boolean tryReadLockDatabases(List<Database> databaseList, long timeout, TimeUnit unit) {
-        for (int i = 0; i < databaseList.size(); i++) {
-            if (!databaseList.get(i).tryReadLock(timeout, unit)) {
-                for (int j = i - 1; j >= 0; j--) {
-                    databaseList.get(j).readUnlock();
-                }
-                return false;
-            }
-        }
-        return true;
-    }
-
     public static void readUnlockDatabases(List<Database> databaseList) {
         for (int i = databaseList.size() - 1; i >= 0; i--) {
             databaseList.get(i).readUnlock();
         }
     }
 
-    public static void writeLockDatabases(List<Database> databaseList) {
-        for (Database database : databaseList) {
-            database.writeLock();
-        }
-    }
-
-    public static boolean tryWriteLockDatabases(List<Database> databaseList, long timeout, TimeUnit unit) {
-        for (int i = 0; i < databaseList.size(); i++) {
-            if (!databaseList.get(i).tryWriteLock(timeout, unit)) {
-                for (int j = i - 1; j >= 0; j--) {
-                    databaseList.get(j).writeUnlock();
-                }
-                return false;
-            }
-        }
-        return true;
-    }
-
-    public static void writeUnlockDatabases(List<Database> databaseList) {
-        for (int i = databaseList.size() - 1; i >= 0; i--) {
-            databaseList.get(i).writeUnlock();
-        }
-    }
-
-
     public static void readLockTables(List<Table> tableList) {
         for (Table table : tableList) {
             table.readLock();
         }
-    }
-
-    public static boolean tryReadLockTables(List<Table> tableList, long timeout, TimeUnit unit) {
-        for (int i = 0; i < tableList.size(); i++) {
-            if (!tableList.get(i).tryReadLock(timeout, unit)) {
-                for (int j = i - 1; j >= 0; j--) {
-                    tableList.get(j).readUnlock();
-                }
-                return false;
-            }
-        }
-        return true;
     }
 
     public static void readUnlockTables(List<Table> tableList) {

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/MetaLockUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/MetaLockUtils.java
@@ -1,0 +1,125 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.common.util;
+
+import org.apache.doris.catalog.Database;
+import org.apache.doris.catalog.Table;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+public class MetaLockUtils {
+
+    public static void readLockDatabases(List<Database> databaseList) {
+        for (Database database : databaseList) {
+            database.readLock();
+        }
+    }
+
+    public static boolean tryReadLockDatabases(List<Database> databaseList, long timeout, TimeUnit unit) {
+        for (int i = 0; i < databaseList.size(); i++) {
+            if (!databaseList.get(i).tryReadLock(timeout, unit)) {
+                for (int j = i - 1; j >= 0; j--) {
+                    databaseList.get(j).readUnlock();
+                }
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public static void readUnlockDatabases(List<Database> databaseList) {
+        for (int i = databaseList.size() - 1; i >= 0; i--) {
+            databaseList.get(i).readUnlock();
+        }
+    }
+
+    public static void writeLockDatabases(List<Database> databaseList) {
+        for (Database database : databaseList) {
+            database.writeLock();
+        }
+    }
+
+    public static boolean tryWriteLockDatabases(List<Database> databaseList, long timeout, TimeUnit unit) {
+        for (int i = 0; i < databaseList.size(); i++) {
+            if (!databaseList.get(i).tryWriteLock(timeout, unit)) {
+                for (int j = i - 1; j >= 0; j--) {
+                    databaseList.get(j).writeUnlock();
+                }
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public static void writeUnlockDatabases(List<Database> databaseList) {
+        for (int i = databaseList.size() - 1; i >= 0; i--) {
+            databaseList.get(i).writeUnlock();
+        }
+    }
+
+
+    public static void readLockTables(List<Table> tableList) {
+        for (Table table : tableList) {
+            table.readLock();
+        }
+    }
+
+    public static boolean tryReadLockTables(List<Table> tableList, long timeout, TimeUnit unit) {
+        for (int i = 0; i < tableList.size(); i++) {
+            if (!tableList.get(i).tryReadLock(timeout, unit)) {
+                for (int j = i - 1; j >= 0; j--) {
+                    tableList.get(j).readUnlock();
+                }
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public static void readUnlockTables(List<Table> tableList) {
+        for (int i = tableList.size() - 1; i >= 0; i--) {
+            tableList.get(i).readUnlock();
+        }
+    }
+
+    public static void writeLockTables(List<Table> tableList) {
+        for (Table table : tableList) {
+            table.writeLock();
+        }
+    }
+
+    public static boolean tryWriteLockTables(List<Table> tableList, long timeout, TimeUnit unit) {
+        for (int i = 0; i < tableList.size(); i++) {
+            if (!tableList.get(i).tryWriteLock(timeout, unit)) {
+                for (int j = i - 1; j >= 0; j--) {
+                    tableList.get(j).writeUnlock();
+                }
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public static void writeUnlockTables(List<Table> tableList) {
+        for (int i = tableList.size() - 1; i >= 0; i--) {
+            tableList.get(i).writeUnlock();
+        }
+    }
+
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/consistency/CheckConsistencyJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/consistency/CheckConsistencyJob.java
@@ -215,11 +215,11 @@ public class CheckConsistencyJob {
 
         if (state != JobState.RUNNING) {
             // failed to send task. set tablet's checked version and version hash to avoid choosing it again
-            db.writeLock();
+            table.writeLock();
             try {
                 tablet.setCheckedVersion(checkedVersion, checkedVersionHash);
             } finally {
-                db.writeUnlock();
+                table.writeUnlock();
             }
             return false;
         }
@@ -260,13 +260,13 @@ public class CheckConsistencyJob {
         }
 
         boolean isConsistent = true;
-        db.writeLock();
+        Table table = db.getTable(tabletMeta.getTableId());
+        if (table == null) {
+            LOG.warn("table[{}] does not exist", tabletMeta.getTableId());
+            return -1;
+        }
+        table.writeLock();
         try {
-            Table table = db.getTable(tabletMeta.getTableId());
-            if (table == null) {
-                LOG.warn("table[{}] does not exist", tabletMeta.getTableId());
-                return -1;
-            }
             OlapTable olapTable = (OlapTable) table;
 
             Partition partition = olapTable.getPartition(tabletMeta.getPartitionId());
@@ -369,7 +369,7 @@ public class CheckConsistencyJob {
             return 1;
 
         } finally {
-            db.writeUnlock();
+            table.writeUnlock();
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/consistency/CheckConsistencyJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/consistency/CheckConsistencyJob.java
@@ -130,13 +130,14 @@ public class CheckConsistencyJob {
         Tablet tablet = null;
 
         AgentBatchTask batchTask = new AgentBatchTask();
-        db.readLock();
+        Table table = db.getTable(tabletMeta.getTableId());
+        if (table == null) {
+            LOG.debug("table[{}] does not exist", tabletMeta.getTableId());
+            return false;
+        }
+
+        table.readLock();
         try {
-            Table table = db.getTable(tabletMeta.getTableId());
-            if (table == null) {
-                LOG.debug("table[{}] does not exist", tabletMeta.getTableId());
-                return false;
-            }
             OlapTable olapTable = (OlapTable) table;
 
             Partition partition = olapTable.getPartition(tabletMeta.getPartitionId());
@@ -209,7 +210,7 @@ public class CheckConsistencyJob {
             }
 
         } finally {
-            db.readUnlock();
+            table.readUnlock();
         }
 
         if (state != JobState.RUNNING) {

--- a/fe/fe-core/src/main/java/org/apache/doris/consistency/ConsistencyChecker.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/consistency/ConsistencyChecker.java
@@ -371,9 +371,9 @@ public class ConsistencyChecker extends MasterDaemon {
 
     public void replayFinishConsistencyCheck(ConsistencyCheckInfo info, Catalog catalog) {
         Database db = catalog.getDb(info.getDbId());
-        db.writeLock();
+        OlapTable table = (OlapTable) db.getTable(info.getTableId());
+        table.writeLock();
         try {
-            OlapTable table = (OlapTable) db.getTable(info.getTableId());
             Partition partition = table.getPartition(info.getPartitionId());
             MaterializedIndex index = partition.getIndex(info.getIndexId());
             Tablet tablet = index.getTablet(info.getTabletId());
@@ -388,7 +388,7 @@ public class ConsistencyChecker extends MasterDaemon {
 
             tablet.setIsConsistent(info.isConsistent());
         } finally {
-            db.writeUnlock();
+            table.writeUnlock();
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/consistency/ConsistencyChecker.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/consistency/ConsistencyChecker.java
@@ -260,14 +260,7 @@ public class ConsistencyChecker extends MasterDaemon {
         try {
             while ((chosenOne = dbQueue.poll()) != null) {
                 Database db = (Database) chosenOne;
-                List<Table> tables = null;
-                db.readLock();
-                try {
-                    tables = db.getTables();
-                } finally {
-                    db.readUnlock();
-                }
-
+                List<Table> tables = db.getTables();
                 // sort tables
                 Queue<MetaObject> tableQueue = new PriorityQueue<>(Math.max(tables.size(), 1), COMPARATOR);
                 for (Table table : tables) {

--- a/fe/fe-core/src/main/java/org/apache/doris/http/meta/MetaService.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/http/meta/MetaService.java
@@ -330,7 +330,6 @@ public class MetaService {
 
             response.appendContent("dump finished. " + dumpFilePath);
             writeResponse(request, response);
-            return;
         }
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/http/rest/GetDdlStmtAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/http/rest/GetDdlStmtAction.java
@@ -81,17 +81,16 @@ public class GetDdlStmtAction extends RestBaseAction {
         List<String> addPartitionStmt = Lists.newArrayList();
         List<String> createRollupStmt = Lists.newArrayList();
 
-        db.readLock();
+        Table table = db.getTable(tableName);
+        if (table == null) {
+            throw new DdlException("Table[" + tableName + "] does not exist");
+        }
+
+        table.readLock();
         try {
-            Table table = db.getTable(tableName);
-            if (table == null) {
-                throw new DdlException("Table[" + tableName + "] does not exist");
-            }
-
             Catalog.getDdlStmt(table, createTableStmt, addPartitionStmt, createRollupStmt, true, false /* show password */);
-
         } finally {
-            db.readUnlock();
+            table.readUnlock();
         }
 
         Map<String, List<String>> results = Maps.newHashMap();

--- a/fe/fe-core/src/main/java/org/apache/doris/http/rest/MigrationAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/http/rest/MigrationAction.java
@@ -119,13 +119,7 @@ public class MigrationAction extends RestBaseAction {
                 olapTable.readUnlock();
             }
         } else {
-            List<Table> tableList = null;
-            db.readLock();
-            try {
-                tableList = db.getTables();
-            } finally {
-                db.readUnlock();
-            }
+            List<Table> tableList = db.getTables();
 
             // get all olap table
             for (Table table : tableList) {

--- a/fe/fe-core/src/main/java/org/apache/doris/http/rest/ShowDataAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/http/rest/ShowDataAction.java
@@ -48,18 +48,21 @@ public class ShowDataAction extends RestBaseAction {
 
     public long getDataSizeOfDatabase(Database db) {
         long totalSize = 0;
-        db.readLock();
+        long tableSize = 0;
         // sort by table name
         List<Table> tables = db.getTables();
         for (Table table : tables) {
             if (table.getType() != TableType.OLAP) {
                 continue;
             }
-
-            long tableSize = ((OlapTable)table).getDataSize();
+            table.readLock();
+            try {
+                tableSize = ((OlapTable)table).getDataSize();
+            } finally {
+                table.readUnlock();
+            }
             totalSize += tableSize;
         } // end for tables
-        db.readUnlock();
         return totalSize;
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/http/rest/StorageTypeCheckAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/http/rest/StorageTypeCheckAction.java
@@ -67,13 +67,7 @@ public class StorageTypeCheckAction extends RestBaseAction {
         }
 
         JSONObject root = new JSONObject();
-        List<Table> tableList = null;
-        db.readLock();
-        try {
-            tableList = db.getTables();
-        } finally {
-            db.readUnlock();
-        }
+        List<Table> tableList = db.getTables();
 
         for (Table tbl : tableList) {
             if (tbl.getType() != TableType.OLAP) {

--- a/fe/fe-core/src/main/java/org/apache/doris/http/rest/StorageTypeCheckAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/http/rest/StorageTypeCheckAction.java
@@ -67,15 +67,22 @@ public class StorageTypeCheckAction extends RestBaseAction {
         }
 
         JSONObject root = new JSONObject();
+        List<Table> tableList = null;
         db.readLock();
         try {
-            List<Table> tbls = db.getTables();
-            for (Table tbl : tbls) {
-                if (tbl.getType() != TableType.OLAP) {
-                    continue;
-                }
+            tableList = db.getTables();
+        } finally {
+            db.readUnlock();
+        }
 
-                OlapTable olapTbl = (OlapTable) tbl;
+        for (Table tbl : tableList) {
+            if (tbl.getType() != TableType.OLAP) {
+                continue;
+            }
+
+            OlapTable olapTbl = (OlapTable) tbl;
+            olapTbl.readLock();
+            try {
                 JSONObject indexObj = new JSONObject();
                 for (Map.Entry<Long, MaterializedIndexMeta> entry : olapTbl.getIndexIdToMeta().entrySet()) {
                     MaterializedIndexMeta indexMeta = entry.getValue();
@@ -84,9 +91,9 @@ public class StorageTypeCheckAction extends RestBaseAction {
                     }
                 }
                 root.put(tbl.getName(), indexObj);
+            } finally {
+                olapTbl.readUnlock();
             }
-        } finally {
-            db.readUnlock();
         }
 
         // to json response

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/GetDdlStmtAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/GetDdlStmtAction.java
@@ -72,16 +72,16 @@ public class GetDdlStmtAction extends RestBaseController {
         List<String> addPartitionStmt = Lists.newArrayList();
         List<String> createRollupStmt = Lists.newArrayList();
 
-        db.readLock();
-        try {
-            Table table = db.getTable(tableName);
-            if (table == null) {
-                return ResponseEntityBuilder.okWithCommonError("Table[" + tableName + "] does not exist");
-            }
+        Table table = db.getTable(tableName);
+        if (table == null) {
+            return ResponseEntityBuilder.okWithCommonError("Table[" + tableName + "] does not exist");
+        }
 
+        table.readLock();
+        try {
             Catalog.getDdlStmt(table, createTableStmt, addPartitionStmt, createRollupStmt, true, false /* show password */);
         } finally {
-            db.readUnlock();
+            table.readUnlock();
         }
 
         Map<String, List<String>> results = Maps.newHashMap();

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/ShowAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/ShowAction.java
@@ -259,9 +259,13 @@ public class ShowAction extends RestBaseController {
                 if (table.getType() != TableType.OLAP) {
                     continue;
                 }
-
-                long tableSize = ((OlapTable) table).getDataSize();
-                totalSize += tableSize;
+                table.readLock();
+                try {
+                    long tableSize = ((OlapTable) table).getDataSize();
+                    totalSize += tableSize;
+                } finally {
+                    table.readUnlock();
+                }
             } // end for tables
         } finally {
             db.readUnlock();

--- a/fe/fe-core/src/main/java/org/apache/doris/load/AsyncDeleteJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/AsyncDeleteJob.java
@@ -50,7 +50,7 @@ public class AsyncDeleteJob implements Writable {
         FINISHED
     }
 
-    private DeleteState state;
+    private volatile DeleteState state;
 
     private long jobId;
     private long dbId;

--- a/fe/fe-core/src/main/java/org/apache/doris/load/DeleteHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/DeleteHandler.java
@@ -131,16 +131,17 @@ public class DeleteHandler implements Writable {
         try {
             MarkedCountDownLatch<Long, Long> countDownLatch;
             long transactionId = -1;
-            db.readLock();
-            try {
-                Table table = db.getTable(tableName);
-                if (table == null) {
-                    throw new DdlException("Table does not exist. name: " + tableName);
-                }
+            Table table = db.getTable(tableName);
+            if (table == null) {
+                throw new DdlException("Table does not exist. name: " + tableName);
+            }
 
-                if (table.getType() != Table.TableType.OLAP) {
-                    throw new DdlException("Not olap type table. type: " + table.getType().name());
-                }
+            if (table.getType() != Table.TableType.OLAP) {
+                throw new DdlException("Not olap type table. type: " + table.getType().name());
+            }
+
+            table.readLock();
+            try {
                 OlapTable olapTable = (OlapTable) table;
 
                 if (olapTable.getState() != OlapTable.OlapTableState.NORMAL) {
@@ -246,7 +247,7 @@ public class DeleteHandler implements Writable {
                 }
                 throw new DdlException(t.getMessage(), t);
             } finally {
-                db.readUnlock();
+                table.readUnlock();
             }
 
             long timeoutMs = deleteJob.getTimeoutMs();

--- a/fe/fe-core/src/main/java/org/apache/doris/load/DeleteHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/DeleteHandler.java
@@ -117,7 +117,7 @@ public class DeleteHandler implements Writable {
         UNKNOWN
     }
 
-    public void process(DeleteStmt stmt) throws DdlException, QueryStateException {
+    public void process(DeleteStmt stmt) throws DdlException, QueryStateException, MetaNotFoundException {
         String dbName = stmt.getDbName();
         String tableName = stmt.getTableName();
         String partitionName = stmt.getPartitionName();
@@ -131,15 +131,7 @@ public class DeleteHandler implements Writable {
         try {
             MarkedCountDownLatch<Long, Long> countDownLatch;
             long transactionId = -1;
-            Table table = db.getTable(tableName);
-            if (table == null) {
-                throw new DdlException("Table does not exist. name: " + tableName);
-            }
-
-            if (table.getType() != Table.TableType.OLAP) {
-                throw new DdlException("Not olap type table. type: " + table.getType().name());
-            }
-
+            Table table = db.getTableOrThrowException(tableName, Table.TableType.OLAP);
             table.readLock();
             try {
                 OlapTable olapTable = (OlapTable) table;

--- a/fe/fe-core/src/main/java/org/apache/doris/load/DeleteHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/DeleteHandler.java
@@ -117,7 +117,7 @@ public class DeleteHandler implements Writable {
         UNKNOWN
     }
 
-    public void process(DeleteStmt stmt) throws DdlException, QueryStateException, MetaNotFoundException {
+    public void process(DeleteStmt stmt) throws DdlException, QueryStateException {
         String dbName = stmt.getDbName();
         String tableName = stmt.getTableName();
         String partitionName = stmt.getPartitionName();
@@ -131,7 +131,13 @@ public class DeleteHandler implements Writable {
         try {
             MarkedCountDownLatch<Long, Long> countDownLatch;
             long transactionId = -1;
-            Table table = db.getTableOrThrowException(tableName, Table.TableType.OLAP);
+            Table table = null;
+            try {
+               table = db.getTableOrThrowException(tableName, Table.TableType.OLAP);
+            } catch (MetaNotFoundException e) {
+                throw new DdlException(e.getMessage());
+            }
+
             table.readLock();
             try {
                 OlapTable olapTable = (OlapTable) table;

--- a/fe/fe-core/src/main/java/org/apache/doris/load/DeleteJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/DeleteJob.java
@@ -91,15 +91,15 @@ public class DeleteJob extends AbstractTxnStateChangeCallback {
         }
 
         short replicaNum = -1;
-        db.readLock();
+        OlapTable table = (OlapTable) db.getTable(tableId);
+        if (table == null) {
+            throw new MetaNotFoundException("can not find table "+ tableId +" when commit delete");
+        }
+        table.readLock();
         try {
-            OlapTable table = (OlapTable) db.getTable(tableId);
-            if (table == null) {
-                throw new MetaNotFoundException("can not find table "+ tableId +" when commit delete");
-            }
             replicaNum = table.getPartitionInfo().getReplicationNum(partitionId);
         } finally {
-            db.readUnlock();
+            table.readUnlock();
         }
 
         short quorumNum = (short) (replicaNum / 2 + 1);

--- a/fe/fe-core/src/main/java/org/apache/doris/load/ExportJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/ExportJob.java
@@ -191,10 +191,11 @@ public class ExportJob implements Writable {
 
         this.partitions = stmt.getPartitions();
 
-        db.readLock();
+        this.exportTable = db.getTable(stmt.getTblName().getTbl());
+
+        exportTable.readLock();
         try {
             this.dbId = db.getId();
-            this.exportTable = db.getTable(stmt.getTblName().getTbl());
             if (exportTable == null) {
                 throw new DdlException("Table " + stmt.getTblName().getTbl() + " does not exist");
             }
@@ -202,7 +203,7 @@ public class ExportJob implements Writable {
             this.tableName = stmt.getTblName();
             genExecFragment();
         } finally {
-            db.readUnlock();
+            exportTable.readUnlock();
         }
 
         this.sql = stmt.toSql();

--- a/fe/fe-core/src/main/java/org/apache/doris/load/Load.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/Load.java
@@ -2526,7 +2526,8 @@ public class Load {
     public void replayQuorumLoadJob(LoadJob job, Catalog catalog) throws DdlException {
         // TODO: need to call this.writeLock()?
         Database db = catalog.getDb(job.getDbId());
-        db.writeLock();
+        Table table = db.getTable(job.getTableId());
+        table.writeLock();
         try {
             writeLock();
             try {
@@ -2535,7 +2536,7 @@ public class Load {
                 writeUnlock();
             }
         } finally {
-            db.writeUnlock();
+            table.writeUnlock();
         }
     }
 
@@ -2594,7 +2595,8 @@ public class Load {
     public void replayFinishLoadJob(LoadJob job, Catalog catalog) {
         // TODO: need to call this.writeLock()?
         Database db = catalog.getDb(job.getDbId());
-        db.writeLock();
+        Table table = db.getTable(job.getTableId());
+        table.writeLock();
         try {
             writeLock();
             try {
@@ -2603,20 +2605,20 @@ public class Load {
                 writeUnlock();
             }
         } finally {
-            db.writeUnlock();
+            table.writeUnlock();
         }
     }
 
     public void replayClearRollupInfo(ReplicaPersistInfo info, Catalog catalog) {
         Database db = catalog.getDb(info.getDbId());
-        db.writeLock();
+        OlapTable olapTable = (OlapTable) db.getTable(info.getTableId());
+        olapTable.writeLock();
         try {
-            OlapTable olapTable = (OlapTable) db.getTable(info.getTableId());
             Partition partition = olapTable.getPartition(info.getPartitionId());
             MaterializedIndex index = partition.getIndex(info.getIndexId());
             index.clearRollupIndexInfo();
         } finally {
-            db.writeUnlock();
+            olapTable.writeUnlock();
         }
     }
 
@@ -2880,7 +2882,7 @@ public class Load {
                 writeUnlock();
             }
         } else {
-            db.writeLock();
+            table.writeLock();
             try {
                 writeLock();
                 try {
@@ -2971,7 +2973,7 @@ public class Load {
                     writeUnlock();
                 }
             } finally {
-                db.writeUnlock();
+                table.writeUnlock();
             }
         }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/load/LoadChecker.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/LoadChecker.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.load;
 
+import avro.shaded.com.google.common.collect.Lists;
 import org.apache.doris.alter.RollupJob;
 import org.apache.doris.catalog.Catalog;
 import org.apache.doris.catalog.Database;
@@ -339,7 +340,7 @@ public class LoadChecker extends MasterDaemon {
                 }
                 tabletCommitInfos.add(new TabletCommitInfo(tabletId, replica.getBackendId()));
             }
-            globalTransactionMgr.commitTransaction(job.getDbId(), job.getTransactionId(), tabletCommitInfos);
+            globalTransactionMgr.commitTransaction(job.getDbId(), Lists.newArrayList(table), job.getTransactionId(), tabletCommitInfos);
         } catch (TabletQuorumFailedException e) {
             // wait the upper application retry
         } catch (UserException e) {

--- a/fe/fe-core/src/main/java/org/apache/doris/load/LoadJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/LoadJob.java
@@ -39,13 +39,13 @@ import org.apache.doris.thrift.TEtlState;
 import org.apache.doris.thrift.TPriority;
 import org.apache.doris.thrift.TResourceInfo;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
-
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 import java.io.DataInput;
 import java.io.DataOutput;
@@ -246,6 +246,8 @@ public class LoadJob implements Writable {
     }
 
     public long getTableId() {
+        // table id may be 0 for some load job, eg, hadoop load job.
+        // use it carefully.
         return tableId;
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/BrokerLoadJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/BrokerLoadJob.java
@@ -99,9 +99,9 @@ public class BrokerLoadJob extends BulkLoadJob {
         MetricRepo.COUNTER_LOAD_ADD.increase(1L);
         transactionId = Catalog.getCurrentGlobalTransactionMgr()
                 .beginTransaction(dbId, Lists.newArrayList(fileGroupAggInfo.getAllTableIds()), label, null,
-                                  new TxnCoordinator(TxnSourceType.FE, FrontendOptions.getLocalHostAddress()),
-                                  TransactionState.LoadJobSourceType.BATCH_LOAD_JOB, id,
-                                  timeoutSecond);
+                        new TxnCoordinator(TxnSourceType.FE, FrontendOptions.getLocalHostAddress()),
+                        TransactionState.LoadJobSourceType.BATCH_LOAD_JOB, id,
+                        timeoutSecond);
     }
 
     @Override
@@ -140,18 +140,18 @@ public class BrokerLoadJob extends BulkLoadJob {
             // check if job has been cancelled
             if (isTxnDone()) {
                 LOG.warn(new LogBuilder(LogKey.LOAD_JOB, id)
-                                 .add("state", state)
-                                 .add("error_msg", "this task will be ignored when job is: " + state)
-                                 .build());
+                        .add("state", state)
+                        .add("error_msg", "this task will be ignored when job is: " + state)
+                        .build());
                 return;
             }
 
             if (finishedTaskIds.contains(attachment.getTaskId())) {
                 LOG.warn(new LogBuilder(LogKey.LOAD_JOB, id)
-                                 .add("task_id", attachment.getTaskId())
-                                 .add("error_msg", "this is a duplicated callback of pending task "
-                                         + "when broker already has loading task")
-                                 .build());
+                        .add("task_id", attachment.getTaskId())
+                        .add("error_msg", "this is a duplicated callback of pending task "
+                                + "when broker already has loading task")
+                        .build());
                 return;
             }
 
@@ -166,9 +166,9 @@ public class BrokerLoadJob extends BulkLoadJob {
             createLoadingTask(db, attachment);
         } catch (UserException e) {
             LOG.warn(new LogBuilder(LogKey.LOAD_JOB, id)
-                             .add("database_id", dbId)
-                             .add("error_msg", "Failed to divide job into loading task.")
-                             .build(), e);
+                    .add("database_id", dbId)
+                    .add("error_msg", "Failed to divide job into loading task.")
+                    .build(), e);
             cancelJobWithoutCheck(new FailMsg(FailMsg.CancelType.ETL_RUN_FAIL, e.getMessage()), true, true);
             return;
         } catch (RejectedExecutionException e) {
@@ -196,12 +196,12 @@ public class BrokerLoadJob extends BulkLoadJob {
                 OlapTable table = (OlapTable) db.getTable(tableId);
                 if (table == null) {
                     LOG.warn(new LogBuilder(LogKey.LOAD_JOB, id)
-                                     .add("database_id", dbId)
-                                     .add("table_id", tableId)
-                                     .add("error_msg", "Failed to divide job into loading task when table not found")
-                                     .build());
+                            .add("database_id", dbId)
+                            .add("table_id", tableId)
+                            .add("error_msg", "Failed to divide job into loading task when table not found")
+                            .build());
                     throw new MetaNotFoundException("Failed to divide job into loading task when table "
-                                                            + tableId + " not found");
+                            + tableId + " not found");
                 }
 
                 // Generate loading task and init the plan of task
@@ -243,17 +243,17 @@ public class BrokerLoadJob extends BulkLoadJob {
             // check if job has been cancelled
             if (isTxnDone()) {
                 LOG.warn(new LogBuilder(LogKey.LOAD_JOB, id)
-                                 .add("state", state)
-                                 .add("error_msg", "this task will be ignored when job is: " + state)
-                                 .build());
+                        .add("state", state)
+                        .add("error_msg", "this task will be ignored when job is: " + state)
+                        .build());
                 return;
             }
 
             // check if task has been finished
             if (finishedTaskIds.contains(attachment.getTaskId())) {
                 LOG.warn(new LogBuilder(LogKey.LOAD_JOB, id)
-                                 .add("task_id", attachment.getTaskId())
-                                 .add("error_msg", "this is a duplicated callback of loading task").build());
+                        .add("task_id", attachment.getTaskId())
+                        .add("error_msg", "this is a duplicated callback of loading task").build());
                 return;
             }
 
@@ -271,8 +271,8 @@ public class BrokerLoadJob extends BulkLoadJob {
 
         if (LOG.isDebugEnabled()) {
             LOG.debug(new LogBuilder(LogKey.LOAD_JOB, id)
-                              .add("commit_infos", Joiner.on(",").join(commitInfos))
-                              .build());
+                    .add("commit_infos", Joiner.on(",").join(commitInfos))
+                    .build());
         }
 
         // check data quality
@@ -286,30 +286,29 @@ public class BrokerLoadJob extends BulkLoadJob {
             db = getDb();
         } catch (MetaNotFoundException e) {
             LOG.warn(new LogBuilder(LogKey.LOAD_JOB, id)
-                             .add("database_id", dbId)
-                             .add("error_msg", "db has been deleted when job is loading")
-                             .build(), e);
+                    .add("database_id", dbId)
+                    .add("error_msg", "db has been deleted when job is loading")
+                    .build(), e);
             cancelJobWithoutCheck(new FailMsg(FailMsg.CancelType.LOAD_RUN_FAIL, e.getMessage()), true, true);
             return;
         }
         db.writeLock();
         try {
             LOG.info(new LogBuilder(LogKey.LOAD_JOB, id)
-                             .add("txn_id", transactionId)
-                             .add("msg", "Load job try to commit txn")
-                             .build());
+                    .add("txn_id", transactionId)
+                    .add("msg", "Load job try to commit txn")
+                    .build());
             MetricRepo.COUNTER_LOAD_FINISHED.increase(1L);
             Catalog.getCurrentGlobalTransactionMgr().commitTransaction(
                     dbId, transactionId, commitInfos,
                     new LoadJobFinalOperation(id, loadingStatus, progress, loadStartTimestamp,
-                                              finishTimestamp, state, failMsg));
+                            finishTimestamp, state, failMsg));
         } catch (UserException e) {
             LOG.warn(new LogBuilder(LogKey.LOAD_JOB, id)
-                             .add("database_id", dbId)
-                             .add("error_msg", "Failed to commit txn with error:" + e.getMessage())
-                             .build(), e);
+                    .add("database_id", dbId)
+                    .add("error_msg", "Failed to commit txn with error:" + e.getMessage())
+                    .build(), e);
             cancelJobWithoutCheck(new FailMsg(FailMsg.CancelType.LOAD_RUN_FAIL, e.getMessage()), true, true);
-            return;
         } finally {
             db.writeUnlock();
         }
@@ -343,11 +342,11 @@ public class BrokerLoadJob extends BulkLoadJob {
 
     private void updateLoadingStatus(BrokerLoadingTaskAttachment attachment) {
         loadingStatus.replaceCounter(DPP_ABNORMAL_ALL,
-                                     increaseCounter(DPP_ABNORMAL_ALL, attachment.getCounter(DPP_ABNORMAL_ALL)));
+                increaseCounter(DPP_ABNORMAL_ALL, attachment.getCounter(DPP_ABNORMAL_ALL)));
         loadingStatus.replaceCounter(DPP_NORMAL_ALL,
-                                     increaseCounter(DPP_NORMAL_ALL, attachment.getCounter(DPP_NORMAL_ALL)));
+                increaseCounter(DPP_NORMAL_ALL, attachment.getCounter(DPP_NORMAL_ALL)));
         loadingStatus.replaceCounter(UNSELECTED_ROWS,
-                                     increaseCounter(UNSELECTED_ROWS, attachment.getCounter(UNSELECTED_ROWS)));
+                increaseCounter(UNSELECTED_ROWS, attachment.getCounter(UNSELECTED_ROWS)));
         if (attachment.getTrackingUrl() != null) {
             loadingStatus.setTrackingUrl(attachment.getTrackingUrl());
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/BrokerLoadJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/BrokerLoadJob.java
@@ -299,10 +299,11 @@ public class BrokerLoadJob extends BulkLoadJob {
                     .add("msg", "Load job try to commit txn")
                     .build());
             MetricRepo.COUNTER_LOAD_FINISHED.increase(1L);
-            Catalog.getCurrentGlobalTransactionMgr().commitTransaction(
-                    dbId, transactionId, commitInfos,
-                    new LoadJobFinalOperation(id, loadingStatus, progress, loadStartTimestamp,
-                            finishTimestamp, state, failMsg));
+//            Catalog.getCurrentGlobalTransactionMgr().commitTransaction(
+//                    dbId, transactionId, commitInfos,
+//                    new LoadJobFinalOperation(id, loadingStatus, progress, loadStartTimestamp,
+//                            finishTimestamp, state, failMsg));
+            throw new UserException("");
         } catch (UserException e) {
             LOG.warn(new LogBuilder(LogKey.LOAD_JOB, id)
                     .add("database_id", dbId)

--- a/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/BrokerLoadJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/BrokerLoadJob.java
@@ -22,6 +22,7 @@ import org.apache.doris.analysis.UserIdentity;
 import org.apache.doris.catalog.Catalog;
 import org.apache.doris.catalog.Database;
 import org.apache.doris.catalog.OlapTable;
+import org.apache.doris.catalog.Table;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.DataQualityException;
@@ -57,6 +58,7 @@ import com.google.common.collect.Lists;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.RejectedExecutionException;
 

--- a/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/BrokerLoadJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/BrokerLoadJob.java
@@ -22,7 +22,6 @@ import org.apache.doris.analysis.UserIdentity;
 import org.apache.doris.catalog.Catalog;
 import org.apache.doris.catalog.Database;
 import org.apache.doris.catalog.OlapTable;
-import org.apache.doris.catalog.Table;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.DataQualityException;
@@ -58,7 +57,6 @@ import com.google.common.collect.Lists;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.RejectedExecutionException;
 

--- a/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/BrokerLoadJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/BrokerLoadJob.java
@@ -309,6 +309,7 @@ public class BrokerLoadJob extends BulkLoadJob {
                     .add("error_msg", "Failed to commit txn with error:" + e.getMessage())
                     .build(), e);
             cancelJobWithoutCheck(new FailMsg(FailMsg.CancelType.LOAD_RUN_FAIL, e.getMessage()), true, true);
+            return;
         } finally {
             db.writeUnlock();
         }
@@ -374,4 +375,3 @@ public class BrokerLoadJob extends BulkLoadJob {
         writeProfile();
     }
 }
-

--- a/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/BulkLoadJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/BulkLoadJob.java
@@ -191,7 +191,7 @@ public abstract class BulkLoadJob extends LoadJob {
     }
 
     @Override
-    public Set<String> getTableNames() throws MetaNotFoundException{
+    public Set<String> getTableNames() throws MetaNotFoundException {
         Set<String> result = Sets.newHashSet();
         Database database = Catalog.getCurrentCatalog().getDb(dbId);
         if (database == null) {

--- a/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/LoadManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/LoadManager.java
@@ -626,14 +626,9 @@ public class LoadManager implements Writable{
      * @throws DdlException
      */
     private void checkTable(Database database, String tableName) throws DdlException {
-        database.readLock();
-        try {
-            if (database.getTable(tableName) == null) {
-                LOG.info("Table {} is not belongs to database {}", tableName, database.getFullName());
-                throw new DdlException("Table[" + tableName + "] does not exist");
-            }
-        } finally {
-            database.readUnlock();
+        if (database.getTable(tableName) == null) {
+            LOG.info("Table {} is not belongs to database {}", tableName, database.getFullName());
+            throw new DdlException("Table[" + tableName + "] does not exist");
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/SparkLoadJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/SparkLoadJob.java
@@ -623,10 +623,11 @@ public class SparkLoadJob extends BulkLoadJob {
         Database db = getDb();
         db.writeLock();
         try {
-            Catalog.getCurrentGlobalTransactionMgr().commitTransaction(
-                    dbId, transactionId, commitInfos,
-                    new LoadJobFinalOperation(id, loadingStatus, progress, loadStartTimestamp,
-                                              finishTimestamp, state, failMsg));
+//            Catalog.getCurrentGlobalTransactionMgr().commitTransaction(
+//                    dbId, transactionId, commitInfos,
+//                    new LoadJobFinalOperation(id, loadingStatus, progress, loadStartTimestamp,
+//                                              finishTimestamp, state, failMsg));
+            throw new TabletQuorumFailedException(1, 1, 1, 1, null);
         } catch (TabletQuorumFailedException e) {
             // retry in next loop
         } finally {

--- a/fe/fe-core/src/main/java/org/apache/doris/load/routineload/KafkaRoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/routineload/KafkaRoutineLoadJob.java
@@ -346,15 +346,9 @@ public class KafkaRoutineLoadJob extends RoutineLoadJob {
             ErrorReport.reportDdlException(ErrorCode.ERR_BAD_DB_ERROR, stmt.getDBName());
         }
 
-        long tableId = -1L;
-        db.readLock();
-        try {
-            checkMeta(db, stmt.getTableName(), stmt.getRoutineLoadDesc());
-            Table table = db.getTable(stmt.getTableName());
-            tableId = table.getId();
-        } finally {
-            db.readUnlock();
-        }
+        checkMeta(db, stmt.getTableName(), stmt.getRoutineLoadDesc());
+        Table table = db.getTable(stmt.getTableName());
+        long tableId = table.getId();
 
         // init kafka routine load job
         long id = Catalog.getCurrentCatalog().getNextId();

--- a/fe/fe-core/src/main/java/org/apache/doris/load/routineload/KafkaRoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/routineload/KafkaRoutineLoadJob.java
@@ -349,7 +349,7 @@ public class KafkaRoutineLoadJob extends RoutineLoadJob {
         long tableId = -1L;
         db.readLock();
         try {
-            unprotectedCheckMeta(db, stmt.getTableName(), stmt.getRoutineLoadDesc());
+            checkMeta(db, stmt.getTableName(), stmt.getRoutineLoadDesc());
             Table table = db.getTable(stmt.getTableName());
             tableId = table.getId();
         } finally {

--- a/fe/fe-core/src/main/java/org/apache/doris/load/routineload/RoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/routineload/RoutineLoadJob.java
@@ -408,12 +408,8 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback impl
         if (database == null) {
             throw new MetaNotFoundException("Database " + dbId + "has been deleted");
         }
-        database.readLock();
-        try {
-            return database.getFullName();
-        } finally {
-            database.readUnlock();
-        }
+
+        return database.getFullName();
     }
 
     public long getTableId() {
@@ -1267,11 +1263,7 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback impl
 
     public List<String> getShowInfo() {
         Database db = Catalog.getCurrentCatalog().getDb(dbId);
-        Table tbl = null;
-        if (db != null) {
-            db.readLock();
-            tbl = db.getTable(tableId);
-        }
+        Table tbl = (db == null) ? null : db.getTable(tableId);
 
         readLock();
         try {

--- a/fe/fe-core/src/main/java/org/apache/doris/load/routineload/RoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/routineload/RoutineLoadJob.java
@@ -1210,7 +1210,6 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback impl
         }
 
         // check table belong to database
-        database.readLock();
         Table table = database.getTable(tableId);
         if (table == null) {
             LOG.warn(new LogBuilder(LogKey.ROUTINE_LOAD_JOB, id).add("db_id", dbId)

--- a/fe/fe-core/src/main/java/org/apache/doris/load/routineload/RoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/routineload/RoutineLoadJob.java
@@ -408,7 +408,12 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback impl
         if (database == null) {
             throw new MetaNotFoundException("Database " + dbId + "has been deleted");
         }
-        return database.getFullName();
+        database.readLock();
+        try {
+            return database.getFullName();
+        } finally {
+            database.readUnlock();
+        }
     }
 
     public long getTableId() {

--- a/fe/fe-core/src/main/java/org/apache/doris/master/MasterImpl.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/master/MasterImpl.java
@@ -334,14 +334,15 @@ public class MasterImpl {
             return;
         }
         LOG.debug("push report state: {}", pushState.name());
-        
-        db.writeLock();
-        try {
-            OlapTable olapTable = (OlapTable) db.getTable(tableId);
-            if (olapTable == null) {
-                throw new MetaNotFoundException("cannot find table[" + tableId + "] when push finished");
-            }
 
+        OlapTable olapTable = (OlapTable) db.getTable(tableId);
+        if (olapTable == null) {
+            AgentTaskQueue.removeTask(backendId, TTaskType.REALTIME_PUSH, signature);
+            LOG.warn("finish push replica error, cannot find table[" + tableId + "] when push finished");
+            return;
+        }
+        olapTable.writeLock();
+        try {
             Partition partition = olapTable.getPartition(partitionId);
             if (partition == null) {
                 throw new MetaNotFoundException("cannot find partition[" + partitionId + "] when push finished");
@@ -421,7 +422,7 @@ public class MasterImpl {
             AgentTaskQueue.removeTask(backendId, TTaskType.REALTIME_PUSH, signature);
             LOG.warn("finish push replica error", e);
         } finally {
-            db.writeUnlock();
+            olapTable.writeUnlock();
         }
     }
 
@@ -548,13 +549,15 @@ public class MasterImpl {
 
         LOG.debug("push report state: {}", pushState.name());
 
-        db.writeLock();
-        try {
-            OlapTable olapTable = (OlapTable) db.getTable(tableId);
-            if (olapTable == null) {
-                throw new MetaNotFoundException("cannot find table[" + tableId + "] when push finished");
-            }
+        OlapTable olapTable = (OlapTable) db.getTable(tableId);
+        if (olapTable == null) {
+            AgentTaskQueue.removeTask(backendId, TTaskType.REALTIME_PUSH, signature);
+            LOG.warn("finish push replica error, cannot find table[" + tableId + "] when push finished");
+            return;
+        }
 
+        olapTable.writeLock();
+        try {
             Partition partition = olapTable.getPartition(partitionId);
             if (partition == null) {
                 throw new MetaNotFoundException("cannot find partition[" + partitionId + "] when push finished");
@@ -626,7 +629,7 @@ public class MasterImpl {
                                           pushTask.getPushType(), pushTask.getTaskType());
             LOG.warn("finish push replica error", e);
         } finally {
-            db.writeUnlock();
+            olapTable.writeUnlock();
         }
     }
     

--- a/fe/fe-core/src/main/java/org/apache/doris/master/MasterImpl.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/master/MasterImpl.java
@@ -265,7 +265,7 @@ public class MasterImpl {
                 }
                 
                 // this should be called before 'countDownLatch()'
-                Catalog.getCurrentSystemInfo().updateBackendReportVersion(task.getBackendId(), request.getReportVersion(), task.getDbId());
+                Catalog.getCurrentSystemInfo().updateBackendReportVersion(task.getBackendId(), request.getReportVersion(), task.getDbId(), task.getTableId());
                 
                 createReplicaTask.countDownLatch(task.getBackendId(), task.getSignature());
                 LOG.debug("finish create replica. tablet id: {}, be: {}, report version: {}",
@@ -358,7 +358,7 @@ public class MasterImpl {
             // should be done before addReplicaPersistInfos and countDownLatch
             long reportVersion = request.getReportVersion();
             Catalog.getCurrentSystemInfo().updateBackendReportVersion(task.getBackendId(), reportVersion,
-                                                                       task.getDbId());
+                                                                       task.getDbId(), task.getTableId());
 
             List<Long> tabletIds = finishTabletInfos.stream().map(
                     tTabletInfo -> tTabletInfo.getTabletId()).collect(Collectors.toList());
@@ -583,7 +583,7 @@ public class MasterImpl {
             // should be done before addReplicaPersistInfos and countDownLatch
             long reportVersion = request.getReportVersion();
             Catalog.getCurrentSystemInfo().updateBackendReportVersion(task.getBackendId(), reportVersion,
-                                                                       task.getDbId());
+                                                                       task.getDbId(), task.getTableId());
 
             if (pushTask.getPushType() == TPushType.LOAD || pushTask.getPushType() == TPushType.LOAD_DELETE) {
                 // handle load job
@@ -648,7 +648,7 @@ public class MasterImpl {
         if (request.isSetReportVersion()) {
             // report version is required. here we check if set, for compatibility.
             long reportVersion = request.getReportVersion();
-            Catalog.getCurrentSystemInfo().updateBackendReportVersion(task.getBackendId(), reportVersion, task.getDbId());
+            Catalog.getCurrentSystemInfo().updateBackendReportVersion(task.getBackendId(), reportVersion, task.getDbId(), task.getTableId());
         }
 
         PublishVersionTask publishVersionTask = (PublishVersionTask) task;

--- a/fe/fe-core/src/main/java/org/apache/doris/master/ReportHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/master/ReportHandler.java
@@ -901,12 +901,13 @@ public class ReportHandler extends Daemon {
                 if (db == null) {
                     continue;
                 }
-                db.readLock();
+                OlapTable olapTable = (OlapTable) db.getTable(tableId);
+                if (olapTable == null) {
+                    continue;
+                }
+
+                olapTable.readLock();
                 try {
-                    OlapTable olapTable = (OlapTable) db.getTable(tableId);
-                    if (olapTable == null) {
-                        continue;
-                    }
                     Partition partition = olapTable.getPartition(partitionId);
                     if (partition == null) {
                         continue;
@@ -916,7 +917,7 @@ public class ReportHandler extends Daemon {
                         tabletToInMemory.add(new ImmutableTriple<>(tabletId, tabletInfo.getSchemaHash(), feIsInMemory));
                     }
                 } finally {
-                    db.readUnlock();
+                    olapTable.readUnlock();
                 }
             }
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/master/ReportHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/master/ReportHandler.java
@@ -381,7 +381,6 @@ public class ReportHandler extends Daemon {
             if (db == null) {
                 continue;
             }
-<<<<<<< HEAD:fe/fe-core/src/main/java/org/apache/doris/master/ReportHandler.java
             db.writeLock();
             try {
                 int syncCounter = 0;
@@ -400,27 +399,7 @@ public class ReportHandler extends Daemon {
                     if (olapTable == null) {
                         continue;
                     }
-=======
->>>>>>> Continue to use table lock to replace db lock:fe/src/main/java/org/apache/doris/master/ReportHandler.java
 
-            int syncCounter = 0;
-            List<Long> tabletIds = tabletSyncMap.get(dbId);
-            LOG.info("before sync tablets in db[{}]. report num: {}. backend[{}]",
-                    dbId, tabletIds.size(), backendId);
-            List<TabletMeta> tabletMetaList = invertedIndex.getTabletMetaList(tabletIds);
-            for (int i = 0; i < tabletMetaList.size(); i++) {
-                TabletMeta tabletMeta = tabletMetaList.get(i);
-                if (tabletMeta == TabletInvertedIndex.NOT_EXIST_TABLET_META) {
-                    continue;
-                }
-                long tabletId = tabletIds.get(i);
-                long tableId = tabletMeta.getTableId();
-                OlapTable olapTable = (OlapTable) db.getTable(tableId);
-                if (olapTable == null) {
-                    continue;
-                }
-                olapTable.writeLock();
-                try {
                     long partitionId = tabletMeta.getPartitionId();
                     Partition partition = olapTable.getPartition(partitionId);
                     if (partition == null) {
@@ -515,11 +494,11 @@ public class ReportHandler extends Daemon {
                                     backendVersion, backendVersionHash);
                         }
                     }
-                } finally {
-                    olapTable.writeUnlock();
-                }
-            } // end for tabletMetaSyncMap
+                } // end for tabletMetaSyncMap
                 LOG.info("sync {} tablets in db[{}]. backend[{}]", syncCounter, dbId, backendId);
+            } finally {
+                db.writeUnlock();
+            }
         } // end for dbs
     }
 
@@ -532,7 +511,6 @@ public class ReportHandler extends Daemon {
             if (db == null) {
                 continue;
             }
-<<<<<<< HEAD:fe/fe-core/src/main/java/org/apache/doris/master/ReportHandler.java
             db.writeLock();
             try {
                 int deleteCounter = 0;
@@ -549,25 +527,7 @@ public class ReportHandler extends Daemon {
                     if (olapTable == null) {
                         continue;
                     }
-=======
->>>>>>> Continue to use table lock to replace db lock:fe/src/main/java/org/apache/doris/master/ReportHandler.java
 
-            int deleteCounter = 0;
-            List<Long> tabletIds = tabletDeleteFromMeta.get(dbId);
-            List<TabletMeta> tabletMetaList = invertedIndex.getTabletMetaList(tabletIds);
-            for (int i = 0; i < tabletMetaList.size(); i++) {
-                TabletMeta tabletMeta = tabletMetaList.get(i);
-                if (tabletMeta == TabletInvertedIndex.NOT_EXIST_TABLET_META) {
-                    continue;
-                }
-                long tabletId = tabletIds.get(i);
-                long tableId  = tabletMeta.getTableId();
-                OlapTable olapTable = (OlapTable) db.getTable(tableId);
-                if (olapTable == null) {
-                    continue;
-                }
-                olapTable.writeLock();
-                try {
                     long partitionId = tabletMeta.getPartitionId();
                     Partition partition = olapTable.getPartition(partitionId);
                     if (partition == null) {
@@ -620,11 +580,7 @@ public class ReportHandler extends Daemon {
                                 if (Config.recover_with_empty_tablet) {
                                     // only create this task if force recovery is true
                                     LOG.warn("tablet {} has only one replica {} on backend {}"
-<<<<<<< HEAD:fe/fe-core/src/main/java/org/apache/doris/master/ReportHandler.java
                                                     + " and it is lost. create an empty replica to recover it",
-=======
-                                                    + "and it is lost. create an empty replica to recover it",
->>>>>>> Continue to use table lock to replace db lock:fe/src/main/java/org/apache/doris/master/ReportHandler.java
                                             tabletId, replica.getId(), backendId);
                                     MaterializedIndexMeta indexMeta = olapTable.getIndexMetaByIndexId(indexId);
                                     Set<String> bfColumns = olapTable.getCopiedBfColumns();
@@ -644,11 +600,7 @@ public class ReportHandler extends Daemon {
                                     // just set this replica as bad
                                     if (replica.setBad(true)) {
                                         LOG.warn("tablet {} has only one replica {} on backend {}"
-<<<<<<< HEAD:fe/fe-core/src/main/java/org/apache/doris/master/ReportHandler.java
                                                         + " and it is lost, set it as bad",
-=======
-                                                        + "and it is lost, set it as bad",
->>>>>>> Continue to use table lock to replace db lock:fe/src/main/java/org/apache/doris/master/ReportHandler.java
                                                 tabletId, replica.getId(), backendId);
                                         BackendTabletsInfo tabletsInfo = new BackendTabletsInfo(backendId);
                                         tabletsInfo.setBad(true);
@@ -684,11 +636,11 @@ public class ReportHandler extends Daemon {
                             LOG.error("invalid situation. tablet[{}] is empty", tabletId);
                         }
                     }
-                } finally {
-                    olapTable.writeUnlock();
-                }
-            } // end for tabletMetas
-            LOG.info("delete {} replica(s) from catalog in db[{}]", deleteCounter, dbId);
+                } // end for tabletMetas
+                LOG.info("delete {} replica(s) from catalog in db[{}]", deleteCounter, dbId);
+            } finally {
+                db.writeUnlock();
+            }
         } // end for dbs
 
         if (Config.recover_with_empty_tablet && createReplicaBatchTask.getTaskNum() > 0) {
@@ -816,7 +768,6 @@ public class ReportHandler extends Daemon {
                 tabletRecoveryMap.size(), backendId);
 
         TabletInvertedIndex invertedIndex = Catalog.getCurrentInvertedIndex();
-<<<<<<< HEAD:fe/fe-core/src/main/java/org/apache/doris/master/ReportHandler.java
         BackendTabletsInfo backendTabletsInfo = new BackendTabletsInfo(backendId);
         backendTabletsInfo.setBad(true);
         for (Long dbId : tabletRecoveryMap.keySet()) {
@@ -845,40 +796,6 @@ public class ReportHandler extends Daemon {
                     if (partition == null) {
                         continue;
                     }
-=======
-        if (!forceRecovery) {
-            LOG.warn("force recovery is disable. try reset the tablets' version"
-                    + " or set it as bad, and waiting clone");
-
-            BackendTabletsInfo backendTabletsInfo = new BackendTabletsInfo(backendId);
-            backendTabletsInfo.setBad(true);
-            for (Long dbId : tabletRecoveryMap.keySet()) {
-                Database db = Catalog.getCurrentCatalog().getDb(dbId);
-                if (db == null) {
-                    continue;
-                }
-
-                List<Long> tabletIds = tabletRecoveryMap.get(dbId);
-                List<TabletMeta> tabletMetaList = invertedIndex.getTabletMetaList(tabletIds);
-                for (int i = 0; i < tabletMetaList.size(); i++) {
-                    TabletMeta tabletMeta = tabletMetaList.get(i);
-                    if (tabletMeta == TabletInvertedIndex.NOT_EXIST_TABLET_META) {
-                        continue;
-                    }
-                    long tabletId = tabletIds.get(i);
-                    long tableId = tabletMeta.getTableId();
-                    OlapTable olapTable = (OlapTable) db.getTable(tableId);
-                    if (olapTable == null) {
-                        continue;
-                    }
-                    olapTable.writeLock();
-                    try {
-                        long partitionId = tabletMeta.getPartitionId();
-                        Partition partition = olapTable.getPartition(partitionId);
-                        if (partition == null) {
-                            continue;
-                        }
->>>>>>> Continue to use table lock to replace db lock:fe/src/main/java/org/apache/doris/master/ReportHandler.java
 
                     long indexId = tabletMeta.getIndexId();
                     MaterializedIndex index = partition.getIndex(indexId);
@@ -938,8 +855,6 @@ public class ReportHandler extends Daemon {
                                 break;
                             }
                         }
-                    } finally {
-                        olapTable.writeUnlock();
                     }
                 }
             } finally {
@@ -986,13 +901,12 @@ public class ReportHandler extends Daemon {
                 if (db == null) {
                     continue;
                 }
-                OlapTable olapTable = (OlapTable) db.getTable(tableId);
-                if (olapTable == null) {
-                    continue;
-                }
-
-                olapTable.readLock();
+                db.readLock();
                 try {
+                    OlapTable olapTable = (OlapTable) db.getTable(tableId);
+                    if (olapTable == null) {
+                        continue;
+                    }
                     Partition partition = olapTable.getPartition(partitionId);
                     if (partition == null) {
                         continue;
@@ -1002,7 +916,7 @@ public class ReportHandler extends Daemon {
                         tabletToInMemory.add(new ImmutableTriple<>(tabletId, tabletInfo.getSchemaHash(), feIsInMemory));
                     }
                 } finally {
-                    olapTable.readUnlock();
+                    db.readUnlock();
                 }
             }
         }
@@ -1049,14 +963,13 @@ public class ReportHandler extends Daemon {
         if (db == null) {
             throw new MetaNotFoundException("db[" + dbId + "] does not exist");
         }
-
-        OlapTable olapTable = (OlapTable) db.getTable(tableId);
-        if (olapTable == null) {
-            throw new MetaNotFoundException("table[" + tableId + "] does not exist");
-        }
-
-        olapTable.writeLock();
+        db.writeLock();
         try {
+            OlapTable olapTable = (OlapTable) db.getTable(tableId);
+            if (olapTable == null) {
+                throw new MetaNotFoundException("table[" + tableId + "] does not exist");
+            }
+
             Partition partition = olapTable.getPartition(partitionId);
             if (partition == null) {
                 throw new MetaNotFoundException("partition[" + partitionId + "] does not exist");
@@ -1152,7 +1065,7 @@ public class ReportHandler extends Daemon {
                         "replica is enough[" + tablet.getReplicas().size() + "-" + replicationNum + "]");
             }
         } finally {
-            olapTable.writeUnlock();
+            db.writeUnlock();
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/master/ReportHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/master/ReportHandler.java
@@ -14,22 +14,6 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-// Licensed to the Apache Software Foundation (ASF) under one
-// or more contributor license agreements.  See the NOTICE file
-// distributed with this work for additional information
-// regarding copyright ownership.  The ASF licenses this file
-// to you under the Apache License, Version 2.0 (the
-// "License"); you may not use this file except in compliance
-// with the License.  You may obtain a copy of the License at
-//
-//   http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing,
-// software distributed under the License is distributed on an
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// KIND, either express or implied.  See the License for the
-// specific language governing permissions and limitations
-// under the License.
 
 package org.apache.doris.master;
 

--- a/fe/fe-core/src/main/java/org/apache/doris/master/ReportHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/master/ReportHandler.java
@@ -381,6 +381,7 @@ public class ReportHandler extends Daemon {
             if (db == null) {
                 continue;
             }
+<<<<<<< HEAD:fe/fe-core/src/main/java/org/apache/doris/master/ReportHandler.java
             db.writeLock();
             try {
                 int syncCounter = 0;
@@ -399,7 +400,27 @@ public class ReportHandler extends Daemon {
                     if (olapTable == null) {
                         continue;
                     }
+=======
+>>>>>>> Continue to use table lock to replace db lock:fe/src/main/java/org/apache/doris/master/ReportHandler.java
 
+            int syncCounter = 0;
+            List<Long> tabletIds = tabletSyncMap.get(dbId);
+            LOG.info("before sync tablets in db[{}]. report num: {}. backend[{}]",
+                    dbId, tabletIds.size(), backendId);
+            List<TabletMeta> tabletMetaList = invertedIndex.getTabletMetaList(tabletIds);
+            for (int i = 0; i < tabletMetaList.size(); i++) {
+                TabletMeta tabletMeta = tabletMetaList.get(i);
+                if (tabletMeta == TabletInvertedIndex.NOT_EXIST_TABLET_META) {
+                    continue;
+                }
+                long tabletId = tabletIds.get(i);
+                long tableId = tabletMeta.getTableId();
+                OlapTable olapTable = (OlapTable) db.getTable(tableId);
+                if (olapTable == null) {
+                    continue;
+                }
+                olapTable.writeLock();
+                try {
                     long partitionId = tabletMeta.getPartitionId();
                     Partition partition = olapTable.getPartition(partitionId);
                     if (partition == null) {
@@ -494,11 +515,11 @@ public class ReportHandler extends Daemon {
                                     backendVersion, backendVersionHash);
                         }
                     }
-                } // end for tabletMetaSyncMap
+                } finally {
+                    olapTable.writeUnlock();
+                }
+            } // end for tabletMetaSyncMap
                 LOG.info("sync {} tablets in db[{}]. backend[{}]", syncCounter, dbId, backendId);
-            } finally {
-                db.writeUnlock();
-            }
         } // end for dbs
     }
 
@@ -511,6 +532,7 @@ public class ReportHandler extends Daemon {
             if (db == null) {
                 continue;
             }
+<<<<<<< HEAD:fe/fe-core/src/main/java/org/apache/doris/master/ReportHandler.java
             db.writeLock();
             try {
                 int deleteCounter = 0;
@@ -527,7 +549,25 @@ public class ReportHandler extends Daemon {
                     if (olapTable == null) {
                         continue;
                     }
+=======
+>>>>>>> Continue to use table lock to replace db lock:fe/src/main/java/org/apache/doris/master/ReportHandler.java
 
+            int deleteCounter = 0;
+            List<Long> tabletIds = tabletDeleteFromMeta.get(dbId);
+            List<TabletMeta> tabletMetaList = invertedIndex.getTabletMetaList(tabletIds);
+            for (int i = 0; i < tabletMetaList.size(); i++) {
+                TabletMeta tabletMeta = tabletMetaList.get(i);
+                if (tabletMeta == TabletInvertedIndex.NOT_EXIST_TABLET_META) {
+                    continue;
+                }
+                long tabletId = tabletIds.get(i);
+                long tableId  = tabletMeta.getTableId();
+                OlapTable olapTable = (OlapTable) db.getTable(tableId);
+                if (olapTable == null) {
+                    continue;
+                }
+                olapTable.writeLock();
+                try {
                     long partitionId = tabletMeta.getPartitionId();
                     Partition partition = olapTable.getPartition(partitionId);
                     if (partition == null) {
@@ -580,7 +620,11 @@ public class ReportHandler extends Daemon {
                                 if (Config.recover_with_empty_tablet) {
                                     // only create this task if force recovery is true
                                     LOG.warn("tablet {} has only one replica {} on backend {}"
+<<<<<<< HEAD:fe/fe-core/src/main/java/org/apache/doris/master/ReportHandler.java
                                                     + " and it is lost. create an empty replica to recover it",
+=======
+                                                    + "and it is lost. create an empty replica to recover it",
+>>>>>>> Continue to use table lock to replace db lock:fe/src/main/java/org/apache/doris/master/ReportHandler.java
                                             tabletId, replica.getId(), backendId);
                                     MaterializedIndexMeta indexMeta = olapTable.getIndexMetaByIndexId(indexId);
                                     Set<String> bfColumns = olapTable.getCopiedBfColumns();
@@ -600,7 +644,11 @@ public class ReportHandler extends Daemon {
                                     // just set this replica as bad
                                     if (replica.setBad(true)) {
                                         LOG.warn("tablet {} has only one replica {} on backend {}"
+<<<<<<< HEAD:fe/fe-core/src/main/java/org/apache/doris/master/ReportHandler.java
                                                         + " and it is lost, set it as bad",
+=======
+                                                        + "and it is lost, set it as bad",
+>>>>>>> Continue to use table lock to replace db lock:fe/src/main/java/org/apache/doris/master/ReportHandler.java
                                                 tabletId, replica.getId(), backendId);
                                         BackendTabletsInfo tabletsInfo = new BackendTabletsInfo(backendId);
                                         tabletsInfo.setBad(true);
@@ -636,11 +684,11 @@ public class ReportHandler extends Daemon {
                             LOG.error("invalid situation. tablet[{}] is empty", tabletId);
                         }
                     }
-                } // end for tabletMetas
-                LOG.info("delete {} replica(s) from catalog in db[{}]", deleteCounter, dbId);
-            } finally {
-                db.writeUnlock();
-            }
+                } finally {
+                    olapTable.writeUnlock();
+                }
+            } // end for tabletMetas
+            LOG.info("delete {} replica(s) from catalog in db[{}]", deleteCounter, dbId);
         } // end for dbs
 
         if (Config.recover_with_empty_tablet && createReplicaBatchTask.getTaskNum() > 0) {
@@ -768,6 +816,7 @@ public class ReportHandler extends Daemon {
                 tabletRecoveryMap.size(), backendId);
 
         TabletInvertedIndex invertedIndex = Catalog.getCurrentInvertedIndex();
+<<<<<<< HEAD:fe/fe-core/src/main/java/org/apache/doris/master/ReportHandler.java
         BackendTabletsInfo backendTabletsInfo = new BackendTabletsInfo(backendId);
         backendTabletsInfo.setBad(true);
         for (Long dbId : tabletRecoveryMap.keySet()) {
@@ -796,6 +845,40 @@ public class ReportHandler extends Daemon {
                     if (partition == null) {
                         continue;
                     }
+=======
+        if (!forceRecovery) {
+            LOG.warn("force recovery is disable. try reset the tablets' version"
+                    + " or set it as bad, and waiting clone");
+
+            BackendTabletsInfo backendTabletsInfo = new BackendTabletsInfo(backendId);
+            backendTabletsInfo.setBad(true);
+            for (Long dbId : tabletRecoveryMap.keySet()) {
+                Database db = Catalog.getCurrentCatalog().getDb(dbId);
+                if (db == null) {
+                    continue;
+                }
+
+                List<Long> tabletIds = tabletRecoveryMap.get(dbId);
+                List<TabletMeta> tabletMetaList = invertedIndex.getTabletMetaList(tabletIds);
+                for (int i = 0; i < tabletMetaList.size(); i++) {
+                    TabletMeta tabletMeta = tabletMetaList.get(i);
+                    if (tabletMeta == TabletInvertedIndex.NOT_EXIST_TABLET_META) {
+                        continue;
+                    }
+                    long tabletId = tabletIds.get(i);
+                    long tableId = tabletMeta.getTableId();
+                    OlapTable olapTable = (OlapTable) db.getTable(tableId);
+                    if (olapTable == null) {
+                        continue;
+                    }
+                    olapTable.writeLock();
+                    try {
+                        long partitionId = tabletMeta.getPartitionId();
+                        Partition partition = olapTable.getPartition(partitionId);
+                        if (partition == null) {
+                            continue;
+                        }
+>>>>>>> Continue to use table lock to replace db lock:fe/src/main/java/org/apache/doris/master/ReportHandler.java
 
                     long indexId = tabletMeta.getIndexId();
                     MaterializedIndex index = partition.getIndex(indexId);
@@ -855,6 +938,8 @@ public class ReportHandler extends Daemon {
                                 break;
                             }
                         }
+                    } finally {
+                        olapTable.writeUnlock();
                     }
                 }
             } finally {
@@ -964,13 +1049,14 @@ public class ReportHandler extends Daemon {
         if (db == null) {
             throw new MetaNotFoundException("db[" + dbId + "] does not exist");
         }
-        db.writeLock();
-        try {
-            OlapTable olapTable = (OlapTable) db.getTable(tableId);
-            if (olapTable == null) {
-                throw new MetaNotFoundException("table[" + tableId + "] does not exist");
-            }
 
+        OlapTable olapTable = (OlapTable) db.getTable(tableId);
+        if (olapTable == null) {
+            throw new MetaNotFoundException("table[" + tableId + "] does not exist");
+        }
+
+        olapTable.writeLock();
+        try {
             Partition partition = olapTable.getPartition(partitionId);
             if (partition == null) {
                 throw new MetaNotFoundException("partition[" + partitionId + "] does not exist");
@@ -1066,7 +1152,7 @@ public class ReportHandler extends Daemon {
                         "replica is enough[" + tablet.getReplicas().size() + "-" + replicationNum + "]");
             }
         } finally {
-            db.writeUnlock();
+            olapTable.writeUnlock();
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/master/ReportHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/master/ReportHandler.java
@@ -14,6 +14,22 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
 
 package org.apache.doris.master;
 

--- a/fe/fe-core/src/main/java/org/apache/doris/master/ReportHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/master/ReportHandler.java
@@ -42,6 +42,7 @@ import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.catalog.Partition;
 import org.apache.doris.catalog.Replica;
 import org.apache.doris.catalog.Replica.ReplicaState;
+import org.apache.doris.catalog.Table;
 import org.apache.doris.catalog.Tablet;
 import org.apache.doris.catalog.Tablet.TabletStatus;
 import org.apache.doris.catalog.TabletInvertedIndex;
@@ -397,25 +398,24 @@ public class ReportHandler extends Daemon {
             if (db == null) {
                 continue;
             }
-            db.writeLock();
-            try {
-                int syncCounter = 0;
-                List<Long> tabletIds = tabletSyncMap.get(dbId);
-                LOG.info("before sync tablets in db[{}]. report num: {}. backend[{}]",
-                        dbId, tabletIds.size(), backendId);
-                List<TabletMeta> tabletMetaList = invertedIndex.getTabletMetaList(tabletIds);
-                for (int i = 0; i < tabletMetaList.size(); i++) {
-                    TabletMeta tabletMeta = tabletMetaList.get(i);
-                    if (tabletMeta == TabletInvertedIndex.NOT_EXIST_TABLET_META) {
-                        continue;
-                    }
-                    long tabletId = tabletIds.get(i);
-                    long tableId = tabletMeta.getTableId();
-                    OlapTable olapTable = (OlapTable) db.getTable(tableId);
-                    if (olapTable == null) {
-                        continue;
-                    }
-
+            int syncCounter = 0;
+            List<Long> tabletIds = tabletSyncMap.get(dbId);
+            LOG.info("before sync tablets in db[{}]. report num: {}. backend[{}]",
+                    dbId, tabletIds.size(), backendId);
+            List<TabletMeta> tabletMetaList = invertedIndex.getTabletMetaList(tabletIds);
+            for (int i = 0; i < tabletMetaList.size(); i++) {
+                TabletMeta tabletMeta = tabletMetaList.get(i);
+                if (tabletMeta == TabletInvertedIndex.NOT_EXIST_TABLET_META) {
+                    continue;
+                }
+                long tabletId = tabletIds.get(i);
+                long tableId = tabletMeta.getTableId();
+                OlapTable olapTable = (OlapTable) db.getTable(tableId);
+                if (olapTable == null) {
+                    continue;
+                }
+                olapTable.writeLock();
+                try {
                     long partitionId = tabletMeta.getPartitionId();
                     Partition partition = olapTable.getPartition(partitionId);
                     if (partition == null) {
@@ -438,6 +438,7 @@ public class ReportHandler extends Daemon {
                     if (replica == null) {
                         continue;
                     }
+
                     // yiguolei: it is very important here, if the replica is under schema change or rollup
                     // should ignore the report.
                     // eg.
@@ -510,11 +511,11 @@ public class ReportHandler extends Daemon {
                                     backendVersion, backendVersionHash);
                         }
                     }
-                } // end for tabletMetaSyncMap
-                LOG.info("sync {} tablets in db[{}]. backend[{}]", syncCounter, dbId, backendId);
-            } finally {
-                db.writeUnlock();
+                } finally {
+                    olapTable.writeUnlock();
+                }
             }
+            LOG.info("sync {} tablets in db[{}]. backend[{}]", syncCounter, dbId, backendId);
         } // end for dbs
     }
 
@@ -527,23 +528,23 @@ public class ReportHandler extends Daemon {
             if (db == null) {
                 continue;
             }
-            db.writeLock();
-            try {
-                int deleteCounter = 0;
-                List<Long> tabletIds = tabletDeleteFromMeta.get(dbId);
-                List<TabletMeta> tabletMetaList = invertedIndex.getTabletMetaList(tabletIds);
-                for (int i = 0; i < tabletMetaList.size(); i++) {
-                    TabletMeta tabletMeta = tabletMetaList.get(i);
-                    if (tabletMeta == TabletInvertedIndex.NOT_EXIST_TABLET_META) {
-                        continue;
-                    }
-                    long tabletId = tabletIds.get(i);
-                    long tableId = tabletMeta.getTableId();
-                    OlapTable olapTable = (OlapTable) db.getTable(tableId);
-                    if (olapTable == null) {
-                        continue;
-                    }
 
+            int deleteCounter = 0;
+            List<Long> tabletIds = tabletDeleteFromMeta.get(dbId);
+            List<TabletMeta> tabletMetaList = invertedIndex.getTabletMetaList(tabletIds);
+            for (int i = 0; i < tabletMetaList.size(); i++) {
+                TabletMeta tabletMeta = tabletMetaList.get(i);
+                if (tabletMeta == TabletInvertedIndex.NOT_EXIST_TABLET_META) {
+                    continue;
+                }
+                long tabletId = tabletIds.get(i);
+                long tableId = tabletMeta.getTableId();
+                OlapTable olapTable = (OlapTable) db.getTable(tableId);
+                if (olapTable == null) {
+                    continue;
+                }
+                olapTable.writeLock();
+                try {
                     long partitionId = tabletMeta.getPartitionId();
                     Partition partition = olapTable.getPartition(partitionId);
                     if (partition == null) {
@@ -652,11 +653,11 @@ public class ReportHandler extends Daemon {
                             LOG.error("invalid situation. tablet[{}] is empty", tabletId);
                         }
                     }
-                } // end for tabletMetas
-                LOG.info("delete {} replica(s) from catalog in db[{}]", deleteCounter, dbId);
-            } finally {
-                db.writeUnlock();
+                } finally {
+                    olapTable.writeUnlock();
+                }
             }
+            LOG.info("delete {} replica(s) from catalog in db[{}]", deleteCounter, dbId);
         } // end for dbs
 
         if (Config.recover_with_empty_tablet && createReplicaBatchTask.getTaskNum() > 0) {
@@ -791,22 +792,21 @@ public class ReportHandler extends Daemon {
             if (db == null) {
                 continue;
             }
-            db.writeLock();
-            try {
-                List<Long> tabletIds = tabletRecoveryMap.get(dbId);
-                List<TabletMeta> tabletMetaList = invertedIndex.getTabletMetaList(tabletIds);
-                for (int i = 0; i < tabletMetaList.size(); i++) {
-                    TabletMeta tabletMeta = tabletMetaList.get(i);
-                    if (tabletMeta == TabletInvertedIndex.NOT_EXIST_TABLET_META) {
-                        continue;
-                    }
-                    long tabletId = tabletIds.get(i);
-                    long tableId = tabletMeta.getTableId();
-                    OlapTable olapTable = (OlapTable) db.getTable(tableId);
-                    if (olapTable == null) {
-                        continue;
-                    }
-
+            List<Long> tabletIds = tabletRecoveryMap.get(dbId);
+            List<TabletMeta> tabletMetaList = invertedIndex.getTabletMetaList(tabletIds);
+            for (int i = 0; i < tabletMetaList.size(); i++) {
+                TabletMeta tabletMeta = tabletMetaList.get(i);
+                if (tabletMeta == TabletInvertedIndex.NOT_EXIST_TABLET_META) {
+                    continue;
+                }
+                long tabletId = tabletIds.get(i);
+                long tableId = tabletMeta.getTableId();
+                OlapTable olapTable = (OlapTable) db.getTable(tableId);
+                if (olapTable == null) {
+                    continue;
+                }
+                olapTable.writeLock();
+                try {
                     long partitionId = tabletMeta.getPartitionId();
                     Partition partition = olapTable.getPartition(partitionId);
                     if (partition == null) {
@@ -872,9 +872,9 @@ public class ReportHandler extends Daemon {
                             }
                         }
                     }
+                } finally {
+                    olapTable.writeUnlock();
                 }
-            } finally {
-                db.writeUnlock();
             }
         } // end for recovery map
 
@@ -917,12 +917,13 @@ public class ReportHandler extends Daemon {
                 if (db == null) {
                     continue;
                 }
-                db.readLock();
+
+                OlapTable olapTable = (OlapTable) db.getTable(tableId);
+                if (olapTable == null) {
+                    continue;
+                }
+                olapTable.readLock();
                 try {
-                    OlapTable olapTable = (OlapTable) db.getTable(tableId);
-                    if (olapTable == null) {
-                        continue;
-                    }
                     Partition partition = olapTable.getPartition(partitionId);
                     if (partition == null) {
                         continue;
@@ -932,7 +933,7 @@ public class ReportHandler extends Daemon {
                         tabletToInMemory.add(new ImmutableTriple<>(tabletId, tabletInfo.getSchemaHash(), feIsInMemory));
                     }
                 } finally {
-                    db.readUnlock();
+                    olapTable.readUnlock();
                 }
             }
         }
@@ -979,13 +980,10 @@ public class ReportHandler extends Daemon {
         if (db == null) {
             throw new MetaNotFoundException("db[" + dbId + "] does not exist");
         }
-        db.writeLock();
-        try {
-            OlapTable olapTable = (OlapTable) db.getTable(tableId);
-            if (olapTable == null) {
-                throw new MetaNotFoundException("table[" + tableId + "] does not exist");
-            }
 
+        OlapTable olapTable = (OlapTable) db.getTableOrThrowException(tableId, Table.TableType.OLAP);
+        olapTable.writeLock();
+        try {
             Partition partition = olapTable.getPartition(partitionId);
             if (partition == null) {
                 throw new MetaNotFoundException("partition[" + partitionId + "] does not exist");
@@ -1081,7 +1079,7 @@ public class ReportHandler extends Daemon {
                         "replica is enough[" + tablet.getReplicas().size() + "-" + replicationNum + "]");
             }
         } finally {
-            db.writeUnlock();
+            olapTable.writeUnlock();
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectProcessor.java
@@ -278,14 +278,14 @@ public class ConnectProcessor {
             ctx.getState().setError("Unknown database(" + ctx.getDatabase() + ")");
             return;
         }
-        db.readLock();
-        try {
-            Table table = db.getTable(tableName);
-            if (table == null) {
-                ctx.getState().setError("Unknown table(" + tableName + ")");
-                return;
-            }
+        Table table = db.getTable(tableName);
+        if (table == null) {
+            ctx.getState().setError("Unknown table(" + tableName + ")");
+            return;
+        }
 
+        table.readLock();
+        try {
             MysqlSerializer serializer = ctx.getSerializer();
             MysqlChannel channel = ctx.getMysqlChannel();
 
@@ -299,7 +299,7 @@ public class ConnectProcessor {
             }
 
         } finally {
-            db.readUnlock();
+            table.readUnlock();
         }
         ctx.getState().setEof();
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ShowExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ShowExecutor.java
@@ -570,13 +570,13 @@ public class ShowExecutor {
             ErrorReport.reportAnalysisException(ErrorCode.ERR_BAD_DB_ERROR, showStmt.getDb());
         }
         List<List<String>> rows = Lists.newArrayList();
-        db.readLock();
-        try {
-            Table table = db.getTable(showStmt.getTable());
-            if (table == null) {
-                ErrorReport.reportAnalysisException(ErrorCode.ERR_BAD_TABLE_ERROR, showStmt.getTable());
-            }
+        Table table = db.getTable(showStmt.getTable());
+        if (table == null) {
+            ErrorReport.reportAnalysisException(ErrorCode.ERR_BAD_TABLE_ERROR, showStmt.getTable());
+        }
 
+        table.readLock();
+        try {
             List<String> createTableStmt = Lists.newArrayList();
             Catalog.getDdlStmt(table, createTableStmt, null, null, false, true /* hide password */);
             if (createTableStmt.isEmpty()) {
@@ -599,7 +599,7 @@ public class ShowExecutor {
                 resultSet = new ShowResultSet(showStmt.getMetaData(), rows);
             }
         } finally {
-            db.readUnlock();
+            table.readUnlock();
         }
     }
 
@@ -615,15 +615,15 @@ public class ShowExecutor {
         List<List<String>> rows = Lists.newArrayList();
         Database db = ctx.getCatalog().getDb(showStmt.getDb());
         if (db != null) {
-            db.readLock();
-            try {
-                Table table = db.getTable(showStmt.getTable());
-                if (table != null) {
-                    PatternMatcher matcher = null;
-                    if (showStmt.getPattern() != null) {
-                        matcher = PatternMatcher.createMysqlPattern(showStmt.getPattern(),
-                                                                    CaseSensibility.COLUMN.getCaseSensibility());
-                    }
+            Table table = db.getTable(showStmt.getTable());
+            if (table != null) {
+                PatternMatcher matcher = null;
+                if (showStmt.getPattern() != null) {
+                    matcher = PatternMatcher.createMysqlPattern(showStmt.getPattern(),
+                            CaseSensibility.COLUMN.getCaseSensibility());
+                }
+                table.readLock();
+                try {
                     List<Column> columns = table.getBaseSchema();
                     for (Column col : columns) {
                         if (matcher != null && !matcher.match(col.getName())) {
@@ -639,29 +639,29 @@ public class ShowExecutor {
                             // Field Type Collation Null Key Default Extra
                             // Privileges Comment
                             rows.add(Lists.newArrayList(columnName,
-                                                        columnType,
-                                                        "",
-                                                        isAllowNull,
-                                                        isKey,
-                                                        defaultValue,
-                                                        aggType,
-                                                        "",
-                                                        col.getComment()));
+                                    columnType,
+                                    "",
+                                    isAllowNull,
+                                    isKey,
+                                    defaultValue,
+                                    aggType,
+                                    "",
+                                    col.getComment()));
                         } else {
                             // Field Type Null Key Default Extra
                             rows.add(Lists.newArrayList(columnName,
-                                                        columnType,
-                                                        isAllowNull,
-                                                        isKey,
-                                                        defaultValue,
-                                                        aggType));
+                                    columnType,
+                                    isAllowNull,
+                                    isKey,
+                                    defaultValue,
+                                    aggType));
                         }
                     }
-                } else {
-                    ErrorReport.reportAnalysisException(ErrorCode.ERR_BAD_TABLE_ERROR, db.getFullName() + "." + showStmt.getTable());
+                } finally {
+                    table.readUnlock();
                 }
-            } finally {
-                db.readUnlock();
+            } else {
+                ErrorReport.reportAnalysisException(ErrorCode.ERR_BAD_TABLE_ERROR, db.getFullName() + "." + showStmt.getTable());
             }
         } else {
             ErrorReport.reportAnalysisException(ErrorCode.ERR_BAD_TABLE_ERROR, showStmt.getDb() + "." + showStmt.getTable());
@@ -677,22 +677,23 @@ public class ShowExecutor {
         if (db == null) {
             ErrorReport.reportAnalysisException(ErrorCode.ERR_BAD_TABLE_ERROR, showStmt.getTableName().toString());
         }
-        db.readLock();
-        try {
-            Table table = db.getTable(showStmt.getTableName().getTbl());
-            if (table != null && table instanceof OlapTable) {
+
+        Table table = db.getTable(showStmt.getTableName().getTbl());
+        if (table != null && table instanceof OlapTable) {
+            table.readLock();
+            try {
                 List<Index> indexes = ((OlapTable) table).getIndexes();
                 for (Index index : indexes) {
                     rows.add(Lists.newArrayList(showStmt.getTableName().toString(), "", index.getIndexName(),
                             "", index.getColumns().stream().collect(Collectors.joining(",")), "", "", "", "",
                             "", index.getIndexType().name(), index.getComment()));
                 }
-            } else {
-                ErrorReport.reportAnalysisException(ErrorCode.ERR_BAD_TABLE_ERROR,
-                        db.getFullName() + "." + showStmt.getTableName().toString());
+            } finally {
+                table.readUnlock();
             }
-        } finally {
-            db.readUnlock();
+        } else {
+            ErrorReport.reportAnalysisException(ErrorCode.ERR_BAD_TABLE_ERROR,
+                    db.getFullName() + "." + showStmt.getTableName().toString());
         }
         resultSet = new ShowResultSet(showStmt.getMetaData(), rows);
     }
@@ -1151,16 +1152,15 @@ public class ShowExecutor {
                     break;
                 }
                 dbName = db.getFullName();
+                Table table = db.getTable(tableId);
+                if (table == null || !(table instanceof OlapTable)) {
+                    isSync = false;
+                    break;
+                }
 
-                db.readLock();
+                table.readLock();
                 try {
-                    Table table = db.getTable(tableId);
-                    if (table == null || !(table instanceof OlapTable)) {
-                        isSync = false;
-                        break;
-                    }
                     tableName = table.getName();
-
                     OlapTable olapTable = (OlapTable) table;
                     Partition partition = olapTable.getPartition(partitionId);
                     if (partition == null) {
@@ -1197,7 +1197,7 @@ public class ShowExecutor {
                     }
 
                 } finally {
-                    db.readUnlock();
+                    table.readUnlock();
                 }
             } while (false);
 
@@ -1213,16 +1213,16 @@ public class ShowExecutor {
                 ErrorReport.reportAnalysisException(ErrorCode.ERR_BAD_DB_ERROR, showStmt.getDbName());
             }
 
-            db.readLock();
-            try {
-                Table table = db.getTable(showStmt.getTableName());
-                if (table == null) {
-                    ErrorReport.reportAnalysisException(ErrorCode.ERR_BAD_TABLE_ERROR, showStmt.getTableName());
-                }
-                if (!(table instanceof OlapTable)) {
-                    ErrorReport.reportAnalysisException(ErrorCode.ERR_NOT_OLAP_TABLE, showStmt.getTableName());
-                }
+            Table table = db.getTable(showStmt.getTableName());
+            if (table == null) {
+                ErrorReport.reportAnalysisException(ErrorCode.ERR_BAD_TABLE_ERROR, showStmt.getTableName());
+            }
+            if (!(table instanceof OlapTable)) {
+                ErrorReport.reportAnalysisException(ErrorCode.ERR_NOT_OLAP_TABLE, showStmt.getTableName());
+            }
 
+            table.readLock();
+            try {
                 OlapTable olapTable = (OlapTable) table;
                 long sizeLimit = -1;
                 if (showStmt.hasOffset() && showStmt.hasLimit()) {
@@ -1298,7 +1298,7 @@ public class ShowExecutor {
                     rows.add(oneTablet);
                 }
             } finally {
-                db.readUnlock();
+                table.readUnlock();
             }
         }
 
@@ -1536,19 +1536,28 @@ public class ShowExecutor {
         List<List<String>> rows = Lists.newArrayList();
         Database db = ctx.getCatalog().getDb(showDynamicPartitionStmt.getDb());
         if (db != null) {
+            List<Table> tableList = null;
             db.readLock();
             try {
-                for (Table tbl : db.getTables()) {
-                    if (!(tbl instanceof OlapTable)) {
-                        continue;
-                    }
+                tableList = db.getTables();
+            } finally {
+                db.readUnlock();
+            }
 
-                    DynamicPartitionScheduler dynamicPartitionScheduler = Catalog.getCurrentCatalog().getDynamicPartitionScheduler();
-                    OlapTable olapTable = (OlapTable) tbl;
+            for (Table tbl : tableList) {
+                if (!(tbl instanceof OlapTable)) {
+                    continue;
+                }
+
+                DynamicPartitionScheduler dynamicPartitionScheduler = Catalog.getCurrentCatalog().getDynamicPartitionScheduler();
+                OlapTable olapTable = (OlapTable) tbl;
+                olapTable.readLock();
+                try {
                     if (!olapTable.dynamicPartitionExists()) {
                         dynamicPartitionScheduler.removeRuntimeInfo(olapTable.getName());
                         continue;
                     }
+
                     // check tbl privs
                     if (!Catalog.getCurrentCatalog().getAuth().checkTblPriv(ConnectContext.get(),
                             db.getFullName(), olapTable.getName(),
@@ -1574,10 +1583,11 @@ public class ShowExecutor {
                             dynamicPartitionScheduler.getRuntimeInfo(tableName, DynamicPartitionScheduler.DYNAMIC_PARTITION_STATE),
                             dynamicPartitionScheduler.getRuntimeInfo(tableName, DynamicPartitionScheduler.CREATE_PARTITION_MSG),
                             dynamicPartitionScheduler.getRuntimeInfo(tableName, DynamicPartitionScheduler.DROP_PARTITION_MSG)));
+                } finally {
+                    olapTable.readUnlock();
                 }
-            } finally {
-                db.readUnlock();
             }
+
             resultSet = new ShowResultSet(showDynamicPartitionStmt.getMetaData(), rows);
         }
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ShowExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ShowExecutor.java
@@ -1263,7 +1263,7 @@ public class ShowExecutor {
                         if (indexId > -1 && index.getId() != indexId) {
                             continue;
                         }
-                        TabletsProcDir procDir = new TabletsProcDir(db, index);
+                        TabletsProcDir procDir = new TabletsProcDir(table, index);
                         tabletInfos.addAll(procDir.fetchComparableResult(
                                 showStmt.getVersion(), showStmt.getBackendId(), showStmt.getReplicaState()));
                         if (sizeLimit > -1 && tabletInfos.size() >= sizeLimit) {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -468,6 +468,7 @@ public class StmtExecutor {
                 }
                 insertStmt.getTables(analyzer, tableMap, parentViewNameSet);
             }
+            // table id in tableList is in ascending order because that table map is a sorted map
             List<Table> tables = Lists.newArrayList(tableMap.values());
             MetaLockUtils.readLockTables(tables);
             try {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.qe;
 
+import com.google.common.collect.Maps;
 import org.apache.doris.analysis.Analyzer;
 import org.apache.doris.analysis.CreateTableAsSelectStmt;
 import org.apache.doris.analysis.DdlStmt;
@@ -40,8 +41,8 @@ import org.apache.doris.analysis.UnsupportedStmt;
 import org.apache.doris.analysis.UseStmt;
 import org.apache.doris.catalog.Catalog;
 import org.apache.doris.catalog.Column;
-import org.apache.doris.catalog.Database;
 import org.apache.doris.catalog.ScalarType;
+import org.apache.doris.catalog.Table;
 import org.apache.doris.catalog.Table.TableType;
 import org.apache.doris.catalog.Type;
 import org.apache.doris.common.AnalysisException;
@@ -54,6 +55,7 @@ import org.apache.doris.common.MetaNotFoundException;
 import org.apache.doris.common.UserException;
 import org.apache.doris.common.Version;
 import org.apache.doris.common.util.DebugUtil;
+import org.apache.doris.common.util.MetaLockUtils;
 import org.apache.doris.common.util.ProfileManager;
 import org.apache.doris.common.util.QueryPlannerProfile;
 import org.apache.doris.common.util.RuntimeProfile;
@@ -87,7 +89,6 @@ import org.apache.doris.transaction.TransactionStatus;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -399,26 +400,6 @@ public class StmtExecutor {
         ProfileManager.getInstance().pushProfile(profile);
     }
 
-    // Lock all database before analyze
-    private void lock(Map<String, Database> dbs) {
-        if (dbs == null) {
-            return;
-        }
-        for (Database db : dbs.values()) {
-            db.readLock();
-        }
-    }
-
-    // unLock all database after analyze
-    private void unLock(Map<String, Database> dbs) {
-        if (dbs == null) {
-            return;
-        }
-        for (Database db : dbs.values()) {
-            db.readUnlock();
-        }
-    }
-
     // Analyze one statement to structure in memory.
     public void analyze(TQueryOptions tQueryOptions) throws UserException {
         LOG.info("begin to analyze stmt: {}, forwarded stmt id: {}", context.getStmtId(), context.getForwardedStmtId());
@@ -472,12 +453,12 @@ public class StmtExecutor {
         if (parsedStmt instanceof QueryStmt
                 || parsedStmt instanceof InsertStmt
                 || parsedStmt instanceof CreateTableAsSelectStmt) {
-            Map<String, Database> dbs = Maps.newTreeMap();
+            Map<Long, Table> tableMap = Maps.newTreeMap();
             QueryStmt queryStmt;
             Set<String> parentViewNameSet = Sets.newHashSet();
             if (parsedStmt instanceof QueryStmt) {
                 queryStmt = (QueryStmt) parsedStmt;
-                queryStmt.getDbs(analyzer, dbs, parentViewNameSet);
+                queryStmt.getTables(analyzer, tableMap, parentViewNameSet);
             } else {
                 InsertStmt insertStmt;
                 if (parsedStmt instanceof InsertStmt) {
@@ -485,10 +466,10 @@ public class StmtExecutor {
                 } else {
                     insertStmt = ((CreateTableAsSelectStmt) parsedStmt).getInsertStmt();
                 }
-                insertStmt.getDbs(analyzer, dbs, parentViewNameSet);
+                insertStmt.getTables(analyzer, tableMap, parentViewNameSet);
             }
-
-            lock(dbs);
+            List<Table> tables = Lists.newArrayList(tableMap.values());
+            MetaLockUtils.readLockTables(tables);
             try {
                 analyzeAndGenerateQueryPlan(tQueryOptions);
             } catch (MVSelectFailedException e) {
@@ -505,7 +486,7 @@ public class StmtExecutor {
                 LOG.warn("Analyze failed because ", e);
                 throw new AnalysisException("Unexpected exception: " + e.getMessage());
             } finally {
-                unLock(dbs);
+                MetaLockUtils.readUnlockTables(tables);
             }
         } else {
             try {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -898,7 +898,7 @@ public class StmtExecutor {
                 return;
             }
             if (Catalog.getCurrentGlobalTransactionMgr().commitAndPublishTransaction(
-                    insertStmt.getDbObj(), insertStmt.getTransactionId(),
+                    insertStmt.getDbObj(), Lists.newArrayList(insertStmt.getTargetTable()), insertStmt.getTransactionId(),
                     TabletCommitInfo.fromThrift(coord.getCommitInfos()),
                     context.getSessionVariable().getInsertVisibleTimeoutMs())) {
                 txnStatus = TransactionStatus.VISIBLE;

--- a/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
@@ -268,7 +268,6 @@ public class FrontendServiceImpl implements FrontendService.Iface {
                         table.getName(), PrivPredicate.SHOW)) {
                     continue;
                 }
-
                 table.readLock();
                 try {
                     if (!Catalog.getCurrentCatalog().getAuth().checkTblPriv(currentUser, params.db,

--- a/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
@@ -922,7 +922,6 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         }
         long timeoutMs = request.isSetThriftRpcTimeoutMs() ? request.getThriftRpcTimeoutMs() : 5000;
         Table table = db.getTableOrThrowException(request.getTbl(), TableType.OLAP);
-        table.readLock();
         if (!table.tryReadLock(timeoutMs, TimeUnit.MILLISECONDS)) {
             throw new UserException("get table read lock timeout, database=" + fullDbName + ",table=" + table.getName());
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
@@ -269,19 +269,27 @@ public class FrontendServiceImpl implements FrontendService.Iface {
                     continue;
                 }
 
-                if (matcher != null && !matcher.match(table.getName())) {
-                    continue;
-                }
-                TTableStatus status = new TTableStatus();
-                status.setName(table.getName());
-                status.setType(table.getMysqlType());
-                status.setEngine(table.getEngine());
-                status.setComment(table.getComment());
-                status.setCreateTime(table.getCreateTime());
-                status.setLastCheckTime(table.getLastCheckTime());
-                status.setDdlSql(table.getDdlSql());
+                table.readLock();
+                try {
+                    if (!Catalog.getCurrentCatalog().getAuth().checkTblPriv(currentUser, params.db,
+                            table.getName(), PrivPredicate.SHOW)) {
+                        continue;
+                    }
 
-                tablesResult.add(status);
+                    if (matcher != null && !matcher.match(table.getName())) {
+                        continue;
+                    }
+                    TTableStatus status = new TTableStatus();
+                    status.setName(table.getName());
+                    status.setType(table.getMysqlType());
+                    status.setEngine(table.getEngine());
+                    status.setComment(table.getComment());
+                    status.setCreateTime(table.getCreateTime());
+                    status.setLastCheckTime(table.getLastCheckTime());
+                    tablesResult.add(status);
+                } finally {
+                    table.readUnlock();
+                }
             }
         }
         return result;

--- a/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
@@ -822,9 +822,11 @@ public class FrontendServiceImpl implements FrontendService.Iface {
             }
             throw new UserException("unknown database, database=" + dbName);
         }
+
         long timeoutMs = request.isSetThriftRpcTimeoutMs() ? request.getThriftRpcTimeoutMs() : 5000;
+        Table table = db.getTableOrThrowException(request.getTbl(), TableType.OLAP);
         boolean ret = Catalog.getCurrentGlobalTransactionMgr().commitAndPublishTransaction(
-                        db, request.getTxnId(),
+                        db, Lists.newArrayList(table), request.getTxnId(),
                         TabletCommitInfo.fromThrift(request.getCommitInfos()),
                         timeoutMs, TxnCommitAttachment.fromThrift(request.txnCommitAttachment));
         if (ret) {

--- a/fe/fe-core/src/main/java/org/apache/doris/system/SystemInfoService.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/system/SystemInfoService.java
@@ -896,7 +896,6 @@ public class SystemInfoService {
         if ((atomicLong = idToReportVersionRef.get(backendId)) != null) {
             Database db = Catalog.getCurrentCatalog().getDb(dbId);
             if (db != null) {
-                db.readLock();
                 try {
                     atomicLong.set(newReportVersion);
                     LOG.debug("update backend {} report version: {}, db: {}", backendId, newReportVersion, dbId);

--- a/fe/fe-core/src/main/java/org/apache/doris/system/SystemInfoService.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/system/SystemInfoService.java
@@ -20,7 +20,6 @@ package org.apache.doris.system;
 import org.apache.doris.catalog.Catalog;
 import org.apache.doris.catalog.Database;
 import org.apache.doris.catalog.DiskInfo;
-import org.apache.doris.catalog.Table;
 import org.apache.doris.cluster.Cluster;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.DdlException;
@@ -30,6 +29,11 @@ import org.apache.doris.common.Status;
 import org.apache.doris.metric.MetricRepo;
 import org.apache.doris.system.Backend.BackendState;
 import org.apache.doris.thrift.TStatusCode;
+import org.apache.doris.thrift.TStorageMedium;
+
+import org.apache.commons.validator.routines.InetAddressValidator;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
@@ -39,11 +43,6 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
-
-import org.apache.commons.validator.routines.InetAddressValidator;
-import org.apache.doris.thrift.TStorageMedium;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
@@ -900,18 +899,8 @@ public class SystemInfoService {
                 LOG.warn("failed to update backend report version, db {} does not exist", dbId);
                 return;
             }
-            Table table = db.getTable(tableId);
-            if (table == null) {
-                LOG.warn("failed to update backend report version, table {} in db {} does not exist", tableId, dbId);
-                return;
-            }
-            table.readLock();
-            try {
-                atomicLong.set(newReportVersion);
-                LOG.debug("update backend {} report version: {}, db: {}, table: {}", backendId, newReportVersion, dbId, tableId);
-            } finally {
-                table.readUnlock();
-            }
+            atomicLong.set(newReportVersion);
+            LOG.debug("update backend {} report version: {}, db: {}, table: {}", backendId, newReportVersion, dbId, tableId);
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/system/SystemInfoService.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/system/SystemInfoService.java
@@ -18,7 +18,6 @@
 package org.apache.doris.system;
 
 import org.apache.doris.catalog.Catalog;
-import org.apache.doris.catalog.Database;
 import org.apache.doris.catalog.DiskInfo;
 import org.apache.doris.cluster.Cluster;
 import org.apache.doris.common.AnalysisException;
@@ -894,17 +893,8 @@ public class SystemInfoService {
     public void updateBackendReportVersion(long backendId, long newReportVersion, long dbId) {
         AtomicLong atomicLong = null;
         if ((atomicLong = idToReportVersionRef.get(backendId)) != null) {
-            Database db = Catalog.getCurrentCatalog().getDb(dbId);
-            if (db != null) {
-                try {
-                    atomicLong.set(newReportVersion);
-                    LOG.debug("update backend {} report version: {}, db: {}", backendId, newReportVersion, dbId);
-                } finally {
-                    db.readUnlock();
-                }
-            } else {
-                LOG.warn("failed to update backend report version, db {} does not exist", dbId);
-            }
+            atomicLong.set(newReportVersion);
+            LOG.debug("update backend {} report version: {}, db: {}", backendId, newReportVersion, dbId);
         } else {
             LOG.warn("failed to update backend report version, backend {} does not exist", backendId);
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/task/LoadPendingTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/task/LoadPendingTask.java
@@ -32,10 +32,10 @@ import org.apache.doris.transaction.TransactionState.LoadJobSourceType;
 import org.apache.doris.transaction.TransactionState.TxnCoordinator;
 import org.apache.doris.transaction.TransactionState.TxnSourceType;
 
-import com.google.common.base.Joiner;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+
+import com.google.common.base.Joiner;
 
 import java.util.List;
 import java.util.UUID;
@@ -69,7 +69,6 @@ public abstract class LoadPendingTask extends MasterTask {
         
         // get db
         long dbId = job.getDbId();
-        long tableId = job.getTableId();
         db = Catalog.getCurrentCatalog().getDb(dbId);
         if (db == null) {
             load.cancelLoadJob(job, CancelType.ETL_SUBMIT_FAIL, "db does not exist. id: " + dbId);

--- a/fe/fe-core/src/main/java/org/apache/doris/task/MiniLoadPendingTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/task/MiniLoadPendingTask.java
@@ -91,14 +91,14 @@ public class MiniLoadPendingTask extends LoadPendingTask {
             long backendId = taskInfo.getBackendId();
             long tableId = taskInfo.getTableId();
 
-            // All the following operation will process when destDb's read lock are hold.
-            db.readLock();
-            try {
-                destTable = (OlapTable) db.getTable(tableId);
-                if (destTable == null) {
-                    throw new LoadException("table does not exist. id: " + tableId);
-                }
+            // All the following operation will process when destTable's read lock are hold.
+            destTable = (OlapTable) db.getTable(tableId);
+            if (destTable == null) {
+                throw new LoadException("table does not exist. id: " + tableId);
+            }
 
+            destTable.readLock();
+            try {
                 registerToDesc();
                 tableSink = new DataSplitSink(destTable, destTupleDesc);
 
@@ -109,7 +109,7 @@ public class MiniLoadPendingTask extends LoadPendingTask {
                 }
                 requests.add(new Pair<Long, TMiniLoadEtlTaskRequest>(backendId, createRequest(taskId)));
             } finally {
-                db.readUnlock();
+                destTable.readUnlock();
             }
         }
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/task/StreamLoadTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/task/StreamLoadTask.java
@@ -28,7 +28,6 @@ import org.apache.doris.analysis.ImportWhereStmt;
 import org.apache.doris.analysis.PartitionNames;
 import org.apache.doris.analysis.SqlParser;
 import org.apache.doris.analysis.SqlScanner;
-import org.apache.doris.catalog.Database;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.UserException;
@@ -196,14 +195,14 @@ public class StreamLoadTask implements LoadTaskInfo {
         return sequenceCol;
     }
 
-    public static StreamLoadTask fromTStreamLoadPutRequest(TStreamLoadPutRequest request, Database db) throws UserException {
+    public static StreamLoadTask fromTStreamLoadPutRequest(TStreamLoadPutRequest request) throws UserException {
         StreamLoadTask streamLoadTask = new StreamLoadTask(request.getLoadId(), request.getTxnId(),
                                                            request.getFileType(), request.getFormatType());
-        streamLoadTask.setOptionalFromTSLPutRequest(request, db);
+        streamLoadTask.setOptionalFromTSLPutRequest(request);
         return streamLoadTask;
     }
 
-    private void setOptionalFromTSLPutRequest(TStreamLoadPutRequest request, Database db) throws UserException {
+    private void setOptionalFromTSLPutRequest(TStreamLoadPutRequest request) throws UserException {
         if (request.isSetColumns()) {
             setColumnToColumnExpr(request.getColumns());
         }
@@ -331,6 +330,7 @@ public class StreamLoadTask implements LoadTaskInfo {
         columnSeparator.analyze();
     }
 
+    @Override
     public long getMemLimit() {
         return execMemLimit;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/transaction/DatabaseTransactionMgr.java
@@ -40,6 +40,7 @@ import org.apache.doris.common.MetaNotFoundException;
 import org.apache.doris.common.Pair;
 import org.apache.doris.common.UserException;
 import org.apache.doris.common.util.DebugUtil;
+import org.apache.doris.common.util.MetaLockUtils;
 import org.apache.doris.common.util.TimeUtils;
 import org.apache.doris.common.util.Util;
 import org.apache.doris.metric.MetricRepo;
@@ -679,9 +680,7 @@ public class DatabaseTransactionMgr {
         }
 
         List<Table> tableList = db.getTablesOnIdOrderOrThrowException(tableIdList);
-        for (Table table : tableList) {
-            table.writeLock();
-        }
+        MetaLockUtils.writeLockTables(tableList);
         try {
             boolean hasError = false;
             Iterator<TableCommitInfo> tableCommitInfoIterator = transactionState.getIdToTableCommitInfos().values().iterator();
@@ -822,9 +821,7 @@ public class DatabaseTransactionMgr {
             }
             updateCatalogAfterVisible(transactionState, db);
         } finally {
-            for (int i = tableList.size() - 1; i >=0; i--) {
-                tableList.get(i).writeUnlock();
-            }
+            MetaLockUtils.writeUnlockTables(tableList);
         }
         LOG.info("finish transaction {} successfully", transactionState);
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/transaction/DatabaseTransactionMgr.java
@@ -349,7 +349,7 @@ public class DatabaseTransactionMgr {
      * 5. persistent transactionState
      * 6. update nextVersion because of the failure of persistent transaction resulting in error version
      */
-    public void commitTransaction(long transactionId, List<TabletCommitInfo> tabletCommitInfos,
+    public void commitTransaction(List<Table> tableList, long transactionId, List<TabletCommitInfo> tabletCommitInfos,
                                   TxnCommitAttachment txnCommitAttachment)
             throws UserException {
         // 1. check status
@@ -393,6 +393,10 @@ public class DatabaseTransactionMgr {
         TabletInvertedIndex tabletInvertedIndex = catalog.getTabletInvertedIndex();
         Map<Long, Set<Long>> tabletToBackends = new HashMap<>();
         Map<Long, Set<Long>> tableToPartition = new HashMap<>();
+        Map<Long, Table> idToTable = new HashMap<>();
+        for (int i = 0; i < tableList.size(); i++) {
+            idToTable.put(tableList.get(i).getId(), tableList.get(i));
+        }
         // 2. validate potential exists problem: db->table->partition
         // guarantee exist exception during a transaction
         // if index is dropped, it does not matter.
@@ -408,7 +412,7 @@ public class DatabaseTransactionMgr {
             }
             long tabletId = tabletIds.get(i);
             long tableId = tabletMeta.getTableId();
-            OlapTable tbl = (OlapTable) db.getTable(tableId);
+            OlapTable tbl = (OlapTable) idToTable.get(tableId);
             if (tbl == null) {
                 // this can happen when tableId == -1 (tablet being dropping)
                 // or table really not exist.

--- a/fe/fe-core/src/main/java/org/apache/doris/transaction/GlobalTransactionMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/transaction/GlobalTransactionMgr.java
@@ -150,9 +150,9 @@ public class GlobalTransactionMgr implements Writable {
 
     }
 
-    public void commitTransaction(long dbId, long transactionId, List<TabletCommitInfo> tabletCommitInfos)
+    public void commitTransaction(long dbId, List<Table> tableList, long transactionId, List<TabletCommitInfo> tabletCommitInfos)
             throws UserException {
-        commitTransaction(dbId, transactionId, tabletCommitInfos, null);
+        commitTransaction(dbId, tableList, transactionId, tabletCommitInfos, null);
     }
     
     /**
@@ -164,7 +164,7 @@ public class GlobalTransactionMgr implements Writable {
      * @note it is necessary to optimize the `lock` mechanism and `lock` scope resulting from wait lock long time
      * @note callers should get db.write lock before call this api
      */
-    public void commitTransaction(long dbId, long transactionId, List<TabletCommitInfo> tabletCommitInfos,
+    public void commitTransaction(long dbId, List<Table> tableList, long transactionId, List<TabletCommitInfo> tabletCommitInfos,
                                   TxnCommitAttachment txnCommitAttachment)
             throws UserException {
         if (Config.disable_load_job) {
@@ -173,7 +173,7 @@ public class GlobalTransactionMgr implements Writable {
         
         LOG.debug("try to commit transaction: {}", transactionId);
         DatabaseTransactionMgr dbTransactionMgr = getDatabaseTransactionMgr(dbId);
-        dbTransactionMgr.commitTransaction(transactionId, tabletCommitInfos, txnCommitAttachment);
+        dbTransactionMgr.commitTransaction(tableList, transactionId, tabletCommitInfos, txnCommitAttachment);
     }
     
     public boolean commitAndPublishTransaction(Database db, List<Table> tableList, long transactionId,
@@ -190,7 +190,7 @@ public class GlobalTransactionMgr implements Writable {
             table.writeLock();
         }
         try {
-            commitTransaction(db.getId(), transactionId, tabletCommitInfos, txnCommitAttachment);
+            commitTransaction(db.getId(), tableList, transactionId, tabletCommitInfos, txnCommitAttachment);
         } finally {
             for (int i = tableList.size() - 1; i >= 0; i--) {
                 tableList.get(i).writeUnlock();

--- a/fe/fe-core/src/main/java/org/apache/doris/transaction/TransactionState.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/transaction/TransactionState.java
@@ -493,12 +493,7 @@ public class TransactionState implements Writable {
         return transactionStatus == TransactionStatus.PREPARE && currentMillis - prepareTime > timeoutMs;
     }
 
-    /*
-     * Add related table indexes to the transaction.
-     * If function should always be called before adding this transaction state to transaction manager,
-     * No other thread will access this state. So no need to lock
-     */
-    public void addTableIndexes(OlapTable table) {
+    public synchronized void addTableIndexes(OlapTable table) {
         Set<Long> indexIds = loadedTblIndexes.get(table.getId());
         if (indexIds == null) {
             indexIds = Sets.newHashSet();

--- a/fe/fe-core/src/test/java/org/apache/doris/alter/AlterTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/alter/AlterTest.java
@@ -571,6 +571,7 @@ public class AlterTest {
         Assert.assertNotNull(replace3.getIndexIdByName("r2"));
     }
 
+    @Test
     public void testExternalTableAlterOperations() throws Exception {
         // external table do not support partition operation
         String stmt = "alter table test.odbc_table add partition p3 values less than('2020-04-01'), add partition p4 values less than('2020-05-01')";

--- a/fe/fe-core/src/test/java/org/apache/doris/alter/RollupJobV2Test.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/alter/RollupJobV2Test.java
@@ -158,12 +158,7 @@ public class RollupJobV2Test {
         alterClauses.add(clause2);
         Database db = masterCatalog.getDb(CatalogTestUtil.testDbId1);
         OlapTable olapTable = (OlapTable) db.getTable(CatalogTestUtil.testTableId1);
-        olapTable.writeLock();
-        try {
-            materializedViewHandler.process(alterClauses, db.getClusterName(), db, olapTable);
-        } finally {
-            olapTable.writeUnlock();
-        }
+        materializedViewHandler.process(alterClauses, db.getClusterName(), db, olapTable);
         Map<Long, AlterJobV2> alterJobsV2 = materializedViewHandler.getAlterJobsV2();
 
         materializedViewHandler.runAfterCatalogReady();
@@ -183,12 +178,7 @@ public class RollupJobV2Test {
         alterClauses.add(clause);
         Database db = masterCatalog.getDb(CatalogTestUtil.testDbId1);
         OlapTable olapTable = (OlapTable) db.getTable(CatalogTestUtil.testTableId1);
-        olapTable.writeLock();
-        try {
-            materializedViewHandler.process(alterClauses, db.getClusterName(), db, olapTable);
-        } finally {
-            olapTable.writeUnlock();
-        }
+        materializedViewHandler.process(alterClauses, db.getClusterName(), db, olapTable);
         Map<Long, AlterJobV2> alterJobsV2 = materializedViewHandler.getAlterJobsV2();
         Assert.assertEquals(1, alterJobsV2.size());
         Assert.assertEquals(OlapTableState.ROLLUP, olapTable.getState());
@@ -208,12 +198,7 @@ public class RollupJobV2Test {
         Database db = masterCatalog.getDb(CatalogTestUtil.testDbId1);
         OlapTable olapTable = (OlapTable) db.getTable(CatalogTestUtil.testTableId1);
         Partition testPartition = olapTable.getPartition(CatalogTestUtil.testPartitionId1);
-        olapTable.writeLock();
-        try {
-            materializedViewHandler.process(alterClauses, db.getClusterName(), db, olapTable);
-        } finally {
-            olapTable.writeUnlock();
-        }
+        materializedViewHandler.process(alterClauses, db.getClusterName(), db, olapTable);
         Map<Long, AlterJobV2> alterJobsV2 = materializedViewHandler.getAlterJobsV2();
         Assert.assertEquals(1, alterJobsV2.size());
         RollupJobV2 rollupJob = (RollupJobV2) alterJobsV2.values().stream().findAny().get();
@@ -317,12 +302,7 @@ public class RollupJobV2Test {
         Database db = masterCatalog.getDb(CatalogTestUtil.testDbId1);
         OlapTable olapTable = (OlapTable) db.getTable(CatalogTestUtil.testTableId1);
         Partition testPartition = olapTable.getPartition(CatalogTestUtil.testPartitionId1);
-        olapTable.writeLock();
-        try {
-            materializedViewHandler.process(alterClauses, db.getClusterName(), db, olapTable);
-        } finally {
-            olapTable.writeUnlock();
-        }
+        materializedViewHandler.process(alterClauses, db.getClusterName(), db, olapTable);
         Map<Long, AlterJobV2> alterJobsV2 = materializedViewHandler.getAlterJobsV2();
         Assert.assertEquals(1, alterJobsV2.size());
         RollupJobV2 rollupJob = (RollupJobV2) alterJobsV2.values().stream().findAny().get();

--- a/fe/fe-core/src/test/java/org/apache/doris/alter/RollupJobV2Test.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/alter/RollupJobV2Test.java
@@ -158,7 +158,12 @@ public class RollupJobV2Test {
         alterClauses.add(clause2);
         Database db = masterCatalog.getDb(CatalogTestUtil.testDbId1);
         OlapTable olapTable = (OlapTable) db.getTable(CatalogTestUtil.testTableId1);
-        materializedViewHandler.process(alterClauses, db.getClusterName(), db, olapTable);
+        olapTable.writeLock();
+        try {
+            materializedViewHandler.process(alterClauses, db.getClusterName(), db, olapTable);
+        } finally {
+            olapTable.writeUnlock();
+        }
         Map<Long, AlterJobV2> alterJobsV2 = materializedViewHandler.getAlterJobsV2();
 
         materializedViewHandler.runAfterCatalogReady();
@@ -178,7 +183,12 @@ public class RollupJobV2Test {
         alterClauses.add(clause);
         Database db = masterCatalog.getDb(CatalogTestUtil.testDbId1);
         OlapTable olapTable = (OlapTable) db.getTable(CatalogTestUtil.testTableId1);
-        materializedViewHandler.process(alterClauses, db.getClusterName(), db, olapTable);
+        olapTable.writeLock();
+        try {
+            materializedViewHandler.process(alterClauses, db.getClusterName(), db, olapTable);
+        } finally {
+            olapTable.writeUnlock();
+        }
         Map<Long, AlterJobV2> alterJobsV2 = materializedViewHandler.getAlterJobsV2();
         Assert.assertEquals(1, alterJobsV2.size());
         Assert.assertEquals(OlapTableState.ROLLUP, olapTable.getState());
@@ -198,7 +208,12 @@ public class RollupJobV2Test {
         Database db = masterCatalog.getDb(CatalogTestUtil.testDbId1);
         OlapTable olapTable = (OlapTable) db.getTable(CatalogTestUtil.testTableId1);
         Partition testPartition = olapTable.getPartition(CatalogTestUtil.testPartitionId1);
-        materializedViewHandler.process(alterClauses, db.getClusterName(), db, olapTable);
+        olapTable.writeLock();
+        try {
+            materializedViewHandler.process(alterClauses, db.getClusterName(), db, olapTable);
+        } finally {
+            olapTable.writeUnlock();
+        }
         Map<Long, AlterJobV2> alterJobsV2 = materializedViewHandler.getAlterJobsV2();
         Assert.assertEquals(1, alterJobsV2.size());
         RollupJobV2 rollupJob = (RollupJobV2) alterJobsV2.values().stream().findAny().get();
@@ -302,7 +317,12 @@ public class RollupJobV2Test {
         Database db = masterCatalog.getDb(CatalogTestUtil.testDbId1);
         OlapTable olapTable = (OlapTable) db.getTable(CatalogTestUtil.testTableId1);
         Partition testPartition = olapTable.getPartition(CatalogTestUtil.testPartitionId1);
-        materializedViewHandler.process(alterClauses, db.getClusterName(), db, olapTable);
+        olapTable.writeLock();
+        try {
+            materializedViewHandler.process(alterClauses, db.getClusterName(), db, olapTable);
+        } finally {
+            olapTable.writeUnlock();
+        }
         Map<Long, AlterJobV2> alterJobsV2 = materializedViewHandler.getAlterJobsV2();
         Assert.assertEquals(1, alterJobsV2.size());
         RollupJobV2 rollupJob = (RollupJobV2) alterJobsV2.values().stream().findAny().get();

--- a/fe/fe-core/src/test/java/org/apache/doris/alter/SchemaChangeJobV2Test.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/alter/SchemaChangeJobV2Test.java
@@ -137,12 +137,7 @@ public class SchemaChangeJobV2Test {
         alterClauses.add(addColumnClause);
         Database db = masterCatalog.getDb(CatalogTestUtil.testDbId1);
         OlapTable olapTable = (OlapTable) db.getTable(CatalogTestUtil.testTableId1);
-        olapTable.writeLock();
-        try {
-            schemaChangeHandler.process(alterClauses, "default_cluster", db, olapTable);
-        } finally {
-            olapTable.writeUnlock();
-        }
+        schemaChangeHandler.process(alterClauses, "default_cluster", db, olapTable);
         Map<Long, AlterJobV2> alterJobsV2 = schemaChangeHandler.getAlterJobsV2();
         Assert.assertEquals(1, alterJobsV2.size());
         Assert.assertEquals(OlapTableState.SCHEMA_CHANGE, olapTable.getState());
@@ -162,12 +157,7 @@ public class SchemaChangeJobV2Test {
         Database db = masterCatalog.getDb(CatalogTestUtil.testDbId1);
         OlapTable olapTable = (OlapTable) db.getTable(CatalogTestUtil.testTableId1);
         Partition testPartition = olapTable.getPartition(CatalogTestUtil.testPartitionId1);
-        olapTable.writeLock();
-        try {
-            schemaChangeHandler.process(alterClauses, "default_cluster", db, olapTable);
-        } finally {
-            olapTable.writeUnlock();
-        }
+        schemaChangeHandler.process(alterClauses, "default_cluster", db, olapTable);
         Map<Long, AlterJobV2> alterJobsV2 = schemaChangeHandler.getAlterJobsV2();
         Assert.assertEquals(1, alterJobsV2.size());
         SchemaChangeJobV2 schemaChangeJob = (SchemaChangeJobV2) alterJobsV2.values().stream().findAny().get();
@@ -243,12 +233,7 @@ public class SchemaChangeJobV2Test {
         Database db = masterCatalog.getDb(CatalogTestUtil.testDbId1);
         OlapTable olapTable = (OlapTable) db.getTable(CatalogTestUtil.testTableId1);
         Partition testPartition = olapTable.getPartition(CatalogTestUtil.testPartitionId1);
-        olapTable.writeLock();
-        try {
-            schemaChangeHandler.process(alterClauses, "default_cluster", db, olapTable);
-        } finally {
-            olapTable.writeUnlock();
-        }
+        schemaChangeHandler.process(alterClauses, "default_cluster", db, olapTable);
         Map<Long, AlterJobV2> alterJobsV2 = schemaChangeHandler.getAlterJobsV2();
         Assert.assertEquals(1, alterJobsV2.size());
         SchemaChangeJobV2 schemaChangeJob = (SchemaChangeJobV2) alterJobsV2.values().stream().findAny().get();
@@ -333,12 +318,7 @@ public class SchemaChangeJobV2Test {
         alterClauses.add(new ModifyTablePropertiesClause(properties));
         Database db = CatalogMocker.mockDb();
         OlapTable olapTable = (OlapTable) db.getTable(CatalogMocker.TEST_TBL2_ID);
-        olapTable.writeLock();
-        try {
-            schemaChangeHandler.process(alterClauses, "default_cluster", db, olapTable);
-        } finally {
-            olapTable.writeUnlock();
-        }
+        schemaChangeHandler.process(alterClauses, "default_cluster", db, olapTable);
         Assert.assertTrue(olapTable.getTableProperty().getDynamicPartitionProperty().isExist());
         Assert.assertTrue(olapTable.getTableProperty().getDynamicPartitionProperty().getEnable());
         Assert.assertEquals("day", olapTable.getTableProperty().getDynamicPartitionProperty().getTimeUnit());
@@ -351,56 +331,31 @@ public class SchemaChangeJobV2Test {
         ArrayList<AlterClause> tmpAlterClauses = new ArrayList<>();
         properties.put(DynamicPartitionProperty.ENABLE, "false");
         tmpAlterClauses.add(new ModifyTablePropertiesClause(properties));
-        olapTable.writeLock();
-        try {
-            schemaChangeHandler.process(tmpAlterClauses, "default_cluster", db, olapTable);
-        } finally {
-            olapTable.writeUnlock();
-        }
+        schemaChangeHandler.process(tmpAlterClauses, "default_cluster", db, olapTable);
         Assert.assertFalse(olapTable.getTableProperty().getDynamicPartitionProperty().getEnable());
         // set dynamic_partition.time_unit = week
         tmpAlterClauses = new ArrayList<>();
         properties.put(DynamicPartitionProperty.TIME_UNIT, "week");
         tmpAlterClauses.add(new ModifyTablePropertiesClause(properties));
-        olapTable.writeLock();
-        try {
-            schemaChangeHandler.process(tmpAlterClauses, "default_cluster", db, olapTable);
-        } finally {
-            olapTable.writeUnlock();
-        }
+        schemaChangeHandler.process(tmpAlterClauses, "default_cluster", db, olapTable);
         Assert.assertEquals("week", olapTable.getTableProperty().getDynamicPartitionProperty().getTimeUnit());
         // set dynamic_partition.end = 10
         tmpAlterClauses = new ArrayList<>();
         properties.put(DynamicPartitionProperty.END, "10");
         tmpAlterClauses.add(new ModifyTablePropertiesClause(properties));
-        olapTable.writeLock();
-        try {
-            schemaChangeHandler.process(tmpAlterClauses, "default_cluster", db, olapTable);
-        } finally {
-            olapTable.writeUnlock();
-        }
+        schemaChangeHandler.process(tmpAlterClauses, "default_cluster", db, olapTable);
         Assert.assertEquals(10, olapTable.getTableProperty().getDynamicPartitionProperty().getEnd());
         // set dynamic_partition.prefix = p1
         tmpAlterClauses = new ArrayList<>();
         properties.put(DynamicPartitionProperty.PREFIX, "p1");
         tmpAlterClauses.add(new ModifyTablePropertiesClause(properties));
-        olapTable.writeLock();
-        try {
-            schemaChangeHandler.process(tmpAlterClauses, "default_cluster", db, olapTable);
-        } finally {
-            olapTable.writeUnlock();
-        }
+        schemaChangeHandler.process(tmpAlterClauses, "default_cluster", db, olapTable);
         Assert.assertEquals("p1", olapTable.getTableProperty().getDynamicPartitionProperty().getPrefix());
         // set dynamic_partition.buckets = 3
         tmpAlterClauses = new ArrayList<>();
         properties.put(DynamicPartitionProperty.BUCKETS, "3");
         tmpAlterClauses.add(new ModifyTablePropertiesClause(properties));
-        olapTable.writeLock();
-        try {
-            schemaChangeHandler.process(tmpAlterClauses, "default_cluster", db, olapTable);
-        } finally {
-            olapTable.writeUnlock();
-        }
+        schemaChangeHandler.process(tmpAlterClauses, "default_cluster", db, olapTable);
         Assert.assertEquals(3, olapTable.getTableProperty().getDynamicPartitionProperty().getBuckets());
     }
 
@@ -420,12 +375,7 @@ public class SchemaChangeJobV2Test {
         expectedEx.expect(DdlException.class);
         expectedEx.expectMessage("errCode = 2, detailMessage = Table test_db.test_tbl2 is not a dynamic partition table. " +
                 "Use command `HELP ALTER TABLE` to see how to change a normal table to a dynamic partition table.");
-        olapTable.writeLock();
-        try {
-            schemaChangeHandler.process(alterClauses, "default_cluster", db, olapTable);
-        } finally {
-            olapTable.writeUnlock();
-        }
+        schemaChangeHandler.process(alterClauses, "default_cluster", db, olapTable);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/alter/SchemaChangeJobV2Test.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/alter/SchemaChangeJobV2Test.java
@@ -65,6 +65,7 @@ import org.apache.doris.transaction.GlobalTransactionMgr;
 
 import com.google.common.collect.Maps;
 
+import org.apache.hadoop.yarn.webapp.hamlet.HamletSpec;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -136,7 +137,12 @@ public class SchemaChangeJobV2Test {
         alterClauses.add(addColumnClause);
         Database db = masterCatalog.getDb(CatalogTestUtil.testDbId1);
         OlapTable olapTable = (OlapTable) db.getTable(CatalogTestUtil.testTableId1);
-        schemaChangeHandler.process(alterClauses, "default_cluster", db, olapTable);
+        olapTable.writeLock();
+        try {
+            schemaChangeHandler.process(alterClauses, "default_cluster", db, olapTable);
+        } finally {
+            olapTable.writeUnlock();
+        }
         Map<Long, AlterJobV2> alterJobsV2 = schemaChangeHandler.getAlterJobsV2();
         Assert.assertEquals(1, alterJobsV2.size());
         Assert.assertEquals(OlapTableState.SCHEMA_CHANGE, olapTable.getState());
@@ -156,7 +162,12 @@ public class SchemaChangeJobV2Test {
         Database db = masterCatalog.getDb(CatalogTestUtil.testDbId1);
         OlapTable olapTable = (OlapTable) db.getTable(CatalogTestUtil.testTableId1);
         Partition testPartition = olapTable.getPartition(CatalogTestUtil.testPartitionId1);
-        schemaChangeHandler.process(alterClauses, "default_cluster", db, olapTable);
+        olapTable.writeLock();
+        try {
+            schemaChangeHandler.process(alterClauses, "default_cluster", db, olapTable);
+        } finally {
+            olapTable.writeUnlock();
+        }
         Map<Long, AlterJobV2> alterJobsV2 = schemaChangeHandler.getAlterJobsV2();
         Assert.assertEquals(1, alterJobsV2.size());
         SchemaChangeJobV2 schemaChangeJob = (SchemaChangeJobV2) alterJobsV2.values().stream().findAny().get();
@@ -232,7 +243,12 @@ public class SchemaChangeJobV2Test {
         Database db = masterCatalog.getDb(CatalogTestUtil.testDbId1);
         OlapTable olapTable = (OlapTable) db.getTable(CatalogTestUtil.testTableId1);
         Partition testPartition = olapTable.getPartition(CatalogTestUtil.testPartitionId1);
-        schemaChangeHandler.process(alterClauses, "default_cluster", db, olapTable);
+        olapTable.writeLock();
+        try {
+            schemaChangeHandler.process(alterClauses, "default_cluster", db, olapTable);
+        } finally {
+            olapTable.writeUnlock();
+        }
         Map<Long, AlterJobV2> alterJobsV2 = schemaChangeHandler.getAlterJobsV2();
         Assert.assertEquals(1, alterJobsV2.size());
         SchemaChangeJobV2 schemaChangeJob = (SchemaChangeJobV2) alterJobsV2.values().stream().findAny().get();
@@ -317,7 +333,12 @@ public class SchemaChangeJobV2Test {
         alterClauses.add(new ModifyTablePropertiesClause(properties));
         Database db = CatalogMocker.mockDb();
         OlapTable olapTable = (OlapTable) db.getTable(CatalogMocker.TEST_TBL2_ID);
-        schemaChangeHandler.process(alterClauses, "default_cluster", db, olapTable);
+        olapTable.writeLock();
+        try {
+            schemaChangeHandler.process(alterClauses, "default_cluster", db, olapTable);
+        } finally {
+            olapTable.writeUnlock();
+        }
         Assert.assertTrue(olapTable.getTableProperty().getDynamicPartitionProperty().isExist());
         Assert.assertTrue(olapTable.getTableProperty().getDynamicPartitionProperty().getEnable());
         Assert.assertEquals("day", olapTable.getTableProperty().getDynamicPartitionProperty().getTimeUnit());
@@ -330,31 +351,56 @@ public class SchemaChangeJobV2Test {
         ArrayList<AlterClause> tmpAlterClauses = new ArrayList<>();
         properties.put(DynamicPartitionProperty.ENABLE, "false");
         tmpAlterClauses.add(new ModifyTablePropertiesClause(properties));
-        schemaChangeHandler.process(tmpAlterClauses, "default_cluster", db, olapTable);
+        olapTable.writeLock();
+        try {
+            schemaChangeHandler.process(tmpAlterClauses, "default_cluster", db, olapTable);
+        } finally {
+            olapTable.writeUnlock();
+        }
         Assert.assertFalse(olapTable.getTableProperty().getDynamicPartitionProperty().getEnable());
         // set dynamic_partition.time_unit = week
         tmpAlterClauses = new ArrayList<>();
         properties.put(DynamicPartitionProperty.TIME_UNIT, "week");
         tmpAlterClauses.add(new ModifyTablePropertiesClause(properties));
-        schemaChangeHandler.process(tmpAlterClauses, "default_cluster", db, olapTable);
+        olapTable.writeLock();
+        try {
+            schemaChangeHandler.process(tmpAlterClauses, "default_cluster", db, olapTable);
+        } finally {
+            olapTable.writeUnlock();
+        }
         Assert.assertEquals("week", olapTable.getTableProperty().getDynamicPartitionProperty().getTimeUnit());
         // set dynamic_partition.end = 10
         tmpAlterClauses = new ArrayList<>();
         properties.put(DynamicPartitionProperty.END, "10");
         tmpAlterClauses.add(new ModifyTablePropertiesClause(properties));
-        schemaChangeHandler.process(tmpAlterClauses, "default_cluster", db, olapTable);
+        olapTable.writeLock();
+        try {
+            schemaChangeHandler.process(tmpAlterClauses, "default_cluster", db, olapTable);
+        } finally {
+            olapTable.writeUnlock();
+        }
         Assert.assertEquals(10, olapTable.getTableProperty().getDynamicPartitionProperty().getEnd());
         // set dynamic_partition.prefix = p1
         tmpAlterClauses = new ArrayList<>();
         properties.put(DynamicPartitionProperty.PREFIX, "p1");
         tmpAlterClauses.add(new ModifyTablePropertiesClause(properties));
-        schemaChangeHandler.process(tmpAlterClauses, "default_cluster", db, olapTable);
+        olapTable.writeLock();
+        try {
+            schemaChangeHandler.process(tmpAlterClauses, "default_cluster", db, olapTable);
+        } finally {
+            olapTable.writeUnlock();
+        }
         Assert.assertEquals("p1", olapTable.getTableProperty().getDynamicPartitionProperty().getPrefix());
         // set dynamic_partition.buckets = 3
         tmpAlterClauses = new ArrayList<>();
         properties.put(DynamicPartitionProperty.BUCKETS, "3");
         tmpAlterClauses.add(new ModifyTablePropertiesClause(properties));
-        schemaChangeHandler.process(tmpAlterClauses, "default_cluster", db, olapTable);
+        olapTable.writeLock();
+        try {
+            schemaChangeHandler.process(tmpAlterClauses, "default_cluster", db, olapTable);
+        } finally {
+            olapTable.writeUnlock();
+        }
         Assert.assertEquals(3, olapTable.getTableProperty().getDynamicPartitionProperty().getBuckets());
     }
 
@@ -374,8 +420,12 @@ public class SchemaChangeJobV2Test {
         expectedEx.expect(DdlException.class);
         expectedEx.expectMessage("errCode = 2, detailMessage = Table test_db.test_tbl2 is not a dynamic partition table. " +
                 "Use command `HELP ALTER TABLE` to see how to change a normal table to a dynamic partition table.");
-
-        schemaChangeHandler.process(alterClauses, "default_cluster", db, olapTable);
+        olapTable.writeLock();
+        try {
+            schemaChangeHandler.process(alterClauses, "default_cluster", db, olapTable);
+        } finally {
+            olapTable.writeUnlock();
+        }
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/DatabaseTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/DatabaseTest.java
@@ -131,12 +131,6 @@ public class DatabaseTest {
         // drop not exist tableFamily
         db.dropTable("invalid");
         Assert.assertEquals(1, db.getTables().size());
-        db.dropTableWithLock("invalid");
-        Assert.assertEquals(1, db.getTables().size());
-
-        // drop normal
-        db.dropTableWithLock(table.getName());
-        Assert.assertEquals(0, db.getTables().size());
 
         db.createTable(table);
         db.dropTable(table.getName());

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/InfoSchemaDbTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/InfoSchemaDbTest.java
@@ -30,7 +30,6 @@ public class InfoSchemaDbTest {
         Assert.assertFalse(db.createTable(null));
         Assert.assertFalse(db.createTableWithLock(null, false, false));
         db.dropTable("authors");
-        db.dropTableWithLock("authors");
         db.write(null);
         Assert.assertNull(db.getTable("authors"));
     }

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/TableTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/TableTest.java
@@ -36,20 +36,42 @@ import java.io.FileOutputStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 public class TableTest {
     private FakeCatalog fakeCatalog;
 
     private Catalog catalog;
 
+    private Table table;
+    private long tableId = 10000;
+
     @Before
     public void setUp() {
         fakeCatalog = new FakeCatalog();
         catalog = Deencapsulation.newInstance(Catalog.class);
-
+        table = new Table(Table.TableType.OLAP);
         FakeCatalog.setCatalog(catalog);
         FakeCatalog.setMetaVersion(FeConstants.meta_version);
     }
+
+    @Test
+    public void lockTest() {
+        table.readLock();
+        try {
+            Assert.assertFalse(table.tryWriteLock(0, TimeUnit.SECONDS));
+        } finally {
+            table.readUnlock();
+        }
+
+        table.writeLock();
+        try {
+            Assert.assertTrue(table.tryWriteLock(0, TimeUnit.SECONDS));
+        } finally {
+            table.writeUnlock();
+        }
+    }
+
 
     @Test
     public void testSerialization() throws Exception {

--- a/fe/fe-core/src/test/java/org/apache/doris/cluster/SystemInfoServiceTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/cluster/SystemInfoServiceTest.java
@@ -24,6 +24,7 @@ import org.apache.doris.analysis.Analyzer;
 import org.apache.doris.analysis.DropBackendClause;
 import org.apache.doris.catalog.Catalog;
 import org.apache.doris.catalog.Database;
+import org.apache.doris.catalog.Table;
 import org.apache.doris.catalog.TabletInvertedIndex;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.DdlException;
@@ -57,6 +58,8 @@ public class SystemInfoServiceTest {
     private TabletInvertedIndex invertedIndex;
     @Mocked
     private Database db;
+    @Mocked
+    private Table table;
 
     private Analyzer analyzer;
 
@@ -77,10 +80,10 @@ public class SystemInfoServiceTest {
                 editLog.logBackendStateChange((Backend) any);
                 minTimes = 0;
 
-                db.readLock();
+                table.readLock();
                 minTimes = 0;
 
-                db.readUnlock();
+                table.readUnlock();
                 minTimes = 0;
 
                 catalog.getNextId();
@@ -94,6 +97,10 @@ public class SystemInfoServiceTest {
                 catalog.getDb(anyLong);
                 minTimes = 0;
                 result = db;
+
+                db.getTable(anyLong);
+                minTimes = 0;
+                result = table;
 
                 catalog.getCluster(anyString);
                 minTimes = 0;
@@ -223,7 +230,7 @@ public class SystemInfoServiceTest {
 
         Assert.assertTrue(Catalog.getCurrentSystemInfo().getBackendReportVersion(backendId) == 0L);
 
-        Catalog.getCurrentSystemInfo().updateBackendReportVersion(backendId, 2L, 20000L);
+        Catalog.getCurrentSystemInfo().updateBackendReportVersion(backendId, 2L, 20000L, 30000L);
         Assert.assertTrue(Catalog.getCurrentSystemInfo().getBackendReportVersion(backendId) == 2L);
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/common/util/MetaLockUtilsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/common/util/MetaLockUtilsTest.java
@@ -1,0 +1,76 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.common.util;
+
+import com.google.common.collect.Lists;
+import org.apache.doris.catalog.Database;
+import org.apache.doris.catalog.Table;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+public class MetaLockUtilsTest {
+
+    @Test
+    public void testReadLockDatabases() {
+        List<Database> databaseList = Lists.newArrayList(new Database(), new Database());
+        MetaLockUtils.readLockDatabases(databaseList);
+        Assert.assertFalse(databaseList.get(0).tryWriteLock(1, TimeUnit.MILLISECONDS));
+        Assert.assertFalse(databaseList.get(1).tryWriteLock(1, TimeUnit.MILLISECONDS));
+        MetaLockUtils.readUnlockDatabases(databaseList);
+        Assert.assertTrue(databaseList.get(0).tryWriteLock(1, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(databaseList.get(1).tryWriteLock(1, TimeUnit.MILLISECONDS));
+        databaseList.get(0).writeUnlock();
+        databaseList.get(1).writeUnlock();
+    }
+
+    @Test
+    public void testReadLockTables() {
+        List<Table> tableList = Lists.newArrayList(new Table(Table.TableType.OLAP), new Table(Table.TableType.OLAP));
+        MetaLockUtils.readLockTables(tableList);
+        Assert.assertFalse(tableList.get(0).tryWriteLock(1, TimeUnit.MILLISECONDS));
+        Assert.assertFalse(tableList.get(1).tryWriteLock(1, TimeUnit.MILLISECONDS));
+        MetaLockUtils.readUnlockTables(tableList);
+        Assert.assertTrue(tableList.get(0).tryWriteLock(1, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(tableList.get(1).tryWriteLock(1, TimeUnit.MILLISECONDS));
+        tableList.get(0).writeUnlock();
+        tableList.get(1).writeUnlock();
+    }
+
+    @Test
+    public void testWriteLockTables() {
+        List<Table> tableList = Lists.newArrayList(new Table(Table.TableType.OLAP), new Table(Table.TableType.OLAP));
+        MetaLockUtils.writeLockTables(tableList);
+        Assert.assertTrue(tableList.get(0).isWriteLockHeldByCurrentThread());
+        Assert.assertTrue(tableList.get(1).isWriteLockHeldByCurrentThread());
+        MetaLockUtils.writeUnlockTables(tableList);
+        Assert.assertFalse(tableList.get(0).isWriteLockHeldByCurrentThread());
+        Assert.assertFalse(tableList.get(1).isWriteLockHeldByCurrentThread());
+        Assert.assertTrue(MetaLockUtils.tryWriteLockTables(tableList, 1, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(tableList.get(0).isWriteLockHeldByCurrentThread());
+        Assert.assertTrue(tableList.get(1).isWriteLockHeldByCurrentThread());
+        MetaLockUtils.writeUnlockTables(tableList);
+        tableList.get(1).readLock();
+        Assert.assertFalse(MetaLockUtils.tryWriteLockTables(tableList, 1, TimeUnit.MILLISECONDS));
+        Assert.assertFalse(tableList.get(0).isWriteLockHeldByCurrentThread());
+        Assert.assertFalse(tableList.get(1).isWriteLockHeldByCurrentThread());
+        tableList.get(1).readUnlock();
+    }
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/load/DeleteHandlerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/load/DeleteHandlerTest.java
@@ -35,6 +35,7 @@ import org.apache.doris.backup.CatalogMocker;
 import org.apache.doris.catalog.Catalog;
 import org.apache.doris.catalog.Database;
 import org.apache.doris.catalog.Replica;
+import org.apache.doris.catalog.Table;
 import org.apache.doris.catalog.TabletInvertedIndex;
 import org.apache.doris.catalog.TabletMeta;
 import org.apache.doris.common.AnalysisException;
@@ -346,7 +347,7 @@ public class DeleteHandlerTest {
         new Expectations(globalTransactionMgr) {
             {
                 try {
-                    globalTransactionMgr.commitTransaction(anyLong, anyLong, (List<TabletCommitInfo>) any, (TxnCommitAttachment) any);
+                    globalTransactionMgr.commitTransaction(anyLong, (List<Table>) any, anyLong, (List<TabletCommitInfo>) any, (TxnCommitAttachment) any);
                 } catch (UserException e) {
                 }
                 result = new UserException("commit fail");

--- a/fe/fe-core/src/test/java/org/apache/doris/load/loadv2/SparkLoadJobTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/load/loadv2/SparkLoadJobTest.java
@@ -381,8 +381,8 @@ public class SparkLoadJobTest {
                 AgentTaskExecutor.submit((AgentBatchTask) any);
                 Catalog.getCurrentGlobalTransactionMgr();
                 result = transactionMgr;
-                transactionMgr.commitTransaction(dbId, transactionId, (List<TabletCommitInfo>) any,
-                                                 (LoadJobFinalOperation) any);
+//                transactionMgr.commitTransaction(dbId, transactionId, (List<TabletCommitInfo>) any,
+//                                                 (LoadJobFinalOperation) any);
             }
         };
 

--- a/fe/fe-core/src/test/java/org/apache/doris/load/loadv2/SparkLoadJobTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/load/loadv2/SparkLoadJobTest.java
@@ -39,6 +39,7 @@ import org.apache.doris.catalog.RangePartitionInfo;
 import org.apache.doris.catalog.Replica;
 import org.apache.doris.catalog.ResourceMgr;
 import org.apache.doris.catalog.SparkResource;
+import org.apache.doris.catalog.Table;
 import org.apache.doris.catalog.Tablet;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.DataQualityException;
@@ -381,8 +382,8 @@ public class SparkLoadJobTest {
                 AgentTaskExecutor.submit((AgentBatchTask) any);
                 Catalog.getCurrentGlobalTransactionMgr();
                 result = transactionMgr;
-//                transactionMgr.commitTransaction(dbId, transactionId, (List<TabletCommitInfo>) any,
-//                                                 (LoadJobFinalOperation) any);
+                transactionMgr.commitTransaction(dbId, (List<Table>) any, transactionId, (List<TabletCommitInfo>) any,
+                                                 (LoadJobFinalOperation) any);
             }
         };
 

--- a/fe/fe-core/src/test/java/org/apache/doris/load/loadv2/SparkLoadJobTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/load/loadv2/SparkLoadJobTest.java
@@ -355,8 +355,10 @@ public class SparkLoadJobTest {
                 result = filePathToSize;
                 catalog.getDb(dbId);
                 result = db;
-                db.getTable(tableId);
-                result = table;
+                db.getTablesOnIdOrderOrThrowException((List<Long>) any);
+                result = Lists.newArrayList(table);
+                table.getId();
+                result = tableId;
                 table.getPartition(partitionId);
                 result = partition;
                 table.getPartitionInfo();

--- a/fe/fe-core/src/test/java/org/apache/doris/planner/StreamLoadPlannerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/planner/StreamLoadPlannerTest.java
@@ -98,7 +98,7 @@ public class StreamLoadPlannerTest {
         request.setLoadId(new TUniqueId(2, 3));
         request.setFileType(TFileType.FILE_STREAM);
         request.setFormatType(TFileFormatType.FORMAT_CSV_PLAIN);
-        StreamLoadTask streamLoadTask = StreamLoadTask.fromTStreamLoadPutRequest(request, db);
+        StreamLoadTask streamLoadTask = StreamLoadTask.fromTStreamLoadPutRequest(request);
         StreamLoadPlanner planner = new StreamLoadPlanner(db, destTable, streamLoadTask);
         planner.plan(streamLoadTask.getId());
     }

--- a/fe/fe-core/src/test/java/org/apache/doris/planner/StreamLoadScanNodeTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/planner/StreamLoadScanNodeTest.java
@@ -174,7 +174,7 @@ public class StreamLoadScanNodeTest {
     
     private StreamLoadScanNode getStreamLoadScanNode(TupleDescriptor dstDesc, TStreamLoadPutRequest request)
             throws UserException {
-        StreamLoadTask streamLoadTask = StreamLoadTask.fromTStreamLoadPutRequest(request, db);
+        StreamLoadTask streamLoadTask = StreamLoadTask.fromTStreamLoadPutRequest(request);
         StreamLoadScanNode scanNode = new StreamLoadScanNode(streamLoadTask.getId(), new PlanNodeId(1), dstDesc, dstTable, streamLoadTask);
         return scanNode;
     }
@@ -238,7 +238,6 @@ public class StreamLoadScanNodeTest {
 
         TStreamLoadPutRequest request = getBaseRequest();
         request.setColumns("k1, k2, v1");
-        StreamLoadTask streamLoadTask = StreamLoadTask.fromTStreamLoadPutRequest(request, db);
         StreamLoadScanNode scanNode = getStreamLoadScanNode(dstDesc, request);
 
         scanNode.init(analyzer);
@@ -268,7 +267,6 @@ public class StreamLoadScanNodeTest {
 
         TStreamLoadPutRequest request = getBaseRequest();
         request.setColumns("k1 k2 v1");
-        StreamLoadTask streamLoadTask = StreamLoadTask.fromTStreamLoadPutRequest(request, null);
         StreamLoadScanNode scanNode = getStreamLoadScanNode(dstDesc, request);
 
         scanNode.init(analyzer);
@@ -314,7 +312,6 @@ public class StreamLoadScanNodeTest {
 
         TStreamLoadPutRequest request = getBaseRequest();
         request.setColumns("k1,k2,v1, v2=k2");
-        StreamLoadTask streamLoadTask = StreamLoadTask.fromTStreamLoadPutRequest(request, db);
         StreamLoadScanNode scanNode = getStreamLoadScanNode(dstDesc, request);
         scanNode.init(analyzer);
         scanNode.finalize(analyzer);
@@ -361,8 +358,8 @@ public class StreamLoadScanNodeTest {
 
         TStreamLoadPutRequest request = getBaseRequest();
         request.setFileType(TFileType.FILE_STREAM);
+
         request.setColumns("k1,k2, v1=" + FunctionSet.HLL_HASH + "(k2)");
-        StreamLoadTask streamLoadTask = StreamLoadTask.fromTStreamLoadPutRequest(request, db);
         StreamLoadScanNode scanNode = getStreamLoadScanNode(dstDesc, request);
 
         scanNode.init(analyzer);
@@ -417,7 +414,7 @@ public class StreamLoadScanNodeTest {
         TStreamLoadPutRequest request = getBaseRequest();
         request.setFileType(TFileType.FILE_LOCAL);
         request.setColumns("k1,k2, v1=hll_hash1(k2)");
-        StreamLoadTask streamLoadTask = StreamLoadTask.fromTStreamLoadPutRequest(request, null);
+        StreamLoadTask streamLoadTask = StreamLoadTask.fromTStreamLoadPutRequest(request);
         StreamLoadScanNode scanNode = getStreamLoadScanNode(dstDesc, request);
 
         scanNode.init(analyzer);
@@ -603,7 +600,7 @@ public class StreamLoadScanNodeTest {
         TStreamLoadPutRequest request = getBaseRequest();
         request.setColumns("k1,k2,v1, v2=k2");
         request.setWhere("k1   1");
-        StreamLoadTask streamLoadTask = StreamLoadTask.fromTStreamLoadPutRequest(request, null);
+        StreamLoadTask streamLoadTask = StreamLoadTask.fromTStreamLoadPutRequest(request);
         StreamLoadScanNode scanNode = new StreamLoadScanNode(streamLoadTask.getId(), new PlanNodeId(1), dstDesc, dstTable,
                                                              streamLoadTask);
 

--- a/fe/fe-core/src/test/java/org/apache/doris/qe/StmtExecutorTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/qe/StmtExecutorTest.java
@@ -197,7 +197,7 @@ public class StmtExecutorTest {
                 minTimes = 0;
                 result = false;
 
-                queryStmt.getDbs((Analyzer) any, (SortedMap) any, Sets.newHashSet());
+                queryStmt.getTables((Analyzer) any, (SortedMap) any, Sets.newHashSet());
                 minTimes = 0;
 
                 queryStmt.getRedirectStatus();

--- a/fe/fe-core/src/test/java/org/apache/doris/transaction/DatabaseTransactionMgrTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/transaction/DatabaseTransactionMgrTest.java
@@ -23,6 +23,7 @@ import org.apache.doris.catalog.Catalog;
 import org.apache.doris.catalog.CatalogTestUtil;
 import org.apache.doris.catalog.FakeCatalog;
 import org.apache.doris.catalog.FakeEditLog;
+import org.apache.doris.catalog.Table;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.FeMetaVersion;
@@ -99,7 +100,8 @@ public class DatabaseTransactionMgrTest {
         transTablets.add(tabletCommitInfo1);
         transTablets.add(tabletCommitInfo2);
         transTablets.add(tabletCommitInfo3);
-        masterTransMgr.commitTransaction(CatalogTestUtil.testDbId1, transactionId1, transTablets);
+        Table testTable1 = masterCatalog.getDb(CatalogTestUtil.testDbId1).getTable(CatalogTestUtil.testTableId1);
+        masterTransMgr.commitTransaction(CatalogTestUtil.testDbId1, Lists.newArrayList(testTable1), transactionId1, transTablets);
         masterTransMgr.finishTransaction(CatalogTestUtil.testDbId1, transactionId1, null);
         LabelToTxnId.put(CatalogTestUtil.testTxnLabel1, transactionId1);
 

--- a/fe/fe-core/src/test/java/org/apache/doris/transaction/GlobalTransactionMgrTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/transaction/GlobalTransactionMgrTest.java
@@ -23,6 +23,7 @@ import org.apache.doris.catalog.FakeCatalog;
 import org.apache.doris.catalog.FakeEditLog;
 import org.apache.doris.catalog.Partition;
 import org.apache.doris.catalog.Replica;
+import org.apache.doris.catalog.Table;
 import org.apache.doris.catalog.Tablet;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.Config;
@@ -166,7 +167,8 @@ public class GlobalTransactionMgrTest {
         transTablets.add(tabletCommitInfo1);
         transTablets.add(tabletCommitInfo2);
         transTablets.add(tabletCommitInfo3);
-        masterTransMgr.commitTransaction(CatalogTestUtil.testDbId1, transactionId, transTablets);
+        Table testTable1 = masterCatalog.getDb(CatalogTestUtil.testDbId1).getTable(CatalogTestUtil.testTableId1);
+        masterTransMgr.commitTransaction(CatalogTestUtil.testDbId1, Lists.newArrayList(testTable1), transactionId, transTablets);
         TransactionState transactionState = fakeEditLog.getTransaction(transactionId);
         // check status is committed
         assertEquals(TransactionStatus.COMMITTED, transactionState.getTransactionStatus());
@@ -204,7 +206,8 @@ public class GlobalTransactionMgrTest {
         List<TabletCommitInfo> transTablets = Lists.newArrayList();
         transTablets.add(tabletCommitInfo1);
         transTablets.add(tabletCommitInfo2);
-        masterTransMgr.commitTransaction(CatalogTestUtil.testDbId1, transactionId, transTablets);
+        Table testTable1 = masterCatalog.getDb(CatalogTestUtil.testDbId1).getTable(CatalogTestUtil.testTableId1);
+        masterTransMgr.commitTransaction(CatalogTestUtil.testDbId1, Lists.newArrayList(testTable1), transactionId, transTablets);
 
         // follower catalog replay the transaction
         transactionState = fakeEditLog.getTransaction(transactionId);
@@ -225,7 +228,7 @@ public class GlobalTransactionMgrTest {
         transTablets.add(tabletCommitInfo1);
         transTablets.add(tabletCommitInfo3);
         try {
-            masterTransMgr.commitTransaction(CatalogTestUtil.testDbId1, transactionId2, transTablets);
+            masterTransMgr.commitTransaction(CatalogTestUtil.testDbId1, Lists.newArrayList(testTable1), transactionId2, transTablets);
             Assert.fail();
         } catch (TabletQuorumFailedException e) {
             transactionState = masterTransMgr.getTransactionState(CatalogTestUtil.testDbId1, transactionId2);
@@ -254,7 +257,7 @@ public class GlobalTransactionMgrTest {
         transTablets.add(tabletCommitInfo1);
         transTablets.add(tabletCommitInfo2);
         transTablets.add(tabletCommitInfo3);
-        masterTransMgr.commitTransaction(CatalogTestUtil.testDbId1, transactionId2, transTablets);
+        masterTransMgr.commitTransaction(CatalogTestUtil.testDbId1, Lists.newArrayList(testTable1), transactionId2, transTablets);
         transactionState = fakeEditLog.getTransaction(transactionId2);
         // check status is commit
         assertEquals(TransactionStatus.COMMITTED, transactionState.getTransactionStatus());
@@ -350,7 +353,8 @@ public class GlobalTransactionMgrTest {
         routineLoadManager.addRoutineLoadJob(routineLoadJob, "db");
 
         Deencapsulation.setField(masterTransMgr.getDatabaseTransactionMgr(CatalogTestUtil.testDbId1), "idToRunningTransactionState", idToTransactionState);
-        masterTransMgr.commitTransaction(1L, 1L, transTablets, txnCommitAttachment);
+        Table testTable1 = masterCatalog.getDb(CatalogTestUtil.testDbId1).getTable(CatalogTestUtil.testTableId1);
+        masterTransMgr.commitTransaction(1L, Lists.newArrayList(testTable1), 1L, transTablets, txnCommitAttachment);
 
         Assert.assertEquals(Long.valueOf(101), Deencapsulation.getField(routineLoadJob, "currentTotalRows"));
         Assert.assertEquals(Long.valueOf(1), Deencapsulation.getField(routineLoadJob, "currentErrorRows"));
@@ -416,7 +420,8 @@ public class GlobalTransactionMgrTest {
         routineLoadManager.addRoutineLoadJob(routineLoadJob, "db");
 
         Deencapsulation.setField(masterTransMgr.getDatabaseTransactionMgr(CatalogTestUtil.testDbId1), "idToRunningTransactionState", idToTransactionState);
-        masterTransMgr.commitTransaction(1L, 1L, transTablets, txnCommitAttachment);
+        Table testTable1 = masterCatalog.getDb(CatalogTestUtil.testDbId1).getTable(CatalogTestUtil.testTableId1);
+        masterTransMgr.commitTransaction(1L, Lists.newArrayList(testTable1), 1L, transTablets, txnCommitAttachment);
 
         // current total rows and error rows will be reset after job pause, so here they should be 0.
         Assert.assertEquals(Long.valueOf(0), Deencapsulation.getField(routineLoadJob, "currentTotalRows"));
@@ -445,7 +450,8 @@ public class GlobalTransactionMgrTest {
         transTablets.add(tabletCommitInfo1);
         transTablets.add(tabletCommitInfo2);
         transTablets.add(tabletCommitInfo3);
-        masterTransMgr.commitTransaction(CatalogTestUtil.testDbId1, transactionId, transTablets);
+        Table testTable1 = masterCatalog.getDb(CatalogTestUtil.testDbId1).getTable(CatalogTestUtil.testTableId1);
+        masterTransMgr.commitTransaction(CatalogTestUtil.testDbId1, Lists.newArrayList(testTable1), transactionId, transTablets);
         TransactionState transactionState = fakeEditLog.getTransaction(transactionId);
         assertEquals(TransactionStatus.COMMITTED, transactionState.getTransactionStatus());
         Set<Long> errorReplicaIds = Sets.newHashSet();
@@ -493,7 +499,8 @@ public class GlobalTransactionMgrTest {
         List<TabletCommitInfo> transTablets = Lists.newArrayList();
         transTablets.add(tabletCommitInfo1);
         transTablets.add(tabletCommitInfo2);
-        masterTransMgr.commitTransaction(CatalogTestUtil.testDbId1, transactionId, transTablets);
+        Table testTable1 = masterCatalog.getDb(CatalogTestUtil.testDbId1).getTable(CatalogTestUtil.testTableId1);
+        masterTransMgr.commitTransaction(CatalogTestUtil.testDbId1, Lists.newArrayList(testTable1), transactionId, transTablets);
 
         // follower catalog replay the transaction
         transactionState = fakeEditLog.getTransaction(transactionId);
@@ -546,7 +553,7 @@ public class GlobalTransactionMgrTest {
         transTablets.add(tabletCommitInfo1);
         transTablets.add(tabletCommitInfo3);
         try {
-            masterTransMgr.commitTransaction(CatalogTestUtil.testDbId1, transactionId2, transTablets);
+            masterTransMgr.commitTransaction(CatalogTestUtil.testDbId1, Lists.newArrayList(testTable1), transactionId2, transTablets);
             Assert.fail();
         } catch (TabletQuorumFailedException e) {
             transactionState = masterTransMgr.getTransactionState(CatalogTestUtil.testDbId1, transactionId2);
@@ -562,7 +569,7 @@ public class GlobalTransactionMgrTest {
         transTablets.add(tabletCommitInfo1);
         transTablets.add(tabletCommitInfo2);
         transTablets.add(tabletCommitInfo3);
-        masterTransMgr.commitTransaction(CatalogTestUtil.testDbId1, transactionId2, transTablets);
+        masterTransMgr.commitTransaction(CatalogTestUtil.testDbId1, Lists.newArrayList(testTable1), transactionId2, transTablets);
         transactionState = fakeEditLog.getTransaction(transactionId2);
         // check status is commit
         assertEquals(TransactionStatus.COMMITTED, transactionState.getTransactionStatus());

--- a/fe/fe-core/src/test/java/org/apache/doris/utframe/AnotherDemoTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/utframe/AnotherDemoTest.java
@@ -161,15 +161,15 @@ public class AnotherDemoTest {
         // 4. get and test the created db and table
         Database db = Catalog.getCurrentCatalog().getDb("default_cluster:db1");
         Assert.assertNotNull(db);
-        db.readLock();
+        OlapTable tbl = (OlapTable) db.getTable("tbl1");
+        tbl.readLock();
         try {
-            OlapTable tbl = (OlapTable) db.getTable("tbl1");
             Assert.assertNotNull(tbl);
             System.out.println(tbl.getName());
             Assert.assertEquals("Doris", tbl.getEngine());
             Assert.assertEquals(1, tbl.getBaseSchema().size());
         } finally {
-            db.readUnlock();
+            tbl.readUnlock();
         }
         // 5. query
         // TODO: we can not process real query for now. So it has to be a explain query

--- a/fe/fe-core/src/test/java/org/apache/doris/utframe/DemoTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/utframe/DemoTest.java
@@ -90,15 +90,15 @@ public class DemoTest {
         // 4. get and test the created db and table
         Database db = Catalog.getCurrentCatalog().getDb("default_cluster:db1");
         Assert.assertNotNull(db);
-        db.readLock();
+        OlapTable tbl = (OlapTable) db.getTable("tbl1");
+        tbl.readLock();
         try {
-            OlapTable tbl = (OlapTable) db.getTable("tbl1");
             Assert.assertNotNull(tbl);
             System.out.println(tbl.getName());
             Assert.assertEquals("Doris", tbl.getEngine());
             Assert.assertEquals(1, tbl.getBaseSchema().size());
         } finally {
-            db.readUnlock();
+            tbl.readUnlock();
         }
         // 5. process a schema change job
         String alterStmtStr = "alter table db1.tbl1 add column k2 int default '1'";
@@ -115,17 +115,17 @@ public class DemoTest {
             System.out.println("alter job " + alterJobV2.getJobId() + " is done. state: " + alterJobV2.getJobState());
             Assert.assertEquals(AlterJobV2.JobState.FINISHED, alterJobV2.getJobState());
         }
-        db.readLock();
-        try {
-            OlapTable tbl = (OlapTable) db.getTable("tbl1");
-            Assert.assertEquals(2, tbl.getBaseSchema().size());
 
-            String baseIndexName = tbl.getIndexNameById(tbl.getBaseIndexId());
-            Assert.assertEquals(baseIndexName, tbl.getName());
-            MaterializedIndexMeta indexMeta = tbl.getIndexMetaByIndexId(tbl.getBaseIndexId());
+        OlapTable tbl1 = (OlapTable) db.getTable("tbl1");
+        tbl1.readLock();
+        try {
+            Assert.assertEquals(2, tbl1.getBaseSchema().size());
+            String baseIndexName = tbl1.getIndexNameById(tbl.getBaseIndexId());
+            Assert.assertEquals(baseIndexName, tbl1.getName());
+            MaterializedIndexMeta indexMeta = tbl1.getIndexMetaByIndexId(tbl1.getBaseIndexId());
             Assert.assertNotNull(indexMeta);
         } finally {
-            db.readUnlock();
+            tbl1.readUnlock();
         }
         // 7. query
         // TODO: we can not process real query for now. So it has to be a explain query


### PR DESCRIPTION
This PR is to reduce lock competition by supporting read and write lock in table level. When we modify or read table's meta, we don't need to get db lock, just get table write or read lock. And when we get db lock, that means meta directly in db cannot be modified by other thread. Db lock only protect meta in Database class, while table lock protect meta in Table class. 
 