### PR TITLE
enable check_java_version

### DIFF
--- a/docs/en/administrator-guide/config/fe_config.md
+++ b/docs/en/administrator-guide/config/fe_config.md
@@ -404,7 +404,7 @@ IsMutable：true
 MasterOnly：true
 
 If disable_storage_medium_check is true, ReportHandler would not check tablet's storage medium and disable storage cool down function, the default value is false. You can set the value true when you don't care what the storage medium of the tablet is.
-  
+
 ### drop_backend_after_decommission
 
 Default：false
@@ -458,9 +458,9 @@ This variable is a dynamic configuration, and users can modify the configuration
 
 ### check_java_version
 
-Default：false
+Default：true
 
-If set to true, Doris will check whether the compiled and running Java versions are compatible
+Doris will check whether the compiled and run Java versions are compatible, if not, it will throw a Java version mismatch exception message and terminate the startup
 
 ### max_running_rollup_job_num_per_table
 

--- a/docs/zh-CN/administrator-guide/config/fe_config.md
+++ b/docs/zh-CN/administrator-guide/config/fe_config.md
@@ -444,9 +444,9 @@ show data （其他用法：HELP SHOW DATA）
 
 ### check_java_version
 
-默认值：false
+默认值：true
 
-如果设置为 true，Doris 将检查已编译和运行的 Java 版本是否兼容
+Doris 将检查已编译和运行的 Java 版本是否兼容，如果不兼容将抛出Java版本不匹配的异常信息，并终止启动
 
 ### max_running_rollup_job_num_per_table
 

--- a/fe/fe-core/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/Config.java
@@ -1271,7 +1271,7 @@ public class Config extends ConfigBase {
      * If set to true, Doris will check if the compiled and running versions of Java are compatible
      */
     @ConfField
-    public static boolean check_java_version = false;
+    public static boolean check_java_version = true;
 
     /**
      * control materialized view


### PR DESCRIPTION
Enable to check the Java version when Doris starts, to prevent the user experience caused by the inconsistency between the compiled version and the running version. If the Java version is compiled and the Java version is run, it will not start, and a prompt message will be given.

# Proposed changes

Issue Number: close #8033 

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (No)
2. Has unit tests been added: (No)
3. Has document been added or modified: (No)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
