### PR TITLE
[Bug] Remove schema hash and fix bug of calculating table signature

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/alter/MaterializedViewHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/MaterializedViewHandler.java
@@ -61,13 +61,13 @@ import org.apache.doris.qe.OriginStatement;
 import org.apache.doris.thrift.TStorageFormat;
 import org.apache.doris.thrift.TStorageMedium;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -331,8 +331,7 @@ public class MaterializedViewHandler extends AlterHandler {
             mvKeysType = olapTable.getKeysType();
         }
         // get rollup schema hash
-        int mvSchemaHash = Util.schemaHash(0 /* init schema version */, mvColumns, olapTable.getCopiedBfColumns(),
-                                           olapTable.getBfFpp());
+        int mvSchemaHash = Util.generateSchemaHash();
         // get short key column count
         short mvShortKeyColumnCount = Catalog.calcShortKeyColumnCount(mvColumns, properties);
         // get timeout

--- a/fe/fe-core/src/main/java/org/apache/doris/backup/RestoreJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/backup/RestoreJob.java
@@ -485,8 +485,8 @@ public class RestoreJob extends AbstractJob {
                             return;
                         }
                         LOG.debug("get intersect part names: {}, job: {}", intersectPartNames, this);
-                        if (localOlapTbl.getSignature(BackupHandler.SIGNATURE_VERSION, intersectPartNames)
-                                != remoteOlapTbl.getSignature(BackupHandler.SIGNATURE_VERSION, intersectPartNames)) {
+                        if (!localOlapTbl.getSignature(BackupHandler.SIGNATURE_VERSION, intersectPartNames).equals(
+                                remoteOlapTbl.getSignature(BackupHandler.SIGNATURE_VERSION, intersectPartNames))) {
                             status = new Status(ErrCode.COMMON_ERROR, "Table " + jobInfo.getAliasByOriginNameIfSet(tblInfo.name)
                                     + " already exist but with different schema");
                             return;

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Catalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Catalog.java
@@ -217,6 +217,11 @@ import org.apache.doris.transaction.GlobalTransactionMgr;
 import org.apache.doris.transaction.PublishVersionDaemon;
 import org.apache.doris.transaction.UpdateDbUsedDataQuotaDaemon;
 
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.codehaus.jackson.map.ObjectMapper;
+
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
@@ -230,11 +235,6 @@ import com.google.common.collect.Sets;
 import com.sleepycat.je.rep.InsufficientLogException;
 import com.sleepycat.je.rep.NetworkRestore;
 import com.sleepycat.je.rep.NetworkRestoreConfig;
-
-import org.apache.commons.collections.CollectionUtils;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.codehaus.jackson.map.ObjectMapper;
 
 import java.io.BufferedInputStream;
 import java.io.DataInputStream;
@@ -3733,7 +3733,7 @@ public class Catalog {
         } catch (AnalysisException e) {
             throw new DdlException(e.getMessage());
         }
-        int schemaHash = Util.schemaHash(schemaVersion, baseSchema, bfColumns, bfFpp);
+        int schemaHash = Util.generateSchemaHash();
         olapTable.setIndexMeta(baseIndexId, tableName, baseSchema, schemaVersion, schemaHash,
                 shortKeyColumnCount, baseIndexStorageType, keysType);
 
@@ -3754,7 +3754,7 @@ public class Catalog {
             List<Column> rollupColumns = getRollupHandler().checkAndPrepareMaterializedView(addRollupClause,
                     olapTable, baseRollupIndex, false);
             short rollupShortKeyColumnCount = Catalog.calcShortKeyColumnCount(rollupColumns, alterClause.getProperties());
-            int rollupSchemaHash = Util.schemaHash(schemaVersion, rollupColumns, bfColumns, bfFpp);
+            int rollupSchemaHash = Util.generateSchemaHash();
             long rollupIndexId = getCurrentCatalog().getNextId();
             olapTable.setIndexMeta(rollupIndexId, addRollupClause.getRollupName(), rollupColumns, schemaVersion,
                     rollupSchemaHash, rollupShortKeyColumnCount, rollupIndexStorageType, keysType);

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
@@ -949,7 +949,7 @@ public class OlapTable extends Table {
         }
 
         String md5 = DigestUtils.md5Hex(sb.toString());
-        LOG.debug("get signature of table {}: {}", name, md5);
+        LOG.debug("get signature of table {}: {}. signature string: {}", name, md5, sb.toString());
         return md5;
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
@@ -52,19 +52,19 @@ import org.apache.doris.thrift.TStorageType;
 import org.apache.doris.thrift.TTableDescriptor;
 import org.apache.doris.thrift.TTableType;
 
+import org.apache.commons.codec.digest.DigestUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Range;
 import com.google.common.collect.Sets;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -75,7 +75,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.zip.Adler32;
 
 /**
  * Internal representation of tableFamilyGroup-related metadata. A OlaptableFamilyGroup contains several tableFamily.
@@ -898,85 +897,58 @@ public class OlapTable extends Table {
         throw new RuntimeException("Don't support anymore");
     }
 
-    public int getSignature(int signatureVersion, List<String> partNames) {
-        Adler32 adler32 = new Adler32();
-        adler32.update(signatureVersion);
-        final String charsetName = "UTF-8";
-
-        try {
-            // table name
-            adler32.update(name.getBytes(charsetName));
-            LOG.debug("signature. table name: {}", name);
-            // type
-            adler32.update(type.name().getBytes(charsetName));
-            LOG.debug("signature. table type: {}", type.name());
-
-            // all indices(should be in order)
-            Set<String> indexNames = Sets.newTreeSet();
-            indexNames.addAll(indexNameToId.keySet());
-            for (String indexName : indexNames) {
-                long indexId = indexNameToId.get(indexName);
-                adler32.update(indexName.getBytes(charsetName));
-                LOG.debug("signature. index name: {}", indexName);
-                MaterializedIndexMeta indexMeta = indexIdToMeta.get(indexId);
-                // schema hash
-                adler32.update(indexMeta.getSchemaHash());
-                LOG.debug("signature. index schema hash: {}", indexMeta.getSchemaHash());
-                // short key column count
-                adler32.update(indexMeta.getShortKeyColumnCount());
-                LOG.debug("signature. index short key: {}", indexMeta.getShortKeyColumnCount());
-                // storage type
-                adler32.update(indexMeta.getStorageType().name().getBytes(charsetName));
-                LOG.debug("signature. index storage type: {}", indexMeta.getStorageType());
-            }
-
-            // bloom filter
-            if (bfColumns != null && !bfColumns.isEmpty()) {
-                for (String bfCol : bfColumns) {
-                    adler32.update(bfCol.getBytes());
-                    LOG.debug("signature. bf col: {}", bfCol);
-                }
-                adler32.update(String.valueOf(bfFpp).getBytes());
-                LOG.debug("signature. bf fpp: {}", bfFpp);
-            }
-
-            // partition type
-            adler32.update(partitionInfo.getType().name().getBytes(charsetName));
-            LOG.debug("signature. partition type: {}", partitionInfo.getType().name());
-            // partition columns
-            if (partitionInfo.getType() == PartitionType.RANGE) {
-                RangePartitionInfo rangePartitionInfo = (RangePartitionInfo) partitionInfo;
-                List<Column> partitionColumns = rangePartitionInfo.getPartitionColumns();
-                adler32.update(Util.schemaHash(0, partitionColumns, null, 0));
-                LOG.debug("signature. partition col hash: {}", Util.schemaHash(0, partitionColumns, null, 0));
-            }
-
-            // partition and distribution
-            Collections.sort(partNames, String.CASE_INSENSITIVE_ORDER);
-            for (String partName : partNames) {
-                Partition partition = getPartition(partName);
-                Preconditions.checkNotNull(partition, partName);
-                adler32.update(partName.getBytes(charsetName));
-                LOG.debug("signature. partition name: {}", partName);
-                DistributionInfo distributionInfo = partition.getDistributionInfo();
-                adler32.update(distributionInfo.getType().name().getBytes(charsetName));
-                if (distributionInfo.getType() == DistributionInfoType.HASH) {
-                    HashDistributionInfo hashDistributionInfo = (HashDistributionInfo) distributionInfo;
-                    adler32.update(Util.schemaHash(0, hashDistributionInfo.getDistributionColumns(), null, 0));
-                    LOG.debug("signature. distribution col hash: {}",
-                              Util.schemaHash(0, hashDistributionInfo.getDistributionColumns(), null, 0));
-                    adler32.update(hashDistributionInfo.getBucketNum());
-                    LOG.debug("signature. bucket num: {}", hashDistributionInfo.getBucketNum());
-                }
-            }
-
-        } catch (UnsupportedEncodingException e) {
-            LOG.error("encoding error", e);
-            return -1;
+    // Get the md5 of signature string of this table with specified partitions.
+    // This method is used to determine whether the tables have the same schema.
+    // Contains:
+    // table name, table type, index name, index schema, short key column count, storage type
+    // bloom filter, partition type and columns, distribution type and columns.
+    // buckets number.
+    public String getSignature(int signatureVersion, List<String> partNames) {
+        StringBuilder sb = new StringBuilder(signatureVersion);
+        sb.append(name);
+        sb.append(type);
+        Set<String> indexNames = Sets.newTreeSet(indexNameToId.keySet());
+        for (String indexName : indexNames) {
+            long indexId = indexNameToId.get(indexName);
+            MaterializedIndexMeta indexMeta = indexIdToMeta.get(indexId);
+            sb.append(indexName);
+            sb.append(Util.getSchemaSignatureString(indexMeta.getSchema(), null, 0.0));
+            sb.append(indexMeta.getShortKeyColumnCount());
+            sb.append(indexMeta.getStorageType());
         }
 
-        LOG.debug("signature: {}", Math.abs((int) adler32.getValue()));
-        return Math.abs((int) adler32.getValue());
+        // bloom filter
+        if (bfColumns != null && !bfColumns.isEmpty()) {
+            for (String bfCol : bfColumns) {
+                sb.append(bfCol);
+            }
+            sb.append(bfFpp);
+        }
+
+        // partition type
+        sb.append(partitionInfo.getType());
+        if (partitionInfo.getType() == PartitionType.RANGE) {
+            RangePartitionInfo rangePartitionInfo = (RangePartitionInfo) partitionInfo;
+            List<Column> partitionColumns = rangePartitionInfo.getPartitionColumns();
+            sb.append(Util.getSchemaSignatureString(partitionColumns, null, 0));
+        }
+
+        // partition and distribution
+        Collections.sort(partNames, String.CASE_INSENSITIVE_ORDER);
+        for (String partName : partNames) {
+            Partition partition = getPartition(partName);
+            Preconditions.checkNotNull(partition, partName);
+            DistributionInfo distributionInfo = partition.getDistributionInfo();
+            sb.append(partName);
+            sb.append(distributionInfo.getType());
+            if (distributionInfo.getType() == DistributionInfoType.HASH) {
+                HashDistributionInfo hashDistributionInfo = (HashDistributionInfo) distributionInfo;
+                sb.append(Util.getSchemaSignatureString(hashDistributionInfo.getDistributionColumns(), null, 0));
+                sb.append(hashDistributionInfo.getBucketNum());
+            }
+        }
+
+        return DigestUtils.md5Hex(sb.toString());
     }
 
     // get intersect partition names with the given table "anotherTbl". not including temp partitions

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
@@ -948,7 +948,9 @@ public class OlapTable extends Table {
             }
         }
 
-        return DigestUtils.md5Hex(sb.toString());
+        String md5 = DigestUtils.md5Hex(sb.toString());
+        LOG.debug("get signature of table {}: {}", name, md5);
+        return md5;
     }
 
     // get intersect partition names with the given table "anotherTbl". not including temp partitions

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
@@ -912,7 +912,7 @@ public class OlapTable extends Table {
             long indexId = indexNameToId.get(indexName);
             MaterializedIndexMeta indexMeta = indexIdToMeta.get(indexId);
             sb.append(indexName);
-            sb.append(Util.getSchemaSignatureString(indexMeta.getSchema(), null, 0.0));
+            sb.append(Util.getSchemaSignatureString(indexMeta.getSchema()));
             sb.append(indexMeta.getShortKeyColumnCount());
             sb.append(indexMeta.getStorageType());
         }
@@ -930,7 +930,7 @@ public class OlapTable extends Table {
         if (partitionInfo.getType() == PartitionType.RANGE) {
             RangePartitionInfo rangePartitionInfo = (RangePartitionInfo) partitionInfo;
             List<Column> partitionColumns = rangePartitionInfo.getPartitionColumns();
-            sb.append(Util.getSchemaSignatureString(partitionColumns, null, 0));
+            sb.append(Util.getSchemaSignatureString(partitionColumns));
         }
 
         // partition and distribution
@@ -943,7 +943,7 @@ public class OlapTable extends Table {
             sb.append(distributionInfo.getType());
             if (distributionInfo.getType() == DistributionInfoType.HASH) {
                 HashDistributionInfo hashDistributionInfo = (HashDistributionInfo) distributionInfo;
-                sb.append(Util.getSchemaSignatureString(hashDistributionInfo.getDistributionColumns(), null, 0));
+                sb.append(Util.getSchemaSignatureString(hashDistributionInfo.getDistributionColumns()));
                 sb.append(hashDistributionInfo.getBucketNum());
             }
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Table.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Table.java
@@ -24,23 +24,23 @@ import org.apache.doris.common.io.Writable;
 import org.apache.doris.common.util.Util;
 import org.apache.doris.thrift.TTableDescriptor;
 
+import org.apache.commons.lang.NotImplementedException;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 
-import org.apache.commons.lang.NotImplementedException;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 import java.time.Instant;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.stream.Collectors;
 
 /**
@@ -366,11 +366,6 @@ public class Table extends MetaObject implements Writable {
     }
 
     public CreateTableStmt toCreateTableStmt(String dbName) {
-        throw new NotImplementedException();
-    }
-
-    @Override
-    public int getSignature(int signatureVersion) {
         throw new NotImplementedException();
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/Util.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/Util.java
@@ -44,7 +44,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
-import java.util.Set;
 import java.util.function.Predicate;
 
 public class Util {
@@ -216,19 +215,11 @@ public class Util {
 
     // Get a string represent the schema signature, contains:
     // list of columns and bloom filter column info.
-    public static String getSchemaSignatureString(List<Column> columns, Set<String> bfColumns, double bfFpp) {
+    public static String getSchemaSignatureString(List<Column> columns) {
         StringBuilder sb = new StringBuilder();
         for (Column column : columns) {
             sb.append(column.getSignatureString(TYPE_STRING_MAP));
         }
-
-        if (bfColumns != null && !bfColumns.isEmpty()) {
-            for (String columnName : bfColumns) {
-                sb.append(columnName);
-            }
-            sb.append(bfFpp);
-        }
-
         return sb.toString();
     }
     

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/Util.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/Util.java
@@ -222,7 +222,7 @@ public class Util {
             sb.append(column.getSignatureString(TYPE_STRING_MAP));
         }
 
-        if (!bfColumns.isEmpty()) {
+        if (bfColumns != null && !bfColumns.isEmpty()) {
             for (String columnName : bfColumns) {
                 sb.append(columnName);
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/Util.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/Util.java
@@ -22,12 +22,12 @@ import org.apache.doris.catalog.PrimitiveType;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.qe.ConnectContext;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
-
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 import java.io.BufferedReader;
 import java.io.DataInput;
@@ -36,7 +36,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.io.UnsupportedEncodingException;
 import java.net.URL;
 import java.net.URLConnection;
 import java.util.ArrayList;
@@ -47,7 +46,6 @@ import java.util.Map;
 import java.util.Random;
 import java.util.Set;
 import java.util.function.Predicate;
-import java.util.zip.Adler32;
 
 public class Util {
     private static final Logger LOG = LogManager.getLogger(Util.class);
@@ -215,72 +213,23 @@ public class Util {
         }
         return tokens;
     }
-    
-    public static int schemaHash(int schemaVersion, List<Column> columns, Set<String> bfColumns, double bfFpp) {
-        Adler32 adler32 = new Adler32();
-        adler32.update(schemaVersion);
-        String charsetName = "UTF-8";
-        try {
-            List<String> indexColumnNames = Lists.newArrayList();
-            List<String> bfColumnNames = Lists.newArrayList();
-            // columns
-            for (Column column : columns) {
-                adler32.update(column.getName().getBytes(charsetName));
-                PrimitiveType dataType = column.getDataType();
-                String typeString = null;
-                switch (dataType) {
-                    case CHAR:
-                        typeString = String.format(
-                                TYPE_STRING_MAP.get(dataType), column.getStrLen());
-                        break;
-                    case VARCHAR:
-                        typeString = String.format(
-                                TYPE_STRING_MAP.get(dataType), column.getStrLen());
-                        break;
-                    case DECIMAL:
-                    case DECIMALV2:
-                        typeString = String.format(
-                                TYPE_STRING_MAP.get(dataType), column.getPrecision(), 
-                                column.getScale());
-                        break;
-                    default:
-                        typeString = TYPE_STRING_MAP.get(dataType);
-                        break;
-                }
-                adler32.update(typeString.getBytes(charsetName));
 
-                String columnName = column.getName();
-                if (column.isKey()) {
-                    indexColumnNames.add(columnName);
-                }
-
-                if (bfColumns != null && bfColumns.contains(columnName)) {
-                    bfColumnNames.add(columnName);
-                }
-            }
-            
-            // index column name
-            for (String columnName : indexColumnNames) {
-                adler32.update(columnName.getBytes(charsetName));
-            }
-
-            // bloom filter index
-            if (!bfColumnNames.isEmpty()) {
-                // bf column name
-                for (String columnName : bfColumnNames) {
-                    adler32.update(columnName.getBytes(charsetName));
-                }
-
-                // bf fpp
-                String bfFppStr = String.valueOf(bfFpp);
-                adler32.update(bfFppStr.getBytes(charsetName));
-            }
-        } catch (UnsupportedEncodingException e) {
-            LOG.error("encoding error", e);
-            return -1;
+    // Get a string represent the schema signature, contains:
+    // list of columns and bloom filter column info.
+    public static String getSchemaSignatureString(List<Column> columns, Set<String> bfColumns, double bfFpp) {
+        StringBuilder sb = new StringBuilder();
+        for (Column column : columns) {
+            sb.append(column.getSignatureString(TYPE_STRING_MAP));
         }
 
-        return Math.abs((int) adler32.getValue());
+        if (!bfColumns.isEmpty()) {
+            for (String columnName : bfColumns) {
+                sb.append(columnName);
+            }
+            sb.append(bfFpp);
+        }
+
+        return sb.toString();
     }
     
     public static long generateVersionHash() {

--- a/fe/fe-core/src/test/java/org/apache/doris/backup/CatalogMocker.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/backup/CatalogMocker.java
@@ -197,8 +197,8 @@ public class CatalogMocker {
         TEST_ROLLUP_SCHEMA.add(k2);
         TEST_ROLLUP_SCHEMA.add(v1);
 
-        SCHEMA_HASH = Util.schemaHash(0, TEST_TBL_BASE_SCHEMA, null, 0);
-        ROLLUP_SCHEMA_HASH = Util.schemaHash(0, TEST_ROLLUP_SCHEMA, null, 0);
+        SCHEMA_HASH = Util.generateSchemaHash();
+        ROLLUP_SCHEMA_HASH = Util.generateSchemaHash();
     }
 
     private static PaloAuth fetchAdminAccess() {


### PR DESCRIPTION
## Proposed changes

1. Schema hash is useless long time ago
    Currently, schema hash can only be generated as a random integer, no need to calculated
    from real schema.

2. The CRC32 algo is not enough to generate the table' signature.
    Table's signature is used to determine whether the tables have the same schema.
    And current CRC32 algo may return same signature even if table's schema are different.

    So I change it to calculate the md5 of a signature string assambled by schema info of a table.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)