### PR TITLE
[Bug] Fix dataTables bootstrap js version differ.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/http/action/WebBaseAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/http/action/WebBaseAction.java
@@ -67,12 +67,12 @@ public class WebBaseAction extends BaseAction {
             + "  rel=\"stylesheet\" media=\"screen\"/>"
             + "  <link href=\"/static/css?res=Bootstrap-3.3.7/css/bootstrap-theme.css\" "
             + "  rel=\"stylesheet\" media=\"screen\"/>"
-            + "  <link href=\"/static/css?res=DataTables-1.10.21/css/dataTables.bootstrap.css\" "
+            + "  <link href=\"/static/css?res=DataTables-1.10.23/css/dataTables.bootstrap.css\" "
             + "    rel=\"stylesheet\" media=\"screen\"/>"
 
             + "  <script type=\"text/javascript\" src=\"/static?res=jQuery-3.3.1/jquery-3.3.1.min.js\"></script>"
-            + "  <script type=\"text/javascript\" src=\"/static?res=DataTables-1.10.21/js/jquery.dataTables.js\"></script>"
-            + "  <script type=\"text/javascript\" src=\"/static?res=DataTables-1.10.21/js/dataTables.bootstrap.js\"></script>"
+            + "  <script type=\"text/javascript\" src=\"/static?res=DataTables-1.10.23/js/jquery.dataTables.js\"></script>"
+            + "  <script type=\"text/javascript\" src=\"/static?res=DataTables-1.10.23/js/dataTables.bootstrap.js\"></script>"
 
             + "  <script type=\"text/javascript\"> "
             + "    $(document).ready(function() { "


### PR DESCRIPTION

FE logs ERROR (nioEventLoopGroup-3-2|84) [StaticResourceAction.executeGet():160] Request with wrong path. url: /static?res=DataTables-1.10.21/js/dataTables.bootstrap.js
because dataTables bootstrap js version differ, The thirdparty/vars.sh is 1.10.23, The WebBaseAction.java is 1.10.21.
We can consider through configuration way to perfect it in the future.