### PR TITLE
[Enhance] Add config to limit the max size of simple tablet

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -578,6 +578,11 @@ CONF_Int32(query_cache_max_partition_count, "1024");
 // This is to avoid too many version num.
 CONF_mInt32(max_tablet_version_num, "500");
 
+// Maximum size of a tablet, the unit is MB. If the size of a tablet exceed limit, the load process
+// will reject new incoming load job of this tablet. This is to avoid too large tablet.
+// There is no limit to tablet size when the parameter is set to "0".
+CONF_mInt32(max_tablet_size_mb, "0");
+
 // Frontend mainly use two thrift sever type: THREAD_POOL, THREADED_SELECTOR. if fe use THREADED_SELECTOR model for thrift server,
 // the thrift_server_type_of_fe should be set THREADED_SELECTOR to make be thrift client to fe constructed with TFramedTransport
 CONF_String(thrift_server_type_of_fe, "THREAD_POOL");

--- a/be/src/olap/delta_writer.cpp
+++ b/be/src/olap/delta_writer.cpp
@@ -103,6 +103,15 @@ OLAPStatus DeltaWriter::init() {
 
     _mem_tracker = MemTracker::CreateTracker(-1, "DeltaWriter:" + std::to_string(_tablet->tablet_id()),
                                              _parent_mem_tracker);
+
+    if (config::max_tablet_size_mb > 0 &&
+        _tablet->tablet_footprint() / (1024 * 1024) > config::max_tablet_size_mb) {
+        LOG(WARNING) << "failed to init delta writer. tablet size: " << _tablet->tablet_footprint()
+                     << " Byte, exceed limit: " << config::max_tablet_size_mb
+                     << "MB. tablet: " << _tablet->full_name();
+        return OLAP_ERR_TOO_LARGE_TABLET;
+    }
+
     // check tablet version number
     if (_tablet->version_count() > config::max_tablet_version_num) {
         LOG(WARNING) << "failed to init delta writer. version count: " << _tablet->version_count()

--- a/be/src/olap/olap_define.h
+++ b/be/src/olap/olap_define.h
@@ -167,6 +167,7 @@ enum OLAPStatus {
     OLAP_ERR_TOO_MANY_VERSION = -235,
     OLAP_ERR_NOT_INITIALIZED = -236,
     OLAP_ERR_ALREADY_CANCELLED = -237,
+    OLAP_ERR_TOO_LARGE_TABLET = -238,
 
     // CommandExecutor
     // [-300, -400)


### PR DESCRIPTION
## Proposed changes

Add a new config `max_tablet_size_mb` to limit the max size of simple tablet. If the size of a tablet exceed limitation, load process will reject new incoming load job of this tablet. There is no limit to the size of the tablet if`max_tablet_size_mb` is set to 0.

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Code refactor (Modify the code structure, format the code, etc...)

