### PR TITLE
[Website] Make web page base proc dir and varibles orderly

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/proc/BaseProcDir.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/proc/BaseProcDir.java
@@ -19,6 +19,8 @@ package org.apache.doris.common.proc;
 
 import org.apache.doris.common.AnalysisException;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 import com.google.common.collect.Lists;
@@ -49,7 +51,9 @@ public class BaseProcDir implements ProcDirInterface {
     public ProcResult fetchResult() throws AnalysisException {
         BaseProcResult result = new BaseProcResult();
         result.setNames(Lists.newArrayList("name"));
-        for (String name : nodeMap.keySet()) {
+        List<String> nameList = Lists.newArrayList(nodeMap.keySet());
+        Collections.sort(nameList);
+        for (String name : nameList) {
             result.addRow(Lists.newArrayList(name));
         }
         return result;

--- a/fe/fe-core/src/main/java/org/apache/doris/http/action/VariableAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/http/action/VariableAction.java
@@ -17,7 +17,6 @@
 
 package org.apache.doris.http.action;
 
-import com.google.common.collect.Lists;
 import org.apache.doris.analysis.SetType;
 import org.apache.doris.common.Config;
 import org.apache.doris.http.ActionController;
@@ -25,6 +24,8 @@ import org.apache.doris.http.BaseRequest;
 import org.apache.doris.http.BaseResponse;
 import org.apache.doris.http.IllegalArgException;
 import org.apache.doris.qe.VariableMgr;
+
+import com.google.common.collect.Lists;
 
 import io.netty.handler.codec.http.HttpMethod;
 
@@ -38,7 +39,7 @@ public class VariableAction extends WebBaseAction {
         super(controller);
     }
 
-    public static void registerAction (ActionController controller) throws IllegalArgException {
+    public static void registerAction(ActionController controller) throws IllegalArgException {
         controller.registerHandler(HttpMethod.GET, "/variable", new VariableAction(controller));
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/http/action/VariableAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/http/action/VariableAction.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.http.action;
 
+import com.clearspring.analytics.util.Lists;
 import org.apache.doris.analysis.SetType;
 import org.apache.doris.common.Config;
 import org.apache.doris.http.ActionController;
@@ -27,6 +28,8 @@ import org.apache.doris.qe.VariableMgr;
 
 import io.netty.handler.codec.http.HttpMethod;
 
+import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 
@@ -57,7 +60,9 @@ public class VariableAction extends WebBaseAction {
         HashMap<String, String> confmap;
         try {
             confmap = Config.dump();
-            for (String key : confmap.keySet()) {
+            List<String> keyList = Lists.newArrayList(confmap.keySet());
+            Collections.sort(keyList);
+            for (String key : keyList) {
                 buffer.append(key + "=" + confmap.get(key) + "\n");
             }
         } catch (Exception e) {

--- a/fe/fe-core/src/main/java/org/apache/doris/http/action/VariableAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/http/action/VariableAction.java
@@ -17,7 +17,7 @@
 
 package org.apache.doris.http.action;
 
-import com.clearspring.analytics.util.Lists;
+import com.google.common.collect.Lists;
 import org.apache.doris.analysis.SetType;
 import org.apache.doris.common.Config;
 import org.apache.doris.http.ActionController;
@@ -28,7 +28,6 @@ import org.apache.doris.qe.VariableMgr;
 
 import io.netty.handler.codec.http.HttpMethod;
 
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;


### PR DESCRIPTION
## Proposed changes

Make FE web page `BaseProcDir` and `varibles` orderly, because disorder is maddening.

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Code refactor (Modify the code structure, format the code, etc...)
- [x] Optimization. Including functional usability improvements and performance improvements.
- [ ] Dependency. Such as changes related to third-party components.
- [ ] Other.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have created an issue on (Fix #ISSUE) and described the bug/feature there in detail
- [ ] Compiling and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If these changes need document changes, I have updated the document
- [ ] Any dependent changes have been merged

## Further comments

If this is a relatively large or complex change, kick off the discussion at dev@doris.apache.org by explaining why you chose the solution you did and what alternatives you considered, etc...
