### PR TITLE
[fix](bitmap-index) Fix bug that bitmap index may return wrong result.

### DIFF
--- a/be/src/olap/rowset/segment_v2/index_page.cpp
+++ b/be/src/olap/rowset/segment_v2/index_page.cpp
@@ -103,7 +103,7 @@ Status IndexPageIterator::seek_at_or_before(const Slice& search_key) {
     // no exact match, the insertion point is `left`
     if (left == 0) {
         // search key is smaller than all keys
-        return Status::NotFound("no page contains the given key");
+        return Status::NotFound("given key is smaller than all keys in page");
     }
     // index entry records the first key of the indexed page,
     // therefore the first page with keys >= searched key is the one before the insertion point

--- a/be/src/olap/rowset/segment_v2/index_page.h
+++ b/be/src/olap/rowset/segment_v2/index_page.h
@@ -126,6 +126,8 @@ public:
     // Return other error status otherwise.
     Status seek_at_or_before(const Slice& search_key);
 
+    void seek_to_first() { _pos = 0; }
+
     // Move to the next index entry.
     // Return true on success, false when no more entries can be read.
     bool move_next() {

--- a/be/src/olap/rowset/segment_v2/ordinal_page_index.h
+++ b/be/src/olap/rowset/segment_v2/ordinal_page_index.h
@@ -71,7 +71,7 @@ public:
 
     // the returned iter points to the largest element which is less than `ordinal`,
     // or points to the first element if all elements are greater than `ordinal`,
-    // or points to "end" if all elementss are smaller than `ordinal`.
+    // or points to "end" if all elements are smaller than `ordinal`.
     OrdinalPageIndexIterator seek_at_or_before(ordinal_t ordinal);
     inline OrdinalPageIndexIterator begin();
     inline OrdinalPageIndexIterator end();

--- a/be/src/olap/rowset/segment_v2/ordinal_page_index.h
+++ b/be/src/olap/rowset/segment_v2/ordinal_page_index.h
@@ -69,6 +69,9 @@ public:
     // load and parse the index page into memory
     Status load(bool use_page_cache, bool kept_in_memory);
 
+    // the returned iter points to the largest element which is less than `ordinal`,
+    // or points to the first element if all elements are greater than `ordinal`,
+    // or points to "end" if all elementss are smaller than `ordinal`.
     OrdinalPageIndexIterator seek_at_or_before(ordinal_t ordinal);
     inline OrdinalPageIndexIterator begin();
     inline OrdinalPageIndexIterator end();


### PR DESCRIPTION
# Proposed changes

Issue Number: close #7765

## Problem Summary:

Fix the following bugs.

1. `column1` created a bitmap index.
2. `column1` has a lot index items in the bitmap index, and the index page is divided into two levels.
3. `column1`'s value range is `[1000, 10000000]`.
4. the query condition is `column1 > 0`
5. the empty result will be returned, while the expected value should be 9999000 rows.

## Checklist(Required)

1. Does it affect the original behavior: (No)
2. Has unit tests been added: (No)
3. Has document been added or modified: (No Need)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
