### PR TITLE
[refactor](optimize)refactor RowRef/RowRefList to decrease hash table memory size

### DIFF
--- a/be/src/vec/exec/join/join_op.h
+++ b/be/src/vec/exec/join/join_op.h
@@ -27,9 +27,9 @@ namespace doris::vectorized {
 struct RowRef {
     using SizeT = uint32_t; /// Do not use size_t cause of memory economy
 
-    // using union to represent two cases
-    // 1. when RowRefList containing only one RowRef, visited + blockptr are valid
-    // 2. when RowRefList contaning multi RowRef, it's used through next pointer
+    // using union to represent two cases for the purpose of memory saving
+    // 1. when RowRefList contains only one RowRef, use visited + blockptr
+    // 2. when RowRefList contains multi RowRef, use next to point to the next Batch
     union { 
         struct {
             uint64_t visited : 1;
@@ -46,7 +46,7 @@ struct RowRef {
     }
 
     void block(Block* ptr) {
-        DCHECK(((uint64_t)ptr & 0x0000000000000001) == 0); //the lowest bit must be 0, Arena.alloc() promised
+        DCHECK(((uint64_t)ptr & 0x0000000000000001) == 0); // the lowest bit must be 0, Arena.alloc() promised
         blockptr = ((uint64_t)ptr >> 1);
     }
 

--- a/be/src/vec/exec/join/vhash_join_node.cpp
+++ b/be/src/vec/exec/join/vhash_join_node.cpp
@@ -209,7 +209,7 @@ struct ProcessHashTableProbe {
                     if (mapped.get_row_count() == 1) {
                         ++repeat_count;
                         for (size_t j = 0; j < _right_col_len; ++j) {
-                            auto& column = *mapped.block->get_by_position(j).column;
+                            auto& column = *mapped.block()->get_by_position(j).column;
                             mcol[j + _right_col_idx]->insert_from(column, mapped.row_num);
                         }
                     } else {
@@ -219,7 +219,7 @@ struct ProcessHashTableProbe {
                         for (auto it = mapped.begin(); it.ok(); ++it) {
                             ++repeat_count;
                             for (size_t j = 0; j < _right_col_len; ++j) {
-                                auto& column = *it->block->get_by_position(j).column;
+                                auto& column = *it->block()->get_by_position(j).column;
                                 // TODO: interface insert from cause serious performance problems
                                 //  when column is nullable. Try to make more effective way
                                 mcol[j + _right_col_idx]->insert_from(column, it->row_num);
@@ -346,9 +346,9 @@ struct ProcessHashTableProbe {
 
                 for (auto it = mapped.begin(); it.ok(); ++it) {
                     ++current_offset;
-                    for (size_t j = 0; j < right_col_len; ++j) {
+                    for (size_t j = 0; j < _right_col_len; ++j) {
                         auto& column = *it->block()->get_by_position(j).column;
-                        mcol[j + right_col_idx]->insert_from(column, it->row_num);
+                        mcol[j + _right_col_idx]->insert_from(column, it->row_num);
                     }
                     visited_map.emplace_back(&(*it));
                 }

--- a/be/src/vec/exec/vset_operation_node.h
+++ b/be/src/vec/exec/vset_operation_node.h
@@ -184,7 +184,7 @@ struct HashTableProbe {
 
     void add_result_columns(RowRefList& value, int& block_size) {
         for (auto idx = _build_col_idx.begin(); idx != _build_col_idx.end(); ++idx) {
-            auto& column = *value.begin()->block->get_by_position(idx->first).column;
+            auto& column = *value.begin()->block()->get_by_position(idx->first).column;
             _mutable_cols[idx->second]->insert_from(column, value.begin()->row_num);
         }
         block_size++;


### PR DESCRIPTION
# Proposed changes
1. use union + bitfield C++ language features to reuse the memory, reduce the size of RowRefList from 32 to 16 bytes
2. ssb test indicate（Q4.1）: benefit from RowRefList size reduce, hash table's memory consuming is greatly decreased, almost 40%
3. refactor RowRefList iterate logic, i think it becomes more simple after modifing
4. run performance, change is little

Issue Number: close #xxx

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
