### PR TITLE
make options of build.sh and run-be-ut.sh work

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -96,7 +96,6 @@ clean_fe() {
 OPTS=$(getopt \
   -n $0 \
   -o '' \
-  -o 'h' \
   -l 'be' \
   -l 'fe' \
   -l 'broker' \
@@ -104,7 +103,7 @@ OPTS=$(getopt \
   -l 'spark-dpp' \
   -l 'clean' \
   -l 'help' \
-  -o 'j:' \
+  -o 'hj:' \
   -- "$@")
 
 if [ $? != 0 ] ; then

--- a/run-be-ut.sh
+++ b/run-be-ut.sh
@@ -65,8 +65,7 @@ OPTS=$(getopt \
   -o '' \
   -l 'run' \
   -l 'clean' \
-  -o 'j:' \
-  -o 'v' \
+  -o 'vj:' \
   -- "$@")
 
 if [ $? != 0 ] ; then


### PR DESCRIPTION
The h option of build.sh and j option of run-be-ut.sh do not work
in the docker with image
apache/incubator-doris:build-env-ldb-toolchain-latest.

# Proposed changes

Issue Number: close #xxx

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (No)
2. Has unit tests been added: (No)
3. Has document been added or modified: (No Need)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
