### PR TITLE
[BUG]Fix broker read buffer size from input stream

### DIFF
--- a/fs_brokers/apache_hdfs_broker/src/main/java/org/apache/doris/broker/hdfs/FileSystemManager.java
+++ b/fs_brokers/apache_hdfs_broker/src/main/java/org/apache/doris/broker/hdfs/FileSystemManager.java
@@ -550,19 +550,20 @@ public class FileSystemManager {
                             currentStreamOffset, offset);
                 }
             }
-            byte[] buf;
+            ByteBuffer buf;
             if (length > readBufferSize) {
-                buf = new byte[readBufferSize];
+                buf = ByteBuffer.allocate(readBufferSize);
             } else {
-                buf = new byte[(int) length];
+                buf = ByteBuffer.allocate((int) length);
             }
             try {
-                int readLength = fsDataInputStream.read(buf);
+                int readLength = readByteBufferFully(fsDataInputStream, buf);
                 if (readLength < 0) {
                     throw new BrokerException(TBrokerOperationStatusCode.END_OF_FILE,
                             "end of file reached");
                 }
-                return ByteBuffer.wrap(buf, 0, readLength);
+                logger.info("read length:" + length + ", readBufferSize:" + readBufferSize + ", return length:" + readLength);
+                return buf;
             } catch (IOException e) {
                 logger.error("errors while read data from stream", e);
                 throw new BrokerException(TBrokerOperationStatusCode.TARGET_STORAGE_SERVICE_ERROR,
@@ -654,6 +655,29 @@ public class FileSystemManager {
     
     private static TBrokerFD parseUUIDToFD(UUID uuid) {
         return new TBrokerFD(uuid.getMostSignificantBits(), uuid.getLeastSignificantBits());
+    }
+
+    private int readByteBuffer(FSDataInputStream is, ByteBuffer dest) throws IOException {
+        int pos = dest.position();
+        int result = is.read(dest);
+        if (result > 0) {
+            // Ensure this explicitly since versions before 2.7 read doesn't do it.
+            dest.position(pos + result);
+        }
+        return result;
+    }
+
+    private int readByteBufferFully(FSDataInputStream is, ByteBuffer dest) throws IOException {
+        int result = 0;
+        while (dest.remaining() > 0) {
+            int n = readByteBuffer(is, dest);
+            if (n <= 0) {
+                break;
+            }
+            result += n;
+        }
+        dest.flip();
+        return result;
     }
     
     class FileSystemExpirationChecker implements Runnable {

--- a/fs_brokers/apache_hdfs_broker/src/main/java/org/apache/doris/broker/hdfs/FileSystemManager.java
+++ b/fs_brokers/apache_hdfs_broker/src/main/java/org/apache/doris/broker/hdfs/FileSystemManager.java
@@ -562,7 +562,7 @@ public class FileSystemManager {
                     throw new BrokerException(TBrokerOperationStatusCode.END_OF_FILE,
                             "end of file reached");
                 }
-                logger.info("read length:" + length + ", readBufferSize:" + readBufferSize + ", return length:" + readLength);
+                logger.debug("read buffer from input stream, buffer size:" + buf.capacity() + ", read length:" + readLength);
                 return buf;
             } catch (IOException e) {
                 logger.error("errors while read data from stream", e);

--- a/fs_brokers/apache_hdfs_broker/src/main/java/org/apache/doris/broker/hdfs/FileSystemManager.java
+++ b/fs_brokers/apache_hdfs_broker/src/main/java/org/apache/doris/broker/hdfs/FileSystemManager.java
@@ -562,7 +562,9 @@ public class FileSystemManager {
                     throw new BrokerException(TBrokerOperationStatusCode.END_OF_FILE,
                             "end of file reached");
                 }
-                logger.debug("read buffer from input stream, buffer size:" + buf.capacity() + ", read length:" + readLength);
+				if (logger.isDebugEnable()) {
+                    logger.debug("read buffer from input stream, buffer size:" + buf.capacity() + ", read length:" + readLength);
+				}
                 return buf;
             } catch (IOException e) {
                 logger.error("errors while read data from stream", e);

--- a/fs_brokers/apache_hdfs_broker/src/main/java/org/apache/doris/broker/hdfs/FileSystemManager.java
+++ b/fs_brokers/apache_hdfs_broker/src/main/java/org/apache/doris/broker/hdfs/FileSystemManager.java
@@ -562,9 +562,9 @@ public class FileSystemManager {
                     throw new BrokerException(TBrokerOperationStatusCode.END_OF_FILE,
                             "end of file reached");
                 }
-				if (logger.isDebugEnable()) {
+                if (logger.isDebugEnable()) {
                     logger.debug("read buffer from input stream, buffer size:" + buf.capacity() + ", read length:" + readLength);
-				}
+                }
                 return buf;
             } catch (IOException e) {
                 logger.error("errors while read data from stream", e);


### PR DESCRIPTION
Fix #3879 
This commit fixs a bug that broker cannot read the full length of buffer size, when the buffer size is set larger than 128k.

This bug will cause the data size returned by pread request to be less than 128K all the time.
