### PR TITLE
Fix mysql return bug

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -640,7 +640,7 @@ public class StmtExecutor {
                 break;
             }
         }
-        if (!isSendFields) {
+        if (!isSendFields && !isOutfileQuery) {
             sendFields(queryStmt.getColLabels(), queryStmt.getResultExprs());
         }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -608,9 +608,6 @@ public class StmtExecutor {
 
         coord.exec();
 
-        // if python's MysqlDb get error after sendfields, it can't catch the exception
-        // so We need to send fields after first batch arrived
-
         // send result
         // 1. If this is a query with OUTFILE clause, eg: select * from tbl1 into outfile xxx,
         //    We will not send real query result to client. Instead, we only send OK to client with
@@ -627,6 +624,8 @@ public class StmtExecutor {
             batch = coord.getNext();
             // for outfile query, there will be only one empty batch send back with eos flag
             if (batch.getBatch() != null && !isOutfileQuery) {
+                // For some language driver, getting error packet after fields packet will be recognized as a success result
+                // so We need to send fields after first batch arrived
                 if (!isSendFields) {
                     sendFields(queryStmt.getColLabels(), queryStmt.getResultExprs());
                     isSendFields = true;


### PR DESCRIPTION
Fix #4449 
Send fields after first row arrived so that error packet can be send to client when exception thrown from coord.getNext(). Golang and Python can not identify error if fields packet arrived before error packet.