### PR TITLE
Fix fe 307 redirect to be Access denied

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/RestBaseController.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/RestBaseController.java
@@ -75,7 +75,11 @@ public class RestBaseController extends BaseController {
         String userInfo = null;
         if (!Strings.isNullOrEmpty(request.getHeader("Authorization"))) {
             ActionAuthorizationInfo authInfo = getAuthorizationInfo(request);
-            userInfo = authInfo.fullUserName + ":" + authInfo.password;
+            // Fix username@cluster:passwod is modified to cluster: username:passwod causes authentication failure
+            // @see https://github.com/apache/incubator-doris/issues/8100
+            userInfo = ClusterNamespace.getNameFromFullName(authInfo.fullUserName) +
+                    "@" + ClusterNamespace.getClusterNameFromFullName(authInfo.fullUserName) +
+                    ":" + authInfo.password;
         }
         try {
             urlObj = new URI(urlStr);


### PR DESCRIPTION

# Proposed changes

Issue Number: close #8100

## Problem Summary:

Fix username@cluster:passwod is modified to cluster: username:passwod causes authentication failure

## Checklist(Required)

1. Does it affect the original behavior: (No)
2. Has unit tests been added: (Need)
3. Has document been added or modified: (Yes)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
