### PR TITLE
[Bug] Unify the timezone

### DIFF
--- a/fe/src/main/java/org/apache/doris/catalog/DynamicPartitionProperty.java
+++ b/fe/src/main/java/org/apache/doris/catalog/DynamicPartitionProperty.java
@@ -48,7 +48,7 @@ public class DynamicPartitionProperty {
     private int buckets;
     private StartOfDate startOfWeek;
     private StartOfDate startOfMonth;
-    private TimeZone tz = TimeUtils.getDefaultTimeZone();
+    private TimeZone tz = TimeUtils.getSystemTimeZone();
 
     public DynamicPartitionProperty(Map<String, String> properties) {
         if (properties != null && !properties.isEmpty()) {

--- a/fe/src/main/java/org/apache/doris/common/util/DynamicPartitionUtil.java
+++ b/fe/src/main/java/org/apache/doris/common/util/DynamicPartitionUtil.java
@@ -47,7 +47,6 @@ import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.time.DayOfWeek;
 import java.time.Month;
-import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Calendar;
@@ -207,7 +206,7 @@ public class DynamicPartitionUtil {
                 throw new DdlException("Must assign dynamic_partition.buckets properties");
             }
             if (Strings.isNullOrEmpty(timeZone)) {
-                properties.put(DynamicPartitionProperty.TIME_ZONE, ZoneId.systemDefault().toString());
+                properties.put(DynamicPartitionProperty.TIME_ZONE, TimeUtils.getSystemTimeZone().getID());
             }
         }
         return true;

--- a/fe/src/main/java/org/apache/doris/common/util/TimeUtils.java
+++ b/fe/src/main/java/org/apache/doris/common/util/TimeUtils.java
@@ -54,7 +54,8 @@ public class TimeUtils {
     private static final TimeZone TIME_ZONE;
 
     // set CST to +08:00 instead of America/Chicago
-    public static final ImmutableMap<String, String> timeZoneAliasMap = ImmutableMap.of("CST", DEFAULT_TIME_ZONE);
+    public static final ImmutableMap<String, String> timeZoneAliasMap = ImmutableMap.of(
+            "CST", DEFAULT_TIME_ZONE, "PRC", DEFAULT_TIME_ZONE);
 
     // NOTICE: Date formats are not synchronized.
     // it must be used as synchronized externally.

--- a/fe/src/main/java/org/apache/doris/common/util/TimeUtils.java
+++ b/fe/src/main/java/org/apache/doris/common/util/TimeUtils.java
@@ -27,10 +27,10 @@ import org.apache.doris.common.FeConstants;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.VariableMgr;
 
-import com.google.common.base.Preconditions;
+import com.google.common.base.Preconditions; 
 import com.google.common.collect.ImmutableMap;
 
-import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.LogManager; 
 import org.apache.logging.log4j.Logger;
 
 import java.text.ParseException;
@@ -126,17 +126,19 @@ public class TimeUtils {
         return TimeZone.getTimeZone(ZoneId.of(timezone, timeZoneAliasMap));
     }
 
-    public static TimeZone getDefaultTimeZone() {
-        return TimeZone.getTimeZone(ZoneId.of(DEFAULT_TIME_ZONE, timeZoneAliasMap));
+    // return the time zone of current system
+    public static TimeZone getSystemTimeZone() {
+        return TimeZone.getTimeZone(ZoneId.of(ZoneId.systemDefault().getId(), timeZoneAliasMap));
     }
 
+    // get time zone of given zone name, or return system time zone if name is null.
     public static TimeZone getOrSystemTimeZone(String timeZone) {
         if (timeZone == null) {
-            timeZone = ZoneId.systemDefault().toString();
+            return getSystemTimeZone();
         }
-        return TimeZone.getTimeZone(timeZone);
+        return TimeZone.getTimeZone(ZoneId.of(timeZone, timeZoneAliasMap));
     }
-
+    
     public static String longToTimeString(long timeStamp, SimpleDateFormat dateFormat) {
         if (timeStamp <= 0L) {
             return FeConstants.null_string;

--- a/fe/src/main/java/org/apache/doris/qe/GlobalVariable.java
+++ b/fe/src/main/java/org/apache/doris/qe/GlobalVariable.java
@@ -18,8 +18,7 @@
 package org.apache.doris.qe;
 
 import org.apache.doris.common.Version;
-
-import java.time.ZoneId;
+import org.apache.doris.common.util.TimeUtils;
 
 // You can place your global variable in this class with public and VariableMgr.VarAttr annotation.
 // You can get this variable from MySQL client with statement `SELECT @@variable_name`,
@@ -50,7 +49,7 @@ public final class GlobalVariable {
 
     // A string to be executed by the server for each client that connects
     @VariableMgr.VarAttr(name = "system_time_zone", flag = VariableMgr.READ_ONLY)
-    public static String systemTimeZone = ZoneId.systemDefault().normalized().toString();
+    public static String systemTimeZone = TimeUtils.getSystemTimeZone().getID();
 
     // The amount of memory allocated for caching query results
     @VariableMgr.VarAttr(name = "query_cache_size")

--- a/fe/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -21,6 +21,7 @@ import org.apache.doris.catalog.Catalog;
 import org.apache.doris.common.FeMetaVersion;
 import org.apache.doris.common.io.Text;
 import org.apache.doris.common.io.Writable;
+import org.apache.doris.common.util.TimeUtils;
 import org.apache.doris.qe.VariableMgr.VarAttr;
 import org.apache.doris.thrift.TQueryOptions;
 
@@ -183,7 +184,7 @@ public class SessionVariable implements Serializable, Writable {
 
     // The current time zone
     @VariableMgr.VarAttr(name = TIME_ZONE)
-    private String timeZone = "CST";
+    private String timeZone = TimeUtils.getSystemTimeZone().getID();
 
     @VariableMgr.VarAttr(name = PARALLEL_EXCHANGE_INSTANCE_NUM)
     private int exchangeInstanceParallel = -1;

--- a/fe/src/test/java/org/apache/doris/common/util/DynamicPartitionUtilTest.java
+++ b/fe/src/test/java/org/apache/doris/common/util/DynamicPartitionUtilTest.java
@@ -24,19 +24,12 @@ import com.google.common.collect.Maps;
 import org.junit.Assert;
 import org.junit.Test;
 
-import java.sql.Time;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
 import java.time.DateTimeException;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
-import java.time.temporal.TemporalAccessor;
-import java.util.Calendar;
-import java.util.Date;
 import java.util.Map;
+import java.util.TimeZone;
 
 public class DynamicPartitionUtilTest {
 
@@ -63,7 +56,12 @@ public class DynamicPartitionUtilTest {
 
     private static ZonedDateTime getZonedDateTimeFromStr(String dateStr) throws DateTimeException {
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern(FORMAT);
-        return LocalDate.parse(dateStr, formatter).atStartOfDay(ZoneId.systemDefault());
+        return LocalDate.parse(dateStr, formatter).atStartOfDay(
+                TimeUtils.getOrSystemTimeZone(TimeUtils.DEFAULT_TIME_ZONE).toZoneId());
+    }
+
+    private static TimeZone getCTSTimeZone() {
+        return TimeUtils.getOrSystemTimeZone(TimeUtils.DEFAULT_TIME_ZONE);
     }
 
     @Test
@@ -75,25 +73,25 @@ public class DynamicPartitionUtilTest {
         String res = DynamicPartitionUtil.getPartitionRangeString(property, getZonedDateTimeFromStr("2020-05-25"), -7,
                 FORMAT);
         Assert.assertEquals("2020-05-18", res);
-        String partName = DynamicPartitionUtil.getFormattedPartitionName(TimeUtils.getDefaultTimeZone(), res, "DAY");
+        String partName = DynamicPartitionUtil.getFormattedPartitionName(getCTSTimeZone(), res, "DAY");
         Assert.assertEquals("20200518", partName);
         // 2. 2020-05-25, offset 0
         res = DynamicPartitionUtil.getPartitionRangeString(property, getZonedDateTimeFromStr("2020-05-25"), 0,
                 FORMAT);
         Assert.assertEquals("2020-05-25", res);
-        partName = DynamicPartitionUtil.getFormattedPartitionName(TimeUtils.getDefaultTimeZone(), res, "DAY");
+        partName = DynamicPartitionUtil.getFormattedPartitionName(getCTSTimeZone(), res, "DAY");
         Assert.assertEquals("20200525", partName);
         // 3. 2020-05-25, offset 7
         res = DynamicPartitionUtil.getPartitionRangeString(property, getZonedDateTimeFromStr("2020-05-25"), 7,
                 FORMAT);
         Assert.assertEquals("2020-06-01", res);
-        partName = DynamicPartitionUtil.getFormattedPartitionName(TimeUtils.getDefaultTimeZone(), res, "DAY");
+        partName = DynamicPartitionUtil.getFormattedPartitionName(getCTSTimeZone(), res, "DAY");
         Assert.assertEquals("20200601", partName);
         // 4. 2020-02-28, offset 3
         res = DynamicPartitionUtil.getPartitionRangeString(property, getZonedDateTimeFromStr("2020-02-28"), 3,
                 FORMAT);
         Assert.assertEquals("2020-03-02", res);
-        partName = DynamicPartitionUtil.getFormattedPartitionName(TimeUtils.getDefaultTimeZone(), res, "DAY");
+        partName = DynamicPartitionUtil.getFormattedPartitionName(getCTSTimeZone(), res, "DAY");
         Assert.assertEquals("20200302", partName);
 
         // TimeUnit: WEEK
@@ -102,7 +100,7 @@ public class DynamicPartitionUtilTest {
         res = DynamicPartitionUtil.getPartitionRangeString(property, getZonedDateTimeFromStr("2020-05-25"), 0,
                 FORMAT);
         Assert.assertEquals("2020-05-25", res);
-        partName = DynamicPartitionUtil.getFormattedPartitionName(TimeUtils.getDefaultTimeZone(), res, "WEEK");
+        partName = DynamicPartitionUtil.getFormattedPartitionName(getCTSTimeZone(), res, "WEEK");
         Assert.assertEquals("2020_22", partName);
 
         // 2. 2020-05-28, start day: MONDAY, offset 0
@@ -110,7 +108,7 @@ public class DynamicPartitionUtilTest {
         res = DynamicPartitionUtil.getPartitionRangeString(property, getZonedDateTimeFromStr("2020-05-28"), 0,
                 FORMAT);
         Assert.assertEquals("2020-05-25", res);
-        partName = DynamicPartitionUtil.getFormattedPartitionName(TimeUtils.getDefaultTimeZone(), res, "WEEK");
+        partName = DynamicPartitionUtil.getFormattedPartitionName(getCTSTimeZone(), res, "WEEK");
         Assert.assertEquals("2020_22", partName);
 
         // 3. 2020-05-25, start day: SUNDAY, offset 0
@@ -118,7 +116,7 @@ public class DynamicPartitionUtilTest {
         res = DynamicPartitionUtil.getPartitionRangeString(property, getZonedDateTimeFromStr("2020-05-25"), 0,
                 FORMAT);
         Assert.assertEquals("2020-05-31", res);
-        partName = DynamicPartitionUtil.getFormattedPartitionName(TimeUtils.getDefaultTimeZone(), res, "WEEK");
+        partName = DynamicPartitionUtil.getFormattedPartitionName(getCTSTimeZone(), res, "WEEK");
         Assert.assertEquals("2020_23", partName);
 
         // 4. 2020-05-25, start day: MONDAY, offset -2
@@ -126,7 +124,7 @@ public class DynamicPartitionUtilTest {
         res = DynamicPartitionUtil.getPartitionRangeString(property, getZonedDateTimeFromStr("2020-05-25"), -2,
                 FORMAT);
         Assert.assertEquals("2020-05-11", res);
-        partName = DynamicPartitionUtil.getFormattedPartitionName(TimeUtils.getDefaultTimeZone(), res, "WEEK");
+        partName = DynamicPartitionUtil.getFormattedPartitionName(getCTSTimeZone(), res, "WEEK");
         Assert.assertEquals("2020_20", partName);
 
         // 5. 2020-02-29, start day: WED, offset 0
@@ -134,7 +132,7 @@ public class DynamicPartitionUtilTest {
         res = DynamicPartitionUtil.getPartitionRangeString(property, getZonedDateTimeFromStr("2020-02-29"), 0,
                 FORMAT);
         Assert.assertEquals("2020-02-26", res);
-        partName = DynamicPartitionUtil.getFormattedPartitionName(TimeUtils.getDefaultTimeZone(), res, "WEEK");
+        partName = DynamicPartitionUtil.getFormattedPartitionName(getCTSTimeZone(), res, "WEEK");
         Assert.assertEquals("2020_09", partName);
 
         // 6. 2020-02-29, start day: TUS, offset 1
@@ -142,7 +140,7 @@ public class DynamicPartitionUtilTest {
         res = DynamicPartitionUtil.getPartitionRangeString(property, getZonedDateTimeFromStr("2020-02-29"), 1,
                 FORMAT);
         Assert.assertEquals("2020-03-03", res);
-        partName = DynamicPartitionUtil.getFormattedPartitionName(TimeUtils.getDefaultTimeZone(), res, "WEEK");
+        partName = DynamicPartitionUtil.getFormattedPartitionName(getCTSTimeZone(), res, "WEEK");
         Assert.assertEquals("2020_10", partName);
 
         // 6. 2020-01-01, start day: MONDAY, offset -1
@@ -150,7 +148,7 @@ public class DynamicPartitionUtilTest {
         res = DynamicPartitionUtil.getPartitionRangeString(property, getZonedDateTimeFromStr("2020-01-01"), -1,
                 FORMAT);
         Assert.assertEquals("2019-12-23", res);
-        partName = DynamicPartitionUtil.getFormattedPartitionName(TimeUtils.getDefaultTimeZone(), res, "WEEK");
+        partName = DynamicPartitionUtil.getFormattedPartitionName(getCTSTimeZone(), res, "WEEK");
         Assert.assertEquals("2019_52", partName);
 
         // 6. 2020-01-01, start day: MONDAY, offset 0
@@ -158,7 +156,7 @@ public class DynamicPartitionUtilTest {
         res = DynamicPartitionUtil.getPartitionRangeString(property, getZonedDateTimeFromStr("2020-01-01"), 0,
                 FORMAT);
         Assert.assertEquals("2019-12-30", res);
-        partName = DynamicPartitionUtil.getFormattedPartitionName(TimeUtils.getDefaultTimeZone(), res, "WEEK");
+        partName = DynamicPartitionUtil.getFormattedPartitionName(getCTSTimeZone(), res, "WEEK");
         Assert.assertEquals("2019_53", partName);
 
         // TimeUnit: MONTH
@@ -167,7 +165,7 @@ public class DynamicPartitionUtilTest {
         res = DynamicPartitionUtil.getPartitionRangeString(property, getZonedDateTimeFromStr("2020-05-25"), 0,
                 FORMAT);
         Assert.assertEquals("2020-05-01", res);
-        partName = DynamicPartitionUtil.getFormattedPartitionName(TimeUtils.getDefaultTimeZone(), res, "MONTH");
+        partName = DynamicPartitionUtil.getFormattedPartitionName(getCTSTimeZone(), res, "MONTH");
         Assert.assertEquals("202005", partName);
 
         // 2. 2020-05-25, start day: 26, offset 0
@@ -175,7 +173,7 @@ public class DynamicPartitionUtilTest {
         res = DynamicPartitionUtil.getPartitionRangeString(property, getZonedDateTimeFromStr("2020-05-25"), 0,
                 FORMAT);
         Assert.assertEquals("2020-04-26", res);
-        partName = DynamicPartitionUtil.getFormattedPartitionName(TimeUtils.getDefaultTimeZone(), res, "MONTH");
+        partName = DynamicPartitionUtil.getFormattedPartitionName(getCTSTimeZone(), res, "MONTH");
         Assert.assertEquals("202004", partName);
 
         // 3. 2020-05-25, start day: 26, offset -1
@@ -183,7 +181,7 @@ public class DynamicPartitionUtilTest {
         res = DynamicPartitionUtil.getPartitionRangeString(property, getZonedDateTimeFromStr("2020-05-25"), -1,
                 FORMAT);
         Assert.assertEquals("2020-03-26", res);
-        partName = DynamicPartitionUtil.getFormattedPartitionName(TimeUtils.getDefaultTimeZone(), res, "MONTH");
+        partName = DynamicPartitionUtil.getFormattedPartitionName(getCTSTimeZone(), res, "MONTH");
         Assert.assertEquals("202003", partName);
 
         // 4. 2020-02-29, start day: 26, offset 3
@@ -191,7 +189,7 @@ public class DynamicPartitionUtilTest {
         res = DynamicPartitionUtil.getPartitionRangeString(property, getZonedDateTimeFromStr("2020-02-29"), 3,
                 FORMAT);
         Assert.assertEquals("2020-05-26", res);
-        partName = DynamicPartitionUtil.getFormattedPartitionName(TimeUtils.getDefaultTimeZone(), res, "MONTH");
+        partName = DynamicPartitionUtil.getFormattedPartitionName(getCTSTimeZone(), res, "MONTH");
         Assert.assertEquals("202005", partName);
 
         // 5. 2020-02-29, start day: 27, offset 0
@@ -199,7 +197,7 @@ public class DynamicPartitionUtilTest {
         res = DynamicPartitionUtil.getPartitionRangeString(property, getZonedDateTimeFromStr("2020-02-29"), 0,
                 FORMAT);
         Assert.assertEquals("2020-02-27", res);
-        partName = DynamicPartitionUtil.getFormattedPartitionName(TimeUtils.getDefaultTimeZone(), res, "MONTH");
+        partName = DynamicPartitionUtil.getFormattedPartitionName(getCTSTimeZone(), res, "MONTH");
         Assert.assertEquals("202002", partName);
 
         // 6. 2020-02-29, start day: 27, offset -3
@@ -207,7 +205,7 @@ public class DynamicPartitionUtilTest {
         res = DynamicPartitionUtil.getPartitionRangeString(property, getZonedDateTimeFromStr("2020-02-29"), -3,
                 FORMAT);
         Assert.assertEquals("2019-11-27", res);
-        partName = DynamicPartitionUtil.getFormattedPartitionName(TimeUtils.getDefaultTimeZone(), res, "MONTH");
+        partName = DynamicPartitionUtil.getFormattedPartitionName(getCTSTimeZone(), res, "MONTH");
         Assert.assertEquals("201911", partName);
     }
 

--- a/fe/src/test/java/org/apache/doris/qe/VariableMgrTest.java
+++ b/fe/src/test/java/org/apache/doris/qe/VariableMgrTest.java
@@ -103,9 +103,15 @@ public class VariableMgrTest {
 
         SetVar setVar3 = new SetVar(SetType.GLOBAL, "time_zone", new StringLiteral("Asia/Shanghai"));
         VariableMgr.setVar(var, setVar3);
-        Assert.assertEquals("CST", var.getTimeZone());
+        Assert.assertEquals("Asia/Shanghai", var.getTimeZone());
         var = VariableMgr.newSessionVariable();
         Assert.assertEquals("Asia/Shanghai", var.getTimeZone());
+
+        setVar3 = new SetVar(SetType.GLOBAL, "time_zone", new StringLiteral("CST"));
+        VariableMgr.setVar(var, setVar3);
+        Assert.assertEquals("Asia/Shanghai", var.getTimeZone());
+        var = VariableMgr.newSessionVariable();
+        Assert.assertEquals("CST", var.getTimeZone());
 
         // Set session variable
         setVar = new SetVar(SetType.GLOBAL, "exec_mem_limit", new IntLiteral(1234L));


### PR DESCRIPTION
When we get default system time zone, it will return `PRC`, which is not supported by us, thus
will cause dynamic partition create failed. Fix #3919

This CL mainly changes:
1. Use a unified method to get the system default time zone
2. Now the default variable `system_time_zone` and `time_zone` is set to the default system
time zone, which is `Asia/Shanghai`.
3. Modify related unit test.
4. Support time zone `PRC`.