### PR TITLE
[BRPC] Support transfer RowBatch in ProtoBuf Request to Controller Attachment

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -529,9 +529,9 @@ CONF_String(default_rowset_type, "BETA");
 CONF_Int64(brpc_max_body_size, "209715200");
 // Max unwritten bytes in each socket, if the limit is reached, Socket.Write fails with EOVERCROWDED
 CONF_Int64(brpc_socket_max_unwritten_bytes, "67108864");
-// The maximum length of RowBatch in ProtoBuf Request,
-// if exceeded, will be transferred to Controller Attachment and sent through brpc.
-CONF_mInt64(brpc_request_rowbatch_max_bytes, "2147483648");
+// Whether to transfer RowBatch in ProtoBuf Request to Controller Attachment and send it
+// through brpc, this will be faster and avoid the error of Request length overflow.
+CONF_mBool(transfer_data_by_brpc_attachment, "false");
 
 // max number of txns for every txn_partition_map in txn manager
 // this is a self protection to avoid too many txns saving in manager

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -529,8 +529,9 @@ CONF_String(default_rowset_type, "BETA");
 CONF_Int64(brpc_max_body_size, "209715200");
 // Max unwritten bytes in each socket, if the limit is reached, Socket.Write fails with EOVERCROWDED
 CONF_Int64(brpc_socket_max_unwritten_bytes, "67108864");
-// This configuration is used to control whether brpc transfers RowBatch in Proto Request to Controller Attachment.
-CONF_Bool(brpc_request_transfer_attachment, "false");
+// The maximum length of RowBatch in ProtoBuf Request,
+// if exceeded, will be transferred to Controller Attachment and sent through brpc.
+CONF_mInt64(brpc_request_rowbatch_max_bytes, "2147483648");
 
 // max number of txns for every txn_partition_map in txn manager
 // this is a self protection to avoid too many txns saving in manager

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -529,6 +529,8 @@ CONF_String(default_rowset_type, "BETA");
 CONF_Int64(brpc_max_body_size, "209715200");
 // Max unwritten bytes in each socket, if the limit is reached, Socket.Write fails with EOVERCROWDED
 CONF_Int64(brpc_socket_max_unwritten_bytes, "67108864");
+// This configuration is used to control whether brpc transfers RowBatch in Proto Request to Controller Attachment.
+CONF_Bool(brpc_request_transfer_attachment, "false");
 
 // max number of txns for every txn_partition_map in txn manager
 // this is a self protection to avoid too many txns saving in manager

--- a/be/src/exec/tablet_sink.cpp
+++ b/be/src/exec/tablet_sink.cpp
@@ -410,9 +410,9 @@ void NodeChannel::try_send_batch() {
         DCHECK(_pending_batches_num == 0);
     }
 
-    request_transfer_attachment<PTabletWriterAddBatchRequest,
-                                ReusableClosure<PTabletWriterAddBatchResult>>(&request,
-                                                                              _add_batch_closure);
+    request_row_batch_transfer_attachment<PTabletWriterAddBatchRequest,
+                                          ReusableClosure<PTabletWriterAddBatchResult>>(
+            &request, _add_batch_closure);
     _add_batch_closure->set_in_flight();
     _stub->tablet_writer_add_batch(&_add_batch_closure->cntl, &request, &_add_batch_closure->result,
                                    _add_batch_closure);

--- a/be/src/exec/tablet_sink.cpp
+++ b/be/src/exec/tablet_sink.cpp
@@ -31,6 +31,7 @@
 #include "util/brpc_stub_cache.h"
 #include "util/debug/sanitizer_scopes.h"
 #include "util/monotime.h"
+#include "util/proto_util.h"
 #include "util/threadpool.h"
 #include "util/time.h"
 #include "util/uid_util.h"
@@ -409,6 +410,9 @@ void NodeChannel::try_send_batch() {
         DCHECK(_pending_batches_num == 0);
     }
 
+    request_transfer_attachment<PTabletWriterAddBatchRequest,
+                                ReusableClosure<PTabletWriterAddBatchResult>>(&request,
+                                                                              _add_batch_closure);
     _add_batch_closure->set_in_flight();
     _stub->tablet_writer_add_batch(&_add_batch_closure->cntl, &request, &_add_batch_closure->result,
                                    _add_batch_closure);

--- a/be/src/runtime/data_stream_sender.cpp
+++ b/be/src/runtime/data_stream_sender.cpp
@@ -45,6 +45,7 @@
 #include "util/debug_util.h"
 #include "util/defer_op.h"
 #include "util/network_util.h"
+#include "util/proto_util.h"
 #include "util/thrift_client.h"
 #include "util/thrift_util.h"
 
@@ -144,6 +145,8 @@ Status DataStreamSender::Channel::send_batch(PRowBatch* batch, bool eos) {
 
     _closure->ref();
     _closure->cntl.set_timeout_ms(_brpc_timeout_ms);
+    request_transfer_attachment<PTransmitDataParams, RefCountClosure<PTransmitDataResult>>(
+            &_brpc_request, _closure);
     _brpc_stub->transmit_data(&_closure->cntl, &_brpc_request, &_closure->result, _closure);
     if (batch != nullptr) {
         _brpc_request.release_row_batch();

--- a/be/src/runtime/data_stream_sender.cpp
+++ b/be/src/runtime/data_stream_sender.cpp
@@ -145,8 +145,9 @@ Status DataStreamSender::Channel::send_batch(PRowBatch* batch, bool eos) {
 
     _closure->ref();
     _closure->cntl.set_timeout_ms(_brpc_timeout_ms);
-    request_transfer_attachment<PTransmitDataParams, RefCountClosure<PTransmitDataResult>>(
-            &_brpc_request, _closure);
+    request_row_batch_transfer_attachment<PTransmitDataParams,
+                                          RefCountClosure<PTransmitDataResult>>(&_brpc_request,
+                                                                                _closure);
     _brpc_stub->transmit_data(&_closure->cntl, &_brpc_request, &_closure->result, _closure);
     if (batch != nullptr) {
         _brpc_request.release_row_batch();

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -32,6 +32,7 @@
 #include "service/brpc.h"
 #include "util/brpc_stub_cache.h"
 #include "util/md5.h"
+#include "util/proto_util.h"
 #include "util/string_util.h"
 #include "util/thrift_util.h"
 #include "util/uid_util.h"
@@ -59,7 +60,14 @@ void PInternalServiceImpl<T>::transmit_data(google::protobuf::RpcController* cnt
                                             google::protobuf::Closure* done) {
     VLOG_ROW << "transmit data: fragment_instance_id=" << print_id(request->finst_id())
              << " node=" << request->node_id();
-    _exec_env->stream_mgr()->transmit_data(request, &done);
+    brpc::Controller* cntl = static_cast<brpc::Controller*>(cntl_base);
+    attachment_transfer_request<PTransmitDataParams>(request, cntl);
+    auto st = _exec_env->stream_mgr()->transmit_data(request, &done);
+    if (!st.ok()) {
+        LOG(WARNING) << "transmit_data failed, message=" << st.get_error_msg()
+                     << ", fragment_instance_id=" << print_id(request->finst_id()) << ", node=" << request->node_id();
+    }
+    st.to_protobuf(response->mutable_status());
     if (done != nullptr) {
         done->Run();
     }
@@ -104,7 +112,7 @@ void PInternalServiceImpl<T>::exec_plan_fragment(google::protobuf::RpcController
 }
 
 template <typename T>
-void PInternalServiceImpl<T>::tablet_writer_add_batch(google::protobuf::RpcController* controller,
+void PInternalServiceImpl<T>::tablet_writer_add_batch(google::protobuf::RpcController* cntl_base,
                                                       const PTabletWriterAddBatchRequest* request,
                                                       PTabletWriterAddBatchResult* response,
                                                       google::protobuf::Closure* done) {
@@ -115,12 +123,14 @@ void PInternalServiceImpl<T>::tablet_writer_add_batch(google::protobuf::RpcContr
     // this will influence query execution, because the pthreads under bthread may be
     // exhausted, so we put this to a local thread pool to process
     int64_t submit_task_time_ns = MonotonicNanos();
-    _tablet_worker_pool.offer([request, response, done, submit_task_time_ns, this]() {
+    _tablet_worker_pool.offer([cntl_base, request, response, done, submit_task_time_ns, this]() {
         int64_t wait_execution_time_ns = MonotonicNanos() - submit_task_time_ns;
         brpc::ClosureGuard closure_guard(done);
         int64_t execution_time_ns = 0;
         {
             SCOPED_RAW_TIMER(&execution_time_ns);
+            brpc::Controller* cntl = static_cast<brpc::Controller*>(cntl_base);
+            attachment_transfer_request<PTabletWriterAddBatchRequest>(request, cntl);
             auto st = _exec_env->load_channel_mgr()->add_batch(*request,
                                                                response->mutable_tablet_vec());
             if (!st.ok()) {

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -61,11 +61,12 @@ void PInternalServiceImpl<T>::transmit_data(google::protobuf::RpcController* cnt
     VLOG_ROW << "transmit data: fragment_instance_id=" << print_id(request->finst_id())
              << " node=" << request->node_id();
     brpc::Controller* cntl = static_cast<brpc::Controller*>(cntl_base);
-    attachment_transfer_request<PTransmitDataParams>(request, cntl);
+    attachment_transfer_request_row_batch<PTransmitDataParams>(request, cntl);
     auto st = _exec_env->stream_mgr()->transmit_data(request, &done);
     if (!st.ok()) {
         LOG(WARNING) << "transmit_data failed, message=" << st.get_error_msg()
-                     << ", fragment_instance_id=" << print_id(request->finst_id()) << ", node=" << request->node_id();
+                     << ", fragment_instance_id=" << print_id(request->finst_id())
+                     << ", node=" << request->node_id();
     }
     st.to_protobuf(response->mutable_status());
     if (done != nullptr) {
@@ -130,7 +131,7 @@ void PInternalServiceImpl<T>::tablet_writer_add_batch(google::protobuf::RpcContr
         {
             SCOPED_RAW_TIMER(&execution_time_ns);
             brpc::Controller* cntl = static_cast<brpc::Controller*>(cntl_base);
-            attachment_transfer_request<PTabletWriterAddBatchRequest>(request, cntl);
+            attachment_transfer_request_row_batch<PTabletWriterAddBatchRequest>(request, cntl);
             auto st = _exec_env->load_channel_mgr()->add_batch(*request,
                                                                response->mutable_tablet_vec());
             if (!st.ok()) {

--- a/be/src/util/proto_util.h
+++ b/be/src/util/proto_util.h
@@ -24,8 +24,7 @@ namespace doris {
 // and it is expected that performance can be improved.
 template <typename Params, typename Closure>
 inline void request_row_batch_transfer_attachment(Params* brpc_request, Closure* closure) {
-    if (brpc_request->has_row_batch() &&
-        brpc_request->row_batch().ByteSizeLong() > config::brpc_request_rowbatch_max_bytes) {
+    if (brpc_request->has_row_batch() && config::transfer_data_by_brpc_attachment == true) {
         butil::IOBuf attachment;
         auto row_batch = brpc_request->mutable_row_batch();
         row_batch->set_transfer_by_attachment(true);

--- a/be/src/util/proto_util.h
+++ b/be/src/util/proto_util.h
@@ -19,33 +19,34 @@
 
 namespace doris {
 
-const int64_t MAX_REQUEST_BYTE_SIZE = 64 * 1024 * 1024;
-
-inline void row_batch_transfer_attachment(doris::PRowBatch* row_batch, butil::IOBuf* attachment) {
-    row_batch->set_tuple_data_size(row_batch->tuple_data().size());
-    attachment->append(row_batch->tuple_data());
-    row_batch->clear_tuple_data();
-    row_batch->set_tuple_data("");
-}
-
+// Transfer RowBatch in ProtoBuf Request to Controller Attachment.
+// This can avoid reaching the upper limit of the ProtoBuf Request length (2G),
+// and it is expected that performance can be improved.
 template <typename Params, typename Closure>
-inline void request_transfer_attachment(Params* brpc_request, Closure* closure) {
-    if (config::brpc_request_transfer_attachment == true &&
-        brpc_request->row_batch().ByteSizeLong() > MAX_REQUEST_BYTE_SIZE) {
+inline void request_row_batch_transfer_attachment(Params* brpc_request, Closure* closure) {
+    if (brpc_request->row_batch().ByteSizeLong() > config::brpc_request_rowbatch_max_bytes) {
         butil::IOBuf attachment;
         auto row_batch = brpc_request->mutable_row_batch();
-        row_batch_transfer_attachment(row_batch, &attachment);
+        row_batch->set_transfer_attachment(true);
+        attachment.append(row_batch->tuple_data());
+        row_batch->clear_tuple_data();
+        row_batch->set_tuple_data("");
         closure->cntl.request_attachment().append(attachment);
     }
 }
 
+// Controller Attachment transferred to RowBatch in ProtoBuf Request.
 template <typename Params>
-inline void attachment_transfer_request(const Params* brpc_request, brpc::Controller* cntl) {
+inline void attachment_transfer_request_row_batch(const Params* brpc_request,
+                                                  brpc::Controller* cntl) {
     if (cntl->request_attachment().size() > 0) {
         Params* req = const_cast<Params*>(brpc_request);
-        const butil::IOBuf& io_buf = cntl->request_attachment();
         auto rb = req->mutable_row_batch();
-        io_buf.copy_to(rb->mutable_tuple_data(), rb->tuple_data_size(), 0);
+        DCHECK(rb->transfer_attachment() == true);
+        if (rb->transfer_attachment() == true) {
+            const butil::IOBuf& io_buf = cntl->request_attachment();
+            io_buf.copy_to(rb->mutable_tuple_data(), io_buf.size(), 0);
+        }
     }
 }
 

--- a/be/src/util/proto_util.h
+++ b/be/src/util/proto_util.h
@@ -24,14 +24,15 @@ namespace doris {
 // and it is expected that performance can be improved.
 template <typename Params, typename Closure>
 inline void request_row_batch_transfer_attachment(Params* brpc_request, Closure* closure) {
-    if (brpc_request->row_batch().ByteSizeLong() > config::brpc_request_rowbatch_max_bytes) {
+    if (brpc_request->has_row_batch() &&
+        brpc_request->row_batch().ByteSizeLong() > config::brpc_request_rowbatch_max_bytes) {
         butil::IOBuf attachment;
         auto row_batch = brpc_request->mutable_row_batch();
         row_batch->set_transfer_attachment(true);
         attachment.append(row_batch->tuple_data());
         row_batch->clear_tuple_data();
         row_batch->set_tuple_data("");
-        closure->cntl.request_attachment().append(attachment);
+        closure->cntl.request_attachment().swap(attachment);
     }
 }
 
@@ -39,11 +40,11 @@ inline void request_row_batch_transfer_attachment(Params* brpc_request, Closure*
 template <typename Params>
 inline void attachment_transfer_request_row_batch(const Params* brpc_request,
                                                   brpc::Controller* cntl) {
-    if (cntl->request_attachment().size() > 0) {
-        Params* req = const_cast<Params*>(brpc_request);
+    Params* req = const_cast<Params*>(brpc_request);
+    if (req->has_row_batch()) {
         auto rb = req->mutable_row_batch();
-        DCHECK(rb->transfer_attachment() == true);
-        if (rb->transfer_attachment() == true) {
+        if (rb->transfer_attachment()) {
+            DCHECK(cntl->request_attachment().size() > 0);
             const butil::IOBuf& io_buf = cntl->request_attachment();
             io_buf.copy_to(rb->mutable_tuple_data(), io_buf.size(), 0);
         }

--- a/be/src/util/proto_util.h
+++ b/be/src/util/proto_util.h
@@ -1,0 +1,52 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+namespace doris {
+
+const int64_t MAX_REQUEST_BYTE_SIZE = 64 * 1024 * 1024;
+
+inline void row_batch_transfer_attachment(doris::PRowBatch* row_batch, butil::IOBuf* attachment) {
+    row_batch->set_tuple_data_size(row_batch->tuple_data().size());
+    attachment->append(row_batch->tuple_data());
+    row_batch->clear_tuple_data();
+    row_batch->set_tuple_data("");
+}
+
+template <typename Params, typename Closure>
+inline void request_transfer_attachment(Params* brpc_request, Closure* closure) {
+    if (config::brpc_request_transfer_attachment == true &&
+        brpc_request->row_batch().ByteSizeLong() > MAX_REQUEST_BYTE_SIZE) {
+        butil::IOBuf attachment;
+        auto row_batch = brpc_request->mutable_row_batch();
+        row_batch_transfer_attachment(row_batch, &attachment);
+        closure->cntl.request_attachment().append(attachment);
+    }
+}
+
+template <typename Params>
+inline void attachment_transfer_request(const Params* brpc_request, brpc::Controller* cntl) {
+    if (cntl->request_attachment().size() > 0) {
+        Params* req = const_cast<Params*>(brpc_request);
+        const butil::IOBuf& io_buf = cntl->request_attachment();
+        auto rb = req->mutable_row_batch();
+        io_buf.copy_to(rb->mutable_tuple_data(), rb->tuple_data_size(), 0);
+    }
+}
+
+} // namespace doris

--- a/be/src/util/proto_util.h
+++ b/be/src/util/proto_util.h
@@ -28,7 +28,7 @@ inline void request_row_batch_transfer_attachment(Params* brpc_request, Closure*
         brpc_request->row_batch().ByteSizeLong() > config::brpc_request_rowbatch_max_bytes) {
         butil::IOBuf attachment;
         auto row_batch = brpc_request->mutable_row_batch();
-        row_batch->set_transfer_attachment(true);
+        row_batch->set_transfer_by_attachment(true);
         attachment.append(row_batch->tuple_data());
         row_batch->clear_tuple_data();
         row_batch->set_tuple_data("");
@@ -43,7 +43,7 @@ inline void attachment_transfer_request_row_batch(const Params* brpc_request,
     Params* req = const_cast<Params*>(brpc_request);
     if (req->has_row_batch()) {
         auto rb = req->mutable_row_batch();
-        if (rb->transfer_attachment()) {
+        if (rb->transfer_by_attachment()) {
             DCHECK(cntl->request_attachment().size() > 0);
             const butil::IOBuf& io_buf = cntl->request_attachment();
             io_buf.copy_to(rb->mutable_tuple_data(), io_buf.size(), 0);

--- a/be/test/exec/tablet_sink_test.cpp
+++ b/be/test/exec/tablet_sink_test.cpp
@@ -36,6 +36,7 @@
 #include "util/brpc_stub_cache.h"
 #include "util/cpu_info.h"
 #include "util/debug/leakcheck_disabler.h"
+#include "util/proto_util.h"
 
 namespace doris {
 namespace stream_load {
@@ -339,6 +340,8 @@ public:
 
             if (request->has_row_batch() && _row_desc != nullptr) {
                 auto tracker = std::make_shared<MemTracker>();
+                brpc::Controller* cntl = static_cast<brpc::Controller*>(controller);
+                attachment_transfer_request_row_batch<PTabletWriterAddBatchRequest>(request, cntl);
                 RowBatch batch(*_row_desc, request->row_batch(), tracker.get());
                 for (int i = 0; i < batch.num_rows(); ++i) {
                     LOG(INFO) << batch.get_row(i)->to_string(*_row_desc);

--- a/docs/en/administrator-guide/config/be_config.md
+++ b/docs/en/administrator-guide/config/be_config.md
@@ -192,11 +192,11 @@ This configuration is mainly used to modify the parameter `socket_max_unwritten_
 
 Sometimes the query fails and an error message of `The server is overcrowded` will appear in the BE log. This means there are too many messages to buffer at the sender side, which may happen when the SQL needs to send large bitmap value. You can avoid this error by increasing the configuration.
 
-### `brpc_request_rowbatch_max_bytes`
+### `transfer_data_by_brpc_attachment`
 
-* Type: int64
-* Description: This configuration is used to control the maximum length of RowBatch in the ProtoBuf Request. If it exceeds the maximum length, it will be transferred to Controller Attachment. Note that when the length of ProtoBuf Request exceeds 2G, an error will be reported: Bad request, error_text=[E1003]Fail to compress request, so this value should not be greater than 2G.
-* Default value: 2G
+* Type: bool
+* Description: This configuration is used to control whether to transfer the RowBatch in the ProtoBuf Request to the Controller Attachment and then send it through brpc. When the length of ProtoBuf Request exceeds 2G, an error will be reported: Bad request, error_text=[E1003]Fail to compress request, Putting RowBatch in Controller Attachment will be faster and avoid this error.
+* Default value: false
 
 ### `brpc_num_threads`
 

--- a/docs/en/administrator-guide/config/be_config.md
+++ b/docs/en/administrator-guide/config/be_config.md
@@ -192,11 +192,11 @@ This configuration is mainly used to modify the parameter `socket_max_unwritten_
 
 Sometimes the query fails and an error message of `The server is overcrowded` will appear in the BE log. This means there are too many messages to buffer at the sender side, which may happen when the SQL needs to send large bitmap value. You can avoid this error by increasing the configuration.
 
-### `brpc_request_transfer_attachment`
+### `brpc_request_rowbatch_max_bytes`
 
-* Type: bool
-* Description: This configuration is used to control whether brpc transfers RowBatch in Proto Request to Controller Attachment.
-* Default value: false
+* Type: int64
+* Description: This configuration is used to control the maximum length of RowBatch in the ProtoBuf Request. If it exceeds the maximum length, it will be transferred to Controller Attachment and sent through brpc.Need<=2G, otherwise an error will be reported: Bad request, error_text=[E1003]Fail to compress request.
+* Default value: 2G
 
 ### `brpc_num_threads`
 

--- a/docs/en/administrator-guide/config/be_config.md
+++ b/docs/en/administrator-guide/config/be_config.md
@@ -192,6 +192,12 @@ This configuration is mainly used to modify the parameter `socket_max_unwritten_
 
 Sometimes the query fails and an error message of `The server is overcrowded` will appear in the BE log. This means there are too many messages to buffer at the sender side, which may happen when the SQL needs to send large bitmap value. You can avoid this error by increasing the configuration.
 
+### `brpc_request_transfer_attachment`
+
+* Type: bool
+* Description: This configuration is used to control whether brpc transfers RowBatch in Proto Request to Controller Attachment.
+* Default value: false
+
 ### `brpc_num_threads`
 
 This configuration is mainly used to modify the number of bthreads for brpc. The default value is set to -1, which means the number of bthreads is #cpu-cores.

--- a/docs/en/administrator-guide/config/be_config.md
+++ b/docs/en/administrator-guide/config/be_config.md
@@ -195,7 +195,7 @@ Sometimes the query fails and an error message of `The server is overcrowded` wi
 ### `brpc_request_rowbatch_max_bytes`
 
 * Type: int64
-* Description: This configuration is used to control the maximum length of RowBatch in the ProtoBuf Request. If it exceeds the maximum length, it will be transferred to Controller Attachment and sent through brpc.Need<=2G, otherwise an error will be reported: Bad request, error_text=[E1003]Fail to compress request.
+* Description: This configuration is used to control the maximum length of RowBatch in the ProtoBuf Request. If it exceeds the maximum length, it will be transferred to Controller Attachment. Note that when the length of ProtoBuf Request exceeds 2G, an error will be reported: Bad request, error_text=[E1003]Fail to compress request, so this value should not be greater than 2G.
 * Default value: 2G
 
 ### `brpc_num_threads`

--- a/docs/zh-CN/administrator-guide/config/be_config.md
+++ b/docs/zh-CN/administrator-guide/config/be_config.md
@@ -189,7 +189,7 @@ Metrics: {"filtered_rows":0,"input_row_num":3346807,"input_rowsets_count":42,"in
 ### `brpc_request_rowbatch_max_bytes`
 
 * 类型：int64
-* 描述：该配置用来控制ProtoBuf Request中RowBatch的最大长度，超出后将转移到Controller Attachment后通过brpc发送。需要<=2G, 否则会报错： Bad request, error_text=[E1003]Fail to compress request.
+* 描述：该配置用来控制ProtoBuf Request中RowBatch的最大长度，超出后将转移到Controller Attachment后通过brpc发送。需注意，ProtoBuf Request的长度超过2G时会报错： Bad request, error_text=[E1003]Fail to compress request，所以这个值不应大于2G.
 * 默认值：2G
 
 ### `brpc_num_threads`

--- a/docs/zh-CN/administrator-guide/config/be_config.md
+++ b/docs/zh-CN/administrator-guide/config/be_config.md
@@ -186,11 +186,11 @@ Metrics: {"filtered_rows":0,"input_row_num":3346807,"input_rowsets_count":42,"in
 
 有时查询失败，BE 日志中会出现 `The server is overcrowded` 的错误信息，表示连接上有过多的未发送数据。当查询需要发送较大的bitmap字段时，可能会遇到该问题，此时可能通过调大该配置避免该错误。
 
-### `brpc_request_rowbatch_max_bytes`
+### `transfer_data_by_brpc_attachment`
 
-* 类型：int64
-* 描述：该配置用来控制ProtoBuf Request中RowBatch的最大长度，超出后将转移到Controller Attachment后通过brpc发送。需注意，ProtoBuf Request的长度超过2G时会报错： Bad request, error_text=[E1003]Fail to compress request，所以这个值不应大于2G.
-* 默认值：2G
+* 类型: bool
+* 描述：该配置用来控制是否将ProtoBuf Request中的RowBatch转移到Controller Attachment后通过brpc发送。ProtoBuf Request的长度超过2G时会报错： Bad request, error_text=[E1003]Fail to compress request，将RowBatch放到Controller Attachment中将更快且避免这个错误。
+* 默认值：false
 
 ### `brpc_num_threads`
 

--- a/docs/zh-CN/administrator-guide/config/be_config.md
+++ b/docs/zh-CN/administrator-guide/config/be_config.md
@@ -186,6 +186,11 @@ Metrics: {"filtered_rows":0,"input_row_num":3346807,"input_rowsets_count":42,"in
 
 有时查询失败，BE 日志中会出现 `The server is overcrowded` 的错误信息，表示连接上有过多的未发送数据。当查询需要发送较大的bitmap字段时，可能会遇到该问题，此时可能通过调大该配置避免该错误。
 
+### `brpc_request_transfer_attachment`
+
+* 类型：bool
+* 描述：该配置用来控制brpc是否将Proto Request中的RowBatch转移到Controller Attachment中。
+* 默认值：false
 
 ### `brpc_num_threads`
 

--- a/docs/zh-CN/administrator-guide/config/be_config.md
+++ b/docs/zh-CN/administrator-guide/config/be_config.md
@@ -186,11 +186,11 @@ Metrics: {"filtered_rows":0,"input_row_num":3346807,"input_rowsets_count":42,"in
 
 有时查询失败，BE 日志中会出现 `The server is overcrowded` 的错误信息，表示连接上有过多的未发送数据。当查询需要发送较大的bitmap字段时，可能会遇到该问题，此时可能通过调大该配置避免该错误。
 
-### `brpc_request_transfer_attachment`
+### `brpc_request_rowbatch_max_bytes`
 
-* 类型：bool
-* 描述：该配置用来控制brpc是否将Proto Request中的RowBatch转移到Controller Attachment中。
-* 默认值：false
+* 类型：int64
+* 描述：该配置用来控制ProtoBuf Request中RowBatch的最大长度，超出后将转移到Controller Attachment后通过brpc发送。需要<=2G, 否则会报错： Bad request, error_text=[E1003]Fail to compress request.
+* 默认值：2G
 
 ### `brpc_num_threads`
 

--- a/gensrc/proto/data.proto
+++ b/gensrc/proto/data.proto
@@ -40,6 +40,7 @@ message PRowBatch {
     repeated int32 tuple_offsets = 3;
     required bytes tuple_data = 4;
     required bool is_compressed = 5;
+    optional int64 tuple_data_size = 6;
 }
 
 message PColumn {

--- a/gensrc/proto/data.proto
+++ b/gensrc/proto/data.proto
@@ -40,7 +40,7 @@ message PRowBatch {
     repeated int32 tuple_offsets = 3;
     required bytes tuple_data = 4;
     required bool is_compressed = 5;
-    optional int64 tuple_data_size = 6;
+    optional bool transfer_attachment = 6;
 }
 
 message PColumn {

--- a/gensrc/proto/data.proto
+++ b/gensrc/proto/data.proto
@@ -40,7 +40,7 @@ message PRowBatch {
     repeated int32 tuple_offsets = 3;
     required bytes tuple_data = 4;
     required bool is_compressed = 5;
-    optional bool transfer_attachment = 6;
+    optional bool transfer_attachment = 6 [default = false];
 }
 
 message PColumn {

--- a/gensrc/proto/data.proto
+++ b/gensrc/proto/data.proto
@@ -40,7 +40,7 @@ message PRowBatch {
     repeated int32 tuple_offsets = 3;
     required bytes tuple_data = 4;
     required bool is_compressed = 5;
-    optional bool transfer_attachment = 6 [default = false];
+    optional bool transfer_by_attachment = 6 [default = false];
 }
 
 message PColumn {


### PR DESCRIPTION
## Proposed changes

Transfer RowBatch in ProtoBuf Request to Controller Attachment, when the maximum length of the RowBatch in the ProtoBuf Request is exceeded.
This can avoid reaching the upper limit of the ProtoBuf Request length (2G), and it is expected that performance can be improved.

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Code refactor (Modify the code structure, format the code, etc...)
- [ ] Optimization. Including functional usability improvements and performance improvements.
- [ ] Dependency. Such as changes related to third-party components.
- [ ] Other.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have created an issue on (Fix #7163) and described the bug/feature there in detail
- [x] Compiling and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If these changes need document changes, I have updated the document
- [ ] Any dependent changes have been merged

## Further comments

If this is a relatively large or complex change, kick off the discussion at dev@doris.apache.org by explaining why you chose the solution you did and what alternatives you considered, etc...
