### PR TITLE
CalcPageLenForRow return void rather than always Status::Ok

### DIFF
--- a/be/src/runtime/buffered_tuple_stream3.cc
+++ b/be/src/runtime/buffered_tuple_stream3.cc
@@ -373,9 +373,8 @@ Status BufferedTupleStream3::NewWritePage(int64_t page_len) noexcept {
     return Status::OK();
 }
 
-Status BufferedTupleStream3::CalcPageLenForRow(int64_t row_size, int64_t* page_len) {
+void BufferedTupleStream3::CalcPageLenForRow(int64_t row_size, int64_t* page_len) {
     *page_len = std::max(default_page_len_, BitUtil::RoundUpToPowerOfTwo(row_size));
-    return Status::OK();
 }
 
 Status BufferedTupleStream3::AdvanceWritePage(int64_t row_size, bool* got_reservation) noexcept {
@@ -384,10 +383,7 @@ Status BufferedTupleStream3::AdvanceWritePage(int64_t row_size, bool* got_reserv
 
     int64_t page_len;
 
-    Status status = CalcPageLenForRow(row_size, &page_len);
-    if (!status.ok()) {
-        return status;
-    }
+    CalcPageLenForRow(row_size, &page_len);
 
     // Reservation may have been saved for the next write page, e.g. by PrepareForWrite()
     // if the stream is empty.
@@ -429,7 +425,7 @@ Status BufferedTupleStream3::AdvanceWritePage(int64_t row_size, bool* got_reserv
     }
     ResetWritePage();
     //RETURN_IF_ERROR(NewWritePage(page_len));
-    status = NewWritePage(page_len);
+    Status status = NewWritePage(page_len);
     if (UNLIKELY(!status.ok())) {
         return status;
     }

--- a/be/src/runtime/buffered_tuple_stream3.h
+++ b/be/src/runtime/buffered_tuple_stream3.h
@@ -562,7 +562,7 @@ private:
 
     /// Determines what page size is needed to fit a row of 'row_size' bytes.
     /// Returns an error if the row cannot fit in a page.
-    Status CalcPageLenForRow(int64_t row_size, int64_t* page_len);
+    void CalcPageLenForRow(int64_t row_size, int64_t* page_len);
 
     /// Wrapper around NewWritePage() that allocates a new write page that fits a row of
     /// 'row_size' bytes. Increases reservation if needed to allocate the next page.


### PR DESCRIPTION
Thus we can remove branches depending on CalcPageLenForRow.

# Proposed changes

Issue Number: close #xxx

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
