### PR TITLE
[Bug] Fix bug that task_worker_pool not work

### DIFF
--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -192,8 +192,10 @@ void TaskWorkerPool::start() {
             .set_max_threads(_worker_count)
             .build(&_thread_pool);
 
-    auto st = _thread_pool->submit_func(cb);
-    CHECK(st.ok()) << st.to_string();
+    for (int i = 0; i < _worker_count; i++) {
+        auto st = _thread_pool->submit_func(cb);
+        CHECK(st.ok()) << st.to_string();
+    }
 #endif
 }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/SelectStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/SelectStmtTest.java
@@ -47,6 +47,7 @@ public class SelectStmtTest {
 
     @BeforeClass
     public static void setUp() throws Exception {
+        Config.enable_batch_delete_by_default = true;
         UtFrameUtils.createMinDorisCluster(runningDir);
         String createTblStmtStr = "create table db1.tbl1(k1 varchar(32), k2 varchar(32), k3 varchar(32), k4 int) "
                 + "AGGREGATE KEY(k1, k2,k3,k4) distributed by hash(k1) buckets 3 properties('replication_num' = '1');";

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/SelectStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/SelectStmtTest.java
@@ -18,6 +18,7 @@
 package org.apache.doris.analysis;
 
 import org.apache.doris.common.AnalysisException;
+import org.apache.doris.common.Config;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.planner.Planner;
 import org.apache.doris.qe.VariableMgr;


### PR DESCRIPTION
## Proposed changes

The number of thread initialized in task worker pool is not right.
This bug is introduced from #4440

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)