### PR TITLE
[Bug](Variables) Fix bug that execute showVariablesStmt with where expression return empty resultset

### DIFF
--- a/fe/fe-core/src/main/cup/sql_parser.cup
+++ b/fe/fe-core/src/main/cup/sql_parser.cup
@@ -3506,15 +3506,15 @@ restore_stmt ::=
 kill_stmt ::=
     KW_KILL INTEGER_LITERAL:value
     {:
-        RESULT = new KillStmt(true, value.longValue());
+        RESULT = new KillStmt(true, value.intValue());
     :}
     | KW_KILL KW_CONNECTION INTEGER_LITERAL:value
     {:
-        RESULT = new KillStmt(true, value.longValue());
+        RESULT = new KillStmt(true, value.intValue());
     :}
     | KW_KILL KW_QUERY INTEGER_LITERAL:value
     {:
-        RESULT = new KillStmt(false, value.longValue());
+        RESULT = new KillStmt(false, value.intValue());
     :}
     ;
 

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/KillStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/KillStmt.java
@@ -24,9 +24,9 @@ package org.apache.doris.analysis;
  */
 public class KillStmt extends StatementBase {
     private final boolean isConnectionKill;
-    private final long connectionId;
+    private final int connectionId;
 
-    public KillStmt(boolean isConnectionKill, long connectionId) {
+    public KillStmt(boolean isConnectionKill, int connectionId) {
         this.isConnectionKill = isConnectionKill;
         this.connectionId = connectionId;
     }
@@ -35,7 +35,7 @@ public class KillStmt extends StatementBase {
         return isConnectionKill;
     }
 
-    public long getConnectionId() {
+    public int getConnectionId() {
         return connectionId;
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/http/rest/ConnectionAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/http/rest/ConnectionAction.java
@@ -47,7 +47,7 @@ public class ConnectionAction extends RestBaseAction {
             sendResult(request, response, HttpResponseStatus.BAD_REQUEST);
             return;
         }
-        long connectionId = Long.valueOf(connStr.trim());
+        int connectionId = Integer.valueOf(connStr.trim());
         ConnectContext context = ExecuteEnv.getInstance().getScheduler().getContext(connectionId);
         if (context == null || context.queryId() == null) {
             response.getContent().append("connection id " + connectionId + " not found.");

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/ConnectionAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/ConnectionAction.java
@@ -65,9 +65,9 @@ public class ConnectionAction extends RestBaseController {
             return ResponseEntityBuilder.badRequest("Missing connection_id");
         }
 
-        long connectionId = -1;
+        int connectionId = -1;
         try {
-            connectionId = Long.valueOf(connStr.trim());
+            connectionId = Integer.valueOf(connStr.trim());
         } catch (NumberFormatException e) {
             return ResponseEntityBuilder.badRequest("Invalid connection id: " + e.getMessage());
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectScheduler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectScheduler.java
@@ -128,7 +128,7 @@ public class ConnectScheduler {
         }
     }
 
-    public ConnectContext getContext(long connectionId) {
+    public ConnectContext getContext(int connectionId) {
         return connectionMap.get(connectionId);
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -728,7 +728,7 @@ public class StmtExecutor implements ProfileWriter {
     // Handle kill statement.
     private void handleKill() throws DdlException {
         KillStmt killStmt = (KillStmt) parsedStmt;
-        long id = killStmt.getConnectionId();
+        int id = killStmt.getConnectionId();
         ConnectContext killCtx = context.getConnectScheduler().getContext(id);
         if (killCtx == null) {
             ErrorReport.reportDdlException(ErrorCode.ERR_NO_SUCH_THREAD, id);

--- a/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
@@ -426,7 +426,7 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         Map<String, String> map = Maps.newHashMap();
         result.setVariables(map);
         // Find connect
-        ConnectContext ctx = exeEnv.getScheduler().getContext(params.getThreadId());
+        ConnectContext ctx = exeEnv.getScheduler().getContext((int) params.getThreadId());
         if (ctx == null) {
             return result;
         }

--- a/fe/fe-core/src/test/java/org/apache/doris/qe/StmtExecutorTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/qe/StmtExecutorTest.java
@@ -342,7 +342,7 @@ public class StmtExecutorTest {
         new Expectations(scheduler) {
             {
                 // suicide
-                scheduler.getContext(1L);
+                scheduler.getContext(1);
                 result = ctx;
             }
         };
@@ -399,7 +399,7 @@ public class StmtExecutorTest {
         new Expectations(scheduler) {
             {
                 // suicide
-                scheduler.getContext(1L);
+                scheduler.getContext(1);
                 result = killCtx;
             }
         };
@@ -420,7 +420,7 @@ public class StmtExecutorTest {
 
                 killStmt.getConnectionId();
                 minTimes = 0;
-                result = 1L;
+                result = 1;
 
                 killStmt.isConnectionKill();
                 minTimes = 0;
@@ -455,7 +455,7 @@ public class StmtExecutorTest {
         new Expectations(scheduler) {
             {
                 // suicide
-                scheduler.getContext(1L);
+                scheduler.getContext(1);
                 result = killCtx;
             }
         };
@@ -475,7 +475,7 @@ public class StmtExecutorTest {
 
                 killStmt.getConnectionId();
                 minTimes = 0;
-                result = 1L;
+                result = 1;
 
                 killStmt.getRedirectStatus();
                 minTimes = 0;
@@ -490,7 +490,7 @@ public class StmtExecutorTest {
 
         new Expectations(scheduler) {
             {
-                scheduler.getContext(1L);
+                scheduler.getContext(1);
                 result = null;
             }
         };


### PR DESCRIPTION
# Proposed changes

Issue Number: close #8093 

## Problem Summary:
This Bug is introduced by PR #7936 , which change key type of connectionMap from Long to Integer, which cause connectionMap could not find connectContext by connectionId 

## Checklist(Required)

1. Does it affect the original behavior: (No)
2. Has unit tests been added: (No)
3. Has document been added or modified: (No)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
