### PR TITLE
[feature](function) Support iot_first/last function

### DIFF
--- a/be/src/common/daemon.cpp
+++ b/be/src/common/daemon.cpp
@@ -44,6 +44,7 @@
 #include "exprs/time_operators.h"
 #include "exprs/timestamp_functions.h"
 #include "exprs/topn_function.h"
+#include "exprs/iot_functions.h"
 #include "exprs/utility_functions.h"
 #include "geo/geo_functions.h"
 #include "olap/options.h"
@@ -265,6 +266,7 @@ void Daemon::init(int argc, char** argv, const std::vector<StorePath>& paths) {
     HllFunctions::init();
     HashFunctions::init();
     TopNFunctions::init();
+    IoTFunctions::init();
     DummyTableFunctions::init();
 
     LOG(INFO) << CpuInfo::debug_string();

--- a/be/src/exprs/CMakeLists.txt
+++ b/be/src/exprs/CMakeLists.txt
@@ -71,6 +71,7 @@ add_library(Exprs
   hll_function.cpp
   grouping_sets_functions.cpp
   topn_function.cpp
+  iot_functions.cpp
 
   table_function/explode_split.cpp
   table_function/explode_bitmap.cpp

--- a/be/src/exprs/iot_functions.cpp
+++ b/be/src/exprs/iot_functions.cpp
@@ -17,6 +17,8 @@
 
 #include "exprs/iot_functions.h"
 
+#include "common/logging.h"
+
 namespace doris {
 
 struct IoTFirstState {
@@ -92,8 +94,12 @@ DoubleVal IoTFunctions::iot_first_finalize(FunctionContext* ctx, const StringVal
     if (src.is_null) {
         return DoubleVal::null();
     }
-    auto* src_data = reinterpret_cast<IoTFirstState*>(src.ptr);
-    return DoubleVal(src_data->val);
+
+    // skip (ts)
+    uint8_t* ptr = src.ptr + sizeof(int64_t);
+    double val;
+    memcpy(&val, ptr, sizeof(double));
+    return DoubleVal(val);
 }
 
 } // namespace doris

--- a/be/src/exprs/iot_functions.cpp
+++ b/be/src/exprs/iot_functions.cpp
@@ -1,0 +1,99 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "exprs/iot_functions.h"
+
+namespace doris {
+
+struct IoTFirstState {
+    BigIntVal ts;
+    DoubleVal val;
+};
+
+void IoTFunctions::init() {}
+
+void IoTFunctions::_init_iot_first_state(FunctionContext* context,
+                                         const BigIntVal& ts, const DoubleVal& val,
+                                         StringVal* dst) {
+    size_t str_len = sizeof(IoTFirstState);
+    dst->is_null = false;
+    dst->ptr = context->allocate(str_len);
+    dst->len = str_len;
+    auto *dst_data = reinterpret_cast<IoTFirstState*>(dst->ptr);
+    dst_data->ts = ts;
+    dst_data->val = val; 
+}
+
+void IoTFunctions::iot_first_update(FunctionContext* context, const BigIntVal& ts, const DoubleVal& val,
+        StringVal* dst) {
+    if (ts.is_null || val.is_null) {
+        return;
+    }
+
+    if (dst->is_null) {
+        // first update
+        _init_iot_first_state(context, ts, val, dst);
+    } else {
+        auto* dst_data = reinterpret_cast<IoTFirstState*>(dst->ptr);
+        if (val.val < dst_data->val.val) {
+            dst_data->ts = ts;
+            dst_data->val = val; 
+        }
+    }
+}
+
+void IoTFunctions::iot_first_merge(FunctionContext* ctx, const StringVal& src, StringVal* dst) {
+    if (src.is_null) {
+        return;
+    }
+    auto* src_data = reinterpret_cast<IoTFirstState*>(src.ptr);
+    if (dst->is_null) {
+        // first update
+        _init_iot_first_state(ctx, src_data->ts, src_data->val, dst);
+    } else {
+        auto* dst_data = reinterpret_cast<IoTFirstState*>(dst->ptr);
+        if (src_data->ts.val < dst_data->ts.val) {
+            dst_data->ts = src_data->ts;
+            src_data->val = src_data->val;
+        }
+    }
+}
+
+StringVal IoTFunctions::iot_first_serialize(FunctionContext* ctx, const StringVal& src) {
+    if (src.is_null) {
+        return src;
+    }
+
+    auto* src_data = reinterpret_cast<IoTFirstState*>(src.ptr);
+    StringVal result(ctx, sizeof(IoTFirstState));
+    uint8_t* ptr = result.ptr;
+    memcpy(ptr, &(src_data->ts.val), sizeof(int64_t));
+    ptr += sizeof(int64_t);
+    memcpy(ptr, &(src_data->val.val), sizeof(double));
+    ctx->free(src.ptr);
+    return result;
+}
+
+DoubleVal IoTFunctions::iot_first_finalize(FunctionContext* ctx, const StringVal& src) {
+    if (src.is_null) {
+        return DoubleVal::null();
+    }
+    auto* src_data = reinterpret_cast<IoTFirstState*>(src.ptr);
+    return DoubleVal(src_data->val);
+}
+
+} // namespace doris

--- a/be/src/exprs/iot_functions.h
+++ b/be/src/exprs/iot_functions.h
@@ -25,18 +25,19 @@ class IoTFunctions {
 public:
     static void init();
 
-    static void iot_first_init(FunctionContext*, StringVal* dst);
-
     static void iot_first_update(FunctionContext*, const BigIntVal& ts, const DoubleVal& val, StringVal* dst);
-
     static void iot_first_merge(FunctionContext*,const StringVal& src, StringVal* dst);
 
-    static StringVal iot_first_serialize(FunctionContext* ctx, const StringVal& src);
+    static void iot_last_update(FunctionContext*, const BigIntVal& ts, const DoubleVal& val, StringVal* dst);
+    static void iot_last_merge(FunctionContext*,const StringVal& src, StringVal* dst);
 
-    static DoubleVal iot_first_finalize(FunctionContext*, const StringVal& src);
+    // serialize for iot_first() iot_last()
+    static StringVal iot_first_last_serialize(FunctionContext* ctx, const StringVal& src);
+    // finalize for iot_first() iot_last()
+    static DoubleVal iot_first_last_finalize(FunctionContext*, const StringVal& src);
 
 private:
-    static void _init_iot_first_state(FunctionContext* context,
+    static void _init_iot_first_last_state(FunctionContext* context,
             const BigIntVal& ts, const DoubleVal& val,
             StringVal* dst);
 };

--- a/be/src/exprs/iot_functions.h
+++ b/be/src/exprs/iot_functions.h
@@ -1,0 +1,45 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include "udf/udf.h"
+
+namespace doris {
+
+class IoTFunctions {
+public:
+    static void init();
+
+    static void iot_first_init(FunctionContext*, StringVal* dst);
+
+    static void iot_first_update(FunctionContext*, const BigIntVal& ts, const DoubleVal& val, StringVal* dst);
+
+    static void iot_first_merge(FunctionContext*,const StringVal& src, StringVal* dst);
+
+    static StringVal iot_first_serialize(FunctionContext* ctx, const StringVal& src);
+
+    static DoubleVal iot_first_finalize(FunctionContext*, const StringVal& src);
+
+private:
+    static void _init_iot_first_state(FunctionContext* context,
+            const BigIntVal& ts, const DoubleVal& val,
+            StringVal* dst);
+};
+
+}
+

--- a/be/test/exprs/CMakeLists.txt
+++ b/be/test/exprs/CMakeLists.txt
@@ -39,4 +39,5 @@ ADD_BE_TEST(topn_function_test)
 ADD_BE_TEST(runtime_filter_test)
 ADD_BE_TEST(bloom_filter_predicate_test)
 ADD_BE_TEST(array_functions_test)
+ADD_BE_TEST(iot_functions_test)
 

--- a/be/test/exprs/iot_functions_test.cpp
+++ b/be/test/exprs/iot_functions_test.cpp
@@ -1,0 +1,122 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "exprs/anyval_util.h"
+#include "exprs/expr_context.h"
+#include "exprs/iot_functions.h"
+#include "testutil/function_utils.h"
+#include "test_util/test_util.h"
+
+#include <gtest/gtest.h>
+#include <unordered_map>
+
+namespace doris {
+
+class IoTFunctionsTest : public testing::Test {
+public:
+    IoTFunctionsTest() = default;
+
+    void SetUp() {
+        utils = new FunctionUtils();
+        ctx = utils->get_fn_ctx();
+    }
+
+    void TearDown() {
+        delete utils;
+    }
+
+private:
+    FunctionUtils *utils;
+    FunctionContext *ctx;
+};
+
+TEST_F(IoTFunctionsTest, iot_first_last_update) {
+    // first
+    StringVal dst;
+    dst.is_null = true;
+    IoTFunctions::iot_first_update(ctx, BigIntVal::null(), DoubleVal(1.1), &dst);
+    IoTFunctions::iot_first_update(ctx, BigIntVal(102), DoubleVal(2.2), &dst);
+    IoTFunctions::iot_first_update(ctx, BigIntVal(100), DoubleVal(1.1), &dst);
+
+    DoubleVal result = IoTFunctions::iot_first_last_finalize(ctx, dst);
+    ASSERT_EQ(DoubleVal(1.1), result);
+
+    // last
+    StringVal dst2;
+    dst2.is_null = true;
+    IoTFunctions::iot_last_update(ctx, BigIntVal::null(), DoubleVal(1.1), &dst2);
+    IoTFunctions::iot_last_update(ctx, BigIntVal(102), DoubleVal(2.2), &dst2);
+    IoTFunctions::iot_last_update(ctx, BigIntVal(100), DoubleVal(1.1), &dst2);
+
+    result = IoTFunctions::iot_first_last_finalize(ctx, dst2);
+    ASSERT_EQ(DoubleVal(2.2), result);
+}
+
+TEST_F(IoTFunctionsTest, iot_first_last_merge) {
+    // first
+    StringVal dst1;
+    dst1.is_null = true;
+    IoTFunctions::iot_first_update(ctx, BigIntVal::null(), DoubleVal(1.1), &dst1);
+    IoTFunctions::iot_first_update(ctx, BigIntVal(102), DoubleVal(2.2), &dst1);
+    IoTFunctions::iot_first_update(ctx, BigIntVal(100), DoubleVal(1.1), &dst1);
+
+    StringVal dst2;
+    dst2.is_null = true;
+    IoTFunctions::iot_first_update(ctx, BigIntVal::null(), DoubleVal(1.1), &dst2);
+    IoTFunctions::iot_first_update(ctx, BigIntVal(99), DoubleVal(3.3), &dst2);
+
+    StringVal ser1 = IoTFunctions::iot_first_last_serialize(ctx, dst1);
+    StringVal ser2 = IoTFunctions::iot_first_last_serialize(ctx, dst2);
+
+    StringVal dst;
+    dst.is_null = true;
+    IoTFunctions::iot_first_merge(ctx, ser1, &dst);
+    IoTFunctions::iot_first_merge(ctx, ser2, &dst);
+
+    DoubleVal result = IoTFunctions::iot_first_last_finalize(ctx, dst);
+    ASSERT_EQ(DoubleVal(3.3), result);
+
+    // last
+    StringVal dst3;
+    dst3.is_null = true;
+    IoTFunctions::iot_last_update(ctx, BigIntVal::null(), DoubleVal(1.1), &dst3);
+    IoTFunctions::iot_last_update(ctx, BigIntVal(102), DoubleVal(2.2), &dst3);
+    IoTFunctions::iot_last_update(ctx, BigIntVal(100), DoubleVal(1.1), &dst3);
+
+    StringVal dst4;
+    dst4.is_null = true;
+    IoTFunctions::iot_last_update(ctx, BigIntVal::null(), DoubleVal(1.1), &dst4);
+    IoTFunctions::iot_last_update(ctx, BigIntVal(99), DoubleVal(3.3), &dst4);
+
+    ser1 = IoTFunctions::iot_first_last_serialize(ctx, dst3);
+    ser2 = IoTFunctions::iot_first_last_serialize(ctx, dst4);
+
+    StringVal dst5;
+    dst5.is_null = true;
+    IoTFunctions::iot_last_merge(ctx, ser1, &dst5);
+    IoTFunctions::iot_last_merge(ctx, ser2, &dst5);
+
+    result = IoTFunctions::iot_first_last_finalize(ctx, dst5);
+    ASSERT_EQ(DoubleVal(2.2), result);
+}
+
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/docs/.vuepress/sidebar/en.js
+++ b/docs/.vuepress/sidebar/en.js
@@ -397,6 +397,8 @@ module.exports = [
               "topn",
               "var_samp",
               "variance",
+              "iot_first",
+              "iot_last",
             ],
           },
           {

--- a/docs/.vuepress/sidebar/zh-CN.js
+++ b/docs/.vuepress/sidebar/zh-CN.js
@@ -401,6 +401,8 @@ module.exports = [
               "topn",
               "var_samp",
               "variance",
+              "iot_first",
+              "iot_last",
             ],
           },
           {

--- a/docs/en/sql-reference/sql-functions/aggregate-functions/iot_first.md
+++ b/docs/en/sql-reference/sql-functions/aggregate-functions/iot_first.md
@@ -1,0 +1,67 @@
+---
+{
+    "title": "IOT_FIRST",
+    "language": "en"
+}
+---
+
+<!-- 
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# IOT_FIRST
+## description
+### Syntax
+
+`iot_first(bigint, double)`
+
+After grouping, the first parameter is sorted from smallest to largest (ignoring the null value), and the value of the corresponding second parameter is returned. Similar to the first function of influxdb.
+
+## example
+
+```
+mysql> select * from iot order by tag;
++------+------------+------+
+| tag  | ts         | val  |
++------+------------+------+
+| tag1 | 1641199000 |  1.1 |
+| tag1 | 1641199001 |  2.2 |
+| tag1 | 1641199002 |  3.3 |
+| tag2 | 1641199001 |   11 |
+| tag2 | 1641199000 |   10 |
+| tag3 |       NULL | NULL |
+| tag3 | 1641199000 |  100 |
+| tag4 |       NULL | NULL |
++------+------------+------+
+8 rows in set (0.01 sec)
+
+mysql> select tag, iot_first(ts, val) from iot group by tag order by tag;
++------+------------------------+
+| tag  | iot_first(`ts`, `val`) |
++------+------------------------+
+| tag1 |                    1.1 |
+| tag2 |                     10 |
+| tag3 |                    100 |
+| tag4 |                   NULL |
++------+------------------------+
+4 rows in set (0.01 sec)
+```
+
+## keyword
+
+    IOT_FIRST

--- a/docs/en/sql-reference/sql-functions/aggregate-functions/iot_last.md
+++ b/docs/en/sql-reference/sql-functions/aggregate-functions/iot_last.md
@@ -1,0 +1,67 @@
+---
+{
+    "title": "IOT_LAST",
+    "language": "zh-CN"
+}
+---
+
+<!-- 
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# IOT_LAST
+## description
+### Syntax
+
+`iot_last(bigint, double)`
+
+After grouping, the first parameter is sorted from largest to smallest (ignoring the null value), and the value of the corresponding second parameter is returned. Similar to influxdb's last function.
+
+## example
+
+```
+mysql> select * from iot order by tag;
++------+------------+------+
+| tag  | ts         | val  |
++------+------------+------+
+| tag1 | 1641199000 |  1.1 |
+| tag1 | 1641199001 |  2.2 |
+| tag1 | 1641199002 |  3.3 |
+| tag2 | 1641199001 |   11 |
+| tag2 | 1641199000 |   10 |
+| tag3 |       NULL | NULL |
+| tag3 | 1641199000 |  100 |
+| tag4 |       NULL | NULL |
++------+------------+------+
+8 rows in set (0.02 sec)
+
+mysql> select tag, iot_last(ts, val) from iot group by tag order by tag;
++------+-----------------------+
+| tag  | iot_last(`ts`, `val`) |
++------+-----------------------+
+| tag1 |                   3.3 |
+| tag2 |                    11 |
+| tag3 |                   100 |
+| tag4 |                  NULL |
++------+-----------------------+
+4 rows in set (0.00 sec)
+```
+
+## keyword
+
+    IOT_LAST

--- a/docs/zh-CN/sql-reference/sql-functions/aggregate-functions/iot_first.md
+++ b/docs/zh-CN/sql-reference/sql-functions/aggregate-functions/iot_first.md
@@ -1,0 +1,67 @@
+---
+{
+    "title": "IOT_FIRST",
+    "language": "zh-CN"
+}
+---
+
+<!-- 
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# IOT_FIRST
+## description
+### Syntax
+
+`iot_first(bigint, double)`
+
+分组后，按第一个参数有小到大排序（忽略null值），返回对应的第二个参数的值。类似 influxdb 的 first 函数。
+
+## example
+
+```
+mysql> select * from iot order by tag;
++------+------------+------+
+| tag  | ts         | val  |
++------+------------+------+
+| tag1 | 1641199000 |  1.1 |
+| tag1 | 1641199001 |  2.2 |
+| tag1 | 1641199002 |  3.3 |
+| tag2 | 1641199001 |   11 |
+| tag2 | 1641199000 |   10 |
+| tag3 |       NULL | NULL |
+| tag3 | 1641199000 |  100 |
+| tag4 |       NULL | NULL |
++------+------------+------+
+8 rows in set (0.01 sec)
+
+mysql> select tag, iot_first(ts, val) from iot group by tag order by tag;
++------+------------------------+
+| tag  | iot_first(`ts`, `val`) |
++------+------------------------+
+| tag1 |                    1.1 |
+| tag2 |                     10 |
+| tag3 |                    100 |
+| tag4 |                   NULL |
++------+------------------------+
+4 rows in set (0.01 sec)
+```
+
+## keyword
+
+    IOT_FIRST

--- a/docs/zh-CN/sql-reference/sql-functions/aggregate-functions/iot_last.md
+++ b/docs/zh-CN/sql-reference/sql-functions/aggregate-functions/iot_last.md
@@ -1,0 +1,67 @@
+---
+{
+    "title": "IOT_LAST",
+    "language": "zh-CN"
+}
+---
+
+<!-- 
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# IOT_LAST
+## description
+### Syntax
+
+`iot_last(bigint, double)`
+
+分组后，按第一个参数有大到小排序（忽略null值），返回对应的第二个参数的值。类似 influxdb 的 last 函数。
+
+## example
+
+```
+mysql> select * from iot order by tag;
++------+------------+------+
+| tag  | ts         | val  |
++------+------------+------+
+| tag1 | 1641199000 |  1.1 |
+| tag1 | 1641199001 |  2.2 |
+| tag1 | 1641199002 |  3.3 |
+| tag2 | 1641199001 |   11 |
+| tag2 | 1641199000 |   10 |
+| tag3 |       NULL | NULL |
+| tag3 | 1641199000 |  100 |
+| tag4 |       NULL | NULL |
++------+------------+------+
+8 rows in set (0.02 sec)
+
+mysql> select tag, iot_last(ts, val) from iot group by tag order by tag;
++------+-----------------------+
+| tag  | iot_last(`ts`, `val`) |
++------+-----------------------+
+| tag1 |                   3.3 |
+| tag2 |                    11 |
+| tag3 |                   100 |
+| tag4 |                  NULL |
++------+-----------------------+
+4 rows in set (0.00 sec)
+```
+
+## keyword
+
+    IOT_LAST

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/FunctionSet.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/FunctionSet.java
@@ -2056,8 +2056,18 @@ public class FunctionSet<min_initIN9doris_udf12DecimalV2ValEEEvPNS2_15FunctionCo
                 initNullString,
                 "_ZN5doris12IoTFunctions16iot_first_updateEPN9doris_udf15FunctionContextERKNS1_9BigIntValERKNS1_9DoubleValEPNS1_9StringValE",
                 "_ZN5doris12IoTFunctions15iot_first_mergeEPN9doris_udf15FunctionContextERKNS1_9StringValEPS4_",
-                "_ZN5doris12IoTFunctions19iot_first_serializeEPN9doris_udf15FunctionContextERKNS1_9StringValE",
-                "_ZN5doris12IoTFunctions18iot_first_finalizeEPN9doris_udf15FunctionContextERKNS1_9StringValE",
+                "_ZN5doris12IoTFunctions24iot_first_last_serializeEPN9doris_udf15FunctionContextERKNS1_9StringValE",
+                "_ZN5doris12IoTFunctions23iot_first_last_finalizeEPN9doris_udf15FunctionContextERKNS1_9StringValE",
+                false, false, false));
+
+        // iot_last(bigint, double)
+        addBuiltin(AggregateFunction.createBuiltin("iot_last",
+                Lists.<Type>newArrayList(Type.BIGINT, Type.DOUBLE), Type.DOUBLE, Type.VARCHAR,
+                initNullString,
+                "_ZN5doris12IoTFunctions15iot_last_updateEPN9doris_udf15FunctionContextERKNS1_9BigIntValERKNS1_9DoubleValEPNS1_9StringValE",
+                "_ZN5doris12IoTFunctions14iot_last_mergeEPN9doris_udf15FunctionContextERKNS1_9StringValEPS4_",
+                "_ZN5doris12IoTFunctions24iot_first_last_serializeEPN9doris_udf15FunctionContextERKNS1_9StringValE",
+                "_ZN5doris12IoTFunctions23iot_first_last_finalizeEPN9doris_udf15FunctionContextERKNS1_9StringValE",
                 false, false, false));
 
         // analytic functions

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/FunctionSet.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/FunctionSet.java
@@ -2050,6 +2050,16 @@ public class FunctionSet<min_initIN9doris_udf12DecimalV2ValEEEvPNS2_15FunctionCo
                 prefix + "22string_concat_finalizeEPN9doris_udf15FunctionContextERKNS1_9StringValE",
                 false, false, false));
 
+        // iot_first(bigint, double)
+        addBuiltin(AggregateFunction.createBuiltin("iot_first",
+                Lists.<Type>newArrayList(Type.BIGINT, Type.DOUBLE), Type.DOUBLE, Type.VARCHAR,
+                initNullString,
+                "_ZN5doris12IoTFunctions16iot_first_updateEPN9doris_udf15FunctionContextERKNS1_9BigIntValERKNS1_9DoubleValEPNS1_9StringValE",
+                "_ZN5doris12IoTFunctions15iot_first_mergeEPN9doris_udf15FunctionContextERKNS1_9StringValEPS4_",
+                "_ZN5doris12IoTFunctions19iot_first_serializeEPN9doris_udf15FunctionContextERKNS1_9StringValE",
+                "_ZN5doris12IoTFunctions18iot_first_finalizeEPN9doris_udf15FunctionContextERKNS1_9StringValE",
+                false, false, false));
+
         // analytic functions
         // Rank
         addBuiltin(AggregateFunction.createAnalyticBuiltin("rank",


### PR DESCRIPTION
## Proposed changes

Related to PR #7459.

Implement `iot_first` and `iot_last` functions.
These are two aggregate functions that are used to implement semantics similar to the
`first` and `last` functions in [influxdb](https://docs.influxdata.com/flux/v0.x/stdlib/universe/first/).

Examples can be found in `iot_first.md` and `iot_last.md`

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Code refactor (Modify the code structure, format the code, etc...)
- [ ] Optimization. Including functional usability improvements and performance improvements.
- [ ] Dependency. Such as changes related to third-party components.
- [ ] Other.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have created an issue on (Fix #ISSUE) and described the bug/feature there in detail
- [ ] Compiling and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If these changes need document changes, I have updated the document
- [ ] Any dependent changes have been merged

## Further comments

If this is a relatively large or complex change, kick off the discussion at dev@doris.apache.org by explaining why you chose the solution you did and what alternatives you considered, etc...
