### PR TITLE
[Bug] Fix alter table failed when none of new load jobs succeed on alter replica

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/alter/AlterJobV2.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/AlterJobV2.java
@@ -208,6 +208,7 @@ public abstract class AlterJobV2 implements Writable {
                 // table is stable, set is to ROLLUP and begin altering.
                 LOG.info("table {} is stable, start {} job {}", tableId, type);
                 tbl.setState(type == JobType.ROLLUP ? OlapTableState.ROLLUP : OlapTableState.SCHEMA_CHANGE);
+                errMsg = "";
                 return true;
             }
         } finally {

--- a/fe/fe-core/src/main/java/org/apache/doris/alter/RollupJobV2.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/RollupJobV2.java
@@ -494,7 +494,6 @@ public class RollupJobV2 extends AlterJobV2 implements GsonPostProcessable {
             partition.visualiseShadowIndex(rollupIndexId, false);
         }
         tbl.rebuildFullSchema();
-        tbl.setState(OlapTableState.NORMAL);
     }
 
     /**
@@ -537,7 +536,6 @@ public class RollupJobV2 extends AlterJobV2 implements GsonPostProcessable {
                         partition.deleteRollupIndex(rollupIndexId);
                     }
                     tbl.deleteIndexInfo(rollupIndexName);
-                    tbl.setState(OlapTableState.NORMAL);
                 } finally {
                     tbl.writeUnlock();
                 }

--- a/fe/fe-core/src/main/java/org/apache/doris/alter/RollupJobV2.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/RollupJobV2.java
@@ -494,6 +494,7 @@ public class RollupJobV2 extends AlterJobV2 implements GsonPostProcessable {
             partition.visualiseShadowIndex(rollupIndexId, false);
         }
         tbl.rebuildFullSchema();
+        tbl.setState(OlapTableState.NORMAL);
     }
 
     /**
@@ -536,6 +537,7 @@ public class RollupJobV2 extends AlterJobV2 implements GsonPostProcessable {
                         partition.deleteRollupIndex(rollupIndexId);
                     }
                     tbl.deleteIndexInfo(rollupIndexName);
+                    tbl.setState(OlapTableState.NORMAL);
                 } finally {
                     tbl.writeUnlock();
                 }
@@ -553,7 +555,7 @@ public class RollupJobV2 extends AlterJobV2 implements GsonPostProcessable {
      * Should replay all changes before this job's state transfer to PENDING.
      * These changes should be same as changes in RollupHander.processAddRollup()
      */
-    private void replayPending(RollupJobV2 replayedJob) {
+    private void replayCreateJob(RollupJobV2 replayedJob) {
         Database db = Catalog.getCurrentCatalog().getDb(dbId);
         if (db == null) {
             // database may be dropped before replaying this log. just return
@@ -602,7 +604,7 @@ public class RollupJobV2 extends AlterJobV2 implements GsonPostProcessable {
      * Replay job in WAITING_TXN state.
      * Should replay all changes in runPendingJob()
      */
-    private void replayWaitingTxn(RollupJobV2 replayedJob) {
+    private void replayPendingJob(RollupJobV2 replayedJob) {
         Database db = Catalog.getCurrentCatalog().getDb(dbId);
         if (db == null) {
             // database may be dropped before replaying this log. just return
@@ -633,7 +635,7 @@ public class RollupJobV2 extends AlterJobV2 implements GsonPostProcessable {
      * Replay job in FINISHED state.
      * Should replay all changes in runRuningJob()
      */
-    private void replayFinished(RollupJobV2 replayedJob) {
+    private void replayRunningJob(RollupJobV2 replayedJob) {
         Database db = Catalog.getCurrentCatalog().getDb(dbId);
         if (db != null) {
             OlapTable tbl = (OlapTable) db.getTable(tableId);
@@ -670,13 +672,13 @@ public class RollupJobV2 extends AlterJobV2 implements GsonPostProcessable {
         RollupJobV2 replayedRollupJob = (RollupJobV2) replayedJob;
         switch (replayedJob.jobState) {
             case PENDING:
-                replayPending(replayedRollupJob);
+                replayCreateJob(replayedRollupJob);
                 break;
             case WAITING_TXN:
-                replayWaitingTxn(replayedRollupJob);
+                replayPendingJob(replayedRollupJob);
                 break;
             case FINISHED:
-                replayFinished(replayedRollupJob);
+                replayRunningJob(replayedRollupJob);
                 break;
             case CANCELLED:
                 replayCancelled(replayedRollupJob);

--- a/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeJobV2.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeJobV2.java
@@ -665,7 +665,7 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
      * Should replay all changes before this job's state transfer to PENDING.
      * These changes should be same as changes in SchemaChangeHandler.createJob()
      */
-    private void replayPending(SchemaChangeJobV2 replayedJob) {
+    private void replayCreateJob(SchemaChangeJobV2 replayedJob) {
         Database db = Catalog.getCurrentCatalog().getDb(dbId);
         if (db == null) {
             // database may be dropped before replaying this log. just return
@@ -713,7 +713,7 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
      * Replay job in WAITING_TXN state.
      * Should replay all changes in runPendingJob()
      */
-    private void replayWaitingTxn(SchemaChangeJobV2 replayedJob) {
+    private void replayPendingJob(SchemaChangeJobV2 replayedJob) {
         Database db = Catalog.getCurrentCatalog().getDb(dbId);
         if (db == null) {
             // database may be dropped before replaying this log. just return
@@ -740,9 +740,9 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
 
     /**
      * Replay job in FINISHED state.
-     * Should replay all changes in runRuningJob()
+     * Should replay all changes in runRunningJob()
      */
-    private void replayFinished(SchemaChangeJobV2 replayedJob) {
+    private void replayRunningJob(SchemaChangeJobV2 replayedJob) {
         Database db = Catalog.getCurrentCatalog().getDb(dbId);
         if (db != null) {
             OlapTable tbl = (OlapTable) db.getTable(tableId);
@@ -777,13 +777,13 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
         SchemaChangeJobV2 replayedSchemaChangeJob = (SchemaChangeJobV2) replayedJob;
         switch (replayedJob.jobState) {
             case PENDING:
-                replayPending(replayedSchemaChangeJob);
+                replayCreateJob(replayedSchemaChangeJob);
                 break;
             case WAITING_TXN:
-                replayWaitingTxn(replayedSchemaChangeJob);
+                replayPendingJob(replayedSchemaChangeJob);
                 break;
             case FINISHED:
-                replayFinished(replayedSchemaChangeJob);
+                replayRunningJob(replayedSchemaChangeJob);
                 break;
             case CANCELLED:
                 replayCancelled(replayedSchemaChangeJob);

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/MaterializedIndex.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/MaterializedIndex.java
@@ -46,13 +46,13 @@ public class MaterializedIndex extends MetaObject implements Writable, GsonPostP
         SHADOW; // index in SHADOW state is visible to load process, but invisible to query
 
         public boolean isVisible() {
-            return this == IndexState.NORMAL || this == IndexState.SCHEMA_CHANGE;
+            return this == IndexState.NORMAL;
         }
     }
     
     public enum IndexExtState {
         ALL,
-        VISIBLE, // index state in NORMAL and SCHEMA_CHANGE
+        VISIBLE, // index state in NORMAL
         SHADOW // index state in SHADOW
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/OlapTableSink.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/OlapTableSink.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.planner;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.doris.analysis.SlotDescriptor;
 import org.apache.doris.analysis.TupleDescriptor;
 import org.apache.doris.catalog.Catalog;
@@ -300,7 +301,8 @@ public class OlapTableSink extends DataSink {
                     Multimap<Long, Long> bePathsMap = tablet.getNormalReplicaBackendPathMap();
                     if (bePathsMap.keySet().size() < quorum) {
                         throw new UserException(InternalErrorCode.REPLICA_FEW_ERR,
-                                "tablet " + tablet.getId() + " has few replicas: " + bePathsMap.keySet().size());
+                                "tablet " + tablet.getId() + " has few replicas: " + bePathsMap.keySet().size()
+                                        + ", alive backends: [" + StringUtils.join(bePathsMap.keySet(), ",") + "]");
                     }
                     locationParam.addToTablets(new TTabletLocation(tablet.getId(), Lists.newArrayList(bePathsMap.keySet())));
                     allBePathsMap.putAll(bePathsMap);

--- a/fe/fe-core/src/main/java/org/apache/doris/system/Backend.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/system/Backend.java
@@ -648,7 +648,7 @@ public class Backend implements Writable {
         } else {
             if (isAlive.compareAndSet(true, false)) {
                 isChanged = true;
-                LOG.info("{} is dead,", this.toString());
+                LOG.warn("{} is dead,", this.toString());
             }
 
             heartbeatErrMsg = hbResponse.getMsg() == null ? "Unknown error" : hbResponse.getMsg();

--- a/fe/fe-core/src/main/java/org/apache/doris/transaction/GlobalTransactionMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/transaction/GlobalTransactionMgr.java
@@ -204,7 +204,7 @@ public class GlobalTransactionMgr implements Writable {
         long publishTimeoutMillis = timeoutMillis - stopWatch.getTime();
         DatabaseTransactionMgr dbTransactionMgr = getDatabaseTransactionMgr(db.getId());
         if (publishTimeoutMillis < 0) {
-            // here commit transaction successfully cost too much time to cause publisTimeoutMillis is less than zero,
+            // here commit transaction successfully cost too much time to cause that publishTimeoutMillis is less than zero,
             // so we just return false to indicate publish timeout
             return false;
         }


### PR DESCRIPTION
## Proposed changes
 If none of new load jobs succeed on alter replica. the version can still be (0-1), and the replica's last failed version may be smaller than the specified version before which the history data has been transformed successfully. , because new load job may load data into alter replica with version smaller than the specified version.

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Code refactor (Modify the code structure, format the code, etc...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have created an issue on (Fix #5612 ) and described the bug/feature there in detail
- [ ] Compiling and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If these changes need document changes, I have updated the document
- [ ] Any dependent changes have been merged

## Further comments

If this is a relatively large or complex change, kick off the discussion at dev@doris.apache.org by explaining why you chose the solution you did and what alternatives you considered, etc...
