### PR TITLE
[Metric][Http Interface] Aggregate metric for any metric label

### DIFF
--- a/be/src/http/action/metrics_action.cpp
+++ b/be/src/http/action/metrics_action.cpp
@@ -36,11 +36,15 @@ namespace doris {
 void MetricsAction::handle(HttpRequest* req) {
     const std::string& type = req->param("type");
     const std::string& with_tablet = req->param("with_tablet");
+    const std::string& aggregate_label = req->param("aggregate_label");
+    const std::string& entity_type = req->param("entity_type");
     std::string str;
     if (type == "core") {
         str = _metric_registry->to_core_string();
     } else if (type == "json") {
         str = _metric_registry->to_json(with_tablet == "true");
+    } else if (type == "aggregate") {
+        str = _metric_registry->aggregate_metric(entity_type, aggregate_label);
     } else {
         str = _metric_registry->to_prometheus(with_tablet == "true");
     }

--- a/be/src/olap/base_tablet.cpp
+++ b/be/src/olap/base_tablet.cpp
@@ -44,7 +44,9 @@ BaseTablet::BaseTablet(TabletMetaSharedPtr tablet_meta, DataDir* data_dir)
 
     _metric_entity = DorisMetrics::instance()->metric_registry()->register_entity(
             strings::Substitute("Tablet.$0", tablet_id()),
-            {{"tablet_id", std::to_string(tablet_id())}}, MetricEntityType::kTablet);
+            {{"tablet_id", std::to_string(tablet_id())},
+                        {"partition_id", std::to_string(partition_id())},
+                        {"table_id", std::to_string(table_id())}},MetricEntityType::kTablet);
     INT_COUNTER_METRIC_REGISTER(_metric_entity, query_scan_bytes);
     INT_COUNTER_METRIC_REGISTER(_metric_entity, query_scan_rows);
     INT_COUNTER_METRIC_REGISTER(_metric_entity, query_scan_count);

--- a/be/src/util/metrics.h
+++ b/be/src/util/metrics.h
@@ -410,6 +410,8 @@ public:
     std::string to_prometheus(bool with_tablet_metrics = false) const;
     std::string to_json(bool with_tablet_metrics = false) const;
     std::string to_core_string() const;
+    std::string aggregate_metric(const std::string& entityType,
+                                 const std::string& aggregate_label) const;
 
 private:
     const std::string _name;


### PR DESCRIPTION
## Proposed changes

Tablet has 5 metrics to record read/write statistic data. 
IntCounter* query_scan_bytes;
IntCounter* query_scan_rows;
IntCounter* query_scan_count;
IntCounter* flush_bytes;
IntCounter* flush_count;

It is meaningful to get these read/write data to find zero-read/write or hot-read/write table and partition. But in these metrics, it has tablet id information, but no table id/partition id information. Therefore this PR add table id/partition id for these 5 metrics. On the other side, there are maybe hundred thousands of tablet. It is difficult to get these metrics directly by http interface. There this patch provide a aggregate http interface. It can aggregate metric data according to metric label.

It is diffcult to write some unit tests to test this patch. Therefore, it is only be tested in offline running system.

Usage:
http://localshot:8040/metrics?type=aggregate&entity_type=tablet&aggregate_label=table_id

type: json/prometheus/aggregate
entity_type: tablet/server
aggregate_lable: aggregate metric by  which metric label 

Result:

`[{"11097":[{"flush_bytes":"0"},{"flush_count":"0"},{"query_scan_bytes":"0"},{"query_scan_count":"0"},{"query_scan_rows":"0"}]},{"11098":[{"flush_bytes":"0"},{"flush_count":"0"},{"query_scan_bytes":"0"},{"query_scan_count":"0"},{"query_scan_rows":"0"}]},{"11099":[{"flush_bytes":"0"},{"flush_count":"0"},{"query_scan_bytes":"0"},{"query_scan_count":"0"},{"query_scan_rows":"0"}]}]`

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Code refactor (Modify the code structure, format the code, etc...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have created an issue on (Fix #ISSUE) and described the bug/feature there in detail
- [ ] Compiling and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If these changes need document changes, I have updated the document
- [ ] Any dependent changes have been merged

## Further comments

If this is a relatively large or complex change, kick off the discussion at dev@doris.apache.org by explaining why you chose the solution you did and what alternatives you considered, etc...
