### PR TITLE
catch throwable instead of exception

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/nio/AcceptListener.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/nio/AcceptListener.java
@@ -78,7 +78,7 @@ public class AcceptListener implements ChannelListener<AcceptingChannel<StreamCo
                     // do not need to print log for this kind of exception.
                     // just clean up the context;
                     context.cleanup();
-                } catch (Exception e) {
+                } catch (Throwable e) {
                     // should be unexpected exception, so print warn log
                     if (context.getCurrentUserIdentity() != null) {
                         LOG.warn("connect processor exception because ", e);


### PR DESCRIPTION
## Proposed changes

Running doris-fe 0.14.x or later with jdk8 will got any exception in logs, but Mysql client connection is hangged.

because of MysqlProto.negotiate(context) throw java.lang.NoSuchMethodError.

catch throwable instead of exception to fix this.

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [ x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Code refactor (Modify the code structure, format the code, etc...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have created an issue on (Fix #ISSUE) and described the bug/feature there in detail
- [ x] Compiling and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If these changes need document changes, I have updated the document
- [ ] Any dependent changes have been merged

