### PR TITLE
(improvement)[test] Combine multiple tests to use only one Doris cluster

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/CastExpr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/CastExpr.java
@@ -17,13 +17,6 @@
 
 package org.apache.doris.analysis;
 
-import java.io.DataInput;
-import java.io.DataOutput;
-import java.io.IOException;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-
 import org.apache.doris.catalog.Catalog;
 import org.apache.doris.catalog.Function;
 import org.apache.doris.catalog.FunctionSet;
@@ -45,6 +38,13 @@ import com.google.common.collect.Maps;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
 
 
 public class CastExpr extends Expr {
@@ -178,22 +178,12 @@ public class CastExpr extends Expr {
 
     @Override
     public String toSqlImpl() {
-        if (ConnectContext.get() != null &&
+        boolean isVerbose = ConnectContext.get() != null &&
                 ConnectContext.get().getExecutor() != null &&
                 ConnectContext.get().getExecutor().getParsedStmt() != null &&
                 ConnectContext.get().getExecutor().getParsedStmt().getExplainOptions() != null &&
-                ConnectContext.get().getExecutor().getParsedStmt().getExplainOptions().isVerbose()) {
-            if (isAnalyzed) {
-                if (type.isStringType()) {
-                    return "CAST(" + getChild(0).toSql() + " AS " + "CHARACTER" + ")";
-                } else {
-                    return "CAST(" + getChild(0).toSql() + " AS " + type.toString() + ")";
-                }
-            } else {
-                return "CAST(" + getChild(0).toSql() + " AS " + targetTypeDef.toSql() + ")";
-            }
-        }
-        if (isImplicit) {
+                ConnectContext.get().getExecutor().getParsedStmt().getExplainOptions().isVerbose();
+        if (isImplicit && !isVerbose) {
             return getChild(0).toSql();
         }
         if (isAnalyzed) {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -1220,6 +1220,7 @@ public class StmtExecutor implements ProfileWriter {
         }
 
         if (insertStmt.getQueryStmt().isExplain()) {
+            insertStmt.setIsExplain(new ExplainOptions(true, false));
             String explainString = planner.getExplainString(planner.getFragments(), new ExplainOptions(true, false));
             handleExplainStmt(explainString);
             return;

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/ExplainTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/ExplainTest.java
@@ -20,28 +20,23 @@ package org.apache.doris.analysis;
 import org.apache.doris.catalog.Catalog;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.utframe.UtFrameUtils;
-import org.junit.AfterClass;
+
 import org.junit.Assert;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.util.UUID;
 
 
 public class ExplainTest {
-    private static String runningDir = "fe/mocked/TableFunctionPlanTest/" + UUID.randomUUID().toString() + "/";
     private static ConnectContext ctx;
 
-
-    @BeforeClass
-    public static void beforeClass() throws Exception {
-        UtFrameUtils.createDorisCluster(runningDir);
-        ctx = UtFrameUtils.createDefaultCtx();
-        String createDbStmtStr = "create database test;";
+    public void before(ConnectContext ctx) throws Exception {
+        this.ctx = ctx;
+        String createDbStmtStr = "create database test_explain;";
         CreateDbStmt createDbStmt = (CreateDbStmt) UtFrameUtils.parseAndAnalyzeStmt(createDbStmtStr, ctx);
         Catalog.getCurrentCatalog().createDb(createDbStmt);
 
-        String t1 =("CREATE TABLE test.t1 (\n" +
+        String t1 = ("CREATE TABLE test_explain.explain_t1 (\n" +
                 "  `dt` int(11) COMMENT \"\",\n" +
                 "  `id` int(11) COMMENT \"\",\n" +
                 "  `value` varchar(8) COMMENT \"\"\n" +
@@ -56,7 +51,7 @@ public class ExplainTest {
         CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameUtils.parseAndAnalyzeStmt(t1, ctx);
         Catalog.getCurrentCatalog().createTable(createTableStmt);
 
-        String t2 =("CREATE TABLE test.t2 (\n" +
+        String t2 =("CREATE TABLE test_explain.explain_t2 (\n" +
                 "  `dt` bigint(11) COMMENT \"\",\n" +
                 "  `id` bigint(11) COMMENT \"\",\n" +
                 "  `value` bigint(8) COMMENT \"\"\n" +
@@ -70,49 +65,46 @@ public class ExplainTest {
                 ");");
         createTableStmt = (CreateTableStmt) UtFrameUtils.parseAndAnalyzeStmt(t2, ctx);
         Catalog.getCurrentCatalog().createTable(createTableStmt);
-
     }
 
-    @AfterClass
-    public static void tearDown() {
-        UtFrameUtils.cleanDorisFeDir(runningDir);
+    public void after() throws Exception {
+        String dropSchemaSql = "drop schema if exists test_explain";
+        String dropDbSql = "drop database if exists test_explain";
+        DropDbStmt dropSchemaStmt = (DropDbStmt) UtFrameUtils.parseAndAnalyzeStmt(dropSchemaSql, ctx);
+        DropDbStmt dropDbStmt = (DropDbStmt) UtFrameUtils.parseAndAnalyzeStmt(dropDbSql, ctx);
+        Assert.assertEquals(dropDbStmt.toSql(), dropSchemaStmt.toSql());
     }
 
-    @Test
     public void testExplainInsertInto() throws Exception {
-        String sql = "explain insert into test.t1 select * from test.t2";
+        String sql = "explain insert into test_explain.explain_t1 select * from test_explain.explain_t2";
         String explainString = UtFrameUtils.getSQLPlanOrErrorMsg(ctx, sql, true);
         System.out.println(explainString);
         Assert.assertTrue(explainString.contains("CAST"));
     }
 
-    @Test
     public void testExplainSelect() throws Exception {
-        String sql = "explain select * from test.t1 where dt = '1001';";
+        String sql = "explain select * from test_explain.explain_t1 where dt = '1001';";
         String explainString = UtFrameUtils.getSQLPlanOrErrorMsg(ctx, sql, false);
         System.out.println(explainString);
         Assert.assertFalse(explainString.contains("CAST"));
     }
 
-    @Test
     public void testExplainVerboseSelect() throws Exception {
-        String queryStr = "explain verbose select * from test.t1 where dt = '1001';";
+        String queryStr = "explain verbose select * from test_explain.explain_t1 where dt = '1001';";
         String explainString = UtFrameUtils.getSQLPlanOrErrorMsg(ctx, queryStr, true);
         System.out.println(explainString);
         Assert.assertTrue(explainString.contains("CAST"));
     }
 
-    @Test
     public void testExplainConcatSelect() throws Exception {
-        String sql = "explain select concat(dt, id) from test.t1;";
+        String sql = "explain select concat(dt, id) from test_explain.explain_t1;";
         String explainString = UtFrameUtils.getSQLPlanOrErrorMsg(ctx, sql, false);
         System.out.println(explainString);
         Assert.assertFalse(explainString.contains("CAST"));
     }
 
-    @Test
     public void testExplainVerboseConcatSelect() throws Exception {
-        String sql = "explain verbose select concat(dt, id) from test.t1;";
+        String sql = "explain verbose select concat(dt, id) from test_explain.explain_t1;";
         String explainString = UtFrameUtils.getSQLPlanOrErrorMsg(ctx, sql, true);
         System.out.println(explainString);
         Assert.assertTrue(explainString.contains("CAST"));

--- a/fe/fe-core/src/test/java/org/apache/doris/planner/QueryPlanTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/planner/QueryPlanTest.java
@@ -22,6 +22,7 @@ import org.apache.doris.analysis.CreateDbStmt;
 import org.apache.doris.analysis.CreateTableStmt;
 import org.apache.doris.analysis.CreateViewStmt;
 import org.apache.doris.analysis.DropDbStmt;
+import org.apache.doris.analysis.ExplainTest;
 import org.apache.doris.analysis.Expr;
 import org.apache.doris.analysis.InformationFunction;
 import org.apache.doris.analysis.LoadStmt;
@@ -44,6 +45,7 @@ import org.apache.doris.common.jmockit.Deencapsulation;
 import org.apache.doris.load.EtlJobType;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.QueryState.MysqlStateType;
+import org.apache.doris.rewrite.RewriteDateLiteralRuleTest;
 import org.apache.doris.thrift.TRuntimeFilterType;
 import org.apache.doris.utframe.UtFrameUtils;
 
@@ -1824,7 +1826,7 @@ public class QueryPlanTest {
         String explainStr = UtFrameUtils.getSQLPlanOrErrorMsg(connectContext, "EXPLAIN " + sql);
         Assert.assertTrue(explainStr.contains("PREDICATES: `date` >= '2021-10-07 00:00:00', `date` <= '2021-10-11 00:00:00'"));
     }
-
+    
     // Fix: issue-#7929
     @Test
     public void testEmptyNodeWithOuterJoinAndAnalyticFunction() throws Exception {
@@ -1862,5 +1864,32 @@ public class QueryPlanTest {
         Assert.assertTrue(explainStr.contains("tuple ids: 0 1 5"));
 
     }
+
+    // --begin-- implicit cast in explain verbose
+    @Test
+    public void testExplainInsertInto() throws Exception {
+        ExplainTest explainTest = new ExplainTest();
+        explainTest.before(connectContext);
+        explainTest.testExplainInsertInto();
+        explainTest.testExplainSelect();
+        explainTest.testExplainVerboseSelect();
+        explainTest.testExplainConcatSelect();
+        explainTest.testExplainVerboseConcatSelect();
+        explainTest.after();
+    }
+    // --end--
+
+    // --begin-- rewrite date literal rule
+    @Test
+    public void testRewriteDateLiteralRule() throws Exception {
+        RewriteDateLiteralRuleTest rewriteDateLiteralRuleTest = new RewriteDateLiteralRuleTest();
+        rewriteDateLiteralRuleTest.before(connectContext);
+        rewriteDateLiteralRuleTest.testWithDoubleFormatDate();
+        rewriteDateLiteralRuleTest.testWithIntFormatDate();
+        rewriteDateLiteralRuleTest.testWithInvalidFormatDate();
+        rewriteDateLiteralRuleTest.testWithStringFormatDate();
+        rewriteDateLiteralRuleTest.after();
+    }
+    // --end--
 
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/utframe/DorisAssert.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/utframe/DorisAssert.java
@@ -23,6 +23,7 @@ import org.apache.doris.analysis.CreateDbStmt;
 import org.apache.doris.analysis.CreateMaterializedViewStmt;
 import org.apache.doris.analysis.CreateTableStmt;
 import org.apache.doris.analysis.CreateViewStmt;
+import org.apache.doris.analysis.DropDbStmt;
 import org.apache.doris.analysis.DropTableStmt;
 import org.apache.doris.analysis.ExplainOptions;
 import org.apache.doris.analysis.SqlParser;
@@ -36,10 +37,9 @@ import org.apache.doris.common.util.SqlParserUtils;
 import org.apache.doris.planner.Planner;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.QueryState;
+import org.apache.doris.qe.SessionVariable;
 import org.apache.doris.qe.StmtExecutor;
 import org.apache.doris.system.SystemInfoService;
-
-import org.apache.doris.qe.SessionVariable;
 
 import org.apache.commons.lang.StringUtils;
 import org.junit.Assert;
@@ -56,6 +56,10 @@ public class DorisAssert {
 
     public DorisAssert() throws IOException {
         this.ctx = UtFrameUtils.createDefaultCtx();
+    }
+
+    public DorisAssert(ConnectContext ctx) {
+        this.ctx = ctx;
     }
 
     public DorisAssert withEnableMV() {
@@ -108,6 +112,12 @@ public class DorisAssert {
         DropTableStmt dropTableStmt =
                 (DropTableStmt) UtFrameUtils.parseAndAnalyzeStmt("drop view " + tableName + ";", ctx);
         Catalog.getCurrentCatalog().dropTable(dropTableStmt);
+        return this;
+    }
+
+    public DorisAssert dropDB(String dbName) throws Exception {
+        DropDbStmt dropDbStmt = (DropDbStmt) UtFrameUtils.parseAndAnalyzeStmt("drop database " + dbName + ";", ctx);
+        Catalog.getCurrentCatalog().dropDb(dropDbStmt);
         return this;
     }
 


### PR DESCRIPTION
## Problem Summary:

This PR mainly includes the following two changes:
1. Shorten FE single measurement time
In Doris's FE unit test, starting a Doris cluster is a time-consuming operation.
In this PR, the unit tests of some small functions are merged into @QueryPlanTest,
the same cluster is used centrally,
so as to avoid the problem that the overall unit test time of FE is too long.

2. Refine the logic of "PR 7851"
Although the function can be implemented correctly in PR #7851,
the logic is not brief enough.
This PR mainly succinct redundant code in terms of engineering implementation.

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
