### PR TITLE
[Routine load] Fix kafka load too many task bug

### DIFF
--- a/be/src/runtime/routine_load/routine_load_task_executor.cpp
+++ b/be/src/runtime/routine_load/routine_load_task_executor.cpp
@@ -37,7 +37,8 @@ DEFINE_GAUGE_METRIC_PROTOTYPE_2ARG(routine_load_task_count, MetricUnit::NOUNIT);
 
 RoutineLoadTaskExecutor::RoutineLoadTaskExecutor(ExecEnv* exec_env)
         : _exec_env(exec_env),
-          _thread_pool(config::routine_load_thread_pool_size, 1),
+          _thread_pool(config::routine_load_thread_pool_size,
+                       config::routine_load_thread_pool_size),
           _data_consumer_pool(10) {
     REGISTER_HOOK_METRIC(routine_load_task_count, [this]() {
         std::lock_guard<std::mutex> l(_lock);
@@ -105,11 +106,11 @@ Status RoutineLoadTaskExecutor::submit_task(const TRoutineLoadTask& task) {
         return Status::OK();
     }
 
-    // thread pool's queue size > 0 means there are tasks waiting to be executed, so no more tasks should be submitted.
-    if (_thread_pool.get_queue_size() > 0) {
+    if (_task_map.size() >= config::routine_load_thread_pool_size) {
         LOG(INFO) << "too many tasks in thread pool. reject task: " << UniqueId(task.id)
                   << ", job id: " << task.job_id
-                  << ", queue size: " << _thread_pool.get_queue_size();
+                  << ", queue size: " << _thread_pool.get_queue_size()
+                  << ", current tasks num: " << _task_map.size();
         return Status::TooManyTasks(UniqueId(task.id).to_string());
     }
 

--- a/be/test/runtime/routine_load_task_executor_test.cpp
+++ b/be/test/runtime/routine_load_task_executor_test.cpp
@@ -51,6 +51,9 @@ public:
         _env._master_info = new TMasterInfo();
         _env._load_stream_mgr = new LoadStreamMgr();
         _env._stream_load_executor = new StreamLoadExecutor(&_env);
+
+        config::routine_load_thread_pool_size = 5;
+        config::max_consumer_num_per_group = 3;
     }
 
     void TearDown() override {


### PR DESCRIPTION
Although there are many threads in thread pool, queue size is 1.
When submitting task, too many task error may occur.

logs:
```
I0118 07:26:57.605834  3358 routine_load_task_executor.cpp:161] submit a new routine load task: id=916d377d538744e9-92b68f3fc9f6456f, job_id=14541, txn_id=1340749, label=user_order-14541-916d377d538744e9-
92b68f3fc9f6456f-1340749, current tasks num: 4
I0118 07:26:57.607491  3358 routine_load_task_executor.cpp:81] too many tasks in thread pool. reject task: 95b8d683ebb04ec4-b29de2aec07a9b3d
W0118 07:26:57.607501  3358 backend_service.cpp:141] failed to submit routine load task. job id: 31306 task id: TUniqueId(hi=-7658135304260268348, lo=-5576051523433358531)
```