### PR TITLE
[Bug] Fix  stream load  detailed error message is missing

### DIFF
--- a/be/src/exec/tablet_sink.cpp
+++ b/be/src/exec/tablet_sink.cpp
@@ -127,7 +127,6 @@ void NodeChannel::open() {
 }
 
 void NodeChannel::_cancel_with_msg(const std::string& msg) {
-    _cancelled = true;
     LOG(WARNING) << msg;
     {
         std::lock_guard<SpinLock> l(_cancel_msg_lock);
@@ -135,6 +134,7 @@ void NodeChannel::_cancel_with_msg(const std::string& msg) {
             _cancel_msg = msg;
         }
     }
+    _cancelled = true;
 }
 
 Status NodeChannel::open_wait() {


### PR DESCRIPTION
## Proposed changes

During stream load, tablet writer write failed in Executor BE would cancel load process, but sometimes detailed error message is missing when client receive stream load result (Not every time).

For example:
```
{
    "TxnId": 36148,
    "Label": "1623907022-615",
    "Status": "Fail",
    "Message": "add row failed. ; ",
    "NumberTotalRows": 0,
    "NumberLoadedRows": 0,
    "NumberFilteredRows": 0,
    "NumberUnselectedRows": 0,
    "LoadBytes": 446611,
    "LoadTimeMs": 7,
    "BeginTxnTimeMs": 0,
    "StreamLoadPutTimeMs": 0,
    "ReadDataTimeMs": 0,
    "WriteDataTimeMs": 5,
    "CommitAndPublishTimeMs": 0
}
```
The correct result should be as follows:
```
{
    "TxnId": 36149,
    "Label": "1623907037-780",
    "Status": "Fail",
    "Message": "add row failed. NodeChannel[10028-10003] add batch req success but status isn't ok, load_id=4a4e6d44c9d13d37-39097d02a3b708ae, txn_id=36149, backend id=10003:8060, errmsg=tablet writer write failed, tablet_id=10069, txn_id=36149, err=-235; ",
    "NumberTotalRows": 0,
    "NumberLoadedRows": 0,
    "NumberFilteredRows": 0,
    "NumberUnselectedRows": 0,
    "LoadBytes": 446606,
    "LoadTimeMs": 10,
    "BeginTxnTimeMs": 0,
    "StreamLoadPutTimeMs": 1,
    "ReadDataTimeMs": 0,
    "WriteDataTimeMs": 8,
    "CommitAndPublishTimeMs": 0
}
```
This is a bug. `_cancel_msg` should be assigned value befor `_cancelled` is set for `true`. Otherwise, `_cancel_msg` may be a empty string when it is returned to client.

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Code refactor (Modify the code structure, format the code, etc...)
