### PR TITLE
[fix](vectorization)Some small fix for SegmentIter Vectorization 

### DIFF
--- a/be/src/olap/rowset/segment_v2/segment_iterator.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.cpp
@@ -613,7 +613,7 @@ void SegmentIterator::_vec_init_lazy_materialization() {
             _is_pred_column[cid] = true;
             pred_column_ids.insert(cid);
 
-            if (type == OLAP_FIELD_TYPE_VARCHAR || type == OLAP_FIELD_TYPE_CHAR || predicate->is_in_predicate()) {
+            if (type == OLAP_FIELD_TYPE_VARCHAR || type == OLAP_FIELD_TYPE_CHAR || type == OLAP_FIELD_TYPE_STRING || predicate->is_in_predicate()) {
                 short_cir_pred_col_id_set.insert(cid);
                 _short_cir_eval_predicate.push_back(predicate);
                 _is_all_column_basic_type = false;

--- a/be/src/olap/rowset/segment_v2/segment_iterator.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.cpp
@@ -613,10 +613,7 @@ void SegmentIterator::_vec_init_lazy_materialization() {
             _is_pred_column[cid] = true;
             pred_column_ids.insert(cid);
 
-            // for date type which can not be executed in a vectorized way, using short circuit execution
-            if (type == OLAP_FIELD_TYPE_VARCHAR || type == OLAP_FIELD_TYPE_CHAR ||
-                type == OLAP_FIELD_TYPE_DECIMAL || type == OLAP_FIELD_TYPE_DATE ||
-                predicate->is_in_predicate()) {
+            if (type == OLAP_FIELD_TYPE_VARCHAR || type == OLAP_FIELD_TYPE_CHAR || predicate->is_in_predicate()) {
                 short_cir_pred_col_id_set.insert(cid);
                 _short_cir_eval_predicate.push_back(predicate);
                 _is_all_column_basic_type = false;

--- a/be/src/vec/columns/column_complex.h
+++ b/be/src/vec/columns/column_complex.h
@@ -67,6 +67,7 @@ public:
             for (size_t i = 0; i < num; i++) {
                 uint32_t len = len_array[i];
                 uint32_t start_offset = start_offset_array[i];
+                insert_default();
                 BitmapValue* pvalue = &get_element(size() - 1);
                 if (len != 0) {
                     BitmapValue value;
@@ -76,6 +77,22 @@ public:
                     *pvalue = std::move(*reinterpret_cast<BitmapValue*>(data_array + start_offset));   
                 }
             }
+        } else if constexpr (std::is_same_v<T, HyperLogLog>) {
+            for (size_t i = 0; i < num; i++) {
+                uint32_t len = len_array[i];
+                uint32_t start_offset = start_offset_array[i];
+                insert_default();
+                HyperLogLog* pvalue = &get_element(size() - 1);
+                if (len != 0) {
+                    HyperLogLog value;
+                    value.deserialize(Slice(data_array + start_offset, len));
+                    *pvalue = std::move(value);
+                } else {
+                    *pvalue = std::move(*reinterpret_cast<HyperLogLog*>(data_array + start_offset));
+                }
+            }
+        } else {
+            LOG(FATAL) << "Unexpected type in column complex";
         }
     }
 

--- a/be/src/vec/columns/column_complex.h
+++ b/be/src/vec/columns/column_complex.h
@@ -63,11 +63,11 @@ public:
     }
 
     void insert_many_binary_data(char* data_array, uint32_t* len_array, uint32_t* start_offset_array, size_t num) override {
+        resize(num);
         if constexpr (std::is_same_v<T, BitmapValue>) {
             for (size_t i = 0; i < num; i++) {
                 uint32_t len = len_array[i];
                 uint32_t start_offset = start_offset_array[i];
-                insert_default();
                 BitmapValue* pvalue = &get_element(size() - 1);
                 if (len != 0) {
                     BitmapValue value;
@@ -81,7 +81,6 @@ public:
             for (size_t i = 0; i < num; i++) {
                 uint32_t len = len_array[i];
                 uint32_t start_offset = start_offset_array[i];
-                insert_default();
                 HyperLogLog* pvalue = &get_element(size() - 1);
                 if (len != 0) {
                     HyperLogLog value;

--- a/be/src/vec/columns/column_vector.h
+++ b/be/src/vec/columns/column_vector.h
@@ -179,7 +179,7 @@ public:
             value |= *(unsigned char*)(cur_ptr);
             vectorized::VecDateTimeValue date;
             date.from_olap_date(value);
-            data.push_back_without_reserve(date);
+            this->insert_data(reinterpret_cast<char*>(&date), 0);
         }
     }
 
@@ -189,7 +189,7 @@ public:
             const char* cur_ptr = data_ptr + value_size * i;
             uint64_t value = *reinterpret_cast<const uint64_t*>(cur_ptr);
             vectorized::VecDateTimeValue date(value);
-            data.push_back_without_reserve(date);
+            this->insert_data(reinterpret_cast<char*>(&date), 0);
         }
     }
 


### PR DESCRIPTION
# Proposed changes
1 No longer using short-circuit to evaluate date type, because the cost of read date type is small, lazy materialization has higher costs.
2 Fix read hll/bitmap/date type error results.

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (No)
2. Has unit tests been added: (No)
3. Has document been added or modified: (No Need)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
