### PR TITLE
[UT] fix the bug of getting current running dir

### DIFF
--- a/be/test/plugin/plugin_loader_test.cpp
+++ b/be/test/plugin/plugin_loader_test.cpp
@@ -18,9 +18,9 @@
 #include "plugin/plugin_loader.h"
 
 #include <gtest/gtest.h>
-#include <libgen.h>
 
 #include "plugin/plugin.h"
+#include "test_util/test_util.h"
 #include "util/file_utils.h"
 
 namespace doris {
@@ -55,10 +55,8 @@ int close_plugin(void* ptr) {
 class PluginLoaderTest : public testing::Test {
 public:
     PluginLoaderTest() {
-        char buf[1024];
-        readlink("/proc/self/exe", buf, 1023);
-        char* dir_path = dirname(buf);
-        _path = std::string(dir_path);
+        _path = GetCurrentRunningDir();
+        EXPECT_FALSE(_path.empty());
     }
 
     ~PluginLoaderTest() {}

--- a/be/test/plugin/plugin_mgr_test.cpp
+++ b/be/test/plugin/plugin_mgr_test.cpp
@@ -18,11 +18,11 @@
 #include "plugin/plugin_mgr.h"
 
 #include <gtest/gtest.h>
-#include <libgen.h>
 
 #include "plugin/plugin.h"
 #include "plugin/plugin_loader.h"
 #include "string"
+#include "test_util/test_util.h"
 
 namespace doris {
 
@@ -60,10 +60,8 @@ Plugin demo_plugin = {
 class PluginMgrTest : public testing::Test {
 public:
     PluginMgrTest() {
-        char buf[1024];
-        readlink("/proc/self/exe", buf, 1023);
-        char* dir_path = dirname(buf);
-        _path = std::string(dir_path);
+        _path = GetCurrentRunningDir();
+        EXPECT_FALSE(_path.empty());
     }
 
     ~PluginMgrTest() {}

--- a/be/test/plugin/plugin_zip_test.cpp
+++ b/be/test/plugin/plugin_zip_test.cpp
@@ -18,7 +18,6 @@
 #include "plugin/plugin_zip.h"
 
 #include <gtest/gtest.h>
-#include <libgen.h>
 
 #include <cstdio>
 #include <cstdlib>
@@ -30,6 +29,7 @@
 #include "http/http_channel.h"
 #include "http/http_handler.h"
 #include "http/http_request.h"
+#include "test_util/test_util.h"
 #include "util/file_utils.h"
 #include "util/slice.h"
 
@@ -37,16 +37,15 @@ namespace doris {
 class HttpTestHandler : public HttpHandler {
 public:
     void handle(HttpRequest* req) override {
-        char buf[1024];
-        readlink("/proc/self/exe", buf, 1023);
-        char* dir_path = dirname(buf);
-        std::string path = std::string(dir_path);
+        std::string path = GetCurrentRunningDir();
+        ASSERT_FALSE(path.empty());
 
         std::unique_ptr<SequentialFile> file;
 
         auto& file_name = req->param("FILE");
 
         FILE* fp = fopen((path + "/plugin_test/source/" + file_name).c_str(), "r");
+        ASSERT_TRUE(fp != nullptr);
 
         std::string response;
         char f[1024];
@@ -68,11 +67,8 @@ public:
 class PluginZipTest : public testing::Test {
 public:
     PluginZipTest() {
-        char buf[1024];
-        readlink("/proc/self/exe", buf, 1023);
-        char* dir_path = dirname(buf);
-        _path = std::string(dir_path);
-
+        _path = GetCurrentRunningDir();
+        EXPECT_FALSE(_path.empty());
         _server.reset(new EvHttpServer(29191));
         _server->register_handler(GET, "/{FILE}", &_handler);
         _server->start();

--- a/be/test/test_util/test_util.cpp
+++ b/be/test/test_util/test_util.cpp
@@ -17,7 +17,12 @@
 
 #include "test_util/test_util.h"
 
+#include <libgen.h>
+#include <linux/limits.h>
+#include <stdlib.h>
 #include <strings.h>
+#include <sys/types.h>
+#include <unistd.h>
 
 #include "gutil/strings/substitute.h"
 
@@ -27,25 +32,37 @@ namespace doris {
 
 static const char* const kSlowTestsEnvVar = "DORIS_ALLOW_SLOW_TESTS";
 
-bool AllowSlowTests() { return GetBooleanEnvironmentVariable(kSlowTestsEnvVar); }
+bool AllowSlowTests() {
+    return GetBooleanEnvironmentVariable(kSlowTestsEnvVar);
+}
 
 bool GetBooleanEnvironmentVariable(const char* env_var_name) {
     const char* const e = getenv(env_var_name);
-    if ((e == nullptr) ||
-        (strlen(e) == 0) ||
-        (strcasecmp(e, "false") == 0) ||
-        (strcasecmp(e, "0") == 0) ||
-        (strcasecmp(e, "no") == 0)) {
+    if ((e == nullptr) || (strlen(e) == 0) || (strcasecmp(e, "false") == 0) ||
+        (strcasecmp(e, "0") == 0) || (strcasecmp(e, "no") == 0)) {
         return false;
     }
-    if ((strcasecmp(e, "true") == 0) ||
-        (strcasecmp(e, "1") == 0) ||
-        (strcasecmp(e, "yes") == 0)) {
+    if ((strcasecmp(e, "true") == 0) || (strcasecmp(e, "1") == 0) || (strcasecmp(e, "yes") == 0)) {
         return true;
     }
-    LOG(FATAL) << Substitute("$0: invalid value for environment variable $0",
-                             e, env_var_name);
-    return false;  // unreachable
+    LOG(FATAL) << Substitute("$0: invalid value for environment variable $0", e, env_var_name);
+    return false; // unreachable
+}
+
+std::string GetCurrentRunningDir() {
+    char exe[PATH_MAX];
+    ssize_t r;
+
+    if ((r = readlink("/proc/self/exe", exe, PATH_MAX)) < 0) {
+        return std::string();
+    }
+
+    if (r == PATH_MAX) {
+        r -= 1;
+    }
+    exe[r] = 0;
+    char* dir = dirname(exe);
+    return std::string(dir);
 }
 
 } // namespace doris

--- a/be/test/test_util/test_util.h
+++ b/be/test/test_util/test_util.h
@@ -17,6 +17,8 @@
 
 #pragma once
 
+#include <string>
+
 namespace doris {
 
 #define LOOP_LESS_OR_MORE(less, more) (AllowSlowTests() ? more : less)
@@ -26,5 +28,9 @@ bool GetBooleanEnvironmentVariable(const char* env_var_name);
 
 // Returns true if slow tests are runtime-enabled.
 bool AllowSlowTests();
+
+// Returns the path of the folder containing the currently running executable.
+// Empty string if get errors.
+std::string GetCurrentRunningDir();
 
 } // namespace doris

--- a/be/test/util/system_metrics_test.cpp
+++ b/be/test/util/system_metrics_test.cpp
@@ -18,9 +18,9 @@
 #include "util/system_metrics.h"
 
 #include <gtest/gtest.h>
-#include <libgen.h>
 
 #include "common/config.h"
+#include "test_util/test_util.h"
 #include "util/logging.h"
 #include "util/metrics.h"
 #include "util/stopwatch.hpp"
@@ -40,9 +40,7 @@ extern const char* k_ut_fd_path;
 extern const char* k_ut_net_snmp_path;
 
 TEST_F(SystemMetricsTest, normal) {
-    char buf[1024];
-    readlink("/proc/self/exe", buf, 1023);
-    char* dir_path = dirname(buf);
+    std::string dir_path = GetCurrentRunningDir();
     std::string stat_path(dir_path);
     stat_path += "/test_data/stat_normal";
     LOG(INFO) << stat_path;
@@ -172,9 +170,7 @@ TEST_F(SystemMetricsTest, normal) {
 }
 
 TEST_F(SystemMetricsTest, no_proc_file) {
-    char buf[1024];
-    readlink("/proc/self/exe", buf, 1023);
-    char* dir_path = dirname(buf);
+    std::string dir_path = GetCurrentRunningDir();
     std::string stat_path(dir_path);
     stat_path += "/test_data/no_stat_normal";
     LOG(INFO) << stat_path;

--- a/be/test/util/zip_util_test.cpp
+++ b/be/test/util/zip_util_test.cpp
@@ -18,7 +18,6 @@
 #include "util/zip_util.h"
 
 #include <gtest/gtest.h>
-#include <libgen.h>
 
 #include <iostream>
 #include <string>
@@ -27,16 +26,14 @@
 #include "gutil/strings/util.h"
 #include "util/file_utils.h"
 #include "util/logging.h"
+#include "test_util/test_util.h"
 
 namespace doris {
 
 using namespace strings;
 
 TEST(ZipUtilTest, basic) {
-    char buf[1024];
-    readlink("/proc/self/exe", buf, 1023);
-    char* dir_path = dirname(buf);
-    std::string path(dir_path);
+    std::string path = GetCurrentRunningDir();
 
     FileUtils::remove_all(path + "/test_data/target");
 
@@ -59,10 +56,7 @@ TEST(ZipUtilTest, basic) {
 }
 
 TEST(ZipUtilTest, dir) {
-    char buf[1024];
-    readlink("/proc/self/exe", buf, 1023);
-    char* dir_path = dirname(buf);
-    std::string path(dir_path);
+    std::string path = GetCurrentRunningDir();
 
     FileUtils::remove_all(path + "/test_data/target");
 
@@ -91,10 +85,7 @@ TEST(ZipUtilTest, dir) {
 }
 
 TEST(ZipUtilTest, targetAlready) {
-    char buf[1024];
-    readlink("/proc/self/exe", buf, 1023);
-    char* dir_path = dirname(buf);
-    std::string path(dir_path);
+    std::string path = GetCurrentRunningDir();
 
     ZipFile f(path + "/test_data/zip_normal.zip");
 
@@ -104,10 +95,7 @@ TEST(ZipUtilTest, targetAlready) {
 }
 
 TEST(ZipUtilTest, notzip) {
-    char buf[1024];
-    readlink("/proc/self/exe", buf, 1023);
-    char* dir_path = dirname(buf);
-    std::string path(dir_path);
+    std::string path = GetCurrentRunningDir();
 
     ZipFile f(path + "/test_data/zip_normal_data");
     Status st = f.extract("test", "test");


### PR DESCRIPTION
## Proposed changes

Fixed the logic after `readlink`, add a test_util function `GetCurrentRunningDir()`.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have create an issue on (Fix #5182), and have described the bug/feature there in detail
- [x] Compiling and unit tests pass locally with my changes
