### PR TITLE
[Bug] Fix bug to reject request with no SQL in TableQueryPlanAction 

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/http/rest/TableQueryPlanAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/http/rest/TableQueryPlanAction.java
@@ -117,7 +117,7 @@ public class TableQueryPlanAction extends RestBaseAction {
             } catch (JSONException e) {
                 throw new DorisHttpException(HttpResponseStatus.BAD_REQUEST, "malformed json [ " + postContent + " ]");
             }
-            sql = String.valueOf(jsonObject.opt("sql"));
+            sql = jsonObject.optString("sql");
             if (Strings.isNullOrEmpty(sql)) {
                 throw new DorisHttpException(HttpResponseStatus.BAD_REQUEST, "POST body must contains [sql] root object");
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/TableQueryPlanAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/TableQueryPlanAction.java
@@ -104,7 +104,7 @@ public class TableQueryPlanAction extends RestBaseController {
                 return ResponseEntityBuilder.badRequest("malformed json: " + e.getMessage());
             }
 
-            sql = String.valueOf(jsonObject.opt("sql"));
+            sql = jsonObject.optString("sql");
             if (Strings.isNullOrEmpty(sql)) {
                 return ResponseEntityBuilder.badRequest("POST body must contains [sql] root object");
             }

--- a/fe/fe-core/src/test/java/org/apache/doris/http/TableQueryPlanActionTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/http/TableQueryPlanActionTest.java
@@ -80,6 +80,46 @@ public class TableQueryPlanActionTest extends DorisHttpTestCase {
     }
 
     @Test
+    public void testNoSqlFailure() throws IOException {
+        RequestBody body = RequestBody.create(JSON, "{}");
+        Request request = new Request.Builder()
+                .post(body)
+                .addHeader("Authorization", rootAuth)
+                .url(URI + PATH_URI)
+                .build();
+        Response response = networkClient.newCall(request).execute();
+        String respStr = response.body().string();
+        System.out.println(respStr);
+        Assert.assertNotNull(respStr);
+        expectThrowsNoException(() -> new JSONObject(respStr));
+        JSONObject jsonObject = new JSONObject(respStr);
+        Assert.assertEquals(400, jsonObject.getInt("status"));
+        String exception = jsonObject.getString("exception");
+        Assert.assertNotNull(exception);
+        Assert.assertEquals("POST body must contains [sql] root object", exception);
+    }
+
+    @Test
+    public void testEmptySqlFailure() throws IOException {
+        RequestBody body = RequestBody.create(JSON, "{ \"sql\" :  \"\" }");
+        Request request = new Request.Builder()
+                .post(body)
+                .addHeader("Authorization", rootAuth)
+                .url(URI + PATH_URI)
+                .build();
+        Response response = networkClient.newCall(request).execute();
+        String respStr = response.body().string();
+        System.out.println(respStr);
+        Assert.assertNotNull(respStr);
+        expectThrowsNoException(() -> new JSONObject(respStr));
+        JSONObject jsonObject = new JSONObject(respStr);
+        Assert.assertEquals(400, jsonObject.getInt("status"));
+        String exception = jsonObject.getString("exception");
+        Assert.assertNotNull(exception);
+        Assert.assertEquals("POST body must contains [sql] root object", exception);
+    }
+
+    @Test
     public void testInconsistentResource() throws IOException {
         RequestBody body = RequestBody.create(JSON, "{ \"sql\" :  \" select k1,k2 from " + DB_NAME + "." + TABLE_NAME + 1 + " \" }");
         Request request = new Request.Builder()


### PR DESCRIPTION
## Proposed changes

String.valueOf() returns string "null" with null input, in which case requests with no SQL will be accepted by `TableQueryPlanAction` unexpectedly with potential risk.

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Code refactor (Modify the code structure, format the code, etc...)
- [ ] Optimization. Including functional usability improvements and performance improvements.
- [ ] Dependency. Such as changes related to third-party components.
- [ ] Other.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have created an issue on (Fix #6842) and described the bug/feature there in detail
- [x] Compiling and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] If these changes need document changes, I have updated the document
- [x] Any dependent changes have been merged
