### PR TITLE
[Docs] some brpc configs can't be modified at runtime 

### DIFF
--- a/docs/en/administrator-guide/config/be_config.md
+++ b/docs/en/administrator-guide/config/be_config.md
@@ -158,15 +158,11 @@ Sometimes the query fails and an error message of `body_size is too large` will 
 
 This error indicates that the packet size of brpc exceeds the configured value. At this time, you can avoid this error by increasing the configuration.
 
-Since this is a brpc configuration, users can also modify this parameter directly during operation. Modify by visiting `http://be_host:brpc_port/flags`.
-
 ### `brpc_socket_max_unwritten_bytes`
 
 This configuration is mainly used to modify the parameter `socket_max_unwritten_bytes` of brpc.
 
 Sometimes the query fails and an error message of `The server is overcrowded` will appear in the BE log. This means there are too many messages to buffer at the sender side, which may happen when the SQL needs to send large bitmap value. You can avoid this error by increasing the configuration.
-
-Since this is a brpc configuration, users can also modify this parameter directly during operation. Modify by visiting `http://be_host:brpc_port/flags`.
 
 ### `brpc_num_threads`
 

--- a/docs/zh-CN/administrator-guide/config/be_config.md
+++ b/docs/zh-CN/administrator-guide/config/be_config.md
@@ -151,7 +151,6 @@ Metrics: {"filtered_rows":0,"input_row_num":3346807,"input_rowsets_count":42,"in
 
 有时查询失败，在 BE 日志中会出现 `body_size is too large` 的错误信息。这可能发生在 SQL 模式为 multi distinct + 无 group by + 超过1T 数据量的情况下。这个错误表示 brpc 的包大小超过了配置值。此时可以通过调大该配置避免这个错误。
 
-由于这是一个 brpc 的配置，用户也可以在运行中直接修改该参数。通过访问 `http://be_host:brpc_port/flags` 修改。
 
 ### `brpc_socket_max_unwritten_bytes`
 
@@ -159,7 +158,6 @@ Metrics: {"filtered_rows":0,"input_row_num":3346807,"input_rowsets_count":42,"in
 
 有时查询失败，BE 日志中会出现 `The server is overcrowded` 的错误信息，表示连接上有过多的未发送数据。当查询需要发送较大的bitmap字段时，可能会遇到该问题，此时可能通过调大该配置避免该错误。
 
-由于这是一个 brpc 的配置，用户也可以在运行中直接修改该参数。通过访问 `http://be_host:brpc_port/flags` 修改。
 
 ### `brpc_num_threads`
 


### PR DESCRIPTION
## Proposed changes
`brpc_max_body_size ` & `brpc_socket_max_unwritten_bytes ` can't be modified at runtime. Only flags which have `(R)`(has_validator_fn) can.

## Types of changes

- [x] Documentation Update (if none of the other choices apply)
