### PR TITLE
[Bug] Fix bug that routine load blocked with TOO_MANY_TASKS error

### DIFF
--- a/be/src/runtime/routine_load/data_consumer.cpp
+++ b/be/src/runtime/routine_load/data_consumer.cpp
@@ -193,7 +193,11 @@ Status KafkaDataConsumer::group_consume(
         consumer_watch.stop();
         switch (msg->err()) {
             case RdKafka::ERR_NO_ERROR:
-                if (!queue->blocking_put(msg.get())) {
+                if (msg->len() == 0) {
+                    // ignore msg with length 0.
+                    // put empty msg into queue will cause the load process shutting down.
+                    break;
+                } else if (!queue->blocking_put(msg.get())) {
                     // queue is shutdown
                     done = true;
                 } else {


### PR DESCRIPTION
## Proposed changes

When receiving empty msg from kafka, the load process will quit abnormally.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have create an issue on (Fix #4860 ), and have described the bug/feature there in detail
