### PR TITLE
[Bug] fix use-after-poison bug in ut schema_change_test 

### DIFF
--- a/be/test/olap/schema_change_test.cpp
+++ b/be/test/olap/schema_change_test.cpp
@@ -873,9 +873,8 @@ TEST_F(TestColumn, ConvertCharToHLL) {
     RowCursor mv_row_cursor;
     mv_row_cursor.init(mv_tablet_schema);
     mutable_block.get_row(0, &mv_row_cursor);
-
     auto dst_slice = reinterpret_cast<Slice*>(mv_row_cursor.cell_ptr(1));
-    HyperLogLog hll(dst_slice->data);
+    HyperLogLog hll(*dst_slice);
     ASSERT_EQ(hll.estimate_cardinality(), 1);
 }
 }

--- a/be/test/olap/schema_change_test.cpp
+++ b/be/test/olap/schema_change_test.cpp
@@ -873,6 +873,7 @@ TEST_F(TestColumn, ConvertCharToHLL) {
     RowCursor mv_row_cursor;
     mv_row_cursor.init(mv_tablet_schema);
     mutable_block.get_row(0, &mv_row_cursor);
+
     auto dst_slice = reinterpret_cast<Slice*>(mv_row_cursor.cell_ptr(1));
     HyperLogLog hll(*dst_slice);
     ASSERT_EQ(hll.estimate_cardinality(), 1);


### PR DESCRIPTION
Ref issue https://github.com/apache/incubator-doris/issues/4116
Using slice->data to create HyperLogLog, it will exec `HyperLogLog(Slice(const char*))`. Then `Slice(const char*)` will use `strlen(data)` to calc the size. But the slice in this ut isn't a C-string. Need to use `Slice`.