### PR TITLE
[Optimize] Remove expired txns in batch to avoid holding lock for too long

### DIFF
--- a/be/src/olap/delta_writer.cpp
+++ b/be/src/olap/delta_writer.cpp
@@ -108,7 +108,7 @@ OLAPStatus DeltaWriter::init() {
         LOG(WARNING) << "failed to init delta writer. version count: " << _tablet->version_count()
                      << ", exceed limit: " << config::max_tablet_version_num
                      << ". tablet: " << _tablet->full_name();
-        return OLAP_ERR_TABLE_NOT_FOUND;
+        return OLAP_ERR_TOO_MANY_VERSION;
     }
 
     {

--- a/be/src/runtime/mysql_result_writer.cpp
+++ b/be/src/runtime/mysql_result_writer.cpp
@@ -61,7 +61,7 @@ Status MysqlResultWriter::init(RuntimeState* state) {
 void MysqlResultWriter::_init_profile() {
     _append_row_batch_timer = ADD_TIMER(_parent_profile, "AppendBatchTime");
     _convert_tuple_timer = ADD_CHILD_TIMER(_parent_profile, "TupleConvertTime", "AppendBatchTime");
-    _result_send_timer = ADD_CHILD_TIMER(_parent_profile, "ResultRendTime", "AppendBatchTime");
+    _result_send_timer = ADD_CHILD_TIMER(_parent_profile, "ResultSendTime", "AppendBatchTime");
     _sent_rows_counter = ADD_COUNTER(_parent_profile, "NumSentRows", TUnit::UNIT);
 }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/Config.java
@@ -127,6 +127,12 @@ public class Config extends ConfigBase {
      */
     @ConfField(mutable = true, masterOnly = true)
     public static int label_keep_max_second = 3 * 24 * 3600; // 3 days
+
+    // For some high frequency load job such as
+    // INSERT、STREAMING LOAD、ROUTINE_LOAD_TASK
+    // Remove the finished job or task if expired.
+    @ConfField(mutable = true, masterOnly = true)
+    public static int streaming_label_keep_max_second = 43200; // 12 hour
   
     /**
      * The max keep time of some kind of jobs.

--- a/fe/fe-core/src/main/java/org/apache/doris/journal/JournalEntity.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/journal/JournalEntity.java
@@ -51,6 +51,7 @@ import org.apache.doris.persist.BackendIdsUpdateInfo;
 import org.apache.doris.persist.BackendTabletsInfo;
 import org.apache.doris.persist.BatchDropInfo;
 import org.apache.doris.persist.BatchModifyPartitionsInfo;
+import org.apache.doris.persist.BatchRemoveTransactionsOperation;
 import org.apache.doris.persist.ClusterInfo;
 import org.apache.doris.persist.ColocatePersistInfo;
 import org.apache.doris.persist.ConsistencyCheckInfo;
@@ -85,10 +86,10 @@ import org.apache.doris.system.Backend;
 import org.apache.doris.system.Frontend;
 import org.apache.doris.transaction.TransactionState;
 
+import com.google.common.base.Preconditions;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-
-import com.google.common.base.Preconditions;
 
 import java.io.DataInput;
 import java.io.DataOutput;
@@ -427,6 +428,11 @@ public class JournalEntity implements Writable {
             case OperationType.OP_DELETE_TRANSACTION_STATE: {
                 data = new TransactionState();
                 ((TransactionState) data).readFields(in);
+                isRead = true;
+                break;
+            }
+            case OperationType.OP_BATCH_REMOVE_TXNS: {
+                data = BatchRemoveTransactionsOperation.read(in);
                 isRead = true;
                 break;
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/load/Load.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/Load.java
@@ -2602,8 +2602,7 @@ public class Load {
             while (iter.hasNext()) {
                 Map.Entry<Long, LoadJob> entry = iter.next();
                 LoadJob job = entry.getValue();
-                if ((currentTimeMs - job.getCreateTimeMs()) / 1000 > Config.label_keep_max_second
-                        && (job.getState() == JobState.FINISHED || job.getState() == JobState.CANCELLED)) {
+                if (job.isExpired(currentTimeMs)) {
                     long dbId = job.getDbId();
                     String label = job.getLabel();
                     // Remove job from idToLoadJob

--- a/fe/fe-core/src/main/java/org/apache/doris/load/LoadJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/LoadJob.java
@@ -1012,5 +1012,9 @@ public class LoadJob implements Writable {
         return false;
     }
 
-
+    // Return true if this job is finished for a long time
+    public boolean isExpired(long currentTimeMs) {
+        return (getState() == JobState.FINISHED || getState() == JobState.CANCELLED)
+            && (currentTimeMs - getLoadFinishTimeMs()) / 1000 > Config.label_keep_max_second;
+    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/LoadJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/LoadJob.java
@@ -1191,4 +1191,18 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
     public int getLoadParallelism() {
         return (int) jobProperties.get(LoadStmt.LOAD_PARALLELISM);
     }
+
+    // Return true if this job is finished for a long time
+    public boolean isExpired(long currentTimeMs) {
+        if (!isCompleted()) {
+            return false;
+        }
+        long expireTime = Config.label_keep_max_second;
+        if (jobType == EtlJobType.INSERT) {
+            expireTime = Config.streaming_label_keep_max_second;
+        }
+
+        return (currentTimeMs - getFinishTimestamp()) / 1000 > expireTime;
+    }
+
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/BatchRemoveTransactionsOperation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/BatchRemoveTransactionsOperation.java
@@ -29,9 +29,11 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
+// Persist the info when removing batch of expired txns
 public class BatchRemoveTransactionsOperation implements Writable {
 
     @SerializedName(value = "dbTxnIds")
+    // dbId -> List of txns
     private Map<Long, List<Long>> dbTxnIds;
 
     public BatchRemoveTransactionsOperation(Map<Long, List<Long>> dbTxnIds) {

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/BatchRemoveTransactionsOperation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/BatchRemoveTransactionsOperation.java
@@ -1,0 +1,55 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.persist;
+
+import org.apache.doris.common.io.Text;
+import org.apache.doris.common.io.Writable;
+import org.apache.doris.persist.gson.GsonUtils;
+
+import com.google.gson.annotations.SerializedName;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+public class BatchRemoveTransactionsOperation implements Writable {
+
+    @SerializedName(value = "dbTxnIds")
+    private Map<Long, List<Long>> dbTxnIds;
+
+    public BatchRemoveTransactionsOperation(Map<Long, List<Long>> dbTxnIds) {
+        this.dbTxnIds = dbTxnIds;
+    }
+
+    public Map<Long, List<Long>> getDbTxnIds() {
+        return dbTxnIds;
+    }
+
+    @Override
+    public void write(DataOutput out) throws IOException {
+        String json = GsonUtils.GSON.toJson(this);
+        Text.writeString(out, json);
+    }
+
+    public static BatchRemoveTransactionsOperation read(DataInput in) throws IOException {
+        String json = Text.readString(in);
+        return GsonUtils.GSON.fromJson(json, BatchRemoveTransactionsOperation.class);
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/EditLog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/EditLog.java
@@ -597,7 +597,7 @@ public class EditLog {
                 }
                 case OperationType.OP_BATCH_REMOVE_TXNS: {
                     final BatchRemoveTransactionsOperation operation = (BatchRemoveTransactionsOperation) journal.getData();
-                    Catalog.getCurrentGlobalTransactionMgr().replayBatchDeleteTransactions(operation);
+                    Catalog.getCurrentGlobalTransactionMgr().replayBatchRemoveTransactions(operation);
                     break;
                 }
                 case OperationType.OP_CREATE_REPOSITORY: {

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/EditLog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/EditLog.java
@@ -595,6 +595,11 @@ public class EditLog {
                     LOG.debug("opcode: {}, tid: {}", opCode, state.getTransactionId());
                     break;
                 }
+                case OperationType.OP_BATCH_REMOVE_TXNS: {
+                    final BatchRemoveTransactionsOperation operation = (BatchRemoveTransactionsOperation) journal.getData();
+                    Catalog.getCurrentGlobalTransactionMgr().replayBatchDeleteTransactions(operation);
+                    break;
+                }
                 case OperationType.OP_CREATE_REPOSITORY: {
                     Repository repository = (Repository) journal.getData();
                     catalog.getBackupHandler().getRepoMgr().addAndInitRepoIfNotExist(repository, true);
@@ -1362,5 +1367,9 @@ public class EditLog {
 
     public void logReplaceTable(ReplaceTableOperationLog log) {
         logEdit(OperationType.OP_REPLACE_TABLE, log);
+    }
+
+    public void logBatchRemoveTransactions(BatchRemoveTransactionsOperation op) {
+        logEdit(OperationType.OP_BATCH_REMOVE_TXNS, op);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/EditLog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/EditLog.java
@@ -1204,11 +1204,7 @@ public class EditLog {
     public void logInsertTransactionState(TransactionState transactionState) {
         logEdit(OperationType.OP_UPSERT_TRANSACTION_STATE, transactionState);
     }
-
-    public void logDeleteTransactionState(TransactionState transactionState) {
-        logEdit(OperationType.OP_DELETE_TRANSACTION_STATE, transactionState);
-    }
-
+    
     public void logBackupJob(BackupJob job) {
         logEdit(OperationType.OP_BACKUP_JOB, job);
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/OperationType.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/OperationType.java
@@ -141,6 +141,7 @@ public class OperationType {
     //real time load 100 -108
     public static final short OP_UPSERT_TRANSACTION_STATE = 100;
     @Deprecated
+    // use OP_BATCH_REMOVE_TXNS instead
     public static final short OP_DELETE_TRANSACTION_STATE = 101;
     public static final short OP_FINISHING_ROLLUP = 102;
     public static final short OP_FINISHING_SCHEMA_CHANGE = 103;

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/OperationType.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/OperationType.java
@@ -140,10 +140,12 @@ public class OperationType {
 
     //real time load 100 -108
     public static final short OP_UPSERT_TRANSACTION_STATE = 100;
+    @Deprecated
     public static final short OP_DELETE_TRANSACTION_STATE = 101;
     public static final short OP_FINISHING_ROLLUP = 102;
     public static final short OP_FINISHING_SCHEMA_CHANGE = 103;
     public static final short OP_SAVE_TRANSACTION_ID = 104;
+    public static final short OP_BATCH_REMOVE_TXNS = 105;
 
     // routine load 110~120
     public static final short OP_ROUTINE_LOAD_JOB = 110;

--- a/fe/fe-core/src/main/java/org/apache/doris/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/transaction/DatabaseTransactionMgr.java
@@ -45,6 +45,7 @@ import org.apache.doris.common.util.TimeUtils;
 import org.apache.doris.common.util.Util;
 import org.apache.doris.metric.MetricRepo;
 import org.apache.doris.mysql.privilege.PrivPredicate;
+import org.apache.doris.persist.BatchRemoveTransactionsOperation;
 import org.apache.doris.persist.EditLog;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.task.AgentBatchTask;
@@ -55,16 +56,16 @@ import org.apache.doris.task.PublishVersionTask;
 import org.apache.doris.thrift.TTaskType;
 import org.apache.doris.thrift.TUniqueId;
 
-import org.apache.commons.collections.CollectionUtils;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.io.DataOutput;
 import java.io.IOException;
@@ -106,9 +107,12 @@ public class DatabaseTransactionMgr {
     // transactionId -> final status TransactionState
     private Map<Long, TransactionState> idToFinalStatusTransactionState = Maps.newHashMap();
 
-
-    // to store transactionStates with final status
-    private ArrayDeque<TransactionState> finalStatusTransactionStateDeque = new ArrayDeque<>();
+    // The following 2 queues are to store transactionStates with final status
+    // These queues are mainly used to avoid traversing all txns and speed up the cleaning time when cleaning up expired txs.
+    // The "Short" queue is used to store the txns of the expire time controlled by Config.streaming_label_keep_max_second.
+    // The "Long" queue is used to store the txns of the expire time controlled by Config.label_keep_max_second.
+    private ArrayDeque<TransactionState> finalStatusTransactionStateDequeShort = new ArrayDeque<>();
+    private ArrayDeque<TransactionState> finalStatusTransactionStateDequeLong = new ArrayDeque<>();
 
     // label -> txn ids
     // this is used for checking if label already used. a label may correspond to multiple txns,
@@ -203,7 +207,7 @@ public class DatabaseTransactionMgr {
 
     @VisibleForTesting
     protected int getFinishedTxnNums() {
-        return finalStatusTransactionStateDeque.size();
+        return idToFinalStatusTransactionState.size();
     }
 
     public List<List<String>> getTxnStateInfoList(boolean running, int limit) {
@@ -214,7 +218,7 @@ public class DatabaseTransactionMgr {
             if (running) {
                 transactionStateCollection = idToRunningTransactionState.values();
             } else {
-                transactionStateCollection = finalStatusTransactionStateDeque;
+                transactionStateCollection = idToFinalStatusTransactionState.values();
             }
             // get transaction order by txn id desc limit 'limit'
             transactionStateCollection.stream()
@@ -590,15 +594,46 @@ public class DatabaseTransactionMgr {
         return transactionState.getTransactionStatus() == TransactionStatus.VISIBLE;
     }
 
-    public void deleteTransaction(TransactionState transactionState) {
+    @Deprecated
+    // use replayBatchDeleteTransaction instead
+    public void replayDeleteTransaction(TransactionState transactionState) {
         writeLock();
         try {
             // here we only delete the oldest element, so if element exist in finalStatusTransactionStateDeque,
             // it must at the front of the finalStatusTransactionStateDeque
-            if (!finalStatusTransactionStateDeque.isEmpty() &&
-            transactionState.getTransactionId() == finalStatusTransactionStateDeque.getFirst().getTransactionId()) {
-                finalStatusTransactionStateDeque.pop();
-                clearTransactionState(transactionState);
+            if (!finalStatusTransactionStateDequeShort.isEmpty() &&
+                    transactionState.getTransactionId() == finalStatusTransactionStateDequeShort.getFirst().getTransactionId()) {
+                finalStatusTransactionStateDequeShort.pop();
+                clearTransactionState(transactionState.getTransactionId());
+            }
+
+            if (!finalStatusTransactionStateDequeLong.isEmpty() &&
+                    transactionState.getTransactionId() == finalStatusTransactionStateDequeLong.getFirst().getTransactionId()) {
+                finalStatusTransactionStateDequeLong.pop();
+                clearTransactionState(transactionState.getTransactionId());
+            }
+        } finally {
+            writeUnlock();
+        }
+    }
+
+    public void replayBatchDeleteTransaction(List<Long> txnIds) {
+        writeLock();
+        try {
+            for (Long txnId : txnIds) {
+                // here we only delete the oldest element, so if element exist in finalStatusTransactionStateDeque,
+                // it must at the front of the finalStatusTransactionStateDeque
+                if (!finalStatusTransactionStateDequeShort.isEmpty() &&
+                        txnId == finalStatusTransactionStateDequeShort.getFirst().getTransactionId()) {
+                    finalStatusTransactionStateDequeShort.pop();
+                    clearTransactionState(txnId);
+                }
+
+                if (!finalStatusTransactionStateDequeLong.isEmpty() &&
+                        txnId == finalStatusTransactionStateDequeLong.getFirst().getTransactionId()) {
+                    finalStatusTransactionStateDequeLong.pop();
+                    clearTransactionState(txnId);
+                }
             }
         } finally {
             writeUnlock();
@@ -889,7 +924,11 @@ public class DatabaseTransactionMgr {
                 }
             }
             idToFinalStatusTransactionState.put(transactionState.getTransactionId(), transactionState);
-            finalStatusTransactionStateDeque.add(transactionState);
+            if (transactionState.isShortTxn()) {
+                finalStatusTransactionStateDequeShort.add(transactionState);
+            } else {
+                finalStatusTransactionStateDequeLong.add(transactionState);
+            }
         }
         updateTxnLabels(transactionState);
     }
@@ -1075,37 +1114,65 @@ public class DatabaseTransactionMgr {
         return partitionInfos;
     }
 
-    public void removeExpiredTxns(long currentMillis) {
+    public void removeExpiredTxns2(long currentMillis) {
+        // 1. get all txn ids
+        List<Long> expiredTxnIds = Lists.newArrayList();
+        readLock();
+        try {
+            getExpiredTxnIds(currentMillis, finalStatusTransactionStateDequeShort, expiredTxnIds);
+            getExpiredTxnIds(currentMillis, finalStatusTransactionStateDequeLong, expiredTxnIds);
+        } finally {
+            readUnlock();
+        }
+
+        // 2. delete expired txns
         writeLock();
         try {
-            while (!finalStatusTransactionStateDeque.isEmpty()) {
-                TransactionState transactionState = finalStatusTransactionStateDeque.getFirst();
-                if (transactionState.isExpired(currentMillis)) {
-                    finalStatusTransactionStateDeque.pop();
-                    clearTransactionState(transactionState);
-                    editLog.logDeleteTransactionState(transactionState);
-                    LOG.info("transaction [" + transactionState.getTransactionId() + "] is expired, remove it from transaction manager");
-                } else {
-                    break;
-                }
-
+            for (Long txnId : expiredTxnIds) {
+                clearTransactionState(txnId);
             }
+
+            Map<Long, List<Long>> dbExpiredTxnIds = Maps.newHashMap();
+            dbExpiredTxnIds.put(dbId, expiredTxnIds);
+            BatchRemoveTransactionsOperation op = new BatchRemoveTransactionsOperation(dbExpiredTxnIds);
+            editLog.logBatchRemoveTransactions(op);
         } finally {
             writeUnlock();
         }
     }
 
-    private void clearTransactionState(TransactionState transactionState) {
-        idToFinalStatusTransactionState.remove(transactionState.getTransactionId());
-        Set<Long> txnIds = unprotectedGetTxnIdsByLabel(transactionState.getLabel());
-        txnIds.remove(transactionState.getTransactionId());
-        if (txnIds.isEmpty()) {
-            labelToTxnIds.remove(transactionState.getLabel());
+    // Get all expired txn ids in the given finalStatusTransactionStateDeque,
+    // Return in expiredTxnIds.
+    private void getExpiredTxnIds(long currentMillis, ArrayDeque<TransactionState> finalStatusTransactionStateDeque,
+                                  List<Long> expiredTxnIds) {
+        while (!finalStatusTransactionStateDeque.isEmpty()) {
+            TransactionState transactionState = finalStatusTransactionStateDeque.getFirst();
+            if (transactionState.isExpired(currentMillis)) {
+                finalStatusTransactionStateDeque.pop();
+                expiredTxnIds.add(transactionState.getTransactionId());
+            } else {
+                break;
+            }
+        }
+    }
+
+    private void clearTransactionState(long txnId) {
+        TransactionState transactionState = idToFinalStatusTransactionState.remove(txnId);
+        if (transactionState != null) {
+            Set<Long> txnIds = unprotectedGetTxnIdsByLabel(transactionState.getLabel());
+            txnIds.remove(transactionState.getTransactionId());
+            if (txnIds.isEmpty()) {
+                labelToTxnIds.remove(transactionState.getLabel());
+            }
+            LOG.info("transaction [" + txnId + "] is expired, remove it from transaction manager");
+        } else {
+            // should not happen, add a warn log to observer
+            LOG.warn("transaction state is not found when clear transaction: " + txnId);
         }
     }
 
     public int getTransactionNum() {
-        return idToRunningTransactionState.size() + finalStatusTransactionStateDeque.size();
+        return idToRunningTransactionState.size() + idToFinalStatusTransactionState.size();
     }
 
 
@@ -1117,7 +1184,7 @@ public class DatabaseTransactionMgr {
                     return txn;
                 }
             }
-            for (TransactionState txn : finalStatusTransactionStateDeque) {
+            for (TransactionState txn : idToFinalStatusTransactionState.values()) {
                 if (txn.getCallbackId() == callbackId && status.contains(txn.getTransactionStatus())) {
                     return txn;
                 }
@@ -1136,7 +1203,7 @@ public class DatabaseTransactionMgr {
                     return txn;
                 }
             }
-            for (TransactionState txn : finalStatusTransactionStateDeque) {
+            for (TransactionState txn : idToFinalStatusTransactionState.values()) {
                 if (txn.getCallbackId() == callbackId) {
                     return txn;
                 }
@@ -1384,7 +1451,7 @@ public class DatabaseTransactionMgr {
     }
 
     public void removeExpiredAndTimeoutTxns(long currentMillis) {
-        removeExpiredTxns(currentMillis);
+        removeExpiredTxns2(currentMillis);
         List<Long> timeoutTxns = getTimeoutTxns(currentMillis);
         // abort timeout txns
         for (Long txnId : timeoutTxns) {
@@ -1436,7 +1503,7 @@ public class DatabaseTransactionMgr {
             entry.getValue().write(out);
         }
 
-        for (TransactionState transactionState : finalStatusTransactionStateDeque) {
+        for (TransactionState transactionState : idToFinalStatusTransactionState.values()) {
             transactionState.write(out);
         }
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/transaction/DatabaseTransactionMgr.java
@@ -600,14 +600,13 @@ public class DatabaseTransactionMgr {
         writeLock();
         try {
             // here we only delete the oldest element, so if element exist in finalStatusTransactionStateDeque,
-            // it must at the front of the finalStatusTransactionStateDeque
+            // it must at the front of the finalStatusTransactionStateDeque.
+            // check both "short" and "long" queue.
             if (!finalStatusTransactionStateDequeShort.isEmpty() &&
                     transactionState.getTransactionId() == finalStatusTransactionStateDequeShort.getFirst().getTransactionId()) {
                 finalStatusTransactionStateDequeShort.pop();
                 clearTransactionState(transactionState.getTransactionId());
-            }
-
-            if (!finalStatusTransactionStateDequeLong.isEmpty() &&
+            } else if (!finalStatusTransactionStateDequeLong.isEmpty() &&
                     transactionState.getTransactionId() == finalStatusTransactionStateDequeLong.getFirst().getTransactionId()) {
                 finalStatusTransactionStateDequeLong.pop();
                 clearTransactionState(transactionState.getTransactionId());
@@ -623,13 +622,12 @@ public class DatabaseTransactionMgr {
             for (Long txnId : txnIds) {
                 // here we only delete the oldest element, so if element exist in finalStatusTransactionStateDeque,
                 // it must at the front of the finalStatusTransactionStateDeque
+                // check both "short" and "long" queue.
                 if (!finalStatusTransactionStateDequeShort.isEmpty() &&
                         txnId == finalStatusTransactionStateDequeShort.getFirst().getTransactionId()) {
                     finalStatusTransactionStateDequeShort.pop();
                     clearTransactionState(txnId);
-                }
-
-                if (!finalStatusTransactionStateDequeLong.isEmpty() &&
+                } else if (!finalStatusTransactionStateDequeLong.isEmpty() &&
                         txnId == finalStatusTransactionStateDequeLong.getFirst().getTransactionId()) {
                     finalStatusTransactionStateDequeLong.pop();
                     clearTransactionState(txnId);

--- a/fe/fe-core/src/main/java/org/apache/doris/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/transaction/DatabaseTransactionMgr.java
@@ -617,7 +617,7 @@ public class DatabaseTransactionMgr {
         }
     }
 
-    public void replayBatchDeleteTransaction(List<Long> txnIds) {
+    public void replayBatchRemoveTransaction(List<Long> txnIds) {
         writeLock();
         try {
             for (Long txnId : txnIds) {
@@ -1114,7 +1114,7 @@ public class DatabaseTransactionMgr {
         return partitionInfos;
     }
 
-    public void removeExpiredTxns2(long currentMillis) {
+    public void removeExpiredTxns(long currentMillis) {
         // 1. get all txn ids
         List<Long> expiredTxnIds = Lists.newArrayList();
         readLock();
@@ -1451,7 +1451,7 @@ public class DatabaseTransactionMgr {
     }
 
     public void removeExpiredAndTimeoutTxns(long currentMillis) {
-        removeExpiredTxns2(currentMillis);
+        removeExpiredTxns(currentMillis);
         List<Long> timeoutTxns = getTimeoutTxns(currentMillis);
         // abort timeout txns
         for (Long txnId : timeoutTxns) {
@@ -1507,5 +1507,4 @@ public class DatabaseTransactionMgr {
             transactionState.write(out);
         }
     }
-
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/transaction/GlobalTransactionMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/transaction/GlobalTransactionMgr.java
@@ -339,12 +339,12 @@ public class GlobalTransactionMgr implements Writable {
         }
     }
 
-    public void replayBatchDeleteTransactions(BatchRemoveTransactionsOperation operation) {
+    public void replayBatchRemoveTransactions(BatchRemoveTransactionsOperation operation) {
         Map<Long, List<Long>> dbTxnIds = operation.getDbTxnIds();
         for (Long dbId : dbTxnIds.keySet()) {
             try {
                 DatabaseTransactionMgr dbTransactionMgr = getDatabaseTransactionMgr(dbId);
-                dbTransactionMgr.replayBatchDeleteTransaction(dbTxnIds.get(dbId));
+                dbTransactionMgr.replayBatchRemoveTransaction(dbTxnIds.get(dbId));
             } catch (AnalysisException e) {
                 LOG.warn("replay batch remove transactions failed. db " + dbId, e);
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/transaction/TransactionState.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/transaction/TransactionState.java
@@ -485,7 +485,21 @@ public class TransactionState implements Writable {
     
     // return true if txn is in final status and label is expired
     public boolean isExpired(long currentMillis) {
-        return transactionStatus.isFinalStatus() && (currentMillis - finishTime) / 1000 > Config.label_keep_max_second;
+        if (!transactionStatus.isFinalStatus()) {
+            return false;
+        }
+        long expireTime = Config.label_keep_max_second;
+        if (isShortTxn()) {
+            expireTime = Config.stream_load_default_timeout_second;
+        }
+        return (currentMillis - finishTime) / 1000 > expireTime;
+    }
+
+    // Return true if this txn is related to streaming load/insert/routine load task.
+    // We call these tasks "Short" tasks because they will be cleaned up in a short time after they are finished.
+    public boolean isShortTxn() {
+        return sourceType == LoadJobSourceType.BACKEND_STREAMING || sourceType == LoadJobSourceType.INSERT_STREAMING
+                || sourceType == LoadJobSourceType.ROUTINE_LOAD_TASK;
     }
 
     // return true if txn is running but timeout

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/FakeEditLog.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/FakeEditLog.java
@@ -22,6 +22,7 @@ import org.apache.doris.alter.BatchAlterJobPersistInfo;
 import org.apache.doris.alter.RollupJob;
 import org.apache.doris.alter.SchemaChangeJob;
 import org.apache.doris.cluster.Cluster;
+import org.apache.doris.persist.BatchRemoveTransactionsOperation;
 import org.apache.doris.persist.EditLog;
 import org.apache.doris.persist.ModifyTablePropertyOperationLog;
 import org.apache.doris.persist.RoutineLoadOperation;
@@ -110,6 +111,11 @@ public class FakeEditLog extends MockUp<EditLog> {
 
     @Mock
     public void logDynamicPartition(ModifyTablePropertyOperationLog info) {
+
+    }
+
+    @Mock
+    public void logBatchRemoveTransactions(BatchRemoveTransactionsOperation info) {
 
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/load/loadv2/LoadManagerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/load/loadv2/LoadManagerTest.java
@@ -161,6 +161,9 @@ public class LoadManagerTest {
                 table.getName();
                 minTimes = 0;
                 result = "tablename";
+                Catalog.getCurrentCatalogJournalVersion();
+                minTimes = 0;
+                result = FeMetaVersion.VERSION_CURRENT;
             }
         };
 
@@ -169,7 +172,7 @@ public class LoadManagerTest {
         Deencapsulation.invoke(loadManager, "addLoadJob", job1);
 
         //make job1 don't serialize
-        Config.label_keep_max_second = 1;
+        Config.streaming_label_keep_max_second = 1;
         Thread.sleep(2000);
 
         File file = serializeToFile(loadManager);

--- a/fe/fe-core/src/test/java/org/apache/doris/persist/BatchRemoveTransactionOperationTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/persist/BatchRemoveTransactionOperationTest.java
@@ -1,0 +1,71 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.persist;
+
+import org.apache.doris.common.FeConstants;
+import org.apache.doris.meta.MetaContext;
+
+import com.clearspring.analytics.util.Lists;
+import com.google.common.collect.Maps;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.util.List;
+import java.util.Map;
+
+public class BatchRemoveTransactionOperationTest {
+    @Test
+    public void testSerialization() throws Exception {
+        MetaContext metaContext = new MetaContext();
+        metaContext.setMetaVersion(FeConstants.meta_version);
+        metaContext.setThreadLocalInfo();
+
+        // 1. Write objects to file
+        File file = new File("./BatchRemoveTransactionOperationTest");
+        file.createNewFile();
+        DataOutputStream dos = new DataOutputStream(new FileOutputStream(file));
+
+        Map<Long, List<Long>> dbTxnIds = Maps.newHashMap();
+        dbTxnIds.put(1000L, Lists.newArrayList());
+        dbTxnIds.get(1000L).add(1L);
+        dbTxnIds.get(1000L).add(2L);
+        dbTxnIds.get(1000L).add(3L);
+        BatchRemoveTransactionsOperation op = new BatchRemoveTransactionsOperation(dbTxnIds);
+        op.write(dos);
+
+        dos.flush();
+        dos.close();
+        
+        // 2. Read objects from file
+        DataInputStream dis = new DataInputStream(new FileInputStream(file));
+        BatchRemoveTransactionsOperation op2 = BatchRemoveTransactionsOperation.read(dis);
+        Assert.assertEquals(1, op2.getDbTxnIds().size());
+        Assert.assertEquals(3, op2.getDbTxnIds().get(1000L).size());
+        Assert.assertTrue(op2.getDbTxnIds().get(1000L).contains(1L));
+
+        // 3. delete files
+        dis.close();
+        file.delete();
+    }
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/transaction/DatabaseTransactionMgrTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/transaction/DatabaseTransactionMgrTest.java
@@ -229,7 +229,7 @@ public class DatabaseTransactionMgrTest {
         DatabaseTransactionMgr masterDbTransMgr = masterTransMgr.getDatabaseTransactionMgr(CatalogTestUtil.testDbId1);
         Config.label_keep_max_second = -1;
         long currentMillis = System.currentTimeMillis();
-        masterDbTransMgr.removeExpiredTxns2(currentMillis);
+        masterDbTransMgr.removeExpiredTxns(currentMillis);
         assertEquals(0, masterDbTransMgr.getFinishedTxnNums());
         assertEquals(3, masterDbTransMgr.getTransactionNum());
         assertNull(masterDbTransMgr.unprotectedGetTxnIdsByLabel(CatalogTestUtil.testTxnLabel1));

--- a/fe/fe-core/src/test/java/org/apache/doris/transaction/DatabaseTransactionMgrTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/transaction/DatabaseTransactionMgrTest.java
@@ -17,8 +17,6 @@
 
 package org.apache.doris.transaction;
 
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 import org.apache.doris.catalog.Catalog;
 import org.apache.doris.catalog.CatalogTestUtil;
 import org.apache.doris.catalog.FakeCatalog;
@@ -31,6 +29,9 @@ import org.apache.doris.common.Pair;
 import org.apache.doris.common.UserException;
 import org.apache.doris.common.util.TimeUtils;
 import org.apache.doris.meta.MetaContext;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -228,7 +229,7 @@ public class DatabaseTransactionMgrTest {
         DatabaseTransactionMgr masterDbTransMgr = masterTransMgr.getDatabaseTransactionMgr(CatalogTestUtil.testDbId1);
         Config.label_keep_max_second = -1;
         long currentMillis = System.currentTimeMillis();
-        masterDbTransMgr.removeExpiredTxns(currentMillis);
+        masterDbTransMgr.removeExpiredTxns2(currentMillis);
         assertEquals(0, masterDbTransMgr.getFinishedTxnNums());
         assertEquals(3, masterDbTransMgr.getTransactionNum());
         assertNull(masterDbTransMgr.unprotectedGetTxnIdsByLabel(CatalogTestUtil.testTxnLabel1));
@@ -264,7 +265,7 @@ public class DatabaseTransactionMgrTest {
         DatabaseTransactionMgr masterDbTransMgr = masterTransMgr.getDatabaseTransactionMgr(CatalogTestUtil.testDbId1);
         long txnId = LabelToTxnId.get(CatalogTestUtil.testTxnLabel1);
         TransactionState transactionState = masterDbTransMgr.getTransactionState(txnId);
-        masterDbTransMgr.deleteTransaction(transactionState);
+        masterDbTransMgr.replayDeleteTransaction(transactionState);
         assertEquals(2, masterDbTransMgr.getRunningTxnNums());
         assertEquals(1, masterDbTransMgr.getRunningRoutineLoadTxnNums());
         assertEquals(0, masterDbTransMgr.getFinishedTxnNums());


### PR DESCRIPTION
## Proposed changes

This CL mainly changes:

1.  Add a config to control the expire time of load job

    Add a new FE config "streaming_label_keep_max_second" to control
    the expire time of some high frequency load job such as INSERT and STREAM LOAD.

2. Remove expired txn in batch to avoid holding transaction lock for a long time

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [x] Code refactor (Modify the code structure, format the code, etc...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [X] I have created an issue on (Fix #5679 ) and described the bug/feature there in detail
- [ ] Compiling and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If these changes need document changes, I have updated the document
- [ ] Any dependent changes have been merged

## Further comments

If this is a relatively large or complex change, kick off the discussion at dev@doris.apache.org by explaining why you chose the solution you did and what alternatives you considered, etc...
