### PR TITLE
[deps][feature](mysql) Add mariadb-connector-c for mysql external table

### DIFF
--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -87,7 +87,6 @@ else()
     option(MAKE_TEST "ON for make unit test or OFF for not" OFF)
 endif()
 message(STATUS "make test: ${MAKE_TEST}")
-option(WITH_MYSQL "Support access MySQL" ON)
 
 # Check gcc
 if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
@@ -198,10 +197,8 @@ if(WITH_LZO)
     set_target_properties(lzo PROPERTIES IMPORTED_LOCATION ${THIRDPARTY_DIR}/lib/liblzo2.a)
 endif()
 
-if (WITH_MYSQL)
-    add_library(mysql STATIC IMPORTED)
-    set_target_properties(mysql PROPERTIES IMPORTED_LOCATION ${THIRDPARTY_DIR}/lib/libmysqlclient.a)
-endif()
+add_library(mysql STATIC IMPORTED)
+set_target_properties(mysql PROPERTIES IMPORTED_LOCATION ${THIRDPARTY_DIR}/lib/mariadb/libmariadbclient.a)
 
 add_library(libevent STATIC IMPORTED)
 set_target_properties(libevent PROPERTIES IMPORTED_LOCATION ${THIRDPARTY_DIR}/lib/libevent.a)
@@ -355,9 +352,7 @@ if ("${CMAKE_BUILD_TARGET_ARCH}" STREQUAL "x86" OR "${CMAKE_BUILD_TARGET_ARCH}" 
 endif()
 set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS}  -Wno-attributes -DS2_USE_GFLAGS -DS2_USE_GLOG")
 
-if (WITH_MYSQL)
-    set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -DDORIS_WITH_MYSQL")
-endif()
+set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -DDORIS_WITH_MYSQL")
 
 if (WITH_LZO)
     set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -DDORIS_WITH_LZO")
@@ -553,6 +548,7 @@ if(ARCH_AARCH64)
 else()
     set(DORIS_DEPENDENCIES
         ${DORIS_DEPENDENCIES}
+        mysql
         ${WL_START_GROUP}
         ${X86_DEPENDENCIES}
         ${WL_END_GROUP}
@@ -565,11 +561,6 @@ if(WITH_LZO)
     )
 endif()
 
-if (WITH_MYSQL)
-    set(DORIS_DEPENDENCIES ${DORIS_DEPENDENCIES}
-        mysql
-        )
-endif()
 
 message(STATUS "DORIS_DEPENDENCIES is ${DORIS_DEPENDENCIES}")
 

--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -519,6 +519,7 @@ set(COMMON_THIRDPARTY
     cctz
     minizip
     breakpad
+    mysql
     ${AWS_LIBS}
 )
 
@@ -548,7 +549,6 @@ if(ARCH_AARCH64)
 else()
     set(DORIS_DEPENDENCIES
         ${DORIS_DEPENDENCIES}
-        mysql
         ${WL_START_GROUP}
         ${X86_DEPENDENCIES}
         ${WL_END_GROUP}

--- a/be/src/exec/CMakeLists.txt
+++ b/be/src/exec/CMakeLists.txt
@@ -109,6 +109,8 @@ set(EXEC_FILES
     s3_reader.cpp
     s3_writer.cpp
     hdfs_reader_writer.cpp
+    mysql_scan_node.cpp
+    mysql_scanner.cpp
 )
 
 if (ARCH_AMD64)
@@ -116,14 +118,6 @@ if (ARCH_AMD64)
         ${EXEC_FILES}
         hdfs_file_reader.cpp
         hdfs_writer.cpp
-        )
-endif()
-
-if (WITH_MYSQL)
-    set(EXEC_FILES
-        ${EXEC_FILES}
-        mysql_scan_node.cpp
-        mysql_scanner.cpp
         )
 endif()
 

--- a/be/src/exec/data_sink.cpp
+++ b/be/src/exec/data_sink.cpp
@@ -103,7 +103,6 @@ Status DataSink::create_data_sink(ObjectPool* pool, const TDataSink& thrift_sink
         break;
     }
     case TDataSinkType::MYSQL_TABLE_SINK: {
-#ifdef DORIS_WITH_MYSQL
         if (!thrift_sink.__isset.mysql_table_sink) {
             return Status::InternalError("Missing data buffer sink.");
         }
@@ -112,10 +111,6 @@ Status DataSink::create_data_sink(ObjectPool* pool, const TDataSink& thrift_sink
         MysqlTableSink* mysql_tbl_sink = new MysqlTableSink(pool, row_desc, output_exprs);
         sink->reset(mysql_tbl_sink);
         break;
-#else
-        return Status::InternalError(
-                "Don't support MySQL table, you should rebuild Doris with WITH_MYSQL option ON");
-#endif
     }
     case TDataSinkType::ODBC_TABLE_SINK: {
         if (!thrift_sink.__isset.odbc_table_sink) {

--- a/be/src/exec/exec_node.cpp
+++ b/be/src/exec/exec_node.cpp
@@ -352,13 +352,9 @@ Status ExecNode::create_node(RuntimeState* state, ObjectPool* pool, const TPlanN
         return Status::OK();
 
     case TPlanNodeType::MYSQL_SCAN_NODE:
-#ifdef DORIS_WITH_MYSQL
         *node = pool->add(new MysqlScanNode(pool, tnode, descs));
         return Status::OK();
-#else
-        return Status::InternalError(
-                "Don't support MySQL table, you should rebuild Doris with WITH_MYSQL option ON");
-#endif
+
     case TPlanNodeType::ODBC_SCAN_NODE:
         *node = pool->add(new OdbcScanNode(pool, tnode, descs));
         return Status::OK();

--- a/be/src/exec/mysql_scanner.cpp
+++ b/be/src/exec/mysql_scanner.cpp
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include <mysql/mysql.h>
+#include <mariadb/mysql.h>
 
 #define __DorisMysql MYSQL
 #define __DorisMysqlRes MYSQL_RES

--- a/be/src/runtime/CMakeLists.txt
+++ b/be/src/runtime/CMakeLists.txt
@@ -113,14 +113,9 @@ set(RUNTIME_FILES
     cache/result_cache.cpp
     odbc_table_sink.cpp	
     minidump.cpp
+    mysql_table_writer.cpp
+    mysql_table_sink.cpp
 )
-
-if (WITH_MYSQL)
-    set(RUNTIME_FILES ${RUNTIME_FILES}
-        mysql_table_writer.cpp
-        mysql_table_sink.cpp
-        )
-endif()
 
 add_library(Runtime STATIC
     ${RUNTIME_FILES}

--- a/be/src/util/CMakeLists.txt
+++ b/be/src/util/CMakeLists.txt
@@ -108,13 +108,8 @@ set(UTIL_FILES
   s3_util.cpp
   topn_counter.cpp
   tuple_row_zorder_compare.cpp
+  mysql_load_error_hub.cpp
 )
-
-if (WITH_MYSQL)
-    set(UTIL_FILES ${UTIL_FILES}
-        mysql_load_error_hub.cpp
-        )
-endif()
 
 add_library(Util STATIC
     ${UTIL_FILES}

--- a/be/src/util/load_error_hub.cpp
+++ b/be/src/util/load_error_hub.cpp
@@ -42,15 +42,10 @@ Status LoadErrorHub::create_hub(ExecEnv* env, const TLoadErrorHubInfo* t_hub_inf
 
     switch (t_hub_info->type) {
     case TErrorHubType::MYSQL:
-#ifdef DORIS_WITH_MYSQL
         tmp_hub = new MysqlLoadErrorHub(t_hub_info->mysql_info);
         tmp_hub->prepare();
         hub->reset(tmp_hub);
         break;
-#else
-        return Status::InternalError(
-                "Don't support MySQL table, you should rebuild Doris with WITH_MYSQL option ON");
-#endif
     case TErrorHubType::BROKER: {
         // the origin file name may contains __shard_0/xxx
         // replace the '/' with '_'

--- a/build.sh
+++ b/build.sh
@@ -164,9 +164,6 @@ if [ ${CLEAN} -eq 1 -a ${BUILD_BE} -eq 0 -a ${BUILD_FE} -eq 0 -a ${BUILD_SPARK_D
     exit 0
 fi
 
-if [[ -z ${WITH_MYSQL} ]]; then
-    WITH_MYSQL=OFF
-fi
 if [[ -z ${GLIBC_COMPATIBILITY} ]]; then
     GLIBC_COMPATIBILITY=ON
 fi
@@ -184,7 +181,6 @@ echo "Get params:
     BUILD_SPARK_DPP     -- $BUILD_SPARK_DPP
     PARALLEL            -- $PARALLEL
     CLEAN               -- $CLEAN
-    WITH_MYSQL          -- $WITH_MYSQL
     WITH_LZO            -- $WITH_LZO
     GLIBC_COMPATIBILITY -- $GLIBC_COMPATIBILITY
     USE_AVX2            -- $USE_AVX2
@@ -214,7 +210,6 @@ if [ ${BUILD_BE} -eq 1 ] ; then
             -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} \
             -DMAKE_TEST=OFF \
             ${CMAKE_USE_CCACHE} \
-            -DWITH_MYSQL=${WITH_MYSQL} \
             -DWITH_LZO=${WITH_LZO} \
             -DUSE_AVX2=${USE_AVX2} \
             -DGLIBC_COMPATIBILITY=${GLIBC_COMPATIBILITY} ../

--- a/docs/en/extending-doris/odbc-of-doris.md
+++ b/docs/en/extending-doris/odbc-of-doris.md
@@ -1,6 +1,6 @@
 ---
 {
-    "title": "ODBC of Doris",
+    "title": "MySQL & ODBC External Table"
     "language": "en"
 }
 ---
@@ -25,16 +25,17 @@ under the License.
 -->
 
 
-# ODBC External Table Of Doris
+# MySQL & ODBC External Table
 
-ODBC external table of Doris provides Doris access to external tables through the standard interface for database access (ODBC). The external table eliminates the tedious data import work and enables Doris to have the ability to access all kinds of databases. It solves the data analysis problem of external tables with Doris' OLAP capability.
+Doris supports access to external tables through the standard database access interface (ODBC), which eliminates the need for cumbersome data import and gives Doris the ability to access various databases and solve the data analysis problems of external tables with the help of Doris' own OLAP capabilities.
 
 1. Support various data sources to access Doris
 2. Support Doris query with tables in various data sources to perform more complex analysis operations
 3. Use insert into to write the query results executed by Doris to the external data source
 
+At the same time, for MySQL database, Doris can also directly connect through mariadb-connector without relying on ODBC.
 
-This document mainly introduces the implementation principle and usage of this ODBC external table.
+This document mainly introduces the realization principle and usage method of this function.
 
 ## Glossary
 
@@ -45,7 +46,43 @@ This document mainly introduces the implementation principle and usage of this O
 
 ## How To Use
 
+### Create MySQL External Table
+
+```
+CREATE EXTERNAL TABLE example_db.table_mysql
+(
+k1 DATE,
+k2 INT,
+k3 SMALLINT,
+k4 VARCHAR(2048),
+k5 DATETIME
+)
+ENGINE=mysql
+PROPERTIES
+(
+"host" = "127.0.0.1",
+"port" = "8239",
+"user" = "mysql_user",
+"password" = "mysql_passwd",
+"database" = "mysql_db_test",
+"table" = "mysql_table_test"
+)
+```
+
+Parameter Description:
+
+Parameters | Description
+---|---
+**hosts** | MySQL database IP
+**port** | MySQL database port
+**user** | The username of the MySQL database
+**password** | MySQL database password
+**database** | Database name in MySQL data
+**table** | The name of the table in the MySQL database
+
 ### Create ODBC External Table 
+
+By installing the ODBC driver (including MySQL) corresponding to the data source, you can create an ODBC external table and connect.
 
 #### 1. Creating ODBC external table without resource
 

--- a/docs/en/installing/compilation.md
+++ b/docs/en/installing/compilation.md
@@ -207,19 +207,16 @@ You can try to compile Doris directly in your own Linux environment.
 
 ## Special statement
 
-Starting from version 0.13, the dependency on the two third-party libraries [1] and [2] will be removed in the default compiled output. These two third-party libraries are under [GNU General Public License V3](https://www.gnu.org/licenses/gpl-3.0.en.html). This license is incompatible with [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0), so it should not appear in the Apache release by default.
+Starting from version 0.13, the dependency [1] will be removed in the default compiled output. This third-party libraries are under [GNU General Public License V3](https://www.gnu.org/licenses/gpl-3.0.en.html). This license is incompatible with [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0), so it should not appear in the Apache release by default.
 
-Remove library [1] will result in the inability to access MySQL external tables. The feature of accessing MySQL external tables will be implemented through `UnixODBC` in future release version.
-
-Remove library [2] will cause some data written in earlier versions (before version 0.8) to be unable to read. Because the data in the earlier version was compressed using the LZO algorithm, in later versions, it has been changed to the LZ4 compression algorithm. We will provide tools to detect and convert this part of the data in the future.
+Remove library [1] will cause some data written in earlier versions (before version 0.8) to be unable to read. Because the data in the earlier version was compressed using the LZO algorithm, in later versions, it has been changed to the LZ4 compression algorithm. We will provide tools to detect and convert this part of the data in the future.
 
 If required, users can continue to use these two dependent libraries. If you want to use it, you need to add the following options when compiling:
 
 ```
-WITH_MYSQL=1 WITH_LZO=1 sh build.sh
+WITH_LZO=1 sh build.sh
 ```
 
 Note that when users rely on these two third-party libraries, Doris is not used under the Apache License 2.0 by default. Please pay attention to the GPL related agreements.
 
-* [1] mysql-5.7.18
-* [2] lzo-2.10
+* [1] lzo-2.10

--- a/docs/zh-CN/extending-doris/odbc-of-doris.md
+++ b/docs/zh-CN/extending-doris/odbc-of-doris.md
@@ -1,6 +1,6 @@
 ---
 {
-    "title": "ODBC of Doris",
+    "title": "MySQL & ODBC External Table",
     "language": "zh-CN"
 }
 ---
@@ -24,25 +24,64 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-# ODBC External Table Of Doris
+# MySQL & ODBC External Table
 
-ODBC External Table Of Doris 提供了Doris通过数据库访问的标准接口(ODBC)来访问外部表，外部表省去了繁琐的数据导入工作，让Doris可以具有了访问各式数据库的能力，并借助Doris本身的OLAP的能力来解决外部表的数据分析问题：
+Doris支持通过数据库访问的标准接口(ODBC)来访问外部表，外部表省去了繁琐的数据导入工作，让Doris可以具有了访问各式数据库的能力，并借助Doris本身的OLAP的能力来解决外部表的数据分析问题：
 
- 1. 支持各种数据源接入Doris
- 2. 支持Doris与各种数据源中的表联合查询，进行更加复杂的分析操作
-  3. 通过insert into将Doris执行的查询结果写入外部的数据源
+1. 支持各种支持ODBC的数据源接入Doris
+2. 支持Doris与各种数据源中的表联合查询，进行更加复杂的分析操作
+3. 通过insert into将Doris执行的查询结果写入外部的数据源
+
+同时，对于 MySQL 数据库，Doris 也可以不依赖 ODBC，而直接通过 mariadb-connector 连接。 
 
 本文档主要介绍该功能的实现原理、使用方式等。
 
 ## 名词解释
 
 ### Doris相关
+
 * FE：Frontend，Doris 的前端节点,负责元数据管理和请求接入
 * BE：Backend，Doris 的后端节点,负责查询执行和数据存储
 
 ## 使用方法
 
-### Doris中创建ODBC的外表
+### 创建 MySQL 外表
+
+```
+CREATE EXTERNAL TABLE example_db.table_mysql
+(
+k1 DATE,
+k2 INT,
+k3 SMALLINT,
+k4 VARCHAR(2048),
+k5 DATETIME
+)
+ENGINE=mysql
+PROPERTIES
+(
+"host" = "127.0.0.1",
+"port" = "8239",
+"user" = "mysql_user",
+"password" = "mysql_passwd",
+"database" = "mysql_db_test",
+"table" = "mysql_table_test"
+)
+```
+
+参数说明：
+
+参数 | 说明
+---|---
+**hosts** | MySQL 数据库 IP
+**port** | MySQL 数据库端口
+**user** | MySQL 数据库的用户名
+**password** | MySQL 数据库的密码
+**database** | MySQL 数据中的数据库名称
+**table** | MySQL 数据库中的表名称
+
+### 创建 ODBC 外表
+
+通过安装对应数据源的 ODBC 驱动（包括 MySQL），可以创建 ODBC 外表并连接。
 
 #### 1. 不使用Resource创建ODBC的外表
 

--- a/docs/zh-CN/installing/compilation.md
+++ b/docs/zh-CN/installing/compilation.md
@@ -208,19 +208,16 @@ under the License.
 
 ## 特别声明
 
-自 0.13 版本开始，默认的编译产出中将取消对 [1] 和 [2] 两个第三方库的依赖。这两个第三方库为 [GNU General Public License V3](https://www.gnu.org/licenses/gpl-3.0.en.html) 协议。该协议与 [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0) 协议不兼容，因此默认不出现在 Apache 发布版本中。
+自 0.13 版本开始，默认的编译产出中将取消对 [1] 的依赖。这个第三方库为 [GNU General Public License V3](https://www.gnu.org/licenses/gpl-3.0.en.html) 协议。该协议与 [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0) 协议不兼容，因此默认不出现在 Apache 发布版本中。
 
-移除依赖库 [1] 会导致无法访问 MySQL 外部表。访问 MySQL 外部表的功能会在后续版本中通过 UnixODBC 实现。
-
-移除依赖库 [2] 会导致在无法读取部分早期版本（0.8版本之前）写入的部分数据。因为早期版本中的数据是使用 LZO 算法压缩的，在之后的版本中，已经更改为 LZ4 压缩算法。后续我们会提供工具用于检测和转换这部分数据。
+移除依赖库 [1] 会导致在无法读取部分早期版本（0.8版本之前）写入的部分数据。因为早期版本中的数据是使用 LZO 算法压缩的，在之后的版本中，已经更改为 LZ4 压缩算法。后续我们会提供工具用于检测和转换这部分数据。
 
 如果有需求，用户可以继续使用这两个依赖库。如需使用，需要在编译时添加如下选项：
 
 ```
-WITH_MYSQL=1 WITH_LZO=1 sh build.sh
+WITH_LZO=1 sh build.sh
 ```
 
 注意，当用户依赖这两个第三方库时，则默认不在 Apache License 2.0 协议框架下使用 Doris。请注意 GPL 相关协议约束。
 
-* [1] mysql-5.7.18
-* [2] lzo-2.10
+* [1] lzo-2.10

--- a/thirdparty/CHANGELOG.md
+++ b/thirdparty/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 This file contains version of the third-party dependency libraries in the build-env image. The docker build-env image is apache/incubator-doris, and the tag is `build-env-${version}`
 
+## v20211229
+
+- Removed: mysql-5.7.18
+- Added: mariadb-connector-c-3.1.15
+
 ## v20211220
 
 - Modified: OpenSSL 1.0.2k -> 1.1.1m

--- a/thirdparty/vars.sh
+++ b/thirdparty/vars.sh
@@ -154,12 +154,6 @@ BOOST_NAME=boost_1_73_0.tar.gz
 BOOST_SOURCE=boost_1_73_0
 BOOST_MD5SUM="4036cd27ef7548b8d29c30ea10956196"
 
-# mysql
-MYSQL_DOWNLOAD="https://github.com/mysql/mysql-server/archive/mysql-5.7.18.tar.gz"
-MYSQL_NAME=mysql-5.7.18.tar.gz
-MYSQL_SOURCE=mysql-server-mysql-5.7.18
-MYSQL_MD5SUM="58598b10dce180e4d1fbdd7cf5fa68d6"
-
 # unix odbc
 ODBC_DOWNLOAD="http://www.unixodbc.org/unixODBC-2.3.7.tar.gz"
 ODBC_NAME=unixODBC-2.3.7.tar.gz
@@ -389,6 +383,12 @@ BREAKPAD_NAME=breakpad-src-38ee0be-with-lss.tar.gz
 BREAKPAD_SOURCE=breakpad-src-38ee0be-with-lss
 BREAKPAD_MD5SUM="fd8c4f6f5cf8b5e03a4c3c39fde83368"
 
+# mariadb-connector-c
+MARIADB_DOWNLOAD="https://github.com/mariadb-corporation/mariadb-connector-c/archive/refs/tags/v3.1.15.tar.gz"
+MARIADB_NAME="mariadb-connector-c-3.1.15.tar.gz"
+MARIADB_SOURCE="mariadb-connector-c-3.1.15"
+MARIADB_MD5SUM="38306253a34b091b05a949dddbccd1c2"
+
 # all thirdparties which need to be downloaded is set in array TP_ARCHIVES
 export TP_ARCHIVES="LIBEVENT
 OPENSSL
@@ -407,7 +407,6 @@ LZO2
 CURL
 RE2
 BOOST
-MYSQL
 ODBC
 LEVELDB
 BRPC
@@ -445,5 +444,6 @@ HDFS3
 LIBDIVIDE
 PDQSORT
 BENCHMARK
-BREAKPAD"
+BREAKPAD
+MARIADB"
 


### PR DESCRIPTION
## Proposed changes

1. Add `mariadb-connector-c v3.1.15`

    The origin MySQL-5.7 is under GPLv2, which is not compatible with APLv2.
    So I use mariadb-connector-c to replace it, which is under LGPL

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [ ] Dependency. Such as changes related to third-party components.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have created an issue on (Fix #ISSUE) and described the bug/feature there in detail
- [ ] Compiling and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If these changes need document changes, I have updated the document
- [ ] Any dependent changes have been merged

## Further comments

If this is a relatively large or complex change, kick off the discussion at dev@doris.apache.org by explaining why you chose the solution you did and what alternatives you considered, etc...
