### PR TITLE
[Bug] Fix bug that tablet report always out of date

### DIFF
--- a/be/src/agent/cgroups_mgr.cpp
+++ b/be/src/agent/cgroups_mgr.cpp
@@ -347,8 +347,8 @@ AgentStatus CgroupsMgr::init_cgroups() {
             _is_cgroups_init_success = true;
             return AgentStatus::DORIS_SUCCESS;
     } else {
-        LOG(ERROR) << "Could not find a valid cgroups path for resource isolation,"
-            << "current value is " << _root_cgroups_path;
+        LOG(WARNING) << "Could not find a valid cgroups path for resource isolation,"
+            << "current value is " << _root_cgroups_path << ". ignore it.";
         _is_cgroups_init_success = false;
         return AgentStatus::DORIS_ERROR;
     }

--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -1086,7 +1086,6 @@ void TaskWorkerPool::_report_tablet_worker_thread_callback() {
     TReportRequest request;
     request.__set_backend(_backend);
     request.__isset.tablets = true;
-    request.__set_report_version(_s_report_version);
 
     while (_is_work) {
         if (_master_info.network_address.port == 0) {
@@ -1116,6 +1115,7 @@ void TaskWorkerPool::_report_tablet_worker_thread_callback() {
                 std::max(DorisMetrics::instance()->tablet_cumulative_max_compaction_score->value(),
                          DorisMetrics::instance()->tablet_base_max_compaction_score->value());
         request.__set_tablet_max_compaction_score(max_compaction_score);
+        request.__set_report_version(_s_report_version);
 
         TMasterResult result;
         AgentStatus status = _master_client->report(request, &result);

--- a/fe/fe-core/src/main/java/org/apache/doris/load/Load.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/Load.java
@@ -2020,6 +2020,8 @@ public class Load {
                 jobInfo.add(TimeUtils.longToTimeString(loadJob.getLoadFinishTimeMs()));
                 // tracking url
                 jobInfo.add(status.getTrackingUrl());
+                // job details
+                jobInfo.add("");
 
                 loadJobInfos.add(jobInfo);
             } // end for loadJobs

--- a/thirdparty/vars.sh
+++ b/thirdparty/vars.sh
@@ -55,7 +55,7 @@ export TP_JAR_DIR=$TP_INSTALL_DIR/lib/jar
 # libevent
 # the last release version of libevent is 2.1.8, which was released on 26 Jan 2017, that is too old.
 # so we use the master version of libevent, which is downloaded on 22 Jun 2018, with commit 24236aed01798303745470e6c498bf606e88724a
-LIBEVENT_DOWNLOAD="https://doris-incubating-repo.bj.bcebos.com/thirdparty/libevent-20180622-24236aed01798303745470e6c498bf606e88724a.zip"
+LIBEVENT_DOWNLOAD="https://doris-thirdparty-repo.bj.bcebos.com/thirdparty/libevent-20180622-24236aed01798303745470e6c498bf606e88724a.zip"
 LIBEVENT_NAME=libevent-20180622-24236aed01798303745470e6c498bf606e88724a.zip
 LIBEVENT_SOURCE=libevent-master
 LIBEVENT_MD5SUM="e8b9ba50270ba3b520aec8ff1089f9d7"


### PR DESCRIPTION
## Proposed changes

This is because the report version is not set correctly in the tablet report request.

Also modify the download url of libevent Fix #4689 Fix #4691 

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have create an issue on (Fix #4694 ), and have described the bug/feature there in detail