### PR TITLE
[refactor][optimize] Code optimization and refactoring for low-cardinality columns in storage layer

### DIFF
--- a/be/src/olap/column_predicate.h
+++ b/be/src/olap/column_predicate.h
@@ -73,7 +73,13 @@ public:
 
     virtual bool is_bloom_filter_predicate() { return false; }
 
+    virtual bool is_equal_comparison_predicate() { return false; }
+
     virtual bool is_range_comparison_predicate() { return false; }
+
+    // Useful only with range comparison predicates
+    virtual bool contain_equal() { return false; }
+    virtual bool is_less() { return false; }
 
 protected:
     uint32_t _column_id;

--- a/be/src/olap/column_predicate.h
+++ b/be/src/olap/column_predicate.h
@@ -86,6 +86,8 @@ public:
     virtual void evaluate_vec(vectorized::IColumn& column, uint16_t size, bool* flags) const {};
     uint32_t column_id() const { return _column_id; }
 
+    virtual void set_dict_code_if_necessary(vectorized::IColumn& column) { }
+
 protected:
     uint32_t _column_id;
     bool _opposite;

--- a/be/src/olap/column_predicate.h
+++ b/be/src/olap/column_predicate.h
@@ -34,17 +34,17 @@ class Schema;
 class RowBlockV2;
 
 enum class PredicateType {
-    Unknown = 0,
+    UNKNOWN = 0,
     EQ = 1,
     NE = 2,
     LT = 3,
     LE = 4,
     GT = 5,
     GE = 6,
-    InList = 7,
-    NotInList = 8,
-    IsNull = 9,
-    NotIsNull = 10,
+    IN_LIST = 7,
+    NO_IN_LIST = 8,
+    IS_NULL = 9,
+    NOT_IS_NULL = 10,
     BF = 11, // BloomFilter
 };
 

--- a/be/src/olap/column_predicate.h
+++ b/be/src/olap/column_predicate.h
@@ -45,7 +45,7 @@ enum class PredicateType {
     NotInList = 8,
     IsNull = 9,
     NotIsNull = 10,
-    BF = 11
+    BF = 11, // BloomFilter
 };
 
 class ColumnPredicate {

--- a/be/src/olap/comparison_predicate.h
+++ b/be/src/olap/comparison_predicate.h
@@ -26,11 +26,12 @@ namespace doris {
 
 class VectorizedRowBatch;
 
-#define COMPARISON_PRED_CLASS_DEFINE(CLASS, IS_RANGE, IS_EQ, CONTAIN_EQ, IS_LESS)                  \
-    template <class type>                                                                          \
+#define COMPARISON_PRED_CLASS_DEFINE(CLASS, PT)                                                    \
+    template <class T>                                                                             \
     class CLASS : public ColumnPredicate {                                                         \
     public:                                                                                        \
-        CLASS(uint32_t column_id, const type& value, bool opposite = false);                       \
+        CLASS(uint32_t column_id, const T& value, bool opposite = false);                          \
+        PredicateType type() const override { return PredicateType::PT; }                          \
         virtual void evaluate(VectorizedRowBatch* batch) const override;                           \
         void evaluate(ColumnBlock* block, uint16_t* sel, uint16_t* size) const override;           \
         void evaluate_or(ColumnBlock* block, uint16_t* sel, uint16_t size,                         \
@@ -46,24 +47,20 @@ class VectorizedRowBatch;
         void evaluate_or(vectorized::IColumn& column, uint16_t* sel, uint16_t size,                \
                          bool* flags) const override;                                              \
         void evaluate_vec(vectorized::IColumn& column, uint16_t size, bool* flags) const override; \
-        bool is_range_comparison_predicate() override { return IS_RANGE; }                         \
-        bool is_equal_comparison_predicate() override { return IS_EQ; }                            \
-        bool contain_equal() override { return CONTAIN_EQ; }                                       \
-        bool is_less() override { return IS_LESS; }                                                \
-        const type& get_value() const { return _value; }                                           \
+        const T& get_value() const { return _value; }                                              \
         void set_dict_code(int32_t code) { _dict_code = code; }                                    \
                                                                                                    \
     private:                                                                                       \
-        type _value;                                                                               \
+        T _value;                                                                                  \
         int32_t _dict_code;                                                                        \
     };
 
-COMPARISON_PRED_CLASS_DEFINE(EqualPredicate, false, true, false, false)
-COMPARISON_PRED_CLASS_DEFINE(NotEqualPredicate, false, true, false, false)
-COMPARISON_PRED_CLASS_DEFINE(LessPredicate, true, false, false, true)
-COMPARISON_PRED_CLASS_DEFINE(LessEqualPredicate, true, false, true, true)
-COMPARISON_PRED_CLASS_DEFINE(GreaterPredicate, true, false, false, false)
-COMPARISON_PRED_CLASS_DEFINE(GreaterEqualPredicate, true, false, true, false)
+COMPARISON_PRED_CLASS_DEFINE(EqualPredicate, EQ)
+COMPARISON_PRED_CLASS_DEFINE(NotEqualPredicate, NE)
+COMPARISON_PRED_CLASS_DEFINE(LessPredicate, LT)
+COMPARISON_PRED_CLASS_DEFINE(LessEqualPredicate, LE)
+COMPARISON_PRED_CLASS_DEFINE(GreaterPredicate, GT)
+COMPARISON_PRED_CLASS_DEFINE(GreaterEqualPredicate, GE)
 
 } //namespace doris
 

--- a/be/src/olap/comparison_predicate.h
+++ b/be/src/olap/comparison_predicate.h
@@ -26,7 +26,7 @@ namespace doris {
 
 class VectorizedRowBatch;
 
-#define COMPARISON_PRED_CLASS_DEFINE(CLASS, IS_RANGE)                                              \
+#define COMPARISON_PRED_CLASS_DEFINE(CLASS, IS_RANGE, IS_EQ, CONTAIN_EQ, IS_LESS)                  \
     template <class type>                                                                          \
     class CLASS : public ColumnPredicate {                                                         \
     public:                                                                                        \
@@ -47,17 +47,23 @@ class VectorizedRowBatch;
                          bool* flags) const override;                                              \
         void evaluate_vec(vectorized::IColumn& column, uint16_t size, bool* flags) const override; \
         bool is_range_comparison_predicate() override { return IS_RANGE; }                         \
+        bool is_equal_comparison_predicate() override { return IS_EQ; }                            \
+        bool contain_equal() override { return CONTAIN_EQ; }                                       \
+        bool is_less() override { return IS_LESS; }                                                \
+        const type& get_value() const { return _value; }                                           \
+        void set_dict_code(int32_t code) { _dict_code = code; }                                    \
                                                                                                    \
     private:                                                                                       \
         type _value;                                                                               \
+        int32_t _dict_code;                                                                        \
     };
 
-COMPARISON_PRED_CLASS_DEFINE(EqualPredicate, false)
-COMPARISON_PRED_CLASS_DEFINE(NotEqualPredicate, false)
-COMPARISON_PRED_CLASS_DEFINE(LessPredicate, true)
-COMPARISON_PRED_CLASS_DEFINE(LessEqualPredicate, true)
-COMPARISON_PRED_CLASS_DEFINE(GreaterPredicate, true)
-COMPARISON_PRED_CLASS_DEFINE(GreaterEqualPredicate, true)
+COMPARISON_PRED_CLASS_DEFINE(EqualPredicate, false, true, false, false)
+COMPARISON_PRED_CLASS_DEFINE(NotEqualPredicate, false, true, false, false)
+COMPARISON_PRED_CLASS_DEFINE(LessPredicate, true, false, false, true)
+COMPARISON_PRED_CLASS_DEFINE(LessEqualPredicate, true, false, true, true)
+COMPARISON_PRED_CLASS_DEFINE(GreaterPredicate, true, false, false, false)
+COMPARISON_PRED_CLASS_DEFINE(GreaterEqualPredicate, true, false, true, false)
 
 } //namespace doris
 

--- a/be/src/olap/comparison_predicate.h
+++ b/be/src/olap/comparison_predicate.h
@@ -47,11 +47,10 @@ class VectorizedRowBatch;
         void evaluate_or(vectorized::IColumn& column, uint16_t* sel, uint16_t size,                \
                          bool* flags) const override;                                              \
         void evaluate_vec(vectorized::IColumn& column, uint16_t size, bool* flags) const override; \
-        const T& get_value() const { return _value; }                                              \
-        void set_dict_code(int32_t code) { _dict_code = code; }                                    \
-                                                                                                   \
+        void set_dict_code_if_necessary(vectorized::IColumn& column) override;                     \
     private:                                                                                       \
         T _value;                                                                                  \
+        bool _dict_code_inited = false;                                                            \
         int32_t _dict_code;                                                                        \
     };
 

--- a/be/src/olap/in_list_predicate.cpp
+++ b/be/src/olap/in_list_predicate.cpp
@@ -27,23 +27,23 @@
 namespace doris {
 
 #define IN_LIST_PRED_CONSTRUCTOR(CLASS)                                                        \
-    template <class type>                                                                      \
-    CLASS<type>::CLASS(uint32_t column_id, phmap::flat_hash_set<type>&& values, bool opposite) \
+    template <class T>                                                                         \
+    CLASS<T>::CLASS(uint32_t column_id, phmap::flat_hash_set<T>&& values, bool opposite)       \
             : ColumnPredicate(column_id, opposite), _values(std::move(values)) {}
 
 IN_LIST_PRED_CONSTRUCTOR(InListPredicate)
 IN_LIST_PRED_CONSTRUCTOR(NotInListPredicate)
 
 #define IN_LIST_PRED_EVALUATE(CLASS, OP)                                                       \
-    template <class type>                                                                      \
-    void CLASS<type>::evaluate(VectorizedRowBatch* batch) const {                              \
+    template <class T>                                                                         \
+    void CLASS<T>::evaluate(VectorizedRowBatch* batch) const {                                 \
         uint16_t n = batch->size();                                                            \
         if (n == 0) {                                                                          \
             return;                                                                            \
         }                                                                                      \
         uint16_t* sel = batch->selected();                                                     \
-        const type* col_vector =                                                               \
-                reinterpret_cast<const type*>(batch->column(_column_id)->col_data());          \
+        const T* col_vector =                                                                  \
+                reinterpret_cast<const T*>(batch->column(_column_id)->col_data());             \
         uint16_t new_size = 0;                                                                 \
         if (batch->column(_column_id)->no_nulls()) {                                           \
             if (batch->selected_in_use()) {                                                    \
@@ -89,15 +89,15 @@ IN_LIST_PRED_EVALUATE(InListPredicate, !=)
 IN_LIST_PRED_EVALUATE(NotInListPredicate, ==)
 
 #define IN_LIST_PRED_COLUMN_BLOCK_EVALUATE(CLASS, OP)                                     \
-    template <class type>                                                                 \
-    void CLASS<type>::evaluate(ColumnBlock* block, uint16_t* sel, uint16_t* size) const { \
+    template <class T>                                                                    \
+    void CLASS<T>::evaluate(ColumnBlock* block, uint16_t* sel, uint16_t* size) const {    \
         uint16_t new_size = 0;                                                            \
         if (block->is_nullable()) {                                                       \
             for (uint16_t i = 0; i < *size; ++i) {                                        \
                 uint16_t idx = sel[i];                                                    \
                 sel[new_size] = idx;                                                      \
-                const type* cell_value =                                                  \
-                        reinterpret_cast<const type*>(block->cell(idx).cell_ptr());       \
+                const T* cell_value =                                                     \
+                        reinterpret_cast<const T*>(block->cell(idx).cell_ptr());          \
                 auto result = (!block->cell(idx).is_null() && _values.find(*cell_value)   \
                                                                       OP _values.end());  \
                 new_size += _opposite ? !result : result;                                 \
@@ -106,8 +106,8 @@ IN_LIST_PRED_EVALUATE(NotInListPredicate, ==)
             for (uint16_t i = 0; i < *size; ++i) {                                        \
                 uint16_t idx = sel[i];                                                    \
                 sel[new_size] = idx;                                                      \
-                const type* cell_value =                                                  \
-                        reinterpret_cast<const type*>(block->cell(idx).cell_ptr());       \
+                const T* cell_value =                                                     \
+                        reinterpret_cast<const T*>(block->cell(idx).cell_ptr());          \
                 auto result = (_values.find(*cell_value) OP _values.end());               \
                 new_size += _opposite ? !result : result;                                 \
             }                                                                             \
@@ -120,8 +120,8 @@ IN_LIST_PRED_COLUMN_BLOCK_EVALUATE(NotInListPredicate, ==)
 
 // todo(zeno) define interface in IColumn to simplify code
 #define IN_LIST_PRED_COLUMN_EVALUATE(CLASS, OP)                                                    \
-    template <class type>                                                                          \
-    void CLASS<type>::evaluate(vectorized::IColumn& column, uint16_t* sel, uint16_t* size) const { \
+    template <class T>                                                                             \
+    void CLASS<T>::evaluate(vectorized::IColumn& column, uint16_t* sel, uint16_t* size) const {    \
         uint16_t new_size = 0;                                                                     \
         if (column.is_nullable()) {                                                                \
             auto* nullable_col =                                                                   \
@@ -130,15 +130,14 @@ IN_LIST_PRED_COLUMN_BLOCK_EVALUATE(NotInListPredicate, ==)
                                         nullable_col->get_null_map_column()).get_data();           \
             auto& nested_col = nullable_col->get_nested_column();                                  \
             if (nested_col.is_column_dictionary()) {                                               \
-                if constexpr (std::is_same_v<type, StringValue>) {                                 \
+                if constexpr (std::is_same_v<T, StringValue>) {                                    \
                     auto* nested_col_ptr = vectorized::check_and_get_column<                       \
                             vectorized::ColumnDictionary<vectorized::Int32>>(nested_col);          \
                     auto& data_array = nested_col_ptr->get_data();                                 \
                     for (uint16_t i = 0; i < *size; i++) {                                         \
                         uint16_t idx = sel[i];                                                     \
                         sel[new_size] = idx;                                                       \
-                        const auto& cell_value =                                                   \
-                                reinterpret_cast<const vectorized::Int32&>(data_array[idx]);       \
+                        const auto& cell_value = data_array[idx];                                  \
                         bool ret = !null_bitmap[idx]                                               \
                                    && (_dict_codes.find(cell_value) OP _dict_codes.end());         \
                         new_size += _opposite ? !ret : ret;                                        \
@@ -146,19 +145,19 @@ IN_LIST_PRED_COLUMN_BLOCK_EVALUATE(NotInListPredicate, ==)
                 }                                                                                  \
             } else {                                                                               \
                 auto* nested_col_ptr = vectorized::check_and_get_column<                           \
-                        vectorized::PredicateColumnType<type>>(nested_col);                        \
+                        vectorized::PredicateColumnType<T>>(nested_col);                           \
                 auto& data_array = nested_col_ptr->get_data();                                     \
                 for (uint16_t i = 0; i < *size; i++) {                                             \
                     uint16_t idx = sel[i];                                                         \
                     sel[new_size] = idx;                                                           \
-                    const type& cell_value = reinterpret_cast<const type&>(data_array[idx]);       \
+                    const auto& cell_value = reinterpret_cast<const T&>(data_array[idx]);          \
                     bool ret = !null_bitmap[idx] && (_values.find(cell_value) OP _values.end());   \
                     new_size += _opposite ? !ret : ret;                                            \
                 }                                                                                  \
             }                                                                                      \
             *size = new_size;                                                                      \
         } else if (column.is_column_dictionary()) {                                                \
-            if constexpr (std::is_same_v<type, StringValue>) {                                     \
+            if constexpr (std::is_same_v<T, StringValue>) {                                        \
                 auto& dict_col =                                                                   \
                         reinterpret_cast<vectorized::ColumnDictionary<vectorized::Int32>&>(        \
                                 column);                                                           \
@@ -166,19 +165,18 @@ IN_LIST_PRED_COLUMN_BLOCK_EVALUATE(NotInListPredicate, ==)
                 for (uint16_t i = 0; i < *size; i++) {                                             \
                     uint16_t idx = sel[i];                                                         \
                     sel[new_size] = idx;                                                           \
-                    const auto& cell_value =                                                       \
-                            reinterpret_cast<const vectorized::Int32&>(data_array[idx]);           \
+                    const auto& cell_value = data_array[idx];                                      \
                     auto result = (_dict_codes.find(cell_value) OP _dict_codes.end());             \
                     new_size += _opposite ? !result : result;                                      \
                 }                                                                                  \
             }                                                                                      \
         } else {                                                                                   \
-            auto& number_column = reinterpret_cast<vectorized::PredicateColumnType<type>&>(column);\
+            auto& number_column = reinterpret_cast<vectorized::PredicateColumnType<T>&>(column);   \
             auto& data_array = number_column.get_data();                                           \
             for (uint16_t i = 0; i < *size; i++) {                                                 \
                 uint16_t idx = sel[i];                                                             \
                 sel[new_size] = idx;                                                               \
-                const type& cell_value = reinterpret_cast<const type&>(data_array[idx]);           \
+                const auto& cell_value = reinterpret_cast<const T&>(data_array[idx]);              \
                 auto result = (_values.find(cell_value) OP _values.end());                         \
                 new_size += _opposite ? !result : result;                                          \
             }                                                                                      \
@@ -190,15 +188,15 @@ IN_LIST_PRED_COLUMN_EVALUATE(InListPredicate, !=)
 IN_LIST_PRED_COLUMN_EVALUATE(NotInListPredicate, ==)
 
 #define IN_LIST_PRED_COLUMN_BLOCK_EVALUATE_OR(CLASS, OP)                                         \
-    template <class type>                                                                        \
-    void CLASS<type>::evaluate_or(ColumnBlock* block, uint16_t* sel, uint16_t size, bool* flags) \
+    template <class T>                                                                           \
+    void CLASS<T>::evaluate_or(ColumnBlock* block, uint16_t* sel, uint16_t size, bool* flags)    \
             const {                                                                              \
         if (block->is_nullable()) {                                                              \
             for (uint16_t i = 0; i < size; ++i) {                                                \
                 if (flags[i]) continue;                                                          \
                 uint16_t idx = sel[i];                                                           \
-                const type* cell_value =                                                         \
-                        reinterpret_cast<const type*>(block->cell(idx).cell_ptr());              \
+                const T* cell_value =                                                            \
+                        reinterpret_cast<const T*>(block->cell(idx).cell_ptr());                 \
                 auto result = (!block->cell(idx).is_null() && _values.find(*cell_value)          \
                                                                       OP _values.end());         \
                 flags[i] |= _opposite ? !result : result;                                        \
@@ -207,8 +205,8 @@ IN_LIST_PRED_COLUMN_EVALUATE(NotInListPredicate, ==)
             for (uint16_t i = 0; i < size; ++i) {                                                \
                 if (flags[i]) continue;                                                          \
                 uint16_t idx = sel[i];                                                           \
-                const type* cell_value =                                                         \
-                        reinterpret_cast<const type*>(block->cell(idx).cell_ptr());              \
+                const T* cell_value =                                                            \
+                        reinterpret_cast<const T*>(block->cell(idx).cell_ptr());                 \
                 auto result = (_values.find(*cell_value) OP _values.end());                      \
                 flags[i] |= _opposite ? !result : result;                                        \
             }                                                                                    \
@@ -219,15 +217,15 @@ IN_LIST_PRED_COLUMN_BLOCK_EVALUATE_OR(InListPredicate, !=)
 IN_LIST_PRED_COLUMN_BLOCK_EVALUATE_OR(NotInListPredicate, ==)
 
 #define IN_LIST_PRED_COLUMN_BLOCK_EVALUATE_AND(CLASS, OP)                                         \
-    template <class type>                                                                         \
-    void CLASS<type>::evaluate_and(ColumnBlock* block, uint16_t* sel, uint16_t size, bool* flags) \
+    template <class T>                                                                            \
+    void CLASS<T>::evaluate_and(ColumnBlock* block, uint16_t* sel, uint16_t size, bool* flags)    \
             const {                                                                               \
         if (block->is_nullable()) {                                                               \
             for (uint16_t i = 0; i < size; ++i) {                                                 \
                 if (!flags[i]) continue;                                                          \
                 uint16_t idx = sel[i];                                                            \
-                const type* cell_value =                                                          \
-                        reinterpret_cast<const type*>(block->cell(idx).cell_ptr());               \
+                const T* cell_value =                                                             \
+                        reinterpret_cast<const T*>(block->cell(idx).cell_ptr());                  \
                 auto result = (!block->cell(idx).is_null() && _values.find(*cell_value)           \
                                                                       OP _values.end());          \
                 flags[i] &= _opposite ? !result : result;                                         \
@@ -236,8 +234,8 @@ IN_LIST_PRED_COLUMN_BLOCK_EVALUATE_OR(NotInListPredicate, ==)
             for (uint16_t i = 0; i < size; ++i) {                                                 \
                 if (!flags[i]) continue;                                                          \
                 uint16_t idx = sel[i];                                                            \
-                const type* cell_value =                                                          \
-                        reinterpret_cast<const type*>(block->cell(idx).cell_ptr());               \
+                const T* cell_value =                                                             \
+                        reinterpret_cast<const T*>(block->cell(idx).cell_ptr());                  \
                 auto result = (_values.find(*cell_value) OP _values.end());                       \
                 flags[i] &= _opposite ? !result : result;                                         \
             }                                                                                     \
@@ -248,8 +246,8 @@ IN_LIST_PRED_COLUMN_BLOCK_EVALUATE_AND(InListPredicate, !=)
 IN_LIST_PRED_COLUMN_BLOCK_EVALUATE_AND(NotInListPredicate, ==)
 
 #define IN_LIST_PRED_BITMAP_EVALUATE(CLASS, OP)                                       \
-    template <class type>                                                             \
-    Status CLASS<type>::evaluate(const Schema& schema,                                \
+    template <class T>                                                                \
+    Status CLASS<T>::evaluate(const Schema& schema,                                   \
                                  const std::vector<BitmapIndexIterator*>& iterators,  \
                                  uint32_t num_rows, roaring::Roaring* result) const { \
         BitmapIndexIterator* iterator = iterators[_column_id];                        \

--- a/be/src/olap/in_list_predicate.cpp
+++ b/be/src/olap/in_list_predicate.cpp
@@ -133,7 +133,6 @@ IN_LIST_PRED_COLUMN_BLOCK_EVALUATE(NotInListPredicate, ==)
                 if constexpr (std::is_same_v<type, StringValue>) {                                 \
                     auto* nested_col_ptr = vectorized::check_and_get_column<                       \
                             vectorized::ColumnDictionary<vectorized::Int32>>(nested_col);          \
-                    auto code_set = nested_col_ptr->find_codes(_values);                           \
                     auto& data_array = nested_col_ptr->get_data();                                 \
                     for (uint16_t i = 0; i < *size; i++) {                                         \
                         uint16_t idx = sel[i];                                                     \
@@ -141,7 +140,7 @@ IN_LIST_PRED_COLUMN_BLOCK_EVALUATE(NotInListPredicate, ==)
                         const auto& cell_value =                                                   \
                                 reinterpret_cast<const vectorized::Int32&>(data_array[idx]);       \
                         bool ret = !null_bitmap[idx]                                               \
-                                   && (code_set.find(cell_value) OP code_set.end());               \
+                                   && (_dict_codes.find(cell_value) OP _dict_codes.end());         \
                         new_size += _opposite ? !ret : ret;                                        \
                     }                                                                              \
                 }                                                                                  \
@@ -164,13 +163,12 @@ IN_LIST_PRED_COLUMN_BLOCK_EVALUATE(NotInListPredicate, ==)
                         reinterpret_cast<vectorized::ColumnDictionary<vectorized::Int32>&>(        \
                                 column);                                                           \
                 auto& data_array = dict_col.get_data();                                            \
-                auto code_set = dict_col.find_codes(_values);                                      \
                 for (uint16_t i = 0; i < *size; i++) {                                             \
                     uint16_t idx = sel[i];                                                         \
                     sel[new_size] = idx;                                                           \
                     const auto& cell_value =                                                       \
                             reinterpret_cast<const vectorized::Int32&>(data_array[idx]);           \
-                    auto result = (code_set.find(cell_value) OP code_set.end());                   \
+                    auto result = (_dict_codes.find(cell_value) OP _dict_codes.end());             \
                     new_size += _opposite ? !result : result;                                      \
                 }                                                                                  \
             }                                                                                      \

--- a/be/src/olap/in_list_predicate.h
+++ b/be/src/olap/in_list_predicate.h
@@ -103,8 +103,8 @@ class VectorizedRowBatch;
         phmap::flat_hash_set<int32_t> _dict_codes;                                                \
     };
 
-IN_LIST_PRED_CLASS_DEFINE(InListPredicate, InList)
-IN_LIST_PRED_CLASS_DEFINE(NotInListPredicate, NotInList)
+IN_LIST_PRED_CLASS_DEFINE(InListPredicate, IN_LIST)
+IN_LIST_PRED_CLASS_DEFINE(NotInListPredicate, NO_IN_LIST)
 
 } //namespace doris
 

--- a/be/src/olap/in_list_predicate.h
+++ b/be/src/olap/in_list_predicate.h
@@ -78,11 +78,12 @@ class VectorizedRowBatch;
 
 // todo(wb) support evaluate_and,evaluate_or
 
-#define IN_LIST_PRED_CLASS_DEFINE(CLASS)                                                          \
-    template <class type>                                                                         \
+#define IN_LIST_PRED_CLASS_DEFINE(CLASS, PT)                                                      \
+    template <class T>                                                                            \
     class CLASS : public ColumnPredicate {                                                        \
     public:                                                                                       \
-        CLASS(uint32_t column_id, phmap::flat_hash_set<type>&& values, bool is_opposite = false); \
+        CLASS(uint32_t column_id, phmap::flat_hash_set<T>&& values, bool is_opposite = false);    \
+        PredicateType type() const override { return PredicateType::PT; }                         \
         virtual void evaluate(VectorizedRowBatch* batch) const override;                          \
         void evaluate(ColumnBlock* block, uint16_t* sel, uint16_t* size) const override;          \
         void evaluate_or(ColumnBlock* block, uint16_t* sel, uint16_t size,                        \
@@ -95,18 +96,17 @@ class VectorizedRowBatch;
         void evaluate(vectorized::IColumn& column, uint16_t* sel, uint16_t* size) const override; \
         void evaluate_and(vectorized::IColumn& column, uint16_t* sel, uint16_t size, bool* flags) const override {} \
         void evaluate_or(vectorized::IColumn& column, uint16_t* sel, uint16_t size, bool* flags) const override {} \
-        bool is_in_predicate() override { return true; }                                          \
-        const phmap::flat_hash_set<type>& get_values() const { return _values; }                  \
+        const phmap::flat_hash_set<T>& get_values() const { return _values; }                     \
         void set_dict_codes(phmap::flat_hash_set<int32_t>& dict_codes) {                          \
             _dict_codes = std::move(dict_codes);                                                  \
         }                                                                                         \
     private:                                                                                      \
-        phmap::flat_hash_set<type> _values;                                                       \
+        phmap::flat_hash_set<T> _values;                                                          \
         phmap::flat_hash_set<int32_t> _dict_codes;                                                \
     };
 
-IN_LIST_PRED_CLASS_DEFINE(InListPredicate)
-IN_LIST_PRED_CLASS_DEFINE(NotInListPredicate)
+IN_LIST_PRED_CLASS_DEFINE(InListPredicate, InList)
+IN_LIST_PRED_CLASS_DEFINE(NotInListPredicate, NotInList)
 
 } //namespace doris
 

--- a/be/src/olap/in_list_predicate.h
+++ b/be/src/olap/in_list_predicate.h
@@ -95,9 +95,14 @@ class VectorizedRowBatch;
         void evaluate(vectorized::IColumn& column, uint16_t* sel, uint16_t* size) const override; \
         void evaluate_and(vectorized::IColumn& column, uint16_t* sel, uint16_t size, bool* flags) const override {} \
         void evaluate_or(vectorized::IColumn& column, uint16_t* sel, uint16_t size, bool* flags) const override {} \
-        bool is_in_predicate() override { return true; }                                                                                          \
+        bool is_in_predicate() override { return true; }                                          \
+        const phmap::flat_hash_set<type>& get_values() const { return _values; }                  \
+        void set_dict_codes(phmap::flat_hash_set<int32_t>& dict_codes) {                          \
+            _dict_codes = std::move(dict_codes);                                                  \
+        }                                                                                         \
     private:                                                                                      \
         phmap::flat_hash_set<type> _values;                                                       \
+        phmap::flat_hash_set<int32_t> _dict_codes;                                                \
     };
 
 IN_LIST_PRED_CLASS_DEFINE(InListPredicate)

--- a/be/src/olap/in_list_predicate.h
+++ b/be/src/olap/in_list_predicate.h
@@ -96,12 +96,10 @@ class VectorizedRowBatch;
         void evaluate(vectorized::IColumn& column, uint16_t* sel, uint16_t* size) const override; \
         void evaluate_and(vectorized::IColumn& column, uint16_t* sel, uint16_t size, bool* flags) const override {} \
         void evaluate_or(vectorized::IColumn& column, uint16_t* sel, uint16_t size, bool* flags) const override {} \
-        const phmap::flat_hash_set<T>& get_values() const { return _values; }                     \
-        void set_dict_codes(phmap::flat_hash_set<int32_t>& dict_codes) {                          \
-            _dict_codes = std::move(dict_codes);                                                  \
-        }                                                                                         \
+        void set_dict_code_if_necessary(vectorized::IColumn& column) override;                    \
     private:                                                                                      \
         phmap::flat_hash_set<T> _values;                                                          \
+        bool _dict_code_inited = false;                                                           \
         phmap::flat_hash_set<int32_t> _dict_codes;                                                \
     };
 

--- a/be/src/olap/null_predicate.cpp
+++ b/be/src/olap/null_predicate.cpp
@@ -29,6 +29,13 @@ namespace doris {
 NullPredicate::NullPredicate(uint32_t column_id, bool is_null, bool opposite)
         : ColumnPredicate(column_id), _is_null(opposite != is_null) {}
 
+PredicateType NullPredicate::type() const {
+    if (_is_null)
+        return PredicateType::IsNull;
+    else
+        return PredicateType::NotIsNull;
+}
+
 void NullPredicate::evaluate(VectorizedRowBatch* batch) const {
     uint16_t n = batch->size();
     if (n == 0) {

--- a/be/src/olap/null_predicate.cpp
+++ b/be/src/olap/null_predicate.cpp
@@ -30,10 +30,7 @@ NullPredicate::NullPredicate(uint32_t column_id, bool is_null, bool opposite)
         : ColumnPredicate(column_id), _is_null(opposite != is_null) {}
 
 PredicateType NullPredicate::type() const {
-    if (_is_null)
-        return PredicateType::IsNull;
-    else
-        return PredicateType::NotIsNull;
+    return _is_null ? PredicateType::IS_NULL : PredicateType::NOT_IS_NULL;
 }
 
 void NullPredicate::evaluate(VectorizedRowBatch* batch) const {

--- a/be/src/olap/null_predicate.h
+++ b/be/src/olap/null_predicate.h
@@ -32,6 +32,8 @@ class NullPredicate : public ColumnPredicate {
 public:
     NullPredicate(uint32_t column_id, bool is_null, bool opposite = false);
 
+    virtual PredicateType type() const override;
+
     virtual void evaluate(VectorizedRowBatch* batch) const override;
 
     void evaluate(ColumnBlock* block, uint16_t* sel, uint16_t* size) const override;

--- a/be/src/olap/rowset/segment_v2/binary_dict_page.cpp
+++ b/be/src/olap/rowset/segment_v2/binary_dict_page.cpp
@@ -240,18 +240,7 @@ void BinaryDictPageDecoder::set_dict_decoder(PageDecoder* dict_decoder, StringRe
 
 Status BinaryDictPageDecoder::next_batch(size_t* n, vectorized::MutableColumnPtr &dst) {
     if (_encoding_type == PLAIN_ENCODING) {
-        // todo(zeno) Handle convert in ColumnDictionary,
-        //  add interface like convert_to_predicate_column_if_necessary
-        auto* col_ptr = dst.get();
-        if (dst->is_nullable()) {
-            auto nullable_col = reinterpret_cast<vectorized::ColumnNullable*>(dst.get());
-            col_ptr = nullable_col->get_nested_column_ptr().get();
-        }
-
-        if (col_ptr->is_column_dictionary()) {
-            auto* dict_col_ptr = reinterpret_cast<vectorized::ColumnDictionary<vectorized::Int32>*>(col_ptr);
-            col_ptr = (*std::move(dict_col_ptr->convert_to_predicate_column())).assume_mutable();
-        }
+        dst = (*(std::move(dst->convert_to_predicate_column_if_dictionary()))).assume_mutable();
         return _data_page_decoder->next_batch(n, dst);
     }
     // dictionary encoding

--- a/be/src/olap/rowset/segment_v2/segment_iterator.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.cpp
@@ -607,8 +607,8 @@ void SegmentIterator::_vec_init_lazy_materialization() {
 
             if (type == OLAP_FIELD_TYPE_VARCHAR || type == OLAP_FIELD_TYPE_CHAR ||
                 type == OLAP_FIELD_TYPE_STRING || predicate->type() == PredicateType::BF ||
-                predicate->type() == PredicateType::InList ||
-                predicate->type() == PredicateType::NotInList) {
+                predicate->type() == PredicateType::IN_LIST ||
+                predicate->type() == PredicateType::NO_IN_LIST) {
                 short_cir_pred_col_id_set.insert(cid);
                 _short_cir_eval_predicate.push_back(predicate);
                 _is_all_column_basic_type = false;

--- a/be/src/olap/rowset/segment_v2/segment_iterator.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.cpp
@@ -840,7 +840,7 @@ void SegmentIterator::_evaluate_short_circuit_predicate(uint16_t* vec_sel_rowid_
             predicate->type() == PredicateType::GT || predicate->type() == PredicateType::GE) {
             col_ptr->convert_dict_codes_if_necessary();
         }
-        col_ptr->set_predicate_dict_code_if_necessary(predicate);
+        predicate->set_dict_code_if_necessary(*short_cir_column);
         predicate->evaluate(*short_cir_column, vec_sel_rowid_idx, selected_size_ptr);
     }
 

--- a/be/src/olap/rowset/segment_v2/segment_iterator.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.cpp
@@ -606,9 +606,9 @@ void SegmentIterator::_vec_init_lazy_materialization() {
             pred_column_ids.insert(cid);
 
             if (type == OLAP_FIELD_TYPE_VARCHAR || type == OLAP_FIELD_TYPE_CHAR ||
-                type == OLAP_FIELD_TYPE_STRING || predicate->type() == PredicateType::InList ||
-                predicate->type() == PredicateType::NotInList ||
-                predicate->type() == PredicateType::BF) {
+                type == OLAP_FIELD_TYPE_STRING || predicate->type() == PredicateType::BF ||
+                predicate->type() == PredicateType::InList ||
+                predicate->type() == PredicateType::NotInList) {
                 short_cir_pred_col_id_set.insert(cid);
                 _short_cir_eval_predicate.push_back(predicate);
                 _is_all_column_basic_type = false;

--- a/be/src/runtime/string_value.h
+++ b/be/src/runtime/string_value.h
@@ -188,6 +188,12 @@ struct StringValue {
             return a.compare(b) < 0;
         }
     };
+
+    struct HashOfStringValue {
+        size_t operator()(const StringValue& v) const {
+            return HashUtil::hash(v.ptr, v.len, 0);
+        }
+    };
 };
 
 // This function must be called 'hash_value' to be picked up by boost.

--- a/be/src/vec/columns/column.h
+++ b/be/src/vec/columns/column.h
@@ -30,7 +30,11 @@
 
 class SipHash;
 
-namespace doris::vectorized {
+namespace doris{
+
+class ColumnPredicate;
+
+namespace vectorized {
 
 class Arena;
 class Field;
@@ -63,6 +67,16 @@ public:
     /// If column isn't ColumnLowCardinality, return itself.
     /// If column is ColumnLowCardinality, transforms is to full column.
     virtual Ptr convert_to_full_column_if_low_cardinality() const { return get_ptr(); }
+
+    /// If column isn't ColumnDictionary, return itself.
+    /// If column is ColumnDictionary, transforms is to predicate column.
+    virtual Ptr convert_to_predicate_column_if_dictionary() { return get_ptr(); }
+
+    /// If column is ColumnDictionary, and is a range comparison predicate, convert dict encoding
+    virtual void convert_dict_codes_if_necessary() {}
+
+    /// If column is ColumnDictionary, set dict code for predicate
+    virtual void set_predicate_dict_code_if_necessary(doris::ColumnPredicate* predicate) {}
 
     /// Creates empty column with the same type.
     virtual MutablePtr clone_empty() const { return clone_resized(0); }
@@ -518,8 +532,8 @@ bool is_column_const(const IColumn& column);
 
 /// True if column's an ColumnNullable instance. It's just a syntax sugar for type check.
 bool is_column_nullable(const IColumn& column);
-
-} // namespace doris::vectorized
+} // namespace vectorized
+} // namespace doris
 
 // Wrap `ColumnPtr` because `ColumnPtr` can't be used in forward declaration.
 namespace doris {

--- a/be/src/vec/columns/column.h
+++ b/be/src/vec/columns/column.h
@@ -30,11 +30,7 @@
 
 class SipHash;
 
-namespace doris{
-
-class ColumnPredicate;
-
-namespace vectorized {
+namespace doris::vectorized {
 
 class Arena;
 class Field;
@@ -74,9 +70,6 @@ public:
 
     /// If column is ColumnDictionary, and is a range comparison predicate, convert dict encoding
     virtual void convert_dict_codes_if_necessary() {}
-
-    /// If column is ColumnDictionary, set dict code for predicate
-    virtual void set_predicate_dict_code_if_necessary(doris::ColumnPredicate* predicate) {}
 
     /// Creates empty column with the same type.
     virtual MutablePtr clone_empty() const { return clone_resized(0); }
@@ -532,8 +525,7 @@ bool is_column_const(const IColumn& column);
 
 /// True if column's an ColumnNullable instance. It's just a syntax sugar for type check.
 bool is_column_nullable(const IColumn& column);
-} // namespace vectorized
-} // namespace doris
+} // namespace doris::vectorized
 
 // Wrap `ColumnPtr` because `ColumnPtr` can't be used in forward declaration.
 namespace doris {

--- a/be/src/vec/columns/column_dictionary.h
+++ b/be/src/vec/columns/column_dictionary.h
@@ -33,6 +33,10 @@
 #include "vec/columns/column_vector.h"
 #include "vec/columns/predicate_column.h"
 #include "vec/core/types.h"
+#include "vec/common/typeid_cast.h"
+#include "olap/column_predicate.h"
+#include "olap/comparison_predicate.h"
+#include "olap/in_list_predicate.h"
 
 namespace doris::vectorized {
 
@@ -54,8 +58,8 @@ private:
     friend class COWHelper<IColumn, ColumnDictionary>;
 
     ColumnDictionary() {}
-    ColumnDictionary(const size_t n) : codes(n) {}
-    ColumnDictionary(const ColumnDictionary& src) : codes(src.codes.begin(), src.codes.end()) {}
+    ColumnDictionary(const size_t n) : _codes(n) {}
+    ColumnDictionary(const ColumnDictionary& src) : _codes(src._codes.begin(), src._codes.end()) {}
 
 public:
     using Self = ColumnDictionary;
@@ -63,13 +67,9 @@ public:
     using Container = PaddedPODArray<value_type>;
     using DictContainer = PaddedPODArray<StringValue>;
 
-    bool is_numeric() const override { return false; }
-
-    bool is_predicate_column() const override { return false; }
-
     bool is_column_dictionary() const override { return true; }
 
-    size_t size() const override { return codes.size(); }
+    size_t size() const override { return _codes.size(); }
 
     [[noreturn]] StringRef get_data_at(size_t n) const override {
         LOG(FATAL) << "get_data_at not supported in ColumnDictionary";
@@ -95,17 +95,17 @@ public:
     }
 
     void insert_data(const char* pos, size_t /*length*/) override {
-        codes.push_back(unaligned_load<T>(pos));
+        _codes.push_back(unaligned_load<T>(pos));
     }
 
-    void insert_data(const T value) { codes.push_back(value); }
+    void insert_data(const T value) { _codes.push_back(value); }
 
-    void insert_default() override { codes.push_back(T()); }
+    void insert_default() override { _codes.push_back(T()); }
 
-    void clear() override { codes.clear(); }
+    void clear() override { _codes.clear(); }
 
     // TODO: Make dict memory usage more precise
-    size_t byte_size() const override { return codes.size() * sizeof(codes[0]); }
+    size_t byte_size() const override { return _codes.size() * sizeof(_codes[0]); }
 
     size_t allocated_bytes() const override { return byte_size(); }
 
@@ -116,7 +116,7 @@ public:
         LOG(FATAL) << "get_permutation not supported in ColumnDictionary";
     }
 
-    void reserve(size_t n) override { codes.reserve(n); }
+    void reserve(size_t n) override { _codes.reserve(n); }
 
     [[noreturn]] const char* get_family_name() const override {
         LOG(FATAL) << "get_family_name not supported in ColumnDictionary";
@@ -130,7 +130,7 @@ public:
         LOG(FATAL) << "insert not supported in ColumnDictionary";
     }
 
-    Field operator[](size_t n) const override { return codes[n]; }
+    Field operator[](size_t n) const override { return _codes[n]; }
 
     void get(size_t n, Field& res) const override { res = (*this)[n]; }
 
@@ -154,19 +154,9 @@ public:
         LOG(FATAL) << "get field not supported in ColumnDictionary";
     }
 
-    Container& get_data() { return codes; }
+    Container& get_data() { return _codes; }
 
-    const Container& get_data() const { return codes; }
-
-    T find_code(const StringValue& value) const { return dict.find_code(value); }
-
-    T find_bound_code(const StringValue& value, bool lower, bool eq) const {
-        return dict.find_bound_code(value, lower, eq);
-    }
-
-    phmap::flat_hash_set<T> find_codes(const phmap::flat_hash_set<StringValue>& values) const {
-        return dict.find_codes(values);
-    }
+    const Container& get_data() const { return _codes; }
 
     // it's impossable to use ComplexType as key , so we don't have to implemnt them
     [[noreturn]] StringRef serialize_value_into_arena(size_t n, Arena& arena,
@@ -223,8 +213,8 @@ public:
         auto* res_col = reinterpret_cast<vectorized::ColumnString*>(col_ptr);
         for (size_t i = 0; i < sel_size; i++) {
             uint16_t n = sel[i];
-            auto& code = reinterpret_cast<T&>(codes[n]);
-            auto value = dict.get_value(code);
+            auto& code = reinterpret_cast<T&>(_codes[n]);
+            auto value = _dict.get_value(code);
             res_col->insert_data(value.ptr, value.len);
         }
         return Status::OK();
@@ -242,18 +232,53 @@ public:
                                const StringRef* dict_array, size_t data_num,
                                uint32_t dict_num) override {
         if (!is_dict_inited()) {
-            dict.reserve(dict_num);
+            _dict.reserve(dict_num);
             for (uint32_t i = 0; i < dict_num; ++i) {
                 auto value = StringValue(dict_array[i].data, dict_array[i].size);
-                dict.insert_value(value);
+                _dict.insert_value(value);
             }
             _dict_inited = true;
         }
 
-        char* end_ptr = (char*)codes.get_end_ptr();
+        char* end_ptr = (char*)_codes.get_end_ptr();
         memcpy(end_ptr, data_array + start_index, data_num * sizeof(T));
         end_ptr += data_num * sizeof(T);
-        codes.set_end_ptr(end_ptr);
+        _codes.set_end_ptr(end_ptr);
+    }
+
+    void convert_dict_codes_if_necessary() override {
+        if (!is_dict_sorted()) {
+            sort_dict();
+        }
+
+        if (!is_dict_code_converted()) {
+            for (size_t i = 0; i < size(); ++i) {
+                _codes[i] = _dict.convert_code(_codes[i]);
+            }
+            _dict_code_converted = true;
+        }
+    }
+
+    void set_predicate_dict_code_if_necessary(doris::ColumnPredicate* predicate) override {
+        if (predicate->is_equal_comparison_predicate()) {
+            // cast to EqualPredicate, just to get value, may not be EqualPredicate
+            auto* comp_pred = reinterpret_cast<doris::EqualPredicate<StringValue>*>(predicate);
+            auto pred_value = comp_pred->get_value();
+            auto code = _dict.find_code(pred_value);
+            comp_pred->set_dict_code(code);
+        } else if (predicate->is_range_comparison_predicate()) {
+            // cast to LessPredicate, just to get value, may not be LessPredicate
+            auto* comp_pred = reinterpret_cast<doris::LessPredicate<StringValue>*>(predicate);
+            auto pred_value = comp_pred->get_value();
+            auto code = _dict.find_bound_code(pred_value, predicate->is_less(),
+                                              predicate->contain_equal());
+            comp_pred->set_dict_code(code);
+        } else if (predicate->is_in_predicate()) {
+            auto* in_pred = reinterpret_cast<doris::InListPredicate<StringValue>*>(predicate);
+            auto pred_values = in_pred->get_values();
+            auto code_set = _dict.find_codes(pred_values);
+            in_pred->set_dict_codes(code_set);
+        }
     }
 
     bool is_dict_inited() const { return _dict_inited; }
@@ -264,32 +289,32 @@ public:
 
     ColumnPtr convert_to_predicate_column() {
         auto res = vectorized::PredicateColumnType<StringValue>::create();
-        size_t size = codes.size();
+        size_t size = _codes.size();
         res->reserve(size);
         for (size_t i = 0; i < size; ++i) {
-            auto& code = reinterpret_cast<T&>(codes[i]);
-            auto value = dict.get_value(code);
+            auto& code = reinterpret_cast<T&>(_codes[i]);
+            auto value = _dict.get_value(code);
             res->insert_data(value.ptr, value.len);
         }
-        dict.clear();
+        _dict.clear();
         return res;
     }
 
-    void convert_dict_codes() {
-        if (!is_dict_sorted()) {
-            sort_dict();
+    ColumnPtr convert_to_predicate_column_if_dictionary() override {
+        auto res = vectorized::PredicateColumnType<StringValue>::create();
+        size_t size = _codes.size();
+        res->reserve(size);
+        for (size_t i = 0; i < size; ++i) {
+            auto& code = reinterpret_cast<T&>(_codes[i]);
+            auto value = _dict.get_value(code);
+            res->insert_data(value.ptr, value.len);
         }
-
-        if (!is_dict_code_converted()) {
-            for (size_t i = 0; i < size(); ++i) {
-                codes[i] = dict.convert_code(codes[i]);
-            }
-            _dict_code_converted = true;
-        }
+        _dict.clear();
+        return res;
     }
 
     void sort_dict() {
-        dict.sort();
+        _dict.sort();
         _dict_sorted = true;
     }
 
@@ -298,18 +323,18 @@ public:
         Dictionary() = default;
 
         void reserve(size_t n) {
-            dict_data.reserve(n);
-            inverted_index.reserve(n);
+            _dict_data.reserve(n);
+            _inverted_index.reserve(n);
         }
 
         inline void insert_value(StringValue& value) {
-            dict_data.push_back_without_reserve(value);
-            inverted_index[value] = inverted_index.size();
+            _dict_data.push_back_without_reserve(value);
+            _inverted_index[value] = _inverted_index.size();
         }
 
         inline T find_code(const StringValue& value) const {
-            auto it = inverted_index.find(value);
-            if (it != inverted_index.end()) {
+            auto it = _inverted_index.find(value);
+            if (it != _inverted_index.end()) {
                 return it->second;
             }
             return -1;
@@ -330,61 +355,60 @@ public:
             }
         }
 
-        inline phmap::flat_hash_set<T> find_codes(
+        inline phmap::flat_hash_set<int32_t> find_codes(
                 const phmap::flat_hash_set<StringValue>& values) const {
-            phmap::flat_hash_set<T> code_set;
+            phmap::flat_hash_set<int32_t> code_set;
             for (const auto& value : values) {
-                auto it = inverted_index.find(value);
-                if (it != inverted_index.end()) {
+                auto it = _inverted_index.find(value);
+                if (it != _inverted_index.end()) {
                     code_set.insert(it->second);
                 }
             }
             return code_set;
         }
 
-        inline StringValue& get_value(T code) { return dict_data[code]; }
+        inline StringValue& get_value(T code) { return _dict_data[code]; }
 
         void clear() {
-            dict_data.clear();
-            inverted_index.clear();
-            code_convert_map.clear();
+            _dict_data.clear();
+            _inverted_index.clear();
+            _code_convert_map.clear();
         }
 
         void sort() {
-            size_t dict_size = dict_data.size();
-            std::sort(dict_data.begin(), dict_data.end(), comparator);
+            size_t dict_size = _dict_data.size();
+            std::sort(_dict_data.begin(), _dict_data.end(), _comparator);
             for (size_t i = 0; i < dict_size; ++i) {
-                code_convert_map[inverted_index.find(dict_data[i])->second] = (T)i;
-                inverted_index[dict_data[i]] = (T)i;
+                _code_convert_map[_inverted_index.find(_dict_data[i])->second] = (T)i;
+                _inverted_index[_dict_data[i]] = (T)i;
             }
         }
 
-        inline T convert_code(const T& code) const { return code_convert_map.find(code)->second; }
+        inline T convert_code(const T& code) const { return _code_convert_map.find(code)->second; }
 
-        size_t byte_size() { return dict_data.size() * sizeof(dict_data[0]); }
+        size_t byte_size() { return _dict_data.size() * sizeof(_dict_data[0]); }
 
     private:
-        struct HashOfStringValue {
-            size_t operator()(const StringValue& value) const {
-                return HashStringThoroughly(value.ptr, value.len);
-            }
-        };
-
-        StringValue::Comparator comparator;
+        StringValue::Comparator _comparator;
         // dict code -> dict value
-        DictContainer dict_data;
+        DictContainer _dict_data;
         // dict value -> dict code
-        phmap::flat_hash_map<StringValue, T, HashOfStringValue> inverted_index;
+        phmap::flat_hash_map<StringValue, T, StringValue::HashOfStringValue> _inverted_index;
         // data page code -> sorted dict code, only used for range comparison predicate
-        phmap::flat_hash_map<T, T> code_convert_map;
+        phmap::flat_hash_map<T, T> _code_convert_map;
     };
 
 private:
     bool _dict_inited = false;
     bool _dict_sorted = false;
     bool _dict_code_converted = false;
-    Dictionary dict;
-    Container codes;
+    Dictionary _dict;
+    Container _codes;
 };
+
+template class ColumnDictionary<uint8_t>;
+template class ColumnDictionary<uint16_t>;
+template class ColumnDictionary<uint32_t>;
+template class ColumnDictionary<int32_t>;
 
 } // namespace doris::vectorized

--- a/be/src/vec/columns/column_dictionary.h
+++ b/be/src/vec/columns/column_dictionary.h
@@ -102,7 +102,10 @@ public:
 
     void insert_default() override { _codes.push_back(T()); }
 
-    void clear() override { _codes.clear(); }
+    void clear() override {
+        _codes.clear();
+        _dict_code_converted = false;
+    }
 
     // TODO: Make dict memory usage more precise
     size_t byte_size() const override { return _codes.size() * sizeof(_codes[0]); }
@@ -226,7 +229,8 @@ public:
 
     void convert_dict_codes_if_necessary() override {
         if (!is_dict_sorted()) {
-            sort_dict();
+            _dict.sort();
+            _dict_sorted = true;
         }
 
         if (!is_dict_code_converted()) {
@@ -310,11 +314,6 @@ public:
         return res;
     }
 
-    void sort_dict() {
-        _dict.sort();
-        _dict_sorted = true;
-    }
-
     class Dictionary {
     public:
         Dictionary() = default;
@@ -344,11 +343,11 @@ public:
             }
 
             if (lower) {
-                return std::lower_bound(dict_data.begin(), dict_data.end(), value) -
-                       dict_data.begin() - eq;
+                return std::lower_bound(_dict_data.begin(), _dict_data.end(), value) -
+                       _dict_data.begin() - eq;
             } else {
-                return std::upper_bound(dict_data.begin(), dict_data.end(), value) -
-                       dict_data.begin() + eq;
+                return std::upper_bound(_dict_data.begin(), _dict_data.end(), value) -
+                       _dict_data.begin() + eq;
             }
         }
 

--- a/be/src/vec/columns/column_dictionary.h
+++ b/be/src/vec/columns/column_dictionary.h
@@ -259,19 +259,6 @@ public:
 
     bool is_dict_code_converted() const { return _dict_code_converted; }
 
-    ColumnPtr convert_to_predicate_column() {
-        auto res = vectorized::PredicateColumnType<StringValue>::create();
-        size_t size = _codes.size();
-        res->reserve(size);
-        for (size_t i = 0; i < size; ++i) {
-            auto& code = reinterpret_cast<T&>(_codes[i]);
-            auto value = _dict.get_value(code);
-            res->insert_data(value.ptr, value.len);
-        }
-        _dict.clear();
-        return res;
-    }
-
     ColumnPtr convert_to_predicate_column_if_dictionary() override {
         auto res = vectorized::PredicateColumnType<StringValue>::create();
         size_t size = _codes.size();

--- a/be/src/vec/columns/column_nullable.h
+++ b/be/src/vec/columns/column_nullable.h
@@ -267,6 +267,21 @@ public:
         LOG(FATAL) << "should not call the method in column nullable";
     }
 
+    ColumnPtr convert_to_predicate_column_if_dictionary() override {
+        IColumn* nested_ptr = get_nested_column_ptr().get();
+        nested_ptr = (*(std::move(nested_ptr->convert_to_predicate_column_if_dictionary()
+                                  ))).assume_mutable();
+        return get_ptr();
+    }
+
+    void convert_dict_codes_if_necessary() override {
+        get_nested_column().convert_dict_codes_if_necessary();
+    }
+
+    void set_predicate_dict_code_if_necessary(doris::ColumnPredicate* predicate) override {
+        get_nested_column().set_predicate_dict_code_if_necessary(predicate);
+    }
+
 private:
     WrappedPtr nested_column;
     WrappedPtr null_map;

--- a/be/src/vec/columns/column_nullable.h
+++ b/be/src/vec/columns/column_nullable.h
@@ -278,10 +278,6 @@ public:
         get_nested_column().convert_dict_codes_if_necessary();
     }
 
-    void set_predicate_dict_code_if_necessary(doris::ColumnPredicate* predicate) override {
-        get_nested_column().set_predicate_dict_code_if_necessary(predicate);
-    }
-
 private:
     WrappedPtr nested_column;
     WrappedPtr null_map;


### PR DESCRIPTION
# Proposed changes

Issue Number: close #8315 
Code optimization and refactoring for low-cardinality columns in storage layer.

## Problem Summary:

Optimization:
- Add `dict_code` member variable to the predicate. Before the predicate is calculated, the conversion of the predicate constant into the dictionary code only needs to be done once


Refactor:
- Add `PredicateType` enum, add `type` method to the predicate, which is used to represent the predicate type, instead of the original less flexible way, for example: `is_in_predicate()` ...
- Added the following interface to `IColumn` to simplify the code of the storage layer and avoid exposing the specific type of column:
     - `convert_to_predicate_column_if_dictionary`
     - `convert_dict_codes_if_necessary`
     - `set_predicate_dict_code_if_necessary`
- Class member variables start with an underscore
- Specify the `int` type only supported by the specialized `ColumnDictionary` template

In addition to this, there are some priorities that I will provide in the coming period.
