### PR TITLE
fix subquery bug when reorder table

### DIFF
--- a/fe/src/main/java/org/apache/doris/analysis/SelectStmt.java
+++ b/fe/src/main/java/org/apache/doris/analysis/SelectStmt.java
@@ -813,12 +813,6 @@ public class SelectStmt extends QueryStmt {
                 return;
             }
         }
-
-        // can not get AST only with equal join, MayBe cross join can help
-        fromClause_.clear();
-        for (Pair<TableRef, Long> candidate : candidates) {
-            fromClause_.add(candidate.first);
-        }
     }
 
     // reorder select table


### PR DESCRIPTION
To solve this [issue](https://github.com/apache/incubator-doris/issues/3908)

Ask a question here:
What‘s the benefits for using candidates which is ordered by rowcounts rather than the original  `fromclause` ?