### PR TITLE
[Spark Load] add job granularity global dict lock

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Catalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Catalog.java
@@ -583,6 +583,10 @@ public class Catalog {
         return pullLoadJobMgr;
     }
 
+    public LoadJobScheduler getLoadJobScheduler() {
+        return loadJobScheduler;
+    }
+
     public BrokerMgr getBrokerMgr() {
         return brokerMgr;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/BulkLoadJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/BulkLoadJob.java
@@ -141,6 +141,9 @@ public abstract class BulkLoadJob extends LoadJob {
             for (DataDescription dataDescription : dataDescriptions) {
                 BrokerFileGroup fileGroup = new BrokerFileGroup(dataDescription);
                 fileGroup.parse(db, dataDescription);
+                if (this instanceof SparkLoadJob && fileGroup.isContainsBitmapColumns()) {
+                    ((SparkLoadJob)this).getTableWithBitmapColumn().add(fileGroup.getTableId());
+                }
                 fileGroupAggInfo.addFileGroup(fileGroup);
             }
         } finally {

--- a/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/LoadJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/LoadJob.java
@@ -887,6 +887,9 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
             finishTimestamp = txnState.getFinishTime();
             state = JobState.CANCELLED;
             Catalog.getCurrentGlobalTransactionMgr().getCallbackFactory().removeCallback(id);
+            if (this instanceof SparkLoadJob && !Catalog.getCurrentCatalog().isCheckpointThread()) {
+                Catalog.getCurrentCatalog().getLoadJobScheduler().removeRunningTable(getId(), ((SparkLoadJob)this).getTableWithBitmapColumn());
+            }
         } finally {
             writeUnlock();
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/SparkEtlJobHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/SparkEtlJobHandler.java
@@ -174,13 +174,13 @@ public class SparkEtlJobHandler {
             }
             if (retry >= GET_APPID_MAX_RETRY_TIMES) {
                 throw new LoadException(errMsg + "wait too much time for getting appid. spark app state: "
-                                                + state.toString());
+                        + state.toString());
             }
 
             // log
             if (retry % 10 == 0) {
                 LOG.info("spark appid that handle get is null. load job id: {}, state: {}, retry times: {}",
-                         loadJobId, state.toString(), retry);
+                        loadJobId, state.toString(), retry);
             }
             try {
                 Thread.sleep(GET_APPID_SLEEP_MS);

--- a/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/SparkLoadPendingTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/SparkLoadPendingTask.java
@@ -547,5 +547,4 @@ public class SparkLoadPendingTask extends LoadTask {
             throw new LoadException("Bitmap global dict should load data from hive table");
         }
     }
-
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/SparkLoadPendingTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/SparkLoadPendingTask.java
@@ -547,4 +547,5 @@ public class SparkLoadPendingTask extends LoadTask {
             throw new LoadException("Bitmap global dict should load data from hive table");
         }
     }
+
 }


### PR DESCRIPTION
#4058 implement a job granularity lock for global dict
**Design Ideas**
1 Implement a lock
    Class ```LoadJobScheduler``` keeps a ```runningBitmapTableMap``` which contains all running job's related Doris table.
    If a new Spark Load Job is submitted, ```LoadJobScheduler``` will check whether the Job's related Doris tables is already in ```runningBitmapTableMap```, if it is, the new Spark Load Job will be pending.

2 The cases to get lock
        2.1 LoadJobScheduler.submit success
        2.2 SparkLoadJob in ETL then replay

3 The cases to release lock
     3.1 SparkLoadJob in pending status then failed
     3.2 SparkLoadJob in etl then status failed
     3.3 SparkLoadJob in etl then status finish
     3.4 LoadJobScheduler.submit failed
     3.5 SparkLoadJob's state convert to Loading
     3.6 transaction abort