### PR TITLE
[Feature](ThreadPool) Support thread pool per disk for scanners

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -147,6 +147,10 @@ CONF_Int32(num_threads_per_core, "3");
 CONF_mBool(compress_rowbatches, "true");
 // interval between profile reports; in seconds
 CONF_mInt32(status_report_interval, "5");
+// if true, each disk will have a separate thread pool for scanner
+CONF_Bool(doris_enable_scanner_thread_pool_per_disk, "true");
+// the timeout of a work thread to wait the blocking priority queue to get a task
+CONF_mInt64(doris_blocking_priority_queue_wait_timeout_ms, "5");
 // number of olap scanner thread pool size
 CONF_Int32(doris_scanner_thread_pool_thread_num, "48");
 // number of olap scanner thread pool queue size

--- a/be/src/exec/olap_scan_node.cpp
+++ b/be/src/exec/olap_scan_node.cpp
@@ -36,6 +36,7 @@
 #include "runtime/string_value.h"
 #include "runtime/tuple_row.h"
 #include "util/priority_thread_pool.hpp"
+#include "util/priority_work_stealing_thread_pool.hpp"
 #include "util/runtime_profile.h"
 
 namespace doris {
@@ -1437,6 +1438,7 @@ void OlapScanNode::transfer_thread(RuntimeState* state) {
                 PriorityThreadPool::Task task;
                 task.work_function = std::bind(&OlapScanNode::scanner_thread, this, *iter);
                 task.priority = _nice;
+                task.queue_id = state->exec_env()->store_path_to_index((*iter)->scan_disk());
                 (*iter)->start_wait_worker_timer();
                 if (thread_pool->offer(task)) {
                     olap_scanners.erase(iter++);

--- a/be/src/runtime/exec_env.h
+++ b/be/src/runtime/exec_env.h
@@ -47,6 +47,7 @@ class MemTracker;
 class StorageEngine;
 class PoolMemTrackerRegistry;
 class PriorityThreadPool;
+class PriorityWorkStealingThreadPool;
 class ReservationTracker;
 class ResultBufferMgr;
 class ResultQueueMgr;
@@ -146,6 +147,7 @@ public:
     SmallFileMgr* small_file_mgr() { return _small_file_mgr; }
 
     const std::vector<StorePath>& store_paths() const { return _store_paths; }
+    size_t store_path_to_index(const std::string& path) { return _store_path_map[path]; }
     void set_store_paths(const std::vector<StorePath>& paths) { _store_paths = paths; }
     StorageEngine* storage_engine() { return _storage_engine; }
     void set_storage_engine(StorageEngine* storage_engine) { _storage_engine = storage_engine; }
@@ -173,6 +175,8 @@ private:
 private:
     bool _is_init;
     std::vector<StorePath> _store_paths;
+    // path => store index
+    std::map<std::string, size_t> _store_path_map;
     // Leave protected so that subclasses can override
     ExternalScanContextMgr* _external_scan_context_mgr = nullptr;
     DataStreamMgr* _stream_mgr = nullptr;

--- a/be/src/util/priority_thread_pool.hpp
+++ b/be/src/util/priority_thread_pool.hpp
@@ -115,7 +115,8 @@ public:
         shutdown();
         join();
     }
-
+protected:
+    virtual bool is_shutdown() { return _shutdown; }
 private:
     // Driver method for each thread in the pool. Continues to read work from the queue
     // until the pool is shutdown.
@@ -130,8 +131,6 @@ private:
             }
         }
     }
-
-    bool is_shutdown() { return _shutdown; }
 
     // Queue on which work items are held until a thread is available to process them in
     // FIFO order.

--- a/be/src/util/priority_work_stealing_thread_pool.hpp
+++ b/be/src/util/priority_work_stealing_thread_pool.hpp
@@ -15,8 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#ifndef DORIS_BE_SRC_COMMON_UTIL_PRIORITY_THREAD_POOL_HPP
-#define DORIS_BE_SRC_COMMON_UTIL_PRIORITY_THREAD_POOL_HPP
+#pragma once
 
 #include <mutex>
 #include <thread>
@@ -26,47 +25,29 @@
 
 namespace doris {
 
-// Simple threadpool which processes items (of type T) in parallel which were placed on a
-// blocking queue by Offer(). Each item is processed by a single user-supplied method.
-class PriorityThreadPool {
+// Work-Stealing threadpool which processes items (of type T) in parallel which were placed on multi
+// blocking queues by Offer(). Each item is processed by a single user-supplied method.
+class PriorityWorkStealingThreadPool : public PriorityThreadPool {
 public:
-    // Signature of a work-processing function. Takes the integer id of the thread which is
-    // calling it (ids run from 0 to num_threads - 1) and a reference to the item to
-    // process.
-    typedef std::function<void()> WorkFunction;
-
-    struct Task {
-    public:
-        int priority;
-        WorkFunction work_function;
-        int queue_id;
-        bool operator<(const Task& o) const { return priority < o.priority; }
-
-        Task& operator++() {
-            priority += 2;
-            return *this;
-        }
-    };
 
     // Creates a new thread pool and start num_threads threads.
     //  -- num_threads: how many threads are part of this pool
+    //  -- num_queues: how many queues are part of this pool
     //  -- queue_size: the maximum size of the queue on which work items are offered. If the
     //     queue exceeds this size, subsequent calls to Offer will block until there is
     //     capacity available.
     //  -- work_function: the function to run every time an item is consumed from the queue
-    PriorityThreadPool(uint32_t num_threads, uint32_t queue_size)
-            : _work_queue(queue_size), _shutdown(false) {
+    PriorityWorkStealingThreadPool(uint32_t num_threads, uint32_t num_queues, uint32_t queue_size)
+            : PriorityThreadPool(0, 0), _shutdown(false) {
+        DCHECK_GE(num_queues, 0);
+        // init _work_queues first because the work thread needs it
+        for (int i = 0; i < num_queues; ++i) {
+            _work_queues.emplace_back(std::make_shared<BlockingPriorityQueue<Task>>(queue_size));
+        }
         for (int i = 0; i < num_threads; ++i) {
             _threads.create_thread(
-                    std::bind<void>(std::mem_fn(&PriorityThreadPool::work_thread), this, i));
+                    std::bind<void>(std::mem_fn(&PriorityWorkStealingThreadPool::work_thread), this, i));
         }
-    }
-
-    // Destructor ensures that all threads are terminated before this object is freed
-    // (otherwise they may continue to run and reference member variables)
-    virtual ~PriorityThreadPool() {
-        shutdown();
-        join();
     }
 
     // Blocking operation that puts a work item on the queue. If the queue is full, blocks
@@ -80,35 +61,45 @@ public:
     //
     // Returns true if the work item was successfully added to the queue, false otherwise
     // (which typically means that the thread pool has already been shut down).
-    virtual bool offer(Task task) { return _work_queue.blocking_put(task); }
+    bool offer(Task task) override {
+        return _work_queues[task.queue_id]->blocking_put(task);
+    }
 
-    virtual bool offer(WorkFunction func) {
+    bool offer(WorkFunction func) override {
         PriorityThreadPool::Task task = {0, func, 0};
-        return _work_queue.blocking_put(task);
+        return _work_queues[task.queue_id]->blocking_put(task);
     }
 
     // Shuts the thread pool down, causing the work queue to cease accepting offered work
     // and the worker threads to terminate once they have processed their current work item.
     // Returns once the shutdown flag has been set, does not wait for the threads to
     // terminate.
-    virtual void shutdown() {
+    void shutdown() override {
         _shutdown = true;
-        _work_queue.shutdown();
+        for (auto work_queue : _work_queues) {
+            work_queue->shutdown();
+        }
     }
 
     // Blocks until all threads are finished. shutdown does not need to have been called,
     // since it may be called on a separate thread.
-    virtual void join() { _threads.join_all(); }
+    void join() override { _threads.join_all(); }
 
-    virtual uint32_t get_queue_size() const { return _work_queue.get_size(); }
+    uint32_t get_queue_size() const override {
+        uint32_t size = 0;
+        for (auto work_queue : _work_queues) {
+            size += work_queue->get_size();
+        }
+        return size;
+    }
 
     // Blocks until the work queue is empty, and then calls shutdown to stop the worker
     // threads and Join to wait until they are finished.
     // Any work Offer()'ed during DrainAndshutdown may or may not be processed.
-    virtual void drain_and_shutdown() {
+    void drain_and_shutdown() override {
         {
             std::unique_lock<std::mutex> l(_lock);
-            while (_work_queue.get_size() != 0) {
+            while (get_queue_size() != 0) {
                 _empty_cv.wait(l);
             }
         }
@@ -120,12 +111,27 @@ private:
     // Driver method for each thread in the pool. Continues to read work from the queue
     // until the pool is shutdown.
     void work_thread(int thread_id) {
+        auto queue_id = thread_id % _work_queues.size();
+        auto steal_queue_id = (queue_id + 1) % _work_queues.size();
         while (!is_shutdown()) {
             Task task;
-            if (_work_queue.blocking_get(&task)) {
+            // avoid blocking get
+            bool is_other_queues_empty = true;
+            // steal work in round-robin if nothing to do
+            while (_work_queues[queue_id]->get_size() == 0 && queue_id != steal_queue_id && !is_shutdown()) {
+                if (_work_queues[steal_queue_id]->non_blocking_get(&task)) {
+                    is_other_queues_empty = false;
+                    task.work_function();
+                }
+                steal_queue_id = (steal_queue_id + 1) % _work_queues.size();
+            }
+            if (queue_id == steal_queue_id) {
+                steal_queue_id = (steal_queue_id + 1) % _work_queues.size();
+            }
+            if (is_other_queues_empty && _work_queues[queue_id]->blocking_get(&task, config::doris_blocking_priority_queue_wait_timeout_ms)) {
                 task.work_function();
             }
-            if (_work_queue.get_size() == 0) {
+            if (_work_queues[queue_id]->get_size() == 0) {
                 _empty_cv.notify_all();
             }
         }
@@ -135,9 +141,9 @@ private:
 
     // Queue on which work items are held until a thread is available to process them in
     // FIFO order.
-    BlockingPriorityQueue<Task> _work_queue;
+    std::vector<std::shared_ptr<BlockingPriorityQueue<Task>>> _work_queues;
 
-    // Collection of worker threads that process work from the queue.
+    // Collection of worker threads that process work from the queues.
     ThreadGroup _threads;
 
     // Guards _empty_cv
@@ -151,5 +157,3 @@ private:
 };
 
 } // namespace doris
-
-#endif

--- a/be/src/vec/exec/volap_scan_node.cpp
+++ b/be/src/vec/exec/volap_scan_node.cpp
@@ -553,6 +553,7 @@ int VOlapScanNode::_start_scanner_thread_task(RuntimeState* state, int block_per
         PriorityThreadPool::Task task;
         task.work_function = std::bind(&VOlapScanNode::scanner_thread, this, *iter);
         task.priority = _nice;
+        task.queue_id = state->exec_env()->store_path_to_index((*iter)->scan_disk());
         (*iter)->start_wait_worker_timer();
         if (thread_pool->offer(task)) {
             olap_scanners.erase(iter++);


### PR DESCRIPTION
# Proposed changes

Issue Number: close #7581

## Problem Summary:

Support thread pool per disk for scanners to prevent pool performance from some high ioutil disks happening

key point:
1. each disk has a thread pool for scanners
2. whenever a thread pool of one disk runs out of local work, tasks can be retrieved from other threads(disks). This is done round-robin.

performance testing: 
vec version: 25% faster than single thread pool in a high io util disk test case
normal version: 8% faster than single thread pool in a high io util disk test case

## Checklist(Required)

1. Does it affect the original behavior: (No)
2. Has unit tests been added: (No)
3. Has document been added or modified: (No)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
