### PR TITLE
Separate parameters for writing and reading control records

### DIFF
--- a/docs/en/extending-doris/flink-doris-connector.md
+++ b/docs/en/extending-doris/flink-doris-connector.md
@@ -254,7 +254,7 @@ outputFormat.close();
 | doris.deserialize.queue.size     | 64                | Asynchronous conversion of the internal processing queue in Arrow format takes effect when doris.deserialize.arrow.async is true        |
 | doris.read.field            | --            | List of column names in the Doris table, separated by commas                  |
 | doris.filter.query          | --            | Filter expression of the query, which is transparently transmitted to Doris. Doris uses this expression to complete source-side data filtering. |
-| sink.batch.size                        | 100            | Maximum number of lines in a single write BE                                             |
+| sink.batch.size                        | 100            | Maximum number of lines in a single write doris                                        |
 | sink.max-retries                        | 1            | Number of retries after writing BE failed                                              |
 | sink.batch.interval                         | 1s            | The flush interval, after which the asynchronous thread will write the data in the cache to BE. The default value is 1 second, and the time units are ms, s, min, h, and d. Set to 0 to turn off periodic writing. |
 | sink.properties.*     | --               | The stream load parameters.eg:sink.properties.column_separator' = ','. Setting 'sink.properties.escape_delimiters' = 'true' if you want to use a control char as a separator, so that such as '\\x01' will translate to binary 0x01<br /> Support JSON format import, you need to enable both 'sink.properties.format' ='json' and 'sink.properties.strip_outer_array' ='true'|

--- a/docs/en/extending-doris/flink-doris-connector.md
+++ b/docs/en/extending-doris/flink-doris-connector.md
@@ -239,7 +239,7 @@ outputFormat.close();
 
 | Key                              | Default Value     | Comment                                                      |
 | -------------------------------- | ----------------- | ------------------------------------------------------------ |
-| fenodes                    | --                | Doris FE http address, support multiple addresses, separated by commas            |
+| fenodes                    | --                | Doris FE http address + FE http_port, for example: 192.168.1.123:8030, multiple addresses are separated by English status commas |
 | table.identifier           | --                | Doris table identifier, eg, db1.tbl1                                 |
 | username                            | --            | Doris username                                            |
 | password                        | --            | Doris password                                              |

--- a/docs/en/extending-doris/spark-doris-connector.md
+++ b/docs/en/extending-doris/spark-doris-connector.md
@@ -182,7 +182,8 @@ kafkaSource.selectExpr("CAST(key AS STRING)", "CAST(value as STRING)")
 | doris.deserialize.arrow.async    | false             | Whether to support asynchronous conversion of Arrow format to RowBatch required for spark-doris-connector iteration                 |
 | doris.deserialize.queue.size     | 64                | Asynchronous conversion of the internal processing queue in Arrow format takes effect when doris.deserialize.arrow.async is true        |
 | doris.write.fields                | --                 | Specifies the fields (or the order of the fields) to write to the Doris table, fileds separated by commas.<br/>By default, all fields are written in the order of Doris table fields. |
-| sink.batch.size | 100             | The maximum number of rows in a single write doris. In order to avoid high-frequency import causing the number of tablet versions to exceed the default 500, it is recommended to set this parameter value larger |
+| sink.batch.size | 100             | The maximum number of rows in a single write doris. In order to avoid high-frequency import causing the number of tablet versions to exceed the default 500, it is recommended to set this parameter value larger，**Note**, it should be noted that the original write only used the parameter doris.batch.size, please pay attention to the modification after the upgrade version |
+|  |  |  |
 
 ### SQL & Dataframe Configuration
 

--- a/docs/en/extending-doris/spark-doris-connector.md
+++ b/docs/en/extending-doris/spark-doris-connector.md
@@ -182,6 +182,7 @@ kafkaSource.selectExpr("CAST(key AS STRING)", "CAST(value as STRING)")
 | doris.deserialize.arrow.async    | false             | Whether to support asynchronous conversion of Arrow format to RowBatch required for spark-doris-connector iteration                 |
 | doris.deserialize.queue.size     | 64                | Asynchronous conversion of the internal processing queue in Arrow format takes effect when doris.deserialize.arrow.async is true        |
 | doris.write.fields                | --                 | Specifies the fields (or the order of the fields) to write to the Doris table, fileds separated by commas.<br/>By default, all fields are written in the order of Doris table fields. |
+| sink.batch.size | 100             | The maximum number of rows in a single write BE. In order to avoid high-frequency import causing the number of tablet versions to exceed the default 500, it is recommended to set this parameter value larger |
 
 ### SQL & Dataframe Configuration
 

--- a/docs/en/extending-doris/spark-doris-connector.md
+++ b/docs/en/extending-doris/spark-doris-connector.md
@@ -182,7 +182,7 @@ kafkaSource.selectExpr("CAST(key AS STRING)", "CAST(value as STRING)")
 | doris.deserialize.arrow.async    | false             | Whether to support asynchronous conversion of Arrow format to RowBatch required for spark-doris-connector iteration                 |
 | doris.deserialize.queue.size     | 64                | Asynchronous conversion of the internal processing queue in Arrow format takes effect when doris.deserialize.arrow.async is true        |
 | doris.write.fields                | --                 | Specifies the fields (or the order of the fields) to write to the Doris table, fileds separated by commas.<br/>By default, all fields are written in the order of Doris table fields. |
-| sink.batch.size | 100             | The maximum number of rows in a single write doris. In order to avoid high-frequency import causing the number of tablet versions to exceed the default 500, it is recommended to set this parameter value larger，**Note**, it should be noted that the original write only used the parameter doris.batch.size, please pay attention to the modification after the upgrade version |
+| sink.batch.size | 100             | The maximum number of rows in a single write doris. In order to avoid the high-frequency import causing the number of tablet versions to exceed the default 500, it is recommended to set this parameter value larger. **Note**, the original write uses the parameter to read data: `doris. batch.size`. After upgrading the version, pay attention to modify to this new parameter |
 |  |  |  |
 
 ### SQL & Dataframe Configuration

--- a/docs/en/extending-doris/spark-doris-connector.md
+++ b/docs/en/extending-doris/spark-doris-connector.md
@@ -182,7 +182,7 @@ kafkaSource.selectExpr("CAST(key AS STRING)", "CAST(value as STRING)")
 | doris.deserialize.arrow.async    | false             | Whether to support asynchronous conversion of Arrow format to RowBatch required for spark-doris-connector iteration                 |
 | doris.deserialize.queue.size     | 64                | Asynchronous conversion of the internal processing queue in Arrow format takes effect when doris.deserialize.arrow.async is true        |
 | doris.write.fields                | --                 | Specifies the fields (or the order of the fields) to write to the Doris table, fileds separated by commas.<br/>By default, all fields are written in the order of Doris table fields. |
-| sink.batch.size | 100             | The maximum number of rows in a single write doris. In order to avoid the high-frequency import causing the number of tablet versions to exceed the default 500, it is recommended to set this parameter value larger. **Note**, the original write uses the parameter to read data: `doris. batch.size`. After upgrading the version, pay attention to modify to this new parameter |
+| sink.batch.size | 10000           | The maximum number of rows in a single write doris. In order to avoid the high-frequency import causing the number of tablet versions to exceed the default 500, If your data is low frequency and small, you can appropriately set this parameter value small. **Note**, the original write uses the parameter to read data: `doris. batch.size`. After upgrading the version, pay attention to modify to this new parameter |
 |  |  |  |
 
 ### SQL & Dataframe Configuration

--- a/docs/en/extending-doris/spark-doris-connector.md
+++ b/docs/en/extending-doris/spark-doris-connector.md
@@ -182,7 +182,7 @@ kafkaSource.selectExpr("CAST(key AS STRING)", "CAST(value as STRING)")
 | doris.deserialize.arrow.async    | false             | Whether to support asynchronous conversion of Arrow format to RowBatch required for spark-doris-connector iteration                 |
 | doris.deserialize.queue.size     | 64                | Asynchronous conversion of the internal processing queue in Arrow format takes effect when doris.deserialize.arrow.async is true        |
 | doris.write.fields                | --                 | Specifies the fields (or the order of the fields) to write to the Doris table, fileds separated by commas.<br/>By default, all fields are written in the order of Doris table fields. |
-| sink.batch.size | 100             | The maximum number of rows in a single write BE. In order to avoid high-frequency import causing the number of tablet versions to exceed the default 500, it is recommended to set this parameter value larger |
+| sink.batch.size | 100             | The maximum number of rows in a single write doris. In order to avoid high-frequency import causing the number of tablet versions to exceed the default 500, it is recommended to set this parameter value larger |
 
 ### SQL & Dataframe Configuration
 

--- a/docs/zh-CN/extending-doris/flink-doris-connector.md
+++ b/docs/zh-CN/extending-doris/flink-doris-connector.md
@@ -257,7 +257,7 @@ outputFormat.close();
 | doris.deserialize.queue.size     | 64                | 异步转换Arrow格式的内部处理队列，当doris.deserialize.arrow.async为true时生效        |
 | doris.read.field            | --            | 读取Doris表的列名列表，多列之间使用逗号分隔                  |
 | doris.filter.query          | --            | 过滤读取数据的表达式，此表达式透传给Doris。Doris使用此表达式完成源端数据过滤。 |
-| sink.batch.size     | 100                | 单次写BE的最大行数        |
+| sink.batch.size     | 100                | 单次写doris的最大行数   |
 | sink.max-retries     | 1                | 写BE失败之后的重试次数       |
 | sink.batch.interval     | 1s                | flush 间隔时间，超过该时间后异步线程将 缓存中数据写入BE。 默认值为1秒，支持时间单位ms、s、min、h和d。设置为0表示关闭定期写入。|
 | sink.properties.*     | --               | Stream load 的导入参数。例如:'sink.properties.column_separator' = ','等。如果需要特殊字符作为分隔符, 可以加上参数'sink.properties.escape_delimiters' = 'true', '\\x01'会被转换为二进制的0x01<br /> 支持JSON格式导入，需要同时开启'sink.properties.format' = 'json'和'sink.properties.strip_outer_array' = 'true' |

--- a/docs/zh-CN/extending-doris/flink-doris-connector.md
+++ b/docs/zh-CN/extending-doris/flink-doris-connector.md
@@ -242,7 +242,7 @@ outputFormat.close();
 
 | Key                              | Default Value     | Comment                                                      |
 | -------------------------------- | ----------------- | ------------------------------------------------------------ |
-| fenodes                    | --                | Doris FE http 地址             |
+| fenodes                    | --                | Doris FE http 地址 + FE http_port,例如：192.168.1.123:8030 ，多个地址用英文状态逗号隔开 |
 | table.identifier           | --                | Doris 表名，如：db1.tbl1                                 |
 | username                            | --            | 访问Doris的用户名                                            |
 | password                        | --            | 访问Doris的密码                                              |

--- a/docs/zh-CN/extending-doris/spark-doris-connector.md
+++ b/docs/zh-CN/extending-doris/spark-doris-connector.md
@@ -186,7 +186,7 @@ kafkaSource.selectExpr("CAST(key AS STRING)", "CAST(value as STRING)")
 | doris.deserialize.arrow.async    | false             | 是否支持异步转换Arrow格式到spark-doris-connector迭代所需的RowBatch                 |
 | doris.deserialize.queue.size     | 64                | 异步转换Arrow格式的内部处理队列，当doris.deserialize.arrow.async为true时生效        |
 | doris.write.fields               | --                 | 指定写入Doris表的字段或者字段顺序，多列之间使用逗号分隔。<br />默认写入时要按照Doris表字段顺序写入全部字段。 |
-| sink.batch.size | 100             | 单次写BE的最大行数,为了避免高频导入引发tablet版本数超过默认的500，建议设大这个参数值 |
+| sink.batch.size | 100             | 单次写doris的最大行数,为了避免高频导入引发tablet版本数超过默认的500，建议设大这个参数值 |
 
 ### SQL 和 Dataframe 专有配置
 

--- a/docs/zh-CN/extending-doris/spark-doris-connector.md
+++ b/docs/zh-CN/extending-doris/spark-doris-connector.md
@@ -186,7 +186,7 @@ kafkaSource.selectExpr("CAST(key AS STRING)", "CAST(value as STRING)")
 | doris.deserialize.arrow.async    | false             | 是否支持异步转换Arrow格式到spark-doris-connector迭代所需的RowBatch                 |
 | doris.deserialize.queue.size     | 64                | 异步转换Arrow格式的内部处理队列，当doris.deserialize.arrow.async为true时生效        |
 | doris.write.fields               | --                 | 指定写入Doris表的字段或者字段顺序，多列之间使用逗号分隔。<br />默认写入时要按照Doris表字段顺序写入全部字段。 |
-| sink.batch.size | 100             | 单次写doris的最大行数,为了避免高频导入引发tablet版本数超过默认的500，建议设大这个参数值 |
+| sink.batch.size | 100             | 单次写doris的最大行数,为了避免高频导入引发tablet版本数超过默认的500，建议设大这个参数值，**注意**，需要注意的是原先写入只用了doris.batch.size这个参数，升级版本之后注意修改 |
 
 ### SQL 和 Dataframe 专有配置
 

--- a/docs/zh-CN/extending-doris/spark-doris-connector.md
+++ b/docs/zh-CN/extending-doris/spark-doris-connector.md
@@ -186,7 +186,7 @@ kafkaSource.selectExpr("CAST(key AS STRING)", "CAST(value as STRING)")
 | doris.deserialize.arrow.async    | false             | 是否支持异步转换Arrow格式到spark-doris-connector迭代所需的RowBatch                 |
 | doris.deserialize.queue.size     | 64                | 异步转换Arrow格式的内部处理队列，当doris.deserialize.arrow.async为true时生效        |
 | doris.write.fields               | --                 | 指定写入Doris表的字段或者字段顺序，多列之间使用逗号分隔。<br />默认写入时要按照Doris表字段顺序写入全部字段。 |
-| sink.batch.size | 100             | 单次写doris的最大行数,为了避免高频导入引发tablet版本数超过默认的500，建议设大这个参数值，**注意**，需要注意的是原先写入只用了doris.batch.size这个参数，升级版本之后注意修改 |
+| sink.batch.size | 100             | 单次写doris的最大行数,为了避免高频导入引发tablet版本数超过默认的500，建议设大这个参数值，**注意**，原来写入使用了读取数据的参数：`doris.batch.size`。 升级版本后注意修改成这个新参数 |
 
 ### SQL 和 Dataframe 专有配置
 

--- a/docs/zh-CN/extending-doris/spark-doris-connector.md
+++ b/docs/zh-CN/extending-doris/spark-doris-connector.md
@@ -186,7 +186,7 @@ kafkaSource.selectExpr("CAST(key AS STRING)", "CAST(value as STRING)")
 | doris.deserialize.arrow.async    | false             | 是否支持异步转换Arrow格式到spark-doris-connector迭代所需的RowBatch                 |
 | doris.deserialize.queue.size     | 64                | 异步转换Arrow格式的内部处理队列，当doris.deserialize.arrow.async为true时生效        |
 | doris.write.fields               | --                 | 指定写入Doris表的字段或者字段顺序，多列之间使用逗号分隔。<br />默认写入时要按照Doris表字段顺序写入全部字段。 |
-| sink.batch.size | 100             | 单次写doris的最大行数,为了避免高频导入引发tablet版本数超过默认的500，建议设大这个参数值，**注意**，原来写入使用了读取数据的参数：`doris.batch.size`。 升级版本后注意修改成这个新参数 |
+| sink.batch.size | 10000           | 单次写doris的最大行数,为了避免高频导入引发tablet版本数超过默认的500，如果你的数据低频、量小可以适当将这个参数值设小，**注意**，原来写入使用了读取数据的参数：`doris.batch.size`。 升级版本后注意修改成这个新参数 |
 
 ### SQL 和 Dataframe 专有配置
 

--- a/docs/zh-CN/extending-doris/spark-doris-connector.md
+++ b/docs/zh-CN/extending-doris/spark-doris-connector.md
@@ -186,6 +186,7 @@ kafkaSource.selectExpr("CAST(key AS STRING)", "CAST(value as STRING)")
 | doris.deserialize.arrow.async    | false             | 是否支持异步转换Arrow格式到spark-doris-connector迭代所需的RowBatch                 |
 | doris.deserialize.queue.size     | 64                | 异步转换Arrow格式的内部处理队列，当doris.deserialize.arrow.async为true时生效        |
 | doris.write.fields               | --                 | 指定写入Doris表的字段或者字段顺序，多列之间使用逗号分隔。<br />默认写入时要按照Doris表字段顺序写入全部字段。 |
+| sink.batch.size | 100             | 单次写BE的最大行数,为了避免高频导入引发tablet版本数超过默认的500，建议设大这个参数值 |
 
 ### SQL 和 Dataframe 专有配置
 

--- a/extension/spark-doris-connector/src/main/java/org/apache/doris/spark/cfg/ConfigurationOptions.java
+++ b/extension/spark-doris-connector/src/main/java/org/apache/doris/spark/cfg/ConfigurationOptions.java
@@ -53,6 +53,9 @@ public interface ConfigurationOptions {
     String DORIS_BATCH_SIZE = "doris.batch.size";
     int DORIS_BATCH_SIZE_DEFAULT = 1024;
 
+    String SINK_BATCH_SIZE = "sink.batch.size";
+    int SINK_BATCH_SIZE_DEFAULT = 100;
+    
     String DORIS_EXEC_MEM_LIMIT = "doris.exec.mem.limit";
     long DORIS_EXEC_MEM_LIMIT_DEFAULT = 2147483648L;
 

--- a/extension/spark-doris-connector/src/main/java/org/apache/doris/spark/cfg/ConfigurationOptions.java
+++ b/extension/spark-doris-connector/src/main/java/org/apache/doris/spark/cfg/ConfigurationOptions.java
@@ -54,7 +54,7 @@ public interface ConfigurationOptions {
     int DORIS_BATCH_SIZE_DEFAULT = 1024;
 
     String SINK_BATCH_SIZE = "sink.batch.size";
-    int SINK_BATCH_SIZE_DEFAULT = 100;
+    int SINK_BATCH_SIZE_DEFAULT = 10000;
     
     String DORIS_EXEC_MEM_LIMIT = "doris.exec.mem.limit";
     long DORIS_EXEC_MEM_LIMIT_DEFAULT = 2147483648L;

--- a/extension/spark-doris-connector/src/main/scala/org/apache/doris/spark/sql/DorisSourceProvider.scala
+++ b/extension/spark-doris-connector/src/main/scala/org/apache/doris/spark/sql/DorisSourceProvider.scala
@@ -59,13 +59,7 @@ private[sql] class DorisSourceProvider extends DataSourceRegister
     // init stream loader
     val dorisStreamLoader = new DorisStreamLoad(sparkSettings)
 
-    var maxRowCount:Int = 0
-    val sink_batch_size:String = sparkSettings.getProperty(ConfigurationOptions.SINK_BATCH_SIZE)
-    if(sink_batch_size != null ) {
-      maxRowCount = sparkSettings.getIntegerProperty(ConfigurationOptions.SINK_BATCH_SIZE, ConfigurationOptions.SINK_BATCH_SIZE_DEFAULT)
-    } else {
-      maxRowCount = sparkSettings.getIntegerProperty(ConfigurationOptions.DORIS_BATCH_SIZE, ConfigurationOptions.DORIS_BATCH_SIZE_DEFAULT)
-    }
+    val maxRowCount: Int = sparkSettings.getIntegerProperty(ConfigurationOptions.SINK_BATCH_SIZE, ConfigurationOptions.SINK_BATCH_SIZE_DEFAULT)
     val maxRetryTimes = sparkSettings.getIntegerProperty(ConfigurationOptions.DORIS_REQUEST_RETRIES, ConfigurationOptions.DORIS_REQUEST_RETRIES_DEFAULT)
 
     data.rdd.foreachPartition(partition => {

--- a/extension/spark-doris-connector/src/main/scala/org/apache/doris/spark/sql/DorisSourceProvider.scala
+++ b/extension/spark-doris-connector/src/main/scala/org/apache/doris/spark/sql/DorisSourceProvider.scala
@@ -59,7 +59,13 @@ private[sql] class DorisSourceProvider extends DataSourceRegister
     // init stream loader
     val dorisStreamLoader = new DorisStreamLoad(sparkSettings)
 
-    val maxRowCount: Int = settings.getIntegerProperty(ConfigurationOptions.SINK_BATCH_SIZE, ConfigurationOptions.SINK_BATCH_SIZE_DEFAULT)
+    var maxRowCount:Int = 0
+    val sink_batch_size:String = sparkSettings.getProperty(ConfigurationOptions.SINK_BATCH_SIZE)
+    if(sink_batch_size != null ) {
+      maxRowCount = sparkSettings.getIntegerProperty(ConfigurationOptions.SINK_BATCH_SIZE, ConfigurationOptions.SINK_BATCH_SIZE_DEFAULT)
+    } else {
+      maxRowCount = sparkSettings.getIntegerProperty(ConfigurationOptions.DORIS_BATCH_SIZE, ConfigurationOptions.DORIS_BATCH_SIZE_DEFAULT)
+    }
     val maxRetryTimes = sparkSettings.getIntegerProperty(ConfigurationOptions.DORIS_REQUEST_RETRIES, ConfigurationOptions.DORIS_REQUEST_RETRIES_DEFAULT)
 
     data.rdd.foreachPartition(partition => {

--- a/extension/spark-doris-connector/src/main/scala/org/apache/doris/spark/sql/DorisSourceProvider.scala
+++ b/extension/spark-doris-connector/src/main/scala/org/apache/doris/spark/sql/DorisSourceProvider.scala
@@ -59,7 +59,7 @@ private[sql] class DorisSourceProvider extends DataSourceRegister
     // init stream loader
     val dorisStreamLoader = new DorisStreamLoad(sparkSettings)
 
-    val maxRowCount = sparkSettings.getIntegerProperty(ConfigurationOptions.DORIS_BATCH_SIZE, ConfigurationOptions.DORIS_BATCH_SIZE_DEFAULT)
+    val maxRowCount: Int = settings.getIntegerProperty(ConfigurationOptions.SINK_BATCH_SIZE, ConfigurationOptions.SINK_BATCH_SIZE_DEFAULT)
     val maxRetryTimes = sparkSettings.getIntegerProperty(ConfigurationOptions.DORIS_REQUEST_RETRIES, ConfigurationOptions.DORIS_REQUEST_RETRIES_DEFAULT)
 
     data.rdd.foreachPartition(partition => {

--- a/extension/spark-doris-connector/src/main/scala/org/apache/doris/spark/sql/DorisStreamLoadSink.scala
+++ b/extension/spark-doris-connector/src/main/scala/org/apache/doris/spark/sql/DorisStreamLoadSink.scala
@@ -32,7 +32,13 @@ private[sql] class DorisStreamLoadSink(sqlContext: SQLContext, settings: SparkSe
 
   private val logger: Logger = LoggerFactory.getLogger(classOf[DorisStreamLoadSink].getName)
   @volatile private var latestBatchId = -1L
-  val maxRowCount: Int = settings.getIntegerProperty(ConfigurationOptions.SINK_BATCH_SIZE, ConfigurationOptions.SINK_BATCH_SIZE_DEFAULT)
+  var maxRowCount:Int = 0
+  val sink_batch_size:String = settings.getProperty(ConfigurationOptions.SINK_BATCH_SIZE)
+  if(sink_batch_size != null ) {
+    maxRowCount = settings.getIntegerProperty(ConfigurationOptions.SINK_BATCH_SIZE, ConfigurationOptions.SINK_BATCH_SIZE_DEFAULT)
+  } else {
+    maxRowCount = settings.getIntegerProperty(ConfigurationOptions.DORIS_BATCH_SIZE, ConfigurationOptions.DORIS_BATCH_SIZE_DEFAULT)
+  }
   val maxRetryTimes: Int = settings.getIntegerProperty(ConfigurationOptions.DORIS_REQUEST_RETRIES, ConfigurationOptions.DORIS_REQUEST_RETRIES_DEFAULT)
   val dorisStreamLoader: DorisStreamLoad = CachedDorisStreamLoadClient.getOrCreate(settings)
 

--- a/extension/spark-doris-connector/src/main/scala/org/apache/doris/spark/sql/DorisStreamLoadSink.scala
+++ b/extension/spark-doris-connector/src/main/scala/org/apache/doris/spark/sql/DorisStreamLoadSink.scala
@@ -32,13 +32,7 @@ private[sql] class DorisStreamLoadSink(sqlContext: SQLContext, settings: SparkSe
 
   private val logger: Logger = LoggerFactory.getLogger(classOf[DorisStreamLoadSink].getName)
   @volatile private var latestBatchId = -1L
-  var maxRowCount:Int = 0
-  val sink_batch_size:String = settings.getProperty(ConfigurationOptions.SINK_BATCH_SIZE)
-  if(sink_batch_size != null ) {
-    maxRowCount = settings.getIntegerProperty(ConfigurationOptions.SINK_BATCH_SIZE, ConfigurationOptions.SINK_BATCH_SIZE_DEFAULT)
-  } else {
-    maxRowCount = settings.getIntegerProperty(ConfigurationOptions.DORIS_BATCH_SIZE, ConfigurationOptions.DORIS_BATCH_SIZE_DEFAULT)
-  }
+  val maxRowCount: Int = settings.getIntegerProperty(ConfigurationOptions.SINK_BATCH_SIZE, ConfigurationOptions.SINK_BATCH_SIZE_DEFAULT)
   val maxRetryTimes: Int = settings.getIntegerProperty(ConfigurationOptions.DORIS_REQUEST_RETRIES, ConfigurationOptions.DORIS_REQUEST_RETRIES_DEFAULT)
   val dorisStreamLoader: DorisStreamLoad = CachedDorisStreamLoadClient.getOrCreate(settings)
 

--- a/extension/spark-doris-connector/src/main/scala/org/apache/doris/spark/sql/DorisStreamLoadSink.scala
+++ b/extension/spark-doris-connector/src/main/scala/org/apache/doris/spark/sql/DorisStreamLoadSink.scala
@@ -32,7 +32,7 @@ private[sql] class DorisStreamLoadSink(sqlContext: SQLContext, settings: SparkSe
 
   private val logger: Logger = LoggerFactory.getLogger(classOf[DorisStreamLoadSink].getName)
   @volatile private var latestBatchId = -1L
-  val maxRowCount: Int = settings.getIntegerProperty(ConfigurationOptions.DORIS_BATCH_SIZE, ConfigurationOptions.DORIS_BATCH_SIZE_DEFAULT)
+  val maxRowCount: Int = settings.getIntegerProperty(ConfigurationOptions.SINK_BATCH_SIZE, ConfigurationOptions.SINK_BATCH_SIZE_DEFAULT)
   val maxRetryTimes: Int = settings.getIntegerProperty(ConfigurationOptions.DORIS_REQUEST_RETRIES, ConfigurationOptions.DORIS_REQUEST_RETRIES_DEFAULT)
   val dorisStreamLoader: DorisStreamLoad = CachedDorisStreamLoadClient.getOrCreate(settings)
 


### PR DESCRIPTION
The parameters for writing and reading control records are separated, and the writing parameters are the same as those of the flink connector

## Proposed changes

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Code refactor (Modify the code structure, format the code, etc...)
- [ ] Optimization. Including functional usability improvements and performance improvements.
- [ ] Dependency. Such as changes related to third-party components.
- [ ] Other.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have created an issue on (Fix #ISSUE) and described the bug/feature there in detail
- [ ] Compiling and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If these changes need document changes, I have updated the document
- [ ] Any dependent changes have been merged

## Further comments

If this is a relatively large or complex change, kick off the discussion at dev@doris.apache.org by explaining why you chose the solution you did and what alternatives you considered, etc...
