### PR TITLE
Fix timeout error when delete condition contains invalid datetime format 

### DIFF
--- a/be/src/olap/utils.cpp
+++ b/be/src/olap/utils.cpp
@@ -26,10 +26,10 @@
 #include <time.h>
 #include <unistd.h>
 
-#include <filesystem>
-#include <boost/regex.hpp>
 #include <cstdint>
 #include <cstring>
+#include <filesystem>
+#include <regex>
 #include <string>
 #include <vector>
 
@@ -86,7 +86,7 @@ OLAPStatus olap_compress(const char* src_buf, size_t src_len, char* dest_buf, si
             return OLAP_ERR_COMPRESS_ERROR;
         } else if (*written_len > dest_len) {
             VLOG_NOTICE << "buffer overflow when compressing. "
-                    << "dest_len=" << dest_len << ", written_len=" << *written_len;
+                        << "dest_len=" << dest_len << ", written_len=" << *written_len;
 
             return OLAP_ERR_BUFFER_OVERFLOW;
         }
@@ -107,7 +107,7 @@ OLAPStatus olap_compress(const char* src_buf, size_t src_len, char* dest_buf, si
             return OLAP_ERR_COMPRESS_ERROR;
         } else if (*written_len > dest_len) {
             VLOG_NOTICE << "buffer overflow when compressing. "
-                    << ", dest_len=" << dest_len << ", written_len=" << *written_len;
+                        << ", dest_len=" << dest_len << ", written_len=" << *written_len;
 
             return OLAP_ERR_BUFFER_OVERFLOW;
         }
@@ -121,7 +121,7 @@ OLAPStatus olap_compress(const char* src_buf, size_t src_len, char* dest_buf, si
         *written_len = lz4_res;
         if (0 == lz4_res) {
             VLOG_TRACE << "compress failed. src_len=" << src_len << ", dest_len=" << dest_len
-                     << ", written_len=" << *written_len << ", lz4_res=" << lz4_res;
+                       << ", written_len=" << *written_len << ", lz4_res=" << lz4_res;
             return OLAP_ERR_BUFFER_OVERFLOW;
         }
         break;
@@ -777,8 +777,8 @@ OLAPStatus read_write_test_file(const string& test_file_path) {
     }
     if (remove(test_file_path.c_str()) != 0) {
         char errmsg[64];
-        VLOG_NOTICE << "fail to delete test file. [err='" << strerror_r(errno, errmsg, 64) << "' path='"
-                << test_file_path << "']";
+        VLOG_NOTICE << "fail to delete test file. [err='" << strerror_r(errno, errmsg, 64)
+                    << "' path='" << test_file_path << "']";
         return OLAP_ERR_IO_ERROR;
     }
     return res;
@@ -913,9 +913,9 @@ bool valid_signed_number<int128_t>(const std::string& value_str) {
 
 bool valid_decimal(const string& value_str, const uint32_t precision, const uint32_t frac) {
     const char* decimal_pattern = "-?\\d+(.\\d+)?";
-    boost::regex e(decimal_pattern);
-    boost::smatch what;
-    if (!boost::regex_match(value_str, what, e) || what[0].str().size() != value_str.size()) {
+    std::regex e(decimal_pattern);
+    std::smatch what;
+    if (!std::regex_match(value_str, what, e) || what[0].str().size() != value_str.size()) {
         LOG(WARNING) << "invalid decimal value. [value=" << value_str << "]";
         return false;
     }
@@ -947,10 +947,10 @@ bool valid_datetime(const string& value_str) {
     const char* datetime_pattern =
             "((?:\\d){4})-((?:\\d){2})-((?:\\d){2})[ ]*"
             "(((?:\\d){2}):((?:\\d){2}):((?:\\d){2}))?";
-    boost::regex e(datetime_pattern);
-    boost::smatch what;
+    std::regex e(datetime_pattern);
+    std::smatch what;
 
-    if (boost::regex_match(value_str, what, e)) {
+    if (std::regex_match(value_str, what, e)) {
         if (what[0].str().size() != value_str.size()) {
             OLAP_LOG_WARNING("datetime str does not fully match. [value_str=%s match=%s]",
                              value_str.c_str(), what[0].str().c_str());

--- a/be/test/olap/delete_handler_test.cpp
+++ b/be/test/olap/delete_handler_test.cpp
@@ -22,8 +22,8 @@
 
 #include <algorithm>
 #include <boost/assign.hpp>
-#include <boost/regex.hpp>
 #include <iostream>
+#include <regex>
 #include <string>
 #include <vector>
 
@@ -32,13 +32,12 @@
 #include "olap/push_handler.h"
 #include "olap/storage_engine.h"
 #include "olap/utils.h"
+#include "util/cpu_info.h"
 #include "util/file_utils.h"
 #include "util/logging.h"
-#include "util/cpu_info.h"
 
 using namespace std;
 using namespace doris;
-using namespace boost::assign;
 using google::protobuf::RepeatedPtrField;
 
 namespace doris {
@@ -1117,7 +1116,7 @@ TEST_F(TestDeleteHandler, FilterDataVersion) {
     _delete_handler.finalize();
 }
 
-}  // namespace doris
+} // namespace doris
 
 int main(int argc, char** argv) {
     doris::init_glog("be-test");

--- a/fe/fe-core/src/main/java/org/apache/doris/load/DeleteHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/DeleteHandler.java
@@ -95,7 +95,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 public class DeleteHandler implements Writable {

--- a/fe/fe-core/src/main/java/org/apache/doris/load/DeleteHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/DeleteHandler.java
@@ -487,17 +487,17 @@ public class DeleteHandler implements Writable {
     private void checkDateTime(PrimitiveType type, String value) throws DdlException {
          if (type == PrimitiveType.DATE) {
             String re = "^(\\d{4})-(0[1-9]|1[012])-([123]0|[012][1-9]|31)$";
-            if (! Pattern.matches(re, value)) {
+            if (!Pattern.matches(re, value)) {
                 throw new DdlException("Invalid column value[" + value + "], must like 'yyyy-MM-dd'");
             }
         } else if (type == PrimitiveType.DATETIME) {
             String re = "^(\\d{4})-(0[1-9]|1[012])-([123]0|[012][1-9]|31) ([01][0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9])$";
-            if (! Pattern.matches(re, value)) {
+            if (!Pattern.matches(re, value)) {
                 throw new DdlException("Invalid column value[" + value + "], must like 'yyyy-MM-dd HH:mm:ss'");
             }
         } else if (type == PrimitiveType.TIME) {
             String re = "^([01][0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9])$";
-            if (! Pattern.matches(re, value)) {
+            if (!Pattern.matches(re, value)) {
                 throw new DdlException("Invalid column value[" + value + "], must like 'HH:mm:ss'");
             }
         }

--- a/fe/fe-core/src/test/java/org/apache/doris/load/DeleteHandlerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/load/DeleteHandlerTest.java
@@ -28,7 +28,6 @@ import org.apache.doris.analysis.TableName;
 import org.apache.doris.backup.CatalogMocker;
 import org.apache.doris.catalog.Catalog;
 import org.apache.doris.catalog.Database;
-import org.apache.doris.catalog.PrimitiveType;
 import org.apache.doris.catalog.Replica;
 import org.apache.doris.catalog.Table;
 import org.apache.doris.catalog.TabletInvertedIndex;
@@ -53,20 +52,20 @@ import org.apache.doris.transaction.TabletCommitInfo;
 import org.apache.doris.transaction.TransactionState;
 import org.apache.doris.transaction.TransactionStatus;
 import org.apache.doris.transaction.TxnCommitAttachment;
+
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
-import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
 import mockit.Expectations;
 import mockit.Mock;
 import mockit.MockUp;
@@ -482,55 +481,6 @@ public class DeleteHandlerTest {
         Assert.assertEquals(1, jobs.size());
         for (DeleteJob job : jobs) {
             Assert.assertEquals(job.getState(), DeleteState.FINISHED);
-        }
-    }
-
-    @Test
-    public void testCheckDateTime() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
-        Method checkmethod = DeleteHandler.class.getDeclaredMethod("checkDateTime", PrimitiveType.class, String.class);
-        checkmethod.setAccessible(true);
-        try {
-            checkmethod.invoke(deleteHandler, PrimitiveType.DATE, "2019-01-01");
-        } catch (Exception e) {
-            Assert.fail(e.getMessage());
-        }
-        try {
-            checkmethod.invoke(deleteHandler, PrimitiveType.DATE, "2019-1-01");
-        } catch (InvocationTargetException e1) {
-            if (!(e1.getTargetException() instanceof DdlException)) {
-                Assert.fail(e1.getMessage());
-            }
-        }
-        try {
-            checkmethod.invoke(deleteHandler, PrimitiveType.TIME, "12:12:12");
-        } catch (InvocationTargetException e) {
-            Assert.fail(e.getMessage());
-        }
-        try {
-            checkmethod.invoke(deleteHandler, PrimitiveType.TIME, "33:65:66");
-        } catch (InvocationTargetException e1) {
-            if (!(e1.getTargetException() instanceof DdlException)) {
-                Assert.fail(e1.getMessage());
-            }
-        }
-        try {
-            checkmethod.invoke(deleteHandler, PrimitiveType.TIME, "323:65:66");
-        } catch (InvocationTargetException e1) {
-            if (!(e1.getTargetException() instanceof DdlException)) {
-                Assert.fail(e1.getMessage());
-            }
-        }
-        try {
-            checkmethod.invoke(deleteHandler, PrimitiveType.DATETIME, "2019-01-01 12:12:12");
-        } catch (Exception e) {
-            Assert.fail(e.getMessage());
-        }
-        try {
-            checkmethod.invoke(deleteHandler, PrimitiveType.DATETIME, "2019-1-01 12:12:12");
-        } catch (InvocationTargetException e1) {
-            if (!(e1.getTargetException() instanceof DdlException)) {
-                Assert.fail(e1.getMessage());
-            }
         }
     }
 }


### PR DESCRIPTION
## Proposed changes

Fix timeout when delete condition contains invalid datetime format  like 
`delete from table1 where k2=20210102`   k2 is date type
```
MySQL [test]> delete from table1 where k2=20210102;
ERROR 1064 (HY000): errCode = 2, detailMessage = failed to execute delete. transaction id 5, timeout(ms) 30000, unfinished replicas: 10002=10017, 10002=10019, 10002=10021, 10002=10007, 10002=10023
```

use std::regex replace boost::regex

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Code refactor (Modify the code structure, format the code, etc...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have created an issue on (Fix #ISSUE) and described the bug/feature there in detail
- [ ] Compiling and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If these changes need document changes, I have updated the document
- [ ] Any dependent changes have been merged

## Further comments

If this is a relatively large or complex change, kick off the discussion at dev@doris.apache.org by explaining why you chose the solution you did and what alternatives you considered, etc...
