### PR TITLE
[Bug]External engines(e.g. ES) don't have segments, ignore those tables

### DIFF
--- a/tools/show_segment_status/fe_meta_resolver.py
+++ b/tools/show_segment_status/fe_meta_resolver.py
@@ -110,12 +110,13 @@ class FeMetaResolver:
         self.exec_sql(sql);
         table_list = self.cur.fetchall()
         for table_tuple in table_list :
-            table = {}
-            table['db_id'] = db['db_id'] 
-            table['db_name'] = db['db_name'] 
-            table['tbl_id'] = long(table_tuple[0])
-            table['tbl_name'] = table_tuple[1]
-            self.table_list.append(table)
+            if table_tuple[6] == "OLAP":
+                table = {}
+                table['db_id'] = db['db_id'] 
+                table['db_name'] = db['db_name'] 
+                table['tbl_id'] = long(table_tuple[0])
+                table['tbl_name'] = table_tuple[1]
+                self.table_list.append(table)
         return
 
     def fetch_rollup_map(self):


### PR DESCRIPTION
It will crash when there are External engine tables in doris after executing "python show_segment_status.py"
The main reason is external engine tables don't have any index and partitions. So it should be ignored. 


