### PR TITLE
[Bug] Regularly clean up old DeleteInfos in the DeleteHandler

### DIFF
--- a/docs/en/administrator-guide/config/fe_config.md
+++ b/docs/en/administrator-guide/config/fe_config.md
@@ -1986,7 +1986,7 @@ IsMutable：true
 
 MasterOnly：true
 
-abels of finished or cancelled load jobs will be removed after *label_keep_max_second* ， The removed labels can be reused.  Set a short time will lower the FE memory usage.  (Because all load jobs' info is kept in memory before being removed)
+labels of finished or cancelled load jobs will be removed after *label_keep_max_second* ， The removed labels can be reused.  Set a short time will lower the FE memory usage.  (Because all load jobs' info is kept in memory before being removed)
 
 In the case of high concurrent writes, if there is a large backlog of jobs and call frontend service failed, check the log. If the metadata write takes too long to lock, you can adjust this value to 12 hours, or 6 hours less
 
@@ -2016,6 +2016,16 @@ Default：4 * 3600  （4 hour）
 
 Load label cleaner will run every *label_clean_interval_second* to clean the outdated jobs.
 
+### delete_info_keep_max_second
+
+Default：3 * 24 * 3600  (3day)
+
+IsMutable：true
+
+MasterOnly：false
+
+Delete all deleteInfo older than *delete_info_keep_max_second* , Setting a shorter time will reduce FE memory usage and image file size. (Because all deleteInfo is stored in memory and image files before being deleted)
+
 ### transaction_clean_interval_second
 
 Default：30
@@ -2023,7 +2033,7 @@ Default：30
 the transaction will be cleaned after transaction_clean_interval_second seconds if the transaction is visible or aborted  we should make this interval as short as possible and each clean cycle as soon as possible
 
 
-### `default_max_query_instances`
+### default_max_query_instances
 
 The default value when user property max_query_instances is equal or less than 0. This config is used to limit the max number of instances for a user. This parameter is less than or equal to 0 means unlimited.
 

--- a/docs/zh-CN/administrator-guide/config/fe_config.md
+++ b/docs/zh-CN/administrator-guide/config/fe_config.md
@@ -2024,6 +2024,18 @@ HOUR: log前缀是：yyyyMMddHH
 
 load 标签清理器将每隔 `label_clean_interval_second` 运行一次以清理过时的作业。
 
+### delete_info_keep_max_second
+
+默认值：3 * 24 * 3600  (3天)
+
+是否可以动态配置：true
+
+是否为 Master FE 节点独有的配置项：false
+
+删除元数据中创建时间大于`delete_info_keep_max_second`的delete信息。
+
+设置较短的时间将减少 FE 内存使用量和镜像文件大小。（因为所有的deleteInfo在被删除之前都存储在内存和镜像文件中）
+
 ### transaction_clean_interval_second
 
 默认值：30
@@ -2031,7 +2043,7 @@ load 标签清理器将每隔 `label_clean_interval_second` 运行一次以清�
 如果事务 visible 或者 aborted 状态，事务将在 `transaction_clean_interval_second` 秒后被清除 ，我们应该让这个间隔尽可能短，每个清洁周期都尽快
 
 
-### `default_max_query_instances`
+### default_max_query_instances
 
 默认值：-1
 

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowDeleteStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowDeleteStmt.java
@@ -80,4 +80,8 @@ public class ShowDeleteStmt extends ShowStmt {
         return toSql();
     }
 
+    @Override
+    public RedirectStatus getRedirectStatus() {
+        return RedirectStatus.FORWARD_NO_SYNC;
+    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Catalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Catalog.java
@@ -2197,6 +2197,7 @@ public class Catalog {
                 load.removeOldLoadJobs();
                 loadManager.removeOldLoadJob();
                 exportMgr.removeOldExportJobs();
+                deleteHandler.removeOldDeleteInfos(new Timestamp());
             }
         };
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/Config.java
@@ -154,6 +154,14 @@ public class Config extends ConfigBase {
     @ConfField public static int label_clean_interval_second = 4 * 3600; // 4 hours
 
     /**
+     * Delete all deleteInfo older than *delete_info_keep_max_second*
+     * Setting a shorter time will reduce FE memory usage and image file size
+     * (Because all deleteInfo is stored in memory and image files before being deleted)
+     */
+    @ConfField(mutable = true)
+    public static int delete_info_keep_max_second = 3 * 24 * 3600; // 3 days
+
+    /**
      * the transaction will be cleaned after transaction_clean_interval_second seconds if the transaction is visible or aborted
      * we should make this interval as short as possible and each clean cycle as soon as possible
      */


### PR DESCRIPTION
## Proposed changes
fix https://github.com/apache/incubator-doris/issues/6447
1. FE master regularly triggers the remove operation
2. After the master completes the removal of deleteInfo, it is synchronized to the Follower through editlog for remove
3. When the DeleteInfo creation time is longer than the current time, it will be cleaned up, which is determined by the `delete_info_keep_max_second` configuration

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)
- [ ] Code refactor (Modify the code structure, format the code, etc...)
- [ ] Optimization. Including functional usability improvements and performance improvements.
- [ ] Dependency. Such as changes related to third-party components.
- [ ] Other.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have created an issue on (Fix #ISSUE) and described the bug/feature there in detail
- [x] Compiling and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] If these changes need document changes, I have updated the document
- [x] Any dependent changes have been merged

## Further comments

If this is a relatively large or complex change, kick off the discussion at dev@doris.apache.org by explaining why you chose the solution you did and what alternatives you considered, etc...
