### PR TITLE
fix core problem: use object replace pointer

### DIFF
--- a/be/src/exec/tablet_info.h
+++ b/be/src/exec/tablet_info.h
@@ -243,6 +243,8 @@ struct NodeInfo {
     std::string host;
     int32_t brpc_port;
 
+    NodeInfo() = default;
+
     NodeInfo(const TNodeInfo& tnode)
             : id(tnode.id),
               option(tnode.option),

--- a/be/src/exec/tablet_sink.cpp
+++ b/be/src/exec/tablet_sink.cpp
@@ -145,8 +145,8 @@ void NodeChannel::_cancel_with_msg(const std::string& msg) {
 Status NodeChannel::open_wait() {
     _open_closure->join();
     if (_open_closure->cntl.Failed()) {
-        if (!ExecEnv::GetInstance()->brpc_stub_cache()->available(_stub, _node_info->host,
-                                                                  _node_info->brpc_port)) {
+        if (!ExecEnv::GetInstance()->brpc_stub_cache()->available(_stub, _node_info.host,
+                                                                  _node_info.brpc_port)) {
             ExecEnv::GetInstance()->brpc_stub_cache()->erase(_open_closure->cntl.remote_side());
         }
         std::stringstream ss;

--- a/be/src/exec/tablet_sink.cpp
+++ b/be/src/exec/tablet_sink.cpp
@@ -62,22 +62,24 @@ NodeChannel::~NodeChannel() {
 // returned directly via "TabletSink::prepare()" method.
 Status NodeChannel::init(RuntimeState* state) {
     _tuple_desc = _parent->_output_tuple_desc;
-    _node_info = _parent->_nodes_info->find_node(_node_id);
-    if (_node_info == nullptr) {
+    auto node =  _parent->_nodes_info->find_node(_node_id);
+    if (node == nullptr) {
         std::stringstream ss;
         ss << "unknown node id, id=" << _node_id;
         _cancelled = true;
         return Status::InternalError(ss.str());
     }
 
+    _node_info = *node;
+
     _row_desc.reset(new RowDescriptor(_tuple_desc, false));
     _batch_size = state->batch_size();
     _cur_batch.reset(new RowBatch(*_row_desc, _batch_size, _parent->_mem_tracker.get()));
 
-    _stub = state->exec_env()->brpc_stub_cache()->get_stub(_node_info->host, _node_info->brpc_port);
-    if (!_stub) {
-        LOG(WARNING) << "Get rpc stub failed, host=" << _node_info->host
-                     << ", port=" << _node_info->brpc_port;
+    _stub = state->exec_env()->brpc_stub_cache()->get_stub(_node_info.host, _node_info.brpc_port);
+    if (_stub == nullptr) {
+        LOG(WARNING) << "Get rpc stub failed, host=" << _node_info.host
+                     << ", port=" << _node_info.brpc_port;
         _cancelled = true;
         return Status::InternalError("get rpc stub failed");
     }

--- a/be/src/exec/tablet_sink.cpp
+++ b/be/src/exec/tablet_sink.cpp
@@ -62,22 +62,24 @@ NodeChannel::~NodeChannel() {
 // returned directly via "TabletSink::prepare()" method.
 Status NodeChannel::init(RuntimeState* state) {
     _tuple_desc = _parent->_output_tuple_desc;
-    _node_info = _parent->_nodes_info->find_node(_node_id);
-    if (_node_info == nullptr) {
+    auto node =  _parent->_nodes_info->find_node(_node_id);
+    if (node == nullptr) {
         std::stringstream ss;
         ss << "unknown node id, id=" << _node_id;
         _cancelled = true;
         return Status::InternalError(ss.str());
     }
 
+    _node_info = *node;
+
     _row_desc.reset(new RowDescriptor(_tuple_desc, false));
     _batch_size = state->batch_size();
     _cur_batch.reset(new RowBatch(*_row_desc, _batch_size, _parent->_mem_tracker.get()));
 
-    _stub = state->exec_env()->brpc_stub_cache()->get_stub(_node_info->host, _node_info->brpc_port);
+    _stub = state->exec_env()->brpc_stub_cache()->get_stub(_node_info.host, _node_info.brpc_port);
     if (_stub == nullptr) {
-        LOG(WARNING) << "Get rpc stub failed, host=" << _node_info->host
-                     << ", port=" << _node_info->brpc_port;
+        LOG(WARNING) << "Get rpc stub failed, host=" << _node_info.host
+                     << ", port=" << _node_info.brpc_port;
         _cancelled = true;
         return Status::InternalError("get rpc stub failed");
     }

--- a/be/src/exec/tablet_sink.h
+++ b/be/src/exec/tablet_sink.h
@@ -203,7 +203,7 @@ public:
         // FIXME(cmy): There is a problem that when calling node_info, the node_info seems not initialized.
         //             But I don't know why. so here I print node_info->id instead of node_info->host
         //             to avoid BE crash. It needs further observation.
-        return fmt::format("{}, {}, node={}:{}", _name, _load_info, _node_info->id, _node_info->brpc_port);
+        return fmt::format("{}, {}, node={}:{}", _name, _load_info, _node_info.id, _node_info.brpc_port);
     } 
 
 private:
@@ -218,7 +218,7 @@ private:
     std::string _name;
 
     TupleDescriptor* _tuple_desc = nullptr;
-    const NodeInfo* _node_info = nullptr;
+    NodeInfo _node_info;
 
     // this should be set in init() using config
     int _rpc_timeout_ms = 60000;


### PR DESCRIPTION
old version:
NodeChannel::_node_info is a pointer member data， this member pointer is set by _parent->_nodes_info->find_node in the function NodeChannel::init(), _parent->_nodes_info is managed by object_pool, the object_pool‘ lifetime is the same with PlanFragmentExecutor.

but _node_info will be used in _add_batch_closure' success handler, it's a async callback, in this callback, PlanFragmentExecutor created for other RPC may be destroy for some reasons, such as timeout or canceled, so continue use _node_info is wrong.

refactor: use NodeInfo _node_info replace NodeInfo *_node_info, just copy NodeInfo in init function