### PR TITLE
Modify mv rewrite rule on 'Count distinct'

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/rewrite/mvrewrite/CountFieldToSum.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/rewrite/mvrewrite/CountFieldToSum.java
@@ -60,6 +60,9 @@ public class CountFieldToSum implements ExprRewriteRule {
         if (fnExpr.getChildren().size() != 1 || !(fnExpr.getChild(0) instanceof SlotRef)) {
             return expr;
         }
+        if (fnExpr.getParams().isDistinct()) {
+            return expr;
+        }
         SlotRef fnChild0 = (SlotRef) fnExpr.getChild(0);
         Column column = fnChild0.getColumn();
         Table table = fnChild0.getTable();

--- a/fe/fe-core/src/test/java/org/apache/doris/rewrite/mvrewrite/CountFieldToSumTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/rewrite/mvrewrite/CountFieldToSumTest.java
@@ -1,0 +1,69 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.rewrite.mvrewrite;
+
+import org.apache.doris.analysis.Analyzer;
+import org.apache.doris.analysis.Expr;
+import org.apache.doris.analysis.FunctionCallExpr;
+import org.apache.doris.analysis.SlotRef;
+import org.apache.doris.analysis.TableName;
+import org.apache.doris.catalog.FunctionSet;
+import org.apache.doris.common.AnalysisException;
+
+import com.google.common.collect.Lists;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.List;
+
+import mockit.Expectations;
+import mockit.Injectable;
+
+public class CountFieldToSumTest {
+
+    @Test
+    public void testCountDistinct(@Injectable Analyzer analyzer,
+                                  @Injectable FunctionCallExpr functionCallExpr) {
+        TableName tableName = new TableName("db1", "table1");
+        SlotRef slotRef = new SlotRef(tableName,"c1");
+        List<Expr>  params = Lists.newArrayList();
+        params.add(slotRef);
+
+        new Expectations() {
+            {
+                functionCallExpr.getFnName().getFunction();
+                result = FunctionSet.COUNT;
+                functionCallExpr.getChildren();
+                result = params;
+                functionCallExpr.getChild(0);
+                result = slotRef;
+                functionCallExpr.getParams().isDistinct();
+                result = true;
+            }
+        };
+        CountFieldToSum countFieldToSum = new CountFieldToSum();
+        try {
+            Expr rewrittenExpr = countFieldToSum.apply(functionCallExpr, analyzer);
+            Assert.assertTrue(rewrittenExpr instanceof FunctionCallExpr);
+            Assert.assertEquals(FunctionSet.COUNT, ((FunctionCallExpr) rewrittenExpr).getFnName().getFunction());
+        } catch (AnalysisException e) {
+            System.out.println(e.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
## Proposed changes

The rewrite rule named `CountToSum` does not distinguish between `Count` and `Count distinct` which causes `Count distinct` is rewritten as `Sum` incorrectly.
So this commit modified matching rule.
When the function is `Count distinct`, the rewrite rule will not take effect.

Fixed #4381

Change-Id: I2b9fbde22c6bc91ba7310e630e29a7e96b909102

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] Documentation Update (if none of the other choices apply)
- [] Code refactor (Modify the code structure, format the code, etc...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have create an issue on (Fix #4381), and have described the bug/feature there in detail
- [x] Compiling and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [] If this change need a document change, I have updated the document
- [] Any dependent changes have been merged
