### PR TITLE
[Planner] Set MysqlScanNode's cardinality to avoid unexpected shuffle join

### DIFF
--- a/fe/src/main/java/org/apache/doris/planner/DistributedPlanner.java
+++ b/fe/src/main/java/org/apache/doris/planner/DistributedPlanner.java
@@ -294,6 +294,11 @@ public class DistributedPlanner {
         // broadcast: send the rightChildFragment's output to each node executing
         // the leftChildFragment; the cost across all nodes is proportional to the
         // total amount of data sent
+
+        // NOTICE(cmy): for now, only MysqlScanNode and OlapScanNode has Cardinality. And MysqlScanNode's Cardinality
+        // is always 0. Other ScanNode's cardinality is -1, so they won't be able the calculate the cost of
+        // join normally and result in both "broadcastCost" and "partitionCost" be 0. And this will lead
+        // to a SHUFFLE join.
         PlanNode rhsTree = rightChildFragment.getPlanRoot();
         long rhsDataSize = 0;
         long broadcastCost = 0;

--- a/fe/src/main/java/org/apache/doris/planner/DistributedPlanner.java
+++ b/fe/src/main/java/org/apache/doris/planner/DistributedPlanner.java
@@ -295,8 +295,13 @@ public class DistributedPlanner {
         // the leftChildFragment; the cost across all nodes is proportional to the
         // total amount of data sent
 
-        // NOTICE(cmy): for now, only MysqlScanNode and OlapScanNode has Cardinality. And MysqlScanNode's Cardinality
-        // is always 0. Other ScanNode's cardinality is -1, so they won't be able to calculate the cost of
+        // NOTICE(cmy):
+        // for now, only MysqlScanNode and OlapScanNode has Cardinality.
+        // OlapScanNode's cardinality is calculated by row num and data size,
+        // and MysqlScanNode's cardinality is always 0.
+        // Other ScanNode's cardinality is -1.
+        //
+        // So if there are other kind of scan node in join query, it won't be able to calculate the cost of
         // join normally and result in both "broadcastCost" and "partitionCost" be 0. And this will lead
         // to a SHUFFLE join.
         PlanNode rhsTree = rightChildFragment.getPlanRoot();

--- a/fe/src/main/java/org/apache/doris/planner/DistributedPlanner.java
+++ b/fe/src/main/java/org/apache/doris/planner/DistributedPlanner.java
@@ -295,7 +295,7 @@ public class DistributedPlanner {
         // the leftChildFragment; the cost across all nodes is proportional to the
         // total amount of data sent
 
-        // NOTICE(cmy):
+        // NOTICE:
         // for now, only MysqlScanNode and OlapScanNode has Cardinality.
         // OlapScanNode's cardinality is calculated by row num and data size,
         // and MysqlScanNode's cardinality is always 0.

--- a/fe/src/main/java/org/apache/doris/planner/DistributedPlanner.java
+++ b/fe/src/main/java/org/apache/doris/planner/DistributedPlanner.java
@@ -296,7 +296,7 @@ public class DistributedPlanner {
         // total amount of data sent
 
         // NOTICE(cmy): for now, only MysqlScanNode and OlapScanNode has Cardinality. And MysqlScanNode's Cardinality
-        // is always 0. Other ScanNode's cardinality is -1, so they won't be able the calculate the cost of
+        // is always 0. Other ScanNode's cardinality is -1, so they won't be able to calculate the cost of
         // join normally and result in both "broadcastCost" and "partitionCost" be 0. And this will lead
         // to a SHUFFLE join.
         PlanNode rhsTree = rightChildFragment.getPlanRoot();

--- a/fe/src/main/java/org/apache/doris/planner/MysqlScanNode.java
+++ b/fe/src/main/java/org/apache/doris/planner/MysqlScanNode.java
@@ -71,6 +71,7 @@ public class MysqlScanNode extends ScanNode {
         // Convert predicates to MySQL columns and filters.
         createMySQLColumns(analyzer);
         createMySQLFilters(analyzer);
+        computeStats(analyzer);
     }
 
     @Override
@@ -149,4 +150,14 @@ public class MysqlScanNode extends ScanNode {
         return 1;
     }
 
+    @Override
+    public void computeStats(Analyzer analyzer) {
+        super.computeStats(analyzer);
+        // even current node scan has no data,at least on backend will be assigned when the fragment actually execute
+        numNodes = numNodes <= 0 ? 1 : numNodes;
+        // this is just to avoid mysql scan node's cardinality being -1. So that we can calculate the join cost
+        // normally.
+        // We assume that the data volume of all mysql tables is very small, so set cardinality directly to 0.
+        cardinality = cardinality == -1 ? 0 : cardinality;
+    }
 }

--- a/fe/src/main/java/org/apache/doris/planner/MysqlScanNode.java
+++ b/fe/src/main/java/org/apache/doris/planner/MysqlScanNode.java
@@ -153,7 +153,7 @@ public class MysqlScanNode extends ScanNode {
     @Override
     public void computeStats(Analyzer analyzer) {
         super.computeStats(analyzer);
-        // even current node scan has no data,at least on backend will be assigned when the fragment actually execute
+        // even if current node scan has no data,at least on backend will be assigned when the fragment actually execute
         numNodes = numNodes <= 0 ? 1 : numNodes;
         // this is just to avoid mysql scan node's cardinality being -1. So that we can calculate the join cost
         // normally.

--- a/fe/src/test/java/org/apache/doris/planner/QueryPlanTest.java
+++ b/fe/src/test/java/org/apache/doris/planner/QueryPlanTest.java
@@ -17,7 +17,6 @@
 
 package org.apache.doris.planner;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.doris.analysis.CreateDbStmt;
 import org.apache.doris.analysis.CreateTableStmt;
 import org.apache.doris.analysis.DropDbStmt;
@@ -27,13 +26,21 @@ import org.apache.doris.analysis.SelectStmt;
 import org.apache.doris.analysis.ShowCreateDbStmt;
 import org.apache.doris.analysis.StatementBase;
 import org.apache.doris.catalog.Catalog;
-import org.apache.doris.common.FeConstants;
+import org.apache.doris.catalog.Database;
+import org.apache.doris.catalog.MaterializedIndex;
+import org.apache.doris.catalog.MaterializedIndex.IndexExtState;
+import org.apache.doris.catalog.OlapTable;
+import org.apache.doris.catalog.Partition;
+import org.apache.doris.catalog.Replica;
+import org.apache.doris.catalog.Tablet;
 import org.apache.doris.catalog.Type;
+import org.apache.doris.common.FeConstants;
 import org.apache.doris.load.EtlJobType;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.QueryState.MysqlStateType;
 import org.apache.doris.utframe.UtFrameUtils;
 
+import org.apache.commons.lang3.StringUtils;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -269,6 +276,22 @@ public class QueryPlanTest {
                 "\"replication_num\" = \"1\",\n" +
                 "\"in_memory\" = \"false\",\n" +
                 "\"storage_format\" = \"DEFAULT\"\n" +
+                ");");
+
+        createTable("create table test.jointest\n" +
+                "(k1 int, k2 int) distributed by hash(k1) buckets 1\n" +
+                "properties(\"replication_num\" = \"1\");");
+
+        createTable("create external table test.mysql_table\n" +
+                "(k1 int, k2 int)\n" +
+                "ENGINE=MYSQL\n" +
+                "PROPERTIES (\n" +
+                "\"host\" = \"127.0.0.1\",\n" +
+                "\"port\" = \"3306\",\n" +
+                "\"user\" = \"root\",\n" +
+                "\"password\" = \"123\",\n" +
+                "\"database\" = \"db1\",\n" +
+                "\"table\" = \"tbl1\"\n" +
                 ");");
     }
 
@@ -838,7 +861,7 @@ public class QueryPlanTest {
 
     @Test
     public void testOrCompoundPredicateFold() throws Exception {
-        String queryStr = "explain select * from  baseall where (k1 > 1) or (k1 > 1 and k2 < 1)";
+        String queryStr = "explain select * from baseall where (k1 > 1) or (k1 > 1 and k2 < 1)";
         String explainString = UtFrameUtils.getSQLPlanOrErrorMsg(connectContext, queryStr);
         Assert.assertTrue(explainString.contains("PREDICATES: (`k1` > 1)\n"));
 
@@ -849,5 +872,35 @@ public class QueryPlanTest {
         queryStr = "explain select * from  baseall where (k1 > 1) or (k1 > 1)";
         explainString = UtFrameUtils.getSQLPlanOrErrorMsg(connectContext, queryStr);
         Assert.assertTrue(explainString.contains("PREDICATES: (`k1` > 1)\n"));
+    }
+
+    @Test
+    public void testJoinWithMysqlTable() throws Exception {
+        connectContext.setDatabase("default_cluster:test");
+
+        // set data size and row count for the olap table
+        Database db = Catalog.getCurrentCatalog().getDb("default_cluster:test");
+        OlapTable tbl = (OlapTable) db.getTable("jointest");
+        for (Partition partition : tbl.getPartitions()) {
+            partition.updateVisibleVersionAndVersionHash(2, 0);
+            for (MaterializedIndex mIndex : partition.getMaterializedIndices(IndexExtState.VISIBLE)) {
+                mIndex.setRowCount(10000);
+                for (Tablet tablet : mIndex.getTablets()) {
+                    for (Replica replica : tablet.getReplicas()) {
+                        replica.updateVersionInfo(2, 0, 200000, 10000);
+                    }
+                }
+            }
+        }
+
+        String queryStr = "explain select * from mysql_table t2, jointest t1 where t1.k1 = t2.k1";
+        String explainString = UtFrameUtils.getSQLPlanOrErrorMsg(connectContext, queryStr);
+        Assert.assertTrue(explainString.contains("INNER JOIN (BROADCAST)"));
+        Assert.assertTrue(explainString.contains("1:SCAN MYSQL"));
+
+        queryStr = "explain select * from jointest t1, mysql_table t2 where t1.k1 = t2.k1";
+        explainString = UtFrameUtils.getSQLPlanOrErrorMsg(connectContext, queryStr);
+        Assert.assertTrue(explainString.contains("INNER JOIN (BROADCAST)"));
+        Assert.assertTrue(explainString.contains("1:SCAN MYSQL"));
     }
 }


### PR DESCRIPTION
Fix #3885

1. Set MysqlScanNode's cardinality to 0