### PR TITLE
[Bug] [Truncate] Fix tablet number is different between the new partition and base partition after truncate operation

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Catalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Catalog.java
@@ -6581,6 +6581,7 @@ public class Catalog {
 
         // check, and save some info which need to be checked again later
         Map<String, Long> origPartitions = Maps.newHashMap();
+        Map<Long, DistributionInfo> partitionsDistributionInfo = Maps.newHashMap();
         OlapTable copiedTbl;
 
         boolean truncateEntireTable = tblRef.getPartitionNames() == null;
@@ -6601,10 +6602,12 @@ public class Catalog {
                         throw new DdlException("Partition " + partName + " does not exist");
                     }
                     origPartitions.put(partName, partition.getId());
+                    partitionsDistributionInfo.put(partition.getId(), partition.getDistributionInfo());
                 }
             } else {
                 for (Partition partition : olapTable.getPartitions()) {
                     origPartitions.put(partition.getName(), partition.getId());
+                    partitionsDistributionInfo.put(partition.getId(), partition.getDistributionInfo());
                 }
             }
             copiedTbl = olapTable.selectiveCopy(origPartitions.keySet(), true, IndexExtState.VISIBLE);
@@ -6629,7 +6632,7 @@ public class Catalog {
                         db.getId(), copiedTbl.getId(), copiedTbl.getBaseIndexId(),
                         newPartitionId, entry.getKey(),
                         copiedTbl.getIndexIdToMeta(),
-                        copiedTbl.getDefaultDistributionInfo(),
+                        partitionsDistributionInfo.get(oldPartitionId),
                         copiedTbl.getPartitionInfo().getDataProperty(oldPartitionId).getStorageMedium(),
                         copiedTbl.getPartitionInfo().getReplicationNum(oldPartitionId),
                         null /* version info */,

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/TruncateTableTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/TruncateTableTest.java
@@ -26,17 +26,14 @@ public class TruncateTableTest {
         connectContext = UtFrameUtils.createDefaultCtx();
         // create database
         String createDbStmtStr = "create database test;";
-        String createTablleStr = "create table test.tbl(" +
-                                        "d1 date," +
-                                        "k1 int," +
-                                        "k2 bigint)" +
+        String createTableStr = "create table test.tbl(d1 date, k1 int, k2 bigint)" +
                                         "duplicate key(d1, k1) " +
                                         "PARTITION BY RANGE(d1)" +
                                         "(PARTITION p20210901 VALUES [('2021-09-01'), ('2021-09-02')))" +
                                         "distributed by hash(k1) buckets 2 " +
                                         "properties('replication_num' = '1');";
         createDb(createDbStmtStr);
-        createTable(createTablleStr);
+        createTable(createTableStr);
     }
 
     @AfterClass
@@ -45,18 +42,8 @@ public class TruncateTableTest {
         file.delete();
     }
 
-    private static void createDb(String sql) throws Exception {
-        CreateDbStmt createDbStmt = (CreateDbStmt) UtFrameUtils.parseAndAnalyzeStmt(sql, connectContext);
-        Catalog.getCurrentCatalog().createDb(createDbStmt);
-    }
-
-    private static void createTable(String sql) throws Exception {
-        CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameUtils.parseAndAnalyzeStmt(sql, connectContext);
-        Catalog.getCurrentCatalog().createTable(createTableStmt);
-    }
-
     @Test
-    public void testTruncatePartition() throws Exception {
+    public void testTruncateTable() throws Exception {
         String stmtStr = "ALTER TABLE test.tbl ADD PARTITION p20210902 VALUES [('2021-09-02'), ('2021-09-03')) DISTRIBUTED BY HASH(`k1`) BUCKETS 3;";
         alterTable(stmtStr);
         stmtStr = "ALTER TABLE test.tbl ADD PARTITION p20210903 VALUES [('2021-09-03'), ('2021-09-04')) DISTRIBUTED BY HASH(`k1`) BUCKETS 4;";
@@ -67,22 +54,52 @@ public class TruncateTableTest {
         checkShowTabletResultNum("test.tbl", "p20210902", 3);
         checkShowTabletResultNum("test.tbl", "p20210903", 4);
         checkShowTabletResultNum("test.tbl", "p20210904", 5);
-        String truncateStr = "truncate table test.tbl partition (p20210901);";
+
+        String truncateStr = "truncate table test.tbl;";
         TruncateTableStmt truncateTableStmt = (TruncateTableStmt)UtFrameUtils.parseAndAnalyzeStmt(truncateStr, connectContext);
         Catalog.getCurrentCatalog().truncateTable(truncateTableStmt);
         checkShowTabletResultNum("test.tbl", "p20210901", 2);
+        checkShowTabletResultNum("test.tbl", "p20210902", 3);
+        checkShowTabletResultNum("test.tbl", "p20210903", 4);
+        checkShowTabletResultNum("test.tbl", "p20210904", 5);
+
+        truncateStr = "truncate table test.tbl partition(p20210901, p20210902, p20210903, p20210904);";
+        truncateTableStmt = (TruncateTableStmt)UtFrameUtils.parseAndAnalyzeStmt(truncateStr, connectContext);
+        Catalog.getCurrentCatalog().truncateTable(truncateTableStmt);
+        checkShowTabletResultNum("test.tbl", "p20210901", 2);
+        checkShowTabletResultNum("test.tbl", "p20210902", 3);
+        checkShowTabletResultNum("test.tbl", "p20210903", 4);
+        checkShowTabletResultNum("test.tbl", "p20210904", 5);
+
+        truncateStr = "truncate table test.tbl partition (p20210901);";
+        truncateTableStmt = (TruncateTableStmt)UtFrameUtils.parseAndAnalyzeStmt(truncateStr, connectContext);
+        Catalog.getCurrentCatalog().truncateTable(truncateTableStmt);
+        checkShowTabletResultNum("test.tbl", "p20210901", 2);
+
         truncateStr = "truncate table test.tbl partition (p20210902);";
         truncateTableStmt = (TruncateTableStmt)UtFrameUtils.parseAndAnalyzeStmt(truncateStr, connectContext);
         Catalog.getCurrentCatalog().truncateTable(truncateTableStmt);
         checkShowTabletResultNum("test.tbl", "p20210902", 3);
+
         truncateStr = "truncate table test.tbl partition (p20210903);";
         truncateTableStmt = (TruncateTableStmt)UtFrameUtils.parseAndAnalyzeStmt(truncateStr, connectContext);
         Catalog.getCurrentCatalog().truncateTable(truncateTableStmt);
         checkShowTabletResultNum("test.tbl", "p20210903", 4);
+
         truncateStr = "truncate table test.tbl partition (p20210904);";
         truncateTableStmt = (TruncateTableStmt)UtFrameUtils.parseAndAnalyzeStmt(truncateStr, connectContext);
         Catalog.getCurrentCatalog().truncateTable(truncateTableStmt);
         checkShowTabletResultNum("test.tbl", "p20210904", 5);
+    }
+
+    private static void createDb(String sql) throws Exception {
+        CreateDbStmt createDbStmt = (CreateDbStmt) UtFrameUtils.parseAndAnalyzeStmt(sql, connectContext);
+        Catalog.getCurrentCatalog().createDb(createDbStmt);
+    }
+
+    private static void createTable(String sql) throws Exception {
+        CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameUtils.parseAndAnalyzeStmt(sql, connectContext);
+        Catalog.getCurrentCatalog().createTable(createTableStmt);
     }
 
     private List<List<String>> checkShowTabletResultNum(String tbl, String partition, int expected) throws Exception {
@@ -103,5 +120,4 @@ public class TruncateTableTest {
             throw e;
         }
     }
-
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/TruncateTableTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/TruncateTableTest.java
@@ -1,0 +1,107 @@
+package org.apache.doris.catalog;
+
+import org.apache.doris.analysis.*;
+import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.qe.ShowExecutor;
+import org.apache.doris.qe.ShowResultSet;
+import org.apache.doris.utframe.UtFrameUtils;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.File;
+import java.util.List;
+import java.util.UUID;
+
+public class TruncateTableTest {
+    private static String runningDir = "fe/mocked/TruncateTableTest/" + UUID.randomUUID().toString() + "/";
+
+    private static ConnectContext connectContext;
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        UtFrameUtils.createMinDorisCluster(runningDir);
+        connectContext = UtFrameUtils.createDefaultCtx();
+        // create database
+        String createDbStmtStr = "create database test;";
+        String createTablleStr = "create table test.tbl(" +
+                                        "d1 date," +
+                                        "k1 int," +
+                                        "k2 bigint)" +
+                                        "duplicate key(d1, k1) " +
+                                        "PARTITION BY RANGE(d1)" +
+                                        "(PARTITION p20210901 VALUES [('2021-09-01'), ('2021-09-02')))" +
+                                        "distributed by hash(k1) buckets 2 " +
+                                        "properties('replication_num' = '1');";
+        createDb(createDbStmtStr);
+        createTable(createTablleStr);
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        File file = new File(runningDir);
+        file.delete();
+    }
+
+    private static void createDb(String sql) throws Exception {
+        CreateDbStmt createDbStmt = (CreateDbStmt) UtFrameUtils.parseAndAnalyzeStmt(sql, connectContext);
+        Catalog.getCurrentCatalog().createDb(createDbStmt);
+    }
+
+    private static void createTable(String sql) throws Exception {
+        CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameUtils.parseAndAnalyzeStmt(sql, connectContext);
+        Catalog.getCurrentCatalog().createTable(createTableStmt);
+    }
+
+    @Test
+    public void testTruncatePartition() throws Exception {
+        String stmtStr = "ALTER TABLE test.tbl ADD PARTITION p20210902 VALUES [('2021-09-02'), ('2021-09-03')) DISTRIBUTED BY HASH(`k1`) BUCKETS 3;";
+        alterTable(stmtStr);
+        stmtStr = "ALTER TABLE test.tbl ADD PARTITION p20210903 VALUES [('2021-09-03'), ('2021-09-04')) DISTRIBUTED BY HASH(`k1`) BUCKETS 4;";
+        alterTable(stmtStr);
+        stmtStr = "ALTER TABLE test.tbl ADD PARTITION p20210904 VALUES [('2021-09-04'), ('2021-09-05')) DISTRIBUTED BY HASH(`k1`) BUCKETS 5;";
+        alterTable(stmtStr);
+        checkShowTabletResultNum("test.tbl", "p20210901", 2);
+        checkShowTabletResultNum("test.tbl", "p20210902", 3);
+        checkShowTabletResultNum("test.tbl", "p20210903", 4);
+        checkShowTabletResultNum("test.tbl", "p20210904", 5);
+        String truncateStr = "truncate table test.tbl partition (p20210901);";
+        TruncateTableStmt truncateTableStmt = (TruncateTableStmt)UtFrameUtils.parseAndAnalyzeStmt(truncateStr, connectContext);
+        Catalog.getCurrentCatalog().truncateTable(truncateTableStmt);
+        checkShowTabletResultNum("test.tbl", "p20210901", 2);
+        truncateStr = "truncate table test.tbl partition (p20210902);";
+        truncateTableStmt = (TruncateTableStmt)UtFrameUtils.parseAndAnalyzeStmt(truncateStr, connectContext);
+        Catalog.getCurrentCatalog().truncateTable(truncateTableStmt);
+        checkShowTabletResultNum("test.tbl", "p20210902", 3);
+        truncateStr = "truncate table test.tbl partition (p20210903);";
+        truncateTableStmt = (TruncateTableStmt)UtFrameUtils.parseAndAnalyzeStmt(truncateStr, connectContext);
+        Catalog.getCurrentCatalog().truncateTable(truncateTableStmt);
+        checkShowTabletResultNum("test.tbl", "p20210903", 4);
+        truncateStr = "truncate table test.tbl partition (p20210904);";
+        truncateTableStmt = (TruncateTableStmt)UtFrameUtils.parseAndAnalyzeStmt(truncateStr, connectContext);
+        Catalog.getCurrentCatalog().truncateTable(truncateTableStmt);
+        checkShowTabletResultNum("test.tbl", "p20210904", 5);
+    }
+
+    private List<List<String>> checkShowTabletResultNum(String tbl, String partition, int expected) throws Exception {
+        String showStr = "show tablet from " + tbl + " partition(" + partition + ")";
+        ShowTabletStmt showStmt = (ShowTabletStmt) UtFrameUtils.parseAndAnalyzeStmt(showStr, connectContext);
+        ShowExecutor executor = new ShowExecutor(connectContext, (ShowStmt) showStmt);
+        ShowResultSet showResultSet = executor.execute();
+        List<List<String>> rows = showResultSet.getResultRows();
+        Assert.assertEquals(expected, rows.size());
+        return rows;
+    }
+
+    private void alterTable(String sql) throws Exception {
+        try {
+            AlterTableStmt alterTableStmt = (AlterTableStmt) UtFrameUtils.parseAndAnalyzeStmt(sql, connectContext);
+            Catalog.getCurrentCatalog().getAlterInstance().processAlterTable(alterTableStmt);
+        } catch (Exception e) {
+            throw e;
+        }
+    }
+
+}


### PR DESCRIPTION
## Proposed changes
Fix #6551 

`Truncate` operation will create new partition to replace base partition. Tablets in new partition would be created based on table default bucket number. If the number of tablet for a partition is different from table default bucket number, the number of tablet will be different between the new created partition and base partition after truncate operation.

In any case, the new partition should have the same number of tablet as the base partition after truncate operation. Tablets in new partition should be created based on tablet number of base partition rather than table default bucket number for truncate operation.

Example：

```
mysql> CREATE TABLE `table_test_2` (
    ->   `event_day` date NULL COMMENT "",
    ->   `siteid` int(11) NULL DEFAULT "10" COMMENT "",
    ->   `citycode` smallint(6) NULL COMMENT "",
    ->   `username` varchar(32) NULL DEFAULT "" COMMENT "",
    ->   `pv` bigint(20) SUM NULL DEFAULT "0" COMMENT ""
    -> ) ENGINE=OLAP
    -> AGGREGATE KEY(`event_day`, `siteid`, `citycode`, `username`)
    -> COMMENT "OLAP"
    -> PARTITION BY RANGE(`event_day`)
    -> (PARTITION p2011 VALUES [('2011-01-01'), ('2012-01-01')))
    -> DISTRIBUTED BY HASH(`siteid`) BUCKETS 10
    -> PROPERTIES (
    -> "replication_num" = "1",
    -> "in_memory" = "false",
    -> "storage_format" = "V2"
    -> );
Query OK, 0 rows affected (0.45 sec)

mysql> alter table table_test_2 ADD PARTITION p2012 VALUES [('2012-01-01'), ('2013-01-01')) DISTRIBUTED BY HASH(`siteid`) BUCKETS 64;
Query OK, 0 rows affected (0.22 sec)

mysql> show tablet from table_test_2 partitions(p2012);
+----------+-----------+-----------+------------+---------+-------------+-------------------+-----------------------+------------------+----------------------+---------------+----------+----------+--------+-------------------------+--------------+------------------+--------------+----------------------+--------------------------------------------------------+----------------------------------------------------------------------------------+
| TabletId | ReplicaId | BackendId | SchemaHash | Version | VersionHash | LstSuccessVersion | LstSuccessVersionHash | LstFailedVersion | LstFailedVersionHash | LstFailedTime | DataSize | RowCount | State  | LstConsistencyCheckTime | CheckVersion | CheckVersionHash | VersionCount | PathHash             | MetaUrl                                                | CompactionStatus                                                                 |
+----------+-----------+-----------+------------+---------+-------------+-------------------+-----------------------+------------------+----------------------+---------------+----------+----------+--------+-------------------------+--------------+------------------+--------------+----------------------+--------------------------------------------------------+----------------------------------------------------------------------------------+
| 97055    | 97056     | 10003     | 767176810  | 1       | 0           | 1                 | 0                     | -1               | 0                    | NULL          | 0        | 0        | NORMAL | NULL                    | -1           | -1               | -1           | -7622875441058176368 | http://172.17.0.2:8040/api/meta/header/97055/767176810 | http://172.17.0.2:8040/api/compaction/show?tablet_id=97055&schema_hash=767176810 |
                                                                                            ...
| 97181    | 97182     | 10003     | 767176810  | 1       | 0           | 1                 | 0                     | -1               | 0                    | NULL          | 0        | 0        | NORMAL | NULL                    | -1           | -1               | -1           | -2924852150888364055 | http://172.17.0.2:8040/api/meta/header/97181/767176810 | http://172.17.0.2:8040/api/compaction/show?tablet_id=97181&schema_hash=767176810 |
+----------+-----------+-----------+------------+---------+-------------+-------------------+-----------------------+------------------+----------------------+---------------+----------+----------+--------+-------------------------+--------------+------------------+--------------+----------------------+--------------------------------------------------------+----------------------------------------------------------------------------------+
64 rows in set (0.00 sec)

mysql> truncate table table_test_2 partitions(p2012);
Query OK, 0 rows affected (0.07 sec)

mysql> show tablet from table_test_2 partitions(p2012);
+----------+-----------+-----------+------------+---------+-------------+-------------------+-----------------------+------------------+----------------------+---------------+----------+----------+--------+-------------------------+--------------+------------------+--------------+----------------------+--------------------------------------------------------+----------------------------------------------------------------------------------+
| TabletId | ReplicaId | BackendId | SchemaHash | Version | VersionHash | LstSuccessVersion | LstSuccessVersionHash | LstFailedVersion | LstFailedVersionHash | LstFailedTime | DataSize | RowCount | State  | LstConsistencyCheckTime | CheckVersion | CheckVersionHash | VersionCount | PathHash             | MetaUrl                                                | CompactionStatus                                                                 |
+----------+-----------+-----------+------------+---------+-------------+-------------------+-----------------------+------------------+----------------------+---------------+----------+----------+--------+-------------------------+--------------+------------------+--------------+----------------------+--------------------------------------------------------+----------------------------------------------------------------------------------+
| 97184    | 97185     | 10003     | 767176810  | 1       | 0           | 1                 | 0                     | -1               | 0                    | NULL          | 0        | 0        | NORMAL | NULL                    | -1           | -1               | -1           | 1406107479780569403  | http://172.17.0.2:8040/api/meta/header/97184/767176810 | http://172.17.0.2:8040/api/compaction/show?tablet_id=97184&schema_hash=767176810 |
                                                                                            ...
| 97310    | 97311     | 10003     | 767176810  | 1       | 0           | 1                 | 0                     | -1               | 0                    | NULL          | 0        | 0        | NORMAL | NULL                    | -1           | -1               | -1           | -7622875441058176368 | http://172.17.0.2:8040/api/meta/header/97310/767176810 | http://172.17.0.2:8040/api/compaction/show?tablet_id=97310&schema_hash=767176810 |
+----------+-----------+-----------+------------+---------+-------------+-------------------+-----------------------+------------------+----------------------+---------------+----------+----------+--------+-------------------------+--------------+------------------+--------------+----------------------+--------------------------------------------------------+----------------------------------------------------------------------------------+
64 rows in set (0.00 sec)
```

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Code refactor (Modify the code structure, format the code, etc...)
- [ ] Optimization. Including functional usability improvements and performance improvements.
- [ ] Dependency. Such as changes related to third-party components.
- [ ] Other.
