### PR TITLE
Fix some return logic error in init BE encoding_map

### DIFF
--- a/be/src/olap/rowset/segment_v2/encoding_info.cpp
+++ b/be/src/olap/rowset/segment_v2/encoding_info.cpp
@@ -189,12 +189,6 @@ private:
     // Not thread-safe
     template <FieldType type, EncodingTypePB encoding_type, bool optimize_value_seek = false>
     void _add_map() {
-        auto key = std::make_pair(type, encoding_type);
-        auto it = _encoding_map.find(key);
-        if (it != _encoding_map.end()) {
-            return;
-        }
-
         EncodingTraits<type, encoding_type> traits;
         std::unique_ptr<EncodingInfo> encoding(new EncodingInfo(traits));
         if (_default_encoding_type_map.find(type) == std::end(_default_encoding_type_map)) {
@@ -203,6 +197,11 @@ private:
         if (optimize_value_seek &&
             _value_seek_encoding_map.find(type) == _value_seek_encoding_map.end()) {
             _value_seek_encoding_map[type] = encoding_type;
+        }
+        auto key = std::make_pair(type, encoding_type);
+        auto it = _encoding_map.find(key);
+        if (it != _encoding_map.end()) {
+            return;
         }
         _encoding_map.emplace(key, encoding.release());
     }


### PR DESCRIPTION
## Proposed changes

Checking _encoding_map in the original code to return in advance will cause some encoding methods cannot be pushed to default_encoding_type_map_ or value_seek_encoding_map_ in EncodingInfoResolver constructor.
E.g:
EncodingInfoResolver::EncodingInfoResolver() {
....
    _add_map<OLAP_FIELD_TYPE_BOOL, PLAIN_ENCODING>();
    _add_map<OLAP_FIELD_TYPE_BOOL, PLAIN_ENCODING, true>();
...
}
The second line code is invilid.

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Code refactor (Modify the code structure, format the code, etc...)
- [ ] Optimization. Including functional usability improvements and performance improvements.
- [ ] Dependency. Such as changes related to third-party components.
- [ ] Other.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have created an issue on (Fix #ISSUE) and described the bug/feature there in detail
- [x] Compiling and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If these changes need document changes, I have updated the document
- [ ] Any dependent changes have been merged

## Further comments

If this is a relatively large or complex change, kick off the discussion at dev@doris.apache.org by explaining why you chose the solution you did and what alternatives you considered, etc...
