### PR TITLE
[Enhancement] Reduce memory consumption by releasing readers earier

### DIFF
--- a/be/src/olap/collect_iterator.cpp
+++ b/be/src/olap/collect_iterator.cpp
@@ -44,55 +44,62 @@ OLAPStatus CollectIterator::add_child(RowsetReaderSharedPtr rs_reader) {
         return OLAP_ERR_DATA_EOF;
     }
 
-    LevelIterator* child_ptr = child.release();
-    _children.push_back(child_ptr);
+    _children.push_back(child.release());
     return OLAP_SUCCESS;
 }
 
 // Build a merge heap. If _merge is true, a rowset with the max rownum
 // status will be used as the base rowset, and the other rowsets will be merged first and
 // then merged with the base rowset.
-void CollectIterator::build_heap() {
-    DCHECK(_reader->_rs_readers.size() == _children.size());
+void CollectIterator::build_heap(const std::vector<RowsetReaderSharedPtr>& rs_readers) {
+    DCHECK(rs_readers.size() == _children.size());
     _reverse = _reader->_tablet->tablet_schema().keys_type() == KeysType::UNIQUE_KEYS;
     if (_children.empty()) {
         _inner_iter.reset(nullptr);
         return;
     } else if (_merge) {
-        DCHECK(!_reader->_rs_readers.empty());
-        // build merge heap with two children， a base rowset as level0iterator and
+        DCHECK(!rs_readers.empty());
+        // build merge heap with two children, a base rowset as level0iterator and
         // other cumulative rowsets as a level1iterator
         if (_children.size() > 1) {
-            // find base rowset(max rownum),
-            RowsetReaderSharedPtr base_reader = _reader->_rs_readers[0];
+            // find 'base rowset', 'base rowset' is the rowset which contains the max row number
+            int64_t max_row_num = 0;
             int base_reader_idx = 0;
-            for (size_t i = 1; i < _reader->_rs_readers.size(); ++i) {
-                if (_reader->_rs_readers[i]->rowset()->rowset_meta()->num_rows() >
-                    base_reader->rowset()->rowset_meta()->num_rows()) {
-                    base_reader = _reader->_rs_readers[i];
+            for (size_t i = 0; i < rs_readers.size(); ++i) {
+                int64_t cur_row_num = rs_readers[i]->rowset()->rowset_meta()->num_rows();
+                if (cur_row_num > max_row_num) {
+                    max_row_num = cur_row_num;
                     base_reader_idx = i;
                 }
             }
-            std::vector<LevelIterator*> cumu_children;
-            for (size_t i = 0; i < _reader->_rs_readers.size(); ++i) {
+            auto base_reader_child = _children.begin();
+            std::advance(base_reader_child, base_reader_idx);
+
+            std::list<LevelIterator*> cumu_children;
+            int i = 0;
+            for (const auto& child : _children) {
                 if (i != base_reader_idx) {
-                    cumu_children.push_back(_children[i]);
+                    cumu_children.push_back(child);
                 }
+                ++i;
             }
             Level1Iterator* cumu_iter =
                     new Level1Iterator(cumu_children, cumu_children.size() > 1, _reverse);
             cumu_iter->init();
-            std::vector<LevelIterator*> children;
-            children.push_back(_children[base_reader_idx]);
+            std::list<LevelIterator*> children;
+            children.push_back(*base_reader_child);
             children.push_back(cumu_iter);
             _inner_iter.reset(new Level1Iterator(children, _merge, _reverse));
         } else {
+            // _children.size() == 1
             _inner_iter.reset(new Level1Iterator(_children, _merge, _reverse));
         }
     } else {
         _inner_iter.reset(new Level1Iterator(_children, _merge, _reverse));
     }
     _inner_iter->init();
+    // Clear _children earlier to release any related references
+    _children.clear();
 }
 
 bool CollectIterator::LevelIteratorComparator::operator()(const LevelIterator* a,
@@ -112,16 +119,6 @@ bool CollectIterator::LevelIteratorComparator::operator()(const LevelIterator* a
         return a->version() < b->version();
     }
     return a->version() > b->version();
-}
-
-void CollectIterator::clear() {
-    for (auto child : _children) {
-        if (child != nullptr) {
-            delete child;
-            child = nullptr;
-        }
-    }
-    _children.clear();
 }
 
 const RowCursor* CollectIterator::current_row(bool* delete_flag) const {
@@ -230,7 +227,7 @@ OLAPStatus CollectIterator::Level0Iterator::next(const RowCursor** row, bool* de
 }
 
 CollectIterator::Level1Iterator::Level1Iterator(
-        const std::vector<CollectIterator::LevelIterator*>& children, bool merge, bool reverse)
+        const std::list<CollectIterator::LevelIterator*>& children, bool merge, bool reverse)
         : _children(children), _merge(merge), _reverse(reverse) {}
 
 CollectIterator::LevelIterator::~LevelIterator() {}
@@ -250,7 +247,7 @@ CollectIterator::Level1Iterator::~Level1Iterator() {
 //      OLAP_ERR_DATA_EOF and set *row to nullptr when EOF is reached.
 //      Others when error happens
 OLAPStatus CollectIterator::Level1Iterator::next(const RowCursor** row, bool* delete_flag) {
-    if (UNLIKELY(_children.size() == 0)) {
+    if (UNLIKELY(_cur_child == nullptr)) {
         return OLAP_ERR_DATA_EOF;
     }
     if (_merge) {
@@ -284,23 +281,25 @@ int64_t CollectIterator::Level1Iterator::version() const {
 }
 
 OLAPStatus CollectIterator::Level1Iterator::init() {
-    if (_children.size() == 0) {
+    if (_children.empty()) {
         return OLAP_SUCCESS;
     }
+
     // Only when there are multiple children that need to be merged
     if (_merge && _children.size() > 1) {
         _heap.reset(new MergeHeap(LevelIteratorComparator(_reverse)));
         for (auto child : _children) {
-            if (child == nullptr || child->current_row() == nullptr) {
-                continue;
-            }
+            DCHECK(child != nullptr);
+            DCHECK(child->current_row() != nullptr);
             _heap->push(child);
-            _cur_child = _heap->top();
         }
+        _cur_child = _heap->top();
+        // Clear _children earlier to release any related references
+        _children.clear();
     } else {
         _merge = false;
         _heap.reset(nullptr);
-        _cur_child = _children[_child_idx];
+        _cur_child = *(_children.begin());
     }
     return OLAP_SUCCESS;
 }
@@ -313,6 +312,8 @@ inline OLAPStatus CollectIterator::Level1Iterator::_merge_next(const RowCursor**
         _heap->push(_cur_child);
         _cur_child = _heap->top();
     } else if (res == OLAP_ERR_DATA_EOF) {
+        // current child has been read, to read next
+        delete _cur_child;
         if (!_heap->empty()) {
             _cur_child = _heap->top();
         } else {
@@ -320,6 +321,7 @@ inline OLAPStatus CollectIterator::Level1Iterator::_merge_next(const RowCursor**
             return OLAP_ERR_DATA_EOF;
         }
     } else {
+        _cur_child = nullptr;
         LOG(WARNING) << "failed to get next from child, res=" << res;
         return res;
     }
@@ -333,10 +335,11 @@ inline OLAPStatus CollectIterator::Level1Iterator::_normal_next(const RowCursor*
     if (LIKELY(res == OLAP_SUCCESS)) {
         return OLAP_SUCCESS;
     } else if (res == OLAP_ERR_DATA_EOF) {
-        // this child has been read, to read next
-        _child_idx++;
-        if (_child_idx < _children.size()) {
-            _cur_child = _children[_child_idx];
+        // current child has been read, to read next
+        delete _cur_child;
+        _children.pop_front();
+        if (!_children.empty()) {
+            _cur_child = *(_children.begin());
             *row = _cur_child->current_row(delete_flag);
             return OLAP_SUCCESS;
         } else {
@@ -344,6 +347,7 @@ inline OLAPStatus CollectIterator::Level1Iterator::_normal_next(const RowCursor*
             return OLAP_ERR_DATA_EOF;
         }
     } else {
+        _cur_child = nullptr;
         LOG(WARNING) << "failed to get next from child, res=" << res;
         return res;
     }

--- a/be/src/olap/generic_iterators.h
+++ b/be/src/olap/generic_iterators.h
@@ -25,14 +25,14 @@ namespace doris {
 //
 // Inputs iterators' ownership is taken by created merge iterator. And client
 // should delete returned iterator after usage.
-RowwiseIterator* new_merge_iterator(std::vector<RowwiseIterator*> inputs, std::shared_ptr<MemTracker> parent);
+RowwiseIterator* new_merge_iterator(std::list<RowwiseIterator*> inputs, std::shared_ptr<MemTracker> parent);
 
 // Create a union iterator for input iterators. Union iterator will read
 // input iterators one by one.
 //
 // Inputs iterators' ownership is taken by created union iterator. And client
 // should delete returned iterator after usage.
-RowwiseIterator* new_union_iterator(std::vector<RowwiseIterator*> inputs, std::shared_ptr<MemTracker> parent);
+RowwiseIterator* new_union_iterator(std::list<RowwiseIterator*> inputs, std::shared_ptr<MemTracker> parent);
 
 // Create an auto increment iterator which returns num_rows data in format of schema.
 // This class aims to be used in unit test.

--- a/be/src/olap/merger.cpp
+++ b/be/src/olap/merger.cpp
@@ -48,6 +48,7 @@ OLAPStatus Merger::merge_rowsets(TabletSharedPtr tablet, ReaderType reader_type,
             "failed to init row cursor when merging rowsets of tablet " + tablet->full_name());
     row_cursor.allocate_memory_for_string_type(tablet->tablet_schema());
 
+    // TODO(yingchun): monitor
     std::shared_ptr<MemTracker> tracker(new MemTracker(-1));
     std::unique_ptr<MemPool> mem_pool(new MemPool(tracker.get()));
 

--- a/be/src/olap/reader.h
+++ b/be/src/olap/reader.h
@@ -124,7 +124,9 @@ private:
 
     OLAPStatus _init_params(const ReaderParams& read_params);
 
-    OLAPStatus _capture_rs_readers(const ReaderParams& read_params);
+    OLAPStatus _capture_rs_readers(const ReaderParams& read_params, std::vector<RowsetReaderSharedPtr>* valid_rs_readers);
+
+    bool _optimize_for_single_rowset(const std::vector<RowsetReaderSharedPtr>& rs_readers);
 
     OLAPStatus _init_keys_param(const ReaderParams& read_params);
 
@@ -174,7 +176,6 @@ private:
     std::vector<uint32_t> _seek_columns;
 
     TabletSharedPtr _tablet;
-    std::vector<RowsetReaderSharedPtr> _rs_readers;
     RowsetReaderContext _reader_context;
     KeysParam _keys_param;
     std::vector<bool> _is_lower_keys_included;

--- a/be/src/olap/row_block.h
+++ b/be/src/olap/row_block.h
@@ -72,6 +72,8 @@ public:
         cursor->attach(_mem_buf + row_index * _mem_row_bytes);
     }
 
+    // TODO(yingchun): why not use _pos directly?
+
     template <typename RowType>
     inline void set_row(uint32_t row_index, const RowType& row) const {
         memcpy(_mem_buf + row_index * _mem_row_bytes, row.row_ptr(), _mem_row_bytes);

--- a/be/src/olap/row_cursor.cpp
+++ b/be/src/olap/row_cursor.cpp
@@ -165,6 +165,7 @@ OLAPStatus RowCursor::init_scan_key(const TabletSchema& schema,
     return OLAP_SUCCESS;
 }
 
+// TODO(yingchun): parameter 'const TabletSchema& schema' is not used
 OLAPStatus RowCursor::allocate_memory_for_string_type(const TabletSchema& schema) {
     // allocate memory for string type(char, varchar, hll)
     // The memory allocated in this function is used in aggregate and copy function

--- a/be/src/olap/rowset/alpha_rowset_reader.h
+++ b/be/src/olap/rowset/alpha_rowset_reader.h
@@ -80,7 +80,6 @@ private:
 
     OLAPStatus _union_block(RowBlock** block);
     OLAPStatus _merge_block(RowBlock** block);
-    OLAPStatus _pull_next_row_for_merge_rowset(RowCursor** row);
     OLAPStatus _pull_next_block(AlphaMergeContext* merge_ctx);
 
     // Doris will split query predicates to several scan keys
@@ -89,8 +88,6 @@ private:
     OLAPStatus _pull_first_block(AlphaMergeContext* merge_ctx);
 
     // merge by priority queue(_merge_heap)
-    // this method has same function with _pull_next_row_for_merge_rowset, but using heap merge.
-    // and this should replace the _pull_next_row_for_merge_rowset later.
     OLAPStatus _pull_next_row_for_merge_rowset_v2(RowCursor** row);
     // init the merge heap, this should be call before calling _pull_next_row_for_merge_rowset_v2();
     OLAPStatus _init_merge_heap();
@@ -108,7 +105,10 @@ private:
     AlphaRowsetMeta* _alpha_rowset_meta;
     const std::vector<std::shared_ptr<SegmentGroup>>& _segment_groups;
 
-    std::vector<AlphaMergeContext> _merge_ctxs;
+    // In '_union_block' mode, it has items to traverse.
+    // In '_merge_block' mode, it will be cleared after '_merge_heap' has been built.
+    std::list<AlphaMergeContext*> _sequential_ctxs;
+
     std::unique_ptr<RowBlock> _read_block;
     OLAPStatus (AlphaRowsetReader::*_next_block)(RowBlock** block) = nullptr;
     RowCursor* _dst_cursor = nullptr;
@@ -119,8 +119,8 @@ private:
     // into consideration deliberately.
     bool _is_segments_overlapping;
 
-    // ordinal of ColumnData upon reading
-    size_t _ordinal;
+    // Current AlphaMergeContext to read data, just valid in '_union_block' mode.
+    AlphaMergeContext* _cur_ctx = nullptr;
 
     RowsetReaderContext* _current_read_context;
     OlapReaderStatistics _owned_stats;

--- a/be/src/olap/rowset/alpha_rowset_reader.h
+++ b/be/src/olap/rowset/alpha_rowset_reader.h
@@ -121,14 +121,13 @@ private:
 
     // Current AlphaMergeContext to read data, just valid in '_union_block' mode.
     AlphaMergeContext* _cur_ctx = nullptr;
+    // A priority queue for merging rowsets, just valid in '_merge_block' mode.
+    std::priority_queue<AlphaMergeContext*, vector<AlphaMergeContext*>, AlphaMergeContextComparator>
+            _merge_heap;
 
     RowsetReaderContext* _current_read_context;
     OlapReaderStatistics _owned_stats;
     OlapReaderStatistics* _stats = &_owned_stats;
-
-    // a priority queue for merging rowsets
-    std::priority_queue<AlphaMergeContext*, vector<AlphaMergeContext*>, AlphaMergeContextComparator>
-            _merge_heap;
 };
 
 } // namespace doris

--- a/be/src/olap/rowset/beta_rowset_reader.cpp
+++ b/be/src/olap/rowset/beta_rowset_reader.cpp
@@ -98,7 +98,7 @@ OLAPStatus BetaRowsetReader::init(RowsetReaderContext* read_context) {
         }
         seg_iterators.push_back(std::move(iter));
     }
-    std::vector<RowwiseIterator*> iterators;
+    std::list<RowwiseIterator*> iterators;
     for (auto& owned_it : seg_iterators) {
         // transfer ownership of segment iterator to `_iterator`
         iterators.push_back(owned_it.release());

--- a/be/src/olap/rowset/unique_rowset_id_generator.h
+++ b/be/src/olap/rowset/unique_rowset_id_generator.h
@@ -25,7 +25,6 @@
 
 namespace doris {
 
-// TODO(yingchun): why use two classes?
 class UniqueRowsetIdGenerator : public RowsetIdGenerator {
 public:
     UniqueRowsetIdGenerator(const UniqueId& backend_uid);

--- a/be/src/olap/rowset/unique_rowset_id_generator.h
+++ b/be/src/olap/rowset/unique_rowset_id_generator.h
@@ -25,6 +25,7 @@
 
 namespace doris {
 
+// TODO(yingchun): why use two classes?
 class UniqueRowsetIdGenerator : public RowsetIdGenerator {
 public:
     UniqueRowsetIdGenerator(const UniqueId& backend_uid);

--- a/be/src/olap/storage_engine.cpp
+++ b/be/src/olap/storage_engine.cpp
@@ -73,7 +73,6 @@ using std::list;
 using std::map;
 using std::nothrow;
 using std::pair;
-using std::priority_queue;
 using std::set;
 using std::set_difference;
 using std::string;

--- a/be/test/olap/generic_iterators_test.cpp
+++ b/be/test/olap/generic_iterators_test.cpp
@@ -77,7 +77,7 @@ TEST(GenericIteratorsTest, AutoIncrement) {
 
 TEST(GenericIteratorsTest, Union) {
     auto schema = create_schema();
-    std::vector<RowwiseIterator*> inputs;
+    std::list<RowwiseIterator*> inputs;
 
     inputs.push_back(new_auto_increment_iterator(schema, 100));
     inputs.push_back(new_auto_increment_iterator(schema, 200));
@@ -116,7 +116,7 @@ TEST(GenericIteratorsTest, Union) {
 
 TEST(GenericIteratorsTest, Merge) {
     auto schema = create_schema();
-    std::vector<RowwiseIterator*> inputs;
+    std::list<RowwiseIterator*> inputs;
 
     inputs.push_back(new_auto_increment_iterator(schema, 100));
     inputs.push_back(new_auto_increment_iterator(schema, 200));


### PR DESCRIPTION
## Proposed changes

We created multiple rowset readers to read data of one tablet, after one rowset reader has reached EOF, it can be released to reduce resource (typicallly memory) comsumption. As the same, we can release segment reader when it reach EOF.

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [x] Code refactor (Modify the code structure, format the code, etc...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have created an issue on (Fix #ISSUE) and described the bug/feature there in detail
- [x] Compiling and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If these changes need document changes, I have updated the document
- [ ] Any dependent changes have been merged
