### PR TITLE
[refactor](storage)(olap) improve pageDecoder using final keyword and reuse BinaryDictPageDecoder's members

### DIFF
--- a/be/src/olap/rowset/segment_v2/binary_dict_page.h
+++ b/be/src/olap/rowset/segment_v2/binary_dict_page.h
@@ -105,7 +105,7 @@ public:
     ~BinaryDictPageDecoder() {
         if (_encoding_type == DICT_ENCODING) {
             _bit_shuffle.~BitShufflePageDecoder<OLAP_FIELD_TYPE_INT>();
-        } else {
+        } else if (_encoding_type == PLAIN_ENCODING) {
             _binary_plain.~BinaryPlainPageDecoder();
         }
     }

--- a/be/src/olap/rowset/segment_v2/binary_plain_page.h
+++ b/be/src/olap/rowset/segment_v2/binary_plain_page.h
@@ -185,13 +185,13 @@ public:
         return Status::OK();
     }
 
-    Status seek_to_position_in_page(size_t pos) override {
+    Status seek_to_position_in_page(size_t pos) override final {
         DCHECK_LE(pos, _num_elems);
         _cur_idx = pos;
         return Status::OK();
     }
 
-    Status next_batch(size_t* n, ColumnBlockView* dst) override {
+    Status next_batch(size_t* n, ColumnBlockView* dst) override final {
         DCHECK(_parsed);
         if (PREDICT_FALSE(*n == 0 || _cur_idx >= _num_elems)) {
             *n = 0;
@@ -230,7 +230,7 @@ public:
         return Status::OK();
     }
 
-    Status next_batch(size_t* n, vectorized::MutableColumnPtr &dst) override {
+    Status next_batch(size_t* n, vectorized::MutableColumnPtr &dst) override final {
         DCHECK(_parsed);
         if (PREDICT_FALSE(*n == 0 || _cur_idx >= _num_elems)) {
             *n = 0;
@@ -252,12 +252,12 @@ public:
         return Status::OK();
     };
 
-    size_t count() const override {
+    size_t count() const override final {
         DCHECK(_parsed);
         return _num_elems;
     }
 
-    size_t current_index() const override {
+    size_t current_index() const override final {
         DCHECK(_parsed);
         return _cur_idx;
     }
@@ -269,6 +269,8 @@ public:
     }
 
     void get_dict_word_info(StringRef* dict_word_info) {
+        if (_num_elems <= 0) return;
+
         char* data_begin = (char*)&_data[0];
         char* offset_ptr = (char*)&_data[_offsets_pos];
 

--- a/be/src/olap/rowset/segment_v2/bitshuffle_page.h
+++ b/be/src/olap/rowset/segment_v2/bitshuffle_page.h
@@ -278,7 +278,7 @@ public:
         return Status::OK();
     }
 
-    Status seek_to_position_in_page(size_t pos) override {
+    Status seek_to_position_in_page(size_t pos) override final {
         DCHECK(_parsed) << "Must call init()";
         if (PREDICT_FALSE(_num_elements == 0)) {
             DCHECK_EQ(0, pos);
@@ -290,7 +290,7 @@ public:
         return Status::OK();
     }
 
-    Status seek_at_or_after_value(const void* value, bool* exact_match) override {
+    Status seek_at_or_after_value(const void* value, bool* exact_match) override final {
         DCHECK(_parsed) << "Must call init() firstly";
 
         if (_num_elements == 0) {
@@ -306,7 +306,7 @@ public:
         // - left == index of first value >= target when found
         // - left == _num_elements when not found (all values < target)
         while (left < right) {
-            size_t mid = left + (right - left) / 2;
+            size_t mid = left + ((right - left) >> 1);
             mid_value = &_chunk.data[mid * SIZE_OF_TYPE];
             if (TypeTraits<Type>::cmp(mid_value, value) < 0) {
                 left = mid + 1;
@@ -328,7 +328,7 @@ public:
         return Status::OK();
     }
 
-    Status next_batch(size_t* n, ColumnBlockView* dst) override { return next_batch<true>(n, dst); }
+    Status next_batch(size_t* n, ColumnBlockView* dst) override final { return next_batch<true>(n, dst); }
 
     template <bool forward_index>
     inline Status next_batch(size_t* n, ColumnBlockView* dst) {
@@ -348,7 +348,7 @@ public:
         return Status::OK();
     }
 
-    Status next_batch(size_t* n, vectorized::MutableColumnPtr& dst) override {
+    Status next_batch(size_t* n, vectorized::MutableColumnPtr& dst) override final {
         DCHECK(_parsed);
         if (PREDICT_FALSE(*n == 0 || _cur_index >= _num_elements)) {
             *n = 0;
@@ -365,13 +365,13 @@ public:
         return Status::OK();
     };
 
-    Status peek_next_batch(size_t* n, ColumnBlockView* dst) override {
+    Status peek_next_batch(size_t* n, ColumnBlockView* dst) override final {
         return next_batch<false>(n, dst);
     }
 
-    size_t count() const override { return _num_elements; }
+    size_t count() const override final { return _num_elements; }
 
-    size_t current_index() const override { return _cur_index; }
+    size_t current_index() const override final { return _cur_index; }
 
 private:
     void _copy_next_values(size_t n, void* data) {

--- a/be/src/olap/rowset/segment_v2/column_reader.cpp
+++ b/be/src/olap/rowset/segment_v2/column_reader.cpp
@@ -675,12 +675,12 @@ Status FileColumnIterator::_read_data_page(const OrdinalPageIndexIterator& iter)
                 _dict_decoder = std::make_unique<BinaryPlainPageDecoder>(dict_data);
                 RETURN_IF_ERROR(_dict_decoder->init());
 
-                auto* pd_decoder = (BinaryPlainPageDecoder*)_dict_decoder.get();
+                auto* pd_decoder = _dict_decoder.get();
                 _dict_word_info.reset(new StringRef[pd_decoder->_num_elems]);
                 pd_decoder->get_dict_word_info(_dict_word_info.get());
             }
 
-            dict_page_decoder->set_dict_decoder(_dict_decoder.get(), _dict_word_info.get());
+            dict_page_decoder->set_dict_word_info(_dict_word_info.get());
         }
     }
     return Status::OK();

--- a/be/src/olap/rowset/segment_v2/column_reader.h
+++ b/be/src/olap/rowset/segment_v2/column_reader.h
@@ -255,15 +255,15 @@ public:
 
     Status seek_to_first() override;
 
-    Status seek_to_ordinal(ordinal_t ord) override;
+    Status seek_to_ordinal(ordinal_t ord) override final;
 
     Status seek_to_page_start();
 
-    Status next_batch(size_t* n, ColumnBlockView* dst, bool* has_null) override;
+    Status next_batch(size_t* n, ColumnBlockView* dst, bool* has_null) override final;
 
-    Status next_batch(size_t* n, vectorized::MutableColumnPtr& dst, bool* has_null) override;
+    Status next_batch(size_t* n, vectorized::MutableColumnPtr& dst, bool* has_null) override final;
 
-    ordinal_t get_current_ordinal() const override { return _current_ordinal; }
+    ordinal_t get_current_ordinal() const override final { return _current_ordinal; }
 
     // get row ranges by zone map
     // - cond_column is user's query predicate
@@ -275,7 +275,7 @@ public:
 
     ParsedPage* get_current_page() { return _page.get(); }
 
-    bool is_nullable() { return _reader->is_nullable(); }
+    bool is_nullable() const { return _reader->is_nullable(); }
 
 private:
     void _seek_to_pos_in_page(ParsedPage* page, ordinal_t offset_in_page);
@@ -292,7 +292,7 @@ private:
     std::unique_ptr<ParsedPage> _page;
 
     // keep dict page decoder
-    std::unique_ptr<PageDecoder> _dict_decoder;
+    std::unique_ptr<BinaryPlainPageDecoder> _dict_decoder;
 
     // keep dict page handle to avoid released
     PageHandle _dict_page_handle;

--- a/be/test/olap/rowset/segment_v2/binary_dict_page_test.cpp
+++ b/be/test/olap/rowset/segment_v2/binary_dict_page_test.cpp
@@ -80,7 +80,7 @@ public:
         PageDecoderOptions decoder_options;
         BinaryDictPageDecoder page_decoder(s.slice(), decoder_options);
 
-        page_decoder.set_dict_decoder(dict_page_decoder.get(), dict_word_info);
+        page_decoder.set_dict_word_info(dict_word_info);
 
         status = page_decoder.init();
         ASSERT_TRUE(status.ok());
@@ -179,7 +179,7 @@ public:
             BinaryDictPageDecoder page_decoder(results[slice_index].slice(), decoder_options);
             status = page_decoder.init();
 
-            page_decoder.set_dict_decoder(dict_page_decoder.get(), dict_word_info);
+            page_decoder.set_dict_word_info(dict_word_info);
             ASSERT_TRUE(status.ok());
 
             //check values

--- a/be/test/tools/benchmark_tool.cpp
+++ b/be/test/tools/benchmark_tool.cpp
@@ -182,7 +182,7 @@ public:
             BinaryDictPageDecoder page_decoder(src.slice(), decoder_options);
             page_decoder.init();
 
-            page_decoder.set_dict_decoder(dict_page_decoder.get(), dict_word_info);
+            page_decoder.set_dict_word_info(dict_word_info);
 
             //check values
             size_t num = page_start_ids[slice_index + 1] - page_start_ids[slice_index];


### PR DESCRIPTION
# Proposed changes
i have tested final keyword's effect, the result shows
1. call virtual member functions through derived class reference/pointer will be more efficient if the function is marked as final
2. for the purpose of performance, we should add final keyword for derived class' overload function wherever possible
3. consider BinaryDictPageDecoder's members pointer _dict_decoder and _bit_shuffle_ptr are not both used, so i reuse the memory by union 
4. in addition, tidy codes, some member data is not necessary, so i deleted them.

here is the test code:
`uint64_t get_time()
{
    timespec end;
    clock_gettime(CLOCK_MONOTONIC, &end);
    return (end.tv_sec) * 1000L * 1000L * 1000L + (end.tv_nsec);
}

class Base {
public:
    Base() : type(0) {}
    virtual ~Base() {}
    virtual void f(int i) { ++x; }
    int x = 0;
    int type = 0;
};

int a[10]  = {1, 3, 4, 8, 9, 2, 6, 7, 5, 0};

class Derived : public Base {
public:
    Derived() { type = 1;}
    void f(int i) /*final*/ { j += a[i]; }
    int j = 0;
};

static void Test1() {
    uint64_t start = get_time();
    Derived* d = new Derived;
    Base* b = d;
    for (int x = 0; x < 1000; ++x)
    {
        for (int i = 0; i < 10; ++i)  b->f(i);
    }
    uint64_t end = get_time();
    std::cout << "j=" << d->j << " time:" << (end - start) << std::endl;
}

static void Test2() {
    uint64_t start = get_time();
    Derived* d = new Derived;
    for (int x = 0; x < 1000; ++x)
    {
        for (int i = 0; i < 10; ++i) d->f(i);
    }
    uint64_t end = get_time();
    std::cout << "j=" << d->j << " time:" << (end - start) << std::endl;
}

int main()
{
    Test1();
    Test2();
    return 0;
}`

Issue Number: close #xxx

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
5. Does it need to update dependencies: (Yes/No)
6. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
