### PR TITLE
[Improve] Support set multi variables in SET_VAR

### DIFF
--- a/docs/en/administrator-guide/variables.md
+++ b/docs/en/administrator-guide/variables.md
@@ -94,7 +94,7 @@ The SET_VAR hint sets the session value of a system variable temporarily (for th
 
 ```
 SELECT /*+ SET_VAR(exec_mem_limit = 8589934592) */ name FROM people ORDER BY name;
-SELECT /*+ SET_VAR(query_timeout = 1) */ sleep(3);
+SELECT /*+ SET_VAR(query_timeout = 1, enable_partition_cache=true) */ sleep(3);
 ```
 
 Note that the comment must start with /*+ and can only follow the SELECT.

--- a/docs/zh-CN/administrator-guide/variables.md
+++ b/docs/zh-CN/administrator-guide/variables.md
@@ -92,7 +92,7 @@ SET forward_to_master = concat('tr', 'u', 'e');
 
 ```
 SELECT /*+ SET_VAR(exec_mem_limit = 8589934592) */ name FROM people ORDER BY name;
-SELECT /*+ SET_VAR(query_timeout = 1) */ sleep(3);
+SELECT /*+ SET_VAR(query_timeout = 1, enable_partition_cache=true) */ sleep(3);
 ```
 
 注意注释必须以/*+ 开头，并且只能跟随在SELECT之后。

--- a/fe/fe-core/src/main/cup/sql_parser.cup
+++ b/fe/fe-core/src/main/cup/sql_parser.cup
@@ -385,7 +385,7 @@ nonterminal InlineViewRef inline_view_ref;
 nonterminal JoinOperator join_operator;
 nonterminal ArrayList<String> opt_plan_hints;
 nonterminal ArrayList<String> opt_sort_hints;
-nonterminal HashMap<String, String> opt_select_hints;
+nonterminal HashMap<String, String> select_hints_list, opt_select_hints;
 nonterminal Expr sign_chain_expr;
 nonterminal Qualifier opt_set_qualifier;
 nonterminal Operation set_op;
@@ -3400,11 +3400,23 @@ select_clause ::=
     :}
     ;
 
-opt_select_hints ::=
-    COMMENTED_PLAN_HINT_START KW_SET_VAR LPAREN ident_or_text:k EQUAL literal:v RPAREN COMMENTED_PLAN_HINT_END
+select_hints_list ::=
+    select_hints_list:map COMMA ident_or_text:k EQUAL literal:v
+    {:
+        map.put(k, v.getStringValue());
+        RESULT = map;
+    :}
+    | ident_or_text:k EQUAL literal:v
     {:
         HashMap<String, String> map = new HashMap<String, String>();
         map.put(k, v.getStringValue());
+        RESULT = map;
+    :}
+    ;
+
+opt_select_hints ::=
+    COMMENTED_PLAN_HINT_START KW_SET_VAR LPAREN select_hints_list:map RPAREN COMMENTED_PLAN_HINT_END
+    {:
         RESULT = map;
     :}
     | /* empty */

--- a/fe/fe-core/src/main/cup/sql_parser.cup
+++ b/fe/fe-core/src/main/cup/sql_parser.cup
@@ -467,7 +467,8 @@ nonterminal GroupByClause group_by_clause, grouping_elements;
 //
 nonterminal String keyword, ident, ident_or_text, variable_name, text_or_password,
         charset_name_or_default, old_or_new_charset_name_or_default, opt_collate,
-        collation_name_or_default, type_func_name_keyword, type_function_name, opt_file_format, time_unit;
+        collation_name_or_default, type_func_name_keyword, type_function_name, opt_file_format, time_unit,
+        literal_or_ident;
 
 nonterminal String opt_db, procedure_or_function, opt_comment, opt_engine;
 nonterminal ColumnDef.DefaultValue opt_default_value;
@@ -3401,16 +3402,27 @@ select_clause ::=
     ;
 
 select_hints_list ::=
-    select_hints_list:map COMMA ident_or_text:k EQUAL literal:v
+    select_hints_list:map COMMA variable_name:k equal literal_or_ident:v
     {:
-        map.put(k, v.getStringValue());
+        map.put(k, v);
         RESULT = map;
     :}
-    | ident_or_text:k EQUAL literal:v
+    | variable_name:k equal literal_or_ident:v
     {:
         HashMap<String, String> map = new HashMap<String, String>();
-        map.put(k, v.getStringValue());
+        map.put(k, v);
         RESULT = map;
+    :}
+    ;
+
+literal_or_ident ::=
+    literal:l
+    {:
+        RESULT = l.getStringValue();
+    :}
+    | ident:i
+    {:
+        RESULT = i;
     :}
     ;
 

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectContext.java
@@ -141,6 +141,11 @@ public class ConnectContext {
         queryDetail = null;
     }
 
+    // Just for unit test
+    public void resetSessionVariables() {
+        sessionVariable = VariableMgr.newSessionVariable();
+    }
+
     public long getStmtId() {
         return stmtId;
     }

--- a/fe/fe-core/src/test/java/org/apache/doris/planner/QueryPlanTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/planner/QueryPlanTest.java
@@ -1471,6 +1471,28 @@ public class QueryPlanTest {
         Assert.assertTrue(explainString.contains("PREDICATES: `query_time` < 1614614400, `query_time` >= 0"));
         
     }
+
+    @Test
+    public void testSetVarInQueryStmt() throws Exception {
+        connectContext.setDatabase("default_cluster:test");
+        connectContext.resetSessionVariables();
+        try {
+            String sql = "select /*+ SET_VAR(query_timeout=1) */ 1;";
+            UtFrameUtils.getSQLPlanOrErrorMsg(connectContext, "EXPLAIN " + sql);
+            Assert.assertEquals(1, connectContext.getSessionVariable().getQueryTimeoutS());
+
+            sql = "select /*+ SET_VAR(query_timeout=10, enable_partition_cache=true, prefer_join_method=shuffle," +
+                    " sql_mode=STRICT_TRANS_TABLES) */ 1;";
+            UtFrameUtils.getSQLPlanOrErrorMsg(connectContext, "EXPLAIN " + sql);
+            Assert.assertEquals(10, connectContext.getSessionVariable().getQueryTimeoutS());
+            Assert.assertEquals(true, connectContext.getSessionVariable().isEnablePartitionCache());
+            Assert.assertEquals("shuffle", connectContext.getSessionVariable().getPreferJoinMethod());
+            Assert.assertEquals(2097152, connectContext.getSessionVariable().getSqlMode());
+        } finally {
+            connectContext.resetSessionVariables();
+        }
+    }
 }
+
 
 


### PR DESCRIPTION
## Proposed changes

Sometimes we need to set multi variables for a single query stmt. like:

SELECT /* SER_VAR(var1=xx, var2=xx) */ ...

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have created an issue on (Fix #5512 ) and described the bug/feature there in detail