### PR TITLE
[Load][Json] Refactor json load logic to make it more reasonable

### DIFF
--- a/be/src/common/status.cpp
+++ b/be/src/common/status.cpp
@@ -143,6 +143,8 @@ std::string Status::code_as_string() const {
         return "Configuration error";
     case TStatusCode::INCOMPLETE:
         return "Incomplete";
+    case TStatusCode::DATA_QUALITY_ERROR:
+        return "Data quality error";
     default: {
         char tmp[30];
         snprintf(tmp, sizeof(tmp), "Unknown code(%d): ", static_cast<int>(code()));

--- a/be/src/common/status.h
+++ b/be/src/common/status.h
@@ -142,6 +142,12 @@ public:
         return Status(TStatusCode::ABORTED, msg, precise_code, msg2);
     }
 
+    static Status DataQualityError(const Slice& msg,
+                          int16_t precise_code = -1,
+                          const Slice& msg2 = Slice()) {
+        return Status(TStatusCode::DATA_QUALITY_ERROR, msg, precise_code, msg2);
+    }
+
     bool ok() const { return _state == nullptr; }
 
     bool is_cancelled() const { return code() == TStatusCode::CANCELLED; }
@@ -163,6 +169,8 @@ public:
 
     // @return @c true iff the status indicates ServiceUnavailable.
     bool is_service_unavailable() const { return code() == TStatusCode::SERVICE_UNAVAILABLE; }
+
+    bool is_data_quality_error() const { return code() == TStatusCode::DATA_QUALITY_ERROR; }
 
     // Convert into TStatus. Call this if 'status_container' contains an optional
     // TStatus field named 'status'. This also sets __isset.status.

--- a/be/src/exec/broker_scanner.cpp
+++ b/be/src/exec/broker_scanner.cpp
@@ -34,7 +34,6 @@
 #include "exec/local_file_reader.h"
 #include "exec/broker_reader.h"
 #include "exec/decompressor.h"
-#include "json_scanner.h"
 #include "util/utf8_check.h"
 
 namespace doris {

--- a/be/src/exec/json_scanner.cpp
+++ b/be/src/exec/json_scanner.cpp
@@ -602,7 +602,6 @@ Status JsonReader::_handle_complex_json(Tuple* tuple, const std::vector<SlotDesc
     }
 }
 
-// 
 Status JsonReader::read(Tuple* tuple, const std::vector<SlotDescriptor*>& slot_descs, MemPool* tuple_pool, bool* eof) {
     if (_parsed_jsonpaths.empty()) { // input is a simple json-string
         return _handle_simple_json(tuple, slot_descs, tuple_pool, eof);

--- a/be/src/exec/json_scanner.cpp
+++ b/be/src/exec/json_scanner.cpp
@@ -143,6 +143,7 @@ Status JsonScanner::open_next_reader() {
         strip_outer_array = range.strip_outer_array;
     }
     _cur_file_reader = new JsonReader(_state, _counter, _profile, file, jsonpath, strip_outer_array);
+    RETURN_IF_ERROR(_cur_file_reader->init());
 
     return Status::OK();
 }
@@ -159,20 +160,18 @@ void JsonScanner::close() {
 
 ////// class JsonDataInternal
 JsonDataInternal::JsonDataInternal(rapidjson::Value* v) :
-        _json_values(v), _iterator(v->Begin()) {
-}
-
-JsonDataInternal::~JsonDataInternal() {
-
+        _json_values(v) {
+   if (v != nullptr) {
+       _iterator = v->Begin();
+   }
 }
 
 rapidjson::Value::ConstValueIterator JsonDataInternal::get_next() {
-    if (_json_values->End() == _iterator) {
+    if (is_null() || _json_values->End() == _iterator) {
         return nullptr;
     }
     return _iterator++;
 }
-
 
 ////// class JsonReader
 JsonReader::JsonReader(
@@ -181,6 +180,7 @@ JsonReader::JsonReader(
         FileReader* file_reader,
         std::string& jsonpath,
         bool strip_outer_array) :
+            _jsonpath(jsonpath),
             _next_line(0),
             _total_lines(0),
             _state(state),
@@ -191,33 +191,39 @@ JsonReader::JsonReader(
             _strip_outer_array(strip_outer_array) {
     _bytes_read_counter = ADD_COUNTER(_profile, "BytesRead", TUnit::BYTES);
     _read_timer = ADD_TIMER(_profile, "FileReadTime");
-
-    init_jsonpath(jsonpath);
 }
 
 JsonReader::~JsonReader() {
-    close();
+    _close();
 }
 
-void JsonReader::init_jsonpath(std::string& jsonpath) {
-    //parse jsonpath
-    if (!jsonpath.empty()) {
-        if (!_jsonpaths_doc.Parse(jsonpath.c_str()).HasParseError()) {
-            if (!_jsonpaths_doc.IsArray()) {
-                _parse_jsonpath_flag = -1;// failed, has none object
+Status JsonReader::init() {
+    // parse jsonpath
+    rapidjson::Document jsonpaths_doc;
+    if (!_jsonpath.empty()) {
+        if (!jsonpaths_doc.Parse(_jsonpath.c_str()).HasParseError()) {
+            if (!jsonpaths_doc.IsArray()) {
+                return Status::InvalidArgument("Invalid json path: " + _jsonpath);
             } else {
-                _parse_jsonpath_flag = 1;// success
+                for (int i = 0; i < jsonpaths_doc.Size(); i++) {
+                    const rapidjson::Value& path = jsonpaths_doc[i];
+                    if (!path.IsString()) {
+                        return Status::InvalidArgument("Invalid json path: " + _jsonpath);
+                    }
+                    path.GetString();    
+                    std::vector<JsonPath> parsed_paths;
+                    JsonFunctions::parse_json_paths(path.GetString(), &parsed_paths);
+                    _parsed_jsonpaths.push_back(parsed_paths);
+                }
             }
         } else {
-            _parse_jsonpath_flag = -1;// parse failed
+            return Status::InvalidArgument("Invalid json path: " + _jsonpath);
         }
-    } else {
-        _parse_jsonpath_flag = 0;
     }
-    return ;
+    return Status::OK();
 }
 
-void JsonReader::close() {
+void JsonReader::_close() {
     if (_closed) {
         return;
     }
@@ -228,7 +234,11 @@ void JsonReader::close() {
     _closed = true;
 }
 
-Status JsonReader::parse_json_doc(bool* eof) {
+// read one json string from file read and parse it to json doc.
+// return Status::DataQualityError() if data has quality error.
+// return other error if encounter other problemes.
+// return Status::OK() if parse succeed or reach EOF.
+Status JsonReader::_parse_json_doc(bool* eof) {
     // read a whole message, must be delete json_str by `delete[]`
     uint8_t* json_str = nullptr;
     size_t length = 0;
@@ -237,48 +247,77 @@ Status JsonReader::parse_json_doc(bool* eof) {
         *eof = true;
         return Status::OK();
     }
-    //  parse jsondata to JsonDoc
+    // parse jsondata to JsonDoc
     if (_json_doc.Parse((char*)json_str, length).HasParseError()) {
+        std::stringstream str_error;
+        str_error << "Parse json data for JsonDoc failed. code = " << _json_doc.GetParseError()
+                << ", error-info:" << rapidjson::GetParseError_En(_json_doc.GetParseError());
+        _state->append_error_msg_to_file(std::string((char*) json_str, length), str_error.str());
+        _counter->num_rows_filtered++;
+        delete[] json_str;
+        return Status::DataQualityError(str_error.str());
+    }
+
+    if (_json_doc.IsArray() && !_strip_outer_array) {
         delete[] json_str;
         std::stringstream str_error;
-        str_error << "Parse json data for JsonDoc is failed. code = " << _json_doc.GetParseError()
-                << ", error-info:" << rapidjson::GetParseError_En(_json_doc.GetParseError());
-        return Status::InternalError(str_error.str());
+        str_error << "JSON data is array-object, `strip_outer_array` must be TRUE.";
+        _state->append_error_msg_to_file(_print_json_value(_json_doc), str_error.str());
+        _counter->num_rows_filtered++;
+        return Status::DataQualityError(str_error.str());
     }
 
     if (!_json_doc.IsArray() && _strip_outer_array) {
         delete[] json_str;
-        return Status::InternalError("JSON ROOT node is array-object, `strip_outer_array` must be TRUE.");
+        std::stringstream str_error;
+        str_error << "JSON data is not an array-object, `strip_outer_array` must be FALSE.";
+        _state->append_error_msg_to_file(_print_json_value(_json_doc), str_error.str());
+        _counter->num_rows_filtered++;
+        return Status::DataQualityError(str_error.str());
     }
 
     delete[] json_str;
     return Status::OK();
 }
 
-size_t JsonReader::get_data_by_jsonpath(const std::vector<SlotDescriptor*>& slot_descs) {
-    size_t max_lines = 0;
-    //iterator jsonpath to find object and save it to Map
-    _jmap.clear();
-
-    for (int i = 0; i < _jsonpaths_doc.Size(); i++) {
-        const rapidjson::Value& path = _jsonpaths_doc[i];
-        if (!path.IsString()) {
-            return -1;
-        }
-
-        // if jsonValues is null, because not match in jsondata.
-        rapidjson::Value* json_values = JsonFunctions::get_json_array_from_parsed_json(path.GetString(), &_json_doc, _json_doc.GetAllocator());
-        if (json_values == nullptr) {
-            return -1;
-        }
-        max_lines = std::max(max_lines, (size_t)json_values->Size());
-        _jmap.emplace(slot_descs[i]->col_name(), json_values);
-    }
-
-    return max_lines;
+std::string JsonReader::_print_json_value(const rapidjson::Value& value) {
+    rapidjson::StringBuffer buffer;
+    buffer.Clear();
+    rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
+    value.Accept(writer);
+    return std::string(buffer.GetString());
 }
 
-void JsonReader::fill_slot(Tuple* tuple, SlotDescriptor* slot_desc, MemPool* mem_pool, const uint8_t* value, int32_t len) {
+void JsonReader::_assemble_jmap(
+        const std::vector<SlotDescriptor*>& slot_descs) {
+    // iterator jsonpath to find object and save it to Map
+    _jmap.clear();
+
+    for (int i = 0; i < _parsed_jsonpaths.size(); i++) {
+        rapidjson::Value* json_value = JsonFunctions::get_json_array_from_parsed_json(_parsed_jsonpaths[i], &_json_doc, _json_doc.GetAllocator());
+        if (json_value == nullptr) {
+            // null means failed to match, we also put it in _jmap, it will be handled later.
+            _jmap.emplace(slot_descs[i]->col_name(), nullptr);
+        } else {
+            if (json_value->Size() == 1) {
+                // see NOTICE1
+                json_value = &((*json_value)[0]);
+            }
+            _jmap.emplace(slot_descs[i]->col_name(), json_value);
+        }
+    }
+    return;
+}
+
+std::string JsonReader::_print_jsonpath(const std::vector<JsonPath>& path) {
+    std::stringstream ss;
+    for (auto& p : path) {
+        ss << p.to_string() << ".";
+    }
+    return ss.str();
+}
+
+void JsonReader::_fill_slot(Tuple* tuple, SlotDescriptor* slot_desc, MemPool* mem_pool, const uint8_t* value, int32_t len) {
     tuple->set_not_null(slot_desc->null_indicator_offset());
     void* slot = tuple->get_slot(slot_desc->tuple_offset());
     StringValue* str_slot = reinterpret_cast<StringValue*>(slot);
@@ -288,38 +327,38 @@ void JsonReader::fill_slot(Tuple* tuple, SlotDescriptor* slot_desc, MemPool* mem
     return;
 }
 
-Status JsonReader::write_data_to_tuple(rapidjson::Value::ConstValueIterator value, SlotDescriptor* desc, Tuple* tuple, MemPool* tuple_pool) {
+void JsonReader::_write_data_to_tuple(rapidjson::Value::ConstValueIterator value, SlotDescriptor* desc, Tuple* tuple, MemPool* tuple_pool, bool* valid) {
     const char* str_value = nullptr;
     uint8_t tmp_buf[128] = {0};
     int32_t wbytes = 0;
     switch (value->GetType()) {
         case rapidjson::Type::kStringType:
             str_value = value->GetString();
-            fill_slot(tuple, desc, tuple_pool, (uint8_t*)str_value, strlen(str_value));
+            _fill_slot(tuple, desc, tuple_pool, (uint8_t*)str_value, strlen(str_value));
             break;
         case rapidjson::Type::kNumberType:
             if (value->IsUint()) {
                 wbytes = sprintf((char*)tmp_buf, "%u", value->GetUint());
-                fill_slot(tuple, desc, tuple_pool, tmp_buf, wbytes);
+                _fill_slot(tuple, desc, tuple_pool, tmp_buf, wbytes);
             } else if (value->IsInt()) {
                 wbytes = sprintf((char*)tmp_buf, "%d", value->GetInt());
-                fill_slot(tuple, desc, tuple_pool, tmp_buf, wbytes);
+                _fill_slot(tuple, desc, tuple_pool, tmp_buf, wbytes);
             } else if (value->IsUint64()) {
                 wbytes = sprintf((char*)tmp_buf, "%lu", value->GetUint64());
-                fill_slot(tuple, desc, tuple_pool, tmp_buf, wbytes);
+                _fill_slot(tuple, desc, tuple_pool, tmp_buf, wbytes);
             } else if (value->IsInt64()) {
                 wbytes = sprintf((char*)tmp_buf, "%ld", value->GetInt64());
-                fill_slot(tuple, desc, tuple_pool, tmp_buf, wbytes);
+                _fill_slot(tuple, desc, tuple_pool, tmp_buf, wbytes);
             } else {
                 wbytes = sprintf((char*)tmp_buf, "%f", value->GetDouble());
-                fill_slot(tuple, desc, tuple_pool, tmp_buf, wbytes);
+                _fill_slot(tuple, desc, tuple_pool, tmp_buf, wbytes);
             }
             break;
         case rapidjson::Type::kFalseType:
-            fill_slot(tuple, desc, tuple_pool, (uint8_t*)"0", 1);
+            _fill_slot(tuple, desc, tuple_pool, (uint8_t*)"0", 1);
             break;
         case rapidjson::Type::kTrueType:
-            fill_slot(tuple, desc, tuple_pool, (uint8_t*)"1", 1);
+            _fill_slot(tuple, desc, tuple_pool, (uint8_t*)"1", 1);
             break;
         case rapidjson::Type::kNullType:
             if (desc->is_nullable()) {
@@ -327,31 +366,40 @@ Status JsonReader::write_data_to_tuple(rapidjson::Value::ConstValueIterator valu
             } else {
                 std::stringstream str_error;
                 str_error << "Json value is null, but the column `" << desc->col_name() << "` is not nullable.";
-                return Status::RuntimeError(str_error.str());
+                _state->append_error_msg_to_file(_print_json_value(*value), str_error.str());
+                _counter->num_rows_filtered++;
+                *valid = false;
+                return;
             }
             break;
         default:
-            std::stringstream str_error;
-            str_error << "Invalid JsonType " << value->GetType() << ", Column Name `" << desc->col_name() << "`.";
-            return Status::RuntimeError(str_error.str());
+            // for other type like array or object. we convert it to string to save
+            std::string json_str = _print_json_value(*value);
+            _fill_slot(tuple, desc, tuple_pool, (uint8_t*) json_str.c_str(), json_str.length());
+            break;
     }
-    return Status::OK();
+    *valid = true;
+    return;
 }
 
-Status JsonReader::set_tuple_value(rapidjson::Value& objectValue, Tuple* tuple, const std::vector<SlotDescriptor*>& slot_descs, MemPool* tuple_pool, bool *valid) {
+// for simple format json
+void JsonReader::_set_tuple_value(rapidjson::Value& objectValue, Tuple* tuple, const std::vector<SlotDescriptor*>& slot_descs, MemPool* tuple_pool, bool *valid) {
     int nullcount = 0;
     for (auto v : slot_descs) {
         if (objectValue.HasMember(v->col_name().c_str())) {
             rapidjson::Value& value = objectValue[v->col_name().c_str()];
-            RETURN_IF_ERROR(write_data_to_tuple(&value, v, tuple, tuple_pool));
-        } else {
+            _write_data_to_tuple(&value, v, tuple, tuple_pool, valid);
+            if (!(*valid)) {
+                return;
+            }
+        } else { // not found
             if (v->is_nullable()) {
                 tuple->set_null(v->null_indicator_offset());
                 nullcount++;
             } else  {
                 std::stringstream str_error;
                 str_error << "The column `" << v->col_name() << "` is not nullable, but it's not found in jsondata.";
-                _state->append_error_msg_to_file("", str_error.str());
+                _state->append_error_msg_to_file(_print_json_value(objectValue), str_error.str());
                 _counter->num_rows_filtered++;
                 *valid = false; // current row is invalid
                 break;
@@ -360,26 +408,31 @@ Status JsonReader::set_tuple_value(rapidjson::Value& objectValue, Tuple* tuple, 
     }
 
     if (nullcount == slot_descs.size()) {
-        _state->append_error_msg_to_file("", "The all fields is null, this is a invalid row.");
+        _state->append_error_msg_to_file(_print_json_value(objectValue), "All fields is null, this is a invalid row.");
         _counter->num_rows_filtered++;
         *valid = false;
-        return Status::OK();
+        return;
     }
     *valid = true;
-    return Status::OK();
+    return;
 }
 
 /**
- * handle input a simple json
+ * handle input a simple json.
+ * A json is a simple json only when user not specifying the json path.
  * For example:
  *  case 1. [{"colunm1":"value1", "colunm2":10}, {"colunm1":"value2", "colunm2":30}]
  *  case 2. {"colunm1":"value1", "colunm2":10}
  */
-Status JsonReader::handle_simple_json(Tuple* tuple, const std::vector<SlotDescriptor*>& slot_descs, MemPool* tuple_pool, bool* eof) {
+Status JsonReader::_handle_simple_json(Tuple* tuple, const std::vector<SlotDescriptor*>& slot_descs, MemPool* tuple_pool, bool* eof) {
     do {
         bool valid = false;
         if (_next_line >= _total_lines) {//parse json and generic document
-            RETURN_IF_ERROR(parse_json_doc(eof));
+            Status st = _parse_json_doc(eof);
+            if (st.is_data_quality_error()) {
+                continue; // continue to read next
+            }
+            RETURN_IF_ERROR(st); // terminate if encounter other errors
             if (*eof) {// read all data, then return
                 return Status::OK();
             }
@@ -391,11 +444,11 @@ Status JsonReader::handle_simple_json(Tuple* tuple, const std::vector<SlotDescri
             _next_line = 0;
         }
 
-        if (_json_doc.IsArray()) {//handle case 1
+        if (_json_doc.IsArray()) { // handle case 1
             rapidjson::Value& objectValue = _json_doc[_next_line];// json object
-            RETURN_IF_ERROR(set_tuple_value(objectValue, tuple, slot_descs, tuple_pool, &valid));
-        } else {// handle case 2
-            RETURN_IF_ERROR(set_tuple_value(_json_doc, tuple, slot_descs, tuple_pool, &valid));
+            _set_tuple_value(objectValue, tuple, slot_descs, tuple_pool, &valid);
+        } else { // handle case 2
+            _set_tuple_value(_json_doc, tuple, slot_descs, tuple_pool, &valid);
         }
         _next_line++;
         if (!valid) {
@@ -406,54 +459,60 @@ Status JsonReader::handle_simple_json(Tuple* tuple, const std::vector<SlotDescri
     return Status::OK();
 }
 
-Status JsonReader::set_tuple_value_from_map(Tuple* tuple, const std::vector<SlotDescriptor*>& slot_descs, MemPool* tuple_pool, bool *valid) {
+// for complex format json with strip_outer_array = false
+Status JsonReader::_set_tuple_value_from_jmap(Tuple* tuple, const std::vector<SlotDescriptor*>& slot_descs, MemPool* tuple_pool, bool *valid) {
     std::unordered_map<std::string, JsonDataInternal>::iterator it_map;
     for (auto v : slot_descs) {
         it_map = _jmap.find(v->col_name());
         if (it_map == _jmap.end()) {
-            return Status::RuntimeError("The column name of table is not foud in jsonpath.");
+            return Status::RuntimeError("The column name of table is not foud in jsonpath: " + v->col_name());
         }
-        rapidjson::Value::ConstValueIterator value = it_map->second.get_next();
+        rapidjson::Value* value = it_map->second.get_value();
         if (value == nullptr) {
             if (v->is_nullable()) {
                 tuple->set_null(v->null_indicator_offset());
             } else  {
                 std::stringstream str_error;
                 str_error << "The column `" << it_map->first << "` is not nullable, but it's not found in jsondata.";
-                _state->append_error_msg_to_file("", str_error.str());
+                _state->append_error_msg_to_file(_print_json_value(*value), str_error.str());
                 _counter->num_rows_filtered++;
                 *valid = false; // current row is invalid
                 break;
             }
         } else {
-            RETURN_IF_ERROR(write_data_to_tuple(value, v, tuple, tuple_pool));
+            _write_data_to_tuple(value, v, tuple, tuple_pool, valid);
+            if (!(*valid)) {
+                return Status::OK();
+            }
         }
     }
     *valid = true;
     return Status::OK();
 }
 
-Status JsonReader::handle_nest_complex_json(Tuple* tuple, const std::vector<SlotDescriptor*>& slot_descs, MemPool* tuple_pool, bool* eof) {
+// _json_doc should be an object
+Status JsonReader::_handle_nested_complex_json(Tuple* tuple, const std::vector<SlotDescriptor*>& slot_descs, MemPool* tuple_pool, bool* eof) {
     do {
         bool valid = false;
         if (_next_line >= _total_lines) {
-            RETURN_IF_ERROR(parse_json_doc(eof));
+            Status st = _parse_json_doc(eof);
+            if (st.is_data_quality_error()) {
+                continue; // continue to read next
+            }
+            RETURN_IF_ERROR(st); // terminate if encounter other errors
             if (*eof) {
                 return Status::OK();
             }
-            _total_lines = get_data_by_jsonpath(slot_descs);
-            if (_total_lines == -1) {
-                return Status::InternalError("Parse json data is failed.");
-            } else if (_total_lines == 0) {
-                *eof = true;
-                return Status::OK();
-            }
+            _assemble_jmap(slot_descs);
+            // for json with strip_outer_array is false, we treat it as a single row.
+            // so _total_lines is always 1.
+            _total_lines = 1;
             _next_line = 0;
         }
 
-        RETURN_IF_ERROR(set_tuple_value_from_map(tuple, slot_descs, tuple_pool, &valid));
+        RETURN_IF_ERROR(_set_tuple_value_from_jmap(tuple, slot_descs, tuple_pool, &valid));
         _next_line++;
-        if (!valid) {// read a invalid row, then read next one
+        if (!valid) { // read a invalid row, then read next one
             continue;
         }
         break; // read a valid row, then break
@@ -462,7 +521,7 @@ Status JsonReader::handle_nest_complex_json(Tuple* tuple, const std::vector<Slot
 }
 
 /**
- * flat array for json
+ * flat array for json. _json_doc should be an array
  * For example:
  *  [{"colunm1":"value1", "colunm2":10}, {"colunm1":"value2", "colunm2":30}]
  * Result:
@@ -471,10 +530,14 @@ Status JsonReader::handle_nest_complex_json(Tuple* tuple, const std::vector<Slot
  *      value1     10
  *      value2     30
  */
-Status JsonReader::handle_flat_array_complex_json(Tuple* tuple, const std::vector<SlotDescriptor*>& slot_descs, MemPool* tuple_pool, bool* eof) {
+Status JsonReader::_handle_flat_array_complex_json(Tuple* tuple, const std::vector<SlotDescriptor*>& slot_descs, MemPool* tuple_pool, bool* eof) {
     do {
-        if (_next_line >= _total_lines) {//parse json and generic document
-            RETURN_IF_ERROR(parse_json_doc(eof));
+        if (_next_line >= _total_lines) {
+            Status st = _parse_json_doc(eof);
+            if (st.is_data_quality_error()) {
+                continue; // continue to read next
+            }
+            RETURN_IF_ERROR(st); // terminate if encounter other errors
             if (*eof) {// read all data, then return
                 return Status::OK();
             }
@@ -483,39 +546,45 @@ Status JsonReader::handle_flat_array_complex_json(Tuple* tuple, const std::vecto
         }
         int nullcount = 0;
         bool valid = true;
-        size_t limit = std::min(slot_descs.size(), (size_t)_jsonpaths_doc.Size());
+        size_t column_num = std::min(slot_descs.size(), _parsed_jsonpaths.size());
         rapidjson::Value& objectValue = _json_doc[_next_line];
 
-        for (size_t i = 0; i < limit; i++) {
-            const rapidjson::Value& path = _jsonpaths_doc[i];
-            if (!path.IsString()) {
-                return Status::InternalError("Jsonpath is not string.");
-            }
-
-            // if jsonValues is null, because not match in jsondata.
-            rapidjson::Value* json_values = JsonFunctions::get_json_array_from_parsed_json(path.GetString(), &objectValue, _json_doc.GetAllocator());
+        for (size_t i = 0; i < column_num; i++) {
+            rapidjson::Value* json_values = JsonFunctions::get_json_array_from_parsed_json(_parsed_jsonpaths[i], &objectValue, _json_doc.GetAllocator());
             if (json_values == nullptr) {
+                // not match in jsondata.
                 if (slot_descs[i]->is_nullable()) {
                     tuple->set_null(slot_descs[i]->null_indicator_offset());
                     nullcount++;
                 } else  {
                     std::stringstream str_error;
                     str_error << "The column `" << slot_descs[i]->col_name() << "` is not nullable, but it's not found in jsondata.";
-                    _state->append_error_msg_to_file("", str_error.str());
+                    _state->append_error_msg_to_file(_print_json_value(objectValue), str_error.str());
                     _counter->num_rows_filtered++;
                     valid = false; // current row is invalid
                     break;
                 }
             } else {
-                RETURN_IF_ERROR(write_data_to_tuple(json_values, slot_descs[i], tuple, tuple_pool));
+                CHECK(json_values->IsArray());
+                CHECK(json_values->Size() >= 1);
+                if (json_values->Size() == 1) {
+                    // NOTICE1: JsonFunctions::get_json_array_from_parsed_json() will wrap the single json object with an array.
+                    // so here we unwrap the array to get the real element.
+                    // if json_values' size > 1, it means we just match an array, not a wrapped one, so no need to unwrap.
+                    json_values = &((*json_values)[0]);
+                }
+                _write_data_to_tuple(json_values, slot_descs[i], tuple, tuple_pool, &valid);
+                if (!valid) {
+                    break;
+                }
             }
         }
         _next_line++;
         if (!valid) {
             continue;
         }
-        if (nullcount == _jsonpaths_doc.Size()) {
-            _state->append_error_msg_to_file("", "The all fields is null, this is a invalid row.");
+        if (nullcount == column_num) {
+            _state->append_error_msg_to_file(_print_json_value(objectValue), "All fields is null or not matched, this is a invalid row.");
             _counter->num_rows_filtered++;
             continue;
         }
@@ -524,21 +593,21 @@ Status JsonReader::handle_flat_array_complex_json(Tuple* tuple, const std::vecto
     return Status::OK();
 }
 
-Status JsonReader::handle_complex_json(Tuple* tuple, const std::vector<SlotDescriptor*>& slot_descs, MemPool* tuple_pool, bool* eof) {
+// handle json with specified json path
+Status JsonReader::_handle_complex_json(Tuple* tuple, const std::vector<SlotDescriptor*>& slot_descs, MemPool* tuple_pool, bool* eof) {
     if (_strip_outer_array) {
-        return handle_flat_array_complex_json(tuple, slot_descs, tuple_pool, eof);
+        return _handle_flat_array_complex_json(tuple, slot_descs, tuple_pool, eof);
     } else {
-        return handle_nest_complex_json(tuple, slot_descs, tuple_pool, eof);
+        return _handle_nested_complex_json(tuple, slot_descs, tuple_pool, eof);
     }
 }
 
+// 
 Status JsonReader::read(Tuple* tuple, const std::vector<SlotDescriptor*>& slot_descs, MemPool* tuple_pool, bool* eof) {
-    if (_parse_jsonpath_flag == -1) {
-        return Status::InternalError("Parse jsonpath is failed.");
-    } else if (_parse_jsonpath_flag == 0) {// input a simple json-string
-        return handle_simple_json(tuple, slot_descs, tuple_pool, eof);
-    } else {// input a complex json-string and a json-path
-        return handle_complex_json(tuple,  slot_descs, tuple_pool, eof);
+    if (_parsed_jsonpaths.empty()) { // input is a simple json-string
+        return _handle_simple_json(tuple, slot_descs, tuple_pool, eof);
+    } else { // input is a complex json-string and a json-path
+        return _handle_complex_json(tuple,  slot_descs, tuple_pool, eof);
     }
 }
 

--- a/be/src/exprs/json_functions.cpp
+++ b/be/src/exprs/json_functions.cpp
@@ -266,6 +266,15 @@ rapidjson::Value* JsonFunctions::get_json_object(
     return match_value(*parsed_paths, document, document->GetAllocator());
 }
 
+rapidjson::Value* JsonFunctions::get_json_array_from_parsed_json(
+        const std::string& json_path,
+        rapidjson::Value* document,
+        rapidjson::Document::AllocatorType& mem_allocator) {
+
+    std::vector<JsonPath> vec;
+    parse_json_paths(json_path, &vec);
+    return get_json_array_from_parsed_json(vec, document, mem_allocator);
+}
 
 rapidjson::Value* JsonFunctions::get_json_array_from_parsed_json(
         const std::vector<JsonPath>& parsed_paths,

--- a/be/src/exprs/json_functions.cpp
+++ b/be/src/exprs/json_functions.cpp
@@ -110,7 +110,11 @@ DoubleVal JsonFunctions::get_json_double(
 }
 
 
-rapidjson::Value* JsonFunctions::match_value(std::vector<JsonPath>& parsed_paths, rapidjson::Value* document, rapidjson::Document::AllocatorType& mem_allocator, bool is_insert_null) {
+rapidjson::Value* JsonFunctions::match_value(
+        const std::vector<JsonPath>& parsed_paths,
+        rapidjson::Value* document,
+        rapidjson::Document::AllocatorType& mem_allocator,
+        bool is_insert_null) {
     rapidjson::Value* root = document;
     rapidjson::Value* array_obj = nullptr;
     for (int i = 1; i < parsed_paths.size(); i++) {
@@ -124,7 +128,7 @@ rapidjson::Value* JsonFunctions::match_value(std::vector<JsonPath>& parsed_paths
             return nullptr;
         }
 
-        std::string& col = parsed_paths[i].key;
+        const std::string& col = parsed_paths[i].key;
         int index = parsed_paths[i].idx;
         if (LIKELY(!col.empty())) {
             if (root->IsArray()) {
@@ -144,7 +148,7 @@ rapidjson::Value* JsonFunctions::match_value(std::vector<JsonPath>& parsed_paths
                             continue;
                         }
                         if (!json_elem->HasMember(col.c_str())) {
-                            if (is_insert_null) {//not found item, then insert a null object.
+                            if (is_insert_null) { // not found item, then insert a null object.
                                 is_null = false;
                                 rapidjson::Value nullObject(rapidjson::kNullType);
                                 array_obj->PushBack(nullObject, mem_allocator);
@@ -263,35 +267,17 @@ rapidjson::Value* JsonFunctions::get_json_object(
 }
 
 
-rapidjson::Value* JsonFunctions::get_json_array_from_parsed_json (
-        const std::string& path_string,
+rapidjson::Value* JsonFunctions::get_json_array_from_parsed_json(
+        const std::vector<JsonPath>& parsed_paths,
         rapidjson::Value* document,
         rapidjson::Document::AllocatorType& mem_allocator) {
-
-    // split path by ".", and escape quota by "\"
-    // eg:
-    //    '$.text#abc.xyz'  ->  [$, text#abc, xyz]
-    //    '$."text.abc".xyz'  ->  [$, text.abc, xyz]
-    //    '$."text.abc"[1].xyz'  ->  [$, text.abc[1], xyz]
-    std::vector<JsonPath> parsed_paths;
-#ifndef BE_TEST
-    boost::tokenizer<boost::escaped_list_separator<char> > tok(path_string, boost::escaped_list_separator<char>("\\", ".", "\""));
-   std::vector<std::string> paths(tok.begin(), tok.end());
-   get_parsed_paths(paths, &parsed_paths);
-#else
-    boost::tokenizer<boost::escaped_list_separator<char> > tok(path_string, boost::escaped_list_separator<char>("\\", ".", "\""));
-    std::vector<std::string> paths(tok.begin(), tok.end());
-    get_parsed_paths(paths, &parsed_paths);
-#endif
-
-    VLOG(10) << "first parsed path: " << parsed_paths[0].debug_string();
 
     if (!parsed_paths[0].is_valid) {
         return nullptr;
     }
 
     rapidjson::Value* root = match_value(parsed_paths, document, mem_allocator, true);
-    if (root == nullptr || root == document) {// not found
+    if (root == nullptr || root == document) { // not found
         return nullptr;
     } else if (!root->IsArray()) {
         rapidjson::Value* array_obj = nullptr;
@@ -330,6 +316,32 @@ void JsonFunctions::json_path_prepare(
     VLOG(10) << "prepare json path. size: " << parsed_paths->size();
 }
 
+void JsonFunctions::json_path_close(
+        doris_udf::FunctionContext* context,
+        doris_udf::FunctionContext::FunctionStateScope scope) {
+    if (scope != FunctionContext::FRAGMENT_LOCAL) {
+        return;
+    }
+    std::vector<JsonPath>* parsed_paths = reinterpret_cast<std::vector<JsonPath>*>(context->get_function_state(scope));
+    if (parsed_paths != nullptr) {
+        delete parsed_paths;
+        VLOG(10) << "close json path";
+    }
+}
+
+void JsonFunctions::parse_json_paths(
+        const std::string& path_string,
+        std::vector<JsonPath>* parsed_paths) {
+    // split path by ".", and escape quota by "\"
+    // eg:
+    //    '$.text#abc.xyz'  ->  [$, text#abc, xyz]
+    //    '$."text.abc".xyz'  ->  [$, text.abc, xyz]
+    //    '$."text.abc"[1].xyz'  ->  [$, text.abc[1], xyz]
+    boost::tokenizer<boost::escaped_list_separator<char> > tok(path_string, boost::escaped_list_separator<char>("\\", ".", "\""));
+    std::vector<std::string> paths(tok.begin(), tok.end());
+    get_parsed_paths(paths, parsed_paths);
+}
+
 void JsonFunctions::get_parsed_paths(
         const std::vector<std::string>& path_exprs,
         std::vector<JsonPath>* parsed_paths) {
@@ -356,19 +368,6 @@ void JsonFunctions::get_parsed_paths(
             }
             parsed_paths->emplace_back(col, idx, true);
         }
-    }
-}
-
-void JsonFunctions::json_path_close(
-        doris_udf::FunctionContext* context,
-        doris_udf::FunctionContext::FunctionStateScope scope) {
-    if (scope != FunctionContext::FRAGMENT_LOCAL) {
-        return;
-    }
-    std::vector<JsonPath>* parsed_paths = reinterpret_cast<std::vector<JsonPath>*>(context->get_function_state(scope));
-    if (parsed_paths != nullptr) {
-        delete parsed_paths;
-        VLOG(10) << "close json path";
     }
 }
 

--- a/be/src/exprs/json_functions.h
+++ b/be/src/exprs/json_functions.h
@@ -37,7 +37,7 @@ class TupleRow;
 
 struct JsonPath {
     std::string key; // key of a json object
-    int idx;    // array index of a json array, -1 means not set
+    int idx;    // array index of a json array, -1 means not set, -2 means *
     bool is_valid;  // true if the path is successfully parsed
 
     JsonPath(const std::string& key_, int idx_, bool is_valid_):
@@ -45,7 +45,16 @@ struct JsonPath {
         idx(idx_),
         is_valid(is_valid_) {}
 
-    std::string debug_string() {
+    std::string to_string() const {
+        std::stringstream ss;
+        if (!is_valid) { return "INVALID"; }
+        if (!key.empty()) { ss << key; }
+        if (idx == -2) { ss << "[*]"; }
+        else if (idx > -1) { ss << "[" << idx << "]"; }
+        return ss.str();
+    }
+
+    std::string debug_string() const {
         std::stringstream ss;
         ss << "key: " << key << ", idx: " << idx << ", valid: " << is_valid;
         return ss.str();
@@ -75,7 +84,7 @@ public:
      * return Value Is Array object
      */
     static rapidjson::Value* get_json_array_from_parsed_json(
-            const std::string& path_string,
+            const std::vector<JsonPath>& parsed_paths,
             rapidjson::Value* document,
             rapidjson::Document::AllocatorType& mem_allocator);
 
@@ -86,8 +95,13 @@ public:
     static void json_path_close(
             doris_udf::FunctionContext*,
             doris_udf::FunctionContext::FunctionStateScope);
+
+    static void parse_json_paths(
+            const std::string& path_strings,
+            std::vector<JsonPath>* parsed_paths);
+
 private:
-    static rapidjson::Value* match_value(std::vector<JsonPath>& parsed_paths,
+    static rapidjson::Value* match_value(const std::vector<JsonPath>& parsed_paths,
             rapidjson::Value* document, rapidjson::Document::AllocatorType& mem_allocator,
             bool is_insert_null = false);
     static void get_parsed_paths(

--- a/be/src/exprs/json_functions.h
+++ b/be/src/exprs/json_functions.h
@@ -88,6 +88,13 @@ public:
             rapidjson::Value* document,
             rapidjson::Document::AllocatorType& mem_allocator);
 
+    // this is only for test, it will parse the json path inside,
+    // so that we can easily pass a json path as string.
+    static rapidjson::Value* get_json_array_from_parsed_json(
+            const std::string& jsonpath,
+            rapidjson::Value* document,
+            rapidjson::Document::AllocatorType& mem_allocator);
+
     static void json_path_prepare(
             doris_udf::FunctionContext*,
             doris_udf::FunctionContext::FunctionStateScope);

--- a/be/src/runtime/stream_load/stream_load_executor.cpp
+++ b/be/src/runtime/stream_load/stream_load_executor.cpp
@@ -86,7 +86,8 @@ Status StreamLoadExecutor::execute_plan_fragment(StreamLoadContext* ctx) {
                     LOG(WARNING) << "fragment execute failed"
                                  << ", query_id="
                                  << UniqueId(ctx->put_result.params.params.query_id)
-                                 << ", err_msg=" << status.get_error_msg() << ctx->brief();
+                                 << ", err_msg=" << status.get_error_msg()
+                                 << ", "<< ctx->brief();
                     // cancel body_sink, make sender known it
                     if (ctx->body_sink != nullptr) {
                         ctx->body_sink->cancel();

--- a/build.sh
+++ b/build.sh
@@ -41,7 +41,8 @@ if [[ ! -f ${DORIS_THIRDPARTY}/installed/lib/libs2.a ]]; then
     ${DORIS_THIRDPARTY}/build-thirdparty.sh
 fi
 
-PARALLEL=$[$(nproc)/4+1]
+#PARALLEL=$[$(nproc)/4+1]
+PARALLEL=12
 
 # Check args
 usage() {

--- a/docs/.vuepress/sidebar/en.js
+++ b/docs/.vuepress/sidebar/en.js
@@ -54,6 +54,7 @@ module.exports = [
           "routine-load-manual",
           "insert-into-manual",
           "delete-manual",
+          "load-json-format",
         ],
         sidebarDepth: 2,
       },

--- a/docs/.vuepress/sidebar/zh-CN.js
+++ b/docs/.vuepress/sidebar/zh-CN.js
@@ -55,6 +55,7 @@ module.exports = [
           "insert-into-manual",
           "spark-load-manual",
           "delete-manual",
+          "load-json-format",
         ],
         sidebarDepth: 2,
       },

--- a/docs/en/administrator-guide/load-data/load-json-format.md
+++ b/docs/en/administrator-guide/load-data/load-json-format.md
@@ -1,0 +1,308 @@
+---
+{
+    "title": "Load Json Format Data",
+    "language": "en"
+}
+---
+
+<!-- 
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Load Json Format Data
+
+Doris supports data load in Json format since version 0.12.
+
+## Supported Load Methods
+
+Currently only the following load methods support data import in Json format:
+
+* Stream Load
+* Routine Load
+
+For specific instructions on the above load methods, please refer to the relevant documentation. This document mainly introduces the instructions for using Json in these load methods.
+
+## Supported Json Format
+
+Currently, only the following two Json formats are supported:
+
+1. Multi-line data represented by Array
+
+    Json format with Array as the root node. Each element in the Array represents a row of data to be loaded, usually an Object. Examples are as follows:
+
+    ```
+    [
+        { "id": 123, "city" : "beijing"},
+        { "id": 456, "city" : "shanghai"},
+        ...
+    ]
+    ```
+    
+    ```
+    [
+        { "id": 123, "city" : { "name" : "beijing", "region" : "haidian"}},
+        { "id": 456, "city" : { "name" : "beijing", "region" : "chaoyang"}},
+        ...
+    ]
+    ```
+    
+    This method is usually used for the Stream Load method to represent multiple rows of data in a batch of load data.
+    
+     This method must be used in conjunction with setting `stripe_outer_array=true`. Doris will expand the array when parsing, and then parse each Object in turn as a row of data.
+
+2. Single row of data represented by Object
+
+    Json format with Object as the root node. The entire Object represents a row of data to be loaded. Examples are as follows:
+    
+    ```
+    { "id": 123, "city" : "beijing"}
+    ```
+    
+    ```
+    { "id": 123, "city" : { "name" : "beijing", "region" : "haidian" }}
+    ```
+    
+    This method is usually used for the Routine Load method, such as representing a message in Kafka, that is, a row of data.
+        
+## Json Path
+
+Doris supports extracting the data specified in Json through Json Path.
+
+**Note: Because for Array type data, Doris will first expand the array, and finally perform single-line processing according to the Object format. Therefore, the examples after this document will be illustrated with Json data in single Object format.**
+
+* Json Path is not specified
+
+    If Json Path is not specified, Doris will use the column names in the table to find the elements in Object by default. Examples are as follows:
+    
+    The table contains two columns: `id`, `city`
+    
+    Json data is as follows:
+    
+    ```
+    { "id": 123, "city" : "beijing"}
+    ```
+    
+    Then Doris will use `id`, `city` to match, and get the final data `123` and `beijing`.
+    
+    If the Json data is as follows:
+    
+    ```
+    { "id": 123, "name" : "beijing"}
+    ```
+
+    Then use `id`, `city` to match and get the final data `123` and `null`.
+    
+* Json Path is specified
+
+    Specify a set of Json Path in the form of a Json data. Each element in the array represents a column to be extracted. Examples are as follows:
+    
+    ```
+    ["$.id", "$.name"]
+    ```
+    ```
+    ["$.id.sub_id", "$.name[0]", "$.city[0]"]
+    ```
+    
+    Doris will use the specified Json Path for data matching and extraction.
+        
+* Match non-primitive types
+
+     The values that the previous example finally matched are all primitive types, such as Integer, String, and so on. Doris currently does not support complex types, such as Array, Map, etc. So when a non-primitive type is matched, Doris will convert the type to a Json format string and load it as a string type. Examples are as follows:
+    
+    ```
+    { "id": 123, "city" : { "name" : "beijing", "region" : "haidian" }}
+    ```
+    
+    The Json Path is `["$.city"]`. Then the matched elements are:
+    
+    ```
+    { "name" : "beijing", "region" : "haidian" }
+    ```
+    
+    This element will be converted into a string for subsequent load operations:
+    
+    ```
+    "{'name':'beijing','region':'haidian'}"
+    ```
+
+* Match failed
+
+    When the match fails, `null` will be returned. Examples are as follows:
+    
+    Json data is:
+    
+    ```
+    { "id": 123, "name" : "beijing"}
+    ```
+    
+    The Json Path is `["$.id", "$.info"]`. Then the matched elements are `123` and `null`.
+    
+     Doris currently does not distinguish between the null value represented in the Json data and the null value generated when the match fails. Suppose the Json data is:
+    
+    ```
+    { "id": 123, "name" : null }
+    ```
+    
+    Then use the following two Json Path will get the same result: `123` and `null`.
+        
+    ```
+    ["$.id", "$.name"]
+    ```
+    ```
+    ["$.id", "$.info"]
+    ```
+    
+* Complete match failed
+
+    In order to prevent misoperation caused by some parameter setting errors. When Doris tries to match a row of data, if all columns fail to match, it will be considered a error row. Suppose the Json data is:
+    
+    ```
+    { "id": 123, "city" : "beijing" }
+    ```
+    
+    If Json Path is incorrectly written as (or when Json Path is not specified, the columns in the table do not contain `id` and `city`):
+    
+    ```
+    ["$.ad", "$.infa"]
+    ```
+    
+    Will result in a complete match failure, the line will be marked as an error row, instead of producing `null, null`.
+
+
+## Examples
+
+### Stream Load
+
+Because of the indivisible nature of the Json format, when using Stream Load to load a Json format file, the file content will be fully loaded into memory before processing. Therefore, if the file is too large, it may occupy more memory.
+
+Suppose the table structure is:
+
+```
+id      INT     NOT NULL,
+city    VARHCAR NULL,
+code    INT     NULL
+```
+
+1. Load single-line data 1
+
+    ```
+    {"id": 100, "city": "beijing", "code" : 1}
+    ```
+
+    * Not specify Json Path
+    
+        ```
+        curl --location-trusted -u user:passwd -H "format: json" -T data.json http://localhost:8030/api/db1/tbl1/_stream_load
+        ```
+        
+        Results：
+        
+        ```
+        100     beijing     1
+        ```
+        
+    * Specify Json Path
+
+        ```
+        curl --location-trusted -u user:passwd -H "format: json" -H "jsonpaths: [\"$.id\",\"$.city\",\"$.code\"]" -T data.json http://localhost:8030/api/db1/tbl1/_stream_load
+        ```
+        
+        Results：
+        
+        ```
+        100     beijing     1
+        ```
+        
+2. Load sigle-line data 2
+
+    ```
+    {"id": 100, "content": {"city": "beijing", "code" : 1}}
+    ```
+
+    * Specify Json Path
+
+        ```
+        curl --location-trusted -u user:passwd -H "format: json" -H "jsonpaths: [\"$.id\",\"$.content.city\",\"$.content.code\"]" -T data.json http://localhost:8030/api/db1/tbl1/_stream_load
+        ```
+
+        Results：
+        
+        ```
+        100     beijing     1
+        ```
+
+3. Load multi-line data
+
+    ```
+    [
+        {"id": 100, "city": "beijing", "code" : 1},
+        {"id": 101, "city": "shanghai"},
+        {"id": 102, "city": "tianjin", "code" : 3},
+        {"id": 103, "city": "chongqing", "code" : 4},
+        {"id": 104, "city": ["zhejiang", "guangzhou"], "code" : 5},
+        {
+            "id": 105,
+            "city": {
+                "order1": ["guangzhou"]
+            }, 
+            "code" : 6
+        }
+    ]
+    ```
+
+    * Specify Json Path
+
+        ```
+        curl --location-trusted -u user:passwd -H "format: json" -H "jsonpaths: [\"$.id\",\"$.city\",\"$.code\"]" -H "strip_outer_array: true" -T data.json http://localhost:8030/api/db1/tbl1/_stream_load
+        ```
+
+        Results：
+        
+        ```
+        100     beijing                     1
+        101     shanghai                    NULL
+        102     tianjin                     3
+        103     chongqing                   4
+        104     ["zhejiang","guangzhou"]    5
+        105     {"order1":["guangzhou"]}    6
+        ```
+        
+4. Convert load data
+
+    The data is still the multi-row data in Example 3. Now you need to add 1 to the `code` column in the loaded data and load it.
+    
+    ```
+    curl --location-trusted -u user:passwd -H "format: json" -H "jsonpaths: [\"$.id\",\"$.city\",\"$.code\"]" -H "strip_outer_array: true" -H "columns: id, city, tmpc, code=tmpc+1" -T data.json http://localhost:8030/api/db1/tbl1/_stream_load
+    ```
+
+    Results：
+        
+    ```
+    100     beijing                     2
+    101     shanghai                    NULL
+    102     tianjin                     4
+    103     chongqing                   5
+    104     ["zhejiang","guangzhou"]    6
+    105     {"order1":["guangzhou"]}    7
+    ```
+
+### Routine Load
+
+Routine Load processes Json data the same as Stream Load. I will not repeat them here.
+
+For the Kafka data source, the content of each Massage is treated as a complete Json data. If multiple rows of data expressed in Array format in a Massage are loaded, multiple rows will be loaded, and Kafka's offset will only increase by 1. If an Array format Json represents multiple rows of data, but because the Json format error causes the parsing Json to fail, the error row will only increase by 1 (because the parsing fails, in fact, Doris cannot determine how many rows of data it contains, and can only add one row of errors rows record).

--- a/docs/en/sql-reference/sql-statements/Data Manipulation/ROUTINE LOAD.md
+++ b/docs/en/sql-reference/sql-statements/Data Manipulation/ROUTINE LOAD.md
@@ -161,7 +161,7 @@ FROM data_source
 
     4. `strict_mode`
 
-        Whether to enable strict mode, the default is on. If turned on, the column type transformation of non-null raw data is filtered if the result is NULL. Specified as "strict_mode" = "true"
+        Whether to enable strict mode, the default is disabled. If turned on, the column type transformation of non-null raw data is filtered if the result is NULL. Specified as "strict_mode" = "true"
             
     5. `timezone`
 

--- a/docs/en/sql-reference/sql-statements/Data Manipulation/STREAM LOAD.md
+++ b/docs/en/sql-reference/sql-statements/Data Manipulation/STREAM LOAD.md
@@ -101,7 +101,7 @@ Specifies the timeout for the load. Unit seconds. The default is 600 seconds. Th
 
 `strict_mode`
 
-The user specifies whether strict load mode is enabled for this load. The default is enabled. The shutdown mode is `-H "strict_mode: false"`.
+The user specifies whether strict load mode is enabled for this load. The default is disabled. Enable it with `-H "strict_mode: true"`.
 
 `timezone`
 

--- a/docs/zh-CN/administrator-guide/load-data/load-json-format.md
+++ b/docs/zh-CN/administrator-guide/load-data/load-json-format.md
@@ -1,0 +1,310 @@
+---
+{
+    "title": "导入 Json 格式数据",
+    "language": "zh-CN"
+}
+---
+
+<!-- 
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# 导入 Json 格式数据
+
+Doris 从 0.12 版本开始支持 Json 格式的数据导入。
+
+## 支持的导入方式
+
+目前只有以下导入方式支持 Json 格式的数据导入：
+
+* Stream Load
+* Routine Load
+
+关于以上导入方式的具体说明，请参阅相关文档。本文档主要介绍在这些导入方式中关于 Json 部分的使用说明。
+
+## 支持的 Json 格式
+
+当前前仅支持以下两种 Json 格式：
+
+1. 以 Array 表示的多行数据
+
+    以 Array 为根节点的 Json 格式。Array 中的每个元素表示要导入的一行数据，通常是一个 Object。示例如下：
+
+    ```
+    [
+        { "id": 123, "city" : "beijing"},
+        { "id": 456, "city" : "shanghai"},
+        ...
+    ]
+    ```
+    
+    ```
+    [
+        { "id": 123, "city" : { "name" : "beijing", "region" : "haidian"}},
+        { "id": 456, "city" : { "name" : "beijing", "region" : "chaoyang"}},
+        ...
+    ]
+    ```
+    
+    这种方式通常用于 Stream Load 导入方式，以便在一批导入数据中表示多行数据。
+    
+    这种方式必须配合设置 `stripe_outer_array=true` 使用。Doris在解析时会将数组展开，然后依次解析其中的每一个 Object 作为一行数据。
+
+2. 以 Object 表示的单行数据
+
+    以 Object 为根节点的 Json 格式。整个 Object 即表示要导入的一行数据。示例如下：
+    
+    ```
+    { "id": 123, "city" : "beijing"}
+    ```
+    
+    ```
+    { "id": 123, "city" : { "name" : "beijing", "region" : "haidian" }}
+    ```
+    
+    这种方式通常用于 Routine Load 导入方式，如表示 Kafka 中的一条消息，即一行数据。
+        
+## Json Path
+
+Doris 支持通过 Json Path 抽取 Json 中指定的数据。
+
+**注：因为对于 Array 类型的数据，Doris 会先进行数组展开，最终按照 Object 格式进行单行处理。所以本文档之后的示例都以单个 Object 格式的 Json 数据进行说明。**
+
+* 不指定 Json Path
+
+    如果没有指定 Json Path，则 Doris 会默认使用表中的列名查找 Object 中的元素。示例如下：
+    
+    表中包含两列: `id`, `city`
+    
+    Json 数据如下：
+    
+    ```
+    { "id": 123, "city" : "beijing"}
+    ```
+    
+    则 Doris 会使用 `id`, `city` 进行匹配，得到最终数据 `123` 和 `beijing`。
+    
+    如果 Json 数据如下：
+    
+    ```
+    { "id": 123, "name" : "beijing"}
+    ```
+
+    则使用 `id`, `city` 进行匹配，得到最终数据 `123` 和 `null`。
+    
+* 指定 Json Path
+
+    通过一个 Json 数据的形式指定一组 Json Path。数组中的每个元素表示一个要抽取的列。示例如下：
+    
+    ```
+    ["$.id", "$.name"]
+    ```
+    ```
+    ["$.id.sub_id", "$.name[0]", "$.city[0]"]
+    ```
+    
+    Doris 会使用指定的 Json Path 进行数据匹配和抽取。
+    
+* 匹配非基本类型
+
+    前面的示例最终匹配到的数值都是基本类型，如整型、字符串等。Doris 当前暂不支持复合类型，如 Array、Map 等。所以当匹配到一个非基本类型时，Doris 会将该类型转换为 Json 格式的字符串，并以字符串类型进行导入。示例如下：
+    
+    Json 数据为：
+    
+    ```
+    { "id": 123, "city" : { "name" : "beijing", "region" : "haidian" }}
+    ```
+    
+    Json Path 为 `["$.city"]`。则匹配到的元素为：
+    
+    ```
+    { "name" : "beijing", "region" : "haidian" }
+    ```
+    
+    该元素会被转换为字符串进行后续导入操作：
+    
+    ```
+    "{'name':'beijing','region':'haidian'}"
+    ```
+
+* 匹配失败
+
+    当匹配失败时，将会返回 `null`。示例如下：
+    
+    Json 数据为：
+    
+    ```
+    { "id": 123, "name" : "beijing"}
+    ```
+    
+    Json Path 为 `["$.id", "$.info"]`。则匹配到的元素为 `123` 和 `null`。
+    
+    Doris 当前不区分 Json 数据中表示的 null 值，和匹配失败时产生的 null 值。假设 Json 数据为：
+    
+    ```
+    { "id": 123, "name" : null }
+    ```
+    
+    则使用以下两种 Json Path 会获得相同的结果：`123` 和 `null`。
+    
+    ```
+    ["$.id", "$.name"]
+    ```
+    ```
+    ["$.id", "$.info"]
+    ```
+    
+* 完全匹配失败
+
+    为防止一些参数设置错误导致的误操作。Doris 在尝试匹配一行数据时，如果所有列都匹配失败，则会认为这个是一个错误行。假设 Json 数据为：
+    
+    ```
+    { "id": 123, "city" : "beijing" }
+    ```
+    
+    如果 Json Path 错误的写为（或者不指定 Json Path 时，表中的列不包含 `id` 和 `city`）：
+    
+    ```
+    ["$.ad", "$.infa"]
+    ```
+    
+    则会导致完全匹配失败，则该行会标记为错误行，而不是产出 `null, null`。
+
+
+## 应用示例
+
+### Stream Load
+
+因为 Json 格式的不可拆分特性，所以在使用 Stream Load 导入 Json 格式的文件时，文件内容会被全部加载到内存后，才开始处理。因此，如果文件过大的话，可能会占用较多的内存。
+
+假设表结构为：
+
+```
+id      INT     NOT NULL,
+city    VARHCAR NULL,
+code    INT     NULL
+```
+
+1. 导入单行数据1
+
+    ```
+    {"id": 100, "city": "beijing", "code" : 1}
+    ```
+
+    * 不指定 Json Path
+    
+        ```
+        curl --location-trusted -u user:passwd -H "format: json" -T data.json http://localhost:8030/api/db1/tbl1/_stream_load
+        ```
+        
+        导入结果：
+        
+        ```
+        100     beijing     1
+        ```
+        
+    * 指定 Json Path
+
+        ```
+        curl --location-trusted -u user:passwd -H "format: json" -H "jsonpaths: [\"$.id\",\"$.city\",\"$.code\"]" -T data.json http://localhost:8030/api/db1/tbl1/_stream_load
+        ```
+        
+        导入结果：
+        
+        ```
+        100     beijing     1
+        ```
+        
+2. 导入单行数据2
+
+    ```
+    {"id": 100, "content": {"city": "beijing", "code" : 1}}
+    ```
+
+    * 指定 Json Path
+
+        ```
+        curl --location-trusted -u user:passwd -H "format: json" -H "jsonpaths: [\"$.id\",\"$.content.city\",\"$.content.code\"]" -T data.json http://localhost:8030/api/db1/tbl1/_stream_load
+        ```
+
+        导入结果：
+        
+        ```
+        100     beijing     1
+        ```
+
+3. 导入多行数据
+
+    ```
+    [
+        {"id": 100, "city": "beijing", "code" : 1},
+        {"id": 101, "city": "shanghai"},
+        {"id": 102, "city": "tianjin", "code" : 3},
+        {"id": 103, "city": "chongqing", "code" : 4},
+        {"id": 104, "city": ["zhejiang", "guangzhou"], "code" : 5},
+        {
+            "id": 105,
+            "city": {
+                "order1": ["guangzhou"]
+            }, 
+            "code" : 6
+        }
+    ]
+    ```
+
+    * 指定 Json Path
+
+        ```
+        curl --location-trusted -u user:passwd -H "format: json" -H "jsonpaths: [\"$.id\",\"$.city\",\"$.code\"]" -H "strip_outer_array: true" -T data.json http://localhost:8030/api/db1/tbl1/_stream_load
+        ```
+
+        导入结果：
+        
+        ```
+        100     beijing                     1
+        101     shanghai                    NULL
+        102     tianjin                     3
+        103     chongqing                   4
+        104     ["zhejiang","guangzhou"]    5
+        105     {"order1":["guangzhou"]}    6
+        ```
+        
+4. 对导入数据进行转换
+
+    数据依然是示例3中的多行数据，现需要对导入数据中的 `code` 列加1后导入。
+    
+    ```
+    curl --location-trusted -u user:passwd -H "format: json" -H "jsonpaths: [\"$.id\",\"$.city\",\"$.code\"]" -H "strip_outer_array: true" -H "columns: id, city, tmpc, code=tmpc+1" -T data.json http://localhost:8030/api/db1/tbl1/_stream_load
+    ```
+
+    导入结果：
+        
+    ```
+    100     beijing                     2
+    101     shanghai                    NULL
+    102     tianjin                     4
+    103     chongqing                   5
+    104     ["zhejiang","guangzhou"]    6
+    105     {"order1":["guangzhou"]}    7
+    ```
+
+### Routine Load
+
+Routine Load 对 Json 数据的处理原理和 Stream Load 相同。在此不再赘述。
+
+对于 Kafka 数据源，每个 Massage 中的内容被视作一个完整的 Json 数据。如果一个 Massage 中是以 Array 格式的表示的多行数据，则会导入多行，而 Kafka 的 offset 只会增加 1。而如果一个 Array 格式的 Json 表示多行数据，但是因为 Json 格式错误导致解析 Json 失败，则错误行只会增加 1（因为解析失败，实际上 Doris 无法判断其中包含多少行数据，只能按一行错误数据记录）。

--- a/docs/zh-CN/sql-reference/sql-statements/Data Manipulation/MINI LOAD.md
+++ b/docs/zh-CN/sql-reference/sql-statements/Data Manipulation/MINI LOAD.md
@@ -87,8 +87,8 @@ under the License.
                             （如果不指定columns，则数据列面的列也可以是表里面的其它非HLL列）通过","分割
                             指定多个hll列使用“:”分割，例如: 'hll1,cuid:hll2,device'
 
-        strict_mode:        指定当前导入是否使用严格模式，默认为 true。严格模式下，非空原始数据在列类型转化后结果为 NULL 的会被过滤。
-                            指定方式为 'strict_mode=false'
+        strict_mode:        指定当前导入是否使用严格模式，默认为 false。严格模式下，非空原始数据在列类型转化后结果为 NULL 的会被过滤。
+                            指定方式为 'strict_mode=true'
     
     NOTE: 
         1. 此种导入方式当前是在一台机器上完成导入工作，因而不宜进行数据量较大的导入工作。

--- a/docs/zh-CN/sql-reference/sql-statements/Data Manipulation/ROUTINE LOAD.md
+++ b/docs/zh-CN/sql-reference/sql-statements/Data Manipulation/ROUTINE LOAD.md
@@ -140,7 +140,7 @@ under the License.
 
         4. strict_mode
 
-            是否开启严格模式，默认为开启。如果开启后，非空原始数据的列类型变换如果结果为 NULL，则会被过滤。指定方式为 "strict_mode" = "true"
+            是否开启严格模式，默认为关闭。如果开启后，非空原始数据的列类型变换如果结果为 NULL，则会被过滤。指定方式为 "strict_mode" = "true"
 
         5. timezone
 

--- a/docs/zh-CN/sql-reference/sql-statements/Data Manipulation/STREAM LOAD.md
+++ b/docs/zh-CN/sql-reference/sql-statements/Data Manipulation/STREAM LOAD.md
@@ -68,7 +68,7 @@ under the License.
 
         timeout: 指定导入的超时时间。单位秒。默认是 600 秒。可设置范围为 1 秒 ~ 259200 秒。
 
-        strict_mode: 用户指定此次导入是否开启严格模式，默认为开启。关闭方式为 -H "strict_mode: false"。
+        strict_mode: 用户指定此次导入是否开启严格模式，默认为关闭。开启方式为 -H "strict_mode: true"。
 
         timezone: 指定本次导入所使用的时区。默认为东八区。该参数会影响所有导入涉及的和时区有关的函数结果。
 
@@ -158,6 +158,7 @@ under the License.
                {"category":"Java","author":"avc","title":"Effective Java","price":95},
                {"category":"Linux","author":"avc","title":"Linux kernel","price":195}
               ]
+
     11. 匹配模式，导入json数据
        json数据格式：
            [

--- a/gensrc/thrift/Status.thrift
+++ b/gensrc/thrift/Status.thrift
@@ -73,7 +73,8 @@ enum TStatusCode {
     UNINITIALIZED       = 42,
     CONFIGURATION_ERROR = 43,
     INCOMPLETE          = 44,
-    OLAP_ERR_VERSION_ALREADY_MERGED = 45
+    OLAP_ERR_VERSION_ALREADY_MERGED = 45,
+    DATA_QUALITY_ERROR  = 46
 }
 
 struct TStatus {


### PR DESCRIPTION
This CL mainly changes:

1. Reorganized the code logic to limit the supported json format to two, and the import behavior is more consistent.
2. Modified the statistical behavior of the number of error rows when loading in json format, so that the error rows can be counted correctly.
3. See `load-json-format.md` to get details of loading json format.