### PR TITLE
handle bdb rollbackexception

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/journal/bdbje/BDBEnvironment.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/journal/bdbje/BDBEnvironment.java
@@ -33,6 +33,7 @@ import com.sleepycat.je.Durability.SyncPolicy;
 import com.sleepycat.je.EnvironmentConfig;
 import com.sleepycat.je.EnvironmentFailureException;
 import com.sleepycat.je.rep.InsufficientLogException;
+import com.sleepycat.je.rep.RollbackException;
 import com.sleepycat.je.rep.NetworkRestore;
 import com.sleepycat.je.rep.NetworkRestoreConfig;
 import com.sleepycat.je.rep.NoConsistencyRequiredPolicy;
@@ -320,6 +321,8 @@ public class BDBEnvironment {
                 break;
             } catch (InsufficientLogException e) {
                 throw e;
+            } catch (RollbackException e) {
+                throw e;
             } catch (EnvironmentFailureException e) {
                 tried++;
                 if (tried == RETRY_TIME) {
@@ -384,6 +387,40 @@ public class BDBEnvironment {
         }
     }
     
+        // Close environment
+    public void closeReplicatedEnvironment() {
+        if (replicatedEnvironment != null) {
+            try {
+                // Finally, close the store and environment.
+                replicatedEnvironment.close();
+            } catch (DatabaseException exception) {
+                LOG.error("Error closing replicatedEnvironment", exception);
+                System.exit(-1);
+            }
+        }
+    }
+        // open environment
+    public void openReplicatedEnvironment(File envHome) {
+        for (int i = 0; i < RETRY_TIME; i++) {
+            try {
+                // open the environment
+                replicatedEnvironment = new ReplicatedEnvironment(envHome, replicationConfig, environmentConfig);
+                break;
+            } catch (DatabaseException e) {
+                if (i < RETRY_TIME - 1) {
+                    try {
+                        Thread.sleep(5 * 1000);
+                    } catch (InterruptedException e1) {
+                        e1.printStackTrace();
+                    }
+                } else {
+                    LOG.error("error to open replicated environment. will exit.", e);
+                    System.exit(-1);
+                }
+            }
+        }
+    }
+
     private SyncPolicy getSyncPolicy(String policy) {
         if (policy.equalsIgnoreCase("SYNC")) {
             return Durability.SyncPolicy.SYNC;


### PR DESCRIPTION
when use 3 fe follow, when restart the fes, and regardless of order，we probability can't start fe success，and bdb throw RollbackException，
In this scenario，the bdb suggest should catch the exception，simply closing all your ReplicatedEnvironment handles, and then reopening.

the error stack is:
`
ERROR (replayer|70) [BDBEnvironment.getDatabaseNames():325] bdb environment failure exception.
com.sleepycat.je.rep.RollbackException: (JE 18.1.11) Environment must be closed, caused by: com.sleepycat.je.rep.RollbackException: Environment invalid because of previous exception: (JE 18.1.11) 10.35.25.207_9010_1625733043423(10):bdb Node 10.35.25.207_9010_1625733043423(10):bdb must rollback 1 total commits(1 of which were durable) to the earliest point indicated by transaction id=-67564
 time=2021-07-09 09:59:30.901 vlsn=112,533 lsn=0xe/0xa625 durable=false in order to rejoin the replication group. All existing ReplicatedEnvironment handles must be closed and reinstantiated.  Log files were truncated to file 0x14, offset 0x42489, vlsn 112,532 HARD_RECOVERY: Rolled back
 past transaction commit or abort. Must run recovery by re-opening Environment handles 
Environment is invalid and must be closed. Originally thrown by HA thread: REPLICA 10.35.25.207_9010_1625733043423(10) Originally thrown by HA thread: REPLICA 
10.35.25.207_9010_1625733043423(10) Environment invalid because of previous exception: (JE 18.1.11) 10.35.25.207_9010_1625733043423(10):bdb Node 
10.35.25.207_9010_1625733043423(10):bdb must rollback 1 total commits(1 of which were durable) to the earliest point indicated by transaction id=-67564 
time=2021-07-09 09:59:30.901 vlsn=112,533 lsn=0xe/0xa625 durable=false in order to rejoin the 
replication group. All existing ReplicatedEnvironment handles must be closed and reinstantiated.
  Log files were truncated to file 0x14, offset 0x42489, vlsn 112,532 HARD_RECOVERY: Rolled back past transaction commit or abort. Must run recovery by re-opening Environment handles Environment is invalid and must be closed. Originally thrown by HA thread: REPLICA 10.35.25.207_9010_1625733043423(10) Originally thrown by HA thread: REPLICA 10.35.25.207_9010_1625733043423(10)
    at com.sleepycat.je.rep.RollbackException.wrapSelf(RollbackException.java:146) ~[je-18.1.11.jar:18.1.11]
    at com.sleepycat.je.rep.RollbackException.wrapSelf(RollbackException.java:62) ~[je-18.1.11.jar:18.1.11]
    at com.sleepycat.je.dbi.EnvironmentImpl.checkIfInvalid(EnvironmentImpl.java:1801) ~[je-18.1.11.jar:18.1.11]
    at com.sleepycat.je.dbi.EnvironmentImpl.checkOpen(EnvironmentImpl.java:1810) ~[je-18.1.11.jar:18.1.11]
    at com.sleepycat.je.Environment.checkOpen(Environment.java:2697) ~[je-18.1.11.jar:18.1.11]
    at com.sleepycat.je.Environment.getDatabaseNames(Environment.java:2455) ~[je-18.1.11.jar:18.1.11]
    at org.apache.doris.journal.bdbje.BDBEnvironment.getDatabaseNames(BDBEnvironment.java:318) [palo-fe.jar:3.4.0]
    at org.apache.doris.journal.bdbje.BDBJEJournal.getMaxJournalId(BDBJEJournal.java:258) [palo-fe.jar:3.4.0]
    at org.apache.doris.persist.EditLog.getMaxJournalId(EditLog.java:95) [palo-fe.jar:3.4.0]
    at org.apache.doris.catalog.Catalog.getMaxJournalId(Catalog.java:4808) [palo-fe.jar:3.4.0]
    at org.apache.doris.catalog.Catalog.replayJournal(Catalog.java:2422) [palo-fe.jar:3.4.0]
    at org.apache.doris.catalog.Catalog$3.runOneCycle(Catalog.java:2227) [palo-fe.jar:3.4.0]
    at org.apache.doris.common.util.Daemon.run(Daemon.java:116) [palo-fe.jar:3.4.0]
`

so we catch the RollbackException, and reopen the ReplicatedEnvironment