### PR TITLE
[Enhancement] Add warn log when client report be state failed and refactor some report code

### DIFF
--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -1084,21 +1084,7 @@ void TaskWorkerPool::_report_task_worker_thread_callback() {
             lock_guard<Mutex> task_signatures_lock(_s_task_signatures_lock);
             request.__set_tasks(_s_task_signatures);
         }
-
-        DorisMetrics::instance()->report_task_requests_total->increment(1);
-        TMasterResult result;
-        AgentStatus status = _master_client->report(request, &result);
-
-        if (status != DORIS_SUCCESS) {
-            DorisMetrics::instance()->report_task_requests_failed->increment(1);
-            LOG(WARNING) << "report task failed. status: " << status
-                         << ", master host: " << _master_info.network_address.hostname
-                         << "port: " << _master_info.network_address.port;
-        } else {
-            LOG(INFO) << "finish report task. master host: "
-                      << _master_info.network_address.hostname
-                      << " port: " << _master_info.network_address.port;
-        }
+        _handle_report(request, ReportType::TASK);
     } while (!_stop_background_threads_latch.wait_for(
             MonoDelta::FromSeconds(config::report_task_interval_seconds)));
 }
@@ -1142,21 +1128,7 @@ void TaskWorkerPool::_report_disk_state_worker_thread_callback() {
             disks[root_path_info.path] = disk;
         }
         request.__set_disks(disks);
-
-        DorisMetrics::instance()->report_disk_requests_total->increment(1);
-        TMasterResult result;
-        AgentStatus status = _master_client->report(request, &result);
-
-        if (status != DORIS_SUCCESS) {
-            DorisMetrics::instance()->report_disk_requests_failed->increment(1);
-            LOG(WARNING) << "report disk state failed. status: " << status
-                         << ", master host: " << _master_info.network_address.hostname
-                         << ", port: " << _master_info.network_address.port;
-        } else {
-            LOG(INFO) << "finish report disk state. master host: "
-                      << _master_info.network_address.hostname
-                      << ", port: " << _master_info.network_address.port;
-        }
+        _handle_report(request, ReportType::DISK);
     }
     StorageEngine::instance()->deregister_report_listener(this);
 }
@@ -1185,12 +1157,12 @@ void TaskWorkerPool::_report_tablet_worker_thread_callback() {
         }
 
         request.tablets.clear();
-        OLAPStatus report_all_tablets_info_status =
-                StorageEngine::instance()->tablet_manager()->report_all_tablets_info(
+        OLAPStatus build_all_report_tablets_info_status =
+                StorageEngine::instance()->tablet_manager()->build_all_report_tablets_info(
                         &request.tablets);
-        if (report_all_tablets_info_status != OLAP_SUCCESS) {
-            LOG(WARNING) << "report get all tablets info failed. status: "
-                         << report_all_tablets_info_status;
+        if (build_all_report_tablets_info_status != OLAP_SUCCESS) {
+            LOG(WARNING) << "build all report tablets info failed. status: "
+                         << build_all_report_tablets_info_status;
             continue;
         }
         int64_t max_compaction_score =
@@ -1198,19 +1170,7 @@ void TaskWorkerPool::_report_tablet_worker_thread_callback() {
                          DorisMetrics::instance()->tablet_base_max_compaction_score->value());
         request.__set_tablet_max_compaction_score(max_compaction_score);
         request.__set_report_version(_s_report_version);
-
-        TMasterResult result;
-        AgentStatus status = _master_client->report(request, &result);
-        if (status != DORIS_SUCCESS) {
-            DorisMetrics::instance()->report_all_tablets_requests_failed->increment(1);
-            LOG(WARNING) << "report tablets failed. status: " << status
-                         << ", master host: " << _master_info.network_address.hostname
-                         << ", port:" << _master_info.network_address.port;
-        } else {
-            LOG(INFO) << "finish report tablets. master host: "
-                      << _master_info.network_address.hostname
-                      << ", port: " << _master_info.network_address.port;
-        }
+        _handle_report(request, ReportType::TABLET);
     }
     StorageEngine::instance()->deregister_report_listener(this);
 }
@@ -1552,6 +1512,54 @@ AgentStatus TaskWorkerPool::_move_dir(const TTabletId tablet_id, const TSchemaHa
     }
 
     return DORIS_SUCCESS;
+}
+
+void TaskWorkerPool::_handle_report(TReportRequest& request, ReportType type) {
+    TMasterResult result;
+    AgentStatus status = _master_client->report(request, &result);
+    bool is_report_success = false;
+    if (status != DORIS_SUCCESS) {
+        LOG(WARNING) << "report " << TYPE_STRING(type)  << " failed. status: " << status
+                     << ", master host: " << _master_info.network_address.hostname
+                     << ", port:" << _master_info.network_address.port;
+    } else if  (result.status.status_code != TStatusCode::OK) {
+        std::stringstream ss;
+        if (!result.status.error_msgs.empty()) {
+            ss << result.status.error_msgs[0];
+            for (int i = 1; i < result.status.error_msgs.size(); i++) {
+                ss << "," << result.status.error_msgs[i];
+            }
+        }
+        LOG(WARNING) << "finish report " << TYPE_STRING(type) << " failed. status:" << result.status.status_code
+                     << ", error msg:" << ss.str();
+    } else {
+        is_report_success = true;
+        LOG(INFO) << "finish report " << TYPE_STRING(type) << ". master host: "
+                  << _master_info.network_address.hostname
+                  << ", port: " << _master_info.network_address.port;
+    }
+    switch (type) {
+    case TASK:
+        DorisMetrics::instance()->report_task_requests_total->increment(1);
+        if (!is_report_success) {
+            DorisMetrics::instance()->report_task_requests_failed->increment(1);
+        }
+        break;
+    case DISK:
+        DorisMetrics::instance()->report_disk_requests_total->increment(1);
+        if (!is_report_success) {
+            DorisMetrics::instance()->report_disk_requests_failed->increment(1);
+        }
+        break;
+    case TABLET:
+        DorisMetrics::instance()->report_tablet_requests_total->increment(1);
+        if (!is_report_success) {
+            DorisMetrics::instance()->report_tablet_requests_failed->increment(1);
+        }
+        break;
+    default:
+        break;
+    }
 }
 
 } // namespace doris

--- a/be/src/agent/task_worker_pool.h
+++ b/be/src/agent/task_worker_pool.h
@@ -72,6 +72,12 @@ public:
         UPDATE_TABLET_META_INFO
     };
 
+    enum ReportType {
+        TASK,
+        DISK,
+        TABLET
+    };
+
     inline const std::string TYPE_STRING(TaskWorkerType type) {
         switch (type) {
         case CREATE_TABLE:
@@ -125,6 +131,19 @@ public:
         }
     }
 
+    inline const std::string TYPE_STRING(ReportType type) {
+        switch (type) {
+        case TASK:
+            return "TASK";
+        case DISK:
+            return "DISK";
+        case TABLET:
+            return "TABLET";
+        default:
+            return "Unknown";
+        }
+    }
+
     TaskWorkerPool(const TaskWorkerType task_worker_type, ExecEnv* env,
                    const TMasterInfo& master_info);
     virtual ~TaskWorkerPool();
@@ -172,6 +191,7 @@ private:
 
     void _alter_tablet(const TAgentTaskRequest& alter_tablet_request, int64_t signature,
                        const TTaskType::type task_type, TFinishTaskRequest* finish_task_request);
+    void _handle_report(TReportRequest& request, ReportType type);
 
     AgentStatus _get_tablet_info(const TTabletId tablet_id, const TSchemaHash schema_hash,
                                  int64_t signature, TTabletInfo* tablet_info);

--- a/be/src/olap/tablet_manager.cpp
+++ b/be/src/olap/tablet_manager.cpp
@@ -944,9 +944,9 @@ OLAPStatus TabletManager::report_tablet_info(TTabletInfo* tablet_info) {
     return res;
 }
 
-OLAPStatus TabletManager::report_all_tablets_info(std::map<TTabletId, TTablet>* tablets_info) {
+OLAPStatus TabletManager::build_all_report_tablets_info(std::map<TTabletId, TTablet>* tablets_info) {
     DCHECK(tablets_info != nullptr);
-    LOG(INFO) << "begin to report all tablets info";
+    LOG(INFO) << "begin to build all report tablets info";
 
     // build the expired txn map first, outside the tablet map lock
     std::map<TabletInfo, std::vector<int64_t>> expire_txn_map;
@@ -983,7 +983,7 @@ OLAPStatus TabletManager::report_all_tablets_info(std::map<TTabletId, TTablet>* 
             }
         }
     }
-    LOG(INFO) << "success to report all tablets info. tablet_count=" << tablets_info->size();
+    LOG(INFO) << "success to build all report tablets info. tablet_count=" << tablets_info->size();
     return OLAP_SUCCESS;
 }
 

--- a/be/src/olap/tablet_manager.h
+++ b/be/src/olap/tablet_manager.h
@@ -115,7 +115,7 @@ public:
     //        OLAP_ERR_INPUT_PARAMETER_ERROR, if tables is null
     OLAPStatus report_tablet_info(TTabletInfo* tablet_info);
 
-    OLAPStatus report_all_tablets_info(std::map<TTabletId, TTablet>* tablets_info);
+    OLAPStatus build_all_report_tablets_info(std::map<TTabletId, TTablet>* tablets_info);
 
     OLAPStatus start_trash_sweep();
     // Prevent schema change executed concurrently.


### PR DESCRIPTION
## Proposed changes
There are some redundant code for report task, disk and tablet in be, and when fe return error report message, there is no any warn log showing report failed.

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [] Bugfix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] Documentation Update (if none of the other choices apply)
- [x] Code refactor (Modify the code structure, format the code, etc...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [] I have created an issue on (Fix #5343 ) and described the bug/feature there in detail
- [] Compiling and unit tests pass locally with my changes
- [] I have added tests that prove my fix is effective or that my feature works
- [] If these changes need document changes, I have updated the document
- [] Any dependent changes have been merged

## Further comments

If this is a relatively large or complex change, kick off the discussion at dev@doris.apache.org by explaining why you chose the solution you did and what alternatives you considered, etc...
