### PR TITLE
cancel export job

### DIFF
--- a/fe/fe-core/src/main/cup/sql_parser.cup
+++ b/fe/fe-core/src/main/cup/sql_parser.cup
@@ -3080,6 +3080,10 @@ cancel_param ::=
     {:
         RESULT = new CancelBackupStmt(db, true);
     :}
+    | KW_EXPORT KW_ON table_name:tbl_name
+    {:
+        RESULT = new CancelExportStmt(tbl_name);
+    :}
     ;
 
 // Delete stmt


### PR DESCRIPTION
**Description**
When exporting a large number data, users should cancel the operation during the operation to release resources as soon as possible.