### PR TITLE
support collate field option in compare predicate sql from datagrip

### DIFF
--- a/fe/fe-core/src/main/cup/sql_parser.cup
+++ b/fe/fe-core/src/main/cup/sql_parser.cup
@@ -3262,6 +3262,46 @@ select_list_item ::=
     {:
         RESULT = new SelectListItem(expr, alias);
     :}
+    | expr:e1 opt_collate:collate EQUAL:op expr:e2 select_alias:alias
+    {:
+        Predicate p = new BinaryPredicate(BinaryPredicate.Operator.EQ, e1, e2);
+        RESULT = new SelectListItem(p, alias);
+    :}
+    | expr:e1 opt_collate:collate NOT EQUAL:op expr:e2 select_alias:alias
+    {:
+        Predicate p = new BinaryPredicate(BinaryPredicate.Operator.NE, e1, e2);
+        RESULT = new SelectListItem(p, alias);
+    :}
+    | expr:e1 opt_collate:collate LESSTHAN GREATERTHAN:op expr:e2 select_alias:alias
+    {:
+        Predicate p = new BinaryPredicate(BinaryPredicate.Operator.NE, e1, e2);
+        RESULT = new SelectListItem(p, alias);
+    :}
+    | expr:e1 opt_collate:collate LESSTHAN EQUAL:op expr:e2 select_alias:alias
+    {:
+        Predicate p = new BinaryPredicate(BinaryPredicate.Operator.LE, e1, e2);
+        RESULT = new SelectListItem(p, alias);
+    :}
+    | expr:e1 opt_collate:collate GREATERTHAN EQUAL:op expr:e2 select_alias:alias
+    {:
+        Predicate p = new BinaryPredicate(BinaryPredicate.Operator.GE, e1, e2);
+        RESULT = new SelectListItem(p, alias);
+    :}
+    | expr:e1 opt_collate:collate LESSTHAN:op expr:e2 select_alias:alias
+    {:
+        Predicate p = new BinaryPredicate(BinaryPredicate.Operator.LT, e1, e2);
+        RESULT = new SelectListItem(p, alias);
+    :}
+    | expr:e1 opt_collate:collate GREATERTHAN:op expr:e2 select_alias:alias
+    {:
+        Predicate p = new BinaryPredicate(BinaryPredicate.Operator.GT, e1, e2);
+        RESULT = new SelectListItem(p, alias);
+    :}
+    | expr:e1 opt_collate:collate LESSTHAN EQUAL GREATERTHAN:op expr:e2 select_alias:alias
+    {:
+        Predicate p = new BinaryPredicate(BinaryPredicate.Operator.EQ_FOR_NULL, e1, e2);
+        RESULT = new SelectListItem(p, alias);
+    :}
     | star_expr:expr
     {:
         RESULT = expr;

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/SelectStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/SelectStmtTest.java
@@ -350,4 +350,16 @@ public class SelectStmtTest {
                 "SELECT v1.k FROM test_view AS v1 LEFT OUTER JOIN test_view AS v2 ON v1.k=v2.k";
         dorisAssert.query(sql).explainQuery();
     }
+
+    @Test
+    public void testDataGripSupport() throws Exception {
+        String sql = "select schema();";
+        dorisAssert.query(sql).explainQuery();
+        sql = "select\n" +
+                "collation_name,\n" +
+                "character_set_name,\n" +
+                "is_default collate utf8_general_ci = 'Yes' as is_default\n" +
+                "from information_schema.collations";
+        dorisAssert.query(sql).explainQuery();
+    }
 }


### PR DESCRIPTION
## Proposed changes

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

Fix #4331  mentioned SQL:
"""
select
collation_name,
character_set_name,
is_default collate utf8_general_ci = 'Yes' as is_default
from information_schema.collations
"""

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] Documentation Update (if none of the other choices apply)
- [] Code refactor (Modify the code structure, format the code, etc...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have create an issue on (Fix #ISSUE), and have described the bug/feature there in detail
- [x] Compiling and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [] If this change need a document change, I have updated the document
- [] Any dependent changes have been merged

## Further comments

代码实现了基本的功能，可以让DataGrip读出来有哪些表和表结构了，但是感觉写得不优雅。
试了很多方式都有冲突，也可以看看怎么改比较好一些。

If this is a relatively large or complex change, kick off the discussion at dev@doris.apache.org by explaining why you chose the solution you did and what alternatives you considered, etc...
