### PR TITLE
[Bug] fix violating C/C++ aliasing rules cause a error hash value in …

### DIFF
--- a/be/src/exprs/bloomfilter_predicate.h
+++ b/be/src/exprs/bloomfilter_predicate.h
@@ -26,7 +26,9 @@
 #include "exprs/block_bloom_filter.hpp"
 #include "exprs/predicate.h"
 #include "olap/bloom_filter.hpp"
+#include "olap/decimal12.h"
 #include "olap/rowset/segment_v2/bloom_filter.h"
+#include "olap/uint24.h"
 #include "runtime/mem_tracker.h"
 #include "runtime/raw_value.h"
 
@@ -223,30 +225,38 @@ struct DateTimeFindOp : public CommonFindOp<DateTimeValue, BloomFilterAdaptor> {
     }
 };
 
+// avoid violating C/C++ aliasing rules.
+// https://gcc.gnu.org/bugzilla/show_bug.cgi?id=101684
+
 template <class BloomFilterAdaptor>
 struct DateFindOp : public CommonFindOp<DateTimeValue, BloomFilterAdaptor> {
     bool find_olap_engine(const BloomFilterAdaptor& bloom_filter, const void* data) const {
-        uint64_t value = 0;
-        value = *(unsigned char*)((char*)data + 2);
-        value <<= 8;
-        value |= *(unsigned char*)((char*)data + 1);
-        value <<= 8;
-        value |= *(unsigned char*)((char*)data);
+        uint24_t date = *static_cast<const uint24_t*>(data);
+        uint64_t value = uint32_t(date);
+
         DateTimeValue date_value;
         date_value.from_olap_date(value);
         date_value.to_datetime();
-        return bloom_filter.test_bytes((char*)&date_value, sizeof(DateTimeValue));
+
+        char data_bytes[sizeof(date_value)];
+        memcpy(&data_bytes, &date_value, sizeof(date_value));
+        return bloom_filter.test_bytes(data_bytes, sizeof(DateTimeValue));
     }
 };
 
 template <class BloomFilterAdaptor>
-struct DecimalV2FindOp : public CommonFindOp<DateTimeValue, BloomFilterAdaptor> {
+struct DecimalV2FindOp : public CommonFindOp<DecimalV2Value, BloomFilterAdaptor> {
     bool find_olap_engine(const BloomFilterAdaptor& bloom_filter, const void* data) const {
+        auto packed_decimal = *static_cast<const decimal12_t*>(data);
         DecimalV2Value value;
-        int64_t int_value = *(int64_t*)(data);
-        int32_t frac_value = *(int32_t*)((char*)data + sizeof(int64_t));
+        int64_t int_value = packed_decimal.integer;
+        int32_t frac_value = packed_decimal.fraction;
         value.from_olap_decimal(int_value, frac_value);
-        return bloom_filter.test_bytes((char*)&value, sizeof(DecimalV2Value));
+
+        constexpr int decimal_value_sz = sizeof(DecimalV2Value);
+        char data_bytes[decimal_value_sz];
+        memcpy(&data_bytes, &value, decimal_value_sz);
+        return bloom_filter.test_bytes(data_bytes, decimal_value_sz);
     }
 };
 

--- a/be/src/olap/rowset/segment_v2/bloom_filter_index_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/bloom_filter_index_writer.cpp
@@ -48,14 +48,12 @@ struct BloomFilterTraits<Slice> {
 };
 
 struct Int128Comparator {
-    bool operator()(const PackedInt128& a, const PackedInt128& b) const {
-        return a.value < b.value;
-    }
+    bool operator()(const int128_t& a, const int128_t& b) const { return a < b; }
 };
 
 template <>
 struct BloomFilterTraits<int128_t> {
-    using ValueDict = std::set<PackedInt128, Int128Comparator>;
+    using ValueDict = std::set<int128_t, Int128Comparator>;
 };
 
 // Builder for bloom filter. In doris, bloom filter index is used in
@@ -90,9 +88,9 @@ public:
                     _typeinfo->deep_copy(&new_value, v, &_pool);
                     _values.insert(new_value);
                 } else if constexpr (_is_int128()) {
-                    PackedInt128 new_value;
-                    memcpy(&new_value.value, v, sizeof(PackedInt128));
-                    _values.insert((*reinterpret_cast<CppType*>(&new_value)));
+                    int128_t new_value;
+                    memcpy(&new_value, v, sizeof(PackedInt128));
+                    _values.insert(new_value);
                 } else {
                     _values.insert(*v);
                 }


### PR DESCRIPTION
…decimal value

In RuntimeFilter BloomFilter, decimal column will got a wrong hash value because violating  aliasing rules
decimal12_t decimal = { 12, 12 };
murmurhash3(decimal) in bloom filter: 2167721464
expect: 4203026776

## Proposed changes

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Code refactor (Modify the code structure, format the code, etc...)
- [ ] Optimization. Including functional usability improvements and performance improvements.
- [ ] Dependency. Such as changes related to third-party components.
- [ ] Other.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have created an issue on (Fix #6345 ) and described the bug/feature there in detail
- [x] Compiling and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If these changes need document changes, I have updated the document
- [ ] Any dependent changes have been merged

## Further comments

If this is a relatively large or complex change, kick off the discussion at dev@doris.apache.org by explaining why you chose the solution you did and what alternatives you considered, etc...
