### PR TITLE
(#5638) stale rowset can't be access after clone finish

### DIFF
--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -192,7 +192,13 @@ OLAPStatus Tablet::revise_tablet_meta(const std::vector<RowsetMetaSharedPtr>& ro
     }
 
     // reconstruct from tablet meta
-    _timestamped_version_tracker.construct_versioned_tracker(_tablet_meta->all_rs_metas(), _tablet_meta->all_stale_rs_metas());
+    _timestamped_version_tracker.construct_versioned_tracker(_tablet_meta->all_rs_metas());
+    // clear stale rowset
+    for (auto& it : _stale_rs_version_map) {
+        StorageEngine::instance()->add_unused_rowset(it.second);
+    }
+    _stale_rs_version_map.clear();
+    _tablet_meta->clear_stale_rowset();
 
     LOG(INFO) << "finish to revise tablet. res=" << res << ", "
               << "table=" << full_name();

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -192,7 +192,7 @@ OLAPStatus Tablet::revise_tablet_meta(const std::vector<RowsetMetaSharedPtr>& ro
     }
 
     // reconstruct from tablet meta
-    _timestamped_version_tracker.construct_versioned_tracker(_tablet_meta->all_rs_metas());
+    _timestamped_version_tracker.construct_versioned_tracker(_tablet_meta->all_rs_metas(), _tablet_meta->all_stale_rs_metas());
 
     LOG(INFO) << "finish to revise tablet. res=" << res << ", "
               << "table=" << full_name();

--- a/be/src/olap/tablet_meta.h
+++ b/be/src/olap/tablet_meta.h
@@ -199,6 +199,11 @@ public:
         _preferred_rowset_type = preferred_rowset_type;
     }
 
+    // used for after tablet cloned to clear stale rowset
+    void clear_stale_rowset() {
+        _stale_rs_metas.clear();
+    }
+
 private:
     OLAPStatus _save_meta(DataDir* data_dir);
 


### PR DESCRIPTION
## Proposed changes
stale rowset can't be access after clone finish
see(#5638)

I 'm testing this pr in our regression environment and gray publish in our production environment.
Currently I'm not quite sure whether this pr has any other effection.
