### PR TITLE
[Bug] Fix bug when delete condition is null but zonemap is not null

### DIFF
--- a/be/src/olap/olap_cond.cpp
+++ b/be/src/olap/olap_cond.cpp
@@ -387,18 +387,20 @@ int Cond::del_eval(const std::pair<WrapperField*, WrapperField*>& stat) const {
                 ret = DEL_SATISFIED;
             } else if (stat.first->is_null() && !stat.second->is_null()) {
                 ret = DEL_PARTIAL_SATISFIED;
+            } else if (!stat.first->is_null() && !stat.second->is_null()){
+                ret = DEL_NOT_SATISFIED;
             } else {
                 CHECK(false) << "It will not happen when the stat's min is not null and max is null";
-                ret = DEL_SATISFIED;
             }
         } else {
             if (stat.first->is_null() && stat.second->is_null()) {
                 ret = DEL_NOT_SATISFIED;
             } else if (stat.first->is_null() && !stat.second->is_null()) {
                 ret = DEL_PARTIAL_SATISFIED;
+            } else if (!stat.first->is_null() && !stat.second->is_null()){
+                ret = DEL_SATISFIED;
             } else {
                 CHECK(false) << "It will not happen when the stat's min is not null and max is null";
-                ret = DEL_SATISFIED;
             }
         }
         return ret;


### PR DESCRIPTION
## Proposed changes

If a column does not have any null value, and execute a delete operation
with "where k1 is null" on it, BE may crash.

This bug is introducaed from #5030

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have create an issue on (Fix #5108), and have described the bug/feature there in detail