### PR TITLE
[git] Ignore all the .flattened-pom.xml files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,7 +37,6 @@ fe/fe-core/src/main/resources/static/
 nohup.out
 
 regression-test/framework/target
-regression-test/framework/.flattened-pom.xml
 regression-test/framework/dependency-reduced-pom.xml
 
 # ignore eclipse project file & idea project file
@@ -66,10 +65,6 @@ ui/package-lock.json
 ui/yarn.lock
 docs/package-lock.json
 fe/fe-common/.classpath
-fe/.flattened-pom.xml
-fe/fe-common/.flattened-pom.xml
-fe/fe-core/.flattened-pom.xml
-fe/spark-dpp/.flattened-pom.xml
 
 rpc_data/
 
@@ -81,3 +76,6 @@ samples/doris-demo/*/target
 be/.devcontainer/
 
 derby.log
+
+# Ignore all the .flattened-pom.xml files
+.flattened-pom.xml


### PR DESCRIPTION
# Proposed changes
Currently, if we build FE via `mvn clean package -DskipTests` in the `fe` dir,  `fe/hive-udf/.flattened-pom.xml` would be produced, which was introduced by #8190.
This file is not ignored by Git now.

This PR proposes to ignore all the `.flattened-pom.xml` files.

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: no
2. Has unit tests been added: no
3. Has document been added or modified: no
4. Does it need to update dependencies: no
5. Are there any changes that cannot be rolled back: no

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
