### PR TITLE
Forbidden the illegal column types on BITMAP_UNION OR HLL_UNION mv

### DIFF
--- a/be/src/exec/union_node.cpp
+++ b/be/src/exec/union_node.cpp
@@ -219,6 +219,7 @@ Status UnionNode::get_next_const(RuntimeState* state, RowBatch* row_batch) {
     while (_const_expr_list_idx < _const_expr_lists.size() && !row_batch->at_capacity()) {
         materialize_exprs(
             _const_expr_lists[_const_expr_list_idx], nullptr, tuple_buf, row_batch);
+        RETURN_IF_ERROR(get_error_msg(_const_expr_lists[_const_expr_list_idx]));
         tuple_buf += _tuple_desc->byte_size();
         ++_const_expr_list_idx;
     }

--- a/be/src/exec/union_node.h
+++ b/be/src/exec/union_node.h
@@ -126,6 +126,8 @@ private:
     void materialize_exprs(const std::vector<ExprContext*>& exprs,
                            TupleRow* row, uint8_t* tuple_buf, RowBatch* dst_batch);
 
+    Status get_error_msg(const std::vector<ExprContext*>& exprs);
+
     /// Returns true if the child at 'child_idx' can be passed through.
     bool is_child_passthrough(int child_idx) const {
         DCHECK_LT(child_idx, _children.size());

--- a/be/src/exec/union_node_ir.cpp
+++ b/be/src/exec/union_node_ir.cpp
@@ -16,6 +16,7 @@
 // under the License.
 
 #include "exec/union_node.h"
+#include "exprs/expr_context.h"
 #include "runtime/tuple_row.h"
 
 namespace doris {
@@ -50,6 +51,16 @@ void UnionNode::materialize_batch(RowBatch* dst_batch, uint8_t** tuple_buf) {
 
     _child_row_idx += num_rows_to_process;
     *tuple_buf = cur_tuple;
+}
+
+Status UnionNode::get_error_msg(const std::vector<ExprContext*>& exprs) {
+    for (auto expr_ctx: exprs) {
+        std::string expr_error = expr_ctx->get_error_msg();
+        if (!expr_error.empty()) {
+            return Status::RuntimeError(expr_error);
+        }
+    }
+    return Status::OK();
 }
 
 }

--- a/docs/en/administrator-guide/materialized_view.md
+++ b/docs/en/administrator-guide/materialized_view.md
@@ -90,6 +90,9 @@ The aggregate functions currently supported by the materialized view function ar
 + SUM, MIN, MAX (Version 0.12)
 + COUNT, BITMAP\_UNION, HLL\_UNION (Version 0.13)
 
++ The form of BITMAP\_UNION must be: `BITMAP_UNION(TO_BITMAP(COLUMN))` The column type can only be an integer (largeint also does not support), or `BITMAP_UNION(COLUMN)` and the base table is an AGG model.
++ The form of HLL\_UNION must be: `HLL_UNION(HLL_HASH(COLUMN))` The column type cannot be DECIMAL, or `HLL_UNION(COLUMN)` and the base table is an AGG model.
+
 ### Update strategy
 
 In order to ensure the data consistency between the materialized view table and the Base table, Doris will import, delete and other operations on the Base table are synchronized to the materialized view table. And through incremental update to improve update efficiency. To ensure atomicity through transaction.

--- a/docs/zh-CN/administrator-guide/materialized_view.md
+++ b/docs/zh-CN/administrator-guide/materialized_view.md
@@ -91,6 +91,9 @@ HELP CREATE MATERIALIZED VIEW
 + SUM, MIN, MAX (Version 0.12)
 + COUNT, BITMAP\_UNION, HLL\_UNION (Version 0.13)
 
++ BITMAP\_UNION 的形式必须为：`BITMAP_UNION(TO_BITMAP(COLUMN))` column 列的类型只能是整数（largeint也不支持), 或者 `BITMAP_UNION(COLUMN)` 且 base 表为 AGG 模型。
++ HLL\_UNION 的形式必须为：`HLL_UNION(HLL_HASH(COLUMN))` column 列的类型不能是 DECIMAL , 或者 `HLL_UNION(COLUMN)` 且 base 表为 AGG 模型。
+
 ### 更新策略
 
 为保证物化视图表和 Base 表的数据一致性, Doris 会将导入，删除等对 base 表的操作都同步到物化视图表中。并且通过增量更新的方式来提升更新效率。通过事务方式来保证原子性。

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/MVColumnBitmapUnionPattern.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/MVColumnBitmapUnionPattern.java
@@ -44,11 +44,13 @@ public class MVColumnBitmapUnionPattern implements MVColumnPattern {
             if (!child0FnExpr.getFnName().getFunction().equalsIgnoreCase(FunctionSet.TO_BITMAP)) {
                 return false;
             }
-            if (child0FnExpr.getChild(0).unwrapSlotRef() == null) {
+            SlotRef slotRef = child0FnExpr.getChild(0).unwrapSlotRef();
+            if (slotRef == null) {
                 return false;
-            } else {
+            } else if (slotRef.getType().isIntegerType()) {
                 return true;
             }
+            return false;
         } else {
             return false;
         }
@@ -56,7 +58,7 @@ public class MVColumnBitmapUnionPattern implements MVColumnPattern {
 
     @Override
     public String toString() {
-        return FunctionSet.BITMAP_UNION + "(" + FunctionSet.TO_BITMAP + "(column)) "
-                + "or " + FunctionSet.BITMAP_UNION + "(bitmap_column) in agg table";
+        return FunctionSet.BITMAP_UNION + "(" + FunctionSet.TO_BITMAP + "(column)), type of column could not be integer. "
+                + "Or " + FunctionSet.BITMAP_UNION + "(bitmap_column) in agg table";
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/MVColumnHLLUnionPattern.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/MVColumnHLLUnionPattern.java
@@ -19,6 +19,7 @@ package org.apache.doris.analysis;
 
 import org.apache.doris.catalog.FunctionSet;
 import org.apache.doris.catalog.PrimitiveType;
+import org.apache.doris.catalog.Type;
 
 public class MVColumnHLLUnionPattern implements MVColumnPattern {
     @Override
@@ -43,11 +44,13 @@ public class MVColumnHLLUnionPattern implements MVColumnPattern {
             if (!child0FnExpr.getFnName().getFunction().equalsIgnoreCase(FunctionSet.HLL_HASH)) {
                 return false;
             }
-            if (child0FnExpr.getChild(0).unwrapSlotRef() == null) {
+            SlotRef slotRef = child0FnExpr.getChild(0).unwrapSlotRef();
+            if (slotRef == null) {
                 return false;
-            } else {
-                return true;
+            } else if (slotRef.getType() == Type.DECIMALV2) {
+                return false;
             }
+            return true;
         } else {
             return false;
         }
@@ -55,7 +58,7 @@ public class MVColumnHLLUnionPattern implements MVColumnPattern {
 
     @Override
     public String toString() {
-        return FunctionSet.HLL_UNION + "(" + FunctionSet.HLL_HASH + "(column))"
-                + "or " + FunctionSet.HLL_UNION + "(hll_column) in agg table";
+        return FunctionSet.HLL_UNION + "(" + FunctionSet.HLL_HASH + "(column)) column could not be decimal. "
+                + "Or " + FunctionSet.HLL_UNION + "(hll_column) in agg table";
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/MVColumnBitmapUnionPatternTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/MVColumnBitmapUnionPatternTest.java
@@ -20,6 +20,7 @@ package org.apache.doris.analysis;
 import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.FunctionSet;
 import org.apache.doris.catalog.Type;
+import org.apache.doris.common.jmockit.Deencapsulation;
 
 import com.google.common.collect.Lists;
 
@@ -37,6 +38,7 @@ public class MVColumnBitmapUnionPatternTest {
     public void testCorrectExpr1() {
         TableName tableName = new TableName("db", "table");
         SlotRef slotRef = new SlotRef(tableName, "c1");
+        Deencapsulation.setField(slotRef, "type", Type.INT);
         List<Expr> child0Params = Lists.newArrayList();
         child0Params.add(slotRef);
         FunctionCallExpr child0 = new FunctionCallExpr(FunctionSet.TO_BITMAP, child0Params);
@@ -51,6 +53,7 @@ public class MVColumnBitmapUnionPatternTest {
     public void testCorrectExpr2(@Injectable CastExpr castExpr) {
         TableName tableName = new TableName("db", "table");
         SlotRef slotRef = new SlotRef(tableName, "c1");
+        Deencapsulation.setField(slotRef, "type", Type.INT);
         new Expectations() {
             {
                 castExpr.unwrapSlotRef();
@@ -71,6 +74,7 @@ public class MVColumnBitmapUnionPatternTest {
     public void testUpperCaseOfFunction() {
         TableName tableName = new TableName("db", "table");
         SlotRef slotRef = new SlotRef(tableName, "c1");
+        Deencapsulation.setField(slotRef, "type", Type.INT);
         List<Expr> child0Params = Lists.newArrayList();
         child0Params.add(slotRef);
         FunctionCallExpr child0 = new FunctionCallExpr(FunctionSet.TO_BITMAP.toUpperCase(), child0Params);
@@ -102,6 +106,21 @@ public class MVColumnBitmapUnionPatternTest {
         ArithmeticExpr arithmeticExpr = new ArithmeticExpr(ArithmeticExpr.Operator.ADD, slotRef1, slotRef2);
         List<Expr> child0Params = Lists.newArrayList();
         child0Params.add(arithmeticExpr);
+        FunctionCallExpr child0 = new FunctionCallExpr(FunctionSet.TO_BITMAP, child0Params);
+        List<Expr> params = Lists.newArrayList();
+        params.add(child0);
+        FunctionCallExpr expr = new FunctionCallExpr(FunctionSet.BITMAP_UNION, params);
+        MVColumnBitmapUnionPattern pattern = new MVColumnBitmapUnionPattern();
+        Assert.assertFalse(pattern.match(expr));
+    }
+
+    @Test
+    public void testIncorrectDecimalSlotRef() {
+        TableName tableName = new TableName("db", "table");
+        SlotRef slotRef1 = new SlotRef(tableName, "c1");
+        Deencapsulation.setField(slotRef1, "type", Type.DECIMALV2);
+        List<Expr> child0Params = Lists.newArrayList();
+        child0Params.add(slotRef1);
         FunctionCallExpr child0 = new FunctionCallExpr(FunctionSet.TO_BITMAP, child0Params);
         List<Expr> params = Lists.newArrayList();
         params.add(child0);

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/MVColumnHLLUnionPatternTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/MVColumnHLLUnionPatternTest.java
@@ -20,6 +20,7 @@ package org.apache.doris.analysis;
 import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.FunctionSet;
 import org.apache.doris.catalog.Type;
+import org.apache.doris.common.jmockit.Deencapsulation;
 
 import com.google.common.collect.Lists;
 
@@ -96,6 +97,21 @@ public class MVColumnHLLUnionPatternTest {
         IntLiteral intLiteral = new IntLiteral(1);
         List<Expr> child0Params = Lists.newArrayList();
         child0Params.add(intLiteral);
+        FunctionCallExpr child0 = new FunctionCallExpr(FunctionSet.HLL_HASH, child0Params);
+        List<Expr> params = Lists.newArrayList();
+        params.add(child0);
+        FunctionCallExpr expr = new FunctionCallExpr(FunctionSet.HLL_UNION, params);
+        MVColumnHLLUnionPattern pattern = new MVColumnHLLUnionPattern();
+        Assert.assertFalse(pattern.match(expr));
+    }
+
+    @Test
+    public void testIncorrectDecimalSlotRef() {
+        TableName tableName = new TableName("db", "table");
+        SlotRef slotRef = new SlotRef(tableName, "c1");
+        Deencapsulation.setField(slotRef, "type", Type.DECIMALV2);
+        List<Expr> child0Params = Lists.newArrayList();
+        child0Params.add(slotRef);
         FunctionCallExpr child0 = new FunctionCallExpr(FunctionSet.HLL_HASH, child0Params);
         List<Expr> params = Lists.newArrayList();
         params.add(child0);


### PR DESCRIPTION
## Proposed changes
1. The base column of bitmap_union could must be integer. The largeint is not supported too.
2. The base column of hll_union could not be decimal.

Check error msg of const expr in Union Node

If user wants to insert a negative number into bitmap mv, Doris will thrown exception 'invalid input'.
The const value in Union Node is checked in this commit.

Change-Id: Ic6a5a059c68d73d83c72cb98c916bdaae1e45e45

Fixed #4431

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)
- [] Code refactor (Modify the code structure, format the code, etc...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have create an issue on (Fix #4431), and have described the bug/feature there in detail
- [x] Compiling and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] If this change need a document change, I have updated the document
- [x] Any dependent changes have been merged

