### PR TITLE
[Feature] Add max_query_timeout and max_exec_mem_limit

### DIFF
--- a/docs/en/administrator-guide/config/fe_config.md
+++ b/docs/en/administrator-guide/config/fe_config.md
@@ -451,6 +451,10 @@ Can cooperate with `mix_clone_task_timeout_sec` to control the maximum and minim
 
 ### `max_distribution_pruner_recursion_depth`
 
+### `max_exec_mem_limit`
+
+This config controls the session parameter `exec_mem_limit`, which only works with the SELECT statement. Defaults to 0, which means not working.
+
 ### `max_layout_length_per_row`
 
 ### `max_load_timeout_second`
@@ -458,6 +462,10 @@ Can cooperate with `mix_clone_task_timeout_sec` to control the maximum and minim
 ### `max_mysql_service_task_threads_num`
 
 ### `max_query_retry_time`
+
+### `max_query_timeout`
+
+This config controls the session parameter `query_timeout`, which only works with the SELECT statement. Defaults to 0, which means not working.
 
 ### `max_routine_load_job_num`
 

--- a/docs/zh-CN/administrator-guide/config/fe_config.md
+++ b/docs/zh-CN/administrator-guide/config/fe_config.md
@@ -445,6 +445,10 @@ HTTP服务允许接收请求的Header的最大长度，单位为比特，默认�
 
 ### `max_distribution_pruner_recursion_depth`
 
+### `max_exec_mem_limit`
+
+该配置控制会话参数 `exec_mem_limit`，仅对SELECT语句生效，默认为0，即不起作用。
+
 ### `max_layout_length_per_row`
 
 ### `max_load_timeout_second`
@@ -452,6 +456,10 @@ HTTP服务允许接收请求的Header的最大长度，单位为比特，默认�
 ### `max_mysql_service_task_threads_num`
 
 ### `max_query_retry_time`
+
+### `max_query_timeout`
+
+该配置控制会话参数 `query_timeout`，仅对SELECT语句生效，默认为0，即不起作用。
 
 ### `max_routine_load_job_num`
 

--- a/fe/fe-core/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/Config.java
@@ -931,6 +931,22 @@ public class Config extends ConfigBase {
     public static int max_query_retry_time = 2;
 
     /**
+     * The max value for session variable query_timeout.
+     * For SELECT statement only.
+     * Default 0, which means not working.
+     */
+    @ConfField(mutable = true)
+    public static int max_query_timeout = 0;
+
+    /**
+     * The max value for session variable exec_mem_limit.
+     * For SELECT statement only.
+     * Default 0, which means not working.
+     */
+    @ConfField(mutable = true)
+    public static long max_exec_mem_limit = 0L;
+
+    /**
      * The tryLock timeout configuration of catalog lock.
      * Normally it does not need to change, unless you need to test something.
      */


### PR DESCRIPTION
## Proposed changes

As #5105.
For now these only affect `SELECT` statements. When handling `QueryStmt`, `StmtExecutor` will set limits to session variable, and set those back when the query is finished. So it won't take affect to `INSERT SELECT`.

## Types of changes

- [] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)
- [] Code refactor (Modify the code structure, format the code, etc...)

## Checklist

- [x] I have create an issue on (Fix #ISSUE), and have described the bug/feature there in detail
- [x] Compiling and unit tests pass locally with my changes
- [] I have added tests that prove my fix is effective or that my feature works
- [x] If this change need a document change, I have updated the document
- [x] Any dependent changes have been merged
