### PR TITLE
Errors during mysql connection establishment should be warned

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/nio/AcceptListener.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/nio/AcceptListener.java
@@ -80,8 +80,10 @@ public class AcceptListener implements ChannelListener<AcceptingChannel<StreamCo
                     context.cleanup();
                 } catch (Throwable e) {
                     // should be unexpected exception, so print warn log
-                    if (context.getCurrentUserIdentity() != null || (e instanceof Error)) {
+                    if (context.getCurrentUserIdentity() != null) {
                         LOG.warn("connect processor exception because ", e);
+                    } else if (e instanceof Error) {
+                        LOG.error("connect processor exception because ", e);
                     } else {
                         // for unauthrorized access such lvs probe request, may cause exception, just log it in debug level
                         LOG.debug("connect processor exception because ", e);

--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/nio/AcceptListener.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/nio/AcceptListener.java
@@ -80,7 +80,7 @@ public class AcceptListener implements ChannelListener<AcceptingChannel<StreamCo
                     context.cleanup();
                 } catch (Throwable e) {
                     // should be unexpected exception, so print warn log
-                    if (context.getCurrentUserIdentity() != null) {
+                    if (context.getCurrentUserIdentity() != null || (e instanceof Error)) {
                         LOG.warn("connect processor exception because ", e);
                     } else {
                         // for unauthrorized access such lvs probe request, may cause exception, just log it in debug level


### PR DESCRIPTION
## Proposed changes
The log of fe cannot print errors during the establishment of the mysql connection. We should print it as an error log for quick troubleshooting.
For example, we started a fe instance and tried to add a backend to it, but we encountered an exception below.
```
[root@xxx ~]# mysql -h127.0.0.1  -P 9030 -uroot
ERROR 2013 (HY000): Lost connection to MySQL server at 'reading initial communication packet', system error: 0
```
We can find the root cause immediately through this patch.
```
2021-07-17 08:52:52,413 INFO (UNKNOWN 192.168.0.30_9010_1626483157415(-1)|1) [NMysqlServer.start():70] Open mysql server success on 9030
2021-07-17 08:52:52,413 INFO (UNKNOWN 192.168.0.30_9010_1626483157415(-1)|1) [QeService.start():60] QE service start.
2021-07-17 08:52:56,502 INFO (doris-mysql-nio I/O-1|92) [AcceptListener.handleEvent():50] Connection established. remote=/127.0.0.1:51866
2021-07-17 08:52:56,528 ERROR (doris-mysql-nio-pool-0|119) [AcceptListener.lambda$handleEvent$1():83] connect processor exception because
java.lang.NoSuchMethodError: java.nio.ByteBuffer.limit(I)Ljava/nio/ByteBuffer;
        at org.apache.doris.mysql.MysqlChannel.sendOnePacket(MysqlChannel.java:259) ~[palo-fe.jar:3.4.0]
        at org.apache.doris.mysql.MysqlChannel.sendAndFlush(MysqlChannel.java:265) ~[palo-fe.jar:3.4.0]
        at org.apache.doris.mysql.MysqlProto.negotiate(MysqlProto.java:142) ~[palo-fe.jar:3.4.0]
        at org.apache.doris.mysql.nio.AcceptListener.lambda$handleEvent$1(AcceptListener.java:63) ~[palo-fe.jar:3.4.0]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [?:1.8.0_252]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [?:1.8.0_252]
        at java.lang.Thread.run(Thread.java:748) [?:1.8.0_252]
```


## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Code refactor (Modify the code structure, format the code, etc...)
- [ ] Optimization. Including functional usability improvements and performance improvements.
- [ ] Dependency. Such as changes related to third-party components.
- [x] Other.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have created an issue on (Fix #ISSUE) and described the bug/feature there in detail
- [x ] Compiling and unit tests pass locally with my changes
- [x ] I have added tests that prove my fix is effective or that my feature works
- [ ] If these changes need document changes, I have updated the document
- [ ] Any dependent changes have been merged