### PR TITLE
Fix null pointer when replay RollupJob

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/alter/RollupJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/RollupJob.java
@@ -903,6 +903,10 @@ public class RollupJob extends AlterJob {
         db.writeLock();
         try {
             OlapTable olapTable = (OlapTable) db.getTable(tableId);
+            if (olapTable == null) {
+                LOG.warn("table {} could not be found when replay rollup job", tableId);
+                return;
+            }
             olapTable.setState(OlapTableState.NORMAL);
         } finally {
             db.writeUnlock();


### PR DESCRIPTION


Change-Id: I302b554a94d42aee645db6b224cd989e00cd3ca6

## Proposed changes

When fe replay rollup job(v1) with deleted table, it will throw null pointer exception and exit.
This commit ignore this error and print a warning log to avoid fe exit.

Fixed #4571

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] Documentation Update (if none of the other choices apply)
- [] Code refactor (Modify the code structure, format the code, etc...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have create an issue on (Fix #ISSUE), and have described the bug/feature there in detail
- [] Compiling and unit tests pass locally with my changes
- [] I have added tests that prove my fix is effective or that my feature works
- [] If this change need a document change, I have updated the document
- [] Any dependent changes have been merged


