### PR TITLE
[Optimize] Reduce lock conflicts in ThreadResourceMgr of be

### DIFF
--- a/be/src/runtime/thread_resource_mgr.h
+++ b/be/src/runtime/thread_resource_mgr.h
@@ -117,14 +117,6 @@ public:
         // Must not be called from from thread_available_cb.
         void release_thread_token(bool required);
 
-        // Add a callback to be notified when a thread is available.
-        // 'arg' is opaque and passed directly to the callback.
-        // The previous callback is no longer notified.
-        // TODO: rethink this.  How we do coordinate when we have multiple places in
-        // the execution that all need threads (e.g. do we use that thread for
-        // the scanner or for the join).
-        void set_thread_available_cb(thread_available_cb fn);
-
         // Returns the number of threads that are from acquire_thread_token.
         int num_required_threads() const { return _num_threads & 0xFFFFFFFF; }
 
@@ -170,13 +162,6 @@ public:
         // swap operations.  The number of required threads is the lower
         // 32 bits and the number of optional threads is the upper 32 bits.
         int64_t _num_threads;
-
-        // Lock for the fields below.  This lock is taken when the callback
-        // function is called.
-        // TODO: reconsider this.
-        std::mutex _lock;
-
-        thread_available_cb _thread_available_fn;
     };
 
     // Create a thread mgr object.  If threads_quota is non-zero, it will be
@@ -214,12 +199,7 @@ private:
     // Recycled list of pool objects
     std::list<ResourcePool*> _free_pool_objs;
 
-    // Updates the per pool quota and notifies any pools that now have
-    // more threads they can use.  Must be called with _lock taken.
-    // If new_pool is non-null, new_pool will *not* be notified.
-    void update_pool_quotas(ResourcePool* new_pool);
-
-    void update_pool_quotas() { update_pool_quotas(NULL); }
+    void update_pool_quotas();
 };
 
 inline void ThreadResourceMgr::ResourcePool::acquire_thread_token() {
@@ -263,20 +243,6 @@ inline void ThreadResourceMgr::ResourcePool::release_thread_token(bool required)
             if (__sync_bool_compare_and_swap(&_num_threads, previous_num_threads, new_value)) {
                 break;
             }
-        }
-    }
-
-    // We need to grab a lock before issuing the callback to prevent the
-    // callback from being removed while it is happening.
-    // Note: this is unlikely to be a big deal for performance currently
-    // since only scanner threads call this with any frequency and that only
-    // happens once when the scanner thread is complete.
-    // TODO: reconsider this.
-    if (num_available_threads() > 0 && _thread_available_fn != NULL) {
-        std::unique_lock<std::mutex> l(_lock);
-
-        if (num_available_threads() > 0 && _thread_available_fn != NULL) {
-            _thread_available_fn(this);
         }
     }
 }

--- a/be/test/runtime/thread_resource_mgr_test.cpp
+++ b/be/test/runtime/thread_resource_mgr_test.cpp
@@ -26,42 +26,20 @@
 
 namespace doris {
 
-class NotifiedCounter {
-public:
-    NotifiedCounter() : _counter(0) {}
-
-    void Notify(ThreadResourceMgr::ResourcePool* consumer) {
-        DCHECK(consumer != NULL);
-        DCHECK_LT(consumer->num_threads(), consumer->quota());
-        ++_counter;
-    }
-
-    int counter() const { return _counter; }
-
-private:
-    int _counter;
-};
-
 TEST(ThreadResourceMgr, BasicTest) {
     ThreadResourceMgr mgr(5);
-    NotifiedCounter counter1;
-    NotifiedCounter counter2;
 
     ThreadResourceMgr::ResourcePool* c1 = mgr.register_pool();
-    c1->set_thread_available_cb(
-            boost::bind<void>(boost::mem_fn(&NotifiedCounter::Notify), &counter1, _1));
     c1->acquire_thread_token();
     c1->acquire_thread_token();
     c1->acquire_thread_token();
     EXPECT_EQ(c1->num_threads(), 3);
     EXPECT_EQ(c1->num_required_threads(), 3);
     EXPECT_EQ(c1->num_optional_threads(), 0);
-    EXPECT_EQ(counter1.counter(), 0);
     c1->release_thread_token(true);
     EXPECT_EQ(c1->num_threads(), 2);
     EXPECT_EQ(c1->num_required_threads(), 2);
     EXPECT_EQ(c1->num_optional_threads(), 0);
-    EXPECT_EQ(counter1.counter(), 1);
     EXPECT_TRUE(c1->try_acquire_thread_token());
     EXPECT_TRUE(c1->try_acquire_thread_token());
     EXPECT_TRUE(c1->try_acquire_thread_token());
@@ -71,12 +49,9 @@ TEST(ThreadResourceMgr, BasicTest) {
     EXPECT_EQ(c1->num_optional_threads(), 3);
     c1->release_thread_token(true);
     c1->release_thread_token(false);
-    EXPECT_EQ(counter1.counter(), 3);
 
     // Register a new consumer, quota is cut in half
     ThreadResourceMgr::ResourcePool* c2 = mgr.register_pool();
-    c2->set_thread_available_cb(
-            boost::bind<void>(boost::mem_fn(&NotifiedCounter::Notify), &counter2, _1));
     EXPECT_FALSE(c1->try_acquire_thread_token());
     EXPECT_EQ(c1->num_threads(), 3);
     c1->acquire_thread_token();
@@ -86,8 +61,6 @@ TEST(ThreadResourceMgr, BasicTest) {
 
     mgr.unregister_pool(c1);
     mgr.unregister_pool(c2);
-    EXPECT_EQ(counter1.counter(), 3);
-    EXPECT_EQ(counter2.counter(), 1);
 }
 
 } // namespace doris


### PR DESCRIPTION

## Proposed changes

Removed some useless code that caused lock conflicts in ThreadResourceMgr of be.

set_thread_available_cb() in ThreadResourceMgr has never been called, and _thread_available_fn is always NULL.
But every time the quota is updated, the thread pool is traversed to execute the _thread_available_fn, that is useless and may cause a lot of lock conflicts.

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Code refactor (Modify the code structure, format the code, etc...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have created an issue on (Fix #ISSUE) and described the bug/feature there in detail
- [x] Compiling and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If these changes need document changes, I have updated the document
- [ ] Any dependent changes have been merged

## Further comments

If this is a relatively large or complex change, kick off the discussion at dev@doris.apache.org by explaining why you chose the solution you did and what alternatives you considered, etc...
