### PR TITLE
[Bug][Cache] Version should not be considered when find the latest partition

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/cache/CacheAnalyzer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/cache/CacheAnalyzer.java
@@ -416,8 +416,7 @@ public class CacheAnalyzer {
         CacheTable table = new CacheTable();
         table.olapTable = olapTable;
         for (Partition partition : olapTable.getPartitions()) {
-            if (partition.getVisibleVersionTime() >= table.latestTime &&
-                    partition.getVisibleVersion() > table.latestVersion) {
+            if (partition.getVisibleVersionTime() >= table.latestTime) {
                 table.latestPartitionId = partition.getId();
                 table.latestTime = partition.getVisibleVersionTime();
                 table.latestVersion = partition.getVisibleVersion();


### PR DESCRIPTION
## Proposed changes

When a table has multiple partitions, each partition has it's own
version, the version doesn't represent whether it's newer or not. When a
partition has a larger version, it may be considered as the latest one
currently, this will cause incorrect query result.
Suppose there are 2 partitions:
```
PartitionName | VisibleVersion |  VisibleVersionTime
p1            |            123 | 2021-02-17 23:31:32
p2            |             23 | 2021-02-22 11:39:19
```
Partition p1 will be considered as the lastest partition, and there is a
cache before p2's last update time, the cache will hit and return an
error result.

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] Documentation Update (if none of the other choices apply)
- [] Code refactor (Modify the code structure, format the code, etc...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [] I have created an issue on (Fix #ISSUE) and described the bug/feature there in detail
- [x] Compiling and unit tests pass locally with my changes
- [] I have added tests that prove my fix is effective or that my feature works
- [] If these changes need document changes, I have updated the document
- [] Any dependent changes have been merged
