### PR TITLE
[Enhancement] Add HTTP RestFul interface to get QueryPlan by QueryID

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -519,6 +519,8 @@ namespace config {
     CONF_Int64(brpc_max_body_size, "209715200");
     // Max unwritten bytes in each socket, if the limit is reached, Socket.Write fails with EOVERCROWDED
     CONF_Int64(brpc_socket_max_unwritten_bytes, "67108864");
+    // If batch size large than brpc_attachment_threashold, use attachment instead
+    CONF_Int64(brpc_attachment_threashold, "67108864");
 
     // max number of txns for every txn_partition_map in txn manager
     // this is a self protection to avoid too many txns saving in manager

--- a/be/src/runtime/data_stream_sender.cpp
+++ b/be/src/runtime/data_stream_sender.cpp
@@ -164,7 +164,7 @@ private:
     int64_t _packet_seq;
 
     // we're accumulating rows into this batch
-    boost::scoped_ptr<RowBatch> _batch;
+    std::unique_ptr<RowBatch> _batch;
 
     bool _need_close;
     int _be_number;
@@ -227,7 +227,11 @@ Status DataStreamSender::Channel::send_batch(PRowBatch* batch, bool eos) {
     }
 
     _brpc_request.set_eos(eos);
-    if (batch != nullptr) {
+    if (batch != nullptr && RowBatch::get_batch_size(*batch) > config::brpc_socket_max_unwritten_bytes) {
+        std::string* tuple_data_to_attachment = batch->release_tuple_data();
+        butil::IOBuf& io_buf = _closure->cntl.request_attachment();
+        io_buf.append(tuple_data_to_attachment->c_str(), tuple_data_to_attachment->size());
+        batch->mutable_tuple_data(); // to padding the required tuple_data field in PB
         _brpc_request.set_allocated_row_batch(batch);
     }
     _brpc_request.set_packet_seq(_packet_seq++);
@@ -270,12 +274,7 @@ Status DataStreamSender::Channel::add_row(TupleRow* row) {
 }
 
 Status DataStreamSender::Channel::send_current_batch(bool eos) {
-    {
-        SCOPED_TIMER(_parent->_serialize_batch_timer);
-        int uncompressed_bytes = _batch->serialize(&_pb_batch);
-        COUNTER_UPDATE(_parent->_bytes_sent_counter, RowBatch::get_batch_size(_pb_batch));
-        COUNTER_UPDATE(_parent->_uncompressed_bytes_counter, uncompressed_bytes);
-    }
+    _parent->serialize_batch(_batch.get(), &_pb_batch, 1);
     _batch->reset();
     RETURN_IF_ERROR(send_batch(&_pb_batch, eos));
     return Status::OK();

--- a/be/src/service/brpc.h
+++ b/be/src/service/brpc.h
@@ -56,3 +56,4 @@
 #include <brpc/closure_guard.h>
 #include <brpc/reloadable_flags.h>
 #include <brpc/protocol.h>
+#include <butil/strings/string_piece.h>

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -49,6 +49,13 @@ void PInternalServiceImpl<T>::transmit_data(google::protobuf::RpcController* cnt
                                          google::protobuf::Closure* done) {
     VLOG_ROW << "transmit data: fragment_instance_id=" << print_id(request->finst_id())
             << " node=" << request->node_id();
+    brpc::Controller* cntl = static_cast<brpc::Controller*>(cntl_base);
+    if (cntl->request_attachment().size() > 0) {
+        PRowBatch* batch = (const_cast<PTransmitDataParams*>(request))->mutable_row_batch();
+        butil::IOBuf& io_buf = cntl->request_attachment();
+        std::string* tuple_data = batch->mutable_tuple_data();
+        io_buf.copy_to(tuple_data);
+    }
     _exec_env->stream_mgr()->transmit_data(request, &done);
     if (done != nullptr) {
         done->Run();


### PR DESCRIPTION
1. Doris is lack of get QueryPlan by QueryID, so I add it.
2. Insert is not be taken into consideration when been profiled.
   Now I add it into QueryDetailQueue to be collected.