### PR TITLE
[Improvement] print log foreground if not use --daemon to start fe

### DIFF
--- a/bin/start_fe.sh
+++ b/bin/start_fe.sh
@@ -166,7 +166,7 @@ fi
 if [ ${RUN_DAEMON} -eq 1 ]; then
     nohup $LIMIT $JAVA $final_java_opt org.apache.doris.PaloFe ${HELPER} "$@" >> $LOG_DIR/fe.out 2>&1 < /dev/null &
 else
-    $LIMIT $JAVA $final_java_opt org.apache.doris.PaloFe ${HELPER} "$@" >> $LOG_DIR/fe.out 2>&1 < /dev/null
+    $LIMIT $JAVA $final_java_opt org.apache.doris.PaloFe ${HELPER} "$@" < /dev/null
 fi
 
 echo $! > $pidfile

--- a/fe/fe-core/src/main/java/org/apache/doris/common/Log4jConfig.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/Log4jConfig.java
@@ -42,6 +42,11 @@ public class Log4jConfig extends XmlConfiguration {
             "\n<!-- Auto Generated. DO NOT MODIFY IT! -->\n" +
             "<Configuration status=\"info\" packages=\"org.apache.doris.common\">\n" +
             "  <Appenders>\n" +
+            "    <Console name=\"Console\" target=\"SYSTEM_OUT\">" + 
+            "      <PatternLayout charset=\"UTF-8\">\n" +
+            "        <Pattern>%d{yyyy-MM-dd HH:mm:ss,SSS} %p (%t|%tid) [%C{1}.%M():%L] %m%n</Pattern>\n" +
+            "      </PatternLayout>\n" +
+            "    </Console>" + 
             "    <RollingFile name=\"Sys\" fileName=\"${sys_log_dir}/fe.log\" filePattern=\"${sys_log_dir}/fe.log.${sys_file_pattern}-%i\">\n" +
             "      <PatternLayout charset=\"UTF-8\">\n" +
             "        <Pattern>%d{yyyy-MM-dd HH:mm:ss,SSS} %p (%t|%tid) [%C{1}.%M():%L] %m%n</Pattern>\n" +
@@ -92,6 +97,7 @@ public class Log4jConfig extends XmlConfiguration {
             "    <Root level=\"${sys_log_level}\">\n" +
             "      <AppenderRef ref=\"Sys\"/>\n" +
             "      <AppenderRef ref=\"SysWF\" level=\"WARN\"/>\n" +
+            "      <AppenderRef ref=\"Console\"/>\n" +
             "    </Root>\n" +
             "    <Logger name=\"audit\" level=\"ERROR\" additivity=\"false\">\n" +
             "      <AppenderRef ref=\"Auditfile\"/>\n" +


### PR DESCRIPTION
Doris does not support start_fe.sh and print all logs to console. It maybe a bug.