### PR TITLE
show lost tabletIds which do not have any available replica

### DIFF
--- a/fe/src/main/java/org/apache/doris/catalog/OlapTable.java
+++ b/fe/src/main/java/org/apache/doris/catalog/OlapTable.java
@@ -1224,7 +1224,7 @@ public class OlapTable extends Table {
 
                     Pair<TabletStatus, TabletSchedCtx.Priority> statusPair = tablet.getHealthStatusWithPriority(
                             infoService, clusterName, visibleVersion, visibleVersionHash, replicationNum,
-                            availableBackendsNum);
+                            availableBackendsNum, false);
                     if (statusPair.first != TabletStatus.HEALTHY) {
                         LOG.info("table {} is not stable because tablet {} status is {}. replicas: {}",
                                 id, tablet.getId(), statusPair.first, tablet.getReplicas());

--- a/fe/src/main/java/org/apache/doris/clone/TabletChecker.java
+++ b/fe/src/main/java/org/apache/doris/clone/TabletChecker.java
@@ -239,7 +239,7 @@ public class TabletChecker extends MasterDaemon {
                                         partition.getVisibleVersion(),
                                         partition.getVisibleVersionHash(),
                                         olapTbl.getPartitionInfo().getReplicationNum(partition.getId()),
-                                        availableBackendsNum);
+                                        availableBackendsNum,false);
 
                                 if (statusWithPrio.first == TabletStatus.HEALTHY) {
                                     // Only set last status check time when status is healthy.

--- a/fe/src/main/java/org/apache/doris/clone/TabletSchedCtx.java
+++ b/fe/src/main/java/org/apache/doris/clone/TabletSchedCtx.java
@@ -803,7 +803,7 @@ public class TabletSchedCtx implements Comparable<TabletSchedCtx> {
             short replicationNum = olapTable.getPartitionInfo().getReplicationNum(partitionId);
             Pair<TabletStatus, TabletSchedCtx.Priority> pair = tablet.getHealthStatusWithPriority(
                     infoService, db.getClusterName(), visibleVersion, visibleVersionHash, replicationNum,
-                    availableBackendsNum);
+                    availableBackendsNum,false);
             if (pair.first == TabletStatus.HEALTHY) {
                 throw new SchedException(Status.FINISHED, "tablet is healthy");
             }

--- a/fe/src/main/java/org/apache/doris/clone/TabletScheduler.java
+++ b/fe/src/main/java/org/apache/doris/clone/TabletScheduler.java
@@ -500,7 +500,7 @@ public class TabletScheduler extends MasterDaemon {
                         partition.getVisibleVersion(),
                         partition.getVisibleVersionHash(),
                         tbl.getPartitionInfo().getReplicationNum(partition.getId()),
-                        availableBackendsNum);
+                        availableBackendsNum, false);
             }
 
             if (tabletCtx.getType() == TabletSchedCtx.Type.BALANCE && tableState != OlapTableState.NORMAL) {

--- a/fe/src/main/java/org/apache/doris/common/proc/IncompleteTabletsProcNode.java
+++ b/fe/src/main/java/org/apache/doris/common/proc/IncompleteTabletsProcNode.java
@@ -29,20 +29,24 @@ import java.util.List;
 
 public class IncompleteTabletsProcNode implements ProcNodeInterface {
     public static final ImmutableList<String> TITLE_NAMES = new ImmutableList.Builder<String>()
-            .add("UnhealthyTablets").add("InconsistentTablets").add("CloningTablets")
+            .add("UnhealthyTablets").add("InconsistentTablets").add("CloningTablets").add("LostTablets")
             .build();
+
     private static final Joiner JOINER = Joiner.on(",");
 
     Collection<Long> unhealthyTabletIds;
     Collection<Long> inconsistentTabletIds;
+    Collection<Long> noAvlreplicaTabletIds;
     Collection<Long> cloningTabletIds;
 
     public IncompleteTabletsProcNode(Collection<Long> unhealthyTabletIds,
                                      Collection<Long> inconsistentTabletIds,
-                                     Collection<Long> cloningTabletIds) {
+                                     Collection<Long> cloningTabletIds,
+                                     Collection<Long> noAvlreplicaTabletIds) {
         this.unhealthyTabletIds = unhealthyTabletIds;
         this.inconsistentTabletIds = inconsistentTabletIds;
         this.cloningTabletIds = cloningTabletIds;
+        this.noAvlreplicaTabletIds = noAvlreplicaTabletIds;
     }
 
     @Override
@@ -55,10 +59,12 @@ public class IncompleteTabletsProcNode implements ProcNodeInterface {
 
         String incompleteTablets = JOINER.join(Arrays.asList(unhealthyTabletIds));
         String inconsistentTablets = JOINER.join(Arrays.asList(inconsistentTabletIds));
+        String noAvlreplicaTablets = JOINER.join(Arrays.asList(noAvlreplicaTabletIds));
         String cloningTablets = JOINER.join(Arrays.asList(cloningTabletIds));
         row.add(incompleteTablets);
         row.add(inconsistentTablets);
         row.add(cloningTablets);
+        row.add(noAvlreplicaTablets);
 
         result.addRow(row);
 

--- a/fe/src/main/java/org/apache/doris/master/ReportHandler.java
+++ b/fe/src/main/java/org/apache/doris/master/ReportHandler.java
@@ -1030,7 +1030,7 @@ public class ReportHandler extends Daemon {
             int availableBackendsNum = infoService.getClusterBackendIds(db.getClusterName(), true).size();
             Pair<TabletStatus, TabletSchedCtx.Priority> status = tablet.getHealthStatusWithPriority(infoService,
                     db.getClusterName(), visibleVersion, visibleVersionHash,
-                    replicationNum, availableBackendsNum);
+                    replicationNum, availableBackendsNum, false);
             
             if (status.first == TabletStatus.VERSION_INCOMPLETE || status.first == TabletStatus.REPLICA_MISSING) {
                 long lastFailedVersion = -1L;


### PR DESCRIPTION
Add tabletIds without available replica in system info page, to improve the monitoring information.