### PR TITLE
[Bug-fix] Ignore modified table log when table has been dropped

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/alter/AlterHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/AlterHandler.java
@@ -410,50 +410,45 @@ public abstract class AlterHandler extends MasterDaemon {
             throw new MetaNotFoundException("database " + task.getDbId() + " does not exist");
         }
 
-        db.readLock();
+        OlapTable tbl = (OlapTable) db.getTableOrThrowException(task.getTableId(), Table.TableType.OLAP);
+        tbl.writeLock();
         try {
-            OlapTable tbl = (OlapTable) db.getTableOrThrowException(task.getTableId(), Table.TableType.OLAP);
-            tbl.writeLock();
-            try {
-                Partition partition = tbl.getPartition(task.getPartitionId());
-                if (partition == null) {
-                    throw new MetaNotFoundException("partition " + task.getPartitionId() + " does not exist");
-                }
-                MaterializedIndex index = partition.getIndex(task.getIndexId());
-                if (index == null) {
-                    throw new MetaNotFoundException("index " + task.getIndexId() + " does not exist");
-                }
-                Tablet tablet = index.getTablet(task.getTabletId());
-                Preconditions.checkNotNull(tablet, task.getTabletId());
-                Replica replica = tablet.getReplicaById(task.getNewReplicaId());
-                if (replica == null) {
-                    throw new MetaNotFoundException("replica " + task.getNewReplicaId() + " does not exist");
-                }
-
-                LOG.info("before handle alter task tablet {}, replica: {}, task version: {}-{}",
-                        task.getSignature(), replica, task.getVersion(), task.getVersionHash());
-                boolean versionChanged = false;
-                if (replica.getVersion() < task.getVersion()) {
-                    replica.updateVersionInfo(task.getVersion(), task.getVersionHash(), replica.getDataSize(), replica.getRowCount());
-                    versionChanged = true;
-                }
-
-                if (versionChanged) {
-                    ReplicaPersistInfo info = ReplicaPersistInfo.createForClone(task.getDbId(), task.getTableId(),
-                            task.getPartitionId(), task.getIndexId(), task.getTabletId(), task.getBackendId(),
-                            replica.getId(), replica.getVersion(), replica.getVersionHash(), -1,
-                            replica.getDataSize(), replica.getRowCount(),
-                            replica.getLastFailedVersion(), replica.getLastFailedVersionHash(),
-                            replica.getLastSuccessVersion(), replica.getLastSuccessVersionHash());
-                    Catalog.getCurrentCatalog().getEditLog().logUpdateReplica(info);
-                }
-
-                LOG.info("after handle alter task tablet: {}, replica: {}", task.getSignature(), replica);
-            } finally {
-                tbl.writeUnlock();
+            Partition partition = tbl.getPartition(task.getPartitionId());
+            if (partition == null) {
+                throw new MetaNotFoundException("partition " + task.getPartitionId() + " does not exist");
             }
+            MaterializedIndex index = partition.getIndex(task.getIndexId());
+            if (index == null) {
+                throw new MetaNotFoundException("index " + task.getIndexId() + " does not exist");
+            }
+            Tablet tablet = index.getTablet(task.getTabletId());
+            Preconditions.checkNotNull(tablet, task.getTabletId());
+            Replica replica = tablet.getReplicaById(task.getNewReplicaId());
+            if (replica == null) {
+                throw new MetaNotFoundException("replica " + task.getNewReplicaId() + " does not exist");
+            }
+
+            LOG.info("before handle alter task tablet {}, replica: {}, task version: {}-{}",
+                    task.getSignature(), replica, task.getVersion(), task.getVersionHash());
+            boolean versionChanged = false;
+            if (replica.getVersion() < task.getVersion()) {
+                replica.updateVersionInfo(task.getVersion(), task.getVersionHash(), replica.getDataSize(), replica.getRowCount());
+                versionChanged = true;
+            }
+
+            if (versionChanged) {
+                ReplicaPersistInfo info = ReplicaPersistInfo.createForClone(task.getDbId(), task.getTableId(),
+                        task.getPartitionId(), task.getIndexId(), task.getTabletId(), task.getBackendId(),
+                        replica.getId(), replica.getVersion(), replica.getVersionHash(), -1,
+                        replica.getDataSize(), replica.getRowCount(),
+                        replica.getLastFailedVersion(), replica.getLastFailedVersionHash(),
+                        replica.getLastSuccessVersion(), replica.getLastSuccessVersionHash());
+                Catalog.getCurrentCatalog().getEditLog().logUpdateReplica(info);
+            }
+
+            LOG.info("after handle alter task tablet: {}, replica: {}", task.getSignature(), replica);
         } finally {
-            db.readUnlock();
+            tbl.writeUnlock();
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeJobV2.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeJobV2.java
@@ -706,7 +706,7 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
         
         this.watershedTxnId = replayedJob.watershedTxnId;
         jobState = JobState.WAITING_TXN;
-        LOG.info("replay pending schema change job: {}", jobId);
+        LOG.info("replay pending schema change job: {}, table id: {}", jobId, tableId);
     }
 
     /**
@@ -735,7 +735,7 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
         // should still be in WAITING_TXN state, so that the alter tasks will be resend again
         this.jobState = JobState.WAITING_TXN;
         this.watershedTxnId = replayedJob.watershedTxnId;
-        LOG.info("replay waiting txn schema change job: {}", jobId);
+        LOG.info("replay waiting txn schema change job: {} table id: {}", jobId, tableId);
     }
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Catalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Catalog.java
@@ -4524,6 +4524,13 @@ public class Catalog {
     public void replayAddReplica(ReplicaPersistInfo info) {
         Database db = getDb(info.getDbId());
         OlapTable olapTable = (OlapTable) db.getTable(info.getTableId());
+        if (olapTable == null) {
+            /**
+             * Same as replayUpdateReplica()
+             */
+            LOG.warn("Olap table is null when the add replica log is replayed, {}", info);
+            return;
+        }
         olapTable.writeLock();
         try {
             unprotectAddReplica(info);
@@ -4568,6 +4575,13 @@ public class Catalog {
     public void replayDeleteReplica(ReplicaPersistInfo info) {
         Database db = getDb(info.getDbId());
         OlapTable tbl = (OlapTable) db.getTable(info.getTableId());
+        if (tbl == null) {
+            /**
+             * Same as replayUpdateReplica()
+             */
+            LOG.warn("Olap table is null when the delete replica log is replayed, {}", info);
+            return;
+        }
         tbl.writeLock();
         try {
             unprotectDeleteReplica(info);

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Database.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Database.java
@@ -433,7 +433,7 @@ public class Database extends MetaObject implements Writable {
      */
     public Table getTableOrThrowException(long tableId, TableType tableType) throws MetaNotFoundException {
         Table table = idToTable.get(tableId);
-        if(table == null) {
+        if (table == null) {
             throw new MetaNotFoundException("unknown table, tableId=" + tableId);
         }
         if (table.getType() != tableType) {

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/ReplicaPersistInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/ReplicaPersistInfo.java
@@ -392,7 +392,6 @@ public class ReplicaPersistInfo implements Writable {
         sb.append("table id: ").append(tableId);
         sb.append(" partition id: ").append(partitionId);
         sb.append(" index id: ").append(indexId);
-        sb.append(" index id: ").append(indexId);
         sb.append(" tablet id: ").append(tabletId);
         sb.append(" backend id: ").append(backendId);
         sb.append(" replica id: ").append(replicaId);


### PR DESCRIPTION
Although the table lock can control the simultaneous modification of the table by different threads.
But it cannot control the drop operation of the table by other threads.
For example, when drop table and table update occur at the same time.

1. get table object by thread 1
2. drop table by thread 2 with table lock
3. update table object by thread 1

The above process is possible.
At this time, step 3 actually operates a table that no longer exists, which will eventually cause NullPointerException.

In fact, the modified table log after the drop table can be ignored. The reason is that it is meaningless to modify information on a table that no longer exists.

Fixed #5687

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Code refactor (Modify the code structure, format the code, etc...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have created an issue on (Fix #5687) and described the bug/feature there in detail
- [x] Compiling and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If these changes need document changes, I have updated the document
- [ ] Any dependent changes have been merged

