### PR TITLE
[Doris On ES] Skip function_call expr when process predicate

### DIFF
--- a/be/src/exec/es/es_predicate.cpp
+++ b/be/src/exec/es/es_predicate.cpp
@@ -54,8 +54,7 @@ using namespace std;
             const Expr* expr_without_cast = Expr::expr_without_cast(expr); \
             if (expr_without_cast->node_type() != TExprNodeType::SLOT_REF) { \
                 return Status::InternalError("build disjuncts failed: child is not slot ref"); \
-            }
-        } \
+            } \
     } while (false)
 
 std::string ExtLiteral::value_to_string() {

--- a/be/src/exec/es/es_predicate.cpp
+++ b/be/src/exec/es/es_predicate.cpp
@@ -49,6 +49,15 @@ namespace doris {
 
 using namespace std;
 
+#define RETURN_ERROR_IF_EXPR_IS_NOT_SLOTREF(expr) \
+    do { \
+            const Expr* expr_without_cast = Expr::expr_without_cast(expr); \
+            if (expr_without_cast->node_type() != TExprNodeType::SLOT_REF) { \
+                return Status::InternalError("build disjuncts failed: child is not slot ref"); \
+            }
+        } \
+    } while (false)
+
 std::string ExtLiteral::value_to_string() {
     std::stringstream ss;
     switch (_type) {
@@ -235,6 +244,8 @@ Status EsPredicate::build_disjuncts_list(const Expr* conjunct) {
         if (TExprNodeType::SLOT_REF == conjunct->get_child(0)->node_type()
             || TExprNodeType::CAST_EXPR == conjunct->get_child(0)->node_type()) {
             expr = conjunct->get_child(1);
+            // process such as sub-query: select * from (select split_part(k, "_", 1) as new_field from case_replay_for_milimin) t where t.new_field > 1;
+            RETURN_ERROR_IF_EXPR_IS_NOT_SLOTREF(conjunct->get_child(0));
             // process cast expr, such as:
             // k (float) > 2.0, k(int) > 3.2
             slot_ref = (SlotRef*)Expr::expr_without_cast(conjunct->get_child(0));
@@ -242,6 +253,10 @@ Status EsPredicate::build_disjuncts_list(const Expr* conjunct) {
         } else if (TExprNodeType::SLOT_REF == conjunct->get_child(1)->node_type()
             || TExprNodeType::CAST_EXPR == conjunct->get_child(1)->node_type()) {
             expr = conjunct->get_child(0);
+            // process such as sub-query: select * from (select split_part(k, "_", 1) as new_field from case_replay_for_milimin) t where t.new_field > 1;
+             RETURN_ERROR_IF_EXPR_IS_NOT_SLOTREF(conjunct->get_child(1));
+            // process cast expr, such as:
+            // k (float) > 2.0, k(int) > 3.2
             slot_ref = (SlotRef*)Expr::expr_without_cast(conjunct->get_child(1));
             op = conjunct->op();
         } else {
@@ -299,6 +314,9 @@ Status EsPredicate::build_disjuncts_list(const Expr* conjunct) {
 
     if (TExprNodeType::FUNCTION_CALL == conjunct->node_type()
         && (conjunct->fn().name.function_name == "is_null_pred" || conjunct->fn().name.function_name == "is_not_null_pred")) {
+        // such as sub-query: select * from (select split_part(k, "_", 1) as new_field from case_replay_for_milimin) t where t.new_field > 1;
+        // conjunct->get_child(0)->node_type() == TExprNodeType::FUNCTION_CALL, at present doris on es can not support push down function 
+        RETURN_ERROR_IF_EXPR_IS_NOT_SLOTREF(conjunct->get_child(0));
         SlotRef* slot_ref = (SlotRef*)(conjunct->get_child(0));
         const SlotDescriptor* slot_desc = get_slot_desc(slot_ref);
         bool is_not_null;

--- a/be/src/exec/es/es_predicate.cpp
+++ b/be/src/exec/es/es_predicate.cpp
@@ -252,10 +252,7 @@ Status EsPredicate::build_disjuncts_list(const Expr* conjunct) {
         } else if (TExprNodeType::SLOT_REF == conjunct->get_child(1)->node_type()
             || TExprNodeType::CAST_EXPR == conjunct->get_child(1)->node_type()) {
             expr = conjunct->get_child(0);
-            // process such as sub-query: select * from (select split_part(k, "_", 1) as new_field from case_replay_for_milimin) t where t.new_field > 1;
-             RETURN_ERROR_IF_EXPR_IS_NOT_SLOTREF(conjunct->get_child(1));
-            // process cast expr, such as:
-            // k (float) > 2.0, k(int) > 3.2
+            RETURN_ERROR_IF_EXPR_IS_NOT_SLOTREF(conjunct->get_child(1));
             slot_ref = (SlotRef*)Expr::expr_without_cast(conjunct->get_child(1));
             op = conjunct->op();
         } else {


### PR DESCRIPTION
https://github.com/apache/incubator-doris/issues/3801
Do not push-down ` function_call` such as `split_xxx` when process predicate, Doris BE is responsible for processing these `predicate`

All rows in table:

```
+------+------+------+------------+------------+
| k1   | k2   | k3   | UpdateTime | ArriveTime |
+------+------+------+------------+------------+
| NULL | NULL | kkk1 |  123456789 |       NULL |
| kkk1 | NULL | NULL |  123456789 |       NULL |
| NULL | kkk2 | NULL |  123456789 |       NULL |
+------+------+------+------------+------------+
```

SQL 1:

```
mysql> select * from (select split_part(k1, "1", 1) as kk from case_replay_for_milimin) t where t.kk is not null;
+------+
| kk   |
+------+
| kkk  |
+------+
1 row in set (0.02 sec)
```

SQL 2:

```
mysql> select * from (select split_part(k1, "1", 1) as kk from case_replay_for_milimin) t where t.kk > 'a';      
+------+
| kk   |
+------+
| kkk  |
+------+
```

SQL 3:

```
mysql> select * from (select split_part(k1, "1", 1) as kk from case_replay_for_milimin) t where t.kk > '2';
+------+
| kk   |
+------+
| kkk  |
+------+
1 row in set (0.03 sec)
```

SQL 4:

```
mysql> select * from (select split_part(k1, "1", 1) as kk from case_replay_for_milimin) t where t.kk > 2;
Empty set (0.02 sec)

```

Some problems：

I do not know whether SQL 4 meets expectations when Doris filters the data.

