### PR TITLE
[fix](demo) scala.Function1 used in java about compiling error:apply$mcVJ$sp(long)

### DIFF
--- a/samples/doris-demo/spark-demo/src/main/java/org/apache/doris/demo/spark/demo/hdfs/MyForeachPartitionFunction.java
+++ b/samples/doris-demo/spark-demo/src/main/java/org/apache/doris/demo/spark/demo/hdfs/MyForeachPartitionFunction.java
@@ -22,7 +22,7 @@ import com.alibaba.fastjson.JSONArray;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.doris.demo.spark.util.DorisStreamLoad;
 import org.apache.doris.demo.spark.vo.TestVo;
-import scala.Function1;
+import scala.runtime.AbstractFunction1;
 import scala.collection.AbstractIterator;
 
 import java.io.Serializable;
@@ -32,7 +32,7 @@ import java.util.Map;
 
 
 @Slf4j
-public class MyForeachPartitionFunction implements Function1, Serializable {
+public class MyForeachPartitionFunction extends AbstractFunction1 implements Serializable {
     DorisStreamLoad dorisStreamLoad;
 
     public MyForeachPartitionFunction(Map<String, Object> parameters) {


### PR DESCRIPTION
…long)

Fix MyForeachPartitionFunction.java:xxx:xxx
java: org.apache.doris.demo.spark.demo.hdfs.MyForeachPartitionFunction is not abstract and does not override abstract method apply$mcVJ$sp(long) in scala.Function1

# Proposed changes

Issue Number: close #7959

## Problem Summary:

Compile spark demo module would throw compile error, apply$mcVJ$sp(…

## Checklist(Required)

1. Does it affect the original behavior: (No)
2. Has unit tests been added: (No Need)
3. Has document been added or modified: (No Need)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
