### PR TITLE
[Help] gcc11 compiles `thread_local` variable, BE start: version `GLIBC_2.18' not found

### DIFF
--- a/be/src/runtime/thread_status.h
+++ b/be/src/runtime/thread_status.h
@@ -1,0 +1,35 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <string>
+
+namespace doris {
+
+class ThreadStatus {
+
+private:
+    // When `thread_local` is a constant int/bool, no problem.
+    // When `thread_local` is a class, if the member variable is `int`, there is no problem.
+    // When `thread_local` is a class, if the member variable is `string`, error: lib64/libc.so.6: version `GLIBC_2.18' not found
+    std::string _query_id; // error
+    // int64_t _untracked_mem = 0;  // no error
+};
+
+inline thread_local ThreadStatus current_thread;
+} // namespace doris

--- a/be/src/service/doris_main.cpp
+++ b/be/src/service/doris_main.cpp
@@ -52,6 +52,7 @@
 #include "service/http_service.h"
 #include "util/debug_util.h"
 #include "util/doris_metrics.h"
+#include "runtime/thread_status.h"
 #include "util/logging.h"
 #include "util/thrift_rpc_helper.h"
 #include "util/thrift_server.h"


### PR DESCRIPTION
## Problem Summary:

Error details in be.out:
````
/home/disk3/zxy/baidu/bdg/doris/core/output/be/lib/palo_be: /lib64/libc.so.6: version `GLIBC_2.18' not found (required by /home/disk3/zxy/ baidu/bdg/doris/core/output/be/lib/palo_be)
````

nm looks at palo_be and finds that the method that depends on GLIBC_2.18 is `__cxa_thread_atexit_impl`
![3be717fca2b8563d447aa1e1c8f1f39a](https://user-images.githubusercontent.com/13197424/151341978-1ecc157e-3178-4fed-b824-08c60f873ec2.png)

I found that the `__cxa_thread_atexit_impl` method was introduced by glibc to support thread_local variables
https://sourceware.org/glibc/wiki/Destructor%20support%20for%20thread_local%20variables

It was no problem to compile through gcc10 before

So, how can I avoid this problem, ask for help.
