### PR TITLE
[Bug] Can not use non-key column as partition column in duplicate table

### DIFF
--- a/fe/src/main/java/org/apache/doris/analysis/HashDistributionDesc.java
+++ b/fe/src/main/java/org/apache/doris/analysis/HashDistributionDesc.java
@@ -17,10 +17,11 @@
 
 package org.apache.doris.analysis;
 
+import org.apache.doris.catalog.AggregateType;
 import org.apache.doris.catalog.Column;
+import org.apache.doris.catalog.DistributionInfo;
 import org.apache.doris.catalog.DistributionInfo.DistributionInfoType;
 import org.apache.doris.catalog.HashDistributionInfo;
-import org.apache.doris.catalog.DistributionInfo;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.DdlException;
 import org.apache.doris.common.io.Text;
@@ -102,8 +103,12 @@ public class HashDistributionDesc extends DistributionDesc {
             boolean find = false;
             for (Column column : columns) {
                 if (column.getName().equalsIgnoreCase(colName)) {
-                    if (!column.isKey()) {
+                    if (!column.isKey() && column.getAggregationType() != AggregateType.NONE) {
                         throw new DdlException("Distribution column[" + colName + "] is not key column");
+                    }
+
+                    if (column.getType().isFloatingPointType()) {
+                        throw new DdlException("Floating point type column can not be distribution column");
                     }
 
                     distributionColumns.add(column);

--- a/fe/src/main/java/org/apache/doris/analysis/RangePartitionDesc.java
+++ b/fe/src/main/java/org/apache/doris/analysis/RangePartitionDesc.java
@@ -150,7 +150,7 @@ public class RangePartitionDesc extends PartitionDesc {
             for (Column column : schema) {
                 if (column.getName().equalsIgnoreCase(colName)) {
                     if (!column.isKey() && column.getAggregationType() != AggregateType.NONE) {
-                        throw new DdlException("Partition column[" + colName + "] is not key column");
+                        throw new DdlException("The partition column could not be aggregated column");
                     }
 
                     if (column.getType().isFloatingPointType()) {

--- a/fe/src/main/java/org/apache/doris/analysis/RangePartitionDesc.java
+++ b/fe/src/main/java/org/apache/doris/analysis/RangePartitionDesc.java
@@ -73,7 +73,7 @@ public class RangePartitionDesc extends PartitionDesc {
             for (ColumnDef columnDef : columnDefs) {
                 if (columnDef.getName().equals(partitionCol)) {
                     if (!columnDef.isKey() && columnDef.getAggregateType() != AggregateType.NONE) {
-                        throw new AnalysisException("Only key column can be partition column");
+                        throw new AnalysisException("The partition column could not be aggregated column");
                     }
                     if (columnDef.getType().isFloatingPointType()) {
                         throw new AnalysisException("Floating point type column can not be partition column");

--- a/fe/src/main/java/org/apache/doris/analysis/RangePartitionDesc.java
+++ b/fe/src/main/java/org/apache/doris/analysis/RangePartitionDesc.java
@@ -18,6 +18,7 @@
 package org.apache.doris.analysis;
 
 import org.apache.doris.analysis.PartitionKeyDesc.PartitionRangeType;
+import org.apache.doris.catalog.AggregateType;
 import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.PartitionInfo;
 import org.apache.doris.catalog.PartitionType;
@@ -71,8 +72,11 @@ public class RangePartitionDesc extends PartitionDesc {
             boolean found = false;
             for (ColumnDef columnDef : columnDefs) {
                 if (columnDef.getName().equals(partitionCol)) {
-                    if (!columnDef.isKey()) {
+                    if (!columnDef.isKey() && columnDef.getAggregateType() != AggregateType.NONE) {
                         throw new AnalysisException("Only key column can be partition column");
+                    }
+                    if (columnDef.getType().isFloatingPointType()) {
+                        throw new AnalysisException("Floating point type column can not be partition column");
                     }
                     found = true;
                     break;
@@ -145,9 +149,14 @@ public class RangePartitionDesc extends PartitionDesc {
             boolean find = false;
             for (Column column : schema) {
                 if (column.getName().equalsIgnoreCase(colName)) {
-                    if (!column.isKey()) {
+                    if (!column.isKey() && column.getAggregationType() != AggregateType.NONE) {
                         throw new DdlException("Partition column[" + colName + "] is not key column");
                     }
+
+                    if (column.getType().isFloatingPointType()) {
+                        throw new DdlException("Floating point type column can not be partition column");
+                    }
+
                     try {
                         RangePartitionInfo.checkRangeColumnType(column);
                     } catch (AnalysisException e) {

--- a/fe/src/test/java/org/apache/doris/common/ExceptionChecker.java
+++ b/fe/src/test/java/org/apache/doris/common/ExceptionChecker.java
@@ -47,6 +47,11 @@ public class ExceptionChecker {
                 "Expected exception " + expectedType.getSimpleName() + " but no exception was thrown", null, runnable);
     }
 
+    /**
+     * Checks a specific exception class is thrown by the given runnable, and
+     * returns it.
+     * Will also check if the given `exceptionMsg` is with exception.
+     */
     public static <T extends Throwable> T expectThrowsWithMsg(Class<T> expectedType, String exceptionMsg,
             ThrowingRunnable runnable) {
         return expectThrows(expectedType,

--- a/fe/src/test/java/org/apache/doris/common/ExceptionChecker.java
+++ b/fe/src/test/java/org/apache/doris/common/ExceptionChecker.java
@@ -17,12 +17,21 @@
 
 package org.apache.doris.common;
 
-import org.apache.doris.http.DorisHttpTestCase;
+import com.google.common.base.Strings;
+
 import junit.framework.AssertionFailedError;
 
 public class ExceptionChecker {
 
-    public static void expectThrowsNoException(DorisHttpTestCase.ThrowingRunnable runnable) {
+    /**
+     * A runnable that can throw any checked exception.
+     */
+    @FunctionalInterface
+    public interface ThrowingRunnable {
+        void run() throws Throwable;
+    }
+
+    public static void expectThrowsNoException(ThrowingRunnable runnable) {
         try {
             runnable.run();
         } catch (Throwable e) {
@@ -33,21 +42,39 @@ public class ExceptionChecker {
     /**
      * Checks a specific exception class is thrown by the given runnable, and returns it.
      */
-    public static <T extends Throwable> T expectThrows(Class<T> expectedType, DorisHttpTestCase.ThrowingRunnable runnable) {
-        return expectThrows(expectedType, "Expected exception " + expectedType.getSimpleName() + " but no exception was thrown", runnable);
+    public static <T extends Throwable> T expectThrows(Class<T> expectedType, ThrowingRunnable runnable) {
+        return expectThrows(expectedType,
+                "Expected exception " + expectedType.getSimpleName() + " but no exception was thrown", null, runnable);
+    }
+
+    public static <T extends Throwable> T expectThrowsWithMsg(Class<T> expectedType, String exceptionMsg,
+            ThrowingRunnable runnable) {
+        return expectThrows(expectedType,
+                "Expected exception " + expectedType.getSimpleName() + " but no exception was thrown", exceptionMsg,
+                runnable);
     }
 
     /**
      * Checks a specific exception class is thrown by the given runnable, and returns it.
      */
-    public static <T extends Throwable> T expectThrows(Class<T> expectedType, String noExceptionMessage, DorisHttpTestCase.ThrowingRunnable runnable) {
+    public static <T extends Throwable> T expectThrows(Class<T> expectedType, String noExceptionMessage,
+            String exceptionMsg, ThrowingRunnable runnable) {
         try {
             runnable.run();
         } catch (Throwable e) {
             if (expectedType.isInstance(e)) {
+                if (!Strings.isNullOrEmpty(exceptionMsg)) {
+                    if (!e.getMessage().contains(exceptionMsg)) {
+                        AssertionFailedError assertion = new AssertionFailedError(
+                                "expceted msg: " + exceptionMsg + ", actual: " + e.getMessage());
+                        assertion.initCause(e);
+                        throw assertion;
+                    }
+                }
                 return expectedType.cast(e);
             }
-            AssertionFailedError assertion = new AssertionFailedError("Unexpected exception type, expected " + expectedType.getSimpleName() + " but got " + e);
+            AssertionFailedError assertion = new AssertionFailedError(
+                    "Unexpected exception type, expected " + expectedType.getSimpleName() + " but got " + e);
             assertion.initCause(e);
             throw assertion;
         }

--- a/fe/src/test/java/org/apache/doris/http/DorisHttpTestCase.java
+++ b/fe/src/test/java/org/apache/doris/http/DorisHttpTestCase.java
@@ -38,6 +38,7 @@ import org.apache.doris.catalog.TabletInvertedIndex;
 import org.apache.doris.catalog.TabletMeta;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.DdlException;
+import org.apache.doris.common.ExceptionChecker.ThrowingRunnable;
 import org.apache.doris.common.jmockit.Deencapsulation;
 import org.apache.doris.load.Load;
 import org.apache.doris.mysql.privilege.PaloAuth;
@@ -343,14 +344,6 @@ abstract public class DorisHttpTestCase {
 
     public void doSetUp() {
 
-    }
-
-    /**
-     * A runnable that can throw any checked exception.
-     */
-    @FunctionalInterface
-    public interface ThrowingRunnable {
-        void run() throws Throwable;
     }
 
     public void expectThrowsNoException(ThrowingRunnable runnable) {

--- a/fe/src/test/java/org/apache/doris/planner/QueryPlanTest.java
+++ b/fe/src/test/java/org/apache/doris/planner/QueryPlanTest.java
@@ -70,8 +70,8 @@ public class QueryPlanTest {
         
         createTable("create table test.test1\n" + 
                 "(\n" +
-                "    time datetime not null comment \"Query start time\",\n" +
                 "    query_id varchar(48) comment \"Unique query id\",\n" +
+                "    time datetime not null comment \"Query start time\",\n" +
                 "    client_ip varchar(32) comment \"Client IP\",\n" + 
                 "    user varchar(64) comment \"User name\",\n" + 
                 "    db varchar(96) comment \"Database of this query\",\n" + 


### PR DESCRIPTION
The following statement will throw error:
```
create table test.tbl2
(k1 int, k2 int, k3 float)
duplicate key(k1)
partition by range(k2)
(partition p1 values less than("10"))
distributed by hash(k3) buckets 1
properties('replication_num' = '1'); 
```
Error: `Only key column can be partition column`

But in duplicate key table, columns can be partition or distribution column
even if they are not in duplicate keys.

This bug is introduced by #3812 