### PR TITLE
[bugfix] issue-6390 , wrong result in query view with an added null column

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/IsNullPredicate.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/IsNullPredicate.java
@@ -132,4 +132,16 @@ public class IsNullPredicate extends Predicate {
     public boolean isNullable() {
         return false;
     }
+    /**
+     * fix issue 6390
+     */
+    @Override
+    public Expr getResultValue() throws AnalysisException {
+        recursiveResetChildrenResult();
+        final Expr childValue = getChild(0);
+        if(!(childValue instanceof LiteralExpr)) {
+            return this;
+        }
+        return childValue instanceof NullLiteral ? new BoolLiteral(!isNotNull) : new BoolLiteral(isNotNull);
+    }
 }


### PR DESCRIPTION
## Proposed changes
Fix fe/fe-core/.../analysis  isNullpredicate.java ,add a getResultValue function to fix issue-6390

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Code refactor (Modify the code structure, format the code, etc...)
- [ ] Optimization. Including functional usability improvements and performance improvements.
- [ ] Dependency. Such as changes related to third-party components.
- [ ] Other.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have created an issue on (Fix #6390 ) and described the bug/feature there in detail
- [ ] Compiling and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If these changes need document changes, I have updated the document
- [ ] Any dependent changes have been merged

## Further comments

If this is a relatively large or complex change, kick off the discussion at dev@doris.apache.org by explaining why you chose the solution you did and what alternatives you considered, etc...
