### PR TITLE
[Optimize] Optimize profile lock conflict and view profile while query is executing

### DIFF
--- a/be/src/runtime/fragment_mgr.cpp
+++ b/be/src/runtime/fragment_mgr.cpp
@@ -287,8 +287,12 @@ void FragmentExecState::coordinator_callback(const Status& status, RuntimeProfil
         if (runtime_state->query_options().query_type == TQueryType::LOAD) {
             params.__set_loaded_rows(runtime_state->num_rows_load_total());
         }
-        profile->to_thrift(&params.profile);
-        params.__isset.profile = true;
+        if (profile == nullptr) {
+            params.__isset.profile = false;
+        } else {
+            profile->to_thrift(&params.profile);
+            params.__isset.profile = true;
+        }
 
         if (!runtime_state->output_files().empty()) {
             params.__isset.delta_urls = true;
@@ -582,31 +586,6 @@ void FragmentMgr::cancel_worker() {
         }
     } while (!_stop_background_threads_latch.wait_for(MonoDelta::FromSeconds(1)));
     LOG(INFO) << "FragmentMgr cancel worker is going to exit.";
-}
-
-Status FragmentMgr::trigger_profile_report(const PTriggerProfileReportRequest* request) {
-    if (request->instance_ids_size() > 0) {
-        for (int i = 0; i < request->instance_ids_size(); i++) {
-            const PUniqueId& p_fragment_id = request->instance_ids(i);
-            TUniqueId id;
-            id.__set_hi(p_fragment_id.hi());
-            id.__set_lo(p_fragment_id.lo());
-            {
-                std::lock_guard<std::mutex> lock(_lock);
-                auto iter = _fragment_map.find(id);
-                if (iter != _fragment_map.end()) {
-                    iter->second->executor()->report_profile_once();
-                }
-            }
-        }
-    } else {
-        std::lock_guard<std::mutex> lock(_lock);
-        auto iter = _fragment_map.begin();
-        for (; iter != _fragment_map.end(); iter++) {
-            iter->second->executor()->report_profile_once();
-        }
-    }
-    return Status::OK();
 }
 
 void FragmentMgr::debug(std::stringstream& ss) {

--- a/be/src/runtime/fragment_mgr.h
+++ b/be/src/runtime/fragment_mgr.h
@@ -73,8 +73,6 @@ public:
 
     virtual void debug(std::stringstream& ss);
 
-    Status trigger_profile_report(const PTriggerProfileReportRequest* request);
-
     // input: TScanOpenParams fragment_instance_id
     // output: selected_columns
     // execute external query, all query info are packed in TScanOpenParams

--- a/be/src/runtime/plan_fragment_executor.cpp
+++ b/be/src/runtime/plan_fragment_executor.cpp
@@ -241,7 +241,7 @@ Status PlanFragmentExecutor::open() {
     // may block
     // TODO: if no report thread is started, make sure to send a final profile
     // at end, otherwise the coordinator hangs in case we finish w/ an error
-    if (!_report_status_cb.empty() && config::status_report_interval > 0) {
+    if (_is_report_success && !_report_status_cb.empty() && config::status_report_interval > 0) {
         std::unique_lock<std::mutex> l(_report_thread_lock);
         _report_thread = boost::thread(&PlanFragmentExecutor::report_profile, this);
         // make sure the thread started up, otherwise report_profile() might get into a race
@@ -365,9 +365,8 @@ void PlanFragmentExecutor::report_profile() {
     int report_fragment_offset = rand() % config::status_report_interval;
     // We don't want to wait longer than it takes to run the entire fragment.
     _stop_report_thread_cv.wait_for(l, std::chrono::seconds(report_fragment_offset));
-    bool is_report_profile_interval = _is_report_success && config::status_report_interval > 0;
     while (_report_thread_active) {
-        if (is_report_profile_interval) {
+        if (config::status_report_interval > 0) {
             // wait_for can return because the timeout occurred or the condition variable
             // was signaled.  We can't rely on its return value to distinguish between the
             // two cases (e.g. there is a race here where the wait timed out but before grabbing
@@ -376,8 +375,8 @@ void PlanFragmentExecutor::report_profile() {
             _stop_report_thread_cv.wait_for(l,
                                             std::chrono::seconds(config::status_report_interval));
         } else {
-            // Artificial triggering, such as show proc "/current_queries".
-            _stop_report_thread_cv.wait(l);
+            LOG(WARNING) << "config::status_report_interval is equal to or less than zero, exiting reporting thread.";
+            break;
         }
 
         if (VLOG_FILE_IS_ON) {
@@ -427,7 +426,11 @@ void PlanFragmentExecutor::send_report(bool done) {
     // This will send a report even if we are cancelled.  If the query completed correctly
     // but fragments still need to be cancelled (e.g. limit reached), the coordinator will
     // be waiting for a final report and profile.
-    _report_status_cb(status, profile(), done || !status.ok());
+    if (_is_report_success) {
+        _report_status_cb(status, profile(), done || !status.ok());
+    } else {
+        _report_status_cb(status, nullptr, done || !status.ok());
+    }
 }
 
 void PlanFragmentExecutor::stop_report_thread() {
@@ -565,7 +568,7 @@ void PlanFragmentExecutor::close() {
             }
         }
 
-        {
+        if (_is_report_success) {
             std::stringstream ss;
             // Compute the _local_time_percent before pretty_print the runtime_profile
             // Before add this operation, the print out like that:

--- a/be/src/runtime/plan_fragment_executor.h
+++ b/be/src/runtime/plan_fragment_executor.h
@@ -143,8 +143,6 @@ public:
 
     DataSink* get_sink() { return _sink.get(); }
 
-    void report_profile_once() { _stop_report_thread_cv.notify_one(); }
-
     void set_is_report_on_cancel(bool val) { _is_report_on_cancel = val; }
 
 private:

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -183,16 +183,6 @@ void PInternalServiceImpl<T>::fetch_data(google::protobuf::RpcController* cntl_b
 }
 
 template <typename T>
-void PInternalServiceImpl<T>::trigger_profile_report(google::protobuf::RpcController* controller,
-                                                     const PTriggerProfileReportRequest* request,
-                                                     PTriggerProfileReportResult* result,
-                                                     google::protobuf::Closure* done) {
-    brpc::ClosureGuard closure_guard(done);
-    auto st = _exec_env->fragment_mgr()->trigger_profile_report(request);
-    st.to_protobuf(result->mutable_status());
-}
-
-template <typename T>
 void PInternalServiceImpl<T>::get_info(google::protobuf::RpcController* controller,
                                        const PProxyRequest* request, PProxyResult* response,
                                        google::protobuf::Closure* done) {

--- a/be/src/service/internal_service.h
+++ b/be/src/service/internal_service.h
@@ -70,11 +70,6 @@ public:
                               PTabletWriterCancelResult* response,
                               google::protobuf::Closure* done) override;
 
-    void trigger_profile_report(google::protobuf::RpcController* controller,
-                                const PTriggerProfileReportRequest* request,
-                                PTriggerProfileReportResult* result,
-                                google::protobuf::Closure* done) override;
-
     void get_info(google::protobuf::RpcController* controller, const PProxyRequest* request,
                   PProxyResult* response, google::protobuf::Closure* done) override;
 

--- a/be/src/util/runtime_profile.cpp
+++ b/be/src/util/runtime_profile.cpp
@@ -57,11 +57,12 @@ RuntimeProfile::RuntimeProfile(const std::string& name, bool is_averaged_profile
 }
 
 RuntimeProfile::~RuntimeProfile() {
-    std::map<std::string, Counter*>::const_iterator iter;
+    for (auto iter = _rate_counters.begin(); iter != _rate_counters.end(); ++iter) {
+        stop_rate_counters_updates(*iter);
+    }
 
-    for (iter = _counter_map.begin(); iter != _counter_map.end(); ++iter) {
-        stop_rate_counters_updates(iter->second);
-        stop_sampling_counters_updates(iter->second);
+    for (auto iter = _sampling_counters.begin(); iter != _sampling_counters.end(); ++iter) {
+        stop_sampling_counters_updates(*iter);
     }
 
     std::set<std::vector<Counter*>*>::const_iterator buckets_iter;
@@ -653,6 +654,7 @@ RuntimeProfile::Counter* RuntimeProfile::add_rate_counter(const std::string& nam
     }
 
     Counter* dst_counter = add_counter(name, dst_type);
+    _rate_counters.push_back(dst_counter);
     register_periodic_counter(src_counter, NULL, dst_counter, RATE_COUNTER);
     return dst_counter;
 }
@@ -675,6 +677,7 @@ RuntimeProfile::Counter* RuntimeProfile::add_sampling_counter(const std::string&
 RuntimeProfile::Counter* RuntimeProfile::add_sampling_counter(const std::string& name,
                                                               SampleFn sample_fn) {
     Counter* dst_counter = add_counter(name, TUnit::DOUBLE_VALUE);
+    _sampling_counters.push_back(dst_counter);
     register_periodic_counter(NULL, sample_fn, dst_counter, SAMPLING_COUNTER);
     return dst_counter;
 }

--- a/be/src/util/runtime_profile.h
+++ b/be/src/util/runtime_profile.h
@@ -514,6 +514,10 @@ private:
     // of the total time in the entire profile tree.
     double _local_time_percent;
 
+    std::vector<Counter*> _rate_counters;
+
+    std::vector<Counter*> _sampling_counters;
+
     enum PeriodicCounterType {
         RATE_COUNTER = 0,
         SAMPLING_COUNTER,

--- a/fe/fe-core/src/main/java/org/apache/doris/common/proc/CurrentQueryFragmentProcNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/proc/CurrentQueryFragmentProcNode.java
@@ -34,6 +34,7 @@ import java.util.List;
 
 /*
  * show proc "/current_queries/{query_id}/fragments"
+ * set variable "set is_report_success = true" to enable "ScanBytes" and "ProcessRows".
  */
 public class CurrentQueryFragmentProcNode implements ProcNodeInterface {
     private static final Logger LOG = LogManager.getLogger(CurrentQueryFragmentProcNode.class);
@@ -79,10 +80,15 @@ public class CurrentQueryFragmentProcNode implements ProcNodeInterface {
             rowData.add(instanceStatistics.getFragmentId());
             rowData.add(instanceStatistics.getInstanceId().toString());
             rowData.add(instanceStatistics.getAddress().toString());
-            rowData.add(QueryStatisticsFormatter.getScanBytes(
-                    instanceStatistics.getScanBytes()));
-            rowData.add(QueryStatisticsFormatter.getRowsReturned(
-                    instanceStatistics.getRowsReturned()));
+            if (item.getIsReportSucc()) {
+                rowData.add(QueryStatisticsFormatter.getScanBytes(
+                        instanceStatistics.getScanBytes()));
+                rowData.add(QueryStatisticsFormatter.getRowsReturned(
+                        instanceStatistics.getRowsReturned()));
+            } else {
+                rowData.add("N/A");
+                rowData.add("N/A");
+            }
             sortedRowData.add(rowData);
         }
 
@@ -90,9 +96,7 @@ public class CurrentQueryFragmentProcNode implements ProcNodeInterface {
         sortedRowData.sort(new Comparator<List<String>>() {
             @Override
             public int compare(List<String> l1, List<String> l2) {
-                final Integer fragmentId1 = Integer.valueOf(l1.get(0));
-                final Integer fragmentId2 = Integer.valueOf(l2.get(0));
-                return fragmentId1.compareTo(fragmentId2);
+                return l1.get(0).compareTo(l2.get(0));
             }
         });
         final BaseProcResult result = new BaseProcResult();

--- a/fe/fe-core/src/main/java/org/apache/doris/common/proc/CurrentQueryStatisticsProcDir.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/proc/CurrentQueryStatisticsProcDir.java
@@ -32,8 +32,10 @@ import org.apache.logging.log4j.Logger;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+
 /*
  * show proc "/current_queries"
+ * only set variable "set is_report_success = true" to enable "ScanBytes" and "ProcessRows".
  */
 public class CurrentQueryStatisticsProcDir implements ProcDirInterface {
     private static final Logger LOG = LogManager.getLogger(CurrentQueryStatisticsProcDir.class);
@@ -78,12 +80,17 @@ public class CurrentQueryStatisticsProcDir implements ProcDirInterface {
             values.add(item.getConnId());
             values.add(item.getDb());
             values.add(item.getUser());
-            final CurrentQueryInfoProvider.QueryStatistics statistics 
-                    = statisticsMap.get(item.getQueryId());
-            values.add(QueryStatisticsFormatter.getScanBytes(
-                    statistics.getScanBytes()));
-            values.add(QueryStatisticsFormatter.getRowsReturned(
-                    statistics.getRowsReturned()));
+            if (item.getIsReportSucc()) {
+                final CurrentQueryInfoProvider.QueryStatistics statistics
+                        = statisticsMap.get(item.getQueryId());
+                values.add(QueryStatisticsFormatter.getScanBytes(
+                        statistics.getScanBytes()));
+                values.add(QueryStatisticsFormatter.getRowsReturned(
+                        statistics.getRowsReturned()));
+            } else {
+                values.add("N/A");
+                values.add("N/A");
+            }
             values.add(item.getQueryExecTime());
             sortedRowData.add(values);
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/ProfileManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/ProfileManager.java
@@ -62,9 +62,10 @@ public class ProfileManager {
     public static final String TOTAL_TIME = "Total";
     public static final String QUERY_TYPE = "Query Type";
     public static final String QUERY_STATE = "Query State";
-    public static final String SQL_STATEMENT = "Sql Statement";
+    public static final String DORIS_VERSION = "Doris Version";
     public static final String USER = "User";
     public static final String DEFAULT_DB = "Default Db";
+    public static final String SQL_STATEMENT = "Sql Statement";
     public static final String IS_CACHED = "Is Cached";
 
     public static final ArrayList<String> PROFILE_HEADERS = new ArrayList(
@@ -78,13 +79,14 @@ public class ProfileManager {
         public String errMsg = "";
     }
     
-    // only protect profileDeque; profileMap is concurrent, no need to protect
+    // only protect queryIdDeque; queryIdToProfileMap is concurrent, no need to protect
     private ReentrantReadWriteLock lock; 
     private ReadLock readLock;
     private WriteLock writeLock;
 
-    private Deque<ProfileElement> profileDeque;
-    private Map<String, ProfileElement> profileMap; // from QueryId to RuntimeProfile
+    // record the order of profiles by queryId
+    private Deque<String> queryIdDeque;
+    private Map<String, ProfileElement> queryIdToProfileMap; // from QueryId to RuntimeProfile
     
     public static ProfileManager getInstance() {
         if (INSTANCE == null) {
@@ -101,8 +103,8 @@ public class ProfileManager {
         lock = new ReentrantReadWriteLock(true); 
         readLock = lock.readLock();
         writeLock = lock.writeLock();
-        profileDeque = new LinkedList<ProfileElement>();
-        profileMap = new ConcurrentHashMap<String, ProfileElement>();
+        queryIdDeque = new LinkedList<>();
+        queryIdToProfileMap = new ConcurrentHashMap<>();
     }
     
     public ProfileElement createElement(RuntimeProfile profile) {
@@ -117,7 +119,7 @@ public class ProfileManager {
             builder.build();
         } catch (Exception e) {
             element.errMsg = e.getMessage();
-            LOG.warn("failed to build profile tree", e);
+            LOG.debug("failed to build profile tree", e);
             return element;
         }
 
@@ -139,15 +141,19 @@ public class ProfileManager {
             LOG.warn("the key or value of Map is null, "
                     + "may be forget to insert 'QUERY_ID' column into infoStrings");
         }
-        
-        profileMap.put(queryId, element);
+
+        // a profile may be updated multiple times in queryIdToProfileMap,
+        // and only needs to be inserted into the queryIdDeque for the first time.
+        queryIdToProfileMap.put(queryId, element);
         writeLock.lock();
-        try { 
-            if (profileDeque.size() >= ARRAY_SIZE) {
-                profileMap.remove(profileDeque.getFirst().infoStrings.get(QUERY_ID));
-                profileDeque.removeFirst();
+        try {
+            if (!queryIdDeque.contains(queryId)) {
+                if (queryIdDeque.size() >= ARRAY_SIZE) {
+                    queryIdToProfileMap.remove(queryIdDeque.getFirst());
+                    queryIdDeque.removeFirst();
+                }
+                queryIdDeque.addLast(queryId);
             }
-            profileDeque.addLast(element);
         } finally {
             writeLock.unlock();
         }
@@ -157,10 +163,14 @@ public class ProfileManager {
         List<List<String>> result = Lists.newArrayList();
         readLock.lock();
         try {
-            Iterator reverse = profileDeque.descendingIterator();
+            Iterator reverse = queryIdDeque.descendingIterator();
             while (reverse.hasNext()) {
-                ProfileElement element = (ProfileElement) reverse.next();
-                Map<String, String> infoStrings = element.infoStrings;
+                String  queryId = (String) reverse.next();
+                ProfileElement profileElement = queryIdToProfileMap.get(queryId);
+                if (profileElement == null){
+                    continue;
+                }
+                Map<String, String> infoStrings = profileElement.infoStrings;
                 
                 List<String> row = Lists.newArrayList();
                 for (String str : PROFILE_HEADERS ) {
@@ -177,7 +187,7 @@ public class ProfileManager {
     public String getProfile(String queryID) {
         readLock.lock();
         try {
-            ProfileElement element = profileMap.get(queryID);
+            ProfileElement element = queryIdToProfileMap.get(queryID);
             if (element == null) {
                 return null;
             }
@@ -191,7 +201,7 @@ public class ProfileManager {
     public String getFragmentProfileTreeString(String queryID) {
         readLock.lock();
         try {
-            ProfileElement element = profileMap.get(queryID);
+            ProfileElement element = queryIdToProfileMap.get(queryID);
             if (element == null || element.builder == null) {
                 return null;
             }
@@ -209,7 +219,7 @@ public class ProfileManager {
         ProfileTreeNode tree;
         readLock.lock();
         try {
-            ProfileElement element = profileMap.get(queryID);
+            ProfileElement element = queryIdToProfileMap.get(queryID);
             if (element == null || element.builder == null) {
                 throw new AnalysisException("failed to get fragment profile tree. err: "
                         + (element == null ? "not found" : element.errMsg));
@@ -224,7 +234,7 @@ public class ProfileManager {
         ProfileTreeBuilder builder;
         readLock.lock();
         try {
-            ProfileElement element = profileMap.get(queryID);
+            ProfileElement element = queryIdToProfileMap.get(queryID);
             if (element == null || element.builder == null) {
                 throw new AnalysisException("failed to get instance list. err: "
                         + (element == null ? "not found" : element.errMsg));
@@ -241,7 +251,7 @@ public class ProfileManager {
         ProfileTreeBuilder builder;
         readLock.lock();
         try {
-            ProfileElement element = profileMap.get(queryID);
+            ProfileElement element = queryIdToProfileMap.get(queryID);
             if (element == null || element.builder == null) {
                 throw new AnalysisException("failed to get instance profile tree. err: "
                         + (element == null ? "not found" : element.errMsg));

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/ProfileWriter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/ProfileWriter.java
@@ -1,0 +1,24 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.common.util;
+
+// this interface is used to write profile to ProfileManager when a task is running.
+public interface ProfileWriter {
+
+    void writeProfile(boolean waitReportDone);
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
@@ -29,6 +29,7 @@ import org.apache.doris.common.Status;
 import org.apache.doris.common.UserException;
 import org.apache.doris.common.util.DebugUtil;
 import org.apache.doris.common.util.ListUtil;
+import org.apache.doris.common.util.ProfileWriter;
 import org.apache.doris.common.util.RuntimeProfile;
 import org.apache.doris.common.util.TimeUtils;
 import org.apache.doris.load.LoadErrorHub;
@@ -156,6 +157,8 @@ public class Coordinator {
 
     private List<RuntimeProfile> fragmentProfile;
 
+    private ProfileWriter profileWriter;
+
     // populated in computeFragmentExecParams()
     private Map<PlanFragmentId, FragmentExecParams> fragmentExecParamsMap = Maps.newHashMap();
 
@@ -266,6 +269,14 @@ public class Coordinator {
 
     public RuntimeProfile getQueryProfile() {
         return queryProfile;
+    }
+
+    public ProfileWriter getProfileWriter() {
+        return profileWriter;
+    }
+
+    public void setProfileWriter(ProfileWriter profileWriter) {
+        this.profileWriter = profileWriter;
     }
 
     public List<String> getDeltaUrls() {
@@ -1403,17 +1414,19 @@ public class Coordinator {
                     jobId, params.backend_id, params.query_id, params.fragment_instance_id, params.loaded_rows,
                     params.done);
         }
-
-        return;
     }
 
     public void endProfile() {
+        endProfile(true);
+    }
+
+    public void endProfile(boolean waitProfileDone) {
         if (backendExecStates.isEmpty()) {
             return;
         }
 
-        // wait for all backends
-        if (needReport) {
+        // Wait for all backends to finish reporting when writing profile last time.
+        if (waitProfileDone && needReport) {
             try {
                 profileDoneSignal.await(2, TimeUnit.SECONDS);
             } catch (InterruptedException e1) {
@@ -1701,7 +1714,7 @@ public class Coordinator {
         PlanFragmentId fragmentId;
         int instanceId;
         boolean initiated;
-        boolean done;
+        volatile boolean done;
         boolean hasCanceled;
         int profileFragmentId;
         RuntimeProfile profile;

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/QueryStatisticsItem.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/QueryStatisticsItem.java
@@ -35,6 +35,7 @@ public final class QueryStatisticsItem {
     private final List<FragmentInstanceInfo> fragmentInstanceInfos;
     // root query profile
     private final RuntimeProfile queryProfile;
+    private final boolean isReportSucc;
 
     private QueryStatisticsItem(Builder builder) {
         this.queryId = builder.queryId;
@@ -45,6 +46,7 @@ public final class QueryStatisticsItem {
         this.queryStartTime = builder.queryStartTime;
         this.fragmentInstanceInfos = builder.fragmentInstanceInfos;
         this.queryProfile = builder.queryProfile;
+        this.isReportSucc = builder.isReportSucc;
     }
 
     public String getDb() {
@@ -80,6 +82,10 @@ public final class QueryStatisticsItem {
         return queryProfile;
     }
 
+    public boolean getIsReportSucc () {
+        return isReportSucc;
+    }
+
     public static final class Builder {
         private String queryId;
         private String db;
@@ -89,6 +95,7 @@ public final class QueryStatisticsItem {
         private long queryStartTime;
         private List<FragmentInstanceInfo> fragmentInstanceInfos;
         private RuntimeProfile queryProfile;
+        private boolean isReportSucc;
 
         public Builder() {
             fragmentInstanceInfos = Lists.newArrayList();
@@ -131,6 +138,11 @@ public final class QueryStatisticsItem {
 
         public Builder profile(RuntimeProfile profile) {
             this.queryProfile = profile;
+            return this;
+        }
+
+        public Builder isReportSucc(boolean isReportSucc) {
+            this.isReportSucc = isReportSucc;
             return this;
         }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/rpc/BackendServiceClient.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/rpc/BackendServiceClient.java
@@ -73,11 +73,6 @@ public class BackendServiceClient {
         return stub.clearCache(request);
     }
 
-    public Future<InternalService.PTriggerProfileReportResult> triggerProfileReport(
-            InternalService.PTriggerProfileReportRequest request) {
-        return stub.triggerProfileReport(request);
-    }
-
     public Future<InternalService.PProxyResult> getInfo(InternalService.PProxyRequest request) {
         return stub.getInfo(request);
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/rpc/BackendServiceProxy.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/rpc/BackendServiceProxy.java
@@ -157,18 +157,6 @@ public class BackendServiceProxy {
         }
     }
 
-    public Future<InternalService.PTriggerProfileReportResult> triggerProfileReportAsync(
-            TNetworkAddress address, InternalService.PTriggerProfileReportRequest request) throws RpcException {
-        try {
-            final BackendServiceClient client = getProxy(address);
-            return client.triggerProfileReport(request);
-        } catch (Throwable e) {
-            LOG.warn("fetch data catch a exception, address={}:{}",
-                    address.getHostname(), address.getPort(), e);
-            throw new RpcException(address.hostname, e.getMessage());
-        }
-    }
-
     public Future<InternalService.PProxyResult> getInfo(
             TNetworkAddress address, InternalService.PProxyRequest request) throws RpcException {
         try {

--- a/fe/fe-core/src/main/java/org/apache/doris/task/ExportExportingTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/task/ExportExportingTask.java
@@ -260,7 +260,7 @@ public class ExportExportingTask extends MasterTask {
 
         summaryProfile.addInfoString(ProfileManager.QUERY_TYPE, "Query");
         summaryProfile.addInfoString(ProfileManager.QUERY_STATE, job.getState().toString());
-        summaryProfile.addInfoString("Doris Version", Version.DORIS_BUILD_VERSION);
+        summaryProfile.addInfoString(ProfileManager.DORIS_VERSION, Version.DORIS_BUILD_VERSION);
         summaryProfile.addInfoString(ProfileManager.USER, "xxx");
         summaryProfile.addInfoString(ProfileManager.DEFAULT_DB, String.valueOf(job.getDbId()));
         summaryProfile.addInfoString(ProfileManager.SQL_STATEMENT, job.getSql());

--- a/fe/fe-core/src/test/java/org/apache/doris/utframe/MockedBackendFactory.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/utframe/MockedBackendFactory.java
@@ -333,14 +333,6 @@ public class MockedBackendFactory {
         }
 
         @Override
-        public void triggerProfileReport(InternalService.PTriggerProfileReportRequest request, StreamObserver<InternalService.PTriggerProfileReportResult> responseObserver) {
-            System.out.println("get triggerProfileReport request");
-            responseObserver.onNext(InternalService.PTriggerProfileReportResult.newBuilder()
-                    .setStatus(Status.PStatus.newBuilder().setStatusCode(0)).build());
-            responseObserver.onCompleted();
-        }
-
-        @Override
         public void getInfo(InternalService.PProxyRequest request, StreamObserver<InternalService.PProxyResult> responseObserver) {
             System.out.println("get get_info request");
             responseObserver.onNext(InternalService.PProxyResult.newBuilder()

--- a/gensrc/proto/internal_service.proto
+++ b/gensrc/proto/internal_service.proto
@@ -211,14 +211,6 @@ message PClearCacheRequest {
 };
 //End cache proto definition
 
-message PTriggerProfileReportRequest {
-    repeated PUniqueId instance_ids = 1;
-};
-
-message PTriggerProfileReportResult {
-    required PStatus status = 1;
-};
-
 message PStringPair {
     required string key = 1;
     required string val = 2;
@@ -257,7 +249,6 @@ service PBackendService {
     rpc tablet_writer_open(PTabletWriterOpenRequest) returns (PTabletWriterOpenResult);
     rpc tablet_writer_add_batch(PTabletWriterAddBatchRequest) returns (PTabletWriterAddBatchResult);
     rpc tablet_writer_cancel(PTabletWriterCancelRequest) returns (PTabletWriterCancelResult);
-    rpc trigger_profile_report(PTriggerProfileReportRequest) returns (PTriggerProfileReportResult);
     rpc get_info(PProxyRequest) returns (PProxyResult); 
     rpc update_cache(PUpdateCacheRequest) returns (PCacheResponse);
     rpc fetch_cache(PFetchCacheRequest) returns (PFetchCacheResult);

--- a/gensrc/proto/palo_internal_service.proto
+++ b/gensrc/proto/palo_internal_service.proto
@@ -34,7 +34,6 @@ service PInternalService {
     rpc tablet_writer_open(doris.PTabletWriterOpenRequest) returns (doris.PTabletWriterOpenResult);
     rpc tablet_writer_add_batch(doris.PTabletWriterAddBatchRequest) returns (doris.PTabletWriterAddBatchResult);
     rpc tablet_writer_cancel(doris.PTabletWriterCancelRequest) returns (doris.PTabletWriterCancelResult);
-    rpc trigger_profile_report(doris.PTriggerProfileReportRequest) returns (doris.PTriggerProfileReportResult);
     rpc get_info(doris.PProxyRequest) returns (doris.PProxyResult);
     rpc update_cache(doris.PUpdateCacheRequest) returns (doris.PCacheResponse);
     rpc fetch_cache(doris.PFetchCacheRequest) returns (doris.PFetchCacheResult);


### PR DESCRIPTION
## Proposed changes

1. Reduce lock conflicts in RuntimeProfile of be;
2. can view query profile when the query is executing;
3. reduce wait time for 'show proc /current_queries'.

Fixed #5761

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Code refactor (Modify the code structure, format the code, etc...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have created an issue on (Fix #ISSUE) and described the bug/feature there in detail
- [ ] Compiling and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If these changes need document changes, I have updated the document
- [ ] Any dependent changes have been merged

## Further comments

If this is a relatively large or complex change, kick off the discussion at dev@doris.apache.org by explaining why you chose the solution you did and what alternatives you considered, etc...
