### PR TITLE
Add LargeInt cast to Date and Datatime,  add  timezone to stale_version_path_json_doc

### DIFF
--- a/be/src/exprs/cast_functions.cpp
+++ b/be/src/exprs/cast_functions.cpp
@@ -222,6 +222,7 @@ StringVal CastFunctions::cast_to_string_val(FunctionContext* ctx, const StringVa
   StringVal sv;
   sv.ptr = val.ptr;
   sv.len = val.len;
+  
   const FunctionContext::TypeDesc& result_type = ctx->get_return_type();
   if (result_type.len > 0) {
       AnyValUtil::TruncateIfNecessary(result_type, &sv);
@@ -305,6 +306,7 @@ CAST_FROM_DATETIME(DoubleVal, double_val);
     CAST_TO_DATETIME(SmallIntVal);\
     CAST_TO_DATETIME(IntVal);\
     CAST_TO_DATETIME(BigIntVal);\
+    CAST_TO_DATETIME(LargeIntVal);\
     CAST_TO_DATETIME(FloatVal);\
     CAST_TO_DATETIME(DoubleVal);
 
@@ -327,6 +329,7 @@ CAST_TO_DATETIMES();
     CAST_TO_DATE(SmallIntVal);\
     CAST_TO_DATE(IntVal);\
     CAST_TO_DATE(BigIntVal);\
+    CAST_TO_DATE(LargeIntVal);\
     CAST_TO_DATE(FloatVal);\
     CAST_TO_DATE(DoubleVal);
 

--- a/be/src/exprs/cast_functions.h
+++ b/be/src/exprs/cast_functions.h
@@ -124,6 +124,7 @@ public:
     static DateTimeVal cast_to_datetime_val(FunctionContext* context, const SmallIntVal& val);
     static DateTimeVal cast_to_datetime_val(FunctionContext* context, const IntVal& val);
     static DateTimeVal cast_to_datetime_val(FunctionContext* context, const BigIntVal& val);
+    static DateTimeVal cast_to_datetime_val(FunctionContext* context, const LargeIntVal& val);
     static DateTimeVal cast_to_datetime_val(FunctionContext* context, const FloatVal& val);
     static DateTimeVal cast_to_datetime_val(FunctionContext* context, const DoubleVal& val);
     static DateTimeVal cast_to_datetime_val(FunctionContext* context, const DateTimeVal& val);
@@ -133,6 +134,7 @@ public:
     static DateTimeVal cast_to_date_val(FunctionContext* context, const SmallIntVal& val);
     static DateTimeVal cast_to_date_val(FunctionContext* context, const IntVal& val);
     static DateTimeVal cast_to_date_val(FunctionContext* context, const BigIntVal& val);
+    static DateTimeVal cast_to_date_val(FunctionContext* context, const LargeIntVal& val);
     static DateTimeVal cast_to_date_val(FunctionContext* context, const FloatVal& val);
     static DateTimeVal cast_to_date_val(FunctionContext* context, const DoubleVal& val);
     static DateTimeVal cast_to_date_val(FunctionContext* context, const DateTimeVal& val);

--- a/be/src/olap/version_graph.cpp
+++ b/be/src/olap/version_graph.cpp
@@ -19,6 +19,7 @@
 
 #include <memory>
 #include <queue>
+#include <cctz/time_zone.h>
 
 #include "common/logging.h"
 #include "util/time.h"
@@ -62,7 +63,11 @@ void TimestampedVersionTracker::get_stale_version_path_json_doc(rapidjson::Docum
         item.AddMember("path id", path_id_value, path_arr.GetAllocator());
 
         // add max create time to item
-        std::string create_time_str = ToStringFromUnix(path_version_path->max_create_time());
+        auto time_zone = cctz::local_time_zone();
+
+        auto tp = std::chrono::system_clock::from_time_t(path_version_path->max_create_time());
+        auto create_time_str = cctz::format("%Y-%m-%d %H:%M:%S %z", tp, time_zone);
+
         rapidjson::Value create_time_value;
         create_time_value.SetString(create_time_str.c_str(), create_time_str.length(), path_arr.GetAllocator());
         item.AddMember("last create time", create_time_value, path_arr.GetAllocator());

--- a/be/test/olap/timestamped_version_tracker_test.cpp
+++ b/be/test/olap/timestamped_version_tracker_test.cpp
@@ -1,4 +1,5 @@
 #include <gtest/gtest.h>
+#include <cctz/time_zone.h>
 #include <sstream>
 #include <fstream>
 #include "boost/filesystem.hpp"
@@ -7,6 +8,7 @@
 #include "olap/version_graph.h"
 #include "olap/olap_meta.h"
 #include "olap/rowset/rowset_meta.h"
+#include "gutil/strings/substitute.h"
 
 namespace doris {
 
@@ -770,29 +772,34 @@ TEST_F(TestTimestampedVersionTracker, get_stale_version_path_json_doc) {
     path_arr.Accept(writer);
     std::string json_result = std::string(strbuf.GetString());
 
+    auto time_zone = cctz::local_time_zone();
+    auto tp = std::chrono::system_clock::now();
+    auto time_zone_str = cctz::format("%z", tp, time_zone);
+
     std::string expect_result = R"([
     {
         "path id": "1",
-        "last create time": "1970-01-01 10:46:40",
+        "last create time": "1970-01-01 10:46:40 $0",
         "path list": "1 -> [2-3] -> [4-5]"
     },
     {
         "path id": "2",
-        "last create time": "1970-01-01 10:46:40",
+        "last create time": "1970-01-01 10:46:40 $0",
         "path list": "2 -> [6-6] -> [7-8]"
     },
     {
         "path id": "3",
-        "last create time": "1970-01-01 10:46:40",
+        "last create time": "1970-01-01 10:46:40 $0",
         "path list": "3 -> [6-8] -> [9-9]"
     },
     {
         "path id": "4",
-        "last create time": "1970-01-01 10:46:40",
+        "last create time": "1970-01-01 10:46:40 $0",
         "path list": "4 -> [10-10]"
     }
 ])";
 
+    expect_result = strings::Substitute(expect_result, time_zone_str);
     ASSERT_EQ(expect_result, json_result);
 }
 


### PR DESCRIPTION
## Proposed changes
**(1) Add LargeInt cast to date and datatime**,  see #3864 
    LargeInt can cast to  date and datatime.  Fix this error: 
Unable to find _ZN5doris13CastFunctions16cast_to_date_valEPN9doris_udf15FunctionContextERKNS1_11LargeIntValE
    
**(2) Add local timezone info to stale_version_path_json_doc rest api.**   
Add timezone to "last create time" field.
{
        "path id": "1",
        "last create time": "1970-01-01 10:46:40 +0800",
        "path list": "1 -> [2-3] -> [4-5]"
 },
 and add timezone to the test unix,  see #4121 .

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] Documentation Update (if none of the other choices apply)
- [] Code refactor (Modify the code structure, format the code, etc...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have create an issue on (Fix #ISSUE), and have described the bug/feature there in detail
- [x] Compiling and unit tests pass locally with my changes
- [] I have added tests that prove my fix is effective or that my feature works
- [] If this change need a document change, I have updated the document
- [] Any dependent changes have been merged


