### PR TITLE
[Metrics] Add metric to monitor timeout canceled fragment count

### DIFF
--- a/be/src/http/ev_http_server.cpp
+++ b/be/src/http/ev_http_server.cpp
@@ -92,7 +92,8 @@ EvHttpServer::~EvHttpServer() {
 
 void EvHttpServer::start() {
     // bind to 
-    CHECK(_bind().ok());
+    auto s = _bind();
+    CHECK(s.ok()) << s.to_string();
     ThreadPoolBuilder("EvHttpServer")
             .set_min_threads(_num_workers)
             .set_max_threads(_num_workers)

--- a/be/src/runtime/fragment_mgr.cpp
+++ b/be/src/runtime/fragment_mgr.cpp
@@ -53,6 +53,7 @@
 namespace doris {
 
 DEFINE_GAUGE_METRIC_PROTOTYPE_2ARG(plan_fragment_count, MetricUnit::NOUNIT);
+DEFINE_GAUGE_METRIC_PROTOTYPE_2ARG(timeout_canceled_fragment_count, MetricUnit::NOUNIT);
 
 std::string to_load_error_http_path(const std::string& file_name) {
     if (file_name.empty()) {
@@ -381,16 +382,19 @@ FragmentMgr::FragmentMgr(ExecEnv* exec_env)
         : _exec_env(exec_env),
           _fragment_map(),
           _stop_background_threads_latch(1) {
+    _entity = DorisMetrics::instance()->metric_registry()->register_entity("FragmentMgr");
+    INT_UGAUGE_METRIC_REGISTER(_entity, timeout_canceled_fragment_count);
+    REGISTER_HOOK_METRIC(plan_fragment_count, [this]() {
+        std::lock_guard<std::mutex> lock(_lock);
+        return _fragment_map.size();
+    });
+
     CHECK(Thread::create("FragmentMgr", "cancel_timeout_plan_fragment",
                          [this]() {
                              this->cancel_worker();
                          },
                          &_cancel_thread).ok());
 
-    REGISTER_HOOK_METRIC(plan_fragment_count, [this]() {
-        std::lock_guard<std::mutex> lock(_lock);
-        return _fragment_map.size();
-    });
     // TODO(zc): we need a better thread-pool
     // now one user can use all the thread pool, others have no resource.
     ThreadPoolBuilder("FragmentMgrThreadPool")
@@ -523,6 +527,7 @@ void FragmentMgr::cancel_worker() {
                 }
             }
         }
+        timeout_canceled_fragment_count->increment(to_delete.size());
         for (auto& id : to_delete) {
             cancel(id, PPlanFragmentCancelReason::TIMEOUT);
             LOG(INFO) << "FragmentMgr cancel worker going to cancel timeout fragment " << print_id(id);

--- a/be/src/runtime/fragment_mgr.h
+++ b/be/src/runtime/fragment_mgr.h
@@ -33,6 +33,7 @@
 #include "http/rest_monitor_iface.h"
 #include "gutil/ref_counted.h"
 #include "util/countdown_latch.h"
+#include "util/metrics.h"
 #include "util/thread.h"
 
 namespace doris {
@@ -93,6 +94,9 @@ private:
     scoped_refptr<Thread> _cancel_thread;
     // every job is a pool
     std::unique_ptr<ThreadPool> _thread_pool;
+
+    std::shared_ptr<MetricEntity> _entity = nullptr;
+    UIntGauge* timeout_canceled_fragment_count = nullptr;
 };
 
 }


### PR DESCRIPTION
## Proposed changes

It would be helpful to monitor the count of timeout canceled fragments
when there is any issuse cause fragments execute failed or queued too
long time.

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] Documentation Update (if none of the other choices apply)
- [] Code refactor (Modify the code structure, format the code, etc...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [] I have create an issue on (Fix #ISSUE), and have described the bug/feature there in detail
- [x] Compiling and unit tests pass locally with my changes
- [] I have added tests that prove my fix is effective or that my feature works
- [] If this change need a document change, I have updated the document
- [] Any dependent changes have been merged
