### PR TITLE
[Fix] Fix bug that __set_ missing for thrift optional fields in be

### DIFF
--- a/be/src/olap/tablet_manager.cpp
+++ b/be/src/olap/tablet_manager.cpp
@@ -906,9 +906,9 @@ OLAPStatus TabletManager::build_all_report_tablets_info(
                 TTabletStat t_tablet_stat;
                 const auto& tablet_info = t_tablet.tablet_infos[0];
                 t_tablet_stat.tablet_id = tablet_info.tablet_id;
-                t_tablet_stat.data_size = tablet_info.data_size;
-                t_tablet_stat.row_num = tablet_info.row_count;
-                t_tablet_stat.version_count = tablet_info.version_count;
+                t_tablet_stat.__set_data_size(tablet_info.data_size);
+                t_tablet_stat.__set_row_num(tablet_info.row_count);
+                t_tablet_stat.__set_version_count(tablet_info.version_count);
                 local_cache->emplace_back(std::move(t_tablet_stat));
             }
         }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #8506 

## Problem Summary:

Introduced from #8146 

## Checklist(Required)

1. Does it affect the original behavior: (No)
2. Has unit tests been added: (No Need)
3. Has document been added or modified: (No Need)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
