### PR TITLE
[runtime] Replace the thread pool in FragmentMgr

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -324,7 +324,7 @@ namespace config {
     // Fragment thread pool
     CONF_Int32(fragment_pool_thread_num_min, "64");
     CONF_Int32(fragment_pool_thread_num_max, "512");
-    CONF_Int32(fragment_pool_queue_size, "1024");
+    CONF_Int32(fragment_pool_queue_size, "2048");
 
     //for cast
     // CONF_Bool(cast, "true");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -322,7 +322,8 @@ namespace config {
     CONF_mInt32(olap_table_sink_send_interval_ms, "10");
 
     // Fragment thread pool
-    CONF_Int32(fragment_pool_thread_num, "64");
+    CONF_Int32(fragment_pool_thread_num_min, "64");
+    CONF_Int32(fragment_pool_thread_num_max, "512");
     CONF_Int32(fragment_pool_queue_size, "1024");
 
     //for cast

--- a/be/src/runtime/fragment_mgr.h
+++ b/be/src/runtime/fragment_mgr.h
@@ -29,7 +29,6 @@
 #include "gen_cpp/DorisExternalService_types.h"
 #include "gen_cpp/Types_types.h"
 #include "gen_cpp/internal_service.pb.h"
-#include "util/priority_thread_pool.hpp"
 #include "util/hash_util.hpp"
 #include "http/rest_monitor_iface.h"
 
@@ -40,6 +39,7 @@ class FragmentExecState;
 class TExecPlanFragmentParams;
 class TUniqueId;
 class PlanFragmentExecutor;
+class ThreadPool;
 
 std::string to_load_error_http_path(const std::string& file_name);
 
@@ -90,7 +90,7 @@ private:
     bool _stop;
     std::thread _cancel_thread;
     // every job is a pool
-    PriorityThreadPool _thread_pool;
+    std::unique_ptr<ThreadPool> _thread_pool;
 };
 
 }

--- a/be/src/runtime/plan_fragment_executor.cpp
+++ b/be/src/runtime/plan_fragment_executor.cpp
@@ -510,6 +510,10 @@ void PlanFragmentExecutor::cancel() {
     _runtime_state->exec_env()->result_mgr()->cancel(_runtime_state->fragment_instance_id());
 }
 
+void PlanFragmentExecutor::set_abort() {
+    update_status(Status::Aborted("Execution aborted before start"));
+}
+
 const RowDescriptor& PlanFragmentExecutor::row_desc() {
     return _plan->row_desc();
 }

--- a/be/src/runtime/plan_fragment_executor.h
+++ b/be/src/runtime/plan_fragment_executor.h
@@ -114,6 +114,11 @@ public:
     // in open()/get_next().
     void close();
 
+    // Abort this execution. Must be called if we skip running open().
+    // It will let DataSink node closed with error status, to avoid use resources which created in open() phase.
+    // DataSink node should distinguish Aborted status from other error status.
+    void set_abort();
+
     // Initiate cancellation. Must not be called until after prepare() returned.
     void cancel();
 

--- a/be/test/runtime/fragment_mgr_test.cpp
+++ b/be/test/runtime/fragment_mgr_test.cpp
@@ -47,6 +47,10 @@ Status PlanFragmentExecutor::open() {
 
 void PlanFragmentExecutor::cancel() {}
 
+void PlanFragmentExecutor::set_abort() {
+    LOG(INFO) << "Plan Aborted";
+}
+
 void PlanFragmentExecutor::close() {}
 
 class FragmentMgrTest : public testing::Test {
@@ -57,9 +61,9 @@ protected:
     virtual void SetUp() {
         s_prepare_status = Status::OK();
         s_open_status = Status::OK();
-        LOG(INFO) << "fragment_pool_thread_num=" << config::fragment_pool_thread_num
-                  << ", pool_size=" << config::fragment_pool_queue_size;
-        config::fragment_pool_thread_num = 32;
+
+        config::fragment_pool_thread_num_min = 32;
+        config::fragment_pool_thread_num_max = 32;
         config::fragment_pool_queue_size = 1024;
     }
     virtual void TearDown() {}
@@ -115,6 +119,19 @@ TEST_F(FragmentMgrTest, PrepareFailed) {
     params.params.fragment_instance_id.__set_hi(100);
     params.params.fragment_instance_id.__set_lo(200);
     ASSERT_FALSE(mgr.exec_plan_fragment(params).ok());
+}
+
+TEST_F(FragmentMgrTest, OfferPoolFailed) {
+    // config::fragment_pool_thread_num = 1;
+    // config::fragment_pool_queue_size = 0;
+    // FragmentMgr mgr(nullptr);
+    // for (int i = 0; i < 8; ++i) {
+    //     TExecPlanFragmentParams params;
+    //     params.params.fragment_instance_id = TUniqueId();
+    //     params.params.fragment_instance_id.__set_hi(100 + i);
+    //     params.params.fragment_instance_id.__set_lo(200);
+    //     ASSERT_TRUE(mgr.exec_plan_fragment(params).ok());
+    // }
 }
 
 } // namespace doris

--- a/be/test/runtime/fragment_mgr_test.cpp
+++ b/be/test/runtime/fragment_mgr_test.cpp
@@ -29,6 +29,7 @@ namespace doris {
 
 static Status s_prepare_status;
 static Status s_open_status;
+static int s_abort_cnt;
 // Mock used for this unittest
 PlanFragmentExecutor::PlanFragmentExecutor(ExecEnv* exec_env,
                                            const report_status_callback& report_status_cb)
@@ -49,6 +50,7 @@ void PlanFragmentExecutor::cancel() {}
 
 void PlanFragmentExecutor::set_abort() {
     LOG(INFO) << "Plan Aborted";
+    s_abort_cnt++;
 }
 
 void PlanFragmentExecutor::close() {}
@@ -122,16 +124,27 @@ TEST_F(FragmentMgrTest, PrepareFailed) {
 }
 
 TEST_F(FragmentMgrTest, OfferPoolFailed) {
-    // config::fragment_pool_thread_num = 1;
-    // config::fragment_pool_queue_size = 0;
-    // FragmentMgr mgr(nullptr);
-    // for (int i = 0; i < 8; ++i) {
-    //     TExecPlanFragmentParams params;
-    //     params.params.fragment_instance_id = TUniqueId();
-    //     params.params.fragment_instance_id.__set_hi(100 + i);
-    //     params.params.fragment_instance_id.__set_lo(200);
-    //     ASSERT_TRUE(mgr.exec_plan_fragment(params).ok());
-    // }
+    config::fragment_pool_thread_num_min = 1;
+    config::fragment_pool_thread_num_max = 1;
+    config::fragment_pool_queue_size = 0;
+    s_abort_cnt = 0;
+    FragmentMgr mgr(nullptr);
+
+    TExecPlanFragmentParams params;
+    params.params.fragment_instance_id = TUniqueId();
+    params.params.fragment_instance_id.__set_hi(100);
+    params.params.fragment_instance_id.__set_lo(200);
+    ASSERT_TRUE(mgr.exec_plan_fragment(params).ok());
+
+    // the first plan open will cost 50ms, so the next 3 plans will be aborted.
+    for (int i = 1; i < 4; ++i) {
+        TExecPlanFragmentParams params;
+        params.params.fragment_instance_id = TUniqueId();
+        params.params.fragment_instance_id.__set_hi(100 + i);
+        params.params.fragment_instance_id.__set_lo(200);
+        ASSERT_FALSE(mgr.exec_plan_fragment(params).ok());
+    }
+    ASSERT_EQ(3, s_abort_cnt);
 }
 
 } // namespace doris


### PR DESCRIPTION
Ref https://github.com/apache/incubator-doris/issues/3416
Thread pool submit func may return error. To support error handling, we need add cancel_before_execute() for it.