### PR TITLE
[vectorized] [join] eliminate branch prediction & opt hash join performance

### DIFF
--- a/be/src/vec/exec/join/join_op.h
+++ b/be/src/vec/exec/join/join_op.h
@@ -26,15 +26,17 @@ namespace doris::vectorized {
 struct RowRef {
     using SizeT = uint32_t; /// Do not use size_t cause of memory economy
 
-    const Block* block = nullptr;
+    // const Block* block = nullptr;
     SizeT row_num = 0;
+
+    uint8_t block_index = 0;
     // Use in right join to mark row is visited
     // TODO: opt the varaible to use it only need
     bool visited = false;
 
     RowRef() {}
-    RowRef(const Block* block_ptr, size_t row_num_count, bool is_visited = false)
-            : block(block_ptr), row_num(row_num_count), visited(is_visited) {}
+    RowRef(uint8_t block_index, size_t row_num_count, bool is_visited = false)
+            : row_num(row_num_count), block_index(block_index), visited(is_visited) {}
 };
 
 /// Single linked list of references to rows. Used for ALL JOINs (non-unique JOINs)
@@ -115,7 +117,7 @@ struct RowRefList : RowRef {
     };
 
     RowRefList() {}
-    RowRefList(const Block* block_, size_t row_num_) : RowRef(block_, row_num_) {}
+    RowRefList(uint8_t block_index, size_t row_num_) : RowRef(block_index, row_num_) {}
 
     ForwardIterator begin() { return ForwardIterator(this); }
     ForwardIterator end() { return ForwardIterator::end(); }

--- a/be/src/vec/exec/join/join_op.h
+++ b/be/src/vec/exec/join/join_op.h
@@ -29,13 +29,9 @@ struct RowRef {
     // const Block* block = nullptr;
     SizeT row_num = 0;
 
-    // Use in right join to mark row is visited
-    // TODO: opt the varaible to use it only need
-    bool visited = false;
-
     RowRef() {}
-    RowRef(size_t row_num_count, bool is_visited = false)
-            : row_num(row_num_count), visited(is_visited) {}
+    RowRef(size_t row_num_count)
+            : row_num(row_num_count) {}
 };
 
 /// Single linked list of references to rows. Used for ALL JOINs (non-unique JOINs)

--- a/be/src/vec/exec/join/join_op.h
+++ b/be/src/vec/exec/join/join_op.h
@@ -29,14 +29,13 @@ struct RowRef {
     // const Block* block = nullptr;
     SizeT row_num = 0;
 
-    uint8_t block_index = 0;
     // Use in right join to mark row is visited
     // TODO: opt the varaible to use it only need
     bool visited = false;
 
     RowRef() {}
-    RowRef(uint8_t block_index, size_t row_num_count, bool is_visited = false)
-            : row_num(row_num_count), block_index(block_index), visited(is_visited) {}
+    RowRef(size_t row_num_count, bool is_visited = false)
+            : row_num(row_num_count), visited(is_visited) {}
 };
 
 /// Single linked list of references to rows. Used for ALL JOINs (non-unique JOINs)
@@ -117,7 +116,7 @@ struct RowRefList : RowRef {
     };
 
     RowRefList() {}
-    RowRefList(uint8_t block_index, size_t row_num_) : RowRef(block_index, row_num_) {}
+    RowRefList(size_t row_num_) : RowRef(row_num_) {}
 
     ForwardIterator begin() { return ForwardIterator(this); }
     ForwardIterator end() { return ForwardIterator::end(); }

--- a/be/src/vec/exec/join/vhash_join_node.cpp
+++ b/be/src/vec/exec/join/vhash_join_node.cpp
@@ -42,14 +42,14 @@ using ProfileCounter = RuntimeProfile::Counter;
 template <class HashTableContext, bool ignore_null, bool build_unique>
 struct ProcessHashTableBuild {
     ProcessHashTableBuild(int rows, Block& acquired_block, ColumnRawPtrs& build_raw_ptrs,
-                          HashJoinNode* join_node, int batch_size, uint8_t blk_ind)
+                          HashJoinNode* join_node, int batch_size, uint8_t offset)
             : _rows(rows),
               _skip_rows(0),
               _acquired_block(acquired_block),
               _build_raw_ptrs(build_raw_ptrs),
               _join_node(join_node),
               _batch_size(batch_size),
-              _blk_ind(blk_ind) {}
+              _offset(offset) {}
 
     Status operator()(HashTableContext& hash_table_ctx, ConstNullMapPtr null_map,
                       bool has_runtime_filter) {
@@ -89,14 +89,14 @@ struct ProcessHashTableBuild {
             }
 
             if (emplace_result.is_inserted()) {
-                new (&emplace_result.get_mapped()) Mapped({_blk_ind, k});
+                new (&emplace_result.get_mapped()) Mapped({_offset+k});
                 if (has_runtime_filter) {
                     inserted_rows.push_back(k);
                 }
             } else {
                 if constexpr (!build_unique) {
                     /// The first element of the list is stored in the value of the hash table, the rest in the pool.
-                    emplace_result.get_mapped().insert({_blk_ind, k}, _join_node->_arena);
+                    emplace_result.get_mapped().insert({_offset+k}, _join_node->_arena);
                     if (has_runtime_filter) {
                         inserted_rows.push_back(k);
                     }
@@ -119,7 +119,7 @@ private:
     ColumnRawPtrs& _build_raw_ptrs;
     HashJoinNode* _join_node;
     int _batch_size;
-    uint8_t _blk_ind;
+    uint32_t _offset;
 };
 
 template <class HashTableContext>
@@ -163,6 +163,7 @@ struct ProcessHashTableProbe {
               _batch_size(batch_size),
               _probe_rows(probe_rows),
               _build_block(join_node->_build_block),
+              _blockptr(join_node->_blockptr),
               _probe_block(join_node->_probe_block),
               _probe_index(join_node->_probe_index),
               _probe_raw_ptrs(join_node->_probe_columns),
@@ -182,7 +183,7 @@ struct ProcessHashTableProbe {
         std::vector<uint32_t> items_counts(_probe_rows);
         auto& mcol = mutable_block.mutable_columns();
         int current_offset = 0;
-        std::vector<std::pair<uint8_t, uint32_t>> _build_index;
+        std::vector<uint32_t> _build_index;
         _build_index.reserve(1.2 * _batch_size);
 
         for (; _probe_index < _probe_rows;) {
@@ -204,14 +205,14 @@ struct ProcessHashTableProbe {
                     // We should rethink whether to use this iterator mode in the future. Now just opt the one row case
                     if (mapped.get_row_count() == 1) {
                         ++repeat_count;
-                        _build_index.emplace_back(std::make_pair(mapped.block_index, mapped.row_num));
+                        _build_index.emplace_back(mapped.row_num);
                     } else {
                         // prefetch is more useful while matching to multiple rows
                         if (_probe_index + 2 < _probe_rows)
                             key_getter.prefetch(hash_table_ctx.hash_table, _probe_index + 2, _arena);
                         for (auto it = mapped.begin(); it.ok(); ++it) {
                             ++repeat_count;
-                            _build_index.emplace_back(std::make_pair(it->block_index, it->row_num));
+                            _build_index.emplace_back(it->row_num);
                         }
                     }
                 }
@@ -238,7 +239,7 @@ struct ProcessHashTableProbe {
                         if constexpr (JoinOpType::value != TJoinOp::RIGHT_ANTI_JOIN && 
                                       JoinOpType::value != TJoinOp::RIGHT_SEMI_JOIN) {
                             ++repeat_count;
-                            _build_index.emplace_back(std::make_pair(mapped.block_index, mapped.row_num));
+                            _build_index.emplace_back(mapped.row_num);
                         }
                     } else {
                         for (auto it = mapped.begin(); it.ok(); ++it) {
@@ -247,7 +248,7 @@ struct ProcessHashTableProbe {
                             if constexpr (JoinOpType::value != TJoinOp::RIGHT_ANTI_JOIN && 
                                           JoinOpType::value != TJoinOp::RIGHT_SEMI_JOIN) {
                                 ++repeat_count;
-                                _build_index.emplace_back(std::make_pair(it->block_index, it->row_num));
+                                _build_index.emplace_back(it->row_num);
                             }
                             it->visited = true;
                         }
@@ -274,14 +275,14 @@ struct ProcessHashTableProbe {
             for (int i = 0; i < _right_col_len; i++) {
                     auto &column = *_build_block[0].get_by_position(i).column;
                 for (int j = 0; j < _build_index.size(); j++) {
-                    mcol[i + _right_col_idx]->insert_from(column, _build_index[j].second);
+                    mcol[i + _right_col_idx]->insert_from(column, _build_index[j]);
                 }
             }
         } else {
             for (int i = 0; i < _right_col_len; i++) {
                 for (int j = 0; j < _build_index.size(); j++) {
-                    auto &column = *_build_block[_build_index[j].first].get_by_position(i).column;
-                    mcol[i + _right_col_idx]->insert_from(column, _build_index[j].second);
+                    auto &column = *_blockptr[_build_index[j]]->get_by_position(i).column;
+                    mcol[i + _right_col_idx]->insert_from(column, _build_index[j]);
                 }
             }
         }
@@ -318,7 +319,7 @@ struct ProcessHashTableProbe {
         std::vector<bool> same_to_prev;
         same_to_prev.reserve(1.2 * _batch_size);
 
-        std::vector<std::pair<uint8_t, uint32_t>> _build_index;
+        std::vector<uint32_t> _build_index;
         _build_index.reserve(1.2 * _batch_size);
 
         int current_offset = 0;
@@ -343,7 +344,7 @@ struct ProcessHashTableProbe {
 
                 for (auto it = mapped.begin(); it.ok(); ++it) {
                     ++current_offset;
-                    _build_index.emplace_back(std::make_pair(it->block_index, it->row_num));
+                    _build_index.emplace_back(it->row_num);
                     visited_map.emplace_back(&it->visited);
                 }
                 same_to_prev.emplace_back(false);
@@ -386,8 +387,8 @@ struct ProcessHashTableProbe {
         // insert all match build rows
         for (int i = 0; i < _right_col_len; i++) {
             for (int j = 0; j < _build_index.size(); j++) {
-                auto &column = *_build_block[_build_index[j].first].get_by_position(i).column;
-                mcol[i + _right_col_idx]->insert_from(column, _build_index[j].second);
+                auto &column = *_blockptr[_build_index[j]]->get_by_position(i).column;
+                mcol[i + _right_col_idx]->insert_from(column, _build_index[j]);
             }
         }
         output_block->swap(mutable_block.to_block());
@@ -511,10 +512,10 @@ struct ProcessHashTableProbe {
         auto& iter = hash_table_ctx.iter;
         auto block_size = 0;
 
-        auto insert_from_hash_table = [&](uint8_t block_index, uint32_t row_num) {
+        auto insert_from_hash_table = [&]( uint32_t row_num) {
             block_size++;
             for (size_t j = 0; j < _right_col_len; ++j) {
-                auto& column = *_build_block[block_index].get_by_position(j).column;
+                auto& column = *_blockptr[row_num]->get_by_position(j).column;
                 mcol[j + _right_col_idx]->insert_from(column, row_num);
             }
         };
@@ -524,10 +525,10 @@ struct ProcessHashTableProbe {
             for (auto it = mapped.begin(); it.ok(); ++it) {
                 if constexpr (JoinOpType::value == TJoinOp::RIGHT_SEMI_JOIN) {
                     if (it->visited)
-                        insert_from_hash_table(it->block_index, it->row_num);
+                        insert_from_hash_table(it->row_num);
                 } else {
                     if (!it->visited)
-                        insert_from_hash_table(it->block_index, it->row_num);
+                        insert_from_hash_table(it->row_num);
                 }
             }
         }
@@ -556,6 +557,7 @@ private:
     const int _batch_size;
     const size_t _probe_rows;
     const std::vector<Block>& _build_block;
+    const std::vector<Block*>& _blockptr;
     const Block& _probe_block;
     int& _probe_index;
     ColumnRawPtrs& _probe_raw_ptrs;
@@ -896,8 +898,10 @@ Status HashJoinNode::_hash_table_build(RuntimeState* state) {
             for (int i = 0; i < right_col_len; ++i) {
                 _build_block.emplace_back(Block({ColumnWithTypeAndName(std::move(columns[i]),_right_table_data_types[i], "")}));
             }
-            RETURN_IF_ERROR(_process_build_block(state, _build_block[index], index));
+
+            RETURN_IF_ERROR(_process_build_block(state, _build_block[index], _blockptr.size()));
             RETURN_IF_LIMIT_EXCEEDED(state, "Hash join, while constructing the hash table.");
+            _blockptr.insert(_blockptr.end(), _build_block[index].rows(), &_build_block[index]);
             ++index;
             for (int i = 0; i < right_col_len; i++) {
                 columns[i] = _right_table_data_types[i]->create_column();
@@ -909,8 +913,9 @@ Status HashJoinNode::_hash_table_build(RuntimeState* state) {
         _build_block.emplace_back(Block({ColumnWithTypeAndName(std::move(columns[i]),_right_table_data_types[i], "")}));
     }
 
-    RETURN_IF_ERROR(_process_build_block(state, _build_block[index], index));
+    RETURN_IF_ERROR(_process_build_block(state, _build_block[index], _blockptr.size()));
     RETURN_IF_LIMIT_EXCEEDED(state, "Hash join, while constructing the hash table.");
+    _blockptr.insert(_blockptr.end(), _build_block[index].rows(), &_build_block[index]);
 
     return std::visit(
             [&](auto&& arg) -> Status {
@@ -1010,7 +1015,7 @@ Status HashJoinNode::extract_probe_join_column(Block& block, NullMap& null_map,
     return Status::OK();
 }
 
-Status HashJoinNode::_process_build_block(RuntimeState* state, Block& block, uint8_t blk_ind) {
+Status HashJoinNode::_process_build_block(RuntimeState* state, Block& block, uint32_t offset) {
     SCOPED_TIMER(_build_table_timer);
     size_t rows = block.rows();
     if (rows == 0) {
@@ -1048,7 +1053,7 @@ Status HashJoinNode::_process_build_block(RuntimeState* state, Block& block, uin
                 if constexpr (!std::is_same_v<HashTableCtxType, std::monostate>) {
 #define CALL_BUILD_FUNCTION(HAS_NULL, BUILD_UNIQUE)                                           \
     ProcessHashTableBuild<HashTableCtxType, HAS_NULL, BUILD_UNIQUE> hash_table_build_process( \
-            rows, block, raw_ptrs, this, state->batch_size(), blk_ind);                       \
+            rows, block, raw_ptrs, this, state->batch_size(), offset);                       \
     st = hash_table_build_process(arg, &null_map_val, has_runtime_filter);
                     if (std::pair {has_null, _build_unique} == std::pair {true, true}) {
                         CALL_BUILD_FUNCTION(true, true);

--- a/be/src/vec/exec/join/vhash_join_node.h
+++ b/be/src/vec/exec/join/vhash_join_node.h
@@ -204,6 +204,7 @@ private:
     AcquireList<Block> _acquire_list;
 
     std::vector<Block> _build_block;
+    std::vector<Block*> _blockptr;
     Block _probe_block;
     ColumnRawPtrs _probe_columns;
     ColumnUInt8::MutablePtr _null_map_column;
@@ -230,7 +231,7 @@ private:
 
 private:
     Status _hash_table_build(RuntimeState* state);
-    Status _process_build_block(RuntimeState* state, Block& block, uint8_t blk_ind);
+    Status _process_build_block(RuntimeState* state, Block& block, uint32_t offset);
 
     Status extract_build_join_column(Block& block, NullMap& null_map, ColumnRawPtrs& raw_ptrs,
                                      bool& ignore_null, RuntimeProfile::Counter& expr_call_timer);

--- a/be/src/vec/exec/join/vhash_join_node.h
+++ b/be/src/vec/exec/join/vhash_join_node.h
@@ -203,6 +203,7 @@ private:
     HashTableVariants _hash_table_variants;
     AcquireList<Block> _acquire_list;
 
+    std::vector<Block> _build_block;
     Block _probe_block;
     ColumnRawPtrs _probe_columns;
     ColumnUInt8::MutablePtr _null_map_column;
@@ -229,7 +230,7 @@ private:
 
 private:
     Status _hash_table_build(RuntimeState* state);
-    Status _process_build_block(RuntimeState* state, Block& block);
+    Status _process_build_block(RuntimeState* state, Block& block, uint8_t blk_ind);
 
     Status extract_build_join_column(Block& block, NullMap& null_map, ColumnRawPtrs& raw_ptrs,
                                      bool& ignore_null, RuntimeProfile::Counter& expr_call_timer);

--- a/be/src/vec/exec/join/vhash_join_node.h
+++ b/be/src/vec/exec/join/vhash_join_node.h
@@ -205,6 +205,7 @@ private:
 
     std::vector<Block> _build_block;
     std::vector<Block*> _blockptr;
+    std::vector<uint8_t> _build_block_visited;
     Block _probe_block;
     ColumnRawPtrs _probe_columns;
     ColumnUInt8::MutablePtr _null_map_column;

--- a/be/src/vec/exec/vset_operation_node.cpp
+++ b/be/src/vec/exec/vset_operation_node.cpp
@@ -54,7 +54,7 @@ struct HashTableBuild {
             }
 
             if (emplace_result.is_inserted()) { //only inserted once as the same key, others skip
-                new (&emplace_result.get_mapped()) Mapped({0, k});
+                new (&emplace_result.get_mapped()) Mapped({k});
                 _operation_node->_valid_element_in_hash_tbl++;
             }
         }

--- a/be/src/vec/exec/vset_operation_node.cpp
+++ b/be/src/vec/exec/vset_operation_node.cpp
@@ -256,6 +256,9 @@ Status VSetOperationNode::hash_table_build(RuntimeState* state) {
         _build_block.insert({std::move(columns[i]),_left_table_data_types[i], ""});
     }
 
+    // inner join && left semi && left anti do not need visited
+    _build_block_visited.assign(_build_block.rows(), (uint8_t)0);
+
     RETURN_IF_ERROR(process_build_block(_build_block));
     RETURN_IF_LIMIT_EXCEEDED(state, "Set Operation Node, while constructing the hash table.");
     return Status::OK();

--- a/be/src/vec/exec/vset_operation_node.h
+++ b/be/src/vec/exec/vset_operation_node.h
@@ -81,6 +81,7 @@ protected:
     //record insert column id during probe
     std::vector<uint16_t> _probe_column_inserted_id;
 
+    Block _build_block;
     Block _probe_block;
     ColumnRawPtrs _probe_columns;
     std::vector<MutableColumnPtr> _mutable_cols;
@@ -150,6 +151,7 @@ struct HashTableProbe {
               _left_table_data_types(operation_node->_left_table_data_types),
               _batch_size(batch_size),
               _probe_rows(probe_rows),
+              _build_block(operation_node->_build_block),
               _probe_block(operation_node->_probe_block),
               _probe_index(operation_node->_probe_index),
               _num_rows_returned(operation_node->_num_rows_returned),
@@ -184,7 +186,7 @@ struct HashTableProbe {
 
     void add_result_columns(RowRefList& value, int& block_size) {
         for (auto idx = _build_col_idx.begin(); idx != _build_col_idx.end(); ++idx) {
-            auto& column = *value.begin()->block->get_by_position(idx->first).column;
+            auto& column = *_build_block.get_by_position(idx->first).column;
             _mutable_cols[idx->second]->insert_from(column, value.begin()->row_num);
         }
         block_size++;
@@ -230,6 +232,7 @@ private:
     const DataTypes& _left_table_data_types;
     const int _batch_size;
     const size_t _probe_rows;
+    const Block& _build_block;
     const Block& _probe_block;
     int& _probe_index;
     int64_t& _num_rows_returned;


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

Opt hash join performance

1. Eliminate hashjoin probe phase branch perdiction by make_bool_variant function in compile time。
especially for innerjoin (most scenes)， left semi join left anti join(mostly used).
2. Reduce mapped memory usage，the hash map traverse mapped is time consuming，so delete the block pointer（8 Bytes）is cache friendly.

After opt, the performance is greatly improved。


My test:(SSB benchmark)
set runime_filter_type=0;
set parallel_fragment_exec_instance_num = 1;
1. inner join: 
(before opt)
MySQL [ssb1]> SELECT count(c_custkey) FROM lineorder,customer WHERE lo_custkey = c_custkey;
+--------------------+
| count(`c_custkey`) |
+--------------------+
|          600037902 |
+--------------------+
1 row in set (43.25 sec)
(after opt)
MySQL [ssb1]> SELECT count(c_custkey) FROM lineorder,customer WHERE lo_custkey = c_custkey;
+--------------------+
| count(`c_custkey`) |
+--------------------+
|          600037902 |
+--------------------+
1 row in set (30.25 sec)

2. ssb q3.3
(before opt)
MySQL [ssb1]> SELECT c_city, s_city, d_year, SUM(lo_revenue) AS  REVENUE FROM customer, lineorder, supplier, dates WHERE lo_custkey = c_custkey AND lo_suppkey = s_suppkey AND  lo_orderdate = d_datekey AND  (c_city='UNITED KI1' OR c_city='UNITED KI5') AND (s_city='UNITED KI1' OR s_city='UNITED KI5') AND d_year >= 1992 AND d_year <= 1997 GROUP BY c_city, s_city, d_year ORDER BY d_year ASC,  REVENUE DESC;
+------------+------------+--------+------------+
| c_city     | s_city     | d_year | REVENUE    |
+------------+------------+--------+------------+
| UNITED KI1 | UNITED KI1 |   1992 | 5776096629 |
| UNITED KI5 | UNITED KI1 |   1992 | 5555883901 |
| UNITED KI5 | UNITED KI5 |   1992 | 5348705805 |
| UNITED KI1 | UNITED KI5 |   1992 | 5326870427 |
| UNITED KI1 | UNITED KI1 |   1993 | 5892974670 |
| UNITED KI1 | UNITED KI5 |   1993 | 5490859451 |
| UNITED KI5 | UNITED KI1 |   1993 | 5468354303 |
| UNITED KI5 | UNITED KI5 |   1993 | 5089909647 |
| UNITED KI5 | UNITED KI1 |   1994 | 5437315108 |
| UNITED KI1 | UNITED KI1 |   1994 | 5348775917 |
| UNITED KI5 | UNITED KI5 |   1994 | 5310936695 |
| UNITED KI1 | UNITED KI5 |   1994 | 5237461110 |
| UNITED KI1 | UNITED KI1 |   1995 | 5737551920 |
| UNITED KI5 | UNITED KI5 |   1995 | 5657584590 |
| UNITED KI5 | UNITED KI1 |   1995 | 5260093556 |
| UNITED KI1 | UNITED KI5 |   1995 | 5213763257 |
| UNITED KI5 | UNITED KI1 |   1996 | 5522325005 |
| UNITED KI1 | UNITED KI1 |   1996 | 5451244409 |
| UNITED KI5 | UNITED KI5 |   1996 | 5231759057 |
| UNITED KI1 | UNITED KI5 |   1996 | 5203962897 |
| UNITED KI1 | UNITED KI1 |   1997 | 5340760807 |
| UNITED KI5 | UNITED KI1 |   1997 | 5295685214 |
| UNITED KI1 | UNITED KI5 |   1997 | 5188428156 |
| UNITED KI5 | UNITED KI5 |   1997 | 5024634475 |
+------------+------------+--------+------------+
24 rows in set (32.15 sec)
(after opt): 
MySQL [ssb1]> SELECT c_city, s_city, d_year, SUM(lo_revenue) AS  REVENUE FROM customer, lineorder, supplier, dates WHERE lo_custkey = c_custkey AND lo_suppkey = s_suppkey AND  lo_orderdate = d_datekey AND  (c_city='UNITED KI1' OR c_city='UNITED KI5') AND (s_city='UNITED KI1' OR s_city='UNITED KI5') AND d_year >= 1992 AND d_year <= 1997 GROUP BY c_city, s_city, d_year ORDER BY d_year ASC,  REVENUE DESC;
+------------+------------+--------+------------+
| c_city     | s_city     | d_year | REVENUE    |
+------------+------------+--------+------------+
| UNITED KI1 | UNITED KI1 |   1992 | 5776096629 |
| UNITED KI5 | UNITED KI1 |   1992 | 5555883901 |
| UNITED KI5 | UNITED KI5 |   1992 | 5348705805 |
| UNITED KI1 | UNITED KI5 |   1992 | 5326870427 |
| UNITED KI1 | UNITED KI1 |   1993 | 5892974670 |
| UNITED KI1 | UNITED KI5 |   1993 | 5490859451 |
| UNITED KI5 | UNITED KI1 |   1993 | 5468354303 |
| UNITED KI5 | UNITED KI5 |   1993 | 5089909647 |
| UNITED KI5 | UNITED KI1 |   1994 | 5437315108 |
| UNITED KI1 | UNITED KI1 |   1994 | 5348775917 |
| UNITED KI5 | UNITED KI5 |   1994 | 5310936695 |
| UNITED KI1 | UNITED KI5 |   1994 | 5237461110 |
| UNITED KI1 | UNITED KI1 |   1995 | 5737551920 |
| UNITED KI5 | UNITED KI5 |   1995 | 5657584590 |
| UNITED KI5 | UNITED KI1 |   1995 | 5260093556 |
| UNITED KI1 | UNITED KI5 |   1995 | 5213763257 |
| UNITED KI5 | UNITED KI1 |   1996 | 5522325005 |
| UNITED KI1 | UNITED KI1 |   1996 | 5451244409 |
| UNITED KI5 | UNITED KI5 |   1996 | 5231759057 |
| UNITED KI1 | UNITED KI5 |   1996 | 5203962897 |
| UNITED KI1 | UNITED KI1 |   1997 | 5340760807 |
| UNITED KI5 | UNITED KI1 |   1997 | 5295685214 |
| UNITED KI1 | UNITED KI5 |   1997 | 5188428156 |
| UNITED KI5 | UNITED KI5 |   1997 | 5024634475 |
+------------+------------+--------+------------+
24 rows in set (11.95 sec)
----------------------------------------------------

## Checklist(Required)

1. Does it affect the original behavior: (No)
2. Has unit tests been added: (No Need)
3. Has document been added or modified: (No Need)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
