### PR TITLE
[revert] "[improvement]upgrade-grpc-version"

### DIFF
--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -111,7 +111,7 @@ under the License.
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <grpc.version>1.44.1</grpc.version>
+        <grpc.version>1.30.0</grpc.version>
         <protobuf.version>3.14.0</protobuf.version>
         <skip.plugin>false</skip.plugin>
         <hive.version>2.3.7</hive.version>


### PR DESCRIPTION
Reverts apache/incubator-doris#8218

Because when using grpc 1.44.1, the corresponding `protoc-gen-grpc-java` plugin
requried GLIBC_2.14, which is not found in CentOS 6.

So I suggest to revert this commit this time. And considering upgrading this component
after most systems have reached glibc version 2.14.

And for Mac M1, you may have to change this version manually for now