### PR TITLE
[BUG] Fix query failure caused by using case-insensitive system view names in information_schema.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/Analyzer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/Analyzer.java
@@ -20,7 +20,6 @@ package org.apache.doris.analysis;
 import org.apache.doris.catalog.Catalog;
 import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.Database;
-import org.apache.doris.catalog.InfoSchemaDb;
 import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.catalog.OlapTable.OlapTableState;
 import org.apache.doris.catalog.Table;
@@ -553,7 +552,7 @@ public class Analyzer {
             ErrorReport.reportAnalysisException(ErrorCode.ERR_BAD_TABLE_STATE, "RESTORING");
         }
 
-        TableName tblName = new TableName(database.getFullName(), table.getName());
+        TableName tblName = new TableName(dbName, tableName.getTbl());
         if (table instanceof View) {
             return new InlineViewRef((View) table, tableRef);
         } else {
@@ -618,10 +617,6 @@ public class Analyzer {
         if (newTblName == null) {
             d = resolveColumnRef(colName);
         } else {
-            if (InfoSchemaDb.isInfoSchemaDb(newTblName.getDb())
-                    || (newTblName.getDb() == null && InfoSchemaDb.isInfoSchemaDb(getDefaultDb()))) {
-                newTblName = new TableName(newTblName.getDb(), newTblName.getTbl().toLowerCase());
-            }
             d = resolveColumnRef(newTblName, colName);
         }
         /*

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/Analyzer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/Analyzer.java
@@ -552,6 +552,12 @@ public class Analyzer {
             ErrorReport.reportAnalysisException(ErrorCode.ERR_BAD_TABLE_STATE, "RESTORING");
         }
 
+        // tableName.getTbl() stores the table name specified by the user in the from statement.
+        // In the case of case-sensitive table names, the value of tableName.getTbl() is the same as table.getName().
+        // However, since the system view is not case-sensitive, table.getName() gets the lowercase view name,
+        // which may not be the same as the user's reference to the table name, causing the table name not to be found
+        // in registerColumnRef(). So here the tblName is constructed using tableName.getTbl()
+        // instead of table.getName().
         TableName tblName = new TableName(dbName, tableName.getTbl());
         if (table instanceof View) {
             return new InlineViewRef((View) table, tableRef);

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/BaseTableRef.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/BaseTableRef.java
@@ -38,7 +38,7 @@ public class BaseTableRef extends TableRef {
         this.name = tableName;
         // Set implicit aliases if no explicit one was given.
         if (hasExplicitAlias()) return;
-        aliases_ = new String[] { name.toString(), tableName.getNoClusterString(), table.getName() };
+        aliases_ = new String[] { name.toString(), tableName.getNoClusterString(), tableName.getTbl() };
     }
 
     protected BaseTableRef(BaseTableRef other) {

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/SelectStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/SelectStmtTest.java
@@ -696,4 +696,11 @@ public class SelectStmtTest {
             Assert.fail(e.getMessage());
         }
     }
+
+    @Test
+    public void testSystemViewCaseInsensitive() throws Exception {
+        String sql = "SELECT ROUTINE_SCHEMA, ROUTINE_NAME FROM information_schema.ROUTINES WHERE ROUTINE_SCHEMA = " +
+                "'ech_dw' ORDER BY ROUTINES.ROUTINE_SCHEMA\n";
+        dorisAssert.query(sql).explainQuery();
+    }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/SelectStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/SelectStmtTest.java
@@ -699,8 +699,20 @@ public class SelectStmtTest {
 
     @Test
     public void testSystemViewCaseInsensitive() throws Exception {
-        String sql = "SELECT ROUTINE_SCHEMA, ROUTINE_NAME FROM information_schema.ROUTINES WHERE ROUTINE_SCHEMA = " +
+        String sql1 = "SELECT ROUTINE_SCHEMA, ROUTINE_NAME FROM information_schema.ROUTINES WHERE ROUTINE_SCHEMA = " +
                 "'ech_dw' ORDER BY ROUTINES.ROUTINE_SCHEMA\n";
-        dorisAssert.query(sql).explainQuery();
+        // The system view names in information_schema are case-insensitive,
+        dorisAssert.query(sql1).explainQuery();
+
+        String sql2 = "SELECT ROUTINE_SCHEMA, ROUTINE_NAME FROM information_schema.ROUTINES WHERE ROUTINE_SCHEMA = " +
+                "'ech_dw' ORDER BY routines.ROUTINE_SCHEMA\n";
+        try {
+            // Should not refer to one of system views using different cases within the same statement.
+            // sql2 is wrong because 'ROUTINES' and 'routines' are used.
+            dorisAssert.query(sql2).explainQuery();
+            Assert.fail("Refer to one of system views using different cases within the same statement is wrong.");
+        } catch (AnalysisException e) {
+            System.out.println(e.getMessage());
+        }
     }
 }


### PR DESCRIPTION
## Proposed changes

fix #6369

The system view names in information_schema are case-insensitive, but you should not refer to one of these using different cases within the same statement.  

The following sql is correct：
```
select * from information_schema.TAbles where TAbles.ENGINE = 'Doris';
```

The following sql is wrong because `TAbles` and `tables` are used:
```
select * from information_schema.TAbles order by tables.CREATE_TIME;
```

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Code refactor (Modify the code structure, format the code, etc...)
- [ ] Optimization. Including functional usability improvements and performance improvements.
- [ ] Dependency. Such as changes related to third-party components.
- [ ] Other.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have created an issue on (Fix #6369) and described the bug/feature there in detail
- [x] Compiling and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If these changes need document changes, I have updated the document
- [ ] Any dependent changes have been merged

## Further comments

If this is a relatively large or complex change, kick off the discussion at dev@doris.apache.org by explaining why you chose the solution you did and what alternatives you considered, etc...
