### PR TITLE
[fix](load) Fix InsertStmt prepareExpressions

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/InsertStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/InsertStmt.java
@@ -667,7 +667,7 @@ public class InsertStmt extends DdlStmt {
     }
 
     public void prepareExpressions() throws UserException {
-        List<Expr> selectList = Expr.cloneList(queryStmt.getBaseTblResultExprs());
+        List<Expr> selectList = Expr.cloneList(queryStmt.getResultExprs());
         // check type compatibility
         int numCols = targetColumns.size();
         for (int i = 0; i < numCols; ++i) {

--- a/fe/fe-core/src/main/java/org/apache/doris/common/profile/PlanTreeBuilder.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/profile/PlanTreeBuilder.java
@@ -56,7 +56,12 @@ public class PlanTreeBuilder {
             PlanTreeNode sinkNode = null;
             if (sink != null) {
                 StringBuilder sb = new StringBuilder();
-                sb.append("[").append(sink.getExchNodeId().asInt()).append(": ").append(sink.getClass().getSimpleName()).append("]");
+                if (sink.getExchNodeId() != null) {
+                    sb.append("[").append(sink.getExchNodeId().asInt()).append(": ")
+                            .append(sink.getClass().getSimpleName()).append("]");
+                } else {
+                    sb.append("[").append(sink.getClass().getSimpleName()).append("]");
+                }
                 sb.append("\n[Fragment: ").append(fragment.getId().asInt()).append("]");
                 sb.append("\n").append(sink.getExplainString("", TExplainLevel.BRIEF));
                 sinkNode = new PlanTreeNode(sink.getExchNodeId(), sb.toString());


### PR DESCRIPTION
Use queryStmt.getResultExprs() instead of queryStmt.getBaseTblResultExprs() in InsertStmt prepareExpressions func.

# Proposed changes

Issue Number: close #8111

## Problem Summary:

Use queryStmt.getResultExprs() instead of queryStmt.getBaseTblResultExprs() in InsertStmt prepareExpressions func.


## Checklist(Required)

1. Does it affect the original behavior: Yes
2. Has unit tests been added:Yes
3. Has document been added or modified: No
4. Does it need to update dependencies:  No
5. Are there any changes that cannot be rolled back: No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
