### PR TITLE
Fix String type column using zonemap to filter data maybe core dump

### DIFF
--- a/be/src/olap/wrapper_field.h
+++ b/be/src/olap/wrapper_field.h
@@ -41,6 +41,9 @@ public:
     virtual ~WrapperField() {
         delete _rep;
         delete[] _owned_buf;
+        if (_long_text_buf) {
+            delete _long_text_buf;
+        }
     }
 
     // 将内部的value转成string输出
@@ -103,6 +106,7 @@ private:
     bool _is_string_type;
     char* _field_buf = nullptr;
     char* _owned_buf = nullptr;
+    char* _long_text_buf = nullptr;
 
     //include fixed and variable length and null bytes
     size_t _length;


### PR DESCRIPTION
## Proposed changes

Fix String type column using zonemap to filter data maybe core dump,  because of not allocating memory before parsing  string type  zonemap 

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Code refactor (Modify the code structure, format the code, etc...)
- [ ] Optimization. Including functional usability improvements and performance improvements.
- [ ] Dependency. Such as changes related to third-party components.
- [ ] Other.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have created an issue on (Fix #ISSUE) and described the bug/feature there in detail
- [ ] Compiling and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If these changes need document changes, I have updated the document
- [ ] Any dependent changes have been merged

## Further comments

If this is a relatively large or complex change, kick off the discussion at dev@doris.apache.org by explaining why you chose the solution you did and what alternatives you considered, etc...
