### PR TITLE
[Bug] Kill the FE process when writing BDBJE journal failed

### DIFF
--- a/docs/en/administrator-guide/config/fe_config.md
+++ b/docs/en/administrator-guide/config/fe_config.md
@@ -182,6 +182,12 @@ It should be less than 'max_running_txn_num_per_db'
 
 ### `bdbje_lock_timeout_second`
 
+### `bdbje_replica_ack_timeout_second`
+
+Metadata will be synchronously written to multiple Follower FEs. This parameter is used to control the timeout period for Master FE to wait for Follower FE to send ack. When the written data is large, the ack time may be longer. If it times out, the metadata writing will fail and the FE process will exit. At this time, you can increase this parameter appropriately.
+
+Default: 10 seconds.
+
 ### `broker_load_default_timeout_second`
 
 ### `brpc_idle_wait_max_time`

--- a/docs/zh-CN/administrator-guide/config/fe_config.md
+++ b/docs/zh-CN/administrator-guide/config/fe_config.md
@@ -180,6 +180,12 @@ FE 的配置项有两种方式进行配置：
 
 ### `bdbje_lock_timeout_second`
 
+### `bdbje_replica_ack_timeout_second`
+
+元数据会同步写入到多个 Follower FE，这个参数用于控制 Master FE 等待 Follower FE 发送 ack 的超时时间。当写入的数据较大时，可能 ack 时间较长，如果超时，会导致写元数据失败，FE 进程退出。此时可以适当调大这个参数。
+
+默认值：10 秒。
+
 ### `broker_load_default_timeout_second`
 
 ### `brpc_idle_wait_max_time`

--- a/fe/fe-core/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/Config.java
@@ -218,7 +218,8 @@ public class Config extends ConfigBase {
      * If the network is experiencing transient problems, of some unexpected long java GC annoying you,
      * you can try to increase this value to decrease the chances of false timeouts
      */
-    @ConfField public static int bdbje_heartbeat_timeout_second = 30;
+    @ConfField
+    public static int bdbje_heartbeat_timeout_second = 30;
 
     /**
      * The lock timeout of bdbje operation
@@ -226,6 +227,14 @@ public class Config extends ConfigBase {
      */
     @ConfField
     public static int bdbje_lock_timeout_second = 1;
+
+    /**
+     * The replica ack timeout when writing to bdbje
+     * When writing some relatively large logs, the ack time may time out, resulting in log writing failure.
+     * At this time, you can increase this value appropriately.
+     */
+    @ConfField
+    public static int bdbje_replica_ack_timeout_second = 10;
 
     /**
      * num of thread to handle heartbeat events in heartbeat_mgr.

--- a/fe/fe-core/src/main/java/org/apache/doris/journal/Journal.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/journal/Journal.java
@@ -19,6 +19,7 @@ package org.apache.doris.journal;
 
 import org.apache.doris.common.io.Writable;
 
+import java.io.IOException;
 import java.util.List;
 
 public interface Journal {
@@ -44,9 +45,9 @@ public interface Journal {
     // Get all the journals whose id: fromKey <= id <= toKey
     // toKey = -1 means toKey = Long.Max_Value
     public JournalCursor read(long fromKey, long toKey);
-    
+
     // Write a journal and sync to disk
-    public void write(short op, Writable writable);
+    public void write(short op, Writable writable) throws IOException;
     
     // Delete journals whose max id is less than deleteToJournalId
     public void deleteJournals(long deleteJournalToId);

--- a/fe/fe-core/src/main/java/org/apache/doris/journal/bdbje/BDBEnvironment.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/journal/bdbje/BDBEnvironment.java
@@ -112,7 +112,7 @@ public class BDBEnvironment {
         replicationConfig.setConfigParam(ReplicationConfig.FEEDER_TIMEOUT, Config.bdbje_heartbeat_timeout_second + " s");
 
         if (isElectable) {
-            replicationConfig.setReplicaAckTimeout(2, TimeUnit.SECONDS);
+            replicationConfig.setReplicaAckTimeout(Config.bdbje_replica_ack_timeout_second, TimeUnit.SECONDS);
             replicationConfig.setConfigParam(ReplicationConfig.REPLICA_MAX_GROUP_COMMIT, "0");
             replicationConfig.setConsistencyPolicy(new NoConsistencyRequiredPolicy());
         } else {

--- a/fe/fe-core/src/main/java/org/apache/doris/journal/local/LocalJournal.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/journal/local/LocalJournal.java
@@ -125,15 +125,11 @@ public class LocalJournal implements Journal {
     }
 
     @Override
-    public synchronized void write(short op, Writable writable) {
-        try {
-            outputStream.write(op, writable);
-            outputStream.setReadyToFlush();
-            outputStream.flush();
-            journalId.incrementAndGet();
-        } catch (IOException e) {
-            LOG.error(e);
-        }
+    public synchronized void write(short op, Writable writable) throws IOException {
+        outputStream.write(op, writable);
+        outputStream.setReadyToFlush();
+        outputStream.flush();
+        journalId.incrementAndGet();
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/EditLog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/EditLog.java
@@ -52,10 +52,10 @@ import org.apache.doris.load.ExportMgr;
 import org.apache.doris.load.Load;
 import org.apache.doris.load.LoadErrorHub;
 import org.apache.doris.load.LoadJob;
+import org.apache.doris.load.StreamLoadRecordMgr.FetchStreamLoadRecord;
 import org.apache.doris.load.loadv2.LoadJob.LoadJobStateUpdateInfo;
 import org.apache.doris.load.loadv2.LoadJobFinalOperation;
 import org.apache.doris.load.routineload.RoutineLoadJob;
-import org.apache.doris.load.StreamLoadRecordMgr.FetchStreamLoadRecord;
 import org.apache.doris.meta.MetaContext;
 import org.apache.doris.metric.MetricRepo;
 import org.apache.doris.mysql.privilege.UserPropertyInfo;
@@ -853,8 +853,9 @@ public class EditLog {
 
         try {
             journal.write(op, writable);
-        } catch (Exception e) {
-            LOG.error("Fatal Error : write stream Exception", e);
+        } catch (Throwable t) {
+            // Throwable contains all Exception and Error, such as IOException and OutOfMemoryError
+            LOG.error("Fatal Error : write stream Exception", t);
             System.exit(-1);
         }
 


### PR DESCRIPTION
## Proposed changes

1. When an oom error occurs when writing bdbje, catch the error and exit the process.
2. Increase the timeout period of bdbje replica ack and change it to a configuration.

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Code refactor (Modify the code structure, format the code, etc...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have created an issue on (Fix #5862 ) and described the bug/feature there in detail
- [ ] Compiling and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If these changes need document changes, I have updated the document
- [ ] Any dependent changes have been merged

## Further comments

If this is a relatively large or complex change, kick off the discussion at dev@doris.apache.org by explaining why you chose the solution you did and what alternatives you considered, etc...
