### PR TITLE
[Bug] Fix analysis error when there are different types in case-when-then-else with group by clause

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/AggregateInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/AggregateInfo.java
@@ -662,8 +662,13 @@ public final class AggregateInfo extends AggregateInfoBase {
         exprs.addAll(aggregateExprs_);
         for (int i = 0; i < exprs.size(); ++i) {
             Expr expr = exprs.get(i);
-            outputTupleSmap_.put(expr.clone(),
-                    new SlotRef(outputTupleDesc_.getSlots().get(i)));
+            if (expr.isImplicitCast()) {
+                outputTupleSmap_.put(expr.getChild(0).clone(),
+                        new SlotRef(outputTupleDesc_.getSlots().get(i)));
+            } else {
+                outputTupleSmap_.put(expr.clone(),
+                        new SlotRef(outputTupleDesc_.getSlots().get(i)));
+            }
             if (!requiresIntermediateTuple()) continue;
 
             intermediateTupleSmap_.put(expr.clone(),

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/SlotRef.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/SlotRef.java
@@ -93,7 +93,6 @@ public class SlotRef extends Expr {
     }
 
     public SlotDescriptor getDesc() {
-        Preconditions.checkState(isAnalyzed);
         Preconditions.checkNotNull(desc);
         return desc;
     }

--- a/fe/fe-core/src/test/java/org/apache/doris/planner/QueryPlanTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/planner/QueryPlanTest.java
@@ -906,6 +906,18 @@ public class QueryPlanTest {
         // 4.2.1 test null in when expr
         String sql421 = "select case 'a' when null then 'a' else 'other' end as col421";
         Assert.assertTrue(StringUtils.containsIgnoreCase(UtFrameUtils.getSQLPlanOrErrorMsg(connectContext, "explain " + sql421), "constant exprs: \n         'other'"));
+
+        String sql51 = "select case when 132 then k7 else 'all' end as col51 from test.baseall group by col51";
+        Assert.assertTrue(StringUtils.containsIgnoreCase(UtFrameUtils.getSQLPlanOrErrorMsg(connectContext, "explain " + sql51),
+                "OUTPUT EXPRS: CASE WHEN 132 THEN `k7` ELSE 'all' END"));
+
+        String sql52 = "select case when 2 < 1 then 'all' else k7 end as col52 from test.baseall group by col52";
+        Assert.assertTrue(StringUtils.containsIgnoreCase(UtFrameUtils.getSQLPlanOrErrorMsg(connectContext, "explain " + sql52),
+                "OUTPUT EXPRS: `k7`"));
+
+        String sql53 = "select case when 2 < 1 then 'all' else k1 end as col53 from test.baseall group by col53";
+        Assert.assertTrue(StringUtils.containsIgnoreCase(UtFrameUtils.getSQLPlanOrErrorMsg(connectContext, "explain " + sql53),
+                "OUTPUT EXPRS:<slot 0> `k1`"));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/planner/QueryPlanTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/planner/QueryPlanTest.java
@@ -907,14 +907,17 @@ public class QueryPlanTest {
         String sql421 = "select case 'a' when null then 'a' else 'other' end as col421";
         Assert.assertTrue(StringUtils.containsIgnoreCase(UtFrameUtils.getSQLPlanOrErrorMsg(connectContext, "explain " + sql421), "constant exprs: \n         'other'"));
 
+        // 5.1 test same type in then expr and else expr
         String sql51 = "select case when 132 then k7 else 'all' end as col51 from test.baseall group by col51";
         Assert.assertTrue(StringUtils.containsIgnoreCase(UtFrameUtils.getSQLPlanOrErrorMsg(connectContext, "explain " + sql51),
                 "OUTPUT EXPRS: CASE WHEN 132 THEN `k7` ELSE 'all' END"));
 
+        // 5.2 test same type in then expr and else expr
         String sql52 = "select case when 2 < 1 then 'all' else k7 end as col52 from test.baseall group by col52";
         Assert.assertTrue(StringUtils.containsIgnoreCase(UtFrameUtils.getSQLPlanOrErrorMsg(connectContext, "explain " + sql52),
                 "OUTPUT EXPRS: `k7`"));
 
+        // 5.3 test different in then expr and else expr, and return CastExpr<SlotRef>
         String sql53 = "select case when 2 < 1 then 'all' else k1 end as col53 from test.baseall group by col53";
         Assert.assertTrue(StringUtils.containsIgnoreCase(UtFrameUtils.getSQLPlanOrErrorMsg(connectContext, "explain " + sql53),
                 "OUTPUT EXPRS:<slot 0> `k1`"));


### PR DESCRIPTION
## Proposed changes

Fix #4645 

Relevant pr https://github.com/apache/incubator-doris/pull/3396

**To Reproduce**
Steps to reproduce the behavior:
1. create table

```
+----------------------+-------------+------+-------+---------------------+---------+
| Field                | Type        | Null | Key   | Default             | Extra   |
+----------------------+-------------+------+-------+---------------------+---------+
| event_day            | INT         | No   | true  | NULL                |         |
| event_hour           | TINYINT     | No   | true  | 0                   |         |
| event_minute         | TINYINT     | No   | true  | 0                   |         |
| event_time           | DATETIME    | No   | true  | 1970-01-01 00:00:00 |         |
| search_page          | VARCHAR(30) | No   | true  |                     |         |
| search_source        | TINYINT     | No   | true  | 0                   |         |
| soft_version         | VARCHAR(30) | No   | true  |                     |         |
| not_arrived_category | VARCHAR(30) | No   | true  |                     |         |
| pv                   | FLOAT       | No   | false | 0                   | REPLACE |
+----------------------+-------------+------+-------+---------------------+---------+
```

```
CREATE TABLE `test_tbl` (
  `event_day` int(11) NOT NULL COMMENT "日期,如20191016",
  `event_hour` tinyint(4) NOT NULL DEFAULT "0" COMMENT "小时,如8",
  `event_minute` tinyint(4) NOT NULL DEFAULT "0" COMMENT "分钟,如59",
  `event_time` datetime NOT NULL DEFAULT "1970-01-01 00:00:00" COMMENT "隶属时间(区间查询用)",
  `search_page` varchar(30) NOT NULL DEFAULT "" COMMENT "page来源",
  `search_source` tinyint(4) NOT NULL DEFAULT "0" COMMENT "search_source来源",
  `soft_version` varchar(30) NOT NULL DEFAULT "" COMMENT "APP版本,如11.15.0.2",
  `not_arrived_category` varchar(30) NOT NULL DEFAULT "" COMMENT "未到达原因",
  `pv` float NOT NULL DEFAULT "0" COMMENT "聚合pv数"
) ENGINE=OLAP
UNIQUE KEY(`event_day`, `event_hour`, `event_minute`, `event_time`, `search_page`, `search_source`, `soft_version`, `not_arrived_category`)
COMMENT "OLAP"
PARTITION BY RANGE(`event_day`)
(PARTITION p202006 VALUES [("20200601"), ("20200701")),
PARTITION p202007 VALUES [("20200701"), ("20200801")),
PARTITION p202008 VALUES [("20200801"), ("20200901")),
PARTITION p202009 VALUES [("20200901"), ("20201001")),
PARTITION p202010 VALUES [("20201001"), ("20201101")),
PARTITION p202011 VALUES [("20201101"), ("20201201")),
PARTITION p202012 VALUES [("20201201"), ("20210101")))
DISTRIBUTED BY HASH(`event_day`) BUCKETS 16
PROPERTIES (
"replication_num" = "3",
"in_memory" = "false",
"storage_format" = "V2"
);
```

2. input sql

```
    SELECT
        case when "condition" = ' ' then 'string' else search_source end as search_source
    FROM test_tbl
    GROUP BY search_source
```

3. doris report an analysis error.

In the sql above, search_source is a `TINYINT` type and 'string' is `VARCHAR(*)` type. Because the value of WhenExpr `"condition" = ' '` is false, so this case-when clause will produce a CastExpr as SelectListItem with a `TINYINT` type SlotRef child represents `search_source` after rewriting the sql. However, the analyzeAggregation() method cannot handle the case where SelectListItem is CaseExpr(implicitCast).

**Expected behavior**
Analysis successfully.


## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have create an issue on (Fix #4645 ), and have described the bug/feature there in detail
- [x] Compiling and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works

## Further comments

If this is a relatively large or complex change, kick off the discussion at dev@doris.apache.org by explaining why you chose the solution you did and what alternatives you considered, etc...
