### PR TITLE
[BUG] Fix segment group add zone map bug when schema change.

### DIFF
--- a/be/src/olap/rowset/segment_group.cpp
+++ b/be/src/olap/rowset/segment_group.cpp
@@ -262,7 +262,10 @@ OLAPStatus SegmentGroup::add_zone_maps_for_linked_schema_change(
         if (_schema->keys_type() == DUP_KEYS && 
             schema_mapping[i].ref_column != -1 &&
             schema_mapping[i].ref_column >= zone_map_fields.size()) {
-            break; // _zone_maps follows _schema column index
+            
+            // the sequence of columns in _zone_maps and _schema must be consistent, so here
+            // should not this column missed zonemap and we break the loap.
+            break; 
         }
         const TabletColumn& column = _schema->column(i);
 
@@ -299,6 +302,8 @@ OLAPStatus SegmentGroup::add_zone_maps_for_linked_schema_change(
             } 
         }
 
+        // first and second can be nullptr, because when type is Varchar then default_value and zone_map_fields in old column
+        // can be nullptr,  and it is checked in olap_cond.cpp eval function.
         _zone_maps.push_back(std::make_pair(first, second));
     }
 

--- a/be/src/olap/rowset/segment_group.cpp
+++ b/be/src/olap/rowset/segment_group.cpp
@@ -258,32 +258,45 @@ OLAPStatus SegmentGroup::add_zone_maps_for_linked_schema_change(
 
     for (size_t i = 0; i < zonemap_col_num; ++i) {
         
-        // in duplicated table update from 0.11 to 0.12, zone map index may be missed
+        // in duplicated table update from 0.11 to 0.12, zone map index may be missed and may not a new column.
         if (_schema->keys_type() == DUP_KEYS && 
             schema_mapping[i].ref_column != -1 &&
             schema_mapping[i].ref_column >= zone_map_fields.size()) {
-            continue;
+            break; // _zone_maps follows _schema column index
         }
         const TabletColumn& column = _schema->column(i);
 
-        WrapperField* first = WrapperField::create(column);
-        DCHECK(first != NULL) << "failed to allocate memory for field: " << i;
-
-        WrapperField* second = WrapperField::create(column);
-        DCHECK(second != NULL) << "failed to allocate memory for field: " << i;
+        // nullptr is checked in olap_cond.cpp eval, note: When we apply column statistic, Field can be NULL when type is Varchar.
+        WrapperField* first = nullptr;
+        WrapperField* second = nullptr;
 
         // when this is no ref_column (add new column), fill default value
         if (schema_mapping[i].ref_column == -1 || schema_mapping[i].ref_column >= zone_map_fields.size()) {
             // ref_column == -1 means this is a new column.
             // for new column, use default value to fill into column_statistics
             if (schema_mapping[i].default_value != nullptr) {
+                first = WrapperField::create(column);
+                DCHECK(first != nullptr) << "failed to allocate memory for field: " << i;
                 first->copy(schema_mapping[i].default_value);
+                second = WrapperField::create(column);
+                DCHECK(second != nullptr) << "failed to allocate memory for field: " << i;
                 second->copy(schema_mapping[i].default_value);
-            }
+            } 
         } else {
-            // use src column's zone map value to fill
-            first->copy(zone_map_fields[schema_mapping[i].ref_column].first);
-            second->copy(zone_map_fields[schema_mapping[i].ref_column].second);
+            WrapperField* wfirst = zone_map_fields[schema_mapping[i].ref_column].first;
+            WrapperField* wsecond = zone_map_fields[schema_mapping[i].ref_column].second;
+
+            if (wfirst != nullptr) {
+                first = WrapperField::create(column);
+                DCHECK(first != nullptr) << "failed to allocate memory for field: " << i;
+                first->copy(wfirst);
+            }
+
+            if (wsecond != nullptr) {
+                second = WrapperField::create(column);
+                DCHECK(second != nullptr) << "failed to allocate memory for field: " << i;
+                second->copy(wsecond);
+            } 
         }
 
         _zone_maps.push_back(std::make_pair(first, second));

--- a/be/src/olap/rowset/segment_group.cpp
+++ b/be/src/olap/rowset/segment_group.cpp
@@ -264,7 +264,7 @@ OLAPStatus SegmentGroup::add_zone_maps_for_linked_schema_change(
             schema_mapping[i].ref_column >= zone_map_fields.size()) {
             
             // the sequence of columns in _zone_maps and _schema must be consistent, so here
-            // process should not add missed zonemap and we break the loap.
+            // process should not add missed zonemap and we break the loop.
             break; 
         }
         const TabletColumn& column = _schema->column(i);

--- a/be/src/olap/rowset/segment_group.cpp
+++ b/be/src/olap/rowset/segment_group.cpp
@@ -264,7 +264,7 @@ OLAPStatus SegmentGroup::add_zone_maps_for_linked_schema_change(
             schema_mapping[i].ref_column >= zone_map_fields.size()) {
             
             // the sequence of columns in _zone_maps and _schema must be consistent, so here
-            // should not this column missed zonemap and we break the loap.
+            // process should not add missed zonemap and we break the loap.
             break; 
         }
         const TabletColumn& column = _schema->column(i);


### PR DESCRIPTION
## Proposed changes

Fix segment group  add zone map bug when schema change.
(1) WrapperField null point check
(2) in DUP_KEYS, let _zone_maps index  consistent with _schema column index

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] Documentation Update (if none of the other choices apply)
- [] Code refactor (Modify the code structure, format the code, etc...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have create an issue on (Fix #4527 ), and have described the bug/feature there in detail
- [x] Compiling and unit tests pass locally with my changes
- [] I have added tests that prove my fix is effective or that my feature works
- [] If this change need a document change, I have updated the document
- [] Any dependent changes have been merged

