### PR TITLE
Use O_SYNC instead of O_DIRECT to be fs agnostic.

### DIFF
--- a/be/src/olap/utils.cpp
+++ b/be/src/olap/utils.cpp
@@ -732,7 +732,7 @@ OLAPStatus read_write_test_file(const string& test_file_path) {
     }
     OLAPStatus res = OLAP_SUCCESS;
     FileHandler file_handler;
-    if ((res = file_handler.open_with_mode(test_file_path.c_str(), O_RDWR | O_CREAT | O_DIRECT,
+    if ((res = file_handler.open_with_mode(test_file_path.c_str(), O_RDWR | O_CREAT | O_SYNC,
                                            S_IRUSR | S_IWUSR)) != OLAP_SUCCESS) {
         LOG(WARNING) << "fail to create test file. path=" << test_file_path;
         return res;


### PR DESCRIPTION
## Proposed changes

Some fs might not support O_DIRECT and O_SYNC is semantically the same to be used for disk checking.