### PR TITLE
Add framework of mv selector

### DIFF
--- a/fe/src/main/java/org/apache/doris/alter/RollupJobV2.java
+++ b/fe/src/main/java/org/apache/doris/alter/RollupJobV2.java
@@ -19,7 +19,6 @@ package org.apache.doris.alter;
 
 import org.apache.doris.analysis.CreateMaterializedViewStmt;
 import org.apache.doris.analysis.Expr;
-import org.apache.doris.analysis.MVColumnItem;
 import org.apache.doris.analysis.SqlParser;
 import org.apache.doris.analysis.SqlScanner;
 import org.apache.doris.catalog.Catalog;
@@ -732,11 +731,11 @@ public class RollupJobV2 extends AlterJobV2 implements GsonPostProcessable {
         this.jobState = jobState;
     }
 
-    private void setColumnsDefineExpr(List<MVColumnItem> items) {
-        for (MVColumnItem item : items) {
+    private void setColumnsDefineExpr(Map<String, Expr> columnNameToDefineExpr) {
+        for (Entry<String, Expr> entry : columnNameToDefineExpr.entrySet()) {
             for (Column column : rollupSchema) {
-                if (column.getName().equals(item.getName())) {
-                    column.setDefineExpr(item.getDefineExpr());
+                if (column.getName().equals(entry.getKey())) {
+                    column.setDefineExpr(entry.getValue());
                     break;
                 }
             }
@@ -812,8 +811,8 @@ public class RollupJobV2 extends AlterJobV2 implements GsonPostProcessable {
         CreateMaterializedViewStmt stmt;
         try {
             stmt = (CreateMaterializedViewStmt) SqlParserUtils.getStmt(parser, origStmt.idx);
-            stmt.analyzeSelectClause();
-            setColumnsDefineExpr(stmt.getMVColumnItemList());
+            Map<String, Expr> columnNameToDefineExpr = stmt.parseDefineExprWithoutAnalyze();
+            setColumnsDefineExpr(columnNameToDefineExpr);
         } catch (Exception e) {
             throw new IOException("error happens when parsing create materialized view stmt: " + origStmt, e);
         }

--- a/fe/src/main/java/org/apache/doris/analysis/AggregateInfo.java
+++ b/fe/src/main/java/org/apache/doris/analysis/AggregateInfo.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.analysis;
 
+import org.apache.doris.catalog.FunctionSet;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.planner.DataPartition;
 import org.apache.doris.thrift.TPartitionType;
@@ -532,7 +533,7 @@ public final class AggregateInfo extends AggregateInfoBase {
             Preconditions.checkState(inputExpr.isAggregateFunction());
             FunctionCallExpr aggExpr = null;
             if (!isMultiDistinct_) {
-                if (inputExpr.getFnName().getFunction().equalsIgnoreCase("COUNT")) {
+                if (inputExpr.getFnName().getFunction().equalsIgnoreCase(FunctionSet.COUNT)) {
                     // COUNT(DISTINCT ...) ->
                     // COUNT(IF(IsNull(<agg slot 1>), NULL, IF(IsNull(<agg slot 2>), NULL, ...)))
                     // We need the nested IF to make sure that we do not count
@@ -543,7 +544,7 @@ public final class AggregateInfo extends AggregateInfoBase {
                             inputDesc.getSlots());
                     Preconditions.checkNotNull(ifExpr);
                     ifExpr.analyzeNoThrow(analyzer);
-                    aggExpr = new FunctionCallExpr("count", Lists.newArrayList(ifExpr));
+                    aggExpr = new FunctionCallExpr(FunctionSet.COUNT, Lists.newArrayList(ifExpr));
                 } else if (inputExpr.getFnName().getFunction().equals("group_concat")) {
                     // Syntax: GROUP_CONCAT([DISTINCT] expression [, separator])
                     ArrayList<Expr> exprList = Lists.newArrayList();

--- a/fe/src/main/java/org/apache/doris/analysis/AggregateInfoBase.java
+++ b/fe/src/main/java/org/apache/doris/analysis/AggregateInfoBase.java
@@ -150,7 +150,7 @@ public abstract class AggregateInfoBase {
 
                 // COUNT(), NDV() and NDV_NO_FINALIZE() are non-nullable. The latter two are used
                 // by compute stats and compute incremental stats, respectively.
-                if (aggExpr.getFnName().getFunction().equals("count")
+                if (aggExpr.getFnName().getFunction().equals(FunctionSet.COUNT)
                         || aggExpr.getFnName().getFunction().equals("ndv")
                         || aggExpr.getFnName().getFunction().equals(FunctionSet.BITMAP_UNION_INT)
                         || aggExpr.getFnName().getFunction().equals("ndv_no_finalize")) {

--- a/fe/src/main/java/org/apache/doris/analysis/AnalyticExpr.java
+++ b/fe/src/main/java/org/apache/doris/analysis/AnalyticExpr.java
@@ -87,7 +87,7 @@ public class AnalyticExpr extends Expr {
     private static String SUM = "SUM";
     private static String COUNT = "COUNT";
 
-    // Internal function used to implement FIRST_VALUE with a window rewrite and
+    // Internal function used to implement FIRST_VALUE with a window equal and
     // additional null handling in the backend.
     public static String FIRST_VALUE_REWRITE = "FIRST_VALUE_REWRITE";
 
@@ -241,7 +241,7 @@ public class AnalyticExpr extends Expr {
      * percent_rank(), cume_dist() and ntile()
      *
      * Returns a new Expr if the analytic expr is rewritten, returns null if it's not one
-     * that we want to rewrite.
+     * that we want to equal.
      */
     public static Expr rewrite(AnalyticExpr analyticExpr) {
         Function fn = analyticExpr.getFnCall().getFn();

--- a/fe/src/main/java/org/apache/doris/analysis/BetweenPredicate.java
+++ b/fe/src/main/java/org/apache/doris/analysis/BetweenPredicate.java
@@ -23,7 +23,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 /**
- * Class describing between predicates. After successful analysis, we rewrite
+ * Class describing between predicates. After successful analysis, we equal
  * the between predicate to a conjunctive/disjunctive compound predicate
  * to be handed to the backend.
  */

--- a/fe/src/main/java/org/apache/doris/analysis/CaseWhenClause.java
+++ b/fe/src/main/java/org/apache/doris/analysis/CaseWhenClause.java
@@ -21,7 +21,7 @@ package org.apache.doris.analysis;
 /**
  * captures info of a single WHEN expr THEN expr clause.
  */
-class CaseWhenClause {
+public class CaseWhenClause {
     private final Expr whenExpr;
     private final Expr thenExpr;
 

--- a/fe/src/main/java/org/apache/doris/analysis/CastExpr.java
+++ b/fe/src/main/java/org/apache/doris/analysis/CastExpr.java
@@ -137,10 +137,14 @@ public class CastExpr extends Expr {
         if (isImplicit) {
             return getChild(0).toSql();
         }
-        if (type.isStringType()) {
-            return "CAST(" + getChild(0).toSql() + " AS " + "CHARACTER" + ")";
+        if (isAnalyzed) {
+            if (type.isStringType()) {
+                return "CAST(" + getChild(0).toSql() + " AS " + "CHARACTER" + ")";
+            } else {
+                return "CAST(" + getChild(0).toSql() + " AS " + type.toString() + ")";
+            }
         } else {
-            return "CAST(" + getChild(0).toSql() + " AS " + type.toString() + ")";
+            return "CAST(" + getChild(0).toSql() + " AS " + targetTypeDef.toSql() + ")";
         }
     }
 

--- a/fe/src/main/java/org/apache/doris/analysis/CastExpr.java
+++ b/fe/src/main/java/org/apache/doris/analysis/CastExpr.java
@@ -43,7 +43,7 @@ public class CastExpr extends Expr {
     private final TypeDef targetTypeDef;
 
     // True if this is a "pre-analyzed" implicit cast.
-    private final boolean isImplicit;
+    private boolean isImplicit;
 
     // True if this cast does not change the type.
     private boolean noOp = false;
@@ -169,6 +169,10 @@ public class CastExpr extends Expr {
 
     public boolean isImplicit() {
         return isImplicit;
+    }
+
+    public void setImplicit(boolean implicit) {
+        isImplicit = implicit;
     }
 
     public void analyze() throws AnalysisException {

--- a/fe/src/main/java/org/apache/doris/analysis/ColumnDef.java
+++ b/fe/src/main/java/org/apache/doris/analysis/ColumnDef.java
@@ -68,7 +68,7 @@ public class ColumnDef {
         public static DefaultValue NOT_SET = new DefaultValue(false, null);
         // default null
         public static DefaultValue NULL_DEFAULT_VALUE = new DefaultValue(true, null);
-        private static String ZERO = new String(new byte[] {0});
+        public static String ZERO = new String(new byte[] {0});
         // default "value", "0" means empty hll
         public static DefaultValue HLL_EMPTY_DEFAULT_VALUE = new DefaultValue(true, ZERO);
         // default "value", "0" means empty bitmap

--- a/fe/src/main/java/org/apache/doris/analysis/CreateMaterializedViewStmt.java
+++ b/fe/src/main/java/org/apache/doris/analysis/CreateMaterializedViewStmt.java
@@ -54,19 +54,19 @@ import java.util.Set;
  */
 public class CreateMaterializedViewStmt extends DdlStmt {
     public static final String MATERIALIZED_VIEW_NAME_PREFIX = "mv_";
-    public static final Map<String, MVColumnPattern> fnNameToPattern;
+    public static final Map<String, MVColumnPattern> FN_NAME_TO_PATTERN;
 
     static {
-        fnNameToPattern = Maps.newHashMap();
-        fnNameToPattern.put(AggregateType.SUM.name().toLowerCase(),
+        FN_NAME_TO_PATTERN = Maps.newHashMap();
+        FN_NAME_TO_PATTERN.put(AggregateType.SUM.name().toLowerCase(),
                 new MVColumnOneChildPattern(AggregateType.SUM.name().toLowerCase()));
-        fnNameToPattern.put(AggregateType.MIN.name().toLowerCase(),
+        FN_NAME_TO_PATTERN.put(AggregateType.MIN.name().toLowerCase(),
                 new MVColumnOneChildPattern(AggregateType.MIN.name().toLowerCase()));
-        fnNameToPattern.put(AggregateType.MAX.name().toLowerCase(),
+        FN_NAME_TO_PATTERN.put(AggregateType.MAX.name().toLowerCase(),
                 new MVColumnOneChildPattern(AggregateType.MAX.name().toLowerCase()));
-        fnNameToPattern.put("count", new MVColumnOneChildPattern("count"));
-        fnNameToPattern.put("bitmap_union", new MVColumnBitmapUnionPattern());
-        fnNameToPattern.put("hll_union", new MVColumnHLLUnionPattern());
+        FN_NAME_TO_PATTERN.put("count", new MVColumnOneChildPattern("count"));
+        FN_NAME_TO_PATTERN.put("bitmap_union", new MVColumnBitmapUnionPattern());
+        FN_NAME_TO_PATTERN.put("hll_union", new MVColumnHLLUnionPattern());
     }
 
     private String mvName;
@@ -187,7 +187,7 @@ public class CreateMaterializedViewStmt extends DdlStmt {
                 // Function must match pattern.
                 FunctionCallExpr functionCallExpr = (FunctionCallExpr) selectListItem.getExpr();
                 String functionName = functionCallExpr.getFnName().getFunction();
-                MVColumnPattern mvColumnPattern = fnNameToPattern.get(functionName.toLowerCase());
+                MVColumnPattern mvColumnPattern = FN_NAME_TO_PATTERN.get(functionName.toLowerCase());
                 if (mvColumnPattern == null) {
                     throw new AnalysisException(
                             "Materialized view does not support this function:" + functionCallExpr.toSqlImpl());

--- a/fe/src/main/java/org/apache/doris/analysis/CreateMaterializedViewStmt.java
+++ b/fe/src/main/java/org/apache/doris/analysis/CreateMaterializedViewStmt.java
@@ -18,6 +18,7 @@
 package org.apache.doris.analysis;
 
 import org.apache.doris.catalog.AggregateType;
+import org.apache.doris.catalog.FunctionSet;
 import org.apache.doris.catalog.KeysType;
 import org.apache.doris.catalog.PrimitiveType;
 import org.apache.doris.catalog.Type;
@@ -64,9 +65,9 @@ public class CreateMaterializedViewStmt extends DdlStmt {
                 new MVColumnOneChildPattern(AggregateType.MIN.name().toLowerCase()));
         FN_NAME_TO_PATTERN.put(AggregateType.MAX.name().toLowerCase(),
                 new MVColumnOneChildPattern(AggregateType.MAX.name().toLowerCase()));
-        FN_NAME_TO_PATTERN.put("count", new MVColumnOneChildPattern("count"));
-        FN_NAME_TO_PATTERN.put("bitmap_union", new MVColumnBitmapUnionPattern());
-        FN_NAME_TO_PATTERN.put("hll_union", new MVColumnHLLUnionPattern());
+        FN_NAME_TO_PATTERN.put(FunctionSet.COUNT, new MVColumnOneChildPattern(FunctionSet.COUNT));
+        FN_NAME_TO_PATTERN.put(FunctionSet.BITMAP_UNION, new MVColumnBitmapUnionPattern());
+        FN_NAME_TO_PATTERN.put(FunctionSet.HLL_UNION, new MVColumnHLLUnionPattern());
     }
 
     private String mvName;
@@ -354,19 +355,19 @@ public class CreateMaterializedViewStmt extends DdlStmt {
                 mvAggregateType = AggregateType.valueOf(functionName.toUpperCase());
                 type = Type.BIGINT;
                 break;
-            case "bitmap_union":
+            case FunctionSet.BITMAP_UNION:
                 mvColumnName = mvColumnBuilder(functionName, baseColumnName);
                 mvAggregateType = AggregateType.valueOf(functionName.toUpperCase());
                 defineExpr = functionChild0;
                 type = Type.BITMAP;
                 break;
-            case "hll_union":
+            case FunctionSet.HLL_UNION:
                 mvColumnName = mvColumnBuilder(functionName, baseColumnName);
                 mvAggregateType = AggregateType.valueOf(functionName.toUpperCase());
                 defineExpr = functionChild0;
                 type = Type.HLL;
                 break;
-            case "count":
+            case FunctionSet.COUNT:
                 mvColumnName = mvColumnBuilder(functionName, baseColumnName);
                 mvAggregateType = AggregateType.SUM;
                 defineExpr = new CaseExpr(null, Lists.newArrayList(new CaseWhenClause(

--- a/fe/src/main/java/org/apache/doris/analysis/CreateMaterializedViewStmt.java
+++ b/fe/src/main/java/org/apache/doris/analysis/CreateMaterializedViewStmt.java
@@ -421,6 +421,7 @@ public class CreateMaterializedViewStmt extends DdlStmt {
                     case FunctionSet.BITMAP_UNION:
                         if (functionCallExpr.getChild(0) instanceof FunctionCallExpr) {
                             CastExpr castExpr = new CastExpr(new TypeDef(Type.VARCHAR), baseSlotRef);
+                            castExpr.setImplicit(true);
                             List<Expr> params = Lists.newArrayList();
                             params.add(castExpr);
                             FunctionCallExpr defineExpr = new FunctionCallExpr(FunctionSet.TO_BITMAP, params);
@@ -432,6 +433,7 @@ public class CreateMaterializedViewStmt extends DdlStmt {
                     case FunctionSet.HLL_UNION:
                         if (functionCallExpr.getChild(0) instanceof FunctionCallExpr) {
                             CastExpr castExpr = new CastExpr(new TypeDef(Type.VARCHAR), baseSlotRef);
+                            castExpr.setImplicit(true);
                             List<Expr> params = Lists.newArrayList();
                             params.add(castExpr);
                             FunctionCallExpr defineExpr = new FunctionCallExpr(FunctionSet.HLL_HASH, params);

--- a/fe/src/main/java/org/apache/doris/analysis/CreateMaterializedViewStmt.java
+++ b/fe/src/main/java/org/apache/doris/analysis/CreateMaterializedViewStmt.java
@@ -365,7 +365,7 @@ public class CreateMaterializedViewStmt extends DdlStmt {
                     mvColumnName = baseColumnName;
                 } else {
                     mvColumnName = mvColumnBuilder(functionName, baseColumnName);
-                    defineExpr = functionChild0;
+                    defineExpr = functionChild0.reset();
                 }
                 mvAggregateType = AggregateType.valueOf(functionName.toUpperCase());
                 type = Type.BITMAP;
@@ -376,7 +376,7 @@ public class CreateMaterializedViewStmt extends DdlStmt {
                     mvColumnName = baseColumnName;
                 } else {
                     mvColumnName = mvColumnBuilder(functionName, baseColumnName);
-                    defineExpr = functionChild0;
+                    defineExpr = functionChild0.reset();
                 }
                 mvAggregateType = AggregateType.valueOf(functionName.toUpperCase());
                 type = Type.HLL;

--- a/fe/src/main/java/org/apache/doris/analysis/CreateMaterializedViewStmt.java
+++ b/fe/src/main/java/org/apache/doris/analysis/CreateMaterializedViewStmt.java
@@ -420,7 +420,7 @@ public class CreateMaterializedViewStmt extends DdlStmt {
                         break;
                     case FunctionSet.BITMAP_UNION:
                         if (functionCallExpr.getChild(0) instanceof FunctionCallExpr) {
-                            CastExpr castExpr = new CastExpr(Type.VARCHAR, baseSlotRef);
+                            CastExpr castExpr = new CastExpr(new TypeDef(Type.VARCHAR), baseSlotRef);
                             List<Expr> params = Lists.newArrayList();
                             params.add(castExpr);
                             FunctionCallExpr defineExpr = new FunctionCallExpr(FunctionSet.TO_BITMAP, params);
@@ -431,7 +431,7 @@ public class CreateMaterializedViewStmt extends DdlStmt {
                         break;
                     case FunctionSet.HLL_UNION:
                         if (functionCallExpr.getChild(0) instanceof FunctionCallExpr) {
-                            CastExpr castExpr = new CastExpr(Type.VARCHAR, baseSlotRef);
+                            CastExpr castExpr = new CastExpr(new TypeDef(Type.VARCHAR), baseSlotRef);
                             List<Expr> params = Lists.newArrayList();
                             params.add(castExpr);
                             FunctionCallExpr defineExpr = new FunctionCallExpr(FunctionSet.HLL_HASH, params);

--- a/fe/src/main/java/org/apache/doris/analysis/CreateMaterializedViewStmt.java
+++ b/fe/src/main/java/org/apache/doris/analysis/CreateMaterializedViewStmt.java
@@ -356,15 +356,25 @@ public class CreateMaterializedViewStmt extends DdlStmt {
                 type = Type.BIGINT;
                 break;
             case FunctionSet.BITMAP_UNION:
-                mvColumnName = mvColumnBuilder(functionName, baseColumnName);
+                // Compatible aggregation models
+                if (baseColumnRef.getType() == Type.BITMAP) {
+                    mvColumnName = baseColumnName;
+                } else {
+                    mvColumnName = mvColumnBuilder(functionName, baseColumnName);
+                    defineExpr = functionChild0;
+                }
                 mvAggregateType = AggregateType.valueOf(functionName.toUpperCase());
-                defineExpr = functionChild0;
                 type = Type.BITMAP;
                 break;
             case FunctionSet.HLL_UNION:
-                mvColumnName = mvColumnBuilder(functionName, baseColumnName);
+                // Compatible aggregation models
+                if (baseColumnRef.getType() == Type.HLL) {
+                    mvColumnName = baseColumnName;
+                } else {
+                    mvColumnName = mvColumnBuilder(functionName, baseColumnName);
+                    defineExpr = functionChild0;
+                }
                 mvAggregateType = AggregateType.valueOf(functionName.toUpperCase());
-                defineExpr = functionChild0;
                 type = Type.HLL;
                 break;
             case FunctionSet.COUNT:

--- a/fe/src/main/java/org/apache/doris/analysis/DataDescription.java
+++ b/fe/src/main/java/org/apache/doris/analysis/DataDescription.java
@@ -20,6 +20,7 @@ package org.apache.doris.analysis;
 import org.apache.doris.analysis.BinaryPredicate.Operator;
 import org.apache.doris.catalog.Catalog;
 import org.apache.doris.catalog.Column;
+import org.apache.doris.catalog.FunctionSet;
 import org.apache.doris.catalog.Type;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.DdlException;
@@ -74,7 +75,6 @@ import java.util.TreeSet;
  */
 public class DataDescription {
     private static final Logger LOG = LogManager.getLogger(DataDescription.class);
-    public static String FUNCTION_HASH_HLL = "hll_hash";
     // function isn't built-in function, hll_hash is not built-in function in hadoop load.
     private static final List<String> HADOOP_SUPPORT_FUNCTION_NAMES = Arrays.asList(
             "strftime",
@@ -84,7 +84,7 @@ public class DataDescription {
             "md5sum",
             "replace_value",
             "now",
-            "hll_hash",
+            FunctionSet.HLL_HASH,
             "substitute");
 
     private final String tableName;
@@ -399,7 +399,7 @@ public class DataDescription {
             validateMd5sum(args, columnNameMap);
         } else if (functionName.equalsIgnoreCase("replace_value")) {
             validateReplaceValue(args, mappingColumn);
-        } else if (functionName.equalsIgnoreCase(FUNCTION_HASH_HLL)) {
+        } else if (functionName.equalsIgnoreCase(FunctionSet.HLL_HASH)) {
             validateHllHash(args, columnNameMap);
         } else if (functionName.equalsIgnoreCase("now")) {
             validateNowFunction(mappingColumn);

--- a/fe/src/main/java/org/apache/doris/analysis/DescribeStmt.java
+++ b/fe/src/main/java/org/apache/doris/analysis/DescribeStmt.java
@@ -164,14 +164,11 @@ public class DescribeStmt extends ShowStmt {
                             if (bfColumns != null && bfColumns.contains(column.getName())) {
                                 extras.add("BLOOM_FILTER");
                             }
-                            if (column.getDefineExpr() != null) {
-                                extras.add(column.getDefineExpr().toSql().toUpperCase());
-                            }
                             String extraStr = StringUtils.join(extras, ",");
 
                             List<String> row = Arrays.asList("",
                                                              "",
-                                                             column.getName(),
+                                                             column.getDisplayName(),
                                                              column.getOriginType().toString(),
                                                              column.isAllowNull() ? "Yes" : "No",
                                                              ((Boolean) column.isKey()).toString(),

--- a/fe/src/main/java/org/apache/doris/analysis/Expr.java
+++ b/fe/src/main/java/org/apache/doris/analysis/Expr.java
@@ -19,6 +19,7 @@ package org.apache.doris.analysis;
 
 import org.apache.doris.catalog.Catalog;
 import org.apache.doris.catalog.Function;
+import org.apache.doris.catalog.FunctionSet;
 import org.apache.doris.catalog.ScalarType;
 import org.apache.doris.catalog.Type;
 import org.apache.doris.common.AnalysisException;
@@ -136,7 +137,7 @@ abstract public class Expr extends TreeNode<Expr> implements ParseNode, Cloneabl
                                 || fnName.equalsIgnoreCase("max")
                                 || fnName.equalsIgnoreCase("min")
                                 || fnName.equalsIgnoreCase("avg")
-                                || fnName.equalsIgnoreCase("count"));
+                                || fnName.equalsIgnoreCase(FunctionSet.COUNT));
                     } else {
                         return false;
                     }

--- a/fe/src/main/java/org/apache/doris/analysis/Expr.java
+++ b/fe/src/main/java/org/apache/doris/analysis/Expr.java
@@ -1110,10 +1110,10 @@ abstract public class Expr extends TreeNode<Expr> implements ParseNode, Cloneabl
         }
     }
 
-    public void getTableNameToColumnNames(Map<String, Set<String>> tableNameToColumnNames) {
-        Preconditions.checkState(tableNameToColumnNames != null);
+    public void getTableIdToColumnNames(Map<Long, Set<String>> tableIdToColumnNames) {
+        Preconditions.checkState(tableIdToColumnNames != null);
         for (Expr child : children) {
-            child.getTableNameToColumnNames(tableNameToColumnNames);
+            child.getTableIdToColumnNames(tableIdToColumnNames);
         }
     }
 

--- a/fe/src/main/java/org/apache/doris/analysis/FunctionCallExpr.java
+++ b/fe/src/main/java/org/apache/doris/analysis/FunctionCallExpr.java
@@ -505,10 +505,10 @@ public class FunctionCallExpr extends Expr {
         }
 
         if (fnName.getFunction().equals("count") && fnParams.isDistinct()) {
-            // Treat COUNT(DISTINCT ...) special because of how we do the rewrite.
+            // Treat COUNT(DISTINCT ...) special because of how we do the equal.
             // There is no version of COUNT() that takes more than 1 argument but after
-            // the rewrite, we only need count(*).
-            // TODO: fix how we rewrite count distinct.
+            // the equal, we only need count(*).
+            // TODO: fix how we equal count distinct.
             fn = getBuiltinFunction(analyzer, fnName.getFunction(), new Type[0],
                     Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
             type = fn.getReturnType();

--- a/fe/src/main/java/org/apache/doris/analysis/FunctionCallExpr.java
+++ b/fe/src/main/java/org/apache/doris/analysis/FunctionCallExpr.java
@@ -104,7 +104,7 @@ public class FunctionCallExpr extends Expr {
 
     private FunctionCallExpr(
         FunctionName fnName, FunctionParams params, boolean isMergeAggFn) {
-                super();
+        super();
         this.fnName = fnName;
         fnParams = params;
         this.isMergeAggFn = isMergeAggFn;
@@ -234,7 +234,7 @@ public class FunctionCallExpr extends Expr {
     }
 
     public boolean isCountStar() {
-        if (fnName.getFunction().equalsIgnoreCase("count")) {
+        if (fnName.getFunction().equalsIgnoreCase(FunctionSet.COUNT)) {
             if (fnParams.isStar()) {
                 return true;
             } else if (fnParams.exprs() == null || fnParams.exprs().isEmpty()) {
@@ -255,7 +255,7 @@ public class FunctionCallExpr extends Expr {
             return false;
         }
 
-        if (!fnName.getFunction().equalsIgnoreCase("count")) {
+        if (!fnName.getFunction().equalsIgnoreCase(FunctionSet.COUNT)) {
             return false;
         }
 
@@ -282,12 +282,12 @@ public class FunctionCallExpr extends Expr {
     }
 
     private void analyzeBuiltinAggFunction(Analyzer analyzer) throws AnalysisException {
-        if (fnParams.isStar() && !fnName.getFunction().equalsIgnoreCase("count")) {
+        if (fnParams.isStar() && !fnName.getFunction().equalsIgnoreCase(FunctionSet.COUNT)) {
             throw new AnalysisException(
                     "'*' can only be used in conjunction with COUNT: " + this.toSql());
         }
 
-        if (fnName.getFunction().equalsIgnoreCase("count")) {
+        if (fnName.getFunction().equalsIgnoreCase(FunctionSet.COUNT)) {
             // for multiple exprs count must be qualified with distinct
             if (children.size() > 1 && !fnParams.isDistinct()) {
                 throw new AnalysisException(
@@ -464,7 +464,7 @@ public class FunctionCallExpr extends Expr {
             return "'*' can only be used in conjunction with COUNT";
         }
 
-        if (fnName.getFunction().equalsIgnoreCase("count")) {
+        if (fnName.getFunction().equalsIgnoreCase(FunctionSet.COUNT)) {
             if (!fnParams.isDistinct() && argTypes.length > 1) {
                 return "COUNT must have DISTINCT for multiple arguments: " + toSql();
             }
@@ -504,7 +504,7 @@ public class FunctionCallExpr extends Expr {
             return;
         }
 
-        if (fnName.getFunction().equals("count") && fnParams.isDistinct()) {
+        if (fnName.getFunction().equals(FunctionSet.COUNT) && fnParams.isDistinct()) {
             // Treat COUNT(DISTINCT ...) special because of how we do the equal.
             // There is no version of COUNT() that takes more than 1 argument but after
             // the equal, we only need count(*).

--- a/fe/src/main/java/org/apache/doris/analysis/InsertStmt.java
+++ b/fe/src/main/java/org/apache/doris/analysis/InsertStmt.java
@@ -459,7 +459,7 @@ public class InsertStmt extends DdlStmt {
                     }
                 }
             }
-            if (column.isNameWithPrefix(CreateMaterializedViewStmt.MATERIALIZED_VIEW_NAME_PRFIX)) {
+            if (column.isNameWithPrefix(CreateMaterializedViewStmt.MATERIALIZED_VIEW_NAME_PREFIX)) {
                 SlotRef refColumn = column.getRefColumn();
                 if (refColumn == null) {
                     ErrorReport.reportAnalysisException(ErrorCode.ERR_BAD_FIELD_ERROR, column.getName(), targetTable.getName());

--- a/fe/src/main/java/org/apache/doris/analysis/JoinOperator.java
+++ b/fe/src/main/java/org/apache/doris/analysis/JoinOperator.java
@@ -31,7 +31,7 @@ public enum JoinOperator {
     FULL_OUTER_JOIN("FULL OUTER JOIN", TJoinOp.FULL_OUTER_JOIN),
     MERGE_JOIN("MERGE JOIN", TJoinOp.MERGE_JOIN),
     CROSS_JOIN("CROSS JOIN", TJoinOp.CROSS_JOIN),
-    // Variant of the LEFT ANTI JOIN that is used for the rewrite of
+    // Variant of the LEFT ANTI JOIN that is used for the equal of
     // NOT IN subqueries. It can have a single equality join conjunct
     // that returns TRUE when the rhs is NULL.
     NULL_AWARE_LEFT_ANTI_JOIN("NULL AWARE LEFT ANTI JOIN",

--- a/fe/src/main/java/org/apache/doris/analysis/MVColumnBitmapUnionPattern.java
+++ b/fe/src/main/java/org/apache/doris/analysis/MVColumnBitmapUnionPattern.java
@@ -34,7 +34,7 @@ public class MVColumnBitmapUnionPattern implements MVColumnPattern {
             return false;
         }
         FunctionCallExpr child0FnExpr = (FunctionCallExpr) fnExpr.getChild(0);
-        if (!child0FnExpr.getFnName().getFunction().equalsIgnoreCase("to_bitmap")) {
+        if (!child0FnExpr.getFnName().getFunction().equalsIgnoreCase(FunctionSet.TO_BITMAP)) {
             return false;
         }
         if (child0FnExpr.getChild(0) instanceof SlotRef) {
@@ -52,6 +52,7 @@ public class MVColumnBitmapUnionPattern implements MVColumnPattern {
 
     @Override
     public String toString() {
-        return "bitmap_union(to_bitmap(column)) or bitmap_union(bitmap_column) in agg table";
+        return FunctionSet.BITMAP_UNION + "(" + FunctionSet.TO_BITMAP + "(column)) "
+                + "or " + FunctionSet.BITMAP_UNION + "(bitmap_column) in agg table";
     }
 }

--- a/fe/src/main/java/org/apache/doris/analysis/MVColumnBitmapUnionPattern.java
+++ b/fe/src/main/java/org/apache/doris/analysis/MVColumnBitmapUnionPattern.java
@@ -1,0 +1,57 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.analysis;
+
+import org.apache.doris.catalog.FunctionSet;
+
+public class MVColumnBitmapUnionPattern implements MVColumnPattern {
+    @Override
+    public boolean match(Expr expr) {
+        if (!(expr instanceof FunctionCallExpr)) {
+            return false;
+        }
+        FunctionCallExpr fnExpr = (FunctionCallExpr) expr;
+        String fnNameString = fnExpr.getFnName().getFunction();
+        if (!fnNameString.equalsIgnoreCase(FunctionSet.BITMAP_UNION)) {
+            return false;
+        }
+        if (!(fnExpr.getChild(0) instanceof FunctionCallExpr)) {
+            return false;
+        }
+        FunctionCallExpr child0FnExpr = (FunctionCallExpr) fnExpr.getChild(0);
+        if (!child0FnExpr.getFnName().getFunction().equalsIgnoreCase("to_bitmap")) {
+            return false;
+        }
+        if (child0FnExpr.getChild(0) instanceof SlotRef) {
+            return true;
+        } else if (child0FnExpr.getChild(0) instanceof CastExpr) {
+            CastExpr castExpr = (CastExpr) child0FnExpr.getChild(0);
+            if (!(castExpr.getChild(0) instanceof SlotRef)) {
+                return false;
+            }
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "bitmap_union(to_bitmap(column)) or bitmap_union(bitmap_column) in agg table";
+    }
+}

--- a/fe/src/main/java/org/apache/doris/analysis/MVColumnBitmapUnionPattern.java
+++ b/fe/src/main/java/org/apache/doris/analysis/MVColumnBitmapUnionPattern.java
@@ -18,7 +18,7 @@
 package org.apache.doris.analysis;
 
 import org.apache.doris.catalog.FunctionSet;
-import org.apache.doris.catalog.Type;
+import org.apache.doris.catalog.PrimitiveType;
 
 public class MVColumnBitmapUnionPattern implements MVColumnPattern {
 
@@ -34,12 +34,12 @@ public class MVColumnBitmapUnionPattern implements MVColumnPattern {
         }
         if (fnExpr.getChild(0) instanceof SlotRef) {
             SlotRef slotRef = (SlotRef) fnExpr.getChild(0);
-            if (slotRef.getType() == Type.BITMAP && slotRef.getColumn() != null) {
+            if (slotRef.getType().getPrimitiveType() == PrimitiveType.BITMAP && slotRef.getColumn() != null) {
                 return true;
             } else {
                 return false;
             }
-        } else if(fnExpr.getChild(0) instanceof FunctionCallExpr) {
+        } else if (fnExpr.getChild(0) instanceof FunctionCallExpr) {
             FunctionCallExpr child0FnExpr = (FunctionCallExpr) fnExpr.getChild(0);
             if (!child0FnExpr.getFnName().getFunction().equalsIgnoreCase(FunctionSet.TO_BITMAP)) {
                 return false;

--- a/fe/src/main/java/org/apache/doris/analysis/MVColumnHLLUnionPattern.java
+++ b/fe/src/main/java/org/apache/doris/analysis/MVColumnHLLUnionPattern.java
@@ -1,0 +1,55 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.analysis;
+
+public class MVColumnHLLUnionPattern implements MVColumnPattern {
+    @Override
+    public boolean match(Expr expr) {
+        if (!(expr instanceof FunctionCallExpr)) {
+            return false;
+        }
+        FunctionCallExpr fnExpr = (FunctionCallExpr) expr;
+        String fnNameString = fnExpr.getFnName().getFunction();
+        if (!fnNameString.equalsIgnoreCase("hll_union")){
+            return false;
+        }
+        if (!(fnExpr.getChild(0) instanceof FunctionCallExpr)) {
+            return false;
+        }
+        FunctionCallExpr child0FnExpr = (FunctionCallExpr) fnExpr.getChild(0);
+        if (!child0FnExpr.getFnName().getFunction().equalsIgnoreCase("hll_hash")) {
+            return false;
+        }
+        if (child0FnExpr.getChild(0) instanceof SlotRef) {
+            return true;
+        } else if (child0FnExpr.getChild(0) instanceof CastExpr) {
+            CastExpr castExpr = (CastExpr) child0FnExpr.getChild(0);
+            if (!(castExpr.getChild(0) instanceof SlotRef)) {
+                return false;
+            }
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "hll_union(hll_hash(column))";
+    }
+}

--- a/fe/src/main/java/org/apache/doris/analysis/MVColumnHLLUnionPattern.java
+++ b/fe/src/main/java/org/apache/doris/analysis/MVColumnHLLUnionPattern.java
@@ -17,6 +17,8 @@
 
 package org.apache.doris.analysis;
 
+import org.apache.doris.catalog.FunctionSet;
+
 public class MVColumnHLLUnionPattern implements MVColumnPattern {
     @Override
     public boolean match(Expr expr) {
@@ -25,14 +27,14 @@ public class MVColumnHLLUnionPattern implements MVColumnPattern {
         }
         FunctionCallExpr fnExpr = (FunctionCallExpr) expr;
         String fnNameString = fnExpr.getFnName().getFunction();
-        if (!fnNameString.equalsIgnoreCase("hll_union")){
+        if (!fnNameString.equalsIgnoreCase(FunctionSet.HLL_UNION)){
             return false;
         }
         if (!(fnExpr.getChild(0) instanceof FunctionCallExpr)) {
             return false;
         }
         FunctionCallExpr child0FnExpr = (FunctionCallExpr) fnExpr.getChild(0);
-        if (!child0FnExpr.getFnName().getFunction().equalsIgnoreCase("hll_hash")) {
+        if (!child0FnExpr.getFnName().getFunction().equalsIgnoreCase(FunctionSet.HLL_HASH)) {
             return false;
         }
         if (child0FnExpr.getChild(0) instanceof SlotRef) {
@@ -50,6 +52,6 @@ public class MVColumnHLLUnionPattern implements MVColumnPattern {
 
     @Override
     public String toString() {
-        return "hll_union(hll_hash(column))";
+        return "hll_union(" + FunctionSet.HLL_HASH + "(column))";
     }
 }

--- a/fe/src/main/java/org/apache/doris/analysis/MVColumnHLLUnionPattern.java
+++ b/fe/src/main/java/org/apache/doris/analysis/MVColumnHLLUnionPattern.java
@@ -38,7 +38,7 @@ public class MVColumnHLLUnionPattern implements MVColumnPattern {
             } else {
                 return false;
             }
-        } else if(fnExpr.getChild(0) instanceof FunctionCallExpr) {
+        } else if (fnExpr.getChild(0) instanceof FunctionCallExpr) {
             FunctionCallExpr child0FnExpr = (FunctionCallExpr) fnExpr.getChild(0);
             if (!child0FnExpr.getFnName().getFunction().equalsIgnoreCase(FunctionSet.HLL_HASH)) {
                 return false;

--- a/fe/src/main/java/org/apache/doris/analysis/MVColumnItem.java
+++ b/fe/src/main/java/org/apache/doris/analysis/MVColumnItem.java
@@ -96,7 +96,7 @@ public class MVColumnItem {
     }
 
     public Column toMVColumn(OlapTable olapTable) throws DdlException {
-        Column baseColumn = olapTable.getColumn(name);
+        Column baseColumn = olapTable.getBaseColumn(name);
         if (baseColumn == null) {
             Preconditions.checkNotNull(defineExpr != null);
             Column result = new Column(name, type, isKey, aggregationType, ColumnDef.DefaultValue.ZERO, "");

--- a/fe/src/main/java/org/apache/doris/analysis/MVColumnOneChildPattern.java
+++ b/fe/src/main/java/org/apache/doris/analysis/MVColumnOneChildPattern.java
@@ -1,0 +1,56 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.analysis;
+
+public class MVColumnOneChildPattern implements MVColumnPattern {
+
+    private String functionName;
+
+    public MVColumnOneChildPattern(String functionName) {
+        this.functionName = functionName;
+    }
+
+    @Override
+    public boolean match(Expr expr) {
+        if (!(expr instanceof FunctionCallExpr)) {
+            return false;
+        }
+        FunctionCallExpr functionCallExpr = (FunctionCallExpr) expr;
+        String exprFnName = functionCallExpr.getFnName().getFunction();
+        if (!exprFnName.equalsIgnoreCase(functionName)) {
+            return false;
+        }
+        if (functionCallExpr.getChildren().size() != 1) {
+            return false;
+        }
+        Expr functionChild0 = functionCallExpr.getChild(0);
+        if (functionChild0 instanceof SlotRef) {
+            return true;
+        } else if (functionChild0 instanceof CastExpr && (functionChild0.getChild(0) instanceof SlotRef)) {
+            return true;
+        } else {
+            return false;
+        }
+
+    }
+
+    @Override
+    public String toString() {
+        return functionName + "(column)";
+    }
+}

--- a/fe/src/main/java/org/apache/doris/analysis/MVColumnOneChildPattern.java
+++ b/fe/src/main/java/org/apache/doris/analysis/MVColumnOneChildPattern.java
@@ -38,15 +38,11 @@ public class MVColumnOneChildPattern implements MVColumnPattern {
         if (functionCallExpr.getChildren().size() != 1) {
             return false;
         }
-        Expr functionChild0 = functionCallExpr.getChild(0);
-        if (functionChild0 instanceof SlotRef) {
-            return true;
-        } else if (functionChild0 instanceof CastExpr && (functionChild0.getChild(0) instanceof SlotRef)) {
-            return true;
-        } else {
+        if (functionCallExpr.getChild(0).unwrapSlotRef() == null) {
             return false;
+        } else {
+            return true;
         }
-
     }
 
     @Override

--- a/fe/src/main/java/org/apache/doris/analysis/MVColumnPattern.java
+++ b/fe/src/main/java/org/apache/doris/analysis/MVColumnPattern.java
@@ -1,0 +1,23 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.analysis;
+
+public interface MVColumnPattern {
+
+    boolean match(Expr expr);
+}

--- a/fe/src/main/java/org/apache/doris/analysis/Predicate.java
+++ b/fe/src/main/java/org/apache/doris/analysis/Predicate.java
@@ -115,8 +115,8 @@ public abstract class Predicate extends Expr {
                 // and all SingleColumnPredicate will be rewritten as "column on the left and the constant on the right".
                 // So usually the right child is constant.
                 //
-                // But if there is a subquery in where clause, the planner will rewrite the subquery to join.
-                // During the rewrite, some auxiliary BinaryPredicate will be automatically generated,
+                // But if there is a subquery in where clause, the planner will equal the subquery to join.
+                // During the equal, some auxiliary BinaryPredicate will be automatically generated,
                 // and these BinaryPredicates will not go through ExprRewriteRule.
                 // As a result, these BinaryPredicates may be as "column on the right and the constant on the left".
                 // Example can be found in QueryPlanTest.java -> testJoinPredicateTransitivityWithSubqueryInWhereClause().

--- a/fe/src/main/java/org/apache/doris/analysis/SelectList.java
+++ b/fe/src/main/java/org/apache/doris/analysis/SelectList.java
@@ -87,7 +87,7 @@ class SelectList {
             if (item.isStar()) {
                 continue;
             }
-            // rewrite subquery in select list
+            // equal subquery in select list
             if (item.getExpr().contains(Predicates.instanceOf(Subquery.class))) {
                 List<Subquery> subqueryExprs = Lists.newArrayList();
                 item.getExpr().collect(Subquery.class, subqueryExprs);

--- a/fe/src/main/java/org/apache/doris/analysis/SelectList.java
+++ b/fe/src/main/java/org/apache/doris/analysis/SelectList.java
@@ -28,7 +28,7 @@ import java.util.List;
 /**
  * Select list items plus distinct clause.
  */
-class SelectList {
+public class SelectList {
     private boolean isDistinct;
 
     // ///////////////////////////////////////

--- a/fe/src/main/java/org/apache/doris/analysis/SelectListItem.java
+++ b/fe/src/main/java/org/apache/doris/analysis/SelectListItem.java
@@ -19,7 +19,7 @@ package org.apache.doris.analysis;
 
 import com.google.common.base.Preconditions;
 
-class SelectListItem {
+public class SelectListItem {
     private Expr expr;
     // for "[name.]*"
     private final TableName tblName;

--- a/fe/src/main/java/org/apache/doris/analysis/SelectStmt.java
+++ b/fe/src/main/java/org/apache/doris/analysis/SelectStmt.java
@@ -21,6 +21,7 @@ import org.apache.doris.catalog.AggregateFunction;
 import org.apache.doris.catalog.Catalog;
 import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.Database;
+import org.apache.doris.catalog.FunctionSet;
 import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.catalog.Table.TableType;
 import org.apache.doris.catalog.Type;
@@ -1223,7 +1224,7 @@ public class SelectStmt extends QueryStmt {
         for (FunctionCallExpr inputExpr : distinctExprs) {
             Expr replaceExpr = null;
             final String functionName = inputExpr.getFnName().getFunction();
-            if (functionName.equalsIgnoreCase("COUNT")) {
+            if (functionName.equalsIgnoreCase(FunctionSet.COUNT)) {
                 final List<Expr> countInputExpr = Lists.newArrayList(inputExpr.getChild(0).clone(null));
                 replaceExpr = new FunctionCallExpr("MULTI_DISTINCT_COUNT",
                         new FunctionParams(inputExpr.isDistinct(), countInputExpr));
@@ -1283,7 +1284,7 @@ public class SelectStmt extends QueryStmt {
         com.google.common.base.Predicate<FunctionCallExpr> isCountPred =
                 new com.google.common.base.Predicate<FunctionCallExpr>() {
                     public boolean apply(FunctionCallExpr expr) {
-                        return expr.getFnName().getFunction().equals("count");
+                        return expr.getFnName().getFunction().equals(FunctionSet.COUNT);
                     }
                 };
 

--- a/fe/src/main/java/org/apache/doris/analysis/SetOperationStmt.java
+++ b/fe/src/main/java/org/apache/doris/analysis/SetOperationStmt.java
@@ -661,10 +661,10 @@ public class SetOperationStmt extends QueryStmt {
             if (isAnalyzed()) {
                 return;
             }
-            // union statement support const expr, so not need to rewrite
+            // union statement support const expr, so not need to equal
             if (operation != Operation.UNION && queryStmt instanceof SelectStmt
                     && ((SelectStmt) queryStmt).fromClause_.isEmpty()) {
-                // rewrite select 1 to select * from (select 1) __DORIS_DUAL__ , because when using select 1 it will be
+                // equal select 1 to select * from (select 1) __DORIS_DUAL__ , because when using select 1 it will be
                 // transformed to a union node, select 1 is a literal, it doesn't have a tuple but will produce a slot,
                 // this will cause be core dump
                 QueryStmt inlineQuery = queryStmt.clone();

--- a/fe/src/main/java/org/apache/doris/analysis/TupleDescriptor.java
+++ b/fe/src/main/java/org/apache/doris/analysis/TupleDescriptor.java
@@ -259,7 +259,7 @@ public class TupleDescriptor {
         for (SlotDescriptor slot: slots) slot.setIsMaterialized(true);
     }
 
-    public void getTableNameToColumnNames(Map<String, Set<String>> tupleDescToColumnNames) {
+    public void getTableIdToColumnNames(Map<Long, Set<String>> tableIdToColumnNames) {
         for (SlotDescriptor slotDescriptor : slots) {
             if (!slotDescriptor.isMaterialized()) {
                 continue;
@@ -269,16 +269,16 @@ public class TupleDescriptor {
                 Preconditions.checkState(parent != null);
                 Table table = parent.getTable();
                 Preconditions.checkState(table != null);
-                String tableName = table.getName();
-                Set<String> columnNames = tupleDescToColumnNames.get(tableName);
+                Long tableId = table.getId();
+                Set<String> columnNames = tableIdToColumnNames.get(tableId);
                 if (columnNames == null) {
                     columnNames = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
-                    tupleDescToColumnNames.put(tableName, columnNames);
+                    tableIdToColumnNames.put(tableId, columnNames);
                 }
                 columnNames.add(slotDescriptor.getColumn().getName());
             } else {
                 for (Expr expr : slotDescriptor.getSourceExprs()) {
-                    expr.getTableNameToColumnNames(tupleDescToColumnNames);
+                    expr.getTableIdToColumnNames(tableIdToColumnNames);
                 }
             }
         }

--- a/fe/src/main/java/org/apache/doris/catalog/AggregateFunction.java
+++ b/fe/src/main/java/org/apache/doris/catalog/AggregateFunction.java
@@ -80,7 +80,7 @@ public class AggregateFunction extends Function {
     private boolean isAggregateFn;
 
     // True if this function returns a non-null value on an empty input. It is used
-    // primarily during the rewrite of scalar subqueries.
+    // primarily during the equal of scalar subqueries.
     // TODO: Instead of manually setting this flag, we should identify this
     // property from the function itself (e.g. evaluating the function on an
     // empty input in BE).

--- a/fe/src/main/java/org/apache/doris/catalog/AggregateType.java
+++ b/fe/src/main/java/org/apache/doris/catalog/AggregateType.java
@@ -38,7 +38,7 @@ public enum AggregateType {
     private static EnumMap<AggregateType, EnumSet<PrimitiveType>> compatibilityMap;
 
     static {
-        compatibilityMap = new EnumMap<AggregateType, EnumSet<PrimitiveType>>(AggregateType.class);
+        compatibilityMap = new EnumMap<>(AggregateType.class);
         List<PrimitiveType> primitiveTypeList = Lists.newArrayList();
 
         primitiveTypeList.add(PrimitiveType.TINYINT);

--- a/fe/src/main/java/org/apache/doris/catalog/Column.java
+++ b/fe/src/main/java/org/apache/doris/catalog/Column.java
@@ -141,6 +141,14 @@ public class Column implements Writable {
         return this.name;
     }
 
+    public String getDisplayName() {
+        if (defineExpr == null) {
+            return name;
+        } else {
+            return defineExpr.toSql();
+        }
+    }
+
     public String getNameWithoutPrefix(String prefix) {
         if (isNameWithPrefix(prefix)) {
             return name.substring(prefix.length());

--- a/fe/src/main/java/org/apache/doris/catalog/FunctionSet.java
+++ b/fe/src/main/java/org/apache/doris/catalog/FunctionSet.java
@@ -284,6 +284,9 @@ public class FunctionSet {
                         "16knuth_var_updateIN9doris_udf9DoubleValEEEvPNS2_15FunctionContextERKT_PNS2_9StringValE")
                 .build();
 
+    public static final String HLL_HASH = "hll_hash";
+    public static final String HLL_UNION = "hll_union";
+
     private static final Map<Type, String> HLL_UPDATE_SYMBOL =
         ImmutableMap.<Type, String>builder()
                 .put(Type.BOOLEAN,
@@ -535,6 +538,7 @@ public class FunctionSet {
 
                 .build();
 
+    public static final String TO_BITMAP = "to_bitmap";
     public static final String BITMAP_UNION = "bitmap_union";
     public static final String BITMAP_UNION_COUNT = "bitmap_union_count";
     public static final String BITMAP_UNION_INT = "bitmap_union_int";
@@ -819,6 +823,7 @@ public class FunctionSet {
         addFunction(fn, true);
     }
 
+    public static final String COUNT = "count";
     // Populate all the aggregate builtins in the catalog.
     // null symbols indicate the function does not need that step of the evaluation.
     // An empty symbol indicates a TODO for the BE to implement the function.
@@ -834,7 +839,7 @@ public class FunctionSet {
 
         // Type stringType[] = {Type.CHAR, Type.VARCHAR};
         // count(*)
-        addBuiltin(AggregateFunction.createBuiltin("count",
+        addBuiltin(AggregateFunction.createBuiltin(FunctionSet.COUNT,
             new ArrayList<Type>(), Type.BIGINT, Type.BIGINT,
             prefix + "9init_zeroIN9doris_udf9BigIntValEEEvPNS2_15FunctionContextEPT_",
             prefix + "17count_star_updateEPN9doris_udf15FunctionContextEPNS1_9BigIntValE",
@@ -851,7 +856,7 @@ public class FunctionSet {
                 continue; // promoted to STRING
             }
             // Count
-            addBuiltin(AggregateFunction.createBuiltin("count",
+            addBuiltin(AggregateFunction.createBuiltin(FunctionSet.COUNT,
                     Lists.newArrayList(t), Type.BIGINT, Type.BIGINT,
                     prefix + "9init_zeroIN9doris_udf9BigIntValEEEvPNS2_15FunctionContextEPT_",
                     prefix + "12count_updateEPN9doris_udf15FunctionContextERKNS1_6AnyValEPNS1_9BigIntValE",
@@ -1027,7 +1032,7 @@ public class FunctionSet {
                     true, true, true));
 
             // HLL_UNION
-            addBuiltin(AggregateFunction.createBuiltin("hll_union",
+            addBuiltin(AggregateFunction.createBuiltin(HLL_UNION,
                     Lists.newArrayList(t), Type.HLL, Type.HLL,
                     "_ZN5doris12HllFunctions8hll_initEPN9doris_udf15FunctionContextEPNS1_9StringValE",
                     "_ZN5doris12HllFunctions9hll_mergeEPN9doris_udf15FunctionContextERKNS1_9StringValEPS4_",

--- a/fe/src/main/java/org/apache/doris/catalog/OlapTable.java
+++ b/fe/src/main/java/org/apache/doris/catalog/OlapTable.java
@@ -346,6 +346,17 @@ public class OlapTable extends Table {
         return partition.getMaterializedIndices(IndexExtState.VISIBLE);
     }
 
+    public Column getVisibleColumn(String columnName) {
+        for (MaterializedIndexMeta meta : getVisibleIndexIdToMeta().values()) {
+            for (Column column : meta.getSchema()) {
+                if (column.getName().equalsIgnoreCase(columnName)) {
+                    return column;
+                }
+            }
+        }
+        return null;
+    }
+
     // this is only for schema change.
     public void renameIndexForSchemaChange(String name, String newName) {
         long idxId = indexNameToId.remove(name);

--- a/fe/src/main/java/org/apache/doris/catalog/OlapTable.java
+++ b/fe/src/main/java/org/apache/doris/catalog/OlapTable.java
@@ -308,7 +308,12 @@ public class OlapTable extends Table {
         long indexId = this.indexNameToId.remove(indexName);
         this.indexIdToMeta.remove(indexId);
         // Some column of deleted index should be removed during `deleteIndexInfo` such as `mv_bitmap_union_c1`
-        rebuildFullSchema();
+        // If deleted index id == base index id, the schema will not be rebuilt.
+        // The reason is that the base index has been removed from indexIdToMeta while the new base index hasn't changed.
+        // The schema could not be rebuild in here with error base index id.
+        if (indexId != baseIndexId) {
+            rebuildFullSchema();
+        }
         return true;
     }
 

--- a/fe/src/main/java/org/apache/doris/catalog/OlapTable.java
+++ b/fe/src/main/java/org/apache/doris/catalog/OlapTable.java
@@ -1298,6 +1298,15 @@ public class OlapTable extends Table {
         return getSchemaByIndexId(baseIndexId);
     }
 
+    public Column getBaseColumn(String columnName) {
+        for (Column column : getBaseSchema()) {
+            if (column.getName().equalsIgnoreCase(columnName)){
+                return column;
+            }
+        }
+        return null;
+    }
+
     public int getKeysNum() {
         int keysNum = 0;
         for (Column column : getBaseSchema()) {

--- a/fe/src/main/java/org/apache/doris/catalog/OlapTable.java
+++ b/fe/src/main/java/org/apache/doris/catalog/OlapTable.java
@@ -307,6 +307,8 @@ public class OlapTable extends Table {
 
         long indexId = this.indexNameToId.remove(indexName);
         this.indexIdToMeta.remove(indexId);
+        // Some column of deleted index should be removed during `deleteIndexInfo` such as `mv_bitmap_union_c1`
+        rebuildFullSchema();
         return true;
     }
 

--- a/fe/src/main/java/org/apache/doris/load/BrokerFileGroupAggInfo.java
+++ b/fe/src/main/java/org/apache/doris/load/BrokerFileGroupAggInfo.java
@@ -85,7 +85,7 @@ import java.util.stream.Collectors;
  *  PARTITION (p2, p3)
  * 
  *  will throw an Exception, because there is an overlap partition(p2) between 2 data descriptions. And we
- *  currently not allow this. You can rewrite the data descriptions like this:
+ *  currently not allow this. You can equal the data descriptions like this:
  *  
  *  DATA INFILE("hdfs://hdfs_host:hdfs_port/input/file1")
  *  INTO TABLE `tbl1`

--- a/fe/src/main/java/org/apache/doris/load/ExportJob.java
+++ b/fe/src/main/java/org/apache/doris/load/ExportJob.java
@@ -281,6 +281,8 @@ public class ExportJob implements Writable {
                 ((OlapScanNode) scanNode).setColumnFilters(Maps.newHashMap());
                 ((OlapScanNode) scanNode).setIsPreAggregation(false, "This an export operation");
                 ((OlapScanNode) scanNode).setCanTurnOnPreAggr(false);
+                scanNode.init(analyzer);
+                ((OlapScanNode) scanNode).selectBestRollupByRollupSelector(analyzer);
                 break;
             case MYSQL:
                 scanNode = new MysqlScanNode(new PlanNodeId(0), exportTupleDesc, (MysqlTable) this.exportTable);

--- a/fe/src/main/java/org/apache/doris/load/Load.java
+++ b/fe/src/main/java/org/apache/doris/load/Load.java
@@ -48,6 +48,7 @@ import org.apache.doris.catalog.AggregateType;
 import org.apache.doris.catalog.Catalog;
 import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.Database;
+import org.apache.doris.catalog.FunctionSet;
 import org.apache.doris.catalog.KeysType;
 import org.apache.doris.catalog.MaterializedIndex;
 import org.apache.doris.catalog.MaterializedIndex.IndexExtState;
@@ -338,8 +339,7 @@ public class Load {
 
                 final String resultColumn = pairList.get(0);
                 final String hashColumn = pairList.get(1);
-                final Pair<String, List<String>> pair = new Pair<String, List<String>>(
-                        DataDescription.FUNCTION_HASH_HLL,
+                final Pair<String, List<String>> pair = new Pair<String, List<String>>(FunctionSet.HLL_HASH,
                         Arrays.asList(hashColumn));
                 dataDescription.addColumnMapping(resultColumn, pair);
             }

--- a/fe/src/main/java/org/apache/doris/planner/LoadScanNode.java
+++ b/fe/src/main/java/org/apache/doris/planner/LoadScanNode.java
@@ -51,7 +51,7 @@ public abstract class LoadScanNode extends ScanNode {
         }
 
         // substitute SlotRef in filter expression
-        // where expr must be rewrite first to transfer some predicates(eg: BetweenPredicate to BinaryPredicate)
+        // where expr must be equal first to transfer some predicates(eg: BetweenPredicate to BinaryPredicate)
         whereExpr = analyzer.getExprRewriter().rewrite(whereExpr, analyzer);
         List<SlotRef> slots = Lists.newArrayList();
         whereExpr.collect(SlotRef.class, slots);

--- a/fe/src/main/java/org/apache/doris/planner/OlapScanNode.java
+++ b/fe/src/main/java/org/apache/doris/planner/OlapScanNode.java
@@ -184,8 +184,7 @@ public class OlapScanNode extends ScanNode {
      * @param reasonOfDisable
      * @throws UserException
      */
-    public void updateScanRangeInfoByNewMVSelector(long selectedIndexId, boolean isPreAggregation, String
-            reasonOfDisable, Analyzer analyzer)
+    public void updateScanRangeInfoByNewMVSelector(long selectedIndexId, boolean isPreAggregation, String reasonOfDisable)
             throws UserException {
         if (selectedIndexId == this.selectedIndexId && isPreAggregation == this.isPreAggregation) {
             return;

--- a/fe/src/main/java/org/apache/doris/planner/OlapScanNode.java
+++ b/fe/src/main/java/org/apache/doris/planner/OlapScanNode.java
@@ -228,8 +228,6 @@ public class OlapScanNode extends ScanNode {
             this.isPreAggregation = isPreAggregation;
             this.reasonOfPreAggregation = reasonOfDisable;
             long start = System.currentTimeMillis();
-            computeTabletInfo();
-//            computeStats(analyzer);
             LOG.debug("distribution prune cost: {} ms", (System.currentTimeMillis() - start));
             LOG.info("Using the new scan range info instead of the old one. {}, {}", situation ,scanRangeInfo);
         } else {

--- a/fe/src/main/java/org/apache/doris/planner/OlapScanNode.java
+++ b/fe/src/main/java/org/apache/doris/planner/OlapScanNode.java
@@ -443,7 +443,8 @@ public class OlapScanNode extends ScanNode {
         // Step2: select best rollup
         long start = System.currentTimeMillis();
         if (olapTable.getKeysType() == KeysType.DUP_KEYS) {
-            isPreAggregation = true;
+            LOG.debug("The best index will be selected later in mv selector");
+            return;
         }
         final RollupSelector rollupSelector = new RollupSelector(analyzer, desc, olapTable);
         selectedIndexId = rollupSelector.selectBestRollup(selectedPartitionIds, conjuncts, isPreAggregation);

--- a/fe/src/main/java/org/apache/doris/planner/Planner.java
+++ b/fe/src/main/java/org/apache/doris/planner/Planner.java
@@ -161,12 +161,12 @@ public class Planner {
         // compute mem layout *before* finalize(); finalize() may reference
         // TupleDescriptor.avgSerializedSize
         analyzer.getDescTbl().computeMemLayout();
-        singleNodePlan.finalize(analyzer);
         // materialized view selector
         boolean selectFailed = singleNodePlanner.selectMaterializedView(queryStmt, analyzer);
         if (selectFailed) {
             throw new MVSelectFailedException("Failed to select materialize view");
         }
+        singleNodePlan.finalize(analyzer);
         if (queryOptions.num_nodes == 1) {
             // single-node execution; we're almost done
             singleNodePlan = addUnassignedConjuncts(analyzer, singleNodePlan);

--- a/fe/src/main/java/org/apache/doris/planner/RollupSelector.java
+++ b/fe/src/main/java/org/apache/doris/planner/RollupSelector.java
@@ -75,7 +75,6 @@ public final class RollupSelector {
                 return v2RollupIndexId;
             }
         }
-
         // Get first partition to select best prefix index rollups, because MaterializedIndex ids in one rollup's partitions are all same.
         final List<Long> bestPrefixIndexRollups = selectBestPrefixIndexRollup(conjuncts, isPreAggregation);
         return selectBestRowCountRollup(bestPrefixIndexRollups, partitionIds);

--- a/fe/src/main/java/org/apache/doris/planner/SingleNodePlanner.java
+++ b/fe/src/main/java/org/apache/doris/planner/SingleNodePlanner.java
@@ -752,17 +752,20 @@ public class SingleNodePlanner {
         return root;
     }
 
-    public void selectMaterializedView(QueryStmt queryStmt, Analyzer analyzer) throws UserException {
+    public boolean selectMaterializedView(QueryStmt queryStmt, Analyzer analyzer)
+            throws UserException {
+        boolean selectFailed = false;
         if (queryStmt instanceof SelectStmt) {
             SelectStmt selectStmt = (SelectStmt) queryStmt;
             for (TableRef tableRef : selectStmt.getTableRefs()) {
                 if (tableRef instanceof InlineViewRef) {
-                    selectMaterializedView(((InlineViewRef) tableRef).getViewStmt(), analyzer);
+                    selectFailed |= selectMaterializedView(((InlineViewRef) tableRef).getViewStmt(),
+                            ((InlineViewRef) tableRef).getAnalyzer());
                 }
             }
             List<ScanNode> scanNodeList = selectStmtToScanNodes.get(selectStmt.getId());
             if (scanNodeList == null) {
-                return;
+                return selectFailed;
             }
             MaterializedViewSelector materializedViewSelector = new MaterializedViewSelector(selectStmt, analyzer);
             for (ScanNode scanNode : scanNodeList) {
@@ -773,19 +776,26 @@ public class SingleNodePlanner {
                 if (olapScanNode.getSelectedPartitionIds().size() == 0 && !FeConstants.runningUnitTest) {
                     continue;
                 }
-                MaterializedViewSelector.BestIndexInfo bestIndexInfo = materializedViewSelector.selectBestMV(
-                        olapScanNode);
-                olapScanNode.updateScanRangeInfoByNewMVSelector(bestIndexInfo.getBestIndexId(), bestIndexInfo.isPreAggregation(),
-                        bestIndexInfo.getReasonOfDisable());
+                MaterializedViewSelector.BestIndexInfo bestIndexInfo = materializedViewSelector.selectBestMV(olapScanNode);
+                if (bestIndexInfo == null) {
+                    selectFailed |= true;
+                    TupleId tupleId = olapScanNode.getTupleId();
+                    selectStmt.updateDisableTuplesMVRewriter(tupleId);
+                    LOG.info("MV rewriter of tuple [] will be disable", tupleId);
+                    continue;
+                }
+                olapScanNode.updateScanRangeInfoByNewMVSelector(bestIndexInfo.getBestIndexId(),
+                        bestIndexInfo.isPreAggregation(), bestIndexInfo.getReasonOfDisable());
             }
 
         } else {
             Preconditions.checkState(queryStmt instanceof SetOperationStmt);
             SetOperationStmt unionStmt = (SetOperationStmt) queryStmt;
             for (SetOperationStmt.SetOperand unionOperand : unionStmt.getOperands()) {
-                selectMaterializedView(unionOperand.getQueryStmt(), analyzer);
+                selectFailed |= selectMaterializedView(unionOperand.getQueryStmt(), analyzer);
             }
         }
+        return selectFailed;
     }
 
     /**

--- a/fe/src/main/java/org/apache/doris/planner/SingleNodePlanner.java
+++ b/fe/src/main/java/org/apache/doris/planner/SingleNodePlanner.java
@@ -781,7 +781,7 @@ public class SingleNodePlanner {
                     selectFailed |= true;
                     TupleId tupleId = olapScanNode.getTupleId();
                     selectStmt.updateDisableTuplesMVRewriter(tupleId);
-                    LOG.info("MV rewriter of tuple [] will be disable", tupleId);
+                    LOG.debug("MV rewriter of tuple [] will be disable", tupleId);
                     continue;
                 }
                 olapScanNode.updateScanRangeInfoByNewMVSelector(bestIndexInfo.getBestIndexId(),

--- a/fe/src/main/java/org/apache/doris/planner/SingleNodePlanner.java
+++ b/fe/src/main/java/org/apache/doris/planner/SingleNodePlanner.java
@@ -785,7 +785,7 @@ public class SingleNodePlanner {
                     continue;
                 }
                 olapScanNode.updateScanRangeInfoByNewMVSelector(bestIndexInfo.getBestIndexId(),
-                        bestIndexInfo.isPreAggregation(), bestIndexInfo.getReasonOfDisable());
+                        bestIndexInfo.isPreAggregation(), bestIndexInfo.getReasonOfDisable(), analyzer);
             }
 
         } else {

--- a/fe/src/main/java/org/apache/doris/planner/SingleNodePlanner.java
+++ b/fe/src/main/java/org/apache/doris/planner/SingleNodePlanner.java
@@ -776,6 +776,9 @@ public class SingleNodePlanner {
                 if (olapScanNode.getSelectedPartitionIds().size() == 0 && !FeConstants.runningUnitTest) {
                     continue;
                 }
+                // select index by the old Rollup selector
+                olapScanNode.selectBestRollupByRollupSelector(analyzer);
+                // select index by the new Materialized selector
                 MaterializedViewSelector.BestIndexInfo bestIndexInfo = materializedViewSelector.selectBestMV(olapScanNode);
                 if (bestIndexInfo == null) {
                     selectFailed |= true;
@@ -784,6 +787,7 @@ public class SingleNodePlanner {
                     LOG.debug("MV rewriter of tuple [] will be disable", tupleId);
                     continue;
                 }
+                // if the new selected index id is different from the old one, scan node will be updated.
                 olapScanNode.updateScanRangeInfoByNewMVSelector(bestIndexInfo.getBestIndexId(),
                         bestIndexInfo.isPreAggregation(), bestIndexInfo.getReasonOfDisable(), analyzer);
             }

--- a/fe/src/main/java/org/apache/doris/planner/SingleNodePlanner.java
+++ b/fe/src/main/java/org/apache/doris/planner/SingleNodePlanner.java
@@ -789,7 +789,7 @@ public class SingleNodePlanner {
                 }
                 // if the new selected index id is different from the old one, scan node will be updated.
                 olapScanNode.updateScanRangeInfoByNewMVSelector(bestIndexInfo.getBestIndexId(),
-                        bestIndexInfo.isPreAggregation(), bestIndexInfo.getReasonOfDisable(), analyzer);
+                        bestIndexInfo.isPreAggregation(), bestIndexInfo.getReasonOfDisable());
             }
 
         } else {

--- a/fe/src/main/java/org/apache/doris/planner/StreamLoadScanNode.java
+++ b/fe/src/main/java/org/apache/doris/planner/StreamLoadScanNode.java
@@ -17,8 +17,6 @@
 
 package org.apache.doris.planner;
 
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 import org.apache.doris.analysis.Analyzer;
 import org.apache.doris.analysis.ArithmeticExpr;
 import org.apache.doris.analysis.Expr;
@@ -31,6 +29,7 @@ import org.apache.doris.analysis.StringLiteral;
 import org.apache.doris.analysis.TupleDescriptor;
 import org.apache.doris.catalog.AggregateType;
 import org.apache.doris.catalog.Column;
+import org.apache.doris.catalog.FunctionSet;
 import org.apache.doris.catalog.PrimitiveType;
 import org.apache.doris.catalog.Table;
 import org.apache.doris.catalog.Type;
@@ -49,6 +48,10 @@ import org.apache.doris.thrift.TPlanNodeType;
 import org.apache.doris.thrift.TScanRange;
 import org.apache.doris.thrift.TScanRangeLocations;
 import org.apache.doris.thrift.TUniqueId;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -188,13 +191,15 @@ public class StreamLoadScanNode extends LoadScanNode {
             // check hll_hash
             if (dstSlotDesc.getType().getPrimitiveType() == PrimitiveType.HLL) {
                 if (!(expr instanceof FunctionCallExpr)) {
-                    throw new AnalysisException("HLL column must use hll_hash function, like "
-                            + dstSlotDesc.getColumn().getName() + "=hll_hash(xxx)");
+                    throw new AnalysisException("HLL column must use " + FunctionSet.HLL_HASH + " function, like "
+                            + dstSlotDesc.getColumn().getName() + "=" + FunctionSet.HLL_HASH + "(xxx)");
                 }
                 FunctionCallExpr fn = (FunctionCallExpr) expr;
-                if (!fn.getFnName().getFunction().equalsIgnoreCase("hll_hash") && !fn.getFnName().getFunction().equalsIgnoreCase("hll_empty")) {
-                    throw new AnalysisException("HLL column must use hll_hash function, like "
-                            + dstSlotDesc.getColumn().getName() + "=hll_hash(xxx) or " + dstSlotDesc.getColumn().getName() + "=hll_empty()");
+                if (!fn.getFnName().getFunction().equalsIgnoreCase(FunctionSet.HLL_HASH)
+                        && !fn.getFnName().getFunction().equalsIgnoreCase("hll_empty")) {
+                    throw new AnalysisException("HLL column must use " + FunctionSet.HLL_HASH + " function, like "
+                            + dstSlotDesc.getColumn().getName() + "=" + FunctionSet.HLL_HASH
+                            + "(xxx) or " + dstSlotDesc.getColumn().getName() + "=hll_empty()");
                 }
                 expr.setType(Type.HLL);
             }

--- a/fe/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -64,8 +64,6 @@ import org.apache.doris.mysql.MysqlSerializer;
 import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.planner.Planner;
 import org.apache.doris.proto.PQueryStatistics;
-import org.apache.doris.qe.QueryDetail;
-import org.apache.doris.qe.QueryDetailQueue;
 import org.apache.doris.qe.QueryState.MysqlStateType;
 import org.apache.doris.rewrite.ExprRewriter;
 import org.apache.doris.rewrite.mvrewrite.MVSelectFailedException;
@@ -441,6 +439,11 @@ public class StmtExecutor {
             try {
                 analyzeAndGenerateQueryPlan(tQueryOptions);
             } catch (MVSelectFailedException e) {
+                /**
+                 * If there is MVSelectFailedException after the first planner, there will be error mv rewritten in query.
+                 * So, the query should be reanalyzed without mv rewritten and planner again.
+                 * Attention: Only error rewritten tuple is forbidden to mv rewrite in the second time.
+                 */
                 resetAnalyzerAndStmt();
                 analyzeAndGenerateQueryPlan(tQueryOptions);
             } catch (UserException e) {

--- a/fe/src/main/java/org/apache/doris/rewrite/ExprRewriteRule.java
+++ b/fe/src/main/java/org/apache/doris/rewrite/ExprRewriteRule.java
@@ -22,7 +22,7 @@ import org.apache.doris.analysis.Expr;
 import org.apache.doris.common.AnalysisException;
 
 /**
- * Base class for all Expr rewrite rules. A rule is free to modify Exprs in place,
+ * Base class for all Expr equal rules. A rule is free to modify Exprs in place,
  * but must return a different Expr object if any modifications were made.
  * An ExprRewriteRule is intended to apply its transformation on a single Expr and not
  * recursively on all its children. The recursive and repeated application of
@@ -35,10 +35,10 @@ import org.apache.doris.common.AnalysisException;
  */
 public interface ExprRewriteRule {
     /**
-     * Applies this rewrite rule to the given analyzed Expr. Returns the transformed and
+     * Applies this equal rule to the given analyzed Expr. Returns the transformed and
      * analyzed Expr or the original unmodified Expr if no changes were made. If any
      * changes were made, the transformed Expr is guaranteed to be a different Expr object,
      * so callers can rely on object reference comparison for change detection.
      */
-    public abstract Expr apply(Expr expr, Analyzer analyzer) throws AnalysisException;
+    Expr apply(Expr expr, Analyzer analyzer) throws AnalysisException;
 }

--- a/fe/src/main/java/org/apache/doris/rewrite/mvrewrite/CountDistinctToBitmap.java
+++ b/fe/src/main/java/org/apache/doris/rewrite/mvrewrite/CountDistinctToBitmap.java
@@ -1,0 +1,101 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.rewrite.mvrewrite;
+
+import org.apache.doris.analysis.Analyzer;
+import org.apache.doris.analysis.CreateMaterializedViewStmt;
+import org.apache.doris.analysis.Expr;
+import org.apache.doris.analysis.FunctionCallExpr;
+import org.apache.doris.analysis.SlotRef;
+import org.apache.doris.analysis.TableName;
+import org.apache.doris.catalog.AggregateType;
+import org.apache.doris.catalog.Column;
+import org.apache.doris.catalog.OlapTable;
+import org.apache.doris.catalog.Table;
+import org.apache.doris.common.AnalysisException;
+import org.apache.doris.rewrite.ExprRewriteRule;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+
+import java.util.List;
+
+/**
+ * For duplicate table, the count distinct(k1) could be rewritten to bitmap_union_count(mv_to_bitmap_k1) when bitmap
+ * mv exists.
+ * For example:
+ * Table: (k1 int, k2 int)
+ * MV: (k1 int, mv_bitmap_union_k2 bitmap bitmap_union)
+ * mv_to_bitmap_k2 = to_bitmap(k2)
+ * Query: select k1, count(distinct k2) from table group by k1
+ * Rewritten query: select k1, bitmap_union_count(mv_to_bitmap_k2) from table group by k1
+ */
+public class CountDistinctToBitmap implements ExprRewriteRule {
+
+    public static final ExprRewriteRule INSTANCE = new CountDistinctToBitmap();
+
+    @Override
+    public Expr apply(Expr expr, Analyzer analyzer) throws AnalysisException {
+        // meet condition
+        if (!(expr instanceof FunctionCallExpr)) {
+            return expr;
+        }
+        FunctionCallExpr fnExpr = (FunctionCallExpr) expr;
+        if (!fnExpr.getParams().isDistinct()) {
+            return expr;
+        }
+        if (!fnExpr.getFnName().getFunction().equalsIgnoreCase("count")) {
+            return expr;
+        }
+        if (fnExpr.getChildren().size() != 1 || !(fnExpr.getChild(0) instanceof SlotRef)) {
+            return expr;
+        }
+        SlotRef fnChild0 = (SlotRef) fnExpr.getChild(0);
+        Column column = fnChild0.getColumn();
+        Table table = fnChild0.getTable();
+        if (column == null || table == null || !(table instanceof OlapTable)) {
+            return expr;
+        }
+        OlapTable olapTable = (OlapTable) table;
+
+        // check column
+        String queryColumnName = column.getName();
+        String mvColumnName = CreateMaterializedViewStmt
+                .mvColumnBuilder(AggregateType.BITMAP_UNION.name().toLowerCase(), queryColumnName);
+        Column mvColumn = olapTable.getVisibleColumn(mvColumnName);
+        if (mvColumn == null) {
+            return expr;
+        }
+
+        // rewrite expr
+        return rewriteExpr(fnChild0, mvColumn, analyzer);
+    }
+
+    public Expr rewriteExpr(SlotRef queryColumnSlotRef, Column mvColumn, Analyzer analyzer) {
+        Preconditions.checkNotNull(mvColumn);
+        Preconditions.checkNotNull(queryColumnSlotRef);
+        TableName tableName = queryColumnSlotRef.getTableName();
+        Preconditions.checkNotNull(tableName);
+        SlotRef mvSlotRef = new SlotRef(tableName, mvColumn.getName());
+        List<Expr> newFnParams = Lists.newArrayList();
+        newFnParams.add(mvSlotRef);
+        FunctionCallExpr result = new FunctionCallExpr("bitmap_union_count", newFnParams);
+        result.analyzeNoThrow(analyzer);
+        return result;
+    }
+}

--- a/fe/src/main/java/org/apache/doris/rewrite/mvrewrite/CountDistinctToBitmap.java
+++ b/fe/src/main/java/org/apache/doris/rewrite/mvrewrite/CountDistinctToBitmap.java
@@ -25,6 +25,7 @@ import org.apache.doris.analysis.SlotRef;
 import org.apache.doris.analysis.TableName;
 import org.apache.doris.catalog.AggregateType;
 import org.apache.doris.catalog.Column;
+import org.apache.doris.catalog.FunctionSet;
 import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.catalog.Table;
 import org.apache.doris.common.AnalysisException;
@@ -59,7 +60,7 @@ public class CountDistinctToBitmap implements ExprRewriteRule {
         if (!fnExpr.getParams().isDistinct()) {
             return expr;
         }
-        if (!fnExpr.getFnName().getFunction().equalsIgnoreCase("count")) {
+        if (!fnExpr.getFnName().getFunction().equalsIgnoreCase(FunctionSet.COUNT)) {
             return expr;
         }
         if (fnExpr.getChildren().size() != 1 || !(fnExpr.getChild(0) instanceof SlotRef)) {

--- a/fe/src/main/java/org/apache/doris/rewrite/mvrewrite/CountDistinctToBitmap.java
+++ b/fe/src/main/java/org/apache/doris/rewrite/mvrewrite/CountDistinctToBitmap.java
@@ -86,7 +86,7 @@ public class CountDistinctToBitmap implements ExprRewriteRule {
         return rewriteExpr(fnChild0, mvColumn, analyzer);
     }
 
-    public Expr rewriteExpr(SlotRef queryColumnSlotRef, Column mvColumn, Analyzer analyzer) {
+    private Expr rewriteExpr(SlotRef queryColumnSlotRef, Column mvColumn, Analyzer analyzer) {
         Preconditions.checkNotNull(mvColumn);
         Preconditions.checkNotNull(queryColumnSlotRef);
         TableName tableName = queryColumnSlotRef.getTableName();

--- a/fe/src/main/java/org/apache/doris/rewrite/mvrewrite/CountDistinctToBitmapOrHLLRule.java
+++ b/fe/src/main/java/org/apache/doris/rewrite/mvrewrite/CountDistinctToBitmapOrHLLRule.java
@@ -1,0 +1,71 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.rewrite.mvrewrite;
+
+import org.apache.doris.analysis.Analyzer;
+import org.apache.doris.analysis.Expr;
+import org.apache.doris.analysis.FunctionCallExpr;
+import org.apache.doris.analysis.FunctionParams;
+import org.apache.doris.catalog.FunctionSet;
+import org.apache.doris.common.AnalysisException;
+import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.rewrite.ExprRewriteRule;
+
+/**
+ * For agg keys type, the count distinct could be rewritten to bitmap or hll depends on the type of column.
+ * For example:
+ * Table: (k1 int, k2 bitmap bitmap_union) agg key(k1)
+ * Query: select k1, count(distinct k2) from table group by k1
+ * Rewritten query: select k1, bitmap_union_count(k2) from table group by k1
+ * <p>
+ * Table: (k1 int, k2 hll hll_union) agg key(k1)
+ * Query: select k1, count(distinct k2) from table group by k1
+ * Rewritten query: select k1, hll_union_agg(k2) from table group by k1
+ * <p>
+ * Attention: this rule only apply AGG keys type.
+ */
+public class CountDistinctToBitmapOrHLLRule implements ExprRewriteRule {
+    public static final ExprRewriteRule INSTANCE = new CountDistinctToBitmapOrHLLRule();
+
+    @Override
+    public Expr apply(Expr expr, Analyzer analyzer) throws AnalysisException {
+        if (ConnectContext.get() == null || !ConnectContext.get().getSessionVariable().isRewriteCountDistinct()) {
+            return expr;
+        }
+
+        // meet condition
+        if (!(expr instanceof FunctionCallExpr)) {
+            return expr;
+        }
+        FunctionCallExpr fnExpr = (FunctionCallExpr) expr;
+        if (!fnExpr.isCountDistinctBitmapOrHLL()) {
+            return expr;
+        }
+        // rewrite expr
+        FunctionParams newParams = new FunctionParams(false, fnExpr.getParams().exprs());
+        if (fnExpr.getChild(0).getType().isBitmapType()) {
+            FunctionCallExpr bitmapExpr = new FunctionCallExpr(FunctionSet.BITMAP_UNION_COUNT, newParams);
+            bitmapExpr.analyzeNoThrow(analyzer);
+            return bitmapExpr;
+        } else {
+            FunctionCallExpr hllExpr = new FunctionCallExpr("hll_union_agg", newParams);
+            hllExpr.analyzeNoThrow(analyzer);
+            return hllExpr;
+        }
+    }
+}

--- a/fe/src/main/java/org/apache/doris/rewrite/mvrewrite/CountFieldToSum.java
+++ b/fe/src/main/java/org/apache/doris/rewrite/mvrewrite/CountFieldToSum.java
@@ -79,7 +79,7 @@ public class CountFieldToSum implements ExprRewriteRule {
         return rewriteExpr(fnChild0, mvColumn, analyzer);
     }
 
-    public Expr rewriteExpr(SlotRef queryColumnSlotRef, Column mvColumn, Analyzer analyzer) {
+    private Expr rewriteExpr(SlotRef queryColumnSlotRef, Column mvColumn, Analyzer analyzer) {
         Preconditions.checkNotNull(mvColumn);
         Preconditions.checkNotNull(queryColumnSlotRef);
         TableName tableName = queryColumnSlotRef.getTableName();

--- a/fe/src/main/java/org/apache/doris/rewrite/mvrewrite/CountFieldToSum.java
+++ b/fe/src/main/java/org/apache/doris/rewrite/mvrewrite/CountFieldToSum.java
@@ -1,0 +1,94 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.rewrite.mvrewrite;
+
+import org.apache.doris.analysis.Analyzer;
+import org.apache.doris.analysis.CreateMaterializedViewStmt;
+import org.apache.doris.analysis.Expr;
+import org.apache.doris.analysis.FunctionCallExpr;
+import org.apache.doris.analysis.SlotRef;
+import org.apache.doris.analysis.TableName;
+import org.apache.doris.catalog.Column;
+import org.apache.doris.catalog.OlapTable;
+import org.apache.doris.catalog.Table;
+import org.apache.doris.common.AnalysisException;
+import org.apache.doris.rewrite.ExprRewriteRule;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+
+import java.util.List;
+
+/**
+ * Rewrite count(k1) to sum(mv_count_k1) when MV Column exists.
+ * For example:
+ * Table: (k1 int ,k2 varchar)
+ * MV: (k1 int, mv_count_k2 bigint sum)
+ *       mv_count_k1 = case when k2 is null then 0 else 1
+ * Query: select k1, count(k2) from table group by k1
+ * Rewritten query: select k1, sum(mv_count_k2) from table group by k1
+ */
+public class CountFieldToSum implements ExprRewriteRule {
+    public static final ExprRewriteRule INSTANCE = new CountFieldToSum();
+
+    @Override
+    public Expr apply(Expr expr, Analyzer analyzer) throws AnalysisException {
+        // meet condition
+        if (!(expr instanceof FunctionCallExpr)) {
+            return expr;
+        }
+        FunctionCallExpr fnExpr = (FunctionCallExpr) expr;
+        if (!fnExpr.getFnName().getFunction().equalsIgnoreCase("count")) {
+            return expr;
+        }
+        if (fnExpr.getChildren().size() != 1 || !(fnExpr.getChild(0) instanceof SlotRef)) {
+            return expr;
+        }
+        SlotRef fnChild0 = (SlotRef) fnExpr.getChild(0);
+        Column column = fnChild0.getColumn();
+        Table table = fnChild0.getTable();
+        if (column == null || table == null || !(table instanceof OlapTable)) {
+            return expr;
+        }
+        OlapTable olapTable = (OlapTable) table;
+
+        // check column
+        String queryColumnName = column.getName();
+        String mvColumnName = CreateMaterializedViewStmt.mvColumnBuilder("count", queryColumnName);
+        Column mvColumn = olapTable.getVisibleColumn(mvColumnName);
+        if (mvColumn == null) {
+            return expr;
+        }
+
+        // rewrite expr
+        return rewriteExpr(fnChild0, mvColumn, analyzer);
+    }
+
+    public Expr rewriteExpr(SlotRef queryColumnSlotRef, Column mvColumn, Analyzer analyzer) {
+        Preconditions.checkNotNull(mvColumn);
+        Preconditions.checkNotNull(queryColumnSlotRef);
+        TableName tableName = queryColumnSlotRef.getTableName();
+        Preconditions.checkNotNull(tableName);
+        SlotRef mvSlotRef = new SlotRef(tableName, mvColumn.getName());
+        List<Expr> newFnParams = Lists.newArrayList();
+        newFnParams.add(mvSlotRef);
+        FunctionCallExpr result = new FunctionCallExpr("sum", newFnParams);
+        result.analyzeNoThrow(analyzer);
+        return result;
+    }
+}

--- a/fe/src/main/java/org/apache/doris/rewrite/mvrewrite/CountFieldToSum.java
+++ b/fe/src/main/java/org/apache/doris/rewrite/mvrewrite/CountFieldToSum.java
@@ -24,6 +24,7 @@ import org.apache.doris.analysis.FunctionCallExpr;
 import org.apache.doris.analysis.SlotRef;
 import org.apache.doris.analysis.TableName;
 import org.apache.doris.catalog.Column;
+import org.apache.doris.catalog.FunctionSet;
 import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.catalog.Table;
 import org.apache.doris.common.AnalysisException;
@@ -53,7 +54,7 @@ public class CountFieldToSum implements ExprRewriteRule {
             return expr;
         }
         FunctionCallExpr fnExpr = (FunctionCallExpr) expr;
-        if (!fnExpr.getFnName().getFunction().equalsIgnoreCase("count")) {
+        if (!fnExpr.getFnName().getFunction().equalsIgnoreCase(FunctionSet.COUNT)) {
             return expr;
         }
         if (fnExpr.getChildren().size() != 1 || !(fnExpr.getChild(0) instanceof SlotRef)) {
@@ -69,7 +70,7 @@ public class CountFieldToSum implements ExprRewriteRule {
 
         // check column
         String queryColumnName = column.getName();
-        String mvColumnName = CreateMaterializedViewStmt.mvColumnBuilder("count", queryColumnName);
+        String mvColumnName = CreateMaterializedViewStmt.mvColumnBuilder(FunctionSet.COUNT, queryColumnName);
         Column mvColumn = olapTable.getVisibleColumn(mvColumnName);
         if (mvColumn == null) {
             return expr;

--- a/fe/src/main/java/org/apache/doris/rewrite/mvrewrite/FunctionCallEqualRule.java
+++ b/fe/src/main/java/org/apache/doris/rewrite/mvrewrite/FunctionCallEqualRule.java
@@ -20,6 +20,7 @@ package org.apache.doris.rewrite.mvrewrite;
 import org.apache.doris.analysis.CastExpr;
 import org.apache.doris.analysis.Expr;
 import org.apache.doris.analysis.FunctionCallExpr;
+import org.apache.doris.catalog.FunctionSet;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSetMultimap;
@@ -34,13 +35,13 @@ public class FunctionCallEqualRule implements MVExprEqualRule {
         builder.put("sum", "sum");
         builder.put("max", "max");
         builder.put("min", "min");
-        builder.put("bitmap_union", "bitmap_union");
-        builder.put("bitmap_union", "bitmap_union_count");
-        builder.put("hll_union", "hll_union_agg");
-        builder.put("hll_union", "hll_union");
-        builder.put("hll_union", "hll_raw_agg");
-        builder.put("to_bitmap", "to_bitmap");
-        builder.put("hll_hash", "hll_hash");
+        builder.put(FunctionSet.BITMAP_UNION, FunctionSet.BITMAP_UNION);
+        builder.put(FunctionSet.BITMAP_UNION, FunctionSet.BITMAP_UNION_COUNT);
+        builder.put(FunctionSet.HLL_UNION, "hll_union_agg");
+        builder.put(FunctionSet.HLL_UNION, "hll_union");
+        builder.put(FunctionSet.HLL_UNION, "hll_raw_agg");
+        builder.put(FunctionSet.TO_BITMAP, FunctionSet.TO_BITMAP);
+        builder.put(FunctionSet.HLL_HASH, FunctionSet.HLL_HASH);
         columnAggTypeMatchFnName = builder.build();
     }
 

--- a/fe/src/main/java/org/apache/doris/rewrite/mvrewrite/FunctionCallEqualRule.java
+++ b/fe/src/main/java/org/apache/doris/rewrite/mvrewrite/FunctionCallEqualRule.java
@@ -1,0 +1,78 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.rewrite.mvrewrite;
+
+import org.apache.doris.analysis.CastExpr;
+import org.apache.doris.analysis.Expr;
+import org.apache.doris.analysis.FunctionCallExpr;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableSetMultimap;
+
+public class FunctionCallEqualRule implements MVExprEqualRule {
+
+    public static MVExprEqualRule INSTANCE = new FunctionCallEqualRule();
+    private static final ImmutableSetMultimap<String, String> columnAggTypeMatchFnName;
+
+    static {
+        ImmutableSetMultimap.Builder<String, String> builder = ImmutableSetMultimap.builder();
+        builder.put("sum", "sum");
+        builder.put("max", "max");
+        builder.put("min", "min");
+        builder.put("bitmap_union", "bitmap_union");
+        builder.put("bitmap_union", "bitmap_union_count");
+        builder.put("hll_union", "hll_union_agg");
+        builder.put("hll_union", "hll_union");
+        builder.put("hll_union", "hll_raw_agg");
+        builder.put("to_bitmap", "to_bitmap");
+        builder.put("hll_hash", "hll_hash");
+        columnAggTypeMatchFnName = builder.build();
+    }
+
+    @Override
+    public boolean equal(Expr queryExpr, Expr mvColumnExpr) {
+        if ((!(queryExpr instanceof FunctionCallExpr)) || (!(mvColumnExpr instanceof FunctionCallExpr))) {
+            return false;
+        }
+        FunctionCallExpr queryFn = (FunctionCallExpr) queryExpr;
+        FunctionCallExpr mvColumnFn = (FunctionCallExpr) mvColumnExpr;
+        // match fn name
+        if (!columnAggTypeMatchFnName.get(mvColumnFn.getFnName().getFunction())
+                .contains(queryFn.getFnName().getFunction().toLowerCase())) {
+            return false;
+        }
+        // match children
+        if (queryFn.getChildren().size() != mvColumnFn.getChildren().size()) {
+            return false;
+        }
+        Preconditions.checkState(queryFn.getChildren().size() == 1);
+        // remove cast to function
+        Expr queryFnChild0 = queryFn.getChild(0);
+        if (queryFnChild0 instanceof CastExpr) {
+            queryFnChild0 = queryFnChild0.getChild(0);
+        }
+        Expr mvColumnFnChild0 = mvColumnFn.getChild(0);
+        if (mvColumnFnChild0 instanceof CastExpr) {
+            mvColumnFnChild0 = mvColumnFnChild0.getChild(0);
+        }
+        if (MVExprEquivalent.mvExprEqual(queryFnChild0, mvColumnFnChild0)) {
+            return true;
+        }
+        return false;
+    }
+}

--- a/fe/src/main/java/org/apache/doris/rewrite/mvrewrite/HLLHashToSlotRefRule.java
+++ b/fe/src/main/java/org/apache/doris/rewrite/mvrewrite/HLLHashToSlotRefRule.java
@@ -99,7 +99,7 @@ public class HLLHashToSlotRefRule implements ExprRewriteRule {
         return rewriteExpr(fnNameString, queryColumnSlotRef, mvColumn, analyzer);
     }
 
-    public Expr rewriteExpr(String fnName, SlotRef queryColumnSlotRef, Column mvColumn, Analyzer analyzer) {
+    private Expr rewriteExpr(String fnName, SlotRef queryColumnSlotRef, Column mvColumn, Analyzer analyzer) {
         Preconditions.checkNotNull(mvColumn);
         Preconditions.checkNotNull(queryColumnSlotRef);
         TableName tableName = queryColumnSlotRef.getTableName();

--- a/fe/src/main/java/org/apache/doris/rewrite/mvrewrite/HLLHashToSlotRefRule.java
+++ b/fe/src/main/java/org/apache/doris/rewrite/mvrewrite/HLLHashToSlotRefRule.java
@@ -1,0 +1,114 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.rewrite.mvrewrite;
+
+import org.apache.doris.analysis.Analyzer;
+import org.apache.doris.analysis.CastExpr;
+import org.apache.doris.analysis.CreateMaterializedViewStmt;
+import org.apache.doris.analysis.Expr;
+import org.apache.doris.analysis.FunctionCallExpr;
+import org.apache.doris.analysis.SlotRef;
+import org.apache.doris.analysis.TableName;
+import org.apache.doris.catalog.AggregateType;
+import org.apache.doris.catalog.Column;
+import org.apache.doris.catalog.OlapTable;
+import org.apache.doris.catalog.Table;
+import org.apache.doris.common.AnalysisException;
+import org.apache.doris.rewrite.ExprRewriteRule;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+
+import java.util.List;
+
+/*
+Rewrite hll_union(hll_hash(c1)) to hll_union(mv_hll_union_c1)
+Rewrite hll_raw_agg(hll_hash(c1)) to hll_raw_agg(mv_hll_union_c1)
+Rewrite hll_union_agg(hll_hash(c1)) to hll_union_agg(mv_hll_union_c1)
+ */
+public class HLLHashToSlotRefRule implements ExprRewriteRule {
+
+    public static final ExprRewriteRule INSTANCE = new HLLHashToSlotRefRule();
+
+    @Override
+    public Expr apply(Expr expr, Analyzer analyzer) throws AnalysisException {
+        SlotRef queryColumnSlotRef;
+        Column mvColumn;
+
+        // meet the condition
+        if (!(expr instanceof FunctionCallExpr)) {
+            return expr;
+        }
+        FunctionCallExpr fnExpr = (FunctionCallExpr) expr;
+        String fnNameString = fnExpr.getFnName().getFunction();
+        if (!fnNameString.equalsIgnoreCase("hll_union")
+                && !fnNameString.equalsIgnoreCase("hll_raw_agg")
+                && !fnNameString.equalsIgnoreCase("hll_union_agg")) {
+            return expr;
+        }
+        if (!(fnExpr.getChild(0) instanceof FunctionCallExpr)) {
+            return expr;
+        }
+        FunctionCallExpr child0FnExpr = (FunctionCallExpr) fnExpr.getChild(0);
+        if (!child0FnExpr.getFnName().getFunction().equalsIgnoreCase("hll_hash")) {
+            return expr;
+        }
+        if (child0FnExpr.getChild(0) instanceof SlotRef) {
+            queryColumnSlotRef = (SlotRef) child0FnExpr.getChild(0);
+        } else if (child0FnExpr.getChild(0) instanceof CastExpr) {
+            CastExpr castExpr = (CastExpr) child0FnExpr.getChild(0);
+            if (!(castExpr.getChild(0) instanceof SlotRef)) {
+                return expr;
+            }
+            queryColumnSlotRef = (SlotRef) castExpr.getChild(0);
+        } else {
+            return expr;
+        }
+        Column column = queryColumnSlotRef.getColumn();
+        Table table = queryColumnSlotRef.getTable();
+        if (column == null || table == null || !(table instanceof OlapTable)) {
+            return expr;
+        }
+        OlapTable olapTable = (OlapTable) table;
+
+        // check column
+        String queryColumnName = column.getName();
+        String mvColumnName = CreateMaterializedViewStmt
+                .mvColumnBuilder(AggregateType.HLL_UNION.name().toLowerCase(), queryColumnName);
+        mvColumn = olapTable.getVisibleColumn(mvColumnName);
+        if (mvColumn == null) {
+            return expr;
+        }
+
+        // equal expr
+        return rewriteExpr(fnNameString, queryColumnSlotRef, mvColumn, analyzer);
+    }
+
+    public Expr rewriteExpr(String fnName, SlotRef queryColumnSlotRef, Column mvColumn, Analyzer analyzer) {
+        Preconditions.checkNotNull(mvColumn);
+        Preconditions.checkNotNull(queryColumnSlotRef);
+        TableName tableName = queryColumnSlotRef.getTableName();
+        Preconditions.checkNotNull(tableName);
+        SlotRef mvSlotRef = new SlotRef(tableName, mvColumn.getName());
+        List<Expr> newFnParams = Lists.newArrayList();
+        newFnParams.add(mvSlotRef);
+        FunctionCallExpr result = new FunctionCallExpr(fnName, newFnParams);
+        result.analyzeNoThrow(analyzer);
+        return result;
+    }
+}

--- a/fe/src/main/java/org/apache/doris/rewrite/mvrewrite/MVExprEqualRule.java
+++ b/fe/src/main/java/org/apache/doris/rewrite/mvrewrite/MVExprEqualRule.java
@@ -1,0 +1,25 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.rewrite.mvrewrite;
+
+import org.apache.doris.analysis.Expr;
+
+public interface MVExprEqualRule {
+
+    boolean equal(Expr queryExpr, Expr mvColumnExpr);
+}

--- a/fe/src/main/java/org/apache/doris/rewrite/mvrewrite/MVExprEquivalent.java
+++ b/fe/src/main/java/org/apache/doris/rewrite/mvrewrite/MVExprEquivalent.java
@@ -21,10 +21,10 @@ import org.apache.doris.analysis.Expr;
 
 import com.google.common.collect.ImmutableList;
 
-/*
-Only support the once match from originExpr and newExpr
-TODO：one query expr could be calculate by a group by mv columns
-TODO: mvExprEqual(queryexpr, mvColumnExprList)
+/**
+ * Only support the once match from originExpr and newExpr
+ * TODO：one query expr could be calculate by a group by mv columns
+ * TODO: mvExprEqual(queryexpr, mvColumnExprList)
  */
 public class MVExprEquivalent {
 

--- a/fe/src/main/java/org/apache/doris/rewrite/mvrewrite/MVExprEquivalent.java
+++ b/fe/src/main/java/org/apache/doris/rewrite/mvrewrite/MVExprEquivalent.java
@@ -1,0 +1,45 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.rewrite.mvrewrite;
+
+import org.apache.doris.analysis.Expr;
+
+import com.google.common.collect.ImmutableList;
+
+/*
+Only support the once match from originExpr and newExpr
+TODO：one query expr could be calculate by a group by mv columns
+TODO: mvExprEqual(queryexpr, mvColumnExprList)
+ */
+public class MVExprEquivalent {
+
+    private static final ImmutableList<MVExprEqualRule> exprRewriteRuleList = ImmutableList
+            .<MVExprEqualRule>builder()
+            .add(FunctionCallEqualRule.INSTANCE)
+            .add(SlotRefEqualRule.INSTANCE)
+            .build();
+
+    public static boolean mvExprEqual(Expr queryExpr, Expr mvColumnExpr) {
+        for (MVExprEqualRule rule : exprRewriteRuleList) {
+            if (rule.equal(queryExpr, mvColumnExpr)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/fe/src/main/java/org/apache/doris/rewrite/mvrewrite/MVSelectFailedException.java
+++ b/fe/src/main/java/org/apache/doris/rewrite/mvrewrite/MVSelectFailedException.java
@@ -1,0 +1,27 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.rewrite.mvrewrite;
+
+import org.apache.doris.common.UserException;
+
+public class MVSelectFailedException extends UserException {
+
+    public MVSelectFailedException(String msg) {
+        super(msg);
+    }
+}

--- a/fe/src/main/java/org/apache/doris/rewrite/mvrewrite/NDVToHll.java
+++ b/fe/src/main/java/org/apache/doris/rewrite/mvrewrite/NDVToHll.java
@@ -1,0 +1,97 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.rewrite.mvrewrite;
+
+import org.apache.doris.analysis.Analyzer;
+import org.apache.doris.analysis.CreateMaterializedViewStmt;
+import org.apache.doris.analysis.Expr;
+import org.apache.doris.analysis.FunctionCallExpr;
+import org.apache.doris.analysis.SlotRef;
+import org.apache.doris.analysis.TableName;
+import org.apache.doris.catalog.AggregateType;
+import org.apache.doris.catalog.Column;
+import org.apache.doris.catalog.OlapTable;
+import org.apache.doris.catalog.Table;
+import org.apache.doris.common.AnalysisException;
+import org.apache.doris.rewrite.ExprRewriteRule;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+
+import java.util.List;
+
+/**
+ * For duplicate table, the ndv(k1) could be rewritten to hll_union_agg(mv_hll_hash_k1) when bitmap
+ * mv exists.
+ * For example:
+ * Table: (k1 int, k2 int)
+ * MV: (k1 int, mv_hll_hash_k2 hll hll_union)
+ * mv_hll_hash_k2 = hll_hash(k2)
+ * Query: select k1, count(distinct k2) from table group by k1
+ * Rewritten query: select k1, hll_union_agg(mv_hll_hash_k2) from table group by k1
+ */
+public class NDVToHll implements ExprRewriteRule{
+    public static final ExprRewriteRule INSTANCE = new NDVToHll();
+
+    @Override
+    public Expr apply(Expr expr, Analyzer analyzer) throws AnalysisException {
+        // meet condition
+        if (!(expr instanceof FunctionCallExpr)) {
+            return expr;
+        }
+        FunctionCallExpr fnExpr = (FunctionCallExpr) expr;
+        if (!fnExpr.getFnName().getFunction().equalsIgnoreCase("ndv")) {
+            return expr;
+        }
+        if (fnExpr.getChildren().size() != 1 || !(fnExpr.getChild(0) instanceof SlotRef)) {
+            return expr;
+        }
+        SlotRef fnChild0 = (SlotRef) fnExpr.getChild(0);
+        Column column = fnChild0.getColumn();
+        Table table = fnChild0.getTable();
+        if (column == null || table == null || !(table instanceof OlapTable)) {
+            return expr;
+        }
+        OlapTable olapTable = (OlapTable) table;
+
+        // check column
+        String queryColumnName = column.getName();
+        String mvColumnName = CreateMaterializedViewStmt
+                .mvColumnBuilder(AggregateType.HLL_UNION.name().toLowerCase(), queryColumnName);
+        Column mvColumn = olapTable.getVisibleColumn(mvColumnName);
+        if (mvColumn == null) {
+            return expr;
+        }
+
+        // rewrite expr
+        return rewriteExpr(fnChild0, mvColumn, analyzer);
+    }
+
+    public Expr rewriteExpr(SlotRef queryColumnSlotRef, Column mvColumn, Analyzer analyzer) {
+        Preconditions.checkNotNull(mvColumn);
+        Preconditions.checkNotNull(queryColumnSlotRef);
+        TableName tableName = queryColumnSlotRef.getTableName();
+        Preconditions.checkNotNull(tableName);
+        SlotRef mvSlotRef = new SlotRef(tableName, mvColumn.getName());
+        List<Expr> newFnParams = Lists.newArrayList();
+        newFnParams.add(mvSlotRef);
+        FunctionCallExpr result = new FunctionCallExpr("hll_union_agg", newFnParams);
+        result.analyzeNoThrow(analyzer);
+        return result;
+    }
+}

--- a/fe/src/main/java/org/apache/doris/rewrite/mvrewrite/NDVToHll.java
+++ b/fe/src/main/java/org/apache/doris/rewrite/mvrewrite/NDVToHll.java
@@ -36,14 +36,14 @@ import com.google.common.collect.Lists;
 import java.util.List;
 
 /**
- * For duplicate table, the ndv(k1) could be rewritten to hll_union_agg(mv_hll_hash_k1) when bitmap
+ * For duplicate table, the ndv(k1) could be rewritten to hll_union_agg(mv_hll_union_k1) when bitmap
  * mv exists.
  * For example:
  * Table: (k1 int, k2 int)
- * MV: (k1 int, mv_hll_hash_k2 hll hll_union)
- * mv_hll_hash_k2 = hll_hash(k2)
+ * MV: (k1 int, mv_hll_union_k2 hll hll_union)
+ * mv_hll_union_k2 = hll_hash(k2)
  * Query: select k1, count(distinct k2) from table group by k1
- * Rewritten query: select k1, hll_union_agg(mv_hll_hash_k2) from table group by k1
+ * Rewritten query: select k1, hll_union_agg(mv_hll_union_k2) from table group by k1
  */
 public class NDVToHll implements ExprRewriteRule{
     public static final ExprRewriteRule INSTANCE = new NDVToHll();

--- a/fe/src/main/java/org/apache/doris/rewrite/mvrewrite/NDVToHll.java
+++ b/fe/src/main/java/org/apache/doris/rewrite/mvrewrite/NDVToHll.java
@@ -82,7 +82,7 @@ public class NDVToHll implements ExprRewriteRule{
         return rewriteExpr(fnChild0, mvColumn, analyzer);
     }
 
-    public Expr rewriteExpr(SlotRef queryColumnSlotRef, Column mvColumn, Analyzer analyzer) {
+    private Expr rewriteExpr(SlotRef queryColumnSlotRef, Column mvColumn, Analyzer analyzer) {
         Preconditions.checkNotNull(mvColumn);
         Preconditions.checkNotNull(queryColumnSlotRef);
         TableName tableName = queryColumnSlotRef.getTableName();

--- a/fe/src/main/java/org/apache/doris/rewrite/mvrewrite/SlotRefEqualRule.java
+++ b/fe/src/main/java/org/apache/doris/rewrite/mvrewrite/SlotRefEqualRule.java
@@ -1,0 +1,39 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.rewrite.mvrewrite;
+
+import org.apache.doris.analysis.Expr;
+import org.apache.doris.analysis.SlotRef;
+
+public class SlotRefEqualRule implements MVExprEqualRule {
+
+    public static MVExprEqualRule INSTANCE = new SlotRefEqualRule();
+
+    @Override
+    public boolean equal(Expr queryExpr, Expr mvColumnExpr) {
+        if ((!(queryExpr instanceof SlotRef)) || (!(mvColumnExpr instanceof SlotRef))) {
+            return false;
+        }
+        SlotRef querySlotRef = (SlotRef) queryExpr;
+        SlotRef mvColumnSlotRef = (SlotRef) mvColumnExpr;
+        if (querySlotRef.getColumnName().equalsIgnoreCase(mvColumnSlotRef.getColumnName())) {
+            return true;
+        }
+        return false;
+    }
+}

--- a/fe/src/main/java/org/apache/doris/rewrite/mvrewrite/ToBitmapToSlotRefRule.java
+++ b/fe/src/main/java/org/apache/doris/rewrite/mvrewrite/ToBitmapToSlotRefRule.java
@@ -98,7 +98,7 @@ public class ToBitmapToSlotRefRule implements ExprRewriteRule {
         return rewriteExpr(fnNameString, queryColumnSlotRef, mvColumn, analyzer);
     }
 
-    public Expr rewriteExpr(String fnName, SlotRef queryColumnSlotRef, Column mvColumn, Analyzer analyzer) {
+    private Expr rewriteExpr(String fnName, SlotRef queryColumnSlotRef, Column mvColumn, Analyzer analyzer) {
         Preconditions.checkNotNull(mvColumn);
         Preconditions.checkNotNull(queryColumnSlotRef);
         TableName tableName = queryColumnSlotRef.getTableName();

--- a/fe/src/main/java/org/apache/doris/rewrite/mvrewrite/ToBitmapToSlotRefRule.java
+++ b/fe/src/main/java/org/apache/doris/rewrite/mvrewrite/ToBitmapToSlotRefRule.java
@@ -37,9 +37,9 @@ import com.google.common.collect.Lists;
 
 import java.util.List;
 
-/*
-Rewrite bitmap_union(to_bitmap(c1)) to bitmap_union(mv_bitmap_c1)
-Rewrite bitmap_union_count(to_bitmap(c1)) to bitmap_union_count(mv_bitmap_c1)
+/**
+ * Rewrite bitmap_union(to_bitmap(c1)) to bitmap_union(mv_bitmap_c1)
+ * Rewrite bitmap_union_count(to_bitmap(c1)) to bitmap_union_count(mv_bitmap_c1)
  */
 public class ToBitmapToSlotRefRule implements ExprRewriteRule {
 

--- a/fe/src/main/java/org/apache/doris/rewrite/mvrewrite/ToBitmapToSlotRefRule.java
+++ b/fe/src/main/java/org/apache/doris/rewrite/mvrewrite/ToBitmapToSlotRefRule.java
@@ -1,0 +1,113 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.rewrite.mvrewrite;
+
+import org.apache.doris.analysis.Analyzer;
+import org.apache.doris.analysis.CastExpr;
+import org.apache.doris.analysis.CreateMaterializedViewStmt;
+import org.apache.doris.analysis.Expr;
+import org.apache.doris.analysis.FunctionCallExpr;
+import org.apache.doris.analysis.SlotRef;
+import org.apache.doris.analysis.TableName;
+import org.apache.doris.catalog.AggregateType;
+import org.apache.doris.catalog.Column;
+import org.apache.doris.catalog.FunctionSet;
+import org.apache.doris.catalog.OlapTable;
+import org.apache.doris.catalog.Table;
+import org.apache.doris.common.AnalysisException;
+import org.apache.doris.rewrite.ExprRewriteRule;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+
+import java.util.List;
+
+/*
+Rewrite bitmap_union(to_bitmap(c1)) to bitmap_union(mv_bitmap_c1)
+Rewrite bitmap_union_count(to_bitmap(c1)) to bitmap_union_count(mv_bitmap_c1)
+ */
+public class ToBitmapToSlotRefRule implements ExprRewriteRule {
+
+    public static final ExprRewriteRule INSTANCE = new ToBitmapToSlotRefRule();
+
+    @Override
+    public Expr apply(Expr expr, Analyzer analyzer) throws AnalysisException {
+        SlotRef queryColumnSlotRef;
+        Column mvColumn;
+
+        // meet the condition
+        if (!(expr instanceof FunctionCallExpr)) {
+            return expr;
+        }
+        FunctionCallExpr fnExpr = (FunctionCallExpr) expr;
+        String fnNameString = fnExpr.getFnName().getFunction();
+        if (!fnNameString.equalsIgnoreCase(FunctionSet.BITMAP_UNION)
+                && !fnNameString.equalsIgnoreCase(FunctionSet.BITMAP_UNION_COUNT)) {
+            return expr;
+        }
+        if (!(fnExpr.getChild(0) instanceof FunctionCallExpr)) {
+            return expr;
+        }
+        FunctionCallExpr child0FnExpr = (FunctionCallExpr) fnExpr.getChild(0);
+        if (!child0FnExpr.getFnName().getFunction().equalsIgnoreCase("to_bitmap")) {
+            return expr;
+        }
+        if (child0FnExpr.getChild(0) instanceof SlotRef) {
+            queryColumnSlotRef = (SlotRef) child0FnExpr.getChild(0);
+        } else if (child0FnExpr.getChild(0) instanceof CastExpr) {
+            CastExpr castExpr = (CastExpr) child0FnExpr.getChild(0);
+            if (!(castExpr.getChild(0) instanceof SlotRef)) {
+                return expr;
+            }
+            queryColumnSlotRef = (SlotRef) castExpr.getChild(0);
+        } else {
+            return expr;
+        }
+        Column column = queryColumnSlotRef.getColumn();
+        Table table = queryColumnSlotRef.getTable();
+        if (column == null || table == null || !(table instanceof OlapTable)) {
+            return expr;
+        }
+        OlapTable olapTable = (OlapTable) table;
+
+        // check column
+        String queryColumnName = column.getName();
+        String mvColumnName = CreateMaterializedViewStmt
+                .mvColumnBuilder(AggregateType.BITMAP_UNION.name().toLowerCase(), queryColumnName);
+        mvColumn = olapTable.getVisibleColumn(mvColumnName);
+        if (mvColumn == null) {
+            return expr;
+        }
+
+        // equal expr
+        return rewriteExpr(fnNameString, queryColumnSlotRef, mvColumn, analyzer);
+    }
+
+    public Expr rewriteExpr(String fnName, SlotRef queryColumnSlotRef, Column mvColumn, Analyzer analyzer) {
+        Preconditions.checkNotNull(mvColumn);
+        Preconditions.checkNotNull(queryColumnSlotRef);
+        TableName tableName = queryColumnSlotRef.getTableName();
+        Preconditions.checkNotNull(tableName);
+        SlotRef mvSlotRef = new SlotRef(tableName, mvColumn.getName());
+        List<Expr> newFnParams = Lists.newArrayList();
+        newFnParams.add(mvSlotRef);
+        FunctionCallExpr result = new FunctionCallExpr(fnName, newFnParams);
+        result.analyzeNoThrow(analyzer);
+        return result;
+    }
+}

--- a/fe/src/main/java/org/apache/doris/task/PullLoadTaskPlanner.java
+++ b/fe/src/main/java/org/apache/doris/task/PullLoadTaskPlanner.java
@@ -102,7 +102,7 @@ public class PullLoadTaskPlanner {
         scanNode.init(analyzer);
         scanNodes.add(scanNode);
 
-        // rewrite node
+        // equal node
         OlapRewriteNode rewriteNode = new OlapRewriteNode(
                 new PlanNodeId(nextNodeId++), scanNode, table, tupleDesc, slotRefs);
         rewriteNode.init(analyzer);

--- a/fe/src/main/java/org/apache/doris/transaction/TransactionState.java
+++ b/fe/src/main/java/org/apache/doris/transaction/TransactionState.java
@@ -501,7 +501,7 @@ public class TransactionState implements Writable {
             indexIds = Sets.newHashSet();
             loadedTblIndexes.put(table.getId(), indexIds);
         }
-        // always rewrite the index ids
+        // always equal the index ids
         indexIds.clear();
         for (Long indexId : table.getIndexIdToMeta().keySet()) {
             indexIds.add(indexId);

--- a/fe/src/test/java/org/apache/doris/alter/MaterializedViewHandlerTest.java
+++ b/fe/src/test/java/org/apache/doris/alter/MaterializedViewHandlerTest.java
@@ -173,34 +173,6 @@ public class MaterializedViewHandlerTest {
     }
 
     @Test
-    public void testInvalidMVColumn(@Injectable CreateMaterializedViewStmt createMaterializedViewStmt,
-                                    @Injectable OlapTable olapTable) {
-        final String mvName = "mv1";
-        final String mvColumnName = "mv_k1";
-        MVColumnItem mvColumnItem = new MVColumnItem(mvColumnName, Type.BIGINT);
-        new Expectations() {
-            {
-                olapTable.hasMaterializedIndex(mvName);
-                result = false;
-                createMaterializedViewStmt.getMVName();
-                result = mvName;
-                createMaterializedViewStmt.getMVColumnItemList();
-                result = Lists.newArrayList(mvColumnItem);
-                olapTable.getColumn(mvColumnName);
-                result = null;
-            }
-        };
-        MaterializedViewHandler materializedViewHandler = new MaterializedViewHandler();
-        try {
-            Deencapsulation.invoke(materializedViewHandler, "checkAndPrepareMaterializedView",
-                                   createMaterializedViewStmt, olapTable);
-            Assert.fail();
-        } catch (Exception e) {
-            System.out.print(e.getMessage());
-        }
-    }
-
-    @Test
     public void testInvalidAggregateType(@Injectable CreateMaterializedViewStmt createMaterializedViewStmt,
                                          @Injectable OlapTable olapTable) {
         final String mvName = "mv1";

--- a/fe/src/test/java/org/apache/doris/alter/MaterializedViewHandlerTest.java
+++ b/fe/src/test/java/org/apache/doris/alter/MaterializedViewHandlerTest.java
@@ -177,7 +177,7 @@ public class MaterializedViewHandlerTest {
                                     @Injectable OlapTable olapTable) {
         final String mvName = "mv1";
         final String mvColumnName = "mv_k1";
-        MVColumnItem mvColumnItem = new MVColumnItem(mvColumnName);
+        MVColumnItem mvColumnItem = new MVColumnItem(mvColumnName, Type.BIGINT);
         new Expectations() {
             {
                 olapTable.hasMaterializedIndex(mvName);
@@ -206,7 +206,7 @@ public class MaterializedViewHandlerTest {
         final String mvName = "mv1";
         final String columnName = "mv_k1";
         Column baseColumn = new Column(columnName, Type.INT, false, AggregateType.SUM, "", "");
-        MVColumnItem mvColumnItem = new MVColumnItem(columnName);
+        MVColumnItem mvColumnItem = new MVColumnItem(columnName, Type.BIGINT);
         mvColumnItem.setIsKey(true);
         mvColumnItem.setAggregationType(null, false);
         new Expectations() {
@@ -239,7 +239,7 @@ public class MaterializedViewHandlerTest {
         final String mvName = "mv1";
         final String columnName1 = "k1";
         Column baseColumn1 = new Column(columnName1, Type.VARCHAR, false, AggregateType.NONE, "", "");
-        MVColumnItem mvColumnItem = new MVColumnItem(columnName1);
+        MVColumnItem mvColumnItem = new MVColumnItem(columnName1, Type.VARCHAR);
         mvColumnItem.setIsKey(true);
         mvColumnItem.setAggregationType(null, false);
         new Expectations() {

--- a/fe/src/test/java/org/apache/doris/alter/MaterializedViewHandlerTest.java
+++ b/fe/src/test/java/org/apache/doris/alter/MaterializedViewHandlerTest.java
@@ -222,7 +222,7 @@ public class MaterializedViewHandlerTest {
                 result = mvName;
                 createMaterializedViewStmt.getMVColumnItemList();
                 result = Lists.newArrayList(mvColumnItem);
-                olapTable.getColumn(columnName1);
+                olapTable.getBaseColumn(columnName1);
                 result = baseColumn1;
                 olapTable.getKeysType();
                 result = KeysType.DUP_KEYS;

--- a/fe/src/test/java/org/apache/doris/alter/RollupJobV2Test.java
+++ b/fe/src/test/java/org/apache/doris/alter/RollupJobV2Test.java
@@ -377,7 +377,7 @@ public class RollupJobV2Test {
         
         short keysCount = 1;
         List<Column> columns = Lists.newArrayList();
-        String mvColumnName =CreateMaterializedViewStmt.MATERIALIZED_VIEW_NAME_PRFIX + "bitmap_" + "c1";
+        String mvColumnName = CreateMaterializedViewStmt.MATERIALIZED_VIEW_NAME_PREFIX + "to_bitmap_" + "c1";
         Column column = new Column(mvColumnName, Type.BITMAP, false, AggregateType.BITMAP_UNION, false, "1", "");
         columns.add(column);
         RollupJobV2 rollupJobV2 = new RollupJobV2(1, 1, 1, "test", 1, 1, 1, "test", "rollup", columns, 1, 1,
@@ -393,7 +393,7 @@ public class RollupJobV2Test {
 
         List<MVColumnItem> itemList = Lists.newArrayList();
         MVColumnItem item = new MVColumnItem(
-                mvColumnName);
+                mvColumnName, Type.BITMAP);
         List<Expr> params = Lists.newArrayList();
         SlotRef param1 = new SlotRef(new TableName(null, "test"), "c1");
         params.add(param1);

--- a/fe/src/test/java/org/apache/doris/analysis/CreateMaterializedViewStmtTest.java
+++ b/fe/src/test/java/org/apache/doris/analysis/CreateMaterializedViewStmtTest.java
@@ -91,7 +91,7 @@ public class CreateMaterializedViewStmtTest {
                 selectStmt.analyze(analyzer);
                 selectStmt.getSelectList();
                 result = selectList;
-                arithmeticExpr.toSql();
+                arithmeticExpr.toString();
                 result = "a+b";
             }
         };
@@ -250,13 +250,15 @@ public class CreateMaterializedViewStmtTest {
 
     @Test
     public void testOrderByAggregateColumn(@Injectable SlotRef slotRef1,
-                                           @Injectable SlotRef slotRef2,
-                                           @Injectable FunctionCallExpr functionCallExpr,
                                            @Injectable TableRef tableRef,
                                            @Injectable SelectStmt selectStmt) throws UserException {
         SelectList selectList = new SelectList();
         SelectListItem selectListItem1 = new SelectListItem(slotRef1, null);
         selectList.addItem(selectListItem1);
+        TableName tableName = new TableName("db", "table");
+        SlotRef slotRef2 = new SlotRef(tableName, "v1");
+        List<Expr> fnChildren = Lists.newArrayList(slotRef2);
+        FunctionCallExpr functionCallExpr = new FunctionCallExpr("sum", fnChildren);
         SelectListItem selectListItem2 = new SelectListItem(functionCallExpr, null);
         selectList.addItem(selectListItem2);
         OrderByElement orderByElement1 = new OrderByElement(functionCallExpr, false, false);
@@ -280,14 +282,6 @@ public class CreateMaterializedViewStmtTest {
                 result = orderByElementList;
                 slotRef1.getColumnName();
                 result = "k1";
-                slotRef2.getColumnName();
-                result = "v1";
-                functionCallExpr.getFnName().getFunction();
-                result = "sum";
-                functionCallExpr.getChildren();
-                result = Lists.newArrayList(slotRef2);
-                functionCallExpr.getChild(0);
-                result = slotRef2;
             }
         };
         CreateMaterializedViewStmt createMaterializedViewStmt = new CreateMaterializedViewStmt("test", selectStmt, null);
@@ -300,12 +294,14 @@ public class CreateMaterializedViewStmtTest {
     }
 
     @Test
-    public void testDuplicateColumn(@Injectable SlotRef slotRef1,
-                                    @Injectable FunctionCallExpr functionCallExpr,
-                                    @Injectable SelectStmt selectStmt) throws UserException {
+    public void testDuplicateColumn(@Injectable SelectStmt selectStmt) throws UserException {
         SelectList selectList = new SelectList();
+        TableName tableName = new TableName("db", "table");
+        SlotRef slotRef1 = new SlotRef(tableName, "k1");
         SelectListItem selectListItem1 = new SelectListItem(slotRef1, null);
         selectList.addItem(selectListItem1);
+        List<Expr> fnChildren = Lists.newArrayList(slotRef1);
+        FunctionCallExpr functionCallExpr = new FunctionCallExpr("sum", fnChildren);
         SelectListItem selectListItem2 = new SelectListItem(functionCallExpr, null);
         selectList.addItem(selectListItem2);
 
@@ -316,14 +312,6 @@ public class CreateMaterializedViewStmtTest {
                 selectStmt.analyze(analyzer);
                 selectStmt.getSelectList();
                 result = selectList;
-                slotRef1.getColumnName();
-                result = "k1";
-                functionCallExpr.getFnName().getFunction();
-                result = "sum";
-                functionCallExpr.getChildren();
-                result = Lists.newArrayList(slotRef1);
-                functionCallExpr.getChild(0);
-                result = slotRef1;
             }
         };
         CreateMaterializedViewStmt createMaterializedViewStmt = new CreateMaterializedViewStmt("test", selectStmt, null);
@@ -336,14 +324,18 @@ public class CreateMaterializedViewStmtTest {
     }
 
     @Test
-    public void testDuplicateColumn1(@Injectable SlotRef slotRef1, @Injectable SlotRef slotRef2,
-            @Injectable FunctionCallExpr functionCallExpr1, @Injectable FunctionCallExpr functionCallExpr2,
+    public void testDuplicateColumn1(@Injectable SlotRef slotRef1,
             @Injectable SelectStmt selectStmt) throws UserException {
         SelectList selectList = new SelectList();
         SelectListItem selectListItem1 = new SelectListItem(slotRef1, null);
         selectList.addItem(selectListItem1);
+        TableName tableName = new TableName("db", "table");
+        SlotRef slotRef2 = new SlotRef(tableName, "k2");
+        List<Expr> fn1Children = Lists.newArrayList(slotRef2);
+        FunctionCallExpr functionCallExpr1 = new FunctionCallExpr("sum", fn1Children);
         SelectListItem selectListItem2 = new SelectListItem(functionCallExpr1, null);
         selectList.addItem(selectListItem2);
+        FunctionCallExpr functionCallExpr2 = new FunctionCallExpr("max", fn1Children);
         SelectListItem selectListItem3 = new SelectListItem(functionCallExpr2, null);
         selectList.addItem(selectListItem3);
 
@@ -356,20 +348,6 @@ public class CreateMaterializedViewStmtTest {
                 result = selectList;
                 slotRef1.getColumnName();
                 result = "k1";
-                slotRef2.getColumnName();
-                result = "k2";
-                functionCallExpr1.getFnName().getFunction();
-                result = "sum";
-                functionCallExpr1.getChildren();
-                result = Lists.newArrayList(slotRef2);
-                functionCallExpr1.getChild(0);
-                result = slotRef2;
-                functionCallExpr2.getFnName().getFunction();
-                result = "max";
-                functionCallExpr2.getChildren();
-                result = Lists.newArrayList(slotRef2);
-                functionCallExpr2.getChild(0);
-                result = slotRef2;
             }
         };
         CreateMaterializedViewStmt createMaterializedViewStmt = new CreateMaterializedViewStmt("test", selectStmt, null);
@@ -384,8 +362,6 @@ public class CreateMaterializedViewStmtTest {
     @Test
     public void testOrderByColumnsLessThenGroupByColumns(@Injectable SlotRef slotRef1,
                                                          @Injectable SlotRef slotRef2,
-                                                         @Injectable FunctionCallExpr functionCallExpr,
-                                                         @Injectable SlotRef functionChild0,
                                                          @Injectable TableRef tableRef,
                                                          @Injectable SelectStmt selectStmt) throws UserException {
         SelectList selectList = new SelectList();
@@ -393,6 +369,10 @@ public class CreateMaterializedViewStmtTest {
         selectList.addItem(selectListItem1);
         SelectListItem selectListItem2 = new SelectListItem(slotRef2, null);
         selectList.addItem(selectListItem2);
+        TableName tableName = new TableName("db", "table");
+        SlotRef functionChild0 = new SlotRef(tableName, "v1");
+        List<Expr> fn1Children = Lists.newArrayList(functionChild0);
+        FunctionCallExpr functionCallExpr = new FunctionCallExpr("sum", fn1Children);
         SelectListItem selectListItem3 = new SelectListItem(functionCallExpr, null);
         selectList.addItem(selectListItem3);
         OrderByElement orderByElement1 = new OrderByElement(slotRef1, false, false);
@@ -417,14 +397,6 @@ public class CreateMaterializedViewStmtTest {
                 result = "k1";
                 slotRef2.getColumnName();
                 result = "non-k2";
-                functionChild0.getColumnName();
-                result = "v1";
-                functionCallExpr.getFnName().getFunction();
-                result = "sum";
-                functionCallExpr.getChildren();
-                result = Lists.newArrayList(slotRef1);
-                functionCallExpr.getChild(0);
-                result = functionChild0;
             }
         };
         CreateMaterializedViewStmt createMaterializedViewStmt = new CreateMaterializedViewStmt("test", selectStmt, null);
@@ -441,8 +413,6 @@ public class CreateMaterializedViewStmtTest {
                                             @Injectable SlotRef slotRef2,
                                             @Injectable SlotRef slotRef3,
                                             @Injectable SlotRef slotRef4,
-                                            @Injectable FunctionCallExpr functionCallExpr,
-                                            @Injectable SlotRef functionChild0,
                                             @Injectable TableRef tableRef,
                                             @Injectable SelectStmt selectStmt,
             @Injectable AggregateInfo aggregateInfo) throws UserException {
@@ -455,14 +425,17 @@ public class CreateMaterializedViewStmtTest {
         selectList.addItem(selectListItem3);
         SelectListItem selectListItem4 = new SelectListItem(slotRef4, null);
         selectList.addItem(selectListItem4);
-
+        TableName tableName = new TableName("db", "table");
+        final String columnName5 = "sum_v2";
+        SlotRef functionChild0 = new SlotRef(tableName, columnName5);
+        List<Expr> fn1Children = Lists.newArrayList(functionChild0);
+        FunctionCallExpr functionCallExpr = new FunctionCallExpr("sum", fn1Children);
         SelectListItem selectListItem5 = new SelectListItem(functionCallExpr, null);
         selectList.addItem(selectListItem5);
         final String columnName1 = "k1";
         final String columnName2 = "k2";
         final String columnName3 = "k3";
         final String columnName4 = "v1";
-        final String columnName5 = "sum_v2";
 
         new Expectations() {
             {
@@ -483,12 +456,6 @@ public class CreateMaterializedViewStmtTest {
                 selectStmt.getLimit();
                 result = -1;
                 selectStmt.analyze(analyzer);
-                functionCallExpr.getChild(0);
-                result = functionChild0;
-                functionCallExpr.getChildren();
-                result = Lists.newArrayList(functionChild0);
-                functionCallExpr.getFnName().getFunction();
-                result = "sum";
                 slotRef1.getColumnName();
                 result = columnName1;
                 slotRef2.getColumnName();
@@ -497,8 +464,6 @@ public class CreateMaterializedViewStmtTest {
                 result = columnName3;
                 slotRef4.getColumnName();
                 result = columnName4;
-                functionChild0.getColumnName();
-                result = columnName5;
             }
         };
 
@@ -939,8 +904,6 @@ public class CreateMaterializedViewStmtTest {
     @Test
     public void testMVColumns(@Injectable SlotRef slotRef1,
             @Injectable SlotRef slotRef2,
-            @Injectable FunctionCallExpr functionCallExpr,
-            @Injectable SlotRef functionChild0,
             @Injectable TableRef tableRef,
             @Injectable SelectStmt selectStmt,
             @Injectable AggregateInfo aggregateInfo) throws UserException {
@@ -949,6 +912,11 @@ public class CreateMaterializedViewStmtTest {
         selectList.addItem(selectListItem1);
         SelectListItem selectListItem2 = new SelectListItem(slotRef2, null);
         selectList.addItem(selectListItem2);
+        TableName tableName = new TableName("db", "table");
+        final String columnName3 = "sum_v2";
+        SlotRef slotRef = new SlotRef(tableName, columnName3);
+        List<Expr> children = Lists.newArrayList(slotRef);
+        FunctionCallExpr functionCallExpr = new FunctionCallExpr("sum", children);
         SelectListItem selectListItem3 = new SelectListItem(functionCallExpr, null);
         selectList.addItem(selectListItem3);
         OrderByElement orderByElement1 = new OrderByElement(slotRef1, false, false);
@@ -956,7 +924,7 @@ public class CreateMaterializedViewStmtTest {
         ArrayList<OrderByElement> orderByElementList = Lists.newArrayList(orderByElement1, orderByElement2);
         final String columnName1 = "k1";
         final String columnName2 = "v1";
-        final String columnName3 = "sum_v2";
+
         new Expectations() {
             {
                 analyzer.getClusterName();
@@ -976,18 +944,10 @@ public class CreateMaterializedViewStmtTest {
                 selectStmt.getLimit();
                 result = -1;
                 selectStmt.analyze(analyzer);
-                functionCallExpr.getChild(0);
-                result = functionChild0;
-                functionCallExpr.getChildren();
-                result = Lists.newArrayList(functionChild0);
-                functionCallExpr.getFnName().getFunction();
-                result = "sum";
                 slotRef1.getColumnName();
                 result = columnName1;
                 slotRef2.getColumnName();
                 result = columnName2;
-                functionChild0.getColumnName();
-                result = columnName3;
             }
         };
 

--- a/fe/src/test/java/org/apache/doris/analysis/CreateMaterializedViewStmtTest.java
+++ b/fe/src/test/java/org/apache/doris/analysis/CreateMaterializedViewStmtTest.java
@@ -100,7 +100,7 @@ public class CreateMaterializedViewStmtTest {
         try {
             createMaterializedViewStmt.analyze(analyzer);
             Assert.fail();
-        } catch (UserException e) {
+        } catch (IllegalArgumentException e) {
             System.out.print(e.getMessage());
         }
     }

--- a/fe/src/test/java/org/apache/doris/analysis/ExprTest.java
+++ b/fe/src/test/java/org/apache/doris/analysis/ExprTest.java
@@ -69,21 +69,21 @@ public class ExprTest {
                 result = tableA;
                 tupleDescriptor2.getTable();
                 result = tableB;
-                tableA.getName();
-                result = "tableA";
-                tableB.getName();
-                result = "tableB";
+                tableA.getId();
+                result = 1;
+                tableB.getId();
+                result = 2;
 
             }
         };
 
-        Map<String, Set<String>> tableNameToColumnNames = Maps.newHashMap();
-        whereExpr.getTableNameToColumnNames(tableNameToColumnNames);
+        Map<Long, Set<String>> tableNameToColumnNames = Maps.newHashMap();
+        whereExpr.getTableIdToColumnNames(tableNameToColumnNames);
         Assert.assertEquals(tableNameToColumnNames.size(), 2);
-        Set<String> tableAColumns = tableNameToColumnNames.get("tableA");
+        Set<String> tableAColumns = tableNameToColumnNames.get(new Long(1));
         Assert.assertNotEquals(tableAColumns, null);
         Assert.assertTrue(tableAColumns.contains("c1"));
-        Set<String> tableBColumns = tableNameToColumnNames.get("tableB");
+        Set<String> tableBColumns = tableNameToColumnNames.get(new Long(2));
         Assert.assertNotEquals(tableBColumns, null);
         Assert.assertTrue(tableBColumns.contains("c1"));
     }

--- a/fe/src/test/java/org/apache/doris/analysis/InsertStmtTest.java
+++ b/fe/src/test/java/org/apache/doris/analysis/InsertStmtTest.java
@@ -17,37 +17,23 @@
 
 package org.apache.doris.analysis;
 
-import mockit.Tested;
 import org.apache.doris.catalog.AggregateType;
-import org.apache.doris.catalog.Catalog;
 import org.apache.doris.catalog.Column;
-import org.apache.doris.catalog.Function;
-import org.apache.doris.catalog.KeysType;
-import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.catalog.PrimitiveType;
 import org.apache.doris.catalog.ScalarType;
 import org.apache.doris.catalog.Table;
 import org.apache.doris.catalog.Type;
-import org.apache.doris.clone.TabletScheduler;
 import org.apache.doris.common.AnalysisException;
-import org.apache.doris.common.Config;
-import org.apache.doris.common.UserException;
 import org.apache.doris.common.jmockit.Deencapsulation;
 import org.apache.doris.common.util.SqlParserUtils;
-import org.apache.doris.planner.StreamLoadScanNode;
-import org.apache.doris.planner.StreamLoadScanNodeTest;
 import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.utframe.DorisAssert;
+import org.apache.doris.utframe.UtFrameUtils;
 
 import com.google.common.collect.Lists;
 
-import org.apache.doris.thrift.TStreamLoadPutRequest;
-import org.apache.doris.utframe.DorisAssert;
-import org.apache.doris.utframe.UtFrameUtils;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.junit.AfterClass;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -58,7 +44,6 @@ import java.util.UUID;
 
 import mockit.Expectations;
 import mockit.Injectable;
-import mockit.Mocked;
 
 public class InsertStmtTest {
     private static String runningDir = "fe/mocked/DemoTest/" + UUID.randomUUID().toString() + "/";
@@ -136,7 +121,8 @@ public class InsertStmtTest {
         v2.setIsAllowNull(false);
         columns.add(v2);
 
-        Column v3 = new Column("__doris_materialized_view_bitmap_k1", PrimitiveType.BITMAP);
+        Column v3 = new Column(CreateMaterializedViewStmt.mvColumnBuilder("bitmap_union", "k1"),
+                PrimitiveType.BITMAP);
         v3.setIsKey(false);
         v3.setAggregationType(AggregateType.BITMAP_UNION, false);
         v3.setIsAllowNull(false);
@@ -150,7 +136,7 @@ public class InsertStmtTest {
         v3.setDefineExpr(defineExpr);
         columns.add(v3);
 
-        Column v4 = new Column("__doris_materialized_view_hll_k2", PrimitiveType.HLL);
+        Column v4 = new Column(CreateMaterializedViewStmt.mvColumnBuilder("hll_union", "k2"), PrimitiveType.HLL);
         v4.setIsKey(false);
         v4.setAggregationType(AggregateType.HLL_UNION, false);
         v4.setIsAllowNull(false);

--- a/fe/src/test/java/org/apache/doris/analysis/MVColumnBitmapUnionPatternTest.java
+++ b/fe/src/test/java/org/apache/doris/analysis/MVColumnBitmapUnionPatternTest.java
@@ -1,0 +1,110 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.analysis;
+
+import org.apache.doris.catalog.FunctionSet;
+
+import com.google.common.collect.Lists;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.List;
+
+import mockit.Expectations;
+import mockit.Injectable;
+
+public class MVColumnBitmapUnionPatternTest {
+
+    @Test
+    public void testCorrectExpr1() {
+        TableName tableName = new TableName("db", "table");
+        SlotRef slotRef = new SlotRef(tableName, "c1");
+        List<Expr> child0Params = Lists.newArrayList();
+        child0Params.add(slotRef);
+        FunctionCallExpr child0 = new FunctionCallExpr(FunctionSet.TO_BITMAP, child0Params);
+        List<Expr> params = Lists.newArrayList();
+        params.add(child0);
+        FunctionCallExpr expr = new FunctionCallExpr(FunctionSet.BITMAP_UNION, params);
+        MVColumnBitmapUnionPattern pattern = new MVColumnBitmapUnionPattern();
+        Assert.assertTrue(pattern.match(expr));
+    }
+
+    @Test
+    public void testCorrectExpr2(@Injectable CastExpr castExpr) {
+        TableName tableName = new TableName("db", "table");
+        SlotRef slotRef = new SlotRef(tableName, "c1");
+        new Expectations() {
+            {
+                castExpr.getChild(0);
+                result = slotRef;
+            }
+        };
+        List<Expr> child0Params = Lists.newArrayList();
+        child0Params.add(castExpr);
+        FunctionCallExpr child0 = new FunctionCallExpr(FunctionSet.TO_BITMAP, child0Params);
+        List<Expr> params = Lists.newArrayList();
+        params.add(child0);
+        FunctionCallExpr expr = new FunctionCallExpr(FunctionSet.BITMAP_UNION, params);
+        MVColumnBitmapUnionPattern pattern = new MVColumnBitmapUnionPattern();
+        Assert.assertTrue(pattern.match(expr));
+    }
+
+    @Test
+    public void testUpperCaseOfFunction() {
+        TableName tableName = new TableName("db", "table");
+        SlotRef slotRef = new SlotRef(tableName, "c1");
+        List<Expr> child0Params = Lists.newArrayList();
+        child0Params.add(slotRef);
+        FunctionCallExpr child0 = new FunctionCallExpr(FunctionSet.TO_BITMAP.toUpperCase(), child0Params);
+        List<Expr> params = Lists.newArrayList();
+        params.add(child0);
+        FunctionCallExpr expr = new FunctionCallExpr(FunctionSet.BITMAP_UNION.toUpperCase(), params);
+        MVColumnBitmapUnionPattern pattern = new MVColumnBitmapUnionPattern();
+        Assert.assertTrue(pattern.match(expr));
+    }
+
+    @Test
+    public void testIncorrectArithmeticExpr1() {
+        TableName tableName = new TableName("db", "table");
+        SlotRef slotRef1 = new SlotRef(tableName, "c1");
+        SlotRef slotRef2 = new SlotRef(tableName, "c2");
+        ArithmeticExpr arithmeticExpr = new ArithmeticExpr(ArithmeticExpr.Operator.ADD, slotRef1, slotRef2);
+        List<Expr> params = Lists.newArrayList();
+        params.add(arithmeticExpr);
+        FunctionCallExpr expr = new FunctionCallExpr(FunctionSet.BITMAP_UNION, params);
+        MVColumnBitmapUnionPattern pattern = new MVColumnBitmapUnionPattern();
+        Assert.assertFalse(pattern.match(expr));
+    }
+
+    @Test
+    public void testIncorrectArithmeticExpr2() {
+        TableName tableName = new TableName("db", "table");
+        SlotRef slotRef1 = new SlotRef(tableName, "c1");
+        SlotRef slotRef2 = new SlotRef(tableName, "c2");
+        ArithmeticExpr arithmeticExpr = new ArithmeticExpr(ArithmeticExpr.Operator.ADD, slotRef1, slotRef2);
+        List<Expr> child0Params = Lists.newArrayList();
+        child0Params.add(arithmeticExpr);
+        FunctionCallExpr child0 = new FunctionCallExpr(FunctionSet.TO_BITMAP, child0Params);
+        List<Expr> params = Lists.newArrayList();
+        params.add(child0);
+        FunctionCallExpr expr = new FunctionCallExpr(FunctionSet.BITMAP_UNION, params);
+        MVColumnBitmapUnionPattern pattern = new MVColumnBitmapUnionPattern();
+        Assert.assertFalse(pattern.match(expr));
+    }
+}

--- a/fe/src/test/java/org/apache/doris/analysis/MVColumnHLLUnionPatternTest.java
+++ b/fe/src/test/java/org/apache/doris/analysis/MVColumnHLLUnionPatternTest.java
@@ -1,0 +1,104 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.analysis;
+
+import org.apache.doris.catalog.FunctionSet;
+
+import com.google.common.collect.Lists;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.List;
+
+import mockit.Expectations;
+import mockit.Injectable;
+
+public class MVColumnHLLUnionPatternTest {
+
+    @Test
+    public void testCorrectExpr1() {
+        TableName tableName = new TableName("db", "table");
+        SlotRef slotRef = new SlotRef(tableName, "c1");
+        List<Expr> child0Params = Lists.newArrayList();
+        child0Params.add(slotRef);
+        FunctionCallExpr child0 = new FunctionCallExpr(FunctionSet.HLL_HASH, child0Params);
+        List<Expr> params = Lists.newArrayList();
+        params.add(child0);
+        FunctionCallExpr expr = new FunctionCallExpr(FunctionSet.HLL_UNION, params);
+        MVColumnHLLUnionPattern pattern = new MVColumnHLLUnionPattern();
+        Assert.assertTrue(pattern.match(expr));
+    }
+
+    @Test
+    public void testCorrectExpr2(@Injectable CastExpr castExpr) {
+        TableName tableName = new TableName("db", "table");
+        SlotRef slotRef = new SlotRef(tableName, "c1");
+        new Expectations() {
+            {
+                castExpr.getChild(0);
+                result = slotRef;
+            }
+        };
+        List<Expr> child0Params = Lists.newArrayList();
+        child0Params.add(castExpr);
+        FunctionCallExpr child0 = new FunctionCallExpr(FunctionSet.HLL_HASH, child0Params);
+        List<Expr> params = Lists.newArrayList();
+        params.add(child0);
+        FunctionCallExpr expr = new FunctionCallExpr(FunctionSet.HLL_UNION, params);
+        MVColumnHLLUnionPattern pattern = new MVColumnHLLUnionPattern();
+        Assert.assertTrue(pattern.match(expr));
+    }
+
+    @Test
+    public void testUpperCaseOfFunction() {
+        TableName tableName = new TableName("db", "table");
+        SlotRef slotRef = new SlotRef(tableName, "c1");
+        List<Expr> child0Params = Lists.newArrayList();
+        child0Params.add(slotRef);
+        FunctionCallExpr child0 = new FunctionCallExpr(FunctionSet.HLL_HASH.toUpperCase(), child0Params);
+        List<Expr> params = Lists.newArrayList();
+        params.add(child0);
+        FunctionCallExpr expr = new FunctionCallExpr(FunctionSet.HLL_UNION.toUpperCase(), params);
+        MVColumnHLLUnionPattern pattern = new MVColumnHLLUnionPattern();
+        Assert.assertTrue(pattern.match(expr));
+    }
+
+    @Test
+    public void testIncorrectLiteralExpr1() {
+        IntLiteral intLiteral = new IntLiteral(1);
+        List<Expr> params = Lists.newArrayList();
+        params.add(intLiteral);
+        FunctionCallExpr expr = new FunctionCallExpr(FunctionSet.HLL_UNION, params);
+        MVColumnBitmapUnionPattern pattern = new MVColumnBitmapUnionPattern();
+        Assert.assertFalse(pattern.match(expr));
+    }
+
+    @Test
+    public void testIncorrectLiteralExpr2() {
+        IntLiteral intLiteral = new IntLiteral(1);
+        List<Expr> child0Params = Lists.newArrayList();
+        child0Params.add(intLiteral);
+        FunctionCallExpr child0 = new FunctionCallExpr(FunctionSet.HLL_HASH, child0Params);
+        List<Expr> params = Lists.newArrayList();
+        params.add(child0);
+        FunctionCallExpr expr = new FunctionCallExpr(FunctionSet.HLL_UNION, params);
+        MVColumnBitmapUnionPattern pattern = new MVColumnBitmapUnionPattern();
+        Assert.assertFalse(pattern.match(expr));
+    }
+}

--- a/fe/src/test/java/org/apache/doris/analysis/MVColumnOneChildPatternTest.java
+++ b/fe/src/test/java/org/apache/doris/analysis/MVColumnOneChildPatternTest.java
@@ -1,0 +1,102 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.analysis;
+
+import org.apache.doris.catalog.AggregateType;
+import org.apache.doris.catalog.FunctionSet;
+
+import com.google.common.collect.Lists;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.List;
+
+import mockit.Expectations;
+import mockit.Injectable;
+
+public class MVColumnOneChildPatternTest {
+
+    @Test
+    public void testCorrectSum() {
+        TableName tableName = new TableName("db", "table");
+        SlotRef slotRef = new SlotRef(tableName, "c1");
+        List<Expr> params = Lists.newArrayList();
+        params.add(slotRef);
+        FunctionCallExpr functionCallExpr = new FunctionCallExpr(AggregateType.SUM.name(), params);
+        MVColumnOneChildPattern mvColumnOneChildPattern = new MVColumnOneChildPattern(
+                AggregateType.SUM.name().toLowerCase());
+        Assert.assertTrue(mvColumnOneChildPattern.match(functionCallExpr));
+    }
+
+    @Test
+    public void testCorrectMin(@Injectable CastExpr castExpr) {
+        TableName tableName = new TableName("db", "table");
+        SlotRef slotRef = new SlotRef(tableName, "c1");
+        List<Expr> child0Params = Lists.newArrayList();
+        child0Params.add(slotRef);
+        new Expectations() {
+            {
+                castExpr.getChild(0);
+                result = child0Params;
+            }
+        };
+        List<Expr> params = Lists.newArrayList();
+        params.add(castExpr);
+        FunctionCallExpr functionCallExpr = new FunctionCallExpr(AggregateType.MIN.name(), params);
+        MVColumnOneChildPattern mvColumnOneChildPattern = new MVColumnOneChildPattern(
+                AggregateType.MIN.name().toLowerCase());
+        Assert.assertTrue(mvColumnOneChildPattern.match(functionCallExpr));
+    }
+
+    @Test
+    public void testCorrectCountField() {
+        TableName tableName = new TableName("db", "table");
+        SlotRef slotRef = new SlotRef(tableName, "c1");
+        List<Expr> params = Lists.newArrayList();
+        params.add(slotRef);
+        FunctionCallExpr functionCallExpr = new FunctionCallExpr(FunctionSet.COUNT, params);
+        MVColumnOneChildPattern mvColumnOneChildPattern = new MVColumnOneChildPattern(FunctionSet.COUNT.toLowerCase());
+        Assert.assertTrue(mvColumnOneChildPattern.match(functionCallExpr));
+    }
+
+    @Test
+    public void testIncorrectLiteral() {
+        IntLiteral intLiteral = new IntLiteral(1);
+        List<Expr> params = Lists.newArrayList();
+        params.add(intLiteral);
+        FunctionCallExpr functionCallExpr = new FunctionCallExpr(AggregateType.SUM.name(), params);
+        MVColumnOneChildPattern mvColumnOneChildPattern = new MVColumnOneChildPattern(
+                AggregateType.SUM.name().toLowerCase());
+        Assert.assertFalse(mvColumnOneChildPattern.match(functionCallExpr));
+    }
+
+    @Test
+    public void testIncorrectArithmeticExpr() {
+        TableName tableName = new TableName("db", "table");
+        SlotRef slotRef1 = new SlotRef(tableName, "c1");
+        SlotRef slotRef2 = new SlotRef(tableName, "c2");
+        ArithmeticExpr arithmeticExpr = new ArithmeticExpr(ArithmeticExpr.Operator.ADD, slotRef1, slotRef2);
+        List<Expr> params = Lists.newArrayList();
+        params.add(arithmeticExpr);
+        FunctionCallExpr functionCallExpr = new FunctionCallExpr(AggregateType.SUM.name(), params);
+        MVColumnOneChildPattern mvColumnOneChildPattern = new MVColumnOneChildPattern(
+                AggregateType.SUM.name().toLowerCase());
+        Assert.assertFalse(mvColumnOneChildPattern.match(functionCallExpr));
+    }
+}

--- a/fe/src/test/java/org/apache/doris/analysis/MVColumnOneChildPatternTest.java
+++ b/fe/src/test/java/org/apache/doris/analysis/MVColumnOneChildPatternTest.java
@@ -52,8 +52,8 @@ public class MVColumnOneChildPatternTest {
         child0Params.add(slotRef);
         new Expectations() {
             {
-                castExpr.getChild(0);
-                result = child0Params;
+                castExpr.unwrapSlotRef();
+                result = slotRef;
             }
         };
         List<Expr> params = Lists.newArrayList();

--- a/fe/src/test/java/org/apache/doris/catalog/MaterializedIndexMetaTest.java
+++ b/fe/src/test/java/org/apache/doris/catalog/MaterializedIndexMetaTest.java
@@ -61,7 +61,7 @@ public class MaterializedIndexMetaTest {
         file.createNewFile();
         DataOutputStream out = new DataOutputStream(new FileOutputStream(file));
 
-        String mvColumnName = CreateMaterializedViewStmt.MATERIALIZED_VIEW_NAME_PRFIX + "bitmap_" + "k1";
+        String mvColumnName = CreateMaterializedViewStmt.MATERIALIZED_VIEW_NAME_PREFIX + "to_bitmap_" + "k1";
         List<Column> schema = Lists.newArrayList();
         schema.add(new Column("k1", Type.TINYINT, true, null, true, "1", "abc"));
         schema.add(new Column("k2", Type.SMALLINT, true, null, true, "1", "debug"));
@@ -89,7 +89,7 @@ public class MaterializedIndexMetaTest {
         out.close();
 
         List<MVColumnItem> itemList = Lists.newArrayList();
-        MVColumnItem item = new MVColumnItem(mvColumnName);
+        MVColumnItem item = new MVColumnItem(mvColumnName, Type.BITMAP);
         List<Expr> params = Lists.newArrayList();
         SlotRef param1 = new SlotRef(new TableName(null, "test"), "c1");
         params.add(param1);

--- a/fe/src/test/java/org/apache/doris/planner/MaterializedViewFunctionTest.java
+++ b/fe/src/test/java/org/apache/doris/planner/MaterializedViewFunctionTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.planner;
 
+import org.apache.doris.analysis.CreateMaterializedViewStmt;
 import org.apache.doris.common.FeConstants;
 import org.apache.doris.utframe.DorisAssert;
 import org.apache.doris.utframe.UtFrameUtils;
@@ -42,6 +43,10 @@ public class MaterializedViewFunctionTest {
     private static final String DEPTS_MV_NAME = "depts_mv";
     private static final String QUERY_USE_DEPTS_MV = "rollup: " + DEPTS_MV_NAME;
     private static final String QUERY_USE_DEPTS = "rollup: " + DEPTS_TABLE_NAME;
+    private static final String USER_TAG_TABLE_NAME = "user_tags";
+    private static final String USER_TAG_MV_NAME = "user_tags_mv";
+    private static final String QUERY_USE_USER_TAG_MV = "rollup: " + USER_TAG_MV_NAME;
+    private static final String QUERY_USE_USER_TAG = "rollup: " + USER_TAG_TABLE_NAME;
     private static final String TEST_TABLE_NAME = "test_tb";
     private static DorisAssert dorisAssert;
 
@@ -66,12 +71,18 @@ public class MaterializedViewFunctionTest {
                 + "(partition p1 values less than MAXVALUE) "
                 + "distributed by hash(deptno) buckets 3 properties('replication_num' = '1');";
         dorisAssert.withTable(createTableSQL);
+        createTableSQL = "create table " + HR_DB_NAME + "." + USER_TAG_TABLE_NAME
+                + " (user_id int, user_name varchar(20), tag_id int) partition by range (user_id) "
+                + " (partition p1 values less than MAXVALUE) "
+                + "distributed by hash(user_id) buckets 3 properties('replication_num' = '1');";
+        dorisAssert.withTable(createTableSQL);
     }
 
     @After
     public void afterMethod() throws Exception {
         dorisAssert.dropTable(EMPS_TABLE_NAME);
         dorisAssert.dropTable(DEPTS_TABLE_NAME);
+        dorisAssert.dropTable(USER_TAG_TABLE_NAME);
     }
 
     @AfterClass
@@ -638,4 +649,148 @@ public class MaterializedViewFunctionTest {
 
 
     }
+
+    @Test
+    public void testBitmapUnionInQuery() throws Exception {
+        String createUserTagMVSql = "create materialized view " + USER_TAG_MV_NAME
+                + " as select user_id, bitmap_union(to_bitmap(tag_id)) from " +
+                USER_TAG_TABLE_NAME + " group by user_id;";
+        dorisAssert.withMaterializedView(createUserTagMVSql);
+        String query = "select user_id, bitmap_union_count(to_bitmap(tag_id)) a from " + USER_TAG_TABLE_NAME
+                + " group by user_id having a>1 order by a;";
+        dorisAssert.query(query).explainContains(QUERY_USE_USER_TAG_MV);
+    }
+
+    @Test
+    public void testBitmapUnionInSubquery() throws Exception {
+        String createUserTagMVSql = "create materialized view " + USER_TAG_MV_NAME + " as select user_id, " +
+                "bitmap_union(to_bitmap(tag_id)) from " + USER_TAG_TABLE_NAME + " group by user_id;";
+        dorisAssert.withMaterializedView(createUserTagMVSql);
+        String query = "select user_id from " + USER_TAG_TABLE_NAME + " where user_id in (select user_id from " +
+                USER_TAG_TABLE_NAME + " group by user_id having bitmap_union_count(to_bitmap(tag_id)) >1 ) ;";
+        dorisAssert.query(query).explainContains(USER_TAG_MV_NAME, USER_TAG_TABLE_NAME);
+    }
+
+    @Test
+    public void testIncorrectMVRewriteInQuery() throws Exception {
+        String createUserTagMVSql = "create materialized view " + USER_TAG_MV_NAME + " as select user_id, "
+                + "bitmap_union(to_bitmap(tag_id)) from " + USER_TAG_TABLE_NAME + " group by user_id;";
+        dorisAssert.withMaterializedView(createUserTagMVSql);
+        String createEMPMVSQL = "create materialized view " + EMPS_MV_NAME + " as select name, deptno from " +
+                EMPS_TABLE_NAME + ";";
+        dorisAssert.withMaterializedView(createEMPMVSQL);
+        String query = "select user_name, bitmap_union_count(to_bitmap(tag_id)) a from " + USER_TAG_TABLE_NAME + ", "
+                + "(select name, deptno from " + EMPS_TABLE_NAME + ") a" + " where user_name=a.name group by "
+                + "user_name having a>1 order by a;";
+        dorisAssert.query(query).explainContains(QUERY_USE_EMPS_MV);
+        dorisAssert.query(query).explainWithout(QUERY_USE_USER_TAG_MV);
+    }
+
+    @Test
+    public void testIncorrectMVRewriteInSubquery() throws Exception {
+        String createUserTagMVSql = "create materialized view " + USER_TAG_MV_NAME + " as select user_id, " +
+                "bitmap_union(to_bitmap(tag_id)) from " + USER_TAG_TABLE_NAME + " group by user_id;";
+        dorisAssert.withMaterializedView(createUserTagMVSql);
+        String query = "select user_id, bitmap_union(to_bitmap(tag_id)) from " + USER_TAG_TABLE_NAME + " where " +
+                "user_name in (select user_name from " + USER_TAG_TABLE_NAME + " group by user_name having " +
+                "bitmap_union_count(to_bitmap(tag_id)) >1 )" + " group by user_id;";
+        dorisAssert.query(query).explainContains(QUERY_USE_USER_TAG);
+    }
+
+    @Test
+    public void testTwoTupleInQuery() throws Exception {
+        String createUserTagMVSql = "create materialized view " + USER_TAG_MV_NAME + " as select user_id, " +
+                "bitmap_union(to_bitmap(tag_id)) from " + USER_TAG_TABLE_NAME + " group by user_id;";
+        dorisAssert.withMaterializedView(createUserTagMVSql);
+        String query = "select * from (select user_id, bitmap_union_count(to_bitmap(tag_id)) x from " +
+                USER_TAG_TABLE_NAME + " group by user_id) a, (select user_name, bitmap_union_count(to_bitmap(tag_id))"
+                + "" + " y from " + USER_TAG_TABLE_NAME + " group by user_name) b where a.x=b.y;";
+        dorisAssert.query(query).explainContains(QUERY_USE_USER_TAG, QUERY_USE_USER_TAG_MV);
+    }
+
+    @Test
+    public void testAggTableCountDistinctInBitmapType() throws Exception {
+        String aggTable = "CREATE TABLE " + TEST_TABLE_NAME + " (k1 int, v1 bitmap bitmap_union) Aggregate KEY (k1) "
+                + "DISTRIBUTED BY HASH(k1) BUCKETS 3 PROPERTIES ('replication_num' = '1');";
+        dorisAssert.withTable(aggTable);
+        String query = "select k1, count(distinct v1) from " + TEST_TABLE_NAME + " group by k1;";
+        dorisAssert.query(query).explainContains(TEST_TABLE_NAME, "bitmap_union_count");
+        dorisAssert.dropTable(TEST_TABLE_NAME);
+    }
+
+    @Test
+    public void testAggTableCountDistinctInHllType() throws Exception {
+        String aggTable = "CREATE TABLE " + TEST_TABLE_NAME + " (k1 int, v1 hll hll_union) Aggregate KEY (k1) " +
+                "DISTRIBUTED BY HASH(k1) BUCKETS 3 PROPERTIES ('replication_num' = '1');";
+        dorisAssert.withTable(aggTable);
+        String query = "select k1, count(distinct v1) from " + TEST_TABLE_NAME + " group by k1;";
+        dorisAssert.query(query).explainContains(TEST_TABLE_NAME, "hll_union_agg");
+        dorisAssert.dropTable(TEST_TABLE_NAME);
+    }
+
+    @Test
+    public void testCountDistinctToBitmap() throws Exception {
+        String createUserTagMVSql = "create materialized view " + USER_TAG_MV_NAME + " as select user_id, " +
+                "bitmap_union(to_bitmap(tag_id)) from " + USER_TAG_TABLE_NAME + " group by user_id;";
+        dorisAssert.withMaterializedView(createUserTagMVSql);
+        String query = "select count(distinct tag_id) from " + USER_TAG_TABLE_NAME + ";";
+        dorisAssert.query(query).explainContains(USER_TAG_MV_NAME, "bitmap_union_count");
+    }
+
+    @Test
+    public void testIncorrectRewriteCountDistinct() throws Exception {
+        String createUserTagMVSql = "create materialized view " + USER_TAG_MV_NAME + " as select user_id, " +
+                "bitmap_union(to_bitmap(tag_id)) from " + USER_TAG_TABLE_NAME + " group by user_id;";
+        dorisAssert.withMaterializedView(createUserTagMVSql);
+        String query = "select user_name, count(distinct tag_id) from " + USER_TAG_TABLE_NAME + " group by user_name;";
+        dorisAssert.query(query).explainContains(USER_TAG_TABLE_NAME, "count");
+    }
+
+    @Test
+    public void testNDVToHll() throws Exception {
+        String createUserTagMVSql = "create materialized view " + USER_TAG_MV_NAME + " as select user_id, " +
+                "`hll_union`(hll_hash(tag_id)) from " + USER_TAG_TABLE_NAME + " group by user_id;";
+        dorisAssert.withMaterializedView(createUserTagMVSql);
+        String query = "select ndv(tag_id) from " + USER_TAG_TABLE_NAME + ";";
+        dorisAssert.query(query).explainContains(USER_TAG_MV_NAME, "hll_union_agg");
+    }
+
+    @Test
+    public void testHLLUnionFamilyRewrite() throws Exception {
+        String createUserTagMVSql = "create materialized view " + USER_TAG_MV_NAME + " as select user_id, " +
+                "`hll_union`(hll_hash(tag_id)) from " + USER_TAG_TABLE_NAME + " group by user_id;";
+        dorisAssert.withMaterializedView(createUserTagMVSql);
+        String query = "select `hll_union`(hll_hash(tag_id)) from " + USER_TAG_TABLE_NAME + ";";
+        String mvColumnName = CreateMaterializedViewStmt.mvColumnBuilder("hll_union", "tag_id");
+        dorisAssert.query(query).explainContains(USER_TAG_MV_NAME, mvColumnName);
+        query = "select hll_union_agg(hll_hash(tag_id)) from " + USER_TAG_TABLE_NAME + ";";
+        dorisAssert.query(query).explainContains(USER_TAG_MV_NAME, mvColumnName);
+        query = "select hll_raw_agg(hll_hash(tag_id)) from " + USER_TAG_TABLE_NAME + ";";
+        dorisAssert.query(query).explainContains(USER_TAG_MV_NAME, mvColumnName);
+    }
+
+    /*
+    ISSUE-3174
+     */
+    @Test
+    public void testAggInHaving() throws Exception {
+        String createMVSQL = "create materialized view " + EMPS_MV_NAME + " as select empid, deptno from "
+                + EMPS_TABLE_NAME + " group by empid, deptno;";
+        dorisAssert.withMaterializedView(createMVSQL);
+        String query = "select empid from " + EMPS_TABLE_NAME + " group by empid having max(salary) > 1;";
+        dorisAssert.query(query).explainWithout(QUERY_USE_EMPS_MV);
+    }
+
+    @Test
+    public void testCountFieldInQuery() throws Exception {
+        String createUserTagMVSql = "create materialized view " + USER_TAG_MV_NAME + " as select user_id, " +
+                "count(tag_id) from " + USER_TAG_TABLE_NAME + " group by user_id;";
+        dorisAssert.withMaterializedView(createUserTagMVSql);
+        String query = "select count(tag_id) from " + USER_TAG_TABLE_NAME + ";";
+        String mvColumnName = CreateMaterializedViewStmt.mvColumnBuilder("count", "tag_id");
+        dorisAssert.query(query).explainContains(USER_TAG_MV_NAME, mvColumnName);
+        query = "select user_name, count(tag_id) from " + USER_TAG_TABLE_NAME + " group by user_name;";
+        dorisAssert.query(query).explainWithout(USER_TAG_MV_NAME);
+    }
+
 }

--- a/fe/src/test/java/org/apache/doris/planner/MaterializedViewSelectorTest.java
+++ b/fe/src/test/java/org/apache/doris/planner/MaterializedViewSelectorTest.java
@@ -19,6 +19,8 @@ package org.apache.doris.planner;
 
 import org.apache.doris.analysis.AggregateInfo;
 import org.apache.doris.analysis.Analyzer;
+import org.apache.doris.analysis.Expr;
+import org.apache.doris.analysis.ExprSubstitutionMap;
 import org.apache.doris.analysis.FunctionCallExpr;
 import org.apache.doris.analysis.SelectStmt;
 import org.apache.doris.analysis.SlotDescriptor;
@@ -38,7 +40,6 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 
-import org.apache.commons.lang3.builder.ToStringExclude;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -90,8 +91,8 @@ public class MaterializedViewSelectorTest {
                 result = tableADesc;
                 tableADesc.getTable();
                 result = tableA;
-                tableA.getName();
-                result = "tableA";
+                tableA.getId();
+                result = 1;
 
                 aggregateInfo.getAggregateExprs();
                 result = Lists.newArrayList(tableAColumn2Sum, tableBColumn1Max);
@@ -114,36 +115,51 @@ public class MaterializedViewSelectorTest {
                 result = tableBDesc;
                 tableBDesc.getTable();
                 result = tableB;
-                tableB.getName();
-                result = "tableB";
+                tableB.getId();
+                result = 2;
+
+                tableAColumn2Desc.isMaterialized();
+                result = true;
+                tableBColumn1Desc.isMaterialized();
+                result = true;
+                tableAColumn2Desc.getColumn().getName();
+                result = "c2";
+                tableBColumn1Desc.getColumn().getName();
+                result = "c1";
             }
         };
 
         MaterializedViewSelector materializedViewSelector = new MaterializedViewSelector(selectStmt, analyzer);
-        Map<String, Set<String>> columnNamesInPredicates =
+        Map<Long, Set<String>> columnNamesInPredicates =
                 Deencapsulation.getField(materializedViewSelector, "columnNamesInPredicates");
         Assert.assertEquals(0, columnNamesInPredicates.size());
         Assert.assertFalse(Deencapsulation.getField(materializedViewSelector, "isSPJQuery"));
-        Map<String, Set<String>> columnNamesInGrouping =
+        Map<Long, Set<String>> columnNamesInGrouping =
                 Deencapsulation.getField(materializedViewSelector, "columnNamesInGrouping");
         Assert.assertEquals(1, columnNamesInGrouping.size());
-        Set<String> tableAColumnNamesInGrouping = columnNamesInGrouping.get("tableA");
+        Set<String> tableAColumnNamesInGrouping = columnNamesInGrouping.get(new Long(1));
         Assert.assertNotEquals(tableAColumnNamesInGrouping, null);
         Assert.assertEquals(1, tableAColumnNamesInGrouping.size());
         Assert.assertTrue(tableAColumnNamesInGrouping.contains("c1"));
-        Map<String, Set<MaterializedViewSelector.AggregatedColumn>> aggregateColumnsInQuery =
-                Deencapsulation.getField(materializedViewSelector, "aggregateColumnsInQuery");
+        Map<Long, Set<FunctionCallExpr>> aggregateColumnsInQuery =
+                Deencapsulation.getField(materializedViewSelector, "aggColumnsInQuery");
         Assert.assertEquals(2, aggregateColumnsInQuery.size());
-        Set<MaterializedViewSelector.AggregatedColumn> tableAAgggregatedColumns = aggregateColumnsInQuery.get("tableA");
+        Set<FunctionCallExpr> tableAAgggregatedColumns = aggregateColumnsInQuery.get(new Long(1));
         Assert.assertEquals(1, tableAAgggregatedColumns.size());
-        MaterializedViewSelector.AggregatedColumn aggregatedColumn1 = tableAAgggregatedColumns.iterator().next();
-        Assert.assertEquals("c2", Deencapsulation.getField(aggregatedColumn1, "columnName"));
-        Assert.assertTrue("SUM".equalsIgnoreCase(Deencapsulation.getField(aggregatedColumn1, "aggFunctionName")));
-        Set<MaterializedViewSelector.AggregatedColumn> tableBAgggregatedColumns = aggregateColumnsInQuery.get("tableB");
+        FunctionCallExpr aggregatedColumn1 = tableAAgggregatedColumns.iterator().next();
+        List<Expr> aggColumn1Params = aggregatedColumn1.getParams().exprs();
+        Assert.assertEquals(1, aggColumn1Params.size());
+        Assert.assertTrue(aggColumn1Params.get(0) instanceof SlotRef);
+        Assert.assertEquals("c2", ((SlotRef) aggColumn1Params.get(0)).getColumnName());
+        Assert.assertTrue("SUM".equalsIgnoreCase(aggregatedColumn1.getFnName().getFunction()));
+        Set<FunctionCallExpr> tableBAgggregatedColumns = aggregateColumnsInQuery.get(new Long(2));
         Assert.assertEquals(1, tableBAgggregatedColumns.size());
-        MaterializedViewSelector.AggregatedColumn aggregatedColumn2 = tableBAgggregatedColumns.iterator().next();
-        Assert.assertEquals("c1", Deencapsulation.getField(aggregatedColumn2, "columnName"));
-        Assert.assertTrue("MAX".equalsIgnoreCase(Deencapsulation.getField(aggregatedColumn2, "aggFunctionName")));
+        FunctionCallExpr aggregatedColumn2 = tableBAgggregatedColumns.iterator().next();
+        List<Expr> aggColumn2Params = aggregatedColumn2.getParams().exprs();
+        Assert.assertEquals(1, aggColumn2Params.size());
+        Assert.assertTrue(aggColumn2Params.get(0) instanceof SlotRef);
+        Assert.assertEquals("c1", ((SlotRef) aggColumn2Params.get(0)).getColumnName());
+        Assert.assertTrue("MAX".equalsIgnoreCase(aggregatedColumn2.getFnName().getFunction()));
     }
 
     @Test
@@ -276,13 +292,15 @@ public class MaterializedViewSelectorTest {
         };
 
         MaterializedViewSelector selector = new MaterializedViewSelector(selectStmt, analyzer);
-        MaterializedViewSelector.AggregatedColumn aggregatedColumn = Deencapsulation.newInnerInstance
-                (MaterializedViewSelector.AggregatedColumn.class, selector, "C1", "sum");
-        Set<MaterializedViewSelector.AggregatedColumn> aggregatedColumnsInQueryOutput = Sets.newHashSet();
-        aggregatedColumnsInQueryOutput.add(aggregatedColumn);
+        TableName tableName = new TableName("db1", "table1");
+        SlotRef slotRef = new SlotRef(tableName, "C1");
+        FunctionCallExpr functionCallExpr = new FunctionCallExpr("sum", Lists.newArrayList(slotRef));
+        Set<FunctionCallExpr> aggregatedColumnsInQueryOutput = Sets.newHashSet();
+        aggregatedColumnsInQueryOutput.add(functionCallExpr);
         Deencapsulation.setField(selector, "isSPJQuery", false);
+        Map<Long, ExprSubstitutionMap> candidateIndexIdToRewriteSMap = Maps.newHashMap();
         Deencapsulation.invoke(selector, "checkAggregationFunction", aggregatedColumnsInQueryOutput,
-                               candidateIndexIdToSchema);
+                               candidateIndexIdToSchema, candidateIndexIdToRewriteSMap);
         Assert.assertEquals(2, candidateIndexIdToSchema.size());
         Assert.assertTrue(candidateIndexIdToSchema.keySet().contains(new Long(1)));
         Assert.assertTrue(candidateIndexIdToSchema.keySet().contains(new Long(3)));

--- a/fe/src/test/java/org/apache/doris/planner/MaterializedViewSelectorTest.java
+++ b/fe/src/test/java/org/apache/doris/planner/MaterializedViewSelectorTest.java
@@ -20,7 +20,6 @@ package org.apache.doris.planner;
 import org.apache.doris.analysis.AggregateInfo;
 import org.apache.doris.analysis.Analyzer;
 import org.apache.doris.analysis.Expr;
-import org.apache.doris.analysis.ExprSubstitutionMap;
 import org.apache.doris.analysis.FunctionCallExpr;
 import org.apache.doris.analysis.SelectStmt;
 import org.apache.doris.analysis.SlotDescriptor;
@@ -284,6 +283,8 @@ public class MaterializedViewSelectorTest {
                 result = null;
                 indexMeta1.getSchema();
                 result = index1Columns;
+                indexMeta1.getKeysType();
+                result = KeysType.DUP_KEYS;
                 indexMeta2.getSchema();
                 result = index2Columns;
                 indexMeta3.getSchema();
@@ -298,9 +299,8 @@ public class MaterializedViewSelectorTest {
         Set<FunctionCallExpr> aggregatedColumnsInQueryOutput = Sets.newHashSet();
         aggregatedColumnsInQueryOutput.add(functionCallExpr);
         Deencapsulation.setField(selector, "isSPJQuery", false);
-        Map<Long, ExprSubstitutionMap> candidateIndexIdToRewriteSMap = Maps.newHashMap();
         Deencapsulation.invoke(selector, "checkAggregationFunction", aggregatedColumnsInQueryOutput,
-                               candidateIndexIdToSchema, candidateIndexIdToRewriteSMap);
+                               candidateIndexIdToSchema);
         Assert.assertEquals(2, candidateIndexIdToSchema.size());
         Assert.assertTrue(candidateIndexIdToSchema.keySet().contains(new Long(1)));
         Assert.assertTrue(candidateIndexIdToSchema.keySet().contains(new Long(3)));

--- a/fe/src/test/java/org/apache/doris/planner/StreamLoadScanNodeTest.java
+++ b/fe/src/test/java/org/apache/doris/planner/StreamLoadScanNodeTest.java
@@ -29,6 +29,7 @@ import org.apache.doris.catalog.AggregateType;
 import org.apache.doris.catalog.Catalog;
 import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.Function;
+import org.apache.doris.catalog.FunctionSet;
 import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.catalog.PrimitiveType;
 import org.apache.doris.catalog.ScalarFunction;
@@ -300,7 +301,7 @@ public class StreamLoadScanNodeTest {
 
         new Expectations() {{
             catalog.getFunction((Function) any, (Function.CompareMode) any);
-            result = new ScalarFunction(new FunctionName("hll_hash"), Lists.newArrayList(), Type.BIGINT, false);
+            result = new ScalarFunction(new FunctionName(FunctionSet.HLL_HASH), Lists.newArrayList(), Type.BIGINT, false);
         }};
         
         new Expectations() {
@@ -318,7 +319,7 @@ public class StreamLoadScanNodeTest {
 
         TStreamLoadPutRequest request = getBaseRequest();
         request.setFileType(TFileType.FILE_STREAM);
-        request.setColumns("k1,k2, v1=hll_hash(k2)");
+        request.setColumns("k1,k2, v1=" + FunctionSet.HLL_HASH + "(k2)");
         StreamLoadTask streamLoadTask = StreamLoadTask.fromTStreamLoadPutRequest(request, null);
         StreamLoadScanNode scanNode = getStreamLoadScanNode(dstDesc, request);
 

--- a/fe/src/test/java/org/apache/doris/utframe/DemoTest.java
+++ b/fe/src/test/java/org/apache/doris/utframe/DemoTest.java
@@ -65,7 +65,6 @@ public class DemoTest {
     public static void beforeClass() throws EnvVarNotSetException, IOException,
             FeStartException, NotInitException, DdlException, InterruptedException {
         FeConstants.default_scheduler_interval_millisecond = 10;
-        FeConstants.runningUnitTest = true;
         UtFrameUtils.createMinDorisCluster(runningDir);
     }
 

--- a/fe/src/test/java/org/apache/doris/utframe/DemoTest.java
+++ b/fe/src/test/java/org/apache/doris/utframe/DemoTest.java
@@ -65,6 +65,7 @@ public class DemoTest {
     public static void beforeClass() throws EnvVarNotSetException, IOException,
             FeStartException, NotInitException, DdlException, InterruptedException {
         FeConstants.default_scheduler_interval_millisecond = 10;
+        FeConstants.runningUnitTest = true;
         UtFrameUtils.createMinDorisCluster(runningDir);
     }
 


### PR DESCRIPTION
This commit mainly supports creating bitmap_union, hll_union, and count materialized views.
* The main changes are as follows:
1. When creating a materialized view, doris judge the semantic analysis of the newly supported aggregate function.
Only bitmap_union(to_bitmap(column)), hll_union(hll_hash(column)) and count(column) are supported.

2. Match the correct materialized view when querying.
After the user sends the query, if there is a possibility of matching the materialized view, the query will be rewritten firstly.
    Such as:
    Table: k1 int, k2 int
    MV: k1 int, mv_bitmap_union_k2 bitmap mv_bitmap_union
        mv_bitmap_union = to_bitmap(k2)
    Query: select k1, count(distinct k2) from Table
    Found that there is a match between the materialized view column and the query column, the query is rewritten as:
    Rewritten query: select k1, bitmap_union_count(mv_bitmap_union_k2) from table

Then when the materialized view is matched, it can be matched to the query materialized view table.
Sometimes the rewritten query may not match any materialized view, which means that the rewriting failed. The query needs to be re-parsed and executed again.
