### PR TITLE
[Bug] Fix bug that should not use "!=" to judge the equivalence of Type

### DIFF
--- a/fe/src/main/java/org/apache/doris/analysis/CompoundPredicate.java
+++ b/fe/src/main/java/org/apache/doris/analysis/CompoundPredicate.java
@@ -17,18 +17,19 @@
 
 package org.apache.doris.analysis;
 
-import java.util.List;
-import java.util.Objects;
-
 import org.apache.doris.catalog.Type;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.thrift.TExprNode;
 import org.apache.doris.thrift.TExprNodeType;
 import org.apache.doris.thrift.TExprOpcode;
+
+import com.google.common.base.Preconditions;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import com.google.common.base.Preconditions;
+import java.util.List;
+import java.util.Objects;
 
 /**
  * &&, ||, ! predicates.
@@ -96,7 +97,7 @@ public class CompoundPredicate extends Predicate {
 
         // Check that children are predicates.
         for (Expr e : children) {
-            if (e.getType() != Type.BOOLEAN && !e.getType().isNull()) {
+            if (!e.getType().equals(Type.BOOLEAN) && !e.getType().isNull()) {
                 throw new AnalysisException(String.format(
                   "Operand '%s' part of predicate " + "'%s' should return type 'BOOLEAN' but " +
                     "returns type '%s'.",

--- a/fe/src/main/java/org/apache/doris/analysis/DataDescription.java
+++ b/fe/src/main/java/org/apache/doris/analysis/DataDescription.java
@@ -513,7 +513,7 @@ public class DataDescription {
     }
 
     private static void validateNowFunction(Column mappingColumn) throws AnalysisException {
-        if (mappingColumn.getOriginType() != Type.DATE && mappingColumn.getOriginType() != Type.DATETIME) {
+        if (!mappingColumn.getOriginType().equals(Type.DATE) && !mappingColumn.getOriginType().equals(Type.DATETIME)) {
             throw new AnalysisException("Now() function is only support for DATE/DATETIME column");
         }
     }

--- a/fe/src/main/java/org/apache/doris/analysis/LiteralExpr.java
+++ b/fe/src/main/java/org/apache/doris/analysis/LiteralExpr.java
@@ -23,6 +23,7 @@ import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.NotImplementedException;
 
 import com.google.common.base.Preconditions;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -43,7 +44,7 @@ public abstract class LiteralExpr extends Expr {
     }
 
     public static LiteralExpr create(String value, Type type) throws AnalysisException {
-        Preconditions.checkArgument(type != Type.INVALID);
+        Preconditions.checkArgument(!type.equals(Type.INVALID));
         LiteralExpr literalExpr = null;
         switch (type.getPrimitiveType()) {
             case NULL_TYPE:
@@ -88,7 +89,7 @@ public abstract class LiteralExpr extends Expr {
     }
 
     public static LiteralExpr createInfinity(Type type, boolean isMax) throws AnalysisException {
-        Preconditions.checkArgument(type != Type.INVALID);
+        Preconditions.checkArgument(!type.equals(Type.INVALID));
         if (isMax) {
             return MaxLiteral.MAX_VALUE;
         }

--- a/fe/src/main/java/org/apache/doris/analysis/SlotRef.java
+++ b/fe/src/main/java/org/apache/doris/analysis/SlotRef.java
@@ -262,7 +262,7 @@ public class SlotRef extends Expr {
 
     @Override
     public void getIds(List<TupleId> tupleIds, List<SlotId> slotIds) {
-        Preconditions.checkState(type != Type.INVALID);
+        Preconditions.checkState(!type.equals(Type.INVALID));
         Preconditions.checkState(desc != null);
         if (slotIds != null) {
             slotIds.add(desc.getId());

--- a/fe/src/main/java/org/apache/doris/planner/LoadScanNode.java
+++ b/fe/src/main/java/org/apache/doris/planner/LoadScanNode.java
@@ -68,7 +68,7 @@ public abstract class LoadScanNode extends ScanNode {
         }
         whereExpr = whereExpr.clone(smap);
         whereExpr.analyze(analyzer);
-        if (whereExpr.getType() != Type.BOOLEAN) {
+        if (!whereExpr.getType().equals(Type.BOOLEAN)) {
             throw new UserException("where statement is not a valid statement return bool");
         }
         addConjuncts(whereExpr.getConjuncts());


### PR DESCRIPTION
`org.apache.doris.catalog.Type` is not an enum, so should not judge the
equivalence of Type using "==" or "!="

Fix #3785