### PR TITLE
[refactor] use c++ 14 deprecated instead of comment, this detect usage of deprecated var or func at compile time

### DIFF
--- a/be/src/agent/agent_server.h
+++ b/be/src/agent/agent_server.h
@@ -45,6 +45,7 @@ public:
 
     // Deprecated
     // TODO(lingbin): This method is deprecated, should be removed later.
+    // [[deprecated]]
     void publish_cluster_state(TAgentResult& agent_result, const TAgentPublishRequest& request);
 
     // Multi-Load will still use the following 3 methods for now.

--- a/be/src/agent/task_worker_pool.h
+++ b/be/src/agent/task_worker_pool.h
@@ -49,12 +49,12 @@ public:
         REALTIME_PUSH,
         PUBLISH_VERSION,
         // Deprecated
-        CLEAR_ALTER_TASK,
+        CLEAR_ALTER_TASK [[deprecated]],
         CLEAR_TRANSACTION_TASK,
         DELETE,
         ALTER_TABLE,
         // Deprecated
-        QUERY_SPLIT_KEY,
+        QUERY_SPLIT_KEY [[deprecated]],
         CLONE,
         STORAGE_MEDIUM_MIGRATE,
         CHECK_CONSISTENCY,
@@ -90,16 +90,12 @@ public:
             return "REALTIME_PUSH";
         case PUBLISH_VERSION:
             return "PUBLISH_VERSION";
-        case CLEAR_ALTER_TASK:
-            return "CLEAR_ALTER_TASK";
         case CLEAR_TRANSACTION_TASK:
             return "CLEAR_TRANSACTION_TASK";
         case DELETE:
             return "DELETE";
         case ALTER_TABLE:
             return "ALTER_TABLE";
-        case QUERY_SPLIT_KEY:
-            return "QUERY_SPLIT_KEY";
         case CLONE:
             return "CLONE";
         case STORAGE_MEDIUM_MIGRATE:

--- a/be/src/exec/tablet_sink.h
+++ b/be/src/exec/tablet_sink.h
@@ -323,13 +323,15 @@ public:
 
     void add_row(BlockRow& block_row, int64_t tablet_id);
 
-    void for_each_node_channel(const std::function<void(const std::shared_ptr<NodeChannel>&)>& func) {
+    void for_each_node_channel(
+            const std::function<void(const std::shared_ptr<NodeChannel>&)>& func) {
         for (auto& it : _node_channels) {
             func(it.second);
         }
     }
 
-    void mark_as_failed(int64_t node_id, const std::string& host, const std::string& err, int64_t tablet_id = -1);
+    void mark_as_failed(int64_t node_id, const std::string& host, const std::string& err,
+                        int64_t tablet_id = -1);
     Status check_intolerable_failure();
 
     // set error tablet info in runtime state, so that it can be returned to FE.
@@ -507,9 +509,7 @@ protected:
     // compute tablet index for every row batch
     // FIND_TABLET_EVERY_SINK is only used for random distribution info, which indicates that we should
     // only compute tablet index in the corresponding partition once for the whole time in olap table sink
-    enum FindTabletMode {
-        FIND_TABLET_EVERY_ROW, FIND_TABLET_EVERY_BATCH, FIND_TABLET_EVERY_SINK
-    };
+    enum FindTabletMode { FIND_TABLET_EVERY_ROW, FIND_TABLET_EVERY_BATCH, FIND_TABLET_EVERY_SINK };
     FindTabletMode findTabletMode = FindTabletMode::FIND_TABLET_EVERY_ROW;
 };
 

--- a/be/src/runtime/file_result_writer.h
+++ b/be/src/runtime/file_result_writer.h
@@ -32,7 +32,7 @@ class RuntimeProfile;
 class TupleRow;
 
 struct ResultFileOptions {
-    // deprecated
+    // [[deprecated]]
     bool is_local_file;
     std::string file_path;
     TFileFormatType::type file_format;
@@ -77,6 +77,7 @@ class BufferControlBlock;
 // write result to file
 class FileResultWriter final : public ResultWriter {
 public:
+    // [[deprecated]]
     FileResultWriter(const ResultFileOptions* file_option,
                      const std::vector<ExprContext*>& output_expr_ctxs,
                      RuntimeProfile* parent_profile, BufferControlBlock* sinker,

--- a/be/src/runtime/primitive_type.h
+++ b/be/src/runtime/primitive_type.h
@@ -52,9 +52,9 @@ enum PrimitiveType {
     TYPE_DATE,     /* 11 */
     TYPE_DATETIME, /* 12 */
     TYPE_BINARY,
-    /* 13 */                // Not implemented
-    TYPE_DECIMAL_DEPRACTED, /* 14 */
-    TYPE_CHAR,              /* 15 */
+    /* 13 */                     // Not implemented
+    TYPE_DECIMAL [[deprecated]], /* 14 */
+    TYPE_CHAR,                   /* 15 */
 
     TYPE_STRUCT,    /* 16 */
     TYPE_ARRAY,     /* 17 */

--- a/be/src/udf/udf.h
+++ b/be/src/udf/udf.h
@@ -74,7 +74,7 @@ public:
         TYPE_LARGEINT,
         TYPE_FLOAT,
         TYPE_DOUBLE,
-        TYPE_DECIMAL_DEPRACTED,
+        TYPE_DECIMAL [[deprecated]],
         TYPE_DATE,
         TYPE_DATETIME,
         TYPE_CHAR,


### PR DESCRIPTION
# Proposed changes

 use c++ 14 deprecated instaed of comment, this detect usage of deprecated var or func at compile time

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (No)
2. Has unit tests been added: (No Need)
3. Has document been added or modified: (No Need)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (Yes)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
