### PR TITLE
[Dynamic Partition]Support set replication_num in dynamic partition property

### DIFF
--- a/docs/en/administrator-guide/dynamic-partition.md
+++ b/docs/en/administrator-guide/dynamic-partition.md
@@ -108,7 +108,11 @@ The rules of dynamic partition are prefixed with `dynamic_partition.`:
 * `dynamic_partition.buckets`
 
     The number of buckets corresponding to the dynamically created partitions.
-    
+
+* `dynamic_partition.replication_num`
+
+    The replication number of dynamic partition.If not filled in, defaults to the number of table's replication number.    
+
 * `dynamic_partition.start_day_of_week`
 
     When `time_unit` is` WEEK`, this parameter is used to specify the starting point of the week. The value ranges from 1 to 7. Where 1 is Monday and 7 is Sunday. The default is 1, which means that every week starts on Monday.

--- a/docs/zh-CN/administrator-guide/dynamic-partition.md
+++ b/docs/zh-CN/administrator-guide/dynamic-partition.md
@@ -106,7 +106,11 @@ under the License.
 * `dynamic_partition.buckets`
 
     动态创建的分区所对应的分桶数量。
-    
+  
+* `dynamic_partition.replication_num`
+
+    动态创建的分区所对应的副本数量，如果不填写，则默认为该表创建时指定的副本数量。
+
 * `dynamic_partition.start_day_of_week`
 
     当 `time_unit` 为 `WEEK` 时，该参数用于指定每周的起始点。取值为 1 到 7。其中 1 表示周一，7 表示周日。默认为 1，即表示每周以周一为起始点。

--- a/fe/src/main/java/org/apache/doris/analysis/ShowDynamicPartitionStmt.java
+++ b/fe/src/main/java/org/apache/doris/analysis/ShowDynamicPartitionStmt.java
@@ -38,6 +38,7 @@ public class ShowDynamicPartitionStmt extends ShowStmt {
                     .addColumn(new Column("End", ScalarType.createVarchar(20)))
                     .addColumn(new Column("Prefix", ScalarType.createVarchar(20)))
                     .addColumn(new Column("Buckets", ScalarType.createVarchar(20)))
+                    .addColumn(new Column("ReplicationNum", ScalarType.createVarchar(20)))
                     .addColumn(new Column("StartOf", ScalarType.createVarchar(20)))
                     .addColumn(new Column("LastUpdateTime", ScalarType.createVarchar(20)))
                     .addColumn(new Column("LastSchedulerTime", ScalarType.createVarchar(20)))

--- a/fe/src/main/java/org/apache/doris/catalog/DynamicPartitionProperty.java
+++ b/fe/src/main/java/org/apache/doris/catalog/DynamicPartitionProperty.java
@@ -35,8 +35,10 @@ public class DynamicPartitionProperty {
     public static final String START_DAY_OF_WEEK = "dynamic_partition.start_day_of_week";
     public static final String START_DAY_OF_MONTH = "dynamic_partition.start_day_of_month";
     public static final String TIME_ZONE = "dynamic_partition.time_zone";
+    public static final String REPLICATION_NUM = "dynamic_partition.replication_num";
 
     public static final int MIN_START_OFFSET = Integer.MIN_VALUE;
+    public static final int NOT_SET_REPLICATION_NUM = -1;
 
     private boolean exist;
 
@@ -49,6 +51,7 @@ public class DynamicPartitionProperty {
     private StartOfDate startOfWeek;
     private StartOfDate startOfMonth;
     private TimeZone tz = TimeUtils.getSystemTimeZone();
+    private int replicationNum;
 
     public DynamicPartitionProperty(Map<String, String> properties) {
         if (properties != null && !properties.isEmpty()) {
@@ -61,6 +64,7 @@ public class DynamicPartitionProperty {
             this.end = Integer.parseInt(properties.get(END));
             this.prefix = properties.get(PREFIX);
             this.buckets = Integer.parseInt(properties.get(BUCKETS));
+            this.replicationNum = Integer.parseInt(properties.getOrDefault(REPLICATION_NUM, String.valueOf(NOT_SET_REPLICATION_NUM)));
             createStartOfs(properties);
         } else {
             this.exist = false;
@@ -133,6 +137,10 @@ public class DynamicPartitionProperty {
         return tz;
     }
 
+    public int getReplicationNum() {
+        return replicationNum;
+    }
+
     @Override
     public String toString() {
         String res = ",\n\"" + ENABLE + "\" = \"" + enable + "\"" +
@@ -141,6 +149,7 @@ public class DynamicPartitionProperty {
                 ",\n\"" + START + "\" = \"" + start + "\"" +
                 ",\n\"" + END + "\" = \"" + end + "\"" +
                 ",\n\"" + PREFIX + "\" = \"" + prefix + "\"" +
+                ",\n\"" + REPLICATION_NUM + "\" = \"" + replicationNum + "\"" +
                 ",\n\"" + BUCKETS + "\" = \"" + buckets + "\"";
         if (getTimeUnit().equalsIgnoreCase(TimeUnit.WEEK.toString())) {
             res += ",\n\"" + START_DAY_OF_WEEK + "\" = \"" + startOfWeek.dayOfWeek + "\"";

--- a/fe/src/main/java/org/apache/doris/clone/DynamicPartitionScheduler.java
+++ b/fe/src/main/java/org/apache/doris/clone/DynamicPartitionScheduler.java
@@ -172,7 +172,11 @@ public class DynamicPartitionScheduler extends MasterDaemon {
             // construct partition desc
             PartitionKeyDesc partitionKeyDesc = new PartitionKeyDesc(Collections.singletonList(lowerValue), Collections.singletonList(upperValue));
             HashMap<String, String> partitionProperties = new HashMap<>(1);
-            partitionProperties.put("replication_num", String.valueOf(DynamicPartitionUtil.estimateReplicateNum(olapTable)));
+            if (dynamicPartitionProperty.getReplicationNum() == DynamicPartitionProperty.NOT_SET_REPLICATION_NUM) {
+                partitionProperties.put("replication_num", String.valueOf(olapTable.getDefaultReplicationNum()));
+            } else {
+                partitionProperties.put("replication_num", String.valueOf(dynamicPartitionProperty.getReplicationNum()));
+            }
             String partitionName = dynamicPartitionProperty.getPrefix() + DynamicPartitionUtil.getFormattedPartitionName(
                     dynamicPartitionProperty.getTimeZone(), prevBorder, dynamicPartitionProperty.getTimeUnit());
             SingleRangePartitionDesc rangePartitionDesc = new SingleRangePartitionDesc(true, partitionName,

--- a/fe/src/main/java/org/apache/doris/common/ErrorCode.java
+++ b/fe/src/main/java/org/apache/doris/common/ErrorCode.java
@@ -232,7 +232,11 @@ public enum ErrorCode {
     ERROR_DYNAMIC_PARTITION_PREFIX(5069, new byte[] {'4', '2', '0', '0', '0'},
             "Invalid dynamic partition prefix: %s."),
     ERR_OPERATION_DISABLED(5070, new byte[] {'4', '2', '0', '0', '0'},
-            "Operation %s is disabled. %s");
+            "Operation %s is disabled. %s"),
+    ERROR_DYNAMIC_PARTITION_REPLICATION_NUM_ZERO(5071, new byte[] {'4', '2', '0', '0', '0'},
+            "Dynamic partition replication num must greater than 0"),
+    ERROR_DYNAMIC_PARTITION_REPLICATION_NUM_FORMAT(5072, new byte[] {'4', '2', '0', '0', '0'},
+            "Invalid dynamic partition replication num: %s.");
 
     ErrorCode(int code, byte[] sqlState, String errorMsg) {
         this.code = code;

--- a/fe/src/main/java/org/apache/doris/common/util/DynamicPartitionUtil.java
+++ b/fe/src/main/java/org/apache/doris/common/util/DynamicPartitionUtil.java
@@ -23,7 +23,6 @@ import org.apache.doris.catalog.Catalog;
 import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.DynamicPartitionProperty;
 import org.apache.doris.catalog.OlapTable;
-import org.apache.doris.catalog.Partition;
 import org.apache.doris.catalog.PartitionInfo;
 import org.apache.doris.catalog.PartitionType;
 import org.apache.doris.catalog.PrimitiveType;
@@ -151,6 +150,19 @@ public class DynamicPartitionUtil {
         }
     }
 
+    private static void checkReplicationNum(String val) throws DdlException {
+        if (Strings.isNullOrEmpty(val)) {
+            throw new DdlException("Invalid properties: " + DynamicPartitionProperty.REPLICATION_NUM);
+        }
+        try {
+            if (Integer.parseInt(val) <= 0) {
+                ErrorReport.reportDdlException(ErrorCode.ERROR_DYNAMIC_PARTITION_REPLICATION_NUM_ZERO);
+            }
+        } catch (NumberFormatException e) {
+            ErrorReport.reportDdlException(ErrorCode.ERROR_DYNAMIC_PARTITION_REPLICATION_NUM_FORMAT, val);
+        }
+    }
+
     public static boolean checkDynamicPartitionPropertiesExist(Map<String, String> properties) {
         if (properties == null) {
             return false;
@@ -161,6 +173,7 @@ public class DynamicPartitionUtil {
                 properties.containsKey(DynamicPartitionProperty.END) ||
                 properties.containsKey(DynamicPartitionProperty.PREFIX) ||
                 properties.containsKey(DynamicPartitionProperty.BUCKETS) ||
+                properties.containsKey(DynamicPartitionProperty.REPLICATION_NUM) ||
                 properties.containsKey(DynamicPartitionProperty.ENABLE) ||
                 properties.containsKey(DynamicPartitionProperty.START_DAY_OF_WEEK) ||
                 properties.containsKey(DynamicPartitionProperty.START_DAY_OF_MONTH);
@@ -179,6 +192,7 @@ public class DynamicPartitionUtil {
         String timeZone = properties.get(DynamicPartitionProperty.TIME_ZONE);
         String end = properties.get(DynamicPartitionProperty.END);
         String buckets = properties.get(DynamicPartitionProperty.BUCKETS);
+        String replicationNum = properties.get(DynamicPartitionProperty.REPLICATION_NUM);
         String enable = properties.get(DynamicPartitionProperty.ENABLE);
         if (!((Strings.isNullOrEmpty(enable) &&
                 Strings.isNullOrEmpty(timeUnit) &&
@@ -283,6 +297,12 @@ public class DynamicPartitionUtil {
             TimeUtils.checkTimeZoneValidAndStandardize(val);
             properties.remove(DynamicPartitionProperty.TIME_ZONE);
             analyzedProperties.put(DynamicPartitionProperty.TIME_ZONE, val);
+        }
+        if (properties.containsKey(DynamicPartitionProperty.REPLICATION_NUM)) {
+            String val = properties.get(DynamicPartitionProperty.REPLICATION_NUM);
+            checkReplicationNum(val);
+            properties.remove(DynamicPartitionProperty.REPLICATION_NUM);
+            analyzedProperties.put(DynamicPartitionProperty.REPLICATION_NUM, val);
         }
         return analyzedProperties;
     }
@@ -438,18 +458,6 @@ public class DynamicPartitionUtil {
     private static String getFormattedTimeWithoutHourMinuteSecond(ZonedDateTime zonedDateTime, String format) {
         ZonedDateTime timeWithoutHourMinuteSecond = zonedDateTime.withHour(0).withMinute(0).withSecond(0);
         return DateTimeFormatter.ofPattern(format).format(timeWithoutHourMinuteSecond);
-    }
-
-    public static int estimateReplicateNum(OlapTable table) {
-        int replicateNum = table.getDefaultReplicationNum();
-        long maxPartitionId = 0;
-        for (Partition partition: table.getPartitions()) {
-            if (partition.getId() > maxPartitionId) {
-                maxPartitionId = partition.getId();
-                replicateNum = table.getPartitionInfo().getReplicationNum(partition.getId());
-            }
-        }
-        return replicateNum;
     }
 
     /**

--- a/fe/src/main/java/org/apache/doris/qe/ShowExecutor.java
+++ b/fe/src/main/java/org/apache/doris/qe/ShowExecutor.java
@@ -1502,6 +1502,8 @@ public class ShowExecutor {
                     }
                     DynamicPartitionProperty dynamicPartitionProperty = olapTable.getTableProperty().getDynamicPartitionProperty();
                     String tableName = olapTable.getName();
+                    int replicationNum = dynamicPartitionProperty.getReplicationNum();
+                    replicationNum = (replicationNum == DynamicPartitionProperty.NOT_SET_REPLICATION_NUM) ? olapTable.getDefaultReplicationNum() : FeConstants.default_replication_num;
                     rows.add(Lists.newArrayList(
                             tableName,
                             String.valueOf(dynamicPartitionProperty.getEnable()),
@@ -1510,6 +1512,7 @@ public class ShowExecutor {
                             String.valueOf(dynamicPartitionProperty.getEnd()),
                             dynamicPartitionProperty.getPrefix(),
                             String.valueOf(dynamicPartitionProperty.getBuckets()),
+                            String.valueOf(replicationNum),
                             dynamicPartitionProperty.getStartOfInfo(),
                             dynamicPartitionScheduler.getRuntimeInfo(tableName, DynamicPartitionScheduler.LAST_UPDATE_TIME),
                             dynamicPartitionScheduler.getRuntimeInfo(tableName, DynamicPartitionScheduler.LAST_SCHEDULER_TIME),


### PR DESCRIPTION
This CL mainly support set replication_num property in dynamic partition table.
 If dynamic_partition.replication_num is not set, the value is the same as table's default replication_num.