### PR TITLE
[fix](meta) Check_time return wrong value when exec show table status

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ShowExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ShowExecutor.java
@@ -739,7 +739,7 @@ public class ShowExecutor {
                 }
                 // Check_time
                 if (table.getLastCheckTime() > 0) {
-                    row.add(TimeUtils.longToTimeString(table.getLastCheckTime() * 1000));
+                    row.add(TimeUtils.longToTimeString(table.getLastCheckTime()));
                 } else {
                     row.add(null);
                 }


### PR DESCRIPTION
# Proposed changes
Fix value error when exec `show table status`
Issue Number: close #xxx

## Problem Summary:
`show table status`
the Check_time is wrong:

`Check_time: 54189-04-24 14:20:05`

<img width="506" alt="image" src="https://user-images.githubusercontent.com/17537020/159410052-8a96fbbe-e7c9-4e95-923c-a8f2af1616e8.png">


Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
