### PR TITLE
[Memory] Add a method to get doris current memory usage and Limt memoey usage when consume

### DIFF
--- a/be/src/exec/hash_table.cpp
+++ b/be/src/exec/hash_table.cpp
@@ -181,7 +181,9 @@ void HashTable::resize_buckets(int64_t num_buckets) {
 
     int64_t old_num_buckets = _num_buckets;
     int64_t delta_bytes = (num_buckets - old_num_buckets) * sizeof(Bucket);
-    if (!_mem_tracker->TryConsume(delta_bytes)) {
+    Status st = _mem_tracker->TryConsume(delta_bytes);
+    WARN_IF_ERROR(st, "resize bucket failed");
+    if (!st) {
         mem_limit_exceeded(delta_bytes);
         return;
     }

--- a/be/src/exec/partitioned_hash_table.cc
+++ b/be/src/exec/partitioned_hash_table.cc
@@ -310,7 +310,9 @@ Status PartitionedHashTableCtx::ExprValuesCache::Init(RuntimeState* state,
                                      MAX_EXPR_VALUES_ARRAY_SIZE / expr_values_bytes_per_row_));
 
     int mem_usage = MemUsage(capacity_, expr_values_bytes_per_row_, num_exprs_);
-    if (UNLIKELY(!tracker->TryConsume(mem_usage))) {
+    Status st = tracker->TryConsume(mem_usage);
+    WARN_IF_ERROR(st, "PartitionedHashTableCtx::ExprValuesCache failed");
+    if (UNLIKELY(!st)) {
         capacity_ = 0;
         string details = Substitute(
                 "PartitionedHashTableCtx::ExprValuesCache failed to allocate $0 bytes.", mem_usage);

--- a/be/src/runtime/bufferpool/reservation_tracker.cc
+++ b/be/src/runtime/bufferpool/reservation_tracker.cc
@@ -187,7 +187,9 @@ bool ReservationTracker::TryConsumeFromMemTracker(int64_t reservation_increase) 
     if (GetParentMemTracker() == nullptr) {
         // At the topmost link, which may be a MemTracker with a limit, we need to use
         // TryConsume() to check the limit.
-        return mem_tracker_->TryConsume(reservation_increase);
+        Status st = mem_tracker_->TryConsume(reservation_increase);
+        WARN_IF_ERROR(st, "TryConsumeFromMemTracker failed");
+        return st.ok();
     } else {
         // For lower links, there shouldn't be a limit to enforce, so we just need to
         // update the consumption of the linked MemTracker since the reservation is

--- a/be/src/runtime/mem_pool.cpp
+++ b/be/src/runtime/mem_pool.cpp
@@ -116,7 +116,9 @@ bool MemPool::find_chunk(size_t min_size, bool check_limits) {
 
     chunk_size = BitUtil::RoundUpToPowerOfTwo(chunk_size);
     if (check_limits) {
-        if (!mem_tracker_->TryConsume(chunk_size)) return false;
+        Status st = mem_tracker_->TryConsume(chunk_size);
+        WARN_IF_ERROR(st, "try to allocate a new buffer failed");
+        if (!st) return false;
     } else {
         mem_tracker_->Consume(chunk_size);
     }

--- a/be/src/runtime/mem_tracker.h
+++ b/be/src/runtime/mem_tracker.h
@@ -30,6 +30,7 @@
 
 #include "common/status.h"
 #include "gen_cpp/Types_types.h" // for TUniqueId
+#include "util/mem_info.h"
 #include "util/metrics.h"
 #include "util/runtime_profile.h"
 #include "util/spinlock.h"
@@ -166,11 +167,16 @@ public:
     /// other callers that may not tolerate allocation failures have a better chance
     /// of success. Returns true if the consumption was successfully updated.
     WARN_UNUSED_RESULT
-    bool TryConsume(int64_t bytes, MemLimit mode = MemLimit::HARD) {
+    Status TryConsume(int64_t bytes, MemLimit mode = MemLimit::HARD) {
         // DCHECK_GE(bytes, 0);
         if (bytes <= 0) {
             Release(-bytes);
-            return true;
+            return Status::OK();
+        }
+        if (MemInfo::current_mem() + bytes >= MemInfo::mem_limit()) {
+            return Status::MemoryLimitExceeded(fmt::format(
+                    "{}: TryConsume failed, bytes={} process whole consumption={}  mem limit={}",
+                    label_, bytes, MemInfo::current_mem(), MemInfo::mem_limit()));
         }
         // if (UNLIKELY(bytes == 0)) return true;
         // if (UNLIKELY(bytes < 0)) return false; // needed in RELEASE, hits DCHECK in DEBUG
@@ -189,26 +195,27 @@ public:
                 while (true) {
                     if (LIKELY(tracker->consumption_->try_add(bytes, limit))) break;
 
-                    VLOG_RPC << "TryConsume failed, bytes=" << bytes
-                             << " consumption=" << tracker->consumption_->current_value()
-                             << " limit=" << limit << " attempting to GC";
                     if (UNLIKELY(tracker->GcMemory(limit - bytes))) {
                         DCHECK_GE(i, 0);
                         // Failed for this mem tracker. Roll back the ones that succeeded.
                         for (int j = all_trackers_.size() - 1; j > i; --j) {
                             all_trackers_[j]->consumption_->add(-bytes);
                         }
-                        return false;
+                        return Status::MemoryLimitExceeded(fmt::format(
+                                "{}: TryConsume failed, bytes={} consumption={}  imit={} "
+                                "attempting to GC",
+                                tracker->label(), bytes, tracker->consumption_->current_value(),
+                                limit));
                     }
-                    VLOG_RPC << "GC succeeded, TryConsume bytes=" << bytes
-                             << " consumption=" << tracker->consumption_->current_value()
-                             << " limit=" << limit;
+                    VLOG_NOTICE << "GC succeeded, TryConsume bytes=" << bytes
+                                << " consumption=" << tracker->consumption_->current_value()
+                                << " limit=" << limit;
                 }
             }
         }
         // Everyone succeeded, return.
         DCHECK_EQ(i, -1);
-        return true;
+        return Status::OK();
     }
 
     /// Decreases consumption of this tracker and its ancestors by 'bytes'.

--- a/be/src/service/doris_main.cpp
+++ b/be/src/service/doris_main.cpp
@@ -264,6 +264,10 @@ int main(int argc, char** argv) {
 #if defined(LEAK_SANITIZER)
         __lsan_do_leak_check();
 #endif
+
+#if !defined(ADDRESS_SANITIZER) && !defined(LEAK_SANITIZER) && !defined(THREAD_SANITIZER)
+        doris::MemInfo::refresh_current_mem();
+#endif
         sleep(10);
     }
     http_service.stop();

--- a/be/src/util/mem_info.cpp
+++ b/be/src/util/mem_info.cpp
@@ -25,8 +25,10 @@
 #include <iostream>
 #include <sstream>
 
+#include "common/config.h"
 #include "gutil/strings/split.h"
 #include "util/cgroup_util.h"
+#include "util/parse_util.h"
 #include "util/pretty_printer.h"
 #include "util/string_parser.hpp"
 
@@ -34,6 +36,8 @@ namespace doris {
 
 bool MemInfo::_s_initialized = false;
 int64_t MemInfo::_s_physical_mem = -1;
+int64_t MemInfo::_s_mem_limit = -1;
+size_t MemInfo::_s_current_mem = 0;
 
 void MemInfo::init() {
     // Read from /proc/meminfo
@@ -79,8 +83,10 @@ void MemInfo::init() {
         LOG(WARNING) << "Could not determine amount of physical memory on this machine.";
     }
 
-    LOG(INFO) << "Physical Memory: " << PrettyPrinter::print(_s_physical_mem, TUnit::BYTES);
+    bool is_percent = true;
+    _s_mem_limit = ParseUtil::parse_mem_spec(config::mem_limit, -1, _s_physical_mem, &is_percent);
 
+    LOG(INFO) << "Physical Memory: " << PrettyPrinter::print(_s_physical_mem, TUnit::BYTES);
     _s_initialized = true;
 }
 
@@ -88,7 +94,10 @@ std::string MemInfo::debug_string() {
     DCHECK(_s_initialized);
     CGroupUtil util;
     std::stringstream stream;
-    stream << "Mem Info: " << PrettyPrinter::print(_s_physical_mem, TUnit::BYTES) << std::endl;
+    stream << "Physical Memory: " << PrettyPrinter::print(_s_physical_mem, TUnit::BYTES)
+           << std::endl;
+    stream << "Memory Limt: " << PrettyPrinter::print(_s_mem_limit, TUnit::BYTES) << std::endl;
+    stream << "Current Usage: " << PrettyPrinter::print(_s_current_mem, TUnit::BYTES) << std::endl;
     stream << "CGroup Info: " << util.debug_string() << std::endl;
     return stream.str();
 }

--- a/be/src/util/mem_info.h
+++ b/be/src/util/mem_info.h
@@ -18,6 +18,8 @@
 #ifndef DORIS_BE_SRC_COMMON_UTIL_MEM_INFO_H
 #define DORIS_BE_SRC_COMMON_UTIL_MEM_INFO_H
 
+#include <gperftools/malloc_extension.h>
+
 #include <string>
 
 #include "common/logging.h"
@@ -33,9 +35,21 @@ public:
     static void init();
 
     // Get total physical memory in bytes (if has cgroups memory limits, return the limits).
-    static int64_t physical_mem() {
+    static inline int64_t physical_mem() {
         DCHECK(_s_initialized);
         return _s_physical_mem;
+    }
+
+    static inline size_t current_mem() { return _s_current_mem; }
+
+    static inline void refresh_current_mem() {
+        MallocExtension::instance()->GetNumericProperty("generic.total_physical_bytes",
+                                                        &_s_current_mem);
+    }
+
+    static inline int64_t mem_limit() {
+        DCHECK(_s_initialized);
+        return _s_mem_limit;
     }
 
     static std::string debug_string();
@@ -43,6 +57,8 @@ public:
 private:
     static bool _s_initialized;
     static int64_t _s_physical_mem;
+    static int64_t _s_mem_limit;
+    static size_t _s_current_mem;
 };
 
 } // namespace doris

--- a/be/src/util/parse_util.cpp
+++ b/be/src/util/parse_util.cpp
@@ -17,12 +17,12 @@
 
 #include "util/parse_util.h"
 
-#include "util/mem_info.h"
 #include "util/string_parser.hpp"
 
 namespace doris {
 
-int64_t ParseUtil::parse_mem_spec(const std::string& mem_spec_str, int64_t parent_limit, bool* is_percent) {
+int64_t ParseUtil::parse_mem_spec(const std::string& mem_spec_str, int64_t parent_limit,
+                                  int64_t physical_mem, bool* is_percent) {
     if (mem_spec_str.empty()) {
         return 0;
     }
@@ -82,7 +82,7 @@ int64_t ParseUtil::parse_mem_spec(const std::string& mem_spec_str, int64_t paren
             bytes = multiplier * limit_val;
         } else if (*is_percent) {
             if (parent_limit == -1) {
-                bytes = (static_cast<double>(limit_val) / 100.0) * MemInfo::physical_mem();
+                bytes = (static_cast<double>(limit_val) / 100.0) * physical_mem;
             } else {
                 bytes = (static_cast<double>(limit_val) / 100.0) * parent_limit;
             }

--- a/be/src/util/parse_util.h
+++ b/be/src/util/parse_util.h
@@ -36,9 +36,9 @@ public:
     // Returns 0 if mem_spec_str is empty or '-1'.
     // Returns -1 if parsing failed.
     // if is_percent, return the percent of parent_limit.
-    // if parent_limit is -1, use MemInfo::physical_mem() as parent limit.
+    // if parent_limit is -1, use physical_mem as parent limit.
     static int64_t parse_mem_spec(const std::string& mem_spec_str, int64_t parent_limit,
-                                  bool* is_percent);
+                                  int64_t physical_mem, bool* is_percent);
 };
 
 } // namespace doris

--- a/be/src/util/system_metrics.cpp
+++ b/be/src/util/system_metrics.cpp
@@ -17,7 +17,6 @@
 
 #include "util/system_metrics.h"
 
-#include <gperftools/malloc_extension.h>
 #include <stdio.h>
 
 #include <functional>
@@ -25,6 +24,7 @@
 #include "gutil/strings/split.h" // for string split
 #include "gutil/strtoint.h"      //  for atoi64
 #include "util/doris_metrics.h"
+#include "util/mem_info.h"
 
 namespace doris {
 
@@ -313,14 +313,7 @@ void SystemMetrics::_install_memory_metrics(MetricEntity* entity) {
 }
 
 void SystemMetrics::_update_memory_metrics() {
-#if defined(ADDRESS_SANITIZER) || defined(LEAK_SANITIZER) || defined(THREAD_SANITIZER)
-    LOG(INFO) << "Memory tracking is not available with address sanitizer builds.";
-#else
-    size_t allocated_bytes = 0;
-    MallocExtension::instance()->GetNumericProperty("generic.current_allocated_bytes",
-                                                    &allocated_bytes);
-    _memory_metrics->memory_allocated_bytes->set_value(allocated_bytes);
-#endif
+    _memory_metrics->memory_allocated_bytes->set_value(MemInfo::current_mem());
 }
 
 void SystemMetrics::_install_disk_metrics(const std::set<std::string>& disk_devices) {

--- a/be/test/exec/hash_table_test.cpp
+++ b/be/test/exec/hash_table_test.cpp
@@ -357,7 +357,7 @@ TEST_F(HashTableTest, GrowTableTest2) {
     int expected_size = 0;
 
     std::shared_ptr<MemTracker> mem_tracker =
-            MemTracker::CreateTracker(1024 * 1024, "hash-table-grow2-tracker", _tracker);
+            MemTracker::CreateTracker(1024 * 1024 * 1024, "hash-table-grow2-tracker", _tracker);
     std::vector<bool> is_null_safe = {false};
     int initial_seed = 1;
     int64_t num_buckets = 4;
@@ -396,6 +396,12 @@ TEST_F(HashTableTest, GrowTableTest2) {
 
 int main(int argc, char** argv) {
     ::testing::InitGoogleTest(&argc, argv);
+    std::string conffile = std::string(getenv("DORIS_HOME")) + "/conf/be.conf";
+    if (!doris::config::init(conffile.c_str(), false)) {
+        fprintf(stderr, "error read config file. \n");
+        return -1;
+    }
     doris::CpuInfo::init();
+    doris::MemInfo::init();
     return RUN_ALL_TESTS();
 }

--- a/be/test/olap/column_reader_test.cpp
+++ b/be/test/olap/column_reader_test.cpp
@@ -2905,6 +2905,7 @@ int main(int argc, char** argv) {
         fprintf(stderr, "error read config file. \n");
         return -1;
     }
+    doris::MemInfo::init();
     int ret = doris::OLAP_SUCCESS;
     testing::InitGoogleTest(&argc, argv);
     ret = RUN_ALL_TESTS();

--- a/be/test/olap/schema_change_test.cpp
+++ b/be/test/olap/schema_change_test.cpp
@@ -955,6 +955,7 @@ int main(int argc, char** argv) {
         return -1;
     }
     doris::init_glog("be-test");
+    doris::MemInfo::init();
     int ret = doris::OLAP_SUCCESS;
     testing::InitGoogleTest(&argc, argv);
     ret = RUN_ALL_TESTS();

--- a/be/test/runtime/mem_limit_test.cpp
+++ b/be/test/runtime/mem_limit_test.cpp
@@ -100,7 +100,7 @@ TEST(MemTestTest, TrackerHierarchyTryConsume) {
     auto c2 = MemTracker::CreateTracker(50, "c2", p);
 
     // everything below limits
-    bool consumption = c1->TryConsume(60);
+    bool consumption = c1->TryConsume(60).ok();
     EXPECT_EQ(consumption, true);
     EXPECT_EQ(c1->consumption(), 60);
     EXPECT_FALSE(c1->LimitExceeded(MemLimit::HARD));
@@ -113,7 +113,7 @@ TEST(MemTestTest, TrackerHierarchyTryConsume) {
     EXPECT_FALSE(p->AnyLimitExceeded(MemLimit::HARD));
 
     // p goes over limit
-    consumption = c2->TryConsume(50);
+    consumption = c2->TryConsume(50).ok();
     EXPECT_EQ(consumption, false);
     EXPECT_EQ(c1->consumption(), 60);
     EXPECT_FALSE(c1->LimitExceeded(MemLimit::HARD));
@@ -137,7 +137,6 @@ TEST(MemTestTest, TrackerHierarchyTryConsume) {
     EXPECT_EQ(p->consumption(), 50);
     EXPECT_FALSE(p->LimitExceeded(MemLimit::HARD));
 
-
     c1->Release(40);
     c2->Release(10);
 }
@@ -145,7 +144,13 @@ TEST(MemTestTest, TrackerHierarchyTryConsume) {
 } // end namespace doris
 
 int main(int argc, char** argv) {
+    std::string conffile = std::string(getenv("DORIS_HOME")) + "/conf/be.conf";
+    if (!doris::config::init(conffile.c_str(), false)) {
+        fprintf(stderr, "error read config file. \n");
+        return -1;
+    }
     doris::init_glog("be-test");
     ::testing::InitGoogleTest(&argc, argv);
+    doris::MemInfo::init();
     return RUN_ALL_TESTS();
 }

--- a/be/test/util/parse_util_test.cpp
+++ b/be/test/util/parse_util_test.cpp
@@ -28,7 +28,8 @@ namespace doris {
 
 static void test_parse_mem_spec(const std::string& mem_spec_str, int64_t result) {
     bool is_percent = true;
-    int64_t bytes = ParseUtil::parse_mem_spec(mem_spec_str, -1, &is_percent);
+    int64_t bytes =
+            ParseUtil::parse_mem_spec(mem_spec_str, -1, MemInfo::_s_physical_mem, &is_percent);
     ASSERT_EQ(result, bytes);
     ASSERT_FALSE(is_percent);
 }
@@ -52,24 +53,24 @@ TEST(TestParseMemSpec, Normal) {
     test_parse_mem_spec("128T", 128L * 1024 * 1024 * 1024 * 1024L);
 
     bool is_percent = false;
-    int64_t bytes = ParseUtil::parse_mem_spec("20%", -1, &is_percent);
+    int64_t bytes = ParseUtil::parse_mem_spec("20%", -1, MemInfo::_s_physical_mem, &is_percent);
     ASSERT_GT(bytes, 0);
     ASSERT_TRUE(is_percent);
 
     MemInfo::_s_physical_mem = 1000;
     is_percent = true;
-    bytes = ParseUtil::parse_mem_spec("0.1%", -1, &is_percent);
+    bytes = ParseUtil::parse_mem_spec("0.1%", -1, MemInfo::_s_physical_mem, &is_percent);
     ASSERT_EQ(bytes, 1);
     ASSERT_TRUE(is_percent);
 
     // test with parent limit
     is_percent = false;
-    bytes = ParseUtil::parse_mem_spec("1%", 1000, &is_percent);
+    bytes = ParseUtil::parse_mem_spec("1%", 1000, MemInfo::_s_physical_mem, &is_percent);
     ASSERT_TRUE(is_percent);
     ASSERT_EQ(10, bytes);
 
     is_percent = true;
-    bytes = ParseUtil::parse_mem_spec("1001", 1000, &is_percent);
+    bytes = ParseUtil::parse_mem_spec("1001", 1000, MemInfo::_s_physical_mem, &is_percent);
     ASSERT_FALSE(is_percent);
     ASSERT_EQ(1001, bytes);
 }
@@ -91,7 +92,7 @@ TEST(TestParseMemSpec, Bad) {
     bad_values.push_back("%");
     for (const auto& value : bad_values) {
         bool is_percent = false;
-        int64_t bytes = ParseUtil::parse_mem_spec(value, -1, &is_percent);
+        int64_t bytes = ParseUtil::parse_mem_spec(value, -1, MemInfo::_s_physical_mem, &is_percent);
         ASSERT_EQ(-1, bytes);
     }
 }


### PR DESCRIPTION
## Proposed changes

Add a method to get Doris current memory usage, get Doris memory usage every 1 second.
This method used to limit the whole memory allocation in Doris
Add all memory usage check when `TryConsume` memory

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [x] Code refactor (Modify the code structure, format the code, etc...)
- [x] Optimization. Including functional usability improvements and performance improvements.
- [ ] Dependency. Such as changes related to third-party components.
- [ ] Other.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have created an issue on (#6978 ) and described the bug/feature there in detail
- [ ] Compiling and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If these changes need document changes, I have updated the document
- [ ] Any dependent changes have been merged

## Further comments

If this is a relatively large or complex change, kick off the discussion at dev@doris.apache.org by explaining why you chose the solution you did and what alternatives you considered, etc...
