### PR TITLE
[Feature] feature(sparkload): support bitmap binary data from hive in spark load

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/SparkLoadPendingTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/SparkLoadPendingTask.java
@@ -555,7 +555,8 @@ public class SparkLoadPendingTask extends LoadTask {
         String functionName = fn.getFnName().getFunction();
         if (!functionName.equalsIgnoreCase("to_bitmap")
                 && !functionName.equalsIgnoreCase("bitmap_hash")
-                && !functionName.equalsIgnoreCase("bitmap_dict")) {
+                && !functionName.equalsIgnoreCase("bitmap_dict")
+                && !functionName.equalsIgnoreCase("binary_bitmap")) {
             throw new LoadException(msg);
         }
 

--- a/fe/spark-dpp/src/main/java/org/apache/doris/load/loadv2/dpp/DppUtils.java
+++ b/fe/spark-dpp/src/main/java/org/apache/doris/load/loadv2/dpp/DppUtils.java
@@ -36,6 +36,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
+import java.util.Set;
 import java.util.zip.CRC32;
 
 public class DppUtils {
@@ -193,6 +194,19 @@ public class DppUtils {
             hashValue.update(buffer.array(), 0, buffer.limit());
         }
         return hashValue.getValue();
+    }
+
+    public static StructType replaceBinaryColsInSchema(Set<String> binaryColumns, StructType dstSchema) {
+        List<StructField> fields = new ArrayList<>();
+        for (StructField originField : dstSchema.fields()) {
+            if (binaryColumns.contains(originField.name())) {
+                fields.add(DataTypes.createStructField(originField.name(), DataTypes.BinaryType, originField.nullable()));
+            } else {
+                fields.add(DataTypes.createStructField(originField.name(), originField.dataType(), originField.nullable()));
+            }
+        }
+        StructType ret = DataTypes.createStructType(fields);
+        return ret;
     }
 
     public static StructType createDstTableSchema(List<EtlJobConfig.EtlColumn> columns, boolean addBucketIdColumn, boolean regardDistinctColumnAsBinary) {


### PR DESCRIPTION
Support to load the binary data of bitmap value from Hive into Doris.

fix #6461 

## Proposed changes

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Code refactor (Modify the code structure, format the code, etc...)
- [ ] Optimization. Including functional usability improvements and performance improvements.
- [ ] Dependency. Such as changes related to third-party components.
- [ ] Other.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have created an issue on (Fix #ISSUE) and described the bug/feature there in detail
- [ ] Compiling and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If these changes need document changes, I have updated the document
- [ ] Any dependent changes have been merged

## Further comments

If this is a relatively large or complex change, kick off the discussion at dev@doris.apache.org by explaining why you chose the solution you did and what alternatives you considered, etc...
