### PR TITLE
[Bug-fix] Fix wrong data distribution judgment

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/OlapScanNode.java
@@ -795,9 +795,7 @@ public class OlapScanNode extends ScanNode {
     }
 
     public DataPartition constructInputPartitionByDistributionInfo() {
-        if (getNumInstances() == 1) {
-            return DataPartition.UNPARTITIONED;
-        } else if (Catalog.getCurrentColocateIndex().isColocateTable(olapTable.getId())) {
+        if (Catalog.getCurrentColocateIndex().isColocateTable(olapTable.getId())) {
             DistributionInfo distributionInfo = olapTable.getDefaultDistributionInfo();
             Preconditions.checkState(distributionInfo instanceof HashDistributionInfo);
             List<Column> distributeColumns = ((HashDistributionInfo) distributionInfo).getDistributionColumns();

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/OlapScanNode.java
@@ -801,7 +801,9 @@ public class OlapScanNode extends ScanNode {
         when data partition of fragment is UNPARTITION.
      */
     public DataPartition constructInputPartitionByDistributionInfo() {
-        if (Catalog.getCurrentColocateIndex().isColocateTable(olapTable.getId())) {
+        if (Catalog.getCurrentColocateIndex().isColocateTable(olapTable.getId())
+                || olapTable.getPartitionInfo().getType() == PartitionType.UNPARTITIONED
+                || olapTable.getPartitions().size() == 1) {
             DistributionInfo distributionInfo = olapTable.getDefaultDistributionInfo();
             Preconditions.checkState(distributionInfo instanceof HashDistributionInfo);
             List<Column> distributeColumns = ((HashDistributionInfo) distributionInfo).getDistributionColumns();

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/OlapScanNode.java
@@ -794,6 +794,12 @@ public class OlapScanNode extends ScanNode {
         }
     }
 
+    /*
+    Although sometimes the scan range only involves one instance,
+        the data distribution cannot be set to UNPARTITION here.
+    The reason is that @coordicator will not set the scan range for the fragment,
+        when data partition of fragment is UNPARTITION.
+     */
     public DataPartition constructInputPartitionByDistributionInfo() {
         if (Catalog.getCurrentColocateIndex().isColocateTable(olapTable.getId())) {
             DistributionInfo distributionInfo = olapTable.getDefaultDistributionInfo();

--- a/fe/fe-core/src/test/java/org/apache/doris/planner/ColocatePlanTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/planner/ColocatePlanTest.java
@@ -50,8 +50,13 @@ public class ColocatePlanTest {
         // create table test_colocate (k1 int ,k2 int, k3 int, k4 int)
         // distributed by hash(k1, k2) buckets 10
         // properties ("replication_num" = "2");
-        String createTblStmtStr = "create table db1.test_colocate(k1 int, k2 int, k3 int, k4 int) "
-                + "distributed by hash(k1, k2) buckets 10 properties('replication_num' = '2');";
+        String createColocateTblStmtStr = "create table db1.test_colocate(k1 int, k2 int, k3 int, k4 int) "
+                + "distributed by hash(k1, k2) buckets 10 properties('replication_num' = '2',"
+                + "'colocate_with' = 'group1');";
+        CreateTableStmt createColocateTableStmt = (CreateTableStmt) UtFrameUtils.parseAndAnalyzeStmt(createColocateTblStmtStr, ctx);
+        Catalog.getCurrentCatalog().createTable(createColocateTableStmt);
+        String createTblStmtStr = "create table db1.test(k1 int, k2 int, k3 int, k4 int)"
+                + "distributed by hash(k1, k2) buckets 10 properties('replication_num' = '2')";
         CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameUtils.parseAndAnalyzeStmt(createTblStmtStr, ctx);
         Catalog.getCurrentCatalog().createTable(createTableStmt);
     }
@@ -117,5 +122,18 @@ public class ColocatePlanTest {
         String plan1 = UtFrameUtils.getSQLPlanOrErrorMsg(ctx, sql);
         Assert.assertEquals(1, StringUtils.countMatches(plan1, "AGGREGATE"));
         Assert.assertTrue(plan1.contains(COLOCATE_ENABLE));
+    }
+
+    // without:
+    // 1. agg columns = distributed columns
+    // 2. table is not in colocate group
+    // 3. more then 1 instances
+    // Fixed #6028
+    @Test
+    public void sqlAggWithNonColocateTable() throws Exception {
+        String sql = "explain select k1, k2 from db1.test group by k1, k2";
+        String plan1 = UtFrameUtils.getSQLPlanOrErrorMsg(ctx, sql);
+        Assert.assertEquals(2, StringUtils.countMatches(plan1, "AGGREGATE"));
+        Assert.assertFalse(plan1.contains(COLOCATE_ENABLE));
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/planner/ColocatePlanTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/planner/ColocatePlanTest.java
@@ -56,6 +56,7 @@ public class ColocatePlanTest {
         CreateTableStmt createColocateTableStmt = (CreateTableStmt) UtFrameUtils.parseAndAnalyzeStmt(createColocateTblStmtStr, ctx);
         Catalog.getCurrentCatalog().createTable(createColocateTableStmt);
         String createTblStmtStr = "create table db1.test(k1 int, k2 int, k3 int, k4 int)"
+                + "partition by range(k1) (partition p1 values less than (\"1\"), partition p2 values less than (\"2\"))"
                 + "distributed by hash(k1, k2) buckets 10 properties('replication_num' = '2')";
         CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameUtils.parseAndAnalyzeStmt(createTblStmtStr, ctx);
         Catalog.getCurrentCatalog().createTable(createTableStmt);

--- a/fe/fe-core/src/test/java/org/apache/doris/planner/QueryPlanTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/planner/QueryPlanTest.java
@@ -1359,7 +1359,7 @@ public class QueryPlanTest {
         sql = "SELECT dt, dis_key, COUNT(1) FROM table_partitioned  group by dt, dis_key";
         explainString = UtFrameUtils.getSQLPlanOrErrorMsg(connectContext, "EXPLAIN " + sql);
         System.out.println(explainString);
-        Assert.assertTrue(explainString.contains("AGGREGATE (update finalize)"));
+        Assert.assertTrue(explainString.contains("AGGREGATE (update serialize)"));
     }
 
     public void testLeadAndLagFunction() throws Exception {


### PR DESCRIPTION
## Proposed changes

The Fragment where OlapScanNode is located has two data distribution possibilities.
1. RANDOM: Involving multi-partitioned tables in OlapScanNode.
2. HASH_PARTITIONED: The involving table is in the colocate group.

For a multi-partition table, although the data in each individual partition is distributed according to the bucketing column,
the same bucketing column between different partitions is not necessarily in the same be.
So the data distribution is RANDOM.

If Doris wrongly plan RANDOM as HASH_PARTITIONED, it will lead to the wrong colocate agg node.
The result of query is incorrect.

Fixed #6028

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Code refactor (Modify the code structure, format the code, etc...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have created an issue on (Fix #6028 ) and described the bug/feature there in detail
- [x] Compiling and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If these changes need document changes, I have updated the document
- [ ] Any dependent changes have been merged


