### PR TITLE
[Vectorized][Join] Mem reuse to speed up join operator

### DIFF
--- a/be/src/vec/columns/column.h
+++ b/be/src/vec/columns/column.h
@@ -263,6 +263,10 @@ public:
     using Offsets = PaddedPODArray<Offset>;
     virtual Ptr replicate(const Offsets& offsets) const = 0;
 
+    virtual void replicate(const uint32_t* counts, size_t target_size, IColumn& column) const {
+        LOG(FATAL) << "not support";
+    };
+
     /** Split column to smaller columns. Each value goes to column index, selected by corresponding element of 'selector'.
       * Selector must contain values from 0 to num_columns - 1.
       * For default implementation, see scatter_impl.

--- a/be/src/vec/columns/column_complex.h
+++ b/be/src/vec/columns/column_complex.h
@@ -186,6 +186,8 @@ public:
 
     ColumnPtr replicate(const IColumn::Offsets& replicate_offsets) const override;
 
+    void replicate(const uint32_t* counts, size_t target_size, IColumn& column) const override;
+
     [[noreturn]] MutableColumns scatter(IColumn::ColumnIndex num_columns,
                                         const IColumn::Selector& selector) const override {
         LOG(FATAL) << "scatter not implemented";
@@ -285,6 +287,25 @@ ColumnPtr ColumnComplexType<T>::replicate(const IColumn::Offsets& offsets) const
         size_t size_to_replicate = offsets[i] - prev_offset;
         prev_offset = offsets[i];
 
+        for (size_t j = 0; j < size_to_replicate; ++j) {
+            res_data.push_back(data[i]);
+        }
+    }
+
+    return res;
+}
+
+template <typename T>
+void ColumnComplexType<T>::replicate(const uint32_t* counts, size_t target_size, IColumn& column) const {
+    size_t size = data.size();
+    if (0 == size) return;
+
+    auto& res = reinterpret_cast<ColumnComplexType<T>&>(column);
+    typename Self::Container& res_data = res.get_data();
+    res_data.reserve(target_size);
+
+    for (size_t i = 0; i < size; ++i) {
+        size_t size_to_replicate = counts[i];
         for (size_t j = 0; j < size_to_replicate; ++j) {
             res_data.push_back(data[i]);
         }

--- a/be/src/vec/columns/column_const.cpp
+++ b/be/src/vec/columns/column_const.cpp
@@ -65,6 +65,12 @@ ColumnPtr ColumnConst::replicate(const Offsets& offsets) const {
     return ColumnConst::create(data, replicated_size);
 }
 
+void ColumnConst::replicate(const uint32_t* counts, size_t target_size, IColumn& column) const {
+    if (s == 0) return;
+    auto& res = reinterpret_cast<ColumnConst&>(column);
+    res.s = s;
+}
+
 ColumnPtr ColumnConst::permute(const Permutation& perm, size_t limit) const {
     if (limit == 0) {
         limit = s;

--- a/be/src/vec/columns/column_const.h
+++ b/be/src/vec/columns/column_const.h
@@ -117,6 +117,7 @@ public:
 
     ColumnPtr filter(const Filter& filt, ssize_t result_size_hint) const override;
     ColumnPtr replicate(const Offsets& offsets) const override;
+    void replicate(const uint32_t* counts, size_t target_size, IColumn& column) const override;
     ColumnPtr permute(const Permutation& perm, size_t limit) const override;
     // ColumnPtr index(const IColumn & indexes, size_t limit) const override;
     void get_permutation(bool reverse, size_t limit, int nan_direction_hint,

--- a/be/src/vec/columns/column_decimal.cpp
+++ b/be/src/vec/columns/column_decimal.cpp
@@ -222,6 +222,20 @@ ColumnPtr ColumnDecimal<T>::replicate(const IColumn::Offsets& offsets) const {
 }
 
 template <typename T>
+void ColumnDecimal<T>::replicate(const uint32_t* counts, size_t target_size, IColumn& column) const {
+    size_t size = data.size();
+    if (0 == size) return;
+
+    auto& res = reinterpret_cast<ColumnDecimal<T>&>(column);
+    typename Self::Container& res_data = res.get_data();
+    res_data.reserve(target_size);
+
+    for (size_t i = 0; i < size; ++i) {
+        res_data.add_num_element_without_reserve(data[i], counts[i]);
+    }
+}
+
+template <typename T>
 void ColumnDecimal<T>::get_extremes(Field& min, Field& max) const {
     if (data.size() == 0) {
         min = NearestFieldType<T>(0, scale);

--- a/be/src/vec/columns/column_decimal.h
+++ b/be/src/vec/columns/column_decimal.h
@@ -147,6 +147,9 @@ public:
     ColumnPtr index_impl(const PaddedPODArray<Type>& indexes, size_t limit) const;
 
     ColumnPtr replicate(const IColumn::Offsets& offsets) const override;
+
+    void replicate(const uint32_t* counts, size_t target_size, IColumn& column) const override;
+
     void get_extremes(Field& min, Field& max) const override;
 
     MutableColumns scatter(IColumn::ColumnIndex num_columns,

--- a/be/src/vec/columns/column_nullable.cpp
+++ b/be/src/vec/columns/column_nullable.cpp
@@ -407,6 +407,12 @@ ColumnPtr ColumnNullable::replicate(const Offsets& offsets) const {
     return ColumnNullable::create(replicated_data, replicated_null_map);
 }
 
+void ColumnNullable::replicate(const uint32_t* counts, size_t target_size, IColumn& column) const {
+    auto& res = reinterpret_cast<ColumnNullable&>(column);
+    get_nested_column().replicate(counts, target_size, res.get_nested_column());
+    get_null_map_column().replicate(counts, target_size, res.get_null_map_column());
+}
+
 template <bool negative>
 void ColumnNullable::apply_null_map_impl(const ColumnUInt8& map) {
     NullMap& arr1 = get_null_map_data();

--- a/be/src/vec/columns/column_nullable.h
+++ b/be/src/vec/columns/column_nullable.h
@@ -111,6 +111,7 @@ public:
     size_t allocated_bytes() const override;
     void protect() override;
     ColumnPtr replicate(const Offsets& replicate_offsets) const override;
+    void replicate(const uint32_t* counts, size_t target_size, IColumn& column) const override;
     void update_hash_with_value(size_t n, SipHash& hash) const override;
     void get_extremes(Field& min, Field& max) const override;
 

--- a/be/src/vec/columns/column_string.cpp
+++ b/be/src/vec/columns/column_string.cpp
@@ -290,6 +290,37 @@ ColumnPtr ColumnString::replicate(const Offsets& replicate_offsets) const {
     return res;
 }
 
+void ColumnString::replicate(const uint32_t* counts, size_t target_size, IColumn& column) const {
+    size_t col_size = size();
+    if (0 == col_size) return;
+
+    auto& res = reinterpret_cast<ColumnString&>(column);
+
+    Chars& res_chars = res.chars;
+    Offsets& res_offsets = res.offsets;
+    res_chars.reserve(chars.size() / col_size * target_size);
+    res_offsets.reserve(target_size);
+
+    Offset prev_string_offset = 0;
+    Offset current_new_offset = 0;
+
+    for (size_t i = 0; i < col_size; ++i) {
+        size_t size_to_replicate = counts[i];
+        size_t string_size = offsets[i] - prev_string_offset;
+
+        for (size_t j = 0; j < size_to_replicate; ++j) {
+            current_new_offset += string_size;
+            res_offsets.push_back(current_new_offset);
+
+            res_chars.resize(res_chars.size() + string_size);
+            memcpy_small_allow_read_write_overflow15(&res_chars[res_chars.size() - string_size],
+                                                     &chars[prev_string_offset], string_size);
+        }
+
+        prev_string_offset = offsets[i];
+    }
+}
+
 void ColumnString::reserve(size_t n) {
     offsets.reserve(n);
 }

--- a/be/src/vec/columns/column_string.h
+++ b/be/src/vec/columns/column_string.h
@@ -224,6 +224,8 @@ public:
 
     ColumnPtr replicate(const Offsets& replicate_offsets) const override;
 
+    void replicate(const uint32_t* counts, size_t target_size, IColumn& column) const override;
+
     MutableColumns scatter(ColumnIndex num_columns, const Selector& selector) const override {
         return scatter_impl<ColumnString>(num_columns, selector);
     }

--- a/be/src/vec/columns/column_vector.cpp
+++ b/be/src/vec/columns/column_vector.cpp
@@ -325,6 +325,20 @@ ColumnPtr ColumnVector<T>::replicate(const IColumn::Offsets& offsets) const {
 }
 
 template <typename T>
+void ColumnVector<T>::replicate(const uint32_t* counts, size_t target_size, IColumn& column) const {
+    size_t size = data.size();
+    if (size == 0) return;
+
+    auto& res = reinterpret_cast<ColumnVector<T>&>(column);
+    typename Self::Container& res_data = res.get_data();
+    res_data.reserve(target_size);
+
+    for (size_t i = 0; i < size; ++i) {
+        res_data.add_num_element_without_reserve(data[i], counts[i]);
+    }
+}
+
+template <typename T>
 void ColumnVector<T>::get_extremes(Field& min, Field& max) const {
     size_t size = data.size();
 

--- a/be/src/vec/columns/column_vector.h
+++ b/be/src/vec/columns/column_vector.h
@@ -232,6 +232,8 @@ public:
 
     ColumnPtr replicate(const IColumn::Offsets& offsets) const override;
 
+    void replicate(const uint32_t* counts, size_t target_size, IColumn& column) const override;
+
     void get_extremes(Field& min, Field& max) const override;
 
     MutableColumns scatter(IColumn::ColumnIndex num_columns,

--- a/be/src/vec/common/hash_table/hash_table.h
+++ b/be/src/vec/common/hash_table/hash_table.h
@@ -240,7 +240,7 @@ void insert_set_mapped(MappedType* dest, const ValueType& src) {
 
 /** Determines the size of the hash table, and when and how much it should be resized.
   */
-template <size_t initial_size_degree = 8>
+template <size_t initial_size_degree = 10>
 struct HashTableGrower {
     /// The state of this structure is enough to get the buffer size of the hash table.
     doris::vectorized::UInt8 size_degree = initial_size_degree;

--- a/be/src/vec/common/pod_array.h
+++ b/be/src/vec/common/pod_array.h
@@ -375,8 +375,8 @@ public:
 
     template <typename U, typename... TAllocatorParams>
     void add_num_element_without_reserve(U&& x, uint32_t num, TAllocatorParams&&... allocator_params) {
-            std::fill(t_end(), t_end() + num, x);
-            this->c_end += sizeof(T) * num;
+        std::fill(t_end(), t_end() + num, x);
+        this->c_end += sizeof(T) * num;
     }
 
     /**

--- a/be/src/vec/functions/math.cpp
+++ b/be/src/vec/functions/math.cpp
@@ -181,7 +181,7 @@ struct HexIntImpl {
         // uint64_t max value 0xFFFFFFFFFFFFFFFF , 16 'F'
         if (num == 0) { return {hex_table, 1};}
 
-        size_t i = 0;
+        int i = 0;
         while (num) {
             ans[i++] = hex_table[num & 15];
             num = num >> 4;
@@ -189,13 +189,13 @@ struct HexIntImpl {
         ans[i] = '\0';
 
         // reverse
-        for (int k = 0, j = i - 1; k <= j; k++, j--) {
+        for (int k = 0, j = i - 1; k <= j && k <= 16; k++, j--) {
             char tmp = ans[j];
             ans[j] = ans[k];
             ans[k] = tmp;
         }
 
-        return {ans, i};
+        return {ans, static_cast<size_t>(i)};
     }
     
     static Status vector(const ColumnInt64::Container& data, ColumnString::Chars& res_data,


### PR DESCRIPTION
# Proposed changes

Issue Number: close #7904

## Problem Summary:

1. Reuse the mem of output block in vec join node
2. Add the function `repliacte` in column

## Checklist(Required)

1. Does it affect the original behavior: (No)
2. Has unit tests been added: (No)
3. Has document been added or modified: (No)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (Yes)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
