### PR TITLE
[Optimize][Clone] Take version count into consideration when choosing src replica for clone task

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/clone/TabletSchedCtx.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/TabletSchedCtx.java
@@ -490,7 +490,7 @@ public class TabletSchedCtx implements Comparable<TabletSchedCtx> {
             throw new SchedException(Status.UNRECOVERABLE, "unable to find source replica");
         }
 
-        long minVersionCount = -1;
+        long minVersionCount = -2;
         boolean findSrcReplica = false;
         // choose a replica which slot is available from candidates.
         for (Replica srcReplica : candidates) {
@@ -501,10 +501,20 @@ public class TabletSchedCtx implements Comparable<TabletSchedCtx> {
             
             long srcPathHash = slot.takeSlot(srcReplica.getPathHash());
             if (srcPathHash != -1) {
-                if (minVersionCount == -1 || srcReplica.getVersionCount() < minVersionCount) {
+                findSrcReplica = true;
+                if (minVersionCount == -2) {
                     minVersionCount = srcReplica.getVersionCount();
                     setSrc(srcReplica);
-                    findSrcReplica = true;
+                } else if (minVersionCount == -1) {
+                    if (srcReplica.getVersionCount() != -1) {
+                        minVersionCount = srcReplica.getVersionCount();
+                        setSrc(srcReplica);
+                    }
+                } else {
+                    if (srcReplica.getVersionCount() != -1 && srcReplica.getVersionCount() < minVersionCount) {
+                        minVersionCount = srcReplica.getVersionCount();
+                        setSrc(srcReplica);
+                    }
                 }
             }
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/clone/TabletSchedCtx.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/TabletSchedCtx.java
@@ -501,10 +501,10 @@ public class TabletSchedCtx implements Comparable<TabletSchedCtx> {
             
             long srcPathHash = slot.takeSlot(srcReplica.getPathHash());
             if (srcPathHash != -1) {
-                findSrcReplica = true;
                 if (minVersionCount == -1 || srcReplica.getVersionCount() < minVersionCount) {
                     minVersionCount = srcReplica.getVersionCount();
                     setSrc(srcReplica);
+                    findSrcReplica = true;
                 }
             }
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/clone/TabletSchedCtx.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/TabletSchedCtx.java
@@ -502,12 +502,12 @@ public class TabletSchedCtx implements Comparable<TabletSchedCtx> {
             long srcPathHash = slot.takeSlot(srcReplica.getPathHash());
             if (srcPathHash != -1) {
                 if (!findSrcReplica) {
+                    // version count is set by report process, so it may not be set yet and default value is -1.
+                    // so we need to check it.
                     minVersionCount = srcReplica.getVersionCount() == -1 ? Long.MAX_VALUE : srcReplica.getVersionCount();
                     setSrc(srcReplica);
                     findSrcReplica = true;
                 } else {
-                    // version count is set by report process, so it may not be set yet and default value is -1.
-                    // so we need to check it.
                     long curVerCount = srcReplica.getVersionCount() == -1 ? Long.MAX_VALUE : srcReplica.getVersionCount();
                     if (curVerCount < minVersionCount) {
                         minVersionCount = curVerCount;


### PR DESCRIPTION
## Proposed changes

Fix #6512 

If there is missing replica for a tablet, clone task will be executed to restore missing replica from a healthy replica. Src replica selector will randomly choose a healthy replica as src replica.

It's better to choose the health replica with minmun version count as src replica so that it could avoid repetitive compaction task. In addition, replica with less version count is good for query performance.

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Code refactor (Modify the code structure, format the code, etc...)
- [x] Optimization. Including functional usability improvements and performance improvements.
- [ ] Dependency. Such as changes related to third-party components.
- [ ] Other.

