### PR TITLE
[Opt] special cmp for equal string compare

### DIFF
--- a/be/src/runtime/string_value.hpp
+++ b/be/src/runtime/string_value.hpp
@@ -67,6 +67,32 @@ static inline int string_compare(const char* s1, int64_t n1, const char* s2, int
     return n1 - n2;
 }
 
+// This is a special compare algorithm for len(s1) == len(s2) scenarios
+// faster than generic string_compare algorithm.
+// This code assumes that the trivial cases are already handled (i.e. len(s1) != len(s2)).
+// Returns:
+//   true  if s1 == s2
+//   false if s1 != s2
+static inline bool eq_string_compare(const char* s1, const char* s2, int64_t len) {
+#ifdef __SSE4_2__
+    while (len >= sse_util::CHARS_PER_128_BIT_REGISTER) {
+        __m128i xmm0 = _mm_loadu_si128(reinterpret_cast<const __m128i*>(s1));
+        __m128i xmm1 = _mm_loadu_si128(reinterpret_cast<const __m128i*>(s2));
+        int chars_match =
+                _mm_cmpestri(xmm0, sse_util::CHARS_PER_128_BIT_REGISTER, xmm1,
+                             sse_util::CHARS_PER_128_BIT_REGISTER, sse_util::STRCMP_MODE);
+        if (chars_match != sse_util::CHARS_PER_128_BIT_REGISTER) {
+            return false;
+        }
+        len -= sse_util::CHARS_PER_128_BIT_REGISTER;
+        s1 += sse_util::CHARS_PER_128_BIT_REGISTER;
+        s2 += sse_util::CHARS_PER_128_BIT_REGISTER;
+    }
+#endif
+    
+    return strncmp(s1, s2, len) == 0;
+}
+
 inline int StringValue::compare(const StringValue& other) const {
     int l = std::min(len, other.len);
 
@@ -89,7 +115,7 @@ inline bool StringValue::eq(const StringValue& other) const {
         return false;
     }
 
-    return string_compare(this->ptr, this->len, other.ptr, other.len, this->len) == 0;
+    return eq_string_compare(this->ptr, other.ptr, this->len);
 }
 
 inline StringValue StringValue::substring(int start_pos) const {


### PR DESCRIPTION
# Proposed changes

高基数列原始的字符串等值比较场景优化

## Problem Summary:

这个pr是对之后低基数列优化的补充，针对的是高基数列原始的字符串等值比较场景

doris通用的字符串比较算法很快了，测试中发现和clickhouse的字符串比较速度差不多
思路都是用_SSE_4处理前面的16*k位(k是整数)，剩下的<=15位再遍历一遍

对于高基数列，doris使用原始的字符串(char*)进行比较
这个pr对于sql中有str1==str2(或者str1!=str2)的长字符串等值比较有一定的加速效果

## Checklist(Required)
<img width="536" alt="111" src="https://user-images.githubusercontent.com/35688959/155321458-31ce65ad-2cc8-49ac-8940-0b26f83701cd.png">
在多次测试取平均值后(部分一两次测试由于数据集等原因可能有波动)，比doris通用的字符串比较算法有20%左右的提速


测试代码:
https://godbolt.org/z/689bGnMzs

@wangbo @HappenLee @zenoyang 
## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
