### PR TITLE
[ubsan] avoid null bit offset to be 255

### DIFF
--- a/be/src/runtime/descriptors.cpp
+++ b/be/src/runtime/descriptors.cpp
@@ -79,6 +79,7 @@ void SlotDescriptor::to_protobuf(PSlotDescriptor* pslot) const {
     pslot->set_byte_offset(_tuple_offset);
     pslot->set_null_indicator_byte(_null_indicator_offset.byte_offset);
     pslot->set_null_indicator_bit(_null_indicator_offset.bit_offset);
+    DCHECK_LE(_null_indicator_offset.bit_offset, 8);
     pslot->set_col_name(_col_name);
     pslot->set_slot_idx(_slot_idx);
     pslot->set_is_materialized(_is_materialized);

--- a/be/src/runtime/descriptors.h
+++ b/be/src/runtime/descriptors.h
@@ -58,12 +58,14 @@ class PSlotDescriptor;
 struct NullIndicatorOffset {
     int byte_offset;
     uint8_t bit_mask;   // to extract null indicator
-    uint8_t bit_offset; // only used to serialize, from 1 to 8
+    int8_t  bit_offset; // only used to serialize, from 1 to 8
 
     NullIndicatorOffset(int byte_offset, int bit_offset_)
             : byte_offset(byte_offset),
               bit_mask(bit_offset_ == -1 ? 0 : 1 << (7 - bit_offset_)),
-              bit_offset(bit_offset_) {}
+              bit_offset(bit_offset_) {
+              DCHECK_LE(bit_offset_, 8);
+              }
 
     bool equals(const NullIndicatorOffset& o) const {
         return this->byte_offset == o.byte_offset && this->bit_mask == o.bit_mask;

--- a/be/src/runtime/descriptors.h
+++ b/be/src/runtime/descriptors.h
@@ -58,7 +58,8 @@ class PSlotDescriptor;
 struct NullIndicatorOffset {
     int byte_offset;
     uint8_t bit_mask;   // to extract null indicator
-    int8_t  bit_offset; // only used to serialize, from 1 to 8
+    int8_t  bit_offset; // only used to serialize, from 1 to 8, invalid null value
+                        // bit_offset is -1.
 
     NullIndicatorOffset(int byte_offset, int bit_offset_)
             : byte_offset(byte_offset),


### PR DESCRIPTION
For now, invalid null bit offset is -1, but bit_offset in
NullIndicator is be of uint8_t, so invalid null bit offset
would be 255. Ubsan detects it.

# Proposed changes

Issue Number: close #xxx

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
