### PR TITLE
[docs] rename DDL Statements to SQL Statements in sidebars of docs in english

### DIFF
--- a/docs/.vuepress/sidebar/en.js
+++ b/docs/.vuepress/sidebar/en.js
@@ -491,7 +491,7 @@ module.exports = [
         ],
       },
       {
-        title: "DDL Statements",
+        title: "SQL Statements",
         directoryPath: "sql-statements/",
         children: [
           {


### PR DESCRIPTION
# rename DDL Statements to SQL Statements in sidebars of docs in English

Issue Number: close #7922 

## fix sidebars of docs in English

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (No)
2. Has unit tests been added: (No)
3. Has document been added or modified: (Yes)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
