### PR TITLE
[fix](connect)(cpp) fix the condition of breaking for loop in functio…

### DIFF
--- a/samples/connect/cpp/doris_client.cpp
+++ b/samples/connect/cpp/doris_client.cpp
@@ -74,7 +74,7 @@ bool DorisClient::exec(const string& sql) {
         std::cout << "Query result:" << std::endl;
         for (int i = 0; i < num_rows; i++) {
             _row = mysql_fetch_row(_result);
-            if (_row < 0) {
+            if (_row == NULL) {
                 break;
             }
             for (int j = 0; j < num_fields; j++) {

--- a/samples/connect/cpp/doris_client.cpp
+++ b/samples/connect/cpp/doris_client.cpp
@@ -74,7 +74,7 @@ bool DorisClient::exec(const string& sql) {
         std::cout << "Query result:" << std::endl;
         for (int i = 0; i < num_rows; i++) {
             _row = mysql_fetch_row(_result);
-            if (_row == NULL) {
+            if (_row == nullptr) {
                 break;
             }
             for (int j = 0; j < num_fields; j++) {


### PR DESCRIPTION
# Proposed changes

Issue Number: nothing closed.

## Problem Summary:

In the cpp version of the connect in samples, where the type of the field `_row` in the class DorisClient is `char **`, so in the for loop, _row would never be smaller than zero.

## Checklist(Required)

1. Does it affect the original behavior: No
2. Has unit tests been added: No
3. Has document been added or modified: No
4. Does it need to update dependencies: No
5. Are there any changes that cannot be rolled back: No

## Further comments

Nothing else.
