### PR TITLE
[vectorized](improving) (exec) optimize VDataStreamSender's send() performance #7747

### DIFF
--- a/be/src/vec/columns/column.h
+++ b/be/src/vec/columns/column.h
@@ -160,6 +160,10 @@ public:
     virtual void insert_many_from(const IColumn& src, size_t position, size_t length) {
         for (size_t i = 0; i < length; ++i) insert_from(src, position);
     }
+ 
+    /// Appends a batch elements from other column with the same type
+    /// indices_begin + indices_end represent the row indices of column src
+    virtual void insert_indices_from(const IColumn& src, const int* indices_begin, const int* indices_end) = 0;
 
     /// Appends data located in specified memory chunk if it is possible (throws an exception if it cannot be implemented).
     /// Is used to optimize some computations (in aggregation, for example).

--- a/be/src/vec/columns/column_complex.h
+++ b/be/src/vec/columns/column_complex.h
@@ -125,6 +125,14 @@ public:
         data.insert(data.end(), st, ed);
     }
 
+    void insert_indices_from(const IColumn& src, const int* indices_begin, const int* indices_end) override {
+        const Self& src_vec = assert_cast<const Self&>(src);
+        data.reserve(size() + (indices_end - indices_begin));
+        for (auto x = indices_begin; x != indices_end; ++x) {
+            data.push_back(src_vec.get_element(*x));
+        }
+    }
+
     void pop_back(size_t n) { data.erase(data.end() - n, data.end()); }
     // it's impossable to use ComplexType as key , so we don't have to implemnt them
     [[noreturn]] StringRef serialize_value_into_arena(size_t n, Arena& arena,

--- a/be/src/vec/columns/column_const.h
+++ b/be/src/vec/columns/column_const.h
@@ -84,6 +84,10 @@ public:
         s += length;
     }
 
+    void insert_indices_from(const IColumn& src, const int* indices_begin, const int* indices_end) override {
+        s += (indices_end - indices_begin);
+    }
+
     void insert(const Field&) override { ++s; }
 
     void insert_data(const char*, size_t) override { ++s; }

--- a/be/src/vec/columns/column_decimal.h
+++ b/be/src/vec/columns/column_decimal.h
@@ -26,6 +26,7 @@
 #include "vec/columns/column_impl.h"
 #include "vec/columns/column_vector_helper.h"
 #include "vec/common/typeid_cast.h"
+#include "vec/common/assert_cast.h"
 #include "vec/core/field.h"
 
 namespace doris::vectorized {
@@ -97,8 +98,10 @@ public:
     }
 
     void insert_indices_from(const IColumn& src, const int* indices_begin, const int* indices_end) override {
+        const Self& src_vec = assert_cast<const Self&>(src);
+        data.reserve(size() + (indices_end - indices_begin));
         for (auto x = indices_begin; x != indices_end; ++x) {
-            Self::insert_from(src, *x);
+            data.push_back_without_reserve(src_vec.get_element(*x));
         }
     }
 

--- a/be/src/vec/columns/column_decimal.h
+++ b/be/src/vec/columns/column_decimal.h
@@ -95,6 +95,13 @@ public:
     void insert_from(const IColumn& src, size_t n) override {
         data.push_back(static_cast<const Self&>(src).get_data()[n]);
     }
+
+    void insert_indices_from(const IColumn& src, const int* indices_begin, const int* indices_end) override {
+        for (auto x = indices_begin; x != indices_end; ++x) {
+            Self::insert_from(src, *x);
+        }
+    }
+
     void insert_data(const char* pos, size_t /*length*/) override;
     void insert_default() override { data.push_back(T()); }
     void insert(const Field& x) override {

--- a/be/src/vec/columns/column_dummy.h
+++ b/be/src/vec/columns/column_dummy.h
@@ -80,6 +80,10 @@ public:
         s += length;
     }
 
+    void insert_indices_from(const IColumn& src, const int* indices_begin, const int* indices_end) override {
+        s += (indices_end - indices_begin);
+    }
+
     ColumnPtr filter(const Filter& filt, ssize_t /*result_size_hint*/) const override {
         return clone_dummy(count_bytes_in_filter(filt));
     }

--- a/be/src/vec/columns/column_nullable.cpp
+++ b/be/src/vec/columns/column_nullable.cpp
@@ -131,6 +131,12 @@ void ColumnNullable::insert_range_from(const IColumn& src, size_t start, size_t 
     get_nested_column().insert_range_from(*nullable_col.nested_column, start, length);
 }
 
+void ColumnNullable::insert_indices_from(const IColumn& src, const int* indices_begin, const int* indices_end) {
+    for (auto x = indices_begin; x != indices_end; ++x) {
+        ColumnNullable::insert_from(src, *x);
+    }
+}
+
 void ColumnNullable::insert(const Field& x) {
     if (x.is_null()) {
         get_nested_column().insert_default();

--- a/be/src/vec/columns/column_nullable.cpp
+++ b/be/src/vec/columns/column_nullable.cpp
@@ -132,9 +132,9 @@ void ColumnNullable::insert_range_from(const IColumn& src, size_t start, size_t 
 }
 
 void ColumnNullable::insert_indices_from(const IColumn& src, const int* indices_begin, const int* indices_end) {
-    for (auto x = indices_begin; x != indices_end; ++x) {
-        ColumnNullable::insert_from(src, *x);
-    }
+    const ColumnNullable& src_concrete = assert_cast<const ColumnNullable&>(src);
+    get_nested_column().insert_indices_from(src_concrete.get_nested_column(), indices_begin, indices_end);
+    get_null_map_column().insert_indices_from(src_concrete.get_null_map_column(), indices_begin, indices_end);
 }
 
 void ColumnNullable::insert(const Field& x) {

--- a/be/src/vec/columns/column_nullable.h
+++ b/be/src/vec/columns/column_nullable.h
@@ -83,6 +83,7 @@ public:
     StringRef serialize_value_into_arena(size_t n, Arena& arena, char const*& begin) const override;
     const char* deserialize_and_insert_from_arena(const char* pos) override;
     void insert_range_from(const IColumn& src, size_t start, size_t length) override;
+    void insert_indices_from(const IColumn& src, const int* indices_begin, const int* indices_end) override;
     void insert(const Field& x) override;
     void insert_from(const IColumn& src, size_t n) override;
 

--- a/be/src/vec/columns/column_string.cpp
+++ b/be/src/vec/columns/column_string.cpp
@@ -94,7 +94,7 @@ void ColumnString::insert_range_from(const IColumn& src, size_t start, size_t le
 }
 
 void ColumnString::insert_indices_from(const IColumn& src, const int* indices_begin, const int* indices_end) {
-    for (auto x = indices_begin; x < indices_end; ++x) {
+    for (auto x = indices_begin; x != indices_end; ++x) {
         ColumnString::insert_from(src, *x);
     }
 }

--- a/be/src/vec/columns/column_string.cpp
+++ b/be/src/vec/columns/column_string.cpp
@@ -93,6 +93,12 @@ void ColumnString::insert_range_from(const IColumn& src, size_t start, size_t le
     }
 }
 
+void ColumnString::insert_indices_from(const IColumn& src, const int* indices_begin, const int* indices_end) {
+    for (auto x = indices_begin; x < indices_end; ++x) {
+        ColumnString::insert_from(src, *x);
+    }
+}
+
 ColumnPtr ColumnString::filter(const Filter& filt, ssize_t result_size_hint) const {
     if (offsets.size() == 0) return ColumnString::create();
 

--- a/be/src/vec/columns/column_string.h
+++ b/be/src/vec/columns/column_string.h
@@ -187,6 +187,8 @@ public:
 
     void insert_range_from(const IColumn& src, size_t start, size_t length) override;
 
+    void insert_indices_from(const IColumn& src, const int* indices_begin, const int* indices_end) override;
+
     ColumnPtr filter(const Filter& filt, ssize_t result_size_hint) const override;
 
     ColumnPtr permute(const Permutation& perm, size_t limit) const override;

--- a/be/src/vec/columns/column_vector.cpp
+++ b/be/src/vec/columns/column_vector.cpp
@@ -27,6 +27,7 @@
 #include <cstring>
 
 #include "vec/common/arena.h"
+#include "vec/common/assert_cast.h"
 #include "vec/common/bit_cast.h"
 #include "vec/common/exception.h"
 #include "vec/common/nan_utils.h"
@@ -219,6 +220,15 @@ void ColumnVector<T>::insert_range_from(const IColumn& src, size_t start, size_t
     size_t old_size = data.size();
     data.resize(old_size + length);
     memcpy(data.data() + old_size, &src_vec.data[start], length * sizeof(data[0]));
+}
+
+template <typename T>
+void ColumnVector<T>::insert_indices_from(const IColumn& src, const int* indices_begin, const int* indices_end) {
+    const Self& src_vec = assert_cast<const Self&>(src);
+    data.reserve(size() + (indices_end - indices_begin));
+    for (auto x = indices_begin; x != indices_end; ++x) {
+        data.push_back(src_vec.get_element(*x));
+    }
 }
 
 template <typename T>

--- a/be/src/vec/columns/column_vector.cpp
+++ b/be/src/vec/columns/column_vector.cpp
@@ -227,7 +227,7 @@ void ColumnVector<T>::insert_indices_from(const IColumn& src, const int* indices
     const Self& src_vec = assert_cast<const Self&>(src);
     data.reserve(size() + (indices_end - indices_begin));
     for (auto x = indices_begin; x != indices_end; ++x) {
-        data.push_back(src_vec.get_element(*x));
+        data.push_back_without_reserve(src_vec.get_element(*x));
     }
 }
 

--- a/be/src/vec/columns/column_vector.h
+++ b/be/src/vec/columns/column_vector.h
@@ -193,6 +193,8 @@ public:
 
     void insert_range_from(const IColumn& src, size_t start, size_t length) override;
 
+    void insert_indices_from(const IColumn& src, const int* indices_begin, const int* indices_end) override;
+
     ColumnPtr filter(const IColumn::Filter& filt, ssize_t result_size_hint) const override;
 
     ColumnPtr permute(const IColumn::Permutation& perm, size_t limit) const override;

--- a/be/src/vec/columns/predicate_column.h
+++ b/be/src/vec/columns/predicate_column.h
@@ -140,6 +140,10 @@ public:
          LOG(FATAL) << "insert_range_from not supported in PredicateColumnType";
     }
 
+    void insert_indices_from(const IColumn& src, const int* indices_begin, const int* indices_end) override {
+         LOG(FATAL) << "insert_indices_from not supported in PredicateColumnType";
+    }
+
     void pop_back(size_t n) override {
         LOG(FATAL) << "pop_back not supported in PredicateColumnType";
     }

--- a/be/src/vec/core/block.cpp
+++ b/be/src/vec/core/block.cpp
@@ -843,6 +843,17 @@ void MutableBlock::add_row(const Block* block, int row) {
     }
 }
 
+void MutableBlock::add_rows(const Block* block, const int* row_begin, const int* row_end) {
+    auto& src_columns_with_schema = block->get_columns_with_type_and_name();
+    for (size_t i = 0; i < _columns.size(); ++i) {
+        auto& dst = _columns[i];
+        auto& src = *src_columns_with_schema[i].column.get();
+        for (const int* row = row_begin; row != row_end; ++row) {
+            dst->insert_from(src, *row);
+        }
+    }
+}
+
 Block MutableBlock::to_block(int start_column) {
     return to_block(start_column, _columns.size());
 }

--- a/be/src/vec/core/block.cpp
+++ b/be/src/vec/core/block.cpp
@@ -837,20 +837,18 @@ size_t MutableBlock::rows() const {
 }
 
 void MutableBlock::add_row(const Block* block, int row) {
-    auto& src_columns_with_schema = block->get_columns_with_type_and_name();
+    auto& block_data = block->get_columns_with_type_and_name();
     for (size_t i = 0; i < _columns.size(); ++i) {
-        _columns[i]->insert_from(*src_columns_with_schema[i].column.get(), row);
+        _columns[i]->insert_from(*block_data[i].column.get(), row);
     }
 }
 
 void MutableBlock::add_rows(const Block* block, const int* row_begin, const int* row_end) {
-    auto& src_columns_with_schema = block->get_columns_with_type_and_name();
+    auto& block_data = block->get_columns_with_type_and_name();
     for (size_t i = 0; i < _columns.size(); ++i) {
         auto& dst = _columns[i];
-        auto& src = *src_columns_with_schema[i].column.get();
-        for (const int* row = row_begin; row != row_end; ++row) {
-            dst->insert_from(src, *row);
-        }
+        auto& src = *block_data[i].column.get();
+        dst->insert_indices_from(src, row_begin, row_end);
     }
 }
 

--- a/be/src/vec/core/block.h
+++ b/be/src/vec/core/block.h
@@ -339,6 +339,8 @@ public:
     Block to_block(int start_column, int end_column);
 
     void add_row(const Block* block, int row);
+    void add_rows(const Block* block, const int* row_begin, const int* row_end);
+
     std::string dump_data(size_t row_limit = 100) const;
 
     void clear() {

--- a/be/src/vec/sink/vdata_stream_sender.cpp
+++ b/be/src/vec/sink/vdata_stream_sender.cpp
@@ -169,6 +169,42 @@ Status VDataStreamSender::Channel::add_row(Block* block, int row) {
     return Status::OK();
 }
 
+Status VDataStreamSender::Channel::add_rows(Block* block, const std::vector<int>& rows) {
+    if (_fragment_instance_id.lo == -1) {
+        return Status::OK();
+    }
+
+    if (_mutable_block.get() == nullptr) {
+        auto empty_block = block->clone_empty();
+        _mutable_block.reset(
+                new MutableBlock(empty_block.mutate_columns(), empty_block.get_data_types()));
+    }
+
+    int row_wait_add = rows.size();
+    int batch_size = _parent->state()->batch_size();
+    const int* begin = &rows[0];
+
+    while (row_wait_add > 0) {
+        int row_add, max_add = batch_size - _mutable_block->rows();
+        if (row_wait_add >= max_add)  {
+            row_add = max_add;
+        } else {
+            row_add = row_wait_add;
+        }
+
+        _mutable_block->add_rows(block, begin, begin + row_add);
+
+        row_wait_add -= row_add;
+        begin += row_add;
+
+        if (row_add == max_add) {
+            RETURN_IF_ERROR(send_current_block());
+        }
+    }
+
+    return Status::OK();
+}
+
 Status VDataStreamSender::Channel::close_wait(RuntimeState* state) {
     if (_need_close) {
         Status st = _wait_last_brpc();
@@ -394,9 +430,9 @@ Status VDataStreamSender::send(RuntimeState* state, Block* block) {
         int num_channels = _channels.size();
         // will only copy schema
         // we don't want send temp columns
-        auto send_block = *block;
 
-        std::vector<int> result(_partition_expr_ctxs.size());
+        int result_size = _partition_expr_ctxs.size();
+        int result[result_size];
         int counter = 0;
 
         for (auto ctx : _partition_expr_ctxs) {
@@ -406,8 +442,10 @@ Status VDataStreamSender::send(RuntimeState* state, Block* block) {
         int rows = block->rows();
         // for each row, we have a siphash val
         std::vector<SipHash> siphashs(rows);
+        // channel2rows' subscript means channel id 
+        std::vector<int> channel2rows[num_channels];
         // result[j] means column index, i means rows index
-        for (int j = 0; j < result.size(); ++j) {
+        for (int j = 0; j < result_size; ++j) {
             auto column = block->get_by_position(result[j]).column;
             for (int i = 0; i < rows; ++i) {
                 column->update_hash_with_value(i, siphashs[i]);
@@ -416,9 +454,14 @@ Status VDataStreamSender::send(RuntimeState* state, Block* block) {
 
         for (int i = 0; i < rows; i++) {
             auto target_channel_id = siphashs[i].get64() % num_channels;
-            RETURN_IF_ERROR(_channels[target_channel_id]->add_row(&send_block, i));
+            channel2rows[target_channel_id].push_back(i);
         }
 
+        for (int i = 0; i < num_channels; ++i)
+            if (!channel2rows[i].empty()) {
+                RETURN_IF_ERROR(_channels[i]->add_rows(block, channel2rows[i]));
+            }
+        }
     } else if (_part_type == TPartitionType::BUCKET_SHFFULE_HASH_PARTITIONED) {
         // 1. caculate hash
         // 2. dispatch rows to channel

--- a/be/src/vec/sink/vdata_stream_sender.cpp
+++ b/be/src/vec/sink/vdata_stream_sender.cpp
@@ -457,7 +457,7 @@ Status VDataStreamSender::send(RuntimeState* state, Block* block) {
             channel2rows[target_channel_id].push_back(i);
         }
 
-        for (int i = 0; i < num_channels; ++i)
+        for (int i = 0; i < num_channels; ++i) {
             if (!channel2rows[i].empty()) {
                 RETURN_IF_ERROR(_channels[i]->add_rows(block, channel2rows[i]));
             }

--- a/be/src/vec/sink/vdata_stream_sender.h
+++ b/be/src/vec/sink/vdata_stream_sender.h
@@ -179,6 +179,7 @@ public:
     Status send_block(PBlock* block, bool eos = false);
 
     Status add_row(Block* block, int row);
+    Status add_rows(Block* block, const std::vector<int>& row);
 
     Status send_current_block(bool eos = false);
 

--- a/be/src/vec/sink/vdata_stream_sender.h
+++ b/be/src/vec/sink/vdata_stream_sender.h
@@ -72,7 +72,7 @@ public:
 private:
     class Channel;
 
-    Status get_partition_column_result(Block* block, int* result) {
+    Status get_partition_column_result(Block* block, int* result) const {
         int counter = 0;
         for (auto ctx : _partition_expr_ctxs) {
             RETURN_IF_ERROR(ctx->execute(block, &result[counter++]));
@@ -215,9 +215,9 @@ public:
         return uid.to_string();
     }
 
-    TUniqueId get_fragment_instance_id() { return _fragment_instance_id; }
+    TUniqueId get_fragment_instance_id() const { return _fragment_instance_id; }
 
-    bool is_local() { return _is_local; }
+    bool is_local() const { return _is_local; }
 
 private:
     inline Status _wait_last_brpc() {

--- a/be/src/vec/sink/vdata_stream_sender.h
+++ b/be/src/vec/sink/vdata_stream_sender.h
@@ -72,6 +72,17 @@ public:
 private:
     class Channel;
 
+    Status get_partition_column_result(Block* block, int* result) {
+        int counter = 0;
+        for (auto ctx : _partition_expr_ctxs) {
+            RETURN_IF_ERROR(ctx->execute(block, &result[counter++]));
+        }
+        return Status::OK();
+    }
+
+    template <typename Channels, typename HashVals>
+    Status channel_add_rows(Channels& channels, int num_channels, const HashVals& hash_vals, int rows, Block* block);
+
     struct hash_128 {
         uint64_t high;
         uint64_t low;
@@ -224,6 +235,7 @@ private:
         return Status::OK();
     }
 
+
 private:
     // Serialize _batch into _thrift_batch and send via send_batch().
     // Returns send_batch() status.
@@ -262,5 +274,24 @@ private:
     size_t _capacity;
     bool _is_local;
 };
+
+template <typename Channels, typename HashVals>
+Status VDataStreamSender::channel_add_rows(Channels& channels, int num_channels, const HashVals& hash_vals, int rows, Block* block) {
+    std::vector<int> channel2rows[num_channels];
+
+    for (int i = 0; i < rows; i++) {
+        auto cid = hash_vals[i] % num_channels;
+        channel2rows[cid].emplace_back(i);
+    }
+
+    for (int i = 0; i < num_channels; ++i) {
+        if (!channel2rows[i].empty()) {
+            RETURN_IF_ERROR(channels[i]->add_rows(block, channel2rows[i]));
+        }
+    }
+
+    return Status::OK();
+}
+
 } // namespace vectorized
 } // namespace doris


### PR DESCRIPTION
# Proposed changes
gather channel's rows, and then send together
handle each column's different rows at a time is good for improving cache hit
comparing test data, wait @zenoyang to provide

Issue Number: close #xxx

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
