### PR TITLE
[Calcite optimzer] support opertor of scan,  filter,  project of One QueryBlock #4223

### DIFF
--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -420,6 +420,12 @@ under the License.
             <artifactId>RoaringBitmap</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>org.apache.calcite</groupId>
+            <artifactId>calcite-core</artifactId>
+            <version>1.21.0</version>
+        </dependency>
+
         <!-- spark -->
         <!-- https://mvnrepository.com/artifact/org.apache.spark/spark-core_2.12 -->
         <dependency>

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/QueryStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/QueryStmt.java
@@ -238,6 +238,13 @@ public abstract class QueryStmt extends StatementBase {
         return baseTblResultExprs;
     }
 
+    public void setBaseResultExpr(List<Expr> resultExprs) {
+        this.baseTblResultExprs.addAll(resultExprs);
+    }
+    public void setResultExpr(List<Expr> resultExprs) {
+        this.resultExprs.addAll(resultExprs);
+    }
+
     public void setNeedToSql(boolean needToSql) {
         this.needToSql = needToSql;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/SlotRef.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/SlotRef.java
@@ -175,7 +175,7 @@ public class SlotRef extends Expr {
             return tblName.toSql() + "." + label + sb.toString();
         } else if (label != null) {
             return label + sb.toString();
-        } else if (desc.getSourceExprs() != null) {
+        } else if (desc.getSourceExprs() != null && desc.getSourceExprs().size() != 0) {
             if (desc.getId().asInt() != 1) {
                 sb.append("<slot " + Integer.toString(desc.getId().asInt()) + ">");
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/optimizer/CalciteMetaMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/optimizer/CalciteMetaMgr.java
@@ -1,0 +1,141 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.optimizer;
+
+
+import org.apache.doris.catalog.Catalog;
+import org.apache.doris.catalog.Column;
+import org.apache.doris.catalog.Database;
+import org.apache.doris.catalog.Table;
+import org.apache.doris.catalog.Type;
+
+import org.apache.calcite.config.CalciteConnectionConfig;
+import org.apache.calcite.plan.Context;
+import org.apache.calcite.plan.RelOptTable;
+import org.apache.calcite.rel.RelRoot;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.schema.SchemaPlus;
+import org.apache.calcite.schema.impl.AbstractTable;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.calcite.sql.validate.SqlConformance;
+import org.apache.calcite.sql.validate.SqlConformanceEnum;
+import org.apache.calcite.tools.FrameworkConfig;
+import org.apache.calcite.tools.Frameworks;
+
+import java.util.List;
+
+public class CalciteMetaMgr {
+    public static SchemaPlus registerRootSchema(String db) {
+        SchemaPlus rootSchema = Frameworks.createRootSchema(true);
+        Database database = Catalog.getCurrentCatalog().getDb(db);
+
+        for (Table table : database.getTables()) {
+            TableImpl tableDef = new TableImpl(table);
+            rootSchema.add(table.getName().toUpperCase(), tableDef);
+        }
+        return rootSchema;
+    }
+
+    public static SqlConformance conformance(FrameworkConfig config) {
+        final Context context = config.getContext();
+        if (context != null) {
+            final CalciteConnectionConfig connectionConfig =
+                    context.unwrap(CalciteConnectionConfig.class);
+            if (connectionConfig != null) {
+                return connectionConfig.conformance();
+            }
+        }
+        return SqlConformanceEnum.DEFAULT;
+    }
+
+    public static RexBuilder createRexBuilder(RelDataTypeFactory typeFactory) {
+        return new RexBuilder(typeFactory);
+    }
+
+    public static class ViewExpanderImpl implements RelOptTable.ViewExpander {
+        public ViewExpanderImpl() {
+        }
+
+        @Override
+        public RelRoot expandView(RelDataType rowType, String queryString, List<String> schemaPath,
+                                  List<String> viewPath) {
+            return null;
+        }
+    }
+
+    private static final class TableImpl extends AbstractTable {
+
+        final Table table;
+
+        private TableImpl(Table table) {
+            this.table = table;
+        }
+
+        @Override
+        public RelDataType getRowType(RelDataTypeFactory typeFactory) {
+            RelDataTypeFactory.Builder builder = new RelDataTypeFactory.Builder(typeFactory);
+            for (Column column : this.table.getBaseSchema()) {
+                builder.add(column.getName().toUpperCase(), convertType(column.getType(), typeFactory, column.isAllowNull()));
+            }
+            return builder.build();
+        }
+
+        private static RelDataType convertType(
+                Type type,
+                RelDataTypeFactory typeFactory, boolean nullable
+        ) {
+            RelDataType relDataType = convertTypeNotNull(type, typeFactory);
+            if (nullable) {
+                return typeFactory.createTypeWithNullability(relDataType, true);
+            } else {
+                return relDataType;
+            }
+        }
+
+        private static RelDataType convertTypeNotNull(
+                Type type,
+                RelDataTypeFactory typeFactory
+        ) {
+
+            switch (type.getPrimitiveType()) {
+                case TINYINT:
+                    return typeFactory.createSqlType(SqlTypeName.TINYINT);
+                case SMALLINT:
+                    return typeFactory.createSqlType(SqlTypeName.SMALLINT);
+                case INT:
+                    return typeFactory.createSqlType(SqlTypeName.INTEGER);
+                case BIGINT:
+                    return typeFactory.createSqlType(SqlTypeName.BIGINT);
+                case VARCHAR:
+                    return typeFactory.createSqlType(SqlTypeName.CHAR);
+                case CHAR:
+                    return typeFactory.createSqlType(SqlTypeName.CHAR);
+                case DATE:
+                    return typeFactory.createSqlType(SqlTypeName.DATE);
+                case DATETIME:
+                    return typeFactory.createSqlType(SqlTypeName.TIMESTAMP);
+                default:
+                    return typeFactory.createSqlType(SqlTypeName.ANY);
+
+            }
+        }
+    }
+}
+

--- a/fe/fe-core/src/main/java/org/apache/doris/optimizer/CalcitePlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/optimizer/CalcitePlanner.java
@@ -1,0 +1,149 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.optimizer;
+
+import com.google.common.base.Preconditions;
+
+import org.apache.calcite.adapter.enumerable.EnumerableConvention;
+import org.apache.calcite.adapter.enumerable.EnumerableRules;
+import org.apache.calcite.avatica.util.Quoting;
+import org.apache.calcite.config.CalciteConnectionConfigImpl;
+import org.apache.calcite.jdbc.CalciteSchema;
+import org.apache.calcite.plan.ConventionTraitDef;
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelOptUtil;
+import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.plan.volcano.VolcanoPlanner;
+import org.apache.calcite.prepare.CalciteCatalogReader;
+import org.apache.calcite.rel.RelDistributionTraitDef;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.RelRoot;
+import org.apache.calcite.rel.rules.FilterJoinRule;
+import org.apache.calcite.rel.rules.PruneEmptyRules;
+import org.apache.calcite.rel.rules.ReduceExpressionsRule;
+import org.apache.calcite.rel.type.RelDataTypeSystem;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.schema.SchemaPlus;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.parser.SqlParser;
+import org.apache.calcite.sql.type.SqlTypeFactoryImpl;
+import org.apache.calcite.sql.validate.SqlConformanceEnum;
+import org.apache.calcite.sql.validate.SqlValidator;
+import org.apache.calcite.sql.validate.SqlValidatorUtil;
+import org.apache.calcite.sql2rel.RelDecorrelator;
+import org.apache.calcite.sql2rel.SqlToRelConverter;
+import org.apache.calcite.tools.FrameworkConfig;
+import org.apache.calcite.tools.Frameworks;
+import org.apache.calcite.tools.RelBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Properties;
+
+
+public class CalcitePlanner {
+    private static final Logger LOGGER = LoggerFactory.getLogger(SqlVolcanoTest.class);
+
+    private static final SqlParser.Config SQL_PARSER_CONFIG =
+            SqlParser.configBuilder(SqlParser.Config.DEFAULT)
+                    .setCaseSensitive(false)
+                    .setConformance(SqlConformanceEnum.MYSQL_5)
+                    .setQuoting(Quoting.BACK_TICK)
+                    .build();
+
+    public RelNode plan(String sql, SchemaPlus rootSchema) {
+        final FrameworkConfig frameworkConfig = Frameworks.newConfigBuilder()
+                .parserConfig(SQL_PARSER_CONFIG)
+                .defaultSchema(rootSchema)
+                .traitDefs(ConventionTraitDef.INSTANCE, RelDistributionTraitDef.INSTANCE)
+                .build();
+
+        // use VolcanoPlanner
+        VolcanoPlanner planner = new VolcanoPlanner();
+        planner.addRelTraitDef(ConventionTraitDef.INSTANCE);
+        planner.addRelTraitDef(RelDistributionTraitDef.INSTANCE);
+        // add rules
+        planner.addRule(FilterJoinRule.FilterIntoJoinRule.FILTER_ON_JOIN);
+        planner.addRule(ReduceExpressionsRule.PROJECT_INSTANCE);
+        planner.addRule(PruneEmptyRules.PROJECT_INSTANCE);
+        // add ConverterRule
+        planner.addRule(EnumerableRules.ENUMERABLE_JOIN_RULE);
+        planner.addRule(EnumerableRules.ENUMERABLE_AGGREGATE_RULE);
+        planner.addRule(EnumerableRules.ENUMERABLE_SORT_RULE);
+        planner.addRule(EnumerableRules.ENUMERABLE_VALUES_RULE);
+        planner.addRule(EnumerableRules.ENUMERABLE_PROJECT_RULE);
+        planner.addRule(EnumerableRules.ENUMERABLE_FILTER_RULE);
+        planner.addRule(EnumerableRules.ENUMERABLE_INTERSECT_RULE);
+        planner.addRule(EnumerableRules.ENUMERABLE_UNION_RULE);
+
+        try {
+            SqlTypeFactoryImpl factory = new SqlTypeFactoryImpl(RelDataTypeSystem.DEFAULT);
+            // sql parser
+            SqlParser parser = SqlParser.create(sql, SqlParser.Config.DEFAULT);
+            SqlNode parsed = parser.parseStmt();
+            LOGGER.info("The SqlNode after parsed is:\n{}", parsed.toString());
+            Properties props = new Properties();
+            // props.put(CalciteConnectionProperty.CASE_SENSITIVE, true);
+            CalciteCatalogReader calciteCatalogReader = new CalciteCatalogReader(
+                    CalciteSchema.from(rootSchema),
+                    CalciteSchema.from(rootSchema).path(null),
+                    factory,
+                    new CalciteConnectionConfigImpl(props));
+
+            // sql validate
+            SqlValidator validator = SqlValidatorUtil.newValidator(SqlStdOperatorTable.instance(), calciteCatalogReader,
+                    factory, CalciteMetaMgr.conformance(frameworkConfig));
+            boolean isCaseSensitive = validator.getCatalogReader().nameMatcher().isCaseSensitive();
+            SqlNode validated = validator.validate(parsed);
+            LOGGER.info("The SqlNode after validated is:\n{} boolean isCaseSensitive{}", validated.toString(), isCaseSensitive);
+
+            final RexBuilder rexBuilder = CalciteMetaMgr.createRexBuilder(factory);
+            final RelOptCluster cluster = RelOptCluster.create(planner, rexBuilder);
+
+            // init SqlToRelConverter config
+            final SqlToRelConverter.Config config = SqlToRelConverter.configBuilder()
+                    .withConfig(frameworkConfig.getSqlToRelConverterConfig())
+                    .withTrimUnusedFields(false)
+                    .withConvertTableAccess(false)
+                    .build();
+            // SqlNode toRelNode
+            final SqlToRelConverter sqlToRelConverter = new SqlToRelConverter(new CalciteMetaMgr.ViewExpanderImpl(),
+                    validator, calciteCatalogReader, cluster, frameworkConfig.getConvertletTable(), config);
+            RelRoot root = sqlToRelConverter.convertQuery(validated, false, true);
+
+            root = root.withRel(sqlToRelConverter.flattenTypes(root.rel, true));
+            final RelBuilder relBuilder = config.getRelBuilderFactory().create(cluster, null);
+            root = root.withRel(RelDecorrelator.decorrelateQuery(root.rel, relBuilder));
+            RelNode relNode = root.rel;
+            LOGGER.info("The relational expression string before optimized is:\n{}", RelOptUtil.toString(relNode));
+
+            RelTraitSet desiredTraits =
+                    relNode.getCluster().traitSet().replace(EnumerableConvention.INSTANCE);
+            relNode = planner.changeTraits(relNode, desiredTraits);
+
+            planner.setRoot(relNode);
+            relNode = planner.findBestExp();
+            return relNode;
+        } catch (Exception e) {
+            e.printStackTrace();
+            Preconditions.checkState(false);
+            return null;
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/optimizer/PlanNodeConverter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/optimizer/PlanNodeConverter.java
@@ -1,0 +1,446 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.optimizer;
+
+import org.apache.doris.analysis.Analyzer;
+import org.apache.doris.analysis.BaseTableRef;
+import org.apache.doris.analysis.BinaryPredicate;
+import org.apache.doris.analysis.CompoundPredicate;
+import org.apache.doris.analysis.Expr;
+import org.apache.doris.analysis.IntLiteral;
+import org.apache.doris.analysis.SlotDescriptor;
+import org.apache.doris.analysis.SlotRef;
+import org.apache.doris.analysis.TableName;
+import org.apache.doris.analysis.TableRef;
+import org.apache.doris.analysis.TupleDescriptor;
+import org.apache.doris.catalog.Column;
+import org.apache.doris.catalog.Database;
+import org.apache.doris.catalog.Table;
+import org.apache.doris.catalog.Type;
+import org.apache.doris.common.AnalysisException;
+import org.apache.doris.common.ErrorCode;
+import org.apache.doris.common.ErrorReport;
+import org.apache.doris.common.UserException;
+import org.apache.doris.planner.OlapScanNode;
+import org.apache.doris.planner.PartitionColumnFilter;
+import org.apache.doris.planner.PlanNode;
+import org.apache.doris.planner.PlanNodeId;
+import org.apache.doris.planner.ScanNode;
+import org.apache.doris.planner.SingleNodePlanner;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.RelVisitor;
+import org.apache.calcite.rel.core.Aggregate;
+import org.apache.calcite.rel.core.Exchange;
+import org.apache.calcite.rel.core.Filter;
+import org.apache.calcite.rel.core.Join;
+import org.apache.calcite.rel.core.Project;
+import org.apache.calcite.rel.core.Sort;
+import org.apache.calcite.rel.core.TableFunctionScan;
+import org.apache.calcite.rel.core.TableScan;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeField;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexFieldAccess;
+import org.apache.calcite.rex.RexInputRef;
+import org.apache.calcite.rex.RexLiteral;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.rex.RexUtil;
+import org.apache.calcite.rex.RexVisitorImpl;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.math.BigDecimal;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+public class PlanNodeConverter {
+    private static final Logger LOG = LoggerFactory.getLogger(PlanNodeConverter.class);
+
+    private final RelNode          root;
+    private RelNode          from;
+    private Filter           where;
+    private Aggregate        groupBy;
+    private Filter           having;
+    private RelNode          select;
+    private RelNode          orderLimit;
+
+    private List<Column>           columns;
+    private TupleDescriptor  tupleDescriptor;
+
+    private Analyzer analyzer;
+    private SingleNodePlanner planner;
+
+    public PlanNodeConverter(RelNode root, Analyzer analyzer, SingleNodePlanner planner) {
+        this.root = root;
+        this.analyzer = analyzer;
+        this.planner = planner;
+    }
+
+    class QBVisitor extends RelVisitor {
+        public void handle(Filter filter) {
+            RelNode child = filter.getInput();
+            if (child instanceof Aggregate && !((Aggregate) child).getGroupSet().isEmpty()) {
+                PlanNodeConverter.this.having = filter;
+            } else {
+                PlanNodeConverter.this.where = filter;
+            }
+        }
+
+        public void handle(Project project) {
+            if (PlanNodeConverter.this.select == null) {
+                PlanNodeConverter.this.select = project;
+            } else {
+                PlanNodeConverter.this.from = project;
+            }
+        }
+
+        public void handle(TableFunctionScan tableFunctionScan) {
+            if (PlanNodeConverter.this.select == null) {
+                PlanNodeConverter.this.select = tableFunctionScan;
+            } else {
+                PlanNodeConverter.this.from = tableFunctionScan;
+            }
+        }
+
+        @Override
+        public void visit(RelNode node, int ordinal, RelNode parent) {
+            if (node instanceof TableScan) {
+                PlanNodeConverter.this.from = node;
+            } else if (node instanceof Filter) {
+                handle((Filter) node);
+            } else if (node instanceof Project) {
+                handle((Project) node);
+            } else if (node instanceof Join) {
+                PlanNodeConverter.this.from = node;
+            } else if (node instanceof Aggregate) {
+                PlanNodeConverter.this.groupBy = (Aggregate) node;
+            } else if (node instanceof Sort || node instanceof Exchange) {
+                if (PlanNodeConverter.this.select != null) {
+                    PlanNodeConverter.this.from = node;
+                } else {
+                    PlanNodeConverter.this.orderLimit = node;
+                }
+            }
+            /*
+             * once the source node is reached; stop traversal for this QB
+             */
+            if (PlanNodeConverter.this.from == null) {
+                node.childrenAccept(this);
+            }
+        }
+    }
+
+    private Type calciteTypeToDorisType(RelDataType type) {
+        String typeName = type.getSqlTypeName().getName();
+        if (typeName.equals("INTEGER")) {
+            return Type.INT;
+        } else if (typeName.equals("CHAR")) {
+            return Type.CHAR;
+        } else {
+            String msg = typeName + " can't supported";
+            throw new UnsupportedOperationException(msg);
+        }
+    }
+
+    private TupleDescriptor createTupleDescriptor(TableScan scan) throws AnalysisException {
+        String dbName = analyzer.getDefaultDb();
+        String tblName = scan.getTable().getQualifiedName().get(0).toLowerCase();
+        TupleDescriptor tupleDesc = analyzer.getDescTbl().createTupleDescriptor(tblName);
+        tupleDesc.setIsMaterialized(true);
+        TableName tableName = new TableName(dbName, tblName);
+
+        Database database = analyzer.getCatalog().getDb(dbName);
+        if (database == null) {
+            ErrorReport.reportAnalysisException(ErrorCode.ERR_BAD_DB_ERROR, dbName);
+        }
+        Table table = database.getTable(tblName);
+        if (table == null) {
+            ErrorReport.reportAnalysisException(ErrorCode.ERR_BAD_TABLE_ERROR, tblName);
+        }
+        TableRef tableRef = new BaseTableRef(new TableRef(tableName, null), table, tableName);
+        tupleDesc.setRef(tableRef);
+        tupleDesc.setTable(table);
+
+        for (RelDataTypeField field : scan.deriveRowType().getFieldList()) {
+            String colName = field.getKey();
+            SlotDescriptor slotDesc = analyzer.addSlotDescriptor(tupleDesc);
+            slotDesc.setLabel(colName);
+            slotDesc.setType(calciteTypeToDorisType(field.getType()));
+            slotDesc.setIsMaterialized(true);
+            Column column = table.getColumn(colName);
+            if (column == null) {
+                ErrorReport.reportAnalysisException(ErrorCode.ERR_BAD_FIELD_ERROR, colName,
+                   tableName);
+            }
+            slotDesc.setColumn(column);
+
+            SlotRef slotRef = new SlotRef(tableName, colName);
+            slotRef.setDesc(slotDesc);
+            slotRef.setType(slotDesc.getType());
+            //slotRef.analyze(analyzer);
+        }
+        tupleDesc.computeMemLayout();
+
+
+        return tupleDesc;
+    }
+
+    private ScanNode convertSource(RelNode r)
+            throws UserException {
+        ScanNode scanNode = null;
+        if (r instanceof TableScan) {
+            TableScan scan = (TableScan)r;
+            TupleDescriptor descriptor = createTupleDescriptor(scan);
+            scanNode = new OlapScanNode(new PlanNodeId(0), descriptor,"OlapScanNode");
+
+            Map<String, PartitionColumnFilter> columnFilters = Maps.newHashMap();
+            List<Expr> conjuncts = analyzer.getUnassignedConjuncts(scanNode);
+
+            for (Column column : descriptor.getTable().getBaseSchema()) {
+                SlotDescriptor slotDesc = descriptor.getColumnSlot(column.getName());
+                if (null == slotDesc) {
+                    continue;
+                }
+                PartitionColumnFilter keyFilter = planner.createPartitionFilter(slotDesc, conjuncts);
+                if (null != keyFilter) {
+                    columnFilters.put(column.getName(), keyFilter);
+                }
+            }
+            scanNode.setColumnFilters(columnFilters);
+            scanNode.init(analyzer);
+            this.tupleDescriptor = descriptor;
+            this.columns = descriptor.getTable().getBaseSchema();
+     } else {
+            Preconditions.checkState(false);
+        }
+        return scanNode;
+    }
+
+    static class RexVisitor extends RexVisitorImpl<Expr> {
+        private final RexBuilder rexBuilder;
+        // this is to keep track of null literal which already has been visited
+        private Map<RexLiteral, Boolean> nullLiteralMap ;
+        private List<Column> columns;
+        private TupleDescriptor tupleDescriptor;
+
+        protected RexVisitor(List<Column> columns, TupleDescriptor descriptor, RexBuilder rexBuilder) {
+            super(true);
+            this.columns = columns;
+            this.tupleDescriptor = descriptor;
+            this.rexBuilder = rexBuilder;
+
+            this.nullLiteralMap =
+                    new TreeMap<>(new Comparator<RexLiteral>(){
+                        // RexLiteral's equal only consider value and type which isn't sufficient
+                        // so providing custom comparator which distinguishes b/w objects irrespective
+                        // of value/type
+                        @Override
+                        public int compare(RexLiteral o1, RexLiteral o2) {
+                            if(o1 == o2) {
+                                return 0;
+                            } else {
+                                return 1;
+                            }
+                        }
+                    });
+        }
+
+        @Override
+        public Expr visitFieldAccess(RexFieldAccess fieldAccess) {
+            // not implement
+            Preconditions.checkState(false);
+            return null;
+        }
+
+        @Override
+        public Expr visitInputRef(RexInputRef inputRef) {
+            Column column = columns.get(inputRef.getIndex());
+            SlotDescriptor slotDescriptor = null;
+            for (SlotDescriptor iter: tupleDescriptor.getSlots()) {
+                if (iter.getColumn().equals(column)) {
+                    slotDescriptor = iter;
+                    break;
+                }
+            }
+            Preconditions.checkState(slotDescriptor != null);
+            return new SlotRef(slotDescriptor);
+        }
+
+        @Override
+        public Expr visitLiteral(RexLiteral literal) {
+            SqlTypeName typeName = literal.getType().getSqlTypeName();
+            switch (typeName) {
+                case TINYINT:
+                case SMALLINT:
+                case INTEGER:
+                case BIGINT:
+                    try {
+                        return new IntLiteral(((BigDecimal)literal.getValue()).longValue(), Type.INT);
+                    } catch (AnalysisException e) {
+                        LOG.warn("", e);
+                        throw new NullPointerException();
+                    }
+                default:
+                    throw new NullPointerException();
+            }
+        }
+
+        private BinaryPredicate.Operator sqlKindrToBinaryOperator(SqlKind sqlKind) {
+            switch (sqlKind) {
+                case EQUALS:
+                    return BinaryPredicate.Operator.EQ;
+                case NOT_EQUALS:
+                    return BinaryPredicate.Operator.NE;
+                case LESS_THAN:
+                    return BinaryPredicate.Operator.LT;
+                case GREATER_THAN:
+                    return BinaryPredicate.Operator.GT;
+                case LESS_THAN_OR_EQUAL:
+                    return BinaryPredicate.Operator.LE;
+                case GREATER_THAN_OR_EQUAL:
+                    return BinaryPredicate.Operator.GE;
+                default:
+                    // the stmt is not executed.
+                    throw new NullPointerException();
+            }
+
+        }
+
+        @Override
+        public Expr visitCall(RexCall call) {
+            if (!deep) {
+                return null;
+            }
+
+            SqlOperator op = call.getOperator();
+            List<Expr> exprList = Lists.newArrayList();
+            switch (op.kind) {
+                case EQUALS:
+                case NOT_EQUALS:
+                case LESS_THAN:
+                case GREATER_THAN:
+                case LESS_THAN_OR_EQUAL:
+                case GREATER_THAN_OR_EQUAL:
+                    if (rexBuilder != null && RexUtil.isReferenceOrAccess(call.operands.get(1), true) &&
+                            RexUtil.isLiteral(call.operands.get(0), true)) {
+                        // Swap to get reference on the left side
+                        return visitCall((RexCall) RexUtil.invert(rexBuilder, call));
+                    } else {
+                        for (RexNode operand : call.operands) {
+                            exprList.add(operand.accept(this));
+                        }
+                        Preconditions.checkState(call.operands.size() == 2);
+                        return new BinaryPredicate(sqlKindrToBinaryOperator(op.kind), exprList.get(0), exprList.get(1));
+                    }
+                case OR:
+                    Expr expr;
+                    for (RexNode operand : call.operands) {
+                        exprList.add(operand.accept(this));
+                    }
+                    expr = new CompoundPredicate(CompoundPredicate.Operator.OR,
+                            exprList.get(0),
+                            exprList.get(1));
+                    for (int i = 2; i < exprList.size(); i++) {
+                        expr = new CompoundPredicate(CompoundPredicate.Operator.OR, expr, exprList.get(i));
+                    }
+                    return expr;
+                default:
+                    for (RexNode operand : call.operands) {
+                        exprList.add(operand.accept(this));
+                    }
+            }
+            return null;
+        }
+    }
+
+    public PlanNode convert(List<Expr> resultExprs, List<String> colLabels)  {
+        /*
+         * 1. Walk RelNode Graph; note from, where, gBy.. nodes.
+         */
+        new QBVisitor().go(root);
+
+        /*
+         * 2. convert from node.
+         */
+        PlanNode node = null;
+        try {
+            node = convertSource(from);
+        } catch (UserException e) {
+            e.printStackTrace();
+            return null;
+        }
+
+        /*
+         * 3. convert filterNode
+         */
+        if (where != null) {
+            List<Expr> conjuncts = Lists.newArrayList();
+            boolean bAndPredicate = false;
+            RexNode rexNode = where.getCondition();
+            if (rexNode instanceof RexCall) {
+                RexCall whereConjuncts = (RexCall) rexNode;
+                if (whereConjuncts.getOperator().getKind() == SqlKind.AND) {
+                    for (RexNode whereConjunct : whereConjuncts.getOperands()) {
+                        Expr expr = whereConjunct.accept(new RexVisitor(columns, tupleDescriptor, root.getCluster().getRexBuilder()));
+                        conjuncts.add(expr);
+                    }
+                    bAndPredicate = true;
+                }
+            }
+            if (!bAndPredicate) {
+                Expr expr = where.getCondition().accept(new RexVisitor(columns, tupleDescriptor, root.getCluster().getRexBuilder()));
+                conjuncts.add(expr);
+            }
+            node.addConjuncts(conjuncts);
+        }
+
+        /*
+         * 4. Project
+         */
+        if (select instanceof Project) {
+            List<RexNode> childExps = ((Project) select).getChildExps();
+            if (childExps.isEmpty()) {
+                LOG.warn("childExpr of Project is null");
+                return null;
+            } else {
+                for (RexNode r : childExps) {
+                    Expr expr = r.accept(new RexVisitor(columns, tupleDescriptor, root.getCluster().getRexBuilder()));
+                    if (expr == null) {
+                        LOG.warn("transport expr fail, RexNode={}", r);
+                        return null;
+                    }
+                    resultExprs.add(expr);
+                    colLabels.add(expr.toSql());
+                }
+            }
+        }
+        return node;
+    }
+}
+

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/OlapScanNode.java
@@ -137,6 +137,10 @@ public class OlapScanNode extends ScanNode {
         this.reasonOfPreAggregation = reason;
     }
 
+    public void setSelectedIndexId(long selectedIndexId) {
+        this.selectedIndexId = selectedIndexId;
+    }
+
     public boolean isPreAggregation() {
         return isPreAggregation;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -106,12 +106,17 @@ public class SessionVariable implements Serializable, Writable {
     public static final String MAX_SCAN_KEY_NUM = "max_scan_key_num";
     public static final String MAX_PUSHDOWN_CONDITIONS_PER_COLUMN = "max_pushdown_conditions_per_column";
 
+    public static final String ENABLE_CALCITE = "enable_calcite";
+
     // max memory used on every backend.
     @VariableMgr.VarAttr(name = EXEC_MEM_LIMIT)
     public long maxExecMemByte = 2147483648L;
 
     @VariableMgr.VarAttr(name = ENABLE_SPILLING)
     public boolean enableSpilling = false;
+
+    @VariableMgr.VarAttr(name = ENABLE_CALCITE)
+    private boolean enableCalcite = false;
 
     // query timeout in second.
     @VariableMgr.VarAttr(name = QUERY_TIMEOUT)
@@ -279,6 +284,9 @@ public class SessionVariable implements Serializable, Writable {
         return isReportSucc;
     }
 
+    public boolean enableCaclite() {
+        return enableCalcite;
+    }
     public int getWaitTimeoutS() {
         return waitTimeout;
     }


### PR DESCRIPTION


## Proposed changes

the predicate of filter operator only support BinaryPredicate and CompoundPredicate.
for example: set enable_calcite = true; select i from t where j > 1 and (k <= 2 or i = 5)

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] Documentation Update (if none of the other choices apply)
- [] Code refactor (Modify the code structure, format the code, etc...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have create an issue on #ISSUE, and have described the bug/feature there in detail
- [] Compiling and unit tests pass locally with my changes
- [] I have added tests that prove my fix is effective or that my feature works
- [] If this change need a document change, I have updated the document
- [] Any dependent changes have been merged

## Further comments
this is the first commit of calcite optimzier
