### PR TITLE
(documation) Update debug-tool.md for scan debug-timer group

### DIFF
--- a/docs/zh-CN/developer-guide/debug-tool.md
+++ b/docs/zh-CN/developer-guide/debug-tool.md
@@ -330,3 +330,5 @@ perf script | ./FlameGraph/stackcollapse-perf.pl | ./FlameGraph/flamegraph.pl > 
 这样也会生成一张当时运行的CPU消耗图。
 
 ![CPU Flame](/images/cpu-flame-demo.svg)
+
+

--- a/docs/zh-CN/developer-guide/debug-tool.md
+++ b/docs/zh-CN/developer-guide/debug-tool.md
@@ -331,4 +331,11 @@ perf script | ./FlameGraph/stackcollapse-perf.pl | ./FlameGraph/flamegraph.pl > 
 
 ![CPU Flame](/images/cpu-flame-demo.svg)
 
+#### scan general debug timer
+OlapScanNode包含一组通用目的调试定时器（_general_debug_timer），_general_debug_timer已关联到OlapReaderStatistics.general_debug_ns数组，记录数据到general_debug_ns数组将自动更新到_general_debug_timer，其结果会在QueryProfile页面显示，供debugging和profiling之用。
 
+general_debug_ns有别于特定用途的有明确含义的定时器，testing和profiling过程中，你可以根据需要，用定时器组中的任何一个记录任何你想记录的内容，但使用general_debug_ns的代码不需要提交到代码库，仅做debugging和profiling之用，获取你想要信息的获取即可。
+
+比如你修改了某处代码，想测这个函数或者代码片段的开销，便可以借助general_debug_ns（下标不重复即可），示例代码如下：
+
+SCOPED_RAW_TIMER(&stats->general_debug_ns[2]);  //demo debug timer


### PR DESCRIPTION
#### scan debug timer

OlapScanNode has a set of debug timers (`_general_debug_timer`) available for debugging and profiling.
`_general_debug_timer` is a timer group, and the `_general_debug_timer` + `index` is very easy to use a specific timer.

The `_general_debug_timer` is different from a timer with a clear meaning for a specific purpose, and you can record
whatever you want during testing and profiling, but ultimately these code records do not need to be committed.

For example, if you have modified a function and want to measure the overhead of the function or code fragment,
you can use _general_debug_timer, with the following example code:

```
SCOPED_RAW_TIMER(&stats->general_debug_ns[2]); //demo debug timer
```

# Proposed changes

Issue Number: close #xxx

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
