### PR TITLE
[Bug] Fix the incompatibility of sql mode between Doris and MySQL

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ExpressionFunctions.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ExpressionFunctions.java
@@ -24,7 +24,6 @@ import org.apache.doris.catalog.ScalarType;
 import org.apache.doris.catalog.Type;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.qe.ConnectContext;
-import org.apache.doris.qe.VariableMgr;
 import org.apache.doris.rewrite.FEFunction;
 import org.apache.doris.rewrite.FEFunctionList;
 import org.apache.doris.rewrite.FEFunctions;
@@ -110,13 +109,7 @@ public enum ExpressionFunctions {
                 }
             }
         } else if (constExpr instanceof SysVariableDesc) {
-            try {
-                VariableMgr.fillValue(ConnectContext.get().getSessionVariable(), (SysVariableDesc) constExpr);
-                return ((SysVariableDesc) constExpr).getLiteralExpr();
-            } catch (AnalysisException e) {
-                LOG.warn("failed to get session variable value: " + ((SysVariableDesc) constExpr).getName());
-                return constExpr;
-            }
+            return ((SysVariableDesc) constExpr).getLiteralExpr();
         }
         return constExpr;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/SysVariableDesc.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/SysVariableDesc.java
@@ -115,7 +115,6 @@ public class SysVariableDesc extends Expr {
 
     @Override
     public Expr getResultValue() throws AnalysisException {
-        Expr expr = super.getResultValue();
         if (!Strings.isNullOrEmpty(name) && VariableVarConverters.hasConverter(name)) {
             // Return the string type here so that it can correctly match the subsequent function signature.
             // And we also set `beConverted` to session variable name in StringLiteral, so that it can be cast back
@@ -128,7 +127,7 @@ public class SysVariableDesc extends Expr {
                 throw new AnalysisException(e.getMessage());
             }
         }
-        return expr;
+        return super.getResultValue();
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/VariableVarConverters.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/VariableVarConverters.java
@@ -28,8 +28,8 @@ import java.util.Map;
  * Each converter should put in map (variable name -> converters) and only converts the variable with specified name.
  *
  * The converted session variable is a special kind of variable.
- * It's real type is int, so for example, when querying `select @@sql_mode`, the return column
- * type is "int".
+ * It's real type is Long or Int, for example, the variable `sql_mode` is Long, when querying `select @@sql_mode`,
+ * the return column type is String.
  * But user usually set this variable by string, such as:
  * `set @@sql_mode = 'STRICT_TRANS_TABLES'`
  * or

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/SetVariableTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/SetVariableTest.java
@@ -58,7 +58,7 @@ public class SetVariableTest {
         stmtExecutor.execute();
         Expr expr = stmtExecutor.getParsedStmt().getResultExprs().get(0);
         Assert.assertTrue(expr instanceof SlotRef);
-        Assert.assertTrue(expr.getType() == Type.BIGINT);
+        Assert.assertSame(expr.getType(), Type.VARCHAR);
     }
 
     @Test


### PR DESCRIPTION
## Proposed changes

Introduce by pr #4359

VariableMgr.fillValue() method should not call in ExpressionFunctions.eval(), because in method analyzeImpl() of SysVariableDesc, it has been already called once. 

If VariableMgr.fillValue() was called twice, the type of SysVariableDesc will become BigInt, which is incorrect.

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have created an issue on (Fix #7106 ) and described the bug/feature there in detail
- [x] Compiling and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If these changes need document changes, I have updated the document
- [ ] Any dependent changes have been merged

## Further comments

If this is a relatively large or complex change, kick off the discussion at dev@doris.apache.org by explaining why you chose the solution you did and what alternatives you considered, etc...
