### PR TITLE
[Bug] Fix bug that BE crash when doing Insert Operation

### DIFF
--- a/be/src/exec/exec_node.cpp
+++ b/be/src/exec/exec_node.cpp
@@ -552,7 +552,7 @@ void ExecNode::try_do_aggregate_serde_improve() {
 void ExecNode::init_runtime_profile(const std::string& name) {
     std::stringstream ss;
     ss << name << " (id=" << _id << ")";
-    _runtime_profile.reset(new RuntimeProfile(_pool, ss.str()));
+    _runtime_profile.reset(new RuntimeProfile(ss.str()));
     _runtime_profile->set_metadata(_id);
 }
 

--- a/be/src/exec/tablet_sink.cpp
+++ b/be/src/exec/tablet_sink.cpp
@@ -457,7 +457,7 @@ Status OlapTableSink::prepare(RuntimeState* state) {
     _num_senders = state->num_per_fragment_instances();
 
     // profile must add to state's object pool
-    _profile = state->obj_pool()->add(new RuntimeProfile(_pool, "OlapTableSink"));
+    _profile = state->obj_pool()->add(new RuntimeProfile("OlapTableSink"));
     _mem_tracker = _pool->add(new MemTracker(-1, "OlapTableSink", state->instance_mem_tracker()));
 
     SCOPED_TIMER(_profile->total_time_counter());

--- a/be/src/runtime/buffered_block_mgr2.cc
+++ b/be/src/runtime/buffered_block_mgr2.cc
@@ -1259,7 +1259,7 @@ void BufferedBlockMgr2::init(
 
     io_mgr->register_context(&_io_request_context);
 
-    _profile.reset(new RuntimeProfile(&_obj_pool, "BlockMgr"));
+    _profile.reset(new RuntimeProfile("BlockMgr"));
     parent_profile->add_child(_profile.get(), true, NULL);
 
     _block_size_counter = ADD_COUNTER(_profile.get(), "MaxBlockSize", TUnit::BYTES);

--- a/be/src/runtime/data_spliter.cpp
+++ b/be/src/runtime/data_spliter.cpp
@@ -94,7 +94,7 @@ Status DataSpliter::prepare(RuntimeState* state) {
     for (auto& iter : _rollup_map) {
         RETURN_IF_ERROR(iter.second->prepare(state, _row_desc, _expr_mem_tracker.get()));
     }
-    _profile = state->obj_pool()->add(new RuntimeProfile(state->obj_pool(), title.str()));
+    _profile = state->obj_pool()->add(new RuntimeProfile(title.str()));
     for (auto iter : _partition_infos) {
         RETURN_IF_ERROR(iter->prepare(state, _row_desc, _expr_mem_tracker.get()));
     }

--- a/be/src/runtime/data_stream_sender.cpp
+++ b/be/src/runtime/data_stream_sender.cpp
@@ -381,7 +381,7 @@ Status DataStreamSender::prepare(RuntimeState* state) {
     _state = state;
     std::stringstream title;
     title << "DataStreamSender (dst_id=" << _dest_node_id << ")";
-    _profile = _pool->add(new RuntimeProfile(_pool, title.str()));
+    _profile = _pool->add(new RuntimeProfile(title.str()));
     SCOPED_TIMER(_profile->total_time_counter());
     _mem_tracker.reset(
             new MemTracker(_profile, -1, "DataStreamSender", state->instance_mem_tracker()));

--- a/be/src/runtime/dpp_sink.cpp
+++ b/be/src/runtime/dpp_sink.cpp
@@ -569,7 +569,7 @@ Status Translator::create_profile(RuntimeState* state) {
     std::stringstream ss;
     ss << "Dpp translator(" << _tablet_desc.partition_id << "_" << _tablet_desc.bucket_id
         << "_" << _rollup_name << ")";
-    _profile = state->obj_pool()->add(new RuntimeProfile(state->obj_pool(), ss.str()));
+    _profile = state->obj_pool()->add(new RuntimeProfile(ss.str()));
 
     _add_batch_timer = ADD_TIMER(_profile, "add batch time");
     _sort_timer = ADD_TIMER(_profile, "sort time");
@@ -875,7 +875,7 @@ Status Translator::close(RuntimeState* state) {
 }
 
 Status DppSink::init(RuntimeState* state) {
-    _profile = state->obj_pool()->add(new RuntimeProfile(state->obj_pool(), "Dpp sink"));
+    _profile = state->obj_pool()->add(new RuntimeProfile("Dpp sink"));
     return Status::OK();
 }
 

--- a/be/src/runtime/export_sink.cpp
+++ b/be/src/runtime/export_sink.cpp
@@ -64,7 +64,7 @@ Status ExportSink::prepare(RuntimeState* state) {
     std::stringstream title;
     title << "ExportSink (frag_id=" << state->fragment_instance_id() << ")";
     // create profile
-    _profile = state->obj_pool()->add(new RuntimeProfile(state->obj_pool(), title.str()));
+    _profile = state->obj_pool()->add(new RuntimeProfile(title.str()));
     SCOPED_TIMER(_profile->total_time_counter());
 
     _mem_tracker.reset(new MemTracker(-1, "ExportSink", state->instance_mem_tracker()));

--- a/be/src/runtime/memory_scratch_sink.cpp
+++ b/be/src/runtime/memory_scratch_sink.cpp
@@ -67,7 +67,7 @@ Status MemoryScratchSink::prepare(RuntimeState* state) {
     std::stringstream title;
     title << "MemoryScratchSink (frag_id=" << fragment_instance_id << ")";
     // create profile
-    _profile = state->obj_pool()->add(new RuntimeProfile(state->obj_pool(), title.str()));
+    _profile = state->obj_pool()->add(new RuntimeProfile(title.str()));
 
     return Status::OK();
 }

--- a/be/src/runtime/mysql_table_sink.cpp
+++ b/be/src/runtime/mysql_table_sink.cpp
@@ -61,7 +61,7 @@ Status MysqlTableSink::prepare(RuntimeState* state) {
     std::stringstream title;
     title << "MysqlTableSink (frag_id=" << state->fragment_instance_id() << ")";
     // create profile
-    _profile = state->obj_pool()->add(new RuntimeProfile(state->obj_pool(), title.str()));
+    _profile = state->obj_pool()->add(new RuntimeProfile(title.str()));
     return Status::OK();
 }
 

--- a/be/src/runtime/result_sink.cpp
+++ b/be/src/runtime/result_sink.cpp
@@ -67,7 +67,7 @@ Status ResultSink::prepare(RuntimeState* state) {
     std::stringstream title;
     title << "DataBufferSender (dst_fragment_instance_id=" << print_id(state->fragment_instance_id()) << ")";
     // create profile
-    _profile = state->obj_pool()->add(new RuntimeProfile(state->obj_pool(), title.str()));
+    _profile = state->obj_pool()->add(new RuntimeProfile(title.str()));
     // prepare output_expr
     RETURN_IF_ERROR(prepare_exprs(state));
 

--- a/be/src/runtime/runtime_state.cpp
+++ b/be/src/runtime/runtime_state.cpp
@@ -51,10 +51,10 @@ RuntimeState::RuntimeState(
         const TUniqueId& fragment_instance_id,
         const TQueryOptions& query_options,
         const TQueryGlobals& query_globals, ExecEnv* exec_env) :
+            _profile("Fragment " + print_id(fragment_instance_id)),
             _obj_pool(new ObjectPool()),
             _data_stream_recvrs_pool(new ObjectPool()),
             _unreported_error_idx(0),
-            _profile(_obj_pool.get(), "Fragment " + print_id(fragment_instance_id)),
             _fragment_mem_tracker(NULL),
             _is_cancelled(false),
             _per_fragment_instance_idx(0),
@@ -76,12 +76,11 @@ RuntimeState::RuntimeState(
         const TExecPlanFragmentParams& fragment_params,
         const TQueryOptions& query_options,
         const TQueryGlobals& query_globals, ExecEnv* exec_env) :
+            _profile("Fragment " + print_id(fragment_params.params.fragment_instance_id)),
             _obj_pool(new ObjectPool()),
             _data_stream_recvrs_pool(new ObjectPool()),
             _unreported_error_idx(0),
             _query_id(fragment_params.params.query_id),
-            _profile(_obj_pool.get(),
-                    "Fragment " + print_id(fragment_params.params.fragment_instance_id)),
             _fragment_mem_tracker(NULL),
             _is_cancelled(false),
             _per_fragment_instance_idx(0),
@@ -100,10 +99,10 @@ RuntimeState::RuntimeState(
 }
 
 RuntimeState::RuntimeState(const TQueryGlobals& query_globals)
-    : _obj_pool(new ObjectPool()),
+    : _profile("<unnamed>"),
+      _obj_pool(new ObjectPool()),
       _data_stream_recvrs_pool(new ObjectPool()),
       _unreported_error_idx(0),
-      _profile(_obj_pool.get(), "<unnamed>"),
       _is_cancelled(false),
       _per_fragment_instance_idx(0) {
     _query_options.batch_size = DEFAULT_BATCH_SIZE;

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -505,7 +505,7 @@ private:
     static const int DEFAULT_BATCH_SIZE = 2048;
 
     // put runtime state before _obj_pool, so that it will be deconstructed after
-    // _obj_pool. And some of object in _obj_pool will use profile when deconstructing.
+    // _obj_pool. Because some of object in _obj_pool will use profile when deconstructing.
     RuntimeProfile _profile;
 
     DescriptorTbl* _desc_tbl;

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -504,6 +504,10 @@ private:
 
     static const int DEFAULT_BATCH_SIZE = 2048;
 
+    // put runtime state before _obj_pool, so that it will be deconstructed after
+    // _obj_pool. And some of object in _obj_pool will use profile when deconstructing.
+    RuntimeProfile _profile;
+
     DescriptorTbl* _desc_tbl;
     std::shared_ptr<ObjectPool> _obj_pool;
 
@@ -541,8 +545,6 @@ private:
     // Thread resource management object for this fragment's execution.  The runtime
     // state is responsible for returning this pool to the thread mgr.
     ThreadResourceMgr::ResourcePool* _resource_pool;
-
-    RuntimeProfile _profile;
 
     // all mem limits that apply to this query
     std::vector<MemTracker*> _mem_trackers;

--- a/be/src/util/dummy_runtime_profile.h
+++ b/be/src/util/dummy_runtime_profile.h
@@ -24,7 +24,7 @@
 namespace doris {
 class DummyProfile {
 public:
-    DummyProfile() : _pool(), _profile(new RuntimeProfile(&_pool, "dummy", false)) {}
+    DummyProfile() : _pool(), _profile(new RuntimeProfile("dummy", false)) {}
     RuntimeProfile* profile() { return _profile; }
     virtual ~DummyProfile() {
         delete _profile;

--- a/be/src/util/runtime_profile.h
+++ b/be/src/util/runtime_profile.h
@@ -275,16 +275,10 @@ public:
         MonotonicStopWatch _sw;
     };
 
-    // Create a runtime profile object with 'name'.  Counters and merged profile are
-    // allocated from pool.
-    RuntimeProfile(ObjectPool* pool, const std::string& name, bool is_averaged_profile = false);
+    // Create a runtime profile object with 'name'.
+    RuntimeProfile(const std::string& name, bool is_averaged_profile = false);
 
     ~RuntimeProfile();
-
-    // Deserialize from thrift.  Runtime profiles are allocated from the pool.
-    static RuntimeProfile* create_from_thrift(
-            ObjectPool* pool,
-            const TRuntimeProfileTree& profiles);
 
     // Adds a child profile.  This is thread safe.
     // 'indent' indicates whether the child will be printed w/ extra indentation
@@ -600,13 +594,6 @@ private:
     // Singleton object that keeps track of all rate counters and the thread
     // for updating them.
     static PeriodicCounterUpdateState _s_periodic_counter_update_state;
-
-    // Create a subtree of runtime profiles from nodes, starting at *node_idx.
-    // On return, *node_idx is the index one past the end of this subtree
-    static RuntimeProfile* create_from_thrift(
-            ObjectPool* pool,
-            const std::vector<TRuntimeProfileNode>& nodes,
-            int* node_idx);
 
     // update a subtree of profiles from nodes, rooted at *idx.
     // On return, *idx points to the node immediately following this subtree.

--- a/be/test/exec/plain_text_line_reader_bzip_test.cpp
+++ b/be/test/exec/plain_text_line_reader_bzip_test.cpp
@@ -27,7 +27,7 @@ namespace doris {
 
 class PlainTextLineReaderTest : public testing::Test {
 public:
-    PlainTextLineReaderTest() : _profile(&_obj_pool, "TestProfile") {
+    PlainTextLineReaderTest() : _profile("TestProfile") {
     }
 
 protected:
@@ -36,7 +36,6 @@ protected:
     virtual void TearDown() {
     }
 private:
-    ObjectPool _obj_pool;
     RuntimeProfile _profile;
 };
 

--- a/be/test/exec/plain_text_line_reader_gzip_test.cpp
+++ b/be/test/exec/plain_text_line_reader_gzip_test.cpp
@@ -27,7 +27,7 @@ namespace doris {
 
 class PlainTextLineReaderTest : public testing::Test {
 public:
-    PlainTextLineReaderTest() : _profile(&_obj_pool, "TestProfile") {
+    PlainTextLineReaderTest() : _profile("TestProfile") {
     }
 
 protected:
@@ -36,7 +36,6 @@ protected:
     virtual void TearDown() {
     }
 private:
-    ObjectPool _obj_pool;
     RuntimeProfile _profile;
 };
 

--- a/be/test/exec/plain_text_line_reader_lz4frame_test.cpp
+++ b/be/test/exec/plain_text_line_reader_lz4frame_test.cpp
@@ -27,7 +27,7 @@ namespace doris {
 
 class PlainTextLineReaderTest : public testing::Test {
 public:
-    PlainTextLineReaderTest() : _profile(&_obj_pool, "TestProfile") {
+    PlainTextLineReaderTest() : _profile("TestProfile") {
     }
 
 protected:
@@ -36,7 +36,6 @@ protected:
     virtual void TearDown() {
     }
 private:
-    ObjectPool _obj_pool;
     RuntimeProfile _profile;
 };
 

--- a/be/test/exec/plain_text_line_reader_lzop_test.cpp
+++ b/be/test/exec/plain_text_line_reader_lzop_test.cpp
@@ -27,7 +27,7 @@ namespace doris {
 
 class PlainTextLineReaderTest : public testing::Test {
 public:
-    PlainTextLineReaderTest() : _profile(&_obj_pool, "TestProfile") {
+    PlainTextLineReaderTest() : _profile("TestProfile") {
     }
 
 protected:
@@ -36,7 +36,6 @@ protected:
     virtual void TearDown() {
     }
 private:
-    ObjectPool _obj_pool;
     RuntimeProfile _profile;
 };
 

--- a/be/test/exec/plain_text_line_reader_uncompressed_test.cpp
+++ b/be/test/exec/plain_text_line_reader_uncompressed_test.cpp
@@ -27,7 +27,7 @@ namespace doris {
 
 class PlainTextLineReaderTest : public testing::Test {
 public:
-    PlainTextLineReaderTest() : _profile(&_obj_pool, "TestProfile") {
+    PlainTextLineReaderTest() : _profile("TestProfile") {
     }
 
 protected:
@@ -36,7 +36,6 @@ protected:
     virtual void TearDown() {
     }
 private:
-    ObjectPool _obj_pool;
     RuntimeProfile _profile;
 };
 

--- a/be/test/runtime/buffered_tuple_stream_test.cpp
+++ b/be/test/runtime/buffered_tuple_stream_test.cpp
@@ -45,7 +45,7 @@ public:
     RowBatch* create_row_batch(int num_rows);
     BufferedTupleStreamTest() {
         _object_pool = new ObjectPool();
-        _profile = new RuntimeProfile(_object_pool, "bufferedStream");
+        _profile = new RuntimeProfile("bufferedStream");
         _runtime_state = new RuntimeState("BufferedTupleStreamTest");
         _runtime_state->exec_env_ = &_exec_env;
         _runtime_state->create_block_mgr();

--- a/be/test/runtime/data_stream_test.cpp
+++ b/be/test/runtime/data_stream_test.cpp
@@ -377,7 +377,7 @@ protected:
     void start_receiver(TPartitionType::type stream_type, int num_senders, int receiver_num,
                         int buffer_size, bool is_merging, TUniqueId* out_id = NULL) {
         VLOG_QUERY << "start receiver";
-        RuntimeProfile* profile = _obj_pool.add(new RuntimeProfile(&_obj_pool, "TestReceiver"));
+        RuntimeProfile* profile = _obj_pool.add(new RuntimeProfile("TestReceiver"));
         TUniqueId instance_id;
         get_next_instance_id(&instance_id);
         _receiver_info.push_back(ReceiverInfo(stream_type, num_senders, receiver_num));

--- a/be/test/runtime/sorter_test.cpp
+++ b/be/test/runtime/sorter_test.cpp
@@ -144,9 +144,7 @@ public:
             row_tuples.push_back(1);
             _output_row_desc = new RowDescriptor(*_desc_tbl, row_tuples, nullable_tuples);
         }
-        _runtime_profile = new RuntimeProfile(get_object_pool(), "sorter");
-        
-
+        _runtime_profile = new RuntimeProfile("sorter");
     }
     virtual ~SorterTest() {
         delete _child_row_desc;
@@ -240,7 +238,6 @@ TEST_F(SorterTest, sorter_run_asc) {
           less_than, exec_exprs.sort_tuple_slot_expr_ctxs(),
           _child_row_desc,
           _runtime_profile, _runtime_state);
-          // new RuntimeProfile(get_object_pool(), "sorter"), _runtime_state);
 
     int num_rows = 5;
     RowBatch* batch = CreateRowBatch(num_rows);
@@ -290,7 +287,6 @@ TEST_F(SorterTest, sorter_run_desc_with_quick_sort) {
           less_than, exec_exprs.sort_tuple_slot_expr_ctxs(),
           _child_row_desc,
           _runtime_profile, _runtime_state);
-          // new RuntimeProfile(get_object_pool(), "sorter"), _runtime_state);
 
     int num_rows = 5;
     RowBatch* batch = CreateRowBatch(num_rows);
@@ -332,7 +328,6 @@ TEST_F(SorterTest, sorter_run_desc) {
           less_than, exec_exprs.sort_tuple_slot_expr_ctxs(),
           _child_row_desc,
           _runtime_profile, _runtime_state);
-          // new RuntimeProfile(get_object_pool(), "sorter"), _runtime_state);
 
     int num_rows = 5;
     RowBatch* batch = CreateRowBatch(num_rows);


### PR DESCRIPTION
Fix: #3871

Mainly change:
1. Fix the bug in `update_status(status)` of `PlanFragmentExecutor`.
2. When the FE Coordinator executes `execRemoteFragmentAsync()`, if it finds an RPC error, return a Future with an error code instead of exception.
3. Protect the `_status` in RuntimeState with lock
4. Move the `_runtime_profile` of RuntimeState before the `_obj_pool`, so that the profile will be
deconstructed after the object pool.
5. Remove the unused `ObjectPool` param in RuntimeProfile constructor. If I don't remove it,
RuntimeProfile will depends on the `_obj_pool` in RuntimeProfile.
