### PR TITLE
[Bug] Fix bug that the min/max function has an error in handling string null values

### DIFF
--- a/be/src/olap/aggregate_func.h
+++ b/be/src/olap/aggregate_func.h
@@ -300,6 +300,7 @@ struct AggregateFuncTraits<OLAP_FIELD_AGGREGATION_MAX, OLAP_FIELD_TYPE_VARCHAR>
                 memory_copy(dst_slice->data, src_slice->data, src_slice->size);
                 dst_slice->size = src_slice->size;
             }
+            dst->set_is_null(false);
         }
     }
 };


### PR DESCRIPTION
## Proposed changes

null should be ignored in min/max function.
And if there is no data, null should be return.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have create an issue on (Fix #5188), and have described the bug/feature there in detail
