### PR TITLE
[revert] "clean too many bdbje log"

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/journal/bdbje/BDBEnvironment.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/journal/bdbje/BDBEnvironment.java
@@ -127,7 +127,6 @@ public class BDBEnvironment {
         environmentConfig.setAllowCreate(true);
         environmentConfig.setCachePercent(MEMORY_CACHE_PERCENT);
         environmentConfig.setLockTimeout(Config.bdbje_lock_timeout_second, TimeUnit.SECONDS);
-        environmentConfig.setConfigParam(EnvironmentConfig.RESERVED_DISK, "1073741824");
         if (isElectable) {
             Durability durability = new Durability(getSyncPolicy(Config.master_sync_policy), 
                     getSyncPolicy(Config.replica_sync_policy), getAckPolicy(Config.replica_ack_policy));


### PR DESCRIPTION
Reverts apache/incubator-doris#7273
Because there is no EnvironmentConfig.RESERVED_DISK.