### PR TITLE
[Bug]  Fix the problem that the result of query from the view is incorrect

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/CompoundPredicate.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/CompoundPredicate.java
@@ -75,8 +75,7 @@ public class CompoundPredicate extends Predicate {
             Preconditions.checkState(op == Operator.NOT);
             return "NOT " + getChild(0).toSql();
         } else {
-            return "(" + getChild(0).toSql() + ")" + " " + op.toString() + " " + "(" + getChild(
-              1).toSql() + ")";
+            return getChild(0).toSql() + " " + op.toString() + " " + getChild(1).toSql();
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/SelectStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/SelectStmt.java
@@ -687,9 +687,13 @@ public class SelectStmt extends QueryStmt {
         } else {
             // rebuild CompoundPredicate if found duplicate predicate will build （predicate) and (.. or ..)  predicate in
             // step 1: will build (.. or ..)
-            result = CollectionUtils.isNotEmpty(cloneExprs) ? new CompoundPredicate(CompoundPredicate.Operator.AND,
-                    temp.get(0), makeCompound(temp.subList(1, temp.size()), CompoundPredicate.Operator.OR))
-                    : makeCompound(temp, CompoundPredicate.Operator.OR);
+            if (CollectionUtils.isNotEmpty(cloneExprs)) {
+                result = new CompoundPredicate(CompoundPredicate.Operator.AND, temp.get(0),
+                        makeCompound(temp.subList(1, temp.size()), CompoundPredicate.Operator.OR));
+                result.setPrintSqlInParens(true);
+            } else {
+                result = makeCompound(temp, CompoundPredicate.Operator.OR);
+            }
         }
         if (LOG.isDebugEnabled()) {
             LOG.debug("equal ors: " + result.toSql());
@@ -711,6 +715,7 @@ public class SelectStmt extends QueryStmt {
         for (int i = 2; i < exprs.size(); ++i) {
             result = new CompoundPredicate(op, result.clone(), exprs.get(i));
         }
+        result.setPrintSqlInParens(true);
         return result;
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/SqlModeTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/SqlModeTest.java
@@ -80,7 +80,7 @@ public class SqlModeTest {
         if (!(expr instanceof CompoundPredicate)) {
             Assert.fail();
         }
-        Assert.assertEquals("(('a') OR ('b')) OR ('c')", expr.toSql());
+        Assert.assertEquals("'a' OR 'b' OR 'c'", expr.toSql());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/qe/PartitionCacheTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/qe/PartitionCacheTest.java
@@ -539,7 +539,7 @@ public class PartitionCacheTest {
 
             cache.rewriteSelectStmt(newRangeList);
             sql = ca.getRewriteStmt().getWhereClause().toSql();
-            Assert.assertEquals(sql, "(`date` >= 20200114) AND (`date` <= 20200115)");
+            Assert.assertEquals(sql, "`date` >= 20200114 AND `date` <= 20200115");
         } catch (Exception e) {
             LOG.warn("ex={}", e);
             Assert.fail(e.getMessage());
@@ -578,7 +578,7 @@ public class PartitionCacheTest {
             hitRange = range.buildDiskPartitionRange(newRangeList);
             cache.rewriteSelectStmt(newRangeList);
             sql = ca.getRewriteStmt().getWhereClause().toSql();
-            Assert.assertEquals(sql,"(`eventdate` >= '2020-01-14') AND (`eventdate` <= '2020-01-15')");
+            Assert.assertEquals(sql,"`eventdate` >= '2020-01-14' AND `eventdate` <= '2020-01-15'");
         } catch(Exception e){
             LOG.warn("ex={}",e);
             Assert.fail(e.getMessage());
@@ -703,7 +703,7 @@ public class PartitionCacheTest {
             cache.rewriteSelectStmt(newRangeList);
 
             sql = ca.getRewriteStmt().getWhereClause().toSql();
-            Assert.assertEquals(sql, "(`eventdate` >= '2020-01-13') AND (`eventdate` <= '2020-01-15')");
+            Assert.assertEquals(sql, "`eventdate` >= '2020-01-13' AND `eventdate` <= '2020-01-15'");
 
             List<PartitionRange.PartitionSingle> updateRangeList = range.buildUpdatePartitionRange();
             Assert.assertEquals(updateRangeList.size(), 2);
@@ -749,7 +749,7 @@ public class PartitionCacheTest {
             cache.rewriteSelectStmt(newRangeList);
             sql = ca.getRewriteStmt().getWhereClause().toSql();
             LOG.warn("MultiPredicate={}", sql);                
-            Assert.assertEquals(sql,"((`eventdate` > '2020-01-13') AND (`eventdate` < '2020-01-16')) AND (`eventid` = 1)");
+            Assert.assertEquals(sql,"`eventdate` > '2020-01-13' AND `eventdate` < '2020-01-16' AND `eventid` = 1");
         } catch(Exception e){
             LOG.warn("multi ex={}",e);
             Assert.fail(e.getMessage());
@@ -791,8 +791,8 @@ public class PartitionCacheTest {
             cache.rewriteSelectStmt(newRangeList);
             sql = ca.getRewriteStmt().getWhereClause().toSql();
             LOG.warn("Join rewrite={}", sql);                
-            Assert.assertEquals(sql,"((`appevent`.`eventdate` >= '2020-01-14')" +
-                    " AND (`appevent`.`eventdate` <= '2020-01-15')) AND (`eventid` = 1)");
+            Assert.assertEquals(sql,"`appevent`.`eventdate` >= '2020-01-14'" +
+                    " AND `appevent`.`eventdate` <= '2020-01-15' AND `eventid` = 1");
         } catch(Exception e){
             LOG.warn("Join ex={}",e);
             Assert.fail(e.getMessage());
@@ -837,7 +837,7 @@ public class PartitionCacheTest {
             LOG.warn("Sub rewrite={}", sql);                
             Assert.assertEquals(sql,"SELECT <slot 7> `eventdate` AS `eventdate`, <slot 8> sum(`pv`) AS `sum(``pv``)` FROM (" + 
                 "SELECT <slot 3> `eventdate` AS `eventdate`, <slot 4> count(`userid`) AS `pv` FROM `testCluster:testDb`.`appevent` WHERE " + 
-                "((`eventdate` > '2020-01-13') AND (`eventdate` < '2020-01-16')) AND (`eventid` = 1) GROUP BY `eventdate`) tbl GROUP BY `eventdate`");
+                "`eventdate` > '2020-01-13' AND `eventdate` < '2020-01-16' AND `eventid` = 1 GROUP BY `eventdate`) tbl GROUP BY `eventdate`");
         } catch(Exception e){
             LOG.warn("sub ex={}",e);
             Assert.fail(e.getMessage());


### PR DESCRIPTION
Fix an issue where the priority of CompoundPredicates in created view does not match the expectation.

## Proposed changes

When creating a view, the where expression needed to be rewritten, and the printSqlInParens variable that controls the print brackets in CompoundPredicate was lost.  This will result in that: NOT(con1 OR con2) -> NOT con1 OR con2.
This pr supplements the printSqlInParens variable in the rewrite of CompoundPredicate.

Fix #5860

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Code refactor (Modify the code structure, format the code, etc...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have created an issue on (Fix #ISSUE) and described the bug/feature there in detail
- [x] Compiling and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If these changes need document changes, I have updated the document
- [ ] Any dependent changes have been merged

## Further comments

If this is a relatively large or complex change, kick off the discussion at dev@doris.apache.org by explaining why you chose the solution you did and what alternatives you considered, etc...
