### PR TITLE
[feature] sql-block-rule: add partition_num, tablet_num, cardinality in SqlBlockRule to block big/slow sql

### DIFF
--- a/docs/en/administrator-guide/block-rule/sql-block.md
+++ b/docs/en/administrator-guide/block-rule/sql-block.md
@@ -26,15 +26,23 @@ under the License.
 
 # SQL Block Rule
 
-Support SQL block rule by user level, by regex way to deny specify SQL.
 This function is only used to limit the query statement, and does not limit the execution of the explain statement.
+Support SQL block rule by user level:
+
+1. by regex way to deny specify SQL
+
+2. by setting partitionNum, tabletNum, cardinality, check whether a sql reaches one of the limitations
+   - partitionNum, tabletNum, cardinality could be set together, and once reach one of them, the sql will be blocked.
 
 ## Rule
 
 SQL block rule CRUD
 - create SQL block rule
-    - sql：Regex pattern，Special characters need to be translated
-    - sqlHash: Sql hash value, Used to match exactly, We print it in fe.audit.log，This parameter is the only choice between sql and sql, If you give a null value, it is an empty string not null
+    - sql：Regex pattern，Special characters need to be translated, "NULL" by default
+    - sqlHash: Sql hash value, Used to match exactly, We print it in fe.audit.log, This parameter is the only choice between sql and sql, "NULL" by default
+    - partitionNum: Max number of partitions will be scanned by a scan node, 0L by default
+    - tabletNum: Max number of tablets will be scanned by a scan node, 0L by default
+    - cardinality: An inaccurate number of scan rows of a scan node, 0L by default
     - global: Whether global(all users)is in effect, false by default
     - enable：Whether to enable block rule，true by default
 ```sql
@@ -51,15 +59,27 @@ When we execute the sql that we defined in the rule just now, an exception error
 mysql> select * from order_analysis;
 ERROR 1064 (HY000): errCode = 2, detailMessage = sql match regex sql block rule: order_analysis_rule
 ```
+
+```sql
+CREATE SQL_BLOCK_RULE test_rule2 PROPERTIES("partitionNum" = "30", "cardinality"="10000000000","global"="false","enable"="true")
+```
+
 - show configured SQL block rules, or show all rules if you do not specify a rule name
 
 ```sql
 SHOW SQL_BLOCK_RULE [FOR RULE_NAME]
 ```
-- alter SQL block rule，Allows changes sql/global/enable anyone
+- alter SQL block rule，Allows changes sql/sqlHash/global/enable/partitionNum/tabletNum/cardinality anyone
+  - sql and sqlHash cannot be set both. It means if sql or sqlHash is set in a rule, another property will never be allowed to be altered
+  - sql/sqlHash and partitionNum/tabletNum/cardinality cannot be set together. For example, partitionNum is set in a rule, then sql or sqlHash will never be allowed to be altered.
 ```sql
 ALTER SQL_BLOCK_RULE test_rule PROPERTIES("sql"="select \\* from test_table","enable"="true")
 ```
+
+```
+ALTER SQL_BLOCK_RULE test_rule2 PROPERTIES("partitionNum" = "10","tabletNum"="300","enable"="true")
+```
+
 - drop SQL block rule，Support multiple rules, separated by `,`
 ```sql
 DROP SQL_BLOCK_RULE test_rule1,test_rule2

--- a/docs/en/administrator-guide/block-rule/sql-block.md
+++ b/docs/en/administrator-guide/block-rule/sql-block.md
@@ -31,8 +31,8 @@ Support SQL block rule by user level:
 
 1. by regex way to deny specify SQL
 
-2. by setting partitionNum, tabletNum, cardinality, check whether a sql reaches one of the limitations
-   - partitionNum, tabletNum, cardinality could be set together, and once reach one of them, the sql will be blocked.
+2. by setting partition_num, tablet_num, cardinality, check whether a sql reaches one of the limitations
+   - partition_num, tablet_num, cardinality could be set together, and once reach one of them, the sql will be blocked.
 
 ## Rule
 
@@ -40,8 +40,8 @@ SQL block rule CRUD
 - create SQL block rule
     - sql：Regex pattern，Special characters need to be translated, "NULL" by default
     - sqlHash: Sql hash value, Used to match exactly, We print it in fe.audit.log, This parameter is the only choice between sql and sql, "NULL" by default
-    - partitionNum: Max number of partitions will be scanned by a scan node, 0L by default
-    - tabletNum: Max number of tablets will be scanned by a scan node, 0L by default
+    - partition_num: Max number of partitions will be scanned by a scan node, 0L by default
+    - tablet_num: Max number of tablets will be scanned by a scan node, 0L by default
     - cardinality: An inaccurate number of scan rows of a scan node, 0L by default
     - global: Whether global(all users)is in effect, false by default
     - enable：Whether to enable block rule，true by default
@@ -60,8 +60,9 @@ mysql> select * from order_analysis;
 ERROR 1064 (HY000): errCode = 2, detailMessage = sql match regex sql block rule: order_analysis_rule
 ```
 
+- create test_rule2, limits the maximum number of scanning partitions to 30 and the maximum scanning cardinality to 10 billion rows. As shown in the following example:
 ```sql
-CREATE SQL_BLOCK_RULE test_rule2 PROPERTIES("partitionNum" = "30", "cardinality"="10000000000","global"="false","enable"="true")
+CREATE SQL_BLOCK_RULE test_rule2 PROPERTIES("partition_num" = "30", "cardinality"="10000000000","global"="false","enable"="true")
 ```
 
 - show configured SQL block rules, or show all rules if you do not specify a rule name
@@ -69,15 +70,15 @@ CREATE SQL_BLOCK_RULE test_rule2 PROPERTIES("partitionNum" = "30", "cardinality"
 ```sql
 SHOW SQL_BLOCK_RULE [FOR RULE_NAME]
 ```
-- alter SQL block rule，Allows changes sql/sqlHash/global/enable/partitionNum/tabletNum/cardinality anyone
+- alter SQL block rule，Allows changes sql/sqlHash/global/enable/partition_num/tablet_num/cardinality anyone
   - sql and sqlHash cannot be set both. It means if sql or sqlHash is set in a rule, another property will never be allowed to be altered
-  - sql/sqlHash and partitionNum/tabletNum/cardinality cannot be set together. For example, partitionNum is set in a rule, then sql or sqlHash will never be allowed to be altered.
+  - sql/sqlHash and partition_num/tablet_num/cardinality cannot be set together. For example, partition_num is set in a rule, then sql or sqlHash will never be allowed to be altered.
 ```sql
 ALTER SQL_BLOCK_RULE test_rule PROPERTIES("sql"="select \\* from test_table","enable"="true")
 ```
 
 ```
-ALTER SQL_BLOCK_RULE test_rule2 PROPERTIES("partitionNum" = "10","tabletNum"="300","enable"="true")
+ALTER SQL_BLOCK_RULE test_rule2 PROPERTIES("partition_num" = "10","tablet_num"="300","enable"="true")
 ```
 
 - drop SQL block rule，Support multiple rules, separated by `,`

--- a/docs/zh-CN/administrator-guide/block-rule/sql-block.md
+++ b/docs/zh-CN/administrator-guide/block-rule/sql-block.md
@@ -26,15 +26,23 @@ under the License.
 
 # SQL黑名单
 
-支持按用户配置SQL黑名单，通过正则匹配的方式拒绝指定SQL。
 该功能仅用于限制查询语句，并且不会限制 explain 语句的执行。
+支持按用户配置SQL黑名单:
+
+1. 通过正则匹配的方式拒绝指定SQL
+
+2. 通过设置partitionNum, tabletNum, cardinality, 检查一个查询是否达到其中一个限制
+  - partitionNum, tabletNum, cardinality 可以一起设置，一旦一个查询达到其中一个限制，查询将会被拦截
 
 ## 规则
 
 对SQL规则增删改查
 - 创建SQL阻止规则
-    - sql：匹配规则(基于正则匹配,特殊字符需要转译)，可选
-    - sqlHash: sql hash值，用于完全匹配，我们会在`fe.audit.log`打印这个值，可选，这个参数和sql只能二选一,如果给空值，是空字符串不是null
+    - sql：匹配规则(基于正则匹配,特殊字符需要转译)，可选，默认值为 "NULL"
+    - sqlHash: sql hash值，用于完全匹配，我们会在`fe.audit.log`打印这个值，可选，这个参数和sql只能二选一，默认值为 "NULL"
+    - partitionNum: 一个扫描节点会扫描的最大partition数量，默认值为0L
+    - tabletNum: 一个扫描节点会扫描的最大扽tablet数量，默认值为0L
+    - cardinality: 一个扫描节点粗略的扫描行数，默认值为0L
     - global：是否全局(所有用户)生效，默认为false  
     - enable：是否开启阻止规则，默认为true
 ```sql
@@ -51,15 +59,27 @@ PROPERTIES(
 mysql> select * from order_analysis;
 ERROR 1064 (HY000): errCode = 2, detailMessage = sql match regex sql block rule: order_analysis_rule
 ```
+
+```sql
+CREATE SQL_BLOCK_RULE test_rule2 PROPERTIES("partitionNum" = "30", "cardinality"="10000000000","global"="false","enable"="true")
+```
+
 - 查看已配置的SQL阻止规则，不指定规则名则为查看所有规则
 
 ```sql
 SHOW SQL_BLOCK_RULE [FOR RULE_NAME]
 ```
-- 修改SQL阻止规则，允许对sql/global/enable等每一项进行修改
+- 修改SQL阻止规则，允许对sql/sqlHash/partitionNum/tabletNum/cardinality/global/enable等每一项进行修改
+  - sql 和 sqlHash 不能同时被设置。这意味着，如果一个rule设置了sql或者sqlHash，则另一个属性将无法被修改
+  - sql/sqlHash 和 partitionNum/tabletNum/cardinality 不能同时被设置。举个例子，如果一个rule设置了partitionNum，那么sql或者sqlHash将无法被修改
 ```sql
-ALTER SQL_BLOCK_RULE test_rule PROPERTIES("sql"="select * from order_analysis","enable"="true")
+ALTER SQL_BLOCK_RULE test_rule PROPERTIES("sql"="select \\* from test_table","enable"="true")
 ```
+
+```
+ALTER SQL_BLOCK_RULE test_rule2 PROPERTIES("partitionNum" = "10","tabletNum"="300","enable"="true")
+```
+
 - 删除SQL阻止规则，支持多规则，以`,`隔开
 ```
 DROP SQL_BLOCK_RULE test_rule1,test_rule2

--- a/docs/zh-CN/administrator-guide/block-rule/sql-block.md
+++ b/docs/zh-CN/administrator-guide/block-rule/sql-block.md
@@ -31,8 +31,8 @@ under the License.
 
 1. 通过正则匹配的方式拒绝指定SQL
 
-2. 通过设置partitionNum, tabletNum, cardinality, 检查一个查询是否达到其中一个限制
-  - partitionNum, tabletNum, cardinality 可以一起设置，一旦一个查询达到其中一个限制，查询将会被拦截
+2. 通过设置partition_num, tablet_num, cardinality, 检查一个查询是否达到其中一个限制
+  - partition_num, tablet_num, cardinality 可以一起设置，一旦一个查询达到其中一个限制，查询将会被拦截
 
 ## 规则
 
@@ -40,8 +40,8 @@ under the License.
 - 创建SQL阻止规则
     - sql：匹配规则(基于正则匹配,特殊字符需要转译)，可选，默认值为 "NULL"
     - sqlHash: sql hash值，用于完全匹配，我们会在`fe.audit.log`打印这个值，可选，这个参数和sql只能二选一，默认值为 "NULL"
-    - partitionNum: 一个扫描节点会扫描的最大partition数量，默认值为0L
-    - tabletNum: 一个扫描节点会扫描的最大扽tablet数量，默认值为0L
+    - partition_num: 一个扫描节点会扫描的最大partition数量，默认值为0L
+    - tablet_num: 一个扫描节点会扫描的最大tablet数量，默认值为0L
     - cardinality: 一个扫描节点粗略的扫描行数，默认值为0L
     - global：是否全局(所有用户)生效，默认为false  
     - enable：是否开启阻止规则，默认为true
@@ -60,8 +60,9 @@ mysql> select * from order_analysis;
 ERROR 1064 (HY000): errCode = 2, detailMessage = sql match regex sql block rule: order_analysis_rule
 ```
 
+- 创建 test_rule2，将最大扫描的分区数量限制在30个，最大扫描基数限制在100亿行，示例如下：
 ```sql
-CREATE SQL_BLOCK_RULE test_rule2 PROPERTIES("partitionNum" = "30", "cardinality"="10000000000","global"="false","enable"="true")
+CREATE SQL_BLOCK_RULE test_rule2 PROPERTIES("partition_num" = "30", "cardinality"="10000000000","global"="false","enable"="true")
 ```
 
 - 查看已配置的SQL阻止规则，不指定规则名则为查看所有规则
@@ -69,15 +70,15 @@ CREATE SQL_BLOCK_RULE test_rule2 PROPERTIES("partitionNum" = "30", "cardinality"
 ```sql
 SHOW SQL_BLOCK_RULE [FOR RULE_NAME]
 ```
-- 修改SQL阻止规则，允许对sql/sqlHash/partitionNum/tabletNum/cardinality/global/enable等每一项进行修改
+- 修改SQL阻止规则，允许对sql/sqlHash/partition_num/tablet_num/cardinality/global/enable等每一项进行修改
   - sql 和 sqlHash 不能同时被设置。这意味着，如果一个rule设置了sql或者sqlHash，则另一个属性将无法被修改
-  - sql/sqlHash 和 partitionNum/tabletNum/cardinality 不能同时被设置。举个例子，如果一个rule设置了partitionNum，那么sql或者sqlHash将无法被修改
+  - sql/sqlHash 和 partition_num/tablet_num/cardinality 不能同时被设置。举个例子，如果一个rule设置了partition_num，那么sql或者sqlHash将无法被修改
 ```sql
 ALTER SQL_BLOCK_RULE test_rule PROPERTIES("sql"="select \\* from test_table","enable"="true")
 ```
 
 ```
-ALTER SQL_BLOCK_RULE test_rule2 PROPERTIES("partitionNum" = "10","tabletNum"="300","enable"="true")
+ALTER SQL_BLOCK_RULE test_rule2 PROPERTIES("partition_num" = "10","tablet_num"="300","enable"="true")
 ```
 
 - 删除SQL阻止规则，支持多规则，以`,`隔开

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/AlterSqlBlockRuleStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/AlterSqlBlockRuleStmt.java
@@ -18,10 +18,13 @@
 package org.apache.doris.analysis;
 
 import org.apache.doris.catalog.Catalog;
+import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.ErrorReport;
 import org.apache.doris.common.UserException;
 import org.apache.doris.common.util.PrintableMap;
+import org.apache.doris.common.util.SqlBlockUtil;
+import org.apache.doris.common.util.Util;
 import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.qe.ConnectContext;
 
@@ -36,6 +39,12 @@ public class AlterSqlBlockRuleStmt extends DdlStmt {
     private String sql;
 
     private String sqlHash;
+
+    private Long partitionNum;
+
+    private Long tabletNum;
+
+    private Long cardinality;
 
     private Boolean global;
 
@@ -60,9 +69,18 @@ public class AlterSqlBlockRuleStmt extends DdlStmt {
         setProperties(properties);
     }
 
-    private void setProperties(Map<String, String> properties) {
-        this.sql = properties.get(CreateSqlBlockRuleStmt.SQL_PROPERTY);
-        this.sqlHash = properties.get(CreateSqlBlockRuleStmt.SQL_HASH_PROPERTY);
+    private void setProperties(Map<String, String> properties) throws AnalysisException {
+        this.sql = properties.getOrDefault(CreateSqlBlockRuleStmt.SQL_PROPERTY, CreateSqlBlockRuleStmt.STRING_NOT_SET);
+        this.sqlHash = properties.getOrDefault(CreateSqlBlockRuleStmt.SQL_HASH_PROPERTY, CreateSqlBlockRuleStmt.STRING_NOT_SET);
+        String partitionNumString = properties.get(CreateSqlBlockRuleStmt.SCANNED_PARTITION_NUM);
+        String tabletNumString = properties.get(CreateSqlBlockRuleStmt.SCANNED_TABLET_NUM);
+        String cardinalityString = properties.get(CreateSqlBlockRuleStmt.SCANNED_CARDINALITY);
+
+        SqlBlockUtil.checkSqlAndSqlHashSetBoth(sql, sqlHash);
+        SqlBlockUtil.checkSqlAndLimitationsSetBoth(sql, sqlHash, partitionNumString, tabletNumString, cardinalityString);
+        this.partitionNum = Util.getLongPropertyOrDefault(partitionNumString, 0L, null, CreateSqlBlockRuleStmt.SCANNED_PARTITION_NUM + " should be a long");
+        this.tabletNum = Util.getLongPropertyOrDefault(tabletNumString, 0L, null, CreateSqlBlockRuleStmt.SCANNED_TABLET_NUM + " should be a long");
+        this.cardinality = Util.getLongPropertyOrDefault(cardinalityString, 0L, null, CreateSqlBlockRuleStmt.SCANNED_CARDINALITY + " should be a long");
         // allow null, represents no modification
         String globalStr = properties.get(CreateSqlBlockRuleStmt.GLOBAL_PROPERTY);
         this.global = StringUtils.isNotEmpty(globalStr) ? Boolean.parseBoolean(globalStr) : null;
@@ -76,6 +94,18 @@ public class AlterSqlBlockRuleStmt extends DdlStmt {
 
     public String getSql() {
         return sql;
+    }
+
+    public Long getPartitionNum() {
+        return partitionNum;
+    }
+
+    public Long getTabletNum() {
+        return tabletNum;
+    }
+
+    public Long getCardinality() {
+        return cardinality;
     }
 
     public Boolean getGlobal() {

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateSqlBlockRuleStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateSqlBlockRuleStmt.java
@@ -24,13 +24,12 @@ import org.apache.doris.common.ErrorReport;
 import org.apache.doris.common.FeNameFormat;
 import org.apache.doris.common.UserException;
 import org.apache.doris.common.util.PrintableMap;
+import org.apache.doris.common.util.SqlBlockUtil;
 import org.apache.doris.common.util.Util;
 import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.qe.ConnectContext;
 
 import com.google.common.collect.ImmutableSet;
-
-import org.apache.commons.lang3.StringUtils;
 
 import java.util.Map;
 import java.util.Optional;
@@ -52,15 +51,29 @@ public class CreateSqlBlockRuleStmt extends DdlStmt {
 
     public static final String SQL_HASH_PROPERTY = "sqlHash";
 
+    public static final String SCANNED_PARTITION_NUM = "partitionNum";
+
+    public static final String SCANNED_TABLET_NUM = "tabletNum";
+
+    public static final String SCANNED_CARDINALITY = "cardinality";
+
     public static final String GLOBAL_PROPERTY = "global";
 
     public static final String ENABLE_PROPERTY = "enable";
+
+    public static final String STRING_NOT_SET = SqlBlockUtil.STRING_DEFAULT;
 
     private final String ruleName;
 
     private String sql;
 
     private String sqlHash;
+
+    private Long partitionNum;
+
+    private Long tabletNum;
+
+    private Long cardinality;
 
     // whether effective global, default is false
     private boolean global;
@@ -77,6 +90,9 @@ public class CreateSqlBlockRuleStmt extends DdlStmt {
             .add(SQL_HASH_PROPERTY)
             .add(GLOBAL_PROPERTY)
             .add(ENABLE_PROPERTY)
+            .add(SCANNED_PARTITION_NUM)
+            .add(SCANNED_TABLET_NUM)
+            .add(SCANNED_CARDINALITY)
             .build();
 
     public CreateSqlBlockRuleStmt(String ruleName, Map<String, String> properties) {
@@ -98,11 +114,18 @@ public class CreateSqlBlockRuleStmt extends DdlStmt {
     }
 
     private void setProperties(Map<String, String> properties) throws UserException {
-        this.sql = properties.get(SQL_PROPERTY);
-        this.sqlHash = properties.get(SQL_HASH_PROPERTY);
-        if ((StringUtils.isNotEmpty(sql) && StringUtils.isNotEmpty(sqlHash)) || (StringUtils.isEmpty(sql) && StringUtils.isEmpty(sqlHash))) {
-            throw new AnalysisException("Only one sql or sqlHash can be configured");
-        }
+        this.sql = properties.getOrDefault(SQL_PROPERTY, STRING_NOT_SET);
+        this.sqlHash = properties.getOrDefault(SQL_HASH_PROPERTY, STRING_NOT_SET);
+        String partitionNumString = properties.get(SCANNED_PARTITION_NUM);
+        String tabletNumString = properties.get(SCANNED_TABLET_NUM);
+        String cardinalityString = properties.get(SCANNED_CARDINALITY);
+
+        SqlBlockUtil.checkSqlAndSqlHashSetBoth(sql, sqlHash);
+        SqlBlockUtil.checkPropertiesValidate(sql, sqlHash, partitionNumString, tabletNumString, cardinalityString);
+
+        this.partitionNum = Util.getLongPropertyOrDefault(partitionNumString, 0L, null, SCANNED_PARTITION_NUM + " should be a long");
+        this.tabletNum = Util.getLongPropertyOrDefault(tabletNumString, 0L, null, SCANNED_TABLET_NUM + " should be a long");
+        this.cardinality = Util.getLongPropertyOrDefault(cardinalityString, 0L, null, SCANNED_CARDINALITY + " should be a long");
 
         this.global = Util.getBooleanPropertyOrDefault(properties.get(GLOBAL_PROPERTY), false, GLOBAL_PROPERTY + " should be a boolean");
         this.enable = Util.getBooleanPropertyOrDefault(properties.get(ENABLE_PROPERTY), true, ENABLE_PROPERTY + " should be a boolean");
@@ -129,6 +152,18 @@ public class CreateSqlBlockRuleStmt extends DdlStmt {
 
     public String getSqlHash() {
         return sqlHash;
+    }
+
+    public Long getPartitionNum() {
+        return partitionNum;
+    }
+
+    public Long getTabletNum() {
+        return tabletNum;
+    }
+
+    public Long getCardinality() {
+        return cardinality;
     }
 
     public boolean isGlobal() {

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateSqlBlockRuleStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateSqlBlockRuleStmt.java
@@ -51,9 +51,9 @@ public class CreateSqlBlockRuleStmt extends DdlStmt {
 
     public static final String SQL_HASH_PROPERTY = "sqlHash";
 
-    public static final String SCANNED_PARTITION_NUM = "partitionNum";
+    public static final String SCANNED_PARTITION_NUM = "partition_num";
 
-    public static final String SCANNED_TABLET_NUM = "tabletNum";
+    public static final String SCANNED_TABLET_NUM = "tablet_num";
 
     public static final String SCANNED_CARDINALITY = "cardinality";
 

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowSqlBlockRuleStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowSqlBlockRuleStmt.java
@@ -43,6 +43,9 @@ public class ShowSqlBlockRuleStmt extends ShowStmt {
                     .addColumn(new Column("Name", ScalarType.createVarchar(50)))
                     .addColumn(new Column("Sql", ScalarType.createVarchar(65535)))
                     .addColumn(new Column("SqlHash", ScalarType.createVarchar(65535)))
+                    .addColumn(new Column("PartitionNum", ScalarType.createVarchar(10)))
+                    .addColumn(new Column("TabletNum", ScalarType.createVarchar(10)))
+                    .addColumn(new Column("Cardinality", ScalarType.createVarchar(20)))
                     .addColumn(new Column("Global", ScalarType.createVarchar(4)))
                     .addColumn(new Column("Enable", ScalarType.createVarchar(4)))
                     .build();

--- a/fe/fe-core/src/main/java/org/apache/doris/blockrule/SqlBlockRule.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/blockrule/SqlBlockRule.java
@@ -51,6 +51,18 @@ public class SqlBlockRule implements Writable {
     @SerializedName(value = "sqlHash")
     private String sqlHash;
 
+    // partitionNum will be scanned
+    @SerializedName(value = "partitionNum")
+    private Long partitionNum;
+
+    // tabletNum will be scanned
+    @SerializedName(value = "tabletNum")
+    private Long tabletNum;
+
+    // cardinality
+    @SerializedName(value = "cardinality")
+    private Long cardinality;
+
     // whether effective global
     @SerializedName(value = "global")
     private Boolean global;
@@ -65,10 +77,13 @@ public class SqlBlockRule implements Writable {
         this.name = name;
     }
 
-    public SqlBlockRule(String name, String sql, String sqlHash, Boolean global, Boolean enable) {
+    public SqlBlockRule(String name, String sql, String sqlHash, Long partitionNum, Long tabletNum, Long cardinality, Boolean global, Boolean enable) {
         this.name = name;
         this.sql = sql;
         this.sqlHash = sqlHash;
+        this.partitionNum = partitionNum;
+        this.tabletNum = tabletNum;
+        this.cardinality = cardinality;
         this.global = global;
         this.enable = enable;
         if (StringUtils.isNotEmpty(sql)) {
@@ -77,11 +92,11 @@ public class SqlBlockRule implements Writable {
     }
 
     public static SqlBlockRule fromCreateStmt(CreateSqlBlockRuleStmt stmt) {
-        return new SqlBlockRule(stmt.getRuleName(), stmt.getSql(), stmt.getSqlHash(), stmt.isGlobal(), stmt.isEnable());
+        return new SqlBlockRule(stmt.getRuleName(), stmt.getSql(), stmt.getSqlHash(), stmt.getPartitionNum(), stmt.getTabletNum(), stmt.getCardinality(), stmt.isGlobal(), stmt.isEnable());
     }
 
     public static SqlBlockRule fromAlterStmt(AlterSqlBlockRuleStmt stmt) {
-        return new SqlBlockRule(stmt.getRuleName(), stmt.getSql(), stmt.getSqlHash(), stmt.getGlobal(), stmt.getEnable());
+        return new SqlBlockRule(stmt.getRuleName(), stmt.getSql(), stmt.getSqlHash(), stmt.getPartitionNum(), stmt.getTabletNum(), stmt.getCardinality(), stmt.getGlobal(), stmt.getEnable());
     }
 
     public String getName() {
@@ -98,6 +113,18 @@ public class SqlBlockRule implements Writable {
 
     public String getSqlHash() {
         return sqlHash;
+    }
+
+    public Long getPartitionNum() {
+        return partitionNum;
+    }
+
+    public Long getTabletNum() {
+        return tabletNum;
+    }
+
+    public Long getCardinality() {
+        return cardinality;
     }
 
     public Boolean getGlobal() {
@@ -120,6 +147,18 @@ public class SqlBlockRule implements Writable {
         this.sqlHash = sqlHash;
     }
 
+    public void setPartitionNum(Long partitionNum) {
+        this.partitionNum = partitionNum;
+    }
+
+    public void setTabletNum(Long tabletNum) {
+        this.tabletNum = tabletNum;
+    }
+
+    public void setCardinality(Long cardinality) {
+        this.cardinality = cardinality;
+    }
+
     public void setGlobal(Boolean global) {
         this.global = global;
     }
@@ -129,7 +168,11 @@ public class SqlBlockRule implements Writable {
     }
 
     public List<String> getShowInfo() {
-        return Lists.newArrayList(this.name, this.sql, this.sqlHash, String.valueOf(this.global), String.valueOf(this.enable));
+        return Lists.newArrayList(this.name, this.sql, this.sqlHash,
+                this.partitionNum == null ? "0" : Long.toString(this.partitionNum),
+                this.tabletNum == null ? "0" : Long.toString(this.tabletNum),
+                this.cardinality == null ? "0" : Long.toString(this.cardinality),
+                String.valueOf(this.global), String.valueOf(this.enable));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/blockrule/SqlBlockRuleMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/blockrule/SqlBlockRuleMgr.java
@@ -232,9 +232,9 @@ public class SqlBlockRuleMgr implements Writable {
                     || (rule.getCardinality() != 0 && rule.getCardinality() < cardinality)) {
                 MetricRepo.COUNTER_HIT_SQL_BLOCK_RULE.increase(1L);
                 if (rule.getPartitionNum() < partitionNum) {
-                    throw new AnalysisException("sql hits sql block rule: " + rule.getName() + ", reach partitionNum : " + rule.getPartitionNum());
+                    throw new AnalysisException("sql hits sql block rule: " + rule.getName() + ", reach partition_num : " + rule.getPartitionNum());
                 } else if (rule.getTabletNum() < tabletNum) {
-                    throw new AnalysisException("sql hits sql block rule: " + rule.getName() + ", reach tabletNum : " + rule.getTabletNum());
+                    throw new AnalysisException("sql hits sql block rule: " + rule.getName() + ", reach tablet_num : " + rule.getTabletNum());
                 } else if (rule.getCardinality() < cardinality) {
                     throw new AnalysisException("sql hits sql block rule: " + rule.getName() + ", reach cardinality : " + rule.getCardinality());
                 }

--- a/fe/fe-core/src/main/java/org/apache/doris/blockrule/SqlBlockRuleMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/blockrule/SqlBlockRuleMgr.java
@@ -27,6 +27,7 @@ import org.apache.doris.common.DdlException;
 import org.apache.doris.common.UserException;
 import org.apache.doris.common.io.Text;
 import org.apache.doris.common.io.Writable;
+import org.apache.doris.common.util.SqlBlockUtil;
 import org.apache.doris.metric.MetricRepo;
 import org.apache.doris.persist.gson.GsonUtils;
 
@@ -98,7 +99,7 @@ public class SqlBlockRuleMgr implements Writable {
         LOG.info("replay create sql block rule: {}", sqlBlockRule);
     }
 
-    public void alterSqlBlockRule(AlterSqlBlockRuleStmt stmt) throws DdlException {
+    public void alterSqlBlockRule(AlterSqlBlockRuleStmt stmt) throws AnalysisException, DdlException {
         writeLock();
         try {
             SqlBlockRule sqlBlockRule = SqlBlockRule.fromAlterStmt(stmt);
@@ -107,11 +108,21 @@ public class SqlBlockRuleMgr implements Writable {
                 throw new DdlException("the sql block rule " + ruleName + " not exist");
             }
             SqlBlockRule originRule = nameToSqlBlockRuleMap.get(ruleName);
+            SqlBlockUtil.checkAlterValidate(sqlBlockRule, originRule);
             if (StringUtils.isEmpty(sqlBlockRule.getSql())) {
                 sqlBlockRule.setSql(originRule.getSql());
             }
             if (StringUtils.isEmpty(sqlBlockRule.getSqlHash())) {
                 sqlBlockRule.setSqlHash(originRule.getSqlHash());
+            }
+            if (StringUtils.isEmpty(sqlBlockRule.getPartitionNum().toString())) {
+                sqlBlockRule.setPartitionNum(originRule.getPartitionNum());
+            }
+            if (StringUtils.isEmpty(sqlBlockRule.getTabletNum().toString())) {
+                sqlBlockRule.setTabletNum(originRule.getTabletNum());
+            }
+            if (StringUtils.isEmpty(sqlBlockRule.getCardinality().toString())) {
+                sqlBlockRule.setCardinality(originRule.getCardinality());
             }
             if (sqlBlockRule.getGlobal() == null) {
                 sqlBlockRule.setGlobal(originRule.getGlobal());
@@ -183,12 +194,50 @@ public class SqlBlockRuleMgr implements Writable {
 
     public void matchSql(SqlBlockRule rule, String originSql, String sqlHash) throws AnalysisException {
         if (rule.getEnable()) {
-            if (StringUtils.isNotEmpty(rule.getSqlHash()) && rule.getSqlHash().equals(sqlHash)) {
+            if (StringUtils.isNotEmpty(rule.getSqlHash()) &&
+                    (!CreateSqlBlockRuleStmt.STRING_NOT_SET.equals(rule.getSqlHash()) && rule.getSqlHash().equals(sqlHash))) {
                 MetricRepo.COUNTER_HIT_SQL_BLOCK_RULE.increase(1L);
                 throw new AnalysisException("sql match hash sql block rule: " + rule.getName());
-            } else if (StringUtils.isNotEmpty(rule.getSql()) && rule.getSqlPattern().matcher(originSql).find()) {
+            } else if (StringUtils.isNotEmpty(rule.getSql()) &&
+                    (!CreateSqlBlockRuleStmt.STRING_NOT_SET.equals(rule.getSql()) && rule.getSqlPattern().matcher(originSql).find())) {
                 MetricRepo.COUNTER_HIT_SQL_BLOCK_RULE.increase(1L);
                 throw new AnalysisException("sql match regex sql block rule: " + rule.getName());
+            }
+        }
+    }
+
+    public void checkLimitaions(Long partitionNum, Long tabletNum, Long cardinality, String user) throws AnalysisException {
+        // match global rule
+        List<SqlBlockRule> globalRules = nameToSqlBlockRuleMap.values().stream().filter(SqlBlockRule::getGlobal).collect(Collectors.toList());
+        for (SqlBlockRule rule : globalRules) {
+            checkLimitaions(rule, partitionNum, tabletNum, cardinality);
+        }
+        // match user rule
+        String[] bindSqlBlockRules = Catalog.getCurrentCatalog().getAuth().getSqlBlockRules(user);
+        for (String ruleName : bindSqlBlockRules) {
+            SqlBlockRule rule = nameToSqlBlockRuleMap.get(ruleName);
+            if (rule == null) {
+                continue;
+            }
+            checkLimitaions(rule, partitionNum, tabletNum, cardinality);
+        }
+    }
+
+    public void checkLimitaions(SqlBlockRule rule, Long partitionNum, Long tabletNum, Long cardinality) throws AnalysisException {
+        if (rule.getPartitionNum() == 0 && rule.getTabletNum() == 0 && rule.getCardinality() == 0) {
+            return;
+        } else if (rule.getEnable()) {
+            if ((rule.getPartitionNum() != 0 && rule.getPartitionNum() < partitionNum)
+                    || (rule.getTabletNum() != 0 && rule.getTabletNum() < tabletNum)
+                    || (rule.getCardinality() != 0 && rule.getCardinality() < cardinality)) {
+                MetricRepo.COUNTER_HIT_SQL_BLOCK_RULE.increase(1L);
+                if (rule.getPartitionNum() < partitionNum) {
+                    throw new AnalysisException("sql hits sql block rule: " + rule.getName() + ", reach partitionNum : " + rule.getPartitionNum());
+                } else if (rule.getTabletNum() < tabletNum) {
+                    throw new AnalysisException("sql hits sql block rule: " + rule.getName() + ", reach tabletNum : " + rule.getTabletNum());
+                } else if (rule.getCardinality() < cardinality) {
+                    throw new AnalysisException("sql hits sql block rule: " + rule.getName() + ", reach cardinality : " + rule.getCardinality());
+                }
             }
         }
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/common/ErrorCode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/ErrorCode.java
@@ -1684,6 +1684,8 @@ public enum ErrorCode {
     ERR_EMPTY_PARTITION_IN_TABLE(5083, new byte[]{'4', '2', '0', '0', '0'},
             "data cannot be inserted into table with empty partition. " +
                     "Use `SHOW PARTITIONS FROM %s` to see the currently partitions of this table. "),
+    ERROR_SQL_AND_LIMITATIONS_SET_IN_ONE_RULE(5084, new byte[]{'4', '2', '0', '0', '0'},
+            "sql/sqlHash and partitionNum/tabletNum/cardinality cannot be set in one rule."),
     ;
 
     // This is error code

--- a/fe/fe-core/src/main/java/org/apache/doris/common/ErrorCode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/ErrorCode.java
@@ -1685,7 +1685,7 @@ public enum ErrorCode {
             "data cannot be inserted into table with empty partition. " +
                     "Use `SHOW PARTITIONS FROM %s` to see the currently partitions of this table. "),
     ERROR_SQL_AND_LIMITATIONS_SET_IN_ONE_RULE(5084, new byte[]{'4', '2', '0', '0', '0'},
-            "sql/sqlHash and partitionNum/tabletNum/cardinality cannot be set in one rule."),
+            "sql/sqlHash and partition_num/tablet_num/cardinality cannot be set in one rule."),
     ;
 
     // This is error code

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/SqlBlockUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/SqlBlockUtil.java
@@ -1,0 +1,99 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+
+package org.apache.doris.common.util;
+
+import org.apache.doris.blockrule.SqlBlockRule;
+import org.apache.doris.common.AnalysisException;
+import org.apache.doris.common.ErrorCode;
+import org.apache.doris.common.ErrorReport;
+
+import org.apache.commons.lang3.StringUtils;
+
+public class SqlBlockUtil {
+
+    public static final String STRING_DEFAULT = "NULL";
+    public static final String LONG_DEFAULT = "0";
+    public static final Long LONG_ZERO = 0L;
+
+
+    public static void checkSqlAndSqlHashSetBoth(String sql, String sqlHash) throws AnalysisException{
+        if (!STRING_DEFAULT.equals(sql) && !STRING_DEFAULT.equals(sqlHash)) {
+            throw new AnalysisException("Only sql or sqlHash can be configured");
+        }
+    }
+
+    // check (sql or sqlHash) and (limitations: partitioNum, tabletNum, cardinality) are not set both
+    public static void checkSqlAndLimitationsSetBoth(String sql, String sqlHash,
+                                                     String partitionNumString, String tabletNumString, String cardinalityString) throws AnalysisException {
+        if ((!STRING_DEFAULT.equals(sql) || !STRING_DEFAULT.equals(sqlHash))
+                && !isSqlBlockLimitationsEmpty(partitionNumString, tabletNumString, cardinalityString)) {
+            ErrorReport.reportAnalysisException(ErrorCode.ERROR_SQL_AND_LIMITATIONS_SET_IN_ONE_RULE);
+        }
+    }
+
+    // 1. check (sql or sqlHash) and (limitations: partitioNum, tabletNum, cardinality) are not set both
+    // 2. check any of limitations is set while sql or sqlHash is not set
+    public static void checkPropertiesValidate(String sql, String sqlHash,
+                                        String partitionNumString, String tabletNumString, String cardinalityString)  throws AnalysisException {
+        if (((!STRING_DEFAULT.equals(sql) || !STRING_DEFAULT.equals(sqlHash))
+                && !isSqlBlockLimitationsEmpty(partitionNumString, tabletNumString, cardinalityString))
+                || ((STRING_DEFAULT.equals(sql) && STRING_DEFAULT.equals(sqlHash))
+                && isSqlBlockLimitationsEmpty(partitionNumString, tabletNumString, cardinalityString))) {
+            ErrorReport.reportAnalysisException(ErrorCode.ERROR_SQL_AND_LIMITATIONS_SET_IN_ONE_RULE);
+        }
+    }
+
+    // check at least one of the (limitations: partitioNum, tabletNum, cardinality) is not empty
+    public static Boolean isSqlBlockLimitationsEmpty(String partitionNumString, String tabletNumString, String cardinalityString) {
+        return StringUtils.isEmpty(partitionNumString) && StringUtils.isEmpty(tabletNumString) && StringUtils.isEmpty(cardinalityString);
+    }
+
+    public static Boolean isSqlBlockLimitationsDefault(Long partitionNum, Long tabletNum, Long cardinality) {
+        return partitionNum == LONG_ZERO && tabletNum == LONG_ZERO && cardinality == LONG_ZERO;
+    }
+
+    public static Boolean isSqlBlockLimitationsNull(Long partitionNum, Long tabletNum, Long cardinality) {
+        return partitionNum == null && tabletNum == null && cardinality == null;
+    }
+
+    // alter operation not allowed to change other properties that not set
+    public static void checkAlterValidate(SqlBlockRule sqlBlockRule, SqlBlockRule originRule) throws AnalysisException {
+        if (!STRING_DEFAULT.equals(sqlBlockRule.getSql())) {
+            if (!STRING_DEFAULT.equals(originRule.getSqlHash()) && StringUtils.isNotEmpty(originRule.getSqlHash())) {
+                throw new AnalysisException("Only sql or sqlHash can be configured");
+            } else if (!isSqlBlockLimitationsDefault(originRule.getPartitionNum(), originRule.getTabletNum(), originRule.getCardinality())
+                    &&!isSqlBlockLimitationsNull(originRule.getPartitionNum(), originRule.getTabletNum(), originRule.getCardinality())) {
+                ErrorReport.reportAnalysisException(ErrorCode.ERROR_SQL_AND_LIMITATIONS_SET_IN_ONE_RULE);
+            }
+        } else if (!STRING_DEFAULT.equals(sqlBlockRule.getSqlHash())) {
+            if (!STRING_DEFAULT.equals(originRule.getSql()) && StringUtils.isNotEmpty(originRule.getSql())) {
+                throw new AnalysisException("Only sql or sqlHash can be configured");
+            } else if (!isSqlBlockLimitationsDefault(originRule.getPartitionNum(), originRule.getTabletNum(), originRule.getCardinality())
+                    && !isSqlBlockLimitationsNull(originRule.getPartitionNum(), originRule.getTabletNum(), originRule.getCardinality())) {
+                ErrorReport.reportAnalysisException(ErrorCode.ERROR_SQL_AND_LIMITATIONS_SET_IN_ONE_RULE);
+            }
+        } else if (!isSqlBlockLimitationsDefault(sqlBlockRule.getPartitionNum(), sqlBlockRule.getTabletNum(), sqlBlockRule.getCardinality())) {
+            if (!STRING_DEFAULT.equals(originRule.getSql()) || !STRING_DEFAULT.equals(originRule.getSqlHash())) {
+                ErrorReport.reportAnalysisException(ErrorCode.ERROR_SQL_AND_LIMITATIONS_SET_IN_ONE_RULE);
+            }
+        }
+    }
+
+}
+

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/OlapScanNode.java
@@ -176,6 +176,14 @@ public class OlapScanNode extends ScanNode {
         this.forceOpenPreAgg = forceOpenPreAgg;
     }
 
+    public Integer getSelectedPartitionNum() {
+        return selectedPartitionNum;
+    }
+
+    public Long getSelectedTabletsNum() {
+        return selectedTabletsNum;
+    }
+
     public Collection<Long> getSelectedPartitionIds() {
         return selectedPartitionIds;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -359,7 +359,7 @@ public class StmtExecutor implements ProfileWriter {
                         context.getState().setError(e.getMysqlErrorCode(), e.getMessage());
                         return;
                     }
-                    // limitations: partitionNum, tabletNum, cardinality
+                    // limitations: partition_num, tablet_num, cardinality
                     List<ScanNode> scanNodeList = planner.getScanNodes();
                     for (ScanNode scanNode : scanNodeList) {
                         if (scanNode instanceof OlapScanNode) {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -81,7 +81,9 @@ import org.apache.doris.mysql.MysqlChannel;
 import org.apache.doris.mysql.MysqlEofPacket;
 import org.apache.doris.mysql.MysqlSerializer;
 import org.apache.doris.mysql.privilege.PrivPredicate;
+import org.apache.doris.planner.OlapScanNode;
 import org.apache.doris.planner.Planner;
+import org.apache.doris.planner.ScanNode;
 import org.apache.doris.proto.Data;
 import org.apache.doris.proto.InternalService;
 import org.apache.doris.qe.QueryState.MysqlStateType;
@@ -358,7 +360,16 @@ public class StmtExecutor implements ProfileWriter {
                         return;
                     }
                     // limitations: partitionNum, tabletNum, cardinality
+                    List<ScanNode> scanNodeList = planner.getScanNodes();
+                    for (ScanNode scanNode : scanNodeList) {
+                        if (scanNode instanceof OlapScanNode) {
+                            OlapScanNode olapScanNode = (OlapScanNode) scanNode;
+                            Catalog.getCurrentCatalog().getSqlBlockRuleMgr().checkLimitaions(olapScanNode.getSelectedPartitionNum().longValue(),
+                                        olapScanNode.getSelectedTabletsNum(), olapScanNode.getCardinality(), analyzer.getQualifiedUser());
+                        }
+                    }
                 }
+
                 MetricRepo.COUNTER_QUERY_BEGIN.increase(1L);
                 int retryTime = Config.max_query_retry_time;
                 for (int i = 0; i < retryTime; i++) {

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/AlterSqlBlockRuleStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/AlterSqlBlockRuleStmtTest.java
@@ -86,7 +86,7 @@ public class AlterSqlBlockRuleStmtTest {
         AlterSqlBlockRuleStmt stmt = new AlterSqlBlockRuleStmt("test_rule", properties);
 
         ExceptionChecker.expectThrowsWithMsg(AnalysisException.class,
-                "errCode = 2, detailMessage = sql/sqlHash and partitionNum/tabletNum/cardinality cannot be set in one rule.",
+                "errCode = 2, detailMessage = sql/sqlHash and partition_num/tablet_num/cardinality cannot be set in one rule.",
                 () -> stmt.analyze(analyzer));
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/AlterSqlBlockRuleStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/AlterSqlBlockRuleStmtTest.java
@@ -17,8 +17,11 @@
 
 package org.apache.doris.analysis;
 
+import org.apache.doris.analysis.CreateSqlBlockRuleStmt;
 import org.apache.doris.blockrule.SqlBlockRule;
 import org.apache.doris.common.AnalysisException;
+import org.apache.doris.common.ErrorReport;
+import org.apache.doris.common.ExceptionChecker;
 import org.apache.doris.common.UserException;
 import org.apache.doris.mysql.privilege.MockedAuth;
 import org.apache.doris.mysql.privilege.PaloAuth;
@@ -61,6 +64,30 @@ public class AlterSqlBlockRuleStmtTest {
         Assert.assertEquals(false, rule.getEnable());
         Assert.assertEquals("select \\* from test_table", rule.getSql());
         Assert.assertEquals("test_rule", rule.getName());
+    }
+
+    @Test
+    public void testSqlAndSqlHashSetBoth() throws UserException {
+        Map<String, String> properties = new HashMap<>();
+        properties.put(CreateSqlBlockRuleStmt.SQL_PROPERTY, "select \\* from test_table");
+        properties.put(CreateSqlBlockRuleStmt.SQL_HASH_PROPERTY, "sqlHash");
+        AlterSqlBlockRuleStmt stmt = new AlterSqlBlockRuleStmt("test_rule", properties);
+
+        ExceptionChecker.expectThrowsWithMsg(AnalysisException.class,
+                "errCode = 2, detailMessage = Only sql or sqlHash can be configured",
+                () -> stmt.analyze(analyzer));
+    }
+
+    @Test
+    public void testSqlAndLimitationsSetBoth() throws UserException {
+        Map<String, String> properties = new HashMap<>();
+        properties.put(CreateSqlBlockRuleStmt.SQL_PROPERTY, "select \\* from test_table");
+        properties.put(CreateSqlBlockRuleStmt.SCANNED_PARTITION_NUM, "4");
+        AlterSqlBlockRuleStmt stmt = new AlterSqlBlockRuleStmt("test_rule", properties);
+
+        ExceptionChecker.expectThrowsWithMsg(AnalysisException.class,
+                "errCode = 2, detailMessage = sql/sqlHash and partitionNum/tabletNum/cardinality cannot be set in one rule.",
+                () -> stmt.analyze(analyzer));
     }
 
     @Test(expected = AnalysisException.class)

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/CreateSqlBlockRuleStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/CreateSqlBlockRuleStmtTest.java
@@ -113,7 +113,7 @@ public class CreateSqlBlockRuleStmtTest {
         CreateSqlBlockRuleStmt stmt = new CreateSqlBlockRuleStmt("test_rule", properties);
 
         ExceptionChecker.expectThrowsWithMsg(AnalysisException.class,
-                "errCode = 2, detailMessage = tabletNum should be a long",
+                "errCode = 2, detailMessage = tablet_num should be a long",
                 () -> stmt.analyze(analyzer));
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/CreateSqlBlockRuleStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/CreateSqlBlockRuleStmtTest.java
@@ -102,7 +102,7 @@ public class CreateSqlBlockRuleStmtTest {
         CreateSqlBlockRuleStmt stmt = new CreateSqlBlockRuleStmt("test_rule", properties);
 
         ExceptionChecker.expectThrowsWithMsg(AnalysisException.class,
-                "errCode = 2, detailMessage = sql/sqlHash and partitionNum/tabletNum/cardinality cannot be set in one rule.",
+                "errCode = 2, detailMessage = sql/sqlHash and partition_num/tablet_num/cardinality cannot be set in one rule.",
                 () -> stmt.analyze(analyzer));
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/CreateSqlBlockRuleStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/CreateSqlBlockRuleStmtTest.java
@@ -19,6 +19,8 @@ package org.apache.doris.analysis;
 
 import org.apache.doris.blockrule.SqlBlockRule;
 import org.apache.doris.common.AnalysisException;
+import org.apache.doris.common.DdlException;
+import org.apache.doris.common.ExceptionChecker;
 import org.apache.doris.common.UserException;
 import org.apache.doris.mysql.privilege.MockedAuth;
 import org.apache.doris.mysql.privilege.PaloAuth;
@@ -61,6 +63,58 @@ public class CreateSqlBlockRuleStmtTest {
         Assert.assertEquals(true, rule.getEnable());
         Assert.assertEquals("select \\* from test_table", rule.getSql());
         Assert.assertEquals("test_rule", rule.getName());
+    }
+
+    @Test
+    public void testLimitationsNormal() throws UserException {
+        Map<String, String> properties = new HashMap<>();
+        properties.put(CreateSqlBlockRuleStmt.SCANNED_PARTITION_NUM, "3");
+        properties.put(CreateSqlBlockRuleStmt.ENABLE_PROPERTY, "true");
+        CreateSqlBlockRuleStmt stmt = new CreateSqlBlockRuleStmt("test_rule", properties);
+        stmt.analyze(analyzer);
+        SqlBlockRule rule = SqlBlockRule.fromCreateStmt(stmt);
+        Assert.assertEquals(true, rule.getEnable());
+        Assert.assertEquals("NULL", rule.getSqlHash());
+        Assert.assertEquals("3", rule.getPartitionNum().toString());
+        Assert.assertEquals("0", rule.getTabletNum().toString());
+        Assert.assertEquals("0", rule.getCardinality().toString());
+        Assert.assertEquals(false, rule.getGlobal());
+        Assert.assertEquals("test_rule", rule.getName());
+    }
+
+    @Test
+    public void testSqlAndSqlHashSetBoth() throws UserException {
+        Map<String, String> properties = new HashMap<>();
+        properties.put(CreateSqlBlockRuleStmt.SQL_PROPERTY, "select \\* from test_table");
+        properties.put(CreateSqlBlockRuleStmt.SQL_HASH_PROPERTY, "sqlHash");
+        CreateSqlBlockRuleStmt stmt = new CreateSqlBlockRuleStmt("test_rule", properties);
+
+        ExceptionChecker.expectThrowsWithMsg(AnalysisException.class,
+                "errCode = 2, detailMessage = Only sql or sqlHash can be configured",
+                () -> stmt.analyze(analyzer));
+    }
+
+    @Test
+    public void testSqlAndLimitationsSetBoth() throws UserException {
+        Map<String, String> properties = new HashMap<>();
+        properties.put(CreateSqlBlockRuleStmt.SQL_PROPERTY, "select \\* from test_table");
+        properties.put(CreateSqlBlockRuleStmt.SCANNED_TABLET_NUM, "3");
+        CreateSqlBlockRuleStmt stmt = new CreateSqlBlockRuleStmt("test_rule", properties);
+
+        ExceptionChecker.expectThrowsWithMsg(AnalysisException.class,
+                "errCode = 2, detailMessage = sql/sqlHash and partitionNum/tabletNum/cardinality cannot be set in one rule.",
+                () -> stmt.analyze(analyzer));
+    }
+
+    @Test
+    public void testInvalidTypeOfLimitations() throws UserException {
+        Map<String, String> properties = new HashMap<>();
+        properties.put(CreateSqlBlockRuleStmt.SCANNED_TABLET_NUM, "notTypeLong");
+        CreateSqlBlockRuleStmt stmt = new CreateSqlBlockRuleStmt("test_rule", properties);
+
+        ExceptionChecker.expectThrowsWithMsg(AnalysisException.class,
+                "errCode = 2, detailMessage = tabletNum should be a long",
+                () -> stmt.analyze(analyzer));
     }
 
     @Test(expected = AnalysisException.class)

--- a/fe/fe-core/src/test/java/org/apache/doris/blockrule/SqlBlockRuleMgrTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/blockrule/SqlBlockRuleMgrTest.java
@@ -29,8 +29,13 @@ import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.DdlException;
 import org.apache.doris.common.ExceptionChecker;
 import org.apache.doris.common.UserException;
+import org.apache.doris.common.jmockit.Deencapsulation;
 import org.apache.doris.metric.MetricRepo;
+import org.apache.doris.planner.OlapScanNode;
+import org.apache.doris.planner.Planner;
+import org.apache.doris.planner.ScanNode;
 import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.qe.StmtExecutor;
 import org.apache.doris.utframe.UtFrameUtils;
 
 import org.apache.commons.codec.digest.DigestUtils;
@@ -40,12 +45,15 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.File;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import java.util.HashMap;
 import java.util.Map;
 
 public class SqlBlockRuleMgrTest {
-    
+
     private static String runningDir = "fe/mocked/SqlBlockRuleMgrTest/" + UUID.randomUUID().toString() + "/";
     
     private static ConnectContext connectContext;
@@ -66,6 +74,22 @@ public class SqlBlockRuleMgrTest {
         createTable("create table test.table1\n" +
                 "(k1 int, k2 int) distributed by hash(k1) buckets 1\n" +
                 "properties(\"replication_num\" = \"1\");");
+
+        createTable("create table test.table2\n" +
+                "(k1 datetime, k2 int)\n" +
+                "ENGINE=OLAP\n" +
+                "PARTITION BY RANGE(k1)\n" +
+                "(\n" +
+                "PARTITION p20211213 VALUES [('2021-12-13 00:00:00'), ('2021-12-14 00:00:00')),\n" +
+                "PARTITION p20211214 VALUES [('2021-12-14 00:00:00'), ('2021-12-15 00:00:00')),\n" +
+                "PARTITION p20211215 VALUES [('2021-12-15 00:00:00'), ('2021-12-16 00:00:00')),\n" +
+                "PARTITION p20211216 VALUES [('2021-12-16 00:00:00'), ('2021-12-17 00:00:00'))\n" +
+                ")\n" +
+                "DISTRIBUTED BY HASH(k1)\n" +
+                "BUCKETS 10\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\"\n" +
+                ");");
         
     }
     
@@ -84,7 +108,7 @@ public class SqlBlockRuleMgrTest {
     public void testUserMatchSql() throws Exception {
         String sql = "select * from table1 limit 10";
         String sqlHash = DigestUtils.md5Hex(sql);
-        SqlBlockRule sqlRule = new SqlBlockRule("test_rule1", null, sqlHash, false, true);
+        SqlBlockRule sqlRule = new SqlBlockRule("test_rule1", null, sqlHash, 0L, 0L, 0L, false, true);
         SqlBlockRuleMgr mgr = new SqlBlockRuleMgr();
         mgr.replayCreate(sqlRule);
         // sql block rules
@@ -99,7 +123,7 @@ public class SqlBlockRuleMgrTest {
     public void testGlobalMatchSql() throws AnalysisException {
         String sql = "select * from test_table1 limit 10";
         String sqlHash = DigestUtils.md5Hex(sql);
-        SqlBlockRule sqlRule = new SqlBlockRule("test_rule1", null, sqlHash, true, true);
+        SqlBlockRule sqlRule = new SqlBlockRule("test_rule1", null, sqlHash, 0L, 0L, 0L, true, true);
         SqlBlockRuleMgr mgr = new SqlBlockRuleMgr();
         mgr.replayCreate(sqlRule);
         ExceptionChecker.expectThrowsWithMsg(AnalysisException.class, "sql match hash sql block rule: " + sqlRule.getName(),
@@ -110,7 +134,7 @@ public class SqlBlockRuleMgrTest {
     public void testRegexMatchSql() throws AnalysisException {
         String sql = "select * from test_table1 tt1 join test_table2 tt2 on tt1.testId=tt2.testId limit 5";
         String sqlHash = DigestUtils.md5Hex(sql);
-        SqlBlockRule sqlRule = new SqlBlockRule("test_rule1", ".* join .*", null, true, true);
+        SqlBlockRule sqlRule = new SqlBlockRule("test_rule1", ".* join .*", null, 0L, 0L, 0L, true, true);
         SqlBlockRuleMgr mgr = new SqlBlockRuleMgr();
         mgr.replayCreate(sqlRule);
         ExceptionChecker.expectThrowsWithMsg(AnalysisException.class, "sql match regex sql block rule: " + sqlRule.getName(),
@@ -122,13 +146,121 @@ public class SqlBlockRuleMgrTest {
         String sql = "select * from test_table1 tt1 join test_table2 tt2 on tt1.testId=tt2.testId limit 5";
         String sqlHash = DigestUtils.md5Hex(sql);
         System.out.println(sqlHash);
-        SqlBlockRule sqlRule = new SqlBlockRule("test_rule1", null, sqlHash, true, true);
+        SqlBlockRule sqlRule = new SqlBlockRule("test_rule1", null, sqlHash, 0L, 0L, 0L, true, true);
         SqlBlockRuleMgr mgr = new SqlBlockRuleMgr();
         mgr.replayCreate(sqlRule);
         ExceptionChecker.expectThrowsWithMsg(AnalysisException.class, "sql match hash sql block rule: " + sqlRule.getName(),
                 () -> mgr.matchSql(sqlRule, sql, sqlHash));
     }
-    
+
+    @Test
+    public void testReachLimitations() throws AnalysisException, Exception {
+        String sql = "select * from test.table2;";
+        StmtExecutor executor = UtFrameUtils.getSqlStmtExecutor(connectContext, sql);
+        Planner planner = executor.planner();
+        List<ScanNode> scanNodeList = planner.getScanNodes();
+        OlapScanNode olapScanNode = (OlapScanNode) scanNodeList.get(0);
+        Integer selectedPartition = Deencapsulation.getField(olapScanNode, "selectedPartitionNum");
+        long selectedPartitionLongValue = selectedPartition.longValue();
+        long selectedTablet = Deencapsulation.getField(olapScanNode, "selectedTabletsNum");
+        long cardinality = Deencapsulation.getField(olapScanNode, "cardinality");
+        Assert.assertEquals(0L, selectedPartitionLongValue);
+        Assert.assertEquals(0L, selectedTablet);
+        Assert.assertEquals(0L, cardinality);
+
+        SqlBlockRuleMgr mgr = Catalog.getCurrentCatalog().getSqlBlockRuleMgr();
+
+        // test reach partitionNum :
+        // cuz there is no data in test.table2, so the selectedPartitionLongValue == 0;
+        // set sqlBlockRule.partitionNum = -1, so it can be blocked.
+        SqlBlockRule sqlBlockRule = new SqlBlockRule("test_rule2", "NULL", "NULL", -1L, 0L, 0L, true, true);
+        mgr.replayCreate(sqlBlockRule);
+        Assert.assertEquals(true, mgr.existRule("test_rule2"));
+        Assert.assertEquals("NULL", sqlBlockRule.getSql());
+        Assert.assertEquals("NULL", sqlBlockRule.getSqlHash());
+        Assert.assertEquals(-1L, (long) sqlBlockRule.getPartitionNum());
+        Assert.assertEquals(0L, (long) sqlBlockRule.getTabletNum());
+        Assert.assertEquals(0L, (long) sqlBlockRule.getCardinality());
+
+        ExceptionChecker.expectThrowsWithMsg(AnalysisException.class, "errCode = 2, detailMessage = sql hits sql block rule: "
+                        + sqlBlockRule.getName() + ", reach partitionNum : " + sqlBlockRule.getPartitionNum(),
+                () -> mgr.checkLimitaions(sqlBlockRule, selectedPartitionLongValue, selectedTablet, cardinality));
+
+        // test reach TabletNum :
+        SqlBlockRule sqlBlockRule2 = new SqlBlockRule("test_rule3", "NULL", "NULL", 0L, -1L, 0L, true, true);
+        mgr.replayCreate(sqlBlockRule2);
+        Assert.assertEquals(true, mgr.existRule("test_rule3"));
+        Assert.assertEquals("NULL", sqlBlockRule2.getSql());
+        Assert.assertEquals("NULL", sqlBlockRule2.getSqlHash());
+        Assert.assertEquals(0L, (long) sqlBlockRule2.getPartitionNum());
+        Assert.assertEquals(-1L, (long) sqlBlockRule2.getTabletNum());
+        Assert.assertEquals(0L, (long) sqlBlockRule2.getCardinality());
+
+        ExceptionChecker.expectThrowsWithMsg(AnalysisException.class, "errCode = 2, detailMessage = sql hits sql block rule: "
+                        + sqlBlockRule2.getName() + ", reach tabletNum : " + sqlBlockRule2.getTabletNum(),
+                () -> mgr.checkLimitaions(sqlBlockRule2, selectedPartitionLongValue, selectedTablet, cardinality));
+
+        // test reach cardinality :
+        SqlBlockRule sqlBlockRule3 = new SqlBlockRule("test_rule4", "NULL", "NULL", 0L, 0L, -1L, true, true);
+        mgr.replayCreate(sqlBlockRule3);
+        Assert.assertEquals(true, mgr.existRule("test_rule4"));
+        Assert.assertEquals("NULL", sqlBlockRule3.getSql());
+        Assert.assertEquals("NULL", sqlBlockRule3.getSqlHash());
+        Assert.assertEquals(0L, (long) sqlBlockRule3.getPartitionNum());
+        Assert.assertEquals(0L, (long) sqlBlockRule3.getTabletNum());
+        Assert.assertEquals(-1L, (long) sqlBlockRule3.getCardinality());
+
+        ExceptionChecker.expectThrowsWithMsg(AnalysisException.class, "errCode = 2, detailMessage = sql hits sql block rule: "
+                        + sqlBlockRule3.getName() + ", reach cardinality : " + sqlBlockRule3.getCardinality(),
+                () -> mgr.checkLimitaions(sqlBlockRule3, selectedPartitionLongValue, selectedTablet, cardinality));
+    }
+
+    @Test
+    public void testAlterInvalid() throws Exception {
+        Analyzer analyzer = new Analyzer(Catalog.getCurrentCatalog(), connectContext);
+        SqlBlockRuleMgr mgr = Catalog.getCurrentCatalog().getSqlBlockRuleMgr();
+
+        // create : sql
+        // alter : sqlHash
+        // AnalysisException : Only sql or sqlHash can be configured
+        SqlBlockRule sqlBlockRule = new SqlBlockRule("test_rule", "select \\* from test_table", "NULL", 0L, 0L, 0L, true, true);
+        mgr.unprotectedAdd(sqlBlockRule);
+        Assert.assertEquals(true, mgr.existRule("test_rule"));
+
+        Map<String, String> properties = new HashMap<>();
+        properties.put(CreateSqlBlockRuleStmt.SQL_HASH_PROPERTY, "xxxx");
+        AlterSqlBlockRuleStmt stmt = new AlterSqlBlockRuleStmt("test_rule", properties);
+        stmt.analyze(analyzer);
+
+        ExceptionChecker.expectThrowsWithMsg(AnalysisException.class, "Only sql or sqlHash can be configured",
+                () -> mgr.alterSqlBlockRule(stmt));
+
+        // create : sql
+        // alter : tabletNum
+        // AnalysisException : sql/sqlHash and partitionNum/tabletNum/cardinality cannot be set in one rule.
+        Map<String, String> properties2 = new HashMap<>();
+        properties2.put(CreateSqlBlockRuleStmt.SCANNED_TABLET_NUM, "4");
+        AlterSqlBlockRuleStmt stmt2 = new AlterSqlBlockRuleStmt("test_rule", properties2);
+
+        stmt2.analyze(analyzer);
+        ExceptionChecker.expectThrowsWithMsg(AnalysisException.class, "sql/sqlHash and partitionNum/tabletNum/cardinality cannot be set in one rule.",
+                () -> mgr.alterSqlBlockRule(stmt2));
+
+        // create : cardinality
+        // alter : sqlHash
+        // AnalysisException : sql/sqlHash and partitionNum/tabletNum/cardinality cannot be set in one rule.
+        SqlBlockRule sqlBlockRule2 = new SqlBlockRule("test_rule2", "NULL", "NULL", 0L, 0L, 10L, true, true);
+        mgr.unprotectedAdd(sqlBlockRule2);
+        Assert.assertEquals(true, mgr.existRule("test_rule2"));
+
+        Map<String, String> properties3 = new HashMap<>();
+        properties3.put(CreateSqlBlockRuleStmt.SQL_HASH_PROPERTY, "xxxx");
+        AlterSqlBlockRuleStmt stmt3 = new AlterSqlBlockRuleStmt("test_rule2", properties3);
+        stmt3.analyze(analyzer);
+        ExceptionChecker.expectThrowsWithMsg(AnalysisException.class, "sql/sqlHash and partitionNum/tabletNum/cardinality cannot be set in one rule.",
+                () -> mgr.alterSqlBlockRule(stmt3));
+    }
+
     @Test
     public void testNormalCreate() throws Exception {
         String createSql = "CREATE SQL_BLOCK_RULE test_rule PROPERTIES(\"sql\"=\"select \\\\* from test_table\",\"enable\"=\"true\")";
@@ -140,7 +272,7 @@ public class SqlBlockRuleMgrTest {
         SqlBlockRuleMgr mgr = new SqlBlockRuleMgr();
         Analyzer analyzer = new Analyzer(Catalog.getCurrentCatalog(), connectContext);
 
-        SqlBlockRule sqlRule = new SqlBlockRule("test_rule1", "test", null, true, true);
+        SqlBlockRule sqlRule = new SqlBlockRule("test_rule1", "test", null, 0L, 0L, 0L, true, true);
         mgr.replayCreate(sqlRule);
 
         Map<String, String> properties = new HashMap<>();

--- a/fe/fe-core/src/test/java/org/apache/doris/blockrule/SqlBlockRuleMgrTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/blockrule/SqlBlockRuleMgrTest.java
@@ -170,9 +170,9 @@ public class SqlBlockRuleMgrTest {
 
         SqlBlockRuleMgr mgr = Catalog.getCurrentCatalog().getSqlBlockRuleMgr();
 
-        // test reach partitionNum :
+        // test reach partition_num :
         // cuz there is no data in test.table2, so the selectedPartitionLongValue == 0;
-        // set sqlBlockRule.partitionNum = -1, so it can be blocked.
+        // set sqlBlockRule.partition_num = -1, so it can be blocked.
         SqlBlockRule sqlBlockRule = new SqlBlockRule("test_rule2", "NULL", "NULL", -1L, 0L, 0L, true, true);
         mgr.replayCreate(sqlBlockRule);
         Assert.assertEquals(true, mgr.existRule("test_rule2"));
@@ -183,10 +183,10 @@ public class SqlBlockRuleMgrTest {
         Assert.assertEquals(0L, (long) sqlBlockRule.getCardinality());
 
         ExceptionChecker.expectThrowsWithMsg(AnalysisException.class, "errCode = 2, detailMessage = sql hits sql block rule: "
-                        + sqlBlockRule.getName() + ", reach partitionNum : " + sqlBlockRule.getPartitionNum(),
+                        + sqlBlockRule.getName() + ", reach partition_num : " + sqlBlockRule.getPartitionNum(),
                 () -> mgr.checkLimitaions(sqlBlockRule, selectedPartitionLongValue, selectedTablet, cardinality));
 
-        // test reach TabletNum :
+        // test reach tablet_num :
         SqlBlockRule sqlBlockRule2 = new SqlBlockRule("test_rule3", "NULL", "NULL", 0L, -1L, 0L, true, true);
         mgr.replayCreate(sqlBlockRule2);
         Assert.assertEquals(true, mgr.existRule("test_rule3"));
@@ -197,7 +197,7 @@ public class SqlBlockRuleMgrTest {
         Assert.assertEquals(0L, (long) sqlBlockRule2.getCardinality());
 
         ExceptionChecker.expectThrowsWithMsg(AnalysisException.class, "errCode = 2, detailMessage = sql hits sql block rule: "
-                        + sqlBlockRule2.getName() + ", reach tabletNum : " + sqlBlockRule2.getTabletNum(),
+                        + sqlBlockRule2.getName() + ", reach tablet_num : " + sqlBlockRule2.getTabletNum(),
                 () -> mgr.checkLimitaions(sqlBlockRule2, selectedPartitionLongValue, selectedTablet, cardinality));
 
         // test reach cardinality :
@@ -237,18 +237,18 @@ public class SqlBlockRuleMgrTest {
 
         // create : sql
         // alter : tabletNum
-        // AnalysisException : sql/sqlHash and partitionNum/tabletNum/cardinality cannot be set in one rule.
+        // AnalysisException : sql/sqlHash and partition_num/tablet_num/cardinality cannot be set in one rule.
         Map<String, String> properties2 = new HashMap<>();
         properties2.put(CreateSqlBlockRuleStmt.SCANNED_TABLET_NUM, "4");
         AlterSqlBlockRuleStmt stmt2 = new AlterSqlBlockRuleStmt("test_rule", properties2);
 
         stmt2.analyze(analyzer);
-        ExceptionChecker.expectThrowsWithMsg(AnalysisException.class, "sql/sqlHash and partitionNum/tabletNum/cardinality cannot be set in one rule.",
+        ExceptionChecker.expectThrowsWithMsg(AnalysisException.class, "sql/sqlHash and partition_num/tablet_num/cardinality cannot be set in one rule.",
                 () -> mgr.alterSqlBlockRule(stmt2));
 
         // create : cardinality
         // alter : sqlHash
-        // AnalysisException : sql/sqlHash and partitionNum/tabletNum/cardinality cannot be set in one rule.
+        // AnalysisException : sql/sqlHash and partition_num/tablet_num/cardinality cannot be set in one rule.
         SqlBlockRule sqlBlockRule2 = new SqlBlockRule("test_rule2", "NULL", "NULL", 0L, 0L, 10L, true, true);
         mgr.unprotectedAdd(sqlBlockRule2);
         Assert.assertEquals(true, mgr.existRule("test_rule2"));
@@ -257,7 +257,7 @@ public class SqlBlockRuleMgrTest {
         properties3.put(CreateSqlBlockRuleStmt.SQL_HASH_PROPERTY, "xxxx");
         AlterSqlBlockRuleStmt stmt3 = new AlterSqlBlockRuleStmt("test_rule2", properties3);
         stmt3.analyze(analyzer);
-        ExceptionChecker.expectThrowsWithMsg(AnalysisException.class, "sql/sqlHash and partitionNum/tabletNum/cardinality cannot be set in one rule.",
+        ExceptionChecker.expectThrowsWithMsg(AnalysisException.class, "sql/sqlHash and partition_num/tablet_num/cardinality cannot be set in one rule.",
                 () -> mgr.alterSqlBlockRule(stmt3));
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/qe/ShowExecutorTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/qe/ShowExecutorTest.java
@@ -596,11 +596,14 @@ public class ShowExecutorTest {
         ShowSqlBlockRuleStmt stmt = new ShowSqlBlockRuleStmt("test_rule");
         ShowExecutor executor = new ShowExecutor(ctx, stmt);
         ShowResultSet resultSet = executor.execute();
-        Assert.assertEquals(5, resultSet.getMetaData().getColumnCount());
+        Assert.assertEquals(8, resultSet.getMetaData().getColumnCount());
         Assert.assertEquals("Name", resultSet.getMetaData().getColumn(0).getName());
         Assert.assertEquals("Sql", resultSet.getMetaData().getColumn(1).getName());
         Assert.assertEquals("SqlHash", resultSet.getMetaData().getColumn(2).getName());
-        Assert.assertEquals("Global", resultSet.getMetaData().getColumn(3).getName());
-        Assert.assertEquals("Enable", resultSet.getMetaData().getColumn(4).getName());
+        Assert.assertEquals("PartitionNum", resultSet.getMetaData().getColumn(3).getName());
+        Assert.assertEquals("TabletNum", resultSet.getMetaData().getColumn(4).getName());
+        Assert.assertEquals("Cardinality", resultSet.getMetaData().getColumn(5).getName());
+        Assert.assertEquals("Global", resultSet.getMetaData().getColumn(6).getName());
+        Assert.assertEquals("Enable", resultSet.getMetaData().getColumn(7).getName());
     }
 }


### PR DESCRIPTION
Add partitionNum, tabletNum, cardinality in SqlBlockRule to block large/slow sql.

	1. set partitionNum, tabletNum, cardinality as limitations to block sqls
	2. compatible with lower version
	3. add unit tests
	4. add docs

## Proposed changes

There are many large queries that scan the entire table or large amounts of data, and most of them are triggered manually or accidentally. In any case, this poses a great threat to the stability of the cluster.
Therefore, we need more precise SQL block methods. 

It should :
1. Just bolck query statement 
2. Let the explain statement execute
3. Block large queries before being executed, but after being planned to get core information of OlapScanNode 

Close related #7202 (replace it with issue number if it exists).

Describe the overview of changes, and introduce why we need it.

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)
- [x] Code refactor (Modify the code structure, format the code, etc...)
- [ ] Optimization. Including functional usability improvements and performance improvements.
- [ ] Dependency. Such as changes related to third-party components.
- [ ] Other.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have created an issue on (Fix #7202 ) and described the bug/feature there in detail
- [ ] Compiling and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] If these changes need document changes, I have updated the document
- [ ] Any dependent changes have been merged

## Further comments

If this is a relatively large or complex change, kick off the discussion at dev@doris.apache.org by explaining why you chose the solution you did and what alternatives you considered, etc...
