### PR TITLE
[Bug] Fix bug that wrong exception message returned by insert statement

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/ErrorCode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/ErrorCode.java
@@ -1685,7 +1685,8 @@ public enum ErrorCode {
             "data cannot be inserted into table with empty partition. " +
                     "Use `SHOW PARTITIONS FROM %s` to see the currently partitions of this table. "),
     ERROR_SQL_AND_LIMITATIONS_SET_IN_ONE_RULE(5084, new byte[]{'4', '2', '0', '0', '0'},
-            "sql/sqlHash and partition_num/tablet_num/cardinality cannot be set in one rule.")
+            "sql/sqlHash and partition_num/tablet_num/cardinality cannot be set in one rule."),
+    ERR_UNHEALTHY_BACKEND_EXISTS(5085, new byte[]{'H', 'Y', '0', '0', '0'}, "There exists unhealthy backend.")
     ;
 
     // This is error code

--- a/fe/fe-core/src/main/java/org/apache/doris/common/ErrorCode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/ErrorCode.java
@@ -1685,8 +1685,7 @@ public enum ErrorCode {
             "data cannot be inserted into table with empty partition. " +
                     "Use `SHOW PARTITIONS FROM %s` to see the currently partitions of this table. "),
     ERROR_SQL_AND_LIMITATIONS_SET_IN_ONE_RULE(5084, new byte[]{'4', '2', '0', '0', '0'},
-            "sql/sqlHash and partition_num/tablet_num/cardinality cannot be set in one rule."),
-    ERR_UNHEALTHY_BACKEND_EXISTS(5085, new byte[]{'H', 'Y', '0', '0', '0'}, "There exists unhealthy backend.")
+            "sql/sqlHash and partition_num/tablet_num/cardinality cannot be set in one rule.")
     ;
 
     // This is error code

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -1248,10 +1248,15 @@ public class StmtExecutor implements ProfileWriter {
 
                 coord.exec();
 
-                coord.join(context.getSessionVariable().getQueryTimeoutS());
+                boolean notTimeout = coord.join(context.getSessionVariable().getQueryTimeoutS());
                 if (!coord.isDone()) {
                     coord.cancel();
-                    ErrorReport.reportDdlException(ErrorCode.ERR_EXECUTE_TIMEOUT);
+                    if (notTimeout) {
+                        ErrorReport.reportDdlException(ErrorCode.ERR_UNHEALTHY_BACKEND_EXISTS);
+                    } else {
+                        ErrorReport.reportDdlException(ErrorCode.ERR_EXECUTE_TIMEOUT);
+                    }
+
                 }
 
                 if (!coord.getExecStatus().ok()) {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -1253,7 +1253,7 @@ public class StmtExecutor implements ProfileWriter {
                     coord.cancel();
                     if (notTimeout) {
                         errMsg = coord.getExecStatus().getErrorMsg();
-                        ErrorReport.reportDdlException(errMsg, ErrorCode.ERR_UNHEALTHY_BACKEND_EXISTS);
+                        ErrorReport.reportDdlException("There exists unhealthy backend. " + errMsg, ErrorCode.ERR_FAILED_WHEN_INSERT);
                     } else {
                         ErrorReport.reportDdlException(ErrorCode.ERR_EXECUTE_TIMEOUT);
                     }

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -1252,11 +1252,11 @@ public class StmtExecutor implements ProfileWriter {
                 if (!coord.isDone()) {
                     coord.cancel();
                     if (notTimeout) {
-                        ErrorReport.reportDdlException(ErrorCode.ERR_UNHEALTHY_BACKEND_EXISTS);
+                        errMsg = coord.getExecStatus().getErrorMsg();
+                        ErrorReport.reportDdlException(errMsg, ErrorCode.ERR_UNHEALTHY_BACKEND_EXISTS);
                     } else {
                         ErrorReport.reportDdlException(ErrorCode.ERR_EXECUTE_TIMEOUT);
                     }
-
                 }
 
                 if (!coord.getExecStatus().ok()) {


### PR DESCRIPTION
# Proposed changes

Issue Number: close #7831

## Problem Summary:

`insert` statement may return exception message `Execute timeout` after load data failed. But the real reason is that there exists unhealthy backend, not execute timeout.
```
MySQL [ssb]> insert into lineorder_flat select * from lineorder_flat;
ERROR 1105 (HY000): errCode = 2, detailMessage = Execute timeout
```

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)
