### PR TITLE
[cache][be]Fix the bug of cross-border access cache

### DIFF
--- a/be/src/runtime/cache/result_node.cpp
+++ b/be/src/runtime/cache/result_node.cpp
@@ -167,14 +167,19 @@ PCacheStatus ResultNode::fetch_partition(const PFetchCacheRequest* request,
                    request->params(param_idx).partition_key() > (*part_it)->get_partition_key()) {
                 part_it++;
             }
-            while (param_idx < request->params_size() &&
-                   request->params(param_idx).partition_key() < (*part_it)->get_partition_key()) {
-                param_idx++;
-            }
-            if (request->params(param_idx).partition_key() == (*part_it)->get_partition_key()) {
-                find = true;
+            if (part_it != _partition_list.end()) {
+                while (param_idx < request->params_size() &&
+                        request->params(param_idx).partition_key() < (*part_it)->get_partition_key()) {
+                    param_idx++;
+                }
+                if (param_idx < request->params_size()) {
+                    if (request->params(param_idx).partition_key() == (*part_it)->get_partition_key()) {
+                        find = true;
+                    }
+                } 
             }
         }
+
         if (find) {
 #ifdef PARTITION_CACHE_DEV
             LOG(INFO) << "Find! Param index : " << param_idx

--- a/be/test/runtime/cache/partition_cache_test.cpp
+++ b/be/test/runtime/cache/partition_cache_test.cpp
@@ -192,6 +192,42 @@ TEST_F(PartitionCacheTest, fetch_range_data) {
     clear();
 }
 
+TEST_F(PartitionCacheTest, fetch_invalid_right_range) {
+    init_default();
+    init_batch_data(1, 1, 3);
+
+    set_sql_key(_fetch_request->mutable_sql_key(), 1, 1);
+    PCacheParam* p1 = _fetch_request->add_params();
+    p1->set_partition_key(4);
+    p1->set_last_version(4);
+    p1->set_last_version_time(4);
+    PCacheParam* p2 = _fetch_request->add_params();
+    p2->set_partition_key(5);
+    p2->set_last_version(5);
+    p2->set_last_version_time(5);
+    _cache->fetch(_fetch_request, _fetch_result);
+
+    ASSERT_TRUE(_fetch_result->status() == PCacheStatus::NO_PARTITION_KEY);
+    ASSERT_EQ(_fetch_result->values_size(), 0);
+    clear();
+}
+
+TEST_F(PartitionCacheTest, fetch_invalid_left_range) {
+    init_default();
+    init_batch_data(1, 1, 3);
+
+    set_sql_key(_fetch_request->mutable_sql_key(), 1, 1);
+    PCacheParam* p1 = _fetch_request->add_params();
+    p1->set_partition_key(0);
+    p1->set_last_version(0);
+    p1->set_last_version_time(0);
+    _cache->fetch(_fetch_request, _fetch_result);
+
+    ASSERT_TRUE(_fetch_result->status() == PCacheStatus::NO_PARTITION_KEY);
+    ASSERT_EQ(_fetch_result->values_size(), 0);
+    clear();
+}
+
 TEST_F(PartitionCacheTest, fetch_invalid_key_range) {
     init_default();
     init_batch_data(1, 2, 1);


### PR DESCRIPTION
## Proposed changes

Issue：#4592 

* When the different partition of the table is updated frequently, the partition key list of the cache is discontinuous, and the partition key in the request cannot hit the key list in the cache, resulting in the access overrun，the BE will crash.

* Add some unit test case，add test cases that fail to hit the boundary value of cache

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] Documentation Update (if none of the other choices apply)
- [] Code refactor (Modify the code structure, format the code, etc...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have create an issue on (Fix #ISSUE), and have described the bug/feature there in detail
- [x] Compiling and unit tests pass locally with my changes
- [] I have added tests that prove my fix is effective or that my feature works
- [] If this change need a document change, I have updated the document
- [] Any dependent changes have been merged

## Further comments

If this is a relatively large or complex change, kick off the discussion at dev@doris.apache.org by explaining why you chose the solution you did and what alternatives you considered, etc...
