### PR TITLE
[Bug][Stream load] Separate the execution of stream load tasks from the HTTP thread pool

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -325,6 +325,9 @@ CONF_mInt32(finished_migration_tasks_size, "10000");
 CONF_Int32(webserver_port, "8040");
 // Number of webserver workers
 CONF_Int32(webserver_num_workers, "48");
+// Number of stream load workers
+CONF_Int32(min_stream_load_num_workers, "8");
+CONF_Int32(max_stream_load_num_workers, "32");
 // Period to update rate counters and sampling counters in ms.
 CONF_mInt32(periodic_counter_update_period_ms, "500");
 

--- a/be/src/http/action/stream_load.h
+++ b/be/src/http/action/stream_load.h
@@ -23,6 +23,7 @@
 #include "http/http_handler.h"
 #include "runtime/client_cache.h"
 #include "runtime/message_body_sink.h"
+#include "util/threadpool.h"
 
 namespace doris {
 
@@ -45,6 +46,7 @@ public:
     void free_handler_ctx(void* ctx) override;
 
 private:
+    void _handle_stream_load(HttpRequest* req);
     Status _on_header(HttpRequest* http_req, StreamLoadContext* ctx);
     Status _handle(StreamLoadContext* ctx);
     Status _data_saved_path(HttpRequest* req, std::string* file_path);
@@ -54,6 +56,8 @@ private:
 
 private:
     ExecEnv* _exec_env;
+
+    std::unique_ptr<ThreadPool> _stream_load_thread_pool;
 
     std::shared_ptr<MetricEntity> _stream_load_entity;
     IntCounter* streaming_load_requests_total;

--- a/be/test/http/stream_load_test.cpp
+++ b/be/test/http/stream_load_test.cpp
@@ -70,6 +70,8 @@ public:
         k_stream_load_plan_status = Status::OK();
         k_response_str = "";
         config::streaming_load_max_mb = 1;
+        config::min_stream_load_num_workers = 1;
+        config::max_stream_load_num_workers = 1;
 
         _env._thread_mgr = new ThreadResourceMgr();
         _env._master_info = new TMasterInfo();
@@ -108,6 +110,10 @@ TEST_F(StreamLoadActionTest, no_auth) {
     request.set_handler(&action);
     action.on_header(&request);
     action.handle(&request);
+
+    while (k_response_str.empty()) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+    }
 
     rapidjson::Document doc;
     doc.Parse(k_response_str.c_str());
@@ -160,6 +166,10 @@ TEST_F(StreamLoadActionTest, normal) {
     action.on_header(&request);
     action.handle(&request);
 
+    while (k_response_str.empty()) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+    }
+
     rapidjson::Document doc;
     doc.Parse(k_response_str.c_str());
     ASSERT_STREQ("Success", doc["Status"].GetString());
@@ -182,6 +192,10 @@ TEST_F(StreamLoadActionTest, put_fail) {
     action.on_header(&request);
     action.handle(&request);
 
+    while (k_response_str.empty()) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+    }
+
     rapidjson::Document doc;
     doc.Parse(k_response_str.c_str());
     ASSERT_STREQ("Fail", doc["Status"].GetString());
@@ -202,6 +216,10 @@ TEST_F(StreamLoadActionTest, commit_fail) {
     action.on_header(&request);
     action.handle(&request);
 
+    while (k_response_str.empty()) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+    }
+
     rapidjson::Document doc;
     doc.Parse(k_response_str.c_str());
     ASSERT_STREQ("Fail", doc["Status"].GetString());
@@ -221,6 +239,10 @@ TEST_F(StreamLoadActionTest, begin_fail) {
     request.set_handler(&action);
     action.on_header(&request);
     action.handle(&request);
+
+    while (k_response_str.empty()) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+    }
 
     rapidjson::Document doc;
     doc.Parse(k_response_str.c_str());
@@ -257,6 +279,10 @@ TEST_F(StreamLoadActionTest, plan_fail) {
     request.set_handler(&action);
     action.on_header(&request);
     action.handle(&request);
+
+    while (k_response_str.empty()) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+    }
 
     rapidjson::Document doc;
     doc.Parse(k_response_str.c_str());


### PR DESCRIPTION
## Proposed changes

Fix #5839
Separate the execution of stream load tasks from the HTTP thread pool and handle stream load task in a separate thread pool.

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Code refactor (Modify the code structure, format the code, etc...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have created an issue on (Fix #5839) and described the bug/feature there in detail
- [x] Compiling and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If these changes need document changes, I have updated the document
- [x] Any dependent changes have been merged
