### PR TITLE
mem_tracker optimization

### DIFF
--- a/be/src/util/runtime_profile.h
+++ b/be/src/util/runtime_profile.h
@@ -148,7 +148,9 @@ public:
 
         virtual void add(int64_t delta) {
             int64_t new_val = current_value_.add(delta);
-            UpdateMax(new_val);
+            if (delta > 0) {
+                UpdateMax(new_val);
+            }
         }
 
         /// Tries to increase the current value by delta. If current_value() + delta


### PR DESCRIPTION
optimise HighWaterMarkCounter::add(),  UpdateMax only if delta greate than 0 to reduce function call times
delete useless code lines to keep MemTrack clean

some member datas never be set, but check its value，the if condition never be satisified, so clean these codes 