### PR TITLE
Support hdfs in select outfile clause

### DIFF
--- a/be/src/exec/CMakeLists.txt
+++ b/be/src/exec/CMakeLists.txt
@@ -105,6 +105,7 @@ set(EXEC_FILES
     assert_num_rows_node.cpp
     s3_reader.cpp
     s3_writer.cpp
+    hdfs_writer.cpp
 )
 
 if (ARCH_AMD64)

--- a/be/src/exec/hdfs_writer.cpp
+++ b/be/src/exec/hdfs_writer.cpp
@@ -1,0 +1,147 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "exec/hdfs_writer.h"
+
+#include "common/logging.h"
+
+namespace doris {
+const static std::string FS_KEY = "fs.defaultFS";
+const static std::string USER = "hdfs_user";
+
+HDFSWriter::HDFSWriter(std::map<std::string, std::string>& properties, const std::string& path)
+        : _properties(properties),
+          _path(path),
+          _hdfs_fs(nullptr) {
+    _parse_properties(_properties);
+}
+
+HDFSWriter::~HDFSWriter() {
+    close();
+}
+
+Status HDFSWriter::open() {
+    RETURN_IF_ERROR(_connect());
+    if (_hdfs_fs == nullptr) {
+        return Status::InternalError("HDFS writer open without client");
+    }
+    int exists = hdfsExists(_hdfs_fs, _path.c_str());
+    if (exists == 0) {
+        // the path already exists
+        return Status::AlreadyExist(_path + " already exists.");
+    }
+    // open file
+    _hdfs_file = hdfsOpenFile(_hdfs_fs, _path.c_str(), O_WRONLY, 0, 0, 0);
+    if (_hdfs_file == nullptr) {
+        std::stringstream ss;
+        ss << "open file failed. namenode:" << _namenode << " path:" << _path;
+        return Status::InternalError(ss.str());
+    }
+    LOG(INFO) << "open file. namenode:" << _namenode << " path:" << _path;
+    return Status::OK();
+}
+
+Status HDFSWriter::write(const uint8_t* buf, size_t buf_len, size_t* written_len) {
+    if (buf_len == 0) {
+        *written_len = 0;
+        return Status::OK();
+    }
+    int32_t result = hdfsWrite(_hdfs_fs, _hdfs_file, buf, buf_len);
+    if (result < 0) {
+        std::stringstream ss;
+        ss << "write file failed. namenode:" << _namenode << " path:" << _path;
+        LOG(WARNING) << ss.str();
+        return Status::InternalError(ss.str());
+    }
+
+    *written_len = (unsigned int) result;
+    return Status::OK();
+}
+
+Status HDFSWriter::close() {
+    if (_closed) {
+        return Status::OK();
+    }
+    _closed = true;
+    if (_hdfs_fs == nullptr) {
+        return Status::OK();
+    }
+    if (_hdfs_file == nullptr) {
+        // Even if there is an error, the resources associated with the hdfsFS will be freed.
+        hdfsDisconnect(_hdfs_fs);
+        return Status::OK();
+    }
+    int result = hdfsFlush(_hdfs_fs, _hdfs_file);
+    if (result == -1) {
+        std::stringstream ss;
+        ss << "failed to flush hdfs file. namenode:" << _namenode << " path:" << _path;
+        LOG(WARNING) << ss.str();
+        return Status::InternalError(ss.str());
+    }
+    hdfsCloseFile(_hdfs_fs, _hdfs_file);
+    hdfsDisconnect(_hdfs_fs);
+
+    _hdfs_file = nullptr;
+    _hdfs_fs = nullptr;
+    return Status::OK();
+}
+
+Status HDFSWriter::_connect() {
+    hdfsBuilder* hdfs_builder = hdfsNewBuilder();
+    hdfsBuilderSetNameNode(hdfs_builder, _namenode.c_str());
+    // set hdfs user
+    if (!_user.empty()) {
+        hdfsBuilderSetUserName(hdfs_builder, _user.c_str());
+    }
+    // set other conf
+    if (!_properties.empty()) {
+        std::map<std::string, std::string>::iterator iter;
+        for (iter = _properties.begin(); iter != _properties.end(); iter++) {
+            hdfsBuilderConfSetStr(hdfs_builder, iter->first.c_str(), iter->second.c_str());
+        }
+    }
+    _hdfs_fs = hdfsBuilderConnect(hdfs_builder);
+    if (_hdfs_fs == nullptr) {
+        std::stringstream ss;
+        ss << "connect failed. namenode:" << _namenode;
+        return Status::InternalError(ss.str());
+    }
+    return Status::OK();
+}
+
+Status HDFSWriter::_parse_properties(std::map<std::string, std::string>& prop) {
+    std::map<std::string, std::string>::iterator iter;
+    for (iter = prop.begin(); iter != prop.end(); iter++) {
+        if (iter->first.compare(FS_KEY) == 0) {
+            _namenode = iter->second;
+            prop.erase(iter);
+        }
+        if (iter->first.compare(USER) == 0) {
+            _user = iter->second;
+            prop.erase(iter);
+        }
+    }
+
+    if (_namenode.empty()) {
+        DCHECK(false) << "hdfs properties is incorrect.";
+        LOG(ERROR) << "hdfs properties is incorrect.";
+        return Status::InternalError("hdfs properties is incorrect");
+    }
+    return Status::OK();
+}
+
+}// end namespace doris

--- a/be/src/exec/hdfs_writer.cpp
+++ b/be/src/exec/hdfs_writer.cpp
@@ -22,6 +22,9 @@
 namespace doris {
 const static std::string FS_KEY = "fs.defaultFS";
 const static std::string USER = "hdfs_user";
+const static std::string KERBEROS_PRINCIPAL = "kerberos_principal";
+const static std::string KERB_TICKET_CACHE_PATH = "kerb_ticket_cache_path";
+const static std::string TOKEN = "token";
 
 HDFSWriter::HDFSWriter(std::map<std::string, std::string>& properties, const std::string& path)
         : _properties(properties),
@@ -107,6 +110,17 @@ Status HDFSWriter::_connect() {
     if (!_user.empty()) {
         hdfsBuilderSetUserName(hdfs_builder, _user.c_str());
     }
+    // set kerberos conf
+    if (!_kerb_principal.empty()) {
+        hdfsBuilderSetPrincipal(hdfs_builder, _kerb_principal.c_str());
+    }
+    if (!_kerb_ticket_cache_path.empty()) {
+        hdfsBuilderSetKerbTicketCachePath(hdfs_builder, _kerb_ticket_cache_path.c_str());
+    }
+    // set token
+    if (!_token.empty()) {
+        hdfsBuilderSetToken(hdfs_builder, _token.c_str());
+    }
     // set other conf
     if (!_properties.empty()) {
         std::map<std::string, std::string>::iterator iter;
@@ -132,6 +146,18 @@ Status HDFSWriter::_parse_properties(std::map<std::string, std::string>& prop) {
         }
         if (iter->first.compare(USER) == 0) {
             _user = iter->second;
+            prop.erase(iter);
+        }
+        if (iter->first.compare(KERBEROS_PRINCIPAL) == 0) {
+            _kerb_principal = iter->second;
+            prop.erase(iter);
+        }
+        if (iter->first.compare(KERB_TICKET_CACHE_PATH) == 0) {
+            _kerb_ticket_cache_path = iter->second;
+            prop.erase(iter);
+        }
+        if (iter->first.compare(TOKEN) == 0) {
+            _token = iter->second;
             prop.erase(iter);
         }
     }

--- a/be/src/exec/hdfs_writer.h
+++ b/be/src/exec/hdfs_writer.h
@@ -1,0 +1,54 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <hdfs/hdfs.h>
+
+#include <map>
+#include <string>
+
+#include "exec/file_writer.h"
+
+namespace doris {
+class HDFSWriter : public FileWriter {
+
+public:
+    HDFSWriter(std::map<std::string, std::string>& properties, const std::string& path);
+    ~HDFSWriter();
+    Status open() override;
+
+    // Writes up to count bytes from the buffer pointed buf to the file.
+    // NOTE: the number of bytes written may be less than count if.
+    Status write(const uint8_t* buf, size_t buf_len, size_t* written_len) override;
+
+    Status close() override;
+
+private:
+    Status _connect();
+    Status _parse_properties(std::map<std::string, std::string>& prop);
+
+    std::map<std::string, std::string> _properties;
+    std::string _user = "";
+    std::string _namenode = "";
+    std::string _path = "";
+    hdfsFS _hdfs_fs = nullptr;
+    hdfsFile _hdfs_file = nullptr;
+    bool _closed = false;
+};
+
+}

--- a/be/src/exec/hdfs_writer.h
+++ b/be/src/exec/hdfs_writer.h
@@ -46,6 +46,9 @@ private:
     std::string _user = "";
     std::string _namenode = "";
     std::string _path = "";
+    std::string _kerb_principal = "";
+    std::string _kerb_ticket_cache_path = "";
+    std::string _token = "";
     hdfsFS _hdfs_fs = nullptr;
     hdfsFile _hdfs_file = nullptr;
     bool _closed = false;

--- a/be/src/runtime/file_result_writer.cpp
+++ b/be/src/runtime/file_result_writer.cpp
@@ -21,6 +21,7 @@
 #include "exec/local_file_writer.h"
 #include "exec/parquet_writer.h"
 #include "exec/s3_writer.h"
+#include "exec/hdfs_writer.h"
 #include "exprs/expr.h"
 #include "exprs/expr_context.h"
 #include "gen_cpp/PaloInternalService_types.h"
@@ -131,12 +132,14 @@ Status FileResultWriter::_create_next_file_writer() {
 Status FileResultWriter::_create_file_writer(const std::string& file_name) {
     if (_storage_type == TStorageBackendType::LOCAL) {
         _file_writer = new LocalFileWriter(file_name, 0 /* start offset */);
-    } else if (_storage_type == TStorageBackendType::BROKER){
+    } else if (_storage_type == TStorageBackendType::BROKER) {
         _file_writer =
                 new BrokerWriter(_state->exec_env(), _file_opts->broker_addresses,
                                  _file_opts->broker_properties, file_name, 0 /*start offset*/);
     } else if (_storage_type == TStorageBackendType::S3) {
         _file_writer =  new S3Writer(_file_opts->broker_properties, file_name, 0 /* offset */);
+    } else if (_storage_type == TStorageBackendType::HDFS) {
+        _file_writer = new HDFSWriter(const_cast<std::map<std::string, std::string>&>(_file_opts->broker_properties), file_name);
     }
     RETURN_IF_ERROR(_file_writer->open());
     switch (_file_opts->file_format) {

--- a/docs/zh-CN/administrator-guide/outfile.md
+++ b/docs/zh-CN/administrator-guide/outfile.md
@@ -30,7 +30,7 @@ under the License.
 
 ## 语法
 
-`SELECT INTO OUTFILE` 语句可以将查询结果导出到文件中。目前支持通过 Broker 进程, 或直接通过 S3 协议导出到远端存储，如 HDFS，S3，BOS，COS（腾讯云）上。语法如下
+`SELECT INTO OUTFILE` 语句可以将查询结果导出到文件中。目前支持通过 Broker 进程, 通过 S3 协议, 或直接通过 HDFS 协议，导出到远端存储，如 HDFS，S3，BOS，COS（腾讯云）上。语法如下
 
 ```
 query_stmt
@@ -65,10 +65,13 @@ INTO OUTFILE "file_path"
     指定相关属性。目前支持通过 Broker 进程, 或通过 S3 协议进行导出。
 
     + Broker 相关属性需加前缀 `broker.`。具体参阅[Broker 文档](./broker.html)。
+    + HDFS 相关属性需加前缀 `hdfs.`。
     + S3 协议则直接执行 S3 协议配置即可。
 
     ```
     ("broker.prop_key" = "broker.prop_val", ...)
+    or
+    ("hdfs.fs.defaultFS" = "xxx", "hdfs.hdfs_user" = "xxx")
     or 
     ("AWS_ENDPOINT" = "xxx", ...)
     ``` 
@@ -90,7 +93,7 @@ INTO OUTFILE "file_path"
 默认情况下，查询结果集的导出是非并发的，也就是单点导出。如果用户希望查询结果集可以并发导出，需要满足以下条件：
 
 1. session variable 'enable_parallel_outfile' 开启并发导出: ```set enable_parallel_outfile = true;```
-2. 导出方式为 S3 , 而不是使用 broker
+2. 导出方式为 S3 , 或者 HDFS， 而不是使用 broker
 3. 查询可以满足并发导出的需求，比如顶层不包含 sort 等单点节点。（后面会举例说明，哪种属于不可并发导出结果集的查询）
 
 满足以上三个条件，就能触发并发导出查询结果集了。并发度 = ```be_instacne_num * parallel_fragment_exec_instance_num```
@@ -136,7 +139,7 @@ explain select xxx from xxx where xxx  into outfile "s3://xxx" format as csv pro
 
 1. 示例1
 
-    将简单查询结果导出到文件 `hdfs:/path/to/result.txt`。指定导出格式为 CSV。使用 `my_broker` 并设置 kerberos 认证信息。指定列分隔符为 `,`，行分隔符为 `\n`。
+    使用 broker 方式导出，将简单查询结果导出到文件 `hdfs:/path/to/result.txt`。指定导出格式为 CSV。使用 `my_broker` 并设置 kerberos 认证信息。指定列分隔符为 `,`，行分隔符为 `\n`。
 
     ```
     SELECT * FROM tbl
@@ -278,6 +281,23 @@ explain select xxx from xxx where xxx  into outfile "s3://xxx" format as csv pro
 
     **但由于查询语句带了一个顶层的排序节点，所以这个查询即使开启并发导出的 session 变量，也是无法并发导出的。**
 
+7. 示例7
+
+    使用 hdfs 方式导出，将简单查询结果导出到文件 `hdfs:/path/to/result.txt`。指定导出格式为 CSV。使用并设置 kerberos 认证信息。
+
+    ```
+    SELECT * FROM tbl
+    INTO OUTFILE "hdfs://path/to/result_"
+    FORMAT AS CSV
+    PROPERTIES
+    (
+        "hdfs.fs.defaultFS" = "hdfs://namenode:port",
+        "hdfs.hadoop.security.authentication" = "kerberos",
+        "hdfs.kerberos_principal" = "doris@YOUR.COM",
+        "hdfs.kerberos_keytab" = "/home/doris/my.keytab"
+    );
+    ```
+    
 ## 返回结果
 
 导出命令为同步命令。命令返回，即表示操作结束。同时会返回一行结果来展示导出的执行结果。

--- a/fe/fe-core/src/main/java/org/apache/doris/backup/HDFSStorage.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/backup/HDFSStorage.java
@@ -19,7 +19,10 @@ package org.apache.doris.backup;
 
 import org.apache.doris.common.UserException;
 
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 // TODO: extend BlobStorage
 public class HDFSStorage {
@@ -29,16 +32,21 @@ public class HDFSStorage {
     public static final String NAME_NODES = "dfs.ha.namenodes";
     public static final String RPC_ADDRESS = "dfs.namenode.rpc-address";
     public static final String FAILOVER_PROXY = "dfs.client.failover.proxy.provider";
+    public static final String AUTHENTICATION = "hadoop.security.authentication";
+    public static final String KERBEROS_PRINCIPAL = "kerberos_principal";
+    public static final String KERBEROS_KEYTAB = "kerberos_keytab";
+
+    public static Set<String> keySets = new HashSet<>(Arrays.asList(HDFS_DEFAULT_FS, USER,
+            NAME_SERVICES, NAME_NODES, RPC_ADDRESS, FAILOVER_PROXY,
+            AUTHENTICATION, KERBEROS_PRINCIPAL, KERBEROS_KEYTAB));
 
 
     public static void checkHDFS(Map<String, String> properties) throws UserException {
         if (!properties.containsKey(HDFS_DEFAULT_FS)) {
-            throw new UserException(HDFS_DEFAULT_FS + " not found.");
+            throw new UserException(HDFS_DEFAULT_FS + " not found. This is required field");
         }
         for (String key : properties.keySet()) {
-            if (!(key.startsWith(NAME_SERVICES) || key.startsWith(NAME_NODES)
-                    || key.startsWith(RPC_ADDRESS) || key.startsWith(FAILOVER_PROXY)
-                    || key.equals(USER) || key.equals(HDFS_DEFAULT_FS))) {
+            if (!keySets.contains(key)) {
                 throw new UserException("Unknown properties " + key);
             }
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/backup/HDFSStorage.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/backup/HDFSStorage.java
@@ -1,0 +1,46 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.backup;
+
+import org.apache.doris.common.UserException;
+
+import java.util.Map;
+
+// TODO: extend BlobStorage
+public class HDFSStorage {
+    public static final String HDFS_DEFAULT_FS = "fs.defaultFS";
+    public static final String USER = "hdfs_user";
+    public static final String NAME_SERVICES = "dfs.nameservices";
+    public static final String NAME_NODES = "dfs.ha.namenodes";
+    public static final String RPC_ADDRESS = "dfs.namenode.rpc-address";
+    public static final String FAILOVER_PROXY = "dfs.client.failover.proxy.provider";
+
+
+    public static void checkHDFS(Map<String, String> properties) throws UserException {
+        if (!properties.containsKey(HDFS_DEFAULT_FS)) {
+            throw new UserException(HDFS_DEFAULT_FS + " not found.");
+        }
+        for (String key : properties.keySet()) {
+            if (!(key.startsWith(NAME_SERVICES) || key.startsWith(NAME_NODES)
+                    || key.startsWith(RPC_ADDRESS) || key.startsWith(FAILOVER_PROXY)
+                    || key.equals(USER) || key.equals(HDFS_DEFAULT_FS))) {
+                throw new UserException("Unknown properties " + key);
+            }
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/backup/HDFSStorage.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/backup/HDFSStorage.java
@@ -34,11 +34,14 @@ public class HDFSStorage {
     public static final String FAILOVER_PROXY = "dfs.client.failover.proxy.provider";
     public static final String AUTHENTICATION = "hadoop.security.authentication";
     public static final String KERBEROS_PRINCIPAL = "kerberos_principal";
-    public static final String KERBEROS_KEYTAB = "kerberos_keytab";
+    public static final String KERB_TICKET_CACHE_PATH = "kerb_ticket_cache_path";
+    public static final String TOKEN = "token";
 
     public static Set<String> keySets = new HashSet<>(Arrays.asList(HDFS_DEFAULT_FS, USER,
             NAME_SERVICES, NAME_NODES, RPC_ADDRESS, FAILOVER_PROXY,
-            AUTHENTICATION, KERBEROS_PRINCIPAL, KERBEROS_KEYTAB));
+            AUTHENTICATION,
+            KERBEROS_PRINCIPAL, KERB_TICKET_CACHE_PATH,
+            TOKEN));
 
 
     public static void checkHDFS(Map<String, String> properties) throws UserException {


### PR DESCRIPTION
## Proposed changes

Support hdfs in select outfile clause without broker.
This PR implement a HDFS writer in BE which is used to write HDFS file directly without using broker.
Also the hdfs outfile  clause syntax check has been added in FE.
The syntax:
```
select * from xx into outfile "hdfs://user/outfile_" format as csv properties ("hdfs.fs.dafultFS" = "xxx", "hdfs.hdfs_user" = "xxx");
```
Note that all hdfs configurations need to carry a prefix `hdfs.`.

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)
- [ ] Code refactor (Modify the code structure, format the code, etc...)
- [ ] Optimization. Including functional usability improvements and performance improvements.
- [ ] Dependency. Such as changes related to third-party components.
- [ ] Other.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have created an issue on (Fix #ISSUE) and described the bug/feature there in detail
- [x] Compiling and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If these changes need document changes, I have updated the document
- [ ] Any dependent changes have been merged


