### PR TITLE
[Bug] Add a flag to prevent repeated close operation of OlapTabletSink

### DIFF
--- a/be/src/exec/tablet_sink.h
+++ b/be/src/exec/tablet_sink.h
@@ -400,6 +400,11 @@ private:
 
     // the timeout of load channels opened by this tablet sink. in second
     int64_t _load_channel_timeout_s = 0;
+
+	// True if this sink has been closed once
+	bool _is_closed = false;
+	// Save the status of close() method
+	Status _close_status;
 };
 
 } // namespace stream_load


### PR DESCRIPTION
## Proposed changes

The close method of OlapTabletSink may be called twice.
In the open_internal() method of plan_fragment_executor, close is called once.
If an error occurs in this call, it will be called again in fragment_mgr.
So here we use a flag to prevent repeated close operations.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)