### PR TITLE
[docs] correct mysql jdbc auto-retry url format

### DIFF
--- a/docs/en/getting-started/advance-usage.md
+++ b/docs/en/getting-started/advance-usage.md
@@ -264,7 +264,7 @@ I retry and load balancing in application layer code. For example, if a connecti
 If you use MySQL JDBC connector to connect Doris, you can use jdbc's automatic retry mechanism:
 
 ```
-jdbc:mysql:/[host:port],[host:port].../[database][? propertyName1][=propertyValue1][&propertyName2][=propertyValue2]...
+jdbc:mysql://[host1][:port1],[host2][:port2][,[host3][:port3]]...[/[database]][?propertyName1=propertyValue1[&propertyName2=propertyValue2]...]
 ```
 
 **The third**

--- a/docs/zh-CN/getting-started/advance-usage.md
+++ b/docs/zh-CN/getting-started/advance-usage.md
@@ -264,7 +264,7 @@ mysql> select sum(table1.pv) from table1 join [shuffle] table2 where table1.site
 如果使用 mysql jdbc connector 来连接Doris，可以使用 jdbc 的自动重试机制:
 
 ```
-jdbc:mysql://[host:port],[host:port].../[database][?propertyName1][=propertyValue1][&propertyName2][=propertyValue2]...
+jdbc:mysql://[host1][:port1],[host2][:port2][,[host3][:port3]]...[/[database]][?propertyName1=propertyValue1[&propertyName2=propertyValue2]...]
 ```
 
 **第三种**


### PR DESCRIPTION
## Problem Summary:

Correct format of mysql jdbc failover auto-retry url.
Reference: [9.1 Configuring Server Failover for Connections Using JDBC
](https://dev.mysql.com/doc/connector-j/8.0/en/connector-j-config-failover.html)

## Checklist(Required)

1. Does it affect the original behavior: (No)
2. Has unit tests been added: (No Need)
3. Has document been added or modified: (Yes)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (No)
