### PR TITLE
[Spill To Disk][4/6] Partition Aggregation Node Support Spill to disk in big query

### DIFF
--- a/be/src/exec/exec_node.cpp
+++ b/be/src/exec/exec_node.cpp
@@ -593,7 +593,7 @@ Status ExecNode::claim_buffer_reservation(RuntimeState* state) {
     ss << print_plan_node_type(_type) << " id=" << _id << " ptr=" << this;
     RETURN_IF_ERROR(buffer_pool->RegisterClient(ss.str(),
                                                 state->instance_buffer_reservation(),
-                                                mem_tracker(), buffer_pool->GetSystemBytesLimit(), 
+                                                nullptr, buffer_pool->GetSystemBytesLimit(),
                                                 runtime_profile(),
                                                 &_buffer_pool_client));
     

--- a/be/src/exec/partitioned_hash_table.inline.h
+++ b/be/src/exec/partitioned_hash_table.inline.h
@@ -111,14 +111,14 @@ inline PartitionedHashTable::HtData* PartitionedHashTable::InsertInternal(
 }
 
 inline bool PartitionedHashTable::Insert(PartitionedHashTableCtx* ht_ctx,
-    BufferedTupleStream3::FlatRowPtr flat_row, TupleRow* row, Status* status) {
+    const BufferedTupleStream2::RowIdx& idx, TupleRow* row, Status* status) {
   HtData* htdata = InsertInternal(ht_ctx, status);
   // If successful insert, update the contents of the newly inserted entry with 'idx'.
   if (LIKELY(htdata != NULL)) {
     if (stores_tuples()) {
       htdata->tuple = row->get_tuple(0);
     } else {
-      htdata->flat_row = flat_row;
+      htdata->idx = idx;
     }
     return true;
   }
@@ -234,7 +234,7 @@ inline PartitionedHashTable::DuplicateNode* PartitionedHashTable::InsertDuplicat
   if (!bucket->hasDuplicates) {
     // This is the first duplicate in this bucket. It means that we need to convert
     // the current entry in the bucket to a node and link it from the bucket.
-    next_node_->htdata.flat_row = bucket->bucketData.htdata.flat_row;
+    next_node_->htdata.idx = bucket->bucketData.htdata.idx;
     DCHECK(!bucket->matched);
     next_node_->matched = false;
     next_node_->next = NULL;
@@ -253,7 +253,7 @@ inline TupleRow* IR_ALWAYS_INLINE PartitionedHashTable::GetRow(HtData& htdata, T
     return reinterpret_cast<TupleRow*>(&htdata.tuple);
   } else {
     // TODO: GetTupleRow() has interpreted code that iterates over the row's descriptor.
-    tuple_stream_->GetTupleRow(htdata.flat_row, row);
+    tuple_stream_->get_tuple_row(htdata.idx, row);
     return row;
   }
 }

--- a/be/src/runtime/bufferpool/buffer_pool.cc
+++ b/be/src/runtime/bufferpool/buffer_pool.cc
@@ -386,7 +386,7 @@ BufferPool::Client::Client(BufferPool* pool, //TmpFileMgr::FileGroup* file_group
   // Set up a child profile with buffer pool info.
   RuntimeProfile* child_profile = profile->create_child("Buffer pool", true, true);
   reservation_.InitChildTracker(
-      child_profile, parent_reservation, mem_tracker, reservation_limit);
+      child_profile, parent_reservation, nullptr, reservation_limit);
   counters_.alloc_time = ADD_TIMER(child_profile, "AllocTime");
   counters_.cumulative_allocations =
       ADD_COUNTER(child_profile, "CumulativeAllocations", TUnit::UNIT);

--- a/be/src/runtime/initial_reservations.cc
+++ b/be/src/runtime/initial_reservations.cc
@@ -40,10 +40,10 @@ InitialReservations::InitialReservations(ObjectPool* obj_pool,
     ReservationTracker* query_reservation, MemTracker* query_mem_tracker,
     int64_t initial_reservation_total_claims)
   : initial_reservation_mem_tracker_(obj_pool->add(
-      new MemTracker(-1, "Unclaimed reservations", query_mem_tracker, false, false))),
+      new MemTracker(-1, "Unclaimed reservations", nullptr, false, false))),
       remaining_initial_reservation_claims_(initial_reservation_total_claims) {
   initial_reservations_.InitChildTracker(nullptr, query_reservation,
-      initial_reservation_mem_tracker_, numeric_limits<int64_t>::max());
+          nullptr, numeric_limits<int64_t>::max());
 }
 
 Status InitialReservations::Init(

--- a/be/src/runtime/runtime_state.cpp
+++ b/be/src/runtime/runtime_state.cpp
@@ -259,7 +259,7 @@ Status RuntimeState::init_mem_trackers(const TUniqueId& query_id) {
 
     if (_instance_buffer_reservation != nullptr) {
         _instance_buffer_reservation->InitChildTracker(&_profile,
-            _buffer_reservation, _instance_mem_tracker.get(),
+            _buffer_reservation, nullptr,
             std::numeric_limits<int64_t>::max());
     } 
 
@@ -291,7 +291,7 @@ Status RuntimeState::init_buffer_poolstate() {
 
   _buffer_reservation = _obj_pool->add(new ReservationTracker);
   _buffer_reservation->InitChildTracker(
-      NULL, exec_env->buffer_reservation(), _query_mem_tracker.get(), max_reservation);
+      NULL, exec_env->buffer_reservation(), nullptr, max_reservation);
   
   return Status::OK();
 }


### PR DESCRIPTION
## Proposed changes

1. Remove MemTracker in ReservationTracker, the men limit in bufferpool will be replace by MemTracker in BufferedBlockMgr2
2. Replace BufferedTupleStream3 by BufferedTupleStream2 in partition hash table, the mem alloc in hash table still use buffer pool  tracker by buffreblockmgr.
3. Replace BufferedTupleStream3 by BufferedTupleStream2 in PartitionAggregationNode, Support Spill to disk in big query.

issue:#3926

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] Documentation Update (if none of the other choices apply)
- [] Code refactor (Modify the code structure, format the code, etc...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have create an issue on #ISSUE, and have described the bug/feature there in detail
- [x] Compiling and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] If this change need a document change, I have updated the document
- [x] Any dependent changes have been merged

