### PR TITLE
[Bug] fix use incorrect table name in expand star

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/SelectStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/SelectStmt.java
@@ -986,7 +986,9 @@ public class SelectStmt extends QueryStmt {
             if (analyzer.isSemiJoined(tableRef.getId())) {
                 continue;
             }
-            expandStar(new TableName(null, tableRef.getAlias()), tableRef.getDesc());
+            expandStar(new TableName(tableRef.getAliasAsName().getDb(),
+                            tableRef.getAliasAsName().getTbl()),
+                    tableRef.getDesc());
         }
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/planner/QueryPlanTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/planner/QueryPlanTest.java
@@ -457,7 +457,7 @@ public class QueryPlanTest {
     public void testBitmapQuery() throws Exception {
         testBitmapQueryPlan(
                 "select * from test.bitmap_table;",
-                "OUTPUT EXPRS:`default_cluster:test.bitmap_table`.`id` | `default_cluster:test.bitmap_table`.`id2`"
+                "OUTPUT EXPRS:`default_cluster:test`.`bitmap_table`.`id` | `default_cluster:test`.`bitmap_table`.`id2`"
         );
 
         testBitmapQueryPlan(
@@ -511,7 +511,7 @@ public class QueryPlanTest {
     public void testHLLTypeQuery() throws Exception {
         testHLLQueryPlan(
                 "select * from test.hll_table;",
-                "OUTPUT EXPRS:`default_cluster:test.hll_table`.`id` | `default_cluster:test.hll_table`.`id2`"
+                "OUTPUT EXPRS:`default_cluster:test`.`hll_table`.`id` | `default_cluster:test`.`hll_table`.`id2`"
         );
 
         testHLLQueryPlan(


### PR DESCRIPTION
## Proposed changes

SelectStmt use new TableName(null, tableRef.getAlias()) to expand star expression. tableRef.getAlias() is full name include database name and table name. Using it as table name will generate wrong sql in CreateViewStmt. This patch fix this problem and use correct database name and table name in expand star method.

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Code refactor (Modify the code structure, format the code, etc...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have created an issue on (Fix #6002  ) and described the bug/feature there in detail
- [ ] Compiling and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If these changes need document changes, I have updated the document
- [ ] Any dependent changes have been merged

## Further comments

If this is a relatively large or complex change, kick off the discussion at dev@doris.apache.org by explaining why you chose the solution you did and what alternatives you considered, etc...
