### PR TITLE
[Doc] Fix a command word spelling error in variables.md

### DIFF
--- a/docs/en/administrator-guide/variables.md
+++ b/docs/en/administrator-guide/variables.md
@@ -53,7 +53,7 @@ SET forward_to_master = true;
 SET time_zone = "Asia/Shanghai";
 ```
 
-For global-level, set by `SET GLOBALE var_name=xxx;`. Such as:
+For global-level, set by `SET GLOBAL var_name=xxx;`. Such as:
 
 ```
 SET GLOBAL exec_mem_limit = 137438953472

--- a/docs/zh-CN/administrator-guide/variables.md
+++ b/docs/zh-CN/administrator-guide/variables.md
@@ -53,7 +53,7 @@ SET forward_to_master = true;
 SET time_zone = "Asia/Shanghai";
 ```
 
-全局生效，通过 `SET GLOBALE var_name=xxx;` 设置。如：
+全局生效，通过 `SET GLOBAL var_name=xxx;` 设置。如：
 
 ```
 SET GLOBAL exec_mem_limit = 137438953472


### PR DESCRIPTION
## Proposed changes

"GLOBALE" command word spelling error in variables.md.


## Types of changes

- [x] Documentation Update (if none of the other choices apply)

## Checklist

- [x] If this change need a document change, I have updated the document

