### PR TITLE
[BUG] Fix "in memory table" may cause a lot of CPU consumption when LRU Cache evict

### DIFF
--- a/be/src/olap/lru_cache.cpp
+++ b/be/src/olap/lru_cache.cpp
@@ -177,8 +177,10 @@ void HandleTable::_resize() {
 
 LRUCache::LRUCache() {
     // Make empty circular linked list
-    _lru.next = &_lru;
-    _lru.prev = &_lru;
+    _lru_normal.next = &_lru_normal;
+    _lru_normal.prev = &_lru_normal;
+    _lru_durable.next = &_lru_durable;
+    _lru_durable.prev = &_lru_durable;
 }
 
 LRUCache::~LRUCache() {
@@ -244,7 +246,11 @@ void LRUCache::release(Cache::Handle* handle) {
                 last_ref = true;
             } else {
                 // put it to LRU free list
-                _lru_append(&_lru, e);
+                if (e->priority == CachePriority::NORMAL) {
+                    _lru_append(&_lru_normal, e);
+                } else if (e->priority == CachePriority::DURABLE) {
+                    _lru_append(&_lru_durable, e);
+                }
             }
         }
     }
@@ -256,21 +262,17 @@ void LRUCache::release(Cache::Handle* handle) {
 }
 
 void LRUCache::_evict_from_lru(size_t charge, LRUHandle** to_remove_head) {
-    LRUHandle* cur = &_lru;
     // 1. evict normal cache entries
-    while (_usage + charge > _capacity && cur->next != &_lru) {
-        LRUHandle* old = cur->next;
-        if (old->priority == CachePriority::DURABLE) {
-            cur = cur->next;
-            continue;
-        }
+    while (_usage + charge > _capacity && _lru_normal.next != &_lru_normal) {
+        LRUHandle* old = _lru_normal.next;
+        DCHECK(old->priority == CachePriority::NORMAL);
         _evict_one_entry(old);
         old->next = *to_remove_head;
         *to_remove_head = old;
     }
     // 2. evict durable cache entries if need
-    while (_usage + charge > _capacity && _lru.next != &_lru) {
-        LRUHandle* old = _lru.next;
+    while (_usage + charge > _capacity && _lru_durable.next != &_lru_durable) {
+        LRUHandle* old = _lru_durable.next;
         DCHECK(old->priority == CachePriority::DURABLE);
         _evict_one_entry(old);
         old->next = *to_remove_head;
@@ -363,19 +365,29 @@ void LRUCache::erase(const CacheKey& key, uint32_t hash) {
     }
 }
 
+void LRUCache::_prune_one(LRUHandle* old) {
+    DCHECK(old->in_cache);
+    DCHECK(old->refs == 1); // LRU list contains elements which may be evicted
+    _lru_remove(old);
+    _table.remove(old);
+    old->in_cache = false;
+    _unref(old);
+    _usage -= old->charge;
+}
+
 int LRUCache::prune() {
     LRUHandle* to_remove_head = nullptr;
     {
         MutexLock l(&_mutex);
-        while (_lru.next != &_lru) {
-            LRUHandle* old = _lru.next;
-            DCHECK(old->in_cache);
-            DCHECK(old->refs == 1); // LRU list contains elements which may be evicted
-            _lru_remove(old);
-            _table.remove(old);
-            old->in_cache = false;
-            _unref(old);
-            _usage -= old->charge;
+        while (_lru_normal.next != &_lru_normal) {
+            LRUHandle* old = _lru_normal.next;
+            _prune_one(old);
+            old->next = to_remove_head;
+            to_remove_head = old;
+        }
+        while (_lru_durable.next != &_lru_durable) {
+            LRUHandle* old = _lru_durable.next;
+            _prune_one(old);
             old->next = to_remove_head;
             to_remove_head = old;
         }
@@ -488,8 +500,8 @@ void ShardedLRUCache::update_cache_metrics() const {
     _mem_tracker->Consume(total_usage - _mem_tracker->consumption());
 }
 
-Cache* new_lru_cache(const std::string& name, size_t capacity, std::shared_ptr<MemTracker> parent_tracekr) {
-    return new ShardedLRUCache(name, capacity, parent_tracekr);
+Cache* new_lru_cache(const std::string& name, size_t capacity, std::shared_ptr<MemTracker> parent_tracker) {
+    return new ShardedLRUCache(name, capacity, parent_tracker);
 }
 
 } // namespace doris

--- a/be/src/olap/lru_cache.h
+++ b/be/src/olap/lru_cache.h
@@ -313,6 +313,7 @@ private:
     bool _unref(LRUHandle* e);
     void _evict_from_lru(size_t charge, LRUHandle** to_remove_head);
     void _evict_one_entry(LRUHandle* e);
+    void _prune_one(LRUHandle* old);
 
     // Initialized before use.
     size_t _capacity = 0;
@@ -322,9 +323,11 @@ private:
     size_t _usage = 0;
 
     // Dummy head of LRU list.
-    // lru.prev is newest entry, lru.next is oldest entry.
     // Entries have refs==1 and in_cache==true.
-    LRUHandle _lru;
+    // _lru_normal.prev is newest entry, _lru_normal.next is oldest entry.
+    LRUHandle _lru_normal;
+    // _lru_durable.prev is newest entry, _lru_durable.next is oldest entry.
+    LRUHandle _lru_durable;
 
     HandleTable _table;
 


### PR DESCRIPTION
## Proposed changes

According to the LRU priority, the `lru list` is split into `lru normal list` and `lru durable list`, and the two lists are traversed in sequence during LRU evict, avoiding invalid cycles.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have created an issue on (Fix #5907) and described the bug/feature there in detail

## Further comments

At present, `in memory table` will always occupy part of the page cache even if this `in memory table` has not been accessed for a long time, causing a waste of cache resources.

Later, we can consider that the page of `in memory table` can be cached for a longer period of time instead of permanent cache, such as increasing the timestamp or weight.