### PR TITLE
[Enhance] Avoid constant expressions being calculated multiple times on the BE side

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -13,3 +13,4 @@ PointerAlignment: Left
 ReflowComments: false
 SortUsingDeclarations: false
 SpacesBeforeTrailingComments: 1
+AlignTrailingComments: true

--- a/be/src/exprs/expr.cpp
+++ b/be/src/exprs/expr.cpp
@@ -632,13 +632,20 @@ std::string Expr::debug_string(const std::vector<ExprContext*>& ctxs) {
     return debug_string(exprs);
 }
 
-bool Expr::is_constant() const {
+bool Expr::is_constant() {
+    if (_set_is_constant) {
+        return _is_constant;
+    }
     for (int i = 0; i < _children.size(); ++i) {
         if (!_children[i]->is_constant()) {
+            _set_is_constant = true;
+            _is_constant = false;
             return false;
         }
     }
 
+    _set_is_constant = true;
+    _is_constant = true;
     return true;
 }
 

--- a/be/src/exprs/expr.h
+++ b/be/src/exprs/expr.h
@@ -152,7 +152,7 @@ public:
     // Returns true if expr doesn't contain slotrefs, ie, can be evaluated
     // with get_value(NULL). The default implementation returns true if all of
     // the children are constant.
-    virtual bool is_constant() const;
+    virtual bool is_constant();
 
     // Returns true ifi expr support vectorized process
     // The default implementation returns true if all the children was supported
@@ -461,6 +461,11 @@ private:
     /// in ScalarExpeEvaluator for the expression subtree rooted at this ScalarExpr node.
     int _fn_ctx_idx_start = 0;
     int _fn_ctx_idx_end = 0;
+
+    // If "_set_is_constant" is true, it means that "_is_constant" is set before.
+    // This can avoid repeated checks when calling "is_constant()"
+    bool _set_is_constant = false;
+    bool _is_constant = false;
 };
 
 inline bool Expr::evaluate(VectorizedRowBatch* batch) {

--- a/be/src/exprs/expr_context.cpp
+++ b/be/src/exprs/expr_context.cpp
@@ -259,6 +259,9 @@ bool ExprContext::is_nullable() {
 }
 
 void* ExprContext::_get_const_val_directly(const PrimitiveType& type) {
+    if (_result.is_null) {
+        return NULL;
+    }
     switch (type) {
     case TYPE_NULL: {
         return NULL;
@@ -318,11 +321,13 @@ void* ExprContext::get_value(Expr* e, TupleRow* row) {
     _result.is_set = true;
     switch (e->_type.type) {
     case TYPE_NULL: {
+        _result.is_null = true;
         return NULL;
     }
     case TYPE_BOOLEAN: {
         doris_udf::BooleanVal v = e->get_boolean_val(this, row);
         if (v.is_null) {
+            _result.is_null = true;
             return NULL;
         }
         _result.bool_val = v.val;
@@ -331,6 +336,7 @@ void* ExprContext::get_value(Expr* e, TupleRow* row) {
     case TYPE_TINYINT: {
         doris_udf::TinyIntVal v = e->get_tiny_int_val(this, row);
         if (v.is_null) {
+            _result.is_null = true;
             return NULL;
         }
         _result.tinyint_val = v.val;
@@ -339,6 +345,7 @@ void* ExprContext::get_value(Expr* e, TupleRow* row) {
     case TYPE_SMALLINT: {
         doris_udf::SmallIntVal v = e->get_small_int_val(this, row);
         if (v.is_null) {
+            _result.is_null = true;
             return NULL;
         }
         _result.smallint_val = v.val;
@@ -347,6 +354,7 @@ void* ExprContext::get_value(Expr* e, TupleRow* row) {
     case TYPE_INT: {
         doris_udf::IntVal v = e->get_int_val(this, row);
         if (v.is_null) {
+            _result.is_null = true;
             return NULL;
         }
         _result.int_val = v.val;
@@ -355,6 +363,7 @@ void* ExprContext::get_value(Expr* e, TupleRow* row) {
     case TYPE_BIGINT: {
         doris_udf::BigIntVal v = e->get_big_int_val(this, row);
         if (v.is_null) {
+            _result.is_null = true;
             return NULL;
         }
         _result.bigint_val = v.val;
@@ -363,6 +372,7 @@ void* ExprContext::get_value(Expr* e, TupleRow* row) {
     case TYPE_LARGEINT: {
         doris_udf::LargeIntVal v = e->get_large_int_val(this, row);
         if (v.is_null) {
+            _result.is_null = true;
             return NULL;
         }
         _result.large_int_val = v.val;
@@ -371,6 +381,7 @@ void* ExprContext::get_value(Expr* e, TupleRow* row) {
     case TYPE_FLOAT: {
         doris_udf::FloatVal v = e->get_float_val(this, row);
         if (v.is_null) {
+            _result.is_null = true;
             return NULL;
         }
         _result.float_val = v.val;
@@ -380,6 +391,7 @@ void* ExprContext::get_value(Expr* e, TupleRow* row) {
     case TYPE_DOUBLE: {
         doris_udf::DoubleVal v = e->get_double_val(this, row);
         if (v.is_null) {
+            _result.is_null = true;
             return NULL;
         }
         _result.double_val = v.val;
@@ -391,6 +403,7 @@ void* ExprContext::get_value(Expr* e, TupleRow* row) {
     case TYPE_OBJECT: {
         doris_udf::StringVal v = e->get_string_val(this, row);
         if (v.is_null) {
+            _result.is_null = true;
             return nullptr;
         }
         _result.string_val.ptr = reinterpret_cast<char*>(v.ptr);
@@ -401,6 +414,7 @@ void* ExprContext::get_value(Expr* e, TupleRow* row) {
     case TYPE_DATETIME: {
         doris_udf::DateTimeVal v = e->get_datetime_val(this, row);
         if (v.is_null) {
+            _result.is_null = true;
             return NULL;
         }
         _result.datetime_val = DateTimeValue::from_datetime_val(v);
@@ -409,6 +423,7 @@ void* ExprContext::get_value(Expr* e, TupleRow* row) {
     case TYPE_DECIMAL: {
         DecimalVal v = e->get_decimal_val(this, row);
         if (v.is_null) {
+            _result.is_null = true;
             return NULL;
         }
         _result.decimal_val = DecimalValue::from_decimal_val(v);
@@ -417,6 +432,7 @@ void* ExprContext::get_value(Expr* e, TupleRow* row) {
     case TYPE_DECIMALV2: {
         DecimalV2Val v = e->get_decimalv2_val(this, row);
         if (v.is_null) {
+            _result.is_null = true;
             return NULL;
         }
         _result.decimalv2_val = DecimalV2Value::from_decimal_val(v);

--- a/be/src/exprs/expr_context.h
+++ b/be/src/exprs/expr_context.h
@@ -167,6 +167,11 @@ public:
     void clear_error_msg();
 
 private:
+    // This function is used to directly return the calculated value only
+    // after the expression is a constant expression and has been calculated once.
+    void* _get_const_val_directly(const PrimitiveType& type);
+
+private:
     friend class Expr;
     friend class ScalarFnCall;
     friend class InPredicate;

--- a/be/src/exprs/expr_value.h
+++ b/be/src/exprs/expr_value.h
@@ -47,6 +47,10 @@ struct ExprValue {
     DecimalValue decimal_val;
     DecimalV2Value decimalv2_val;
 
+    // Set to true if the value has been set.
+    // This value is meaningful only in constant expressions
+    bool is_set;
+
     ExprValue()
             : bool_val(false),
               tinyint_val(0),
@@ -60,7 +64,8 @@ struct ExprValue {
               string_val(NULL, 0),
               datetime_val(),
               decimal_val(),
-              decimalv2_val() {}
+              decimalv2_val(),
+              is_set(false) {}
 
     ExprValue(bool v) : bool_val(v) {}
     ExprValue(int8_t v) : tinyint_val(v) {}

--- a/be/src/exprs/expr_value.h
+++ b/be/src/exprs/expr_value.h
@@ -50,6 +50,7 @@ struct ExprValue {
     // Set to true if the value has been set.
     // This value is meaningful only in constant expressions
     bool is_set;
+    bool is_null;
 
     ExprValue()
             : bool_val(false),
@@ -65,7 +66,8 @@ struct ExprValue {
               datetime_val(),
               decimal_val(),
               decimalv2_val(),
-              is_set(false) {}
+              is_set(false),
+              is_null(false) {}
 
     ExprValue(bool v) : bool_val(v) {}
     ExprValue(int8_t v) : tinyint_val(v) {}

--- a/be/src/exprs/scalar_fn_call.cpp
+++ b/be/src/exprs/scalar_fn_call.cpp
@@ -225,8 +225,13 @@ void ScalarFnCall::close(RuntimeState* state, ExprContext* context,
     Expr::close(state, context, scope);
 }
 
-bool ScalarFnCall::is_constant() const {
+bool ScalarFnCall::is_constant() {
+    if (_set_is_constant) {
+        return _is_constant;
+    }
     if (_fn.name.function_name == "rand") {
+        _set_is_constant = true;
+        _is_constant = false;
         return false;
     }
     return Expr::is_constant();

--- a/be/src/exprs/scalar_fn_call.h
+++ b/be/src/exprs/scalar_fn_call.h
@@ -64,7 +64,7 @@ protected:
     virtual void close(RuntimeState* state, ExprContext* context,
                        FunctionContext::FunctionStateScope scope);
 
-    virtual bool is_constant() const;
+    virtual bool is_constant();
 
     virtual doris_udf::BooleanVal get_boolean_val(ExprContext* context, TupleRow*);
     virtual doris_udf::TinyIntVal get_tiny_int_val(ExprContext* context, TupleRow*);

--- a/be/src/exprs/slot_ref.h
+++ b/be/src/exprs/slot_ref.h
@@ -50,7 +50,7 @@ public:
     static bool vector_compute_fn(Expr* expr, VectorizedRowBatch* batch);
     static bool is_nullable(Expr* expr);
     virtual std::string debug_string() const;
-    virtual bool is_constant() const { return false; }
+    virtual bool is_constant() { return false; }
     virtual bool is_vectorized() const { return true; }
     virtual bool is_bound(std::vector<TupleId>* tuple_ids) const;
     virtual int get_slot_ids(std::vector<SlotId>* slot_ids) const;

--- a/be/src/exprs/timestamp_functions.cpp
+++ b/be/src/exprs/timestamp_functions.cpp
@@ -512,10 +512,10 @@ DateTimeVal from_olap_datetime(uint64_t datetime) {
 static const DateTimeVal FIRST_DAY = from_olap_datetime(19700101000000);
 static const DateTimeVal FIRST_SUNDAY = from_olap_datetime(19700104000000);
 
-#define TIME_ROUND(UNIT, unit, ORIGIN)                                    \
-    _TR_4(FLOOR, floor, UNIT, unit)                                       \
-    _TR_4(CEIL, ceil, UNIT, unit) _TR_5(FLOOR, floor, UNIT, unit, ORIGIN) \
-            _TR_5(CEIL, ceil, UNIT, unit, ORIGIN)
+#define TIME_ROUND(UNIT, unit, ORIGIN) \
+    _TR_4(FLOOR, floor, UNIT, unit)    \
+    _TR_4(CEIL, ceil, UNIT, unit)      \
+    _TR_5(FLOOR, floor, UNIT, unit, ORIGIN) _TR_5(CEIL, ceil, UNIT, unit, ORIGIN)
 
 TIME_ROUND(YEAR, year, FIRST_DAY)
 TIME_ROUND(MONTH, month, FIRST_DAY)

--- a/be/src/gutil/cpu.cc
+++ b/be/src/gutil/cpu.cc
@@ -133,7 +133,7 @@ std::string* CpuInfoBrand() {
     }();
     return brand;
 }
-#endif  // defined(ARCH_CPU_ARM_FAMILY) && (defined(OS_ANDROID) || defined(OS_LINUX))
+#endif // defined(ARCH_CPU_ARM_FAMILY) && (defined(OS_ANDROID) || defined(OS_LINUX))
 
 } // namespace
 void CPU::Initialize() {

--- a/be/src/gutil/port.h
+++ b/be/src/gutil/port.h
@@ -733,7 +733,7 @@ struct AlignType {
 #define ALIGNED_CHAR_ARRAY(T, Size) AlignType<Size * sizeof(T)>::result
 
 #endif // !SWIG
-#else // __cpluscplus
+#else  // __cpluscplus
 #define ALIGNED_CHAR_ARRAY ALIGNED_CHAR_ARRAY_is_not_available_without_Cplusplus
 #endif // __cplusplus
 
@@ -772,7 +772,7 @@ struct AlignType {
 #undef ERROR
 
 #include <float.h> // for nextafter functionality on windows
-#include <math.h> // for HUGE_VAL
+#include <math.h>  // for HUGE_VAL
 
 #ifndef HUGE_VALF
 #define HUGE_VALF (static_cast<float>(HUGE_VAL))
@@ -1167,7 +1167,7 @@ inline void UnalignedCopy64(const void* src, void* dst) {
 
 #ifdef PTHREADS_REDHAT_WIN32
 #include <iosfwd>
-using std::ostream; // NOLINT(build/include)
+using std::ostream;  // NOLINT(build/include)
 #include <pthread.h> // NOLINT(build/include)
 // pthread_t is not a simple integer or pointer on Win32
 std::ostream& operator<<(std::ostream& out, const pthread_t& thread_id);

--- a/be/src/gutil/walltime.h
+++ b/be/src/gutil/walltime.h
@@ -204,4 +204,4 @@ private:
 
 // inline method bodies
 #include "gutil/cycleclock-inl.h" // IWYU pragma: export
-#endif // GUTIL_WALLTIME_H_
+#endif                            // GUTIL_WALLTIME_H_

--- a/be/src/runtime/decimal_value.cpp
+++ b/be/src/runtime/decimal_value.cpp
@@ -119,9 +119,10 @@ int32_t do_add(const DecimalValue& value1, const DecimalValue& value2, DecimalVa
     int32_t intg0 = std::max(intg1, intg2);
 
     // Is there a need for extra word because of carry?
-    int32_t first_big_digit_sum = intg1 > intg2   ? value1._buffer[0]
-                                  : intg2 > intg1 ? value2._buffer[0]
-                                                  : value1._buffer[0] + value2._buffer[0];
+    int32_t first_big_digit_sum =
+            intg1 > intg2
+                    ? value1._buffer[0]
+                    : intg2 > intg1 ? value2._buffer[0] : value1._buffer[0] + value2._buffer[0];
     if (first_big_digit_sum > DIG_MAX - 1) {
         // yes, there is
         ++intg0;

--- a/be/src/util/mysql_global.h
+++ b/be/src/util/mysql_global.h
@@ -37,12 +37,12 @@ typedef unsigned char uchar;
 #define MY_ALIGN(A, L) (((A) + (L)-1) & ~((L)-1))
 #define SIZEOF_CHARP 8
 
-#define MAX_TINYINT_WIDTH 3 /* Max width for a TINY w.o. sign */
-#define MAX_SMALLINT_WIDTH 5 /* Max width for a SHORT w.o. sign */
-#define MAX_MEDIUMINT_WIDTH 8 /* Max width for a INT24 w.o. sign */
-#define MAX_INT_WIDTH 10 /* Max width for a LONG w.o. sign */
-#define MAX_BIGINT_WIDTH 20 /* Max width for a LONGLONG */
-#define MAX_CHAR_WIDTH 255 /* Max length for a CHAR column */
+#define MAX_TINYINT_WIDTH 3     /* Max width for a TINY w.o. sign */
+#define MAX_SMALLINT_WIDTH 5    /* Max width for a SHORT w.o. sign */
+#define MAX_MEDIUMINT_WIDTH 8   /* Max width for a INT24 w.o. sign */
+#define MAX_INT_WIDTH 10        /* Max width for a LONG w.o. sign */
+#define MAX_BIGINT_WIDTH 20     /* Max width for a LONGLONG */
+#define MAX_CHAR_WIDTH 255      /* Max length for a CHAR column */
 #define MAX_BLOB_WIDTH 16777216 /* Default width for blob */
 
 #define MAX_DECPT_FOR_F_FORMAT DBL_DIG

--- a/build-support/check-format.sh
+++ b/build-support/check-format.sh
@@ -28,6 +28,8 @@ ROOT=`cd "$ROOT"; pwd`
 
 export DORIS_HOME=`cd "${ROOT}/.."; pwd`
 
+. ${DORIS_HOME}/env.sh
+
 CLANG_FORMAT=${CLANG_FORMAT_BINARY:=$(which clang-format)}
 
 python3 ${DORIS_HOME}/build-support/run_clang_format.py --clang_format_binary="${CLANG_FORMAT}" --source_dirs="${DORIS_HOME}/be/src,${DORIS_HOME}/be/test" --quiet

--- a/build-support/clang-format.sh
+++ b/build-support/clang-format.sh
@@ -28,6 +28,8 @@ ROOT=`cd "$ROOT"; pwd`
 
 export DORIS_HOME=`cd "${ROOT}/.."; pwd`
 
+. ${DORIS_HOME}/env.sh
+
 CLANG_FORMAT=${CLANG_FORMAT_BINARY:=$(which clang-format)}
 
 python3 ${DORIS_HOME}/build-support/run_clang_format.py --clang_format_binary="${CLANG_FORMAT}" --fix --source_dirs="${DORIS_HOME}/be/src","${DORIS_HOME}/be/test"

--- a/docs/en/developer-guide/format-code.md
+++ b/docs/en/developer-guide/format-code.md
@@ -49,7 +49,12 @@ Centos 7:
 The version of clang-format installed by yum is too old. Compiling clang from source
 is recommended.
 
+You can also install clang-format using the following npm command:
+
+`npm install -g clang-format`
+
 ### Clang-format plugins
+
 Clion IDE supports the plugin "ClangFormat", you can search in `File->Setting->Plugins`
  and download it.
 But the version is not match with clang-format. Judging from the options supported, 
@@ -58,6 +63,7 @@ the version is lower than clang-format-9.0.
 ## Usage
 
 ### CMD
+
 Change directory to the root directory of Doris sources and run the following command:
 `build-support/clang-format.sh`
 
@@ -65,10 +71,12 @@ NOTE: Python3 is required to run the `clang-format.sh` script.
 
 ### Using clang-format in IDEs or Editors
 #### Clion
+
 If using the plugin 'ClangFormat' in Clion, choose `Reformat Code` or press the keyboard 
 shortcut.
 
 #### VS Code
+
 VS Code needs install the extension 'Clang-Format', and specify the executable path of 
 clang-format in settings.
 

--- a/docs/en/installing/compilation.md
+++ b/docs/en/installing/compilation.md
@@ -35,7 +35,7 @@ This document focuses on how to code Doris through source code.
 
 1. Download Docker Mirror
 
-	`$ docker pull apachedoris/doris-dev:build-env`
+	`$ docker pull apachedoris/doris-dev:build-env-1.2`
 
 	Check mirror download completed:
 
@@ -51,6 +51,7 @@ Note: For different versions of Oris, you need to download the corresponding mir
 |---|---|---|
 | apachedoris/doris-dev:build-env | before [ff0dd0d](https://github.com/apache/incubator-doris/commit/ff0dd0d2daa588f18b6db56f947e813a56d8ec81) | 0.8.x, 0.9.x |
 | apachedoris/doris-dev:build-env-1.1 | [ff0dd0d](https://github.com/apache/incubator-doris/commit/ff0dd0d2daa588f18b6db56f947e813a56d8ec81) or later | 0.10.x or later |
+| apachedoris/doris-dev:build-env-1.2 | [4ef5a8c](https://github.com/apache/incubator-doris/commit/4ef5a8c8560351d7fff7ff8fd51c4c7a75e006a8) or later | 0.12.x or later
 
 2. Running Mirror
 

--- a/docs/zh-CN/developer-guide/format-code.md
+++ b/docs/zh-CN/developer-guide/format-code.md
@@ -46,7 +46,12 @@ Centos 7:
 
 centos yum安装的clang-format版本过老，支持的StyleOption太少，建议源码编译10.0版本。
 
+也可以使用以下 npm 命令安装 clang-format：
+
+`npm install -g clang-format`
+
 ### clang-format插件
+
 Clion IDE可使用插件"ClangFormat"，`File->Setting->Plugins`搜索下载。但版本无法和
 clang-format程序的版本匹配，从支持的StyleOption上看，应该是低于clang-format-9.0。
 

--- a/docs/zh-CN/installing/compilation.md
+++ b/docs/zh-CN/installing/compilation.md
@@ -34,7 +34,7 @@ under the License.
 
 1. 下载 Docker 镜像
 
-    `$ docker pull apachedoris/doris-dev:build-env`
+    `$ docker pull apachedoris/doris-dev:build-env-1.2`
     
     检查镜像下载完成：
     


### PR DESCRIPTION
## Proposed changes

At present, some constant expressions cannot be folded on the FE side,
and these expressions may be executed multiple times on the BE side.
The main modification of this CL is to avoid constant expressions being calculated
multiple times on the BE side.