### PR TITLE
Fix NPE when using `ConnectContext` instance in partition pruning related logic.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/Analyzer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/Analyzer.java
@@ -1757,6 +1757,8 @@ public class Analyzer {
         return schemaTable;
     }
 
+    // TODO: `globalState.context` could be null, refactor return value type to
+    // `Optional<ConnectContext>`.
     public ConnectContext getContext() {
         return globalState.context;
     }
@@ -1802,6 +1804,15 @@ public class Analyzer {
             return false;
         }
         return globalState.context.getSessionVariable().isEnableInferPredicate();
+    }
+
+    // Use V2 version as default implementation.
+    public boolean partitionPruneV2Enabled() {
+        if (globalState.context == null) {
+            return true;
+        } else {
+            return globalState.context.getSessionVariable().getPartitionPruneAlgorithmVersion() == 2;
+        }
     }
 
     // The cost based join reorder is turned on

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/OlapScanNode.java
@@ -426,7 +426,7 @@ public class OlapScanNode extends ScanNode {
         }
 
         if (partitionInfo.getType() == PartitionType.RANGE) {
-            if (analyzer.getContext().getSessionVariable().getPartitionPruneAlgorithmVersion() == 2) {
+            if (analyzer.partitionPruneV2Enabled()) {
                 partitionPruner = new RangePartitionPrunerV2(keyItemMap,
                         partitionInfo.getPartitionColumns(), columnNameToRange);
             } else {
@@ -434,7 +434,7 @@ public class OlapScanNode extends ScanNode {
                         partitionInfo.getPartitionColumns(), columnFilters);
             }
         } else if (partitionInfo.getType() == PartitionType.LIST) {
-            if (analyzer.getContext().getSessionVariable().getPartitionPruneAlgorithmVersion() == 2) {
+            if (analyzer.partitionPruneV2Enabled()) {
                 partitionPruner = new ListPartitionPrunerV2(keyItemMap, partitionInfo.getPartitionColumns(),
                     columnNameToRange);
             } else {

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/ScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/ScanNode.java
@@ -133,7 +133,7 @@ abstract public class ScanNode extends PlanNode {
                 columnFilters.put(column.getName(), keyFilter);
             }
 
-            if (analyzer.getContext().getSessionVariable().getPartitionPruneAlgorithmVersion() == 2) {
+            if (analyzer.partitionPruneV2Enabled()) {
                 ColumnRange columnRange = createColumnRange(slotDesc, conjuncts);
                 if (columnRange != null) {
                     columnNameToRange.put(column.getName(), columnRange);


### PR DESCRIPTION
## Proposed changes
Before this PR, NPE would occur when running SQL without `ConnectContext`, e.g., `EXPORT TABLE  t TO "file:///home/data/export.txt"`.


## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Code refactor (Modify the code structure, format the code, etc...)
- [ ] Optimization. Including functional usability improvements and performance improvements.
- [ ] Dependency. Such as changes related to third-party components.
- [ ] Other.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have created an issue on (Fix #ISSUE) and described the bug/feature there in detail
- [ ] Compiling and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If these changes need document changes, I have updated the document
- [ ] Any dependent changes have been merged

## Further comments

If this is a relatively large or complex change, kick off the discussion at dev@doris.apache.org by explaining why you chose the solution you did and what alternatives you considered, etc...
