### PR TITLE
Fix except node child not order correctly

### DIFF
--- a/fe/src/test/java/org/apache/doris/planner/PlannerTest.java
+++ b/fe/src/test/java/org/apache/doris/planner/PlannerTest.java
@@ -231,6 +231,16 @@ public class PlannerTest {
         Assert.assertEquals(2, StringUtils.countMatches(plan9, "UNION"));
         Assert.assertEquals(3, StringUtils.countMatches(plan9, "INTERSECT"));
         Assert.assertEquals(2, StringUtils.countMatches(plan9, "EXCEPT"));
+
+        String sql10 = "select 499 union select 670 except select 499";
+        StmtExecutor stmtExecutor10 = new StmtExecutor(ctx, sql10);
+        stmtExecutor10.execute();
+        Planner planner10 = stmtExecutor10.planner();
+        List<PlanFragment> fragments10 = planner10.getFragments();
+        Assert.assertTrue(fragments10.get(0).getPlanRoot().getFragment()
+                .getPlanRoot().getChild(0) instanceof AggregationNode);
+        Assert.assertTrue(fragments10.get(0).getPlanRoot()
+                .getFragment().getPlanRoot().getChild(1) instanceof UnionNode);
     }
 
 }


### PR DESCRIPTION
Fixes #3995 
## Why does it happen
When SetOperations encounters that the previous node needs Aggregate, the timing of add AggregationNode is wrong. You should add AggregationNode first before add other children.
## Why doesn't intersect and union have this problem
intersect and union conform to the commutation law, so it doesn't matter if the order is wrong
## Why this problem has not been tested before
In the previous test case, not cover the previous node was not AggregationNode