### PR TITLE
[fix](toolchain) Support ldb_toolchain on ubuntu 20

### DIFF
--- a/thirdparty/build-thirdparty.sh
+++ b/thirdparty/build-thirdparty.sh
@@ -265,9 +265,9 @@ build_thrift() {
     # NOTE(amos): libtool discard -static. --static works.
     ./configure CPPFLAGS="-I${TP_INCLUDE_DIR}" LDFLAGS="-L${TP_LIB_DIR} --static" LIBS="-lcrypto -ldl -lssl" CFLAGS="-fPIC" \
     --prefix=$TP_INSTALL_DIR --docdir=$TP_INSTALL_DIR/doc --enable-static --disable-shared --disable-tests \
-    --disable-tutorial --without-qt4 --without-qt5 --without-csharp --without-erlang --without-nodejs \
-    --without-lua --without-perl --without-php --without-php_extension --without-dart --without-ruby \
-    --without-haskell --without-go --without-haxe --without-d --without-python -without-java -without-rs --with-cpp \
+    --disable-tutorial --without-qt4 --without-qt5 --without-csharp --without-erlang --without-nodejs --without-nodets --without-swift \
+    --without-lua --without-perl --without-php --without-php_extension --without-dart --without-ruby --without-cl \
+    --without-haskell --without-go --without-haxe --without-d --without-python -without-java --without-dotnetcore -without-rs --with-cpp \
     --with-libevent=$TP_INSTALL_DIR --with-boost=$TP_INSTALL_DIR --with-openssl=$TP_INSTALL_DIR
 
     if [ -f compiler/cpp/thrifty.hh ];then

--- a/thirdparty/patches/mysql-server-mysql-5.7.18.patch
+++ b/thirdparty/patches/mysql-server-mysql-5.7.18.patch
@@ -51,3 +51,15 @@ diff -uprN a/cmd-line-utils/libedit/terminal.c b/cmd-line-utils/libedit/terminal
  
  
  	if (term == NULL)
+diff -uprN a/CMakeLists.txt b/CMakeLists.txt
+--- a/CMakeLists.txt    2022-01-23 23:30:48.915006943 +0800
++++ b/CMakeLists.txt    2022-01-23 23:31:04.785141731 +0800
+@@ -484,8 +484,6 @@ INCLUDE_DIRECTORIES(
+ MYSQL_CHECK_ZLIB_WITH_COMPRESS()
+ # Add bundled yassl/taocrypt or system openssl.
+ MYSQL_CHECK_SSL()
+-# Add system/bundled editline.
+-MYSQL_CHECK_EDITLINE()
+ # Add libevent
+ MYSQL_CHECK_LIBEVENT()
+ # Add lz4 library


### PR DESCRIPTION
# Proposed changes

Issue Number: close #7843 

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (No)
2. Has unit tests been added: (No Need)
3. Has document been added or modified: (No Need)
4. Does it need to update dependencies: (Yes)
5. Are there any changes that cannot be rolled back: (No)

## Further comments

ldb_toolchain now (>= v0.4) supports compiling Doris on ubuntu 20.