### PR TITLE
[Feature][Meta]Update/Read/Write VisibleVersionTime for Partition#4076

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/FeMetaVersion.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/FeMetaVersion.java
@@ -185,6 +185,8 @@ public final class FeMetaVersion {
     public static final int VERSION_86 = 86;
     // spark resource, resource privilege, broker file group for hive table
     public static final int VERSION_87 = 87;
+    // add partition visibleVersionTime
+    public static final int VERSION_88 = 88;
     // note: when increment meta version, should assign the latest version to VERSION_CURRENT
-    public static final int VERSION_CURRENT = VERSION_87;
+    public static final int VERSION_CURRENT = VERSION_88;
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/common/proc/PartitionsProcDir.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/proc/PartitionsProcDir.java
@@ -64,7 +64,8 @@ import java.util.stream.Collectors;
  */
 public class PartitionsProcDir implements ProcDirInterface {
     public static final ImmutableList<String> TITLE_NAMES = new ImmutableList.Builder<String>()
-            .add("PartitionId").add("PartitionName").add("VisibleVersion").add("VisibleVersionHash")
+            .add("PartitionId").add("PartitionName")
+            .add("VisibleVersion").add("VisibleVersionTime").add("VisibleVersionHash")
             .add("State").add("PartitionKey").add("Range").add("DistributionKey")
             .add("Buckets").add("ReplicationNum").add("StorageMedium").add("CooldownTime")
             .add("LastConsistencyCheckTime")
@@ -231,6 +232,7 @@ public class PartitionsProcDir implements ProcDirInterface {
                 partitionInfo.add(partitionId);
                 partitionInfo.add(partitionName);
                 partitionInfo.add(partition.getVisibleVersion());
+                partitionInfo.add(TimeUtils.longToTimeString(partition.getVisibleVersionTime()));
                 partitionInfo.add(partition.getVisibleVersionHash());
                 partitionInfo.add(partition.getState());
 

--- a/fe/fe-core/src/main/java/org/apache/doris/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/transaction/DatabaseTransactionMgr.java
@@ -788,8 +788,8 @@ public class DatabaseTransactionMgr {
                 OlapTable table = (OlapTable) db.getTable(tableId);
                 Partition partition = table.getPartition(partitionId);
                 PartitionCommitInfo partitionCommitInfo = new PartitionCommitInfo(partitionId,
-                        partition.getNextVersion(),
-                        partition.getNextVersionHash());
+                        partition.getNextVersion(), partition.getNextVersionHash(),
+                        System.currentTimeMillis() /* use as partition visible time */);
                 tableCommitInfo.addPartitionCommitInfo(partitionCommitInfo);
             }
             transactionState.putIdToTableCommitInfo(tableId, tableCommitInfo);

--- a/fe/fe-core/src/main/java/org/apache/doris/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/transaction/DatabaseTransactionMgr.java
@@ -1258,8 +1258,9 @@ public class DatabaseTransactionMgr {
                     }
                 } // end for indices
                 long version = partitionCommitInfo.getVersion();
+                long versionTime = partitionCommitInfo.getVersionTime();
                 long versionHash = partitionCommitInfo.getVersionHash();
-                partition.updateVisibleVersionAndVersionHash(version, versionHash);
+                partition.updateVisibleVersionAndVersionHash(version, versionTime, versionHash);
                 if (LOG.isDebugEnabled()) {
                     LOG.debug("transaction state {} set partition {}'s version to [{}] and version hash to [{}]",
                             transactionState, partition.getId(), version, versionHash);

--- a/fe/fe-core/src/main/java/org/apache/doris/transaction/PartitionCommitInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/transaction/PartitionCommitInfo.java
@@ -17,6 +17,8 @@
 
 package org.apache.doris.transaction;
 
+import org.apache.doris.catalog.Catalog;
+import org.apache.doris.common.FeMetaVersion;
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -27,6 +29,7 @@ public class PartitionCommitInfo implements Writable {
 
     private long partitionId;
     private long version;
+    private long versionTime;
     private long versionHash;
 
     public PartitionCommitInfo() {
@@ -37,6 +40,7 @@ public class PartitionCommitInfo implements Writable {
         super();
         this.partitionId = partitionId;
         this.version = version;
+        this.versionTime = System.currentTimeMillis(); 
         this.versionHash = versionHash;
     }
 
@@ -44,12 +48,16 @@ public class PartitionCommitInfo implements Writable {
     public void write(DataOutput out) throws IOException {
         out.writeLong(partitionId);
         out.writeLong(version);
+        out.writeLong(versionTime);
         out.writeLong(versionHash);
     }
 
     public void readFields(DataInput in) throws IOException {
         partitionId = in.readLong();
         version = in.readLong();
+        if (Catalog.getCurrentCatalogJournalVersion() >= FeMetaVersion.VERSION_88) {
+            versionTime = in.readLong();
+        }     
         versionHash = in.readLong();
     }
 
@@ -59,6 +67,10 @@ public class PartitionCommitInfo implements Writable {
 
     public long getVersion() {
         return version;
+    }
+    
+    public long getVersionTime() {
+        return versionTime;
     }
 
     public long getVersionHash() {

--- a/fe/fe-core/src/main/java/org/apache/doris/transaction/PartitionCommitInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/transaction/PartitionCommitInfo.java
@@ -19,46 +19,55 @@ package org.apache.doris.transaction;
 
 import org.apache.doris.catalog.Catalog;
 import org.apache.doris.common.FeMetaVersion;
+import org.apache.doris.common.io.Text;
+import org.apache.doris.common.io.Writable;
+import org.apache.doris.persist.gson.GsonUtils;
+
+import com.google.gson.annotations.SerializedName;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 
-import org.apache.doris.common.io.Writable;
-
 public class PartitionCommitInfo implements Writable {
 
+    @SerializedName(value = "partitionId")
     private long partitionId;
+    @SerializedName(value = "version")
     private long version;
+    @SerializedName(value = "versionTime")
     private long versionTime;
+    @SerializedName(value = "versionHash")
     private long versionHash;
 
     public PartitionCommitInfo() {
         
     }
 
-    public PartitionCommitInfo(long partitionId, long version, long versionHash) {
+    public PartitionCommitInfo(long partitionId, long version, long versionHash, long visibleTime) {
         super();
         this.partitionId = partitionId;
         this.version = version;
-        this.versionTime = System.currentTimeMillis(); 
+        this.versionTime = visibleTime;
         this.versionHash = versionHash;
     }
 
     @Override
     public void write(DataOutput out) throws IOException {
-        out.writeLong(partitionId);
-        out.writeLong(version);
-        out.writeLong(versionTime);
-        out.writeLong(versionHash);
+        String json = GsonUtils.GSON.toJson(this);
+        Text.writeString(out, json);
     }
 
-    public void readFields(DataInput in) throws IOException {
-        partitionId = in.readLong();
-        version = in.readLong();
-        if (Catalog.getCurrentCatalogJournalVersion() >= FeMetaVersion.VERSION_88) {
-            versionTime = in.readLong();
-        }     
-        versionHash = in.readLong();
+    public static PartitionCommitInfo read(DataInput in) throws IOException {
+        if (Catalog.getCurrentCatalogJournalVersion() < FeMetaVersion.VERSION_88) {
+            long partitionId = in.readLong();
+            long version = in.readLong();
+            long versionHash = in.readLong();
+            return new PartitionCommitInfo(partitionId, version, versionHash, System.currentTimeMillis());
+        } else {
+            String json = Text.readString(in);
+            return GsonUtils.GSON.fromJson(json, PartitionCommitInfo.class);
+        }
     }
 
     public long getPartitionId() {
@@ -79,12 +88,11 @@ public class PartitionCommitInfo implements Writable {
     
     @Override
     public String toString() {
-        StringBuffer strBuffer = new StringBuffer("partitionid=");
-        strBuffer.append(partitionId);
-        strBuffer.append(", version=");
-        strBuffer.append(version);
-        strBuffer.append(", versionHash=");
-        strBuffer.append(versionHash);
-        return strBuffer.toString();
+        StringBuilder sb = new StringBuilder("partitionid=");
+        sb.append(partitionId);
+        sb.append(", version=").append(version);
+        sb.append(", versionHash=").append(versionHash);
+        sb.append(", versionTime=").append(versionTime);
+        return sb.toString();
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/transaction/TableCommitInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/transaction/TableCommitInfo.java
@@ -17,13 +17,14 @@
 
 package org.apache.doris.transaction;
 
+import org.apache.doris.common.io.Writable;
+
+import com.google.common.collect.Maps;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 import java.util.Map;
-
-import org.apache.doris.common.io.Writable;
-import com.google.common.collect.Maps;
 
 public class TableCommitInfo implements Writable {
     
@@ -60,8 +61,7 @@ public class TableCommitInfo implements Writable {
         if (hasPartitionInfo) {
             int elementNum = in.readInt();
             for (int i = 0; i < elementNum; ++i) {
-                PartitionCommitInfo partitionCommitInfo = new PartitionCommitInfo();
-                partitionCommitInfo.readFields(in);
+                PartitionCommitInfo partitionCommitInfo = PartitionCommitInfo.read(in);
                 idToPartitionCommitInfo.put(partitionCommitInfo.getPartitionId(), partitionCommitInfo);
             }
         }


### PR DESCRIPTION
#4076 
1. The visibleVersionTime is updated when insert data to partition
2. GlobalTransactionMgr call partition.updateVisibleVersionAndVersionHash(version, versionHash) when fe is restarted
3. If fe restart, VisibleVersionTime may be changed, but the changed value is newer than the old value