### PR TITLE
[Improvement] (fe-unit-test) Pass conf map to create Doris cluster.

### DIFF
--- a/fe/fe-core/src/test/java/org/apache/doris/utframe/UtFrameUtilsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/utframe/UtFrameUtilsTest.java
@@ -1,0 +1,26 @@
+package org.apache.doris.utframe;
+
+import org.apache.doris.common.Config;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class UtFrameUtilsTest {
+
+    @Test
+    public void testCreateDorisCluster() throws Exception {
+        String runningDir = UtFrameUtils.generateRandomFeRunningDir(UtFrameUtilsTest.class);
+        assertTrue(runningDir.startsWith("fe/mocked/UtFrameUtilsTest/"));
+        Map<String, String> feConfMap = new HashMap<>();
+        feConfMap.put("cluster_name", "Doris Test");
+        feConfMap.put("enable_complex_type_support", "true");
+        UtFrameUtils.createDorisCluster(runningDir, feConfMap);
+        assertEquals("Doris Test", Config.cluster_name);
+        assertTrue(Config.enable_complex_type_support);
+        UtFrameUtils.cleanDorisFeDir(runningDir);
+    }
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/utframe/UtFrameUtilsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/utframe/UtFrameUtilsTest.java
@@ -18,26 +18,24 @@
 package org.apache.doris.utframe;
 
 import org.apache.doris.common.Config;
+import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.HashMap;
 import java.util.Map;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 public class UtFrameUtilsTest {
 
     @Test
     public void testCreateDorisCluster() throws Exception {
         String runningDir = UtFrameUtils.generateRandomFeRunningDir(UtFrameUtilsTest.class);
-        assertTrue(runningDir.startsWith("fe/mocked/UtFrameUtilsTest/"));
+        Assert.assertTrue(runningDir.startsWith("fe/mocked/UtFrameUtilsTest/"));
         Map<String, String> feConfMap = new HashMap<>();
         feConfMap.put("cluster_name", "Doris Test");
         feConfMap.put("enable_complex_type_support", "true");
         UtFrameUtils.createDorisCluster(runningDir, feConfMap);
-        assertEquals("Doris Test", Config.cluster_name);
-        assertTrue(Config.enable_complex_type_support);
+        Assert.assertEquals("Doris Test", Config.cluster_name);
+        Assert.assertTrue(Config.enable_complex_type_support);
         UtFrameUtils.cleanDorisFeDir(runningDir);
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/utframe/UtFrameUtilsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/utframe/UtFrameUtilsTest.java
@@ -1,3 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package org.apache.doris.utframe;
 
 import org.apache.doris.common.Config;


### PR DESCRIPTION
# Proposed changes

Issue Number: close #7873 

## Problem Summary:

Passing conf map to create Doris cluster which can change some fe configuration while running fe unit tests.

## Checklist(Required)

1. Does it affect the original behavior: No.
2. Has unit tests been added: Yes.
3. Has document been added or modified: No Need.
4. Does it need to update dependencies: No.
5. Are there any changes that cannot be rolled back: No.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
