### PR TITLE
[Bug] Fix bug that modification of global variable can not be persisted.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/SetVar.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/SetVar.java
@@ -143,8 +143,8 @@ public class SetVar {
         }
 
         if (getVariable().toLowerCase().equals("exec_mem_limit")) {
-            this.value = new StringLiteral(TimeUtils.checkTimeZoneValidAndStandardize(getValue().getStringValue()));
-            this.result = new StringLiteral(Long.toString(ParseUtil.analyzeDataVolumn(getValue().getStringValue())));
+            this.value = new StringLiteral(Long.toString(ParseUtil.analyzeDataVolumn(getValue().getStringValue())));
+            this.result = (LiteralExpr) this.value;
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/SetVar.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/SetVar.java
@@ -17,18 +17,21 @@
 
 package org.apache.doris.analysis;
 
-import com.google.common.base.Strings;
 import org.apache.doris.catalog.Catalog;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.ErrorReport;
 import org.apache.doris.common.UserException;
+import org.apache.doris.common.util.ParseUtil;
+import org.apache.doris.common.util.TimeUtils;
 import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.mysql.privilege.UserResource;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.GlobalVariable;
 import org.apache.doris.qe.SessionVariable;
 import org.apache.doris.system.HeartbeatFlags;
+
+import com.google.common.base.Strings;
 
 // change one variable.
 public class SetVar {
@@ -124,6 +127,24 @@ public class SetVar {
             if (result != null && !HeartbeatFlags.isValidRowsetType(result.getStringValue())) {
                 throw new AnalysisException("Invalid rowset type, now we support {alpha, beta}.");
             }
+        }
+
+        if (getVariable().toLowerCase().equals("prefer_join_method")) {
+            String value = getValue().getStringValue();
+            if (!value.toLowerCase().equals("broadcast") && !value.toLowerCase().equals("shuffle")) {
+                ErrorReport.reportAnalysisException(ErrorCode.ERR_WRONG_VALUE_FOR_VAR, "prefer_join_method", value);
+            }
+        }
+
+        // Check variable time_zone value is valid
+        if (getVariable().toLowerCase().equals("time_zone")) {
+            this.value = new StringLiteral(TimeUtils.checkTimeZoneValidAndStandardize(getValue().getStringValue()));
+            this.result = (LiteralExpr) this.value;
+        }
+
+        if (getVariable().toLowerCase().equals("exec_mem_limit")) {
+            this.value = new StringLiteral(TimeUtils.checkTimeZoneValidAndStandardize(getValue().getStringValue()));
+            this.result = new StringLiteral(Long.toString(ParseUtil.analyzeDataVolumn(getValue().getStringValue())));
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Catalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Catalog.java
@@ -171,6 +171,7 @@ import org.apache.doris.persist.DropInfo;
 import org.apache.doris.persist.DropLinkDbAndUpdateDbInfo;
 import org.apache.doris.persist.DropPartitionInfo;
 import org.apache.doris.persist.EditLog;
+import org.apache.doris.persist.GlobalVarPersistInfo;
 import org.apache.doris.persist.ModifyPartitionInfo;
 import org.apache.doris.persist.ModifyTablePropertyOperationLog;
 import org.apache.doris.persist.OperationType;
@@ -210,6 +211,8 @@ import org.apache.doris.thrift.TTabletType;
 import org.apache.doris.thrift.TTaskType;
 import org.apache.doris.transaction.GlobalTransactionMgr;
 import org.apache.doris.transaction.PublishVersionDaemon;
+import org.apache.doris.transaction.UpdateDbUsedDataQuotaDaemon;
+
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
@@ -225,7 +228,6 @@ import com.sleepycat.je.rep.NetworkRestore;
 import com.sleepycat.je.rep.NetworkRestoreConfig;
 
 import org.apache.commons.collections.CollectionUtils;
-import org.apache.doris.transaction.UpdateDbUsedDataQuotaDaemon;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.codehaus.jackson.map.ObjectMapper;
@@ -2228,6 +2230,10 @@ public class Catalog {
 
     public void replayGlobalVariable(SessionVariable variable) throws IOException, DdlException {
         VariableMgr.replayGlobalVariable(variable);
+    }
+
+    public void replayGlobalVariableV2(GlobalVarPersistInfo info) throws IOException, DdlException {
+        VariableMgr.replayGlobalVariableV2(info);
     }
 
     public long saveLoadJobsV2(DataOutputStream out, long checksum) throws IOException {

--- a/fe/fe-core/src/main/java/org/apache/doris/common/FeMetaVersion.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/FeMetaVersion.java
@@ -190,6 +190,8 @@ public final class FeMetaVersion {
     // force drop db, force drop table, force drop partition
     // make force drop operation do not recycle meta
     public static final int VERSION_89 = 89;
+    // for global variable persist
+    public static final int VERSION_90 = 90;
     // note: when increment meta version, should assign the latest version to VERSION_CURRENT
-    public static final int VERSION_CURRENT = VERSION_89;
+    public static final int VERSION_CURRENT = VERSION_90;
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/TimeUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/TimeUtils.java
@@ -27,10 +27,10 @@ import org.apache.doris.common.FeConstants;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.VariableMgr;
 
-import com.google.common.base.Preconditions; 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 
-import org.apache.logging.log4j.LogManager; 
+import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.text.ParseException;
@@ -122,7 +122,7 @@ public class TimeUtils {
         if (ConnectContext.get() != null) {
             timezone = ConnectContext.get().getSessionVariable().getTimeZone();
         } else {
-            timezone = VariableMgr.getGlobalSessionVariable().getTimeZone();
+            timezone = VariableMgr.getDefaultSessionVariable().getTimeZone();
         }
         return TimeZone.getTimeZone(ZoneId.of(timezone, timeZoneAliasMap));
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/journal/JournalEntity.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/journal/JournalEntity.java
@@ -62,6 +62,7 @@ import org.apache.doris.persist.DropInfo;
 import org.apache.doris.persist.DropLinkDbAndUpdateDbInfo;
 import org.apache.doris.persist.DropPartitionInfo;
 import org.apache.doris.persist.DropResourceOperationLog;
+import org.apache.doris.persist.GlobalVarPersistInfo;
 import org.apache.doris.persist.HbPackage;
 import org.apache.doris.persist.ModifyPartitionInfo;
 import org.apache.doris.persist.ModifyTablePropertyOperationLog;
@@ -578,6 +579,11 @@ public class JournalEntity implements Writable {
             }
             case OperationType.OP_ALTER_ROUTINE_LOAD_JOB: {
                 data = AlterRoutineLoadJobOperationLog.read(in);
+                isRead = true;
+                break;
+            }
+            case OperationType.OP_GLOBAL_VARIABLE_V2: {
+                data = GlobalVarPersistInfo.read(in);
                 isRead = true;
                 break;
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/EditLog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/EditLog.java
@@ -792,6 +792,7 @@ public class EditLog {
                 case OperationType.OP_GLOBAL_VARIABLE_V2: {
                     GlobalVarPersistInfo info = (GlobalVarPersistInfo) journal.getData();
                     catalog.replayGlobalVariableV2(info);
+                    break;
                 }
                 default: {
                     IOException e = new IOException();
@@ -1361,6 +1362,6 @@ public class EditLog {
     }
 
     public void logGlobalVariableV2(GlobalVarPersistInfo info) {
-        logEdit(OperationType.OP_GLOBAL_VARIABLE, info);
+        logEdit(OperationType.OP_GLOBAL_VARIABLE_V2, info);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/EditLog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/EditLog.java
@@ -789,6 +789,10 @@ public class EditLog {
                     catalog.getRoutineLoadManager().replayAlterRoutineLoadJob(log);
                     break;
                 }
+                case OperationType.OP_GLOBAL_VARIABLE_V2: {
+                    GlobalVarPersistInfo info = (GlobalVarPersistInfo) journal.getData();
+                    catalog.replayGlobalVariableV2(info);
+                }
                 default: {
                     IOException e = new IOException();
                     LOG.error("UNKNOWN Operation Type {}", opCode, e);
@@ -1354,5 +1358,9 @@ public class EditLog {
 
     public void logAlterRoutineLoadJob(AlterRoutineLoadJobOperationLog log) {
         logEdit(OperationType.OP_ALTER_ROUTINE_LOAD_JOB, log);
+    }
+
+    public void logGlobalVariableV2(GlobalVarPersistInfo info) {
+        logEdit(OperationType.OP_GLOBAL_VARIABLE, info);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/GlobalVarPersistInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/GlobalVarPersistInfo.java
@@ -1,0 +1,140 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.persist;
+
+import org.apache.doris.common.io.Text;
+import org.apache.doris.common.io.Writable;
+import org.apache.doris.qe.GlobalVariable;
+import org.apache.doris.qe.SessionVariable;
+import org.apache.doris.qe.VariableMgr;
+
+import com.google.common.base.Preconditions;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.json.JSONObject;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.util.List;
+
+// for persist global variables
+public class GlobalVarPersistInfo implements Writable {
+    private static final Logger LOG = LogManager.getLogger(GlobalVarPersistInfo.class);
+    // current default session variable when writing the edit log
+    private SessionVariable defaultSessionVariable;
+    // variable names which are modified
+    private List<String> varNames;
+
+    // the modified variable info will be saved as a json string
+    private String persistJsonString;
+
+    private GlobalVarPersistInfo() {
+        // for persist
+    }
+
+    public GlobalVarPersistInfo(SessionVariable defaultSessionVariable, List<String> varNames) {
+        this.defaultSessionVariable = defaultSessionVariable;
+        this.varNames = varNames;
+    }
+
+    public String getPersistJsonString() {
+        return persistJsonString;
+    }
+
+    @Override
+    public void write(DataOutput out) throws IOException {
+        try {
+            JSONObject root = new JSONObject();
+            for (String varName : varNames) {
+                // find attr in defaultSessionVariable or GlobalVariables
+                Object varInstance = null;
+                Field theField = null;
+                boolean found = false;
+                // 1. first find in defaultSessionVariable
+                for (Field field : SessionVariable.class.getDeclaredFields()) {
+                    VariableMgr.VarAttr attr = field.getAnnotation(VariableMgr.VarAttr.class);
+                    if (attr == null) {
+                        continue;
+                    }
+                    if (attr.name().equalsIgnoreCase(varName)) {
+                        varInstance = this.defaultSessionVariable;
+                        theField = field;
+                        found = true;
+                        break;
+                    }
+                }
+
+                if (!found) {
+                    // find in GlobalVariables
+                    for (Field field : GlobalVariable.class.getDeclaredFields()) {
+                        VariableMgr.VarAttr attr = field.getAnnotation(VariableMgr.VarAttr.class);
+                        if (attr == null) {
+                            continue;
+                        }
+
+                        if (attr.name().equalsIgnoreCase(varName)) {
+                            found = true;
+                            varInstance = null;
+                            theField = field;
+                            break;
+                        }
+                    }
+                }
+                Preconditions.checkState(found, varName);
+
+                String fieldName = theField.getAnnotation(VariableMgr.VarAttr.class).name();
+                switch (theField.getType().getSimpleName()) {
+                    case "boolean":
+                        root.put(fieldName, (Boolean) theField.get(varInstance));
+                        break;
+                    case "int":
+                        root.put(fieldName, (Integer) theField.get(varInstance));
+                        break;
+                    case "long":
+                        root.put(fieldName, (Long) theField.get(varInstance));
+                        break;
+                    case "float":
+                        root.put(fieldName, (Float) theField.get(varInstance));
+                        break;
+                    case "double":
+                        root.put(fieldName, (Double) theField.get(varInstance));
+                        break;
+                    case "String":
+                        root.put(fieldName, (String) theField.get(varInstance));
+                        break;
+                    default:
+                        // Unsupported type variable.
+                        throw new IOException("invalid type: " + theField.getType().getSimpleName());
+                }
+            } // end for all variables
+
+            Text.writeString(out, root.toString());
+        } catch (Exception e) {
+            throw new IOException("failed to write session variable: " + e.getMessage());
+        }
+    }
+
+    public static GlobalVarPersistInfo read(DataInput in) throws IOException {
+        GlobalVarPersistInfo info = new GlobalVarPersistInfo();
+        info.persistJsonString = Text.readString(in);
+        return info;
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/GlobalVarPersistInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/GlobalVarPersistInfo.java
@@ -100,6 +100,7 @@ public class GlobalVarPersistInfo implements Writable {
                 }
                 Preconditions.checkState(found, varName);
 
+                theField.setAccessible(true);
                 String fieldName = theField.getAnnotation(VariableMgr.VarAttr.class).name();
                 switch (theField.getType().getSimpleName()) {
                     case "boolean":

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/OperationType.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/OperationType.java
@@ -117,6 +117,7 @@ public class OperationType {
     public static final short OP_SHOW_CLUSTERS = 80;
     public static final short OP_UPDATE_DB = 82;
     public static final short OP_DROP_LINKDB = 83;
+    public static final short OP_GLOBAL_VARIABLE_V2 = 84;
 
     public static final short OP_ADD_BROKER = 85;
     public static final short OP_DROP_BROKER = 86;

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/OperationType.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/OperationType.java
@@ -105,7 +105,8 @@ public class OperationType {
     public static final short OP_TIMESTAMP = 70;
     public static final short OP_MASTER_INFO_CHANGE = 71;
     public static final short OP_META_VERSION = 72;
-
+    @Deprecated
+    // replaced by OP_GLOBAL_VARIABLE_V2
     public static final short OP_GLOBAL_VARIABLE = 73;
 
     public static final short OP_CREATE_CLUSTER = 74;

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/GlobalVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/GlobalVariable.java
@@ -20,6 +20,11 @@ package org.apache.doris.qe;
 import org.apache.doris.common.Version;
 import org.apache.doris.common.util.TimeUtils;
 
+import com.google.common.collect.Lists;
+
+import java.lang.reflect.Field;
+import java.util.List;
+
 // You can place your global variable in this class with public and VariableMgr.VarAttr annotation.
 // You can get this variable from MySQL client with statement `SELECT @@variable_name`,
 // and change its value through `SET variable_name = xxx`
@@ -72,5 +77,17 @@ public final class GlobalVariable {
     // Don't allow create instance.
     private GlobalVariable() {
 
+    }
+
+    public static List<String> getAllGlobalVarNames() {
+        List<String> varNames = Lists.newArrayList();
+        for (Field field : GlobalVariable.class.getDeclaredFields()) {
+            VariableMgr.VarAttr attr = field.getAnnotation(VariableMgr.VarAttr.class);
+            if (attr == null || attr.flag() != VariableMgr.GLOBAL) {
+                continue;
+            }
+            varNames.add(attr.name());
+        }
+        return varNames;
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/VariableMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/VariableMgr.java
@@ -335,7 +335,7 @@ public class VariableMgr {
                     LOG.error("failed to get global variable {} when replaying", varName);
                     continue;
                 }
-                setValue(varContext.getObj(), varContext.getField(), root.getString(varName));
+                setValue(varContext.getObj(), varContext.getField(), root.get(varName).toString());
             }
         } finally {
             wlock.unlock();

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/VariableMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/VariableMgr.java
@@ -19,7 +19,6 @@ package org.apache.doris.qe;
 
 import org.apache.doris.analysis.SetType;
 import org.apache.doris.analysis.SetVar;
-import org.apache.doris.analysis.StringLiteral;
 import org.apache.doris.analysis.SysVariableDesc;
 import org.apache.doris.catalog.Catalog;
 import org.apache.doris.catalog.Type;
@@ -27,10 +26,10 @@ import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.DdlException;
 import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.ErrorReport;
+import org.apache.doris.common.FeMetaVersion;
 import org.apache.doris.common.PatternMatcher;
-import org.apache.doris.common.util.ParseUtil;
-import org.apache.doris.common.util.TimeUtils;
 import org.apache.doris.persist.EditLog;
+import org.apache.doris.persist.GlobalVarPersistInfo;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSortedMap;
@@ -39,6 +38,7 @@ import com.google.common.collect.Lists;
 import org.apache.commons.lang.SerializationUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.json.JSONObject;
 
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
@@ -46,7 +46,6 @@ import java.io.IOException;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.reflect.Field;
-import java.lang.reflect.Modifier;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
@@ -55,7 +54,40 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
-// Variable manager, merge session variable and global variable
+/**
+ * Variable manager, merge session variable and global variable.
+ * <p>
+ * There are two types of variables, SESSION and GLOBAL.
+ * <p>
+ * The GLOBAL variable is more like a system configuration, which takes effect globally.
+ * The settings for global variables are global and persistent.
+ * After the cluster is restarted, the set values ​​can still be restored.
+ * The global variables are defined in `GlobalVariable`.
+ * The variable of the READ_ONLY attribute cannot be changed,
+ * and the variable of the GLOBAL attribute can be changed at runtime.
+ * <p>
+ * Session variables are session-level, and the scope of these variables is usually
+ * in a session connection. The session variables are defined in `SessionVariable`.
+ * <p>
+ * For the setting of the global variable, the value of the field in the `GlobalVariable` class
+ * will be modified directly through the reflection mechanism of Java.
+ * <p>
+ * For the setting of session variables, there are also two types: Global and Session.
+ * <p>
+ * 1. Use `set global` comment to set session variables
+ * <p>
+ * This setting method is equivalent to changing the default value of the session variable.
+ * It will modify the `defaultSessionVariable` member.
+ * This operation is persistent and global. After the setting is complete, when a new session
+ * is established, this default value will be used to generate session-level session variables.
+ * This operation will only affect the value of the variable in the newly established session,
+ * but will not affect the value of the variable in the current session.
+ * <p>
+ * 2. Use the `set` comment (no global) to set the session variable
+ * <p>
+ * This setting method will only change the value of the variable in the current session.
+ * After the session ends, this setting will also become invalid.
+ */
 public class VariableMgr {
     private static final Logger LOG = LogManager.getLogger(VariableMgr.class);
 
@@ -72,12 +104,14 @@ public class VariableMgr {
     public static final int INVISIBLE = 16;
 
     // Map variable name to variable context which have enough information to change variable value.
+    // This map contains info of all session and global variables.
     private static ImmutableMap<String, VarContext> ctxByVarName;
 
-    // global session variable
-    private static SessionVariable globalSessionVariable;
+    // This variable is equivalent to the default value of session variables.
+    // Whenever a new session is established, the value in this object is copied to the session-level variable.
+    private static SessionVariable defaultSessionVariable;
 
-    // Global read/write lock to protect access global variable.
+    // Global read/write lock to protect access of globalSessionVariable.
     private static final ReadWriteLock rwlock = new ReentrantReadWriteLock();
     private static final Lock rlock = rwlock.readLock();
     private static final Lock wlock = rwlock.writeLock();
@@ -85,7 +119,7 @@ public class VariableMgr {
     // Form map from variable name to its field in Java class.
     static {
         // Session value
-        globalSessionVariable = new SessionVariable();
+        defaultSessionVariable = new SessionVariable();
         ImmutableSortedMap.Builder<String, VarContext> builder =
                 ImmutableSortedMap.orderedBy(String.CASE_INSENSITIVE_ORDER);
         for (Field field : SessionVariable.class.getDeclaredFields()) {
@@ -96,8 +130,8 @@ public class VariableMgr {
 
             field.setAccessible(true);
             builder.put(attr.name(),
-                    new VarContext(field, globalSessionVariable, SESSION | attr.flag(),
-                            getValue(globalSessionVariable, field)));
+                    new VarContext(field, defaultSessionVariable, SESSION | attr.flag(),
+                            getValue(defaultSessionVariable, field)));
         }
 
         // Variables only exist in global environment.
@@ -106,30 +140,17 @@ public class VariableMgr {
             if (attr == null) {
                 continue;
             }
-            if ((field.getModifiers() & Modifier.STATIC) == 0) {
-                LOG.warn("Field in GlobalVariable with VarAttr annotation must have static modifier.");
-                continue;
-            }
 
             field.setAccessible(true);
             builder.put(attr.name(),
                     new VarContext(field, null, GLOBAL | attr.flag(), getValue(null, field)));
-
         }
 
         ctxByVarName = builder.build();
     }
 
-    public static Lock readLock() {
-        return rlock;
-    }
-
-    public static Lock writeLock() {
-        return wlock;
-    }
-
-    public static SessionVariable getGlobalSessionVariable() {
-        return globalSessionVariable;
+    public static SessionVariable getDefaultSessionVariable() {
+        return defaultSessionVariable;
     }
 
     // Set value to a variable
@@ -188,13 +209,13 @@ public class VariableMgr {
     public static SessionVariable newSessionVariable() {
         wlock.lock();
         try {
-            return (SessionVariable) SerializationUtils.clone(globalSessionVariable);
+            return (SessionVariable) SerializationUtils.clone(defaultSessionVariable);
         } finally {
             wlock.unlock();
         }
     }
 
-    // Check if this setVar can
+    // Check if this setVar can be set correctly
     private static void checkUpdate(SetVar setVar, int flag) throws DdlException {
         if ((flag & READ_ONLY) != 0) {
             ErrorReport.reportDdlException(ErrorCode.ERR_VARIABLE_IS_READONLY, setVar.getVariable());
@@ -207,7 +228,10 @@ public class VariableMgr {
         }
     }
 
-    // Get from show name to field
+    // Entry of handling SetVarStmt
+    // Input:
+    //      sessionVariable: the variable of current session
+    //      setVar: variable information that needs to be set
     public static void setVar(SessionVariable sessionVariable, SetVar setVar) throws DdlException {
         VarContext ctx = ctxByVarName.get(setVar.getVariable());
         if (ctx == null) {
@@ -215,21 +239,6 @@ public class VariableMgr {
         }
         // Check variable attribute and setVar
         checkUpdate(setVar, ctx.getFlag());
-        // Check variable time_zone value is valid
-        if (setVar.getVariable().toLowerCase().equals("time_zone")) {
-            setVar = new SetVar(
-                    setVar.getType(), setVar.getVariable(),
-                    new StringLiteral(TimeUtils.checkTimeZoneValidAndStandardize(setVar.getValue().getStringValue())));
-        }
-        if (setVar.getVariable().toLowerCase().equals("exec_mem_limit")) {
-            try {
-            setVar = new SetVar(
-                    setVar.getType(), setVar.getVariable(),
-                    new StringLiteral(Long.toString(ParseUtil.analyzeDataVolumn(setVar.getValue().getStringValue()))));
-            } catch (AnalysisException e) {
-                throw new DdlException(e.getMessage());
-            }
-        }
 
         // To modify to default value.
         VarAttr attr = ctx.getField().getAnnotation(VarAttr.class);
@@ -244,47 +253,55 @@ public class VariableMgr {
             }
         }
 
-        if (setVar.getVariable().toLowerCase().equals("prefer_join_method")) {
-            if (!value.toLowerCase().equals("broadcast") && !value.toLowerCase().equals("shuffle")) {
-                ErrorReport.reportDdlException(ErrorCode.ERR_WRONG_VALUE_FOR_VAR, "prefer_join_method", value);
-            }
-        }
-
         if (setVar.getType() == SetType.GLOBAL) {
+            // set global variable should not affect variables of current session.
+            // global variable will only make effect when connecting in.
             wlock.lock();
             try {
                 setValue(ctx.getObj(), ctx.getField(), value);
+                // write edit log
+                GlobalVarPersistInfo info = new GlobalVarPersistInfo(defaultSessionVariable, Lists.newArrayList(attr.name()));
+                EditLog editLog = Catalog.getCurrentCatalog().getEditLog();
+                editLog.logGlobalVariableV2(info);
             } finally {
                 wlock.unlock();
             }
-            writeGlobalVariableUpdate(globalSessionVariable, "update global variables");
         } else {
-            // set global variable should not affect variables of current session.
-            // global variable will only make effect when connecting in.
+            // set session variable
             setValue(sessionVariable, ctx.getField(), value);
         }
     }
 
     // global variable persistence
     public static void write(DataOutputStream out) throws IOException {
-        globalSessionVariable.write(out);
+        defaultSessionVariable.write(out);
+        // get all global variables
+        List<String> varNames = GlobalVariable.getAllGlobalVarNames();
+        GlobalVarPersistInfo info = new GlobalVarPersistInfo(defaultSessionVariable, varNames);
+        info.write(out);
     }
-    
+
     public static void read(DataInputStream in) throws IOException, DdlException {
         wlock.lock();
         try {
-            globalSessionVariable.readFields(in);
+            defaultSessionVariable.readFields(in);
+            if (Catalog.getCurrentCatalogJournalVersion() >= FeMetaVersion.VERSION_90) {
+                GlobalVarPersistInfo info = GlobalVarPersistInfo.read(in);
+                replayGlobalVariableV2(info);
+            }
         } finally {
             wlock.unlock();
         }
     }
 
+    @Deprecated
     private static void writeGlobalVariableUpdate(SessionVariable variable, String msg) {
         EditLog editLog = Catalog.getCurrentCatalog().getEditLog();
         editLog.logGlobalVariable(variable);
     }
 
-    public static void replayGlobalVariable(SessionVariable variable) throws IOException, DdlException {
+    @Deprecated
+    public static void replayGlobalVariable(SessionVariable variable) throws DdlException {
         wlock.lock();
         try {
             for (Field field : SessionVariable.class.getDeclaredFields()) {
@@ -300,6 +317,25 @@ public class VariableMgr {
                     String value = getValue(variable, ctx.getField());
                     setValue(ctx.getObj(), ctx.getField(), value);
                 }
+            }
+        } finally {
+            wlock.unlock();
+        }
+    }
+
+    // this method is used to replace the `replayGlobalVariable()`
+    public static void replayGlobalVariableV2(GlobalVarPersistInfo info) throws DdlException {
+        wlock.lock();
+        try {
+            String json = info.getPersistJsonString();
+            JSONObject root = new JSONObject(json);
+            for (String varName : root.keySet()) {
+                VarContext varContext = ctxByVarName.get(varName);
+                if (varContext == null) {
+                    LOG.error("failed to get global variable {} when replaying", varName);
+                    continue;
+                }
+                setValue(varContext.getObj(), varContext.getField(), root.getString(varName));
             }
         } finally {
             wlock.unlock();
@@ -417,7 +453,7 @@ public class VariableMgr {
         return "";
     }
 
-    // Dump all fields
+    // Dump all fields. Used for `show variables`
     public static List<List<String>> dump(SetType type, SessionVariable sessionVar, PatternMatcher matcher) {
         List<List<String>> rows = Lists.newArrayList();
         // Hold the read lock when session dump, because this option need to access global variable.
@@ -433,7 +469,7 @@ public class VariableMgr {
                 List<String> row = Lists.newArrayList();
 
                 row.add(entry.getKey());
-                if (type != SetType.GLOBAL && ctx.getObj() == globalSessionVariable) {
+                if (type != SetType.GLOBAL && ctx.getObj() == defaultSessionVariable) {
                     // In this condition, we may retrieve session variables for caller.
                     row.add(getValue(sessionVar, ctx.getField()));
                 } else {

--- a/fe/fe-core/src/test/java/org/apache/doris/persist/GlobalVarPersistInfoTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/persist/GlobalVarPersistInfoTest.java
@@ -1,0 +1,73 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.persist;
+
+import org.apache.doris.qe.SessionVariable;
+import org.apache.doris.qe.VariableMgr;
+
+import com.google.common.collect.Lists;
+
+import org.junit.After;
+import org.junit.Test;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.List;
+
+public class GlobalVarPersistInfoTest {
+    private static String fileName = "./GlobalVarPersistInfoTest";
+
+    @After
+    public void tearDown() {
+        File file = new File(fileName);
+        file.delete();
+    }
+
+    @Test
+    public void testSerialzeAlterViewInfo() throws IOException {
+        // 1. Write objects to file
+        File file = new File(fileName);
+        file.createNewFile();
+        DataOutputStream out = new DataOutputStream(new FileOutputStream(file));
+
+
+        SessionVariable sessionVariable = VariableMgr.newSessionVariable();
+        List<String> varNames = Lists.newArrayList();
+        varNames.add("exec_mem_limit");
+        varNames.add("default_rowset_type");
+        GlobalVarPersistInfo info = new GlobalVarPersistInfo(sessionVariable, varNames);
+
+        info.write(out);
+        out.flush();
+        out.close();
+
+        // 2. Read objects from file
+        DataInputStream in = new DataInputStream(new FileInputStream(file));
+
+        GlobalVarPersistInfo newInfo = GlobalVarPersistInfo.read(in);
+        System.out.println(newInfo.getPersistJsonString());
+
+        in.close();
+    }
+
+
+}


### PR DESCRIPTION
## Proposed changes

When setting global variables, such as `set global default_rowset_type=beta`,
the operation is not correctly persisted.

This CL change the fe meta version to 90.

---------------

The main reason for this problem is that for the modification of global variable,
we directly use Java's reflection mechanism to modify static member variables in `GlobalVariable` class.

But in the persistence method of the `set` operation, we only persist the value stored
in the `globalSessionVariable` variable, and this variable does not contain Global Variable.

So I added a new OperationType: `OP_GLOBAL_VARIABLE_V2`,
and added a `GlobalVarPersistInfo` class to record all changes.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have create an issue on (Fix #4323), and have described the bug/feature there in detail
- [x] Compiling and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works