### PR TITLE
[improvement] optimize compaction too slow replica process, will set to ok if the replica compaction is done

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/PaloFe.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/PaloFe.java
@@ -38,9 +38,9 @@ import org.apache.doris.service.FrontendOptions;
 import com.google.common.base.Charsets;
 import com.google.common.base.Strings;
 
-import org.apache.commons.cli.BasicParser;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
+import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 import org.apache.logging.log4j.LogManager;
@@ -208,7 +208,7 @@ public class PaloFe {
      *
      */
     private static CommandLineOptions parseArgs(String[] args) {
-        CommandLineParser commandLineParser = new BasicParser();
+        CommandLineParser commandLineParser = new DefaultParser();
         Options options = new Options();
         options.addOption("v", "version", false, "Print the version of Palo Frontend");
         options.addOption("h", "helper", true, "Specify the helper node when joining a bdb je replication group");

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/VirtualSlotRef.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/VirtualSlotRef.java
@@ -61,6 +61,13 @@ public class VirtualSlotRef extends SlotRef {
         return virtualSlotRef;
     }
 
+    public String getRealColumnName() {
+        if (getColumnName().startsWith(GroupingInfo.GROUPING_PREFIX)) {
+            return getColumnName().substring(GroupingInfo.GROUPING_PREFIX.length());
+        }
+        return getColumnName();
+    }
+
     @Override
     public void write(DataOutput out) throws IOException {
         super.write(out);

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Replica.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Replica.java
@@ -45,10 +45,12 @@ public class Replica implements Writable {
         SCHEMA_CHANGE,
         CLONE,
         ALTER, // replica is under rollup or schema change
-        DECOMMISSION; // replica is ready to be deleted
+        DECOMMISSION, // replica is ready to be deleted
+        COMPACTION_TOO_SLOW; // replica version count is too large
+
 
         public boolean canLoad() {
-            return this == NORMAL || this == SCHEMA_CHANGE || this == ALTER;
+            return this == NORMAL || this == SCHEMA_CHANGE || this == ALTER || this == COMPACTION_TOO_SLOW;
         }
 
         public boolean canQuery() {
@@ -401,19 +403,23 @@ public class Replica implements Writable {
     public void setState(ReplicaState replicaState) {
         this.state = replicaState;
     }
-    
+
     public ReplicaState getState() {
         return this.state;
     }
 
+    public boolean tooSlow() {
+        return state == ReplicaState.COMPACTION_TOO_SLOW;
+    }
+
     public long getVersionCount() {
-		return versionCount;
-	}
+        return versionCount;
+    }
 
     public void setVersionCount(long versionCount) {
-		this.versionCount = versionCount;
-	}
-    
+        this.versionCount = versionCount;
+    }
+
     @Override
     public String toString() {
         StringBuffer strBuffer = new StringBuffer("[replicaId=");

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Tablet.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Tablet.java
@@ -68,7 +68,7 @@ public class Tablet extends MetaObject implements Writable {
         COLOCATE_MISMATCH, // replicas do not all locate in right colocate backends set.
         COLOCATE_REDUNDANT, // replicas match the colocate backends set, but redundant.
         NEED_FURTHER_REPAIR, // one of replicas need a definite repair.
-        UNRECOVERABLE,   // non of replicas are healthy
+        UNRECOVERABLE,   // none of replicas are healthy
         REPLICA_COMPACTION_TOO_SLOW // one replica's version count is much more than other replicas;
     }
 
@@ -406,7 +406,8 @@ public class Tablet extends MetaObject implements Writable {
         ArrayList<Long> versions = new ArrayList<>();
         for (Replica replica : replicas) {
             Backend backend = systemInfoService.getBackend(replica.getBackendId());
-            if (backend == null || !backend.isAlive() || !replica.isAlive() || !hosts.add(backend.getHost())) {
+            if (backend == null || !backend.isAlive() || !replica.isAlive() || !hosts.add(backend.getHost())
+                    || replica.tooSlow()) {
                 // this replica is not alive,
                 // or if this replica is on same host with another replica, we also treat it as 'dead',
                 // so that Tablet Scheduler will create a new replica on different host.

--- a/fe/fe-core/src/main/java/org/apache/doris/clone/TabletScheduler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/TabletScheduler.java
@@ -39,7 +39,6 @@ import org.apache.doris.clone.TabletSchedCtx.Type;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.FeConstants;
-import org.apache.doris.common.MetaNotFoundException;
 import org.apache.doris.common.Pair;
 import org.apache.doris.common.util.MasterDaemon;
 import org.apache.doris.persist.ReplicaPersistInfo;
@@ -53,6 +52,8 @@ import org.apache.doris.task.AgentTaskQueue;
 import org.apache.doris.task.CloneTask;
 import org.apache.doris.task.DropReplicaTask;
 import org.apache.doris.thrift.TFinishTaskRequest;
+import org.apache.doris.transaction.DatabaseTransactionMgr;
+import org.apache.doris.transaction.TransactionState;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.EvictingQueue;
@@ -63,8 +64,6 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.google.common.collect.Table;
 
-import org.apache.doris.transaction.DatabaseTransactionMgr;
-import org.apache.doris.transaction.TransactionState;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -639,13 +638,17 @@ public class TabletScheduler extends MasterDaemon {
      */
     private void handleReplicaMissing(TabletSchedCtx tabletCtx, AgentBatchTask batchTask) throws SchedException {
         stat.counterReplicaMissingErr.incrementAndGet();
+        // check compaction too slow file is recovered
+        if (tabletCtx.compactionRecovered()) {
+            return;
+        }
+
         // find proper tag
         Tag tag = chooseProperTag(tabletCtx, true);
         // find an available dest backend and path
         RootPathLoadStatistic destPath = chooseAvailableDestPath(tabletCtx, tag, false /* not for colocate */);
         Preconditions.checkNotNull(destPath);
         tabletCtx.setDest(destPath.getBeId(), destPath.getPathHash());
-
         // choose a source replica for cloning from
         tabletCtx.chooseSrcReplica(backendsWorkingSlots, -1);
 
@@ -664,7 +667,7 @@ public class TabletScheduler extends MasterDaemon {
         Map<Tag, Short> currentAllocMap = Maps.newHashMap();
         for (Replica replica : replicas) {
             Backend be = infoService.getBackend(replica.getBackendId());
-            if (be != null && be.isScheduleAvailable() && replica.isAlive()) {
+            if (be != null && be.isScheduleAvailable() && replica.isAlive() && !replica.tooSlow()) {
                 Short num = currentAllocMap.getOrDefault(be.getTag(), (short) 0);
                 currentAllocMap.put(be.getTag(), (short) (num + 1));
             }
@@ -780,6 +783,7 @@ public class TabletScheduler extends MasterDaemon {
         if (deleteBackendDropped(tabletCtx, force)
                 || deleteBadReplica(tabletCtx, force)
                 || deleteBackendUnavailable(tabletCtx, force)
+                || deleteTooSlowReplica(tabletCtx, force)
                 || deleteCloneOrDecommissionReplica(tabletCtx, force)
                 || deleteReplicaWithFailedVersion(tabletCtx, force)
                 || deleteReplicaWithLowerVersion(tabletCtx, force)
@@ -810,6 +814,16 @@ public class TabletScheduler extends MasterDaemon {
         for (Replica replica : tabletCtx.getReplicas()) {
             if (replica.isBad()) {
                 deleteReplicaInternal(tabletCtx, replica, "replica is bad", force);
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean deleteTooSlowReplica(TabletSchedCtx tabletCtx, boolean force) throws SchedException {
+        for (Replica replica : tabletCtx.getReplicas()) {
+            if (replica.tooSlow()) {
+                deleteReplicaInternal(tabletCtx, replica, "replica is too slow", force);
                 return true;
             }
         }
@@ -1007,12 +1021,16 @@ public class TabletScheduler extends MasterDaemon {
      * remove the replica which has the most version count, and much more than others
      * return true if delete one replica, otherwise, return false.
      */
-    private boolean handleReplicaTooSlow(TabletSchedCtx tabletCtx) throws SchedException {
+    private void handleReplicaTooSlow(TabletSchedCtx tabletCtx) throws SchedException {
         Replica chosenReplica = null;
         Replica minReplica = null;
         long maxVersionCount = -1;
         long minVersionCount = Integer.MAX_VALUE;
+        int normalReplicaCount = 0;
         for (Replica replica : tabletCtx.getReplicas()) {
+            if (replica.isAlive() && !replica.tooSlow()) {
+                normalReplicaCount++;
+            }
             if (replica.getVersionCount() > maxVersionCount) {
                 maxVersionCount = replica.getVersionCount();
                 chosenReplica = replica;
@@ -1023,17 +1041,15 @@ public class TabletScheduler extends MasterDaemon {
             }
         }
 
-        if (chosenReplica != null && !chosenReplica.equals(minReplica) && minReplica.isAlive()) {
-            try {
-                Catalog.getCurrentCatalog().setReplicaStatus(tabletCtx.getTabletId(), chosenReplica.getBackendId(),
-                        Replica.ReplicaStatus.BAD);
-                throw new SchedException(Status.FINISHED, "set slow replica as bad");
-            } catch (MetaNotFoundException e) {
-                LOG.warn("set slow replica bad failed:", e);
-                return false;
-            }
+        if (chosenReplica != null && !chosenReplica.equals(minReplica) && minReplica.isAlive() && !minReplica.tooSlow()
+                && normalReplicaCount >= 1) {
+            chosenReplica.setState(ReplicaState.COMPACTION_TOO_SLOW);
+            LOG.info("set replica id :{} tablet id: {}, backend id: {} to COMPACTION_TOO_SLOW", chosenReplica.getId()
+                    , tabletCtx.getTablet()
+                    .getId(), chosenReplica.getBackendId());
+            throw new SchedException(Status.FINISHED, "set replica to COMPACTION_TOO_SLOW");
         }
-        return false;
+        throw new SchedException(Status.FINISHED, "No replica too slow");
     }
 
     private void deleteReplicaInternal(TabletSchedCtx tabletCtx, Replica replica, String reason, boolean force) throws SchedException {

--- a/fe/fe-core/src/test/java/org/apache/doris/planner/QueryPlanTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/planner/QueryPlanTest.java
@@ -2002,12 +2002,28 @@ public class QueryPlanTest {
                 "\"in_memory\" = \"false\",\n" +
                 "\"storage_format\" = \"V2\"\n" +
                 ")");
+        createTable("CREATE TABLE issue7971.`t1` (\n" +
+                "  `k1` tinyint(4) NULL COMMENT \"\",\n" +
+                "  `k21` smallint(6) NULL COMMENT \"\",\n" +
+                "  `k31` smallint(6) NULL COMMENT \"\"\n" +
+                ") ENGINE=OLAP\n" +
+                "DUPLICATE KEY(`k1`)\n" +
+                "COMMENT \"OLAP\"\n" +
+                "DISTRIBUTED BY HASH(`k1`) BUCKETS 1\n" +
+                "PROPERTIES (\n" +
+                "\"replication_allocation\" = \"tag.location.default: 1\",\n" +
+                "\"in_memory\" = \"false\",\n" +
+                "\"storage_format\" = \"V2\"\n" +
+                ")");
         String sql = "SELECT k1, k2, GROUPING(k1), GROUPING(k2), SUM(k3) FROM issue7971.t GROUP BY GROUPING SETS ( (k1, k2), (k2), (k1), ( ) );";
         String explainStr = UtFrameUtils.getSQLPlanOrErrorMsg(connectContext, sql);
         Assert.assertTrue(explainStr.contains("REPEAT_NODE"));
         sql = "SELECT k1 ,GROUPING(k2) FROM issue7971.t GROUP BY CUBE (k1) ORDER BY k1;";
         explainStr = UtFrameUtils.getSQLPlanOrErrorMsg(connectContext, sql);
         Assert.assertTrue(explainStr.contains("errCode = 2"));
+        sql = "select grouping_id(t1.k1), t1.k1, max(k2) from issue7971.t left join issue7971.t1 on t.k3 = t1.k1 group by grouping sets ((k1), ());";
+        explainStr = UtFrameUtils.getSQLPlanOrErrorMsg(connectContext, sql);
+        Assert.assertTrue(explainStr.contains("REPEAT_NODE"));
     }
 
     @Test


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

optimize compaction too slow replica process, will set to ok if the replica compaction is done. And will not set bad if more than half repilca is too slow,
fix field in grouping_id() is not the same name will cause error lile  `select list expression not produced by aggregation output (missing from GROUP BY clause?): id`

## Checklist(Required)

1. Does it affect the original behavior: (No)
2. Has unit tests been added: (No Need)
3. Has document been added or modified: (No Need)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
