### PR TITLE
[Bug-Fix] Use the param UseDeclareFetch to fix the memmory consumption of PostgreSQL Driver && Fix the bug of mysql client 5.1 query failed doris

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/OdbcTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/OdbcTable.java
@@ -274,7 +274,7 @@ public class OdbcTable extends Table {
                         "utf8");
                 break;
             case POSTGRESQL:
-                connectString = String.format("Driver=%s;Server=%s;Port=%s;DataBase=%s;Uid=%s;Pwd=%s;charset=%s",
+                connectString = String.format("Driver=%s;Server=%s;Port=%s;DataBase=%s;Uid=%s;Pwd=%s;charset=%s;UseDeclareFetch=1;Fetch=4096",
                         getOdbcDriver(),
                         getHost(),
                         getPort(),
@@ -282,6 +282,7 @@ public class OdbcTable extends Table {
                         getUserName(),
                         getPasswd(),
                         "utf8");
+                break;
             case MYSQL:
                 connectString = String.format("Driver=%s;Server=%s;Port=%s;DataBase=%s;Uid=%s;Pwd=%s;charset=%s;forward_cursor=1;no_cache=1",
                         getOdbcDriver(),

--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/MysqlProto.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/MysqlProto.java
@@ -172,7 +172,10 @@ public class MysqlProto {
         // with password.
         // So Doris support the Protocol::AuthSwitchRequest to tell client to keep the default password plugin
         // which Doris is using now.
-        if (!handshakePacket.checkAuthPluginSameAsDoris(authPacket.getPluginName())) {
+        // Note: Check the authPacket whether support plugin auth firstly, before we check AuthPlugin between doris and client
+        // to compatible with older version: like mysql 5.1
+        if (authPacket.getCapability().isPluginAuth() &&
+                !handshakePacket.checkAuthPluginSameAsDoris(authPacket.getPluginName())) {
             // 1. clear the serializer
             serializer.reset();
             // 2. build the auth switch request and send to the client


### PR DESCRIPTION
## Proposed changes

1. Use the param `UseDeclareFetch` to fix the memmory consumption of PostgreSQL Driver
2. Fix the bug of mysql client 5.1 query failed doris

fix #5739 

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Code refactor (Modify the code structure, format the code, etc...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have created an issue on (Fix #ISSUE) and described the bug/feature there in detail
- [x] Compiling and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] If these changes need document changes, I have updated the document
- [x] Any dependent changes have been merged


