### PR TITLE
[BUG] Tablet is not readable and delete handler report -1903 error, when condition value contains \n

### DIFF
--- a/be/src/olap/delete_handler.cpp
+++ b/be/src/olap/delete_handler.cpp
@@ -198,12 +198,12 @@ bool DeleteHandler::_parse_condition(const std::string& condition_str, TConditio
 
     try {
         // Condition string format, the format is (column_name)(op)(value) 
-        // eg:   c1 = 1597751948193618247  and length(source)<1;\n;\n
-        // group1:  (\w+) matchs "c1"
-        // group2:  ((?:=)|(?:!=)|(?:>>)|(?:<<)|(?:>=)|(?:<=)|(?:\*=)|(?:IS)) matchs  "="
-        // group3:  ((?:[\r\n\t\S ]+)?) matchs "1597751948193618247  and length(source)<1;\n;\n"
+        // eg:  condition_str="c1 = 1597751948193618247  and length(source)<1;\n;\n"
+        //  group1:  (\w+) matchs "c1"
+        //  group2:  ((?:=)|(?:!=)|(?:>>)|(?:<<)|(?:>=)|(?:<=)|(?:\*=)|(?:IS)) matchs  "="
+        //  group3:  ((?:[\s\S]+)?) matchs "1597751948193618247  and length(source)<1;\n;\n"
         const char* const CONDITION_STR_PATTERN =
-                R"((\w+)\s*((?:=)|(?:!=)|(?:>>)|(?:<<)|(?:>=)|(?:<=)|(?:\*=)|(?:IS))\s*((?:[\r\n\t\S ]+)?))";
+                R"((\w+)\s*((?:=)|(?:!=)|(?:>>)|(?:<<)|(?:>=)|(?:<=)|(?:\*=)|(?:IS))\s*((?:[\s\S]+)?))";
         regex ex(CONDITION_STR_PATTERN);
         if (regex_match(condition_str, what, ex)) {
             if (condition_str.size() != what[0].str().size()) {

--- a/be/src/olap/delete_handler.cpp
+++ b/be/src/olap/delete_handler.cpp
@@ -199,7 +199,7 @@ bool DeleteHandler::_parse_condition(const std::string& condition_str, TConditio
     try {
         // Condition string format
         const char* const CONDITION_STR_PATTERN =
-                R"((\w+)\s*((?:=)|(?:!=)|(?:>>)|(?:<<)|(?:>=)|(?:<=)|(?:\*=)|(?:IS))\s*((?:[\r\n\S ]+)?))";
+                R"((\w+)\s*((?:=)|(?:!=)|(?:>>)|(?:<<)|(?:>=)|(?:<=)|(?:\*=)|(?:IS))\s*((?:[\r\n\t\S ]+)?))";
         regex ex(CONDITION_STR_PATTERN);
         if (regex_match(condition_str, what, ex)) {
             if (condition_str.size() != what[0].str().size()) {

--- a/be/src/olap/delete_handler.cpp
+++ b/be/src/olap/delete_handler.cpp
@@ -197,7 +197,11 @@ bool DeleteHandler::_parse_condition(const std::string& condition_str, TConditio
     smatch what;
 
     try {
-        // Condition string format
+        // Condition string format, the format is (column_name)(op)(value) 
+        // eg:   c1 = 1597751948193618247  and length(source)<1;\n;\n
+        // group1:  (\w+) matchs "c1"
+        // group2:  ((?:=)|(?:!=)|(?:>>)|(?:<<)|(?:>=)|(?:<=)|(?:\*=)|(?:IS)) matchs  "="
+        // group3:  ((?:[\r\n\t\S ]+)?) matchs "1597751948193618247  and length(source)<1;\n;\n"
         const char* const CONDITION_STR_PATTERN =
                 R"((\w+)\s*((?:=)|(?:!=)|(?:>>)|(?:<<)|(?:>=)|(?:<=)|(?:\*=)|(?:IS))\s*((?:[\r\n\t\S ]+)?))";
         regex ex(CONDITION_STR_PATTERN);

--- a/be/src/olap/delete_handler.cpp
+++ b/be/src/olap/delete_handler.cpp
@@ -199,7 +199,7 @@ bool DeleteHandler::_parse_condition(const std::string& condition_str, TConditio
     try {
         // Condition string format
         const char* const CONDITION_STR_PATTERN =
-                R"((\w+)\s*((?:=)|(?:!=)|(?:>>)|(?:<<)|(?:>=)|(?:<=)|(?:\*=)|(?:IS))\s*((?:[\S ]+)?))";
+                R"((\w+)\s*((?:=)|(?:!=)|(?:>>)|(?:<<)|(?:>=)|(?:<=)|(?:\*=)|(?:IS))\s*((?:[\r\n\S ]+)?))";
         regex ex(CONDITION_STR_PATTERN);
         if (regex_match(condition_str, what, ex)) {
             if (condition_str.size() != what[0].str().size()) {


### PR DESCRIPTION
## Proposed changes

Delete handler parse condition error, when value contains \n. It generates -1903 error, when we query tablet and do base compaction.

SQL: delete from bjh_content_order_showx where order_id='1597751948193618247 and length(source)<1;\n ;\n '

W0903 19:40:43.671677 90527 reader.cpp:574] fail to init delete param. [res=-1903]
W0903 19:40:43.671686 90527 reader.cpp:319] fail to init reader when init params. res:-1903, tablet_id:11123, schema_hash:945479433, reader type:0, version:[0-12]

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] Documentation Update (if none of the other choices apply)
- [] Code refactor (Modify the code structure, format the code, etc...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have create an issue on (Fix #4530 ), and have described the bug/feature there in detail
- [x] Compiling and unit tests pass locally with my changes
- [] I have added tests that prove my fix is effective or that my feature works
- [] If this change need a document change, I have updated the document
- [] Any dependent changes have been merged
