### PR TITLE
[Bug][RoutineLoad] Fix bug that exception thrown when txn of a routineload task become visible

### DIFF
--- a/fe/src/main/java/org/apache/doris/load/routineload/RoutineLoadJob.java
+++ b/fe/src/main/java/org/apache/doris/load/routineload/RoutineLoadJob.java
@@ -924,8 +924,9 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback impl
             errorLogUrls.add(rlTaskTxnCommitAttachment.getErrorLogUrl());
         }
 
+        routineLoadTaskInfo.setTxnStatus(txnStatus);
+
         if (state == JobState.RUNNING) {
-            routineLoadTaskInfo.setTxnStatus(txnStatus);
             if (txnStatus == TransactionStatus.ABORTED) {
                 RoutineLoadTaskInfo newRoutineLoadTaskInfo = unprotectRenewTask(routineLoadTaskInfo);
                 Catalog.getCurrentCatalog().getRoutineLoadTaskScheduler().addTaskInQueue(newRoutineLoadTaskInfo);

--- a/fe/src/main/java/org/apache/doris/load/routineload/RoutineLoadJob.java
+++ b/fe/src/main/java/org/apache/doris/load/routineload/RoutineLoadJob.java
@@ -978,13 +978,12 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback impl
     }
 
     protected void unprotectUpdateState(JobState jobState, ErrorReason reason, boolean isReplay) throws UserException {
-        if (LOG.isDebugEnabled()) {
-            LOG.debug(new LogBuilder(LogKey.ROUTINE_LOAD_JOB, id)
-                              .add("current_job_state", getState())
-                              .add("desire_job_state", jobState)
-                              .add("msg", reason)
-                              .build());
-        }
+        LOG.info(new LogBuilder(LogKey.ROUTINE_LOAD_JOB, id)
+                .add("current_job_state", getState())
+                .add("desire_job_state", jobState)
+                .add("msg", reason)
+                .build());
+      
         checkStateTransform(jobState);
         switch (jobState) {
             case RUNNING:

--- a/fe/src/main/java/org/apache/doris/load/routineload/RoutineLoadTaskInfo.java
+++ b/fe/src/main/java/org/apache/doris/load/routineload/RoutineLoadTaskInfo.java
@@ -30,9 +30,9 @@ import org.apache.doris.service.FrontendOptions;
 import org.apache.doris.thrift.TRoutineLoadTask;
 import org.apache.doris.transaction.BeginTransactionException;
 import org.apache.doris.transaction.TransactionState;
-import org.apache.doris.transaction.TransactionStatus;
-import org.apache.doris.transaction.TransactionState.TxnSourceType;
 import org.apache.doris.transaction.TransactionState.TxnCoordinator;
+import org.apache.doris.transaction.TransactionState.TxnSourceType;
+import org.apache.doris.transaction.TransactionStatus;
 
 import com.google.common.collect.Lists;
 
@@ -150,7 +150,7 @@ public abstract class RoutineLoadTaskInfo {
         }
 
         if (isRunning() && System.currentTimeMillis() - executeStartTimeMs > timeoutMs) {
-            LOG.debug("task {} is timeout. start: {}, timeout: {}", DebugUtil.printId(id),
+            LOG.info("task {} is timeout. start: {}, timeout: {}", DebugUtil.printId(id),
                     executeStartTimeMs, timeoutMs);
             return true;
         }


### PR DESCRIPTION
Fix #3889 

Set the transaction status in routine load task info, even if routine load is not running.