### PR TITLE
[docs](install-deploy) fix misplaced whitespace(#7814)

### DIFF
--- a/docs/en/installing/install-deploy.md
+++ b/docs/en/installing/install-deploy.md
@@ -220,7 +220,7 @@ See the section on `lower_case_table_names` variables in [Variables](../administ
 
 * View BE status
 
-	Connect to FE using mysql-client and execute `SHOW PROC'/ backends'; `View BE operation. If everything is normal, the `isAlive`column should be `true`.
+	Connect to FE using mysql-client and execute `SHOW PROC '/backends'; `View BE operation. If everything is normal, the `isAlive`column should be `true`.
 
 #### (Optional) FS_Broker deployment
 


### PR DESCRIPTION
Misplaced whitespace causes unexpected output. Fix it so newcomers need not to
worry if they are lost by the docs.

# Proposed changes

Issue Number: close #7814

1. Does it affect the original behavior: No
2. Has unit tests been added: No need
3. Has document been added or modified: Yes
4. Does it need to update dependencies: No
5. Are there any changes that cannot be rolled back: No
