### PR TITLE
Remove rs when version conflict when insert to a tablet

### DIFF
--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -849,11 +849,8 @@ bool Tablet::_drop_rowset_if_version_conflict(const RowsetSharedPtr& rowset) {
         vector<RowsetSharedPtr> to_delete;
         to_delete.push_back(exist_rs);
         modify_rowsets(to_add, to_delete);
-        std::stringstream ss;
-        ss << "Remove rs " << exist_rs->rowset_id().to_string();
-        ss << " in " << full_name();
-        ss << " for version conflict with " << rowset->rowset_id().to_string();
-        LOG(WARNING) << ss.str();
+        LOG(WARNING) << "Remove rs " << exist_rs->rowset_id().to_string() << " in " << full_name()
+        << " for version conflict with " << rowset->rowset_id().to_string();
         return true;
     }
     return false;

--- a/be/src/olap/tablet.h
+++ b/be/src/olap/tablet.h
@@ -230,6 +230,7 @@ private:
     OLAPStatus _init_once_action();
     void _print_missed_versions(const std::vector<Version>& missed_versions) const;
     bool _contains_rowset(const RowsetId rowset_id);
+    bool _drop_rowset_if_version_conflict(const RowsetSharedPtr& rowset);
     OLAPStatus _contains_version(const Version& version);
     void _max_continuous_version_from_begining_unlocked(Version* version,
                                                         VersionHash* v_hash) const ;


### PR DESCRIPTION
For #3976 
In this PR, when insert to a tablet, if the tablet has a different rs with the same version, remove it.