### PR TITLE
Adding a column with SUM aggregation to table should restrict the default value

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeHandler.java
@@ -753,7 +753,8 @@ public class SchemaChangeHandler extends AlterHandler {
                 throw new DdlException("Can not assign aggregation method on key column: " +  newColName);
             } else if (null == newColumn.getAggregationType()) {
                 newColumn.setIsKey(true);
-            } else if (newColumn.getAggregationType() == AggregateType.SUM && !newColumn.getDefaultValue().equals("0")) {
+            } else if (newColumn.getAggregationType() == AggregateType.SUM
+                       && newColumn.getDefaultValue() != null && !newColumn.getDefaultValue().equals("0")) {
                 throw new DdlException("The default value of '" + newColName + "' with SUM aggregation function must be zero");
             }
         } else if (KeysType.UNIQUE_KEYS == olapTable.getKeysType()) {

--- a/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeHandler.java
@@ -753,6 +753,8 @@ public class SchemaChangeHandler extends AlterHandler {
                 throw new DdlException("Can not assign aggregation method on key column: " +  newColName);
             } else if (null == newColumn.getAggregationType()) {
                 newColumn.setIsKey(true);
+            } else if (newColumn.getAggregationType() == AggregateType.SUM && !newColumn.getDefaultValue().equals("0")) {
+                throw new DdlException("The default value of '" + newColName + "' with SUM aggregation function must be zero");
             }
         } else if (KeysType.UNIQUE_KEYS == olapTable.getKeysType()) {
             if (newColumn.getAggregationType() != null) {


### PR DESCRIPTION
One Tablet have three replicas, the compaction progress is different.
Considering the following scenario, replica A have 3 versions(1, 2, 3);
replica B have 2 versions(1-2, 3);
replica C have 1 versions(1-3).
Now a column named city been added with default zero 1.
Replica A will be resulted as 3, replica B results as 2,
replica C results as 1.

So there is a necessity to restrict the default value to zero for SUM aggregation column.