### PR TITLE
[BUG] fix streaming_preagg dcheck cause be down

### DIFF
--- a/be/src/exec/partitioned_aggregation_node.cc
+++ b/be/src/exec/partitioned_aggregation_node.cc
@@ -1146,7 +1146,6 @@ Status PartitionedAggregationNode::CreateHashPartitions(int level, int single_pa
             RETURN_IF_ERROR(partition->InitHashTable(&got_memory));
             // Spill the partition if we cannot create a hash table for a merge aggregation.
             if (UNLIKELY(!got_memory)) {
-                DCHECK(!is_streaming_preagg_) << "Preagg reserves enough memory for hash tables";
                 // If we're repartitioning, we will be writing aggregated rows first.
                 RETURN_IF_ERROR(partition->Spill(level > 0));
             }


### PR DESCRIPTION
in debug mode，query memory not enough, may cause be down
fe set useStreamingPreagg true, but be function CreateHashPartitions check is_streaming_preagg_ should false.

then casue core dump.
```
*** Check failure stack trace: ***
    @          0x2aa48ad  google::LogMessage::Fail()
    @          0x2aa6734  google::LogMessage::SendToLog()
    @          0x2aa43d4  google::LogMessage::Flush()
    @          0x2aa7169  google::LogMessageFatal::~LogMessageFatal()
    @          0x24703be  doris::PartitionedAggregationNode::CreateHashPartitions()
    @          0x2468fd6  doris::PartitionedAggregationNode::open()
    @          0x1e3b153  doris::PlanFragmentExecutor::open_internal()
    @          0x1e3af4b  doris::PlanFragmentExecutor::open()
    @          0x1d81b92  doris::FragmentExecState::execute()
    @          0x1d840f7  doris::FragmentMgr::_exec_actual()
```

we should remove DCHECK(!is_streaming_preagg_)
