### PR TITLE
[LOG]Hiding stack info of memory exceed in the log

### DIFF
--- a/be/src/runtime/mem_tracker.cpp
+++ b/be/src/runtime/mem_tracker.cpp
@@ -499,8 +499,9 @@ Status MemTracker::MemLimitExceeded(MemTracker* mtracker, RuntimeState* state,
     const int64_t process_capacity = process_tracker->SpareCapacity(MemLimit::HARD);
     ss << "Memory left in process limit: " << PrettyPrinter::print(process_capacity, TUnit::BYTES)
        << std::endl;
+    Status status = Status::MemoryLimitExceeded(ss.str());
 
-    // Always log the query tracker (if available).
+    // only print the query tracker in be log(if available).
     MemTracker* query_tracker = nullptr;
     if (mtracker != nullptr) {
         query_tracker = mtracker->GetQueryMemTracker();
@@ -522,8 +523,6 @@ Status MemTracker::MemLimitExceeded(MemTracker* mtracker, RuntimeState* state,
         // dumping the process tracker to only two layers.
         ss << process_tracker->LogUsage(PROCESS_MEMTRACKER_LIMITED_DEPTH);
     }
-
-    Status status = Status::MemoryLimitExceeded(ss.str());
     if (state != nullptr) state->log_error(status.to_string());
     return status;
 }

--- a/be/src/runtime/mem_tracker.cpp
+++ b/be/src/runtime/mem_tracker.cpp
@@ -523,7 +523,8 @@ Status MemTracker::MemLimitExceeded(MemTracker* mtracker, RuntimeState* state,
         // dumping the process tracker to only two layers.
         ss << process_tracker->LogUsage(PROCESS_MEMTRACKER_LIMITED_DEPTH);
     }
-    if (state != nullptr) state->log_error(status.to_string());
+    if (state != nullptr) state->log_error(ss.str());
+    LOG(WARNING) << ss.str();
     return status;
 }
 


### PR DESCRIPTION
If query is memory exceed, a detail info where memory exceed is required.
However it is not necessary to return the entire query stack to the end user.
The query stack only needs to be printed in the be log.
