### PR TITLE
[Enhancement] add spark load config `spark_load_checker_interval_second`

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/Config.java
@@ -493,6 +493,12 @@ public class Config extends ConfigBase {
     @ConfField public static int load_checker_interval_second = 5;
 
     /**
+     * The spark load scheduler running interval.
+     * Default 60 seconds, because spark load job is heavy and yarn client returns slowly.
+     */
+    @ConfField public static int spark_load_checker_interval_second = 60;
+
+    /**
      * Concurrency of HIGH priority pending load jobs.
      * Load job priority is defined as HIGH or NORMAL.
      * All mini batch load jobs are HIGH priority, other types of load jobs are NORMAL priority.

--- a/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/LoadEtlChecker.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/LoadEtlChecker.java
@@ -32,7 +32,7 @@ public class LoadEtlChecker extends MasterDaemon {
     private LoadManager loadManager;
 
     public LoadEtlChecker(LoadManager loadManager) {
-        super("Load etl checker", Config.load_checker_interval_second * 1000);
+        super("Load etl checker", Config.spark_load_checker_interval_second * 1000);
         this.loadManager = loadManager;
     }
 


### PR DESCRIPTION
the internal seconds for spark load to check and update etl job status, 60 seconds for default

See #6808 

## Proposed changes

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Code refactor (Modify the code structure, format the code, etc...)
- [x] Optimization. Including functional usability improvements and performance improvements.
- [ ] Dependency. Such as changes related to third-party components.
- [ ] Other.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have created an issue on (Fix #ISSUE) and described the bug/feature there in detail
- [ ] Compiling and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If these changes need document changes, I have updated the document
- [ ] Any dependent changes have been merged

## Further comments

If this is a relatively large or complex change, kick off the discussion at dev@doris.apache.org by explaining why you chose the solution you did and what alternatives you considered, etc...
