### PR TITLE
[Bug] fix core dump at some bitmap function

### DIFF
--- a/be/src/util/bitmap_value.h
+++ b/be/src/util/bitmap_value.h
@@ -598,7 +598,7 @@ public:
             if (iter->second.isEmpty()) {
                 // empty Roarings are 84 bytes
                 savedBytes += 88;
-                roarings.erase(iter++);
+                iter = roarings.erase(iter);
             } else {
                 savedBytes += iter->second.shrinkToFit();
                 iter++;
@@ -928,7 +928,7 @@ public:
     const_iterator end() const;
 
 private:
-    std::map<uint32_t, roaring::Roaring> roarings {};
+    phmap::btree_map<uint32_t, roaring::Roaring> roarings {};
     bool copyOnWrite {false};
     static uint32_t highBytes(const uint64_t in) { return uint32_t(in >> 32); }
     static uint32_t lowBytes(const uint64_t in) { return uint32_t(in); }
@@ -1066,9 +1066,9 @@ public:
     }
 
 protected:
-    const std::map<uint32_t, roaring::Roaring>& p;
-    std::map<uint32_t, roaring::Roaring>::const_iterator map_iter {};
-    std::map<uint32_t, roaring::Roaring>::const_iterator map_end {};
+    const phmap::btree_map<uint32_t, roaring::Roaring>& p;
+    phmap::btree_map<uint32_t, roaring::Roaring>::const_iterator map_iter {};
+    phmap::btree_map<uint32_t, roaring::Roaring>::const_iterator map_end {};
     roaring::api::roaring_uint32_iterator_t i {};
 };
 
@@ -1118,7 +1118,7 @@ public:
     }
 
 protected:
-    std::map<uint32_t, roaring::Roaring>::const_iterator map_begin;
+    phmap::btree_map<uint32_t, roaring::Roaring>::const_iterator map_begin;
 };
 
 inline Roaring64MapSetBitForwardIterator Roaring64Map::begin() const {

--- a/be/src/util/bitmap_value.h
+++ b/be/src/util/bitmap_value.h
@@ -928,7 +928,7 @@ public:
     const_iterator end() const;
 
 private:
-    phmap::btree_map<uint32_t, roaring::Roaring> roarings {};
+    std::map<uint32_t, roaring::Roaring> roarings {};
     bool copyOnWrite {false};
     static uint32_t highBytes(const uint64_t in) { return uint32_t(in >> 32); }
     static uint32_t lowBytes(const uint64_t in) { return uint32_t(in); }
@@ -1066,9 +1066,9 @@ public:
     }
 
 protected:
-    const phmap::btree_map<uint32_t, roaring::Roaring>& p;
-    phmap::btree_map<uint32_t, roaring::Roaring>::const_iterator map_iter {};
-    phmap::btree_map<uint32_t, roaring::Roaring>::const_iterator map_end {};
+    const std::map<uint32_t, roaring::Roaring>& p;
+    std::map<uint32_t, roaring::Roaring>::const_iterator map_iter {};
+    std::map<uint32_t, roaring::Roaring>::const_iterator map_end {};
     roaring::api::roaring_uint32_iterator_t i {};
 };
 
@@ -1118,7 +1118,7 @@ public:
     }
 
 protected:
-    phmap::btree_map<uint32_t, roaring::Roaring>::const_iterator map_begin;
+    std::map<uint32_t, roaring::Roaring>::const_iterator map_begin;
 };
 
 inline Roaring64MapSetBitForwardIterator Roaring64Map::begin() const {


### PR DESCRIPTION
## Proposed changes

`select bitmap_xor(bitmap_from_string('1'), bitmap_from_string('1,1'));`

`https://github.com/greg7mdp/parallel-hashmap`
```
The btree containers are direct ports from Abseil, and should behave exactly the same as the Abseil ones, modulo small differences (such as supporting std::string_view instead of absl::string_view, and being forward declarable).

When btrees are mutated, values stored within can be moved in memory. This means that pointers or iterators to values stored in btree containers can be invalidated when that btree is modified. This is a significant difference with std::map and std::set, as the std containers do offer a guarantee of pointer stability. The same is true for the 'flat' hash maps and sets.
```

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Code refactor (Modify the code structure, format the code, etc...)
- [ ] Optimization. Including functional usability improvements and performance improvements.
- [ ] Dependency. Such as changes related to third-party components.
- [ ] Other.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [X] I have created an issue on (Fix #7218) and described the bug/feature there in detail
- [ ] Compiling and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If these changes need document changes, I have updated the document
- [ ] Any dependent changes have been merged

## Further comments

If this is a relatively large or complex change, kick off the discussion at dev@doris.apache.org by explaining why you chose the solution you did and what alternatives you considered, etc...
