### PR TITLE
[Doris On ES] Add docvalue limitation for doc_values scan and enable doc_values scan default

### DIFF
--- a/be/src/exec/es/es_scan_reader.h
+++ b/be/src/exec/es/es_scan_reader.h
@@ -40,7 +40,7 @@ public:
     static constexpr const char* KEY_QUERY = "query";
     static constexpr const char* KEY_BATCH_SIZE = "batch_size";
     static constexpr const char* KEY_TERMINATE_AFTER = "limit";
-    static constexpr const char* KEY_DOC_VALUE_MODE = "doc_values_mode";
+    static constexpr const char* KEY_DOC_VALUES_MODE = "doc_values_mode";
     ESScanReader(const std::string& target, const std::map<std::string, std::string>& props, bool doc_value_mode);
     ~ESScanReader();
 

--- a/be/src/exec/es/es_scan_reader.h
+++ b/be/src/exec/es/es_scan_reader.h
@@ -40,6 +40,7 @@ public:
     static constexpr const char* KEY_QUERY = "query";
     static constexpr const char* KEY_BATCH_SIZE = "batch_size";
     static constexpr const char* KEY_TERMINATE_AFTER = "limit";
+    static constexpr const char* KEY_DOC_VALUE_MODE = "doc_values_mode";
     ESScanReader(const std::string& target, const std::map<std::string, std::string>& props, bool doc_value_mode);
     ~ESScanReader();
 

--- a/be/src/exec/es/es_scroll_query.cpp
+++ b/be/src/exec/es/es_scroll_query.cpp
@@ -79,7 +79,7 @@ std::string ESScrollQueryBuilder::build(const std::map<std::string, std::string>
 
     // Doris FE already has checked docvalue-scan optimization
     if (properties.find(ESScanReader::KEY_DOC_VALUES_MODE) != properties.end()) {
-        pure_docvalue = atoi(properties.at(ESScanReader::KEY_DOC_VALUE_MODE).c_str());
+        pure_docvalue = atoi(properties.at(ESScanReader::KEY_DOC_VALUES_MODE).c_str());
     } else {
         // check docvalue scan optimization, used for compatibility
         if (docvalue_context.size() == 0 || docvalue_context.size() < fields.size()) {

--- a/be/src/exec/es/es_scroll_query.cpp
+++ b/be/src/exec/es/es_scroll_query.cpp
@@ -76,14 +76,20 @@ std::string ESScrollQueryBuilder::build(const std::map<std::string, std::string>
     // note: add `query` for this value....
     es_query_dsl.AddMember("query", query_node, allocator);
     bool pure_docvalue = true;
-    // check docvalue sacan optimization
-    if (docvalue_context.size() == 0 || docvalue_context.size() < fields.size()) {
-        pure_docvalue = false;
+
+    // Doris FE already has checked docvalue-scan optimization
+    if (properties.find(ESScanReader::KEY_DOC_VALUE_MODE) != properties.end()) {
+        pure_docvalue = atoi(properties.at(ESScanReader::KEY_DOC_VALUE_MODE).c_str());
     } else {
-        for (auto& select_field : fields) {
-            if (docvalue_context.find(select_field) == docvalue_context.end()) {
-                pure_docvalue = false;
-                break;
+        // check docvalue scan optimization, used for compatibility
+        if (docvalue_context.size() == 0 || docvalue_context.size() < fields.size()) {
+            pure_docvalue = false;
+        } else {
+            for (auto& select_field : fields) {
+                if (docvalue_context.find(select_field) == docvalue_context.end()) {
+                    pure_docvalue = false;
+                    break;
+                }
             }
         }
     }

--- a/be/src/exec/es/es_scroll_query.cpp
+++ b/be/src/exec/es/es_scroll_query.cpp
@@ -78,7 +78,7 @@ std::string ESScrollQueryBuilder::build(const std::map<std::string, std::string>
     bool pure_docvalue = true;
 
     // Doris FE already has checked docvalue-scan optimization
-    if (properties.find(ESScanReader::KEY_DOC_VALUE_MODE) != properties.end()) {
+    if (properties.find(ESScanReader::KEY_DOC_VALUES_MODE) != properties.end()) {
         pure_docvalue = atoi(properties.at(ESScanReader::KEY_DOC_VALUE_MODE).c_str());
     } else {
         // check docvalue scan optimization, used for compatibility

--- a/fe/src/main/java/org/apache/doris/catalog/Catalog.java
+++ b/fe/src/main/java/org/apache/doris/catalog/Catalog.java
@@ -4154,6 +4154,7 @@ public class Catalog {
             sb.append("\"type\" = \"").append(esTable.getMappingType()).append("\",\n");
             sb.append("\"transport\" = \"").append(esTable.getTransport()).append("\",\n");
             sb.append("\"enable_docvalue_scan\" = \"").append(esTable.isDocValueScanEnable()).append("\",\n");
+            sb.append("\"max_docvalue_fields\" = \"").append(esTable.maxDocValueFields()).append("\",\n");
             sb.append("\"enable_keyword_sniff\" = \"").append(esTable.isKeywordSniffEnable()).append("\"\n");
             sb.append(")");
         } else if (table.getType() == TableType.HIVE) {

--- a/fe/src/main/java/org/apache/doris/catalog/EsTable.java
+++ b/fe/src/main/java/org/apache/doris/catalog/EsTable.java
@@ -223,8 +223,8 @@ public class EsTable extends Table {
         if (properties.containsKey(MAX_DOCVALUE_FIELDS)) {
             try {
                 maxDocValueFields = Integer.parseInt(properties.get(MAX_DOCVALUE_FIELDS).trim());
-                if (maxDocValueFields < 1) {
-                    maxDocValueFields = 1;
+                if (maxDocValueFields < 0) {
+                    maxDocValueFields = 0;
                 }
             } catch (Exception e) {
                 maxDocValueFields = DEFAULT_MAX_DOCVALUE_FIELDS;
@@ -335,7 +335,7 @@ public class EsTable extends Table {
                 try {
                     maxDocValueFields = Integer.parseInt(tableContext.get("maxDocValueFields"));
                 } catch (Exception e) {
-                    maxDocValueFields = 30;
+                    maxDocValueFields = DEFAULT_MAX_DOCVALUE_FIELDS;
                 }
             }
 

--- a/fe/src/main/java/org/apache/doris/catalog/EsTable.java
+++ b/fe/src/main/java/org/apache/doris/catalog/EsTable.java
@@ -57,28 +57,51 @@ public class EsTable extends Table {
     public static final String TYPE = "type";
     public static final String TRANSPORT = "transport";
     public static final String VERSION = "version";
+    public static final String DOC_VALUES_MODE = "doc_values_mode";
 
     public static final String TRANSPORT_HTTP = "http";
     public static final String TRANSPORT_THRIFT = "thrift";
     public static final String DOC_VALUE_SCAN = "enable_docvalue_scan";
     public static final String KEYWORD_SNIFF = "enable_keyword_sniff";
+    public static final String MAX_DOCVALUE_FIELDS = "max_docvalue_fields";
 
     private String hosts;
     private String[] seeds;
     private String userName = "";
     private String passwd = "";
+    // index name can be specific index、wildcard matched or alias.
     private String indexName;
+
+    // which type used for `indexName`, default to `_doc`
     private String mappingType = "_doc";
     private String transport = "http";
     // only save the partition definition, save the partition key,
     // partition list is got from es cluster dynamically and is saved in esTableState
     private PartitionInfo partitionInfo;
     private EsTablePartitions esTablePartitions;
-    private boolean enableDocValueScan = false;
-    private boolean enableKeywordSniff = true;
 
+    // Whether to enable docvalues scan optimization for fetching fields more fast, default to true
+    private boolean enableDocValueScan = true;
+    // Whether to enable sniffing keyword for filtering more reasonable, default to true
+    private boolean enableKeywordSniff = true;
+    // if the number of fields which value extracted from `doc_value` exceeding this max limitation
+    // would downgrade to extract value from `stored_fields`
+    private int maxDocValueFields = DEFAULT_MAX_DOCVALUE_FIELDS;
+
+    // Solr doc_values vs stored_fields performance-smackdown indicate:
+    // It is possible to notice that retrieving an high number of fields leads
+    // to a sensible worsening of performance if DocValues are used.
+    // Instead,  the (almost) surprising thing is that, by returning less than 20 fields,
+    // DocValues performs better than stored fields and the difference gets little as the number of fields returned increases.
+    // Asking for 9 DocValues fields and 1 stored field takes an average query time is 6.86 (more than returning 10 stored fields)
+    // Here we have a slightly conservative value of 20, but at the same time we also provide configurable parameters for expert-using
+    // @see `MAX_DOCVALUE_FIELDS`
+    private static final int DEFAULT_MAX_DOCVALUE_FIELDS = 20;
+
+    // version would be used to be compatible with different ES Cluster
     public EsMajorVersion majorVersion = null;
 
+    // tableContext is used for being convenient to persist some configuration parameters uniformly
     private Map<String, String> tableContext = new HashMap<>();
 
     // record the latest and recently exception when sync ES table metadata (mapping, shard location)
@@ -102,6 +125,10 @@ public class EsTable extends Table {
 
     public Map<String, String> docValueContext() {
         return esMetaStateTracker.searchContext().docValueFieldsContext();
+    }
+
+    public int maxDocValueFields() {
+        return maxDocValueFields;
     }
 
     public boolean isDocValueScanEnable() {
@@ -166,8 +193,6 @@ public class EsTable extends Table {
                         + properties.get(VERSION).trim() + " ,`enable_docvalue_scan`"
                         + " shoud be like 'true' or 'false'， value should be double quotation marks");
             }
-        } else {
-            enableDocValueScan = false;
         }
 
         if (properties.containsKey(KEYWORD_SNIFF)) {
@@ -194,6 +219,17 @@ public class EsTable extends Table {
                         + " but value is " + transport);
             }
         }
+
+        if (properties.containsKey(MAX_DOCVALUE_FIELDS)) {
+            try {
+                maxDocValueFields = Integer.parseInt(properties.get(MAX_DOCVALUE_FIELDS).trim());
+                if (maxDocValueFields < 1) {
+                    maxDocValueFields = 1;
+                }
+            } catch (Exception e) {
+                maxDocValueFields = DEFAULT_MAX_DOCVALUE_FIELDS;
+            }
+        }
         tableContext.put("hosts", hosts);
         tableContext.put("userName", userName);
         tableContext.put("passwd", passwd);
@@ -205,6 +241,7 @@ public class EsTable extends Table {
         }
         tableContext.put("enableDocValueScan", String.valueOf(enableDocValueScan));
         tableContext.put("enableKeywordSniff", String.valueOf(enableKeywordSniff));
+        tableContext.put("maxDocValueFields", String.valueOf(maxDocValueFields));
     }
 
     public TTableDescriptor toThrift() {
@@ -293,6 +330,13 @@ public class EsTable extends Table {
                 enableKeywordSniff = Boolean.parseBoolean(tableContext.get("enableKeywordSniff"));
             } else {
                 enableKeywordSniff = true;
+            }
+            if (tableContext.containsKey("maxDocValueFields")) {
+                try {
+                    maxDocValueFields = Integer.parseInt(tableContext.get("maxDocValueFields"));
+                } catch (Exception e) {
+                    maxDocValueFields = 30;
+                }
             }
 
             PartitionType partType = PartitionType.valueOf(Text.readString(in));


### PR DESCRIPTION
https://github.com/apache/incubator-doris/issues/3306 
When reading more column values such as above 20  (default, can be configured), switch from column(`doc_value`)reading to row(`_source` or `stored_fields`) reading, And we set `enable_docvalue_scan` to true for default.

It is possible to notice that retrieving an high number of fields leads to a sensible worsening of performance if DocValues are used(referenced from Solr performance-smackdown)
![image](https://user-images.githubusercontent.com/5183061/86993902-bd859880-c1d7-11ea-9ab1-934d734ef652.png)

Doris On ES would provide 20(default value) for max doc_value fields, if exceeding this value, would use `_source`（_stored_fields）

BTW: after ES 6.x,  ES introduce a dynamic index level setting `index.max_docvalue_fields_search` which default value is `100` 