### PR TITLE
[BUG] Fix colocate join memory limit problem (#4894)

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/Config.java
@@ -763,7 +763,7 @@ public class Config extends ConfigBase {
      * exec_mem_limit / min (query_colocate_join_memory_limit_penalty_factor, instance_num)
      */
     @ConfField(mutable = true)
-    public static int query_colocate_join_memory_limit_penalty_factor = 8;
+    public static int query_colocate_join_memory_limit_penalty_factor = 1;
 
     /**
      * Deprecated after 0.10


### PR DESCRIPTION
## Proposed changes

In colocate join, the memory limit of each instance is usually less than the value of `exec_mem_limit`, which could lead to query failure (Memory exceed limit).
Since the purpose of resetting colocate-join memory limit (`/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java`) is unclear to me, I just change the default value of `query_colocate_join_memory_limit_penalty_factor` from `8` to `1`, as a hotfix.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] Documentation Update (if none of the other choices apply)
- [] Code refactor (Modify the code structure, format the code, etc...)

## Checklist

- [x] I have create an issue on (Fix #4894 ), and have described the bug/feature there in detail
- [] Compiling and unit tests pass locally with my changes
- [] I have added tests that prove my fix is effective or that my feature works
- [] If this change need a document change, I have updated the document
- [] Any dependent changes have been merged
