### PR TITLE
fix mem_tracker in olap_scanner and olap_scan_node

### DIFF
--- a/be/src/exec/olap_scan_node.cpp
+++ b/be/src/exec/olap_scan_node.cpp
@@ -1397,8 +1397,8 @@ void OlapScanNode::transfer_thread(RuntimeState* state) {
             if (mem_consume < (mem_limit * 6) / 10) {
                 thread_slot_num = max_thread - assigned_thread_num;
             } else {
-                // Memory already exceed
-                if (_scan_row_batches.empty()) {
+                // Memory already exceeds, start a scanner only if two lists are empty.
+                if (_scan_row_batches.empty() && _materialized_row_batches.empty()) {
                     // NOTE(zc): here need to lock row_batches_lock_
                     //  be worried about dead lock, so don't check here
                     // if (materialized_row_batches_.empty()) {
@@ -1406,10 +1406,8 @@ void OlapScanNode::transfer_thread(RuntimeState* state) {
                     //         " are empty when memory exceed";
                     // }
                     // Just for notify if scan_row_batches_ is empty and no running thread
-                    if (assigned_thread_num == 0) {
-                        thread_slot_num = 1;
-                        // NOTE: if olap_scanners_ is empty, scanner_done_ should be true
-                    }
+                    // thread_slot_num must be zero dueto if else.
+                    thread_slot_num = 1;
                 }
             }
             thread_slot_num = std::min(thread_slot_num, _olap_scanners.size());


### PR DESCRIPTION
Now OlapScanNode starts one scanner when memory is used too much and
scanner_row_batch is empty. When memory is under pressure, we should
start a scanner only if both scanner_row_batch and materized_queue are
empty.

Now OlapSanner allocates memory by calling MemPool::allocate method,
however, MemPool::allocate does not check limit, so we should check limit.

This patch can avoids oom crash, and the 'select * or insert into select'
fails due to memory over limit.

We should add another patch, which control memory consumption of OlapScanner
and OlapTableSink by percent of exec_mem_limit. Thus, the query does not
fail due to memory over limit.


# Proposed changes

Issue Number: close #xxx

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
