### PR TITLE
[Feature]Use table buckets as dynamic partition buckets default value

### DIFF
--- a/docs/en/administrator-guide/dynamic-partition.md
+++ b/docs/en/administrator-guide/dynamic-partition.md
@@ -111,7 +111,7 @@ The rules of dynamic partition are prefixed with `dynamic_partition.`:
 
 * `dynamic_partition.buckets`
 
-    The number of buckets corresponding to the dynamically created partitions.
+    The number of buckets corresponding to the dynamically created partitions, If not filled in, defaults to the number of table's bucket.
 
 * `dynamic_partition.replication_num`
 

--- a/docs/zh-CN/administrator-guide/dynamic-partition.md
+++ b/docs/zh-CN/administrator-guide/dynamic-partition.md
@@ -109,7 +109,7 @@ under the License.
 
 * `dynamic_partition.buckets`
 
-    动态创建的分区所对应的分桶数量。
+    动态创建的分区所对应的分桶数量，如果不填写，则默认为创建表时指定的bucket数量。
 
 * `dynamic_partition.replication_num`
 

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Catalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Catalog.java
@@ -4135,7 +4135,7 @@ public class Catalog {
 
             // dynamic partition
             if (olapTable.dynamicPartitionExists()) {
-                sb.append(olapTable.getTableProperty().getDynamicPartitionProperty().getProperties(replicaAlloc));
+                sb.append(olapTable.getTableProperty().getDynamicPartitionProperty().getProperties(replicaAlloc, distributionInfo.getBucketNum()));
             }
 
             // in memory

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/DynamicPartitionProperty.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/DynamicPartitionProperty.java
@@ -48,6 +48,7 @@ public class DynamicPartitionProperty {
     public static final int MAX_END_OFFSET = Integer.MAX_VALUE;
     public static final int NOT_SET_REPLICATION_NUM = -1;
     public static final int NOT_SET_HISTORY_PARTITION_NUM = -1;
+    public static final int NOT_SET_BUCKETS = -1;
 
     private boolean exist;
 
@@ -78,7 +79,7 @@ public class DynamicPartitionProperty {
             this.start = Integer.parseInt(properties.getOrDefault(START, String.valueOf(MIN_START_OFFSET)));
             this.end = Integer.parseInt(properties.get(END));
             this.prefix = properties.get(PREFIX);
-            this.buckets = Integer.parseInt(properties.get(BUCKETS));
+            this.buckets = Integer.parseInt(properties.getOrDefault(BUCKETS, String.valueOf(NOT_SET_BUCKETS)));
             this.replicaAlloc = analyzeReplicaAllocation(properties);
             this.createHistoryPartition = Boolean.parseBoolean(properties.get(CREATE_HISTORY_PARTITION));
             this.historyPartitionNum = Integer.parseInt(properties.getOrDefault(HISTORY_PARTITION_NUM, String.valueOf(NOT_SET_HISTORY_PARTITION_NUM)));
@@ -182,9 +183,14 @@ public class DynamicPartitionProperty {
 
     /**
      * use table replication_num as dynamic_partition.replication_num default value
+     * use table buckets as dynamic_partition.buckets default value
      */
-    public String getProperties(ReplicaAllocation tableReplicaAlloc) {
+    public String getProperties(ReplicaAllocation tableReplicaAlloc, int tableBuckets) {
         ReplicaAllocation tmpAlloc = this.replicaAlloc.isNotSet() ? tableReplicaAlloc : this.replicaAlloc;
+        int useTableBuckets = buckets;
+        if(useTableBuckets == NOT_SET_BUCKETS){
+            useTableBuckets = tableBuckets;
+        }
         String res = ",\n\"" + ENABLE + "\" = \"" + enable + "\"" +
                 ",\n\"" + TIME_UNIT + "\" = \"" + timeUnit + "\"" +
                 ",\n\"" + TIME_ZONE + "\" = \"" + tz.getID() + "\"" +
@@ -192,7 +198,7 @@ public class DynamicPartitionProperty {
                 ",\n\"" + END + "\" = \"" + end + "\"" +
                 ",\n\"" + PREFIX + "\" = \"" + prefix + "\"" +
                 ",\n\"" + REPLICATION_ALLOCATION + "\" = \"" + tmpAlloc.toCreateStmt() + "\"" +
-                ",\n\"" + BUCKETS + "\" = \"" + buckets + "\"" +
+                ",\n\"" + BUCKETS + "\" = \"" + useTableBuckets + "\"" +
                 ",\n\"" + CREATE_HISTORY_PARTITION + "\" = \"" + createHistoryPartition + "\"" +
                 ",\n\"" + HISTORY_PARTITION_NUM + "\" = \"" + historyPartitionNum + "\"" +
                 ",\n\"" + HOT_PARTITION_NUM + "\" = \"" + hotPartitionNum + "\"";

--- a/fe/fe-core/src/main/java/org/apache/doris/clone/DynamicPartitionScheduler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/DynamicPartitionScheduler.java
@@ -226,7 +226,11 @@ public class DynamicPartitionScheduler extends MasterDaemon {
             for (Column distributionColumn : hashDistributionInfo.getDistributionColumns()) {
                 distColumnNames.add(distributionColumn.getName());
             }
-            DistributionDesc distributionDesc = new HashDistributionDesc(dynamicPartitionProperty.getBuckets(), distColumnNames);
+            int numBucket = dynamicPartitionProperty.getBuckets();
+            if (numBucket == DynamicPartitionProperty.NOT_SET_BUCKETS){
+                numBucket = hashDistributionInfo.getBucketNum();
+            }
+            DistributionDesc distributionDesc = new HashDistributionDesc(numBucket, distColumnNames);
 
             // add partition according to partition desc and distribution desc
             addPartitionClauses.add(new AddPartitionClause(rangePartitionDesc, distributionDesc, null, false));

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/DynamicPartitionUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/DynamicPartitionUtil.java
@@ -251,7 +251,6 @@ public class DynamicPartitionUtil {
         String start = properties.get(DynamicPartitionProperty.START);
         String timeZone = properties.get(DynamicPartitionProperty.TIME_ZONE);
         String end = properties.get(DynamicPartitionProperty.END);
-        String buckets = properties.get(DynamicPartitionProperty.BUCKETS);
         String enable = properties.get(DynamicPartitionProperty.ENABLE);
         String createHistoryPartition = properties.get(DynamicPartitionProperty.CREATE_HISTORY_PARTITION);
         String historyPartitionNum = properties.get(DynamicPartitionProperty.HISTORY_PARTITION_NUM);
@@ -261,7 +260,6 @@ public class DynamicPartitionUtil {
                 Strings.isNullOrEmpty(prefix) &&
                 Strings.isNullOrEmpty(start) &&
                 Strings.isNullOrEmpty(end) &&
-                Strings.isNullOrEmpty(buckets) &&
                 Strings.isNullOrEmpty(createHistoryPartition) &&
                 Strings.isNullOrEmpty(historyPartitionNum))) {
             if (Strings.isNullOrEmpty(enable)) {
@@ -278,9 +276,6 @@ public class DynamicPartitionUtil {
             }
             if (Strings.isNullOrEmpty(end)) {
                 throw new DdlException("Must assign dynamic_partition.end properties");
-            }
-            if (Strings.isNullOrEmpty(buckets)) {
-                throw new DdlException("Must assign dynamic_partition.buckets properties");
             }
             if (Strings.isNullOrEmpty(timeZone)) {
                 properties.put(DynamicPartitionProperty.TIME_ZONE, TimeUtils.getSystemTimeZone().getID());

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ShowExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ShowExecutor.java
@@ -1817,6 +1817,8 @@ public class ShowExecutor {
                     if (replicaAlloc.isNotSet()) {
                         replicaAlloc = olapTable.getDefaultReplicaAllocation();
                     }
+                    int buckets = dynamicPartitionProperty.getBuckets();
+                    buckets = (buckets == DynamicPartitionProperty.NOT_SET_BUCKETS) ? olapTable.getDefaultDistributionInfo().getBucketNum() : buckets;
                     rows.add(Lists.newArrayList(
                             tableName,
                             String.valueOf(dynamicPartitionProperty.getEnable()),
@@ -1824,7 +1826,7 @@ public class ShowExecutor {
                             String.valueOf(dynamicPartitionProperty.getStart()),
                             String.valueOf(dynamicPartitionProperty.getEnd()),
                             dynamicPartitionProperty.getPrefix(),
-                            String.valueOf(dynamicPartitionProperty.getBuckets()),
+                            String.valueOf(buckets),
                             String.valueOf(replicaAlloc.getTotalReplicaNum()),
                             replicaAlloc.toCreateStmt(),
                             dynamicPartitionProperty.getStartOfInfo(),

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/DynamicPartitionTableTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/DynamicPartitionTableTest.java
@@ -245,7 +245,7 @@ public class DynamicPartitionTableTest {
 
     @Test
     public void testMissBuckets() throws Exception {
-        String createOlapTblStmt = "CREATE TABLE test.`dynamic_partition_buckets` (\n" +
+        String createOlapTblStmt = "CREATE TABLE test.`dynamic_partition_none_buckets` (\n" +
                 "  `k1` date NULL COMMENT \"\",\n" +
                 "  `k2` int NULL COMMENT \"\",\n" +
                 "  `k3` smallint NULL COMMENT \"\",\n" +
@@ -269,9 +269,10 @@ public class DynamicPartitionTableTest {
                 "\"dynamic_partition.time_unit\" = \"day\",\n" +
                 "\"dynamic_partition.prefix\" = \"p\"\n" +
                 ");";
-        expectedException.expect(DdlException.class);
-        expectedException.expectMessage("errCode = 2, detailMessage = Must assign dynamic_partition.buckets properties");
         createTable(createOlapTblStmt);
+        Database db = Catalog.getCurrentCatalog().getDbOrAnalysisException("default_cluster:test");
+        OlapTable table = (OlapTable) db.getTableOrAnalysisException("dynamic_partition_none_buckets");
+        Assert.assertTrue(table.getTableProperty().getDynamicPartitionProperty().getBuckets() == DynamicPartitionProperty.NOT_SET_BUCKETS);
     }
 
     @Test


### PR DESCRIPTION
## Proposed changes

In most scenarios, the number of buckets for dynamic partitions will be the same as the table buckets, so default value should be set.

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Code refactor (Modify the code structure, format the code, etc...)
- [ ] Optimization. Including functional usability improvements and performance improvements.
- [ ] Dependency. Such as changes related to third-party components.
- [ ] Other.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have created an issue on (Fix #ISSUE) and described the bug/feature there in detail
- [x] Compiling and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] If these changes need document changes, I have updated the document
- [ ] Any dependent changes have been merged

## Further comments

If this is a relatively large or complex change, kick off the discussion at dev@doris.apache.org by explaining why you chose the solution you did and what alternatives you considered, etc...
