### PR TITLE
generage compile_command.json

### DIFF
--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -28,6 +28,8 @@ endif()
 
 project(doris CXX C)
 
+# Write compile_commands.json
+set(CMAKE_EXPORT_COMPILE_COMMANDS 1)
 # set platforms
 
 if (CMAKE_SYSTEM_PROCESSOR MATCHES "amd64|x86_64")


### PR DESCRIPTION
Set cmake to generate `compile_commands.json`, which is useful for lsp like clangd, cquery, et.