### PR TITLE
[Metrics] Support tablet level metrics

### DIFF
--- a/be/src/exec/olap_scanner.cpp
+++ b/be/src/exec/olap_scanner.cpp
@@ -479,6 +479,9 @@ void OlapScanner::update_counter() {
     DorisMetrics::instance()->query_scan_bytes.increment(_compressed_bytes_read);
     DorisMetrics::instance()->query_scan_rows.increment(_raw_rows_read);
 
+    _tablet->query_scan_bytes.increment(_compressed_bytes_read);
+    _tablet->query_scan_rows.increment(_raw_rows_read);
+
     _has_update_counter = true;
 }
 

--- a/be/src/http/action/metrics_action.cpp
+++ b/be/src/http/action/metrics_action.cpp
@@ -34,13 +34,14 @@ namespace doris {
 
 void MetricsAction::handle(HttpRequest* req) {
     const std::string& type = req->param("type");
+    const std::string& with_tablet = req->param("with_tablet");
     std::string str;
     if (type == "core") {
         str = _metric_registry->to_core_string();
     } else if (type == "json") {
-        str = _metric_registry->to_json();
+        str = _metric_registry->to_json(with_tablet == "true");
     } else {
-        str = _metric_registry->to_prometheus();
+        str = _metric_registry->to_prometheus(with_tablet == "true");
     }
 
     req->add_output_header(HttpHeaders::CONTENT_TYPE, "text/plain; version=0.0.4");

--- a/be/src/http/action/stream_load.cpp
+++ b/be/src/http/action/stream_load.cpp
@@ -96,7 +96,7 @@ StreamLoadAction::StreamLoadAction(ExecEnv* exec_env) : _exec_env(exec_env) {
 }
 
 StreamLoadAction::~StreamLoadAction() {
-    DorisMetrics::instance()->metric_registry()->deregister_entity("stream_load");
+    DorisMetrics::instance()->metric_registry()->deregister_entity(_stream_load_entity->name());
 }
 
 void StreamLoadAction::handle(HttpRequest* req) {

--- a/be/src/olap/base_tablet.cpp
+++ b/be/src/olap/base_tablet.cpp
@@ -17,10 +17,15 @@
 
 #include "olap/base_tablet.h"
 
+#include "gutil/strings/substitute.h"
 #include "olap/data_dir.h"
+#include "util/doris_metrics.h"
 #include "util/path_util.h"
 
 namespace doris {
+
+extern MetricPrototype METRIC_query_scan_bytes;
+extern MetricPrototype METRIC_query_scan_rows;
 
 BaseTablet::BaseTablet(TabletMetaSharedPtr tablet_meta, DataDir* data_dir)
         : _state(tablet_meta->tablet_state()),
@@ -28,9 +33,18 @@ BaseTablet::BaseTablet(TabletMetaSharedPtr tablet_meta, DataDir* data_dir)
           _schema(tablet_meta->tablet_schema()),
           _data_dir(data_dir) {
     _gen_tablet_path();
+
+    _metric_entity = DorisMetrics::instance()->metric_registry()->register_entity(
+        strings::Substitute("Tablet.$0", tablet_id()),
+        {{"tablet_id", std::to_string(tablet_id())}},
+        MetricEntityType::kTablet);
+    METRIC_REGISTER(_metric_entity, query_scan_bytes);
+    METRIC_REGISTER(_metric_entity, query_scan_rows);
 }
 
-BaseTablet::~BaseTablet() {}
+BaseTablet::~BaseTablet() {
+    DorisMetrics::instance()->metric_registry()->deregister_entity(_metric_entity->name());
+}
 
 OLAPStatus BaseTablet::set_tablet_state(TabletState state) {
     if (_tablet_meta->tablet_state() == TABLET_SHUTDOWN && state != TABLET_SHUTDOWN) {

--- a/be/src/olap/base_tablet.h
+++ b/be/src/olap/base_tablet.h
@@ -23,6 +23,7 @@
 #include "olap/olap_define.h"
 #include "olap/tablet_meta.h"
 #include "olap/utils.h"
+#include "util/metrics.h"
 
 namespace doris {
 
@@ -73,6 +74,12 @@ protected:
 
     DataDir* _data_dir;
     std::string _tablet_path;
+
+    // metrics of this tablet
+    MetricEntity* _metric_entity = nullptr;
+public:
+    IntCounter query_scan_bytes;
+    IntCounter query_scan_rows;
 
 private:
     DISALLOW_COPY_AND_ASSIGN(BaseTablet);

--- a/be/src/olap/data_dir.cpp
+++ b/be/src/olap/data_dir.cpp
@@ -86,7 +86,7 @@ DataDir::DataDir(const std::string& path, int64_t capacity_bytes,
 }
 
 DataDir::~DataDir() {
-    DorisMetrics::instance()->metric_registry()->deregister_entity(std::string("data_dir.") + _path);
+    DorisMetrics::instance()->metric_registry()->deregister_entity(_data_dir_metric_entity->name());
     delete _id_generator;
     delete _meta;
 }

--- a/be/src/olap/delta_writer.cpp
+++ b/be/src/olap/delta_writer.cpp
@@ -60,6 +60,10 @@ DeltaWriter::~DeltaWriter() {
     if (_flush_token != nullptr) {
         // cancel and wait all memtables in flush queue to be finished
         _flush_token->cancel();
+
+        const FlushStatistic& stat = _flush_token->get_stats();
+        _tablet->flush_bytes.increment(stat.flush_size_bytes);
+        _tablet->flush_count.increment(stat.flush_count);
     }
 
     if (_tablet != nullptr) {
@@ -92,7 +96,7 @@ OLAPStatus DeltaWriter::init() {
     TabletManager* tablet_mgr = _storage_engine->tablet_manager();
     _tablet = tablet_mgr->get_tablet(_req.tablet_id, _req.schema_hash);
     if (_tablet == nullptr) {
-        LOG(WARNING) << "fail to find tablet . tablet_id=" << _req.tablet_id
+        LOG(WARNING) << "fail to find tablet. tablet_id=" << _req.tablet_id
                      << ", schema_hash=" << _req.schema_hash;
         return OLAP_ERR_TABLE_NOT_FOUND;
     }

--- a/be/src/olap/memtable_flush_executor.h
+++ b/be/src/olap/memtable_flush_executor.h
@@ -35,7 +35,7 @@ class MemTable;
 // use atomic because it may be updated by multi threads
 struct FlushStatistic {
     int64_t flush_time_ns = 0;
-    int64_t flush_count= 0;
+    int64_t flush_count = 0;
     int64_t flush_size_bytes = 0;
 };
 

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -48,6 +48,9 @@ using std::sort;
 using std::string;
 using std::vector;
 
+DEFINE_COUNTER_METRIC_PROTOTYPE_2ARG(flush_bytes, MetricUnit::BYTES);
+DEFINE_COUNTER_METRIC_PROTOTYPE_2ARG(flush_count, MetricUnit::OPERATIONS);
+
 TabletSharedPtr Tablet::create_tablet_from_meta(TabletMetaSharedPtr tablet_meta,
                                                 DataDir* data_dir) {
     return std::make_shared<Tablet>(tablet_meta, data_dir);
@@ -63,6 +66,9 @@ Tablet::Tablet(TabletMetaSharedPtr tablet_meta, DataDir* data_dir) :
         _cumulative_point(kInvalidCumulativePoint) {
     // change _rs_graph to _timestamped_version_tracker
     _timestamped_version_tracker.construct_versioned_tracker(_tablet_meta->all_rs_metas());
+
+    METRIC_REGISTER(_metric_entity, flush_bytes);
+    METRIC_REGISTER(_metric_entity, flush_count);
 }
 
 OLAPStatus Tablet::_init_once_action() {

--- a/be/src/olap/tablet.h
+++ b/be/src/olap/tablet.h
@@ -296,6 +296,10 @@ private:
     std::atomic<int32_t> _newly_created_rowset_num;
     std::atomic<int64_t> _last_checkpoint_time;
     DISALLOW_COPY_AND_ASSIGN(Tablet);
+
+public:
+    IntCounter flush_bytes;
+    IntCounter flush_count;
 };
 
 inline bool Tablet::init_succeeded() {

--- a/be/src/util/metrics.cpp
+++ b/be/src/util/metrics.cpp
@@ -156,8 +156,8 @@ void MetricEntity::trigger_hook_unlocked(bool force) const {
 MetricRegistry::~MetricRegistry() {
 }
 
-MetricEntity* MetricRegistry::register_entity(const std::string& name, const Labels& labels) {
-    std::shared_ptr<MetricEntity> entity = std::make_shared<MetricEntity>(name, labels);
+MetricEntity* MetricRegistry::register_entity(const std::string& name, const Labels& labels, MetricEntityType type) {
+    std::shared_ptr<MetricEntity> entity = std::make_shared<MetricEntity>(type, name, labels);
 
     std::lock_guard<SpinLock> l(_lock);
     DCHECK(_entities.find(name) == _entities.end()) << name;
@@ -187,12 +187,15 @@ void MetricRegistry::trigger_all_hooks(bool force) const {
     }
 }
 
-std::string MetricRegistry::to_prometheus() const {
+std::string MetricRegistry::to_prometheus(bool with_tablet_metrics) const {
     std::stringstream ss;
     // Reorder by MetricPrototype
     EntityMetricsByType entity_metrics_by_types;
     std::lock_guard<SpinLock> l(_lock);
     for (const auto& entity : _entities) {
+        if (entity.second->_type == MetricEntityType::kTablet && !with_tablet_metrics) {
+            continue;
+        }
         std::lock_guard<SpinLock> l(entity.second->_lock);
         entity.second->trigger_hook_unlocked(false);
         for (const auto& metric : entity.second->_metrics) {
@@ -224,11 +227,14 @@ std::string MetricRegistry::to_prometheus() const {
     return ss.str();
 }
 
-std::string MetricRegistry::to_json() const {
+std::string MetricRegistry::to_json(bool with_tablet_metrics) const {
     rj::Document doc{rj::kArrayType};
     rj::Document::AllocatorType& allocator = doc.GetAllocator();
     std::lock_guard<SpinLock> l(_lock);
     for (const auto& entity : _entities) {
+        if (entity.second->_type == MetricEntityType::kTablet && !with_tablet_metrics) {
+            continue;
+        }
         std::lock_guard<SpinLock> l(entity.second->_lock);
         entity.second->trigger_hook_unlocked(false);
         for (const auto& metric : entity.second->_metrics) {

--- a/be/src/util/metrics.h
+++ b/be/src/util/metrics.h
@@ -284,10 +284,17 @@ struct MetricPrototypeEqualTo {
 
 using MetricMap = std::unordered_map<const MetricPrototype*, Metric*, MetricPrototypeHash, MetricPrototypeEqualTo>;
 
+enum class MetricEntityType {
+    kServer,
+    kTablet
+};
+
 class MetricEntity {
 public:
-    MetricEntity(const std::string& name, const Labels& labels)
-        : _name(name), _labels(labels) {}
+    MetricEntity(MetricEntityType type, const std::string& name, const Labels& labels)
+        : _type(type), _name(name), _labels(labels) {}
+
+    const std::string& name() const { return _name; }
 
     void register_metric(const MetricPrototype* metric_type, Metric* metric);
     void deregister_metric(const MetricPrototype* metric_type);
@@ -301,6 +308,7 @@ public:
 private:
     friend class MetricRegistry;
 
+    MetricEntityType _type;
     std::string _name;
     Labels _labels;
 
@@ -316,14 +324,14 @@ public:
     MetricRegistry(const std::string& name) : _name(name) {}
     ~MetricRegistry();
 
-    MetricEntity* register_entity(const std::string& name, const Labels& labels);
+    MetricEntity* register_entity(const std::string& name, const Labels& labels, MetricEntityType type = MetricEntityType::kServer);
     void deregister_entity(const std::string& name);
     std::shared_ptr<MetricEntity> get_entity(const std::string& name);
 
     void trigger_all_hooks(bool force) const;
 
-    std::string to_prometheus() const;
-    std::string to_json() const;
+    std::string to_prometheus(bool with_tablet_metrics = false) const;
+    std::string to_json(bool with_tablet_metrics = false) const;
     std::string to_core_string() const;
 
 private:

--- a/be/test/util/new_metrics_test.cpp
+++ b/be/test/util/new_metrics_test.cpp
@@ -205,7 +205,7 @@ TEST_F(MetricsTest, MetricPrototype) {
 }
 
 TEST_F(MetricsTest, MetricEntityWithMetric) {
-    MetricEntity entity("test_entity", {});
+    MetricEntity entity(MetricEntityType::kServer, "test_entity", {});
 
     IntCounter cpu_idle;
     MetricPrototype cpu_idle_type(MetricType::COUNTER, MetricUnit::PERCENT, "cpu_idle");
@@ -234,7 +234,7 @@ TEST_F(MetricsTest, MetricEntityWithMetric) {
 }
 
 TEST_F(MetricsTest, MetricEntityWithHook) {
-    MetricEntity entity("test_entity", {});
+    MetricEntity entity(MetricEntityType::kServer, "test_entity", {});
 
     IntCounter cpu_idle;
     MetricPrototype cpu_idle_type(MetricType::COUNTER, MetricUnit::PERCENT, "cpu_idle");

--- a/docs/en/administrator-guide/operation/monitor-metrics/be-metrics.md
+++ b/docs/en/administrator-guide/operation/monitor-metrics/be-metrics.md
@@ -38,9 +38,14 @@ BE metrics can be viewed by visiting:
 
 The default format is of [Prometheus](https://prometheus.io/).
 
-You can get Json format by visiting:
+### Optional Parameters
+- You can get Json format by visiting:
 
-`http://be_host:be_webserver_port/metrics?type=json`
+  `http://be_host:be_webserver_port/metrics?type=json`
+
+- You can get Tablet level metrics by visiting:
+
+  `http://be_host:be_webserver_port/metrics?with_tablet=true`
 
 ## Metrics List
 

--- a/docs/zh-CN/administrator-guide/operation/monitor-metrics/be-metrics.md
+++ b/docs/zh-CN/administrator-guide/operation/monitor-metrics/be-metrics.md
@@ -38,9 +38,14 @@ BE 的监控项可以通过以下方式访问：
 
 默认显示为 [Prometheus](https://prometheus.io/) 格式。
 
-通过以下接口可以获取 Json 格式的监控项：
+### 可选参数
+- 通过以下接口可以获取 Json 格式的监控项：
 
-`http://be_host:be_webserver_port/metrics?type=json`
+  `http://be_host:be_webserver_port/metrics?type=json`
+
+- 通过以下接口可以获取 Tablet 级别的监控项：
+  
+  `http://be_host:be_webserver_port/metrics?with_tablet=true`
 
 ## 监控项列表
 


### PR DESCRIPTION
## Proposed changes

Sometimes we want to detect the hotspot of a cluster, for example, hot scanned tablet, hot wrote tablet, but we have no insight about tablets in the cluster.
This patch introduce tablet level metrics to help to achieve this object, now support 4 metrics on tablets: `query_scan_bytes `, `query_scan_rows `, `flush_bytes `, `flush_count `. However, one BE may holds hundreds of thousands of tablets, so I add a parameter for the metrics HTTP request, and not return tablet level metrics by default.

ref https://github.com/apache/incubator-doris/issues/3517 https://github.com/apache/incubator-doris/issues/4027
## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] Documentation Update (if none of the other choices apply)
- [] Code refactor (Modify the code structure, format the code, etc...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [] I have create an issue on (Fix #ISSUE), and have described the bug/feature there in detail
- [x] Compiling and unit tests pass locally with my changes
- [] I have added tests that prove my fix is effective or that my feature works
- [] If this change need a document change, I have updated the document
- [] Any dependent changes have been merged

## Further comments

-