### PR TITLE
[fix](olap) add check statement to protect get_dict_word_info() from crash

### DIFF
--- a/be/src/olap/rowset/segment_v2/binary_plain_page.h
+++ b/be/src/olap/rowset/segment_v2/binary_plain_page.h
@@ -269,6 +269,8 @@ public:
     }
 
     void get_dict_word_info(StringRef* dict_word_info) {
+        if (_num_elems <= 0) [[unlikely]] return;
+
         char* data_begin = (char*)&_data[0];
         char* offset_ptr = (char*)&_data[_offsets_pos];
 


### PR DESCRIPTION
# Proposed changes
check _num_elems firstly at the beginning of get_dict_word_info for safe

This will fix be crash bug introduced from #8162 

```
    @     0x5618e2e172f2 google::(anonymous namespace)::FailureSignalHandler()
    @     0x7f0eae5a6920 (unknown)
    @     0x5618e1aa091e doris::segment_v2::FileColumnIterator::_read_data_page()
    @     0x5618e1aa0cee doris::segment_v2::FileColumnIterator::seek_to_ordinal()
    @     0x5618e1a6a28b doris::segment_v2::SegmentIterator::_seek_columns()
    @     0x5618e1a70852 doris::segment_v2::SegmentIterator::next_batch()
    @     0x5618e1163e36 doris::BetaRowsetReader::next_block()
    @     0x5618e1086d71 doris::CollectIterator::Level0Iterator::_refresh_current_row_v2()
    @     0x5618e108831a doris::CollectIterator::add_child()
    @     0x5618e1054af8 doris::TupleReader::_init_collect_iter()
    @     0x5618e1054f8c doris::TupleReader::init()
    @     0x5618e18edd2f doris::OlapScanner::open()
    @     0x5618e18a84ca doris::OlapScanNode::scanner_thread()
    @     0x5618e11ce45a doris::PriorityWorkStealingThreadPool::work_thread()
    @     0x5618e4985b50 execute_native_thread_routine
    @     0x7f0eae35e851 start_thread
    @     0x7f0eae65b67d clone
    @                0x0 (unknown)
```

Issue Number: close #xxx

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
