### PR TITLE
disable the creation of segment v1 table

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -550,7 +550,7 @@ namespace config {
 
     // config for default rowset type
     // Valid configs: ALPHA, BETA
-    CONF_String(default_rowset_type, "ALPHA");
+    CONF_String(default_rowset_type, "BETA");
 
     // Maximum size of a single message body in all protocols
     CONF_Int64(brpc_max_body_size, "209715200");

--- a/fe/fe-core/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/Config.java
@@ -1293,4 +1293,12 @@ public class Config extends ConfigBase {
      */
     @ConfField
     public static String http_api_extra_base_path = "";
+
+    /**
+     * Whether to support the creation of alpha rowset tables.
+     * The default is false and should only be used in emergency situations,
+     * this config should be remove in some future version
+     */
+    @ConfField
+    public static boolean enable_alpha_rowset = false;
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/PropertyAnalyzer.java
@@ -411,6 +411,10 @@ public class PropertyAnalyzer {
         }
 
         if (storageFormat.equalsIgnoreCase("v1")) {
+            if (!Config.enable_alpha_rowset) {
+                throw new AnalysisException("StorageFormat V1 has been deprecated since version 0.14," +
+                        " please use V2 instead");
+            }
             return TStorageFormat.V1;
         } else if (storageFormat.equalsIgnoreCase("v2")) {
             return TStorageFormat.V2;

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/PropertyAnalyzer.java
@@ -412,7 +412,7 @@ public class PropertyAnalyzer {
 
         if (storageFormat.equalsIgnoreCase("v1")) {
             if (!Config.enable_alpha_rowset) {
-                throw new AnalysisException("StorageFormat V1 has been deprecated since version 0.14," +
+                throw new AnalysisException("Storage format V1 has been deprecated since version 0.14," +
                         " please use V2 instead");
             }
             return TStorageFormat.V1;

--- a/fe/fe-core/src/test/java/org/apache/doris/alter/AlterJobV2Test.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/alter/AlterJobV2Test.java
@@ -63,7 +63,7 @@ public class AlterJobV2Test {
 
         createTable("CREATE TABLE test.schema_change_test(k1 int, k2 int, k3 int) distributed by hash(k1) buckets 3 properties('replication_num' = '1');");
 
-        createTable("CREATE TABLE test.segmentv2(k1 int, k2 int, v1 int sum) distributed by hash(k1) buckets 3 properties('replication_num' = '1', 'storage_format' = 'v1');");
+        createTable("CREATE TABLE test.segmentv2(k1 int, k2 int, v1 int sum) distributed by hash(k1) buckets 3 properties('replication_num' = '1', 'storage_format' = 'v2');");
     }
 
     @AfterClass

--- a/fe/fe-core/src/test/java/org/apache/doris/alter/AlterJobV2Test.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/alter/AlterJobV2Test.java
@@ -133,7 +133,7 @@ public class AlterJobV2Test {
         Assert.assertNotNull(db);
         OlapTable tbl = (OlapTable) db.getTable("segmentv2");
         Assert.assertNotNull(tbl);
-        Assert.assertEquals(TStorageFormat.V1, tbl.getTableProperty().getStorageFormat());
+        Assert.assertEquals(TStorageFormat.V2, tbl.getTableProperty().getStorageFormat());
         
         // 1. create a rollup r1
         String alterStmtStr = "alter table test.segmentv2 add rollup r1(k2, v1)";


### PR DESCRIPTION
## Proposed changes

Disable v1 storage format when creating a new table in version 0.14, as we discussed in doris-dev and  Issue #4835, I will forbidden the creation of segment v1 table 

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] Documentation Update (if none of the other choices apply)
- [] Code refactor (Modify the code structure, format the code, etc...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have create an issue on (Fix #4835), and have described the bug/feature there in detail
- [x] Compiling and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [] If this change need a document change, I have updated the document
- [] Any dependent changes have been merged

## Further comments

If this is a relatively large or complex change, kick off the discussion at dev@doris.apache.org by explaining why you chose the solution you did and what alternatives you considered, etc...
