### PR TITLE
[BUG] Fix an error when fetch string type field may cause malformed packet error

### DIFF
--- a/be/src/exprs/anyval_util.h
+++ b/be/src/exprs/anyval_util.h
@@ -312,7 +312,7 @@ public:
         }
     }
 
-    static StringVal from_buffer(FunctionContext* ctx, const char* ptr, int len) {
+    static StringVal from_buffer(FunctionContext* ctx, const char* ptr, int64_t len) {
         StringVal result(ctx, len);
         memcpy(result.ptr, ptr, len);
         return result;
@@ -323,7 +323,7 @@ public:
         return val;
     }
 
-    static StringVal from_buffer_temp(FunctionContext* ctx, const char* ptr, int len) {
+    static StringVal from_buffer_temp(FunctionContext* ctx, const char* ptr, int64_t len) {
         StringVal result = StringVal::create_temp_string_val(ctx, len);
         memcpy(result.ptr, ptr, len);
         return result;

--- a/be/src/runtime/buffer_control_block.cpp
+++ b/be/src/runtime/buffer_control_block.cpp
@@ -53,12 +53,7 @@ void GetResultBatchCtx::on_data(const std::unique_ptr<TFetchDataResult>& t_resul
         ThriftSerializer ser(false, 4096);
         st = ser.serialize(&t_result->result_batch, &len, &buf);
         if (st.ok()) {
-            if (resp_in_attachment) {
-                // TODO(yangzhengguo) this is just for compatible with old version, this should be removed in the release 0.15
-                cntl->response_attachment().append(buf, len);
-            } else {
-                result->set_row_batch(std::string((const char*)buf, len));
-            }
+            result->set_row_batch(std::string((const char*)buf, len));
             result->set_packet_seq(packet_seq);
             result->set_eos(eos);
         } else {

--- a/be/src/runtime/buffer_control_block.h
+++ b/be/src/runtime/buffer_control_block.h
@@ -44,22 +44,17 @@ class PFetchDataResult;
 
 struct GetResultBatchCtx {
     brpc::Controller* cntl = nullptr;
-    // In version 0.15, we change brpc client from jprotobuf to grpc.
-    // And the response data is moved from rpc attachment to protobuf boby.
-    // This variables is for backwards compatibility when upgrading Doris.
-    // If set to true, the response data is still transferred as attachment.
-    // If set to false, the response data is transferred in protobuf body.
-    bool resp_in_attachment = true;
     PFetchDataResult* result = nullptr;
     google::protobuf::Closure* done = nullptr;
 
-    GetResultBatchCtx(brpc::Controller* cntl_, bool resp_in_attachment_, PFetchDataResult* result_,
+    GetResultBatchCtx(brpc::Controller* cntl_, PFetchDataResult* result_,
                       google::protobuf::Closure* done_)
-            : cntl(cntl_), resp_in_attachment(resp_in_attachment_), result(result_), done(done_) {}
+            : cntl(cntl_), result(result_), done(done_) {}
 
     void on_failure(const Status& status);
     void on_close(int64_t packet_seq, QueryStatistics* statistics = nullptr);
-    void on_data(const std::unique_ptr<TFetchDataResult>& t_result, int64_t packet_seq, bool eos = false);
+    void on_data(const std::unique_ptr<TFetchDataResult>& t_result, int64_t packet_seq,
+                 bool eos = false);
 };
 
 // buffer used for result customer and producer

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -195,9 +195,7 @@ void PInternalServiceImpl<T>::fetch_data(google::protobuf::RpcController* cntl_b
                                          const PFetchDataRequest* request, PFetchDataResult* result,
                                          google::protobuf::Closure* done) {
     brpc::Controller* cntl = static_cast<brpc::Controller*>(cntl_base);
-    bool resp_in_attachment =
-            request->has_resp_in_attachment() ? request->resp_in_attachment() : true;
-    GetResultBatchCtx* ctx = new GetResultBatchCtx(cntl, resp_in_attachment, result, done);
+    GetResultBatchCtx* ctx = new GetResultBatchCtx(cntl, result, done);
     _exec_env->result_mgr()->fetch_data(request->finst_id(), ctx);
 }
 

--- a/be/src/udf/udf.cpp
+++ b/be/src/udf/udf.cpp
@@ -369,7 +369,7 @@ bool StringVal::resize(FunctionContext* ctx, int64_t new_len) {
     return false;
 }
 
-StringVal StringVal::copy_from(FunctionContext* ctx, const uint8_t* buf, size_t len) {
+StringVal StringVal::copy_from(FunctionContext* ctx, const uint8_t* buf, int64_t len) {
     StringVal result(ctx, len);
     if (!result.is_null) {
         memcpy(result.ptr, buf, len);
@@ -382,7 +382,7 @@ StringVal StringVal::create_temp_string_val(FunctionContext* ctx, int64_t len) {
     return StringVal((uint8_t*)ctx->impl()->string_result().c_str(), len);
 }
 
-void StringVal::append(FunctionContext* ctx, const uint8_t* buf, size_t buf_len) {
+void StringVal::append(FunctionContext* ctx, const uint8_t* buf, int64_t buf_len) {
     if (UNLIKELY(len + buf_len > StringVal::MAX_LENGTH)) {
         ctx->set_error(
                 "Concatenated string length larger than allowed limit of "
@@ -398,8 +398,8 @@ void StringVal::append(FunctionContext* ctx, const uint8_t* buf, size_t buf_len)
     }
 }
 
-void StringVal::append(FunctionContext* ctx, const uint8_t* buf, size_t buf_len,
-                       const uint8_t* buf2, size_t buf2_len) {
+void StringVal::append(FunctionContext* ctx, const uint8_t* buf, int64_t buf_len,
+                       const uint8_t* buf2, int64_t buf2_len) {
     if (UNLIKELY(len + buf_len + buf2_len > StringVal::MAX_LENGTH)) {
         ctx->set_error(
                 "Concatenated string length larger than allowed limit of "

--- a/be/src/udf/udf.h
+++ b/be/src/udf/udf.h
@@ -638,14 +638,14 @@ struct StringVal : public AnyVal {
     /// Will create a new StringVal with the given dimension and copy the data from the
     /// parameters. In case of an error will return a nullptr string and set an error on the
     /// function context.
-    static StringVal copy_from(FunctionContext* ctx, const uint8_t* buf, size_t len);
+    static StringVal copy_from(FunctionContext* ctx, const uint8_t* buf, int64_t len);
 
     /// Append the passed buffer to this StringVal. Reallocate memory to fit the buffer. If
     /// the memory allocation becomes too large, will set an error on FunctionContext and
     /// return a nullptr string.
-    void append(FunctionContext* ctx, const uint8_t* buf, size_t len);
-    void append(FunctionContext* ctx, const uint8_t* buf, size_t len, const uint8_t* buf2,
-                size_t buf2_len);
+    void append(FunctionContext* ctx, const uint8_t* buf, int64_t len);
+    void append(FunctionContext* ctx, const uint8_t* buf, int64_t len, const uint8_t* buf2,
+                int64_t buf2_len);
 };
 
 struct DecimalV2Val : public AnyVal {

--- a/be/src/util/mysql_row_buffer.cpp
+++ b/be/src/util/mysql_row_buffer.cpp
@@ -90,19 +90,19 @@ void MysqlRowBuffer::close_dynamic_mode() {
     }
 }
 
-int MysqlRowBuffer::reserve(int size) {
+int MysqlRowBuffer::reserve(int64_t size) {
     if (size < 0) {
         LOG(ERROR) << "alloc memory failed. size = " << size;
         return -1;
     }
 
-    int need_size = size + (_pos - _buf);
+    int64_t need_size = size + (_pos - _buf);
 
     if (need_size <= _buf_size) {
         return 0;
     }
 
-    int alloc_size = std::max(need_size, _buf_size * 2);
+    int64_t alloc_size = std::max(need_size, _buf_size * 2);
     char* new_buf = new (std::nothrow) char[alloc_size];
 
     if (nullptr == new_buf) {
@@ -324,7 +324,7 @@ int MysqlRowBuffer::push_decimal(const DecimalV2Value& data, int round_scale) {
     return 0;
 }
 
-int MysqlRowBuffer::push_string(const char* str, int length) {
+int MysqlRowBuffer::push_string(const char* str, int64_t length) {
     // 9 for length pack max, 1 for sign, other for digits
     if (nullptr == str) {
         LOG(ERROR) << "input string is nullptr.";
@@ -364,7 +364,7 @@ int MysqlRowBuffer::push_null() {
     return 0;
 }
 
-char* MysqlRowBuffer::reserved(int size) {
+char* MysqlRowBuffer::reserved(int64_t size) {
     int ret = reserve(size);
 
     if (0 != ret) {

--- a/be/src/util/mysql_row_buffer.h
+++ b/be/src/util/mysql_row_buffer.h
@@ -25,7 +25,7 @@ namespace doris {
 /**
 // Now only support text protocol
  * helper for construct MySQL send row
- * The MYSQL protocal:
+ * The MYSQL protocol:
  *
  * | flag | (length) | value | flag | (length) | value | ......
  * <--------A column--------><--------A column--------><-.....->
@@ -33,9 +33,9 @@ namespace doris {
  * The flag means value's length or null value:
  * If value is nullptr, flag is 251
  * If value's length < 251, flag is the value's length
- * If 251 <= value's length < 65536, flag is 252 and the next two byte is length
- * If 65536 <= value's length < 16777216 , flag is 253 and the next three byte is length
- * If 16777216 <= value's length, flag is 254 and the next eighth byte is length
+ * If 251 <= value's length < 65536, flag is 252 and the next two bytes is length
+ * If 65536 <= value's length < 16777216 , flag is 253 and the next three bytes is length
+ * If 16777216 <= value's length, flag is 254 and the next eighth bytes is length
  *
  * the code example:
  *     mrb.push_null();
@@ -71,16 +71,16 @@ public:
     int push_time(double data);
     int push_datetime(const DateTimeValue& data);
     int push_decimal(const DecimalV2Value& data, int round_scale);
-    int push_string(const char* str, int length);
+    int push_string(const char* str, int64_t length);
     int push_null();
 
     // this function reserved size, change the pos step size, return old pos
     // Becareful when use the returned pointer.
-    char* reserved(int size);
+    char* reserved(int64_t size);
 
     const char* buf() const { return _buf; }
     const char* pos() const { return _pos; }
-    int length() const { return _pos - _buf; }
+    int64_t length() const { return _pos - _buf; }
 
     /**
      * Why?
@@ -117,11 +117,11 @@ public:
     void close_dynamic_mode();
 
 private:
-    int reserve(int size);
+    int reserve(int64_t size);
 
     char* _pos;
     char* _buf;
-    int _buf_size;
+    int64_t _buf_size;
     char _default_buf[4096];
 
     int _dynamic_mode;

--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/MysqlChannel.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/MysqlChannel.java
@@ -33,7 +33,7 @@ import java.nio.channels.SocketChannel;
 public class MysqlChannel {
     // max length which one MySQL physical can hold, if one logical packet is bigger than this,
     // one packet will split to many packets
-    protected static final int MAX_PHYSICAL_PACKET_LENGTH = 0xffffff - 1;
+    protected static final int MAX_PHYSICAL_PACKET_LENGTH = 0xffffff;
     // MySQL packet header length
     protected static final int PACKET_HEADER_LEN = 4;
     // logger for this class

--- a/gensrc/script/doris_builtins_functions.py
+++ b/gensrc/script/doris_builtins_functions.py
@@ -1193,7 +1193,7 @@ visible_functions = [
     [['bitmap_and_not'], 'BITMAP', ['BITMAP','BITMAP'],
         '_ZN5doris15BitmapFunctions14bitmap_and_notEPN9doris_udf15FunctionContextERKNS1_9StringValES6_',
         '', '', '', ''],
-    [['bitmap_to_string'], 'VARCHAR', ['BITMAP'],
+    [['bitmap_to_string'], 'STRING', ['BITMAP'],
         '_ZN5doris15BitmapFunctions16bitmap_to_stringEPN9doris_udf15FunctionContextERKNS1_9StringValE',
         '', '', 'vec', ''],
     [['bitmap_from_string'], 'BITMAP', ['VARCHAR'],


### PR DESCRIPTION
## Proposed changes

1. Fix an error when fetch string type field may cause malformed packet error.
   This is because of a const field MAX_PHYSICAL_PACKET_LENGTH  in fe should be 2^24 -1,
   but it is set as 2^24 -2 by mistake.
2. Fix bitmap_to_string may fail when the result is larger than 2G

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Code refactor (Modify the code structure, format the code, etc...)
- [ ] Optimization. Including functional usability improvements and performance improvements.
- [ ] Dependency. Such as changes related to third-party components.
- [ ] Other.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have created an issue on (Fix #7261) and described the bug/feature there in detail
- [ ] Compiling and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If these changes need document changes, I have updated the document
- [ ] Any dependent changes have been merged

## Further comments

If this is a relatively large or complex change, kick off the discussion at dev@doris.apache.org by explaining why you chose the solution you did and what alternatives you considered, etc...
