### PR TITLE
[BUG] modify isDecommissioned be capacity calculate rule

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/system/SystemInfoService.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/system/SystemInfoService.java
@@ -1071,7 +1071,7 @@ public class SystemInfoService {
             if (backend.isDecommissioned()) {
                 // Data on decommissioned backend will move to other backends,
                 // So we need to minus size of those data.
-                capacity -= backend.getTotalCapacityB() - backend.getAvailableCapacityB();
+                capacity -= backend.getDataUsedCapacityB();
             } else {
                 capacity += backend.getAvailableCapacityB();
             }


### PR DESCRIPTION
## Proposed changes

I use containerized deployment of BE nodes, both using the same distributed disk. When doing data migration, the current logic will lead to errors. For example, my distributed disk has 10t and has been used by other services for 9T, at this time, it is assumed that all the 9T data is used by BE nodes

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] Documentation Update (if none of the other choices apply)
- [] Code refactor (Modify the code structure, format the code, etc...)

https://github.com/apache/incubator-doris/issues/4888
