### PR TITLE
[Bug] Cache cannot sense the modification of the view

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/alter/Alter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/Alter.java
@@ -455,12 +455,15 @@ public class Alter {
             } catch (UserException e) {
                 throw new DdlException("failed to init view stmt", e);
             }
+            long updateTime = System.currentTimeMillis() / 1000;
+            view.setUpdateTime(updateTime);
             view.setNewFullSchema(newFullSchema);
             String viewName = view.getName();
             db.dropTable(viewName);
             db.createTable(view);
 
-            AlterViewInfo alterViewInfo = new AlterViewInfo(db.getId(), view.getId(), inlineViewDef, newFullSchema, sqlMode);
+            AlterViewInfo alterViewInfo =
+                    new AlterViewInfo(db.getId(), view.getId(), inlineViewDef, newFullSchema, sqlMode, updateTime);
             Catalog.getCurrentCatalog().getEditLog().logModifyViewDef(alterViewInfo);
             LOG.info("modify view[{}] definition to {}", viewName, inlineViewDef);
         } finally {
@@ -474,6 +477,7 @@ public class Alter {
         long tableId = alterViewInfo.getTableId();
         String inlineViewDef = alterViewInfo.getInlineViewDef();
         List<Column> newFullSchema = alterViewInfo.getNewFullSchema();
+        long updateTime = alterViewInfo.getUpdateTime();
 
         Database db = Catalog.getCurrentCatalog().getDbOrMetaException(dbId);
         View view = db.getTableOrMetaException(tableId, TableType.VIEW);
@@ -488,6 +492,7 @@ public class Alter {
             } catch (UserException e) {
                 throw new DdlException("failed to init view stmt", e);
             }
+            view.setUpdateTime(updateTime);
             view.setNewFullSchema(newFullSchema);
 
             db.dropTable(viewName);

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/InlineViewRef.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/InlineViewRef.java
@@ -417,6 +417,14 @@ public class InlineViewRef extends TableRef {
         return baseTblSmap;
     }
 
+    public long getUpdateTime() {
+        return (view == null) ? -1L : view.getUpdateTime();
+    }
+
+    public boolean isLocalView() {
+        return view == null || view.isLocalView();
+    }
+
     @Override
     public String tableRefToSql() {
         // Enclose the alias in quotes if Hive cannot parse it without quotes.

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Table.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Table.java
@@ -70,6 +70,7 @@ public class Table extends MetaObject implements Writable {
     protected volatile String name;
     protected TableType type;
     protected long createTime;
+    protected long updateTime;
     protected ReentrantReadWriteLock rwLock;
 
     /*
@@ -132,6 +133,7 @@ public class Table extends MetaObject implements Writable {
         }
         this.rwLock = new ReentrantReadWriteLock();
         this.createTime = Instant.now().getEpochSecond();
+        this.updateTime = createTime;
     }
 
     public void readLock() {
@@ -234,7 +236,11 @@ public class Table extends MetaObject implements Writable {
     }
 
     public long getUpdateTime() {
-        return -1L;
+        return updateTime;
+    }
+
+    public void setUpdateTime(long updateTime) {
+        this.updateTime = updateTime;
     }
 
     public long getRowCount() {
@@ -302,6 +308,7 @@ public class Table extends MetaObject implements Writable {
 
         // write create time
         out.writeLong(createTime);
+        out.writeLong(updateTime);
     }
 
     public void readFields(DataInput in) throws IOException {
@@ -334,6 +341,12 @@ public class Table extends MetaObject implements Writable {
             this.createTime = in.readLong();
         } else {
             this.createTime = -1L;
+        }
+
+        if (Catalog.getCurrentCatalogJournalVersion() >= FeMetaVersion.VERSION_106) {
+            this.updateTime = in.readLong();
+        } else {
+            this.updateTime = -1L;
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/common/FeMetaVersion.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/FeMetaVersion.java
@@ -222,6 +222,8 @@ public final class FeMetaVersion {
     public static final int VERSION_104 = 104;
     // change replica to replica allocation
     public static final int VERSION_105 = 105;
+    // for view update time
+    public static final int VERSION_106 = 106;
     // note: when increment meta version, should assign the latest version to VERSION_CURRENT
-    public static final int VERSION_CURRENT = VERSION_105;
+    public static final int VERSION_CURRENT = VERSION_106;
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/AlterViewInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/AlterViewInfo.java
@@ -41,18 +41,22 @@ public class AlterViewInfo implements Writable {
     private long sqlMode;
     @SerializedName(value = "newFullSchema")
     private List<Column> newFullSchema;
+    @SerializedName(value = "updateTime")
+    private long updateTime;
 
     public AlterViewInfo() {
         // for persist
         newFullSchema = Lists.newArrayList();
     }
 
-    public AlterViewInfo(long dbId, long tableId, String inlineViewDef, List<Column> newFullSchema, long sqlMode) {
+    public AlterViewInfo(long dbId, long tableId, String inlineViewDef,
+                         List<Column> newFullSchema, long sqlMode, long updateTime) {
         this.dbId = dbId;
         this.tableId = tableId;
         this.inlineViewDef = inlineViewDef;
         this.newFullSchema = newFullSchema;
         this.sqlMode = sqlMode;
+        this.updateTime = updateTime;
     }
 
     public long getDbId() {
@@ -75,9 +79,13 @@ public class AlterViewInfo implements Writable {
         return sqlMode;
     }
 
+    public long getUpdateTime() {
+        return updateTime;
+    }
+
     @Override
     public int hashCode() {
-        return Objects.hash(dbId, tableId, inlineViewDef, sqlMode, newFullSchema);
+        return Objects.hash(dbId, tableId, inlineViewDef, sqlMode, newFullSchema, updateTime);
     }
 
     @Override
@@ -89,7 +97,7 @@ public class AlterViewInfo implements Writable {
         AlterViewInfo otherInfo = (AlterViewInfo) other;
         return dbId == otherInfo.getDbId() && tableId == otherInfo.getTableId() &&
                 inlineViewDef.equalsIgnoreCase(otherInfo.getInlineViewDef()) && sqlMode == otherInfo.getSqlMode() &&
-                newFullSchema.equals(otherInfo.getNewFullSchema());
+                newFullSchema.equals(otherInfo.getNewFullSchema()) && updateTime == otherInfo.updateTime;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/cache/Cache.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/cache/Cache.java
@@ -43,6 +43,7 @@ public abstract class Cache {
     protected CacheAnalyzer.CacheTable latestTable;
     protected CacheProxy proxy;
     protected HitRange hitRange;
+    protected long latestViewUpdateTime;
 
     protected Cache(TUniqueId queryId, SelectStmt selectStmt) {
         this.queryId = queryId;

--- a/fe/fe-core/src/test/java/org/apache/doris/persist/AlterViewInfoTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/persist/AlterViewInfoTest.java
@@ -56,7 +56,10 @@ public class AlterViewInfoTest {
         Column column1 = new Column("col1", PrimitiveType.BIGINT);
         Column column2 = new Column("col2", PrimitiveType.DOUBLE);
 
-        AlterViewInfo alterViewInfo = new AlterViewInfo(dbId, tableId, inlineViewDef, Lists.newArrayList(column1, column2), sqlMode);
+        long updateTime = System.currentTimeMillis() / 1000;
+
+        AlterViewInfo alterViewInfo = new AlterViewInfo(dbId, tableId, inlineViewDef,
+                Lists.newArrayList(column1, column2), sqlMode, updateTime);
         alterViewInfo.write(out);
         out.flush();
         out.close();


### PR DESCRIPTION
## Proposed changes

Modifying the view is equivalent to modifying the sql, but because the sql string has not changed, the query will hit the cached result before the view is modified.

Fix the bug that the cache cannot perceive view modification:
- Add `updateTime` field to record the view update time
- Use `originalSql + latestViewUpdateTime` as the input of the md5 function to generate a sql_key



## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Code refactor (Modify the code structure, format the code, etc...)
- [ ] Optimization. Including functional usability improvements and performance improvements.
- [ ] Dependency. Such as changes related to third-party components.
- [ ] Other.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have created an issue on (Fix #ISSUE) and described the bug/feature there in detail
- [ ] Compiling and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If these changes need document changes, I have updated the document
- [ ] Any dependent changes have been merged

## Further comments

If this is a relatively large or complex change, kick off the discussion at dev@doris.apache.org by explaining why you chose the solution you did and what alternatives you considered, etc...
