### PR TITLE
[improvement] support build with parallel parameter only

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -120,6 +120,8 @@ BUILD_UI=
 BUILD_SPARK_DPP=
 CLEAN=
 HELP=0
+PARAMETER_COUNT=$#
+PARAMETER_FLAG=0
 if [ $# == 1 ] ; then
     # default
     BUILD_BE=1
@@ -145,11 +147,20 @@ else
             --clean) CLEAN=1 ; shift ;;
             -h) HELP=1; shift ;;
             --help) HELP=1; shift ;;
-            -j) PARALLEL=$2; shift 2 ;;
+            -j) PARALLEL=$2; PARAMETER_FLAG=1; shift 2 ;;
             --) shift ;  break ;;
             *) echo "Internal error" ; exit 1 ;;
         esac
     done
+    #only ./build.sh -j xx then build all 
+    if [[ ${PARAMETER_COUNT} -eq 3 ]] && [[ ${PARAMETER_FLAG} -eq 1 ]];then
+        BUILD_BE=1
+        BUILD_FE=1
+        BUILD_BROKER=1
+        BUILD_UI=1
+        BUILD_SPARK_DPP=1
+        CLEAN=0
+    fi
 fi
 
 if [[ ${HELP} -eq 1 ]]; then

--- a/docs/en/installing/install-deploy.md
+++ b/docs/en/installing/install-deploy.md
@@ -152,7 +152,7 @@ At this point, DROP must remove the BE that added errors and re-use the correct 
 
 FE is the same.
 
-BROKER does not currently have, nor does it need, priority_networks. Broker's services are bound to 0.0.0 by default. Simply execute the correct accessible BROKER IP when ADD BROKER is used.
+BROKER does not currently have, nor does it need, priority\_networks. Broker's services are bound to 0.0.0 by default. Simply execute the correct accessible BROKER IP when ADD BROKER is used.
 
 #### Table Name Case Sensitivity Setting
 
@@ -224,15 +224,15 @@ See the section on `lower_case_table_names` variables in [Variables](../administ
 
 	BE nodes need to be added in FE before they can join the cluster. You can use mysql-client([Download MySQL 5.7](https://dev.mysql.com/downloads/mysql/5.7.html)) to connect to FE:
 
-	`./mysql-client -h host -P query_port -uroot`
+	`./mysql-client -h fe_host -P query_port -uroot`
 
-	The host is the node IP where FE is located; the query_port in fe/conf/fe.conf; the root account is used by default and no password is used to login.
+	The fe_host is the node IP where FE is located; the query_port in fe/conf/fe.conf; the root account is used by default and no password is used to login.
 
 	After login, execute the following commands to add each BE:
 
-	`ALTER SYSTEM ADD BACKEND "host:heartbeat_service_port";`
+	`ALTER SYSTEM ADD BACKEND "be_host:heartbeat_service_port";`
 
-	The host is the node IP where BE is located; the heartbeat_service_port in be/conf/be.conf.
+	The be_host is the node IP where BE is located; the heartbeat_service_port in be/conf/be.conf.
 
 * Start BE
 
@@ -264,9 +264,9 @@ Broker is deployed as a plug-in, independent of Doris. If you need to import dat
 
 	Use mysql-client to connect the FE started, and execute the following commands:
 
-	`ALTER SYSTEM ADD BROKER broker_name "host1:broker_ipc_port1","host2:broker_ipc_port2",...;`
+	`ALTER SYSTEM ADD BROKER broker_name "broker_host1:broker_ipc_port1","broker_host2:broker_ipc_port2",...;`
 
-	The host is Broker's node ip; the broker_ipc_port is in the Broker configuration file.
+	The broker\_host is Broker's node ip; the broker_ipc_port is in the Broker configuration file.
 
 * View Broker status
 
@@ -302,13 +302,13 @@ The first FE to start automatically becomes Leader. On this basis, several Follo
 
 Add Follower or Observer. Connect to the started FE using mysql-client and execute:
 
-`ALTER SYSTEM ADD FOLLOWER "host:edit_log_port";`
+`ALTER SYSTEM ADD FOLLOWER "follower_host:edit_log_port";`
 
 or
 
-`ALTER SYSTEM ADD OBSERVER "host:edit_log_port";`
+`ALTER SYSTEM ADD OBSERVER "observer_host:edit_log_port";`
 
-The host is the node IP of Follower or Observer, and the edit\_log\_port in its configuration file fe.conf.
+The follower\_host and observer\_host is the node IP of Follower or Observer, and the edit\_log\_port in its configuration file fe.conf.
 
 Configure and start Follower or Observer. Follower and Observer are configured with Leader. The following commands need to be executed at the first startup:
 

--- a/docs/en/installing/install-deploy.md
+++ b/docs/en/installing/install-deploy.md
@@ -152,7 +152,7 @@ At this point, DROP must remove the BE that added errors and re-use the correct 
 
 FE is the same.
 
-BROKER does not currently have, nor does it need, priority\ networks. Broker's services are bound to 0.0.0 by default. Simply execute the correct accessible BROKER IP when ADD BROKER is used.
+BROKER does not currently have, nor does it need, priority_networks. Broker's services are bound to 0.0.0 by default. Simply execute the correct accessible BROKER IP when ADD BROKER is used.
 
 #### Table Name Case Sensitivity Setting
 
@@ -224,15 +224,15 @@ See the section on `lower_case_table_names` variables in [Variables](../administ
 
 	BE nodes need to be added in FE before they can join the cluster. You can use mysql-client([Download MySQL 5.7](https://dev.mysql.com/downloads/mysql/5.7.html)) to connect to FE:
 
-	`./mysql-client -h host -P port -uroot`
+	`./mysql-client -h host -P query_port -uroot`
 
-	The host is the node IP where FE is located; the port is the query_port in fe/conf/fe.conf; the root account is used by default and no password is used to login.
+	The host is the node IP where FE is located; the query_port in fe/conf/fe.conf; the root account is used by default and no password is used to login.
 
 	After login, execute the following commands to add each BE:
 
-	`ALTER SYSTEM ADD BACKEND "host:port";`
+	`ALTER SYSTEM ADD BACKEND "host:heartbeat_service_port";`
 
-	The host is the node IP where BE is located; the port is heartbeat_service_port in be/conf/be.conf.
+	The host is the node IP where BE is located; the heartbeat_service_port in be/conf/be.conf.
 
 * Start BE
 
@@ -256,7 +256,7 @@ Broker is deployed as a plug-in, independent of Doris. If you need to import dat
 
 * Start Broker
 
-	`bin/start_broker.sh --daemon ` start Broker
+	`bin/start_broker.sh --daemon`
 
 * Add Broker
 
@@ -264,9 +264,9 @@ Broker is deployed as a plug-in, independent of Doris. If you need to import dat
 
 	Use mysql-client to connect the FE started, and execute the following commands:
 
-	`ALTER SYSTEM ADD BROKER broker_name "host1:port1","host2:port2",...;`
+	`ALTER SYSTEM ADD BROKER broker_name "host1:broker_ipc_port1","host2:broker_ipc_port2",...;`
 
-	The host is Broker's node ip; the port is broker port in the Broker configuration file.
+	The host is Broker's node ip; the broker_ipc_port is in the Broker configuration file.
 
 * View Broker status
 
@@ -288,7 +288,7 @@ Users can login to Master FE through MySQL client. By:
 
 To view the current FE node situation.
 
-You can also view the FE node through the front-end page connection: ``http://fe_hostname: fe_http_port/frontend`` or ```http://fe_hostname: fe_http_port/system? Path=//frontends```.
+You can also view the FE node through the front-end page connection: ``http://fe_hostname:fe_http_port/frontend`` or ```http://fe_hostname:fe_http_port/system?Path=//frontends```.
 
 All of the above methods require Doris's root user rights.
 
@@ -302,21 +302,25 @@ The first FE to start automatically becomes Leader. On this basis, several Follo
 
 Add Follower or Observer. Connect to the started FE using mysql-client and execute:
 
-`ALTER SYSTEM ADD FOLLOWER "host:port";`
+`ALTER SYSTEM ADD FOLLOWER "host:edit_log_port";`
 
 or
 
-`ALTER SYSTEM ADD OBSERVER "host:port";`
+`ALTER SYSTEM ADD OBSERVER "host:edit_log_port";`
 
-The host is the node IP of Follower or Observer, and the port is edit\_log\_port in its configuration file fe.conf.
+The host is the node IP of Follower or Observer, and the edit\_log\_port in its configuration file fe.conf.
 
 Configure and start Follower or Observer. Follower and Observer are configured with Leader. The following commands need to be executed at the first startup:
 
-`./bin/start_fe.sh --helper host:port --daemon`
+`bin/start_fe.sh --helper host:edit_log_port --daemon`
 
-The host is the node IP of Leader, and the port is edit\_log\_port in Lead's configuration file fe.conf. The --helper is only required when follower/observer is first startup.
+The host is the node IP of Leader, and the edit\_log\_port in Lead's configuration file fe.conf. The --helper is only required when follower/observer is first startup.
 
-View the status of Follower or Observer. Connect to any booted FE using mysql-client and execute: SHOW PROC'/frontends'; you can view the FE currently joined the cluster and its corresponding roles.
+View the status of Follower or Observer. Connect to any booted FE using mysql-client and execute: 
+
+```SHOW PROC '/frontends';```
+
+You can view the FE currently joined the cluster and its corresponding roles.
 
 > Notes for FE expansion:
 > 
@@ -343,7 +347,7 @@ Users can login to Leader FE through mysql-client. By:
 
 To see the current BE node situation.
 
-You can also view the BE node through the front-end page connection: ``http://fe_hostname: fe_http_port/backend`` or ``http://fe_hostname: fe_http_port/system? Path=//backends``.
+You can also view the BE node through the front-end page connection: ``http://fe_hostname:fe_http_port/backend`` or ``http://fe_hostname:fe_http_port/system?Path=//backends``.
 
 All of the above methods require Doris's root user rights.
 

--- a/docs/zh-CN/installing/install-deploy.md
+++ b/docs/zh-CN/installing/install-deploy.md
@@ -223,15 +223,15 @@ doris默认为表名大小写敏感，如有表名大小写不敏感的需求需
 
     BE 节点需要先在 FE 中添加，才可加入集群。可以使用 mysql-client([下载MySQL 5.7](https://dev.mysql.com/downloads/mysql/5.7.html)) 连接到 FE：
 
-    `./mysql-client -h host -P port -uroot`
+    `./mysql-client -h fe_host -P query_port -uroot`
 
-    其中 host 为 FE 所在节点 ip；port 为 fe/conf/fe.conf 中的 query_port；默认使用 root 账户，无密码登录。
+    其中 fe_host 为 FE 所在节点 ip；query_port 在 fe/conf/fe.conf 中的；默认使用 root 账户，无密码登录。
 
     登录后，执行以下命令来添加每一个 BE：
 
-    `ALTER SYSTEM ADD BACKEND "host:port";`
+    `ALTER SYSTEM ADD BACKEND "be_host:heartbeat-service_port";`
 
-      	其中 host 为 BE 所在节点 ip；port 为 be/conf/be.conf 中的 heartbeat_service_port。
+    其中 be_host 为 BE 所在节点 ip；heartbeat_service_port 在 be/conf/be.conf 中。
 
 * 启动 BE
 
@@ -255,7 +255,7 @@ Broker 以插件的形式，独立于 Doris 部署。如果需要从第三方存
 
  * 启动 Broker
 
-    `bin/start_broker.sh --daemon` 启动 Broker。
+    `bin/start_broker.sh --daemon`
 
 * 添加 Broker
 
@@ -263,9 +263,9 @@ Broker 以插件的形式，独立于 Doris 部署。如果需要从第三方存
 
     使用 mysql-client 连接启动的 FE，执行以下命令：
 
-    `ALTER SYSTEM ADD BROKER broker_name "host1:port1","host2:port2",...;`
+    `ALTER SYSTEM ADD BROKER broker_name "broker_host1:broker_ipc_port1","broker_host2:broker_ipc_port2",...;`
 
-    其中 host 为 Broker 所在节点 ip；port 为 Broker 配置文件中的 broker\_ipc\_port。
+    其中 broker_host 为 Broker 所在节点 ip；broker_ipc_port 在 Broker 配置文件中的conf/apache_hdfs_broker.conf。
 
 * 查看 Broker 状态
 
@@ -301,19 +301,19 @@ FE 分为 Leader，Follower 和 Observer 三种角色。 默认一个集群，�
 
 添加 Follower 或 Observer。使用 mysql-client 连接到已启动的 FE，并执行：
 
-`ALTER SYSTEM ADD FOLLOWER "host:port";`
+`ALTER SYSTEM ADD FOLLOWER "follower_host:edit_log_port";`
 
 或
 
-`ALTER SYSTEM ADD OBSERVER "host:port";`
+`ALTER SYSTEM ADD OBSERVER "observer_host:edit_log_port";`
 
-其中 host 为 Follower 或 Observer 所在节点 ip，port 为其配置文件 fe.conf 中的 edit\_log\_port。
+其中 follower\_host和observer\_host 为 Follower 或 Observer 所在节点 ip，edit\_log\_port 在其配置文件 fe.conf 中。
 
 配置及启动 Follower 或 Observer。Follower 和 Observer 的配置同 Leader 的配置。第一次启动时，需执行以下命令：
 
-`./bin/start_fe.sh --helper host:port --daemon`
+`./bin/start_fe.sh --helper leader_fe_host:edit_log_port --daemon`
 
-其中 host 为 Leader 所在节点 ip, port 为 Leader 的配置文件 fe.conf 中的 edit_log_port。--helper 参数仅在 follower 和 observer 第一次启动时才需要。
+其中 leader\_fe\_host 为 Leader 所在节点 ip, edit\_log\_port 在 Leader 的配置文件 fe.conf 中。--helper 参数仅在 follower 和 observer 第一次启动时才需要。
 
 查看 Follower 或 Observer 运行状态。使用 mysql-client 连接到任一已启动的 FE，并执行：SHOW PROC '/frontends'; 可以查看当前已加入集群的 FE 及其对应角色。
 


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

when sh build.sh -j n, which is followed by parallel parameter only , the output will be null because the script must follow --be or --fe etc... explicitly

so, the behavior is not the same as ` make -j n `. 

with this pr, we will support this.

## Checklist(Required)

1. Does it affect the original behavior: (Yes)
2. Has unit tests been added: (No)
3. Has document been added or modified: (No)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
