### PR TITLE
[improvement](meta) Use meta_version constant to replace magic number when check catalog journal version

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/alter/AlterJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/AlterJob.java
@@ -306,7 +306,7 @@ public abstract class AlterJob implements Writable {
     public synchronized void readFields(DataInput in) throws IOException {
         // read common members as write in AlterJob.write().
         // except 'type' member, which is read in AlterJob.read()
-        if (Catalog.getCurrentCatalogJournalVersion() >= 4) {
+        if (Catalog.getCurrentCatalogJournalVersion() >= FeMetaVersion.VERSION_4) {
             state = JobState.valueOf(Text.readString(in));
         }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/MetaObject.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/MetaObject.java
@@ -61,7 +61,7 @@ public class MetaObject implements Writable {
             this.signature = in.readLong();
         }
 
-        if (Catalog.getCurrentCatalogJournalVersion() >= 6) {
+        if (Catalog.getCurrentCatalogJournalVersion() >= FeMetaVersion.VERSION_6) {
             this.lastCheckTime = in.readLong();
         }
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Tablet.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Tablet.java
@@ -21,6 +21,7 @@ import org.apache.doris.catalog.Replica.ReplicaState;
 import org.apache.doris.clone.TabletSchedCtx;
 import org.apache.doris.clone.TabletSchedCtx.Priority;
 import org.apache.doris.common.Config;
+import org.apache.doris.common.FeMetaVersion;
 import org.apache.doris.common.Pair;
 import org.apache.doris.common.io.Writable;
 import org.apache.doris.resource.Tag;
@@ -341,7 +342,7 @@ public class Tablet extends MetaObject implements Writable {
             }
         }
 
-        if (Catalog.getCurrentCatalogJournalVersion() >= 6) {
+        if (Catalog.getCurrentCatalogJournalVersion() >= FeMetaVersion.VERSION_6) {
             checkedVersion = in.readLong();
             checkedVersionHash = in.readLong();
             isConsistent = in.readBoolean();

--- a/fe/fe-core/src/main/java/org/apache/doris/common/FeMetaVersion.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/FeMetaVersion.java
@@ -18,6 +18,20 @@
 package org.apache.doris.common;
 
 public final class FeMetaVersion {
+
+    public static final int VERSION_1 = 1;
+
+    public static final int VERSION_2 = 2;
+
+    public static final int VERSION_3 = 3;
+
+    public static final int VERSION_4 = 4;
+
+    public static final int VERSION_5 = 5;
+
+    public static final int VERSION_6 = 6;
+
+    public static final int VERSION_7 = 7;
     // jira 1902
     public static final int VERSION_8 = 8;
     // jira 529

--- a/fe/fe-core/src/main/java/org/apache/doris/load/HadoopEtlJobInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/HadoopEtlJobInfo.java
@@ -19,6 +19,7 @@ package org.apache.doris.load;
 
 import org.apache.doris.catalog.Catalog;
 import org.apache.doris.common.Config;
+import org.apache.doris.common.FeMetaVersion;
 import org.apache.doris.common.io.Text;
 
 import java.io.DataInput;
@@ -93,7 +94,7 @@ public class HadoopEtlJobInfo extends EtlJobInfo {
         etlJobId = Text.readString(in);
         etlOutputDir = Text.readString(in);
 
-        if (Catalog.getCurrentCatalogJournalVersion() >= 7) {
+        if (Catalog.getCurrentCatalogJournalVersion() >= FeMetaVersion.VERSION_7) {
             if (in.readBoolean()) {
                 dppConfig = new DppConfig();
                 dppConfig.readFields(in);

--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/UserProperty.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/UserProperty.java
@@ -543,7 +543,7 @@ public class UserProperty implements Writable {
             // boolean isAdmin
             in.readBoolean();
 
-            if (Catalog.getCurrentCatalogJournalVersion() >= 1) {
+            if (Catalog.getCurrentCatalogJournalVersion() >= FeMetaVersion.VERSION_1) {
                 // boolean isSuperuser
                 in.readBoolean();
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/system/Backend.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/system/Backend.java
@@ -563,13 +563,13 @@ public class Backend implements Writable {
         }
         isAlive.set(in.readBoolean());
 
-        if (Catalog.getCurrentCatalogJournalVersion() >= 5) {
+        if (Catalog.getCurrentCatalogJournalVersion() >= FeMetaVersion.VERSION_5) {
             isDecommissioned.set(in.readBoolean());
         }
 
         lastUpdateMs = in.readLong();
 
-        if (Catalog.getCurrentCatalogJournalVersion() >= 2) {
+        if (Catalog.getCurrentCatalogJournalVersion() >= FeMetaVersion.VERSION_2) {
             lastStartTime = in.readLong();
 
             Map<String, DiskInfo> disks = Maps.newHashMap();


### PR DESCRIPTION
# Proposed changes

Issue Number: close #7877

## Problem Summary:

Add multiple FeMetaVersion constants and make simple numbers point to them.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
