### PR TITLE
[Bug] Fix hard cardinality check which makes queries fail

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/planner/PlanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/PlanNode.java
@@ -428,6 +428,9 @@ abstract public class PlanNode extends TreeNode<PlanNode> {
     protected double computeSelectivity() {
         double prod = 1.0;
         for (Expr e : conjuncts) {
+            if (e.getSelectivity() < 0) {
+                return -1.0;
+            }
             prod *= e.getSelectivity();
         }
         return prod;

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/SelectNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/SelectNode.java
@@ -69,7 +69,7 @@ public class SelectNode extends PlanNode {
         } else {
             this.cardinality = Math.round(cardinality * selectivity);
         }
-        LOG.info("stats Select: cardinality={}", this.cardinality);
+        LOG.debug("stats Select: cardinality={}", this.cardinality);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/SelectNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/SelectNode.java
@@ -24,7 +24,6 @@ import org.apache.doris.analysis.Expr;
 import org.apache.doris.thrift.TExplainLevel;
 import org.apache.doris.thrift.TPlanNode;
 import org.apache.doris.thrift.TPlanNodeType;
-import com.google.common.base.Preconditions;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
 import java.util.List;
@@ -63,13 +62,14 @@ public class SelectNode extends PlanNode {
     @Override
     public void computeStats(Analyzer analyzer) {
         super.computeStats(analyzer);
-        if (getChild(0).cardinality == -1) {
-            cardinality = -1;
+        long cardinality = getChild(0).cardinality;
+        double selectivity = computeSelectivity();
+        if (cardinality < 0 || selectivity < 0) {
+            this.cardinality = -1;
         } else {
-            cardinality = Math.round(((double) getChild(0).cardinality) * computeSelectivity());
-            Preconditions.checkState(cardinality >= 0);
+            this.cardinality = Math.round(cardinality * selectivity);
         }
-        LOG.info("stats Select: cardinality=" + Long.toString(cardinality));
+        LOG.info("stats Select: cardinality={}", this.cardinality);
     }
 
     @Override


### PR DESCRIPTION
## Proposed changes

#4581
fix hard `Preconditions.checkState()` by setting `cardinality` to `-1` when computation is invalid.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] Documentation Update (if none of the other choices apply)
- [] Code refactor (Modify the code structure, format the code, etc...)

## Checklist

- [x] I have create an issue on (Fix #4581), and have described the bug/feature there in detail
- [x] Compiling and unit tests pass locally with my changes
- [] I have added tests that prove my fix is effective or that my feature works
- [] If this change need a document change, I have updated the document
- [x] Any dependent changes have been merged
