### PR TITLE
[BUG] fixbug sql execution sometimes due to failed to get tablet

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
@@ -1234,7 +1234,7 @@ public class Coordinator {
         }
 
         for (PlanNode childNode : node.getChildren()) {
-            if (isColocateFragment(planFragment, childNode)) {
+            if (childNode.getFragmentId().asInt() == planFragment.getId().asInt() && isColocateFragment(planFragment, childNode)) {
                 return true;
             }
         }


### PR DESCRIPTION
 ## Proposed changes

When there are multiple fragments in the SQL execution plan, and the lower part of the fragment has Colocate join, it may cause the join nodes of other fragments to use Colocate join incorrectly. Therefore, olapTableScan reaches the incorrect be, and finally tablet not found appears.

The isColocateFragment(PlanFragment planFragment, PlanNode node) method of the Coordinator class will traverse all the downstream nodes of the node, whether it should only traverse the downstream node nodes belonging to planFragment

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Code refactor (Modify the code structure, format the code, etc...)
- [ ] Optimization. Including functional usability improvements and performance improvements.
- [ ] Dependency. Such as changes related to third-party components.
- [ ] Other.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have created an issue on (Fix #6967) and described the bug/feature there in detail
- [x] Compiling and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If these changes need document changes, I have updated the document
- [ ] Any dependent changes have been merged

## Further comments

If this is a relatively large or complex change, kick off the discussion at dev@doris.apache.org by explaining why you chose the solution you did and what alternatives you considered, etc...