### PR TITLE
[ODBC/MySQL] Support Limit Clause Push Down For ODBC Table And MySQL Table(#4706)

### DIFF
--- a/be/src/exec/mysql_scan_node.cpp
+++ b/be/src/exec/mysql_scan_node.cpp
@@ -116,7 +116,8 @@ Status MysqlScanNode::open(RuntimeState* state) {
     RETURN_IF_CANCELLED(state);
     SCOPED_TIMER(_runtime_profile->total_time_counter());
     RETURN_IF_ERROR(_mysql_scanner->open());
-    RETURN_IF_ERROR(_mysql_scanner->query(_table_name, _columns, _filters));
+    RETURN_IF_ERROR(_mysql_scanner->query(_table_name, _columns, _filters, _limit));
+
     // check materialize slot num
     int materialize_num = 0;
 
@@ -161,11 +162,6 @@ Status MysqlScanNode::get_next(RuntimeState* state, RowBatch* row_batch, bool* e
     SCOPED_TIMER(_runtime_profile->total_time_counter());
     SCOPED_TIMER(materialize_tuple_timer());
 
-    if (reached_limit()) {
-        *eos = true;
-        return Status::OK();
-    }
-
     // create new tuple buffer for row_batch
     int tuple_buffer_size = row_batch->capacity() * _tuple_desc->byte_size();
     void* tuple_buffer = _tuple_pool->allocate(tuple_buffer_size);
@@ -181,11 +177,10 @@ Status MysqlScanNode::get_next(RuntimeState* state, RowBatch* row_batch, bool* e
     while (true) {
         RETURN_IF_CANCELLED(state);
 
-        if (reached_limit() || row_batch->is_full()) {
+        if (row_batch->is_full()) {
             // hang on to last allocated chunk in pool, we'll keep writing into it in the
             // next get_next() call
             row_batch->tuple_data_pool()->acquire_data(_tuple_pool.get(), !reached_limit());
-            *eos = reached_limit();
             return Status::OK();
         }
 

--- a/be/src/exec/mysql_scanner.cpp
+++ b/be/src/exec/mysql_scanner.cpp
@@ -111,7 +111,7 @@ Status MysqlScanner::query(const std::string& query) {
 }
 
 Status MysqlScanner::query(const std::string& table, const std::vector<std::string>& fields,
-                           const std::vector<std::string>& filters) {
+                           const std::vector<std::string>& filters, const uint64_t limit) {
     if (!_is_open) {
         return Status::InternalError("Query before open.");
     }
@@ -138,6 +138,10 @@ Status MysqlScanner::query(const std::string& table, const std::vector<std::stri
 
             _sql_str += " (" + filters[i] + ") ";
         }
+    }
+
+    if (limit != -1) {
+        _sql_str += " LIMIT " + std::to_string(limit);
     }
 
     return query(_sql_str);

--- a/be/src/exec/mysql_scanner.h
+++ b/be/src/exec/mysql_scanner.h
@@ -56,7 +56,7 @@ public:
 
     // query for DORIS
     Status query(const std::string& table, const std::vector<std::string>& fields,
-                 const std::vector<std::string>& filters);
+                 const std::vector<std::string>& filters, const uint64_t limit);
     Status get_next_row(char** *buf, unsigned long** lengths, bool* eos);
 
     int field_num() const {

--- a/be/src/exec/odbc_scan_node.cpp
+++ b/be/src/exec/odbc_scan_node.cpp
@@ -34,9 +34,9 @@ OdbcScanNode::OdbcScanNode(ObjectPool* pool, const TPlanNode& tnode,
         : ScanNode(pool, tnode, descs),
           _is_init(false),
           _table_name(tnode.odbc_scan_node.table_name),
+          _connect_string(std::move(tnode.odbc_scan_node.connect_string)),
+          _query_string(std::move(tnode.odbc_scan_node.query_string)),
           _tuple_id(tnode.odbc_scan_node.tuple_id),
-          _columns(tnode.odbc_scan_node.columns),
-          _filters(tnode.odbc_scan_node.filters),
           _tuple_desc(nullptr) {
 }
 
@@ -63,21 +63,9 @@ Status OdbcScanNode::prepare(RuntimeState* state) {
     }
 
     _slot_num = _tuple_desc->slots().size();
-    // get odbc table info
-    const ODBCTableDescriptor* odbc_table =
-            static_cast<const ODBCTableDescriptor*>(_tuple_desc->table_desc());
 
-    if (NULL == odbc_table) {
-        return Status::InternalError("odbc table pointer is NULL.");
-    }
-
-    _odbc_param.host = odbc_table->host();
-    _odbc_param.port = odbc_table->port();
-    _odbc_param.user = odbc_table->user();
-    _odbc_param.passwd = odbc_table->passwd();
-    _odbc_param.db = odbc_table->db();
-    _odbc_param.drivier = odbc_table->driver();
-    _odbc_param.type = odbc_table->type();
+    _odbc_param.connect_string = std::move(_connect_string);
+    _odbc_param.query_string = std::move(_query_string);
     _odbc_param.tuple_desc = _tuple_desc;
 
     _odbc_scanner.reset(new (std::nothrow)ODBCScanner(_odbc_param));
@@ -119,7 +107,7 @@ Status OdbcScanNode::open(RuntimeState* state) {
     RETURN_IF_CANCELLED(state);
     SCOPED_TIMER(_runtime_profile->total_time_counter());
     RETURN_IF_ERROR(_odbc_scanner->open());
-    RETURN_IF_ERROR(_odbc_scanner->query(_table_name, _columns, _filters));
+    RETURN_IF_ERROR(_odbc_scanner->query());
     // check materialize slot num
 
     return Status::OK();
@@ -153,11 +141,6 @@ Status OdbcScanNode::get_next(RuntimeState* state, RowBatch* row_batch, bool* eo
     SCOPED_TIMER(_runtime_profile->total_time_counter());
     SCOPED_TIMER(materialize_tuple_timer());
 
-    if (reached_limit()) {
-        *eos = true;
-        return Status::OK();
-    }
-
     // create new tuple buffer for row_batch
     int tuple_buffer_size = row_batch->capacity() * _tuple_desc->byte_size();
     void* tuple_buffer = _tuple_pool->allocate(tuple_buffer_size);
@@ -173,11 +156,10 @@ Status OdbcScanNode::get_next(RuntimeState* state, RowBatch* row_batch, bool* eo
     while (true) {
         RETURN_IF_CANCELLED(state);
 
-        if (reached_limit() || row_batch->is_full()) {
+        if (row_batch->is_full()) {
             // hang on to last allocated chunk in pool, we'll keep writing into it in the
             // next get_next() call
             row_batch->tuple_data_pool()->acquire_data(_tuple_pool.get(), !reached_limit());
-            *eos = reached_limit();
             return Status::OK();
         }
 
@@ -238,8 +220,6 @@ Status OdbcScanNode::get_next(RuntimeState* state, RowBatch* row_batch, bool* eo
             _tuple = reinterpret_cast<Tuple*>(new_tuple);
         }
     }
-
-    return Status::OK();
 }
 
 Status OdbcScanNode::close(RuntimeState* state) {

--- a/be/src/exec/odbc_scan_node.h
+++ b/be/src/exec/odbc_scan_node.h
@@ -68,13 +68,12 @@ private:
     // Name of Odbc table
     std::string _table_name;
 
+    std::string _connect_string;
+
+    std::string _query_string;
     // Tuple id resolved in prepare() to set _tuple_desc;
     TupleId _tuple_id;
 
-    // select columns
-    std::vector<std::string> _columns;
-    // where clause
-    std::vector<std::string> _filters;
 
     // Descriptor of tuples read from ODBC table.
     const TupleDescriptor* _tuple_desc;

--- a/be/src/exec/odbc_scanner.h
+++ b/be/src/exec/odbc_scanner.h
@@ -32,15 +32,9 @@
 namespace doris {
 
 struct ODBCScannerParam {
-    std::string host;
-    std::string port;
-    std::string user;
-    std::string passwd;
-    std::string db;
-    std::string drivier;
-    std::string charest = "utf8";
+    std::string connect_string;
+    std::string query_string;
 
-    TOdbcTableType::type type;
     const TupleDescriptor* tuple_desc;
 };
 
@@ -67,11 +61,8 @@ public:
 
     Status open();
 
-    Status query(const std::string& query);
-
-    // query for DORIS
-    Status query(const std::string& table, const std::vector<std::string>& fields,
-                 const std::vector<std::string>& filters);
+    // query for ODBC table
+    Status query();
 
     Status get_next_row(bool* eos);
 
@@ -80,8 +71,6 @@ public:
     }
 
 private:
-    static std::string build_connect_string(const ODBCScannerParam& param);
-
     static Status error_status(const std::string& prefix, const std::string& error_msg);
 
     static std::string handle_diagnostic_record (SQLHANDLE      hHandle,
@@ -90,7 +79,6 @@ private:
 
     std::string _connect_string;
     std::string _sql_str;
-    TOdbcTableType::type _type;
     const TupleDescriptor* _tuple_desc;
 
     bool _is_open;

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/OdbcTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/OdbcTable.java
@@ -59,8 +59,6 @@ public class OdbcTable extends Table {
     static {
         Map<String, TOdbcTableType> tempMap = new HashMap<>();
         tempMap.put("oracle", TOdbcTableType.ORACLE);
-        // we will support mysql driver in the future after we solve the core problem of
-        // driver and static library
         tempMap.put("mysql", TOdbcTableType.MYSQL);
         TABLE_TYPE_MAP = Collections.unmodifiableMap(tempMap);
     }
@@ -242,6 +240,36 @@ public class OdbcTable extends Table {
             return odbcTableTypeName;
         }
         return getPropertyFromResource(ODBC_TYPE);
+    }
+
+    public String getConnectString() {
+        String connectString = "";
+        // different database have different connection string
+        switch (getOdbcTableType()) {
+            case ORACLE:
+                connectString = String.format("Driver=%s;Dbq=//%s:%s/%s;DataBase=%s;Uid=%s;Pwd=%s;charset=%s",
+                        getOdbcDriver(),
+                        getHost(),
+                        getPort(),
+                        getOdbcDatabaseName(),
+                        getOdbcDatabaseName(),
+                        getUserName(),
+                        getPasswd(),
+                        "utf8");
+                break;
+            case MYSQL:
+                connectString = String.format("Driver=%s;Server=%s;Port=%s;DataBase=%s;Uid=%s;Pwd=%s;charset=%s",
+                        getOdbcDriver(),
+                        getHost(),
+                        getPort(),
+                        getOdbcDatabaseName(),
+                        getUserName(),
+                        getPasswd(),
+                        "utf8");
+                break;
+            default:
+        }
+        return connectString;
     }
 
     public TOdbcTableType getOdbcTableType() {

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/MysqlScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/MysqlScanNode.java
@@ -92,6 +92,11 @@ public class MysqlScanNode extends ScanNode {
             sql.append(Joiner.on(") AND (").join(filters));
             sql.append(")");
         }
+
+        if (limit != -1) {
+            sql.append(" LIMIT " + limit);
+        }
+
         return sql.toString();
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/planner/QueryPlanTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/planner/QueryPlanTest.java
@@ -1129,6 +1129,26 @@ public class QueryPlanTest {
     }
 
     @Test
+    public void testLimitOfExternalTable() throws Exception {
+        connectContext.setDatabase("default_cluster:test");
+
+        // ODBC table (MySQL)
+        String queryStr = "explain select * from odbc_mysql where k1 > 10 and abs(k1) > 10 limit 10";
+        String explainString = UtFrameUtils.getSQLPlanOrErrorMsg(connectContext, queryStr);
+        Assert.assertTrue(explainString.contains("LIMIT 10"));
+
+        // ODBC table (Oracle)
+        queryStr = "explain select * from odbc_oracle where k1 > 10 and abs(k1) > 10 limit 10";
+        explainString = UtFrameUtils.getSQLPlanOrErrorMsg(connectContext, queryStr);
+        Assert.assertTrue(explainString.contains("ROWNUM <= 10"));
+
+        // MySQL table
+        queryStr = "explain select * from mysql_table where k1 > 10 and abs(k1) > 10 limit 10";
+        explainString = UtFrameUtils.getSQLPlanOrErrorMsg(connectContext, queryStr);
+        Assert.assertTrue(explainString.contains("LIMIT 10"));
+    }
+
+    @Test
     public void testPreferBroadcastJoin() throws Exception {
         connectContext.setDatabase("default_cluster:test");
         String queryStr = "explain select * from (select k1 from jointest group by k1)t2, jointest t1 where t1.k1 = t2.k1";

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -202,10 +202,16 @@ struct TMySQLScanNode {
 struct TOdbcScanNode {
   1: optional Types.TTupleId tuple_id
   2: optional string table_name
+
+  //Deprecated
   3: optional string driver
   4: optional Types.TOdbcTableType type
   5: optional list<string> columns
   6: optional list<string> filters
+
+  //Use now
+  7: optional string connect_string
+  8: optional string query_string
 }
 
 


### PR DESCRIPTION
## Proposed changes

1. Support limit clause push down both odbc table and mysql table.
2. Code refactor of ODBC Scan Node, change `build_connect_string` and `query_string` from BE to FE to make it easily to modify

Fix #4706 

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] Documentation Update (if none of the other choices apply)
- [] Code refactor (Modify the code structure, format the code, etc...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have create an issue on (Fix #ISSUE), and have described the bug/feature there in detail
- [x] Compiling and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] If this change need a document change, I have updated the document
- [x] Any dependent changes have been merged

