### PR TITLE
[Feature] FE add default configuration of max_fiter_ratio #4541#

### DIFF
--- a/docs/en/administrator-guide/config/fe_config.md
+++ b/docs/en/administrator-guide/config/fe_config.md
@@ -692,6 +692,13 @@ If this parameter is set to true, Doris can support ODBC external table creation
 
 The function is still in the experimental stage, so the default value is false.
 
+
 ### `default_db_data_quota_bytes`
 
 Used to set default database data quota size, default is 1T.
+
+
+### 'default_max_filter_ratio'
+
+Used to set default max filter ratio of load Job. It will be overridden by 'max_filter_ratio' of the load job properties，default value is 0, value range 0-1.
+

--- a/docs/zh-CN/administrator-guide/config/fe_config.md
+++ b/docs/zh-CN/administrator-guide/config/fe_config.md
@@ -693,3 +693,9 @@ thrift_client_timeout_ms 的值被设置为大于0来避免线程卡在java.net.
 ### `default_db_data_quota_bytes`
 
 用于设置database data的默认quota值，单位为 bytes，默认1T.
+
+### 'default_max_filter_ratio'
+
+默认的最大容忍可过滤（数据不规范等原因）的数据比例。它将被Load Job 中设置的"max_filter_ratio"覆盖，默认0，取值范围0-1.
+
+

--- a/fe/fe-core/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/Config.java
@@ -1256,4 +1256,11 @@ public class Config extends ConfigBase {
      */
     @ConfField(mutable = true, masterOnly = true)
     public static long default_db_data_quota_bytes = 1024 * 1024 * 1024 * 1024L; // 1TB
+
+    /*
+     * Maximum percentage of data that can be filtered (due to reasons such as data is irregulary)
+     * The default value is 0.
+     */
+    @ConfField(mutable = true, masterOnly = true)
+    public static double default_max_filter_ratio = 0;
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/load/LoadJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/LoadJob.java
@@ -74,7 +74,6 @@ public class LoadJob implements Writable {
     }
 
     private static final int DEFAULT_TIMEOUT_S = 0;
-    private static final double DEFAULT_MAX_FILTER_RATIO = 0;
     private static final long DEFAULT_EXEC_MEM_LIMIT = 2147483648L; // 2GB
 
     private long id;
@@ -85,7 +84,7 @@ public class LoadJob implements Writable {
     private long transactionId = -1;
     long timestamp;
     private int timeoutSecond;
-    private double maxFilterRatio;
+    private double maxFilterRatio = Config.default_max_filter_ratio;
     private JobState state;
 
     private BrokerDesc brokerDesc;
@@ -137,7 +136,7 @@ public class LoadJob implements Writable {
     }
 
     public LoadJob(String label) {
-        this(label, DEFAULT_TIMEOUT_S, DEFAULT_MAX_FILTER_RATIO);
+        this(label, DEFAULT_TIMEOUT_S, Config.default_max_filter_ratio);
     }
     
     // convert an async delete job to load job

--- a/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/LoadJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/LoadJob.java
@@ -99,7 +99,7 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
     // timeout second need to be reset in constructor of subclass
     protected long timeoutSecond = Config.broker_load_default_timeout_second;
     protected long execMemLimit = 2147483648L; // 2GB;
-    protected double maxFilterRatio = 0;
+    protected double maxFilterRatio = Config.default_max_filter_ratio;
     protected boolean strictMode = false; // default is false
     protected String timezone = TimeUtils.DEFAULT_TIME_ZONE;
     @Deprecated


### PR DESCRIPTION
Fe add default configuration of database data quota and replica quota #4541#

Proposed changes

Add default_max_filter_ratio configuration in Config.java. It will be overridden by 'max_filter_ratio' from the load job properties.
 So, if a load job set 'max_filter_ratio' properties, the 'max_filter_ratio' will effective, otherwise the max_filter_ratio of the load job will use 'default_max_filter_ratio'. We don't set 'max_filter_ratio' properties in each load statement.

Types of changes

[] Bugfix (non-breaking change which fixes an issue)
[-] New feature (non-breaking change which adds functionality  #4541#)
[] Breaking change (fix or feature that would cause existing functionality to not work as expected)
[-] Documentation Update (if none of the other choices apply)
[] Code refactor (Modify the code structure, format the code, etc...)

Checklist

[-] I have create an issue on (Fix #4541 ), and have described the bug/feature there in detail
[-] Compiling and unit tests pass locally with my changes
[] I have added tests that prove my fix is effective or that my feature works
[-] If this change need a document change, I have updated the document
[] Any dependent changes have been merged
