### PR TITLE
[fix](stream-load) fix bug that stream load may be blocked with unqualified data

### DIFF
--- a/be/src/runtime/fragment_mgr.cpp
+++ b/be/src/runtime/fragment_mgr.cpp
@@ -511,7 +511,7 @@ Status FragmentMgr::exec_plan_fragment(const TExecPlanFragmentParams& params) {
         RETURN_IF_ERROR(_exec_env->load_stream_mgr()->put(stream_load_cxt->id, pipe));
 
         RETURN_IF_ERROR(
-                _exec_env->stream_load_executor()->execute_plan_fragment(stream_load_cxt, pipe));
+                _exec_env->stream_load_executor()->execute_plan_fragment(stream_load_cxt));
         set_pipe(params.params.fragment_instance_id, pipe);
         return Status::OK();
     } else {

--- a/be/src/runtime/message_body_sink.h
+++ b/be/src/runtime/message_body_sink.h
@@ -31,6 +31,14 @@ public:
     virtual Status finish() { return Status::OK(); }
     // called when read HTTP failed
     virtual void cancel(const std::string& reason) {}
+
+    bool finished() const { return _finished; }
+    bool cancelled() const { return _cancelled; }
+
+protected:
+    bool _finished = false;
+    bool _cancelled = false;
+    std::string _cancelled_reason = "";
 };
 
 // write message to a local file

--- a/be/src/runtime/plan_fragment_executor.cpp
+++ b/be/src/runtime/plan_fragment_executor.cpp
@@ -297,7 +297,7 @@ Status PlanFragmentExecutor::open_vectorized_internal() {
             _collect_query_statistics();
         }
 
-        auto st =_sink->send(runtime_state(), block);
+        auto st = _sink->send(runtime_state(), block);
         if (st.is_end_of_file()) {
             break;
         }

--- a/be/src/runtime/stream_load/stream_load_executor.h
+++ b/be/src/runtime/stream_load/stream_load_executor.h
@@ -50,7 +50,6 @@ public:
 
     Status execute_plan_fragment(StreamLoadContext* ctx);
 
-    Status execute_plan_fragment(StreamLoadContext* ctx, std::shared_ptr<StreamLoadPipe> pipe);
 private:
     // collect the load statistics from context and set them to stat
     // return true if stat is set, otherwise, return false

--- a/be/src/runtime/stream_load/stream_load_pipe.h
+++ b/be/src/runtime/stream_load/stream_load_pipe.h
@@ -40,9 +40,7 @@ public:
               _max_buffered_bytes(max_buffered_bytes),
               _min_chunk_size(min_chunk_size),
               _total_length(total_length),
-              _use_proto(use_proto),
-              _finished(false),
-              _cancelled(false) {}
+              _use_proto(use_proto) {}
     virtual ~StreamLoadPipe() {}
 
     Status open() override { return Status::OK(); }
@@ -270,9 +268,6 @@ private:
     std::condition_variable _put_cond;
     std::condition_variable _get_cond;
 
-    bool _finished;
-    bool _cancelled;
-    std::string _cancelled_reason = "";
 
     ByteBufferPtr _write_buf;
 };


### PR DESCRIPTION
# Proposed changes

Issue Number: close #8177 

## Problem Summary:

The stream load pipe need to be cancelled after the load process finish.

## Checklist(Required)

1. Does it affect the original behavior: (No)
2. Has unit tests been added: (No Need)
3. Has document been added or modified: (No Need)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
