### PR TITLE
Analyze define expr before replay Rollup job

### DIFF
--- a/fe/fe-core/src/test/java/org/apache/doris/alter/RollupJobV2Test.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/alter/RollupJobV2Test.java
@@ -28,6 +28,7 @@ import org.apache.doris.analysis.CreateMaterializedViewStmt;
 import org.apache.doris.analysis.Expr;
 import org.apache.doris.analysis.FunctionCallExpr;
 import org.apache.doris.analysis.FunctionName;
+import org.apache.doris.analysis.MVColumnItem;
 import org.apache.doris.analysis.SlotRef;
 import org.apache.doris.analysis.TableName;
 import org.apache.doris.catalog.AggregateType;
@@ -371,6 +372,7 @@ public class RollupJobV2Test {
     @Test
     public void testSerializeOfRollupJob(@Mocked CreateMaterializedViewStmt stmt) throws IOException,
             AnalysisException {
+        Config.enable_materialized_view = true;
         // prepare file
         File file = new File(fileName);
         file.createNewFile();
@@ -395,12 +397,14 @@ public class RollupJobV2Test {
         List<Expr> params = Lists.newArrayList();
         SlotRef param1 = new SlotRef(new TableName(null, "test"), "c1");
         params.add(param1);
-        Map<String, Expr> columnNameToDefineExpr = Maps.newHashMap();
-        columnNameToDefineExpr.put(mvColumnName, new FunctionCallExpr(new FunctionName("to_bitmap"), params));
+        MVColumnItem mvColumnItem = new MVColumnItem(mvColumnName, Type.BITMAP);
+        mvColumnItem.setDefineExpr(new FunctionCallExpr(new FunctionName("to_bitmap"), params));
+        List<MVColumnItem> mvColumnItemList = Lists.newArrayList();
+        mvColumnItemList.add(mvColumnItem);
         new Expectations() {
             {
-                stmt.parseDefineExprWithoutAnalyze();
-                result = columnNameToDefineExpr;
+                stmt.getMVColumnItemList();
+                result =  mvColumnItemList;
             }
         };
 


### PR DESCRIPTION
The define expr should be analyzed after replay RollupJob.
The slot desc of define expr is used to transform to thrift and send to backend.
Closed#4208

Change-Id: I4297de9708010dcbbd8a85789aa9905f214a4476

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] Documentation Update (if none of the other choices apply)
- [] Code refactor (Modify the code structure, format the code, etc...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have create an issue on #ISSUE, and have described the bug/feature there in detail
- [] Compiling and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [] If this change need a document change, I have updated the document
- [] Any dependent changes have been merged
