### PR TITLE
Add a new  global variable  "performance_schema" to enable doris support Mysql JDBC 8.0.16 or later.#4537# 

### DIFF
--- a/docs/en/administrator-guide/variables.md
+++ b/docs/en/administrator-guide/variables.md
@@ -318,6 +318,10 @@ SET forward_to_master = concat('tr', 'u', 'e');
 * `version`
 
     Used for compatibility with MySQL clients. No practical effect.
+
+* `performance_schema`
+
+    Used for compatibility with MySQL JDBC 8.0.16 or later version. No practical effect.    
     
 * `version_comment`
 

--- a/docs/zh-CN/administrator-guide/variables.md
+++ b/docs/zh-CN/administrator-guide/variables.md
@@ -317,6 +317,10 @@ SET forward_to_master = concat('tr', 'u', 'e');
 * `version`
 
     用于兼容 MySQL 客户端。无实际作用。
+
+* `performance_schema`
+
+    用于兼容 8.0.16及以上版本的MySQL JDBC。无实际作用。     
     
 * `version_comment`
 

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/GlobalVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/GlobalVariable.java
@@ -40,6 +40,7 @@ public final class GlobalVariable {
     public static final String SYSTEM_TIME_ZONE = "system_time_zone";
     public static final String QUERY_CACHE_SIZE = "query_cache_size";
     public static final String DEFAULT_ROWSET_TYPE = "default_rowset_type";
+    public static final String PERFORMANCE_SCHEMA = "performance_schema";
 
     @VariableMgr.VarAttr(name = VERSION_COMMENT, flag = VariableMgr.READ_ONLY)
     public static String versionComment = "Doris version " + Version.DORIS_BUILD_VERSION;
@@ -73,6 +74,10 @@ public final class GlobalVariable {
 
     @VariableMgr.VarAttr(name = DEFAULT_ROWSET_TYPE, flag = VariableMgr.GLOBAL)
     public volatile static String defaultRowsetType = "alpha";
+
+    // add performance schema to support MYSQL JDBC 8.0.16 or later versions.
+    @VariableMgr.VarAttr(name = PERFORMANCE_SCHEMA, flag = VariableMgr.READ_ONLY)
+    public static String performanceSchema = "OFF";
 
     // Don't allow create instance.
     private GlobalVariable() {


### PR DESCRIPTION

Add a new global variable performance_schema to enable Doris can support Mysql jdbc 8.0.16 or later versions.

## Proposed changes

Add a  static field performanceSchema to the GlobalVariable class,  so that Doris can support MySQL JDBC 8.0.16 or later versions #4537#.

## Types of changes
- [] Bugfix (4537)

## Checklist
- [] I have create an issue on (Fix #4537), and have described the bug/feature there in detail

## Further comments
