### PR TITLE
turn on glibc compatibility by default for upgrading gcc10

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -135,7 +135,7 @@ if [[ -z ${WITH_MYSQL} ]]; then
     WITH_MYSQL=OFF
 fi
 if [[ -z ${GLIBC_COMPATIBILITY} ]]; then
-    GLIBC_COMPATIBILITY=OFF
+    GLIBC_COMPATIBILITY=ON
 fi
 if [[ -z ${WITH_LZO} ]]; then
     WITH_LZO=OFF

--- a/run-be-ut.sh
+++ b/run-be-ut.sh
@@ -107,7 +107,7 @@ if [ ! -d ${CMAKE_BUILD_DIR} ]; then
 fi
 
 if [[ -z ${GLIBC_COMPATIBILITY} ]]; then
-    GLIBC_COMPATIBILITY=OFF
+    GLIBC_COMPATIBILITY=ON
 fi
 
 cd ${CMAKE_BUILD_DIR}


### PR DESCRIPTION
## Proposed changes

turn on glibc compatibility by default for upgrading gcc10, because gcc10's glibc is too new

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Code refactor (Modify the code structure, format the code, etc...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have created an issue on (Fix #ISSUE) and described the bug/feature there in detail
- [ ] Compiling and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If these changes need document changes, I have updated the document
- [ ] Any dependent changes have been merged

## Further comments

If this is a relatively large or complex change, kick off the discussion at dev@doris.apache.org by explaining why you chose the solution you did and what alternatives you considered, etc...
