### PR TITLE
Revert "[improvement](reader) optimize for single rowset reading  (#7351)"

### DIFF
--- a/be/src/olap/tuple_reader.cpp
+++ b/be/src/olap/tuple_reader.cpp
@@ -79,16 +79,9 @@ OLAPStatus TupleReader::init(const ReaderParams& read_params) {
     auto status = _init_collect_iter(read_params, &rs_readers);
     if (status != OLAP_SUCCESS) { return status; }
 
-    // optimize for single rowset reading without do aggregation when reading all columns, 
-    // and otherwise should use _agg_key_next_row for AGG_KEYS
     if (_optimize_for_single_rowset(rs_readers)) {
-        if(_tablet->keys_type() == AGG_KEYS && _return_columns.size() == _tablet->tablet_schema().num_columns()) {
-            _next_row_func = &TupleReader::_direct_agg_key_next_row;
-        } else if (_tablet->keys_type() == AGG_KEYS) {
-            _next_row_func = &TupleReader::_agg_key_next_row;
-        } else {
-            _next_row_func = &TupleReader::_direct_next_row;
-        }
+        _next_row_func = _tablet->keys_type() == AGG_KEYS ? &TupleReader::_direct_agg_key_next_row
+                                                          : &TupleReader::_direct_next_row;
         return OLAP_SUCCESS;
     }
 


### PR DESCRIPTION
Reverts apache/incubator-doris#7351

This commit will cause wrong result with agg table.
For example, an agg table `(k1, k2, v1 sum)` with single non-overlapping rowset

`select count(k1) from tbl1;` should using `_direct_agg_key_next_row` instead of `_agg_key_next_row`.

Otherwise it return less rows than expected.(because `_agg_key_next_row` will only do aggregation with `k1`)