### PR TITLE
[Cache][Enhancement] Assure sql cache only one version

### DIFF
--- a/be/src/runtime/cache/result_node.h
+++ b/be/src/runtime/cache/result_node.h
@@ -128,6 +128,8 @@ public:
     PCacheStatus update_partition(const PUpdateCacheRequest* request, bool& is_update_firstkey);
     PCacheStatus fetch_partition(const PFetchCacheRequest* request,
                                  PartitionRowBatchList& rowBatchList, bool& is_hit_firstkey);
+    PCacheStatus update_sql_cache(const PUpdateCacheRequest* request, bool& is_update_firstkey);
+    PCacheStatus update_partition_cache(const PUpdateCacheRequest* request, bool& is_update_firstkey);
 
     size_t prune_first();
     void clear();

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/cache/RowBatchBuilder.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/cache/RowBatchBuilder.java
@@ -102,7 +102,9 @@ public class RowBatchBuilder {
 
     public InternalService.PUpdateCacheRequest buildSqlUpdateRequest(String sql, long partitionKey, long lastVersion, long lastestTime) {
         if (updateRequest == null) {
-            updateRequest = InternalService.PUpdateCacheRequest.newBuilder().setSqlKey(CacheProxy.getMd5(sql)).build();
+            updateRequest = InternalService.PUpdateCacheRequest.newBuilder()
+                    .setSqlKey(CacheProxy.getMd5(sql))
+                    .setCacheType(InternalService.CacheType.SQL_CACHE).build();
         }
         updateRequest = updateRequest.toBuilder()
                 .addValues(InternalService.PCacheValue.newBuilder()
@@ -139,7 +141,9 @@ public class RowBatchBuilder {
      */
     public InternalService.PUpdateCacheRequest buildPartitionUpdateRequest(String sql) {
         if (updateRequest == null) {
-            updateRequest = InternalService.PUpdateCacheRequest.newBuilder().setSqlKey(CacheProxy.getMd5(sql)).build();
+            updateRequest = InternalService.PUpdateCacheRequest.newBuilder()
+                    .setSqlKey(CacheProxy.getMd5(sql))
+                    .setCacheType(InternalService.CacheType.PARTITION_CACHE).build();
         }
         HashMap<Long, List<byte[]>> partRowMap = new HashMap<>();
         List<byte[]> partitionRowList;

--- a/gensrc/proto/internal_service.proto
+++ b/gensrc/proto/internal_service.proto
@@ -164,6 +164,11 @@ enum PCacheStatus {
     EMPTY_DATA = 8;
 };
 
+enum CacheType {
+    SQL_CACHE = 1;
+    PARTITION_CACHE = 2;
+};
+
 message PCacheParam {
     required int64 partition_key = 1;
     optional int64 last_version = 2;
@@ -184,6 +189,7 @@ message PCacheResponse {
 message PUpdateCacheRequest{
     required PUniqueId sql_key = 1;
     repeated PCacheValue values = 2;
+    optional CacheType cache_type = 3;
 };
 
 message PFetchCacheRequest {


### PR DESCRIPTION
## Proposed changes

For PR #5792. This patch add a new param `cache type` to distinguish sql cache and partition cache. When update sql cache,  we make assure one sql key only has one version cache.

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Code refactor (Modify the code structure, format the code, etc...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have created an issue on (Fix #ISSUE) and described the bug/feature there in detail
- [x] Compiling and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] If these changes need document changes, I have updated the document
- [x] Any dependent changes have been merged

## Further comments

If this is a relatively large or complex change, kick off the discussion at dev@doris.apache.org by explaining why you chose the solution you did and what alternatives you considered, etc...
