### PR TITLE
[Bug]Support get all rowset meta info in memory from tablet meta url

### DIFF
--- a/be/src/http/action/meta_action.cpp
+++ b/be/src/http/action/meta_action.cpp
@@ -60,13 +60,11 @@ Status MetaAction::_handle_header(HttpRequest* req, std::string* json_meta) {
         LOG(WARNING) << "no tablet for tablet_id:" << tablet_id << " schema hash:" << schema_hash;
         return Status::InternalError("no tablet exist");
     }
-    OLAPStatus s =
-            TabletMetaManager::get_json_meta(tablet->data_dir(), tablet_id, schema_hash, json_meta);
-    if (s == OLAP_ERR_META_KEY_NOT_FOUND) {
-        return Status::InternalError("no header exist");
-    } else if (s != OLAP_SUCCESS) {
-        return Status::InternalError("backend error");
-    }
+    TabletMetaSharedPtr tablet_meta(new TabletMeta());
+    tablet->generate_tablet_meta_copy(tablet_meta);
+    json2pb::Pb2JsonOptions json_options;
+    json_options.pretty_json = true;
+    tablet_meta->to_json(json_meta, json_options);
     return Status::OK();
 }
 

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -991,11 +991,7 @@ bool Tablet::rowset_meta_is_useful(RowsetMetaSharedPtr rowset_meta) {
             find_version = true;
         }
     }
-    if (find_rowset_id || !find_version) {
-        return true;
-    } else {
-        return false;
-    }
+    return find_rowset_id || !find_version;
 }
 
 bool Tablet::_contains_rowset(const RowsetId rowset_id) {
@@ -1050,10 +1046,12 @@ void Tablet::build_tablet_report_info(TTabletInfo* tablet_info) {
 // should use this method to get a copy of current tablet meta
 // there are some rowset meta in local meta store and in in-memory tablet meta
 // but not in tablet meta in local meta store
-// TODO(lingbin): do we need _meta_lock?
 void Tablet::generate_tablet_meta_copy(TabletMetaSharedPtr new_tablet_meta) const {
     TabletMetaPB tablet_meta_pb;
-    _tablet_meta->to_meta_pb(&tablet_meta_pb);
+    {
+        ReadLock rdlock(&_meta_lock);
+        _tablet_meta->to_meta_pb(&tablet_meta_pb);
+    }
     new_tablet_meta->init_from_pb(tablet_meta_pb);
 }
 


### PR DESCRIPTION
This PR is to fix bug that we cannot get the newest tablet meta info from tablet meta url. 