### PR TITLE
[BUG]. Fix CacheAnalyzer's bug when aggregate column contains expr

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/cache/CacheAnalyzer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/cache/CacheAnalyzer.java
@@ -399,6 +399,10 @@ public class CacheAnalyzer {
             groupbyCount += 1;
             boolean matched = false;
             for (Expr groupExpr : groupExprs) {
+                if (!(groupExpr instanceof SlotRef)) {
+                    continue;
+                }
+
                 SlotRef slot = (SlotRef) groupExpr;
                 if (partColumn.getName().equals(slot.getColumnName())) {
                     matched = true;


### PR DESCRIPTION
When partition_cache is enabled, if Query's aggregate columns contain expression, CacheAnalyzer may throw exception and causes the query to fail.

## Proposed changes

Handled the case where the aggregate columns contain expr

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Code refactor (Modify the code structure, format the code, etc...)
- [ ] Optimization. Including functional usability improvements and performance improvements.
- [ ] Dependency. Such as changes related to third-party components.
- [ ] Other.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have created an issue on (Fix #7084) and described the bug/feature there in detail
- [x] Compiling and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If these changes need document changes, I have updated the document
- [ ] Any dependent changes have been merged

## Further comments

More details in #7084
