### PR TITLE
[Spark Load][Bug] Keep the column splitting in spark load consistent with broker load / mini load

### DIFF
--- a/fe/spark-dpp/src/main/java/org/apache/doris/load/loadv2/dpp/SparkDpp.java
+++ b/fe/spark-dpp/src/main/java/org/apache/doris/load/loadv2/dpp/SparkDpp.java
@@ -644,6 +644,9 @@ public final class SparkDpp implements java.io.Serializable {
 
     // This method is to keep the splitting consistent with broker load / mini load
     private String[] splitLine(String line, char sep) {
+        if (line == null || line.equals("")) {
+            return new String[0];
+        }
         int index = 0;
         int lastIndex = 0;
         // line-begin char and line-end char are considered to be 'delimeter'

--- a/fe/spark-dpp/src/main/java/org/apache/doris/load/loadv2/dpp/SparkDpp.java
+++ b/fe/spark-dpp/src/main/java/org/apache/doris/load/loadv2/dpp/SparkDpp.java
@@ -62,6 +62,7 @@ import java.io.IOException;
 import java.math.BigInteger;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -553,12 +554,13 @@ public final class SparkDpp implements java.io.Serializable {
         for (EtlJobConfig.EtlColumn column : baseIndex.columns) {
             parsers.add(ColumnParser.create(column));
         }
+        char separator = (char)fileGroup.columnSeparator.getBytes(Charset.forName("UTF-8"))[0];
         // now we first support csv file
         // TODO: support parquet file and orc file
         JavaRDD<Row> rowRDD = sourceDataRdd.flatMap(
                 record -> {
                     scannedRowsAcc.add(1);
-                    String[] attributes = splitLine(record, fileGroup.columnSeparator);
+                    String[] attributes = splitLine(record, separator);
                     List<Row> result = new ArrayList<>();
                     boolean validRow = true;
                     if (attributes.length != columnSize) {
@@ -641,8 +643,7 @@ public final class SparkDpp implements java.io.Serializable {
     }
 
     // This method is to keep the splitting consistent with broker load / mini load
-    private String[] splitLine(String line, String columnSeparator) {
-        char sep = columnSeparator.charAt(0);
+    private String[] splitLine(String line, char sep) {
         int index = 0;
         int lastIndex = 0;
         // line-begin char and line-end char are considered to be 'delimeter'

--- a/fe/spark-dpp/src/main/java/org/apache/doris/load/loadv2/etl/EtlJobConfig.java
+++ b/fe/spark-dpp/src/main/java/org/apache/doris/load/loadv2/etl/EtlJobConfig.java
@@ -510,14 +510,6 @@ public class EtlJobConfig implements Serializable {
             this.columnMappings = columnMappings;
             this.where = where;
             this.partitions = partitions;
-
-            // Convert some special characters in column separator
-//            char sep = Strings.isNullOrEmpty(columnSeparator) ? '\t' : columnSeparator.charAt(0);
-//            if (".$|()[]{}^?*+\\".indexOf(sep) != -1) {
-//                this.columnSeparator = new String(new char[]{'\\', sep});
-//            } else {
-//                this.columnSeparator = Character.toString(sep);
-//            }
         }
 
         // for data from table

--- a/fe/spark-dpp/src/main/java/org/apache/doris/load/loadv2/etl/EtlJobConfig.java
+++ b/fe/spark-dpp/src/main/java/org/apache/doris/load/loadv2/etl/EtlJobConfig.java
@@ -503,6 +503,7 @@ public class EtlJobConfig implements Serializable {
             this.filePaths = filePaths;
             this.fileFieldNames = fileFieldNames;
             this.columnsFromPath = columnsFromPath;
+            this.columnSeparator = Strings.isNullOrEmpty(columnSeparator) ? "\t" : columnSeparator;
             this.lineDelimiter = lineDelimiter;
             this.isNegative = isNegative;
             this.fileFormat = fileFormat;
@@ -511,12 +512,12 @@ public class EtlJobConfig implements Serializable {
             this.partitions = partitions;
 
             // Convert some special characters in column separator
-            char sep = Strings.isNullOrEmpty(columnSeparator) ? '\t' : columnSeparator.charAt(0);
-            if (".$|()[]{}^?*+\\".indexOf(sep) != -1) {
-                this.columnSeparator = new String(new char[]{'\\', sep});
-            } else {
-                this.columnSeparator = Character.toString(sep);
-            }
+//            char sep = Strings.isNullOrEmpty(columnSeparator) ? '\t' : columnSeparator.charAt(0);
+//            if (".$|()[]{}^?*+\\".indexOf(sep) != -1) {
+//                this.columnSeparator = new String(new char[]{'\\', sep});
+//            } else {
+//                this.columnSeparator = Character.toString(sep);
+//            }
         }
 
         // for data from table


### PR DESCRIPTION
## Proposed changes

There is a 4 columns source data:

```
1|1|jim|2|
2|1|grace|2|
3|2|tom|2|
4|3|bush|3|
5|3|helen|3|
5|3|helen|6|
6|3|helen|3|
6|3|helen|3|
...
```
Given the same column terminator '|', broker load determines that it is 5 columns, and spark load determines that it is 4 columns.

And there is another 4 columns source

```
1|1|jim|2
2|1|grace|2
3|2|tom|2
4|3|bush|3
5|3|helen|3
5|3|helen|6
6|3|helen|3
6|3|helen|3
...
```
Given the same column terminator '|', both the broker load and spark load determines that it is 4 columns.

**To Reproduce**
Steps to reproduce the behavior:
1. Submit a broker load.

```
load label ssb_db.broker_load_label 
( 
    data infile ("hdfs://ymy-host:port/user/palo/table1") 
    into table test_tbl 
    COLUMNS TERMINATED BY "|" 
    (k1,k2,name,clicks ) 
) 
with broker "doris" ("username"  =  "test", "password"  =  "test");
```
2. Submit a spark load.

```
load label ssb_db.spark_load_label 
( data infile ("hdfs://ymy-host:port/user/palo/table1") 
    into table test_tbl 
    COLUMNS TERMINATED BY "|" 
    (k1,k2,name,clicks ) 
) with resource "spark0" 
("spark.executor.memory"  =  "24g", "spark.executor.cores"  =  "2", "spark.executor.instances"  =  "8");
```
3. Broker Load will report an error "quality not good enough to cancel"

**The reson of this bug**
This is because the first character and the last character of a line are not considered to be delimeter in spark load.
 

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have create an issue on (Fix #4520 ), and have described the bug/feature there in detail
