### PR TITLE
[improvement](lateral-view) Add number rows filtered in profile

### DIFF
--- a/be/src/exec/table_function_node.h
+++ b/be/src/exec/table_function_node.h
@@ -74,6 +74,9 @@ private:
     std::vector<int> _child_slot_sizes;
     // indicate if child node reach the end
     bool _child_eos = false;
+
+    RuntimeProfile::Counter* _num_rows_filtered_counter = nullptr;
+    uint64_t _num_rows_filtered = 0;
 };
 
 }; // namespace doris

--- a/be/src/exprs/table_function/explode_bitmap.cpp
+++ b/be/src/exprs/table_function/explode_bitmap.cpp
@@ -22,7 +22,9 @@
 
 namespace doris {
 
-ExplodeBitmapTableFunction::ExplodeBitmapTableFunction() {}
+ExplodeBitmapTableFunction::ExplodeBitmapTableFunction() {
+    _fn_name = "explode_bitmap";
+}
 
 ExplodeBitmapTableFunction::~ExplodeBitmapTableFunction() {
     if (_cur_iter != nullptr) {

--- a/be/src/exprs/table_function/explode_json_array.cpp
+++ b/be/src/exprs/table_function/explode_json_array.cpp
@@ -128,6 +128,20 @@ int ParsedData::set_output(ExplodeJsonArrayType type, rapidjson::Document& docum
 ExplodeJsonArrayTableFunction::ExplodeJsonArrayTableFunction(ExplodeJsonArrayType type)
     : _type(type) {
     
+    switch (type) {
+        case ExplodeJsonArrayType::INT:
+            _fn_name = "explode_json_array_int";
+            break;
+        case ExplodeJsonArrayType::DOUBLE:
+            _fn_name = "explode_json_array_double";
+            break;
+        case ExplodeJsonArrayType::STRING:
+            _fn_name = "explode_json_array_string";
+            break;
+        default:
+            _fn_name = "unknown";
+            break;
+    }
 }
 
 ExplodeJsonArrayTableFunction::~ExplodeJsonArrayTableFunction() {

--- a/be/src/exprs/table_function/explode_split.cpp
+++ b/be/src/exprs/table_function/explode_split.cpp
@@ -24,6 +24,7 @@
 namespace doris {
 
 ExplodeSplitTableFunction::ExplodeSplitTableFunction() {
+    _fn_name = "explode_split";
 }
 
 ExplodeSplitTableFunction::~ExplodeSplitTableFunction() {

--- a/be/src/exprs/table_function/table_function.h
+++ b/be/src/exprs/table_function/table_function.h
@@ -42,6 +42,7 @@ public:
     virtual Status forward(bool *eos) = 0;
 
 public:
+    std::string name() const { return _fn_name; }
     bool eos() const { return _eos; }
 
     void set_expr_context(ExprContext* expr_context) {


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

Add `RowsFiltered` counter in TableFunctionNode profile.
So that we can know the total number of rows that TableFunctionNode processed

## Checklist(Required)

1. Does it affect the original behavior: (No)
2. Has unit tests been added: (No Need)
3. Has document been added or modified: (No Need)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
