### PR TITLE
Make some readFields methods Deprecated

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/alter/AlterJobV2.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/AlterJobV2.java
@@ -266,6 +266,7 @@ public abstract class AlterJobV2 implements Writable {
         out.writeLong(timeoutMs);
     }
 
+    @Deprecated
     public void readFields(DataInput in) throws IOException {
         // read common members as write in AlterJobV2.write().
         // except 'type' member, which is read in AlterJobV2.read()

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Column.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Column.java
@@ -445,6 +445,7 @@ public class Column implements Writable {
         Text.writeString(out, json);
     }
 
+    @Deprecated
     private void readFields(DataInput in) throws IOException {
         name = Text.readString(in);
         type = ColumnType.read(in);

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/FsBroker.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/FsBroker.java
@@ -119,6 +119,7 @@ public class FsBroker implements Writable, Comparable<FsBroker> {
         Text.writeString(out, json);
     }
 
+    @Deprecated
     private void readFields(DataInput in) throws IOException {
         ip = Text.readString(in);
         port = in.readInt();

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/TempPartitions.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/TempPartitions.java
@@ -133,6 +133,7 @@ public class TempPartitions implements Writable, GsonPostProcessable {
         }
     }
 
+    @Deprecated
     private void readFields(DataInput in) throws IOException {
         int size = in.readInt();
         for (int i = 0; i < size; i++) {

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/DropDbInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/DropDbInfo.java
@@ -51,6 +51,7 @@ public class DropDbInfo implements Writable {
         return  forceDrop;
     }
 
+    @Deprecated
     private void readFields(DataInput in) throws IOException {
         dbName = Text.readString(in);
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/DropPartitionInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/DropPartitionInfo.java
@@ -72,6 +72,7 @@ public class DropPartitionInfo implements Writable {
         return forceDrop;
     }
 
+    @Deprecated
     private void readFields(DataInput in) throws IOException {
         dbId = in.readLong();
         tableId = in.readLong();

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/TruncateTableInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/TruncateTableInfo.java
@@ -87,6 +87,7 @@ public class TruncateTableInfo implements Writable {
         Text.writeString(out, json);
     }
 
+    @Deprecated
     private void readFields(DataInput in) throws IOException {
         dbId = in.readLong();
         tblId = in.readLong();

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -578,51 +578,56 @@ public class SessionVariable implements Serializable, Writable {
         Text.writeString(out, root.toString());
     }
 
+    @Deprecated
+    private void readFromStream(DataInput in) throws IOException {
+        codegenLevel = in.readInt();
+        netBufferLength = in.readInt();
+        sqlSafeUpdates = in.readInt();
+        timeZone = Text.readString(in);
+        netReadTimeout = in.readInt();
+        netWriteTimeout = in.readInt();
+        waitTimeout = in.readInt();
+        interactiveTimeout = in.readInt();
+        queryCacheType = in.readInt();
+        autoIncrementIncrement = in.readInt();
+        maxAllowedPacket = in.readInt();
+        sqlSelectLimit = in.readLong();
+        sqlAutoIsNull = in.readBoolean();
+        collationDatabase = Text.readString(in);
+        collationConnection = Text.readString(in);
+        charsetServer = Text.readString(in);
+        charsetResults = Text.readString(in);
+        charsetConnection = Text.readString(in);
+        charsetClient = Text.readString(in);
+        txIsolation = Text.readString(in);
+        autoCommit = in.readBoolean();
+        resourceGroup = Text.readString(in);
+        if (Catalog.getCurrentCatalogJournalVersion() >= FeMetaVersion.VERSION_65) {
+            sqlMode = in.readLong();
+        } else {
+            // read old version SQL mode
+            Text.readString(in);
+            sqlMode = 0L;
+        }
+        isReportSucc = in.readBoolean();
+        queryTimeoutS = in.readInt();
+        maxExecMemByte = in.readLong();
+        if (Catalog.getCurrentCatalogJournalVersion() >= FeMetaVersion.VERSION_37) {
+            collationServer = Text.readString(in);
+        }
+        if (Catalog.getCurrentCatalogJournalVersion() >= FeMetaVersion.VERSION_38) {
+            batchSize = in.readInt();
+            disableStreamPreaggregations = in.readBoolean();
+            parallelExecInstanceNum = in.readInt();
+        }
+        if (Catalog.getCurrentCatalogJournalVersion() >= FeMetaVersion.VERSION_62) {
+            exchangeInstanceParallel = in.readInt();
+        }
+    }
+
     public void readFields(DataInput in) throws IOException {
         if (Catalog.getCurrentCatalogJournalVersion() < FeMetaVersion.VERSION_67) {
-            codegenLevel = in.readInt();
-            netBufferLength = in.readInt();
-            sqlSafeUpdates = in.readInt();
-            timeZone = Text.readString(in);
-            netReadTimeout = in.readInt();
-            netWriteTimeout = in.readInt();
-            waitTimeout = in.readInt();
-            interactiveTimeout = in.readInt();
-            queryCacheType = in.readInt();
-            autoIncrementIncrement = in.readInt();
-            maxAllowedPacket = in.readInt();
-            sqlSelectLimit = in.readLong();
-            sqlAutoIsNull = in.readBoolean();
-            collationDatabase = Text.readString(in);
-            collationConnection = Text.readString(in);
-            charsetServer = Text.readString(in);
-            charsetResults = Text.readString(in);
-            charsetConnection = Text.readString(in);
-            charsetClient = Text.readString(in);
-            txIsolation = Text.readString(in);
-            autoCommit = in.readBoolean();
-            resourceGroup = Text.readString(in);
-            if (Catalog.getCurrentCatalogJournalVersion() >= FeMetaVersion.VERSION_65) {
-                sqlMode = in.readLong();
-            } else {
-                // read old version SQL mode
-                Text.readString(in);
-                sqlMode = 0L;
-            }
-            isReportSucc = in.readBoolean();
-            queryTimeoutS = in.readInt();
-            maxExecMemByte = in.readLong();
-            if (Catalog.getCurrentCatalogJournalVersion() >= FeMetaVersion.VERSION_37) {
-                collationServer = Text.readString(in);
-            }
-            if (Catalog.getCurrentCatalogJournalVersion() >= FeMetaVersion.VERSION_38) {
-                batchSize = in.readInt();
-                disableStreamPreaggregations = in.readBoolean();
-                parallelExecInstanceNum = in.readInt();
-            }
-            if (Catalog.getCurrentCatalogJournalVersion() >= FeMetaVersion.VERSION_62) {
-                exchangeInstanceParallel = in.readInt();
-            }
+            readFromStream(in);
         } else {
             readFromJson(in);
         }


### PR DESCRIPTION
## Proposed changes

We have changed most of our serialization methods to json. In order to be compatible with previous data, these classes still retain the readFields method. Some prs that involve modifying metadata often modify the readFields method. To avoid this, we should Mark these methods as Deprecated #4398 

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [] Bugfix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] Documentation Update (if none of the other choices apply)
- [x] Code refactor (Modify the code structure, format the code, etc...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have create an issue on (Fix #ISSUE), and have described the bug/feature there in detail
- [x] Compiling and unit tests pass locally with my changes
- [] I have added tests that prove my fix is effective or that my feature works
- [] If this change need a document change, I have updated the document
- [x] Any dependent changes have been merged
