### PR TITLE
[Bug] Fix lack of rdlock before rowset_with_max_version() in compaction log

### DIFF
--- a/be/src/olap/compaction.cpp
+++ b/be/src/olap/compaction.cpp
@@ -134,9 +134,15 @@ OLAPStatus Compaction::do_compaction_impl(int64_t permits) {
         _tablet->set_last_base_compaction_success_time(now);
     }
 
+    int64_t current_max_version;
+    {
+        ReadLock rdlock(_tablet->get_header_lock_ptr());
+        current_max_version = _tablet->rowset_with_max_version()->end_version();
+    }
+
     LOG(INFO) << "succeed to do " << compaction_name() << ". tablet=" << _tablet->full_name()
               << ", output_version=" << _output_version.first << "-" << _output_version.second
-              << ", current_max_version=" << _tablet->rowset_with_max_version()->end_version()
+              << ", current_max_version=" current_max_version
               << ", disk=" << _tablet->data_dir()->path() << ", segments=" << segments_num
               << ". elapsed time=" << watch.get_elapse_second() << "s. cumulative_compaction_policy="
               << _tablet->cumulative_compaction_policy()->name() << ".";

--- a/be/src/olap/compaction.cpp
+++ b/be/src/olap/compaction.cpp
@@ -142,7 +142,7 @@ OLAPStatus Compaction::do_compaction_impl(int64_t permits) {
 
     LOG(INFO) << "succeed to do " << compaction_name() << ". tablet=" << _tablet->full_name()
               << ", output_version=" << _output_version.first << "-" << _output_version.second
-              << ", current_max_version=" current_max_version
+              << ", current_max_version=" << current_max_version
               << ", disk=" << _tablet->data_dir()->path() << ", segments=" << segments_num
               << ". elapsed time=" << watch.get_elapse_second() << "s. cumulative_compaction_policy="
               << _tablet->cumulative_compaction_policy()->name() << ".";


### PR DESCRIPTION
## Proposed changes

Fix lack of rdlock before rowset_with_max_version() in compaction log.

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Code refactor (Modify the code structure, format the code, etc...)

