### PR TITLE
[Bug] SimplifyInvalidDateBinaryPredicatesDateRule may cause invalid query plan

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -517,7 +517,7 @@ CONF_mInt32(path_scan_interval_second, "86400");
 // The following 2 configs limit the max usage of disk capacity of a data dir.
 // If both of these 2 threshold reached, no more data can be writen into that data dir.
 // The percent of max used capacity of a data dir
-CONF_mInt32(storage_flood_stage_usage_percent, "95"); // 95%
+CONF_mInt32(storage_flood_stage_usage_percent, "90"); // 90%
 // The min bytes that should be left of a data dir
 CONF_mInt64(storage_flood_stage_left_capacity_bytes, "1073741824"); // 1GB
 // number of thread for flushing memtable per store

--- a/be/src/olap/storage_engine.cpp
+++ b/be/src/olap/storage_engine.cpp
@@ -624,7 +624,9 @@ OLAPStatus StorageEngine::_start_trash_sweep(double* usage) {
 
     const int32_t snapshot_expire = config::snapshot_expire_time_sec;
     const int32_t trash_expire = config::trash_file_expire_time_sec;
-    const double guard_space = config::storage_flood_stage_usage_percent / 100.0;
+    // the guard space should be lower than storage_flood_stage_usage_percent,
+    // so here we multiply 0.9
+    const double guard_space = config::storage_flood_stage_usage_percent / 100.0 * 0.9;
     std::vector<DataDirInfo> data_dir_infos;
     RETURN_NOT_OK_LOG(get_all_data_dir_info(&data_dir_infos, false),
                       "failed to get root path stat info when sweep trash.")

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/DateLiteral.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/DateLiteral.java
@@ -28,10 +28,6 @@ import org.apache.doris.thrift.TDateLiteral;
 import org.apache.doris.thrift.TExprNode;
 import org.apache.doris.thrift.TExprNodeType;
 
-import com.google.common.base.Preconditions;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.joda.time.DateTime;
@@ -39,6 +35,10 @@ import org.joda.time.DateTimeZone;
 import org.joda.time.LocalDateTime;
 import org.joda.time.format.DateTimeFormatter;
 import org.joda.time.format.DateTimeFormatterBuilder;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 
 import java.io.DataInput;
 import java.io.DataOutput;
@@ -265,7 +265,8 @@ public class DateLiteral extends LiteralExpr {
             if (type.equals(Type.DATE)) {
                 if (s.split("-")[0].length() == 2) {
                     dateTime = DATE_FORMATTER_TWO_DIGIT.parseLocalDateTime(s);
-                } else if(s.length() == DATEKEY_LENGTH) {
+                } else if (s.length() == DATEKEY_LENGTH && !s.contains("-")) {
+                    // handle format like 20210106, but should not handle 2021-1-6
                     dateTime = DATEKEY_FORMATTER.parseLocalDateTime(s);
                 } else {
                     dateTime = DATE_FORMATTER.parseLocalDateTime(s);

--- a/fe/fe-core/src/main/java/org/apache/doris/common/NotLiteralExprPredicate.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/NotLiteralExprPredicate.java
@@ -1,0 +1,32 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.common;
+
+import org.apache.doris.analysis.LiteralExpr;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import com.google.common.base.Predicate;
+
+public class NotLiteralExprPredicate implements Predicate {
+
+    @Override
+    public boolean apply(@Nullable Object o) {
+        return o == null || !(o instanceof LiteralExpr);
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/rewrite/SimplifyInvalidDateBinaryPredicatesDateRule.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/rewrite/SimplifyInvalidDateBinaryPredicatesDateRule.java
@@ -23,6 +23,7 @@ import org.apache.doris.analysis.CastExpr;
 import org.apache.doris.analysis.Expr;
 import org.apache.doris.analysis.NullLiteral;
 import org.apache.doris.common.AnalysisException;
+import org.apache.doris.common.NotLiteralExprPredicate;
 
 /**
  * this rule try to convert date expression, if date is invalid, it will be
@@ -35,6 +36,7 @@ import org.apache.doris.common.AnalysisException;
 public class SimplifyInvalidDateBinaryPredicatesDateRule implements ExprRewriteRule {
     public static ExprRewriteRule INSTANCE = new SimplifyInvalidDateBinaryPredicatesDateRule();
     public static final int DATETIME_STRING_MAX_LENGTH = new String("yyyy-MM-dd HH:ii:ss").length();
+    private static final NotLiteralExprPredicate NOT_LITERAL_EXPR_PREDICATE = new NotLiteralExprPredicate();
 
     @Override
     public Expr apply(Expr expr, Analyzer analyzer) throws AnalysisException {
@@ -50,13 +52,29 @@ public class SimplifyInvalidDateBinaryPredicatesDateRule implements ExprRewriteR
         if (!valueExpr.isConstant()) {
             return expr;
         }
+
+        // This is not a very good implementation and tricky.
+        // We have to handle the following cases:
+        // A. k1 is datetime, sql with "k1 > to_date(now())" will be converted to k1 > cast(to_date("xxxx-xx-xx"))
+        // B. k1 is datetime, sql with "k1 > '2021-10-32 10:00:00.100010'" will be converted to k1 > cast('2021-10-32 10:00:00.100010' as datetime)
+        // C. k1 is datetime, sql with "k1 > '2021-10-32'" will be converted to k1 > cast('2021-10-32' as datetime)
         if (valueExpr instanceof CastExpr) {
-            String dateStr = valueExpr.toSql();
-            // if it contains millisecond, microsecond, nanosecond, do nothing
-            if (dateStr.length() > DATETIME_STRING_MAX_LENGTH && dateStr.contains(".")) {
+            valueExpr = valueExpr.getChild(0);
+            if (valueExpr.contains(NOT_LITERAL_EXPR_PREDICATE)) {
+                // Case A.
                 return expr;
             }
+            String dateStr = valueExpr.toSql();
+            if (dateStr.length() > DATETIME_STRING_MAX_LENGTH && dateStr.contains(".")) {
+                // Case B
+                return expr;
+            }
+            // Case C
             return new NullLiteral();
+        } else {
+            if (valueExpr.contains(NOT_LITERAL_EXPR_PREDICATE)) {
+                return expr;
+            }
         }
         return expr;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/rewrite/SimplifyInvalidDateBinaryPredicatesDateRule.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/rewrite/SimplifyInvalidDateBinaryPredicatesDateRule.java
@@ -57,7 +57,7 @@ public class SimplifyInvalidDateBinaryPredicatesDateRule implements ExprRewriteR
         // We have to handle the following cases:
         // A. k1 is datetime, sql with "k1 > to_date(now())" will be converted to k1 > cast(to_date("xxxx-xx-xx"))
         // B. k1 is datetime, sql with "k1 > '2021-10-32 10:00:00.100010'" will be converted to k1 > cast('2021-10-32 10:00:00.100010' as datetime)
-        // C. k1 is datetime, sql with "k1 > '2021-10-32'" will be converted to k1 > cast('2021-10-32' as datetime)
+        // C. k1 is datetime, sql with "k1 > '2021-10-32'" will be converted to k1 > cast('2021-10-32' as datetime), and finally to converted to NullLiteral.
         if (valueExpr instanceof CastExpr) {
             valueExpr = valueExpr.getChild(0);
             if (valueExpr.contains(NOT_LITERAL_EXPR_PREDICATE)) {

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/DateLiteralTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/DateLiteralTest.java
@@ -21,6 +21,7 @@ import org.apache.doris.catalog.Type;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.InvalidFormatException;
 import org.apache.doris.common.jmockit.Deencapsulation;
+
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -51,6 +52,39 @@ public class DateLiteralTest {
             DateLiteral literal7 = new DateLiteral("00-10-07", Type.DATE);
             Assert.assertEquals(2000, literal7.getYear());
 
+        } catch (AnalysisException e) {
+            e.printStackTrace();
+            hasException = true;
+        }
+        Assert.assertFalse(hasException);
+    }
+
+    @Test
+    public void testDateFormat() {
+        boolean hasException = false;
+        try {
+            DateLiteral literal = new DateLiteral("1997-10-7", Type.DATE);
+            Assert.assertEquals(1997, literal.getYear());
+
+            literal = new DateLiteral("2021-06-1", Type.DATE);
+            Assert.assertEquals(2021, literal.getYear());
+            Assert.assertEquals(6, literal.getMonth());
+            Assert.assertEquals(1, literal.getDay());
+
+            literal = new DateLiteral("2022-6-01", Type.DATE);
+            Assert.assertEquals(2022, literal.getYear());
+            Assert.assertEquals(6, literal.getMonth());
+            Assert.assertEquals(1, literal.getDay());
+
+            literal = new DateLiteral("2023-6-1", Type.DATE);
+            Assert.assertEquals(2023, literal.getYear());
+            Assert.assertEquals(6, literal.getMonth());
+            Assert.assertEquals(1, literal.getDay());
+
+            literal = new DateLiteral("20230601", Type.DATE);
+            Assert.assertEquals(2023, literal.getYear());
+            Assert.assertEquals(6, literal.getMonth());
+            Assert.assertEquals(1, literal.getDay());
         } catch (AnalysisException e) {
             e.printStackTrace();
             hasException = true;

--- a/fe/fe-core/src/test/java/org/apache/doris/planner/QueryPlanTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/planner/QueryPlanTest.java
@@ -1581,5 +1581,13 @@ public class QueryPlanTest {
         sql = "select day from tbl_int_date where date = '1604031150000'";
         explainString = UtFrameUtils.getSQLPlanOrErrorMsg(connectContext, "EXPLAIN " + sql);
         Assert.assertTrue(explainString.contains("EMPTYSET"));
+
+        String queryStr = "explain select count(*) from test.baseall where k11 > to_date(now())";
+        explainString = UtFrameUtils.getSQLPlanOrErrorMsg(connectContext, queryStr);
+        Assert.assertTrue(explainString.contains("PREDICATES: `k11` > to_date"));
+
+        queryStr = "explain select count(*) from test.baseall where k11 > '2021-6-1'";
+        explainString = UtFrameUtils.getSQLPlanOrErrorMsg(connectContext, queryStr);
+        Assert.assertTrue(explainString.contains("PREDICATES: `k11` > '2021-06-01 00:00:00'"));
     }
 }


### PR DESCRIPTION
## Proposed changes

1. "where 1k > to_date(now())" will return EMPTYSET in query plan.
2. DateLiteral should accept date string like "2021-6-1".

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Code refactor (Modify the code structure, format the code, etc...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have created an issue on (Fix #5988 ) and described the bug/feature there in detail
- [ ] Compiling and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If these changes need document changes, I have updated the document
- [ ] Any dependent changes have been merged

## Further comments

If this is a relatively large or complex change, kick off the discussion at dev@doris.apache.org by explaining why you chose the solution you did and what alternatives you considered, etc...
