### PR TITLE
[Bug-fix] Fix Be cores when user specified HLL or BITMAP as operand of BinaryPredicate

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/BinaryPredicate.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/BinaryPredicate.java
@@ -284,10 +284,10 @@ public class BinaryPredicate extends Predicate implements Writable {
 
         for (Expr e : getChildren()) {
             if (e.getType().getPrimitiveType() == PrimitiveType.HLL) {
-                throw new AnalysisException("Hll type can not be a operand: " + toSql());
+                throw new AnalysisException("Hll type dose not support operand: " + toSql());
             }
             if (e.getType().getPrimitiveType() == PrimitiveType.BITMAP) {
-                throw new AnalysisException("Bitmap type can not be a operand: " + toSql());
+                throw new AnalysisException("Bitmap type dose not support operand: " + toSql());
             }
         }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/BinaryPredicate.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/BinaryPredicate.java
@@ -279,6 +279,9 @@ public class BinaryPredicate extends Predicate implements Writable {
     }
 
     private Type getCmpType() throws AnalysisException {
+        PrimitiveType t1 = getChild(0).getType().getResultType().getPrimitiveType();
+        PrimitiveType t2 = getChild(1).getType().getResultType().getPrimitiveType();
+
         for (Expr e : getChildren()) {
             if (e.getType().getPrimitiveType() == PrimitiveType.HLL) {
                 throw new AnalysisException("Hll type can not be a operand: " + toSql());
@@ -287,9 +290,6 @@ public class BinaryPredicate extends Predicate implements Writable {
                 throw new AnalysisException("Bitmap type can not be a operand: " + toSql());
             }
         }
-
-        PrimitiveType t1 = getChild(0).getType().getResultType().getPrimitiveType();
-        PrimitiveType t2 = getChild(1).getType().getResultType().getPrimitiveType();
 
         if (canCompareDate(getChild(0).getType().getPrimitiveType(), getChild(1).getType().getPrimitiveType())) {
             return Type.DATETIME;

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/BinaryPredicate.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/BinaryPredicate.java
@@ -278,7 +278,16 @@ public class BinaryPredicate extends Predicate implements Writable {
         }
     }
 
-    private Type getCmpType() {
+    private Type getCmpType() throws AnalysisException {
+        for (Expr e : getChildren()) {
+            if (e.getType().getPrimitiveType() == PrimitiveType.HLL) {
+                throw new AnalysisException("Hll type can not be a operand: " + toSql());
+            }
+            if (e.getType().getPrimitiveType() == PrimitiveType.BITMAP) {
+                throw new AnalysisException("Bitmap type can not be a operand: " + toSql());
+            }
+        }
+
         PrimitiveType t1 = getChild(0).getType().getResultType().getPrimitiveType();
         PrimitiveType t2 = getChild(1).getType().getResultType().getPrimitiveType();
 

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/BinaryPredicateTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/BinaryPredicateTest.java
@@ -17,19 +17,18 @@
 
 package org.apache.doris.analysis;
 
+import mockit.Expectations;
+import mockit.Injectable;
+import mockit.Mocked;
+
+import org.apache.doris.catalog.ScalarType;
 import org.apache.doris.catalog.Type;
 import org.apache.doris.common.AnalysisException;
-
 import org.apache.doris.common.jmockit.Deencapsulation;
-
 import com.google.common.collect.Lists;
 
 import org.junit.Assert;
 import org.junit.Test;
-
-import mockit.Expectations;
-import mockit.Injectable;
-import mockit.Mocked;
 
 public class BinaryPredicateTest {
 
@@ -74,6 +73,36 @@ public class BinaryPredicateTest {
             Assert.assertSame(null, Deencapsulation.getField(binaryPredicate, "fn"));
         } catch (AnalysisException e) {
             Assert.fail(e.getMessage());
+        }
+    }
+
+    @Test
+    public void testWrongOperand(@Injectable Expr child0, @Injectable Expr child1) {
+        BinaryPredicate predicate1 = new BinaryPredicate(
+                BinaryPredicate.Operator.EQ, child0, new StringLiteral("test"));
+        BinaryPredicate predicate2 = new BinaryPredicate(
+                BinaryPredicate.Operator.EQ, child1, new StringLiteral("test"));
+
+        new Expectations() {
+            {
+                child0.getType();
+                result = ScalarType.createType("HLL");
+
+                child1.getType();
+                result = ScalarType.createType("BITMAP");
+            }
+        };
+
+        try {
+            predicate1.analyzeImpl(analyzer);
+            Assert.fail();
+        } catch (AnalysisException e) {
+        }
+
+        try {
+            predicate2.analyzeImpl(analyzer);
+            Assert.fail();
+        } catch (AnalysisException e) {
         }
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/BinaryPredicateTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/BinaryPredicateTest.java
@@ -17,10 +17,6 @@
 
 package org.apache.doris.analysis;
 
-import mockit.Expectations;
-import mockit.Injectable;
-import mockit.Mocked;
-
 import org.apache.doris.catalog.ScalarType;
 import org.apache.doris.catalog.Type;
 import org.apache.doris.common.AnalysisException;
@@ -29,6 +25,10 @@ import com.google.common.collect.Lists;
 
 import org.junit.Assert;
 import org.junit.Test;
+
+import mockit.Expectations;
+import mockit.Injectable;
+import mockit.Mocked;
 
 public class BinaryPredicateTest {
 


### PR DESCRIPTION
## Proposed changes

Fix be cores when user specified HLL or BITMAP type as operand of BinaryPredicate.

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have created an issue on (Fix #5798 ) and described the bug/feature there in detail
- [x] Compiling and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works

## Further comments

If this is a relatively large or complex change, kick off the discussion at dev@doris.apache.org by explaining why you chose the solution you did and what alternatives you considered, etc...
