### PR TITLE
[Bug]Fix BE coredump when manual compaction task is triggered

### DIFF
--- a/be/src/http/action/compaction_action.cpp
+++ b/be/src/http/action/compaction_action.cpp
@@ -49,7 +49,7 @@ Status CompactionAction::_check_param(HttpRequest* req, uint64_t* tablet_id,
     if (req_tablet_id == "" && req_schema_hash == "") {
         return Status::OK();
     }
-    
+
     try {
         *tablet_id = std::stoull(req_tablet_id);
         *schema_hash = std::stoul(req_schema_hash);

--- a/be/src/http/action/compaction_action.cpp
+++ b/be/src/http/action/compaction_action.cpp
@@ -217,7 +217,7 @@ Status CompactionAction::_handle_run_status_compaction(HttpRequest* req, std::st
 OLAPStatus CompactionAction::_execute_compaction_callback(TabletSharedPtr tablet,
                                                           const std::string& compaction_type) {
     std::shared_ptr<CumulativeCompactionPolicy> cumulative_compaction_policy =
-            _update_cumulative_compaction_policy();
+            _create_cumulative_compaction_policy();
     if (tablet->get_cumulative_compaction_policy() == nullptr ||
         tablet->get_cumulative_compaction_policy()->name() != cumulative_compaction_policy->name()) {
         tablet->set_cumulative_compaction_policy(cumulative_compaction_policy);
@@ -283,7 +283,7 @@ void CompactionAction::handle(HttpRequest* req) {
     }
 }
 
-std::shared_ptr<CumulativeCompactionPolicy> CompactionAction::_update_cumulative_compaction_policy() {
+std::shared_ptr<CumulativeCompactionPolicy> CompactionAction::_create_cumulative_compaction_policy() {
     std::string current_policy = "";
     {
         std::lock_guard<std::mutex> lock(*config::get_mutable_string_config_lock());

--- a/be/src/http/action/compaction_action.cpp
+++ b/be/src/http/action/compaction_action.cpp
@@ -49,7 +49,7 @@ Status CompactionAction::_check_param(HttpRequest* req, uint64_t* tablet_id,
     if (req_tablet_id == "" && req_schema_hash == "") {
         return Status::OK();
     }
-
+    
     try {
         *tablet_id = std::stoull(req_tablet_id);
         *schema_hash = std::stoul(req_schema_hash);
@@ -216,6 +216,13 @@ Status CompactionAction::_handle_run_status_compaction(HttpRequest* req, std::st
 
 OLAPStatus CompactionAction::_execute_compaction_callback(TabletSharedPtr tablet,
                                                           const std::string& compaction_type) {
+    std::shared_ptr<CumulativeCompactionPolicy> cumulative_compaction_policy =
+            _update_cumulative_compaction_policy();
+    if (tablet->get_cumulative_compaction_policy() == nullptr ||
+        tablet->get_cumulative_compaction_policy()->name() != cumulative_compaction_policy->name()) {
+        tablet->set_cumulative_compaction_policy(cumulative_compaction_policy);
+    }
+
     OLAPStatus status = OLAP_SUCCESS;
     if (compaction_type == PARAM_COMPACTION_BASE) {
         std::string tracker_label = "CompactionAction:BaseCompaction:" + std::to_string(syscall(__NR_gettid));
@@ -274,5 +281,21 @@ void CompactionAction::handle(HttpRequest* req) {
             HttpChannel::send_reply(req, HttpStatus::OK, json_result);
         }
     }
+}
+
+std::shared_ptr<CumulativeCompactionPolicy> CompactionAction::_update_cumulative_compaction_policy() {
+    std::string current_policy = "";
+    {
+        std::lock_guard<std::mutex> lock(*config::get_mutable_string_config_lock());
+        current_policy = config::cumulative_compaction_policy;
+    }
+    boost::to_upper(current_policy);
+
+    if (current_policy == CUMULATIVE_SIZE_BASED_POLICY) {
+        // check size_based cumulative compaction config
+        StorageEngine::instance()->check_cumulative_compaction_config();
+    }
+
+    return CumulativeCompactionPolicyFactory::create_cumulative_compaction_policy(current_policy);
 }
 } // end namespace doris

--- a/be/src/http/action/compaction_action.h
+++ b/be/src/http/action/compaction_action.h
@@ -66,6 +66,8 @@ private:
     /// check param and fetch tablet_id and schema_hash from req
     Status _check_param(HttpRequest* req, uint64_t* tablet_id, uint32_t* schema_hash);
 
+    std::shared_ptr<CumulativeCompactionPolicy> _update_cumulative_compaction_policy();
+
 private:
     CompactionActionType _type;
 

--- a/be/src/http/action/compaction_action.h
+++ b/be/src/http/action/compaction_action.h
@@ -66,7 +66,7 @@ private:
     /// check param and fetch tablet_id and schema_hash from req
     Status _check_param(HttpRequest* req, uint64_t* tablet_id, uint32_t* schema_hash);
 
-    std::shared_ptr<CumulativeCompactionPolicy> _update_cumulative_compaction_policy();
+    std::shared_ptr<CumulativeCompactionPolicy> _create_cumulative_compaction_policy();
 
 private:
     CompactionActionType _type;

--- a/be/src/olap/olap_server.cpp
+++ b/be/src/olap/olap_server.cpp
@@ -203,7 +203,7 @@ void StorageEngine::_disk_stat_monitor_thread_callback() {
     } while (!_stop_background_threads_latch.wait_for(MonoDelta::FromSeconds(interval)));
 }
 
-void StorageEngine::_check_cumulative_compaction_config() {
+void StorageEngine::check_cumulative_compaction_config() {
     int64_t size_based_promotion_size = config::cumulative_size_based_promotion_size_mbytes;
     int64_t size_based_promotion_min_size = config::cumulative_size_based_promotion_min_size_mbytes;
     int64_t size_based_compaction_lower_bound_size =
@@ -435,7 +435,7 @@ std::vector<TabletSharedPtr> StorageEngine::_generate_compaction_tasks(
         _cumulative_compaction_policy->name() != current_policy) {
         if (current_policy == CUMULATIVE_SIZE_BASED_POLICY) {
             // check size_based cumulative compaction config
-            _check_cumulative_compaction_config();
+            check_cumulative_compaction_config();
         }
         _cumulative_compaction_policy =
                 CumulativeCompactionPolicyFactory::create_cumulative_compaction_policy(

--- a/be/src/olap/storage_engine.h
+++ b/be/src/olap/storage_engine.h
@@ -188,6 +188,9 @@ public:
     std::shared_ptr<MemTracker> tablet_mem_tracker() { return _tablet_mem_tracker; }
     std::shared_ptr<MemTracker> schema_change_mem_tracker() { return _schema_change_mem_tracker; }
 
+    // check cumulative compaction config
+    void check_cumulative_compaction_config();
+
 private:
     // Instance should be inited from `static open()`
     // MUST NOT be called in other circumstances.
@@ -217,9 +220,6 @@ private:
     // All these xxx_callback() functions are for Background threads
     // unused rowset monitor thread
     void _unused_rowset_monitor_thread_callback();
-
-    // check cumulative compaction config
-    void _check_cumulative_compaction_config();
 
     // garbage sweep thread process function. clear snapshot and trash folder
     void _garbage_sweeper_thread_callback();

--- a/be/src/olap/tablet.h
+++ b/be/src/olap/tablet.h
@@ -250,6 +250,15 @@ public:
     void set_clone_occurred(bool clone_occurred) { _is_clone_occurred = clone_occurred; }
     bool get_clone_occurred() { return _is_clone_occurred; }
 
+    void set_cumulative_compaction_policy(
+            std::shared_ptr<CumulativeCompactionPolicy> cumulative_compaction_policy) {
+        _cumulative_compaction_policy = cumulative_compaction_policy;
+    }
+
+    std::shared_ptr<CumulativeCompactionPolicy> get_cumulative_compaction_policy() {
+        return _cumulative_compaction_policy;
+    }
+
 private:
     OLAPStatus _init_once_action();
     void _print_missed_versions(const std::vector<Version>& missed_versions) const;


### PR DESCRIPTION
## Proposed changes

Fix #7259
BE coredump will occurs when manual compaction task is triggered by http interface. 

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Code refactor (Modify the code structure, format the code, etc...)
- [ ] Optimization. Including functional usability improvements and performance improvements.
- [ ] Dependency. Such as changes related to third-party components.
- [ ] Other.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have created an issue on (Fix #7259) and described the bug/feature there in detail
- [ ] Compiling and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If these changes need document changes, I have updated the document
- [ ] Any dependent changes have been merged
