### PR TITLE
[Bug] Fix bug of load error hub and schema change

### DIFF
--- a/be/src/olap/schema_change.cpp
+++ b/be/src/olap/schema_change.cpp
@@ -1197,10 +1197,9 @@ OLAPStatus SchemaChangeWithSorting::process(RowsetReaderSharedPtr rowset_reader,
         }
 
         uint64_t filtered_rows = 0;
-        if (!_row_block_changer.change_row_block(ref_row_block, rowset_reader->version().second,
-                                                 new_row_block, &filtered_rows)) {
+        if ((res = _row_block_changer.change_row_block(ref_row_block, rowset_reader->version().second,
+                                                 new_row_block, &filtered_rows)) != OLAP_SUCCESS) {
             LOG(WARNING) << "failed to change data in row block.";
-            res = OLAP_ERR_ALTER_STATUS_ERR;
             goto SORTING_PROCESS_ERR;
         }
         add_filtered_rows(filtered_rows);

--- a/be/src/olap/schema_change.cpp
+++ b/be/src/olap/schema_change.cpp
@@ -1023,8 +1023,8 @@ OLAPStatus SchemaChangeDirectly::process(RowsetReaderSharedPtr rowset_reader, Ro
 
         // 将ref改为new。这一步按道理来说确实需要等大的块，但理论上和writer无关。
         uint64_t filtered_rows = 0;
-        if ((res = _row_block_changer.change_row_block(ref_row_block, rowset_reader->version().second,
-                new_row_block, &filtered_rows)) != OLAP_SUCCESS) {
+        res = _row_block_changer.change_row_block(ref_row_block, rowset_reader->version().second, new_row_block, &filtered_rows);
+        if (res != OLAP_SUCCESS) {
             LOG(WARNING) << "failed to change data in row block.";
             goto DIRECTLY_PROCESS_ERR;
         }
@@ -1197,8 +1197,8 @@ OLAPStatus SchemaChangeWithSorting::process(RowsetReaderSharedPtr rowset_reader,
         }
 
         uint64_t filtered_rows = 0;
-        if ((res = _row_block_changer.change_row_block(ref_row_block, rowset_reader->version().second,
-                                                 new_row_block, &filtered_rows)) != OLAP_SUCCESS) {
+        res = _row_block_changer.change_row_block(ref_row_block, rowset_reader->version().second, new_row_block, &filtered_rows);
+        if (res != OLAP_SUCCESS) {
             LOG(WARNING) << "failed to change data in row block.";
             goto SORTING_PROCESS_ERR;
         }

--- a/be/src/runtime/runtime_state.cpp
+++ b/be/src/runtime/runtime_state.cpp
@@ -475,8 +475,12 @@ void RuntimeState::export_load_error(const std::string& err_msg) {
         if (_load_error_hub_info == nullptr) {
             return;
         }
-        LoadErrorHub::create_hub(_exec_env, _load_error_hub_info.get(),
+        Status st = LoadErrorHub::create_hub(_exec_env, _load_error_hub_info.get(),
                 _error_log_file_path, &_error_hub);
+        if (!st.ok()) {
+            LOG(WARNING) << "failed to create load error hub: " << st.get_error_msg();
+            return;
+        }
     }
 
     if (_error_row_number <= HUB_MAX_ERROR_NUM) {


### PR DESCRIPTION
## Proposed changes

1. When WITH_MYSQL is off, load error hub does not suport MySQL load error hub,
   we should check its return value. (introduced by #4371 )

2. misjudge the return value of `change_row_block` in schema_change.cpp (Introduced by #4388 )

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)