### PR TITLE
[Improvement](Lateral view) Support lateral view based on subquery 

### DIFF
--- a/fe/fe-core/src/main/cup/sql_parser.cup
+++ b/fe/fe-core/src/main/cup/sql_parser.cup
@@ -4066,10 +4066,16 @@ table_ref_list ::=
   ;
 
 table_ref ::=
-  base_table_ref:b
-  {: RESULT = b; :}
-  | inline_view_ref:s
-  {: RESULT = s; :}
+  base_table_ref:b opt_lateral_view_ref_list:lateralViewRefList
+  {:
+    b.setLateralViewRefs(lateralViewRefList);
+    RESULT = b;
+  :}
+  | inline_view_ref:s opt_lateral_view_ref_list:lateralViewRefList
+  {:
+    s.setLateralViewRefs(lateralViewRefList);
+    RESULT = s;
+  :}
   ;
 
 inline_view_ref ::=
@@ -4095,9 +4101,8 @@ base_table_ref_list ::=
 
 base_table_ref ::=
     table_name:name opt_partition_names:partitionNames opt_table_alias:alias opt_common_hints:commonHints
-    opt_lateral_view_ref_list:lateralViewRefList
     {:
-        RESULT = new TableRef(name, alias, partitionNames, commonHints, lateralViewRefList);
+        RESULT = new TableRef(name, alias, partitionNames, commonHints);
     :}
     ;
 

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/Analyzer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/Analyzer.java
@@ -1221,6 +1221,9 @@ public class Analyzer {
         for (ExprId conjunctId : remainConjunctIds) {
             Expr e = globalState.conjuncts.get(conjunctId);
             Preconditions.checkState(e != null);
+            if (e.isAuxExpr()) {
+                continue;
+            }
             result.add(e);
         }
         return result;

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/BaseTableRef.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/BaseTableRef.java
@@ -68,20 +68,10 @@ public class BaseTableRef extends TableRef {
         name.analyze(analyzer);
         desc = analyzer.registerTableRef(this);
         isAnalyzed = true;  // true that we have assigned desc
+        analyzeLateralViewRef(analyzer);
         analyzeJoin(analyzer);
         analyzeSortHints();
         analyzeHints();
-        analyzeLateralViewRef(analyzer);
-    }
-
-    private void analyzeLateralViewRef(Analyzer analyzer) throws UserException {
-        if (lateralViewRefs == null) {
-            return;
-        }
-        for (LateralViewRef lateralViewRef : lateralViewRefs) {
-            lateralViewRef.setRelatedTable(this);
-            lateralViewRef.analyze(analyzer);
-        }
     }
 }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/FunctionCallExpr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/FunctionCallExpr.java
@@ -170,6 +170,7 @@ public class FunctionCallExpr extends Expr {
         }
         this.isMergeAggFn = other.isMergeAggFn;
         fn = other.fn;
+        this.isTableFnCall = other.isTableFnCall;
     }
 
     public String parseJsonDataType(boolean useKeyCheck) throws AnalysisException {

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/InlineViewRef.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/InlineViewRef.java
@@ -223,6 +223,9 @@ public class InlineViewRef extends TableRef {
             LOG.debug("inline view " + getUniqueAlias() + " baseTblSmap: " + baseTblSmap.debugString());
         }
 
+        // anlayzeLateralViewRefs
+        analyzeLateralViewRef(analyzer);
+
         // Now do the remaining join analysis
         analyzeJoin(analyzer);
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/LateralViewRef.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/LateralViewRef.java
@@ -20,7 +20,6 @@ package org.apache.doris.analysis;
 import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.FunctionSet;
 import org.apache.doris.catalog.InlineView;
-import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.catalog.Type;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.Config;
@@ -40,7 +39,7 @@ public class LateralViewRef extends TableRef {
     private Expr expr;
     private String viewName;
     private String columnName;
-    private BaseTableRef relatedTableRef;
+    private TableRef relatedTableRef;
 
     // after analyzed
     private FunctionCallExpr fnExpr;
@@ -55,7 +54,7 @@ public class LateralViewRef extends TableRef {
         this.columnName = columnName;
     }
 
-    public void setRelatedTable(BaseTableRef relatedTableRef) {
+    public void setRelatedTable(TableRef relatedTableRef) {
         this.relatedTableRef = relatedTableRef;
     }
 
@@ -73,10 +72,6 @@ public class LateralViewRef extends TableRef {
             return;
         }
         Preconditions.checkNotNull(relatedTableRef);
-        // analyze table
-        if (!(relatedTableRef.getTable() instanceof OlapTable)) {
-            throw new AnalysisException("Only doris table could be exploded");
-        }
         // analyze function and slot
         if (!(expr instanceof FunctionCallExpr)) {
             throw new AnalysisException("Only support function call expr in lateral view");

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/TableRef.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/TableRef.java
@@ -142,11 +142,10 @@ public class TableRef implements ParseNode, Writable {
     }
 
     public TableRef(TableName name, String alias, PartitionNames partitionNames) {
-        this(name, alias, partitionNames, null, null);
+        this(name, alias, partitionNames, null);
     }
 
-    public TableRef(TableName name, String alias, PartitionNames partitionNames, ArrayList<String> commonHints,
-                    ArrayList<LateralViewRef> lateralViewRefs) {
+    public TableRef(TableName name, String alias, PartitionNames partitionNames, ArrayList<String> commonHints) {
         this.name = name;
         if (alias != null) {
             aliases_ = new String[]{alias};
@@ -156,7 +155,6 @@ public class TableRef implements ParseNode, Writable {
         }
         this.partitionNames = partitionNames;
         this.commonHints = commonHints;
-        this.lateralViewRefs = lateralViewRefs;
         isAnalyzed = false;
     }
     // Only used to clone
@@ -333,8 +331,22 @@ public class TableRef implements ParseNode, Writable {
         return sortColumn;
     }
 
+    public void setLateralViewRefs(ArrayList<LateralViewRef> lateralViewRefs) {
+        this.lateralViewRefs = lateralViewRefs;
+    }
+
     public ArrayList<LateralViewRef> getLateralViewRefs() {
         return lateralViewRefs;
+    }
+
+    protected void analyzeLateralViewRef(Analyzer analyzer) throws UserException {
+        if (lateralViewRefs == null) {
+            return;
+        }
+        for (LateralViewRef lateralViewRef : lateralViewRefs) {
+            lateralViewRef.setRelatedTable(this);
+            lateralViewRef.analyze(analyzer);
+        }
     }
 
     protected void analyzeSortHints() throws AnalysisException {

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/SingleNodePlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/SingleNodePlanner.java
@@ -1866,7 +1866,6 @@ public class SingleNodePlanner {
         PlanNode scanNode = null;
         if (tblRef instanceof BaseTableRef) {
             scanNode = createScanNode(analyzer, tblRef, selectStmt);
-            return scanNode;
         }
         if (tblRef instanceof InlineViewRef) {
             scanNode = createInlineViewPlan(analyzer, (InlineViewRef) tblRef);

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/SingleNodePlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/SingleNodePlanner.java
@@ -1862,19 +1862,23 @@ public class SingleNodePlanner {
      * table ref is not implemented.
      */
     private PlanNode createTableRefNode(Analyzer analyzer, TableRef tblRef, SelectStmt selectStmt)
-            throws UserException, AnalysisException {
+            throws UserException {
+        PlanNode scanNode = null;
         if (tblRef instanceof BaseTableRef) {
-            PlanNode scanNode = createScanNode(analyzer, tblRef, selectStmt);
-            List<LateralViewRef> lateralViewRefs = tblRef.getLateralViewRefs();
-            if (lateralViewRefs != null && lateralViewRefs.size() != 0) {
-                return createTableFunctionNode(analyzer, scanNode, lateralViewRefs, selectStmt);
-            }
+            scanNode = createScanNode(analyzer, tblRef, selectStmt);
             return scanNode;
         }
         if (tblRef instanceof InlineViewRef) {
-            return createInlineViewPlan(analyzer, (InlineViewRef) tblRef);
+            scanNode = createInlineViewPlan(analyzer, (InlineViewRef) tblRef);
         }
-        throw new UserException("unknown TableRef node");
+        if (scanNode == null) {
+            throw new UserException("unknown TableRef node");
+        }
+        List<LateralViewRef> lateralViewRefs = tblRef.getLateralViewRefs();
+        if (lateralViewRefs == null || lateralViewRefs.size() == 0) {
+            return scanNode;
+        }
+        return createTableFunctionNode(analyzer, scanNode, lateralViewRefs, selectStmt);
     }
 
     private PlanNode createTableFunctionNode(Analyzer analyzer, PlanNode inputNode,

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/TableFunctionNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/TableFunctionNode.java
@@ -19,7 +19,6 @@ package org.apache.doris.planner;
 
 import org.apache.doris.analysis.Analyzer;
 import org.apache.doris.analysis.Expr;
-import org.apache.doris.analysis.FunctionCallExpr;
 import org.apache.doris.analysis.LateralViewRef;
 import org.apache.doris.analysis.SelectStmt;
 import org.apache.doris.analysis.SlotId;
@@ -34,6 +33,7 @@ import org.apache.doris.thrift.TTableFunctionNode;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -41,7 +41,7 @@ import java.util.stream.Collectors;
 public class TableFunctionNode extends PlanNode {
 
     private List<LateralViewRef> lateralViewRefs;
-    private List<FunctionCallExpr> fnCallExprList;
+    private ArrayList<Expr> fnCallExprList;
     private List<TupleId> lateralViewTupleIds;
 
     // The output slot ids of TableFunctionNode
@@ -103,7 +103,20 @@ public class TableFunctionNode extends PlanNode {
     @Override
     public void init(Analyzer analyzer) throws UserException {
         super.init(analyzer);
-        fnCallExprList = lateralViewRefs.stream().map(e -> e.getFnExpr()).collect(Collectors.toList());
+        fnCallExprList = new ArrayList<>(lateralViewRefs.stream().map(e -> e.getFnExpr()).collect(Collectors.toList()));
+        /*
+        When the expression of the lateral view involves the column of the subquery,
+        the column needs to be rewritten as the real column in the subquery through childrenSmap.
+        Example:
+          select e1 from (select a from t1) tmp1 lateral view explode_split(a, ",") tmp2 as e1
+          Slot 'a' is originally linked to tuple 'tmp1'. <tmp1.a>
+          But tmp1 is just a virtual and unreal inline view tuple.
+          So we need to push down 'a' and hang it on the real tuple 't1'. <t1.a>
+         */
+        outputSmap = getCombinedChildSmap();
+        fnCallExprList = Expr.substituteList(fnCallExprList, outputSmap, analyzer, false);
+        // end
+
         computeStats(analyzer);
     }
 
@@ -118,8 +131,8 @@ public class TableFunctionNode extends PlanNode {
     public String getNodeExplainString(String prefix, TExplainLevel detailLevel) {
         StringBuilder output = new StringBuilder();
         output.append(prefix + "table function: ");
-        for (FunctionCallExpr fnExpr : fnCallExprList) {
-            output.append(fnExpr.toSqlImpl() + " ");
+        for (Expr fnExpr : fnCallExprList) {
+            output.append(fnExpr.toSql() + " ");
         }
         output.append("\n");
 
@@ -132,12 +145,6 @@ public class TableFunctionNode extends PlanNode {
         if (detailLevel == TExplainLevel.BRIEF) {
             return output.toString();
         }
-
-        output.append(prefix + "tuple id: ");
-        for (TupleId tupleId : tupleIds) {
-            output.append(tupleId.asInt() + " ");
-        }
-        output.append("\n");
 
         output.append(prefix + "output slot id: ");
         for (SlotId slotId : outputSlotIds) {


### PR DESCRIPTION
## Proposed changes
[Improvement](Lateral view) Support lateral view based on subquery (#6746)
issue: #6746

Support lateral view of the result column in subquery.
For example:
  ```
  select e1 from (select k2 as a from test_explode group by a) tmp1
  lateral view explode_split(a, ",") tmp2 as e1;
  ```
The lateral view will parse the inline view column
and put the table function node above the subquery.

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Code refactor (Modify the code structure, format the code, etc...)
- [ ] Optimization. Including functional usability improvements and performance improvements.
- [ ] Dependency. Such as changes related to third-party components.
- [ ] Other.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have created an issue on (Fix #6746) and described the bug/feature there in detail
- [x] Compiling and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If these changes need document changes, I have updated the document
- [ ] Any dependent changes have been merged

## Further comments

WIP unit test
