### PR TITLE
[Spill to Disk] Aggregation Node Support Spill to disk in big query

### DIFF
--- a/be/src/vec/olap/block_reader.cpp
+++ b/be/src/vec/olap/block_reader.cpp
@@ -314,7 +314,7 @@ size_t BlockReader::_copy_agg_data() {
 
     for (size_t i = 0; i < copy_size; i++) {
         auto& ref = _stored_row_ref[i];
-        _temp_ref_map[ref.block].emplace_back(ref.row_pos, i);
+        _temp_ref_map[ref.block.get()].emplace_back(ref.row_pos, i);
     }
 
     for (auto idx : _agg_columns_idx) {

--- a/be/src/vec/olap/block_reader.h
+++ b/be/src/vec/olap/block_reader.h
@@ -86,7 +86,7 @@ private:
     void _update_agg_value(MutableColumns& columns, int begin, int end, bool is_close = true);
 
     VCollectIterator _vcollect_iter;
-    IteratorRowRef _next_row {nullptr, -1, false};
+    IteratorRowRef _next_row {{}, -1, false};
 
     std::vector<AggregateFunctionPtr> _agg_functions;
     std::vector<AggregateDataPtr> _agg_places;

--- a/be/src/vec/olap/vcollect_iterator.cpp
+++ b/be/src/vec/olap/vcollect_iterator.cpp
@@ -16,6 +16,7 @@
 // under the License.
 
 #include "vec/olap/vcollect_iterator.h"
+#include <memory>
 
 #include "olap/rowset/beta_rowset_reader.h"
 
@@ -163,8 +164,8 @@ OLAPStatus VCollectIterator::next(Block* block) {
 VCollectIterator::Level0Iterator::Level0Iterator(RowsetReaderSharedPtr rs_reader, TabletReader* reader)
         : LevelIterator(reader), _rs_reader(rs_reader), _reader(reader) {
     DCHECK_EQ(RowsetTypePB::BETA_ROWSET, rs_reader->type());
-    _block = _schema.create_block(_reader->_return_columns);
-    _ref.block = &_block;
+    _block = std::make_shared<Block>(_schema.create_block(_reader->_return_columns));
+    _ref.block = _block;
     _ref.row_pos = 0;
     _ref.is_same = false;
 }
@@ -179,18 +180,18 @@ int64_t VCollectIterator::Level0Iterator::version() const {
 
 OLAPStatus VCollectIterator::Level0Iterator::_refresh_current_row() {
     do {
-        if (_block.rows() != 0 && _ref.row_pos < _block.rows()) {
+        if (_block->rows() != 0 && _ref.row_pos < _block->rows()) {
             return OLAP_SUCCESS;
         } else {
             _ref.is_same = false;
             _ref.row_pos = 0;
-            _block.clear_column_data();
-            auto res = _rs_reader->next_block(&_block);
+            _block->clear_column_data();
+            auto res = _rs_reader->next_block(_block.get());
             if (res != OLAP_SUCCESS) {
                 return res;
             }
         }
-    } while (_block.rows() != 0);
+    } while (_block->rows() != 0);
     _ref.row_pos = -1;
     return OLAP_ERR_DATA_EOF;
 }
@@ -341,9 +342,7 @@ OLAPStatus VCollectIterator::Level1Iterator::_normal_next(IteratorRowRef* ref) {
         _children.pop_front();
         if (!_children.empty()) {
             _cur_child = *(_children.begin());
-            auto result = _cur_child->next(ref);
-            _ref = *ref;
-            return result;
+            return _normal_next(ref);
         } else {
             _cur_child = nullptr;
             return OLAP_ERR_DATA_EOF;

--- a/be/src/vec/olap/vcollect_iterator.h
+++ b/be/src/vec/olap/vcollect_iterator.h
@@ -35,7 +35,7 @@ class TabletSchema;
 namespace vectorized {
 
 struct IteratorRowRef {
-    const Block* block;
+    std::shared_ptr<Block> block;
     int16_t row_pos;
     bool is_same;
 };
@@ -137,7 +137,7 @@ private:
 
         RowsetReaderSharedPtr _rs_reader;
         TabletReader* _reader = nullptr;
-        Block _block;
+        std::shared_ptr<Block> _block;
     };
 
     // Iterate from LevelIterators (maybe Level0Iterators or Level1Iterator or mixed)


### PR DESCRIPTION
#3926 issue

This pr mainly about:

1. Clear_reservations of buffer block client when node close()
2. Replace ```buffered_tuple_stream3``` by ```buffered_tuple_stream2``` in ```PartitionAggregationNode``` to support spill to disk 
3. Fix bug of available IO buffer can be used in ```spill_sorter```.
4. Fix the bug of count of ```_unfullfilled_reserved_buffers``` in ```buffered_block_mgr2.cc```, we should only count reverved_buffer when the buffer size == IO block size.