### PR TITLE
fix the FE logs dir create issue 

### DIFF
--- a/bin/start_fe.sh
+++ b/bin/start_fe.sh
@@ -97,6 +97,11 @@ jdk_version() {
     fi
     echo "$result"
 }
+
+# need check and create if the log directory existed before outing message to the log file.
+if [ ! -d $LOG_DIR ]; then
+    mkdir -p $LOG_DIR
+fi
  
 # check java version and choose correct JAVA_OPTS
 java_version=$(jdk_version)
@@ -117,9 +122,6 @@ for f in $DORIS_HOME/lib/*.jar; do
 done
 export CLASSPATH=${CLASSPATH}:${DORIS_HOME}/lib
 
-if [ ! -d $LOG_DIR ]; then
-    mkdir -p $LOG_DIR
-fi
 
 pidfile=$PID_DIR/fe.pid
 


### PR DESCRIPTION
## Proposed changes

This is a minor issue when we had FE start after a fresh installation, but it will occur an error about the log directory is missing due to **log directory is not existed before some environment check message outputing to the log file.** , the log directory creation code in bin/start_fe.sh is in the wrong place, only need to put the log directory creation code in the beginning.


## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] Documentation Update (if none of the other choices apply)
- [] Code refactor (Modify the code structure, format the code, etc...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [] I have create an issue on (Fix #ISSUE), and have described the bug/feature there in detail
- [x] Compiling and unit tests pass locally with my changes
- [] I have added tests that prove my fix is effective or that my feature works
- [] If this change need a document change, I have updated the document
- [] Any dependent changes have been merged

