### PR TITLE
[BUG] fix big inline_view table  join small mysql table choose shuffle join bug

### DIFF
--- a/fe/src/main/java/org/apache/doris/planner/MysqlScanNode.java
+++ b/fe/src/main/java/org/apache/doris/planner/MysqlScanNode.java
@@ -157,7 +157,7 @@ public class MysqlScanNode extends ScanNode {
         numNodes = numNodes <= 0 ? 1 : numNodes;
         // this is just to avoid mysql scan node's cardinality being -1. So that we can calculate the join cost
         // normally.
-        // We assume that the data volume of all mysql tables is very small, so set cardinality directly to 0.
-        cardinality = cardinality == -1 ? 0 : cardinality;
+        // We assume that the data volume of all mysql tables is very small, so set cardinality directly to 1.
+        cardinality = cardinality == -1 ? 1 : cardinality;
     }
 }

--- a/fe/src/test/java/org/apache/doris/planner/QueryPlanTest.java
+++ b/fe/src/test/java/org/apache/doris/planner/QueryPlanTest.java
@@ -902,5 +902,9 @@ public class QueryPlanTest {
         explainString = UtFrameUtils.getSQLPlanOrErrorMsg(connectContext, queryStr);
         Assert.assertTrue(explainString.contains("INNER JOIN (BROADCAST)"));
         Assert.assertTrue(explainString.contains("1:SCAN MYSQL"));
+        
+        queryStr = "explain select * from jointest t1, mysql_table t2, mysql_table t3 where t1.k1 = t3.k1";
+        explainString = UtFrameUtils.getSQLPlanOrErrorMsg(connectContext, queryStr);
+        Assert.assertFalse(explainString.contains("INNER JOIN (PARTITIONED)"));
     }
 }


### PR DESCRIPTION
fix #4047 

#3886 has certain relevance to this case。

the sql : bigtable t1 join mysqltable t2 join mysqltable t3 on t1.k1 = t3.k1
1、after reorder:  
    t1, t2, t3
2、choose join t1 with t2:  
   t1 join t2 with no conditions, and doris choose cross join
3、choose join (t1 join on t2) with t3:  
 in old code, the t2 is mysqlTable, so the cardinality is zero,
and "the cross join t1 with t2" 's cardinality is t1.cardinality multiply t2.cardiantiry, 
for t2 is mysql, so t2.cardinality is zero, and "the cross join t1 with t2" is zero.
t3 is mysqltable, t3's cardinatiry is zero.

**If two tables need to be joined both are zero，we will choose the shuffle join**

So I change the mysql table ‘s cardinaliry from 0 to 1,  the cross join's cardinality is not zero.



