### PR TITLE
[Typo] Optimize some code comments style for 'be/src/common/*'

### DIFF
--- a/be/src/common/compiler_util.h
+++ b/be/src/common/compiler_util.h
@@ -38,10 +38,10 @@
 
 #define PREFETCH(addr) __builtin_prefetch(addr)
 
-/// Force inlining. The 'inline' keyword is treated by most compilers as a hint,
-/// not a command. This should be used sparingly for cases when either the function
-/// needs to be inlined for a specific reason or the compiler's heuristics make a bad
-/// decision, e.g. not inlining a small function on a hot path.
+// Force inlining. The 'inline' keyword is treated by most compilers as a hint,
+// not a command. This should be used sparingly for cases when either the function
+// needs to be inlined for a specific reason or the compiler's heuristics make a bad
+// decision, e.g. not inlining a small function on a hot path.
 #ifdef ALWAYS_INLINE
 #undef ALWAYS_INLINE
 #endif

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -22,18 +22,18 @@
 
 namespace doris {
 namespace config {
-// Dir of custom config file
+// Dir of custom config file.
 CONF_String(custom_config_dir, "${DORIS_HOME}/conf");
 
-// cluster id
+// The cluster id.
 CONF_Int32(cluster_id, "-1");
-// port on which BackendService is exported
+// The port on which backend service is exported.
 CONF_Int32(be_port, "9060");
 
-// port for brpc
+// The port for brpc server.
 CONF_Int32(brpc_port, "8060");
 
-// the number of bthreads for brpc, the default value is set to -1, which means the number of bthreads is #cpu-cores
+// The number of bthreads for brpc, the default value is set to -1, which means the number of bthreads is #cpu-cores.
 CONF_Int32(brpc_num_threads, "-1");
 
 // Declare a selection strategy for those servers have many ips.
@@ -45,9 +45,9 @@ CONF_String(priority_networks, "");
 ////
 //// tcmalloc gc parameter
 ////
-// min memory for TCmalloc, when used memory is smaller than this, do not returned to OS
+// Min memory for TCmalloc, when used memory is smaller than this, do not returned to OS.
 CONF_mInt64(tc_use_memory_min, "10737418240");
-// free memory rate.[0-100]
+// Free memory rate.[0-100].
 CONF_mInt64(tc_free_memory_rate, "20");
 
 // Bound on the total amount of bytes allocated to thread caches.
@@ -60,7 +60,7 @@ CONF_mInt64(tc_free_memory_rate, "20");
 //            https://github.com/gperftools/gperftools/issues/1111
 CONF_Int64(tc_max_total_thread_cache_bytes, "1073741824");
 
-// process memory limit specified as number of bytes
+// Process memory limit specified as number of bytes
 // ('<int>[bB]?'), megabytes ('<float>[mM]'), gigabytes ('<float>[gG]'),
 // or percentage of the physical memory ('<int>%').
 // defaults to bytes if no unit is given"
@@ -68,53 +68,53 @@ CONF_Int64(tc_max_total_thread_cache_bytes, "1073741824");
 // it will be set to physical memory size.
 CONF_String(mem_limit, "80%");
 
-// the port heartbeat service used
+// The port heartbeat service used.
 CONF_Int32(heartbeat_service_port, "9050");
-// the count of heart beat service
+// The count of heart beat service.
 CONF_Int32(heartbeat_service_thread_count, "1");
-// the count of thread to create table
+// The count of thread to create table.
 CONF_Int32(create_tablet_worker_count, "3");
-// the count of thread to drop table
+// The count of thread to drop table.
 CONF_Int32(drop_tablet_worker_count, "3");
-// the count of thread to batch load
+// The count of thread to batch load.
 CONF_Int32(push_worker_count_normal_priority, "3");
-// the count of thread to high priority batch load
+// The count of thread to high priority batch load.
 CONF_Int32(push_worker_count_high_priority, "3");
-// the count of thread to publish version
+// The count of thread to publish version.
 CONF_Int32(publish_version_worker_count, "8");
-// the count of thread to clear transaction task
+// The count of thread to clear transaction task.
 CONF_Int32(clear_transaction_task_worker_count, "1");
-// the count of thread to delete
+// The count of thread to delete.
 CONF_Int32(delete_worker_count, "3");
-// the count of thread to alter table
+// The count of thread to alter table.
 CONF_Int32(alter_tablet_worker_count, "3");
-// the count of thread to clone
+// The count of thread to clone.
 CONF_Int32(clone_worker_count, "3");
-// the count of thread to clone
+// The count of thread to clone.
 CONF_Int32(storage_medium_migrate_count, "1");
-// the count of thread to check consistency
+// The count of thread to check consistency.
 CONF_Int32(check_consistency_worker_count, "1");
-// the count of thread to upload
+// The count of thread to upload.
 CONF_Int32(upload_worker_count, "1");
-// the count of thread to download
+// The count of thread to download.
 CONF_Int32(download_worker_count, "1");
-// the count of thread to make snapshot
+// The count of thread to make snapshot.
 CONF_Int32(make_snapshot_worker_count, "5");
-// the count of thread to release snapshot
+// Tthe count of thread to release snapshot.
 CONF_Int32(release_snapshot_worker_count, "5");
-// the interval time(seconds) for agent report tasks signatrue to FE
+// The interval time(seconds) for agent report tasks signature to FE.
 CONF_mInt32(report_task_interval_seconds, "10");
-// the interval time(seconds) for agent report disk state to FE
+// The interval time(seconds) for agent report disk state to FE.
 CONF_mInt32(report_disk_state_interval_seconds, "60");
-// the interval time(seconds) for agent report olap table to FE
+// The interval time(seconds) for agent report olap table to FE.
 CONF_mInt32(report_tablet_interval_seconds, "60");
-// the max download speed(KB/s)
+// The max download speed(KB/s).
 CONF_mInt32(max_download_speed_kbps, "50000");
-// download low speed limit(KB/s)
+// Download low speed limit(KB/s).
 CONF_mInt32(download_low_speed_limit_kbps, "50");
-// download low speed time(seconds)
+// Download low speed time(seconds).
 CONF_mInt32(download_low_speed_time, "300");
-// sleep time for one second
+// Sleep time for one second.
 CONF_Int32(sleep_one_second, "1");
 
 // log dir
@@ -133,54 +133,54 @@ CONF_Int32(sys_log_verbose_level, "10");
 // log buffer level
 CONF_String(log_buffer_level, "");
 
-// number of threads available to serve backend execution requests
+// The number of threads available to serve backend execution requests.
 CONF_Int32(be_service_threads, "64");
 
-// cgroups allocated for doris
+// cgroups allocated for doris.
 CONF_String(doris_cgroups, "");
 
 // Controls the number of threads to run work per core.  It's common to pick 2x
 // or 3x the number of cores.  This keeps the cores busy without causing excessive
 // thrashing.
 CONF_Int32(num_threads_per_core, "3");
-// if true, compresses tuple data in Serialize
+// If true, compresses tuple data in Serialize.
 CONF_mBool(compress_rowbatches, "true");
-// interval between profile reports; in seconds
+// Interval between profile reports; in seconds.
 CONF_mInt32(status_report_interval, "5");
-// if true, each disk will have a separate thread pool for scanner
+// If true, each disk will have a separate thread pool for scanner.
 CONF_Bool(doris_enable_scanner_thread_pool_per_disk, "true");
-// the timeout of a work thread to wait the blocking priority queue to get a task
+// The timeout of a work thread to wait the blocking priority queue to get a task.
 CONF_mInt64(doris_blocking_priority_queue_wait_timeout_ms, "5");
-// number of olap scanner thread pool size
+// Number of olap scanner thread pool size.
 CONF_Int32(doris_scanner_thread_pool_thread_num, "48");
-// number of olap scanner thread pool queue size
+// Number of olap scanner thread pool queue size.
 CONF_Int32(doris_scanner_thread_pool_queue_size, "102400");
-// number of etl thread pool size
+// Number of etl thread pool size.
 CONF_Int32(etl_thread_pool_size, "8");
-// number of etl thread pool size
+// Number of etl thread pool size.
 CONF_Int32(etl_thread_pool_queue_size, "256");
-// default thrift client connect timeout(in seconds)
+// Default thrift client connect timeout(in seconds).
 CONF_mInt32(thrift_connect_timeout_seconds, "3");
-// default thrift client retry interval (in milliseconds)
+// Default thrift client retry interval (in milliseconds).
 CONF_mInt64(thrift_client_retry_interval_ms, "1000");
-// max row count number for single scan range, used in segmentv1
+// Max row count number for single scan range, used in segmentv1.
 CONF_mInt32(doris_scan_range_row_count, "524288");
-// max bytes number for single scan range, used in segmentv2
+// Max bytes number for single scan range, used in segmentv2.
 CONF_mInt32(doris_scan_range_max_mb, "0");
-// size of scanner queue between scanner thread and compute thread
+// Size of scanner queue between scanner thread and compute thread.
 CONF_mInt32(doris_scanner_queue_size, "1024");
-// single read execute fragment row number
+// Single read execute fragment row number.
 CONF_mInt32(doris_scanner_row_num, "16384");
-// single read execute fragment row bytes
+// Single read execute fragment row bytes.
 CONF_mInt32(doris_scanner_row_bytes, "10485760");
-// number of max scan keys
+// Number of max scan keys.
 CONF_mInt32(doris_max_scan_key_num, "1024");
-// the max number of push down values of a single column.
+// The max number of push down values of a single column.
 // if exceed, no conditions will be pushed down for that column.
 CONF_mInt32(max_pushdown_conditions_per_column, "1024");
 // return_row / total_row
 CONF_mInt32(doris_max_pushdown_conjuncts_return_rate, "90");
-// (Advanced) Maximum size of per-query receive-side buffer
+// (Advanced) Maximum size of per-query receive-side buffer.
 CONF_mInt32(exchg_node_buffer_size_bytes, "10485760");
 // push_write_mbytes_per_sec
 CONF_mInt32(push_write_mbytes_per_sec, "100");
@@ -190,7 +190,7 @@ CONF_mInt64(column_dictionary_key_size_threshold, "0");
 // memory_limitation_per_thread_for_schema_change_bytes unit bytes
 CONF_mInt64(memory_limitation_per_thread_for_schema_change_bytes, "2147483648");
 
-// the clean interval of file descriptor cache and segment cache
+// The clean interval of file descriptor cache and segment cache.
 CONF_mInt32(cache_clean_interval, "1800");
 CONF_mInt32(disk_stat_monitor_interval, "5");
 CONF_mInt32(unused_rowset_monitor_interval, "30");
@@ -217,19 +217,18 @@ CONF_mInt32(snapshot_expire_time_sec, "172800");
 CONF_mInt32(trash_file_expire_time_sec, "259200");
 // check row nums for BE/CE and schema change. true is open, false is closed.
 CONF_mBool(row_nums_check, "true");
-//file descriptors cache, by default, cache 32768 descriptors
+// File descriptors cache, by default, cache 32768 descriptors.
 CONF_Int32(file_descriptor_cache_capacity, "32768");
-// minimum file descriptor number
-// modify them upon necessity
+// Minimum file descriptor number modify them upon necessity.
 CONF_Int32(min_file_descriptor_number, "60000");
 CONF_Int64(index_stream_cache_capacity, "10737418240");
 
-// Cache for storage page size
+// Cache for storage page size.
 CONF_String(storage_page_cache_limit, "20%");
 // Percentage for index page cache
-// all storage page cache will be divided into data_page_cache and index_page_cache
+// all storage page cache will be divided into `data_page_cache` and `index_page_cache`.
 CONF_Int32(index_page_cache_percentage, "10");
-// whether to disable page cache feature in storage
+// Whether to disable page cache feature in storage.
 CONF_Bool(disable_storage_page_cache, "false");
 
 CONF_Bool(enable_storage_vectorization, "false");
@@ -239,7 +238,7 @@ CONF_Bool(enable_low_cardinality_optimize, "false");
 // be policy
 // whether disable automatic compaction task
 CONF_mBool(disable_auto_compaction, "false");
-// check the configuration of auto compaction in seconds when auto compaction disabled
+// Check the configuration of auto compaction in seconds when auto compaction disabled.
 CONF_mInt32(check_auto_compaction_interval_seconds, "5");
 
 CONF_mInt64(base_compaction_num_cumulative_deltas, "5");
@@ -274,15 +273,15 @@ CONF_mInt64(cumulative_size_based_promotion_min_size_mbytes, "64");
 // this size, size_based policy may not do to cumulative compaction. The unit is m byte.
 CONF_mInt64(cumulative_size_based_compaction_lower_size_mbytes, "64");
 
-// cumulative compaction policy: min and max delta file's number
+// Cumulative compaction policy: min and max delta file's number
 CONF_mInt64(min_cumulative_compaction_num_singleton_deltas, "5");
 CONF_mInt64(max_cumulative_compaction_num_singleton_deltas, "1000");
-// cumulative compaction skips recently published deltas in order to prevent
+// Cumulative compaction skips recently published deltas in order to prevent
 // compacting a version that might be queried (in case the query planning phase took some time).
-// the following config set the window size
+// The following config set the window size.
 CONF_mInt32(cumulative_compaction_skip_window_seconds, "30");
 
-// if compaction of a tablet failed, this tablet should not be chosen to
+// If compaction of a tablet failed, this tablet should not be chosen to
 // compaction until this interval passes.
 CONF_mInt64(min_compaction_failure_interval_sec, "600"); // 10 min
 
@@ -295,13 +294,13 @@ CONF_Int32(max_meta_checkpoint_threads, "-1");
 // The upper limit of "permits" held by all compaction tasks. This config can be set to limit memory consumption for compaction.
 CONF_mInt64(total_permits_for_compaction_score, "10000");
 
-// sleep interval in ms after generated compaction tasks
+// Sleep interval in ms after generated compaction tasks.
 CONF_mInt32(generate_compaction_tasks_min_interval_ms, "10");
 
 // Compaction task number per disk.
 // Must be greater than 2, because Base compaction and Cumulative compaction have at least one thread each.
 CONF_mInt32(compaction_task_num_per_disk, "2");
-// compaction thread num for fast disk(typically .SSD), must be greater than 2.
+// Compaction thread num for fast disk(typically .SSD), must be greater than 2.
 CONF_mInt32(compaction_task_num_per_fast_disk, "4");
 CONF_Validator(compaction_task_num_per_disk, [](const int config) -> bool { return config >= 2; });
 CONF_Validator(compaction_task_num_per_fast_disk,
@@ -321,9 +320,9 @@ CONF_mBool(disable_compaction_trace_log, "true");
 // Threshold to logging agent task trace, in seconds.
 CONF_mInt32(agent_task_trace_threshold_sec, "2");
 
-// time interval to record tablet scan count in second for the purpose of calculating tablet scan frequency
+// Time interval to record tablet scan count in second for the purpose of calculating tablet scan frequency.
 CONF_mInt64(tablet_scan_frequency_time_node_interval_second, "300");
-// coefficient for tablet scan frequency and compaction score when finding a tablet for compaction
+// Coefficient for tablet scan frequency and compaction score when finding a tablet for compaction.
 CONF_mInt32(compaction_tablet_scan_frequency_factor, "0");
 CONF_mInt32(compaction_tablet_compaction_score_factor, "1");
 
@@ -338,7 +337,7 @@ CONF_mInt32(migration_remaining_size_threshold_mb, "10");
 // tablet max size / migration min speed * factor = 10GB / 1MBps * 2 = 20480 seconds
 CONF_mInt32(migration_task_timeout_secs, "20480");
 
-// Port to start debug webserver on
+// Port to start debug webserver on.
 CONF_Int32(webserver_port, "8040");
 // Number of webserver workers
 CONF_Int32(webserver_num_workers, "48");
@@ -347,7 +346,7 @@ CONF_mInt32(periodic_counter_update_period_ms, "500");
 
 // Used for mini Load. mini load data file will be removed after this time.
 CONF_Int64(load_data_reserve_hours, "4");
-// log error log will be removed after this time
+// Log error log will be removed after this time.
 CONF_mInt64(load_error_log_reserve_hours, "48");
 CONF_Int32(number_tablet_writer_threads, "16");
 
@@ -357,23 +356,23 @@ CONF_mInt64(streaming_load_max_mb, "10240");
 // Therefore, it is necessary to limit the maximum number of
 // such data when using stream load to prevent excessive memory consumption.
 CONF_mInt64(streaming_load_json_max_mb, "100");
-// the alive time of a TabletsChannel.
+// The alive time of a TabletsChannel.
 // If the channel does not receive any data till this time,
 // the channel will be removed.
 CONF_mInt32(streaming_load_rpc_max_alive_time_sec, "1200");
-// the timeout of a rpc to open the tablet writer in remote BE.
-// short operation time, can set a short timeout
+// The timeout of a rpc to open the tablet writer in remote BE.
+// short operation time, can set a short timeout.
 CONF_Int32(tablet_writer_open_rpc_timeout_sec, "60");
 // You can ignore brpc error '[E1011]The server is overcrowded' when writing data.
 CONF_mBool(tablet_writer_ignore_eovercrowded, "false");
 // Whether to enable stream load record function, the default is false.
-// False: disable stream load record
+// False: disable stream load record.
 CONF_mBool(enable_stream_load_record, "false");
-// batch size of stream load record reported to FE
+// Batch size of stream load record reported to FE.
 CONF_mInt32(stream_load_record_batch_size, "50");
-// expire time of stream load record in rocksdb.
+// The expire time of stream load record in rocksdb.
 CONF_Int32(stream_load_record_expire_time_secs, "28800");
-// time interval to clean expired stream load records
+// The time interval to clean expired stream load records.
 CONF_mInt64(clean_stream_load_record_interval_secs, "1800");
 CONF_mBool(disable_stream_load_2pc, "true");
 
@@ -381,7 +380,7 @@ CONF_mBool(disable_stream_load_2pc, "true");
 // You may need to lower the speed when the sink receiver bes are too busy.
 CONF_mInt32(olap_table_sink_send_interval_ms, "1");
 
-// Fragment thread pool
+// Fragment thread pool.
 CONF_Int32(fragment_pool_thread_num_min, "64");
 CONF_Int32(fragment_pool_thread_num_max, "512");
 CONF_Int32(fragment_pool_queue_size, "2048");
@@ -417,16 +416,16 @@ CONF_Bool(use_mmap_allocate_chunk, "false");
 CONF_Int64(chunk_reserved_bytes_limit, "2147483648");
 
 // The probing algorithm of partitioned hash table.
-// Enable quadratic probing hash table
+// Enable quadratic probing hash table.
 CONF_Bool(enable_quadratic_probing, "false");
 
 // for pprof
 CONF_String(pprof_profile_dir, "${DORIS_HOME}/log");
 
-// to forward compatibility, will be removed later
+// To forward compatibility, will be removed later
 CONF_mBool(enable_token_check, "true");
 
-// to open/close system metrics
+// To open or close system metrics.
 CONF_Bool(enable_system_metrics, "true");
 
 CONF_mBool(enable_prefetch, "true");
@@ -436,33 +435,33 @@ CONF_mBool(enable_prefetch, "true");
 CONF_Int32(num_cores, "0");
 
 // When BE start, If there is a broken disk, BE process will exit by default.
-// Otherwise, we will ignore the broken disk,
+// Otherwise, we will ignore the broken disk.
 CONF_Bool(ignore_broken_disk, "false");
 
-// linux transparent huge page
+// Linux transparent huge page.
 CONF_Bool(madvise_huge_pages, "false");
 
-// whether use mmap to allocate memory
+// Whether use mmap to allocate memory.
 CONF_Bool(mmap_buffers, "false");
 
-// max memory can be allocated by buffer pool
-// This is the percentage of mem_limit
+// Max memory can be allocated by buffer pool.
+// This is the percentage of `mem_limit`.
 CONF_String(buffer_pool_limit, "20%");
 
-// clean page can be hold by buffer pool
-// This is the percentage of buffer_pool_limit
+// Clean page can be hold by buffer pool
+// This is the percentage of `buffer_pool_limit`.
 CONF_String(buffer_pool_clean_pages_limit, "50%");
 
-// Sleep time in seconds between memory maintenance iterations
+// Sleep time in seconds between memory maintenance iterations.
 CONF_mInt64(memory_maintenance_sleep_time_s, "10");
 
-// Alignment
+// The max memory alignment.
 CONF_Int32(memory_max_alignment, "16");
 
-// write buffer size before flush
+// Write buffer size before flush.
 CONF_mInt64(write_buffer_size, "209715200");
 
-// following 2 configs limit the memory consumption of load process on a Backend.
+// Following 2 configs limit the memory consumption of load process on a Backend.
 // eg: memory limit to 80% of mem limit config but up to 100GB(default)
 // NOTICE(cmy): set these default values very large because we don't want to
 // impact the load performance when user upgrading Doris.
@@ -470,37 +469,37 @@ CONF_mInt64(write_buffer_size, "209715200");
 CONF_Int64(load_process_max_memory_limit_bytes, "107374182400"); // 100GB
 CONF_Int32(load_process_max_memory_limit_percent, "80");         // 80%
 
-// result buffer cancelled time (unit: second)
+// Result buffer cancelled time (unit: second).
 CONF_mInt32(result_buffer_cancelled_interval_time, "300");
 
-// the increased frequency of priority for remaining tasks in BlockingPriorityQueue
+// The increased frequency of priority for remaining tasks in blocking priority queue.
 CONF_mInt32(priority_queue_remaining_tasks_increased_frequency, "512");
 
-// sync tablet_meta when modifying meta
+// Sync tablet meta when modifying meta.
 CONF_mBool(sync_tablet_meta, "false");
 
-// default thrift rpc timeout ms
+// Default thrift rpc timeout ms.
 CONF_mInt32(thrift_rpc_timeout_ms, "10000");
 
-// txn commit rpc timeout
+// `txn` commit rpc timeout.
 CONF_mInt32(txn_commit_rpc_timeout_ms, "10000");
 
-// If set to true, metric calculator will run
+// If set to true, metric calculator will run.
 CONF_Bool(enable_metric_calculator, "true");
 
-// max consumer num in one data consumer group, for routine load
+// Max consumer num in one data consumer group, for routine load.
 CONF_mInt32(max_consumer_num_per_group, "3");
 
-// the size of thread pool for routine load task.
-// this should be larger than FE config 'max_routine_load_task_num_per_be' (default 5)
+// The size of thread pool for routine load task.
+// this should be larger than FE config 'max_routine_load_task_num_per_be' (default 5).
 CONF_Int32(routine_load_thread_pool_size, "10");
 
-// max external scan cache batch count, means cache max_memory_cache_batch_count * batch_size row
-// default is 20, batch_size's default value is 1024 means 20 * 1024 rows will be cached
+// Max external scan cache batch count, means cache max_memory_cache_batch_count * batch_size row
+// default is 20, batch_size's default value is 1024 means 20 * 1024 rows will be cached.
 CONF_mInt32(max_memory_sink_batch_count, "20");
 
 // This configuration is used for the context gc thread schedule period
-// note: unit is minute, default is 5min
+// note: unit is minute, default is 5min.
 CONF_mInt32(scan_context_gc_interval_min, "5");
 
 // es scroll keep-alive
@@ -509,13 +508,14 @@ CONF_String(es_scroll_keepalive, "5m");
 // HTTP connection timeout for es
 CONF_mInt32(es_http_timeout_ms, "5000");
 
-// the max client cache number per each host
+// The max client cache number per each host.
 // There are variety of client cache in BE, but currently we use the
 // same cache size configuration.
+//
 // TODO(cmy): use different config to set different client cache if necessary.
 CONF_Int32(max_client_cache_size_per_host, "10");
 
-// Dir to save files downloaded by SmallFileMgr
+// Dir to save files downloaded by SmallFileMgr.
 CONF_String(small_file_dir, "${DORIS_HOME}/lib/small_file/");
 // path gc
 CONF_Bool(path_gc_check, "true");
@@ -530,12 +530,12 @@ CONF_mInt32(path_scan_interval_second, "86400");
 CONF_mInt32(storage_flood_stage_usage_percent, "90"); // 90%
 // The min bytes that should be left of a data dir
 CONF_mInt64(storage_flood_stage_left_capacity_bytes, "1073741824"); // 1GB
-// number of thread for flushing memtable per store
+// The number of thread for flushing memtable per store.
 CONF_Int32(flush_thread_num_per_store, "2");
-// number of thread for flushing memtable per store, for high priority load task
+// The number of thread for flushing memtable per store, for high priority load task.
 CONF_Int32(high_priority_flush_thread_num_per_store, "1");
 
-// config for tablet meta checkpoint
+// Config for tablet meta checkpoint.
 CONF_mInt32(tablet_meta_checkpoint_min_new_rowsets_num, "10");
 CONF_mInt32(tablet_meta_checkpoint_min_interval_secs, "600");
 CONF_Int32(generate_tablet_meta_checkpoint_tasks_interval_secs, "600");
@@ -552,16 +552,16 @@ CONF_Int64(brpc_socket_max_unwritten_bytes, "1073741824");
 // through brpc, this will be faster and avoid the error of Request length overflow.
 CONF_mBool(transfer_data_by_brpc_attachment, "false");
 
-// max number of txns for every txn_partition_map in txn manager
-// this is a self protection to avoid too many txns saving in manager
+// Max number of txns for every txn_partition_map in txn manager,
+// this is a self protection to avoid too many txns saving in manager.
 CONF_mInt64(max_runnings_transactions_per_txn_map, "100");
 
-// tablet_map_lock shard size, the value is 2^n, n=0,1,2,3,4
-// this is a an enhancement for better performance to manage tablet
+// `tablet_map_lock` shard size, the value is 2^n, n=0,1,2,3,4
+// this is a enhancement for better performance to manage tablet.
 CONF_Int32(tablet_map_shard_size, "1");
 
-// txn_map_lock shard size, the value is 2^n, n=0,1,2,3,4
-// this is a an enhancement for better performance to manage txn
+// `txn_map_lock` shard size, the value is 2^n, n=0,1,2,3,4
+// this is a enhancement for better performance to manage txn.
 CONF_Int32(txn_map_shard_size, "128");
 
 // txn_lock shard size, the value is 2^n, n=0,1,2,3,4
@@ -595,10 +595,10 @@ CONF_mInt32(max_tablet_version_num, "500");
 // the thrift_server_type_of_fe should be set THREADED_SELECTOR to make be thrift client to fe constructed with TFramedTransport
 CONF_String(thrift_server_type_of_fe, "THREAD_POOL");
 
-// disable zone map index when page row is too few
+// Disable zone map index when page row is too few.
 CONF_mInt32(zone_map_row_num_threshold, "20");
 
-// aws sdk log level
+// Aws sdk log level:
 //    Off = 0,
 //    Fatal = 1,
 //    Error = 2,
@@ -608,7 +608,7 @@ CONF_mInt32(zone_map_row_num_threshold, "20");
 //    Trace = 6
 CONF_Int32(aws_log_level, "3");
 
-// the buffer size when read data from remote storage like s3
+// The buffer size when read data from remote storage like s3.
 CONF_mInt32(remote_storage_read_buffer_mb, "16");
 
 // Whether Hook TCmalloc new/delete, currently consume/release tls mem tracker in Hook.
@@ -644,20 +644,20 @@ CONF_mBool(memory_leak_detection, "false");
 // In most cases, it does not need to be modified.
 CONF_mDouble(tablet_version_graph_orphan_vertex_ratio, "0.1");
 
-// if set runtime_filter_use_async_rpc true, publish runtime filter will be a async method
-// else we will call sync method
+// If set `runtime_filter_use_async_rpc` true, publish runtime filter will be async method
+// else we will call sync method.
 CONF_mBool(runtime_filter_use_async_rpc, "true");
 
-// max send batch parallelism for OlapTableSink
-// The value set by the user for send_batch_parallelism is not allowed to exceed max_send_batch_parallelism_per_job,
-// if exceed, the value of send_batch_parallelism would be max_send_batch_parallelism_per_job
+// Max send batch parallelism for OlapTableSink.
+// The value set by the user for `send_batch_parallelism` is not allowed to exceed max_send_batch_parallelism_per_job,
+// if exceed, the value of `send_batch_parallelism` would be `max_send_batch_parallelism_per_job`.
 CONF_mInt32(max_send_batch_parallelism_per_job, "5");
 CONF_Validator(max_send_batch_parallelism_per_job,
                [](const int config) -> bool { return config >= 1; });
 
-// number of send batch thread pool size
+// The number of send batch thread pool size.
 CONF_Int32(send_batch_thread_pool_thread_num, "64");
-// number of send batch thread pool queue size
+// The number of send batch thread pool queue size.
 CONF_Int32(send_batch_thread_pool_queue_size, "102400");
 
 // Limit the number of segment of a newly created rowset.
@@ -703,7 +703,7 @@ CONF_Int32(max_minidump_file_number, "10");
 // and the valid values are: 0.9.0, 0.8.2, 0.8.1, 0.8.0.
 CONF_String(kafka_broker_version_fallback, "0.10.0");
 
-// The the number of pool siz of routine load consumer.
+// The number of pool siz of routine load consumer.
 // If you meet the error describe in https://github.com/edenhill/librdkafka/issues/3608
 // Change this size to 0 to fix it temporarily.
 CONF_Int32(routine_load_consumer_pool_size, "10");
@@ -719,21 +719,20 @@ CONF_mInt32(load_task_high_priority_threshold_second, "120");
 // Increase this config may avoid rpc timeout.
 CONF_mInt32(min_load_rpc_timeout_ms, "20000");
 
-// use which protocol to access function service, candicate is baidu_std/h2:grpc
+// Use which protocol to access function service, candicate is baidu_std/h2:grpc.
 CONF_String(function_service_protocol, "h2:grpc");
 
-// use which load balancer to select server to connect
+// Use which load balancer to select server to connect.
 CONF_String(rpc_load_balancer, "rr");
 
-// a soft limit of string type length, the hard limit is 2GB - 4, but if too long will cause very low performance,
-// so we set a soft limit, default is 1MB
+// A soft limit of string type length, the hard limit is 2GB - 4, but if too long will cause very low performance,
+// so we set a soft limit, default is 1MB.
 CONF_mInt32(string_type_length_soft_limit_bytes, "1048576");
 
 CONF_Validator(string_type_length_soft_limit_bytes,
                [](const int config) -> bool { return config > 0 && config <= 2147483643; });
 
 } // namespace config
-
 } // namespace doris
 
 #endif // DORIS_BE_SRC_COMMON_CONFIG_H

--- a/be/src/common/configbase.cpp
+++ b/be/src/common/configbase.cpp
@@ -68,7 +68,7 @@ void splitkv(const std::string& s, std::string& k, std::string& v) {
     }
 }
 
-// replace env variables
+// Replace env variables.
 bool replaceenv(std::string& s) {
     std::size_t pos = 0;
     std::size_t start = 0;
@@ -183,14 +183,14 @@ bool convert(const std::string& value, T& retval) {
     return strtox(valstr, retval);
 }
 
-// load conf file
+// Load conf file.
 bool Properties::load(const char* conf_file, bool must_exist) {
-    // if conf_file is null, use the empty props
+    // If conf_file is null, use the empty props.
     if (conf_file == nullptr) {
         return true;
     }
 
-    // open the conf file
+    // Open the conf file.
     std::ifstream input(conf_file);
     if (!input.is_open()) {
         if (must_exist) {
@@ -200,33 +200,33 @@ bool Properties::load(const char* conf_file, bool must_exist) {
         return true;
     }
 
-    // load properties
+    // Load properties.
     std::string line;
     std::string key;
     std::string value;
     line.reserve(512);
     while (input) {
-        // read one line at a time
+        // Read one line at a time.
         std::getline(input, line);
 
-        // remove left and right spaces
+        // Remove left and right spaces.
         trim(line);
 
-        // ignore comments
+        // Ignore comments.
         if (line.empty() || line[0] == '#') {
             continue;
         }
 
-        // read key and value
+        // Read key and value.
         splitkv(line, key, value);
         trim(key);
         trim(value);
 
-        // insert into file_conf_map
+        // Insert into `file_conf_map`.
         file_conf_map[key] = value;
     }
 
-    // close the conf file
+    // Close the conf file.
     input.close();
 
     return true;
@@ -238,7 +238,7 @@ bool Properties::get_or_default(const char* key, const char* defstr, T& retval, 
     std::string valstr;
     if (it == file_conf_map.end()) {
         if (defstr == nullptr) {
-            // Not found in conf map, and no default value need to be set, just return
+            // Not found in conf map, and no default value need to be set, just return.
             *is_retval_set = false;
             return true;
         } else {
@@ -324,19 +324,18 @@ std::ostream& operator<<(std::ostream& out, const std::vector<T>& v) {
         continue;                                                                                             \
     }
 
-// init conf fields
+// Init conf fields.
 bool init(const char* conf_file, bool fill_conf_map, bool must_exist, bool set_to_default) {
     Properties props;
-    // load properties file
+    // Load properties file.
     if (!props.load(conf_file, must_exist)) {
         return false;
     }
-    // fill full_conf_map ?
     if (fill_conf_map && full_conf_map == nullptr) {
         full_conf_map = new std::map<std::string, std::string>();
     }
 
-    // set conf fields
+    // Set conf fields.
     for (const auto& it : *Register::_s_field_map) {
         SET_FIELD(it.second, bool, fill_conf_map, set_to_default);
         SET_FIELD(it.second, int16_t, fill_conf_map, set_to_default);
@@ -383,10 +382,10 @@ bool init(const char* conf_file, bool fill_conf_map, bool must_exist, bool set_t
         return Status::OK();                                                                            \
     }
 
-// write config to be_custom.conf
-// the caller need to make sure that the given config is valid
+// Write config to `be_custom.conf`.
+// The caller need to make sure that the given config is valid.
 bool persist_config(const std::string& field, const std::string& value) {
-    // lock to make sure only one thread can modify the be_custom.conf
+    // Lock to make sure only one thread can modify the `be_custom.conf`.
     std::lock_guard<std::mutex> l(custom_conf_lock);
 
     static const string conffile = string(getenv("DORIS_HOME")) + "/conf/be_custom.conf";

--- a/be/src/common/configbase.h
+++ b/be/src/common/configbase.h
@@ -19,12 +19,11 @@
 #define DORIS_BE_SRC_COMMON_CONFIGBASE_H
 
 #include <cstdint>
-
+#include <functional>
 #include <map>
 #include <mutex>
 #include <string>
 #include <vector>
-#include <functional>
 
 namespace doris {
 class Status;
@@ -60,12 +59,11 @@ public:
         Field field(ftype, fname, fstorage, fdefval, fvalmutable);
         _s_field_map->insert(std::make_pair(std::string(fname), field));
     }
-
 };
 
 // RegisterConfValidator class is used to store validator function of registered config fields in
-// Register::_s_field_map.
-// If any validator return false when BE bootstart, the bootstart will be terminated.
+// `Register::_s_field_map`.
+// If any validator return false when BE bootstrap, the bootstrap will be terminated.
 // If validator return false when use http API to update some config, the config will not
 // be modified and the API will return failure.
 class RegisterConfValidator {
@@ -78,7 +76,7 @@ public:
         if (_s_field_validator == nullptr) {
             _s_field_validator = new std::map<std::string, std::function<bool()>>();
         }
-        // register validator to _s_field_validator
+        // Register validator to `_s_field_validator`.
         _s_field_validator->insert(std::make_pair(std::string(fname), validator));
     }
 };
@@ -90,10 +88,10 @@ public:
 
 #define DECLARE_FIELD(FIELD_TYPE, FIELD_NAME) extern FIELD_TYPE FIELD_NAME;
 
-#define DEFINE_VALIDATOR(FIELD_NAME, VALIDATOR)                                            \
-    static auto validator_##FIELD_NAME = VALIDATOR;                                        \
-    static RegisterConfValidator reg_validator_##FIELD_NAME(#FIELD_NAME,                   \
-            []() -> bool { return validator_##FIELD_NAME(FIELD_NAME); });
+#define DEFINE_VALIDATOR(FIELD_NAME, VALIDATOR)              \
+    static auto validator_##FIELD_NAME = VALIDATOR;          \
+    static RegisterConfValidator reg_validator_##FIELD_NAME( \
+            #FIELD_NAME, []() -> bool { return validator_##FIELD_NAME(FIELD_NAME); });
 
 #define DECLARE_VALIDATOR(FIELD_NAME) ;
 
@@ -158,14 +156,14 @@ public:
 
     void set_force(const std::string& key, const std::string& val);
 
-    // dump props to conf file
+    // Dump props to conf file.
     bool dump(const std::string& conffile);
 
 private:
     std::map<std::string, std::string> file_conf_map;
 };
 
-// full configurations.
+// Full configurations.
 extern std::map<std::string, std::string>* full_conf_map;
 
 extern std::mutex custom_conf_lock;

--- a/be/src/common/daemon.cpp
+++ b/be/src/common/daemon.cpp
@@ -91,7 +91,7 @@ void Daemon::memory_maintenance_thread() {
     while (!_stop_background_threads_latch.wait_for(
             MonoDelta::FromSeconds(config::memory_maintenance_sleep_time_s))) {
         ExecEnv* env = ExecEnv::GetInstance();
-        // ExecEnv may not have been created yet or this may be the catalogd or statestored,
+        // ExecEnv may not have been created yet or this may be the cataloged or statestored,
         // which don't have ExecEnvs.
         if (env != nullptr) {
             BufferPool* buffer_pool = env->buffer_pool();
@@ -101,7 +101,7 @@ void Daemon::memory_maintenance_thread() {
 }
 
 /*
- * this thread will calculate some metrics at a fix interval(15 sec)
+ * This thread will calculate some metrics at a fix interval(15 sec)
  * 1. push bytes per second
  * 2. scan bytes per second
  * 3. max io util of all disks
@@ -132,7 +132,7 @@ void Daemon::calculate_metrics_thread() {
             long interval = (current_ts - last_ts) / 1000;
             last_ts = current_ts;
 
-            // 1. push bytes per second
+            // 1. push bytes per second.
             int64_t current_push_bytes =
                     DorisMetrics::instance()->push_request_write_bytes->value();
             int64_t pps = (current_push_bytes - lst_push_bytes) / (interval + 1);
@@ -140,20 +140,20 @@ void Daemon::calculate_metrics_thread() {
                                                                                              : pps);
             lst_push_bytes = current_push_bytes;
 
-            // 2. query bytes per second
+            // 2. query bytes per second.
             int64_t current_query_bytes = DorisMetrics::instance()->query_scan_bytes->value();
             int64_t qps = (current_query_bytes - lst_query_bytes) / (interval + 1);
             DorisMetrics::instance()->query_scan_bytes_per_second->set_value(qps < 0 ? 0 : qps);
             lst_query_bytes = current_query_bytes;
 
-            // 3. max disk io util
+            // 3. max disk io util.
             DorisMetrics::instance()->max_disk_io_util_percent->set_value(
                     DorisMetrics::instance()->system_metrics()->get_max_io_util(lst_disks_io_time,
                                                                                 15));
-            // update lst map
+            // Update lst map.
             DorisMetrics::instance()->system_metrics()->get_disks_io_time(&lst_disks_io_time);
 
-            // 4. max network traffic
+            // 4. max network traffic.
             int64_t max_send = 0;
             int64_t max_receive = 0;
             DorisMetrics::instance()->system_metrics()->get_max_net_traffic(

--- a/be/src/common/daemon.h
+++ b/be/src/common/daemon.h
@@ -38,10 +38,10 @@ public:
     // performed until after this method returns.
     void init(int argc, char** argv, const std::vector<StorePath>& paths);
 
-    // Start background threads
+    // Start background threads.
     void start();
 
-    // Stop background threads
+    // Stop background threads.
     void stop();
 
 private:

--- a/be/src/common/global_types.h
+++ b/be/src/common/global_types.h
@@ -20,9 +20,9 @@
 
 namespace doris {
 
-// for now, these are simply ints; if we find we need to generate ids in the
+// For now, these are simply ints; if we find we need to generate ids in the
 // backend, we can also introduce separate classes for these to make them
-// assignment-incompatible
+// assignment-incompatible.
 typedef int TupleId;
 typedef int SlotId;
 typedef int TableId;

--- a/be/src/common/logconfig.cpp
+++ b/be/src/common/logconfig.cpp
@@ -159,7 +159,7 @@ std::string FormatTimestampForLog(MicrosecondsInt64 micros_since_epoch) {
                         tm_time.tm_hour, tm_time.tm_min, tm_time.tm_sec, usecs);
 }
 
-/// Custom your log format here
+// Custom your log format here.
 void TaggableLogger::flush() {
     _stream << _message;
     Tags* head = _tags;
@@ -172,7 +172,7 @@ void TaggableLogger::flush() {
     }
 }
 
-/// Modify these tag names to suit your log format and collector.
+// Modify these tag names to suit your log format and collector.
 const std::string TaggableLogger::QUERY_ID = "query_id";
 const std::string TaggableLogger::INSTANCE_ID = "instance_id";
 

--- a/be/src/common/logging.h
+++ b/be/src/common/logging.h
@@ -18,17 +18,17 @@
 #pragma once
 
 // GLOG defines this based on the system but doesn't check if it's already
-// been defined.  undef it first to avoid warnings.
-// glog MUST be included before gflags.  Instead of including them,
+// been defined. undef it first to avoid warnings.
+// glog MUST be included before gflags. Instead of including them,
 // our files should include this file instead.
 #undef _XOPEN_SOURCE
-// This is including a glog internal file.  We want this to expose the
+// This is including a glog internal file. We want this to expose the
 // function to get the stack trace.
 #include <glog/logging.h>
 #undef MutexLock
 
-// Define VLOG levels.  We want display per-row info less than per-file which
-// is less than per-query.  For now per-connection is the same as per-query.
+// Define VLOG levels. We want display per-row info less than per-file which
+// is less than per-query. For now per-connection is the same as per-query.
 #define VLOG_CONNECTION VLOG(1)
 #define VLOG_RPC VLOG(8)
 #define VLOG_QUERY VLOG(1)
@@ -50,8 +50,8 @@
 #define VLOG_NOTICE_IS_ON VLOG_IS_ON(3)
 #define VLOG_CRITICAL_IS_ON VLOG_IS_ON(1)
 
-/// Define a wrapper around DCHECK for strongly typed enums that print a useful error
-/// message on failure.
+// Define a wrapper around `DCHECK` for strongly typed enums that print a useful error
+// message on failure.
 #define DCHECK_ENUM_EQ(a, b)                                                 \
     DCHECK(a == b) << "[ " #a " = " << static_cast<int>(a) << " , " #b " = " \
                    << static_cast<int>(b) << " ]"

--- a/be/src/common/object_pool.h
+++ b/be/src/common/object_pool.h
@@ -64,10 +64,10 @@ private:
     ObjectPool(const ObjectPool&) = delete;
     void operator=(const ObjectPool&) = delete;
 
-    /// A generic deletion function pointer. Deletes its first argument.
+    // A generic deletion function pointer. Deletes its first argument.
     using DeleteFn = void (*)(void*);
 
-    /// For each object, a pointer to the object and a function that deletes it.
+    // For each object, a pointer to the object and a function that deletes it.
     struct Element {
         void* obj;
         DeleteFn delete_fn;

--- a/be/src/common/resource_tls.cpp
+++ b/be/src/common/resource_tls.cpp
@@ -58,7 +58,7 @@ int ResourceTls::set_resource_tls(TResourceInfo* info) {
 
     int ret = pthread_setspecific(s_resource_key, info);
     if (ret == 0) {
-        // OK, now we delete old one
+        // OK, now we delete old one.
         delete old_info;
     }
     return ret;

--- a/be/src/common/signal_handler.h
+++ b/be/src/common/signal_handler.h
@@ -32,17 +32,17 @@
 // Implementation of InstallFailureSignalHandler().
 
 #define BOOST_STACKTRACE_USE_BACKTRACE
-#include <boost/stacktrace.hpp>
 #include <glog/logging.h>
 #include <gutil/macros.h>
 
+#include <boost/stacktrace.hpp>
 #include <csignal>
 #include <ctime>
 #ifdef HAVE_UCONTEXT_H
-# include <ucontext.h>
+#include <ucontext.h>
 #endif
 #ifdef HAVE_SYS_UCONTEXT_H
-# include <sys/ucontext.h>
+#include <sys/ucontext.h>
 #endif
 #include <algorithm>
 
@@ -56,15 +56,11 @@ namespace {
 //
 // The list should be synced with the comment in signalhandler.h.
 const struct {
-  int number;
-  const char *name;
+    int number;
+    const char* name;
 } kFailureSignals[] = {
-  { SIGSEGV, "SIGSEGV" },
-  { SIGILL, "SIGILL" },
-  { SIGFPE, "SIGFPE" },
-  { SIGABRT, "SIGABRT" },
-  { SIGBUS, "SIGBUS" },
-  { SIGTERM, "SIGTERM" },
+        {SIGSEGV, "SIGSEGV"}, {SIGILL, "SIGILL"}, {SIGFPE, "SIGFPE"},
+        {SIGABRT, "SIGABRT"}, {SIGBUS, "SIGBUS"}, {SIGTERM, "SIGTERM"},
 };
 
 static bool kFailureSignalHandlerInstalled = false;
@@ -86,163 +82,160 @@ static bool kFailureSignalHandlerInstalled = false;
  * These signal explainer is copied from Meta's Folly
  */
 const char* sigill_reason(int si_code) {
-  switch (si_code) {
+    switch (si_code) {
     case ILL_ILLOPC:
-      return "illegal opcode";
+        return "illegal opcode";
     case ILL_ILLOPN:
-      return "illegal operand";
+        return "illegal operand";
     case ILL_ILLADR:
-      return "illegal addressing mode";
+        return "illegal addressing mode";
     case ILL_ILLTRP:
-      return "illegal trap";
+        return "illegal trap";
     case ILL_PRVOPC:
-      return "privileged opcode";
+        return "privileged opcode";
     case ILL_PRVREG:
-      return "privileged register";
+        return "privileged register";
     case ILL_COPROC:
-      return "coprocessor error";
+        return "coprocessor error";
     case ILL_BADSTK:
-      return "internal stack error";
+        return "internal stack error";
 
     default:
-      return nullptr;
-  }
+        return nullptr;
+    }
 }
 
 const char* sigfpe_reason(int si_code) {
-  switch (si_code) {
+    switch (si_code) {
     case FPE_INTDIV:
-      return "integer divide by zero";
+        return "integer divide by zero";
     case FPE_INTOVF:
-      return "integer overflow";
+        return "integer overflow";
     case FPE_FLTDIV:
-      return "floating-point divide by zero";
+        return "floating-point divide by zero";
     case FPE_FLTOVF:
-      return "floating-point overflow";
+        return "floating-point overflow";
     case FPE_FLTUND:
-      return "floating-point underflow";
+        return "floating-point underflow";
     case FPE_FLTRES:
-      return "floating-point inexact result";
+        return "floating-point inexact result";
     case FPE_FLTINV:
-      return "floating-point invalid operation";
+        return "floating-point invalid operation";
     case FPE_FLTSUB:
-      return "subscript out of range";
+        return "subscript out of range";
 
     default:
-      return nullptr;
-  }
+        return nullptr;
+    }
 }
 
 const char* sigsegv_reason(int si_code) {
-  switch (si_code) {
+    switch (si_code) {
     case SEGV_MAPERR:
-      return "address not mapped to object";
+        return "address not mapped to object";
     case SEGV_ACCERR:
-      return "invalid permissions for mapped object";
+        return "invalid permissions for mapped object";
 
     default:
-      return nullptr;
-  }
+        return nullptr;
+    }
 }
 
 const char* sigbus_reason(int si_code) {
-  switch (si_code) {
+    switch (si_code) {
     case BUS_ADRALN:
-      return "invalid address alignment";
+        return "invalid address alignment";
     case BUS_ADRERR:
-      return "nonexistent physical address";
+        return "nonexistent physical address";
     case BUS_OBJERR:
-      return "object-specific hardware error";
+        return "object-specific hardware error";
 
-      // MCEERR_AR and MCEERR_AO: in sigaction(2) but not in headers.
+        // MCEERR_AR and MCEERR_AO: in sigaction(2) but not in headers.
 
     default:
-      return nullptr;
-  }
+        return nullptr;
+    }
 }
 
 const char* signal_reason(int signum, int si_code) {
-  switch (signum) {
+    switch (signum) {
     case SIGILL:
-      return sigill_reason(si_code);
+        return sigill_reason(si_code);
     case SIGFPE:
-      return sigfpe_reason(si_code);
+        return sigfpe_reason(si_code);
     case SIGSEGV:
-      return sigsegv_reason(si_code);
+        return sigsegv_reason(si_code);
     case SIGBUS:
-      return sigbus_reason(si_code);
+        return sigbus_reason(si_code);
     default:
-      return nullptr;
-  }
+        return nullptr;
+    }
 }
 
-// The class is used for formatting error messages.  We don't use printf()
+// The class is used for formatting error messages. We don't use printf()
 // as it's not async signal safe.
 class MinimalFormatter {
- public:
-  MinimalFormatter(char *buffer, size_t size)
-      : buffer_(buffer),
-        cursor_(buffer),
-        end_(buffer + size) {
-  }
+public:
+    MinimalFormatter(char* buffer, size_t size)
+            : buffer_(buffer), cursor_(buffer), end_(buffer + size) {}
 
-  // Returns the number of bytes written in the buffer.
-  std::size_t num_bytes_written() const { return static_cast<std::size_t>(cursor_ - buffer_); }
+    // Returns the number of bytes written in the buffer.
+    std::size_t num_bytes_written() const { return static_cast<std::size_t>(cursor_ - buffer_); }
 
-  // Appends string from "str" and updates the internal cursor.
-  void AppendString(const char* str) {
-    ptrdiff_t i = 0;
-    while (str[i] != '\0' && cursor_ + i < end_) {
-      cursor_[i] = str[i];
-      ++i;
+    // Appends string from "str" and updates the internal cursor.
+    void AppendString(const char* str) {
+        ptrdiff_t i = 0;
+        while (str[i] != '\0' && cursor_ + i < end_) {
+            cursor_[i] = str[i];
+            ++i;
+        }
+        cursor_ += i;
     }
-    cursor_ += i;
-  }
 
-  // Formats "number" in "radix" and updates the internal cursor.
-  // Lowercase letters are used for 'a' - 'z'.
-  void AppendUint64(uint64 number, unsigned radix) {
-    unsigned i = 0;
-    while (cursor_ + i < end_) {
-      const uint64 tmp = number % radix;
-      number /= radix;
-      cursor_[i] = static_cast<char>(tmp < 10 ? '0' + tmp : 'a' + tmp - 10);
-      ++i;
-      if (number == 0) {
-        break;
-      }
+    // Formats "number" in "radix" and updates the internal cursor.
+    // Lowercase letters are used for 'a' - 'z'.
+    void AppendUint64(uint64 number, unsigned radix) {
+        unsigned i = 0;
+        while (cursor_ + i < end_) {
+            const uint64 tmp = number % radix;
+            number /= radix;
+            cursor_[i] = static_cast<char>(tmp < 10 ? '0' + tmp : 'a' + tmp - 10);
+            ++i;
+            if (number == 0) {
+                break;
+            }
+        }
+        // Reverse the bytes written.
+        std::reverse(cursor_, cursor_ + i);
+        cursor_ += i;
     }
-    // Reverse the bytes written.
-    std::reverse(cursor_, cursor_ + i);
-    cursor_ += i;
-  }
 
-  // Formats "number" as hexadecimal number, and updates the internal
-  // cursor.  Padding will be added in front if needed.
-  void AppendHexWithPadding(uint64 number, int width) {
-    char* start = cursor_;
-    AppendString("0x");
-    AppendUint64(number, 16);
-    // Move to right and add padding in front if needed.
-    if (cursor_ < start + width) {
-      const int64 delta = start + width - cursor_;
-      std::copy(start, cursor_, start + delta);
-      std::fill(start, start + delta, ' ');
-      cursor_ = start + width;
+    // Formats "number" as hexadecimal number, and updates the internal
+    // cursor.  Padding will be added in front if needed.
+    void AppendHexWithPadding(uint64 number, int width) {
+        char* start = cursor_;
+        AppendString("0x");
+        AppendUint64(number, 16);
+        // Move to right and add padding in front if needed.
+        if (cursor_ < start + width) {
+            const int64 delta = start + width - cursor_;
+            std::copy(start, cursor_, start + delta);
+            std::fill(start, start + delta, ' ');
+            cursor_ = start + width;
+        }
     }
-  }
 
- private:
-  char *buffer_;
-  char *cursor_;
-  const char * const end_;
+private:
+    char* buffer_;
+    char* cursor_;
+    const char* const end_;
 };
 
 // Writes the given data with the size to the standard error.
 void WriteToStderr(const char* data, size_t size) {
-  if (write(STDERR_FILENO, data, size) < 0) {
-    // Ignore errors.
-  }
+    if (write(STDERR_FILENO, data, size) < 0) {
+        // Ignore errors.
+    }
 }
 
 // The writer function can be changed by InstallFailureWriter().
@@ -251,196 +244,190 @@ void (*g_failure_writer)(const char* data, size_t size) = WriteToStderr;
 // Dumps time information.  We don't dump human-readable time information
 // as localtime() is not guaranteed to be async signal safe.
 void DumpTimeInfo() {
-  time_t time_in_sec = time(NULL);
-  char buf[256];  // Big enough for time info.
-  MinimalFormatter formatter(buf, sizeof(buf));
-  formatter.AppendString("*** Aborted at ");
-  formatter.AppendUint64(static_cast<uint64>(time_in_sec), 10);
-  formatter.AppendString(" (unix time)");
-  formatter.AppendString(" try \"date -d @");
-  formatter.AppendUint64(static_cast<uint64>(time_in_sec), 10);
-  formatter.AppendString("\" if you are using GNU date ***\n");
-  g_failure_writer(buf, formatter.num_bytes_written());
+    time_t time_in_sec = time(NULL);
+    char buf[256]; // Big enough for time info.
+    MinimalFormatter formatter(buf, sizeof(buf));
+    formatter.AppendString("*** Aborted at ");
+    formatter.AppendUint64(static_cast<uint64>(time_in_sec), 10);
+    formatter.AppendString(" (unix time)");
+    formatter.AppendString(" try \"date -d @");
+    formatter.AppendUint64(static_cast<uint64>(time_in_sec), 10);
+    formatter.AppendString("\" if you are using GNU date ***\n");
+    g_failure_writer(buf, formatter.num_bytes_written());
 }
 
 // Dumps information about the signal to STDERR.
-void DumpSignalInfo(int signal_number, siginfo_t *siginfo) {
-  // Get the signal name.
-  const char* signal_name = NULL;
-  for (size_t i = 0; i < ARRAYSIZE(kFailureSignals); ++i) {
-    if (signal_number == kFailureSignals[i].number) {
-      signal_name = kFailureSignals[i].name;
+void DumpSignalInfo(int signal_number, siginfo_t* siginfo) {
+    // Get the signal name.
+    const char* signal_name = NULL;
+    for (size_t i = 0; i < ARRAYSIZE(kFailureSignals); ++i) {
+        if (signal_number == kFailureSignals[i].number) {
+            signal_name = kFailureSignals[i].name;
+        }
     }
-  }
 
-  char buf[256];  // Big enough for signal info.
-  MinimalFormatter formatter(buf, sizeof(buf));
+    char buf[256]; // Big enough for signal info.
+    MinimalFormatter formatter(buf, sizeof(buf));
 
-  formatter.AppendString("*** ");
-  if (signal_name) {
-    formatter.AppendString(signal_name);
-  } else {
-    // Use the signal number if the name is unknown.  The signal name
-    // should be known, but just in case.
-    formatter.AppendString("Signal ");
-    formatter.AppendUint64(static_cast<uint64>(signal_number), 10);
-  }
-  formatter.AppendString(" ");
-  // Detail reason explain
-  auto reason = signal_reason(signal_number, siginfo->si_code);
+    formatter.AppendString("*** ");
+    if (signal_name) {
+        formatter.AppendString(signal_name);
+    } else {
+        // Use the signal number if the name is unknown.  The signal name
+        // should be known, but just in case.
+        formatter.AppendString("Signal ");
+        formatter.AppendUint64(static_cast<uint64>(signal_number), 10);
+    }
+    formatter.AppendString(" ");
+    // Detail reason explain.
+    auto reason = signal_reason(signal_number, siginfo->si_code);
 
-  // If we can't find a reason code make a best effort to print the (int) code.
-  if (reason != nullptr) {
-    formatter.AppendString(reason);
-  } else {
-    formatter.AppendString("unkown detail explain");
-  }
-  formatter.AppendString(" (@0x");
-  formatter.AppendUint64(reinterpret_cast<uintptr_t>(siginfo->si_addr), 16);
-  formatter.AppendString(")");
-  formatter.AppendString(" received by PID ");
-  formatter.AppendUint64(static_cast<uint64>(getpid()), 10);
-  formatter.AppendString(" (TID 0x");
-  // We assume pthread_t is an integral number or a pointer, rather
-  // than a complex struct.  In some environments, pthread_self()
-  // returns an uint64 but in some other environments pthread_self()
-  // returns a pointer.
-  pthread_t id = pthread_self();
-  formatter.AppendUint64(
-      reinterpret_cast<uint64>(reinterpret_cast<const char*>(id)), 16);
-  formatter.AppendString(") ");
-  // Only linux has the PID of the signal sender in si_pid.
-  formatter.AppendString("from PID ");
-  formatter.AppendUint64(static_cast<uint64>(siginfo->si_pid), 10);
-  formatter.AppendString("; ");
-  formatter.AppendString("stack trace: ***\n");
-  g_failure_writer(buf, formatter.num_bytes_written());
+    // If we can't find a reason code make a best effort to print the (int) code.
+    if (reason != nullptr) {
+        formatter.AppendString(reason);
+    } else {
+        formatter.AppendString("unkown detail explain");
+    }
+    formatter.AppendString(" (@0x");
+    formatter.AppendUint64(reinterpret_cast<uintptr_t>(siginfo->si_addr), 16);
+    formatter.AppendString(")");
+    formatter.AppendString(" received by PID ");
+    formatter.AppendUint64(static_cast<uint64>(getpid()), 10);
+    formatter.AppendString(" (TID 0x");
+    // We assume pthread_t is an integral number or a pointer, rather
+    // than a complex struct. In some environments, pthread_self()
+    // returns an uint64 but in some other environments pthread_self()
+    // returns a pointer.
+    pthread_t id = pthread_self();
+    formatter.AppendUint64(reinterpret_cast<uint64>(reinterpret_cast<const char*>(id)), 16);
+    formatter.AppendString(") ");
+    // Only linux has the PID of the signal sender in `si_pid`.
+    formatter.AppendString("from PID ");
+    formatter.AppendUint64(static_cast<uint64>(siginfo->si_pid), 10);
+    formatter.AppendString("; ");
+    formatter.AppendString("stack trace: ***\n");
+    g_failure_writer(buf, formatter.num_bytes_written());
 }
 
 // Invoke the default signal handler.
 void InvokeDefaultSignalHandler(int signal_number) {
-  struct sigaction sig_action;
-  memset(&sig_action, 0, sizeof(sig_action));
-  sigemptyset(&sig_action.sa_mask);
-  sig_action.sa_handler = SIG_DFL;
-  sigaction(signal_number, &sig_action, NULL);
-  kill(getpid(), signal_number);
+    struct sigaction sig_action;
+    memset(&sig_action, 0, sizeof(sig_action));
+    sigemptyset(&sig_action.sa_mask);
+    sig_action.sa_handler = SIG_DFL;
+    sigaction(signal_number, &sig_action, NULL);
+    kill(getpid(), signal_number);
 }
 
-// This variable is used for protecting FailureSignalHandler() from
-// dumping stuff while another thread is doing it.  Our policy is to let
+// This variable is used for protecting `FailureSignalHandler()` from
+// dumping stuff while another thread is doing it. Our policy is to let
 // the first thread dump stuff and let other threads wait.
-// See also comments in FailureSignalHandler().
+// See also comments in `FailureSignalHandler()`.
 static pthread_t* g_entered_thread_id_pointer = NULL;
 
-// Wrapper of __sync_val_compare_and_swap. If the GCC extension isn't
+// Wrapper of `__sync_val_compare_and_swap`. If the GCC extension isn't
 // defined, we try the CPU specific logics (we only support x86 and
 // x86_64 for now) first, then use a naive implementation, which has a
 // race condition.
-template<typename T>
+template <typename T>
 inline T sync_val_compare_and_swap(T* ptr, T oldval, T newval) {
 #if defined(HAVE___SYNC_VAL_COMPARE_AND_SWAP)
-  return __sync_val_compare_and_swap(ptr, oldval, newval);
+    return __sync_val_compare_and_swap(ptr, oldval, newval);
 #elif defined(__GNUC__) && (defined(__i386__) || defined(__x86_64__))
-  T ret;
-  __asm__ __volatile__("lock; cmpxchg %1, (%2);"
-                       :"=a"(ret)
-                        // GCC may produces %sil or %dil for
-                        // constraint "r", but some of apple's gas
-                        // dosn't know the 8 bit registers.
-                        // We use "q" to avoid these registers.
-                       :"q"(newval), "q"(ptr), "a"(oldval)
-                       :"memory", "cc");
-  return ret;
+    T ret;
+    __asm__ __volatile__("lock; cmpxchg %1, (%2);"
+                         : "=a"(ret)
+                         // GCC may produces %sil or %dil for
+                         // constraint "r", but some of apple's gas
+                         // dosn't know the 8 bit registers.
+                         // We use "q" to avoid these registers.
+                         : "q"(newval), "q"(ptr), "a"(oldval)
+                         : "memory", "cc");
+    return ret;
 #else
-  T ret = *ptr;
-  if (ret == oldval) {
-    *ptr = newval;
-  }
-  return ret;
+    T ret = *ptr;
+    if (ret == oldval) {
+        *ptr = newval;
+    }
+    return ret;
 #endif
 }
 
 // Dumps signal and stack frame information, and invokes the default
 // signal handler once our job is done.
-void FailureSignalHandler(int signal_number,
-                          siginfo_t *signal_info,
-                          void *ucontext)
-{
-  // First check if we've already entered the function.  We use an atomic
-  // compare and swap operation for platforms that support it.  For other
-  // platforms, we use a naive method that could lead to a subtle race.
+void FailureSignalHandler(int signal_number, siginfo_t* signal_info, void* ucontext) {
+    // First check if we've already entered the function.  We use an atomic
+    // compare and swap operation for platforms that support it.  For other
+    // platforms, we use a naive method that could lead to a subtle race.
 
-  // We assume pthread_self() is async signal safe, though it's not
-  // officially guaranteed.
-  pthread_t my_thread_id = pthread_self();
-  // NOTE: We could simply use pthread_t rather than pthread_t* for this,
-  // if pthread_self() is guaranteed to return non-zero value for thread
-  // ids, but there is no such guarantee.  We need to distinguish if the
-  // old value (value returned from __sync_val_compare_and_swap) is
-  // different from the original value (in this case NULL).
-  pthread_t* old_thread_id_pointer =
-      sync_val_compare_and_swap(
-          &g_entered_thread_id_pointer,
-          static_cast<pthread_t*>(NULL),
-          &my_thread_id);
-  if (old_thread_id_pointer != NULL) {
-    // We've already entered the signal handler.  What should we do?
-    if (pthread_equal(my_thread_id, *g_entered_thread_id_pointer)) {
-      // It looks the current thread is reentering the signal handler.
-      // Something must be going wrong (maybe we are reentering by another
-      // type of signal?).  Kill ourself by the default signal handler.
-      InvokeDefaultSignalHandler(signal_number);
+    // We assume pthread_self() is async signal safe, though it's not
+    // officially guaranteed.
+    pthread_t my_thread_id = pthread_self();
+
+    // NOTE: we could simply use pthread_t rather than pthread_t* for this,
+    // if pthread_self() is guaranteed to return non-zero value for thread
+    // ids, but there is no such guarantee.  We need to distinguish if the
+    // old value (value returned from __sync_val_compare_and_swap) is
+    // different from the original value (in this case NULL).
+    pthread_t* old_thread_id_pointer = sync_val_compare_and_swap(
+            &g_entered_thread_id_pointer, static_cast<pthread_t*>(NULL), &my_thread_id);
+    if (old_thread_id_pointer != NULL) {
+        // We've already entered the signal handler.
+        if (pthread_equal(my_thread_id, *g_entered_thread_id_pointer)) {
+            // It looks the current thread is reentering the signal handler.
+            // Something must be going wrong (maybe we are reentering by another
+            // type of signal?).  Kill ourself by the default signal handler.
+            InvokeDefaultSignalHandler(signal_number);
+        }
+        // Another thread is dumping stuff. Let's wait until that thread
+        // finishes the job and kills the process.
+        while (true) {
+            sleep(1);
+        }
     }
-    // Another thread is dumping stuff.  Let's wait until that thread
-    // finishes the job and kills the process.
-    while (true) {
-      sleep(1);
-    }
-  }
-  // This is the first time we enter the signal handler.  We are going to
-  // do some interesting stuff from here.
-  // TODO(satorux): We might want to set timeout here using alarm(), but
-  // mixing alarm() and sleep() can be a bad idea.
+    // This is the first time we enter the signal handler.  We are going to
+    // do some interesting stuff from here.
+    //
+    // TODO(satorux): we might want to set timeout here using `alarm()`, but
+    // mixing `alarm()` and `sleep()` can be a bad idea.
 
-  // First dump time info.
-  DumpTimeInfo();
-  DumpSignalInfo(signal_number, signal_info);
+    // First dump time info.
+    DumpTimeInfo();
+    DumpSignalInfo(signal_number, signal_info);
 
-  // *** TRANSITION ***
-  //
-  // BEFORE this point, all code must be async-termination-safe!
-  // (See WARNING above.)
-  //
-  // AFTER this point, we do unsafe things, like using LOG()!
-  // The process could be terminated or hung at any time.  We try to
-  // do more useful things first and riskier things later.
+    // *** TRANSITION ***
+    //
+    // BEFORE this point, all code must be async-termination-safe!
+    // (See WARNING above.)
+    //
+    // AFTER this point, we do unsafe things, like using LOG()!
+    // The process could be terminated or hung at any time.  We try to
+    // do more useful things first and riskier things later.
+    // Use boost stacktrace to print more detail info.
+    std::cout << boost::stacktrace::stacktrace() << std::endl;
 
-  // Use boost stacktrace to print more detail info
-  std::cout << boost::stacktrace::stacktrace() << std::endl;
+    // Flush the logs before we do anything in case 'anything'
+    // causes problems.
+    google::FlushLogFilesUnsafe(0);
 
-  // Flush the logs before we do anything in case 'anything'
-  // causes problems.
-  google::FlushLogFilesUnsafe(0);
-
-  // Kill ourself by the default signal handler.
-  InvokeDefaultSignalHandler(signal_number);
+    // Kill ourself by the default signal handler.
+    InvokeDefaultSignalHandler(signal_number);
 }
 
-}  // namespace
+} // namespace
 
 void InstallFailureSignalHandler() {
-  // Build the sigaction struct.
-  struct sigaction sig_action;
-  memset(&sig_action, 0, sizeof(sig_action));
-  sigemptyset(&sig_action.sa_mask);
-  sig_action.sa_flags |= SA_SIGINFO;
-  sig_action.sa_sigaction = &FailureSignalHandler;
+    // Build the sigaction struct.
+    struct sigaction sig_action;
+    memset(&sig_action, 0, sizeof(sig_action));
+    sigemptyset(&sig_action.sa_mask);
+    sig_action.sa_flags |= SA_SIGINFO;
+    sig_action.sa_sigaction = &FailureSignalHandler;
 
-  for (size_t i = 0; i < ARRAYSIZE(kFailureSignals); ++i) {
-    CHECK_ERR(sigaction(kFailureSignals[i].number, &sig_action, NULL));
-  }
-  kFailureSignalHandlerInstalled = true;
+    for (size_t i = 0; i < ARRAYSIZE(kFailureSignals); ++i) {
+        CHECK_ERR(sigaction(kFailureSignals[i].number, &sig_action, NULL));
+    }
+    kFailureSignalHandlerInstalled = true;
 }
 
-} // namespace doris
+} // namespace doris::signal

--- a/be/src/common/status.cpp
+++ b/be/src/common/status.cpp
@@ -126,7 +126,6 @@ std::string Status::code_as_string() const {
         return tmp;
     }
     }
-    return std::string();
 }
 
 std::string Status::to_string() const {

--- a/be/src/common/status.h
+++ b/be/src/common/status.h
@@ -16,26 +16,23 @@
 namespace doris {
 
 class Status {
-    enum { 
+    enum {
         // If the error and log returned by the query are truncated, the status to string may be too long.
         STATE_CAPACITY = 2048,
         HEADER_LEN = 7,
         MESSAGE_LEN = STATE_CAPACITY - HEADER_LEN
     };
+
 public:
     Status() : _length(0) {}
 
-    // copy c'tor makes copy of error detail so Status can be returned by value
-    Status(const Status& rhs) {
-        *this = rhs;
-    }
+    // Copy c'tor makes copy of error detail so Status can be returned by value.
+    Status(const Status& rhs) { *this = rhs; }
 
-    // move c'tor
-    Status(Status&& rhs) {
-        *this = rhs;
-    }
+    // Move c'tor.
+    Status(Status&& rhs) { *this = rhs; }
 
-    // same as copy c'tor
+    // Same as copy c'tor.
     Status& operator=(const Status& rhs) {
         if (rhs._length) {
             memcpy(_state, rhs._state, rhs._length + Status::HEADER_LEN);
@@ -45,7 +42,7 @@ public:
         return *this;
     }
 
-    // move assign
+    // Move assign.
     Status& operator=(Status&& rhs) {
         this->operator=(rhs);
         return *this;
@@ -162,22 +159,22 @@ public:
     bool is_already_exist() const { return code() == TStatusCode::ALREADY_EXIST; }
     bool is_io_error() const { return code() == TStatusCode::IO_ERROR; }
 
-    /// @return @c true iff the status indicates Uninitialized.
+    // Return true iff the status indicates Uninitialized.
     bool is_uninitialized() const { return code() == TStatusCode::UNINITIALIZED; }
 
-    // @return @c true iff the status indicates an Aborted error.
+    // Return true iff the status indicates an Aborted error.
     bool is_aborted() const { return code() == TStatusCode::ABORTED; }
 
-    /// @return @c true iff the status indicates an InvalidArgument error.
+    // Return true iff the status indicates an InvalidArgument error.
     bool is_invalid_argument() const { return code() == TStatusCode::INVALID_ARGUMENT; }
 
-    // @return @c true iff the status indicates ServiceUnavailable.
+    // Return true iff the status indicates ServiceUnavailable.
     bool is_service_unavailable() const { return code() == TStatusCode::SERVICE_UNAVAILABLE; }
 
     bool is_data_quality_error() const { return code() == TStatusCode::DATA_QUALITY_ERROR; }
 
-    // Convert into TStatus. Call this if 'status_container' contains an optional
-    // TStatus field named 'status'. This also sets __isset.status.
+    // Convert into 'TStatus'. Call this if 'status_container' contains an optional
+    // TStatus field named 'status'. This also sets '__isset.status'.
     template <typename T>
     void set_t_status(T* status_container) const {
         to_thrift(&status_container->status);
@@ -194,56 +191,38 @@ public:
         return std::string(msg.data, msg.size);
     }
 
-    /// @return A string representation of this status suitable for printing.
-    ///   Returns the string "OK" for success.
+    // Return a string representation of this status suitable for printing.
     std::string to_string() const;
 
-    /// @return A string representation of the status code, without the message
-    ///   text or sub code information.
+    // Return a string representation of the  status code, without the message text or sub code
+    // information.
     std::string code_as_string() const;
 
-    // This is similar to to_string, except that it does not include
+    // This is similar to  `to_string`, except that it does not include
     // the stringified error code or sub code.
     //
-    // @note The returned Slice is only valid as long as this Status object
-    //   remains live and unchanged.
-    //
-    // @return The message portion of the Status. For @c OK statuses,
-    //   this returns an empty string.
+    // NOTE: the returned slice is only valid as long as this Status object remains live and unchanged.
     Slice message() const;
 
     TStatusCode::type code() const {
         return ok() ? TStatusCode::OK : static_cast<TStatusCode::type>(_code);
     }
 
-    int16_t precise_code() const {
-        return ok() ? 0 : _precise_code;
-    }
+    int16_t precise_code() const { return ok() ? 0 : _precise_code; }
 
-    /// Clone this status and add the specified prefix to the message.
-    ///
-    /// If this status is OK, then an OK status will be returned.
-    ///
-    /// @param [in] msg
-    ///   The message to prepend.
-    /// @return A new Status object with the same state plus an additional
-    ///   leading message.
+    // Clone this status and add the specified prefix to the message. If this status is OK,
+    // then an OK status will be returned.
     Status clone_and_prepend(const Slice& msg) const;
 
-    /// Clone this status and add the specified suffix to the message.
-    ///
-    /// If this status is OK, then an OK status will be returned.
-    ///
-    /// @param [in] msg
-    ///   The message to append.
-    /// @return A new Status object with the same state plus an additional
-    ///   trailing message.
+    // Clone this status and add the specified suffix to the message. If this status is OK,
+    // then an OK status will be returned.
     Status clone_and_append(const Slice& msg) const;
 
     operator bool() const { return this->ok(); }
 
 private:
-    void assemble_state(TStatusCode::type code, const Slice& msg, int16_t precise_code, const Slice& msg2) {
+    void assemble_state(TStatusCode::type code, const Slice& msg, int16_t precise_code,
+                        const Slice& msg2) {
         DCHECK(code != TStatusCode::OK);
         uint32_t len1 = msg.size;
         uint32_t len2 = msg2.size;
@@ -267,13 +246,13 @@ private:
         _precise_code = precise_code;
 
         // copy msg
-        char* result =  _state + HEADER_LEN;
+        char* result = _state + HEADER_LEN;
         uint32_t len = std::min<uint32_t>(len1, MESSAGE_LEN);
         memcpy(result, msg.data, len);
 
         // copy msg2
         if (len2 > 0 && len < MESSAGE_LEN - 2) {
-            result[len++] = ':'; 
+            result[len++] = ':';
             result[len++] = ' ';
             memcpy(&result[len], msg2.data, std::min<uint32_t>(len2, MESSAGE_LEN - len));
         }
@@ -294,15 +273,15 @@ private:
         char _state[STATE_CAPACITY];
 
         struct {
-            int64_t _length : 32;       // message length
-            int64_t _code : 8;          
+            int64_t _length : 32; // message length
+            int64_t _code : 8;
             int64_t _precise_code : 16;
-            int64_t _message : 8;       // save message since here
+            int64_t _message : 8; // save message since here
         };
     };
 };
 
-// some generally useful macros
+// Some generally useful macros.
 #define RETURN_IF_ERROR(stmt)            \
     do {                                 \
         const Status& _status_ = (stmt); \
@@ -329,7 +308,7 @@ private:
         }                                          \
     } while (false)
 
-/// @brief Emit a warning if @c to_call returns a bad status.
+// Emit a warning if `to_call` returns a bad status.
 #define WARN_IF_ERROR(to_call, warning_prefix)                          \
     do {                                                                \
         const Status& _s = (to_call);                                   \
@@ -356,6 +335,7 @@ private:
         }                                                                      \
     } while (false);
 } // namespace doris
+
 #ifdef WARN_UNUSED_RESULT
 #undef WARN_UNUSED_RESULT
 #endif

--- a/be/src/common/utils.h
+++ b/be/src/common/utils.h
@@ -36,9 +36,9 @@ struct AuthInfo {
 template <class T>
 void set_request_auth(T* req, const AuthInfo& auth) {
     if (auth.auth_code != -1) {
-        // if auth_code is set, no need to set other info
+        // If  `auth_code` is set, no need to set other info.
         req->__set_auth_code(auth.auth_code);
-        // user name and passwd is unused, but they are required field.
+        // `username` and `passwd` is unused, but they are required field.
         // so they have to be set.
         req->user = "";
         req->passwd = "";
@@ -58,7 +58,7 @@ void set_request_auth(T* req, const AuthInfo& auth) {
 // This is the threshold used to periodically release the memory occupied by the expression. 
 // RELEASE_CONTEXT_COUNTER should be power of 2
 // GCC will optimize the modulo operation to &(release_context_counter - 1)
-// _conjunct_ctxs will free local alloc after this probe calculations
+// `_conjunct_ctxs` will free local alloc after this probe calculations.
 static constexpr int RELEASE_CONTEXT_COUNTER = 1 << 7;
 static_assert((RELEASE_CONTEXT_COUNTER & (RELEASE_CONTEXT_COUNTER - 1)) == 0,
               "should be power of 2");

--- a/be/src/vec/columns/column.h
+++ b/be/src/vec/columns/column.h
@@ -168,13 +168,14 @@ public:
     virtual void insert_many_from(const IColumn& src, size_t position, size_t length) {
         for (size_t i = 0; i < length; ++i) insert_from(src, position);
     }
- 
+
     /// Appends a batch elements from other column with the same type
     /// indices_begin + indices_end represent the row indices of column src
     /// Warning:
     ///       if *indices == -1 means the row is null, only use in outer join, do not use in any other place
     ///       insert JOIN_NULL_HINT in null map to hint the null is produced by outer join
-    virtual void insert_indices_from(const IColumn& src, const int* indices_begin, const int* indices_end) = 0;
+    virtual void insert_indices_from(const IColumn& src, const int* indices_begin,
+                                     const int* indices_end) = 0;
 
     /// Appends data located in specified memory chunk if it is possible (throws an exception if it cannot be implemented).
     /// Is used to optimize some computations (in aggregation, for example).
@@ -183,17 +184,19 @@ public:
     virtual void insert_data(const char* pos, size_t length) = 0;
 
     virtual void insert_many_fix_len_data(const char* pos, size_t num) {
-      LOG(FATAL) << "Method insert_many_fix_len_data is not supported for " << get_name();
+        LOG(FATAL) << "Method insert_many_fix_len_data is not supported for " << get_name();
     }
 
     // todo(zeno) Use dict_args temp object to cover all arguments
     virtual void insert_many_dict_data(const int32_t* data_array, size_t start_index,
-                                       const StringRef* dict, size_t data_num, uint32_t dict_num = 0) {
-      LOG(FATAL) << "Method insert_many_dict_data is not supported for " << get_name();
+                                       const StringRef* dict, size_t data_num,
+                                       uint32_t dict_num = 0) {
+        LOG(FATAL) << "Method insert_many_dict_data is not supported for " << get_name();
     }
- 
-    virtual void insert_many_binary_data(char* data_array, uint32_t* len_array, uint32_t* start_offset_array, size_t num) {
-      LOG(FATAL) << "Method insert_many_binary_data is not supported for " << get_name();
+
+    virtual void insert_many_binary_data(char* data_array, uint32_t* len_array,
+                                         uint32_t* start_offset_array, size_t num) {
+        LOG(FATAL) << "Method insert_many_binary_data is not supported for " << get_name();
     }
 
     /// Appends "default value".


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

The current code comment style is not uniform. I want to unify the code comment style to improve code readability. Thanks.

## Checklist(Required)

1. Does it affect the original behavior: No
2. Has unit tests been added: No Need
3. Has document been added or modified: No Need
4. Does it need to update dependencies: No
5. Are there any changes that cannot be rolled back: No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
