### PR TITLE
[feature] Window funnel

### DIFF
--- a/be/src/exprs/aggregate_functions.cpp
+++ b/be/src/exprs/aggregate_functions.cpp
@@ -2265,6 +2265,7 @@ void AggregateFunctions::offset_fn_update(FunctionContext* ctx, const T& src, co
     *dst = src;
 }
 
+// Refer to AggregateFunctionWindowFunnel.h in https://github.com/ClickHouse/ClickHouse.git
 struct WindowFunnelState {
     std::vector<std::pair<DateTimeValue, int>> events;
     int max_event_level;

--- a/be/src/exprs/aggregate_functions.cpp
+++ b/be/src/exprs/aggregate_functions.cpp
@@ -2265,6 +2265,206 @@ void AggregateFunctions::offset_fn_update(FunctionContext* ctx, const T& src, co
     *dst = src;
 }
 
+struct WindowFunnelState {
+    std::vector<std::pair<DateTimeValue, int>> events;
+    int max_event_level;
+    bool sorted;
+    int64_t window;
+
+    WindowFunnelState() {
+        sorted = true;
+        max_event_level = 0;
+        window = 0;
+    }
+
+    void add(DateTimeValue& timestamp, int event_idx, int event_num, int64_t win) {
+        window = win;
+        max_event_level = event_num;
+        if (sorted && events.size() > 0) {
+            if (events.back().first == timestamp) {
+                sorted = events.back().second <= event_idx;
+            } else {
+                sorted = events.back().first < timestamp;
+            }
+        }
+        events.emplace_back(timestamp, event_idx);
+    }
+
+    void sort() {
+        if (sorted) {
+            return;
+        }
+        std::stable_sort(events.begin(), events.end());
+    }
+
+    int get_event_level() {
+        std::vector<std::optional<DateTimeValue>> events_timestamp(max_event_level);
+        for (int64_t i = 0; i < events.size(); i++) {
+            int& event_idx = events[i].second;
+            DateTimeValue& timestamp = events[i].first;
+            if (event_idx == 0) {
+                events_timestamp[0] = timestamp;
+                continue;
+            }
+            if (events_timestamp[event_idx - 1].has_value()) {
+                DateTimeValue& first_timestamp = events_timestamp[event_idx - 1].value();
+                DateTimeValue last_timestamp = first_timestamp;
+                TimeInterval interval(SECOND, window, false);
+                last_timestamp.date_add_interval(interval, SECOND);
+
+                if (timestamp <= last_timestamp) {
+                    events_timestamp[event_idx] = first_timestamp;
+                    if (event_idx + 1 == max_event_level) {
+                        // Usually, max event level is small.
+                        return max_event_level;
+                    }
+                }
+            }
+        }
+
+        for (int64_t i = events_timestamp.size() - 1; i >= 0; i--) {
+            if (events_timestamp[i].has_value()) {
+                return i + 1;
+            }
+        }
+
+        return 0;
+    }
+
+    void merge(WindowFunnelState *other) {
+        if (other->events.empty()) {
+            return;
+        }
+
+        int64_t orig_size = events.size();
+        events.insert(std::end(events), std::begin(other->events), std::end(other->events));
+        const auto begin = std::begin(events);
+        const auto middle = std::next(events.begin(), orig_size);
+        const auto end = std::end(events);
+        if (!other->sorted) {
+            std::stable_sort(middle, end);
+        }
+
+        if (!sorted) {
+            std::stable_sort(begin, middle);
+        }
+        std::inplace_merge(begin, middle, end);
+        max_event_level = max_event_level > 0 ? max_event_level : other->max_event_level;
+        window = window > 0 ? window : other->window;
+
+        sorted = true;
+    }
+
+    int64_t serialized_size() {
+        return sizeof(int) + sizeof(int64_t) + sizeof(uint64_t) +
+               events.size() * (sizeof(int64_t) + sizeof(int));
+    }
+
+    void serialize(uint8_t *buf) {
+        memcpy(buf, &max_event_level, sizeof(int));
+        buf += sizeof(int);
+        memcpy(buf, &window, sizeof(int64_t));
+        buf += sizeof(int64_t);
+
+        uint64_t event_num = events.size();
+        memcpy(buf, &event_num, sizeof(uint64_t));
+        buf += sizeof(uint64_t);
+        for (int64_t i = 0; i < events.size(); i++) {
+            int64_t timestamp = events[i].first;
+            int event_idx = events[i].second;
+            memcpy(buf, &timestamp, sizeof(int64_t));
+            buf += sizeof(int64_t);
+            memcpy(buf, &event_idx, sizeof(int));
+            buf += sizeof(int);
+        }
+    }
+
+    void deserialize(uint8_t *buf) {
+        uint64_t size;
+
+        memcpy(&max_event_level, buf, sizeof(int));
+        buf += sizeof(int);
+        memcpy(&window, buf, sizeof(int64_t));
+        buf += sizeof(int64_t);
+        memcpy(&size, buf, sizeof(uint64_t));
+        buf += sizeof(uint64_t);
+        for (int64_t i = 0; i < size; i++) {
+            int64_t timestamp;
+            int event_idx;
+
+            memcpy(&timestamp, buf, sizeof(int64_t));
+            buf += sizeof(int64_t);
+            memcpy(&event_idx, buf, sizeof(int));
+            buf += sizeof(int);
+            DateTimeValue time_value;
+            time_value.from_date_int64(timestamp);
+            add(time_value, event_idx, max_event_level, window);
+        }
+    }
+};
+
+void AggregateFunctions::window_funnel_init(FunctionContext* ctx, StringVal* dst) {
+    dst->is_null = false;
+    dst->len = sizeof(WindowFunnelState);
+    dst->ptr = (uint8_t*)new WindowFunnelState();
+}
+
+void AggregateFunctions::window_funnel_update(FunctionContext* ctx, const BigIntVal& window,
+                                             const DateTimeVal& timestamp, int num_cond,
+                                             const BooleanVal* conds, StringVal* dst) {
+    DCHECK(dst->ptr != nullptr);
+    DCHECK_EQ(sizeof(WindowFunnelState), dst->len);
+
+    if (window.is_null || timestamp.is_null) {
+        return;
+    }
+
+    WindowFunnelState* state = reinterpret_cast<WindowFunnelState*>(dst->ptr);
+    for (int i = 0; i < num_cond; i++) {
+        if (conds[i].is_null) {
+            continue;
+        }
+        if (conds[i].val) {
+            DateTimeValue time_value = DateTimeValue::from_datetime_val(timestamp);
+            state->add(time_value, i, num_cond, window.val);
+        }
+    }
+}
+
+StringVal AggregateFunctions::window_funnel_serialize(FunctionContext* ctx,
+                                                const StringVal& src) {
+    WindowFunnelState* state = reinterpret_cast<WindowFunnelState*>(src.ptr);
+    int64_t serialized_size = state->serialized_size();
+    StringVal result(ctx, sizeof(double) + serialized_size);
+    state->serialize(result.ptr);
+
+    delete state;
+    return result;
+}
+
+void AggregateFunctions::window_funnel_merge(FunctionContext* ctx, const StringVal& src,
+                                            StringVal* dst) {
+    DCHECK(dst->ptr != nullptr);
+    DCHECK_EQ(sizeof(WindowFunnelState), dst->len);
+    WindowFunnelState* dst_state = reinterpret_cast<WindowFunnelState*>(dst->ptr);
+
+    WindowFunnelState* src_state = new WindowFunnelState;
+
+    src_state->deserialize(src.ptr);
+    dst_state->merge(src_state);
+    delete src_state;
+}
+
+IntVal AggregateFunctions::window_funnel_finalize(FunctionContext* ctx, const StringVal& src) {
+    DCHECK(!src.is_null);
+
+    WindowFunnelState* state = reinterpret_cast<WindowFunnelState*>(src.ptr);
+    state->sort();
+    int val = state->get_event_level();
+    delete state;
+    return doris_udf::IntVal(val);
+}
+
 // Stamp out the templates for the types we need.
 template void AggregateFunctions::init_zero_null<BigIntVal>(FunctionContext*, BigIntVal* dst);
 template void AggregateFunctions::init_zero_null<LargeIntVal>(FunctionContext*, LargeIntVal* dst);
@@ -2740,4 +2940,5 @@ template void AggregateFunctions::percentile_approx_update<doris_udf::DoubleVal>
 template void AggregateFunctions::percentile_approx_update<doris_udf::DoubleVal>(
         FunctionContext* ctx, const doris_udf::DoubleVal&, const doris_udf::DoubleVal&,
         const doris_udf::DoubleVal&, doris_udf::StringVal*);
+
 } // namespace doris

--- a/be/src/exprs/aggregate_functions.h
+++ b/be/src/exprs/aggregate_functions.h
@@ -349,6 +349,16 @@ public:
     static void offset_fn_update(doris_udf::FunctionContext*, const T& src,
                                  const doris_udf::BigIntVal&, const T&, T* dst);
 
+    // windowFunnel
+    static void window_funnel_init(FunctionContext* ctx, StringVal* dst);
+    static void window_funnel_update(FunctionContext* ctx, const BigIntVal& window,
+                             const DateTimeVal& timestamp, int num_cond,
+                             const BooleanVal* conds, StringVal* dst);
+    static void window_funnel_merge(FunctionContext* ctx, const StringVal& src,
+                            StringVal* dst);
+    static StringVal window_funnel_serialize(FunctionContext* ctx, const StringVal& src);
+    static IntVal window_funnel_finalize(FunctionContext* ctx, const StringVal& src);
+
     // todo(kks): keep following HLL methods only for backward compatibility, we should remove these methods
     //            when doris 0.12 release
     static void hll_init(doris_udf::FunctionContext*, doris_udf::StringVal* slot);

--- a/be/src/exprs/aggregate_functions.h
+++ b/be/src/exprs/aggregate_functions.h
@@ -352,8 +352,8 @@ public:
     // windowFunnel
     static void window_funnel_init(FunctionContext* ctx, StringVal* dst);
     static void window_funnel_update(FunctionContext* ctx, const BigIntVal& window,
-                             const DateTimeVal& timestamp, int num_cond,
-                             const BooleanVal* conds, StringVal* dst);
+                             const StringVal& mode, const DateTimeVal& timestamp,
+                             int num_cond, const BooleanVal* conds, StringVal* dst);
     static void window_funnel_merge(FunctionContext* ctx, const StringVal& src,
                             StringVal* dst);
     static StringVal window_funnel_serialize(FunctionContext* ctx, const StringVal& src);

--- a/be/src/vec/CMakeLists.txt
+++ b/be/src/vec/CMakeLists.txt
@@ -20,6 +20,7 @@ set(LIBRARY_OUTPUT_PATH "${BUILD_DIR}/src/vec")
 set(EXECUTABLE_OUTPUT_PATH "${BUILD_DIR}/src/vec")
 
 set(VEC_FILES
+  aggregate_functions/aggregate_function_window_funnel.cpp
   aggregate_functions/aggregate_function_avg.cpp
   aggregate_functions/aggregate_function_count.cpp
   aggregate_functions/aggregate_function_distinct.cpp

--- a/be/src/vec/aggregate_functions/aggregate_function.h
+++ b/be/src/vec/aggregate_functions/aggregate_function.h
@@ -102,7 +102,7 @@ public:
     virtual bool allocates_memory_in_arena() const { return false; }
 
     /// Inserts results into a column.
-    virtual void insert_result_into(ConstAggregateDataPtr __restrict place, IColumn& to) const = 0;
+    virtual void insert_result_into(AggregateDataPtr __restrict place, IColumn& to) const = 0;
 
     /** Returns true for aggregate functions of type -State.
       * They are executed as other aggregate functions, but not finalized (return an aggregation state that can be combined with another).

--- a/be/src/vec/aggregate_functions/aggregate_function_approx_count_distinct.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_approx_count_distinct.h
@@ -98,7 +98,7 @@ public:
         this->data(place).read(buf);
     }
 
-    void insert_result_into(ConstAggregateDataPtr __restrict place, IColumn& to) const override {
+    void insert_result_into(AggregateDataPtr __restrict place, IColumn& to) const override {
         auto& column = static_cast<ColumnInt64&>(to);
         column.get_data().push_back(this->data(place).get());
     }

--- a/be/src/vec/aggregate_functions/aggregate_function_avg.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_avg.h
@@ -116,7 +116,7 @@ public:
         this->data(place).read(buf);
     }
 
-    void insert_result_into(ConstAggregateDataPtr __restrict place, IColumn& to) const override {
+    void insert_result_into(AggregateDataPtr __restrict place, IColumn& to) const override {
         auto& column = static_cast<ColVecResult&>(to);
         column.get_data().push_back(this->data(place).template result<ResultType>());
     }

--- a/be/src/vec/aggregate_functions/aggregate_function_bitmap.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_bitmap.h
@@ -113,7 +113,7 @@ public:
         this->data(place).read(buf);
     }
 
-    void insert_result_into(ConstAggregateDataPtr __restrict place, IColumn& to) const override {
+    void insert_result_into(AggregateDataPtr __restrict place, IColumn& to) const override {
         auto& column = static_cast<ColVecResult&>(to);
         column.get_data().push_back(
                 const_cast<AggregateFunctionBitmapData<Op>&>(this->data(place)).get());
@@ -167,7 +167,7 @@ public:
         this->data(place).read(buf);
     }
 
-    void insert_result_into(ConstAggregateDataPtr __restrict place, IColumn& to) const override {
+    void insert_result_into(AggregateDataPtr __restrict place, IColumn& to) const override {
         auto& value_data = const_cast<AggFunctionData&>(this->data(place)).get();
         auto& column = static_cast<ColVecResult&>(to);
         column.get_data().push_back(value_data.cardinality());

--- a/be/src/vec/aggregate_functions/aggregate_function_count.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_count.h
@@ -66,7 +66,7 @@ public:
         read_var_uint(data(place).count, buf);
     }
 
-    void insert_result_into(ConstAggregateDataPtr __restrict place, IColumn& to) const override {
+    void insert_result_into(AggregateDataPtr __restrict place, IColumn& to) const override {
         assert_cast<ColumnInt64&>(to).get_data().push_back(data(place).count);
     }
 };
@@ -104,7 +104,7 @@ public:
         read_var_uint(data(place).count, buf);
     }
 
-    void insert_result_into(ConstAggregateDataPtr __restrict place, IColumn& to) const override {
+    void insert_result_into(AggregateDataPtr __restrict place, IColumn& to) const override {
         if (to.is_nullable()) {
             auto& null_column = assert_cast<ColumnNullable&>(to);
             null_column.get_null_map_data().push_back(0);

--- a/be/src/vec/aggregate_functions/aggregate_function_distinct.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_distinct.h
@@ -185,7 +185,7 @@ public:
     }
 
     // void insert_result_into(AggregateDataPtr place, IColumn & to, Arena * arena) const override
-    void insert_result_into(ConstAggregateDataPtr targetplace, IColumn& to) const override {
+    void insert_result_into(AggregateDataPtr targetplace, IColumn& to) const override {
         auto place = const_cast<AggregateDataPtr>(targetplace);
         auto arguments = this->data(place).get_arguments(this->argument_types);
         ColumnRawPtrs arguments_raw(arguments.size());

--- a/be/src/vec/aggregate_functions/aggregate_function_group_concat.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_group_concat.h
@@ -131,7 +131,7 @@ public:
         this->data(place).read(buf);
     }
 
-    void insert_result_into(ConstAggregateDataPtr __restrict place, IColumn& to) const override {
+    void insert_result_into(AggregateDataPtr __restrict place, IColumn& to) const override {
         std::string result = this->data(place).get();
         static_cast<ColumnString&>(to).insert_data(result.c_str(), result.length());
     }

--- a/be/src/vec/aggregate_functions/aggregate_function_min_max.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_min_max.h
@@ -516,7 +516,7 @@ public:
 
     bool allocates_memory_in_arena() const override { return AllocatesMemoryInArena; }
 
-    void insert_result_into(ConstAggregateDataPtr __restrict place, IColumn& to) const override {
+    void insert_result_into(AggregateDataPtr __restrict place, IColumn& to) const override {
         this->data(place).insert_result_into(to);
     }
 };

--- a/be/src/vec/aggregate_functions/aggregate_function_nothing.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_nothing.h
@@ -61,7 +61,7 @@ public:
 
     void deserialize(AggregateDataPtr, BufferReadable& buf, Arena*) const override {}
 
-    void insert_result_into(ConstAggregateDataPtr, IColumn& to) const override {
+    void insert_result_into(AggregateDataPtr, IColumn& to) const override {
         to.insert_default();
     }
 };

--- a/be/src/vec/aggregate_functions/aggregate_function_null.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_null.h
@@ -140,7 +140,7 @@ public:
         }
     }
 
-    void insert_result_into(ConstAggregateDataPtr __restrict place, IColumn& to) const override {
+    void insert_result_into(AggregateDataPtr __restrict place, IColumn& to) const override {
         if constexpr (result_is_nullable) {
             ColumnNullable& to_concrete = assert_cast<ColumnNullable&>(to);
             if (get_flag(place)) {

--- a/be/src/vec/aggregate_functions/aggregate_function_percentile_approx.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_percentile_approx.h
@@ -127,7 +127,7 @@ public:
         this->data(place).read(buf);
     }
 
-    void insert_result_into(ConstAggregateDataPtr __restrict place, IColumn& to) const override {
+    void insert_result_into(AggregateDataPtr __restrict place, IColumn& to) const override {
         ColumnNullable& nullable_column = assert_cast<ColumnNullable&>(to);
         double result = this->data(place).get();
 
@@ -258,7 +258,7 @@ public:
         this->data(place).read(buf);
     }
 
-    void insert_result_into(ConstAggregateDataPtr __restrict place, IColumn& to) const override {
+    void insert_result_into(AggregateDataPtr __restrict place, IColumn& to) const override {
         auto& col = assert_cast<ColumnVector<Float64>&>(to);
         col.insert_value(this->data(place).get());
     }

--- a/be/src/vec/aggregate_functions/aggregate_function_simple_factory.cpp
+++ b/be/src/vec/aggregate_functions/aggregate_function_simple_factory.cpp
@@ -41,6 +41,7 @@ void register_aggregate_function_stddev_variance(AggregateFunctionSimpleFactory&
 void register_aggregate_function_topn(AggregateFunctionSimpleFactory& factory);
 void register_aggregate_function_approx_count_distinct(AggregateFunctionSimpleFactory& factory);
 void register_aggregate_function_group_concat(AggregateFunctionSimpleFactory& factory);
+void register_aggregate_function_window_funnel(AggregateFunctionSimpleFactory& factory);
 
 void register_aggregate_function_percentile_approx(AggregateFunctionSimpleFactory& factory);
 AggregateFunctionSimpleFactory& AggregateFunctionSimpleFactory::instance() {
@@ -61,6 +62,7 @@ AggregateFunctionSimpleFactory& AggregateFunctionSimpleFactory::instance() {
         register_aggregate_function_approx_count_distinct(instance);
         register_aggregate_function_group_concat(instance);
         register_aggregate_function_percentile_approx(instance);
+        register_aggregate_function_window_funnel(instance);
 
         // if you only register function with no nullable, and wants to add nullable automatically, you should place function above this line
         register_aggregate_function_combinator_null(instance);

--- a/be/src/vec/aggregate_functions/aggregate_function_stddev.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_stddev.h
@@ -277,7 +277,7 @@ public:
         this->data(place).read(buf);
     }
 
-    void insert_result_into(ConstAggregateDataPtr __restrict place, IColumn& to) const override {
+    void insert_result_into(AggregateDataPtr __restrict place, IColumn& to) const override {
         this->data(place).insert_result_into(to);
     }
 };

--- a/be/src/vec/aggregate_functions/aggregate_function_sum.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_sum.h
@@ -95,7 +95,7 @@ public:
         this->data(place).read(buf);
     }
 
-    void insert_result_into(ConstAggregateDataPtr __restrict place, IColumn& to) const override {
+    void insert_result_into(AggregateDataPtr __restrict place, IColumn& to) const override {
         auto& column = static_cast<ColVecResult&>(to);
         column.get_data().push_back(this->data(place).get());
     }

--- a/be/src/vec/aggregate_functions/aggregate_function_topn.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_topn.h
@@ -230,7 +230,7 @@ public:
         this->data(place).read(buf);
     }
 
-    void insert_result_into(ConstAggregateDataPtr __restrict place, IColumn& to) const override {
+    void insert_result_into(AggregateDataPtr __restrict place, IColumn& to) const override {
         std::string result = this->data(place).get();
         static_cast<ColumnString&>(to).insert_data(result.c_str(), result.length());
     }

--- a/be/src/vec/aggregate_functions/aggregate_function_uniq.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_uniq.h
@@ -123,7 +123,7 @@ public:
         this->data(place).set.read(buf);
     }
 
-    void insert_result_into(ConstAggregateDataPtr __restrict place, IColumn& to) const override {
+    void insert_result_into(AggregateDataPtr __restrict place, IColumn& to) const override {
         assert_cast<ColumnInt64&>(to).get_data().push_back(this->data(place).set.size());
     }
 };

--- a/be/src/vec/aggregate_functions/aggregate_function_window.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_window.h
@@ -55,7 +55,7 @@ public:
 
     void reset(AggregateDataPtr place) const override { this->data(place).count = 0; }
 
-    void insert_result_into(ConstAggregateDataPtr place, IColumn& to) const override {
+    void insert_result_into(AggregateDataPtr place, IColumn& to) const override {
         assert_cast<ColumnInt64&>(to).get_data().push_back(data(place).count);
     }
 
@@ -100,7 +100,7 @@ public:
         this->data(place).peer_group_start = -1;
     }
 
-    void insert_result_into(ConstAggregateDataPtr place, IColumn& to) const override {
+    void insert_result_into(AggregateDataPtr place, IColumn& to) const override {
         assert_cast<ColumnInt64&>(to).get_data().push_back(data(place).rank);
     }
 
@@ -141,7 +141,7 @@ public:
         this->data(place).peer_group_start = -1;
     }
 
-    void insert_result_into(ConstAggregateDataPtr place, IColumn& to) const override {
+    void insert_result_into(AggregateDataPtr place, IColumn& to) const override {
         assert_cast<ColumnInt64&>(to).get_data().push_back(data(place).rank);
     }
 
@@ -386,7 +386,7 @@ public:
 
     void reset(AggregateDataPtr place) const override { this->data(place).reset(); }
 
-    void insert_result_into(ConstAggregateDataPtr place, IColumn& to) const override {
+    void insert_result_into(AggregateDataPtr place, IColumn& to) const override {
         this->data(place).insert_result_into(to);
     }
 

--- a/be/src/vec/aggregate_functions/aggregate_function_window_funnel.cpp
+++ b/be/src/vec/aggregate_functions/aggregate_function_window_funnel.cpp
@@ -1,0 +1,37 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "vec/aggregate_functions/aggregate_function_window_funnel.h"
+
+#include "common/logging.h"
+#include "vec/aggregate_functions/aggregate_function_simple_factory.h"
+#include "vec/aggregate_functions/factory_helpers.h"
+#include "vec/aggregate_functions/helpers.h"
+
+namespace doris::vectorized {
+
+AggregateFunctionPtr create_aggregate_function_window_funnel(const std::string& name,
+                                                             const DataTypes& argument_types,
+                                                             const Array& parameters,
+                                                             const bool result_is_nullable) {
+    return std::make_shared<AggregateFunctionWindowFunnel>(argument_types);
+}
+
+void register_aggregate_function_window_funnel(AggregateFunctionSimpleFactory& factory) {
+    factory.register_function("window_funnel", create_aggregate_function_window_funnel, false);
+}
+} // namespace doris::vectorized

--- a/be/src/vec/aggregate_functions/aggregate_function_window_funnel.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_window_funnel.h
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+// Refer to AggregateFunctionWindowFunnel.h in https://github.com/ClickHouse/ClickHouse.git
+
 #pragma once
 
 #include "common/logging.h"
@@ -41,8 +43,7 @@ struct WindowFunnelState {
         sorted = true;
         max_event_level = 0;
         window = 0;
-        std::vector<std::pair<VecDateTimeValue, int>> tmp;
-        events.swap(tmp);
+        events.shrink_to_fit();
     }
 
     void add(const VecDateTimeValue& timestamp, int event_idx, int event_num, int64_t win) {

--- a/be/src/vec/aggregate_functions/aggregate_function_window_funnel.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_window_funnel.h
@@ -177,12 +177,15 @@ public:
     void add(AggregateDataPtr __restrict place, const IColumn** columns, size_t row_num,
              Arena*) const override {
         const auto& window = static_cast<const ColumnVector<Int64>&>(*columns[0]).get_data()[row_num];
+        // handle mode in the future.
         // be/src/olap/row_block2.cpp copy_data_to_column
-        const auto& timestamp = static_cast<const ColumnVector<VecDateTimeValue>&>(*columns[1]).get_data()[row_num];
-        for (int i = 2; i < get_argument_types().size(); i++) {
+        const auto& timestamp = static_cast<const ColumnVector<VecDateTimeValue>&>(*columns[2]).get_data()[row_num];
+        const int NON_EVENT_NUM = 3;
+        for (int i = NON_EVENT_NUM; i < get_argument_types().size(); i++) {
             const auto& is_set = static_cast<const ColumnVector<UInt8>&>(*columns[i]).get_data()[row_num];
             if (is_set) {
-                this->data(place).add(timestamp, i - 2, get_argument_types().size() - 2, window);
+                this->data(place).add(timestamp, i - NON_EVENT_NUM,
+                                      get_argument_types().size() - NON_EVENT_NUM, window);
             }
         }
     }

--- a/be/src/vec/aggregate_functions/aggregate_function_window_funnel.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_window_funnel.h
@@ -167,10 +167,8 @@ public:
 
     String get_name() const override { return "window_funnel"; }
 
-    bool insert_to_null_default() const override { return false; }
-
     DataTypePtr get_return_type() const override {
-        return make_nullable(std::make_shared<DataTypeInt32>());
+        return std::make_shared<DataTypeInt32>();
     }
 
     void reset(AggregateDataPtr __restrict place) const override { this->data(place).reset(); }

--- a/be/src/vec/aggregate_functions/aggregate_function_window_funnel.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_window_funnel.h
@@ -1,0 +1,210 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include "common/logging.h"
+#include "vec/aggregate_functions/aggregate_function.h"
+#include "vec/columns/columns_number.h"
+#include "vec/data_types/data_type_decimal.h"
+#include "vec/io/var_int.h"
+
+namespace doris::vectorized {
+
+struct WindowFunnelState {
+    std::vector<std::pair<VecDateTimeValue, int>> events;
+    int max_event_level;
+    bool sorted;
+    int64_t window;
+
+    WindowFunnelState() {
+        sorted = true;
+        max_event_level = 0;
+        window = 0;
+    }
+
+    void reset() {
+        sorted = true;
+        max_event_level = 0;
+        window = 0;
+        std::vector<std::pair<VecDateTimeValue, int>> tmp;
+        events.swap(tmp);
+    }
+
+    void add(const VecDateTimeValue& timestamp, int event_idx, int event_num, int64_t win) {
+        window = win;
+        max_event_level = event_num;
+        if (sorted && events.size() > 0) {
+            if (events.back().first == timestamp) {
+                sorted = events.back().second <= event_idx;
+            } else {
+                sorted = events.back().first < timestamp;
+            }
+        }
+        events.emplace_back(timestamp, event_idx);
+    }
+
+    void sort() {
+        if (sorted) {
+            return;
+        }
+        std::stable_sort(events.begin(), events.end());
+    }
+
+    int get() const {
+        std::vector<std::optional<VecDateTimeValue>> events_timestamp(max_event_level);
+        for (int64_t i = 0; i < events.size(); i++) {
+            const int& event_idx = events[i].second;
+            const VecDateTimeValue& timestamp = events[i].first;
+            if (event_idx == 0) {
+                events_timestamp[0] = timestamp;
+                continue;
+            }
+            if (events_timestamp[event_idx - 1].has_value()) {
+                const VecDateTimeValue& first_timestamp = events_timestamp[event_idx - 1].value();
+                VecDateTimeValue last_timestamp = first_timestamp;
+                TimeInterval interval(SECOND, window, false);
+                last_timestamp.date_add_interval(interval, SECOND);
+
+                if (timestamp <= last_timestamp) {
+                    events_timestamp[event_idx] = first_timestamp;
+                    if (event_idx + 1 == max_event_level) {
+                        // Usually, max event level is small.
+                        return max_event_level;
+                    }
+                }
+            }
+        }
+
+        for (int64_t i = events_timestamp.size() - 1; i >= 0; i--) {
+            if (events_timestamp[i].has_value()) {
+                return i + 1;
+            }
+        }
+
+        return 0;
+    }
+
+    void merge(const WindowFunnelState& other) {
+        if (other.events.empty()) {
+            return;
+        }
+
+        int64_t orig_size = events.size();
+        events.insert(std::end(events), std::begin(other.events), std::end(other.events));
+        const auto begin = std::begin(events);
+        const auto middle = std::next(events.begin(), orig_size);
+        const auto end = std::end(events);
+        if (!other.sorted) {
+            std::stable_sort(middle, end);
+        }
+
+        if (!sorted) {
+            std::stable_sort(begin, middle);
+        }
+        std::inplace_merge(begin, middle, end);
+        max_event_level = max_event_level > 0 ? max_event_level : other.max_event_level;
+        window = window > 0 ? window : other.window;
+
+        sorted = true;
+    }
+
+    void write(BufferWritable &out) const {
+        write_var_int(max_event_level, out);
+        write_var_int(window, out);
+        write_var_int(events.size(), out);
+
+        for (int64_t i = 0; i < events.size(); i++) {
+            int64_t timestamp = events[i].first;
+            int event_idx = events[i].second;
+            write_var_int(timestamp, out);
+            write_var_int(event_idx, out);
+        }
+    }
+
+    void read(BufferReadable& in) {
+        int64_t event_level;
+        read_var_int(event_level, in);
+        max_event_level = (int)event_level;
+        read_var_int(window, in);
+        int64_t size = 0;
+        read_var_int(size, in);
+        for (int64_t i = 0; i < size; i++) {
+            int64_t timestamp;
+            int64_t event_idx;
+
+            read_var_int(timestamp, in);
+            read_var_int(event_idx, in);
+            VecDateTimeValue time_value(timestamp);
+            add(time_value, (int)event_idx, max_event_level, window);
+        }
+    }
+};
+
+class AggregateFunctionWindowFunnel
+        : public IAggregateFunctionDataHelper<WindowFunnelState,
+                                              AggregateFunctionWindowFunnel> {
+public:
+    AggregateFunctionWindowFunnel(const DataTypes& argument_types_)
+            : IAggregateFunctionDataHelper<WindowFunnelState,
+                                           AggregateFunctionWindowFunnel>(argument_types_, {}) {
+    }
+
+    String get_name() const override { return "window_funnel"; }
+
+    bool insert_to_null_default() const override { return false; }
+
+    DataTypePtr get_return_type() const override {
+        return make_nullable(std::make_shared<DataTypeInt32>());
+    }
+
+    void reset(AggregateDataPtr __restrict place) const override { this->data(place).reset(); }
+
+    void add(AggregateDataPtr __restrict place, const IColumn** columns, size_t row_num,
+             Arena*) const override {
+        const auto& window = static_cast<const ColumnVector<Int64>&>(*columns[0]).get_data()[row_num];
+        // be/src/olap/row_block2.cpp copy_data_to_column
+        const auto& timestamp = static_cast<const ColumnVector<VecDateTimeValue>&>(*columns[1]).get_data()[row_num];
+        for (int i = 2; i < get_argument_types().size(); i++) {
+            const auto& is_set = static_cast<const ColumnVector<UInt8>&>(*columns[i]).get_data()[row_num];
+            if (is_set) {
+                this->data(place).add(timestamp, i - 2, get_argument_types().size() - 2, window);
+            }
+        }
+    }
+
+    void merge(AggregateDataPtr __restrict place, ConstAggregateDataPtr rhs,
+               Arena*) const override {
+        this->data(place).merge(this->data(rhs));
+    }
+
+    void serialize(ConstAggregateDataPtr __restrict place, BufferWritable& buf) const override {
+        this->data(place).write(buf);
+    }
+
+    void deserialize(AggregateDataPtr __restrict place, BufferReadable& buf,
+                     Arena*) const override {
+        this->data(place).read(buf);
+    }
+
+    void insert_result_into(AggregateDataPtr __restrict place, IColumn& to) const override {
+        this->data(place).sort();
+        assert_cast<ColumnInt32&>(to).get_data().push_back(data(place).get());
+    }
+};
+
+} // namespace doris::vectorized

--- a/be/test/exprs/CMakeLists.txt
+++ b/be/test/exprs/CMakeLists.txt
@@ -39,4 +39,5 @@ ADD_BE_TEST(topn_function_test)
 ADD_BE_TEST(runtime_filter_test)
 ADD_BE_TEST(bloom_filter_predicate_test)
 ADD_BE_TEST(array_functions_test)
+ADD_BE_TEST(window_funnel_test)
 

--- a/be/test/exprs/window_funnel_test.cpp
+++ b/be/test/exprs/window_funnel_test.cpp
@@ -1,0 +1,356 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <gtest/gtest.h>
+
+#include "common/logging.h"
+#include "exprs/aggregate_functions.h"
+#include "runtime/datetime_value.h"
+#include "testutil/function_utils.h"
+
+namespace doris {
+
+class WindowFunnelTest : public testing::Test {
+public:
+    WindowFunnelTest() {}
+};
+
+TEST_F(WindowFunnelTest, testMax4SortedNoMerge) {
+    FunctionUtils* futil = new FunctionUtils();
+    doris_udf::FunctionContext* context = futil->get_fn_ctx();
+
+    const int NUM_CONDS = 4;
+    for (int i = -1; i < NUM_CONDS + 4; i++) {
+        StringVal stringVal1;
+        BigIntVal window(i);
+        AggregateFunctions::window_funnel_init(context, &stringVal1);
+
+        DateTimeVal timestamp;
+        DateTimeValue time_value;
+        time_value.set_time(2020, 2, 28, 0, 0, 1, 0);
+        time_value.to_datetime_val(&timestamp);
+        BooleanVal conds[NUM_CONDS] = {true, false, false, false};
+        AggregateFunctions::window_funnel_update(context, window, timestamp, NUM_CONDS,
+                                          conds, &stringVal1);
+
+        time_value.set_time(2020, 2, 28, 0, 0, 2, 0);
+        time_value.to_datetime_val(&timestamp);
+        BooleanVal conds1[NUM_CONDS] = {false, true, false, false};
+        AggregateFunctions::window_funnel_update(context, window, timestamp, NUM_CONDS,
+                                          conds1, &stringVal1);
+
+        time_value.set_time(2020, 2, 28, 0, 0, 3, 0);
+        time_value.to_datetime_val(&timestamp);
+        BooleanVal conds2[NUM_CONDS] = {false, false, true, false};
+        AggregateFunctions::window_funnel_update(context, window, timestamp, NUM_CONDS,
+                                          conds2, &stringVal1);
+
+        time_value.set_time(2020, 2, 28, 0, 0, 4, 0);
+        time_value.to_datetime_val(&timestamp);
+        BooleanVal conds3[NUM_CONDS] = {false, false, false, true};
+        AggregateFunctions::window_funnel_update(context, window, timestamp, NUM_CONDS,
+                                          conds3, &stringVal1);
+
+        IntVal v = AggregateFunctions::window_funnel_finalize(context, stringVal1);
+        LOG(INFO) << "event num: " << NUM_CONDS << " window: " << window.val;
+        ASSERT_EQ(v.val, i < 0 ? 1 : (i < NUM_CONDS ? i + 1 : NUM_CONDS));
+    }
+    delete futil;
+}
+
+TEST_F(WindowFunnelTest, testMax4SortedMerge) {
+    FunctionUtils* futil = new FunctionUtils();
+    doris_udf::FunctionContext* context = futil->get_fn_ctx();
+
+    const int NUM_CONDS = 4;
+    for (int i = -1; i < NUM_CONDS + 4; i++) {
+        StringVal stringVal1;
+        BigIntVal window(i);
+        AggregateFunctions::window_funnel_init(context, &stringVal1);
+
+        DateTimeVal timestamp;
+        DateTimeValue time_value;
+        time_value.set_time(2020, 2, 28, 0, 0, 1, 0);
+        time_value.to_datetime_val(&timestamp);
+
+        BooleanVal conds[NUM_CONDS] = {true, false, false, false};
+        AggregateFunctions::window_funnel_update(context, window, timestamp, NUM_CONDS,
+                                          conds, &stringVal1);
+
+        time_value.set_time(2020, 2, 28, 0, 0, 2, 0);
+        time_value.to_datetime_val(&timestamp);
+        BooleanVal conds1[NUM_CONDS] = {false, true, false, false};
+        AggregateFunctions::window_funnel_update(context, window, timestamp, NUM_CONDS,
+                                          conds1, &stringVal1);
+
+        time_value.set_time(2020, 2, 28, 0, 0, 3, 0);
+        time_value.to_datetime_val(&timestamp);
+        BooleanVal conds2[NUM_CONDS] = {false, false, true, false};
+        AggregateFunctions::window_funnel_update(context, window, timestamp, NUM_CONDS,
+                                          conds2, &stringVal1);
+
+        time_value.set_time(2020, 2, 28, 0, 0, 4, 0);
+        time_value.to_datetime_val(&timestamp);
+        BooleanVal conds3[NUM_CONDS] = {false, false, false, true};
+        AggregateFunctions::window_funnel_update(context, window, timestamp, NUM_CONDS,
+                                          conds3, &stringVal1);
+
+        StringVal s = AggregateFunctions::window_funnel_serialize(context, stringVal1);
+
+        StringVal stringVal2;
+        AggregateFunctions::window_funnel_init(context, &stringVal2);
+        AggregateFunctions::window_funnel_merge(context, s, &stringVal2);
+        IntVal v = AggregateFunctions::window_funnel_finalize(context, stringVal2);
+        LOG(INFO) << "event num: " << NUM_CONDS << " window: " << window.val;
+        ASSERT_EQ(v.val, i < 0 ? 1 : (i < NUM_CONDS ? i + 1 : NUM_CONDS));
+    }
+    delete futil;
+}
+
+TEST_F(WindowFunnelTest, testMax4ReverseSortedNoMerge) {
+    FunctionUtils* futil = new FunctionUtils();
+    doris_udf::FunctionContext* context = futil->get_fn_ctx();
+
+    const int NUM_CONDS = 4;
+    for (int i = -1; i < NUM_CONDS + 4; i++) {
+        StringVal stringVal1;
+        BigIntVal window(i);
+        AggregateFunctions::window_funnel_init(context, &stringVal1);
+
+        DateTimeVal timestamp;
+        DateTimeValue time_value;
+        time_value.set_time(2020, 2, 28, 0, 0, 3, 0);
+        time_value.to_datetime_val(&timestamp);
+
+        BooleanVal conds[NUM_CONDS] = {true, false, false, false};
+        AggregateFunctions::window_funnel_update(context, window, timestamp, NUM_CONDS,
+                                          conds, &stringVal1);
+
+        time_value.set_time(2020, 2, 28, 0, 0, 2, 0);
+        time_value.to_datetime_val(&timestamp);
+        BooleanVal conds1[NUM_CONDS] = {false, true, false, false};
+        AggregateFunctions::window_funnel_update(context, window, timestamp, NUM_CONDS,
+                                          conds1, &stringVal1);
+
+        time_value.set_time(2020, 2, 28, 0, 0, 1, 0);
+        time_value.to_datetime_val(&timestamp);
+        BooleanVal conds2[NUM_CONDS] = {false, false, true, false};
+        AggregateFunctions::window_funnel_update(context, window, timestamp, NUM_CONDS,
+                                          conds2, &stringVal1);
+
+        time_value.set_time(2020, 2, 28, 0, 0, 0, 0);
+        time_value.to_datetime_val(&timestamp);
+        BooleanVal conds3[NUM_CONDS] = {false, false, false, true};
+        AggregateFunctions::window_funnel_update(context, window, timestamp, NUM_CONDS,
+                                          conds3, &stringVal1);
+
+        IntVal v = AggregateFunctions::window_funnel_finalize(context, stringVal1);
+        LOG(INFO) << "event num: " << NUM_CONDS << " window: " << window.val;
+        ASSERT_EQ(v.val, 1);
+    }
+    delete futil;
+}
+
+TEST_F(WindowFunnelTest, testMax4ReverseSortedMerge) {
+    FunctionUtils* futil = new FunctionUtils();
+    doris_udf::FunctionContext* context = futil->get_fn_ctx();
+
+    const int NUM_CONDS = 4;
+    for (int i = -1; i < NUM_CONDS + 4; i++) {
+        StringVal stringVal1;
+        BigIntVal window(i);
+        AggregateFunctions::window_funnel_init(context, &stringVal1);
+
+        DateTimeVal timestamp;
+        DateTimeValue time_value;
+        time_value.set_time(2020, 2, 28, 0, 0, 3, 0);
+        time_value.to_datetime_val(&timestamp);
+
+        BooleanVal conds[NUM_CONDS] = {true, false, false, false};
+        AggregateFunctions::window_funnel_update(context, window, timestamp, NUM_CONDS,
+                                          conds, &stringVal1);
+
+        time_value.set_time(2020, 2, 28, 0, 0, 2, 0);
+        time_value.to_datetime_val(&timestamp);
+        BooleanVal conds1[NUM_CONDS] = {false, true, false, false};
+        AggregateFunctions::window_funnel_update(context, window, timestamp, NUM_CONDS,
+                                          conds1, &stringVal1);
+
+        time_value.set_time(2020, 2, 28, 0, 0, 1, 0);
+        time_value.to_datetime_val(&timestamp);
+        BooleanVal conds2[NUM_CONDS] = {false, false, true, false};
+        AggregateFunctions::window_funnel_update(context, window, timestamp, NUM_CONDS,
+                                          conds2, &stringVal1);
+
+        time_value.set_time(2020, 2, 28, 0, 0, 0, 0);
+        time_value.to_datetime_val(&timestamp);
+        BooleanVal conds3[NUM_CONDS] = {false, false, false, true};
+        AggregateFunctions::window_funnel_update(context, window, timestamp, NUM_CONDS,
+                                          conds3, &stringVal1);
+
+        StringVal s = AggregateFunctions::window_funnel_serialize(context, stringVal1);
+
+        StringVal stringVal2;
+        AggregateFunctions::window_funnel_init(context, &stringVal2);
+        AggregateFunctions::window_funnel_merge(context, s, &stringVal2);
+        IntVal v = AggregateFunctions::window_funnel_finalize(context, stringVal2);
+        LOG(INFO) << "event num: " << NUM_CONDS << " window: " << window.val;
+        ASSERT_EQ(v.val, 1);
+    }
+    delete futil;
+}
+
+TEST_F(WindowFunnelTest, testMax4DuplicateSortedNoMerge) {
+    FunctionUtils* futil = new FunctionUtils();
+    doris_udf::FunctionContext* context = futil->get_fn_ctx();
+
+    const int NUM_CONDS = 4;
+    for (int i = -1; i < NUM_CONDS + 4; i++) {
+        StringVal stringVal1;
+        BigIntVal window(i);
+        AggregateFunctions::window_funnel_init(context, &stringVal1);
+
+        DateTimeVal timestamp;
+        DateTimeValue time_value;
+        time_value.set_time(2020, 2, 28, 0, 0, 0, 0);
+        time_value.to_datetime_val(&timestamp);
+
+        BooleanVal conds[NUM_CONDS] = {true, false, false, false};
+        AggregateFunctions::window_funnel_update(context, window, timestamp, NUM_CONDS,
+                                          conds, &stringVal1);
+
+        time_value.set_time(2020, 2, 28, 0, 0, 1, 0);
+        time_value.to_datetime_val(&timestamp);
+        BooleanVal conds1[NUM_CONDS] = {false, true, false, false};
+        AggregateFunctions::window_funnel_update(context, window, timestamp, NUM_CONDS,
+                                          conds1, &stringVal1);
+
+        time_value.set_time(2020, 2, 28, 0, 0, 2, 0);
+        time_value.to_datetime_val(&timestamp);
+        BooleanVal conds2[NUM_CONDS] = {true, false, false, false};
+        AggregateFunctions::window_funnel_update(context, window, timestamp, NUM_CONDS,
+                                          conds2, &stringVal1);
+
+        time_value.set_time(2020, 2, 28, 0, 0, 3, 0);
+        time_value.to_datetime_val(&timestamp);
+        BooleanVal conds3[NUM_CONDS] = {false, false, false, false};
+        AggregateFunctions::window_funnel_update(context, window, timestamp, NUM_CONDS,
+                                          conds3, &stringVal1);
+
+        IntVal v = AggregateFunctions::window_funnel_finalize(context, stringVal1);
+        LOG(INFO) << "event num: " << NUM_CONDS << " window: " << window.val;
+        ASSERT_EQ(v.val, i < 0 ? 1 : (i < 2 ? i + 1 : 2));
+    }
+    delete futil;
+}
+
+TEST_F(WindowFunnelTest, testMax4DuplicateSortedMerge) {
+    FunctionUtils* futil = new FunctionUtils();
+    doris_udf::FunctionContext* context = futil->get_fn_ctx();
+
+    const int NUM_CONDS = 4;
+    for (int i = -1; i < NUM_CONDS + 4; i++) {
+        StringVal stringVal1;
+        BigIntVal window(i);
+        AggregateFunctions::window_funnel_init(context, &stringVal1);
+
+        DateTimeVal timestamp;
+        DateTimeValue time_value;
+        time_value.set_time(2020, 2, 28, 0, 0, 0, 0);
+        time_value.to_datetime_val(&timestamp);
+
+        BooleanVal conds[NUM_CONDS] = {true, false, false, false};
+        AggregateFunctions::window_funnel_update(context, window, timestamp, NUM_CONDS,
+                                          conds, &stringVal1);
+
+        time_value.set_time(2020, 2, 28, 0, 0, 1, 0);
+        time_value.to_datetime_val(&timestamp);
+        BooleanVal conds1[NUM_CONDS] = {false, true, false, false};
+        AggregateFunctions::window_funnel_update(context, window, timestamp, NUM_CONDS,
+                                          conds1, &stringVal1);
+
+        time_value.set_time(2020, 2, 28, 0, 0, 2, 0);
+        time_value.to_datetime_val(&timestamp);
+        BooleanVal conds2[NUM_CONDS] = {true, false, false, false};
+        AggregateFunctions::window_funnel_update(context, window, timestamp, NUM_CONDS,
+                                          conds2, &stringVal1);
+
+        time_value.set_time(2020, 2, 28, 0, 0, 3, 0);
+        time_value.to_datetime_val(&timestamp);
+        BooleanVal conds3[NUM_CONDS] = {false, false, false, false};
+        AggregateFunctions::window_funnel_update(context, window, timestamp, NUM_CONDS,
+                                          conds3, &stringVal1);
+
+        StringVal s = AggregateFunctions::window_funnel_serialize(context, stringVal1);
+
+        StringVal stringVal2;
+        AggregateFunctions::window_funnel_init(context, &stringVal2);
+        AggregateFunctions::window_funnel_merge(context, s, &stringVal2);
+        IntVal v = AggregateFunctions::window_funnel_finalize(context, stringVal2);
+        LOG(INFO) << "event num: " << NUM_CONDS << " window: " << window.val;
+        ASSERT_EQ(v.val, i < 0 ? 1 : (i < 2 ? i + 1 : 2));
+    }
+    delete futil;
+}
+
+TEST_F(WindowFunnelTest, testNoMatchedEvent) {
+    FunctionUtils* futil = new FunctionUtils();
+    doris_udf::FunctionContext* context = futil->get_fn_ctx();
+
+    StringVal stringVal1;
+    BigIntVal window(0);
+    AggregateFunctions::window_funnel_init(context, &stringVal1);
+
+    DateTimeVal timestamp;
+    DateTimeValue time_value;
+    time_value.set_time(2020, 2, 28, 0, 0, 0, 0);
+    time_value.to_datetime_val(&timestamp);
+
+    BooleanVal conds[4] = {false, false, false, false};
+    AggregateFunctions::window_funnel_update(context, window, timestamp, 4,
+                                      conds, &stringVal1);
+
+    IntVal v = AggregateFunctions::window_funnel_finalize(context, stringVal1);
+    ASSERT_EQ(v.val, 0);
+    delete futil;
+}
+
+TEST_F(WindowFunnelTest, testNoEvent) {
+    FunctionUtils* futil = new FunctionUtils();
+    doris_udf::FunctionContext* context = futil->get_fn_ctx();
+
+    StringVal stringVal1;
+    AggregateFunctions::window_funnel_init(context, &stringVal1);
+
+    IntVal v = AggregateFunctions::window_funnel_finalize(context, stringVal1);
+    ASSERT_EQ(v.val, 0);
+
+    StringVal stringVal2;
+    AggregateFunctions::window_funnel_init(context, &stringVal2);
+
+    v = AggregateFunctions::window_funnel_finalize(context, stringVal2);
+    ASSERT_EQ(v.val, 0);
+
+    delete futil;
+}
+
+} // namespace doris
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/be/test/exprs/window_funnel_test.cpp
+++ b/be/test/exprs/window_funnel_test.cpp
@@ -37,6 +37,12 @@ TEST_F(WindowFunnelTest, testMax4SortedNoMerge) {
     for (int i = -1; i < NUM_CONDS + 4; i++) {
         StringVal stringVal1;
         BigIntVal window(i);
+        StringVal mode("default");
+        std::vector<doris_udf::AnyVal*> constant_args;
+        constant_args.emplace_back(&window);
+        constant_args.emplace_back(&mode);
+        context->impl()->set_constant_args(std::move(constant_args));
+
         AggregateFunctions::window_funnel_init(context, &stringVal1);
 
         DateTimeVal timestamp;
@@ -44,25 +50,25 @@ TEST_F(WindowFunnelTest, testMax4SortedNoMerge) {
         time_value.set_time(2020, 2, 28, 0, 0, 1, 0);
         time_value.to_datetime_val(&timestamp);
         BooleanVal conds[NUM_CONDS] = {true, false, false, false};
-        AggregateFunctions::window_funnel_update(context, window, timestamp, NUM_CONDS,
+        AggregateFunctions::window_funnel_update(context, window, mode, timestamp, NUM_CONDS,
                                           conds, &stringVal1);
 
         time_value.set_time(2020, 2, 28, 0, 0, 2, 0);
         time_value.to_datetime_val(&timestamp);
         BooleanVal conds1[NUM_CONDS] = {false, true, false, false};
-        AggregateFunctions::window_funnel_update(context, window, timestamp, NUM_CONDS,
+        AggregateFunctions::window_funnel_update(context, window, mode, timestamp, NUM_CONDS,
                                           conds1, &stringVal1);
 
         time_value.set_time(2020, 2, 28, 0, 0, 3, 0);
         time_value.to_datetime_val(&timestamp);
         BooleanVal conds2[NUM_CONDS] = {false, false, true, false};
-        AggregateFunctions::window_funnel_update(context, window, timestamp, NUM_CONDS,
+        AggregateFunctions::window_funnel_update(context, window, mode, timestamp, NUM_CONDS,
                                           conds2, &stringVal1);
 
         time_value.set_time(2020, 2, 28, 0, 0, 4, 0);
         time_value.to_datetime_val(&timestamp);
         BooleanVal conds3[NUM_CONDS] = {false, false, false, true};
-        AggregateFunctions::window_funnel_update(context, window, timestamp, NUM_CONDS,
+        AggregateFunctions::window_funnel_update(context, window, mode, timestamp, NUM_CONDS,
                                           conds3, &stringVal1);
 
         IntVal v = AggregateFunctions::window_funnel_finalize(context, stringVal1);
@@ -80,6 +86,12 @@ TEST_F(WindowFunnelTest, testMax4SortedMerge) {
     for (int i = -1; i < NUM_CONDS + 4; i++) {
         StringVal stringVal1;
         BigIntVal window(i);
+        StringVal mode("default");
+        std::vector<doris_udf::AnyVal*> constant_args;
+        constant_args.emplace_back(&window);
+        constant_args.emplace_back(&mode);
+        context->impl()->set_constant_args(std::move(constant_args));
+
         AggregateFunctions::window_funnel_init(context, &stringVal1);
 
         DateTimeVal timestamp;
@@ -88,25 +100,25 @@ TEST_F(WindowFunnelTest, testMax4SortedMerge) {
         time_value.to_datetime_val(&timestamp);
 
         BooleanVal conds[NUM_CONDS] = {true, false, false, false};
-        AggregateFunctions::window_funnel_update(context, window, timestamp, NUM_CONDS,
+        AggregateFunctions::window_funnel_update(context, window, mode, timestamp, NUM_CONDS,
                                           conds, &stringVal1);
 
         time_value.set_time(2020, 2, 28, 0, 0, 2, 0);
         time_value.to_datetime_val(&timestamp);
         BooleanVal conds1[NUM_CONDS] = {false, true, false, false};
-        AggregateFunctions::window_funnel_update(context, window, timestamp, NUM_CONDS,
+        AggregateFunctions::window_funnel_update(context, window, mode, timestamp, NUM_CONDS,
                                           conds1, &stringVal1);
 
         time_value.set_time(2020, 2, 28, 0, 0, 3, 0);
         time_value.to_datetime_val(&timestamp);
         BooleanVal conds2[NUM_CONDS] = {false, false, true, false};
-        AggregateFunctions::window_funnel_update(context, window, timestamp, NUM_CONDS,
+        AggregateFunctions::window_funnel_update(context, window, mode, timestamp, NUM_CONDS,
                                           conds2, &stringVal1);
 
         time_value.set_time(2020, 2, 28, 0, 0, 4, 0);
         time_value.to_datetime_val(&timestamp);
         BooleanVal conds3[NUM_CONDS] = {false, false, false, true};
-        AggregateFunctions::window_funnel_update(context, window, timestamp, NUM_CONDS,
+        AggregateFunctions::window_funnel_update(context, window, mode, timestamp, NUM_CONDS,
                                           conds3, &stringVal1);
 
         StringVal s = AggregateFunctions::window_funnel_serialize(context, stringVal1);
@@ -129,6 +141,12 @@ TEST_F(WindowFunnelTest, testMax4ReverseSortedNoMerge) {
     for (int i = -1; i < NUM_CONDS + 4; i++) {
         StringVal stringVal1;
         BigIntVal window(i);
+        StringVal mode("default");
+        std::vector<doris_udf::AnyVal*> constant_args;
+        constant_args.emplace_back(&window);
+        constant_args.emplace_back(&mode);
+        context->impl()->set_constant_args(std::move(constant_args));
+
         AggregateFunctions::window_funnel_init(context, &stringVal1);
 
         DateTimeVal timestamp;
@@ -137,25 +155,25 @@ TEST_F(WindowFunnelTest, testMax4ReverseSortedNoMerge) {
         time_value.to_datetime_val(&timestamp);
 
         BooleanVal conds[NUM_CONDS] = {true, false, false, false};
-        AggregateFunctions::window_funnel_update(context, window, timestamp, NUM_CONDS,
+        AggregateFunctions::window_funnel_update(context, window, mode, timestamp, NUM_CONDS,
                                           conds, &stringVal1);
 
         time_value.set_time(2020, 2, 28, 0, 0, 2, 0);
         time_value.to_datetime_val(&timestamp);
         BooleanVal conds1[NUM_CONDS] = {false, true, false, false};
-        AggregateFunctions::window_funnel_update(context, window, timestamp, NUM_CONDS,
+        AggregateFunctions::window_funnel_update(context, window, mode, timestamp, NUM_CONDS,
                                           conds1, &stringVal1);
 
         time_value.set_time(2020, 2, 28, 0, 0, 1, 0);
         time_value.to_datetime_val(&timestamp);
         BooleanVal conds2[NUM_CONDS] = {false, false, true, false};
-        AggregateFunctions::window_funnel_update(context, window, timestamp, NUM_CONDS,
+        AggregateFunctions::window_funnel_update(context, window, mode, timestamp, NUM_CONDS,
                                           conds2, &stringVal1);
 
         time_value.set_time(2020, 2, 28, 0, 0, 0, 0);
         time_value.to_datetime_val(&timestamp);
         BooleanVal conds3[NUM_CONDS] = {false, false, false, true};
-        AggregateFunctions::window_funnel_update(context, window, timestamp, NUM_CONDS,
+        AggregateFunctions::window_funnel_update(context, window, mode, timestamp, NUM_CONDS,
                                           conds3, &stringVal1);
 
         IntVal v = AggregateFunctions::window_funnel_finalize(context, stringVal1);
@@ -173,6 +191,12 @@ TEST_F(WindowFunnelTest, testMax4ReverseSortedMerge) {
     for (int i = -1; i < NUM_CONDS + 4; i++) {
         StringVal stringVal1;
         BigIntVal window(i);
+        StringVal mode("default");
+        std::vector<doris_udf::AnyVal*> constant_args;
+        constant_args.emplace_back(&window);
+        constant_args.emplace_back(&mode);
+        context->impl()->set_constant_args(std::move(constant_args));
+
         AggregateFunctions::window_funnel_init(context, &stringVal1);
 
         DateTimeVal timestamp;
@@ -181,25 +205,25 @@ TEST_F(WindowFunnelTest, testMax4ReverseSortedMerge) {
         time_value.to_datetime_val(&timestamp);
 
         BooleanVal conds[NUM_CONDS] = {true, false, false, false};
-        AggregateFunctions::window_funnel_update(context, window, timestamp, NUM_CONDS,
+        AggregateFunctions::window_funnel_update(context, window, mode, timestamp, NUM_CONDS,
                                           conds, &stringVal1);
 
         time_value.set_time(2020, 2, 28, 0, 0, 2, 0);
         time_value.to_datetime_val(&timestamp);
         BooleanVal conds1[NUM_CONDS] = {false, true, false, false};
-        AggregateFunctions::window_funnel_update(context, window, timestamp, NUM_CONDS,
+        AggregateFunctions::window_funnel_update(context, window, mode, timestamp, NUM_CONDS,
                                           conds1, &stringVal1);
 
         time_value.set_time(2020, 2, 28, 0, 0, 1, 0);
         time_value.to_datetime_val(&timestamp);
         BooleanVal conds2[NUM_CONDS] = {false, false, true, false};
-        AggregateFunctions::window_funnel_update(context, window, timestamp, NUM_CONDS,
+        AggregateFunctions::window_funnel_update(context, window, mode, timestamp, NUM_CONDS,
                                           conds2, &stringVal1);
 
         time_value.set_time(2020, 2, 28, 0, 0, 0, 0);
         time_value.to_datetime_val(&timestamp);
         BooleanVal conds3[NUM_CONDS] = {false, false, false, true};
-        AggregateFunctions::window_funnel_update(context, window, timestamp, NUM_CONDS,
+        AggregateFunctions::window_funnel_update(context, window, mode, timestamp, NUM_CONDS,
                                           conds3, &stringVal1);
 
         StringVal s = AggregateFunctions::window_funnel_serialize(context, stringVal1);
@@ -222,6 +246,12 @@ TEST_F(WindowFunnelTest, testMax4DuplicateSortedNoMerge) {
     for (int i = -1; i < NUM_CONDS + 4; i++) {
         StringVal stringVal1;
         BigIntVal window(i);
+        StringVal mode("default");
+        std::vector<doris_udf::AnyVal*> constant_args;
+        constant_args.emplace_back(&window);
+        constant_args.emplace_back(&mode);
+        context->impl()->set_constant_args(std::move(constant_args));
+
         AggregateFunctions::window_funnel_init(context, &stringVal1);
 
         DateTimeVal timestamp;
@@ -230,25 +260,25 @@ TEST_F(WindowFunnelTest, testMax4DuplicateSortedNoMerge) {
         time_value.to_datetime_val(&timestamp);
 
         BooleanVal conds[NUM_CONDS] = {true, false, false, false};
-        AggregateFunctions::window_funnel_update(context, window, timestamp, NUM_CONDS,
+        AggregateFunctions::window_funnel_update(context, window, mode, timestamp, NUM_CONDS,
                                           conds, &stringVal1);
 
         time_value.set_time(2020, 2, 28, 0, 0, 1, 0);
         time_value.to_datetime_val(&timestamp);
         BooleanVal conds1[NUM_CONDS] = {false, true, false, false};
-        AggregateFunctions::window_funnel_update(context, window, timestamp, NUM_CONDS,
+        AggregateFunctions::window_funnel_update(context, window, mode, timestamp, NUM_CONDS,
                                           conds1, &stringVal1);
 
         time_value.set_time(2020, 2, 28, 0, 0, 2, 0);
         time_value.to_datetime_val(&timestamp);
         BooleanVal conds2[NUM_CONDS] = {true, false, false, false};
-        AggregateFunctions::window_funnel_update(context, window, timestamp, NUM_CONDS,
+        AggregateFunctions::window_funnel_update(context, window, mode, timestamp, NUM_CONDS,
                                           conds2, &stringVal1);
 
         time_value.set_time(2020, 2, 28, 0, 0, 3, 0);
         time_value.to_datetime_val(&timestamp);
         BooleanVal conds3[NUM_CONDS] = {false, false, false, false};
-        AggregateFunctions::window_funnel_update(context, window, timestamp, NUM_CONDS,
+        AggregateFunctions::window_funnel_update(context, window, mode, timestamp, NUM_CONDS,
                                           conds3, &stringVal1);
 
         IntVal v = AggregateFunctions::window_funnel_finalize(context, stringVal1);
@@ -266,6 +296,12 @@ TEST_F(WindowFunnelTest, testMax4DuplicateSortedMerge) {
     for (int i = -1; i < NUM_CONDS + 4; i++) {
         StringVal stringVal1;
         BigIntVal window(i);
+        StringVal mode("default");
+        std::vector<doris_udf::AnyVal*> constant_args;
+        constant_args.emplace_back(&window);
+        constant_args.emplace_back(&mode);
+        context->impl()->set_constant_args(std::move(constant_args));
+
         AggregateFunctions::window_funnel_init(context, &stringVal1);
 
         DateTimeVal timestamp;
@@ -274,25 +310,25 @@ TEST_F(WindowFunnelTest, testMax4DuplicateSortedMerge) {
         time_value.to_datetime_val(&timestamp);
 
         BooleanVal conds[NUM_CONDS] = {true, false, false, false};
-        AggregateFunctions::window_funnel_update(context, window, timestamp, NUM_CONDS,
+        AggregateFunctions::window_funnel_update(context, window, mode, timestamp, NUM_CONDS,
                                           conds, &stringVal1);
 
         time_value.set_time(2020, 2, 28, 0, 0, 1, 0);
         time_value.to_datetime_val(&timestamp);
         BooleanVal conds1[NUM_CONDS] = {false, true, false, false};
-        AggregateFunctions::window_funnel_update(context, window, timestamp, NUM_CONDS,
+        AggregateFunctions::window_funnel_update(context, window, mode, timestamp, NUM_CONDS,
                                           conds1, &stringVal1);
 
         time_value.set_time(2020, 2, 28, 0, 0, 2, 0);
         time_value.to_datetime_val(&timestamp);
         BooleanVal conds2[NUM_CONDS] = {true, false, false, false};
-        AggregateFunctions::window_funnel_update(context, window, timestamp, NUM_CONDS,
+        AggregateFunctions::window_funnel_update(context, window, mode, timestamp, NUM_CONDS,
                                           conds2, &stringVal1);
 
         time_value.set_time(2020, 2, 28, 0, 0, 3, 0);
         time_value.to_datetime_val(&timestamp);
         BooleanVal conds3[NUM_CONDS] = {false, false, false, false};
-        AggregateFunctions::window_funnel_update(context, window, timestamp, NUM_CONDS,
+        AggregateFunctions::window_funnel_update(context, window, mode, timestamp, NUM_CONDS,
                                           conds3, &stringVal1);
 
         StringVal s = AggregateFunctions::window_funnel_serialize(context, stringVal1);
@@ -313,6 +349,12 @@ TEST_F(WindowFunnelTest, testNoMatchedEvent) {
 
     StringVal stringVal1;
     BigIntVal window(0);
+    StringVal mode("default");
+    std::vector<doris_udf::AnyVal*> constant_args;
+    constant_args.emplace_back(&window);
+    constant_args.emplace_back(&mode);
+    context->impl()->set_constant_args(std::move(constant_args));
+
     AggregateFunctions::window_funnel_init(context, &stringVal1);
 
     DateTimeVal timestamp;
@@ -321,7 +363,7 @@ TEST_F(WindowFunnelTest, testNoMatchedEvent) {
     time_value.to_datetime_val(&timestamp);
 
     BooleanVal conds[4] = {false, false, false, false};
-    AggregateFunctions::window_funnel_update(context, window, timestamp, 4,
+    AggregateFunctions::window_funnel_update(context, window, mode, timestamp, 4,
                                       conds, &stringVal1);
 
     IntVal v = AggregateFunctions::window_funnel_finalize(context, stringVal1);
@@ -334,6 +376,13 @@ TEST_F(WindowFunnelTest, testNoEvent) {
     doris_udf::FunctionContext* context = futil->get_fn_ctx();
 
     StringVal stringVal1;
+    BigIntVal window(0);
+    StringVal mode("default");
+    std::vector<doris_udf::AnyVal*> constant_args;
+    constant_args.emplace_back(&window);
+    constant_args.emplace_back(&mode);
+    context->impl()->set_constant_args(std::move(constant_args));
+
     AggregateFunctions::window_funnel_init(context, &stringVal1);
 
     IntVal v = AggregateFunctions::window_funnel_finalize(context, stringVal1);
@@ -343,6 +392,32 @@ TEST_F(WindowFunnelTest, testNoEvent) {
     AggregateFunctions::window_funnel_init(context, &stringVal2);
 
     v = AggregateFunctions::window_funnel_finalize(context, stringVal2);
+    ASSERT_EQ(v.val, 0);
+
+    delete futil;
+}
+
+TEST_F(WindowFunnelTest, testInputNull) {
+    FunctionUtils* futil = new FunctionUtils();
+    doris_udf::FunctionContext* context = futil->get_fn_ctx();
+
+    BigIntVal window(0);
+    StringVal mode("default");
+    std::vector<doris_udf::AnyVal*> constant_args;
+    constant_args.emplace_back(&window);
+    constant_args.emplace_back(&mode);
+    context->impl()->set_constant_args(std::move(constant_args));
+
+    StringVal stringVal1;
+    AggregateFunctions::window_funnel_init(context, &stringVal1);
+
+    DateTimeVal timestamp = DateTimeVal::null();
+    BooleanVal conds[4] = {false, false, false, false};
+    AggregateFunctions::window_funnel_update(context, window, mode, timestamp, 4,
+                                      conds, &stringVal1);
+
+
+    IntVal v = AggregateFunctions::window_funnel_finalize(context, stringVal1);
     ASSERT_EQ(v.val, 0);
 
     delete futil;

--- a/be/test/vec/aggregate_functions/CMakeLists.txt
+++ b/be/test/vec/aggregate_functions/CMakeLists.txt
@@ -19,5 +19,6 @@
 set(EXECUTABLE_OUTPUT_PATH "${BUILD_DIR}/test/vec/aggregate_functions")
 
 ADD_BE_TEST(agg_test)
+ADD_BE_TEST(vec_window_funnel_test)
 
 

--- a/be/test/vec/aggregate_functions/vec_window_funnel_test.cpp
+++ b/be/test/vec/aggregate_functions/vec_window_funnel_test.cpp
@@ -1,0 +1,398 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <gtest/gtest.h>
+
+#include "common/logging.h"
+#include "gtest/gtest.h"
+#include "vec/aggregate_functions/aggregate_function.h"
+#include "vec/aggregate_functions/aggregate_function_simple_factory.h"
+#include "vec/aggregate_functions/aggregate_function_topn.h"
+#include "vec/columns/column_vector.h"
+#include "vec/data_types/data_type.h"
+#include "vec/data_types/data_type_number.h"
+#include "vec/data_types/data_type_string.h"
+
+namespace doris::vectorized {
+
+void register_aggregate_function_window_funnel(AggregateFunctionSimpleFactory& factory);
+
+class WindowFunnelTest : public testing::Test {
+public:
+    AggregateFunctionPtr agg_function;
+
+    WindowFunnelTest() {}
+
+    void SetUp() {
+        AggregateFunctionSimpleFactory factory = AggregateFunctionSimpleFactory::instance();
+        DataTypes data_types = {
+                std::make_shared<DataTypeInt64>(),
+                std::make_shared<DataTypeDateTime>(),
+                std::make_shared<DataTypeUInt8>(),
+                std::make_shared<DataTypeUInt8>(),
+                std::make_shared<DataTypeUInt8>(),
+                std::make_shared<DataTypeUInt8>(),
+                };
+        Array array;
+        agg_function = factory.get("window_funnel", data_types, array, false);
+        ASSERT_NE(agg_function, nullptr);
+    }
+
+    void TearDown() {
+    }
+};
+
+TEST_F(WindowFunnelTest, testEmpty) {
+    std::unique_ptr<char[]> memory(new char[agg_function->size_of_data()]);
+    AggregateDataPtr place = memory.get();
+    agg_function->create(place);
+
+    ColumnString buf;
+    VectorBufferWriter buf_writer(buf);
+    agg_function->serialize(place, buf_writer);
+    buf_writer.commit();
+    LOG(INFO) << "buf size : " << buf.size();
+    VectorBufferReader buf_reader(buf.get_data_at(0));
+    agg_function->deserialize(place, buf_reader, nullptr);
+
+    std::unique_ptr<char[]> memory2(new char[agg_function->size_of_data()]);
+    AggregateDataPtr place2 = memory2.get();
+    agg_function->create(place2);
+
+    agg_function->merge(place, place2, nullptr);
+    ColumnVector<Int32> column_result;
+    agg_function->insert_result_into(place, column_result);
+    ASSERT_EQ(column_result.get_data()[0], 0);
+
+    ColumnVector<Int32> column_result2;
+    agg_function->insert_result_into(place2, column_result2);
+    ASSERT_EQ(column_result2.get_data()[0], 0);
+
+    agg_function->destroy(place);
+    agg_function->destroy(place2);
+}
+
+TEST_F(WindowFunnelTest, testSerialize) {
+    const int NUM_CONDS = 4;
+    auto column_timestamp = ColumnVector<Int64>::create();
+    for (int i = 0; i < NUM_CONDS; i++) {
+        VecDateTimeValue time_value;
+        time_value.set_time(2022, 2, 28, 0, 0, i);
+        column_timestamp->insert_data((char *)&time_value, 0);
+    }
+    auto column_event1 = ColumnVector<UInt8>::create();
+    column_event1->insert(1);
+    column_event1->insert(0);
+    column_event1->insert(0);
+    column_event1->insert(0);
+
+    auto column_event2 = ColumnVector<UInt8>::create();
+    column_event2->insert(0);
+    column_event2->insert(1);
+    column_event2->insert(0);
+    column_event2->insert(0);
+
+    auto column_event3 = ColumnVector<UInt8>::create();
+    column_event3->insert(0);
+    column_event3->insert(0);
+    column_event3->insert(1);
+    column_event3->insert(0);
+
+    auto column_event4 = ColumnVector<UInt8>::create();
+    column_event4->insert(0);
+    column_event4->insert(0);
+    column_event4->insert(0);
+    column_event4->insert(1);
+
+    auto column_window = ColumnVector<Int64>::create();
+    for (int i = 0; i < NUM_CONDS; i++) {
+        column_window->insert(2);
+    }
+
+    std::unique_ptr<char[]> memory(new char[agg_function->size_of_data()]);
+    AggregateDataPtr place = memory.get();
+    agg_function->create(place);
+    const IColumn* column[6] = { column_window.get(), column_timestamp.get(),
+                                 column_event1.get(), column_event2.get(),
+                                 column_event3.get(), column_event4.get() };
+    for (int i = 0; i < NUM_CONDS; i++) {
+        agg_function->add(place, column, i, nullptr);
+    }
+
+    ColumnString buf;
+    VectorBufferWriter buf_writer(buf);
+    agg_function->serialize(place, buf_writer);
+    buf_writer.commit();
+
+    std::unique_ptr<char[]> memory2(new char[agg_function->size_of_data()]);
+    AggregateDataPtr place2 = memory2.get();
+    agg_function->create(place2);
+
+    VectorBufferReader buf_reader(buf.get_data_at(0));
+    agg_function->deserialize(place2, buf_reader, nullptr);
+
+    ColumnVector<Int32> column_result;
+    agg_function->insert_result_into(place, column_result);
+    ASSERT_EQ(column_result.get_data()[0], 3);
+    agg_function->destroy(place);
+
+    ColumnVector<Int32> column_result2;
+    agg_function->insert_result_into(place2, column_result2);
+    ASSERT_EQ(column_result2.get_data()[0], 3);
+    agg_function->destroy(place2);
+}
+
+
+TEST_F(WindowFunnelTest, testMax4SortedNoMerge) {
+    const int NUM_CONDS = 4;
+    auto column_timestamp = ColumnVector<Int64>::create();
+    for (int i = 0; i < NUM_CONDS; i++) {
+        VecDateTimeValue time_value;
+        time_value.set_time(2022, 2, 28, 0, 0, i);
+        column_timestamp->insert_data((char *)&time_value, 0);
+    }
+    auto column_event1 = ColumnVector<UInt8>::create();
+    column_event1->insert(1);
+    column_event1->insert(0);
+    column_event1->insert(0);
+    column_event1->insert(0);
+
+    auto column_event2 = ColumnVector<UInt8>::create();
+    column_event2->insert(0);
+    column_event2->insert(1);
+    column_event2->insert(0);
+    column_event2->insert(0);
+
+    auto column_event3 = ColumnVector<UInt8>::create();
+    column_event3->insert(0);
+    column_event3->insert(0);
+    column_event3->insert(1);
+    column_event3->insert(0);
+
+    auto column_event4 = ColumnVector<UInt8>::create();
+    column_event4->insert(0);
+    column_event4->insert(0);
+    column_event4->insert(0);
+    column_event4->insert(1);
+
+    for(int win = -1; win < NUM_CONDS + 1; win++) {
+        auto column_window = ColumnVector<Int64>::create();
+        for (int i = 0; i < NUM_CONDS; i++) {
+            column_window->insert(win);
+        }
+
+        std::unique_ptr<char[]> memory(new char[agg_function->size_of_data()]);
+        AggregateDataPtr place = memory.get();
+        agg_function->create(place);
+        const IColumn* column[6] = { column_window.get(), column_timestamp.get(),
+                                     column_event1.get(), column_event2.get(),
+                                     column_event3.get(), column_event4.get() };
+        for (int i = 0; i < NUM_CONDS; i++) {
+            agg_function->add(place, column, i, nullptr);
+        }
+
+        ColumnVector<Int32> column_result;
+        agg_function->insert_result_into(place, column_result);
+        ASSERT_EQ(column_result.get_data()[0], win < 0 ? 1 : (win < NUM_CONDS ? win + 1 : NUM_CONDS));
+        agg_function->destroy(place);
+    }
+}
+
+TEST_F(WindowFunnelTest, testMax4SortedMerge) {
+    const int NUM_CONDS = 4;
+    auto column_timestamp = ColumnVector<Int64>::create();
+    for (int i = 0; i < NUM_CONDS; i++) {
+        VecDateTimeValue time_value;
+        time_value.set_time(2022, 2, 28, 0, 0, i);
+        column_timestamp->insert_data((char *)&time_value, 0);
+    }
+    auto column_event1 = ColumnVector<UInt8>::create();
+    column_event1->insert(1);
+    column_event1->insert(0);
+    column_event1->insert(0);
+    column_event1->insert(0);
+
+    auto column_event2 = ColumnVector<UInt8>::create();
+    column_event2->insert(0);
+    column_event2->insert(1);
+    column_event2->insert(0);
+    column_event2->insert(0);
+
+    auto column_event3 = ColumnVector<UInt8>::create();
+    column_event3->insert(0);
+    column_event3->insert(0);
+    column_event3->insert(1);
+    column_event3->insert(0);
+
+    auto column_event4 = ColumnVector<UInt8>::create();
+    column_event4->insert(0);
+    column_event4->insert(0);
+    column_event4->insert(0);
+    column_event4->insert(1);
+
+    for(int win = -1; win < NUM_CONDS + 1; win++) {
+        auto column_window = ColumnVector<Int64>::create();
+        for (int i = 0; i < NUM_CONDS; i++) {
+            column_window->insert(win);
+        }
+
+        std::unique_ptr<char[]> memory(new char[agg_function->size_of_data()]);
+        AggregateDataPtr place = memory.get();
+        agg_function->create(place);
+        const IColumn* column[6] = { column_window.get(), column_timestamp.get(),
+                                     column_event1.get(), column_event2.get(),
+                                     column_event3.get(), column_event4.get() };
+        for (int i = 0; i < NUM_CONDS; i++) {
+            agg_function->add(place, column, i, nullptr);
+        }
+
+        std::unique_ptr<char[]> memory2(new char[agg_function->size_of_data()]);
+        AggregateDataPtr place2 = memory2.get();
+        agg_function->create(place2);
+
+        agg_function->merge(place2, place, nullptr);
+        ColumnVector<Int32> column_result;
+        agg_function->insert_result_into(place2, column_result);
+        ASSERT_EQ(column_result.get_data()[0], win < 0 ? 1 : (win < NUM_CONDS ? win + 1 : NUM_CONDS));
+        agg_function->destroy(place);
+        agg_function->destroy(place2);
+    }
+}
+
+TEST_F(WindowFunnelTest, testMax4ReverseSortedNoMerge) {
+    const int NUM_CONDS = 4;
+    auto column_timestamp = ColumnVector<Int64>::create();
+    for (int i = 0; i < NUM_CONDS; i++) {
+        VecDateTimeValue time_value;
+        time_value.set_time(2022, 2, 28, 0, 0, NUM_CONDS - i);
+        column_timestamp->insert_data((char *)&time_value, 0);
+    }
+    auto column_event1 = ColumnVector<UInt8>::create();
+    column_event1->insert(0);
+    column_event1->insert(0);
+    column_event1->insert(0);
+    column_event1->insert(1);
+
+    auto column_event2 = ColumnVector<UInt8>::create();
+    column_event2->insert(0);
+    column_event2->insert(0);
+    column_event2->insert(1);
+    column_event2->insert(0);
+
+    auto column_event3 = ColumnVector<UInt8>::create();
+    column_event3->insert(0);
+    column_event3->insert(1);
+    column_event3->insert(0);
+    column_event3->insert(0);
+
+    auto column_event4 = ColumnVector<UInt8>::create();
+    column_event4->insert(1);
+    column_event4->insert(0);
+    column_event4->insert(0);
+    column_event4->insert(0);
+
+    for(int win = -1; win < NUM_CONDS + 1; win++) {
+        auto column_window = ColumnVector<Int64>::create();
+        for (int i = 0; i < NUM_CONDS; i++) {
+            column_window->insert(win);
+        }
+
+        std::unique_ptr<char[]> memory(new char[agg_function->size_of_data()]);
+        AggregateDataPtr place = memory.get();
+        agg_function->create(place);
+        const IColumn* column[6] = { column_window.get(), column_timestamp.get(),
+                                     column_event1.get(), column_event2.get(),
+                                     column_event3.get(), column_event4.get() };
+        for (int i = 0; i < NUM_CONDS; i++) {
+            agg_function->add(place, column, i, nullptr);
+        }
+
+        LOG(INFO) << "win " << win;
+        ColumnVector<Int32> column_result;
+        agg_function->insert_result_into(place, column_result);
+        ASSERT_EQ(column_result.get_data()[0], win < 0 ? 1 : (win < NUM_CONDS ? win + 1 : NUM_CONDS));
+        agg_function->destroy(place);
+    }
+}
+
+TEST_F(WindowFunnelTest, testMax4ReverseSortedMerge) {
+    const int NUM_CONDS = 4;
+    auto column_timestamp = ColumnVector<Int64>::create();
+    for (int i = 0; i < NUM_CONDS; i++) {
+        VecDateTimeValue time_value;
+        time_value.set_time(2022, 2, 28, 0, 0, NUM_CONDS - i);
+        column_timestamp->insert_data((char *)&time_value, 0);
+    }
+    auto column_event1 = ColumnVector<UInt8>::create();
+    column_event1->insert(0);
+    column_event1->insert(0);
+    column_event1->insert(0);
+    column_event1->insert(1);
+
+    auto column_event2 = ColumnVector<UInt8>::create();
+    column_event2->insert(0);
+    column_event2->insert(0);
+    column_event2->insert(1);
+    column_event2->insert(0);
+
+    auto column_event3 = ColumnVector<UInt8>::create();
+    column_event3->insert(0);
+    column_event3->insert(1);
+    column_event3->insert(0);
+    column_event3->insert(0);
+
+    auto column_event4 = ColumnVector<UInt8>::create();
+    column_event4->insert(1);
+    column_event4->insert(0);
+    column_event4->insert(0);
+    column_event4->insert(0);
+
+    for(int win = -1; win < NUM_CONDS + 1; win++) {
+        auto column_window = ColumnVector<Int64>::create();
+        for (int i = 0; i < NUM_CONDS; i++) {
+            column_window->insert(win);
+        }
+
+        std::unique_ptr<char[]> memory(new char[agg_function->size_of_data()]);
+        AggregateDataPtr place = memory.get();
+        agg_function->create(place);
+        const IColumn* column[6] = { column_window.get(), column_timestamp.get(),
+                                     column_event1.get(), column_event2.get(),
+                                     column_event3.get(), column_event4.get() };
+        for (int i = 0; i < NUM_CONDS; i++) {
+            agg_function->add(place, column, i, nullptr);
+        }
+
+        std::unique_ptr<char[]> memory2(new char[agg_function->size_of_data()]);
+        AggregateDataPtr place2 = memory2.get();
+        agg_function->create(place2);
+
+        agg_function->merge(place2, place, NULL);
+        ColumnVector<Int32> column_result;
+        agg_function->insert_result_into(place2, column_result);
+        ASSERT_EQ(column_result.get_data()[0], win < 0 ? 1 : (win < NUM_CONDS ? win + 1 : NUM_CONDS));
+        agg_function->destroy(place);
+        agg_function->destroy(place2);
+    }
+}
+
+} // namespace doris::vectorized
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/be/test/vec/aggregate_functions/vec_window_funnel_test.cpp
+++ b/be/test/vec/aggregate_functions/vec_window_funnel_test.cpp
@@ -41,6 +41,7 @@ public:
         AggregateFunctionSimpleFactory factory = AggregateFunctionSimpleFactory::instance();
         DataTypes data_types = {
                 std::make_shared<DataTypeInt64>(),
+                std::make_shared<DataTypeString>(),
                 std::make_shared<DataTypeDateTime>(),
                 std::make_shared<DataTypeUInt8>(),
                 std::make_shared<DataTypeUInt8>(),
@@ -88,6 +89,11 @@ TEST_F(WindowFunnelTest, testEmpty) {
 
 TEST_F(WindowFunnelTest, testSerialize) {
     const int NUM_CONDS = 4;
+    auto column_mode = ColumnString::create();
+    for (int i = 0; i < NUM_CONDS; i++) {
+        column_mode->insert("mode");
+    }
+
     auto column_timestamp = ColumnVector<Int64>::create();
     for (int i = 0; i < NUM_CONDS; i++) {
         VecDateTimeValue time_value;
@@ -126,7 +132,8 @@ TEST_F(WindowFunnelTest, testSerialize) {
     std::unique_ptr<char[]> memory(new char[agg_function->size_of_data()]);
     AggregateDataPtr place = memory.get();
     agg_function->create(place);
-    const IColumn* column[6] = { column_window.get(), column_timestamp.get(),
+    const IColumn* column[7] = { column_window.get(), column_mode.get(),
+                                 column_timestamp.get(),
                                  column_event1.get(), column_event2.get(),
                                  column_event3.get(), column_event4.get() };
     for (int i = 0; i < NUM_CONDS; i++) {
@@ -159,6 +166,10 @@ TEST_F(WindowFunnelTest, testSerialize) {
 
 TEST_F(WindowFunnelTest, testMax4SortedNoMerge) {
     const int NUM_CONDS = 4;
+    auto column_mode = ColumnString::create();
+    for (int i = 0; i < NUM_CONDS; i++) {
+        column_mode->insert("mode");
+    }
     auto column_timestamp = ColumnVector<Int64>::create();
     for (int i = 0; i < NUM_CONDS; i++) {
         VecDateTimeValue time_value;
@@ -198,7 +209,8 @@ TEST_F(WindowFunnelTest, testMax4SortedNoMerge) {
         std::unique_ptr<char[]> memory(new char[agg_function->size_of_data()]);
         AggregateDataPtr place = memory.get();
         agg_function->create(place);
-        const IColumn* column[6] = { column_window.get(), column_timestamp.get(),
+        const IColumn* column[7] = { column_window.get(), column_mode.get(),
+                                     column_timestamp.get(),
                                      column_event1.get(), column_event2.get(),
                                      column_event3.get(), column_event4.get() };
         for (int i = 0; i < NUM_CONDS; i++) {
@@ -214,6 +226,10 @@ TEST_F(WindowFunnelTest, testMax4SortedNoMerge) {
 
 TEST_F(WindowFunnelTest, testMax4SortedMerge) {
     const int NUM_CONDS = 4;
+    auto column_mode = ColumnString::create();
+    for (int i = 0; i < NUM_CONDS; i++) {
+        column_mode->insert("mode");
+    }
     auto column_timestamp = ColumnVector<Int64>::create();
     for (int i = 0; i < NUM_CONDS; i++) {
         VecDateTimeValue time_value;
@@ -253,7 +269,8 @@ TEST_F(WindowFunnelTest, testMax4SortedMerge) {
         std::unique_ptr<char[]> memory(new char[agg_function->size_of_data()]);
         AggregateDataPtr place = memory.get();
         agg_function->create(place);
-        const IColumn* column[6] = { column_window.get(), column_timestamp.get(),
+        const IColumn* column[7] = { column_window.get(), column_mode.get(),
+                                     column_timestamp.get(),
                                      column_event1.get(), column_event2.get(),
                                      column_event3.get(), column_event4.get() };
         for (int i = 0; i < NUM_CONDS; i++) {
@@ -275,6 +292,10 @@ TEST_F(WindowFunnelTest, testMax4SortedMerge) {
 
 TEST_F(WindowFunnelTest, testMax4ReverseSortedNoMerge) {
     const int NUM_CONDS = 4;
+    auto column_mode = ColumnString::create();
+    for (int i = 0; i < NUM_CONDS; i++) {
+        column_mode->insert("mode");
+    }
     auto column_timestamp = ColumnVector<Int64>::create();
     for (int i = 0; i < NUM_CONDS; i++) {
         VecDateTimeValue time_value;
@@ -314,7 +335,8 @@ TEST_F(WindowFunnelTest, testMax4ReverseSortedNoMerge) {
         std::unique_ptr<char[]> memory(new char[agg_function->size_of_data()]);
         AggregateDataPtr place = memory.get();
         agg_function->create(place);
-        const IColumn* column[6] = { column_window.get(), column_timestamp.get(),
+        const IColumn* column[7] = { column_window.get(), column_mode.get(),
+                                     column_timestamp.get(),
                                      column_event1.get(), column_event2.get(),
                                      column_event3.get(), column_event4.get() };
         for (int i = 0; i < NUM_CONDS; i++) {
@@ -331,6 +353,10 @@ TEST_F(WindowFunnelTest, testMax4ReverseSortedNoMerge) {
 
 TEST_F(WindowFunnelTest, testMax4ReverseSortedMerge) {
     const int NUM_CONDS = 4;
+    auto column_mode = ColumnString::create();
+    for (int i = 0; i < NUM_CONDS; i++) {
+        column_mode->insert("mode");
+    }
     auto column_timestamp = ColumnVector<Int64>::create();
     for (int i = 0; i < NUM_CONDS; i++) {
         VecDateTimeValue time_value;
@@ -370,7 +396,8 @@ TEST_F(WindowFunnelTest, testMax4ReverseSortedMerge) {
         std::unique_ptr<char[]> memory(new char[agg_function->size_of_data()]);
         AggregateDataPtr place = memory.get();
         agg_function->create(place);
-        const IColumn* column[6] = { column_window.get(), column_timestamp.get(),
+        const IColumn* column[7] = { column_window.get(), column_mode.get(),
+                                     column_timestamp.get(),
                                      column_event1.get(), column_event2.get(),
                                      column_event3.get(), column_event4.get() };
         for (int i = 0; i < NUM_CONDS; i++) {

--- a/fe/fe-core/src/main/cup/sql_parser.cup
+++ b/fe/fe-core/src/main/cup/sql_parser.cup
@@ -4750,10 +4750,6 @@ function_call_expr ::=
       RESULT = new FunctionCallExpr(fn_name, params);
     }
   :}
-  | function_name:fn_name LPAREN function_params:left_params RPAREN LPAREN function_params:params RPAREN
-  {:
-    RESULT = new FunctionCallExpr(fn_name, params, left_params);
-  :}
   ;
 
 array_expr ::=

--- a/fe/fe-core/src/main/cup/sql_parser.cup
+++ b/fe/fe-core/src/main/cup/sql_parser.cup
@@ -4750,6 +4750,10 @@ function_call_expr ::=
       RESULT = new FunctionCallExpr(fn_name, params);
     }
   :}
+  | function_name:fn_name LPAREN function_params:left_params RPAREN LPAREN function_params:params RPAREN
+  {:
+    RESULT = new FunctionCallExpr(fn_name, params, left_params);
+  :}
   ;
 
 array_expr ::=

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/Analyzer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/Analyzer.java
@@ -731,7 +731,6 @@ public class Analyzer {
             result.setMultiRef(true);
             return result;
         }
-
         result = addSlotDescriptor(tupleDescriptor);
         Column col = new Column(colName, type);
         result.setColumn(col);

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/FunctionCallExpr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/FunctionCallExpr.java
@@ -54,7 +54,6 @@ import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 import java.text.StringCharacterIterator;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -66,7 +65,6 @@ public class FunctionCallExpr extends Expr {
     private FunctionName fnName;
     // private BuiltinAggregateFunction.Operator aggOp;
     private FunctionParams fnParams;
-    private FunctionParams leftFnParams;
 
     // check analytic function
     private boolean isAnalyticFnCall = false;
@@ -128,31 +126,19 @@ public class FunctionCallExpr extends Expr {
     }
 
     public FunctionCallExpr(String fnName, FunctionParams params) {
-        this(new FunctionName(fnName), params);
+        this(new FunctionName(fnName), params, false);
     }
 
     public FunctionCallExpr(FunctionName fnName, FunctionParams params) {
-        this(fnName, params, new FunctionParams(new ArrayList<Expr>()), false);
-    }
-
-    public FunctionCallExpr(FunctionName fnName, FunctionParams params, FunctionParams leftParams) {
-        this(fnName, params, leftParams, false);
-    }
-
-    private FunctionCallExpr(FunctionName fnName, FunctionParams params, boolean isMergeAggFn) {
-         this(fnName, params, new FunctionParams(new ArrayList<Expr>()), isMergeAggFn);
+        this(fnName, params, false);
     }
 
     private FunctionCallExpr(
-            FunctionName fnName, FunctionParams params, FunctionParams leftParams, boolean isMergeAggFn) {
+            FunctionName fnName, FunctionParams params, boolean isMergeAggFn) {
         super();
         this.fnName = fnName;
         fnParams = params;
-        leftFnParams = leftParams;
         this.isMergeAggFn = isMergeAggFn;
-        if (leftParams.exprs() != null) {
-            children.addAll(leftParams.exprs());
-        }
         if (params.exprs() != null) {
             children.addAll(params.exprs());
         }
@@ -160,20 +146,16 @@ public class FunctionCallExpr extends Expr {
     }
 
     // Constructs the same agg function with new params.
-    public FunctionCallExpr(FunctionCallExpr e, FunctionParams params, FunctionParams leftParams) {
+    public FunctionCallExpr(FunctionCallExpr e, FunctionParams params) {
         Preconditions.checkState(e.isAnalyzed);
         Preconditions.checkState(e.isAggregateFunction() || e.isAnalyticFnCall);
         fnName = e.fnName;
         // aggOp = e.aggOp;
         isAnalyticFnCall = e.isAnalyticFnCall;
         fnParams = params;
-        leftParams = leftParams;
         // Just inherit the function object from 'e'.
         fn = e.fn;
         this.isMergeAggFn = e.isMergeAggFn;
-        if (leftParams.exprs() != null) {
-            children.addAll(leftParams.exprs());
-        }
         if (params.exprs() != null) {
             children.addAll(params.exprs());
         }
@@ -187,20 +169,11 @@ public class FunctionCallExpr extends Expr {
         // fnParams = other.fnParams;
         // Clone the params in a way that keeps the children_ and the params.exprs()
         // in sync. The children have already been cloned in the super c'tor.
-        if (other.leftFnParams.isStar()) {
-            leftFnParams = FunctionParams.createStarParam();
-        } else {
-            leftFnParams = new FunctionParams(other.leftFnParams.isDistinct(),
-                               other.leftFnParams.exprs() == null || children == null ? null :
-                               children.subList(0, other.leftFnParams.exprs().size()));
-        }
         if (other.fnParams.isStar()) {
             Preconditions.checkState(children.isEmpty());
             fnParams = FunctionParams.createStarParam();
         } else {
-            fnParams = new FunctionParams(other.fnParams.isDistinct(),
-                              children == null || leftFnParams.exprs() == null ? children :
-                              children.subList(leftFnParams.exprs().size(), children.size()));
+            fnParams = new FunctionParams(other.fnParams.isDistinct(), children);
         }
         this.isMergeAggFn = other.isMergeAggFn;
         fn = other.fn;
@@ -261,9 +234,7 @@ public class FunctionCallExpr extends Expr {
         FunctionCallExpr o = (FunctionCallExpr) obj;
         return /*opcode == o.opcode && aggOp == o.aggOp &&*/ fnName.equals(o.fnName)
                 && fnParams.isDistinct() == o.fnParams.isDistinct()
-                && fnParams.isStar() == o.fnParams.isStar()
-                && leftFnParams.isDistinct() == o.leftFnParams.isDistinct()
-                && leftFnParams.isStar() == o.leftFnParams.isStar();
+                && fnParams.isStar() == o.fnParams.isStar();
     }
 
     private String paramsToSql(FunctionParams params) {
@@ -312,9 +283,6 @@ public class FunctionCallExpr extends Expr {
         }
         StringBuilder sb = new StringBuilder();
         sb.append(((FunctionCallExpr) expr).fnName);
-        if (leftFnParams.exprs() != null && leftFnParams.exprs().size() > 0) {
-            sb.append(paramsToSql(leftFnParams));
-        }
         sb.append(paramsToSql(fnParams));
         if (fnName.getFunction().equalsIgnoreCase("json_quote") ||
             fnName.getFunction().equalsIgnoreCase("json_array") ||
@@ -808,28 +776,29 @@ public class FunctionCallExpr extends Expr {
             fn = getBuiltinFunction(analyzer, fnName.getFunction(), new Type[]{compatibleType},
                     Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
         } else if (fnName.getFunction().equalsIgnoreCase("window_funnel")) {
-            if (leftFnParams.exprs() == null || leftFnParams.exprs().size() != 1) {
-                throw new AnalysisException("The " + fnName + " function must have left params, like window_funnel()()");
-            }
-
-            if (fnParams.exprs() == null || fnParams.exprs().size() < 2) {
-                throw new AnalysisException("The " + fnName + " function must have at lest one param");
+            if (fnParams.exprs() == null || fnParams.exprs().size() < 4) {
+                throw new AnalysisException("The " + fnName + " function must have at least four params");
             }
 
             if (!children.get(0).type.isIntegerType()) {
-                throw new AnalysisException("The left params of " + fnName + " function must be integer");
+                throw new AnalysisException("The window params of " + fnName + " function must be integer");
+            }
+            if (!children.get(1).type.isStringType()) {
+                throw new AnalysisException("The mode params of " + fnName + " function must be integer");
+            }
+            if (!children.get(2).type.isDateType()) {
+                throw new AnalysisException("The 3rd param of " + fnName + " function must be DATE or DATETIME");
             }
 
-            Type[] childTypes = new Type[children.size() - 1];
-            if (!children.get(1).type.isDateType()) {
-                throw new AnalysisException("The 1st param of " + fnName + " function must be DATE or DATETIME");
+            Type[] childTypes = new Type[children.size()];
+            for (int i = 0; i < 3; i++) {
+                childTypes[i] = children.get(i).type;
             }
-            childTypes[0] = children.get(0).type;
-            for (int i = 2; i < children.size(); i++) {
+            for (int i = 3; i < children.size(); i++) {
                 if (children.get(i).type != Type.BOOLEAN) {
-                    throw new AnalysisException("The params of " + fnName + " function must be boolean");
+                    throw new AnalysisException("The 4th and subsequent params of " + fnName + " function must be boolean");
                 }
-                childTypes[i - 1] = children.get(i).type;
+                childTypes[i] = children.get(i).type;
             }
 
             fn = getBuiltinFunction(analyzer, fnName.getFunction(), childTypes,

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/FunctionCallExpr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/FunctionCallExpr.java
@@ -54,6 +54,7 @@ import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 import java.text.StringCharacterIterator;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -65,6 +66,7 @@ public class FunctionCallExpr extends Expr {
     private FunctionName fnName;
     // private BuiltinAggregateFunction.Operator aggOp;
     private FunctionParams fnParams;
+    private FunctionParams leftFnParams;
 
     // check analytic function
     private boolean isAnalyticFnCall = false;
@@ -130,32 +132,48 @@ public class FunctionCallExpr extends Expr {
     }
 
     public FunctionCallExpr(FunctionName fnName, FunctionParams params) {
-        this(fnName, params, false);
+        this(fnName, params, new FunctionParams(new ArrayList<Expr>()), false);
+    }
+
+    public FunctionCallExpr(FunctionName fnName, FunctionParams params, FunctionParams leftParams) {
+        this(fnName, params, leftParams, false);
+    }
+
+    private FunctionCallExpr(FunctionName fnName, FunctionParams params, boolean isMergeAggFn) {
+         this(fnName, params, new FunctionParams(new ArrayList<Expr>()), isMergeAggFn);
     }
 
     private FunctionCallExpr(
-            FunctionName fnName, FunctionParams params, boolean isMergeAggFn) {
+            FunctionName fnName, FunctionParams params, FunctionParams leftParams, boolean isMergeAggFn) {
         super();
         this.fnName = fnName;
         fnParams = params;
+        leftFnParams = leftParams;
         this.isMergeAggFn = isMergeAggFn;
+        if (leftParams.exprs() != null) {
+            children.addAll(leftParams.exprs());
+        }
         if (params.exprs() != null) {
             children.addAll(params.exprs());
-            originChildSize = children.size();
         }
+        originChildSize = children.size();
     }
 
     // Constructs the same agg function with new params.
-    public FunctionCallExpr(FunctionCallExpr e, FunctionParams params) {
+    public FunctionCallExpr(FunctionCallExpr e, FunctionParams params, FunctionParams leftParams) {
         Preconditions.checkState(e.isAnalyzed);
         Preconditions.checkState(e.isAggregateFunction() || e.isAnalyticFnCall);
         fnName = e.fnName;
         // aggOp = e.aggOp;
         isAnalyticFnCall = e.isAnalyticFnCall;
         fnParams = params;
+        leftParams = leftParams;
         // Just inherit the function object from 'e'.
         fn = e.fn;
         this.isMergeAggFn = e.isMergeAggFn;
+        if (leftParams.exprs() != null) {
+            children.addAll(leftParams.exprs());
+        }
         if (params.exprs() != null) {
             children.addAll(params.exprs());
         }
@@ -169,11 +187,20 @@ public class FunctionCallExpr extends Expr {
         // fnParams = other.fnParams;
         // Clone the params in a way that keeps the children_ and the params.exprs()
         // in sync. The children have already been cloned in the super c'tor.
+        if (other.leftFnParams.isStar()) {
+            leftFnParams = FunctionParams.createStarParam();
+        } else {
+            leftFnParams = new FunctionParams(other.leftFnParams.isDistinct(),
+                               other.leftFnParams.exprs() == null || children == null ? null :
+                               children.subList(0, other.leftFnParams.exprs().size()));
+        }
         if (other.fnParams.isStar()) {
             Preconditions.checkState(children.isEmpty());
             fnParams = FunctionParams.createStarParam();
         } else {
-            fnParams = new FunctionParams(other.fnParams.isDistinct(), children);
+            fnParams = new FunctionParams(other.fnParams.isDistinct(),
+                              children == null || leftFnParams.exprs() == null ? children :
+                              children.subList(leftFnParams.exprs().size(), children.size()));
         }
         this.isMergeAggFn = other.isMergeAggFn;
         fn = other.fn;
@@ -234,32 +261,26 @@ public class FunctionCallExpr extends Expr {
         FunctionCallExpr o = (FunctionCallExpr) obj;
         return /*opcode == o.opcode && aggOp == o.aggOp &&*/ fnName.equals(o.fnName)
                 && fnParams.isDistinct() == o.fnParams.isDistinct()
-                && fnParams.isStar() == o.fnParams.isStar();
+                && fnParams.isStar() == o.fnParams.isStar()
+                && leftFnParams.isDistinct() == o.leftFnParams.isDistinct()
+                && leftFnParams.isStar() == o.leftFnParams.isStar();
     }
 
-    @Override
-    public String toSqlImpl() {
-        Expr expr;
-        if (originStmtFnExpr != null) {
-            expr = originStmtFnExpr;
-        } else {
-            expr = this;
-        }
+    private String paramsToSql(FunctionParams params) {
         StringBuilder sb = new StringBuilder();
-        sb.append(((FunctionCallExpr) expr).fnName).append("(");
-        if (((FunctionCallExpr) expr).fnParams.isStar()) {
+        sb.append("(");
+
+        if (params.isStar()) {
             sb.append("*");
         }
-        if (((FunctionCallExpr) expr).fnParams.isDistinct()) {
+        if (params.isDistinct()) {
             sb.append("DISTINCT ");
         }
-        boolean isJsonFunction = false;
-        int len = children.size();
+        int len = params.exprs().size();
         List<String> result = Lists.newArrayList();
         if (fnName.getFunction().equalsIgnoreCase("json_array") ||
                 fnName.getFunction().equalsIgnoreCase("json_object")) {
             len = len - 1;
-            isJsonFunction = true;
         }
         if (fnName.getFunction().equalsIgnoreCase("aes_decrypt") ||
                 fnName.getFunction().equalsIgnoreCase("aes_encrypt") ||
@@ -274,11 +295,30 @@ public class FunctionCallExpr extends Expr {
                     fnName.getFunction().equalsIgnoreCase("sm4_encrypt"))) {
                 result.add("\'***\'");
             } else {
-                result.add(children.get(i).toSql());
+                result.add(params.exprs().get(i).toSql());
             }
         }
         sb.append(Joiner.on(", ").join(result)).append(")");
-        if (fnName.getFunction().equalsIgnoreCase("json_quote") || isJsonFunction) {
+        return sb.toString();
+    }
+
+    @Override
+    public String toSqlImpl() {
+        Expr expr;
+        if (originStmtFnExpr != null) {
+            expr = originStmtFnExpr;
+        } else {
+            expr = this;
+        }
+        StringBuilder sb = new StringBuilder();
+        sb.append(((FunctionCallExpr) expr).fnName);
+        if (leftFnParams.exprs() != null && leftFnParams.exprs().size() > 0) {
+            sb.append(paramsToSql(leftFnParams));
+        }
+        sb.append(paramsToSql(fnParams));
+        if (fnName.getFunction().equalsIgnoreCase("json_quote") ||
+            fnName.getFunction().equalsIgnoreCase("json_array") ||
+            fnName.getFunction().equalsIgnoreCase("json_object")) {
             return forJSON(sb.toString());
         }
         return sb.toString();
@@ -703,6 +743,7 @@ public class FunctionCallExpr extends Expr {
 
     @Override
     public void analyzeImpl(Analyzer analyzer) throws AnalysisException {
+
         if (isMergeAggFn) {
             // This is the function call expr after splitting up to a merge aggregation.
             // The function has already been analyzed so just do the minimal sanity
@@ -765,6 +806,33 @@ public class FunctionCallExpr extends Expr {
             }
 
             fn = getBuiltinFunction(analyzer, fnName.getFunction(), new Type[]{compatibleType},
+                    Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
+        } else if (fnName.getFunction().equalsIgnoreCase("window_funnel")) {
+            if (leftFnParams.exprs() == null || leftFnParams.exprs().size() != 1) {
+                throw new AnalysisException("The " + fnName + " function must have left params, like window_funnel()()");
+            }
+
+            if (fnParams.exprs() == null || fnParams.exprs().size() < 2) {
+                throw new AnalysisException("The " + fnName + " function must have at lest one param");
+            }
+
+            if (!children.get(0).type.isIntegerType()) {
+                throw new AnalysisException("The left params of " + fnName + " function must be integer");
+            }
+
+            Type[] childTypes = new Type[children.size() - 1];
+            if (!children.get(1).type.isDateType()) {
+                throw new AnalysisException("The 1st param of " + fnName + " function must be DATE or DATETIME");
+            }
+            childTypes[0] = children.get(0).type;
+            for (int i = 2; i < children.size(); i++) {
+                if (children.get(i).type != Type.BOOLEAN) {
+                    throw new AnalysisException("The params of " + fnName + " function must be boolean");
+                }
+                childTypes[i - 1] = children.get(i).type;
+            }
+
+            fn = getBuiltinFunction(analyzer, fnName.getFunction(), childTypes,
                     Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
         } else {
             // now first find table function in table function sets

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/AggregateFunction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/AggregateFunction.java
@@ -49,7 +49,7 @@ public class AggregateFunction extends Function {
     private static final Logger LOG = LogManager.getLogger(AggregateFunction.class);
 
     public static ImmutableSet<String> NOT_NULLABLE_AGGREGATE_FUNCTION_NAME_SET =
-            ImmutableSet.of("row_number", "rank", "dense_rank", "hll_union_agg", "hll_union", "bitmap_union", "bitmap_intersect", FunctionSet.COUNT, "ndv", FunctionSet.BITMAP_UNION_INT, FunctionSet.BITMAP_UNION_COUNT, "ndv_no_finalize");
+            ImmutableSet.of("row_number", "rank", "dense_rank", "hll_union_agg", "hll_union", "bitmap_union", "bitmap_intersect", FunctionSet.COUNT, "ndv", FunctionSet.BITMAP_UNION_INT, FunctionSet.BITMAP_UNION_COUNT, "ndv_no_finalize", "window_funnel");
 
     // Set if different from retType_, null otherwise.
     private Type intermediateType;

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Function.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Function.java
@@ -103,8 +103,6 @@ public class Function implements Writable {
     private Type retType;
     // Array of parameter types.  empty array if this function does not have parameters.
     private Type[] argTypes;
-    // Only used by window_funnel()()
-    private Type[] leftParamsTypes;
     // If true, this function has variable arguments.
     // TODO: we don't currently support varargs with no fixed types. i.e. fn(...)
     private boolean hasVarArgs;

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Function.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Function.java
@@ -103,6 +103,8 @@ public class Function implements Writable {
     private Type retType;
     // Array of parameter types.  empty array if this function does not have parameters.
     private Type[] argTypes;
+    // Only used by window_funnel()()
+    private Type[] leftParamsTypes;
     // If true, this function has variable arguments.
     // TODO: we don't currently support varargs with no fixed types. i.e. fn(...)
     private boolean hasVarArgs;

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/FunctionSet.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/FunctionSet.java
@@ -1242,6 +1242,35 @@ public class FunctionSet<min_initIN9doris_udf12DecimalV2ValEEEvPNS2_15FunctionCo
                 prefix + "17count_star_removeEPN9doris_udf15FunctionContextEPNS1_9BigIntValE",
                 null, false, true, true, true));
 
+        // windowFunnel
+        addBuiltin(AggregateFunction.createBuiltin("window_funnel",
+                Lists.newArrayList(Type.BIGINT, Type.DATETIME, Type.BOOLEAN),
+                Type.INT,
+                Type.VARCHAR,
+                true,
+                prefix + "18window_funnel_initEPN9doris_udf15FunctionContextEPNS1_9StringValE",
+                prefix + "20window_funnel_updateEPN9doris_udf15FunctionContextERKNS1_9BigIntValERKNS1_11DateTimeValEiPKNS1_10BooleanValEPNS1_9StringValE",
+                prefix + "19window_funnel_mergeEPN9doris_udf15FunctionContextERKNS1_9StringValEPS4_",
+                prefix + "23window_funnel_serializeEPN9doris_udf15FunctionContextERKNS1_9StringValE",
+                "",
+                "",
+                prefix + "22window_funnel_finalizeEPN9doris_udf15FunctionContextERKNS1_9StringValE",
+                true, false, true));
+
+        addBuiltin(AggregateFunction.createBuiltin("window_funnel",
+                Lists.newArrayList(Type.BIGINT, Type.DATETIME, Type.BOOLEAN),
+                Type.INT,
+                Type.VARCHAR,
+                true,
+                prefix + "18window_funnel_initEPN9doris_udf15FunctionContextEPNS1_9StringValE",
+                prefix + "20window_funnel_updateEPN9doris_udf15FunctionContextERKNS1_9BigIntValERKNS1_11DateTimeValEiPKNS1_10BooleanValEPNS1_9StringValE",
+                prefix + "19window_funnel_mergeEPN9doris_udf15FunctionContextERKNS1_9StringValEPS4_",
+                prefix + "23window_funnel_serializeEPN9doris_udf15FunctionContextERKNS1_9StringValE",
+                "",
+                "",
+                prefix + "22window_funnel_finalizeEPN9doris_udf15FunctionContextERKNS1_9StringValE",
+                true, false, true, true));
+
         for (Type t : Type.getSupportedTypes()) {
             if (t.isNull()) {
                 continue; // NULL is handled through type promotion.

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/FunctionSet.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/FunctionSet.java
@@ -1244,12 +1244,12 @@ public class FunctionSet<min_initIN9doris_udf12DecimalV2ValEEEvPNS2_15FunctionCo
 
         // windowFunnel
         addBuiltin(AggregateFunction.createBuiltin("window_funnel",
-                Lists.newArrayList(Type.BIGINT, Type.DATETIME, Type.BOOLEAN),
+                Lists.newArrayList(Type.BIGINT, Type.STRING, Type.DATETIME, Type.BOOLEAN),
                 Type.INT,
                 Type.VARCHAR,
                 true,
                 prefix + "18window_funnel_initEPN9doris_udf15FunctionContextEPNS1_9StringValE",
-                prefix + "20window_funnel_updateEPN9doris_udf15FunctionContextERKNS1_9BigIntValERKNS1_11DateTimeValEiPKNS1_10BooleanValEPNS1_9StringValE",
+                prefix + "20window_funnel_updateEPN9doris_udf15FunctionContextERKNS1_9BigIntValERKNS1_9StringValERKNS1_11DateTimeValEiPKNS1_10BooleanValEPS7_",
                 prefix + "19window_funnel_mergeEPN9doris_udf15FunctionContextERKNS1_9StringValEPS4_",
                 prefix + "23window_funnel_serializeEPN9doris_udf15FunctionContextERKNS1_9StringValE",
                 "",
@@ -1257,18 +1257,19 @@ public class FunctionSet<min_initIN9doris_udf12DecimalV2ValEEEvPNS2_15FunctionCo
                 prefix + "22window_funnel_finalizeEPN9doris_udf15FunctionContextERKNS1_9StringValE",
                 true, false, true));
 
+        // Vectorization does not need symbol any more, we should clean it in the future.
         addBuiltin(AggregateFunction.createBuiltin("window_funnel",
-                Lists.newArrayList(Type.BIGINT, Type.DATETIME, Type.BOOLEAN),
+                Lists.newArrayList(Type.BIGINT, Type.STRING, Type.DATETIME, Type.BOOLEAN),
                 Type.INT,
                 Type.VARCHAR,
                 true,
-                prefix + "18window_funnel_initEPN9doris_udf15FunctionContextEPNS1_9StringValE",
-                prefix + "20window_funnel_updateEPN9doris_udf15FunctionContextERKNS1_9BigIntValERKNS1_11DateTimeValEiPKNS1_10BooleanValEPNS1_9StringValE",
-                prefix + "19window_funnel_mergeEPN9doris_udf15FunctionContextERKNS1_9StringValEPS4_",
-                prefix + "23window_funnel_serializeEPN9doris_udf15FunctionContextERKNS1_9StringValE",
                 "",
                 "",
-                prefix + "22window_funnel_finalizeEPN9doris_udf15FunctionContextERKNS1_9StringValE",
+                "",
+                "",
+                "",
+                "",
+                "",
                 true, false, true, true));
 
         for (Type t : Type.getSupportedTypes()) {


### PR DESCRIPTION
# Proposed changes

Implement window_funnel aggregate function.

Issue Number: close #xxx

## Problem Summary:

The function searches for event chains in a sliding time window and calculates the maximum number of events that occurred in the chain from the beginning. An event is defined by an integer number while an event chain is defined by a series of events. 

The function can be used like window_funnel(window, mode, timestamp, event1, event2, ..., eventN).

-  window is the length of sliding window in seconds
-  mode is reserved and not used currently 
-  timestamp is a column name of DATE or DATETIME,
-  eventN is in the form of 'event column = event id', event column must be Int.

For example, we create a table using below statement.

CREATE TABLE windowfunnel(event_datetime DATETIME, user_id int, event_id int, action string)
ENGINE=OLAP UNIQUE KEY(event_data, user_id) 
DISTRIBUTED BY HASH(user_id) BUCKETS 8
PROPERTIES (
    "replication_num" = "1",
    "storage_format" = "V2"
)

Then we insert below values

('2020-01-01 08:00:00', 1, 9001, 'browse')
('2020-01-02 07:00:00', 1, 9013, 'buy')
('2020-01-03 08:00:00', 2, 9001, 'browse')
('2020-01-02 07:30:00', 1, 9020, 'pay')

We can use below sql to find users who browse, buy and pay.

select user_id, window_funnel(48*3600, event_datetime, 'mode', event_id = 9001, event_id = 9013, event_id = 9020)

The SQL would return 
1, 3
2, 1

## Checklist(Required)

1. Does it affect the original behavior: (No)
2. Has unit tests been added: (Yes)
3. Has document been added or modified: (No)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (No)

## Further comments

Document will be added later.

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
