### PR TITLE
[Bug] Fix Backend UT Problem 

### DIFF
--- a/be/test/runtime/user_function_cache_test.cpp
+++ b/be/test/runtime/user_function_cache_test.cpp
@@ -96,7 +96,7 @@ public:
         hostname = "http://127.0.0.1:" + std::to_string(real_port);
 
         // compile code to so
-        system("g++ -shared ./be/test/runtime/test_data/user_function_cache/lib/my_add.cc -o "
+        system("g++ -shared -fPIC ./be/test/runtime/test_data/user_function_cache/lib/my_add.cc -o "
                "./be/test/runtime/test_data/user_function_cache/lib/my_add.so");
 
         my_add_md5sum =

--- a/be/test/util/filesystem_util_test.cpp
+++ b/be/test/util/filesystem_util_test.cpp
@@ -35,8 +35,9 @@ TEST(FileSystemUtil, rlimit) {
 }
 
 TEST(FileSystemUtil, CreateDirectory) {
+    char filename[] = "temp-XXXXXX";
     // Setup a temporary directory with one subdir
-    std::string dir_name = std::tmpnam(nullptr);
+    std::string dir_name = mkdtemp(filename);
     path dir{dir_name};
     path subdir1 = dir / "path1";
     path subdir2 = dir / "path2";

--- a/be/test/util/threadpool_test.cpp
+++ b/be/test/util/threadpool_test.cpp
@@ -314,6 +314,7 @@ TEST_F(ThreadPoolTest, TestZeroQueueSize) {
 // deadlocks, so we'll disable the entire test instead.
 #ifndef THREAD_SANITIZER
 TEST_F(ThreadPoolTest, TestDeadlocks) {
+    ::testing::FLAGS_gtest_death_test_style = "threadsafe";
     const char* death_msg = "called pool function that would result in deadlock";
     ASSERT_DEATH(
             {


### PR DESCRIPTION
1. relocation R_X86_64_32 against `__gxx_personality_v0' can not be used when making a shared object; recompile with -fPIC
2. warning: the use of `tmpnam' is dangerous, better use `mkstemp'
3. Death tests use fork(), which is unsafe particularly in a threaded context. For this test, Google Test couldn't detect the number of threads.


## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Code refactor (Modify the code structure, format the code, etc...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have created an issue on (Fix #5784) and described the bug/feature there in detail
- [x] Compiling and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] If these changes need document changes, I have updated the document
- [x] Any dependent changes have been merged

