### PR TITLE
[Bug] Checkpoint thread is not running

### DIFF
--- a/fe/src/main/java/org/apache/doris/catalog/Catalog.java
+++ b/fe/src/main/java/org/apache/doris/catalog/Catalog.java
@@ -554,6 +554,12 @@ public class Catalog {
         }
     }
 
+    // NOTICE: in most case, we should use getCurrentCatalog() to get the right catalog.
+    // but in some cases, we should get the serving catalog explicitly.
+    public static Catalog getServingCatalog() {
+        return SingletonHolder.INSTANCE;
+    }
+
     public PullLoadJobMgr getPullLoadJobMgr() {
         return pullLoadJobMgr;
     }

--- a/fe/src/main/java/org/apache/doris/common/util/MasterDaemon.java
+++ b/fe/src/main/java/org/apache/doris/common/util/MasterDaemon.java
@@ -42,8 +42,8 @@ public class MasterDaemon extends Daemon {
 
     @Override
     protected final void runOneCycle() {
-        while (!Catalog.getCurrentCatalog().isReady()) {
-            // here we use getInstance(), not getCurrentCatalog() because we truly want the Catalog instance,
+        while (!Catalog.getServingCatalog().isReady()) {
+            // here we use getServingCatalog(), not getCurrentCatalog() because we truly want the Catalog instance,
             // not the Checkpoint catalog instance.
             // and if catalog is not ready, do not run
             try {

--- a/fe/src/main/java/org/apache/doris/journal/bdbje/BDBJEJournal.java
+++ b/fe/src/main/java/org/apache/doris/journal/bdbje/BDBJEJournal.java
@@ -337,7 +337,7 @@ public class BDBJEJournal implements Journal {
                      *  This is the very first time to open. Usually, we will open a new database named "1".
                      *  But when we start cluster with an image file copied from other cluster, 
                      *  here we should open database with name image max journal id + 1.
-                     *  (default Catalog.getInstance().getReplayedJournalId() is 0)
+                     *  (default Catalog.getCurrentCatalog().getReplayedJournalId() is 0)
                      */
                     String dbName = Long.toString(Catalog.getCurrentCatalog().getReplayedJournalId() + 1);
                     LOG.info("the very first time to open bdb, dbname is {}", dbName);

--- a/fe/src/main/java/org/apache/doris/master/Checkpoint.java
+++ b/fe/src/main/java/org/apache/doris/master/Checkpoint.java
@@ -55,7 +55,7 @@ public class Checkpoint extends MasterDaemon {
 
     public Checkpoint(EditLog editLog) {
         super("leaderCheckpointer", FeConstants.checkpoint_interval_second * 1000L);
-        this.imageDir = Catalog.getCurrentCatalog().getImageDir();
+        this.imageDir = Catalog.getServingCatalog().getImageDir();
         this.editLog = editLog;
     }
 
@@ -124,14 +124,14 @@ public class Checkpoint extends MasterDaemon {
         
         // push image file to all the other non master nodes
         // DO NOT get other nodes from HaProtocol, because node may not in bdbje replication group yet.
-        List<Frontend> allFrontends = Catalog.getCurrentCatalog().getFrontends(null);
+        List<Frontend> allFrontends = Catalog.getServingCatalog().getFrontends(null);
         int successPushed = 0;
         int otherNodesCount = 0;
         if (!allFrontends.isEmpty()) {
             otherNodesCount = allFrontends.size() - 1; // skip master itself
             for (Frontend fe : allFrontends) {
                 String host = fe.getHost();
-                if (host.equals(Catalog.getCurrentCatalog().getMasterIp())) {
+                if (host.equals(Catalog.getServingCatalog().getMasterIp())) {
                     // skip master itself
                     continue;
                 }
@@ -160,7 +160,7 @@ public class Checkpoint extends MasterDaemon {
             if (successPushed > 0) {
                 for (Frontend fe : allFrontends) {
                     String host = fe.getHost();
-                    if (host.equals(Catalog.getCurrentCatalog().getMasterIp())) {
+                    if (host.equals(Catalog.getServingCatalog().getMasterIp())) {
                         // skip master itself
                         continue;
                     }

--- a/fe/src/test/java/org/apache/doris/alter/RollupJobV2Test.java
+++ b/fe/src/test/java/org/apache/doris/alter/RollupJobV2Test.java
@@ -134,10 +134,6 @@ public class RollupJobV2Test {
 
         new MockUp<Catalog>() {
             @Mock
-            public Catalog getInstance() {
-                return masterCatalog;
-            }
-            @Mock
             public Catalog getCurrentCatalog() {
                 return masterCatalog;
             }

--- a/fe/src/test/java/org/apache/doris/analysis/DescribeStmtTest.java
+++ b/fe/src/test/java/org/apache/doris/analysis/DescribeStmtTest.java
@@ -17,11 +17,7 @@
 
 package org.apache.doris.analysis;
 
-import mockit.Expectations;
-import mockit.Mock;
-import mockit.MockUp;
 import org.apache.doris.catalog.Catalog;
-import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.UserException;
 import org.apache.doris.qe.ConnectContext;
 
@@ -29,6 +25,9 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
+
+import mockit.Mock;
+import mockit.MockUp;
 
 public class DescribeStmtTest {
     private Analyzer analyzer;
@@ -52,10 +51,6 @@ public class DescribeStmtTest {
         };
 
         new MockUp<Catalog>() {
-            @Mock
-            Catalog getInstance() {
-                return catalog;
-            }
             @Mock
             Catalog getCurrentCatalog() {
                 return catalog;

--- a/fe/src/test/java/org/apache/doris/http/DorisHttpTestCase.java
+++ b/fe/src/test/java/org/apache/doris/http/DorisHttpTestCase.java
@@ -316,10 +316,6 @@ abstract public class DorisHttpTestCase {
                 return new MaterializedViewHandler();
             }
             @Mock
-            Catalog getInstance() {
-                return catalog;
-            }
-            @Mock
             Catalog getCurrentCatalog() {
                 return catalog;
             }

--- a/fe/src/test/java/org/apache/doris/qe/ShowExecutorTest.java
+++ b/fe/src/test/java/org/apache/doris/qe/ShowExecutorTest.java
@@ -17,9 +17,6 @@
 
 package org.apache.doris.qe;
 
-import mockit.Expectations;
-import mockit.Mock;
-import mockit.MockUp;
 import org.apache.doris.analysis.AccessTestUtil;
 import org.apache.doris.analysis.Analyzer;
 import org.apache.doris.analysis.DescribeStmt;
@@ -68,6 +65,10 @@ import org.junit.rules.ExpectedException;
 import java.io.IOException;
 import java.net.URL;
 import java.util.List;
+
+import mockit.Expectations;
+import mockit.Mock;
+import mockit.MockUp;
 
 public class ShowExecutorTest {
     private ConnectContext ctx;
@@ -295,10 +296,6 @@ public class ShowExecutorTest {
         Catalog catalog = AccessTestUtil.fetchAdminCatalog();
 
         new MockUp<Catalog>() {
-            @Mock
-            Catalog getInstance() {
-                return catalog;
-            }
             @Mock
             Catalog getCurrentCatalog() {
                 return catalog;

--- a/fs_brokers/apache_hdfs_broker/src/main/java/org/apache/doris/broker/hdfs/FileSystemManager.java
+++ b/fs_brokers/apache_hdfs_broker/src/main/java/org/apache/doris/broker/hdfs/FileSystemManager.java
@@ -562,7 +562,7 @@ public class FileSystemManager {
                     throw new BrokerException(TBrokerOperationStatusCode.END_OF_FILE,
                             "end of file reached");
                 }
-                if (logger.isDebugEnable()) {
+                if (logger.isDebugEnabled()) {
                     logger.debug("read buffer from input stream, buffer size:" + buf.capacity() + ", read length:" + readLength);
                 }
                 return buf;


### PR DESCRIPTION
This bug is introduced by PR #3784 
In #3784, I remove the `Catalog.getInstance()`, and use `Catalog.getCurrentCatalog()` instead.

But actually, there are some place that should use the serving catalog explicitly.

Mainly changed:

1. Add a new method `getServingCatalog()` to explicitly return the real catalog instance.
2. Fix a compile bug of broker introduced by #3881 