### PR TITLE
[Compile] Update pluginRepository for java-cup-plugins and update dependency Repository for java-cup

### DIFF
--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -84,7 +84,7 @@ under the License.
                 <!-- for java-cup -->
                 <repository>
                     <id>cloudera-thirdparty</id>
-                    <url>https://repository.cloudera.com/content/repositories/third-party/</url>
+                    <url>https://repository.cloudera.com/artifactory/cloudera-repos/</url>
                 </repository>
                 <!-- for bdb je -->
                 <repository>
@@ -94,10 +94,14 @@ under the License.
             </repositories>
 
             <pluginRepositories>
-                <!-- for cup-maven-plugin -->
                 <pluginRepository>
                     <id>spring-plugins</id>
                     <url>https://repo.spring.io/plugins-release/</url>
+                </pluginRepository>
+                <!-- for cup-maven-plugin -->
+                <pluginRepository>
+                    <id>cloudera-plugins</id>
+                    <url>https://repository.cloudera.com/artifactory/cloudera-repos/</url>
                 </pluginRepository>
             </pluginRepositories>
         </profile>


### PR DESCRIPTION
[Compile] Update pluginRepository for java-cup-plugins
the cup-maven-plugin of net.sourceforge.czt.dev is missing in maven central repo.
It has been moved to https://repository.cloudera.com/artifactory/cloudera-repos/

[Compile] Update dependencyRepository for java-cup
the cup-maven of net.sourceforge.czt.dev is missing in maven central repo.
It has been moved to https://repository.cloudera.com/artifactory/cloudera-repos/


