### PR TITLE
[LOG] Reduce verbose exception log by catch exceptions

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/MysqlProto.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/MysqlProto.java
@@ -138,8 +138,12 @@ public class MysqlProto {
         serializer.reset();
         MysqlHandshakePacket handshakePacket = new MysqlHandshakePacket(context.getConnectionId());
         handshakePacket.writeTo(serializer);
-        channel.sendAndFlush(serializer.toByteBuffer());
-
+        try {
+            channel.sendAndFlush(serializer.toByteBuffer());
+        } catch (IOException e) {
+            LOG.warn("Send and flush channel exception, ignore. Exception: " + e.toString());
+            return false;
+        }
         // Server receive authenticate packet from client.
         ByteBuffer handshakeResponse = channel.fetchOnePacket();
         if (handshakeResponse == null) {

--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/nio/NMysqlChannel.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/nio/NMysqlChannel.java
@@ -54,18 +54,22 @@ public class NMysqlChannel extends MysqlChannel {
      *
      * @param dstBuf
      * @return
-     * @throws IOException
      */
     @Override
-    protected int readAll(ByteBuffer dstBuf) throws IOException {
+    protected int readAll(ByteBuffer dstBuf) {
         int readLen = 0;
-        while (dstBuf.remaining() != 0) {
-            int ret = Channels.readBlocking(conn.getSourceChannel(), dstBuf);
-            // return -1 when remote peer close the channel
-            if (ret == -1) {
-                return readLen;
+        try {
+            while (dstBuf.remaining() != 0) {
+                int ret = Channels.readBlocking(conn.getSourceChannel(), dstBuf);
+                // return -1 when remote peer close the channel
+                if (ret == -1) {
+                    return readLen;
+                }
+                readLen += ret;
             }
-            readLen += ret;
+        } catch (IOException e) {
+            LOG.warn("Read channel exception, ignore. Exception: " + e.toString());
+            return 0;
         }
         return readLen;
     }

--- a/fe/fe-core/src/test/java/org/apache/doris/mysql/MysqlProtoTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/mysql/MysqlProtoTest.java
@@ -183,14 +183,14 @@ public class MysqlProtoTest {
         Assert.assertTrue(MysqlProto.negotiate(context));
     }
 
-    @Test(expected = IOException.class)
+    @Test
     public void testNegotiateSendFail() throws Exception {
         mockChannel("user", false);
         mockPassword(true);
         mockAccess();
         ConnectContext context = new ConnectContext(null);
         MysqlProto.negotiate(context);
-        Assert.fail("No Exception throws.");
+        Assert.assertFalse(MysqlProto.negotiate(context));
     }
 
     @Test


### PR DESCRIPTION

## Proposed changes

In our product enviroment, we use LVS to dispatch requests to FEs,
however, LVS will send probes to check whether FE is alive, and will
close the connecttion immediately. It will cause much verbose log,
this patch aim to reduce these log by catch related exceptions.

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [] Bugfix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] Documentation Update (if none of the other choices apply)
- [x] Code refactor (Modify the code structure, format the code, etc...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [] I have create an issue on (Fix #ISSUE), and have described the bug/feature there in detail
- [x] Compiling and unit tests pass locally with my changes
- [] I have added tests that prove my fix is effective or that my feature works
- [] If this change need a document change, I have updated the document
- [] Any dependent changes have been merged

