### PR TITLE
fix partition rebalance bug

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/clone/TwoDimensionalGreedyRebalanceAlgo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/TwoDimensionalGreedyRebalanceAlgo.java
@@ -135,6 +135,17 @@ public class TwoDimensionalGreedyRebalanceAlgo {
             // Nothing to balance: cluster is empty.
             return Lists.newArrayList();
         }
+		
+        NavigableSet<Long> keySet = info.beByTotalReplicaCount.keySet();
+        if (keySet.isEmpty() || keySet.last() == 0L) {
+            // the number of replica on specified medium we get from getReplicaNumByBeIdAndStorageMedium() is
+            // defined by table properties,but in fact there may not has SSD/HDD disk on this backend.
+            // So if we found that no SSD/HDD disk on this backend, set the replica number to 0,
+            // but the partitionInfoBySkew doesn't consider this scene, medium has no SSD/HDD disk also skew,
+            // cause rebalance exception
+            return Lists.newArrayList();
+        }
+
 
         List<PartitionMove> moves = Lists.newArrayList();
         for (int i = 0; i < maxMovesNum; ++i) {


### PR DESCRIPTION
the number of replica on specified medium we get from getReplicaNumByBeIdAndStorageMedium() is
defined by table properties,but in fact there may not has SSD/HDD disk on this backend.  So if we found that no SSD/HDD disk on this backend, set the replica number to 0,
but the partitionInfoBySkew doesn't consider this scene, medium has no SSD/HDD disk also skew, cause rebalance exception

``` 
java.lang.IllegalStateException: fromBe has no replica in the map, can't move
        at com.google.common.base.Preconditions.checkState(Preconditions.java:508) ~[spark-dpp-1.0.0.jar:1.0.0]
        at org.apache.doris.clone.TwoDimensionalGreedyRebalanceAlgo.moveOneReplica(TwoDimensionalGreedyRebalanceAlgo.java:322) ~[palo-fe.jar:3.4.0]
        at org.apache.doris.clone.TwoDimensionalGreedyRebalanceAlgo.applyMove(TwoDimensionalGreedyRebalanceAlgo.java:261) ~[palo-fe.jar:3.4.0]
        at org.apache.doris.clone.TwoDimensionalGreedyRebalanceAlgo.getNextMoves(TwoDimensionalGreedyRebalanceAlgo.java:142) ~[palo-fe.jar:3.4.0]
        at org.apache.doris.clone.PartitionRebalancer.selectAlternativeTabletsForCluster(PartitionRebalancer.java:110) ~[palo-fe.jar:3.4.0]
        at org.apache.doris.clone.Rebalancer.selectAlternativeTablets(Rebalancer.java:61) ~[palo-fe.jar:3.4.0]
        at org.apache.doris.clone.TabletScheduler.selectTabletsForBalance(TabletScheduler.java:1054) ~[palo-fe.jar:3.4.0]
        at org.apache.doris.clone.TabletScheduler.runAfterCatalogReady(TabletScheduler.java:280) ~[palo-fe.jar:3.4.0]
        at org.apache.doris.common.util.MasterDaemon.runOneCycle(MasterDaemon.java:58) ~[palo-fe.jar:3.4.0]
        at org.apache.doris.common.util.Daemon.run(Daemon.java:116) [palo-fe.jar:3.4.0]
```

## Proposed changes

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [x ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Code refactor (Modify the code structure, format the code, etc...)
- [ ] Optimization. Including functional usability improvements and performance improvements.
- [ ] Dependency. Such as changes related to third-party components.
- [ ] Other.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have created an issue on (Fix #ISSUE) and described the bug/feature there in detail
- [ ] Compiling and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If these changes need document changes, I have updated the document
- [ ] Any dependent changes have been merged

## Further comments

If this is a relatively large or complex change, kick off the discussion at dev@doris.apache.org by explaining why you chose the solution you did and what alternatives you considered, etc...
