### PR TITLE
Align Date and Datetime by 16 bytes

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/TupleDescriptor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/TupleDescriptor.java
@@ -230,7 +230,6 @@ public class TupleDescriptor {
         }
 
         this.byteSize = offset;
-        LOG.info("tuple is {}", byteSize);
     }
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/TupleDescriptor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/TupleDescriptor.java
@@ -203,10 +203,7 @@ public class TupleDescriptor {
             }
             if (slotSize > 1) {
                 // insert padding
-                int alignTo = Math.min(slotSize, 8);
-                if (slotSize == 40) {
-                    alignTo = 4;
-                }
+                int alignTo = slotSize;
                 offset = (offset + alignTo - 1) / alignTo * alignTo;
             }
 
@@ -233,7 +230,7 @@ public class TupleDescriptor {
         }
 
         this.byteSize = offset;
-        // LOG.debug("tuple is {}", byteSize);
+        LOG.info("tuple is {}", byteSize);
     }
 
     /**


### PR DESCRIPTION
The previous alignment of Doris is up to 8 bytes.
For types with more than 8 bytes, such as Date, Datetime is not aligned.
This PR is mainly to relax the maximum 8-byte limitation
Also, because the data type Decimal v1 no longer exists,
the logic of the 40-byte Decimal v1 is also discarded.