### PR TITLE
[Bug] Fix bug of NPE when replaying spark load job.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/SparkResource.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/SparkResource.java
@@ -27,17 +27,16 @@ import org.apache.doris.common.proc.BaseProcResult;
 import org.apache.doris.load.loadv2.SparkRepository;
 import org.apache.doris.load.loadv2.SparkYarnConfigFiles;
 
-import com.google.common.base.Preconditions;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.gson.annotations.SerializedName;
+
 import java.io.File;
 import java.util.Map;
-
-import com.google.gson.annotations.SerializedName;
 
 /**
  * Spark resource for etl or query.
@@ -109,8 +108,9 @@ public class SparkResource extends Resource {
         this(name, Maps.newHashMap(), null, null, Maps.newHashMap());
     }
 
-    private SparkResource(String name, Map<String, String> sparkConfigs, String workingDir, String broker,
-                          Map<String, String> brokerProperties) {
+    // "public" for testing
+    public SparkResource(String name, Map<String, String> sparkConfigs, String workingDir, String broker,
+                         Map<String, String> brokerProperties) {
         super(name, ResourceType.SPARK);
         this.sparkConfigs = sparkConfigs;
         this.workingDir = workingDir;

--- a/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/SparkLoadJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/SparkLoadJob.java
@@ -168,23 +168,23 @@ public class SparkLoadJob extends BulkLoadJob {
      * @throws DdlException
      */
     private void setResourceInfo() throws DdlException {
-        // spark resource
         if (resourceDesc == null) {
             // resourceDesc is null means this is a replay thread.
             // And resourceDesc is not persisted, so it should be null.
-            // And sparkResource should not be null because it is persisted.
-            Preconditions.checkNotNull(sparkResource);
-        } else {
-            String resourceName = resourceDesc.getName();
-            Resource oriResource = Catalog.getCurrentCatalog().getResourceMgr().getResource(resourceName);
-            if (oriResource == null) {
-                throw new DdlException("Resource does not exist. name: " + resourceName);
-            }
-            sparkResource = ((SparkResource) oriResource).getCopiedResource();
-            sparkResource.update(resourceDesc);
+            // sparkResource and brokerDesc are both persisted, so no need to handle them
+            // in replay process.
+            return;
         }
 
-        // broker desc
+        // set sparkResource and brokerDesc
+        String resourceName = resourceDesc.getName();
+        Resource oriResource = Catalog.getCurrentCatalog().getResourceMgr().getResource(resourceName);
+        if (oriResource == null) {
+            throw new DdlException("Resource does not exist. name: " + resourceName);
+        }
+        sparkResource = ((SparkResource) oriResource).getCopiedResource();
+        sparkResource.update(resourceDesc);
+
         Map<String, String> brokerProperties = sparkResource.getBrokerPropertiesWithoutPrefix();
         brokerDesc = new BrokerDesc(sparkResource.getBroker(), brokerProperties);
     }


### PR DESCRIPTION
## Proposed changes

The resourceDesc in spark load job may be null because it is not persisted.
So when replaying the job, we should check it.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)