### PR TITLE
[Bug] Fix bug that BE core will loading empty json array

### DIFF
--- a/be/src/exec/json_scanner.cpp
+++ b/be/src/exec/json_scanner.cpp
@@ -665,6 +665,11 @@ Status JsonReader::_handle_flat_array_complex_json(Tuple* tuple,
             }
             _total_lines = _json_doc->Size();
             _next_line = 0;
+
+            if (_total_lines == 0) {
+                // meet an empty json array.
+                continue;
+            }
         }
         rapidjson::Value& objectValue = (*_json_doc)[_next_line++];
         if (!_write_values_by_jsonpath(objectValue, tuple_pool, tuple, slot_descs)) {


### PR DESCRIPTION
## Proposed changes

When loading json data like `[]` (an empty array). BE will crash with stack:

```
*** Aborted at 1612273824 (unix time) try "date -d @1612273824" if you are using GNU date ***
PC: @           0xe0cce7 rapidjson::GenericValue<>::Accept<>()
*** SIGSEGV (@0xe) received by PID 36798 (TID 0x7f7812114700) from PID 14; stack trace: ***
    @     0x7f791b74b470 (unknown)
    @           0xe0cce7 rapidjson::GenericValue<>::Accept<>()
    @          0x169ff79 _ZN5doris10JsonReader17_print_json_valueB5cxx11ERKN9rapidjson12GenericValueINS1_4UTF8IcEENS1_19MemoryPoolAllocatorINS1_12CrtAllocatorEEEEE
    @          0x16a0689 doris::JsonReader::_write_values_by_jsonpath()
    @          0x16a2cb4 doris::JsonReader::_handle_flat_array_complex_json()
    @          0x16a3761 doris::JsonScanner::get_next()
    @          0x1659bd4 doris::BrokerScanNode::scanner_scan()
    @          0x165a671 doris::BrokerScanNode::scanner_worker()
    @          0x281f67f execute_native_thread_routine
    @     0x7f791b5001c3 start_thread
    @     0x7f791b7fd12d __clone
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
