### PR TITLE
[FE] [BUG] GroupingFunctionCallExpr: realChildren should be copied too.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/GroupingFunctionCallExpr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/GroupingFunctionCallExpr.java
@@ -49,6 +49,9 @@ public class GroupingFunctionCallExpr extends FunctionCallExpr {
     public GroupingFunctionCallExpr(GroupingFunctionCallExpr other) {
         super(other);
         this.childrenReseted = other.childrenReseted;
+        if (this.childrenReseted) {
+            this.realChildren = Expr.cloneList(other.realChildren);
+        }
     }
 
     @Override


### PR DESCRIPTION
## Proposed changes

realChildren should be copied too when children was reseted. #5583 

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Code refactor (Modify the code structure, format the code, etc...)

## Checklist

- [x] I have created an issue on (Fix #5583) and described the bug/feature there in detail
- [ ] Compiling and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If these changes need document changes, I have updated the document
- [ ] Any dependent changes have been merged
