### PR TITLE
[improvement] (storage) Dict decoder optimization

### DIFF
--- a/be/src/olap/rowset/segment_v2/binary_dict_page.h
+++ b/be/src/olap/rowset/segment_v2/binary_dict_page.h
@@ -99,6 +99,14 @@ private:
 
 class BinaryDictPageDecoder : public PageDecoder {
 public:
+    struct WordInfo {
+        uint64_t dummy;
+        struct {
+            uint32_t start_offset;
+            uint32_t len;
+        };
+    };
+
     BinaryDictPageDecoder(Slice data, const PageDecoderOptions& options);
 
     Status init() override;
@@ -115,7 +123,7 @@ public:
 
     bool is_dict_encoding() const;
 
-    void set_dict_decoder(PageDecoder* dict_decoder, uint32_t* start_offset_array = nullptr, uint32_t* len_array = nullptr);
+    void set_dict_decoder(PageDecoder* dict_decoder, WordInfo* _dict_word_info = nullptr);
 
     ~BinaryDictPageDecoder();
 
@@ -129,9 +137,7 @@ private:
     EncodingTypePB _encoding_type;
     // use as data buf.
     std::unique_ptr<ColumnVectorBatch> _batch;
-
-    uint32_t* _start_offset_array = nullptr;
-    uint32_t* _len_array = nullptr;
+    WordInfo* _dict_word_info = nullptr;
 };
 
 } // namespace segment_v2

--- a/be/src/olap/rowset/segment_v2/binary_dict_page.h
+++ b/be/src/olap/rowset/segment_v2/binary_dict_page.h
@@ -99,14 +99,6 @@ private:
 
 class BinaryDictPageDecoder : public PageDecoder {
 public:
-    struct WordInfo {
-        uint64_t dummy;
-        struct {
-            uint32_t start_offset;
-            uint32_t len;
-        };
-    };
-
     BinaryDictPageDecoder(Slice data, const PageDecoderOptions& options);
 
     Status init() override;
@@ -123,9 +115,7 @@ public:
 
     bool is_dict_encoding() const;
 
-    void set_dict_decoder(PageDecoder* dict_decoder, WordInfo* _dict_word_info = nullptr);
-
-    ~BinaryDictPageDecoder();
+    void set_dict_decoder(PageDecoder* dict_decoder, StringValue* dict_word_info = nullptr);
 
 private:
     Slice _data;
@@ -137,7 +127,7 @@ private:
     EncodingTypePB _encoding_type;
     // use as data buf.
     std::unique_ptr<ColumnVectorBatch> _batch;
-    WordInfo* _dict_word_info = nullptr;
+    StringValue* _dict_word_info = nullptr;
 };
 
 } // namespace segment_v2

--- a/be/src/olap/rowset/segment_v2/binary_plain_page.h
+++ b/be/src/olap/rowset/segment_v2/binary_plain_page.h
@@ -313,8 +313,7 @@ public:
             dict_word_info[i].len = (char*)dict_word_info[i+1].ptr - (char*)dict_word_info[i].ptr;
         }
 
-        uint32_t offset = decode_fixed32_le((uint8_t*)offset_ptr);
-        dict_word_info[_num_elems-1].len = (data_begin + offset) - (char*)dict_word_info[_num_elems-1].ptr;
+        dict_word_info[_num_elems-1].len = (data_begin + _offsets_pos) - (char*)dict_word_info[_num_elems-1].ptr;
     }
 
 private:

--- a/be/src/olap/rowset/segment_v2/binary_plain_page.h
+++ b/be/src/olap/rowset/segment_v2/binary_plain_page.h
@@ -300,6 +300,22 @@ public:
         return Slice(&_data[start_offset], len);
     }
 
+    void get_dict_word_info(StringValue* dict_word_info) {
+        char* data_begin = (char*)&_data[0];
+        char* offset_ptr = (char*)&_data[_offsets_pos];
+
+        for (uint32_t i = 0; i < _num_elems; ++i) {
+            uint32_t offset = decode_fixed32_le((uint8_t*)offset_ptr);
+            dict_word_info[i].ptr = data_begin + offset;
+            offset_ptr += sizeof(uint32_t);
+        }
+
+        for (int i = 0; i < (int)_num_elems - 1; ++i) {
+            dict_word_info[i].len = dict_word_info[i+1].ptr - dict_word_info[i].ptr;
+        }
+        dict_word_info[_num_elems-1].len = dict_word_info[_num_elems].ptr - dict_word_info[_num_elems-1].ptr;
+    }
+
 private:
     // Return the offset within '_data' where the string value with index 'idx' can be found.
     uint32_t offset(size_t idx) const {

--- a/be/src/olap/rowset/segment_v2/binary_plain_page.h
+++ b/be/src/olap/rowset/segment_v2/binary_plain_page.h
@@ -305,15 +305,16 @@ public:
         char* offset_ptr = (char*)&_data[_offsets_pos];
 
         for (uint32_t i = 0; i < _num_elems; ++i) {
-            uint32_t offset = decode_fixed32_le((uint8_t*)offset_ptr);
-            dict_word_info[i].ptr = data_begin + offset;
+            dict_word_info[i].ptr = data_begin + decode_fixed32_le((uint8_t*)offset_ptr);
             offset_ptr += sizeof(uint32_t);
         }
 
         for (int i = 0; i < (int)_num_elems - 1; ++i) {
-            dict_word_info[i].len = dict_word_info[i+1].ptr - dict_word_info[i].ptr;
+            dict_word_info[i].len = (char*)dict_word_info[i+1].ptr - (char*)dict_word_info[i].ptr;
         }
-        dict_word_info[_num_elems-1].len = dict_word_info[_num_elems].ptr - dict_word_info[_num_elems-1].ptr;
+
+        uint32_t offset = decode_fixed32_le((uint8_t*)offset_ptr);
+        dict_word_info[_num_elems-1].len = (data_begin + offset) - (char*)dict_word_info[_num_elems-1].ptr;
     }
 
 private:

--- a/be/src/olap/rowset/segment_v2/column_reader.cpp
+++ b/be/src/olap/rowset/segment_v2/column_reader.cpp
@@ -459,9 +459,7 @@ FileColumnIterator::FileColumnIterator(ColumnReader* reader) : _reader(reader) {
 
 FileColumnIterator::~FileColumnIterator() {
     _opts.mem_tracker->Release(_opts.mem_tracker->consumption());
-
-    delete[] _dict_start_offset_array;
-    delete[] _dict_len_array;
+    delete[] _dict_word_info;
 }
 
 Status FileColumnIterator::seek_to_first() {
@@ -680,18 +678,17 @@ Status FileColumnIterator::_read_data_page(const OrdinalPageIndexIterator& iter)
             }
 
             BinaryPlainPageDecoder* pd_decoder = (BinaryPlainPageDecoder*)_dict_decoder.get();
-            _dict_start_offset_array = new uint32_t[pd_decoder->_num_elems];
-            _dict_len_array = new uint32_t[pd_decoder->_num_elems];
+            _dict_word_info = new BinaryDictPageDecoder::WordInfo[pd_decoder->_num_elems];
 
             // todo(wb) padding dict value for SIMD comparison
             for (int i = 0; i < pd_decoder->_num_elems; i++) {
                 const uint32_t start_offset = pd_decoder->offset(i);
                 uint32_t len = pd_decoder->offset(i + 1) - start_offset;
-                _dict_start_offset_array[i] = start_offset;
-                _dict_len_array[i] = len;
+                _dict_word_info[i].start_offset = start_offset;
+                _dict_word_info[i].len = len;
             }
 
-            dict_page_decoder->set_dict_decoder(_dict_decoder.get(), _dict_start_offset_array, _dict_len_array);
+            dict_page_decoder->set_dict_decoder(_dict_decoder.get(), _dict_word_info);
         }
     }
     return Status::OK();

--- a/be/src/olap/rowset/segment_v2/column_reader.cpp
+++ b/be/src/olap/rowset/segment_v2/column_reader.cpp
@@ -678,16 +678,8 @@ Status FileColumnIterator::_read_data_page(const OrdinalPageIndexIterator& iter)
             }
 
             BinaryPlainPageDecoder* pd_decoder = (BinaryPlainPageDecoder*)_dict_decoder.get();
-            _dict_word_info = new BinaryDictPageDecoder::WordInfo[pd_decoder->_num_elems];
-
-            // todo(wb) padding dict value for SIMD comparison
-            for (int i = 0; i < pd_decoder->_num_elems; i++) {
-                const uint32_t start_offset = pd_decoder->offset(i);
-                uint32_t len = pd_decoder->offset(i + 1) - start_offset;
-                _dict_word_info[i].start_offset = start_offset;
-                _dict_word_info[i].len = len;
-            }
-
+            _dict_word_info = new StringValue[pd_decoder->_num_elems];
+            pd_decoder->get_dict_word_info(_dict_word_info);
             dict_page_decoder->set_dict_decoder(_dict_decoder.get(), _dict_word_info);
         }
     }

--- a/be/src/olap/rowset/segment_v2/column_reader.h
+++ b/be/src/olap/rowset/segment_v2/column_reader.h
@@ -26,6 +26,7 @@
 #include "gen_cpp/segment_v2.pb.h"                      // for ColumnMetaPB
 #include "olap/olap_cond.h"                             // for CondColumn
 #include "olap/rowset/segment_v2/bitmap_index_reader.h" // for BitmapIndexReader
+#include "olap/rowset/segment_v2/binary_dict_page.h"    // for BinaryDictPageDecoder::WordInfo
 #include "olap/rowset/segment_v2/common.h"
 #include "olap/rowset/segment_v2/ordinal_page_index.h" // for OrdinalPageIndexIterator
 #include "olap/rowset/segment_v2/page_handle.h"        // for PageHandle
@@ -169,10 +170,12 @@ private:
     uint64_t _num_rows;
     FilePathDesc _path_desc;
 
-    const TypeInfo* _type_info = nullptr; // initialized in init(), may changed by subclasses.
-    const EncodingInfo* _encoding_info =
-            nullptr; // initialized in init(), used for create PageDecoder
-    const BlockCompressionCodec* _compress_codec = nullptr; // initialized in init()
+    // initialized in init(), may changed by subclasses.
+    const TypeInfo* _type_info = nullptr; 
+    // initialized in init(), used for create PageDecoder
+    const EncodingInfo* _encoding_info = nullptr; 
+    // initialized in init()
+    const BlockCompressionCodec* _compress_codec = nullptr; 
 
     // meta for various column indexes (null if the index is absent)
     const ZoneMapIndexPB* _zone_map_index_meta = nullptr;
@@ -320,8 +323,7 @@ private:
     // current value ordinal
     ordinal_t _current_ordinal = 0;
 
-    uint32_t* _dict_start_offset_array = nullptr;
-    uint32_t* _dict_len_array = nullptr;
+    BinaryDictPageDecoder::WordInfo* _dict_word_info = nullptr; 
 };
 
 class ArrayFileColumnIterator final : public ColumnIterator {

--- a/be/src/olap/rowset/segment_v2/column_reader.h
+++ b/be/src/olap/rowset/segment_v2/column_reader.h
@@ -323,7 +323,7 @@ private:
     // current value ordinal
     ordinal_t _current_ordinal = 0;
 
-    BinaryDictPageDecoder::WordInfo* _dict_word_info = nullptr; 
+    StringValue* _dict_word_info = nullptr; 
 };
 
 class ArrayFileColumnIterator final : public ColumnIterator {

--- a/be/test/olap/rowset/segment_v2/binary_dict_page_test.cpp
+++ b/be/test/olap/rowset/segment_v2/binary_dict_page_test.cpp
@@ -73,20 +73,19 @@ public:
         // because every slice is unique
         ASSERT_EQ(slices.size(), dict_page_decoder->count());
 
-        uint32_t dict_start_offset_array[dict_page_decoder->_num_elems];
-        uint32_t dict_len_array[dict_page_decoder->_num_elems];
+        BinaryDictPageDecoder::WordInfo* dict_word_info[dict_page_decoder->_num_elems];
         for (int i = 0; i < dict_page_decoder->_num_elems; i++) {
             const uint32_t start_offset = dict_page_decoder->offset(i);
             uint32_t len = dict_page_decoder->offset(i + 1) - start_offset;
-            dict_start_offset_array[i] = start_offset;
-            dict_len_array[i] = len;
+            dict_word_info[i].start_offset = start_offset;
+            dict_word_info[i].len = len;
         }
 
         // decode
         PageDecoderOptions decoder_options;
         BinaryDictPageDecoder page_decoder(s.slice(), decoder_options);
 
-        page_decoder.set_dict_decoder(dict_page_decoder.get(), dict_start_offset_array, dict_len_array);
+        page_decoder.set_dict_decoder(dict_page_decoder.get(), dict_word_info);
 
         status = page_decoder.init();
         ASSERT_TRUE(status.ok());
@@ -177,13 +176,12 @@ public:
             status = dict_page_decoder->init();
             ASSERT_TRUE(status.ok());
 
-            uint32_t dict_start_offset_array[dict_page_decoder->_num_elems];
-            uint32_t dict_len_array[dict_page_decoder->_num_elems];
+            BinaryDictPageDecoder::WordInfo dict_word_info[dict_page_decoder->_num_elems];
             for (int i = 0; i < dict_page_decoder->_num_elems; i++) {
                 const uint32_t start_offset = dict_page_decoder->offset(i);
                 uint32_t len = dict_page_decoder->offset(i + 1) - start_offset;
-                dict_start_offset_array[i] = start_offset;
-                dict_len_array[i] = len;
+                dict_word_info[i].start_offset = start_offset;
+                dict_word_info[i].len = len;
             }
 
             // decode
@@ -191,7 +189,7 @@ public:
             BinaryDictPageDecoder page_decoder(results[slice_index].slice(), decoder_options);
             status = page_decoder.init();
 
-            page_decoder.set_dict_decoder(dict_page_decoder.get(), dict_start_offset_array, dict_len_array);
+            page_decoder.set_dict_decoder(dict_page_decoder.get(), dict_word_info);
             ASSERT_TRUE(status.ok());
 
             //check values

--- a/be/test/olap/rowset/segment_v2/binary_dict_page_test.cpp
+++ b/be/test/olap/rowset/segment_v2/binary_dict_page_test.cpp
@@ -73,13 +73,8 @@ public:
         // because every slice is unique
         ASSERT_EQ(slices.size(), dict_page_decoder->count());
 
-        BinaryDictPageDecoder::WordInfo* dict_word_info[dict_page_decoder->_num_elems];
-        for (int i = 0; i < dict_page_decoder->_num_elems; i++) {
-            const uint32_t start_offset = dict_page_decoder->offset(i);
-            uint32_t len = dict_page_decoder->offset(i + 1) - start_offset;
-            dict_word_info[i].start_offset = start_offset;
-            dict_word_info[i].len = len;
-        }
+        StringValue dict_word_info[dict_page_decoder->_num_elems];
+        dict_page_decoder->get_dict_word_info(dict_word_info);
 
         // decode
         PageDecoderOptions decoder_options;
@@ -176,13 +171,8 @@ public:
             status = dict_page_decoder->init();
             ASSERT_TRUE(status.ok());
 
-            BinaryDictPageDecoder::WordInfo dict_word_info[dict_page_decoder->_num_elems];
-            for (int i = 0; i < dict_page_decoder->_num_elems; i++) {
-                const uint32_t start_offset = dict_page_decoder->offset(i);
-                uint32_t len = dict_page_decoder->offset(i + 1) - start_offset;
-                dict_word_info[i].start_offset = start_offset;
-                dict_word_info[i].len = len;
-            }
+            StringValue dict_word_info[dict_page_decoder->_num_elems];
+            dict_page_decoder->get_dict_word_info(dict_word_info);
 
             // decode
             PageDecoderOptions decoder_options;

--- a/be/test/tools/benchmark_tool.cpp
+++ b/be/test/tools/benchmark_tool.cpp
@@ -173,22 +173,15 @@ public:
                     new BinaryPlainPageDecoder(dict_slice.slice(), dict_decoder_options));
             dict_page_decoder->init();
 
-            uint32_t dict_start_offset_array[dict_page_decoder->_num_elems];
-            uint32_t dict_len_array[dict_page_decoder->_num_elems];
-            for (int i = 0; i < dict_page_decoder->_num_elems; i++) {
-                const uint32_t start_offset = dict_page_decoder->offset(i);
-                uint32_t len = dict_page_decoder->offset(i + 1) - start_offset;
-                dict_start_offset_array[i] = start_offset;
-                dict_len_array[i] = len;
-            }
+            StringValue dict_word_info[dict_page_decoder->_num_elems];
+            dict_page_decoder->get_dict_word_info(dict_word_info);
 
             // decode
             PageDecoderOptions decoder_options;
             BinaryDictPageDecoder page_decoder(src.slice(), decoder_options);
             page_decoder.init();
 
-            page_decoder.set_dict_decoder(dict_page_decoder.get(), dict_start_offset_array,
-                                          dict_len_array);
+            page_decoder.set_dict_decoder(dict_page_decoder.get(), dict_word_info);
 
             //check values
             size_t num = page_start_ids[slice_index + 1] - page_start_ids[slice_index];


### PR DESCRIPTION
# Proposed changes
1. using StringValue _dict_word_info[] replace _start_offset_array + _len_array, two separate uint32_t array are not cache-friendly
2. to store String-pointer + String-len together is better, before changing,  reading String word must use the expression '_data + offset', after changing, we visit String word by _dict_word_info[subscript] directly
3. designing a new interface get_dict_word_info() to build _dict_word_info, one loop for String-ptr, another loop for calculating String-len, simper loop is good for SIMD, this benifit is wait for proving
4. multi-table ssb test result for SQL 2.1:
- before: 9 seconds
- after: 8.87 seconds

Issue Number: close #xxx

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
