### PR TITLE
[Bug] Fix tablet shared ptr circular reference causing the tablet not to be cleared

### DIFF
--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -1426,4 +1426,12 @@ void Tablet::execute_compaction(CompactionType compaction_type) {
     }
 }
 
+void Tablet::reset_compaction(CompactionType compaction_type) {
+    if (compaction_type == CompactionType::CUMULATIVE_COMPACTION) {
+        _cumulative_compaction.reset();
+    } else {
+        _base_compaction.reset();
+    }
+}
+
 }  // namespace doris

--- a/be/src/olap/tablet.h
+++ b/be/src/olap/tablet.h
@@ -246,6 +246,7 @@ public:
 
     int64_t prepare_compaction_and_calculate_permits(CompactionType compaction_type, TabletSharedPtr tablet);
     void execute_compaction(CompactionType compaction_type);
+    void reset_compaction(CompactionType compaction_type);
 
     void set_clone_occurred(bool clone_occurred) { _is_clone_occurred = clone_occurred; }
     bool get_clone_occurred() { return _is_clone_occurred; }


### PR DESCRIPTION
## Proposed changes

Regardless of whether the tablet is submitted for compaction or not,
we need to call 'reset_compaction' to clean up the base_compaction or cumulative_compaction objects
in the tablet, because these two objects store the tablet's own shared_ptr.
If it is not cleaned up, the reference count of the tablet will always be greater than 1,
thus cannot be collected by the garbage collector. (TabletManager::start_trash_sweep)

This bug is introduced from #4891

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
