### PR TITLE
[fix](lateral-view) Error analyze when lateral view + subquery rewrite

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/LateralViewRef.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/LateralViewRef.java
@@ -176,5 +176,18 @@ public class LateralViewRef extends TableRef {
             throw new AnalysisException("Subquery is not allowed in lateral view");
         }
     }
+
+    @Override
+    public void reset() {
+        isAnalyzed = false;
+        expr.reset();
+        fnExpr = null;
+        originSlotRefList = Lists.newArrayList();
+        view = null;
+        explodeSlotRef = null;
+        // There is no need to call the reset function of @relatedTableRef here.
+        // The main reason is that @lateralViewRef itself is an attribute of @relatedTableRef
+        // The reset of @lateralViewRef happens in the reset() of @relatedTableRef.
+    }
 }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/TableRef.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/TableRef.java
@@ -716,6 +716,11 @@ public class TableRef implements ParseNode, Writable {
         allMaterializedTupleIds_.clear();
         correlatedTupleIds_.clear();
         desc = null;
+        if (lateralViewRefs != null) {
+            for (LateralViewRef lateralViewRef : lateralViewRefs) {
+                lateralViewRef.reset();
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
# Proposed changes

Issue Number: close #7823

After the subquery is rewritten, the rewritten stmt needs to be reset
(that is, the content of the first analyze semantic analysis is cleared),
and then the rewritten stmt can be reAnalyzed.

The lateral view ref in the previous implementation forgot to implement the reset function.
This caused him to keep the first error message in the second analyze.
Eventually, two duplicate tupleIds appear in the new stmt and are marked with different tuple.
From the explain string, the following syntax will have an additional wrong join predicate.
```
Query: explain select k1 from test_explode lateral view explode_split(k2, ",") tmp as e1  where k1 in (select k3 from tbl1);
Error equal join conjunct: `k3` = `k3`
```

This pr mainly adds the reset function of the lateral view
to avoid possible errors in the second analyze
when the lateral view and subquery rewrite occur at the same time.
