### PR TITLE
[Bug] fix LOOP_LESS_OR_MORE

### DIFF
--- a/be/test/olap/memory/column_test.cpp
+++ b/be/test/olap/memory/column_test.cpp
@@ -47,7 +47,9 @@ struct ColumnTest {
         scoped_refptr<Column> newc;
         ASSERT_TRUE(writer->finalize(2).ok());
         ASSERT_TRUE(writer->get_new_column(&newc).ok());
-        if (!AllowSlowTests()) {
+        // The less `InsertCount` won't make COW performed，
+        // expect the new column object only when inserting more。
+        if (AllowSlowTests()) {
             EXPECT_TRUE(c.get() != newc.get());
         }
         std::unique_ptr<ColumnReader> readc;

--- a/be/test/olap/memory/column_test.cpp
+++ b/be/test/olap/memory/column_test.cpp
@@ -78,7 +78,7 @@ struct ColumnTest {
         scoped_refptr<Column> newc;
         ASSERT_TRUE(writer->finalize(2).ok());
         ASSERT_TRUE(writer->get_new_column(&newc).ok());
-        if (!AllowSlowTests()) {
+        if (AllowSlowTests()) {
             EXPECT_TRUE(c.get() != newc.get());
         }
         std::unique_ptr<ColumnReader> readc;

--- a/be/test/test_util/test_util.h
+++ b/be/test/test_util/test_util.h
@@ -19,7 +19,7 @@
 
 namespace doris {
 
-#define LOOP_LESS_OR_MORE(less, more) (AllowSlowTests() ? less : more)
+#define LOOP_LESS_OR_MORE(less, more) (AllowSlowTests() ? more : less)
 
 // Get the value of an environment variable that has boolean semantics.
 bool GetBooleanEnvironmentVariable(const char* env_var_name);


### PR DESCRIPTION
## Proposed changes

This bug introduced by #5131. When `AllowSlowTests()` is true, we should loop more. 

## Types of changes

What types of changes does your code introduce to Doris?

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] Compiling and unit tests pass locally with my changes
