### PR TITLE
[test]let framework support sql cases and run cases in parallel and random order

### DIFF
--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/Config.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/Config.groovy
@@ -49,12 +49,15 @@ class Config {
     public String testSuites
     public boolean generateOutputFile
     public boolean forceGenerateOutputFile
+    public boolean randomOrder
 
     public Properties otherConfigs = new Properties()
 
     public Set<String> suiteWildcard = new HashSet<>()
     public Set<String> groups = new HashSet<>()
     public InetSocketAddress feHttpInetSocketAddress
+    public Integer parallel
+    public Integer times
 
     Config() {}
 
@@ -119,6 +122,10 @@ class Config {
         config.feHttpPassword = cmd.getOptionValue(feHttpPasswordOpt, config.feHttpPassword)
         config.generateOutputFile = cmd.hasOption(genOutOpt)
         config.forceGenerateOutputFile = cmd.hasOption(forceGenOutOpt)
+        config.parallel = Integer.parseInt(cmd.getOptionValue(parallelOpt, "1"))
+        config.times = Integer.parseInt(cmd.getOptionValue(timesOpt, "1"))
+        config.randomOrder = cmd.hasOption(randomOrderOpt)
+
         Properties props = cmd.getOptionProperties("conf")
         config.otherConfigs.putAll(props)
 
@@ -210,6 +217,16 @@ class Config {
         if (config.testSuites == null) {
             config.testSuites = ""
             log.info("Set testSuites to empty because not specify.".toString())
+        }
+
+        if (config.parallel == null) {
+            config.parallel = 1
+            log.info("Set parallel to 1 because not specify.".toString())
+        }
+
+        if (config.randomOrder == null) {
+            config.randomOrder = false
+            log.info("set randomOrder to false becasue not specify".toString())
         }
     }
     

--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/ConfigOptions.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/ConfigOptions.groovy
@@ -42,6 +42,9 @@ class ConfigOptions {
     static Option confOpt
     static Option genOutOpt
     static Option forceGenOutOpt
+    static Option parallelOpt
+    static Option randomOrderOpt
+    static Option timesOpt
 
     static CommandLine initCommands(String[] args) {
         helpOption = Option.builder("h")
@@ -167,6 +170,29 @@ class ConfigOptions {
                 .longOpt("configurations, format: key=value")
                 .desc("set addition context configurations")
                 .build()
+        parallelOpt = Option.builder("parallel")
+                .argName("parallel")
+                .required(false)
+                .hasArg(true)
+                .optionalArg(true)
+                .type(String.class)
+                .longOpt("parallel")
+                .desc("the num of threads running test")
+                .build()
+        randomOrderOpt = Option.builder("randomOrder")
+                .required(false)
+                .hasArg(false)
+                .desc("run tests in random order")
+                .build()
+        timesOpt = Option.builder("times")
+                .argName("times")
+                .required(false)
+                .hasArg(true)
+                .optionalArg(true)
+                .type(String.class)
+                .longOpt("times")
+                .desc("the times tests run, load.groovy is run only one time.")
+                .build()
 
         Options options = new Options()
                 .addOption(helpOption)
@@ -184,6 +210,8 @@ class ConfigOptions {
                 .addOption(genOutOpt)
                 .addOption(confFileOpt)
                 .addOption(forceGenOutOpt)
+                .addOption(parallelOpt)
+                .addOption(randomOrderOpt)
 
         CommandLine cmd = new DefaultParser().parse(options, args, true)
         if (cmd.hasOption(helpOption)) {

--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/RegressionTest.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/RegressionTest.groovy
@@ -14,7 +14,6 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-
 package org.apache.doris.regression
 
 import groovy.transform.CompileStatic
@@ -32,6 +31,7 @@ import java.util.stream.Collectors
 @Slf4j
 @CompileStatic
 class RegressionTest {
+
     static ClassLoader classloader
     static CompilerConfiguration compileConfig
     static GroovyShell shell
@@ -57,25 +57,62 @@ class RegressionTest {
 
     static List<File> findSuiteFiles(String root) {
         if (root == null) {
-            log.warn("Not specify suite path")
+            log.warn('Not specify suite path')
             return new ArrayList<File>()
         }
         List<File> files = new ArrayList<>()
+        // 1. generate groovy for sql
         new File(root).eachFileRecurse { f ->
-            if (f.isFile() && f.name.endsWith(".groovy")) {
+            if (f.isFile() && f.name.endsWith('.sql')) {
+                genetate_groovy_from_sql(f)
+            }
+        }
+
+        // 2. collect groovy files.
+        new File(root).eachFileRecurse { f ->
+            if (f.isFile() && f.name.endsWith('.groovy')) {
                 files.add(f)
             }
         }
         return files
     }
 
+    static void genetate_groovy_from_sql(File f) {
+        File groovy_file = new File(f.getAbsolutePath() + '.generated.groovy')
+        groovy_file.delete()
+        groovy_file.createNewFile()
+        int separatorIndex = f.name.lastIndexOf('.')
+        String action_name = f.name.substring(0, separatorIndex)
+        groovy_file.text = "qt_${action_name} \"\"\"${f.text}\"\"\""
+    }
+
     static String parseGroup(Config config, File suiteFile) {
         String group = new File(config.suitePath).relativePath(suiteFile)
         int separatorIndex = group.lastIndexOf(File.separator)
         if (separatorIndex == -1) {
-            return ""
+            return ''
         } else {
             return group.substring(0, separatorIndex)
+        }
+    }
+
+    static void runSuite(Config config, SuiteFile sf, Recorder recorder) {
+        File file = sf.file
+        String suiteName = sf.suiteName
+        String group = sf.group
+        def suiteConn = config.getConnection()
+        new SuiteContext(file, suiteConn, config, recorder).withCloseable { context ->
+            try {
+                log.info("Run ${suiteName} in $file".toString())
+                Suite suite = shell.parse(file) as Suite
+                suite.init(suiteName, group, context)
+                suite.run()
+                recorder.onSuccess(new SuiteInfo(file, group, suiteName))
+                log.info("Run ${suiteName} in ${file.absolutePath} succeed".toString())
+            } catch (Throwable t) {
+                recorder.onFailure(new SuiteInfo(file, group, suiteName))
+                log.error("Run ${suiteName} in ${file.absolutePath} failed".toString(), t)
+            }
         }
     }
 
@@ -83,44 +120,28 @@ class RegressionTest {
         def files = findSuiteFiles(config.suitePath)
         def recorder = new Recorder()
         List<SuiteFile> runScripts = files.stream().map({ file ->
-            String suiteName = file.name.substring(0, file.name.lastIndexOf("."))
+            String suiteName = file.name.substring(0, file.name.lastIndexOf('.'))
             String group = parseGroup(config, file)
             return new SuiteFile(file, suiteName, group)
         }).filter({ sf ->
             canRun(config, sf.suiteName, sf.group)
         }).collect(Collectors.toList())
 
-        log.info("Start to run suites")
+        log.info('Start to run suites')
         int totalFile = runScripts.size()
         runScripts.eachWithIndex { sf, i ->
-            File file = sf.file
-            String suiteName = sf.suiteName
-            String group = sf.group
-            def suiteConn = config.getConnection()
-            new SuiteContext(file, suiteConn, config, recorder).withCloseable { context ->
-                try {
-                    log.info("[${i + 1}/${totalFile}] Run ${suiteName} in $file".toString())
-                    Suite suite = shell.parse(file) as Suite
-                    suite.init(suiteName, group, context)
-                    suite.run()
-                    recorder.onSuccess(new SuiteInfo(file, group, suiteName))
-                    log.info("Run ${suiteName} in ${file.absolutePath} succeed".toString())
-                } catch (Throwable t) {
-                    recorder.onFailure(new SuiteInfo(file, group, suiteName))
-                    log.error("Run ${suiteName} in ${file.absolutePath} failed".toString(), t)
-                }
-            }
+            log.info("[${i + 1}/${totalFile}] Run ${sf.suiteName} in ${sf.file}".toString())
+            runSuite(config, sf, recorder)
         }
         return recorder
     }
 
     static boolean canRun(Config config, String suiteName, String group) {
-        Set<String> suiteGroups = group.split(",").collect {g -> g.trim()}.toSet()
+        Set<String> suiteGroups = group.split(',').collect { g -> g.trim() }.toSet()
         if (config.suiteWildcard.size() == 0 ||
                 (suiteName != null && (config.suiteWildcard.any {
                     suiteWildcard -> Wildcard.match(suiteName, suiteWildcard)
                 }))) {
-
             if (config.groups == null || config.groups.isEmpty()
                     || !config.groups.intersect(suiteGroups).isEmpty()) {
                 return true
@@ -138,7 +159,7 @@ class RegressionTest {
         {
             String successList = recorder.successList.collect { info ->
                 "${info.file.absolutePath}: group=${info.group}, name=${info.suiteName}"
-            }.join("\n")
+            }.join('\n')
             log.info("successList suites:\n${successList}".toString())
         }
 
@@ -146,36 +167,37 @@ class RegressionTest {
         if (!recorder.failureList.isEmpty()) {
             def failureList = recorder.failureList.collect() { info ->
                 "${info.file.absolutePath}: group=${info.group}, name=${info.suiteName}"
-            }.join("\n")
+            }.join('\n')
             log.info("Failure suites:\n${failureList}".toString())
             printFailed()
-            throw new IllegalStateException("Test failed")
+            throw new IllegalStateException('Test failed')
         } else {
             printPassed()
         }
     }
 
     static void printPassed() {
-        log.info("""All suites success.
-                 | ____   _    ____ ____  _____ ____  
-                 ||  _ \\ / \\  / ___/ ___|| ____|  _ \\ 
+        log.info('''All suites success.
+                 | ____   _    ____ ____  _____ ____
+                 ||  _ \\ / \\  / ___/ ___|| ____|  _ \\
                  || |_) / _ \\ \\___ \\___ \\|  _| | | | |
                  ||  __/ ___ \\ ___) |__) | |___| |_| |
-                 ||_| /_/   \\_\\____/____/|_____|____/                         
-                 |""".stripMargin())
+                 ||_| /_/   \\_\\____/____/|_____|____/
+                 |'''.stripMargin())
     }
 
     static void printFailed() {
-        log.info("""Some suites failed.
-                 | _____ _    ___ _     _____ ____  
-                 ||  ___/ \\  |_ _| |   | ____|  _ \\ 
+        log.info('''Some suites failed.
+                 | _____ _    ___ _     _____ ____
+                 ||  ___/ \\  |_ _| |   | ____|  _ \\
                  || |_ / _ \\  | || |   |  _| | | | |
                  ||  _/ ___ \\ | || |___| |___| |_| |
-                 ||_|/_/   \\_\\___|_____|_____|____/ 
-                 |""".stripMargin())
+                 ||_|/_/   \\_\\___|_____|_____|____/
+                 |'''.stripMargin())
     }
 
     static class SuiteFile {
+
         File file
         String suiteName
         String group
@@ -185,5 +207,7 @@ class RegressionTest {
             this.suiteName = suiteName
             this.group = group
         }
+
     }
+
 }

--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/RegressionTest.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/RegressionTest.groovy
@@ -87,13 +87,19 @@ class RegressionTest {
     }
 
     static String parseGroup(Config config, File suiteFile) {
+        // ./run-regression-test.sh -g group_name runs all groups
+        // whose name starting with ${group_name}.
         String group = new File(config.suitePath).relativePath(suiteFile)
         int separatorIndex = group.lastIndexOf(File.separator)
-        if (separatorIndex == -1) {
-            return ''
-        } else {
-            return group.substring(0, separatorIndex)
+        String groups = ",";
+        while (separatorIndex != -1) {
+            group = group.substring(0, separatorIndex)
+            groups += "${group},"
+            separatorIndex = group.lastIndexOf(File.separator)
         }
+        // remove ',' at head and trail
+        groups = groups.substring(1, groups.length() - 1);
+        return groups;
     }
 
     static void runSuite(Config config, SuiteFile sf, Recorder recorder) {

--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/RegressionTest.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/RegressionTest.groovy
@@ -26,6 +26,9 @@ import org.apache.commons.cli.*
 import org.apache.doris.regression.util.SuiteInfo
 import org.codehaus.groovy.control.CompilerConfiguration
 
+import java.util.concurrent.Executors
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Future
 import java.util.stream.Collectors
 
 @Slf4j
@@ -35,6 +38,7 @@ class RegressionTest {
     static ClassLoader classloader
     static CompilerConfiguration compileConfig
     static GroovyShell shell
+    static ExecutorService executorService;
 
     static void main(String[] args) {
         CommandLine cmd = ConfigOptions.initCommands(args)
@@ -44,15 +48,21 @@ class RegressionTest {
 
         Config config = Config.fromCommandLine(cmd)
         initGroovyEnv(config)
-        Recorder recorder = runSuites(config)
-        printResult(config, recorder)
+        for (int i = 0; i < config.times; i++) {
+            log.info("=== run ${i} time ===")
+            Recorder recorder = runSuites(config)
+            printResult(config, recorder)
+        }
     }
 
     static void initGroovyEnv(Config config) {
+        log.info("parallel = ${config.parallel}")
         classloader = new GroovyClassLoader()
         compileConfig = new CompilerConfiguration()
         compileConfig.setScriptBaseClass((Suite as Class).name)
         shell = new GroovyShell(classloader, new Binding(), compileConfig)
+        log.info("starting ${config.parallel} threads")
+        executorService = Executors.newFixedThreadPool(config.parallel);
     }
 
     static List<File> findSuiteFiles(String root) {
@@ -102,7 +112,7 @@ class RegressionTest {
         return groups;
     }
 
-    static void runSuite(Config config, SuiteFile sf, Recorder recorder) {
+    static Integer runSuite(Config config, SuiteFile sf, Recorder recorder) {
         File file = sf.file
         String suiteName = sf.suiteName
         String group = sf.group
@@ -120,16 +130,12 @@ class RegressionTest {
                 log.error("Run ${suiteName} in ${file.absolutePath} failed".toString(), t)
             }
         }
+
+        return 0
     }
 
-    static Recorder runSuites(Config config) {
-        runSuites(config, suiteName -> { suiteName == "load" } ) 
-        runSuites(config, suiteName -> { suiteName != "load" } )
-    }
-
-    static Recorder runSuites(Config config, Closure suiteNameMatch) {
+    static void runSuites(Config config, Recorder recorder, Closure suiteNameMatch) {
         def files = findSuiteFiles(config.suitePath)
-        def recorder = new Recorder()
         List<SuiteFile> runScripts = files.stream().map({ file ->
             String suiteName = file.name.substring(0, file.name.lastIndexOf('.'))
             String group = parseGroup(config, file)
@@ -138,12 +144,30 @@ class RegressionTest {
             { suiteNameMatch(sf.suiteName) && canRun(config, sf.suiteName, sf.group) }
         }).collect(Collectors.toList())
 
+        if (config.randomOrder) {
+            Collections.shuffle(files)
+        }
         log.info('Start to run suites')
         int totalFile = runScripts.size()
+        def futures = new ArrayList<Future>()
         runScripts.eachWithIndex { sf, i ->
             log.info("[${i + 1}/${totalFile}] Run ${sf.suiteName} in ${sf.file}".toString())
-            runSuite(config, sf, recorder)
+            Future future = executorService.submit(
+                             ()-> { runSuite(config, sf, recorder)}
+                             )
+            futures.add(future)
         }
+
+        for (Future<Integer> future : futures) {
+            future.get()
+        }
+    }
+
+    static Recorder runSuites(Config config) {
+        def recorder = new Recorder()
+        runSuites(config, recorder, suiteName -> { suiteName == "load" } )
+        runSuites(config, recorder, suiteName -> { suiteName != "load" } )
+
         return recorder
     }
 

--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/RegressionTest.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/RegressionTest.groovy
@@ -123,6 +123,11 @@ class RegressionTest {
     }
 
     static Recorder runSuites(Config config) {
+        runSuites(config, suiteName -> { suiteName == "load" } ) 
+        runSuites(config, suiteName -> { suiteName != "load" } )
+    }
+
+    static Recorder runSuites(Config config, Closure suiteNameMatch) {
         def files = findSuiteFiles(config.suitePath)
         def recorder = new Recorder()
         List<SuiteFile> runScripts = files.stream().map({ file ->
@@ -130,7 +135,7 @@ class RegressionTest {
             String group = parseGroup(config, file)
             return new SuiteFile(file, suiteName, group)
         }).filter({ sf ->
-            canRun(config, sf.suiteName, sf.group)
+            { suiteNameMatch(sf.suiteName) && canRun(config, sf.suiteName, sf.group) }
         }).collect(Collectors.toList())
 
         log.info('Start to run suites')

--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/RegressionTest.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/RegressionTest.groovy
@@ -71,9 +71,9 @@ class RegressionTest {
             return new ArrayList<File>()
         }
         List<File> files = new ArrayList<>()
-        // 1. generate groovy for sql
+        // 1. generate groovy for sql, excluding ddl
         new File(root).eachFileRecurse { f ->
-            if (f.isFile() && f.name.endsWith('.sql')) {
+            if (f.isFile() && f.name.endsWith('.sql') && f.getParentFile().name != "ddl") {
                 genetate_groovy_from_sql(f)
             }
         }

--- a/run-regression-test.sh
+++ b/run-regression-test.sh
@@ -57,6 +57,9 @@ Usage: $0 <shell_options> <framework_options>
      -h                                **print all framework options usage**
      -genOut                           generate .out file if not exist
      -forceGenOut                      delete and generate .out file if not exist
+     -parallel                         run tests using specified threads
+     -randomOrder                      run tests in a random order
+     -times                            rum tests {times} times
 
   Eg.
     $0                                 build regression test framework and run all suite which in default group


### PR DESCRIPTION
We generate groovy files from sql cases and run the generated groovy
file. This way, we can just put sql cases, then framework handles
left work.

# Proposed changes

Issue Number: close #xxx

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
