### PR TITLE
[fix]Need to set the size after realloc in `Field::agg_update`

### DIFF
--- a/be/src/olap/field.h
+++ b/be/src/olap/field.h
@@ -91,6 +91,7 @@ public:
             if (dst_slice->size < src_slice->size) {
                 *_long_text_buf = static_cast<char*>(realloc(*_long_text_buf, src_slice->size));
                 dst_slice->data = *_long_text_buf;
+                dst_slice->size = src_slice->size;
             }
         }
         _agg_info->update(dest, src, mem_pool);


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

The size of slice was not updated after reallocating the data ptr.

## Checklist(Required)

1. Does it affect the original behavior: (No)
2. Has unit tests been added: (No Need)
3. Has document been added or modified: (No Need)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (Yes)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
