### PR TITLE
[Colocate plan][Step2] Colocate aggregation covers more situations

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/AggregateInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/AggregateInfo.java
@@ -807,8 +807,16 @@ public final class AggregateInfo extends AggregateInfoBase {
     }
 
     @Override
-    protected String tupleDebugName() { return "agg-tuple"; }
+    protected String tupleDebugName() {
+        return "agg-tuple";
+    }
 
     @Override
-    public AggregateInfo clone() { return new AggregateInfo(this); }
+    public AggregateInfo clone() {
+        return new AggregateInfo(this);
+    }
+
+    public List<Expr> getInputPartitionExprs() {
+        return partitionExprs_ != null ? partitionExprs_ : groupingExprs_;
+    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/Expr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/Expr.java
@@ -1364,6 +1364,27 @@ abstract public class Expr extends TreeNode<Expr> implements ParseNode, Cloneabl
         return sourceExpr.get(0).getSrcSlotRef();
     }
 
+    public boolean comeFrom(Expr srcExpr) {
+        SlotRef unwrapSloRef = this.unwrapSlotRef();
+        if (unwrapSloRef == null) {
+            return false;
+        }
+        SlotRef unwrapSrcSlotRef = srcExpr.unwrapSlotRef();
+        if (unwrapSrcSlotRef == null) {
+            return false;
+        }
+        if (unwrapSloRef.columnEqual(unwrapSrcSlotRef)) {
+            return true;
+        }
+        // check source expr
+        SlotDescriptor slotDescriptor = unwrapSloRef.getDesc();
+        if (slotDescriptor == null || slotDescriptor.getSourceExprs() == null
+                || slotDescriptor.getSourceExprs().size() != 1) {
+            return false;
+        }
+        return slotDescriptor.getSourceExprs().get(0).comeFrom(unwrapSrcSlotRef);
+    }
+
     /**
      * If 'this' is a SlotRef or a Cast that wraps a SlotRef, returns that SlotRef.
      * Otherwise returns null.

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/SlotRef.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/SlotRef.java
@@ -123,6 +123,43 @@ public class SlotRef extends Expr {
         this.desc = desc;
     }
 
+    public boolean columnEqual(Expr srcExpr) {
+        Preconditions.checkState(srcExpr instanceof SlotRef);
+        SlotRef srcSlotRef = (SlotRef) srcExpr;
+        if (desc != null && srcSlotRef.desc != null) {
+            return desc.getId().equals(srcSlotRef.desc.getId());
+        }
+        TableName srcTableName = srcSlotRef.tblName;
+        if (srcTableName == null && srcSlotRef.desc != null) {
+            srcTableName = srcSlotRef.getTableName();
+        }
+        TableName thisTableName = tblName;
+        if (thisTableName == null && desc != null) {
+            thisTableName = getTableName();
+        }
+        if ((thisTableName == null) != (srcTableName == null)) {
+            return false;
+        }
+        if (thisTableName != null && !thisTableName.equals(srcTableName)) {
+            return false;
+        }
+        String srcColumnName = srcSlotRef.getColumnName();
+        if (srcColumnName == null && srcSlotRef.desc != null && srcSlotRef.getDesc().getColumn() != null) {
+            srcColumnName = srcSlotRef.desc.getColumn().getName();
+        }
+        String thisColumnName = getColumnName();
+        if (thisColumnName == null && desc != null && desc.getColumn() != null) {
+            thisColumnName = desc.getColumn().getName();
+        }
+        if ((thisColumnName == null) != (srcColumnName == null)) {
+            return false;
+        }
+        if (thisColumnName != null && !thisColumnName.toLowerCase().equals(srcColumnName.toLowerCase())) {
+            return false;
+        }
+        return true;
+    }
+
     @Override
     public void vectorizedAnalyze(Analyzer analyzer) {
         computeOutputColumn(analyzer);

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/DataPartition.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/DataPartition.java
@@ -24,12 +24,14 @@ import org.apache.doris.common.AnalysisException;
 import org.apache.doris.thrift.TDataPartition;
 import org.apache.doris.thrift.TExplainLevel;
 import org.apache.doris.thrift.TPartitionType;
+
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
-import org.apache.logging.log4j.Logger;
+
 import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.List;
 

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/DistributedPlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/DistributedPlanner.java
@@ -480,11 +480,7 @@ public class DistributedPlanner {
 
     /**
      * Colocate Join can be performed when the following 4 conditions are met at the same time.
-<<<<<<< HEAD
      * 1. Session variables disable_colocate_plan = false
-=======
-     * 1. Session variables disable_colocate_plan = true
->>>>>>> 26f4e1fa8 ([Colocate plan][Step1] Colocate join covers more situations)
      * 2. There is no join hints in HashJoinNode
      * 3. There are no exchange node between source scan node and HashJoinNode.
      * 4. The scan nodes which are related by EqConjuncts in HashJoinNode are colocate and group can be matched.
@@ -986,13 +982,13 @@ public class DistributedPlanner {
 
     /**
      * Colocate Agg can be performed when the following 2 conditions are met at the same time.
-     * 1. Session variables disable_colocate_plan = true
+     * 1. Session variables disable_colocate_plan = false
      * 2. The input data partition of child fragment < agg node partition exprs
      */
     private boolean canColocateAgg(AggregateInfo aggregateInfo, List<DataPartition> childFragmentDataPartition) {
         // Condition1
         if (ConnectContext.get().getSessionVariable().isDisableColocatePlan()) {
-            LOG.info("Agg node is not colocate in:" + ConnectContext.get().getQueryDetail().getQueryId()
+            LOG.debug("Agg node is not colocate in:" + ConnectContext.get().getQueryDetail().getQueryId()
                     + ", reason:" + DistributedPlanColocateRule.SESSION_DISABLED);
             return false;
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/DistributedPlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/DistributedPlanner.java
@@ -475,7 +475,11 @@ public class DistributedPlanner {
 
     /**
      * Colocate Join can be performed when the following 4 conditions are met at the same time.
+<<<<<<< HEAD
      * 1. Session variables disable_colocate_plan = false
+=======
+     * 1. Session variables disable_colocate_plan = true
+>>>>>>> 26f4e1fa8 ([Colocate plan][Step1] Colocate join covers more situations)
      * 2. There is no join hints in HashJoinNode
      * 3. There are no exchange node between source scan node and HashJoinNode.
      * 4. The scan nodes which are related by EqConjuncts in HashJoinNode are colocate and group can be matched.
@@ -542,8 +546,10 @@ public class DistributedPlanner {
         }
     }
 
-    private boolean dataDistributionMatchEqPredicate(Map<Pair<OlapScanNode, OlapScanNode>,
-            List<BinaryPredicate>> scanNodeWithJoinConjuncts, List<String> cannotReason) {
+    private boolean dataDistributionMatchEqPredicate(Map<Pair<OlapScanNode, OlapScanNode>, List<BinaryPredicate>> scanNodeWithJoinConjuncts,
+                                                     List<String> cannotReason) {
+        // If left table and right table is same table and they select same single partition or no partition
+        // they are naturally colocate relationship no need to check colocate group
         for (Map.Entry<Pair<OlapScanNode, OlapScanNode>, List<BinaryPredicate>> entry : scanNodeWithJoinConjuncts.entrySet()) {
             OlapScanNode leftScanNode = entry.getKey().first;
             OlapScanNode rightScanNode = entry.getKey().second;
@@ -842,6 +848,7 @@ public class DistributedPlanner {
         }
 
         // There is at least one partitioned child fragment.
+        // TODO(ML): here
         PlanFragment setOperationFragment = new PlanFragment(ctx_.getNextFragmentId(), setOperationNode,
                 DataPartition.RANDOM);
         for (int i = 0; i < childFragments.size(); ++i) {
@@ -964,6 +971,7 @@ public class DistributedPlanner {
         } else {
             // Check table's distribution. See #4481.
             PlanNode childPlan = childFragment.getPlanRoot();
+            // TODO(ML): here
             if (childPlan instanceof OlapScanNode &&
                     ((OlapScanNode) childPlan).getOlapTable().meetAggDistributionRequirements(node.getAggInfo())) {
                 childFragment.addPlanRoot(node);
@@ -1204,6 +1212,7 @@ public class DistributedPlanner {
             // required if the sort partition exprs reference a tuple that is made nullable in
             // 'childFragment' to bring NULLs from outer-join non-matches together.
             DataPartition sortPartition = sortNode.getInputPartition();
+            // TODO(ML): here
             if (!childFragment.getDataPartition().equals(sortPartition)) {
                 // TODO(zc) || childFragment.refsNullableTupleId(sortPartition.getPartitionExprs())) {
                 analyticFragment = createParentFragment(childFragment, sortNode.getInputPartition());

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/OlapScanNode.java
@@ -775,7 +775,7 @@ public class OlapScanNode extends ScanNode {
         return expr instanceof SlotRef;
     }
 
-    private void filterDeletedRows(Analyzer analyzer) throws AnalysisException{
+    private void filterDeletedRows(Analyzer analyzer) throws AnalysisException {
         if (!Util.showHiddenColumns() && olapTable.hasDeleteSign()) {
             SlotRef deleteSignSlot = new SlotRef(desc.getAliasAsName(), Column.DELETE_SIGN);
             deleteSignSlot.analyze(analyzer);
@@ -784,5 +784,17 @@ public class OlapScanNode extends ScanNode {
             conjunct.analyze(analyzer);
             conjuncts.add(conjunct);
         }
+    }
+
+    public DataPartition constructInputPartitionByDistributionInfo() {
+        DistributionInfo distributionInfo = olapTable.getDefaultDistributionInfo();
+        Preconditions.checkState(distributionInfo instanceof HashDistributionInfo);
+        List<Column> distributeColumns = ((HashDistributionInfo) distributionInfo).getDistributionColumns();
+        List<Expr> dataDistributeExprs = Lists.newArrayList();
+        for (Column column : distributeColumns) {
+            SlotRef slotRef = new SlotRef(desc.getRef().getName(), column.getName());
+            dataDistributeExprs.add(slotRef);
+        }
+        return DataPartition.hashPartitioned(dataDistributeExprs);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/PlanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/PlanNode.java
@@ -645,7 +645,7 @@ abstract public class PlanNode extends TreeNode<PlanNode> {
         sb.append("\n").append(getNodeExplainString("", TExplainLevel.BRIEF));
         return sb.toString();
     }
-    
+
     public ScanNode getScanNodeInOneFragmentByTupleId(TupleId tupleId) {
         if (this instanceof ScanNode && tupleIds.contains(tupleId)) {
             return (ScanNode) this;

--- a/fe/fe-core/src/test/java/org/apache/doris/planner/ColocatePlanTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/planner/ColocatePlanTest.java
@@ -56,7 +56,6 @@ public class ColocatePlanTest {
         Catalog.getCurrentCatalog().createTable(createTableStmt);
     }
 
-
     @AfterClass
     public static void tearDown() {
         File file = new File(runningDir);

--- a/fe/fe-core/src/test/java/org/apache/doris/planner/OlapScanNodeTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/planner/OlapScanNodeTest.java
@@ -17,14 +17,6 @@
 
 package org.apache.doris.planner;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-
-import org.junit.Assert;
-import org.junit.Test;
-
 import org.apache.doris.analysis.Expr;
 import org.apache.doris.analysis.InPredicate;
 import org.apache.doris.analysis.IntLiteral;
@@ -34,8 +26,17 @@ import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.PartitionKey;
 import org.apache.doris.catalog.PrimitiveType;
 import org.apache.doris.common.AnalysisException;
+
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.Test;
 
 public class OlapScanNodeTest {    
     // columnA in (1) hashmode=3
@@ -157,6 +158,21 @@ public class OlapScanNodeTest {
             long hashValue = hashKey.getHashValue();
             long mod = (int) ((hashValue & 0xffffffff) % 3);
             Assert.assertEquals(mod, 2);
-        } 
+        }
     }
+
+//    @Test
+//    public void testConstructInputPartitionByDistributionInfo(@Injectable OlapTable olapTable,
+//                                                              @Injectable TupleDescriptor tupleDescriptor) {
+//        PlanNodeId planNodeId = new PlanNodeId(1);
+//        OlapScanNode olapScanNode = new OlapScanNode(planNodeId, tupleDescriptor, "scan node");
+//        Deencapsulation.setField(olapScanNode, "olapTable", olapTable);
+//        new Expectations() {
+//            {
+//                olapTable.getDefaultDistributionInfo();
+//                result =
+//            }
+//        };
+//        olapScanNode.constructInputPartitionByDistributionInfo();
+//    }
 }


### PR DESCRIPTION
## Proposed changes

[Colocate plan][Step2] Colocate aggregation covers more situations

    The old colocate aggregation can only cover the case where the child is scan.
    In fact, as long as the child's data distribution meets the requirements,
      no matter what the plan node on the child node is, a colocate aggregation can be performed.

    This PR also fixes the correct data partition attribute of fragment.
    The data partition of fragment which contains scan node is Hash Partition rather than Random.
    This modification is mainly to determine the possibility of colocate
      through the correct distribution of child fragments.

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Code refactor (Modify the code structure, format the code, etc...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have created an issue on (Fix #5589) and described the bug/feature there in detail
- [x] Compiling and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If these changes need document changes, I have updated the document
- [ ] Any dependent changes have been merged

## Further comments

unit test is coming.
