### PR TITLE
[Doris On ES][Optimization] Ignore _total node for efficiency and fully trusted document count

### DIFF
--- a/be/src/exec/es/es_scan_reader.cpp
+++ b/be/src/exec/es/es_scan_reader.cpp
@@ -162,7 +162,7 @@ Status ESScanReader::get_next(bool* scan_eos, std::unique_ptr<ScrollParser>& scr
         _eos = true;
     } else {
         _scroll_id = scroll_parser->get_scroll_id();
-        if (scroll_parser->get_total() == 0) {
+        if (scroll_parser->get_size() == 0) {
             _eos = true;
             return Status::OK();
         }

--- a/be/src/exec/es/es_scroll_parser.h
+++ b/be/src/exec/es/es_scroll_parser.h
@@ -38,13 +38,11 @@ public:
                 MemPool* mem_pool, bool* line_eof, const std::map<std::string, std::string>& docvalue_context);
 
     const std::string& get_scroll_id();
-    int get_total();
     int get_size();
 
 private:
 
     std::string _scroll_id;
-    int _total;
     int _size;
     rapidjson::SizeType _line_index;
 


### PR DESCRIPTION
Prior to this PR, Doris On ES merged another PR https://github.com/apache/incubator-doris/pull/3513 which misusing the `total` node.  After Doris On ES introduce `terminate_after` (https://github.com/apache/incubator-doris/issues/2576), the `total` documents would not be computed, rely  on this `total` field would be dangerous， we just rely on the actual document count by counting the `inner hits` node which it means to be. So we just remove all total parsing and related logic from Doris On ES, this maybe improve performance slightly because of ignoring and skipping `total` json node.
