### PR TITLE
[Metrics][LOG] Update metrics of 'max_compaction_score' and log for compaction

### DIFF
--- a/be/src/olap/compaction.cpp
+++ b/be/src/olap/compaction.cpp
@@ -133,6 +133,7 @@ OLAPStatus Compaction::do_compaction_impl(int64_t permits) {
 
     LOG(INFO) << "succeed to do " << compaction_name() << ". tablet=" << _tablet->full_name()
               << ", output_version=" << _output_version.first << "-" << _output_version.second
+              << ", current_max_version=" << _tablet->rowset_with_max_version()->end_version()
               << ", segments=" << segments_num << ". elapsed time=" << watch.get_elapse_second()
               << "s.";
 

--- a/be/src/olap/compaction.cpp
+++ b/be/src/olap/compaction.cpp
@@ -134,8 +134,8 @@ OLAPStatus Compaction::do_compaction_impl(int64_t permits) {
     LOG(INFO) << "succeed to do " << compaction_name() << ". tablet=" << _tablet->full_name()
               << ", output_version=" << _output_version.first << "-" << _output_version.second
               << ", current_max_version=" << _tablet->rowset_with_max_version()->end_version()
-              << ", segments=" << segments_num << ". elapsed time=" << watch.get_elapse_second()
-              << "s.";
+              << ", disk=" << _tablet->data_dir()->path() << ", segments=" << segments_num
+              << ". elapsed time=" << watch.get_elapse_second() << "s.";
 
     return OLAP_SUCCESS;
 }

--- a/be/src/olap/olap_server.cpp
+++ b/be/src/olap/olap_server.cpp
@@ -386,6 +386,7 @@ void StorageEngine::_compaction_tasks_producer_callback() {
 std::vector<TabletSharedPtr> StorageEngine::_compaction_tasks_generator(
         CompactionType compaction_type, std::vector<DataDir*> data_dirs) {
     std::vector<TabletSharedPtr> tablets_compaction;
+    uint32_t max_compaction_score = 0;
     std::random_shuffle(data_dirs.begin(), data_dirs.end());
     for (auto data_dir : data_dirs) {
         std::unique_lock<std::mutex> lock(_tablet_submitted_compaction_mutex);
@@ -393,11 +394,20 @@ std::vector<TabletSharedPtr> StorageEngine::_compaction_tasks_generator(
             continue;
         }
         if (!data_dir->reach_capacity_limit(0)) {
+            uint32_t disk_max_score = 0;
             TabletSharedPtr tablet = _tablet_manager->find_best_tablet_to_compaction(
-                    compaction_type, data_dir, _tablet_submitted_compaction[data_dir]);
+                    compaction_type, data_dir, _tablet_submitted_compaction[data_dir], disk_max_score);
             if (tablet != nullptr) {
                 tablets_compaction.emplace_back(tablet);
+                max_compaction_score = disk_max_score > max_compaction_score ? disk_max_score : max_compaction_score;
             }
+        }
+    }
+    if (tablets_compaction.size() > 0) {
+        if (compaction_type == CompactionType::BASE_COMPACTION) {
+            DorisMetrics::instance()->tablet_base_max_compaction_score->set_value(max_compaction_score);
+        } else {
+            DorisMetrics::instance()->tablet_cumulative_max_compaction_score->set_value(max_compaction_score);
         }
     }
     return tablets_compaction;

--- a/be/src/olap/olap_server.cpp
+++ b/be/src/olap/olap_server.cpp
@@ -396,7 +396,7 @@ std::vector<TabletSharedPtr> StorageEngine::_compaction_tasks_generator(
         if (!data_dir->reach_capacity_limit(0)) {
             uint32_t disk_max_score = 0;
             TabletSharedPtr tablet = _tablet_manager->find_best_tablet_to_compaction(
-                    compaction_type, data_dir, _tablet_submitted_compaction[data_dir], disk_max_score);
+                    compaction_type, data_dir, _tablet_submitted_compaction[data_dir], &disk_max_score);
             if (tablet != nullptr) {
                 tablets_compaction.emplace_back(tablet);
                 max_compaction_score = std::max(max_compaction_score, disk_max_score);

--- a/be/src/olap/olap_server.cpp
+++ b/be/src/olap/olap_server.cpp
@@ -399,11 +399,11 @@ std::vector<TabletSharedPtr> StorageEngine::_compaction_tasks_generator(
                     compaction_type, data_dir, _tablet_submitted_compaction[data_dir], disk_max_score);
             if (tablet != nullptr) {
                 tablets_compaction.emplace_back(tablet);
-                max_compaction_score = disk_max_score > max_compaction_score ? disk_max_score : max_compaction_score;
+                max_compaction_score = std::max(max_compaction_score, disk_max_score);
             }
         }
     }
-    if (tablets_compaction.size() > 0) {
+    if (!tablets_compaction.empty()) {
         if (compaction_type == CompactionType::BASE_COMPACTION) {
             DorisMetrics::instance()->tablet_base_max_compaction_score->set_value(max_compaction_score);
         } else {

--- a/be/src/olap/tablet_manager.cpp
+++ b/be/src/olap/tablet_manager.cpp
@@ -681,7 +681,7 @@ void TabletManager::get_tablet_stat(TTabletStatResult* result) {
 
 TabletSharedPtr TabletManager::find_best_tablet_to_compaction(
         CompactionType compaction_type, DataDir* data_dir,
-        std::vector<TTabletId>& tablet_submitted_compaction) {
+        std::vector<TTabletId>& tablet_submitted_compaction, uint32_t& score) {
     int64_t now_ms = UnixMillis();
     const string& compaction_type_str =
             compaction_type == CompactionType::BASE_COMPACTION ? "base" : "cumulative";
@@ -776,14 +776,7 @@ TabletSharedPtr TabletManager::find_best_tablet_to_compaction(
                 << ", compaction_score=" << compaction_score
                 << ", tablet_scan_frequency=" << tablet_scan_frequency
                 << ", highest_score=" << highest_score;
-        // TODO(lingbin): Remove 'max' from metric name, it would be misunderstood as the
-        // biggest in history(like peak), but it is really just the value at current moment.
-        if (compaction_type == CompactionType::BASE_COMPACTION) {
-            DorisMetrics::instance()->tablet_base_max_compaction_score->set_value(compaction_score);
-        } else {
-            DorisMetrics::instance()->tablet_cumulative_max_compaction_score->set_value(
-                    compaction_score);
-        }
+        score = compaction_score;
     }
     return best_tablet;
 }

--- a/be/src/olap/tablet_manager.cpp
+++ b/be/src/olap/tablet_manager.cpp
@@ -681,7 +681,7 @@ void TabletManager::get_tablet_stat(TTabletStatResult* result) {
 
 TabletSharedPtr TabletManager::find_best_tablet_to_compaction(
         CompactionType compaction_type, DataDir* data_dir,
-        std::vector<TTabletId>& tablet_submitted_compaction, uint32_t& score) {
+        std::vector<TTabletId>& tablet_submitted_compaction, uint32_t* score) {
     int64_t now_ms = UnixMillis();
     const string& compaction_type_str =
             compaction_type == CompactionType::BASE_COMPACTION ? "base" : "cumulative";
@@ -776,7 +776,7 @@ TabletSharedPtr TabletManager::find_best_tablet_to_compaction(
                 << ", compaction_score=" << compaction_score
                 << ", tablet_scan_frequency=" << tablet_scan_frequency
                 << ", highest_score=" << highest_score;
-        score = compaction_score;
+        *score = compaction_score;
     }
     return best_tablet;
 }

--- a/be/src/olap/tablet_manager.h
+++ b/be/src/olap/tablet_manager.h
@@ -71,7 +71,7 @@ public:
 
     TabletSharedPtr find_best_tablet_to_compaction(CompactionType compaction_type,
                                                    DataDir* data_dir,
-                                                   vector<TTabletId>& tablet_submitted_compaction);
+                                                   vector<TTabletId>& tablet_submitted_compaction, uint32_t& score);
 
     TabletSharedPtr get_tablet(TTabletId tablet_id, SchemaHash schema_hash,
                                bool include_deleted = false, std::string* err = nullptr);

--- a/be/src/olap/tablet_manager.h
+++ b/be/src/olap/tablet_manager.h
@@ -72,7 +72,7 @@ public:
     TabletSharedPtr find_best_tablet_to_compaction(CompactionType compaction_type,
                                                    DataDir* data_dir,
                                                    vector<TTabletId>& tablet_submitted_compaction,
-                                                   uint32_t& score);
+                                                   uint32_t* score);
 
     TabletSharedPtr get_tablet(TTabletId tablet_id, SchemaHash schema_hash,
                                bool include_deleted = false, std::string* err = nullptr);

--- a/be/src/olap/tablet_manager.h
+++ b/be/src/olap/tablet_manager.h
@@ -71,7 +71,8 @@ public:
 
     TabletSharedPtr find_best_tablet_to_compaction(CompactionType compaction_type,
                                                    DataDir* data_dir,
-                                                   vector<TTabletId>& tablet_submitted_compaction, uint32_t& score);
+                                                   vector<TTabletId>& tablet_submitted_compaction,
+                                                   uint32_t& score);
 
     TabletSharedPtr get_tablet(TTabletId tablet_id, SchemaHash schema_hash,
                                bool include_deleted = false, std::string* err = nullptr);


### PR DESCRIPTION
## Proposed changes

1. Update metrics of `tablet_base_max_compaction_score` and `tablet_cumulative_max_compaction_score`. This two metrics should show `max compaction score` for base comapction and cumulative compaction after a round of task production in BE.
2. Update log to show current max version after each compaction task finished so that we can see whether compaction can keep up with data load.

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [x] Code refactor (Modify the code structure, format the code, etc...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have created an issue on (Fix #ISSUE) and described the bug/feature there in detail
- [x] Compiling and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If these changes need document changes, I have updated the document
- [x] Any dependent changes have been merged
