### PR TITLE
[fix](dynamic-partition) fix bug that can not set "dynamic_partition.replication_allocation" property

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/TableProperty.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/TableProperty.java
@@ -149,6 +149,7 @@ public class TableProperty implements Writable {
 
     public void modifyTableProperties(Map<String, String> modifyProperties) {
         properties.putAll(modifyProperties);
+        removeDuplicateReplicaNumProperty();
     }
 
     public void modifyDataSortInfoProperties(DataSortInfo dataSortInfo) {
@@ -237,7 +238,18 @@ public class TableProperty implements Writable {
                         ReplicaAllocation.DEFAULT_ALLOCATION.toCreateStmt());
             }
         }
+        tableProperty.removeDuplicateReplicaNumProperty();
         tableProperty.buildReplicaAllocation();
         return tableProperty;
+    }
+
+    // For some historical reason, both "dynamic_partition.replication_num" and "dynamic_partition.replication_allocation"
+    // may be exist in "properties". we need remove the "dynamic_partition.replication_num", or it will always replace
+    // the "dynamic_partition.replication_allocation", result in unable to set "dynamic_partition.replication_allocation".
+    private void removeDuplicateReplicaNumProperty() {
+        if (properties.containsKey(DynamicPartitionProperty.REPLICATION_NUM)
+                && properties.containsKey(DynamicPartitionProperty.REPLICATION_ALLOCATION)) {
+            properties.remove(DynamicPartitionProperty.REPLICATION_NUM);
+        }
     }
 }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #8472 

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (No)
2. Has unit tests been added: (No Need)
3. Has document been added or modified: (No Need)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
