### PR TITLE
[Bug][Vectorized] Fix bug of decimal cast to double loss precision && join code dump in semi/anti join

### DIFF
--- a/be/src/vec/data_types/data_type_decimal.h
+++ b/be/src/vec/data_types/data_type_decimal.h
@@ -290,7 +290,7 @@ convert_from_decimal(const typename FromDataType::FieldType& value, UInt32 scale
     using ToFieldType = typename ToDataType::FieldType;
 
     if constexpr (std::is_floating_point_v<ToFieldType>)
-        return static_cast<ToFieldType>(value) / FromDataType::get_scale_multiplier(scale);
+        return binary_cast<int128_t, DecimalV2Value>(value);
     else {
         FromFieldType converted_value =
                 convert_decimals<FromDataType, FromDataType>(value, scale, 0);

--- a/be/src/vec/exec/join/vhash_join_node.h
+++ b/be/src/vec/exec/join/vhash_join_node.h
@@ -223,8 +223,6 @@ private:
     bool _have_other_join_conjunct = false;
 
     RowDescriptor _row_desc_for_other_join_conjunt;
-    int _right_col_idx = 0;
-    int _right_col_len = 0;
 
     std::vector<uint32_t> _items_counts;
     std::vector<int8_t> _build_block_offsets;


### PR DESCRIPTION
# Proposed changes

Issue Number: close #8215 #8824

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes)
2. Has unit tests been added: (No Need)
3. Has document been added or modified: (No Need)
4. Does it need to update dependencies: (Yes)
5. Are there any changes that cannot be rolled back: (Yes)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
