### PR TITLE
(fix)[Lateral view] Solve the problem of not recognizing the lateral view on the view

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/InlineViewRef.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/InlineViewRef.java
@@ -108,9 +108,12 @@ public class InlineViewRef extends TableRef {
         // TODO(zc)
         // view_.getTableName().toString().toLowerCase(), view.getName().toLowerCase()
         if (view.isLocalView()) {
-            aliases_ = new String[] { view.getName() };
+            aliases_ = new String[]{view.getName()};
         } else {
-            aliases_ = new String[] { name.toString(), view.getName() };
+            aliases_ = new String[]{name.toString(), view.getName()};
+        }
+        if (origTblRef.getLateralViewRefs() != null) {
+            lateralViewRefs = (ArrayList<LateralViewRef>) origTblRef.getLateralViewRefs().clone();
         }
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/planner/TableFunctionPlanTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/planner/TableFunctionPlanTest.java
@@ -510,17 +510,15 @@ public class TableFunctionPlanTest {
         Assert.assertTrue(explainString.contains("table function: explode_split(`default_cluster:db1`.`table_for_view`.`k3`, ',') "));
     }
 
-    @Ignore
-    // errCode = 2, detailMessage = Unknown column 'e1' in 'table list'
+    @Test
     public void testLaterViewWithCTEBug() throws Exception {
         String sql = "with tmp as (select * from db1.table_for_view where k2=1) select k1,e1 from tmp lateral view explode_split(k3,',') tmp2 as e1;";
         String explainString = UtFrameUtils.getSQLPlanOrErrorMsg(ctx, sql, true);
         Assert.assertTrue(!explainString.contains("Unknown column 'e1' in 'table list'"));
     }
 
-    @Ignore
-    // errCode = 2, detailMessage = Unknown column 'e1' in 'table list'
-    public void testLaterViewUnknowColumnBug() throws Exception {
+    @Test
+    public void testLaterViewUnknownColumnBug() throws Exception {
         // test2
         String createViewStr = "create view db1.v2 (k1,k3) as select k1,k3 from db1.table_for_view;";
         CreateViewStmt createViewStmt = (CreateViewStmt) UtFrameUtils.parseAndAnalyzeStmt(createViewStr, ctx);

--- a/fe/fe-core/src/test/java/org/apache/doris/planner/TableFunctionPlanTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/planner/TableFunctionPlanTest.java
@@ -480,7 +480,7 @@ public class TableFunctionPlanTest {
     }
 
     @Test
-    public void testLaterViewWithView() throws Exception {
+    public void testLateralViewWithView() throws Exception {
         // test 1
         String createViewStr = "create view db1.v1 (k1,e1) as select k1,e1 from db1.table_for_view lateral view explode_split(k3,',') tmp as e1;";
         CreateViewStmt createViewStmt = (CreateViewStmt) UtFrameUtils.parseAndAnalyzeStmt(createViewStr, ctx);
@@ -495,7 +495,7 @@ public class TableFunctionPlanTest {
     }
 
     @Test
-    public void testLaterViewWithWhere() throws Exception {
+    public void testLateralViewWithWhere() throws Exception {
         String sql = "select k1,e1 from db1.table_for_view lateral view explode_split(k3,',') tmp as e1 where k1 in (select k2 from db1.table_for_view);";
         String explainString = UtFrameUtils.getSQLPlanOrErrorMsg(ctx, sql, true);
         Assert.assertTrue(explainString.contains("join op: LEFT SEMI JOIN (BROADCAST)"));
@@ -504,21 +504,21 @@ public class TableFunctionPlanTest {
     }
 
     @Test
-    public void testLaterViewWithCTE() throws Exception {
+    public void testLateralViewWithCTE() throws Exception {
         String sql = "with tmp as (select k1,e1 from db1.table_for_view lateral view explode_split(k3,',') tmp2 as e1) select * from tmp;";
         String explainString = UtFrameUtils.getSQLPlanOrErrorMsg(ctx, sql, true);
         Assert.assertTrue(explainString.contains("table function: explode_split(`default_cluster:db1`.`table_for_view`.`k3`, ',') "));
     }
 
     @Test
-    public void testLaterViewWithCTEBug() throws Exception {
+    public void testLateralViewWithCTEBug() throws Exception {
         String sql = "with tmp as (select * from db1.table_for_view where k2=1) select k1,e1 from tmp lateral view explode_split(k3,',') tmp2 as e1;";
         String explainString = UtFrameUtils.getSQLPlanOrErrorMsg(ctx, sql, true);
         Assert.assertTrue(!explainString.contains("Unknown column 'e1' in 'table list'"));
     }
 
     @Test
-    public void testLaterViewUnknownColumnBug() throws Exception {
+    public void testLateralViewUnknownColumnBug() throws Exception {
         // test2
         String createViewStr = "create view db1.v2 (k1,k3) as select k1,k3 from db1.table_for_view;";
         CreateViewStmt createViewStmt = (CreateViewStmt) UtFrameUtils.parseAndAnalyzeStmt(createViewStr, ctx);


### PR DESCRIPTION
# Proposed changes

Issue Number: close #7823

## Problem Summary:

If the tableRef behind represents a CTE or a view,
the tableRef will be reset during semantic parsing.
The new tableRef needs to inherit the lateral view property of the origin tableRef
to ensure that the lateral view is not accidentally lost during parsing.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)
