### PR TITLE
[fix](user-property) Fix bug that can not set exec_mem_limit at user level

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/UserProperty.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/UserProperty.java
@@ -329,7 +329,7 @@ public class UserProperty implements Writable {
         this.commonProperties.setCpuResourceLimit(cpuResourceLimit);
         this.commonProperties.setResourceTags(resourceTags);
         this.commonProperties.setExecMemLimit(execMemLimit);
-        this.commonProperties.setExecMemLimit(loadMemLimit);
+        this.commonProperties.setLoadMemLimit(loadMemLimit);
         resource = newResource;
         if (newDppConfigs.containsKey(newDefaultLoadCluster)) {
             defaultLoadCluster = newDefaultLoadCluster;
@@ -451,6 +451,12 @@ public class UserProperty implements Writable {
 
         // cpu resource limit
         result.add(Lists.newArrayList(PROP_CPU_RESOURCE_LIMIT, String.valueOf(commonProperties.getCpuResourceLimit())));
+
+        // exec mem limit
+        result.add(Lists.newArrayList(PROP_EXEC_MEM_LIMIT, String.valueOf(commonProperties.getExecMemLimit())));
+
+        // load mem limit
+        result.add(Lists.newArrayList(PROP_LOAD_MEM_LIMIT, String.valueOf(commonProperties.getLoadMemLimit())));
 
         // resource tag
         result.add(Lists.newArrayList(PROP_RESOURCE_TAGS, Joiner.on(", ").join(commonProperties.getResourceTags())));

--- a/fe/fe-core/src/test/java/org/apache/doris/planner/ResourceTagQueryTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/planner/ResourceTagQueryTest.java
@@ -271,6 +271,20 @@ public class ResourceTagQueryTest {
         explainString = UtFrameUtils.getSQLPlanOrErrorMsg(connectContext, queryStr);
         System.out.println(explainString);
         Assert.assertTrue(explainString.contains("tabletRatio=30/30"));
+
+        // set user exec mem limit
+        String setExecMemLimitStr = "set property for 'root' 'exec_mem_limit' = '1000000';";
+        ExceptionChecker.expectThrowsNoException(() -> setProperty(setExecMemLimitStr));
+        long execMemLimit = Catalog.getCurrentCatalog().getAuth().getExecMemLimit(PaloAuth.ROOT_USER);
+        Assert.assertEquals(1000000, execMemLimit);
+
+        String setLoadMemLimitStr = "set property for 'root' 'load_mem_limit' = '2000000';";
+        ExceptionChecker.expectThrowsNoException(() -> setProperty(setLoadMemLimitStr));
+        long loadMemLimit = Catalog.getCurrentCatalog().getAuth().getLoadMemLimit(PaloAuth.ROOT_USER);
+        Assert.assertEquals(2000000, loadMemLimit);
+
+        List<List<String>> userProps = Catalog.getCurrentCatalog().getAuth().getUserProperties(PaloAuth.ROOT_USER);
+        Assert.assertEquals(17, userProps.size());
     }
 
     private void checkTableReplicaAllocation(OlapTable tbl) throws InterruptedException {


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (No)
2. Has unit tests been added: (Yes)
3. Has document been added or modified: (No Need)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
