### PR TITLE
[BUG]Join query result is unstable when the predicate is pushed down to exchange node

### DIFF
--- a/be/src/exprs/tuple_is_null_predicate.cpp
+++ b/be/src/exprs/tuple_is_null_predicate.cpp
@@ -33,6 +33,7 @@ Status TupleIsNullPredicate::prepare(RuntimeState* state, const RowDescriptor& r
     RETURN_IF_ERROR(Expr::prepare(state, row_desc, ctx));
     DCHECK_EQ(0, _children.size());
 
+    _tuple_idxs.clear();
     // Resolve tuple ids to tuple indexes.
     for (int i = 0; i < _tuple_ids.size(); ++i) {
         int32_t tuple_idx = row_desc.get_tuple_idx(_tuple_ids[i]);


### PR DESCRIPTION
## Proposed changes

fix #6525

This should be a problem until the Runtime Filter version.


## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Code refactor (Modify the code structure, format the code, etc...)
- [ ] Optimization. Including functional usability improvements and performance improvements.
- [ ] Dependency. Such as changes related to third-party components.
- [ ] Other.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have created an issue on (Fix #6525) and described the bug/feature there in detail
- [ ] Compiling and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If these changes need document changes, I have updated the document
- [ ] Any dependent changes have been merged

## Further comments

If this is a relatively large or complex change, kick off the discussion at dev@doris.apache.org by explaining why you chose the solution you did and what alternatives you considered, etc...
