### PR TITLE
[ShowIndex] Make Show Index stmt act same as MySQL behavior

### DIFF
--- a/fe/src/test/java/org/apache/doris/analysis/ShowIndexStmtTest.java
+++ b/fe/src/test/java/org/apache/doris/analysis/ShowIndexStmtTest.java
@@ -40,7 +40,7 @@ public class ShowIndexStmtTest {
 
     @Before
     public void setUp() {
-        analyzer = AccessTestUtil.fetchAdminAnalyzer(false);
+        analyzer = AccessTestUtil.fetchAdminAnalyzer(true);
         MockedAuth.mockedAuth(auth);
         MockedAuth.mockedConnectContext(ctx, "root", "192.168.1.1");
     }
@@ -49,13 +49,16 @@ public class ShowIndexStmtTest {
     public void testNormal() throws UserException {
         ShowIndexStmt stmt = new ShowIndexStmt("testDb", new TableName("", "testTbl"));
         stmt.analyze(analyzer);
-        Assert.assertEquals("SHOW INDEX FROM `testDb`.`testTbl`", stmt.toSql());
+        Assert.assertEquals("SHOW INDEX FROM `testCluster:testDb`.`testTbl`", stmt.toSql());
         stmt = new ShowIndexStmt("", new TableName("", "testTbl"));
         stmt.analyze(analyzer);
-        Assert.assertEquals("SHOW INDEX FROM `testDb`.`testTbl`", stmt.toSql());
+        Assert.assertEquals("SHOW INDEX FROM `testCluster:testDb`.`testTbl`", stmt.toSql());
         stmt = new ShowIndexStmt(null, new TableName("testDb", "testTbl"));
         stmt.analyze(analyzer);
-        Assert.assertEquals("SHOW INDEX FROM `testDb`.`testTbl`", stmt.toSql());
+        Assert.assertEquals("SHOW INDEX FROM `testCluster:testDb`.`testTbl`", stmt.toSql());
+        stmt = new ShowIndexStmt("testDb", new TableName("testDb2", "testTbl"));
+        stmt.analyze(analyzer);
+        Assert.assertEquals("SHOW INDEX FROM `testCluster:testDb`.`testTbl`", stmt.toSql());
     }
 
     @Test(expected = AnalysisException.class)


### PR DESCRIPTION
`SHOW INDEX FROM db2.tbl1 FROM db1;` will be same as
`SHOW INDEX FROM db1.tbl1;`