### PR TITLE
[Bug] Fix partition prune (#4833)

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/planner/SingleNodePlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/SingleNodePlanner.java
@@ -960,10 +960,9 @@ public class SingleNodePlanner {
                 if (!inPredicate.isLiteralChildren() || inPredicate.isNotIn()) {
                     continue;
                 }
-                if (inPredicate.getChild(0).unwrapExpr(false) instanceof LiteralExpr) {
-                    // If child(0) of the in predicate is a constant expression,
+                if (!(inPredicate.getChild(0).unwrapExpr(false) instanceof SlotRef)) {
+                    // If child(0) of the in predicate is not a SlotRef,
                     // then other children of in predicate should not be used as a condition for partition prune.
-                    // Such as "where  'Hi' in ('Hi', 'hello') and ... "
                     continue;
                 }
                 if (null == partitionColumnFilter) {


### PR DESCRIPTION
## Proposed changes

According to @morningman in #4836
> We should check if inPredicate.getChild(0) is not a slotRef, do not create partition filter for it.
> So it won't goes to the compareLiteral() logic.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] Documentation Update (if none of the other choices apply)
- [] Code refactor (Modify the code structure, format the code, etc...)

## Checklist

- [] I have create an issue on (Fix #ISSUE), and have described the bug/feature there in detail
- [x] Compiling and unit tests pass locally with my changes
- [] I have added tests that prove my fix is effective or that my feature works
- [] If this change need a document change, I have updated the document
- [] Any dependent changes have been merged
