### PR TITLE
[Metrics][LOG] Add metrics for compaction permits and log for merge rowsets

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -324,6 +324,9 @@ namespace config {
     // How many rounds of cumulative compaction for each round of base compaction when compaction tasks generation.
     CONF_mInt32(cumulative_compaction_rounds_for_each_base_compaction_round, "9");
 
+    // Merge log will be printed for each "row_step_for_compaction_merge_log" rows merged during compaction
+    CONF_mInt64(row_step_for_compaction_merge_log, "0");
+
     // Threshold to logging compaction trace, in seconds.
     CONF_mInt32(base_compaction_trace_threshold, "10");
     CONF_mInt32(cumulative_compaction_trace_threshold, "2");

--- a/be/src/olap/compaction_permit_limiter.cpp
+++ b/be/src/olap/compaction_permit_limiter.cpp
@@ -22,6 +22,7 @@ namespace doris {
 CompactionPermitLimiter::CompactionPermitLimiter() : _used_permits(0) {}
 
 bool CompactionPermitLimiter::request(int64_t permits) {
+    DorisMetrics::instance()->compaction_waitting_permits->set_value(permits);
     if (permits > config::total_permits_for_compaction_score) {
         // when tablet's compaction score is larger than "config::total_permits_for_compaction_score",
         // it's necessary to do compaction for this tablet because this tablet will not get "permits"
@@ -40,11 +41,14 @@ bool CompactionPermitLimiter::request(int64_t permits) {
         }
     }
     _used_permits += permits;
+    DorisMetrics::instance()->compaction_waitting_permits->set_value(0);
+    DorisMetrics::instance()->compaction_used_permits->set_value(_used_permits);
     return true;
 }
 
 void CompactionPermitLimiter::release(int64_t permits) {
     _used_permits -= permits;
     _permits_cv.notify_one();
+    DorisMetrics::instance()->compaction_used_permits->set_value(_used_permits);
 }
 } // namespace doris

--- a/be/src/olap/compaction_permit_limiter.h
+++ b/be/src/olap/compaction_permit_limiter.h
@@ -22,6 +22,7 @@
 
 #include "common/config.h"
 #include "olap/utils.h"
+#include "util/doris_metrics.h"
 
 namespace doris {
 

--- a/be/src/olap/merger.cpp
+++ b/be/src/olap/merger.cpp
@@ -65,6 +65,10 @@ OLAPStatus Merger::merge_rowsets(TabletSharedPtr tablet,
         RETURN_NOT_OK_LOG(dst_rowset_writer->add_row(row_cursor),
                           "failed to write row when merging rowsets of tablet " + tablet->full_name());
         output_rows++;
+        LOG_IF(INFO, config::row_step_for_compaction_merge_log != 0 && output_rows % config::row_step_for_compaction_merge_log == 0)
+              << "Merge rowsets stay alive. "
+              << "tablet=" << tablet->full_name()
+              << ", merged rows=" << output_rows;
         // the memory allocate by mem pool has been copied,
         // so we should release memory immediately
         mem_pool->clear();

--- a/be/src/util/doris_metrics.cpp
+++ b/be/src/util/doris_metrics.cpp
@@ -110,6 +110,9 @@ DEFINE_GAUGE_METRIC_PROTOTYPE_2ARG(process_fd_num_limit_hard, MetricUnit::NOUNIT
 DEFINE_GAUGE_METRIC_PROTOTYPE_2ARG(tablet_cumulative_max_compaction_score, MetricUnit::NOUNIT);
 DEFINE_GAUGE_METRIC_PROTOTYPE_2ARG(tablet_base_max_compaction_score, MetricUnit::NOUNIT);
 
+DEFINE_GAUGE_METRIC_PROTOTYPE_2ARG(compaction_used_permits, MetricUnit::NOUNIT);
+DEFINE_GAUGE_METRIC_PROTOTYPE_2ARG(compaction_waitting_permits, MetricUnit::NOUNIT);
+
 DEFINE_GAUGE_CORE_METRIC_PROTOTYPE_2ARG(push_request_write_bytes_per_second, MetricUnit::BYTES);
 DEFINE_GAUGE_CORE_METRIC_PROTOTYPE_2ARG(query_scan_bytes_per_second, MetricUnit::BYTES);
 DEFINE_GAUGE_CORE_METRIC_PROTOTYPE_2ARG(max_disk_io_util_percent, MetricUnit::PERCENT);
@@ -213,6 +216,9 @@ DorisMetrics::DorisMetrics() : _metric_registry(_s_registry_name) {
 
     INT_GAUGE_METRIC_REGISTER(_server_metric_entity, tablet_cumulative_max_compaction_score);
     INT_GAUGE_METRIC_REGISTER(_server_metric_entity, tablet_base_max_compaction_score);
+
+    INT_GAUGE_METRIC_REGISTER(_server_metric_entity, compaction_used_permits);
+    INT_GAUGE_METRIC_REGISTER(_server_metric_entity, compaction_waitting_permits);
 
     INT_GAUGE_METRIC_REGISTER(_server_metric_entity, push_request_write_bytes_per_second);
     INT_GAUGE_METRIC_REGISTER(_server_metric_entity, query_scan_bytes_per_second);

--- a/be/src/util/doris_metrics.h
+++ b/be/src/util/doris_metrics.h
@@ -133,6 +133,11 @@ public:
     IntGauge* tablet_cumulative_max_compaction_score;
     IntGauge* tablet_base_max_compaction_score;
 
+    // permits have been used for all compaction tasks
+    IntGauge* compaction_used_permits;
+    // permits required by the compaction task which is waitting for permits
+    IntGauge* compaction_waitting_permits;
+
     // The following metrics will be calculated
     // by metric calculator
     IntGauge* push_request_write_bytes_per_second;

--- a/docs/en/administrator-guide/config/be_config.md
+++ b/docs/en/administrator-guide/config/be_config.md
@@ -655,6 +655,13 @@ Indicates how many tablets in this data directory failed to load. At the same ti
 
 ### `row_nums_check`
 
+### `row_step_for_compaction_merge_log`
+
+* Type: int64
+* Description: Merge log will be printed for each "row_step_for_compaction_merge_log" rows merged during compaction. If the value is set to 0, merge log will not be printed.
+* Default value: 0
+* Dynamically modify: true
+
 ### `scan_context_gc_interval_min`
 
 ### `scratch_dirs`
@@ -801,6 +808,13 @@ This configuration indicates the service model used by FE's Thrift service. The 
 If the parameter is `THREADED`, the model is a non-blocking I/O model,
 
 If the parameter is `THREAD_POOL`, the model is a blocking I/O model.
+
+### `total_permits_for_compaction_score`
+
+* Type: int64
+* Description: The upper limit of "permits" held by all compaction tasks. This config can be set to limit memory consumption for compaction.
+* Default: 10000
+* Dynamically modify: true
 
 ### `trash_file_expire_time_sec`
 

--- a/docs/zh-CN/administrator-guide/config/be_config.md
+++ b/docs/zh-CN/administrator-guide/config/be_config.md
@@ -654,6 +654,13 @@ load tablets from header failed, failed tablets size: xxx, path=xxx
 
 ### `row_nums_check`
 
+### `row_step_for_compaction_merge_log`
+
+* 类型：int64
+* 描述：Compaction执行过程中，每次合并row_step_for_compaction_merge_log行数据会打印一条LOG。如果该参数被设置为0，表示merge过程中不需要打印LOG。
+* 默认值： 0
+* 可动态修改：是
+
 ### `scan_context_gc_interval_min`
 
 ### `scratch_dirs`
@@ -798,6 +805,13 @@ Stream Load 一般适用于导入几个GB以内的数据，不适合导入过大
 若该参数为`THREADED`, 该模型为非阻塞式I/O模型，
 
 若该参数为`THREAD_POOL`, 该模型为阻塞式I/O模型。
+
+### `total_permits_for_compaction_score`
+
+* 类型：int64
+* 描述：被所有的compaction任务所能持有的 "permits" 上限，用来限制compaction占用的内存。
+* 默认值：10000
+* 可动态修改：是
 
 ### `trash_file_expire_time_sec`
 


### PR DESCRIPTION
## Proposed changes

1. Add metrics to `used permits` and `waitting permits` for compaction. It would be useful to monitor `permits` hold by all executing compaction tasks and waitting compaction task.

2. Add log which can be chosen by config  for merge rowsets.  It would be helpful to track the process of rowsets merging for compaction task which lasts for a long time.

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)
- [] Code refactor (Modify the code structure, format the code, etc...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [] I have create an issue on (Fix #ISSUE), and have described the bug/feature there in detail
- [x] Compiling and unit tests pass locally with my changes
- [] I have added tests that prove my fix is effective or that my feature works
- [x] If this change need a document change, I have updated the document
- [x] Any dependent changes have been merged
