### PR TITLE
[Lateral View] Pruning output slot of TableFunctionNode

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/Analyzer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/Analyzer.java
@@ -1204,6 +1204,29 @@ public class Analyzer {
     }
 
     /**
+     * Get all predicates belonging to one or more tuples that have not yet been assigned
+     * Since these predicates will be assigned by upper-level plan nodes in the future,
+     * the columns associated with these predicates will also be required by upper-level nodes.
+     * So these columns should be projected in the table function node.
+     */
+    public List<Expr> getRemainConjuncts(List<TupleId> tupleIds) {
+        Set<ExprId> remainConjunctIds = Sets.newHashSet();
+        for (TupleId tupleId : tupleIds) {
+            if (tuplePredicates.get(tupleId) !=null) {
+                remainConjunctIds.addAll(tuplePredicates.get(tupleId));
+            }
+        }
+        remainConjunctIds.removeAll(globalState.assignedConjuncts);
+        List<Expr> result = Lists.newArrayList();
+        for (ExprId conjunctId : remainConjunctIds) {
+            Expr e = globalState.conjuncts.get(conjunctId);
+            Preconditions.checkState(e != null);
+            result.add(e);
+        }
+        return result;
+    }
+
+    /**
      * Makes the given semi-joined tuple visible such that its slots can be referenced.
      * If tid is null, makes the currently visible semi-joined tuple invisible again.
      */

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/BaseTableRef.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/BaseTableRef.java
@@ -79,7 +79,7 @@ public class BaseTableRef extends TableRef {
             return;
         }
         for (LateralViewRef lateralViewRef : lateralViewRefs) {
-            lateralViewRef.setRelatedTable(table);
+            lateralViewRef.setRelatedTable(this);
             lateralViewRef.analyze(analyzer);
         }
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/Expr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/Expr.java
@@ -1156,6 +1156,15 @@ abstract public class Expr extends TreeNode<Expr> implements ParseNode, Cloneabl
         return !exprSlotIds.retainAll(slotIds);
     }
 
+    // Get all the slotRefs that are bound to the tupleIds.
+    // As long as it is bound to one tuple
+    // Recursively call all levels of expr
+    public void getSlotRefsBoundByTupleIds(List<TupleId> tupleIds, Set<SlotRef> boundSlotRefs) {
+        for (Expr child : children) {
+            child.getSlotRefsBoundByTupleIds(tupleIds, boundSlotRefs);
+        }
+    }
+
     public void getIds(List<TupleId> tupleIds, List<SlotId> slotIds) {
         for (Expr child : children) {
             child.getIds(tupleIds, slotIds);

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/LateralViewRef.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/LateralViewRef.java
@@ -21,8 +21,9 @@ import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.FunctionSet;
 import org.apache.doris.catalog.InlineView;
 import org.apache.doris.catalog.OlapTable;
-import org.apache.doris.catalog.Table;
+import org.apache.doris.catalog.Type;
 import org.apache.doris.common.AnalysisException;
+import org.apache.doris.common.Config;
 import org.apache.doris.common.UserException;
 
 import com.google.common.base.Preconditions;
@@ -39,12 +40,11 @@ public class LateralViewRef extends TableRef {
     private Expr expr;
     private String viewName;
     private String columnName;
-    private Table relatedTable;
+    private BaseTableRef relatedTableRef;
 
     // after analyzed
     private FunctionCallExpr fnExpr;
-    private Column originColumn;
-    private SlotRef originSlotRef;
+    private List<SlotRef> originSlotRefList = Lists.newArrayList();
     private InlineView view;
     private SlotRef explodeSlotRef;
 
@@ -55,8 +55,8 @@ public class LateralViewRef extends TableRef {
         this.columnName = columnName;
     }
 
-    public void setRelatedTable(Table relatedTable) {
-        this.relatedTable = relatedTable;
+    public void setRelatedTable(BaseTableRef relatedTableRef) {
+        this.relatedTableRef = relatedTableRef;
     }
 
     public FunctionCallExpr getFnExpr() {
@@ -72,9 +72,9 @@ public class LateralViewRef extends TableRef {
         if (isAnalyzed) {
             return;
         }
-        Preconditions.checkNotNull(relatedTable);
+        Preconditions.checkNotNull(relatedTableRef);
         // analyze table
-        if (!(relatedTable instanceof OlapTable)) {
+        if (!(relatedTableRef.getTable() instanceof OlapTable)) {
             throw new AnalysisException("Only doris table could be exploded");
         }
         // analyze function and slot
@@ -83,24 +83,16 @@ public class LateralViewRef extends TableRef {
         }
         fnExpr = (FunctionCallExpr) expr;
         fnExpr.setTableFnCall(true);
+        checkAndSupplyDefaultTableName(fnExpr);
         fnExpr.analyze(analyzer);
         if (!fnExpr.getFnName().getFunction().equals(FunctionSet.EXPLODE_SPLIT)) {
             throw new AnalysisException("Only support explode function in lateral view");
         }
-        if (!(fnExpr.getChild(0) instanceof SlotRef)) {
-            throw new AnalysisException("Explode column must be varchar column");
-        }
+        checkScalarFunction(fnExpr.getChild(0));
         if (!(fnExpr.getChild(1) instanceof StringLiteral)) {
             throw new AnalysisException("Split separator of explode must be a string const");
         }
-        originSlotRef = ((SlotRef) fnExpr.getChild(0));
-        originColumn = originSlotRef.getColumn();
-        if (originColumn == null) {
-            throw new AnalysisException("The explode column must be a real column in table");
-        }
-        if (!originColumn.getType().isStringType()) {
-           throw new AnalysisException("The explode column must be VARCHAR/CHAR/STRING type");
-        }
+        fnExpr.getChild(0).collect(SlotRef.class, originSlotRefList);
         // analyze lateral view
         desc = analyzer.registerTableRef(this);
         explodeSlotRef = new SlotRef(new TableName(null, viewName), columnName);
@@ -112,8 +104,8 @@ public class LateralViewRef extends TableRef {
     public TupleDescriptor createTupleDescriptor(Analyzer analyzer) throws AnalysisException {
         // Create a fake catalog table for the lateral view
         List<Column> columnList = Lists.newArrayList();
-        columnList.add(new Column(columnName, originColumn.getType(),
-                false, null, originColumn.isAllowNull(),
+        columnList.add(new Column(columnName, Type.VARCHAR,
+                false, null, true,
                 null, ""));
         view = new InlineView(viewName, columnList);
 
@@ -124,7 +116,68 @@ public class LateralViewRef extends TableRef {
     }
 
     public void materializeRequiredSlots() {
-        originSlotRef.getDesc().setIsMaterialized(true);
+        for (SlotRef originSlotRef : originSlotRefList) {
+            originSlotRef.getDesc().setIsMaterialized(true);
+        }
         explodeSlotRef.getDesc().setIsMaterialized(true);
+    }
+
+    // The default table name must be origin table name
+    // If there is table name in slot ref which is different from origin, it will thrown exception.
+    private void checkAndSupplyDefaultTableName(FunctionCallExpr expr) throws AnalysisException {
+        List<SlotRef> slotRefList = Lists.newArrayList();
+        expr.collect(SlotRef.class, slotRefList);
+        TableName relatedTableName = relatedTableRef.getAliasAsName();
+        for (SlotRef slotRef : slotRefList) {
+            TableName tableName = slotRef.getOriginTableName();
+            if (tableName == null) {
+                // t1 lateral view explode_split(k1, ",")
+                slotRef.setTblName(relatedTableName.cloneWithoutAnalyze());
+            } else if (tableName.getDb() == null && tableName.getTbl() != null) {
+                if (Config.lower_case_table_names != 0) {
+                    // TODO support case insensitive
+                    throw new AnalysisException("Not support specify table name in table function "
+                            + "when config.lower_case_table_names is not 0");
+                }
+                if (tableName.getTbl().equals(relatedTableName.getTbl())) {
+                    // t1 lateral view explode_split(t1.k1, ",")
+                    tableName.setDb(relatedTableName.getDb());
+                } else {
+                    // t1 lateral view explode_split(t2.k1, ",")
+                    throw new AnalysisException("The column " + slotRef.toMySql()
+                            + " in lateral view must come from the origin table "
+                            + relatedTableName.toSql());
+                }
+            } else {
+                if (!tableName.getDb().equalsIgnoreCase(relatedTableName.getDb())) {
+                    // db2.t1 lateral view explode_split(db1.t1.k1, ",")
+                    throw new AnalysisException("The column " + slotRef.toMySql()
+                            + " in lateral view must come from the origin table "
+                            + relatedTableRef.toSql());
+                }
+            }
+        }
+    }
+
+    // 1. it must be a scalar function
+    private void checkScalarFunction(Expr child0) throws AnalysisException {
+        List<GroupingFunctionCallExpr> groupingFunctionCallExprList = Lists.newArrayList();
+        child0.collect(GroupingFunctionCallExpr.class, groupingFunctionCallExprList);
+        if (!groupingFunctionCallExprList.isEmpty()) {
+            throw new AnalysisException("Grouping function are not allowed in lateral view.");
+        }
+        if (child0.containsAggregate()) {
+            throw new AnalysisException("Agg function are not allowed in lateral view.");
+        }
+        List<AnalyticExpr> analyticExprList = Lists.newArrayList();
+        child0.collect(AnalyticExpr.class, analyticExprList);
+        if (!analyticExprList.isEmpty()) {
+            throw new AnalysisException("Analytic expr are not allowed in lateral view.");
+        }
+        List<Subquery> subqueryList = Lists.newArrayList();
+        child0.collect(Subquery.class, subqueryList);
+        if (!subqueryList.isEmpty()) {
+            throw new AnalysisException("Subquery is not allowed in lateral view");
+        }
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/SlotRef.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/SlotRef.java
@@ -316,6 +316,23 @@ public class SlotRef extends Expr {
     }
 
     @Override
+    public void getSlotRefsBoundByTupleIds(List<TupleId> tupleIds, Set<SlotRef> boundSlotRefs) {
+        if (desc == null) {
+            return;
+        }
+        if (tupleIds.contains(desc.getParent().getId())) {
+            boundSlotRefs.add(this);
+            return;
+        }
+        if (desc.getSourceExprs() == null) {
+            return;
+        }
+        for (Expr sourceExpr : desc.getSourceExprs()) {
+            sourceExpr.getSlotRefsBoundByTupleIds(tupleIds, boundSlotRefs);
+        }
+    }
+
+    @Override
     public void getIds(List<TupleId> tupleIds, List<SlotId> slotIds) {
         Preconditions.checkState(!type.equals(Type.INVALID));
         Preconditions.checkState(desc != null);

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/SlotRef.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/SlotRef.java
@@ -244,6 +244,10 @@ public class SlotRef extends Expr {
         return tblName;
     }
 
+    public TableName getOriginTableName() {
+        return tblName;
+    }
+
     @Override
     public String toColumnLabel() {
         // return tblName == null ? col : tblName.getTbl() + "." + col;

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/TableName.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/TableName.java
@@ -141,4 +141,10 @@ public class TableName implements Writable {
         db = Text.readString(in);
         tbl = Text.readString(in);
     }
+
+    public TableName cloneWithoutAnalyze() {
+        TableName tableName = new TableName(this.db, this.tbl);
+        return tableName;
+    }
 }
+

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/SingleNodePlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/SingleNodePlanner.java
@@ -1867,7 +1867,7 @@ public class SingleNodePlanner {
             PlanNode scanNode = createScanNode(analyzer, tblRef, selectStmt);
             List<LateralViewRef> lateralViewRefs = tblRef.getLateralViewRefs();
             if (lateralViewRefs != null && lateralViewRefs.size() != 0) {
-                return createTableFunctionNode(analyzer, scanNode, lateralViewRefs);
+                return createTableFunctionNode(analyzer, scanNode, lateralViewRefs, selectStmt);
             }
             return scanNode;
         }
@@ -1878,13 +1878,14 @@ public class SingleNodePlanner {
     }
 
     private PlanNode createTableFunctionNode(Analyzer analyzer, PlanNode inputNode,
-                                                      List<LateralViewRef> lateralViewRefs)
+                                              List<LateralViewRef> lateralViewRefs, SelectStmt selectStmt)
             throws UserException {
         Preconditions.checkNotNull(lateralViewRefs);
         Preconditions.checkState(lateralViewRefs.size() > 0);
         TableFunctionNode tableFunctionNode = new TableFunctionNode(ctx_.getNextNodeId(), inputNode,
                 lateralViewRefs);
         tableFunctionNode.init(analyzer);
+        tableFunctionNode.projectSlots(analyzer, selectStmt);
         inputNode = tableFunctionNode;
         return inputNode;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/TableFunctionNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/TableFunctionNode.java
@@ -21,6 +21,9 @@ import org.apache.doris.analysis.Analyzer;
 import org.apache.doris.analysis.Expr;
 import org.apache.doris.analysis.FunctionCallExpr;
 import org.apache.doris.analysis.LateralViewRef;
+import org.apache.doris.analysis.SelectStmt;
+import org.apache.doris.analysis.SlotId;
+import org.apache.doris.analysis.SlotRef;
 import org.apache.doris.analysis.TupleId;
 import org.apache.doris.common.UserException;
 import org.apache.doris.thrift.TExplainLevel;
@@ -29,13 +32,21 @@ import org.apache.doris.thrift.TPlanNodeType;
 import org.apache.doris.thrift.TTableFunctionNode;
 
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
+
+import com.clearspring.analytics.util.Lists;
+import org.glassfish.jersey.internal.guava.Sets;
 
 public class TableFunctionNode extends PlanNode {
 
     private List<LateralViewRef> lateralViewRefs;
     private List<FunctionCallExpr> fnCallExprList;
     private List<TupleId> lateralViewTupleIds;
+
+    // The output slot ids of TableFunctionNode
+    // Only the slot whose id is in this list will be output by TableFunctionNode
+    private List<SlotId> outputSlotIds = Lists.newArrayList();
 
     protected TableFunctionNode(PlanNodeId id, PlanNode inputNode, List<LateralViewRef> lateralViewRefs) {
         super(id, "TABLE FUNCTION NODE");
@@ -47,6 +58,46 @@ public class TableFunctionNode extends PlanNode {
         tblRefIds.addAll(lateralViewTupleIds);
         children.add(inputNode);
         this.lateralViewRefs = lateralViewRefs;
+    }
+
+    /**
+     * This function is mainly used to calculate @outputSlotIds.
+     * After the PlanNode executes the @fnCallExpr,
+     * it needs to perform projection operation.
+     * This function is used to calculate which columns should be projected.
+     * The slot belongs to outputSlotIds should be retained after the projection is completed.
+     * Slots in selectItems and unassigned predicates should be projected.
+     * <p>
+     * Case1: The slot belongs to selectItems. The outputSlotIds should include it.
+     * For example:
+     * Query: select k1, v1 from table lateral view explode_split(v1, ",") t1 as c1;
+     * The outputSlots: [k1, v1, c1]
+     * <p>
+     * Case2: The slot belongs to where clause and the predicate has not been assigned.
+     * Query: select k1 from table a lateral view explode_split(v1, ",") t1 as c1, table b where a.v1=b.v1;
+     * The outputSlots: [a.k1, a.v1, t1.c1]
+     * <p>
+     * Case3: The slot neither is part of the unassigned predicate, nor appears in the selectItems.
+     * Query: select k1 from table a lateral view explode_split(v1, ",") t1 as c1;
+     * The outputSlots: [k1, c1]
+     */
+    public void projectSlots(Analyzer analyzer, SelectStmt selectStmt) {
+        Set<SlotRef> outputSlotRef = Sets.newHashSet();
+        // case1
+        List<Expr> resultExprs = selectStmt.getResultExprs();
+        for (Expr resultExpr : resultExprs) {
+            // find all slotRef bound by tupleIds in resultExpr
+            resultExpr.getSlotRefsBoundByTupleIds(tupleIds, outputSlotRef);
+        }
+        // case2
+        List<Expr> remainConjuncts = analyzer.getRemainConjuncts(tupleIds);
+        for (Expr expr : remainConjuncts) {
+            expr.getSlotRefsBoundByTupleIds(tupleIds, outputSlotRef);
+        }
+        // set output slot ids
+        for (SlotRef slotRef : outputSlotRef) {
+            outputSlotIds.add(slotRef.getSlotId());
+        }
     }
 
     @Override
@@ -88,6 +139,12 @@ public class TableFunctionNode extends PlanNode {
         }
         output.append("\n");
 
+        output.append(prefix + "output slot id: ");
+        for (SlotId slotId : outputSlotIds) {
+            output.append(slotId.asInt() + " ");
+        }
+        output.append("\n");
+
         if (!conjuncts.isEmpty()) {
             output.append(prefix).append("PREDICATES: ").append(
                     getExplainString(conjuncts)).append("\n");
@@ -101,5 +158,8 @@ public class TableFunctionNode extends PlanNode {
         msg.node_type = TPlanNodeType.TABLE_FUNCTION_NODE;
         msg.table_function_node = new TTableFunctionNode();
         msg.table_function_node.setFnCallExprList(Expr.treesToThrift(fnCallExprList));
+        for (SlotId slotId : outputSlotIds) {
+            msg.table_function_node.addToOutputSlotIds(slotId.asInt());
+        }
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/TableFunctionNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/TableFunctionNode.java
@@ -31,12 +31,12 @@ import org.apache.doris.thrift.TPlanNode;
 import org.apache.doris.thrift.TPlanNodeType;
 import org.apache.doris.thrift.TTableFunctionNode;
 
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
-
-import com.clearspring.analytics.util.Lists;
-import org.glassfish.jersey.internal.guava.Sets;
 
 public class TableFunctionNode extends PlanNode {
 

--- a/fe/fe-core/src/test/java/org/apache/doris/planner/TableFunctionPlanTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/planner/TableFunctionPlanTest.java
@@ -51,7 +51,7 @@ public class TableFunctionPlanTest {
         CreateDbStmt createDbStmt = (CreateDbStmt) UtFrameUtils.parseAndAnalyzeStmt(createDbStmtStr, ctx);
         Catalog.getCurrentCatalog().createDb(createDbStmt);
         // 3. create table tbl1
-        String createTblStmtStr = "create table db1.tbl1(k1 int, k2 varchar) "
+        String createTblStmtStr = "create table db1.tbl1(k1 int, k2 varchar, k3 varchar) "
                 + "DUPLICATE KEY(k1) distributed by hash(k1) buckets 3 properties('replication_num' = '1');";
         CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameUtils.parseAndAnalyzeStmt(createTblStmtStr, ctx);
         Catalog.getCurrentCatalog().createTable(createTableStmt);
@@ -66,7 +66,7 @@ public class TableFunctionPlanTest {
         String sql = "desc verbose select k1, e1 from db1.tbl1 lateral view explode_split(k2, \",\") tmp as e1;";
         String explainString = UtFrameUtils.getSQLPlanOrErrorMsg(ctx, sql, true);
         Assert.assertTrue(explainString.contains("1:TABLE FUNCTION NODE"));
-        Assert.assertTrue(explainString.contains("table function: explode_split(`k2`, ',')"));
+        Assert.assertTrue(explainString.contains("table function: explode_split(`default_cluster:db1`.`tbl1`.`k2`, ',')"));
         Assert.assertTrue(explainString.contains("tuple ids: 0 1"));
         Assert.assertTrue(explainString.contains("TupleDescriptor{id=1, tbl=tmp, byteSize=32, materialized=true}"));
         Assert.assertTrue(explainString.contains("SlotDescriptor{id=1, col=e1, type=VARCHAR(*)}"));
@@ -81,7 +81,7 @@ public class TableFunctionPlanTest {
         String explainString = UtFrameUtils.getSQLPlanOrErrorMsg(ctx, sql, true);
         Assert.assertTrue(explainString.contains("OUTPUT EXPRS:`k1`"));
         Assert.assertTrue(explainString.contains("1:TABLE FUNCTION NODE"));
-        Assert.assertTrue(explainString.contains("table function: explode_split(`k2`, ',')"));
+        Assert.assertTrue(explainString.contains("table function: explode_split(`default_cluster:db1`.`tbl1`.`k2`, ',')"));
         Assert.assertTrue(explainString.contains("tuple ids: 0 1"));
         Assert.assertTrue(explainString.contains("TupleDescriptor{id=1, tbl=tmp, byteSize=32, materialized=true}"));
         Assert.assertTrue(explainString.contains("SlotDescriptor{id=1, col=e1, type=VARCHAR(*)}"));
@@ -100,7 +100,7 @@ public class TableFunctionPlanTest {
         Assert.assertTrue(explainString.contains("group by: `k1`, `e1`"));
         // table function node
         Assert.assertTrue(explainString.contains("1:TABLE FUNCTION NODE"));
-        Assert.assertTrue(explainString.contains("table function: explode_split(`k2`, ',')"));
+        Assert.assertTrue(explainString.contains("table function: explode_split(`default_cluster:db1`.`tbl1`.`k2`, ',')"));
         Assert.assertTrue(explainString.contains("tuple ids: 0 1"));
         Assert.assertTrue(explainString.contains("TupleDescriptor{id=1, tbl=tmp, byteSize=32, materialized=true}"));
         Assert.assertTrue(explainString.contains("SlotDescriptor{id=1, col=e1, type=VARCHAR(*)}"));
@@ -117,7 +117,7 @@ public class TableFunctionPlanTest {
                 + "where e1='1'; ";
         String explainString = UtFrameUtils.getSQLPlanOrErrorMsg(ctx, sql, true);
         Assert.assertTrue(explainString.contains("1:TABLE FUNCTION NODE"));
-        Assert.assertTrue(explainString.contains("table function: explode_split(`k2`, ',')"));
+        Assert.assertTrue(explainString.contains("table function: explode_split(`default_cluster:db1`.`tbl1`.`k2`, ',')"));
         Assert.assertTrue(explainString.contains("PREDICATES: `e1` = '1'"));
         Assert.assertTrue(explainString.contains("tuple ids: 0 1"));
         Assert.assertTrue(explainString.contains("TupleDescriptor{id=1, tbl=tmp, byteSize=32, materialized=true}"));
@@ -133,7 +133,7 @@ public class TableFunctionPlanTest {
                 + "where k1=1; ";
         String explainString = UtFrameUtils.getSQLPlanOrErrorMsg(ctx, sql, true);
         Assert.assertTrue(explainString.contains("1:TABLE FUNCTION NODE"));
-        Assert.assertTrue(explainString.contains("table function: explode_split(`k2`, ',')"));
+        Assert.assertTrue(explainString.contains("table function: explode_split(`default_cluster:db1`.`tbl1`.`k2`, ',')"));
         Assert.assertTrue(explainString.contains("tuple ids: 0 1"));
         Assert.assertTrue(explainString.contains("TupleDescriptor{id=1, tbl=tmp, byteSize=32, materialized=true}"));
         Assert.assertTrue(explainString.contains("SlotDescriptor{id=1, col=e1, type=VARCHAR(*)}"));
@@ -151,7 +151,7 @@ public class TableFunctionPlanTest {
                 + " lateral view explode_split(k2, \",\") tmp2 as e2;";
         String explainString = UtFrameUtils.getSQLPlanOrErrorMsg(ctx, sql, true);
         Assert.assertTrue(explainString.contains("1:TABLE FUNCTION NODE"));
-        Assert.assertTrue(explainString.contains("table function: explode_split(`k2`, ',') explode_split(`k2`, ',')"));
+        Assert.assertTrue(explainString.contains("table function: explode_split(`default_cluster:db1`.`tbl1`.`k2`, ',') explode_split(`default_cluster:db1`.`tbl1`.`k2`, ',')"));
         Assert.assertTrue(explainString.contains("lateral view tuple id: 1 2"));
         // lateral view 2 tuple
         Assert.assertTrue(explainString.contains("TupleDescriptor{id=1, tbl=tmp2, byteSize=32, materialized=true}"));
@@ -205,7 +205,7 @@ public class TableFunctionPlanTest {
         String sql = "desc verbose select k1, e1 from db1.tbl1 lateral view explode_split(k2, \",\") tmp1 as e1;";
         String explainString = UtFrameUtils.getSQLPlanOrErrorMsg(ctx, sql, true);
         Assert.assertTrue(explainString.contains("1:TABLE FUNCTION NODE"));
-        Assert.assertTrue(explainString.contains("table function: explode_split(`k2`, ',')"));
+        Assert.assertTrue(explainString.contains("table function: explode_split(`default_cluster:db1`.`tbl1`.`k2`, ',')"));
         Assert.assertTrue(explainString.contains("lateral view tuple id: 1"));
         Assert.assertTrue(explainString.contains("output slot id: 1 2"));
     }
@@ -222,7 +222,7 @@ public class TableFunctionPlanTest {
                 + " group by k1;";
         String explainString = UtFrameUtils.getSQLPlanOrErrorMsg(ctx, sql, true);
         Assert.assertTrue(explainString.contains("1:TABLE FUNCTION NODE"));
-        Assert.assertTrue(explainString.contains("table function: explode_split(`k2`, ',')"));
+        Assert.assertTrue(explainString.contains("table function: explode_split(`default_cluster:db1`.`tbl1`.`k2`, ',')"));
         Assert.assertTrue(explainString.contains("lateral view tuple id: 1"));
         Assert.assertTrue(explainString.contains("output slot id: 1 2"));
     }
@@ -239,7 +239,7 @@ public class TableFunctionPlanTest {
                 + " where k2=1;";
         String explainString = UtFrameUtils.getSQLPlanOrErrorMsg(ctx, sql, true);
         Assert.assertTrue(explainString.contains("1:TABLE FUNCTION NODE"));
-        Assert.assertTrue(explainString.contains("table function: explode_split(`k2`, ',')"));
+        Assert.assertTrue(explainString.contains("table function: explode_split(`default_cluster:db1`.`tbl1`.`k2`, ',')"));
         Assert.assertTrue(explainString.contains("lateral view tuple id: 1"));
         Assert.assertTrue(explainString.contains("output slot id: 1 2"));
     }
@@ -256,7 +256,7 @@ public class TableFunctionPlanTest {
                 + " right join db1.tbl1 b on a.k1=b.k1 where a.k2=1;";
         String explainString = UtFrameUtils.getSQLPlanOrErrorMsg(ctx, sql, true);
         Assert.assertTrue(explainString.contains("1:TABLE FUNCTION NODE"));
-        Assert.assertTrue(explainString.contains("table function: explode_split(`k2`, ',')"));
+        Assert.assertTrue(explainString.contains("table function: explode_split(`a`.`k2`, ',')"));
         Assert.assertTrue(explainString.contains("lateral view tuple id: 1"));
         Assert.assertTrue(explainString.contains("output slot id: 0 1 2"));
     }
@@ -274,8 +274,65 @@ public class TableFunctionPlanTest {
                 + " left join db1.tbl1 b on a.k1=b.k1 where a.k2=1";
         String explainString = UtFrameUtils.getSQLPlanOrErrorMsg(ctx, sql, true);
         Assert.assertTrue(explainString.contains("1:TABLE FUNCTION NODE"));
-        Assert.assertTrue(explainString.contains("table function: explode_split(`k2`, ',')"));
+        Assert.assertTrue(explainString.contains("table function: explode_split(`a`.`k2`, ',')"));
         Assert.assertTrue(explainString.contains("lateral view tuple id: 1"));
         Assert.assertTrue(explainString.contains("output slot id: 2"));
+    }
+
+    // scalar function in explode_split
+    /*
+    Case1 invalid column in scalar function
+    select a.k1 from table a lateral view explode_split(t2.k2, ",") t1 as e1
+    invalid column: t2.k2
+    Case2
+    select a.k1 from table a lateral view explode_split(k100, ",") t1 as e1
+    invalid column: t1.k100
+    Case3
+    select a.k1 from db1.table a lateral view explode_split(db2.table.k2, ",") t1 as e1
+    invalid column: db2.table.k2
+     */
+    @Test
+    public void invalidColumnInExplodeSplit() throws Exception {
+        String sql = "explain select a.k1 from db1.tbl1 a lateral view explode_split(tbl2.k1, \",\") tmp1 as e1";
+        String explainString = UtFrameUtils.getSQLPlanOrErrorMsg(ctx, sql, true);
+        Assert.assertTrue(explainString.contains("The column k1 in lateral view must come from the origin table"));
+        sql = "explain select a.k1 from db1.tbl1 a lateral view explode_split(k100, \",\") tmp1 as e1";
+        explainString = UtFrameUtils.getSQLPlanOrErrorMsg(ctx, sql, true);
+        Assert.assertTrue(explainString.contains("Unknown column 'k100'"));
+        sql = "explain select a.k1 from db1.tbl1 a lateral view explode_split(db2.tbl1.k2, \",\") tmp1 as e1";
+        explainString = UtFrameUtils.getSQLPlanOrErrorMsg(ctx, sql, true);
+        Assert.assertTrue(explainString.contains("The column k2 in lateral view must come from the origin table"));
+    }
+
+    /*
+    Case1 invalid agg function
+    select a.k1 from db1.tbl1 a lateral view explode_split(sum(a.k1), ",") tmp1 as e1
+    Case2 subquery
+    select a.k1 from db1.tbl1 a lateral view explode_split(a in )
+     */
+    @Test
+    public void invalidFunctionInLateralView() throws Exception {
+        String sql = "explain select a.k1 from db1.tbl1 a lateral view explode_split(sum(k1), \",\") tmp1 as e1";
+        String explainString = UtFrameUtils.getSQLPlanOrErrorMsg(ctx, sql, true);
+        Assert.assertTrue(explainString.contains("Agg function are not allowed in lateral view."));
+        sql = "explain select a.k1 from db1.tbl1 a lateral view explode_split(k1=(select k1 from db1.tbl1), \",\") tmp1 as e1";
+        explainString = UtFrameUtils.getSQLPlanOrErrorMsg(ctx, sql, true);
+        Assert.assertTrue(explainString.contains("Subquery is not allowed in lateral view"));
+    }
+
+    /*
+    Case1 valid scalar function
+    select a.k1 from db1.tbl1 a lateral view explode_split(concat('a', ',', 'b'), ",") tmp1 as e1
+     */
+    @Test
+    public void scalarFunctionInLateralView() throws Exception {
+        String sql = "desc verbose select a.k1 from db1.tbl1 a lateral view explode_split(concat(k2, ',' , k3), \",\") tmp1 as e1 ";
+        String explainString = UtFrameUtils.getSQLPlanOrErrorMsg(ctx, sql, true);
+        Assert.assertTrue(explainString.contains("1:TABLE FUNCTION NODE"));
+        Assert.assertTrue(explainString.contains("table function: explode_split(concat(`a`.`k2`, ',', `a`.`k3`), ',')"));
+        Assert.assertTrue(explainString.contains("lateral view tuple id: 1"));
+        Assert.assertTrue(explainString.contains("output slot id: 3"));
+        Assert.assertTrue(explainString.contains("SlotDescriptor{id=0, col=k2, type=VARCHAR(*)}"));
+        Assert.assertTrue(explainString.contains("SlotDescriptor{id=1, col=k3, type=VARCHAR(*)}"));
     }
 }

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -658,6 +658,7 @@ struct TOlapRewriteNode {
 
 struct TTableFunctionNode {
     1: required list<Exprs.TExpr> fnCallExprList
+    2: required list<Types.TSlotId> outputSlotIds
 }
 
 // This contains all of the information computed by the plan as part of the resource

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -657,8 +657,8 @@ struct TOlapRewriteNode {
 }
 
 struct TTableFunctionNode {
-    1: required list<Exprs.TExpr> fnCallExprList
-    2: required list<Types.TSlotId> outputSlotIds
+    1: optional list<Exprs.TExpr> fnCallExprList
+    2: optional list<Types.TSlotId> outputSlotIds
 }
 
 // This contains all of the information computed by the plan as part of the resource


### PR DESCRIPTION
## Proposed changes

If the calculation of the lateral view function is completed,
the result will be directly returned to the upper layer.
It will cause a lot of memory copy and network transmission.
The reason is that the original column that generally participates
in the lateral view is very likely to be a very long value.
If Doris still retain this column after calculating the lateral view,
it need to perform a memory copy.
However, in many cases, the upper plan node does not need the original columns of the lateral view,
so it is necessary to perform column pruning after the calculation of the lateral view,
so as to avoid useless memory copy and network transmission.
For example, the following query can prune the original column v1
```select k1, e1 from table lateral view explode_split(v1, ",") tmp as e1;```

The `outputSlotIds` in TableFunctionNode is used to store the columns that should be retained after pruning.

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Code refactor (Modify the code structure, format the code, etc...)
- [ ] Optimization. Including functional usability improvements and performance improvements.
- [ ] Dependency. Such as changes related to third-party components.
- [ ] Other.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have created an issue on (Fix #6746 ) and described the bug/feature there in detail
- [x] Compiling and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If these changes need document changes, I have updated the document
- [ ] Any dependent changes have been merged
