### PR TITLE
[BUG] Fix printing ReservationTrackerCounters cause BE crash when mem_limit is reached

### DIFF
--- a/be/src/runtime/mem_tracker.cpp
+++ b/be/src/runtime/mem_tracker.cpp
@@ -369,16 +369,19 @@ std::string MemTracker::LogUsage(int max_recursive_depth, const string& prefix,
     if (CheckLimitExceeded(MemLimit::HARD)) ss << " memory limit exceeded.";
     if (limit_ > 0) ss << " Limit=" << PrettyPrinter::print(limit_, TUnit::BYTES);
 
-    ReservationTrackerCounters* reservation_counters = reservation_counters_.load();
-    if (reservation_counters != nullptr) {
-        int64_t reservation = reservation_counters->peak_reservation->current_value();
-        ss << " Reservation=" << PrettyPrinter::print(reservation, TUnit::BYTES);
-        if (reservation_counters->reservation_limit != nullptr) {
-            int64_t limit = reservation_counters->reservation_limit->value();
-            ss << " ReservationLimit=" << PrettyPrinter::print(limit, TUnit::BYTES);
-        }
-        ss << " OtherMemory=" << PrettyPrinter::print(curr_consumption - reservation, TUnit::BYTES);
-    }
+    // TODO(zxy): ReservationTrackerCounters is not actually used in the current Doris. 
+    // Printing here ReservationTrackerCounters may cause BE crash when high concurrency.
+    // The memory tracker in Doris will be redesigned in the future.
+    // ReservationTrackerCounters* reservation_counters = reservation_counters_.load();
+    // if (reservation_counters != nullptr) {
+    //     int64_t reservation = reservation_counters->peak_reservation->current_value();
+    //     ss << " Reservation=" << PrettyPrinter::print(reservation, TUnit::BYTES);
+    //     if (reservation_counters->reservation_limit != nullptr) {
+    //         int64_t limit = reservation_counters->reservation_limit->value();
+    //         ss << " ReservationLimit=" << PrettyPrinter::print(limit, TUnit::BYTES);
+    //     }
+    //     ss << " OtherMemory=" << PrettyPrinter::print(curr_consumption - reservation, TUnit::BYTES);
+    // }
     ss << " Total=" << PrettyPrinter::print(curr_consumption, TUnit::BYTES);
     // Peak consumption is not accurate if the metric is lazily updated (i.e.
     // this is a non-root tracker that exists only for reporting purposes).


### PR DESCRIPTION
When the memory usage of BE reaches mem_limit, printing ReservationTrackerCounters through MemTracker may cause BE crash in high concurrency.

ReservationTrackerCounters is not actually used in the current Doris, and the memory tracker in Doris will be redesigned in the future.

## Proposed changes

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Code refactor (Modify the code structure, format the code, etc...)
- [ ] Optimization. Including functional usability improvements and performance improvements.
- [ ] Dependency. Such as changes related to third-party components.
- [ ] Other.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have created an issue on (Fix #6844) and described the bug/feature there in detail
- [x] Compiling and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If these changes need document changes, I have updated the document
- [ ] Any dependent changes have been merged

## Further comments

If this is a relatively large or complex change, kick off the discussion at dev@doris.apache.org by explaining why you chose the solution you did and what alternatives you considered, etc...
