### PR TITLE
[Optimize] Make the max stmt length to be loaded in audit table can be defined by user

### DIFF
--- a/fe_plugins/auditloader/src/main/assembly/plugin.conf
+++ b/fe_plugins/auditloader/src/main/assembly/plugin.conf
@@ -23,6 +23,9 @@ max_batch_size=52428800
 # The max interval of batch loaded, default is 60 seconds
 max_batch_interval_sec=60
 
+# the max stmt length to be loaded in audit table, default is 4096
+max_stmt_length=4096
+
 # Doris FE host for loading the audit, default is 127.0.0.1:8030.
 # this should be the host port for stream load
 frontend_host_port=127.0.0.1:8030


### PR DESCRIPTION
## Proposed changes

Currently the length of stmt in AuditTable is a fixed value(4096 bytes). When the sql is longer than 4096 bytes, user can not get the whole sql. 
Therefore, this PR make the max stmt length to be loaded in audit table can be defined by user.

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Code refactor (Modify the code structure, format the code, etc...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have created an issue on (Fix #ISSUE) and described the bug/feature there in detail
- [ ] Compiling and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] If these changes need document changes, I have updated the document
- [ ] Any dependent changes have been merged

## Further comments

If this is a relatively large or complex change, kick off the discussion at dev@doris.apache.org by explaining why you chose the solution you did and what alternatives you considered, etc...
