### PR TITLE
[Bug] Fix duplicate columns in case when statement

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/CaseExpr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/CaseExpr.java
@@ -281,6 +281,13 @@ public class CaseExpr extends Expr {
         LiteralExpr caseExpr;
         int startIndex = 0;
         int endIndex = expr.getChildren().size();
+
+        for (Expr child : expr.getChildren()) {
+            if (child instanceof CastExpr && (child.getChild(0) instanceof SlotRef)) {
+                child.resetAnalysisState();
+            }
+        }
+
         if (expr.hasCaseExpr()) {
             // just deal literal here
             // and avoid `float compute` in java,float should be dealt in be

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/CaseExpr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/CaseExpr.java
@@ -282,6 +282,7 @@ public class CaseExpr extends Expr {
         int startIndex = 0;
         int endIndex = expr.getChildren().size();
 
+        // CastExpr with SlotRef child should be reset to re-analyze in selectListItem
         for (Expr child : expr.getChildren()) {
             if (child instanceof CastExpr && (child.getChild(0) instanceof SlotRef)) {
                 child.resetAnalysisState();

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/CaseExpr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/CaseExpr.java
@@ -282,10 +282,14 @@ public class CaseExpr extends Expr {
         int startIndex = 0;
         int endIndex = expr.getChildren().size();
 
-        // CastExpr with SlotRef child should be reset to re-analyze in selectListItem
+        // CastExpr contains SlotRef child should be reset to re-analyze in selectListItem
         for (Expr child : expr.getChildren()) {
-            if (child instanceof CastExpr && (child.getChild(0) instanceof SlotRef)) {
-                child.resetAnalysisState();
+            if (child instanceof CastExpr && (child.contains(SlotRef.class))) {
+                List<CastExpr> castExprList = Lists.newArrayList();
+                child.collect(CastExpr.class, castExprList);
+                for (CastExpr castExpr : castExprList) {
+                    castExpr.resetAnalysisState();
+                }
             }
         }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/CastExpr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/CastExpr.java
@@ -207,7 +207,9 @@ public class CastExpr extends Expr {
 
     @Override
     public void analyzeImpl(Analyzer analyzer) throws AnalysisException {
-        Preconditions.checkState(!isImplicit);
+        if (isImplicit) {
+            return;
+        }
         // When cast target type is string and it's length is default -1, the result length
         // of cast is decided by child.
         if (targetTypeDef.getType().isScalarType()) {

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/SlotRef.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/SlotRef.java
@@ -93,6 +93,7 @@ public class SlotRef extends Expr {
     }
 
     public SlotDescriptor getDesc() {
+        Preconditions.checkState(isAnalyzed);
         Preconditions.checkNotNull(desc);
         return desc;
     }

--- a/fe/fe-core/src/test/java/org/apache/doris/planner/QueryPlanTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/planner/QueryPlanTest.java
@@ -926,6 +926,11 @@ public class QueryPlanTest {
         String sql54 = "select k2, case when 2 < 1 then 'all' else k1 end as col54, k7 from test.baseall group by k2, col54, k7";
         Assert.assertTrue(StringUtils.containsIgnoreCase(UtFrameUtils.getSQLPlanOrErrorMsg(connectContext, "explain " + sql54),
                 "OUTPUT EXPRS:<slot 3> `k2` | <slot 4> `k1` | <slot 5> `k7`"));
+
+        // 5.5 test return CastExpr<CastExpr<SlotRef>> with other SlotRef in selectListItem
+        String sql55 = "select case when 2 < 1 then 'all' else cast(k1 as int) end as col55, k7 from test.baseall group by col55, k7";
+        Assert.assertTrue(StringUtils.containsIgnoreCase(UtFrameUtils.getSQLPlanOrErrorMsg(connectContext, "explain " + sql55),
+                "OUTPUT EXPRS:<slot 2> CAST(`k1` AS INT) | <slot 3> `k7`"));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/planner/QueryPlanTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/planner/QueryPlanTest.java
@@ -917,10 +917,15 @@ public class QueryPlanTest {
         Assert.assertTrue(StringUtils.containsIgnoreCase(UtFrameUtils.getSQLPlanOrErrorMsg(connectContext, "explain " + sql52),
                 "OUTPUT EXPRS: `k7`"));
 
-        // 5.3 test different in then expr and else expr, and return CastExpr<SlotRef>
+        // 5.3 test different type in then expr and else expr, and return CastExpr<SlotRef>
         String sql53 = "select case when 2 < 1 then 'all' else k1 end as col53 from test.baseall group by col53";
         Assert.assertTrue(StringUtils.containsIgnoreCase(UtFrameUtils.getSQLPlanOrErrorMsg(connectContext, "explain " + sql53),
-                "OUTPUT EXPRS:<slot 0> `k1`"));
+                "OUTPUT EXPRS: `k1`"));
+
+        // 5.4 test return CastExpr<SlotRef> with other SlotRef in selectListItem
+        String sql54 = "select k2, case when 2 < 1 then 'all' else k1 end as col54, k7 from test.baseall group by k2, col54, k7";
+        Assert.assertTrue(StringUtils.containsIgnoreCase(UtFrameUtils.getSQLPlanOrErrorMsg(connectContext, "explain " + sql54),
+                "OUTPUT EXPRS:<slot 3> `k2` | <slot 4> `k1` | <slot 5> `k7`"));
     }
 
     @Test


### PR DESCRIPTION
## Proposed changes

Fix #4692 
The reason of this bug is case-when statement may produce implicit CastExpr\<SlotRef\> as SelectListItem in analyze step.
And these CastExpr\<SlotRef\> in SelectList will not be re-anlyze after rewrite step, which will result in the incorrect number of self-incrementing SlotDescriptor ID in resultExprs .

So we need to reset the analysis state of CastExpr\<SlotRef\> in rewrite step.

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have create an issue on (Fix #4692 ), and have described the bug/feature there in detail
- [x] Compiling and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
