### PR TITLE
Fix errors when alter materialized view which based on dup table

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeHandler.java
@@ -129,7 +129,7 @@ public class SchemaChangeHandler extends AlterHandler {
 
         Set<String> newColNameSet = Sets.newHashSet(column.getName());
         addColumnInternal(olapTable, column, columnPos, targetIndexId, baseIndexId,
-                          baseIndexName, indexSchemaMap, newColNameSet);
+                          indexSchemaMap, newColNameSet);
     }
 
     private void processAddColumns(AddColumnsClause alterClause, OlapTable olapTable,
@@ -154,7 +154,7 @@ public class SchemaChangeHandler extends AlterHandler {
 
         for (Column column : columns) {
             addColumnInternal(olapTable, column, null, targetIndexId, baseIndexId,
-                    baseIndexName, indexSchemaMap, newColNameSet);
+                    indexSchemaMap, newColNameSet);
         }
     }
 
@@ -531,7 +531,7 @@ public class SchemaChangeHandler extends AlterHandler {
      * Modified schema will be saved in 'indexSchemaMap'
      */
     private void addColumnInternal(OlapTable olapTable, Column newColumn, ColumnPosition columnPos,
-                                   long targetIndexId, long baseIndexId, String baseIndexName,
+                                   long targetIndexId, long baseIndexId,
                                    Map<Long, LinkedList<Column>> indexSchemaMap,
                                    Set<String> newColNameSet) throws DdlException {
         
@@ -556,6 +556,10 @@ public class SchemaChangeHandler extends AlterHandler {
                 throw new DdlException("Can not assign aggregation method on column in Duplicate data model table: " + newColName);
             }
             if (!newColumn.isKey()) {
+                if (targetIndexId != -1L &&
+                        olapTable.getIndexMetaByIndexId(targetIndexId).getKeysType() == KeysType.AGG_KEYS) {
+                    throw new DdlException("Please add non-key column on base table directly");
+                }
                 newColumn.setAggregationType(AggregateType.NONE, true);
             }
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
@@ -556,7 +556,9 @@ public class OlapTable extends Table {
     }
 
     public KeysType getKeysTypeByIndexId(long indexId) {
-        return indexIdToMeta.get(indexId).getKeysType();
+        MaterializedIndexMeta indexMeta = indexIdToMeta.get(indexId);
+        Preconditions.checkNotNull(indexMeta);
+        return indexMeta.getKeysType();
     }
 
     public PartitionInfo getPartitionInfo() {

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
@@ -557,8 +557,8 @@ public class OlapTable extends Table {
 
     public KeysType getKeysTypeByIndexId(long indexId) {
         MaterializedIndexMeta indexMeta = indexIdToMeta.get(indexId);
-        Preconditions.checkNotNull(indexMeta);
-        return indexMeta.getKeysType();
+        Preconditions.checkNotNull(indexMeta, "index id:" + indexId + " meta is null");
+         return indexMeta.getKeysType();
     }
 
     public PartitionInfo getPartitionInfo() {

--- a/fe/fe-core/src/test/java/org/apache/doris/alter/SchemaChangeHandlerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/alter/SchemaChangeHandlerTest.java
@@ -1,0 +1,64 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.alter;
+
+import org.apache.doris.analysis.ColumnPosition;
+import org.apache.doris.catalog.Column;
+import org.apache.doris.catalog.KeysType;
+import org.apache.doris.catalog.OlapTable;
+import org.apache.doris.common.jmockit.Deencapsulation;
+
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import mockit.Expectations;
+import mockit.Injectable;
+
+public class SchemaChangeHandlerTest {
+
+    @Test
+    public void testAddValueColumnOnAggMV(@Injectable OlapTable olapTable, @Injectable Column newColumn,
+                                          @Injectable ColumnPosition columnPosition) {
+        SchemaChangeHandler schemaChangeHandler = new SchemaChangeHandler();
+        new Expectations() {
+            {
+                olapTable.getKeysType();
+                result = KeysType.DUP_KEYS;
+                newColumn.getAggregationType();
+                result = null;
+                olapTable.getIndexMetaByIndexId(2).getKeysType();
+                result = KeysType.AGG_KEYS;
+                newColumn.isKey();
+                result = false;
+            }
+        };
+
+        try {
+            Deencapsulation.invoke(schemaChangeHandler, "addColumnInternal", olapTable, newColumn, columnPosition,
+                                   new Long(2), new Long(1),
+                                   Maps.newHashMap(), Sets.newHashSet());
+            Assert.fail();
+        } catch (Exception e) {
+            System.out.println(e.getMessage());
+        }
+
+    }
+}


### PR DESCRIPTION
## Proposed changes

1. Input the correct keys type when mv is updated.
The keys type of mv should be used in schema change job rather then keys type of base table.
Otherwise, the be will core and thrown exception "Create replicas failed".

2. Forbidden add non-key column on agg mv directly when base table is duplicate model
If a dup table has a agg mv, user will not add a non-key column on mv.
The non-key column can only be added to dup index.

Fixed #4374
Change-Id: I375f695b3109e513622110cf0ca04a4034780909

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] Documentation Update (if none of the other choices apply)
- [] Code refactor (Modify the code structure, format the code, etc...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have create an issue on (Fix #ISSUE), and have described the bug/feature there in detail
- [x] Compiling and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [] If this change need a document change, I have updated the document
- [] Any dependent changes have been merged