### PR TITLE
Column Pruning under count start

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/AggregateInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/AggregateInfo.java
@@ -745,8 +745,7 @@ public final class AggregateInfo extends AggregateInfoBase {
         materializedSlots_.clear();
         List<Expr> exprs = Lists.newArrayList();
         exprs.addAll(groupingExprs_);
-     
-        boolean hasCountStar = false;
+        
         int aggregateExprsSize = aggregateExprs_.size();
         int groupExprsSize = groupingExprs_.size();
         boolean isDistinctAgg = isDistinctAgg();
@@ -761,10 +760,6 @@ public final class AggregateInfo extends AggregateInfoBase {
                 intermediateSlotDesc.setIsMaterialized(true);
             }
             
-            if (functionCallExpr.isCountStar()) {
-                hasCountStar = true;
-            }
-            
             if (!slotDesc.isMaterialized()) continue;
             
             intermediateSlotDesc.setIsMaterialized(true);
@@ -773,14 +768,6 @@ public final class AggregateInfo extends AggregateInfoBase {
         }
         
         List<Expr> resolvedExprs = Expr.substituteList(exprs, smap, analyzer, false);
-        
-        // In order to meet the requirements materialize slots In the top-down phase 
-        // over query statements, if aggregate functions contain count(*), now 
-        // materialize all slots this SelectStmt maps.
-        // chenhao added.
-        if (hasCountStar && smap != null && smap.size() > 0) {
-            resolvedExprs.addAll(smap.getRhs());
-        } 
         analyzer.materializeSlots(resolvedExprs);
 
         if (isDistinctAgg()) {

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/SingleNodePlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/SingleNodePlanner.java
@@ -1889,13 +1889,14 @@ public class SingleNodePlanner {
 
     /**
      * When materialized table ref is a empty tbl ref, the planner should add a mini column for this tuple.
-     * There are two situation:
+     * There are situations:
      * 1. The tbl ref is empty, such as select a from (select 'c1' a from test) t;
      * Inner tuple: tuple 0 without slot
      * 2. The materialized slot in tbl ref is empty, such as select a from (select 'c1' a, k1 from test) t;
      * Inner tuple: tuple 0 with a not materialized slot k1
      * In the above two cases, it is necessary to add a mini column to the inner tuple
      * to ensure that the number of rows in the inner query result is the number of rows in the table.
+     * 2. count star: select count(*) from t;
      * <p>
      * After this function, the inner tuple is following:
      * case1. tuple 0: slot<k1> materialized true (new slot)
@@ -1927,7 +1928,13 @@ public class SingleNodePlanner {
     }
 
     /**
-     * materialize InlineViewRef result'exprs for Cross Join or Count Star
+     * Materialize InlineViewRef result'exprs for Cross Join or Count Star
+     * For example: select count(*) from (select k1+1 ,k2 ,k3 from base) tmp
+     * Columns: k1 tinyint, k2 bigint, k3 double
+     * Input: tmp, analyzer
+     * Output:
+     *   Materialized slot: k1 true, k2 false, k3 false
+     *   Materialized tuple: base
      *
      * @param inlineView
      * @param analyzer
@@ -1950,7 +1957,7 @@ public class SingleNodePlanner {
                 if (!slot.isMaterialized()) {
                     exprIsMaterialized = false;
                 }
-                exprSize += slot.getByteSize();
+                exprSize += slot.getType().getSlotSize();
             }
 
             // Result Expr contains materialized expr, return
@@ -1958,7 +1965,7 @@ public class SingleNodePlanner {
                 return;
             }
 
-            if (exprSize <= resultExprSelectedSize) {
+            if (resultExprSelected == null || exprSize < resultExprSelectedSize) {
                 resultExprSelectedSize = exprSize;
                 resultExprSelected = e;
             }


### PR DESCRIPTION
## Proposed changes

When there is count(*) function in query, we only need to scan the smallest column.
For example:
Query: select count(*) from (select k1, k2, k3 from base) tmp;
Only k1 which is the smallest column should be scanned.
The remaining columns (k2, k3) should be pruning.

This pr achieves this optimazation of column pruning.
Fixed #5409

Change-Id: Ie6fefe3e54f1c311bcdb35919da09668a8be5b3e

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [] Bugfix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] Documentation Update (if none of the other choices apply)
- [] Code refactor (Modify the code structure, format the code, etc...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have created an issue on (Fix ##5409) and described the bug/feature there in detail
- [x] Compiling and unit tests pass locally with my changes
- [] I have added tests that prove my fix is effective or that my feature works
- [] If these changes need document changes, I have updated the document
- [] Any dependent changes have been merged
