### PR TITLE
[Enhancement] Add more comprehensive prometheus jvm thread metrics on fe

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/proc/JvmProcDir.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/proc/JvmProcDir.java
@@ -94,6 +94,12 @@ public class JvmProcDir implements ProcNodeInterface {
         Threads threads = jvmStats.getThreads();
         result.addRow(genRow("threads count", threads.getCount()));
         result.addRow(genRow("threads peak count", threads.getPeakCount()));
+        result.addRow(genRow("threads new count", threads.getThreadsNewCount()));
+        result.addRow(genRow("threads runnable count", threads.getThreadsRunnableCount()));
+        result.addRow(genRow("threads blocked count", threads.getThreadsBlockedCount()));
+        result.addRow(genRow("threads waiting count", threads.getThreadsWaitingCount()));
+        result.addRow(genRow("threads timed_waiting count", threads.getThreadsTimedWaitingCount()));
+        result.addRow(genRow("threads terminated count", threads.getThreadsTerminatedCount()));
 
         return result;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/common/proc/JvmProcDir.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/proc/JvmProcDir.java
@@ -100,7 +100,6 @@ public class JvmProcDir implements ProcNodeInterface {
         result.addRow(genRow("threads waiting count", threads.getThreadsWaitingCount()));
         result.addRow(genRow("threads timed_waiting count", threads.getThreadsTimedWaitingCount()));
         result.addRow(genRow("threads terminated count", threads.getThreadsTerminatedCount()));
-
         return result;
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/metric/PrometheusMetricVisitor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/metric/PrometheusMetricVisitor.java
@@ -134,12 +134,12 @@ public class PrometheusMetricVisitor extends MetricVisitor {
         sb.append(Joiner.on(" ").join(TYPE, JVM_THREAD, "gauge\n"));
         sb.append(JVM_THREAD).append("{type=\"count\"} ").append(threads.getCount()).append("\n");
         sb.append(JVM_THREAD).append("{type=\"peak_count\"} ").append(threads.getPeakCount()).append("\n");
-        sb.append(JVM_THREAD).append("{type=\"threads_new_count\"} ").append(threads.getThreadsNewCount()).append("\n");
-        sb.append(JVM_THREAD).append("{type=\"threads_runnable_count\"} ").append(threads.getThreadsRunnableCount()).append("\n");
-        sb.append(JVM_THREAD).append("{type=\"threads_blocked_count\"} ").append(threads.getThreadsBlockedCount()).append("\n");
-        sb.append(JVM_THREAD).append("{type=\"threads_waiting_count\"} ").append(threads.getThreadsWaitingCount()).append("\n");
-        sb.append(JVM_THREAD).append("{type=\"threads_timed_waiting_count\"} ").append(threads.getThreadsTimedWaitingCount()).append("\n");
-        sb.append(JVM_THREAD).append("{type=\"threads_terminated_count\"} ").append(threads.getThreadsTerminatedCount()).append("\n");
+        sb.append(JVM_THREAD).append("{type=\"new_count\"} ").append(threads.getThreadsNewCount()).append("\n");
+        sb.append(JVM_THREAD).append("{type=\"runnable_count\"} ").append(threads.getThreadsRunnableCount()).append("\n");
+        sb.append(JVM_THREAD).append("{type=\"blocked_count\"} ").append(threads.getThreadsBlockedCount()).append("\n");
+        sb.append(JVM_THREAD).append("{type=\"waiting_count\"} ").append(threads.getThreadsWaitingCount()).append("\n");
+        sb.append(JVM_THREAD).append("{type=\"timed_waiting_count\"} ").append(threads.getThreadsTimedWaitingCount()).append("\n");
+        sb.append(JVM_THREAD).append("{type=\"terminated_count\"} ").append(threads.getThreadsTerminatedCount()).append("\n");
         return;
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/metric/PrometheusMetricVisitor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/metric/PrometheusMetricVisitor.java
@@ -134,6 +134,12 @@ public class PrometheusMetricVisitor extends MetricVisitor {
         sb.append(Joiner.on(" ").join(TYPE, JVM_THREAD, "gauge\n"));
         sb.append(JVM_THREAD).append("{type=\"count\"} ").append(threads.getCount()).append("\n");
         sb.append(JVM_THREAD).append("{type=\"peak_count\"} ").append(threads.getPeakCount()).append("\n");
+        sb.append(JVM_THREAD).append("{type=\"threads_new_count\"} ").append(threads.getThreadsNewCount()).append("\n");
+        sb.append(JVM_THREAD).append("{type=\"threads_runnable_count\"} ").append(threads.getThreadsRunnableCount()).append("\n");
+        sb.append(JVM_THREAD).append("{type=\"threads_blocked_count\"} ").append(threads.getThreadsBlockedCount()).append("\n");
+        sb.append(JVM_THREAD).append("{type=\"threads_waiting_count\"} ").append(threads.getThreadsWaitingCount()).append("\n");
+        sb.append(JVM_THREAD).append("{type=\"threads_timed_waiting_count\"} ").append(threads.getThreadsTimedWaitingCount()).append("\n");
+        sb.append(JVM_THREAD).append("{type=\"threads_terminated_count\"} ").append(threads.getThreadsTerminatedCount()).append("\n");
         return;
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/monitor/jvm/JvmStats.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/monitor/jvm/JvmStats.java
@@ -100,6 +100,7 @@ public class JvmStats {
                 case WAITING:       threadsWaiting++;       break;
                 case TIMED_WAITING: threadsTimedWaiting++;  break;
                 case TERMINATED:    threadsTerminated++;    break;
+                default:                                    break;
             }
         }
         Threads threads = new Threads(threadMXBean.getThreadCount(), threadMXBean.getPeakThreadCount(), threadsNew,

--- a/fe/fe-core/src/main/java/org/apache/doris/monitor/jvm/JvmStats.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/monitor/jvm/JvmStats.java
@@ -29,6 +29,7 @@ import java.lang.management.MemoryPoolMXBean;
 import java.lang.management.MemoryUsage;
 import java.lang.management.RuntimeMXBean;
 import java.lang.management.ThreadMXBean;
+import java.lang.management.ThreadInfo;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -82,7 +83,27 @@ public class JvmStats {
         }
         Mem mem = new Mem(heapCommitted, heapUsed, heapMax, nonHeapCommitted, nonHeapUsed,
                 Collections.unmodifiableList(pools));
-        Threads threads = new Threads(threadMXBean.getThreadCount(), threadMXBean.getPeakThreadCount());
+
+        int threadsNew = 0;
+        int threadsRunnable = 0;
+        int threadsBlocked = 0;
+        int threadsWaiting = 0;
+        int threadsTimedWaiting = 0;
+        int threadsTerminated = 0;
+        long threadIds[] = threadMXBean.getAllThreadIds();
+        for (ThreadInfo threadInfo : threadMXBean.getThreadInfo(threadIds, 0)) {
+            if (threadInfo == null) continue; // race protection
+            switch (threadInfo.getThreadState()) {
+                case NEW:           threadsNew++;           break;
+                case RUNNABLE:      threadsRunnable++;      break;
+                case BLOCKED:       threadsBlocked++;       break;
+                case WAITING:       threadsWaiting++;       break;
+                case TIMED_WAITING: threadsTimedWaiting++;  break;
+                case TERMINATED:    threadsTerminated++;    break;
+            }
+        }
+        Threads threads = new Threads(threadMXBean.getThreadCount(), threadMXBean.getPeakThreadCount(), threadsNew,
+                threadsRunnable, threadsBlocked, threadsWaiting, threadsTimedWaiting, threadsTerminated);
 
         List<GarbageCollectorMXBean> gcMxBeans = ManagementFactory.getGarbageCollectorMXBeans();
         GarbageCollector[] collectors = new GarbageCollector[gcMxBeans.size()];
@@ -192,6 +213,12 @@ public class JvmStats {
         static final String THREADS = "threads";
         static final String COUNT = "count";
         static final String PEAK_COUNT = "peak_count";
+        static final String THREADS_NEW_COUNT = "threads_new_count";
+        static final String THREADS_RUNNING_COUNT = "threads_runnable_count";
+        static final String THREADS_BLOCKED_COUNT = "threads_blocked_count";
+        static final String THREADS_WAITING_COUNT = "threads_waiting_count";
+        static final String THREADS_TIMED_WAITING_COUNT = "threads_timed_waiting_count";
+        static final String THREADS_TERMINATED_COUNT = "threads_terminated_count";
 
         static final String GC = "gc";
         static final String COLLECTORS = "collectors";
@@ -264,10 +291,23 @@ public class JvmStats {
 
         private final int count;
         private final int peakCount;
+        private final int threadsNewCount;
+        private final int threadsRunnableCount;
+        private final int threadsBlockedCount;
+        private final int threadsWaitingCount;
+        private final int threadsTimedWaitingCount;
+        private final int threadsTerminatedCount;
 
-        public Threads(int count, int peakCount) {
+        public Threads(int count, int peakCount, int threadsNewCount, int threadsRunnableCount, int threadsBlockedCount,
+                       int threadsWaitingCount, int threadsTimedWaitingCount, int threadsTerminatedCount) {
             this.count = count;
             this.peakCount = peakCount;
+            this.threadsNewCount = threadsNewCount;
+            this.threadsRunnableCount = threadsRunnableCount;
+            this.threadsBlockedCount = threadsBlockedCount;
+            this.threadsWaitingCount = threadsWaitingCount;
+            this.threadsTimedWaitingCount = threadsTimedWaitingCount;
+            this.threadsTerminatedCount = threadsTerminatedCount;
         }
 
         public int getCount() {
@@ -276,6 +316,30 @@ public class JvmStats {
 
         public int getPeakCount() {
             return peakCount;
+        }
+
+        public int getThreadsNewCount() {
+            return threadsNewCount;
+        }
+
+        public int getThreadsRunnableCount() {
+            return threadsRunnableCount;
+        }
+
+        public int getThreadsBlockedCount() {
+            return threadsBlockedCount;
+        }
+
+        public int getThreadsWaitingCount() {
+            return threadsWaitingCount;
+        }
+
+        public int getThreadsTimedWaitingCount() {
+            return threadsTimedWaitingCount;
+        }
+
+        public int getThreadsTerminatedCount() {
+            return threadsTerminatedCount;
         }
 
         @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/monitor/jvm/JvmStats.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/monitor/jvm/JvmStats.java
@@ -213,12 +213,12 @@ public class JvmStats {
         static final String THREADS = "threads";
         static final String COUNT = "count";
         static final String PEAK_COUNT = "peak_count";
-        static final String THREADS_NEW_COUNT = "threads_new_count";
-        static final String THREADS_RUNNING_COUNT = "threads_runnable_count";
-        static final String THREADS_BLOCKED_COUNT = "threads_blocked_count";
-        static final String THREADS_WAITING_COUNT = "threads_waiting_count";
-        static final String THREADS_TIMED_WAITING_COUNT = "threads_timed_waiting_count";
-        static final String THREADS_TERMINATED_COUNT = "threads_terminated_count";
+        static final String NEW_COUNT = "new_count";
+        static final String RUNNING_COUNT = "runnable_count";
+        static final String BLOCKED_COUNT = "blocked_count";
+        static final String WAITING_COUNT = "waiting_count";
+        static final String TIMED_WAITING_COUNT = "timed_waiting_count";
+        static final String TERMINATED_COUNT = "terminated_count";
 
         static final String GC = "gc";
         static final String COLLECTORS = "collectors";


### PR DESCRIPTION
## Proposed changes
Currently, fe thread metrics is very simple, only have thread count and peak_count. I think we may need more comprehensive prometheus jvm thread metrics on fe. This will be useful when we want to analysis fe's running status.

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] Documentation Update (if none of the other choices apply)
- [] Code refactor (Modify the code structure, format the code, etc...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [] I have create an issue on (Fix #ISSUE), and have described the bug/feature there in detail
- [x] Compiling and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] If this change need a document change, I have updated the document
- [x] Any dependent changes have been merged

## Further comments

If this is a relatively large or complex change, kick off the discussion at dev@doris.apache.org by explaining why you chose the solution you did and what alternatives you considered, etc...
