### PR TITLE
[Bug][Vectorized] fix column_dictionary compile error on clang because inconsistent-missing-override

### DIFF
--- a/be/src/vec/columns/column_dictionary.h
+++ b/be/src/vec/columns/column_dictionary.h
@@ -17,8 +17,9 @@
 
 #pragma once
 
-#include <algorithm>
 #include <parallel_hashmap/phmap.h>
+
+#include <algorithm>
 
 #include "gutil/hash/string_hash.h"
 #include "olap/decimal12.h"
@@ -169,20 +170,20 @@ public:
 
     // it's impossable to use ComplexType as key , so we don't have to implemnt them
     [[noreturn]] StringRef serialize_value_into_arena(size_t n, Arena& arena,
-                                                      char const*& begin) const {
+                                                      char const*& begin) const override {
         LOG(FATAL) << "serialize_value_into_arena not supported in ColumnDictionary";
     }
 
-    [[noreturn]] const char* deserialize_and_insert_from_arena(const char* pos) {
+    [[noreturn]] const char* deserialize_and_insert_from_arena(const char* pos) override {
         LOG(FATAL) << "deserialize_and_insert_from_arena not supported in ColumnDictionary";
     }
 
     [[noreturn]] int compare_at(size_t n, size_t m, const IColumn& rhs,
-                                int nan_direction_hint) const {
+                                int nan_direction_hint) const override {
         LOG(FATAL) << "compare_at not supported in ColumnDictionary";
     }
 
-    void get_extremes(Field& min, Field& max) const {
+    void get_extremes(Field& min, Field& max) const override {
         LOG(FATAL) << "get_extremes not supported in ColumnDictionary";
     }
 
@@ -321,13 +322,16 @@ public:
             }
 
             if (lower) {
-                return std::lower_bound(dict_data.begin(), dict_data.end(), value) - dict_data.begin() - eq;
+                return std::lower_bound(dict_data.begin(), dict_data.end(), value) -
+                       dict_data.begin() - eq;
             } else {
-                return std::upper_bound(dict_data.begin(), dict_data.end(), value) - dict_data.begin() + eq;
+                return std::upper_bound(dict_data.begin(), dict_data.end(), value) -
+                       dict_data.begin() + eq;
             }
         }
 
-        inline phmap::flat_hash_set<T> find_codes(const phmap::flat_hash_set<StringValue>& values) const {
+        inline phmap::flat_hash_set<T> find_codes(
+                const phmap::flat_hash_set<StringValue>& values) const {
             phmap::flat_hash_set<T> code_set;
             for (const auto& value : values) {
                 auto it = inverted_index.find(value);


### PR DESCRIPTION
# Proposed changes

Issue Number: close #8551

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
