### PR TITLE
[Refactor][Compaction] Produce compaction tasks for all disks by visiting full tablets once

### DIFF
--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -690,14 +690,14 @@ bool Tablet::version_for_load_deletion(const Version& version) {
     return rowset->delete_flag();
 }
 
-bool Tablet::can_do_compaction(size_t path_hash, CompactionType compaction_type) {
+bool Tablet::can_do_compaction(CompactionType compaction_type) {
     if (compaction_type == CompactionType::BASE_COMPACTION && tablet_state() != TABLET_RUNNING) {
         // base compaction can only be done for tablet in TABLET_RUNNING state.
         // but cumulative compaction can be done for TABLET_NOTREADY, such as tablet under alter process.
         return false;
     }
 
-    if (data_dir()->path_hash() != path_hash || !is_used() || !init_succeeded()) {
+    if (!is_used() || !init_succeeded()) {
         return false;
     }
 

--- a/be/src/olap/tablet.h
+++ b/be/src/olap/tablet.h
@@ -158,7 +158,7 @@ public:
     inline RWMutex* get_migration_lock_ptr() { return &_migration_lock; }
 
     // operation for compaction
-    bool can_do_compaction(size_t path_hash, CompactionType compaction_type);
+    bool can_do_compaction(CompactionType compaction_type);
     uint32_t calc_compaction_score(
             CompactionType compaction_type,
             std::shared_ptr<CumulativeCompactionPolicy> cumulative_compaction_policy);

--- a/be/src/olap/tablet_manager.h
+++ b/be/src/olap/tablet_manager.h
@@ -70,10 +70,11 @@ public:
 
     OLAPStatus drop_tablets_on_error_root_path(const std::vector<TabletInfo>& tablet_info_vec);
 
-    TabletSharedPtr find_best_tablet_to_compaction(
-            CompactionType compaction_type, DataDir* data_dir,
-            const std::unordered_set<TTabletId>& tablet_submitted_compaction, uint32_t* score,
-            std::shared_ptr<CumulativeCompactionPolicy> cumulative_compaction_policy);
+    std::map<DataDir*, TabletSharedPtr> find_best_tablet_to_compaction(
+            CompactionType compaction_type, const std::unordered_set<DataDir*>& disks_need_pick_tablet,
+            std::map<DataDir*, std::unordered_set<TTabletId>>& tablet_submitted_compaction,
+    uint32_t* max_score, std::shared_ptr<CumulativeCompactionPolicy> cumulative_compaction_policy,
+    bool check_score);
 
     TabletSharedPtr get_tablet(TTabletId tablet_id, SchemaHash schema_hash,
                                bool include_deleted = false, std::string* err = nullptr);

--- a/be/src/olap/tablet_manager.h
+++ b/be/src/olap/tablet_manager.h
@@ -70,11 +70,11 @@ public:
 
     OLAPStatus drop_tablets_on_error_root_path(const std::vector<TabletInfo>& tablet_info_vec);
 
-    std::map<DataDir*, TabletSharedPtr> find_best_tablet_to_compaction(
-            CompactionType compaction_type, const std::unordered_set<DataDir*>& disks_need_pick_tablet,
+    void find_best_tablet_to_compaction(
+            CompactionType compaction_type, std::map<DataDir*, TabletSharedPtr>* disk_best_tablet,
             std::map<DataDir*, std::unordered_set<TTabletId>>& tablet_submitted_compaction,
     uint32_t* max_score, std::shared_ptr<CumulativeCompactionPolicy> cumulative_compaction_policy,
-    bool check_score);
+    const bool check_score);
 
     TabletSharedPtr get_tablet(TTabletId tablet_id, SchemaHash schema_hash,
                                bool include_deleted = false, std::string* err = nullptr);


### PR DESCRIPTION
## Proposed changes

Compaction producer will produce compaction tasks for all disks in turn, and full tablets would be visited for each disk task. Maybe it's more elegant to produce compaction tasks for all disks by visiting full tablets once.

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [x] Code refactor (Modify the code structure, format the code, etc...)
- [ ] Optimization. Including functional usability improvements and performance improvements.
- [ ] Dependency. Such as changes related to third-party components.
- [ ] Other.

