### PR TITLE
[fix](storage)fix bitmap wrong result in storage layer

### DIFF
--- a/be/src/vec/columns/column_complex.h
+++ b/be/src/vec/columns/column_complex.h
@@ -63,11 +63,11 @@ public:
     }
 
     void insert_many_binary_data(char* data_array, uint32_t* len_array, uint32_t* start_offset_array, size_t num) override {
-        resize(num);
         if constexpr (std::is_same_v<T, BitmapValue>) {
             for (size_t i = 0; i < num; i++) {
                 uint32_t len = len_array[i];
                 uint32_t start_offset = start_offset_array[i];
+                insert_default();
                 BitmapValue* pvalue = &get_element(size() - 1);
                 if (len != 0) {
                     BitmapValue value;
@@ -81,6 +81,7 @@ public:
             for (size_t i = 0; i < num; i++) {
                 uint32_t len = len_array[i];
                 uint32_t start_offset = start_offset_array[i];
+                insert_default();
                 HyperLogLog* pvalue = &get_element(size() - 1);
                 if (len != 0) {
                     HyperLogLog value;


### PR DESCRIPTION
# Proposed changes
Fix a bug when query bitmap return wrong result, even the simplest query. 
Such as
```
CREATE TABLE `pv_bitmap_fix2` (
`dt` int(11) NULL COMMENT "",
`page` varchar(10) NULL COMMENT "",
`user_id_bitmap` bitmap BITMAP_UNION NULL COMMENT ""
) ENGINE=OLAP 
AGGREGATE KEY(`dt`, `page`) 
COMMENT "OLAP" DISTRIBUTED BY HASH(`dt`) BUCKETS 2
PROPERTIES (
"replication_allocation" = "tag.location.default: 1",
"in_memory" = "false",
"storage_format" = "V2"
)

Insert any hundreds of rows of data

select count(distinct user_id_bitmap) from pv_bitmap_fix2

the result is wrong
```
This is a bug of vectorization of storage layer.


## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (No)
2. Has unit tests been added: (No)
3. Has document been added or modified: (No)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
