### PR TITLE
[Bug] Fix SchemaChangeJobV2's meta persist bug

### DIFF
--- a/fe/src/main/java/org/apache/doris/common/Pair.java
+++ b/fe/src/main/java/org/apache/doris/common/Pair.java
@@ -17,26 +17,15 @@
 
 package org.apache.doris.common;
 
-import org.apache.doris.common.io.Text;
-import org.apache.doris.common.io.Writable;
-import org.apache.doris.persist.gson.GsonUtils;
-
-import com.google.gson.annotations.SerializedName;
-
-import java.io.DataInput;
-import java.io.DataOutput;
-import java.io.IOException;
 import java.util.Comparator;
 
 /**
  * The equivalent of C++'s std::pair<>.
  */
-public class Pair<F, S> implements Writable {
+public class Pair<F, S> {
     public static PairComparator<Pair<?, Comparable>> PAIR_VALUE_COMPARATOR = new PairComparator<>();
 
-    @SerializedName(value = "f")
     public F first;
-    @SerializedName(value = "s")
     public S second;
 
     public Pair(F first, S second) {
@@ -78,16 +67,5 @@ public class Pair<F, S> implements Writable {
         public int compare(T o1, T o2) {
             return o1.second.compareTo(o2.second);
         }
-    }
-
-    public static Pair read(DataInput in) throws IOException {
-        String json = Text.readString(in);
-        return GsonUtils.GSON.fromJson(json, Pair.class);
-    }
-
-    @Override
-    public void write(DataOutput out) throws IOException {
-        String json = GsonUtils.GSON.toJson(this);
-        Text.writeString(out, json);
     }
 }

--- a/fe/src/main/java/org/apache/doris/common/Pair.java
+++ b/fe/src/main/java/org/apache/doris/common/Pair.java
@@ -17,15 +17,26 @@
 
 package org.apache.doris.common;
 
+import org.apache.doris.common.io.Text;
+import org.apache.doris.common.io.Writable;
+import org.apache.doris.persist.gson.GsonUtils;
+
+import com.google.gson.annotations.SerializedName;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
 import java.util.Comparator;
 
 /**
  * The equivalent of C++'s std::pair<>.
  */
-public class Pair<F, S> {
+public class Pair<F, S> implements Writable {
     public static PairComparator<Pair<?, Comparable>> PAIR_VALUE_COMPARATOR = new PairComparator<>();
 
+    @SerializedName(value = "f")
     public F first;
+    @SerializedName(value = "s")
     public S second;
 
     public Pair(F first, S second) {
@@ -67,5 +78,16 @@ public class Pair<F, S> {
         public int compare(T o1, T o2) {
             return o1.second.compareTo(o2.second);
         }
+    }
+
+    public static Pair read(DataInput in) throws IOException {
+        String json = Text.readString(in);
+        return GsonUtils.GSON.fromJson(json, Pair.class);
+    }
+
+    @Override
+    public void write(DataOutput out) throws IOException {
+        String json = GsonUtils.GSON.toJson(this);
+        Text.writeString(out, json);
     }
 }

--- a/fe/src/main/java/org/apache/doris/common/SchemaVersionAndHash.java
+++ b/fe/src/main/java/org/apache/doris/common/SchemaVersionAndHash.java
@@ -49,6 +49,11 @@ public class SchemaVersionAndHash implements Writable {
         Text.writeString(out, json);
     }
 
+    @Override
+    public String toString() {
+        return schemaVersion + ":" + schemaHash;
+    }
+
     public static SchemaVersionAndHash read(DataInput in) throws IOException {
         String json = Text.readString(in);
         return GsonUtils.GSON.fromJson(json, SchemaVersionAndHash.class);

--- a/fe/src/main/java/org/apache/doris/common/SchemaVersionAndHash.java
+++ b/fe/src/main/java/org/apache/doris/common/SchemaVersionAndHash.java
@@ -1,0 +1,56 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.common;
+
+import org.apache.doris.common.io.Text;
+import org.apache.doris.common.io.Writable;
+import org.apache.doris.persist.gson.GsonUtils;
+
+import com.google.gson.annotations.SerializedName;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+
+/*
+ * Currently just used for persisting schema version and schema hash pair
+ * using GSON
+ */
+public class SchemaVersionAndHash implements Writable {
+
+    @SerializedName(value = "version")
+    public int schemaVersion;
+    @SerializedName(value = "hash")
+    public int schemaHash;
+
+    public SchemaVersionAndHash(int schemaVersion, int schemaHash) {
+        this.schemaVersion = schemaVersion;
+        this.schemaHash = schemaHash;
+    }
+
+    @Override
+    public void write(DataOutput out) throws IOException {
+        String json = GsonUtils.GSON.toJson(this);
+        Text.writeString(out, json);
+    }
+
+    public static SchemaVersionAndHash read(DataInput in) throws IOException {
+        String json = Text.readString(in);
+        return GsonUtils.GSON.fromJson(json, SchemaVersionAndHash.class);
+    }
+}

--- a/fe/src/main/java/org/apache/doris/persist/EditLog.java
+++ b/fe/src/main/java/org/apache/doris/persist/EditLog.java
@@ -29,9 +29,9 @@ import org.apache.doris.backup.RestoreJob;
 import org.apache.doris.catalog.BrokerMgr;
 import org.apache.doris.catalog.Catalog;
 import org.apache.doris.catalog.Database;
-import org.apache.doris.catalog.Resource;
 import org.apache.doris.catalog.Function;
 import org.apache.doris.catalog.FunctionSearchDesc;
+import org.apache.doris.catalog.Resource;
 import org.apache.doris.cluster.BaseParam;
 import org.apache.doris.cluster.Cluster;
 import org.apache.doris.common.Config;
@@ -779,6 +779,7 @@ public class EditLog {
             }
         } catch (Exception e) {
             LOG.error("Operation Type {}", opCode, e);
+            System.exit(-1);
         }
     }
 


### PR DESCRIPTION
1. Missing field `partitionIndexMap` in SchemaChangeJobV2
2. Pair in field `indexSchemaVersionAndHashMap` can not be persisted by GSON
3. Exit the FE process when replay edit log error.

Fix: #3802