### PR TITLE
[Bug] Fix bug that checkpoint thread failed to start

### DIFF
--- a/fe/src/main/java/org/apache/doris/PaloFe.java
+++ b/fe/src/main/java/org/apache/doris/PaloFe.java
@@ -72,7 +72,6 @@ public class PaloFe {
             return;
         }
 
-
         CommandLineOptions cmdLineOpts = parseArgs(args);
         System.out.println(cmdLineOpts.toString());
 

--- a/fe/src/main/java/org/apache/doris/catalog/Catalog.java
+++ b/fe/src/main/java/org/apache/doris/catalog/Catalog.java
@@ -541,16 +541,13 @@ public class Catalog {
         }
     }
 
-    // use this to get CheckPoint Catalog instance
-    public static Catalog getCheckpoint() {
-        if (CHECKPOINT == null) {
-            CHECKPOINT = new Catalog();
-        }
-        return CHECKPOINT;
-    }
-
     public static Catalog getCurrentCatalog() {
         if (isCheckpointThread()) {
+            // only checkpoint thread it self will goes here.
+            // so no need to care about the thread safe.
+            if (CHECKPOINT == null) {
+                CHECKPOINT = new Catalog();
+            }
             return CHECKPOINT;
         } else {
             return SingletonHolder.INSTANCE;
@@ -1204,8 +1201,11 @@ public class Catalog {
         // start checkpoint thread
         checkpointer = new Checkpoint(editLog);
         checkpointer.setMetaContext(metaContext);
-        checkpointer.start();
+        // set "checkpointThreadId" before the checkpoint thread start, because the thread
+        // need to check the "checkpointThreadId" when running.
         checkpointThreadId = checkpointer.getId();
+
+        checkpointer.start();
         LOG.info("checkpointer thread started. thread id is {}", checkpointThreadId);
 
         // heartbeat mgr

--- a/fe/src/main/java/org/apache/doris/common/util/Daemon.java
+++ b/fe/src/main/java/org/apache/doris/common/util/Daemon.java
@@ -115,7 +115,7 @@ public class Daemon extends Thread {
             try {
                 runOneCycle();
             } catch (Throwable e) {
-                LOG.error("daemon thread got exception: ", e);
+                LOG.error("daemon thread got exception. name: {}", getName(), e);
             }
 
             try {

--- a/fe/src/main/java/org/apache/doris/master/Checkpoint.java
+++ b/fe/src/main/java/org/apache/doris/master/Checkpoint.java
@@ -94,7 +94,7 @@ public class Checkpoint extends MasterDaemon {
         long replayedJournalId = -1;
         // generate new image file
         LOG.info("begin to generate new image: image.{}", checkPointVersion);
-        catalog = Catalog.getCheckpoint();
+        catalog = Catalog.getCurrentCatalog();
         catalog.setEditLog(editLog);
         try {
             catalog.loadImage(imageDir);


### PR DESCRIPTION
1. Set thread id before starting the checkpoint thread
2. Init the CHECKPOINT catalog instance before visiting it.

Fix #3794
