### PR TITLE
Fix bug that sql with limit query statistics are wrong

### DIFF
--- a/be/src/runtime/query_statistics.cpp
+++ b/be/src/runtime/query_statistics.cpp
@@ -33,7 +33,7 @@ void QueryStatisticsRecvr::insert(const PQueryStatistics& statistics, int sender
     } else {
         query_statistics = iter->second;
     }
-    query_statistics->merge_pb(statistics);
+    query_statistics->from_pb(statistics);
 }
 
 QueryStatisticsRecvr::~QueryStatisticsRecvr() {

--- a/be/src/runtime/query_statistics.h
+++ b/be/src/runtime/query_statistics.h
@@ -65,10 +65,10 @@ public:
         statistics->set_returned_rows(returned_rows);
     }
 
-    void merge_pb(const PQueryStatistics& statistics) {
-        scan_rows += statistics.scan_rows();
-        scan_bytes += statistics.scan_bytes();
-        cpu_ms += statistics.cpu_ms();
+    void from_pb(const PQueryStatistics& statistics) {
+        scan_rows = statistics.scan_rows();
+        scan_bytes = statistics.scan_bytes();
+        cpu_ms = statistics.cpu_ms();
     }
 
 private:


### PR DESCRIPTION
When querying sql is with `limit`, the query statistics will be enlarged by merging the query statistics of each batch.

fix #5340 