### PR TITLE
[Spark load][Bug] fix that cancelling a spark load in the `PENDING` phase will not succeed

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/SparkEtlJobHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/SparkEtlJobHandler.java
@@ -264,7 +264,7 @@ public class SparkEtlJobHandler {
 
     public void killEtlJob(SparkLoadAppHandle handle, String appId, long loadJobId, SparkResource resource) throws LoadException {
         if (resource.isYarnMaster()) {
-            // The appId may be empty in when the load job is in PENDING phase. This is because the appId is
+            // The appId may be empty when the load job is in PENDING phase. This is because the appId is
             // parsed from the spark launcher process's output (spark launcher process submit job and then
             // return appId). In this case, the spark job has still not been submitted, we only need to kill
             // the spark launcher process.

--- a/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/SparkEtlJobHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/SparkEtlJobHandler.java
@@ -265,7 +265,7 @@ public class SparkEtlJobHandler {
 
     public void killEtlJob(SparkLoadAppHandle handle, String appId, long loadJobId, SparkResource resource) throws LoadException {
         if (resource.isYarnMaster()) {
-            // When users kill the load job in PENDING phase, it is possible that the appId is empty. This is
+            // When users kill a spark load in PENDING phase, it is possible that the appId is empty. This is
             // because the appId is parsed from the spark launcher process's output (spark launcher process
             // submit job and then return appId). In this case, the spark job has still not been submitted,
             // we only need to kill the spark launcher process.

--- a/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/SparkLauncherMonitor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/SparkLauncherMonitor.java
@@ -106,6 +106,11 @@ public class SparkLauncherMonitor {
         // UNKNOWN/SUBMITTED for a long time.
         @Override
         public void run() {
+            if (handle.getState() == SparkLoadAppHandle.State.KILLED) {
+                // If handle has been killed, kill the process
+                process.destroyForcibly();
+                return;
+            }
             BufferedReader outReader = null;
             String line = null;
             long startTime = System.currentTimeMillis();

--- a/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/SparkLoadAppHandle.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/SparkLoadAppHandle.java
@@ -134,6 +134,10 @@ public class SparkLoadAppHandle implements Writable {
 
     public String getLogPath() { return this.logPath; }
 
+    public void setProcess(Process process) {
+        this.process = process;
+    }
+
     public void setState(State state) {
         this.state = state;
         this.fireEvent(false);

--- a/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/SparkLoadJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/SparkLoadJob.java
@@ -715,6 +715,10 @@ public class SparkLoadJob extends BulkLoadJob {
         return etlStartTimestamp;
     }
 
+    public SparkLoadAppHandle getHandle() {
+        return sparkLoadAppHandle;
+    }
+
     public void clearSparkLauncherLog() {
         String logPath = sparkLoadAppHandle.getLogPath();
         if (!Strings.isNullOrEmpty(logPath)) {

--- a/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/SparkLoadPendingTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/SparkLoadPendingTask.java
@@ -57,15 +57,14 @@ import org.apache.doris.load.loadv2.etl.EtlJobConfig.EtlTable;
 import org.apache.doris.load.loadv2.etl.EtlJobConfig.FilePatternVersion;
 import org.apache.doris.load.loadv2.etl.EtlJobConfig.SourceType;
 import org.apache.doris.transaction.TransactionState;
-
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Range;
 import com.google.common.collect.Sets;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.List;
 import java.util.Map;
@@ -84,6 +83,7 @@ public class SparkLoadPendingTask extends LoadTask {
     private final long loadJobId;
     private final long transactionId;
     private EtlJobConfig etlJobConfig;
+    private SparkLoadAppHandle sparkLoadAppHandle;
 
     public SparkLoadPendingTask(SparkLoadJob loadTaskCallback,
                                 Map<FileGroupAggKey, List<BrokerFileGroup>> aggKeyToBrokerFileGroups,
@@ -98,6 +98,7 @@ public class SparkLoadPendingTask extends LoadTask {
         this.loadJobId = loadTaskCallback.getId();
         this.loadLabel = loadTaskCallback.getLabel();
         this.transactionId = loadTaskCallback.getTransactionId();
+        this.sparkLoadAppHandle = loadTaskCallback.getHandle();
         this.failMsg = new FailMsg(FailMsg.CancelType.ETL_SUBMIT_FAIL);
     }
 
@@ -115,7 +116,7 @@ public class SparkLoadPendingTask extends LoadTask {
 
         // handler submit etl job
         SparkEtlJobHandler handler = new SparkEtlJobHandler();
-        handler.submitEtlJob(loadJobId, loadLabel, etlJobConfig, resource, brokerDesc, sparkAttachment);
+        handler.submitEtlJob(loadJobId, loadLabel, etlJobConfig, resource, brokerDesc, sparkLoadAppHandle, sparkAttachment);
         LOG.info("submit spark etl job success. load job id: {}, attachment: {}", loadJobId, sparkAttachment);
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/load/loadv2/SparkEtlJobHandlerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/load/loadv2/SparkEtlJobHandlerTest.java
@@ -167,7 +167,7 @@ public class SparkEtlJobHandlerTest {
         BrokerDesc brokerDesc = new BrokerDesc(broker, Maps.newHashMap());
         SparkPendingTaskAttachment attachment = new SparkPendingTaskAttachment(pendingTaskId);
         SparkEtlJobHandler handler = new SparkEtlJobHandler();
-        handler.submitEtlJob(loadJobId, label, etlJobConfig, resource, brokerDesc, attachment);
+        handler.submitEtlJob(loadJobId, label, etlJobConfig, resource, brokerDesc, handle, attachment);
 
         // check submit etl job success
         Assert.assertEquals(appId, attachment.getAppId());
@@ -203,7 +203,7 @@ public class SparkEtlJobHandlerTest {
         BrokerDesc brokerDesc = new BrokerDesc(broker, Maps.newHashMap());
         SparkPendingTaskAttachment attachment = new SparkPendingTaskAttachment(pendingTaskId);
         SparkEtlJobHandler handler = new SparkEtlJobHandler();
-        handler.submitEtlJob(loadJobId, label, etlJobConfig, resource, brokerDesc, attachment);
+        handler.submitEtlJob(loadJobId, label, etlJobConfig, resource, brokerDesc, handle, attachment);
     }
 
     @Test


### PR DESCRIPTION
## Proposed changes

**To Reproduce**
Steps to reproduce the behavior:
1. Submit a spark load job
2. The job state is `PENDDING` at the beginning.
3. cancel load job.
4. Show load. And you can see the job state is `CANCELLED` with msg `user cancel`
5. Open the web interface of the yarn cluster with browser, you can see that the spark job has been submitted successfully and is running well.

**Expected behavior**
The spark job should not be submmited.

**The reson of this Bug**
When a user wants to cancel a loadjob in the pending phase, it is possible that the `appId` in the SparkLoadJob is empty,  causing the yarn command to fail, so we need to get the `appId` through the handle.

If the `appId` still cannot be get from handle, which means the spark mission hasn't been submitted, the spark launcher process should be killed to prevent the spark mission from being submitted to yarn cluster.

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have create an issue on (Fix #4518 ), and have described the bug/feature there in detail
- [x] Compiling and unit tests pass locally with my changes
