### PR TITLE
[Vectorized][HashJoin] Opt HashJoin Performance

### DIFF
--- a/be/src/vec/columns/column_complex.h
+++ b/be/src/vec/columns/column_complex.h
@@ -153,9 +153,15 @@ public:
     void insert_indices_from(const IColumn& src, const int* indices_begin,
                              const int* indices_end) override {
         const Self& src_vec = assert_cast<const Self&>(src);
-        data.reserve(size() + (indices_end - indices_begin));
-        for (auto x = indices_begin; x != indices_end; ++x) {
-            data.push_back(src_vec.get_element(*x));
+        auto new_size = indices_end - indices_begin;
+
+        for (int i = 0; i < new_size; ++i) {
+            auto offset = *(indices_begin + i);
+            if (offset == -1) {
+                data.emplace_back(T{});
+            } else {
+                data.emplace_back(src_vec.get_element(offset));
+            }
         }
     }
 

--- a/be/src/vec/columns/column_decimal.h
+++ b/be/src/vec/columns/column_decimal.h
@@ -101,9 +101,13 @@ public:
     void insert_indices_from(const IColumn& src, const int* indices_begin,
                              const int* indices_end) override {
         const Self& src_vec = assert_cast<const Self&>(src);
-        data.reserve(size() + (indices_end - indices_begin));
-        for (auto x = indices_begin; x != indices_end; ++x) {
-            data.push_back_without_reserve(src_vec.get_element(*x));
+        auto origin_size = size();
+        auto new_size = indices_end - indices_begin;
+        data.resize(origin_size + new_size);
+
+        for (int i = 0; i < new_size; ++i) {
+            auto offset = *(indices_begin + i);
+            data[origin_size + i] = offset == -1 ? T{} : src_vec.get_element(offset);
         }
     }
 

--- a/be/src/vec/columns/column_string.cpp
+++ b/be/src/vec/columns/column_string.cpp
@@ -95,7 +95,11 @@ void ColumnString::insert_range_from(const IColumn& src, size_t start, size_t le
 
 void ColumnString::insert_indices_from(const IColumn& src, const int* indices_begin, const int* indices_end) {
     for (auto x = indices_begin; x != indices_end; ++x) {
-        ColumnString::insert_from(src, *x);
+        if (*x == -1) {
+            ColumnString::insert_default();
+        } else {
+            ColumnString::insert_from(src, *x);
+        }
     }
 }
 

--- a/be/src/vec/columns/column_vector.cpp
+++ b/be/src/vec/columns/column_vector.cpp
@@ -221,9 +221,20 @@ void ColumnVector<T>::insert_range_from(const IColumn& src, size_t start, size_t
 template <typename T>
 void ColumnVector<T>::insert_indices_from(const IColumn& src, const int* indices_begin, const int* indices_end) {
     const Self& src_vec = assert_cast<const Self&>(src);
-    data.reserve(size() + (indices_end - indices_begin));
-    for (auto x = indices_begin; x != indices_end; ++x) {
-        data.push_back_without_reserve(src_vec.get_element(*x));
+    auto origin_size = size();
+    auto new_size = indices_end - indices_begin;
+    data.resize(origin_size + new_size);
+
+    for (int i = 0; i < new_size; ++i) {
+        int offset = indices_begin[i];
+        if constexpr (std::is_same_v<T, UInt8>) {
+            // Now Uint8 use to identify null and non null
+            // 1. nullable column : offset == -1 means is null at the here, set true here
+            // 2. real data column : offset == -1 what at is meaningless
+            data[origin_size + i] = (offset == -1) ? T{1} : src_vec.get_element(offset);
+        } else {
+            data[origin_size + i] = (offset == -1) ? T{0} : src_vec.get_element(offset);
+        }
     }
 }
 

--- a/be/src/vec/exec/join/join_op.h
+++ b/be/src/vec/exec/join/join_op.h
@@ -26,15 +26,15 @@ namespace doris::vectorized {
 struct RowRef {
     using SizeT = uint32_t; /// Do not use size_t cause of memory economy
 
-    const Block* block = nullptr;
     SizeT row_num = 0;
+    uint8_t block_offset;
     // Use in right join to mark row is visited
     // TODO: opt the varaible to use it only need
     bool visited = false;
 
     RowRef() {}
-    RowRef(const Block* block_ptr, size_t row_num_count, bool is_visited = false)
-            : block(block_ptr), row_num(row_num_count), visited(is_visited) {}
+    RowRef(size_t row_num_count, uint8_t block_offset_, bool is_visited = false)
+            : row_num(row_num_count), block_offset(block_offset_), visited(is_visited) {}
 };
 
 /// Single linked list of references to rows. Used for ALL JOINs (non-unique JOINs)
@@ -115,10 +115,10 @@ struct RowRefList : RowRef {
     };
 
     RowRefList() {}
-    RowRefList(const Block* block_, size_t row_num_) : RowRef(block_, row_num_) {}
+    RowRefList(size_t row_num_, uint8_t block_offset_) : RowRef(row_num_, block_offset_) {}
 
     ForwardIterator begin() { return ForwardIterator(this); }
-    ForwardIterator end() { return ForwardIterator::end(); }
+    static ForwardIterator end() { return ForwardIterator::end(); }
 
     /// insert element after current one
     void insert(RowRef&& row_ref, Arena& pool) {
@@ -138,6 +138,4 @@ private:
     uint32_t row_count = 1;
 };
 
-// using MapI32 = doris::vectorized::HashMap<UInt32, MappedAll, HashCRC32<UInt32>>;
-// using I32KeyType = doris::vectorized::ColumnsHashing::HashMethodOneNumber<MapI32::value_type, MappedAll, UInt32, false>;
 } // namespace doris::vectorized

--- a/be/src/vec/exec/join/vhash_join_node.h
+++ b/be/src/vec/exec/join/vhash_join_node.h
@@ -201,8 +201,8 @@ private:
 
     Arena _arena;
     HashTableVariants _hash_table_variants;
-    AcquireList<Block> _acquire_list;
 
+    std::vector<Block> _build_blocks;
     Block _probe_block;
     ColumnRawPtrs _probe_columns;
     ColumnUInt8::MutablePtr _null_map_column;
@@ -218,7 +218,6 @@ private:
     const bool _match_all_build; // output all rows coming from the build input. Full/Right Join
     bool _build_unique;          // build a hash table without duplicated rows. Left semi/anti Join
 
-    const bool _is_left_semi_anti;
     const bool _is_right_semi_anti;
     const bool _is_outer_join;
     bool _have_other_join_conjunct = false;
@@ -227,9 +226,12 @@ private:
     int _right_col_idx = 0;
     int _right_col_len = 0;
 
+    std::vector<uint32_t> _items_counts;
+    std::vector<int8_t> _build_block_offsets;
+    std::vector<int> _build_block_rows;
 private:
     Status _hash_table_build(RuntimeState* state);
-    Status _process_build_block(RuntimeState* state, Block& block);
+    Status _process_build_block(RuntimeState* state, Block& block, uint8_t offset);
 
     Status extract_build_join_column(Block& block, NullMap& null_map, ColumnRawPtrs& raw_ptrs,
                                      bool& ignore_null, RuntimeProfile::Counter& expr_call_timer);

--- a/be/src/vec/exec/vset_operation_node.cpp
+++ b/be/src/vec/exec/vset_operation_node.cpp
@@ -26,8 +26,9 @@ namespace vectorized {
 template <class HashTableContext>
 struct HashTableBuild {
     HashTableBuild(int rows, Block& acquired_block, ColumnRawPtrs& build_raw_ptrs,
-                   VSetOperationNode* operation_node)
+                   VSetOperationNode* operation_node, uint8_t offset)
             : _rows(rows),
+              _offset(offset),
               _acquired_block(acquired_block),
               _build_raw_ptrs(build_raw_ptrs),
               _operation_node(operation_node) {}
@@ -54,7 +55,7 @@ struct HashTableBuild {
             }
 
             if (emplace_result.is_inserted()) { //only inserted once as the same key, others skip
-                new (&emplace_result.get_mapped()) Mapped({&_acquired_block, k});
+                new (&emplace_result.get_mapped()) Mapped({k, _offset});
                 _operation_node->_valid_element_in_hash_tbl++;
             }
         }
@@ -63,6 +64,7 @@ struct HashTableBuild {
 
 private:
     const int _rows;
+    const uint8_t _offset;
     Block& _acquired_block;
     ColumnRawPtrs& _build_raw_ptrs;
     VSetOperationNode* _operation_node;
@@ -138,6 +140,7 @@ Status VSetOperationNode::prepare(RuntimeState* state) {
         _left_table_data_types.push_back(ctx->root()->data_type());
     }
     hash_table_init();
+
     return Status::OK();
 }
 
@@ -225,6 +228,10 @@ void VSetOperationNode::hash_table_init() {
 Status VSetOperationNode::hash_table_build(RuntimeState* state) {
     RETURN_IF_ERROR(child(0)->open(state));
     Block block;
+    MutableBlock mutable_block(_left_table_data_types);
+
+    uint8_t index = 0;
+    int64_t last_mem_used = 0;
     bool eos = false;
     while (!eos) {
         block.clear();
@@ -237,29 +244,44 @@ Status VSetOperationNode::hash_table_build(RuntimeState* state) {
         _mem_used += allocated_bytes;
 
         RETURN_IF_LIMIT_EXCEEDED(state, "Set Operation Node, while getting next from the child 0.");
-        RETURN_IF_ERROR(process_build_block(block));
-        RETURN_IF_LIMIT_EXCEEDED(state, "Set Operation Node, while constructing the hash table.");
+        if (block.rows() != 0) { mutable_block.merge(block); }
+
+        // make one block for each 4 gigabytes
+        constexpr static auto BUILD_BLOCK_MAX_SIZE =  4 * 1024UL * 1024UL * 1024UL;
+        if (_mem_used - last_mem_used > BUILD_BLOCK_MAX_SIZE) {
+             _build_blocks.emplace_back(mutable_block.to_block());
+            // TODO:: Rethink may we should do the proess after we recevie all build blocks ?
+            // which is better.
+            RETURN_IF_ERROR(process_build_block(_build_blocks[index], index));
+            RETURN_IF_LIMIT_EXCEEDED(state, "Set Operation Node, while constructing the hash table.");
+            mutable_block = MutableBlock(_left_table_data_types);
+            ++index;
+            last_mem_used = _mem_used;
+        }
     }
+
+    _build_blocks.emplace_back(mutable_block.to_block());
+    RETURN_IF_ERROR(process_build_block(_build_blocks[index], index));
+    RETURN_IF_LIMIT_EXCEEDED(state, "Set Operation Node, while constructing the hash table.");
     return Status::OK();
 }
 
-Status VSetOperationNode::process_build_block(Block& block) {
+Status VSetOperationNode::process_build_block(Block& block, uint8_t offset) {
     size_t rows = block.rows();
     if (rows == 0) {
         return Status::OK();
     }
 
-    auto& acquired_block = _acquire_list.acquire(std::move(block));
-    vectorized::materialize_block_inplace(acquired_block);
+    vectorized::materialize_block_inplace(block);
     ColumnRawPtrs raw_ptrs(_child_expr_lists[0].size());
-    RETURN_IF_ERROR(extract_build_column(acquired_block, raw_ptrs));
+    RETURN_IF_ERROR(extract_build_column(block, raw_ptrs));
 
     std::visit(
             [&](auto&& arg) {
                 using HashTableCtxType = std::decay_t<decltype(arg)>;
                 if constexpr (!std::is_same_v<HashTableCtxType, std::monostate>) {
-                    HashTableBuild<HashTableCtxType> hash_table_build_process(rows, acquired_block,
-                                                                              raw_ptrs, this);
+                    HashTableBuild<HashTableCtxType> hash_table_build_process(rows, block,
+                                                                              raw_ptrs, this, offset);
                     hash_table_build_process(arg);
                 } else {
                     LOG(FATAL) << "FATAL: uninited hash table";

--- a/be/src/vec/exec/vset_operation_node.h
+++ b/be/src/vec/exec/vset_operation_node.h
@@ -49,7 +49,7 @@ protected:
     //It's time to abstract out the same methods and provide them directly to others;
     void hash_table_init();
     Status hash_table_build(RuntimeState* state);
-    Status process_build_block(Block& block);
+    Status process_build_block(Block& block, uint8_t offset);
     Status extract_build_column(Block& block, ColumnRawPtrs& raw_ptrs);
     Status extract_probe_column(Block& block, ColumnRawPtrs& raw_ptrs, int child_id);
     template <bool keep_matched>
@@ -81,6 +81,7 @@ protected:
     //record insert column id during probe
     std::vector<uint16_t> _probe_column_inserted_id;
 
+    std::vector<Block> _build_blocks;
     Block _probe_block;
     ColumnRawPtrs _probe_columns;
     std::vector<MutableColumnPtr> _mutable_cols;
@@ -150,6 +151,7 @@ struct HashTableProbe {
               _left_table_data_types(operation_node->_left_table_data_types),
               _batch_size(batch_size),
               _probe_rows(probe_rows),
+              _build_blocks(operation_node->_build_blocks),
               _probe_block(operation_node->_probe_block),
               _probe_index(operation_node->_probe_index),
               _num_rows_returned(operation_node->_num_rows_returned),
@@ -183,9 +185,10 @@ struct HashTableProbe {
     }
 
     void add_result_columns(RowRefList& value, int& block_size) {
+        auto it = value.begin();
         for (auto idx = _build_col_idx.begin(); idx != _build_col_idx.end(); ++idx) {
-            auto& column = *value.begin()->block->get_by_position(idx->first).column;
-            _mutable_cols[idx->second]->insert_from(column, value.begin()->row_num);
+            auto& column = *_build_blocks[it->block_offset].get_by_position(idx->first).column;
+            _mutable_cols[idx->second]->insert_from(column, it->row_num);
         }
         block_size++;
     }
@@ -230,6 +233,7 @@ private:
     const DataTypes& _left_table_data_types;
     const int _batch_size;
     const size_t _probe_rows;
+    const std::vector<Block>& _build_blocks;
     const Block& _probe_block;
     int& _probe_index;
     int64_t& _num_rows_returned;

--- a/be/src/vec/sink/vdata_stream_sender.cpp
+++ b/be/src/vec/sink/vdata_stream_sender.cpp
@@ -156,9 +156,7 @@ Status VDataStreamSender::Channel::add_row(Block* block, int row) {
     }
 
     if (_mutable_block.get() == nullptr) {
-        auto empty_block = block->clone_empty();
-        _mutable_block.reset(
-                new MutableBlock(empty_block.mutate_columns(), empty_block.get_data_types()));
+        _mutable_block.reset(new MutableBlock(block->clone_empty()));
     }
     _mutable_block->add_row(block, row);
 
@@ -174,9 +172,7 @@ Status VDataStreamSender::Channel::add_rows(Block* block, const std::vector<int>
     }
 
     if (_mutable_block.get() == nullptr) {
-        auto empty_block = block->clone_empty();
-        _mutable_block.reset(
-                new MutableBlock(empty_block.mutate_columns(), empty_block.get_data_types()));
+        _mutable_block.reset(new MutableBlock(block->clone_empty()));
     }
 
     int row_wait_add = rows.size();


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

1. Opt hash join performance
Reduce mapped(RowRef) memory usage，the hash map traverse mapped is time consuming，so delete the block pointer（8 Bytes）is cache friendly.
After opt, the hash join performance is greatly improved。

My test:(SSB benchmark)
set runime_filter_type=0;
set parallel_fragment_exec_instance_num = 1;

inner join:
(before opt)
MySQL [ssb1]> SELECT count(c_custkey) FROM lineorder,customer WHERE lo_custkey = c_custkey;
+--------------------+
| count(c_custkey) |
+--------------------+
| 600037902 |
+--------------------+
1 row in set (43.25 sec)
(after opt)
MySQL [ssb1]> SELECT count(c_custkey) FROM customer inner join lineorder on lo_custkey = c_custkey;
+--------------------+
| count(`c_custkey`) |
+--------------------+
|          600037902 |
+--------------------+
1 row in set (21.66 sec)

ssb q3.3
MySQL [ssb1]> SELECT c_city, s_city, d_year, SUM(lo_revenue) AS REVENUE FROM customer, lineorder, supplier, dates WHERE lo_custkey = c_custkey AND lo_suppkey = s_suppkey AND lo_orderdate = d_datekey AND (c_city='UNITED KI1' OR c_city='UNITED KI5') AND (s_city='UNITED KI1' OR s_city='UNITED KI5') AND d_year >= 1992 AND d_year <= 1997 GROUP BY c_city, s_city, d_year ORDER BY d_year ASC, REVENUE DESC;
(before opt)
24 rows in set (32.15 sec)
(after opt):
24 rows in set (11.95 sec)

## Checklist(Required)

1. Does it affect the original behavior: (No)
2. Has unit tests been added: (No Need)
3. Has document been added or modified: (No Need)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
