### PR TITLE
fix stdfs link error in some gcc version

### DIFF
--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -532,6 +532,7 @@ set(DORIS_LINK_LIBS ${DORIS_LINK_LIBS}
     ${DORIS_DEPENDENCIES}
     -static-libstdc++
     -static-libgcc
+    -lstdc++fs
 )
 
 if ("${CMAKE_BUILD_TYPE}" STREQUAL "BCC")


### PR DESCRIPTION
## Proposed changes

fix 
```
../runtime/libRuntime.a(snapshot_loader.cpp.o): In function `doris::SnapshotLoader::move(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::shared_ptr<doris::Tablet>, bool)': /opt/soft/incubator-doris/be/src/runtime/snapshot_loader.cpp:433: undefined reference to `std::filesystem::remove_all(std::filesystem::__cxx11::path const&)' /opt/soft/incubator-doris/be/src/runtime/snapshot_loader.cpp:435: undefined reference to `std::filesystem::create_directory(std::filesystem::__cxx11::path const&)' ../runtime/libRuntime.a(snapshot_loader.cpp.o):(.gcc_except_table+0x83c): undefined reference to `typeinfo for std::filesystem::__cxx11::filesystem_error' ../runtime/libRuntime.a(snapshot_loader.cpp.o):(.gcc_except_table+0x878): undefined reference to `typeinfo for std::filesystem::__cxx11::filesystem_error' ../util/libUtil.a(broker_storage_backend.cpp.o): In function `std::filesystem::__cxx11::path::path<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::filesystem::__cxx11::path>(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::filesystem::__cxx11::path::format)': /usr/local/include/c++/8.4.0/bits/fs_path.h:185: undefined reference to `std::filesystem::__cxx11::path::_M_split_cmpts()' ../util/libUtil.a(broker_storage_backend.cpp.o): In function `doris::BrokerStorageBackend::download(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)': /opt/soft/incubator-doris/be/src/util/broker_storage_backend.cpp:58: undefined reference to `std::filesystem::remove(std::filesystem::__cxx11::path const&)' collect2: error: ld returned 1 exit status make[2]: *** [src/service/palo_be] Error 1 make[1]: *** [src/service/CMakeFiles/palo_be.dir/all] Error 2 make: *** [all] Error 2
```

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Code refactor (Modify the code structure, format the code, etc...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have created an issue on (Fix #ISSUE) and described the bug/feature there in detail
- [ ] Compiling and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If these changes need document changes, I have updated the document
- [ ] Any dependent changes have been merged

## Further comments

If this is a relatively large or complex change, kick off the discussion at dev@doris.apache.org by explaining why you chose the solution you did and what alternatives you considered, etc...
