### PR TITLE
[chore] Make build setting BUILD_META_TOOL optional.

### DIFF
--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -769,7 +769,7 @@ add_subdirectory(${SRC_DIR}/runtime)
 add_subdirectory(${SRC_DIR}/service)
 add_subdirectory(${SRC_DIR}/udf)
 
-if (${BUILD_META_TOOL} STREQUAL "ON")
+if (BUILD_META_TOOL AND BUILD_META_TOOL STREQUAL "ON")
     add_subdirectory(${SRC_DIR}/tools)
 endif()
 


### PR DESCRIPTION
# Proposed changes

Issue Number: close #7947 .

## Problem Summary:

Please refer to #7947 .

## Checklist(Required)

1. Does it affect the original behavior: No.
2. Has unit tests been added: No Need.
3. Has document been added or modified: No.
4. Does it need to update dependencies: No.
5. Are there any changes that cannot be rolled back: No.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
