### PR TITLE
(improving) refactor column::insert_many_dict_data

### DIFF
--- a/be/src/vec/columns/column.h
+++ b/be/src/vec/columns/column.h
@@ -174,7 +174,7 @@ public:
       LOG(FATAL) << "Method insert_many_fix_len_data is not supported for " << get_name();
     }
  
-    virtual void insert_many_dict_data(const int32_t* data_array, size_t start_index, const StringRef* dict, size_t num) {
+    virtual void insert_many_dict_data(const int32_t* __restrict data_array, size_t start_index, const StringRef* __restrict dict, size_t num) {
       LOG(FATAL) << "Method insert_many_dict_data is not supported for " << get_name();
     }
  

--- a/be/src/vec/columns/column_nullable.h
+++ b/be/src/vec/columns/column_nullable.h
@@ -96,7 +96,7 @@ public:
         get_nested_column().insert_many_fix_len_data(pos, num);
     }
  
-    void insert_many_dict_data(const int32_t* data_array, size_t start_index, const StringRef* dict, size_t num) override {
+    void insert_many_dict_data(const int32_t* __restrict data_array, size_t start_index, const StringRef* __restrict dict, size_t num) override {
         get_null_map_column().fill(0, num);
         get_nested_column().insert_many_dict_data(data_array, start_index, dict, num);
     }

--- a/be/src/vec/columns/column_string.h
+++ b/be/src/vec/columns/column_string.h
@@ -168,7 +168,6 @@ public:
     };
  
     void insert_many_dict_data(const int32_t* __restrict data_array, size_t start_index, const StringRef* __restrict dict, size_t num) override {
-        size_t index = start_index;
         const size_t end = start_index + num;
 
         // handle offsets
@@ -177,8 +176,8 @@ public:
 
         size_t chars_old_size = chars.size();
         size_t chars_new_size = chars_old_size;
-        for (; index < end; ++index) {
-            int32_t codeword = data_array[index];
+        for (size_t index = start_index; index < end; ++index) {
+            auto codeword = data_array[index];
             chars_new_size += (dict[codeword].size + 1); // extra 1 for zero ending
             offsets[old_size++] = chars_new_size;
         }
@@ -187,9 +186,8 @@ public:
         chars.resize(chars_new_size);
         unsigned char* c_data = chars.data();
 
-        index = start_index;
-        for (; index < end; ++index) {
-            int32_t codeword = data_array[index];
+        for (size_t index = start_index; index < end; ++index) {
+            auto codeword = data_array[index];
             const StringRef& word = dict[codeword]; 
             memory_copy(c_data + chars_old_size, word.data, word.size);
             chars_old_size += word.size;

--- a/be/src/vec/columns/predicate_column.h
+++ b/be/src/vec/columns/predicate_column.h
@@ -217,11 +217,16 @@ public:
         }
     }
 
-    void insert_many_dict_data(const int32_t* data_array, size_t start_index, const StringRef* dict, size_t num) override {
+    void insert_many_dict_data(const int32_t* __restrict data_array, size_t start_index, const StringRef* __restrict dict, size_t num) override {
         if constexpr (std::is_same_v<T, StringValue>) {
+            size_t old_size = data.size();
+            data.resize(old_size + num);
+            StringValue* sv = &data[old_size];
             for (size_t end_index = start_index+num; start_index < end_index; ++start_index) {
                 int32_t codeword = data_array[start_index];
-                insert_string_value(dict[codeword].data, dict[codeword].size);
+                sv->ptr = (char*)dict[codeword].data;
+                sv->len = dict[codeword].size;
+                ++sv;
             }
         }
     }


### PR DESCRIPTION
# Proposed changes

i have tested this changes by adding global atomic timer: clock_gettime(CLOCK_MONOTONIC, &ts);

before vs after modifying,  test sql ssb Q2.1
SELECT sum(lo_revenue), year(lo_orderdate) AS year,  p_brand 
FROM lineorder_flat 
WHERE p_category = 'MFGR#12' AND s_region = 'AMERICA' 
GROUP BY year,  p_brand 
ORDER BY year, p_brand;

result:
PredicateColumnType::insert_many_dict_data() 11970424864 vs 8907241614  
ColumnString::insert_many_dict_data                 3044568165 vs 2467506128 

Issue Number: close #xxx

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
