### PR TITLE
[Bug] Fix the problem of floating point precision when importing parquet data

### DIFF
--- a/be/src/exec/orc_scanner.cpp
+++ b/be/src/exec/orc_scanner.cpp
@@ -230,7 +230,7 @@ Status ORCScanner::get_next(Tuple* tuple, MemPool* tuple_pool, bool* eof) {
                     case orc::FLOAT:
                     case orc::DOUBLE: {
                         double value = ((orc::DoubleVectorBatch*)cvb)->data[_current_line_of_group];
-                        wbytes = sprintf((char*)tmp_buf, "%f", value);
+                        wbytes = sprintf((char*)tmp_buf, "%.9f", value);
                         str_slot->ptr = reinterpret_cast<char*>(tuple_pool->allocate(wbytes));
                         memcpy(str_slot->ptr, tmp_buf, wbytes);
                         str_slot->len = wbytes;

--- a/be/src/exec/parquet_reader.cpp
+++ b/be/src/exec/parquet_reader.cpp
@@ -425,7 +425,10 @@ Status ParquetReaderWrap::read(Tuple* tuple, const std::vector<SlotDescriptor*>&
                     RETURN_IF_ERROR(set_field_null(tuple, slot_desc));
                 } else {
                     float value = float_array->Value(_current_line_of_batch);
-                    wbytes = sprintf((char*)tmp_buf, "%f", value);
+                    // Because the decimal type currently only supports (27, 9).
+                    // Therefore, we use %.9f to give priority to the progress of the decimal type.
+                    // Cannot use %f directly, this will cause 4000.9 to be converted to 4000.8999
+                    wbytes = sprintf((char*)tmp_buf, "%.9f", value);
                     fill_slot(tuple, slot_desc, mem_pool, tmp_buf, wbytes);
                 }
                 break;
@@ -436,8 +439,8 @@ Status ParquetReaderWrap::read(Tuple* tuple, const std::vector<SlotDescriptor*>&
                 if (double_array->IsNull(_current_line_of_batch)) {
                     RETURN_IF_ERROR(set_field_null(tuple, slot_desc));
                 } else {
-                    float value = double_array->Value(_current_line_of_batch);
-                    wbytes = sprintf((char*)tmp_buf, "%f", value);
+                    double value = double_array->Value(_current_line_of_batch);
+                    wbytes = sprintf((char*)tmp_buf, "%.9f", value);
                     fill_slot(tuple, slot_desc, mem_pool, tmp_buf, wbytes);
                 }
                 break;


### PR DESCRIPTION
The double data "4206.9" in parquet is converted to decimal data "4206.8999" in Doris,
which is not right.