### PR TITLE
[Optimize][Extension] optimize extension spark-doris-connector , Remove import doris via csv in spark-doris-connector, only support via json

### DIFF
--- a/extension/spark-doris-connector/pom.xml
+++ b/extension/spark-doris-connector/pom.xml
@@ -225,6 +225,12 @@
             <version>4.1.27.Final</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>com.alibaba</groupId>
+            <artifactId>fastjson</artifactId>
+            <version>1.2.75</version>
+            <scope>provided</scope>
+        </dependency>
 
     </dependencies>
 

--- a/extension/spark-doris-connector/src/main/java/org/apache/doris/spark/DorisStreamLoad.java
+++ b/extension/spark-doris-connector/src/main/java/org/apache/doris/spark/DorisStreamLoad.java
@@ -16,6 +16,8 @@
 // under the License.
 package org.apache.doris.spark;
 
+import com.alibaba.fastjson.JSONArray;
+import com.alibaba.fastjson.JSONObject;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.doris.spark.cfg.ConfigurationOptions;
 import org.apache.doris.spark.cfg.SparkSettings;
@@ -113,6 +115,8 @@ public class DorisStreamLoad implements Serializable{
         if (columns != null && !columns.equals("")) {
             conn.addRequestProperty("columns", columns);
         }
+        conn.addRequestProperty("format","json");
+        conn.addRequestProperty("strip_outer_array","true");
         conn.setDoOutput(true);
         conn.setDoInput(true);
         return conn;
@@ -154,11 +158,30 @@ public class DorisStreamLoad implements Serializable{
         return lines.toString();
     }
 
-
-    public void load(List<List<Object>> rows) throws StreamLoadException {
-        String records = listToString(rows);
-        load(records);
+    public void loadV2(List<List<Object>> rows) throws StreamLoadException {
+        if (null == columns || columns.length() < 1){
+            throw  new StreamLoadException("doris.write.fields parameter is not configured.");
+        }
+        JSONArray loadData = new JSONArray();
+        try {
+            for (List<Object> row : rows){
+                JSONObject loadLineData = new JSONObject();
+                String[] columnsArray = columns.split("\\,");
+                if (columnsArray.length == row.size()){
+                    for (int i = 0; i < columnsArray.length; i++) {
+                        loadLineData.put(columnsArray[i],row.get(i) == null ? NULL_VALUE : row.get(i));
+                    }
+                }else {
+                    throw  new StreamLoadException("The number of configured columns does not match the number of data columns.");
+                }
+                loadData.add(loadLineData);
+            }
+        }catch (Exception e){
+            throw  new StreamLoadException("data parse json error:  " + e.getMessage() );
+        }
+        load(loadData.toString());
     }
+
     public void load(String value) throws StreamLoadException {
         LOG.debug("Streamload Request:{} ,Body:{}", loadUrlStr, value);
         LoadResponse loadResponse = loadBatch(value);

--- a/extension/spark-doris-connector/src/main/scala/org/apache/doris/spark/sql/DorisSourceProvider.scala
+++ b/extension/spark-doris-connector/src/main/scala/org/apache/doris/spark/sql/DorisSourceProvider.scala
@@ -93,7 +93,7 @@ private[sql] class DorisSourceProvider extends DataSourceRegister
 
           for (i <- 1 to maxRetryTimes) {
             try {
-              dorisStreamLoader.load(rowsBuffer)
+              dorisStreamLoader.loadV2(rowsBuffer)
               rowsBuffer.clear()
               loop.break()
             }


### PR DESCRIPTION
1.Remove import doris via csv format, only support via json;
2.DataframeWrite must be configured with doris.write.fields, \
  e.g df.write.format("doris").option("doris.write.fields", "name,gender");
3.StructuredStreamingWrite import data format must be jsonarray format;

# Proposed changes

Issue Number: close #xxx

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
