### PR TITLE
Rewrite GroupByClause.oriGroupingExprs

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/GroupByClause.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/GroupByClause.java
@@ -114,6 +114,10 @@ public class GroupByClause implements ParseNode {
         }
     }
 
+    public List<Expr> getOriGroupingExprs() {
+        return oriGroupingExprs;
+    }
+
     public ArrayList<Expr> getGroupingExprs() {
         if (!exprGenerated) {
             try {

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/SelectStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/SelectStmt.java
@@ -1407,6 +1407,10 @@ public class SelectStmt extends QueryStmt {
             if (groupingExprs != null) {
                 rewriter.rewriteList(groupingExprs, analyzer);
             }
+            List<Expr> oriGroupingExprs = groupByClause.getOriGroupingExprs();
+            if (oriGroupingExprs != null) {
+                rewriter.rewriteList(oriGroupingExprs, analyzer);
+            }
         }
         if (orderByElements != null) {
             for (OrderByElement orderByElem : orderByElements) {

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/SelectStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/SelectStmtTest.java
@@ -331,4 +331,10 @@ public class SelectStmtTest {
             System.out.println(e.getMessage());
         }
     }
+
+    @Test
+    public void testGroupByConstantExpression() throws Exception {
+        String sql = "SELECT k1 - 4*60*60 FROM baseall GROUP BY k1 - 4*60*60";
+        dorisAssert.query(sql).explainQuery();
+    }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/utframe/MockedBackend.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/utframe/MockedBackend.java
@@ -18,11 +18,14 @@
 package org.apache.doris.utframe;
 
 import org.apache.doris.common.ThriftServer;
+import org.apache.doris.common.util.JdkUtils;
 import org.apache.doris.thrift.BackendService;
 import org.apache.doris.thrift.HeartbeatService;
 import org.apache.doris.thrift.TNetworkAddress;
 import org.apache.doris.utframe.MockedBackendFactory.BeThriftService;
 
+import com.baidu.bjf.remoting.protobuf.utils.JDKCompilerHelper;
+import com.baidu.bjf.remoting.protobuf.utils.compiler.JdkCompiler;
 import com.baidu.jprotobuf.pbrpc.transport.RpcServer;
 
 import org.apache.thrift.TProcessor;
@@ -55,6 +58,11 @@ public class MockedBackend {
     // the fe address: fe host and fe rpc port.
     // This must be set explicitly after creating mocked Backend
     private TNetworkAddress feAddress;
+
+    static {
+        int javaRuntimeVersion = JdkUtils.getJavaVersionAsInteger(System.getProperty("java.version"));
+        JDKCompilerHelper.setCompiler(new JdkCompiler(JdkCompiler.class.getClassLoader(), String.valueOf(javaRuntimeVersion)));
+    }
 
     public MockedBackend(String host, int heartbeatPort, int thriftPort, int brpcPort, int httpPort,
             HeartbeatService.Iface hbService,


### PR DESCRIPTION
Fix #4196

In this PR, Fe will rewrite `GroupByClause.oriGroupingExprs`.
