### PR TITLE
[Bug] Fix bug that tablets are not dropped when replacing tables

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/alter/Alter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/Alter.java
@@ -295,7 +295,7 @@ public class Alter {
             if (swapTable) {
                 origTable.checkAndSetName(newTblName, true);
             }
-            replaceTableInternal(db, origTable, olapNewTbl, swapTable);
+            replaceTableInternal(db, origTable, olapNewTbl, swapTable, false);
             // write edit log
             ReplaceTableOperationLog log = new ReplaceTableOperationLog(db.getId(), origTable.getId(), olapNewTbl.getId(), swapTable);
             Catalog.getCurrentCatalog().getEditLog().logReplaceTable(log);
@@ -316,7 +316,7 @@ public class Alter {
         OlapTable newTbl = (OlapTable) db.getTable(newTblId);
 
         try {
-            replaceTableInternal(db, origTable, newTbl, log.isSwapTable());
+            replaceTableInternal(db, origTable, newTbl, log.isSwapTable(), true);
         } catch (DdlException e) {
             LOG.warn("should not happen", e);
         }
@@ -337,7 +337,8 @@ public class Alter {
      * 1.1 check if B can be renamed to A (checking name conflict, etc...)
      * 1.2 rename B to A, drop old A, and add new A to database.
      */
-    private void replaceTableInternal(Database db, OlapTable origTable, OlapTable newTbl, boolean swapTable)
+    private void replaceTableInternal(Database db, OlapTable origTable, OlapTable newTbl, boolean swapTable,
+                                      boolean isReplay)
             throws DdlException {
         String oldTblName = origTable.getName();
         String newTblName = newTbl.getName();
@@ -354,6 +355,9 @@ public class Alter {
             // rename origin table name to new table name and add it to database
             origTable.checkAndSetName(newTblName, false);
             db.createTable(origTable);
+        } else {
+            // not swap, the origin table is not used anymore, need to drop all its tablets.
+            Catalog.getCurrentCatalog().onEraseOlapTable(origTable, isReplay);
         }
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/alter/AlterTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/alter/AlterTest.java
@@ -29,6 +29,8 @@ import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.catalog.Partition;
 import org.apache.doris.catalog.PrimitiveType;
 import org.apache.doris.catalog.Table;
+import org.apache.doris.catalog.Tablet;
+import org.apache.doris.catalog.TabletInvertedIndex;
 import org.apache.doris.catalog.Type;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.FeConstants;
@@ -37,12 +39,13 @@ import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.thrift.TStorageMedium;
 import org.apache.doris.utframe.UtFrameUtils;
 
-import com.google.common.collect.Lists;
-
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 
 import java.io.File;
 import java.util.List;
@@ -531,6 +534,49 @@ public class AlterTest {
         createTable(stmt4);
         Database db = Catalog.getCurrentCatalog().getDb("default_cluster:test");
 
+        // table name -> tabletIds
+        Map<String, List<Long>> tblNameToTabletIds = Maps.newHashMap();
+        OlapTable replace1Tbl = (OlapTable) db.getTable("replace1");
+        OlapTable r1Tbl = (OlapTable) db.getTable("r1");
+        OlapTable replace2Tbl = (OlapTable) db.getTable("replace2");
+        OlapTable replace3Tbl = (OlapTable) db.getTable("replace3");
+
+        tblNameToTabletIds.put("replace1", Lists.newArrayList());
+        for (Partition partition : replace1Tbl.getAllPartitions()) {
+            for (MaterializedIndex index : partition.getMaterializedIndices(MaterializedIndex.IndexExtState.VISIBLE)) {
+                for (Tablet tablet : index.getTablets()) {
+                    tblNameToTabletIds.get("replace1").add(tablet.getId());
+                }
+            }
+        }
+
+        tblNameToTabletIds.put("r1", Lists.newArrayList());
+        for (Partition partition : r1Tbl.getAllPartitions()) {
+            for (MaterializedIndex index : partition.getMaterializedIndices(MaterializedIndex.IndexExtState.VISIBLE)) {
+                for (Tablet tablet : index.getTablets()) {
+                    tblNameToTabletIds.get("r1").add(tablet.getId());
+                }
+            }
+        }
+
+        tblNameToTabletIds.put("replace2", Lists.newArrayList());
+        for (Partition partition : replace2Tbl.getAllPartitions()) {
+            for (MaterializedIndex index : partition.getMaterializedIndices(MaterializedIndex.IndexExtState.VISIBLE)) {
+                for (Tablet tablet : index.getTablets()) {
+                    tblNameToTabletIds.get("replace2").add(tablet.getId());
+                }
+            }
+        }
+
+        tblNameToTabletIds.put("replace3", Lists.newArrayList());
+        for (Partition partition : replace3Tbl.getAllPartitions()) {
+            for (MaterializedIndex index : partition.getMaterializedIndices(MaterializedIndex.IndexExtState.VISIBLE)) {
+                for (Tablet tablet : index.getTablets()) {
+                    tblNameToTabletIds.get("replace3").add(tablet.getId());
+                }
+            }
+        }
+
         // name conflict
         String replaceStmt = "ALTER TABLE test.replace1 REPLACE WITH TABLE r1";
         alterTable(replaceStmt, true);
@@ -543,6 +589,8 @@ public class AlterTest {
         Assert.assertEquals(1, replace2.getPartition("replace2").getMaterializedIndices(MaterializedIndex.IndexExtState.VISIBLE).size());
 
         alterTable(replaceStmt, false);
+        Assert.assertTrue(checkAllTabletsExists(tblNameToTabletIds.get("replace1")));
+        Assert.assertTrue(checkAllTabletsExists(tblNameToTabletIds.get("replace2")));
 
         replace1 = (OlapTable) db.getTable("replace1");
         replace2 = (OlapTable) db.getTable("replace2");
@@ -559,6 +607,8 @@ public class AlterTest {
         Assert.assertNull(replace2);
         Assert.assertEquals(3, replace1.getPartition("replace1").getMaterializedIndices(MaterializedIndex.IndexExtState.VISIBLE).size());
         Assert.assertEquals("replace1", replace1.getIndexNameById(replace1.getBaseIndexId()));
+        Assert.assertTrue(checkAllTabletsNotExists(tblNameToTabletIds.get("replace2")));
+        Assert.assertTrue(checkAllTabletsExists(tblNameToTabletIds.get("replace1")));
 
         replaceStmt = "ALTER TABLE test.replace1 REPLACE WITH TABLE replace3 properties('swap' = 'true')";
         alterTable(replaceStmt, false);
@@ -569,9 +619,39 @@ public class AlterTest {
         Assert.assertNotNull(replace1.getIndexIdByName("r3"));
         Assert.assertNotNull(replace1.getIndexIdByName("r4"));
 
+        Assert.assertTrue(checkAllTabletsExists(tblNameToTabletIds.get("replace1")));
+        Assert.assertTrue(checkAllTabletsExists(tblNameToTabletIds.get("replace3")));
+
         Assert.assertEquals(3, replace3.getPartition("replace3").getMaterializedIndices(MaterializedIndex.IndexExtState.VISIBLE).size());
         Assert.assertNotNull(replace3.getIndexIdByName("r1"));
         Assert.assertNotNull(replace3.getIndexIdByName("r2"));
+    }
+
+    private boolean checkAllTabletsExists(List<Long> tabletIds) {
+        TabletInvertedIndex invertedIndex = Catalog.getCurrentCatalog().getTabletInvertedIndex();
+        for (long tabletId : tabletIds) {
+            if (invertedIndex.getTabletMeta(tabletId) == null) {
+                return false;
+            }
+            if (invertedIndex.getReplicasByTabletId(tabletId).isEmpty()) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private boolean checkAllTabletsNotExists(List<Long> tabletIds) {
+        TabletInvertedIndex invertedIndex = Catalog.getCurrentCatalog().getTabletInvertedIndex();
+        for (long tabletId : tabletIds) {
+            if (invertedIndex.getTabletMeta(tabletId) != null) {
+                return false;
+            }
+
+            if (!invertedIndex.getReplicasByTabletId(tabletId).isEmpty()) {
+                return false;
+            }
+        }
+        return true;
     }
 
     @Test


### PR DESCRIPTION
## Proposed changes

When replacing table with swap = false, the origin table's tablets
should be removed from tablet inverted index.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Code refactor (Modify the code structure, format the code, etc...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have created an issue on (Fix #5626 ) and described the bug/feature there in detail
- [ ] Compiling and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If these changes need document changes, I have updated the document
- [ ] Any dependent changes have been merged

## Further comments

If this is a relatively large or complex change, kick off the discussion at dev@doris.apache.org by explaining why you chose the solution you did and what alternatives you considered, etc...
