### PR TITLE
[Bug]  Fix Bug that fe's connection which is timed out can't be released

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectScheduler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectScheduler.java
@@ -46,7 +46,7 @@ public class ConnectScheduler {
     private int maxConnections;
     private int numberConnection;
     private AtomicInteger nextConnectionId;
-    private Map<Long, ConnectContext> connectionMap = Maps.newHashMap();
+    private Map<Long, ConnectContext> connectionMap = Maps.newConcurrentMap();
     private Map<String, AtomicInteger> connByUser = Maps.newHashMap();
     private ExecutorService executor = ThreadPoolManager.newDaemonCacheThreadPool(Config.max_connection_scheduler_threads_num, "connect-scheduler-pool", true);
 


### PR DESCRIPTION
#4773 
Thread [Connect-Scheduler-Check-Timer] will stop due to failing to iterate the connectionMap , because other threads will modify the connectionMap at the same time.

Fe's connection whic is timed out can't be released because of  thread [Connect-Scheduler-Check-Timer] not working.

## Exception 
[fe.out]
INFO: Use Simple share channel pool to create protobuf RPC proxy with interface interface org.apache.doris.rpc.PBackendService
Exception in thread "ConnectScheduler Check Timer" java.util.ConcurrentModificationException
        at java.util.HashMap$HashIterator.nextNode(HashMap.java:1445)
        at java.util.HashMap$ValueIterator.next(HashMap.java:1474)
        at org.apache.doris.qe.ConnectScheduler$TimeoutChecker.run(ConnectScheduler.java:89)
        at java.util.TimerThread.mainLoop(Timer.java:555)
        at java.util.TimerThread.run(Timer.java:505)

