### PR TITLE
[typo](storage) Optinmize dict page decoder init

### DIFF
--- a/be/src/olap/rowset/segment_v2/column_reader.cpp
+++ b/be/src/olap/rowset/segment_v2/column_reader.cpp
@@ -677,18 +677,18 @@ Status FileColumnIterator::_read_data_page(const OrdinalPageIndexIterator& iter)
                 // PLAIN_ENCODING is supported for dict page right now
                 _dict_decoder.reset(new BinaryPlainPageDecoder(dict_data));
                 RETURN_IF_ERROR(_dict_decoder->init());
-            }
 
-            BinaryPlainPageDecoder* pd_decoder = (BinaryPlainPageDecoder*)_dict_decoder.get();
-            _dict_start_offset_array = new uint32_t[pd_decoder->_num_elems];
-            _dict_len_array = new uint32_t[pd_decoder->_num_elems];
+                auto* pd_decoder = (BinaryPlainPageDecoder*)_dict_decoder.get();
+                _dict_start_offset_array = new uint32_t[pd_decoder->_num_elems];
+                _dict_len_array = new uint32_t[pd_decoder->_num_elems];
 
-            // todo(wb) padding dict value for SIMD comparison
-            for (int i = 0; i < pd_decoder->_num_elems; i++) {
-                const uint32_t start_offset = pd_decoder->offset(i);
-                uint32_t len = pd_decoder->offset(i + 1) - start_offset;
-                _dict_start_offset_array[i] = start_offset;
-                _dict_len_array[i] = len;
+                // todo(wb) padding dict value for SIMD comparison
+                for (int i = 0; i < pd_decoder->_num_elems; i++) {
+                    const uint32_t start_offset = pd_decoder->offset(i);
+                    uint32_t len = pd_decoder->offset(i + 1) - start_offset;
+                    _dict_start_offset_array[i] = start_offset;
+                    _dict_len_array[i] = len;
+                }
             }
 
             dict_page_decoder->set_dict_decoder(_dict_decoder.get(), _dict_start_offset_array, _dict_len_array);


### PR DESCRIPTION
# Proposed changes

Issue Number: close #7916 

Traverse the dict page once, and then call each time `dict_page_decoder->set_dict_decoder` reuses the result of `_dict_start_offset_array, _dict_len_array`



## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
