### PR TITLE
[Bug][SparkLoad] fix Roaring64Map big-endian read/write in de/seriali…

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/io/Roaring64Map.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/io/Roaring64Map.java
@@ -1322,7 +1322,8 @@ public class Roaring64Map {
         Codec.encodeVarint64(highToBitmap.size(), out);
 
         for (Map.Entry<Integer, BitmapDataProvider> entry : highToBitmap.entrySet()) {
-            out.writeInt(entry.getKey().intValue());
+            // serialized in little end for BE cpp read in case of bugs when the value is larger than 32bits
+            out.writeInt(Integer.reverseBytes(entry.getKey().intValue()));
             entry.getValue().serialize(out);
         }
     }
@@ -1356,7 +1357,8 @@ public class Roaring64Map {
 
         long nbHighs = Codec.decodeVarint64(in);
         for (int i = 0; i < nbHighs; i++) {
-            int high = in.readInt();
+            // keep the same behavior with little-end serialize
+            int high = Integer.reverseBytes(in.readInt());
             RoaringBitmap provider = new RoaringBitmap();
             provider.deserialize(in);
             highToBitmap.put(high, provider);


### PR DESCRIPTION


See #7479
This bug is triggered when the bitmap exceeds 32 bits.



## Proposed changes

Close related #issue (replace it with issue number if it exists).

Describe the overview of changes, and introduce why we need it.

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Code refactor (Modify the code structure, format the code, etc...)
- [ ] Optimization. Including functional usability improvements and performance improvements.
- [ ] Dependency. Such as changes related to third-party components.
- [ ] Other.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have created an issue on (Fix #ISSUE) and described the bug/feature there in detail
- [ ] Compiling and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If these changes need document changes, I have updated the document
- [ ] Any dependent changes have been merged

## Further comments

If this is a relatively large or complex change, kick off the discussion at dev@doris.apache.org by explaining why you chose the solution you did and what alternatives you considered, etc...
