### PR TITLE
[MySQL Compatibility 1/4][Bug] Fix bug that set sql_mode with concat() function failed

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/SetVar.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/SetVar.java
@@ -29,8 +29,6 @@ import org.apache.doris.qe.GlobalVariable;
 import org.apache.doris.qe.SessionVariable;
 import org.apache.doris.system.HeartbeatFlags;
 
-import com.google.common.base.Strings;
-
 // change one variable.
 public class SetVar {
 
@@ -107,16 +105,6 @@ public class SetVar {
             throw new AnalysisException("Set statement does't support non-constant expr.");
         }
 
-        /*
-        ExprRewriter exprRewriter = analyzer.getExprRewriter();
-        exprRewriter.reset();
-        value = exprRewriter.rewrite(value, analyzer);
-        if (exprRewriter.changed()) {
-            Analyzer newAnalyzer = new Analyzer(analyzer.getCatalog(), analyzer.getContext());
-            value.analyze(newAnalyzer);
-        }
-        */
-        
         final Expr literalExpr = value.getResultValue();
         if (!(literalExpr instanceof LiteralExpr)) {
             throw new AnalysisException("Set statement does't support computing expr:" + literalExpr.toSql());

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/SetVar.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/SetVar.java
@@ -28,6 +28,7 @@ import org.apache.doris.mysql.privilege.UserResource;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.GlobalVariable;
 import org.apache.doris.qe.SessionVariable;
+import org.apache.doris.rewrite.ExprRewriter;
 import org.apache.doris.system.HeartbeatFlags;
 
 // change one variable.
@@ -106,6 +107,10 @@ public class SetVar {
             throw new AnalysisException("Set statement does't support non-constant expr.");
         }
 
+        ExprRewriter exprRewriter = analyzer.getExprRewriter();
+        exprRewriter.reset();
+        value = exprRewriter.rewrite(value, analyzer);
+        
         final Expr literalExpr = value.getResultValue();
         if (!(literalExpr instanceof LiteralExpr)) {
             throw new AnalysisException("Set statement does't support computing expr:" + literalExpr.toSql());

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/SetVar.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/SetVar.java
@@ -17,7 +17,6 @@
 
 package org.apache.doris.analysis;
 
-import com.google.common.base.Strings;
 import org.apache.doris.catalog.Catalog;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.ErrorCode;
@@ -28,8 +27,9 @@ import org.apache.doris.mysql.privilege.UserResource;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.GlobalVariable;
 import org.apache.doris.qe.SessionVariable;
-import org.apache.doris.rewrite.ExprRewriter;
 import org.apache.doris.system.HeartbeatFlags;
+
+import com.google.common.base.Strings;
 
 // change one variable.
 public class SetVar {
@@ -107,9 +107,15 @@ public class SetVar {
             throw new AnalysisException("Set statement does't support non-constant expr.");
         }
 
+        /*
         ExprRewriter exprRewriter = analyzer.getExprRewriter();
         exprRewriter.reset();
         value = exprRewriter.rewrite(value, analyzer);
+        if (exprRewriter.changed()) {
+            Analyzer newAnalyzer = new Analyzer(analyzer.getCatalog(), analyzer.getContext());
+            value.analyze(newAnalyzer);
+        }
+        */
         
         final Expr literalExpr = value.getResultValue();
         if (!(literalExpr instanceof LiteralExpr)) {

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/SetVar.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/SetVar.java
@@ -29,6 +29,8 @@ import org.apache.doris.qe.GlobalVariable;
 import org.apache.doris.qe.SessionVariable;
 import org.apache.doris.system.HeartbeatFlags;
 
+import com.google.common.base.Strings;
+
 // change one variable.
 public class SetVar {
 

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/SysVariableDesc.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/SysVariableDesc.java
@@ -118,6 +118,10 @@ public class SysVariableDesc extends Expr {
     public Expr getResultValue() throws AnalysisException {
         Expr expr = super.getResultValue();
         if (!Strings.isNullOrEmpty(name) && name.equalsIgnoreCase(SessionVariable.SQL_MODE)) {
+            // SQL_MODE is a special variable. Its type is int, but it is usually set using a string.
+            // Such as `set sql_mode =  concat(@@sql_mode, "STRICT_TRANS_TABLES");`
+            // So we return the string type here so that it can correctly match the subsequent function signature.
+            // We will convert the string to int in VariableMgr.
             try {
                 return new StringLiteral(SqlModeHelper.decode(intValue));
             } catch (DdlException e) {

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/SysVariableDesc.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/SysVariableDesc.java
@@ -115,6 +115,19 @@ public class SysVariableDesc extends Expr {
     }
 
     @Override
+    public Expr getResultValue() throws AnalysisException {
+        Expr expr = super.getResultValue();
+        if (!Strings.isNullOrEmpty(name) && name.equalsIgnoreCase(SessionVariable.SQL_MODE)) {
+            try {
+                return new StringLiteral(SqlModeHelper.decode(intValue));
+            } catch (DdlException e) {
+                throw new AnalysisException(e.getMessage());
+            }
+        }
+        return expr;
+    }
+
+    @Override
     protected boolean isConstantImpl() {
         return true;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/SysVariableDesc.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/SysVariableDesc.java
@@ -17,7 +17,6 @@
 
 package org.apache.doris.analysis;
 
-import com.google.common.base.Strings;
 import org.apache.doris.catalog.Type;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.DdlException;
@@ -32,6 +31,8 @@ import org.apache.doris.thrift.TFloatLiteral;
 import org.apache.doris.thrift.TIntLiteral;
 import org.apache.doris.thrift.TStringLiteral;
 
+import com.google.common.base.Strings;
+
 // System variable
 // Converted to StringLiteral in analyze, if this variable is not exist, throw AnalysisException.
 public class SysVariableDesc extends Expr {
@@ -41,6 +42,8 @@ public class SysVariableDesc extends Expr {
     private long intValue;
     private double floatValue;
     private String strValue;
+
+    private LiteralExpr literalExpr;
 
     public SysVariableDesc(String name) {
         this(name, SetType.SESSION);
@@ -89,18 +92,31 @@ public class SysVariableDesc extends Expr {
 
     public void setBoolValue(boolean value) {
         this.boolValue = value;
+        this.literalExpr = new BoolLiteral(value);
     }
 
     public void setIntValue(long value) {
         this.intValue = value;
+        this.literalExpr = new IntLiteral(value);
     }
 
     public void setFloatValue(double value) {
         this.floatValue = value;
+        this.literalExpr = new FloatLiteral(value);
     }
 
     public void setStringValue(String value) {
         this.strValue = value;
+        this.literalExpr = new StringLiteral(value);
+    }
+
+    public Expr getLiteralExpr() {
+        return this.literalExpr;
+    }
+
+    @Override
+    protected boolean isConstantImpl() {
+        return true;
     }
 
     @Override

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/SetVariableTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/SetVariableTest.java
@@ -1,0 +1,52 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.analysis;
+
+import org.apache.doris.common.AnalysisException;
+import org.apache.doris.common.UserException;
+import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.qe.StmtExecutor;
+import org.apache.doris.utframe.UtFrameUtils;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.UUID;
+
+public class SetVariableTest {
+    // use a unique dir so that it won't be conflict with other unit test which
+    // may also start a Mocked Frontend
+    private static String runningDir = "fe/mocked/QueryPlanTest/" + UUID.randomUUID().toString() + "/";
+
+    private static ConnectContext connectContext;
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        UtFrameUtils.createMinDorisCluster(runningDir);
+        // create connect context
+        connectContext = UtFrameUtils.createDefaultCtx();
+    }
+
+    @Test
+    public void testNormal() throws UserException, AnalysisException {
+        String setStr = "set sql_mode = concat(@@sql_mode, 'STRICT_TRANS_TABLES');";
+        connectContext.getState().reset();
+        StmtExecutor stmtExecutor = new StmtExecutor(connectContext, setStr);
+        System.out.println(connectContext.getSessionVariable().getSqlMode());
+    }
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/SetVariableTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/SetVariableTest.java
@@ -17,12 +17,12 @@
 
 package org.apache.doris.analysis;
 
-import org.apache.doris.common.AnalysisException;
-import org.apache.doris.common.UserException;
 import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.qe.SqlModeHelper;
 import org.apache.doris.qe.StmtExecutor;
 import org.apache.doris.utframe.UtFrameUtils;
 
+import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -43,10 +43,21 @@ public class SetVariableTest {
     }
 
     @Test
-    public void testNormal() throws UserException, AnalysisException {
+    public void testSqlMode() throws Exception {
         String setStr = "set sql_mode = concat(@@sql_mode, 'STRICT_TRANS_TABLES');";
         connectContext.getState().reset();
         StmtExecutor stmtExecutor = new StmtExecutor(connectContext, setStr);
-        System.out.println(connectContext.getSessionVariable().getSqlMode());
+        stmtExecutor.execute();
+        Assert.assertEquals("STRICT_TRANS_TABLES",
+                SqlModeHelper.decode(connectContext.getSessionVariable().getSqlMode()));
+    }
+
+    @Test
+    public void testExecMemLimit() throws Exception {
+        String setStr = "set exec_mem_limit = @@exec_mem_limit * 10";
+        connectContext.getState().reset();
+        StmtExecutor stmtExecutor = new StmtExecutor(connectContext, setStr);
+        stmtExecutor.execute();
+        Assert.assertEquals(21474836480L, connectContext.getSessionVariable().getMaxExecMemByte());
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/planner/QueryPlanTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/planner/QueryPlanTest.java
@@ -40,13 +40,13 @@ import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.QueryState.MysqlStateType;
 import org.apache.doris.utframe.UtFrameUtils;
 
-import com.google.common.collect.Lists;
-
 import org.apache.commons.lang3.StringUtils;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
+
+import com.google.common.collect.Lists;
 
 import java.io.File;
 import java.util.List;
@@ -1005,15 +1005,5 @@ public class QueryPlanTest {
             Assert.assertTrue(explainString.contains(emptyNode));
             Assert.assertFalse(explainString.contains(denseRank));
         }
-    }
-
-    @Test
-    public void testConst() throws Exception {
-        connectContext.setDatabase("default_cluster:test");
-        // String queryStr = "set sql_mode = concat(@@sql_mode, \"STRICT_TRANS_TABLES\")";
-        // String queryStr = "select concat(@@sql_mode, \"STRICT_TRANS_TABLES\")";
-        String queryStr = "select concat(@@exec_mem_limit, \"STRICT_TRANS_TABLES\")";
-        // default set PreferBroadcastJoin true
-        String explainString = UtFrameUtils.getSQLPlanOrErrorMsg(connectContext, queryStr);
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/planner/QueryPlanTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/planner/QueryPlanTest.java
@@ -1010,7 +1010,9 @@ public class QueryPlanTest {
     @Test
     public void testConst() throws Exception {
         connectContext.setDatabase("default_cluster:test");
-        String queryStr = "set sql_mode = concat(@@exec_mem_limit, \"abc\")";
+        // String queryStr = "set sql_mode = concat(@@sql_mode, \"STRICT_TRANS_TABLES\")";
+        // String queryStr = "select concat(@@sql_mode, \"STRICT_TRANS_TABLES\")";
+        String queryStr = "select concat(@@exec_mem_limit, \"STRICT_TRANS_TABLES\")";
         // default set PreferBroadcastJoin true
         String explainString = UtFrameUtils.getSQLPlanOrErrorMsg(connectContext, queryStr);
     }

--- a/fe/fe-core/src/test/java/org/apache/doris/planner/QueryPlanTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/planner/QueryPlanTest.java
@@ -17,7 +17,6 @@
 
 package org.apache.doris.planner;
 
-import com.google.common.collect.Lists;
 import org.apache.doris.analysis.CreateDbStmt;
 import org.apache.doris.analysis.CreateTableStmt;
 import org.apache.doris.analysis.DropDbStmt;
@@ -40,6 +39,8 @@ import org.apache.doris.load.EtlJobType;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.QueryState.MysqlStateType;
 import org.apache.doris.utframe.UtFrameUtils;
+
+import com.google.common.collect.Lists;
 
 import org.apache.commons.lang3.StringUtils;
 import org.junit.AfterClass;
@@ -1004,5 +1005,13 @@ public class QueryPlanTest {
             Assert.assertTrue(explainString.contains(emptyNode));
             Assert.assertFalse(explainString.contains(denseRank));
         }
+    }
+
+    @Test
+    public void testConst() throws Exception {
+        connectContext.setDatabase("default_cluster:test");
+        String queryStr = "set sql_mode = concat(@@exec_mem_limit, \"abc\")";
+        // default set PreferBroadcastJoin true
+        String explainString = UtFrameUtils.getSQLPlanOrErrorMsg(connectContext, queryStr);
     }
 }


### PR DESCRIPTION
## Proposed changes

Support `set sql_mode = concat(@@sql_mode, "STRICT_TRANS_TABLES");`

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have create an issue on (Fix #4358), and have described the bug/feature there in detail
- [x] Compiling and unit tests pass locally with my changes