### PR TITLE
Forbidden float column in short key

### DIFF
--- a/fe/src/main/java/org/apache/doris/alter/MaterializedViewHandler.java
+++ b/fe/src/main/java/org/apache/doris/alter/MaterializedViewHandler.java
@@ -576,7 +576,7 @@ public class MaterializedViewHandler extends AlterHandler {
                     keySizeByte += column.getType().getIndexSize();
                     if (theBeginIndexOfValue + 1 > FeConstants.shortkey_max_column_count
                             || keySizeByte > FeConstants.shortkey_maxsize_bytes) {
-                        if (theBeginIndexOfValue == 0 && column.getType().getPrimitiveType() == PrimitiveType.VARCHAR) {
+                        if (theBeginIndexOfValue == 0 && column.getType().getPrimitiveType().isCharFamily()) {
                             column.setIsKey(true);
                             theBeginIndexOfValue++;
                         }

--- a/fe/src/main/java/org/apache/doris/alter/MaterializedViewHandler.java
+++ b/fe/src/main/java/org/apache/doris/alter/MaterializedViewHandler.java
@@ -593,7 +593,7 @@ public class MaterializedViewHandler extends AlterHandler {
                     column.setIsKey(true);
                 }
                 if (theBeginIndexOfValue == 0) {
-                    throw new DdlException("The first column could not be float or double, use decimal instead.");
+                    throw new DdlException("The first column could not be float or double");
                 }
                 // Supplement value of MV columns
                 for (; theBeginIndexOfValue < rollupSchema.size(); theBeginIndexOfValue++) {

--- a/fe/src/main/java/org/apache/doris/analysis/ColumnDef.java
+++ b/fe/src/main/java/org/apache/doris/analysis/ColumnDef.java
@@ -158,7 +158,7 @@ public class ColumnDef {
 
         if (type.getPrimitiveType() == PrimitiveType.FLOAT || type.getPrimitiveType() == PrimitiveType.DOUBLE) {
             if (isOlap && isKey) {
-                throw new AnalysisException("Float or double can not used as a short key, use decimal instead.");
+                throw new AnalysisException("Float or double can not used as a key, use decimal instead.");
             }
         }
 

--- a/fe/src/main/java/org/apache/doris/analysis/ColumnDef.java
+++ b/fe/src/main/java/org/apache/doris/analysis/ColumnDef.java
@@ -158,7 +158,7 @@ public class ColumnDef {
 
         if (type.getPrimitiveType() == PrimitiveType.FLOAT || type.getPrimitiveType() == PrimitiveType.DOUBLE) {
             if (isOlap && isKey) {
-                throw new AnalysisException("Float or double can not used as a key, use decimal instead.");
+                throw new AnalysisException("Float or double can not used as a short key, use decimal instead.");
             }
         }
 

--- a/fe/src/main/java/org/apache/doris/analysis/CreateMaterializedViewStmt.java
+++ b/fe/src/main/java/org/apache/doris/analysis/CreateMaterializedViewStmt.java
@@ -114,14 +114,17 @@ public class CreateMaterializedViewStmt extends DdlStmt {
         analyzeSelectClause();
         analyzeFromClause();
         if (selectStmt.getWhereClause() != null) {
-            throw new AnalysisException("The where clause is not supported in add materialized view clause, expr:" + selectStmt.getWhereClause().toSql());
+            throw new AnalysisException("The where clause is not supported in add materialized view clause, expr:"
+                    + selectStmt.getWhereClause().toSql());
         }
         if (selectStmt.getHavingPred() != null) {
-            throw new AnalysisException("The having clause is not supported in add materialized view clause, expr:" + selectStmt.getHavingPred().toSql());
+            throw new AnalysisException("The having clause is not supported in add materialized view clause, expr:"
+                    + selectStmt.getHavingPred().toSql());
         }
         analyzeOrderByClause();
         if (selectStmt.getLimit() != -1) {
-            throw new AnalysisException("The limit clause is not supported in add materialized view clause, expr:" + " limit " + selectStmt.getLimit());
+            throw new AnalysisException("The limit clause is not supported in add materialized view clause, expr:"
+                    + " limit " + selectStmt.getLimit());
         }
     }
 
@@ -146,7 +149,8 @@ public class CreateMaterializedViewStmt extends DdlStmt {
             SelectListItem selectListItem = selectList.getItems().get(i);
             Expr selectListItemExpr = selectListItem.getExpr();
             if (!(selectListItemExpr instanceof SlotRef) && !(selectListItemExpr instanceof FunctionCallExpr)) {
-                throw new AnalysisException("The materialized view only support the single column or function expr. " + "Error column: " + selectListItemExpr.toSql());
+                throw new AnalysisException("The materialized view only support the single column or function expr. "
+                        + "Error column: " + selectListItemExpr.toSql());
             }
             if (selectListItem.getExpr() instanceof SlotRef) {
                 if (meetAggregate) {
@@ -166,8 +170,11 @@ public class CreateMaterializedViewStmt extends DdlStmt {
                 String functionName = functionCallExpr.getFnName().getFunction();
                 Expr defineExpr = null;
                 // TODO(ml): support REPLACE, REPLACE_IF_NOT_NULL only for aggregate table, HLL_UNION, BITMAP_UNION
-                if (!functionName.equalsIgnoreCase("sum") && !functionName.equalsIgnoreCase("min") && !functionName.equalsIgnoreCase("max")) {
-                    throw new AnalysisException("The materialized view only support the sum, min and max aggregate " + "function. Error function: " + functionCallExpr.toSqlImpl());
+                if (!functionName.equalsIgnoreCase("sum")
+                        && !functionName.equalsIgnoreCase("min")
+                        && !functionName.equalsIgnoreCase("max")) {
+                    throw new AnalysisException("The materialized view only support the sum, min and max aggregate "
+                            + "function. Error function: " + functionCallExpr.toSqlImpl());
                 }
 
                 Preconditions.checkState(functionCallExpr.getChildren().size() == 1);
@@ -178,7 +185,8 @@ public class CreateMaterializedViewStmt extends DdlStmt {
                 } else if (functionChild0 instanceof CastExpr && (functionChild0.getChild(0) instanceof SlotRef)) {
                     slotRef = (SlotRef) functionChild0.getChild(0);
                 } else {
-                    throw new AnalysisException("The children of aggregate function only support one original column. " + "Error function: " + functionCallExpr.toSqlImpl());
+                    throw new AnalysisException("The children of aggregate function only support one original column. "
+                            + "Error function: " + functionCallExpr.toSqlImpl());
                 }
                 meetAggregate = true;
                 // check duplicate column

--- a/fe/src/main/java/org/apache/doris/analysis/CreateMaterializedViewStmt.java
+++ b/fe/src/main/java/org/apache/doris/analysis/CreateMaterializedViewStmt.java
@@ -237,7 +237,7 @@ public class CreateMaterializedViewStmt extends DdlStmt {
                         break;
                     }
                     if (mvColumnItem.getType().isFloatingPointType()) {
-                        throw new AnalysisException("Float or double can not used as a key, use decimal instead.");
+                        throw new AnalysisException("Float or double can not used as a sort key, use decimal instead.");
                     }
                     mvColumnItem.setIsKey(true);
                 }

--- a/fe/src/main/java/org/apache/doris/analysis/CreateMaterializedViewStmt.java
+++ b/fe/src/main/java/org/apache/doris/analysis/CreateMaterializedViewStmt.java
@@ -69,7 +69,6 @@ public class CreateMaterializedViewStmt extends DdlStmt {
     private String baseIndexName;
     private String dbName;
     private KeysType mvKeysType = KeysType.DUP_KEYS;
-    private int shortKeyColumnCount;
 
     public CreateMaterializedViewStmt(String mvName, SelectStmt selectStmt, Map<String, String> properties) {
         this.mvName = mvName;

--- a/fe/src/main/java/org/apache/doris/analysis/CreateMaterializedViewStmt.java
+++ b/fe/src/main/java/org/apache/doris/analysis/CreateMaterializedViewStmt.java
@@ -19,6 +19,7 @@ package org.apache.doris.analysis;
 
 import org.apache.doris.catalog.AggregateType;
 import org.apache.doris.catalog.KeysType;
+import org.apache.doris.catalog.PrimitiveType;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.ErrorCode;
@@ -308,7 +309,7 @@ public class CreateMaterializedViewStmt extends DdlStmt {
                 if (column.getType().isFloatingPointType()) {
                     break;
                 }
-                if (column.getType().getPrimitiveType().isCharFamily()) {
+                if (column.getType().getPrimitiveType() == PrimitiveType.VARCHAR) {
                     column.setIsKey(true);
                     theBeginIndexOfValue++;
                     break;

--- a/fe/src/main/java/org/apache/doris/analysis/CreateMaterializedViewStmt.java
+++ b/fe/src/main/java/org/apache/doris/analysis/CreateMaterializedViewStmt.java
@@ -19,7 +19,6 @@ package org.apache.doris.analysis;
 
 import org.apache.doris.catalog.AggregateType;
 import org.apache.doris.catalog.KeysType;
-import org.apache.doris.catalog.PrimitiveType;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.ErrorCode;
@@ -300,7 +299,7 @@ public class CreateMaterializedViewStmt extends DdlStmt {
                 keySizeByte += column.getType().getIndexSize();
                 if (theBeginIndexOfValue + 1 > FeConstants.shortkey_max_column_count
                         || keySizeByte > FeConstants.shortkey_maxsize_bytes) {
-                    if (theBeginIndexOfValue == 0 && column.getType().getPrimitiveType() == PrimitiveType.VARCHAR) {
+                    if (theBeginIndexOfValue == 0 && column.getType().getPrimitiveType().isCharFamily()) {
                         column.setIsKey(true);
                         theBeginIndexOfValue++;
                     }
@@ -309,7 +308,7 @@ public class CreateMaterializedViewStmt extends DdlStmt {
                 if (column.getType().isFloatingPointType()) {
                     break;
                 }
-                if (column.getType().getPrimitiveType() == PrimitiveType.VARCHAR) {
+                if (column.getType().getPrimitiveType().isCharFamily()) {
                     column.setIsKey(true);
                     theBeginIndexOfValue++;
                     break;

--- a/fe/src/main/java/org/apache/doris/analysis/CreateTableStmt.java
+++ b/fe/src/main/java/org/apache/doris/analysis/CreateTableStmt.java
@@ -25,6 +25,7 @@ import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.Index;
 import org.apache.doris.catalog.KeysType;
 import org.apache.doris.catalog.PartitionType;
+import org.apache.doris.catalog.PrimitiveType;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.ErrorCode;
@@ -295,7 +296,7 @@ public class CreateTableStmt extends DdlStmt {
                         if (columnDef.getType().isFloatingPointType()) {
                             break;
                         }
-                        if (columnDef.getType().getPrimitiveType().isCharFamily()) {
+                        if (columnDef.getType().getPrimitiveType() == PrimitiveType.VARCHAR) {
                             keysColumnNames.add(columnDef.getName());
                             break;
                         }

--- a/fe/src/main/java/org/apache/doris/analysis/CreateTableStmt.java
+++ b/fe/src/main/java/org/apache/doris/analysis/CreateTableStmt.java
@@ -25,7 +25,6 @@ import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.Index;
 import org.apache.doris.catalog.KeysType;
 import org.apache.doris.catalog.PartitionType;
-import org.apache.doris.catalog.PrimitiveType;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.ErrorCode;
@@ -288,7 +287,7 @@ public class CreateTableStmt extends DdlStmt {
                         if (keysColumnNames.size() >= FeConstants.shortkey_max_column_count
                                 || keyLength > FeConstants.shortkey_maxsize_bytes) {
                             if (keysColumnNames.size() == 0
-                                    && columnDef.getType().getPrimitiveType() == PrimitiveType.VARCHAR) {
+                                    && columnDef.getType().getPrimitiveType().isCharFamily()) {
                                 keysColumnNames.add(columnDef.getName());
                             }
                             break;
@@ -296,7 +295,7 @@ public class CreateTableStmt extends DdlStmt {
                         if (columnDef.getType().isFloatingPointType()) {
                             break;
                         }
-                        if (columnDef.getType().getPrimitiveType() == PrimitiveType.VARCHAR) {
+                        if (columnDef.getType().getPrimitiveType().isCharFamily()) {
                             keysColumnNames.add(columnDef.getName());
                             break;
                         }

--- a/fe/src/main/java/org/apache/doris/analysis/CreateTableStmt.java
+++ b/fe/src/main/java/org/apache/doris/analysis/CreateTableStmt.java
@@ -295,8 +295,8 @@ public class CreateTableStmt extends DdlStmt {
                     // The OLAP table must has at least one short key and the float and double should not be short key.
                     // So the float and double could not be the first column in OLAP table.
                     if (keysColumnNames.isEmpty()) {
-                        throw new AnalysisException(
-                                "The first column could not be float or double, " + "use decimal instead.");
+                        throw new AnalysisException("The first column could not be float or double,"
+                                + " use decimal instead.");
                     }
                     keysDesc = new KeysDesc(KeysType.DUP_KEYS, keysColumnNames);
                 }

--- a/fe/src/main/java/org/apache/doris/analysis/CreateTableStmt.java
+++ b/fe/src/main/java/org/apache/doris/analysis/CreateTableStmt.java
@@ -25,6 +25,7 @@ import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.Index;
 import org.apache.doris.catalog.KeysType;
 import org.apache.doris.catalog.PartitionType;
+import org.apache.doris.catalog.PrimitiveType;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.ErrorCode;
@@ -284,13 +285,22 @@ public class CreateTableStmt extends DdlStmt {
                 } else {
                     for (ColumnDef columnDef : columnDefs) {
                         keyLength += columnDef.getType().getStorageLayoutBytes();
-                        if ((!columnDef.getType().getPrimitiveType().isFloatingPointType())
-                                && ((keysColumnNames.size() < FeConstants.shortkey_max_column_count)
-                                || (keyLength < FeConstants.shortkey_maxsize_bytes))) {
-                            keysColumnNames.add(columnDef.getName());
-                        } else {
+                        if (keysColumnNames.size() >= FeConstants.shortkey_max_column_count
+                                || keyLength > FeConstants.shortkey_maxsize_bytes) {
+                            if (keysColumnNames.size() == 0
+                                    && columnDef.getType().getPrimitiveType() == PrimitiveType.VARCHAR) {
+                                keysColumnNames.add(columnDef.getName());
+                            }
                             break;
                         }
+                        if (columnDef.getType().isFloatingPointType()) {
+                            break;
+                        }
+                        if (columnDef.getType().getPrimitiveType() == PrimitiveType.VARCHAR) {
+                            keysColumnNames.add(columnDef.getName());
+                            break;
+                        }
+                        keysColumnNames.add(columnDef.getName());
                     }
                     // The OLAP table must has at least one short key and the float and double should not be short key.
                     // So the float and double could not be the first column in OLAP table.

--- a/fe/src/main/java/org/apache/doris/analysis/CreateTableStmt.java
+++ b/fe/src/main/java/org/apache/doris/analysis/CreateTableStmt.java
@@ -284,7 +284,7 @@ public class CreateTableStmt extends DdlStmt {
                     keysDesc = new KeysDesc(KeysType.AGG_KEYS, keysColumnNames);
                 } else {
                     for (ColumnDef columnDef : columnDefs) {
-                        keyLength += columnDef.getType().getStorageLayoutBytes();
+                        keyLength += columnDef.getType().getIndexSize();
                         if (keysColumnNames.size() >= FeConstants.shortkey_max_column_count
                                 || keyLength > FeConstants.shortkey_maxsize_bytes) {
                             if (keysColumnNames.size() == 0

--- a/fe/src/main/java/org/apache/doris/analysis/MVColumnItem.java
+++ b/fe/src/main/java/org/apache/doris/analysis/MVColumnItem.java
@@ -18,6 +18,7 @@
 package org.apache.doris.analysis;
 
 import org.apache.doris.catalog.AggregateType;
+import org.apache.doris.catalog.PrimitiveType;
 
 /**
  * This is a result of semantic analysis for AddMaterializedViewClause.
@@ -27,6 +28,8 @@ import org.apache.doris.catalog.AggregateType;
  */
 public class MVColumnItem {
     private String name;
+    // the origin type of slot ref
+    private PrimitiveType type;
     private boolean isKey;
     private AggregateType aggregationType;
     private boolean isAggregationTypeImplicit;
@@ -38,6 +41,14 @@ public class MVColumnItem {
 
     public String getName() {
         return name;
+    }
+
+    public void setType(PrimitiveType type) {
+        this.type = type;
+    }
+
+    public PrimitiveType getType() {
+        return type;
     }
 
     public void setIsKey(boolean key) {

--- a/fe/src/main/java/org/apache/doris/analysis/MVColumnItem.java
+++ b/fe/src/main/java/org/apache/doris/analysis/MVColumnItem.java
@@ -19,6 +19,7 @@ package org.apache.doris.analysis;
 
 import org.apache.doris.catalog.AggregateType;
 import org.apache.doris.catalog.PrimitiveType;
+import org.apache.doris.catalog.Type;
 
 /**
  * This is a result of semantic analysis for AddMaterializedViewClause.
@@ -29,7 +30,7 @@ import org.apache.doris.catalog.PrimitiveType;
 public class MVColumnItem {
     private String name;
     // the origin type of slot ref
-    private PrimitiveType type;
+    private Type type;
     private boolean isKey;
     private AggregateType aggregationType;
     private boolean isAggregationTypeImplicit;
@@ -43,12 +44,12 @@ public class MVColumnItem {
         return name;
     }
 
-    public void setType(PrimitiveType type) {
-        this.type = type;
+    public Type getType() {
+        return type;
     }
 
-    public PrimitiveType getType() {
-        return type;
+    public void setType(Type type) {
+        this.type = type;
     }
 
     public void setIsKey(boolean key) {

--- a/fe/src/main/java/org/apache/doris/analysis/MVColumnItem.java
+++ b/fe/src/main/java/org/apache/doris/analysis/MVColumnItem.java
@@ -18,7 +18,6 @@
 package org.apache.doris.analysis;
 
 import org.apache.doris.catalog.AggregateType;
-import org.apache.doris.catalog.PrimitiveType;
 import org.apache.doris.catalog.Type;
 
 /**

--- a/fe/src/main/java/org/apache/doris/catalog/Catalog.java
+++ b/fe/src/main/java/org/apache/doris/catalog/Catalog.java
@@ -4879,29 +4879,30 @@ public class Catalog {
              * contains at most one VARCHAR column. And if contains, it should
              * be at the last position of the short key list.
              */
-            shortKeyColumnCount = 1;
+            shortKeyColumnCount = 0;
             int shortKeySizeByte = 0;
-            Column firstColumn = indexColumns.get(0);
-            if (firstColumn.getDataType() != PrimitiveType.VARCHAR) {
-                shortKeySizeByte = firstColumn.getOlapColumnIndexSize();
-                int maxShortKeyColumnCount = Math.min(indexColumns.size(), FeConstants.shortkey_max_column_count);
-                for (int i = 1; i < maxShortKeyColumnCount; i++) {
-                    Column column = indexColumns.get(i);
-                    shortKeySizeByte += column.getOlapColumnIndexSize();
-                    if (shortKeySizeByte > FeConstants.shortkey_maxsize_bytes) {
-                        break;
-                    }
+            int maxShortKeyColumnCount = Math.min(indexColumns.size(), FeConstants.shortkey_max_column_count);
+            for (int i = 0; i < maxShortKeyColumnCount; i++) {
+                Column column = indexColumns.get(i);
+                shortKeySizeByte += column.getOlapColumnIndexSize();
+                if (shortKeySizeByte > FeConstants.shortkey_maxsize_bytes) {
                     if (column.getDataType() == PrimitiveType.VARCHAR) {
                         ++shortKeyColumnCount;
-                        break;
                     }
-                    ++shortKeyColumnCount;
+                    break;
                 }
+                if (column.getType().isFloatingPointType()) {
+                    break;
+                }
+                if (column.getDataType() == PrimitiveType.VARCHAR) {
+                    ++shortKeyColumnCount;
+                    break;
+                }
+                ++shortKeyColumnCount;
             }
-            // else
-            // first column type is VARCHAR
-            // use only first column as shortKey
-            // do nothing here
+            if (shortKeyColumnCount == 0) {
+                throw new DdlException("The first column could not be float or double type, use decimal instead");
+            }
 
         } // end calc shortKeyColumnCount
 

--- a/fe/src/main/java/org/apache/doris/catalog/Catalog.java
+++ b/fe/src/main/java/org/apache/doris/catalog/Catalog.java
@@ -4894,7 +4894,7 @@ public class Catalog {
                 if (column.getType().isFloatingPointType()) {
                     break;
                 }
-                if (column.getDataType().isCharFamily()) {
+                if (column.getDataType() == PrimitiveType.VARCHAR) {
                     ++shortKeyColumnCount;
                     break;
                 }

--- a/fe/src/main/java/org/apache/doris/catalog/Catalog.java
+++ b/fe/src/main/java/org/apache/doris/catalog/Catalog.java
@@ -4886,7 +4886,7 @@ public class Catalog {
                 Column column = indexColumns.get(i);
                 shortKeySizeByte += column.getOlapColumnIndexSize();
                 if (shortKeySizeByte > FeConstants.shortkey_maxsize_bytes) {
-                    if (column.getDataType() == PrimitiveType.VARCHAR) {
+                    if (column.getDataType().isCharFamily()) {
                         ++shortKeyColumnCount;
                     }
                     break;
@@ -4894,7 +4894,7 @@ public class Catalog {
                 if (column.getType().isFloatingPointType()) {
                     break;
                 }
-                if (column.getDataType() == PrimitiveType.VARCHAR) {
+                if (column.getDataType().isCharFamily()) {
                     ++shortKeyColumnCount;
                     break;
                 }

--- a/fe/src/main/java/org/apache/doris/catalog/PrimitiveType.java
+++ b/fe/src/main/java/org/apache/doris/catalog/PrimitiveType.java
@@ -17,15 +17,15 @@
 
 package org.apache.doris.catalog;
 
-import java.util.List;
-
 import org.apache.doris.mysql.MysqlColType;
 import org.apache.doris.thrift.TPrimitiveType;
+
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSetMultimap;
 import com.google.common.collect.Lists;
 
 import java.util.ArrayList;
+import java.util.List;
 
 public enum PrimitiveType {
     INVALID_TYPE("INVALID_TYPE", -1, TPrimitiveType.INVALID_TYPE),
@@ -669,6 +669,10 @@ public enum PrimitiveType {
 
     public boolean isStringType() {
         return (this == VARCHAR || this == CHAR || this == HLL);
+    }
+
+    public boolean isCharFamily() {
+        return (this == VARCHAR || this == CHAR);
     }
 
     public boolean isIntegerType() {

--- a/fe/src/main/java/org/apache/doris/catalog/Type.java
+++ b/fe/src/main/java/org/apache/doris/catalog/Type.java
@@ -1030,4 +1030,12 @@ public abstract class Type {
     public int getStorageLayoutBytes() {
         return 0;
     }
+
+    public int getIndexSize() {
+        if (this.getPrimitiveType() == PrimitiveType.CHAR) {
+            return ((ScalarType) this).getLength();
+        } else {
+            return this.getPrimitiveType().getOlapColumnIndexSize();
+        }
+    }
 }

--- a/fe/src/test/java/org/apache/doris/analysis/CreateMaterializedViewStmtTest.java
+++ b/fe/src/test/java/org/apache/doris/analysis/CreateMaterializedViewStmtTest.java
@@ -689,22 +689,18 @@ public class CreateMaterializedViewStmtTest {
                 result = columnName3;
                 slotRef4.getColumnName();
                 result = columnName4;
-                selectStmt.getResultExprs();
-                result = Lists.newArrayList(slotRef1, slotRef2, slotRef3, slotRef4);
-                slotRef1.getType().getStorageLayoutBytes();
+                slotRef1.getType().getIndexSize();
                 result = 1;
                 slotRef1.getType().getPrimitiveType();
                 result = PrimitiveType.INT;
-                slotRef2.getType().getStorageLayoutBytes();
+                slotRef2.getType().getIndexSize();
                 result = 2;
                 slotRef2.getType().getPrimitiveType();
                 result = PrimitiveType.INT;
-                slotRef3.getType().getStorageLayoutBytes();
+                slotRef3.getType().getIndexSize();
                 result = 3;
-                slotRef3.getType().getPrimitiveType();
-                result = PrimitiveType.FLOAT;
-                slotRef4.getType().getPrimitiveType();
-                result = PrimitiveType.INT;
+                slotRef3.getType().isFloatingPointType();
+                result = true;
                 selectStmt.getAggInfo(); // return null, so that the mv can be a duplicate mv
                 result = null;
             }
@@ -732,6 +728,104 @@ public class CreateMaterializedViewStmtTest {
             Assert.assertTrue(mvColumn2.isAggregationTypeImplicit());
             Assert.assertEquals(columnName3, mvColumn2.getName());
             Assert.assertEquals(AggregateType.NONE, mvColumn2.getAggregationType());
+            MVColumnItem mvColumn3 = mvColumns.get(3);
+            Assert.assertFalse(mvColumn3.isKey());
+            Assert.assertTrue(mvColumn3.isAggregationTypeImplicit());
+            Assert.assertEquals(columnName4, mvColumn3.getName());
+            Assert.assertEquals(AggregateType.NONE, mvColumn3.getAggregationType());
+        } catch (UserException e) {
+            Assert.fail(e.getMessage());
+        }
+    }
+
+    /*
+    ISSUE: #3811
+    */
+    @Test
+    public void testMVColumnsWithoutOrderbyWithoutAggregationWithVarchar(@Injectable SlotRef slotRef1,
+            @Injectable SlotRef slotRef2, @Injectable SlotRef slotRef3, @Injectable SlotRef slotRef4,
+            @Injectable TableRef tableRef, @Injectable SelectStmt selectStmt) throws UserException {
+        SelectList selectList = new SelectList();
+        SelectListItem selectListItem1 = new SelectListItem(slotRef1, null);
+        selectList.addItem(selectListItem1);
+        SelectListItem selectListItem2 = new SelectListItem(slotRef2, null);
+        selectList.addItem(selectListItem2);
+        SelectListItem selectListItem3 = new SelectListItem(slotRef3, null);
+        selectList.addItem(selectListItem3);
+        SelectListItem selectListItem4 = new SelectListItem(slotRef4, null);
+        selectList.addItem(selectListItem4);
+
+        final String columnName1 = "k1";
+        final String columnName2 = "k2";
+        final String columnName3 = "v1";
+        final String columnName4 = "v2";
+
+        new Expectations() {
+            {
+                analyzer.getClusterName();
+                result = "default";
+                selectStmt.getAggInfo();
+                result = null;
+                selectStmt.getSelectList();
+                result = selectList;
+                selectStmt.getTableRefs();
+                result = Lists.newArrayList(tableRef);
+                selectStmt.getWhereClause();
+                result = null;
+                selectStmt.getHavingPred();
+                result = null;
+                selectStmt.getOrderByElements();
+                result = null;
+                selectStmt.getLimit();
+                result = -1;
+                selectStmt.analyze(analyzer);
+                slotRef1.getColumnName();
+                result = columnName1;
+                slotRef2.getColumnName();
+                result = columnName2;
+                slotRef3.getColumnName();
+                result = columnName3;
+                slotRef4.getColumnName();
+                result = columnName4;
+                slotRef1.getType().getIndexSize();
+                result = 1;
+                slotRef1.getType().getPrimitiveType();
+                result = PrimitiveType.INT;
+                slotRef2.getType().getIndexSize();
+                result = 2;
+                slotRef2.getType().getPrimitiveType();
+                result = PrimitiveType.INT;
+                slotRef3.getType().getIndexSize();
+                result = 3;
+                slotRef3.getType().getPrimitiveType();
+                result = PrimitiveType.VARCHAR;
+                selectStmt.getAggInfo(); // return null, so that the mv can be a duplicate mv
+                result = null;
+            }
+        };
+
+
+        CreateMaterializedViewStmt createMaterializedViewStmt = new CreateMaterializedViewStmt("test", selectStmt, null);
+        try {
+            createMaterializedViewStmt.analyze(analyzer);
+            Assert.assertEquals(KeysType.DUP_KEYS, createMaterializedViewStmt.getMVKeysType());
+            List<MVColumnItem> mvColumns = createMaterializedViewStmt.getMVColumnItemList();
+            Assert.assertEquals(4, mvColumns.size());
+            MVColumnItem mvColumn0 = mvColumns.get(0);
+            Assert.assertTrue(mvColumn0.isKey());
+            Assert.assertFalse(mvColumn0.isAggregationTypeImplicit());
+            Assert.assertEquals(columnName1, mvColumn0.getName());
+            Assert.assertEquals(null, mvColumn0.getAggregationType());
+            MVColumnItem mvColumn1 = mvColumns.get(1);
+            Assert.assertTrue(mvColumn1.isKey());
+            Assert.assertFalse(mvColumn1.isAggregationTypeImplicit());
+            Assert.assertEquals(columnName2, mvColumn1.getName());
+            Assert.assertEquals(null, mvColumn1.getAggregationType());
+            MVColumnItem mvColumn2 = mvColumns.get(2);
+            Assert.assertTrue(mvColumn2.isKey());
+            Assert.assertFalse(mvColumn2.isAggregationTypeImplicit());
+            Assert.assertEquals(columnName3, mvColumn2.getName());
+            Assert.assertEquals(null, mvColumn2.getAggregationType());
             MVColumnItem mvColumn3 = mvColumns.get(3);
             Assert.assertFalse(mvColumn3.isKey());
             Assert.assertTrue(mvColumn3.isAggregationTypeImplicit());
@@ -773,12 +867,8 @@ public class CreateMaterializedViewStmtTest {
                 selectStmt.analyze(analyzer);
                 slotRef1.getColumnName();
                 result = columnName1;
-                selectStmt.getResultExprs();
-                result = Lists.newArrayList(slotRef1);
-                slotRef1.getType().getStorageLayoutBytes();
-                result = 35;
-                slotRef1.getType().getPrimitiveType();
-                result = PrimitiveType.FLOAT;
+                slotRef1.getType().isFloatingPointType();
+                result = true;
                 selectStmt.getAggInfo(); // return null, so that the mv can be a duplicate mv
                 result = null;
             }
@@ -793,6 +883,62 @@ public class CreateMaterializedViewStmtTest {
             System.out.print(e.getMessage());
         }
     }
+
+    /*
+    ISSUE: #3811
+    */
+    @Test
+    public void testMVColumnsWithFirstVarchar(@Injectable SlotRef slotRef1,
+            @Injectable TableRef tableRef, @Injectable SelectStmt selectStmt) throws UserException {
+        SelectList selectList = new SelectList();
+        SelectListItem selectListItem1 = new SelectListItem(slotRef1, null);
+        selectList.addItem(selectListItem1);
+
+        final String columnName1 = "k1";
+
+        new Expectations() {
+            {
+                analyzer.getClusterName();
+                result = "default";
+                selectStmt.getAggInfo();
+                result = null;
+                selectStmt.getSelectList();
+                result = selectList;
+                selectStmt.getTableRefs();
+                result = Lists.newArrayList(tableRef);
+                selectStmt.getWhereClause();
+                result = null;
+                selectStmt.getHavingPred();
+                result = null;
+                selectStmt.getOrderByElements();
+                result = null;
+                selectStmt.getLimit();
+                result = -1;
+                selectStmt.analyze(analyzer);
+                slotRef1.getColumnName();
+                result = columnName1;
+                slotRef1.getType().getPrimitiveType();
+                result = PrimitiveType.VARCHAR;
+            }
+        };
+
+
+        CreateMaterializedViewStmt createMaterializedViewStmt = new CreateMaterializedViewStmt("test", selectStmt, null);
+        try {
+            createMaterializedViewStmt.analyze(analyzer);
+            Assert.assertEquals(KeysType.DUP_KEYS, createMaterializedViewStmt.getMVKeysType());
+            List<MVColumnItem> mvColumns = createMaterializedViewStmt.getMVColumnItemList();
+            Assert.assertEquals(1, mvColumns.size());
+            MVColumnItem mvColumn0 = mvColumns.get(0);
+            Assert.assertTrue(mvColumn0.isKey());
+            Assert.assertFalse(mvColumn0.isAggregationTypeImplicit());
+            Assert.assertEquals(columnName1, mvColumn0.getName());
+            Assert.assertEquals(null, mvColumn0.getAggregationType());
+        } catch (UserException e) {
+            Assert.fail(e.getMessage());
+        }
+    }
+
 
     @Test
     public void testMVColumns(@Injectable SlotRef slotRef1,

--- a/fe/src/test/java/org/apache/doris/analysis/CreateMaterializedViewStmtTest.java
+++ b/fe/src/test/java/org/apache/doris/analysis/CreateMaterializedViewStmtTest.java
@@ -19,6 +19,7 @@ package org.apache.doris.analysis;
 
 import org.apache.doris.catalog.AggregateType;
 import org.apache.doris.catalog.KeysType;
+import org.apache.doris.catalog.PrimitiveType;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.UserException;
 import org.apache.doris.common.jmockit.Deencapsulation;
@@ -588,12 +589,20 @@ public class CreateMaterializedViewStmtTest {
                 result = Lists.newArrayList(slotRef1, slotRef2, slotRef3, slotRef4);
                 slotRef1.getType().getStorageLayoutBytes();
                 result = 35;
+                slotRef1.getType().getPrimitiveType();
+                result = PrimitiveType.INT;
                 slotRef2.getType().getStorageLayoutBytes();
                 result = 2;
+                slotRef2.getType().getPrimitiveType();
+                result = PrimitiveType.INT;
                 slotRef3.getType().getStorageLayoutBytes();
                 result = 3;
+                slotRef3.getType().getPrimitiveType();
+                result = PrimitiveType.INT;
                 slotRef4.getType().getStorageLayoutBytes();
                 result = 4;
+                slotRef4.getType().getPrimitiveType();
+                result = PrimitiveType.INT;
                 selectStmt.getAggInfo(); // return null, so that the mv can be a duplicate mv
                 result = null;
             }
@@ -628,6 +637,156 @@ public class CreateMaterializedViewStmtTest {
             Assert.assertEquals(AggregateType.NONE, mvColumn3.getAggregationType());
         } catch (UserException e) {
             Assert.fail(e.getMessage());
+        }
+    }
+
+    @Test
+    public void testMVColumnsWithoutOrderbyWithoutAggregationWithFloat(@Injectable SlotRef slotRef1,
+            @Injectable SlotRef slotRef2, @Injectable SlotRef slotRef3, @Injectable SlotRef slotRef4,
+            @Injectable TableRef tableRef, @Injectable SelectStmt selectStmt) throws UserException {
+        SelectList selectList = new SelectList();
+        SelectListItem selectListItem1 = new SelectListItem(slotRef1, null);
+        selectList.addItem(selectListItem1);
+        SelectListItem selectListItem2 = new SelectListItem(slotRef2, null);
+        selectList.addItem(selectListItem2);
+        SelectListItem selectListItem3 = new SelectListItem(slotRef3, null);
+        selectList.addItem(selectListItem3);
+        SelectListItem selectListItem4 = new SelectListItem(slotRef4, null);
+        selectList.addItem(selectListItem4);
+
+        final String columnName1 = "k1";
+        final String columnName2 = "k2";
+        final String columnName3 = "v1";
+        final String columnName4 = "v2";
+
+        new Expectations() {
+            {
+                analyzer.getClusterName();
+                result = "default";
+                selectStmt.getAggInfo();
+                result = null;
+                selectStmt.getSelectList();
+                result = selectList;
+                selectStmt.getTableRefs();
+                result = Lists.newArrayList(tableRef);
+                selectStmt.getWhereClause();
+                result = null;
+                selectStmt.getHavingPred();
+                result = null;
+                selectStmt.getOrderByElements();
+                result = null;
+                selectStmt.getLimit();
+                result = -1;
+                selectStmt.analyze(analyzer);
+                slotRef1.getColumnName();
+                result = columnName1;
+                slotRef2.getColumnName();
+                result = columnName2;
+                slotRef3.getColumnName();
+                result = columnName3;
+                slotRef4.getColumnName();
+                result = columnName4;
+                selectStmt.getResultExprs();
+                result = Lists.newArrayList(slotRef1, slotRef2, slotRef3, slotRef4);
+                slotRef1.getType().getStorageLayoutBytes();
+                result = 35;
+                slotRef1.getType().getPrimitiveType();
+                result = PrimitiveType.INT;
+                slotRef2.getType().getStorageLayoutBytes();
+                result = 2;
+                slotRef2.getType().getPrimitiveType();
+                result = PrimitiveType.INT;
+                slotRef3.getType().getStorageLayoutBytes();
+                result = 3;
+                slotRef3.getType().getPrimitiveType();
+                result = PrimitiveType.FLOAT;
+                slotRef4.getType().getStorageLayoutBytes();
+                result = 4;
+                slotRef4.getType().getPrimitiveType();
+                result = PrimitiveType.INT;
+                selectStmt.getAggInfo(); // return null, so that the mv can be a duplicate mv
+                result = null;
+            }
+        };
+
+
+        CreateMaterializedViewStmt createMaterializedViewStmt = new CreateMaterializedViewStmt("test", selectStmt, null);
+        try {
+            createMaterializedViewStmt.analyze(analyzer);
+            Assert.assertEquals(KeysType.DUP_KEYS, createMaterializedViewStmt.getMVKeysType());
+            List<MVColumnItem> mvColumns = createMaterializedViewStmt.getMVColumnItemList();
+            Assert.assertEquals(4, mvColumns.size());
+            MVColumnItem mvColumn0 = mvColumns.get(0);
+            Assert.assertTrue(mvColumn0.isKey());
+            Assert.assertFalse(mvColumn0.isAggregationTypeImplicit());
+            Assert.assertEquals(columnName1, mvColumn0.getName());
+            Assert.assertEquals(null, mvColumn0.getAggregationType());
+            MVColumnItem mvColumn1 = mvColumns.get(1);
+            Assert.assertTrue(mvColumn1.isKey());
+            Assert.assertFalse(mvColumn1.isAggregationTypeImplicit());
+            Assert.assertEquals(columnName2, mvColumn1.getName());
+            Assert.assertEquals(null, mvColumn1.getAggregationType());
+            MVColumnItem mvColumn2 = mvColumns.get(2);
+            Assert.assertFalse(mvColumn2.isKey());
+            Assert.assertTrue(mvColumn2.isAggregationTypeImplicit());
+            Assert.assertEquals(columnName3, mvColumn2.getName());
+            Assert.assertEquals(AggregateType.NONE, mvColumn2.getAggregationType());
+            MVColumnItem mvColumn3 = mvColumns.get(3);
+            Assert.assertFalse(mvColumn3.isKey());
+            Assert.assertTrue(mvColumn3.isAggregationTypeImplicit());
+            Assert.assertEquals(columnName4, mvColumn3.getName());
+            Assert.assertEquals(AggregateType.NONE, mvColumn3.getAggregationType());
+        } catch (UserException e) {
+            Assert.fail(e.getMessage());
+        }
+    }
+
+    @Test
+    public void testMVColumnsWithFirstFloat(@Injectable SlotRef slotRef1,
+            @Injectable TableRef tableRef, @Injectable SelectStmt selectStmt) throws UserException {
+        SelectList selectList = new SelectList();
+        SelectListItem selectListItem1 = new SelectListItem(slotRef1, null);
+        selectList.addItem(selectListItem1);
+
+        final String columnName1 = "k1";
+
+        new Expectations() {
+            {
+                analyzer.getClusterName();
+                result = "default";
+                selectStmt.getAggInfo();
+                result = null;
+                selectStmt.getSelectList();
+                result = selectList;
+                selectStmt.getTableRefs();
+                result = Lists.newArrayList(tableRef);
+                selectStmt.getWhereClause();
+                result = null;
+                selectStmt.getHavingPred();
+                result = null;
+                selectStmt.getOrderByElements();
+                result = null;
+                selectStmt.analyze(analyzer);
+                slotRef1.getColumnName();
+                result = columnName1;
+                selectStmt.getResultExprs();
+                result = Lists.newArrayList(slotRef1);
+                slotRef1.getType().getStorageLayoutBytes();
+                result = 35;
+                slotRef1.getType().getPrimitiveType();
+                result = PrimitiveType.FLOAT;
+                selectStmt.getAggInfo(); // return null, so that the mv can be a duplicate mv
+                result = null;
+            }
+        };
+
+
+        CreateMaterializedViewStmt createMaterializedViewStmt = new CreateMaterializedViewStmt("test", selectStmt, null);
+        try {
+            createMaterializedViewStmt.analyze(analyzer);
+            Assert.fail("The first column could not be float or double, use decimal instead");
+        } catch (UserException e) {
+            System.out.print(e.getMessage());
         }
     }
 

--- a/fe/src/test/java/org/apache/doris/analysis/CreateMaterializedViewStmtTest.java
+++ b/fe/src/test/java/org/apache/doris/analysis/CreateMaterializedViewStmtTest.java
@@ -585,24 +585,20 @@ public class CreateMaterializedViewStmtTest {
                 result = columnName3;
                 slotRef4.getColumnName();
                 result = columnName4;
-                selectStmt.getResultExprs();
-                result = Lists.newArrayList(slotRef1, slotRef2, slotRef3, slotRef4);
-                slotRef1.getType().getStorageLayoutBytes();
-                result = 35;
+                slotRef1.getType().getIndexSize();
+                result = 34;
                 slotRef1.getType().getPrimitiveType();
                 result = PrimitiveType.INT;
-                slotRef2.getType().getStorageLayoutBytes();
-                result = 2;
+                slotRef2.getType().getIndexSize();
+                result = 1;
                 slotRef2.getType().getPrimitiveType();
                 result = PrimitiveType.INT;
-                slotRef3.getType().getStorageLayoutBytes();
-                result = 3;
+                slotRef3.getType().getIndexSize();
+                result = 1;
                 slotRef3.getType().getPrimitiveType();
                 result = PrimitiveType.INT;
-                slotRef4.getType().getStorageLayoutBytes();
+                slotRef4.getType().getIndexSize();
                 result = 4;
-                slotRef4.getType().getPrimitiveType();
-                result = PrimitiveType.INT;
                 selectStmt.getAggInfo(); // return null, so that the mv can be a duplicate mv
                 result = null;
             }

--- a/fe/src/test/java/org/apache/doris/analysis/CreateMaterializedViewStmtTest.java
+++ b/fe/src/test/java/org/apache/doris/analysis/CreateMaterializedViewStmtTest.java
@@ -640,6 +640,9 @@ public class CreateMaterializedViewStmtTest {
         }
     }
 
+    /*
+    ISSUE: #3811
+     */
     @Test
     public void testMVColumnsWithoutOrderbyWithoutAggregationWithFloat(@Injectable SlotRef slotRef1,
             @Injectable SlotRef slotRef2, @Injectable SlotRef slotRef3, @Injectable SlotRef slotRef4,
@@ -689,7 +692,7 @@ public class CreateMaterializedViewStmtTest {
                 selectStmt.getResultExprs();
                 result = Lists.newArrayList(slotRef1, slotRef2, slotRef3, slotRef4);
                 slotRef1.getType().getStorageLayoutBytes();
-                result = 35;
+                result = 1;
                 slotRef1.getType().getPrimitiveType();
                 result = PrimitiveType.INT;
                 slotRef2.getType().getStorageLayoutBytes();
@@ -700,8 +703,6 @@ public class CreateMaterializedViewStmtTest {
                 result = 3;
                 slotRef3.getType().getPrimitiveType();
                 result = PrimitiveType.FLOAT;
-                slotRef4.getType().getStorageLayoutBytes();
-                result = 4;
                 slotRef4.getType().getPrimitiveType();
                 result = PrimitiveType.INT;
                 selectStmt.getAggInfo(); // return null, so that the mv can be a duplicate mv
@@ -741,6 +742,9 @@ public class CreateMaterializedViewStmtTest {
         }
     }
 
+    /*
+    ISSUE: #3811
+     */
     @Test
     public void testMVColumnsWithFirstFloat(@Injectable SlotRef slotRef1,
             @Injectable TableRef tableRef, @Injectable SelectStmt selectStmt) throws UserException {

--- a/fe/src/test/java/org/apache/doris/planner/QueryPlanTest.java
+++ b/fe/src/test/java/org/apache/doris/planner/QueryPlanTest.java
@@ -69,9 +69,9 @@ public class QueryPlanTest {
         Catalog.getCurrentCatalog().createDb(createDbStmt);
         
         createTable("create table test.test1\n" + 
-                "(\n" + 
-                "    query_id varchar(48) comment \"Unique query id\",\n" + 
-                "    time datetime not null comment \"Query start time\",\n" + 
+                "(\n" +
+                "    time datetime not null comment \"Query start time\",\n" +
+                "    query_id varchar(48) comment \"Unique query id\",\n" +
                 "    client_ip varchar(32) comment \"Client IP\",\n" + 
                 "    user varchar(64) comment \"User name\",\n" + 
                 "    db varchar(96) comment \"Database of this query\",\n" + 

--- a/fe/src/test/java/org/apache/doris/utframe/DorisAssert.java
+++ b/fe/src/test/java/org/apache/doris/utframe/DorisAssert.java
@@ -141,11 +141,15 @@ public class DorisAssert {
         }
 
         public String explainQuery() throws Exception {
-            StmtExecutor stmtExecutor = new StmtExecutor(connectContext, "explain " + sql);
+            return internalExecute("explain " + sql);
+        }
+
+        private String internalExecute(String sql) throws Exception {
+            StmtExecutor stmtExecutor = new StmtExecutor(connectContext, sql);
             stmtExecutor.execute();
             QueryState queryState = connectContext.getState();
             if (queryState.getStateType() == QueryState.MysqlStateType.ERR) {
-                switch (queryState.getErrType()){
+                switch (queryState.getErrType()) {
                     case ANALYSIS_ERR:
                         throw new AnalysisException(queryState.getErrorMessage());
                     case OTHER_ERR:


### PR DESCRIPTION
When the user does not specify the key column, doris will automatically supplement the key column.
However, doris does not support float or double as the key column, so when adding the key column, doris should avoid setting those column as the key column.

The CreateMaterailizedView, AddRollup and CreateDuplicateTable need to forbidden float column in short key.
If the float column is directly encountered during the supplement process, the subsequent columns are all value columns.
If the first column is float or double, Doris will throw the exception.

Fixed #3811

Change-Id: Ib66d9355acefcd8f281906bcb7b4dd684319ff08