### PR TITLE
fix ExportJob ErrorMsg is UNKNOWN when job cancelled cause by time out

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/task/ExportExportingTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/task/ExportExportingTask.java
@@ -243,6 +243,8 @@ public class ExportExportingTask extends MasterTask {
         isCancelled = true;
         this.failStatus = new Status(TStatusCode.TIMEOUT, "timeout");
         cancelType = ExportFailMsg.CancelType.TIMEOUT;
+        String failMsg = "export exporting job timeout.";
+        job.setFailMsg(new ExportFailMsg(cancelType, failMsg));
         LOG.warn("export exporting job timeout. job: {}", job);
     }
 


### PR DESCRIPTION
ExportJob ErrorMsg is "type:UNKNOWN; msg: "when job cancelled cause by time out


## Proposed changes

"type:TIMEOUT; msg:export exporting job timeout." should be shown

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Code refactor (Modify the code structure, format the code, etc...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have created an issue on (Fix https://github.com/apache/incubator-doris/issues/5914) and described the bug/feature there in detail
- [x] Compiling and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If these changes need document changes, I have updated the document
- [ ] Any dependent changes have been merged

## related issue

https://github.com/apache/incubator-doris/issues/5914


