### PR TITLE
[Bug] group_concat(value,null) not return null

### DIFF
--- a/be/src/exprs/aggregate_functions.cpp
+++ b/be/src/exprs/aggregate_functions.cpp
@@ -784,7 +784,7 @@ void AggregateFunctions::max(FunctionContext*, const DateTimeVal& src, DateTimeV
 
 void AggregateFunctions::string_concat(FunctionContext* ctx, const StringVal& src,
                                        const StringVal& separator, StringVal* result) {
-    if (src.is_null) {
+    if (src.is_null || separator.is_null) {
         return;
     }
 
@@ -819,7 +819,7 @@ void AggregateFunctions::string_concat_update(FunctionContext* ctx, const String
 
 void AggregateFunctions::string_concat_update(FunctionContext* ctx, const StringVal& src,
                                               const StringVal& separator, StringVal* result) {
-    if (src.is_null) {
+    if (src.is_null || separator.is_null) {
         return;
     }
     const StringVal* sep = separator.is_null ? &DEFAULT_STRING_CONCAT_DELIM : &separator;

--- a/docs/en/sql-reference/sql-functions/aggregate-functions/group_concat.md
+++ b/docs/en/sql-reference/sql-functions/aggregate-functions/group_concat.md
@@ -58,6 +58,13 @@ mysql> select GROUP_CONCAT(value, " ") from test;
 +----------------------------+
 | a b c                      |
 +----------------------------+
+
+mysql> select GROUP_CONCAT(value, NULL) from test;
++----------------------------+
+| GROUP_CONCAT(`value`, NULL)|
++----------------------------+
+| NULL                       |
++----------------------------+
 ```
 ## keyword
 GROUP_CONCAT,GROUP,CONCAT

--- a/docs/zh-CN/sql-reference/sql-functions/aggregate-functions/group_concat.md
+++ b/docs/zh-CN/sql-reference/sql-functions/aggregate-functions/group_concat.md
@@ -58,6 +58,13 @@ mysql> select GROUP_CONCAT(value, " ") from test;
 +----------------------------+
 | a b c                      |
 +----------------------------+
+
+mysql> select GROUP_CONCAT(value, NULL) from test;
++----------------------------+
+| GROUP_CONCAT(`value`, NULL)|
++----------------------------+
+| NULL                       |
++----------------------------+
 ```
 ## keyword
 GROUP_CONCAT,GROUP,CONCAT


### PR DESCRIPTION
# Proposed changes
@HappenLee 
Issue Number: close #8231

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
