### PR TITLE
[Bug] Fix bug introduced by split RowsDelFiltered profile

### DIFF
--- a/be/src/olap/olap_common.h
+++ b/be/src/olap/olap_common.h
@@ -259,8 +259,11 @@ struct OlapReaderStatistics {
     int64_t rows_key_range_filtered = 0;
     int64_t rows_stats_filtered = 0;
     int64_t rows_bf_filtered = 0;
-    int64_t rows_del_filtered = 0;
-    int64_t rows_conditions_filtered = 0;
+    // Including the number of rows filtered out according to the Delete information in the Tablet, 
+    // and the number of rows filtered for marked deleted rows under the unique key model.
+    int64_t rows_del_filtered = 0; 
+    // the number of rows filtered by various column indexes.
+    int64_t rows_conditions_filtered = 0; 
 
     int64_t index_load_ns = 0;
 

--- a/be/src/olap/rowset/beta_rowset_reader.h
+++ b/be/src/olap/rowset/beta_rowset_reader.h
@@ -48,7 +48,8 @@ public:
 
     RowsetSharedPtr rowset() override { return std::dynamic_pointer_cast<Rowset>(_rowset); }
 
-    int64_t filtered_rows() override { return _stats->rows_del_filtered; }
+    // Return the total number of filtered rows, will be used for validation of schema change
+    int64_t filtered_rows() override { return _stats->rows_del_filtered + _stats->rows_conditions_filtered; }
 
 private:
     BetaRowsetSharedPtr _rowset;


### PR DESCRIPTION
## Proposed changes

bug introduced from pr #4825, will cause `schema_change` to report an error:
```
schema_change.cpp:1271] fail to check row num! source_rows=1, merged_rows=0, filtered_rows=0, new_index_rows=0
schema_change.cpp:1921] failed to process the version. version=2-2
schema_change.cpp:1615] failed to alter tablet. base_tablet=44643.1383650721.b140317f6662c1e0-65bcbc87db8d22bc, drop new_tablet=45680.1530531459.474e41f3dd538fb6-9284085daac24f83
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)