### PR TITLE
[Bug] Fix bug that the buffered reader may read at wrong position.

### DIFF
--- a/be/src/exec/buffered_reader.cpp
+++ b/be/src/exec/buffered_reader.cpp
@@ -32,6 +32,9 @@ BufferedReader::BufferedReader(FileReader* reader, int64_t buffer_size)
           _buffer_limit(0),
           _cur_offset(0) {
     _buffer = new char[_buffer_size];
+    // set the _cur_offset of this reader as same as the inner reader's,
+    // to make sure the buffer reader will start to read at right position.
+    _reader->tell(&_cur_offset);
 }
 
 BufferedReader::~BufferedReader() {

--- a/be/src/exec/s3_reader.cpp
+++ b/be/src/exec/s3_reader.cpp
@@ -68,6 +68,7 @@ Status S3Reader::open() {
         return Status::InternalError(out.str());
     }
 }
+
 Status S3Reader::read(uint8_t* buf, int64_t buf_len, int64_t* bytes_read, bool* eof) {
     DCHECK_NE(buf_len, 0);
     RETURN_IF_ERROR(readat(_cur_offset, buf_len, bytes_read, buf));
@@ -78,6 +79,7 @@ Status S3Reader::read(uint8_t* buf, int64_t buf_len, int64_t* bytes_read, bool* 
     }
     return Status::OK();
 }
+
 Status S3Reader::readat(int64_t position, int64_t nbytes, int64_t* bytes_read, void* out) {
     CHECK_S3_CLIENT(_client);
     if (position >= _file_size) {
@@ -107,6 +109,7 @@ Status S3Reader::readat(int64_t position, int64_t nbytes, int64_t* bytes_read, v
     response.GetResult().GetBody().read((char*)out, *bytes_read);
     return Status::OK();
 }
+
 Status S3Reader::read_one_message(std::unique_ptr<uint8_t[]>* buf, int64_t* length) {
     bool eof;
     int64_t file_size = size() - _cur_offset;
@@ -123,17 +126,21 @@ Status S3Reader::read_one_message(std::unique_ptr<uint8_t[]>* buf, int64_t* leng
 int64_t S3Reader::size() {
     return _file_size;
 }
+
 Status S3Reader::seek(int64_t position) {
     _cur_offset = position;
     return Status::OK();
 }
+
 Status S3Reader::tell(int64_t* position) {
     *position = _cur_offset;
     return Status::OK();
 }
+
 void S3Reader::close() {
     _closed = true;
 }
+
 bool S3Reader::closed() {
     return _closed;
 }


### PR DESCRIPTION
## Proposed changes

The buffered reader's _cur_offset should be initialized as same as the inner file reader's,
to make sure that the reader will start to read at right position.

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Code refactor (Modify the code structure, format the code, etc...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have created an issue on (Fix #ISSUE) and described the bug/feature there in detail
- [ ] Compiling and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If these changes need document changes, I have updated the document
- [ ] Any dependent changes have been merged

## Further comments

If this is a relatively large or complex change, kick off the discussion at dev@doris.apache.org by explaining why you chose the solution you did and what alternatives you considered, etc...
