### PR TITLE
fix wrong error content on Load

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/load/Load.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/Load.java
@@ -1028,6 +1028,9 @@ public class Load {
             for (Entry<String, Pair<String, List<String>>> entry : columnToHadoopFunction.entrySet()) {
                 String mappingColumnName = entry.getKey();
                 Column mappingColumn = tbl.getColumn(mappingColumnName);
+                if (mappingColumn == null) {
+                    throw new DdlException("Mapping column is not in table. column: " + mappingColumnName);
+                }
                 Pair<String, List<String>> function = entry.getValue();
                 try {
                     DataDescription.validateMappingFunction(function.first, function.second, columnNameMap,


### PR DESCRIPTION
# Proposed changes

Issue Number: close #8624 

## Problem Summary:

The reason is that the field is null, and the subsequent logic only deals with AnalysisException, so there is no timely error report in the analysis stage.

see the issue content. 

## Checklist(Required)

1. Does it affect the original behavior: (No)
2. Has unit tests been added: (No)
3. Has document been added or modified: (No)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
