### PR TITLE
[improvement](log) Add query id info in error log for easy tracking

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/QueryStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/QueryStmt.java
@@ -23,11 +23,14 @@ import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.ErrorReport;
 import org.apache.doris.common.UserException;
 import org.apache.doris.rewrite.ExprRewriter;
+
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -177,8 +180,8 @@ public abstract class QueryStmt extends StatementBase {
     private void analyzeLimit(Analyzer analyzer) throws AnalysisException {
         // TODO chenhao
         if (limitElement.getOffset() > 0 && !hasOrderByClause()) {
-          throw new AnalysisException("OFFSET requires an ORDER BY clause: " +
-                  limitElement.toSql().trim());
+            throw new AnalysisException("OFFSET requires an ORDER BY clause: " +
+                    limitElement.toSql().trim());
         }
         limitElement.analyze(analyzer);
     }
@@ -213,7 +216,7 @@ public abstract class QueryStmt extends StatementBase {
 
         List<TableRef> tblRefs = Lists.newArrayList();
         collectTableRefs(tblRefs);
-        for (TableRef tblRef: tblRefs) {
+        for (TableRef tblRef : tblRefs) {
             if (absoluteRef == null && !tblRef.isRelative()) absoluteRef = tblRef;
             /*if (tblRef.isCorrelated()) {
              *   
@@ -313,19 +316,21 @@ public abstract class QueryStmt extends StatementBase {
         // are ignored.
         if (!hasLimit() && !hasOffset() && (!analyzer.isRootAnalyzer() || fromInsert)) {
             evaluateOrderBy = false;
-            // Return a warning that the order by was ignored.
-            StringBuilder strBuilder = new StringBuilder();
-            strBuilder.append("Ignoring ORDER BY clause without LIMIT or OFFSET: ");
-            strBuilder.append("ORDER BY ");
-            strBuilder.append(orderByElements.get(0).toSql());
-            for (int i = 1; i < orderByElements.size(); ++i) {
-                strBuilder.append(", ").append(orderByElements.get(i).toSql());
+            if (LOG.isDebugEnabled()) {
+                // Return a warning that the order by was ignored.
+                StringBuilder strBuilder = new StringBuilder();
+                strBuilder.append("Ignoring ORDER BY clause without LIMIT or OFFSET: ");
+                strBuilder.append("ORDER BY ");
+                strBuilder.append(orderByElements.get(0).toSql());
+                for (int i = 1; i < orderByElements.size(); ++i) {
+                    strBuilder.append(", ").append(orderByElements.get(i).toSql());
+                }
+                strBuilder.append(".\nAn ORDER BY appearing in a view, subquery, union operand, ");
+                strBuilder.append("or an insert/ctas statement has no effect on the query result ");
+                strBuilder.append("unless a LIMIT and/or OFFSET is used in conjunction ");
+                strBuilder.append("with the ORDER BY.");
+                LOG.debug(strBuilder.toString());
             }
-            strBuilder.append(".\nAn ORDER BY appearing in a view, subquery, union operand, ");
-            strBuilder.append("or an insert/ctas statement has no effect on the query result ");
-            strBuilder.append("unless a LIMIT and/or OFFSET is used in conjunction ");
-            strBuilder.append("with the ORDER BY.");
-            LOG.info(strBuilder.toString());
         } else {
             evaluateOrderBy = true;
         }
@@ -378,7 +383,7 @@ public abstract class QueryStmt extends StatementBase {
      * exprs is an ambiguous alias.
      */
     protected Expr getFirstAmbiguousAlias(List<Expr> exprs) {
-        for (Expr exp: exprs) {
+        for (Expr exp : exprs) {
             if (ambiguousAliasList.contains(exp)) return exp;
         }
         return null;
@@ -453,13 +458,15 @@ public abstract class QueryStmt extends StatementBase {
      * collect all exprs of a QueryStmt to a map
      * @param exprMap
      */
-    public void collectExprs(Map<String, Expr> exprMap) {}
+    public void collectExprs(Map<String, Expr> exprMap) {
+    }
 
     /**
      * put all rewritten exprs back to the ori QueryStmt
      * @param rewrittenExprMap
      */
-    public void putBackExprs(Map<String, Expr> rewrittenExprMap) {}
+    public void putBackExprs(Map<String, Expr> rewrittenExprMap) {
+    }
 
 
     @Override
@@ -551,14 +558,29 @@ public abstract class QueryStmt extends StatementBase {
         orderByElements = null;
     }
 
-    public void setWithClause(WithClause withClause) { this.withClause_ = withClause; }
-    public boolean hasWithClause() { return withClause_ != null; }
-    public WithClause getWithClause() { return withClause_; }
+    public void setWithClause(WithClause withClause) {
+        this.withClause_ = withClause;
+    }
+
+    public boolean hasWithClause() {
+        return withClause_ != null;
+    }
+
+    public WithClause getWithClause() {
+        return withClause_;
+    }
+
     public boolean hasOrderByClause() {
         return orderByElements != null;
     }
-    public boolean hasLimit() { return limitElement != null && limitElement.hasLimit(); }
-    public boolean hasOffset() { return limitElement != null && limitElement.hasOffset(); }
+
+    public boolean hasLimit() {
+        return limitElement != null && limitElement.hasLimit();
+    }
+
+    public boolean hasOffset() {
+        return limitElement != null && limitElement.hasOffset();
+    }
 
     public long getLimit() {
         return limitElement.getLimit();
@@ -601,7 +623,11 @@ public abstract class QueryStmt extends StatementBase {
     public SortInfo getSortInfo() {
         return sortInfo;
     }
-    public boolean evaluateOrderBy() { return evaluateOrderBy; }
+
+    public boolean evaluateOrderBy() {
+        return evaluateOrderBy;
+    }
+
     public ArrayList<Expr> getResultExprs() {
         return resultExprs;
     }
@@ -650,7 +676,7 @@ public abstract class QueryStmt extends StatementBase {
      */
     protected void materializeSlots(Analyzer analyzer, List<Expr> exprs) {
         List<SlotId> slotIds = Lists.newArrayList();
-        for (Expr e: exprs) {
+        for (Expr e : exprs) {
             e.getIds(null, slotIds);
         }
         analyzer.getDescTbl().markSlotsMaterialized(slotIds);
@@ -665,7 +691,7 @@ public abstract class QueryStmt extends StatementBase {
         if (orderByElements == null) return null;
         ArrayList<OrderByElement> result =
                 Lists.newArrayListWithCapacity(orderByElements.size());
-        for (OrderByElement o: orderByElements) result.add(o.clone());
+        for (OrderByElement o : orderByElements) result.add(o.clone());
         return result;
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/nio/AcceptListener.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/nio/AcceptListener.java
@@ -22,6 +22,7 @@ import org.apache.doris.mysql.MysqlProto;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.ConnectProcessor;
 import org.apache.doris.qe.ConnectScheduler;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.xnio.ChannelListener;
@@ -48,7 +49,7 @@ public class AcceptListener implements ChannelListener<AcceptingChannel<StreamCo
             if (connection == null) {
                 return;
             }
-            LOG.info("Connection established. remote={}", connection.getPeerAddress());
+            LOG.debug("Connection established. remote={}", connection.getPeerAddress());
             // connection has been established, so need to call context.cleanup()
             // if exception happens.
             NConnectContext context = new NConnectContext(connection);

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectContext.java
@@ -22,6 +22,7 @@ import org.apache.doris.catalog.Catalog;
 import org.apache.doris.catalog.Database;
 import org.apache.doris.cluster.ClusterNamespace;
 import org.apache.doris.common.UserException;
+import org.apache.doris.common.util.DebugUtil;
 import org.apache.doris.mysql.MysqlCapability;
 import org.apache.doris.mysql.MysqlChannel;
 import org.apache.doris.mysql.MysqlCommand;
@@ -538,5 +539,9 @@ public class ConnectContext {
             row.add("");
             return row;
         }
+    }
+
+    public String getQueryIdentifier() {
+        return "stmt[" + stmtId + ", " + DebugUtil.printId(queryId) + "]";
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -364,7 +364,7 @@ public class StmtExecutor implements ProfileWriter {
                         if (scanNode instanceof OlapScanNode) {
                             OlapScanNode olapScanNode = (OlapScanNode) scanNode;
                             Catalog.getCurrentCatalog().getSqlBlockRuleMgr().checkLimitaions(olapScanNode.getSelectedPartitionNum().longValue(),
-                                        olapScanNode.getSelectedTabletsNum(), olapScanNode.getCardinality(), analyzer.getQualifiedUser());
+                                    olapScanNode.getSelectedTabletsNum(), olapScanNode.getCardinality(), analyzer.getQualifiedUser());
                         }
                     }
                 }
@@ -439,18 +439,18 @@ public class StmtExecutor implements ProfileWriter {
                 context.getState().setError(ErrorCode.ERR_NOT_SUPPORTED_YET, "Do not support this query.");
             }
         } catch (IOException e) {
-            LOG.warn("execute IOException ", e);
+            LOG.warn("execute IOException. {}", context.getQueryIdentifier(), e);
             // the exception happens when interact with client
             // this exception shows the connection is gone
             context.getState().setError(ErrorCode.ERR_UNKNOWN_ERROR, e.getMessage());
             throw e;
         } catch (UserException e) {
             // analysis exception only print message, not print the stack
-            LOG.warn("execute Exception. {}", e.getMessage());
+            LOG.warn("execute Exception. {}, {}", context.getQueryIdentifier(), e.getMessage());
             context.getState().setError(e.getMysqlErrorCode(), e.getMessage());
             context.getState().setErrType(QueryState.ErrType.ANALYSIS_ERR);
         } catch (Exception e) {
-            LOG.warn("execute Exception", e);
+            LOG.warn("execute Exception. {}", context.getQueryIdentifier(), e);
             context.getState().setError(ErrorCode.ERR_UNKNOWN_ERROR,
                     e.getClass().getSimpleName() + ", msg: " + e.getMessage());
             if (parsedStmt instanceof KillStmt) {
@@ -466,7 +466,7 @@ public class StmtExecutor implements ProfileWriter {
                 sessionVariable.setIsSingleSetVar(false);
                 sessionVariable.clearSessionOriginValue();
             } catch (DdlException e) {
-                LOG.warn("failed to revert Session value.", e);
+                LOG.warn("failed to revert Session value. {}", context.getQueryIdentifier(), e);
                 context.getState().setError(e.getMysqlErrorCode(), e.getMessage());
             }
             if (!context.isTxnModel() && parsedStmt instanceof InsertStmt) {
@@ -480,7 +480,7 @@ public class StmtExecutor implements ProfileWriter {
                                 insertStmt.getDbObj().getId(), insertStmt.getTransactionId(),
                                 (errMsg == null ? "unknown reason" : errMsg));
                     } catch (Exception abortTxnException) {
-                        LOG.warn("errors when abort txn", abortTxnException);
+                        LOG.warn("errors when abort txn. {}", context.getQueryIdentifier(), abortTxnException);
                     }
                 }
             }
@@ -580,7 +580,7 @@ public class StmtExecutor implements ProfileWriter {
             } catch (UserException e) {
                 throw e;
             } catch (Exception e) {
-                LOG.warn("Analyze failed because ", e);
+                LOG.warn("Analyze failed. {}", context.getQueryIdentifier(), e);
                 throw new AnalysisException("Unexpected exception: " + e.getMessage());
             } finally {
                 MetaLockUtils.readUnlockTables(tables);
@@ -591,7 +591,7 @@ public class StmtExecutor implements ProfileWriter {
             } catch (UserException e) {
                 throw e;
             } catch (Exception e) {
-                LOG.warn("Analyze failed because ", e);
+                LOG.warn("Analyze failed. {}", context.getQueryIdentifier(), e);
                 throw new AnalysisException("Unexpected exception: " + e.getMessage());
             }
         }
@@ -678,7 +678,7 @@ public class StmtExecutor implements ProfileWriter {
                 }
                 if (explainOptions != null) parsedStmt.setIsExplain(explainOptions);
             }
-            
+
             if (parsedStmt instanceof InsertStmt && parsedStmt.isExplain()) {
                 if (ConnectContext.get() != null &&
                         ConnectContext.get().getExecutor() != null &&


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

This PR #7936 change some FE log level to debug, so that when error happens, it is not easy to find out
which SQL cause the error.
So I add stmt id and query id in error log, so that user can use these identifiers to find SQL in fe.audit.log

## Checklist(Required)

1. Does it affect the original behavior: (No)
2. Has unit tests been added: (No Need)
3. Has document been added or modified: (No Need)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
