### PR TITLE
[Bug] Add readlock when calling get_rowset_by_version()

### DIFF
--- a/be/src/olap/schema_change.cpp
+++ b/be/src/olap/schema_change.cpp
@@ -1498,12 +1498,11 @@ OLAPStatus SchemaChangeHandler::_do_process_alter_tablet_v2(const TAlterTabletRe
         LOG(INFO) << "begin to remove all data from new tablet to prevent rewrite."
                   << " new_tablet=" << new_tablet->full_name();
         std::vector<RowsetSharedPtr> rowsets_to_delete;
-        std::vector<Version> new_tablet_versions;
-        new_tablet->list_versions(&new_tablet_versions);
-        for (auto& version : new_tablet_versions) {
-            if (version.second <= max_rowset->end_version()) {
-                RowsetSharedPtr rowset = new_tablet->get_rowset_by_version(version);
-                rowsets_to_delete.push_back(rowset);
+        std::vector<std::pair<Version, RowsetSharedPtr>> version_rowsets;
+        new_tablet->acquire_version_and_rowsets(&version_rowsets);
+        for (auto& pair : version_rowsets) {
+            if (pair.first.second <= max_rowset->end_version()) {
+                rowsets_to_delete.push_back(pair.second);
             }
         }
         std::vector<RowsetSharedPtr> empty_vec;
@@ -2197,12 +2196,10 @@ OLAPStatus SchemaChangeHandler::_validate_alter_result(TabletSharedPtr new_table
         return OLAP_ERR_VERSION_NOT_EXIST;
     }
 
-    std::vector<Version> new_tablet_versions;
-    // lock so that list_versions() and get_rowset_by_version() can be done atomically.
-    ReadLock lock(new_tablet->get_header_lock_ptr());
-    new_tablet->list_versions(&new_tablet_versions);
-    for (auto& version : new_tablet_versions) {
-        RowsetSharedPtr rowset = new_tablet->get_rowset_by_version(version);
+    std::vector<std::pair<Version, RowsetSharedPtr>> version_rowsets;
+    new_tablet->acquire_version_and_rowsets(&version_rowsets);
+    for (auto& pair : version_rowsets) {
+        RowsetSharedPtr rowset = pair.second;
         if (!rowset->check_file_exist()) {
             return OLAP_ERR_FILE_NOT_EXIST;
         }

--- a/be/src/olap/schema_change.cpp
+++ b/be/src/olap/schema_change.cpp
@@ -2198,6 +2198,8 @@ OLAPStatus SchemaChangeHandler::_validate_alter_result(TabletSharedPtr new_table
     }
 
     std::vector<Version> new_tablet_versions;
+    // lock so that list_versions() and get_rowset_by_version() can be done atomically.
+    ReadLock lock(new_tablet->get_header_lock_ptr());
     new_tablet->list_versions(&new_tablet_versions);
     for (auto& version : new_tablet_versions) {
         RowsetSharedPtr rowset = new_tablet->get_rowset_by_version(version);

--- a/be/src/olap/schema_change.cpp
+++ b/be/src/olap/schema_change.cpp
@@ -2197,7 +2197,10 @@ OLAPStatus SchemaChangeHandler::_validate_alter_result(TabletSharedPtr new_table
     }
 
     std::vector<std::pair<Version, RowsetSharedPtr>> version_rowsets;
-    new_tablet->acquire_version_and_rowsets(&version_rowsets);
+    {
+        ReadLock rdlock(new_tablet->get_header_lock_ptr());
+        new_tablet->acquire_version_and_rowsets(&version_rowsets);
+    }
     for (auto& pair : version_rowsets) {
         RowsetSharedPtr rowset = pair.second;
         if (!rowset->check_file_exist()) {

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -591,13 +591,10 @@ bool Tablet::check_version_exist(const Version& version) const {
     return false;
 }
 
-void Tablet::list_versions(vector<Version>* versions) const {
-    DCHECK(versions != nullptr && versions->empty());
-
-    versions->reserve(_rs_version_map.size());
-    // versions vector is not sorted.
+void Tablet::acquire_version_and_rowsets(std::vector<std::pair<Version, RowsetSharedPtr>>* version_rowsets) const {
+    ReadLock rdlock(&_meta_lock);
     for (const auto& it : _rs_version_map) {
-        versions->push_back(it.first);
+        version_rowsets->emplace_back(it.first, it.second);
     }
 }
 
@@ -947,8 +944,6 @@ OLAPStatus Tablet::split_range(const OlapTuple& start_key_strings, const OlapTup
 // NOTE: only used when create_table, so it is sure that there is no concurrent reader and writer.
 void Tablet::delete_all_files() {
     // Release resources like memory and disk space.
-    // we have to call list_versions first, or else error occurs when
-    // removing hash_map item and iterating hash_map concurrently.
     ReadLock rdlock(&_meta_lock);
     for (auto it : _rs_version_map) {
         it.second->remove();

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -591,8 +591,8 @@ bool Tablet::check_version_exist(const Version& version) const {
     return false;
 }
 
+// The meta read lock should be held before calling
 void Tablet::acquire_version_and_rowsets(std::vector<std::pair<Version, RowsetSharedPtr>>* version_rowsets) const {
-    ReadLock rdlock(&_meta_lock);
     for (const auto& it : _rs_version_map) {
         version_rowsets->emplace_back(it.first, it.second);
     }

--- a/be/src/olap/tablet.h
+++ b/be/src/olap/tablet.h
@@ -116,7 +116,7 @@ public:
                                            vector<Version>* version_path) const;
     OLAPStatus check_version_integrity(const Version& version);
     bool check_version_exist(const Version& version) const;
-    void list_versions(std::vector<Version>* versions) const;
+    void acquire_version_and_rowsets(std::vector<std::pair<Version, RowsetSharedPtr>>* version_rowsets) const;
 
     OLAPStatus capture_consistent_rowsets(const Version& spec_version,
                                           vector<RowsetSharedPtr>* rowsets) const;


### PR DESCRIPTION
## Proposed changes

Alter doing schema change job, Doris will check all rowsets of the new tablet.
It will first get all versions of the new tablet by calling `rowset->list_version()`,
than get rowset of each version by calling `tablet->get_rowset_by_version()`,

But these 2 calls are not protected by tablet meta lock, so there may be some undefined behavior.

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Code refactor (Modify the code structure, format the code, etc...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have created an issue on (Fix #6119 ) and described the bug/feature there in detail
- [ ] Compiling and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If these changes need document changes, I have updated the document
- [ ] Any dependent changes have been merged

## Further comments

If this is a relatively large or complex change, kick off the discussion at dev@doris.apache.org by explaining why you chose the solution you did and what alternatives you considered, etc...
