### PR TITLE
[Compaction] Support to switching cumulative compaction policy dynamically

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -247,7 +247,7 @@ CONF_mInt32(base_compaction_write_mbytes_per_sec, "5");
 // num_based policy, the original version of cumulative compaction, cumulative version compaction once.
 // size_based policy, a optimization version of cumulative compaction, targeting the use cases requiring
 // lower write amplification, trading off read amplification and space amplification.
-CONF_String(cumulative_compaction_policy, "size_based");
+CONF_mString(cumulative_compaction_policy, "size_based");
 CONF_Validator(cumulative_compaction_policy, [](const std::string config) -> bool {
   return config == "size_based" || config == "num_based";
 });

--- a/be/src/common/configbase.h
+++ b/be/src/common/configbase.h
@@ -116,6 +116,7 @@ public:
 #define CONF_mInt32(name, defaultstr) DEFINE_FIELD(int32_t, name, defaultstr, true)
 #define CONF_mInt64(name, defaultstr) DEFINE_FIELD(int64_t, name, defaultstr, true)
 #define CONF_mDouble(name, defaultstr) DEFINE_FIELD(double, name, defaultstr, true)
+#define CONF_mString(name, defaultstr) DEFINE_FIELD(std::string, name, defaultstr, true)
 #define CONF_Validator(name, validator) DEFINE_VALIDATOR(name, validator)
 
 #else
@@ -136,6 +137,7 @@ public:
 #define CONF_mInt32(name, defaultstr) DECLARE_FIELD(int32_t, name)
 #define CONF_mInt64(name, defaultstr) DECLARE_FIELD(int64_t, name)
 #define CONF_mDouble(name, defaultstr) DECLARE_FIELD(double, name)
+#define CONF_mString(name, defaultstr) DECLARE_FIELD(std::string, name)
 #define CONF_Validator(name, validator) DECLARE_VALIDATOR(name)
 #endif
 
@@ -176,6 +178,8 @@ bool init(const char* conf_file, bool fill_conf_map = false, bool must_exist = t
 Status set_config(const std::string& field, const std::string& value, bool need_persist = false);
 
 bool persist_config(const std::string& field, const std::string& value);
+
+std::mutex* get_mutable_string_config_lock();
 
 } // namespace config
 } // namespace doris

--- a/be/src/http/default_path_handlers.cpp
+++ b/be/src/http/default_path_handlers.cpp
@@ -74,6 +74,7 @@ void logs_handler(const WebPageHandler::ArgumentMap& args, std::stringstream* ou
 void config_handler(const WebPageHandler::ArgumentMap& args, std::stringstream* output) {
     (*output) << "<h2>Configurations</h2>";
     (*output) << "<pre>";
+    std::lock_guard<std::mutex> lock(*config::get_mutable_string_config_lock());
     for (const auto& it : *(config::full_conf_map)) {
         (*output) << it.first << "=" << it.second << std::endl;
     }

--- a/be/src/olap/compaction.cpp
+++ b/be/src/olap/compaction.cpp
@@ -136,7 +136,8 @@ OLAPStatus Compaction::do_compaction_impl(int64_t permits) {
               << ", output_version=" << _output_version.first << "-" << _output_version.second
               << ", current_max_version=" << _tablet->rowset_with_max_version()->end_version()
               << ", disk=" << _tablet->data_dir()->path() << ", segments=" << segments_num
-              << ". elapsed time=" << watch.get_elapse_second() << "s.";
+              << ". elapsed time=" << watch.get_elapse_second() << "s. cumulative_compaction_policy="
+              << _tablet->cumulative_compaction_policy()->name() << ".";
 
     return OLAP_SUCCESS;
 }

--- a/be/src/olap/cumulative_compaction_policy.cpp
+++ b/be/src/olap/cumulative_compaction_policy.cpp
@@ -438,7 +438,7 @@ void CumulativeCompactionPolicy::pick_candidate_rowsets(
     std::sort(candidate_rowsets->begin(), candidate_rowsets->end(), Rowset::comparator);
 }
 
-std::unique_ptr<CumulativeCompactionPolicy>
+std::shared_ptr<CumulativeCompactionPolicy>
 CumulativeCompactionPolicyFactory::create_cumulative_compaction_policy(std::string type) {
     CompactionPolicy policy_type;
     _parse_cumulative_compaction_policy(type, &policy_type);
@@ -451,12 +451,11 @@ CumulativeCompactionPolicyFactory::create_cumulative_compaction_policy(std::stri
                 new SizeBasedCumulativeCompactionPolicy());
     }
 
-    return std::unique_ptr<CumulativeCompactionPolicy>(new NumBasedCumulativeCompactionPolicy());
+    return std::shared_ptr<CumulativeCompactionPolicy>(new NumBasedCumulativeCompactionPolicy());
 }
 
 void CumulativeCompactionPolicyFactory::_parse_cumulative_compaction_policy(
         std::string type, CompactionPolicy* policy_type) {
-    boost::to_upper(type);
     if (type == CUMULATIVE_NUM_BASED_POLICY) {
         *policy_type = NUM_BASED_POLICY;
     } else if (type == CUMULATIVE_SIZE_BASED_POLICY) {

--- a/be/src/olap/cumulative_compaction_policy.h
+++ b/be/src/olap/cumulative_compaction_policy.h
@@ -248,7 +248,7 @@ class CumulativeCompactionPolicyFactory {
 public:
     /// Static factory function. It can product different policy according to the `policy` parameter and use tablet ptr
     /// to construct the policy. Now it can product size based and num based policies.
-    static std::unique_ptr<CumulativeCompactionPolicy> create_cumulative_compaction_policy(
+    static std::shared_ptr<CumulativeCompactionPolicy> create_cumulative_compaction_policy(
             std::string policy);
 
 private:

--- a/be/src/olap/storage_engine.h
+++ b/be/src/olap/storage_engine.h
@@ -357,6 +357,8 @@ private:
 
     std::shared_ptr<StreamLoadRecorder> _stream_load_recorder;
 
+    std::shared_ptr<CumulativeCompactionPolicy> _cumulative_compaction_policy;
+
     DISALLOW_COPY_AND_ASSIGN(StorageEngine);
 };
 

--- a/be/src/olap/tablet.h
+++ b/be/src/olap/tablet.h
@@ -56,7 +56,7 @@ public:
                                                    DataDir* data_dir = nullptr);
 
     Tablet(TabletMetaSharedPtr tablet_meta, DataDir* data_dir,
-           const std::string& cumulative_compaction_type = config::cumulative_compaction_policy);
+           const std::string& cumulative_compaction_type = "");
 
     OLAPStatus init();
     inline bool init_succeeded();
@@ -162,7 +162,8 @@ public:
 
     // operation for compaction
     bool can_do_compaction();
-    const uint32_t calc_compaction_score(CompactionType compaction_type) const;
+    uint32_t calc_compaction_score(CompactionType compaction_type,
+               std::shared_ptr<CumulativeCompactionPolicy> cumulative_compaction_policy);
     static void compute_version_hash_from_rowsets(const std::vector<RowsetSharedPtr>& rowsets,
                                                   VersionHash* version_hash);
 
@@ -263,7 +264,8 @@ private:
     OLAPStatus _capture_consistent_rowsets_unlocked(const vector<Version>& version_path,
                                                     vector<RowsetSharedPtr>* rowsets) const;
 
-    const uint32_t _calc_cumulative_compaction_score() const;
+    const uint32_t _calc_cumulative_compaction_score(
+            std::shared_ptr<CumulativeCompactionPolicy> cumulative_compaction_policy);
     const uint32_t _calc_base_compaction_score() const;
 
 public:
@@ -307,7 +309,7 @@ private:
     std::atomic<int64_t> _last_checkpoint_time;
 
     // cumulative compaction policy
-    std::unique_ptr<CumulativeCompactionPolicy> _cumulative_compaction_policy;
+    std::shared_ptr<CumulativeCompactionPolicy> _cumulative_compaction_policy;
     std::string _cumulative_compaction_type;
 
     // the value of metric 'query_scan_count' and timestamp will be recorded when every time

--- a/be/src/olap/tablet_manager.cpp
+++ b/be/src/olap/tablet_manager.cpp
@@ -697,7 +697,8 @@ void TabletManager::get_tablet_stat(TTabletStatResult* result) {
 
 TabletSharedPtr TabletManager::find_best_tablet_to_compaction(
         CompactionType compaction_type, DataDir* data_dir,
-        const std::map<TTabletId, CompactionType>& tablet_submitted_compaction, uint32_t* score) {
+        const std::map<TTabletId, CompactionType>& tablet_submitted_compaction, uint32_t* score,
+        std::shared_ptr<CumulativeCompactionPolicy> cumulative_compaction_policy) {
     int64_t now_ms = UnixMillis();
     const string& compaction_type_str =
             compaction_type == CompactionType::BASE_COMPACTION ? "base" : "cumulative";
@@ -763,7 +764,7 @@ TabletSharedPtr TabletManager::find_best_tablet_to_compaction(
                 }
 
                 uint32_t current_compaction_score =
-                        tablet_ptr->calc_compaction_score(compaction_type);
+                        tablet_ptr->calc_compaction_score(compaction_type, cumulative_compaction_policy);
 
                 double scan_frequency = 0.0;
                 if (config::compaction_tablet_scan_frequency_factor != 0) {

--- a/be/src/olap/tablet_manager.h
+++ b/be/src/olap/tablet_manager.h
@@ -72,7 +72,8 @@ public:
     TabletSharedPtr find_best_tablet_to_compaction(CompactionType compaction_type,
                                                    DataDir* data_dir,
                                                    const std::map<TTabletId, CompactionType>& tablet_submitted_compaction,
-                                                   uint32_t* score);
+                                                   uint32_t* score,
+                                                   std::shared_ptr<CumulativeCompactionPolicy> cumulative_compaction_policy);
 
     TabletSharedPtr get_tablet(TTabletId tablet_id, SchemaHash schema_hash,
                                bool include_deleted = false, std::string* err = nullptr);

--- a/be/test/olap/cumulative_compaction_policy_test.cpp
+++ b/be/test/olap/cumulative_compaction_policy_test.cpp
@@ -210,8 +210,12 @@ TEST_F(TestNumBasedCumulativeCompactionPolicy, calc_cumulative_compaction_score)
 
     TabletSharedPtr _tablet(new Tablet(_tablet_meta, nullptr, CUMULATIVE_NUM_BASED_POLICY));
     _tablet->init();
+    std::shared_ptr<CumulativeCompactionPolicy> cumulative_compaction_policy =
+                        CumulativeCompactionPolicyFactory::create_cumulative_compaction_policy(
+                    CUMULATIVE_NUM_BASED_POLICY);
 
-    const uint32_t score = _tablet->calc_compaction_score(CompactionType::CUMULATIVE_COMPACTION);
+    const uint32_t score = _tablet->calc_compaction_score(CompactionType::CUMULATIVE_COMPACTION,
+                                                          cumulative_compaction_policy);
 
     ASSERT_EQ(15, score);
 }
@@ -665,7 +669,11 @@ TEST_F(TestSizeBasedCumulativeCompactionPolicy, calc_cumulative_compaction_score
     _tablet->init();
     _tablet->calculate_cumulative_point();
 
-    const uint32_t score = _tablet->calc_compaction_score(CompactionType::CUMULATIVE_COMPACTION);
+    std::shared_ptr<CumulativeCompactionPolicy> cumulative_compaction_policy =
+            CumulativeCompactionPolicyFactory::create_cumulative_compaction_policy(
+                    CUMULATIVE_SIZE_BASED_POLICY);
+    const uint32_t score = _tablet->calc_compaction_score(CompactionType::CUMULATIVE_COMPACTION,
+                                                          cumulative_compaction_policy);
 
     ASSERT_EQ(15, score);
 }
@@ -681,7 +689,11 @@ TEST_F(TestSizeBasedCumulativeCompactionPolicy, calc_cumulative_compaction_score
     TabletSharedPtr _tablet(new Tablet(_tablet_meta, nullptr, CUMULATIVE_SIZE_BASED_POLICY));
     _tablet->init();
     _tablet->calculate_cumulative_point();
-    const uint32_t score = _tablet->calc_compaction_score(CompactionType::CUMULATIVE_COMPACTION);
+    std::shared_ptr<CumulativeCompactionPolicy> cumulative_compaction_policy =
+            CumulativeCompactionPolicyFactory::create_cumulative_compaction_policy(
+                    CUMULATIVE_SIZE_BASED_POLICY);
+    const uint32_t score = _tablet->calc_compaction_score(CompactionType::CUMULATIVE_COMPACTION,
+                                                          cumulative_compaction_policy);
 
     ASSERT_EQ(7, score);
 }


### PR DESCRIPTION
## Proposed changes

Support to switching cumulative compaction policy between`num_based` and `size_based` dynamically without restarting BE.

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [x] Code refactor (Modify the code structure, format the code, etc...)

