### PR TITLE
[typo] (docs) update backup and restore docs

### DIFF
--- a/docs/en/sql-reference/sql-statements/Data Definition/BACKUP.md
+++ b/docs/en/sql-reference/sql-statements/Data Definition/BACKUP.md
@@ -30,7 +30,7 @@ This statement is used to backup data under the specified database. This command
 Grammar:
 BACKUP SNAPSHOT [db_name].{snapshot_name}
 TO `repository_name`
-ON (
+ON/EXCLUDE (
 `Table_name` [partition (`P1',...)],
 ...
 )
@@ -39,7 +39,8 @@ PROPERTIES ("key"="value", ...);
 Explain:
 1. Only one BACKUP or RESTORE task can be performed under the same database.
 2. The ON clause identifies the tables and partitions that need to be backed up. If no partition is specified, all partitions of the table are backed up by default.
-3. PROPERTIES currently supports the following attributes:
+3. The EXCLUDE clause identifies the tables and partitions that need not to be backed up. All partitions of all tables in the database except the specified tables or partitions will be backed up.
+4. PROPERTIES currently supports the following attributes:
 "Type" = "full": means that this is a full update (default).
 "Timeout" = "3600": Task timeout, default to one day. Unit seconds.
 
@@ -59,6 +60,11 @@ ON
 example_tbl PARTITION (p1,p2),
 Example:
 );
+
+3. Back up all tables in example_db except example_tbl to the warehouse example_repo:
+BACKUP SNAPSHOT example_db.snapshot_label3
+TO example_repo
+EXCLUDE (example_tbl);
 
 ## keyword
 BACKUP

--- a/docs/en/sql-reference/sql-statements/Data Definition/BACKUP.md
+++ b/docs/en/sql-reference/sql-statements/Data Definition/BACKUP.md
@@ -30,7 +30,7 @@ This statement is used to backup data under the specified database. This command
 Grammar:
 BACKUP SNAPSHOT [db_name].{snapshot_name}
 TO `repository_name`
-ON/EXCLUDE (
+[ON|EXCLUDE] (
 `Table_name` [partition (`P1',...)],
 ...
 )

--- a/docs/en/sql-reference/sql-statements/Data Definition/RESTORE.md
+++ b/docs/en/sql-reference/sql-statements/Data Definition/RESTORE.md
@@ -31,7 +31,7 @@ This statement is used to restore the data previously backed up by the BACKUP co
 Grammar:
 SNAPSHOT RESTORE [dbu name].{snapshot name}
 FROM `repository_name`
-ON (
+ON/EXCLUDE (
 "`Table `uname'[`partition (`p1',...)] [as `tbl `uu alias'],
 ...
 )
@@ -40,10 +40,11 @@ PROPERTIES ("key"="value", ...);
 Explain:
 1. Only one BACKUP or RESTORE task can be performed under the same database.
 2. The ON clause identifies the tables and partitions that need to be restored. If no partition is specified, all partitions of the table are restored by default. The specified tables and partitions must already exist in the warehouse backup.
-3. The backup tables in the warehouse can be restored to new tables through AS statements. But the new table name cannot already exist in the database. Partition name cannot be changed.
-4. The backup tables in the warehouse can be restored and replaced with the same-name tables in the database, but the table structure of the two tables must be completely consistent. Table structure includes: table name, column, partition, Rollup and so on.
-5. Partitions of the recovery table can be specified, and the system checks whether the partition Range or List matches.
-6. PROPERTIES currently supports the following attributes:
+3. The EXCLUDE clause identifies the tables and partiitons that need not to be restored. All partitions of all tables in the warehouse except the specified tables or partitions will be restored.
+4. The backup tables in the warehouse can be restored to new tables through AS statements. But the new table name cannot already exist in the database. Partition name cannot be changed.
+5. The backup tables in the warehouse can be restored and replaced with the same-name tables in the database, but the table structure of the two tables must be completely consistent. Table structure includes: table name, column, partition, Rollup and so on.
+6. Partitions of the recovery table can be specified, and the system checks whether the partition Range or List matches.
+7. PROPERTIES currently supports the following attributes:
 "Backup_timestamp" = "2018-05-04-16-45-08": specifies which version of the time to restore the corresponding backup must be filled in. This information can be obtained through the `SHOW SNAPSHOT ON repo;'statement.
 "Replication_num" = "3": Specifies the number of replicas of the restored table or partition. The default is 3. If an existing table or partition is restored, the number of copies must be the same as the number of copies of an existing table or partition. At the same time, there must be enough hosts to accommodate multiple copies.
 "Timeout" = "3600": Task timeout, default to one day. Unit seconds.
@@ -73,6 +74,14 @@ PROPERTIES
 "backup_timestamp"="2018-05-04-17-11-01"
 );
 
+3. Restore backup all partiitons of all tables in snapshot_3 from example_repo to database example_db1 except backup_tbl with the time version of "2018-05-04-18-12-18".
+RESTORE SNAPSHOT example_db1.`snapshot_3`
+FROM `example_repo`
+EXCLUDE ( `backup_tbl` )
+PROPERTIES
+(
+    "backup_timestamp"="2018-05-04-18-12-18"
+);
 ## keyword
 RESTORE
 

--- a/docs/en/sql-reference/sql-statements/Data Definition/RESTORE.md
+++ b/docs/en/sql-reference/sql-statements/Data Definition/RESTORE.md
@@ -31,7 +31,7 @@ This statement is used to restore the data previously backed up by the BACKUP co
 Grammar:
 SNAPSHOT RESTORE [dbu name].{snapshot name}
 FROM `repository_name`
-ON/EXCLUDE (
+[ON|EXCLUDE] (
 "`Table `uname'[`partition (`p1',...)] [as `tbl `uu alias'],
 ...
 )

--- a/docs/zh-CN/sql-reference/sql-statements/Data Definition/BACKUP.md
+++ b/docs/zh-CN/sql-reference/sql-statements/Data Definition/BACKUP.md
@@ -30,7 +30,7 @@ under the License.
     语法：
         BACKUP SNAPSHOT [db_name].{snapshot_name}
         TO `repository_name`
-        ON/EXCLUDE (
+        [ON|EXCLUDE] (
             `table_name` [PARTITION (`p1`, ...)],
             ...
         )

--- a/docs/zh-CN/sql-reference/sql-statements/Data Definition/BACKUP.md
+++ b/docs/zh-CN/sql-reference/sql-statements/Data Definition/BACKUP.md
@@ -30,7 +30,7 @@ under the License.
     语法：
         BACKUP SNAPSHOT [db_name].{snapshot_name}
         TO `repository_name`
-        ON (
+        ON/EXCLUDE (
             `table_name` [PARTITION (`p1`, ...)],
             ...
         )
@@ -39,7 +39,8 @@ under the License.
     说明：
         1. 同一数据库下只能有一个正在执行的 BACKUP 或 RESTORE 任务。
         2. ON 子句中标识需要备份的表和分区。如果不指定分区，则默认备份该表的所有分区。
-        3. PROPERTIES 目前支持以下属性：
+        3. EXCLUDE 子句中标识不需要备份的表和分区。备份除了指定的表或分区之外这个数据库中所有表的所有分区数据。
+        4. PROPERTIES 目前支持以下属性：
                 "type" = "full"：表示这是一次全量更新（默认）。
                 "timeout" = "3600"：任务超时时间，默认为一天。单位秒。
 
@@ -59,6 +60,11 @@ under the License.
             example_tbl PARTITION (p1,p2),
             example_tbl2
         );
+
+    3. 全量备份 example_db 下除了表 example_tbl 的其他所有表到仓库 example_repo 中： 
+        BACKUP SNAPSHOT example_db.snapshot_label3
+        TO example_repo
+        EXCLUDE (example_tbl);
 
 ## keyword
     BACKUP

--- a/docs/zh-CN/sql-reference/sql-statements/Data Definition/RESTORE.md
+++ b/docs/zh-CN/sql-reference/sql-statements/Data Definition/RESTORE.md
@@ -31,7 +31,7 @@ under the License.
     语法：
         RESTORE SNAPSHOT [db_name].{snapshot_name}
         FROM `repository_name`
-        ON (
+        ON/EXCLUDE (
             `table_name` [PARTITION (`p1`, ...)] [AS `tbl_alias`],
             ...
         )
@@ -40,10 +40,11 @@ under the License.
     说明：
         1. 同一数据库下只能有一个正在执行的 BACKUP 或 RESTORE 任务。
         2. ON 子句中标识需要恢复的表和分区。如果不指定分区，则默认恢复该表的所有分区。所指定的表和分区必须已存在于仓库备份中。
-        3. 可以通过 AS 语句将仓库中备份的表名恢复为新的表。但新表名不能已存在于数据库中。分区名称不能修改。
-        4. 可以将仓库中备份的表恢复替换数据库中已有的同名表，但须保证两张表的表结构完全一致。表结构包括：表名、列、分区、Rollup等等。
-        5. 可以指定恢复表的部分分区，系统会检查分区 Range 或者 List 是否能够匹配。
-        6. PROPERTIES 目前支持以下属性：
+        3. EXCLUDE 子句中标识不需要恢复的表和分区。除了所指定的表或分区之外仓库中所有其他表的所有分区将被恢复。
+        4. 可以通过 AS 语句将仓库中备份的表名恢复为新的表。但新表名不能已存在于数据库中。分区名称不能修改。
+        5. 可以将仓库中备份的表恢复替换数据库中已有的同名表，但须保证两张表的表结构完全一致。表结构包括：表名、列、分区、Rollup等等。
+        6. 可以指定恢复表的部分分区，系统会检查分区 Range 或者 List 是否能够匹配。
+        7. PROPERTIES 目前支持以下属性：
                 "backup_timestamp" = "2018-05-04-16-45-08"：指定了恢复对应备份的哪个时间版本，必填。该信息可以通过 `SHOW SNAPSHOT ON repo;` 语句获得。
                 "replication_num" = "3"：指定恢复的表或分区的副本数。默认为3。若恢复已存在的表或分区，则副本数必须和已存在表或分区的副本数相同。同时，必须有足够的 host 容纳多个副本。
                 "timeout" = "3600"：任务超时时间，默认为一天。单位秒。
@@ -71,6 +72,15 @@ under the License.
         PROPERTIES
         (
             "backup_timestamp"="2018-05-04-17-11-01"
+        );
+
+    3. 从 example_repo 中恢复备份 snapshot_3 中除了表 backup_tbl 的其他所有表到数据库 example_db1，时间版本为 "2018-05-04-18-12-18"。
+        RESTORE SNAPSHOT example_db1.`snapshot_3`
+        FROM `example_repo`
+        EXCLUDE ( `backup_tbl` )
+        PROPERTIES
+        (
+            "backup_timestamp"="2018-05-04-18-12-18"
         );
 
 ## keyword

--- a/docs/zh-CN/sql-reference/sql-statements/Data Definition/RESTORE.md
+++ b/docs/zh-CN/sql-reference/sql-statements/Data Definition/RESTORE.md
@@ -31,7 +31,7 @@ under the License.
     语法：
         RESTORE SNAPSHOT [db_name].{snapshot_name}
         FROM `repository_name`
-        ON/EXCLUDE (
+        [ON|EXCLUDE] (
             `table_name` [PARTITION (`p1`, ...)] [AS `tbl_alias`],
             ...
         )


### PR DESCRIPTION
# Proposed changes

## Problem Summary:

The 'backup' and 'restore' commands already support the 'EXCLUDE' clause, but viewing the help documentation with 'help backup' and 'help restore' commands has no information about it.

## Checklist(Required)

1. Does it affect the original behavior: (No)
2. Has unit tests been added: (No)
3. Has document been added or modified: (Yes)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
