### PR TITLE
[BUG] Fix parse error when the memory parameter is a float value percentage

### DIFF
--- a/be/test/util/parse_util_test.cpp
+++ b/be/test/util/parse_util_test.cpp
@@ -55,6 +55,12 @@ TEST(TestParseMemSpec, Normal) {
     int64_t bytes = ParseUtil::parse_mem_spec("20%", &is_percent);
     ASSERT_GT(bytes, 0);
     ASSERT_TRUE(is_percent);
+
+    MemInfo::_s_physical_mem = 1000;
+    is_percent = true;
+    bytes = ParseUtil::parse_mem_spec("0.1%", &is_percent);
+    ASSERT_EQ(bytes, 1);
+    ASSERT_TRUE(is_percent);
 }
 
 TEST(TestParseMemSpec, Bad) {


### PR DESCRIPTION
## Proposed changes

When parsing memory parameters in `ParseUtil::parse_mem_spec`, convert the percentage to `double` instead of `int`.

The currently affected parameters include `mem_limit` and `storage_page_cache_limit`

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have created an issue on (Fix #5818) and described the bug/feature there in detail