### PR TITLE
[vectorized][refactor](common) eliminate class COW dependence on boost

### DIFF
--- a/be/src/vec/exec/vanalytic_eval_node.cpp
+++ b/be/src/vec/exec/vanalytic_eval_node.cpp
@@ -391,7 +391,7 @@ BlockRowPos VAnalyticEvalNode::_compare_row_to_find_end(int idx, BlockRowPos sta
     }
 
     //check whether need get column again, maybe same as first init
-    if (start_column != start_next_block_column) {
+    if (start_column.get() != start_next_block_column.get()) {
         start_init_row_num = 0;
         start.block_num = start_block_num;
         start_column = _input_blocks[start.block_num].get_by_position(idx).column;

--- a/be/src/vec/functions/function_cast.h
+++ b/be/src/vec/functions/function_cast.h
@@ -1110,7 +1110,7 @@ private:
                 const auto& tmp_res = tmp_block.get_by_position(tmp_res_index);
 
                 /// May happen in fuzzy tests. For debug purpose.
-                if (!tmp_res.column) {
+                if (!tmp_res.column.get()) {
                     return Status::RuntimeError(fmt::format(
                             "Couldn't convert {} to {} in prepare_remove_nullable wrapper.",
                             block.get_by_position(arguments[0]).type->get_name(),


### PR DESCRIPTION
## Proposed changes

1. replace boost library relative classes & functions with hand writing implement
2. avoid casting for get_ptr()
3. COW and its derived class COWHelper both defined non-virtual member derived() , it is bad practice and should avoid doing like this
4. i try to use deriving from std::unique_ptr to implement mutable_ptr, and deriving from std::shared_ptr to implement immutable_ptr，but it's very difficult to complete because will result in massive modifications

Close related #issue (replace it with issue number if it exists).

Describe the overview of changes, and introduce why we need it.

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Code refactor (Modify the code structure, format the code, etc...)
- [ ] Optimization. Including functional usability improvements and performance improvements.
- [ ] Dependency. Such as changes related to third-party components.
- [ ] Other.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have created an issue on (Fix #ISSUE) and described the bug/feature there in detail
- [ ] Compiling and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If these changes need document changes, I have updated the document
- [ ] Any dependent changes have been merged

## Further comments

If this is a relatively large or complex change, kick off the discussion at dev@doris.apache.org by explaining why you chose the solution you did and what alternatives you considered, etc...
