### PR TITLE
Fix be may core dump when linked schema change

### DIFF
--- a/be/src/olap/rowset/segment_group.cpp
+++ b/be/src/olap/rowset/segment_group.cpp
@@ -256,7 +256,7 @@ OLAPStatus SegmentGroup::add_zone_maps_for_linked_schema_change(
 
     int zonemap_col_num = get_num_zone_map_columns();
     CHECK(zonemap_col_num <= schema_mapping.size()) << zonemap_col_num << " vs. " << schema_mapping.size();
-    // if uprade from 0.11 the zone map not contain the value column, so zone_map_fields.size() is less
+    // if upgrade from 0.11 the zone map not contain the value column, so zone_map_fields.size() is less
     // than zonemap_col_num, this may be cause core dump at access zone_map_fields by index in the following code
     for (size_t i = 0; i < zonemap_col_num && i < zone_map_fields.size(); ++i) {
         const TabletColumn& column = _schema->column(i);

--- a/be/src/olap/rowset/segment_group.cpp
+++ b/be/src/olap/rowset/segment_group.cpp
@@ -257,7 +257,8 @@ OLAPStatus SegmentGroup::add_zone_maps_for_linked_schema_change(
     int zonemap_col_num = get_num_zone_map_columns();
     CHECK(zonemap_col_num <= schema_mapping.size()) << zonemap_col_num << " vs. " << schema_mapping.size();
     // if upgrade from 0.11 the zone map not contain the value column, so zone_map_fields.size() is less
-    // than zonemap_col_num, this may be cause core dump at access zone_map_fields by index in the following code
+    // than zonemap_col_num, this may be cause core dump at access zone_map_fields by index in the following code,
+    // so check the zone_map_fields.size() to set the actual zone map fields
     for (size_t i = 0; i < zonemap_col_num && i < zone_map_fields.size(); ++i) {
         const TabletColumn& column = _schema->column(i);
 

--- a/be/src/olap/rowset/segment_group.cpp
+++ b/be/src/olap/rowset/segment_group.cpp
@@ -256,7 +256,9 @@ OLAPStatus SegmentGroup::add_zone_maps_for_linked_schema_change(
 
     int zonemap_col_num = get_num_zone_map_columns();
     CHECK(zonemap_col_num <= schema_mapping.size()) << zonemap_col_num << " vs. " << schema_mapping.size();
-    for (size_t i = 0; i < zonemap_col_num; ++i) {
+    // if uprade from 0.11 the zone map not contain the value column, so zone_map_fields.size() is less
+    // than zonemap_col_num, this may be cause core dump at access zone_map_fields by index in the following code
+    for (size_t i = 0; i < zonemap_col_num && i < zone_map_fields.size(); ++i) {
         const TabletColumn& column = _schema->column(i);
 
         WrapperField* first = WrapperField::create(column);


### PR DESCRIPTION
fixes #4078
If the server upgrade from 0.11 and has a duplicate table. After upgrade we add a column by linked schema change, this will be cause a core dump
this is becase of the zone map in duplcate table in 0.11 does not contains the value column, so that the vector may out of boundary