### PR TITLE
[bug] Support if not exists in create table like stmt

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateTableLikeStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateTableLikeStmt.java
@@ -45,7 +45,7 @@ public class CreateTableLikeStmt extends DdlStmt {
         this.existedTableName = existedTableName;
     }
 
-    public boolean isSetIfNotExists() {
+    public boolean isIfNotExists() {
         return ifNotExists;
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateTableStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateTableStmt.java
@@ -169,6 +169,8 @@ public class CreateTableStmt extends DdlStmt {
 
     public void addColumnDef(ColumnDef columnDef) { columnDefs.add(columnDef); }
 
+    public void setIfNotExists(boolean ifNotExists) { this.ifNotExists = ifNotExists; }
+
     public boolean isSetIfNotExists() {
         return ifNotExists;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Catalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Catalog.java
@@ -3024,6 +3024,7 @@ public class Catalog {
             }
             CreateTableStmt parsedCreateTableStmt = (CreateTableStmt) SqlParserUtils.parseAndAnalyzeStmt(createTableStmt.get(0), ConnectContext.get());
             parsedCreateTableStmt.setTableName(stmt.getTableName());
+            parsedCreateTableStmt.setIfNotExists(stmt.isIfNotExists());
             createTable(parsedCreateTableStmt);
         } catch (UserException e) {
             throw new DdlException("Failed to execute CREATE TABLE LIKE " + stmt.getExistedTableName() + ". Reason: " + e.getMessage());

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/CreateTableLikeTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/CreateTableLikeTest.java
@@ -218,6 +218,21 @@ public class CreateTableLikeTest {
         String newTblName8 = "testMysqlTbl_like";
         String existedTblName8 = "testMysqlTbl";
         checkCreateMysqlTableLike(createNonOlapTableSql, createTableLikeSql8, newDbName8, existedDbName8, newTblName8, existedTblName8);
+
+        // 9. test if not exist
+        String createTableLikeSql9 = "create table test.testMysqlTbl_like like test.testMysqlTbl";
+        try {
+            createTableLike(createTableLikeSql9);
+            Assert.fail();
+        } catch (Exception e) {
+            Assert.assertTrue(e.getMessage().contains("already exists"));
+        }
+        createTableLikeSql9 = "create table if not exists test.testMysqlTbl_like like test.testMysqlTbl";
+        try {
+            createTableLike(createTableLikeSql9);
+        } catch (Exception e) {
+            Assert.fail(e.getMessage());
+        }
     }
 
     @Test


### PR DESCRIPTION
## Proposed changes

Currently we support syntax `create table xx if not exists like xxx`, but `if not exists` does not work well.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)