### PR TITLE
Fix duplicate result in colocated agg node

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/planner/DistributedPlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/DistributedPlanner.java
@@ -321,6 +321,7 @@ public class DistributedPlanner {
             node.setChild(1, rightChildFragment.getPlanRoot());
             leftChildFragment.setPlanRoot(node);
             fragments.remove(rightChildFragment);
+            leftChildFragment.setHasColocatePlanNode(true);
             return leftChildFragment;
         } else {
             node.setColocate(false, reason.get(0));
@@ -932,6 +933,7 @@ public class DistributedPlanner {
         } else {
             if (canColocateAgg(node.getAggInfo(), childFragment.getInputDataPartition())) {
                 childFragment.addPlanRoot(node);
+                childFragment.setHasColocatePlanNode(true);
                 return childFragment;
             } else {
                 return createMergeAggregationFragment(node, childFragment);

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/PlanFragment.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/PlanFragment.java
@@ -134,6 +134,9 @@ public class PlanFragment extends TreeNode<PlanFragment> {
     // The runtime filter id that is expected to be used
     private Set<RuntimeFilterId> targetRuntimeFilterIds;
 
+    // has colocate plan node
+    private boolean hasColocatePlanNode = false;
+
     /**
      * C'tor for fragment with specific partition; the output is by default broadcast.
      */
@@ -204,6 +207,14 @@ public class PlanFragment extends TreeNode<PlanFragment> {
 
     public void setTargetRuntimeFilterIds(RuntimeFilterId rid) {
         this.targetRuntimeFilterIds.add(rid);
+    }
+
+    public void setHasColocatePlanNode(boolean hasColocatePlanNode) {
+        this.hasColocatePlanNode = hasColocatePlanNode;
+    }
+
+    public boolean hasColocatePlanNode() {
+        return hasColocatePlanNode;
     }
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
@@ -1119,7 +1119,7 @@ public class Coordinator {
 
             int parallelExecInstanceNum = fragment.getParallelExecNum();
             //for ColocateJoin fragment
-            if ((isColocateJoin(fragment.getPlanRoot()) && fragmentIdToSeqToAddressMap.containsKey(fragment.getFragmentId())
+            if ((isColocateFragment(fragment, fragment.getPlanRoot()) && fragmentIdToSeqToAddressMap.containsKey(fragment.getFragmentId())
                     && fragmentIdToSeqToAddressMap.get(fragment.getFragmentId()).size() > 0)) {
                 computeColocateJoinInstanceParam(fragment.getFragmentId(), parallelExecInstanceNum, params);
             } else if (bucketShuffleJoinController.isBucketShuffleJoin(fragment.getFragmentId().asInt())) {
@@ -1203,8 +1203,8 @@ public class Coordinator {
         runtimeFilterMergeInstanceId = uppermostParams.instanceExecParams.get(0).instanceId;
     }
 
-    // One fragment could only have one HashJoinNode
-    private boolean isColocateJoin(PlanNode node) {
+    // If fragment has colocated plan node, it will return true.
+    private boolean isColocateFragment(PlanFragment planFragment, PlanNode node) {
         // TODO(cmy): some internal process, such as broker load task, do not have ConnectContext.
         // Any configurations needed by the Coordinator should be passed in Coordinator initialization.
         // Refine this later.
@@ -1220,6 +1220,10 @@ public class Coordinator {
             return true;
         }
 
+        if (planFragment.hasColocatePlanNode()) {
+            return true;
+        }
+
         if (node instanceof HashJoinNode) {
             HashJoinNode joinNode = (HashJoinNode) node;
             if (joinNode.isColocate()) {
@@ -1229,7 +1233,7 @@ public class Coordinator {
         }
 
         for (PlanNode childNode : node.getChildren()) {
-            if (isColocateJoin(childNode)) {
+            if (isColocateFragment(planFragment, childNode)) {
                 return true;
             }
         }
@@ -1355,7 +1359,7 @@ public class Coordinator {
             scanNodeIds.add(scanNode.getId().asInt());
 
             FragmentScanRangeAssignment assignment = fragmentExecParamsMap.get(scanNode.getFragmentId()).scanRangeAssignment;
-            boolean fragmentContainsColocateJoin = isColocateJoin(scanNode.getFragment().getPlanRoot());
+            boolean fragmentContainsColocateJoin = isColocateFragment(scanNode.getFragment(), scanNode.getFragment().getPlanRoot());
             boolean fragmentContainsBucketShuffleJoin = bucketShuffleJoinController.isBucketShuffleJoin(scanNode.getFragmentId().asInt(), scanNode.getFragment().getPlanRoot());
 
             // A fragment may contain both colocate join and bucket shuffle join

--- a/fe/fe-core/src/test/java/org/apache/doris/planner/ColocatePlanTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/planner/ColocatePlanTest.java
@@ -21,17 +21,23 @@ import org.apache.doris.analysis.CreateDbStmt;
 import org.apache.doris.analysis.CreateTableStmt;
 import org.apache.doris.catalog.Catalog;
 import org.apache.doris.common.FeConstants;
+import org.apache.doris.common.jmockit.Deencapsulation;
 import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.qe.Coordinator;
+import org.apache.doris.qe.QueryStatisticsItem;
+import org.apache.doris.qe.StmtExecutor;
 import org.apache.doris.utframe.UtFrameUtils;
 
 import org.apache.commons.lang.StringUtils;
+
+import java.io.File;
+import java.util.List;
+import java.util.UUID;
+
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
-
-import java.io.File;
-import java.util.UUID;
 
 public class ColocatePlanTest {
     private static final String COLOCATE_ENABLE = "colocate: true";
@@ -59,6 +65,13 @@ public class ColocatePlanTest {
                 + "distributed by hash(k1, k2) buckets 10 properties('replication_num' = '2')";
         CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameUtils.parseAndAnalyzeStmt(createTblStmtStr, ctx);
         Catalog.getCurrentCatalog().createTable(createTableStmt);
+
+        String createMultiPartitionTableStmt = "create table db1.test_multi_partition(k1 int, k2 int)"
+                + "partition by range(k1) (partition p1 values less than(\"1\"), partition p2 values less than (\"2\"))"
+                + "distributed by hash(k2) buckets 10 properties ('replication_num' = '2', 'colocate_with' = 'group2')";
+        CreateTableStmt createMultiTableStmt = (CreateTableStmt) UtFrameUtils.
+                parseAndAnalyzeStmt(createMultiPartitionTableStmt, ctx);
+        Catalog.getCurrentCatalog().createTable(createMultiTableStmt);
     }
 
     @AfterClass
@@ -136,4 +149,27 @@ public class ColocatePlanTest {
         Assert.assertEquals(2, StringUtils.countMatches(plan1, "AGGREGATE"));
         Assert.assertFalse(plan1.contains(COLOCATE_ENABLE));
     }
+
+    // check colocate add scan range
+    // Fix #6726
+    // 1. colocate agg node
+    // 2. scan node with two tablet one instance
+    @Test
+    public void sqlAggWithColocateTable() throws Exception {
+        String sql = "select k1, k2, count(*) from db1.test_multi_partition where k2 = 1 group by k1, k2";
+        StmtExecutor executor = UtFrameUtils.getSqlStmtExecutor(ctx, sql);
+        Planner planner = executor.planner();
+        Coordinator coordinator = Deencapsulation.getField(executor, "coord");
+        List<ScanNode> scanNodeList = planner.getScanNodes();
+        Assert.assertEquals(scanNodeList.size(), 1);
+        Assert.assertTrue(scanNodeList.get(0) instanceof OlapScanNode);
+        OlapScanNode olapScanNode = (OlapScanNode) scanNodeList.get(0);
+        Assert.assertEquals(olapScanNode.getSelectedPartitionIds().size(), 2);
+        long selectedTablet = Deencapsulation.getField(olapScanNode, "selectedTabletsNum");
+        Assert.assertEquals(selectedTablet, 2);
+
+        List<QueryStatisticsItem.FragmentInstanceInfo> instanceInfo = coordinator.getFragmentInstanceInfos();
+        Assert.assertEquals(instanceInfo.size(), 2);
+    }
+
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/utframe/UtFrameUtils.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/utframe/UtFrameUtils.java
@@ -33,6 +33,7 @@ import org.apache.doris.common.util.SqlParserUtils;
 import org.apache.doris.mysql.privilege.PaloAuth;
 import org.apache.doris.planner.Planner;
 import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.qe.Coordinator;
 import org.apache.doris.qe.QueryState;
 import org.apache.doris.qe.StmtExecutor;
 import org.apache.doris.system.Backend;
@@ -260,6 +261,17 @@ public class UtFrameUtils {
         stmtExecutor.execute();
         if (ctx.getState().getStateType() != QueryState.MysqlStateType.ERR) {
             return stmtExecutor.planner();
+        } else {
+            return null;
+        }
+    }
+
+    public static StmtExecutor getSqlStmtExecutor(ConnectContext ctx, String queryStr) throws Exception {
+        ctx.getState().reset();
+        StmtExecutor stmtExecutor = new StmtExecutor(ctx, queryStr);
+        stmtExecutor.execute();
+        if (ctx.getState().getStateType() != QueryState.MysqlStateType.ERR) {
+            return stmtExecutor;
         } else {
             return null;
         }


### PR DESCRIPTION
## Proposed changes

Fixed #6726

If the plan fragment contains colocated agg plan node, it will be a colocated fragment.
The scan range and backend id of colocated fragment instance should be differnt from ordinary scheduler logic.
Tablets in the same bucket must fall on the same be.
For example, for the same bucket in different partitions,
even though the tablet id is different, they must be scheduled to the same be for scan node.

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Code refactor (Modify the code structure, format the code, etc...)
- [ ] Optimization. Including functional usability improvements and performance improvements.
- [ ] Dependency. Such as changes related to third-party components.
- [ ] Other.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have created an issue on (Fix #6726) and described the bug/feature there in detail
- [x] Compiling and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If these changes need document changes, I have updated the document
- [ ] Any dependent changes have been merged


