### PR TITLE
[improvment] Ignore the case of column name, when do the stream load in json format

### DIFF
--- a/be/src/exec/json_scanner.cpp
+++ b/be/src/exec/json_scanner.cpp
@@ -668,7 +668,7 @@ Status JsonReader::_handle_simple_json(Tuple* tuple, const std::vector<SlotDescr
                 for (auto v : slot_descs) {
                     for (int i = 0; i < objectValue->MemberCount(); ++i) {
                         auto it = objectValue->MemberBegin() + i;
-                        if (v->col_name() == it->name.GetString()) {
+                        if (strcasecmp(v->col_name().c_str(), it->name.GetString()) == 0) {
                             _name_map[v->col_name()] = i;
                             break;
                         }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #8070

## Problem Summary:

stream load in json format is case sensitive, In order to be consistent with sql standard, change it to  case insensitive

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
