### PR TITLE
[Optimize] Use flat_hash_set to replace unorderd_set in InPredicate

### DIFF
--- a/be/src/olap/in_list_predicate.cpp
+++ b/be/src/olap/in_list_predicate.cpp
@@ -23,9 +23,9 @@
 
 namespace doris {
 
-#define IN_LIST_PRED_CONSTRUCTOR(CLASS)                                                      \
-    template <class type>                                                                    \
-    CLASS<type>::CLASS(uint32_t column_id, std::unordered_set<type>&& values, bool opposite) \
+#define IN_LIST_PRED_CONSTRUCTOR(CLASS)                                       \
+    template <class type>                                                     \
+    CLASS<type>::CLASS(uint32_t column_id, phmap::flat_hash_set<type>&& values, bool opposite) \
             : ColumnPredicate(column_id, opposite), _values(std::move(values)) {}
 
 IN_LIST_PRED_CONSTRUCTOR(InListPredicate)
@@ -210,29 +210,18 @@ IN_LIST_PRED_COLUMN_BLOCK_EVALUATE_AND(NotInListPredicate, ==)
 IN_LIST_PRED_BITMAP_EVALUATE(InListPredicate, &=)
 IN_LIST_PRED_BITMAP_EVALUATE(NotInListPredicate, -=)
 
-#define IN_LIST_PRED_CONSTRUCTOR_DECLARATION(CLASS)                                              \
-    template CLASS<int8_t>::CLASS(uint32_t column_id, std::unordered_set<int8_t>&& values,       \
-                                  bool opposite);                                                \
-    template CLASS<int16_t>::CLASS(uint32_t column_id, std::unordered_set<int16_t>&& values,     \
-                                   bool opposite);                                               \
-    template CLASS<int32_t>::CLASS(uint32_t column_id, std::unordered_set<int32_t>&& values,     \
-                                   bool opposite);                                               \
-    template CLASS<int64_t>::CLASS(uint32_t column_id, std::unordered_set<int64_t>&& values,     \
-                                   bool opposite);                                               \
-    template CLASS<int128_t>::CLASS(uint32_t column_id, std::unordered_set<int128_t>&& values,   \
-                                    bool opposite);                                              \
-    template CLASS<float>::CLASS(uint32_t column_id, std::unordered_set<float>&& values,         \
-                                 bool opposite);                                                 \
-    template CLASS<double>::CLASS(uint32_t column_id, std::unordered_set<double>&& values,       \
-                                  bool opposite);                                                \
-    template CLASS<decimal12_t>::CLASS(uint32_t column_id,                                       \
-                                       std::unordered_set<decimal12_t>&& values, bool opposite); \
-    template CLASS<StringValue>::CLASS(uint32_t column_id,                                       \
-                                       std::unordered_set<StringValue>&& values, bool opposite); \
-    template CLASS<uint24_t>::CLASS(uint32_t column_id, std::unordered_set<uint24_t>&& values,   \
-                                    bool opposite);                                              \
-    template CLASS<uint64_t>::CLASS(uint32_t column_id, std::unordered_set<uint64_t>&& values,   \
-                                    bool opposite);
+#define IN_LIST_PRED_CONSTRUCTOR_DECLARATION(CLASS)                                                        \
+    template CLASS<int8_t>::CLASS(uint32_t column_id, phmap::flat_hash_set<int8_t>&& values, bool opposite);           \
+    template CLASS<int16_t>::CLASS(uint32_t column_id, phmap::flat_hash_set<int16_t>&& values, bool opposite);         \
+    template CLASS<int32_t>::CLASS(uint32_t column_id, phmap::flat_hash_set<int32_t>&& values, bool opposite);         \
+    template CLASS<int64_t>::CLASS(uint32_t column_id, phmap::flat_hash_set<int64_t>&& values, bool opposite);         \
+    template CLASS<int128_t>::CLASS(uint32_t column_id, phmap::flat_hash_set<int128_t>&& values, bool opposite);       \
+    template CLASS<float>::CLASS(uint32_t column_id, phmap::flat_hash_set<float>&& values, bool opposite);             \
+    template CLASS<double>::CLASS(uint32_t column_id, phmap::flat_hash_set<double>&& values, bool opposite);           \
+    template CLASS<decimal12_t>::CLASS(uint32_t column_id, phmap::flat_hash_set<decimal12_t>&& values, bool opposite); \
+    template CLASS<StringValue>::CLASS(uint32_t column_id, phmap::flat_hash_set<StringValue>&& values, bool opposite); \
+    template CLASS<uint24_t>::CLASS(uint32_t column_id, phmap::flat_hash_set<uint24_t>&& values, bool opposite);       \
+    template CLASS<uint64_t>::CLASS(uint32_t column_id, phmap::flat_hash_set<uint64_t>&& values, bool opposite);
 
 IN_LIST_PRED_CONSTRUCTOR_DECLARATION(InListPredicate)
 IN_LIST_PRED_CONSTRUCTOR_DECLARATION(NotInListPredicate)

--- a/be/src/olap/in_list_predicate.h
+++ b/be/src/olap/in_list_predicate.h
@@ -21,8 +21,7 @@
 #include <stdint.h>
 
 #include <roaring/roaring.hh>
-#include <set>
-#include <unordered_set>
+#include <parallel_hashmap/phmap.h>
 
 #include "decimal12.h"
 #include "olap/column_predicate.h"
@@ -81,7 +80,7 @@ class VectorizedRowBatch;
     template <class type>                                                                       \
     class CLASS : public ColumnPredicate {                                                      \
     public:                                                                                     \
-        CLASS(uint32_t column_id, std::unordered_set<type>&& values, bool is_opposite = false); \
+        CLASS(uint32_t column_id, phmap::flat_hash_set<type>&& values, bool is_opposite = false); \
         virtual void evaluate(VectorizedRowBatch* batch) const override;                        \
         void evaluate(ColumnBlock* block, uint16_t* sel, uint16_t* size) const override;        \
         void evaluate_or(ColumnBlock* block, uint16_t* sel, uint16_t size,                      \
@@ -93,7 +92,7 @@ class VectorizedRowBatch;
                                 uint32_t num_rows, Roaring* bitmap) const override;             \
                                                                                                 \
     private:                                                                                    \
-        std::unordered_set<type> _values;                                                       \
+        phmap::flat_hash_set<type> _values;                                                       \
     };
 
 IN_LIST_PRED_CLASS_DEFINE(InListPredicate)

--- a/be/src/olap/reader.cpp
+++ b/be/src/olap/reader.cpp
@@ -18,6 +18,7 @@
 #include "olap/reader.h"
 
 #include <boost/algorithm/string/case_conv.hpp>
+#include <parallel_hashmap/phmap.h>
 #include <sstream>
 #include <unordered_set>
 
@@ -755,7 +756,7 @@ ColumnPredicate* Reader::_parse_to_predicate(const TCondition& condition, bool o
                condition.condition_values.size() > 1) {
         switch (column.type()) {
         case OLAP_FIELD_TYPE_TINYINT: {
-            std::unordered_set<int8_t> values;
+            phmap::flat_hash_set<int8_t> values;
             for (auto& cond_val : condition.condition_values) {
                 int32_t value = 0;
                 std::stringstream ss(cond_val);
@@ -770,7 +771,7 @@ ColumnPredicate* Reader::_parse_to_predicate(const TCondition& condition, bool o
             break;
         }
         case OLAP_FIELD_TYPE_SMALLINT: {
-            std::unordered_set<int16_t> values;
+            phmap::flat_hash_set<int16_t> values;
             for (auto& cond_val : condition.condition_values) {
                 int16_t value = 0;
                 std::stringstream ss(cond_val);
@@ -785,7 +786,7 @@ ColumnPredicate* Reader::_parse_to_predicate(const TCondition& condition, bool o
             break;
         }
         case OLAP_FIELD_TYPE_INT: {
-            std::unordered_set<int32_t> values;
+            phmap::flat_hash_set<int32_t> values;
             for (auto& cond_val : condition.condition_values) {
                 int32_t value = 0;
                 std::stringstream ss(cond_val);
@@ -800,7 +801,7 @@ ColumnPredicate* Reader::_parse_to_predicate(const TCondition& condition, bool o
             break;
         }
         case OLAP_FIELD_TYPE_BIGINT: {
-            std::unordered_set<int64_t> values;
+            phmap::flat_hash_set<int64_t> values;
             for (auto& cond_val : condition.condition_values) {
                 int64_t value = 0;
                 std::stringstream ss(cond_val);
@@ -815,7 +816,7 @@ ColumnPredicate* Reader::_parse_to_predicate(const TCondition& condition, bool o
             break;
         }
         case OLAP_FIELD_TYPE_LARGEINT: {
-            std::unordered_set<int128_t> values;
+            phmap::flat_hash_set<int128_t> values;
             for (auto& cond_val : condition.condition_values) {
                 int128_t value = 0;
                 std::stringstream ss(cond_val);
@@ -830,7 +831,7 @@ ColumnPredicate* Reader::_parse_to_predicate(const TCondition& condition, bool o
             break;
         }
         case OLAP_FIELD_TYPE_DECIMAL: {
-            std::unordered_set<decimal12_t> values;
+            phmap::flat_hash_set<decimal12_t> values;
             for (auto& cond_val : condition.condition_values) {
                 decimal12_t value = {0, 0};
                 value.from_string(cond_val);
@@ -844,7 +845,7 @@ ColumnPredicate* Reader::_parse_to_predicate(const TCondition& condition, bool o
             break;
         }
         case OLAP_FIELD_TYPE_CHAR: {
-            std::unordered_set<StringValue> values;
+            phmap::flat_hash_set<StringValue> values;
             for (auto& cond_val : condition.condition_values) {
                 StringValue value;
                 size_t length = std::max(static_cast<size_t>(column.length()), cond_val.length());
@@ -863,7 +864,7 @@ ColumnPredicate* Reader::_parse_to_predicate(const TCondition& condition, bool o
             break;
         }
         case OLAP_FIELD_TYPE_VARCHAR: {
-            std::unordered_set<StringValue> values;
+            phmap::flat_hash_set<StringValue> values;
             for (auto& cond_val : condition.condition_values) {
                 StringValue value;
                 int32_t length = cond_val.length();
@@ -881,7 +882,7 @@ ColumnPredicate* Reader::_parse_to_predicate(const TCondition& condition, bool o
             break;
         }
         case OLAP_FIELD_TYPE_DATE: {
-            std::unordered_set<uint24_t> values;
+            phmap::flat_hash_set<uint24_t> values;
             for (auto& cond_val : condition.condition_values) {
                 uint24_t value = timestamp_from_date(cond_val);
                 values.insert(value);
@@ -894,7 +895,7 @@ ColumnPredicate* Reader::_parse_to_predicate(const TCondition& condition, bool o
             break;
         }
         case OLAP_FIELD_TYPE_DATETIME: {
-            std::unordered_set<uint64_t> values;
+            phmap::flat_hash_set<uint64_t> values;
             for (auto& cond_val : condition.condition_values) {
                 uint64_t value = timestamp_from_datetime(cond_val);
                 values.insert(value);

--- a/be/test/olap/in_list_predicate_test.cpp
+++ b/be/test/olap/in_list_predicate_test.cpp
@@ -156,7 +156,7 @@ public:
             *(col_data + i) = i;                                                                  \
         }                                                                                         \
                                                                                                   \
-        std::unordered_set<TYPE> values;                                                          \
+        phmap::flat_hash_set<TYPE> values;                                                        \
         values.insert(4);                                                                         \
         values.insert(5);                                                                         \
         values.insert(6);                                                                         \
@@ -203,7 +203,7 @@ TEST_IN_LIST_PREDICATE(int128_t, LARGEINT, "LARGEINT")
         int size = 10;                                                                            \
         Schema schema(tablet_schema);                                                             \
         RowBlockV2 block(schema, size);                                                           \
-        std::unordered_set<TYPE> values;                                                          \
+        phmap::flat_hash_set<TYPE> values;                                                        \
         values.insert(4);                                                                         \
         values.insert(5);                                                                         \
         values.insert(6);                                                                         \
@@ -268,7 +268,7 @@ TEST_F(TestInListPredicate, FLOAT_COLUMN) {
     for (int i = 0; i < tablet_schema.num_columns(); ++i) {
         return_columns.push_back(i);
     }
-    std::unordered_set<float> values;
+    phmap::flat_hash_set<float> values;
     values.insert(4.1);
     values.insert(5.1);
     values.insert(6.1);
@@ -352,7 +352,7 @@ TEST_F(TestInListPredicate, DOUBLE_COLUMN) {
     for (int i = 0; i < tablet_schema.num_columns(); ++i) {
         return_columns.push_back(i);
     }
-    std::unordered_set<double> values;
+    phmap::flat_hash_set<double> values;
     values.insert(4.1);
     values.insert(5.1);
     values.insert(6.1);
@@ -437,7 +437,7 @@ TEST_F(TestInListPredicate, DECIMAL_COLUMN) {
     for (int i = 0; i < tablet_schema.num_columns(); ++i) {
         return_columns.push_back(i);
     }
-    std::unordered_set<decimal12_t> values;
+    phmap::flat_hash_set<decimal12_t> values;
 
     decimal12_t value1 = {4, 4};
     values.insert(value1);
@@ -530,7 +530,7 @@ TEST_F(TestInListPredicate, CHAR_COLUMN) {
     for (int i = 0; i < tablet_schema.num_columns(); ++i) {
         return_columns.push_back(i);
     }
-    std::unordered_set<StringValue> values;
+    phmap::flat_hash_set<StringValue> values;
     StringValue value1;
     const char* value1_buffer = "aaaaa";
     value1.ptr = const_cast<char*>(value1_buffer);
@@ -658,7 +658,7 @@ TEST_F(TestInListPredicate, VARCHAR_COLUMN) {
     for (int i = 0; i < tablet_schema.num_columns(); ++i) {
         return_columns.push_back(i);
     }
-    std::unordered_set<StringValue> values;
+    phmap::flat_hash_set<StringValue> values;
     StringValue value1;
     const char* value1_buffer = "a";
     value1.ptr = const_cast<char*>(value1_buffer);
@@ -783,7 +783,7 @@ TEST_F(TestInListPredicate, DATE_COLUMN) {
     for (int i = 0; i < tablet_schema.num_columns(); ++i) {
         return_columns.push_back(i);
     }
-    std::unordered_set<uint24_t> values;
+    phmap::flat_hash_set<uint24_t> values;
     uint24_t value1 = datetime::timestamp_from_date("2017-09-09");
     values.insert(value1);
 
@@ -892,7 +892,7 @@ TEST_F(TestInListPredicate, DATETIME_COLUMN) {
     for (int i = 0; i < tablet_schema.num_columns(); ++i) {
         return_columns.push_back(i);
     }
-    std::unordered_set<uint64_t> values;
+    phmap::flat_hash_set<uint64_t> values;
     uint64_t value1 = datetime::timestamp_from_datetime("2017-09-09 00:00:01");
     values.insert(value1);
 

--- a/be/test/olap/rowset/segment_v2/segment_test.cpp
+++ b/be/test/olap/rowset/segment_v2/segment_test.cpp
@@ -1087,7 +1087,7 @@ TEST_F(SegmentReaderWriterTest, TestBitmapPredicate) {
         // test where v1 in (10,20,1)
         {
             std::vector<ColumnPredicate*> column_predicates;
-            std::unordered_set<int32_t> values;
+            phmap::flat_hash_set<int32_t> values;
             values.insert(10);
             values.insert(20);
             values.insert(1);
@@ -1111,7 +1111,7 @@ TEST_F(SegmentReaderWriterTest, TestBitmapPredicate) {
         // test where v1 not in (10,20)
         {
             std::vector<ColumnPredicate*> column_predicates;
-            std::unordered_set<int32_t> values;
+            phmap::flat_hash_set<int32_t> values;
             values.insert(10);
             values.insert(20);
             std::unique_ptr<ColumnPredicate> predicate(

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Catalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Catalog.java
@@ -849,8 +849,9 @@ public class Catalog {
                     // nodeName should be like "192.168.1.1_9217_1620296111213"
                     // and the selfNode should be the prefix of nodeName.
                     // If not, it means that the ip used last time is different from this time, which is not allowed.
+                    // But is metadata_failure_recovery is true, we will not check it because this may be a FE migration.
                     String[] split = nodeName.split("_");
-                    if (!selfNode.first.equalsIgnoreCase(split[0])) {
+                    if (Config.metadata_failure_recovery.equals("false") && !selfNode.first.equalsIgnoreCase(split[0])) {
                         throw new IOException("the self host " + selfNode.first + " does not equal to the host in ROLE" +
                                 " file " + split[0] + ". You need to set 'priority_networks' config in fe.conf to match" +
                                 " the host " + split[0]);


### PR DESCRIPTION
## Proposed changes

Use parallel_hashmap to speed up the In Predicate

Also fix a bug that when `metadata_failure_recovery=true`, FE will not check if the IP is changed.

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Code refactor (Modify the code structure, format the code, etc...)
- [ ] Optimization. Including functional usability improvements and performance improvements.
- [ ] Dependency. Such as changes related to third-party components.
- [ ] Other.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have created an issue on (Fix #ISSUE) and described the bug/feature there in detail
- [ ] Compiling and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If these changes need document changes, I have updated the document
- [ ] Any dependent changes have been merged

## Further comments

If this is a relatively large or complex change, kick off the discussion at dev@doris.apache.org by explaining why you chose the solution you did and what alternatives you considered, etc...
