### PR TITLE
[Cache] Add all view stmt as the suffix of cache sqlkey

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/InlineViewRef.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/InlineViewRef.java
@@ -422,6 +422,10 @@ public class InlineViewRef extends TableRef {
         return view == null || view.isLocalView();
     }
 
+    public View getView() {
+        return view;
+    }
+
     @Override
     public String tableRefToSql() {
         // Enclose the alias in quotes if Hive cannot parse it without quotes.

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/InlineViewRef.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/InlineViewRef.java
@@ -418,6 +418,10 @@ public class InlineViewRef extends TableRef {
         return baseTblSmap;
     }
 
+    public boolean isLocalView() {
+        return view == null || view.isLocalView();
+    }
+
     @Override
     public String tableRefToSql() {
         // Enclose the alias in quotes if Hive cannot parse it without quotes.

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/cache/Cache.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/cache/Cache.java
@@ -43,6 +43,7 @@ public abstract class Cache {
     protected CacheAnalyzer.CacheTable latestTable;
     protected CacheProxy proxy;
     protected HitRange hitRange;
+    protected String allViewStmtSuffix;
 
     protected Cache(TUniqueId queryId, SelectStmt selectStmt) {
         this.queryId = queryId;

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/cache/Cache.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/cache/Cache.java
@@ -43,7 +43,7 @@ public abstract class Cache {
     protected CacheAnalyzer.CacheTable latestTable;
     protected CacheProxy proxy;
     protected HitRange hitRange;
-    protected String allViewStmtSuffix;
+    protected String allViewExpandStmtListStr;
 
     protected Cache(TUniqueId queryId, SelectStmt selectStmt) {
         this.queryId = queryId;

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/cache/PartitionCache.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/cache/PartitionCache.java
@@ -66,13 +66,14 @@ public class PartitionCache extends Cache {
     }
 
     public void setCacheInfo(CacheAnalyzer.CacheTable latestTable, RangePartitionInfo partitionInfo, Column partColumn,
-                             CompoundPredicate partitionPredicate) {
+                             CompoundPredicate partitionPredicate, String allViewStmtSuffix) {
         this.latestTable = latestTable;
         this.olapTable = latestTable.olapTable;
         this.partitionInfo = partitionInfo;
         this.partColumn = partColumn;
         this.partitionPredicate = partitionPredicate;
         this.newRangeList = Lists.newArrayList();
+        this.allViewStmtSuffix = allViewStmtSuffix;
     }
 
     public InternalService.PFetchCacheResult getCacheData(Status status) {
@@ -84,8 +85,10 @@ public class PartitionCache extends Cache {
             status.setStatus("analytics range error");
             return null;
         }
+
+        String nokeyStmtWithViewStmt = nokeyStmt.toSql() + allViewStmtSuffix;
         InternalService.PFetchCacheRequest request = InternalService.PFetchCacheRequest.newBuilder()
-                .setSqlKey(CacheProxy.getMd5(nokeyStmt.toSql()))
+                .setSqlKey(CacheProxy.getMd5(nokeyStmtWithViewStmt))
                 .addAllParams(range.getPartitionSingleList().stream().map(
                         p -> InternalService.PCacheParam.newBuilder()
                                 .setPartitionKey(p.getCacheKey().realValue())

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/cache/PartitionCache.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/cache/PartitionCache.java
@@ -66,14 +66,14 @@ public class PartitionCache extends Cache {
     }
 
     public void setCacheInfo(CacheAnalyzer.CacheTable latestTable, RangePartitionInfo partitionInfo, Column partColumn,
-                             CompoundPredicate partitionPredicate, String allViewStmtSuffix) {
+                             CompoundPredicate partitionPredicate, String allViewExpandStmtListStr) {
         this.latestTable = latestTable;
         this.olapTable = latestTable.olapTable;
         this.partitionInfo = partitionInfo;
         this.partColumn = partColumn;
         this.partitionPredicate = partitionPredicate;
         this.newRangeList = Lists.newArrayList();
-        this.allViewStmtSuffix = allViewStmtSuffix;
+        this.allViewExpandStmtListStr = allViewExpandStmtListStr;
     }
 
     public InternalService.PFetchCacheResult getCacheData(Status status) {
@@ -86,7 +86,7 @@ public class PartitionCache extends Cache {
             return null;
         }
 
-        String nokeyStmtWithViewStmt = nokeyStmt.toSql() + allViewStmtSuffix;
+        String nokeyStmtWithViewStmt = nokeyStmt.toSql() + allViewExpandStmtListStr;
         InternalService.PFetchCacheRequest request = InternalService.PFetchCacheRequest.newBuilder()
                 .setSqlKey(CacheProxy.getMd5(nokeyStmtWithViewStmt))
                 .addAllParams(range.getPartitionSingleList().stream().map(

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/cache/SqlCache.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/cache/SqlCache.java
@@ -35,13 +35,15 @@ public class SqlCache extends Cache {
         super(queryId, selectStmt);
     }
 
-    public void setCacheInfo(CacheAnalyzer.CacheTable latestTable) {
+    public void setCacheInfo(CacheAnalyzer.CacheTable latestTable, String allViewStmtSuffix) {
         this.latestTable = latestTable;
+        this.allViewStmtSuffix = allViewStmtSuffix;
     }
 
     public InternalService.PFetchCacheResult getCacheData(Status status) {
+        String originStmtWithViewStmt = selectStmt.getOrigStmt().originStmt + allViewStmtSuffix;
         InternalService.PFetchCacheRequest request = InternalService.PFetchCacheRequest.newBuilder()
-                .setSqlKey(CacheProxy.getMd5(selectStmt.getOrigStmt().originStmt))
+                .setSqlKey(CacheProxy.getMd5(originStmtWithViewStmt))
                 .addParams(InternalService.PCacheParam.newBuilder()
                         .setPartitionKey(latestTable.latestPartitionId)
                         .setLastVersion(latestTable.latestVersion)

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/cache/SqlCache.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/cache/SqlCache.java
@@ -35,13 +35,13 @@ public class SqlCache extends Cache {
         super(queryId, selectStmt);
     }
 
-    public void setCacheInfo(CacheAnalyzer.CacheTable latestTable, String allViewStmtSuffix) {
+    public void setCacheInfo(CacheAnalyzer.CacheTable latestTable, String allViewExpandStmtListStr) {
         this.latestTable = latestTable;
-        this.allViewStmtSuffix = allViewStmtSuffix;
+        this.allViewExpandStmtListStr = allViewExpandStmtListStr;
     }
 
     public InternalService.PFetchCacheResult getCacheData(Status status) {
-        String originStmtWithViewStmt = selectStmt.getOrigStmt().originStmt + allViewStmtSuffix;
+        String originStmtWithViewStmt = selectStmt.getOrigStmt().originStmt + allViewExpandStmtListStr;
         InternalService.PFetchCacheRequest request = InternalService.PFetchCacheRequest.newBuilder()
                 .setSqlKey(CacheProxy.getMd5(originStmtWithViewStmt))
                 .addParams(InternalService.PCacheParam.newBuilder()


### PR DESCRIPTION
fix #6735

## Proposed changes

Use all view stmt as the cache sqlkey suffix, so that when the view is modified, the cache can recognize.

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Code refactor (Modify the code structure, format the code, etc...)
- [ ] Optimization. Including functional usability improvements and performance improvements.
- [ ] Dependency. Such as changes related to third-party components.
- [ ] Other.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have created an issue on (Fix #ISSUE) and described the bug/feature there in detail
- [ ] Compiling and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If these changes need document changes, I have updated the document
- [ ] Any dependent changes have been merged

## Further comments

If this is a relatively large or complex change, kick off the discussion at dev@doris.apache.org by explaining why you chose the solution you did and what alternatives you considered, etc...
