### PR TITLE
[shell] Fix BUILD_TYPE not used bug

### DIFF
--- a/run-ut.sh
+++ b/run-ut.sh
@@ -76,20 +76,23 @@ else
     done
 fi
 
+CMAKE_BUILD_TYPE=${BUILD_TYPE:-ASAN}
+CMAKE_BUILD_TYPE="${CMAKE_BUILD_TYPE^^}"
 echo "Build Backend UT"
 
+CMAKE_BUILD_DIR=${DORIS_HOME}/be/ut_build_${CMAKE_BUILD_TYPE}
 if [ ${CLEAN} -eq 1 ]; then
-    rm ${DORIS_HOME}/be/ut_build/ -rf
+    rm ${CMAKE_BUILD_DIR} -rf
     rm ${DORIS_HOME}/be/output/ -rf
 fi
 
-if [ ! -d ${DORIS_HOME}/be/ut_build ]; then
-    mkdir -p ${DORIS_HOME}/be/ut_build/
+if [ ! -d ${CMAKE_BUILD_DIR} ]; then
+    mkdir -p ${CMAKE_BUILD_DIR}
 fi
 
-cd ${DORIS_HOME}/be/ut_build/
+cd ${CMAKE_BUILD_DIR}
 
-${CMAKE_CMD} ../ -DWITH_MYSQL=OFF -DMAKE_TEST=ON -DCMAKE_BUILD_TYPE=ASAN
+${CMAKE_CMD} ../ -DWITH_MYSQL=OFF -DMAKE_TEST=ON -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
 make -j${PARALLEL}
 
 if [ ${RUN} -ne 1 ]; then


### PR DESCRIPTION
We can build unit tests by specify BUILD_TYPE to DEBUG/RELEASE/LSAN/ASAN,
and outputs in each mode will be placed to different directories, it will
save time if rebuild in a same mode.