### PR TITLE
[Bug-fix][Backup] Modify the persistence logic of backup and restore

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/persist/gson/GsonUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/gson/GsonUtils.java
@@ -132,8 +132,12 @@ public class GsonUtils {
             .registerTypeAdapter(ImmutableMap.class, new ImmutableMapDeserializer())
             .registerTypeAdapter(AtomicBoolean.class, new AtomicBooleanAdapter());
 
+    private static final GsonBuilder GSON_BUILDER_PRETTY_PRINTING = GSON_BUILDER.setPrettyPrinting();
+
     // this instance is thread-safe.
     public static final Gson GSON = GSON_BUILDER.create();
+
+    public static final Gson GSON_PRETTY_PRINTING = GSON_BUILDER_PRETTY_PRINTING.create();
 
     /*
      * The exclusion strategy of GSON serialization.

--- a/fe/fe-core/src/test/java/org/apache/doris/backup/BackupJobInfoTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/backup/BackupJobInfoTest.java
@@ -17,11 +17,6 @@
 
 package org.apache.doris.backup;
 
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
-
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.File;
@@ -30,6 +25,11 @@ import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.PrintWriter;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
 
 public class BackupJobInfoTest {
 
@@ -169,6 +169,7 @@ public class BackupJobInfoTest {
         Assert.assertEquals("view1", jobInfo.newBackupObjects.views.get(0).name);
 
         File tmpFile = new File("./tmp");
+        File tmpFile1 = new File("./tmp1");
         try {
             DataOutputStream out = new DataOutputStream(new FileOutputStream(tmpFile));
             jobInfo.write(out);
@@ -186,11 +187,28 @@ public class BackupJobInfoTest {
             Assert.assertEquals(jobInfo.newBackupObjects.views.size(), newInfo.newBackupObjects.views.size());
             Assert.assertEquals("view1", newInfo.newBackupObjects.views.get(0).name);
 
+            out = new DataOutputStream(new FileOutputStream(tmpFile1));
+            newInfo.write(out);
+            out.flush();
+            out.close();
+
+            in = new DataInputStream(new FileInputStream(tmpFile1));
+            BackupJobInfo newInfo1 = BackupJobInfo.read(in);
+            in.close();
+
+            Assert.assertEquals(
+                    newInfo.backupOlapTableObjects.get("table2").getPartInfo("partition1")
+                            .indexes.get("table2").sortedTabletInfoList.size(),
+                    newInfo1.backupOlapTableObjects.get("table2").getPartInfo("partition1")
+                            .indexes.get("table2").sortedTabletInfoList.size());
+
         } catch (IOException e) {
             e.printStackTrace();
             Assert.fail();
         } finally {
             tmpFile.delete();
+            tmpFile1.delete();
         }
+
     }
 }


### PR DESCRIPTION
The expose annotation is used in the persistence logic used by the old backup recovery.
This annotation by itself is meant to ignore some variables when serializing and deserializing.
However, this variable was used incorrectly and gson did not ignore the variables that should have been ignored.
This results in duplicate initialization when fe is restarted.

This pr uses the doris wrapped Gson directly, than eliminates the use of the expose annotation.
Fixed sortedTabletInfoList being repeatedly initialized resulting in incorrect numbers.

Fixed #5852 

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Code refactor (Modify the code structure, format the code, etc...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have created an issue on (Fix #5852 ) and described the bug/feature there in detail
- [x] Compiling and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If these changes need document changes, I have updated the document
- [ ] Any dependent changes have been merged

