### PR TITLE
(refactor) (olap) (refactor) optimize SegmentIterator::next_batch()

### DIFF
--- a/be/src/olap/block_column_predicate.cpp
+++ b/be/src/olap/block_column_predicate.cpp
@@ -215,14 +215,8 @@ void AndBlockColumnPredicate::evaluate_vec(vectorized::MutableColumns& block, ui
     if (num_of_column_predicate() == 1) {
         _block_column_predicate_vec[0]->evaluate_vec(block, size, flags);
     } else {
-        bool new_flags[size];
         for (auto block_column_predicate : _block_column_predicate_vec) {
-            memset(new_flags, true, size);
-            block_column_predicate->evaluate_vec(block, size, new_flags);
- 
-            for (uint16_t j = 0; j < size; j++) {
-                flags[j] &= new_flags[j] ;
-            }
+            block_column_predicate->evaluate_vec(block, size, flags);
         }
     }
 }

--- a/be/src/olap/comparison_predicate.cpp
+++ b/be/src/olap/comparison_predicate.cpp
@@ -191,13 +191,13 @@ COMPARISON_PRED_COLUMN_EVALUATE(GreaterEqualPredicate, >=)
             auto& data_array = reinterpret_cast<const vectorized::PredicateColumnType<type>&>(nullable_column->get_nested_column()).get_data();              \
             auto& null_bitmap = reinterpret_cast<const vectorized::ColumnVector<uint8_t>&>(*(nullable_column->get_null_map_column_ptr())).get_data(); \
             for (uint16_t i = 0; i < size; i++) {                                                                                                     \
-                flags[i] = (data_array[i] OP _value) && (!null_bitmap[i]);                                                                            \
+                flags[i] &= (data_array[i] OP _value) && (!null_bitmap[i]);                                                                            \
             }                                                                                                                                         \
         } else {                                                                                                                                      \
             auto& predicate_column = reinterpret_cast<vectorized::PredicateColumnType<type>&>(column);                                                \
             auto& data_array = predicate_column.get_data();                                                                                           \
             for (uint16_t i = 0; i < size; i++) {                                                                                                     \
-                flags[i] = data_array[i] OP _value;                                                                                                   \
+                flags[i] &= data_array[i] OP _value;                                                                                                   \
             }                                                                                                                                         \
         }                                                                                                                                             \
         if (_opposite) {                                                                                                                              \

--- a/be/src/olap/rowset/segment_v2/segment_iterator.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.cpp
@@ -44,13 +44,10 @@ namespace segment_v2 {
 //   output ranges: [0,2), [4,8), [10,11), [15,18), [18,20) (when max_range_size=3)
 class SegmentIterator::BitmapRangeIterator {
 public:
-    explicit BitmapRangeIterator(const roaring::Roaring& bitmap)
-            : _last_val(0), _buf(new uint32_t[256]), _buf_pos(0), _buf_size(0), _eof(false) {
+    explicit BitmapRangeIterator(const roaring::Roaring& bitmap) {
         roaring_init_iterator(&bitmap.roaring, &_iter);
         _read_next_batch();
     }
-
-    ~BitmapRangeIterator() { delete[] _buf; }
 
     bool has_more_range() const { return !_eof; }
 
@@ -61,34 +58,35 @@ public:
             return false;
         }
         *from = _buf[_buf_pos];
-        uint32_t range_size = 0;
+        uint32_t range_size = 0, last_val;
         do {
-            _last_val = _buf[_buf_pos];
+            last_val = _buf[_buf_pos];
             _buf_pos++;
             range_size++;
-            if (_buf_pos == _buf_size) { // read next batch
+            if (UNLIKELY(_buf_pos == _buf_size)) { // read next batch
                 _read_next_batch();
+                if (_eof)  {
+                    break;
+                }
             }
-        } while (range_size < max_range_size && !_eof && _buf[_buf_pos] == _last_val + 1);
+        } while (range_size < max_range_size && _buf[_buf_pos] == last_val + 1);
         *to = *from + range_size;
         return true;
     }
 
 private:
     void _read_next_batch() {
-        uint32_t n = roaring::api::roaring_read_uint32_iterator(&_iter, _buf, kBatchSize);
         _buf_pos = 0;
-        _buf_size = n;
-        _eof = n == 0;
+        _buf_size = roaring::api::roaring_read_uint32_iterator(&_iter, _buf, kBatchSize);
+        _eof = (_buf_size == 0);
     }
 
     static const uint32_t kBatchSize = 256;
     roaring::api::roaring_uint32_iterator_t _iter;
-    uint32_t _last_val;
-    uint32_t* _buf = nullptr;
-    uint32_t _buf_pos;
-    uint32_t _buf_size;
-    bool _eof;
+    uint32_t _buf[kBatchSize];
+    uint32_t _buf_pos = 0;
+    uint32_t _buf_size = 0;
+    bool _eof = false;
 };
 
 SegmentIterator::SegmentIterator(std::shared_ptr<Segment> segment, const Schema& schema,
@@ -224,7 +222,7 @@ Status SegmentIterator::_get_row_ranges_by_column_conditions() {
     RETURN_IF_ERROR(_apply_bitmap_index());
 
     if (!_row_bitmap.isEmpty() &&
-        (_opts.conditions != nullptr || _opts.delete_conditions.size() > 0)) {
+        (_opts.conditions != nullptr || !_opts.delete_conditions.empty())) {
         RowRanges condition_row_ranges = RowRanges::create_single(_segment->num_rows());
         RETURN_IF_ERROR(_get_row_ranges_from_conditions(&condition_row_ranges));
         size_t pre_size = _row_bitmap.cardinality();
@@ -620,10 +618,11 @@ void SegmentIterator::_vec_init_lazy_materialization() {
                 if (_pre_eval_block_predicate == nullptr) {
                     _pre_eval_block_predicate = new AndBlockColumnPredicate();
                 }
-                reinterpret_cast<MutilColumnBlockPredicate*>(_pre_eval_block_predicate)->add_column_predicate(new SingleColumnBlockPredicate(predicate));
+                _pre_eval_block_predicate->add_column_predicate(new SingleColumnBlockPredicate(predicate));
             }
         }
 
+        // handle delete_condition
         std::set<ColumnId> del_cond_id_set;
         _opts.delete_condition_predicates.get()->get_all_column_ids(del_cond_id_set);
         short_cir_pred_col_id_set.insert(del_cond_id_set.begin(), del_cond_id_set.end());
@@ -660,7 +659,7 @@ void SegmentIterator::_vec_init_lazy_materialization() {
 
         // when _is_all_column_basic_type = true, _first_read_column_ids should keep the same order with _schema.column_ids which stands for return column order
         for (int i = 0; i < _schema.num_column_ids(); i++) {
-            auto cid = _schema.column_ids()[i];
+            auto cid = _schema.column_id(i);
             if (pred_set.find(cid) != pred_set.end()) {
                 _first_read_column_ids.push_back(cid);    
             } else if (non_pred_set.find(cid) != non_pred_set.end()) {
@@ -683,7 +682,7 @@ void SegmentIterator::_vec_init_lazy_materialization() {
     // make _schema_block_id_map
     _schema_block_id_map.resize(_schema.columns().size());
     for (int i = 0; i < _schema.num_column_ids(); i++) {
-        auto cid = _schema.column_ids()[i];
+        auto cid = _schema.column_id(i);
         _schema_block_id_map[cid] = i;
     }
 
@@ -709,8 +708,8 @@ void SegmentIterator::_init_current_block(vectorized::Block* block, std::vector<
         block->clear_column_data();
     } else { // pre fill output block here
         for (size_t i = 0; i < _schema.num_column_ids(); i++) {
-            auto cid = _schema.column_ids()[i];
-            auto* column_desc = _schema.columns()[cid];
+            auto cid = _schema.column_id(i);
+            auto column_desc = _schema.column(cid);
             auto data_type = Schema::get_data_type_ptr(column_desc->type());
             if (column_desc->is_nullable()) {
                 block->insert({nullptr, std::make_shared<vectorized::DataTypeNullable>(std::move(data_type)), column_desc->name()});
@@ -721,11 +720,11 @@ void SegmentIterator::_init_current_block(vectorized::Block* block, std::vector<
     }
 
     for (size_t i = 0; i < _schema.num_column_ids(); i++) {
-        auto cid = _schema.column_ids()[i];
+        auto cid = _schema.column_id(i);
         if (_is_pred_column[cid]) {  //todo(wb) maybe we can relase it after output block
             current_columns[cid]->clear();
         } else { // non-predicate column
-            auto &column_desc = _schema.columns()[cid];
+            auto column_desc = _schema.column(cid);
             if (is_block_mem_reuse) {
                 current_columns[cid] = std::move(*block->get_by_position(i).column).mutate();
             } else {
@@ -795,10 +794,9 @@ Status SegmentIterator::_read_columns_by_index(uint32_t nrows_read_limit, uint32
 }
 
 void SegmentIterator::_evaluate_vectorization_predicate(uint16_t* sel_rowid_idx, uint16_t& selected_size) {
-    uint16_t new_size = 0;
-    if (_vec_pred_column_ids.size() == 0) {
+    if (_vec_pred_column_ids.empty()) {
         for (uint32_t i = 0; i < selected_size; ++i) {
-            sel_rowid_idx[new_size++] = i;
+            sel_rowid_idx[i] = i;
         }
         return;
     }
@@ -808,6 +806,7 @@ void SegmentIterator::_evaluate_vectorization_predicate(uint16_t* sel_rowid_idx,
     memset(ret_flags, 1, selected_size);
     _pre_eval_block_predicate->evaluate_vec(_current_return_columns, selected_size, ret_flags);
     
+    uint16_t new_size = 0;
     for (uint32_t i = 0; i < selected_size; ++i) {
         if (ret_flags[i]) {
             sel_rowid_idx[new_size++] = i;
@@ -819,7 +818,7 @@ void SegmentIterator::_evaluate_vectorization_predicate(uint16_t* sel_rowid_idx,
 }
 
 void SegmentIterator::_evaluate_short_circuit_predicate(uint16_t* vec_sel_rowid_idx, uint16_t* selected_size_ptr) {
-    if (_short_cir_pred_column_ids.size() == 0) {
+    if (_short_cir_pred_column_ids.empty()) {
         return;
     }
     
@@ -855,13 +854,13 @@ Status SegmentIterator::next_batch(vectorized::Block* block) {
         RETURN_IF_ERROR(_init(true));
         _inited = true;
         if (_vec_pred_column_ids.size() > 0 || _short_cir_pred_column_ids.size() > 0) {
-            _block_rowids.reserve(_opts.block_row_max);
+            _block_rowids.resize(_opts.block_row_max);
         }
         _current_return_columns.resize(_schema.columns().size()); 
         for (size_t i = 0; i < _schema.num_column_ids(); i++) {
-            auto cid = _schema.column_ids()[i];
+            auto cid = _schema.column_id(i);
             if (_is_pred_column[cid]) {
-                auto& column_desc = _schema.columns()[cid];
+                auto column_desc = _schema.column(cid);
                 _current_return_columns[cid] = Schema::get_predicate_column_nullable_ptr(column_desc->type(), column_desc->is_nullable());
                 _current_return_columns[cid]->reserve(_opts.block_row_max);
             }
@@ -872,20 +871,20 @@ Status SegmentIterator::next_batch(vectorized::Block* block) {
     
     uint32_t nrows_read = 0;
     uint32_t nrows_read_limit = _opts.block_row_max;
-    _read_columns_by_index(nrows_read_limit, nrows_read, _col_predicates.size() > 0);
+    _read_columns_by_index(nrows_read_limit, nrows_read, !_col_predicates.empty());
 
     _opts.stats->blocks_load += 1;
     _opts.stats->raw_rows_read += nrows_read;
 
     if (nrows_read == 0) {
         for (int i = 0; i < _schema.num_column_ids(); i++) {
-            auto cid = _schema.column_ids()[i];
+            auto cid = _schema.column_id(i);
             // todo(wb) abstract make column where
             if (!_is_pred_column[cid]) { // non-predicate
                 block->replace_by_position(i, std::move(_current_return_columns[cid]));
             } else { // predicate
                 if (!is_mem_reuse) {
-                    auto* column_desc = _schema.columns()[cid];
+                    auto column_desc = _schema.column(cid);
                     auto data_type = Schema::get_data_type_ptr(column_desc->type());
                     block->replace_by_position(i, data_type->create_column());
                 }
@@ -899,7 +898,7 @@ Status SegmentIterator::next_batch(vectorized::Block* block) {
     }
 
     // when no predicate(include delete condition) is provided, output column directly
-    if (_vec_pred_column_ids.size() == 0 && _short_cir_pred_column_ids.size() == 0) {
+    if (_vec_pred_column_ids.empty() && _short_cir_pred_column_ids.empty()) {
         _output_non_pred_columns(block, is_mem_reuse);
     } else { // need predicate evaluation
         uint16_t selected_size = nrows_read;
@@ -909,7 +908,7 @@ Status SegmentIterator::next_batch(vectorized::Block* block) {
         _evaluate_vectorization_predicate(sel_rowid_idx, selected_size);
 
         // When predicate column and no-predicate column are both basic type, lazy materialization is eliminate
-        // So output block directly after vecorization evaluation
+        // So output block directly after vectorization evaluation
         if (_is_all_column_basic_type) {
             _output_column_by_sel_idx(block, _first_read_column_ids, sel_rowid_idx, selected_size, is_mem_reuse);
             return Status::OK();
@@ -922,7 +921,7 @@ Status SegmentIterator::next_batch(vectorized::Block* block) {
         _evaluate_short_circuit_predicate(sel_rowid_idx, &selected_size);
         
         // step3: read non_predicate column
-        if (_non_predicate_columns.size() != 0) {
+        if (!_non_predicate_columns.empty()) {
             _read_columns_by_rowids(_non_predicate_columns, _block_rowids, sel_rowid_idx, selected_size, &_current_return_columns);
         }
 
@@ -934,7 +933,6 @@ Status SegmentIterator::next_batch(vectorized::Block* block) {
         _output_column_by_sel_idx(block, _short_cir_pred_column_ids, sel_rowid_idx, selected_size, is_mem_reuse);
         // 4.3 output vectorizatioin predicate column
         _output_column_by_sel_idx(block, _vec_pred_column_ids, sel_rowid_idx, selected_size, is_mem_reuse);
-
     }
 
     return Status::OK();

--- a/be/src/olap/schema.h
+++ b/be/src/olap/schema.h
@@ -132,6 +132,7 @@ public:
     size_t num_columns() const { return _cols.size(); }
     size_t num_column_ids() const { return _col_ids.size(); }
     const std::vector<ColumnId>& column_ids() const { return _col_ids; }
+    ColumnId column_id(size_t index) const { return _col_ids[index]; }
     int32_t delete_sign_idx() const { return _delete_sign_idx; }
     bool has_sequence_col() const { return _has_sequence_col; }
 

--- a/be/src/vec/columns/column_vector.h
+++ b/be/src/vec/columns/column_vector.h
@@ -120,10 +120,13 @@ private:
     ColumnVector(std::initializer_list<T> il) : data {il} {}
 
     void insert_res_column(const uint16_t* sel, size_t sel_size, vectorized::ColumnVector<T>* res_ptr) {
+        auto& res_data = res_ptr->data; 
+        res_data.reserve(res_ptr->size() + sel_size);
+        T* t = (T*)res_data.get_end_ptr();
         for (size_t i = 0; i < sel_size; i++) {
-            T* val_ptr = &data[sel[i]];
-            res_ptr->insert_data((char*)val_ptr, 0);
+            t[i] = T(data[sel[i]]);
         }
+        res_data.set_end_ptr(t + sel_size);
     }
 
 public:

--- a/be/src/vec/columns/predicate_column.h
+++ b/be/src/vec/columns/predicate_column.h
@@ -91,10 +91,13 @@ private:
 
     template <typename Y>
     void insert_default_value_res_column(const uint16_t* sel, size_t sel_size, vectorized::ColumnVector<Y>* res_ptr) {
+        auto& res_data = res_ptr->get_data();
+        res_data.reserve(res_ptr->size() + sel_size);
+        T* t = (T*)res_data.get_end_ptr();
         for (size_t i = 0; i < sel_size; i++) {
-            T* val_ptr = &data[sel[i]];
-            res_ptr->insert_data((char*)val_ptr, 0);
+            t[i] = T(data[sel[i]]);
         }
+        res_data.set_end_ptr(t + sel_size);
     }
 
     void insert_byte_to_res_column(const uint16_t* sel, size_t sel_size, vectorized::IColumn* res_ptr) {

--- a/be/src/vec/common/pod_array.h
+++ b/be/src/vec/common/pod_array.h
@@ -333,6 +333,9 @@ public:
     const_iterator cbegin() const { return t_start(); }
     const_iterator cend() const { return t_end(); }
 
+    void* get_end_ptr() const { return this->c_end; }
+    void set_end_ptr(void* ptr) { this->c_end = (char*)ptr; }
+
     /// Same as resize, but zeroes new elements.
     void resize_fill(size_t n) {
         size_t old_size = this->size();


### PR DESCRIPTION
# Proposed changes
1. refactor BitmapRangeIterator, avoid new/delete, check _eof in loop while _read_next_batch to simply outloop's check
2. modify evaluate_vec, avoid set and check new_flags out of block_column_predicate->evaluate_vec()
3. replace _block_rowids.reserve() with _block_rowids.resize(). access vector's data with subscript is illegal after reverving, when via at() or operator[] access vector's data may assert failed, the behavior is depend on STL's implements 
4. optimize insert_default_value_res_column and insert_res_column by operating PODArray data directly
5. using empty() interface instead of 'size() > 0', because empty() is fittable, sometimes faster, such as for container list, refer to Effective C++ 
6. some other small changes

Issue Number: close #xxx

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
