### PR TITLE
[Bug] Fix range partition pruner bug

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/PartitionKey.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/PartitionKey.java
@@ -131,6 +131,19 @@ public class PartitionKey implements Comparable<PartitionKey>, Writable {
         types.remove(types.size() - 1);
     }
 
+    public int fillWithInfinity(List<Column> columns, boolean isMax)
+            throws AnalysisException {
+        int count = 0;
+        int startIndex = keys.size();
+        for (int index = startIndex; index < columns.size(); index++) {
+            Column column = columns.get(index);
+            Type type = Type.fromPrimitiveType(column.getDataType());
+            pushColumn(LiteralExpr.createInfinity(type, isMax), column.getDataType());
+            count++;
+        }
+        return count;
+    }
+
     public List<LiteralExpr> getKeys() {
         return keys;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/RangePartitionPruner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/RangePartitionPruner.java
@@ -122,11 +122,20 @@ public class RangePartitionPruner implements PartitionPruner {
             if (filter.lowerBound != null) {
                 minKey.pushColumn(filter.lowerBound, keyColumn.getDataType());
                 pushMinCount++;
-                if (filter.lowerBoundInclusive && columnIdx != lastColumnId) {
-                    Column column = partitionColumns.get(columnIdx + 1);
-                    Type type = Type.fromPrimitiveType(column.getDataType());
-                    minKey.pushColumn(LiteralExpr.createInfinity(type, false), column.getDataType());
-                    pushMinCount++;
+                if (filter.lowerBoundInclusive) {
+                    for (int i = columnIdx + 1; i <= lastColumnId; i++) {
+                        Column column = partitionColumns.get(i);
+                        Type type = Type.fromPrimitiveType(column.getDataType());
+                        minKey.pushColumn(LiteralExpr.createInfinity(type, false), column.getDataType());
+                        pushMinCount++;
+                    }
+                } else {
+                    for (int i = columnIdx + 1; i <= lastColumnId; i++) {
+                        Column column = partitionColumns.get(i);
+                        Type type = Type.fromPrimitiveType(column.getDataType());
+                        minKey.pushColumn(LiteralExpr.createInfinity(type, true), column.getDataType());
+                        pushMinCount++;
+                    }
                 }
             } else {
                 Type type = Type.fromPrimitiveType(keyColumn.getDataType());
@@ -136,11 +145,20 @@ public class RangePartitionPruner implements PartitionPruner {
             if (filter.upperBound != null) {
                 maxKey.pushColumn(filter.upperBound, keyColumn.getDataType());
                 pushMaxCount++;
-                if (filter.upperBoundInclusive && columnIdx != lastColumnId) {
-                    Column column = partitionColumns.get(columnIdx + 1);
-                    maxKey.pushColumn(LiteralExpr.createInfinity(Type.fromPrimitiveType(column.getDataType()), true),
-                            column.getDataType());
-                    pushMaxCount++;
+                if (filter.upperBoundInclusive) {
+                    for (int i = columnIdx + 1; i <= lastColumnId; i++) {
+                        Column column = partitionColumns.get(i);
+                        maxKey.pushColumn(LiteralExpr.createInfinity(Type.fromPrimitiveType(column.getDataType()), true),
+                          column.getDataType());
+                        pushMaxCount++;
+                    }
+                } else {
+                    for (int i = columnIdx + 1; i <= lastColumnId; i++) {
+                        Column column = partitionColumns.get(i);
+                        maxKey.pushColumn(LiteralExpr.createInfinity(Type.fromPrimitiveType(column.getDataType()), false),
+                          column.getDataType());
+                        pushMaxCount++;
+                    }
                 }
             } else {
                 maxKey.pushColumn(LiteralExpr.createInfinity(Type.fromPrimitiveType(keyColumn.getDataType()), true),

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/RangePartitionPruner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/RangePartitionPruner.java
@@ -75,6 +75,7 @@ public class RangePartitionPruner implements PartitionPruner {
         Column keyColumn = partitionColumns.get(columnIdx);
         PartitionColumnFilter filter = partitionColumnFilters.get(keyColumn.getName());
         if (null == filter) {
+            // todo
             minKey.pushColumn(LiteralExpr.createInfinity(Type.fromPrimitiveType(keyColumn.getDataType()), false),
                     keyColumn.getDataType());
             maxKey.pushColumn(LiteralExpr.createInfinity(Type.fromPrimitiveType(keyColumn.getDataType()), true),
@@ -118,17 +119,12 @@ public class RangePartitionPruner implements PartitionPruner {
             BoundType upperType = filter.upperBoundInclusive ? BoundType.CLOSED : BoundType.OPEN;
             int pushMinCount = 0;
             int pushMaxCount = 0;
-            int lastColumnId = partitionColumns.size() - 1;
             if (filter.lowerBound != null) {
                 minKey.pushColumn(filter.lowerBound, keyColumn.getDataType());
                 pushMinCount++;
-                for (int i = columnIdx + 1; i <= lastColumnId; i++) {
-                    Column column = partitionColumns.get(i);
-                    Type type = Type.fromPrimitiveType(column.getDataType());
-                    minKey.pushColumn(LiteralExpr.createInfinity(type, !filter.lowerBoundInclusive), column.getDataType());
-                    pushMinCount++;
-                }
+                pushMinCount += minKey.fillWithInfinity(partitionColumns, !filter.lowerBoundInclusive);
             } else {
+                // todo
                 Type type = Type.fromPrimitiveType(keyColumn.getDataType());
                 minKey.pushColumn(LiteralExpr.createInfinity(type, false), keyColumn.getDataType());
                 pushMinCount++;
@@ -136,13 +132,9 @@ public class RangePartitionPruner implements PartitionPruner {
             if (filter.upperBound != null) {
                 maxKey.pushColumn(filter.upperBound, keyColumn.getDataType());
                 pushMaxCount++;
-                for (int i = columnIdx + 1; i <= lastColumnId; i++) {
-                    Column column = partitionColumns.get(i);
-                    maxKey.pushColumn(LiteralExpr.createInfinity(Type.fromPrimitiveType(column.getDataType()), filter.upperBoundInclusive),
-                      column.getDataType());
-                    pushMaxCount++;
-                }
+                pushMaxCount += maxKey.fillWithInfinity(partitionColumns, filter.upperBoundInclusive);
             } else {
+                // todo
                 maxKey.pushColumn(LiteralExpr.createInfinity(Type.fromPrimitiveType(keyColumn.getDataType()), true),
                         keyColumn.getDataType());
                 pushMaxCount++;

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/RangePartitionPruner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/RangePartitionPruner.java
@@ -122,20 +122,11 @@ public class RangePartitionPruner implements PartitionPruner {
             if (filter.lowerBound != null) {
                 minKey.pushColumn(filter.lowerBound, keyColumn.getDataType());
                 pushMinCount++;
-                if (filter.lowerBoundInclusive) {
-                    for (int i = columnIdx + 1; i <= lastColumnId; i++) {
-                        Column column = partitionColumns.get(i);
-                        Type type = Type.fromPrimitiveType(column.getDataType());
-                        minKey.pushColumn(LiteralExpr.createInfinity(type, false), column.getDataType());
-                        pushMinCount++;
-                    }
-                } else {
-                    for (int i = columnIdx + 1; i <= lastColumnId; i++) {
-                        Column column = partitionColumns.get(i);
-                        Type type = Type.fromPrimitiveType(column.getDataType());
-                        minKey.pushColumn(LiteralExpr.createInfinity(type, true), column.getDataType());
-                        pushMinCount++;
-                    }
+                for (int i = columnIdx + 1; i <= lastColumnId; i++) {
+                    Column column = partitionColumns.get(i);
+                    Type type = Type.fromPrimitiveType(column.getDataType());
+                    minKey.pushColumn(LiteralExpr.createInfinity(type, !filter.lowerBoundInclusive), column.getDataType());
+                    pushMinCount++;
                 }
             } else {
                 Type type = Type.fromPrimitiveType(keyColumn.getDataType());
@@ -145,20 +136,11 @@ public class RangePartitionPruner implements PartitionPruner {
             if (filter.upperBound != null) {
                 maxKey.pushColumn(filter.upperBound, keyColumn.getDataType());
                 pushMaxCount++;
-                if (filter.upperBoundInclusive) {
-                    for (int i = columnIdx + 1; i <= lastColumnId; i++) {
-                        Column column = partitionColumns.get(i);
-                        maxKey.pushColumn(LiteralExpr.createInfinity(Type.fromPrimitiveType(column.getDataType()), true),
-                          column.getDataType());
-                        pushMaxCount++;
-                    }
-                } else {
-                    for (int i = columnIdx + 1; i <= lastColumnId; i++) {
-                        Column column = partitionColumns.get(i);
-                        maxKey.pushColumn(LiteralExpr.createInfinity(Type.fromPrimitiveType(column.getDataType()), false),
-                          column.getDataType());
-                        pushMaxCount++;
-                    }
+                for (int i = columnIdx + 1; i <= lastColumnId; i++) {
+                    Column column = partitionColumns.get(i);
+                    maxKey.pushColumn(LiteralExpr.createInfinity(Type.fromPrimitiveType(column.getDataType()), filter.upperBoundInclusive),
+                      column.getDataType());
+                    pushMaxCount++;
                 }
             } else {
                 maxKey.pushColumn(LiteralExpr.createInfinity(Type.fromPrimitiveType(keyColumn.getDataType()), true),

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/RangePartitionPruner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/RangePartitionPruner.java
@@ -85,8 +85,7 @@ public class RangePartitionPruner implements PartitionPruner {
                     keyColumn.getDataType());
                 pushMinCount = 1;
                 pushMaxCount = 1;
-            }
-            else {
+            } else {
                 pushMinCount = minKey.fillWithInfinity(partitionColumns, false);
                 pushMaxCount = maxKey.fillWithInfinity(partitionColumns, true);
             }

--- a/fe/fe-core/src/test/java/org/apache/doris/planner/RangePartitionPrunerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/planner/RangePartitionPrunerTest.java
@@ -1,0 +1,110 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.planner;
+
+import org.apache.doris.analysis.CreateDbStmt;
+import org.apache.doris.analysis.CreateTableStmt;
+import org.apache.doris.catalog.Catalog;
+import org.apache.doris.common.FeConstants;
+import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.utframe.UtFrameUtils;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.File;
+import java.util.UUID;
+
+public class RangePartitionPrunerTest {
+
+
+  private static final String runningDir = "fe/mocked/RangePartitionPrunerTest/" + UUID.randomUUID() + "/";
+
+  private static ConnectContext connectContext;
+
+  @BeforeClass
+  public static void beforeClass() throws Exception {
+    UtFrameUtils.createMinDorisCluster(runningDir);
+
+    // create connect context
+    connectContext = UtFrameUtils.createDefaultCtx();
+    // create database
+    String createDbStmtStr = "create database test;";
+    CreateDbStmt createDbStmt = (CreateDbStmt) UtFrameUtils.parseAndAnalyzeStmt(createDbStmtStr, connectContext);
+    Catalog.getCurrentCatalog().createDb(createDbStmt);
+
+    String sql = "CREATE TABLE test.`prune1` (\n" +
+      "  `a` int(11) NULL COMMENT \"\",\n" +
+      "  `b` int(11) NULL COMMENT \"\",\n" +
+      "  `c` int(11) NULL COMMENT \"\",\n" +
+      "  `d` int(11) NULL COMMENT \"\"\n" +
+      ")\n" +
+      "UNIQUE KEY(`a`,`b`,`c`)\n" +
+      "COMMENT \"OLAP\"\n" +
+      "PARTITION BY RANGE(`a`,`b`,`c`)(\n" +
+      "  PARTITION p VALUES LESS THAN ('0')\n" +
+      ")\n" +
+      "DISTRIBUTED BY HASH(`a`) BUCKETS 2 \n" +
+      "PROPERTIES(\"replication_num\" = \"1\");" ;
+    createTable(sql);
+
+  }
+
+  @AfterClass
+  public static void tearDown() {
+    File file = new File(runningDir);
+    file.delete();
+  }
+
+  private static void createTable(String sql) throws Exception {
+    CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameUtils.parseAndAnalyzeStmt(sql, connectContext);
+    Catalog.getCurrentCatalog().createTable(createTableStmt);
+  }
+
+  @Before
+  public void before() {
+    FeConstants.runningUnitTest = true;
+  }
+
+  @After
+  public void after() {
+    FeConstants.runningUnitTest = false;
+  }
+
+  @Test
+  public void testGe() throws Exception {
+    String queryStr = "explain select * from test.`prune1` where a >= 0;";
+    String explainString = UtFrameUtils.getSQLPlanOrErrorMsg(connectContext, queryStr);
+    Assert.assertTrue(explainString.contains("partitions=0/1"));
+    Assert.assertFalse(explainString.contains("partitions=1/1"));
+  }
+
+  @Test
+  public void testGt() throws Exception {
+    String queryStr = "explain select * from test.`prune1` where a > 0;";
+    String explainString = UtFrameUtils.getSQLPlanOrErrorMsg(connectContext, queryStr);
+    Assert.assertTrue(explainString.contains("partitions=0/1"));
+    Assert.assertFalse(explainString.contains("partitions=1/1"));
+  }
+
+
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/planner/RangePartitionPrunerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/planner/RangePartitionPrunerTest.java
@@ -37,74 +37,74 @@ import java.util.UUID;
 public class RangePartitionPrunerTest {
 
 
-  private static final String runningDir = "fe/mocked/RangePartitionPrunerTest/" + UUID.randomUUID() + "/";
+    private static final String runningDir = "fe/mocked/RangePartitionPrunerTest/" + UUID.randomUUID() + "/";
 
-  private static ConnectContext connectContext;
+    private static ConnectContext connectContext;
 
-  @BeforeClass
-  public static void beforeClass() throws Exception {
-    UtFrameUtils.createMinDorisCluster(runningDir);
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        UtFrameUtils.createMinDorisCluster(runningDir);
 
-    // create connect context
-    connectContext = UtFrameUtils.createDefaultCtx();
-    // create database
-    String createDbStmtStr = "create database test;";
-    CreateDbStmt createDbStmt = (CreateDbStmt) UtFrameUtils.parseAndAnalyzeStmt(createDbStmtStr, connectContext);
-    Catalog.getCurrentCatalog().createDb(createDbStmt);
+        // create connect context
+        connectContext = UtFrameUtils.createDefaultCtx();
+        // create database
+        String createDbStmtStr = "create database test;";
+        CreateDbStmt createDbStmt = (CreateDbStmt) UtFrameUtils.parseAndAnalyzeStmt(createDbStmtStr, connectContext);
+        Catalog.getCurrentCatalog().createDb(createDbStmt);
 
-    String sql = "CREATE TABLE test.`prune1` (\n" +
-      "  `a` int(11) NULL COMMENT \"\",\n" +
-      "  `b` int(11) NULL COMMENT \"\",\n" +
-      "  `c` int(11) NULL COMMENT \"\",\n" +
-      "  `d` int(11) NULL COMMENT \"\"\n" +
-      ")\n" +
-      "UNIQUE KEY(`a`,`b`,`c`)\n" +
-      "COMMENT \"OLAP\"\n" +
-      "PARTITION BY RANGE(`a`,`b`,`c`)(\n" +
-      "  PARTITION p VALUES LESS THAN ('0')\n" +
-      ")\n" +
-      "DISTRIBUTED BY HASH(`a`) BUCKETS 2 \n" +
-      "PROPERTIES(\"replication_num\" = \"1\");" ;
-    createTable(sql);
+        String sql = "CREATE TABLE test.`prune1` (\n" +
+            "  `a` int(11) NULL COMMENT \"\",\n" +
+            "  `b` int(11) NULL COMMENT \"\",\n" +
+            "  `c` int(11) NULL COMMENT \"\",\n" +
+            "  `d` int(11) NULL COMMENT \"\"\n" +
+            ")\n" +
+            "UNIQUE KEY(`a`,`b`,`c`)\n" +
+            "COMMENT \"OLAP\"\n" +
+            "PARTITION BY RANGE(`a`,`b`,`c`)(\n" +
+            "  PARTITION p VALUES LESS THAN ('0')\n" +
+            ")\n" +
+            "DISTRIBUTED BY HASH(`a`) BUCKETS 2 \n" +
+            "PROPERTIES(\"replication_num\" = \"1\");";
+        createTable(sql);
 
-  }
+    }
 
-  @AfterClass
-  public static void tearDown() {
-    File file = new File(runningDir);
-    file.delete();
-  }
+    @AfterClass
+    public static void tearDown() {
+        File file = new File(runningDir);
+        file.delete();
+    }
 
-  private static void createTable(String sql) throws Exception {
-    CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameUtils.parseAndAnalyzeStmt(sql, connectContext);
-    Catalog.getCurrentCatalog().createTable(createTableStmt);
-  }
+    private static void createTable(String sql) throws Exception {
+        CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameUtils.parseAndAnalyzeStmt(sql, connectContext);
+        Catalog.getCurrentCatalog().createTable(createTableStmt);
+    }
 
-  @Before
-  public void before() {
-    FeConstants.runningUnitTest = true;
-  }
+    @Before
+    public void before() {
+        FeConstants.runningUnitTest = true;
+    }
 
-  @After
-  public void after() {
-    FeConstants.runningUnitTest = false;
-  }
+    @After
+    public void after() {
+        FeConstants.runningUnitTest = false;
+    }
 
-  @Test
-  public void testGe() throws Exception {
-    String queryStr = "explain select * from test.`prune1` where a >= 0;";
-    String explainString = UtFrameUtils.getSQLPlanOrErrorMsg(connectContext, queryStr);
-    Assert.assertTrue(explainString.contains("partitions=0/1"));
-    Assert.assertFalse(explainString.contains("partitions=1/1"));
-  }
+    @Test
+    public void testGe() throws Exception {
+        String queryStr = "explain select * from test.`prune1` where a >= 0;";
+        String explainString = UtFrameUtils.getSQLPlanOrErrorMsg(connectContext, queryStr);
+        Assert.assertTrue(explainString.contains("partitions=0/1"));
+        Assert.assertFalse(explainString.contains("partitions=1/1"));
+    }
 
-  @Test
-  public void testGt() throws Exception {
-    String queryStr = "explain select * from test.`prune1` where a > 0;";
-    String explainString = UtFrameUtils.getSQLPlanOrErrorMsg(connectContext, queryStr);
-    Assert.assertTrue(explainString.contains("partitions=0/1"));
-    Assert.assertFalse(explainString.contains("partitions=1/1"));
-  }
+    @Test
+    public void testGt() throws Exception {
+        String queryStr = "explain select * from test.`prune1` where a > 0;";
+        String explainString = UtFrameUtils.getSQLPlanOrErrorMsg(connectContext, queryStr);
+        Assert.assertTrue(explainString.contains("partitions=0/1"));
+        Assert.assertFalse(explainString.contains("partitions=1/1"));
+    }
 
 
 }


### PR DESCRIPTION
## Proposed changes
- Fix the bug in issue [5989](https://github.com/apache/incubator-doris/issues/5989).
```sql
CREATE TABLE xxx ( ..... ) 
UNIQUE KEY (`a`,`b`,`c`) 
PARTITION BY RANGE (`a`,`b`,`c`) (
    PARTITION p VALUES LESS THAN ('0')
)   ......
```
```sql
INSERT INTO xxx VALUES ('-1', '-1', '-1' .... );
```
```sql
EXPLAIN SELECT * FROM xxx where a > 0;
EXPLAIN SELECT * FROM xxx where a >= 0;
EXPLAIN SELECT * FROM xxx where a = 0;
EXPLAIN SELECT * FROM xxx where a in (0);
```
- Before fix the bug，the result of explain contains "partitions=1/1"
- After fix the bug，the result of explain contains "partitions=0/1"



## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Code refactor (Modify the code structure, format the code, etc...)

## Checklist

- [x] I have created an issue on [5989](https://github.com/apache/incubator-doris/issues/5989) and described the bug there in detail
- [x] Compiling and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If these changes need document changes, I have updated the document
- [ ] Any dependent changes have been merged

## Further comments
