### PR TITLE
[refactor](schema_hash) remove schema_hash since every tablet id in be is unique

### DIFF
--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -976,11 +976,9 @@ void TaskWorkerPool::_storage_medium_migrate_worker_thread_callback() {
 OLAPStatus TaskWorkerPool::_check_migrate_request(const TStorageMediumMigrateReq& req,
                                                   TabletSharedPtr& tablet, DataDir** dest_store) {
     int64_t tablet_id = req.tablet_id;
-    int32_t schema_hash = req.schema_hash;
-    tablet = StorageEngine::instance()->tablet_manager()->get_tablet(tablet_id, schema_hash);
+    tablet = StorageEngine::instance()->tablet_manager()->get_tablet(tablet_id);
     if (tablet == nullptr) {
-        LOG(WARNING) << "can't find tablet. tablet_id= " << tablet_id
-                     << " schema_hash=" << schema_hash;
+        LOG(WARNING) << "can't find tablet. tablet_id= " << tablet_id;
         return OLAP_ERR_TABLE_NOT_FOUND;
     }
 
@@ -1551,10 +1549,9 @@ void TaskWorkerPool::_move_dir_thread_callback() {
 Status TaskWorkerPool::_move_dir(const TTabletId tablet_id, const TSchemaHash schema_hash,
                                       const std::string& src, int64_t job_id, bool overwrite) {
     TabletSharedPtr tablet =
-            StorageEngine::instance()->tablet_manager()->get_tablet(tablet_id, schema_hash);
+            StorageEngine::instance()->tablet_manager()->get_tablet(tablet_id);
     if (tablet == nullptr) {
-        LOG(INFO) << "failed to get tablet. tablet_id:" << tablet_id
-                  << ", schema hash:" << schema_hash;
+        LOG(INFO) << "failed to get tablet. tablet_id:" << tablet_id;
         return Status::InvalidArgument("Could not find tablet");
     }
 

--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -378,8 +378,7 @@ void TaskWorkerPool::_create_tablet_worker_thread_callback() {
         } else {
             ++_s_report_version;
             // get path hash of the created tablet
-            TabletSharedPtr tablet = StorageEngine::instance()->tablet_manager()->get_tablet(
-                    create_tablet_req.tablet_id, create_tablet_req.tablet_schema.schema_hash);
+            TabletSharedPtr tablet = StorageEngine::instance()->tablet_manager()->get_tablet(create_tablet_req.tablet_id);
             DCHECK(tablet != nullptr);
             TTabletInfo tablet_info;
             tablet_info.tablet_id = tablet->table_id();
@@ -433,7 +432,7 @@ void TaskWorkerPool::_drop_tablet_worker_thread_callback() {
         TStatus task_status;
         string err;
         TabletSharedPtr dropped_tablet = StorageEngine::instance()->tablet_manager()->get_tablet(
-                drop_tablet_req.tablet_id, drop_tablet_req.schema_hash, false, &err);
+                drop_tablet_req.tablet_id, false, &err);
         if (dropped_tablet != nullptr) {
             OLAPStatus drop_status = StorageEngine::instance()->tablet_manager()->drop_tablet(
                     drop_tablet_req.tablet_id, drop_tablet_req.schema_hash);
@@ -824,7 +823,7 @@ void TaskWorkerPool::_update_tablet_meta_worker_thread_callback() {
 
         for (auto tablet_meta_info : update_tablet_meta_req.tabletMetaInfos) {
             TabletSharedPtr tablet = StorageEngine::instance()->tablet_manager()->get_tablet(
-                    tablet_meta_info.tablet_id, tablet_meta_info.schema_hash);
+                    tablet_meta_info.tablet_id);
             if (tablet == nullptr) {
                 LOG(WARNING) << "could not find tablet when update partition id"
                              << " tablet_id=" << tablet_meta_info.tablet_id

--- a/be/src/exec/olap_scan_node.cpp
+++ b/be/src/exec/olap_scan_node.cpp
@@ -771,8 +771,7 @@ Status OlapScanNode::start_scan_thread(RuntimeState* state) {
         auto tablet_id = scan_range->tablet_id;
         int32_t schema_hash = strtoul(scan_range->schema_hash.c_str(), nullptr, 10);
         std::string err;
-        TabletSharedPtr tablet = StorageEngine::instance()->tablet_manager()->get_tablet(
-                tablet_id, schema_hash, true, &err);
+        TabletSharedPtr tablet = StorageEngine::instance()->tablet_manager()->get_tablet(tablet_id, true, &err);
         if (tablet == nullptr) {
             std::stringstream ss;
             ss << "failed to get tablet: " << tablet_id << " with schema hash: " << schema_hash

--- a/be/src/exec/olap_scanner.cpp
+++ b/be/src/exec/olap_scanner.cpp
@@ -74,8 +74,7 @@ Status OlapScanner::prepare(
     _version = strtoul(scan_range.version.c_str(), nullptr, 10);
     {
         std::string err;
-        _tablet = StorageEngine::instance()->tablet_manager()->get_tablet(tablet_id, schema_hash,
-                                                                          true, &err);
+        _tablet = StorageEngine::instance()->tablet_manager()->get_tablet(tablet_id, true, &err);
         if (_tablet.get() == nullptr) {
             std::stringstream ss;
             ss << "failed to get tablet. tablet_id=" << tablet_id

--- a/be/src/http/action/compaction_action.cpp
+++ b/be/src/http/action/compaction_action.cpp
@@ -42,20 +42,17 @@ const static std::string HEADER_JSON = "application/json";
 bool CompactionAction::_is_compaction_running = false;
 std::mutex CompactionAction::_compaction_running_mutex;
 
-Status CompactionAction::_check_param(HttpRequest* req, uint64_t* tablet_id,
-                                      uint32_t* schema_hash) {
+Status CompactionAction::_check_param(HttpRequest* req, uint64_t* tablet_id) {
     std::string req_tablet_id = req->param(TABLET_ID_KEY);
-    std::string req_schema_hash = req->param(TABLET_SCHEMA_HASH_KEY);
-    if (req_tablet_id == "" && req_schema_hash == "") {
+    if (req_tablet_id == "") {
         return Status::OK();
     }
 
     try {
         *tablet_id = std::stoull(req_tablet_id);
-        *schema_hash = std::stoul(req_schema_hash);
     } catch (const std::exception& e) {
         return Status::InternalError(
-            strings::Substitute("convert tablet_id and schema_hash failed, $0", e.what()));
+            strings::Substitute("convert tablet_id failed, $0", e.what()));
     }
 
     return Status::OK();
@@ -64,16 +61,14 @@ Status CompactionAction::_check_param(HttpRequest* req, uint64_t* tablet_id,
 // for viewing the compaction status
 Status CompactionAction::_handle_show_compaction(HttpRequest* req, std::string* json_result) {
     uint64_t tablet_id = 0;
-    uint32_t schema_hash = 0;
-    RETURN_NOT_OK_STATUS_WITH_WARN(_check_param(req, &tablet_id, &schema_hash),
+    RETURN_NOT_OK_STATUS_WITH_WARN(_check_param(req, &tablet_id),
                                    "check param failed");
 
     TabletSharedPtr tablet =
-            StorageEngine::instance()->tablet_manager()->get_tablet(tablet_id, schema_hash);
+            StorageEngine::instance()->tablet_manager()->get_tablet(tablet_id);
     if (tablet == nullptr) {
         return Status::NotFound(
-            strings::Substitute("Tablet not found. tablet_id=$0, schema_hash=$1",
-                                tablet_id, schema_hash));
+            strings::Substitute("Tablet not found. tablet_id=$0", tablet_id));
     }
 
     tablet->get_compaction_status(json_result);
@@ -82,10 +77,9 @@ Status CompactionAction::_handle_show_compaction(HttpRequest* req, std::string* 
 
 Status CompactionAction::_handle_run_compaction(HttpRequest* req, std::string* json_result) {
     // 1. param check
-    // check req_tablet_id and req_schema_hash is not empty
+    // check req_tablet_id is not empty
     uint64_t tablet_id = 0;
-    uint32_t schema_hash = 0;
-    RETURN_NOT_OK_STATUS_WITH_WARN(_check_param(req, &tablet_id, &schema_hash),
+    RETURN_NOT_OK_STATUS_WITH_WARN(_check_param(req, &tablet_id),
                                    "check param failed");
 
     // check compaction_type equals 'base' or 'cumulative'
@@ -96,13 +90,12 @@ Status CompactionAction::_handle_run_compaction(HttpRequest* req, std::string* j
             strings::Substitute("The compaction type '$0' is not supported", compaction_type));
     }
 
-    // 2. fetch the tablet by tablet_id and schema_hash
+    // 2. fetch the tablet by tablet_id
     TabletSharedPtr tablet =
-            StorageEngine::instance()->tablet_manager()->get_tablet(tablet_id, schema_hash);
+            StorageEngine::instance()->tablet_manager()->get_tablet(tablet_id);
     if (tablet == nullptr) {
         return Status::NotFound(
-            strings::Substitute("Tablet not found. tablet_id=$0, schema_hash=$1",
-                                tablet_id, schema_hash));
+            strings::Substitute("Tablet not found. tablet_id=$0", tablet_id));
     }
 
     // 3. execute compaction task
@@ -146,27 +139,21 @@ Status CompactionAction::_handle_run_compaction(HttpRequest* req, std::string* j
 
 Status CompactionAction::_handle_run_status_compaction(HttpRequest* req, std::string* json_result) {
     uint64_t tablet_id = 0;
-    uint32_t schema_hash = 0;
 
-    // check req_tablet_id and req_schema_hash is not empty
-    RETURN_NOT_OK_STATUS_WITH_WARN(_check_param(req, &tablet_id, &schema_hash),
-                                   "check param failed");
-
+    // check req_tablet_id is not empty
+    RETURN_NOT_OK_STATUS_WITH_WARN(_check_param(req, &tablet_id),"check param failed");
 
     if (tablet_id == 0) {
         // overall compaction status
         RETURN_IF_ERROR(StorageEngine::instance()->get_compaction_status_json(json_result));
         return Status::OK();
     } else {
-        // fetch the tablet by tablet_id and schema_hash
-        TabletSharedPtr tablet =
-                StorageEngine::instance()->tablet_manager()->get_tablet(tablet_id, schema_hash);
-    
+        // fetch the tablet by tablet_id
+        TabletSharedPtr tablet = StorageEngine::instance()->tablet_manager()->get_tablet(tablet_id);
         if (tablet == nullptr) {
-            LOG(WARNING) << "invalid argument.tablet_id:" << tablet_id
-                         << ", schema_hash:" << schema_hash;
+            LOG(WARNING) << "invalid argument.tablet_id:" << tablet_id;
             return Status::InternalError(
-                    strings::Substitute("fail to get $0, $1", tablet_id, schema_hash));
+                    strings::Substitute("fail to get $0", tablet_id));
         }
     
         std::string json_template = R"({
@@ -174,8 +161,7 @@ Status CompactionAction::_handle_run_status_compaction(HttpRequest* req, std::st
             "run_status" : $0,
             "msg" : "$1",
             "tablet_id" : $2,
-            "schema_hash" : $3,
-            "compact_type" : "$4"
+            "compact_type" : "$3"
 })";
     
         std::string msg = "compaction task for this tablet is not running";
@@ -190,7 +176,7 @@ Status CompactionAction::_handle_run_status_compaction(HttpRequest* req, std::st
                 compaction_type = "cumulative";
                 run_status = 1;
                 *json_result = strings::Substitute(json_template, run_status, msg, tablet_id,
-                                                   schema_hash, compaction_type);
+                                                   compaction_type);
                 return Status::OK();
             }
         }
@@ -202,14 +188,12 @@ Status CompactionAction::_handle_run_status_compaction(HttpRequest* req, std::st
                 msg = "compaction task for this tablet is running";
                 compaction_type = "base";
                 run_status = 1;
-                *json_result = strings::Substitute(json_template, run_status, msg, tablet_id,
-                                                   schema_hash, compaction_type);
+                *json_result = strings::Substitute(json_template, run_status, msg, tablet_id, compaction_type);
                 return Status::OK();
             }
         }
         // not running any compaction
-        *json_result = strings::Substitute(json_template, run_status, msg, tablet_id, schema_hash,
-                                           compaction_type);
+        *json_result = strings::Substitute(json_template, run_status, msg, tablet_id, compaction_type);
         return Status::OK();
     }
 }

--- a/be/src/http/action/compaction_action.h
+++ b/be/src/http/action/compaction_action.h
@@ -64,8 +64,8 @@ private:
     /// fetch compaction running status
     Status _handle_run_status_compaction(HttpRequest* req, std::string* json_result);
 
-    /// check param and fetch tablet_id and schema_hash from req
-    Status _check_param(HttpRequest* req, uint64_t* tablet_id, uint32_t* schema_hash);
+    /// check param and fetch tablet_id from req
+    Status _check_param(HttpRequest* req, uint64_t* tablet_id);
 
     std::shared_ptr<CumulativeCompactionPolicy> _create_cumulative_compaction_policy();
 

--- a/be/src/http/action/meta_action.cpp
+++ b/be/src/http/action/meta_action.cpp
@@ -41,28 +41,23 @@ const static std::string HEADER_JSON = "application/json";
 Status MetaAction::_handle_header(HttpRequest* req, std::string* json_meta) {
     req->add_output_header(HttpHeaders::CONTENT_TYPE, HEADER_JSON.c_str());
     std::string req_tablet_id = req->param(TABLET_ID_KEY);
-    std::string req_schema_hash = req->param(TABLET_SCHEMA_HASH_KEY);
     std::string req_enable_base64 = req->param(ENABLE_BYTE_TO_BASE64);
     uint64_t tablet_id = 0;
-    uint32_t schema_hash = 0;
     bool enable_byte_to_base64 = false;
     if (std::strcmp(req_enable_base64.c_str(), "true") == 0) {
         enable_byte_to_base64 = true;
     }
     try {
         tablet_id = std::stoull(req_tablet_id);
-        schema_hash = std::stoul(req_schema_hash);
     } catch (const std::exception& e) {
         LOG(WARNING) << "invalid argument.tablet_id:" << req_tablet_id
-                     << ", schema_hash:" << req_schema_hash
                      << ", enable_byte_to_base64: " << req_enable_base64;
         return Status::InternalError(strings::Substitute("convert failed, $0", e.what()));
     }
 
-    TabletSharedPtr tablet =
-            StorageEngine::instance()->tablet_manager()->get_tablet(tablet_id, schema_hash);
+    TabletSharedPtr tablet = StorageEngine::instance()->tablet_manager()->get_tablet(tablet_id);
     if (tablet == nullptr) {
-        LOG(WARNING) << "no tablet for tablet_id:" << tablet_id << " schema hash:" << schema_hash;
+        LOG(WARNING) << "no tablet for tablet_id:" << tablet_id;
         return Status::InternalError("no tablet exist");
     }
     TabletMetaSharedPtr tablet_meta(new TabletMeta());

--- a/be/src/http/action/restore_tablet_action.cpp
+++ b/be/src/http/action/restore_tablet_action.cpp
@@ -82,8 +82,7 @@ Status RestoreTabletAction::_handle(HttpRequest* req) {
     int32_t schema_hash = std::atoi(schema_hash_str.c_str());
     LOG(INFO) << "get restore tablet action request: " << tablet_id << "-" << schema_hash;
 
-    TabletSharedPtr tablet =
-            StorageEngine::instance()->tablet_manager()->get_tablet(tablet_id, schema_hash);
+    TabletSharedPtr tablet = StorageEngine::instance()->tablet_manager()->get_tablet(tablet_id);
     if (tablet != nullptr) {
         LOG(WARNING) << "find tablet. tablet_id=" << tablet_id << " schema_hash=" << schema_hash;
         return Status::InternalError("tablet already exists, can not restore.");

--- a/be/src/http/action/tablet_migration_action.cpp
+++ b/be/src/http/action/tablet_migration_action.cpp
@@ -187,9 +187,9 @@ Status TabletMigrationAction::_check_param(HttpRequest* req, int64_t& tablet_id,
 Status TabletMigrationAction::_check_migrate_request(int64_t tablet_id, int32_t schema_hash,
                                                      string dest_disk, TabletSharedPtr& tablet,
                                                      DataDir** dest_store) {
-    tablet = StorageEngine::instance()->tablet_manager()->get_tablet(tablet_id, schema_hash);
+    tablet = StorageEngine::instance()->tablet_manager()->get_tablet(tablet_id);
     if (tablet == nullptr) {
-        LOG(WARNING) << "no tablet for tablet_id:" << tablet_id << " schema hash:" << schema_hash;
+        LOG(WARNING) << "no tablet for tablet_id:" << tablet_id;
         return Status::NotFound("Tablet not found");
     }
 

--- a/be/src/olap/data_dir.cpp
+++ b/be/src/olap/data_dir.cpp
@@ -586,7 +586,7 @@ void DataDir::perform_path_gc_by_tablet() {
                          << ", path=" << path;
             continue;
         }
-        TabletSharedPtr tablet = _tablet_manager->get_tablet(tablet_id, schema_hash);
+        TabletSharedPtr tablet = _tablet_manager->get_tablet(tablet_id);
         if (tablet != nullptr) {
             // could find the tablet, then skip check it
             continue;
@@ -636,7 +636,7 @@ void DataDir::perform_path_gc_by_rowsetid() {
             RowsetId rowset_id;
             bool is_rowset_file = TabletManager::get_rowset_id_from_path(path, &rowset_id);
             if (is_rowset_file) {
-                TabletSharedPtr tablet = _tablet_manager->get_tablet(tablet_id, schema_hash);
+                TabletSharedPtr tablet = _tablet_manager->get_tablet(tablet_id);
                 if (tablet != nullptr) {
                     if (!tablet->check_rowset_id(rowset_id) &&
                         !StorageEngine::instance()->check_rowset_id_in_unused_rowsets(rowset_id)) {

--- a/be/src/olap/delta_writer.cpp
+++ b/be/src/olap/delta_writer.cpp
@@ -87,7 +87,7 @@ void DeltaWriter::_garbage_collection() {
 
 OLAPStatus DeltaWriter::init() {
     TabletManager* tablet_mgr = _storage_engine->tablet_manager();
-    _tablet = tablet_mgr->get_tablet(_req.tablet_id, _req.schema_hash);
+    _tablet = tablet_mgr->get_tablet(_req.tablet_id);
     if (_tablet == nullptr) {
         LOG(WARNING) << "fail to find tablet. tablet_id=" << _req.tablet_id
                      << ", schema_hash=" << _req.schema_hash;

--- a/be/src/olap/olap_define.h
+++ b/be/src/olap/olap_define.h
@@ -404,7 +404,6 @@ static const std::string END_ROWSET_ID = "end_rowset_id";
 static const std::string CONVERTED_FLAG = "true";
 static const std::string TABLET_CONVERT_FINISHED = "tablet_convert_finished";
 const std::string TABLET_ID_KEY = "tablet_id";
-const std::string TABLET_SCHEMA_HASH_KEY = "schema_hash";
 const std::string ENABLE_BYTE_TO_BASE64 = "byte_to_base64";
 const std::string TABLET_ID_PREFIX = "t_";
 const std::string ROWSET_ID_PREFIX = "s_";

--- a/be/src/olap/schema_change.cpp
+++ b/be/src/olap/schema_change.cpp
@@ -1401,8 +1401,7 @@ OLAPStatus SchemaChangeHandler::process_alter_tablet_v2(const TAlterTabletReqV2&
               << ", new_tablet_id=" << request.new_tablet_id
               << ", alter_version=" << request.alter_version;
 
-    TabletSharedPtr base_tablet = StorageEngine::instance()->tablet_manager()->get_tablet(
-            request.base_tablet_id, request.base_schema_hash);
+    TabletSharedPtr base_tablet = StorageEngine::instance()->tablet_manager()->get_tablet(request.base_tablet_id);
     if (base_tablet == nullptr) {
         LOG(WARNING) << "fail to find base tablet. base_tablet=" << request.base_tablet_id;
         return OLAP_ERR_TABLE_NOT_FOUND;
@@ -1427,21 +1426,17 @@ OLAPStatus SchemaChangeHandler::process_alter_tablet_v2(const TAlterTabletReqV2&
 // Should delete the old code after upgrade finished.
 OLAPStatus SchemaChangeHandler::_do_process_alter_tablet_v2(const TAlterTabletReqV2& request) {
     OLAPStatus res = OLAP_SUCCESS;
-    TabletSharedPtr base_tablet = StorageEngine::instance()->tablet_manager()->get_tablet(
-            request.base_tablet_id, request.base_schema_hash);
+    TabletSharedPtr base_tablet = StorageEngine::instance()->tablet_manager()->get_tablet(request.base_tablet_id);
     if (base_tablet == nullptr) {
-        LOG(WARNING) << "fail to find base tablet. base_tablet=" << request.base_tablet_id
-                     << ", base_schema_hash=" << request.base_schema_hash;
+        LOG(WARNING) << "fail to find base tablet. base_tablet=" << request.base_tablet_id;
         return OLAP_ERR_TABLE_NOT_FOUND;
     }
 
     // new tablet has to exist
-    TabletSharedPtr new_tablet = StorageEngine::instance()->tablet_manager()->get_tablet(
-            request.new_tablet_id, request.new_schema_hash);
+    TabletSharedPtr new_tablet = StorageEngine::instance()->tablet_manager()->get_tablet(request.new_tablet_id);
     if (new_tablet == nullptr) {
         LOG(WARNING) << "fail to find new tablet."
-                     << " new_tablet=" << request.new_tablet_id
-                     << ", new_schema_hash=" << request.new_schema_hash;
+                     << " new_tablet=" << request.new_tablet_id;
         return OLAP_ERR_TABLE_NOT_FOUND;
     }
 

--- a/be/src/olap/storage_engine.cpp
+++ b/be/src/olap/storage_engine.cpp
@@ -619,12 +619,10 @@ void StorageEngine::clear_transaction_task(const TTransactionId transaction_id,
         for (auto& tablet_info : tablet_infos) {
             // should use tablet uid to ensure clean txn correctly
             TabletSharedPtr tablet = _tablet_manager->get_tablet(tablet_info.first.tablet_id,
-                                                                 tablet_info.first.schema_hash,
                                                                  tablet_info.first.tablet_uid);
             // The tablet may be dropped or altered, leave a INFO log and go on process other tablet
             if (tablet == nullptr) {
                 LOG(INFO) << "tablet is no longer exist. tablet_id=" << tablet_info.first.tablet_id
-                          << ", schema_hash=" << tablet_info.first.schema_hash
                           << ", tablet_uid=" << tablet_info.first.tablet_uid;
                 continue;
             }
@@ -737,8 +735,7 @@ void StorageEngine::_clean_unused_rowset_metas() {
             return true;
         }
 
-        TabletSharedPtr tablet = _tablet_manager->get_tablet(
-                rowset_meta->tablet_id(), rowset_meta->tablet_schema_hash());
+        TabletSharedPtr tablet = _tablet_manager->get_tablet(rowset_meta->tablet_id());
         if (tablet == nullptr) {
             // tablet may be dropped
             // TODO(cmy): this is better to be a VLOG, because drop table is a very common case.
@@ -788,8 +785,7 @@ void StorageEngine::_clean_unused_txns() {
     std::set<TabletInfo> tablet_infos;
     _txn_manager->get_all_related_tablets(&tablet_infos);
     for (auto& tablet_info : tablet_infos) {
-        TabletSharedPtr tablet = _tablet_manager->get_tablet(
-                tablet_info.tablet_id, tablet_info.schema_hash, tablet_info.tablet_uid, true);
+        TabletSharedPtr tablet = _tablet_manager->get_tablet(tablet_info.tablet_id, tablet_info.tablet_uid, true);
         if (tablet == nullptr) {
             // TODO(ygl) :  should check if tablet still in meta, it's a improvement
             // case 1: tablet still in meta, just remove from memory
@@ -1026,7 +1022,7 @@ OLAPStatus StorageEngine::execute_task(EngineTask* task) {
         std::vector<UniqueWriteLock> wrlocks;
         for (TabletInfo& tablet_info : tablet_infos) {
             TabletSharedPtr tablet =
-                    _tablet_manager->get_tablet(tablet_info.tablet_id, tablet_info.schema_hash);
+                    _tablet_manager->get_tablet(tablet_info.tablet_id);
             if (tablet != nullptr) {
                 related_tablets.push_back(tablet);
                 wrlocks.push_back(UniqueWriteLock(tablet->get_header_lock()));
@@ -1057,7 +1053,7 @@ OLAPStatus StorageEngine::execute_task(EngineTask* task) {
         std::vector<UniqueWriteLock> wrlocks;
         for (TabletInfo& tablet_info : tablet_infos) {
             TabletSharedPtr tablet =
-                    _tablet_manager->get_tablet(tablet_info.tablet_id, tablet_info.schema_hash);
+                    _tablet_manager->get_tablet(tablet_info.tablet_id);
             if (tablet != nullptr) {
                 related_tablets.push_back(tablet);
                 wrlocks.push_back(UniqueWriteLock(tablet->get_header_lock()));

--- a/be/src/olap/tablet_manager.cpp
+++ b/be/src/olap/tablet_manager.cpp
@@ -425,8 +425,7 @@ TabletSharedPtr TabletManager::_create_tablet_meta_and_dir_unlocked(
     return nullptr;
 }
 
-OLAPStatus TabletManager::drop_tablet(TTabletId tablet_id, SchemaHash schema_hash,
-                                      bool keep_files) {
+OLAPStatus TabletManager::drop_tablet(TTabletId tablet_id, bool keep_files) {
     WriteLock wrlock(_get_tablets_shard_lock(tablet_id));
     SCOPED_SWITCH_THREAD_LOCAL_MEM_TRACKER(_mem_tracker);
     return _drop_tablet_unlocked(tablet_id, keep_files);
@@ -489,8 +488,7 @@ OLAPStatus TabletManager::drop_tablets_on_error_root_path(
     return res;
 }
 
-TabletSharedPtr TabletManager::get_tablet(TTabletId tablet_id, SchemaHash schema_hash,
-                                          bool include_deleted, string* err) {
+TabletSharedPtr TabletManager::get_tablet(TTabletId tablet_id, bool include_deleted, string* err) {
     ReadLock rdlock(_get_tablets_shard_lock(tablet_id));
     return _get_tablet_unlocked(tablet_id, include_deleted, err);
 }
@@ -527,8 +525,7 @@ TabletSharedPtr TabletManager::_get_tablet_unlocked(TTabletId tablet_id, bool in
     return tablet;
 }
 
-TabletSharedPtr TabletManager::get_tablet(TTabletId tablet_id, SchemaHash schema_hash,
-                                          TabletUid tablet_uid, bool include_deleted, string* err) {
+TabletSharedPtr TabletManager::get_tablet(TTabletId tablet_id, TabletUid tablet_uid, bool include_deleted, string* err) {
     ReadLock rdlock(_get_tablets_shard_lock(tablet_id));
     TabletSharedPtr tablet = _get_tablet_unlocked(tablet_id, include_deleted, err);
     if (tablet != nullptr && tablet->tablet_uid() == tablet_uid) {
@@ -794,16 +791,13 @@ OLAPStatus TabletManager::load_tablet_from_dir(DataDir* store, TTabletId tablet_
 OLAPStatus TabletManager::report_tablet_info(TTabletInfo* tablet_info) {
     DorisMetrics::instance()->report_tablet_requests_total->increment(1);
     LOG(INFO) << "begin to process report tablet info."
-              << "tablet_id=" << tablet_info->tablet_id
-              << ", schema_hash=" << tablet_info->schema_hash;
-
+              << "tablet_id=" << tablet_info->tablet_id;
     OLAPStatus res = OLAP_SUCCESS;
 
-    TabletSharedPtr tablet = get_tablet(tablet_info->tablet_id, tablet_info->schema_hash);
+    TabletSharedPtr tablet = get_tablet(tablet_info->tablet_id);
     if (tablet == nullptr) {
         LOG(WARNING) << "can't find tablet. "
-                     << " tablet=" << tablet_info->tablet_id
-                     << " schema_hash=" << tablet_info->schema_hash;
+                     << " tablet=" << tablet_info->tablet_id;
         return OLAP_ERR_TABLE_NOT_FOUND;
     }
 

--- a/be/src/olap/tablet_manager.cpp
+++ b/be/src/olap/tablet_manager.cpp
@@ -1291,8 +1291,7 @@ void TabletManager::get_tablets_distribution_on_different_disks(
         std::set<TabletInfo>::iterator tablet_info_iter = (partition_iter->second).begin();
         for (; tablet_info_iter != (partition_iter->second).end(); ++tablet_info_iter) {
             // get_tablet() will hold 'tablet_shard_lock'
-            TabletSharedPtr tablet =
-                    get_tablet(tablet_info_iter->tablet_id, tablet_info_iter->schema_hash);
+            TabletSharedPtr tablet = get_tablet(tablet_info_iter->tablet_id);
             if (tablet == nullptr) {
                 continue;
             }

--- a/be/src/olap/tablet_manager.h
+++ b/be/src/olap/tablet_manager.h
@@ -67,7 +67,7 @@ public:
     // Return OLAP_SUCCESS, if run ok
     //        OLAP_ERR_TABLE_DELETE_NOEXIST_ERROR, if tablet not exist
     //        OLAP_ERR_NOT_INITED, if not inited
-    OLAPStatus drop_tablet(TTabletId tablet_id, SchemaHash schema_hash, bool keep_files = false);
+    OLAPStatus drop_tablet(TTabletId tablet_id, bool keep_files = false);
 
     OLAPStatus drop_tablets_on_error_root_path(const std::vector<TabletInfo>& tablet_info_vec);
 
@@ -76,11 +76,10 @@ public:
             const std::unordered_set<TTabletId>& tablet_submitted_compaction, uint32_t* score,
             std::shared_ptr<CumulativeCompactionPolicy> cumulative_compaction_policy);
 
-    TabletSharedPtr get_tablet(TTabletId tablet_id, SchemaHash schema_hash,
-                               bool include_deleted = false, std::string* err = nullptr);
+    TabletSharedPtr get_tablet(TTabletId tablet_id, bool include_deleted = false, std::string* err = nullptr);
 
-    TabletSharedPtr get_tablet(TTabletId tablet_id, SchemaHash schema_hash, TabletUid tablet_uid,
-                               bool include_deleted = false, std::string* err = nullptr);
+    TabletSharedPtr get_tablet(TTabletId tablet_id, TabletUid tablet_uid, bool include_deleted = false,
+                               std::string* err = nullptr);
 
     // Extract tablet_id and schema_hash from given path.
     //

--- a/be/src/olap/task/engine_checksum_task.cpp
+++ b/be/src/olap/task/engine_checksum_task.cpp
@@ -50,7 +50,7 @@ OLAPStatus EngineChecksumTask::_compute_checksum() {
     }
 
     TabletSharedPtr tablet =
-            StorageEngine::instance()->tablet_manager()->get_tablet(_tablet_id, _schema_hash);
+            StorageEngine::instance()->tablet_manager()->get_tablet(_tablet_id);
     if (nullptr == tablet.get()) {
         OLAP_LOG_WARNING("can't find tablet. [tablet_id=%ld schema_hash=%d]", _tablet_id,
                          _schema_hash);

--- a/be/src/olap/task/engine_publish_version_task.cpp
+++ b/be/src/olap/task/engine_publish_version_task.cpp
@@ -76,7 +76,7 @@ OLAPStatus EnginePublishVersionTask::finish() {
                 continue;
             }
             TabletSharedPtr tablet = StorageEngine::instance()->tablet_manager()->get_tablet(
-                    tablet_info.tablet_id, tablet_info.schema_hash, tablet_info.tablet_uid);
+                    tablet_info.tablet_id, tablet_info.tablet_uid);
             if (tablet == nullptr) {
                 LOG(WARNING) << "can't get tablet when publish version. tablet_id="
                              << tablet_info.tablet_id << " schema_hash=" << tablet_info.schema_hash;

--- a/be/src/olap/task/engine_storage_migration_task.cpp
+++ b/be/src/olap/task/engine_storage_migration_task.cpp
@@ -170,8 +170,7 @@ OLAPStatus EngineStorageMigrationTask::_reload_tablet(
     TabletSharedPtr new_tablet =
             StorageEngine::instance()->tablet_manager()->get_tablet(tablet_id);
     if (new_tablet == nullptr) {
-        LOG(WARNING) << "tablet not found. tablet_id=" << tablet_id
-                        << " schema_hash=" << schema_hash;
+        LOG(WARNING) << "tablet not found. tablet_id=" << tablet_id;
         return OLAP_ERR_TABLE_NOT_FOUND;
     }
     return res;

--- a/be/src/olap/task/engine_storage_migration_task.cpp
+++ b/be/src/olap/task/engine_storage_migration_task.cpp
@@ -168,7 +168,7 @@ OLAPStatus EngineStorageMigrationTask::_reload_tablet(
     // if old tablet finished schema change, then the schema change status of the new tablet is DONE
     // else the schema change status of the new tablet is FAILED
     TabletSharedPtr new_tablet =
-            StorageEngine::instance()->tablet_manager()->get_tablet(tablet_id, schema_hash);
+            StorageEngine::instance()->tablet_manager()->get_tablet(tablet_id);
     if (new_tablet == nullptr) {
         LOG(WARNING) << "tablet not found. tablet_id=" << tablet_id
                         << " schema_hash=" << schema_hash;

--- a/be/src/runtime/snapshot_loader.cpp
+++ b/be/src/runtime/snapshot_loader.cpp
@@ -225,8 +225,7 @@ Status SnapshotLoader::download(const std::map<std::string, std::string>& src_to
             return Status::InternalError(ss.str());
         }
 
-        TabletSharedPtr tablet =
-                _env->storage_engine()->tablet_manager()->get_tablet(local_tablet_id, schema_hash);
+        TabletSharedPtr tablet = _env->storage_engine()->tablet_manager()->get_tablet(local_tablet_id);
         if (tablet == nullptr) {
             std::stringstream ss;
             ss << "failed to get local tablet: " << local_tablet_id;

--- a/be/src/service/http_service.cpp
+++ b/be/src/service/http_service.cpp
@@ -119,7 +119,7 @@ Status HttpService::start() {
     }
 
     MetaAction* meta_action = _pool.add(new MetaAction(HEADER));
-    _ev_http_server->register_handler(HttpMethod::GET, "/api/meta/header/{tablet_id}/{schema_hash}",
+    _ev_http_server->register_handler(HttpMethod::GET, "/api/meta/header/{tablet_id}",
                                       meta_action);
 
 #ifndef BE_TEST

--- a/be/src/vec/exec/volap_scan_node.cpp
+++ b/be/src/vec/exec/volap_scan_node.cpp
@@ -338,14 +338,12 @@ Status VOlapScanNode::start_scan_thread(RuntimeState* state) {
     std::unordered_set<std::string> disk_set;
     for (auto& scan_range : _scan_ranges) {
         auto tablet_id = scan_range->tablet_id;
-        int32_t schema_hash = strtoul(scan_range->schema_hash.c_str(), nullptr, 10);
         std::string err;
         TabletSharedPtr tablet = StorageEngine::instance()->tablet_manager()->get_tablet(
                 tablet_id, true, &err);
         if (tablet == nullptr) {
             std::stringstream ss;
-            ss << "failed to get tablet: " << tablet_id << " with schema hash: " << schema_hash
-               << ", reason: " << err;
+            ss << "failed to get tablet: " << tablet_id << ", reason: " << err;
             LOG(WARNING) << ss.str();
             return Status::InternalError(ss.str());
         }

--- a/be/src/vec/exec/volap_scan_node.cpp
+++ b/be/src/vec/exec/volap_scan_node.cpp
@@ -341,7 +341,7 @@ Status VOlapScanNode::start_scan_thread(RuntimeState* state) {
         int32_t schema_hash = strtoul(scan_range->schema_hash.c_str(), nullptr, 10);
         std::string err;
         TabletSharedPtr tablet = StorageEngine::instance()->tablet_manager()->get_tablet(
-                tablet_id, schema_hash, true, &err);
+                tablet_id, true, &err);
         if (tablet == nullptr) {
             std::stringstream ss;
             ss << "failed to get tablet: " << tablet_id << " with schema hash: " << schema_hash

--- a/be/test/olap/tablet_mgr_test.cpp
+++ b/be/test/olap/tablet_mgr_test.cpp
@@ -104,7 +104,7 @@ TEST_F(TabletMgrTest, CreateTablet) {
     data_dirs.push_back(_data_dir);
     OLAPStatus create_st = _tablet_mgr->create_tablet(create_tablet_req, data_dirs);
     ASSERT_TRUE(create_st == OLAP_SUCCESS);
-    TabletSharedPtr tablet = _tablet_mgr->get_tablet(111, 3333);
+    TabletSharedPtr tablet = _tablet_mgr->get_tablet(111);
     ASSERT_TRUE(tablet != nullptr);
     // check dir exist
     bool dir_exist = FileUtils::check_exist(tablet->tablet_path_desc().filepath);
@@ -118,7 +118,7 @@ TEST_F(TabletMgrTest, CreateTablet) {
     create_st = _tablet_mgr->create_tablet(create_tablet_req, data_dirs);
     ASSERT_TRUE(create_st == OLAP_SUCCESS);
 
-    OLAPStatus drop_st = _tablet_mgr->drop_tablet(111, 3333, false);
+    OLAPStatus drop_st = _tablet_mgr->drop_tablet(111, false);
     ASSERT_TRUE(drop_st == OLAP_SUCCESS);
     tablet.reset();
     OLAPStatus trash_st = _tablet_mgr->start_trash_sweep();
@@ -163,7 +163,7 @@ TEST_F(TabletMgrTest, CreateTabletWithSequence) {
     OLAPStatus create_st = _tablet_mgr->create_tablet(create_tablet_req, data_dirs);
     ASSERT_TRUE(create_st == OLAP_SUCCESS);
 
-    TabletSharedPtr tablet = _tablet_mgr->get_tablet(111, 3333);
+    TabletSharedPtr tablet = _tablet_mgr->get_tablet(111);
     ASSERT_TRUE(tablet != nullptr);
     // check dir exist
     bool dir_exist = FileUtils::check_exist(tablet->tablet_path_desc().filepath);
@@ -173,7 +173,7 @@ TEST_F(TabletMgrTest, CreateTabletWithSequence) {
     OLAPStatus check_meta_st = TabletMetaManager::get_meta(_data_dir, 111, 3333, new_tablet_meta);
     ASSERT_TRUE(check_meta_st == OLAP_SUCCESS);
 
-    OLAPStatus drop_st = _tablet_mgr->drop_tablet(111, 3333, false);
+    OLAPStatus drop_st = _tablet_mgr->drop_tablet(111, false);
     ASSERT_TRUE(drop_st == OLAP_SUCCESS);
     tablet.reset();
     OLAPStatus trash_st = _tablet_mgr->start_trash_sweep();
@@ -203,21 +203,21 @@ TEST_F(TabletMgrTest, DropTablet) {
     data_dirs.push_back(_data_dir);
     OLAPStatus create_st = _tablet_mgr->create_tablet(create_tablet_req, data_dirs);
     ASSERT_TRUE(create_st == OLAP_SUCCESS);
-    TabletSharedPtr tablet = _tablet_mgr->get_tablet(111, 3333);
+    TabletSharedPtr tablet = _tablet_mgr->get_tablet(111);
     ASSERT_TRUE(tablet != nullptr);
 
     // drop unexist tablet will be success
-    OLAPStatus drop_st = _tablet_mgr->drop_tablet(1121, 4444, false);
+    OLAPStatus drop_st = _tablet_mgr->drop_tablet(1121, false);
     ASSERT_TRUE(drop_st == OLAP_SUCCESS);
-    tablet = _tablet_mgr->get_tablet(111, 3333);
+    tablet = _tablet_mgr->get_tablet(111);
     ASSERT_TRUE(tablet != nullptr);
 
     // drop exist tablet will be success
-    drop_st = _tablet_mgr->drop_tablet(111, 3333, false);
+    drop_st = _tablet_mgr->drop_tablet(111, false);
     ASSERT_TRUE(drop_st == OLAP_SUCCESS);
-    tablet = _tablet_mgr->get_tablet(111, 3333);
+    tablet = _tablet_mgr->get_tablet(111);
     ASSERT_TRUE(tablet == nullptr);
-    tablet = _tablet_mgr->get_tablet(111, 3333, true);
+    tablet = _tablet_mgr->get_tablet(111, true);
     ASSERT_TRUE(tablet != nullptr);
 
     // check dir exist
@@ -229,7 +229,7 @@ TEST_F(TabletMgrTest, DropTablet) {
     // because tablet ptr referenced it
     OLAPStatus trash_st = _tablet_mgr->start_trash_sweep();
     ASSERT_TRUE(trash_st == OLAP_SUCCESS);
-    tablet = _tablet_mgr->get_tablet(111, 3333, true);
+    tablet = _tablet_mgr->get_tablet(111, true);
     ASSERT_TRUE(tablet != nullptr);
     dir_exist = FileUtils::check_exist(tablet_path);
     ASSERT_TRUE(dir_exist);
@@ -238,7 +238,7 @@ TEST_F(TabletMgrTest, DropTablet) {
     tablet.reset();
     trash_st = _tablet_mgr->start_trash_sweep();
     ASSERT_TRUE(trash_st == OLAP_SUCCESS);
-    tablet = _tablet_mgr->get_tablet(111, 3333, true);
+    tablet = _tablet_mgr->get_tablet(111, true);
     ASSERT_TRUE(tablet == nullptr);
     dir_exist = FileUtils::check_exist(tablet_path);
     ASSERT_TRUE(!dir_exist);

--- a/docs/en/administrator-guide/http-actions/compaction-action.md
+++ b/docs/en/administrator-guide/http-actions/compaction-action.md
@@ -56,7 +56,7 @@ This structure represents the id of the tablet that is performing the compaction
 ### Specify the compaction status of the tablet
 
 ```
-curl -X GET http://be_host:webserver_port/api/compaction/show?tablet_id=xxxx\&schema_hash=yyyy
+curl -X GET http://be_host:webserver_port/api/compaction/show?tablet_id=xxxx
 ```
 
 If the tablet does not exist, an error in JSON format is returned:
@@ -113,13 +113,13 @@ Explanation of results:
 ### Examples
 
 ```
-curl -X GET http://192.168.10.24:8040/api/compaction/show?tablet_id=10015\&schema_hash=1294206575
+curl -X GET http://192.168.10.24:8040/api/compaction/show?tablet_id=10015
 ```
 
 ## Manually trigger Compaction
 
 ```
-curl -X POST http://be_host:webserver_port/api/compaction/run?tablet_id=xxxx\&schema_hash=yyyy\&compact_type=cumulative
+curl -X POST http://be_host:webserver_port/api/compaction/run?tablet_id=xxxx\&compact_type=cumulative
 ```
 
 The only one manual compaction task that can be performed at a moment, and the value range of compact_type is base or cumulative
@@ -159,13 +159,13 @@ Explanation of results:
 ### Examples
 
 ```
-curl -X POST http://192.168.10.24:8040/api/compaction/run?tablet_id=10015\&schema_hash=1294206575\&compact_type=cumulative
+curl -X POST http://192.168.10.24:8040/api/compaction/run?tablet_id=10015\&compact_type=cumulative
 ```
 
 ## Manual Compaction execution status
 
 ```
-curl -X GET http://be_host:webserver_port/api/compaction/run_status?tablet_id=xxxx\&schema_hash=yyyy
+curl -X GET http://be_host:webserver_port/api/compaction/run_status?tablet_id=xxxx
 ```
 If the tablet does not exist, an error in JSON format is returned:
 
@@ -184,7 +184,6 @@ If the tablet exists and the tablet is not running, JSON format is returned:
     "run_status" : false,
     "msg" : "this tablet_id is not running",
     "tablet_id" : 11308,
-    "schema_hash" : 700967178,
     "compact_type" : ""
 }
 ```
@@ -197,7 +196,6 @@ If the tablet exists and the tablet is running, JSON format is returned:
     "run_status" : true,
     "msg" : "this tablet_id is running",
     "tablet_id" : 11308,
-    "schema_hash" : 700967178,
     "compact_type" : "cumulative"
 }
 ```
@@ -209,5 +207,5 @@ Explanation of results:
 ### Examples
 
 ```
-curl -X GET http://192.168.10.24:8040/api/compaction/run_status?tablet_id=10015\&schema_hash=1294206575
+curl -X GET http://192.168.10.24:8040/api/compaction/run_status?tablet_id=10015
 

--- a/docs/en/administrator-guide/http-actions/fe/system-action.md
+++ b/docs/en/administrator-guide/http-actions/fe/system-action.md
@@ -66,7 +66,7 @@ Take `/dbs/10003/10054/partitions/10053/10055` as an example:
 			"LstFailedTime": "\\N",
 			"LstFailedVersion": "-1",
 			"MetaUrl": "URL",
-			"__hrefPaths": ["http://192.168.100.100:8030/rest/v1/system?path=/dbs/10003/10054/partitions/10053/10055/10056", "http://192.168.100.100:8043/api/meta/header/10056/1294206575", "http://192.168.100.100:8043/api/compaction/show?tablet_id=10056&schema_hash=1294206575"],
+			"__hrefPaths": ["http://192.168.100.100:8030/rest/v1/system?path=/dbs/10003/10054/partitions/10053/10055/10056", "http://192.168.100.100:8043/api/meta/header/10056", "http://192.168.100.100:8043/api/compaction/show?tablet_id=10056"],
 			"CheckVersionHash": "-1",
 			"ReplicaId": "10057",
 			"VersionHash": "4611804212003004639",

--- a/docs/en/administrator-guide/operation/tablet-meta-tool.md
+++ b/docs/en/administrator-guide/operation/tablet-meta-tool.md
@@ -50,7 +50,7 @@ Access BE's HTTP interface to obtain the corresponding Tablet Meta information:
 
 api:
 
-`http://{host}:{port}/api/meta/header/{tablet_id}/{schema_hash}`
+`http://{host}:{port}/api/meta/header/{tablet_id}`
 
 
 > Host: be Hostname
@@ -58,12 +58,10 @@ api:
 > port: BE's HTTP port
 >
 > tablet id: tablet id
->
-> schema hash: tablet schema hash
 
 Give an example:
 
-`http://be_host:8040/api/meta/header/14156/2458238340`
+`http://be_host:8040/api/meta/header/14156`
 
 If the final query is successful, the Tablet Meta will be returned as json.
 

--- a/docs/zh-CN/administrator-guide/http-actions/compaction-action.md
+++ b/docs/zh-CN/administrator-guide/http-actions/compaction-action.md
@@ -56,7 +56,7 @@ curl -X GET http://be_host:webserver_port/api/compaction/run_status
 ### 指定 tablet 的 compaction 状态
 
 ```
-curl -X GET http://be_host:webserver_port/api/compaction/show?tablet_id=xxxx\&schema_hash=yyyy
+curl -X GET http://be_host:webserver_port/api/compaction/show?tablet_id=xxxx
 ```
 
 若 tablet 不存在，返回 JSON 格式的错误：
@@ -113,13 +113,13 @@ curl -X GET http://be_host:webserver_port/api/compaction/show?tablet_id=xxxx\&sc
 ### 示例
 
 ```
-curl -X GET http://192.168.10.24:8040/api/compaction/show?tablet_id=10015\&schema_hash=1294206575
+curl -X GET http://192.168.10.24:8040/api/compaction/show?tablet_id=10015
 ```
 
 ## 手动触发 Compaction
 
 ```
-curl -X POST http://be_host:webserver_port/api/compaction/run?tablet_id=xxxx\&schema_hash=yyyy\&compact_type=cumulative
+curl -X POST http://be_host:webserver_port/api/compaction/run?tablet_id=xxxx&compact_type=cumulative
 ```
 
 当前仅能执行一个手动compaction任务，其中compact_type取值为base或cumulative
@@ -158,13 +158,13 @@ curl -X POST http://be_host:webserver_port/api/compaction/run?tablet_id=xxxx\&sc
 ### 示例
 
 ```
-curl -X POST http://192.168.10.24:8040/api/compaction/run?tablet_id=10015\&schema_hash=1294206575\&compact_type=cumulative
+curl -X POST http://192.168.10.24:8040/api/compaction/run?tablet_id=10015\&compact_type=cumulative
 ```
 
 ## 手动 Compaction 执行状态
 
 ```
-curl -X GET http://be_host:webserver_port/api/compaction/run_status?tablet_id=xxxx\&schema_hash=yyyy
+curl -X GET http://be_host:webserver_port/api/compaction/run_status?tablet_id=xxxx
 ```
 
 若 tablet 不存在，返回 JSON 格式：
@@ -209,4 +209,4 @@ curl -X GET http://be_host:webserver_port/api/compaction/run_status?tablet_id=xx
 ### 示例
 
 ```
-curl -X GET http://192.168.10.24:8040/api/compaction/run_status?tablet_id=10015\&schema_hash=1294206575
+curl -X GET http://192.168.10.24:8040/api/compaction/run_status?tablet_id=10015

--- a/docs/zh-CN/administrator-guide/http-actions/fe/system-action.md
+++ b/docs/zh-CN/administrator-guide/http-actions/fe/system-action.md
@@ -66,7 +66,7 @@ System Action 用于 Doris 内置的 Proc 系统的相关信息。
 			"LstFailedTime": "\\N",
 			"LstFailedVersion": "-1",
 			"MetaUrl": "URL",
-			"__hrefPaths": ["http://192.168.100.100:8030/rest/v1/system?path=/dbs/10003/10054/partitions/10053/10055/10056", "http://192.168.100.100:8043/api/meta/header/10056/1294206575", "http://192.168.100.100:8043/api/compaction/show?tablet_id=10056&schema_hash=1294206575"],
+			"__hrefPaths": ["http://192.168.100.100:8030/rest/v1/system?path=/dbs/10003/10054/partitions/10053/10055/10056", "http://192.168.100.100:8043/api/meta/header/10056", "http://192.168.100.100:8043/api/compaction/show?tablet_id=10056"],
 			"CheckVersionHash": "-1",
 			"ReplicaId": "10057",
 			"VersionHash": "4611804212003004639",

--- a/docs/zh-CN/administrator-guide/operation/tablet-meta-tool.md
+++ b/docs/zh-CN/administrator-guide/operation/tablet-meta-tool.md
@@ -50,7 +50,7 @@ meta\_tool 工具存放在 BE 的 lib/ 目录下。
 
 api：
 
-`http://{host}:{port}/api/meta/header/{tablet_id}/{schema_hash}`
+`http://{host}:{port}/api/meta/header/{tablet_id}`
 
 
 > host: BE 的 hostname
@@ -58,12 +58,10 @@ api：
 > port: BE 的 http 端口
 > 
 > tablet_id: tablet id
-> 
-> schema_hash: tablet 的 schema hash
 
 举例：
     
-`http://be_host:8040/api/meta/header/14156/2458238340`
+`http://be_host:8040/api/meta/header/14156`
 
 最终查询成功的话，会将 Tablet Meta 以 json 形式返回。
 

--- a/fe/fe-core/src/main/java/org/apache/doris/common/proc/ReplicasProcNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/proc/ReplicasProcNode.java
@@ -58,13 +58,13 @@ public class ReplicasProcNode implements ProcNodeInterface {
             Backend be = backendMap.get(replica.getBackendId());
             String host = (be == null ? Backend.DUMMY_IP : be.getHost());
             int port = (be == null ? 0 : be.getHttpPort());
-            String metaUrl = String.format("http://%s:%d/api/meta/header/%d/%d",
+            String metaUrl = String.format("http://%s:%d/api/meta/header/%d",
                     host, port,
                     tabletId,
                     replica.getSchemaHash());
 
             String compactionUrl = String.format(
-                    "http://%s:%d/api/compaction/show?tablet_id=%d&schema_hash=%d",
+                    "http://%s:%d/api/compaction/show?tablet_id=%d",
                     host, port,
                     tabletId,
                     replica.getSchemaHash());

--- a/fe/fe-core/src/main/java/org/apache/doris/common/proc/TabletsProcDir.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/proc/TabletsProcDir.java
@@ -120,14 +120,14 @@ public class TabletsProcDir implements ProcDirInterface {
                         tabletInfo.add(tablet.getCheckedVersion());
                         tabletInfo.add(replica.getVersionCount());
                         tabletInfo.add(replica.getPathHash());
-                        String metaUrl = String.format("http://%s:%d/api/meta/header/%d/%d",
+                        String metaUrl = String.format("http://%s:%d/api/meta/header/%d",
                                 backendMap.get(replica.getBackendId()).getHost(),
                                 backendMap.get(replica.getBackendId()).getHttpPort(),
                                 tabletId,
                                 replica.getSchemaHash());
                         tabletInfo.add(metaUrl);
                         String compactionUrl = String.format(
-                                "http://%s:%d/api/compaction/show?tablet_id=%d&schema_hash=%d",
+                                "http://%s:%d/api/compaction/show?tablet_id=%d",
                                 backendMap.get(replica.getBackendId()).getHost(),
                                 backendMap.get(replica.getBackendId()).getHttpPort(),
                                 tabletId,


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

1.Now, schema_hash is part of the data_dir path, but tablet id is unique, so we can read tablet info only by tablet_id,
so this PR only modify get_tablet and drop_tablet function in be, not refactor write schema_hash logic in be.
module in be who use get_tablet and drop_tablet function will be affected.
2. For users, this PR change two httpAction in be, one is metaAction, and the other is CompactionAction. so I also modify the doc and fe code.
3.The main Purpose of this PR is to simplify managing tablet, whether to remove all schema_hash still need more discussion, because we need to consider compatibility and correctness after refactor.
 
## Checklist(Required)

1. Does it affect the original behavior: (Yes)
2. Has unit tests been added: (No)
3. Has document been added or modified: (Yes)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
