### PR TITLE
Optimized the read performance of the table when have multi versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,8 +50,19 @@ be/src/gen_cpp/*.cc
 be/src/gen_cpp/*.cpp
 be/src/gen_cpp/*.h
 be/src/gen_cpp/opcode
-be/ut_build_ASAN/
+be/ut_build_*
 be/tags
+be/build*
+be/test/olap/test_data/tablet_meta_test.hdr
+build
+
+ui/dist
+ui/node_modules
+ui/package-lock.json
+docs/package-lock.json
+fe/fe-common/.classpath
+rpc_data/
+
 
 #ignore vscode project file
 .vscode

--- a/be/src/olap/CMakeLists.txt
+++ b/be/src/olap/CMakeLists.txt
@@ -33,6 +33,7 @@ add_library(Olap STATIC
     bloom_filter_reader.cpp
     bloom_filter_writer.cpp
     byte_buffer.cpp
+    collect_iterator.cpp
     compaction.cpp
     compaction_permit_limiter.cpp
     comparison_predicate.cpp

--- a/be/src/olap/collect_iterator.cpp
+++ b/be/src/olap/collect_iterator.cpp
@@ -1,0 +1,344 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "olap/collect_iterator.h"
+
+#include "olap/reader.h"
+#include "olap/row.h"
+#include "olap/row_block.h"
+#include "olap/row_cursor.h"
+
+namespace doris {
+
+CollectIterator::~CollectIterator() {
+    for (auto child : _children) {
+        if (child != nullptr) {
+            delete child;
+            child = nullptr;
+        }
+    }
+}
+
+void CollectIterator::init(Reader* reader) {
+    _reader = reader;
+    // when aggregate is enabled or key_type is DUP_KEYS, we don't merge
+    // multiple data to aggregate for performance in user fetch
+    if (_reader->_reader_type == READER_QUERY &&
+        (_reader->_aggregation || _reader->_tablet->keys_type() == KeysType::DUP_KEYS)) {
+        _merge = false;
+    }
+}
+
+OLAPStatus CollectIterator::add_child(RowsetReaderSharedPtr rs_reader) {
+    std::unique_ptr<LevelIterator> child(new Level0Iterator(rs_reader, _reader));
+    RETURN_NOT_OK(child->init());
+    if (child->current_row() == nullptr) {
+        return OLAP_SUCCESS;
+    }
+
+    LevelIterator* child_ptr = child.release();
+    _children.push_back(child_ptr);
+    _rs_readers.push_back(rs_reader);
+    return OLAP_SUCCESS;
+}
+
+// Build a merge heap. If _merge is true, a rowset with the max rownum and nonoverlapping
+// status will be used as the base rowset, and the other rowsets will be merged first and
+// then merged with the base rowset.
+void CollectIterator::build_heap() {
+    DCHECK(_rs_readers.size() == _children.size());
+    _reverse = _reader->_tablet->tablet_schema().keys_type() == KeysType::UNIQUE_KEYS;
+    if (_children.empty()) {
+        _inner_iter.reset(nullptr);
+        return;
+    } else if (_merge) {
+        DCHECK(!_rs_readers.empty());
+        // find base rowset(max rownum and non-overlapping),
+        RowsetReaderSharedPtr base_reader = _rs_readers[0];
+        int base_reader_idx = base_reader->rowset()->rowset_meta()->is_segments_overlapping() ? -1 : 0;
+        for (size_t i = 1; i < _rs_readers.size(); ++i) {
+            if (_rs_readers[i]->rowset()->rowset_meta()->is_segments_overlapping()) {
+                continue;
+            }
+            if (_rs_readers[i]->rowset()->rowset_meta()->num_rows() > base_reader->rowset()->rowset_meta()->num_rows()) {
+                base_reader = _rs_readers[i];
+                base_reader_idx = i;
+            }
+        }
+        // build merge heap with two children， a base rowset as level0iterator and
+        // other cumulative rowsets as a level1iterator
+        if (_children.size() > 1 && base_reader_idx >= 0) {
+            std::vector<LevelIterator*> cumu_children;
+            for (size_t i = 0; i < _rs_readers.size(); ++i) {
+                if (i != base_reader_idx) {
+                    cumu_children.push_back(_children[i]);
+                }
+            }
+            Level1Iterator* cumu_iter =
+                    new Level1Iterator(cumu_children, cumu_children.size() > 1, _reverse);
+            cumu_iter->init();
+            std::vector<LevelIterator*> children;
+            children.push_back(_children[base_reader_idx]);
+            children.push_back(cumu_iter);
+            _inner_iter.reset(new Level1Iterator(children, _merge, _reverse));
+        } else {
+            _inner_iter.reset(new Level1Iterator(_children, _merge, _reverse));
+        }
+    } else {
+        _inner_iter.reset(new Level1Iterator(_children, _merge, _reverse));
+    }
+    _inner_iter->init();
+}
+
+bool CollectIterator::LevelIteratorComparator::operator()(const LevelIterator* a,
+                                                          const LevelIterator* b) {
+    // First compare row cursor.
+    const RowCursor* first = a->current_row();
+    const RowCursor* second = b->current_row();
+    int cmp_res = compare_row(*first, *second);
+    if (cmp_res != 0) {
+        return cmp_res > 0;
+    }
+    // if row cursors equal, compare data version.
+    // read data from higher version to lower version.
+    // for UNIQUE_KEYS just read the highest version and no need agg_update.
+    // for AGG_KEYS if a version is deleted, the lower version no need to agg_update
+    if (_reverse) {
+        return a->version() < b->version();
+    }
+    return a->version() > b->version();
+}
+
+void CollectIterator::clear() {
+    for (auto child : _children) {
+        if (child != nullptr) {
+            delete child;
+            child = nullptr;
+        }
+    }
+    _children.clear();
+}
+
+const RowCursor* CollectIterator::current_row(bool* delete_flag) const {
+    if (LIKELY(_inner_iter)) {
+        return _inner_iter->current_row(delete_flag);
+    }
+    return nullptr;
+}
+
+OLAPStatus CollectIterator::next(const RowCursor** row, bool* delete_flag) {
+    if (LIKELY(_inner_iter)) {
+        return _inner_iter->next(row, delete_flag);
+    } else {
+        return OLAP_ERR_DATA_EOF;
+    }
+}
+
+CollectIterator::Level0Iterator::Level0Iterator(RowsetReaderSharedPtr rs_reader, Reader* reader)
+        : _rs_reader(rs_reader), _is_delete(rs_reader->delete_flag()), _reader(reader) {}
+
+CollectIterator::Level0Iterator::~Level0Iterator() {}
+
+OLAPStatus CollectIterator::Level0Iterator::init() {
+    auto res = _row_cursor.init(_reader->_tablet->tablet_schema(), _reader->_seek_columns);
+    if (res != OLAP_SUCCESS) {
+        LOG(WARNING) << "failed to init row cursor, res=" << res;
+        return res;
+    }
+    RETURN_NOT_OK(_refresh_current_row());
+    return OLAP_SUCCESS;
+}
+
+const RowCursor* CollectIterator::Level0Iterator::current_row(bool* delete_flag) const {
+    *delete_flag = _is_delete || _current_row->is_delete();
+    return _current_row;
+}
+
+const RowCursor* CollectIterator::Level0Iterator::current_row() const {
+    return _current_row;
+}
+
+int32_t CollectIterator::Level0Iterator::version() const {
+    return _rs_reader->version().second;
+}
+
+OLAPStatus CollectIterator::Level0Iterator::_refresh_current_row() {
+    do {
+        if (_row_block != nullptr && _row_block->has_remaining()) {
+            size_t pos = _row_block->pos();
+            _row_block->get_row(pos, &_row_cursor);
+            if (_row_block->block_status() == DEL_PARTIAL_SATISFIED &&
+                _reader->_delete_handler.is_filter_data(_rs_reader->version().second,
+                                                        _row_cursor)) {
+                _reader->_stats.rows_del_filtered++;
+                _row_block->pos_inc();
+                continue;
+            }
+            _current_row = &_row_cursor;
+            return OLAP_SUCCESS;
+        } else {
+            auto res = _rs_reader->next_block(&_row_block);
+            if (res != OLAP_SUCCESS) {
+                _current_row = nullptr;
+                return res;
+            }
+        }
+    } while (_row_block != nullptr);
+    _current_row = nullptr;
+    return OLAP_ERR_DATA_EOF;
+}
+
+bool CollectIterator::Level0Iterator::overlapping() {
+    return _rs_reader->rowset()->rowset_meta()->is_segments_overlapping();
+}
+
+OLAPStatus CollectIterator::Level0Iterator::next(const RowCursor** row, bool* delete_flag) {
+    _row_block->pos_inc();
+    auto res = _refresh_current_row();
+    *row = _current_row;
+    *delete_flag = _is_delete;
+    if (_current_row != nullptr) {
+        *delete_flag = _is_delete || _current_row->is_delete();
+    }
+    return res;
+}
+
+CollectIterator::Level1Iterator::Level1Iterator(
+        const std::vector<CollectIterator::LevelIterator*>& children, bool merge, bool reverse)
+        : _children(children), _merge(merge), _reverse(reverse) {
+    for (const auto child : _children) {
+        _overlapping |= child->overlapping();
+    }
+}
+
+CollectIterator::LevelIterator::~LevelIterator() {}
+
+CollectIterator::Level1Iterator::~Level1Iterator() {}
+
+// Read next row into *row.
+// Returns
+//      OLAP_SUCCESS when read successfully.
+//      OLAP_ERR_DATA_EOF and set *row to nullptr when EOF is reached.
+//      Others when error happens
+OLAPStatus CollectIterator::Level1Iterator::next(const RowCursor** row, bool* delete_flag) {
+    if (UNLIKELY(_children.size() == 0)) {
+        return OLAP_ERR_DATA_EOF;
+    }
+    if (_merge) {
+        return _merge_next(row, delete_flag);
+    } else {
+        return _normal_next(row, delete_flag);
+    }
+}
+
+bool CollectIterator::Level1Iterator::overlapping() {
+    return _overlapping;
+}
+
+// Get top row of the heap, nullptr if reach end.
+const RowCursor* CollectIterator::Level1Iterator::current_row(bool* delete_flag) const {
+    if (_cur_child != nullptr) {
+        return _cur_child->current_row(delete_flag);
+    }
+    return nullptr;
+}
+
+// Get top row of the heap, nullptr if reach end.
+const RowCursor* CollectIterator::Level1Iterator::current_row() const {
+    if (_cur_child != nullptr) {
+        return _cur_child->current_row();
+    }
+    return nullptr;
+}
+
+int32_t CollectIterator::Level1Iterator::version() const {
+    if (_cur_child != nullptr) {
+        return _cur_child->version();
+    }
+    return -1;
+}
+
+OLAPStatus CollectIterator::Level1Iterator::init() {
+    if (_children.size() == 0) {
+        return OLAP_SUCCESS;
+    }
+    // Only when there are multiple children that need to be merged,
+    // or there is only one child, but the rowset status of this child is overlapping,
+    // the mergeheap needs to be really established. If there is only one child and the
+    // child status is nonoverlapping, it only needs to be read in the order, without merging
+    if (_merge && (_children.size() > 1 || _overlapping)) {
+        _heap.reset(new MergeHeap(LevelIteratorComparator(_reverse)));
+        for (auto child : _children) {
+            if (child == nullptr || child->current_row() == nullptr) {
+                continue;
+            }
+            _heap->push(child);
+            _cur_child = _heap->top();
+        }
+    } else {
+        _merge = false;
+        _heap.reset(nullptr);
+        _cur_child = _children[_child_idx];
+    }
+    return OLAP_SUCCESS;
+}
+
+inline OLAPStatus CollectIterator::Level1Iterator::_merge_next(const RowCursor** row,
+                                                               bool* delete_flag) {
+    _heap->pop();
+    auto res = _cur_child->next(row, delete_flag);
+    if (res == OLAP_SUCCESS) {
+        _heap->push(_cur_child);
+        _cur_child = _heap->top();
+    } else if (res == OLAP_ERR_DATA_EOF) {
+        if (!_heap->empty()) {
+            _cur_child = _heap->top();
+        } else {
+            _cur_child = nullptr;
+            return OLAP_ERR_DATA_EOF;
+        }
+    } else {
+        LOG(WARNING) << "failed to get next from child, res=" << res;
+        return res;
+    }
+    *row = _cur_child->current_row(delete_flag);
+    return OLAP_SUCCESS;
+}
+
+inline OLAPStatus CollectIterator::Level1Iterator::_normal_next(const RowCursor** row,
+                                                                bool* delete_flag) {
+    auto res = _cur_child->next(row, delete_flag);
+    if (LIKELY(res == OLAP_SUCCESS)) {
+        return OLAP_SUCCESS;
+    } else if (res == OLAP_ERR_DATA_EOF) {
+        // this child has been read, to read next
+        _child_idx++;
+        if (_child_idx < _children.size()) {
+            _cur_child = _children[_child_idx];
+            *row = _cur_child->current_row(delete_flag);
+            return OLAP_SUCCESS;
+        } else {
+            _cur_child = nullptr;
+            return OLAP_ERR_DATA_EOF;
+        }
+    } else {
+        LOG(WARNING) << "failed to get next from child, res=" << res;
+        return res;
+    }
+}
+
+} // namespace doris

--- a/be/src/olap/collect_iterator.cpp
+++ b/be/src/olap/collect_iterator.cpp
@@ -24,14 +24,7 @@
 
 namespace doris {
 
-CollectIterator::~CollectIterator() {
-    for (auto child : _children) {
-        if (child != nullptr) {
-            delete child;
-            child = nullptr;
-        }
-    }
-}
+CollectIterator::~CollectIterator() {}
 
 void CollectIterator::init(Reader* reader) {
     _reader = reader;

--- a/be/src/olap/collect_iterator.h
+++ b/be/src/olap/collect_iterator.h
@@ -68,7 +68,6 @@ private:
         virtual int32_t version() const = 0;
 
         virtual OLAPStatus next(const RowCursor** row, bool* delete_flag) = 0;
-        virtual bool overlapping() = 0;
         virtual ~LevelIterator() = 0;
     };
     // Compare row cursors between multiple merge elements,
@@ -100,7 +99,6 @@ private:
         int32_t version() const;
 
         OLAPStatus next(const RowCursor** row, bool* delete_flag);
-        bool overlapping();
 
         ~Level0Iterator();
 
@@ -130,7 +128,6 @@ private:
         int32_t version() const;
 
         OLAPStatus next(const RowCursor** row, bool* delete_flag);
-        bool overlapping();
 
         ~Level1Iterator();
 
@@ -151,7 +148,6 @@ private:
         // *partially* ordered.
         bool _merge = true;
         bool _reverse = false;
-        bool _overlapping = false;
         // used when `_merge == true`
         std::unique_ptr<MergeHeap> _heap;
         // used when `_merge == false`

--- a/be/src/olap/collect_iterator.h
+++ b/be/src/olap/collect_iterator.h
@@ -1,0 +1,175 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include "olap/olap_define.h"
+#include "olap/row_cursor.h"
+#include "olap/rowset/rowset_reader.h"
+
+namespace doris {
+
+class Reader;
+class RowCursor;
+
+class CollectIterator {
+public:
+    ~CollectIterator();
+
+    // Hold reader point to get reader params
+    void init(Reader* reader);
+
+    OLAPStatus add_child(RowsetReaderSharedPtr rs_reader);
+
+    void build_heap();
+
+    // Get top row of the heap, nullptr if reach end.
+    const RowCursor* current_row(bool* delete_flag) const;
+
+    // Read next row into *row.
+    // Returns
+    //      OLAP_SUCCESS when read successfully.
+    //      OLAP_ERR_DATA_EOF and set *row to nullptr when EOF is reached.
+    //      Others when error happens
+    OLAPStatus next(const RowCursor** row, bool* delete_flag);
+
+    // Clear the MergeSet element and reset state.
+    void clear();
+
+private:
+    // This interface is the actual implementation of the new version of iterator.
+    // It currently contains two implementations, one is Level0Iterator,
+    // which only reads data from the rowset reader, and the other is Level1Iterator,
+    // which can read merged data from multiple LevelIterators through MergeHeap.
+    // By using Level1Iterator, some rowset readers can be merged in advance and 
+    // then merged with other rowset readers.
+    class LevelIterator {
+    public:
+        virtual OLAPStatus init() = 0;
+
+        virtual const RowCursor* current_row(bool* delete_flag) const = 0;
+
+        virtual const RowCursor* current_row() const = 0;
+
+        virtual int32_t version() const = 0;
+
+        virtual OLAPStatus next(const RowCursor** row, bool* delete_flag) = 0;
+        virtual bool overlapping() = 0;
+        virtual ~LevelIterator() = 0;
+    };
+    // Compare row cursors between multiple merge elements,
+    // if row cursors equal, compare data version.
+    class LevelIteratorComparator {
+    public:
+        LevelIteratorComparator(const bool reverse = false) : _reverse(reverse) {}
+        bool operator()(const LevelIterator* a, const LevelIterator* b);
+
+    private:
+        bool _reverse;
+        OlapReaderStatistics* _stats;
+    };
+
+    typedef std::priority_queue<LevelIterator*, std::vector<LevelIterator*>,
+                                LevelIteratorComparator>
+            MergeHeap;
+    // Iterate from rowset reader. This Iterator usually like a leaf node
+    class Level0Iterator : public LevelIterator {
+    public:
+        Level0Iterator(RowsetReaderSharedPtr rs_reader, Reader* reader);
+
+        OLAPStatus init();
+
+        const RowCursor* current_row(bool* delete_flag) const;
+
+        const RowCursor* current_row() const;
+
+        int32_t version() const;
+
+        OLAPStatus next(const RowCursor** row, bool* delete_flag);
+        bool overlapping();
+
+        ~Level0Iterator();
+
+    private:
+        // refresh_current_row
+        OLAPStatus _refresh_current_row();
+
+        RowsetReaderSharedPtr _rs_reader;
+        const RowCursor* _current_row = nullptr;
+        bool _is_delete = false;
+        Reader* _reader = nullptr;
+        // point to rows inside `_row_block`
+        RowCursor _row_cursor;
+        RowBlock* _row_block = nullptr;
+    };
+    // Iterate from LevelIterators (maybe Level0Iterators or Level1Iterator or mixed)
+    class Level1Iterator : public LevelIterator {
+    public:
+        Level1Iterator(const std::vector<LevelIterator*>& children, bool merge, bool reverse);
+
+        OLAPStatus init();
+
+        const RowCursor* current_row(bool* delete_flag) const;
+
+        const RowCursor* current_row() const;
+
+        int32_t version() const;
+
+        OLAPStatus next(const RowCursor** row, bool* delete_flag);
+        bool overlapping();
+
+        ~Level1Iterator();
+
+    private:
+        inline OLAPStatus _merge_next(const RowCursor** row, bool* delete_flag);
+        inline OLAPStatus _normal_next(const RowCursor** row, bool* delete_flag);
+
+        // each Level0Iterator corresponds to a rowset reader
+        const std::vector<LevelIterator*> _children;
+        // point to the Level0Iterator containing the next output row.
+        // null when CollectIterator hasn't been initialized or reaches EOF.
+        LevelIterator* _cur_child = nullptr;
+
+        // when `_merge == true`, rowset reader returns ordered rows and CollectIterator uses a priority queue to merge
+        // sort them. The output of CollectIterator is also ordered.
+        // When `_merge == false`, rowset reader returns *partial* ordered rows. CollectIterator simply returns all rows
+        // from the first rowset, the second rowset, .., the last rowset. The output of CollectorIterator is also
+        // *partially* ordered.
+        bool _merge = true;
+        bool _reverse = false;
+        bool _overlapping = false;
+        // used when `_merge == true`
+        std::unique_ptr<MergeHeap> _heap;
+        // used when `_merge == false`
+        int _child_idx = 0;
+    };
+
+    std::unique_ptr<LevelIterator> _inner_iter;
+
+    // each LevelIterator corresponds to a rowset reader
+    std::vector<LevelIterator*> _children;
+
+    bool _merge = true;
+    bool _reverse = false;
+
+    // Hold reader point to access read params, such as fetch conditions.
+    Reader* _reader = nullptr;
+    std::vector<RowsetReaderSharedPtr> _rs_readers;
+
+};
+
+} // namespace doris

--- a/be/src/olap/reader.cpp
+++ b/be/src/olap/reader.cpp
@@ -83,14 +83,12 @@ std::string Reader::KeysParam::to_string() const {
     for (auto start_key : start_keys) {
         ss << " keys=" << start_key->to_string();
     }
-}
+    for (auto end_key : end_keys) {
+        ss << " end_keys=" << end_key->to_string();
+    }
 
-for (auto end_key : end_keys) {
-    ss << " end_keys=" << end_key->to_string();
+    return ss.str();
 }
-
-return ss.str();
-} // namespace doris
 
 Reader::Reader() {
     _tracker.reset(new MemTracker(-1));

--- a/be/src/olap/reader.cpp
+++ b/be/src/olap/reader.cpp
@@ -122,26 +122,31 @@ OLAPStatus Reader::init(const ReaderParams& read_params) {
         return res;
     }
 
-    switch (_tablet->keys_type()) {
-    case KeysType::DUP_KEYS:
+    if (_rs_readers.size() == 1 &&
+        !_rs_readers[0]->rowset()->rowset_meta()->is_segments_overlapping()) {
         _next_row_func = &Reader::_dup_key_next_row;
-        break;
-    case KeysType::UNIQUE_KEYS:
-        _next_row_func = &Reader::_unique_key_next_row;
-        break;
-    case KeysType::AGG_KEYS:
-        _next_row_func = &Reader::_agg_key_next_row;
-        break;
-    default:
-        break;
+    } else {
+        switch (_tablet->keys_type()) {
+        case KeysType::DUP_KEYS:
+            _next_row_func = &Reader::_dup_key_next_row;
+            break;
+        case KeysType::UNIQUE_KEYS:
+            _next_row_func = &Reader::_unique_key_next_row;
+            break;
+        case KeysType::AGG_KEYS:
+            _next_row_func = &Reader::_agg_key_next_row;
+            break;
+        default:
+            break;
+        }
     }
-    DCHECK(_next_row_func != nullptr) << "No next row function for type:" << _tablet->keys_type();
+    DCHECK(_next_row_func != nullptr) << "No next row function for type:"
+        << _tablet->keys_type();
 
     return OLAP_SUCCESS;
 }
 
-OLAPStatus Reader::_dup_key_next_row(RowCursor* row_cursor, MemPool* mem_pool, ObjectPool* agg_pool,
-                                     bool* eof) {
+OLAPStatus Reader::_dup_key_next_row(RowCursor* row_cursor, MemPool* mem_pool, ObjectPool* agg_pool, bool* eof) {
     if (UNLIKELY(_next_key == nullptr)) {
         *eof = true;
         return OLAP_SUCCESS;
@@ -156,8 +161,7 @@ OLAPStatus Reader::_dup_key_next_row(RowCursor* row_cursor, MemPool* mem_pool, O
     return OLAP_SUCCESS;
 }
 
-OLAPStatus Reader::_agg_key_next_row(RowCursor* row_cursor, MemPool* mem_pool, ObjectPool* agg_pool,
-                                     bool* eof) {
+OLAPStatus Reader::_agg_key_next_row(RowCursor* row_cursor, MemPool* mem_pool, ObjectPool* agg_pool, bool* eof) {
     if (UNLIKELY(_next_key == nullptr)) {
         *eof = true;
         return OLAP_SUCCESS;
@@ -194,8 +198,7 @@ OLAPStatus Reader::_agg_key_next_row(RowCursor* row_cursor, MemPool* mem_pool, O
     return OLAP_SUCCESS;
 }
 
-OLAPStatus Reader::_unique_key_next_row(RowCursor* row_cursor, MemPool* mem_pool,
-                                        ObjectPool* agg_pool, bool* eof) {
+OLAPStatus Reader::_unique_key_next_row(RowCursor* row_cursor, MemPool* mem_pool, ObjectPool* agg_pool, bool* eof) {
     *eof = false;
     bool cur_delete_flag = false;
     int64_t merged_count = 0;
@@ -227,8 +230,7 @@ OLAPStatus Reader::_unique_key_next_row(RowCursor* row_cursor, MemPool* mem_pool
             cur_delete_flag = _next_delete_flag;
             // if has sequence column, the higher version need to merge the lower versions
             if (_has_sequence_col) {
-                agg_update_row_with_sequence(_value_cids, row_cursor, *_next_key,
-                                             _sequence_col_idx);
+                agg_update_row_with_sequence(_value_cids, row_cursor, *_next_key, _sequence_col_idx);
             }
         }
 
@@ -309,9 +311,7 @@ OLAPStatus Reader::_capture_rs_readers(const ReaderParams& read_params) {
         _is_upper_keys_included.push_back(is_upper_key_included);
     }
 
-    if (eof) {
-        return OLAP_SUCCESS;
-    }
+    if (eof) { return OLAP_SUCCESS; }
 
     bool need_ordered_result = true;
     if (read_params.reader_type == READER_QUERY) {
@@ -457,6 +457,7 @@ OLAPStatus Reader::_init_return_columns(const ReaderParams& read_params) {
     return OLAP_SUCCESS;
 }
 
+
 void Reader::_init_seek_columns() {
     std::unordered_set<uint32_t> column_set(_return_columns.begin(), _return_columns.end());
     for (auto& it : _conditions.columns()) {
@@ -491,13 +492,13 @@ OLAPStatus Reader::_init_keys_param(const ReaderParams& read_params) {
     size_t start_key_size = read_params.start_key.size();
     _keys_param.start_keys.resize(start_key_size, nullptr);
     for (size_t i = 0; i < start_key_size; ++i) {
-        if ((_keys_param.start_keys[i] = new (nothrow) RowCursor()) == nullptr) {
+        if ((_keys_param.start_keys[i] = new(nothrow) RowCursor()) == nullptr) {
             OLAP_LOG_WARNING("fail to new RowCursor!");
             return OLAP_ERR_MALLOC_ERROR;
         }
 
-        OLAPStatus res = _keys_param.start_keys[i]->init_scan_key(
-                _tablet->tablet_schema(), read_params.start_key[i].values());
+        OLAPStatus res = _keys_param.start_keys[i]->init_scan_key(_tablet->tablet_schema(),
+                                                       read_params.start_key[i].values());
         if (res != OLAP_SUCCESS) {
             OLAP_LOG_WARNING("fail to init row cursor. [res=%d]", res);
             return res;
@@ -513,13 +514,13 @@ OLAPStatus Reader::_init_keys_param(const ReaderParams& read_params) {
     size_t end_key_size = read_params.end_key.size();
     _keys_param.end_keys.resize(end_key_size, NULL);
     for (size_t i = 0; i < end_key_size; ++i) {
-        if ((_keys_param.end_keys[i] = new (nothrow) RowCursor()) == NULL) {
+        if ((_keys_param.end_keys[i] = new(nothrow) RowCursor()) == NULL) {
             OLAP_LOG_WARNING("fail to new RowCursor!");
             return OLAP_ERR_MALLOC_ERROR;
         }
 
         OLAPStatus res = _keys_param.end_keys[i]->init_scan_key(_tablet->tablet_schema(),
-                                                                read_params.end_key[i].values());
+                                                     read_params.end_key[i].values());
         if (res != OLAP_SUCCESS) {
             OLAP_LOG_WARNING("fail to init row cursor. [res=%d]", res);
             return res;
@@ -548,96 +549,94 @@ void Reader::_init_conditions_param(const ReaderParams& read_params) {
     }
 }
 
-#define COMPARISON_PREDICATE_CONDITION_VALUE(NAME, PREDICATE)                              \
-    ColumnPredicate* Reader::_new_##NAME##_pred(const TabletColumn& column, int index,     \
-                                                const std::string& cond) {                 \
-        ColumnPredicate* predicate = nullptr;                                              \
-        switch (column.type()) {                                                           \
-        case OLAP_FIELD_TYPE_TINYINT: {                                                    \
-            std::stringstream ss(cond);                                                    \
-            int32_t value = 0;                                                             \
-            ss >> value;                                                                   \
-            predicate = new PREDICATE<int8_t>(index, value);                               \
-            break;                                                                         \
-        }                                                                                  \
-        case OLAP_FIELD_TYPE_SMALLINT: {                                                   \
-            std::stringstream ss(cond);                                                    \
-            int16_t value = 0;                                                             \
-            ss >> value;                                                                   \
-            predicate = new PREDICATE<int16_t>(index, value);                              \
-            break;                                                                         \
-        }                                                                                  \
-        case OLAP_FIELD_TYPE_INT: {                                                        \
-            std::stringstream ss(cond);                                                    \
-            int32_t value = 0;                                                             \
-            ss >> value;                                                                   \
-            predicate = new PREDICATE<int32_t>(index, value);                              \
-            break;                                                                         \
-        }                                                                                  \
-        case OLAP_FIELD_TYPE_BIGINT: {                                                     \
-            std::stringstream ss(cond);                                                    \
-            int64_t value = 0;                                                             \
-            ss >> value;                                                                   \
-            predicate = new PREDICATE<int64_t>(index, value);                              \
-            break;                                                                         \
-        }                                                                                  \
-        case OLAP_FIELD_TYPE_LARGEINT: {                                                   \
-            std::stringstream ss(cond);                                                    \
-            int128_t value = 0;                                                            \
-            ss >> value;                                                                   \
-            predicate = new PREDICATE<int128_t>(index, value);                             \
-            break;                                                                         \
-        }                                                                                  \
-        case OLAP_FIELD_TYPE_DECIMAL: {                                                    \
-            decimal12_t value(0, 0);                                                       \
-            value.from_string(cond);                                                       \
-            predicate = new PREDICATE<decimal12_t>(index, value);                          \
-            break;                                                                         \
-        }                                                                                  \
-        case OLAP_FIELD_TYPE_CHAR: {                                                       \
-            StringValue value;                                                             \
-            size_t length = std::max(static_cast<size_t>(column.length()), cond.length()); \
+#define COMPARISON_PREDICATE_CONDITION_VALUE(NAME, PREDICATE) \
+ColumnPredicate* Reader::_new_##NAME##_pred(const TabletColumn& column, int index, const std::string& cond) { \
+    ColumnPredicate* predicate = nullptr; \
+    switch (column.type()) { \
+        case OLAP_FIELD_TYPE_TINYINT: { \
+            std::stringstream ss(cond); \
+            int32_t value = 0; \
+            ss >> value; \
+            predicate = new PREDICATE<int8_t>(index, value); \
+            break; \
+        } \
+        case OLAP_FIELD_TYPE_SMALLINT: { \
+            std::stringstream ss(cond); \
+            int16_t value = 0; \
+            ss >> value; \
+            predicate = new PREDICATE<int16_t>(index, value); \
+            break; \
+        } \
+        case OLAP_FIELD_TYPE_INT: { \
+            std::stringstream ss(cond); \
+            int32_t value = 0; \
+            ss >> value; \
+            predicate = new PREDICATE<int32_t>(index, value); \
+            break; \
+        } \
+        case OLAP_FIELD_TYPE_BIGINT: { \
+            std::stringstream ss(cond); \
+            int64_t value = 0; \
+            ss >> value; \
+            predicate = new PREDICATE<int64_t>(index, value); \
+            break; \
+        } \
+        case OLAP_FIELD_TYPE_LARGEINT: { \
+            std::stringstream ss(cond); \
+            int128_t value = 0; \
+            ss >> value; \
+            predicate = new PREDICATE<int128_t>(index, value); \
+            break; \
+        } \
+        case OLAP_FIELD_TYPE_DECIMAL: { \
+            decimal12_t value(0, 0); \
+            value.from_string(cond); \
+            predicate = new PREDICATE<decimal12_t>(index, value); \
+            break; \
+        } \
+        case OLAP_FIELD_TYPE_CHAR: {\
+            StringValue value; \
+            size_t length = std::max(static_cast<size_t>(column.length()), cond.length());\
             char* buffer = reinterpret_cast<char*>(_predicate_mem_pool->allocate(length)); \
-            memset(buffer, 0, length);                                                     \
-            memory_copy(buffer, cond.c_str(), cond.length());                              \
-            value.len = length;                                                            \
-            value.ptr = buffer;                                                            \
-            predicate = new PREDICATE<StringValue>(index, value);                          \
-            break;                                                                         \
-        }                                                                                  \
-        case OLAP_FIELD_TYPE_VARCHAR: {                                                    \
-            StringValue value;                                                             \
-            int32_t length = cond.length();                                                \
+            memset(buffer, 0, length); \
+            memory_copy(buffer, cond.c_str(), cond.length()); \
+            value.len = length; \
+            value.ptr = buffer; \
+            predicate = new PREDICATE<StringValue>(index, value); \
+            break; \
+        } \
+        case OLAP_FIELD_TYPE_VARCHAR: { \
+            StringValue value; \
+            int32_t length = cond.length(); \
             char* buffer = reinterpret_cast<char*>(_predicate_mem_pool->allocate(length)); \
-            memory_copy(buffer, cond.c_str(), length);                                     \
-            value.len = length;                                                            \
-            value.ptr = buffer;                                                            \
-            predicate = new PREDICATE<StringValue>(index, value);                          \
-            break;                                                                         \
-        }                                                                                  \
-        case OLAP_FIELD_TYPE_DATE: {                                                       \
-            uint24_t value = timestamp_from_date(cond);                                    \
-            predicate = new PREDICATE<uint24_t>(index, value);                             \
-            break;                                                                         \
-        }                                                                                  \
-        case OLAP_FIELD_TYPE_DATETIME: {                                                   \
-            uint64_t value = timestamp_from_datetime(cond);                                \
-            predicate = new PREDICATE<uint64_t>(index, value);                             \
-            break;                                                                         \
-        }                                                                                  \
-        case OLAP_FIELD_TYPE_BOOL: {                                                       \
-            std::stringstream ss(cond);                                                    \
-            bool value = false;                                                            \
-            ss >> value;                                                                   \
-            predicate = new PREDICATE<bool>(index, value);                                 \
-            break;                                                                         \
-        }                                                                                  \
-        default:                                                                           \
-            break;                                                                         \
-        }                                                                                  \
-                                                                                           \
-        return predicate;                                                                  \
-    }
+            memory_copy(buffer, cond.c_str(), length); \
+            value.len = length; \
+            value.ptr = buffer; \
+            predicate = new PREDICATE<StringValue>(index, value); \
+            break; \
+        } \
+        case OLAP_FIELD_TYPE_DATE: { \
+            uint24_t value = timestamp_from_date(cond); \
+            predicate = new PREDICATE<uint24_t>(index, value); \
+            break; \
+        } \
+        case OLAP_FIELD_TYPE_DATETIME: { \
+            uint64_t value = timestamp_from_datetime(cond); \
+            predicate = new PREDICATE<uint64_t>(index, value); \
+            break; \
+        } \
+        case OLAP_FIELD_TYPE_BOOL: { \
+            std::stringstream ss(cond); \
+            bool value = false; \
+            ss >> value; \
+            predicate = new PREDICATE<bool>(index, value); \
+            break; \
+        } \
+        default: break; \
+    } \
+ \
+    return predicate; \
+} \
 
 COMPARISON_PREDICATE_CONDITION_VALUE(eq, EqualPredicate)
 COMPARISON_PREDICATE_CONDITION_VALUE(ne, NotEqualPredicate)
@@ -669,121 +668,120 @@ ColumnPredicate* Reader::_parse_to_predicate(const TCondition& condition) {
         predicate = _new_ge_pred(column, index, condition.condition_values[0]);
     } else if (condition.condition_op == "*=" && condition.condition_values.size() > 1) {
         switch (column.type()) {
-        case OLAP_FIELD_TYPE_TINYINT: {
-            std::set<int8_t> values;
-            for (auto& cond_val : condition.condition_values) {
-                int32_t value = 0;
-                std::stringstream ss(cond_val);
-                ss >> value;
-                values.insert(value);
+            case OLAP_FIELD_TYPE_TINYINT: {
+                std::set<int8_t> values;
+                for (auto& cond_val : condition.condition_values) {
+                    int32_t value = 0;
+                    std::stringstream ss(cond_val);
+                    ss >> value;
+                    values.insert(value);
+                }
+                predicate = new InListPredicate<int8_t>(index, std::move(values));
+                break;
             }
-            predicate = new InListPredicate<int8_t>(index, std::move(values));
-            break;
-        }
-        case OLAP_FIELD_TYPE_SMALLINT: {
-            std::set<int16_t> values;
-            for (auto& cond_val : condition.condition_values) {
-                int16_t value = 0;
-                std::stringstream ss(cond_val);
-                ss >> value;
-                values.insert(value);
+            case OLAP_FIELD_TYPE_SMALLINT: {
+                std::set<int16_t> values;
+                for (auto& cond_val : condition.condition_values) {
+                    int16_t value = 0;
+                    std::stringstream ss(cond_val);
+                    ss >> value;
+                    values.insert(value);
+                }
+                predicate = new InListPredicate<int16_t>(index, std::move(values));
+                break;
             }
-            predicate = new InListPredicate<int16_t>(index, std::move(values));
-            break;
-        }
-        case OLAP_FIELD_TYPE_INT: {
-            std::set<int32_t> values;
-            for (auto& cond_val : condition.condition_values) {
-                int32_t value = 0;
-                std::stringstream ss(cond_val);
-                ss >> value;
-                values.insert(value);
+            case OLAP_FIELD_TYPE_INT: {
+                std::set<int32_t> values;
+                for (auto& cond_val : condition.condition_values) {
+                    int32_t value = 0;
+                    std::stringstream ss(cond_val);
+                    ss >> value;
+                    values.insert(value);
+                }
+                predicate = new InListPredicate<int32_t>(index, std::move(values));
+                break;
             }
-            predicate = new InListPredicate<int32_t>(index, std::move(values));
-            break;
-        }
-        case OLAP_FIELD_TYPE_BIGINT: {
-            std::set<int64_t> values;
-            for (auto& cond_val : condition.condition_values) {
-                int64_t value = 0;
-                std::stringstream ss(cond_val);
-                ss >> value;
-                values.insert(value);
+            case OLAP_FIELD_TYPE_BIGINT: {
+                std::set<int64_t> values;
+                for (auto& cond_val : condition.condition_values) {
+                    int64_t value = 0;
+                    std::stringstream ss(cond_val);
+                    ss >> value;
+                    values.insert(value);
+                }
+                predicate = new InListPredicate<int64_t>(index, std::move(values));
+                break;
             }
-            predicate = new InListPredicate<int64_t>(index, std::move(values));
-            break;
-        }
-        case OLAP_FIELD_TYPE_LARGEINT: {
-            std::set<int128_t> values;
-            for (auto& cond_val : condition.condition_values) {
-                int128_t value = 0;
-                std::stringstream ss(cond_val);
-                ss >> value;
-                values.insert(value);
+            case OLAP_FIELD_TYPE_LARGEINT: {
+                std::set<int128_t> values;
+                for (auto& cond_val : condition.condition_values) {
+                    int128_t value = 0;
+                    std::stringstream ss(cond_val);
+                    ss >> value;
+                    values.insert(value);
+                }
+                predicate = new InListPredicate<int128_t>(index, std::move(values));
+                break;
             }
-            predicate = new InListPredicate<int128_t>(index, std::move(values));
-            break;
-        }
-        case OLAP_FIELD_TYPE_DECIMAL: {
-            std::set<decimal12_t> values;
-            for (auto& cond_val : condition.condition_values) {
-                decimal12_t value;
-                value.from_string(cond_val);
-                values.insert(value);
+            case OLAP_FIELD_TYPE_DECIMAL: {
+                std::set<decimal12_t> values;
+                for (auto& cond_val : condition.condition_values) {
+                    decimal12_t value;
+                    value.from_string(cond_val);
+                    values.insert(value);
+                }
+                predicate = new InListPredicate<decimal12_t>(index, std::move(values));
+                break;
             }
-            predicate = new InListPredicate<decimal12_t>(index, std::move(values));
-            break;
-        }
-        case OLAP_FIELD_TYPE_CHAR: {
-            std::set<StringValue> values;
-            for (auto& cond_val : condition.condition_values) {
-                StringValue value;
-                size_t length = std::max(static_cast<size_t>(column.length()), cond_val.length());
-                char* buffer = reinterpret_cast<char*>(_predicate_mem_pool->allocate(length));
-                memset(buffer, 0, length);
-                memory_copy(buffer, cond_val.c_str(), cond_val.length());
-                value.len = length;
-                value.ptr = buffer;
-                values.insert(value);
+            case OLAP_FIELD_TYPE_CHAR: {
+                std::set<StringValue> values;
+                for (auto& cond_val : condition.condition_values) {
+                    StringValue value;
+                    size_t length = std::max(static_cast<size_t>(column.length()), cond_val.length());
+                    char* buffer = reinterpret_cast<char*>(_predicate_mem_pool->allocate(length));
+                    memset(buffer, 0, length);
+                    memory_copy(buffer, cond_val.c_str(), cond_val.length());
+                    value.len = length;
+                    value.ptr = buffer;
+                    values.insert(value);
+                }
+                predicate = new InListPredicate<StringValue>(index, std::move(values));
+                break;
             }
-            predicate = new InListPredicate<StringValue>(index, std::move(values));
-            break;
-        }
-        case OLAP_FIELD_TYPE_VARCHAR: {
-            std::set<StringValue> values;
-            for (auto& cond_val : condition.condition_values) {
-                StringValue value;
-                int32_t length = cond_val.length();
-                char* buffer = reinterpret_cast<char*>(_predicate_mem_pool->allocate(length));
-                memory_copy(buffer, cond_val.c_str(), length);
-                value.len = length;
-                value.ptr = buffer;
-                values.insert(value);
+            case OLAP_FIELD_TYPE_VARCHAR: {
+                std::set<StringValue> values;
+                for (auto& cond_val : condition.condition_values) {
+                    StringValue value;
+                    int32_t length = cond_val.length();
+                    char* buffer = reinterpret_cast<char*>(_predicate_mem_pool->allocate(length));
+                    memory_copy(buffer, cond_val.c_str(), length);
+                    value.len = length;
+                    value.ptr = buffer;
+                    values.insert(value);
+                }
+                predicate = new InListPredicate<StringValue>(index, std::move(values));
+                break;
             }
-            predicate = new InListPredicate<StringValue>(index, std::move(values));
-            break;
-        }
-        case OLAP_FIELD_TYPE_DATE: {
-            std::set<uint24_t> values;
-            for (auto& cond_val : condition.condition_values) {
-                uint24_t value = timestamp_from_date(cond_val);
-                values.insert(value);
+            case OLAP_FIELD_TYPE_DATE: {
+                std::set<uint24_t> values;
+                for (auto& cond_val : condition.condition_values) {
+                    uint24_t value = timestamp_from_date(cond_val);
+                    values.insert(value);
+                }
+                predicate = new InListPredicate<uint24_t>(index, std::move(values));
+                break;
             }
-            predicate = new InListPredicate<uint24_t>(index, std::move(values));
-            break;
-        }
-        case OLAP_FIELD_TYPE_DATETIME: {
-            std::set<uint64_t> values;
-            for (auto& cond_val : condition.condition_values) {
-                uint64_t value = timestamp_from_datetime(cond_val);
-                values.insert(value);
+            case OLAP_FIELD_TYPE_DATETIME: {
+                std::set<uint64_t> values;
+                for (auto& cond_val : condition.condition_values) {
+                    uint64_t value = timestamp_from_datetime(cond_val);
+                    values.insert(value);
+                }
+                predicate = new InListPredicate<uint64_t>(index, std::move(values));
+                break;
             }
-            predicate = new InListPredicate<uint64_t>(index, std::move(values));
-            break;
-        }
-        // OLAP_FIELD_TYPE_BOOL is not valid in this case.
-        default:
-            break;
+            // OLAP_FIELD_TYPE_BOOL is not valid in this case.
+            default: break;
         }
     } else if (condition.condition_op == "is") {
         predicate = new NullPredicate(index, condition.condition_values[0] == "null");
@@ -795,8 +793,8 @@ void Reader::_init_load_bf_columns(const ReaderParams& read_params) {
     // add all columns with condition to _load_bf_columns
     for (const auto& cond_column : _conditions.columns()) {
         for (const Cond* cond : cond_column.second->conds()) {
-            if (cond->op == OP_EQ ||
-                (cond->op == OP_IN && cond->operand_set.size() < MAX_OP_IN_FIELD_NUM)) {
+            if (cond->op == OP_EQ
+                    || (cond->op == OP_IN && cond->operand_set.size() < MAX_OP_IN_FIELD_NUM)) {
                 _load_bf_columns.insert(cond_column.first);
             }
         }
@@ -855,17 +853,19 @@ void Reader::_init_load_bf_columns(const ReaderParams& read_params) {
 OLAPStatus Reader::_init_delete_condition(const ReaderParams& read_params) {
     if (read_params.reader_type != READER_CUMULATIVE_COMPACTION) {
         _tablet->obtain_header_rdlock();
-        OLAPStatus ret = _delete_handler.init(
-                _tablet->tablet_schema(), _tablet->delete_predicates(), read_params.version.second);
+        OLAPStatus ret = _delete_handler.init(_tablet->tablet_schema(),
+                                              _tablet->delete_predicates(),
+                                              read_params.version.second);
         _tablet->release_header_lock();
 
         if (read_params.reader_type == READER_BASE_COMPACTION) {
             _filter_delete = true;
         }
         return ret;
-    } else {
+    }
+    else {
         return OLAP_SUCCESS;
     }
 }
 
-} // namespace doris
+}  // namespace doris

--- a/be/src/olap/reader.cpp
+++ b/be/src/olap/reader.cpp
@@ -19,6 +19,7 @@
 
 #include <sstream>
 
+#include "olap/collect_iterator.h"
 #include "olap/comparison_predicate.h"
 #include "olap/in_list_predicate.h"
 #include "olap/null_predicate.h"
@@ -39,261 +40,56 @@ using std::vector;
 
 namespace doris {
 
-class CollectIterator {
-public:
-    ~CollectIterator();
-
-    // Hold reader point to get reader params
-    void init(Reader* reader);
-
-    OLAPStatus add_child(RowsetReaderSharedPtr rs_reader);
-
-    // Get top row of the heap, nullptr if reach end.
-    const RowCursor* current_row(bool* delete_flag) const {
-        if (_cur_child != nullptr) {
-            return _cur_child->current_row(delete_flag);
-        }
-        return nullptr;
-    }
-
-    // Read next row into *row.
-    // Returns
-    //      OLAP_SUCCESS when read successfully.
-    //      OLAP_ERR_DATA_EOF and set *row to nullptr when EOF is reached.
-    //      Others when error happens
-    OLAPStatus next(const RowCursor** row, bool* delete_flag) {
-        DCHECK(_cur_child != nullptr);
-        if (_merge) {
-            return _merge_next(row, delete_flag);
-        } else {
-            return _normal_next(row, delete_flag);
-        }
-    }
-
-    // Clear the MergeSet element and reset state.
-    void clear();
-
-private:
-    class ChildCtx {
-    public:
-        ChildCtx(RowsetReaderSharedPtr rs_reader, Reader* reader)
-                : _rs_reader(rs_reader), _is_delete(rs_reader->delete_flag()), _reader(reader) {}
-
-        OLAPStatus init() {
-            auto res = _row_cursor.init(_reader->_tablet->tablet_schema(), _reader->_seek_columns);
-            if (res != OLAP_SUCCESS) {
-                LOG(WARNING) << "failed to init row cursor, res=" << res;
-                return res;
-            }
-            RETURN_NOT_OK(_refresh_current_row());
-            return OLAP_SUCCESS;
-        }
-
-        const RowCursor* current_row(bool* delete_flag) const {
-            *delete_flag = _is_delete || _current_row->is_delete();
-            return _current_row;
-        }
-
-        const RowCursor* current_row() const { return _current_row; }
-
-        int32_t version() const { return _rs_reader->version().second; }
-
-        OLAPStatus next(const RowCursor** row, bool* delete_flag) {
-            _row_block->pos_inc();
-            auto res = _refresh_current_row();
-            *row = _current_row;
-            *delete_flag = _is_delete;
-            if (_current_row != nullptr) {
-                *delete_flag = _is_delete || _current_row->is_delete();
-            };
-            return res;
-        }
-
-    private:
-        // refresh_current_row
-        OLAPStatus _refresh_current_row() {
-            do {
-                if (_row_block != nullptr && _row_block->has_remaining()) {
-                    size_t pos = _row_block->pos();
-                    _row_block->get_row(pos, &_row_cursor);
-                    if (_row_block->block_status() == DEL_PARTIAL_SATISFIED &&
-                        _reader->_delete_handler.is_filter_data(_rs_reader->version().second,
-                                                                _row_cursor)) {
-                        _reader->_stats.rows_del_filtered++;
-                        _row_block->pos_inc();
-                        continue;
-                    }
-                    _current_row = &_row_cursor;
-                    return OLAP_SUCCESS;
-                } else {
-                    auto res = _rs_reader->next_block(&_row_block);
-                    if (res != OLAP_SUCCESS) {
-                        _current_row = nullptr;
-                        return res;
-                    }
-                }
-            } while (_row_block != nullptr);
-            _current_row = nullptr;
-            return OLAP_ERR_DATA_EOF;
-        }
-
-        RowsetReaderSharedPtr _rs_reader;
-        const RowCursor* _current_row = nullptr;
-        bool _is_delete = false;
-        Reader* _reader = nullptr;
-
-        RowCursor _row_cursor; // point to rows inside `_row_block`
-        RowBlock* _row_block = nullptr;
-    };
-
-    // Compare row cursors between multiple merge elements,
-    // if row cursors equal, compare data version.
-    class ChildCtxComparator {
-    public:
-        ChildCtxComparator(const bool& revparam = false) { _reverse = revparam; }
-        bool operator()(const ChildCtx* a, const ChildCtx* b);
-
-    private:
-        bool _reverse;
-    };
-
-    inline OLAPStatus _merge_next(const RowCursor** row, bool* delete_flag);
-    inline OLAPStatus _normal_next(const RowCursor** row, bool* delete_flag);
-
-    // each ChildCtx corresponds to a rowset reader
-    std::vector<ChildCtx*> _children;
-    // point to the ChildCtx containing the next output row.
-    // null when CollectIterator hasn't been initialized or reaches EOF.
-    ChildCtx* _cur_child = nullptr;
-
-    // when `_merge == true`, rowset reader returns ordered rows and CollectIterator uses a priority queue to merge
-    // sort them. The output of CollectIterator is also ordered.
-    // When `_merge == false`, rowset reader returns *partial* ordered rows. CollectIterator simply returns all rows
-    // from the first rowset, the second rowset, .., the last rowset. The output of CollectorIterator is also
-    // *partially* ordered.
-    bool _merge = true;
-    // used when `_merge == true`
-    typedef std::priority_queue<ChildCtx*, std::vector<ChildCtx*>, ChildCtxComparator> MergeHeap;
-    std::unique_ptr<MergeHeap> _heap;
-    // used when `_merge == false`
-    int _child_idx = 0;
-
-    // Hold reader point to access read params, such as fetch conditions.
-    Reader* _reader = nullptr;
-};
-
-CollectIterator::~CollectIterator() {
-    for (auto child : _children) {
-        delete child;
+void ReaderParams::check_validation() const {
+    if (UNLIKELY(version.first == -1)) {
+        LOG(FATAL) << "version is not set. tablet=" << tablet->full_name();
     }
 }
 
-void CollectIterator::init(Reader* reader) {
-    _reader = reader;
-    // when aggregate is enabled or key_type is DUP_KEYS, we don't merge
-    // multiple data to aggregate for performance in user fetch
-    if (_reader->_reader_type == READER_QUERY &&
-        (_reader->_aggregation || _reader->_tablet->keys_type() == KeysType::DUP_KEYS)) {
-        _merge = false;
-        _heap.reset(nullptr);
-    } else if (_reader->_tablet->keys_type() == KeysType::UNIQUE_KEYS) {
-        _heap.reset(new MergeHeap(ChildCtxComparator(true)));
-    } else {
-        _heap.reset(new MergeHeap());
+std::string ReaderParams::to_string() {
+    std::stringstream ss;
+    ss << "tablet=" << tablet->full_name() << " reader_type=" << reader_type
+       << " aggregation=" << aggregation << " version=" << version << " range=" << range
+       << " end_range=" << end_range;
+
+    for (auto& key : start_key) {
+        ss << " keys=" << key;
+    }
+
+    for (auto& key : end_key) {
+        ss << " end_keys=" << key;
+    }
+
+    for (auto& condition : conditions) {
+        ss << " conditions=" << apache::thrift::ThriftDebugString(condition);
+    }
+
+    return ss.str();
+}
+Reader::KeysParam::~KeysParam() {
+    for (auto start_key : start_keys) {
+        SAFE_DELETE(start_key);
+    }
+
+    for (auto end_key : end_keys) {
+        SAFE_DELETE(end_key);
     }
 }
 
-OLAPStatus CollectIterator::add_child(RowsetReaderSharedPtr rs_reader) {
-    std::unique_ptr<ChildCtx> child(new ChildCtx(rs_reader, _reader));
-    RETURN_NOT_OK(child->init());
-    if (child->current_row() == nullptr) {
-        return OLAP_SUCCESS;
-    }
+std::string Reader::KeysParam::to_string() const {
+    std::stringstream ss;
+    ss << "range=" << range << " end_range=" << end_range;
 
-    ChildCtx* child_ptr = child.release();
-    _children.push_back(child_ptr);
-    if (_merge) {
-        _heap->push(child_ptr);
-        _cur_child = _heap->top();
-    } else {
-        if (_cur_child == nullptr) {
-            _cur_child = _children[_child_idx];
-        }
-    }
-    return OLAP_SUCCESS;
-}
-
-inline OLAPStatus CollectIterator::_merge_next(const RowCursor** row, bool* delete_flag) {
-    _heap->pop();
-    auto res = _cur_child->next(row, delete_flag);
-    if (res == OLAP_SUCCESS) {
-        _heap->push(_cur_child);
-        _cur_child = _heap->top();
-    } else if (res == OLAP_ERR_DATA_EOF) {
-        if (!_heap->empty()) {
-            _cur_child = _heap->top();
-        } else {
-            _cur_child = nullptr;
-            return OLAP_ERR_DATA_EOF;
-        }
-    } else {
-        LOG(WARNING) << "failed to get next from child, res=" << res;
-        return res;
-    }
-    *row = _cur_child->current_row(delete_flag);
-    return OLAP_SUCCESS;
-}
-
-inline OLAPStatus CollectIterator::_normal_next(const RowCursor** row, bool* delete_flag) {
-    auto res = _cur_child->next(row, delete_flag);
-    if (LIKELY(res == OLAP_SUCCESS)) {
-        return OLAP_SUCCESS;
-    } else if (res == OLAP_ERR_DATA_EOF) {
-        // this child has been read, to read next
-        _child_idx++;
-        if (_child_idx < _children.size()) {
-            _cur_child = _children[_child_idx];
-            *row = _cur_child->current_row(delete_flag);
-            return OLAP_SUCCESS;
-        } else {
-            _cur_child = nullptr;
-            return OLAP_ERR_DATA_EOF;
-        }
-    } else {
-        LOG(WARNING) << "failed to get next from child, res=" << res;
-        return res;
+    for (auto start_key : start_keys) {
+        ss << " keys=" << start_key->to_string();
     }
 }
 
-bool CollectIterator::ChildCtxComparator::operator()(const ChildCtx* a, const ChildCtx* b) {
-    // First compare row cursor.
-    const RowCursor* first = a->current_row();
-    const RowCursor* second = b->current_row();
-    int cmp_res = compare_row(*first, *second);
-    if (cmp_res != 0) {
-        return cmp_res > 0;
+    for (auto end_key : end_keys) {
+        ss << " end_keys=" << end_key->to_string();
     }
-    // if row cursors equal, compare data version.
-    // read data from higher version to lower version.
-    // for UNIQUE_KEYS just read the highest version and no need agg_update.
-    // for AGG_KEYS if a version is deleted, the lower version no need to agg_update
-    if (_reverse) {
-        return a->version() < b->version();
-    }
-    return a->version() > b->version();
-}
 
-void CollectIterator::clear() {
-    while (_heap != nullptr && !_heap->empty()) {
-        _heap->pop();
-    }
-    for (auto child : _children) {
-        delete child;
-    }
-    // _children.swap(std::vector<ChildCtx*>());
-    _children.clear();
-    _cur_child = nullptr;
-    _child_idx = 0;
+    return ss.str();
 }
 
 Reader::Reader() {
@@ -555,7 +351,7 @@ OLAPStatus Reader::_capture_rs_readers(const ReaderParams& read_params) {
         }
         _rs_readers.push_back(rs_reader);
     }
-
+    _collect_iter->build_heap();
     _next_key = _collect_iter->current_row(&_next_delete_flag);
     return OLAP_SUCCESS;
 }

--- a/be/src/olap/reader.h
+++ b/be/src/olap/reader.h
@@ -74,32 +74,9 @@ struct ReaderParams {
     RuntimeProfile* profile = nullptr;
     RuntimeState* runtime_state = nullptr;
 
-    void check_validation() const {
-        if (UNLIKELY(version.first == -1)) {
-            LOG(FATAL) << "version is not set. tablet=" << tablet->full_name();
-        }
-    }
+    void check_validation() const;
 
-    std::string to_string() {
-        std::stringstream ss;
-        ss << "tablet=" << tablet->full_name() << " reader_type=" << reader_type
-           << " aggregation=" << aggregation << " version=" << version << " range=" << range
-           << " end_range=" << end_range;
-
-        for (auto& key : start_key) {
-            ss << " keys=" << key;
-        }
-
-        for (auto& key : end_key) {
-            ss << " end_keys=" << key;
-        }
-
-        for (auto& condition : conditions) {
-            ss << " conditions=" << apache::thrift::ThriftDebugString(condition);
-        }
-
-        return ss.str();
-    }
+    std::string to_string();
 };
 
 class Reader {
@@ -130,30 +107,9 @@ public:
 
 private:
     struct KeysParam {
-        ~KeysParam() {
-            for (auto start_key : start_keys) {
-                SAFE_DELETE(start_key);
-            }
+        ~KeysParam();
 
-            for (auto end_key : end_keys) {
-                SAFE_DELETE(end_key);
-            }
-        }
-
-        std::string to_string() const {
-            std::stringstream ss;
-            ss << "range=" << range << " end_range=" << end_range;
-
-            for (auto start_key : start_keys) {
-                ss << " keys=" << start_key->to_string();
-            }
-
-            for (auto end_key : end_keys) {
-                ss << " end_keys=" << end_key->to_string();
-            }
-
-            return ss.str();
-        }
+        std::string to_string() const;
 
         std::string range;
         std::string end_range;

--- a/be/src/olap/tablet_manager.cpp
+++ b/be/src/olap/tablet_manager.cpp
@@ -725,7 +725,7 @@ TabletSharedPtr TabletManager::find_best_tablet_to_compaction(
                 }
                 if (now_ms - last_failure_ms <=
                     config::min_compaction_failure_interval_sec * 1000) {
-                    VLOG(1) << "Too often to check compaction, skip it."
+                    VLOG(1) << "Too often to check compaction, skip it. "
                             << "compaction_type=" << compaction_type_str
                             << ", last_failure_time_ms=" << last_failure_ms
                             << ", tablet_id=" << tablet_ptr->tablet_id();


### PR DESCRIPTION
changed the merge method of the unique table,
merged the cumulative version data first, and then merged with the base version.
For the data with only one base version, read directly without merging

## Proposed changes

Optimize the read performance of AGG and UNIQUE table with too much versions
the benchmark as follows
By the way, in most cases, the meaning of merge in our code is merge sort, so to avoid ambiguity I renamed some functions and variables
MergeHeap -> MergeSortHeap
MergeIterator -> MergeSortIterator
new_merge_iterator -> new_sort_iterator
## Test Data 

This test data set is the catalog_sales data in the tpcds 10G data set. The data is divided into two parts, one is the complete data (corresponding to the big table) 3G, a total of 28802522 (after unqiue 14401261) rows, one only has 200M sampling data (corresponding to test The table) has a total of 1,000,000 rows, only one partition is used, and the complete data is divided into 10 buckets.

All tables are in segment V2 format

```
+-------+--------------+------+-------+---------+---------+
| Field | Type         | Null | Key   | Default | Extra   |
+-------+--------------+------+-------+---------+---------+
| k1    | BIGINT       | No   | true  | NULL    |         |
| k2    | BIGINT       | No   | true  | NULL    |         |
| k3    | BIGINT       | Yes  | true  | NULL    |         |
| k4    | BIGINT       | Yes  | true  | NULL    |         |
| k5    | BIGINT       | Yes  | true  | NULL    |         |
| k6    | BIGINT       | Yes  | true  | NULL    |         |
| k7    | BIGINT       | Yes  | true  | NULL    |         |
| k8    | BIGINT       | Yes  | true  | NULL    |         |
| k9    | BIGINT       | Yes  | true  | NULL    |         |
| k10   | BIGINT       | Yes  | true  | NULL    |         |
| v1    | BIGINT       | Yes  | false | NULL    | REPLACE |
| v2    | BIGINT       | Yes  | false | NULL    | REPLACE |
| v3    | BIGINT       | Yes  | false | NULL    | REPLACE |
| v4    | BIGINT       | Yes  | false | NULL    | REPLACE |
| v5    | BIGINT       | Yes  | false | NULL    | REPLACE |
| v6    | BIGINT       | Yes  | false | NULL    | REPLACE |
| v7    | BIGINT       | Yes  | false | NULL    | REPLACE |
| v8    | BIGINT       | Yes  | false | NULL    | REPLACE |
| v9    | BIGINT       | Yes  | false | NULL    | REPLACE |
| v10   | DECIMAL(7,2) | Yes  | false | NULL    | REPLACE |
| v11   | DECIMAL(7,2) | Yes  | false | NULL    | REPLACE |
| v12   | DECIMAL(7,2) | Yes  | false | NULL    | REPLACE |
| v13   | DECIMAL(7,2) | Yes  | false | NULL    | REPLACE |
| v14   | DECIMAL(7,2) | Yes  | false | NULL    | REPLACE |
| v15   | DECIMAL(7,2) | Yes  | false | NULL    | REPLACE |
| v16   | DECIMAL(7,2) | Yes  | false | NULL    | REPLACE |
| v17   | DECIMAL(7,2) | Yes  | false | NULL    | REPLACE |
| v18   | DECIMAL(7,2) | Yes  | false | NULL    | REPLACE |
| v19   | DECIMAL(7,2) | Yes  | false | NULL    | REPLACE |
| v20   | DECIMAL(7,2) | Yes  | false | NULL    | REPLACE |
| v21   | DECIMAL(7,2) | Yes  | false | NULL    | REPLACE |
| v22   | DECIMAL(7,2) | Yes  | false | NULL    | REPLACE |
| v23   | DECIMAL(7,2) | Yes  | false | NULL    | REPLACE |
| v24   | DECIMAL(7,2) | Yes  | false | NULL    | REPLACE |
+-------+--------------+------+-------+---------+---------+
```

This test is mainly to test the read performance, especially when there are a large number of small versions that are merged, so the test query for this time is `select count(*) from (select k1,k2,k3,k4,k5 ,k6,k7,k8,k9,k10 from table_name) a;`

### UNIQUE_KEY and UNIQUE_KEY comparison

First of all, this test compares the difference in read performance between the UNIQUE_KEY table and the DUPLICTE_KEY table. The first version of the two versions is an empty version

| Table | Data size | Number of partitions | Number of buckets | Number of rows | Number of versions | Query time (s) |
| ------------- | --------- | ------ | ------ | ---------- | ------ | ------------- |
| test_uniq | 93.585 MB | 1 | 1 | 1,000,000 | 2 | 9 |
| test_uniq_big | 1.327 GB | 10 | 10 | 14,401,261 | 2 | 13.5 |
| test_dup | 93.724 MB | 1 | 1 | 1,000,000 | 2 | 4.8 |
| test_dup_big | 2.571 G | 10 | 10 | 28,802,522 | 2 | 7 |

It can be seen that the read speed of the duplicate table is about **1 times** that of unique

Optimized data

| Table | Data size | Number of partitions | Number of buckets | Number of rows | Number of versions | Query time (s) |
| ------------- | --------- | ------ | ------ | ---------- | ------ | ------------- |
| test_uniq | 93.585 MB | 1 | 1 | 1,000,000 | 2 | 4.8 |
| test_uniq_big | 1.327 GB | 10 | 10 | 14,401,261 | 2 | 7.4 |
| test_dup | 93.724 MB | 1 | 1 | 1,000,000 | 2 | 4.7 |
| test_dup_big | 2.571 G | 10 | 10 | 28,802,522 | 2 | 7 |

 After optimization, when the number of base versions is relatively small, the query performance is not much different.

### UNIQUE_KEY multi-version reading optimization comparison

Since the data imported in multiple versions is random data, the data of the non-full version is a bit different, the test query is `select count(*) from table_name`

| Table | Data size | Number of partitions | Number of buckets | Number of rows | Number of versions | Query time (s) |
| ------------------------------ | -------------- | ------ | ------ | ------------ | --------- | ------------- |
| test_uniq(before)              | 136.288 MB     | 1      | 1      | 1008592      | 10000     | 11.7          |
| **test_uniq(after)**          | **136.266 MB** | **1**  | **1**  | **1008635**  | **10000** | **7.1**       |
| test_uniq_big(before）         | 1.368 GB       | 1      | 10     | 14401261     | 10000     | 15.5          |
| **test_uniq_big(after）**     | **1.368 GB**   | **1**  | **10** | **14401261** | **10000** | **12**        |
| test_uniq_base(before)         | 94.252 MB      | 1      | 1      | 1000000      | 1         | 4             |
| **test_uniq_base(after)**     | **94.252 MB**  | **1**  | **1**  | **1000000**  | **1**     | **3.75**      |
| test_uniq_big_base(before)     | 1.327 GB       | 1      | 10     | 14401261     | 1         | 6             |
| **test_uniq_big_base(after)** | **1.327 GB**   | **1**  | **10** | **14401261** | **1**     | **5.6**       |
| test_uniq(before)              | 96.348 MB      | 1      | 1      | 1008592      | 500       | 7.1           |
| **test_uniq(after)**          | **96.349 MB**  | **1**  | **1**  | **1008635**  | **500**   | **4.5**       |
| test_uniq_big(before）         | 1.329 GB       | 1      | 10     | 14401261     | 500       | 8.8           |
| **test_uniq_big(after）**     | **1.327 GB**   | **1**  | **10** | **14401261** | **500**   | 6.7           |


When there are many versions of a table, we have a lot of time spent on sorting and merging rowset
In our scenario, this sorting is actually a merge sorting of multiple ordered queues, and usually due to the existence of compapction, we will have a relatively large base rowset and several small rowset, so we can combine The small rowset is sorted first and merged with the large rowset to optimize the read performance

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] Documentation Update (if none of the other choices apply)
- [] Code refactor (Modify the code structure, format the code, etc...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have create an issue on (Fix #4957 ), and have described the bug/feature there in detail
- [] Compiling and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [] If this change need a document change, I have updated the document
- [] Any dependent changes have been merged

## Further comments

If this is a relatively large or complex change, kick off the discussion at dev@doris.apache.org by explaining why you chose the solution you did and what alternatives you considered, etc...
