### PR TITLE
[Feature] Support setting the number and time threshold for displaying query profile

### DIFF
--- a/docs/en/administrator-guide/variables.md
+++ b/docs/en/administrator-guide/variables.md
@@ -68,7 +68,7 @@ Variables that support both session-level and global-level setting include:
 * `wait_timeout`
 * `sql_mode`
 * `is_report_success`
-* `report_query_time_threshold`
+* `report_query_time_threshold_ms`
 * `query_timeout`
 * `exec_mem_limit`
 * `batch_size`
@@ -239,13 +239,10 @@ Note that the comment must start with /*+ and can only follow the SELECT.
     
     `fe_host:fe_http:port/query`
     
-    It will display the most recent 100 (use `report_query_array_size` to set a custom quantity) queries which `is_report_success` is set to true.
+    It will display the most recent 100 (use fe config `report_query_array_size` to set a custom quantity) queries which `is_report_success` is set to true.
     
-* `report_query_time_threshold`
+* `report_query_time_threshold_ms`
     Used to set the time threshold for displaying query profile. The unit is ms and the default is -1.
-
-* `report_query_array_size`
-    Used to set the maximum number of display query profile. The defaule is 100.
 
 * `language`
 

--- a/docs/en/administrator-guide/variables.md
+++ b/docs/en/administrator-guide/variables.md
@@ -68,6 +68,7 @@ Variables that support both session-level and global-level setting include:
 * `wait_timeout`
 * `sql_mode`
 * `is_report_success`
+* `report_query_time_threshold`
 * `query_timeout`
 * `exec_mem_limit`
 * `batch_size`
@@ -238,8 +239,14 @@ Note that the comment must start with /*+ and can only follow the SELECT.
     
     `fe_host:fe_http:port/query`
     
-    It will display the most recent 100 queries which `is_report_success` is set to true.
+    It will display the most recent 100 (use `report_query_array_size` to set a custom quantity) queries which `is_report_success` is set to true.
     
+* `report_query_time_threshold`
+    Used to set the time threshold for displaying query profile. The unit is ms and the default is -1.
+
+* `report_query_array_size`
+    Used to set the maximum number of display query profile. The defaule is 100.
+
 * `language`
 
     Used for compatibility with MySQL clients. No practical effect.

--- a/docs/zh-CN/administrator-guide/variables.md
+++ b/docs/zh-CN/administrator-guide/variables.md
@@ -68,6 +68,7 @@ SET GLOBAL exec_mem_limit = 137438953472
 * `wait_timeout`
 * `sql_mode`
 * `is_report_success`
+* `report_query_time_threshold`
 * `query_timeout`
 * `exec_mem_limit`
 * `batch_size`
@@ -234,7 +235,13 @@ SELECT /*+ SET_VAR(query_timeout = 1, enable_partition_cache=true) */ sleep(3);
     
     `fe_host:fe_http_port/query`
     
-    其中会显示最近100条，开启 `is_report_success` 的查询的 profile。
+    其中默认会显示最近100条（可以通过`reporty_query_array_size`进行设置），开启 `is_report_success` 的查询的 profile。
+
+* `report_query_time_threshold`
+    用于设置展示查询 profile 的耗时阈值，单位 ms，默认为 -1，展示所有查询 profile。
+
+* `report_query_array_size` 
+    用于设置展示查询 profile 的数量，默认为100。
     
 * `language`
 

--- a/docs/zh-CN/administrator-guide/variables.md
+++ b/docs/zh-CN/administrator-guide/variables.md
@@ -68,7 +68,7 @@ SET GLOBAL exec_mem_limit = 137438953472
 * `wait_timeout`
 * `sql_mode`
 * `is_report_success`
-* `report_query_time_threshold`
+* `report_query_time_threshold_ms`
 * `query_timeout`
 * `exec_mem_limit`
 * `batch_size`
@@ -235,13 +235,11 @@ SELECT /*+ SET_VAR(query_timeout = 1, enable_partition_cache=true) */ sleep(3);
     
     `fe_host:fe_http_port/query`
     
-    其中默认会显示最近100条（可以通过`reporty_query_array_size`进行设置），开启 `is_report_success` 的查询的 profile。
+    其中默认会显示最近100条（可以通过fe配置项`report_query_array_size`进行设置），开启 `is_report_success` 的查询的 profile。
 
-* `report_query_time_threshold`
+* `report_query_time_threshold_ms`
     用于设置展示查询 profile 的耗时阈值，单位 ms，默认为 -1，展示所有查询 profile。
 
-* `report_query_array_size` 
-    用于设置展示查询 profile 的数量，默认为100。
     
 * `language`
 

--- a/fe/fe-core/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/Config.java
@@ -1086,6 +1086,10 @@ public class Config extends ConfigBase {
     public static int report_queue_size = 100;
 
     /**
+     * The number of query profile that fe will save.
+     */
+    @ConfField public  static  int report_query_array_size = 100;
+    /**
      * If set to true, metric collector will be run as a daemon timer to collect metrics at fix interval
      */
     @ConfField public static boolean enable_metric_calculator = true;

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/ProfileManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/ProfileManager.java
@@ -17,22 +17,9 @@
 
 package org.apache.doris.common.util;
 
-import org.apache.doris.common.AnalysisException;
-import org.apache.doris.common.Config;
-import org.apache.doris.common.profile.ProfileTreeBuilder;
-import org.apache.doris.common.profile.ProfileTreeNode;
-import org.apache.doris.common.profile.ProfileTreePrinter;
-
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-
-import org.apache.commons.lang3.tuple.Triple;
-import org.apache.doris.qe.ConnectContext;
-import org.apache.doris.qe.GlobalVariable;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Deque;
@@ -44,6 +31,15 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock.ReadLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock.WriteLock;
+import org.apache.commons.lang3.tuple.Triple;
+import org.apache.doris.common.AnalysisException;
+import org.apache.doris.common.Config;
+import org.apache.doris.common.profile.ProfileTreeBuilder;
+import org.apache.doris.common.profile.ProfileTreeNode;
+import org.apache.doris.common.profile.ProfileTreePrinter;
+import org.apache.doris.qe.ConnectContext;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /*
  * if you want to visit the attribute(such as queryID,defaultDb)

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/ProfileManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/ProfileManager.java
@@ -17,9 +17,21 @@
 
 package org.apache.doris.common.util;
 
+import org.apache.doris.common.AnalysisException;
+import org.apache.doris.common.Config;
+import org.apache.doris.common.profile.ProfileTreeBuilder;
+import org.apache.doris.common.profile.ProfileTreeNode;
+import org.apache.doris.common.profile.ProfileTreePrinter;
+import org.apache.doris.qe.ConnectContext;
+
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+
+import org.apache.commons.lang3.tuple.Triple;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Deque;
@@ -31,15 +43,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock.ReadLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock.WriteLock;
-import org.apache.commons.lang3.tuple.Triple;
-import org.apache.doris.common.AnalysisException;
-import org.apache.doris.common.Config;
-import org.apache.doris.common.profile.ProfileTreeBuilder;
-import org.apache.doris.common.profile.ProfileTreeNode;
-import org.apache.doris.common.profile.ProfileTreePrinter;
-import org.apache.doris.qe.ConnectContext;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 /*
  * if you want to visit the attribute(such as queryID,defaultDb)

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/ProfileManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/ProfileManager.java
@@ -18,6 +18,7 @@
 package org.apache.doris.common.util;
 
 import org.apache.doris.common.AnalysisException;
+import org.apache.doris.common.Config;
 import org.apache.doris.common.profile.ProfileTreeBuilder;
 import org.apache.doris.common.profile.ProfileTreeNode;
 import org.apache.doris.common.profile.ProfileTreePrinter;
@@ -138,7 +139,7 @@ public class ProfileManager {
         // filter profile that take more time than threshold
         ProfileElement element = createElement(profile);
         if (ConnectContext.get() != null) {
-            long timeThreshold = ConnectContext.get().getSessionVariable().getReportQueryTimeThreshold();
+            long timeThreshold = ConnectContext.get().getSessionVariable().getReportQueryTimeThresholdMs();
             if (element.totalTimeMs < timeThreshold) {
                 return;
             }
@@ -157,7 +158,7 @@ public class ProfileManager {
         writeLock.lock();
         try {
             if (!queryIdDeque.contains(queryId)) {
-                if (queryIdDeque.size() >= GlobalVariable.reportQueryArraySize) {
+                if (queryIdDeque.size() >= Config.report_query_array_size) {
                     queryIdToProfileMap.remove(queryIdDeque.getFirst());
                     queryIdDeque.removeFirst();
                 }

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/RuntimeProfile.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/RuntimeProfile.java
@@ -49,6 +49,7 @@ public class RuntimeProfile {
     public static String ROOT_COUNTER = "";
     private Counter counterTotalTime;
     private double localTimePercent;
+    private long totalTimeMs;
 
     private Map<String, String> infoStrings = Maps.newHashMap();
     private List<String> infoStringsDisplayOrder = Lists.newArrayList();
@@ -78,6 +79,14 @@ public class RuntimeProfile {
 
     public String getName() {
         return name;
+    }
+
+    public long getTotalTimeMs() {
+        return totalTimeMs;
+    }
+
+    public void setTotalTimeMs(long totalTimeMs) {
+        this.totalTimeMs = totalTimeMs;
     }
 
     public Counter getCounterTotalTime() {

--- a/fe/fe-core/src/main/java/org/apache/doris/http/action/QueryAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/http/action/QueryAction.java
@@ -17,21 +17,22 @@
 
 package org.apache.doris.http.action;
 
+import org.apache.doris.common.Config;
 import org.apache.doris.common.util.ProfileManager;
 import org.apache.doris.http.ActionController;
 import org.apache.doris.http.BaseRequest;
 import org.apache.doris.http.BaseResponse;
 import org.apache.doris.http.IllegalArgException;
+import org.apache.doris.qe.GlobalVariable;
 
 import com.google.common.base.Strings;
 
-import io.netty.handler.codec.http.HttpMethod;
-
-import org.apache.doris.qe.GlobalVariable;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.List;
+
+import io.netty.handler.codec.http.HttpMethod;
 
 public class QueryAction extends WebBaseAction {
     private static final Logger LOG = LogManager.getLogger(QueryAction.class);
@@ -58,7 +59,7 @@ public class QueryAction extends WebBaseAction {
     // Note: we do not show 'Query ID' column in web page
     private void addFinishedQueryInfo(StringBuilder buffer) {
         buffer.append("<h2>Finished Queries</h2>");
-        buffer.append("<p>This table lists the latest " + GlobalVariable.reportQueryArraySize + " queries</p>");
+        buffer.append("<p>This table lists the latest " + Config.report_query_array_size + " queries</p>");
         
         List<List<String>> finishedQueries = ProfileManager.getInstance().getAllQueries();
         List<String> columnHeaders = ProfileManager.PROFILE_HEADERS;

--- a/fe/fe-core/src/main/java/org/apache/doris/http/action/QueryAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/http/action/QueryAction.java
@@ -23,7 +23,6 @@ import org.apache.doris.http.ActionController;
 import org.apache.doris.http.BaseRequest;
 import org.apache.doris.http.BaseResponse;
 import org.apache.doris.http.IllegalArgException;
-import org.apache.doris.qe.GlobalVariable;
 
 import com.google.common.base.Strings;
 

--- a/fe/fe-core/src/main/java/org/apache/doris/http/action/QueryAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/http/action/QueryAction.java
@@ -27,6 +27,7 @@ import com.google.common.base.Strings;
 
 import io.netty.handler.codec.http.HttpMethod;
 
+import org.apache.doris.qe.GlobalVariable;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -57,7 +58,7 @@ public class QueryAction extends WebBaseAction {
     // Note: we do not show 'Query ID' column in web page
     private void addFinishedQueryInfo(StringBuilder buffer) {
         buffer.append("<h2>Finished Queries</h2>");
-        buffer.append("<p>This table lists the latest 100 queries</p>");
+        buffer.append("<p>This table lists the latest " + GlobalVariable.reportQueryArraySize + " queries</p>");
         
         List<List<String>> finishedQueries = ProfileManager.getInstance().getAllQueries();
         List<String> columnHeaders = ProfileManager.PROFILE_HEADERS;

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/GlobalVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/GlobalVariable.java
@@ -41,6 +41,7 @@ public final class GlobalVariable {
     public static final String QUERY_CACHE_SIZE = "query_cache_size";
     public static final String DEFAULT_ROWSET_TYPE = "default_rowset_type";
     public static final String PERFORMANCE_SCHEMA = "performance_schema";
+    public static final String REPORT_QUERY_ARRAY_SIZE = "report_query_array_size";
 
     @VariableMgr.VarAttr(name = VERSION_COMMENT, flag = VariableMgr.READ_ONLY)
     public static String versionComment = "Doris version " +
@@ -79,6 +80,9 @@ public final class GlobalVariable {
     // add performance schema to support MYSQL JDBC 8.0.16 or later versions.
     @VariableMgr.VarAttr(name = PERFORMANCE_SCHEMA, flag = VariableMgr.READ_ONLY)
     public static String performanceSchema = "OFF";
+
+    @VariableMgr.VarAttr(name = REPORT_QUERY_ARRAY_SIZE, flag = VariableMgr.GLOBAL)
+    public volatile static int reportQueryArraySize = 100;
 
     // Don't allow create instance.
     private GlobalVariable() {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/GlobalVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/GlobalVariable.java
@@ -41,7 +41,6 @@ public final class GlobalVariable {
     public static final String QUERY_CACHE_SIZE = "query_cache_size";
     public static final String DEFAULT_ROWSET_TYPE = "default_rowset_type";
     public static final String PERFORMANCE_SCHEMA = "performance_schema";
-    public static final String REPORT_QUERY_ARRAY_SIZE = "report_query_array_size";
 
     @VariableMgr.VarAttr(name = VERSION_COMMENT, flag = VariableMgr.READ_ONLY)
     public static String versionComment = "Doris version " +
@@ -80,9 +79,6 @@ public final class GlobalVariable {
     // add performance schema to support MYSQL JDBC 8.0.16 or later versions.
     @VariableMgr.VarAttr(name = PERFORMANCE_SCHEMA, flag = VariableMgr.READ_ONLY)
     public static String performanceSchema = "OFF";
-
-    @VariableMgr.VarAttr(name = REPORT_QUERY_ARRAY_SIZE, flag = VariableMgr.GLOBAL)
-    public volatile static int reportQueryArraySize = 100;
 
     // Don't allow create instance.
     private GlobalVariable() {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -120,6 +120,7 @@ public class SessionVariable implements Serializable, Writable {
 
     public static final String DELETE_WITHOUT_PARTITION = "delete_without_partition";
 
+    public static final String REPORT_QUERY_TIME_THRESHOLD = "report_query_time_threshold";
 
     public static final long DEFAULT_INSERT_VISIBLE_TIMEOUT_MS = 10_000;
     public static final long MIN_INSERT_VISIBLE_TIMEOUT_MS = 1000; // If user set a very small value, use this value instead.
@@ -306,6 +307,9 @@ public class SessionVariable implements Serializable, Writable {
 
     @VariableMgr.VarAttr(name = DELETE_WITHOUT_PARTITION, needForward = true)
     public boolean deleteWithoutPartition = false;
+
+    @VariableMgr.VarAttr(name = REPORT_QUERY_TIME_THRESHOLD)
+    private int reportQueryTimeThreshold = -1;
 
     public long getMaxExecMemByte() {
         return maxExecMemByte;
@@ -619,6 +623,14 @@ public class SessionVariable implements Serializable, Writable {
 
     public boolean isDeleteWithoutPartition() {
         return deleteWithoutPartition;
+    }
+    
+    public int getReportQueryTimeThreshold() {
+        return reportQueryTimeThreshold;
+    }
+
+    public void setReportQueryTimeThreshold(int reportQueryTimeThreshold) {
+        this.reportQueryTimeThreshold = reportQueryTimeThreshold;
     }
 
     // Serialize to thrift object

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -120,7 +120,7 @@ public class SessionVariable implements Serializable, Writable {
 
     public static final String DELETE_WITHOUT_PARTITION = "delete_without_partition";
 
-    public static final String REPORT_QUERY_TIME_THRESHOLD = "report_query_time_threshold";
+    public static final String REPORT_QUERY_TIME_THRESHOLD_MS = "report_query_time_threshold_ms";
 
     public static final long DEFAULT_INSERT_VISIBLE_TIMEOUT_MS = 10_000;
     public static final long MIN_INSERT_VISIBLE_TIMEOUT_MS = 1000; // If user set a very small value, use this value instead.
@@ -308,8 +308,8 @@ public class SessionVariable implements Serializable, Writable {
     @VariableMgr.VarAttr(name = DELETE_WITHOUT_PARTITION, needForward = true)
     public boolean deleteWithoutPartition = false;
 
-    @VariableMgr.VarAttr(name = REPORT_QUERY_TIME_THRESHOLD)
-    private int reportQueryTimeThreshold = -1;
+    @VariableMgr.VarAttr(name = REPORT_QUERY_TIME_THRESHOLD_MS)
+    private int reportQueryTimeThresholdMs = -1;
 
     public long getMaxExecMemByte() {
         return maxExecMemByte;
@@ -625,12 +625,12 @@ public class SessionVariable implements Serializable, Writable {
         return deleteWithoutPartition;
     }
     
-    public int getReportQueryTimeThreshold() {
-        return reportQueryTimeThreshold;
+    public int getReportQueryTimeThresholdMs() {
+        return reportQueryTimeThresholdMs;
     }
 
-    public void setReportQueryTimeThreshold(int reportQueryTimeThreshold) {
-        this.reportQueryTimeThreshold = reportQueryTimeThreshold;
+    public void setReportQueryTimeThresholdMs(int reportQueryTimeThresholdMs) {
+        this.reportQueryTimeThresholdMs = reportQueryTimeThresholdMs;
     }
 
     // Serialize to thrift object

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -171,6 +171,7 @@ public class StmtExecutor implements ProfileWriter {
             summaryProfile.addInfoString(ProfileManager.START_TIME, TimeUtils.longToTimeString(context.getStartTime()));
             summaryProfile.addInfoString(ProfileManager.END_TIME, TimeUtils.longToTimeString(currentTimestamp));
             summaryProfile.addInfoString(ProfileManager.TOTAL_TIME, DebugUtil.getPrettyStringMs(totalTimeMs));
+            summaryProfile.setTotalTimeMs(totalTimeMs);
             summaryProfile.addInfoString(ProfileManager.QUERY_TYPE, "Query");
             summaryProfile.addInfoString(ProfileManager.QUERY_STATE, context.getState().toString());
             summaryProfile.addInfoString(ProfileManager.DORIS_VERSION, Version.DORIS_BUILD_VERSION);

--- a/fe/fe-core/src/main/java/org/apache/doris/task/ExportExportingTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/task/ExportExportingTask.java
@@ -259,6 +259,7 @@ public class ExportExportingTask extends MasterTask {
         long totalTimeMs = currentTimestamp - job.getStartTimeMs();
         summaryProfile.addInfoString(ProfileManager.END_TIME, TimeUtils.longToTimeString(currentTimestamp));
         summaryProfile.addInfoString(ProfileManager.TOTAL_TIME, DebugUtil.getPrettyStringMs(totalTimeMs));
+        summaryProfile.setTotalTimeMs(totalTimeMs);
 
         summaryProfile.addInfoString(ProfileManager.QUERY_TYPE, "Query");
         summaryProfile.addInfoString(ProfileManager.QUERY_STATE, job.getState().toString());


### PR DESCRIPTION
## Proposed changes
Sometimes we only need to care about big queries, so we can filter out queries that we don’t need to care about by setting a time threshold.

Usage:
```
set is_report_success = true;
set report_query_time_threshold = 100;
--------
set global report_query_array_size = 150;
```

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Code refactor (Modify the code structure, format the code, etc...)


