### PR TITLE
[Bug] Fix export job sometimes stuck in exporting state after timeout

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/task/ExportExportingTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/task/ExportExportingTask.java
@@ -135,7 +135,10 @@ public class ExportExportingTask extends MasterTask {
                         DebugUtil.printId(coord.getQueryId()), job.getId(), progress);
             }
 
-            coord.getQueryProfile().getCounterTotalTime().setValue(TimeUtils.getEstimatedTime(job.getStartTimeMs()));
+            RuntimeProfile queryProfile = coord.getQueryProfile();
+            if (queryProfile != null) {
+                queryProfile.getCounterTotalTime().setValue(TimeUtils.getEstimatedTime(job.getStartTimeMs()));
+            }
             coord.endProfile();
             fragmentProfiles.add(coord.getQueryProfile());
         }
@@ -248,8 +251,7 @@ public class ExportExportingTask extends MasterTask {
 
     private void initProfile() {
         profile = new RuntimeProfile("Query");
-        RuntimeProfile summaryProfile = new RuntimeProfile("Query");
-        summaryProfile = new RuntimeProfile("Summary");
+        RuntimeProfile summaryProfile = new RuntimeProfile("Summary");
         summaryProfile.addInfoString(ProfileManager.QUERY_ID, String.valueOf(job.getId()));
         summaryProfile.addInfoString(ProfileManager.START_TIME, TimeUtils.longToTimeString(job.getStartTimeMs()));
 


### PR DESCRIPTION
## Proposed changes

Fix #5931 
The reason is that sometime the method `coordinate.exec()` is not call when the job is timeout, so that the query profile in this coordinate is not be initialized, which will cause an NPE error in the execution of ExportExportingTask.

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have created an issue on (Fix #ISSUE) and described the bug/feature there in detail
- [x] Compiling and unit tests pass locally with my changes

## Further comments

If this is a relatively large or complex change, kick off the discussion at dev@doris.apache.org by explaining why you chose the solution you did and what alternatives you considered, etc...
