### PR TITLE
[Bug][Memroy Leak]Fix bug TransactionState is not clear from idToFinalStatusTransactionState

### DIFF
--- a/fe/src/main/java/org/apache/doris/transaction/DatabaseTransactionMgr.java
+++ b/fe/src/main/java/org/apache/doris/transaction/DatabaseTransactionMgr.java
@@ -563,12 +563,7 @@ public class DatabaseTransactionMgr {
             if (!finalStatusTransactionStateDeque.isEmpty() &&
             transactionState.getTransactionId() == finalStatusTransactionStateDeque.getFirst().getTransactionId()) {
                 finalStatusTransactionStateDeque.pop();
-                idToFinalStatusTransactionState.remove(transactionState.getTransactionId());
-                Set<Long> txnIds = unprotectedGetTxnIdsByLabel(transactionState.getLabel());
-                txnIds.remove(transactionState.getTransactionId());
-                if (txnIds.isEmpty()) {
-                    labelToTxnIds.remove(transactionState.getLabel());
-                }
+                clearTransactionState(transactionState);
             }
         } finally {
             writeUnlock();
@@ -1030,11 +1025,7 @@ public class DatabaseTransactionMgr {
                 TransactionState transactionState = finalStatusTransactionStateDeque.getFirst();
                 if (transactionState.isExpired(currentMillis)) {
                     finalStatusTransactionStateDeque.pop();
-                    Set<Long> txnIds = unprotectedGetTxnIdsByLabel(transactionState.getLabel());
-                    txnIds.remove(transactionState.getTransactionId());
-                    if (txnIds.isEmpty()) {
-                        labelToTxnIds.remove(transactionState.getLabel());
-                    }
+                    clearTransactionState(transactionState);
                     editLog.logDeleteTransactionState(transactionState);
                     LOG.info("transaction [" + transactionState.getTransactionId() + "] is expired, remove it from transaction manager");
                 } else {
@@ -1044,6 +1035,15 @@ public class DatabaseTransactionMgr {
             }
         } finally {
             writeUnlock();
+        }
+    }
+
+    private void clearTransactionState(TransactionState transactionState) {
+        idToFinalStatusTransactionState.remove(transactionState.getTransactionId());
+        Set<Long> txnIds = unprotectedGetTxnIdsByLabel(transactionState.getLabel());
+        txnIds.remove(transactionState.getTransactionId());
+        if (txnIds.isEmpty()) {
+            labelToTxnIds.remove(transactionState.getLabel());
         }
     }
 


### PR DESCRIPTION
This CL includes:
1. Memory leak because transactionState is not removed.
2. Extacting the clear logic to method to avoid forget.