### PR TITLE
[Doc] Fix typo for stream load content in basic-usage.md

### DIFF
--- a/docs/en/getting-started/basic-usage.md
+++ b/docs/en/getting-started/basic-usage.md
@@ -268,17 +268,17 @@ The local file `table1_data` takes `,` as the separation between data, and the s
 Example 2: With "table2_20170707" as Label, import table2 tables using the local file table2_data.
 
 ```
-curl --location-trusted -u test:test -H "label:table2_20170707" -H "column_separator:," -T table1_data http://127.0.0.1:8030/api/example_db/table2/_stream_load
+curl --location-trusted -u test:test -H "label:table2_20170707" -H "column_separator:|" -T table2_data http://127.0.0.1:8030/api/example_db/table2/_stream_load
 ```
 
-The local file `table2_data'is separated by `t'. The details are as follows:
+The local file `table2_data'is separated by `|'. The details are as follows:
 
 ```
-2017-07-03  1   1   jim   2
-2017-07-05  2   1   grace 2
-2017-07-12  3   2   tom   2
-2017-07-15  4   3   bush  3
-2017-07-12  5   3   helen 3
+2017-07-03|1|1|jim|2
+2017-07-05|2|1|grace|2
+2017-07-12|3|2|tom|2
+2017-07-15|4|3|bush|3
+2017-07-12|5|3|helen|3
 ```
 
 > Notes:

--- a/docs/zh-CN/getting-started/basic-usage.md
+++ b/docs/zh-CN/getting-started/basic-usage.md
@@ -267,7 +267,7 @@ curl --location-trusted -u test:test -H "label:table1_20170707" -H "column_separ
 示例2: 以 "table2_20170707" 为 Label，使用本地文件 table2_data 导入 table2 表。
 
 ```
-curl --location-trusted -u test:test -H "label:table2_20170707" -H "column_separator:|" -T table1_data http://127.0.0.1:8030/api/example_db/table2/_stream_load
+curl --location-trusted -u test:test -H "label:table2_20170707" -H "column_separator:|" -T table2_data http://127.0.0.1:8030/api/example_db/table2/_stream_load
 ```
 
 本地文件 `table2_data` 以 `|` 作为数据之间的分隔，具体内容如下：


### PR DESCRIPTION
## Proposed changes

Fix typo for stream load content in basic-usage.md and make english content be consistent with chinese content.

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_
- [x] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have create an issue on [Doris's issues #4184](https://github.com/apache/incubator-doris/issues/4184), and have described the bug/feature there in detail.
## Further comments

If this is a relatively large or complex change, kick off the discussion at dev@doris.apache.org by explaining why you chose the solution you did and what alternatives you considered, etc...