### PR TITLE
[Bug]Dynamic partition check interval seconds is not right

### DIFF
--- a/fe/src/main/java/org/apache/doris/clone/DynamicPartitionScheduler.java
+++ b/fe/src/main/java/org/apache/doris/clone/DynamicPartitionScheduler.java
@@ -380,7 +380,7 @@ public class DynamicPartitionScheduler extends MasterDaemon {
             // check Dynamic Partition tables only when FE start
             initDynamicPartitionTable();
         }
-        setInterval(Config.dynamic_partition_check_interval_seconds);
+        setInterval(Config.dynamic_partition_check_interval_seconds * 1000L);
         if (Config.dynamic_partition_enable) {
             executeDynamicPartition();
         }

--- a/fe/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/src/main/java/org/apache/doris/common/Config.java
@@ -1044,7 +1044,7 @@ public class Config extends ConfigBase {
      * Decide how often to check dynamic partition
      */
     @ConfField(mutable = true, masterOnly = true)
-    public static int dynamic_partition_check_interval_seconds = 600;
+    public static long dynamic_partition_check_interval_seconds = 600;
 
     /*
      * If set to true, dynamic partition feature will open


### PR DESCRIPTION
dynamic partition interval's unit is ms, should multiplied by 1000.