### PR TITLE
optimize default value of replication_num

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateTableStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateTableStmt.java
@@ -73,6 +73,8 @@ public class CreateTableStmt extends DdlStmt {
     private String comment;
     private List<AlterClause> rollupAlterClauseList;
 
+    private int replicaNum = FeConstants.default_replication_num;
+
     private static Set<String> engineNames;
 
     // set in analyze
@@ -238,6 +240,14 @@ public class CreateTableStmt extends DdlStmt {
 
     public List<Index> getIndexes() {
         return indexes;
+    }
+
+    public int getReplicaNum() {
+        return replicaNum;
+    }
+
+    public void setReplicaNum(int replicaNum) {
+        this.replicaNum = replicaNum;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Catalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Catalog.java
@@ -3612,6 +3612,7 @@ public class Catalog {
 
             replicationNum = PropertyAnalyzer.analyzeReplicationNum(properties, replicationNum);
             olapTable.setReplicationNum(replicationNum);
+            stmt.setReplicaNum(replicationNum);
         } catch (AnalysisException e) {
             throw new DdlException(e.getMessage());
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Catalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Catalog.java
@@ -3605,11 +3605,13 @@ public class Catalog {
         // analyze replication_num
         short replicationNum = FeConstants.default_replication_num;
         try {
-            boolean isReplicationNumSet = properties != null && properties.containsKey(PropertyAnalyzer.PROPERTIES_REPLICATION_NUM);
-            replicationNum = PropertyAnalyzer.analyzeReplicationNum(properties, replicationNum);
-            if (isReplicationNumSet) {
-                olapTable.setReplicationNum(replicationNum);
+            int backendNum = getCluster(stmt.getClusterName()).getBackendIdList().size();
+            if (replicationNum > backendNum && backendNum > 0) {
+                replicationNum = (short) backendNum;
             }
+
+            replicationNum = PropertyAnalyzer.analyzeReplicationNum(properties, replicationNum);
+            olapTable.setReplicationNum(replicationNum);
         } catch (AnalysisException e) {
             throw new DdlException(e.getMessage());
         }


### PR DESCRIPTION
## Proposed changes

In the current code, if we do not specify replication_num when creating OlapTable, the default value of 3 will be used, but for some test environments and small clusters, the number of backends is likely to be less than 3, which will cause confusion for users
Therefore, when the number of backends is less than 3 When the default replication_num should be equal to the number of backends, the default value should be 3 when the number of backends is greater than 3.

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] Documentation Update (if none of the other choices apply)
- [] Code refactor (Modify the code structure, format the code, etc...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have create an issue on (Fix #4412 ), and have described the bug/feature there in detail
- [x] Compiling and unit tests pass locally with my changes
- [] I have added tests that prove my fix is effective or that my feature works
- [] If this change need a document change, I have updated the document
- [x] Any dependent changes have been merged

## Further comments

If this is a relatively large or complex change, kick off the discussion at dev@doris.apache.org by explaining why you chose the solution you did and what alternatives you considered, etc...
