### PR TITLE
[Bug] Fix version in log is always 0 bug

### DIFF
--- a/be/src/olap/txn_manager.cpp
+++ b/be/src/olap/txn_manager.cpp
@@ -251,7 +251,7 @@ OLAPStatus TxnManager::commit_txn(OlapMeta* meta, TPartitionId partition_id,
                   << " partition_id: " << key.first << ", transaction_id: " << key.second
                   << ", tablet: " << tablet_info.to_string()
                   << ", rowsetid: " << rowset_ptr->rowset_id()
-                  << ", version: " << rowset_ptr->version().first;
+                  << ", version: " << rowset_ptr->version().second;
     }
     return OLAP_SUCCESS;
 }
@@ -380,7 +380,7 @@ OLAPStatus TxnManager::delete_txn(OlapMeta* meta, TPartitionId partition_id,
                              << ",partition_id: " << key.first << ", transaction_id: " << key.second
                              << ", tablet: " << tablet_info.to_string()
                              << ", rowset id: " << load_info.rowset->rowset_id()
-                             << ", version: " << load_info.rowset->version().first;
+                             << ", version: " << load_info.rowset->version().second;
                 return OLAP_ERR_TRANSACTION_ALREADY_VISIBLE;
             } else {
                 RowsetMetaManager::remove(meta, tablet_uid, load_info.rowset->rowset_id());

--- a/be/src/olap/txn_manager.cpp
+++ b/be/src/olap/txn_manager.cpp
@@ -380,7 +380,7 @@ OLAPStatus TxnManager::delete_txn(OlapMeta* meta, TPartitionId partition_id,
                              << ",partition_id: " << key.first << ", transaction_id: " << key.second
                              << ", tablet: " << tablet_info.to_string()
                              << ", rowset id: " << load_info.rowset->rowset_id()
-                             << ", version: " << load_info.rowset->version().second;
+                             << ", version: " << load_info.rowset->version().first;
                 return OLAP_ERR_TRANSACTION_ALREADY_VISIBLE;
             } else {
                 RowsetMetaManager::remove(meta, tablet_uid, load_info.rowset->rowset_id());


### PR DESCRIPTION
## Proposed changes

Version in txn_manager.cpp's log is always `0`, because it print the version.first member, it's better to print version.second to make it more meaningful for debug.

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] Documentation Update (if none of the other choices apply)
- [] Code refactor (Modify the code structure, format the code, etc...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [] I have create an issue on (Fix #ISSUE), and have described the bug/feature there in detail
- [x] Compiling and unit tests pass locally with my changes
- [] I have added tests that prove my fix is effective or that my feature works
- [] If this change need a document change, I have updated the document
- [] Any dependent changes have been merged
