### PR TITLE
[build](fe) Support building an individual maven module.

### DIFF
--- a/fe/fe-common/pom.xml
+++ b/fe/fe-common/pom.xml
@@ -22,7 +22,7 @@ under the License.
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.doris</groupId>
-        <version>${revision}</version>
+        <version>1.0-SNAPSHOT</version>
         <artifactId>fe</artifactId>
         <relativePath>../pom.xml</relativePath>
     </parent>

--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -22,7 +22,7 @@ under the License.
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.doris</groupId>
-        <version>${revision}</version>
+        <version>1.0-SNAPSHOT</version>
         <artifactId>fe</artifactId>
         <relativePath>../pom.xml</relativePath>
     </parent>

--- a/fe/hive-udf/pom.xml
+++ b/fe/hive-udf/pom.xml
@@ -23,7 +23,7 @@ under the License.
 
     <parent>
         <groupId>org.apache.doris</groupId>
-        <version>${revision}</version>
+        <version>1.0-SNAPSHOT</version>
         <artifactId>fe</artifactId>
         <relativePath>../pom.xml</relativePath>
     </parent>

--- a/fe/java-udf/pom.xml
+++ b/fe/java-udf/pom.xml
@@ -23,7 +23,7 @@ under the License.
 
     <parent>
         <groupId>org.apache.doris</groupId>
-        <version>${revision}</version>
+        <version>1.0-SNAPSHOT</version>
         <artifactId>fe</artifactId>
         <relativePath>../pom.xml</relativePath>
     </parent>

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -27,7 +27,7 @@ under the License.
     </parent>
     <groupId>org.apache.doris</groupId>
     <artifactId>fe</artifactId>
-    <version>${revision}</version>
+    <version>1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Doris FE Project Parent POM</name>
     <url>https://doris.apache.org/</url>
@@ -237,8 +237,6 @@ under the License.
         <httpcore.version>4.4.15</httpcore.version>
         <aws-java-sdk-s3.version>1.11.95</aws-java-sdk-s3.version>
         <mariadb-java-client.version>3.0.4</mariadb-java-client.version>
-
-        <revision>1.0-SNAPSHOT</revision>
         <project.scm.id>github</project.scm.id>
     </properties>
     <profiles>

--- a/fe/spark-dpp/pom.xml
+++ b/fe/spark-dpp/pom.xml
@@ -22,7 +22,7 @@ under the License.
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.doris</groupId>
-        <version>${revision}</version>
+        <version>1.0-SNAPSHOT</version>
         <artifactId>fe</artifactId>
         <relativePath>../pom.xml</relativePath>
     </parent>


### PR DESCRIPTION
# Proposed changes

Current, if we build an individual FE maven module, e.g., build `fe-core` moudle via `mvn clean package -pl fe-core`, the below error would occur
```
[ERROR] Failed to execute goal on project fe-core: Could not resolve dependencies for project org.apache.doris:fe-core:jar:0.15-SNAPSHOT: Failed to collect dependencies at org.apache.doris:spark-dpp:jar:0.15-SNAPSHOT: Failed to read artifact descriptor for org.apache.doris:spark-dpp:jar:0.15-SNAPSHOT: Could not find artifact org.apache.doris:fe:pom:${revision}
```
It's because the maven module version is a property defined in the root pom.xml:
https://github.com/apache/incubator-doris/blob/246ac4e37aa4da6836b7850cb990f02d1c3725a3/fe/pom.xml#L121

This PR tried to fix this issue.

1. Use the version value in every pom.xml file instead of a property in the root pom.xml
2. If we want to change the project version, we could run the following commands in the `fe` dir:
``` bash
mvn versions:set -DnewVersion=${new_version}
mvn versions:commit
```
Please see https://www.mojohaus.org/versions-maven-plugin/examples/set.html for more details.
## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: no
4. Has unit tests been added: no
5. Has document been added or modified: no
6. Does it need to update dependencies: no
7. Are there any changes that cannot be rolled back: no

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
