### PR TITLE
[Bug][RoutineLoad] Can not match whole json in routine load

### DIFF
--- a/be/src/exprs/json_functions.cpp
+++ b/be/src/exprs/json_functions.cpp
@@ -281,6 +281,16 @@ rapidjson::Value* JsonFunctions::get_json_array_from_parsed_json(
         return nullptr;
     }
 
+    if (parsed_paths.size() == 1) {
+        // the json path is "$", just return entire document
+        // wrapper an array
+        rapidjson::Value* array_obj = nullptr;
+        array_obj = static_cast<rapidjson::Value*>(mem_allocator.Malloc(sizeof(rapidjson::Value)));
+        array_obj->SetArray();
+        array_obj->PushBack(*document, mem_allocator);
+        return array_obj;
+    }
+
     rapidjson::Value* root = match_value(parsed_paths, document, mem_allocator, true);
     if (root == nullptr || root == document) { // not found
         return nullptr;
@@ -299,6 +309,11 @@ rapidjson::Value* JsonFunctions::get_json_object_from_parsed_json(
         rapidjson::Document::AllocatorType& mem_allocator) {
     if (!parsed_paths[0].is_valid) {
         return nullptr;
+    }
+
+    if (parsed_paths.size() == 1) {
+        // the json path is "$", just return entire document
+        return document;
     }
 
     rapidjson::Value* root = match_value(parsed_paths, document, mem_allocator, true);

--- a/be/test/exprs/json_function_test.cpp
+++ b/be/test/exprs/json_function_test.cpp
@@ -187,8 +187,8 @@ TEST_F(JsonFunctionTest, special_char) {
 
 TEST_F(JsonFunctionTest, json_path1) {
     std::string json_raw_data(
-            "[{\"k1\":\"v1\", \"keyname\":{\"ip\":\"10.10.0.1\", \"value\":20}},{\"k1\":\"v1-1\", "
-            "\"keyname\":{\"ip\":\"10.20.10.1\", \"value\":20}}]");
+            "[{\"k1\":\"v1\",\"keyname\":{\"ip\":\"10.10.0.1\",\"value\":20}},{\"k1\":\"v1-1\","
+            "\"keyname\":{\"ip\":\"10.20.10.1\",\"value\":20}}]");
     rapidjson::Document jsonDoc;
     if (jsonDoc.Parse(json_raw_data.c_str()).HasParseError()) {
         ASSERT_TRUE(false);
@@ -207,6 +207,14 @@ TEST_F(JsonFunctionTest, json_path1) {
     for (int i = 0; i < res3->Size(); i++) {
         std::cout << (*res3)[i].GetString() << std::endl;
     }
+
+    res3 = JsonFunctions::get_json_array_from_parsed_json("$", &jsonDoc, jsonDoc.GetAllocator());
+    ASSERT_TRUE(res3->IsArray());
+    rapidjson::StringBuffer buffer;
+    buffer.Clear();
+    rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
+    (*res3)[0].Accept(writer);
+    ASSERT_EQ(json_raw_data, std::string(buffer.GetString()));
 }
 
 TEST_F(JsonFunctionTest, json_path_get_nullobject) {


### PR DESCRIPTION
## Proposed changes

Support using json path "$" to match the whole json in routine load

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Code refactor (Modify the code structure, format the code, etc...)
- [ ] Optimization. Including functional usability improvements and performance improvements.
- [ ] Dependency. Such as changes related to third-party components.
- [ ] Other.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have created an issue on (Fix #ISSUE) and described the bug/feature there in detail
- [ ] Compiling and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If these changes need document changes, I have updated the document
- [ ] Any dependent changes have been merged

## Further comments

If this is a relatively large or complex change, kick off the discussion at dev@doris.apache.org by explaining why you chose the solution you did and what alternatives you considered, etc...
