### PR TITLE
hll optimize

### DIFF
--- a/be/src/exprs/aggregate_functions.cpp
+++ b/be/src/exprs/aggregate_functions.cpp
@@ -1112,7 +1112,7 @@ void AggregateFunctions::hll_update(FunctionContext* ctx, const T& src, StringVa
     if (hash_value != 0) {
         int idx = hash_value % dst->len;
         uint8_t first_one_bit = __builtin_ctzl(hash_value >> HLL_COLUMN_PRECISION) + 1;
-        dst->ptr[idx] = std::max(dst->ptr[idx], first_one_bit);
+        dst->ptr[idx] = (dst->ptr[idx] < first_one_bit ? first_one_bit : dst->ptr[idx]);
     }
 }
 
@@ -1122,8 +1122,10 @@ void AggregateFunctions::hll_merge(FunctionContext* ctx, const StringVal& src, S
     DCHECK_EQ(dst->len, std::pow(2, HLL_COLUMN_PRECISION));
     DCHECK_EQ(src.len, std::pow(2, HLL_COLUMN_PRECISION));
 
+    auto dp = dst->ptr;
+    auto sp = src.ptr;
     for (int i = 0; i < src.len; ++i) {
-        dst->ptr[i] = std::max(dst->ptr[i], src.ptr[i]);
+        dp[i] = (dp[i] < sp[i] ? sp[i] : dp[i]);
     }
 }
 

--- a/be/src/olap/hll.cpp
+++ b/be/src/olap/hll.cpp
@@ -32,10 +32,10 @@ using std::stringstream;
 namespace doris {
 
 HyperLogLog::HyperLogLog(const Slice& src) {
-	// When deserialize return false, we make this object a empty
-	if (!deserialize(src)) {
-		_type = HLL_DATA_EMPTY;
-	}
+    // When deserialize return false, we make this object a empty
+    if (!deserialize(src)) {
+        _type = HLL_DATA_EMPTY;
+    }
 }
 
 // Convert explicit values to register format, and clear explicit values.
@@ -43,13 +43,13 @@ HyperLogLog::HyperLogLog(const Slice& src) {
 void HyperLogLog::_convert_explicit_to_register() {
     DCHECK(_type == HLL_DATA_EXPLICIT) << "_type(" << _type << ") should be explicit("
         << HLL_DATA_EXPLICIT << ")";
-	_registers = new uint8_t[HLL_REGISTERS_COUNT]();
+    _registers = new uint8_t[HLL_REGISTERS_COUNT]();
 
-	for (uint32_t i = 0; i < _explicit_data_num; ++i) {
+    for (uint32_t i = 0; i < _explicit_data_num; ++i) {
         _update_registers(_explicit_data[i]);
     }
 
-	_explicit_data_num = 0;
+    _explicit_data_num = 0;
 }
 
 // Change HLL_DATA_EXPLICIT to HLL_DATA_FULL directly, because HLL_DATA_SPARSE
@@ -57,15 +57,15 @@ void HyperLogLog::_convert_explicit_to_register() {
 void HyperLogLog::update(uint64_t hash_value) {
     switch (_type) {
     case HLL_DATA_EMPTY:
-		_explicit_data[0] = hash_value;
-		_explicit_data_num = 1;
+        _explicit_data[0] = hash_value;
+        _explicit_data_num = 1;
         _type = HLL_DATA_EXPLICIT;
         break;
     case HLL_DATA_EXPLICIT:
         if (_explicit_data_num < HLL_EXPLICIT_INT64_NUM) {
-			_explicit_data_insert(hash_value);
+            _explicit_data_insert(hash_value);
             break;
-        }
+        }   
         _convert_explicit_to_register();
         _type = HLL_DATA_FULL;
         // fall through
@@ -87,12 +87,12 @@ void HyperLogLog::merge(const HyperLogLog& other) {
         _type = other._type;
         switch (other._type) {
         case HLL_DATA_EXPLICIT:
-			_explicit_data_num = other._explicit_data_num;
-			memcpy(_explicit_data, other._explicit_data, sizeof(*_explicit_data) * _explicit_data_num);
+            _explicit_data_num = other._explicit_data_num;
+            memcpy(_explicit_data, other._explicit_data, sizeof(*_explicit_data) * _explicit_data_num);
             break;
         case HLL_DATA_SPARSE:
         case HLL_DATA_FULL:
-			_registers = new uint8_t[HLL_REGISTERS_COUNT];
+            _registers = new uint8_t[HLL_REGISTERS_COUNT];
             memcpy(_registers, other._registers, HLL_REGISTERS_COUNT);
             break;
         default:
@@ -103,57 +103,57 @@ void HyperLogLog::merge(const HyperLogLog& other) {
     case HLL_DATA_EXPLICIT: {
         switch (other._type) {
         case HLL_DATA_EXPLICIT: {
-				// Merge other's explicit values first, then check if the number is exceed
-				// HLL_EXPLICIT_INT64_NUM. This is OK because the max value is 2 * 160.
-				if (other._explicit_data_num > HLL_EXPLICIT_INT64_NUM / 2) { //merge
-					uint64_t explicit_data[HLL_EXPLICIT_INT64_NUM * 2];
-					memcpy(explicit_data, _explicit_data, sizeof(*_explicit_data) * _explicit_data_num);
-					uint32_t explicit_data_num = _explicit_data_num;
-					_explicit_data_num = 0;
+            // Merge other's explicit values first, then check if the number is exceed
+            // HLL_EXPLICIT_INT64_NUM. This is OK because the max value is 2 * 160.
+            if (other._explicit_data_num > HLL_EXPLICIT_INT64_NUM / 2) { //merge
+                uint64_t explicit_data[HLL_EXPLICIT_INT64_NUM * 2];
+                memcpy(explicit_data, _explicit_data, sizeof(*_explicit_data) * _explicit_data_num);
+                uint32_t explicit_data_num = _explicit_data_num;
+                _explicit_data_num = 0;
 
-					// merge _explicit_data and other's _explicit_data to _explicit_data
-					uint32_t i = 0, j = 0, k = 0;
-					while (i < explicit_data_num || j < other._explicit_data_num) {
-						if (i == explicit_data_num) {
-							uint32_t n = other._explicit_data_num - j;
-							memcpy(_explicit_data + k, other._explicit_data + j, n * sizeof(*_explicit_data));
-							k += n; break;
-						} else if (j == other._explicit_data_num) {
-							uint32_t n = explicit_data_num - i;
-							memcpy(_explicit_data + k, explicit_data + i, n * sizeof(*_explicit_data));
-							k += n; break;
-						} else {
-							if (explicit_data[i] < other._explicit_data[j]) {
-								_explicit_data[k++] = explicit_data[i++];
-							} else if (explicit_data[i] > other._explicit_data[j]) {
-								_explicit_data[k++] = other._explicit_data[j++];
-							} else {
-								_explicit_data[k++] = explicit_data[i++]; j++;
-							}
-						}
-					}
-					_explicit_data_num = k;
-				} else { //依次插入
-					int32_t n = other._explicit_data_num;
-					const uint64_t *data = other._explicit_data;
-					for (int32_t i = 0; i < n; ++i) {
-						_explicit_data_insert(data[i]);
-					}
-				}
+                // merge _explicit_data and other's _explicit_data to _explicit_data
+                uint32_t i = 0, j = 0, k = 0;
+                while (i < explicit_data_num || j < other._explicit_data_num) {
+                    if (i == explicit_data_num) {
+                        uint32_t n = other._explicit_data_num - j;
+                        memcpy(_explicit_data + k, other._explicit_data + j, n * sizeof(*_explicit_data));
+                        k += n; break;
+                    } else if (j == other._explicit_data_num) {
+                        uint32_t n = explicit_data_num - i;
+                        memcpy(_explicit_data + k, explicit_data + i, n * sizeof(*_explicit_data));
+                        k += n; break;
+                    } else {
+                        if (explicit_data[i] < other._explicit_data[j]) { 
+                            _explicit_data[k++] = explicit_data[i++];
+                        } else if (explicit_data[i] > other._explicit_data[j]) {
+                            _explicit_data[k++] = other._explicit_data[j++];
+                        } else {
+                            _explicit_data[k++] = explicit_data[i++]; j++;
+                        }
+                    }
+                }
+                _explicit_data_num = k;
+            } else { //依次插入 
+                int32_t n = other._explicit_data_num; 
+                const uint64_t *data = other._explicit_data; 
+                for (int32_t i = 0; i < n; ++i) { 
+                    _explicit_data_insert(data[i]); 
+                }
+            }
 
-				if (_explicit_data_num > HLL_EXPLICIT_INT64_NUM) {
-					_convert_explicit_to_register();
-					_type = HLL_DATA_FULL;
-				}
+            if (_explicit_data_num > HLL_EXPLICIT_INT64_NUM) { 
+                _convert_explicit_to_register(); 
+                _type = HLL_DATA_FULL; 
+            }
 			}
             break;
         case HLL_DATA_SPARSE:
-        case HLL_DATA_FULL:
-            _convert_explicit_to_register();
-            _merge_registers(other._registers);
-            _type = HLL_DATA_FULL;
+        case HLL_DATA_FULL: 
+            _convert_explicit_to_register(); 
+            _merge_registers(other._registers); 
+            _type = HLL_DATA_FULL; 
             break;
-        default:
+        default: 
             break;
         }
         break;
@@ -161,13 +161,13 @@ void HyperLogLog::merge(const HyperLogLog& other) {
     case HLL_DATA_SPARSE:
     case HLL_DATA_FULL: {
         switch (other._type) {
-        case HLL_DATA_EXPLICIT:
-			for (int32_t i = 0; i < other._explicit_data_num; ++i) {
-                _update_registers(other._explicit_data[i]);
+        case HLL_DATA_EXPLICIT: 
+            for (int32_t i = 0; i < other._explicit_data_num; ++i) { 
+                _update_registers(other._explicit_data[i]); 
             }
             break;
         case HLL_DATA_SPARSE:
-        case HLL_DATA_FULL:
+        case HLL_DATA_FULL: 
             _merge_registers(other._registers);
             break;
         default:
@@ -211,11 +211,11 @@ size_t HyperLogLog::serialize(uint8_t* dst) const {
         *ptr++ = (uint8_t)_explicit_data_num;
 
 #if __BYTE_ORDER == __LITTLE_ENDIAN
-		memcpy(ptr, _explicit_data, _explicit_data_num * sizeof(*_explicit_data));
-		ptr += _explicit_data_num * sizeof(*_explicit_data);
+        memcpy(ptr, _explicit_data, _explicit_data_num * sizeof(*_explicit_data));
+        ptr += _explicit_data_num * sizeof(*_explicit_data);
 #else
-		for (int32_t i = 0; i < _explicit_data_num; ++i) {
-			*(uint64_t*)ptr = (uint64_t)gbswap_64(_explicit_data[i]);
+        for (int32_t i = 0; i < _explicit_data_num; ++i) {
+            *(uint64_t*)ptr = (uint64_t)gbswap_64(_explicit_data[i]);
             ptr += 8;
         }    
 #endif
@@ -225,7 +225,7 @@ size_t HyperLogLog::serialize(uint8_t* dst) const {
     case HLL_DATA_FULL: {
         uint32_t num_non_zero_registers = 0;
         for (int i = 0; i < HLL_REGISTERS_COUNT; ++i) {
-			num_non_zero_registers += (_registers[i] != 0);
+            num_non_zero_registers += (_registers[i] != 0);
         }
 
         // each register in sparse format will occupy 3bytes, 2 for index and
@@ -247,29 +247,29 @@ size_t HyperLogLog::serialize(uint8_t* dst) const {
                     continue;
                 } 
 				
-				if (UNLIKELY(_registers[i])) {
-					encode_fixed16_le(ptr, i); ptr += 2; // 2 bytes: register index 
-					*ptr++ = _registers[i]; // 1 byte: register value
-				}
-				++i;
+                if (UNLIKELY(_registers[i])) {
+                    encode_fixed16_le(ptr, i); ptr += 2; // 2 bytes: register index 
+                    *ptr++ = _registers[i]; // 1 byte: register value
+                }
+                ++i;
 
-				if (UNLIKELY(_registers[i])) {
-					encode_fixed16_le(ptr, i); ptr += 2; // 2 bytes: register index 
-					*ptr++ = _registers[i]; // 1 byte: register value
-				}
-				++i;
+                if (UNLIKELY(_registers[i])) {
+                    encode_fixed16_le(ptr, i); ptr += 2; // 2 bytes: register index 
+                    *ptr++ = _registers[i]; // 1 byte: register value
+                }
+                ++i;
 
-				if (UNLIKELY(_registers[i])) {
-					encode_fixed16_le(ptr, i); ptr += 2; // 2 bytes: register index 
-					*ptr++ = _registers[i]; // 1 byte: register value
-				}
-				++i;
+                if (UNLIKELY(_registers[i])) {
+                    encode_fixed16_le(ptr, i); ptr += 2; // 2 bytes: register index 
+                    *ptr++ = _registers[i]; // 1 byte: register value
+                }
+                ++i;
 
-				if (UNLIKELY(_registers[i])) {
-					encode_fixed16_le(ptr, i); ptr += 2; // 2 bytes: register index 
-					*ptr++ = _registers[i]; // 1 byte: register value
-				}
-				++i;
+                if (UNLIKELY(_registers[i])) {
+                    encode_fixed16_le(ptr, i); ptr += 2; // 2 bytes: register index 
+                    *ptr++ = _registers[i]; // 1 byte: register value
+                }
+                ++i;
             }
         }
         break;

--- a/be/src/olap/hll.cpp
+++ b/be/src/olap/hll.cpp
@@ -112,7 +112,7 @@ void HyperLogLog::merge(const HyperLogLog& other) {
 					_explicit_data_num = 0;
 
 					// merge _explicit_data and other's _explicit_data to _explicit_data
-					register uint32_t i = 0, j = 0, k = 0;
+					uint32_t i = 0, j = 0, k = 0;
 					while (i < explicit_data_num || j < other._explicit_data_num) {
 						if (i == explicit_data_num) {
 							uint32_t n = other._explicit_data_num - j;
@@ -223,7 +223,7 @@ size_t HyperLogLog::serialize(uint8_t* dst) const {
     }
     case HLL_DATA_SPARSE:
     case HLL_DATA_FULL: {
-        register uint32_t num_non_zero_registers = 0;
+        uint32_t num_non_zero_registers = 0;
         for (int i = 0; i < HLL_REGISTERS_COUNT; ++i) {
 			num_non_zero_registers += (_registers[i] != 0);
         }

--- a/be/src/olap/hll.cpp
+++ b/be/src/olap/hll.cpp
@@ -32,24 +32,24 @@ using std::stringstream;
 namespace doris {
 
 HyperLogLog::HyperLogLog(const Slice& src) {
-    // When deserialize return false, we make this object a empty
-    if (!deserialize(src)) {
-        _type = HLL_DATA_EMPTY;
-    }
+	// When deserialize return false, we make this object a empty
+	if (!deserialize(src)) {
+		_type = HLL_DATA_EMPTY;
+	}
 }
 
 // Convert explicit values to register format, and clear explicit values.
 // NOTE: this function won't modify _type.
 void HyperLogLog::_convert_explicit_to_register() {
-    DCHECK(_type == HLL_DATA_EXPLICIT)
-            << "_type(" << _type << ") should be explicit(" << HLL_DATA_EXPLICIT << ")";
-    _registers = new uint8_t[HLL_REGISTERS_COUNT];
-    memset(_registers, 0, HLL_REGISTERS_COUNT);
-    for (auto value : _hash_set) {
-        _update_registers(value);
+    DCHECK(_type == HLL_DATA_EXPLICIT) << "_type(" << _type << ") should be explicit("
+        << HLL_DATA_EXPLICIT << ")";
+	_registers = new uint8_t[HLL_REGISTERS_COUNT]();
+
+	for (uint32_t i = 0; i < _explicit_data_num; ++i) {
+        _update_registers(_explicit_data[i]);
     }
-    // clear _hash_set
-    std::set<uint64_t>().swap(_hash_set);
+
+	_explicit_data_num = 0;
 }
 
 // Change HLL_DATA_EXPLICIT to HLL_DATA_FULL directly, because HLL_DATA_SPARSE
@@ -57,12 +57,13 @@ void HyperLogLog::_convert_explicit_to_register() {
 void HyperLogLog::update(uint64_t hash_value) {
     switch (_type) {
     case HLL_DATA_EMPTY:
-        _hash_set.insert(hash_value);
+		_explicit_data[0] = hash_value;
+		_explicit_data_num = 1;
         _type = HLL_DATA_EXPLICIT;
         break;
     case HLL_DATA_EXPLICIT:
-        if (_hash_set.size() < HLL_EXPLICIT_INT64_NUM) {
-            _hash_set.insert(hash_value);
+        if (_explicit_data_num < HLL_EXPLICIT_INT64_NUM) {
+			_explicit_data_insert(hash_value);
             break;
         }
         _convert_explicit_to_register();
@@ -86,11 +87,12 @@ void HyperLogLog::merge(const HyperLogLog& other) {
         _type = other._type;
         switch (other._type) {
         case HLL_DATA_EXPLICIT:
-            _hash_set = other._hash_set;
+			_explicit_data_num = other._explicit_data_num;
+			memcpy(_explicit_data, other._explicit_data, sizeof(*_explicit_data) * _explicit_data_num);
             break;
         case HLL_DATA_SPARSE:
         case HLL_DATA_FULL:
-            _registers = new uint8_t[HLL_REGISTERS_COUNT];
+			_registers = new uint8_t[HLL_REGISTERS_COUNT];
             memcpy(_registers, other._registers, HLL_REGISTERS_COUNT);
             break;
         default:
@@ -100,14 +102,50 @@ void HyperLogLog::merge(const HyperLogLog& other) {
     }
     case HLL_DATA_EXPLICIT: {
         switch (other._type) {
-        case HLL_DATA_EXPLICIT:
-            // Merge other's explicit values first, then check if the number is exceed
-            // HLL_EXPLICIT_INT64_NUM. This is OK because the max value is 2 * 160.
-            _hash_set.insert(other._hash_set.begin(), other._hash_set.end());
-            if (_hash_set.size() > HLL_EXPLICIT_INT64_NUM) {
-                _convert_explicit_to_register();
-                _type = HLL_DATA_FULL;
-            }
+        case HLL_DATA_EXPLICIT: {
+				// Merge other's explicit values first, then check if the number is exceed
+				// HLL_EXPLICIT_INT64_NUM. This is OK because the max value is 2 * 160.
+				if (other._explicit_data_num > HLL_EXPLICIT_INT64_NUM / 2) { //merge
+					uint64_t explicit_data[HLL_EXPLICIT_INT64_NUM * 2];
+					memcpy(explicit_data, _explicit_data, sizeof(*_explicit_data) * _explicit_data_num);
+					uint32_t explicit_data_num = _explicit_data_num;
+					_explicit_data_num = 0;
+
+					// merge _explicit_data and other's _explicit_data to _explicit_data
+					register uint32_t i = 0, j = 0, k = 0;
+					while (i < explicit_data_num || j < other._explicit_data_num) {
+						if (i == explicit_data_num) {
+							uint32_t n = other._explicit_data_num - j;
+							memcpy(_explicit_data + k, other._explicit_data + j, n * sizeof(*_explicit_data));
+							k += n; break;
+						} else if (j == other._explicit_data_num) {
+							uint32_t n = explicit_data_num - i;
+							memcpy(_explicit_data + k, explicit_data + i, n * sizeof(*_explicit_data));
+							k += n; break;
+						} else {
+							if (explicit_data[i] < other._explicit_data[j]) {
+								_explicit_data[k++] = explicit_data[i++];
+							} else if (explicit_data[i] > other._explicit_data[j]) {
+								_explicit_data[k++] = other._explicit_data[j++];
+							} else {
+								_explicit_data[k++] = explicit_data[i++]; j++;
+							}
+						}
+					}
+					_explicit_data_num = k;
+				} else { //依次插入
+					int32_t n = other._explicit_data_num;
+					const uint64_t *data = other._explicit_data;
+					for (int32_t i = 0; i < n; ++i) {
+						_explicit_data_insert(data[i]);
+					}
+				}
+
+				if (_explicit_data_num > HLL_EXPLICIT_INT64_NUM) {
+					_convert_explicit_to_register();
+					_type = HLL_DATA_FULL;
+				}
+			}
             break;
         case HLL_DATA_SPARSE:
         case HLL_DATA_FULL:
@@ -124,8 +162,8 @@ void HyperLogLog::merge(const HyperLogLog& other) {
     case HLL_DATA_FULL: {
         switch (other._type) {
         case HLL_DATA_EXPLICIT:
-            for (auto hash_value : other._hash_set) {
-                _update_registers(hash_value);
+			for (int32_t i = 0; i < other._explicit_data_num; ++i) {
+                _update_registers(other._explicit_data[i]);
             }
             break;
         case HLL_DATA_SPARSE:
@@ -146,7 +184,7 @@ size_t HyperLogLog::max_serialized_size() const {
     default:
         return 1;
     case HLL_DATA_EXPLICIT:
-        return 2 + _hash_set.size() * 8;
+        return 2 + _explicit_data_num * 8;
     case HLL_DATA_SPARSE:
     case HLL_DATA_FULL:
         return 1 + HLL_REGISTERS_COUNT;
@@ -155,34 +193,41 @@ size_t HyperLogLog::max_serialized_size() const {
 
 size_t HyperLogLog::serialize(uint8_t* dst) const {
     uint8_t* ptr = dst;
+
     switch (_type) {
     case HLL_DATA_EMPTY:
     default: {
         // When the _type is unknown, which may not happen, we encode it as
         // Empty HyperLogLog object.
         *ptr++ = HLL_DATA_EMPTY;
+        
         break;
     }
     case HLL_DATA_EXPLICIT: {
-        DCHECK(_hash_set.size() <= HLL_EXPLICIT_INT64_NUM)
-                << "Number of explicit elements(" << _hash_set.size()
-                << ") should be less or equal than " << HLL_EXPLICIT_INT64_NUM;
+        DCHECK(_explicit_data_num < HLL_EXPLICIT_INT64_NUM)
+            << "Number of explicit elements(" << _explicit_data_num
+            << ") should be less or equal than " << HLL_EXPLICIT_INT64_NUM;
         *ptr++ = _type;
-        *ptr++ = (uint8_t)_hash_set.size();
-        for (auto hash_value : _hash_set) {
-            encode_fixed64_le(ptr, hash_value);
+        *ptr++ = (uint8_t)_explicit_data_num;
+
+#if __BYTE_ORDER == __LITTLE_ENDIAN
+		memcpy(ptr, _explicit_data, _explicit_data_num * sizeof(*_explicit_data));
+		ptr += _explicit_data_num * sizeof(*_explicit_data);
+#else
+		for (int32_t i = 0; i < _explicit_data_num; ++i) {
+			*(uint64_t*)ptr = (uint64_t)gbswap_64(_explicit_data[i]);
             ptr += 8;
-        }
+        }    
+#endif
         break;
     }
     case HLL_DATA_SPARSE:
     case HLL_DATA_FULL: {
-        uint32_t num_non_zero_registers = 0;
-        for (int i = 0; i < HLL_REGISTERS_COUNT; i++) {
-            if (_registers[i] != 0) {
-                num_non_zero_registers++;
-            }
+        register uint32_t num_non_zero_registers = 0;
+        for (int i = 0; i < HLL_REGISTERS_COUNT; ++i) {
+			num_non_zero_registers += (_registers[i] != 0);
         }
+
         // each register in sparse format will occupy 3bytes, 2 for index and
         // 1 for register value. So if num_non_zero_registers is greater than
         // 4K we use full encode format.
@@ -196,15 +241,35 @@ size_t HyperLogLog::serialize(uint8_t* dst) const {
             encode_fixed32_le(ptr, num_non_zero_registers);
             ptr += 4;
 
-            for (uint32_t i = 0; i < HLL_REGISTERS_COUNT; ++i) {
-                if (_registers[i] == 0) {
+            for (uint32_t i = 0; i < HLL_REGISTERS_COUNT;) {
+                if (*(uint32_t*)(&_registers[i]) == 0) {
+					i += 4;
                     continue;
-                }
-                // 2 bytes: register index
-                // 1 byte: register value
-                encode_fixed16_le(ptr, i);
-                ptr += 2;
-                *ptr++ = _registers[i];
+                } 
+				
+				if (UNLIKELY(_registers[i])) {
+					encode_fixed16_le(ptr, i); ptr += 2; // 2 bytes: register index 
+					*ptr++ = _registers[i]; // 1 byte: register value
+				}
+				++i;
+
+				if (UNLIKELY(_registers[i])) {
+					encode_fixed16_le(ptr, i); ptr += 2; // 2 bytes: register index 
+					*ptr++ = _registers[i]; // 1 byte: register value
+				}
+				++i;
+
+				if (UNLIKELY(_registers[i])) {
+					encode_fixed16_le(ptr, i); ptr += 2; // 2 bytes: register index 
+					*ptr++ = _registers[i]; // 1 byte: register value
+				}
+				++i;
+
+				if (UNLIKELY(_registers[i])) {
+					encode_fixed16_le(ptr, i); ptr += 2; // 2 bytes: register index 
+					*ptr++ = _registers[i]; // 1 byte: register value
+				}
+				++i;
             }
         }
         break;
@@ -272,45 +337,44 @@ bool HyperLogLog::deserialize(const Slice& slice) {
     // first byte : type
     _type = (HllDataType)*ptr++;
     switch (_type) {
-    case HLL_DATA_EMPTY:
-        break;
-    case HLL_DATA_EXPLICIT: {
-        // 2: number of explicit values
-        // make sure that num_explicit is positive
-        uint8_t num_explicits = *ptr++;
-        // 3+: 8 bytes hash value
-        for (int i = 0; i < num_explicits; ++i) {
-            _hash_set.insert(decode_fixed64_le(ptr));
-            ptr += 8;
+        case HLL_DATA_EMPTY:
+            break;
+        case HLL_DATA_EXPLICIT: {
+            // 2: number of explicit values
+            // make sure that num_explicit is positive
+            uint8_t num_explicits = *ptr++;
+            // 3+: 8 bytes hash value
+            for (int i = 0; i < num_explicits; ++i) {
+				_explicit_data_insert(decode_fixed64_le(ptr));
+                ptr += 8;
+            }
+            break;
         }
-        break;
-    }
-    case HLL_DATA_SPARSE: {
-        _registers = new uint8_t[HLL_REGISTERS_COUNT];
-        memset(_registers, 0, HLL_REGISTERS_COUNT);
-
-        // 2-5(4 byte): number of registers
-        uint32_t num_registers = decode_fixed32_le(ptr);
-        ptr += 4;
-        for (uint32_t i = 0; i < num_registers; ++i) {
-            // 2 bytes: register index
-            // 1 byte: register value
-            uint16_t register_idx = decode_fixed16_le(ptr);
-            ptr += 2;
-            _registers[register_idx] = *ptr++;
+        case HLL_DATA_SPARSE: {
+			_registers = new uint8_t[HLL_REGISTERS_COUNT]();
+            // 2-5(4 byte): number of registers
+            uint32_t num_registers = decode_fixed32_le(ptr);
+			uint16_t register_idx = 0;
+            ptr += 4;
+            for (uint32_t i = 0; i < num_registers; ++i) {
+                // 2 bytes: register index 
+                // 1 byte: register value
+                register_idx = decode_fixed16_le(ptr);
+                ptr += 2;
+                _registers[register_idx] = *ptr++;
+            }
+            break;
         }
-        break;
-    }
-    case HLL_DATA_FULL: {
-        _registers = new uint8_t[HLL_REGISTERS_COUNT];
-        // 2+ : hll register value
-        memcpy(_registers, ptr, HLL_REGISTERS_COUNT);
-        break;
-    }
-    default:
-        // revert type to EMPTY
-        _type = HLL_DATA_EMPTY;
-        return false;
+        case HLL_DATA_FULL: {
+			_registers = new uint8_t[HLL_REGISTERS_COUNT];
+            // 2+ : hll register value
+            memcpy(_registers, ptr, HLL_REGISTERS_COUNT);
+            break;
+        }
+        default:
+            // revert type to EMPTY
+            _type = HLL_DATA_EMPTY;
+            return false;
     }
     return true;
 }
@@ -320,7 +384,7 @@ int64_t HyperLogLog::estimate_cardinality() const {
         return 0;
     }
     if (_type == HLL_DATA_EXPLICIT) {
-        return _hash_set.size();
+        return _explicit_data_num;
     }
 
     const int num_streams = HLL_REGISTERS_COUNT;
@@ -363,8 +427,8 @@ int64_t HyperLogLog::estimate_cardinality() const {
         // there are relatively large fluctuations, we fixed the problem refer to redis.
         double bias = 5.9119 * 1.0e-18 * (estimate * estimate * estimate * estimate) -
                       1.4253 * 1.0e-12 * (estimate * estimate * estimate) +
-                      1.2940 * 1.0e-7 * (estimate * estimate) - 5.2921 * 1.0e-3 * estimate +
-                      83.3216;
+                      1.2940 * 1.0e-7 * (estimate * estimate) -
+                      5.2921 * 1.0e-3 * estimate + 83.3216;
         estimate -= estimate * (bias / 100);
     }
     return (int64_t)(estimate + 0.5);
@@ -372,44 +436,44 @@ int64_t HyperLogLog::estimate_cardinality() const {
 
 void HllSetResolver::parse() {
     // skip LengthValueType
-    char* pdata = _buf_ref;
+    char*  pdata = _buf_ref;
     _set_type = (HllDataType)pdata[0];
     char* sparse_data = NULL;
     switch (_set_type) {
-    case HLL_DATA_EXPLICIT:
-        // first byte : type
-        // second～five byte : hash values's number
-        // five byte later : hash value
-        _explicit_num = (ExplicitLengthValueType)(pdata[sizeof(SetTypeValueType)]);
-        _explicit_value =
-                (uint64_t*)(pdata + sizeof(SetTypeValueType) + sizeof(ExplicitLengthValueType));
-        break;
-    case HLL_DATA_SPARSE:
-        // first byte : type
-        // second ～（2^HLL_COLUMN_PRECISION)/8 byte : bitmap mark which is not zero
-        // 2^HLL_COLUMN_PRECISION)/8 ＋ 1以后value
-        _sparse_count = (SparseLengthValueType*)(pdata + sizeof(SetTypeValueType));
-        sparse_data = pdata + sizeof(SetTypeValueType) + sizeof(SparseLengthValueType);
-        for (int i = 0; i < *_sparse_count; i++) {
-            SparseIndexType* index = (SparseIndexType*)sparse_data;
-            sparse_data += sizeof(SparseIndexType);
-            SparseValueType* value = (SparseValueType*)sparse_data;
-            _sparse_map[*index] = *value;
-            sparse_data += sizeof(SetTypeValueType);
-        }
-        break;
-    case HLL_DATA_FULL:
-        // first byte : type
-        // second byte later : hll register value
-        _full_value_position = pdata + sizeof(SetTypeValueType);
-        break;
-    default:
-        // HLL_DATA_EMPTY
-        break;
+        case HLL_DATA_EXPLICIT:
+            // first byte : type
+            // second～five byte : hash values's number
+            // five byte later : hash value
+            _explicit_num = (ExplicitLengthValueType) (pdata[sizeof(SetTypeValueType)]);
+            _explicit_value = (uint64_t*)(pdata + sizeof(SetTypeValueType)
+                    + sizeof(ExplicitLengthValueType));
+            break;
+        case HLL_DATA_SPARSE:
+            // first byte : type
+            // second ～（2^HLL_COLUMN_PRECISION)/8 byte : bitmap mark which is not zero
+            // 2^HLL_COLUMN_PRECISION)/8 ＋ 1以后value
+            _sparse_count = (SparseLengthValueType*)(pdata + sizeof (SetTypeValueType));
+            sparse_data = pdata + sizeof(SetTypeValueType) + sizeof(SparseLengthValueType);
+            for (int i = 0; i < *_sparse_count; i++) {
+                SparseIndexType* index = (SparseIndexType*)sparse_data;
+                sparse_data += sizeof(SparseIndexType);
+                SparseValueType* value = (SparseValueType*)sparse_data;
+                _sparse_map[*index] = *value;
+                sparse_data += sizeof(SetTypeValueType);
+            }
+            break;
+        case HLL_DATA_FULL:
+            // first byte : type
+            // second byte later : hll register value
+            _full_value_position = pdata + sizeof (SetTypeValueType);
+            break;
+        default:
+            // HLL_DATA_EMPTY
+            break;
     }
 }
 
-void HllSetHelper::set_sparse(char* result, const std::map<int, uint8_t>& index_to_value,
+void HllSetHelper::set_sparse(char *result, const std::map<int, uint8_t>& index_to_value, 
                               int& len) {
     result[0] = HLL_DATA_SPARSE;
     len = sizeof(HllSetResolver::SetTypeValueType) + sizeof(HllSetResolver::SparseLengthValueType);

--- a/be/src/olap/hll.cpp
+++ b/be/src/olap/hll.cpp
@@ -145,7 +145,7 @@ void HyperLogLog::merge(const HyperLogLog& other) {
                 _convert_explicit_to_register(); 
                 _type = HLL_DATA_FULL; 
             }
-			}
+            }
             break;
         case HLL_DATA_SPARSE:
         case HLL_DATA_FULL: 
@@ -243,7 +243,7 @@ size_t HyperLogLog::serialize(uint8_t* dst) const {
 
             for (uint32_t i = 0; i < HLL_REGISTERS_COUNT;) {
                 if (*(uint32_t*)(&_registers[i]) == 0) {
-					i += 4;
+                    i += 4;
                     continue;
                 } 
 				
@@ -345,16 +345,16 @@ bool HyperLogLog::deserialize(const Slice& slice) {
             uint8_t num_explicits = *ptr++;
             // 3+: 8 bytes hash value
             for (int i = 0; i < num_explicits; ++i) {
-				_explicit_data_insert(decode_fixed64_le(ptr));
+                _explicit_data_insert(decode_fixed64_le(ptr));
                 ptr += 8;
             }
             break;
         }
         case HLL_DATA_SPARSE: {
-			_registers = new uint8_t[HLL_REGISTERS_COUNT]();
+            _registers = new uint8_t[HLL_REGISTERS_COUNT]();
             // 2-5(4 byte): number of registers
-            uint32_t num_registers = decode_fixed32_le(ptr);
-			uint16_t register_idx = 0;
+            uint32_t num_registers = decode_fixed32_le(ptr); 
+            uint16_t register_idx = 0;
             ptr += 4;
             for (uint32_t i = 0; i < num_registers; ++i) {
                 // 2 bytes: register index 
@@ -365,8 +365,8 @@ bool HyperLogLog::deserialize(const Slice& slice) {
             }
             break;
         }
-        case HLL_DATA_FULL: {
-			_registers = new uint8_t[HLL_REGISTERS_COUNT];
+        case HLL_DATA_FULL: { 
+            _registers = new uint8_t[HLL_REGISTERS_COUNT];
             // 2+ : hll register value
             memcpy(_registers, ptr, HLL_REGISTERS_COUNT);
             break;

--- a/be/src/olap/hll.h
+++ b/be/src/olap/hll.h
@@ -153,9 +153,8 @@ public:
 private:
     HllDataType _type = HLL_DATA_EMPTY;
 
-	//TODO: 二叉堆的实现是更优解
-	uint32_t _explicit_data_num = 0;
-	uint64_t _explicit_data[HLL_EXPLICIT_INT64_NUM * 2];
+    uint32_t _explicit_data_num = 0;
+    uint64_t _explicit_data[HLL_EXPLICIT_INT64_NUM * 2];
 
     // This field is much space consuming(HLL_REGISTERS_COUNT), we create
     // it only when it is really needed.

--- a/be/src/olap/hll.h
+++ b/be/src/olap/hll.h
@@ -183,10 +183,9 @@ private:
         for (int i = 0; i < HLL_REGISTERS_COUNT; ++i) {
              _registers[i] = (_registers[i] < other[i] ? other[i] : _registers[i]);
         }
-	}
+    }
 
-	bool _explicit_data_insert(uint64_t data)
-	{
+    bool _explicit_data_insert(uint64_t data) {
         //find insert pos
         int32_t i = (int32_t)_explicit_data_num - 1;
         while (i >= 0) {
@@ -210,7 +209,7 @@ private:
         _explicit_data[i] = data;
         _explicit_data_num++;
         return true;
-	}
+    }
 };
 
 // todo(kks): remove this when dpp_sink class was removed

--- a/be/src/olap/hll.h
+++ b/be/src/olap/hll.h
@@ -82,8 +82,8 @@ public:
 
     HyperLogLog() = default;
     explicit HyperLogLog(uint64_t hash_value): _type(HLL_DATA_EXPLICIT) {
-		_explicit_data[0] = hash_value;
-		_explicit_data_num = 1;
+        _explicit_data[0] = hash_value;
+        _explicit_data_num = 1;
     }
 
     explicit HyperLogLog(const Slice& src);
@@ -180,16 +180,16 @@ private:
 
     // absorb other registers into this registers
     void _merge_registers(const uint8_t* other) {
-		for (int i = 0; i < HLL_REGISTERS_COUNT; ++i) {
-            _registers[i] = (_registers[i] < other[i] ? other[i] : _registers[i]);
-		}
+        for (int i = 0; i < HLL_REGISTERS_COUNT; ++i) {
+             _registers[i] = (_registers[i] < other[i] ? other[i] : _registers[i]);
+        }
 	}
 
 	bool _explicit_data_insert(uint64_t data)
 	{
         //find insert pos
-		int32_t i = (int32_t)_explicit_data_num - 1;
-		while (i >= 0) {
+        int32_t i = (int32_t)_explicit_data_num - 1;
+        while (i >= 0) {
             if (_explicit_data[i] == data) {
                 return false;
             } else if (_explicit_data[i] < data) {
@@ -209,7 +209,7 @@ private:
         //insert data
         _explicit_data[i] = data;
         _explicit_data_num++;
-		return true;
+        return true;
 	}
 };
 

--- a/be/src/olap/hll.h
+++ b/be/src/olap/hll.h
@@ -18,10 +18,10 @@
 #ifndef DORIS_BE_SRC_OLAP_HLL_H
 #define DORIS_BE_SRC_OLAP_HLL_H
 
+#include <map>
 #include <math.h>
 #include <stdio.h>
 #include <set>
-#include <map>
 #include <string>
 
 #include "gutil/macros.h"
@@ -131,22 +131,22 @@ public:
     // only for debug
     std::string to_string() {
         switch (_type) {
-            case HLL_DATA_EMPTY:
-                return {};
-            case HLL_DATA_EXPLICIT:
-            case HLL_DATA_SPARSE:
-            case HLL_DATA_FULL:
-                {
-                    std::string str {"hash set size: "};
-                    str.append(std::to_string((size_t)_explicit_data_num));
-                    str.append("\ncardinality:\t");
-                    str.append(std::to_string(estimate_cardinality()));
-                    str.append("\ntype:\t");
-                    str.append(std::to_string(_type));
-                    return str;
-                }
-            default:
-                return {};
+        case HLL_DATA_EMPTY:
+            return {};
+        case HLL_DATA_EXPLICIT:
+        case HLL_DATA_SPARSE:
+        case HLL_DATA_FULL:
+            {
+                std::string str {"hash set size: "};
+                str.append(std::to_string((size_t)_explicit_data_num));
+                str.append("\ncardinality:\t");
+                str.append(std::to_string(estimate_cardinality()));
+                str.append("\ntype:\t");
+                str.append(std::to_string(_type));
+                return str;
+            }
+        default:
+            return {};
         }
     }
 
@@ -174,13 +174,13 @@ private:
         // make sure max first_one_bit is HLL_ZERO_COUNT_BITS + 1
         hash_value |= ((uint64_t)1 << HLL_ZERO_COUNT_BITS);
         uint8_t first_one_bit = __builtin_ctzl(hash_value) + 1;
-        _registers[idx] = (_registers[idx] > first_one_bit ? _registers[idx] : first_one_bit);
+        _registers[idx] = _registers[idx] > first_one_bit ? _registers[idx] : first_one_bit;
     }
 
     // absorb other registers into this registers
     void _merge_registers(const uint8_t* other) {
         for (int i = 0; i < HLL_REGISTERS_COUNT; ++i) {
-             _registers[i] = (_registers[i] < other[i] ? other[i] : _registers[i]);
+            _registers[i] = _registers[i] < other[i] ? other[i] : _registers[i];
         }
     }
 

--- a/be/src/olap/hll.h
+++ b/be/src/olap/hll.h
@@ -20,9 +20,8 @@
 
 #include <math.h>
 #include <stdio.h>
-
-#include <map>
 #include <set>
+#include <map>
 #include <string>
 
 #include "gutil/macros.h"
@@ -65,7 +64,7 @@ const static int HLL_EMPTY_SIZE = 1;
 // (1 + 4 + 3 * 4096) = 12293.
 //
 // HLL_DATA_FULL: most space-consuming, store all registers
-//
+// 
 // A HLL value will change in the sequence empty -> explicit -> sparse -> full, and not
 // allow reverse.
 //
@@ -80,9 +79,11 @@ enum HllDataType {
 
 class HyperLogLog {
 public:
+
     HyperLogLog() = default;
-    explicit HyperLogLog(uint64_t hash_value) : _type(HLL_DATA_EXPLICIT) {
-        _hash_set.emplace(hash_value);
+    explicit HyperLogLog(uint64_t hash_value): _type(HLL_DATA_EXPLICIT) {
+		_explicit_data[0] = hash_value;
+		_explicit_data_num = 1;
     }
 
     explicit HyperLogLog(const Slice& src);
@@ -124,33 +125,37 @@ public:
 
     // Check if input slice is a valid serialized binary of HyperLogLog.
     // This function only check the encoded type in slice, whose complex
-    // function is O(1).
+    // function is O(1). 
     static bool is_valid(const Slice& slice);
 
     // only for debug
     std::string to_string() {
         switch (_type) {
-        case HLL_DATA_EMPTY:
-            return {};
-        case HLL_DATA_EXPLICIT:
-        case HLL_DATA_SPARSE:
-        case HLL_DATA_FULL: {
-            std::string str{"hash set size: "};
-            str.append(std::to_string(_hash_set.size()));
-            str.append("\ncardinality:\t");
-            str.append(std::to_string(estimate_cardinality()));
-            str.append("\ntype:\t");
-            str.append(std::to_string(_type));
-            return str;
-        }
-        default:
-            return {};
+            case HLL_DATA_EMPTY:
+                return {};
+            case HLL_DATA_EXPLICIT:
+            case HLL_DATA_SPARSE:
+            case HLL_DATA_FULL:
+                {
+                    std::string str {"hash set size: "};
+                    str.append(std::to_string((size_t)_explicit_data_num));
+                    str.append("\ncardinality:\t");
+                    str.append(std::to_string(estimate_cardinality()));
+                    str.append("\ntype:\t");
+                    str.append(std::to_string(_type));
+                    return str;
+                }
+            default:
+                return {};
         }
     }
 
 private:
     HllDataType _type = HLL_DATA_EMPTY;
-    std::set<uint64_t> _hash_set;
+
+	//TODO: 二叉堆的实现是更优解
+	uint32_t _explicit_data_num = 0;
+	uint64_t _explicit_data[HLL_EXPLICIT_INT64_NUM * 2];
 
     // This field is much space consuming(HLL_REGISTERS_COUNT), we create
     // it only when it is really needed.
@@ -162,7 +167,7 @@ private:
     void _convert_explicit_to_register();
 
     // update one hash value into this registers
-    void _update_registers(uint64_t hash_value) {
+    inline void _update_registers(uint64_t hash_value) {
         // Use the lower bits to index into the number of streams and then
         // find the first 1 bit after the index bits.
         int idx = hash_value % HLL_REGISTERS_COUNT;
@@ -170,27 +175,53 @@ private:
         // make sure max first_one_bit is HLL_ZERO_COUNT_BITS + 1
         hash_value |= ((uint64_t)1 << HLL_ZERO_COUNT_BITS);
         uint8_t first_one_bit = __builtin_ctzl(hash_value) + 1;
-        _registers[idx] = std::max((uint8_t)_registers[idx], first_one_bit);
+        _registers[idx] = (_registers[idx] > first_one_bit ? _registers[idx] : first_one_bit);
     }
 
     // absorb other registers into this registers
-    void _merge_registers(const uint8_t* other_registers) {
-        for (int i = 0; i < HLL_REGISTERS_COUNT; ++i) {
-            _registers[i] = std::max(_registers[i], other_registers[i]);
+    void _merge_registers(const uint8_t* other) {
+		for (int i = 0; i < HLL_REGISTERS_COUNT; ++i) {
+            _registers[i] = (_registers[i] < other[i] ? other[i] : _registers[i]);
+		}
+	}
+
+	bool _explicit_data_insert(uint64_t data)
+	{
+        //find insert pos
+		int32_t i = (int32_t)_explicit_data_num - 1;
+		while (i >= 0) {
+            if (_explicit_data[i] == data) {
+                return false;
+            } else if (_explicit_data[i] < data) {
+                break;
+            } else {
+                --i;
+            }
         }
-    }
+
+        ++i; //now, i is the insert position
+
+        size_t n = (_explicit_data_num - i) * sizeof(*_explicit_data);
+        if (n) {
+            memmove(_explicit_data+i+1, _explicit_data+i, n);
+        }
+
+        //insert data
+        _explicit_data[i] = data;
+        _explicit_data_num++;
+		return true;
+	}
 };
 
 // todo(kks): remove this when dpp_sink class was removed
 class HllSetResolver {
 public:
-    HllSetResolver()
-            : _buf_ref(nullptr),
-              _buf_len(0),
-              _set_type(HLL_DATA_EMPTY),
-              _full_value_position(nullptr),
-              _explicit_value(nullptr),
-              _explicit_num(0) {}
+    HllSetResolver() : _buf_ref(nullptr),
+                       _buf_len(0),
+                       _set_type(HLL_DATA_EMPTY),
+                       _full_value_position(nullptr),
+                       _explicit_value(nullptr),
+                       _explicit_num(0) {}
 
     ~HllSetResolver() {}
 
@@ -201,16 +232,16 @@ public:
     typedef uint8_t SparseValueType;
 
     // only save pointer
-    void init(char* buf, int len) {
+    void init(char* buf, int len){
         this->_buf_ref = buf;
         this->_buf_len = len;
     }
 
     // hll set type
-    HllDataType get_hll_data_type() { return _set_type; };
+    HllDataType get_hll_data_type() { return _set_type; }
 
     // explicit value num
-    int get_explicit_count() { return (int)_explicit_num; };
+    int get_explicit_count() { return (int)_explicit_num; }
 
     // get explicit index value 64bit
     uint64_t get_explicit_value(int index) {
@@ -218,21 +249,20 @@ public:
             return -1;
         }
         return _explicit_value[index];
-    };
+    }
 
     // get full register value
-    char* get_full_value() { return _full_value_position; };
+    char* get_full_value() { return _full_value_position; }
 
     // get (index, value) map
-    std::map<SparseIndexType, SparseValueType>& get_sparse_map() { return _sparse_map; };
+    std::map<SparseIndexType, SparseValueType>& get_sparse_map() { return _sparse_map; }
 
     // parse set , call after copy() or init()
     void parse();
-
-private:
-    char* _buf_ref;        // set
-    int _buf_len;          // set len
-    HllDataType _set_type; //set type
+private :
+    char* _buf_ref;    // set
+    int _buf_len;      // set len
+    HllDataType _set_type;        //set type
     char* _full_value_position;
     uint64_t* _explicit_value;
     ExplicitLengthValueType _explicit_num;
@@ -249,6 +279,6 @@ public:
                          const int set_len, int& len);
 };
 
-} // namespace doris
+}  // namespace doris
 
 #endif // DORIS_BE_SRC_OLAP_HLL_H

--- a/be/src/util/coding.h
+++ b/be/src/util/coding.h
@@ -27,37 +27,37 @@ inline void encode_fixed8(uint8_t* buf, uint8_t val) {
 
 inline void encode_fixed16_le(uint8_t* buf, uint16_t val) {
 #if __BYTE_ORDER == __LITTLE_ENDIAN
-    memcpy(buf, &val, sizeof(val));
+    *(uint16_t*)buf = val;
 #else
     uint16_t res = bswap_16(val);
-    memcpy(buf, &res, sizeof(res));
+    *(uint16_t*)buf = res;
 #endif
 }
 
 inline void encode_fixed32_le(uint8_t* buf, uint32_t val) {
 #if __BYTE_ORDER == __LITTLE_ENDIAN
-    memcpy(buf, &val, sizeof(val));
+    *(uint32_t*)buf = val;
 #else
     uint32_t res = bswap_32(val);
-    memcpy(buf, &res, sizeof(res));
+    *(uint32_t*)buf = res;
 #endif
 }
 
 inline void encode_fixed64_le(uint8_t* buf, uint64_t val) {
 #if __BYTE_ORDER == __LITTLE_ENDIAN
-    memcpy(buf, &val, sizeof(val));
+    *(uint64_t*)buf = val;
 #else
     uint64_t res = gbswap_64(val);
-    memcpy(buf, &res, sizeof(res));
+    *(uint64_t*)buf = res;
 #endif
 }
 
 inline void encode_fixed128_le(uint8_t* buf, uint128_t val) {
 #if __BYTE_ORDER == __LITTLE_ENDIAN
-    memcpy(buf, &val, sizeof(val));
+    *(uint128_t*)buf = val;
 #else
     uint128_t res = gbswap_128(val);
-    memcpy(buf, &res, sizeof(res));
+    *(uint128_t*)buf = res;
 #endif
 }
 
@@ -66,8 +66,7 @@ inline uint8_t decode_fixed8(const uint8_t* buf) {
 }
 
 inline uint16_t decode_fixed16_le(const uint8_t* buf) {
-    uint16_t res;
-    memcpy(&res, buf, sizeof(res));
+    uint16_t res = *(uint16_t*)buf;
 #if __BYTE_ORDER == __LITTLE_ENDIAN
     return res;
 #else
@@ -76,8 +75,7 @@ inline uint16_t decode_fixed16_le(const uint8_t* buf) {
 }
 
 inline uint32_t decode_fixed32_le(const uint8_t* buf) {
-    uint32_t res;
-    memcpy(&res, buf, sizeof(res));
+    uint32_t res = *(uint32_t*)buf;
 #if __BYTE_ORDER == __LITTLE_ENDIAN
     return res;
 #else
@@ -86,8 +84,7 @@ inline uint32_t decode_fixed32_le(const uint8_t* buf) {
 }
 
 inline uint64_t decode_fixed64_le(const uint8_t* buf) {
-    uint64_t res;
-    memcpy(&res, buf, sizeof(res));
+    uint64_t res = *(uint64_t*)buf;
 #if __BYTE_ORDER == __LITTLE_ENDIAN
     return res;
 #else
@@ -96,8 +93,7 @@ inline uint64_t decode_fixed64_le(const uint8_t* buf) {
 }
 
 inline uint128_t decode_fixed128_le(const uint8_t* buf) {
-    uint128_t res;
-    memcpy(&res, buf, sizeof(res));
+    uint128_t res = *(uint128_t*)buf;
 #if __BYTE_ORDER == __LITTLE_ENDIAN
     return res;
 #else

--- a/be/src/util/coding.h
+++ b/be/src/util/coding.h
@@ -27,37 +27,37 @@ inline void encode_fixed8(uint8_t* buf, uint8_t val) {
 
 inline void encode_fixed16_le(uint8_t* buf, uint16_t val) {
 #if __BYTE_ORDER == __LITTLE_ENDIAN
-    *(uint16_t*)buf = val;
+    memcpy(buf, &val, sizeof(val));
 #else
     uint16_t res = bswap_16(val);
-    *(uint16_t*)buf = res;
+    memcpy(buf, &res, sizeof(res));
 #endif
 }
 
 inline void encode_fixed32_le(uint8_t* buf, uint32_t val) {
 #if __BYTE_ORDER == __LITTLE_ENDIAN
-    *(uint32_t*)buf = val;
+    memcpy(buf, &val, sizeof(val));
 #else
     uint32_t res = bswap_32(val);
-    *(uint32_t*)buf = res;
+    memcpy(buf, &res, sizeof(res));
 #endif
 }
 
 inline void encode_fixed64_le(uint8_t* buf, uint64_t val) {
 #if __BYTE_ORDER == __LITTLE_ENDIAN
-    *(uint64_t*)buf = val;
+    memcpy(buf, &val, sizeof(val));
 #else
     uint64_t res = gbswap_64(val);
-    *(uint64_t*)buf = res;
+    memcpy(buf, &res, sizeof(res));
 #endif
 }
 
 inline void encode_fixed128_le(uint8_t* buf, uint128_t val) {
 #if __BYTE_ORDER == __LITTLE_ENDIAN
-    *(uint128_t*)buf = val;
+    memcpy(buf, &val, sizeof(val));
 #else
     uint128_t res = gbswap_128(val);
-    *(uint128_t*)buf = res;
+    memcpy(buf, &res, sizeof(res));
 #endif
 }
 
@@ -66,7 +66,8 @@ inline uint8_t decode_fixed8(const uint8_t* buf) {
 }
 
 inline uint16_t decode_fixed16_le(const uint8_t* buf) {
-    uint16_t res = *(uint16_t*)buf;
+    uint16_t res;
+    memcpy(&res, buf, sizeof(res));
 #if __BYTE_ORDER == __LITTLE_ENDIAN
     return res;
 #else
@@ -75,7 +76,8 @@ inline uint16_t decode_fixed16_le(const uint8_t* buf) {
 }
 
 inline uint32_t decode_fixed32_le(const uint8_t* buf) {
-    uint32_t res = *(uint32_t*)buf;
+    uint32_t res;
+    memcpy(&res, buf, sizeof(res));
 #if __BYTE_ORDER == __LITTLE_ENDIAN
     return res;
 #else
@@ -84,7 +86,8 @@ inline uint32_t decode_fixed32_le(const uint8_t* buf) {
 }
 
 inline uint64_t decode_fixed64_le(const uint8_t* buf) {
-    uint64_t res = *(uint64_t*)buf;
+    uint64_t res;
+    memcpy(&res, buf, sizeof(res));
 #if __BYTE_ORDER == __LITTLE_ENDIAN
     return res;
 #else
@@ -93,7 +96,8 @@ inline uint64_t decode_fixed64_le(const uint8_t* buf) {
 }
 
 inline uint128_t decode_fixed128_le(const uint8_t* buf) {
-    uint128_t res = *(uint128_t*)buf;
+    uint128_t res;
+    memcpy(&res, buf, sizeof(res));
 #if __BYTE_ORDER == __LITTLE_ENDIAN
     return res;
 #else


### PR DESCRIPTION
1. 通过三目表达式替换std::max，std::max相对三目运算符重很多
2. 通过数组替代std::set，std::set基于红黑树，遍历会沿着链域走，cache命中性不好
3. 优化了serialize函数，通过减少分支，提升num_non_zero_registers计算速度，优化后_registers的序列化更快
4. 测试发现，性能提升较为明显