### PR TITLE
[Bug] fix illegal defer in Tablet::rowset_with_max_version()

### DIFF
--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -327,8 +327,10 @@ const RowsetSharedPtr Tablet::rowset_with_max_version() const {
     }
 
     auto iter = _rs_version_map.find(max_version);
-    DCHECK(_rs_version_map.find(max_version) != _rs_version_map.end())
-        << "invalid version:" << max_version;
+    if (iter == _rs_version_map.end()) {
+        DCHECK(false) << "invalid version:" << max_version;
+        return nullptr;
+    }
     return iter->second;
 }
 


### PR DESCRIPTION
## Proposed changes

We use max_version to find iter. And if iter==end(), it will return end()->second, cuz DCHECK won't effect in release mode.
It'll cause a coredump, because the ->second is a RowsetSharedPtr.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have create an issue on (Fix #4736 ), and have described the bug/feature there in detail
- [x] Compiling and unit tests pass locally with my changes
