### PR TITLE
[Replica][Config] Add max/min replica config for create/alter table

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeHandler.java
@@ -1637,6 +1637,11 @@ public class SchemaChangeHandler extends AlterHandler {
                         return;
                     } else if (properties.containsKey("default." + PropertyAnalyzer.PROPERTIES_REPLICATION_NUM)) {
                         Preconditions.checkNotNull(properties.get(PropertyAnalyzer.PROPERTIES_REPLICATION_NUM));
+                        short replicaNum = Short.parseShort(properties.getOrDefault(PropertyAnalyzer.PROPERTIES_REPLICATION_NUM,
+                                String.valueOf(FeConstants.default_replication_num)));
+                        if (replicaNum > Config.max_replica_num || replicaNum < Config.min_replica_num) {
+                            throw new UserException("replica number is out of limit range");
+                        }
                         Catalog.getCurrentCatalog().modifyTableDefaultReplicationNum(db, olapTable, properties);
                         return;
                     } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_REPLICATION_NUM)) {

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Catalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Catalog.java
@@ -3631,6 +3631,9 @@ public class Catalog {
             boolean isReplicationNumSet = properties != null && properties.containsKey(PropertyAnalyzer.PROPERTIES_REPLICATION_NUM);
             replicationNum = PropertyAnalyzer.analyzeReplicationNum(properties, replicationNum);
             if (isReplicationNumSet) {
+                if (replicationNum < Config.min_replica_num || replicationNum > Config.max_replica_num) {
+                    throw new DdlException("replication num is out of range limit");
+                }
                 olapTable.setReplicationNum(replicationNum);
             }
         } catch (AnalysisException e) {

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Catalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Catalog.java
@@ -3631,9 +3631,6 @@ public class Catalog {
             boolean isReplicationNumSet = properties != null && properties.containsKey(PropertyAnalyzer.PROPERTIES_REPLICATION_NUM);
             replicationNum = PropertyAnalyzer.analyzeReplicationNum(properties, replicationNum);
             if (isReplicationNumSet) {
-                if (replicationNum < Config.min_replica_num || replicationNum > Config.max_replica_num) {
-                    throw new DdlException("replication num is out of range limit");
-                }
                 olapTable.setReplicationNum(replicationNum);
             }
         } catch (AnalysisException e) {

--- a/fe/fe-core/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/Config.java
@@ -1396,4 +1396,12 @@ public class Config extends ConfigBase {
      */
     @ConfField(mutable = true, masterOnly = true)
     public static int max_dynamic_partition_num = 500;
+
+    /**
+     * min/max replica number limit
+     */
+    @ConfField(mutable = true)
+    public static int min_replica_num = 1;
+    @ConfField(mutable = true)
+    public static int max_replica_num = Integer.MAX_VALUE;
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/common/ErrorCode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/ErrorCode.java
@@ -241,7 +241,9 @@ public enum ErrorCode {
     ERROR_CREATE_TABLE_LIKE_EMPTY(5073, new byte[] {'4', '2', '0', '0', '0'},
             "Origin create table stmt is empty"),
     ERROR_DYNAMIC_PARTITION_CREATE_HISTORY_PARTITION(5074, new byte[]{'4', '2', '0', '0', '0'},
-            "Invalid dynamic partition create_history_partition: %s. Expected true or false");
+            "Invalid dynamic partition create_history_partition: %s. Expected true or false"),
+    ERROR_DYNAMIC_PARTITION_REPLICATION_NUM_LIMIT(5075, new byte[] {'4', '2', '0', '0', '0'},
+            "Dynamic partition replication num out of [%s,%s].");
 
     ErrorCode(int code, byte[] sqlState, String errorMsg) {
         this.code = code;

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/DynamicPartitionUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/DynamicPartitionUtil.java
@@ -187,8 +187,9 @@ public class DynamicPartitionUtil {
             throw new DdlException("Invalid properties: " + DynamicPartitionProperty.REPLICATION_NUM);
         }
         try {
-            if (Integer.parseInt(val) <= 0) {
-                ErrorReport.reportDdlException(ErrorCode.ERROR_DYNAMIC_PARTITION_REPLICATION_NUM_ZERO);
+            if (Integer.parseInt(val) < Config.min_replica_num || Integer.parseInt(val) > Config.max_replica_num) {
+                ErrorReport.reportDdlException(ErrorCode.ERROR_DYNAMIC_PARTITION_REPLICATION_NUM_LIMIT,
+                        Config.min_replica_num, Config.max_replica_num);
             }
         } catch (NumberFormatException e) {
             ErrorReport.reportDdlException(ErrorCode.ERROR_DYNAMIC_PARTITION_REPLICATION_NUM_FORMAT, val);

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/PropertyAnalyzer.java
@@ -32,14 +32,11 @@ import org.apache.doris.thrift.TStorageFormat;
 import org.apache.doris.thrift.TStorageMedium;
 import org.apache.doris.thrift.TStorageType;
 import org.apache.doris.thrift.TTabletType;
-
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.Sets;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -183,12 +180,10 @@ public class PropertyAnalyzer {
             } catch (Exception e) {
                 throw new AnalysisException(e.getMessage());
             }
-
-            if (replicationNum <= 0) {
-                throw new AnalysisException("Replication num should larger than 0. (suggested 3)");
-            }
-
             properties.remove(PROPERTIES_REPLICATION_NUM);
+            if (replicationNum > Config.max_replica_num || replicationNum < Config.min_replica_num) {
+                throw new AnalysisException("replica number is out of limit range");
+            }
         }
         return replicationNum;
     }

--- a/fe/fe-core/src/test/java/org/apache/doris/alter/AlterJobV2Test.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/alter/AlterJobV2Test.java
@@ -186,4 +186,26 @@ public class AlterJobV2Test {
             Assert.assertTrue(e.getMessage().contains("Nothing is changed"));
         }
     }
+
+    @Test
+    public void testReplicaNumLimit() throws Exception {
+        Config.min_replica_num = 3;
+        Config.max_replica_num = 3;
+        // 1. process a schema change job
+        String alterStmtStr = "alter table test.schema_change_test set (\"default.replication_num\" = \"1\")";
+        AlterTableStmt alterTableStmt = (AlterTableStmt) UtFrameUtils.parseAndAnalyzeStmt(alterStmtStr, connectContext);
+        try {
+            Catalog.getCurrentCatalog().getAlterInstance().processAlterTable(alterTableStmt);
+        } catch (Exception e) {
+            Assert.assertTrue(e.getMessage().contains("replica number is out of limit range"));
+        }
+
+        alterStmtStr = "alter table test.schema_change_test set (\"default.replication_num\" = \"3\")";
+        alterTableStmt = (AlterTableStmt) UtFrameUtils.parseAndAnalyzeStmt(alterStmtStr, connectContext);
+        try {
+            Catalog.getCurrentCatalog().getAlterInstance().processAlterTable(alterTableStmt);
+        } catch (Exception e) {
+            Assert.fail();
+        }
+    }
 }


### PR DESCRIPTION
## Proposed changes

We found some user create a tale with only one replica. It is high risking for losing data. We also found some users own a table with more than 5 replicas, it is big waste of storage.

Therefore this PR add min/max replica config to limit creating/altering table.

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Code refactor (Modify the code structure, format the code, etc...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have created an issue on (Fix #6035) and described the bug/feature there in detail
- [x] Compiling and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] If these changes need document changes, I have updated the document
- [x] Any dependent changes have been merged

## Further comments

If this is a relatively large or complex change, kick off the discussion at dev@doris.apache.org by explaining why you chose the solution you did and what alternatives you considered, etc...
