### PR TITLE
[Bug][Bloom Filter] Fix bug of bloom filter null value flag not be reset

### DIFF
--- a/be/src/olap/rowset/segment_v2/bloom_filter_index_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/bloom_filter_index_writer.cpp
@@ -117,6 +117,7 @@ public:
         _bf_buffer_size += bf->size();
         _bfs.push_back(std::move(bf));
         _values.clear();
+        _has_null = false;
         return Status::OK();
     }
 


### PR DESCRIPTION
## Proposed changes

Fix #6366 

There is a bloom filter for each data page in a column which has bloom filter index. `_has_null` flag can help to judge whether `null` exists in a data page. If `null` value is added to a data page, `_has_null` will be set `true`. After bloom filter for a data page finished, `_has_null`should be reset to `false` to prepare for next data page.

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Code refactor (Modify the code structure, format the code, etc...)
- [ ] Optimization. Including functional usability improvements and performance improvements.
- [ ] Dependency. Such as changes related to third-party components.
- [ ] Other.
