### PR TITLE
[improvement]support build with parallel parameter only

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -120,6 +120,8 @@ BUILD_UI=
 BUILD_SPARK_DPP=
 CLEAN=
 HELP=0
+PARAMETER_COUNT=$#
+PARAMETER_FLAG=0
 if [ $# == 1 ] ; then
     # default
     BUILD_BE=1
@@ -145,11 +147,20 @@ else
             --clean) CLEAN=1 ; shift ;;
             -h) HELP=1; shift ;;
             --help) HELP=1; shift ;;
-            -j) PARALLEL=$2; shift 2 ;;
+            -j) PARALLEL=$2; PARAMETER_FLAG=1; shift 2 ;;
             --) shift ;  break ;;
             *) echo "Internal error" ; exit 1 ;;
         esac
     done
+    #only ./build.sh -j xx then build all 
+    if [[ ${PARAMETER_COUNT} -eq 3 ]] && [[ ${PARAMETER_FLAG} -eq 1 ]];then
+        BUILD_BE=1
+        BUILD_FE=1
+        BUILD_BROKER=1
+        BUILD_UI=1
+        BUILD_SPARK_DPP=1
+        CLEAN=0
+    fi
 fi
 
 if [[ ${HELP} -eq 1 ]]; then


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

when sh build.sh -j n, which is followed by parallel parameter only , the output will be null because the script must follow --be or --fe etc... explicitly

so, the behavior is not the same as make -j n.

with this pr, we will support this.

## Checklist(Required)

1. Does it affect the original behavior: (Yes)
2. Has unit tests been added: (No Need)
3. Has document been added or modified: (No)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
