### PR TITLE
optimize cumulative compaction point calculate when after restart be

### DIFF
--- a/be/src/olap/cumulative_compaction_policy.cpp
+++ b/be/src/olap/cumulative_compaction_policy.cpp
@@ -83,7 +83,7 @@ void SizeBasedCumulativeCompactionPolicy::calculate_cumulative_point(
 
         bool is_delete = tablet->version_for_delete_predicate(rs->version());
 
-        // break the loop if segments in this rowset is overlapping, or is a singleton.
+        // break the loop if segments in this rowset is overlapping.
         if (!is_delete && rs->is_segments_overlapping()) {
             *ret_cumulative_point = rs->version().first;
             break;
@@ -95,6 +95,7 @@ void SizeBasedCumulativeCompactionPolicy::calculate_cumulative_point(
             break;
         }
 
+        // include one satuation: When the segment is not deleted, and is singleton delta, and is NONOVERLAPPING, ret_cumulative_point cumulate 
         prev_version = rs->version().second;
         *ret_cumulative_point = prev_version + 1;
     }

--- a/be/src/olap/cumulative_compaction_policy.cpp
+++ b/be/src/olap/cumulative_compaction_policy.cpp
@@ -84,7 +84,7 @@ void SizeBasedCumulativeCompactionPolicy::calculate_cumulative_point(
         bool is_delete = tablet->version_for_delete_predicate(rs->version());
 
         // break the loop if segments in this rowset is overlapping, or is a singleton.
-        if (!is_delete && (rs->is_segments_overlapping() || rs->is_singleton_delta())) {
+        if (!is_delete && rs->is_segments_overlapping()) {
             *ret_cumulative_point = rs->version().first;
             break;
         }

--- a/be/src/olap/cumulative_compaction_policy.cpp
+++ b/be/src/olap/cumulative_compaction_policy.cpp
@@ -95,7 +95,7 @@ void SizeBasedCumulativeCompactionPolicy::calculate_cumulative_point(
             break;
         }
 
-        // include one satuation: When the segment is not deleted, and is singleton delta, and is NONOVERLAPPING, ret_cumulative_point increase 
+        // include one situation: When the segment is not deleted, and is singleton delta, and is NONOVERLAPPING, ret_cumulative_point increase 
         prev_version = rs->version().second;
         *ret_cumulative_point = prev_version + 1;
     }

--- a/be/src/olap/cumulative_compaction_policy.cpp
+++ b/be/src/olap/cumulative_compaction_policy.cpp
@@ -95,7 +95,7 @@ void SizeBasedCumulativeCompactionPolicy::calculate_cumulative_point(
             break;
         }
 
-        // include one satuation: When the segment is not deleted, and is singleton delta, and is NONOVERLAPPING, ret_cumulative_point cumulate 
+        // include one satuation: When the segment is not deleted, and is singleton delta, and is NONOVERLAPPING, ret_cumulative_point increase 
         prev_version = rs->version().second;
         *ret_cumulative_point = prev_version + 1;
     }


### PR DESCRIPTION
## Proposed changes

This pr is to reduce a large number of useless cumulative compactions caused by cumulative compaction point calculation problems after be restarts.

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Code refactor (Modify the code structure, format the code, etc...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have created an issue on (Fix #5556) and described the bug/feature there in detail
- [x] Compiling and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If these changes need document changes, I have updated the document
- [ ] Any dependent changes have been merged

## Further comments

If this is a relatively large or complex change, kick off the discussion at dev@doris.apache.org by explaining why you chose the solution you did and what alternatives you considered, etc...
