### PR TITLE
fix sort spill memory limit

### DIFF
--- a/be/src/runtime/buffered_block_mgr2.h
+++ b/be/src/runtime/buffered_block_mgr2.h
@@ -383,6 +383,10 @@ public:
         { return _writes_issued; }
     }
 
+    bool should_spill() {
+        return (_mem_tracker->consumption() - _free_io_buffers_bytes) > _mem_tracker->limit() / 2;
+    }
+
 private:
     friend class Client;
 
@@ -553,6 +557,7 @@ private:
     // (!block->_is_pinned  && !block->_in_write  && !_unpinned_blocks.Contains(block)).
     // All of these buffers are io sized.
     InternalQueue<BufferDescriptor> _free_io_buffers;
+    std::atomic<size_t> _free_io_buffers_bytes = 0;
 
     // All allocated io-sized buffers.
     std::list<BufferDescriptor*> _all_io_buffers;

--- a/be/src/runtime/runtime_state.cpp
+++ b/be/src/runtime/runtime_state.cpp
@@ -279,7 +279,7 @@ Status RuntimeState::init_buffer_poolstate() {
 Status RuntimeState::create_block_mgr() {
     DCHECK(_block_mgr2.get() == nullptr);
 
-    int64_t block_mgr_limit = _query_mem_tracker->limit();
+    int64_t block_mgr_limit = _query_mem_tracker->limit() / 2;
     if (block_mgr_limit < 0) {
         block_mgr_limit = std::numeric_limits<int64_t>::max();
     }

--- a/be/src/runtime/spill_sorter.cc
+++ b/be/src/runtime/spill_sorter.cc
@@ -1100,7 +1100,7 @@ Status SpillSorter::add_batch(RowBatch* batch) {
                     _unsorted_run->add_batch<false>(batch, cur_batch_index, &num_processed));
         }
         cur_batch_index += num_processed;
-        if (cur_batch_index < batch->num_rows()) {
+        if (cur_batch_index < batch->num_rows() || _block_mgr->should_spill()) {
             // The current run is full. Sort it and begin the next one.
             RETURN_IF_ERROR(sort_run());
             RETURN_IF_ERROR(_sorted_runs.back()->unpin_all_blocks());


### PR DESCRIPTION

# Proposed changes

Issue Number: NA

## Problem Summary:

Sort spill does not work since spill is triggered when memory limit exceed but some more memory need to be allocated during spilling.

This pr fix sort spill memory limit by:
1.change block_mgr_limit from exec_mem_limit to half of block_mgr_limit
2.trigger spill when 1/2 of block_mgr_limit is used, implemented in should_spill() function
## Checklist(Required)

1. Does it affect the original behavior: (No)
2. Has unit tests been added: (No)
3. Has document been added or modified: (No Need)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
