### PR TITLE
[bug] (sql_block_rule) Fix sql block rule bug

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/blockrule/SqlBlockRuleMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/blockrule/SqlBlockRuleMgr.java
@@ -231,11 +231,11 @@ public class SqlBlockRuleMgr implements Writable {
                     || (rule.getTabletNum() != 0 && rule.getTabletNum() < tabletNum)
                     || (rule.getCardinality() != 0 && rule.getCardinality() < cardinality)) {
                 MetricRepo.COUNTER_HIT_SQL_BLOCK_RULE.increase(1L);
-                if (rule.getPartitionNum() < partitionNum) {
+                if (rule.getPartitionNum() < partitionNum && rule.getPartitionNum() != 0) {
                     throw new AnalysisException("sql hits sql block rule: " + rule.getName() + ", reach partition_num : " + rule.getPartitionNum());
-                } else if (rule.getTabletNum() < tabletNum) {
+                } else if (rule.getTabletNum() < tabletNum && rule.getTabletNum() != 0) {
                     throw new AnalysisException("sql hits sql block rule: " + rule.getName() + ", reach tablet_num : " + rule.getTabletNum());
-                } else if (rule.getCardinality() < cardinality) {
+                } else if (rule.getCardinality() < cardinality && rule.getCardinality() != 0) {
                     throw new AnalysisException("sql hits sql block rule: " + rule.getName() + ", reach cardinality : " + rule.getCardinality());
                 }
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/UserProperty.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/UserProperty.java
@@ -275,9 +275,9 @@ public class UserProperty implements Writable {
                     throw new DdlException(PROP_SQL_BLOCK_RULES + " format error");
                 }
                 // check if sql_block_rule has already exist
-                for (String rule_name : value.replaceAll(" ","").split(",")){
-                    if (!rule_name.equals("") && !Catalog.getCurrentCatalog().getSqlBlockRuleMgr().existRule(rule_name)){
-                        throw new DdlException("the sql block rule " + rule_name + " not exist");
+                for (String ruleName : value.replaceAll(" ","").split(",")){
+                    if (!ruleName.equals("") && !Catalog.getCurrentCatalog().getSqlBlockRuleMgr().existRule(ruleName)){
+                        throw new DdlException("the sql block rule " + ruleName + " not exist");
                     }
                 }
                 sqlBlockRules = value;

--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/UserProperty.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/UserProperty.java
@@ -274,6 +274,12 @@ public class UserProperty implements Writable {
                 if (keyArr.length != 1) {
                     throw new DdlException(PROP_SQL_BLOCK_RULES + " format error");
                 }
+                // check if sql_block_rule has already exist
+                for (String rule_name : value.replaceAll(" ","").split(",")){
+                    if (!rule_name.equals("") && !Catalog.getCurrentCatalog().getSqlBlockRuleMgr().existRule(rule_name)){
+                        throw new DdlException("the sql block rule " + rule_name + " not exist");
+                    }
+                }
                 sqlBlockRules = value;
             } else if (keyArr[0].equalsIgnoreCase(PROP_CPU_RESOURCE_LIMIT)) {
                 // set property "cpu_resource_limit" = "2";

--- a/fe/fe-core/src/test/java/org/apache/doris/blockrule/SqlBlockRuleMgrTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/blockrule/SqlBlockRuleMgrTest.java
@@ -287,4 +287,41 @@ public class SqlBlockRuleMgrTest {
         Assert.assertEquals(1, mgr.getSqlBlockRule(showStmt).size());
         Assert.assertEquals("select \\* from test_table", mgr.getSqlBlockRule(showStmt).get(0).getSql());
     }
+
+    @Test
+    public void testLimitationsInvalid() throws Exception {
+        SqlBlockRuleMgr mgr = new SqlBlockRuleMgr();
+
+        // create sql_block_rule with partition_num = -1
+        // DdlException: the value of partition_num can't be a negative
+        String createSql = "CREATE SQL_BLOCK_RULE test_rule PROPERTIES(\"partition_num\"=\"-1\",\"enable\"=\"true\")";
+        CreateSqlBlockRuleStmt stmt = (CreateSqlBlockRuleStmt) UtFrameUtils.parseAndAnalyzeStmt(createSql, connectContext);
+        ExceptionChecker.expectThrowsWithMsg(DdlException.class, "the value of partition_num can't be a negative",
+                () -> mgr.createSqlBlockRule(stmt));
+
+        // create sql_block_rule with tablet_num = -1
+        // DdlException: the value of tablet_num can't be a negative
+        String createSql1 = "CREATE SQL_BLOCK_RULE test_rule PROPERTIES(\"tablet_num\"=\"-1\",\"enable\"=\"true\")";
+        CreateSqlBlockRuleStmt stmt1 = (CreateSqlBlockRuleStmt) UtFrameUtils.parseAndAnalyzeStmt(createSql1, connectContext);
+        ExceptionChecker.expectThrowsWithMsg(DdlException.class, "the value of tablet_num can't be a negative",
+                () -> mgr.createSqlBlockRule(stmt1));
+
+        // create sql_block_rule with cardinality = -1
+        // DdlException: the value of cardinality can't be a negative
+        String createSql2 = "CREATE SQL_BLOCK_RULE test_rule PROPERTIES(\"cardinality\"=\"-1\",\"enable\"=\"true\")";
+        CreateSqlBlockRuleStmt stmt2 = (CreateSqlBlockRuleStmt) UtFrameUtils.parseAndAnalyzeStmt(createSql2, connectContext);
+        ExceptionChecker.expectThrowsWithMsg(DdlException.class, "the value of cardinality can't be a negative",
+                () -> mgr.createSqlBlockRule(stmt2));
+    }
+
+    @Test
+    public void testUserPropertyInvalid() throws Exception {
+        // sql block rules
+        String setPropertyStr = "set property for \"root\" \"sql_block_rules\" = \"test_rule\"";
+        SetUserPropertyStmt setUserPropertyStmt = (SetUserPropertyStmt) UtFrameUtils.parseAndAnalyzeStmt(setPropertyStr, connectContext);
+
+        ExceptionChecker.expectThrowsWithMsg(DdlException.class, "the sql block rule test_rule not exist",
+                () -> Catalog.getCurrentCatalog().getAuth().updateUserProperty(setUserPropertyStmt));
+
+    }
 }


### PR DESCRIPTION
# Proposed changes

Issue Number: #8629 & #8621

## Problem Summary:

1. Check properties'  effectiveness of a sql_block_rule, can't set limitations of sql_block_rule to be negative.
2. Optimize the judgment conditions when a query hits a sql_block_rule
3. Check if sql_block_rule has already exist when exec `set property for "user" "sql_block_rule" = "xxx"`

## Checklist(Required)

1. Does it affect the original behavior: (Yes)
4. Has unit tests been added: (No Need)
5. Has document been added or modified: (No)
6. Does it need to update dependencies: (No)
7. Are there any changes that cannot be rolled back: (No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
