### PR TITLE
[Bug] Fix coredump of stddev function

### DIFF
--- a/be/src/vec/aggregate_functions/aggregate_function_stddev.cpp
+++ b/be/src/vec/aggregate_functions/aggregate_function_stddev.cpp
@@ -90,11 +90,14 @@ AggregateFunctionPtr create_aggregate_function_stddev_pop(const std::string& nam
 
 void register_aggregate_function_stddev_variance(AggregateFunctionSimpleFactory& factory) {
     factory.register_function("variance_samp", create_aggregate_function_variance_samp<false>);
-    factory.register_function("variance", create_aggregate_function_variance_pop<false>);
+    factory.register_function("variance_samp", create_aggregate_function_variance_samp<false>, true);
+    factory.register_function("stddev_samp", create_aggregate_function_stddev_samp<true>);
+    factory.register_function("stddev_samp", create_aggregate_function_stddev_samp<true>, true);
     factory.register_alias("variance_samp", "var_samp");
+
+    factory.register_function("variance", create_aggregate_function_variance_pop<false>);
     factory.register_alias("variance", "var_pop");
     factory.register_alias("variance", "variance_pop");
-    factory.register_function("stddev_samp", create_aggregate_function_stddev_samp<true>);
     factory.register_function("stddev", create_aggregate_function_stddev_pop<true>);
     factory.register_alias("stddev", "stddev_pop");
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/AggregateFunction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/AggregateFunction.java
@@ -51,6 +51,9 @@ public class AggregateFunction extends Function {
     public static ImmutableSet<String> NOT_NULLABLE_AGGREGATE_FUNCTION_NAME_SET =
             ImmutableSet.of("row_number", "rank", "dense_rank", "hll_union_agg", "hll_union", "bitmap_union", "bitmap_intersect", FunctionSet.COUNT, "ndv", FunctionSet.BITMAP_UNION_INT, FunctionSet.BITMAP_UNION_COUNT, "ndv_no_finalize");
 
+    public static ImmutableSet<String> ALWAYS_NULLABLE_AGGREGATE_FUNCTION_NAME_SET =
+            ImmutableSet.of("stddev_samp", "variance_samp", "var_samp");
+
     // Set if different from retType_, null otherwise.
     private Type intermediateType;
 
@@ -150,7 +153,8 @@ public class AggregateFunction extends Function {
                              String removeFnSymbol, String finalizeFnSymbol, boolean vectorized) {
         // only `count` is always not nullable, other aggregate function is always nullable
         super(fnName, argTypes, retType, hasVarArgs, vectorized,
-                AggregateFunction.NOT_NULLABLE_AGGREGATE_FUNCTION_NAME_SET.contains(fnName.getFunction()) ? NullableMode.ALWAYS_NOT_NULLABLE : NullableMode.DEPEND_ON_ARGUMENT);
+                AggregateFunction.NOT_NULLABLE_AGGREGATE_FUNCTION_NAME_SET.contains(fnName.getFunction()) ? NullableMode.ALWAYS_NOT_NULLABLE :
+                AggregateFunction.ALWAYS_NULLABLE_AGGREGATE_FUNCTION_NAME_SET.contains(fnName.getFunction()) ? NullableMode.ALWAYS_NULLABLE : NullableMode.DEPEND_ON_ARGUMENT);
         setLocation(location);
         this.intermediateType = (intermediateType.equals(retType)) ? null : intermediateType;
         this.updateFnSymbol = updateFnSymbol;

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/FunctionSet.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/FunctionSet.java
@@ -1665,6 +1665,7 @@ public class FunctionSet<min_initIN9doris_udf12DecimalV2ValEEEvPNS2_15FunctionCo
                         null,
                         prefix + STDDEV_POP_FINALIZE_SYMBOL.get(t),
                         false, false, false));
+
                 //vec stddev stddev_samp stddev_pop
                 addBuiltin(AggregateFunction.createBuiltin("stddev",
                         Lists.newArrayList(t), STDDEV_RETTYPE_SYMBOL.get(t), t,


### PR DESCRIPTION
# Proposed changes

Issue Number: close #8542 

## Problem Summary:

This is only a temporary fix its performance is not ideal. Finally, we need to reconstruct the functions of `stddev` and delete the interface of `insert_to_null_default ()` .

CC @zhangstar333 

## Checklist(Required)

1. Does it affect the original behavior: (No)
2. Has unit tests been added: (No Need)
3. Has document been added or modified: (No Need)
4. Does it need to update dependencies: (Yes)
5. Are there any changes that cannot be rolled back: (Yes)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
