### PR TITLE
[BUG] fix compression bug while compaction

### DIFF
--- a/be/src/olap/fs/file_block_manager.cpp
+++ b/be/src/olap/fs/file_block_manager.cpp
@@ -169,7 +169,7 @@ Status FileWritableBlock::appendv(const Slice* data, size_t data_cnt) {
 
     // Calculate the amount of data written
     size_t bytes_written = accumulate(data, data + data_cnt, static_cast<size_t>(0),
-                                      [&](int sum, const Slice& curr) { return sum + curr.size; });
+                                      [](size_t sum, const Slice& curr) { return sum + curr.size; });
     _bytes_appended += bytes_written;
     return Status::OK();
 }

--- a/be/src/util/block_compression.cpp
+++ b/be/src/util/block_compression.cpp
@@ -26,6 +26,8 @@
 #include "gutil/strings/substitute.h"
 #include "util/faststring.h"
 
+#include <limits>
+
 namespace doris {
 
 using strings::Substitute;
@@ -71,7 +73,12 @@ public:
         return Status::OK();
     }
 
-    size_t max_compressed_len(size_t len) const override { return LZ4_compressBound(len); }
+    size_t max_compressed_len(size_t len) const override { 
+        if (len > std::numeric_limits<int32_t>::max()) {
+            return 0;
+        }
+        return LZ4_compressBound(len); 
+    }
 };
 
 // Used for LZ4 frame format, decompress speed is two times faster than LZ4.
@@ -120,6 +127,9 @@ public:
     }
 
     size_t max_compressed_len(size_t len) const override {
+        if (len > std::numeric_limits<int32_t>::max()) {
+            return 0;
+        }
         return std::max(LZ4F_compressBound(len, &_s_preferences),
                         LZ4F_compressFrameBound(len, &_s_preferences));
     }


### PR DESCRIPTION
Because the maximum length of LZ4 compression is 2^32, it can cause some memory problems

## Proposed changes

will close #5892 
may fix #5849 problem 2

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Code refactor (Modify the code structure, format the code, etc...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have created an issue on (Fix #ISSUE) and described the bug/feature there in detail
- [x] Compiling and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If these changes need document changes, I have updated the document
- [ ] Any dependent changes have been merged

## Further comments

If this is a relatively large or complex change, kick off the discussion at dev@doris.apache.org by explaining why you chose the solution you did and what alternatives you considered, etc...
