### PR TITLE
Do not add exchange when table's distributioin satisfy the distribution requirements

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/planner/DistributedPlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/DistributedPlanner.java
@@ -863,6 +863,14 @@ public class DistributedPlanner {
             //     childFragment.addPlanRoot(node);
             //     return childFragment;
             // }
+
+            PlanNode childPlan = childFragment.getPlanRoot();
+            if (childPlan instanceof OlapScanNode &&
+                    ((OlapScanNode)childPlan).getOlapTable().satisfyHashDistribution(partitionExprs)) {
+                childFragment.addPlanRoot(node);
+                return childFragment;
+            }
+
             // the parent fragment is partitioned on the grouping exprs;
             // substitute grouping exprs to reference the *output* of the agg, not the input
             partitionExprs = Expr.substituteList(partitionExprs,


### PR DESCRIPTION
For #4481.

## Proposed changes

In DistributedPlanner, do not add the unnecessary Exchanges.
For case 1, we only need to judge that the table's distribute hash keys is a subset of the aggregate keys.
For case 2, we should jude two conditions:
 - partition keys are also hash keys.
 - the table's distribute hash keys is a subset of the aggregate keys.
