### PR TITLE
[Bug][Vectorized] fix core dump on deep_copy_tuple when data is null

### DIFF
--- a/be/src/vec/core/block.cpp
+++ b/be/src/vec/core/block.cpp
@@ -711,9 +711,9 @@ doris::Tuple* Block::deep_copy_tuple(const doris::TupleDescriptor& desc, MemPool
             dst->set_null(slot_desc->null_indicator_offset());
         } else {
             dst->set_not_null(slot_desc->null_indicator_offset());
+            deep_copy_slot(dst->get_slot(slot_desc->tuple_offset()), pool, type_desc, data_ref,
+                           column.get(), row, padding_char);
         }
-        deep_copy_slot(dst->get_slot(slot_desc->tuple_offset()), pool, type_desc, data_ref,
-                       column.get(), row, padding_char);
     }
     return dst;
 }


### PR DESCRIPTION
# Proposed changes
@adonis0147 Please take a look.
Issue Number: close #8619

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
