### PR TITLE
[improvement]avoid read bitmap index when no index works

### DIFF
--- a/be/src/olap/rowset/segment_v2/segment_iterator.h
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.h
@@ -45,6 +45,11 @@ class BitmapIndexIterator;
 class BitmapIndexReader;
 class ColumnIterator;
 
+enum ReadIndexType {
+    READ_WITH_BITMAP,
+    READ_WITHOUT_BITMAP,
+};
+
 class SegmentIterator : public RowwiseIterator {
 public:
     SegmentIterator(std::shared_ptr<Segment> segment, const Schema& _schema,
@@ -91,6 +96,7 @@ private:
     // for vectorization implementation
     Status _read_columns(const std::vector<ColumnId>& column_ids,
                          vectorized::MutableColumns& column_block, size_t nrows);
+    template<ReadIndexType T>
     Status _read_columns_by_index(uint32_t nrows_read_limit, uint32_t& nrows_read,
                                   bool set_block_rowid);
     void _init_current_block(vectorized::Block* block,
@@ -129,6 +135,7 @@ private:
     // remember the rowids we've read for the current row block.
     // could be a local variable of next_batch(), kept here to reuse vector memory
     std::vector<rowid_t> _block_rowids;
+    bool _is_bitmap_index_pruned = true;
 
     // fields for vectorization execution
     bool _is_all_column_basic_type;


### PR DESCRIPTION
# Proposed changes

Issue Number: close #8388

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (No)
2. Has unit tests been added: (No Need)
3. Has document been added or modified: (No Need)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (No)

## Further comments

Performance test has been added, see #8388
