### PR TITLE
[Opt] Optimize hotspot functions in pre-compaction

### DIFF
--- a/be/src/olap/cumulative_compaction_policy.cpp
+++ b/be/src/olap/cumulative_compaction_policy.cpp
@@ -460,7 +460,7 @@ void NumBasedCumulativeCompactionPolicy::calculate_cumulative_point(
 
 void CumulativeCompactionPolicy::pick_candidate_rowsets(
         int64_t skip_window_sec,
-        const std::unordered_map<Version, RowsetSharedPtr, HashOfVersion>& rs_version_map,
+        const phmap::flat_hash_map<Version, RowsetSharedPtr, HashOfVersion>& rs_version_map,
         int64_t cumulative_point, std::vector<RowsetSharedPtr>* candidate_rowsets) {
     int64_t now = UnixSeconds();
     for (auto& it : rs_version_map) {

--- a/be/src/olap/cumulative_compaction_policy.h
+++ b/be/src/olap/cumulative_compaction_policy.h
@@ -18,7 +18,7 @@
 #pragma once
 
 #include <string>
-
+#include <parallel_hashmap/phmap.h>
 #include "olap/rowset/rowset.h"
 #include "olap/rowset/rowset_meta.h"
 #include "olap/tablet.h"
@@ -75,7 +75,7 @@ public:
     /// return candidate_rowsets, the container of candidate rowsets
     virtual void pick_candidate_rowsets(
             int64_t skip_window_sec,
-            const std::unordered_map<Version, RowsetSharedPtr, HashOfVersion>& rs_version_map,
+            const phmap::flat_hash_map<Version, RowsetSharedPtr, HashOfVersion>& rs_version_map,
             int64_t cumulative_point, std::vector<RowsetSharedPtr>* candidate_rowsets);
 
     /// Pick input rowsets from candidate rowsets for compaction. This function is pure virtual function.

--- a/be/src/olap/snapshot_manager.cpp
+++ b/be/src/olap/snapshot_manager.cpp
@@ -156,7 +156,7 @@ Status SnapshotManager::convert_rowset_ids(const FilePathDesc& clone_dir_desc, i
     TabletSchema tablet_schema;
     tablet_schema.init_from_pb(new_tablet_meta_pb.schema());
 
-    std::unordered_map<Version, RowsetMetaPB*, HashOfVersion> rs_version_map;
+    phmap::flat_hash_map<Version, RowsetMetaPB*, HashOfVersion> rs_version_map;
     for (auto& visible_rowset : cloned_tablet_meta_pb.rs_metas()) {
         RowsetMetaPB* rowset_meta = new_tablet_meta_pb.add_rs_metas();
         RowsetId rowset_id = StorageEngine::instance()->next_rowset_id();

--- a/be/src/olap/tablet.h
+++ b/be/src/olap/tablet.h
@@ -21,7 +21,7 @@
 #include <memory>
 #include <set>
 #include <string>
-#include <unordered_map>
+#include <parallel_hashmap/phmap.h>
 #include <vector>
 
 #include "gen_cpp/AgentService_types.h"
@@ -302,11 +302,11 @@ private:
     mutable std::shared_mutex _meta_lock;
     // After version 0.13, all newly created rowsets are saved in _rs_version_map.
     // And if rowset being compacted, the old rowsetis will be saved in _stale_rs_version_map;
-    std::unordered_map<Version, RowsetSharedPtr, HashOfVersion> _rs_version_map;
+    phmap::flat_hash_map<Version, RowsetSharedPtr, HashOfVersion> _rs_version_map;
     // This variable _stale_rs_version_map is used to record these rowsets which are be compacted.
     // These _stale rowsets are been removed when rowsets' pathVersion is expired,
     // this policy is judged and computed by TimestampedVersionTracker.
-    std::unordered_map<Version, RowsetSharedPtr, HashOfVersion> _stale_rs_version_map;
+    phmap::flat_hash_map<Version, RowsetSharedPtr, HashOfVersion> _stale_rs_version_map;
     // if this tablet is broken, set to true. default is false
     std::atomic<bool> _is_bad;
     // timestamp of last cumu compaction failure

--- a/be/src/olap/tablet_meta.h
+++ b/be/src/olap/tablet_meta.h
@@ -123,6 +123,7 @@ public:
     // disk space occupied by tablet
     size_t tablet_footprint() const;
     size_t version_count() const;
+    void update_max_version();
     Version max_version() const;
 
     TabletState tablet_state() const;
@@ -198,7 +199,8 @@ private:
     // the reference of _schema may use in tablet, so here need keep
     // the lifetime of tablemeta and _schema is same with tablet
     std::shared_ptr<TabletSchema> _schema;
-
+    // _maxVersion record _rs_metas's max endVersion Version
+    Version _maxVersion = {-1, 0};
     std::vector<RowsetMetaSharedPtr> _rs_metas;
     // This variable _stale_rs_metas is used to record these rowsets‘ meta which are be compacted.
     // These stale rowsets meta are been removed when rowsets' pathVersion is expired,

--- a/be/src/olap/tablet_meta.h
+++ b/be/src/olap/tablet_meta.h
@@ -199,8 +199,8 @@ private:
     // the reference of _schema may use in tablet, so here need keep
     // the lifetime of tablemeta and _schema is same with tablet
     std::shared_ptr<TabletSchema> _schema;
-    // _maxVersion record _rs_metas's max endVersion Version
-    Version _maxVersion = {-1, 0};
+    // _max_version record _rs_metas's max endVersion Version
+    Version _max_version = {-1, 0};
     std::vector<RowsetMetaSharedPtr> _rs_metas;
     // This variable _stale_rs_metas is used to record these rowsets‘ meta which are be compacted.
     // These stale rowsets meta are been removed when rowsets' pathVersion is expired,


### PR DESCRIPTION
## Proposed changes
**Compaction** is very cpu consuming, 
after test, I found partial bottleneck is in function `rowset_with_max_version` 
so made following targeted performance tuning:

- better time cost O(1) function`max_version()` rather than previous heavy and hotspot O(n)
- use faster `phmap::flat_hash_map` replace `rs_version_map` and `_stale_rs_version_map` data structure
- use key word `inline` for frequently used small function
- remove some unnecessary inline keywords 

reference:
https://llvm.org/docs/CodingStandards.html#don-t-use-inline-when-defining-a-function-in-a-class-definition 
https://isocpp.org/wiki/faq/inline-functions#where-to-put-inline-keyword

### Previous: 
`Tablet::can_do_compaction` 40%, like Health Kit in China, red means unhealth.

<img width="1331" alt="previous" src="https://user-images.githubusercontent.com/35688959/159883132-ce6f2409-b9b3-4f68-b486-8996f5c54106.png">

### Enhancement:
`Tablet::can_do_compaction` 20%, like Health Kit in China, green means health.

<img width="1347" alt="max_version_V2" src="https://user-images.githubusercontent.com/35688959/159883088-19b9c97c-3ecd-49f5-9524-a662b40c0f29.png">