### PR TITLE
[Improvement] broker load with hdfs support wildcard

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/BrokerUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/BrokerUtil.java
@@ -187,7 +187,7 @@ public class BrokerUtil {
             }
             try {
                 FileSystem fs = FileSystem.get(new URI(hdfsFsName), conf, user);
-                FileStatus[] statusList = fs.listStatus(new Path(path));
+                FileStatus[] statusList = fs.globStatus(new Path(path));
                 for (FileStatus status : statusList) {
                     if (status.isFile()) {
                         fileStatuses.add(new TBrokerFileStatus(status.getPath().toUri().getPath(),


### PR DESCRIPTION
# Proposed changes

Issue Number: close #8717

## Problem Summary:

using globStatus instant of listStatus to support wildcard char.

## Checklist(Required)

1. Does it affect the original behavior: (Yes)
2. Has unit tests been added: (No)
3. Has document been added or modified: (No)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
