### PR TITLE
Support setting balance_load_score_threshold for storage media

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/clone/BackendLoadStatistic.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/BackendLoadStatistic.java
@@ -232,7 +232,7 @@ public class BackendLoadStatistic {
             }
 
             if (Math.abs(pathStat.getUsedPercent() - avgUsedPercent)
-                    / avgUsedPercent > Config.balance_load_score_threshold) {
+                    / avgUsedPercent > ClusterLoadStatistic.getLoadScoreThreshold(medium)) {
                 if (pathStat.getUsedPercent() > avgUsedPercent) {
                     pathStat.setClazz(Classification.HIGH);
                     highCounter++;

--- a/fe/fe-core/src/main/java/org/apache/doris/clone/ClusterLoadStatistic.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/ClusterLoadStatistic.java
@@ -167,7 +167,7 @@ public class ClusterLoadStatistic {
                 continue;
             }
 
-            if (Math.abs(beStat.getLoadScore(medium) - avgLoadScore) / avgLoadScore > Config.balance_load_score_threshold) {
+            if (Math.abs(beStat.getLoadScore(medium) - avgLoadScore) / avgLoadScore > getLoadScoreThreshold(medium)) {
                 if (beStat.getLoadScore(medium) > avgLoadScore) {
                     beStat.setClazz(medium, Classification.HIGH);
                     highCounter++;
@@ -183,6 +183,16 @@ public class ClusterLoadStatistic {
 
         LOG.info("classify backend by load. medium: {} avg load score: {}. low/mid/high: {}/{}/{}",
                 medium, avgLoadScore, lowCounter, midCounter, highCounter);
+    }
+
+    public static double getLoadScoreThreshold(TStorageMedium medium) {
+        if (medium == TStorageMedium.HDD && Config.balance_load_score_threshold_hdd > 0) {
+            return Config.balance_load_score_threshold_hdd;
+        } else if (medium == TStorageMedium.SSD && Config.balance_load_score_threshold_ssd > 0) {
+            return Config.balance_load_score_threshold_ssd;
+        } else {
+            return Config.balance_load_score_threshold;
+        }
     }
 
     private static void sortBeStats(List<BackendLoadStatistic> beStats, TStorageMedium medium) {

--- a/fe/fe-core/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/Config.java
@@ -1110,6 +1110,20 @@ public class Config extends ConfigBase {
     public static double balance_load_score_threshold = 0.1; // 10%
 
     /**
+     * same as balance_load_score_threshold, just for hdd medium.
+     * the value 0 means that this configuration does not work
+     */
+    @ConfField(mutable = true, masterOnly = true)
+    public static double balance_load_score_threshold_hdd = 0;
+
+    /**
+     * same as balance_load_score_threshold, just for ssd medium.
+     * the value 0 means that this configuration does not work
+     */
+    @ConfField(mutable = true, masterOnly = true)
+    public static double balance_load_score_threshold_ssd = 0;
+
+    /**
      * if set to true, TabletScheduler will not do balance.
      */
     @ConfField(mutable = true, masterOnly = true)


### PR DESCRIPTION
## Proposed changes

when there are two storage media, ssd and hdd, different balance_load_score_threshold can be set for each storage medium.

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Code refactor (Modify the code structure, format the code, etc...)
- [ ] Optimization. Including functional usability improvements and performance improvements.
- [ ] Dependency. Such as changes related to third-party components.
- [ ] Other.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x ] I have created an issue on (Fix #7368) and described the bug/feature there in detail
- [ ] Compiling and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If these changes need document changes, I have updated the document
- [ ] Any dependent changes have been merged

## Further comments

If this is a relatively large or complex change, kick off the discussion at dev@doris.apache.org by explaining why you chose the solution you did and what alternatives you considered, etc...
