### PR TITLE
[Bug] Make compaction metrics value is right

### DIFF
--- a/be/src/olap/base_compaction.cpp
+++ b/be/src/olap/base_compaction.cpp
@@ -51,13 +51,14 @@ OLAPStatus BaseCompaction::compact() {
     // 3. set state to success
     _state = CompactionState::SUCCESS;
 
-    // 4. garbage collect input rowsets after base compaction 
-    RETURN_NOT_OK(gc_unused_rowsets());
-    TRACE("unused rowsets have been moved to GC queue");
-
-    // 5. add metric to base compaction
+    // 4. add metric to base compaction
     DorisMetrics::instance()->base_compaction_deltas_total.increment(_input_rowsets.size());
     DorisMetrics::instance()->base_compaction_bytes_total.increment(_input_rowsets_size);
+    TRACE("save base compaction metrics");
+
+    // 5. garbage collect input rowsets after base compaction 
+    RETURN_NOT_OK(gc_unused_rowsets());
+    TRACE("unused rowsets have been moved to GC queue");
 
     return OLAP_SUCCESS;
 }

--- a/be/src/olap/cumulative_compaction.cpp
+++ b/be/src/olap/cumulative_compaction.cpp
@@ -60,13 +60,14 @@ OLAPStatus CumulativeCompaction::compact() {
     // 5. set cumulative point
     _tablet->set_cumulative_layer_point(_input_rowsets.back()->end_version() + 1);
     
-    // 6. garbage collect input rowsets after cumulative compaction 
-    RETURN_NOT_OK(gc_unused_rowsets());
-    TRACE("unused rowsets have been moved to GC queue");
-
-    // 7. add metric to cumulative compaction
+    // 6. add metric to cumulative compaction
     DorisMetrics::instance()->cumulative_compaction_deltas_total.increment(_input_rowsets.size());
     DorisMetrics::instance()->cumulative_compaction_bytes_total.increment(_input_rowsets_size);
+    TRACE("save cumulative compaction metrics");
+
+    // 7. garbage collect input rowsets after cumulative compaction 
+    RETURN_NOT_OK(gc_unused_rowsets());
+    TRACE("unused rowsets have been moved to GC queue");
 
     return OLAP_SUCCESS;
 }


### PR DESCRIPTION
Now _input_rowsets will be cleared when calling gc_used_rowsets().
After that, the metrics is not right upon be calculated.