### PR TITLE
[Compile] Add pluginRepository for java-cup-plugins

### DIFF
--- a/docs/en/installing/compilation.md
+++ b/docs/en/installing/compilation.md
@@ -56,10 +56,12 @@ Note: For different versions of Oris, you need to download the corresponding mir
 
 	`$ docker run -it apachedoris/doris-dev:build-env`
 
-	If you want to compile the local Doris source code, you can mount the path:
+    It is recommended to run the container by mounting the local Doris source directory, so that the compiled binary file will be stored in the host machine and will not disappear because the container exits.
+
+     At the same time, it is recommended to mount the maven `.m2` directory in the mirror to the host directory at the same time to prevent repeated downloading of maven's dependent libraries each time the compilation is started.
 
     ```
-    $ docker run -it -v /your/local/incubator-doris-DORIS-x.x.x-release/:/root/incubator-doris-DORIS-x.x.x-release/ apachedoris/doris-dev:build-env
+    $ docker run -it -v /your/local/.m2:/root/.m2 -v /your/local/incubator-doris-DORIS-x.x.x-release/:/root/incubator-doris-DORIS-x.x.x-release/ apachedoris/doris-dev:build-env
     ```
 
 3. Download source code

--- a/docs/zh-CN/installing/compilation.md
+++ b/docs/zh-CN/installing/compilation.md
@@ -56,10 +56,12 @@ under the License.
 
     `$ docker run -it apachedoris/doris-dev:build-env`
     
-    如果你希望编译本地 Doris 源码，则可以挂载路径：
-    
+    建议以挂载本地 Doris 源码目录的方式运行镜像，这样编译的产出二进制文件会存储在宿主机中，不会因为镜像退出而消失。
+
+    同时，建议同时将镜像中 maven 的 `.m2` 目录挂载到宿主机目录，以防止每次启动镜像编译时，重复下载 maven 的依赖库。
+
     ```
-    $ docker run -it -v /your/local/incubator-doris-DORIS-x.x.x-release/:/root/incubator-doris-DORIS-x.x.x-release/ apachedoris/doris-dev:build-env
+    $ docker run -it -v /your/local/.m2:/root/.m2 -v /your/local/incubator-doris-DORIS-x.x.x-release/:/root/incubator-doris-DORIS-x.x.x-release/ apachedoris/doris-dev:build-env
     ```
     
 3. 下载源码

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -105,10 +105,14 @@ under the License.
             </repositories>
 
             <pluginRepositories>
-                <!-- for cup-maven-plugin -->
                 <pluginRepository>
                     <id>spring-plugins</id>
                     <url>https://repo.spring.io/plugins-release/</url>
+                </pluginRepository>
+                <!-- for cup-maven-plugin -->
+                <pluginRepository>
+                    <id>cloudera-plugins</id>
+                    <url>https://repository.cloudera.com/content/groups/public/</url>
                 </pluginRepository>
             </pluginRepositories>
         </profile>


### PR DESCRIPTION
## Proposed changes

the cup-maven-plugin of net.sourceforge.czt.dev is missing in maven central repo.
It has been moved to https://repository.cloudera.com/content/groups/public/

Fix #4637 

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)