### PR TITLE
Use the right queryId to audit master only query in non master

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectProcessor.java
@@ -475,6 +475,9 @@ public class ConnectProcessor {
         // no matter the master execute success or fail, the master must transfer the result to follower
         // and tell the follower the current journalID.
         TMasterOpResult result = new TMasterOpResult();
+        if (ctx.queryId() != null) {
+            result.setQueryId(ctx.queryId);
+        }
         result.setMaxJournalId(Catalog.getCurrentCatalog().getMaxJournalId().longValue());
         result.setPacket(getResultPacket());
         if (executor != null && executor.getProxyResultSet() != null) {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/MasterOpExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/MasterOpExecutor.java
@@ -24,6 +24,7 @@ import org.apache.doris.thrift.TMasterOpRequest;
 import org.apache.doris.thrift.TMasterOpResult;
 import org.apache.doris.thrift.TNetworkAddress;
 import org.apache.doris.thrift.TQueryOptions;
+import org.apache.doris.thrift.TUniqueId;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -127,6 +128,15 @@ public class MasterOpExecutor {
         }
         return result.packet;
     }
+
+    public TUniqueId getQueryId() {
+        if (result != null && result.isSetQueryId()) {
+            return result.getQueryId();
+        } else {
+            return null;
+        }
+    }
+
     
     public ShowResultSet getProxyResultSet() {
         if (result == null) {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -264,6 +264,9 @@ public class StmtExecutor {
 
             if (isForwardToMaster()) {
                 forwardToMaster();
+                if (masterOpExecutor != null && masterOpExecutor.getQueryId() != null) {
+                    context.setQueryId(masterOpExecutor.getQueryId());
+                }
                 return;
             } else {
                 LOG.debug("no need to transfer to Master. stmt: {}", context.getStmtId());
@@ -824,6 +827,7 @@ public class StmtExecutor {
         Throwable throwable = null;
 
         String label = insertStmt.getLabel();
+        LOG.info("Do insert [{}] with query id: {}", label, DebugUtil.printId(context.queryId()));
 
         long loadedRows = 0;
         int filteredRows = 0;

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -463,6 +463,7 @@ struct TMasterOpResult {
     1: required i64 maxJournalId;
     2: required binary packet;
     3: optional TShowResultSet resultSet;
+    4: optional Types.TUniqueId queryId;
 }
 
 struct TLoadCheckRequest {


### PR DESCRIPTION
Fix #4977

## Proposed changes
Add queryId in TMasterOpResult.
Audit it in non master FE.

## Types of changes

What types of changes does your code introduce to Doris?

- [x] Bugfix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] Documentation Update (if none of the other choices apply)
- [] Code refactor (Modify the code structure, format the code, etc...)

## Checklist


- [x] I have create an issue on (Fix #4977 ), and have described the bug/feature there in detail
- [] Compiling and unit tests pass locally with my changes
- [] I have added tests that prove my fix is effective or that my feature works
- [] If this change need a document change, I have updated the document
- [] Any dependent changes have been merged

## Further comments

If this is a relatively large or complex change, kick off the discussion at dev@doris.apache.org by explaining why you chose the solution you did and what alternatives you considered, etc...
