### PR TITLE
[Bug] Fix bug that memory copy may overflow in MemIndex::load_segment

### DIFF
--- a/be/src/olap/olap_index.cpp
+++ b/be/src/olap/olap_index.cpp
@@ -209,17 +209,15 @@ OLAPStatus MemIndex::load_segment(const char* file, size_t *current_num_rows_per
 
                 // 2. copy length and content
                 bool is_null = *reinterpret_cast<bool*>(mem_ptr);
-                if (is_null) {
-                    continue;
+                if (!is_null) {
+                    size_t storage_field_bytes =
+                        *reinterpret_cast<StringLengthType*>(storage_ptr + null_byte);
+                    Slice* slice = reinterpret_cast<Slice*>(mem_ptr + 1);
+                    char* data = reinterpret_cast<char*>(_mem_pool->allocate(storage_field_bytes));
+                    memory_copy(data, storage_ptr + sizeof(StringLengthType) + null_byte, storage_field_bytes);
+                    slice->data = data;
+                    slice->size = storage_field_bytes;
                 }
-
-                size_t storage_field_bytes =
-                    *reinterpret_cast<StringLengthType*>(storage_ptr + null_byte);
-                Slice* slice = reinterpret_cast<Slice*>(mem_ptr + 1);
-                char* data = reinterpret_cast<char*>(_mem_pool->allocate(storage_field_bytes));
-                memory_copy(data, storage_ptr + sizeof(StringLengthType) + null_byte, storage_field_bytes);
-                slice->data = data;
-                slice->size = storage_field_bytes;
 
                 mem_ptr += mem_row_bytes;
                 storage_ptr += storage_row_bytes;
@@ -241,15 +239,13 @@ OLAPStatus MemIndex::load_segment(const char* file, size_t *current_num_rows_per
 
                 // 2. copy length and content
                 bool is_null = *reinterpret_cast<bool*>(mem_ptr);
-                if (is_null) {
-                    continue;
+                if (!is_null) {
+                    Slice* slice = reinterpret_cast<Slice*>(mem_ptr + 1);
+                    char* data = reinterpret_cast<char*>(_mem_pool->allocate(storage_field_bytes));
+                    memory_copy(data, storage_ptr + null_byte, storage_field_bytes);
+                    slice->data = data;
+                    slice->size = storage_field_bytes;
                 }
-
-                Slice* slice = reinterpret_cast<Slice*>(mem_ptr + 1);
-                char* data = reinterpret_cast<char*>(_mem_pool->allocate(storage_field_bytes));
-                memory_copy(data, storage_ptr + null_byte, storage_field_bytes);
-                slice->data = data;
-                slice->size = storage_field_bytes;
 
                 mem_ptr += mem_row_bytes;
                 storage_ptr += storage_row_bytes;
@@ -263,11 +259,9 @@ OLAPStatus MemIndex::load_segment(const char* file, size_t *current_num_rows_per
 
                 // 2. copy content
                 bool is_null = *reinterpret_cast<bool*>(mem_ptr);
-                if (is_null) {
-                    continue;
+                if (!is_null) {
+                    memory_copy(mem_ptr + 1, storage_ptr + null_byte, storage_field_bytes);
                 }
-
-                memory_copy(mem_ptr + 1, storage_ptr + null_byte, storage_field_bytes);
 
                 mem_ptr += mem_row_bytes;
                 storage_ptr += storage_row_bytes;

--- a/be/src/olap/rowset/segment_group.cpp
+++ b/be/src/olap/rowset/segment_group.cpp
@@ -577,6 +577,7 @@ OLAPStatus SegmentGroup::add_segment() {
             return OLAP_ERR_MALLOC_ERROR;
         }
 
+        memset(_short_key_buf, 0, _short_key_length);
         if (_current_index_row.init(*_schema) != OLAP_SUCCESS) {
             OLAP_LOG_WARNING("init _current_index_row fail.");
             return OLAP_ERR_INIT_FAILED;


### PR DESCRIPTION
## Proposed changes

Segment index file content is not set as 0 when it is constructed in write procedure, so when load index from this file, and meet a null VARCHAR cell, the null field of this cell is 0, but the length field which is not initialized maybe a large random number, then memory copy may cause overflow.
This patch fix this bug, and also skip useless memory copy to improve a bit of performance.

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] Documentation Update (if none of the other choices apply)
- [] Code refactor (Modify the code structure, format the code, etc...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have create an issue on (Fix https://github.com/apache/incubator-doris/issues/4459), and have described the bug/feature there in detail
- [x] Compiling and unit tests pass locally with my changes
- [] I have added tests that prove my fix is effective or that my feature works
- [] If this change need a document change, I have updated the document
- [] Any dependent changes have been merged

## Further comments

none
