### PR TITLE
[Bug] Add regular column when materialized slot is empty in tuple

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/planner/SingleNodePlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/SingleNodePlanner.java
@@ -1902,7 +1902,7 @@ public class SingleNodePlanner {
      * @param analyzer
      */
     private void materializeBaseTableRefResultForCrossJoinOrCountStar(BaseTableRef tblRef, Analyzer analyzer) {
-        if (tblRef.getDesc().getSlots().isEmpty()) {
+        if (tblRef.getDesc().getMaterializedSlots().isEmpty()) {
             Column minimuColumn = null;
             for (Column col : tblRef.getTable().getBaseSchema()) {
                 if (minimuColumn == null || col.getDataType().getSlotSize() < minimuColumn

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/SingleNodePlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/SingleNodePlanner.java
@@ -1887,7 +1887,7 @@ public class SingleNodePlanner {
      */
     private void materializeTableResultForCrossJoinOrCountStar(TableRef tblRef, Analyzer analyzer) {
         if (tblRef instanceof BaseTableRef) {
-            materializeBaseTableRefResultForCrossJoinOrCountStar((BaseTableRef) tblRef, analyzer);
+            materializeSlotForEmptyMaterializedTableRef((BaseTableRef) tblRef, analyzer);
         } else if (tblRef instanceof InlineViewRef) {
             materializeInlineViewResultExprForCrossJoinOrCountStar((InlineViewRef) tblRef, analyzer);
         } else {
@@ -1896,12 +1896,22 @@ public class SingleNodePlanner {
     }
 
     /**
-     * materialize BaseTableRef result' exprs for Cross Join or Count Star
+     * When materialized table ref is a empty tbl ref, the planner should add a mini column for this tuple.
+     * There are two situation:
+     * 1. The tbl ref is empty, such as select a from (select 'c1' a from test) t;
+     * Inner tuple: tuple 0 without slot
+     * 2. The materialized slot in tbl ref is empty, such as select a from (select 'c1' a, k1 from test) t;
+     * Inner tuple: tuple 0 with a not materialized slot k1
+     * In the above two cases, it is necessary to add a mini column to the inner tuple
+     * to ensure that the number of rows in the inner query result is the number of rows in the table.
      *
+     * After this function, the inner tuple is following:
+     * case1. tuple 0: slot<k1> materialized true (new slot)
+     * case2. tuple 0: slot<k1> materialized true (changed)
      * @param tblRef
      * @param analyzer
      */
-    private void materializeBaseTableRefResultForCrossJoinOrCountStar(BaseTableRef tblRef, Analyzer analyzer) {
+    private void materializeSlotForEmptyMaterializedTableRef(BaseTableRef tblRef, Analyzer analyzer) {
         if (tblRef.getDesc().getMaterializedSlots().isEmpty()) {
             Column minimuColumn = null;
             for (Column col : tblRef.getTable().getBaseSchema()) {

--- a/fe/fe-core/src/test/java/org/apache/doris/planner/SingleNodePlannerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/planner/SingleNodePlannerTest.java
@@ -1,0 +1,74 @@
+/*
+ * // Licensed to the Apache Software Foundation (ASF) under one
+ * // or more contributor license agreements.  See the NOTICE file
+ * // distributed with this work for additional information
+ * // regarding copyright ownership.  The ASF licenses this file
+ * // to you under the Apache License, Version 2.0 (the
+ * // "License"); you may not use this file except in compliance
+ * // with the License.  You may obtain a copy of the License at
+ * //
+ * //   http://www.apache.org/licenses/LICENSE-2.0
+ * //
+ * // Unless required by applicable law or agreed to in writing,
+ * // software distributed under the License is distributed on an
+ * // "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * // KIND, either express or implied.  See the License for the
+ * // specific language governing permissions and limitations
+ * // under the License.
+ *
+ */
+
+package org.apache.doris.planner;
+
+import org.apache.doris.analysis.Analyzer;
+import org.apache.doris.analysis.BaseTableRef;
+import org.apache.doris.analysis.SlotDescriptor;
+import org.apache.doris.analysis.SlotId;
+import org.apache.doris.analysis.TableName;
+import org.apache.doris.analysis.TableRef;
+import org.apache.doris.analysis.TupleDescriptor;
+import org.apache.doris.analysis.TupleId;
+import org.apache.doris.catalog.Column;
+import org.apache.doris.catalog.Table;
+import org.apache.doris.common.jmockit.Deencapsulation;
+
+import com.google.common.collect.Lists;
+
+import org.junit.Test;
+
+import java.util.List;
+
+import mockit.Expectations;
+import mockit.Injectable;
+
+public class SingleNodePlannerTest {
+
+    @Test
+    public void testMaterializeBaseTableRefResultForCrossJoinOrCountStar(@Injectable Table table,
+                                                                         @Injectable TableName tableName,
+                                                                         @Injectable Analyzer analyzer,
+                                                                         @Injectable PlannerContext plannerContext,
+                                                                         @Injectable Column column) {
+        TableRef tableRef = new TableRef();
+        Deencapsulation.setField(tableRef, "isAnalyzed", true);
+        BaseTableRef baseTableRef = new BaseTableRef(tableRef, table, tableName);
+        TupleDescriptor tupleDescriptor = new TupleDescriptor(new TupleId(1));
+        SlotDescriptor slotDescriptor = new SlotDescriptor(new SlotId(1), tupleDescriptor);
+        slotDescriptor.setIsMaterialized(false);
+        tupleDescriptor.addSlot(slotDescriptor);
+        Deencapsulation.setField(tableRef, "desc", tupleDescriptor);
+        Deencapsulation.setField(baseTableRef, "desc", tupleDescriptor);
+        tupleDescriptor.setTable(table);
+        List<Column> columnList = Lists.newArrayList();
+        columnList.add(column);
+        new Expectations() {
+            {
+                table.getBaseSchema();
+                result = columnList;
+            }
+        };
+        SingleNodePlanner singleNodePlanner = new SingleNodePlanner(plannerContext);
+        Deencapsulation.invoke(singleNodePlanner, "materializeBaseTableRefResultForCrossJoinOrCountStar",
+                               baseTableRef, analyzer);
+    }
+}


### PR DESCRIPTION
If the materialized slot is empty in inline view, the scanner will throw exception 'no materialized slot!'.
When the outer query does not need any real columns of the inner query at all, such as the outer query only contains constant calculations,
all slots in the inner query will not be materialized.
For example:
```
select c1 from (select 'xx' c1, k1 from test) t1;
```

But this does not mean that the inner query (select 'xx' c1, k1 from test) does not need to be executed.
Because the number of rows in the outer result needs to be determined by the number of rows in the inner query.
In this case, the inner query scan node needs to add a column to ensure the correct result.
At the same time it can avoid the scan node reporting errors.

Fixed #4716

Change-Id: I86bb52efab65b658ea78094037543cb23dbff1d4

## Proposed changes

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] Documentation Update (if none of the other choices apply)
- [] Code refactor (Modify the code structure, format the code, etc...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have create an issue on (Fix #ISSUE), and have described the bug/feature there in detail
- [x] Compiling and unit tests pass locally with my changes
- [] I have added tests that prove my fix is effective or that my feature works
- [] If this change need a document change, I have updated the document
- [] Any dependent changes have been merged

## Further comments

If this is a relatively large or complex change, kick off the discussion at dev@doris.apache.org by explaining why you chose the solution you did and what alternatives you considered, etc...
