### PR TITLE
[Repair] Add an option whether to allow the partition column to be NULL

### DIFF
--- a/docs/en/administrator-guide/variables.md
+++ b/docs/en/administrator-guide/variables.md
@@ -73,6 +73,7 @@ Variables that support both session-level and global-level setting include:
 * `batch_size`
 * `parallel_fragment_exec_instance_num`
 * `parallel_exchange_instance_num`
+* `allow_partition_column_nullable`
 
 Variables that support only global-level setting include:
 
@@ -360,3 +361,7 @@ Note that the comment must start with /*+ and can only follow the SELECT.
     When choosing the join method(broadcast join or shuffle join), if the broadcast join cost and shuffle join cost are equal, which join method should we prefer.
 
     Currently, the optional values for this variable are "broadcast" or "shuffle".
+
+* `allow_partition_column_nullable`
+
+    Whether to allow the partition column to be NULL when creating the table. The default is true, which means NULL is allowed. false means the partition column must be defined as NOT NULL.

--- a/docs/zh-CN/administrator-guide/variables.md
+++ b/docs/zh-CN/administrator-guide/variables.md
@@ -73,6 +73,7 @@ SET GLOBAL exec_mem_limit = 137438953472
 * `batch_size`
 * `parallel_fragment_exec_instance_num`
 * `parallel_exchange_instance_num`
+* `allow_partition_column_nullable`
 
 只支持全局生效的变量包括：
 
@@ -359,3 +360,7 @@ SELECT /*+ SET_VAR(query_timeout = 1) */ sleep(3);
     在选择join的具体实现方式是broadcast join还是shuffle join时，如果broadcast join cost和shuffle join cost相等时，优先选择哪种join方式。
 
     目前该变量的可选值为"broadcast" 或者 "shuffle"。
+
+* `allow_partition_column_nullable`
+
+    建表时是否允许分区列为NULL。默认为true，表示允许为NULL。false 表示分区列必须被定义为NOT NULL

--- a/docs/zh-CN/sql-reference/sql-statements/Data Definition/CREATE TABLE.md
+++ b/docs/zh-CN/sql-reference/sql-statements/Data Definition/CREATE TABLE.md
@@ -96,7 +96,7 @@ under the License.
        * REPLACE_IF_NOT_NULL：这个聚合类型的含义是当且仅当新导入数据是非NULL值时会发生替换行为，如果新导入的数据是NULL，那么Doris仍然会保留原值。注意：如果用在建表时REPLACE_IF_NOT_NULL列指定了NOT NULL，那么Doris仍然会将其转化NULL，不会向用户报错。用户可以借助这个类型完成部分列导入的功能。
        * 该类型只对聚合模型(key_desc的type为AGGREGATE KEY)有用，其它模型不需要指这个。
 
-    是否允许为NULL: 默认不允许为 NULL。NULL 值在导入数据中用 \N 来表示
+    是否允许为NULL: 默认允许为 NULL。NULL 值在导入数据中用 \N 来表示
 
     注意：
         BITMAP_UNION聚合类型列在导入时的原始数据类型必须是TINYINT,SMALLINT,INT,BIGINT。

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/RangePartitionDesc.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/RangePartitionDesc.java
@@ -29,6 +29,7 @@ import org.apache.doris.common.DdlException;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+import org.apache.doris.qe.ConnectContext;
 
 import java.util.List;
 import java.util.Map;
@@ -77,6 +78,10 @@ public class RangePartitionDesc extends PartitionDesc {
                     }
                     if (columnDef.getType().isFloatingPointType()) {
                         throw new AnalysisException("Floating point type column can not be partition column");
+                    }
+                    if (!ConnectContext.get().getSessionVariable().isAllowPartitionColumnNullable()
+                            && columnDef.isAllowNull()) {
+                        throw new AnalysisException("The partition column must be NOT NULL");
                     }
                     found = true;
                     break;
@@ -155,6 +160,11 @@ public class RangePartitionDesc extends PartitionDesc {
 
                     if (column.getType().isFloatingPointType()) {
                         throw new DdlException("Floating point type column can not be partition column");
+                    }
+
+                    if (!ConnectContext.get().getSessionVariable().isAllowPartitionColumnNullable()
+                            && column.isAllowNull()) {
+                        throw new DdlException("The partition column must be NOT NULL");
                     }
 
                     try {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -108,6 +108,9 @@ public class SessionVariable implements Serializable, Writable {
     public static final String MAX_SCAN_KEY_NUM = "max_scan_key_num";
     public static final String MAX_PUSHDOWN_CONDITIONS_PER_COLUMN = "max_pushdown_conditions_per_column";
 
+    // when true, the partition column must be set to NOT NULL.
+    public static final String ALLOW_PARTITION_COLUMN_NULLABLE = "allow_partition_column_nullable";
+
     // max memory used on every backend.
     @VariableMgr.VarAttr(name = EXEC_MEM_LIMIT)
     public long maxExecMemByte = 2147483648L;
@@ -269,6 +272,9 @@ public class SessionVariable implements Serializable, Writable {
     private int maxPushdownConditionsPerColumn = -1;
     @VariableMgr.VarAttr(name = SHOW_HIDDEN_COLUMNS, flag = VariableMgr.SESSION_ONLY)
     private boolean showHiddenColumns = false;
+
+    @VariableMgr.VarAttr(name = ALLOW_PARTITION_COLUMN_NULLABLE)
+    private boolean allowPartitionColumnNullable = true;
 
     public long getMaxExecMemByte() {
         return maxExecMemByte;
@@ -527,6 +533,8 @@ public class SessionVariable implements Serializable, Writable {
     public void setShowHiddenColumns(boolean showHiddenColumns) {
         this.showHiddenColumns = showHiddenColumns;
     }
+
+    public boolean isAllowPartitionColumnNullable() { return allowPartitionColumnNullable; }
 
 
     // Serialize to thrift object


### PR DESCRIPTION
## Proposed changes

Add an option `allow_partition_column_nullable`, which means whether to allow the partition column to be NULL.
When the option is enabled, the partition column must be NOT NULL when create table, otherwise an error will be reported.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have create an issue on (Fix #5012), and have described the bug/feature there in detail
- [x] Compiling and unit tests pass locally with my changes
- [x] If this change need a document change, I have updated the document