### PR TITLE
 [Bug] Fix bug that the stale rowset file will not be deleted

### DIFF
--- a/be/src/olap/schema_change.cpp
+++ b/be/src/olap/schema_change.cpp
@@ -1478,7 +1478,8 @@ OLAPStatus SchemaChangeHandler::_do_process_alter_tablet_v2(const TAlterTabletRe
                 rowsets_to_delete.push_back(rowset);
             }
         }
-        new_tablet->modify_rowsets(std::vector<RowsetSharedPtr>(), rowsets_to_delete);
+        std::vector<RowsetSharedPtr> empty_vec;
+        new_tablet->modify_rowsets(empty_vec, rowsets_to_delete);
         // inherit cumulative_layer_point from base_tablet
         // check if new_tablet.ce_point > base_tablet.ce_point?
         new_tablet->set_cumulative_layer_point(-1);

--- a/be/src/olap/tablet.h
+++ b/be/src/olap/tablet.h
@@ -95,8 +95,8 @@ public:
 
     // operation in rowsets
     OLAPStatus add_rowset(RowsetSharedPtr rowset, bool need_persist = true);
-    void modify_rowsets(const vector<RowsetSharedPtr>& to_add,
-                        const vector<RowsetSharedPtr>& to_delete);
+    void modify_rowsets(vector<RowsetSharedPtr>& to_add,
+                        vector<RowsetSharedPtr>& to_delete);
 
     // _rs_version_map and _stale_rs_version_map should be protected by _meta_lock
     // The caller must call hold _meta_lock when call this two function.

--- a/be/src/olap/tablet_meta.cpp
+++ b/be/src/olap/tablet_meta.cpp
@@ -499,7 +499,8 @@ void TabletMeta::delete_rs_meta_by_version(const Version& version,
 }
 
 void TabletMeta::modify_rs_metas(const std::vector<RowsetMetaSharedPtr>& to_add,
-                                 const std::vector<RowsetMetaSharedPtr>& to_delete) {
+                                 const std::vector<RowsetMetaSharedPtr>& to_delete,
+                                 bool same_version) {
     // Remove to_delete rowsets from _rs_metas
     for (auto rs_to_del : to_delete) {
         auto it = _rs_metas.begin();
@@ -516,8 +517,10 @@ void TabletMeta::modify_rs_metas(const std::vector<RowsetMetaSharedPtr>& to_add,
             }
         }
     }
-    // put to_delete rowsets in _stale_rs_metas.
-    _stale_rs_metas.insert(_stale_rs_metas.end(), to_delete.begin(), to_delete.end());
+    if (!same_version) {
+        // put to_delete rowsets in _stale_rs_metas.
+        _stale_rs_metas.insert(_stale_rs_metas.end(), to_delete.begin(), to_delete.end());
+    }
     // put to_add rowsets in _rs_metas.
     _rs_metas.insert(_rs_metas.end(), to_add.begin(), to_add.end());
 }

--- a/be/src/olap/tablet_meta.h
+++ b/be/src/olap/tablet_meta.h
@@ -167,8 +167,11 @@ public:
     OLAPStatus add_rs_meta(const RowsetMetaSharedPtr& rs_meta);
     void delete_rs_meta_by_version(const Version& version,
                                    std::vector<RowsetMetaSharedPtr>* deleted_rs_metas);
+    // If same_version is true, the rowset in "to_delete" will not be added
+    // to _stale_rs_meta, but to be deleted from rs_meta directly.
     void modify_rs_metas(const std::vector<RowsetMetaSharedPtr>& to_add,
-                         const std::vector<RowsetMetaSharedPtr>& to_delete);
+                         const std::vector<RowsetMetaSharedPtr>& to_delete,
+                         bool same_version = false);
     void revise_rs_metas(std::vector<RowsetMetaSharedPtr>&& rs_metas);
 
     inline const std::vector<RowsetMetaSharedPtr>& all_stale_rs_metas() const;

--- a/be/src/olap/version_graph.cpp
+++ b/be/src/olap/version_graph.cpp
@@ -284,7 +284,7 @@ void TimestampedVersionTracker::recover_versioned_tracker(
         }
         _path_map_iter++;
     }
-    LOG(INFO) << "recover_versioned_tracker current map info " << _get_current_path_map_str();
+    LOG(INFO) << "recover_versioned_tracker current map info " << get_current_path_map_str();
 }
 
 void TimestampedVersionTracker::add_version(const Version& version) {
@@ -354,7 +354,7 @@ PathVersionListSharedPtr TimestampedVersionTracker::fetch_and_delete_path_by_id(
         return nullptr;
     }
 
-    VLOG_NOTICE << _get_current_path_map_str();
+    VLOG_NOTICE << get_current_path_map_str();
     PathVersionListSharedPtr ptr = fetch_path_version_by_id(path_id);
 
     _stale_version_path_map.erase(path_id);
@@ -365,7 +365,7 @@ PathVersionListSharedPtr TimestampedVersionTracker::fetch_and_delete_path_by_id(
     return ptr;
 }
 
-std::string TimestampedVersionTracker::_get_current_path_map_str() {
+std::string TimestampedVersionTracker::get_current_path_map_str() {
     std::stringstream tracker_info;
     tracker_info << "current expired next_path_id " << _next_path_id << std::endl;
 

--- a/be/src/olap/version_graph.h
+++ b/be/src/olap/version_graph.h
@@ -171,7 +171,7 @@ public:
     PathVersionListSharedPtr fetch_and_delete_path_by_id(int64_t path_id);
 
     /// Print all expired version path in a tablet.
-    std::string _get_current_path_map_str();
+    std::string get_current_path_map_str();
 
     /// Get json document of _stale_version_path_map. Fill the path_id and version_path
     /// list in the document. The parameter path arr is used as return variable.

--- a/fe/fe-core/src/main/java/org/apache/doris/common/proc/BackendProcNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/proc/BackendProcNode.java
@@ -66,7 +66,7 @@ public class BackendProcNode implements ProcNodeInterface {
             long totalB = entry.getValue().getTotalCapacityB();
             Pair<Double, String> totalUnitPair = DebugUtil.getByteUint(totalB);
             // other
-            long otherB = totalB - availB;
+            long otherB = totalB - availB - dataUsedB;
             Pair<Double, String> otherUnitPair = DebugUtil.getByteUint(otherB);
 
             info.add(DebugUtil.DECIMAL_FORMAT_SCALE_3.format(otherUnitPair.first) + " " + otherUnitPair.second);


### PR DESCRIPTION
## Proposed changes

1. If cumulative compaction compact only one rowset, the old rowset will not be put into `stale_rowset_meta_map`

2. Show rowset id in `/api/compaction/show`

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have created an issue on (Fix #5526 ) and described the bug/feature there in detail