### PR TITLE
[BUG] Fix `curdate()+0` to behave like mysql

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/DateLiteral.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/DateLiteral.java
@@ -374,7 +374,7 @@ public class DateLiteral extends LiteralExpr {
         if (!getType().equals(expr.getType())) {
             if (getType().equals(Type.DATE)) {
                 thisExprLongValue *= BASIC_ZERO_TIME;
-            } else {
+            } else if (expr.getType().equals(Type.DATE)) {
                 otherExprLongValue *= BASIC_ZERO_TIME;
             }
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/DateLiteral.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/DateLiteral.java
@@ -361,8 +361,18 @@ public class DateLiteral extends LiteralExpr {
         if (expr == MaxLiteral.MAX_VALUE) {
             return -1;
         }
+
+        long thisExprLongValue = getLongValue();
+        long otherExprLongValue = expr.getLongValue();
+        if (!getType().equals(expr.getType())) {
+            if (getType().equals(Type.DATE)) {
+                thisExprLongValue *= 1000000;
+            } else {
+                otherExprLongValue *= 1000000;
+            }
+        }
         // date time will not overflow when doing addition and subtraction
-        return Long.signum(getLongValue() - expr.getLongValue());
+        return Long.signum(thisExprLongValue - otherExprLongValue);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/DateLiteral.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/DateLiteral.java
@@ -66,6 +66,13 @@ public class DateLiteral extends LiteralExpr {
     private static final int MAX_MICROSECOND = 999999;
     private static final int DATETIME_TO_MINUTE_STRING_LENGTH = 16;
     private static final int DATETIME_TO_HOUR_STRING_LENGTH = 13;
+    /*
+     * A long value datetime in the form of 'yyyyMMddHHmmss' divided by BASIC_ZERO_TIME
+     * should obtain a long value date in the form of 'yyyyMMdd'.
+     * Conversely, a long value date in the form of 'yyyyMMdd' times BASIC_ZERO_TIME
+     * should obtain a long value datetime in the form of 'yyyyMMddHHmmss', means zero o'clock of that day.
+     */
+    public static final long BASIC_ZERO_TIME = 1000000L;
 
     private static DateTimeFormatter DATE_TIME_FORMATTER = null;
     private static DateTimeFormatter DATE_TIME_FORMATTER_TO_HOUR = null;
@@ -366,9 +373,9 @@ public class DateLiteral extends LiteralExpr {
         long otherExprLongValue = expr.getLongValue();
         if (!getType().equals(expr.getType())) {
             if (getType().equals(Type.DATE)) {
-                thisExprLongValue *= 1000000;
+                thisExprLongValue *= BASIC_ZERO_TIME;
             } else {
-                otherExprLongValue *= 1000000;
+                otherExprLongValue *= BASIC_ZERO_TIME;
             }
         }
         // date time will not overflow when doing addition and subtraction

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/DateLiteral.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/DateLiteral.java
@@ -385,7 +385,11 @@ public class DateLiteral extends LiteralExpr {
 
     @Override
     public long getLongValue() {
-        return (year * 10000 + month * 100 + day) * 1000000L + hour * 10000 + minute * 100 + second;
+        if (this.type.equals(Type.DATE)) {
+            return year * 10000 + month * 100 + day;
+        } else {
+            return (year * 10000 + month * 100 + day) * 1000000L + hour * 10000 + minute * 100 + second;
+        }
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/cache/PartitionRange.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/cache/PartitionRange.java
@@ -238,7 +238,11 @@ public class PartitionRange {
         }
 
         private Date getDateValue(LiteralExpr expr) {
-            value = expr.getLongValue() / 1000000;
+            if (expr.getType().equals(Type.DATE)) {
+                value = expr.getLongValue();
+            } else {
+                value = expr.getLongValue() / 1000000;
+            }
             Date dt = null;
             try {
                 dt = df8.parse(String.valueOf(value));

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/cache/PartitionRange.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/cache/PartitionRange.java
@@ -48,8 +48,6 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
-import static org.apache.doris.analysis.DateLiteral.BASIC_ZERO_TIME;
-
 /**
  * Convert the range of the partition to the list
  * all partition by day/week/month split to day list
@@ -243,7 +241,7 @@ public class PartitionRange {
             if (expr.getType().equals(Type.DATE)) {
                 value = expr.getLongValue();
             } else {
-                value = expr.getLongValue() / BASIC_ZERO_TIME;
+                value = expr.getLongValue() / DateLiteral.BASIC_ZERO_TIME;
             }
             Date dt = null;
             try {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/cache/PartitionRange.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/cache/PartitionRange.java
@@ -48,6 +48,8 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
+import static org.apache.doris.analysis.DateLiteral.BASIC_ZERO_TIME;
+
 /**
  * Convert the range of the partition to the list
  * all partition by day/week/month split to day list
@@ -241,7 +243,7 @@ public class PartitionRange {
             if (expr.getType().equals(Type.DATE)) {
                 value = expr.getLongValue();
             } else {
-                value = expr.getLongValue() / 1000000;
+                value = expr.getLongValue() / BASIC_ZERO_TIME;
             }
             Date dt = null;
             try {

--- a/fe/fe-core/src/main/java/org/apache/doris/rewrite/FEFunctions.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/rewrite/FEFunctions.java
@@ -251,6 +251,11 @@ public class FEFunctions {
         return new DateLiteral(LocalDateTime.now(DateTimeZone.forTimeZone(TimeUtils.getTimeZone())), Type.DATE);
     }
 
+    @FEFunction(name = "current_date", argTypes = {}, returnType = "DATE")
+    public static DateLiteral currentDate() throws AnalysisException {
+        return curDate();
+    }
+
     @FEFunction(name = "curtime", argTypes = {}, returnType = "TIME")
     public static FloatLiteral curTime() throws AnalysisException {
         DateLiteral now = now();

--- a/fe/fe-core/src/test/java/org/apache/doris/planner/QueryPlanTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/planner/QueryPlanTest.java
@@ -17,7 +17,6 @@
 
 package org.apache.doris.planner;
 
-import com.google.common.base.Splitter;
 import org.apache.doris.analysis.Analyzer;
 import org.apache.doris.analysis.CreateDbStmt;
 import org.apache.doris.analysis.CreateTableStmt;
@@ -47,6 +46,7 @@ import org.apache.doris.qe.QueryState.MysqlStateType;
 import org.apache.doris.utframe.UtFrameUtils;
 
 import com.google.common.collect.Lists;
+import com.google.common.base.Splitter;
 
 import org.apache.commons.lang3.StringUtils;
 import org.junit.AfterClass;

--- a/fe/fe-core/src/test/java/org/apache/doris/rewrite/FEFunctionsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/rewrite/FEFunctionsTest.java
@@ -94,25 +94,25 @@ public class FEFunctionsTest {
         expectedResult = new IntLiteral(-30);
         Assert.assertEquals(expectedResult, actualResult);
     }
-    
+
     @Test
     public void dateAddTest() throws AnalysisException {
-        DateLiteral actualResult = FEFunctions.dateAdd(new DateLiteral("2018-08-08", Type.DATE), new IntLiteral(1));
+        DateLiteral actualResult = FEFunctions.dateAdd(new DateLiteral("2018-08-08 00:00:00", Type.DATETIME), new IntLiteral(1));
         DateLiteral expectedResult = new DateLiteral("2018-08-09 00:00:00", Type.DATETIME);
         Assert.assertEquals(expectedResult, actualResult);
 
-        actualResult = FEFunctions.dateAdd(new DateLiteral("2018-08-08", Type.DATE), new IntLiteral(-1));
+        actualResult = FEFunctions.dateAdd(new DateLiteral("2018-08-08 00:00:00", Type.DATETIME), new IntLiteral(-1));
         expectedResult = new DateLiteral("2018-08-07 00:00:00", Type.DATETIME);
         Assert.assertEquals(expectedResult, actualResult);
     }
-    
+
     @Test
     public void addDateTest() throws AnalysisException {
-        DateLiteral actualResult = FEFunctions.addDate(new DateLiteral("2018-08-08", Type.DATE), new IntLiteral(1));
+        DateLiteral actualResult = FEFunctions.addDate(new DateLiteral("2018-08-08 00:00:00", Type.DATETIME), new IntLiteral(1));
         DateLiteral expectedResult = new DateLiteral("2018-08-09 00:00:00", Type.DATETIME);
         Assert.assertEquals(expectedResult, actualResult);
 
-        actualResult = FEFunctions.addDate(new DateLiteral("2018-08-08", Type.DATE), new IntLiteral(-1));
+        actualResult = FEFunctions.addDate(new DateLiteral("2018-08-08 00:00:00", Type.DATETIME), new IntLiteral(-1));
         expectedResult = new DateLiteral("2018-08-07 00:00:00", Type.DATETIME);
         Assert.assertEquals(expectedResult, actualResult);
 

--- a/fe/fe-core/src/test/java/org/apache/doris/rewrite/FEFunctionsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/rewrite/FEFunctionsTest.java
@@ -97,22 +97,22 @@ public class FEFunctionsTest {
 
     @Test
     public void dateAddTest() throws AnalysisException {
-        DateLiteral actualResult = FEFunctions.dateAdd(new DateLiteral("2018-08-08 00:00:00", Type.DATETIME), new IntLiteral(1));
+        DateLiteral actualResult = FEFunctions.dateAdd(new DateLiteral("2018-08-08", Type.DATE), new IntLiteral(1));
         DateLiteral expectedResult = new DateLiteral("2018-08-09 00:00:00", Type.DATETIME);
         Assert.assertEquals(expectedResult, actualResult);
 
-        actualResult = FEFunctions.dateAdd(new DateLiteral("2018-08-08 00:00:00", Type.DATETIME), new IntLiteral(-1));
+        actualResult = FEFunctions.dateAdd(new DateLiteral("2018-08-08", Type.DATE), new IntLiteral(-1));
         expectedResult = new DateLiteral("2018-08-07 00:00:00", Type.DATETIME);
         Assert.assertEquals(expectedResult, actualResult);
     }
 
     @Test
     public void addDateTest() throws AnalysisException {
-        DateLiteral actualResult = FEFunctions.addDate(new DateLiteral("2018-08-08 00:00:00", Type.DATETIME), new IntLiteral(1));
+        DateLiteral actualResult = FEFunctions.addDate(new DateLiteral("2018-08-08", Type.DATE), new IntLiteral(1));
         DateLiteral expectedResult = new DateLiteral("2018-08-09 00:00:00", Type.DATETIME);
         Assert.assertEquals(expectedResult, actualResult);
 
-        actualResult = FEFunctions.addDate(new DateLiteral("2018-08-08 00:00:00", Type.DATETIME), new IntLiteral(-1));
+        actualResult = FEFunctions.addDate(new DateLiteral("2018-08-08", Type.DATE), new IntLiteral(-1));
         expectedResult = new DateLiteral("2018-08-07 00:00:00", Type.DATETIME);
         Assert.assertEquals(expectedResult, actualResult);
 


### PR DESCRIPTION
## Proposed changes

I proposed this point in [PR-6005](https://github.com/apache/incubator-doris/pull/6005).
Now I try to make `curdate()+0` behave like mysql.
NOW✅:
```
mysql> SELECT CURDATE() + 0;
+-----------------+
| CURDATE() + 0.0 |
+-----------------+
|        20211123 |
+-----------------+
```
BEFORE❌:
```
mysql> select CURDATE() + 0;
+-----------------+
| curdate() + 0.0 |
+-----------------+
|  20211123104151 |
+-----------------+
```

Also, I add `current_date` annotated as a FEFunction.

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Code refactor (Modify the code structure, format the code, etc...)
- [ ] Optimization. Including functional usability improvements and performance improvements.
- [ ] Dependency. Such as changes related to third-party components.
- [ ] Other.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have created an issue on (Fix #ISSUE) and described the bug/feature there in detail
- [x] Compiling and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If these changes need document changes, I have updated the document
- [ ] Any dependent changes have been merged
