### PR TITLE
[Bug][vec] make sure the mem address use in agg is align in proper way before use

### DIFF
--- a/be/src/vec/aggregate_functions/aggregate_function_distinct.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_distinct.h
@@ -202,6 +202,8 @@ public:
 
     size_t size_of_data() const override { return prefix_size + nested_func->size_of_data(); }
 
+    size_t align_of_data() const override { return nested_func->align_of_data(); }
+
     void create(AggregateDataPtr __restrict place) const override {
         new (place) Data;
         nested_func->create(get_nested_place(place));

--- a/be/src/vec/exec/vaggregation_node.h
+++ b/be/src/vec/exec/vaggregation_node.h
@@ -425,8 +425,7 @@ private:
     bool _is_streaming_preagg;
     Block _preagg_block = Block();
     bool _should_expand_hash_table = true;
-    char* _streaming_pre_agg_buffer = nullptr;
-    size_t _max_size_of_stream_pre_agg_buffer = 0;
+    std::vector<char*> _streaming_pre_places;
 
     /// Expose the minimum reduction factor to continue growing the hash tables.
     RuntimeProfile::Counter* preagg_streaming_ht_min_reduction_;


### PR DESCRIPTION
# Proposed changes

Issue Number: close #7958 

## Problem Summary:

Fix the core dump in distinct agg 

## Checklist(Required)

1. Does it affect the original behavior: (No)
2. Has unit tests been added: (No)
3. Has document been added or modified: (No Need)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (Yes)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
