### PR TITLE
[Docs]Fixed typo in `CREATE TABLE`

### DIFF
--- a/docs/zh-CN/sql-reference/sql-statements/Data Definition/CREATE TABLE.md
+++ b/docs/zh-CN/sql-reference/sql-statements/Data Definition/CREATE TABLE.md
@@ -34,7 +34,7 @@ under the License.
 ```
     CREATE [EXTERNAL] TABLE [IF NOT EXISTS] [database.]table_name
     (column_definition1[, column_definition2, ...]
-    [, index_definition1[, ndex_definition12,]])
+    [, index_definition1[, index_definition2, ...]])
     [ENGINE = [olap|mysql|broker|hive|iceberg]]
     [key_desc]
     [COMMENT "table comment"];


### PR DESCRIPTION
## Problem Summary:

Fixed in docs 'SQL手册-DDL-CREATE TABLE-description'
Change to：
    (column_definition1[, column_definition2, ...]
    [, index_definition1[, index_definition2, ...]])

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)