### PR TITLE
[UT] cleanup storage engine creation in tablet_mgr_test etc

### DIFF
--- a/be/test/olap/olap_snapshot_converter_test.cpp
+++ b/be/test/olap/olap_snapshot_converter_test.cpp
@@ -55,10 +55,8 @@ public:
         config::tablet_map_shard_size = 1;
         config::txn_map_shard_size = 1;
         config::txn_shard_size = 1;
-        std::vector<StorePath> paths;
-        paths.emplace_back("_engine_data_path", -1);
         EngineOptions options;
-        options.store_paths = paths;
+        // won't open engine, options.path is needless
         options.backend_uid = UniqueId::gen_uid();
         if (k_engine == nullptr) {
             k_engine = new StorageEngine(options);

--- a/be/test/olap/rowset/rowset_meta_manager_test.cpp
+++ b/be/test/olap/rowset/rowset_meta_manager_test.cpp
@@ -49,10 +49,8 @@ public:
         config::tablet_map_shard_size = 1;
         config::txn_map_shard_size = 1;
         config::txn_shard_size = 1;
-        std::vector<StorePath> paths;
-        paths.emplace_back("_engine_data_path", -1);
         EngineOptions options;
-        options.store_paths = paths;
+        // won't open engine, options.path is needless
         options.backend_uid = UniqueId::gen_uid();
         if (k_engine == nullptr) {
             k_engine = new StorageEngine(options);

--- a/be/test/olap/tablet_mgr_test.cpp
+++ b/be/test/olap/tablet_mgr_test.cpp
@@ -58,7 +58,7 @@ public:
         FileUtils::create_dir(_engine_data_path + "/meta");
 
         std::vector<StorePath> paths;
-        paths.emplace_back("_engine_data_path", -1);
+        paths.emplace_back(_engine_data_path, -1);
         EngineOptions options;
         options.store_paths = paths;
         options.backend_uid = UniqueId::gen_uid();

--- a/be/test/olap/tablet_mgr_test.cpp
+++ b/be/test/olap/tablet_mgr_test.cpp
@@ -48,19 +48,17 @@ static StorageEngine* k_engine = nullptr;
 class TabletMgrTest : public testing::Test {
 public:
     virtual void SetUp() {
-        config::tablet_map_shard_size = 1;
-        config::txn_map_shard_size = 1;
-        config::txn_shard_size = 1;
         string test_engine_data_path = "./be/test/olap/test_data/converter_test_data/data";
         _engine_data_path = "./be/test/olap/test_data/converter_test_data/tmp";
         boost::filesystem::remove_all(_engine_data_path);
         FileUtils::create_dir(_engine_data_path);
         FileUtils::create_dir(_engine_data_path + "/meta");
 
-        std::vector<StorePath> paths;
-        paths.emplace_back(_engine_data_path, -1);
+        config::tablet_map_shard_size = 1;
+        config::txn_map_shard_size = 1;
+        config::txn_shard_size = 1;
         EngineOptions options;
-        options.store_paths = paths;
+        // won't open engine, options.path is needless
         options.backend_uid = UniqueId::gen_uid();
         if (k_engine == nullptr) {
             k_engine = new StorageEngine(options);

--- a/be/test/olap/txn_manager_test.cpp
+++ b/be/test/olap/txn_manager_test.cpp
@@ -94,15 +94,14 @@ public:
     }
 
     virtual void SetUp() {
+        config::max_runnings_transactions_per_txn_map = 500;
+        _txn_mgr.reset(new TxnManager(64, 1024));
+
         config::tablet_map_shard_size = 1;
         config::txn_map_shard_size = 1;
         config::txn_shard_size = 1;
-        config::max_runnings_transactions_per_txn_map = 500;
-        _txn_mgr.reset(new TxnManager(64, 1024));
-        std::vector<StorePath> paths;
-        paths.emplace_back("_engine_data_path", -1);
         EngineOptions options;
-        options.store_paths = paths;
+        // won't open engine, options.path is needless
         options.backend_uid = UniqueId::gen_uid();
         if (k_engine == nullptr) {
             k_engine = new StorageEngine(options);


### PR DESCRIPTION
## Proposed changes

Mistakenly use the string '_engine_data_path' as the path, actually the storage engine is not open, so option/path is needless. Cleaup it to avoid any doubt about the file path management.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] Compiling and unit tests pass locally with my changes


