### PR TITLE
[Bug] Fix bug of NPE caused by the absence of table in replay process.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/alter/MaterializedViewHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/MaterializedViewHandler.java
@@ -61,13 +61,13 @@ import org.apache.doris.qe.OriginStatement;
 import org.apache.doris.thrift.TStorageFormat;
 import org.apache.doris.thrift.TStorageMedium;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -834,6 +834,10 @@ public class MaterializedViewHandler extends AlterHandler {
 
         TabletInvertedIndex invertedIndex = Catalog.getCurrentInvertedIndex();
         OlapTable olapTable = (OlapTable) db.getTable(tableId);
+        if (olapTable == null) {
+            LOG.warn("table {} does not exist when replaying drop rollup. db: {}", tableId, db.getId());
+            return;
+        }
         olapTable.writeLock();
         try {
             for (Partition partition : olapTable.getPartitions()) {

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Catalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Catalog.java
@@ -3388,6 +3388,10 @@ public class Catalog {
     public void replayDropPartition(DropPartitionInfo info) {
         Database db = this.getDb(info.getDbId());
         OlapTable olapTable = (OlapTable) db.getTable(info.getTableId());
+        if (olapTable == null) {
+            LOG.warn("table {} does not exist when replaying drop rollup. db: {}", info.getTableId(), db.getId());
+            return;
+        }
         olapTable.writeLock();
         try {
             if (info.isTempPartition()) {
@@ -3408,6 +3412,10 @@ public class Catalog {
         long dbId = info.getDbId();
         Database db = getDb(dbId);
         Table table = db.getTable(info.getTableId());
+        if (table == null) {
+            LOG.warn("table {} does not exist when replaying drop rollup. db: {}", info.getTableId(), db.getId());
+            return;
+        }
         table.writeLock();
         try {
             Catalog.getCurrentRecycleBin().replayRecoverPartition((OlapTable) table, info.getPartitionId());
@@ -5200,7 +5208,7 @@ public class Catalog {
         }
     }
 
-    // the invoker should keep db write lock
+    // the invoker should keep table's write lock
     public void modifyTableColocate(Database db, OlapTable table, String colocateGroup, boolean isReplay,
             GroupId assignedGroupId)
             throws DdlException {
@@ -5285,6 +5293,11 @@ public class Catalog {
 
         Database db = getDb(info.getGroupId().dbId);
         OlapTable table = (OlapTable) db.getTable(tableId);
+        if (table == null) {
+            LOG.warn("table {} does not exist when replaying modify table colocate. db: {}",
+                    tableId, info.getGroupId().dbId);
+            return;
+        }
         table.writeLock();
         try {
             modifyTableColocate(db, table, properties.get(PropertyAnalyzer.PROPERTIES_COLOCATE_WITH), true,
@@ -5345,6 +5358,10 @@ public class Catalog {
 
         Database db = getDb(dbId);
         OlapTable table = (OlapTable) db.getTable(tableId);
+        if (table == null) {
+            LOG.warn("table {} does not exist when replaying rename rollup. db: {}", tableId, dbId);
+            return;
+        }
         table.writeLock();
         try {
             String rollupName = table.getIndexNameById(indexId);
@@ -5398,7 +5415,7 @@ public class Catalog {
         }
     }
 
-    public void replayRenamePartition(TableInfo tableInfo) throws DdlException {
+    public void replayRenamePartition(TableInfo tableInfo) {
         long dbId = tableInfo.getDbId();
         long tableId = tableInfo.getTableId();
         long partitionId = tableInfo.getPartitionId();
@@ -5406,6 +5423,10 @@ public class Catalog {
 
         Database db = getDb(dbId);
         OlapTable table = (OlapTable) db.getTable(tableId);
+        if (table == null) {
+            LOG.warn("table {} does not exist when replaying rename partition. db: {}", tableId, dbId);
+            return;
+        }
         table.writeLock();
         try {
             Partition partition = table.getPartition(partitionId);
@@ -5451,7 +5472,7 @@ public class Catalog {
      * @param properties
      * @throws DdlException
      */
-    // The caller need to hold the db write lock
+    // The caller need to hold the table's write lock
     public void modifyTableReplicationNum(Database db, OlapTable table, Map<String, String> properties) throws DdlException {
         Preconditions.checkArgument(table.isWriteLockHeldByCurrentThread());
         String defaultReplicationNumName = "default."+ PropertyAnalyzer.PROPERTIES_REPLICATION_NUM;
@@ -5486,7 +5507,7 @@ public class Catalog {
      * @param table
      * @param properties
      */
-    // The caller need to hold the db write lock
+    // The caller need to hold the table's write lock
     public void modifyTableDefaultReplicationNum(Database db, OlapTable table, Map<String, String> properties) {
         Preconditions.checkArgument(table.isWriteLockHeldByCurrentThread());
         TableProperty tableProperty = table.getTableProperty();
@@ -5530,6 +5551,10 @@ public class Catalog {
 
         Database db = getDb(dbId);
         OlapTable olapTable = (OlapTable) db.getTable(tableId);
+        if (olapTable == null) {
+            LOG.warn("table {} does not exist when replaying modify table property log. db: {}", tableId, dbId);
+            return;
+        }
         olapTable.writeLock();
         try {
             TableProperty tableProperty = olapTable.getTableProperty();
@@ -6608,6 +6633,11 @@ public class Catalog {
     public void replayTruncateTable(TruncateTableInfo info) {
         Database db = getDb(info.getDbId());
         OlapTable olapTable = (OlapTable) db.getTable(info.getTblId());
+        if (olapTable == null) {
+            LOG.warn("table {} does not exist when replaying truncate table log. db id: {}",
+                    info.getTblId(), info.getDbId());
+            return;
+        }
         olapTable.writeLock();
         try {
             truncateTableInternal(olapTable, info.getPartitions(), info.isEntireTable());
@@ -6759,6 +6789,11 @@ public class Catalog {
     public void replayConvertDistributionType(TableInfo tableInfo) {
         Database db = getDb(tableInfo.getDbId());
         OlapTable tbl = (OlapTable) db.getTable(tableInfo.getTableId());
+        if (tbl == null) {
+            LOG.warn("table {} does not exist when replaying convert distribution type. db: {}",
+                    tableInfo.getTableId(), tableInfo.getDbId());
+            return;
+        }
         tbl.writeLock();
         try {
             tbl.convertRandomDistributionToHashDistribution();

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/ColocateTableIndex.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/ColocateTableIndex.java
@@ -444,9 +444,13 @@ public class ColocateTableIndex implements Writable {
     public void replayAddTableToGroup(ColocatePersistInfo info) {
         Database db = Catalog.getCurrentCatalog().getDb(info.getGroupId().dbId);
         Preconditions.checkNotNull(db);
-        OlapTable tbl = (OlapTable)db.getTable(info.getTableId());
-        Preconditions.checkNotNull(tbl);
-        
+        OlapTable tbl = (OlapTable) db.getTable(info.getTableId());
+        if (tbl == null) {
+            LOG.warn("table {} does not exist when replaying rename rollup. db: {}",
+                    info.getTableId(), info.getGroupId().dbId);
+            return;
+        }
+
         writeLock();
         try {
             if (!group2BackendsPerBucketSeq.containsKey(info.getGroupId())) {

--- a/fe/fe-core/src/main/java/org/apache/doris/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/transaction/DatabaseTransactionMgr.java
@@ -1289,6 +1289,11 @@ public class DatabaseTransactionMgr {
         for (TableCommitInfo tableCommitInfo : transactionState.getIdToTableCommitInfos().values()) {
             long tableId = tableCommitInfo.getTableId();
             OlapTable table = (OlapTable) db.getTable(tableId);
+            if (table == null) {
+                LOG.warn("table {} does not exist when update catalog after committed. transaction: {}, db: {}",
+                        tableId, transactionState.getTransactionId(), db.getId());
+                continue;
+            }
             for (PartitionCommitInfo partitionCommitInfo : tableCommitInfo.getIdToPartitionCommitInfo().values()) {
                 long partitionId = partitionCommitInfo.getPartitionId();
                 Partition partition = table.getPartition(partitionId);
@@ -1324,6 +1329,11 @@ public class DatabaseTransactionMgr {
         for (TableCommitInfo tableCommitInfo : transactionState.getIdToTableCommitInfos().values()) {
             long tableId = tableCommitInfo.getTableId();
             OlapTable table = (OlapTable) db.getTable(tableId);
+            if (table == null) {
+                LOG.warn("table {} does not exist when update catalog after visible. transaction: {}, db: {}",
+                        tableId, transactionState.getTransactionId(), db.getId());
+                continue;
+            }
             for (PartitionCommitInfo partitionCommitInfo : tableCommitInfo.getIdToPartitionCommitInfo().values()) {
                 long partitionId = partitionCommitInfo.getPartitionId();
                 long newCommitVersion = partitionCommitInfo.getVersion();


### PR DESCRIPTION
## Proposed changes

In the previous version, we changed the db level lock to the table level
to reduce lock contention. But this change will cause some metadata playback problems.

Because most operations on a table will only acquire table locks. These operations
may occur at the same time as the operation of dropping the table.
This may cause the metadata operation sequence to be inconsistent with the log replay sequence,
which may cause some problems.

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Code refactor (Modify the code structure, format the code, etc...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have created an issue on (Fix #6135 ) and described the bug/feature there in detail
- [ ] Compiling and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If these changes need document changes, I have updated the document
- [ ] Any dependent changes have been merged

## Further comments

If this is a relatively large or complex change, kick off the discussion at dev@doris.apache.org by explaining why you chose the solution you did and what alternatives you considered, etc...
