### PR TITLE
[Debug Enhancement] Associate the old and new query id by retry

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -290,7 +290,7 @@ public class StmtExecutor implements ProfileWriter {
                         if (i > 0) {
                             UUID uuid = UUID.randomUUID();
                             TUniqueId newQueryId = new TUniqueId(uuid.getMostSignificantBits(), uuid.getLeastSignificantBits());
-                            LOG.warn("Query {} {} times with new query id: {}", DebugUtil.printId(queryId), i, newQueryId);
+                            LOG.warn("Query {} {} times with new query id: {}", DebugUtil.printId(queryId), i, DebugUtil.printId(newQueryId));
                             context.setQueryId(newQueryId);
                         }
                         handleQueryStmt();


### PR DESCRIPTION
## Proposed changes

When a query is retried, the FE log cannot quickly associate the new and old queries by query id.
This will increase the complexity of troubleshooting.
Modify the log printing logic of FE to associate the new and old query ids, and the print log looks like this:
Query {old_query_id} {retry_times} times with new query id: {new_query_id}
