### PR TITLE
[Revert] "[Bug] When using view, make toSql method generates the final sql (#6736)"

### DIFF
--- a/conf/be.conf
+++ b/conf/be.conf
@@ -22,7 +22,6 @@ sys_log_level = INFO
 
 # ports for admin, web, heartbeat service 
 be_port = 9060
-be_rpc_port = 9070
 webserver_port = 8040
 heartbeat_service_port = 9050
 brpc_port = 8060

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/InlineViewRef.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/InlineViewRef.java
@@ -423,23 +423,17 @@ public class InlineViewRef extends TableRef {
         // This is needed for view compatibility between Impala and Hive.
         String aliasSql = null;
         String alias = getExplicitAlias();
-        if (alias != null) aliasSql = ToSqlUtils.getIdentSql(alias);
-
-        StringBuilder sb = new StringBuilder();
-        if (view != null) {
-            // When it is a local view, it does not need to be expanded into a statement,
-            // because toSql function already contains `with` statement
-            if (view.isLocalView()) {
-                return name.toSql() + (aliasSql == null ? "" : " " + aliasSql);
-            }
-
-            sb.append("(")
-                    .append(view.getInlineViewDef())
-                    .append(")")
-                    .append(aliasSql == null ? "" : " " + aliasSql);
-            return sb.toString();
+        if (alias != null) {
+            aliasSql = ToSqlUtils.getIdentSql(alias);
         }
 
+        if (view != null) {
+            // FIXME: this may result in a sql cache problem
+            // See pr #6736 and issue #6735
+            return name.toSql() + (aliasSql == null ? "" : " " + aliasSql);
+        }
+
+        StringBuilder sb = new StringBuilder();
         sb.append("(")
                 .append(queryStmt.toSql())
                 .append(") ")

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/StmtRewriter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/StmtRewriter.java
@@ -110,7 +110,9 @@ public class StmtRewriter {
             result = rewriteHavingClauseSubqueries(result, analyzer);
         }
         result.sqlString_ = null;
-        if (LOG.isDebugEnabled()) LOG.debug("rewritten stmt: " + result.toSql());
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("rewritten stmt: " + result.toSql());
+        }
         return result;
     }
 
@@ -204,7 +206,7 @@ public class StmtRewriter {
         } catch (UserException e) {
             throw new AnalysisException(e.getMessage());
         }
-        LOG.debug("Outer query is changed to " + inlineViewRef.tableRefToSql());
+        LOG.debug("Outer query is changed to {}", inlineViewRef.tableRefToSql());
 
         /*
          * Columns which belong to outer query can substitute for output columns of inline view

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ShowExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ShowExecutor.java
@@ -784,9 +784,6 @@ public class ShowExecutor {
             }
 
             if (table instanceof View) {
-                View view = (View) table;
-                StringBuilder sb = new StringBuilder();
-                sb.append("CREATE VIEW `").append(table.getName()).append("` AS ").append(view.getInlineViewDef());
                 rows.add(Lists.newArrayList(table.getName(), createTableStmt.get(0), "utf8", "utf8_general_ci"));
                 resultSet = new ShowResultSet(ShowCreateTableStmt.getViewMetaData(), rows);
             } else {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/cache/SqlCache.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/cache/SqlCache.java
@@ -41,7 +41,7 @@ public class SqlCache extends Cache {
 
     public InternalService.PFetchCacheResult getCacheData(Status status) {
         InternalService.PFetchCacheRequest request = InternalService.PFetchCacheRequest.newBuilder()
-                .setSqlKey(CacheProxy.getMd5(selectStmt.toSql()))
+                .setSqlKey(CacheProxy.getMd5(selectStmt.getOrigStmt().originStmt))
                 .addParams(InternalService.PCacheParam.newBuilder()
                         .setPartitionKey(latestTable.latestPartitionId)
                         .setLastVersion(latestTable.latestVersion)
@@ -74,7 +74,7 @@ public class SqlCache extends Cache {
         }
 
         InternalService.PUpdateCacheRequest updateRequest =
-                rowBatchBuilder.buildSqlUpdateRequest(selectStmt.toSql(), latestTable.latestPartitionId,
+                rowBatchBuilder.buildSqlUpdateRequest(selectStmt.getOrigStmt().originStmt, latestTable.latestPartitionId,
                         latestTable.latestVersion, latestTable.latestTime);
         if (updateRequest.getValuesCount() > 0) {
             CacheBeProxy proxy = new CacheBeProxy();

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/SelectStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/SelectStmtTest.java
@@ -25,6 +25,7 @@ import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.VariableMgr;
 import org.apache.doris.utframe.DorisAssert;
 import org.apache.doris.utframe.UtFrameUtils;
+
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 
@@ -38,6 +39,7 @@ import org.junit.rules.ExpectedException;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
+
 import mockit.Mock;
 import mockit.MockUp;
 
@@ -752,51 +754,5 @@ public class SelectStmtTest {
         stmt2.rewriteExprs(new Analyzer(ctx.getCatalog(), ctx).getExprRewriter());
         Assert.assertTrue(stmt2.toSql().contains("WITH v1 AS (SELECT `t1`.`k1` AS `k1` FROM " +
                 "`default_cluster:db1`.`tbl1` t1),v2 AS (SELECT `t2`.`k1` AS `k1` FROM `default_cluster:db1`.`tbl1` t2)"));
-    }
-
-    @Test
-    public void testViewConvertFinalSql() throws Exception {
-        ConnectContext ctx = UtFrameUtils.createDefaultCtx();
-        dorisAssert.useDatabase("db1");
-        String testView1 = "CREATE VIEW `view1` as (select t1.k1, t1.k2 from db1.tbl1 t1)";
-        dorisAssert.withView(testView1);
-
-        String sql1 = "select * from db1.view1;";
-        SelectStmt stmt1 = (SelectStmt) UtFrameUtils.parseAndAnalyzeStmt(sql1, ctx);
-        stmt1.rewriteExprs(new Analyzer(ctx.getCatalog(), ctx).getExprRewriter());
-        Assert.assertTrue(stmt1.toSql().contains("FROM " +
-                "(SELECT `t1`.`k1` AS `k1`, `t1`.`k2` AS `k2` FROM `default_cluster:db1`.`tbl1` t1)"));
-
-        String sql2 =
-                "select \n" +
-                "  t.k1 \n" +
-                "from (\n" +
-                "  select v1.k1 from db1.view1 v1\n" +
-                ") t";
-        SelectStmt stmt2 = (SelectStmt) UtFrameUtils.parseAndAnalyzeStmt(sql2, ctx);
-        stmt2.rewriteExprs(new Analyzer(ctx.getCatalog(), ctx).getExprRewriter());
-        Assert.assertTrue(stmt2.toSql().contains("FROM " +
-                "(SELECT `t1`.`k1` AS `k1`, `t1`.`k2` AS `k2` FROM `default_cluster:db1`.`tbl1` t1) v1"));
-
-        // WITH statement contains view, that is, localView contains normal view
-        String sql3 =
-                "with\n" +
-                "    v1 as (select t1.k1 from db1.view1 t1),\n" +
-                "    v2 as (select t2.k1 from db1.view1 t2)\n" +
-                "select\n" +
-                "  t.k1\n" +
-                "from (\n" +
-                "  select v1.k1 as k1 from v1\n" +
-                "  union\n" +
-                "  select v2.k1 as k1 from v2\n" +
-                ") t";
-        SelectStmt stmt3 = (SelectStmt) UtFrameUtils.parseAndAnalyzeStmt(sql3, ctx);
-        stmt3.rewriteExprs(new Analyzer(ctx.getCatalog(), ctx).getExprRewriter());
-        System.out.println(stmt3.toSql());
-        Assert.assertTrue(stmt3.toSql().contains("WITH " +
-                "v1 AS (SELECT `t1`.`k1` AS `k1` FROM (SELECT `t1`.`k1` AS `k1`, `t1`.`k2` AS `k2` FROM `default_cluster:db1`.`tbl1` t1) t1)," +
-                "v2 AS (SELECT `t2`.`k1` AS `k1` FROM (SELECT `t1`.`k1` AS `k1`, `t1`.`k2` AS `k2` FROM `default_cluster:db1`.`tbl1` t1) t2)"));
-
-        dorisAssert.dropView("view1");
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/CreateViewTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/CreateViewTest.java
@@ -115,4 +115,18 @@ public class CreateViewTest {
         Assert.assertTrue(view5.getDdlSql().contains("hour") && view5.getDdlSql().contains("now")
                 && view5.getDdlSql().contains("curdate"));
     }
+
+    @Test
+    public void testNestedViews() throws Exception {
+        ExceptionChecker.expectThrowsNoException(
+                () -> createView("create view test.nv1 as select * from test.tbl1;"));
+
+        ExceptionChecker.expectThrowsNoException(
+                () -> createView("create view test.nv2 as select * from test.nv1;"));
+
+        String sql = "select * from test.nv2";
+        String explainString = UtFrameUtils.getSQLPlanOrErrorMsg(connectContext, "EXPLAIN " + sql);
+        System.out.println(explainString);
+        Assert.assertTrue(explainString.contains("OlapScanNode"));
+    }
 }


### PR DESCRIPTION
## Proposed changes

This reverts part of commit 11ec38dd6fd9f86632d83c47bd9d8bc05db69a2b(#6736)
Because it will cause view query problem described in #6792 

The following bug fix remained:
1. Fix the problem that the WITH statement cannot be printed when UNION is included in SQL

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Code refactor (Modify the code structure, format the code, etc...)
- [ ] Optimization. Including functional usability improvements and performance improvements.
- [ ] Dependency. Such as changes related to third-party components.
- [ ] Other.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have created an issue on (Fix #6792) and described the bug/feature there in detail
- [ ] Compiling and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If these changes need document changes, I have updated the document
- [ ] Any dependent changes have been merged

## Further comments

If this is a relatively large or complex change, kick off the discussion at dev@doris.apache.org by explaining why you chose the solution you did and what alternatives you considered, etc...
