### PR TITLE
[Config]Add uri param to demonstrate tablet meta content of byte type for debug

### DIFF
--- a/be/src/http/action/meta_action.cpp
+++ b/be/src/http/action/meta_action.cpp
@@ -42,14 +42,20 @@ Status MetaAction::_handle_header(HttpRequest* req, std::string* json_meta) {
     req->add_output_header(HttpHeaders::CONTENT_TYPE, HEADER_JSON.c_str());
     std::string req_tablet_id = req->param(TABLET_ID_KEY);
     std::string req_schema_hash = req->param(TABLET_SCHEMA_HASH_KEY);
+    std::string req_enable_base64 = req->param(ENABLE_BYTE_TO_BASE64);
     uint64_t tablet_id = 0;
     uint32_t schema_hash = 0;
+    bool enable_byte_to_base64 = false;
+    if (std::strcmp(req_enable_base64.c_str(), "true") == 0) {
+        enable_byte_to_base64 = true;
+    }
     try {
         tablet_id = std::stoull(req_tablet_id);
         schema_hash = std::stoul(req_schema_hash);
     } catch (const std::exception& e) {
         LOG(WARNING) << "invalid argument.tablet_id:" << req_tablet_id
-                     << ", schema_hash:" << req_schema_hash;
+                     << ", schema_hash:" << req_schema_hash
+                     << ", enable_byte_to_base64: " << req_enable_base64;
         return Status::InternalError(strings::Substitute("convert failed, $0", e.what()));
     }
 
@@ -63,6 +69,8 @@ Status MetaAction::_handle_header(HttpRequest* req, std::string* json_meta) {
     tablet->generate_tablet_meta_copy(tablet_meta);
     json2pb::Pb2JsonOptions json_options;
     json_options.pretty_json = true;
+    // default value of bytes_to_base64 is true, compatible with previous config
+    json_options.bytes_to_base64 = enable_byte_to_base64;
     tablet_meta->to_json(json_meta, json_options);
     return Status::OK();
 }

--- a/be/src/http/action/meta_action.cpp
+++ b/be/src/http/action/meta_action.cpp
@@ -69,7 +69,6 @@ Status MetaAction::_handle_header(HttpRequest* req, std::string* json_meta) {
     tablet->generate_tablet_meta_copy(tablet_meta);
     json2pb::Pb2JsonOptions json_options;
     json_options.pretty_json = true;
-    // default value of bytes_to_base64 is true, compatible with previous config
     json_options.bytes_to_base64 = enable_byte_to_base64;
     tablet_meta->to_json(json_meta, json_options);
     return Status::OK();

--- a/be/src/olap/olap_define.h
+++ b/be/src/olap/olap_define.h
@@ -391,6 +391,7 @@ static const std::string CONVERTED_FLAG = "true";
 static const std::string TABLET_CONVERT_FINISHED = "tablet_convert_finished";
 const std::string TABLET_ID_KEY = "tablet_id";
 const std::string TABLET_SCHEMA_HASH_KEY = "schema_hash";
+const std::string ENABLE_BYTE_TO_BASE64 = "byte_to_base64";
 const std::string TABLET_ID_PREFIX = "t_";
 const std::string ROWSET_ID_PREFIX = "s_";
 


### PR DESCRIPTION
## Proposed changes

When get a table meta content by a http interface, Doris will transfer tablet meta into json string. If a field is byte type, it wiil be enconded into base64 code, like Pic1 Field `default:"MTA="`. 
![2021-04-22 17-28-33屏幕截图](https://user-images.githubusercontent.com/12771191/115699896-b1e71500-a398-11eb-8529-ced8ff7ae134.png)

It is unreadble for debug. Therefore we add a uri param `enable_byte_to_base64` to support not transfer byte into base64 code.  Look at Pic2, Field `default : "10"` is readble. For example, `localhost:8040/api/meta/header/13310/385479563?enable_byte_base64=false`
![2021-04-22 18-20-48屏幕截图](https://user-images.githubusercontent.com/12771191/115699958-c7f4d580-a398-11eb-9616-ebd8039a0899.png)


## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Code refactor (Modify the code structure, format the code, etc...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have created an issue on (Fix #ISSUE) and described the bug/feature there in detail
- [x] Compiling and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] If these changes need document changes, I have updated the document
- [x] Any dependent changes have been merged

## Further comments

If this is a relatively large or complex change, kick off the discussion at dev@doris.apache.org by explaining why you chose the solution you did and what alternatives you considered, etc...
