### PR TITLE
[Doc][RESTfulAPI] Develop a specification document for restful api 

### DIFF
--- a/docs/zh-CN/administrator-guide/http-actions/fe/bootstrap-action.md
+++ b/docs/zh-CN/administrator-guide/http-actions/fe/bootstrap-action.md
@@ -1,0 +1,125 @@
+---
+{
+    "title": "Bootstrap Action",
+    "language": "zh-CN"
+}
+---
+
+<!-- 
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Bootstrap Action
+
+## Request
+
+`GET /api/bootstrap`
+
+## Description
+
+用于判断FE是否启动完成。当不提供任何参数时，仅返回是否启动成功。如果提供了 `token` 和 `cluster_id`，则返回更多详细信息
+    
+## Path parameters
+
+无
+
+## Query parameters
+
+* `cluster_id`
+
+    集群id。可以在 `palo-meta/image/VERSION` 文件中查看。
+    
+* `token`
+
+    集群token。可以在 `palo-meta/image/VERSION` 文件中查看。
+
+## Request body
+
+无
+
+## Response
+
+* 不提供参数
+
+    ```
+    {
+    	"msg": "OK",
+    	"code": 0,
+    	"data": null,
+    	"count": 0
+    }
+    ```
+    
+    code 为 200 表示FE节点启动成功。非 200 的错误码表示其他错误。
+    
+* 提供 `token` 和 `cluster_id`
+
+    ```
+    {
+    	"msg": "OK",
+    	"code": 0,
+    	"data": {
+    		"queryPort": 9030,
+    		"rpcPort": 9020,
+    		"maxReplayedJournal": 17287
+    	},
+    	"count": 0
+    }
+    ```
+    
+    * `queryPort` 是 FE 节点的 MySQL 协议端口。
+    * `rpcPort` 是 FE 节点的 thrift RPC 端口。
+    * `maxReplayedJournal` 表示 FE 节点当前回放的最大元数据日志id。
+    
+## Examples
+
+1. 不提供参数
+
+    ```
+    GET /api/bootstrap
+
+    Response:
+    {
+    	"msg": "OK",
+    	"code": 0,
+    	"data": null,
+    	"count": 0
+    }
+    ```
+    
+2. 提供 `token` 和 `cluster_id`
+
+    ```
+    GET /api/bootstrap?cluster_id=935437471&token=ad87f6dd-c93f-4880-bcdb-8ca8c9ab3031
+
+    Response:
+    {
+    	"msg": "OK",
+    	"code": 0,
+    	"data": {
+    		"queryPort": 9030,
+    		"rpcPort": 9020,
+    		"maxReplayedJournal": 17287
+    	},
+    	"count": 0
+    }
+    ```
+
+
+
+

--- a/docs/zh-CN/administrator-guide/http-actions/fe/cancel-load.md
+++ b/docs/zh-CN/administrator-guide/http-actions/fe/cancel-load.md
@@ -1,0 +1,96 @@
+---
+{
+    "title": "CANCEL LOAD",
+    "language": "zh-CN"
+}
+---
+
+<!-- 
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# CANCEL LOAD
+
+## Request
+
+`POST /api/<db>/_cancel`
+
+## Description
+
+用于取消掉指定label的导入任务。
+    
+## Path parameters
+
+* `<db>`
+
+    指定数据库名称
+
+## Query parameters
+
+* `<label>`
+
+    指定导入label
+
+## Request body
+
+无
+
+## Response
+
+* 取消成功
+
+    ```
+    {
+    	"msg": "OK",
+    	"code": 0,
+    	"data": null,
+    	"count": 0
+    }
+    ```
+
+* 取消失败
+
+    ```
+    {
+    	"msg": "Error msg...",
+    	"code": 1,
+    	"data": null,
+    	"count": 0
+    }
+    ```
+    
+## Examples
+
+1. 取消指定label的导入事务
+
+    ```
+    POST /api/example_db/_cancel?label=my_label1
+
+    Response:
+    {
+    	"msg": "OK",
+    	"code": 0,
+    	"data": null,
+    	"count": 0
+    }
+    ```
+    
+
+
+
+

--- a/docs/zh-CN/administrator-guide/http-actions/fe/check-decommission-action.md
+++ b/docs/zh-CN/administrator-guide/http-actions/fe/check-decommission-action.md
@@ -1,0 +1,84 @@
+---
+{
+    "title": "Check Decommission Action",
+    "language": "zh-CN"
+}
+---
+
+<!-- 
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Check Decommission Action
+
+## Request
+
+`GET /api/check_decommission`
+
+## Description
+
+用于指定的BE是否能够被下线。比如判断节点下线后，剩余的节点是否能够满足空间要求和副本数要求等。
+    
+## Path parameters
+
+无
+
+## Query parameters
+
+* `host_ports`
+
+    指定一个多个BE，由逗号分隔。如：`ip1:port1,ip2:port2,...`。
+
+    其中 port 为 BE 的 heartbeat port。
+
+## Request body
+
+TODO
+
+## Response
+
+返回可以被下线的节点列表
+
+```
+{
+	"msg": "OK",
+	"code": 0,
+	"data": ["192.168.10.11:9050", "192.168.10.11:9050"],
+	"count": 0
+}
+```
+    
+## Examples
+
+1. 查看指定BE节点是否可以下线
+
+    ```
+    GET /api/check_decommission?host_ports=192.168.10.11:9050,192.168.10.11:9050
+    
+    Response:
+    {
+    	"msg": "OK",
+    	"code": 0,
+    	"data": ["192.168.10.11:9050"],
+    	"count": 0
+    }
+    ```
+
+
+
+

--- a/docs/zh-CN/administrator-guide/http-actions/fe/check-storage-type-action.md
+++ b/docs/zh-CN/administrator-guide/http-actions/fe/check-storage-type-action.md
@@ -1,0 +1,84 @@
+---
+{
+    "title": "Check Storage Type Action",
+    "language": "zh-CN"
+}
+---
+
+<!-- 
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Check Storage Type Action
+
+## Request
+
+`GET /api/_check_storagetype`
+
+## Description
+
+用于检查指定数据库下的表的存储格式否是行存格式。（行存格式已废弃）
+    
+## Path parameters
+
+无
+
+## Query parameters
+
+* `db`
+
+    指定数据库
+
+## Request body
+
+无
+
+## Response
+
+```
+{
+	"msg": "success",
+	"code": 0,
+	"data": {
+		"tbl2": {},
+		"tbl1": {}
+	},
+	"count": 0
+}
+```
+
+如果表名后由内容，则会显示存储格式为行存的 base 或者 rollup 表。
+
+## Examples
+
+1. 检查指定数据库下表的存储格式是否为行存
+
+    ```
+    GET /api/_check_storagetype
+    
+    Response:
+    {
+    	"msg": "success",
+    	"code": 0,
+    	"data": {
+    		"tbl2": {},
+    		"tbl1": {}
+    	},
+    	"count": 0
+    }
+    ```

--- a/docs/zh-CN/administrator-guide/http-actions/fe/connection-action.md
+++ b/docs/zh-CN/administrator-guide/http-actions/fe/connection-action.md
@@ -1,0 +1,82 @@
+---
+{
+    "title": "Connection",
+    "language": "zh-CN"
+}
+---
+
+<!-- 
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Conection
+
+## Request
+
+`GET /api/connection`
+
+## Description
+
+给定一个 connection id，返回这个连接当前正在执行的，或最后一次执行完成的 query id。
+
+connection id 可以通过 MySQL 命令 `show processlist;` 中的 id 列查看。
+    
+## Path parameters
+
+无
+
+## Query parameters
+
+* `connection_id`
+
+    指定的 connection id
+
+## Request body
+
+无
+
+## Response
+
+```
+{
+	"msg": "OK",
+	"code": 0,
+	"data": {
+		"query_id": "b52513ce3f0841ca-9cb4a96a268f2dba"
+	},
+	"count": 0
+}
+```
+    
+## Examples
+
+1. 获取指定 connection id 的 query id
+
+    ```
+    GET /api/connection?connection_id=101
+    
+    Response:
+    {
+    	"msg": "OK",
+    	"code": 0,
+    	"data": {
+    		"query_id": "b52513ce3f0841ca-9cb4a96a268f2dba"
+    	},
+    	"count": 0
+    }
+    ```

--- a/docs/zh-CN/administrator-guide/http-actions/fe/get-ddl-stmt-action.md
+++ b/docs/zh-CN/administrator-guide/http-actions/fe/get-ddl-stmt-action.md
@@ -1,0 +1,92 @@
+---
+{
+    "title": "Get DDL Statement Action",
+    "language": "zh-CN"
+}
+---
+
+<!-- 
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Get DDL Statement Action
+
+## Request
+
+`GET /api/_get_ddl`
+
+## Description
+
+用于获取指定表的建表语句、建分区语句和建rollup语句。
+    
+## Path parameters
+
+无
+
+## Query parameters
+
+* `db`
+
+    指定数据库
+
+* `table`
+    
+    指定表
+
+## Request body
+
+无
+
+## Response
+
+```
+{
+	"msg": "OK",
+	"code": 0,
+	"data": {
+		"create_partition": ["ALTER TABLE `tbl1` ADD PARTITION ..."],
+		"create_table": ["CREATE TABLE `tbl1` ...],
+		"create_rollup": ["ALTER TABLE `tbl1` ADD ROLLUP ..."]
+	},
+	"count": 0
+}
+```
+    
+## Examples
+
+1. 获取指定表的 DDL 语句
+
+    ```
+    GET GET /api/_get_ddl?db=db1&table=tbl1
+    
+    Response
+    {
+    	"msg": "OK",
+    	"code": 0,
+    	"data": {
+    		"create_partition": [],
+    		"create_table": ["CREATE TABLE `tbl1` (\n  `k1` int(11) NULL COMMENT \"\",\n  `k2` int(11) NULL COMMENT \"\"\n) ENGINE=OLAP\nDUPLICATE KEY(`k1`, `k2`)\nCOMMENT \"OLAP\"\nDISTRIBUTED BY HASH(`k1`) BUCKETS 1\nPROPERTIES (\n\"replication_num\" = \"1\",\n\"version_info\" = \"1,0\",\n\"in_memory\" = \"false\",\n\"storage_format\" = \"DEFAULT\"\n);"],
+    		"create_rollup": []
+    	},
+    	"count": 0
+    }
+    ```
+
+
+
+

--- a/docs/zh-CN/administrator-guide/http-actions/fe/get-load-info-action.md
+++ b/docs/zh-CN/administrator-guide/http-actions/fe/get-load-info-action.md
@@ -1,0 +1,95 @@
+---
+{
+    "title": "Get Load Info Action",
+    "language": "zh-CN"
+}
+---
+
+<!-- 
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+
+# Get Load Info Action
+
+## Request
+
+`GET /api/<db>/_load_info`
+
+## Description
+
+用于获取指定label的导入作业的信息。
+    
+## Path parameters
+
+* `<db>`
+
+    指定数据库
+
+## Query parameters
+
+* `label`
+
+    指定导入Label
+
+## Request body
+
+无
+
+## Response
+
+```
+{
+	"msg": "success",
+	"code": 0,
+	"data": {
+		"dbName": "default_cluster:db1",
+		"tblNames": ["tbl1"],
+		"label": "my_label",
+		"clusterName": "default_cluster",
+		"state": "FINISHED",
+		"failMsg": "",
+		"trackingUrl": ""
+	},
+	"count": 0
+}
+```
+    
+## Examples
+
+1. 获取指定 label 的导入作业信息
+
+    ```
+    GET /api/example_db/_load_info?label=my_label
+    
+    Response
+    {
+    	"msg": "success",
+    	"code": 0,
+    	"data": {
+    		"dbName": "default_cluster:db1",
+    		"tblNames": ["tbl1"],
+    		"label": "my_label",
+    		"clusterName": "default_cluster",
+    		"state": "FINISHED",
+    		"failMsg": "",
+    		"trackingUrl": ""
+    	},
+    	"count": 0
+    }
+    ```

--- a/docs/zh-CN/administrator-guide/http-actions/fe/get-load-state.md
+++ b/docs/zh-CN/administrator-guide/http-actions/fe/get-load-state.md
@@ -1,0 +1,88 @@
+---
+{
+    "title": "Get Load State",
+    "language": "zh-CN"
+}
+---
+
+<!-- 
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Get Load State
+
+## Request
+
+`GET /api/<db>/get_load_state`
+
+## Description
+
+返回指定label的导入事务的状态
+    
+## Path parameters
+
+* <db>
+
+    指定数据库
+
+## Query parameters
+
+* `label`
+
+    指定导入label
+
+## Request body
+
+无
+
+## Response
+
+```
+{
+	"msg": "success",
+	"code": 0,
+	"data": "VISIBLE",
+	"count": 0
+}
+```
+
+如label不存在，则返回：
+
+```
+{
+	"msg": "success",
+	"code": 0,
+	"data": "UNKNOWN",
+	"count": 0
+}
+```
+    
+## Examples
+
+1. 回去指定label的导入事务的状态。
+
+    ```
+    GET /api/example_db/get_load_state?label=my_label
+    
+    {
+    	"msg": "success",
+    	"code": 0,
+    	"data": "VISIBLE",
+    	"count": 0
+    }
+    ```

--- a/docs/zh-CN/administrator-guide/http-actions/fe/get-log-file-action.md
+++ b/docs/zh-CN/administrator-guide/http-actions/fe/get-log-file-action.md
@@ -1,0 +1,114 @@
+---
+{
+    "title": "Get FE log file",
+    "language": "zh-CN"
+}
+---
+
+<!-- 
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+
+# Get FE log file
+
+## Request
+
+`HEAD /api/get_log_file`
+
+`GET /api/get_log_file`
+
+## Description
+
+用户可以通过该 HTTP 接口获取 FE 的日志文件。
+
+其中 HEAD 请求用于获取指定日志类型的日志文件列表。GET 请求用于下载指定的日志文件。
+    
+## Path parameters
+
+无
+
+## Query parameters
+
+* `type`
+
+    指定日志类型，支持如下类型：
+    
+    * `fe.audit.log`：FE 审计日志
+
+* `file`
+
+    指定的文件名。
+
+指定表
+
+## Request body
+
+无
+
+## Response
+
+* `HEAD`
+
+    ```
+    HTTP/1.1 200 OK
+    file_infos: {"fe.audit.log":24759,"fe.audit.log.20190528.1":132934}
+    content-type: text/html
+    connection: keep-alive
+    ```
+    
+    返回的 header 中罗列出了当前所有指定类型的日志文件，以及每个文件的大小。
+    
+* `GET`
+
+    以文本形式下载指定日志文件
+    
+## Examples
+
+1. 获取对应类型的日志文件列表
+
+    ```
+    HEAD /api/get_log/file?type=fe.audit.log
+    
+    Response:
+    
+    HTTP/1.1 200 OK
+    file_infos: {"fe.audit.log":24759,"fe.audit.log.20190528.1":132934}
+    content-type: text/html
+    connection: keep-alive
+    ```
+    
+    在返回的 header 中，`file_infos` 字段以 json 格式展示文件列表以及对应文件大小（单位字节）
+    
+2. 下载日志文件
+    
+    ```
+    GET /api/get_log/file?type=fe.audit.log&file=fe.audit.log.20190528.1
+    
+    Response:
+    
+    < HTTP/1.1 200
+    < Vary: Origin
+    < Vary: Access-Control-Request-Method
+    < Vary: Access-Control-Request-Headers
+    < Content-Disposition: attachment;fileName=fe.audit.log
+    < Content-Type: application/octet-stream;charset=UTF-8
+    < Transfer-Encoding: chunked
+    
+    ... File Content ...
+    ```

--- a/docs/zh-CN/administrator-guide/http-actions/fe/get-small-file.md
+++ b/docs/zh-CN/administrator-guide/http-actions/fe/get-small-file.md
@@ -1,0 +1,101 @@
+---
+{
+    "title": "Get Small File Action",
+    "language": "zh-CN"
+}
+---
+
+<!-- 
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Get Small File
+
+## Request
+
+`GET /api/get_small_file`
+
+## Description
+
+通过文件id，下载在文件管理器中的文件。    
+## Path parameters
+
+无
+
+## Query parameters
+
+* `token`
+
+    集群的token。可以在 `palo-meta/image/VERSION` 文件中查看。
+
+* `file_id`
+    
+    文件管理器中显示的文件id。文件id可以通过 `SHOW FILE` 命令查看。
+
+## Request body
+
+无
+
+## Response
+
+```
+< HTTP/1.1 200
+< Vary: Origin
+< Vary: Access-Control-Request-Method
+< Vary: Access-Control-Request-Headers
+< Content-Disposition: attachment;fileName=ca.pem
+< Content-Type: application/json;charset=UTF-8
+< Transfer-Encoding: chunked
+
+... File Content ...
+```
+
+如有错误，则返回：
+
+```
+{
+	"msg": "File not found or is not content",
+	"code": 1,
+	"data": null,
+	"count": 0
+}
+```
+    
+## Examples
+
+1. 下载指定id的文件
+
+    ```
+    GET /api/get_small_file?token=98e8c0a6-3a41-48b8-a72b-0432e42a7fe5\&file_id=11002
+    
+    Response:
+    
+    < HTTP/1.1 200
+    < Vary: Origin
+    < Vary: Access-Control-Request-Method
+    < Vary: Access-Control-Request-Headers
+    < Content-Disposition: attachment;fileName=ca.pem
+    < Content-Type: application/json;charset=UTF-8
+    < Transfer-Encoding: chunked
+    
+    ... File Content ...
+    ```
+
+
+
+

--- a/docs/zh-CN/administrator-guide/http-actions/fe/health-action.md
+++ b/docs/zh-CN/administrator-guide/http-actions/fe/health-action.md
@@ -1,0 +1,80 @@
+---
+{
+    "title": "Health Action",
+    "language": "zh-CN"
+}
+---
+
+<!-- 
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Health Action
+
+## Request
+
+`GET /api/health`
+
+## Description
+
+返回集群当前存活的 BE 节点数和宕机的 BE 节点数。
+    
+## Path parameters
+
+无
+
+## Query parameters
+
+无
+
+## Request body
+
+无
+
+## Response
+
+```
+{
+	"msg": "success",
+	"code": 0,
+	"data": {
+		"online_backend_num": 10,
+		"total_backend_num": 10
+	},
+	"count": 0
+}
+```
+    
+## Examples
+
+1. 获取集群节点健康信息
+
+    ```
+    GET /api/health
+    
+    Response:
+    {
+    	"msg": "success",
+    	"code": 0,
+    	"data": {
+    		"online_backend_num": 10,
+    		"total_backend_num": 10
+    	},
+    	"count": 0
+    }
+    ```

--- a/docs/zh-CN/administrator-guide/http-actions/fe/meta-action.md
+++ b/docs/zh-CN/administrator-guide/http-actions/fe/meta-action.md
@@ -1,0 +1,61 @@
+---
+{
+    "title": "Meta Action",
+    "language": "zh-CN"
+}
+---
+
+<!-- 
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Meta Action
+
+## Request
+
+```
+GET /image
+GET /info
+GET /version
+GET /put
+GET /journal_id
+GET /role
+GET /check
+GET /dump
+```
+
+## Description
+
+这是一组 FE 元数据相关的 API，除了 `/dump` 以外，都为 FE 节点之间内部通讯用。
+    
+## Path parameters
+
+
+## Query parameters
+
+无
+
+## Request body
+
+无
+
+## Response
+
+    
+## Examples
+

--- a/docs/zh-CN/administrator-guide/http-actions/fe/meta-replay-state-action.md
+++ b/docs/zh-CN/administrator-guide/http-actions/fe/meta-replay-state-action.md
@@ -1,0 +1,61 @@
+---
+{
+    "title": "Meta Replay State Action",
+    "language": "zh-CN"
+}
+---
+
+<!-- 
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Meta Replay State Action
+
+（未实现）
+
+## Request
+
+`GET /api/_meta_replay_state`
+
+## Description
+
+获取 FE 节点元数据回放的状态。
+    
+## Path parameters
+
+无
+
+## Query parameters
+
+无
+
+## Request body
+
+无
+
+## Response
+
+TODO
+    
+## Examples
+
+TODO
+
+
+
+

--- a/docs/zh-CN/administrator-guide/http-actions/fe/profile-action.md
+++ b/docs/zh-CN/administrator-guide/http-actions/fe/profile-action.md
@@ -1,0 +1,80 @@
+---
+{
+    "title": "Profile Action",
+    "language": "zh-CN"
+}
+---
+
+<!-- 
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Profile Action
+
+## Request
+
+`GET /api/profile`
+
+## Description
+
+用于获取指定 query id 的 query profile
+    
+## Path parameters
+
+无
+
+## Query parameters
+
+* query_id
+
+    指定的 query id
+
+## Request body
+
+无
+
+## Response
+
+```
+{
+	"msg": "success",
+	"code": 0,
+	"data": {
+		"profile": "query profile ..."
+	},
+	"count": 0
+}
+```
+    
+## Examples
+
+1. 获取指定 query_id 的 query profile
+
+    ```
+    GET /api/profile?query_id=f732084bc8e74f39-8313581c9c3c0b58
+    
+    Response:
+    {
+    	"msg": "success",
+    	"code": 0,
+    	"data": {
+    		"profile": "query profile ..."
+    	},
+    	"count": 0
+    }
+    ```

--- a/docs/zh-CN/administrator-guide/http-actions/fe/query-detail-action.md
+++ b/docs/zh-CN/administrator-guide/http-actions/fe/query-detail-action.md
@@ -1,0 +1,116 @@
+---
+{
+    "title": "Query Detail Action",
+    "language": "zh-CN"
+}
+---
+
+<!-- 
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Query Detail Action
+
+## Request
+
+`GET /api/query_detail`
+
+## Description
+
+用于获取指定时间点之后的所有查询的信息
+    
+## Path parameters
+
+无
+
+## Query parameters
+
+* `event_time`
+
+    指定的时间点（Unix 时间戳，单位毫秒），获取该时间点之后的查询信息。
+    
+## Request body
+
+无
+
+## Response
+
+```
+{
+	"msg": "success",
+	"code": 0,
+	"data": {
+		"query_details": [{
+			"eventTime": 1596462699216,
+			"queryId": "f732084bc8e74f39-8313581c9c3c0b58",
+			"startTime": 1596462698969,
+			"endTime": 1596462699216,
+			"latency": 247,
+			"state": "FINISHED",
+			"database": "db1",
+			"sql": "select * from tbl1"
+		}, {
+			"eventTime": 1596463013929,
+			"queryId": "ed2d0d80855d47a5-8b518a0f1472f60c",
+			"startTime": 1596463013913,
+			"endTime": 1596463013929,
+			"latency": 16,
+			"state": "FINISHED",
+			"database": "db1",
+			"sql": "select k1 from tbl1"
+		}]
+	},
+	"count": 0
+}
+```
+    
+## Examples
+
+1. 获取指定时间点之后的查询详情。
+
+    ```
+    GET /api/query_detail?event_time=1596462079958
+    
+    Response:
+    {
+    	"msg": "success",
+    	"code": 0,
+    	"data": {
+    		"query_details": [{
+    			"eventTime": 1596462699216,
+    			"queryId": "f732084bc8e74f39-8313581c9c3c0b58",
+    			"startTime": 1596462698969,
+    			"endTime": 1596462699216,
+    			"latency": 247,
+    			"state": "FINISHED",
+    			"database": "db1",
+    			"sql": "select * from tbl1"
+    		}, {
+    			"eventTime": 1596463013929,
+    			"queryId": "ed2d0d80855d47a5-8b518a0f1472f60c",
+    			"startTime": 1596463013913,
+    			"endTime": 1596463013929,
+    			"latency": 16,
+    			"state": "FINISHED",
+    			"database": "db1",
+    			"sql": "select k1 from tbl1"
+    		}]
+    	},
+    	"count": 0
+    }
+    ```

--- a/docs/zh-CN/administrator-guide/http-actions/fe/row-count-action.md
+++ b/docs/zh-CN/administrator-guide/http-actions/fe/row-count-action.md
@@ -1,0 +1,84 @@
+---
+{
+    "title": "Row Count Action",
+    "language": "zh-CN"
+}
+---
+
+<!-- 
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Row Count Action
+
+## Request
+
+`GET /api/rowcount`
+
+## Description
+
+用于手动更新指定表的行数统计信息。在更新行数统计信息的同时，也会以 JSON 格式返回表以及对应rollup的行数
+    
+## Path parameters
+
+无
+
+## Query parameters
+
+* `db`
+
+    指定的数据库
+
+* `table`
+
+    指定的表名
+
+## Request body
+
+无
+
+## Response
+
+```
+{
+	"msg": "success",
+	"code": 0,
+	"data": {
+		"tbl1": 10000
+	},
+	"count": 0
+}
+```
+    
+## Examples
+
+1. 更新并获取指定 Table 的行数
+
+    ```
+    GET /api/rowcount?db=example_db&table=tbl1
+    
+    Response:
+    {
+    	"msg": "success",
+    	"code": 0,
+    	"data": {
+    		"tbl1": 10000
+    	},
+    	"count": 0
+    }
+    ```

--- a/docs/zh-CN/administrator-guide/http-actions/fe/set-config-action.md
+++ b/docs/zh-CN/administrator-guide/http-actions/fe/set-config-action.md
@@ -1,0 +1,93 @@
+---
+{
+    "title": "Set Config Action",
+    "language": "zh-CN"
+}
+---
+
+<!-- 
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Set Config Action
+
+## Request
+
+`GET /api/_set_config`
+
+## Description
+
+用于动态设置 FE 的参数。该命令等通过 `ADMIN SET FRONTEND CONFIG` 命令。但该命令仅会设置对应 FE 节点的配置。并且不会自动转发 `MasterOnly` 配置项给 Master
+ FE 节点。
+    
+## Path parameters
+
+无
+
+## Query parameters
+
+* `confkey1=confvalue1`
+
+    指定要设置的配置名称，其值为要修改的配置值。
+
+## Request body
+
+无
+
+## Response
+
+```
+{
+	"msg": "success",
+	"code": 0,
+	"data": {
+		"set": {
+			"storage_min_left_capacity_bytes": "1024",
+			"qe_max_connection": "2048"
+		},
+		"err": {
+		   "replica_ack_policy": "SIMPLE_MAJORITY"
+		}
+	},
+	"count": 0
+}
+```
+
+`set` 字段表示设置成功的配置。`err` 字段表示设置失败的配置。
+    
+## Examples
+
+1. 设置 `max_bytes_per_broker_scanner` 和 `max_broker_concurrency` 两个配置的值。
+
+    ```
+    GET /api/_set_config?max_bytes_per_broker_scanner=21474836480&max_broker_concurrency=20
+    
+    Response:
+    {
+    	"msg": "success",
+    	"code": 0,
+    	"data": {
+    		"set": {
+    			"max_bytes_per_broker_scanner": "21474836480",
+    			"max_broker_concurrency": "20"
+    		},
+    		"err": {}
+    	},
+    	"count": 0
+    }
+    ```

--- a/docs/zh-CN/administrator-guide/http-actions/fe/show-data-action.md
+++ b/docs/zh-CN/administrator-guide/http-actions/fe/show-data-action.md
@@ -1,0 +1,111 @@
+---
+{
+    "title": "Set Data Action",
+    "language": "zh-CN"
+}
+---
+
+<!-- 
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Set Data Action
+
+## Request
+
+`GET /api/show_data`
+
+## Description
+
+用于获取集群的总数据量，或者指定数据库的数据量。单位字节。
+    
+## Path parameters
+
+无
+
+## Query parameters
+
+* `db`
+
+    可选。如果指定，则获取指定数据库的数据量。
+
+## Request body
+
+无
+
+## Response
+
+1. 指定数据库的数据量。
+
+    ```
+    {
+    	"msg": "success",
+    	"code": 0,
+    	"data": {
+    		"default_cluster:db1": 381
+    	},
+    	"count": 0
+    }
+    ```
+    
+2. 总数据量
+
+    ```
+    {
+    	"msg": "success",
+    	"code": 0,
+    	"data": {
+    		"__total_size": 381
+    	},
+    	"count": 0
+    }
+    ```
+    
+## Examples
+
+1. 获取指定数据库的数据量
+
+    ```
+    GET /api/show_data?db=db1
+    
+    Response:
+    {
+    	"msg": "success",
+    	"code": 0,
+    	"data": {
+    		"default_cluster:db1": 381
+    	},
+    	"count": 0
+    }
+    ```
+
+2. 获取集群总数据量
+
+    ```
+    GET /api/show_data
+        
+    Response:
+    {
+    	"msg": "success",
+    	"code": 0,
+    	"data": {
+    		"__total_size": 381
+    	},
+    	"count": 0
+    }
+    ```

--- a/docs/zh-CN/administrator-guide/http-actions/fe/show-meta-info-action.md
+++ b/docs/zh-CN/administrator-guide/http-actions/fe/show-meta-info-action.md
@@ -1,0 +1,138 @@
+---
+{
+    "title": "Show Meta Info Action",
+    "language": "zh-CN"
+}
+---
+
+<!-- 
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Show Meta Info Action
+
+## Request
+
+`GET /api/show_meta_info`
+
+## Description
+
+用于显示一些元数据信息
+    
+## Path parameters
+
+无
+
+## Query parameters
+
+* action
+
+    指定要获取的元数据信息类型。目前支持如下：
+    
+    * `SHOW_DB_SIZE`
+
+        获取指定数据库的数据量大小，单位为字节。
+        
+    * `SHOW_HA`
+
+        获取 FE 元数据日志的回放情况，以及可选举组的情况。
+
+## Request body
+
+无
+
+## Response
+
+
+* `SHOW_DB_SIZE`
+
+    ```
+    {
+    	"msg": "success",
+    	"code": 0,
+    	"data": {
+    		"default_cluster:information_schema": 0,
+    		"default_cluster:db1": 381
+    	},
+    	"count": 0
+    }
+    ```
+    
+* `SHOW_HA`
+
+    ```
+    {
+    	"msg": "success",
+    	"code": 0,
+    	"data": {
+    		"can_read": "true",
+    		"role": "MASTER",
+    		"is_ready": "true",
+    		"last_checkpoint_version": "1492",
+    		"last_checkpoint_time": "1596465109000",
+    		"current_journal_id": "1595",
+    		"electable_nodes": "",
+    		"observer_nodes": "",
+    		"master": "10.81.85.89"
+    	},
+    	"count": 0
+    }
+    ```
+    
+## Examples
+
+1. 查看集群各个数据库的数据量大小
+
+    ```
+    GET /api/show_meta_info?action=show_db_size
+    
+    Response:
+    {
+    	"msg": "success",
+    	"code": 0,
+    	"data": {
+    		"default_cluster:information_schema": 0,
+    		"default_cluster:db1": 381
+    	},
+    	"count": 0
+    }
+    ```
+    
+2. 查看FE选举组情况
+
+    ```
+    GET /api/show_meta_info?action=show_ha
+    
+    Response:
+    {
+    	"msg": "success",
+    	"code": 0,
+    	"data": {
+    		"can_read": "true",
+    		"role": "MASTER",
+    		"is_ready": "true",
+    		"last_checkpoint_version": "1492",
+    		"last_checkpoint_time": "1596465109000",
+    		"current_journal_id": "1595",
+    		"electable_nodes": "",
+    		"observer_nodes": "",
+    		"master": "10.81.85.89"
+    	},
+    	"count": 0
+    }
+    ```

--- a/docs/zh-CN/administrator-guide/http-actions/fe/show-proc-action.md
+++ b/docs/zh-CN/administrator-guide/http-actions/fe/show-proc-action.md
@@ -1,0 +1,104 @@
+---
+{
+    "title": "Show Proc Action",
+    "language": "zh-CN"
+}
+---
+
+<!-- 
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Show Proc Action
+
+## Request
+
+`GET /api/show_proc`
+
+## Description
+
+用于获取 PROC 信息。
+    
+## Path parameters
+
+无
+
+## Query parameters
+
+* path
+
+    指定的 Proc Path
+    
+* forward
+
+    是否转发给 Master FE 执行
+
+## Request body
+
+无
+
+## Response
+
+```
+{
+	"msg": "success",
+	"code": 0,
+	"data": [
+		proc infos ...
+	],
+	"count": 0
+}
+```
+    
+## Examples
+
+1. 查看 `/statistic` 信息
+
+    ```
+    GET /api/show_proc?path=/statistic
+    
+    Response:
+    {
+    	"msg": "success",
+    	"code": 0,
+    	"data": [
+    		["10003", "default_cluster:db1", "2", "3", "3", "3", "3", "0", "0", "0"],
+    		["10013", "default_cluster:doris_audit_db__", "1", "4", "4", "4", "4", "0", "0", "0"],
+    		["Total", "2", "3", "7", "7", "7", "7", "0", "0", "0"]
+    	],
+    	"count": 0
+    }
+    ```
+    
+2. 转发到 Master 执行
+
+    ```
+    GET /api/show_proc?path=/statistic&forward=true
+    
+    Response:
+    {
+    	"msg": "success",
+    	"code": 0,
+    	"data": [
+    		["10003", "default_cluster:db1", "2", "3", "3", "3", "3", "0", "0", "0"],
+    		["10013", "default_cluster:doris_audit_db__", "1", "4", "4", "4", "4", "0", "0", "0"],
+    		["Total", "2", "3", "7", "7", "7", "7", "0", "0", "0"]
+    	],
+    	"count": 0
+    }
+    ```

--- a/docs/zh-CN/administrator-guide/http-actions/fe/show-runtime-info-action.md
+++ b/docs/zh-CN/administrator-guide/http-actions/fe/show-runtime-info-action.md
@@ -1,0 +1,84 @@
+---
+{
+    "title": "Show Runtime Info Action",
+    "language": "zh-CN"
+}
+---
+
+<!-- 
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Show Runtime Info Action
+
+## Request
+
+`GET /api/show_runtime_info`
+
+## Description
+
+用于获取 FE JVM 的 Runtime 信息
+    
+## Path parameters
+
+无
+
+## Query parameters
+
+无
+
+## Request body
+
+无
+
+## Response
+
+```
+{
+	"msg": "success",
+	"code": 0,
+	"data": {
+		"free_mem": "855642056",
+		"total_mem": "1037959168",
+		"thread_cnt": "98",
+		"max_mem": "1037959168"
+	},
+	"count": 0
+}
+```
+    
+## Examples
+
+1. 回去当前 FE 节点的 JVM 信息
+
+    ```
+    GET /api/show_runtime_info
+    
+    Response:
+    {
+    	"msg": "success",
+    	"code": 0,
+    	"data": {
+    		"free_mem": "855642056",
+    		"total_mem": "1037959168",
+    		"thread_cnt": "98",
+    		"max_mem": "1037959168"
+    	},
+    	"count": 0
+    }
+    ```

--- a/docs/zh-CN/administrator-guide/http-actions/fe/table-query-plan-action.md
+++ b/docs/zh-CN/administrator-guide/http-actions/fe/table-query-plan-action.md
@@ -1,0 +1,113 @@
+---
+{
+    "title": "Table Query Plan Action",
+    "language": "zh-CN"
+}
+---
+
+<!-- 
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Table Query Plan Action
+
+## Request
+
+`POST /api/<db>/<table>/_query_plan`
+
+## Description
+
+给定一个 SQL，用于获取该 SQL 对应的查询计划。
+
+该接口目前用于 Spark-Doris-Connector 中，Spark 获取 Doris 的查询计划。
+    
+## Path parameters
+
+* `<db>`
+
+    指定数据库
+    
+* `<table>`
+
+    指定表
+
+## Query parameters
+
+无
+
+## Request body
+
+```
+{
+	"sql": "select * from db1.tbl1;"
+}
+```
+
+## Response
+
+```
+{
+	"msg": "success",
+	"code": 0,
+	"data": {
+		"partitions": {
+			"10039": {
+				"routings": ["10.81.85.89:9062"],
+				"version": 2,
+				"versionHash": 982459448378619656,
+				"schemaHash": 1294206575
+			}
+		},
+		"opaqued_query_plan": "DAABDAACDwABDAAAAAEIAAEAAAAACAACAAAAAAgAAwAAAAAKAAT//////////w8ABQgAAAABAAAAAA8ABgIAAAABAAIACAAMABIIAAEAAAAADwACCwAAAAIAAAACazEAAAACazIPAAMIAAAAAgAAAAUAAAAFAgAEAQAAAA8ABAwAAAACDwABDAAAAAEIAAEAAAAQDAACDwABDAAAAAEIAAEAAAAADAACCAABAAAABQAAAAgABAAAAAAMAA8IAAEAAAAACAACAAAAAAAIABT/////CAAX/////wAADwABDAAAAAEIAAEAAAAQDAACDwABDAAAAAEIAAEAAAAADAACCAABAAAABQAAAAgABAAAAAAMAA8IAAEAAAABCAACAAAAAAAIABT/////CAAX/////wAADAAFCAABAAAABgwACAAADAAGCAABAAAAAA8AAgwAAAAAAAoABwAAAAAAAAAACgAIAAAAAAAAAAAADQACCgwAAAABAAAAAAAAJzcKAAEAAAAAAAAnNwoAAgAAAAAAAAACCgADDaJlqbrVdwgIAARNJAZvAAwAAw8AAQwAAAACCAABAAAAAAgAAgAAAAAMAAMPAAEMAAAAAQgAAQAAAAAMAAIIAAEAAAAFAAAACAAE/////wgABQAAAAQIAAYAAAAACAAHAAAAAAsACAAAAAJrMQgACQAAAAACAAoBAAgAAQAAAAEIAAIAAAAADAADDwABDAAAAAEIAAEAAAAADAACCAABAAAABQAAAAgABP////8IAAUAAAAICAAGAAAAAAgABwAAAAELAAgAAAACazIIAAkAAAABAgAKAQAPAAIMAAAAAQgAAQAAAAAIAAIAAAAMCAADAAAAAQoABAAAAAAAACc1CAAFAAAAAgAPAAMMAAAAAQoAAQAAAAAAACc1CAACAAAAAQgAAwAAAAIIAAQAAAAACwAHAAAABHRibDELAAgAAAAADAALCwABAAAABHRibDEAAAAMAAQKAAFfL5rpxl1I4goAArgs6f+h6eMxAAA=",
+		"status": 200
+	},
+	"count": 0
+}
+```
+
+其中 `opaqued_query_plan` 为查询计划的二进制格式。
+    
+## Examples
+
+1. 获取指定 sql 的查询计划
+
+    ```
+    POST /api/db1/tbl1/_query_plan
+    {
+        "sql": "select * from db1.tbl1;"
+    }
+    
+    Response:
+    {
+    	"msg": "success",
+    	"code": 0,
+    	"data": {
+    		"partitions": {
+    			"10039": {
+    				"routings": ["10.81.85.89:9062"],
+    				"version": 2,
+    				"versionHash": 982459448378619656,
+    				"schemaHash": 1294206575
+    			}
+    		},
+    		"opaqued_query_plan": "DAABDAACDwABD...",
+    		"status": 200
+    	},
+    	"count": 0
+    }
+    ```

--- a/docs/zh-CN/administrator-guide/http-actions/fe/table-row-count-action.md
+++ b/docs/zh-CN/administrator-guide/http-actions/fe/table-row-count-action.md
@@ -1,0 +1,88 @@
+---
+{
+    "title": "Table Row Count Action",
+    "language": "zh-CN"
+}
+---
+
+<!-- 
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Table Row Count Action
+
+## Request
+
+`GET /api/<db>/<table>/_count`
+
+## Description
+
+用于获取指定表的行数统计信息。该接口目前用于 Spark-Doris-Connector 中，Spark 获取 Doris 的表统计信息。
+    
+## Path parameters
+
+* `<db>`
+
+    指定数据库
+
+* `<table>`
+
+    指定表
+
+## Query parameters
+
+无
+
+## Request body
+
+无
+
+## Response
+
+```
+{
+	"msg": "success",
+	"code": 0,
+	"data": {
+		"size": 1,
+		"status": 200
+	},
+	"count": 0
+}
+```
+
+其中 `data.size` 字段表示指定表的行数。
+    
+## Examples
+
+1. 获取指定表的行数。
+
+    ```
+    GET /api/db1/tbl1/_count
+    
+    Response:
+    {
+    	"msg": "success",
+    	"code": 0,
+    	"data": {
+    		"size": 1,
+    		"status": 200
+    	},
+    	"count": 0
+    }
+    ```

--- a/docs/zh-CN/administrator-guide/http-actions/fe/table-schema-action.md
+++ b/docs/zh-CN/administrator-guide/http-actions/fe/table-schema-action.md
@@ -1,0 +1,102 @@
+---
+{
+    "title": "Table Schema Action",
+    "language": "zh-CN"
+}
+---
+
+<!-- 
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Table Schema Action
+
+## Request
+
+`GET /api/<db>/<table>/_schema`
+
+## Description
+
+用于获取指定表的表结构信息。该接口目前用于 Spark-Doris-Connector 中，Spark 获取 Doris 的表结构信息。
+    
+## Path parameters
+
+* `<db>`
+
+    指定数据库
+
+* `<table>`
+
+    指定表
+
+## Query parameters
+
+无
+
+## Request body
+
+无
+
+## Response
+
+```
+{
+	"msg": "success",
+	"code": 0,
+	"data": {
+		"properties": [{
+			"type": "INT",
+			"name": "k1",
+			"comment": ""
+		}, {
+			"type": "INT",
+			"name": "k2",
+			"comment": ""
+		}],
+		"status": 200
+	},
+	"count": 0
+}
+```
+    
+## Examples
+
+1. 获取指定表的表结构信息。
+
+    ```
+    GET /api/db1/tbl1/_schema
+    
+    Response:
+    {
+    	"msg": "success",
+    	"code": 0,
+    	"data": {
+    		"properties": [{
+    			"type": "INT",
+    			"name": "k1",
+    			"comment": ""
+    		}, {
+    			"type": "INT",
+    			"name": "k2",
+    			"comment": ""
+    		}],
+    		"status": 200
+    	},
+    	"count": 0
+    }
+    ```

--- a/docs/zh-CN/developer-guide/restful-api-design-doc.md
+++ b/docs/zh-CN/developer-guide/restful-api-design-doc.md
@@ -1,0 +1,119 @@
+---
+{
+    "title": "RESTful API Design Doc",
+    "language": "zh-CN"
+}
+---
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# RESTful API 设计文档
+
+为了便于后续前端和后端代码分离，需要规范后端提供的 RESTful API 的语义和返回结果。本文档给出一个简单的设计原则，供后续修改或新增 API 时参考。
+
+## 总体设计
+
+### URI 设计
+
+1. Path
+
+    资源访问路径，一般由名词组成。如:
+    
+    ```
+    /api/v1/load
+    /api/v1/query
+    ```
+    
+    通常 `/api/v1` 为固定开头样式，表示 api 的版本信息。
+    
+    Path 的设计通常要满足资源的从属关系。示例如下：
+    
+    ```
+    /api/v1/load/<db>/stream_load/
+    /api/v1/load/<db>/bulk_load/
+    ```
+    
+    其中 `stream_load` 和 `bulk_load` 为 `load` 类型下的子类。而 `<db>` 为 Path Parameter，在 Path 中表示**在具体对象下将要展开的操作**。
+
+2. Path parameter
+
+    Path parameter 是在 Path 中传递的参数，通常为必须参数，
+    
+3. Query parameter
+
+    在URI中问号（?）之后出现的key-value的参数，通常是可选参数。但这并不是强制的，可以根据需要灵活选择。
+    
+### 方法设计
+
+RESTful API 中常见的操作方法为 POST、PUT、GET、DELETE。
+
+1. POST
+
+    POST 通常意味着创建一个新的资源。这个方法不强调幂等性。可以携带 JSON 格式的 Request Body。而返回结果通常也是 JSON 格式的。执行成功的 HTTP status code 通常为 201。
+    
+2. PUT
+
+    PUT 通常用来对已有资源进行更新。并且通常是进行全量更新而不是部分更新。这个方法建议保证幂等性。可以携带 JSON 格式的 Request Body。而返回结果通常也是 JSON 格式的。执行成功的 HTTP status code 通常为 200。
+
+3. DELETE
+
+    DELETE 用于删除资源。本身建议保证幂等性。执行成功的 HTTP status code 通常为 204。
+    
+4. GET
+
+    GET 用于获取资源。执行成功的 HTTP status code 通常为 202。GET 方法的条件通常通过 Query Parameter 传递。但对于一些非常复杂的查询场景，可能导致 URI 非常长。因此，有时也可以使用 POST 方法将查询条件放在 Request Body 中，来实现复杂的查询请求。
+
+
+## Frontend
+
+原则上 Frontend 的虽有 RESTful API 都应该遵循总体设计原则。但是一些现存的 API 考虑到兼容性问题和改动成本，保留已有的设计实现。
+
+1. Http Status Code
+
+    * 401：权限校验失败后返回。包括密码错误、权限错误等。
+    * 400：Bad Request。参数缺失、参数格式错误等。
+    * 500：内部错误。通常表示一些未知错误或者未正确处理的错误。任何在预期内的错误和服务端能够处理的错误，都不应该返回 500。
+    * 200(201,204)：执行成功时返回。执行成功包括请求被正常处理，以及请求失败但被服务器正确处理的请求。
+
+2. Response Body
+
+    除了一些已经在大规模使用的 API 外，返回结构应统一使用以下格式：
+    
+    ```
+    {
+        "code": 0,
+        "msg": "success",
+        "data": {
+        	...
+        },
+        "count": 0
+    }
+    ```
+    
+    该返回体只有在 Http Status Code 为 200(201, 204) 的情况下才会返回。
+    
+    * code：Doris 内部的错误码。0表示执行成功。其他值表示执行错误。
+    * msg：如果 code 为 0，则这个字段为 success，否则，这个字段会显示详细的错误信息。
+    * data：API 的具体返回结果。只有当 code 为 0 时，该字段才会被设置。否则，该字段为 null。data 字段内的具体格式暂不做要求，可以为任意 JSON 类型。但需要考虑扩展性，比如方便后续增加其他返回结果。
+    * count：用于一些前端查看返回结果的大小（如行数）。当前暂不使用。
+
+## Backend
+
+（TODO）


### PR DESCRIPTION
## Proposed changes

In the future, Doris needs to separate the front(UI) and back(Server) ends,
so a standardized RESTful api document is needed to guide the subsequent api design.

You can view the `restful-api-design-doc.md` to see the design guidance of API.
And I rewrite of document of FE RESULT api under `http-actions/fe/`.

This CL does not change any existing code. Only add document.
The change of these API will be in next PR after discuss.


## Types of changes

- [x] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have create an issue on #4260, and have described the bug/feature there in detail
- [x] If this change need a document change, I have updated the document

## Further comments

This CL only contains docs in Chinese, after discussion, I will add English doc later.
