### PR TITLE
[improvement]upgrade-grpc-version

### DIFF
--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -111,7 +111,7 @@ under the License.
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <grpc.version>1.30.0</grpc.version>
+        <grpc.version>1.44.1</grpc.version>
         <protobuf.version>3.14.0</protobuf.version>
         <skip.plugin>false</skip.plugin>
         <hive.version>2.3.7</hive.version>


### PR DESCRIPTION
# Proposed changes

upgrade grpc.version, so macos with M1 chip can build Fe correctly.

## Problem Summary:

Building Fe In macos with M1 chip, io.grpc:protoc-gen-grpc-java:1.30.0 doesn't have osx-aarch_64.exe which supplied in version 1.42.0.

## Checklist(Required)

1. Does it affect the original behavior: (No)
2. Has unit tests been added: (No)
3. Has document been added or modified: (No)
4. Does it need to update dependencies: (Yes)
5. Are there any changes that cannot be rolled back: (Yes)
