### PR TITLE
Little fix in spark load

### DIFF
--- a/fe/spark-dpp/src/main/java/org/apache/doris/common/Codec.java
+++ b/fe/spark-dpp/src/main/java/org/apache/doris/common/Codec.java
@@ -28,7 +28,7 @@ public class Codec {
         assert source >= 0;
         short B = 128;
 
-        while (source > B) {
+        while (source >= B) {
             out.write((int) (source & (B - 1) | B));
             source = source >> 7;
         }

--- a/fe/spark-dpp/src/main/java/org/apache/doris/load/loadv2/dpp/BitmapValue.java
+++ b/fe/spark-dpp/src/main/java/org/apache/doris/load/loadv2/dpp/BitmapValue.java
@@ -113,12 +113,13 @@ public class BitmapValue {
                 break;
             case SINGLE_VALUE:
                 // is 32-bit enough
+                // FE is big end but BE is little end.
                 if (isLongValue32bitEnough(singleValue)) {
                     output.write(SINGLE32);
-                    output.writeInt((int)singleValue);
+                    output.writeInt(Integer.reverseBytes((int)singleValue));
                 } else {
                     output.writeByte(SINGLE64);
-                    output.writeLong(singleValue);
+                    output.writeLong(Long.reverseBytes(singleValue));
                 }
                 break;
             case BITMAP_VALUE:
@@ -134,11 +135,11 @@ public class BitmapValue {
             case EMPTY:
                 break;
             case SINGLE32:
-                singleValue = Util.toUnsignedLong(input.readInt());
+                singleValue = Util.toUnsignedLong(Integer.reverseBytes(input.readInt()));
                 this.bitmapType = SINGLE_VALUE;
                 break;
             case SINGLE64:
-                singleValue = input.readLong();
+                singleValue = Long.reverseBytes(input.readLong());
                 this.bitmapType = SINGLE_VALUE;
                 break;
             case BITMAP32:

--- a/fe/spark-dpp/src/main/java/org/apache/doris/load/loadv2/dpp/SparkRDDAggregator.java
+++ b/fe/spark-dpp/src/main/java/org/apache/doris/load/loadv2/dpp/SparkRDDAggregator.java
@@ -233,8 +233,8 @@ class BitmapUnionAggregator extends SparkRDDAggregator<BitmapValue> {
             BitmapValue bitmapValue = new BitmapValue();
             if (value instanceof byte[]) {
                 bitmapValue.deserialize(new DataInputStream(new ByteArrayInputStream((byte[]) value)));
-            } else {
-                bitmapValue.add(value == null ? 0l : Long.valueOf(value.toString()));
+            } else if (value != null){
+                bitmapValue.add(Long.valueOf(value.toString()));
             }
             return bitmapValue;
         } catch (Exception e) {
@@ -277,8 +277,8 @@ class HllUnionAggregator extends SparkRDDAggregator<Hll> {
             Hll hll = new Hll();
             if (value instanceof byte[]) {
                 hll.deserialize(new DataInputStream(new ByteArrayInputStream((byte[]) value)));
-            } else {
-                hll.updateWithHash(value == null ? 0 : value);
+            } else if (value != null){
+                hll.updateWithHash(value);
             }
             return hll;
         } catch (Exception e) {


### PR DESCRIPTION
The distinct count result of bitmap/hll column may be incorrect in the spark load mode.

Fix some bugs in spark load to solve the above problem.
1. FE is big end but BE is little end. BitmapValues should be transfered to little end in FE's serialization
2. BitmapUnionAggregator/HllUnionAggregator ignore `null` value
3. Make sure encodeVarint64 in FE is consistent with BE

## Proposed changes

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Code refactor (Modify the code structure, format the code, etc...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have created an issue on (Fix #ISSUE) and described the bug/feature there in detail
- [ ] Compiling and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If these changes need document changes, I have updated the document
- [ ] Any dependent changes have been merged

## Further comments

If this is a relatively large or complex change, kick off the discussion at dev@doris.apache.org by explaining why you chose the solution you did and what alternatives you considered, etc...
