### PR TITLE
(refactor)(common) optimize Status implemention: no dynamic new

### DIFF
--- a/be/src/common/status.h
+++ b/be/src/common/status.h
@@ -211,7 +211,7 @@ public:
     Slice message() const;
 
     TStatusCode::type code() const {
-        return ok() ? TStatusCode::OK : static_cast<TStatusCode::type>(_state[4]);
+        return ok() ? TStatusCode::OK : static_cast<TStatusCode::type>(_code);
     }
 
     int16_t precise_code() const {
@@ -257,9 +257,12 @@ private:
         _code = (char)code;
         _precise_code = precise_code;
 
+        // copy msg
         char* result =  _state + HEADER_LEN;
         uint32_t len = std::min<uint32_t>(len1, MESSAGE_LEN);
         memcpy(result, msg.data, len);
+
+        // copy msg2
         if (len2 > 0 && len < MESSAGE_LEN - 2) {
             result[len++] = ':'; 
             result[len++] = ' ';

--- a/be/src/common/status.h
+++ b/be/src/common/status.h
@@ -249,7 +249,7 @@ private:
 
         // limited to MESSAGE_LEN
         if (UNLIKELY(size > MESSAGE_LEN)) {
-            LOG(INFO) << "warning: Status msg truncated" << std::endl;
+            LOG(WARNING) << "warning: Status msg truncated, " << to_string();
             size = MESSAGE_LEN;
         }
 

--- a/be/src/common/status.h
+++ b/be/src/common/status.h
@@ -249,7 +249,14 @@ private:
 
         // limited to MESSAGE_LEN
         if (UNLIKELY(size > MESSAGE_LEN)) {
-            LOG(WARNING) << "warning: Status msg truncated, " << to_string();
+            std::string str = code_as_string();
+            str.append(": ");
+            str.append(msg.data, msg.size);
+            char buf[64] = {};
+            int n = snprintf(buf, sizeof(buf), " precise_code:%d ", precise_code);
+            str.append(buf, n);
+            str.append(msg2.data, msg2.size);
+            LOG(WARNING) << "warning: Status msg truncated, " << str;
             size = MESSAGE_LEN;
         }
 

--- a/be/src/common/status.h
+++ b/be/src/common/status.h
@@ -16,30 +16,37 @@
 namespace doris {
 
 class Status {
+    enum { 
+        STATE_CAPACITY = 256,
+        HEADER_LEN = 7,
+        MESSAGE_LEN = STATE_CAPACITY - HEADER_LEN
+    };
 public:
-    Status() : _state(nullptr) {}
-    ~Status() noexcept { delete[] _state; }
+    Status() : _length(0) {}
 
     // copy c'tor makes copy of error detail so Status can be returned by value
-    Status(const Status& s) : _state(s._state == nullptr ? nullptr : copy_state(s._state)) {}
+    Status(const Status& rhs) {
+        *this = rhs;
+    }
+
+    // move c'tor
+    Status(Status&& rhs) {
+        *this = rhs;
+    }
 
     // same as copy c'tor
-    Status& operator=(const Status& s) {
-        // The following condition catches both aliasing (when this == &s),
-        // and the common case where both s and *this are OK.
-        if (_state != s._state) {
-            delete[] _state;
-            _state = (s._state == nullptr) ? nullptr : copy_state(s._state);
+    Status& operator=(const Status& rhs) {
+        if (rhs._length) {
+            memcpy(_state, rhs._state, rhs._length + Status::HEADER_LEN);
+        } else {
+            _length = 0;
         }
         return *this;
     }
 
-    // move c'tor
-    Status(Status&& s) noexcept : _state(s._state) { s._state = nullptr; }
-
     // move assign
-    Status& operator=(Status&& s) noexcept {
-        std::swap(_state, s._state);
+    Status& operator=(Status&& rhs) {
+        this->operator=(rhs);
         return *this;
     }
 
@@ -143,7 +150,8 @@ public:
         return Status(TStatusCode::DATA_QUALITY_ERROR, msg, precise_code, msg2);
     }
 
-    bool ok() const { return _state == nullptr; }
+    bool ok() const { return _length == 0; }
+    void set_ok() { _length = 0; }
 
     bool is_cancelled() const { return code() == TStatusCode::CANCELLED; }
     bool is_mem_limit_exceeded() const { return code() == TStatusCode::MEM_LIMIT_EXCEEDED; }
@@ -203,16 +211,11 @@ public:
     Slice message() const;
 
     TStatusCode::type code() const {
-        return _state == nullptr ? TStatusCode::OK : static_cast<TStatusCode::type>(_state[4]);
+        return ok() ? TStatusCode::OK : static_cast<TStatusCode::type>(_state[4]);
     }
 
     int16_t precise_code() const {
-        if (_state == nullptr) {
-            return 0;
-        }
-        int16_t precise_code;
-        memcpy(&precise_code, _state + 5, sizeof(precise_code));
-        return precise_code;
+        return ok() ? 0 : _precise_code;
     }
 
     /// Clone this status and add the specified prefix to the message.
@@ -235,21 +238,56 @@ public:
     ///   trailing message.
     Status clone_and_append(const Slice& msg) const;
 
-    operator bool() { return this->ok(); }
+    operator bool() const { return this->ok(); }
 
 private:
-    const char* copy_state(const char* state);
+    void assemble_state(TStatusCode::type code, const Slice& msg, int16_t precise_code, const Slice& msg2) {
+        DCHECK(code != TStatusCode::OK);
+        uint32_t len1 = msg.size;
+        uint32_t len2 = msg2.size;
+        uint32_t size = len1 + ((len2 > 0) ? (2 + len2) : 0);
 
-    Status(TStatusCode::type code, const Slice& msg, int16_t precise_code, const Slice& msg2);
+        // limited to MESSAGE_LEN
+        if (UNLIKELY(size > MESSAGE_LEN)) {
+            LOG(INFO) << "warning: Status msg truncated" << std::endl;
+            size = MESSAGE_LEN;
+        }
+
+        _length = size;
+        _code = (char)code;
+        _precise_code = precise_code;
+
+        char* result =  _state + HEADER_LEN;
+        uint32_t len = std::min<uint32_t>(len1, MESSAGE_LEN);
+        memcpy(result, msg.data, len);
+        if (len2 > 0 && len < MESSAGE_LEN - 2) {
+            result[len++] = ':'; 
+            result[len++] = ' ';
+            memcpy(&result[len], msg2.data, std::min<uint32_t>(len2, MESSAGE_LEN - len));
+        }
+    }
+
+    Status(TStatusCode::type code, const Slice& msg, int16_t precise_code, const Slice& msg2) {
+        assemble_state(code, msg, precise_code, msg2);
+    }
 
 private:
-    // OK status has a nullptr _state.  Otherwise, _state is a new[] array
+    // OK status has a zero _length.  Otherwise, _state is a static array
     // of the following form:
     //    _state[0..3] == length of message
     //    _state[4]    == code
     //    _state[5..6] == precise_code
     //    _state[7..]  == message
-    const char* _state;
+    union {
+        char _state[STATE_CAPACITY];
+
+        struct {
+            int64_t _length : 32;       // message length
+            int64_t _code : 8;          
+            int64_t _precise_code : 16;
+            int64_t _message : 8;       // save message since here
+        };
+    };
 };
 
 // some generally useful macros

--- a/be/src/runtime/buffered_tuple_stream3.cc
+++ b/be/src/runtime/buffered_tuple_stream3.cc
@@ -892,7 +892,7 @@ bool BufferedTupleStream3::AddRowSlow(TupleRow* row, Status* status) noexcept {
 }
 
 uint8_t* BufferedTupleStream3::AddRowCustomBeginSlow(int64_t size, Status* status) noexcept {
-    bool got_reservation;
+    bool got_reservation = false;
     *status = AdvanceWritePage(size, &got_reservation);
     if (!status->ok() || !got_reservation) {
         return nullptr;

--- a/be/src/runtime/minidump.cpp
+++ b/be/src/runtime/minidump.cpp
@@ -120,7 +120,7 @@ void Minidump::_clean_old_minidump() {
 
         // list all files
         std::vector<std::string> files;
-        Status st = FileUtils::list_files(Env::Default(), config::minidump_dir, &files);
+        FileUtils::list_files(Env::Default(), config::minidump_dir, &files);
         for (auto it = files.begin(); it != files.end();) {
             if (!ends_with(*it, ".dmp")) {
                 it = files.erase(it);


### PR DESCRIPTION
# Proposed changes
**why i do this?**
1. Status is used widely, dynamic new and free bring some extra cost(50-200cycles each call), although it's not the key of system, but to improve Status is still worth to do
2. because of new/delete, Status can not be created as pure stack object
3. the most important members are code and precise-code, the others(msg+msg2) are just used for log and tips, so truncate msg is not fatal error for us
4. by using bitfield, Status implemention becomes more clear and meanful after refactor  
5. if truncating occur, one log will generated, but in my ssb test such log not be found, so seems working good now

Issue Number: close #xxx

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
