### PR TITLE
[Bug] Fix bug that BE crash when doing some queries

### DIFF
--- a/be/src/runtime/data_stream_recvr.cc
+++ b/be/src/runtime/data_stream_recvr.cc
@@ -361,7 +361,7 @@ DataStreamRecvr::DataStreamRecvr(
             _is_merging(is_merging),
             _num_buffered_bytes(0),
             _sub_plan_query_statistics_recvr(sub_plan_query_statistics_recvr) {
-    _profile.reset(new RuntimeProfile(nullptr, "DataStreamRecvr"));
+    _profile.reset(new RuntimeProfile("DataStreamRecvr"));
     profile->add_child(_profile.get(), true, nullptr);
 
     // TODO: Now the parent tracker may cause problem when we need spill to disk, so we


### PR DESCRIPTION
This bug is introduced by PR #3872 

In that PR, I removed the `obj_pool` param of the RuntimeProfile constructor.
So the first param is `std::string`.
But in `DataStreamRecv`, it accidentally pass a `nullptr` to `std::string`, it compiles
OK but will cause runtime error.

Fix #3917