### PR TITLE
Avoid duplicate column when adding slot in empty tuple

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/planner/SingleNodePlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/SingleNodePlanner.java
@@ -1401,7 +1401,7 @@ public class SingleNodePlanner {
                 if ((tblRef.getJoinOp().isInnerJoin() || tblRef.getJoinOp().isLeftOuterJoin())) {
                     List<Expr> allConjuncts = analyzer.getConjuncts(analyzer.getAllTupleIds());
                     allConjuncts.removeAll(conjuncts);
-                    for (Expr conjunct: allConjuncts) {
+                    for (Expr conjunct : allConjuncts) {
                         if (org.apache.doris.analysis.Predicate.canPushDownPredicate(conjunct)) {
                             for (Expr eqJoinPredicate : eqJoinPredicates) {
                                 // we can ensure slot is left node, because NormalizeBinaryPredicatesRule
@@ -1473,7 +1473,7 @@ public class SingleNodePlanner {
 
         if (oldPredicate instanceof InPredicate) {
             InPredicate oldIP = (InPredicate) oldPredicate;
-            InPredicate ip =  new InPredicate(leftChild, oldIP.getListChildren(), oldIP.isNotIn());
+            InPredicate ip = new InPredicate(leftChild, oldIP.getListChildren(), oldIP.isNotIn());
             ip.analyzeNoThrow(analyzer);
             return ip;
         }
@@ -1898,10 +1898,11 @@ public class SingleNodePlanner {
      * Inner tuple: tuple 0 with a not materialized slot k1
      * In the above two cases, it is necessary to add a mini column to the inner tuple
      * to ensure that the number of rows in the inner query result is the number of rows in the table.
-     *
+     * <p>
      * After this function, the inner tuple is following:
      * case1. tuple 0: slot<k1> materialized true (new slot)
      * case2. tuple 0: slot<k1> materialized true (changed)
+     *
      * @param tblRef
      * @param analyzer
      */
@@ -1915,9 +1916,14 @@ public class SingleNodePlanner {
                 }
             }
             if (minimuColumn != null) {
-                SlotDescriptor slot = analyzer.getDescTbl().addSlotDescriptor(tblRef.getDesc());
-                slot.setColumn(minimuColumn);
-                slot.setIsMaterialized(true);
+                SlotDescriptor slot = tblRef.getDesc().getColumnSlot(minimuColumn.getName());
+                if (slot != null) {
+                    slot.setIsMaterialized(true);
+                } else {
+                    slot = analyzer.getDescTbl().addSlotDescriptor(tblRef.getDesc());
+                    slot.setColumn(minimuColumn);
+                    slot.setIsMaterialized(true);
+                }
             }
         }
     }
@@ -2087,7 +2093,7 @@ public class SingleNodePlanner {
                     } else {
                         // if grouping type is GROUPING_SETS and the predicate not in all grouping list,
                         // the predicate cannot be push down
-                        for (List<Expr> exprs: stmt.getGroupByClause().getGroupingSetList()) {
+                        for (List<Expr> exprs : stmt.getGroupByClause().getGroupingSetList()) {
                             if (!exprs.contains(sourceExpr)) {
                                 isAllSlotReferingGroupBys = false;
                                 break;


### PR DESCRIPTION
Fixed #4900

## Proposed changes

When the supplementary column already exists in the tuple, this column is directly materialized instead of adding a new slot.

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] Documentation Update (if none of the other choices apply)
- [] Code refactor (Modify the code structure, format the code, etc...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have create an issue on (Fix #4900), and have described the bug/feature there in detail
- [] Compiling and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [] If this change need a document change, I have updated the document
- [] Any dependent changes have been merged

