### PR TITLE
(improvement)(olap) using placement-new to avoid dynamic mallocing for ParsedPage

### DIFF
--- a/be/src/olap/rowset/segment_v2/column_reader.cpp
+++ b/be/src/olap/rowset/segment_v2/column_reader.cpp
@@ -465,27 +465,24 @@ Status FileColumnIterator::seek_to_first() {
     RETURN_IF_ERROR(_reader->seek_to_first(&_page_iter));
     RETURN_IF_ERROR(_read_data_page(_page_iter));
 
-    _seek_to_pos_in_page(_page.get(), 0);
+    _seek_to_pos_in_page(&_page, 0);
     _current_ordinal = 0;
     return Status::OK();
 }
 
 Status FileColumnIterator::seek_to_ordinal(ordinal_t ord) {
     // if current page contains this row, we don't need to seek
-    if (_page == nullptr || !_page->contains(ord) || !_page_iter.valid()) {
+    if (!_page || !_page.contains(ord) || !_page_iter.valid()) {
         RETURN_IF_ERROR(_reader->seek_at_or_before(ord, &_page_iter));
         RETURN_IF_ERROR(_read_data_page(_page_iter));
     }
-    _seek_to_pos_in_page(_page.get(), ord - _page->first_ordinal);
+    _seek_to_pos_in_page(&_page, ord - _page.first_ordinal);
     _current_ordinal = ord;
     return Status::OK();
 }
 
 Status FileColumnIterator::seek_to_page_start() {
-    if (_page == nullptr) {
-        return Status::NotSupported("Can not seek to page first when page is nullptr");
-    }
-    return seek_to_ordinal(_page->first_ordinal);
+    return seek_to_ordinal(_page.first_ordinal);
 }
 
 void FileColumnIterator::_seek_to_pos_in_page(ParsedPage* page, ordinal_t offset_in_page) {
@@ -495,7 +492,7 @@ void FileColumnIterator::_seek_to_pos_in_page(ParsedPage* page, ordinal_t offset
     }
 
     ordinal_t pos_in_data = offset_in_page;
-    if (_page->has_null) {
+    if (_page.has_null) {
         ordinal_t offset_in_data = 0;
         ordinal_t skips = offset_in_page;
 
@@ -521,7 +518,7 @@ Status FileColumnIterator::next_batch(size_t* n, ColumnBlockView* dst, bool* has
     size_t remaining = *n;
     *has_null = false;
     while (remaining > 0) {
-        if (!_page->has_remaining()) {
+        if (!_page.has_remaining()) {
             bool eos = false;
             RETURN_IF_ERROR(_load_next_page(&eos));
             if (eos) {
@@ -530,9 +527,9 @@ Status FileColumnIterator::next_batch(size_t* n, ColumnBlockView* dst, bool* has
         }
 
         // number of rows to be read from this page
-        size_t nrows_in_page = std::min(remaining, _page->remaining());
+        size_t nrows_in_page = std::min(remaining, _page.remaining());
         size_t nrows_to_read = nrows_in_page;
-        if (_page->has_null) {
+        if (_page.has_null) {
             // when this page contains NULLs we read data in some runs
             // first we read null bits in the same value, if this is null, we
             // don't need to read value from page.
@@ -541,11 +538,11 @@ Status FileColumnIterator::next_batch(size_t* n, ColumnBlockView* dst, bool* has
             // will lead too many function calls to PageDecoder
             while (nrows_to_read > 0) {
                 bool is_null = false;
-                size_t this_run = _page->null_decoder.GetNextRun(&is_null, nrows_to_read);
+                size_t this_run = _page.null_decoder.GetNextRun(&is_null, nrows_to_read);
                 // we use num_rows only for CHECK
                 size_t num_rows = this_run;
                 if (!is_null) {
-                    RETURN_IF_ERROR(_page->data_decoder->next_batch(&num_rows, dst));
+                    RETURN_IF_ERROR(_page.data_decoder->next_batch(&num_rows, dst));
                     DCHECK_EQ(this_run, num_rows);
                 } else {
                     *has_null = true;
@@ -555,19 +552,19 @@ Status FileColumnIterator::next_batch(size_t* n, ColumnBlockView* dst, bool* has
                 dst->set_null_bits(this_run, is_null);
 
                 nrows_to_read -= this_run;
-                _page->offset_in_page += this_run;
+                _page.offset_in_page += this_run;
                 dst->advance(this_run);
                 _current_ordinal += this_run;
             }
         } else {
-            RETURN_IF_ERROR(_page->data_decoder->next_batch(&nrows_to_read, dst));
+            RETURN_IF_ERROR(_page.data_decoder->next_batch(&nrows_to_read, dst));
             DCHECK_EQ(nrows_to_read, nrows_in_page);
 
             if (dst->is_nullable()) {
                 dst->set_null_bits(nrows_to_read, false);
             }
 
-            _page->offset_in_page += nrows_to_read;
+            _page.offset_in_page += nrows_to_read;
             dst->advance(nrows_to_read);
             _current_ordinal += nrows_to_read;
         }
@@ -585,7 +582,7 @@ Status FileColumnIterator::next_batch(size_t* n, vectorized::MutableColumnPtr &d
     size_t remaining = *n;
     *has_null = false;
     while (remaining > 0) {
-        if (!_page->has_remaining()) {
+        if (!_page.has_remaining()) {
             bool eos = false;
             RETURN_IF_ERROR(_load_next_page(&eos));
             if (eos) {
@@ -594,16 +591,16 @@ Status FileColumnIterator::next_batch(size_t* n, vectorized::MutableColumnPtr &d
         }
 
         // number of rows to be read from this page
-        size_t nrows_in_page = std::min(remaining, _page->remaining());
+        size_t nrows_in_page = std::min(remaining, _page.remaining());
         size_t nrows_to_read = nrows_in_page;
-        if (_page->has_null) {
+        if (_page.has_null) {
             while (nrows_to_read > 0) {
                 bool is_null = false;
-                size_t this_run = _page->null_decoder.GetNextRun(&is_null, nrows_to_read);
+                size_t this_run = _page.null_decoder.GetNextRun(&is_null, nrows_to_read);
                 // we use num_rows only for CHECK
                 size_t num_rows = this_run;
                 if (!is_null) {
-                    RETURN_IF_ERROR(_page->data_decoder->next_batch(&num_rows, dst));
+                    RETURN_IF_ERROR(_page.data_decoder->next_batch(&num_rows, dst));
                     DCHECK_EQ(this_run, num_rows);
                 } else {
                     *has_null = true;
@@ -614,14 +611,14 @@ Status FileColumnIterator::next_batch(size_t* n, vectorized::MutableColumnPtr &d
                 }
 
                 nrows_to_read -= this_run;
-                _page->offset_in_page += this_run;
+                _page.offset_in_page += this_run;
                 _current_ordinal += this_run;
             }
         } else {
-            RETURN_IF_ERROR(_page->data_decoder->next_batch(&nrows_to_read, dst));
+            RETURN_IF_ERROR(_page.data_decoder->next_batch(&nrows_to_read, dst));
             DCHECK_EQ(nrows_to_read, nrows_in_page);
 
-            _page->offset_in_page += nrows_to_read;
+            _page.offset_in_page += nrows_to_read;
             _current_ordinal += nrows_to_read;
         }
         remaining -= nrows_in_page;
@@ -639,7 +636,7 @@ Status FileColumnIterator::_load_next_page(bool* eos) {
     }
 
     RETURN_IF_ERROR(_read_data_page(_page_iter));
-    _seek_to_pos_in_page(_page.get(), 0);
+    _seek_to_pos_in_page(&_page, 0);
     *eos = false;
     return Status::OK();
 }
@@ -661,7 +658,7 @@ Status FileColumnIterator::_read_data_page(const OrdinalPageIndexIterator& iter)
     // note that concurrent iterators for the same column won't repeatedly read dictionary page
     // because of page cache.
     if (_reader->encoding_info()->encoding() == DICT_ENCODING) {
-        auto dict_page_decoder = reinterpret_cast<BinaryDictPageDecoder*>(_page->data_decoder);
+        auto dict_page_decoder = reinterpret_cast<BinaryDictPageDecoder*>(_page.data_decoder);
         if (dict_page_decoder->is_dict_encoding()) {
             if (_dict_decoder == nullptr) {
                 // read dictionary page

--- a/be/src/olap/rowset/segment_v2/column_reader.h
+++ b/be/src/olap/rowset/segment_v2/column_reader.h
@@ -273,7 +273,7 @@ public:
 
     Status get_row_ranges_by_bloom_filter(CondColumn* cond_column, RowRanges* row_ranges) override;
 
-    ParsedPage* get_current_page() { return _page.get(); }
+    ParsedPage* get_current_page() { return &_page; }
 
     bool is_nullable() { return _reader->is_nullable(); }
 
@@ -288,8 +288,7 @@ private:
     // 1. The _page represents current page.
     // 2. We define an operation is one seek and following read,
     //    If new seek is issued, the _page will be reset.
-    // 3. When _page is null, it means that this reader can not be read.
-    std::unique_ptr<ParsedPage> _page;
+    ParsedPage _page;
 
     // keep dict page decoder
     std::unique_ptr<PageDecoder> _dict_decoder;

--- a/be/src/olap/rowset/segment_v2/indexed_column_reader.h
+++ b/be/src/olap/rowset/segment_v2/indexed_column_reader.h
@@ -140,7 +140,7 @@ private:
     // current in-use index iterator, could be `&_ordinal_iter` or `&_value_iter` or null
     IndexPageIterator* _current_iter = nullptr;
     // seeked data page, containing value at `_current_ordinal`
-    std::unique_ptr<ParsedPage> _data_page;
+    ParsedPage _data_page;
     // next_batch() will read from this position
     ordinal_t _current_ordinal = 0;
     // open file handle


### PR DESCRIPTION
# Proposed changes
use C++ placement-new feature to save consuming, placement-new can seperate mallocing from constructing.

Issue Number: close #xxx

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
