### PR TITLE
[Bug] Fix BE coredump for 'ferror(nullptr)' in UserFunctionCache

### DIFF
--- a/be/src/runtime/user_function_cache.cpp
+++ b/be/src/runtime/user_function_cache.cpp
@@ -305,7 +305,7 @@ Status UserFunctionCache::_download_lib(const std::string& url, UserFunctionCach
     auto fp_closer = [](FILE* fp) { fclose(fp); };
     std::unique_ptr<FILE, decltype(fp_closer)> fp(fopen(tmp_file.c_str(), "w"), fp_closer);
     if (fp == nullptr) {
-        LOG(WARNING) << "fail to open file, file=" << tmp_file << ", error=" << ferror(fp.get());
+        LOG(WARNING) << "fail to open file, file=" << tmp_file;
         return Status::InternalError("fail to open file");
     }
 


### PR DESCRIPTION
## Proposed changes
Fix #6330

In function `doris::UserFunctionCache::_download_lib()`,  `ferror(fp.get())` will trigger BE coredump if it failed to open file `tmp_file` and `fp`is `nullptr`. 

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Code refactor (Modify the code structure, format the code, etc...)
- [ ] Optimization. Including functional usability improvements and performance improvements.
- [ ] Dependency. Such as changes related to third-party components.
- [ ] Other.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have created an issue on (Fix #6330) and described the bug/feature there in detail
- [ ] Compiling and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If these changes need document changes, I have updated the document
- [x] Any dependent changes have been merged

## Further comments

If this is a relatively large or complex change, kick off the discussion at dev@doris.apache.org by explaining why you chose the solution you did and what alternatives you considered, etc...
