### PR TITLE
[Bug-fix] Avoid using 'QueryDetail' in planning stage

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/planner/DistributedPlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/DistributedPlanner.java
@@ -988,7 +988,7 @@ public class DistributedPlanner {
     private boolean canColocateAgg(AggregateInfo aggregateInfo, List<DataPartition> childFragmentDataPartition) {
         // Condition1
         if (ConnectContext.get().getSessionVariable().isDisableColocatePlan()) {
-            LOG.debug("Agg node is not colocate in:" + ConnectContext.get().getQueryDetail().getQueryId()
+            LOG.debug("Agg node is not colocate in:" + ConnectContext.get().queryId()
                     + ", reason:" + DistributedPlanColocateRule.SESSION_DISABLED);
             return false;
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectContext.java
@@ -98,6 +98,9 @@ public class ConnectContext {
 
     protected String remoteIP;
 
+    // This is used to statistic the current query details.
+    // This property will only be set when the query starts to execute.
+    // So in the query planning stage, do not use any value in this attribute.
     protected QueryDetail queryDetail;
 
     public static ConnectContext get() {


### PR DESCRIPTION
## Proposed changes

QueryDetail is used to statistic the current query details.
This property will only be set when the query starts to execute.
So in the query planning stage, using this attribute in the first query will cause 'NullPointerException'.
After that, this attribute retains the value of the previous query
  until it is updated by the subsequent process.
Because code of 'colocateagg' uses this attribute incorrectly in its planning,
  it causes 'NullPointerException' when clients like pymysql connect to doris and send the first query.
Fixed #6017

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Code refactor (Modify the code structure, format the code, etc...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have created an issue on (Fix #6017) and described the bug/feature there in detail
- [x] Compiling and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If these changes need document changes, I have updated the document
- [ ] Any dependent changes have been merged

