### PR TITLE
Replace null with empty String in master proxy result set.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ShowResultSet.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ShowResultSet.java
@@ -21,6 +21,7 @@ import com.google.common.collect.Lists;
 import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.PrimitiveType;
 import org.apache.doris.catalog.ScalarType;
+import org.apache.doris.common.FeConstants;
 import org.apache.doris.thrift.TColumnDefinition;
 import org.apache.doris.thrift.TShowResultSet;
 import org.apache.doris.thrift.TShowResultSetMetaData;
@@ -65,7 +66,7 @@ public class ShowResultSet extends AbstractResultSet {
         for (int i = 0; i < resultRows.size(); i ++) {
             ArrayList<String> list = Lists.newArrayList();
             for (int j = 0; j < resultRows.get(i).size(); j ++) {
-                list.add(resultRows.get(i).get(j));
+                list.add(resultRows.get(i).get(j) == null ? FeConstants.null_string : resultRows.get(i).get(j));
             }
             set.resultRows.add(list);
         }    


### PR DESCRIPTION
Replace null with empty String in master proxy result set. This is to fix NPE when the master proxy result set contains a null item. The NPE could cause the thrift server crash and fail to send the result back to the client which is a follower or an observer fe.

## Problem Summary:

Suppose we have 3 follower FEs, say A, B and C. A is currently the master. If B becomes the master after A crashes, we will get the following error when we run "show frontends" command in the mysql client with connection to C:
`ERROR 1105 (HY000): TTransportException, msg: Socket is closed by peer.`
which is caused by the thrift server side NPE (ResultSet couldn't contain null):
```
2022-03-21 15:55:13 ERROR TThreadPoolServer:321 - Error occurred during processing of message.
java.lang.NullPointerException
	at org.apache.thrift.protocol.TBinaryProtocol.writeString(TBinaryProtocol.java:225)
	at org.apache.doris.thrift.TShowResultSet$TShowResultSetStandardScheme.write(TShowResultSet.java:488)
	at org.apache.doris.thrift.TShowResultSet$TShowResultSetStandardScheme.write(TShowResultSet.java:409)
	at org.apache.doris.thrift.TShowResultSet.write(TShowResultSet.java:346)
	at org.apache.doris.thrift.TMasterOpResult$TMasterOpResultStandardScheme.write(TMasterOpResult.java:637)
	at org.apache.doris.thrift.TMasterOpResult$TMasterOpResultStandardScheme.write(TMasterOpResult.java:562)
	at org.apache.doris.thrift.TMasterOpResult.write(TMasterOpResult.java:480)
	at org.apache.doris.thrift.FrontendService$forward_result$forward_resultStandardScheme.write(FrontendService.java:14456)
	at org.apache.doris.thrift.FrontendService$forward_result$forward_resultStandardScheme.write(FrontendService.java:14418)
	at org.apache.doris.thrift.FrontendService$forward_result.write(FrontendService.java:14369)
	at org.apache.thrift.ProcessFunction.process(ProcessFunction.java:58)
	at org.apache.thrift.TBaseProcessor.process(TBaseProcessor.java:38)
	at org.apache.thrift.server.TThreadPoolServer$WorkerProcess.run(TThreadPoolServer.java:313)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)
```

## Checklist(Required)

1. Does it affect the original behavior: No
2. Has unit tests been added: No Need
3. Has document been added or modified: No Need
4. Does it need to update dependencies: No
5. Are there any changes that cannot be rolled back: No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
