### PR TITLE
Support max_stream_load_timeout_second config in fe

### DIFF
--- a/docs/en/administrator-guide/config/fe_config.md
+++ b/docs/en/administrator-guide/config/fe_config.md
@@ -415,7 +415,7 @@ Generally it is not recommended to increase this configuration value. An excessi
 
 ### `max_stream_load_timeout_second`
 
-This configuration is specifically used to limit timeout setting for stream load. It is to prevent that failed stream load transactions to be aborted after a long time because of the user's large timeout setting. 
+This configuration is specifically used to limit timeout setting for stream load. It is to prevent that failed stream load transactions cannot be canceled within a short time because of the user's large timeout setting. 
 
 ### `max_tolerable_backend_down_num`
 

--- a/docs/en/administrator-guide/config/fe_config.md
+++ b/docs/en/administrator-guide/config/fe_config.md
@@ -413,6 +413,10 @@ Generally it is not recommended to increase this configuration value. An excessi
 
 ### `max_small_file_size_bytes`
 
+### `max_stream_load_timeout_second`
+
+This configuration is specifically used to limit timeout setting for stream load. It is to prevent that failed stream load transactions to be canceled after a long time because of the user's large timeout setting. 
+
 ### `max_tolerable_backend_down_num`
 
 ### `max_unfinished_load_job`

--- a/docs/en/administrator-guide/config/fe_config.md
+++ b/docs/en/administrator-guide/config/fe_config.md
@@ -415,7 +415,7 @@ Generally it is not recommended to increase this configuration value. An excessi
 
 ### `max_stream_load_timeout_second`
 
-This configuration is specifically used to limit timeout setting for stream load. It is to prevent that failed stream load transactions to be canceled after a long time because of the user's large timeout setting. 
+This configuration is specifically used to limit timeout setting for stream load. It is to prevent that failed stream load transactions to be aborted after a long time because of the user's large timeout setting. 
 
 ### `max_tolerable_backend_down_num`
 

--- a/docs/zh-CN/administrator-guide/config/fe_config.md
+++ b/docs/zh-CN/administrator-guide/config/fe_config.md
@@ -411,6 +411,10 @@ current running txns on db xxx is xx, larger than limit xx
 
 ### `max_small_file_size_bytes`
 
+### `max_stream_load_timeout_second`
+
+该配置是专门用来限制stream load的超时时间配置，防止失败的stream load事务因为用户的超长时间设置需要很长时间才能被取消掉。
+
 ### `max_tolerable_backend_down_num`
 
 ### `max_unfinished_load_job`

--- a/docs/zh-CN/administrator-guide/config/fe_config.md
+++ b/docs/zh-CN/administrator-guide/config/fe_config.md
@@ -413,7 +413,7 @@ current running txns on db xxx is xx, larger than limit xx
 
 ### `max_stream_load_timeout_second`
 
-该配置是专门用来限制stream load的超时时间配置，防止失败的stream load事务因为用户的超长时间设置需要很长时间才能被取消掉。
+该配置是专门用来限制stream load的超时时间配置，防止失败的stream load事务因为用户的超长时间设置无法在短时间内被取消掉。
 
 ### `max_tolerable_backend_down_num`
 

--- a/fe/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/src/main/java/org/apache/doris/common/Config.java
@@ -474,10 +474,16 @@ public class Config extends ConfigBase {
     public static int stream_load_default_timeout_second = 600; // 600s
 
     /*
-     * Max load timeout applicable to all type of load
+     * Max load timeout applicable to all type of load except for stream load
      */
     @ConfField(mutable = true, masterOnly = true)
     public static int max_load_timeout_second = 259200; // 3days
+
+    /*
+     * Max stream load and streaming mini load timeout
+     */
+    @ConfField(mutable = true, masterOnly = true)
+    public static int max_stream_load_timeout_second = 600; // 600s
 
     /*
     * Min stream load timeout applicable to all type of load

--- a/fe/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/src/main/java/org/apache/doris/common/Config.java
@@ -483,7 +483,7 @@ public class Config extends ConfigBase {
      * Max stream load and streaming mini load timeout
      */
     @ConfField(mutable = true, masterOnly = true)
-    public static int max_stream_load_timeout_second = 600; // 600s
+    public static int max_stream_load_timeout_second = 259200; // 3days
 
     /*
     * Min stream load timeout applicable to all type of load


### PR DESCRIPTION
This configuration is specifically used to limit timeout setting for stream load. It is to prevent that failed stream load transactions cannot be canceled within a short time because of the user's large timeout setting.