### PR TITLE
[Performance Optimization] Remove push down conjuncts in olap scan node

### DIFF
--- a/be/src/exec/olap_scan_node.h
+++ b/be/src/exec/olap_scan_node.h
@@ -133,7 +133,14 @@ protected:
         VLOG(1) << s.str() << "\n]";
     }
 
+    // In order to ensure the accuracy of the query result
+    // only key column conjuncts will be remove as idle conjunct
+    bool is_key_column(const std::string& key_name);
+    void remove_pushed_conjuncts(RuntimeState *state);
+
     Status start_scan(RuntimeState* state);
+
+    void eval_const_conjuncts();
     Status normalize_conjuncts();
     Status build_olap_filters();
     Status build_scan_key();
@@ -178,6 +185,9 @@ private:
     int _tuple_idx;
     // string slots
     std::vector<SlotDescriptor*> _string_slots;
+    // conjunct's index which already be push down storage engine
+    // should be remove in olap_scan_node, no need check this conjunct again
+    std::set<uint32_t> _pushed_conjuncts_index;
 
     bool _eos;
 

--- a/be/src/exec/olap_utils.h
+++ b/be/src/exec/olap_utils.h
@@ -190,9 +190,9 @@ inline int get_olap_size(PrimitiveType type) {
 inline SQLFilterOp to_olap_filter_type(TExprOpcode::type type, bool opposite) {
     switch (type) {
     case TExprOpcode::LT:
+        return opposite ? FILTER_LARGER : FILTER_LESS;
+
     case TExprOpcode::LE:
-        // NOTE: Datetime may be truncated to a date column, so we convert LT to LE
-        //  for example: '2010-01-01 00:00:01' will be truncate to '2010-01-01'
         return opposite ? FILTER_LARGER_OR_EQUAL : FILTER_LESS_OR_EQUAL;
 
     case TExprOpcode::GT:

--- a/be/src/runtime/datetime_value.h
+++ b/be/src/runtime/datetime_value.h
@@ -273,6 +273,12 @@ public:
     int minute() const { return _minute; }
     int second() const { return _second; }
 
+    bool check_loss_accuracy_cast_to_date() {
+        auto loss_accuracy = _hour != 0 || _minute != 0 || _second != 0 || _microsecond != 0;
+        cast_to_date();
+        return loss_accuracy;
+    }
+    
     void cast_to_date() {
         _hour = 0;
         _minute = 0;

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/OlapScanNode.java
@@ -630,6 +630,7 @@ public class OlapScanNode extends ScanNode {
         if (null != sortColumn) {
             msg.olap_scan_node.setSortColumn(sortColumn);
         }
+	msg.olap_scan_node.setKeyType(olapTable.getKeysType().toThrift());
     }
 
     // export some tablets

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -314,7 +314,9 @@ struct TOlapScanNode {
   3: required list<Types.TPrimitiveType> key_column_type
   4: required bool is_preaggregation
   5: optional string sort_column
+  6: optional Types.TKeysType keyType
 }
+
 struct TEqJoinCondition {
   // left-hand side of "<a> = <b>"
   1: required Exprs.TExpr left;


### PR DESCRIPTION
## Proposed changes

Push conjunct to Storage Engine as more as possible

olap scan node do not need filter data use push down conjuncts again.

fix #4986 

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] Documentation Update (if none of the other choices apply)
- [] Code refactor (Modify the code structure, format the code, etc...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have create an issue on (Fix #ISSUE), and have described the bug/feature there in detail
- [x] Compiling and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] If this change need a document change, I have updated the document
- [x] Any dependent changes have been merged

