### PR TITLE
[improvement][refactor](vec) Refactor serde of vec block and using brpc attachment

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -144,7 +144,7 @@ CONF_String(doris_cgroups, "");
 // thrashing.
 CONF_Int32(num_threads_per_core, "3");
 // if true, compresses tuple data in Serialize
-CONF_Bool(compress_rowbatches, "true");
+CONF_mBool(compress_rowbatches, "true");
 // interval between profile reports; in seconds
 CONF_mInt32(status_report_interval, "5");
 // number of olap scanner thread pool size

--- a/be/src/vec/core/block.cpp
+++ b/be/src/vec/core/block.cpp
@@ -52,69 +52,69 @@ namespace doris::vectorized {
 
 inline DataTypePtr create_data_type(const PColumnMeta& pcolumn_meta) {
     switch (pcolumn_meta.type()) {
-    case PDataType::UINT8: {
+    case PGenericType::UINT8: {
         return std::make_shared<DataTypeUInt8>();
     }
-    case PDataType::UINT16: {
+    case PGenericType::UINT16: {
         return std::make_shared<DataTypeUInt16>();
     }
-    case PDataType::UINT32: {
+    case PGenericType::UINT32: {
         return std::make_shared<DataTypeUInt32>();
     }
-    case PDataType::UINT64: {
+    case PGenericType::UINT64: {
         return std::make_shared<DataTypeUInt64>();
     }
-    case PDataType::UINT128: {
+    case PGenericType::UINT128: {
         return std::make_shared<DataTypeUInt128>();
     }
-    case PDataType::INT8: {
+    case PGenericType::INT8: {
         return std::make_shared<DataTypeInt8>();
     }
-    case PDataType::INT16: {
+    case PGenericType::INT16: {
         return std::make_shared<DataTypeInt16>();
     }
-    case PDataType::INT32: {
+    case PGenericType::INT32: {
         return std::make_shared<DataTypeInt32>();
     }
-    case PDataType::INT64: {
+    case PGenericType::INT64: {
         return std::make_shared<DataTypeInt64>();
     }
-    case PDataType::INT128: {
+    case PGenericType::INT128: {
         return std::make_shared<DataTypeInt128>();
     }
-    case PDataType::FLOAT32: {
+    case PGenericType::FLOAT: {
         return std::make_shared<DataTypeFloat32>();
     }
-    case PDataType::FLOAT64: {
+    case PGenericType::DOUBLE: {
         return std::make_shared<DataTypeFloat64>();
     }
-    case PDataType::STRING: {
+    case PGenericType::STRING: {
         return std::make_shared<DataTypeString>();
     }
-    case PDataType::DATE: {
+    case PGenericType::DATE: {
         return std::make_shared<DataTypeDate>();
     }
-    case PDataType::DATETIME: {
+    case PGenericType::DATETIME: {
         return std::make_shared<DataTypeDateTime>();
     }
-    case PDataType::DECIMAL32: {
+    case PGenericType::DECIMAL32: {
         return std::make_shared<DataTypeDecimal<Decimal32>>(pcolumn_meta.decimal_param().precision(),
                                                             pcolumn_meta.decimal_param().scale());
     }
-    case PDataType::DECIMAL64: {
+    case PGenericType::DECIMAL64: {
         return std::make_shared<DataTypeDecimal<Decimal64>>(pcolumn_meta.decimal_param().precision(),
                                                             pcolumn_meta.decimal_param().scale());
     }
-    case PDataType::DECIMAL128: {
+    case PGenericType::DECIMAL128: {
         return std::make_shared<DataTypeDecimal<Decimal128>>(pcolumn_meta.decimal_param().precision(),
                                                              pcolumn_meta.decimal_param().scale());
     }
-    case PDataType::BITMAP: {
+    case PGenericType::BITMAP: {
         return std::make_shared<DataTypeBitMap>();
     }
     default: {
         LOG(FATAL) << fmt::format("Unknown data type: {}, data type name: {}", pcolumn_meta.type(),
-                                  PDataType_Type_Name(pcolumn_meta.type()));
+                                  PGenericType_TypeId_Name(pcolumn_meta.type()));
         return nullptr;
     }
     }

--- a/be/src/vec/core/block.h
+++ b/be/src/vec/core/block.h
@@ -26,6 +26,7 @@
 #include <vector>
 #include <parallel_hashmap/phmap.h>
 
+#include "gen_cpp/data.pb.h"
 #include "vec/columns/column_nullable.h"
 #include "vec/core/block_info.h"
 #include "vec/core/column_with_type_and_name.h"
@@ -215,7 +216,7 @@ public:
     }
 
     // serialize block to PBlock
-    size_t serialize(PBlock* pblock) const;
+    Status serialize(PBlock* pblock, size_t* uncompressed_bytes, size_t* compressed_bytes, std::string* allocated_buf) const;
 
     // serialize block to PRowbatch
     void serialize(RowBatch*, const RowDescriptor&);

--- a/be/src/vec/core/column_with_type_and_name.cpp
+++ b/be/src/vec/core/column_with_type_and_name.cpp
@@ -65,8 +65,14 @@ String ColumnWithTypeAndName::dump_structure() const {
     dump_structure(out);
     return out.str();
 }
+
 std::string ColumnWithTypeAndName::to_string(size_t row_num) const {
     return type->to_string(*column->convert_to_full_column_if_const().get(), row_num);
+}
+
+void ColumnWithTypeAndName::to_pb_column_meta(PColumnMeta* col_meta) const {
+    col_meta->set_name(name);
+    type->to_pb_column_meta(col_meta);
 }
 
 } // namespace doris::vectorized

--- a/be/src/vec/core/column_with_type_and_name.h
+++ b/be/src/vec/core/column_with_type_and_name.h
@@ -51,6 +51,8 @@ struct ColumnWithTypeAndName {
     void dump_structure(std::ostream& out) const;
     String dump_structure() const;
     std::string to_string(size_t row_num) const;
+
+    void to_pb_column_meta(PColumnMeta* col_meta) const;
 };
 
 } // namespace doris::vectorized

--- a/be/src/vec/data_types/data_type.cpp
+++ b/be/src/vec/data_types/data_type.cpp
@@ -100,48 +100,48 @@ void IDataType::to_pb_column_meta(PColumnMeta* col_meta) const {
     col_meta->set_type(get_pdata_type(this));
 }
 
-PDataType_Type IDataType::get_pdata_type(const IDataType* data_type) {
+PGenericType_TypeId IDataType::get_pdata_type(const IDataType* data_type) {
     switch (data_type->get_type_id()) {
     case TypeIndex::UInt8:
-        return PDataType::UINT8;
+        return PGenericType::UINT8;
     case TypeIndex::UInt16:
-        return PDataType::UINT16;
+        return PGenericType::UINT16;
     case TypeIndex::UInt32:
-        return PDataType::UINT32;
+        return PGenericType::UINT32;
     case TypeIndex::UInt64:
-        return PDataType::UINT64;
+        return PGenericType::UINT64;
     case TypeIndex::UInt128:
-        return PDataType::UINT128;
+        return PGenericType::UINT128;
     case TypeIndex::Int8:
-        return PDataType::INT8;
+        return PGenericType::INT8;
     case TypeIndex::Int16:
-        return PDataType::INT16;
+        return PGenericType::INT16;
     case TypeIndex::Int32:
-        return PDataType::INT32;
+        return PGenericType::INT32;
     case TypeIndex::Int64:
-        return PDataType::INT64;
+        return PGenericType::INT64;
     case TypeIndex::Int128:
-        return PDataType::INT128;
+        return PGenericType::INT128;
     case TypeIndex::Float32:
-        return PDataType::FLOAT32;
+        return PGenericType::FLOAT;
     case TypeIndex::Float64:
-        return PDataType::FLOAT64;
+        return PGenericType::DOUBLE;
     case TypeIndex::Decimal32:
-        return PDataType::DECIMAL32;
+        return PGenericType::DECIMAL32;
     case TypeIndex::Decimal64:
-        return PDataType::DECIMAL64;
+        return PGenericType::DECIMAL64;
     case TypeIndex::Decimal128:
-        return PDataType::DECIMAL128;
+        return PGenericType::DECIMAL128;
     case TypeIndex::String:
-        return PDataType::STRING;
+        return PGenericType::STRING;
     case TypeIndex::Date:
-        return PDataType::DATE;
+        return PGenericType::DATE;
     case TypeIndex::DateTime:
-        return PDataType::DATETIME;
+        return PGenericType::DATETIME;
     case TypeIndex::BitMap:
-        return PDataType::BITMAP;
+        return PGenericType::BITMAP;
     default:
-        return PDataType::UNKNOWN;
+        return PGenericType::UNKNOWN;
     }
 }
 

--- a/be/src/vec/data_types/data_type.cpp
+++ b/be/src/vec/data_types/data_type.cpp
@@ -89,10 +89,60 @@ void IDataType::to_string(const IColumn& column, size_t row_num, BufferWritable&
 
 std::string IDataType::to_string(const IColumn& column, size_t row_num) const {
     LOG(FATAL) << fmt::format("Data type {} to_string not implement.", get_name());
+    return "";
 }
 
 void IDataType::insert_default_into(IColumn& column) const {
     column.insert_default();
+}
+
+void IDataType::to_pb_column_meta(PColumnMeta* col_meta) const {
+    col_meta->set_type(get_pdata_type(this));
+}
+
+PDataType_Type IDataType::get_pdata_type(const IDataType* data_type) {
+    switch (data_type->get_type_id()) {
+    case TypeIndex::UInt8:
+        return PDataType::UINT8;
+    case TypeIndex::UInt16:
+        return PDataType::UINT16;
+    case TypeIndex::UInt32:
+        return PDataType::UINT32;
+    case TypeIndex::UInt64:
+        return PDataType::UINT64;
+    case TypeIndex::UInt128:
+        return PDataType::UINT128;
+    case TypeIndex::Int8:
+        return PDataType::INT8;
+    case TypeIndex::Int16:
+        return PDataType::INT16;
+    case TypeIndex::Int32:
+        return PDataType::INT32;
+    case TypeIndex::Int64:
+        return PDataType::INT64;
+    case TypeIndex::Int128:
+        return PDataType::INT128;
+    case TypeIndex::Float32:
+        return PDataType::FLOAT32;
+    case TypeIndex::Float64:
+        return PDataType::FLOAT64;
+    case TypeIndex::Decimal32:
+        return PDataType::DECIMAL32;
+    case TypeIndex::Decimal64:
+        return PDataType::DECIMAL64;
+    case TypeIndex::Decimal128:
+        return PDataType::DECIMAL128;
+    case TypeIndex::String:
+        return PDataType::STRING;
+    case TypeIndex::Date:
+        return PDataType::DATE;
+    case TypeIndex::DateTime:
+        return PDataType::DATETIME;
+    case TypeIndex::BitMap:
+        return PDataType::BITMAP;
+    default:
+        return PDataType::UNKNOWN;
+    }
 }
 
 DataTypePtr IDataType::from_thrift(const doris::PrimitiveType& type, const bool is_nullable){

--- a/be/src/vec/data_types/data_type.h
+++ b/be/src/vec/data_types/data_type.h
@@ -240,7 +240,7 @@ public:
 
     virtual void to_pb_column_meta(PColumnMeta* col_meta) const;
 
-    static PDataType_Type get_pdata_type(const IDataType* data_type);
+    static PGenericType_TypeId get_pdata_type(const IDataType* data_type);
     static DataTypePtr from_thrift(const doris::PrimitiveType& type, const bool is_nullable = true);
     static DataTypePtr from_olap_engine(const doris::FieldType& type, const bool is_nullable = true);
 

--- a/be/src/vec/data_types/data_type.h
+++ b/be/src/vec/data_types/data_type.h
@@ -23,6 +23,7 @@
 #include <boost/noncopyable.hpp>
 #include <memory>
 
+#include "gen_cpp/data.pb.h"
 #include "runtime/primitive_type.h"
 #include "vec/common/cow.h"
 #include "vec/common/string_buffer.hpp"
@@ -233,9 +234,13 @@ public:
     /// Updates avg_value_size_hint for newly read column. Uses to optimize deserialization. Zero expected for first column.
     static void update_avg_value_size_hint(const IColumn& column, double& avg_value_size_hint);
 
-    virtual size_t serialize(const IColumn& column, PColumn* pcolumn) const = 0;
-    virtual void deserialize(const PColumn& pcolumn, IColumn* column) const = 0;
+    virtual int64_t get_uncompressed_serialized_bytes(const IColumn& column) const = 0;
+    virtual char* serialize(const IColumn& column, char* buf) const = 0;
+    virtual const char* deserialize(const char* buf, IColumn* column) const = 0;
 
+    virtual void to_pb_column_meta(PColumnMeta* col_meta) const;
+
+    static PDataType_Type get_pdata_type(const IDataType* data_type);
     static DataTypePtr from_thrift(const doris::PrimitiveType& type, const bool is_nullable = true);
     static DataTypePtr from_olap_engine(const doris::FieldType& type, const bool is_nullable = true);
 

--- a/be/src/vec/data_types/data_type_bitmap.h
+++ b/be/src/vec/data_types/data_type_bitmap.h
@@ -36,8 +36,10 @@ public:
 
     TypeIndex get_type_id() const override { return TypeIndex::BitMap; }
 
-    size_t serialize(const IColumn& column, PColumn* pcolumn) const override;
-    void deserialize(const PColumn& pcolumn, IColumn* column) const override;
+    int64_t get_uncompressed_serialized_bytes(const IColumn& column) const override;
+    char* serialize(const IColumn& column, char* buf) const override;
+    const char* deserialize(const char* buf, IColumn* column) const override;
+
     MutableColumnPtr create_column() const override;
 
     bool get_is_parametric() const override { return false; }

--- a/be/src/vec/data_types/data_type_decimal.h
+++ b/be/src/vec/data_types/data_type_decimal.h
@@ -116,8 +116,12 @@ public:
     std::string do_get_name() const override;
     TypeIndex get_type_id() const override { return TypeId<T>::value; }
 
-    size_t serialize(const IColumn& column, PColumn* pcolumn) const override;
-    void deserialize(const PColumn& pcolumn, IColumn* column) const override;
+    int64_t get_uncompressed_serialized_bytes(const IColumn& column) const override;
+    char* serialize(const IColumn& column, char* buf) const override;
+    const char* deserialize(const char* buf, IColumn* column) const override;
+
+    void to_pb_column_meta(PColumnMeta* col_meta) const override;
+
     Field get_default() const override;
     bool can_be_promoted() const override { return true; }
     DataTypePtr promote_numeric_type() const override;

--- a/be/src/vec/data_types/data_type_nothing.cpp
+++ b/be/src/vec/data_types/data_type_nothing.cpp
@@ -30,11 +30,14 @@ MutableColumnPtr DataTypeNothing::create_column() const {
     return ColumnNothing::create(0);
 }
 
-size_t DataTypeNothing::serialize(const IColumn&, PColumn* pcolumn) const {
-    return 0;
+char* DataTypeNothing::serialize(const IColumn& column, char* buf) const {
+    return buf;
 }
 
-void DataTypeNothing::deserialize(const PColumn& pcolumn, IColumn* column) const {}
+const char* DataTypeNothing::deserialize(const char* buf, IColumn* column) const {
+    return buf;
+}
+
 bool DataTypeNothing::equals(const IDataType& rhs) const {
     return typeid(rhs) == typeid(*this);
 }

--- a/be/src/vec/data_types/data_type_nothing.h
+++ b/be/src/vec/data_types/data_type_nothing.h
@@ -48,8 +48,10 @@ public:
     size_t get_size_of_value_in_memory() const override { return 0; }
     bool can_be_inside_nullable() const override { return true; }
 
-    size_t serialize(const IColumn& column, PColumn* pcolumn) const override;
-    void deserialize(const PColumn& pcolumn, IColumn* column) const override;
+    int64_t get_uncompressed_serialized_bytes(const IColumn& column) const override { return 0; }
+    char* serialize(const IColumn& column, char* buf) const override;
+    const char* deserialize(const char* buf, IColumn* column) const override;
+
     [[noreturn]] Field get_default() const override {
         LOG(FATAL) << "Method get_default() is not implemented for data type " << get_name();
     }

--- a/be/src/vec/data_types/data_type_nullable.h
+++ b/be/src/vec/data_types/data_type_nullable.h
@@ -36,8 +36,12 @@ public:
     const char* get_family_name() const override { return "Nullable"; }
     TypeIndex get_type_id() const override { return TypeIndex::Nullable; }
 
-    size_t serialize(const IColumn& column, PColumn* pcolumn) const override;
-    void deserialize(const PColumn& pcolumn, IColumn* column) const override;
+    int64_t get_uncompressed_serialized_bytes(const IColumn& column) const override;
+    char* serialize(const IColumn& column, char* buf) const override;
+    const char* deserialize(const char* buf, IColumn* column) const override;
+
+    void to_pb_column_meta(PColumnMeta* col_meta) const override;
+
     MutableColumnPtr create_column() const override;
 
     Field get_default() const override;

--- a/be/src/vec/data_types/data_type_number_base.h
+++ b/be/src/vec/data_types/data_type_number_base.h
@@ -42,8 +42,10 @@ public:
     TypeIndex get_type_id() const override { return TypeId<T>::value; }
     Field get_default() const override;
 
-    size_t serialize(const IColumn& column, PColumn* pcolumn) const override;
-    void deserialize(const PColumn& pcolumn, IColumn* column) const override;
+    int64_t get_uncompressed_serialized_bytes(const IColumn& column) const override;
+    char* serialize(const IColumn& column, char* buf) const override;
+    const char* deserialize(const char* buf, IColumn* column) const override;
+
     MutableColumnPtr create_column() const override;
 
     bool get_is_parametric() const override { return false; }

--- a/be/src/vec/data_types/data_type_string.h
+++ b/be/src/vec/data_types/data_type_string.h
@@ -35,8 +35,10 @@ public:
     const char* get_family_name() const override { return "String"; }
 
     TypeIndex get_type_id() const override { return TypeIndex::String; }
-    size_t serialize(const IColumn& column, PColumn* pcolumn) const override;
-    void deserialize(const PColumn& pcolumn, IColumn* column) const override;
+
+    int64_t get_uncompressed_serialized_bytes(const IColumn& column) const override;
+    char* serialize(const IColumn& column, char* buf) const override;
+    const char* deserialize(const char* buf, IColumn* column) const override;
 
     MutableColumnPtr create_column() const override;
 

--- a/be/src/vec/io/io_helper.h
+++ b/be/src/vec/io/io_helper.h
@@ -140,37 +140,6 @@ inline void write_binary(const Type& x, BufferWritable& buf) {
     write_pod_binary(x, buf);
 }
 
-inline size_t write_binary(const std::ostringstream& buf, PColumn* pcolumn) {
-    std::string uncompressed = buf.str();
-    std::string compressed;
-    snappy::Compress(uncompressed.data(), uncompressed.size(), &compressed);
-    if (static_cast<double>(compressed.size()) / uncompressed.size() > 0.7) {
-        pcolumn->set_compressed(false);
-        pcolumn->mutable_binary()->append(uncompressed);
-    } else {
-        pcolumn->set_compressed(true);
-        pcolumn->mutable_binary()->append(compressed);
-    }
-
-    return uncompressed.size();
-}
-
-inline size_t compress_binary(PColumn* pcolumn) {
-    auto uncompressed = pcolumn->mutable_binary();
-    auto uncompressed_size = uncompressed->size();
-    std::string compressed;
-    snappy::Compress(uncompressed->data(), uncompressed_size, &compressed);
-
-    if (static_cast<double>(compressed.size()) / uncompressed_size > 0.7) {
-        pcolumn->set_compressed(false);
-    } else {
-        pcolumn->set_compressed(true);
-        pcolumn->mutable_binary()->swap(compressed);
-    }
-
-    return uncompressed_size;
-}
-
 /// Read POD-type in native format
 template <typename Type>
 inline void read_pod_binary(Type& x, BufferReadable& buf) {
@@ -249,6 +218,7 @@ inline void read_binary(Type& x, BufferReadable& buf) {
     read_pod_binary(x, buf);
 }
 
+#if 0
 inline void read_binary(const PColumn& pcolumn, std::string* data) {
     if (pcolumn.compressed()) {
         snappy::Uncompress(pcolumn.binary().data(), pcolumn.binary().size(), data);
@@ -256,6 +226,7 @@ inline void read_binary(const PColumn& pcolumn, std::string* data) {
         *data = pcolumn.binary();
     }
 }
+#endif
 
 template <typename T>
 bool read_float_text_fast_impl(T& x, ReadBuffer& in) {

--- a/be/test/vec/runtime/vdata_stream_test.cpp
+++ b/be/test/vec/runtime/vdata_stream_test.cpp
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#include "service/brpc.h"
 #include "common/object_pool.h"
 #include "gen_cpp/internal_service.pb.h"
 #include "google/protobuf/descriptor.h"
@@ -22,6 +23,7 @@
 #include "gtest/gtest.h"
 #include "runtime/exec_env.h"
 #include "testutil/desc_tbl_builder.h"
+#include "util/proto_util.h"
 #include "vec/columns/columns_number.h"
 #include "vec/runtime/vdata_stream_mgr.h"
 #include "vec/runtime/vdata_stream_recvr.h"
@@ -34,7 +36,19 @@ public:
     void transmit_block(::google::protobuf::RpcController* controller,
                         const ::doris::PTransmitDataParams* request,
                         ::doris::PTransmitDataResult* response, ::google::protobuf::Closure* done) {
-        stream_mgr->transmit_block(request, &done);
+        // stream_mgr->transmit_block(request, &done);
+        brpc::Controller* cntl = static_cast<brpc::Controller*>(controller);
+        attachment_transfer_request_block<PTransmitDataParams>(request, cntl);
+        // The response is accessed when done->Run is called in transmit_block(),
+        // give response a default value to avoid null pointers in high concurrency.
+        Status st;
+        st.to_protobuf(response->mutable_status());
+        st = stream_mgr->transmit_block(request, &done);
+        if (!st.ok()) {
+            LOG(WARNING) << "transmit_block failed, message=" << st.get_error_msg()
+                << ", fragment_instance_id=" << print_id(request->finst_id())
+                << ", node=" << request->node_id();
+        }
     }
 
 private:

--- a/fe/fe-core/src/main/java/org/apache/doris/system/SystemInfoService.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/system/SystemInfoService.java
@@ -874,6 +874,9 @@ public class SystemInfoService {
                 backends.addAll(list);
             } else {
                 list = list.stream().filter(beAvailablePredicate::isMatch).collect(Collectors.toList());
+                if (list.isEmpty()) {
+                    continue;
+                }
                 Collections.shuffle(list);
                 backends.add(list.get(0));
             }

--- a/gensrc/proto/data.proto
+++ b/gensrc/proto/data.proto
@@ -20,6 +20,8 @@ syntax="proto2";
 package doris;
 option java_package = "org.apache.doris.proto";
 
+import "types.proto";
+
 message PNodeStatistics {
     required int64 node_id = 1;
     optional int64 peak_memory_bytes = 2;
@@ -45,55 +47,19 @@ message PRowBatch {
     repeated int64 new_tuple_offsets = 6;
 }
 
-message PColumn {
-    enum DataType {
-        UINT8 = 0;
-        UINT16 = 1;
-        UINT32 = 2;
-        UINT64 = 3;
-        UINT128 = 4;
-        UINT256 = 5;
-        INT16 = 6;
-        INT8 = 7;
-        INT32 = 8;
-        INT64 = 9;
-        INT128 = 10;
-        INT256 = 11;
-        FLOAT32 = 12;
-        FLOAT64 = 13;
-        BOOLEAN = 14;
-        DATE = 15;
-        DATETIME = 16;
-        HLL = 17;
-        BITMAP = 18;
-        ARRAY = 19;
-        MAP = 20;
-        STRUCT =21;
-        STRING = 22;
-        DECIMAL32 = 23;
-        DECIMAL64 = 24;
-        DECIMAL128 = 25;
-        BYTES = 26;
-        NOTHING = 27;
-        UNKNOWN = 999;
-    }
+message PColumnMeta {
     message Decimal {
         optional uint32 precision = 1;
         optional uint32 scale = 2;
     }
     required string name = 1;
-    // origin column data_type
-    required DataType type = 2;
-    // serialized data type
-    repeated bool is_null = 3;
-    // store in plain text or in binary data
-    optional bytes binary = 4;
-    optional bool compressed = 5 [default = false];
-    optional Decimal decimal_param = 6;
+    required PDataType.Type type = 2;
+    optional bool is_nullable = 3 [default = false];
+    optional Decimal decimal_param = 4;
 }
 
 message PBlock {
-    optional uint64 num_rows = 1;
-    optional uint32 num_columns = 2;
-    repeated PColumn columns = 3;
+    repeated PColumnMeta column_metas = 1;
+    optional bytes column_values = 2;
+    optional bool compressed = 3 [default = false];
 }

--- a/gensrc/proto/data.proto
+++ b/gensrc/proto/data.proto
@@ -53,7 +53,7 @@ message PColumnMeta {
         optional uint32 scale = 2;
     }
     required string name = 1;
-    required PDataType.Type type = 2;
+    required PGenericType.TypeId type = 2;
     optional bool is_nullable = 3 [default = false];
     optional Decimal decimal_param = 4;
 }

--- a/gensrc/proto/types.proto
+++ b/gensrc/proto/types.proto
@@ -214,3 +214,4 @@ message PHandShakeResponse {
     optional PStatus status = 1;
     optional string hello = 2;
 }
+

--- a/gensrc/proto/types.proto
+++ b/gensrc/proto/types.proto
@@ -81,8 +81,8 @@ message PGenericType {
         INT64 = 9;
         INT128 = 10;
         INT256 = 11;
-        FLOAT = 12;
-        DOUBLE = 13;
+        FLOAT = 12; // map to Float32
+        DOUBLE = 13; // map to Float64
         BOOLEAN = 14;
         DATE = 15;
         DATETIME = 16;


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

This PR mainly changes:

1. Change the define of PBlock

    The new PBlock consists of a set of PColumnMeta and a binary buffer.
    The PColumnMeta records the metadata information of all columns in the Block,
    while the buffer stores the serialized binary data of all columns.
    
2. Refactor the serialize/deserizlie method of data type

    Rewrite the `serialize()/deserialize()` of IDataType. And also add
    a new method `get_uncompressed_serialized_bytes()` to get the total length
    of uncompressed serialized data of a column.
    
3. Rewrite the serialize/deserizlie method of Block

    Now, when serializing a Block to PBlock, it will first get the total length
    of uncompressed serialized data of all columns in this Block, and then allocate
    the memory to write the serialized data to the buffer.
    
4. Use brpc attachment to transmit the serialized column data

## Checklist(Required)

1. Does it affect the original behavior: (Yes)
    The way of transmitting serialized block has been changed 
2. Has unit tests been added: (Yes)
3. Has document been added or modified: (No Need)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (Yes)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
