### PR TITLE
[Doc] Fix the error description for the number of bytes of double type.

### DIFF
--- a/docs/en/sql-reference/sql-statements/Data Definition/CREATE TABLE.md
+++ b/docs/en/sql-reference/sql-statements/Data Definition/CREATE TABLE.md
@@ -64,7 +64,7 @@ Syntax:
             Range: -2^127 + 1 ~ 2^127 - 1
         FLOAT(4 Bytes)
             Support scientific notation
-        DOUBLE(12 Bytes)
+        DOUBLE(8 Bytes)
             Support scientific notation
         DECIMAL[(precision, scale)] (16 Bytes)
             Default is DECIMAL(10, 0)

--- a/docs/zh-CN/sql-reference/sql-statements/Data Definition/CREATE TABLE.md
+++ b/docs/zh-CN/sql-reference/sql-statements/Data Definition/CREATE TABLE.md
@@ -66,7 +66,7 @@ under the License.
             范围：-2^127 + 1 ~ 2^127 - 1
         FLOAT（4字节）
             支持科学计数法
-        DOUBLE（12字节）
+        DOUBLE（8字节）
             支持科学计数法
         DECIMAL[(precision, scale)] (16字节)
             保证精度的小数类型。默认是 DECIMAL(10, 0)


### PR DESCRIPTION
Fix the error description of double type: 12 bytes is modified to 8 bytes