### PR TITLE
[Doris On ES] Support fetch  `_id` field from ES 

### DIFF
--- a/be/src/exec/es/es_scan_reader.cpp
+++ b/be/src/exec/es/es_scan_reader.cpp
@@ -28,7 +28,9 @@
 
 namespace doris {
 
-const std::string SOURCE_SCROLL_SEARCH_FILTER_PATH = "filter_path=_scroll_id,hits.hits._source,hits.total,_id";
+// hits.hits._id used for obtain ES document `_id`
+const std::string SOURCE_SCROLL_SEARCH_FILTER_PATH = "filter_path=_scroll_id,hits.hits._source,hits.total,hits.hits._id";
+// hits.hits._score used for processing field not exists in one batch
 const std::string DOCVALUE_SCROLL_SEARCH_FILTER_PATH = "filter_path=_scroll_id,hits.total,hits.hits._score,hits.hits.fields";
 
 const std::string REQUEST_SCROLL_PATH = "_scroll";

--- a/fe/src/main/java/org/apache/doris/common/FeNameFormat.java
+++ b/fe/src/main/java/org/apache/doris/common/FeNameFormat.java
@@ -26,6 +26,7 @@ import com.google.common.base.Strings;
 public class FeNameFormat {
     private static final String LABEL_REGEX = "^[-_A-Za-z0-9]{1,128}$";
     private static final String COMMON_NAME_REGEX = "^[a-zA-Z][a-zA-Z0-9_]{0,63}$";
+    private static final String COLUMN_NAME_REGEX = "^[_a-zA-Z][a-zA-Z0-9_]{0,63}$";
 
     public static final String FORBIDDEN_PARTITION_NAME = "placeholder_";
 
@@ -61,7 +62,7 @@ public class FeNameFormat {
     }
 
     public static void checkColumnName(String columnName) throws AnalysisException {
-        if (Strings.isNullOrEmpty(columnName) || !columnName.matches(COMMON_NAME_REGEX)) {
+        if (Strings.isNullOrEmpty(columnName) || !columnName.matches(COLUMN_NAME_REGEX)) {
             ErrorReport.reportAnalysisException(ErrorCode.ERR_WRONG_COLUMN_NAME, columnName);
         }
         if (columnName.startsWith(SchemaChangeHandler.SHADOW_NAME_PRFIX)) {

--- a/fe/src/test/java/org/apache/doris/common/ExceptionChecker.java
+++ b/fe/src/test/java/org/apache/doris/common/ExceptionChecker.java
@@ -1,0 +1,56 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.common;
+
+import org.apache.doris.http.DorisHttpTestCase;
+import junit.framework.AssertionFailedError;
+
+public class ExceptionChecker {
+
+    public static void expectThrowsNoException(DorisHttpTestCase.ThrowingRunnable runnable) {
+        try {
+            runnable.run();
+        } catch (Throwable e) {
+            throw new AssertionFailedError(e.getMessage());
+        }
+    }
+
+    /**
+     * Checks a specific exception class is thrown by the given runnable, and returns it.
+     */
+    public static <T extends Throwable> T expectThrows(Class<T> expectedType, DorisHttpTestCase.ThrowingRunnable runnable) {
+        return expectThrows(expectedType, "Expected exception " + expectedType.getSimpleName() + " but no exception was thrown", runnable);
+    }
+
+    /**
+     * Checks a specific exception class is thrown by the given runnable, and returns it.
+     */
+    public static <T extends Throwable> T expectThrows(Class<T> expectedType, String noExceptionMessage, DorisHttpTestCase.ThrowingRunnable runnable) {
+        try {
+            runnable.run();
+        } catch (Throwable e) {
+            if (expectedType.isInstance(e)) {
+                return expectedType.cast(e);
+            }
+            AssertionFailedError assertion = new AssertionFailedError("Unexpected exception type, expected " + expectedType.getSimpleName() + " but got " + e);
+            assertion.initCause(e);
+            throw assertion;
+        }
+        throw new AssertionFailedError(noExceptionMessage);
+    }
+}

--- a/fe/src/test/java/org/apache/doris/common/FeNameFormatTest.java
+++ b/fe/src/test/java/org/apache/doris/common/FeNameFormatTest.java
@@ -1,0 +1,34 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.common;
+
+import org.junit.Test;
+
+public class FeNameFormatTest {
+
+    @Test
+    public void testCheckColumnName() {
+        ExceptionChecker.expectThrowsNoException(() -> FeNameFormat.checkColumnName("_id"));
+        ExceptionChecker.expectThrowsNoException(() -> FeNameFormat.checkColumnName("__id"));
+        ExceptionChecker.expectThrowsNoException(() -> FeNameFormat.checkColumnName("___id"));
+        ExceptionChecker.expectThrowsNoException(() -> FeNameFormat.checkColumnName("___id_"));
+        ExceptionChecker.expectThrows(AnalysisException.class, () -> FeNameFormat.checkColumnName("?id_"));
+        ExceptionChecker.expectThrows(AnalysisException.class, () -> FeNameFormat.checkColumnName("#id_"));
+    }
+
+}


### PR DESCRIPTION
More information can be found: https://github.com/apache/incubator-doris/issues/3901

The created ES external Table must contains `_id` column if you want to fetch the Elasticsearch document `_id`.
```
CREATE EXTERNAL TABLE `doe_id2` (
  `_id` varchar COMMENT "",
   `city`  varchar COMMENT ""
) ENGINE=ELASTICSEARCH
PROPERTIES (
"hosts" = "http://127.0.0.1:8200",
"user" = "root",
"password" = "root",
"index" = "doe",
"type" = "doc",
"version" = "6.5.3",
"enable_docvalue_scan" = "true",
"transport" = "http"
);

Query:

```
mysql> select * from doe_id2 limit 10;
+----------------------+------+
| _id                  | city |
+----------------------+------+
| iRHNc3IB8XwmcbhB7lEB | gz   |
| jBHNc3IB8XwmcbhB71Ef | gz   |
| jRHNc3IB8XwmcbhB71GI | gz   |
| jhHNc3IB8XwmcbhB71Hx | gz   |
| ThHNc3IB8XwmcbhBkFHB | sh   |
| TxHNc3IB8XwmcbhBkFH9 | sh   |
| URHNc3IB8XwmcbhBklFA | sh   |
| ahHNc3IB8XwmcbhBxlFq | gz   |
| axHNc3IB8XwmcbhBxlHw | gz   |
| bxHNc3IB8XwmcbhByVFO | gz   |
+----------------------+------+
```

NOTICE:
This change the column name format to support column name start with "_".