### PR TITLE
[Config] Modify compaction policy comment in config.h

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -243,7 +243,7 @@ CONF_mInt64(base_compaction_interval_seconds_since_last_operation, "86400");
 CONF_mInt32(base_compaction_write_mbytes_per_sec, "5");
 
 // config the cumulative compaction policy
-// Valid configs: num_base, size_based
+// Valid configs: num_based, size_based
 // num_based policy, the original version of cumulative compaction, cumulative version compaction once.
 // size_based policy, a optimization version of cumulative compaction, targeting the use cases requiring
 // lower write amplification, trading off read amplification and space amplification.


### PR DESCRIPTION
## Proposed changes

There is a mistake comment for the configure of cumulative_compaction_policy in config.h.  If we want to use `NUM_BASED_POLICY`for cumulative compaction, We should set `num_based` instead of `num_base`as described in the comments for `cumulative_compaction_policy`. Otherwise, there will be a warning entry in log file for each tablet when BE starts, as following:

```
W0203 19:20:42.062183 175162 cumulative_compaction_policy.cpp:464] parse cumulative compaction policy error NUM_BASE, default use NUM_BASED
W0203 19:20:42.062296 175162 cumulative_compaction_policy.cpp:464] parse cumulative compaction policy error NUM_BASE, default use NUM_BASED
W0203 19:20:42.062374 175162 cumulative_compaction_policy.cpp:464] parse cumulative compaction policy error NUM_BASE, default use NUM_BASED
W0203 19:20:42.062439 175162 cumulative_compaction_policy.cpp:464] parse cumulative compaction policy error NUM_BASE, default use NUM_BASED
W0203 19:20:42.062508 175162 cumulative_compaction_policy.cpp:464] parse cumulative compaction policy error NUM_BASE, default use NUM_BASED
W0203 19:20:42.062588 175162 cumulative_compaction_policy.cpp:464] parse cumulative compaction policy error NUM_BASE, default use NUM_BASED
W0203 19:20:42.062660 175162 cumulative_compaction_policy.cpp:464] parse cumulative compaction policy error NUM_BASE, default use NUM_BASED
W0203 19:20:42.062729 175162 cumulative_compaction_policy.cpp:464] parse cumulative compaction policy error NUM_BASE, default use NUM_BASED
W0203 19:20:42.062798 175162 cumulative_compaction_policy.cpp:464] parse cumulative compaction policy error NUM_BASE, default use NUM_BASED
W0203 19:20:42.062855 175162 cumulative_compaction_policy.cpp:464] parse cumulative compaction policy error NUM_BASE, default use NUM_BASED
W0203 19:20:42.062933 175162 cumulative_compaction_policy.cpp:464] parse cumulative compaction policy error NUM_BASE, default use NUM_BASED
W0203 19:20:42.063000 175162 cumulative_compaction_policy.cpp:464] parse cumulative compaction policy error NUM_BASE, default use NUM_BASED
W0203 19:20:42.063063 175162 cumulative_compaction_policy.cpp:464] parse cumulative compaction policy error NUM_BASE, default use NUM_BASED
W0203 19:20:42.063140 175162 cumulative_compaction_policy.cpp:464] parse cumulative compaction policy error NUM_BASE, default use NUM_BASED
W0203 19:20:42.063213 175162 cumulative_compaction_policy.cpp:464] parse cumulative compaction policy error NUM_BASE, default use NUM_BASED
W0203 19:20:42.063269 175162 cumulative_compaction_policy.cpp:464] parse cumulative compaction policy error NUM_BASE, default use NUM_BASED
W0203 19:20:42.063323 175162 cumulative_compaction_policy.cpp:464] parse cumulative compaction policy error NUM_BASE, default use NUM_BASED
W0203 19:20:42.063395 175162 cumulative_compaction_policy.cpp:464] parse cumulative compaction policy error NUM_BASE, default use NUM_BASED
W0203 19:20:42.063470 175162 cumulative_compaction_policy.cpp:464] parse cumulative compaction policy error NUM_BASE, default use NUM_BASED
W0203 19:20:42.063529 175162 cumulative_compaction_policy.cpp:464] parse cumulative compaction policy error NUM_BASE, default use NUM_BASED
W0203 19:20:42.063581 175162 cumulative_compaction_policy.cpp:464] parse cumulative compaction policy error NUM_BASE, default use NUM_BASED
W0203 19:20:42.063635 175162 cumulative_compaction_policy.cpp:464] parse cumulative compaction policy error NUM_BASE, default use NUM_BASED
```
