### PR TITLE
[fix](ldap) fix ldap password logic

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/SetLdapPassVar.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/SetLdapPassVar.java
@@ -17,20 +17,19 @@
 
 package org.apache.doris.analysis;
 
-import com.google.common.base.Strings;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.ErrorReport;
-import org.apache.doris.common.util.SymmetricEncryption;
 import org.apache.doris.mysql.privilege.PaloAuth;
 import org.apache.doris.qe.ConnectContext;
 
+import com.google.common.base.Strings;
+
 public class SetLdapPassVar extends SetVar {
-    private String passwd;
+    private final String passwd;
 
     public SetLdapPassVar(String passwd) {
-        //  Encrypted password
-        this.passwd = SymmetricEncryption.encrypt(passwd);
+        this.passwd = passwd;
     }
 
     public String getLdapPassword() {

--- a/fe/fe-core/src/main/java/org/apache/doris/common/FeMetaVersion.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/FeMetaVersion.java
@@ -222,6 +222,8 @@ public final class FeMetaVersion {
     public static final int VERSION_104 = 104;
     // change replica to replica allocation
     public static final int VERSION_105 = 105;
+    // add ldap info
+    public static final int VERSION_106 = 106;
     // note: when increment meta version, should assign the latest version to VERSION_CURRENT
-    public static final int VERSION_CURRENT = VERSION_105;
+    public static final int VERSION_CURRENT = VERSION_106;
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/ldap/LdapClient.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/ldap/LdapClient.java
@@ -45,7 +45,7 @@ import lombok.Data;
 public class LdapClient {
     private static final Logger LOG = LogManager.getLogger(LdapClient.class);
 
-    private static ClientInfo clientInfo;
+    private volatile static ClientInfo clientInfo;
 
     @Data
     private static class ClientInfo {

--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/PaloAuth.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/PaloAuth.java
@@ -42,7 +42,6 @@ import org.apache.doris.common.LdapConfig;
 import org.apache.doris.common.Pair;
 import org.apache.doris.common.UserException;
 import org.apache.doris.common.io.Writable;
-import org.apache.doris.ldap.LdapClient;
 import org.apache.doris.ldap.LdapPrivsChecker;
 import org.apache.doris.load.DppConfig;
 import org.apache.doris.persist.LdapInfo;
@@ -52,13 +51,13 @@ import org.apache.doris.resource.Tag;
 import org.apache.doris.thrift.TFetchResourceResult;
 import org.apache.doris.thrift.TPrivilegeStatus;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.io.DataInput;
 import java.io.DataOutput;
@@ -85,6 +84,8 @@ public class PaloAuth implements Writable {
 
     private RoleManager roleManager = new RoleManager();;
     private UserPropertyMgr propertyMgr = new UserPropertyMgr();
+
+    private LdapInfo ldapInfo = new LdapInfo();
 
     private ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
 
@@ -124,8 +125,16 @@ public class PaloAuth implements Writable {
         return tablePrivTable;
     }
 
+    public LdapInfo getLdapInfo() {
+        return ldapInfo;
+    }
+
+    public void setLdapInfo(LdapInfo ldapInfo) {
+        this.ldapInfo = ldapInfo;
+    }
+
     private GlobalPrivEntry grantGlobalPrivs(UserIdentity userIdentity, boolean errOnExist, boolean errOnNonExist,
-            PrivBitSet privs) throws DdlException {
+                                             PrivBitSet privs) throws DdlException {
         if (errOnExist && errOnNonExist) {
             throw new DdlException("Can only specified errOnExist or errOnNonExist");
         }
@@ -1026,13 +1035,13 @@ public class PaloAuth implements Writable {
 
     // set ldap admin password.
     public void setLdapPassword(SetLdapPassVar stmt) {
-        LdapClient.init(stmt.getLdapPassword());
-        LdapInfo info = new LdapInfo(stmt.getLdapPassword());
-        Catalog.getCurrentCatalog().getEditLog().logSetLdapPassword(info);
+        ldapInfo = new LdapInfo(stmt.getLdapPassword());
+        Catalog.getCurrentCatalog().getEditLog().logSetLdapPassword(ldapInfo);
+        LOG.info("finished to set ldap password.");
     }
 
     public void replaySetLdapPassword(LdapInfo info) {
-        LdapClient.init(info.getLdapPasswd());
+        ldapInfo = info;
         LOG.debug("finish replaying ldap admin password.");
     }
 
@@ -1602,6 +1611,7 @@ public class PaloAuth implements Writable {
         tablePrivTable.write(out);
         resourcePrivTable.write(out);
         propertyMgr.write(out);
+        ldapInfo.write(out);
     }
 
     public void readFields(DataInput in) throws IOException {
@@ -1613,6 +1623,9 @@ public class PaloAuth implements Writable {
             resourcePrivTable = (ResourcePrivTable) PrivTable.read(in);
         }
         propertyMgr = UserPropertyMgr.read(in);
+        if (Catalog.getCurrentCatalogJournalVersion() >= FeMetaVersion.VERSION_106) {
+            ldapInfo = LdapInfo.read(in);
+        }
 
         if (userPrivTable.isEmpty()) {
             // init root and admin user
@@ -1629,6 +1642,7 @@ public class PaloAuth implements Writable {
         sb.append(resourcePrivTable).append("\n");
         sb.append(roleManager).append("\n");
         sb.append(propertyMgr).append("\n");
+        sb.append(ldapInfo).append("\n");
         return sb.toString();
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/LdapInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/LdapInfo.java
@@ -17,10 +17,12 @@
 
 package org.apache.doris.persist;
 
-import com.google.gson.annotations.SerializedName;
 import org.apache.doris.common.io.Text;
 import org.apache.doris.common.io.Writable;
+import org.apache.doris.common.util.SymmetricEncryption;
 import org.apache.doris.persist.gson.GsonUtils;
+
+import com.google.gson.annotations.SerializedName;
 
 import java.io.DataInput;
 import java.io.DataOutput;
@@ -28,14 +30,32 @@ import java.io.IOException;
 
 public class LdapInfo implements Writable {
     @SerializedName(value = "ldapPasswd")
-    private String ldapPasswd;
+    private String ldapPasswdEncrypted;
+
+    @SerializedName(value = "secretKey")
+    private byte[] secretKey;
+
+    @SerializedName(value = "iv")
+    private byte[] iv;
+
+    public LdapInfo() {}
 
     public LdapInfo(String ldapPasswd) {
-        this.ldapPasswd = ldapPasswd;
+        secretKey = SymmetricEncryption.generateKey();
+        iv = SymmetricEncryption.generateIv();
+        ldapPasswdEncrypted = SymmetricEncryption.encrypt(ldapPasswd, secretKey, iv);
     }
 
-    public String getLdapPasswd() {
-        return ldapPasswd;
+    public String getLdapPasswdEncrypted() {
+        return ldapPasswdEncrypted;
+    }
+
+    public byte[] getSecretKey() {
+        return secretKey;
+    }
+
+    public byte[] getIv() {
+        return iv;
     }
 
     @Override

--- a/fe/fe-core/src/test/java/org/apache/doris/common/util/SymmetricEncryptionTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/common/util/SymmetricEncryptionTest.java
@@ -1,0 +1,39 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.common.util;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class SymmetricEncryptionTest {
+
+    @Test
+    public void test() {
+        testEncryptionAndDecryption("123456");
+        testEncryptionAndDecryption("1qaz2wsx[poikl;mnb,78k*&");
+        testEncryptionAndDecryption("张三的密码");
+    }
+
+    private void testEncryptionAndDecryption(String password) {
+        byte[] key = SymmetricEncryption.generateKey();
+        byte[] iv = SymmetricEncryption.generateIv();
+        String passwdEncrypted = SymmetricEncryption.encrypt(password, key, iv);
+        String passwdDecrypted = SymmetricEncryption.decrypt(passwdEncrypted, key, iv);
+        Assert.assertEquals(password, passwdDecrypted);
+    }
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/ldap/LdapClientTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/ldap/LdapClientTest.java
@@ -17,12 +17,13 @@
 
 package org.apache.doris.ldap;
 
-import com.clearspring.analytics.util.Lists;
-import mockit.Delegate;
-import mockit.Expectations;
-import mockit.Mocked;
+import org.apache.doris.catalog.Catalog;
 import org.apache.doris.common.LdapConfig;
-import org.apache.doris.common.util.SymmetricEncryption;
+import org.apache.doris.mysql.privilege.PaloAuth;
+import org.apache.doris.persist.LdapInfo;
+
+import com.clearspring.analytics.util.Lists;
+
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -32,14 +33,42 @@ import org.springframework.ldap.query.LdapQuery;
 
 import java.util.List;
 
+import mockit.Delegate;
+import mockit.Expectations;
+import mockit.Mocked;
+
 public class LdapClientTest {
     private static final String ADMIN_PASSWORD = "admin";
 
     @Mocked
     private LdapTemplate ldapTemplate;
 
+    @Mocked
+    private Catalog catalog;
+
+    @Mocked
+    private PaloAuth auth;
+
+    private LdapInfo ldapInfo = new LdapInfo(ADMIN_PASSWORD);
+
     @Before
     public void setUp() {
+        new Expectations() {
+            {
+                Catalog.getCurrentCatalog();
+                minTimes = 0;
+                result = catalog;
+
+                catalog.getAuth();
+                minTimes = 0;
+                result = auth;
+
+                auth.getLdapInfo();
+                minTimes = 0;
+                result = ldapInfo;
+            }
+        };
+
         LdapConfig.ldap_authentication_enabled = true;
         LdapConfig.ldap_host = "127.0.0.1";
         LdapConfig.ldap_port = 389;
@@ -47,7 +76,6 @@ public class LdapClientTest {
         LdapConfig.ldap_user_basedn = "dc=baidu,dc=com";
         LdapConfig.ldap_group_basedn = "ou=group,dc=baidu,dc=com";
         LdapConfig.ldap_user_filter = "(&(uid={login}))";
-        LdapClient.init(SymmetricEncryption.encrypt(ADMIN_PASSWORD));
     }
     
     private void mockLdapTemplateSearch(List list) {

--- a/fe/fe-core/src/test/java/org/apache/doris/persist/LdapInfoTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/persist/LdapInfoTest.java
@@ -17,6 +17,8 @@
 
 package org.apache.doris.persist;
 
+import org.apache.doris.common.util.SymmetricEncryption;
+
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -31,7 +33,9 @@ public class LdapInfoTest {
 
     @Test
     public void test() throws IOException {
-        LdapInfo ldapInfo = new LdapInfo("123456");
+        String passwd = "123456";
+
+        LdapInfo ldapInfo = new LdapInfo(passwd);
 
         // 1. Write objects to file
         File file = new File("./ldapInfo");
@@ -43,7 +47,10 @@ public class LdapInfoTest {
 
         // 2. Read objects from file
         DataInputStream dis = new DataInputStream(new FileInputStream(file));
-        Assert.assertEquals("123456", LdapInfo.read(dis).getLdapPasswd());
+        LdapInfo ldapInfo2 = LdapInfo.read(dis);
+        Assert.assertEquals(passwd,
+                SymmetricEncryption.decrypt(ldapInfo2.getLdapPasswdEncrypted(),
+                        ldapInfo2.getSecretKey(), ldapInfo2.getIv()));
 
         // 3. delete files
         dis.close();


### PR DESCRIPTION
1. write ldap info to image;
2. optimizing LdapClient class thread safety.

# Proposed changes

Issue Number: close #xxx

## Problem Summary:

1. Write LdapInfo to image to avoid losing ldap admin password.
2. Add a lock when modifying LdapClient to make it thread-safe.

## Checklist(Required)

1. Does it affect the original behavior: (Yes)
2. Has unit tests been added: (Yes)
3. Has document been added or modified: (No Need)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
