### PR TITLE
Fixbug: json load

### DIFF
--- a/be/src/exprs/json_functions.cpp
+++ b/be/src/exprs/json_functions.cpp
@@ -299,6 +299,23 @@ rapidjson::Value* JsonFunctions::get_json_array_from_parsed_json(
     return root;
 }
 
+
+rapidjson::Value* JsonFunctions::get_json_object_from_parsed_json(
+        const std::vector<JsonPath>& parsed_paths,
+        rapidjson::Value* document,
+        rapidjson::Document::AllocatorType& mem_allocator) {
+
+    if (!parsed_paths[0].is_valid) {
+        return nullptr;
+    }
+
+    rapidjson::Value* root = match_value(parsed_paths, document, mem_allocator, true);
+    if (root == nullptr || root == document) { // not found
+        return nullptr;
+    }
+    return root;
+}
+
 void JsonFunctions::json_path_prepare(
         doris_udf::FunctionContext* context,
         doris_udf::FunctionContext::FunctionStateScope scope) {

--- a/be/src/exprs/json_functions.h
+++ b/be/src/exprs/json_functions.h
@@ -95,6 +95,11 @@ public:
             rapidjson::Value* document,
             rapidjson::Document::AllocatorType& mem_allocator);
 
+    static rapidjson::Value* get_json_object_from_parsed_json(
+            const std::vector<JsonPath>& parsed_paths,
+            rapidjson::Value* document,
+            rapidjson::Document::AllocatorType& mem_allocator);
+
     static void json_path_prepare(
             doris_udf::FunctionContext*,
             doris_udf::FunctionContext::FunctionStateScope);

--- a/be/src/http/action/stream_load.cpp
+++ b/be/src/http/action/stream_load.cpp
@@ -371,11 +371,14 @@ Status StreamLoadAction::_process_put(HttpRequest* http_req, StreamLoadContext* 
             return Status::InvalidArgument("Invalid mem limit format");
         }
     }
-    if (!http_req->header(HTTP_EXEC_JSONPATHS).empty()) {
-        request.__set_jsonpaths(http_req->header(HTTP_EXEC_JSONPATHS));
+    if (!http_req->header(HTTP_JSONPATHS).empty()) {
+        request.__set_jsonpaths(http_req->header(HTTP_JSONPATHS));
     }
-    if (!http_req->header(HTTP_EXEC_STRIP_OUTER_ARRAY).empty()) {
-        if (boost::iequals(http_req->header(HTTP_EXEC_STRIP_OUTER_ARRAY), "true")) {
+    if (!http_req->header(HTTP_JSONROOT).empty()) {
+       request.__set_json_root(http_req->header(HTTP_JSONROOT));
+    }
+    if (!http_req->header(HTTP_STRIP_OUTER_ARRAY).empty()) {
+        if (boost::iequals(http_req->header(HTTP_STRIP_OUTER_ARRAY), "true")) {
             request.__set_strip_outer_array(true);
         } else {
             request.__set_strip_outer_array(false);

--- a/be/src/http/http_common.h
+++ b/be/src/http/http_common.h
@@ -36,8 +36,9 @@ static const std::string HTTP_NEGATIVE = "negative";
 static const std::string HTTP_STRICT_MODE = "strict_mode";
 static const std::string HTTP_TIMEZONE = "timezone";
 static const std::string HTTP_EXEC_MEM_LIMIT = "exec_mem_limit";
-static const std::string HTTP_EXEC_JSONPATHS  = "jsonpaths";
-static const std::string HTTP_EXEC_STRIP_OUTER_ARRAY = "strip_outer_array";
+static const std::string HTTP_JSONPATHS  = "jsonpaths";
+static const std::string HTTP_JSONROOT  = "json_root";
+static const std::string HTTP_STRIP_OUTER_ARRAY = "strip_outer_array";
 
 static const std::string HTTP_100_CONTINUE = "100-continue";
 

--- a/be/test/exec/json_scanner_test.cpp
+++ b/be/test/exec/json_scanner_test.cpp
@@ -401,6 +401,8 @@ TEST_F(JsonSannerTest, normal_simple_arrayjson) {
         range.start_offset = 0;
         range.size = -1;
         range.format_type = TFileFormatType::FORMAT_JSON;
+        range.strip_outer_array = true;
+        range.__isset.strip_outer_array = true;
         range.splittable = true;
         range.path = "./be/test/exec/test_data/json_scanner/test_simple2.json";
         range.file_type = TFileType::FILE_LOCAL;

--- a/docs/en/sql-reference/sql-statements/Data Manipulation/ROUTINE LOAD.md
+++ b/docs/en/sql-reference/sql-statements/Data Manipulation/ROUTINE LOAD.md
@@ -178,6 +178,9 @@ FROM data_source
     8. `strip_outer_array`
         Boolean type, true to indicate that json data starts with an array object and flattens objects in the array object, default value is false.
 
+    9. `json_root`
+        json_root is a valid JSONPATH string that specifies the root node of the JSON Document. The default value is "".
+
 5. data_source
 
     The type of data source. Current support:
@@ -461,6 +464,36 @@ FROM data_source
      1）If the json data starts as an array and each object in the array is a record, you need to set the strip_outer_array to true to represent the flat array.
      2）If the json data starts with an array, and each object in the array is a record, our ROOT node is actually an object in the array when we set jsonpath.
 
+6. User specifies the json_root node
+        CREATE ROUTINE LOAD example_db.test1 ON example_tbl
+        COLUMNS(category, author, price, timestamp, dt=from_unixtime(timestamp, '%Y%m%d'))
+        PROPERTIES
+        (
+            "desired_concurrent_number"="3",
+            "max_batch_interval" = "20",
+            "max_batch_rows" = "300000",
+            "max_batch_size" = "209715200",
+            "strict_mode" = "false",
+            "format" = "json",
+            "jsonpaths" = "[\"$.category\",\"$.author\",\"$.price\",\"$.timestamp\"]",
+            "strip_outer_array" = "true",
+            "json_root" = "$.RECORDS"
+        )
+        FROM KAFKA
+        (
+            "kafka_broker_list" = "broker1:9092,broker2:9092,broker3:9092",
+            "kafka_topic" = "my_topic",
+            "kafka_partitions" = "0,1,2",
+            "kafka_offsets" = "0,0,0"
+        );
+   For example json data:
+        {
+        "RECORDS":[
+            {"category":"11","title":"SayingsoftheCentury","price":895,"timestamp":1589191587},
+            {"category":"22","author":"2avc","price":895,"timestamp":1589191487},
+            {"category":"33","author":"3avc","title":"SayingsoftheCentury","timestamp":1589191387}
+            ]
+        }
 ## keyword
 
     CREATE, ROUTINE, LOAD

--- a/docs/en/sql-reference/sql-statements/Data Manipulation/STREAM LOAD.md
+++ b/docs/en/sql-reference/sql-statements/Data Manipulation/STREAM LOAD.md
@@ -120,6 +120,9 @@ There are two ways to import json: simple mode and matched mode. If jsonpath is 
 `strip_outer_array`
 Boolean type, true to indicate that json data starts with an array object and flattens objects in the array object, default value is false.
 
+`json_root`
+json_root is a valid JSONPATH string that specifies the root node of the JSON Document. The default value is "".
+
 RETURN VALUES
 
 After the load is completed, the related content of this load will be returned in Json format. Current field included
@@ -213,7 +216,7 @@ Where url is the url given by ErrorURL.
                {"category":"Linux","author":"avc","title":"Linux kernel","price":195}
               ]
 11. Matched load json by jsonpaths
-       json data：
+       For example json data:
            [
            {"category":"xuxb111","author":"1avc","title":"SayingsoftheCentury","price":895},
            {"category":"xuxb222","author":"2avc","title":"SayingsoftheCentury","price":895},
@@ -224,6 +227,18 @@ Where url is the url given by ErrorURL.
        Tips：
         1）If the json data starts as an array and each object in the array is a record, you need to set the strip_outer_array to true to represent the flat array.
         2）If the json data starts with an array, and each object in the array is a record, our ROOT node is actually an object in the array when we set jsonpath.
+
+12. User specifies the json_root node
+       For example json data:
+            {
+            "RECORDS":[
+                {"category":"11","title":"SayingsoftheCentury","price":895,"timestamp":1589191587},
+                {"category":"22","author":"2avc","price":895,"timestamp":1589191487},
+                {"category":"33","author":"3avc","title":"SayingsoftheCentury","timestamp":1589191387}
+                ]
+            }
+       Matched imports are made by specifying jsonpath parameter, such as `category`, `author`, and `price`, for example: 
+         curl --location-trusted -u root  -H "columns: category, price, author" -H "label:123" -H "format: json" -H "jsonpaths: [\"$.category\",\"$.price\",\"$.author\"]" -H "strip_outer_array: true" -H "json_root: $.RECORDS" -T testData http://host:port/api/testDb/testTbl/_stream_load
 
 ## keyword
 

--- a/docs/zh-CN/sql-reference/sql-statements/Data Manipulation/ROUTINE LOAD.md
+++ b/docs/zh-CN/sql-reference/sql-statements/Data Manipulation/ROUTINE LOAD.md
@@ -158,6 +158,10 @@ under the License.
 
             布尔类型，为true表示json数据以数组对象开始且将数组对象中进行展平，默认值是false。
 
+        9. json_root
+
+        json_root为合法的jsonpath字符串，用于指定json document的根节点，默认值为""。
+
     5. data_source
 
         数据源的类型。当前支持：
@@ -398,6 +402,36 @@ under the License.
            1）如果json数据是以数组开始，并且数组中每个对象是一条记录，则需要将strip_outer_array设置成true，表示展平数组。
            2）如果json数据是以数组开始，并且数组中每个对象是一条记录，在设置jsonpath时，我们的ROOT节点实际上是数组中对象。
 
+    6. 用户指定根节点json_root
+        CREATE ROUTINE LOAD example_db.test1 ON example_tbl
+        COLUMNS(category, author, price, timestamp, dt=from_unixtime(timestamp, '%Y%m%d'))
+        PROPERTIES
+        (
+            "desired_concurrent_number"="3",
+            "max_batch_interval" = "20",
+            "max_batch_rows" = "300000",
+            "max_batch_size" = "209715200",
+            "strict_mode" = "false",
+            "format" = "json",
+            "jsonpaths" = "[\"$.category\",\"$.author\",\"$.price\",\"$.timestamp\"]",
+            "strip_outer_array" = "true",
+            "json_root" = "$.RECORDS"
+        )
+        FROM KAFKA
+        (
+            "kafka_broker_list" = "broker1:9092,broker2:9092,broker3:9092",
+            "kafka_topic" = "my_topic",
+            "kafka_partitions" = "0,1,2",
+            "kafka_offsets" = "0,0,0"
+        );
+   json数据格式:
+        {
+        "RECORDS":[
+            {"category":"11","title":"SayingsoftheCentury","price":895,"timestamp":1589191587},
+            {"category":"22","author":"2avc","price":895,"timestamp":1589191487},
+            {"category":"33","author":"3avc","title":"SayingsoftheCentury","timestamp":1589191387}
+            ]
+        }
 ## keyword
 
     CREATE,ROUTINE,LOAD

--- a/docs/zh-CN/sql-reference/sql-statements/Data Manipulation/STREAM LOAD.md
+++ b/docs/zh-CN/sql-reference/sql-statements/Data Manipulation/STREAM LOAD.md
@@ -89,6 +89,8 @@ under the License.
            ]
            当strip_outer_array为true，最后导入到doris中会生成两行数据。
 
+        json_root: json_root为合法的jsonpath字符串，用于指定json document的根节点，默认值为""。
+
     RETURN VALUES
         导入完成后，会以Json格式返回这次导入的相关内容。当前包括一下字段
         Status: 导入最后的状态。
@@ -171,6 +173,18 @@ under the License.
          说明：
            1）如果json数据是以数组开始，并且数组中每个对象是一条记录，则需要将strip_outer_array设置成true，表示展平数组。
            2）如果json数据是以数组开始，并且数组中每个对象是一条记录，在设置jsonpath时，我们的ROOT节点实际上是数组中对象。
+
+    12. 用户指定json根节点
+       json数据格式:
+            {
+            "RECORDS":[
+                {"category":"11","title":"SayingsoftheCentury","price":895,"timestamp":1589191587},
+                {"category":"22","author":"2avc","price":895,"timestamp":1589191487},
+                {"category":"33","author":"3avc","title":"SayingsoftheCentury","timestamp":1589191387}
+                ]
+            }
+        通过指定jsonpath进行精准导入，例如只导入category、author、price三个属性  
+         curl --location-trusted -u root  -H "columns: category, price, author" -H "label:123" -H "format: json" -H "jsonpaths: [\"$.category\",\"$.price\",\"$.author\"]" -H "strip_outer_array: true" -H "json_root: $.RECORDS" -T testData http://host:port/api/testDb/testTbl/_stream_load
 
 ## keyword
     STREAM,LOAD

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateRoutineLoadStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateRoutineLoadStmt.java
@@ -92,6 +92,7 @@ public class CreateRoutineLoadStmt extends DdlStmt {
     public static final String FORMAT = "format";// the value is csv or json, default is csv
     public static final String STRIP_OUTER_ARRAY = "strip_outer_array";
     public static final String JSONPATHS = "jsonpaths";
+    public static final String JSONROOT = "json_root";
 
     // kafka type properties
     public static final String KAFKA_BROKER_LIST_PROPERTY = "kafka_broker_list";
@@ -113,6 +114,7 @@ public class CreateRoutineLoadStmt extends DdlStmt {
             .add(FORMAT)
             .add(JSONPATHS)
             .add(STRIP_OUTER_ARRAY)
+            .add(JSONROOT)
             .add(LoadStmt.STRICT_MODE)
             .add(LoadStmt.TIMEZONE)
             .build();
@@ -149,10 +151,10 @@ public class CreateRoutineLoadStmt extends DdlStmt {
      *   1) dataFormat = "json"
      *   2) jsonPaths = "$.XXX.xxx"
      */
-    private String format   = ""; //default is csv.
-    private String jsonPaths     = "";
+    private String format     = ""; //default is csv.
+    private String jsonPaths  = "";
+    private String jsonRoot   = ""; // MUST be a jsonpath string
     private boolean stripOuterArray = false;
-
 
     // kafka related properties
     private String kafkaBrokerList;
@@ -238,6 +240,10 @@ public class CreateRoutineLoadStmt extends DdlStmt {
 
     public String getJsonPaths() {
         return jsonPaths;
+    }
+
+    public String getJsonRoot() {
+        return jsonRoot;
     }
 
     public String getKafkaBrokerList() {
@@ -364,6 +370,7 @@ public class CreateRoutineLoadStmt extends DdlStmt {
             } else if (format.equalsIgnoreCase("json")) {
                 format = "json";
                 jsonPaths = jobProperties.get(JSONPATHS);
+                jsonRoot = jobProperties.get(JSONROOT);
                 stripOuterArray = Boolean.valueOf(jobProperties.get(STRIP_OUTER_ARRAY));
             } else {
                 throw new UserException("Format type is invalid. format=`" + format + "`");

--- a/fe/fe-core/src/main/java/org/apache/doris/load/routineload/RoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/routineload/RoutineLoadJob.java
@@ -61,7 +61,6 @@ import org.apache.doris.transaction.AbstractTxnStateChangeCallback;
 import org.apache.doris.transaction.TransactionException;
 import org.apache.doris.transaction.TransactionState;
 import org.apache.doris.transaction.TransactionStatus;
-
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
@@ -70,7 +69,6 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -184,6 +182,7 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback impl
     private static final String PROPS_FORMAT = "format";
     private static final String PROPS_STRIP_OUTER_ARRAY = "strip_outer_array";
     private static final String PROPS_JSONPATHS = "jsonpaths";
+    private static final String PROPS_JSONROOT = "json_root";
 
     protected int currentTaskConcurrentNum;
     protected RoutineLoadProgress progress;
@@ -285,12 +284,18 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback impl
             jobProperties.put(PROPS_FORMAT, "csv");
             jobProperties.put(PROPS_STRIP_OUTER_ARRAY, "false");
             jobProperties.put(PROPS_JSONPATHS, "");
+            jobProperties.put(PROPS_JSONROOT, "");
         } else if (stmt.getFormat().equals("json")) {
             jobProperties.put(PROPS_FORMAT, "json");
             if (!Strings.isNullOrEmpty(stmt.getJsonPaths())) {
                 jobProperties.put(PROPS_JSONPATHS, stmt.getJsonPaths());
             } else {
                 jobProperties.put(PROPS_JSONPATHS, "");
+            }
+            if (!Strings.isNullOrEmpty(stmt.getJsonRoot())) {
+                jobProperties.put(PROPS_JSONROOT, stmt.getJsonRoot());
+            } else {
+                jobProperties.put(PROPS_JSONROOT, "");
             }
             if (stmt.isStripOuterArray()) {
                 jobProperties.put(PROPS_STRIP_OUTER_ARRAY, "true");
@@ -466,6 +471,14 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback impl
 
     public String getJsonPaths() {
         String value = jobProperties.get(PROPS_JSONPATHS);
+        if (value == null) {
+            return "";
+        }
+        return value;
+    }
+
+    public String getJsonRoot() {
+        String value = jobProperties.get(PROPS_JSONROOT);
         if (value == null) {
             return "";
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/StreamLoadScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/StreamLoadScanNode.java
@@ -103,6 +103,9 @@ public class StreamLoadScanNode extends LoadScanNode {
             if (!streamLoadTask.getJsonPaths().isEmpty()) {
                 rangeDesc.setJsonpaths(streamLoadTask.getJsonPaths());
             }
+            if (!streamLoadTask.getJsonRoot().isEmpty()) {
+                rangeDesc.setJson_root(streamLoadTask.getJsonRoot());
+            }
             rangeDesc.setStrip_outer_array(streamLoadTask.isStripOuterArray());
         }
         rangeDesc.splittable = false;

--- a/fe/fe-core/src/main/java/org/apache/doris/task/StreamLoadTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/task/StreamLoadTask.java
@@ -53,6 +53,7 @@ public class StreamLoadTask {
     private TFileFormatType formatType;
     private boolean stripOuterArray;
     private String jsonPaths;
+    private String jsonRoot;
 
     // optional
     private List<ImportColumnDesc> columnExprDescs = Lists.newArrayList();
@@ -72,6 +73,7 @@ public class StreamLoadTask {
         this.fileType = fileType;
         this.formatType = formatType;
         this.jsonPaths = "";
+        this.jsonRoot = "";
         this.stripOuterArray = false;
     }
 
@@ -143,6 +145,14 @@ public class StreamLoadTask {
         this.jsonPaths = jsonPaths;
     }
 
+    public String getJsonRoot() {
+        return jsonRoot;
+    }
+
+    public void setJsonRoot(String jsonRoot) {
+        this.jsonRoot = jsonRoot;
+    }
+
     public static StreamLoadTask fromTStreamLoadPutRequest(TStreamLoadPutRequest request, Database db) throws UserException {
         StreamLoadTask streamLoadTask = new StreamLoadTask(request.getLoadId(), request.getTxnId(),
                                                            request.getFileType(), request.getFormatType());
@@ -194,6 +204,9 @@ public class StreamLoadTask {
             if (request.getJsonpaths() != null) {
                 jsonPaths = request.getJsonpaths();
             }
+            if (request.getJson_root() != null) {
+                jsonRoot = request.getJson_root();
+            }
             stripOuterArray = request.isStrip_outer_array();
         }
     }
@@ -224,6 +237,9 @@ public class StreamLoadTask {
         timeout = (int) routineLoadJob.getMaxBatchIntervalS() * 2;
         if (!routineLoadJob.getJsonPaths().isEmpty()) {
             jsonPaths = routineLoadJob.getJsonPaths();
+        }
+        if (!routineLoadJob.getJsonRoot().isEmpty()) {
+            jsonRoot = routineLoadJob.getJsonRoot();
         }
         stripOuterArray = routineLoadJob.isStripOuterArray();
     }

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -551,6 +551,7 @@ struct TStreamLoadPutRequest {
     23: optional bool strip_outer_array
     24: optional string jsonpaths
     25: optional i64 thrift_rpc_timeout_ms
+    26: optional string json_root
 }
 
 struct TStreamLoadPutResult {

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -129,6 +129,7 @@ struct TBrokerRangeDesc {
     //  it's usefull when format_type == FORMAT_JSON
     11: optional bool strip_outer_array;
     12: optional string jsonpaths;
+    13: optional string json_root;
 }
 
 struct TBrokerScanRangeParams {


### PR DESCRIPTION
1) FixBug: load a json object is failed in routine load
    for example json-data:  {"category":"11","title":"SayingsoftheCentury","price":895,"timestamp":1589191587}

2) add `json_root` for nest json data
   for example json-data:
        {
        "RECORDS":[
            {"category":"11","title":"SayingsoftheCentury","price":895,"timestamp":1589191587},
            {"category":"22","author":"2avc","price":895,"timestamp":1589191487},
            {"category":"33","author":"3avc","title":"SayingsoftheCentury","timestamp":1589191387}
            ]
        }
Routine load:
        CREATE ROUTINE LOAD example_db.test1 ON example_tbl
        COLUMNS(category, author, price, timestamp, dt=from_unixtime(timestamp, '%Y%m%d'))
        PROPERTIES
        (
            "desired_concurrent_number"="3",
            "max_batch_interval" = "20",
            "max_batch_rows" = "300000",
            "max_batch_size" = "209715200",
            "strict_mode" = "false",
            "format" = "json",
            "jsonpaths" = "[\"$.category\",\"$.author\",\"$.price\",\"$.timestamp\"]",
            "strip_outer_array" = "true",
            "json_root" = "$.RECORDS"
        )
        FROM KAFKA
        (
            "kafka_broker_list" = "broker1:9092,broker2:9092,broker3:9092",
            "kafka_topic" = "my_topic",
            "kafka_partitions" = "0,1,2",
            "kafka_offsets" = "0,0,0"
        );
