### PR TITLE
[Bug][Load][Json] #4124 Load json format with stream load failed

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -303,11 +303,14 @@ namespace config {
     CONF_Int64(load_data_reserve_hours, "4");
     // log error log will be removed after this time
     CONF_mInt64(load_error_log_reserve_hours, "48");
-    // Deprecated, use streaming_load_max_mb instead
-    // CONF_Int64(mini_load_max_mb, "2048");
     CONF_Int32(number_tablet_writer_threads, "16");
 
+    // The maximum amount of data that can be processed by a stream load
     CONF_mInt64(streaming_load_max_mb, "10240");
+    // Some data formats, such as JSON, cannot be streamed.
+    // Therefore, it is necessary to limit the maximum number of
+    // such data when using stream load to prevent excessive memory consumption.
+    CONF_mInt64(streaming_load_max_batch_size_mb, "100");
     // the alive time of a TabletsChannel.
     // If the channel does not receive any data till this time,
     // the channel will be removed.

--- a/be/src/exec/json_scanner.cpp
+++ b/be/src/exec/json_scanner.cpp
@@ -243,6 +243,7 @@ Status JsonReader::_parse_json_doc(bool* eof) {
     uint8_t* json_str = nullptr;
     size_t length = 0;
     RETURN_IF_ERROR(_file_reader->read_one_message(&json_str, &length));
+    LOG(INFO) << "cmy get json length: " << length;
     if (length == 0) {
         *eof = true;
         return Status::OK();

--- a/be/src/exec/json_scanner.cpp
+++ b/be/src/exec/json_scanner.cpp
@@ -243,7 +243,6 @@ Status JsonReader::_parse_json_doc(bool* eof) {
     uint8_t* json_str = nullptr;
     size_t length = 0;
     RETURN_IF_ERROR(_file_reader->read_one_message(&json_str, &length));
-    LOG(INFO) << "cmy get json length: " << length;
     if (length == 0) {
         *eof = true;
         return Status::OK();

--- a/be/src/http/action/stream_load.cpp
+++ b/be/src/http/action/stream_load.cpp
@@ -218,7 +218,7 @@ Status StreamLoadAction::_on_header(HttpRequest* http_req, StreamLoadContext* ct
             LOG(WARNING) << "body exceed max size." << ctx->brief();
 
             std::stringstream ss;
-            ss << "body exceed max size, max_body_bytes=" << max_body_bytes;
+            ss << "body exceed max size: " << max_body_bytes << ", limit: " << max_body_bytes;
             return Status::InternalError(ss.str());
         }
     } else {
@@ -234,10 +234,18 @@ Status StreamLoadAction::_on_header(HttpRequest* http_req, StreamLoadContext* ct
     } else {
         ctx->format = parse_format(http_req->header(HTTP_FORMAT_KEY));
         if (ctx->format == TFileFormatType::FORMAT_UNKNOWN) {
-            LOG(WARNING) << "unknown data format." << ctx->brief();
             std::stringstream ss;
             ss << "unknown data format, format=" << http_req->header(HTTP_FORMAT_KEY);
             return Status::InternalError(ss.str());
+        }
+
+        size_t max_body_bytes = config::streaming_load_max_batch_size_mb * 1024 * 1024;
+        if (ctx->format == TFileFormatType::FORMAT_JSON) {
+            if (ctx->body_bytes > max_body_bytes) {
+                std::stringstream ss;
+                ss << "body exceed max size of json format: " << ctx->body_bytes << ", limit: " << max_body_bytes;
+                return Status::InternalError(ss.str());
+            }
         }
     }
 
@@ -312,7 +320,10 @@ Status StreamLoadAction::_process_put(HttpRequest* http_req, StreamLoadContext* 
     request.formatType = ctx->format;
     request.__set_loadId(ctx->id.to_thrift());
     if (ctx->use_streaming) {
-        auto pipe = std::make_shared<StreamLoadPipe>(1024 * 1024, 64* 1024, ctx->body_bytes);
+        auto pipe = std::make_shared<StreamLoadPipe>(
+                1024 * 1024 /* max_buffered_bytes */,
+                64 * 1024 /* min_chunk_size */,
+                ctx->body_bytes /* total_length */);
         RETURN_IF_ERROR(_exec_env->load_stream_mgr()->put(ctx->id, pipe));
         request.fileType = TFileType::FILE_STREAM;
         ctx->body_sink = pipe;

--- a/be/src/http/action/stream_load.cpp
+++ b/be/src/http/action/stream_load.cpp
@@ -312,7 +312,7 @@ Status StreamLoadAction::_process_put(HttpRequest* http_req, StreamLoadContext* 
     request.formatType = ctx->format;
     request.__set_loadId(ctx->id.to_thrift());
     if (ctx->use_streaming) {
-        auto pipe = std::make_shared<StreamLoadPipe>();
+        auto pipe = std::make_shared<StreamLoadPipe>(1024 * 1024, 64* 1024, ctx->body_bytes);
         RETURN_IF_ERROR(_exec_env->load_stream_mgr()->put(ctx->id, pipe));
         request.fileType = TFileType::FILE_STREAM;
         ctx->body_sink = pipe;

--- a/be/src/runtime/stream_load/stream_load_pipe.h
+++ b/be/src/runtime/stream_load/stream_load_pipe.h
@@ -90,10 +90,14 @@ public:
     // just get the next buffer directly from the buffer queue, because one buffer contains a complete piece of data.
     // Otherwise, this should be a stream load task that needs to read the specified amount of data.
     Status read_one_message(uint8_t** data, size_t* length) override {
-        if (_total_length == 0 || _total_length < -1) {
+        if (_total_length < -1) {
             std::stringstream ss;
             ss << "invalid, _total_length is: " << _total_length;
             return Status::InternalError(ss.str());
+        } else if (_total_length == 0) {
+            // no data
+            *length = 0;
+            return Status::OK();
         }
 
         if (_total_length == -1) {

--- a/be/src/runtime/stream_load/stream_load_pipe.h
+++ b/be/src/runtime/stream_load/stream_load_pipe.h
@@ -34,7 +34,7 @@ class StreamLoadPipe : public MessageBodySink, public FileReader {
 public:
     StreamLoadPipe(size_t max_buffered_bytes = 1024 * 1024,
                    size_t min_chunk_size = 64 * 1024,
-                   size_t total_length = -1)
+                   int64_t total_length = -1)
         : _buffered_bytes(0),
         _max_buffered_bytes(max_buffered_bytes),
         _min_chunk_size(min_chunk_size),
@@ -86,15 +86,29 @@ public:
         return _append(buf);
     }
 
+    // If _total_length == -1, this should be a Kafka routine load task,
+    // just get the next buffer directly from the buffer queue, because one buffer contains a complete piece of data.
+    // Otherwise, this should be a stream load task that needs to read the specified amount of data.
     Status read_one_message(uint8_t** data, size_t* length) override {
-        if (_total_length == -1) {
-            return Status::InternalError("invalid call");
+        if (_total_length == 0 || _total_length < -1) {
+            std::stringstream ss;
+            ss << "invalid, _total_length is: " << _total_length;
+            return Status::InternalError(ss.str());
         }
-        *data = new uint8_t[_total_length];
 
+        if (_total_length == -1) {
+            return _read_next_buffer(data, length);
+        }
+
+        // _total_length > 0, read the entire data
+        *data = new uint8_t[_total_length];
         *length = _total_length;
         bool eof = false;
-        return read(*data, length, &eof);
+        Status st = read(*data, length, &eof);
+        if (eof) {
+            *length = 0;
+        }
+        return st;
     }
 
     Status read(uint8_t* data, size_t* data_size, bool* eof) override {
@@ -182,6 +196,34 @@ public:
     }
 
 private:
+    // read the next buffer from _buf_queue
+    Status _read_next_buffer(uint8_t** data, size_t* length) {
+        std::unique_lock<std::mutex> l(_lock);
+        while (!_cancelled && !_finished && _buf_queue.empty()) {
+            _get_cond.wait(l);
+        }
+        // cancelled
+        if (_cancelled) {
+            return Status::InternalError("cancelled");
+        }
+        // finished
+        if (_buf_queue.empty()) {
+            DCHECK(_finished);
+            *data = nullptr;
+            *length = 0;
+            return Status::OK();
+        }
+        auto buf = _buf_queue.front();
+        *length = buf->remaining();
+        *data = new uint8_t[*length];
+        buf->get_bytes((char*)(*data) , *length);
+
+        _buf_queue.pop_front();
+        _buffered_bytes -= buf->limit;
+        _put_cond.notify_one();
+        return Status::OK();
+    }
+
     Status _append(const ByteBufferPtr& buf) {
         {
             std::unique_lock<std::mutex> l(_lock);
@@ -207,7 +249,14 @@ private:
     size_t _buffered_bytes;
     size_t _max_buffered_bytes;
     size_t _min_chunk_size;
-    size_t _total_length;
+    // The total amount of data expected to be read.
+    // In some scenarios, such as loading json format data through stream load,
+    // the data needs to be completely read before it can be parsed,
+    // so the total size of the data needs to be known.
+    // The default is -1, which means that the data arrives in a stream
+    // and the length is unknown.
+    // size_t is unsigned, so use int64_t
+    int64_t _total_length = -1;
     std::deque<ByteBufferPtr> _buf_queue;
     std::condition_variable _put_cond;
     std::condition_variable _get_cond;

--- a/docs/en/administrator-guide/config/be_config.md
+++ b/docs/en/administrator-guide/config/be_config.md
@@ -437,6 +437,22 @@ Indicates how many tablets in this data directory failed to load. At the same ti
 
 ### `streaming_load_max_mb`
 
+* Type: int64
+* Description: Used to limit the maximum amount of data allowed in one Stream load. The unit is MB.
+* Default value: 10240
+* Dynamically modify: yes
+
+Stream Load is generally suitable for loading data less than a few GB, not suitable for loading` too large data.
+
+### `streaming_load_max_batch_size_mb`
+
+* Type: int64
+* Description: For some data formats, such as JSON, it is used to limit the maximum amount of data allowed in one Stream load. The unit is MB.
+* Default value: 100
+* Dynamically modify: yes
+
+Some data formats, such as JSON, cannot be split. Doris must read all the data into the memory before parsing can begin. Therefore, this value is used to limit the maximum amount of data that can be loaded in a single Stream load.
+
 ### `streaming_load_rpc_max_alive_time_sec`
 
 ### `sync_tablet_meta`

--- a/docs/zh-CN/administrator-guide/config/be_config.md
+++ b/docs/zh-CN/administrator-guide/config/be_config.md
@@ -436,6 +436,22 @@ load tablets from header failed, failed tablets size: xxx, path=xxx
 
 ### `streaming_load_max_mb`
 
+* 类型：int64
+* 描述：用于限制一次 Stream load 导入中，允许的最大数据量。单位 MB。
+* 默认值： 10240
+* 可动态修改：是
+
+Stream Load 一般适用于导入几个GB以内的数据，不适合导入过大的数据。
+
+### `streaming_load_max_batch_size_mb`
+
+* 类型：int64
+* 描述：对于某些数据格式，如 JSON，用于限制一次 Stream load 导入中，允许的最大数据量。单位 MB。
+* 默认值： 100
+* 可动态修改：是
+
+一些数据格式，如 JSON，无法进行拆分处理，必须读取全部数据到内存后才能开始解析，因此，这个值用于限制此类格式数据单次导入最大数据量。
+
 ### `streaming_load_rpc_max_alive_time_sec`
 
 ### `sync_tablet_meta`


### PR DESCRIPTION
## Proposed changes

Stream load should read all the data completely before parsing the json.
And also add a new BE config `streaming_load_max_batch_read_mb`
to limit the data size when loading json data.

Fix: #4124

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have create an issue on #4124, and have described the bug/feature there in detail
- [x] Commit messages in my PR start with the related issues ID, like "#4071 Add pull request template to doris project"
- [x] Compiling and unit tests pass locally with my changes
- [x] If this change need a document change, I have updated the document
- [x] Any dependent changes have been merged