### PR TITLE
[fix] brpc will check required field in proto and need_gen_rollup is moved will throw exception

### DIFF
--- a/be/src/exec/tablet_sink.cpp
+++ b/be/src/exec/tablet_sink.cpp
@@ -121,6 +121,7 @@ void NodeChannel::open() {
         ptablet->set_tablet_id(tablet.tablet_id);
     }
     request.set_num_senders(_parent->_num_senders);
+    request.set_need_gen_rollup(false); // Useless but it is a required field in pb
     request.set_load_mem_limit(_parent->_load_mem_limit);
     request.set_load_channel_timeout_s(_parent->_load_channel_timeout_s);
     request.set_is_high_priority(_parent->_is_high_priority);

--- a/be/test/runtime/load_channel_mgr_test.cpp
+++ b/be/test/runtime/load_channel_mgr_test.cpp
@@ -208,6 +208,7 @@ TEST_F(LoadChannelMgrTest, normal) {
             tablet->set_tablet_id(20 + i);
         }
         request.set_num_senders(1);
+        request.set_need_gen_rollup(false);
         auto st = mgr.open(request);
         request.release_id();
         ASSERT_TRUE(st.ok());
@@ -295,6 +296,7 @@ TEST_F(LoadChannelMgrTest, cancel) {
             tablet->set_tablet_id(20 + i);
         }
         request.set_num_senders(1);
+        request.set_need_gen_rollup(false);
         auto st = mgr.open(request);
         request.release_id();
         ASSERT_TRUE(st.ok());
@@ -337,6 +339,7 @@ TEST_F(LoadChannelMgrTest, open_failed) {
             tablet->set_tablet_id(20 + i);
         }
         request.set_num_senders(1);
+        request.set_need_gen_rollup(false);
         open_status = OLAP_ERR_TABLE_NOT_FOUND;
         auto st = mgr.open(request);
         request.release_id();
@@ -371,6 +374,7 @@ TEST_F(LoadChannelMgrTest, add_failed) {
             tablet->set_tablet_id(20 + i);
         }
         request.set_num_senders(1);
+        request.set_need_gen_rollup(false);
         auto st = mgr.open(request);
         request.release_id();
         ASSERT_TRUE(st.ok());
@@ -460,6 +464,7 @@ TEST_F(LoadChannelMgrTest, close_failed) {
             tablet->set_tablet_id(20 + i);
         }
         request.set_num_senders(1);
+        request.set_need_gen_rollup(false);
         auto st = mgr.open(request);
         request.release_id();
         ASSERT_TRUE(st.ok());
@@ -551,6 +556,7 @@ TEST_F(LoadChannelMgrTest, unknown_tablet) {
             tablet->set_tablet_id(20 + i);
         }
         request.set_num_senders(1);
+        request.set_need_gen_rollup(false);
         auto st = mgr.open(request);
         request.release_id();
         ASSERT_TRUE(st.ok());
@@ -636,6 +642,7 @@ TEST_F(LoadChannelMgrTest, duplicate_packet) {
             tablet->set_tablet_id(20 + i);
         }
         request.set_num_senders(1);
+        request.set_need_gen_rollup(false);
         auto st = mgr.open(request);
         request.release_id();
         ASSERT_TRUE(st.ok());


### PR DESCRIPTION
# Proposed changes

Issue Number: close #8417 

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
