### PR TITLE
[fix] fix some UT compile or run failed cases

### DIFF
--- a/be/src/exprs/bitmap_function.cpp
+++ b/be/src/exprs/bitmap_function.cpp
@@ -156,14 +156,16 @@ void read_from(const char** src, StringValue* result) {
 } // namespace detail
 
 static StringVal serialize(FunctionContext* ctx, BitmapValue* value) {
-    BitmapValue empty_bitmap;
     if (!value) {
-        value = &empty_bitmap;
+        BitmapValue empty_bitmap;
+        StringVal result(ctx, empty_bitmap.getSizeInBytes());
+        empty_bitmap.write((char*)result.ptr);
+        return result;
+    } else {
+        StringVal result(ctx, value->getSizeInBytes());
+        value->write((char*)result.ptr);
+        return result;
     }
-
-    StringVal result(ctx, value->getSizeInBytes());
-    value->write((char*)result.ptr);
-    return result;
 }
 
 // Calculate the intersection of two or more bitmaps

--- a/be/src/exprs/bitmap_function.cpp
+++ b/be/src/exprs/bitmap_function.cpp
@@ -156,6 +156,11 @@ void read_from(const char** src, StringValue* result) {
 } // namespace detail
 
 static StringVal serialize(FunctionContext* ctx, BitmapValue* value) {
+    BitmapValue empty_bitmap;
+    if (!value) {
+        value = &empty_bitmap;
+    }
+
     StringVal result(ctx, value->getSizeInBytes());
     value->write((char*)result.ptr);
     return result;

--- a/be/src/olap/tablet_schema.h
+++ b/be/src/olap/tablet_schema.h
@@ -144,7 +144,7 @@ public:
     inline bool has_sequence_col() const { return _sequence_col_idx != -1; }
     inline int32_t sequence_col_idx() const { return _sequence_col_idx; }
     vectorized::Block create_block(const std::vector<uint32_t>& return_columns,
-            const std::unordered_set<uint32_t>* tablet_columns_need_convert_null) const;
+            const std::unordered_set<uint32_t>* tablet_columns_need_convert_null = nullptr) const;
 
 private:
     // Only for unit test

--- a/be/test/olap/delta_writer_test.cpp
+++ b/be/test/olap/delta_writer_test.cpp
@@ -367,7 +367,7 @@ TEST_F(TestDeltaWriter, open) {
     load_id.set_hi(0);
     load_id.set_lo(0);
     WriteRequest write_req = {10003, 270068375, WriteType::LOAD, 20001,
-                              30001, load_id,   false,           tuple_desc};
+                              30001, load_id, tuple_desc};
     DeltaWriter* delta_writer = nullptr;
     DeltaWriter::open(&write_req, k_mem_tracker, &delta_writer);
     ASSERT_NE(delta_writer, nullptr);
@@ -401,7 +401,7 @@ TEST_F(TestDeltaWriter, write) {
     load_id.set_hi(0);
     load_id.set_lo(0);
     WriteRequest write_req = {10004, 270068376,  WriteType::LOAD,       20002, 30002, load_id,
-                              false, tuple_desc, &(tuple_desc->slots())};
+                              tuple_desc, &(tuple_desc->slots())};
     DeltaWriter* delta_writer = nullptr;
     DeltaWriter::open(&write_req, k_mem_tracker, &delta_writer);
     ASSERT_NE(delta_writer, nullptr);
@@ -527,7 +527,7 @@ TEST_F(TestDeltaWriter, sequence_col) {
     load_id.set_hi(0);
     load_id.set_lo(0);
     WriteRequest write_req = {10005, 270068377,  WriteType::LOAD,       20003, 30003, load_id,
-                              false, tuple_desc, &(tuple_desc->slots())};
+                              tuple_desc, &(tuple_desc->slots())};
     DeltaWriter* delta_writer = nullptr;
     DeltaWriter::open(&write_req, k_mem_tracker, &delta_writer);
     ASSERT_NE(delta_writer, nullptr);

--- a/be/test/util/arrow/arrow_row_batch_test.cpp
+++ b/be/test/util/arrow/arrow_row_batch_test.cpp
@@ -28,6 +28,7 @@
 #include <arrow/json/api.h>
 #include <arrow/json/test_common.h>
 #include <arrow/pretty_print.h>
+#include <arrow/record_batch.h>
 #include <arrow/result.h>
 
 #include "common/object_pool.h"


### PR DESCRIPTION
…ck to make it compatible

# Proposed changes

Issue Number: close #8488

## Problem Summary:

Describe the overview of changes.
1. Add default value for TabletSchema::create_block, to make it forward compatible
2. fix UT compile error in file be/test/olap/delta_writer_test.cpp
3. serialize consider nullptr in be/src/exprs/bitmap_function.cpp

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
4. Has unit tests been added: (Yes/No/No Need)
5. Has document been added or modified: (Yes/No/No Need)
6. Does it need to update dependencies: (Yes/No)
7. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
