### PR TITLE
[Feature] Clean up old sync jobs regularly

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/load/sync/SyncChecker.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/sync/SyncChecker.java
@@ -32,7 +32,7 @@ import java.util.List;
 public class SyncChecker extends MasterDaemon {
     private static final Logger LOG = LogManager.getLogger(SyncChecker.class);
 
-    private SyncJobManager syncJobManager;
+    private final SyncJobManager syncJobManager;
 
     public SyncChecker(SyncJobManager syncJobManager) {
         super("sync checker", Config.sync_checker_interval_second * 1000L);
@@ -73,5 +73,7 @@ public class SyncChecker extends MasterDaemon {
                 job.cancel(msgType, exception.getMessage());
             }
         }
+
+        this.syncJobManager.cleanOldSyncJobs();
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/load/sync/SyncChecker.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/sync/SyncChecker.java
@@ -44,6 +44,7 @@ public class SyncChecker extends MasterDaemon {
         LOG.debug("start check sync jobs.");
         try {
             process();
+            cleanOldSyncJobs();
         } catch (Throwable e) {
             LOG.warn("Failed to process one round of SyncChecker", e);
         }
@@ -73,7 +74,10 @@ public class SyncChecker extends MasterDaemon {
                 job.cancel(msgType, exception.getMessage());
             }
         }
+    }
 
+    private void cleanOldSyncJobs() {
+        // clean up expired sync jobs
         this.syncJobManager.cleanOldSyncJobs();
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/load/sync/SyncJobManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/sync/SyncJobManager.java
@@ -285,7 +285,6 @@ public class SyncJobManager implements Writable {
     public void cleanOldSyncJobs() {
         LOG.debug("begin to clean old sync jobs ");
         long currentTimeMs = System.currentTimeMillis();
-
         writeLock();
         try {
             Iterator<Map.Entry<Long, SyncJob>> iterator = idToSyncJob.entrySet().iterator();
@@ -302,7 +301,6 @@ public class SyncJobManager implements Writable {
                         dbIdToJobNameToSyncJobs.remove(syncJob.getDbId());
                     }
                     iterator.remove();
-
                     LOG.info(new LogBuilder(LogKey.SYNC_JOB, syncJob.getId())
                             .add("finishTimeMs", syncJob.getFinishTimeMs())
                             .add("currentTimeMs", currentTimeMs)

--- a/fe/fe-core/src/main/java/org/apache/doris/load/sync/SyncJobManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/sync/SyncJobManager.java
@@ -291,6 +291,9 @@ public class SyncJobManager implements Writable {
             while (iterator.hasNext()) {
                 SyncJob syncJob = iterator.next().getValue();
                 if (syncJob.isExpired(currentTimeMs)) {
+                    if (!dbIdToJobNameToSyncJobs.containsKey(syncJob.getDbId())) {
+                        continue;
+                    }
                     Map<String, List<SyncJob>> map = dbIdToJobNameToSyncJobs.get(syncJob.getDbId());
                     List<SyncJob> list = map.get(syncJob.getJobName());
                     list.remove(syncJob);

--- a/fe/fe-core/src/main/java/org/apache/doris/load/sync/SyncJobManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/sync/SyncJobManager.java
@@ -41,6 +41,7 @@ import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 import java.util.Collection;
+import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -276,6 +277,42 @@ public class SyncJobManager implements Writable {
             if (!syncJob.isCompleted()) {
                 syncJob.checkAndDoUpdate();
             }
+        }
+    }
+
+    // Remove old sync jobs. Called periodically.
+    // Stopped jobs will be removed after Config.label_keep_max_second.
+    public void cleanOldSyncJobs() {
+        LOG.debug("begin to clean old sync jobs ");
+        long currentTimeMs = System.currentTimeMillis();
+
+        writeLock();
+        try {
+            Iterator<Map.Entry<Long, SyncJob>> iterator = idToSyncJob.entrySet().iterator();
+            while (iterator.hasNext()) {
+                SyncJob syncJob = iterator.next().getValue();
+                if (syncJob.isExpired(currentTimeMs)) {
+                    Map<String, List<SyncJob>> map = dbIdToJobNameToSyncJobs.get(syncJob.getDbId());
+                    List<SyncJob> list = map.get(syncJob.getJobName());
+                    list.remove(syncJob);
+                    if (list.isEmpty()) {
+                        map.remove(syncJob.getJobName());
+                    }
+                    if (map.isEmpty()) {
+                        dbIdToJobNameToSyncJobs.remove(syncJob.getDbId());
+                    }
+                    iterator.remove();
+
+                    LOG.info(new LogBuilder(LogKey.SYNC_JOB, syncJob.getId())
+                            .add("finishTimeMs", syncJob.getFinishTimeMs())
+                            .add("currentTimeMs", currentTimeMs)
+                            .add("jobState", syncJob.getJobState())
+                            .add("msg", "old sync job has been cleaned")
+                    );
+                }
+            }
+        } finally {
+            writeUnlock();
         }
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/load/sync/SyncJobManagerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/load/sync/SyncJobManagerTest.java
@@ -407,7 +407,7 @@ public class SyncJobManagerTest {
 
     @Test
     public void testCleanOldSyncJobs() {
-        CanalSyncJob canalSyncJob = new CanalSyncJob(jobId, jobName, dbId);
+        SyncJob canalSyncJob = new CanalSyncJob(jobId, jobName, dbId);
         // change sync job state to cancelled
         try {
             canalSyncJob.updateState(JobState.CANCELLED, false);
@@ -424,12 +424,12 @@ public class SyncJobManagerTest {
         Map<Long, Map<String, List<SyncJob>>> dbIdToJobNameToSyncJobs = Maps.newHashMap();
         Map<String, List<SyncJob>> jobNameToSyncJobs = Maps.newHashMap();
         jobNameToSyncJobs.put(jobName, Lists.newArrayList(canalSyncJob));
-        dbIdToJobNameToSyncJobs.put(jobId, jobNameToSyncJobs);
+        dbIdToJobNameToSyncJobs.put(dbId, jobNameToSyncJobs);
 
         Deencapsulation.setField(manager, "idToSyncJob", idToSyncJob);
         Deencapsulation.setField(manager, "dbIdToJobNameToSyncJobs", dbIdToJobNameToSyncJobs);
 
-        new Expectations() {
+        new Expectations(canalSyncJob) {
             {
                 canalSyncJob.isExpired(anyLong);
                 result = true;

--- a/fe/fe-core/src/test/java/org/apache/doris/load/sync/SyncJobManagerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/load/sync/SyncJobManagerTest.java
@@ -405,5 +405,41 @@ public class SyncJobManagerTest {
         Assert.assertEquals(MsgType.USER_CANCEL, canalSyncJob.getFailMsg().getMsgType());
     }
 
+    @Test
+    public void testCleanOldSyncJobs() {
+        CanalSyncJob canalSyncJob = new CanalSyncJob(jobId, jobName, dbId);
+        // change sync job state to cancelled
+        try {
+            canalSyncJob.updateState(JobState.CANCELLED, false);
+        } catch (UserException e) {
+            Assert.fail();
+        }
+        Assert.assertEquals(JobState.CANCELLED, canalSyncJob.getJobState());
+
+        SyncJobManager manager = new SyncJobManager();
+
+        // add a sync job to manager
+        Map<Long, SyncJob> idToSyncJob = Maps.newHashMap();
+        idToSyncJob.put(jobId, canalSyncJob);
+        Map<Long, Map<String, List<SyncJob>>> dbIdToJobNameToSyncJobs = Maps.newHashMap();
+        Map<String, List<SyncJob>> jobNameToSyncJobs = Maps.newHashMap();
+        jobNameToSyncJobs.put(jobName, Lists.newArrayList(canalSyncJob));
+        dbIdToJobNameToSyncJobs.put(jobId, jobNameToSyncJobs);
+
+        Deencapsulation.setField(manager, "idToSyncJob", idToSyncJob);
+        Deencapsulation.setField(manager, "dbIdToJobNameToSyncJobs", dbIdToJobNameToSyncJobs);
+
+        new Expectations() {
+            {
+                canalSyncJob.isExpired(anyLong);
+                result = true;
+            }
+        };
+        manager.cleanOldSyncJobs();
+
+        Assert.assertEquals(0, idToSyncJob.size());
+        Assert.assertEquals(0, dbIdToJobNameToSyncJobs.size());
+    }
+
 
 }


### PR DESCRIPTION
## Proposed changes

#7060 
#6287 

Each job that has been stopped for more than 3 days(set with Config.label_keep_max_second) will be permanently cleaned up.

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have created an issue on (Fix #7060 ) and described the bug/feature there in detail
- [x] Compiling and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works

## Further comments

If this is a relatively large or complex change, kick off the discussion at dev@doris.apache.org by explaining why you chose the solution you did and what alternatives you considered, etc...
