### PR TITLE
Add session variable to close join order

### DIFF
--- a/docs/en/administrator-guide/variables.md
+++ b/docs/en/administrator-guide/variables.md
@@ -439,3 +439,7 @@ Translated with www.DeepL.com/Translator (free version)
      This parameter will be overridden by the `cpu_resource_limit` configuration in the user property.
 
      The default is -1, which means no limit.
+
+* `disable_join_reorder`
+
+    Used to turn off all automatic join reorder algorithms in the system. There are two values: true and false.It is closed by default, that is, the automatic join reorder algorithm of the system is adopted. After set to true, the system will close all automatic sorting algorithms, adopt the original SQL table order, and execute join

--- a/docs/zh-CN/administrator-guide/variables.md
+++ b/docs/zh-CN/administrator-guide/variables.md
@@ -432,3 +432,7 @@ SELECT /*+ SET_VAR(query_timeout = 1, enable_partition_cache=true) */ sleep(3);
     该参数会被 user property 中的 `cpu_resource_limit` 配置覆盖。
 
     默认 -1，即不限制。
+
+* `disable_join_reorder`
+
+   用于关闭所有系统自动的 join reorder 算法。取值有两种：true 和 false。默认行况下关闭，也就是采用系统自动的 join reorder 算法。设置为 true 后，系统会关闭所有自动排序的算法，采用 SQL 原始的表顺序，执行 join

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/Analyzer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/Analyzer.java
@@ -1644,16 +1644,16 @@ public class Analyzer {
     }
 
     // The star join reorder is turned on
-    // when 'enable_join_reorder_based_cost = false' and 'close_join_reorder = false'
+    // when 'enable_join_reorder_based_cost = false' and 'disable_join_reorder = false'
     public boolean enableStarJoinReorder() {
         if (globalState.context == null) {
             return false;
         }
-        return !globalState.context.getSessionVariable().isEnableJoinReorderBasedCost() && !globalState.context.getSessionVariable().isCloseJoinReorder();
+        return !globalState.context.getSessionVariable().isEnableJoinReorderBasedCost() && !globalState.context.getSessionVariable().isDisableJoinReorder();
     }
 
     // The cost based join reorder is turned on
-    // when 'enable_join_reorder_based_cost = true' and 'close_join_reorder = false'
+    // when 'enable_join_reorder_based_cost = true' and 'disable_join_reorder = false'
     // Load plan and query plan are the same framework
     // Some Load method in doris access through http protocol, which will cause the session may be empty.
     // In order to avoid the occurrence of null pointer exceptions, a check will be added here
@@ -1661,7 +1661,7 @@ public class Analyzer {
         if (globalState.context == null) {
             return false;
         }
-        return globalState.context.getSessionVariable().isEnableJoinReorderBasedCost() && !globalState.context.getSessionVariable().isCloseJoinReorder();
+        return globalState.context.getSessionVariable().isEnableJoinReorderBasedCost() && !globalState.context.getSessionVariable().isDisableJoinReorder();
     }
     
     public boolean safeIsEnableFoldConstantByBe() {

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/Analyzer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/Analyzer.java
@@ -1643,6 +1643,17 @@ public class Analyzer {
         this.changeResSmap = changeResSmap;
     }
 
+    // The star join reorder is turned on
+    // when 'enable_join_reorder_based_cost = false' and 'close_join_reorder = false'
+    public boolean enableStarJoinReorder() {
+        if (globalState.context == null) {
+            return false;
+        }
+        return !globalState.context.getSessionVariable().isEnableJoinReorderBasedCost() && !globalState.context.getSessionVariable().isCloseJoinReorder();
+    }
+
+    // The cost based join reorder is turned on
+    // when 'enable_join_reorder_based_cost = true' and 'close_join_reorder = false'
     // Load plan and query plan are the same framework
     // Some Load method in doris access through http protocol, which will cause the session may be empty.
     // In order to avoid the occurrence of null pointer exceptions, a check will be added here
@@ -1650,7 +1661,7 @@ public class Analyzer {
         if (globalState.context == null) {
             return false;
         }
-        return globalState.context.getSessionVariable().isEnableJoinReorderBasedCost();
+        return globalState.context.getSessionVariable().isEnableJoinReorderBasedCost() && !globalState.context.getSessionVariable().isCloseJoinReorder();
     }
     
     public boolean safeIsEnableFoldConstantByBe() {

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/FromClause.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/FromClause.java
@@ -129,7 +129,7 @@ public class FromClause implements ParseNode, Iterable<TableRef> {
         // This change will cause the predicate in on clause be adjusted to the front of the association table,
         // causing semantic analysis to fail. Unknown column 'column1' in 'table1'
         // So we need to readjust the order of the tables here.
-        if (!analyzer.safeIsEnableJoinReorderBasedCost()) {
+        if (analyzer.enableStarJoinReorder()) {
             sortTableRefKeepSequenceOfOnClause();
         }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/SelectStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/SelectStmt.java
@@ -520,7 +520,7 @@ public class SelectStmt extends QueryStmt {
         if (needToSql) {
             sqlString_ = toSql();
         }
-        if (!analyzer.safeIsEnableJoinReorderBasedCost()) {
+        if (analyzer.enableStarJoinReorder()) {
             LOG.debug("use old reorder logical in select stmt");
             reorderTable(analyzer);
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -148,6 +148,9 @@ public class SessionVariable implements Serializable, Writable {
     // then the coordinator be will use the value of `max_send_batch_parallelism_per_job`
     public static final String SEND_BATCH_PARALLELISM = "send_batch_parallelism";
 
+    // turn off all automatic join reorder algorithms
+    public static final String CLOSE_JOIN_REORDER = "close_join_reorder";
+
     public static final long DEFAULT_INSERT_VISIBLE_TIMEOUT_MS = 10_000;
 
     public static final String EXTRACT_WIDE_RANGE_EXPR = "extract_wide_range_expr";
@@ -383,6 +386,9 @@ public class SessionVariable implements Serializable, Writable {
 
     @VariableMgr.VarAttr(name = ENABLE_LATERAL_VIEW, needForward = true)
     public boolean enableLateralView = false;
+
+    @VariableMgr.VarAttr(name = CLOSE_JOIN_REORDER)
+    private boolean closeJoinReorder = false;
 
     public long getMaxExecMemByte() {
         return maxExecMemByte;
@@ -798,6 +804,10 @@ public class SessionVariable implements Serializable, Writable {
 
     public void setEnableLateralView(boolean enableLateralView) {
         this.enableLateralView = enableLateralView;
+    }
+
+    public boolean isCloseJoinReorder() {
+        return closeJoinReorder;
     }
 
     // Serialize to thrift object

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -149,7 +149,7 @@ public class SessionVariable implements Serializable, Writable {
     public static final String SEND_BATCH_PARALLELISM = "send_batch_parallelism";
 
     // turn off all automatic join reorder algorithms
-    public static final String CLOSE_JOIN_REORDER = "close_join_reorder";
+    public static final String DISABLE_JOIN_REORDER = "disable_join_reorder";
 
     public static final long DEFAULT_INSERT_VISIBLE_TIMEOUT_MS = 10_000;
 
@@ -387,8 +387,8 @@ public class SessionVariable implements Serializable, Writable {
     @VariableMgr.VarAttr(name = ENABLE_LATERAL_VIEW, needForward = true)
     public boolean enableLateralView = false;
 
-    @VariableMgr.VarAttr(name = CLOSE_JOIN_REORDER)
-    private boolean closeJoinReorder = false;
+    @VariableMgr.VarAttr(name = DISABLE_JOIN_REORDER)
+    private boolean disableJoinReorder = false;
 
     public long getMaxExecMemByte() {
         return maxExecMemByte;
@@ -806,8 +806,8 @@ public class SessionVariable implements Serializable, Writable {
         this.enableLateralView = enableLateralView;
     }
 
-    public boolean isCloseJoinReorder() {
-        return closeJoinReorder;
+    public boolean isDisableJoinReorder() {
+        return disableJoinReorder;
     }
 
     // Serialize to thrift object


### PR DESCRIPTION
## Proposed changes

The new session variable 'close_join_reorder' is used to turn off all automatic join reorder algorithms.
If close_join_reorder is true, the Doris will execute query by the order in the original query.
## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Code refactor (Modify the code structure, format the code, etc...)
- [ ] Optimization. Including functional usability improvements and performance improvements.
- [ ] Dependency. Such as changes related to third-party components.
- [ ] Other.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have created an issue on (Fix #ISSUE) and described the bug/feature there in detail
- [ ] Compiling and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If these changes need document changes, I have updated the document
- [ ] Any dependent changes have been merged

## Further comments

If this is a relatively large or complex change, kick off the discussion at dev@doris.apache.org by explaining why you chose the solution you did and what alternatives you considered, etc...
