### PR TITLE
Revert "[improvement](planner) make BinaryPredicate do not cast date to datetime/varchar (#7045)"

### DIFF
--- a/be/src/exprs/bloomfilter_predicate.h
+++ b/be/src/exprs/bloomfilter_predicate.h
@@ -223,10 +223,11 @@ struct DateTimeFindOp : public CommonFindOp<DateTimeValue, BloomFilterAdaptor> {
     }
 };
 
+// avoid violating C/C++ aliasing rules.
+// https://gcc.gnu.org/bugzilla/show_bug.cgi?id=101684
+
 template <class BloomFilterAdaptor>
 struct DateFindOp : public CommonFindOp<DateTimeValue, BloomFilterAdaptor> {
-    // avoid violating C/C++ aliasing rules.
-    // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=101684
     bool find_olap_engine(const BloomFilterAdaptor& bloom_filter, const void* data) const {
         uint24_t date = *static_cast<const uint24_t*>(data);
         uint64_t value = uint32_t(date);
@@ -243,8 +244,6 @@ struct DateFindOp : public CommonFindOp<DateTimeValue, BloomFilterAdaptor> {
 
 template <class BloomFilterAdaptor>
 struct DecimalV2FindOp : public CommonFindOp<DecimalV2Value, BloomFilterAdaptor> {
-    // avoid violating C/C++ aliasing rules.
-    // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=101684
     bool find_olap_engine(const BloomFilterAdaptor& bloom_filter, const void* data) const {
         auto packed_decimal = *static_cast<const decimal12_t*>(data);
         DecimalV2Value value;

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/BinaryPredicate.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/BinaryPredicate.java
@@ -265,7 +265,26 @@ public class BinaryPredicate extends Predicate implements Writable {
         LOG.debug(debugString() + " opcode: " + vectorOpcode);
     }
 
+    private boolean canCompareDate(PrimitiveType t1, PrimitiveType t2) {
+        if (t1.isDateType()) {
+            if (t2.isDateType() || t2.isStringType() || t2.isIntegerType()) {
+                return true;
+            }
+            return false;
+        } else if (t2.isDateType()) {
+            if (t1.isStringType() || t1.isIntegerType()) {
+                return true;
+            }
+            return false;
+        } else {
+            return false;
+        }
+    }
+
     private Type getCmpType() throws AnalysisException {
+        PrimitiveType t1 = getChild(0).getType().getResultType().getPrimitiveType();
+        PrimitiveType t2 = getChild(1).getType().getResultType().getPrimitiveType();
+
         for (Expr e : getChildren()) {
             if (e.getType().getPrimitiveType() == PrimitiveType.HLL) {
                 throw new AnalysisException("Hll type dose not support operand: " + toSql());
@@ -275,39 +294,29 @@ public class BinaryPredicate extends Predicate implements Writable {
             }
         }
 
-        Type t1 = getChild(0).getType();
-        Type t2 = getChild(1).getType();
-
-        if (Type.canCompareDate(t1.getPrimitiveType(), t2.getPrimitiveType())) {
-            return Type.DATE;
-        }
-
-        if (Type.canCompareDatetime(t1.getPrimitiveType(), t2.getPrimitiveType())) {
+        if (canCompareDate(getChild(0).getType().getPrimitiveType(), getChild(1).getType().getPrimitiveType())) {
             return Type.DATETIME;
         }
 
-        PrimitiveType t1ResultType = t1.getResultType().getPrimitiveType();
-        PrimitiveType t2ResultType = t2.getResultType().getPrimitiveType();
-
         // Following logical is compatible with MySQL:
-        // Cast to DOUBLE by default, because DOUBLE has the largest range of values.
-        if (t1ResultType == PrimitiveType.VARCHAR && t2ResultType == PrimitiveType.VARCHAR) {
+        //    Cast to DOUBLE by default, because DOUBLE has the largest range of values.
+        if (t1 == PrimitiveType.VARCHAR && t2 == PrimitiveType.VARCHAR) {
             return Type.VARCHAR;
         }
-        if (t1ResultType == PrimitiveType.STRING && t2ResultType == PrimitiveType.STRING
-                || t1ResultType == PrimitiveType.STRING && t2ResultType == PrimitiveType.VARCHAR
-                || t1ResultType == PrimitiveType.VARCHAR && t2ResultType == PrimitiveType.STRING) {
+        if (t1 == PrimitiveType.STRING && t2 == PrimitiveType.STRING
+                || t1 == PrimitiveType.STRING && t2 == PrimitiveType.VARCHAR
+                || t1 == PrimitiveType.VARCHAR && t2 == PrimitiveType.STRING) {
             return Type.STRING;
         }
-        if (t1ResultType == PrimitiveType.BIGINT && t2ResultType == PrimitiveType.BIGINT) {
-            return Type.getAssignmentCompatibleType(t1, t2, false);
+        if (t1 == PrimitiveType.BIGINT && t2 == PrimitiveType.BIGINT) {
+            return Type.getAssignmentCompatibleType(getChild(0).getType(), getChild(1).getType(), false);
         }
-        if ((t1ResultType == PrimitiveType.BIGINT || t1ResultType == PrimitiveType.DECIMALV2)
-                && (t2ResultType == PrimitiveType.BIGINT || t2ResultType == PrimitiveType.DECIMALV2)) {
+        if ((t1 == PrimitiveType.BIGINT || t1 == PrimitiveType.DECIMALV2)
+                && (t2 == PrimitiveType.BIGINT || t2 == PrimitiveType.DECIMALV2)) {
             return Type.DECIMALV2;
         }
-        if ((t1ResultType == PrimitiveType.BIGINT || t1ResultType == PrimitiveType.LARGEINT)
-                && (t2ResultType == PrimitiveType.BIGINT || t2ResultType == PrimitiveType.LARGEINT)) {
+        if ((t1 == PrimitiveType.BIGINT || t1 == PrimitiveType.LARGEINT)
+                && (t2 == PrimitiveType.BIGINT || t2 == PrimitiveType.LARGEINT)) {
             return Type.LARGEINT;
         }
 
@@ -318,19 +327,17 @@ public class BinaryPredicate extends Predicate implements Writable {
         // When int column compares with string, Mysql will convert string to int.
         // So it is also compatible with Mysql.
 
-        if (t1ResultType == PrimitiveType.BIGINT
-                && (t2ResultType == PrimitiveType.VARCHAR || t2ResultType == PrimitiveType.STRING)) {
+        if (t1 == PrimitiveType.BIGINT && (t2 == PrimitiveType.VARCHAR || t2 ==PrimitiveType.STRING)) {
             Expr rightChild = getChild(1);
             Long parsedLong = Type.tryParseToLong(rightChild);
-            if (parsedLong != null) {
+            if(parsedLong != null) {
                 return Type.BIGINT;
             }
         }
-        if ((t1ResultType == PrimitiveType.VARCHAR || t1ResultType == PrimitiveType.STRING)
-                && t2ResultType == PrimitiveType.BIGINT) {
+        if ((t1 == PrimitiveType.VARCHAR || t1 ==PrimitiveType.STRING) && t2 == PrimitiveType.BIGINT) {
             Expr leftChild = getChild(0);
             Long parsedLong = Type.tryParseToLong(leftChild);
-            if (parsedLong != null) {
+            if(parsedLong != null) {
                 return Type.BIGINT;
             }
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Type.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Type.java
@@ -1005,20 +1005,15 @@ public abstract class Type {
             return t1;
         }
 
+        PrimitiveType t1ResultType = t1.getResultType().getPrimitiveType();
+        PrimitiveType t2ResultType = t2.getResultType().getPrimitiveType();
         if (canCompareDate(t1.getPrimitiveType(), t2.getPrimitiveType())) {
-            return Type.DATE;
-        }
-
-        if (canCompareDatetime(t1.getPrimitiveType(), t2.getPrimitiveType())) {
             return Type.DATETIME;
         }
 
-        PrimitiveType t1ResultType = t1.getResultType().getPrimitiveType();
-        PrimitiveType t2ResultType = t2.getResultType().getPrimitiveType();
-
         // Following logical is compatible with MySQL.
         if (t1ResultType == PrimitiveType.VARCHAR && t2ResultType == PrimitiveType.VARCHAR) {
-            return Type.VARCHAR;
+            return Type.VARCHAR; 
         }
         if ((t1ResultType == PrimitiveType.STRING && t2ResultType == PrimitiveType.STRING)
                 || (t1ResultType == PrimitiveType.STRING && t2ResultType == PrimitiveType.VARCHAR)
@@ -1027,30 +1022,30 @@ public abstract class Type {
         }
 
         // int family type and char family type should cast to char family type
-        if ((t1ResultType.isFixedPointType() && t2ResultType.isCharFamily())
-                || (t2ResultType.isFixedPointType() && t1ResultType.isCharFamily())) {
-            return t1.isStringType() ? t1 : t2;
+        if ((t1ResultType.isFixedPointType() && t2ResultType.isCharFamily()) ||
+                (t2ResultType.isFixedPointType() && t1ResultType.isCharFamily())) {
+            return t1.isStringType() ?  t1 : t2;
         }
 
         if (t1ResultType == PrimitiveType.BIGINT && t2ResultType == PrimitiveType.BIGINT) {
             return getAssignmentCompatibleType(t1, t2, false);
         }
-        if ((t1ResultType == PrimitiveType.BIGINT || t1ResultType == PrimitiveType.DECIMALV2)
-                && (t2ResultType == PrimitiveType.BIGINT || t2ResultType == PrimitiveType.DECIMALV2)) {
+        if ((t1ResultType == PrimitiveType.BIGINT
+                || t1ResultType == PrimitiveType.DECIMALV2)
+                && (t2ResultType == PrimitiveType.BIGINT
+                || t2ResultType == PrimitiveType.DECIMALV2)) {
             return Type.DECIMALV2;
         }
-        if ((t1ResultType == PrimitiveType.BIGINT || t1ResultType == PrimitiveType.LARGEINT)
-                && (t2ResultType == PrimitiveType.BIGINT || t2ResultType == PrimitiveType.LARGEINT)) {
+        if ((t1ResultType == PrimitiveType.BIGINT
+                || t1ResultType == PrimitiveType.LARGEINT)
+                && (t2ResultType == PrimitiveType.BIGINT
+                || t2ResultType == PrimitiveType.LARGEINT)) {
             return Type.LARGEINT;
         }
         return Type.DOUBLE;
     }
 
     public static boolean canCompareDate(PrimitiveType t1, PrimitiveType t2) {
-        return (t1 == PrimitiveType.DATE && t2 == PrimitiveType.DATE);
-    }
-
-    public static boolean canCompareDatetime(PrimitiveType t1, PrimitiveType t2) {
         if (t1.isDateType()) {
             if (t2.isDateType() || t2.isStringType() || t2.isIntegerType()) {
                 return true;

--- a/fe/fe-core/src/test/java/org/apache/doris/planner/QueryPlanTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/planner/QueryPlanTest.java
@@ -1605,11 +1605,6 @@ public class QueryPlanTest {
         String sql = "select day from tbl_int_date where day = '2020-10-30'";
         String explainString = UtFrameUtils.getSQLPlanOrErrorMsg(connectContext, "EXPLAIN " + sql);
         Assert.assertTrue(explainString.contains("PREDICATES: `day` = '2020-10-30 00:00:00'"));
-
-        sql = "select day from tbl_int_date where day = cast('2020-10-30' as date)";
-        explainString = UtFrameUtils.getSQLPlanOrErrorMsg(connectContext, "EXPLAIN " + sql);
-        Assert.assertTrue(explainString.contains("PREDICATES: `day` = '2020-10-30'"));
-
         sql = "select day from tbl_int_date where day = from_unixtime(1196440219)";
         explainString = UtFrameUtils.getSQLPlanOrErrorMsg(connectContext, "EXPLAIN " + sql);
         Assert.assertTrue(explainString.contains("PREDICATES: `day` = '2007-12-01 00:30:19'"));


### PR DESCRIPTION
## Proposed changes

The PR #7045 will cause wrong result with runtime filter with date/datetime type.

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Code refactor (Modify the code structure, format the code, etc...)
- [ ] Optimization. Including functional usability improvements and performance improvements.
- [ ] Dependency. Such as changes related to third-party components.
- [ ] Other.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have created an issue on (Fix #ISSUE) and described the bug/feature there in detail
- [ ] Compiling and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If these changes need document changes, I have updated the document
- [ ] Any dependent changes have been merged

## Further comments

If this is a relatively large or complex change, kick off the discussion at dev@doris.apache.org by explaining why you chose the solution you did and what alternatives you considered, etc...
