### PR TITLE
fix decimal delete error

### DIFF
--- a/be/src/olap/tablet_meta.cpp
+++ b/be/src/olap/tablet_meta.cpp
@@ -125,7 +125,8 @@ TabletMeta::TabletMeta(int64_t table_id, int64_t partition_id,
         string data_type;
         EnumToString(TPrimitiveType, tcolumn.column_type.type, data_type);
         column->set_type(data_type);
-        if (tcolumn.column_type.type == TPrimitiveType::DECIMAL) {
+        if (tcolumn.column_type.type == TPrimitiveType::DECIMAL ||
+            tcolumn.column_type.type == TPrimitiveType::DECIMALV2) {
             column->set_precision(tcolumn.column_type.precision);
             column->set_frac(tcolumn.column_type.scale);
         }


### PR DESCRIPTION
## Proposed changes

Fixes #4227   
Querys like `DELETE FROM tbl WHERE decimal_key <= "123.456";` when the type of decimal_key is `DECIMALV2` may failed randomly, this is because the `precision` and `scale `is not initialized

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Code refactor (Modify the code structure, format the code, etc...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have create an issue on #ISSUE, and have described the bug/feature there in detail
- [x] Compiling and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If this change need a document change, I have updated the document
- [x] Any dependent changes have been merged

