### PR TITLE
[Metrics] Add broker load costTimestamp in metrics

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/LoadJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/LoadJob.java
@@ -99,6 +99,7 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
     protected long createTimestamp = System.currentTimeMillis();
     protected long loadStartTimestamp = -1;
     protected long finishTimestamp = -1;
+    protected long costTimestamp = 0;
 
     protected long transactionId;
     protected FailMsg failMsg;
@@ -281,6 +282,10 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
         return finishTimestamp;
     }
 
+    public long getCostTimestamp() {
+        return System.currentTimeMillis() - createTimestamp;
+    }
+
     public long getTransactionId() {
         return transactionId;
     }
@@ -296,6 +301,10 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
     public void setLoadFileInfo(int fileNum, long fileSize) {
         this.loadStatistic.fileNum = fileNum;
         this.loadStatistic.totalFileSizeB = fileSize;
+    }
+
+    public void setCreateTimestamp(long createTimestamp) {
+        this.createTimestamp = createTimestamp;
     }
 
     public TUniqueId getRequestId() {

--- a/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/LoadManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/LoadManager.java
@@ -436,6 +436,14 @@ public class LoadManager implements Writable{
         }
     }
 
+    public Map<Long, Map<String, List<LoadJob>>> getDbIdToLabelToLoadJobs() {
+        return dbIdToLabelToLoadJobs;
+    }
+
+    public Map<Long, LoadJob> getIdToLoadJob() {
+        return idToLoadJob;
+    }
+
     public void removeOldLoadJob() {
         long currentTimeMs = System.currentTimeMillis();
 

--- a/fe/fe-core/src/test/java/org/apache/doris/load/loadv2/LoadJobTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/load/loadv2/LoadJobTest.java
@@ -206,5 +206,12 @@ public class LoadJobTest {
         Assert.assertEquals(100, (int)Deencapsulation.getField(loadJob, "progress"));
         Assert.assertEquals(0, loadJob.idToTasks.size());
     }
+
+    @Test
+    public void testGetCostTimestamp() {
+        LoadJob loadJob = new BrokerLoadJob();
+        loadJob.setCreateTimestamp(1000L);
+        Assert.assertNotEquals(System.currentTimeMillis() - 1000L, (long) Deencapsulation.getField(loadJob, "costTimestamp"));
+    }
 }
 


### PR DESCRIPTION
## Proposed changes

According to issue #6414 .
We need a metric to show the cost timestamp of BROKER LOAD jobs when the state of the job is PENDING/ETL/LOADING/COMMITTED.

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Code refactor (Modify the code structure, format the code, etc...)
- [ ] Optimization. Including functional usability improvements and performance improvements.
- [ ] Dependency. Such as changes related to third-party components.
- [ ] Other.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x ] I have created an issue on (Fix #ISSUE) and described the bug/feature there in detail
- [x ] Compiling and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If these changes need document changes, I have updated the document
- [ ] Any dependent changes have been merged

## Further comments

If this is a relatively large or complex change, kick off the discussion at dev@doris.apache.org by explaining why you chose the solution you did and what alternatives you considered, etc...
