### PR TITLE
[Spark load] Fix dpp and submit push task bugs

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/SparkEtlJobHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/SparkEtlJobHandler.java
@@ -250,9 +250,11 @@ public class SparkEtlJobHandler {
                 byte[] data = BrokerUtil.readFile(dppResultFilePath, brokerDesc);
                 String dppResultStr = new String(data, "UTF-8");
                 DppResult dppResult = new Gson().fromJson(dppResultStr, DppResult.class);
-                status.setDppResult(dppResult);
-                if (status.getState() == TEtlState.CANCELLED && !Strings.isNullOrEmpty(dppResult.failedReason)) {
-                    status.setFailMsg(dppResult.failedReason);
+                if (dppResult != null) {
+                    status.setDppResult(dppResult);
+                    if (status.getState() == TEtlState.CANCELLED && !Strings.isNullOrEmpty(dppResult.failedReason)) {
+                        status.setFailMsg(dppResult.failedReason);
+                    }
                 }
             } catch (UserException | JsonSyntaxException | UnsupportedEncodingException e) {
                 LOG.warn("read broker file failed. path: {}", dppResultFilePath, e);

--- a/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/SparkLoadJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/SparkLoadJob.java
@@ -414,6 +414,14 @@ public class SparkLoadJob extends BulkLoadJob {
         try {
             writeLock();
             try {
+                // check state is still loading. If state is cancelled or finished, return.
+                // if state is cancelled or finished and not return, this would throw all partitions have no load data exception,
+                // because tableToLoadPartitions was already cleaned up,
+                if (state != JobState.LOADING) {
+                    LOG.warn("job state is not loading. job id: {}, state: {}", id, state);
+                    return totalTablets;
+                }
+
                 for (Map.Entry<Long, Set<Long>> entry : tableToLoadPartitions.entrySet()) {
                     long tableId = entry.getKey();
                     OlapTable table = (OlapTable) db.getTable(tableId);
@@ -567,6 +575,10 @@ public class SparkLoadJob extends BulkLoadJob {
 
         // submit push tasks
         Set<Long> totalTablets = submitPushTasks();
+        if (totalTablets.isEmpty()) {
+            LOG.warn("total tablets set is empty. job id: {}, state: {}", id, state);
+            return;
+        }
 
         // update status
         boolean canCommitJob = false;

--- a/fe/fe-core/src/test/java/org/apache/doris/load/loadv2/SparkLoadJobTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/load/loadv2/SparkLoadJobTest.java
@@ -415,6 +415,22 @@ public class SparkLoadJobTest {
     }
 
     @Test
+    public void testSubmitTasksWhenStateFinished(@Mocked Catalog catalog, @Injectable String originStmt,
+                                                 @Injectable Database db) throws Exception {
+        new Expectations() {
+            {
+                catalog.getDb(dbId);
+                result = db;
+            }
+        };
+
+        SparkLoadJob job = getEtlStateJob(originStmt);
+        job.state = JobState.FINISHED;
+        Set<Long> totalTablets = Deencapsulation.invoke(job, "submitPushTasks");
+        Assert.assertTrue(totalTablets.isEmpty());
+    }
+
+    @Test
     public void testStateUpdateInfoPersist() throws IOException {
         String fileName = "./testStateUpdateInfoPersistFile";
         File file = new File(fileName);

--- a/fe/spark-dpp/src/main/java/org/apache/doris/load/loadv2/dpp/ColumnParser.java
+++ b/fe/spark-dpp/src/main/java/org/apache/doris/load/loadv2/dpp/ColumnParser.java
@@ -138,7 +138,8 @@ class BooleanParser extends ColumnParser {
     @Override
     public boolean parse(String value) {
         if (value.equalsIgnoreCase("true")
-                || value.equalsIgnoreCase("false")) {
+                || value.equalsIgnoreCase("false")
+                || value.equals("0") || value.equals("1")) {
             return true;
         }
         return false;

--- a/fe/spark-dpp/src/main/java/org/apache/doris/load/loadv2/etl/EtlJobConfig.java
+++ b/fe/spark-dpp/src/main/java/org/apache/doris/load/loadv2/etl/EtlJobConfig.java
@@ -111,7 +111,10 @@ import java.util.Map;
                 },
                 "where": "k2 > 10",
                 "isNegative": false,
-                "hiveTableName": "hive_db.table"
+                "hiveDbTableName": "hive_db.table",
+                "hiveTableProperties": {
+                    "hive.metastore.uris": "thrift://host:port"
+                }
             }]
         }
     },


### PR DESCRIPTION
1. fix write dpp result when dpp throw exception
2. boolean value：true, false(IgnoreCase), 0, 1
3. wrong dest column for source data check
4. support * in source file path 
5. if job state is cancelled or finished, submitPushTasks would throw all partitions have no load data exception, because tableToLoadPartitions was already cleaned up

#3433 