### PR TITLE
Prevent invalid expr continue parse

### DIFF
--- a/be/src/exprs/expr.cpp
+++ b/be/src/exprs/expr.cpp
@@ -283,6 +283,9 @@ Status Expr::create_tree_from_thrift(ObjectPool* pool, const std::vector<TExprNo
     Expr* expr = NULL;
     RETURN_IF_ERROR(create_expr(pool, nodes[*node_idx], &expr));
     DCHECK(expr != NULL);
+    if (expr == NULL) {
+        return Status::InternalError("Parse TExpr to Expr failed because of expr == NULL.");
+    }
     if (parent != NULL) {
         parent->add_child(expr);
     } else {


### PR DESCRIPTION
## Proposed changes

In some cases, when expr == null, continue parse statement may be visit invalid memory, which will casuse BE process failure.


## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Code refactor (Modify the code structure, format the code, etc...)
- [ ] Optimization. Including functional usability improvements and performance improvements.
- [ ] Dependency. Such as changes related to third-party components.
- [ ] Other.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have created an issue on (Fix #ISSUE) and described the bug/feature there in detail
- [ ] Compiling and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If these changes need document changes, I have updated the document
- [ ] Any dependent changes have been merged

## Further comments

If this is a relatively large or complex change, kick off the discussion at dev@doris.apache.org by explaining why you chose the solution you did and what alternatives you considered, etc...
