### PR TITLE
Persistence stale rowsets meta

### DIFF
--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -919,6 +919,12 @@ bool Tablet::check_path(const std::string& path_to_check) const {
             return true;
         }
     }
+    for (auto& stale_version_rowset : _stale_rs_version_map) {
+        bool ret = stale_version_rowset.second->check_path(path_to_check);
+        if (ret) {
+            return true;
+        }
+    }
     return false;
 }
 
@@ -940,6 +946,11 @@ bool Tablet::check_rowset_id(const RowsetId& rowset_id) {
     }
     for (auto& inc_version_rowset : _inc_rs_version_map) {
         if (inc_version_rowset.second->rowset_id() == rowset_id) {
+            return true;
+        }
+    }
+    for (auto& stale_version_rowset : _stale_rs_version_map) {
+        if (stale_version_rowset.second->rowset_id() == rowset_id) {
             return true;
         }
     }
@@ -1141,6 +1152,14 @@ bool Tablet::rowset_meta_is_useful(RowsetMetaSharedPtr rowset_meta) {
             find_rowset_id = true;
         }
         if (inc_version_rowset.second->contains_version(rowset_meta->version())) {
+            find_version = true;
+        }
+    }
+    for (auto& stale_version_rowset : _stale_rs_version_map) {
+        if (stale_version_rowset.second->rowset_id() == rowset_meta->rowset_id()) {
+            find_rowset_id = true;
+        }
+        if (stale_version_rowset.second->contains_version(rowset_meta->version())) {
             find_version = true;
         }
     }

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -112,15 +112,13 @@ OLAPStatus Tablet::_init_once_action() {
     // init stale rowset
     for (auto& stale_rs_meta : _tablet_meta->all_stale_rs_metas()) {
         Version version = stale_rs_meta->version();
-        RowsetSharedPtr rowset = get_stale_rowset_by_version(version);
-        if (rowset == nullptr) {
-            res = RowsetFactory::create_rowset(&_schema, _tablet_path, stale_rs_meta, &rowset);
-            if (res != OLAP_SUCCESS) {
-                LOG(WARNING) << "fail to init stale rowset. tablet_id:" << tablet_id()
-                             << ", schema_hash:" << schema_hash() << ", version=" << version
-                             << ", res:" << res;
-                return res;
-            }
+        RowsetSharedPtr rowset;
+        res = RowsetFactory::create_rowset(&_schema, _tablet_path, stale_rs_meta, &rowset);
+        if (res != OLAP_SUCCESS) {
+            LOG(WARNING) << "fail to init stale rowset. tablet_id:" << tablet_id()
+                         << ", schema_hash:" << schema_hash() << ", version=" << version
+                         << ", res:" << res;
+            return res;
         }
         _stale_rs_version_map[version] = std::move(rowset);
     }

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -63,7 +63,7 @@ Tablet::Tablet(TabletMetaSharedPtr tablet_meta, DataDir* data_dir,
         _last_base_compaction_success_millis(0),
         _cumulative_point(K_INVALID_CUMULATIVE_POINT),
         _cumulative_compaction_type(cumulative_compaction_type) {
-    // construct _timestamped_versioned_tracker
+    // construct _timestamped_versioned_tracker from rs and stale rs meta
     _timestamped_version_tracker.construct_versioned_tracker(_tablet_meta->all_rs_metas(),
                                                              _tablet_meta->all_stale_rs_metas());
 }

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -279,14 +279,14 @@ const RowsetSharedPtr Tablet::get_rowset_by_version(const Version& version) cons
 // This function only be called by SnapshotManager to perform incremental clone.
 // It will be called under protected of _meta_lock(SnapshotManager will fetch it manually),
 // so it is no need to lock here.
-const RowsetSharedPtr Tablet::get_inc_rowset_by_version(const Version& version) const {
-    auto iter = _inc_rs_version_map.find(version);
-    if (iter == _inc_rs_version_map.end()) {
-        VLOG(3) << "no rowset for version:" << version << ", tablet: " << full_name();
-        return nullptr;
-    }
-    return iter->second;
-}
+// const RowsetSharedPtr Tablet::get_inc_rowset_by_version(const Version& version) const {
+//     auto iter = _inc_rs_version_map.find(version);
+//     if (iter == _inc_rs_version_map.end()) {
+//         VLOG(3) << "no rowset for version:" << version << ", tablet: " << full_name();
+//         return nullptr;
+//     }
+//     return iter->second;
+// }
 
 // Already under _meta_lock
 const RowsetSharedPtr Tablet::rowset_with_max_version() const {
@@ -336,18 +336,18 @@ OLAPStatus Tablet::add_inc_rowset(const RowsetSharedPtr& rowset) {
     return OLAP_SUCCESS;
 }
 
-void Tablet::_delete_inc_rowset_by_version(const Version& version,
-                                           const VersionHash& version_hash) {
-    // delete incremental rowset from map
-    _inc_rs_version_map.erase(version);
+// void Tablet::_delete_inc_rowset_by_version(const Version& version,
+//                                            const VersionHash& version_hash) {
+//     // delete incremental rowset from map
+//     _inc_rs_version_map.erase(version);
 
-    RowsetMetaSharedPtr rowset_meta = _tablet_meta->acquire_inc_rs_meta_by_version(version);
-    if (rowset_meta == nullptr) {
-        return;
-    }
-    _tablet_meta->delete_inc_rs_meta_by_version(version);
-    VLOG(3) << "delete incremental rowset. tablet=" << full_name() << ", version=" << version;
-}
+//     RowsetMetaSharedPtr rowset_meta = _tablet_meta->acquire_inc_rs_meta_by_version(version);
+//     if (rowset_meta == nullptr) {
+//         return;
+//     }
+//     _tablet_meta->delete_inc_rs_meta_by_version(version);
+//     VLOG(3) << "delete incremental rowset. tablet=" << full_name() << ", version=" << version;
+// }
 
 void Tablet::_delete_stale_rowset_by_version(const Version& version) {
 
@@ -359,34 +359,34 @@ void Tablet::_delete_stale_rowset_by_version(const Version& version) {
     VLOG(3) << "delete stale rowset. tablet=" << full_name() << ", version=" << version;
 }
 
-void Tablet::delete_expired_inc_rowsets() {
-    int64_t now = UnixSeconds();
-    vector<pair<Version, VersionHash>> expired_versions;
-    WriteLock wrlock(&_meta_lock);
-    for (auto& rs_meta : _tablet_meta->all_inc_rs_metas()) {
-        double diff = ::difftime(now, rs_meta->creation_time());
-        if (diff >= config::inc_rowset_expired_sec) {
-            Version version(rs_meta->version());
-            expired_versions.push_back(std::make_pair(version, rs_meta->version_hash()));
-            VLOG(3) << "find expire incremental rowset. tablet=" << full_name()
-                    << ", version=" << version
-                    << ", version_hash=" << rs_meta->version_hash()
-                    << ", exist_sec=" << diff;
-        }
-    }
+// void Tablet::delete_expired_inc_rowsets() {
+//     int64_t now = UnixSeconds();
+//     vector<pair<Version, VersionHash>> expired_versions;
+//     WriteLock wrlock(&_meta_lock);
+//     for (auto& rs_meta : _tablet_meta->all_inc_rs_metas()) {
+//         double diff = ::difftime(now, rs_meta->creation_time());
+//         if (diff >= config::inc_rowset_expired_sec) {
+//             Version version(rs_meta->version());
+//             expired_versions.push_back(std::make_pair(version, rs_meta->version_hash()));
+//             VLOG(3) << "find expire incremental rowset. tablet=" << full_name()
+//                     << ", version=" << version
+//                     << ", version_hash=" << rs_meta->version_hash()
+//                     << ", exist_sec=" << diff;
+//         }
+//     }
 
-    if (expired_versions.empty()) {
-        return;
-    }
+//     if (expired_versions.empty()) {
+//         return;
+//     }
 
-    for (auto& pair: expired_versions) {
-        _delete_inc_rowset_by_version(pair.first, pair.second);
-        VLOG(3) << "delete expire incremental data. tablet=" << full_name()
-                << ", version=" << pair.first;
-    }
+//     for (auto& pair: expired_versions) {
+//         _delete_inc_rowset_by_version(pair.first, pair.second);
+//         VLOG(3) << "delete expire incremental data. tablet=" << full_name()
+//                 << ", version=" << pair.first;
+//     }
 
-    save_meta();
-}
+//     save_meta();
+// }
 
 void Tablet::delete_expired_stale_rowset() {
 

--- a/be/src/olap/tablet.h
+++ b/be/src/olap/tablet.h
@@ -100,6 +100,7 @@ public:
     // The caller must call hold _meta_lock when call this two function.
     const RowsetSharedPtr get_rowset_by_version(const Version& version) const;
     const RowsetSharedPtr get_inc_rowset_by_version(const Version& version) const;
+    const RowsetSharedPtr get_stale_rowset_by_version(const Version& version) const;
 
     const RowsetSharedPtr rowset_with_max_version() const;
 
@@ -240,7 +241,7 @@ private:
     void _max_continuous_version_from_begining_unlocked(Version* version,
                                                         VersionHash* v_hash) const ;
     RowsetSharedPtr _rowset_with_largest_size();
-    // void _delete_inc_rowset_by_version(const Version& version, const VersionHash& version_hash);
+    void _delete_inc_rowset_by_version(const Version& version, const VersionHash& version_hash);
     /// Delete stale rowset by version. This method not only delete the version in expired rowset map,
     /// but also delete the version in rowset meta vector.
     void _delete_stale_rowset_by_version(const Version& version);

--- a/be/src/olap/tablet.h
+++ b/be/src/olap/tablet.h
@@ -240,7 +240,7 @@ private:
     void _max_continuous_version_from_begining_unlocked(Version* version,
                                                         VersionHash* v_hash) const ;
     RowsetSharedPtr _rowset_with_largest_size();
-    void _delete_inc_rowset_by_version(const Version& version, const VersionHash& version_hash);
+    // void _delete_inc_rowset_by_version(const Version& version, const VersionHash& version_hash);
     /// Delete stale rowset by version. This method not only delete the version in expired rowset map,
     /// but also delete the version in rowset meta vector.
     void _delete_stale_rowset_by_version(const Version& version);

--- a/be/src/olap/tablet_meta.cpp
+++ b/be/src/olap/tablet_meta.cpp
@@ -549,14 +549,6 @@ void TabletMeta::revise_inc_rs_metas(std::vector<RowsetMetaSharedPtr>&& rs_metas
     _inc_rs_metas = std::move(rs_metas);
 }
 
-void TabletMeta::revise_stale_rs_metas(std::vector<RowsetMetaSharedPtr>&& rs_metas) {
-    WriteLock wrlock(&_meta_lock);
-    // delete alter task
-    _alter_task.reset();
-
-    _stale_rs_metas = std::move(rs_metas);
-}
-
 OLAPStatus TabletMeta::add_inc_rs_meta(const RowsetMetaSharedPtr& rs_meta) {
     // check RowsetMeta is valid
     for (auto rs : _inc_rs_metas) {

--- a/be/src/olap/tablet_meta.cpp
+++ b/be/src/olap/tablet_meta.cpp
@@ -532,26 +532,34 @@ void TabletMeta::revise_rs_metas(std::vector<RowsetMetaSharedPtr>&& rs_metas) {
     _rs_metas = std::move(rs_metas);
 }
 
-void TabletMeta::revise_inc_rs_metas(std::vector<RowsetMetaSharedPtr>&& rs_metas) {
+void TabletMeta::revise_stale_rs_metas(std::vector<RowsetMetaSharedPtr>&& stale_rs_metas) {
     WriteLock wrlock(&_meta_lock);
     // delete alter task
     _alter_task.reset();
 
-    _inc_rs_metas = std::move(rs_metas);
+    _stale_rs_metas = std::move(stale_rs_metas);
 }
 
-OLAPStatus TabletMeta::add_inc_rs_meta(const RowsetMetaSharedPtr& rs_meta) {
-    // check RowsetMeta is valid
-    for (auto rs : _inc_rs_metas) {
-        if (rs->version() == rs_meta->version()) {
-            LOG(WARNING) << "rowset already exist. rowset_id=" << rs->rowset_id();
-            return OLAP_ERR_ROWSET_ALREADY_EXIST;
-        }
-    }
+// void TabletMeta::revise_inc_rs_metas(std::vector<RowsetMetaSharedPtr>&& rs_metas) {
+//     WriteLock wrlock(&_meta_lock);
+//     // delete alter task
+//     _alter_task.reset();
 
-    _inc_rs_metas.push_back(rs_meta);
-    return OLAP_SUCCESS;
-}
+//     _inc_rs_metas = std::move(rs_metas);
+// }
+
+// OLAPStatus TabletMeta::add_inc_rs_meta(const RowsetMetaSharedPtr& rs_meta) {
+//     // check RowsetMeta is valid
+//     for (auto rs : _inc_rs_metas) {
+//         if (rs->version() == rs_meta->version()) {
+//             LOG(WARNING) << "rowset already exist. rowset_id=" << rs->rowset_id();
+//             return OLAP_ERR_ROWSET_ALREADY_EXIST;
+//         }
+//     }
+
+//     _inc_rs_metas.push_back(rs_meta);
+//     return OLAP_SUCCESS;
+// }
 
 void TabletMeta::delete_stale_rs_meta_by_version(const Version& version) {
     auto it = _stale_rs_metas.begin();

--- a/be/src/olap/tablet_meta.h
+++ b/be/src/olap/tablet_meta.h
@@ -172,7 +172,6 @@ public:
     void revise_rs_metas(std::vector<RowsetMetaSharedPtr>&& rs_metas);
 
     void revise_inc_rs_metas(std::vector<RowsetMetaSharedPtr>&& rs_metas);
-    void revise_stale_rs_metas(std::vector<RowsetMetaSharedPtr>&& rs_metas);
 
     inline const std::vector<RowsetMetaSharedPtr>& all_inc_rs_metas() const;
     inline const std::vector<RowsetMetaSharedPtr>& all_stale_rs_metas() const;

--- a/be/src/olap/tablet_meta.h
+++ b/be/src/olap/tablet_meta.h
@@ -172,8 +172,8 @@ public:
     void revise_rs_metas(std::vector<RowsetMetaSharedPtr>&& rs_metas);
 
 
-    void revise_inc_rs_metas(std::vector<RowsetMetaSharedPtr>&& rs_metas);
-    inline const std::vector<RowsetMetaSharedPtr>& all_inc_rs_metas() const;
+    void revise_stale_rs_metas(std::vector<RowsetMetaSharedPtr>&& rs_metas);
+    // inline const std::vector<RowsetMetaSharedPtr>& all_inc_rs_metas() const;
     inline const std::vector<RowsetMetaSharedPtr>& all_stale_rs_metas() const;
     OLAPStatus add_inc_rs_meta(const RowsetMetaSharedPtr& rs_meta);
     void delete_inc_rs_meta_by_version(const Version& version);
@@ -224,7 +224,7 @@ private:
     TabletSchema _schema;
 
     std::vector<RowsetMetaSharedPtr> _rs_metas;
-    std::vector<RowsetMetaSharedPtr> _inc_rs_metas;
+    // std::vector<RowsetMetaSharedPtr> _inc_rs_metas;
     // This variable _stale_rs_metas is used to record these rowsets‘ meta which are be compacted.
     // These stale rowsets meta are been removed when rowsets' pathVersion is expired, 
     // this policy is judged and computed by TimestampedVersionTracker.

--- a/be/src/olap/tablet_meta.h
+++ b/be/src/olap/tablet_meta.h
@@ -171,9 +171,10 @@ public:
                          const std::vector<RowsetMetaSharedPtr>& to_delete);
     void revise_rs_metas(std::vector<RowsetMetaSharedPtr>&& rs_metas);
 
-
+    void revise_inc_rs_metas(std::vector<RowsetMetaSharedPtr>&& rs_metas);
     void revise_stale_rs_metas(std::vector<RowsetMetaSharedPtr>&& rs_metas);
-    // inline const std::vector<RowsetMetaSharedPtr>& all_inc_rs_metas() const;
+
+    inline const std::vector<RowsetMetaSharedPtr>& all_inc_rs_metas() const;
     inline const std::vector<RowsetMetaSharedPtr>& all_stale_rs_metas() const;
     OLAPStatus add_inc_rs_meta(const RowsetMetaSharedPtr& rs_meta);
     void delete_inc_rs_meta_by_version(const Version& version);
@@ -224,7 +225,7 @@ private:
     TabletSchema _schema;
 
     std::vector<RowsetMetaSharedPtr> _rs_metas;
-    // std::vector<RowsetMetaSharedPtr> _inc_rs_metas;
+    std::vector<RowsetMetaSharedPtr> _inc_rs_metas;
     // This variable _stale_rs_metas is used to record these rowsets‘ meta which are be compacted.
     // These stale rowsets meta are been removed when rowsets' pathVersion is expired, 
     // this policy is judged and computed by TimestampedVersionTracker.

--- a/be/src/olap/version_graph.cpp
+++ b/be/src/olap/version_graph.cpp
@@ -45,17 +45,164 @@ void TimestampedVersionTracker::construct_versioned_tracker(const std::vector<Ro
 
 void TimestampedVersionTracker::construct_versioned_tracker(
         const std::vector<RowsetMetaSharedPtr>& rs_metas,
-        std::vector<const std::vector<RowsetMetaSharedPtr>>& stale_rs_metas) {
+        const std::vector<RowsetMetaSharedPtr>& stale_metas) {
 
     if (rs_metas.empty()) {
         VLOG(3) << "there is no version in the header.";
         return;
     }
-    construct_versioned_tracker(rs_metas);
+    _stale_version_path_map.clear();
+    _next_path_id = 1;
+    _construct_versioned_tracker(rs_metas);
 
-    for (auto& path: stale_rs_metas) {
-        add_stale_path_version(path);
+    // init _stale_version_path_map
+    _init_stale_version_path_map(rs_metas, stale_metas);
+}
+
+void TimestampedVersionTracker::_init_stale_version_path_map(
+        const std::vector<RowsetMetaSharedPtr>& rs_metas,
+        const std::vector<RowsetMetaSharedPtr>& stale_metas) {
+
+    if (stale_metas.empty()) {
+        return;
     }
+
+    // sort stale meta by version diff (second version - first version)
+    std::list<RowsetMetaSharedPtr> sorted_stale_metas;
+    for (auto& rs : stale_metas) {
+        sorted_stale_metas.emplace_back(rs);
+    }
+
+    // 1. Sort the existing rowsets by version in ascending order
+    sorted_stale_metas.sort([](const RowsetMetaSharedPtr& a, const RowsetMetaSharedPtr& b) {
+        // compare by version diff between version.first and version.second
+        int64_t a_diff = a->version().second - a->version().first;
+        int64_t b_diff = b->version().second - b->version().first;
+
+        int diff = a_diff - b_diff;
+        if (diff < 0) {
+            return true;
+        }
+        else if (diff > 0) {
+            return false;
+        }
+        // when the version diff is equal, compare rowset createtime
+        return a->creation_time() < b->creation_time();
+    });
+
+    // first_version -> (second_version -> rowset_meta)
+    std::unordered_map<int64_t, std::unordered_map<int64_t, RowsetMetaSharedPtr>> stale_map;
+
+    // 2. generate stale path from stale_metas. traverse sorted_stale_metas and each time add stale_meta to stale_map.
+    // when a stale path in stale_map can replace stale_meta in sorted_stale_metas, stale_map remove rowset_metas of a stale path
+    // and add the path to _stale_version_path_map.
+    for(auto& stale_meta:sorted_stale_metas) {
+        std::vector<RowsetMetaSharedPtr> stale_path;
+        // 2.1 find a path in stale_map can replace current stale_meta version
+        bool r = _find_path_from_stale_map(stale_map, stale_meta->start_version(), stale_meta->end_version(), &stale_path);
+
+        // 2.2 add stale_meta to stale_map
+        auto start_iter = stale_map.find(stale_meta->start_version());
+        if (start_iter != stale_map.end()) {
+            start_iter->second[stale_meta->end_version()] = stale_meta;
+        } else {
+            std::unordered_map<int64_t, RowsetMetaSharedPtr> item;
+            item[stale_meta->end_version()] = stale_meta;
+            stale_map[stale_meta->start_version()] = std::move(item);
+        }
+        // 2.3 add version to version_graph
+        Version stale_meta_version = stale_meta->version();
+        add_version(stale_meta_version);
+        // 2.4 find the path
+        if (r) {
+            // add the path to _stale_version_path_map
+            add_stale_path_version(stale_path);
+            // remove stale_path from stale_map
+            for (auto stale_item:stale_path) {
+                stale_map[stale_item->start_version()].erase(stale_item->end_version());
+            
+                if (stale_map[stale_item->start_version()].empty()) {
+                    stale_map.erase(stale_item->start_version());
+                }
+            }
+        }
+    }
+
+    // 3. generate stale path from rs_metas
+    for(auto& stale_meta:rs_metas) {
+        std::vector<RowsetMetaSharedPtr> stale_path;
+        // 3.1 find a path in stale_map can replace current stale_meta version
+        bool r = _find_path_from_stale_map(stale_map, stale_meta->start_version(), stale_meta->end_version(), &stale_path);
+        
+        // 3.2 find the path 
+        if (r) {
+            // add the path to _stale_version_path_map
+            add_stale_path_version(stale_path);
+            // remove stale_path from stale_map
+            for (auto stale_item:stale_path) {
+                stale_map[stale_item->start_version()].erase(stale_item->end_version());
+            
+                if (stale_map[stale_item->start_version()].empty()) {
+                    stale_map.erase(stale_item->start_version());
+                }
+            }
+        }
+    }
+
+    // 4. process remain stale rowset_meta in stale_map
+    auto map_iter = stale_map.begin();
+    while (map_iter != stale_map.end()) {
+        auto second_iter = map_iter->second.begin();
+        while(second_iter != map_iter->second.end()) {
+            // each remain stale rowset_meta generate a stale path
+            std::vector<RowsetMetaSharedPtr> stale_path;
+            stale_path.push_back(second_iter->second);
+            add_stale_path_version(stale_path);
+
+            second_iter++;
+        }
+        map_iter++;
+    }
+}
+
+bool TimestampedVersionTracker::_find_path_from_stale_map(
+        const std::unordered_map<int64_t, std::unordered_map<int64_t, RowsetMetaSharedPtr>>& stale_map,
+        int64_t first_version, int64_t second_version, std::vector<RowsetMetaSharedPtr>* stale_path) {
+
+    auto first_iter = stale_map.find(first_version);
+    // if first_version not in stale_map, there is no path.
+    if (first_iter == stale_map.end()) {
+        return false;
+    }
+    auto& second_version_map = first_iter->second;
+    auto second_iter = second_version_map.find(second_version);
+    // if second_version in stale_map, find a path.
+    if (second_iter != second_version_map.end()) {
+        auto row_meta = second_iter->second;
+        // add rowset to path
+        stale_path->push_back(row_meta);
+        return true;
+    }
+
+    // traverse the first version map to backtracking _find_path_from_stale_map
+    auto map_iter = second_version_map.begin();
+    while (map_iter != second_version_map.end()) {
+        // the version greater than second_version, we can't find path in stale_map
+        if (map_iter->first > second_version) {
+            continue;
+        }
+        // backtracking _find_path_from_stale_map find from map_iter->first + 1 to second_version
+        stale_path->push_back(map_iter->second);
+        bool r = _find_path_from_stale_map(stale_map, map_iter->first + 1, second_version, stale_path);
+        if (r) {
+            return true;
+        }
+        // there is no path in current version, pop and continue
+        stale_path->pop_back();
+        map_iter++;
+    }
+
+    return false;
 }
 
 void TimestampedVersionTracker::get_stale_version_path_json_doc(rapidjson::Document& path_arr) {

--- a/be/src/olap/version_graph.cpp
+++ b/be/src/olap/version_graph.cpp
@@ -29,7 +29,7 @@ namespace doris {
 void TimestampedVersionTracker::_construct_versioned_tracker(const std::vector<RowsetMetaSharedPtr>& rs_metas) {
     int64_t max_version = 0;
 
-    // construct the roset graph
+    // construct the rowset graph
     _version_graph.reconstruct_version_graph(rs_metas, &max_version);
 }
 
@@ -43,6 +43,20 @@ void TimestampedVersionTracker::construct_versioned_tracker(const std::vector<Ro
     _construct_versioned_tracker(rs_metas);
 }
 
+void TimestampedVersionTracker::construct_versioned_tracker(
+        const std::vector<RowsetMetaSharedPtr>& rs_metas,
+        std::vector<const std::vector<RowsetMetaSharedPtr>>& stale_rs_metas) {
+
+    if (rs_metas.empty()) {
+        VLOG(3) << "there is no version in the header.";
+        return;
+    }
+    construct_versioned_tracker(rs_metas);
+
+    for (auto& path: stale_rs_metas) {
+        add_stale_path_version(path);
+    }
+}
 
 void TimestampedVersionTracker::get_stale_version_path_json_doc(rapidjson::Document& path_arr) {
 

--- a/be/src/olap/version_graph.h
+++ b/be/src/olap/version_graph.h
@@ -139,6 +139,11 @@ public:
     /// Construct rowsets version tracker by rs_metas and stale version path map.
     void construct_versioned_tracker(const std::vector<RowsetMetaSharedPtr>& rs_metas);
 
+    /// Construct rowsets version tracker by rs_metas and stale version path map and stale rs meta
+    void construct_versioned_tracker(
+            const std::vector<RowsetMetaSharedPtr>& rs_metas,
+            const std::vector<RowsetMetaSharedPtr>& stale_metas));
+
     /// Recover rowsets version tracker from stale version path map. When delete operation fails, the 
     /// tracker can be recovered from deleted stale_version_path_map.
     void recover_versioned_tracker(const std::map<int64_t, PathVersionListSharedPtr>& stale_version_path_map);

--- a/be/src/olap/version_graph.h
+++ b/be/src/olap/version_graph.h
@@ -136,13 +136,12 @@ using PathVersionListSharedPtr = std::shared_ptr<TimestampedVersionPathContainer
 /// after the path is expired.
 class TimestampedVersionTracker {
 public:
-    /// Construct rowsets version tracker by rs_metas and stale version path map.
+    /// Construct rowsets version tracker by main path rowset meta.
     void construct_versioned_tracker(const std::vector<RowsetMetaSharedPtr>& rs_metas);
 
-    /// Construct rowsets version tracker by rs_metas and stale version path map and stale rs meta
-    void construct_versioned_tracker(
-            const std::vector<RowsetMetaSharedPtr>& rs_metas,
-            const std::vector<RowsetMetaSharedPtr>& stale_metas));
+    /// Construct rowsets version tracker by main path rowset meta and stale rowset meta.
+    void construct_versioned_tracker(const std::vector<RowsetMetaSharedPtr>& rs_metas,
+                                     const std::vector<RowsetMetaSharedPtr>& stale_metas);
 
     /// Recover rowsets version tracker from stale version path map. When delete operation fails, the 
     /// tracker can be recovered from deleted stale_version_path_map.
@@ -185,8 +184,18 @@ public:
     void get_stale_version_path_json_doc(rapidjson::Document& path_arr);
 
 private:
-    /// Construct rowsets version tracker with stale rowsets.
+    /// Construct rowsets version tracker with main path rowset meta.
     void _construct_versioned_tracker(const std::vector<RowsetMetaSharedPtr>& rs_metas);
+
+    /// init stale_version_path_map by main path rowset meta and stale rowset meta.
+    void _init_stale_version_path_map(const std::vector<RowsetMetaSharedPtr>& rs_metas,
+                                      const std::vector<RowsetMetaSharedPtr>& stale_metas);
+
+    /// find a path in stale_map from first_version to second_version, stale_path is used as result.
+    bool _find_path_from_stale_map(
+            const std::unordered_map<int64_t, std::unordered_map<int64_t, RowsetMetaSharedPtr>>& stale_map,
+            int64_t first_version, int64_t second_version,
+            std::vector<RowsetMetaSharedPtr>* stale_path);
 
 private:
     // This variable records the id of path version which will be dispatched to next path version, 

--- a/be/test/olap/timestamped_version_tracker_test.cpp
+++ b/be/test/olap/timestamped_version_tracker_test.cpp
@@ -480,6 +480,23 @@ TEST_F(TestTimestampedVersionTracker, construct_versioned_tracker) {
     ASSERT_EQ(1, tracker._next_path_id);
 }
 
+TEST_F(TestTimestampedVersionTracker, construct_version_tracker_by_stale_meta) {
+
+    std::vector<RowsetMetaSharedPtr> rs_metas;
+    std::vector<RowsetMetaSharedPtr> expried_rs_metas;
+    std::vector<Version> version_path;
+
+    init_all_rs_meta(&rs_metas);
+    init_expried_row_rs_meta(&expried_rs_metas);
+
+    TimestampedVersionTracker tracker;
+    tracker.construct_versioned_tracker(rs_metas, expried_rs_metas);
+
+    ASSERT_EQ(10, tracker._version_graph._version_graph.size());
+    ASSERT_EQ(4, tracker._stale_version_path_map.size());
+    ASSERT_EQ(5, tracker._next_path_id);
+}
+
 TEST_F(TestTimestampedVersionTracker, construct_versioned_tracker_with_same_rowset) {
 
     std::vector<RowsetMetaSharedPtr> rs_metas;

--- a/gensrc/proto/olap_file.proto
+++ b/gensrc/proto/olap_file.proto
@@ -308,6 +308,7 @@ message TabletMetaPB {
     optional int64 end_rowset_id = 15;
     optional RowsetTypePB preferred_rowset_type = 16;
     optional TabletTypePB tablet_type = 17;
+    repeated RowsetMetaPB stale_rs_metas = 18;
 }
 
 message OLAPIndexHeaderMessage {


### PR DESCRIPTION
## Proposed changes

Persistence stale rowsets meta. When be reboots, stale rowsets meta can resume and the stale version can also be readable before stale gc time.  

ISSUE: #4453

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] Documentation Update (if none of the other choices apply)
- [] Code refactor (Modify the code structure, format the code, etc...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have create an issue on (Fix #4453), and have described the bug/feature there in detail
- [x] Compiling and unit tests pass locally with my changes
- [] I have added tests that prove my fix is effective or that my feature works
- [] If this change need a document change, I have updated the document
- [] Any dependent changes have been merged
