### PR TITLE
[Compaction] Use separate thread pool for base and cumulative compaction

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -283,8 +283,10 @@ CONF_mInt32(cumulative_compaction_skip_window_seconds, "30");
 CONF_mInt64(min_compaction_failure_interval_sec, "600"); // 10 min
 
 // This config can be set to limit thread number in compaction thread pool.
-CONF_mInt32(min_compaction_threads, "10");
-CONF_mInt32(max_compaction_threads, "10");
+CONF_mInt32(min_base_compaction_threads, "10");
+CONF_mInt32(max_base_compaction_threads, "10");
+CONF_mInt32(min_cumulative_compaction_threads, "10");
+CONF_mInt32(max_cumulative_compaction_threads, "10");
 
 // The upper limit of "permits" held by all compaction tasks. This config can be set to limit memory consumption for compaction.
 CONF_mInt64(total_permits_for_compaction_score, "10000");
@@ -293,7 +295,8 @@ CONF_mInt64(total_permits_for_compaction_score, "10000");
 CONF_mInt32(generate_compaction_tasks_min_interval_ms, "10")
 
 // Compaction task number per disk.
-CONF_mInt32(compaction_task_num_per_disk, "2");
+CONF_mInt32(max_base_compaction_task_num_per_disk, "2");
+CONF_mInt32(max_cumulative_compaction_task_num_per_disk, "2");
 
 // How many rounds of cumulative compaction for each round of base compaction when compaction tasks generation.
 CONF_mInt32(cumulative_compaction_rounds_for_each_base_compaction_round, "9");

--- a/be/src/olap/storage_engine.cpp
+++ b/be/src/olap/storage_engine.cpp
@@ -140,8 +140,12 @@ StorageEngine::~StorageEngine() {
     DEREGISTER_HOOK_METRIC(compaction_mem_current_consumption);
     _clear();
 
-    if(_compaction_thread_pool){
-        _compaction_thread_pool->shutdown();
+    if(_base_compaction_thread_pool){
+        _base_compaction_thread_pool->shutdown();
+    }
+
+    if(_cumulative_compaction_thread_pool){
+        _cumulative_compaction_thread_pool->shutdown();
     }
 }
 

--- a/be/src/olap/storage_engine.h
+++ b/be/src/olap/storage_engine.h
@@ -239,8 +239,10 @@ private:
     void _compaction_tasks_producer_callback();
     vector<TabletSharedPtr> _compaction_tasks_generator(CompactionType compaction_type,
                                                         std::vector<DataDir*> data_dirs);
-    void _push_tablet_into_submitted_compaction(TabletSharedPtr tablet);
-    void _pop_tablet_from_submitted_compaction(TabletSharedPtr tablet);
+    void _push_tablet_into_submitted_base_compaction(TabletSharedPtr tablet);
+    void _pop_tablet_from_submitted_base_compaction(TabletSharedPtr tablet);
+    void _push_tablet_into_submitted_cumulative_compaction(TabletSharedPtr tablet);
+    void _pop_tablet_from_submitted_cumulative_compaction(TabletSharedPtr tablet);
 
 private:
     struct CompactionCandidate {
@@ -334,12 +336,15 @@ private:
 
     HeartbeatFlags* _heartbeat_flags;
 
-    std::unique_ptr<ThreadPool> _compaction_thread_pool;
+    std::unique_ptr<ThreadPool> _base_compaction_thread_pool;
+    std::unique_ptr<ThreadPool> _cumulative_compaction_thread_pool;
 
     CompactionPermitLimiter _permit_limiter;
 
-    std::mutex _tablet_submitted_compaction_mutex;
-    std::map<DataDir*, vector<TTabletId>> _tablet_submitted_compaction;
+    std::mutex _tablet_submitted_base_compaction_mutex;
+    std::map<DataDir*, std::set<TTabletId>> _tablet_submitted_base_compaction;
+    std::mutex _tablet_submitted_cumulative_compaction_mutex;
+    std::map<DataDir*, std::set<TTabletId>> _tablet_submitted_cumulative_compaction;
 
     AtomicInt32 _wakeup_producer_flag;
 

--- a/be/src/olap/storage_engine.h
+++ b/be/src/olap/storage_engine.h
@@ -341,9 +341,9 @@ private:
 
     CompactionPermitLimiter _permit_limiter;
 
-    std::mutex _tablet_submitted_base_compaction_mutex;
+    RWMutex _tablet_submitted_base_compaction_mutex;
     std::map<DataDir*, std::set<TTabletId>> _tablet_submitted_base_compaction;
-    std::mutex _tablet_submitted_cumulative_compaction_mutex;
+    RWMutex _tablet_submitted_cumulative_compaction_mutex;
     std::map<DataDir*, std::set<TTabletId>> _tablet_submitted_cumulative_compaction;
 
     AtomicInt32 _wakeup_producer_flag;

--- a/be/src/olap/tablet_manager.cpp
+++ b/be/src/olap/tablet_manager.cpp
@@ -681,8 +681,8 @@ void TabletManager::get_tablet_stat(TTabletStatResult* result) {
 
 TabletSharedPtr TabletManager::find_best_tablet_to_compaction(
         CompactionType compaction_type, DataDir* data_dir,
-        std::set<TTabletId>& tablet_submitted_base_compaction,
-        std::set<TTabletId>& tablet_submitted_cumulative_compaction) {
+        std::set<TTabletId>* tablet_submitted_base_compaction,
+        std::set<TTabletId>* tablet_submitted_cumulative_compaction) {
     int64_t now_ms = UnixMillis();
     const string& compaction_type_str =
             compaction_type == CompactionType::BASE_COMPACTION ? "base" : "cumulative";
@@ -695,14 +695,15 @@ TabletSharedPtr TabletManager::find_best_tablet_to_compaction(
         for (const auto& tablet_map : tablets_shard.tablet_map) {
             for (const TabletSharedPtr& tablet_ptr : tablet_map.second.table_arr) {
                 std::set<TTabletId>::iterator it_tablet =
-                        tablet_submitted_base_compaction.find(tablet_ptr->tablet_id());
-                if (it_tablet != tablet_submitted_base_compaction.end()) {
+                        (*tablet_submitted_base_compaction).find(tablet_ptr->tablet_id());
+                if (it_tablet != (*tablet_submitted_base_compaction).end()) {
                     continue;
                 }
-                it_tablet = tablet_submitted_cumulative_compaction.find(tablet_ptr->tablet_id());
-                if (it_tablet != tablet_submitted_cumulative_compaction.end()) {
+                it_tablet = (*tablet_submitted_cumulative_compaction).find(tablet_ptr->tablet_id());
+                if (it_tablet != (*tablet_submitted_cumulative_compaction).end()) {
                     continue;
                 }
+
                 AlterTabletTaskSharedPtr cur_alter_task = tablet_ptr->alter_task();
                 if (cur_alter_task != nullptr && cur_alter_task->alter_state() != ALTER_FINISHED &&
                     cur_alter_task->alter_state() != ALTER_FAILED) {

--- a/be/src/olap/tablet_manager.h
+++ b/be/src/olap/tablet_manager.h
@@ -71,8 +71,8 @@ public:
 
     TabletSharedPtr find_best_tablet_to_compaction(CompactionType compaction_type,
                                                    DataDir* data_dir,
-                                                   std::set<TTabletId>& tablet_submitted_base_compaction,
-                                                   std::set<TTabletId>& tablet_submitted_cumulative_compaction);
+                                                   std::set<TTabletId>* tablet_submitted_base_compaction,
+                                                   std::set<TTabletId>* tablet_submitted_cumulative_compaction);
 
     TabletSharedPtr get_tablet(TTabletId tablet_id, SchemaHash schema_hash,
                                bool include_deleted = false, std::string* err = nullptr);

--- a/be/src/olap/tablet_manager.h
+++ b/be/src/olap/tablet_manager.h
@@ -71,7 +71,8 @@ public:
 
     TabletSharedPtr find_best_tablet_to_compaction(CompactionType compaction_type,
                                                    DataDir* data_dir,
-                                                   vector<TTabletId>& tablet_submitted_compaction);
+                                                   std::set<TTabletId>& tablet_submitted_base_compaction,
+                                                   std::set<TTabletId>& tablet_submitted_cumulative_compaction);
 
     TabletSharedPtr get_tablet(TTabletId tablet_id, SchemaHash schema_hash,
                                bool include_deleted = false, std::string* err = nullptr);


### PR DESCRIPTION
## Proposed changes

We hope that `cumulative compaction` can be implemented as soon as possible, but `base compaction` tasks are likely to  execute for a long time and occupy most of the threads in thread pool, which may result in high CPU load. 

This patch submits `cumulative compaction` and `base compaction` into separate thread pool. So we have more flexibility to adjust the execution of `cumulative compaction` and `base compaction`according to the status of cluster.
## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [x] Code refactor (Modify the code structure, format the code, etc...)
