### PR TITLE
[Optimize] Send fragments in batch to reduce RPC

### DIFF
--- a/be/src/olap/push_handler.cpp
+++ b/be/src/olap/push_handler.cpp
@@ -944,7 +944,7 @@ OLAPStatus PushBrokerReader::init(const Schema* schema,
     fragment_params.protocol_version = PaloInternalServiceVersion::V1;
     TQueryOptions query_options;
     TQueryGlobals query_globals;
-    _runtime_state.reset(new RuntimeState(fragment_params, query_options, query_globals,
+    _runtime_state.reset(new RuntimeState(params, query_options, query_globals,
                                           ExecEnv::GetInstance()));
     DescriptorTbl* desc_tbl = NULL;
     Status status = DescriptorTbl::create(_runtime_state->obj_pool(), t_desc_tbl, &desc_tbl);

--- a/be/src/olap/rowset/beta_rowset_reader.h
+++ b/be/src/olap/rowset/beta_rowset_reader.h
@@ -48,7 +48,7 @@ public:
 
     RowsetSharedPtr rowset() override { return std::dynamic_pointer_cast<Rowset>(_rowset); }
 
-    int64_t filtered_rows() override { return _stats->rows_del_filtered; }
+    int64_t filtered_rows() override { return _stats->rows_del_filtered + _stats->rows_conditions_filtered; }
 
 private:
     BetaRowsetSharedPtr _rowset;

--- a/be/src/runtime/fragment_mgr.cpp
+++ b/be/src/runtime/fragment_mgr.cpp
@@ -463,6 +463,7 @@ void FragmentMgr::exec_actual(
     // NOTE: 'exec_state' is desconstructed here without lock
 }
 
+// _exec_actual_v2 works with batch fragment execution
 void FragmentMgr::_exec_actual_v2(
         std::shared_ptr<FragmentExecState> exec_state,
         std::shared_ptr<BatchFragmentsCtx> batch_ctx,

--- a/be/src/runtime/plan_fragment_executor.cpp
+++ b/be/src/runtime/plan_fragment_executor.cpp
@@ -79,8 +79,9 @@ Status PlanFragmentExecutor::prepare(
                << " backend_num=" << request.backend_num;
     // VLOG(2) << "request:\n" << apache::thrift::ThriftDebugString(request);
 
+    const TQueryGlobals& query_globals = batch_ctx == nullptr ? request.query_globals : batch_ctx->query_globals;
     _runtime_state.reset(new RuntimeState(
-            params, request.query_options, batch_ctx->query_globals, _exec_env));
+            params, request.query_options, query_globals, _exec_env));
 
     RETURN_IF_ERROR(_runtime_state->init_mem_trackers(_query_id));
     _runtime_state->set_be_number(request.backend_num);
@@ -141,166 +142,13 @@ Status PlanFragmentExecutor::prepare(
     RETURN_IF_ERROR(_runtime_state->create_block_mgr());
 
     // set up desc tbl
-    _runtime_state->set_desc_tbl(batch_ctx->desc_tbl);
-
-    // set up plan
-    DCHECK(request.__isset.fragment);
-    RETURN_IF_ERROR(
-            ExecNode::create_tree(_runtime_state.get(), obj_pool(), request.fragment.plan, *(batch_ctx->desc_tbl), &_plan));
-    _runtime_state->set_fragment_root_id(_plan->id());
-
-    if (params.__isset.debug_node_id) {
-        DCHECK(params.__isset.debug_action);
-        DCHECK(params.__isset.debug_phase);
-        ExecNode::set_debug_options(
-            params.debug_node_id, params.debug_phase,
-            params.debug_action, _plan);
-    }
-
-    // set #senders of exchange nodes before calling Prepare()
-    std::vector<ExecNode*> exch_nodes;
-    _plan->collect_nodes(TPlanNodeType::EXCHANGE_NODE, &exch_nodes);
-    BOOST_FOREACH(ExecNode * exch_node, exch_nodes) {
-        DCHECK_EQ(exch_node->type(), TPlanNodeType::EXCHANGE_NODE);
-        int num_senders = find_with_default(params.per_exch_num_senders, exch_node->id(), 0);
-        DCHECK_GT(num_senders, 0);
-        static_cast<ExchangeNode*>(exch_node)->set_num_senders(num_senders);
-    }
- 
-    RETURN_IF_ERROR(_plan->prepare(_runtime_state.get()));
-    // set scan ranges
-    std::vector<ExecNode*> scan_nodes;
-    std::vector<TScanRangeParams> no_scan_ranges;
-    _plan->collect_scan_nodes(&scan_nodes);
-    VLOG(1) << "scan_nodes.size()=" << scan_nodes.size();
-    VLOG(1) << "params.per_node_scan_ranges.size()=" << params.per_node_scan_ranges.size();
-
-    _plan->try_do_aggregate_serde_improve();
-
-    for (int i = 0; i < scan_nodes.size(); ++i) {
-        ScanNode* scan_node = static_cast<ScanNode*>(scan_nodes[i]);
-        const std::vector<TScanRangeParams>& scan_ranges =
-            find_with_default(params.per_node_scan_ranges, scan_node->id(), no_scan_ranges);
-        scan_node->set_scan_ranges(scan_ranges);
-        VLOG(1) << "scan_node_Id=" << scan_node->id() << " size=" << scan_ranges.size();
-    }
-
-    _runtime_state->set_per_fragment_instance_idx(params.sender_id);
-    _runtime_state->set_num_per_fragment_instances(params.num_senders);
-
-    // set up sink, if required
-    if (request.fragment.__isset.output_sink) {
-        RETURN_IF_ERROR(DataSink::create_data_sink(obj_pool(),
-                        request.fragment.output_sink, request.fragment.output_exprs, params,
-                        row_desc(), &_sink));
-        RETURN_IF_ERROR(_sink->prepare(runtime_state()));
-
-        RuntimeProfile* sink_profile = _sink->profile();
-
-        if (sink_profile != NULL) {
-            profile()->add_child(sink_profile, true, NULL);
-        }
-
-        _collect_query_statistics_with_every_batch = params.__isset.send_query_statistics_with_every_batch ?
-            params.send_query_statistics_with_every_batch : false;
+    DescriptorTbl* desc_tbl = nullptr;
+    if (batch_ctx != nullptr) {
+        desc_tbl = batch_ctx->desc_tbl;
     } else {
-        // _sink is set to NULL
-        _sink.reset(NULL);
+        DCHECK(request.__isset.desc_tbl);
+        RETURN_IF_ERROR(DescriptorTbl::create(obj_pool(), request.desc_tbl, &desc_tbl));
     }
-
-    // set up profile counters
-    profile()->add_child(_plan->runtime_profile(), true, NULL);
-    _rows_produced_counter = ADD_COUNTER(profile(), "RowsProduced", TUnit::UNIT);
-
-    _row_batch.reset(new RowBatch(
-            _plan->row_desc(),
-            _runtime_state->batch_size(),
-            _runtime_state->instance_mem_tracker().get()));
-    // _row_batch->tuple_data_pool()->set_limits(*_runtime_state->mem_trackers());
-    VLOG(3) << "plan_root=\n" << _plan->debug_string();
-    _prepared = true;
-
-    _query_statistics.reset(new QueryStatistics());
-    if (_sink.get() != NULL) {
-        _sink->set_query_statistics(_query_statistics);
-    }
-    return Status::OK();
-}
-
-Status PlanFragmentExecutor::prepare(const TExecPlanFragmentParams& request) {
-    const TPlanFragmentExecParams& params = request.params;
-    _query_id = params.query_id;
-
-    LOG(INFO) << "Prepare(): query_id=" << print_id(_query_id)
-               << " fragment_instance_id=" << print_id(params.fragment_instance_id)
-               << " backend_num=" << request.backend_num;
-    // VLOG(2) << "request:\n" << apache::thrift::ThriftDebugString(request);
-
-    _runtime_state.reset(new RuntimeState(
-            request, request.query_options, request.query_globals, _exec_env));
-
-    RETURN_IF_ERROR(_runtime_state->init_mem_trackers(_query_id));
-    _runtime_state->set_be_number(request.backend_num);
-    if (request.__isset.import_label) {
-        _runtime_state->set_import_label(request.import_label);
-    }
-    if (request.__isset.db_name) {
-        _runtime_state->set_db_name(request.db_name);
-    }
-    if (request.__isset.load_job_id) {
-        _runtime_state->set_load_job_id(request.load_job_id);
-    }
-    if (request.__isset.load_error_hub_info) {
-        _runtime_state->set_load_error_hub_info(request.load_error_hub_info);
-    }
-
-    if (request.query_options.__isset.is_report_success) {
-        _is_report_success = request.query_options.is_report_success;
-    }
-
-    // Reserve one main thread from the pool
-    _runtime_state->resource_pool()->acquire_thread_token();
-    _has_thread_token = true;
-
-    _average_thread_tokens = profile()->add_sampling_counter(
-            "AverageThreadTokens",
-            boost::bind<int64_t>(boost::mem_fn(
-                    &ThreadResourceMgr::ResourcePool::num_threads),
-                    _runtime_state->resource_pool()));
-
-    // if (_exec_env->process_mem_tracker() != NULL) {
-    //     // we have a global limit
-    //     _runtime_state->mem_trackers()->push_back(_exec_env->process_mem_tracker());
-    // }
-
-    int64_t bytes_limit = request.query_options.mem_limit;
-    if (bytes_limit <= 0) {
-        // sometimes the request does not set the query mem limit, we use default one.
-        // TODO(cmy): we should not allow request without query mem limit.
-        bytes_limit = 2 * 1024 * 1024 * 1024L;
-    }
-
-    if (bytes_limit > _exec_env->process_mem_tracker()->limit()) {
-        LOG(WARNING) << "Query memory limit "
-            << PrettyPrinter::print(bytes_limit, TUnit::BYTES)
-            << " exceeds process memory limit of "
-            << PrettyPrinter::print(_exec_env->process_mem_tracker()->limit(), TUnit::BYTES)
-            << ". Using process memory limit instead";
-        bytes_limit = _exec_env->process_mem_tracker()->limit();
-    }
-    // NOTE: this MemTracker only for olap
-    _mem_tracker = MemTracker::CreateTracker(bytes_limit, "fragment mem-limit", _exec_env->process_mem_tracker());
-    _runtime_state->set_fragment_mem_tracker(_mem_tracker);
-
-    LOG(INFO) << "Using query memory limit: "
-        << PrettyPrinter::print(bytes_limit, TUnit::BYTES);
-
-    RETURN_IF_ERROR(_runtime_state->create_block_mgr());
-
-    // set up desc tbl
-    DescriptorTbl* desc_tbl = NULL;
-    DCHECK(request.__isset.desc_tbl);
-    RETURN_IF_ERROR(DescriptorTbl::create(obj_pool(), request.desc_tbl, &desc_tbl));
     _runtime_state->set_desc_tbl(desc_tbl);
 
     // set up plan
@@ -309,12 +157,12 @@ Status PlanFragmentExecutor::prepare(const TExecPlanFragmentParams& request) {
             ExecNode::create_tree(_runtime_state.get(), obj_pool(), request.fragment.plan, *desc_tbl, &_plan));
     _runtime_state->set_fragment_root_id(_plan->id());
 
-    if (request.params.__isset.debug_node_id) {
-        DCHECK(request.params.__isset.debug_action);
-        DCHECK(request.params.__isset.debug_phase);
+    if (params.__isset.debug_node_id) {
+        DCHECK(params.__isset.debug_action);
+        DCHECK(params.__isset.debug_phase);
         ExecNode::set_debug_options(
-            request.params.debug_node_id, request.params.debug_phase,
-            request.params.debug_action, _plan);
+            params.debug_node_id, params.debug_phase,
+            params.debug_action, _plan);
     }
 
     // set #senders of exchange nodes before calling Prepare()

--- a/be/src/runtime/plan_fragment_executor.h
+++ b/be/src/runtime/plan_fragment_executor.h
@@ -93,11 +93,10 @@ public:
     // If request.query_options.mem_limit > 0, it is used as an approximate limit on the
     // number of bytes this query can consume at runtime.
     // The query will be aborted (MEM_LIMIT_EXCEEDED) if it goes over that limit.
-    Status prepare(const TExecPlanFragmentParams& request);
-
+    // If batch_ctx is not null, some components will be got from batch_ctx.
     Status prepare(
             const TExecPlanFragmentParams& request,
-            const BatchFragmentsCtx* batch_ctx);
+            const BatchFragmentsCtx* batch_ctx = nullptr);
 
     // Start execution. Call this prior to get_next().
     // If this fragment has a sink, open() will send all rows produced

--- a/be/src/runtime/runtime_state.cpp
+++ b/be/src/runtime/runtime_state.cpp
@@ -73,32 +73,6 @@ RuntimeState::RuntimeState(
 }
 
 RuntimeState::RuntimeState(
-        const TExecPlanFragmentParams& fragment_params,
-        const TQueryOptions& query_options,
-        const TQueryGlobals& query_globals, ExecEnv* exec_env) :
-            _fragment_mem_tracker(nullptr),
-            _profile("Fragment " + print_id(fragment_params.params.fragment_instance_id)),
-            _obj_pool(new ObjectPool()),
-            _data_stream_recvrs_pool(new ObjectPool()),
-            _unreported_error_idx(0),
-            _query_id(fragment_params.params.query_id),
-            _is_cancelled(false),
-            _per_fragment_instance_idx(0),
-            _root_node_id(-1),
-            _num_rows_load_total(0),
-            _num_rows_load_filtered(0),
-            _num_rows_load_unselected(0),
-            _num_print_error_rows(0),
-            _normal_row_number(0),
-            _error_row_number(0),
-            _error_log_file_path(""),
-            _error_log_file(nullptr),
-            _instance_buffer_reservation(new ReservationTracker) {
-    Status status = init(fragment_params.params.fragment_instance_id, query_options, query_globals, exec_env);
-    DCHECK(status.ok());
-}
-
-RuntimeState::RuntimeState(
         const TPlanFragmentExecParams& fragment_exec_params,
         const TQueryOptions& query_options,
         const TQueryGlobals& query_globals, ExecEnv* exec_env) :

--- a/be/src/runtime/runtime_state.cpp
+++ b/be/src/runtime/runtime_state.cpp
@@ -98,6 +98,32 @@ RuntimeState::RuntimeState(
     DCHECK(status.ok());
 }
 
+RuntimeState::RuntimeState(
+        const TPlanFragmentExecParams& fragment_exec_params,
+        const TQueryOptions& query_options,
+        const TQueryGlobals& query_globals, ExecEnv* exec_env) :
+            _fragment_mem_tracker(nullptr),
+            _profile("Fragment " + print_id(fragment_exec_params.fragment_instance_id)),
+            _obj_pool(new ObjectPool()),
+            _data_stream_recvrs_pool(new ObjectPool()),
+            _unreported_error_idx(0),
+            _query_id(fragment_exec_params.query_id),
+            _is_cancelled(false),
+            _per_fragment_instance_idx(0),
+            _root_node_id(-1),
+            _num_rows_load_total(0),
+            _num_rows_load_filtered(0),
+            _num_rows_load_unselected(0),
+            _num_print_error_rows(0),
+            _normal_row_number(0),
+            _error_row_number(0),
+            _error_log_file_path(""),
+            _error_log_file(nullptr),
+            _instance_buffer_reservation(new ReservationTracker) {
+    Status status = init(fragment_exec_params.fragment_instance_id, query_options, query_globals, exec_env);
+    DCHECK(status.ok());
+}
+
 RuntimeState::RuntimeState(const TQueryGlobals& query_globals)
     : _profile("<unnamed>"),
       _obj_pool(new ObjectPool()),

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -70,11 +70,6 @@ public:
                  const TQueryGlobals& query_globals, ExecEnv* exec_env);
 
     RuntimeState(
-        const TExecPlanFragmentParams& fragment_params,
-        const TQueryOptions& query_options,
-        const TQueryGlobals& query_globals, ExecEnv* exec_env);
-
-    RuntimeState(
         const TPlanFragmentExecParams& fragment_exec_params,
         const TQueryOptions& query_options,
         const TQueryGlobals& query_globals, ExecEnv* exec_env);

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -74,6 +74,11 @@ public:
         const TQueryOptions& query_options,
         const TQueryGlobals& query_globals, ExecEnv* exec_env);
 
+    RuntimeState(
+        const TPlanFragmentExecParams& fragment_exec_params,
+        const TQueryOptions& query_options,
+        const TQueryGlobals& query_globals, ExecEnv* exec_env);
+
     // RuntimeState for executing expr in fe-support.
     RuntimeState(const TQueryGlobals& query_globals);
 

--- a/be/src/runtime/test_env.cc
+++ b/be/src/runtime/test_env.cc
@@ -53,7 +53,7 @@ RuntimeState* TestEnv::create_runtime_state(int64_t query_id) {
     TExecPlanFragmentParams plan_params = TExecPlanFragmentParams();
     plan_params.params.query_id.hi = 0;
     plan_params.params.query_id.lo = query_id;
-    return new RuntimeState(plan_params, TQueryOptions(), TQueryGlobals(), _exec_env.get());
+    return new RuntimeState(plan_params.params, TQueryOptions(), TQueryGlobals(), _exec_env.get());
 }
 
 Status TestEnv::create_query_state(int64_t query_id, int max_buffers, int block_size,

--- a/be/src/service/internal_service.h
+++ b/be/src/service/internal_service.h
@@ -48,6 +48,13 @@ public:
         PExecPlanFragmentResult* result,
         google::protobuf::Closure* done) override;
 
+    // "request" contains a batch of plan fragments.
+    void batch_exec_plan_fragments(
+        google::protobuf::RpcController* controller,
+        const PExecPlanFragmentRequest* request,
+        PExecPlanFragmentResult* result,
+        google::protobuf::Closure* done) override;
+
     void cancel_plan_fragment(
         google::protobuf::RpcController* controller,
         const PCancelPlanFragmentRequest* request,
@@ -103,6 +110,7 @@ public:
         google::protobuf::Closure* done) override;
 private:
     Status _exec_plan_fragment(brpc::Controller* cntl);
+    Status _batch_exec_plan_fragments(brpc::Controller* cntl);
 private:
     ExecEnv* _exec_env;
     PriorityThreadPool _tablet_worker_pool;

--- a/be/test/runtime/buffered_block_mgr2_test.cpp
+++ b/be/test/runtime/buffered_block_mgr2_test.cpp
@@ -553,8 +553,6 @@ protected:
         const int num_threads = 4;
         boost::thread_group workers;
         // Create a shared RuntimeState with no BufferedBlockMgr2.
-        // RuntimeState* shared_state = new RuntimeState(TExecPlanFragmentParams(), "",
-        //     _test_env->exec_env());
         RuntimeState* shared_state = new RuntimeState(TUniqueId(), TQueryOptions(), TQueryGlobals(),
                                                       _test_env->exec_env());
         for (int i = 0; i < num_threads; ++i) {

--- a/be/test/runtime/fragment_mgr_test.cpp
+++ b/be/test/runtime/fragment_mgr_test.cpp
@@ -37,7 +37,9 @@ PlanFragmentExecutor::PlanFragmentExecutor(ExecEnv* exec_env,
 
 PlanFragmentExecutor::~PlanFragmentExecutor() {}
 
-Status PlanFragmentExecutor::prepare(const TExecPlanFragmentParams& request) {
+Status PlanFragmentExecutor::prepare(
+        const TExecPlanFragmentParams& request,
+        const BatchFragmentsCtx* batch_ctx) {
     return s_prepare_status;
 }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/Config.java
@@ -1293,4 +1293,12 @@ public class Config extends ConfigBase {
      */
     @ConfField
     public static String http_api_extra_base_path = "";
+
+    /*
+     * Used to enable the batch fragment execution feature.
+     * This is to avoid some error when using this new feature.
+     * Should be removed later.
+     */
+    @ConfField
+    public static boolean enable_batch_fragment_execution = true;
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/QueryPlannerProfile.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/QueryPlannerProfile.java
@@ -1,0 +1,104 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.common.util;
+
+import org.apache.doris.thrift.TUnit;
+
+/**
+ * This profile is mainly used to record the time-consuming situation related to
+ * executing SQL parsing, planning, scheduling, and fetching results on the FE side.
+ * Can be expanded later.
+ *
+ * All timestamp is in nona second
+ */
+public class QueryPlannerProfile {
+    public static final String KEY_ANALYSIS = "Analysis Time";
+    public static final String KEY_PLAN = "Plan Time";
+    public static final String KEY_SCHEDULE = "Schedule Time";
+    public static final String KEY_FETCH = "Wait and Fetch Result Time";
+
+    // timestamp of query begin
+    private long queryBeginTime = -1;
+    // Analysis end time
+    private long queryAnalysisFinishTime = -1;
+    // Plan end time
+    private long queryPlanFinishTime = -1;
+    // Fragment schedule and send end time
+    private long queryScheduleFinishTime = -1;
+    // Query result fetch end time
+    private long queryFetchResultFinishTime = -1;
+
+    public void setQueryBeginTime() {
+        this.queryBeginTime = TimeUtils.getStartTime();
+    }
+
+    public void setQueryAnalysisFinishTime() {
+        this.queryAnalysisFinishTime = TimeUtils.getStartTime();
+    }
+
+    public void setQueryPlanFinishTime() {
+        this.queryPlanFinishTime = TimeUtils.getStartTime();
+    }
+
+    public void setQueryScheduleFinishTime() {
+        this.queryScheduleFinishTime = TimeUtils.getStartTime();
+    }
+
+    public void setQueryFetchResultFinishTime() {
+        this.queryFetchResultFinishTime = TimeUtils.getStartTime();
+    }
+
+    public long getQueryBeginTime() {
+        return queryBeginTime;
+    }
+
+    private String getPrettyQueryAnalysisFinishTime() {
+        if (queryBeginTime == -1 || queryAnalysisFinishTime == -1) {
+            return "N/A";
+        }
+        return RuntimeProfile.printCounter(queryAnalysisFinishTime - queryBeginTime, TUnit.TIME_NS);
+    }
+
+    private String getPrettyQueryPlanFinishTime() {
+        if (queryAnalysisFinishTime == -1 || queryPlanFinishTime == -1) {
+            return "N/A";
+        }
+        return RuntimeProfile.printCounter(queryPlanFinishTime - queryAnalysisFinishTime, TUnit.TIME_NS);
+    }
+
+    private String getPrettyQueryScheduleFinishTime() {
+        if (queryPlanFinishTime == -1 || queryScheduleFinishTime == -1) {
+            return "N/A";
+        }
+        return RuntimeProfile.printCounter(queryScheduleFinishTime - queryPlanFinishTime, TUnit.TIME_NS);
+    }
+
+    private String getPrettyQueryFetchResultFinishTime() {
+        if (queryScheduleFinishTime == -1 || queryFetchResultFinishTime == -1) {
+            return "N/A";
+        }
+        return RuntimeProfile.printCounter(queryFetchResultFinishTime - queryScheduleFinishTime, TUnit.TIME_NS);
+    }
+
+    public void initRuntimeProfile(RuntimeProfile plannerProfile) {
+        plannerProfile.addInfoString(KEY_ANALYSIS, getPrettyQueryAnalysisFinishTime());
+        plannerProfile.addInfoString(KEY_PLAN, getPrettyQueryPlanFinishTime());
+        plannerProfile.addInfoString(KEY_SCHEDULE, getPrettyQueryScheduleFinishTime());
+        plannerProfile.addInfoString(KEY_FETCH, getPrettyQueryFetchResultFinishTime());
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/RuntimeProfile.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/RuntimeProfile.java
@@ -240,8 +240,8 @@ public class RuntimeProfile {
             this.printChildCounters(prefix + "  ", childCounterName, builder);
         }
     }
-    
-    private String printCounter(long value, TUnit type) {
+
+    public static String printCounter(long value, TUnit type) {
         StringBuilder builder = new StringBuilder();
         long tmpValue = value;
         switch (type) {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
@@ -1977,6 +1977,7 @@ public class Coordinator {
                 paramsList.setParamsList(tRequests);
                 pRequest.setRequest(paramsList);
 
+                LOG.debug("send fragment to backend: {}, query: {}", backend.getHost(), DebugUtil.printId(queryId));
                 return BackendServiceProxy.getInstance().batchExecPlanFragmentsAsync(
                         new TNetworkAddress(backend.getHost(), backend.getBrpcPort()), pRequest);
             } catch (RpcException e) {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -29,15 +29,15 @@ import org.apache.doris.analysis.QueryStmt;
 import org.apache.doris.analysis.RedirectStatus;
 import org.apache.doris.analysis.SelectStmt;
 import org.apache.doris.analysis.SetStmt;
+import org.apache.doris.analysis.SetVar;
 import org.apache.doris.analysis.ShowStmt;
 import org.apache.doris.analysis.SqlParser;
 import org.apache.doris.analysis.SqlScanner;
 import org.apache.doris.analysis.StatementBase;
 import org.apache.doris.analysis.StmtRewriter;
+import org.apache.doris.analysis.StringLiteral;
 import org.apache.doris.analysis.UnsupportedStmt;
 import org.apache.doris.analysis.UseStmt;
-import org.apache.doris.analysis.SetVar;
-import org.apache.doris.analysis.StringLiteral;
 import org.apache.doris.catalog.Catalog;
 import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.Database;
@@ -55,6 +55,7 @@ import org.apache.doris.common.UserException;
 import org.apache.doris.common.Version;
 import org.apache.doris.common.util.DebugUtil;
 import org.apache.doris.common.util.ProfileManager;
+import org.apache.doris.common.util.QueryPlannerProfile;
 import org.apache.doris.common.util.RuntimeProfile;
 import org.apache.doris.common.util.SqlParserUtils;
 import org.apache.doris.common.util.TimeUtils;
@@ -123,6 +124,8 @@ public class StmtExecutor {
     private PQueryStatistics statisticsForAuditLog;
     private boolean isCached;
 
+    private QueryPlannerProfile plannerProfile = new QueryPlannerProfile();
+
     // this constructor is mainly for proxy
     public StmtExecutor(ConnectContext context, OriginStatement originStmt, boolean isProxy) {
         this.context = context;
@@ -146,7 +149,8 @@ public class StmtExecutor {
     }
 
     // At the end of query execution, we begin to add up profile
-    public void initProfile(long beginTimeInNanoSecond) {
+    public void initProfile(QueryPlannerProfile plannerProfile) {
+        // Summary profile
         profile = new RuntimeProfile("Query");
         summaryProfile = new RuntimeProfile("Summary");
         summaryProfile.addInfoString(ProfileManager.QUERY_ID, DebugUtil.printId(context.queryId()));
@@ -165,9 +169,14 @@ public class StmtExecutor {
         summaryProfile.addInfoString(ProfileManager.SQL_STATEMENT, originStmt.originStmt);
         summaryProfile.addInfoString(ProfileManager.IS_CACHED, isCached ? "Yes" : "No");
 
+        RuntimeProfile plannerRuntimeProfile = new RuntimeProfile("Execution Summary");
+        plannerProfile.initRuntimeProfile(plannerRuntimeProfile);
+        summaryProfile.addChild(plannerRuntimeProfile);
+
         profile.addChild(summaryProfile);
+
         if (coord != null) {
-            coord.getQueryProfile().getCounterTotalTime().setValue(TimeUtils.getEstimatedTime(beginTimeInNanoSecond));
+            coord.getQueryProfile().getCounterTotalTime().setValue(TimeUtils.getEstimatedTime(plannerProfile.getQueryBeginTime()));
             coord.endProfile();
             profile.addChild(coord.getQueryProfile());
             coord = null;
@@ -229,7 +238,7 @@ public class StmtExecutor {
     //  IOException: talk with client failed.
     public void execute() throws Exception {
 
-        long beginTimeInNanoSecond = TimeUtils.getStartTime();
+        plannerProfile.setQueryBeginTime();
         context.setStmtId(STMT_ID_GENERATOR.incrementAndGet());
 
         // set query id
@@ -270,7 +279,7 @@ public class StmtExecutor {
                         }
                         handleQueryStmt();
                         if (context.getSessionVariable().isReportSucc()) {
-                            writeProfile(beginTimeInNanoSecond);
+                            writeProfile();
                         }
                         break;
                     } catch (RpcException e) {
@@ -298,7 +307,7 @@ public class StmtExecutor {
                 try {
                     handleInsertStmt();
                     if (context.getSessionVariable().isReportSucc()) {
-                        writeProfile(beginTimeInNanoSecond);
+                        writeProfile();
                     }
                 } catch (Throwable t) {
                     LOG.warn("handle insert stmt fail", t);
@@ -364,8 +373,8 @@ public class StmtExecutor {
         masterOpExecutor.execute();
     }
 
-    private void writeProfile(long beginTimeInNanoSecond) {
-        initProfile(beginTimeInNanoSecond);
+    private void writeProfile() {
+        initProfile(plannerProfile);
         profile.computeTimeInChildProfile();
         StringBuilder builder = new StringBuilder();
         profile.prettyPrint(builder, "");
@@ -533,6 +542,7 @@ public class StmtExecutor {
                 if (isExplain) parsedStmt.setIsExplain(isExplain, isVerbose);
             }
         }
+        plannerProfile.setQueryAnalysisFinishTime();
 
         // create plan
         planner = new Planner();
@@ -544,6 +554,8 @@ public class StmtExecutor {
         }
         // TODO(zc):
         // Preconditions.checkState(!analyzer.hasUnassignedConjuncts());
+
+        plannerProfile.setQueryPlanFinishTime();
     }
 
     private void resetAnalyzerAndStmt() {
@@ -747,6 +759,7 @@ public class StmtExecutor {
         QeProcessorImpl.INSTANCE.registerQuery(context.queryId(),
                 new QeProcessorImpl.QueryInfo(context, originStmt.originStmt, coord));
         coord.exec();
+        plannerProfile.setQueryScheduleFinishTime();
         while (true) {
             batch = coord.getNext();
             // for outfile query, there will be only one empty batch send back with eos flag
@@ -776,6 +789,7 @@ public class StmtExecutor {
         } else {
             context.getState().setOk(statisticsForAuditLog.returned_rows, 0, "");
         }
+        plannerProfile.setQueryFetchResultFinishTime();
     }
 
     // Process a select statement.

--- a/fe/fe-core/src/main/java/org/apache/doris/rpc/PBackendService.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/rpc/PBackendService.java
@@ -17,18 +17,18 @@
 
 package org.apache.doris.rpc;
 
+import org.apache.doris.proto.PCacheResponse;
 import org.apache.doris.proto.PCancelPlanFragmentRequest;
 import org.apache.doris.proto.PCancelPlanFragmentResult;
+import org.apache.doris.proto.PClearCacheRequest;
 import org.apache.doris.proto.PExecPlanFragmentResult;
+import org.apache.doris.proto.PFetchCacheRequest;
+import org.apache.doris.proto.PFetchCacheResult;
 import org.apache.doris.proto.PFetchDataResult;
 import org.apache.doris.proto.PProxyRequest;
 import org.apache.doris.proto.PProxyResult;
 import org.apache.doris.proto.PTriggerProfileReportResult;
 import org.apache.doris.proto.PUpdateCacheRequest;
-import org.apache.doris.proto.PClearCacheRequest;
-import org.apache.doris.proto.PCacheResponse;
-import org.apache.doris.proto.PFetchCacheRequest;
-import org.apache.doris.proto.PFetchCacheResult;
 
 import com.baidu.jprotobuf.pbrpc.ProtobufRPC;
 
@@ -38,6 +38,10 @@ public interface PBackendService {
     @ProtobufRPC(serviceName = "PBackendService", methodName = "exec_plan_fragment",
             attachmentHandler = ThriftClientAttachmentHandler.class, onceTalkTimeout = 10000)
     Future<PExecPlanFragmentResult> execPlanFragmentAsync(PExecPlanFragmentRequest request);
+
+    @ProtobufRPC(serviceName = "PBackendService", methodName = "batch_exec_plan_fragments",
+            attachmentHandler = ThriftClientAttachmentHandler.class, onceTalkTimeout = 10000)
+    Future<PExecPlanFragmentResult> batchExecPlanFragmentsAsync(PExecPlanFragmentRequest request);
 
     @ProtobufRPC(serviceName = "PBackendService", methodName = "cancel_plan_fragment",
             onceTalkTimeout = 5000)

--- a/gensrc/proto/internal_service.proto
+++ b/gensrc/proto/internal_service.proto
@@ -247,6 +247,7 @@ message PProxyResult {
 service PBackendService {
     rpc transmit_data(PTransmitDataParams) returns (PTransmitDataResult);
     rpc exec_plan_fragment(PExecPlanFragmentRequest) returns (PExecPlanFragmentResult);
+    rpc batch_exec_plan_fragments(PExecPlanFragmentRequest) returns (PExecPlanFragmentResult);
     rpc cancel_plan_fragment(PCancelPlanFragmentRequest) returns (PCancelPlanFragmentResult);
     rpc fetch_data(PFetchDataRequest) returns (PFetchDataResult);
     rpc tablet_writer_open(PTabletWriterOpenRequest) returns (PTabletWriterOpenResult);

--- a/gensrc/proto/palo_internal_service.proto
+++ b/gensrc/proto/palo_internal_service.proto
@@ -29,6 +29,7 @@ option cc_generic_services = true;
 service PInternalService {
     rpc transmit_data(doris.PTransmitDataParams) returns (doris.PTransmitDataResult);
     rpc exec_plan_fragment(doris.PExecPlanFragmentRequest) returns (doris.PExecPlanFragmentResult);
+    rpc batch_exec_plan_fragments(doris.PExecPlanFragmentRequest) returns (doris.PExecPlanFragmentResult);
     rpc cancel_plan_fragment(doris.PCancelPlanFragmentRequest) returns (doris.PCancelPlanFragmentResult);
     rpc fetch_data(doris.PFetchDataRequest) returns (doris.PFetchDataResult);
     rpc tablet_writer_open(doris.PTabletWriterOpenRequest) returns (doris.PTabletWriterOpenResult);

--- a/gensrc/thrift/PaloInternalService.thrift
+++ b/gensrc/thrift/PaloInternalService.thrift
@@ -223,6 +223,7 @@ struct TExecPlanFragmentParams {
   2: optional Planner.TPlanFragment fragment
 
   // required in V1
+  // @Deprecated, move to TExecPlanFragmentParamsList
   3: optional Descriptors.TDescriptorTable desc_tbl
 
   // required in V1
@@ -231,6 +232,7 @@ struct TExecPlanFragmentParams {
   // Initiating coordinator.
   // TODO: determine whether we can get this somehow via the Thrift rpc mechanism.
   // required in V1
+  // @Deprecated, move to TExecPlanFragmentParamsList
   5: optional Types.TNetworkAddress coord
 
   // backend number assigned by coord to identify backend
@@ -239,6 +241,7 @@ struct TExecPlanFragmentParams {
 
   // Global query parameters assigned by coordinator.
   // required in V1
+  // @Deprecated, move to TExecPlanFragmentParamsList
   7: optional TQueryGlobals query_globals
 
   // options for the query
@@ -250,6 +253,7 @@ struct TExecPlanFragmentParams {
   9: optional bool is_report_success
 
   // required in V1
+  // @Deprecated, move to TExecPlanFragmentParamsList
   10: optional Types.TResourceInfo resource_info
 
   // load job related
@@ -257,6 +261,18 @@ struct TExecPlanFragmentParams {
   12: optional string db_name
   13: optional i64 load_job_id
   14: optional TLoadErrorHubInfo load_error_hub_info
+}
+
+// A set of TExecPlanFragmentParams.
+// The common part in a set of TExecPlanFragmentParams is extracted
+// to avoid sending duplicate content in the query plan.
+struct TExecPlanFragmentParamsList {
+  1: optional Types.TUniqueId query_id
+  2: optional Descriptors.TDescriptorTable desc_tbl
+  3: optional Types.TNetworkAddress coord
+  4: optional TQueryGlobals query_globals
+  5: optional Types.TResourceInfo resource_info
+  6: optional list<TExecPlanFragmentParams> paramsList
 }
 
 struct TExecPlanFragmentResult {


### PR DESCRIPTION
## Proposed changes

This CL mainly changes:

1. Send and execute Fragments in batch

    In the previous implementation, a SQL execution plan may generate multiple Fragments.
Even if these Fragments are sent to the same BE node, they are sent separately in multiple RPCs.
These Fragments will have some common information, such as DescriptorTable, QueryGlobals, etc.
Sending one by one through RPC will repeatedly DeSer these information, resulting in unnecessary overhead.

    After the modification, the Coordinator merges multiple Fragments of same BE and sends them in one RPC,
and extracts common information to avoid multiple repeated DeSer operations. At the same time,
the Fragment execution part on the BE side is modified, multiple Fragments are executed in one request,
and the common structure is avoided constructing repeatedly.

    In the local single-node test, a SQL which generates 300 fragments, the execution time is reduced from
7 seconds to 2 seconds. The main reduction part is the receiving and executing Fragment part on the BE side.
The remaining time is mainly spent on query planning on the FE side, which will be improved in next PR.

2. Add the time-consuming part of FE logic in Profile

    Including SQL analysis, planning, Fragment scheduling and sending on the FE side, and the time to fetch data.

3. Add a FE config to switch on/off this feature

    Add a temp config `enable_batch_fragment_execution` to switch on/off this "batch execution" feature.
In case that some bugs happen after online. This CL has pass our Daily Test. And I test it with 100 concurrency by
`jmeter`, both on and off, it works well and the performance remain the same(For small query, the performance is expected).

## Types of changes

- [x] Code refactor (Modify the code structure, format the code, etc...)

## Checklist

- [x] I have create an issue on (Fix #4656), and have described the bug/feature there in detail

## Further comments

The query planner is still time-consuming when processing complex SQL. It will be optimized later.
