### PR TITLE
[Bug-Fix][Bitmap][Be] Resolve bitmap_not calculate wrong result(#5440)

### DIFF
--- a/be/src/util/bitmap_value.h
+++ b/be/src/util/bitmap_value.h
@@ -1035,7 +1035,9 @@ public:
                     case EMPTY:
                         break;
                     case SINGLE:
-                        remove(rhs._sv);
+                        if (rhs._bitmap.contains(_sv)) {
+                            _type = EMPTY;
+                        }
                         break;
                     case BITMAP:
                         _bitmap -= rhs._bitmap;

--- a/be/test/exprs/bitmap_function_test.cpp
+++ b/be/test/exprs/bitmap_function_test.cpp
@@ -358,6 +358,15 @@ TEST_F(BitmapFunctionsTest, bitmap_not) {
     result = BitmapFunctions::bitmap_count(ctx, bitmap_str);
     expected = BigIntVal(0);
     ASSERT_EQ(expected, result);
+
+    bitmap1 = BitmapValue({1});
+    bitmap2 = BitmapValue({2, 1});
+
+    bitmap_src = convert_bitmap_to_string(ctx, bitmap1);
+    bitmap_dst = convert_bitmap_to_string(ctx, bitmap2);
+    bitmap_str = BitmapFunctions::bitmap_not(ctx, bitmap_src, bitmap_dst);
+    result = BitmapFunctions::bitmap_count(ctx, bitmap_str);
+    ASSERT_EQ(expected, result);
 }
 
 TEST_F(BitmapFunctionsTest, bitmap_contains) {


### PR DESCRIPTION
## Proposed changes
fix #5440 

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] Documentation Update (if none of the other choices apply)
- [] Code refactor (Modify the code structure, format the code, etc...)

## Checklist
- [] I have created an issue on (Fix #ISSUE) and described the bug/feature there in detail
- [x] Compiling and unit tests pass locally with my changes
- [] I have added tests that prove my fix is effective or that my feature works
- [] If these changes need document changes, I have updated the document
- [] Any dependent changes have been merged

## Further comments
None