### PR TITLE
[BUG] Using attachement strategy of brpc to send packet with big size.

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -519,8 +519,6 @@ namespace config {
     CONF_Int64(brpc_max_body_size, "209715200");
     // Max unwritten bytes in each socket, if the limit is reached, Socket.Write fails with EOVERCROWDED
     CONF_Int64(brpc_socket_max_unwritten_bytes, "67108864");
-    // If batch size large than brpc_attachment_threashold, use attachment instead
-    CONF_Int64(brpc_attachment_threashold, "67108864");
 
     // max number of txns for every txn_partition_map in txn manager
     // this is a self protection to avoid too many txns saving in manager

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -519,6 +519,8 @@ namespace config {
     CONF_Int64(brpc_max_body_size, "209715200");
     // Max unwritten bytes in each socket, if the limit is reached, Socket.Write fails with EOVERCROWDED
     CONF_Int64(brpc_socket_max_unwritten_bytes, "67108864");
+    // If batch size large than brpc_attachment_threashold, use attachment instead
+    CONF_Int64(brpc_attachment_threashold, "67108864");
 
     // max number of txns for every txn_partition_map in txn manager
     // this is a self protection to avoid too many txns saving in manager

--- a/be/src/runtime/data_stream_sender.cpp
+++ b/be/src/runtime/data_stream_sender.cpp
@@ -230,7 +230,7 @@ Status DataStreamSender::Channel::send_batch(PRowBatch* batch, bool eos) {
     if (batch != nullptr) {
         butil::IOBuf& io_buf = _closure->cntl.request_attachment();
         io_buf.append(batch->tuple_data());
-        batch->mutable_tuple_data(); // to padding the required tuple_data field in PB
+        batch->set_tuple_data(""); // to padding the required tuple_data field in PB
         _brpc_request.set_allocated_row_batch(batch);
     }
     _brpc_request.set_packet_seq(_packet_seq++);

--- a/be/src/service/brpc.h
+++ b/be/src/service/brpc.h
@@ -56,3 +56,4 @@
 #include <brpc/closure_guard.h>
 #include <brpc/reloadable_flags.h>
 #include <brpc/protocol.h>
+#include <butil/strings/string_piece.h>

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -49,6 +49,13 @@ void PInternalServiceImpl<T>::transmit_data(google::protobuf::RpcController* cnt
                                          google::protobuf::Closure* done) {
     VLOG_ROW << "transmit data: fragment_instance_id=" << print_id(request->finst_id())
             << " node=" << request->node_id();
+    brpc::Controller* cntl = static_cast<brpc::Controller*>(cntl_base);
+    if (cntl->request_attachment().size() > 0) {
+        PRowBatch* batch = (const_cast<PTransmitDataParams*>(request))->mutable_row_batch();
+        butil::IOBuf& io_buf = cntl->request_attachment();
+        std::string* tuple_data = batch->mutable_tuple_data();
+        io_buf.copy_to(tuple_data);
+    }
     _exec_env->stream_mgr()->transmit_data(request, &done);
     if (done != nullptr) {
         done->Run();


### PR DESCRIPTION
BRPC send packet should serialize it first and then send it.
If we send one batch with big size, it will encounter a connection failed.
So we can use attachment strategy to bypass the problem and eliminate
the serialization cost.