### PR TITLE
[Compaction] Resolve the `-230` error by saving latest read version of a tablet

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -266,7 +266,6 @@ namespace config {
     CONF_mInt64(min_cumulative_compaction_num_singleton_deltas, "5");
     CONF_mInt64(max_cumulative_compaction_num_singleton_deltas, "1000");
     CONF_Int32(cumulative_compaction_num_threads_per_disk, "1");
-    CONF_mInt64(cumulative_compaction_budgeted_bytes, "104857600");
     // CONF_Int32(cumulative_compaction_write_mbytes_per_sec, "100");
     // cumulative compaction skips recently published deltas in order to prevent
     // compacting a version that might be queried (in case the query planning phase took some time).

--- a/be/src/exec/olap_scanner.cpp
+++ b/be/src/exec/olap_scanner.cpp
@@ -111,6 +111,7 @@ Status OlapScanner::_prepare(
                 << ", res=" << acquire_reader_st << ", backend=" << BackendOptions::get_localhost();
                 return Status::InternalError(ss.str().c_str());
             }
+            _tablet->update_latest_read_version(_version);
         }
     }
 

--- a/be/src/olap/cumulative_compaction.cpp
+++ b/be/src/olap/cumulative_compaction.cpp
@@ -188,7 +188,7 @@ OLAPStatus CumulativeCompaction::_check_limitation() {
     }
 
     // the _input_rowsets is already sorted by version here.
-    // iterate it from begin to last, only select rowsets  if one of the following conditions meet:
+    // iterate it from begin to last, only select rowsets if one of the following conditions meet:
     // 1. rowset's end version <= latest read version. This is to avoid -230 error
     // 2. The difference between the creation time of rowset and the current time is greater than
     //    config::cumulative_compaction_skip_window_seconds. This is to avoid accumulating too many versions.

--- a/be/src/olap/cumulative_compaction.cpp
+++ b/be/src/olap/cumulative_compaction.cpp
@@ -52,21 +52,21 @@ OLAPStatus CumulativeCompaction::compact() {
     // 3. check some limitation about the input rowsets
     RETURN_NOT_OK(_check_limitation());
 
-    // 3. do cumulative compaction, merge rowsets
+    // 4. do cumulative compaction, merge rowsets
     RETURN_NOT_OK(do_compaction());
     TRACE("compaction finished");
 
-    // 4. set state to success
+    // 5. set state to success
     _state = CompactionState::SUCCESS;
 
-    // 5. set cumulative point
+    // 6. set cumulative point
     _tablet->set_cumulative_layer_point(_input_rowsets.back()->end_version() + 1);
     
-    // 6. garbage collect input rowsets after cumulative compaction 
+    // 7. garbage collect input rowsets after cumulative compaction 
     RETURN_NOT_OK(gc_unused_rowsets());
     TRACE("unused rowsets have been moved to GC queue");
 
-    // 7. add metric to cumulative compaction
+    // 8. add metric to cumulative compaction
     DorisMetrics::instance()->cumulative_compaction_deltas_total.increment(_input_rowsets.size());
     DorisMetrics::instance()->cumulative_compaction_bytes_total.increment(_input_rowsets_size);
 

--- a/be/src/olap/cumulative_compaction.cpp
+++ b/be/src/olap/cumulative_compaction.cpp
@@ -23,8 +23,7 @@
 namespace doris {
 
 CumulativeCompaction::CumulativeCompaction(TabletSharedPtr tablet)
-    : Compaction(tablet),
-      _cumulative_rowset_size_threshold(config::cumulative_compaction_budgeted_bytes)
+    : Compaction(tablet)
 { }
 
 CumulativeCompaction::~CumulativeCompaction() { }

--- a/be/src/olap/cumulative_compaction.h
+++ b/be/src/olap/cumulative_compaction.h
@@ -43,6 +43,10 @@ protected:
     }
 
 private:
+    // check some limitation after calling pick_rowsets_to_compact.
+    // This may modify the input rowsets.
+    OLAPStatus _check_limitation();
+
     int64_t _cumulative_rowset_size_threshold;
 
     DISALLOW_COPY_AND_ASSIGN(CumulativeCompaction);

--- a/be/src/olap/cumulative_compaction.h
+++ b/be/src/olap/cumulative_compaction.h
@@ -47,8 +47,6 @@ private:
     // This may modify the input rowsets.
     OLAPStatus _check_limitation();
 
-    int64_t _cumulative_rowset_size_threshold;
-
     DISALLOW_COPY_AND_ASSIGN(CumulativeCompaction);
 };
 

--- a/be/src/olap/tablet.h
+++ b/be/src/olap/tablet.h
@@ -290,7 +290,7 @@ private:
     std::atomic<int64_t> _cumulative_point;
     std::atomic<int32_t> _newly_created_rowset_num;
     std::atomic<int64_t> _last_checkpoint_time;
-    // save the maximum read version specified in the read request.
+    // save the current largest read version which has been read by query
     std::atomic<int64_t> _latest_read_version;
 
     DISALLOW_COPY_AND_ASSIGN(Tablet);

--- a/docs/en/administrator-guide/config/be_config.md
+++ b/docs/en/administrator-guide/config/be_config.md
@@ -51,7 +51,7 @@ This document mainly introduces the relevant configuration items of BE.
 
 ### `base_compaction_num_threads_per_disk`
 
-### base_compaction_trace_threshold
+### `base_compaction_trace_threshold`
 
 * Type: int32
 * Description: Threshold to logging base compaction's trace information, in seconds
@@ -132,15 +132,18 @@ User can set this configuration to a larger value to get better QPS performance.
 
 ### `create_tablet_worker_count`
 
-### `cumulative_compaction_budgeted_bytes`
-
 ### `cumulative_compaction_check_interval_seconds`
 
 ### `cumulative_compaction_num_threads_per_disk`
 
 ### `cumulative_compaction_skip_window_seconds`
 
-### cumulative_compaction_trace_threshold
+* Type: int32
+* Description: This config will control Cumulative Compaction to skip the newly generated data version in the most recent period. The default is 30. The unit is second. It means that Cumulative Compaction will not select the data version that was just generated in the last 30 seconds to merge. This config is mainly to mitigate the `-230` error in the query. This error indicates that the specified read version has been merged during the query. If the `-230` error occurs frequently during the query, you can consider increasing this value. However, increasing this value may also result in a backlog of data versions, thereby reducing data reading efficiency.
+* Default value: 30
+* Special instructions: in version 0.13. Doris has improved Cumulative Compaction's logic for selecting the data version. While referring to this configuration, it will also refer to `last read version`, which is the current maximum version which has been read by query. (This value can be obtained through [Compaction Action](../http-actions/compaction-action.md)). In the new version, if a table is read more frequently (such as at least once a minute), you can consider increasing this value (such as 300 seconds) to further reduce the probability of `-230` error.
+
+### `cumulative_compaction_trace_threshold`
 
 * Type: int32
 * Description: Threshold to logging cumulative compaction's trace information, in seconds

--- a/docs/en/administrator-guide/config/be_config.md
+++ b/docs/en/administrator-guide/config/be_config.md
@@ -54,7 +54,7 @@ This document mainly introduces the relevant configuration items of BE.
 ### `base_compaction_trace_threshold`
 
 * Type: int32
-* Description: Threshold to logging base compaction's trace information, in seconds
+* Description: Threshold to logging base compaction's trace information, in seconds. If the time taken for a base compaction exceeds the configuration, trace information will be printed.
 * Default value: 10
 
 Base compaction is a long time cost background task, this configuration is the threshold to logging trace information. Trace information in log file looks like:

--- a/docs/en/administrator-guide/http-actions/compaction-action.md
+++ b/docs/en/administrator-guide/http-actions/compaction-action.md
@@ -58,6 +58,7 @@ If the tablet exists, the result is returned in JSON format:
     "last base failure time": "2019-12-16 18:13:23.320",
     "last cumu success time": "2019-12-16 18:12:15.110",
     "last base success time": "2019-12-16 18:11:50.780",
+    "latest read version": 50
     "rowsets": [
         "[0-48] 10 DATA OVERLAPPING",
         "[49-49] 2 DATA OVERLAPPING",
@@ -67,12 +68,15 @@ If the tablet exists, the result is returned in JSON format:
 }
 ```
 
+* The URL can also be obtained directly from the `CompactionStatus` field in the `SHOW TABLET` command result.
+
 Explanation of results:
 
 * cumulative point: The version boundary between base and cumulative compaction. Versions before (excluding) points are handled by base compaction. Versions after (inclusive) are handled by cumulative compaction.
 * last cumulative failure time: The time when the last cumulative compaction failed. After 10 minutes by default, cumulative compaction is attempted on the this tablet again.
 * last base failure time: The time when the last base compaction failed. After 10 minutes by default, base compaction is attempted on the this tablet again.
 * rowsets: The current rowsets collection of this tablet. [0-48] means a rowset with version 0-48. The second number is the number of segments in a rowset. The `DELETE` indicates the delete version. `OVERLAPPING` and `NONOVERLAPPING` indicates whether data between segments is overlap.
+* latest read version: new attribute added in version 0.13. Represents the largest version of the tablet that has been queried. Compaction logic will try to avoid merging version data after this version. For specific instructions, please refer to the parameter description of `cumulative_compaction_skip_window_seconds` in [BE Configuration Item] (../config/be_config.md).
 
 ### Examples
 

--- a/docs/zh-CN/administrator-guide/config/be_config.md
+++ b/docs/zh-CN/administrator-guide/config/be_config.md
@@ -54,7 +54,7 @@ under the License.
 ### `base_compaction_trace_threshold`
 
 * 类型：int32
-* 描述：打印base compaction的trace信息的阈值，单位秒
+* 描述：打印base compaction的trace信息的阈值，单位秒。如果一个 base compaction 的耗时超过了该配置，则会打印 trace 信息。
 * 默认值：10
 
 base compaction是一个耗时较长的后台操作，为了跟踪其运行信息，可以调整这个阈值参数来控制trace日志的打印。打印信息如下：

--- a/docs/zh-CN/administrator-guide/http-actions/compaction-action.md
+++ b/docs/zh-CN/administrator-guide/http-actions/compaction-action.md
@@ -58,6 +58,7 @@ curl -X GET http://be_host:webserver_port/api/compaction/show?tablet_id=xxxx\&sc
     "last base failure time": "2019-12-16 18:13:23.320",
     "last cumu success time": "2019-12-16 18:12:15.110",
     "last base success time": "2019-12-16 18:11:50.780",
+    "latest read version": 50
     "rowsets": [
         "[0-48] 10 DATA OVERLAPPING",
         "[49-49] 2 DATA OVERLAPPING",
@@ -67,12 +68,15 @@ curl -X GET http://be_host:webserver_port/api/compaction/show?tablet_id=xxxx\&sc
 }
 ```
 
+* 该 URL 也可以直接通过 `SHOW TABLET` 命令结果中的 `CompactionStatus` 字段获取。
+
 结果说明：
 
 * cumulative point：base 和 cumulative compaction 的版本分界线。在 point（不含）之前的版本由 base compaction 处理。point（含）之后的版本由 cumulative compaction 处理。
 * last cumulative failure time：上一次尝试 cumulative compaction 失败的时间。默认 10min 后才会再次尝试对该 tablet 做 cumulative compaction。
 * last base failure time：上一次尝试 base compaction 失败的时间。默认 10min 后才会再次尝试对该 tablet 做 base compaction。
 * rowsets：该 tablet 当前的 rowset 集合。如 [0-48] 表示 0-48 版本。第二位数字表示该版本中 segment 的数量。`DELETE` 表示 delete 版本。`DATA` 表示数据版本。`OVERLAPPING` 和 `NONOVERLAPPING` 表示segment数据是否重叠。
+* latest read version：0.13 版本中新加入的属性。表示该 tablet 被查询过的最大版本。Compaction 逻辑会尝试避免合并这个版本之后的版本数据。具体说明可以参阅 [BE 配置项](../config/be_config.md) 中的 `cumulative_compaction_skip_window_seconds` 参数说明。
 
 ### 示例
 


### PR DESCRIPTION
Fix #3859

This CL mainly changes:
1. add a new field `_latest_read_version` for tablet on BE to save the largest version which has
been read by query.
2. Modify the cumulative compaction logic. When select rowset to merge, consider both
`cumulative_compaction_skip_window_seconds` and `_latest_read_version`.
3. Add some docs for config
4. Remove unused config `cumulative_compaction_budgeted_bytes`