### PR TITLE
[Docs] fix a typo

### DIFF
--- a/docs/en/administrator-guide/alter-table/alter-table-bitmap-index.md
+++ b/docs/en/administrator-guide/alter-table/alter-table-bitmap-index.md
@@ -71,7 +71,7 @@ Please refer to [Schema Change](alter-table-schema-change.html)
     * `UNSIGNEDINT`
     * `BIGINT`
     * `CHAR`
-    * `VARCHAE`
+    * `VARCHAR`
     * `DATE`
     * `DATETIME`
     * `LARGEINT`

--- a/docs/zh-CN/administrator-guide/alter-table/alter-table-bitmap-index.md
+++ b/docs/zh-CN/administrator-guide/alter-table/alter-table-bitmap-index.md
@@ -72,7 +72,7 @@ create/drop index 语法
     * `UNSIGNEDINT`
     * `BIGINT`
     * `CHAR`
-    * `VARCHAE`
+    * `VARCHAR`
     * `DATE`
     * `DATETIME`
     * `LARGEINT`


### PR DESCRIPTION
fix typo :
`VARCHAE` -> `VARCHAR`