### PR TITLE
[Broker Load] Ignore empty file when file format is parquet or orc.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/load/BrokerFileGroup.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/BrokerFileGroup.java
@@ -17,7 +17,6 @@
 
 package org.apache.doris.load;
 
-import com.google.common.base.Strings;
 import org.apache.doris.analysis.ColumnSeparator;
 import org.apache.doris.analysis.DataDescription;
 import org.apache.doris.analysis.Expr;
@@ -40,13 +39,14 @@ import org.apache.doris.common.FeMetaVersion;
 import org.apache.doris.common.Pair;
 import org.apache.doris.common.io.Text;
 import org.apache.doris.common.io.Writable;
-
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
-
 import org.apache.doris.load.loadv2.LoadTask;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+
+import com.google.common.base.Strings;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 
 import java.io.DataInput;
 import java.io.DataOutput;
@@ -278,6 +278,10 @@ public class BrokerFileGroup implements Writable {
 
     public boolean hasSequenceCol() {
         return !Strings.isNullOrEmpty(sequenceCol);
+    }
+
+    public boolean isBinaryFileFormat() {
+        return fileFormat.toLowerCase().equals("parquet") || fileFormat.toLowerCase().equals("orc");
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/load/BrokerFileGroup.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/BrokerFileGroup.java
@@ -41,12 +41,12 @@ import org.apache.doris.common.io.Text;
 import org.apache.doris.common.io.Writable;
 import org.apache.doris.load.loadv2.LoadTask;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.io.DataInput;
 import java.io.DataOutput;
@@ -281,6 +281,10 @@ public class BrokerFileGroup implements Writable {
     }
 
     public boolean isBinaryFileFormat() {
+        if (fileFormat == null) {
+            // null means default: csv
+            return false;
+        }
         return fileFormat.toLowerCase().equals("parquet") || fileFormat.toLowerCase().equals("orc");
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/BrokerLoadPendingTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/BrokerLoadPendingTask.java
@@ -27,10 +27,10 @@ import org.apache.doris.load.BrokerFileGroupAggInfo.FileGroupAggKey;
 import org.apache.doris.load.FailMsg;
 import org.apache.doris.thrift.TBrokerFileStatus;
 
-import com.google.common.collect.Lists;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+
+import com.google.common.collect.Lists;
 
 import java.util.List;
 import java.util.Map;
@@ -78,7 +78,6 @@ public class BrokerLoadPendingTask extends LoadTask {
                     BrokerUtil.parseFile(path, brokerDesc, fileStatuses);
                 }
                 boolean isBinaryFileFormat = fileGroup.isBinaryFileFormat();
-                int fileNum = 0;
                 List<TBrokerFileStatus> filteredFileStatuses = Lists.newArrayList();
                 for (TBrokerFileStatus fstatus : fileStatuses) {
                     if (fstatus.getSize() == 0 && isBinaryFileFormat) {
@@ -90,7 +89,6 @@ public class BrokerLoadPendingTask extends LoadTask {
                         }
                     } else {
                         groupFileSize += fstatus.size;
-                        fileNum++;
                         filteredFileStatuses.add(fstatus);
                         if (LOG.isDebugEnabled()) {
                             LOG.debug(new LogBuilder(LogKey.LOAD_JOB, callback.getCallbackId())
@@ -100,9 +98,10 @@ public class BrokerLoadPendingTask extends LoadTask {
                 }
                 fileStatusList.add(filteredFileStatuses);
                 tableTotalFileSize += groupFileSize;
-                tableTotalFileNum += fileNum;
+                tableTotalFileNum += filteredFileStatuses.size();
                 LOG.info("get {} files in file group {} for table {}. size: {}. job: {}, broker: {} ",
-                        fileNum, groupNum, entry.getKey(), groupFileSize, callback.getCallbackId(), BrokerUtil.getAddress(brokerDesc));
+                        filteredFileStatuses.size(), groupNum, entry.getKey(), groupFileSize,
+                        callback.getCallbackId(), BrokerUtil.getAddress(brokerDesc));
                 groupNum++;
             }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/BrokerLoadPendingTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/BrokerLoadPendingTask.java
@@ -27,10 +27,10 @@ import org.apache.doris.load.BrokerFileGroupAggInfo.FileGroupAggKey;
 import org.apache.doris.load.FailMsg;
 import org.apache.doris.thrift.TBrokerFileStatus;
 
-import com.google.common.collect.Lists;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+
+import com.google.common.collect.Lists;
 
 import java.util.List;
 import java.util.Map;
@@ -77,18 +77,29 @@ public class BrokerLoadPendingTask extends LoadTask {
                 for (String path : fileGroup.getFilePaths()) {
                     BrokerUtil.parseFile(path, brokerDesc, fileStatuses);
                 }
-                fileStatusList.add(fileStatuses);
+                boolean isBinaryFileFormat = fileGroup.isBinaryFileFormat();
+                int fileNum = 0;
                 for (TBrokerFileStatus fstatus : fileStatuses) {
-                    groupFileSize += fstatus.getSize();
-                    if (LOG.isDebugEnabled()) {
-                        LOG.debug(new LogBuilder(LogKey.LOAD_JOB, callback.getCallbackId())
-                                .add("file_status", fstatus).build());
+                    if (fstatus.getSize() == 0 && isBinaryFileFormat) {
+                        // For parquet or orc file, if it is an empty file, ignore it.
+                        // Because we can not read an empty parquet or orc file.
+                        if (LOG.isDebugEnabled()) {
+                            LOG.debug(new LogBuilder(LogKey.LOAD_JOB, callback.getCallbackId())
+                                    .add("empty file", fstatus).build());
+                        }
+                    } else {
+                        groupFileSize += fstatus.getSize();
+                        fileNum++;
+                        if (LOG.isDebugEnabled()) {
+                            LOG.debug(new LogBuilder(LogKey.LOAD_JOB, callback.getCallbackId())
+                                    .add("file_status", fstatus).build());
+                        }
                     }
                 }
                 tableTotalFileSize += groupFileSize;
-                tableTotalFileNum += fileStatuses.size();
+                tableTotalFileNum += fileNum;
                 LOG.info("get {} files in file group {} for table {}. size: {}. job: {}, broker: {} ",
-                        fileStatuses.size(), groupNum, entry.getKey(), groupFileSize, callback.getCallbackId(), BrokerUtil.getAddress(brokerDesc));
+                        fileNum, groupNum, entry.getKey(), groupFileSize, callback.getCallbackId(), BrokerUtil.getAddress(brokerDesc));
                 groupNum++;
             }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/load/loadv2/BrokerLoadPendingTaskTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/load/loadv2/BrokerLoadPendingTaskTest.java
@@ -17,6 +17,12 @@
 
 package org.apache.doris.load.loadv2;
 
+import mockit.Expectations;
+import mockit.Injectable;
+import mockit.Mock;
+import mockit.MockUp;
+import mockit.Mocked;
+
 import org.apache.doris.analysis.BrokerDesc;
 import org.apache.doris.catalog.Catalog;
 import org.apache.doris.common.UserException;
@@ -30,25 +36,26 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.util.List;
 import java.util.Map;
 
-import mockit.Expectations;
-import mockit.Injectable;
-import mockit.Mock;
-import mockit.MockUp;
-import mockit.Mocked;
-
 public class BrokerLoadPendingTaskTest {
+
+    private static TBrokerFileStatus tBrokerFileStatus = new TBrokerFileStatus();
+
+    @BeforeClass
+    public static void setUp() {
+        tBrokerFileStatus.size = 1;
+    }
 
     @Test
     public void testExecuteTask(@Injectable BrokerLoadJob brokerLoadJob,
                                 @Injectable BrokerFileGroup brokerFileGroup,
                                 @Injectable BrokerDesc brokerDesc,
-                                @Mocked Catalog catalog,
-                                @Injectable TBrokerFileStatus tBrokerFileStatus) throws UserException {
+                                @Mocked Catalog catalog) throws UserException {
         Map<FileGroupAggKey, List<BrokerFileGroup>> aggKeyToFileGroups = Maps.newHashMap();
         List<BrokerFileGroup> brokerFileGroups = Lists.newArrayList();
         brokerFileGroups.add(brokerFileGroup);
@@ -62,6 +69,7 @@ public class BrokerLoadPendingTaskTest {
                 result = "hdfs://localhost:8900/test_column";
             }
         };
+
         new MockUp<BrokerUtil>() {
             @Mock
             public void parseFile(String path, BrokerDesc brokerDesc, List<TBrokerFileStatus> fileStatuses) {


### PR DESCRIPTION
## Proposed changes

We can not read empty parquet or orc format file. So we should skip them
when doing broker load.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have create an issue on (Fix #4812), and have described the bug/feature there in detail

