### PR TITLE
Add delayed deletion of rowsets function, fix -230 error.

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -232,6 +232,8 @@ namespace config {
     CONF_mInt32(pending_data_expire_time_sec, "1800");
     // inc_rowset expired interval
     CONF_mInt32(inc_rowset_expired_sec, "1800");
+    // inc_rowset snapshot rs sweep time interval
+    CONF_mInt32(tablet_rowset_expired_snapshot_sweep_time, "1800");
     // garbage sweep policy
     CONF_Int32(max_garbage_sweep_interval, "3600");
     CONF_Int32(min_garbage_sweep_interval, "180");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -233,7 +233,7 @@ namespace config {
     // inc_rowset expired interval
     CONF_mInt32(inc_rowset_expired_sec, "1800");
     // inc_rowset snapshot rs sweep time interval
-    CONF_mInt32(tablet_rowset_expired_snapshot_sweep_time, "1800");
+    CONF_mInt32(tablet_rowset_stale_sweep_time_sec, "1800");
     // garbage sweep policy
     CONF_Int32(max_garbage_sweep_interval, "3600");
     CONF_Int32(min_garbage_sweep_interval, "180");
@@ -542,7 +542,7 @@ namespace config {
     CONF_Bool(ignore_load_tablet_failure, "false");
 
     // Whether to continue to start be when load tablet from header failed.
-    CONF_Bool(ignore_rowset_expired_snapshot_unconsistent_delete, "false");
+    CONF_Bool(ignore_rowset_stale_unconsistent_delete, "false");
 
 } // namespace config
 

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -540,6 +540,10 @@ namespace config {
 
     // Whether to continue to start be when load tablet from header failed.
     CONF_Bool(ignore_load_tablet_failure, "false");
+
+    // Whether to continue to start be when load tablet from header failed.
+    CONF_Bool(ignore_rowset_expired_snapshot_unconsistent_delete, "false");
+
 } // namespace config
 
 } // namespace doris

--- a/be/src/olap/CMakeLists.txt
+++ b/be/src/olap/CMakeLists.txt
@@ -63,7 +63,7 @@ add_library(Olap STATIC
     row_block.cpp
     row_block2.cpp
     row_cursor.cpp
-    rowset_graph.cpp
+    version_graph.cpp
     schema.cpp
     schema_change.cpp
     serialize.cpp

--- a/be/src/olap/base_compaction.cpp
+++ b/be/src/olap/base_compaction.cpp
@@ -56,11 +56,6 @@ OLAPStatus BaseCompaction::compact() {
     DorisMetrics::instance()->base_compaction_bytes_total.increment(_input_rowsets_size);
     TRACE("save base compaction metrics");
 
-    // delay garbage operation 
-    // 5. garbage collect input rowsets after base compaction 
-    // RETURN_NOT_OK(gc_unused_rowsets());
-    // TRACE("unused rowsets have been moved to GC queue");
-
     return OLAP_SUCCESS;
 }
 

--- a/be/src/olap/base_compaction.cpp
+++ b/be/src/olap/base_compaction.cpp
@@ -56,9 +56,10 @@ OLAPStatus BaseCompaction::compact() {
     DorisMetrics::instance()->base_compaction_bytes_total.increment(_input_rowsets_size);
     TRACE("save base compaction metrics");
 
+    // delay garbage operation 
     // 5. garbage collect input rowsets after base compaction 
-    RETURN_NOT_OK(gc_unused_rowsets());
-    TRACE("unused rowsets have been moved to GC queue");
+    // RETURN_NOT_OK(gc_unused_rowsets());
+    // TRACE("unused rowsets have been moved to GC queue");
 
     return OLAP_SUCCESS;
 }

--- a/be/src/olap/cumulative_compaction.cpp
+++ b/be/src/olap/cumulative_compaction.cpp
@@ -65,9 +65,10 @@ OLAPStatus CumulativeCompaction::compact() {
     DorisMetrics::instance()->cumulative_compaction_bytes_total.increment(_input_rowsets_size);
     TRACE("save cumulative compaction metrics");
 
+    // delay garbage operation
     // 7. garbage collect input rowsets after cumulative compaction 
-    RETURN_NOT_OK(gc_unused_rowsets());
-    TRACE("unused rowsets have been moved to GC queue");
+    // RETURN_NOT_OK(gc_unused_rowsets());
+    // TRACE("unused rowsets have been moved to GC queue");
 
     return OLAP_SUCCESS;
 }

--- a/be/src/olap/cumulative_compaction.cpp
+++ b/be/src/olap/cumulative_compaction.cpp
@@ -65,11 +65,6 @@ OLAPStatus CumulativeCompaction::compact() {
     DorisMetrics::instance()->cumulative_compaction_bytes_total.increment(_input_rowsets_size);
     TRACE("save cumulative compaction metrics");
 
-    // delay garbage operation
-    // 7. garbage collect input rowsets after cumulative compaction 
-    // RETURN_NOT_OK(gc_unused_rowsets());
-    // TRACE("unused rowsets have been moved to GC queue");
-
     return OLAP_SUCCESS;
 }
 

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -62,7 +62,6 @@ Tablet::Tablet(TabletMetaSharedPtr tablet_meta, DataDir* data_dir) :
         _last_base_compaction_success_millis(0),
         _cumulative_point(kInvalidCumulativePoint) {
     // change _rs_graph to _versioned_rs_tracker
-    // _rs_graph.construct_rowset_graph(_tablet_meta->all_rs_metas());
     _versioned_rs_tracker.construct_versioned_tracker(_tablet_meta->all_rs_metas(),
                                                      _tablet_meta->all_expired_snapshot_rs_metas());
 }
@@ -255,7 +254,6 @@ void Tablet::modify_rowsets(const vector<RowsetSharedPtr>& to_add,
     _tablet_meta->modify_rs_metas(rs_metas_to_add, rs_metas_to_delete);
 
     // change _rs_graph to _versioned_rs_tracker
-    // _rs_graph.reconstruct_rowset_graph(_tablet_meta->all_rs_metas());
      _versioned_rs_tracker.add_expired_path_version(rs_metas_to_delete);
 }
 

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -417,8 +417,7 @@ void Tablet::delete_expired_stale_rowset() {
             LOG(WARNING) << "The consistent version check fails, there are bugs. "
                 << "Reconstruct the tracker to recover versions in tablet=" << tablet_id();
 
-            _timestamped_version_tracker.reconstruct_versioned_tracker(
-                    _tablet_meta->all_rs_metas(), stale_version_path_map);
+            _timestamped_version_tracker.recover_versioned_tracker(stale_version_path_map);
 
             // double check the consistent versions
             status = capture_consistent_versions(test_version, nullptr);

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -246,7 +246,6 @@ void Tablet::modify_rowsets(const vector<RowsetSharedPtr>& to_add,
     for (auto& rs : to_add) {
         rs_metas_to_add.push_back(rs->rowset_meta());
         _rs_version_map[rs->version()] = rs;
-
         ++_newly_created_rowset_num;
     }
 

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -1016,6 +1016,9 @@ void Tablet::get_compaction_status(std::string* json_result) {
     rapidjson::Document root;
     root.SetObject();
 
+    rapidjson::Document path_arr;
+    path_arr.SetArray();
+
     std::vector<RowsetSharedPtr> rowsets;
     std::vector<bool> delete_flags;
     {
@@ -1030,11 +1033,8 @@ void Tablet::get_compaction_status(std::string* json_result) {
         for (auto& rs : rowsets) {
             delete_flags.push_back(version_for_delete_predicate(rs->version()));
         }
-<<<<<<< HEAD
-=======
         // get snapshot version path json_doc
         _timestamped_version_tracker.get_stale_version_path_json_doc(path_arr);
->>>>>>> 100209d2... Add delayed deletion of rowsets function, fix -230 error.
     }
 
     root.AddMember("cumulative point", _cumulative_point.load(), root.GetAllocator());
@@ -1069,12 +1069,9 @@ void Tablet::get_compaction_status(std::string* json_result) {
     }
     root.AddMember("rowsets", versions_arr, root.GetAllocator());
 
-<<<<<<< HEAD
-=======
     // add stale version rowsets 
     root.AddMember("stale version path", path_arr, root.GetAllocator());
 
->>>>>>> 100209d2... Add delayed deletion of rowsets function, fix -230 error.
     // to json string
     rapidjson::StringBuffer strbuf;
     rapidjson::PrettyWriter<rapidjson::StringBuffer> writer(strbuf);

--- a/be/src/olap/tablet.h
+++ b/be/src/olap/tablet.h
@@ -249,7 +249,7 @@ private:
 private:
     static const int64_t kInvalidCumulativePoint = -1;
 
-    TimestampedVersionTracker _versioned_rs_tracker;
+    TimestampedVersionTracker _timestamped_version_tracker;
     
     DorisCallOnce<OLAPStatus> _init_once;
     // meta store lock is used for prevent 2 threads do checkpoint concurrently

--- a/be/src/olap/tablet.h
+++ b/be/src/olap/tablet.h
@@ -30,7 +30,7 @@
 #include "olap/data_dir.h"
 #include "olap/olap_define.h"
 #include "olap/tuple.h"
-#include "olap/rowset_graph.h"
+#include "olap/version_graph.h"
 #include "olap/rowset/rowset.h"
 #include "olap/rowset/rowset_reader.h"
 #include "olap/tablet_meta.h"
@@ -249,7 +249,7 @@ private:
 private:
     static const int64_t kInvalidCumulativePoint = -1;
 
-    VersionedRowsetTracker _versioned_rs_tracker;
+    TimestampedVersionTracker _versioned_rs_tracker;
     
     DorisCallOnce<OLAPStatus> _init_once;
     // meta store lock is used for prevent 2 threads do checkpoint concurrently
@@ -277,7 +277,7 @@ private:
     std::unordered_map<Version, RowsetSharedPtr, HashOfVersion> _inc_rs_version_map;
     // This variable _expired_snapshot_rs_version_map is used to record these rowsets which are be compacted.
     // These _expired_snapshot rowsets are been removed when rowsets' pathVersion is expired, 
-    // this policy is judged and computed by VersionedRowsetTracker.
+    // this policy is judged and computed by TimestampedVersionTracker.
     std::unordered_map<Version, RowsetSharedPtr, HashOfVersion> _expired_snapshot_rs_version_map;
     // if this tablet is broken, set to true. default is false
     std::atomic<bool> _is_bad;

--- a/be/src/olap/tablet.h
+++ b/be/src/olap/tablet.h
@@ -101,11 +101,11 @@ public:
 
     OLAPStatus add_inc_rowset(const RowsetSharedPtr& rowset);
     void delete_expired_inc_rowsets();
-    /// Delete expired snapshot rowset by timing. This delete policy uses now() munis 
-    /// config::tablet_rowset_expired_snapshot_sweep_time to compute the deadline of expired rowset 
+    /// Delete stale rowset by timing. This delete policy uses now() munis 
+    /// config::tablet_rowset_expired_stale_sweep_time_sec to compute the deadline of expired rowset 
     /// to delete.  When rowset is deleted, it will be added to StorageEngine unused map and record
     /// need to delete flag.
-    void delete_expired_snapshot_rowset();
+    void delete_expired_stale_rowset();
 
     OLAPStatus capture_consistent_versions(const Version& spec_version,
                                            vector<Version>* version_path) const;
@@ -240,9 +240,9 @@ private:
                                                         VersionHash* v_hash) const ;
     RowsetSharedPtr _rowset_with_largest_size();
     void _delete_inc_rowset_by_version(const Version& version, const VersionHash& version_hash);
-    /// Delete expired snapshot rowset by version. This method not only delete the version in expired rowset map,
+    /// Delete stale rowset by version. This method not only delete the version in expired rowset map,
     /// but also delete the version in rowset meta vector.
-    void _delete_expired_snapshot_rowset_by_version(const Version& version);
+    void _delete_stale_rowset_by_version(const Version& version);
     OLAPStatus _capture_consistent_rowsets_unlocked(const vector<Version>& version_path,
                                                     vector<RowsetSharedPtr>* rowsets) const;
 
@@ -275,10 +275,10 @@ private:
     // _inc_rs_version_map may do not exist in _rs_version_map.
     std::unordered_map<Version, RowsetSharedPtr, HashOfVersion> _rs_version_map;
     std::unordered_map<Version, RowsetSharedPtr, HashOfVersion> _inc_rs_version_map;
-    // This variable _expired_snapshot_rs_version_map is used to record these rowsets which are be compacted.
-    // These _expired_snapshot rowsets are been removed when rowsets' pathVersion is expired, 
+    // This variable _stale_rs_version_map is used to record these rowsets which are be compacted.
+    // These _stale rowsets are been removed when rowsets' pathVersion is expired, 
     // this policy is judged and computed by TimestampedVersionTracker.
-    std::unordered_map<Version, RowsetSharedPtr, HashOfVersion> _expired_snapshot_rs_version_map;
+    std::unordered_map<Version, RowsetSharedPtr, HashOfVersion> _stale_rs_version_map;
     // if this tablet is broken, set to true. default is false
     std::atomic<bool> _is_bad;
     // timestamp of last cumu compaction failure

--- a/be/src/olap/tablet_manager.cpp
+++ b/be/src/olap/tablet_manager.cpp
@@ -982,6 +982,7 @@ OLAPStatus TabletManager::start_trash_sweep() {
 
             for (const auto& tablet : all_tablets) {
                 tablet->delete_expired_inc_rowsets();
+                tablet->delete_expired_snapshot_rowset();
             }
             all_tablets.clear();
 

--- a/be/src/olap/tablet_manager.cpp
+++ b/be/src/olap/tablet_manager.cpp
@@ -982,7 +982,7 @@ OLAPStatus TabletManager::start_trash_sweep() {
 
             for (const auto& tablet : all_tablets) {
                 tablet->delete_expired_inc_rowsets();
-                tablet->delete_expired_snapshot_rowset();
+                tablet->delete_expired_stale_rowset();
             }
             all_tablets.clear();
 

--- a/be/src/olap/tablet_meta.cpp
+++ b/be/src/olap/tablet_meta.cpp
@@ -497,6 +497,7 @@ void TabletMeta::delete_rs_meta_by_version(const Version& version,
 
 void TabletMeta::modify_rs_metas(const vector<RowsetMetaSharedPtr>& to_add,
                                  const vector<RowsetMetaSharedPtr>& to_delete) {
+    // Remove to_delete rowsets from _rs_metas                                 
     for (auto rs_to_del : to_delete) {
         auto it = _rs_metas.begin();
         while (it != _rs_metas.end()) {
@@ -512,6 +513,9 @@ void TabletMeta::modify_rs_metas(const vector<RowsetMetaSharedPtr>& to_add,
             }
         }
     }
+    // put to_delete rowsets in _expired_snapshot_rs_metas.
+    _expired_snapshot_rs_metas.insert(_expired_snapshot_rs_metas.end(), to_delete.begin(), to_delete.end());
+    // put to_add rowsets in _rs_metas.
     _rs_metas.insert(_rs_metas.end(), to_add.begin(), to_add.end());
 }
 
@@ -542,6 +546,27 @@ OLAPStatus TabletMeta::add_inc_rs_meta(const RowsetMetaSharedPtr& rs_meta) {
 
     _inc_rs_metas.push_back(rs_meta);
     return OLAP_SUCCESS;
+}
+
+void TabletMeta::delete_expired_snapshot_rs_meta_by_version(const Version& version) {
+    auto it = _expired_snapshot_rs_metas.begin();
+    while (it != _expired_snapshot_rs_metas.end()) {
+        if ((*it)->version() == version) {
+            _expired_snapshot_rs_metas.erase(it);
+            break;
+        } else {
+            it++;
+        }
+    }
+}
+
+RowsetMetaSharedPtr TabletMeta::acquire_expired_snapshot_rs_meta_by_version(const Version& version) const {
+    for (auto it : _expired_snapshot_rs_metas) {
+        if (it->version() == version) {
+            return it;
+        }
+    }
+    return nullptr;
 }
 
 void TabletMeta::delete_inc_rs_meta_by_version(const Version& version) {

--- a/be/src/olap/tablet_meta.cpp
+++ b/be/src/olap/tablet_meta.cpp
@@ -513,8 +513,8 @@ void TabletMeta::modify_rs_metas(const vector<RowsetMetaSharedPtr>& to_add,
             }
         }
     }
-    // put to_delete rowsets in _expired_snapshot_rs_metas.
-    _expired_snapshot_rs_metas.insert(_expired_snapshot_rs_metas.end(), to_delete.begin(), to_delete.end());
+    // put to_delete rowsets in _stale_rs_metas.
+    _stale_rs_metas.insert(_stale_rs_metas.end(), to_delete.begin(), to_delete.end());
     // put to_add rowsets in _rs_metas.
     _rs_metas.insert(_rs_metas.end(), to_add.begin(), to_add.end());
 }
@@ -548,20 +548,19 @@ OLAPStatus TabletMeta::add_inc_rs_meta(const RowsetMetaSharedPtr& rs_meta) {
     return OLAP_SUCCESS;
 }
 
-void TabletMeta::delete_expired_snapshot_rs_meta_by_version(const Version& version) {
-    auto it = _expired_snapshot_rs_metas.begin();
-    while (it != _expired_snapshot_rs_metas.end()) {
+void TabletMeta::delete_stale_rs_meta_by_version(const Version& version) {
+    auto it = _stale_rs_metas.begin();
+    while (it != _stale_rs_metas.end()) {
         if ((*it)->version() == version) {
-            _expired_snapshot_rs_metas.erase(it);
-            break;
+            it = _stale_rs_metas.erase(it);
         } else {
             it++;
         }
     }
 }
 
-RowsetMetaSharedPtr TabletMeta::acquire_expired_snapshot_rs_meta_by_version(const Version& version) const {
-    for (auto it : _expired_snapshot_rs_metas) {
+RowsetMetaSharedPtr TabletMeta::acquire_stale_rs_meta_by_version(const Version& version) const {
+    for (auto it : _stale_rs_metas) {
         if (it->version() == version) {
             return it;
         }

--- a/be/src/olap/tablet_meta.h
+++ b/be/src/olap/tablet_meta.h
@@ -227,7 +227,7 @@ private:
     std::vector<RowsetMetaSharedPtr> _inc_rs_metas;
     // This variable _expired_snapshot_rs_metas is used to record these rowsets‘ meta which are be compacted.
     // These _expired_snapshot rowsets meta are been removed when rowsets' pathVersion is expired, 
-    // this policy is judged and computed by VersionedRowsetTracker.
+    // this policy is judged and computed by TimestampedVersionTracker.
     std::vector<RowsetMetaSharedPtr> _expired_snapshot_rs_metas;
 
     DelPredicateArray _del_pred_array;

--- a/be/src/olap/tablet_meta.h
+++ b/be/src/olap/tablet_meta.h
@@ -174,9 +174,12 @@ public:
 
     void revise_inc_rs_metas(std::vector<RowsetMetaSharedPtr>&& rs_metas);
     inline const std::vector<RowsetMetaSharedPtr>& all_inc_rs_metas() const;
+    inline const std::vector<RowsetMetaSharedPtr>& all_expired_snapshot_rs_metas() const;
     OLAPStatus add_inc_rs_meta(const RowsetMetaSharedPtr& rs_meta);
     void delete_inc_rs_meta_by_version(const Version& version);
     RowsetMetaSharedPtr acquire_inc_rs_meta_by_version(const Version& version) const;
+    void delete_expired_snapshot_rs_meta_by_version(const Version& version);
+    RowsetMetaSharedPtr acquire_expired_snapshot_rs_meta_by_version(const Version& version) const;
 
     void add_delete_predicate(const DeletePredicatePB& delete_predicate, int64_t version);
     void remove_delete_predicate_by_version(const Version& version);
@@ -219,8 +222,14 @@ private:
 
     TabletState _tablet_state = TABLET_NOTREADY;
     TabletSchema _schema;
+
     std::vector<RowsetMetaSharedPtr> _rs_metas;
     std::vector<RowsetMetaSharedPtr> _inc_rs_metas;
+    // This variable _expired_snapshot_rs_metas is used to record these rowsets‘ meta which are be compacted.
+    // These _expired_snapshot rowsets meta are been removed when rowsets' pathVersion is expired, 
+    // this policy is judged and computed by VersionedRowsetTracker.
+    std::vector<RowsetMetaSharedPtr> _expired_snapshot_rs_metas;
+
     DelPredicateArray _del_pred_array;
     AlterTabletTaskSharedPtr _alter_task;
     bool _in_restore_mode = false;
@@ -323,6 +332,10 @@ inline const std::vector<RowsetMetaSharedPtr>& TabletMeta::all_rs_metas() const 
 
 inline const std::vector<RowsetMetaSharedPtr>& TabletMeta::all_inc_rs_metas() const {
     return _inc_rs_metas;
+}
+
+inline const std::vector<RowsetMetaSharedPtr>& TabletMeta::all_expired_snapshot_rs_metas() const {
+    return _expired_snapshot_rs_metas;
 }
 
 // Only for unit test now.

--- a/be/src/olap/tablet_meta.h
+++ b/be/src/olap/tablet_meta.h
@@ -174,12 +174,12 @@ public:
 
     void revise_inc_rs_metas(std::vector<RowsetMetaSharedPtr>&& rs_metas);
     inline const std::vector<RowsetMetaSharedPtr>& all_inc_rs_metas() const;
-    inline const std::vector<RowsetMetaSharedPtr>& all_expired_snapshot_rs_metas() const;
+    inline const std::vector<RowsetMetaSharedPtr>& all_stale_rs_metas() const;
     OLAPStatus add_inc_rs_meta(const RowsetMetaSharedPtr& rs_meta);
     void delete_inc_rs_meta_by_version(const Version& version);
     RowsetMetaSharedPtr acquire_inc_rs_meta_by_version(const Version& version) const;
-    void delete_expired_snapshot_rs_meta_by_version(const Version& version);
-    RowsetMetaSharedPtr acquire_expired_snapshot_rs_meta_by_version(const Version& version) const;
+    void delete_stale_rs_meta_by_version(const Version& version);
+    RowsetMetaSharedPtr acquire_stale_rs_meta_by_version(const Version& version) const;
 
     void add_delete_predicate(const DeletePredicatePB& delete_predicate, int64_t version);
     void remove_delete_predicate_by_version(const Version& version);
@@ -225,10 +225,10 @@ private:
 
     std::vector<RowsetMetaSharedPtr> _rs_metas;
     std::vector<RowsetMetaSharedPtr> _inc_rs_metas;
-    // This variable _expired_snapshot_rs_metas is used to record these rowsets‘ meta which are be compacted.
-    // These _expired_snapshot rowsets meta are been removed when rowsets' pathVersion is expired, 
+    // This variable _stale_rs_metas is used to record these rowsets‘ meta which are be compacted.
+    // These stale rowsets meta are been removed when rowsets' pathVersion is expired, 
     // this policy is judged and computed by TimestampedVersionTracker.
-    std::vector<RowsetMetaSharedPtr> _expired_snapshot_rs_metas;
+    std::vector<RowsetMetaSharedPtr> _stale_rs_metas;
 
     DelPredicateArray _del_pred_array;
     AlterTabletTaskSharedPtr _alter_task;
@@ -334,8 +334,8 @@ inline const std::vector<RowsetMetaSharedPtr>& TabletMeta::all_inc_rs_metas() co
     return _inc_rs_metas;
 }
 
-inline const std::vector<RowsetMetaSharedPtr>& TabletMeta::all_expired_snapshot_rs_metas() const {
-    return _expired_snapshot_rs_metas;
+inline const std::vector<RowsetMetaSharedPtr>& TabletMeta::all_stale_rs_metas() const {
+    return _stale_rs_metas;
 }
 
 // Only for unit test now.

--- a/be/src/olap/txn_manager.cpp
+++ b/be/src/olap/txn_manager.cpp
@@ -309,7 +309,8 @@ OLAPStatus TxnManager::publish_txn(OlapMeta* meta, TPartitionId partition_id, TT
                       << " partition_id: " << key.first
                       << ", txn_id: " << key.second
                       << ", tablet: " << tablet_info.to_string()
-                      << ", rowsetid: " << rowset_ptr->rowset_id();
+                      << ", rowsetid: " << rowset_ptr->rowset_id()
+                      << ", version: " << version.first <<"," << version.second;
             if (it->second.empty()) {
                 txn_tablet_map.erase(it);
                 _clear_txn_partition_map_unlocked(transaction_id, partition_id);

--- a/be/src/olap/version_graph.cpp
+++ b/be/src/olap/version_graph.cpp
@@ -21,6 +21,7 @@
 #include <queue>
 
 #include "common/logging.h"
+#include "util/time.h"
 
 namespace doris {
 
@@ -31,16 +32,18 @@ void TimestampedVersionTracker::_construct_versioned_tracker(const std::vector<R
     _version_graph.reconstruct_version_graph(rs_metas, &max_version);
 }
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-void TimestampedVersionTracker::construct_versioned_tracker(
-        const std::vector<RowsetMetaSharedPtr>& rs_metas,
-        const std::vector<RowsetMetaSharedPtr>& expired_snapshot_rs_metas) {
-=======
-void TimestampedVersionTracker::get_snapshot_version_path_json_doc(rapidjson::Document& path_arr) {
-=======
+void TimestampedVersionTracker::construct_versioned_tracker(const std::vector<RowsetMetaSharedPtr>& rs_metas) {
+    if (rs_metas.empty()) {
+        VLOG(3) << "there is no version in the header.";
+        return;
+    }
+    _stale_version_path_map.clear();
+    _next_path_id = 1;
+    _construct_versioned_tracker(rs_metas);
+}
+
+
 void TimestampedVersionTracker::get_stale_version_path_json_doc(rapidjson::Document& path_arr) {
->>>>>>> 100209d2... Add delayed deletion of rowsets function, fix -230 error.
 
     auto path_arr_iter = _stale_version_path_map.begin();
 
@@ -88,17 +91,6 @@ void TimestampedVersionTracker::get_stale_version_path_json_doc(rapidjson::Docum
 
         path_arr_iter++;
     }
-}
-
-void TimestampedVersionTracker::construct_versioned_tracker(const std::vector<RowsetMetaSharedPtr>& rs_metas) {
->>>>>>> d7e83dfb... Add delayed deletion of rowsets function, fix -230 error.
-    if (rs_metas.empty()) {
-        VLOG(3) << "there is no version in the header.";
-        return;
-    }
-    _stale_version_path_map.clear();
-    _next_path_id = 1;
-    _construct_versioned_tracker(rs_metas);
 }
 
 void TimestampedVersionTracker::reconstruct_versioned_tracker(
@@ -164,15 +156,10 @@ OLAPStatus TimestampedVersionTracker::capture_consistent_versions(
 }
 
 void TimestampedVersionTracker::capture_expired_paths(
-<<<<<<< HEAD
-        int64_t expired_snapshot_sweep_endtime, std::vector<int64_t>* path_version_vec) const {
-    std::unordered_map<int64_t, PathVersionListSharedPtr>::const_iterator iter =
-            _expired_snapshot_version_path_map.begin();
-=======
         int64_t stale_sweep_endtime, std::vector<int64_t>* path_version_vec) const {
+
     std::map<int64_t, PathVersionListSharedPtr>::const_iterator iter =
             _stale_version_path_map.begin();
->>>>>>> 100209d2... Add delayed deletion of rowsets function, fix -230 error.
 
     while (iter != _stale_version_path_map.end()) {
         int64_t max_create_time = iter->second->max_create_time();
@@ -215,15 +202,9 @@ std::string TimestampedVersionTracker::_get_current_path_map_str() {
     std::stringstream tracker_info;
     tracker_info << "current expired next_path_id " << _next_path_id << std::endl;
 
-<<<<<<< HEAD
-    std::unordered_map<int64_t, PathVersionListSharedPtr>::const_iterator iter =
-            _expired_snapshot_version_path_map.begin();
-    while (iter != _expired_snapshot_version_path_map.end()) {
-=======
     std::map<int64_t, PathVersionListSharedPtr>::const_iterator iter =
             _stale_version_path_map.begin();
     while (iter != _stale_version_path_map.end()) {
->>>>>>> 100209d2... Add delayed deletion of rowsets function, fix -230 error.
         
         tracker_info << "current expired path_version " << iter->first;
         std::vector<TimestampedVersionSharedPtr>& timestamped_versions = iter->second->timestamped_versions();

--- a/be/src/olap/version_graph.cpp
+++ b/be/src/olap/version_graph.cpp
@@ -93,15 +93,8 @@ void TimestampedVersionTracker::get_stale_version_path_json_doc(rapidjson::Docum
     }
 }
 
-void TimestampedVersionTracker::reconstruct_versioned_tracker(
-        const std::vector<RowsetMetaSharedPtr>& rs_metas,
-        const std::map<int64_t, PathVersionListSharedPtr>& stale_version_path_map) {
-    if (rs_metas.empty()) {
-        VLOG(3) << "there is no version in the header.";
-        return;
-    }
-
-    _construct_versioned_tracker(rs_metas);
+void TimestampedVersionTracker::recover_versioned_tracker(const std::map<int64_t, PathVersionListSharedPtr>& stale_version_path_map) {
+    
     auto _path_map_iter = stale_version_path_map.begin();
     // recover stale_version_path_map
     while (_path_map_iter != stale_version_path_map.end()) {
@@ -117,7 +110,7 @@ void TimestampedVersionTracker::reconstruct_versioned_tracker(
         }
         _path_map_iter++;
     }
-    LOG(INFO) <<"construct_versioned_tracker current map info "<< _get_current_path_map_str();
+    LOG(INFO) <<"recover_versioned_tracker current map info "<< _get_current_path_map_str();
 }
 
 void TimestampedVersionTracker::add_version(const Version& version) {

--- a/be/src/olap/version_graph.h
+++ b/be/src/olap/version_graph.h
@@ -161,15 +161,15 @@ public:
     /// When the last rowset createtime of a path greater than expired time  which can be expressed
     /// "now() - tablet_rowset_expired_snapshot_sweep_time" , this path will be remained.
     /// Otherwise, this path will be added to path_version.
-    void capture_expired_path_version(int64_t expired_snapshot_sweep_endtime,
+    void capture_expired_paths(int64_t expired_snapshot_sweep_endtime,
                                       std::vector<int64_t>* path_version) const;
 
     /// Fetch all versions with a path_version.
-    void fetch_path_version(int64_t path_version, std::vector<Version>& version_path);
+    void fetch_path_version_by_id(int64_t path_id, std::vector<Version>& version_path);
 
     /// Fetch all versions with a path_version, at the same time remove this path from the tracker.
     /// Next time, fetch this path, it will return empty. 
-    void fetch_and_delete_path_version(int64_t path_version, std::vector<Version>& version_path);
+    void fetch_and_delete_path_by_id(int64_t path_id, std::vector<Version>& version_path);
 
     /// Print all expired version path in a tablet.
     std::string _get_current_path_map_str();
@@ -183,11 +183,11 @@ private:
 private:
     // This variable records the id of path version which will be dispatched to next path version, 
     // it is not persisted.
-    int64_t _next_path_version = 1;
+    int64_t _next_path_id = 1;
     
     // path_version -> list of path version,
     // This variable is used to maintain the map from path version and it's all version. 
-    std::unordered_map<int64_t, PathVersionListSharedPtr> _expired_snapshot_rs_path_map;
+    std::unordered_map<int64_t, PathVersionListSharedPtr> _expired_snapshot_version_path_map;
 
     VersionGraph _version_graph;
 };

--- a/be/src/olap/version_graph.h
+++ b/be/src/olap/version_graph.h
@@ -165,11 +165,11 @@ public:
                                       std::vector<int64_t>* path_version) const;
 
     /// Fetch all versions with a path_version.
-    void fetch_path_version_by_id(int64_t path_id, std::vector<Version>& version_path);
+    void fetch_path_version_by_id(int64_t path_id, std::vector<Version>* version_path);
 
     /// Fetch all versions with a path_version, at the same time remove this path from the tracker.
     /// Next time, fetch this path, it will return empty. 
-    void fetch_and_delete_path_by_id(int64_t path_id, std::vector<Version>& version_path);
+    void fetch_and_delete_path_by_id(int64_t path_id, std::vector<Version>* version_path);
 
     /// Print all expired version path in a tablet.
     std::string _get_current_path_map_str();

--- a/be/src/olap/version_graph.h
+++ b/be/src/olap/version_graph.h
@@ -18,6 +18,10 @@
 #ifndef DORIS_BE_SRC_OLAP_VERSION_GRAPH_H
 #define DORIS_BE_SRC_OLAP_VERSION_GRAPH_H
 
+#include <rapidjson/stringbuffer.h>
+#include <rapidjson/prettywriter.h>
+#include <rapidjson/document.h>
+
 #include "olap/olap_common.h"
 #include "olap/olap_define.h"
 #include "olap/rowset/rowset_meta.h"
@@ -172,13 +176,10 @@ public:
     /// Print all expired version path in a tablet.
     std::string _get_current_path_map_str();
 
-<<<<<<< HEAD
-=======
     /// Get json document of _stale_version_path_map. Fill the path_id and version_path 
     /// list in the document. The parameter path arr is used as return variable.
     void get_stale_version_path_json_doc(rapidjson::Document& path_arr);
 
->>>>>>> 100209d2... Add delayed deletion of rowsets function, fix -230 error.
 private:
     /// Construct rowsets version tracker with stale rowsets.
     void _construct_versioned_tracker(const std::vector<RowsetMetaSharedPtr>& rs_metas);
@@ -190,11 +191,7 @@ private:
     
     // path_version -> list of path version,
     // This variable is used to maintain the map from path version and it's all version. 
-<<<<<<< HEAD
-    std::unordered_map<int64_t, PathVersionListSharedPtr> _expired_snapshot_version_path_map;
-=======
     std::map<int64_t, PathVersionListSharedPtr> _stale_version_path_map;
->>>>>>> 100209d2... Add delayed deletion of rowsets function, fix -230 error.
 
     VersionGraph _version_graph;
 };

--- a/be/src/olap/version_graph.h
+++ b/be/src/olap/version_graph.h
@@ -139,10 +139,9 @@ public:
     /// Construct rowsets version tracker by rs_metas and stale version path map.
     void construct_versioned_tracker(const std::vector<RowsetMetaSharedPtr>& rs_metas);
 
-    /// Reconstruct rowsets version tracker by rs_metas and stale version path map.
-    void reconstruct_versioned_tracker(
-            const std::vector<RowsetMetaSharedPtr>& rs_metas,
-            const std::map<int64_t, PathVersionListSharedPtr>& stale_version_path_map);
+    /// Recover rowsets version tracker from stale version path map. When delete operation fails, the 
+    /// tracker can be recovered from deleted stale_version_path_map.
+    void recover_versioned_tracker(const std::map<int64_t, PathVersionListSharedPtr>& stale_version_path_map);
 
     /// Add a version to tracker, this version is a new version rowset, not merged rowset.
     void add_version(const Version& version);

--- a/be/src/olap/version_graph.h
+++ b/be/src/olap/version_graph.h
@@ -132,15 +132,13 @@ using PathVersionListSharedPtr = std::shared_ptr<TimestampedVersionPathContainer
 /// after the path is expired.
 class TimestampedVersionTracker {
 public:
-    /// Construct rowsets version tracker by rs_metas and expired snapshot rowsets.
-    void construct_versioned_tracker(
-            const std::vector<RowsetMetaSharedPtr>& rs_metas,
-            const std::vector<RowsetMetaSharedPtr>& expired_snapshot_rs_metas);
+    /// Construct rowsets version tracker by rs_metas and expired snapshot version path map.
+    void construct_versioned_tracker(const std::vector<RowsetMetaSharedPtr>& rs_metas);
 
-    /// Reconstruct rowsets version tracker by rs_metas and expired snapshot rowsets.
+    /// Reconstruct rowsets version tracker by rs_metas and expired snapshot version path map.
     void reconstruct_versioned_tracker(
             const std::vector<RowsetMetaSharedPtr>& rs_metas,
-            const std::vector<RowsetMetaSharedPtr>& expired_snapshot_rs_metas);
+            const std::map<int64_t, PathVersionListSharedPtr>& expired_snapshot_version_path_map);
 
     /// Add a version to tracker, this version is a new version rowset, not merged rowset.
     void add_version(const Version& version);
@@ -165,20 +163,18 @@ public:
                                       std::vector<int64_t>* path_version) const;
 
     /// Fetch all versions with a path_version.
-    void fetch_path_version_by_id(int64_t path_id, std::vector<Version>* version_path);
+    PathVersionListSharedPtr fetch_path_version_by_id(int64_t path_id);
 
     /// Fetch all versions with a path_version, at the same time remove this path from the tracker.
     /// Next time, fetch this path, it will return empty. 
-    void fetch_and_delete_path_by_id(int64_t path_id, std::vector<Version>* version_path);
+    PathVersionListSharedPtr fetch_and_delete_path_by_id(int64_t path_id);
 
     /// Print all expired version path in a tablet.
     std::string _get_current_path_map_str();
 
 private:
     /// Construct rowsets version tracker with expired snapshot rowsets.
-    void _construct_versioned_tracker(
-            const std::vector<RowsetMetaSharedPtr>& rs_metas,
-            const std::vector<RowsetMetaSharedPtr>& expired_snapshot_rs_metas);
+    void _construct_versioned_tracker(const std::vector<RowsetMetaSharedPtr>& rs_metas);
 
 private:
     // This variable records the id of path version which will be dispatched to next path version, 

--- a/be/src/olap/version_graph.h
+++ b/be/src/olap/version_graph.h
@@ -132,22 +132,22 @@ using PathVersionListSharedPtr = std::shared_ptr<TimestampedVersionPathContainer
 /// after the path is expired.
 class TimestampedVersionTracker {
 public:
-    /// Construct rowsets version tracker by rs_metas and expired snapshot version path map.
+    /// Construct rowsets version tracker by rs_metas and stale version path map.
     void construct_versioned_tracker(const std::vector<RowsetMetaSharedPtr>& rs_metas);
 
-    /// Reconstruct rowsets version tracker by rs_metas and expired snapshot version path map.
+    /// Reconstruct rowsets version tracker by rs_metas and stale version path map.
     void reconstruct_versioned_tracker(
             const std::vector<RowsetMetaSharedPtr>& rs_metas,
-            const std::map<int64_t, PathVersionListSharedPtr>& expired_snapshot_version_path_map);
+            const std::map<int64_t, PathVersionListSharedPtr>& stale_version_path_map);
 
     /// Add a version to tracker, this version is a new version rowset, not merged rowset.
     void add_version(const Version& version);
 
-    /// Add a version path with expired_snapshot_rs_metas, this versions in version path
+    /// Add a version path with stale_rs_metas, this versions in version path
     /// are merged rowsets.  These rowsets are tracked and removed after they are expired.
     /// TabletManager sweep these rowsets using tracker by timing.
-    void add_expired_path_version(
-            const std::vector<RowsetMetaSharedPtr>& expired_snapshot_rs_metas);
+    void add_stale_path_version(
+            const std::vector<RowsetMetaSharedPtr>& stale_rs_metas);
 
     /// Given a spec_version, this method can find a version path which is the shortest path
     /// in the graph. The version paths are added to version_path as return info.
@@ -157,9 +157,9 @@ public:
 
     /// Capture all expired path version.
     /// When the last rowset createtime of a path greater than expired time  which can be expressed
-    /// "now() - tablet_rowset_expired_snapshot_sweep_time" , this path will be remained.
+    /// "now() - tablet_rowset_stale_sweep_time_sec" , this path will be remained.
     /// Otherwise, this path will be added to path_version.
-    void capture_expired_paths(int64_t expired_snapshot_sweep_endtime,
+    void capture_expired_paths(int64_t stale_sweep_endtime,
                                       std::vector<int64_t>* path_version) const;
 
     /// Fetch all versions with a path_version.
@@ -172,8 +172,15 @@ public:
     /// Print all expired version path in a tablet.
     std::string _get_current_path_map_str();
 
+<<<<<<< HEAD
+=======
+    /// Get json document of _stale_version_path_map. Fill the path_id and version_path 
+    /// list in the document. The parameter path arr is used as return variable.
+    void get_stale_version_path_json_doc(rapidjson::Document& path_arr);
+
+>>>>>>> 100209d2... Add delayed deletion of rowsets function, fix -230 error.
 private:
-    /// Construct rowsets version tracker with expired snapshot rowsets.
+    /// Construct rowsets version tracker with stale rowsets.
     void _construct_versioned_tracker(const std::vector<RowsetMetaSharedPtr>& rs_metas);
 
 private:
@@ -183,7 +190,11 @@ private:
     
     // path_version -> list of path version,
     // This variable is used to maintain the map from path version and it's all version. 
+<<<<<<< HEAD
     std::unordered_map<int64_t, PathVersionListSharedPtr> _expired_snapshot_version_path_map;
+=======
+    std::map<int64_t, PathVersionListSharedPtr> _stale_version_path_map;
+>>>>>>> 100209d2... Add delayed deletion of rowsets function, fix -230 error.
 
     VersionGraph _version_graph;
 };

--- a/be/src/olap/version_graph.h
+++ b/be/src/olap/version_graph.h
@@ -175,7 +175,7 @@ public:
     std::string _get_current_path_map_str();
 
 private:
-    /// Construct rowsets version tracker with expired snapshot rowsets
+    /// Construct rowsets version tracker with expired snapshot rowsets.
     void _construct_versioned_tracker(
             const std::vector<RowsetMetaSharedPtr>& rs_metas,
             const std::vector<RowsetMetaSharedPtr>& expired_snapshot_rs_metas);

--- a/be/test/olap/CMakeLists.txt
+++ b/be/test/olap/CMakeLists.txt
@@ -21,7 +21,7 @@ set(LIBRARY_OUTPUT_PATH "${BUILD_DIR}/test/olap")
 # where to put generated binaries
 set(EXECUTABLE_OUTPUT_PATH "${BUILD_DIR}/test/olap")
 
-ADD_BE_TEST(rowset_graph_test)
+ADD_BE_TEST(version_graph_test)
 ADD_BE_TEST(row_block_test)
 ADD_BE_TEST(row_block_v2_test)
 ADD_BE_TEST(bit_field_test)

--- a/be/test/olap/CMakeLists.txt
+++ b/be/test/olap/CMakeLists.txt
@@ -21,6 +21,7 @@ set(LIBRARY_OUTPUT_PATH "${BUILD_DIR}/test/olap")
 # where to put generated binaries
 set(EXECUTABLE_OUTPUT_PATH "${BUILD_DIR}/test/olap")
 
+ADD_BE_TEST(rowset_graph_test)
 ADD_BE_TEST(row_block_test)
 ADD_BE_TEST(row_block_v2_test)
 ADD_BE_TEST(bit_field_test)

--- a/be/test/olap/CMakeLists.txt
+++ b/be/test/olap/CMakeLists.txt
@@ -21,7 +21,7 @@ set(LIBRARY_OUTPUT_PATH "${BUILD_DIR}/test/olap")
 # where to put generated binaries
 set(EXECUTABLE_OUTPUT_PATH "${BUILD_DIR}/test/olap")
 
-ADD_BE_TEST(version_graph_test)
+ADD_BE_TEST(timestamped_version_tracker_test)
 ADD_BE_TEST(row_block_test)
 ADD_BE_TEST(row_block_v2_test)
 ADD_BE_TEST(bit_field_test)

--- a/be/test/olap/rowset_graph_test.cpp
+++ b/be/test/olap/rowset_graph_test.cpp
@@ -1,0 +1,399 @@
+#include <gtest/gtest.h>
+#include <sstream>
+#include <fstream>
+#include "boost/filesystem.hpp"
+#include "json2pb/json_to_pb.h"
+
+#include "olap/rowset_graph.h"
+#include "olap/olap_meta.h"
+#include "olap/rowset/rowset_meta.h"
+
+namespace doris {
+
+class TestVersionedRowsetTracker : public testing::Test {
+public:
+    TestVersionedRowsetTracker() {}
+    void SetUp() {
+        _json_rowset_meta = R"({
+            "rowset_id": 540081,
+            "tablet_id": 15673,
+            "txn_id": 4042,
+            "tablet_schema_hash": 567997577,
+            "rowset_type": "ALPHA_ROWSET",
+            "rowset_state": "VISIBLE",
+            "start_version": 2,
+            "end_version": 2,
+            "version_hash": 8391828013814912580,
+            "num_rows": 3929,
+            "total_disk_size": 84699,
+            "data_disk_size": 84464,
+            "index_disk_size": 235,
+            "empty": false,
+            "load_id": {
+                "hi": -5350970832824939812,
+                "lo": -6717994719194512122
+            },
+            "creation_time": 1553765670,
+            "alpha_rowset_extra_meta_pb": {
+                "segment_groups": [
+                {
+                    "segment_group_id": 0,
+                    "num_segments": 1,
+                    "index_size": 132,
+                    "data_size": 576,
+                    "num_rows": 5,
+                    "zone_maps": [
+                    {
+                        "min": "MQ==",
+                        "max": "NQ==",
+                        "null_flag": false
+                    },
+                    {
+                        "min": "MQ==",
+                        "max": "Mw==",
+                        "null_flag": false
+                    },
+                    {
+                        "min": "J2J1c2gn",
+                        "max": "J3RvbSc=",
+                        "null_flag": false
+                    }
+                    ],
+                    "empty": false
+                },
+                {
+                    "segment_group_id": 1,
+                    "num_segments": 1,
+                    "index_size": 132,
+                    "data_size": 576,
+                    "num_rows": 5,
+                    "zone_maps": [
+                    {
+                        "min": "MQ==",
+                        "max": "NQ==",
+                        "null_flag": false
+                    },
+                    {
+                        "min": "MQ==",
+                        "max": "Mw==",
+                        "null_flag": false
+                    },
+                    {
+                        "min": "J2J1c2gn",
+                        "max": "J3RvbSc=",
+                        "null_flag": false
+                    }
+                    ],
+                    "empty": false
+                }
+                ]
+            }
+        })";
+    }
+    void TearDown() {
+    }
+
+    void init_rs_meta(RowsetMetaSharedPtr &pb1, int64_t start, int64_t end) {
+
+        pb1->init_from_json(_json_rowset_meta);
+        pb1->set_start_version(start);
+        pb1->set_end_version(end);
+        pb1->set_creation_time(10000);
+    }
+
+    void init_all_rs_meta(std::vector<RowsetMetaSharedPtr>* rs_metas) {
+        RowsetMetaSharedPtr ptr1(new RowsetMeta());
+        init_rs_meta(ptr1, 0, 0);
+        rs_metas->push_back(ptr1);
+
+        RowsetMetaSharedPtr ptr2(new RowsetMeta());
+        init_rs_meta(ptr2, 1, 1);
+        rs_metas->push_back(ptr2);
+
+        RowsetMetaSharedPtr ptr3(new RowsetMeta());
+        init_rs_meta(ptr3, 2, 5);
+        rs_metas->push_back(ptr3);
+
+        RowsetMetaSharedPtr ptr4(new RowsetMeta());
+        init_rs_meta(ptr4, 6, 9);
+        rs_metas->push_back(ptr4);
+
+        RowsetMetaSharedPtr ptr5(new RowsetMeta());
+        init_rs_meta(ptr5, 10, 11);
+        rs_metas->push_back(ptr5);
+    }
+
+    void init_expried_row_rs_meta(std::vector<RowsetMetaSharedPtr>* rs_metas) {
+
+        RowsetMetaSharedPtr ptr1(new RowsetMeta());
+        init_rs_meta(ptr1, 2, 3);
+        rs_metas->push_back(ptr1);
+
+        RowsetMetaSharedPtr ptr2(new RowsetMeta());
+        init_rs_meta(ptr2, 4, 5);
+        rs_metas->push_back(ptr2);
+
+        RowsetMetaSharedPtr ptr3(new RowsetMeta());
+        init_rs_meta(ptr3, 6, 6);
+        rs_metas->push_back(ptr3);
+
+        RowsetMetaSharedPtr ptr4(new RowsetMeta());
+        init_rs_meta(ptr4, 7, 8);
+        rs_metas->push_back(ptr4);
+
+        RowsetMetaSharedPtr ptr5(new RowsetMeta());
+        init_rs_meta(ptr5, 6, 8);
+        rs_metas->push_back(ptr5);
+
+        RowsetMetaSharedPtr ptr6(new RowsetMeta());
+        init_rs_meta(ptr6, 9, 9);
+        rs_metas->push_back(ptr6);
+
+        RowsetMetaSharedPtr ptr7(new RowsetMeta());
+        init_rs_meta(ptr7, 10, 10);
+        rs_metas->push_back(ptr7);
+
+    }
+
+private:
+    OlapMeta* _meta;
+    std::string _json_rowset_meta;
+
+};
+
+TEST_F(TestVersionedRowsetTracker, construct_rowset_graph) {
+
+    std::vector<RowsetMetaSharedPtr> rs_metas;
+    RowsetGraph rowset_graph;
+
+    init_all_rs_meta(&rs_metas);
+    int64_t max_version = 0;
+    rowset_graph.construct_rowset_graph(rs_metas, max_version);
+
+    ASSERT_EQ(6, rowset_graph._version_graph.size());
+    int64_t exp = 11;
+    ASSERT_EQ(exp, max_version);
+}
+
+TEST_F(TestVersionedRowsetTracker, reconstruct_rowset_graph) {
+
+    std::vector<RowsetMetaSharedPtr> rs_metas;
+    RowsetGraph rowset_graph;
+
+    init_all_rs_meta(&rs_metas);
+    int64_t max_version = 0;
+    rowset_graph.reconstruct_rowset_graph(rs_metas, max_version);
+
+    ASSERT_EQ(6, rowset_graph._version_graph.size());
+    int64_t exp = 11;
+    ASSERT_EQ(exp, max_version);
+}
+
+TEST_F(TestVersionedRowsetTracker, delete_version_from_graph) {
+
+    RowsetGraph rowset_graph;
+
+    Version version0(0, 0);
+
+    rowset_graph.add_version_to_graph(version0);
+    rowset_graph.delete_version_from_graph(version0);
+
+    ASSERT_EQ(2, rowset_graph._version_graph.size());
+    ASSERT_EQ(0, rowset_graph._version_graph[0].edges.size());
+}
+
+TEST_F(TestVersionedRowsetTracker, add_version_to_graph) {
+
+    RowsetGraph rowset_graph;
+
+    Version version0(0, 0);
+    Version version1(1, 1);
+
+    rowset_graph.add_version_to_graph(version0);
+    rowset_graph.add_version_to_graph(version1);
+
+    ASSERT_EQ(3, rowset_graph._version_graph.size());
+    ASSERT_EQ(0, rowset_graph._vertex_index_map.find(0)->second);
+    ASSERT_EQ(1, rowset_graph._vertex_index_map.find(1)->second);
+}
+
+TEST_F(TestVersionedRowsetTracker, capture_consistent_versions) {
+
+    std::vector<RowsetMetaSharedPtr> rs_metas;
+    std::vector<RowsetMetaSharedPtr> expried_rs_metas;
+    std::vector<Version> version_path;
+
+    init_all_rs_meta(&rs_metas);
+    init_expried_row_rs_meta(&expried_rs_metas);
+
+    RowsetGraph rowset_graph;
+    int64_t max_version = 0;
+    rs_metas.insert(rs_metas.end(), expried_rs_metas.begin(),
+                        expried_rs_metas.end());
+
+    rowset_graph.construct_rowset_graph(rs_metas, max_version);
+
+    Version spec_version(0, 8);
+    rowset_graph.capture_consistent_versions(spec_version, &version_path);
+
+    ASSERT_EQ(4, version_path.size());
+    ASSERT_EQ(Version(0, 0), version_path[0]);
+    ASSERT_EQ(Version(1, 1), version_path[1]);
+    ASSERT_EQ(Version(2, 5), version_path[2]);
+    ASSERT_EQ(Version(6, 8), version_path[3]);
+}
+
+TEST_F(TestVersionedRowsetTracker, construct_versioned_tracker) {
+
+    std::vector<RowsetMetaSharedPtr> rs_metas;
+    std::vector<RowsetMetaSharedPtr> expried_rs_metas;
+    std::vector<Version> version_path;
+
+    init_all_rs_meta(&rs_metas);
+    init_expried_row_rs_meta(&expried_rs_metas);
+
+    VersionedRowsetTracker tracker;
+    tracker.construct_versioned_tracker(rs_metas, expried_rs_metas);
+
+    ASSERT_EQ(10, tracker._rowsetGraph._version_graph.size());
+    ASSERT_EQ(4, tracker._expired_snapshot_rs_path_map.size());
+    ASSERT_EQ(5, tracker.next_path_version);
+}
+
+TEST_F(TestVersionedRowsetTracker, reconstruct_versioned_tracker) {
+
+    std::vector<RowsetMetaSharedPtr> rs_metas;
+    std::vector<RowsetMetaSharedPtr> expried_rs_metas;
+    std::vector<Version> version_path;
+
+    init_all_rs_meta(&rs_metas);
+    init_expried_row_rs_meta(&expried_rs_metas);
+
+    VersionedRowsetTracker tracker;
+    tracker.reconstruct_versioned_tracker(rs_metas, expried_rs_metas);
+
+    ASSERT_EQ(10, tracker._rowsetGraph._version_graph.size());
+    ASSERT_EQ(4, tracker._expired_snapshot_rs_path_map.size());
+    ASSERT_EQ(5, tracker.next_path_version);
+}
+
+TEST_F(TestVersionedRowsetTracker, add_version) {
+
+    VersionedRowsetTracker tracker;
+
+    Version version0(0, 0);
+    Version version1(1, 1);
+
+    tracker.add_version(version0);
+    tracker.add_version(version1);
+
+    ASSERT_EQ(3, tracker._rowsetGraph._version_graph.size());
+    ASSERT_EQ(0, tracker._rowsetGraph._vertex_index_map.find(0)->second);
+    ASSERT_EQ(1, tracker._rowsetGraph._vertex_index_map.find(1)->second);
+}
+
+TEST_F(TestVersionedRowsetTracker, add_expired_path_version) {
+
+    std::vector<RowsetMetaSharedPtr> rs_metas;
+    std::vector<RowsetMetaSharedPtr> expried_rs_metas;
+    std::vector<Version> version_path;
+
+    init_all_rs_meta(&rs_metas);
+    VersionedRowsetTracker tracker;
+    tracker.construct_versioned_tracker(rs_metas, expried_rs_metas);
+
+    init_expried_row_rs_meta(&expried_rs_metas);
+    tracker.add_expired_path_version(expried_rs_metas);
+
+    ASSERT_EQ(1, tracker._expired_snapshot_rs_path_map.size());
+    ASSERT_EQ(7, tracker._expired_snapshot_rs_path_map.begin()->second->size());
+}
+
+TEST_F(TestVersionedRowsetTracker, capture_consistent_versions_tracker) {
+
+    std::vector<RowsetMetaSharedPtr> rs_metas;
+    std::vector<RowsetMetaSharedPtr> expried_rs_metas;
+    std::vector<Version> version_path;
+
+    init_all_rs_meta(&rs_metas);
+    init_expried_row_rs_meta(&expried_rs_metas);
+
+    VersionedRowsetTracker tracker;
+    tracker.construct_versioned_tracker(rs_metas, expried_rs_metas);
+
+    Version spec_version(0, 8);
+    tracker.capture_consistent_versions(spec_version, &version_path);
+
+    ASSERT_EQ(4, version_path.size());
+    ASSERT_EQ(Version(0, 0), version_path[0]);
+    ASSERT_EQ(Version(1, 1), version_path[1]);
+    ASSERT_EQ(Version(2, 5), version_path[2]);
+    ASSERT_EQ(Version(6, 8), version_path[3]);
+}
+
+TEST_F(TestVersionedRowsetTracker, fetch_and_delete_path_version) {
+
+    std::vector<RowsetMetaSharedPtr> rs_metas;
+    std::vector<RowsetMetaSharedPtr> expried_rs_metas;
+    std::vector<Version> version_path;
+
+    init_all_rs_meta(&rs_metas);
+    init_expried_row_rs_meta(&expried_rs_metas);
+
+    VersionedRowsetTracker tracker;
+    tracker.construct_versioned_tracker(rs_metas, expried_rs_metas);
+
+    ASSERT_EQ(4, tracker._expired_snapshot_rs_path_map.size());
+
+    Version spec_version(0, 8);
+    tracker.fetch_and_delete_path_version(1, version_path);
+    ASSERT_EQ(2, version_path.size());
+    ASSERT_EQ(Version(2, 3), version_path[0]);
+    ASSERT_EQ(Version(4, 5), version_path[1]);
+
+    version_path.clear();
+    tracker.fetch_and_delete_path_version(2, version_path);
+    ASSERT_EQ(2, version_path.size());
+    ASSERT_EQ(Version(6, 6), version_path[0]);
+    ASSERT_EQ(Version(7, 8), version_path[1]);
+
+    version_path.clear();
+    tracker.fetch_and_delete_path_version(3, version_path);
+    ASSERT_EQ(2, version_path.size());
+    ASSERT_EQ(Version(6, 8), version_path[0]);
+    ASSERT_EQ(Version(9, 9), version_path[1]);
+
+    version_path.clear();
+    tracker.fetch_and_delete_path_version(4, version_path);
+    ASSERT_EQ(1, version_path.size());
+    ASSERT_EQ(Version(10, 10), version_path[0]);
+
+    ASSERT_EQ(0, tracker._expired_snapshot_rs_path_map.size());
+}
+
+TEST_F(TestVersionedRowsetTracker, capture_expired_path_version) {
+
+    std::vector<RowsetMetaSharedPtr> rs_metas;
+    std::vector<RowsetMetaSharedPtr> expried_rs_metas;
+    std::vector<int64_t> path_version;
+
+    init_all_rs_meta(&rs_metas);
+    init_expried_row_rs_meta(&expried_rs_metas);
+
+    VersionedRowsetTracker tracker;
+    tracker.construct_versioned_tracker(rs_metas, expried_rs_metas);
+
+    tracker.capture_expired_path_version(9999, &path_version);
+    ASSERT_EQ(0, path_version.size());
+
+    tracker.capture_expired_path_version(10001, &path_version);
+    ASSERT_EQ(4, path_version.size());
+}
+
+}
+
+// @brief Test Stub
+int main(int argc, char** argv) {
+    testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS(); 
+}

--- a/be/test/olap/timestamped_version_tracker_test.cpp
+++ b/be/test/olap/timestamped_version_tracker_test.cpp
@@ -256,8 +256,8 @@ TEST_F(TestTimestampedVersionTracker, construct_versioned_tracker) {
     tracker.construct_versioned_tracker(rs_metas, expried_rs_metas);
 
     ASSERT_EQ(10, tracker._version_graph._version_graph.size());
-    ASSERT_EQ(4, tracker._expired_snapshot_rs_path_map.size());
-    ASSERT_EQ(5, tracker._next_path_version);
+    ASSERT_EQ(4, tracker._expired_snapshot_version_path_map.size());
+    ASSERT_EQ(5, tracker._next_path_id);
 }
 
 TEST_F(TestTimestampedVersionTracker, reconstruct_versioned_tracker) {
@@ -273,8 +273,8 @@ TEST_F(TestTimestampedVersionTracker, reconstruct_versioned_tracker) {
     tracker.reconstruct_versioned_tracker(rs_metas, expried_rs_metas);
 
     ASSERT_EQ(10, tracker._version_graph._version_graph.size());
-    ASSERT_EQ(4, tracker._expired_snapshot_rs_path_map.size());
-    ASSERT_EQ(5, tracker._next_path_version);
+    ASSERT_EQ(4, tracker._expired_snapshot_version_path_map.size());
+    ASSERT_EQ(5, tracker._next_path_id);
 }
 
 TEST_F(TestTimestampedVersionTracker, add_version) {
@@ -305,8 +305,8 @@ TEST_F(TestTimestampedVersionTracker, add_expired_path_version) {
     init_expried_row_rs_meta(&expried_rs_metas);
     tracker.add_expired_path_version(expried_rs_metas);
 
-    ASSERT_EQ(1, tracker._expired_snapshot_rs_path_map.size());
-    ASSERT_EQ(7, tracker._expired_snapshot_rs_path_map.begin()->second->timestamped_versions().size());
+    ASSERT_EQ(1, tracker._expired_snapshot_version_path_map.size());
+    ASSERT_EQ(7, tracker._expired_snapshot_version_path_map.begin()->second->timestamped_versions().size());
 }
 
 TEST_F(TestTimestampedVersionTracker, capture_consistent_versions_tracker) {
@@ -343,32 +343,32 @@ TEST_F(TestTimestampedVersionTracker, fetch_and_delete_path_version) {
     TimestampedVersionTracker tracker;
     tracker.construct_versioned_tracker(rs_metas, expried_rs_metas);
 
-    ASSERT_EQ(4, tracker._expired_snapshot_rs_path_map.size());
+    ASSERT_EQ(4, tracker._expired_snapshot_version_path_map.size());
 
     Version spec_version(0, 8);
-    tracker.fetch_and_delete_path_version(1, version_path);
+    tracker.fetch_and_delete_path_by_id(1, version_path);
     ASSERT_EQ(2, version_path.size());
     ASSERT_EQ(Version(2, 3), version_path[0]);
     ASSERT_EQ(Version(4, 5), version_path[1]);
 
     version_path.clear();
-    tracker.fetch_and_delete_path_version(2, version_path);
+    tracker.fetch_and_delete_path_by_id(2, version_path);
     ASSERT_EQ(2, version_path.size());
     ASSERT_EQ(Version(6, 6), version_path[0]);
     ASSERT_EQ(Version(7, 8), version_path[1]);
 
     version_path.clear();
-    tracker.fetch_and_delete_path_version(3, version_path);
+    tracker.fetch_and_delete_path_by_id(3, version_path);
     ASSERT_EQ(2, version_path.size());
     ASSERT_EQ(Version(6, 8), version_path[0]);
     ASSERT_EQ(Version(9, 9), version_path[1]);
 
     version_path.clear();
-    tracker.fetch_and_delete_path_version(4, version_path);
+    tracker.fetch_and_delete_path_by_id(4, version_path);
     ASSERT_EQ(1, version_path.size());
     ASSERT_EQ(Version(10, 10), version_path[0]);
 
-    ASSERT_EQ(0, tracker._expired_snapshot_rs_path_map.size());
+    ASSERT_EQ(0, tracker._expired_snapshot_version_path_map.size());
 }
 
 TEST_F(TestTimestampedVersionTracker, capture_expired_path_version) {
@@ -383,10 +383,10 @@ TEST_F(TestTimestampedVersionTracker, capture_expired_path_version) {
     TimestampedVersionTracker tracker;
     tracker.construct_versioned_tracker(rs_metas, expried_rs_metas);
 
-    tracker.capture_expired_path_version(9999, &path_version);
+    tracker.capture_expired_paths(9999, &path_version);
     ASSERT_EQ(0, path_version.size());
 
-    tracker.capture_expired_path_version(10001, &path_version);
+    tracker.capture_expired_paths(10001, &path_version);
     ASSERT_EQ(4, path_version.size());
 }
 

--- a/be/test/olap/timestamped_version_tracker_test.cpp
+++ b/be/test/olap/timestamped_version_tracker_test.cpp
@@ -743,13 +743,7 @@ TEST_F(TestTimestampedVersionTracker, capture_expired_path_version) {
     ASSERT_EQ(4, path_version.size());
 }
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
-TEST_F(TestTimestampedVersionTracker, get_snapshot_version_path_json_doc) {
-=======
 TEST_F(TestTimestampedVersionTracker, get_stale_version_path_json_doc) {
->>>>>>> 100209d2... Add delayed deletion of rowsets function, fix -230 error.
 
     std::vector<RowsetMetaSharedPtr> rs_metas;
     std::vector<RowsetMetaSharedContainerPtr> expried_rs_metas;
@@ -827,7 +821,6 @@ TEST_F(TestTimestampedVersionTracker, get_stale_version_path_json_doc_empty) {
 
     ASSERT_EQ(expect_result, json_result);
 }
->>>>>>> d7e83dfb... Add delayed deletion of rowsets function, fix -230 error.
 }
 
 // @brief Test Stub

--- a/be/test/olap/timestamped_version_tracker_test.cpp
+++ b/be/test/olap/timestamped_version_tracker_test.cpp
@@ -10,6 +10,8 @@
 
 namespace doris {
 
+using RowsetMetaSharedContainerPtr = std::shared_ptr<std::vector<RowsetMetaSharedPtr>>;
+
 class TestTimestampedVersionTracker : public testing::Test {
 public:
     TestTimestampedVersionTracker() {}
@@ -191,6 +193,92 @@ public:
 
     }
 
+    void fetch_expried_row_rs_meta(std::vector<RowsetMetaSharedContainerPtr>* rs_metas) {
+
+        RowsetMetaSharedContainerPtr v2(new std::vector<RowsetMetaSharedPtr>());
+        RowsetMetaSharedPtr ptr1(new RowsetMeta());
+        init_rs_meta(ptr1, 2, 3);
+        v2->push_back(ptr1);
+
+        RowsetMetaSharedPtr ptr2(new RowsetMeta());
+        init_rs_meta(ptr2, 4, 5);
+        v2->push_back(ptr2);
+
+        RowsetMetaSharedContainerPtr v3(new std::vector<RowsetMetaSharedPtr>());
+        RowsetMetaSharedPtr ptr3(new RowsetMeta());
+        init_rs_meta(ptr3, 6, 6);
+        v3->push_back(ptr3);
+
+        RowsetMetaSharedPtr ptr4(new RowsetMeta());
+        init_rs_meta(ptr4, 7, 8);
+        v3->push_back(ptr4);
+
+        RowsetMetaSharedContainerPtr v4(new std::vector<RowsetMetaSharedPtr>());
+        RowsetMetaSharedPtr ptr5(new RowsetMeta());
+        init_rs_meta(ptr5, 6, 8);
+        v4->push_back(ptr5);
+
+        RowsetMetaSharedPtr ptr6(new RowsetMeta());
+        init_rs_meta(ptr6, 9, 9);
+        v4->push_back(ptr6);
+
+        RowsetMetaSharedContainerPtr v5(new std::vector<RowsetMetaSharedPtr>());
+        RowsetMetaSharedPtr ptr7(new RowsetMeta());
+        init_rs_meta(ptr7, 10, 10);
+        v5->push_back(ptr7);
+
+        rs_metas->push_back(v2);
+        rs_metas->push_back(v3);
+        rs_metas->push_back(v4);
+        rs_metas->push_back(v5);
+    }
+
+    void fetch_expried_row_rs_meta_with_same_rowset(std::vector<RowsetMetaSharedContainerPtr>* rs_metas) {
+
+        RowsetMetaSharedContainerPtr v1(new std::vector<RowsetMetaSharedPtr>());
+        RowsetMetaSharedPtr ptr0(new RowsetMeta());
+        init_rs_meta(ptr0, 1, 1);
+        v1->push_back(ptr0);
+
+        RowsetMetaSharedContainerPtr v2(new std::vector<RowsetMetaSharedPtr>());
+        RowsetMetaSharedPtr ptr1(new RowsetMeta());
+        init_rs_meta(ptr1, 2, 3);
+        v2->push_back(ptr1);
+
+        RowsetMetaSharedPtr ptr2(new RowsetMeta());
+        init_rs_meta(ptr2, 4, 5);
+        v2->push_back(ptr2);
+
+        RowsetMetaSharedContainerPtr v3(new std::vector<RowsetMetaSharedPtr>());
+        RowsetMetaSharedPtr ptr3(new RowsetMeta());
+        init_rs_meta(ptr3, 6, 6);
+        v3->push_back(ptr3);
+
+        RowsetMetaSharedPtr ptr4(new RowsetMeta());
+        init_rs_meta(ptr4, 7, 8);
+        v3->push_back(ptr4);
+
+        RowsetMetaSharedContainerPtr v4(new std::vector<RowsetMetaSharedPtr>());
+        RowsetMetaSharedPtr ptr5(new RowsetMeta());
+        init_rs_meta(ptr5, 6, 8);
+        v4->push_back(ptr5);
+
+        RowsetMetaSharedPtr ptr6(new RowsetMeta());
+        init_rs_meta(ptr6, 9, 9);
+        v4->push_back(ptr6);
+
+        RowsetMetaSharedContainerPtr v5(new std::vector<RowsetMetaSharedPtr>());
+        RowsetMetaSharedPtr ptr7(new RowsetMeta());
+        init_rs_meta(ptr7, 10, 10);
+        v5->push_back(ptr7);
+
+        rs_metas->push_back(v1);
+        rs_metas->push_back(v2);
+        rs_metas->push_back(v3);
+        rs_metas->push_back(v4);
+        rs_metas->push_back(v5);
+    }
+
 private:
     OlapMeta* _meta;
     std::string _json_rowset_meta;
@@ -219,14 +307,13 @@ TEST_F(TestTimestampedVersionTracker, construct_version_graph_with_same_version)
     VersionGraph version_graph;
 
     init_all_rs_meta(&rs_metas);
-    init_expried_row_rs_meta_with_same_rowset(&expried_rs_metas);
 
     rs_metas.insert(rs_metas.end(), expried_rs_metas.begin(),
                         expried_rs_metas.end());
     int64_t max_version = 0;
     version_graph.construct_version_graph(rs_metas, &max_version);
 
-    ASSERT_EQ(10, version_graph._version_graph.size());
+    ASSERT_EQ(6, version_graph._version_graph.size());
     int64_t exp = 11;
     ASSERT_EQ(exp, max_version);
 }
@@ -364,12 +451,14 @@ TEST_F(TestTimestampedVersionTracker, construct_versioned_tracker) {
     init_all_rs_meta(&rs_metas);
     init_expried_row_rs_meta(&expried_rs_metas);
 
+    rs_metas.insert(rs_metas.end(), expried_rs_metas.begin(),
+                        expried_rs_metas.end());
     TimestampedVersionTracker tracker;
-    tracker.construct_versioned_tracker(rs_metas, expried_rs_metas);
+    tracker.construct_versioned_tracker(rs_metas);
 
     ASSERT_EQ(10, tracker._version_graph._version_graph.size());
-    ASSERT_EQ(4, tracker._expired_snapshot_version_path_map.size());
-    ASSERT_EQ(5, tracker._next_path_id);
+    ASSERT_EQ(0, tracker._expired_snapshot_version_path_map.size());
+    ASSERT_EQ(1, tracker._next_path_id);
 }
 
 TEST_F(TestTimestampedVersionTracker, construct_versioned_tracker_with_same_rowset) {
@@ -381,12 +470,14 @@ TEST_F(TestTimestampedVersionTracker, construct_versioned_tracker_with_same_rows
     init_all_rs_meta(&rs_metas);
     init_expried_row_rs_meta_with_same_rowset(&expried_rs_metas);
 
+    rs_metas.insert(rs_metas.end(), expried_rs_metas.begin(),
+                        expried_rs_metas.end());
     TimestampedVersionTracker tracker;
-    tracker.construct_versioned_tracker(rs_metas, expried_rs_metas);
+    tracker.construct_versioned_tracker(rs_metas);
 
     ASSERT_EQ(10, tracker._version_graph._version_graph.size());
-    ASSERT_EQ(5, tracker._expired_snapshot_version_path_map.size());
-    ASSERT_EQ(6, tracker._next_path_id);
+    ASSERT_EQ(0, tracker._expired_snapshot_version_path_map.size());
+    ASSERT_EQ(1, tracker._next_path_id);
 }
 
 TEST_F(TestTimestampedVersionTracker, reconstruct_versioned_tracker) {
@@ -397,30 +488,16 @@ TEST_F(TestTimestampedVersionTracker, reconstruct_versioned_tracker) {
 
     init_all_rs_meta(&rs_metas);
     init_expried_row_rs_meta(&expried_rs_metas);
+    rs_metas.insert(rs_metas.end(), expried_rs_metas.begin(),
+                        expried_rs_metas.end());
 
+    const std::map<int64_t, PathVersionListSharedPtr> expired_snapshot_version_path_map;
     TimestampedVersionTracker tracker;
-    tracker.reconstruct_versioned_tracker(rs_metas, expried_rs_metas);
+    tracker.reconstruct_versioned_tracker(rs_metas, expired_snapshot_version_path_map);
 
     ASSERT_EQ(10, tracker._version_graph._version_graph.size());
-    ASSERT_EQ(4, tracker._expired_snapshot_version_path_map.size());
-    ASSERT_EQ(5, tracker._next_path_id);
-}
-
-TEST_F(TestTimestampedVersionTracker, reconstruct_versioned_tracker_with_same_rowset) {
-
-    std::vector<RowsetMetaSharedPtr> rs_metas;
-    std::vector<RowsetMetaSharedPtr> expried_rs_metas;
-    std::vector<Version> version_path;
-
-    init_all_rs_meta(&rs_metas);
-    init_expried_row_rs_meta_with_same_rowset(&expried_rs_metas);
-
-    TimestampedVersionTracker tracker;
-    tracker.reconstruct_versioned_tracker(rs_metas, expried_rs_metas);
-
-    ASSERT_EQ(10, tracker._version_graph._version_graph.size());
-    ASSERT_EQ(5, tracker._expired_snapshot_version_path_map.size());
-    ASSERT_EQ(6, tracker._next_path_id);
+    ASSERT_EQ(0, tracker._expired_snapshot_version_path_map.size());
+    ASSERT_EQ(1, tracker._next_path_id);
 }
 
 TEST_F(TestTimestampedVersionTracker, add_version) {
@@ -460,7 +537,7 @@ TEST_F(TestTimestampedVersionTracker, add_expired_path_version) {
 
     init_all_rs_meta(&rs_metas);
     TimestampedVersionTracker tracker;
-    tracker.construct_versioned_tracker(rs_metas, expried_rs_metas);
+    tracker.construct_versioned_tracker(rs_metas);
 
     init_expried_row_rs_meta(&expried_rs_metas);
     tracker.add_expired_path_version(expried_rs_metas);
@@ -472,31 +549,39 @@ TEST_F(TestTimestampedVersionTracker, add_expired_path_version) {
 TEST_F(TestTimestampedVersionTracker, add_expired_path_version_with_same_rowset) {
 
     std::vector<RowsetMetaSharedPtr> rs_metas;
-    std::vector<RowsetMetaSharedPtr> expried_rs_metas;
+    std::vector<RowsetMetaSharedContainerPtr> expried_rs_metas;
     std::vector<Version> version_path;
 
     init_all_rs_meta(&rs_metas);
     TimestampedVersionTracker tracker;
-    tracker.construct_versioned_tracker(rs_metas, expried_rs_metas);
+    tracker.construct_versioned_tracker(rs_metas);
 
-    init_expried_row_rs_meta_with_same_rowset(&expried_rs_metas);
-    tracker.add_expired_path_version(expried_rs_metas);
+    fetch_expried_row_rs_meta_with_same_rowset(&expried_rs_metas);
+    for(auto ptr:expried_rs_metas) {
+        tracker.add_expired_path_version(*ptr);
+    }
 
-    ASSERT_EQ(1, tracker._expired_snapshot_version_path_map.size());
-    ASSERT_EQ(8, tracker._expired_snapshot_version_path_map.begin()->second->timestamped_versions().size());
+    ASSERT_EQ(5, tracker._expired_snapshot_version_path_map.size());
+    ASSERT_EQ(1, tracker._expired_snapshot_version_path_map.begin()->second->timestamped_versions().size());
 }
 
 TEST_F(TestTimestampedVersionTracker, capture_consistent_versions_tracker) {
 
     std::vector<RowsetMetaSharedPtr> rs_metas;
-    std::vector<RowsetMetaSharedPtr> expried_rs_metas;
+    std::vector<RowsetMetaSharedContainerPtr> expried_rs_metas;
     std::vector<Version> version_path;
 
     init_all_rs_meta(&rs_metas);
-    init_expried_row_rs_meta(&expried_rs_metas);
+    fetch_expried_row_rs_meta(&expried_rs_metas);
 
     TimestampedVersionTracker tracker;
-    tracker.construct_versioned_tracker(rs_metas, expried_rs_metas);
+    tracker.construct_versioned_tracker(rs_metas);
+    for(auto ptr:expried_rs_metas) {
+        for (auto rs : *ptr) {
+            tracker.add_version(rs->version());
+        }
+        tracker.add_expired_path_version(*ptr);
+    }
 
     Version spec_version(0, 8);
     tracker.capture_consistent_versions(spec_version, &version_path);
@@ -511,14 +596,20 @@ TEST_F(TestTimestampedVersionTracker, capture_consistent_versions_tracker) {
 TEST_F(TestTimestampedVersionTracker, capture_consistent_versions_tracker_with_same_rowset) {
 
     std::vector<RowsetMetaSharedPtr> rs_metas;
-    std::vector<RowsetMetaSharedPtr> expried_rs_metas;
+    std::vector<RowsetMetaSharedContainerPtr> expried_rs_metas;
     std::vector<Version> version_path;
 
     init_all_rs_meta(&rs_metas);
-    init_expried_row_rs_meta_with_same_rowset(&expried_rs_metas);
+    fetch_expried_row_rs_meta_with_same_rowset(&expried_rs_metas);
 
     TimestampedVersionTracker tracker;
-    tracker.construct_versioned_tracker(rs_metas, expried_rs_metas);
+    tracker.construct_versioned_tracker(rs_metas);
+    for(auto ptr:expried_rs_metas) {
+        for (auto rs : *ptr) {
+            tracker.add_version(rs->version());
+        }
+        tracker.add_expired_path_version(*ptr);
+    }
 
     Version spec_version(0, 8);
     tracker.capture_consistent_versions(spec_version, &version_path);
@@ -533,39 +624,46 @@ TEST_F(TestTimestampedVersionTracker, capture_consistent_versions_tracker_with_s
 TEST_F(TestTimestampedVersionTracker, fetch_and_delete_path_version) {
 
     std::vector<RowsetMetaSharedPtr> rs_metas;
-    std::vector<RowsetMetaSharedPtr> expried_rs_metas;
-    std::vector<Version> version_path;
+    std::vector<RowsetMetaSharedContainerPtr> expried_rs_metas;
 
     init_all_rs_meta(&rs_metas);
-    init_expried_row_rs_meta(&expried_rs_metas);
+    fetch_expried_row_rs_meta(&expried_rs_metas);
 
     TimestampedVersionTracker tracker;
-    tracker.construct_versioned_tracker(rs_metas, expried_rs_metas);
+    tracker.construct_versioned_tracker(rs_metas);
+    for(auto ptr:expried_rs_metas) {
+        for (auto rs : *ptr) {
+            tracker.add_version(rs->version());
+        }
+        tracker.add_expired_path_version(*ptr);
+    }
 
     ASSERT_EQ(4, tracker._expired_snapshot_version_path_map.size());
 
     Version spec_version(0, 8);
-    tracker.fetch_and_delete_path_by_id(1, &version_path);
-    ASSERT_EQ(2, version_path.size());
-    ASSERT_EQ(Version(2, 3), version_path[0]);
-    ASSERT_EQ(Version(4, 5), version_path[1]);
+    PathVersionListSharedPtr ptr = tracker.fetch_and_delete_path_by_id(1);
+    std::vector<TimestampedVersionSharedPtr>& timestamped_versions = ptr->timestamped_versions();
 
-    version_path.clear();
-    tracker.fetch_and_delete_path_by_id(2, &version_path);
-    ASSERT_EQ(2, version_path.size());
-    ASSERT_EQ(Version(6, 6), version_path[0]);
-    ASSERT_EQ(Version(7, 8), version_path[1]);
+    ASSERT_EQ(2, timestamped_versions.size());
+    ASSERT_EQ(Version(2, 3), timestamped_versions[0]->version());
+    ASSERT_EQ(Version(4, 5), timestamped_versions[1]->version());
 
-    version_path.clear();
-    tracker.fetch_and_delete_path_by_id(3, &version_path);
-    ASSERT_EQ(2, version_path.size());
-    ASSERT_EQ(Version(6, 8), version_path[0]);
-    ASSERT_EQ(Version(9, 9), version_path[1]);
+    ptr = tracker.fetch_and_delete_path_by_id(2);
+    std::vector<TimestampedVersionSharedPtr>& timestamped_versions2 = ptr->timestamped_versions();
+    ASSERT_EQ(2, timestamped_versions2.size());
+    ASSERT_EQ(Version(6, 6), timestamped_versions2[0]->version());
+    ASSERT_EQ(Version(7, 8), timestamped_versions2[1]->version());
 
-    version_path.clear();
-    tracker.fetch_and_delete_path_by_id(4, &version_path);
-    ASSERT_EQ(1, version_path.size());
-    ASSERT_EQ(Version(10, 10), version_path[0]);
+    ptr = tracker.fetch_and_delete_path_by_id(3);
+    std::vector<TimestampedVersionSharedPtr>& timestamped_versions3 = ptr->timestamped_versions();
+    ASSERT_EQ(2, timestamped_versions3.size());
+    ASSERT_EQ(Version(6, 8), timestamped_versions3[0]->version());
+    ASSERT_EQ(Version(9, 9), timestamped_versions3[1]->version());
+
+    ptr = tracker.fetch_and_delete_path_by_id(4);
+    std::vector<TimestampedVersionSharedPtr>& timestamped_versions4 = ptr->timestamped_versions();
+    ASSERT_EQ(1, timestamped_versions4.size());
+    ASSERT_EQ(Version(10, 10), timestamped_versions4[0]->version());
 
     ASSERT_EQ(0, tracker._expired_snapshot_version_path_map.size());
 }
@@ -573,43 +671,49 @@ TEST_F(TestTimestampedVersionTracker, fetch_and_delete_path_version) {
 TEST_F(TestTimestampedVersionTracker, fetch_and_delete_path_version_with_same_rowset) {
 
     std::vector<RowsetMetaSharedPtr> rs_metas;
-    std::vector<RowsetMetaSharedPtr> expried_rs_metas;
-    std::vector<Version> version_path;
+    std::vector<RowsetMetaSharedContainerPtr> expried_rs_metas;
 
     init_all_rs_meta(&rs_metas);
-    init_expried_row_rs_meta_with_same_rowset(&expried_rs_metas);
+    fetch_expried_row_rs_meta_with_same_rowset(&expried_rs_metas);
 
     TimestampedVersionTracker tracker;
-    tracker.construct_versioned_tracker(rs_metas, expried_rs_metas);
+    tracker.construct_versioned_tracker(rs_metas);
+    for(auto ptr:expried_rs_metas) {
+        for (auto rs : *ptr) {
+            tracker.add_version(rs->version());
+        }
+        tracker.add_expired_path_version(*ptr);
+    }
 
     ASSERT_EQ(5, tracker._expired_snapshot_version_path_map.size());
 
-    tracker.fetch_and_delete_path_by_id(1, &version_path);
-    ASSERT_EQ(1, version_path.size());
-    ASSERT_EQ(Version(1, 1), version_path[0]);
+    PathVersionListSharedPtr ptr = tracker.fetch_and_delete_path_by_id(1);
+    std::vector<TimestampedVersionSharedPtr>& timestamped_versions = ptr->timestamped_versions();
+    ASSERT_EQ(1, timestamped_versions.size());
+    ASSERT_EQ(Version(1, 1), timestamped_versions[0]->version());
 
-    version_path.clear();
-    tracker.fetch_and_delete_path_by_id(2, &version_path);
-    ASSERT_EQ(2, version_path.size());
-    ASSERT_EQ(Version(2, 3), version_path[0]);
-    ASSERT_EQ(Version(4, 5), version_path[1]);
+    ptr = tracker.fetch_and_delete_path_by_id(2);
+    std::vector<TimestampedVersionSharedPtr>& timestamped_versions2 = ptr->timestamped_versions();
+    ASSERT_EQ(2, timestamped_versions2.size());
+    ASSERT_EQ(Version(2, 3), timestamped_versions2[0]->version());
+    ASSERT_EQ(Version(4, 5), timestamped_versions2[1]->version());
 
-    version_path.clear();
-    tracker.fetch_and_delete_path_by_id(3, &version_path);
-    ASSERT_EQ(2, version_path.size());
-    ASSERT_EQ(Version(6, 6), version_path[0]);
-    ASSERT_EQ(Version(7, 8), version_path[1]);
+    ptr = tracker.fetch_and_delete_path_by_id(3);
+    std::vector<TimestampedVersionSharedPtr>& timestamped_versions3 = ptr->timestamped_versions();
+    ASSERT_EQ(2, timestamped_versions3.size());
+    ASSERT_EQ(Version(6, 6), timestamped_versions3[0]->version());
+    ASSERT_EQ(Version(7, 8), timestamped_versions3[1]->version());
 
-    version_path.clear();
-    tracker.fetch_and_delete_path_by_id(4, &version_path);
-    ASSERT_EQ(2, version_path.size());
-    ASSERT_EQ(Version(6, 8), version_path[0]);
-    ASSERT_EQ(Version(9, 9), version_path[1]);
+    ptr = tracker.fetch_and_delete_path_by_id(4);
+    std::vector<TimestampedVersionSharedPtr>& timestamped_versions4 = ptr->timestamped_versions();
+    ASSERT_EQ(2, timestamped_versions4.size());
+    ASSERT_EQ(Version(6, 8), timestamped_versions4[0]->version());
+    ASSERT_EQ(Version(9, 9), timestamped_versions4[1]->version());
 
-    version_path.clear();
-    tracker.fetch_and_delete_path_by_id(5, &version_path);
-    ASSERT_EQ(1, version_path.size());
-    ASSERT_EQ(Version(10, 10), version_path[0]);
+    ptr = tracker.fetch_and_delete_path_by_id(5);
+    std::vector<TimestampedVersionSharedPtr>& timestamped_versions5 = ptr->timestamped_versions();
+    ASSERT_EQ(1, timestamped_versions5.size());
+    ASSERT_EQ(Version(10, 10), timestamped_versions5[0]->version());
 
     ASSERT_EQ(0, tracker._expired_snapshot_version_path_map.size());
 }
@@ -617,14 +721,20 @@ TEST_F(TestTimestampedVersionTracker, fetch_and_delete_path_version_with_same_ro
 TEST_F(TestTimestampedVersionTracker, capture_expired_path_version) {
 
     std::vector<RowsetMetaSharedPtr> rs_metas;
-    std::vector<RowsetMetaSharedPtr> expried_rs_metas;
+    std::vector<RowsetMetaSharedContainerPtr> expried_rs_metas;
     std::vector<int64_t> path_version;
 
     init_all_rs_meta(&rs_metas);
-    init_expried_row_rs_meta(&expried_rs_metas);
+    fetch_expried_row_rs_meta(&expried_rs_metas);
 
     TimestampedVersionTracker tracker;
-    tracker.construct_versioned_tracker(rs_metas, expried_rs_metas);
+    tracker.construct_versioned_tracker(rs_metas);
+    for(auto ptr:expried_rs_metas) {
+        for (auto rs : *ptr) {
+            tracker.add_version(rs->version());
+        }
+        tracker.add_expired_path_version(*ptr);
+    }
 
     tracker.capture_expired_paths(9999, &path_version);
     ASSERT_EQ(0, path_version.size());
@@ -633,6 +743,88 @@ TEST_F(TestTimestampedVersionTracker, capture_expired_path_version) {
     ASSERT_EQ(4, path_version.size());
 }
 
+<<<<<<< HEAD
+=======
+TEST_F(TestTimestampedVersionTracker, get_snapshot_version_path_json_doc) {
+
+    std::vector<RowsetMetaSharedPtr> rs_metas;
+    std::vector<RowsetMetaSharedContainerPtr> expried_rs_metas;
+    std::vector<Version> version_path;
+
+    init_all_rs_meta(&rs_metas);
+    fetch_expried_row_rs_meta(&expried_rs_metas);
+
+    TimestampedVersionTracker tracker;
+    tracker.construct_versioned_tracker(rs_metas);
+    for(auto ptr:expried_rs_metas) {
+        for (auto rs : *ptr) {
+            tracker.add_version(rs->version());
+        }
+        tracker.add_expired_path_version(*ptr);
+    }
+    rapidjson::Document path_arr;
+    path_arr.SetArray();
+
+    tracker.get_snapshot_version_path_json_doc(path_arr);
+
+    rapidjson::StringBuffer strbuf;
+    rapidjson::PrettyWriter<rapidjson::StringBuffer> writer(strbuf);
+    path_arr.Accept(writer);
+    std::string json_result = std::string(strbuf.GetString());
+
+    std::string expect_result = R"([
+    {
+        "path id": "1",
+        "last create time": "1970-01-01 10:46:40",
+        "path list": "1 -> [2-3] -> [4-5]"
+    },
+    {
+        "path id": "2",
+        "last create time": "1970-01-01 10:46:40",
+        "path list": "2 -> [6-6] -> [7-8]"
+    },
+    {
+        "path id": "3",
+        "last create time": "1970-01-01 10:46:40",
+        "path list": "3 -> [6-8] -> [9-9]"
+    },
+    {
+        "path id": "4",
+        "last create time": "1970-01-01 10:46:40",
+        "path list": "4 -> [10-10]"
+    }
+])";
+
+    ASSERT_EQ(expect_result, json_result);
+}
+
+TEST_F(TestTimestampedVersionTracker, get_snapshot_version_path_json_doc_empty) {
+
+    std::vector<RowsetMetaSharedPtr> rs_metas;
+    std::vector<RowsetMetaSharedContainerPtr> expried_rs_metas;
+    std::vector<Version> version_path;
+
+    init_all_rs_meta(&rs_metas);
+    fetch_expried_row_rs_meta(&expried_rs_metas);
+
+    TimestampedVersionTracker tracker;
+    tracker.construct_versioned_tracker(rs_metas);
+    
+    rapidjson::Document path_arr;
+    path_arr.SetArray();
+
+    tracker.get_snapshot_version_path_json_doc(path_arr);
+
+    rapidjson::StringBuffer strbuf;
+    rapidjson::PrettyWriter<rapidjson::StringBuffer> writer(strbuf);
+    path_arr.Accept(writer);
+    std::string json_result = std::string(strbuf.GetString());
+
+    std::string expect_result = R"([])";
+
+    ASSERT_EQ(expect_result, json_result);
+}
+>>>>>>> d7e83dfb... Add delayed deletion of rowsets function, fix -230 error.
 }
 
 // @brief Test Stub

--- a/be/test/olap/timestamped_version_tracker_test.cpp
+++ b/be/test/olap/timestamped_version_tracker_test.cpp
@@ -480,7 +480,7 @@ TEST_F(TestTimestampedVersionTracker, construct_versioned_tracker_with_same_rows
     ASSERT_EQ(1, tracker._next_path_id);
 }
 
-TEST_F(TestTimestampedVersionTracker, reconstruct_versioned_tracker) {
+TEST_F(TestTimestampedVersionTracker, recover_versioned_tracker) {
 
     std::vector<RowsetMetaSharedPtr> rs_metas;
     std::vector<RowsetMetaSharedPtr> expried_rs_metas;
@@ -493,7 +493,8 @@ TEST_F(TestTimestampedVersionTracker, reconstruct_versioned_tracker) {
 
     const std::map<int64_t, PathVersionListSharedPtr> stale_version_path_map;
     TimestampedVersionTracker tracker;
-    tracker.reconstruct_versioned_tracker(rs_metas, stale_version_path_map);
+    tracker.construct_versioned_tracker(rs_metas);
+    tracker.recover_versioned_tracker(stale_version_path_map);
 
     ASSERT_EQ(10, tracker._version_graph._version_graph.size());
     ASSERT_EQ(0, tracker._stale_version_path_map.size());

--- a/be/test/olap/timestamped_version_tracker_test.cpp
+++ b/be/test/olap/timestamped_version_tracker_test.cpp
@@ -770,7 +770,6 @@ TEST_F(TestTimestampedVersionTracker, get_stale_version_path_json_doc) {
     path_arr.SetArray();
 
     tracker.get_stale_version_path_json_doc(path_arr);
-
     rapidjson::StringBuffer strbuf;
     rapidjson::PrettyWriter<rapidjson::StringBuffer> writer(strbuf);
     path_arr.Accept(writer);

--- a/docs/en/administrator-guide/config/be_config.md
+++ b/docs/en/administrator-guide/config/be_config.md
@@ -245,6 +245,15 @@ When BE starts, it will check all the paths under the `storage_root_path` in  co
 
 The default value is `false`.
 
+### ignore_rowset_stale_unconsistent_delete
+
+* Type: boolean
+* Description：It is used to decide whether to delete the outdated merged rowset if it cannot form a consistent version path.
+* Default: false
+
+The merged expired rowset version path will be deleted after half an hour. In abnormal situations, deleting these versions will result in the problem that the consistent path of the query cannot be constructed. When the configuration is false, the program check is strict and the program will directly report an error and exit.
+When configured as true, the program will run normally and ignore this error. In general, ignoring this error will not affect the query, only when the merged version is dispathed by fe, -230 error will appear.
+
 ### inc_rowset_expired_sec
 
 * Type: boolean
@@ -261,8 +270,6 @@ Indicates how many tablets in this data directory failed to load. At the same ti
 
 1. If the tablet information is not repairable, you can delete the wrong tablet through the `meta_tool` tool under the condition that other copies are normal.
 2. Set `ignore_load_tablet_failure` to true, BE will ignore these wrong tablets and start normally.
-
-### `inc_rowset_expired_sec`
 
 ### `index_stream_cache_capacity`
 
@@ -453,6 +460,14 @@ Indicates how many tablets in this data directory failed to load. At the same ti
 ### `tablet_meta_checkpoint_min_new_rowsets_num`
 
 ### `tablet_stat_cache_update_interval_second`
+
+### `tablet_rowset_stale_sweep_time_sec`
+
+* Type: int64
+* Description: It is used to control the expiration time of cleaning up the merged rowset version. When the current time now() minus the max created rowset‘s create time in a version path is greater than tablet_rowset_stale_sweep_time_sec, the current path is cleaned up and these merged rowsets are deleted, the unit is second.
+* Default: 1800
+
+When writing is too frequent and the disk time is insufficient, you can configure less tablet_rowset_stale_sweep_time_sec. However, if this time is less than 5 minutes, it may cause fe to query the version that has been merged, causing a query -230 error.
 
 ### `tablet_writer_open_rpc_timeout_sec`
 

--- a/docs/en/administrator-guide/http-actions/compaction-action.md
+++ b/docs/en/administrator-guide/http-actions/compaction-action.md
@@ -64,7 +64,7 @@ If the tablet exists, the result is returned in JSON format:
         "[50-50] 0 DELETE NONOVERLAPPING",
         "[51-51] 5 DATA OVERLAPPING"
     ],
-    "expired snapshot version path": [
+    "stale version path": [
         {
             "path id": "2",
             "last create time": "2019-12-16 18:11:15.110",
@@ -85,7 +85,7 @@ Explanation of results:
 * last cumulative failure time: The time when the last cumulative compaction failed. After 10 minutes by default, cumulative compaction is attempted on the this tablet again.
 * last base failure time: The time when the last base compaction failed. After 10 minutes by default, base compaction is attempted on the this tablet again.
 * rowsets: The current rowsets collection of this tablet. [0-48] means a rowset with version 0-48. The second number is the number of segments in a rowset. The `DELETE` indicates the delete version. `OVERLAPPING` and `NONOVERLAPPING` indicates whether data between segments is overlap.
-* expired snapshot version path: The merged version path of the rowset collection currently merged in the tablet. It is an array structure and each element represents a merged path. Each element contains three attributes: path id indicates the version path id, and last create time indicates the creation time of the most recent rowset on the path. By default, all rowsets on this path will be deleted after half an hour at the last create time.
+* stale version path: The merged version path of the rowset collection currently merged in the tablet. It is an array structure and each element represents a merged path. Each element contains three attributes: path id indicates the version path id, and last create time indicates the creation time of the most recent rowset on the path. By default, all rowsets on this path will be deleted after half an hour at the last create time.
 
 ### Examples
 

--- a/docs/en/administrator-guide/http-actions/compaction-action.md
+++ b/docs/en/administrator-guide/http-actions/compaction-action.md
@@ -63,6 +63,18 @@ If the tablet exists, the result is returned in JSON format:
         "[49-49] 2 DATA OVERLAPPING",
         "[50-50] 0 DELETE NONOVERLAPPING",
         "[51-51] 5 DATA OVERLAPPING"
+    ],
+    "expired snapshot version path": [
+        {
+            "path id": "2",
+            "last create time": "2019-12-16 18:11:15.110",
+            "path list": "2-> [0-24] -> [25-48]"
+        }, 
+        {
+            "path id": "1",
+            "last create time": "2019-12-16 18:13:15.110",
+            "path list": "1-> [25-40] -> [40-48]"
+        }
     ]
 }
 ```
@@ -73,6 +85,7 @@ Explanation of results:
 * last cumulative failure time: The time when the last cumulative compaction failed. After 10 minutes by default, cumulative compaction is attempted on the this tablet again.
 * last base failure time: The time when the last base compaction failed. After 10 minutes by default, base compaction is attempted on the this tablet again.
 * rowsets: The current rowsets collection of this tablet. [0-48] means a rowset with version 0-48. The second number is the number of segments in a rowset. The `DELETE` indicates the delete version. `OVERLAPPING` and `NONOVERLAPPING` indicates whether data between segments is overlap.
+* expired snapshot version path: The merged version path of the rowset collection currently merged in the tablet. It is an array structure and each element represents a merged path. Each element contains three attributes: path id indicates the version path id, and last create time indicates the creation time of the most recent rowset on the path. By default, all rowsets on this path will be deleted after half an hour at the last create time.
 
 ### Examples
 

--- a/docs/zh-CN/administrator-guide/http-actions/compaction-action.md
+++ b/docs/zh-CN/administrator-guide/http-actions/compaction-action.md
@@ -56,13 +56,25 @@ curl -X GET http://be_host:webserver_port/api/compaction/show?tablet_id=xxxx\&sc
     "cumulative point": 50,
     "last cumulative failure time": "2019-12-16 18:13:43.224",
     "last base failure time": "2019-12-16 18:13:23.320",
-    "last cumu success time": "2019-12-16 18:12:15.110",
+    "last cumu success time": ,
     "last base success time": "2019-12-16 18:11:50.780",
     "rowsets": [
         "[0-48] 10 DATA OVERLAPPING",
         "[49-49] 2 DATA OVERLAPPING",
         "[50-50] 0 DELETE NONOVERLAPPING",
         "[51-51] 5 DATA OVERLAPPING"
+    ],
+    "expired snapshot version path": [
+        {
+            "path id": "2",
+            "last create time": "2019-12-16 18:11:15.110",
+            "path list": "2-> [0-24] -> [25-48]"
+        }, 
+        {
+            "path id": "1",
+            "last create time": "2019-12-16 18:13:15.110",
+            "path list": "1-> [25-40] -> [40-48]"
+        }
     ]
 }
 ```
@@ -73,6 +85,7 @@ curl -X GET http://be_host:webserver_port/api/compaction/show?tablet_id=xxxx\&sc
 * last cumulative failure time：上一次尝试 cumulative compaction 失败的时间。默认 10min 后才会再次尝试对该 tablet 做 cumulative compaction。
 * last base failure time：上一次尝试 base compaction 失败的时间。默认 10min 后才会再次尝试对该 tablet 做 base compaction。
 * rowsets：该 tablet 当前的 rowset 集合。如 [0-48] 表示 0-48 版本。第二位数字表示该版本中 segment 的数量。`DELETE` 表示 delete 版本。`DATA` 表示数据版本。`OVERLAPPING` 和 `NONOVERLAPPING` 表示segment数据是否重叠。
+* expired snapshot version path：该 table 当前被合并rowset集合的合并版本路径，该结构是一个数组结构，每个元素表示一个合并路径。每个元素中包含了三个属性：path id 表示版本路径id，last create time 表示当前路径上最近的 rowset 创建时间，默认在这个时间半个小时之后这条路径上的所有 rowset 会被过期删除。
 
 ### 示例
 

--- a/docs/zh-CN/administrator-guide/http-actions/compaction-action.md
+++ b/docs/zh-CN/administrator-guide/http-actions/compaction-action.md
@@ -64,7 +64,7 @@ curl -X GET http://be_host:webserver_port/api/compaction/show?tablet_id=xxxx\&sc
         "[50-50] 0 DELETE NONOVERLAPPING",
         "[51-51] 5 DATA OVERLAPPING"
     ],
-    "expired snapshot version path": [
+    "stale version path": [
         {
             "path id": "2",
             "last create time": "2019-12-16 18:11:15.110",
@@ -85,7 +85,7 @@ curl -X GET http://be_host:webserver_port/api/compaction/show?tablet_id=xxxx\&sc
 * last cumulative failure time：上一次尝试 cumulative compaction 失败的时间。默认 10min 后才会再次尝试对该 tablet 做 cumulative compaction。
 * last base failure time：上一次尝试 base compaction 失败的时间。默认 10min 后才会再次尝试对该 tablet 做 base compaction。
 * rowsets：该 tablet 当前的 rowset 集合。如 [0-48] 表示 0-48 版本。第二位数字表示该版本中 segment 的数量。`DELETE` 表示 delete 版本。`DATA` 表示数据版本。`OVERLAPPING` 和 `NONOVERLAPPING` 表示segment数据是否重叠。
-* expired snapshot version path：该 table 当前被合并rowset集合的合并版本路径，该结构是一个数组结构，每个元素表示一个合并路径。每个元素中包含了三个属性：path id 表示版本路径id，last create time 表示当前路径上最近的 rowset 创建时间，默认在这个时间半个小时之后这条路径上的所有 rowset 会被过期删除。
+* stale version path：该 table 当前被合并rowset集合的合并版本路径，该结构是一个数组结构，每个元素表示一个合并路径。每个元素中包含了三个属性：path id 表示版本路径id，last create time 表示当前路径上最近的 rowset 创建时间，默认在这个时间半个小时之后这条路径上的所有 rowset 会被过期删除。
 
 ### 示例
 

--- a/run-ut.sh
+++ b/run-ut.sh
@@ -269,7 +269,7 @@ ${DORIS_TEST_BINARY_DIR}/olap/skiplist_test
 ${DORIS_TEST_BINARY_DIR}/olap/serialize_test
 # ${DORIS_TEST_BINARY_DIR}/olap/memtable_flush_executor_test
 ${DORIS_TEST_BINARY_DIR}/olap/options_test
-${DORIS_TEST_BINARY_DIR}/olap/version_graph_test
+${DORIS_TEST_BINARY_DIR}/olap/timestamped_version_tracker_test
 
 # Running memory engine Unittest
 ${DORIS_TEST_BINARY_DIR}/olap/memory/hash_index_test

--- a/run-ut.sh
+++ b/run-ut.sh
@@ -269,6 +269,7 @@ ${DORIS_TEST_BINARY_DIR}/olap/skiplist_test
 ${DORIS_TEST_BINARY_DIR}/olap/serialize_test
 # ${DORIS_TEST_BINARY_DIR}/olap/memtable_flush_executor_test
 ${DORIS_TEST_BINARY_DIR}/olap/options_test
+${DORIS_TEST_BINARY_DIR}/olap/rowset_graph_test
 
 # Running memory engine Unittest
 ${DORIS_TEST_BINARY_DIR}/olap/memory/hash_index_test

--- a/run-ut.sh
+++ b/run-ut.sh
@@ -269,7 +269,7 @@ ${DORIS_TEST_BINARY_DIR}/olap/skiplist_test
 ${DORIS_TEST_BINARY_DIR}/olap/serialize_test
 # ${DORIS_TEST_BINARY_DIR}/olap/memtable_flush_executor_test
 ${DORIS_TEST_BINARY_DIR}/olap/options_test
-${DORIS_TEST_BINARY_DIR}/olap/rowset_graph_test
+${DORIS_TEST_BINARY_DIR}/olap/version_graph_test
 
 # Running memory engine Unittest
 ${DORIS_TEST_BINARY_DIR}/olap/memory/hash_index_test


### PR DESCRIPTION
Related issue #4017, main changes as follows:
1. Add expired_snapshot_rs_version_map，_expired_snapshot_rs_metas，
2. Add  VersionedRowsetTracker record compacted path version
3. Record path version when rowsets compact
4. In gc process, add expired snapshot rowsets to unused set to remove.