### PR TITLE
[fix](cache) Some view stmt cannot be obtained when view in the subquery and add cache key UT

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/InlineViewRef.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/InlineViewRef.java
@@ -429,6 +429,10 @@ public class InlineViewRef extends TableRef {
         return view;
     }
 
+    public QueryStmt getQueryStmt() {
+        return queryStmt;
+    }
+
     @Override
     public String tableRefToSql() {
         // Enclose the alias in quotes if Hive cannot parse it without quotes.

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/cache/CacheAnalyzer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/cache/CacheAnalyzer.java
@@ -217,7 +217,7 @@ public class CacheAnalyzer {
         latestTable.Debug();
 
         addAllViewStmt(selectStmt);
-        String allViewExpandStmtListStr = StringUtils.join(allViewStmtSet, ",");
+        String allViewExpandStmtListStr = StringUtils.join(allViewStmtSet, "|");
 
         if (now == 0) {
             now = nowtime();
@@ -459,6 +459,7 @@ public class CacheAnalyzer {
                     addAllViewStmt(inlineViewRef.getViewStmt());
                     allViewStmtSet.add(inlineViewRef.getView().getInlineViewDef());
                 }
+                addAllViewStmt(inlineViewRef.getQueryStmt());
             }
         }
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/cache/PartitionCache.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/cache/PartitionCache.java
@@ -62,8 +62,8 @@ public class PartitionCache extends Cache {
         return nokeyStmt;
     }
 
-    private String getSqlWithViewStmt() {
-        return nokeyStmt.toSql() + allViewExpandStmtListStr;
+    public String getSqlWithViewStmt() {
+        return nokeyStmt.toSql() + "|" + allViewExpandStmtListStr;
     }
 
     public PartitionCache(TUniqueId queryId, SelectStmt selectStmt) {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/cache/SqlCache.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/cache/SqlCache.java
@@ -40,8 +40,8 @@ public class SqlCache extends Cache {
         this.allViewExpandStmtListStr = allViewExpandStmtListStr;
     }
 
-    private String getSqlWithViewStmt() {
-        return selectStmt.toSql() + allViewExpandStmtListStr;
+    public String getSqlWithViewStmt() {
+        return selectStmt.toSql() + "|" + allViewExpandStmtListStr;
     }
 
     public InternalService.PFetchCacheResult getCacheData(Status status) {


### PR DESCRIPTION

## Proposed changes

issue: #7374 
1. Some view stmt cannot be obtained when view in the subquery
2. Add cache key UT

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Code refactor (Modify the code structure, format the code, etc...)
- [ ] Optimization. Including functional usability improvements and performance improvements.
- [ ] Dependency. Such as changes related to third-party components.
- [ ] Other.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have created an issue on (Fix #ISSUE) and described the bug/feature there in detail
- [x] Compiling and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If these changes need document changes, I have updated the document
- [ ] Any dependent changes have been merged

## Further comments

If this is a relatively large or complex change, kick off the discussion at dev@doris.apache.org by explaining why you chose the solution you did and what alternatives you considered, etc...
