### PR TITLE
[Bug][RoutineLoad] Avoid TOO_MANY_TASKS error

### DIFF
--- a/be/src/runtime/routine_load/data_consumer.cpp
+++ b/be/src/runtime/routine_load/data_consumer.cpp
@@ -33,6 +33,7 @@
 
 namespace doris {
 
+static const std::string PROP_GROUP_ID = "group.id";
 // init kafka consumer will only set common configs such as
 // brokers, groupid
 Status KafkaDataConsumer::init(StreamLoadContext* ctx) {
@@ -47,10 +48,6 @@ Status KafkaDataConsumer::init(StreamLoadContext* ctx) {
     // conf has to be deleted finally
     Defer delete_conf{[conf]() { delete conf; }};
 
-    std::stringstream ss;
-    ss << BackendOptions::get_localhost() << "_";
-    std::string group_id = ss.str() + UniqueId::gen_uid().to_string();
-    LOG(INFO) << "init kafka consumer with group id: " << group_id;
 
     std::string errstr;
     auto set_conf = [&conf, &errstr](const std::string& conf_key, const std::string& conf_val) {
@@ -74,7 +71,6 @@ Status KafkaDataConsumer::init(StreamLoadContext* ctx) {
     };
 
     RETURN_IF_ERROR(set_conf("metadata.broker.list", ctx->kafka_info->brokers));
-    RETURN_IF_ERROR(set_conf("group.id", group_id));
     RETURN_IF_ERROR(set_conf("enable.partition.eof", "false"));
     RETURN_IF_ERROR(set_conf("enable.auto.offset.store", "false"));
     // TODO: set it larger than 0 after we set rd_kafka_conf_set_stats_cb()
@@ -107,6 +103,18 @@ Status KafkaDataConsumer::init(StreamLoadContext* ctx) {
         }
         _custom_properties.emplace(item.first, item.second);
     }
+
+	// if not specified group id, generate a random one.
+	// ATTN: In the new version, we have set a group.id on the FE side for jobs that have not set a groupid,
+	// but in order to ensure compatibility, we still do a check here.
+	if (_custom_properties.find(PROP_GROUP_ID) == _custom_properties.end()) {
+		std::stringstream ss;
+		ss << BackendOptions::get_localhost() << "_";
+		std::string group_id = ss.str() + UniqueId::gen_uid().to_string();
+		RETURN_IF_ERROR(set_conf(PROP_GROUP_ID, group_id));
+		_custom_properties.emplace(PROP_GROUP_ID, group_id);
+	}
+	LOG(INFO) << "init kafka consumer with group id: " << _custom_properties[PROP_GROUP_ID];
 
     if (conf->set("event_cb", &_k_event_cb, errstr) != RdKafka::Conf::CONF_OK) {
         std::stringstream ss;

--- a/be/src/runtime/routine_load/data_consumer.cpp
+++ b/be/src/runtime/routine_load/data_consumer.cpp
@@ -354,7 +354,9 @@ Status KafkaDataConsumer::reset() {
 }
 
 Status KafkaDataConsumer::commit(std::vector<RdKafka::TopicPartition*>& offset) {
-    RdKafka::ErrorCode err = _k_consumer->commitSync(offset);
+    // Use async commit so that it will not block for a long time.
+    // Commit failure has no effect on Doris, subsequent tasks will continue to commit the new offset
+    RdKafka::ErrorCode err = _k_consumer->commitAsync(offset);
     if (err != RdKafka::ERR_NO_ERROR) {
         std::stringstream ss;
         ss << "failed to commit kafka offset : " << RdKafka::err2str(err);

--- a/be/src/runtime/routine_load/data_consumer.cpp
+++ b/be/src/runtime/routine_load/data_consumer.cpp
@@ -104,17 +104,17 @@ Status KafkaDataConsumer::init(StreamLoadContext* ctx) {
         _custom_properties.emplace(item.first, item.second);
     }
 
-	// if not specified group id, generate a random one.
-	// ATTN: In the new version, we have set a group.id on the FE side for jobs that have not set a groupid,
-	// but in order to ensure compatibility, we still do a check here.
-	if (_custom_properties.find(PROP_GROUP_ID) == _custom_properties.end()) {
-		std::stringstream ss;
-		ss << BackendOptions::get_localhost() << "_";
-		std::string group_id = ss.str() + UniqueId::gen_uid().to_string();
-		RETURN_IF_ERROR(set_conf(PROP_GROUP_ID, group_id));
-		_custom_properties.emplace(PROP_GROUP_ID, group_id);
-	}
-	LOG(INFO) << "init kafka consumer with group id: " << _custom_properties[PROP_GROUP_ID];
+    // if not specified group id, generate a random one.
+    // ATTN: In the new version, we have set a group.id on the FE side for jobs that have not set a groupid,
+    // but in order to ensure compatibility, we still do a check here.
+    if (_custom_properties.find(PROP_GROUP_ID) == _custom_properties.end()) {
+        std::stringstream ss;
+        ss << BackendOptions::get_localhost() << "_";
+        std::string group_id = ss.str() + UniqueId::gen_uid().to_string();
+        RETURN_IF_ERROR(set_conf(PROP_GROUP_ID, group_id));
+        _custom_properties.emplace(PROP_GROUP_ID, group_id);
+    }
+    LOG(INFO) << "init kafka consumer with group id: " << _custom_properties[PROP_GROUP_ID];
 
     if (conf->set("event_cb", &_k_event_cb, errstr) != RdKafka::Conf::CONF_OK) {
         std::stringstream ss;

--- a/be/src/runtime/routine_load/routine_load_task_executor.cpp
+++ b/be/src/runtime/routine_load/routine_load_task_executor.cpp
@@ -325,9 +325,10 @@ void RoutineLoadTaskExecutor::exec_task(StreamLoadContext* ctx, DataConsumerPool
             std::for_each(topic_partitions.begin(), topic_partitions.end(),
                           [](RdKafka::TopicPartition* tp1) { delete tp1; });
         }};
-    } break;
+        break;
+    }
     default:
-        return;
+        break;
     }
     cb(ctx);
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/load/routineload/KafkaRoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/routineload/KafkaRoutineLoadJob.java
@@ -61,9 +61,9 @@ import java.io.DataOutput;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.HashMap;
 import java.util.TimeZone;
 import java.util.UUID;
 
@@ -75,6 +75,7 @@ public class KafkaRoutineLoadJob extends RoutineLoadJob {
     private static final Logger LOG = LogManager.getLogger(KafkaRoutineLoadJob.class);
 
     public static final String KAFKA_FILE_CATALOG = "kafka";
+    public static final String PROP_GROUP_ID = "group.id";
 
     private String brokerList;
     private String topic;
@@ -444,6 +445,10 @@ public class KafkaRoutineLoadJob extends RoutineLoadJob {
         }
         if (!stmt.getCustomKafkaProperties().isEmpty()) {
             setCustomKafkaProperties(stmt.getCustomKafkaProperties());
+        }
+        // set group id if not specified
+        if (!this.customProperties.containsKey(PROP_GROUP_ID)) {
+            this.customProperties.put(PROP_GROUP_ID, name + "_" + UUID.randomUUID().toString());
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/load/routineload/RoutineLoadManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/routineload/RoutineLoadManager.java
@@ -360,18 +360,21 @@ public class RoutineLoadManager implements Writable {
         try {
             Map<Long, Integer> beIdToConcurrentTasks = getBeCurrentTasksNumMap();
             // 1. Find if the given BE id has available slots
-            int idleTaskNum = 0;
-            if (beIdToConcurrentTasks.containsKey(previoudBeId)) {
-                idleTaskNum = beIdToMaxConcurrentTasks.get(previoudBeId) - beIdToConcurrentTasks.get(previoudBeId);
-            } else {
-                idleTaskNum = Config.max_routine_load_task_num_per_be;
-            }
-            if (idleTaskNum > 0) {
-                return previoudBeId;
+            if (previoudBeId != -1L) {
+                int idleTaskNum = 0;
+                if (beIdToConcurrentTasks.containsKey(previoudBeId)) {
+                    idleTaskNum = beIdToMaxConcurrentTasks.get(previoudBeId) - beIdToConcurrentTasks.get(previoudBeId);
+                } else {
+                    idleTaskNum = Config.max_routine_load_task_num_per_be;
+                }
+                if (idleTaskNum > 0) {
+                    return previoudBeId;
+                }
             }
 
             // 2. The given BE id does not have available slots, find a BE with min tasks
             updateBeIdToMaxConcurrentTasks();
+            int idleTaskNum = 0;
             long resultBeId = -1L;
             int maxIdleSlotNum = 0;
             for (Long beId : beIdsInCluster) {

--- a/fe/fe-core/src/test/java/org/apache/doris/load/routineload/RoutineLoadManagerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/load/routineload/RoutineLoadManagerTest.java
@@ -17,12 +17,12 @@
 
 package org.apache.doris.load.routineload;
 
-import org.apache.doris.analysis.Separator;
 import org.apache.doris.analysis.CreateRoutineLoadStmt;
 import org.apache.doris.analysis.LabelName;
 import org.apache.doris.analysis.ParseNode;
 import org.apache.doris.analysis.PauseRoutineLoadStmt;
 import org.apache.doris.analysis.ResumeRoutineLoadStmt;
+import org.apache.doris.analysis.Separator;
 import org.apache.doris.analysis.StopRoutineLoadStmt;
 import org.apache.doris.analysis.TableName;
 import org.apache.doris.catalog.Catalog;
@@ -739,7 +739,7 @@ public class RoutineLoadManagerTest {
         RoutineLoadManager routineLoadManager = new RoutineLoadManager();
         Config.max_routine_load_task_num_per_be = 10;
         Deencapsulation.setField(routineLoadManager, "beIdToMaxConcurrentTasks", beIdToMaxConcurrentTasks);
-        Assert.assertEquals(true, routineLoadManager.checkBeToTask(1L, "default"));
+        Assert.assertEquals(1L, routineLoadManager.getAvailableBeForTask(1L, "default"));
     }
 
     @Test


### PR DESCRIPTION
## Proposed changes

Use `commitAsync` to commit offset to kafka, instread of using `commitSync`, which may block for a long time.
Also assign a group.id to routine load if user not specified "property.group.id" property, so that all consumer of
this job will use same group.id instead of a random id for each consume task.

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Code refactor (Modify the code structure, format the code, etc...)
- [ ] Optimization. Including functional usability improvements and performance improvements.
- [ ] Dependency. Such as changes related to third-party components.
- [ ] Other.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have created an issue on (Fix #6340) and described the bug/feature there in detail
- [ ] Compiling and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If these changes need document changes, I have updated the document
- [ ] Any dependent changes have been merged

## Further comments

If this is a relatively large or complex change, kick off the discussion at dev@doris.apache.org by explaining why you chose the solution you did and what alternatives you considered, etc...
