### PR TITLE
Fix cancel query bug

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectProcessor.java
@@ -189,6 +189,7 @@ public class ConnectProcessor {
                 parsedStmt = stmts.get(i);
                 parsedStmt.setOrigStmt(new OriginStatement(originStmt, i));
                 executor = new StmtExecutor(ctx, parsedStmt);
+                ctx.setExecutor(executor);
                 executor.execute();
 
                 if (i != stmts.size() - 1) {


### PR DESCRIPTION
ConnectContext.kill() use executor to cancel query, but executor has never been set.