### PR TITLE
[BE] Add scanner/etl thread pool queue size metric.

### DIFF
--- a/be/src/runtime/exec_env.h
+++ b/be/src/runtime/exec_env.h
@@ -148,6 +148,9 @@ private:
     /// Initialise 'buffer_pool_' and 'buffer_reservation_' with given capacity.
     void _init_buffer_pool(int64_t min_page_len, int64_t capacity, int64_t clean_pages_limit);
 
+    void _register_metrics();
+    void _deregister_metrics();
+
 private:
     bool _is_init;
     std::vector<StorePath> _store_paths;

--- a/be/src/runtime/exec_env_init.cpp
+++ b/be/src/runtime/exec_env_init.cpp
@@ -64,6 +64,9 @@
 
 namespace doris {
 
+DEFINE_GAUGE_METRIC_PROTOTYPE_5ARG(scanner_thread_pool_queue_size, MetricUnit::NOUNIT);
+DEFINE_GAUGE_METRIC_PROTOTYPE_5ARG(etl_thread_pool_queue_size, MetricUnit::NOUNIT);
+
 Status ExecEnv::init(ExecEnv* env, const std::vector<StorePath>& store_paths) {
     return env->_init(store_paths);
 }
@@ -125,6 +128,7 @@ Status ExecEnv::_init(const std::vector<StorePath>& store_paths) {
 
     RETURN_IF_ERROR(_load_channel_mgr->init(_mem_tracker->limit()));
     _heartbeat_flags = new HeartbeatFlags();
+    _register_metrics();
     _is_init = true;
     return Status::OK();
 }
@@ -208,11 +212,27 @@ void ExecEnv::_init_buffer_pool(int64_t min_page_size, int64_t capacity,
     _buffer_reservation->InitRootTracker(nullptr, capacity);
 }
 
+void ExecEnv::_register_metrics() {
+    REGISTER_HOOK_METRIC(scanner_thread_pool_queue_size, [this]() {
+        return _thread_pool->get_queue_size();
+    });
+
+    REGISTER_HOOK_METRIC(etl_thread_pool_queue_size, [this]() {
+        return _etl_thread_pool->get_queue_size();
+    });
+}
+
+void ExecEnv::_deregister_metrics() {
+    DEREGISTER_HOOK_METRIC(scanner_thread_pool_queue_size);
+    DEREGISTER_HOOK_METRIC(etl_thread_pool_queue_size);
+}
+
 void ExecEnv::_destroy() {
     //Only destroy once after init
     if (!_is_init) {
         return;
     }
+    _deregister_metrics();
     SAFE_DELETE(_brpc_stub_cache);
     SAFE_DELETE(_load_stream_mgr);
     SAFE_DELETE(_load_channel_mgr);

--- a/be/src/runtime/exec_env_init.cpp
+++ b/be/src/runtime/exec_env_init.cpp
@@ -64,8 +64,8 @@
 
 namespace doris {
 
-DEFINE_GAUGE_METRIC_PROTOTYPE_5ARG(scanner_thread_pool_queue_size, MetricUnit::NOUNIT);
-DEFINE_GAUGE_METRIC_PROTOTYPE_5ARG(etl_thread_pool_queue_size, MetricUnit::NOUNIT);
+DEFINE_GAUGE_METRIC_PROTOTYPE_2ARG(scanner_thread_pool_queue_size, MetricUnit::NOUNIT);
+DEFINE_GAUGE_METRIC_PROTOTYPE_2ARG(etl_thread_pool_queue_size, MetricUnit::NOUNIT);
 
 Status ExecEnv::init(ExecEnv* env, const std::vector<StorePath>& store_paths) {
     return env->_init(store_paths);

--- a/be/src/util/doris_metrics.h
+++ b/be/src/util/doris_metrics.h
@@ -180,6 +180,9 @@ public:
     UIntGauge* query_cache_sql_total_count;
     UIntGauge* query_cache_partition_total_count;
 
+    UIntGauge* scanner_thread_pool_queue_size;
+    UIntGauge* etl_thread_pool_queue_size;
+
     static DorisMetrics* instance() {
         static DorisMetrics instance;
         return &instance;


### PR DESCRIPTION
## Proposed changes

Sometimes the scanner thread pool will become a performance bottleneck. In this case, we can solve it by adding scanner thread.But, now there is no relevant metric that can help us quickly find this problem. 

This PR adds metric for scanner/etl thread_pool's queue size, which can reflect the load of the thread pool. And can help us quickly locate the performance problems related to the etl/scanner thread pool.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Code refactor (Modify the code structure, format the code, etc...)

## Checklist

- [ ] I have created an issue on (Fix #ISSUE) and described the bug/feature there in detail
- [ ] Compiling and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If these changes need document changes, I have updated the document
- [ ] Any dependent changes have been merged
