### PR TITLE
[bug] Fix zone map init error for string type

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -116,8 +116,6 @@ CONF_mInt32(download_low_speed_limit_kbps, "50");
 CONF_mInt32(download_low_speed_time, "300");
 // sleep time for one second
 CONF_Int32(sleep_one_second, "1");
-// sleep time for five seconds
-CONF_Int32(sleep_five_seconds, "5");
 
 // log dir
 CONF_String(sys_log_dir, "${DORIS_HOME}/log");
@@ -134,9 +132,6 @@ CONF_Strings(sys_log_verbose_modules, "");
 CONF_Int32(sys_log_verbose_level, "10");
 // log buffer level
 CONF_String(log_buffer_level, "");
-
-// Pull load task dir
-CONF_String(pull_load_task_dir, "${DORIS_HOME}/var/pull_load");
 
 // number of threads available to serve backend execution requests
 CONF_Int32(be_service_threads, "64");
@@ -160,8 +155,6 @@ CONF_Int32(doris_scanner_thread_pool_queue_size, "102400");
 CONF_Int32(etl_thread_pool_size, "8");
 // number of etl thread pool size
 CONF_Int32(etl_thread_pool_queue_size, "256");
-// port on which to run Doris test backend
-CONF_Int32(port, "20001");
 // default thrift client connect timeout(in seconds)
 CONF_mInt32(thrift_connect_timeout_seconds, "3");
 // default thrift client retry interval (in milliseconds)
@@ -367,10 +360,6 @@ CONF_mInt32(olap_table_sink_send_interval_ms, "1");
 CONF_Int32(fragment_pool_thread_num_min, "64");
 CONF_Int32(fragment_pool_thread_num_max, "512");
 CONF_Int32(fragment_pool_queue_size, "2048");
-
-// Spill to disk when query
-// Writable scratch directories, split by ";"
-CONF_String(query_scratch_dirs, "${DORIS_HOME}");
 
 // Control the number of disks on the machine.  If 0, this comes from the system settings.
 CONF_Int32(num_disks, "0");

--- a/be/src/runtime/tuple.cpp
+++ b/be/src/runtime/tuple.cpp
@@ -274,13 +274,14 @@ void Tuple::materialize_exprs(TupleRow* row, const TupleDescriptor& desc,
         // TODO: revisit this logic in the FE
         PrimitiveType slot_type = slot_desc->type().type;
         PrimitiveType expr_type = materialize_expr_ctxs[mat_expr_index]->root()->type().type;
-        if ((slot_type == TYPE_CHAR) || (slot_type == TYPE_VARCHAR) || (slot_type == TYPE_HLL)) {
-            DCHECK((expr_type == TYPE_CHAR) || (expr_type == TYPE_VARCHAR) ||
-                   (expr_type == TYPE_HLL));
-        } else if ((slot_type == TYPE_DATE) || (slot_type == TYPE_DATETIME)) {
-            DCHECK((expr_type == TYPE_DATE) || (expr_type == TYPE_DATETIME));
+        if (slot_type == TYPE_CHAR || slot_type == TYPE_VARCHAR || slot_type == TYPE_HLL ||
+            slot_type == TYPE_STRING) {
+            DCHECK(expr_type == TYPE_CHAR || expr_type == TYPE_VARCHAR || expr_type == TYPE_HLL ||
+                   expr_type == TYPE_STRING);
+        } else if (slot_type == TYPE_DATE || slot_type == TYPE_DATETIME) {
+            DCHECK(expr_type == TYPE_DATE || expr_type == TYPE_DATETIME);
         } else if (slot_type == TYPE_ARRAY) {
-            DCHECK((expr_type == TYPE_ARRAY));
+            DCHECK(expr_type == TYPE_ARRAY);
         } else {
             DCHECK(slot_type == TYPE_NULL || slot_type == expr_type);
         }


### PR DESCRIPTION
## Proposed changes

init zone map for string type such as `varchar` `string` `char`,  when the string is too long, it will cut off by 512 bytes,  but we should make it a little larger than the origin string  

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Code refactor (Modify the code structure, format the code, etc...)
- [ ] Optimization. Including functional usability improvements and performance improvements.
- [ ] Dependency. Such as changes related to third-party components.
- [ ] Other.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have created an issue on (Fix #ISSUE) and described the bug/feature there in detail
- [ ] Compiling and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If these changes need document changes, I have updated the document
- [ ] Any dependent changes have been merged

## Further comments

If this is a relatively large or complex change, kick off the discussion at dev@doris.apache.org by explaining why you chose the solution you did and what alternatives you considered, etc...
