### PR TITLE
[Vectorized][Feature] Support min_by/max_by function.

### DIFF
--- a/be/src/vec/CMakeLists.txt
+++ b/be/src/vec/CMakeLists.txt
@@ -26,6 +26,7 @@ set(VEC_FILES
   aggregate_functions/aggregate_function_distinct.cpp
   aggregate_functions/aggregate_function_sum.cpp
   aggregate_functions/aggregate_function_min_max.cpp
+  aggregate_functions/aggregate_function_min_max_by.cpp
   aggregate_functions/aggregate_function_null.cpp
   aggregate_functions/aggregate_function_uniq.cpp
   aggregate_functions/aggregate_function_hll_union_agg.cpp

--- a/be/src/vec/aggregate_functions/aggregate_function_min_max_by.cpp
+++ b/be/src/vec/aggregate_functions/aggregate_function_min_max_by.cpp
@@ -1,0 +1,57 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "vec/aggregate_functions/aggregate_function_min_max.h"
+
+#include "vec/aggregate_functions/aggregate_function_simple_factory.h"
+#include "vec/aggregate_functions/factory_helpers.h"
+#include "vec/aggregate_functions/helpers.h"
+
+namespace doris::vectorized {
+
+/// min_by, max_by
+template <template <typename, bool> class AggregateFunctionTemplate, template <typename> class Data>
+static IAggregateFunction* create_aggregate_function_min_max_by(const String& name,
+                                                                  const DataTypes& argument_types,
+                                                                  const Array& parameters) {
+    assert_no_parameters(name, parameters);
+    assert_binary(name, argument_types);
+
+    const DataTypePtr& argument_type = argument_types[0];
+
+    WhichDataType which(argument_type);
+#define DISPATCH(TYPE)                                                                 \
+    if (which.idx == TypeIndex::TYPE)                                                  \
+        return new AggregateFunctionTemplate<Data<SingleValueDataFixed<TYPE>>, false>( \
+                argument_type);
+    FOR_NUMERIC_TYPES(DISPATCH)
+#undef DISPATCH
+    if (which.idx == TypeIndex::String) {
+        return new AggregateFunctionTemplate<Data<SingleValueDataString>, false>(argument_type);
+    }
+    if (which.idx == TypeIndex::DateTime || which.idx == TypeIndex::Date) {
+        return new AggregateFunctionTemplate<Data<SingleValueDataFixed<Int64>>, false>(
+                argument_type);
+    }
+    if (which.idx == TypeIndex::Decimal128) {
+        return new AggregateFunctionTemplate<Data<SingleValueDataFixed<DecimalV2Value>>, false>(
+                argument_type);
+    }
+    return nullptr;
+}
+
+} // namespace doris::vectorized

--- a/be/src/vec/aggregate_functions/aggregate_function_min_max_by.cpp
+++ b/be/src/vec/aggregate_functions/aggregate_function_min_max_by.cpp
@@ -16,6 +16,7 @@
 // under the License.
 
 #include "vec/aggregate_functions/aggregate_function_min_max.h"
+#include "vec/aggregate_functions/aggregate_function_min_max_by.h"
 
 #include "vec/aggregate_functions/aggregate_function_simple_factory.h"
 #include "vec/aggregate_functions/factory_helpers.h"
@@ -24,34 +25,92 @@
 namespace doris::vectorized {
 
 /// min_by, max_by
-template <template <typename, bool> class AggregateFunctionTemplate, template <typename> class Data>
-static IAggregateFunction* create_aggregate_function_min_max_by(const String& name,
-                                                                  const DataTypes& argument_types,
-                                                                  const Array& parameters) {
-    assert_no_parameters(name, parameters);
-    assert_binary(name, argument_types);
+template <template <typename, bool> class AggregateFunctionTemplate,
+          template <typename, typename> class Data, typename VT>
+static IAggregateFunction* create_aggregate_function_min_max_by_impl(
+        const DataTypes& argument_types) {
+    const DataTypePtr& value_arg_type = argument_types[0];
+    const DataTypePtr& key_arg_type = argument_types[1];
 
-    const DataTypePtr& argument_type = argument_types[0];
-
-    WhichDataType which(argument_type);
-#define DISPATCH(TYPE)                                                                 \
-    if (which.idx == TypeIndex::TYPE)                                                  \
-        return new AggregateFunctionTemplate<Data<SingleValueDataFixed<TYPE>>, false>( \
-                argument_type);
+    WhichDataType which(key_arg_type);
+#define DISPATCH(TYPE)                                                                     \
+    if (which.idx == TypeIndex::TYPE)                                                      \
+        return new AggregateFunctionTemplate<Data<VT, SingleValueDataFixed<TYPE>>, false>( \
+                value_arg_type, key_arg_type);
     FOR_NUMERIC_TYPES(DISPATCH)
 #undef DISPATCH
     if (which.idx == TypeIndex::String) {
-        return new AggregateFunctionTemplate<Data<SingleValueDataString>, false>(argument_type);
+        return new AggregateFunctionTemplate<Data<VT, SingleValueDataString>, false>(value_arg_type,
+                                                                                     key_arg_type);
     }
     if (which.idx == TypeIndex::DateTime || which.idx == TypeIndex::Date) {
-        return new AggregateFunctionTemplate<Data<SingleValueDataFixed<Int64>>, false>(
-                argument_type);
+        return new AggregateFunctionTemplate<Data<VT, SingleValueDataFixed<Int64>>, false>(
+                value_arg_type, key_arg_type);
     }
     if (which.idx == TypeIndex::Decimal128) {
-        return new AggregateFunctionTemplate<Data<SingleValueDataFixed<DecimalV2Value>>, false>(
-                argument_type);
+        return new AggregateFunctionTemplate<Data<VT, SingleValueDataFixed<DecimalV2Value>>, false>(
+                value_arg_type, key_arg_type);
     }
     return nullptr;
+}
+
+/// min_by, max_by
+template <template <typename, bool> class AggregateFunctionTemplate,
+          template <typename, typename> class Data>
+static IAggregateFunction* create_aggregate_function_min_max_by(const String& name,
+                                                                const DataTypes& argument_types,
+                                                                const Array& parameters) {
+    assert_no_parameters(name, parameters);
+    assert_binary(name, argument_types);
+
+    const DataTypePtr& value_arg_type = argument_types[0];
+
+    WhichDataType which(value_arg_type);
+#define DISPATCH(TYPE)                                                                    \
+    if (which.idx == TypeIndex::TYPE)                                                     \
+        return create_aggregate_function_min_max_by_impl<AggregateFunctionTemplate, Data, \
+                                                         SingleValueDataFixed<TYPE>>(     \
+                argument_types);
+    FOR_NUMERIC_TYPES(DISPATCH)
+#undef DISPATCH
+    if (which.idx == TypeIndex::String) {
+        return create_aggregate_function_min_max_by_impl<AggregateFunctionTemplate, Data,
+                                                         SingleValueDataString>(argument_types);
+    }
+    if (which.idx == TypeIndex::DateTime || which.idx == TypeIndex::Date) {
+        return create_aggregate_function_min_max_by_impl<AggregateFunctionTemplate, Data,
+                                                         SingleValueDataFixed<Int64>>(
+                argument_types);
+    }
+    if (which.idx == TypeIndex::Decimal128) {
+        return create_aggregate_function_min_max_by_impl<AggregateFunctionTemplate, Data,
+                                                         SingleValueDataFixed<DecimalV2Value>>(
+                argument_types);
+    }
+    return nullptr;
+}
+
+AggregateFunctionPtr create_aggregate_function_max_by(const std::string& name,
+                                                      const DataTypes& argument_types,
+                                                      const Array& parameters,
+                                                      const bool result_is_nullable) {
+    return AggregateFunctionPtr(create_aggregate_function_min_max_by<AggregateFunctionsMinMaxBy,
+                                                                     AggregateFunctionMaxByData>(
+            name, argument_types, parameters));
+}
+
+AggregateFunctionPtr create_aggregate_function_min_by(const std::string& name,
+                                                      const DataTypes& argument_types,
+                                                      const Array& parameters,
+                                                      const bool result_is_nullable) {
+    return AggregateFunctionPtr(create_aggregate_function_min_max_by<AggregateFunctionsMinMaxBy,
+                                                                     AggregateFunctionMinByData>(
+            name, argument_types, parameters));
+}
+
+void register_aggregate_function_min_max_by(AggregateFunctionSimpleFactory& factory) {
+    factory.register_function("max_by", create_aggregate_function_max_by);
+    factory.register_function("min_by", create_aggregate_function_min_by);
 }
 
 } // namespace doris::vectorized

--- a/be/src/vec/aggregate_functions/aggregate_function_min_max_by.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_min_max_by.h
@@ -1,0 +1,114 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include "common/logging.h"
+#include "vec/aggregate_functions/aggregate_function.h"
+#include "vec/columns/column_decimal.h"
+#include "vec/columns/column_vector.h"
+#include "vec/common/assert_cast.h"
+#include "vec/io/io_helper.h"
+
+namespace doris::vectorized {
+template <typename VT, typename KT>
+struct AggregateFunctionMaxByData {
+private:
+    VT value;
+    KT key;
+public:
+    using Self = AggregateFunctionMaxByData;
+
+    bool change_if_better(const IColumn& value_column, const IColumn& key_column, size_t row_num, Arena* arena) {
+        if (key.change_if_greater(key_column, row_num, arena)) {
+            value.change(value_column, row_num, arena);
+        }
+    }
+
+    bool change_if_better(const Self& to, Arena* arena) {
+        if (key.change_if_greater(to.key, arena)) {
+            value.change(to.value, arena);
+        }
+    }
+};
+
+template <typename Data, bool AllocatesMemoryInArena>
+class AggregateFunctionsMinMaxBy final
+        : public IAggregateFunctionDataHelper<
+                  Data, AggregateFunctionsMinMaxBy<Data, AllocatesMemoryInArena>> {
+private:
+    DataTypePtr& type;
+
+public:
+    AggregateFunctionsMinMaxBy(const DataTypePtr& type_)
+            : IAggregateFunctionDataHelper<
+                      Data, AggregateFunctionsMinMaxBy<Data, AllocatesMemoryInArena>>({type_},
+                                                                                         {}),
+              type(this->argument_types[0]) {
+        if (StringRef(Data::name()) == StringRef("min") ||
+            StringRef(Data::name()) == StringRef("max")) {
+            if (!type->is_comparable()) {
+                LOG(FATAL) << fmt::format(
+                        "Illegal type {} of argument of aggregate function {} because the values "
+                        "of that data type are not comparable",
+                        type->get_name(), get_name());
+            }
+        }
+    }
+
+    String get_name() const override { return Data::name(); }
+
+    DataTypePtr get_return_type() const override { return type; }
+
+    void add(AggregateDataPtr __restrict place, const IColumn** columns, size_t row_num,
+             Arena* arena) const override {
+        this->data(place).change_if_better(*columns[0], row_num, arena);
+    }
+
+    void reset(AggregateDataPtr place) const override { this->data(place).reset(); }
+
+    void merge(AggregateDataPtr __restrict place, ConstAggregateDataPtr rhs,
+               Arena* arena) const override {
+        this->data(place).change_if_better(this->data(rhs), arena);
+    }
+
+    void serialize(ConstAggregateDataPtr __restrict place, BufferWritable& buf) const override {
+        this->data(place).write(buf);
+    }
+
+    void deserialize(AggregateDataPtr __restrict place, BufferReadable& buf,
+                     Arena*) const override {
+        this->data(place).read(buf);
+    }
+
+    bool allocates_memory_in_arena() const override { return AllocatesMemoryInArena; }
+
+    void insert_result_into(ConstAggregateDataPtr __restrict place, IColumn& to) const override {
+        this->data(place).insert_result_into(to);
+    }
+};
+
+AggregateFunctionPtr create_aggregate_function_max_by(const std::string& name,
+                                                   const DataTypes& argument_types,
+                                                   const Array& parameters,
+                                                   const bool result_is_nullable);
+
+AggregateFunctionPtr create_aggregate_function_min_by(const std::string& name,
+                                                   const DataTypes& argument_types,
+                                                   const Array& parameters,
+                                                   const bool result_is_nullable);
+} // namespace doris::vectorized

--- a/be/src/vec/aggregate_functions/aggregate_function_min_max_by.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_min_max_by.h
@@ -112,12 +112,7 @@ public:
               key_type(this->argument_types[1]) {
         if (StringRef(Data::name()) == StringRef("min_by") ||
             StringRef(Data::name()) == StringRef("max_by")) {
-            if (!key_type_->is_comparable()) {
-                LOG(FATAL) << fmt::format(
-                        "Illegal type {} of argument of aggregate function {} because the values "
-                        "of that data type are not comparable",
-                        key_type_->get_name(), get_name());
-            }
+            CHECK(key_type_->is_comparable());
         }
     }
 

--- a/be/src/vec/aggregate_functions/aggregate_function_simple_factory.cpp
+++ b/be/src/vec/aggregate_functions/aggregate_function_simple_factory.cpp
@@ -29,6 +29,7 @@ class AggregateFunctionSimpleFactory;
 void register_aggregate_function_sum(AggregateFunctionSimpleFactory& factory);
 void register_aggregate_function_combinator_null(AggregateFunctionSimpleFactory& factory);
 void register_aggregate_function_minmax(AggregateFunctionSimpleFactory& factory);
+void register_aggregate_function_min_max_by(AggregateFunctionSimpleFactory& factory);
 void register_aggregate_function_avg(AggregateFunctionSimpleFactory& factory);
 void register_aggregate_function_count(AggregateFunctionSimpleFactory& factory);
 void register_aggregate_function_HLL_union_agg(AggregateFunctionSimpleFactory& factory);
@@ -51,6 +52,7 @@ AggregateFunctionSimpleFactory& AggregateFunctionSimpleFactory::instance() {
     std::call_once(oc, [&]() {
         register_aggregate_function_sum(instance);
         register_aggregate_function_minmax(instance);
+        register_aggregate_function_min_max_by(instance);
         register_aggregate_function_avg(instance);
         register_aggregate_function_count(instance);
         register_aggregate_function_uniq(instance);

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -331,6 +331,7 @@ set(VEC_TEST_FILES
     vec/aggregate_functions/agg_test.cpp
     vec/aggregate_functions/agg_min_max_test.cpp
     vec/aggregate_functions/vec_window_funnel_test.cpp
+    vec/aggregate_functions/agg_min_max_by_test.cpp
     vec/core/block_test.cpp
     vec/core/column_array_test.cpp
     vec/core/column_complex_test.cpp

--- a/be/test/vec/aggregate_functions/agg_min_max_by_test.cpp
+++ b/be/test/vec/aggregate_functions/agg_min_max_by_test.cpp
@@ -100,8 +100,3 @@ TEST_P(AggMinMaxByTest, min_max_by_test) {
 INSTANTIATE_TEST_SUITE_P(Params, AggMinMaxByTest,
                          ::testing::ValuesIn(std::vector<std::string> {"min_by", "max_by"}));
 } // namespace doris::vectorized
-
-int main(int argc, char** argv) {
-    ::testing::InitGoogleTest(&argc, argv);
-    return RUN_ALL_TESTS();
-}

--- a/be/test/vec/aggregate_functions/agg_min_max_by_test.cpp
+++ b/be/test/vec/aggregate_functions/agg_min_max_by_test.cpp
@@ -1,0 +1,107 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <memory>
+#include <string>
+
+#include "gtest/gtest.h"
+#include "vec/aggregate_functions/aggregate_function.h"
+#include "vec/aggregate_functions/aggregate_function_simple_factory.h"
+#include "vec/aggregate_functions/aggregate_function_min_max_by.h"
+#include "vec/columns/column_vector.h"
+#include "vec/data_types/data_type.h"
+#include "vec/data_types/data_type_number.h"
+#include "vec/data_types/data_type_string.h"
+
+const int agg_test_batch_size = 4096;
+
+namespace doris::vectorized {
+// declare function
+void register_aggregate_function_min_max_by(AggregateFunctionSimpleFactory& factory);
+
+class AggMinMaxByTest : public ::testing::TestWithParam<std::string> {};
+
+TEST_P(AggMinMaxByTest, min_max_by_test) {
+    std::string min_max_by_type = GetParam();
+    // Prepare test data.
+    auto column_vector_value = ColumnInt32::create();
+    auto column_vector_key_int32 = ColumnInt32::create();
+    auto column_vector_key_str = ColumnString::create();
+    auto max_pair = std::make_pair<std::string, int32_t>("foo_0", 0);
+    auto min_pair = max_pair;
+    for (int i = 0; i < agg_test_batch_size; i++) {
+        column_vector_value->insert(cast_to_nearest_field_type(i));
+        column_vector_key_int32->insert(cast_to_nearest_field_type(agg_test_batch_size - i));
+        std::string str_val = fmt::format("foo_{}", i);
+        if (max_pair.first < str_val) {
+            max_pair.first = str_val;
+            max_pair.second = i;
+        }
+        if (min_pair.first > str_val) {
+            min_pair.first = str_val;
+            min_pair.second = i;
+        }
+        column_vector_key_str->insert(cast_to_nearest_field_type(str_val));
+    }
+
+    // Prepare test function and parameters.
+    AggregateFunctionSimpleFactory factory;
+    register_aggregate_function_min_max_by(factory);
+
+    // Test on 2 kind of key types (int32, string).
+    for (int i = 0; i < 2; i++) {
+        DataTypes data_types = {std::make_shared<DataTypeInt32>(),
+                                i == 0 ? (DataTypePtr)std::make_shared<DataTypeInt32>()
+                                       : (DataTypePtr)std::make_shared<DataTypeString>()};
+        Array array;
+        auto agg_function = factory.get(min_max_by_type, data_types, array);
+        std::unique_ptr<char[]> memory(new char[agg_function->size_of_data()]);
+        AggregateDataPtr place = memory.get();
+        agg_function->create(place);
+
+        // Do aggregation.
+        const IColumn* columns[2] = {column_vector_value.get(),
+                                     i == 0 ? (IColumn*)column_vector_key_int32.get()
+                                            : (IColumn*)column_vector_key_str.get()};
+        for (int j = 0; j < agg_test_batch_size; j++) {
+            agg_function->add(place, columns, j, nullptr);
+        }
+
+        // Check result.
+        ColumnInt32 ans;
+        agg_function->insert_result_into(place, ans);
+        if (i == 0) {
+            // Key type is int32.
+            ASSERT_EQ(min_max_by_type == "max_by" ? 0 : agg_test_batch_size - 1,
+                      ans.get_element(0));
+        } else {
+            // Key type is string.
+            ASSERT_EQ(min_max_by_type == "max_by" ? max_pair.second : min_pair.second,
+                      ans.get_element(0));
+        }
+        agg_function->destroy(place);
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(Params, AggMinMaxByTest,
+                         ::testing::ValuesIn(std::vector<std::string> {"min_by", "max_by"}));
+} // namespace doris::vectorized
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/docs/en/sql-reference/sql-functions/aggregate-functions/max_by.md
+++ b/docs/en/sql-reference/sql-functions/aggregate-functions/max_by.md
@@ -1,0 +1,56 @@
+---
+{
+    "title": "MAX_BY",
+    "language": "en"
+}
+---
+
+<!-- 
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# MAX_BY
+## description
+### Syntax
+
+`MAX_BY(expr1, expr2)`
+
+
+Returns the value of an expr1 associated with the maximum value of expr2 in a group.
+
+## example
+```
+MySQL > select * from tbl;
++------+------+------+------+
+| k1   | k2   | k3   | k4   |
++------+------+------+------+
+|    0 | 3    | 2    |  100 |
+|    1 | 2    | 3    |    4 |
+|    4 | 3    | 2    |    1 |
+|    3 | 4    | 2    |    1 |
++------+------+------+------+
+
+MySQL > select max_by(k1, k4) from tbl;
++--------------------+
+| max_by(`k1`, `k4`) |
++--------------------+
+|                  0 |
++--------------------+ 
+```
+## keyword
+MAX_BY

--- a/docs/en/sql-reference/sql-functions/aggregate-functions/min_by.md
+++ b/docs/en/sql-reference/sql-functions/aggregate-functions/min_by.md
@@ -1,0 +1,56 @@
+---
+{
+    "title": "MIN_BY",
+    "language": "en"
+}
+---
+
+<!-- 
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# MIN_BY
+## description
+### Syntax
+
+`MIN_BY(expr1, expr2)`
+
+
+Returns the value of an expr1 associated with the minimum value of expr2 in a group.
+
+## example
+```
+MySQL > select * from tbl;
++------+------+------+------+
+| k1   | k2   | k3   | k4   |
++------+------+------+------+
+|    0 | 3    | 2    |  100 |
+|    1 | 2    | 3    |    4 |
+|    4 | 3    | 2    |    1 |
+|    3 | 4    | 2    |    1 |
++------+------+------+------+
+
+MySQL > select min_by(k1, k4) from tbl;
++--------------------+
+| min_by(`k1`, `k4`) |
++--------------------+
+|                  4 |
++--------------------+ 
+```
+## keyword
+MIN_BY

--- a/docs/zh-CN/sql-reference/sql-functions/aggregate-functions/max_by.md
+++ b/docs/zh-CN/sql-reference/sql-functions/aggregate-functions/max_by.md
@@ -1,0 +1,56 @@
+---
+{
+    "title": "MAX_BY",
+    "language": "zh-CN"
+}
+---
+
+<!-- 
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# MAX_BY
+## description
+### Syntax
+
+`MAX_BY(expr1, expr2)`
+
+
+返回与 expr2 的最大值关联的 expr1 的值。
+
+## example
+```
+MySQL > select * from tbl;
++------+------+------+------+
+| k1   | k2   | k3   | k4   |
++------+------+------+------+
+|    0 | 3    | 2    |  100 |
+|    1 | 2    | 3    |    4 |
+|    4 | 3    | 2    |    1 |
+|    3 | 4    | 2    |    1 |
++------+------+------+------+
+
+MySQL > select max_by(k1, k4) from tbl;
++--------------------+
+| max_by(`k1`, `k4`) |
++--------------------+
+|                  0 |
++--------------------+ 
+```
+## keyword
+MAX_BY

--- a/docs/zh-CN/sql-reference/sql-functions/aggregate-functions/min_by.md
+++ b/docs/zh-CN/sql-reference/sql-functions/aggregate-functions/min_by.md
@@ -1,0 +1,56 @@
+---
+{
+    "title": "MIN_BY",
+    "language": "zh-CN"
+}
+---
+
+<!-- 
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# MIN_BY
+## description
+### Syntax
+
+`MIN_BY(expr1, expr2)`
+
+
+返回与 expr2 的最小值关联的 expr1 的值。
+
+## example
+```
+MySQL > select * from tbl;
++------+------+------+------+
+| k1   | k2   | k3   | k4   |
++------+------+------+------+
+|    0 | 3    | 2    |  100 |
+|    1 | 2    | 3    |    4 |
+|    4 | 3    | 2    |    1 |
+|    3 | 4    | 2    |    1 |
++------+------+------+------+
+
+MySQL > select min_by(k1, k4) from tbl;
++--------------------+
+| min_by(`k1`, `k4`) |
++--------------------+
+|                  4 |
++--------------------+ 
+```
+## keyword
+MIN_BY

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/AggregateInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/AggregateInfo.java
@@ -452,10 +452,14 @@ public final class AggregateInfo extends AggregateInfoBase {
         for (int i = 0; i < getAggregateExprs().size(); ++i) {
             FunctionCallExpr inputExpr = getAggregateExprs().get(i);
             Preconditions.checkState(inputExpr.isAggregateFunction());
-            Expr aggExprParam =
-                    new SlotRef(inputDesc.getSlots().get(i + getGroupingExprs().size()));
+            List<Expr> paramExprs = new ArrayList<>();
+            if (inputExpr.fn.functionName().equals("max_by")) {
+                paramExprs.addAll(inputExpr.getFnParams().exprs());
+            } else {
+                paramExprs.add(new SlotRef(inputDesc.getSlots().get(i + getGroupingExprs().size())));
+            }
             FunctionCallExpr aggExpr = FunctionCallExpr.createMergeAggCall(
-                    inputExpr, Lists.newArrayList(aggExprParam));
+                    inputExpr, paramExprs);
             aggExpr.analyzeNoThrow(analyzer);
             aggExprs.add(aggExpr);
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/AggregateInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/AggregateInfo.java
@@ -453,7 +453,10 @@ public final class AggregateInfo extends AggregateInfoBase {
             FunctionCallExpr inputExpr = getAggregateExprs().get(i);
             Preconditions.checkState(inputExpr.isAggregateFunction());
             List<Expr> paramExprs = new ArrayList<>();
-            if (inputExpr.fn.functionName().equals("max_by")) {
+            // TODO(zhannngchen), change intermediate argument to a list, and remove this
+            // ad-hoc logic
+            if (inputExpr.fn.functionName().equals("max_by") ||
+                    inputExpr.fn.functionName().equals("min_by")) {
                 paramExprs.addAll(inputExpr.getFnParams().exprs());
             } else {
                 paramExprs.add(new SlotRef(inputDesc.getSlots().get(i + getGroupingExprs().size())));

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/FunctionSet.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/FunctionSet.java
@@ -1600,6 +1600,9 @@ public class FunctionSet<min_initIN9doris_udf12DecimalV2ValEEEvPNS2_15FunctionCo
 
             // vectorized
             for (Type kt : Type.getSupportedTypes()) {
+                if (kt.isNull()) {
+                    continue;
+                }
                 addBuiltin(AggregateFunction.createBuiltin("max_by", Lists.newArrayList(t, kt), t, Type.VARCHAR,
                         "", "", "", "", "", null, "",
                         true, true, false, true));

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/FunctionSet.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/FunctionSet.java
@@ -1598,6 +1598,17 @@ public class FunctionSet<min_initIN9doris_udf12DecimalV2ValEEEvPNS2_15FunctionCo
                     minMaxSerializeOrFinalize, minMaxGetValue,
                     null, minMaxSerializeOrFinalize, true, true, false, true));
 
+            // vectorized
+            for (Type kt : Type.getSupportedTypes()) {
+                addBuiltin(AggregateFunction.createBuiltin("max_by", Lists.newArrayList(t, kt), t, Type.VARCHAR,
+                        "", "", "", "", "", null, "",
+                        true, true, false, true));
+                addBuiltin(AggregateFunction.createBuiltin("min_by", Lists.newArrayList(t, kt), t, Type.VARCHAR,
+                        "", "", "", "", "", null, "",
+                        true, true, false, true));
+            }
+
+
             // NDV
             // ndv return string
             addBuiltin(AggregateFunction.createBuiltin("ndv", Lists.newArrayList(t), Type.BIGINT, Type.VARCHAR,


### PR DESCRIPTION
# Proposed changes

Issue Number: open #7678

## Problem Summary:

Support min_by/max_by on vectorized engine.

## Checklist(Required)

1. Does it affect the original behavior: (No)
2. Has unit tests been added: (Yes)
3. Has document been added or modified: (Yes)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (No)

## Further comments
1. This is an initial patch, I will add the document later.
2. For now, aggregate functions only supports 1 intermediate type, but min_by/max_by needs 2 type information, I've did a tricky work-around in this initial patch, but we need to discuss that do we really need to change the intermediate type to an intermediate type list? @morningman @HappenLee  @dataroaring. Another solution is to serialize the type information in the intermediate data.
3. To support these 2 functions in the non-vectorized code needs to pay much more efforts, we may need to do some refactor. Do we need to support this?
