### PR TITLE
[bug](vec) fix coredump for aggregate function

### DIFF
--- a/be/src/vec/aggregate_functions/aggregate_function_min_max.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_min_max.h
@@ -225,7 +225,7 @@ private:
     char small_data[MAX_SMALL_STRING_SIZE]; /// Including the terminating zero.
 
 public:
-    ~SingleValueDataString() { delete large_data; }
+    ~SingleValueDataString() { delete[] large_data; }
 
     bool has() const { return size >= 0; }
 
@@ -242,7 +242,7 @@ public:
         if (size != -1) {
             size = -1;
             capacity = 0;
-            delete large_data;
+            delete[] large_data;
             large_data = nullptr;
         }
     }
@@ -266,7 +266,7 @@ public:
             } else {
                 if (capacity < rhs_size) {
                     capacity = static_cast<UInt32>(round_up_to_power_of_two_or_zero(rhs_size));
-                    delete large_data;
+                    delete[] large_data;
                     large_data = new char[capacity];
                 }
 
@@ -296,7 +296,7 @@ public:
             if (capacity < value_size) {
                 /// Don't free large_data here.
                 capacity = round_up_to_power_of_two_or_zero(value_size);
-                delete large_data;
+                delete[] large_data;
                 large_data = new char[capacity];
             }
 


### PR DESCRIPTION
fix coredump for vectorize aggregate function when delete large_data, due to alloc-dealloc-mismatch

# Proposed changes

Issue Number: close #8639

## Problem Summary:

BE coredump when running yundex metrica case

## Checklist(Required)

1. Does it affect the original behavior: (No)
2. Has unit tests been added: (No Need)
3. Has document been added or modified: (No Need)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
