### PR TITLE
[Bug][Load]Fix BE coredump when flushing memtable

### DIFF
--- a/be/src/olap/rowset/beta_rowset_writer.cpp
+++ b/be/src/olap/rowset/beta_rowset_writer.cpp
@@ -144,13 +144,10 @@ OLAPStatus BetaRowsetWriter::flush_single_memtable(MemTable* memtable, int64_t* 
     std::unique_ptr<segment_v2::SegmentWriter> writer;
 
     MemTable::Iterator it(memtable);
-    it.seek_to_first();
-    if (it.valid()) {
-        // Only create writer if memtable has data.
-        // Because we do not allow to flush a empty segment writer.
-        RETURN_NOT_OK(_create_segment_writer(&writer));
-    }
-    for ( ; it.valid(); it.next()) {
+    for (it.seek_to_first(); it.valid(); it.next()) {
+        if (PREDICT_FALSE(writer == nullptr)) {
+            RETURN_NOT_OK(_create_segment_writer(&writer));
+        }
         ContiguousRow dst_row = it.get_current_row();
         auto s = writer->append_row(dst_row);
         if (PREDICT_FALSE(!s.ok())) {


### PR DESCRIPTION
## Proposed changes

Fix #6316

If the size of memtable is greater than max segment size and the memtable will flush more than one segment file. BE coredump will be triggered when flushing memtable.

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Code refactor (Modify the code structure, format the code, etc...)
- [ ] Optimization. Including functional usability improvements and performance improvements.
- [ ] Dependency. Such as changes related to third-party components.
- [ ] Other.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have created an issue on (Fix #6316) and described the bug/feature there in detail
- [x] Compiling and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If these changes need document changes, I have updated the document
- [x] Any dependent changes have been merged

