### PR TITLE
[Docs]adding instructions for converting dynamic and manual partition tables to each other

### DIFF
--- a/docs/en/administrator-guide/dynamic-partition.md
+++ b/docs/en/administrator-guide/dynamic-partition.md
@@ -332,10 +332,12 @@ For a table, dynamic and manual partitioning can be freely converted, but they c
 
 If a table is not dynamically partitioned when it is created, it can be converted to dynamic partitioning at runtime by modifying the dynamic partitioning properties with `ALTER TABLE`, an example of which can be seen with `HELP ALTER TABLE`.
 
-**Note**: If `dynamic_partition.start` is set, historical partitions that are partitioned before the start offset of the dynamic partition will be deleted.
+When dynamic partitioning feature is enabled, Doris will no longer allow users to manage partitions manually, but will automatically manage partitions based on dynamic partition properties.
+
+**NOTICE**: If ``dynamic_partition.start` is set, historical partitions with a partition range before the start offset of the dynamic partition will be deleted.
 
 #### Converting Dynamic Partitioning to Manual Partitioning
 
-You can turn off dynamic partitioning and convert it to a manual partition table by executing `ALTER TABLE tbl_name SET ("dynamic_partition.enable" = "false") `.
+The dynamic partitioning feature can be disabled by executing `ALTER TABLE tbl_name SET ("dynamic_partition.enable" = "false") ` and converting it to a manual partition table.
 
-When dynamic partitioning is turned on, Doris no longer allows manual modification of partitions. If you need to modify a partition manually, you need to convert the table to a manual partition table before you can operate on its partition.
+When dynamic partitioning feature is turned off, Doris will no longer manage partitions automatically, and users will have to create or delete partitions manually by using `ALTER TABLE`.

--- a/docs/en/administrator-guide/dynamic-partition.md
+++ b/docs/en/administrator-guide/dynamic-partition.md
@@ -334,10 +334,10 @@ If a table is not dynamically partitioned when it is created, it can be converte
 
 When dynamic partitioning feature is enabled, Doris will no longer allow users to manage partitions manually, but will automatically manage partitions based on dynamic partition properties.
 
-**NOTICE**: If ``dynamic_partition.start` is set, historical partitions with a partition range before the start offset of the dynamic partition will be deleted.
+**NOTICE**: If `dynamic_partition.start` is set, historical partitions with a partition range before the start offset of the dynamic partition will be deleted.
 
 #### Converting Dynamic Partitioning to Manual Partitioning
 
 The dynamic partitioning feature can be disabled by executing `ALTER TABLE tbl_name SET ("dynamic_partition.enable" = "false") ` and converting it to a manual partition table.
 
-When dynamic partitioning feature is turned off, Doris will no longer manage partitions automatically, and users will have to create or delete partitions manually by using `ALTER TABLE`.
+When dynamic partitioning feature is disabled, Doris will no longer manage partitions automatically, and users will have to create or delete partitions manually by using `ALTER TABLE`.

--- a/docs/en/administrator-guide/dynamic-partition.md
+++ b/docs/en/administrator-guide/dynamic-partition.md
@@ -324,3 +324,10 @@ mysql> SHOW DYNAMIC PARTITION TABLES;
     
     `curl --location-trusted -u username:password -XGET http://fe_host:fe_http_port/api/_set_config?dynamic_partition_check_interval_seconds=432000`
     
+### Manually Modify Partitions
+
+When dynamic partition feature is enabled, Doris no longer allows manual modification of partitions.
+
+If you want to modify partitions manually when dynamic partition feature is already enabled, you need to set `dynamic_partition_enable` to `false` first, and then perform `add/drop` partitioning. After the operation is finished, set `dynamic_partition_enable` to `true` to start dynamic partition feature again.
+
+**Note**: Manually added partitions will also be deleted if they hit dynamic partition's delete history rule.

--- a/docs/en/administrator-guide/dynamic-partition.md
+++ b/docs/en/administrator-guide/dynamic-partition.md
@@ -324,10 +324,18 @@ mysql> SHOW DYNAMIC PARTITION TABLES;
     
     `curl --location-trusted -u username:password -XGET http://fe_host:fe_http_port/api/_set_config?dynamic_partition_check_interval_seconds=432000`
     
-### Manually Modify Partitions
+### Converting dynamic and manual partition tables to each other
 
-When dynamic partition feature is enabled, Doris no longer allows manual modification of partitions.
+For a table, dynamic and manual partitioning can be freely converted, but they cannot exist at the same time, there is and only one state.
 
-If you want to modify partitions manually when dynamic partition feature is already enabled, you need to set `dynamic_partition_enable` to `false` first, and then perform `add/drop` partitioning. After the operation is finished, set `dynamic_partition_enable` to `true` to start dynamic partition feature again.
+#### Converting Manual Partitioning to Dynamic Partitioning
 
-**Note**: Manually added partitions will also be deleted if they hit dynamic partition's delete history rule.
+If a table is not dynamically partitioned when it is created, it can be converted to dynamic partitioning at runtime by modifying the dynamic partitioning properties with `ALTER TABLE`, an example of which can be seen with `HELP ALTER TABLE`.
+
+**Note**: If `dynamic_partition.start` is set, historical partitions that are partitioned before the start offset of the dynamic partition will be deleted.
+
+#### Converting Dynamic Partitioning to Manual Partitioning
+
+You can turn off dynamic partitioning and convert it to a manual partition table by executing `ALTER TABLE tbl_name SET ("dynamic_partition.enable" = "false") `.
+
+When dynamic partitioning is turned on, Doris no longer allows manual modification of partitions. If you need to modify a partition manually, you need to convert the table to a manual partition table before you can operate on its partition.

--- a/docs/zh-CN/administrator-guide/dynamic-partition.md
+++ b/docs/zh-CN/administrator-guide/dynamic-partition.md
@@ -322,10 +322,19 @@ mysql> SHOW DYNAMIC PARTITION TABLES;
     
     `curl --location-trusted -u username:password -XGET http://fe_host:fe_http_port/api/_set_config?dynamic_partition_check_interval_seconds=432000`
 
-### 手动修改分区
+### 动态分区表与手动分区表相互转换
 
-在开启动态分区功能后，Doris 不再允许手动修改分区。
+对于一个表来说，动态分区和手动分区可以自由转换，但二者不能同时存在，有且只有一种状态。
 
-已经开通动态分区的情况下，如果想手动修改分区，需要先将 `dynamic_partition_enable` 置为 `false`，然后在执行 `add/drop` 分区操作。操作完成后，将 `dynamic_partition_enable` 置为 `true` 即可又开启动态分区功能。
+#### 手动分区转换为动态分区
 
-**注意**：手动添加的分区如果命中动态分区的删除历史分区规则，也会被删除。
+如果一个表在创建时未指定动态分区，可以通过 `ALTER TABLE` 在运行时修改动态分区相关属性来转化为动态分区，具体示例可以通过 `HELP ALTER TABLE` 查看。
+
+**注意**：如果已设定 `dynamic_partition.start`，分区范围在动态分区起始偏移之前的历史分区将会被删除。
+
+#### 动态分区转换为手动分区
+
+通过执行 `ALTER TABLE tbl_name SET ("dynamic_partition.enable" = "false")` 即可关闭动态分区功能，将其转换为手动分区表。
+
+开启动态分区功能后，Doris 不再允许手动修改分区。如果需要手动修改分区，需先将表转换为手动分区表，然后再对其分区进行操作。
+

--- a/docs/zh-CN/administrator-guide/dynamic-partition.md
+++ b/docs/zh-CN/administrator-guide/dynamic-partition.md
@@ -321,3 +321,11 @@ mysql> SHOW DYNAMIC PARTITION TABLES;
     HTTP 协议：
     
     `curl --location-trusted -u username:password -XGET http://fe_host:fe_http_port/api/_set_config?dynamic_partition_check_interval_seconds=432000`
+
+### 手动修改分区
+
+在开启动态分区功能后，Doris 不再允许手动修改分区。
+
+已经开通动态分区的情况下，如果想手动修改分区，需要先将 `dynamic_partition_enable` 置为 `false`，然后在执行 `add/drop` 分区操作。操作完成后，将 `dynamic_partition_enable` 置为 `true` 即可又开启动态分区功能。
+
+**注意**：手动添加的分区如果命中动态分区的删除历史分区规则，也会被删除。

--- a/docs/zh-CN/administrator-guide/dynamic-partition.md
+++ b/docs/zh-CN/administrator-guide/dynamic-partition.md
@@ -330,11 +330,12 @@ mysql> SHOW DYNAMIC PARTITION TABLES;
 
 如果一个表在创建时未指定动态分区，可以通过 `ALTER TABLE` 在运行时修改动态分区相关属性来转化为动态分区，具体示例可以通过 `HELP ALTER TABLE` 查看。
 
+开启动态分区功能后，Doris 将不再允许用户手动管理分区，会根据动态分区属性来自动管理分区。
+
 **注意**：如果已设定 `dynamic_partition.start`，分区范围在动态分区起始偏移之前的历史分区将会被删除。
 
 #### 动态分区转换为手动分区
 
 通过执行 `ALTER TABLE tbl_name SET ("dynamic_partition.enable" = "false")` 即可关闭动态分区功能，将其转换为手动分区表。
 
-开启动态分区功能后，Doris 不再允许手动修改分区。如果需要手动修改分区，需先将表转换为手动分区表，然后再对其分区进行操作。
-
+关闭动态分区功能后，Doris 将不再自动管理分区，需要用户手动通过 `ALTER TABLE` 的方式创建或删除分区。


### PR DESCRIPTION
## Proposed changes

There is no clear instruction to mannully modify partitions, when dynamic partition feature is enabled. 

The user will be informed only after trying to modify the partition in the command line.

This PR adds  instructions for converting dynamic and manual partition tables to each other

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [] Bugfix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)
- [] Code refactor (Modify the code structure, format the code, etc...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [] I have create an issue on (Fix #ISSUE), and have described the bug/feature there in detail
- [] Compiling and unit tests pass locally with my changes
- [] I have added tests that prove my fix is effective or that my feature works
- [x] If this change need a document change, I have updated the document
- [] Any dependent changes have been merged

## Further comments

If this is a relatively large or complex change, kick off the discussion at dev@doris.apache.org by explaining why you chose the solution you did and what alternatives you considered, etc...
