### PR TITLE
[Function] Let "str_to_date" return correct type 

### DIFF
--- a/be/src/udf/udf_internal.h
+++ b/be/src/udf/udf_internal.h
@@ -102,6 +102,8 @@ public:
 
     std::string& string_result() { return _string_result; }
 
+    const doris_udf::FunctionContext::TypeDesc& get_return_type() const { return _return_type; } 
+
 private:
     friend class doris_udf::FunctionContext;
     friend class ExprContext;

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/DateLiteral.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/DateLiteral.java
@@ -498,12 +498,16 @@ public class DateLiteral extends LiteralExpr {
                 dateTime.getHourOfDay(),
                 dateTime.getMinuteOfHour(),
                 dateTime.getSecondOfMinute());
-        if(HAS_TIME_PART.matcher(pattern).matches()) {
+        if (HAS_TIME_PART.matcher(pattern).matches()) {
             dateLiteral.setType(Type.DATETIME);
         } else {
             dateLiteral.setType(Type.DATE);
         }
         return dateLiteral;
+    }
+
+    public static boolean hasTimePart(String format) {
+        return HAS_TIME_PART.matcher(format).matches();
     }
 
     //Return the date stored in the dateliteral as pattern format.

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/FunctionCallExpr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/FunctionCallExpr.java
@@ -647,10 +647,35 @@ public class FunctionCallExpr extends Expr {
             }
         }
 
+        /**
+         * The return type of str_to_date depends on whether the time part is included in the format.
+         * If included, it is datetime, otherwise it is date.
+         * If the format parameter is not constant, the return type will be datetime.
+         * The above judgment has been completed in the FE query planning stage,
+         * so here we directly set the value type to the return type set in the query plan.
+         *
+         * For example:
+         * A table with one column k1 varchar, and has 2 lines:
+         *     "%Y-%m-%d"
+         *     "%Y-%m-%d %H:%i:%s"
+         * Query:
+         *     SELECT str_to_date("2020-09-01", k1) from tbl;
+         * Result will be:
+         *     2020-09-01 00:00:00
+         *     2020-09-01 00:00:00
+         *
+         * Query:
+         *      SELECT str_to_date("2020-09-01", "%Y-%m-%d");
+         * Return type is DATE
+         *
+         * Query:
+         *      SELECT str_to_date("2020-09-01", "%Y-%m-%d %H:%i:%s");
+         * Return type is DATETIME
+         */
         if (fn.getFunctionName().getFunction().equals("str_to_date")) {
-            Expr child1 = getChild(1);
-            if (child1 instanceof StringLiteral) {
-                if (DateLiteral.hasTimePart(((StringLiteral)child1).getStringValue())) {
+            Expr child1Result = getChild(1).getResultValue();
+            if (child1Result instanceof StringLiteral) {
+                if (DateLiteral.hasTimePart(((StringLiteral) child1Result).getStringValue())) {
                     this.type = Type.DATETIME;
                 } else {
                     this.type = Type.DATE;
@@ -748,3 +773,4 @@ public class FunctionCallExpr extends Expr {
         return result;
     }
 }
+

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/FunctionCallExpr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/FunctionCallExpr.java
@@ -646,7 +646,21 @@ public class FunctionCallExpr extends Expr {
                 }
             }
         }
-        this.type = fn.getReturnType();
+
+        if (fn.getFunctionName().getFunction().equals("str_to_date")) {
+            Expr child1 = getChild(1);
+            if (child1 instanceof StringLiteral) {
+                if (DateLiteral.hasTimePart(((StringLiteral)child1).getStringValue())) {
+                    this.type = Type.DATETIME;
+                } else {
+                    this.type = Type.DATE;
+                }
+            } else {
+                this.type = Type.DATETIME;
+            }
+        } else {
+            this.type = fn.getReturnType();
+        }
     }
 
     @Override


### PR DESCRIPTION
## Proposed changes

The return type of str_to_date depends on whether the time part is included in the format.
If included, it is DATETIME, otherwise it is DATE.
If the format parameter is not constant, the return type will be DATETIME.
The above judgment has been completed in the FE query planning stage,
so here we directly set the value type to the return type set in the query plan.

For example:
A table with one column k1 varchar, and has 2 lines:
    "%Y-%m-%d"
    "%Y-%m-%d %H:%i:%s"
Query:
    SELECT str_to_date("2020-09-01", k1) from tbl;
Result will be:
    2020-09-01 00:00:00
    2020-09-01 00:00:00

Query:
     SELECT str_to_date("2020-09-01", "%Y-%m-%d");
Return type is DATE

Query:
     SELECT str_to_date("2020-09-01", "%Y-%m-%d %H:%i:%s");
Return type is DATETIME

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)