### PR TITLE
[Compaction] Cache compaction score for tablet to avoid calculating each tablet score in every production

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -276,6 +276,9 @@ CONF_mInt32(cumulative_compaction_skip_window_seconds, "30");
 // compaction until this interval passes.
 CONF_mInt64(min_compaction_failure_interval_sec, "600"); // 10 min
 
+// interval of updating all tablets' compaction score
+CONF_mInt64(update_all_compaction_score_interval_sec, "14400"); // 0.5 day
+
 // This config can be set to limit thread number in compaction thread pool.
 CONF_mInt32(min_compaction_threads, "10");
 CONF_mInt32(max_compaction_threads, "10");

--- a/be/src/olap/compaction.cpp
+++ b/be/src/olap/compaction.cpp
@@ -127,8 +127,11 @@ OLAPStatus Compaction::do_compaction_impl(int64_t permits) {
     int64_t now = UnixMillis();
     if (compaction_type() == ReaderType::READER_CUMULATIVE_COMPACTION) {
         _tablet->set_last_cumu_compaction_success_time(now);
+        _tablet->update_cumulative_compaction_score(_tablet->calc_compaction_score(CompactionType::CUMULATIVE_COMPACTION));
+        _tablet->update_base_compaction_score(_tablet->calc_compaction_score(CompactionType::BASE_COMPACTION));
     } else {
         _tablet->set_last_base_compaction_success_time(now);
+        _tablet->update_base_compaction_score(_tablet->calc_compaction_score(CompactionType::BASE_COMPACTION));
     }
 
     LOG(INFO) << "succeed to do " << compaction_name() << ". tablet=" << _tablet->full_name()

--- a/be/src/olap/compaction.cpp
+++ b/be/src/olap/compaction.cpp
@@ -127,12 +127,12 @@ OLAPStatus Compaction::do_compaction_impl(int64_t permits) {
     int64_t now = UnixMillis();
     if (compaction_type() == ReaderType::READER_CUMULATIVE_COMPACTION) {
         _tablet->set_last_cumu_compaction_success_time(now);
-        _tablet->update_cumulative_compaction_score(_tablet->calc_compaction_score(CompactionType::CUMULATIVE_COMPACTION));
-        _tablet->update_base_compaction_score(_tablet->calc_compaction_score(CompactionType::BASE_COMPACTION));
     } else {
         _tablet->set_last_base_compaction_success_time(now);
-        _tablet->update_base_compaction_score(_tablet->calc_compaction_score(CompactionType::BASE_COMPACTION));
     }
+
+    _tablet->update_cumulative_compaction_score();
+    _tablet->update_base_compaction_score();
 
     LOG(INFO) << "succeed to do " << compaction_name() << ". tablet=" << _tablet->full_name()
               << ", output_version=" << _output_version.first << "-" << _output_version.second

--- a/be/src/olap/olap_server.cpp
+++ b/be/src/olap/olap_server.cpp
@@ -321,7 +321,7 @@ void StorageEngine::_compaction_tasks_producer_callback() {
         data_dirs.push_back(tmp_store.second);
         _tablet_submitted_compaction[tmp_store.second] = tablet_submitted;
     }
-    _tablet_manager->init_tablet_score();
+    _tablet_manager->update_all_tablets_compaction_score();
 
     int round = 0;
     CompactionType compaction_type;

--- a/be/src/olap/olap_server.cpp
+++ b/be/src/olap/olap_server.cpp
@@ -321,6 +321,7 @@ void StorageEngine::_compaction_tasks_producer_callback() {
         data_dirs.push_back(tmp_store.second);
         _tablet_submitted_compaction[tmp_store.second] = tablet_submitted;
     }
+    _tablet_manager->init_tablet_score();
 
     int round = 0;
     CompactionType compaction_type;

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -761,6 +761,15 @@ const uint32_t Tablet::calc_compaction_score(CompactionType compaction_type) con
     }
 }
 
+const uint32_t Tablet::get_compaction_score(CompactionType compaction_type) {
+    if (compaction_type == CompactionType::CUMULATIVE_COMPACTION) {
+        return _cumulative_compaction_score.value();
+    } else {
+        DCHECK_EQ(compaction_type, CompactionType::BASE_COMPACTION);
+        return _base_compaction_score.value();
+    }
+}
+
 const uint32_t Tablet::_calc_cumulative_compaction_score() const {
     uint32_t score = 0;
     _cumulative_compaction_policy->calc_cumulative_compaction_score(

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -770,6 +770,14 @@ const uint32_t Tablet::get_compaction_score(CompactionType compaction_type) {
     }
 }
 
+void Tablet::update_base_compaction_score() {
+    _base_compaction_score.set_value(calc_compaction_score(CompactionType::BASE_COMPACTION));
+}
+
+void Tablet::update_cumulative_compaction_score() {
+    _cumulative_compaction_score.set_value(calc_compaction_score(CompactionType::CUMULATIVE_COMPACTION));
+}
+
 const uint32_t Tablet::_calc_cumulative_compaction_score() const {
     uint32_t score = 0;
     _cumulative_compaction_policy->calc_cumulative_compaction_score(

--- a/be/src/olap/tablet.h
+++ b/be/src/olap/tablet.h
@@ -165,6 +165,9 @@ public:
     // operation for compaction
     bool can_do_compaction();
     const uint32_t calc_compaction_score(CompactionType compaction_type) const;
+    const uint32_t get_compaction_score(CompactionType compaction_type);
+    void update_base_compaction_score(uint32_t compaction_score) { _base_compaction_score.set_value(compaction_score); }
+    void update_cumulative_compaction_score(uint32_t compaction_score) { _cumulative_compaction_score.set_value(compaction_score); }
     static void compute_version_hash_from_rowsets(const std::vector<RowsetSharedPtr>& rowsets,
                                                   VersionHash* version_hash);
 
@@ -329,6 +332,9 @@ private:
     int64_t _last_record_scan_count;
     // the timestamp of the last record.
     time_t _last_record_scan_count_timestamp;
+
+    UIntGauge _base_compaction_score;
+    UIntGauge _cumulative_compaction_score;
 
     std::shared_ptr<CumulativeCompaction> _cumulative_compaction;
     std::shared_ptr<BaseCompaction> _base_compaction;

--- a/be/src/olap/tablet.h
+++ b/be/src/olap/tablet.h
@@ -166,8 +166,8 @@ public:
     bool can_do_compaction();
     const uint32_t calc_compaction_score(CompactionType compaction_type) const;
     const uint32_t get_compaction_score(CompactionType compaction_type);
-    void update_base_compaction_score(uint32_t compaction_score) { _base_compaction_score.set_value(compaction_score); }
-    void update_cumulative_compaction_score(uint32_t compaction_score) { _cumulative_compaction_score.set_value(compaction_score); }
+    void update_base_compaction_score();
+    void update_cumulative_compaction_score();
     static void compute_version_hash_from_rowsets(const std::vector<RowsetSharedPtr>& rowsets,
                                                   VersionHash* version_hash);
 

--- a/be/src/olap/tablet_manager.h
+++ b/be/src/olap/tablet_manager.h
@@ -69,6 +69,8 @@ public:
 
     OLAPStatus drop_tablets_on_error_root_path(const std::vector<TabletInfo>& tablet_info_vec);
 
+    void init_tablet_score();
+
     TabletSharedPtr find_best_tablet_to_compaction(CompactionType compaction_type,
                                                    DataDir* data_dir,
                                                    vector<TTabletId>& tablet_submitted_compaction);

--- a/be/src/olap/tablet_manager.h
+++ b/be/src/olap/tablet_manager.h
@@ -69,7 +69,7 @@ public:
 
     OLAPStatus drop_tablets_on_error_root_path(const std::vector<TabletInfo>& tablet_info_vec);
 
-    void init_tablet_score();
+    void update_all_tablets_compaction_score();
 
     TabletSharedPtr find_best_tablet_to_compaction(CompactionType compaction_type,
                                                    DataDir* data_dir,
@@ -231,6 +231,9 @@ private:
     std::map<int64_t, TTabletStat> _tablet_stat_cache;
     // last update time of tablet stat cache
     int64_t _last_update_stat_ms;
+
+    // timestamp of last update all tablets' compaction score
+    int64_t _last_update_compaction_score_ms;
 
     tablet_map_t& _get_tablet_map(TTabletId tablet_id);
 

--- a/be/src/olap/task/engine_clone_task.cpp
+++ b/be/src/olap/task/engine_clone_task.cpp
@@ -277,8 +277,8 @@ void EngineCloneTask::_set_tablet_info(AgentStatus status, bool is_new_tablet) {
             _tablet_infos->push_back(tablet_info);
             TabletSharedPtr tablet = StorageEngine::instance()->tablet_manager()->get_tablet(
                     _clone_req.tablet_id, _clone_req.schema_hash);
-            tablet->update_cumulative_compaction_score(tablet->calc_compaction_score(CompactionType::CUMULATIVE_COMPACTION));
-            tablet->update_base_compaction_score(tablet->calc_compaction_score(CompactionType::BASE_COMPACTION));
+            tablet->update_cumulative_compaction_score();
+            tablet->update_base_compaction_score();
         }
     }
     *_res_status = status;

--- a/be/src/olap/task/engine_clone_task.cpp
+++ b/be/src/olap/task/engine_clone_task.cpp
@@ -275,6 +275,10 @@ void EngineCloneTask::_set_tablet_info(AgentStatus status, bool is_new_tablet) {
                       << ", schema_hash:" << _clone_req.schema_hash << ", signature:" << _signature
                       << ", version:" << tablet_info.version;
             _tablet_infos->push_back(tablet_info);
+            TabletSharedPtr tablet = StorageEngine::instance()->tablet_manager()->get_tablet(
+                    _clone_req.tablet_id, _clone_req.schema_hash);
+            tablet->update_cumulative_compaction_score(tablet->calc_compaction_score(CompactionType::CUMULATIVE_COMPACTION));
+            tablet->update_base_compaction_score(tablet->calc_compaction_score(CompactionType::BASE_COMPACTION));
         }
     }
     *_res_status = status;

--- a/be/src/olap/task/engine_publish_version_task.cpp
+++ b/be/src/olap/task/engine_publish_version_task.cpp
@@ -19,6 +19,7 @@
 
 #include <map>
 
+#include "olap/olap_common.h"
 #include "olap/data_dir.h"
 #include "olap/rowset/rowset_meta_manager.h"
 #include "olap/tablet_manager.h"
@@ -109,6 +110,7 @@ OLAPStatus EnginePublishVersionTask::finish() {
                 continue;
             }
             partition_related_tablet_infos.erase(tablet_info);
+            tablet->update_cumulative_compaction_score(tablet->calc_compaction_score(CompactionType::CUMULATIVE_COMPACTION));
             LOG(INFO) << "publish version successfully on tablet. tablet=" << tablet->full_name()
                       << ", transaction_id=" << transaction_id << ", version=" << version.first
                       << ", res=" << publish_status;

--- a/be/src/olap/task/engine_publish_version_task.cpp
+++ b/be/src/olap/task/engine_publish_version_task.cpp
@@ -110,7 +110,7 @@ OLAPStatus EnginePublishVersionTask::finish() {
                 continue;
             }
             partition_related_tablet_infos.erase(tablet_info);
-            tablet->update_cumulative_compaction_score(tablet->calc_compaction_score(CompactionType::CUMULATIVE_COMPACTION));
+            tablet->update_cumulative_compaction_score();
             LOG(INFO) << "publish version successfully on tablet. tablet=" << tablet->full_name()
                       << ", transaction_id=" << transaction_id << ", version=" << version.first
                       << ", res=" << publish_status;


### PR DESCRIPTION
## Proposed changes

Keep tablet `compaction score` in memory to avoid calculating tablet score in every production. After `load`, `clone` and `compaction`，updating the tablet `compaction score`in memory.

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] Documentation Update (if none of the other choices apply)
- [x] Code refactor (Modify the code structure, format the code, etc...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [] I have created an issue on (Fix #ISSUE) and described the bug/feature there in detail
- [x] Compiling and unit tests pass locally with my changes
- [] I have added tests that prove my fix is effective or that my feature works
- [] If these changes need document changes, I have updated the document
- [x] Any dependent changes have been merged

