### PR TITLE
fix close exprContext bug

### DIFF
--- a/be/src/exprs/expr_context.cpp
+++ b/be/src/exprs/expr_context.cpp
@@ -83,7 +83,9 @@ Status ExprContext::open(std::vector<ExprContext*> evals, RuntimeState* state) {
 }
 
 void ExprContext::close(RuntimeState* state) {
-    DCHECK(!_closed);
+    //DCHECK(!_closed);
+    if (_closed)
+        return;
     FunctionContext::FunctionStateScope scope =
             _is_clone ? FunctionContext::THREAD_LOCAL : FunctionContext::FRAGMENT_LOCAL;
     _root->close(state, this, scope);


### PR DESCRIPTION
when close all ExprContext, case be  core dump, then be quit

``` *** Check failure stack trace: ***
    @          0x2abc6dd  google::LogMessage::Fail()
    @          0x2abe564  google::LogMessage::SendToLog()
    @          0x2abc204  google::LogMessage::Flush()
    @          0x2abef99  google::LogMessageFatal::~LogMessageFatal()
    @          0x1951ecd  doris::ExprContext::close()
    @          0x19405e5  doris::Expr::close()
    @          0x2620b66  doris::DataStreamSender::close()
    @          0x1e5d1a7  doris::PlanFragmentExecutor::close()
    @          0x1da18eb  doris::FragmentExecState::execute()
    @          0x1da3cc3  doris::FragmentMgr::_exec_actual()
    @          0x1db7b01  _ZSt13__invoke_implIvRMN5doris11FragmentMgrEFvSt10shared_ptrINS0_17FragmentExecStateEESt8functionIFvPNS0_20PlanFragmentExecutorEEEERPS1_JRS4_RS9_EET_St21__invoke_memfun_derefOT0_OT1_DpOT2_
    @          0x1db67ad  _ZSt8__invokeIRMN5doris11FragmentMgrEFvSt10shared_ptrINS0_17FragmentExecStateEESt8functionIFvPNS0_20PlanFragmentExecutorEEEEJRPS1_RS4_RS9_EENSt15__invoke_resultIT_JDpT0_EE4typeEOSI_DpOSJ_
    @          0x1db4b2a  _ZNSt12_Bind_resultIvFMN5doris11FragmentMgrEFvSt10shared_ptrINS0_17FragmentExecStateEESt8functionIFvPNS0_20PlanFragmentExecutorEEEEPS1_S4_S9_EE6__callIvJEJLm0ELm1ELm2EEEENSt9enable_ifIXtlSt7is_voidIT_EEEvE4typeEOSt5tupleIJDpT0_EESt12_Index_tupleIJXspT1_EEE
    @          0x1db19a4  _ZNSt12_Bind_resultIvFMN5doris11FragmentMgrEFvSt10shared_ptrINS0_17FragmentExecStateEESt8functionIFvPNS0_20PlanFragmentExecutorEEEEPS1_S4_S9_EEclIJEEEvDpOT_
    @          0x1daef61  std::_Function_handler<>::_M_invoke()
    @          0x1e263e8  std::function<>::operator()()
    @          0x1faedee  doris::FunctionRunnable::run()
    @          0x1fad89a  doris::ThreadPool::dispatch_thread()
    @          0x1fb86ff  _ZSt13__invoke_implIvRMN5doris10ThreadPoolEFvvERPS1_JEET_St21__invoke_memfun_derefOT0_OT1_DpOT2_
    @          0x1fb7bbd  _ZSt8__invokeIRMN5doris10ThreadPoolEFvvEJRPS1_EENSt15__invoke_resultIT_JDpT0_EE4typeEOS8_DpOS9_
    @          0x1fb6bcc  _ZNSt5_BindIFMN5doris10ThreadPoolEFvvEPS1_EE6__callIvJEJLm0EEEET_OSt5tupleIJDpT0_EESt12_Index_tupleIJXspT1_EEE
    @          0x1fb5810  _ZNSt5_BindIFMN5doris10ThreadPoolEFvvEPS1_EEclIJEvEET0_DpOT_
    @          0x1fb38da  std::_Function_handler<>::_M_invoke()
    @          0x1e263e8  std::function<>::operator()()
    @          0x1fa276e  doris::Thread::supervise_thread()
    @     0x7fec1d1a7e65  start_thread
    @     0x7fec1d4ba88d  __clone
**** 
```
so we should remove this DCHECK
