### PR TITLE
[Enhancement] Modify the method of calculating compaction score

### DIFF
--- a/be/src/olap/rowset/rowset_meta.h
+++ b/be/src/olap/rowset/rowset_meta.h
@@ -265,15 +265,14 @@ public:
     }
 
     // get the compaction score of this rowset.
-    // if segments are overlapping, the score equals to the number of segments,
+    // if segments are overlapping or the number of segments is 0, the score equals to the number of segments,
     // otherwise, score is 1.
     uint32_t get_compaction_score() const {
         uint32_t score = 0;
-        if (!is_segments_overlapping()) {
+        if (num_segments() > 0 && !is_segments_overlapping()) {
             score = 1;
         } else {
             score = num_segments();
-            CHECK(score > 0);
         }
         return score;
     }

--- a/be/src/olap/rowset/rowset_meta.h
+++ b/be/src/olap/rowset/rowset_meta.h
@@ -269,7 +269,7 @@ public:
     // otherwise, score is 1.
     uint32_t get_compaction_score() const {
         uint32_t score = 0;
-        if (num_segments() > 0 && !is_segments_overlapping()) {
+        if ((num_segments() > 0 && !is_segments_overlapping()) || has_delete_predicate()) {
             score = 1;
         } else {
             score = num_segments();


### PR DESCRIPTION

## Proposed changes

There are many compaction tasks that do not actually merge segments instead of merging many rowsets with 0 segments as follows. But we expect small segment files can be merged by compaction task as soon as possible. 

![2021-07-16 13-06-31 的屏幕截图](https://user-images.githubusercontent.com/68884553/125894776-87a43869-ce08-4518-9fa9-6194b583c3bf.png)

The purpose of this PR is to modify calculation method of compaction score to lower the priority of rowset with 0 segments for compaction.

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Code refactor (Modify the code structure, format the code, etc...)
- [x] Optimization. Including functional usability improvements and performance improvements.
- [ ] Dependency. Such as changes related to third-party components.
- [ ] Other.
