### PR TITLE
[Bug] fix(sparkload): bitmap value in `or` operator in spark load should be deep copied

### DIFF
--- a/be/src/olap/push_handler.cpp
+++ b/be/src/olap/push_handler.cpp
@@ -150,7 +150,7 @@ OLAPStatus PushHandler::_do_streaming_ingestion(TabletSharedPtr tablet, const TP
     if (res != OLAP_SUCCESS) {
         LOG(WARNING) << "fail to convert tmp file when realtime push. res=" << res
                      << ", failed to process realtime push."
-                     << ", table=" << tablet->full_name()
+                     << ", tablet=" << tablet->full_name()
                      << ", transaction_id=" << request.transaction_id;
         for (TabletVars& tablet_var : *tablet_vars) {
             if (tablet_var.tablet == nullptr) {

--- a/fe/spark-dpp/src/main/java/org/apache/doris/load/loadv2/dpp/BitmapValue.java
+++ b/fe/spark-dpp/src/main/java/org/apache/doris/load/loadv2/dpp/BitmapValue.java
@@ -208,7 +208,9 @@ public class BitmapValue {
             case BITMAP_VALUE:
                 switch (this.bitmapType) {
                     case EMPTY:
-                        this.bitmap = other.bitmap;
+                        // deep copy the bitmap in case of multi-rollups update the bitmap repeatedly
+                        this.bitmap = new Roaring64Map();
+                        this.bitmap.or(other.bitmap);
                         this.bitmapType = BITMAP_VALUE;
                         break;
                     case SINGLE_VALUE:

--- a/fe/spark-dpp/src/test/java/org/apache/doris/load/loadv2/dpp/BitmapValueTest.java
+++ b/fe/spark-dpp/src/test/java/org/apache/doris/load/loadv2/dpp/BitmapValueTest.java
@@ -462,6 +462,30 @@ public class BitmapValueTest {
         Assert.assertFalse(bitmapValue.equals(bitmapValue1));
     }
 
+
+    @Test
+    public void testBitmapOrDeepCopy(){
+        // this test is added for issue #6452
+        // baseIndex bitmap == Roaring64Map
+        BitmapValue baseIndex1 = new BitmapValue();
+        baseIndex1.add(1L);
+        baseIndex1.add(2L);
+        //rollupIndex bitmap == Roaring64Map
+        BitmapValue rollup1 = new BitmapValue();
+        rollup1.add(3L);
+        rollup1.add(4L);
+        Assert.assertTrue(rollup1.getBitmapType() == BitmapValue.BITMAP_VALUE);
+        BitmapValue merge = new BitmapValue();
+        // or operator is supposed to deep copy Roaring64Map object
+        merge.or(baseIndex1);
+        merge.or(rollup1);
+        Assert.assertTrue(merge.getBitmapType() == BitmapValue.BITMAP_VALUE);
+
+        Assert.assertTrue(baseIndex1.cardinality() == 2L);
+        Assert.assertTrue(rollup1.cardinality() == 2L);
+        Assert.assertTrue(merge.cardinality() == 4L);
+    }
+
     @Test
     public void testToString() {
         BitmapValue empty = new BitmapValue();


### PR DESCRIPTION
fix multi rollup hold the same Ref of bitmapvalue which may be updated repeatedly.

fix #6452 
## Proposed changes

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Code refactor (Modify the code structure, format the code, etc...)
- [ ] Optimization. Including functional usability improvements and performance improvements.
- [ ] Dependency. Such as changes related to third-party components.
- [ ] Other.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have created an issue on (Fix #ISSUE) and described the bug/feature there in detail
- [ ] Compiling and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If these changes need document changes, I have updated the document
- [ ] Any dependent changes have been merged

## Further comments

If this is a relatively large or complex change, kick off the discussion at dev@doris.apache.org by explaining why you chose the solution you did and what alternatives you considered, etc...
