### PR TITLE
[fix] Fix may coredump when check if all rowset is beta-rowset of a tablet

### DIFF
--- a/be/src/olap/tablet.h
+++ b/be/src/olap/tablet.h
@@ -246,8 +246,7 @@ public:
     double calculate_scan_frequency();
 
     Status prepare_compaction_and_calculate_permits(CompactionType compaction_type,
-                                                    TabletSharedPtr tablet,
-                                                    int64_t* permits);
+                                                    TabletSharedPtr tablet, int64_t* permits);
     void execute_compaction(CompactionType compaction_type);
     void reset_compaction(CompactionType compaction_type);
 
@@ -263,7 +262,10 @@ public:
         return _cumulative_compaction_policy;
     }
 
-    inline bool all_beta() const { return _tablet_meta->all_beta(); }
+    inline bool all_beta() const {
+        ReadLock rdlock(_meta_lock);
+        return _tablet_meta->all_beta();
+    }
 
 private:
     OLAPStatus _init_once_action();
@@ -274,7 +276,8 @@ private:
     // Returns:
     // version: the max continuous version from beginning
     // max_version: the max version of this tablet
-    void _max_continuous_version_from_beginning_unlocked(Version* version, Version* max_version) const;
+    void _max_continuous_version_from_beginning_unlocked(Version* version,
+                                                         Version* max_version) const;
     RowsetSharedPtr _rowset_with_largest_size();
     /// Delete stale rowset by version. This method not only delete the version in expired rowset map,
     /// but also delete the version in rowset meta vector.


### PR DESCRIPTION
# Proposed changes

Fix may coredump when check if all rowset is beta-rowset of a tablet
## Problem Summary:

core dump like
```
*** Aborted at 1647468467 (unix time) try "date -d @1647468467" if you are using GNU date ***
PC: @     0x5555576940b0 doris::OlapScanNode::start_scan_thread()
*** SIGSEGV (@0x84) received by PID 39139 (TID 0x7ffee8388700) from PID 132; stack trace: ***
    @     0x555558926212 google::(anonymous namespace)::FailureSignalHandler()
    @     0x7ffff753d400 (unknown)
    @     0x5555576940b0 doris::OlapScanNode::start_scan_thread()
    @     0x555557696e1b doris::OlapScanNode::start_scan()
    @     0x55555769737d doris::OlapScanNode::get_next()
    @     0x5555570784f5 doris::PlanFragmentExecutor::get_next_internal()
    @     0x55555707d24c doris::PlanFragmentExecutor::open_internal()
    @     0x55555707e72f doris::PlanFragmentExecutor::open()
    @     0x555556ffab95 doris::FragmentExecState::execute()
    @     0x555556fff0ed doris::FragmentMgr::_exec_actual()
    @     0x5555570088ec std::_Function_handler<>::_M_invoke()
    @     0x55555719a099 doris::ThreadPool::dispatch_thread()
    @     0x555557193a8f doris::Thread::supervise_thread()
    @     0x7ffff72f2ea5 start_thread
    @     0x7ffff76058dd __clone
    @                0x0 (unknown)
```

## Checklist(Required)

1. Does it affect the original behavior: (No)
2. Has unit tests been added: (No Need)
3. Has document been added or modified: (No Need)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
