### PR TITLE
[log] Downgrade a log in RunLengthByteReader from WARNING to VLOG

### DIFF
--- a/be/src/olap/rowset/run_length_byte_reader.cpp
+++ b/be/src/olap/rowset/run_length_byte_reader.cpp
@@ -99,7 +99,7 @@ OLAPStatus RunLengthByteReader::seek(PositionProvider* position) {
 
     res = _input->seek(position);
     if (OLAP_SUCCESS != res) {
-        OLAP_LOG_WARNING("fail to ReadOnlyFileStream seek.[res = %d]", res);
+        OLAP_LOG_INFO("fail to ReadOnlyFileStream seek.[res = %d]", res);
         return res;
     }
 

--- a/be/src/olap/rowset/run_length_byte_reader.cpp
+++ b/be/src/olap/rowset/run_length_byte_reader.cpp
@@ -99,7 +99,7 @@ OLAPStatus RunLengthByteReader::seek(PositionProvider* position) {
 
     res = _input->seek(position);
     if (OLAP_SUCCESS != res) {
-        OLAP_LOG_INFO("fail to ReadOnlyFileStream seek.[res = %d]", res);
+        VLOG(10) << "fail to ReadOnlyFileStream seek. res = " << res;
         return res;
     }
 

--- a/be/src/olap/rowset/run_length_byte_writer.h
+++ b/be/src/olap/rowset/run_length_byte_writer.h
@@ -26,9 +26,9 @@ namespace doris {
 class OutStream;
 class RowIndexEntryMessage;
 
-// A Writer that writes a sequence of bytes. A control byte is written before
-// each run with positive values 0 to 127 meaning 2 to 129 repetitions. If the
-// bytes is -1 to -128, 1 to 128 literal byte values follow.
+// A writer that writes a sequence of bytes. A control byte is written before
+// each run with positive values 0 to 127 meaning 3 to 130 repetitions. If the
+// byte is -1 to -128, 1 to 128 literal byte values follow.
 class RunLengthByteWriter {
 public:
     explicit RunLengthByteWriter(OutStream* output);

--- a/be/src/olap/utils.h
+++ b/be/src/olap/utils.h
@@ -340,7 +340,6 @@ bool valid_datetime(const std::string& value_str);
 // Log define for non-network usage
 // 屏蔽DEBUG和TRACE日志以满足性能测试需求
 #define OLAP_LOG_WARNING(fmt, arg...) OLAP_LOG_WRITE(WARNING, fmt, ##arg)
-#define OLAP_LOG_INFO(fmt, arg...) OLAP_LOG_WRITE(INFO, fmt, ##arg)
 #define OLAP_LOG_NOTICE_DIRECT_SOCK(fmt, arg...) OLAP_LOG_WRITE(INFO, fmt, ##arg)
 #define OLAP_LOG_WARNING_SOCK(fmt, arg...) OLAP_LOG_WRITE(WARNING, fmt, ##arg)
 #define OLAP_LOG_SETBASIC(type, fmt, arg...)

--- a/be/src/olap/utils.h
+++ b/be/src/olap/utils.h
@@ -340,6 +340,7 @@ bool valid_datetime(const std::string& value_str);
 // Log define for non-network usage
 // 屏蔽DEBUG和TRACE日志以满足性能测试需求
 #define OLAP_LOG_WARNING(fmt, arg...) OLAP_LOG_WRITE(WARNING, fmt, ##arg)
+#define OLAP_LOG_INFO(fmt, arg...) OLAP_LOG_WRITE(INFO, fmt, ##arg)
 #define OLAP_LOG_NOTICE_DIRECT_SOCK(fmt, arg...) OLAP_LOG_WRITE(INFO, fmt, ##arg)
 #define OLAP_LOG_WARNING_SOCK(fmt, arg...) OLAP_LOG_WRITE(WARNING, fmt, ##arg)
 #define OLAP_LOG_SETBASIC(type, fmt, arg...)


### PR DESCRIPTION
There are too many logs in be.WARNING looks like:
```
W0622 17:47:52.513341 26554 run_length_byte_reader.cpp:102] fail to ReadOnlyFileStream seek.[res = -1705]
W0622 17:47:52.513417 26554 run_length_byte_reader.cpp:102] fail to ReadOnlyFileStream seek.[res = -1705]
W0622 17:47:52.513466 26554 run_length_byte_reader.cpp:102] fail to ReadOnlyFileStream seek.[res = -1705]
```
It's a normal case when a run length is EOF, so we can downgrade it from
WARNING to INFO to reduce useless log in be.WARNING