### PR TITLE
[Bug] fix bug in WindowFunctionLastData::data, it keeps the first dat…

### DIFF
--- a/be/src/vec/aggregate_functions/aggregate_function_window.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_window.h
@@ -358,9 +358,6 @@ struct WindowFunctionLastData : Data {
         this->set_value(columns, frame_end - 1);
     }
     void add(int64_t row, const IColumn** columns) {
-        if (this->has_set_value()) {
-            return;
-        }
         this->set_value(columns, row);
     }
     static const char* name() { return "last_value"; }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

WindowFunctionLastData::add should keep the last value, but current implementation keeps the first one. Obviously, this code is copied from WindowFunctionFirstData::add.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
