### PR TITLE
[LoadBalance] make BeLoadRebalancer extends from base class Rebalancer

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/clone/BeLoadRebalancer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/BeLoadRebalancer.java
@@ -27,7 +27,6 @@ import org.apache.doris.clone.TabletSchedCtx.Priority;
 import org.apache.doris.clone.TabletScheduler.PathSlot;
 import org.apache.doris.system.Backend;
 import org.apache.doris.system.SystemInfoService;
-import org.apache.doris.task.AgentBatchTask;
 import org.apache.doris.thrift.TStorageMedium;
 
 import com.google.common.collect.Lists;

--- a/fe/fe-core/src/main/java/org/apache/doris/clone/BeLoadRebalancer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/BeLoadRebalancer.java
@@ -197,7 +197,7 @@ public class BeLoadRebalancer extends Rebalancer {
      * 2. Select a low load backend as destination. And tablet should not has replica on this backend.
      */
     @Override
-    public void completePlan(TabletSchedCtx tabletCtx, Map<Long, PathSlot> backendsWorkingSlots) throws SchedException {
+    public void completeSchedCtx(TabletSchedCtx tabletCtx, Map<Long, PathSlot> backendsWorkingSlots) throws SchedException {
         ClusterLoadStatistic clusterStat = statisticMap.get(tabletCtx.getCluster());
         if (clusterStat == null) {
             throw new SchedException(Status.UNRECOVERABLE, "cluster does not exist");

--- a/fe/fe-core/src/main/java/org/apache/doris/clone/BeLoadRebalancer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/BeLoadRebalancer.java
@@ -108,8 +108,7 @@ public class BeLoadRebalancer extends Rebalancer {
         // choose tablets from high load backends.
         // BackendLoadStatistic is sorted by load score in ascend order,
         // so we need to traverse it from last to first
-        OUTER:
-        for (int i = highBEs.size() - 1; i >= 0; i--) {
+        OUTER:for (int i = highBEs.size() - 1; i >= 0; i--) {
             BackendLoadStatistic beStat = highBEs.get(i);
 
             // classify the paths.

--- a/fe/fe-core/src/main/java/org/apache/doris/clone/BeLoadRebalancer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/BeLoadRebalancer.java
@@ -195,7 +195,6 @@ public class BeLoadRebalancer extends Rebalancer {
      * 1. Check if this tablet has replica on high load backend. If not, the balance will be cancelled.
      *    If yes, select a replica as source replica.
      * 2. Select a low load backend as destination. And tablet should not has replica on this backend.
-     * 3. Create a clone task.
      */
     @Override
     public void completePlan(TabletSchedCtx tabletCtx, Map<Long, PathSlot> backendsWorkingSlots) throws SchedException {

--- a/fe/fe-core/src/main/java/org/apache/doris/clone/BeLoadRebalancer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/BeLoadRebalancer.java
@@ -17,7 +17,11 @@
 
 package org.apache.doris.clone;
 
-import org.apache.doris.catalog.*;
+import org.apache.doris.catalog.Catalog;
+import org.apache.doris.catalog.ColocateTableIndex;
+import org.apache.doris.catalog.Replica;
+import org.apache.doris.catalog.TabletInvertedIndex;
+import org.apache.doris.catalog.TabletMeta;
 import org.apache.doris.clone.SchedException.Status;
 import org.apache.doris.clone.TabletSchedCtx.Priority;
 import org.apache.doris.clone.TabletScheduler.PathSlot;

--- a/fe/fe-core/src/main/java/org/apache/doris/clone/BeLoadRebalancer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/BeLoadRebalancer.java
@@ -17,14 +17,12 @@
 
 package org.apache.doris.clone;
 
-import org.apache.doris.catalog.Catalog;
-import org.apache.doris.catalog.ColocateTableIndex;
-import org.apache.doris.catalog.Replica;
-import org.apache.doris.catalog.TabletMeta;
+import org.apache.doris.catalog.*;
 import org.apache.doris.clone.SchedException.Status;
 import org.apache.doris.clone.TabletSchedCtx.Priority;
 import org.apache.doris.clone.TabletScheduler.PathSlot;
 import org.apache.doris.system.Backend;
+import org.apache.doris.system.SystemInfoService;
 import org.apache.doris.task.AgentBatchTask;
 import org.apache.doris.thrift.TStorageMedium;
 
@@ -49,8 +47,8 @@ import java.util.Set;
 public class BeLoadRebalancer extends Rebalancer {
     private static final Logger LOG = LogManager.getLogger(BeLoadRebalancer.class);
 
-    public BeLoadRebalancer(Map<String, ClusterLoadStatistic> statisticMap) {
-        super(statisticMap);
+    public BeLoadRebalancer(SystemInfoService infoService, TabletInvertedIndex invertedIndex) {
+        super(infoService, invertedIndex);
     }
 
     /*

--- a/fe/fe-core/src/main/java/org/apache/doris/clone/Rebalancer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/Rebalancer.java
@@ -65,6 +65,8 @@ public abstract class Rebalancer {
         return alternativeTablets;
     }
 
+    // The return TabletSchedCtx should have the tablet id at least. {srcReplica, destBe} can be complete here or
+    // later(when createBalanceTask called).
     protected abstract List<TabletSchedCtx> selectAlternativeTabletsForCluster(
             String clusterName, ClusterLoadStatistic clusterStat, TStorageMedium medium);
 
@@ -76,10 +78,10 @@ public abstract class Rebalancer {
     }
 
     // Before createCloneReplicaAndTask, we need to complete the TabletSchedCtx.
-    // 1. If you generate {tabletId, srcReplica, destReplica} in selectAlternativeTablets(), it may be invalid at
+    // 1. If you generate {tabletId, srcReplica, destBe} in selectAlternativeTablets(), it may be invalid at
     // this point(it may have a long interval between selectAlternativeTablets & createBalanceTask).
     // You should check the moves' validation.
-    // 2. If you want to generate {srcReplica, destReplica} here, just do it.
+    // 2. If you want to generate {srcReplica, destBe} here, just do it.
     // 3. You should check the path slots of src & dest.
     protected abstract void completePlan(TabletSchedCtx tabletCtx, Map<Long, PathSlot> backendsWorkingSlots)
             throws SchedException;

--- a/fe/fe-core/src/main/java/org/apache/doris/clone/Rebalancer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/Rebalancer.java
@@ -46,14 +46,15 @@ import java.util.Map;
 public abstract class Rebalancer {
     private static final Logger LOG = LogManager.getLogger(Rebalancer.class);
 
+    // When Rebalancer init, the statisticMap is empty so that it's no need to be an arg.
+    // Use updateLoadStatistic() to load stats only.
     protected Map<String, ClusterLoadStatistic> statisticMap;
     protected TabletInvertedIndex invertedIndex;
     protected SystemInfoService infoService;
 
-    public Rebalancer(Map<String, ClusterLoadStatistic> statisticMap) {
-        this.statisticMap = statisticMap;
-        this.infoService = Catalog.getCurrentSystemInfo();
-        this.invertedIndex = Catalog.getCurrentInvertedIndex();
+    public Rebalancer(SystemInfoService infoService, TabletInvertedIndex invertedIndex) {
+        this.infoService = infoService;
+        this.invertedIndex = invertedIndex;
     }
 
     public List<TabletSchedCtx> selectAlternativeTablets() {

--- a/fe/fe-core/src/main/java/org/apache/doris/clone/Rebalancer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/Rebalancer.java
@@ -35,11 +35,11 @@ import java.util.Map;
  * 1. selectAlternativeTablets: selecting alternative tablets by one rebalance strategy,
  * and return them to tablet scheduler(maybe contains the concrete moves, or maybe not).
  * 2. createBalanceTask: given a tablet, try to create a clone task for this tablet.
- * 3. getCachedSrcBackendId: if the rebalance strategy wants to delete the replica of a specified be,
+ * 3. getSrcBackendId: if the rebalance strategy wants to delete the replica of a specified be,
  * override this func.
  * NOTICE:
  * It may have a long interval between selectAlternativeTablets() & createBalanceTask(). So the concrete moves may be
- * invalid when we createBalanceTask(), you should check the moves' validation.
+ * invalid when we generating a clone task in createBalanceTask(), you should check the moves' validation.
  */
 public abstract class Rebalancer {
     // When Rebalancer init, the statisticMap is usually empty. So it's no need to be an arg.
@@ -70,7 +70,7 @@ public abstract class Rebalancer {
     public abstract void createBalanceTask(TabletSchedCtx tabletCtx, Map<Long, PathSlot> backendsWorkingSlots,
                                            AgentBatchTask batchTask) throws SchedException;
 
-    public Long getCachedSrcBackendId(Long tabletId) {
+    public Long getSrcBackendId(Long tabletId) {
         return -1L;
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/clone/Rebalancer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/Rebalancer.java
@@ -28,6 +28,7 @@ import com.google.common.collect.Lists;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -46,9 +47,9 @@ import java.util.Map;
 public abstract class Rebalancer {
     private static final Logger LOG = LogManager.getLogger(Rebalancer.class);
 
-    // When Rebalancer init, the statisticMap is empty so that it's no need to be an arg.
-    // Use updateLoadStatistic() to load stats only.
-    protected Map<String, ClusterLoadStatistic> statisticMap;
+    // When Rebalancer init, the statisticMap is usually empty. So it's no need to be an arg.
+    // Only use updateLoadStatistic() to load stats.
+    protected Map<String, ClusterLoadStatistic> statisticMap = new HashMap<>();
     protected TabletInvertedIndex invertedIndex;
     protected SystemInfoService infoService;
 

--- a/fe/fe-core/src/main/java/org/apache/doris/clone/Rebalancer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/Rebalancer.java
@@ -17,7 +17,6 @@
 
 package org.apache.doris.clone;
 
-import org.apache.doris.catalog.Catalog;
 import org.apache.doris.catalog.TabletInvertedIndex;
 import org.apache.doris.clone.TabletScheduler.PathSlot;
 import org.apache.doris.system.SystemInfoService;
@@ -25,8 +24,6 @@ import org.apache.doris.task.AgentBatchTask;
 import org.apache.doris.thrift.TStorageMedium;
 
 import com.google.common.collect.Lists;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 import java.util.HashMap;
 import java.util.List;
@@ -45,8 +42,6 @@ import java.util.Map;
  * invalid when we createBalanceTask(), you should check the moves' validation.
  */
 public abstract class Rebalancer {
-    private static final Logger LOG = LogManager.getLogger(Rebalancer.class);
-
     // When Rebalancer init, the statisticMap is usually empty. So it's no need to be an arg.
     // Only use updateLoadStatistic() to load stats.
     protected Map<String, ClusterLoadStatistic> statisticMap = new HashMap<>();

--- a/fe/fe-core/src/main/java/org/apache/doris/clone/Rebalancer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/Rebalancer.java
@@ -73,7 +73,7 @@ public abstract class Rebalancer {
 
     public void createBalanceTask(TabletSchedCtx tabletCtx, Map<Long, PathSlot> backendsWorkingSlots,
                                   AgentBatchTask batchTask) throws SchedException {
-        completePlan(tabletCtx, backendsWorkingSlots);
+        completeSchedCtx(tabletCtx, backendsWorkingSlots);
         batchTask.addTask(tabletCtx.createCloneReplicaAndTask());
     }
 
@@ -83,7 +83,7 @@ public abstract class Rebalancer {
     // You should check the moves' validation.
     // 2. If you want to generate {srcReplica, destBe} here, just do it.
     // 3. You should check the path slots of src & dest.
-    protected abstract void completePlan(TabletSchedCtx tabletCtx, Map<Long, PathSlot> backendsWorkingSlots)
+    protected abstract void completeSchedCtx(TabletSchedCtx tabletCtx, Map<Long, PathSlot> backendsWorkingSlots)
             throws SchedException;
 
     public Long getToDeleteReplicaId(Long tabletId) {

--- a/fe/fe-core/src/main/java/org/apache/doris/clone/Rebalancer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/Rebalancer.java
@@ -35,7 +35,7 @@ import java.util.Map;
  * 1. selectAlternativeTablets: selecting alternative tablets by one rebalance strategy,
  * and return them to tablet scheduler(maybe contains the concrete moves, or maybe not).
  * 2. createBalanceTask: given a tablet, try to create a clone task for this tablet.
- * 3. getSrcBackendId: if the rebalance strategy wants to delete the replica of a specified be,
+ * 3. getSrcReplicaId: if the rebalance strategy wants to delete the src replica,
  * override this func.
  * NOTICE:
  * It may have a long interval between selectAlternativeTablets() & createBalanceTask(). So the concrete moves may be
@@ -70,7 +70,7 @@ public abstract class Rebalancer {
     public abstract void createBalanceTask(TabletSchedCtx tabletCtx, Map<Long, PathSlot> backendsWorkingSlots,
                                            AgentBatchTask batchTask) throws SchedException;
 
-    public Long getSrcBackendId(Long tabletId) {
+    public Long getSrcReplicaId(Long tabletId) {
         return -1L;
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/clone/Rebalancer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/Rebalancer.java
@@ -1,0 +1,83 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.clone;
+
+import org.apache.doris.catalog.Catalog;
+import org.apache.doris.catalog.TabletInvertedIndex;
+import org.apache.doris.clone.TabletScheduler.PathSlot;
+import org.apache.doris.system.SystemInfoService;
+import org.apache.doris.task.AgentBatchTask;
+import org.apache.doris.thrift.TStorageMedium;
+
+import com.google.common.collect.Lists;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.List;
+import java.util.Map;
+
+
+/*
+ * Rebalancer is responsible for
+ * 1. selectAlternativeTablets: selecting alternative tablets by one rebalance strategy,
+ * and return them to tablet scheduler(maybe contains the concrete moves, or maybe not).
+ * 2. createBalanceTask: given a tablet, try to create a clone task for this tablet.
+ * 3. getCachedSrcBackendId: if the rebalance strategy wants to delete the replica of a specified be,
+ * override this func.
+ * NOTICE:
+ * It may have a long interval between selectAlternativeTablets() & createBalanceTask(). So the concrete moves may be
+ * invalid when we createBalanceTask(), you should check the moves' validation.
+ */
+public abstract class Rebalancer {
+    private static final Logger LOG = LogManager.getLogger(Rebalancer.class);
+
+    protected Map<String, ClusterLoadStatistic> statisticMap;
+    protected TabletInvertedIndex invertedIndex;
+    protected SystemInfoService infoService;
+
+    public Rebalancer(Map<String, ClusterLoadStatistic> statisticMap) {
+        this.statisticMap = statisticMap;
+        this.infoService = Catalog.getCurrentSystemInfo();
+        this.invertedIndex = Catalog.getCurrentInvertedIndex();
+    }
+
+    public List<TabletSchedCtx> selectAlternativeTablets() {
+        List<TabletSchedCtx> alternativeTablets = Lists.newArrayList();
+        for (Map.Entry<String, ClusterLoadStatistic> entry : statisticMap.entrySet()) {
+            for (TStorageMedium medium : TStorageMedium.values()) {
+                alternativeTablets.addAll(selectAlternativeTabletsForCluster(entry.getKey(),
+                        entry.getValue(), medium));
+            }
+        }
+        return alternativeTablets;
+    }
+
+    protected abstract List<TabletSchedCtx> selectAlternativeTabletsForCluster(
+            String clusterName, ClusterLoadStatistic clusterStat, TStorageMedium medium);
+
+    public abstract void createBalanceTask(TabletSchedCtx tabletCtx, Map<Long, PathSlot> backendsWorkingSlots,
+                                           AgentBatchTask batchTask) throws SchedException;
+
+    public Long getCachedSrcBackendId(Long tabletId) {
+        return -1L;
+    }
+
+    public void updateLoadStatistic(Map<String, ClusterLoadStatistic> statisticMap) {
+        this.statisticMap = statisticMap;
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/clone/TabletScheduler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/TabletScheduler.java
@@ -833,7 +833,7 @@ public class TabletScheduler extends MasterDaemon {
     }
 
     private boolean deleteReplicaChosenByRebalancer(TabletSchedCtx tabletCtx, boolean force) throws SchedException {
-        Long id = rebalancer.getSrcReplicaId(tabletCtx.getTabletId());
+        Long id = rebalancer.getToDeleteReplicaId(tabletCtx.getTabletId());
         if (id == -1L) {
             return false;
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/clone/TabletScheduler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/TabletScheduler.java
@@ -145,7 +145,7 @@ public class TabletScheduler extends MasterDaemon {
         this.invertedIndex = invertedIndex;
         this.colocateTableIndex = catalog.getColocateTableIndex();
         this.stat = stat;
-        this.rebalancer = new BeLoadRebalancer(statisticMap);
+        this.rebalancer = new BeLoadRebalancer(infoService, invertedIndex);
     }
 
     public TabletSchedulerStat getStat() {

--- a/fe/fe-core/src/main/java/org/apache/doris/clone/TabletScheduler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/TabletScheduler.java
@@ -833,11 +833,11 @@ public class TabletScheduler extends MasterDaemon {
     }
 
     private boolean deleteReplicaChosenByRebalancer(TabletSchedCtx tabletCtx, boolean force) throws SchedException {
-        Long id = rebalancer.getSrcBackendId(tabletCtx.getTabletId());
+        Long id = rebalancer.getSrcReplicaId(tabletCtx.getTabletId());
         if (id == -1L) {
             return false;
         }
-        Replica chosenReplica = tabletCtx.getTablet().getReplicaByBackendId(id);
+        Replica chosenReplica = tabletCtx.getTablet().getReplicaById(id);
         if (chosenReplica != null) {
             deleteReplicaInternal(tabletCtx, chosenReplica, "src replica of rebalance", force);
             return true;


### PR DESCRIPTION
## Proposed changes
Create a base class `Rebalancer`, support to delete the specified replica(actually add a new priority in handling redundant replica).
The origin LoadBalancer, which will named as BeLoadRebalancer, just need to extend from Rebalancer without any logic change.

## Types of changes

- [x] Code refactor (Modify the code structure, format the code, etc...)

## Checklist

- [x] I have create an issue on (Fix #4763), and have described the bug/feature there in detail
- [x] Compiling and unit tests pass locally with my changes

