### PR TITLE
fix semi/anti join error when table has delete sign column

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/Analyzer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/Analyzer.java
@@ -655,7 +655,7 @@ public class Analyzer {
         // find table all name
         for (TupleDescriptor desc : tupleByAlias.get(tblName.toString())) {
             //result = desc;
-            if (!isVisible(desc.getId())) {
+            if (!colName.equalsIgnoreCase(Column.DELETE_SIGN) && !isVisible(desc.getId())) {
                 ErrorReport.reportAnalysisException(ErrorCode.ERR_ILLEGAL_COLUMN_REFERENCE_ERROR, 
                         Joiner.on(".").join(tblName.getTbl(),colName));
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/BaseTableRef.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/BaseTableRef.java
@@ -53,11 +53,6 @@ public class BaseTableRef extends TableRef {
     }
 
     @Override
-    public Table getTable() {
-        return table;
-    }
-
-    @Override
     public TupleDescriptor createTupleDescriptor(Analyzer analyzer) {
         TupleDescriptor result = analyzer.getDescTbl().createTupleDescriptor();
         result.setTable(table);

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/BaseTableRef.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/BaseTableRef.java
@@ -53,6 +53,11 @@ public class BaseTableRef extends TableRef {
     }
 
     @Override
+    public Table getTable() {
+        return table;
+    }
+
+    @Override
     public TupleDescriptor createTupleDescriptor(Analyzer analyzer) {
         TupleDescriptor result = analyzer.getDescTbl().createTupleDescriptor();
         result.setTable(table);

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/SelectStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/SelectStmt.java
@@ -531,6 +531,10 @@ public class SelectStmt extends QueryStmt {
                 whereClause = new BoolLiteral(true);
             }
         }
+        Expr deDuplicatedWhere = deduplicateOrs(whereClause);
+        if (deDuplicatedWhere != null) {
+            whereClause = deDuplicatedWhere;
+        }
     }
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/SelectStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/SelectStmt.java
@@ -523,7 +523,7 @@ public class SelectStmt extends QueryStmt {
         return result;
     }
 
-    private void whereClauseRewrite() throws AnalysisException {
+    private void whereClauseRewrite() {
         if (whereClause instanceof IntLiteral) {
             if (((IntLiteral) whereClause).getLongValue() == 0) {
                 whereClause = new BoolLiteral(false);

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/SelectStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/SelectStmt.java
@@ -22,7 +22,6 @@ import org.apache.doris.catalog.Catalog;
 import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.Database;
 import org.apache.doris.catalog.FunctionSet;
-import org.apache.doris.catalog.KeysType;
 import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.catalog.Table.TableType;
 import org.apache.doris.catalog.Type;
@@ -340,7 +339,6 @@ public class SelectStmt extends QueryStmt {
             return;
         }
         super.analyze(analyzer);
-        whereClauseRewrite();
         fromClause_.setNeedToSql(needToSql);
         fromClause_.analyze(analyzer);
 
@@ -439,6 +437,7 @@ public class SelectStmt extends QueryStmt {
         }
         // do this before whereClause.analyze , some expr is not analyzed, this may cause some
         // function not work as expected such as equals;
+        whereClauseRewrite();
         if (whereClause != null) {
             if (checkGroupingFn(whereClause)) {
                 throw new AnalysisException("grouping operations are not allowed in WHERE.");
@@ -524,25 +523,6 @@ public class SelectStmt extends QueryStmt {
         return result;
     }
 
-    private Expr filterDeleteSignCol(Expr origExpr) throws AnalysisException {
-        Expr expr = origExpr;
-        for (TableRef tableRef : fromClause_.getTableRefs()) {
-            tableRef = analyzer.resolveTableRef(tableRef);
-            if (!isForbiddenMVRewrite() && tableRef instanceof BaseTableRef && tableRef.getTable() instanceof OlapTable
-                    && ((OlapTable) tableRef.getTable()).getKeysType() == KeysType.UNIQUE_KEYS
-                    && ((OlapTable) tableRef.getTable()).hasDeleteSign()) {
-                BinaryPredicate filterDeleteExpr = new BinaryPredicate(BinaryPredicate.Operator.EQ,
-                        new SlotRef(tableRef.getName(), Column.DELETE_SIGN), new IntLiteral(0));
-                if (expr == null) {
-                    expr = filterDeleteExpr;
-                } else {
-                    expr = new CompoundPredicate(CompoundPredicate.Operator.AND, filterDeleteExpr, expr);
-                }
-            }
-        }
-        return expr;
-    }
-
     private void whereClauseRewrite() throws AnalysisException {
         if (whereClause instanceof IntLiteral) {
             if (((IntLiteral) whereClause).getLongValue() == 0) {
@@ -550,22 +530,6 @@ public class SelectStmt extends QueryStmt {
             } else {
                 whereClause = new BoolLiteral(true);
             }
-        }
-        // filter deleted data by and DELETE_SIGN column = 0, DELETE_SIGN is a hidden column
-        // that indicates whether the row is delete
-        if (fromClause_.getTableRefs().size() == 2
-                && (fromClause_.getTableRefs().get(1).getJoinOp() == JoinOperator.LEFT_SEMI_JOIN
-                || fromClause_.getTableRefs().get(1).getJoinOp() == JoinOperator.RIGHT_SEMI_JOIN
-                || fromClause_.getTableRefs().get(1).getJoinOp() == JoinOperator.LEFT_ANTI_JOIN
-                || fromClause_.getTableRefs().get(1).getJoinOp() == JoinOperator.RIGHT_ANTI_JOIN)) {
-            fromClause_.getTableRefs().get(1).setOnClause(
-                    filterDeleteSignCol(fromClause_.getTableRefs().get(1).getOnClause()));
-        } else {
-            whereClause = filterDeleteSignCol(whereClause);
-        }
-        Expr deDuplicatedWhere = deduplicateOrs(whereClause);
-        if (deDuplicatedWhere != null) {
-            whereClause = deDuplicatedWhere;
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/SingleNodePlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/SingleNodePlanner.java
@@ -1362,8 +1362,7 @@ public class SingleNodePlanner {
 
         switch (tblRef.getTable().getType()) {
             case OLAP:
-                OlapScanNode olapNode = new OlapScanNode(ctx_.getNextNodeId(), tblRef.getDesc(),
-                        "OlapScanNode");
+                OlapScanNode olapNode = new OlapScanNode(ctx_.getNextNodeId(), tblRef.getDesc(), "OlapScanNode");
                 if (((OlapTable) tblRef.getTable()).hasDeleteSign()) {
                     Expr conjunct = new BinaryPredicate(BinaryPredicate.Operator.EQ,
                             new SlotRef(tblRef.getAliasAsName(), Column.DELETE_SIGN), new IntLiteral(0));

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/SelectStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/SelectStmtTest.java
@@ -64,11 +64,42 @@ public class SelectStmtTest {
                 "\"storage_type\" = \"COLUMN\",\n" +
                 "\"replication_num\" = \"1\"\n" +
                 ");";
+
+        String tbl1 = "CREATE TABLE db1.table1 (\n" +
+                "  `siteid` int(11) NULL DEFAULT \"10\" COMMENT \"\",\n" +
+                "  `citycode` smallint(6) NULL COMMENT \"\",\n" +
+                "  `username` varchar(32) NULL DEFAULT \"\" COMMENT \"\",\n" +
+                "  `pv` bigint(20) NULL DEFAULT \"0\" COMMENT \"\"\n" +
+                ") ENGINE=OLAP\n" +
+                "UNIQUE KEY(`siteid`, `citycode`, `username`)\n" +
+                "COMMENT \"OLAP\"\n" +
+                "DISTRIBUTED BY HASH(`siteid`) BUCKETS 10\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\",\n" +
+                "\"in_memory\" = \"false\",\n" +
+                "\"storage_format\" = \"V2\"\n" +
+                ")";
+        String tbl2 = "CREATE TABLE db1.table2 (\n" +
+                "  `siteid` int(11) NULL DEFAULT \"10\" COMMENT \"\",\n" +
+                "  `citycode` smallint(6) NULL COMMENT \"\",\n" +
+                "  `username` varchar(32) NULL DEFAULT \"\" COMMENT \"\",\n" +
+                "  `pv` bigint(20) NULL DEFAULT \"0\" COMMENT \"\"\n" +
+                ") ENGINE=OLAP\n" +
+                "UNIQUE KEY(`siteid`, `citycode`, `username`)\n" +
+                "COMMENT \"OLAP\"\n" +
+                "DISTRIBUTED BY HASH(`siteid`) BUCKETS 10\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\",\n" +
+                "\"in_memory\" = \"false\",\n" +
+                "\"storage_format\" = \"V2\"\n" +
+                ")";
         dorisAssert = new DorisAssert();
         dorisAssert.withDatabase("db1").useDatabase("db1");
         dorisAssert.withTable(createTblStmtStr)
                    .withTable(createBaseAllStmtStr)
-                   .withTable(createPratitionTableStr);
+                   .withTable(createPratitionTableStr)
+                   .withTable(tbl1)
+                   .withTable(tbl2);
     }
 
     @Test
@@ -395,5 +426,18 @@ public class SelectStmtTest {
                 .query(sql)
                 .explainQuery()
                 .contains("`datekey` = 20200730"));
+    }
+    @Test
+    public void testDeleteSign() throws Exception {
+        ConnectContext ctx = UtFrameUtils.createDefaultCtx();
+        String sql1 = "SELECT * FROM db1.table1  LEFT ANTI JOIN db1.table2 ON db1.table1.siteid = db1.table2.siteid;";
+        SelectStmt stmt1 = (SelectStmt) UtFrameUtils.parseAndAnalyzeStmt(sql1, ctx);
+        Assert.assertTrue(stmt1.toSql().contains("ON (`default_cluster:db1`.`table2`.`__DORIS_DELETE_SIGN__` = 0) " +
+                "AND ((`default_cluster:db1`.`table1`.`__DORIS_DELETE_SIGN__` = 0) AND " +
+                "(`db1`.`table1`.`siteid` = `db1`.`table2`.`siteid`))"));
+        String sql2 = "SELECT * FROM db1.table1 JOIN db1.table2 ON db1.table1.siteid = db1.table2.siteid;";
+        SelectStmt stmt2 = (SelectStmt) UtFrameUtils.parseAndAnalyzeStmt(sql2, ctx);
+        Assert.assertTrue(stmt2.toSql().contains(" WHERE (`default_cluster:db1`.`table2`.`__DORIS_DELETE_SIGN__` = 0)" +
+                " AND (`default_cluster:db1`.`table1`.`__DORIS_DELETE_SIGN__` = 0)"));
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/SelectStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/SelectStmtTest.java
@@ -429,15 +429,13 @@ public class SelectStmtTest {
     }
     @Test
     public void testDeleteSign() throws Exception {
-        ConnectContext ctx = UtFrameUtils.createDefaultCtx();
         String sql1 = "SELECT * FROM db1.table1  LEFT ANTI JOIN db1.table2 ON db1.table1.siteid = db1.table2.siteid;";
-        SelectStmt stmt1 = (SelectStmt) UtFrameUtils.parseAndAnalyzeStmt(sql1, ctx);
-        Assert.assertTrue(stmt1.toSql().contains("ON (`default_cluster:db1`.`table2`.`__DORIS_DELETE_SIGN__` = 0) " +
-                "AND ((`default_cluster:db1`.`table1`.`__DORIS_DELETE_SIGN__` = 0) AND " +
-                "(`db1`.`table1`.`siteid` = `db1`.`table2`.`siteid`))"));
+        Assert.assertTrue(dorisAssert.query(sql1).explainQuery().contains("`table1`.`__DORIS_DELETE_SIGN__` = 0"));
         String sql2 = "SELECT * FROM db1.table1 JOIN db1.table2 ON db1.table1.siteid = db1.table2.siteid;";
-        SelectStmt stmt2 = (SelectStmt) UtFrameUtils.parseAndAnalyzeStmt(sql2, ctx);
-        Assert.assertTrue(stmt2.toSql().contains(" WHERE (`default_cluster:db1`.`table2`.`__DORIS_DELETE_SIGN__` = 0)" +
-                " AND (`default_cluster:db1`.`table1`.`__DORIS_DELETE_SIGN__` = 0)"));
+        Assert.assertTrue(dorisAssert.query(sql2).explainQuery().contains("`table1`.`__DORIS_DELETE_SIGN__` = 0"));
+        String sql3 = "SELECT * FROM table1";
+        Assert.assertTrue(dorisAssert.query(sql3).explainQuery().contains("`table1`.`__DORIS_DELETE_SIGN__` = 0"));
+        String sql4 = " SELECT * FROM table1 table2";
+        Assert.assertTrue(dorisAssert.query(sql4).explainQuery().contains("`table2`.`__DORIS_DELETE_SIGN__` = 0"));
     }
 }


### PR DESCRIPTION
## Proposed changes

It is possible to report "Illegal column/field reference'table2.__DORIS_DELETE_SIGN__' of semi-/anti-join" when executing a semi/anti join statement on a table with hidden columns. This is because the filter conditions of semi/anti join cannot Caused in the where statement, pr#4492 is also about this

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] Documentation Update (if none of the other choices apply)
- [] Code refactor (Modify the code structure, format the code, etc...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have create an issue on (Fix #4492), and have described the bug/feature there in detail
- [x] Compiling and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [] If this change need a document change, I have updated the document
- [] Any dependent changes have been merged

## Further comments

If this is a relatively large or complex change, kick off the discussion at dev@doris.apache.org by explaining why you chose the solution you did and what alternatives you considered, etc...
