### PR TITLE
[Optimize] Make tablet meta checkpoint to be threadpool model

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -286,6 +286,9 @@ CONF_mInt64(min_compaction_failure_interval_sec, "600"); // 10 min
 CONF_mInt32(min_compaction_threads, "10");
 CONF_mInt32(max_compaction_threads, "10");
 
+// Thread count to do tablet meta checkpoint, -1 means use the data directories count.
+CONF_Int32(max_meta_checkpoint_threads, "-1");
+
 // The upper limit of "permits" held by all compaction tasks. This config can be set to limit memory consumption for compaction.
 CONF_mInt64(total_permits_for_compaction_score, "10000");
 
@@ -516,6 +519,7 @@ CONF_Int32(flush_thread_num_per_store, "2");
 // config for tablet meta checkpoint
 CONF_mInt32(tablet_meta_checkpoint_min_new_rowsets_num, "10");
 CONF_mInt32(tablet_meta_checkpoint_min_interval_secs, "600");
+CONF_Int32(generate_tablet_meta_checkpoint_tasks_interval_secs, "600");
 
 // config for default rowset type
 // Valid configs: ALPHA, BETA

--- a/be/src/olap/storage_engine.cpp
+++ b/be/src/olap/storage_engine.cpp
@@ -144,6 +144,9 @@ StorageEngine::~StorageEngine() {
     if(_compaction_thread_pool){
         _compaction_thread_pool->shutdown();
     }
+    if (_tablet_meta_checkpoint_thread_pool) {
+        _tablet_meta_checkpoint_thread_pool->shutdown();
+    }
 }
 
 void StorageEngine::load_data_dirs(const std::vector<DataDir*>& data_dirs) {
@@ -515,6 +518,7 @@ void StorageEngine::stop() {
     THREAD_JOIN(_garbage_sweeper_thread);
     THREAD_JOIN(_disk_stat_monitor_thread);
     THREAD_JOIN(_fd_cache_clean_thread);
+    THREAD_JOIN(_tablet_checkpoint_tasks_producer_thread);
 #undef THREAD_JOIN
 
 #define THREADS_JOIN(threads)           \
@@ -526,7 +530,6 @@ void StorageEngine::stop() {
 
     THREADS_JOIN(_path_gc_threads);
     THREADS_JOIN(_path_scan_threads);
-    THREADS_JOIN(_tablet_checkpoint_threads);
 #undef THREADS_JOIN
 }
 

--- a/be/src/olap/storage_engine.h
+++ b/be/src/olap/storage_engine.h
@@ -221,7 +221,7 @@ private:
 
     void _path_scan_thread_callback(DataDir* data_dir);
 
-    void _tablet_checkpoint_callback(DataDir* data_dir);
+    void _tablet_checkpoint_callback(const std::vector<DataDir*>& data_dirs);
 
     // parse the default rowset type config to RowsetTypePB
     void _parse_default_rowset_type();
@@ -313,8 +313,8 @@ private:
     std::vector<scoped_refptr<Thread>> _path_gc_threads;
     // threads to scan disk paths
     std::vector<scoped_refptr<Thread>> _path_scan_threads;
-    // threads to run tablet checkpoint
-    std::vector<scoped_refptr<Thread>> _tablet_checkpoint_threads;
+    // thread to produce tablet checkpoint tasks
+    scoped_refptr<Thread> _tablet_checkpoint_tasks_producer_thread;
 
     // For tablet and disk-stat report
     std::mutex _report_mtx;
@@ -336,6 +336,8 @@ private:
     HeartbeatFlags* _heartbeat_flags;
 
     std::unique_ptr<ThreadPool> _compaction_thread_pool;
+
+    std::unique_ptr<ThreadPool> _tablet_meta_checkpoint_thread_pool;
 
     CompactionPermitLimiter _permit_limiter;
 


### PR DESCRIPTION
## Proposed changes

Currently Tablet meta checkpoint is a memory-exhausted operation. If a host has 12 disks, it will start 12 threads to do tablet meta checkpoint. In our experience, the data size of one tablet can be as high as 2G. If 12 threads do the checkpoint at the same time, it maybe cause OOM.
Therefore, this PR try to solve this problem. Firstly, it only start one thread to produce table meta checkpoint tasks. Secondly, it creates a threadpool to handle these tasks. You can configure the size of the thread pool to control the parrallelism  in case of OOM. It is a prducer-customer model.

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Code refactor (Modify the code structure, format the code, etc...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have created an issue on (Fix #ISSUE) and described the bug/feature there in detail
- [x] Compiling and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] If these changes need document changes, I have updated the document
- [x] Any dependent changes have been merged

## Further comments

If this is a relatively large or complex change, kick off the discussion at dev@doris.apache.org by explaining why you chose the solution you did and what alternatives you considered, etc...
