### PR TITLE
[Bug] Fix core dump in BloomFilter while build Runtime Filter right table string column contains null

### DIFF
--- a/be/src/exprs/bloomfilter_predicate.h
+++ b/be/src/exprs/bloomfilter_predicate.h
@@ -184,10 +184,15 @@ template <class BloomFilterAdaptor>
 struct StringFindOp {
     ALWAYS_INLINE void insert(BloomFilterAdaptor& bloom_filter, const void* data) const {
         const auto* value = reinterpret_cast<const StringValue*>(data);
-        bloom_filter.add_bytes(value->ptr, value->len);
+        if (value) {
+            bloom_filter.add_bytes(value->ptr, value->len);
+        }
     }
     ALWAYS_INLINE bool find(const BloomFilterAdaptor& bloom_filter, const void* data) const {
         const auto* value = reinterpret_cast<const StringValue*>(data);
+        if (value == nullptr) {
+            return false;
+        }
         return bloom_filter.test_bytes(value->ptr, value->len);
     }
     ALWAYS_INLINE bool find_olap_engine(const BloomFilterAdaptor& bloom_filter,
@@ -196,6 +201,8 @@ struct StringFindOp {
     }
 };
 
+// We do not need to judge whether data is empty, because null will not appear
+// when filer used by the storage engine
 template <class BloomFilterAdaptor>
 struct FixedStringFindOp : public StringFindOp<BloomFilterAdaptor> {
     ALWAYS_INLINE bool find_olap_engine(const BloomFilterAdaptor& bloom_filter,

--- a/be/src/exprs/runtime_filter.h
+++ b/be/src/exprs/runtime_filter.h
@@ -299,8 +299,10 @@ public:
             auto iter = _runtime_filters.find(i);
             if (iter != _runtime_filters.end()) {
                 void* val = _build_expr_context[i]->get_value(row);
-                for (auto filter : iter->second) {
-                    filter->insert(val);
+                if (val != nullptr) {
+                    for (auto filter : iter->second) {
+                        filter->insert(val);
+                    }
                 }
             }
         }

--- a/be/test/exprs/bloom_filter_predicate_test.cpp
+++ b/be/test/exprs/bloom_filter_predicate_test.cpp
@@ -98,6 +98,8 @@ TEST_F(BloomFilterPredicateTest, bloom_filter_func_stringval_test) {
 
     ASSERT_TRUE(func->find_olap_engine((const void*)&fixed_char_true));
     ASSERT_TRUE(func->find_olap_engine((const void*)&fixed_char_false));
+
+    func->find(nullptr);
 }
 
 TEST_F(BloomFilterPredicateTest, bloom_filter_size_test) {


### PR DESCRIPTION
when right table has null value in string column, runtime filter may coredump
```
select count(*) from baseall t1 join test t2 where t1.k7 = t2.k7;
```

## Proposed changes

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Code refactor (Modify the code structure, format the code, etc...)
- [ ] Optimization. Including functional usability improvements and performance improvements.
- [ ] Dependency. Such as changes related to third-party components.
- [ ] Other.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have created an issue on (Fix #6304 ) and described the bug/feature there in detail
- [x] Compiling and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If these changes need document changes, I have updated the document
- [ ] Any dependent changes have been merged

## Further comments

If this is a relatively large or complex change, kick off the discussion at dev@doris.apache.org by explaining why you chose the solution you did and what alternatives you considered, etc...
