### PR TITLE
[Metrics] Add some large memtrackers' metric

### DIFF
--- a/be/src/olap/schema_change.h
+++ b/be/src/olap/schema_change.h
@@ -182,7 +182,10 @@ private:
 
 class SchemaChangeHandler {
 public:
-    static SchemaChangeHandler* instance() { return &_s_instance; }
+    static SchemaChangeHandler* instance() {
+        static SchemaChangeHandler instance;
+        return &instance;
+    }
 
     OLAPStatus schema_version_convert(TabletSharedPtr base_tablet, TabletSharedPtr new_tablet,
                                       RowsetSharedPtr* base_rowset, RowsetSharedPtr* new_rowset);
@@ -242,13 +245,12 @@ private:
                                            const TabletColumn& column_schema,
                                            const std::string& value);
 private:
-    SchemaChangeHandler() : _mem_tracker(MemTracker::CreateTracker(-1, "SchemaChange")) {}
-    virtual ~SchemaChangeHandler() {}
+    SchemaChangeHandler();
+    virtual ~SchemaChangeHandler();
     SchemaChangeHandler(const SchemaChangeHandler&) = delete;
     SchemaChangeHandler& operator=(const SchemaChangeHandler&) = delete;
 
     std::shared_ptr<MemTracker> _mem_tracker;
-    static SchemaChangeHandler _s_instance;
 };
 
 using RowBlockDeleter = std::function<void(RowBlock*)>;

--- a/be/src/olap/tablet_manager.h
+++ b/be/src/olap/tablet_manager.h
@@ -47,9 +47,7 @@ class DataDir;
 class TabletManager {
 public:
     TabletManager(int32_t tablet_map_lock_shard_size);
-    ~TabletManager() {
-        _mem_tracker->Release(_mem_tracker->consumption());
-    }
+    ~TabletManager();
 
     bool check_tablet_id_exist(TTabletId tablet_id);
 

--- a/be/src/runtime/exec_env_init.cpp
+++ b/be/src/runtime/exec_env_init.cpp
@@ -66,6 +66,8 @@ namespace doris {
 
 DEFINE_GAUGE_METRIC_PROTOTYPE_2ARG(scanner_thread_pool_queue_size, MetricUnit::NOUNIT);
 DEFINE_GAUGE_METRIC_PROTOTYPE_2ARG(etl_thread_pool_queue_size, MetricUnit::NOUNIT);
+DEFINE_GAUGE_METRIC_PROTOTYPE_5ARG(query_mem_consumption, MetricUnit::BYTES, "",
+                                   mem_consumption, Labels({{"type", "query"}}));
 
 Status ExecEnv::init(ExecEnv* env, const std::vector<StorePath>& store_paths) {
     return env->_init(store_paths);
@@ -199,6 +201,10 @@ Status ExecEnv::_init_mem_tracker() {
     int32_t index_page_cache_percentage = config::index_page_cache_percentage;
     StoragePageCache::create_global_cache(storage_cache_limit, index_page_cache_percentage);
 
+    REGISTER_HOOK_METRIC(query_mem_consumption, [this]() {
+      return _mem_tracker->consumption();
+    });
+
     // TODO(zc): The current memory usage configuration is a bit confusing,
     // we need to sort out the use of memory
     return Status::OK();
@@ -260,6 +266,9 @@ void ExecEnv::_destroy() {
     SAFE_DELETE(_routine_load_task_executor);
     SAFE_DELETE(_external_scan_context_mgr);
     SAFE_DELETE(_heartbeat_flags);
+
+    DEREGISTER_HOOK_METRIC(query_mem_consumption);
+
     _is_init = false;
 }
 

--- a/be/src/util/doris_metrics.h
+++ b/be/src/util/doris_metrics.h
@@ -173,7 +173,11 @@ public:
     UIntGauge* brpc_endpoint_stub_count;
     UIntGauge* tablet_writer_count;
 
-    UIntGauge* compaction_mem_current_consumption;
+    UIntGauge* compaction_mem_consumption;
+    UIntGauge* load_mem_consumption;
+    UIntGauge* query_mem_consumption;
+    UIntGauge* schema_change_mem_consumption;
+    UIntGauge* tablet_meta_mem_consumption;
 
     // Cache metrics
     UIntGauge* query_cache_memory_total_byte;

--- a/be/src/util/metrics.h
+++ b/be/src/util/metrics.h
@@ -283,6 +283,9 @@ public:
 #define DEFINE_GAUGE_METRIC_PROTOTYPE_3ARG(name, unit, desc) \
     DEFINE_METRIC_PROTOTYPE(name, MetricType::GAUGE, unit, desc, "", Labels(), false)
 
+#define DEFINE_GAUGE_METRIC_PROTOTYPE_5ARG(name, unit, desc, group, labels) \
+    DEFINE_METRIC_PROTOTYPE(name, MetricType::GAUGE, unit, desc, #group, labels, false)
+
 #define INT_COUNTER_METRIC_REGISTER(entity, metric) \
     metric = (IntCounter*)(entity->register_metric<IntCounter>(&METRIC_##metric))
 

--- a/be/test/exec/hash_table_test.cpp
+++ b/be/test/exec/hash_table_test.cpp
@@ -40,6 +40,7 @@
 #include "util/cpu_info.h"
 #include "util/runtime_profile.h"
 #include "util/time.h"
+#include "test_util/test_util.h"
 
 namespace doris {
 
@@ -309,7 +310,7 @@ TEST_F(HashTableTest, ScanTest) {
 // This test continues adding to the hash table to trigger the resize code paths
 TEST_F(HashTableTest, GrowTableTest) {
     int build_row_val = 0;
-    int num_to_add = 4;
+    int num_to_add = LOOP_LESS_OR_MORE(2, 4);
     int expected_size = 0;
 
     std::shared_ptr<MemTracker> mem_tracker =
@@ -321,8 +322,7 @@ TEST_F(HashTableTest, GrowTableTest) {
                          mem_tracker, num_buckets);
     EXPECT_FALSE(mem_tracker->limit_exceeded());
 
-    // This inserts about 5M entries
-    for (int i = 0; i < 20; ++i) {
+    for (int i = 0; i < LOOP_LESS_OR_MORE(1, 20); ++i) {
         for (int j = 0; j < num_to_add; ++build_row_val, ++j) {
             hash_table.insert(create_tuple_row(build_row_val));
         }
@@ -333,7 +333,7 @@ TEST_F(HashTableTest, GrowTableTest) {
     }
     LOG(INFO) << "consume:" << mem_tracker->consumption() << ",expected_size:" << expected_size;
 
-    EXPECT_TRUE(mem_tracker->limit_exceeded());
+    EXPECT_EQ(LOOP_LESS_OR_MORE(0, 1), mem_tracker->limit_exceeded());
 
     // Validate that we can find the entries
     for (int i = 0; i < expected_size * 5; i += 100000) {

--- a/be/test/exprs/topn_function_test.cpp
+++ b/be/test/exprs/topn_function_test.cpp
@@ -136,7 +136,8 @@ void test_topn_accuracy(FunctionContext* ctx, int key_space, int space_expand_ra
     topn_dst->sort_retain(TOPN_NUM, &topn_sort_vec);
 
     uint32_t error = 0;
-    for (uint32_t i = 0; i < TOPN_NUM; ++i) {
+    int min_size = std::min(accuracy_sort_vec.size(), topn_sort_vec.size());
+    for (uint32_t i = 0; i < min_size; ++i) {
         Counter& accuracy_counter = accuracy_sort_vec[i];
         Counter& topn_counter = topn_sort_vec[i];
         if (accuracy_counter.get_count() != topn_counter.get_count()) {
@@ -146,6 +147,7 @@ void test_topn_accuracy(FunctionContext* ctx, int key_space, int space_expand_ra
             LOG(INFO) << "topn counter : (" << topn_counter.get_item() << ", " << topn_counter.get_count() << ")";
         }
     }
+    error += std::abs((int32_t)(accuracy_sort_vec.size() - topn_sort_vec.size()));
     LOG(INFO) << "Total errors : " << error;
     TopNFunctions::topn_finalize(ctx, dst);
 }


### PR DESCRIPTION

## Proposed changes

MemTracker can provide memory consumption for us to find out which
module consume more memory, but it's just a current value, this patch
add metrics for some large memory consumers, then we can find out
which module consume more memory in timeline, it would be useful to
troubleshoot OOM problems and optimize configs.

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  metric compaction_mem_current_consumption has been changed to mem_consumption {type="compaction"}
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Code refactor (Modify the code structure, format the code, etc...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have created an issue on (Fix #ISSUE) and described the bug/feature there in detail
- [x] Compiling and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If these changes need document changes, I have updated the document
- [ ] Any dependent changes have been merged
