### PR TITLE
[fix] (vectorization)Fix nullable column compute the hash value error

### DIFF
--- a/be/src/vec/columns/column.h
+++ b/be/src/vec/columns/column.h
@@ -33,7 +33,6 @@ class SipHash;
 namespace doris::vectorized {
 
 class Arena;
-class ColumnGathererStream;
 class Field;
 
 /// Declares interface to store columns in memory.

--- a/be/src/vec/columns/column_nullable.cpp
+++ b/be/src/vec/columns/column_nullable.cpp
@@ -44,9 +44,10 @@ ColumnNullable::ColumnNullable(MutableColumnPtr&& nested_column_, MutableColumnP
 }
 
 void ColumnNullable::update_hash_with_value(size_t n, SipHash& hash) const {
-    const auto& arr = get_null_map_data();
-    hash.update(arr[n]);
-    if (arr[n] == 0) get_nested_column().update_hash_with_value(n, hash);
+    if (is_null_at(n))
+        hash.update(0);
+    else
+        get_nested_column().update_hash_with_value(n, hash);
 }
 
 MutableColumnPtr ColumnNullable::clone_resized(size_t new_size) const {

--- a/be/test/vec/core/CMakeLists.txt
+++ b/be/test/vec/core/CMakeLists.txt
@@ -20,4 +20,5 @@ set(EXECUTABLE_OUTPUT_PATH "${BUILD_DIR}/test/vec/core")
 
 ADD_BE_TEST(block_test)
 ADD_BE_TEST(column_complex_test)
+ADD_BE_TEST(column_nullable_test)
 

--- a/be/test/vec/core/column_nullable_test.cpp
+++ b/be/test/vec/core/column_nullable_test.cpp
@@ -1,0 +1,52 @@
+
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "vec/columns/column_nullable.h"
+#include "vec/columns/column_vector.h"
+#include "vec/common/sip_hash.h"
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <string>
+
+namespace doris::vectorized {
+
+TEST(ColumnNullableTest, HashTest) {
+    ColumnPtr column = ColumnVector<int>::create({10, 20});
+    ASSERT_EQ(column->size(), 2);
+
+    auto nullable_column = ColumnNullable::create(column, ColumnUInt8::create(column->size(), 0));
+    SipHash hashes[2];
+    column->update_hash_with_value(0, hashes[0]);
+    nullable_column->update_hash_with_value(0, hashes[1]);
+    ASSERT_EQ(hashes[0].get64(), hashes[1].get64());
+
+    auto& null_map = ((ColumnNullable)(*nullable_column)).get_null_map_data();
+    null_map[1] = true;
+    column->update_hash_with_value(1, hashes[0]);
+    nullable_column->update_hash_with_value(1, hashes[1]);
+    ASSERT_NE(hashes[0].get64(), hashes[1].get64());
+}
+
+} // namespace doris::vectorized
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
# Proposed changes

Issue Number: close #8103 

## Problem Summary:

Fix nullable column compute the hash value error
6 and not null 6 compute the same hash value

## Checklist(Required)

1. Does it affect the original behavior: (Yes)
2. Has unit tests been added: (Yes)
3. Has document been added or modified: (No)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
