### PR TITLE
[fix][query] Add init function in result_file_sink

### DIFF
--- a/be/src/runtime/result_file_sink.cpp
+++ b/be/src/runtime/result_file_sink.cpp
@@ -70,6 +70,10 @@ ResultFileSink::~ResultFileSink() {
     }
 }
 
+Status ResultFileSink::init(const TDataSink& tsink) {
+    return Status::OK();
+}
+
 Status ResultFileSink::prepare_exprs(RuntimeState* state) {
     // From the thrift expressions create the real exprs.
     RETURN_IF_ERROR(Expr::create_expr_trees(state->obj_pool(), _t_output_expr, &_output_expr_ctxs));

--- a/be/src/runtime/result_file_sink.h
+++ b/be/src/runtime/result_file_sink.h
@@ -49,6 +49,7 @@ public:
                    const std::vector<TPlanFragmentDestination>& destinations, ObjectPool* pool,
                    int sender_id, DescriptorTbl& descs);
     virtual ~ResultFileSink();
+    virtual Status init(const TDataSink& thrift_sink);
     virtual Status prepare(RuntimeState* state);
     virtual Status open(RuntimeState* state);
     // send data in 'batch' to this backend stream mgr


### PR DESCRIPTION
# Proposed changes

Issue Number: close #7926 
Add `init` function in `result_file_sink` to fix the error `Empty partiton info`, which is occasional reported when using `SELECT INFO OUTFILE`.

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
