### PR TITLE
[Bug] fix uninitialized member vars

### DIFF
--- a/be/src/olap/fs/block_manager.cpp
+++ b/be/src/olap/fs/block_manager.cpp
@@ -48,7 +48,5 @@ namespace fs {
 // TODO(lingbin): move it to conf later, to allow adjust dynamicaly.
 const std::string BlockManager::block_manager_preflush_control = "finalize";
 
-BlockManagerOptions::BlockManagerOptions() : read_only(false) {}
-
 } // namespace fs
 } // namespace doris

--- a/be/src/olap/fs/block_manager.h
+++ b/be/src/olap/fs/block_manager.h
@@ -176,17 +176,17 @@ struct CreateBlockOptions {
 
 // Block manager creation options.
 struct BlockManagerOptions {
-    BlockManagerOptions();
+    BlockManagerOptions() = default;
 
     // The memory tracker under which all new memory trackers will be parented.
     // If NULL, new memory trackers will be parented to the root tracker.
     std::shared_ptr<MemTracker> parent_mem_tracker;
 
     // If false, metrics will not be produced.
-    bool enable_metric;
+    bool enable_metric = false;
 
     // Whether the block manager should only allow reading. Defaults to false.
-    bool read_only;
+    bool read_only = false;
 };
 
 // Utilities for Block lifecycle management. All methods are thread-safe.

--- a/be/src/olap/row_block.h
+++ b/be/src/olap/row_block.h
@@ -39,7 +39,7 @@ struct RowBlockInfo {
 
     uint32_t checksum;
     uint32_t row_num;       // block最大数据行数
-    bool null_supported;
+    bool null_supported = false;
     std::vector<uint32_t> column_ids;
 };
 

--- a/be/src/olap/tablet_schema.h
+++ b/be/src/olap/tablet_schema.h
@@ -40,7 +40,7 @@ public:
     inline bool is_key() const { return _is_key; }
     inline bool is_nullable() const { return _is_nullable; }
     inline bool is_bf_column() const { return _is_bf_column; }
-    inline bool has_bitmap_index() const {return _has_bitmap_index; }
+    inline bool has_bitmap_index() const { return _has_bitmap_index; }
     bool has_default_value() const { return _has_default_value; }
     std::string default_value() const { return _default_value; }
     bool has_reference_column() const { return _has_referenced_column; }
@@ -65,23 +65,23 @@ private:
     int32_t _unique_id;
     std::string _col_name;
     FieldType _type;
-    bool _is_key;
+    bool _is_key = false;
     FieldAggregationMethod _aggregation;
-    bool _is_nullable;
+    bool _is_nullable = false;
 
-    bool _has_default_value;
+    bool _has_default_value = false;
     std::string _default_value;
 
-    bool _is_decimal;
+    bool _is_decimal = false;
     int32_t _precision;
     int32_t _frac;
 
     int32_t _length;
     int32_t _index_length;
 
-    bool _is_bf_column;
+    bool _is_bf_column = false;
 
-    bool _has_referenced_column;
+    bool _has_referenced_column = false;
     int32_t _referenced_column_id;
     std::string _referenced_column;
 
@@ -109,10 +109,8 @@ public:
     inline CompressKind compress_kind() const { return _compress_kind; }
     inline size_t next_column_unique_id() const { return _next_column_unique_id; }
     inline double bloom_filter_fpp() const { return _bf_fpp; }
-    inline bool is_in_memory() const {return _is_in_memory; }
-    inline void set_is_in_memory (bool is_in_memory) {
-        _is_in_memory = is_in_memory;
-    }
+    inline bool is_in_memory() const { return _is_in_memory; }
+    inline void set_is_in_memory(bool is_in_memory) { _is_in_memory = is_in_memory; }
 
 private:
     friend bool operator==(const TabletSchema& a, const TabletSchema& b);

--- a/run-ut.sh
+++ b/run-ut.sh
@@ -89,7 +89,7 @@ fi
 
 cd ${DORIS_HOME}/be/ut_build/
 
-${CMAKE_CMD} ../ -DWITH_MYSQL=OFF -DMAKE_TEST=ON
+${CMAKE_CMD} ../ -DWITH_MYSQL=OFF -DMAKE_TEST=ON -DCMAKE_BUILD_TYPE=DEBUG
 make -j${PARALLEL}
 
 if [ ${RUN} -ne 1 ]; then


### PR DESCRIPTION
Ref https://github.com/apache/incubator-doris/issues/3821

This fix is based on UBSAN unit test. So if we create & use class obj in a different way, may have `runtime error: load of value XX, which is not a valid value for type 'YYY'` warnings again.

Unit test should build in DEBUG or XXSAN mode(at lease DEBUG). RELEASE mode will add `-DNDEBUG`, turn off dchecks/asserts/debug.