### PR TITLE
[Doris On ES][Feature] Support create table with wildcard or aliase index

### DIFF
--- a/fe/src/main/java/org/apache/doris/external/elasticsearch/DorisEsException.java
+++ b/fe/src/main/java/org/apache/doris/external/elasticsearch/DorisEsException.java
@@ -19,11 +19,11 @@ package org.apache.doris.external.elasticsearch;
 
 import org.apache.doris.common.UserException;
 
-public class ExternalDataSourceException extends UserException {
+public class DorisEsException extends UserException {
 
     private static final long serialVersionUID = 7912833584319374692L;
 
-    public ExternalDataSourceException(String msg) {
+    public DorisEsException(String msg) {
         super(msg);
     }
 }

--- a/fe/src/main/java/org/apache/doris/external/elasticsearch/EsFieldInfos.java
+++ b/fe/src/main/java/org/apache/doris/external/elasticsearch/EsFieldInfos.java
@@ -64,7 +64,7 @@ public class EsFieldInfos {
      * @return fieldsContext and docValueContext
      * @throws Exception
      */
-    public static EsFieldInfos fromMapping(List<Column> colList, String indexName, String indexMapping, String docType) throws ExternalDataSourceException {
+    public static EsFieldInfos fromMapping(List<Column> colList, String indexName, String indexMapping, String docType) throws DorisEsException {
         JSONObject jsonObject = new JSONObject(indexMapping);
         // the indexName use alias takes the first mapping
         Iterator<String> keys = jsonObject.keys();
@@ -103,7 +103,7 @@ public class EsFieldInfos {
             properties = rootSchema.optJSONObject("properties");
         }
         if (properties == null) {
-            throw new ExternalDataSourceException( "index[" + indexName + "] type[" + docType + "] mapping not found for the Elasticsearch Cluster");
+            throw new DorisEsException( "index[" + indexName + "] type[" + docType + "] mapping not found for the Elasticsearch Cluster");
         }
         return parseProperties(colList, properties);
     }

--- a/fe/src/main/java/org/apache/doris/external/elasticsearch/EsRestClient.java
+++ b/fe/src/main/java/org/apache/doris/external/elasticsearch/EsRestClient.java
@@ -95,7 +95,7 @@ public class EsRestClient {
         String path = indexName + "/_mapping";
         String indexMapping = execute(path);
         if (indexMapping == null) {
-            throw new ExternalDataSourceException( "index[" + indexName + "] not found for the Elasticsearch Cluster");
+            throw new DorisEsException( "index[" + indexName + "] not found for the Elasticsearch Cluster");
         }
         return EsFieldInfos.fromMapping(colList, indexName, indexMapping, docType);
     }
@@ -105,7 +105,7 @@ public class EsRestClient {
         String path = indexName + "/_search_shards";
         String searchShards = execute(path);
         if (searchShards == null) {
-            throw new ExternalDataSourceException( "index[" + indexName + "] search_shards not found for the Elasticsearch Cluster");
+            throw new DorisEsException( "index[" + indexName + "] search_shards not found for the Elasticsearch Cluster");
         }
         return EsShardPartitions.findShardPartitions(indexName, searchShards);
     }

--- a/fe/src/main/java/org/apache/doris/external/elasticsearch/EsShardRouting.java
+++ b/fe/src/main/java/org/apache/doris/external/elasticsearch/EsShardRouting.java
@@ -18,10 +18,10 @@
 package org.apache.doris.external.elasticsearch;
 
 
+import org.apache.doris.thrift.TNetworkAddress;
 import org.apache.commons.lang.StringUtils;
 import org.json.JSONObject;
 
-import org.apache.doris.thrift.TNetworkAddress;
 
 public class EsShardRouting {
 
@@ -41,9 +41,8 @@ public class EsShardRouting {
         this.nodeId = nodeId;
     }
     
-    public static EsShardRouting parseShardRouting(String indexName, String shardKey,
-            JSONObject shardInfo, JSONObject nodesMap) {
-        String nodeId = shardInfo.getString("node");
+    public static EsShardRouting newSearchShard(String indexName, int shardId, boolean isPrimary,
+            String nodeId, JSONObject nodesMap) {
         JSONObject nodeInfo = nodesMap.getJSONObject(nodeId);
         String[] transportAddr = nodeInfo.getString("transport_address").split(":");
         // get thrift port from node info
@@ -53,9 +52,7 @@ public class EsShardRouting {
         if (!StringUtils.isEmpty(thriftPort)) {
             addr = new TNetworkAddress(transportAddr[0], Integer.parseInt(thriftPort));
         }
-        boolean isPrimary = shardInfo.getBoolean("primary");
-        return new EsShardRouting(indexName, Integer.parseInt(shardKey),
-                isPrimary, addr, nodeId);
+        return new EsShardRouting(indexName, shardId, isPrimary, addr, nodeId);
     }
     
     public int getShardId() {

--- a/fe/src/main/java/org/apache/doris/external/elasticsearch/EsTablePartitions.java
+++ b/fe/src/main/java/org/apache/doris/external/elasticsearch/EsTablePartitions.java
@@ -17,12 +17,6 @@
 
 package org.apache.doris.external.elasticsearch;
 
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Map;
-import java.util.Random;
-
 import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.EsTable;
 import org.apache.doris.catalog.PartitionInfo;
@@ -31,10 +25,18 @@ import org.apache.doris.catalog.RangePartitionInfo;
 import org.apache.doris.catalog.SinglePartitionInfo;
 import org.apache.doris.common.DdlException;
 import org.apache.doris.thrift.TNetworkAddress;
-import com.google.common.collect.Maps;
-import com.google.common.collect.Range;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+
+import com.google.common.collect.Maps;
+import com.google.common.collect.Range;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
 
 /**
  * save the dynamic info parsed from es cluster state such as shard routing, partition info
@@ -56,7 +58,7 @@ public class EsTablePartitions {
     }
 
     public static EsTablePartitions fromShardPartitions(EsTable esTable, EsShardPartitions shardPartitions)
-            throws ExternalDataSourceException, DdlException {
+            throws DorisEsException, DdlException {
         EsTablePartitions esTablePartitions = new EsTablePartitions();
         RangePartitionInfo partitionInfo = null;
         if (esTable.getPartitionInfo() != null) {
@@ -82,7 +84,7 @@ public class EsTablePartitions {
                 LOG.debug("begin to parse es table [{}] state from search shards, "
                         + "with no partition info", esTable.getName());
             } else {
-                throw new ExternalDataSourceException("es table only support range partition, "
+                throw new DorisEsException("es table only support range partition, "
                         + "but current partition type is "
                         + esTable.getPartitionInfo().getType());
             }

--- a/fe/src/main/java/org/apache/doris/planner/EsScanNode.java
+++ b/fe/src/main/java/org/apache/doris/planner/EsScanNode.java
@@ -40,15 +40,15 @@ import org.apache.doris.thrift.TScanRange;
 import org.apache.doris.thrift.TScanRangeLocation;
 import org.apache.doris.thrift.TScanRangeLocations;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Range;
 import com.google.common.collect.Sets;
-
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -214,7 +214,7 @@ public class EsScanNode extends ScanNode {
                 // Generate on es scan range
                 TEsScanRange esScanRange = new TEsScanRange();
                 esScanRange.setEs_hosts(shardAllocations);
-                esScanRange.setIndex(indexState.getIndexName());
+                esScanRange.setIndex(shardRouting.get(0).getIndexName());
                 esScanRange.setType(table.getMappingType());
                 esScanRange.setShard_id(shardRouting.get(0).getShardId());
                 // Scan range

--- a/fe/src/test/java/org/apache/doris/external/elasticsearch/EsRepositoryTest.java
+++ b/fe/src/test/java/org/apache/doris/external/elasticsearch/EsRepositoryTest.java
@@ -91,7 +91,7 @@ public class EsRepositoryTest {
         
     }
     
-    @Test(expected = ExternalDataSourceException.class)
+    @Test(expected = DorisEsException.class)
     public void testSetErrorType() throws Exception {
         EsTable esTable = (EsTable) Catalog.getCurrentCatalog()
                 .getDb(CatalogTestUtil.testDb1)
@@ -101,7 +101,7 @@ public class EsRepositoryTest {
     }
     
     @Test
-    public void testSetTableState() throws ExternalDataSourceException, DdlException {
+    public void testSetTableState() throws DorisEsException, DdlException {
         EsTable esTable = (EsTable) Catalog.getCurrentCatalog()
                 .getDb(CatalogTestUtil.testDb1)
                 .getTable(CatalogTestUtil.testEsTableId1);


### PR DESCRIPTION
https://github.com/apache/incubator-doris/issues/3967

Create multiple index with same mapping in ES:

```
PUT wildcard_1
{
   "settings": {
      "number_of_replicas": 0,
      "number_of_shards": 1
   },
   "mappings": {
      "doc": {
         "properties": {
            "k1": {
               "type": "integer"
            },
            "k2": {
               "type": "keyword"
            }
         }
      }
   }
}

PUT wildcard_2
{
   "settings": {
      "number_of_replicas": 0,
      "number_of_shards": 1
   },
   "mappings": {
      "doc": {
         "properties": {
            "k1": {
               "type": "integer"
            },
            "index": {
               "type": "keyword"
            }
         }
      }
   }
}

PUT wildcard_3
{
   "settings": {
      "number_of_replicas": 0,
      "number_of_shards": 1
   },
   "mappings": {
      "doc": {
         "properties": {
            "k1": {
               "type": "integer"
            },
            "index": {
               "type": "keyword"
            }
         }
      }
   }
}
```

`k2` used for indicating the data from which index

Create `wildcard_alias` aliases contains those above three index:

```
POST /_aliases
{
   "actions": [
      {
         "add": {
            "indices": [
               "wildcard_3",
               "wildcard_2",
               "wildcard_1"
            ],
            "alias": "wildcard_alias"
         }
      }
   ]
}
```
Create ES external table within Doris:

* Support `aliase` matched index:
```
CREATE EXTERNAL TABLE `wildcard_alias` (
  `k1` int COMMENT "",
   `k2`  varchar COMMENT ""
) ENGINE=ELASTICSEARCH
PROPERTIES (
"hosts" = "http://127.0.0.1:8200",
"user" = "root",
"password" = "root",
"index" = "wildcard_alias",
"type" = "doc",
"version" = "6.5.3",
"enable_docvalue_scan" = "true"
);
```

* Support `wildcard` matched index (pattern: `wildcard_*`):

```
CREATE EXTERNAL TABLE `wildcard_alias` (
  `k1` int COMMENT "",
   `k2`  varchar COMMENT ""
) ENGINE=ELASTICSEARCH
PROPERTIES (
"hosts" = "http://10.74.167.16:8200",
"user" = "root",
"password" = "root",
"index" = "wildcard_*",
"type" = "doc",
"version" = "6.5.3",
"enable_docvalue_scan" = "true"
);
```

And execute SQL on Doris:

```
 select * from wildcard_alias;
  or
 select * from wildcard;
```

Finally we get all document within those three index:

```
+------+-------------+
| k1   | k2          |
+------+-------------+
|  111 | wiladcard_1 |
| 1111 | wiladcard_1 |
| 1112 | wiladcard_1 |
|  110 | wiladcard_1 |
|  222 | wiladcard_2 |
|  223 | wiladcard_2 |
|  223 | wiladcard_2 |
|   33 | wiladcard_3 |
|   33 | wiladcard_3 |
|   33 | wiladcard_3 |
|   33 | wiladcard_3 |
|   33 | wiladcard_3 |
+------+-------------+
```
BTW: predicates which can push down would push down to all related indices
