### PR TITLE
[Bug] Remove duplicate memtracker

### DIFF
--- a/be/src/olap/rowset/segment_v2/column_reader.h
+++ b/be/src/olap/rowset/segment_v2/column_reader.h
@@ -72,8 +72,7 @@ struct ColumnIteratorOptions {
     // INDEX_PAGE including index_page, dict_page and short_key_page
     PageTypePB type;
 
-    std::shared_ptr<MemTracker> mem_tracker =
-            MemTracker::CreateTracker(-1, "ColumnIteratorOptionsDefault", nullptr, false);
+    std::shared_ptr<MemTracker> mem_tracker;
 
     void sanity_check() const {
         CHECK_NOTNULL(rblock);

--- a/be/test/olap/rowset/segment_v2/column_reader_writer_test.cpp
+++ b/be/test/olap/rowset/segment_v2/column_reader_writer_test.cpp
@@ -141,6 +141,7 @@ void test_nullable_data(uint8_t* src_data, uint8_t* src_is_null, int num_rows,
         OlapReaderStatistics stats;
         iter_opts.stats = &stats;
         iter_opts.rblock = rblock.get();
+        iter_opts.mem_tracker = std::make_shared<MemTracker>();
         st = iter->init(iter_opts);
         ASSERT_TRUE(st.ok());
         // sequence read
@@ -303,6 +304,7 @@ void test_array_nullable_data(Collection* src_data, uint8_t* src_is_null, int nu
         OlapReaderStatistics stats;
         iter_opts.stats = &stats;
         iter_opts.rblock = rblock.get();
+        iter_opts.mem_tracker = std::make_shared<MemTracker>();
         st = iter->init(iter_opts);
         ASSERT_TRUE(st.ok());
         // sequence read
@@ -438,6 +440,7 @@ void test_read_default_value(string value, void* result) {
                                         tablet_column.default_value(), tablet_column.is_nullable(),
                                         type_info, tablet_column.length());
         ColumnIteratorOptions iter_opts;
+        iter_opts.mem_tracker = std::make_shared<MemTracker>();
         auto st = iter.init(iter_opts);
         ASSERT_TRUE(st.ok());
         // sequence read


### PR DESCRIPTION
## Proposed changes

This problem will cause frequent creation of memtracker and affect query concurrency.

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Code refactor (Modify the code structure, format the code, etc...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have created an issue on (Fix #ISSUE) and described the bug/feature there in detail
- [ ] Compiling and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If these changes need document changes, I have updated the document
- [ ] Any dependent changes have been merged

## Further comments

If this is a relatively large or complex change, kick off the discussion at dev@doris.apache.org by explaining why you chose the solution you did and what alternatives you considered, etc...
