### PR TITLE
Show column display name on `Show Proc` stmt

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/proc/IndexSchemaProcNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/proc/IndexSchemaProcNode.java
@@ -67,7 +67,7 @@ public class IndexSchemaProcNode implements ProcNodeInterface {
             }
             String extraStr = StringUtils.join(extras, ",");
 
-            List<String> rowList = Arrays.asList(column.getName(),
+            List<String> rowList = Arrays.asList(column.getDisplayName(),
                                                  column.getOriginType().toString(),
                                                  column.isAllowNull() ? "Yes" : "No",
                                                  ((Boolean) column.isKey()).toString(),

--- a/fe/fe-core/src/main/java/org/apache/doris/http/rest/TableSchemaAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/http/rest/TableSchemaAction.java
@@ -107,7 +107,7 @@ public class TableSchemaAction extends RestBaseAction {
                         }
                         baseInfo.put("type", primitiveType.toString());
                         baseInfo.put("comment", column.getComment());
-                        baseInfo.put("name", column.getName());
+                        baseInfo.put("name", column.getDisplayName());
                         propList.add(baseInfo);
                     }
                     resultMap.put("status", 200);

--- a/fe/fe-core/src/test/java/org/apache/doris/common/proc/IndexSchemaProcNodeTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/common/proc/IndexSchemaProcNodeTest.java
@@ -1,0 +1,55 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.common.proc;
+
+import org.apache.doris.analysis.FunctionCallExpr;
+import org.apache.doris.analysis.SlotRef;
+import org.apache.doris.analysis.TableName;
+import org.apache.doris.catalog.AggregateType;
+import org.apache.doris.catalog.Column;
+import org.apache.doris.catalog.Type;
+import org.apache.doris.common.AnalysisException;
+
+import com.google.common.collect.Lists;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.List;
+
+public class IndexSchemaProcNodeTest {
+
+    @Test
+    public void testFetchResult() throws AnalysisException {
+        List<Column> columnList = Lists.newArrayList();
+        Column column1 = new Column("k1", Type.INT, true, null, true, "", "");
+        Column column2 = new Column("mv_bitmap_union_v1", Type.BITMAP, false, AggregateType.BITMAP_UNION, true, "", "");
+        TableName tableName = new TableName("db1", "t1");
+        SlotRef slotRef = new SlotRef(tableName, "v1");
+        FunctionCallExpr functionCallExpr = new FunctionCallExpr("to_bitmap", Lists.newArrayList(slotRef));
+        column2.setDefineExpr(functionCallExpr);
+        columnList.add(column1);
+        columnList.add(column2);
+        IndexSchemaProcNode indexSchemaProcNode = new IndexSchemaProcNode(columnList, null);
+        ProcResult procResult = indexSchemaProcNode.fetchResult();
+        Assert.assertEquals(2, procResult.getRows().size());
+        Assert.assertTrue(procResult.getRows().get(1).contains(column2.getDisplayName()));
+        Assert.assertFalse(procResult.getRows().get(1).contains(column2.getName()));
+
+    }
+}


### PR DESCRIPTION
## Proposed changes
The mv column with bitmap_union function is named `mv_bitmap_union_k1` inside of Doris.
But this column name should not be shown to user in `Show Proc` stmt.
Instead, using define expr is easier to understand.

Change-Id: Id07274fef9b3a97c97f1635dd3d6cf7b09561c1e

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [] Bugfix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] Documentation Update (if none of the other choices apply)
- [] Code refactor (Modify the code structure, format the code, etc...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [] I have create an issue on (Fix #ISSUE), and have described the bug/feature there in detail
- [x] Compiling and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [] If this change need a document change, I have updated the document
- [] Any dependent changes have been merged
