### PR TITLE
[UDF] StringVal::operator==(): avoid pass NULL to memcmp()

### DIFF
--- a/be/src/udf/udf.h
+++ b/be/src/udf/udf.h
@@ -644,7 +644,7 @@ struct StringVal : public AnyVal {
             return false;
         }
 
-        return ptr == other.ptr || memcmp(ptr, other.ptr, len) == 0;
+        return len == 0 || ptr == other.ptr || memcmp(ptr, other.ptr, len) == 0;
     }
 
     bool operator!=(const StringVal& other) const {


### PR DESCRIPTION
Ref https://github.com/apache/incubator-doris/issues/3843

If we exec "StringVal(len=0, ptr="") == StringVal(len=0,ptr=NULL)", it will pass NULL ptr to memcmp(). It should be avoided.
