### PR TITLE
[Compatible]http v2 and v1 interface compatible

### DIFF
--- a/extension/flink-doris-connector/src/main/java/org/apache/doris/flink/rest/SchemaUtils.java
+++ b/extension/flink-doris-connector/src/main/java/org/apache/doris/flink/rest/SchemaUtils.java
@@ -33,7 +33,7 @@ public class SchemaUtils {
      */
     public static Schema convertToSchema(List<TScanColumnDesc> tscanColumnDescs) {
         Schema schema = new Schema(tscanColumnDescs.size());
-        tscanColumnDescs.stream().forEach(desc -> schema.put(new Field(desc.getName(), desc.getType().name(), "", 0, 0,"")));
+        tscanColumnDescs.stream().forEach(desc -> schema.put(new Field(desc.getName(), desc.getType().name(), "", 0, 0, "")));
         return schema;
     }
 }

--- a/extension/flink-doris-connector/src/main/java/org/apache/doris/flink/rest/SchemaUtils.java
+++ b/extension/flink-doris-connector/src/main/java/org/apache/doris/flink/rest/SchemaUtils.java
@@ -33,7 +33,7 @@ public class SchemaUtils {
      */
     public static Schema convertToSchema(List<TScanColumnDesc> tscanColumnDescs) {
         Schema schema = new Schema(tscanColumnDescs.size());
-        tscanColumnDescs.stream().forEach(desc -> schema.put(new Field(desc.getName(), desc.getType().name(), "", 0, 0)));
+        tscanColumnDescs.stream().forEach(desc -> schema.put(new Field(desc.getName(), desc.getType().name(), "", 0, 0,"")));
         return schema;
     }
 }

--- a/extension/flink-doris-connector/src/main/java/org/apache/doris/flink/rest/models/Field.java
+++ b/extension/flink-doris-connector/src/main/java/org/apache/doris/flink/rest/models/Field.java
@@ -30,7 +30,7 @@ public class Field {
     public Field() {
     }
 
-    public Field(String name, String type, String comment, int precision, int scale,String aggregation_type) {
+    public Field(String name, String type, String comment, int precision, int scale, String aggregation_type) {
         this.name = name;
         this.type = type;
         this.comment = comment;

--- a/extension/flink-doris-connector/src/main/java/org/apache/doris/flink/rest/models/Field.java
+++ b/extension/flink-doris-connector/src/main/java/org/apache/doris/flink/rest/models/Field.java
@@ -25,16 +25,26 @@ public class Field {
     private String comment;
     private int precision;
     private int scale;
+    private String aggregation_type;
 
     public Field() {
     }
 
-    public Field(String name, String type, String comment, int precision, int scale) {
+    public Field(String name, String type, String comment, int precision, int scale,String aggregation_type) {
         this.name = name;
         this.type = type;
         this.comment = comment;
         this.precision = precision;
         this.scale = scale;
+        this.aggregation_type = aggregation_type;
+    }
+
+    public String getAggregation_type() {
+        return aggregation_type;
+    }
+
+    public void setAggregation_type(String aggregation_type) {
+        this.aggregation_type = aggregation_type;
     }
 
     public String getName() {

--- a/extension/flink-doris-connector/src/main/java/org/apache/doris/flink/rest/models/Schema.java
+++ b/extension/flink-doris-connector/src/main/java/org/apache/doris/flink/rest/models/Schema.java
@@ -58,8 +58,8 @@ public class Schema {
         this.properties = properties;
     }
 
-    public void put(String name, String type, String comment, int scale, int precision,String aggregation_type) {
-        properties.add(new Field(name, type, comment, scale, precision,aggregation_type));
+    public void put(String name, String type, String comment, int scale, int precision, String aggregation_type) {
+        properties.add(new Field(name, type, comment, scale, precision, aggregation_type));
     }
 
     public void put(Field f) {

--- a/extension/flink-doris-connector/src/main/java/org/apache/doris/flink/rest/models/Schema.java
+++ b/extension/flink-doris-connector/src/main/java/org/apache/doris/flink/rest/models/Schema.java
@@ -58,8 +58,8 @@ public class Schema {
         this.properties = properties;
     }
 
-    public void put(String name, String type, String comment, int scale, int precision) {
-        properties.add(new Field(name, type, comment, scale, precision));
+    public void put(String name, String type, String comment, int scale, int precision,String aggregation_type) {
+        properties.add(new Field(name, type, comment, scale, precision,aggregation_type));
     }
 
     public void put(Field f) {

--- a/extension/flink-doris-connector/src/test/java/org/apache/doris/flink/serialization/TestRowBatch.java
+++ b/extension/flink-doris-connector/src/test/java/org/apache/doris/flink/serialization/TestRowBatch.java
@@ -232,8 +232,8 @@ public class TestRowBatch {
                 + "\"name\":\"k4\",\"comment\":\"\"},{\"type\":\"FLOAT\",\"name\":\"k9\",\"comment\":\"\"},"
                 + "{\"type\":\"DOUBLE\",\"name\":\"k8\",\"comment\":\"\"},{\"type\":\"DATE\",\"name\":\"k10\","
                 + "\"comment\":\"\"},{\"type\":\"DATETIME\",\"name\":\"k11\",\"comment\":\"\"},"
-                + "{\"name\":\"k5\",\"scale\":\"9\",\"comment\":\"\","
-                + "\"type\":\"DECIMAL\",\"precision\":\"2\"},{\"type\":\"CHAR\",\"name\":\"k6\",\"comment\":\"\"}],"
+                + "{\"name\":\"k5\",\"scale\":\"0\",\"comment\":\"\","
+                + "\"type\":\"DECIMAL\",\"precision\":\"9\",\"aggregation_type\":\"\"},{\"type\":\"CHAR\",\"name\":\"k6\",\"comment\":\"\",\"aggregation_type\":\"REPLACE_IF_NOT_NULL\"}],"
                 + "\"status\":200}";
 
         Schema schema = RestService.parseSchema(schemaStr, logger);

--- a/extension/spark-doris-connector/src/main/java/org/apache/doris/spark/rest/models/Field.java
+++ b/extension/spark-doris-connector/src/main/java/org/apache/doris/spark/rest/models/Field.java
@@ -30,7 +30,7 @@ public class Field {
 
     public Field() { }
 
-    public Field(String name, String type, String comment, int precision, int scale,String aggregation_type) {
+    public Field(String name, String type, String comment, int precision, int scale, String aggregation_type) {
         this.name = name;
         this.type = type;
         this.comment = comment;

--- a/extension/spark-doris-connector/src/main/java/org/apache/doris/spark/rest/models/Field.java
+++ b/extension/spark-doris-connector/src/main/java/org/apache/doris/spark/rest/models/Field.java
@@ -26,14 +26,25 @@ public class Field {
     private int precision;
     private int scale;
 
+    private String aggregation_type;
+
     public Field() { }
 
-    public Field(String name, String type, String comment, int precision, int scale) {
+    public Field(String name, String type, String comment, int precision, int scale,String aggregation_type) {
         this.name = name;
         this.type = type;
         this.comment = comment;
         this.precision = precision;
         this.scale = scale;
+        this.aggregation_type = aggregation_type;
+    }
+
+    public String getAggregation_type() {
+        return aggregation_type;
+    }
+
+    public void setAggregation_type(String aggregation_type) {
+        this.aggregation_type = aggregation_type;
     }
 
     public String getName() {

--- a/extension/spark-doris-connector/src/main/java/org/apache/doris/spark/rest/models/Schema.java
+++ b/extension/spark-doris-connector/src/main/java/org/apache/doris/spark/rest/models/Schema.java
@@ -49,8 +49,8 @@ public class Schema {
         this.properties = properties;
     }
 
-    public void put(String name, String type, String comment, int scale, int precision,String aggregation_type) {
-        properties.add(new Field(name, type, comment, scale, precision,aggregation_type));
+    public void put(String name, String type, String comment, int scale, int precision, String aggregation_type) {
+        properties.add(new Field(name, type, comment, scale, precision, aggregation_type));
     }
 
     public void put(Field f) {

--- a/extension/spark-doris-connector/src/main/java/org/apache/doris/spark/rest/models/Schema.java
+++ b/extension/spark-doris-connector/src/main/java/org/apache/doris/spark/rest/models/Schema.java
@@ -49,8 +49,8 @@ public class Schema {
         this.properties = properties;
     }
 
-    public void put(String name, String type, String comment, int scale, int precision) {
-        properties.add(new Field(name, type, comment, scale, precision));
+    public void put(String name, String type, String comment, int scale, int precision,String aggregation_type) {
+        properties.add(new Field(name, type, comment, scale, precision,aggregation_type));
     }
 
     public void put(Field f) {

--- a/extension/spark-doris-connector/src/main/scala/org/apache/doris/spark/sql/SchemaUtils.scala
+++ b/extension/spark-doris-connector/src/main/scala/org/apache/doris/spark/sql/SchemaUtils.scala
@@ -103,7 +103,7 @@ private[spark] object SchemaUtils {
    */
   def convertToSchema(tscanColumnDescs: Seq[TScanColumnDesc]): Schema = {
     val schema = new Schema(tscanColumnDescs.length)
-    tscanColumnDescs.foreach(desc => schema.put(new Field(desc.getName, desc.getType.name, "", 0, 0)))
+    tscanColumnDescs.foreach(desc => schema.put(new Field(desc.getName, desc.getType.name, "", 0, 0, "")))
     schema
   }
 }

--- a/extension/spark-doris-connector/src/test/java/org/apache/doris/spark/rest/TestRestService.java
+++ b/extension/spark-doris-connector/src/test/java/org/apache/doris/spark/rest/TestRestService.java
@@ -120,8 +120,8 @@ public class TestRestService {
 
     @Test
     public void testFeResponseToSchema() throws Exception {
-        String res = "{\"properties\":[{\"type\":\"TINYINT\",\"name\":\"k1\",\"comment\":\"\"},{\"name\":\"k5\","
-                + "\"scale\":\"0\",\"comment\":\"\",\"type\":\"DECIMALV2\",\"precision\":\"9\",\"}],\"status\":200}";
+        String res = "{\"properties\":[{\"type\":\"TINYINT\",\"name\":\"k1\",\"comment\":\"\",\"aggregation_type\":\"\"},{\"name\":\"k5\","
+                + "\"scale\":\"0\",\"comment\":\"\",\"type\":\"DECIMALV2\",\"precision\":\"9\",\"aggregation_type\":\"\"}],\"status\":200}";
         Schema expected = new Schema();
         expected.setStatus(200);
         Field k1 = new Field("k1", "TINYINT", "", 0, 0, "");

--- a/extension/spark-doris-connector/src/test/java/org/apache/doris/spark/rest/TestRestService.java
+++ b/extension/spark-doris-connector/src/test/java/org/apache/doris/spark/rest/TestRestService.java
@@ -125,7 +125,7 @@ public class TestRestService {
         Schema expected = new Schema();
         expected.setStatus(200);
         Field k1 = new Field("k1", "TINYINT", "", 0, 0, "");
-        Field k5 = new Field("k5", "DECIMALV2", "", 9, 0,"");
+        Field k5 = new Field("k5", "DECIMALV2", "", 9, 0, "");
         expected.put(k1);
         expected.put(k5);
         Assert.assertEquals(expected, RestService.parseSchema(res, logger));

--- a/extension/spark-doris-connector/src/test/java/org/apache/doris/spark/rest/TestRestService.java
+++ b/extension/spark-doris-connector/src/test/java/org/apache/doris/spark/rest/TestRestService.java
@@ -124,7 +124,7 @@ public class TestRestService {
                 + "\"scale\":\"0\",\"comment\":\"\",\"type\":\"DECIMALV2\",\"precision\":\"9\",\"}],\"status\":200}";
         Schema expected = new Schema();
         expected.setStatus(200);
-        Field k1 = new Field("k1", "TINYINT", "", 0, 0,"");
+        Field k1 = new Field("k1", "TINYINT", "", 0, 0, "");
         Field k5 = new Field("k5", "DECIMALV2", "", 9, 0,"");
         expected.put(k1);
         expected.put(k5);

--- a/extension/spark-doris-connector/src/test/java/org/apache/doris/spark/rest/TestRestService.java
+++ b/extension/spark-doris-connector/src/test/java/org/apache/doris/spark/rest/TestRestService.java
@@ -121,11 +121,11 @@ public class TestRestService {
     @Test
     public void testFeResponseToSchema() throws Exception {
         String res = "{\"properties\":[{\"type\":\"TINYINT\",\"name\":\"k1\",\"comment\":\"\"},{\"name\":\"k5\","
-                + "\"scale\":\"0\",\"comment\":\"\",\"type\":\"DECIMALV2\",\"precision\":\"9\"}],\"status\":200}";
+                + "\"scale\":\"0\",\"comment\":\"\",\"type\":\"DECIMALV2\",\"precision\":\"9\",\"}],\"status\":200}";
         Schema expected = new Schema();
         expected.setStatus(200);
-        Field k1 = new Field("k1", "TINYINT", "", 0, 0);
-        Field k5 = new Field("k5", "DECIMALV2", "", 9, 0);
+        Field k1 = new Field("k1", "TINYINT", "", 0, 0,"");
+        Field k5 = new Field("k5", "DECIMALV2", "", 9, 0,"");
         expected.put(k1);
         expected.put(k5);
         Assert.assertEquals(expected, RestService.parseSchema(res, logger));

--- a/extension/spark-doris-connector/src/test/java/org/apache/doris/spark/serialization/TestRowBatch.java
+++ b/extension/spark-doris-connector/src/test/java/org/apache/doris/spark/serialization/TestRowBatch.java
@@ -235,7 +235,7 @@ public class TestRowBatch {
                 + "{\"type\":\"DOUBLE\",\"name\":\"k8\",\"comment\":\"\"},{\"type\":\"DATE\",\"name\":\"k10\","
                 + "\"comment\":\"\"},{\"type\":\"DATETIME\",\"name\":\"k11\",\"comment\":\"\"},"
                 + "{\"name\":\"k5\",\"scale\":\"0\",\"comment\":\"\","
-                + "\"type\":\"DECIMAL\",\"precision\":\"9\"},{\"type\":\"CHAR\",\"name\":\"k6\",\"comment\":\"\"}],"
+                + "\"type\":\"DECIMAL\",\"precision\":\"9\",\"aggregation_type\":\"\"},{\"type\":\"CHAR\",\"name\":\"k6\",\"comment\":\"\",\"aggregation_type\":\"REPLACE_IF_NOT_NULL\"}],"
                 + "\"status\":200}";
 
         Schema schema = RestService.parseSchema(schemaStr, logger);

--- a/extension/spark-doris-connector/src/test/scala/org/apache/doris/spark/sql/TestSchemaUtils.scala
+++ b/extension/spark-doris-connector/src/test/scala/org/apache/doris/spark/sql/TestSchemaUtils.scala
@@ -31,8 +31,8 @@ class TestSchemaUtils extends ExpectedExceptionTest {
   def testConvertToStruct(): Unit = {
     val schema = new Schema
     schema.setStatus(200)
-    val k1 = new Field("k1", "TINYINT", "", 0, 0)
-    val k5 = new Field("k5", "BIGINT", "", 0, 0)
+    val k1 = new Field("k1", "TINYINT", "", 0, 0, "")
+    val k5 = new Field("k5", "BIGINT", "", 0, 0, "")
     schema.put(k1)
     schema.put(k5)
 
@@ -84,8 +84,8 @@ class TestSchemaUtils extends ExpectedExceptionTest {
 
     val expected = new Schema
     expected.setStatus(0)
-    val ek1 = new Field("k1", "BOOLEAN", "", 0, 0)
-    val ek2 = new Field("k2", "DOUBLE", "", 0, 0)
+    val ek1 = new Field("k1", "BOOLEAN", "", 0, 0, "")
+    val ek2 = new Field("k2", "DOUBLE", "", 0, 0, "")
     expected.put(ek1)
     expected.put(ek2)
 

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/TableSchemaAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/TableSchemaAction.java
@@ -87,6 +87,8 @@ public class TableSchemaAction extends RestBaseController {
                         baseInfo.put("type", primitiveType.toString());
                         baseInfo.put("comment", column.getComment());
                         baseInfo.put("name", column.getDisplayName());
+                        Optional aggregationType = Optional.ofNullable(column.getAggregationType());
+                        baseInfo.put("aggregation_type", aggregationType.isPresent() ? column.getAggregationType().toSql() : "");
                         propList.add(baseInfo);
                     }
                     resultMap.put("status", 200);


### PR DESCRIPTION
http v2 TableSchemaAction adds the return value of aggregation_type, and modifies the corresponding code of Flink/Spark Connector

# Proposed changes

Issue Number: close #xxx

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (No)
2. Has unit tests been added: (Yes)
3. Has document been added or modified: (No Need)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
