### PR TITLE
[refactor](olap) prefer to malloc for _variable_buf once rather than malloc repeatedly

### DIFF
--- a/be/src/olap/row_cursor.cpp
+++ b/be/src/olap/row_cursor.cpp
@@ -301,9 +301,17 @@ std::string RowCursor::to_string() const {
 
     return result;
 }
+
 OLAPStatus RowCursor::_alloc_buf() {
     // variable_len for null bytes
     size_t len = _variable_len;
+    /*
+     * calc buf len in advance, and then alloc the whole buf by new char[len]
+     * the beginning _variable_len of the _variable_buf is for Slice 
+     * followed by the pointer array[_string_field_count], each item pointer to the text_buf
+     * followed by the text buf as the last part of _variable_buf
+     * do as this can reduce calling new times, the buf is continuous, it's a common idiom 
+     * */
     len += _string_field_count * (sizeof(char*) + DEFAULT_TEXT_LENGTH);
 
     _variable_buf = new (nothrow) char[len];

--- a/be/src/olap/row_cursor.h
+++ b/be/src/olap/row_cursor.h
@@ -36,10 +36,13 @@ class RowCursor {
 public:
     static const int DEFAULT_TEXT_LENGTH = 128;
 
-    RowCursor();
+    RowCursor() = default;
 
     // 遍历销毁field指针
-    ~RowCursor();
+    ~RowCursor() {
+        delete [] _owned_fixed_buf;
+        delete [] _variable_buf;
+    }
 
     // 根据传入schema的创建RowCursor
     OLAPStatus init(const TabletSchema& schema);
@@ -161,13 +164,12 @@ private:
     std::unique_ptr<Schema> _schema;
 
     char* _fixed_buf = nullptr; // point to fixed buf
-    size_t _fixed_len;
+    size_t _fixed_len = 0;
     char* _owned_fixed_buf = nullptr; // point to buf allocated in init function
 
     char* _variable_buf = nullptr;
-    size_t _variable_len;
-    size_t _string_field_count;
-    char** _long_text_buf;
+    size_t _variable_len = 0;
+    size_t _string_field_count = 0;
 
     DISALLOW_COPY_AND_ASSIGN(RowCursor);
 };


### PR DESCRIPTION
## Proposed changes

1. calc the total buf len before mallocing in the function _alloc_buf()
2. delete unnecessary member data such as _long_text_buf
3. use std::iota() to set std::vector<int> columns  consistently

I have completed the comparing test, result shows that using a whole buf is quicker

Close related #issue (replace it with issue number if it exists).

Describe the overview of changes, and introduce why we need it.

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ x] Code refactor (Modify the code structure, format the code, etc...)
- [ ] Optimization. Including functional usability improvements and performance improvements.
- [ ] Dependency. Such as changes related to third-party components.
- [ ] Other.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have created an issue on (Fix #ISSUE) and described the bug/feature there in detail
- [ ] Compiling and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If these changes need document changes, I have updated the document
- [ ] Any dependent changes have been merged

## Further comments

If this is a relatively large or complex change, kick off the discussion at dev@doris.apache.org by explaining why you chose the solution you did and what alternatives you considered, etc...
