### PR TITLE
[build][scripts] add set -e to download_thirdparty.sh

### DIFF
--- a/thirdparty/download-thirdparty.sh
+++ b/thirdparty/download-thirdparty.sh
@@ -16,7 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-#set -e
+set -e
 ################################################################
 # This script will download all thirdparties and java libraries
 # which are defined in *vars.sh*, unpack patch them if necessary.


### PR DESCRIPTION
Let the build process stop immediately if some command execute faild. For example, patch failed due to command not found, otherwise it will stop until compile error.