### PR TITLE
[Outfile] Support exporting query result to local disk

### DIFF
--- a/be/src/runtime/result_sink.cpp
+++ b/be/src/runtime/result_sink.cpp
@@ -79,7 +79,7 @@ Status ResultSink::prepare(RuntimeState* state) {
     case TResultSinkType::FILE:
         CHECK(_file_opts.get() != nullptr);
         _writer.reset(new (std::nothrow)
-                              FileResultWriter(_file_opts.get(), _output_expr_ctxs, _profile));
+                              FileResultWriter(_file_opts.get(), _output_expr_ctxs, _profile, _sender.get()));
         break;
     default:
         return Status::InternalError("Unknown result sink type");

--- a/be/src/runtime/result_writer.h
+++ b/be/src/runtime/result_writer.h
@@ -38,7 +38,7 @@ public:
 
     virtual Status close() = 0;
 
-    int64_t get_written_rows() const { return _written_rows; }
+    virtual int64_t get_written_rows() const { return _written_rows; }
 
     static const std::string NULL_IN_CSV;
 

--- a/docs/en/administrator-guide/outfile.md
+++ b/docs/en/administrator-guide/outfile.md
@@ -160,20 +160,22 @@ WITH BROKER `broker_name`
 4. Example 4
 
     Export simple query results to the file `cos://${bucket_name}/path/result.txt`. Specify the export format as CSV.
+    And create a mark file after export finished.
     
     ```
-   select k1,k2,v1 from tbl1 limit 100000
-   into outfile "s3a://my_bucket/export/my_file_"
-   FORMAT AS CSV
-   PROPERTIES
-   (
+    select k1,k2,v1 from tbl1 limit 100000
+    into outfile "s3a://my_bucket/export/my_file_"
+    FORMAT AS CSV
+    PROPERTIES
+    (
        "broker.name" = "hdfs_broker",
        "broker.fs.s3a.access.key" = "xxx",
        "broker.fs.s3a.secret.key" = "xxxx",
        "broker.fs.s3a.endpoint" = "https://cos.xxxxxx.myqcloud.com/",
        "column_separator" = ",",
        "line_delimiter" = "\n",
-       "max_file_size" = "1024MB"
+       "max_file_size" = "1024MB",
+       "success_file_name" = "SUCCESS"
     )
     ```
     
@@ -188,19 +190,30 @@ WITH BROKER `broker_name`
 ## Return result
 
 The command is a synchronization command. The command returns, which means the operation is over.
+At the same time, a row of results will be returned to show the exported execution result.
 
 If it exports and returns normally, the result is as follows:
 
 ```
-mysql> SELECT * FROM tbl INTO OUTFILE ...                                                                                                                                                                                                                                                                  Query OK, 100000 row affected (5.86 sec)
+mysql> select * from tbl1 limit 10 into outfile "file:///home/work/path/result_";
++------------+-----------+----------+--------------+
+| FileNumber | TotalRows | FileSize | URL          |
++------------+-----------+----------+--------------+
+|          1 |         2 |        8 | 192.168.1.10 |
++------------+-----------+----------+--------------+
+1 row in set (0.05 sec)
 ```
 
-`100000 row affected` Indicates the size of the exported result set.
+* FileNumber: The number of files finally generated.
+* TotalRows: The number of rows in the result set.
+* FileSize: The total size of the exported file. Unit byte.
+* URL: If it is exported to a local disk, the Compute Node to which it is exported is displayed here.
 
 If the execution is incorrect, an error message will be returned, such as:
 
 ```
-mysql> SELECT * FROM tbl INTO OUTFILE ...                                                                                                                                                                                                                                                                  ERROR 1064 (HY000): errCode = 2, detailMessage = Open broker writer failed ...
+mysql> SELECT * FROM tbl INTO OUTFILE ...
+ERROR 1064 (HY000): errCode = 2, detailMessage = Open broker writer failed ...
 ```
 
 ## Notice

--- a/fe/fe-core/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/Config.java
@@ -1349,4 +1349,10 @@ public class Config extends ConfigBase {
      */
     @ConfField(mutable = true, masterOnly = true)
     public static boolean enable_access_file_without_broker = false;
+
+    /**
+     * Whether to allow the outfile function to export the results to the local disk.
+     */
+    @ConfField
+    public static boolean enable_outfile_to_local = false;
 }

--- a/gensrc/thrift/DataSinks.thrift
+++ b/gensrc/thrift/DataSinks.thrift
@@ -48,6 +48,7 @@ struct TResultFileSinkOptions {
     5: optional i64 max_file_size_bytes
     6: optional list<Types.TNetworkAddress> broker_addresses; // only for remote file
     7: optional map<string, string> broker_properties // only for remote file
+    8: optional string success_file_name
 }
 
 struct TMemoryScratchSink {


### PR DESCRIPTION
## Proposed changes

1.
User can export query result to local disk like:

`select * from tbl into outfile ("file:///disk1/result_");`

And modify the return result to show the details of export:

```
mysql> select * from tbl1 limit 10 into outfile "file:///home/work/path/result_";
+------------+-----------+----------+--------------+
| FileNumber | TotalRows | FileSize | URL          |
+------------+-----------+----------+--------------+
|          1 |         2 |        8 | 192.168.1.10 |
+------------+-----------+----------+--------------+
```

2.
Support create a mark file after export successfully finished.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)
- [x] Code refactor (Modify the code structure, format the code, etc...)

## Checklist

- [x] I have created an issue on (Fix #5490) and described the bug/feature there in detail