### PR TITLE
[fix](cache) ClassCastException when multiple EXCEPT, INTERSECT and UNION in the local view

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/cache/CacheAnalyzer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/cache/CacheAnalyzer.java
@@ -469,7 +469,7 @@ public class CacheAnalyzer {
             addAllViewStmt(((SelectStmt) queryStmt).getTableRefs());
         } else if (queryStmt instanceof SetOperationStmt) {
             for (SetOperationStmt.SetOperand operand : ((SetOperationStmt) queryStmt).getOperands()) {
-                addAllViewStmt(((SelectStmt) operand.getQueryStmt()).getTableRefs());
+                addAllViewStmt(operand.getQueryStmt());
             }
         }
     }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #8082
Throws ClassCastException when there are multiple EXCEPT, INTERSECT and UNION in the local view.  

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
