### PR TITLE
[Bug] Set a weight for empty version when calculating compaction score

### DIFF
--- a/be/src/olap/olap_server.cpp
+++ b/be/src/olap/olap_server.cpp
@@ -394,7 +394,7 @@ void StorageEngine::_compaction_tasks_producer_callback() {
             for (const auto& tablet : tablets_compaction) {
                 int64_t permits =
                         tablet->prepare_compaction_and_calculate_permits(compaction_type, tablet);
-                if (permits > 0 && _permit_limiter.request(permits)) {
+                if (permits >= 0 && _permit_limiter.request(permits)) {
                     // Push to _tablet_submitted_compaction before submitting task
                     _push_tablet_into_submitted_compaction(tablet, compaction_type);
                     auto st = _compaction_thread_pool->submit_func([=]() {

--- a/be/src/olap/tablet.h
+++ b/be/src/olap/tablet.h
@@ -250,6 +250,10 @@ public:
     void set_clone_occurred(bool clone_occurred) { _is_clone_occurred = clone_occurred; }
     bool get_clone_occurred() { return _is_clone_occurred; }
 
+    static uint32_t compute_empty_rowsets_score(const uint32_t empty_rowset_num) {
+        return (uint32_t)(empty_rowset_num * 0.8);
+    }
+
 private:
     OLAPStatus _init_once_action();
     void _print_missed_versions(const std::vector<Version>& missed_versions) const;

--- a/be/test/olap/cumulative_compaction_policy_test.cpp
+++ b/be/test/olap/cumulative_compaction_policy_test.cpp
@@ -120,6 +120,11 @@ public:
         pb1->set_creation_time(10000);
     }
 
+    void init_empty_rs_meta(RowsetMetaSharedPtr& pb1, int64_t start, int64_t end) {
+        init_rs_meta(pb1, start, end);
+        pb1->set_num_segments(0);
+    }
+
     void init_all_rs_meta(std::vector<RowsetMetaSharedPtr>* rs_metas) {
         RowsetMetaSharedPtr ptr1(new RowsetMeta());
         init_rs_meta(ptr1, 0, 0);
@@ -140,6 +145,34 @@ public:
         RowsetMetaSharedPtr ptr5(new RowsetMeta());
         init_rs_meta(ptr5, 4, 4);
         rs_metas->push_back(ptr5);
+    }
+
+    void init_all_rs_meta_with_empty_rowset(std::vector<RowsetMetaSharedPtr>* rs_metas) {
+        init_all_rs_meta(rs_metas);
+
+        RowsetMetaSharedPtr ptr6(new RowsetMeta());
+        init_empty_rs_meta(ptr6, 5, 5);
+        rs_metas->push_back(ptr6);
+
+        RowsetMetaSharedPtr ptr7(new RowsetMeta());
+        init_empty_rs_meta(ptr7, 6, 6);
+        rs_metas->push_back(ptr7);
+
+        RowsetMetaSharedPtr ptr8(new RowsetMeta());
+        init_empty_rs_meta(ptr8, 7, 7);
+        rs_metas->push_back(ptr8);
+
+        RowsetMetaSharedPtr ptr9(new RowsetMeta());
+        init_empty_rs_meta(ptr9, 8, 8);
+        rs_metas->push_back(ptr9);
+
+        RowsetMetaSharedPtr ptr10(new RowsetMeta());
+        init_empty_rs_meta(ptr10, 9, 9);
+        rs_metas->push_back(ptr10);
+
+        RowsetMetaSharedPtr ptr11(new RowsetMeta());
+        init_empty_rs_meta(ptr11, 10, 10);
+        rs_metas->push_back(ptr11);
     }
 
     void init_all_rs_meta_cal_point(std::vector<RowsetMetaSharedPtr>* rs_metas) {
@@ -218,6 +251,26 @@ TEST_F(TestNumBasedCumulativeCompactionPolicy, calc_cumulative_compaction_score)
                                                           cumulative_compaction_policy);
 
     ASSERT_EQ(15, score);
+}
+
+TEST_F(TestNumBasedCumulativeCompactionPolicy, calc_cumulative_compaction_score_with_empty_rowset) {
+    std::vector<RowsetMetaSharedPtr> rs_metas;
+    init_all_rs_meta_with_empty_rowset(&rs_metas);
+
+    for (auto& rowset : rs_metas) {
+    _tablet_meta->add_rs_meta(rowset);
+    }
+
+    TabletSharedPtr _tablet(new Tablet(_tablet_meta, nullptr, CUMULATIVE_NUM_BASED_POLICY));
+    _tablet->init();
+    std::shared_ptr<CumulativeCompactionPolicy> cumulative_compaction_policy =
+            CumulativeCompactionPolicyFactory::create_cumulative_compaction_policy(
+                    CUMULATIVE_NUM_BASED_POLICY);
+
+    const uint32_t score = _tablet->calc_compaction_score(CompactionType::CUMULATIVE_COMPACTION,
+                                                          cumulative_compaction_policy);
+
+    ASSERT_EQ(19, score);
 }
 
 TEST_F(TestNumBasedCumulativeCompactionPolicy, calculate_cumulative_point) {
@@ -411,6 +464,11 @@ public:
         pb1->set_creation_time(10000);
     }
 
+    void init_empty_rs_meta(RowsetMetaSharedPtr& pb1, int64_t start, int64_t end) {
+        init_rs_meta(pb1, start, end);
+        pb1->set_num_segments(0);
+    }
+
     void init_rs_meta_small_base(std::vector<RowsetMetaSharedPtr>* rs_metas) {
         RowsetMetaSharedPtr ptr1(new RowsetMeta());
         init_rs_meta(ptr1, 0, 0);
@@ -431,6 +489,34 @@ public:
         RowsetMetaSharedPtr ptr5(new RowsetMeta());
         init_rs_meta(ptr5, 4, 4);
         rs_metas->push_back(ptr5);
+    }
+
+    void init_rs_meta_small_base_with_empy_rowset(std::vector<RowsetMetaSharedPtr>* rs_metas) {
+        init_rs_meta_small_base(rs_metas);
+
+        RowsetMetaSharedPtr ptr6(new RowsetMeta());
+        init_empty_rs_meta(ptr6, 5, 5);
+        rs_metas->push_back(ptr6);
+
+        RowsetMetaSharedPtr ptr7(new RowsetMeta());
+        init_empty_rs_meta(ptr7, 6, 6);
+        rs_metas->push_back(ptr7);
+
+        RowsetMetaSharedPtr ptr8(new RowsetMeta());
+        init_empty_rs_meta(ptr8, 7, 7);
+        rs_metas->push_back(ptr8);
+
+        RowsetMetaSharedPtr ptr9(new RowsetMeta());
+        init_empty_rs_meta(ptr9, 8, 8);
+        rs_metas->push_back(ptr9);
+
+        RowsetMetaSharedPtr ptr10(new RowsetMeta());
+        init_empty_rs_meta(ptr10, 9, 9);
+        rs_metas->push_back(ptr10);
+
+        RowsetMetaSharedPtr ptr11(new RowsetMeta());
+        init_empty_rs_meta(ptr11, 10, 10);
+        rs_metas->push_back(ptr11);
     }
 
     void init_rs_meta_big_base(std::vector<RowsetMetaSharedPtr>* rs_metas) {
@@ -676,6 +762,27 @@ TEST_F(TestSizeBasedCumulativeCompactionPolicy, calc_cumulative_compaction_score
                                                           cumulative_compaction_policy);
 
     ASSERT_EQ(15, score);
+}
+
+TEST_F(TestSizeBasedCumulativeCompactionPolicy, calc_cumulative_compaction_score_with_empty_rowset) {
+    std::vector<RowsetMetaSharedPtr> rs_metas;
+    init_rs_meta_small_base_with_empy_rowset(&rs_metas);
+
+    for (auto& rowset : rs_metas) {
+    _tablet_meta->add_rs_meta(rowset);
+    }
+
+    TabletSharedPtr _tablet(new Tablet(_tablet_meta, nullptr, CUMULATIVE_SIZE_BASED_POLICY));
+    _tablet->init();
+    _tablet->calculate_cumulative_point();
+
+    std::shared_ptr<CumulativeCompactionPolicy> cumulative_compaction_policy =
+            CumulativeCompactionPolicyFactory::create_cumulative_compaction_policy(
+                    CUMULATIVE_SIZE_BASED_POLICY);
+    const uint32_t score = _tablet->calc_compaction_score(CompactionType::CUMULATIVE_COMPACTION,
+                                                          cumulative_compaction_policy);
+
+    ASSERT_EQ(19, score);
 }
 
 TEST_F(TestSizeBasedCumulativeCompactionPolicy, calc_cumulative_compaction_score_big_base) {


### PR DESCRIPTION
## Proposed changes

To avoid that too many rowsets with 0 segment can not be merged when data skew, we should set a weight for empty version when calculating compaction score. 

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Code refactor (Modify the code structure, format the code, etc...)
- [ ] Optimization. Including functional usability improvements and performance improvements.
- [ ] Dependency. Such as changes related to third-party components.
- [ ] Other.

