### PR TITLE
[Optimize] Take 'deleted rows' into consideration when selecting a tablet for compaction task

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -334,8 +334,9 @@ CONF_mInt32(cumulative_compaction_trace_threshold, "2");
 // time interval to record tablet scan count in second for the purpose of calculating tablet scan frequency
 CONF_mInt64(tablet_scan_frequency_time_node_interval_second, "300");
 // coefficient for tablet scan frequency and compaction score when finding a tablet for compaction
-CONF_mInt32(compaction_tablet_scan_frequency_factor, "0");
-CONF_mInt32(compaction_tablet_compaction_score_factor, "1");
+CONF_mDouble(compaction_tablet_scan_frequency_factor, "0.0");
+CONF_mDouble(compaction_tablet_compaction_score_factor, "1.0");
+CONF_mDouble(compaction_tablet_del_rows_factor, "0.0");
 
 // Port to start debug webserver on
 CONF_Int32(webserver_port, "8040");

--- a/be/src/exec/olap_scanner.cpp
+++ b/be/src/exec/olap_scanner.cpp
@@ -508,6 +508,7 @@ void OlapScanner::update_counter() {
     _tablet->query_scan_bytes->increment(_compressed_bytes_read);
     _tablet->query_scan_rows->increment(_raw_rows_read);
     _tablet->query_scan_count->increment(1);
+    _tablet->query_del_rows->increment(_reader->stats().rows_del_filtered);
 
     _has_update_counter = true;
 }

--- a/be/src/olap/base_tablet.cpp
+++ b/be/src/olap/base_tablet.cpp
@@ -27,6 +27,7 @@ namespace doris {
 extern MetricPrototype METRIC_query_scan_bytes;
 extern MetricPrototype METRIC_query_scan_rows;
 extern MetricPrototype METRIC_query_scan_count;
+extern MetricPrototype METRIC_query_del_rows;
 
 BaseTablet::BaseTablet(TabletMetaSharedPtr tablet_meta, DataDir* data_dir)
         : _state(tablet_meta->tablet_state()),
@@ -46,6 +47,7 @@ BaseTablet::BaseTablet(TabletMetaSharedPtr tablet_meta, DataDir* data_dir)
     INT_COUNTER_METRIC_REGISTER(_metric_entity, query_scan_bytes);
     INT_COUNTER_METRIC_REGISTER(_metric_entity, query_scan_rows);
     INT_COUNTER_METRIC_REGISTER(_metric_entity, query_scan_count);
+    INT_GAUGE_METRIC_REGISTER(_metric_entity, query_del_rows);
 }
 
 BaseTablet::~BaseTablet() {

--- a/be/src/olap/base_tablet.h
+++ b/be/src/olap/base_tablet.h
@@ -84,6 +84,7 @@ public:
     IntCounter* query_scan_bytes;
     IntCounter* query_scan_rows;
     IntCounter* query_scan_count;
+    IntGauge* query_del_rows;
 
 private:
     DISALLOW_COPY_AND_ASSIGN(BaseTablet);

--- a/be/src/olap/compaction.cpp
+++ b/be/src/olap/compaction.cpp
@@ -129,6 +129,7 @@ OLAPStatus Compaction::do_compaction_impl(int64_t permits) {
         _tablet->set_last_cumu_compaction_success_time(now);
     } else {
         _tablet->set_last_base_compaction_success_time(now);
+        _tablet->query_del_rows->set_value(0);
     }
 
     LOG(INFO) << "succeed to do " << compaction_name() << ". tablet=" << _tablet->full_name()

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -1434,4 +1434,17 @@ void Tablet::reset_compaction(CompactionType compaction_type) {
     }
 }
 
-}  // namespace doris
+double Tablet::calculate_tablet_score_for_compaction(uint32_t compaction_score) {
+    double scan_frequency = 0.0;
+    if (config::compaction_tablet_scan_frequency_factor != 0) {
+        scan_frequency = calculate_scan_frequency();
+    }
+    double tablet_score =
+            config::compaction_tablet_scan_frequency_factor * scan_frequency +
+            config::compaction_tablet_compaction_score_factor * compaction_score +
+            config::compaction_tablet_del_rows_factor * query_del_rows->value();
+    return tablet_score;
+}
+
+} // namespace doris
+

--- a/be/src/olap/tablet.h
+++ b/be/src/olap/tablet.h
@@ -243,6 +243,7 @@ public:
     void get_compaction_status(std::string* json_result);
 
     double calculate_scan_frequency();
+    double calculate_tablet_score_for_compaction(uint32_t compaction_score);
 
     int64_t prepare_compaction_and_calculate_permits(CompactionType compaction_type, TabletSharedPtr tablet);
     void execute_compaction(CompactionType compaction_type);

--- a/be/src/olap/tablet_manager.cpp
+++ b/be/src/olap/tablet_manager.cpp
@@ -676,7 +676,6 @@ TabletSharedPtr TabletManager::find_best_tablet_to_compaction(
             compaction_type == CompactionType::BASE_COMPACTION ? "base" : "cumulative";
     double highest_score = 0.0;
     uint32_t compaction_score = 0;
-    double tablet_scan_frequency = 0.0;
     TabletSharedPtr best_tablet;
     for (const auto& tablets_shard : _tablets_shards) {
         ReadLock rlock(tablets_shard.lock.get());
@@ -736,22 +735,11 @@ TabletSharedPtr TabletManager::find_best_tablet_to_compaction(
                     }
                 }
 
-                uint32_t current_compaction_score =
-                        tablet_ptr->calc_compaction_score(compaction_type);
-
-                double scan_frequency = 0.0;
-                if (config::compaction_tablet_scan_frequency_factor != 0) {
-                    scan_frequency = tablet_ptr->calculate_scan_frequency();
-                }
-
-                double tablet_score =
-                        config::compaction_tablet_scan_frequency_factor * scan_frequency +
-                        config::compaction_tablet_compaction_score_factor *
-                                current_compaction_score;
+                uint32_t current_compaction_score = tablet_ptr->calc_compaction_score(compaction_type);
+                double tablet_score = tablet_ptr->calculate_tablet_score_for_compaction(current_compaction_score);
                 if (tablet_score > highest_score) {
                     highest_score = tablet_score;
                     compaction_score = current_compaction_score;
-                    tablet_scan_frequency = scan_frequency;
                     best_tablet = tablet_ptr;
                 }
             }
@@ -762,8 +750,6 @@ TabletSharedPtr TabletManager::find_best_tablet_to_compaction(
         VLOG(1) << "Found the best tablet for compaction. "
                 << "compaction_type=" << compaction_type_str
                 << ", tablet_id=" << best_tablet->tablet_id() << ", path=" << data_dir->path()
-                << ", compaction_score=" << compaction_score
-                << ", tablet_scan_frequency=" << tablet_scan_frequency
                 << ", highest_score=" << highest_score;
         // TODO(lingbin): Remove 'max' from metric name, it would be misunderstood as the
         // biggest in history(like peak), but it is really just the value at current moment.

--- a/be/src/util/doris_metrics.cpp
+++ b/be/src/util/doris_metrics.cpp
@@ -35,6 +35,7 @@ DEFINE_COUNTER_METRIC_PROTOTYPE_2ARG(http_request_send_bytes, MetricUnit::BYTES)
 DEFINE_COUNTER_METRIC_PROTOTYPE_2ARG(query_scan_bytes, MetricUnit::BYTES);
 DEFINE_COUNTER_METRIC_PROTOTYPE_2ARG(query_scan_rows, MetricUnit::ROWS);
 DEFINE_COUNTER_METRIC_PROTOTYPE_2ARG(query_scan_count, MetricUnit::NOUNIT);
+DEFINE_GAUGE_METRIC_PROTOTYPE_2ARG(query_del_rows, MetricUnit::ROWS);
 DEFINE_COUNTER_METRIC_PROTOTYPE_5ARG(push_requests_success_total, MetricUnit::REQUESTS, "",
                                      push_requests_total, Labels({{"status", "SUCCESS"}}));
 DEFINE_COUNTER_METRIC_PROTOTYPE_5ARG(push_requests_fail_total, MetricUnit::REQUESTS, "",

--- a/docs/en/administrator-guide/config/be_config.md
+++ b/docs/en/administrator-guide/config/be_config.md
@@ -218,20 +218,26 @@ This value is usually delivered by the FE to the BE by the heartbeat, no need to
 
 ### `compaction_tablet_compaction_score_factor`
 
-* Type: int32
+* Type: double
 * Description: Coefficient for compaction score when calculating tablet score to find a tablet for compaction.
-* Default value: 1
+* Default value: 1.0
+
+### `compaction_tablet_del_rows_factor`
+
+* Type: double
+* Description: Coefficient for query_del_rows when calculating tablet score to find a tablet for compaction.
+* Default value: 0.0
 
 ### `compaction_tablet_scan_frequency_factor`
 
-* Type: int32
+* Type: double
 * Description: Coefficient for tablet scan frequency when calculating tablet score to find a tablet for compaction.
-* Default value: 0
+* Default value: 0.0
 
-Tablet scan frequency can be taken into consideration when selecting an tablet for compaction and preferentially do compaction for those tablets which are scanned frequently during a latest period of time at the present.
+Tablet scan frequency and the filtered rows during scan operation can be taken into consideration when selecting an tablet for compaction and preferentially do compaction for those tablets which contain a lot of deleted rows and are scanned frequently during a latest period of time at the present.
 Tablet score can be calculated like this:
 
-tablet_score = compaction_tablet_scan_frequency_factor * tablet_scan_frequency + compaction_tablet_scan_frequency_factor * compaction_score
+tablet_score = compaction_tablet_scan_frequency_factor * tablet_scan_frequency + compaction_tablet_scan_frequency_factor * compaction_score + compaction_tablet_del_rows_factor * query_del_rows
 
 ### `compaction_task_num_per_disk`
 

--- a/docs/zh-CN/administrator-guide/config/be_config.md
+++ b/docs/zh-CN/administrator-guide/config/be_config.md
@@ -213,20 +213,26 @@ BE缓存池最大的内存可用量，buffer pool是BE新的内存管理结构�
 
 ### `compaction_tablet_compaction_score_factor`
 
-* 类型：int32
+* 类型：double
 * 描述：选择tablet进行compaction时，计算 tablet score 的公式中 compaction score的权重。
-* 默认值：1
+* 默认值：1.0
+
+### `compaction_tablet_del_rows_factor`
+
+* 类型：double
+* 描述：选择tablet进行compaction时，计算 tablet score 的公式中 query_del_rows的权重。
+* 默认值：0.0
 
 ### `compaction_tablet_scan_frequency_factor`
 
-* 类型：int32
+* 类型：double
 * 描述：选择tablet进行compaction时，计算 tablet score 的公式中 tablet scan frequency 的权重。
-* 默认值：0
+* 默认值：0.0
 
-选择一个tablet执行compaction任务时，可以将tablet的scan频率作为一个选择依据，对当前最近一段时间频繁scan的tablet优先执行compaction。
+选择一个tablet执行compaction任务时，可以将tablet的scan频率以及scan过程中因为delete操作而过滤的行数作为一个选择依据，对当前最近一段时间频繁scan的tablet以及scan过程中因为delete操作而过滤行数较多的tablet优先执行compaction。
 tablet score可以通过以下公式计算：
 
-tablet_score = compaction_tablet_scan_frequency_factor * tablet_scan_frequency + compaction_tablet_scan_frequency_factor * compaction_score
+tablet_score = compaction_tablet_scan_frequency_factor * tablet_scan_frequency + compaction_tablet_scan_frequency_factor * compaction_score + compaction_tablet_del_rows_factor * query_del_rows
 
 ### `compaction_task_num_per_disk`
 


### PR DESCRIPTION
## Proposed changes

The rows deleted by `delete operation` will not be deleted from the disk untill base compaction for the relevant tablet is performed. The data deleted logically not only occupies disk space, but also has an effects on scan performance. So it is necessary to perform compaction task for the tablet that contains a lot of deleted rows. 

For a tablet, we can record the filtered rows during scan operation since last base compaction, and take the filtered rows as a consideration factor when selecting a tablet for compaction task.

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] Documentation Update (if none of the other choices apply)
- [x] Code refactor (Modify the code structure, format the code, etc...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have create an issue on (Fix #4997), and have described the bug/feature there in detail
- [x] Compiling and unit tests pass locally with my changes
- [] I have added tests that prove my fix is effective or that my feature works
- [x] If this change need a document change, I have updated the document
- [x] Any dependent changes have been merged
