### PR TITLE
[Bug] The SQL operation returns the wrong set of data when there is a constant in select clause

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/TupleIsNullPredicate.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/TupleIsNullPredicate.java
@@ -146,7 +146,7 @@ public class TupleIsNullPredicate extends Predicate {
      * Throws an InternalException if expr evaluation in the BE failed.
      */
     private static boolean requiresNullWrapping(Expr expr, Analyzer analyzer) {
-        if (expr.isConstant() || expr.getType().isNull()) {
+        if (expr.getType().isNull()) {
             return false;
         }
         return true;


### PR DESCRIPTION
# Proposed changes

Fix the wrong set of data when there is a constant in select clause with left/right/full join statement,
The constant literal expr also requires the null wrapping in inline view plan created method.

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] Documentation Update (if none of the other choices apply)
- [] Code refactor (Modify the code structure, format the code, etc...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have create an issue on (Fix #4762 ), and have described the bug/feature there in detail
- [x] Compiling and unit tests pass locally with my changes
- [] I have added tests that prove my fix is effective or that my feature works
- [] If this change need a document change, I have updated the document
- [] Any dependent changes have been merged

## Further comments

If this is a relatively large or complex change, kick off the discussion at dev@doris.apache.org by explaining why you chose the solution you did and what alternatives you considered, etc...
