### PR TITLE
[fix](report) fix bug that tablet may already be delete when reporting

### DIFF
--- a/be/src/olap/tablet.h
+++ b/be/src/olap/tablet.h
@@ -177,7 +177,8 @@ public:
 
     // This function to find max continuous version from the beginning.
     // For example: If there are 1, 2, 3, 5, 6, 7 versions belongs tablet, then 3 is target.
-    void max_continuous_version_from_beginning(Version* version);
+    // 3 will be saved in "version", and 7 will be saved in "max_version", if max_version != nullptr
+    void max_continuous_version_from_beginning(Version* version, Version* max_version = nullptr);
 
     // operation for query
     OLAPStatus split_range(const OlapTuple& start_key_strings, const OlapTuple& end_key_strings,
@@ -275,7 +276,8 @@ private:
 
     // Returns:
     // version: the max continuous version from beginning
-    void _max_continuous_version_from_beginning_unlocked(Version* version) const;
+    // max_version: the max version of this tablet
+    void _max_continuous_version_from_beginning_unlocked(Version* version, Version* max_version) const;
     RowsetSharedPtr _rowset_with_largest_size();
     /// Delete stale rowset by version. This method not only delete the version in expired rowset map,
     /// but also delete the version in rowset meta vector.

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Catalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Catalog.java
@@ -6938,6 +6938,14 @@ public class Catalog {
         List<BackendReplicasInfo.ReplicaReportInfo> replicaInfos = backendReplicasInfo.getReplicaReportInfos();
 
         for (BackendReplicasInfo.ReplicaReportInfo info : replicaInfos) {
+            if (tabletInvertedIndex.getTabletMeta(info.tabletId) == null) {
+                // The tablet has been deleted. Because the reporting of tablet and
+                // the deletion of tablet are two independent events,
+                // and directly do not do mutually exclusive processing,
+                // so it may appear that the tablet is deleted first, and the reporting information is processed later.
+                // Here we simply ignore the deleted tablet.
+                continue;
+            }
             Replica replica = tabletInvertedIndex.getReplica(info.tabletId, backendId);
             if (replica == null) {
                 LOG.warn("failed to find replica of tablet {} on backend {} when replaying backend report info",


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

1.
This bug was introduced by #8209.
Error in fe.warn.log:
```
java.lang.IllegalStateException: 560278
        at com.google.common.base.Preconditions.checkState(Preconditions.java:508) ~[spark-dpp-0.15-SNAPSHOT.jar:0.15-SNAPSHOT]
        at org.apache.doris.catalog.TabletInvertedIndex.getReplica(TabletInvertedIndex.java:462) ~[palo-fe.jar:0.15-SNAPSHOT]
        at org.apache.doris.catalog.Catalog.replayBackendReplicasInfo(Catalog.java:6941) ~[palo-fe.jar:0.15-SNAPSHOT]
        at org.apache.doris.persist.EditLog.loadJournal(EditLog.java:626) [palo-fe.jar:0.15-SNAPSHOT]
        at org.apache.doris.catalog.Catalog.replayJournal(Catalog.java:2446) [palo-fe.jar:0.15-SNAPSHOT]
        at org.apache.doris.master.Checkpoint.doCheckpoint(Checkpoint.java:116) [palo-fe.jar:0.15-SNAPSHOT]
        at org.apache.doris.master.Checkpoint.runAfterCatalogReady(Checkpoint.java:74) [palo-fe.jar:0.15-SNAPSHOT]
        at org.apache.doris.common.util.MasterDaemon.runOneCycle(MasterDaemon.java:58) [palo-fe.jar:0.15-SNAPSHOT]
        at org.apache.doris.common.util.Daemon.run(Daemon.java:116) [palo-fe.jar:0.15-SNAPSHOT]
```

Since the reporting of a tablet and the deletion of a tablet are two independent events
and are not mutually exclusive, it may happen that the tablet is deleted first and the reporting is done later.

2.
Change the tablet report info. Now, the version of a tablet report from BE is the largest continuous version.
Eg, versions: [1,2,3,5,7], the report version of this tablet will be 3.

## Checklist(Required)

1. Does it affect the original behavior: (No)
2. Has unit tests been added: (No Need)
3. Has document been added or modified: (No)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
