### PR TITLE
[Bug] Fix bug that tablet meta lock twice

### DIFF
--- a/be/src/olap/snapshot_manager.cpp
+++ b/be/src/olap/snapshot_manager.cpp
@@ -372,7 +372,7 @@ OLAPStatus SnapshotManager::_create_snapshot_files(
             if (res != OLAP_SUCCESS) {
                 break;
             }
-            ref_tablet->generate_tablet_meta_copy(new_tablet_meta);
+            ref_tablet->generate_tablet_meta_copy_unlocked(new_tablet_meta);
         } else {
             ReadLock rdlock(ref_tablet->get_header_lock_ptr());
             // get latest version
@@ -404,7 +404,7 @@ OLAPStatus SnapshotManager::_create_snapshot_files(
                 break;
             }
 
-            ref_tablet->generate_tablet_meta_copy(new_tablet_meta);
+            ref_tablet->generate_tablet_meta_copy_unlocked(new_tablet_meta);
         }
 
         vector<RowsetMetaSharedPtr> rs_metas;

--- a/be/src/olap/tablet.h
+++ b/be/src/olap/tablet.h
@@ -222,6 +222,8 @@ public:
     void build_tablet_report_info(TTabletInfo* tablet_info);
 
     void generate_tablet_meta_copy(TabletMetaSharedPtr new_tablet_meta) const;
+    // caller should hold the _meta_load before calling this method
+    void generate_tablet_meta_copy_unlocked(TabletMetaSharedPtr new_tablet_meta) const;
 
     // return a json string to show the compaction status of this tablet
     void get_compaction_status(std::string* json_result);

--- a/be/src/olap/tablet.h
+++ b/be/src/olap/tablet.h
@@ -222,7 +222,7 @@ public:
     void build_tablet_report_info(TTabletInfo* tablet_info);
 
     void generate_tablet_meta_copy(TabletMetaSharedPtr new_tablet_meta) const;
-    // caller should hold the _meta_load before calling this method
+    // caller should hold the _meta_lock before calling this method
     void generate_tablet_meta_copy_unlocked(TabletMetaSharedPtr new_tablet_meta) const;
 
     // return a json string to show the compaction status of this tablet

--- a/be/src/olap/task/engine_storage_migration_task.cpp
+++ b/be/src/olap/task/engine_storage_migration_task.cpp
@@ -231,7 +231,7 @@ void EngineStorageMigrationTask::_generate_new_header(
         const std::vector<RowsetSharedPtr>& consistent_rowsets,
         TabletMetaSharedPtr new_tablet_meta) {
     DCHECK(store != nullptr);
-    tablet->generate_tablet_meta_copy(new_tablet_meta);
+    tablet->generate_tablet_meta_copy_unlocked(new_tablet_meta);
 
     vector<RowsetMetaSharedPtr> rs_metas;
     for (auto& rs : consistent_rowsets) {


### PR DESCRIPTION
## Proposed changes

The tablet meta lock may already be hold before calling
`generate_tablet_meta_copy()`, so we need provide a unlocked
version of `generate_tablet_meta_copy()`.
This bug  is introduced by #4061 

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have create an issue on Fix #4111
- [ ] Commit messages in my PR start with the related issues ID, like "#4071 Add pull request template to doris project"
- [x] Compiling and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If this change need a document change, I have updated the document
- [ ] Any dependent changes have been merged