### PR TITLE
Fix be crash caused by decimal to date

### DIFF
--- a/be/src/exprs/decimalv2_operators.cpp
+++ b/be/src/exprs/decimalv2_operators.cpp
@@ -147,6 +147,22 @@ DateTimeVal DecimalV2Operators::cast_to_datetime_val(
     return result;
 }
 
+DateTimeVal DecimalV2Operators::cast_to_date_val(
+        FunctionContext* context, const DecimalV2Val& val) {
+    if (val.is_null) {
+        return DateTimeVal::null();
+    }
+    const DecimalV2Value& dv = DecimalV2Value::from_decimal_val(val);
+    DateTimeValue dt;
+    if (!dt.from_date_int64(dv)) {
+        return DateTimeVal::null();
+    }
+    dt.cast_to_date();
+    DateTimeVal result;
+    dt.to_datetime_val(&result);
+    return result;
+}
+
 DecimalVal DecimalV2Operators::cast_to_decimal_val(
             FunctionContext* context, const DecimalV2Val& val) {
     if (val.is_null) return DecimalVal::null();

--- a/be/src/exprs/decimalv2_operators.cpp
+++ b/be/src/exprs/decimalv2_operators.cpp
@@ -152,6 +152,8 @@ DateTimeVal DecimalV2Operators::cast_to_date_val(
     if (val.is_null) {
         return DateTimeVal::null();
     }
+
+    // convert from DecimalV2Val to DecimalV2Value for caculation
     const DecimalV2Value& dv = DecimalV2Value::from_decimal_val(val);
     DateTimeValue dt;
     if (!dt.from_date_int64(dv)) {

--- a/be/src/exprs/decimalv2_operators.h
+++ b/be/src/exprs/decimalv2_operators.h
@@ -54,6 +54,7 @@ public:
     static DoubleVal cast_to_double_val(FunctionContext*, const DecimalV2Val&);
     static StringVal cast_to_string_val(FunctionContext*, const DecimalV2Val&);
     static DateTimeVal cast_to_datetime_val(FunctionContext*, const DecimalV2Val&);
+    static DateTimeVal cast_to_date_val(FunctionContext*, const DecimalV2Val&);
     static DecimalVal cast_to_decimal_val(FunctionContext*, const DecimalV2Val&);
 
     static DecimalV2Val add_decimalv2_val_decimalv2_val(


### PR DESCRIPTION
## Proposed changes

Fix be crash caused by cast decimal to date. A be crashed bug caused by Unable to find. _ZN5doris18DecimalV2Operators16cast_to_date_val.
also see #4281 

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] Documentation Update (if none of the other choices apply)
- [] Code refactor (Modify the code structure, format the code, etc...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have create an issue on #ISSUE, and have described the bug/feature there in detail
- [x] Compiling and unit tests pass locally with my changes
- [] I have added tests that prove my fix is effective or that my feature works
- [] If this change need a document change, I have updated the document
- [] Any dependent changes have been merged

