### PR TITLE
[Bug] Rebuilt version graph of a tablet when there are too many orphan vertex

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -604,6 +604,16 @@ CONF_mInt32(remote_storage_read_buffer_mb, "256");
 //      DEBUG: 1
 // the level equal or lower than mem_tracker_level will show in web page
 CONF_Int16(mem_tracker_level, "0");
+
+// The version information of the tablet will be stored in the memory
+// in an adjacency graph data structure.
+// And as the new version is written and the old version is deleted,
+// the data structure will begin to have empty vertex with no edge associations(orphan vertex).
+// This config is used to control that when the proportion of orphan vertex is greater than the threshold,
+// the adjacency graph will be rebuilt to ensure that the data structure will not expand indefinitely.
+// This config usually only needs to be modified during testing.
+// In most cases, it does not need to be modified.
+CONF_mDouble(tablet_version_graph_orphan_vertex_ratio, "0.1");
 } // namespace config
 
 } // namespace doris

--- a/be/src/olap/storage_engine.cpp
+++ b/be/src/olap/storage_engine.cpp
@@ -531,9 +531,11 @@ void StorageEngine::stop() {
     // trigger the waiting threads
     notify_listeners();
 
-    std::lock_guard<std::mutex> l(_store_lock);
-    for (auto& store_pair : _store_map) {
-        store_pair.second->stop_bg_worker();
+    {
+        std::lock_guard<std::mutex> l(_store_lock);
+        for (auto& store_pair : _store_map) {
+            store_pair.second->stop_bg_worker();
+        }
     }
 
     _stop_background_threads_latch.count_down();

--- a/be/src/olap/tablet.h
+++ b/be/src/olap/tablet.h
@@ -272,6 +272,10 @@ private:
             std::shared_ptr<CumulativeCompactionPolicy> cumulative_compaction_policy);
     const uint32_t _calc_base_compaction_score() const;
 
+    // When the proportion of empty edges in the adjacency matrix used to represent the version graph
+    // in the version tracker is greater than the threshold, rebuild the version tracker
+    bool _reconstruct_version_tracker_if_necessary();
+
 public:
     static const int64_t K_INVALID_CUMULATIVE_POINT = -1;
 

--- a/be/src/olap/version_graph.cpp
+++ b/be/src/olap/version_graph.cpp
@@ -397,6 +397,10 @@ std::string TimestampedVersionTracker::get_current_path_map_str() {
     return tracker_info.str();
 }
 
+double TimestampedVersionTracker::get_orphan_vertex_ratio() {
+    return _version_graph.get_orphan_vertex_ratio();
+}
+
 void TimestampedVersionPathContainer::add_timestamped_version(TimestampedVersionSharedPtr version) {
     // compare and refresh _max_create_time
     if (version->get_create_time() > _max_create_time) {
@@ -515,6 +519,9 @@ OLAPStatus VersionGraph::delete_version_from_graph(const Version& version) {
         end_edges_iter++;
     }
 
+    // Here we do not delete vertex in _version_graph even if its edges are empty.
+    // the _version_graph will be rebuilt when doing trash sweep.
+
     return OLAP_SUCCESS;
 }
 
@@ -629,6 +636,17 @@ OLAPStatus VersionGraph::capture_consistent_versions(const Version& spec_version
     }
 
     return OLAP_SUCCESS;
+}
+
+double VersionGraph::get_orphan_vertex_ratio() {
+    int64_t vertex_num = _version_graph.size();
+    int64_t orphan_vertex_num = 0;
+    for (auto& iter : _version_graph) {
+        if (iter.edges.empty()) {
+            ++orphan_vertex_num;
+        }
+    }
+    return orphan_vertex_num / (double) vertex_num;
 }
 
 } // namespace doris

--- a/be/src/olap/version_graph.h
+++ b/be/src/olap/version_graph.h
@@ -51,6 +51,9 @@ public:
     OLAPStatus capture_consistent_versions(const Version& spec_version,
                                            std::vector<Version>* version_path) const;
 
+    // See comment of TimestampedVersionTracker's get_orphan_vertex_ratio();
+    double get_orphan_vertex_ratio();
+
 private:
     /// Private method add a version to graph.
     void _add_vertex_to_graph(int64_t vertex_value);
@@ -176,6 +179,10 @@ public:
     /// Get json document of _stale_version_path_map. Fill the path_id and version_path
     /// list in the document. The parameter path arr is used as return variable.
     void get_stale_version_path_json_doc(rapidjson::Document& path_arr);
+
+    // Return proportion of orphan vertex in VersionGraph's _version_graph.
+    // If a vertex is no longer the starting point of any edge, then this vertex is defined as orphan vertex
+    double get_orphan_vertex_ratio();
 
 private:
     /// Construct rowsets version tracker with main path rowset meta.

--- a/be/test/olap/timestamped_version_tracker_test.cpp
+++ b/be/test/olap/timestamped_version_tracker_test.cpp
@@ -826,6 +826,26 @@ TEST_F(TestTimestampedVersionTracker, get_stale_version_path_json_doc_empty) {
 
     ASSERT_EQ(expect_result, json_result);
 }
+
+TEST_F(TestTimestampedVersionTracker, get_version_graph_orphan_vertex_ratio) {
+    VersionGraph version_graph;
+
+    Version version0(0, 5);
+    Version version1(6, 8);
+    Version version2(9, 10);
+    Version version3(11, 12);
+
+    version_graph.add_version_to_graph(version0);
+    version_graph.add_version_to_graph(version1);
+    version_graph.add_version_to_graph(version2);
+    version_graph.add_version_to_graph(version3);
+    version_graph.delete_version_from_graph(version2);
+    version_graph.delete_version_from_graph(version3);
+
+    ASSERT_EQ(5, version_graph._version_graph.size());
+    ASSERT_EQ(0.4, version_graph.get_orphan_vertex_ratio());
+}
+
 } // namespace doris
 
 // @brief Test Stub


### PR DESCRIPTION
## Proposed changes

The version information of the tablet will be stored in the memory
in an adjacency graph data structure.
And as the new version is written and the old version is deleted,
the data structure will begin to have empty vertex with no edge associations(orphan vertex).

These orphan vertexs should be removed somehow.

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Code refactor (Modify the code structure, format the code, etc...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have created an issue on (Fix #5943 ) and described the bug/feature there in detail
- [ ] Compiling and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If these changes need document changes, I have updated the document
- [ ] Any dependent changes have been merged

## Further comments

If this is a relatively large or complex change, kick off the discussion at dev@doris.apache.org by explaining why you chose the solution you did and what alternatives you considered, etc...
