### PR TITLE
[Bug] Fix row_number and group by have inconsistent partition results for (0.0, -0.0)

### DIFF
--- a/be/src/util/hash_util.hpp
+++ b/be/src/util/hash_util.hpp
@@ -29,6 +29,7 @@
 #include <nmmintrin.h>
 #endif
 #include <zlib.h>
+#include <cmath>
 #include "util/cpu_info.h"
 #include "util/murmur_hash3.h"
 #include "gen_cpp/Types_types.h"
@@ -58,6 +59,10 @@ public:
         uint32_t words = bytes / sizeof(uint32_t);
         bytes = bytes % sizeof(uint32_t);
 
+        // When data is negative zero, rewrite it to 0.0, see Doris#5226
+        if (*(double*)data == 0.0 and std::signbit(*(double*)data) == true) {
+            *(double*)data = 0.0;
+        }
         const uint32_t* p = reinterpret_cast<const uint32_t*>(data);
 
         while (words--) {
@@ -219,6 +224,13 @@ public:
     // is taken on the hash, all values will collide to the same bucket.
     // For string values, Fnv is slightly faster than boost.
     static uint32_t fnv_hash(const void* data, int32_t bytes, uint32_t hash) {
+        // When data is negative zero, rewrite it to 0.0, which will be used in 
+        // DataStreamSender::send HashPartition, because the original value of 
+        // data is covered here, so -0.0 in the data after DataStreamSender 
+        // will be changed to 0.0, see Doris#5226
+        if (*(double*)data == 0.0 and std::signbit(*(double*)data) == true) {
+            *(double*)data = 0.0;
+        }
         const uint8_t* ptr = reinterpret_cast<const uint8_t*>(data);
 
         while (bytes--) {


### PR DESCRIPTION
## Problem analysis
The essence of the problem is behavior of negative zero (- 0.0) in comparison with positive zero (+ 0.0).
Currently in GroupBy and HashPartition, -0.0 is not equal to 0.0 (result of Hash function), so the -0.0 and 0.0 are divided into 2 partitions.

In row_number analytic function, for the sorted data, a new partition will be opened when the values ​​​​of the upper and lower rows are not equal. But in C++ the comparison 0.0 == -0.0 is true, so 0.0 and -0.0 are divided into the same partition for row_number.

(Floating point arithmetic in C++ is often IEEE-754. This norm defines two different representations for the value zero: positive zero and negative zero. It is also defined that those two representations must compare equals. Refer to https://stackoverflow.com/questions/45795397)

## Fix method
1. (Deprecated) Modifies the eq comparison of two Doubles in BinaryPredicate, and returns -0.0 == 0.0 as false when both sides of expr are SlotRef.
Problems:
  (1) When order by is still considered equal to 0.0 and -0.0, the order of 0.0 and -0.0 in the result is random
  (2) The reason for restricting both sides of BinaryPredicate to be SlotRef is that the constant cannot be defined as -0.0. For example, the expression of `where k1 = -0.0` in SQL in actual calculation is `where k1 = 0.0`.

2. Modify the Hash function in `hash_util.hpp`, when data is negative zero, rewrite it to 0.0, which will be used in `DataStreamSender::send HashPartition` and `GroupBy`, because the original value of data is covered, so -0.0 in the original data after Hash will be changed to 0.0.

Our goal is that -0.0 will not appear in Doris, and all will be replaced with 0.0. Therefore, you need to modify the Broker Load in the future, and change -0.0 to 0.0 when importing. Mysql and SparkSQL are currently converted to 0.0 when Load -0.0 to Double column. But there is a situation that may not be avoided, that is, `select round(-0.2,0);`, the returned `-0.0` is meaningful, refer to https://www.johndcook.com/blog/2010/06/15/why-computers-have-signed-zero/

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have create an issue on (Fix #5225), and have described the bug/feature there in detail
- [x] Compiling and unit tests pass locally with my changes