### PR TITLE
[BUG] fix spring boot web maximum upload file limit config error

### DIFF
--- a/docs/en/administrator-guide/config/fe_config.md
+++ b/docs/en/administrator-guide/config/fe_config.md
@@ -185,9 +185,9 @@ HTTP Server V2 is implemented by SpringBoot. It uses an architecture that separa
 
 ### http_max_request_size
 
-Default：100M
+Default：100MB
 
-The above two parameters are the http v2 version, the web maximum upload file limit, the default is 100M, you can modify it according to your needs.
+The above two parameters are the http v2 version, the web maximum upload file limit, the default is 100MB, you can modify it according to your needs.
 
 ### frontend_address
 

--- a/docs/zh-CN/administrator-guide/config/fe_config.md
+++ b/docs/zh-CN/administrator-guide/config/fe_config.md
@@ -184,9 +184,9 @@ HTTP Server V2 由 SpringBoot 实现。它采用前后端分离的架构。只�
 
 ### http_max_request_size
 
-默认值：100M
+默认值：100MB
 
-以上两个参数是http v2版本，web最大上传文件限制，默认100M，可以根据自己需要修改
+以上两个参数是http v2版本，web最大上传文件限制，默认100MB，可以根据自己需要修改
 
 ### default_max_filter_ratio
 

--- a/fe/fe-core/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/Config.java
@@ -326,10 +326,10 @@ public class Config extends ConfigBase {
     @ConfField public static int http_backlog_num = 1024;
 
     /**
-     *Maximum file limit for single upload of web request, default value: 100M
+     *Maximum file limit for single upload of web request, default value: 100MB
      */
-    @ConfField public static String http_max_file_size = "100M";
-    @ConfField public static String http_max_request_size = "100M";
+    @ConfField public static String http_max_file_size = "100MB";
+    @ConfField public static String http_max_request_size = "100MB";
 
     /**
      * The backlog_num for mysql nio server


### PR DESCRIPTION
## Proposed changes

FE startup error:

```
FE startup error, Failed to bind properties under'spring.servlet.multipart.max-file-size' to org.springframework.uti
l.unit.DataSize.
Failed to convert from type [java.lang.String] to type [org.springframework.util.unit.DataSize] for value '100M'; nested exception is java.lang.IllegalArgumentException: '100M' is not a valid data size​
```

Modify the parameters `http_max_file_size` and `http_max_request_size` to `100MB`

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have created an issue on (Fix #6071) and described the bug/feature there in detail
- [x] If these changes need document changes, I have updated the document