### PR TITLE
[BUG] Fixed the materialized number of resultExprs/constExprs and output slot of Union Node is inconsistent.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/planner/DistributedPlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/DistributedPlanner.java
@@ -840,7 +840,6 @@ public class DistributedPlanner {
             childFragment.setOutputPartition(
                     DataPartition.hashPartitioned(setOperationNode.getMaterializedResultExprLists_().get(i)));
         }
-        setOperationNode.init(ctx_.getRootAnalyzer());
         return setOperationFragment;
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/planner/PlannerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/planner/PlannerTest.java
@@ -251,6 +251,28 @@ public class PlannerTest {
                 .getPlanRoot().getChild(0) instanceof AggregationNode);
         Assert.assertTrue(fragments10.get(0).getPlanRoot()
                 .getFragment().getPlanRoot().getChild(1) instanceof UnionNode);
+
+        String sql11 = "SELECT a.x FROM\n" +
+                "(SELECT '01' x) a \n" +
+                "INNER JOIN\n" +
+                "(SELECT '01' x UNION all SELECT '02') b";
+        StmtExecutor stmtExecutor11 = new StmtExecutor(ctx, sql11);
+        stmtExecutor11.execute();
+        Planner planner11 = stmtExecutor11.planner();
+        SetOperationNode setNode11 = (SetOperationNode)(planner11.getFragments().get(1).getPlanRoot());
+        Assert.assertEquals(2, setNode11.getMaterializedConstExprLists_().size());
+
+        String sql12 = "SELECT a.x \n" +
+                "FROM (SELECT '01' x) a \n" +
+                "INNER JOIN \n" +
+                "(SELECT k1 from db1.tbl1 \n" +
+                "UNION all \n" +
+                "SELECT k1 from db1.tbl1) b;";
+        StmtExecutor stmtExecutor12 = new StmtExecutor(ctx, sql12);
+        stmtExecutor12.execute();
+        Planner planner12 = stmtExecutor12.planner();
+        SetOperationNode setNode12 = (SetOperationNode)(planner12.getFragments().get(1).getPlanRoot());
+        Assert.assertEquals(2, setNode12.getMaterializedResultExprLists_().size());
     }
 
     @Test


### PR DESCRIPTION
## Proposed changes
fix #6327
### Analysis
#### First case
```
SELECT a.x FROM
(SELECT '01' x) a 
INNER JOIN
(SELECT '01' x UNION all SELECT '02') b
```
The length of the tnode.union_node.const_expr_lists obtained by BE UnionNode is not equal to the length of the materialized slots of the tuple.
In UnionNode::prepare, DCHECK_EQ(exprs.size(), _tuple_desc->slots().size()); will prompt.

#### Second case
```
SELECT a.x 
FROM (SELECT '01' x) a 
INNER JOIN 
(SELECT C_CUSTKEY from CUSTOMER 
UNION all 
SELECT C_CUSTKEY from CUSTOMER) b;
```
materializedResultExprs is empty when new DataPartition() in new setOperationFragment().

### The reason for materialized number of resultExprs/constExprs and output slot of Union Node is inconsistent:
The reason is that select stmt and on-clause does not contain the slot of the union node on the build side of Join, so no slot in the union node tuple is materialized during sql parse.

After the union node on the join build side is created, when calling SetOperationNode::init(), it will decide which resultExprs/constExprs to put into the materializedResultExprs/materializedConstExprs according to the materialized slot, because no slot is materialized in the union node tuple, So materializedResultExprs/materializedConstExprs is empty.

After the join node itself is created, the materializeTableResultForCrossJoinOrCountStar() method is called to ensure that at least one slot of the join build side node tuple is materialized, so the slot corresponding to `x` in the union node tuple is materialized.

Under normal circumstances, will call SetOperationNode::init() again at the end of createSetOperationNodeFragment() to update materializedResultExprs/materializedConstExprs. to ensure that eventually the resultExprs/constExprs and the corresponding output slot have the same materialized state.

In the first case, because the slot of the union node only has constants, `setOperationNode.getChildren().isEmpty()=true`, will not call SetOperationNode::init() again at the end of createSetOperationNodeFragment(), resulting in the number of materialized slots being different from the number of materializedConstExprs.

In the second case, new setOperationFragment() before calling SetOperationNode::init() again

### Solution
Moved computePassthrough() and the materialized position of resultExprs/constExprs from this.init to this.finalize, and will not call SetOperationNode::init() again at the end of createSetOperationNodeFragment().

#### Reasons for move computePassthrough():
Because the byteSize of the tuple corresponding to OlapScanNode is updated after singleNodePlanner.createSingleNodePlan() and before singleNodePlan.finalize(), calling computePassthrough() in SetOperationNode::init() may not be able to accurately determine whether the child is pass through. In the previous logic , Will call SetOperationNode::init() again at the end of createSetOperationNodeFragment().

#### Reasons for move materialized position of resultExprs/constExprs:
Because the output slot is materialized at various positions in the planner stage, this is to ensure that eventually the resultExprs/constExprs and the corresponding output slot have the same materialized state.
And the order of materialized resultExprs must be the same as the order of children adjusted by computePassthrough(), so resultExprs materialized must be placed after computePassthrough().

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Code refactor (Modify the code structure, format the code, etc...)
- [ ] Optimization. Including functional usability improvements and performance improvements.
- [ ] Dependency. Such as changes related to third-party components.
- [ ] Other.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have created an issue on (Fix #6327) and described the bug/feature there in detail
- [x] Compiling and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If these changes need document changes, I have updated the document
- [ ] Any dependent changes have been merged

## Further comments

If this is a relatively large or complex change, kick off the discussion at dev@doris.apache.org by explaining why you chose the solution you did and what alternatives you considered, etc...
