### PR TITLE
[Bug] Fix 'nan' returned by function 'percentile_approx' can not be parsed as double type by JDBC

### DIFF
--- a/be/src/exprs/aggregate_functions.cpp
+++ b/be/src/exprs/aggregate_functions.cpp
@@ -347,7 +347,11 @@ DoubleVal AggregateFunctions::percentile_approx_finalize(FunctionContext* ctx,
     double result = percentile->digest->quantile(quantile);
 
     delete percentile;
-    return DoubleVal(result);
+    if (isnan(result)) {
+        return DoubleVal(result).null();
+    } else {
+        return DoubleVal(result);
+    }
 }
 
 struct AvgState {


### PR DESCRIPTION
## Proposed changes

Close related #7510 

Change function `percentile_approx` return value from `nan` to `null` (like hive.) to ensure that return value of function `percentile_approx`can be parsed by JDBC successfully.

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Code refactor (Modify the code structure, format the code, etc...)
- [ ] Optimization. Including functional usability improvements and performance improvements.
- [ ] Dependency. Such as changes related to third-party components.
- [ ] Other.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have created an issue on (Fix #7510 ) and described the bug/feature there in detail
- [ ] Compiling and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If these changes need document changes, I have updated the document
- [ ] Any dependent changes have been merged

