### PR TITLE
[Metrics] Add metric items for prometheus histogram metrics

### DIFF
--- a/be/src/util/metrics.cpp
+++ b/be/src/util/metrics.cpp
@@ -174,6 +174,21 @@ std::string HistogramMetric::to_prometheus(const std::string& display_name,
     ss << display_name << "_count"
        << labels_to_string({&entity_labels, &metric_labels})
        << " " << _stats.num() << "\n";
+    ss << display_name << "_max"
+       << labels_to_string({&entity_labels, &metric_labels})
+       << " " << _stats.max() << "\n";
+    ss << display_name << "_min"
+       << labels_to_string({&entity_labels, &metric_labels})
+       << " " << _stats.min() << "\n";
+    ss << display_name << "_average"
+       << labels_to_string({&entity_labels, &metric_labels})
+       << " " << _stats.average() << "\n";
+    ss << display_name << "_median"
+       << labels_to_string({&entity_labels, &metric_labels})
+       << " " << _stats.median() << "\n";
+    ss << display_name << "_standard_deviation"
+       << labels_to_string({&entity_labels, &metric_labels})
+       << " " << _stats.standard_deviation() << "\n";
 
     return ss.str();
 }


### PR DESCRIPTION
## Proposed changes

Add metric items (`max`、`min`、`average`、`median` and `standard deviation`) for prometheus histogram metrics.

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Code refactor (Modify the code structure, format the code, etc...)
