### PR TITLE
[Bug] Ignore drop table log when table has been dropped

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Catalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Catalog.java
@@ -4482,6 +4482,13 @@ public class Catalog {
         Table table = db.getTable(tableId);
         // delete from db meta
         db.writeLock();
+        if (table == null) {
+            /**
+             * Same as replayUpdateReplica()
+             */
+            LOG.warn("Olap table is null when the drop table log is replayed, tableId: {}", tableId);
+            return;
+        }
         table.writeLock();
         try {
             unprotectDropTable(db, table, isForceDrop, true);

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Catalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Catalog.java
@@ -4481,7 +4481,6 @@ public class Catalog {
     public void replayDropTable(Database db, long tableId, boolean isForceDrop) {
         Table table = db.getTable(tableId);
         // delete from db meta
-        db.writeLock();
         if (table == null) {
             /**
              * Same as replayUpdateReplica()
@@ -4489,6 +4488,7 @@ public class Catalog {
             LOG.warn("Olap table is null when the drop table log is replayed, tableId: {}", tableId);
             return;
         }
+        db.writeLock();
         table.writeLock();
         try {
             unprotectDropTable(db, table, isForceDrop, true);


### PR DESCRIPTION
## Proposed changes

Although the table lock can control the simultaneous modification of the table by different threads.
But it cannot control the drop operation of the table by other threads.
For example, when drop table and table update occur at the same time.

get table object by thread 1
drop table by thread 2 with table lock
update table object by thread 1
The above process is possible.
At this time, step 3 actually operates a table that no longer exists, which will eventually cause NullPointerException.

In fact, the modified table log after the drop table can be ignored. The reason is that it is meaningless to modify information on a table that no longer exists.

Fixed #5687

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Code refactor (Modify the code structure, format the code, etc...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have created an issue on (Fix #5687 ) and described the bug/feature there in detail
- [x] Compiling and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If these changes need document changes, I have updated the document
- [ ] Any dependent changes have been merged

## Further comments

If this is a relatively large or complex change, kick off the discussion at dev@doris.apache.org by explaining why you chose the solution you did and what alternatives you considered, etc...
