### PR TITLE
Fix BE crash when query contains HLL column

### DIFF
--- a/be/src/olap/aggregate_func.h
+++ b/be/src/olap/aggregate_func.h
@@ -451,8 +451,8 @@ struct AggregateFuncTraits<OLAP_FIELD_AGGREGATION_HLL_UNION, OLAP_FIELD_TYPE_HLL
     static void init(RowCursorCell* dst, const char* src, bool src_null, MemPool* mem_pool, ObjectPool* agg_pool) {
         dst->set_not_null();
 
-        auto *src_slice = reinterpret_cast<const Slice *>(src);
-        auto *dst_slice = reinterpret_cast<Slice *>(dst->mutable_cell_ptr());
+        auto* src_slice = reinterpret_cast<const Slice*>(src);
+        auto* dst_slice = reinterpret_cast<Slice*>(dst->mutable_cell_ptr());
 
         // Because of history bug, we ingest some NULL HLL data in storage,
         // which slice data is nullptr or invalid address,

--- a/be/src/olap/field.h
+++ b/be/src/olap/field.h
@@ -467,7 +467,7 @@ public:
 
     // Hll storage data always not null
     void agg_init(RowCursorCell* dst, const RowCursorCell& src, MemPool* mem_pool, ObjectPool* agg_pool) const override {
-        _agg_info->init(dst, (const char*)src.cell_ptr(), false, mem_pool, agg_pool);
+        _agg_info->init(dst, (const char*)src.cell_ptr(), src.is_null(), mem_pool, agg_pool);
     }
 
     char* allocate_memory(char* cell_ptr, char* variable_ptr) const override {


### PR DESCRIPTION
  According #3868,  BE will core because of invalid address, This bug happens occasionally because most of the time HyperLogLog's data are nullptr, which does not cause crashes, but sometimes this value is invalid address, which causes crashes during deserialize.
   Whether slice data is nullptr or invalid address is determined by the RowBlock, however the RowBlock did not use `memset` when it was initialized, so invalid data may exist.