### PR TITLE
[Improvement] Default cooldown time for storage medium SSD

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/DataProperty.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/DataProperty.java
@@ -43,7 +43,13 @@ public class DataProperty implements Writable {
     }
 
     public DataProperty(TStorageMedium medium) {
-        this(medium, MAX_COOLDOWN_TIME_MS);
+        this.storageMedium = medium;
+        if (medium == TStorageMedium.SSD) {
+            long currentTimeMs = System.currentTimeMillis();
+            this.cooldownTimeMs = currentTimeMs + Config.storage_cooldown_second * 1000L;
+        } else {
+            this.cooldownTimeMs = MAX_COOLDOWN_TIME_MS;
+        }
     }
 
     public DataProperty(TStorageMedium medium, long cooldown) {

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/DataPropertyTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/DataPropertyTest.java
@@ -1,0 +1,42 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.catalog;
+
+import org.apache.doris.common.Config;
+import org.apache.doris.thrift.TStorageMedium;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class DataPropertyTest {
+
+    @Test
+    public void tesCooldownTimeMs() throws Exception {
+        Config.default_storage_medium = "ssd";
+        DataProperty dataProperty = DataProperty.DEFAULT_DATA_PROPERTY;
+        Assert.assertNotEquals(DataProperty.MAX_COOLDOWN_TIME_MS, dataProperty.getCooldownTimeMs());
+
+        dataProperty = new DataProperty(TStorageMedium.SSD);
+        Assert.assertNotEquals(DataProperty.MAX_COOLDOWN_TIME_MS, dataProperty.getCooldownTimeMs());
+
+        dataProperty = new DataProperty(TStorageMedium.SSD, System.currentTimeMillis() + 24 * 3600 * 1000L);
+        Assert.assertEquals(System.currentTimeMillis() + 24 * 3600 * 1000L, dataProperty.getCooldownTimeMs());
+
+        dataProperty = new DataProperty(TStorageMedium.HDD);
+        Assert.assertEquals(DataProperty.MAX_COOLDOWN_TIME_MS, dataProperty.getCooldownTimeMs());
+    }
+}


### PR DESCRIPTION
## Proposed changes
Refer to this issule https://github.com/apache/incubator-doris/issues/7528

When setting property `default_storage_medium=ssd` and `storage_cooldown_second=xxx` in `fe.conf`
`cooldownTime=System.currentTimeMillis()+ storage_cooldown_second` , not always `MAX_COOLDOWN_TIME_MS`

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Code refactor (Modify the code structure, format the code, etc...)
- [x] Optimization. Including functional usability improvements and performance improvements.
- [ ] Dependency. Such as changes related to third-party components.
- [ ] Other.

## Checklist

- [x] I have created an issue on (Fix #ISSUE) and described the bug/feature there in detail
- [x] Compiling and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If these changes need document changes, I have updated the document
- [ ] Any dependent changes have been merged

