### PR TITLE
[feature-wip][udf] support java udf in FE

### DIFF
--- a/gensrc/thrift/Types.thrift
+++ b/gensrc/thrift/Types.thrift
@@ -269,6 +269,8 @@ enum TFunctionBinaryType {
 
   // call udfs by rpc service
   RPC,
+
+  JAVA_UDF,
 }
 
 // Represents a fully qualified function name.


### PR DESCRIPTION
# Proposed changes

Related Issue:
[#8389](https://github.com/apache/incubator-doris/issues/8389)
[#8441](https://github.com/apache/incubator-doris/issues/8441)

## Problem Summary:

First step to support Java UDF in Doris. After this PR, we can create Java UDF in doris.

For example, we create Java UDF function by code below.
`CREATE FUNCTION test_udf(int) RETURNS int 
PROPERTIES (
"file"="file:///root/hive-udf-1.0-SNAPSHOT.jar",
"symbol"="udf.Main", 
"type"="JAVA_UDF"
)`
1. `file` indicate where user file is.
2. `symbol` for java udf means udf class in this jar.
3. `type` indicate this function is a java udf.

## Checklist(Required)

1. Does it affect the original behavior: (No)
4. Has unit tests been added: (No Need)
5. Has document been added or modified: (No Need)
6. Does it need to update dependencies: (No)
7. Are there any changes that cannot be rolled back: (No)

## Further comments

Furthermore, Im planning to implement java udf on vectorized engine. If you need this feature on row-based engine, please let me know
