### PR TITLE
[Feature][array-type]add proto for complex data type ARRAY

### DIFF
--- a/gensrc/proto/data.proto
+++ b/gensrc/proto/data.proto
@@ -52,10 +52,11 @@ message PColumnMeta {
         optional uint32 precision = 1;
         optional uint32 scale = 2;
     }
-    required string name = 1;
+    optional string name = 1 [default = ""];
     required PGenericType.TypeId type = 2;
     optional bool is_nullable = 3 [default = false];
     optional Decimal decimal_param = 4;
+    repeated PColumnMeta children = 5;
 }
 
 message PBlock {

--- a/gensrc/proto/data.proto
+++ b/gensrc/proto/data.proto
@@ -53,7 +53,7 @@ message PColumnMeta {
         optional uint32 scale = 2;
     }
     optional string name = 1 [default = ""];
-    required PGenericType.TypeId type = 2;
+    optional PGenericType.TypeId type = 2 [default = UNKNOWN];
     optional bool is_nullable = 3 [default = false];
     optional Decimal decimal_param = 4;
     repeated PColumnMeta children = 5;


### PR DESCRIPTION
# Proposed changes

This issue is a sub task of #7570

## Problem Summary:

1. Add repeated PBlock.PColumnMeta.children field for complex data type, such as ARRAY;
2. change PBlock.PColumnMeta.name to optional, nested columns do not need to a column name;

## Checklist(Required)

1. Does it affect the original behavior: (No)
2. Has unit tests been added: (No)
3. Has document been added or modified: (No)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
