### PR TITLE
[Bug] Fix coredump bug when create new tablets

### DIFF
--- a/be/src/olap/data_dir.cpp
+++ b/be/src/olap/data_dir.cpp
@@ -992,6 +992,11 @@ void DataDir::update_user_data_size(int64_t size) {
     disks_data_used_capacity->set_value(size);
 }
 
+size_t DataDir::tablet_size() const {
+    std::lock_guard<std::mutex> l(_mutex);
+    return _tablet_set.size();
+}
+
 bool DataDir::reach_capacity_limit(int64_t incoming_data_size) {
     double used_pct = (_disk_capacity_bytes - _available_bytes + incoming_data_size) /
                       (double)_disk_capacity_bytes;

--- a/be/src/olap/data_dir.h
+++ b/be/src/olap/data_dir.h
@@ -126,7 +126,7 @@ public:
 
     void update_user_data_size(int64_t size);
 
-    std::set<TabletInfo> tablet_set() { return _tablet_set; }
+    size_t tablet_size() const;
 
     void disks_compaction_score_increment(int64_t delta);
 
@@ -180,7 +180,7 @@ private:
     bool _to_be_deleted;
 
     // used to protect _current_shard and _tablet_set
-    std::mutex _mutex;
+    mutable std::mutex _mutex;
     uint64_t _current_shard;
     std::set<TabletInfo> _tablet_set;
 

--- a/be/src/olap/storage_engine.cpp
+++ b/be/src/olap/storage_engine.cpp
@@ -434,7 +434,7 @@ std::vector<DataDir*> StorageEngine::get_stores_for_create_tablet(
     for (int i = 0; i < stores.size(); i++) {
         int j = i + 1;
         if (j < stores.size()) {
-            if (stores[i]->tablet_set().size() > stores[j]->tablet_set().size()) {
+            if (stores[i]->tablet_size() > stores[j]->tablet_size()) {
                 std::swap(stores[i], stores[j]);
             }
             std::random_shuffle(stores.begin() + j, stores.end());


### PR DESCRIPTION
## Proposed changes

There is a bug may cause BE coredump when create tablet, the accessing of tablet_set of a data dir should be protected by lock.

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] Documentation Update (if none of the other choices apply)
- [] Code refactor (Modify the code structure, format the code, etc...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have create an issue on (Fix https://github.com/apache/incubator-doris/issues/5090), and have described the bug/feature there in detail
- [x] Compiling and unit tests pass locally with my changes
- [] I have added tests that prove my fix is effective or that my feature works
- [] If this change need a document change, I have updated the document
- [] Any dependent changes have been merged
