### PR TITLE
[Enhancement] Make report version unchanged for publish task

### DIFF
--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -727,7 +727,6 @@ void* TaskWorkerPool::_publish_version_worker_thread_callback(void* arg_this) {
             st = Status::RuntimeError(strings::Substitute("publish version failed. error=$0", res));
             finish_task_request.__set_error_tablet_ids(error_tablet_ids);
         } else {
-            _s_report_version++;
             LOG(INFO) << "publish_version success. signature:" << agent_task_req.signature;
         }
 

--- a/fe/src/main/java/org/apache/doris/master/ReportHandler.java
+++ b/fe/src/main/java/org/apache/doris/master/ReportHandler.java
@@ -761,8 +761,7 @@ public class ReportHandler extends Daemon {
         }
 
         // print a warn log here to indicate the exceptions on the backend
-        LOG.warn("find {} tablets with report version less than version in meta, or is set bad, on backend {}"
-                + ", they need clone or force recovery",
+        LOG.warn("find {} tablets on backend {} which is bad or misses versions that need clone or force recovery",
                 tabletRecoveryMap.size(), backendId);
 
         TabletInvertedIndex invertedIndex = Catalog.getCurrentInvertedIndex();


### PR DESCRIPTION
Fixes #3893 

In a cluster with frequent load activities, FE will ignore most tablet report from BE  because currently it only handle reports whose version >= BE's latest report version (which is increased each time a transaction is published). This can be observed from FE's log, with many 
 logs like `out of date report version 15919277405765 from backend[177969252]. current report version[15919277405766]` in it.

However many system functionalities rely on TabletReport processing to work properly. For example
1. bad or version miss replica is detected and repaired during TabletReport
2. storage medium migration decision and action is made based on TabletReport
3. BE's old transaction is cleared/republished during TabletReport

In fact, it is not necessary to update the report version after the publish task. Because this is actually a problem left over by history. In the reporting logic of the current version, we will no longer decrease the version information of the replica in the FE metadata according to the report. So even if we receive a stale version of the report, it does not matter.

This CL contains mainly two changes

1. do not increase report version for publish task
2. populate `tabletWithoutPartitionId` out of read lock of TabletInvertedIndex