### PR TITLE
[Doris On ES][Bug-fix] Sync ES metadata failure after restart or upgrade FE

### DIFF
--- a/fe/src/main/java/org/apache/doris/external/elasticsearch/EsRepository.java
+++ b/fe/src/main/java/org/apache/doris/external/elasticsearch/EsRepository.java
@@ -93,7 +93,7 @@ public class EsRepository extends MasterDaemon {
             List<Table> tables = database.getTables();
             for (Table table : tables) {
                 if (table.getType() == TableType.ELASTICSEARCH) {
-                    esTables.put(table.getId(), (EsTable) table);
+                    registerTable((EsTable) table);
                 }
             }
         }

--- a/fe/src/test/java/org/apache/doris/metric/MetricsTest.java
+++ b/fe/src/test/java/org/apache/doris/metric/MetricsTest.java
@@ -36,7 +36,7 @@ public class MetricsTest {
     @Test
     public void testTcpMetrics() {
         List<Metric> metrics = MetricRepo.getMetricsByName("snmp");
-        Assert.assertEquals(2, metrics.size());
+        Assert.assertEquals(4, metrics.size());
         for (Metric metric : metrics) {
             GaugeMetric<Long> gm = (GaugeMetric<Long>) metric;
             if (gm.getLabels().get(0).getValue().equals("tcp_retrans_segs")) {


### PR DESCRIPTION
ISSUE:https://github.com/apache/incubator-doris/issues/3960
PR https://github.com/apache/incubator-doris/pull/3454  introduce the caching for EsClient,  but the initialization of the `client` was only during `editlog` replay, all this work should done also during `image` replay.

This happens when restart or upgrade FE

BTW: modify a UT failure for metric