### PR TITLE
[BUG] Fix except wrong answer bug

### DIFF
--- a/be/src/exec/except_node.cpp
+++ b/be/src/exec/except_node.cpp
@@ -56,16 +56,12 @@ Status ExceptNode::open(RuntimeState* state) {
                     new HashTable(_child_expr_lists[0], _child_expr_lists[i], _build_tuple_size,
                                   true, _find_nulls, id(), mem_tracker(), 1024));
             _hash_tbl_iterator = _hash_tbl->begin();
-            uint32_t previous_hash = -1;
             while (_hash_tbl_iterator.has_next()) {
-                if (previous_hash != _hash_tbl_iterator.get_hash()) {
-                    previous_hash = _hash_tbl_iterator.get_hash();
-                    if (!_hash_tbl_iterator.matched()) {
-                        VLOG_ROW << "rebuild row: "
-                                 << get_row_output_string(_hash_tbl_iterator.get_row(),
-                                                          child(0)->row_desc());
-                        temp_tbl->insert(_hash_tbl_iterator.get_row());
-                    }
+                if (!_hash_tbl_iterator.matched()) {
+                    VLOG_ROW << "rebuild row: "
+                             << get_row_output_string(_hash_tbl_iterator.get_row(),
+                                                      child(0)->row_desc());
+                    temp_tbl->insert(_hash_tbl_iterator.get_row());
                 }
                 _hash_tbl_iterator.next<false>();
             }


### PR DESCRIPTION
Doris use HashTable to implement except.
If user send A except B except C, first do A except B and then except C.
After A except B, HashTable will be rebuild.
There is a bug here to throw some rows.

## Proposed changes

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] Documentation Update (if none of the other choices apply)
- [] Code refactor (Modify the code structure, format the code, etc...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [] I have create an issue on (Fix #ISSUE), and have described the bug/feature there in detail
- [] Compiling and unit tests pass locally with my changes
- [] I have added tests that prove my fix is effective or that my feature works
- [] If this change need a document change, I have updated the document
- [] Any dependent changes have been merged

## Further comments

If this is a relatively large or complex change, kick off the discussion at dev@doris.apache.org by explaining why you chose the solution you did and what alternatives you considered, etc...
