### PR TITLE
[improvement](vectorized) Make bloom filter predicate run short-circuit logic

### DIFF
--- a/be/src/olap/bloom_filter_predicate.h
+++ b/be/src/olap/bloom_filter_predicate.h
@@ -65,6 +65,8 @@ public:
 
     void evaluate(vectorized::IColumn& column, uint16_t* sel, uint16_t* size) const override;
 
+    bool is_bloom_filter_predicate() override { return true; }
+
 private:
     std::shared_ptr<IBloomFilterFuncBase> _filter;
     SpecificFilter* _specific_filter; // owned by _filter

--- a/be/src/olap/column_predicate.h
+++ b/be/src/olap/column_predicate.h
@@ -71,6 +71,8 @@ public:
 
     virtual bool is_in_predicate() { return false; }
 
+    virtual bool is_bloom_filter_predicate() { return false; }
+
 protected:
     uint32_t _column_id;
     bool _opposite;

--- a/be/src/olap/rowset/segment_v2/segment_iterator.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.cpp
@@ -613,7 +613,9 @@ void SegmentIterator::_vec_init_lazy_materialization() {
             _is_pred_column[cid] = true;
             pred_column_ids.insert(cid);
 
-            if (type == OLAP_FIELD_TYPE_VARCHAR || type == OLAP_FIELD_TYPE_CHAR || type == OLAP_FIELD_TYPE_STRING || predicate->is_in_predicate()) {
+            if (type == OLAP_FIELD_TYPE_VARCHAR || type == OLAP_FIELD_TYPE_CHAR
+                || type == OLAP_FIELD_TYPE_STRING || predicate->is_in_predicate()
+                || predicate->is_bloom_filter_predicate()) {
                 short_cir_pred_col_id_set.insert(cid);
                 _short_cir_eval_predicate.push_back(predicate);
                 _is_all_column_basic_type = false;


### PR DESCRIPTION
# Proposed changes

Issue Number: close #8474 

## Problem Summary:

The current BloomFilter runs vectorization predicate evaluate, but `evaluate_vec` interface is not implemented, so the RuntimeFilter does not play a role after it is pushed down to the storage layer.
And BF predicate computation cannot be automatically vectorized, thus making BloomFilter run short-circuit logic.

For SSB Q2.1，`enable_storage_vectorization = true;`
```
test before impl:
- Total: 36s164ms
- RowsVectorPredFiltered: 0
- RealRuntimeFilterType: bloomfilter
- HasPushDownToEngine: true

test after impl:
- Total: 2s345ms
- RowsVectorPredFiltered: 595.247102M (595247102)
- RealRuntimeFilterType: bloomfilter
- HasPushDownToEngine: true
```


## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
