### PR TITLE
Fix bug of count(*) in MV selector

### DIFF
--- a/fe/src/main/java/org/apache/doris/analysis/SelectStmt.java
+++ b/fe/src/main/java/org/apache/doris/analysis/SelectStmt.java
@@ -497,6 +497,19 @@ public class SelectStmt extends QueryStmt {
         return result;
     }
 
+    public List<TupleId> getTableRefIdsWithoutInlineView() {
+        List<TupleId> result = Lists.newArrayList();
+
+        for (TableRef ref : fromClause_) {
+            if (ref instanceof InlineViewRef) {
+                continue;
+            }
+            result.add(ref.getId());
+        }
+
+        return result;
+    }
+
     @Override
     public List<TupleId> collectTupleIds() {
         List<TupleId> result = Lists.newArrayList();

--- a/fe/src/main/java/org/apache/doris/planner/MaterializedViewSelector.java
+++ b/fe/src/main/java/org/apache/doris/planner/MaterializedViewSelector.java
@@ -43,7 +43,6 @@ import com.google.common.collect.Sets;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
@@ -474,8 +473,7 @@ public class MaterializedViewSelector {
 
         // Step4: compute the output column
         // ISSUE-3174: all of columns which belong to top tuple should be considered in selector.
-        ArrayList<TupleId> topTupleIds = Lists.newArrayList();
-        selectStmt.getMaterializedTupleIds(topTupleIds);
+        List<TupleId> topTupleIds = selectStmt.getTableRefIdsWithoutInlineView();
         for (TupleId tupleId : topTupleIds) {
             TupleDescriptor tupleDescriptor = analyzer.getTupleDesc(tupleId);
             tupleDescriptor.getTableNameToColumnNames(columnNamesInQueryOutput);


### PR DESCRIPTION
Fix bug of count(*) in MV selector

The output columns of query should be collected by all of tupleIds in BaseTableRef rather than the top tupleIds of query.
The top tupleIds of count(*) is Agg tuple which does not expand the star.

Fixed #4065

Change-Id: Icd21a10f505e01fefba30c8dfce8a0fa162cffa6