### PR TITLE
Use ThreadPoolManager to manage some native thread

### DIFF
--- a/fe/src/main/java/org/apache/doris/common/ThreadPoolManager.java
+++ b/fe/src/main/java/org/apache/doris/common/ThreadPoolManager.java
@@ -30,6 +30,8 @@ import java.util.Map;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.RejectedExecutionHandler;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
@@ -111,6 +113,13 @@ public class ThreadPoolManager {
         ThreadPoolExecutor threadPool = new ThreadPoolExecutor(corePoolSize, maximumPoolSize, keepAliveTime, unit, workQueue, threadFactory, handler);
         nameToThreadPoolMap.put(poolName, threadPool);
         return threadPool;
+    }
+
+    public static ScheduledThreadPoolExecutor newScheduledThreadPool(int maxNumThread, String poolName) {
+        ThreadFactory threadFactory = namedThreadFactory(poolName);
+        ScheduledThreadPoolExecutor scheduledThreadPoolExecutor = new ScheduledThreadPoolExecutor(maxNumThread, threadFactory);
+        nameToThreadPoolMap.put(poolName, scheduledThreadPoolExecutor);
+        return scheduledThreadPoolExecutor;
     }
 
     /**

--- a/fe/src/main/java/org/apache/doris/common/ThreadPoolManager.java
+++ b/fe/src/main/java/org/apache/doris/common/ThreadPoolManager.java
@@ -30,7 +30,6 @@ import java.util.Map;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.RejectedExecutionHandler;
-import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadFactory;

--- a/fe/src/main/java/org/apache/doris/common/publish/FixedTimePublisher.java
+++ b/fe/src/main/java/org/apache/doris/common/publish/FixedTimePublisher.java
@@ -18,6 +18,7 @@
 package org.apache.doris.common.publish;
 
 import org.apache.doris.common.Config;
+import org.apache.doris.common.ThreadPoolManager;
 
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -27,7 +28,7 @@ import java.util.concurrent.TimeUnit;
 public class FixedTimePublisher {
     private static FixedTimePublisher INSTANCE;
 
-    private ScheduledThreadPoolExecutor scheduler = new ScheduledThreadPoolExecutor(1);
+    private ScheduledThreadPoolExecutor scheduler = ThreadPoolManager.newScheduledThreadPool(1, "Fixed-Time-Publisher");
     private ClusterStatePublisher publisher;
 
     public FixedTimePublisher(ClusterStatePublisher publisher) {

--- a/fe/src/main/java/org/apache/doris/metric/MetricRepo.java
+++ b/fe/src/main/java/org/apache/doris/metric/MetricRepo.java
@@ -22,6 +22,7 @@ import org.apache.doris.alter.AlterJob.JobType;
 import org.apache.doris.catalog.Catalog;
 import org.apache.doris.catalog.TabletInvertedIndex;
 import org.apache.doris.common.Config;
+import org.apache.doris.common.ThreadPoolManager;
 import org.apache.doris.load.EtlJobType;
 import org.apache.doris.load.loadv2.JobState;
 import org.apache.doris.load.loadv2.LoadManager;
@@ -42,7 +43,8 @@ import org.apache.logging.log4j.Logger;
 import java.util.List;
 import java.util.Map;
 import java.util.SortedMap;
-import java.util.Timer;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 public final class MetricRepo {
@@ -84,7 +86,7 @@ public final class MetricRepo {
     public static GaugeMetricImpl<Double> GAUGE_QUERY_ERR_RATE;
     public static GaugeMetricImpl<Long> GAUGE_MAX_TABLET_COMPACTION_SCORE;
 
-    private static Timer metricTimer = new Timer();
+    private static ScheduledThreadPoolExecutor metricTimer = ThreadPoolManager.newScheduledThreadPool(1, "Metric-Timer-Pool");
     private static MetricCalculator metricCalculator = new MetricCalculator();
 
     public static synchronized void init() {
@@ -249,7 +251,7 @@ public final class MetricRepo {
         isInit.set(true);
 
         if (Config.enable_metric_calculator) {
-            metricTimer.scheduleAtFixedRate(metricCalculator, 0, 15 * 1000 /* 15s */);
+            metricTimer.scheduleAtFixedRate(metricCalculator, 0, 15 * 1000L, TimeUnit.MILLISECONDS);
         }
     }
 

--- a/fe/src/main/java/org/apache/doris/mysql/MysqlServer.java
+++ b/fe/src/main/java/org/apache/doris/mysql/MysqlServer.java
@@ -102,7 +102,7 @@ public class MysqlServer {
         @Override
         public void run() {
             while (running && serverChannel.isOpen()) {
-                SocketChannel clientChannel = null;
+                SocketChannel clientChannel;
                 try {
                     clientChannel = serverChannel.accept();
                     if (clientChannel == null) {

--- a/fe/src/main/java/org/apache/doris/mysql/MysqlServer.java
+++ b/fe/src/main/java/org/apache/doris/mysql/MysqlServer.java
@@ -71,9 +71,8 @@ public class MysqlServer {
 
         // start accept thread
         listener = ThreadPoolManager.newDaemonCacheThreadPool(1, "MySQL-Protocol-Listener");
-        listenerFuture = listener.submit(new Listener());
-
         running = true;
+        listenerFuture = listener.submit(new Listener());
 
         return true;
     }

--- a/fe/src/main/java/org/apache/doris/mysql/MysqlServer.java
+++ b/fe/src/main/java/org/apache/doris/mysql/MysqlServer.java
@@ -18,7 +18,6 @@
 package org.apache.doris.mysql;
 
 import org.apache.doris.catalog.Catalog;
-import org.apache.doris.common.Config;
 import org.apache.doris.common.ThreadPoolManager;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.ConnectScheduler;
@@ -29,7 +28,6 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.nio.channels.ServerSocketChannel;
 import java.nio.channels.SocketChannel;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.ThreadPoolExecutor;
 

--- a/fe/src/main/java/org/apache/doris/qe/ConnectScheduler.java
+++ b/fe/src/main/java/org/apache/doris/qe/ConnectScheduler.java
@@ -32,9 +32,10 @@ import org.apache.logging.log4j.Logger;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Timer;
 import java.util.TimerTask;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 // 查询请求的调度器
@@ -53,14 +54,14 @@ public class ConnectScheduler {
     // 1. If use a scheduler, the task maybe a huge number when query is messy.
     //    Let timeout is 10m, and 5000 qps, then there are up to 3000000 tasks in scheduler.
     // 2. Use a thread to poll maybe lose some accurate, but is enough to us.
-    private Timer checkTimer;
+    private ScheduledExecutorService checkTimer = ThreadPoolManager.newScheduledThreadPool(1,
+            "Connect-Scheduler-Check-Timer");
 
     public ConnectScheduler(int maxConnections) {
         this.maxConnections = maxConnections;
         numberConnection = 0;
         nextConnectionId = new AtomicInteger(0);
-        checkTimer = new Timer("ConnectScheduler Check Timer", true);
-        checkTimer.scheduleAtFixedRate(new TimeoutChecker(), 0, 1000);
+        checkTimer.scheduleAtFixedRate(new TimeoutChecker(), 0, 1000L, TimeUnit.MILLISECONDS);
     }
 
     private class TimeoutChecker extends TimerTask {

--- a/fe/src/main/java/org/apache/doris/task/MasterTaskExecutor.java
+++ b/fe/src/main/java/org/apache/doris/task/MasterTaskExecutor.java
@@ -26,7 +26,6 @@ import org.apache.logging.log4j.Logger;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;

--- a/fe/src/main/java/org/apache/doris/task/MasterTaskExecutor.java
+++ b/fe/src/main/java/org/apache/doris/task/MasterTaskExecutor.java
@@ -19,6 +19,7 @@ package org.apache.doris.task;
 
 import com.google.common.collect.Maps;
 
+import org.apache.doris.common.ThreadPoolManager;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -37,7 +38,7 @@ public class MasterTaskExecutor {
     private Map<Long, Future<?>> runningTasks;
 
     public MasterTaskExecutor(int threadNum) {
-        executor = Executors.newScheduledThreadPool(threadNum);
+        executor = ThreadPoolManager.newScheduledThreadPool(threadNum, "Master-Task-Executor-Pool");
         runningTasks = Maps.newHashMap();
         executor.scheduleAtFixedRate(new TaskChecker(), 0L, 1000L, TimeUnit.MILLISECONDS);
     }


### PR DESCRIPTION
Now, FE use ThreadPoolManager to manage and monitor all Thread, but there are stil some threads are not managed. And FE use `Timer` class to do some scheduler task, but `Timer` class has some problem and is out of date, It should replace by ScheduledThreadPool.