### PR TITLE
【Feature】Doris can  set default configuration of database data quota and replica quota #4540#

### DIFF
--- a/docs/en/administrator-guide/config/fe_config.md
+++ b/docs/en/administrator-guide/config/fe_config.md
@@ -691,3 +691,11 @@ Default is false.
 If this parameter is set to true, Doris can support ODBC external table creation and query. For specific usage of ODBC table, please refer to the use document of ODBC table
 
 The function is still in the experimental stage, so the default value is false.
+
+### `default_db_data_quota_bytes`
+
+Used to set default database quota size, default is 1T.
+
+### `default_db_replica_quota_bytes`
+
+Used to set default database replica quota size, default is 1G.

--- a/docs/en/administrator-guide/config/fe_config.md
+++ b/docs/en/administrator-guide/config/fe_config.md
@@ -694,7 +694,7 @@ The function is still in the experimental stage, so the default value is false.
 
 ### `default_db_data_quota_bytes`
 
-Used to set default database quota size, default is 1T.
+Used to set default database data quota size, default is 1T.
 
 ### `default_db_replica_quota_bytes`
 

--- a/docs/en/administrator-guide/config/fe_config.md
+++ b/docs/en/administrator-guide/config/fe_config.md
@@ -695,7 +695,3 @@ The function is still in the experimental stage, so the default value is false.
 ### `default_db_data_quota_bytes`
 
 Used to set default database data quota size, default is 1T.
-
-### `default_db_replica_quota_bytes`
-
-Used to set default database replica quota size, default is 1G.

--- a/docs/zh-CN/administrator-guide/config/fe_config.md
+++ b/docs/zh-CN/administrator-guide/config/fe_config.md
@@ -693,7 +693,3 @@ thrift_client_timeout_ms 的值被设置为大于0来避免线程卡在java.net.
 ### `default_db_data_quota_bytes`
 
 用于设置database data的默认quota值，单位为 bytes，默认1T.
-
-### `default_db_replica_quota_bytes`
-
-用于设置database replia的默认quota值，单位为 byte，默认1G.

--- a/docs/zh-CN/administrator-guide/config/fe_config.md
+++ b/docs/zh-CN/administrator-guide/config/fe_config.md
@@ -692,7 +692,7 @@ thrift_client_timeout_ms 的值被设置为大于0来避免线程卡在java.net.
 
 ### `default_db_data_quota_bytes`
 
-用于设置database的默认quota值，单位为 bytes，默认1T.
+用于设置database data的默认quota值，单位为 bytes，默认1T.
 
 ### `default_db_replica_quota_bytes`
 

--- a/docs/zh-CN/administrator-guide/config/fe_config.md
+++ b/docs/zh-CN/administrator-guide/config/fe_config.md
@@ -690,4 +690,10 @@ thrift_client_timeout_ms 的值被设置为大于0来避免线程卡在java.net.
 在该功能仍然在实验阶段，所以当前改参数默认为 false。
 
 
+### `default_db_data_quota_bytes`
 
+用于设置database的默认quota值，单位为 bytes，默认1T.
+
+### `default_db_replica_quota_bytes`
+
+用于设置database replia的默认quota值，单位为 byte，默认1G.

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Database.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Database.java
@@ -19,8 +19,8 @@ package org.apache.doris.catalog;
 
 import org.apache.doris.catalog.Table.TableType;
 import org.apache.doris.cluster.ClusterNamespace;
+import org.apache.doris.common.Config;
 import org.apache.doris.common.DdlException;
-import org.apache.doris.common.FeConstants;
 import org.apache.doris.common.FeMetaVersion;
 import org.apache.doris.common.Pair;
 import org.apache.doris.common.UserException;
@@ -111,8 +111,8 @@ public class Database extends MetaObject implements Writable {
         this.rwLock = new ReentrantReadWriteLock(true);
         this.idToTable = new ConcurrentHashMap<>();
         this.nameToTable = new HashMap<>();
-        this.dataQuotaBytes = FeConstants.default_db_data_quota_bytes;
-        this.replicaQuotaSize = FeConstants.default_db_replica_quota_size;
+        this.dataQuotaBytes = Config.default_db_data_quota_bytes;
+        this.replicaQuotaSize = Config.default_db_replica_quota_bytes;
         this.dbState = DbState.NORMAL;
         this.attachDbName = "";
         this.clusterName = "";
@@ -483,7 +483,7 @@ public class Database extends MetaObject implements Writable {
         if (Catalog.getCurrentCatalogJournalVersion() >= FeMetaVersion.VERSION_81) {
             replicaQuotaSize = in.readLong();
         } else {
-            replicaQuotaSize = FeConstants.default_db_replica_quota_size;
+            replicaQuotaSize = Config.default_db_replica_quota_bytes;
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Database.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Database.java
@@ -21,6 +21,7 @@ import org.apache.doris.catalog.Table.TableType;
 import org.apache.doris.cluster.ClusterNamespace;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.DdlException;
+import org.apache.doris.common.FeConstants;
 import org.apache.doris.common.FeMetaVersion;
 import org.apache.doris.common.Pair;
 import org.apache.doris.common.UserException;
@@ -112,7 +113,7 @@ public class Database extends MetaObject implements Writable {
         this.idToTable = new ConcurrentHashMap<>();
         this.nameToTable = new HashMap<>();
         this.dataQuotaBytes = Config.default_db_data_quota_bytes;
-        this.replicaQuotaSize = Config.default_db_replica_quota_bytes;
+        this.replicaQuotaSize = FeConstants.default_db_replica_quota_size;
         this.dbState = DbState.NORMAL;
         this.attachDbName = "";
         this.clusterName = "";
@@ -483,7 +484,7 @@ public class Database extends MetaObject implements Writable {
         if (Catalog.getCurrentCatalogJournalVersion() >= FeMetaVersion.VERSION_81) {
             replicaQuotaSize = in.readLong();
         } else {
-            replicaQuotaSize = Config.default_db_replica_quota_bytes;
+            replicaQuotaSize = FeConstants.default_db_replica_quota_size;
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/Config.java
@@ -1254,12 +1254,6 @@ public class Config extends ConfigBase {
     /**
      * Used to set default db data quota bytes.
      */
-    @ConfField(mutable = true, masterOnly = false)
+    @ConfField(mutable = true, masterOnly = true)
     public static long default_db_data_quota_bytes = 1024 * 1024 * 1024 * 1024L; // 1TB
-
-    /**
-     * Used to set default db replica quota bytes.
-     */
-    @ConfField(mutable = true, masterOnly = false)
-    public static long default_db_replica_quota_bytes = 1024 * 1024 * 1024;
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/Config.java
@@ -1250,4 +1250,16 @@ public class Config extends ConfigBase {
      */
     @ConfField(mutable = true, masterOnly = true)
     public static boolean enable_batch_delete_by_default = false;
+
+    /**
+     * Used to set default db data quota bytes.
+     */
+    @ConfField(mutable = true, masterOnly = false)
+    public static long default_db_data_quota_bytes = 1024 * 1024 * 1024 * 1024L; // 1TB
+
+    /**
+     * Used to set default db replica quota bytes.
+     */
+    @ConfField(mutable = true, masterOnly = false)
+    public static long default_db_replica_quota_bytes = 1024 * 1024 * 1024;
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/common/FeConstants.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/FeConstants.java
@@ -30,6 +30,7 @@ public class FeConstants {
      */
     public static int shortkey_max_column_count = 3;
     public static int shortkey_maxsize_bytes = 36;
+    public static long default_db_replica_quota_size = 1024 * 1024 * 1024;
 
     public static int heartbeat_interval_second = 5;
     public static int checkpoint_interval_second = 60; // 1 minutes

--- a/fe/fe-core/src/main/java/org/apache/doris/common/FeConstants.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/FeConstants.java
@@ -30,8 +30,6 @@ public class FeConstants {
      */
     public static int shortkey_max_column_count = 3;
     public static int shortkey_maxsize_bytes = 36;
-    public static long default_db_data_quota_bytes = 1024 * 1024 * 1024 * 1024L; // 1TB
-    public static long default_db_replica_quota_size = 1024 * 1024 * 1024;
 
     public static int heartbeat_interval_second = 5;
     public static int checkpoint_interval_second = 60; // 1 minutes


### PR DESCRIPTION
Doris can  set default configuration of database data quota and replica quota #4505#
## Proposed changes
When Doris create a  database, the database of data quota and replica quota is initialized by configuration(Config.default_db_data_quota_bytes and Config.default_db_replica_quota_bytes). In other words, I convert FeConstants.default_db_data_quota_bytes to Config.default_db_data_quota_bytes and convert FeConstants.default_db_replica_quota_size to Config.default_db_replica_quota_bytes. Config.default_db_data_quota_bytes and Config.default_db_replica_quota_bytes can be change in configuration file.

## Types of changes
What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [] Bugfix (non-breaking change which fixes an issue)
- [-] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [-] Documentation Update (if none of the other choices apply)
- [] Code refactor (Modify the code structure, format the code, etc...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [-] I have create an issue on (Fix #4540 ), and have described the bug/feature there in detail
- [-] Compiling and unit tests pass locally with my changes
- [] I have added tests that prove my fix is effective or that my feature works
- [-] If this change need a document change, I have updated the document
- [] Any dependent changes have been merged

## Further comments
