### PR TITLE
[Memory] BitShufflePageDecoder use memory allocated by ChunkAllocator instead of Faststring

### DIFF
--- a/be/src/runtime/memory/chunk_allocator.h
+++ b/be/src/runtime/memory/chunk_allocator.h
@@ -65,6 +65,8 @@ public:
     // Otherwise return false.
     bool allocate(size_t size, Chunk* chunk);
 
+    bool allocate_align(size_t size, Chunk* chunk);
+
     // Free chunk allocated from this allocator
     void free(const Chunk& chunk);
 


### PR DESCRIPTION
## Proposed changes

BitShufflePageDecoder reuses the memory for storing decoder results, allocate memory directly from the `ChunkAllocator`, the performance is improved to a certain extent.

In the case of #6285, the total time consumption is reduced by 13.5%, and the time consumption ratio of `~Reader()` has also been reduced from 17.65% to 1.53%, and the memory allocation is unified to `ChunkAllocator` for centralized management , Which is conducive to subsequent memory optimization.

which can avoid the memory waste caused by `Mempool`, because the chunk can be free at any time, but the performance is lower than the allocation from `Mempool`. The guess is that there is no `Mempool` after secondary allocation of large chunks , Will directly apply for a large number of small chunks from `ChunkAllocator`, and it takes longer to lock in `pop_free_chunk` and `push_free_chunk` (but this is not proven from the flame graphs of BE's cpu and contention).

Average time: 1032s (jmeter test, see issue #6285 for environment and configuration,  2021.10.08)
![image](https://user-images.githubusercontent.com/13197424/136552999-4cf97f6d-6796-43bf-87b1-32dd7cdedc75.png)

## Some previous attempts

### 1. Memory allocated by Mempool instead of Faststring.

Average time: 971s
![image](https://user-images.githubusercontent.com/13197424/136556086-dfede2b3-7fd4-4f5d-9700-6041c7dd5850.png)

But this will cause the memory requested in BitShufflePageDecoder to be released uniformly when FileColumnIterator is destructed, resulting in a waste of memory.

### 2. Reuse the Faststring object

Create a faststring object in FileColumnIterator, and then pass the pointer to each page BitShufflePageDecoder. The length of each decode in BitShufflePageDecoder is variable. If the length is insufficient during faststring resize, the capacity will be expanded, otherwise it will be reused directly. 

In theory, the results of all page decodes in a FileColumnIterator are roughly the same, so there should be no memory waste problem. However, the performance of reusing faststring is lower than using mempool to allocate cached memory. 

![image](https://user-images.githubusercontent.com/13197424/131029731-0e24ace1-e416-4bca-b6da-bd9b3dc138e3.png)
![image](https://user-images.githubusercontent.com/13197424/131029697-1ef301b2-6219-4264-85a9-43d127abdb17.png)

### 3. Modify Faststring to allocate space from Mempool

Currently Faststring allocates space through `new`

![faststring_test_all_no_leng](https://user-images.githubusercontent.com/13197424/126459746-ca039c96-14ea-46a2-b157-76c98030a580.png)
![faststring_test_faststring_noleng](https://user-images.githubusercontent.com/13197424/126459767-b5bd54be-cca2-423c-8c06-a7beb0be0a25.png)

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Code refactor (Modify the code structure, format the code, etc...)
- [x] Optimization. Including functional usability improvements and performance improvements.
- [ ] Dependency. Such as changes related to third-party components.
- [ ] Other.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have created an issue on (Fix #6285) and described the bug/feature there in detail
- [x] Compiling and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If these changes need document changes, I have updated the document
- [ ] Any dependent changes have been merged

## Further comments

If this is a relatively large or complex change, kick off the discussion at dev@doris.apache.org by explaining why you chose the solution you did and what alternatives you considered, etc...
