### PR TITLE
[Feature] Support variable sql_select_limit (#5326)

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -776,6 +776,10 @@ public class StmtExecutor {
                     channel.sendOnePacket(row);
                 }
                 context.updateReturnRows(batch.getBatch().getRows().size());
+                long selectLimit = context.getSessionVariable().getSqlSelectLimit();
+                if (selectLimit > 0 && context.getReturnRows() > selectLimit) {
+                    break;
+                }
             }
             if (batch.isEos()) {
                 break;


### PR DESCRIPTION
## Proposed changes

as #5326
This is mainly used for stopping big rowset. The ReturnRows is not exactly as `sql_select_limit`, but stop after the last RowBatch sended.

## Types of changes

- [] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] Documentation Update (if none of the other choices apply)
- [] Code refactor (Modify the code structure, format the code, etc...)

## Checklist

- [x] I have created an issue on (Fix #ISSUE) and described the bug/feature there in detail
- [x] Compiling and unit tests pass locally with my changes
- [] I have added tests that prove my fix is effective or that my feature works
- [] If these changes need document changes, I have updated the document
- [x] Any dependent changes have been merged
