### PR TITLE
[Bug] Consider backend status when more than one backends exists in same host 

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/system/SystemInfoService.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/system/SystemInfoService.java
@@ -873,6 +873,7 @@ public class SystemInfoService {
             if (FeConstants.runningUnitTest || Config.allow_replica_on_same_host) {
                 backends.addAll(list);
             } else {
+                list = list.stream().filter(beAvailablePredicate::isMatch).collect(Collectors.toList());
                 Collections.shuffle(list);
                 backends.add(list.get(0));
             }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #7783

## Problem Summary:

Consider backend status when more than one backends exists in same host 

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
