### PR TITLE
[fix](partition_cache) Fix Partition Cache NullPointerException bug

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/cache/PartitionRange.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/cache/PartitionRange.java
@@ -47,6 +47,7 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * Convert the range of the partition to the list
@@ -353,8 +354,10 @@ public class PartitionRange {
     }
 
     /**
-     * Only the range query of the key of the partition is supported, and the separated partition key query is not supported.
-     * Because a query can only be divided into two parts, part1 get data from cache, part2 fetch_data by scan node from BE.
+     * Only the range query of the key of the partition is supported, and the separated partition key query is not
+     * supported.
+     * Because a query can only be divided into two parts, part1 get data from cache, part2 fetch_data by scan node
+     * from BE.
      * Partition cache : 20191211-20191215
      * Hit cache parameter : [20191211 - 20191215], [20191212 - 20191214], [20191212 - 20191216],[20191210 - 20191215]
      * Miss cache parameter: [20191210 - 20191216]
@@ -503,6 +506,10 @@ public class PartitionRange {
         for (PartitionSingle single : partitionSingleList) {
             single.setPartition(table.getPartition(single.getPartitionId()));
         }
+
+        // filter the partitions in predicate but not in OlapTable
+        partitionSingleList =
+                partitionSingleList.stream().filter(p -> p.getPartition() != null).collect(Collectors.toList());
     }
 
     /**


### PR DESCRIPTION
# Proposed changes

Issue Number: close #8337 

## Problem Summary:

Filter the partitions in predicate but not in OlapTable.

## Checklist(Required)

1. Does it affect the original behavior: (No)
2. Has unit tests been added: (Yes)
3. Has document been added or modified: (No)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
