### PR TITLE
[fix](storage) Using unique_ptr to refactor some class members

### DIFF
--- a/be/src/olap/rowset/segment_v2/column_reader.cpp
+++ b/be/src/olap/rowset/segment_v2/column_reader.cpp
@@ -459,9 +459,6 @@ FileColumnIterator::FileColumnIterator(ColumnReader* reader) : _reader(reader) {
 
 FileColumnIterator::~FileColumnIterator() {
     _opts.mem_tracker->Release(_opts.mem_tracker->consumption());
-
-    delete[] _dict_start_offset_array;
-    delete[] _dict_len_array;
 }
 
 Status FileColumnIterator::seek_to_first() {
@@ -679,8 +676,8 @@ Status FileColumnIterator::_read_data_page(const OrdinalPageIndexIterator& iter)
                 RETURN_IF_ERROR(_dict_decoder->init());
 
                 auto* pd_decoder = (BinaryPlainPageDecoder*)_dict_decoder.get();
-                _dict_start_offset_array = new uint32_t[pd_decoder->_num_elems];
-                _dict_len_array = new uint32_t[pd_decoder->_num_elems];
+                _dict_start_offset_array.reset(new uint32_t[pd_decoder->_num_elems]);
+                _dict_len_array.reset(new uint32_t[pd_decoder->_num_elems]);
 
                 // todo(wb) padding dict value for SIMD comparison
                 for (int i = 0; i < pd_decoder->_num_elems; i++) {
@@ -691,7 +688,7 @@ Status FileColumnIterator::_read_data_page(const OrdinalPageIndexIterator& iter)
                 }
             }
 
-            dict_page_decoder->set_dict_decoder(_dict_decoder.get(), _dict_start_offset_array, _dict_len_array);
+            dict_page_decoder->set_dict_decoder(_dict_decoder.get(), _dict_start_offset_array.get(), _dict_len_array.get());
         }
     }
     return Status::OK();

--- a/be/src/olap/rowset/segment_v2/column_reader.h
+++ b/be/src/olap/rowset/segment_v2/column_reader.h
@@ -320,8 +320,8 @@ private:
     // current value ordinal
     ordinal_t _current_ordinal = 0;
 
-    uint32_t* _dict_start_offset_array = nullptr;
-    uint32_t* _dict_len_array = nullptr;
+    std::unique_ptr<uint32_t[]> _dict_start_offset_array;
+    std::unique_ptr<uint32_t[]> _dict_len_array;
 };
 
 class ArrayFileColumnIterator final : public ColumnIterator {

--- a/be/src/olap/rowset/segment_v2/segment_iterator.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.cpp
@@ -618,7 +618,7 @@ void SegmentIterator::_vec_init_lazy_materialization() {
             } else {
                 vec_pred_col_id_set.insert(predicate->column_id());
                 if (_pre_eval_block_predicate == nullptr) {
-                    _pre_eval_block_predicate = new AndBlockColumnPredicate();
+                    _pre_eval_block_predicate.reset(new AndBlockColumnPredicate());
                 }
                 _pre_eval_block_predicate->add_column_predicate(new SingleColumnBlockPredicate(predicate));
             }

--- a/be/src/olap/rowset/segment_v2/segment_iterator.h
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.h
@@ -134,7 +134,7 @@ private:
     std::vector<ColumnId> _short_cir_pred_column_ids; // keep columnId of columns for short circuit predicate evaluation
     vector<bool> _is_pred_column; // columns hold by segmentIter
     vectorized::MutableColumns _current_return_columns;
-    AndBlockColumnPredicate* _pre_eval_block_predicate = nullptr;
+    std::unique_ptr<AndBlockColumnPredicate> _pre_eval_block_predicate;
     std::vector<ColumnPredicate*> _short_cir_eval_predicate;
     // when lazy materialization is enable, segmentIter need to read data at least twice
     // first, read predicate columns by various index


### PR DESCRIPTION
# Proposed changes

Using unique_ptr to refactor some class members.
Fix mem leak for ```SegmengIterator``` 's ```_pre_eval_block_predicate```.

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
