### PR TITLE
[FE] Prohibit pointing helper to itself when starting FE

### DIFF
--- a/docs/en/installing/install-deploy.md
+++ b/docs/en/installing/install-deploy.md
@@ -274,6 +274,7 @@ View the status of Follower or Observer. Connect to any booted FE using mysql-cl
 > 1. The number of Follower FEs (including Leaders) must be odd. It is recommended that a maximum of three constituent high availability (HA) modes be deployed.
 > 2. When FE is in a highly available deployment (1 Leader, 2 Follower), we recommend that the reading service capability of FE be extended by adding Observer FE. Of course, you can continue to add Follower FE, but it's almost unnecessary.
 > 3. Usually a FE node can handle 10-20 BE nodes. It is suggested that the total number of FE nodes should be less than 10. Usually three can meet most of the needs.
+> 4. The helper cannot point to the FE itself, it must point to one or more existing running Master/Follower FEs.
 
 #### Delete FE nodes
 

--- a/docs/zh-CN/installing/install-deploy.md
+++ b/docs/zh-CN/installing/install-deploy.md
@@ -269,6 +269,7 @@ FE 分为 Leader，Follower 和 Observer 三种角色。 默认一个集群，�
 > 1. Follower FE（包括 Leader）的数量必须为奇数，建议最多部署 3 个组成高可用（HA）模式即可。  
 > 2. 当 FE 处于高可用部署时（1个 Leader，2个 Follower），我们建议通过增加 Observer FE 来扩展 FE 的读服务能力。当然也可以继续增加 Follower FE，但几乎是不必要的。  
 > 3. 通常一个 FE 节点可以应对 10-20 台 BE 节点。建议总的 FE 节点数量在 10 个以下。而通常 3 个即可满足绝大部分需求。  
+> 4. helper 不能指向 FE 自身，必须指向一个或多个已存在并且正常运行中的 Master/Follower FE。
 
 #### 删除 FE 节点
 

--- a/fe/src/main/java/org/apache/doris/catalog/Catalog.java
+++ b/fe/src/main/java/org/apache/doris/catalog/Catalog.java
@@ -1055,7 +1055,22 @@ public class Catalog {
             if (helpers != null) {
                 String[] splittedHelpers = helpers.split(",");
                 for (String helper : splittedHelpers) {
-                    helperNodes.add(SystemInfoService.validateHostAndPort(helper));
+                    Pair<String, Integer> helperHostPort = SystemInfoService.validateHostAndPort(helper);
+                    if (helperHostPort.equals(selfNode)) {
+                        /**
+                         * If user specified the helper node to this FE itself,
+                         * we will stop the starting FE process and report an error.
+                         * First, it is meaningless to point the helper to itself.
+                         * Secondly, when some users add FE for the first time, they will mistakenly
+                         * point the helper that should have pointed to the Master to themselves.
+                         * In this case, some errors have caused users to be troubled.
+                         * So here directly exit the program and inform the user to avoid unnecessary trouble.
+                         */
+                        throw new AnalysisException(
+                                "Do not specify the helper node to FE itself. "
+                                        + "Please specify it to the existing running Master or Follower FE");
+                    }
+                    helperNodes.add(helperHostPort);
                 }
             } else {
                 // If helper node is not designated, use local node as helper node.


### PR DESCRIPTION
When starting FE with `start_fe.sh --helper xxx` command, do not allow to
point helper to FE itself. Because this is meaningless and may cause some
confusing problems.