### PR TITLE
[New Feature][Meta][Image] Add file header and footer for image

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/io/CountingDataOutputStream.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/io/CountingDataOutputStream.java
@@ -1,0 +1,74 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.common.io;
+
+import java.io.DataOutputStream;
+import java.io.FilterOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+
+/**
+ * This class adds a long type counter for DataOutputStream to
+ * count the bytes written to the data output stream so far.
+ */
+
+public class CountingDataOutputStream extends DataOutputStream {
+
+    public CountingDataOutputStream(OutputStream out) {
+        super(new CountingOutputStream(out, 0L));
+    }
+
+    public CountingDataOutputStream(OutputStream out, long count) {
+        super(new CountingOutputStream(out, count));
+    }
+
+    public long getCount() {
+        return ((CountingOutputStream)this.out).getCount();
+    }
+
+    public void close() throws IOException {
+        this.out.close();
+    }
+
+    public static class CountingOutputStream extends FilterOutputStream {
+        private long count;
+
+        public CountingOutputStream(OutputStream out, long count) {
+            super(out);
+            this.count = count;
+        }
+
+        public long getCount() {
+            return this.count;
+        }
+
+        public void write(byte[] b, int off, int len) throws IOException {
+            this.out.write(b, off, len);
+            this.count += (long)len;
+        }
+
+        public void write(int b) throws IOException {
+            this.out.write(b);
+            ++this.count;
+        }
+
+        public void close() throws IOException {
+            this.out.close();
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Catalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Catalog.java
@@ -1536,7 +1536,6 @@ public class Catalog {
         switch (metaHeader.getMetaFormat()) {
             case COR1:
                 return loadHeaderCOR1(dis, checksum);
-            case ETL1:
             default:
                 throw new DdlException("unsupported image format.");
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Catalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Catalog.java
@@ -110,6 +110,7 @@ import org.apache.doris.common.ErrorReport;
 import org.apache.doris.common.FeConstants;
 import org.apache.doris.common.FeMetaVersion;
 import org.apache.doris.common.MarkedCountDownLatch;
+import org.apache.doris.common.MetaHeader;
 import org.apache.doris.common.MetaNotFoundException;
 import org.apache.doris.common.Pair;
 import org.apache.doris.common.ThreadPoolManager;
@@ -1489,11 +1490,22 @@ public class Catalog {
         replayedJournalId.set(storage.getImageSeq());
         LOG.info("start load image from {}. is ckpt: {}", curFile.getAbsolutePath(), Catalog.isCheckpointThread());
         long loadImageStartTime = System.currentTimeMillis();
+        MetaHeader metaHeader = MetaHeader.readHeader(curFile);
         DataInputStream dis = new DataInputStream(new BufferedInputStream(new FileInputStream(curFile)));
 
         long checksum = 0;
         try {
-            checksum = loadHeader(dis, checksum);
+            if (metaHeader.getLength() > 0) {
+                dis.skip(metaHeader.getLength());
+            }
+            switch (metaHeader.getMetaFormat()) {
+                case COR1:
+                    checksum = loadHeader(dis, checksum);
+                    break;
+                case ETL1:
+                default:
+                    throw new DdlException("unsupported image format.");
+            }
             checksum = loadMasterInfo(dis, checksum);
             checksum = loadFrontends(dis, checksum);
             checksum = Catalog.getCurrentSystemInfo().loadBackends(dis, checksum);
@@ -1939,7 +1951,8 @@ public class Catalog {
 
         long checksum = 0;
         long saveImageStartTime = System.currentTimeMillis();
-        try (DataOutputStream dos = new DataOutputStream(new BufferedOutputStream(new FileOutputStream(curFile)))) {
+        MetaHeader.writeHeader(curFile);
+        try (DataOutputStream dos = new DataOutputStream(new BufferedOutputStream(new FileOutputStream(curFile, true)))) {
             checksum = saveHeader(dos, replayedJournalId, checksum);
             checksum = saveMasterInfo(dos, checksum);
             checksum = saveFrontends(dos, checksum);

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Catalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Catalog.java
@@ -112,9 +112,12 @@ import org.apache.doris.common.FeMetaVersion;
 import org.apache.doris.common.MarkedCountDownLatch;
 import org.apache.doris.common.MetaHeader;
 import org.apache.doris.common.MetaNotFoundException;
+import org.apache.doris.common.MetaReader;
+import org.apache.doris.common.MetaWriter;
 import org.apache.doris.common.Pair;
 import org.apache.doris.common.ThreadPoolManager;
 import org.apache.doris.common.UserException;
+import org.apache.doris.common.io.CountingDataOutputStream;
 import org.apache.doris.common.io.Text;
 import org.apache.doris.common.util.Daemon;
 import org.apache.doris.common.util.DynamicPartitionUtil;
@@ -238,14 +241,10 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.codehaus.jackson.map.ObjectMapper;
 
-import java.io.BufferedInputStream;
-import java.io.BufferedOutputStream;
 import java.io.BufferedReader;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
@@ -1488,63 +1487,10 @@ public class Catalog {
             return;
         }
         replayedJournalId.set(storage.getImageSeq());
-        LOG.info("start load image from {}. is ckpt: {}", curFile.getAbsolutePath(), Catalog.isCheckpointThread());
-        long loadImageStartTime = System.currentTimeMillis();
-        MetaHeader metaHeader = MetaHeader.readHeader(curFile);
-        DataInputStream dis = new DataInputStream(new BufferedInputStream(new FileInputStream(curFile)));
-
-        long checksum = 0;
-        try {
-            if (metaHeader.getLength() > 0) {
-                dis.skip(metaHeader.getLength());
-            }
-            switch (metaHeader.getMetaFormat()) {
-                case COR1:
-                    checksum = loadHeader(dis, checksum);
-                    break;
-                case ETL1:
-                default:
-                    throw new DdlException("unsupported image format.");
-            }
-            checksum = loadMasterInfo(dis, checksum);
-            checksum = loadFrontends(dis, checksum);
-            checksum = Catalog.getCurrentSystemInfo().loadBackends(dis, checksum);
-            checksum = loadDb(dis, checksum);
-            // ATTN: this should be done after load Db, and before loadAlterJob
-            recreateTabletInvertIndex();
-            // rebuild es state state
-            esRepository.loadTableFromCatalog();
-
-            checksum = loadLoadJob(dis, checksum);
-            checksum = loadAlterJob(dis, checksum);
-            checksum = loadRecycleBin(dis, checksum);
-            checksum = loadGlobalVariable(dis, checksum);
-            checksum = loadCluster(dis, checksum);
-            checksum = loadBrokers(dis, checksum);
-            checksum = loadResources(dis, checksum);
-            checksum = loadExportJob(dis, checksum);
-            checksum = loadBackupHandler(dis, checksum);
-            checksum = loadPaloAuth(dis, checksum);
-            // global transaction must be replayed before load jobs v2
-            checksum = loadTransactionState(dis, checksum);
-            checksum = loadColocateTableIndex(dis, checksum);
-            checksum = loadRoutineLoadJobs(dis, checksum);
-            checksum = loadLoadJobsV2(dis, checksum);
-            checksum = loadSmallFiles(dis, checksum);
-            checksum = loadPlugins(dis, checksum);
-            checksum = loadDeleteHandler(dis, checksum);
-
-            long remoteChecksum = dis.readLong();
-            Preconditions.checkState(remoteChecksum == checksum, remoteChecksum + " vs. " + checksum);
-        } finally {
-            dis.close();
-        }
-
-        long loadImageEndTime = System.currentTimeMillis();
-        LOG.info("finished to load image in " + (loadImageEndTime - loadImageStartTime) + " ms");
+        MetaReader.read(curFile, this);
     }
 
-    private void recreateTabletInvertIndex() {
+    public void recreateTabletInvertIndex() {
         if (isCheckpointThread()) {
             return;
         }
@@ -1586,7 +1532,17 @@ public class Catalog {
         } // end for dbs
     }
 
-    public long loadHeader(DataInputStream dis, long checksum) throws IOException {
+    public long loadHeader(DataInputStream dis, MetaHeader metaHeader, long checksum) throws IOException, DdlException {
+        switch (metaHeader.getMetaFormat()) {
+            case COR1:
+                return loadHeaderCOR1(dis, checksum);
+            case ETL1:
+            default:
+                throw new DdlException("unsupported image format.");
+        }
+    }
+
+    public long loadHeaderCOR1(DataInputStream dis, long checksum) throws IOException {
         int journalVersion = dis.readInt();
         long newChecksum = checksum ^ journalVersion;
         MetaContext.get().setMetaVersion(journalVersion);
@@ -1830,21 +1786,11 @@ public class Catalog {
         return checksum;
     }
 
-    public long saveBackupHandler(DataOutputStream dos, long checksum) throws IOException {
-        getBackupHandler().write(dos);
-        return checksum;
-    }
-
     public long loadDeleteHandler(DataInputStream dis, long checksum) throws IOException {
         if (Catalog.getCurrentCatalogJournalVersion() >= FeMetaVersion.VERSION_82) {
             this.deleteHandler = DeleteHandler.read(dis);
         }
         LOG.info("finished replay deleteHandler from image");
-        return checksum;
-    }
-
-    public long saveDeleteHandler(DataOutputStream dos, long checksum) throws IOException {
-        getDeleteHandler().write(dos);
         return checksum;
     }
 
@@ -1882,6 +1828,15 @@ public class Catalog {
             }
         }
         LOG.info("finished replay recycleBin from image");
+        return checksum;
+    }
+
+    // global variable persistence
+    public long loadGlobalVariable(DataInputStream in, long checksum) throws IOException, DdlException {
+        if (Catalog.getCurrentCatalogJournalVersion() >= FeMetaVersion.VERSION_22) {
+            VariableMgr.read(in);
+        }
+        LOG.info("finished replay globalVariable from image");
         return checksum;
     }
 
@@ -1945,45 +1900,10 @@ public class Catalog {
         if (!curFile.exists()) {
             curFile.createNewFile();
         }
-
-        // save image does not need any lock. because only checkpoint thread will call this method.
-        LOG.info("start save image to {}. is ckpt: {}", curFile.getAbsolutePath(), Catalog.isCheckpointThread());
-
-        long checksum = 0;
-        long saveImageStartTime = System.currentTimeMillis();
-        MetaHeader.writeHeader(curFile);
-        try (DataOutputStream dos = new DataOutputStream(new BufferedOutputStream(new FileOutputStream(curFile, true)))) {
-            checksum = saveHeader(dos, replayedJournalId, checksum);
-            checksum = saveMasterInfo(dos, checksum);
-            checksum = saveFrontends(dos, checksum);
-            checksum = Catalog.getCurrentSystemInfo().saveBackends(dos, checksum);
-            checksum = saveDb(dos, checksum);
-            checksum = saveLoadJob(dos, checksum);
-            checksum = saveAlterJob(dos, checksum);
-            checksum = saveRecycleBin(dos, checksum);
-            checksum = saveGlobalVariable(dos, checksum);
-            checksum = saveCluster(dos, checksum);
-            checksum = saveBrokers(dos, checksum);
-            checksum = saveResources(dos, checksum);
-            checksum = saveExportJob(dos, checksum);
-            checksum = saveBackupHandler(dos, checksum);
-            checksum = savePaloAuth(dos, checksum);
-            checksum = saveTransactionState(dos, checksum);
-            checksum = saveColocateTableIndex(dos, checksum);
-            checksum = saveRoutineLoadJobs(dos, checksum);
-            checksum = saveLoadJobsV2(dos, checksum);
-            checksum = saveSmallFiles(dos, checksum);
-            checksum = savePlugins(dos, checksum);
-            checksum = saveDeleteHandler(dos, checksum);
-            dos.writeLong(checksum);
-        }
-
-        long saveImageEndTime = System.currentTimeMillis();
-        LOG.info("finished save image {} in {} ms. checksum is {}",
-                curFile.getAbsolutePath(), (saveImageEndTime - saveImageStartTime), checksum);
+        MetaWriter.write(curFile, this);
     }
 
-    public long saveHeader(DataOutputStream dos, long replayedJournalId, long checksum) throws IOException {
+    public long saveHeader(CountingDataOutputStream dos, long replayedJournalId, long checksum) throws IOException {
         // Write meta version
         checksum ^= FeConstants.meta_version;
         dos.writeInt(FeConstants.meta_version);
@@ -2002,7 +1922,7 @@ public class Catalog {
         return checksum;
     }
 
-    public long saveMasterInfo(DataOutputStream dos, long checksum) throws IOException {
+    public long saveMasterInfo(CountingDataOutputStream dos, long checksum) throws IOException {
         Text.writeString(dos, masterIp);
 
         checksum ^= masterRpcPort;
@@ -2014,7 +1934,7 @@ public class Catalog {
         return checksum;
     }
 
-    public long saveFrontends(DataOutputStream dos, long checksum) throws IOException {
+    public long saveFrontends(CountingDataOutputStream dos, long checksum) throws IOException {
         int size = frontends.size();
         checksum ^= size;
 
@@ -2034,7 +1954,7 @@ public class Catalog {
         return checksum;
     }
 
-    public long saveDb(DataOutputStream dos, long checksum) throws IOException {
+    public long saveDb(CountingDataOutputStream dos, long checksum) throws IOException {
         int dbCount = idToDb.size() - nameToCluster.keySet().size();
         checksum ^= dbCount;
         dos.writeInt(dbCount);
@@ -2050,7 +1970,7 @@ public class Catalog {
         return checksum;
     }
 
-    public long saveLoadJob(DataOutputStream dos, long checksum) throws IOException {
+    public long saveLoadJob(CountingDataOutputStream dos, long checksum) throws IOException {
         // 1. save load.dbToLoadJob
         Map<Long, List<LoadJob>> dbToLoadJob = load.getDbToLoadJobs();
         int jobSize = dbToLoadJob.size();
@@ -2089,7 +2009,7 @@ public class Catalog {
         return checksum;
     }
 
-    public long saveExportJob(DataOutputStream dos, long checksum) throws IOException {
+    public long saveExportJob(CountingDataOutputStream dos, long checksum) throws IOException {
         Map<Long, ExportJob> idToJob = exportMgr.getIdToJob();
         int size = idToJob.size();
         checksum ^= size;
@@ -2104,14 +2024,14 @@ public class Catalog {
         return checksum;
     }
 
-    public long saveAlterJob(DataOutputStream dos, long checksum) throws IOException {
+    public long saveAlterJob(CountingDataOutputStream dos, long checksum) throws IOException {
         for (JobType type : JobType.values()) {
             checksum = saveAlterJob(dos, checksum, type);
         }
         return checksum;
     }
 
-    public long saveAlterJob(DataOutputStream dos, long checksum, JobType type) throws IOException {
+    public long saveAlterJob(CountingDataOutputStream dos, long checksum, JobType type) throws IOException {
         Map<Long, AlterJob> alterJobs = null;
         ConcurrentLinkedQueue<AlterJob> finishedOrCancelledAlterJobs = null;
         Map<Long, AlterJobV2> alterJobsV2 = Maps.newHashMap();
@@ -2161,12 +2081,22 @@ public class Catalog {
         return checksum;
     }
 
-    public long savePaloAuth(DataOutputStream dos, long checksum) throws IOException {
+    public long saveBackupHandler(CountingDataOutputStream dos, long checksum) throws IOException {
+        getBackupHandler().write(dos);
+        return checksum;
+    }
+
+    public long saveDeleteHandler(CountingDataOutputStream dos, long checksum) throws IOException {
+        getDeleteHandler().write(dos);
+        return checksum;
+    }
+
+    public long savePaloAuth(CountingDataOutputStream dos, long checksum) throws IOException {
         auth.write(dos);
         return checksum;
     }
 
-    public long saveTransactionState(DataOutputStream dos, long checksum) throws IOException {
+    public long saveTransactionState(CountingDataOutputStream dos, long checksum) throws IOException {
         int size = globalTransactionMgr.getTransactionNum();
         checksum ^= size;
         dos.writeInt(size);
@@ -2174,33 +2104,24 @@ public class Catalog {
         return checksum;
     }
 
-    public long saveRecycleBin(DataOutputStream dos, long checksum) throws IOException {
+    public long saveRecycleBin(CountingDataOutputStream dos, long checksum) throws IOException {
         CatalogRecycleBin recycleBin = Catalog.getCurrentRecycleBin();
         recycleBin.write(dos);
         return checksum;
     }
 
-    public long saveColocateTableIndex(DataOutputStream dos, long checksum) throws IOException {
+    public long saveColocateTableIndex(CountingDataOutputStream dos, long checksum) throws IOException {
         Catalog.getCurrentColocateIndex().write(dos);
         return checksum;
     }
 
-    public long saveRoutineLoadJobs(DataOutputStream dos, long checksum) throws IOException {
+    public long saveRoutineLoadJobs(CountingDataOutputStream dos, long checksum) throws IOException {
         Catalog.getCurrentCatalog().getRoutineLoadManager().write(dos);
         return checksum;
     }
 
-    // global variable persistence
-    public long loadGlobalVariable(DataInputStream in, long checksum) throws IOException, DdlException {
-        if (Catalog.getCurrentCatalogJournalVersion() >= FeMetaVersion.VERSION_22) {
-            VariableMgr.read(in);
-        }
-        LOG.info("finished replay globalVariable from image");
-        return checksum;
-    }
-
-    public long saveGlobalVariable(DataOutputStream out, long checksum) throws IOException {
-        VariableMgr.write(out);
+    public long saveGlobalVariable(CountingDataOutputStream dos, long checksum) throws IOException {
+        VariableMgr.write(dos);
         return checksum;
     }
 
@@ -2212,18 +2133,18 @@ public class Catalog {
         VariableMgr.replayGlobalVariableV2(info);
     }
 
-    public long saveLoadJobsV2(DataOutputStream out, long checksum) throws IOException {
-        Catalog.getCurrentCatalog().getLoadManager().write(out);
+    public long saveLoadJobsV2(CountingDataOutputStream dos, long checksum) throws IOException {
+        Catalog.getCurrentCatalog().getLoadManager().write(dos);
         return checksum;
     }
 
-    public long saveResources(DataOutputStream out, long checksum) throws IOException {
-        Catalog.getCurrentCatalog().getResourceMgr().write(out);
+	public long saveResources(CountingDataOutputStream dos, long checksum) throws IOException {
+        Catalog.getCurrentCatalog().getResourceMgr().write(dos);
         return checksum;
     }
 
-    private long saveSmallFiles(DataOutputStream out, long checksum) throws IOException {
-        smallFileMgr.write(out);
+    public long saveSmallFiles(CountingDataOutputStream dos, long checksum) throws IOException {
+        smallFileMgr.write(dos);
         return checksum;
     }
 
@@ -6428,7 +6349,7 @@ public class Catalog {
         db.setDbState(info.getDbState());
     }
 
-    public long saveCluster(DataOutputStream dos, long checksum) throws IOException {
+    public long saveCluster(CountingDataOutputStream dos, long checksum) throws IOException {
         final int clusterCount = idToCluster.size();
         checksum ^= clusterCount;
         dos.writeInt(clusterCount);
@@ -6443,7 +6364,7 @@ public class Catalog {
         return checksum;
     }
 
-    public long saveBrokers(DataOutputStream dos, long checksum) throws IOException {
+    public long saveBrokers(CountingDataOutputStream dos, long checksum) throws IOException {
         Map<String, List<FsBroker>> addressListMap = brokerMgr.getBrokerListMap();
         int size = addressListMap.size();
         checksum ^= size;

--- a/fe/fe-core/src/main/java/org/apache/doris/common/FeConstants.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/FeConstants.java
@@ -51,6 +51,9 @@ public class FeConstants {
     // Current meta data version. Use this version to write journals and image
     public static int meta_version = FeMetaVersion.VERSION_CURRENT;
 
+    // Current meta format. Use this format to read and write image.
+    public static FeMetaFormat meta_format = FeMetaFormat.COR1;
+
     // use \N to indicate NULL
     public static String null_string = "\\N";
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/common/FeMetaFormat.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/FeMetaFormat.java
@@ -1,0 +1,39 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.common;
+
+public enum FeMetaFormat {
+    COR1("COR1", "v1"),
+    ETL1("ETL1", "v1");
+
+    private final String magicString;
+    private final String version;
+
+    private FeMetaFormat(String magicString, String version) {
+        this.magicString = magicString;
+        this.version = version;
+    }
+
+    public String getMagicString() {
+        return magicString;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/common/FeMetaFormat.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/FeMetaFormat.java
@@ -18,8 +18,7 @@
 package org.apache.doris.common;
 
 public enum FeMetaFormat {
-    COR1("COR1", "v1"),
-    ETL1("ETL1", "v1");
+    COR1("COR1", "v1");
 
     private final String magicString;
     private final String version;

--- a/fe/fe-core/src/main/java/org/apache/doris/common/MetaFooter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/MetaFooter.java
@@ -1,0 +1,86 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.common;
+
+import com.google.common.collect.Lists;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.util.Arrays;
+import java.util.List;
+
+public class MetaFooter {
+    private static final Logger LOG = LogManager.getLogger(MetaFooter.class);
+
+    private static final long FOOTER_LENGTH_SIZE = 8L;
+    public static final MetaFooter EMPTY_FOOTER = new MetaFooter(null, 0L);
+
+    // length of footer
+    private long length;
+    // meta indices
+    public List<MetaIndex> metaIndices;
+
+    public static MetaFooter read(File imageFile) throws IOException {
+        try(RandomAccessFile raf = new RandomAccessFile(imageFile, "r")) {
+            long fileLength = raf.length();
+            long footerLengthIndex = fileLength - FOOTER_LENGTH_SIZE - MetaMagicNumber.MAGIC_STR.length();
+            raf.seek(footerLengthIndex);
+            long footerLength = raf.readLong();
+            MetaMagicNumber magicNumber = MetaMagicNumber.read(raf);
+            if (!Arrays.equals(MetaMagicNumber.MAGIC, magicNumber.getBytes())) {
+                LOG.warn("Image file {} format mismatch. Expected magic number is {}, actual is {}",
+                        imageFile.getPath(), Arrays.toString(MetaMagicNumber.MAGIC), Arrays.toString(magicNumber.getBytes()));
+                return EMPTY_FOOTER;
+            }
+            long footerIndex = footerLengthIndex - footerLength;
+            raf.seek(footerIndex);
+            int indexNum = raf.readInt();
+            List<MetaIndex> metaIndices = Lists.newArrayList();
+            for (int i = 0; i < indexNum; i++) {
+                MetaIndex index = MetaIndex.read(raf);
+                metaIndices.add(index);
+            }
+            LOG.info("Image footer length: {}, indices: {}", footerLength, metaIndices.toArray());
+            return new MetaFooter(metaIndices, footerLength);
+        }
+    }
+
+    public static void write(File imageFile, List<MetaIndex> metaIndices) throws IOException {
+        try(RandomAccessFile raf = new RandomAccessFile(imageFile, "rw")) {
+            long startIndex = raf.length();
+            raf.seek(startIndex);
+            raf.writeInt(metaIndices.size());
+            for (MetaIndex metaIndex : metaIndices) {
+                MetaIndex.write(raf, metaIndex);
+            }
+            long endIndex = raf.length();
+            raf.writeLong(endIndex - startIndex);
+            MetaMagicNumber.write(raf);
+        }
+    }
+
+    public MetaFooter(List<MetaIndex> metaIndices, long length) {
+        this.metaIndices = metaIndices;
+        this.length = length;
+    }
+
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/common/MetaFooter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/MetaFooter.java
@@ -28,6 +28,20 @@ import java.io.RandomAccessFile;
 import java.util.Arrays;
 import java.util.List;
 
+/**
+ * Footer Format:
+ * |- Footer -----------------------------|
+ * | |- object index --------------|      |
+ * | | - index a                   |      |
+ * | | - index b                   |      |
+ * | | ...                         |      |
+ * | |-----------------------------|      |
+ * | - other value(undecided)             |
+ * |--------------------------------------|
+ * - Footer Length (8 bytes)
+ * - Magic String (4 bytes)
+ */
+
 public class MetaFooter {
     private static final Logger LOG = LogManager.getLogger(MetaFooter.class);
 

--- a/fe/fe-core/src/main/java/org/apache/doris/common/MetaHeader.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/MetaHeader.java
@@ -95,9 +95,7 @@ public class MetaHeader {
 
         public static MetaFileHeader read(RandomAccessFile raf) throws IOException {
             int headerLength = raf.readInt();
-            LOG.info("read json length {}", headerLength);
             byte[] headerBytes = new byte[headerLength];
-            LOG.info("read json {}", headerBytes);
             raf.readFully(headerBytes);
             return MetaFileHeader.fromJson(new String(headerBytes));
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/common/MetaHeader.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/MetaHeader.java
@@ -1,0 +1,148 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.common;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.codehaus.jackson.map.ObjectMapper;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.charset.Charset;
+import java.util.Arrays;
+
+public class MetaHeader {
+    private static final Logger LOG = LogManager.getLogger(MetaHeader.class);
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final MetaHeader EMPTY_HEADER = new MetaHeader(null, null, 0);
+
+    public long length;
+    public FeMetaFormat metaFormat;
+    public MetaMagicNumber metaMagicNumber;
+    public MetaFileHeader metaFileHeader;
+
+    public static MetaHeader readHeader(File imageFile) throws IOException {
+        LOG.info("start load image header from {}.", imageFile.getAbsolutePath());
+        try(RandomAccessFile raf = new RandomAccessFile(imageFile, "r")) {
+            raf.seek(0);
+            MetaMagicNumber magicMagicNumber = MetaMagicNumber.read(raf);
+            if (!Arrays.equals(MetaMagicNumber.MAGIC, magicMagicNumber.bytes)) {
+                LOG.warn("Image file {} format mismatch. Expected magic number is {}, actual is {}",
+                        imageFile.getPath(), Arrays.toString(MetaMagicNumber.MAGIC), Arrays.toString(magicMagicNumber.bytes));
+                return EMPTY_HEADER;
+            }
+            MetaFileHeader metaFileHeader = MetaFileHeader.read(raf);
+            if (!MetaFileHeader.IMAGE_VERSION.equalsIgnoreCase(metaFileHeader.imageVersion)) {
+                LOG.warn("Image file {} format mismatch. Expected version is {}, actual is {}",
+                        imageFile.getPath(), MetaFileHeader.IMAGE_VERSION, metaFileHeader.imageVersion);
+                return EMPTY_HEADER;
+            }
+
+            return new MetaHeader(magicMagicNumber, metaFileHeader, raf.getFilePointer(),
+                    FeMetaFormat.valueOf(new String(magicMagicNumber.bytes)));
+        }
+    }
+
+    public static long writeHeader(File imageFile) throws IOException {
+        LOG.info("start save image header to {}.", imageFile.getAbsolutePath());
+        try (RandomAccessFile raf = new RandomAccessFile(imageFile, "rw")) {
+            raf.seek(0);
+            MetaMagicNumber.write(raf);
+            MetaFileHeader.write(raf);
+            return raf.getFilePointer();
+        }
+    }
+
+    public static class MetaMagicNumber {
+        public static final String MAGIC_STR = FeConstants.meta_format.getMagicString();
+        public static final byte[] MAGIC = MAGIC_STR.getBytes(Charset.forName("ASCII"));
+        public byte[] bytes;
+
+        public static MetaMagicNumber read(RandomAccessFile raf) throws IOException {
+            MetaMagicNumber metaMagicNumber = new MetaMagicNumber();
+            byte[] magicBytes = new byte[MAGIC_STR.length()];
+            raf.readFully(magicBytes);
+            metaMagicNumber.bytes = magicBytes;
+            return metaMagicNumber;
+        }
+
+        public static void write(RandomAccessFile raf) throws IOException {
+            raf.write(MAGIC);
+        }
+    }
+
+    public static class MetaFileHeader {
+        public static final String IMAGE_VERSION = FeConstants.meta_format.getVersion();
+        // the version of image format
+        public String imageVersion;
+
+        public static MetaFileHeader read(RandomAccessFile raf) throws IOException {
+            int headerLength = raf.readInt();
+            LOG.info("read json length {}", headerLength);
+            byte[] headerBytes = new byte[headerLength];
+            LOG.info("read json {}", headerBytes);
+            raf.readFully(headerBytes);
+            return MetaFileHeader.fromJson(new String(headerBytes));
+        }
+
+        public static void write(RandomAccessFile raf) throws IOException {
+            MetaFileHeader metaFileHeader = new MetaFileHeader();
+            metaFileHeader.imageVersion = IMAGE_VERSION;
+            byte[] headerBytes =  MetaFileHeader.toJson(metaFileHeader).getBytes();
+            raf.writeInt(headerBytes.length);
+            raf.write(headerBytes);
+        }
+
+        private static MetaFileHeader fromJson(String json) throws IOException {
+            return (MetaFileHeader) OBJECT_MAPPER.readValue(json, MetaFileHeader.class);
+        }
+
+        private static String toJson(MetaFileHeader fileHeader) throws IOException {
+            return OBJECT_MAPPER.writeValueAsString(fileHeader);
+        }
+    }
+
+    public MetaHeader(MetaMagicNumber metaMagicNumber, MetaFileHeader metaFileHeader, long length) {
+        this(metaMagicNumber, metaFileHeader, length, FeMetaFormat.COR1);
+    }
+
+    public MetaHeader(MetaMagicNumber metaMagicNumber, MetaFileHeader metaFileHeader, long length, FeMetaFormat metaFormat) {
+        this.metaMagicNumber = metaMagicNumber;
+        this.metaFileHeader = metaFileHeader;
+        this.length = length;
+        this.metaFormat = metaFormat;
+    }
+
+    public long getLength() {
+        return length;
+    }
+
+    public FeMetaFormat getMetaFormat() {
+        return metaFormat;
+    }
+
+    public MetaMagicNumber getMetaMagicNumber() {
+        return metaMagicNumber;
+    }
+
+    public MetaFileHeader getMetaFileHeader() {
+        return metaFileHeader;
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/common/MetaHeader.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/MetaHeader.java
@@ -25,6 +25,18 @@ import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.util.Arrays;
 
+/**
+ * Header Format:
+ * - Magic String (4 bytes)
+ * - Header Length (4 bytes)
+ * |- Header -----------------------------|
+ * | |- Json Header ---------------|      |
+ * | | - version                   |      |
+ * | | - other key/value(undecided)|      |
+ * | |-----------------------------|      |
+ * |--------------------------------------|
+ */
+
 public class MetaHeader {
     private static final Logger LOG = LogManager.getLogger(MetaHeader.class);
 

--- a/fe/fe-core/src/main/java/org/apache/doris/common/MetaIndex.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/MetaIndex.java
@@ -17,28 +17,37 @@
 
 package org.apache.doris.common;
 
-public enum FeMetaFormat {
-    COR1("COR1", "v1"),
-    ETL1("ETL1", "v1");
+import org.apache.doris.common.io.Text;
 
-    private final String magicString;
-    private final String version;
+import java.io.IOException;
+import java.io.RandomAccessFile;
 
-    private FeMetaFormat(String magicString, String version) {
-        this.magicString = magicString;
-        this.version = version;
+public class MetaIndex {
+    public String name;
+    public long offset;
+
+    public MetaIndex() {
     }
 
-    public String getMagicString() {
-        return magicString;
+    public MetaIndex(String name, long offset) {
+        this.name = name;
+        this.offset = offset;
     }
 
-    public String getVersion() {
-        return version;
+    public static MetaIndex read(RandomAccessFile raf) throws IOException {
+        MetaIndex metaIndex = new MetaIndex();
+        metaIndex.name = Text.readString(raf);
+        metaIndex.offset = raf.readLong();
+        return metaIndex;
+    }
+
+    public static void write(RandomAccessFile raf, MetaIndex metaIndex) throws IOException {
+        Text.writeString(raf, metaIndex.name);
+        raf.writeLong(metaIndex.offset);
     }
 
     @Override
     public String toString() {
-        return getMagicString();
+        return name + ":" + offset;
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/common/MetaJsonHeader.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/MetaJsonHeader.java
@@ -1,0 +1,52 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.common;
+
+import org.apache.doris.common.io.Text;
+
+import org.codehaus.jackson.map.ObjectMapper;
+
+import java.io.IOException;
+import java.io.RandomAccessFile;
+
+public class MetaJsonHeader {
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    public static final String IMAGE_VERSION = FeConstants.meta_format.getVersion();
+    // the version of image format
+    public String imageVersion;
+
+    public static MetaJsonHeader read(RandomAccessFile raf) throws IOException {
+        String jsonHeader = Text.readString(raf);
+        return MetaJsonHeader.fromJson(jsonHeader);
+    }
+
+    public static void write(RandomAccessFile raf) throws IOException {
+        MetaJsonHeader metaJsonHeader = new MetaJsonHeader();
+        metaJsonHeader.imageVersion = IMAGE_VERSION;
+        String jsonHeader =  MetaJsonHeader.toJson(metaJsonHeader);
+        Text.writeString(raf, jsonHeader);
+    }
+
+    private static MetaJsonHeader fromJson(String json) throws IOException {
+        return (MetaJsonHeader) OBJECT_MAPPER.readValue(json, MetaJsonHeader.class);
+    }
+
+    private static String toJson(MetaJsonHeader jsonHeader) throws IOException {
+        return OBJECT_MAPPER.writeValueAsString(jsonHeader);
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/common/MetaMagicNumber.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/MetaMagicNumber.java
@@ -17,28 +17,32 @@
 
 package org.apache.doris.common;
 
-public enum FeMetaFormat {
-    COR1("COR1", "v1"),
-    ETL1("ETL1", "v1");
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.charset.Charset;
 
-    private final String magicString;
-    private final String version;
+public class MetaMagicNumber {
+    public static final String MAGIC_STR = FeConstants.meta_format.getMagicString();
+    public static final byte[] MAGIC = MAGIC_STR.getBytes(Charset.forName("ASCII"));
+    private byte[] bytes;
 
-    private FeMetaFormat(String magicString, String version) {
-        this.magicString = magicString;
-        this.version = version;
+    public static MetaMagicNumber read(RandomAccessFile raf) throws IOException {
+        MetaMagicNumber metaMagicNumber = new MetaMagicNumber();
+        byte[] magicBytes = new byte[MAGIC_STR.length()];
+        raf.readFully(magicBytes);
+        metaMagicNumber.setBytes(magicBytes);
+        return metaMagicNumber;
     }
 
-    public String getMagicString() {
-        return magicString;
+    public static void write(RandomAccessFile raf) throws IOException {
+        raf.write(MAGIC);
     }
 
-    public String getVersion() {
-        return version;
+    public byte[] getBytes() {
+        return bytes;
     }
 
-    @Override
-    public String toString() {
-        return getMagicString();
+    public void setBytes(byte[] bytes) {
+        this.bytes = bytes;
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/common/MetaReader.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/MetaReader.java
@@ -1,0 +1,112 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.common;
+
+import org.apache.doris.catalog.Catalog;
+import com.google.common.base.Preconditions;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.BufferedInputStream;
+import java.io.DataInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+
+/**
+ * Image Format:
+ * |- Image --------------------------------------|
+ * | - Magic String (4 bytes)                     |
+ * | - Header Length (4 bytes)                    |
+ * | |- Header -----------------------------|     |
+ * | | |- Json Header ---------------|      |     |
+ * | | | - version                   |      |     |
+ * | | | - other key/value(undecided)|      |     |
+ * | | |-----------------------------|      |     |
+ * | |--------------------------------------|     |
+ * |                                              |
+ * | |- Image Body -------------------------|     |
+ * | | Object a                             |     |
+ * | | Object b                             |     |
+ * | | ...                                  |     |
+ * | |--------------------------------------|     |
+ * |                                              |
+ * | |- Footer -----------------------------|     |
+ * | | |- object index --------------|      |     |
+ * | | | - index a                   |      |     |
+ * | | | - index b                   |      |     |
+ * | | | ...                         |      |     |
+ * | | |-----------------------------|      |     |
+ * | | - other value(undecided)             |     |
+ * | |--------------------------------------|     |
+ * | - Footer Length (8 bytes)                    |
+ * | - Magic String (4 bytes)                     |
+ * |----------------------------------------------|
+ */
+
+public class MetaReader {
+    private static final Logger LOG = LogManager.getLogger(MetaReader.class);
+
+    public static void read(File imageFile, Catalog catalog) throws IOException, DdlException {
+        LOG.info("start load image from {}. is ckpt: {}", imageFile.getAbsolutePath(), Catalog.isCheckpointThread());
+        long loadImageStartTime = System.currentTimeMillis();
+        MetaHeader metaHeader = MetaHeader.read(imageFile);
+
+        long checksum = 0;
+        try (DataInputStream dis = new DataInputStream(new BufferedInputStream(new FileInputStream(imageFile)))) {
+            IOUtils.skipFully(dis, metaHeader.getEnd());
+            checksum = catalog.loadHeader(dis, metaHeader, checksum);
+            checksum = catalog.loadMasterInfo(dis, checksum);
+            checksum = catalog.loadFrontends(dis, checksum);
+            checksum = Catalog.getCurrentSystemInfo().loadBackends(dis, checksum);
+            checksum = catalog.loadDb(dis, checksum);
+            // ATTN: this should be done after load Db, and before loadAlterJob
+            catalog.recreateTabletInvertIndex();
+            // rebuild es state state
+            catalog.getEsRepository().loadTableFromCatalog();
+            checksum = catalog.loadLoadJob(dis, checksum);
+            checksum = catalog.loadAlterJob(dis, checksum);
+            checksum = catalog.loadRecycleBin(dis, checksum);
+            checksum = catalog.loadGlobalVariable(dis, checksum);
+            checksum = catalog.loadCluster(dis, checksum);
+            checksum = catalog.loadBrokers(dis, checksum);
+            checksum = catalog.loadResources(dis, checksum);
+            checksum = catalog.loadExportJob(dis, checksum);
+            checksum = catalog.loadBackupHandler(dis, checksum);
+            checksum = catalog.loadPaloAuth(dis, checksum);
+            // global transaction must be replayed before load jobs v2
+            checksum = catalog.loadTransactionState(dis, checksum);
+            checksum = catalog.loadColocateTableIndex(dis, checksum);
+            checksum = catalog.loadRoutineLoadJobs(dis, checksum);
+            checksum = catalog.loadLoadJobsV2(dis, checksum);
+            checksum = catalog.loadSmallFiles(dis, checksum);
+            checksum = catalog.loadPlugins(dis, checksum);
+            checksum = catalog.loadDeleteHandler(dis, checksum);
+
+            long remoteChecksum = dis.readLong();
+            Preconditions.checkState(remoteChecksum == checksum, remoteChecksum + " vs. " + checksum);
+        }
+
+        MetaFooter metaFooter = MetaFooter.read(imageFile);
+
+        long loadImageEndTime = System.currentTimeMillis();
+        LOG.info("finished to load image in " + (loadImageEndTime - loadImageStartTime) + " ms");
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/common/MetaReader.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/MetaReader.java
@@ -18,6 +18,7 @@
 package org.apache.doris.common;
 
 import org.apache.doris.catalog.Catalog;
+
 import com.google.common.base.Preconditions;
 
 import org.apache.commons.io.IOUtils;
@@ -49,6 +50,7 @@ import java.io.IOException;
  * | |--------------------------------------|     |
  * |                                              |
  * | |- Footer -----------------------------|     |
+ * | | - Checksum (8 bytes)                 |     |
  * | | |- object index --------------|      |     |
  * | | | - index a                   |      |     |
  * | | | - index b                   |      |     |
@@ -99,14 +101,14 @@ public class MetaReader {
             checksum = catalog.loadSmallFiles(dis, checksum);
             checksum = catalog.loadPlugins(dis, checksum);
             checksum = catalog.loadDeleteHandler(dis, checksum);
-
-            long remoteChecksum = dis.readLong();
-            Preconditions.checkState(remoteChecksum == checksum, remoteChecksum + " vs. " + checksum);
         }
 
         MetaFooter metaFooter = MetaFooter.read(imageFile);
+        long remoteChecksum = metaFooter.checksum;
+        Preconditions.checkState(remoteChecksum == checksum, remoteChecksum + " vs. " + checksum);
 
         long loadImageEndTime = System.currentTimeMillis();
         LOG.info("finished to load image in " + (loadImageEndTime - loadImageStartTime) + " ms");
     }
+
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/common/MetaWriter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/MetaWriter.java
@@ -1,0 +1,131 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.common;
+
+import org.apache.doris.catalog.Catalog;
+import org.apache.doris.common.io.CountingDataOutputStream;
+import com.google.common.collect.Lists;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * Image Format:
+ * |- Image --------------------------------------|
+ * | - Magic String (4 bytes)                     |
+ * | - Header Length (4 bytes)                    |
+ * | |- Header -----------------------------|     |
+ * | | |- Json Header ---------------|      |     |
+ * | | | - version                   |      |     |
+ * | | | - other key/value(undecided)|      |     |
+ * | | |-----------------------------|      |     |
+ * | |--------------------------------------|     |
+ * |                                              |
+ * | |- Image Body -------------------------|     |
+ * | | Object a                             |     |
+ * | | Object b                             |     |
+ * | | ...                                  |     |
+ * | |--------------------------------------|     |
+ * |                                              |
+ * | |- Footer -----------------------------|     |
+ * | | |- object index --------------|      |     |
+ * | | | - index a                   |      |     |
+ * | | | - index b                   |      |     |
+ * | | | ...                         |      |     |
+ * | | |-----------------------------|      |     |
+ * | | - other value(undecided)             |     |
+ * | |--------------------------------------|     |
+ * | - Footer Length (8 bytes)                    |
+ * | - Magic String (4 bytes)                     |
+ * |----------------------------------------------|
+ */
+
+public class MetaWriter {
+    private static final Logger LOG = LogManager.getLogger(MetaWriter.class);
+
+    public static void write(File imageFile, Catalog catalog) throws IOException {
+        // save image does not need any lock. because only checkpoint thread will call this method.
+        LOG.info("start save image to {}. is ckpt: {}", imageFile.getAbsolutePath(), Catalog.isCheckpointThread());
+
+        long checksum = 0;
+        long saveImageStartTime = System.currentTimeMillis();
+        long startPosition = MetaHeader.write(imageFile);
+        List<MetaIndex> metaIndices = Lists.newArrayList();
+        try (CountingDataOutputStream dos = new CountingDataOutputStream(new BufferedOutputStream(
+                new FileOutputStream(imageFile, true)), startPosition)) {
+            long replayedJournalId = catalog.getReplayedJournalId();
+            metaIndices.add(new MetaIndex("header", dos.getCount()));
+            checksum = catalog.saveHeader(dos, replayedJournalId, checksum);
+            metaIndices.add(new MetaIndex("masterInfo", dos.getCount()));
+            checksum = catalog.saveMasterInfo(dos, checksum);
+            metaIndices.add(new MetaIndex("frontends", dos.getCount()));
+            checksum = catalog.saveFrontends(dos, checksum);
+            metaIndices.add(new MetaIndex("backends", dos.getCount()));
+            checksum = Catalog.getCurrentSystemInfo().saveBackends(dos, checksum);
+            metaIndices.add(new MetaIndex("db", dos.getCount()));
+            checksum = catalog.saveDb(dos, checksum);
+            metaIndices.add(new MetaIndex("loadJob", dos.getCount()));
+            checksum = catalog.saveLoadJob(dos, checksum);
+            metaIndices.add(new MetaIndex("alterJob", dos.getCount()));
+            checksum = catalog.saveAlterJob(dos, checksum);
+            metaIndices.add(new MetaIndex("recycleBin", dos.getCount()));
+            checksum = catalog.saveRecycleBin(dos, checksum);
+            metaIndices.add(new MetaIndex("globalVariable", dos.getCount()));
+            checksum = catalog.saveGlobalVariable(dos, checksum);
+            metaIndices.add(new MetaIndex("cluster", dos.getCount()));
+            checksum = catalog.saveCluster(dos, checksum);
+            metaIndices.add(new MetaIndex("broker", dos.getCount()));
+            checksum = catalog.saveBrokers(dos, checksum);
+            metaIndices.add(new MetaIndex("resources", dos.getCount()));
+            checksum = catalog.saveResources(dos, checksum);
+            metaIndices.add(new MetaIndex("exportJob", dos.getCount()));
+            checksum = catalog.saveExportJob(dos, checksum);
+            metaIndices.add(new MetaIndex("backupHandler", dos.getCount()));
+            checksum = catalog.saveBackupHandler(dos, checksum);
+            metaIndices.add(new MetaIndex("paloAuth", dos.getCount()));
+            checksum = catalog.savePaloAuth(dos, checksum);
+            metaIndices.add(new MetaIndex("transactionState", dos.getCount()));
+            checksum = catalog.saveTransactionState(dos, checksum);
+            metaIndices.add(new MetaIndex("colocateTableIndex", dos.getCount()));
+            checksum = catalog.saveColocateTableIndex(dos, checksum);
+            metaIndices.add(new MetaIndex("routineLoadJobs", dos.getCount()));
+            checksum = catalog.saveRoutineLoadJobs(dos, checksum);
+            metaIndices.add(new MetaIndex("loadJobV2", dos.getCount()));
+            checksum = catalog.saveLoadJobsV2(dos, checksum);
+            metaIndices.add(new MetaIndex("smallFiles", dos.getCount()));
+            checksum = catalog.saveSmallFiles(dos, checksum);
+            metaIndices.add(new MetaIndex("plugins", dos.getCount()));
+            checksum = catalog.savePlugins(dos, checksum);
+            metaIndices.add(new MetaIndex("deleteHandler", dos.getCount()));
+            checksum = catalog.saveDeleteHandler(dos, checksum);
+            dos.writeLong(checksum);
+        }
+        MetaFooter.write(imageFile, metaIndices);
+
+        long saveImageEndTime = System.currentTimeMillis();
+        LOG.info("finished save image {} in {} ms. checksum is {}",
+                imageFile.getAbsolutePath(), (saveImageEndTime - saveImageStartTime), checksum);
+    }
+
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/common/MetaWriter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/MetaWriter.java
@@ -49,6 +49,7 @@ import java.util.List;
  * | |--------------------------------------|     |
  * |                                              |
  * | |- Footer -----------------------------|     |
+ * | | | - Checksum (8 bytes)               |     |
  * | | |- object index --------------|      |     |
  * | | | - index a                   |      |     |
  * | | | - index b                   |      |     |
@@ -119,9 +120,8 @@ public class MetaWriter {
             checksum = catalog.savePlugins(dos, checksum);
             metaIndices.add(new MetaIndex("deleteHandler", dos.getCount()));
             checksum = catalog.saveDeleteHandler(dos, checksum);
-            dos.writeLong(checksum);
         }
-        MetaFooter.write(imageFile, metaIndices);
+        MetaFooter.write(imageFile, metaIndices, checksum);
 
         long saveImageEndTime = System.currentTimeMillis();
         LOG.info("finished save image {} in {} ms. checksum is {}",

--- a/fe/fe-core/src/main/java/org/apache/doris/system/SystemInfoService.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/system/SystemInfoService.java
@@ -27,11 +27,11 @@ import org.apache.doris.common.FeConstants;
 import org.apache.doris.common.FeMetaVersion;
 import org.apache.doris.common.Pair;
 import org.apache.doris.common.Status;
+import org.apache.doris.common.io.CountingDataOutputStream;
 import org.apache.doris.metric.MetricRepo;
 import org.apache.doris.system.Backend.BackendState;
 import org.apache.doris.thrift.TStatusCode;
 import org.apache.doris.thrift.TStorageMedium;
-
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
@@ -46,7 +46,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.io.DataInputStream;
-import java.io.DataOutputStream;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
@@ -910,7 +909,7 @@ public class SystemInfoService {
         }
     }
 
-    public long saveBackends(DataOutputStream dos, long checksum) throws IOException {
+    public long saveBackends(CountingDataOutputStream dos, long checksum) throws IOException {
         ImmutableMap<Long, Backend> idToBackend = idToBackendRef;
         int backendCount = idToBackend.size();
         checksum ^= backendCount;

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/CatalogTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/CatalogTest.java
@@ -17,13 +17,14 @@
 
 package org.apache.doris.catalog;
 
-import mockit.Expectations;
 import org.apache.doris.alter.AlterJob;
 import org.apache.doris.alter.AlterJob.JobType;
 import org.apache.doris.alter.SchemaChangeJob;
 import org.apache.doris.catalog.MaterializedIndex.IndexState;
 import org.apache.doris.cluster.Cluster;
 import org.apache.doris.common.FeConstants;
+import org.apache.doris.common.MetaHeader;
+import org.apache.doris.common.io.CountingDataOutputStream;
 import org.apache.doris.load.Load;
 import org.apache.doris.load.LoadJob;
 import org.apache.doris.meta.MetaContext;
@@ -34,7 +35,6 @@ import org.junit.Test;
 
 import java.io.BufferedInputStream;
 import java.io.DataInputStream;
-import java.io.DataOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
@@ -45,6 +45,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import mockit.Expectations;
 
 public class CatalogTest {
 
@@ -133,7 +134,7 @@ public class CatalogTest {
         mkdir(dir);
         File file = new File(dir, "image");
         file.createNewFile();
-        DataOutputStream dos = new DataOutputStream(new FileOutputStream(file));
+        CountingDataOutputStream dos = new CountingDataOutputStream(new FileOutputStream(file));
         Catalog catalog = Catalog.getCurrentCatalog();
         MetaContext.get().setMetaVersion(FeConstants.meta_version);
         Field field = catalog.getClass().getDeclaredField("load");
@@ -147,7 +148,7 @@ public class CatalogTest {
         
         DataInputStream dis = new DataInputStream(new BufferedInputStream(new FileInputStream(file)));
         catalog = Catalog.getCurrentCatalog();
-        long checksum2 = catalog.loadHeader(dis, 0);
+        long checksum2 = catalog.loadHeader(dis, MetaHeader.EMPTY_HEADER ,0);
         Assert.assertEquals(checksum1, checksum2);
         dis.close();
         
@@ -160,7 +161,7 @@ public class CatalogTest {
         mkdir(dir);
         File file = new File(dir, "image");
         file.createNewFile();
-        DataOutputStream dos = new DataOutputStream(new FileOutputStream(file));
+        CountingDataOutputStream dos = new CountingDataOutputStream(new FileOutputStream(file));
 
         Catalog catalog = Catalog.getCurrentCatalog();
         MetaContext.get().setMetaVersion(FeConstants.meta_version);
@@ -196,7 +197,7 @@ public class CatalogTest {
         mkdir(dir);
         File file = new File(dir, "image");
         file.createNewFile();
-        DataOutputStream dos = new DataOutputStream(new FileOutputStream(file));
+        CountingDataOutputStream dos = new CountingDataOutputStream(new FileOutputStream(file));
         Catalog catalog = Catalog.getCurrentCatalog();
         MetaContext.get().setMetaVersion(FeConstants.meta_version);
         Field field = catalog.getClass().getDeclaredField("load");

--- a/fe/fe-core/src/test/java/org/apache/doris/cluster/SystemInfoServiceTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/cluster/SystemInfoServiceTest.java
@@ -17,8 +17,6 @@
 
 package org.apache.doris.cluster;
 
-import mockit.Expectations;
-import mockit.Mocked;
 import org.apache.doris.analysis.AddBackendClause;
 import org.apache.doris.analysis.Analyzer;
 import org.apache.doris.analysis.DropBackendClause;
@@ -29,11 +27,11 @@ import org.apache.doris.catalog.TabletInvertedIndex;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.DdlException;
 import org.apache.doris.common.FeConstants;
+import org.apache.doris.common.io.CountingDataOutputStream;
 import org.apache.doris.persist.EditLog;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.system.Backend;
 import org.apache.doris.system.SystemInfoService;
-
 import com.google.common.collect.Lists;
 
 import org.junit.Assert;
@@ -42,11 +40,12 @@ import org.junit.Test;
 
 import java.io.BufferedInputStream;
 import java.io.DataInputStream;
-import java.io.DataOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import mockit.Expectations;
+import mockit.Mocked;
 
 public class SystemInfoServiceTest {
 
@@ -268,7 +267,7 @@ public class SystemInfoServiceTest {
         mkdir(dir);
         File file = new File(dir, "image");
         file.createNewFile();
-        DataOutputStream dos = new DataOutputStream(new FileOutputStream(file));
+        CountingDataOutputStream dos = new CountingDataOutputStream(new FileOutputStream(file));
         SystemInfoService systemInfoService = Catalog.getCurrentSystemInfo();
         Backend back1 = new Backend(1L, "localhost", 3);
         back1.updateOnce(4, 6, 8);


### PR DESCRIPTION
## Proposed changes

#6206 

At present, our image file does not have file header/footer. When we need to change the image format (such as adding different journal versions to the image), there is no way to distinguish different image formats.

Therefore, we suggest adding file header and footer to the image. By the new image format, we can freely distinguish and define different image reading ways.

The format of the image is as follows:

```
/**
 * Image Format:
 * |- Image --------------------------------------|
 * | - Magic String (4 bytes)                     |
 * | - Header Length (4 bytes)                    |
 * | |- Header -----------------------------|     |
 * | | |- Json Header ---------------|      |     |
 * | | | - version                   |      |     |
 * | | | - other key/value(undecided)|      |     |
 * | | |-----------------------------|      |     |
 * | |--------------------------------------|     |
 * |                                              |
 * | |- Image Body -------------------------|     |
 * | | Object a                             |     |
 * | | Object b                             |     |
 * | | ...                                  |     |
 * | |--------------------------------------|     |
 * |                                              |
 * | |- Footer -----------------------------|     |
 * | | | - Checksum (8 bytes)               |     |
 * | | |- object index --------------|      |     |
 * | | | - index a                   |      |     |
 * | | | - index b                   |      |     |
 * | | | ...                         |      |     |
 * | | |-----------------------------|      |     |
 * | | - other value(undecided)             |     |
 * | |--------------------------------------|     |
 * | - Footer Length (8 bytes)                    |
 * | - Magic String (4 bytes)                     |
 * |----------------------------------------------|
 */
```
1. Magic Nuumber
One image format is identified by one magic string and one version field. The magic string is save in the first 4 bytes and last 4 bytes in the images.

2. Image Header:
The version is save in the header with json format now.

3. Image Body:
Equal to the original image.

4.Image Footer:
Image footer stores the file offset(index) of many image objects. If necessary, we can read some objects in the image by the footer.

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [x] New feature (non-breaking change which adds functionality)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have created an issue on (Fix #6206 ) and described the bug/feature there in detail
- [x] Compiling and unit tests pass locally with my changes

## Further comments

If this is a relatively large or complex change, kick off the discussion at dev@doris.apache.org by explaining why you chose the solution you did and what alternatives you considered, etc...
