### PR TITLE
Revert "[Enhancement] Modify the method of calculating compaction score"

### DIFF
--- a/be/src/olap/rowset/rowset_meta.h
+++ b/be/src/olap/rowset/rowset_meta.h
@@ -265,14 +265,15 @@ public:
     }
 
     // get the compaction score of this rowset.
-    // if segments are overlapping or the number of segments is 0, the score equals to the number of segments,
+    // if segments are overlapping, the score equals to the number of segments,
     // otherwise, score is 1.
     uint32_t get_compaction_score() const {
         uint32_t score = 0;
-        if ((num_segments() > 0 && !is_segments_overlapping()) || has_delete_predicate()) {
+        if (!is_segments_overlapping()) {
             score = 1;
         } else {
             score = num_segments();
+            CHECK(score > 0);
         }
         return score;
     }


### PR DESCRIPTION
Reverts apache/incubator-doris#6252

This commit may cause tablet which segments are all empty never to compaction, and results in -235 error.
I will revert this commit, and the problem will be solved in #6671