### PR TITLE
[Compaction][ThreadPool]Support adjust compaction threads num at runtime

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -280,7 +280,7 @@ CONF_mInt32(cumulative_compaction_skip_window_seconds, "30");
 CONF_mInt64(min_compaction_failure_interval_sec, "600"); // 10 min
 
 // This config can be set to limit thread number in compaction thread pool.
-CONF_Int32(max_compaction_threads, "10");
+CONF_mInt32(max_compaction_threads, "10");
 
 // Thread count to do tablet meta checkpoint, -1 means use the data directories count.
 CONF_Int32(max_meta_checkpoint_threads, "-1");

--- a/be/src/olap/olap_server.cpp
+++ b/be/src/olap/olap_server.cpp
@@ -333,6 +333,30 @@ void StorageEngine::_compaction_tasks_producer_callback() {
     int64_t interval = config::generate_compaction_tasks_min_interval_ms;
     do {
         if (!config::disable_auto_compaction) {
+            VLOG_CRITICAL << "compaction thread pool. num_threads: " << _compaction_thread_pool->num_threads()
+                      << ", num_threads_pending_start: " << _compaction_thread_pool->num_threads_pending_start()
+                      << ", num_active_threads: " << _compaction_thread_pool->num_active_threads()
+                      << ", max_threads: " << _compaction_thread_pool->max_threads()
+                      << ", min_threads: " << _compaction_thread_pool->min_threads()
+                      << ", num_total_queued_tasks: " << _compaction_thread_pool->get_queue_size();
+
+            if(_compaction_thread_pool->max_threads() != config::max_compaction_threads) {
+                int old_max_threads = _compaction_thread_pool->max_threads();
+                Status status = _compaction_thread_pool->set_max_threads(config::max_compaction_threads);
+                if (status.ok()) {
+                    LOG(INFO) << "update compaction thread pool max_threads from "
+                              << old_max_threads << " to " << config::max_compaction_threads;
+                }
+            }
+            if(_compaction_thread_pool->min_threads() != config::max_compaction_threads) {
+                int old_min_threads = _compaction_thread_pool->min_threads();
+                Status status = _compaction_thread_pool->set_min_threads(config::max_compaction_threads);
+                if (status.ok()) {
+                    LOG(INFO) << "update compaction thread pool min_threads from "
+                              << old_min_threads << " to " << config::max_compaction_threads;
+                }
+            }
+
             bool check_score = false;
             int64_t cur_time = UnixMillis();
             if (round < config::cumulative_compaction_rounds_for_each_base_compaction_round) {

--- a/be/src/util/threadpool.cpp
+++ b/be/src/util/threadpool.cpp
@@ -673,7 +673,7 @@ Status ThreadPool::set_max_threads(int max_threads) {
     }
 
     _max_threads = max_threads;
-    if (_max_threads > _num_threads - _num_threads_pending_start) {
+    if (_max_threads > _num_threads + _num_threads_pending_start) {
         int addition_threads = _max_threads - _num_threads - _num_threads_pending_start;
         addition_threads = std::min(addition_threads, _total_queued_tasks);
         _num_threads_pending_start += addition_threads;

--- a/be/src/util/threadpool.cpp
+++ b/be/src/util/threadpool.cpp
@@ -472,7 +472,7 @@ Status ThreadPool::do_submit(std::shared_ptr<Runnable> r, ThreadPoolToken* token
             }
             // If we failed to create a thread, but there are still some other
             // worker threads, log a warning message and continue.
-            LOG(ERROR) << "Thread pool failed to create thread: " << status.to_string();
+            LOG(WARNING) << "Thread pool failed to create thread: " << status.to_string();
         }
     }
 
@@ -509,9 +509,6 @@ void ThreadPool::dispatch_thread() {
     DCHECK_GT(_num_threads_pending_start, 0);
     _num_threads++;
     _num_threads_pending_start--;
-    // If we are one of the first '_min_threads' to start, we must be
-    // a "permanent" thread.
-    bool permanent = _num_threads <= _min_threads;
 
     // Owned by this worker thread and added/removed from _idle_threads as needed.
     IdleThread me(&_lock);
@@ -520,6 +517,10 @@ void ThreadPool::dispatch_thread() {
         // Note: Status::Aborted() is used to indicate normal shutdown.
         if (!_pool_status.ok()) {
             VLOG_CRITICAL << "DispatchThread exiting: " << _pool_status.to_string();
+            break;
+        }
+
+        if (_num_threads + _num_threads_pending_start > _max_threads) {
             break;
         }
 
@@ -536,21 +537,17 @@ void ThreadPool::dispatch_thread() {
                     _idle_threads.erase(_idle_threads.iterator_to(me));
                 }
             });
-            if (permanent) {
-                me.not_empty.wait();
-            } else {
-                if (!me.not_empty.wait_for(_idle_timeout)) {
-                    // After much investigation, it appears that pthread condition variables have
-                    // a weird behavior in which they can return ETIMEDOUT from timed_wait even if
-                    // another thread did in fact signal. Apparently after a timeout there is some
-                    // brief period during which another thread may actually grab the internal mutex
-                    // protecting the state, signal, and release again before we get the mutex. So,
-                    // we'll recheck the empty queue case regardless.
-                    if (_queue.empty()) {
+            if (!me.not_empty.wait_for(_idle_timeout)) {
+                // After much investigation, it appears that pthread condition variables have
+                // a weird behavior in which they can return ETIMEDOUT from timed_wait even if
+                // another thread did in fact signal. Apparently after a timeout there is some
+                // brief period during which another thread may actually grab the internal mutex
+                // protecting the state, signal, and release again before we get the mutex. So,
+                // we'll recheck the empty queue case regardless.
+                if (_queue.empty() && _num_threads + _num_threads_pending_start > _min_threads) {
                         VLOG_NOTICE << "Releasing worker thread from pool " << _name << " after "
                                 << _idle_timeout.ToMilliseconds() << "ms of idle time.";
                         break;
-                    }
                 }
             }
             continue;
@@ -643,6 +640,53 @@ void ThreadPool::check_not_pool_thread_unlocked() {
                 "name '$1' called pool function that would result in deadlock",
                 _name, current->name());
     }
+}
+
+Status ThreadPool::set_min_threads(int min_threads) {
+    MutexLock unique_lock(&_lock);
+    if (min_threads > _max_threads) {
+        // min threads can not be set greater than max threads
+        return Status::InternalError("set thread pool min_threads failed");
+    }
+
+    _min_threads = min_threads;
+    if (min_threads > _num_threads + _num_threads_pending_start) {
+        int addition_threads = min_threads - _num_threads - _num_threads_pending_start;
+        _num_threads_pending_start += addition_threads;
+        for (int i = 0; i < addition_threads; i++) {
+            Status status = create_thread();
+            if (!status.ok()) {
+                _num_threads_pending_start--;
+                LOG(WARNING) << "Thread pool failed to create thread: " << status.to_string();
+                return status;
+            }
+        }
+    }
+    return Status::OK();
+}
+
+Status ThreadPool::set_max_threads(int max_threads) {
+    MutexLock unique_lock(&_lock);
+    if (_min_threads > max_threads) {
+        // max threads can not be set less than min threads
+        return Status::InternalError("set thread pool max_threads failed");
+    }
+
+    _max_threads = max_threads;
+    if (_max_threads > _num_threads - _num_threads_pending_start) {
+        int addition_threads = _max_threads - _num_threads - _num_threads_pending_start;
+        addition_threads = std::min(addition_threads, _total_queued_tasks);
+        _num_threads_pending_start += addition_threads;
+        for (int i = 0; i < addition_threads; i++) {
+            Status status = create_thread();
+            if (!status.ok()) {
+                _num_threads_pending_start--;
+                LOG(WARNING) << "Thread pool failed to create thread: " << status.to_string();
+                return status;
+            }
+        }
+    }
+    return Status::OK();
 }
 
 std::ostream& operator<<(std::ostream& o, ThreadPoolToken::State s) {

--- a/be/src/util/threadpool.h
+++ b/be/src/util/threadpool.h
@@ -27,6 +27,7 @@
 #include <unordered_set>
 #include <utility>
 
+#include "common/atomic.h"
 #include "common/status.h"
 #include "gutil/ref_counted.h"
 #include "util/condition_variable.h"
@@ -179,6 +180,9 @@ public:
     // Returns true if the pool reached the idle state, false otherwise.
     bool wait_for(const MonoDelta& delta);
 
+    Status set_min_threads(int min_threads);
+    Status set_max_threads(int max_threads);
+
     // Allocates a new token for use in token-based task submission. All tokens
     // must be destroyed before their ThreadPool is destroyed.
     //
@@ -199,6 +203,26 @@ public:
         return _num_threads + _num_threads_pending_start;
     }
 
+    int max_threads() const {
+        MutexLock l(&_lock);
+        return _max_threads;
+    }
+
+    int min_threads() const {
+        MutexLock l(&_lock);
+        return _min_threads;
+    }
+
+    int num_threads_pending_start() const {
+        MutexLock l(&_lock);
+        return _num_threads_pending_start;
+    }
+
+    int num_active_threads() const {
+        MutexLock l(&_lock);
+        return _active_threads;
+    }
+    
     int get_queue_size() const {
         MutexLock l(&_lock);
         return _total_queued_tasks;
@@ -241,8 +265,8 @@ private:
     void release_token(ThreadPoolToken* t);
 
     const std::string _name;
-    const int _min_threads;
-    const int _max_threads;
+    int _min_threads;
+    int _max_threads;
     const int _max_queue_size;
     const MonoDelta _idle_timeout;
 


### PR DESCRIPTION
## Proposed changes

The number of threads in compaction thread pool remains constant(`max_thread_num` is the same as `min_thread_num` in compaction thread pool). Sometimes, we need to adjust compaction thread number dynamically according to memory usage and cpu load of BE.

The method of adjusting `max_thread_num` and `min_thread_num` of thread pool at runtime has been described in ISSUE #5779 .

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Code refactor (Modify the code structure, format the code, etc...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have created an issue on (Fix #5779) and described the bug/feature there in detail
- [x] Compiling and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If these changes need document changes, I have updated the document
- [x] Any dependent changes have been merged

