### PR TITLE
fix concurrent synchorinzation problem in NodeChannel::try_send_batch

### DIFF
--- a/be/src/exec/tablet_sink.cpp
+++ b/be/src/exec/tablet_sink.cpp
@@ -472,13 +472,13 @@ int NodeChannel::try_send_and_fetch_status(RuntimeState* state,
     // packet_in_flight because try_send_patch sets packet_in_flight before
     // _last_patch_processed_finished.
     // If we read _add_batch_closure before cmp_exchange _last_patch_processed_finished,
-    // then somting bad would happend. e.g.
-    // |----------------------------------------------------------------------------
+    // then something bad would happend. e.g.
+    // |----------------------------------------------------------------------------|
     // | Thread try_send_and_fetch_status  | Thread try_send_batch                  |
-    // |-----------------------------------------------------------------------------
+    // |----------------------------------------------------------------------------|
     // | read packet_in_flight false       | before seting packet_in_flight         |
     // |-----------------------------------------------------------------------------
-    // |                                   | set _last_patch_processed_finished true|
+    // |                                   | setting _last_patch_processed_finished true|
     // |----------------------------------------------------------------------------|
     // |chxg _last_patch_processed_finished|                                        |
     // |----------------------------------------------------------------------------|

--- a/be/src/exec/tablet_sink.h
+++ b/be/src/exec/tablet_sink.h
@@ -113,9 +113,13 @@ public:
         cid = cntl.call_id();
     }
 
-    void set_in_flight() {
-        DCHECK(_packet_in_flight == false);
-        _packet_in_flight = true;
+    bool try_set_in_flight() {
+        bool value = false;
+        return _packet_in_flight.compare_exchange_strong(value, true);
+    }
+
+    void clear_in_flight() {
+        _packet_in_flight = false;
     }
 
     bool is_packet_in_flight() { return _packet_in_flight; }
@@ -134,7 +138,7 @@ public:
         } else {
             success_handler(result, _is_last_rpc);
         }
-        _packet_in_flight = false;
+        clear_in_flight();
     }
 
     brpc::Controller cntl;
@@ -244,8 +248,6 @@ private:
 
     // add batches finished means the last rpc has be response, used to check whether this channel can be closed
     std::atomic<bool> _add_batches_finished {false};
-
-    std::atomic<bool> _last_patch_processed_finished {true};
 
     bool _eos_is_produced {false}; // only for restricting producer behaviors
 


### PR DESCRIPTION
The patch fixes two problems.
1. Memory order problem accessing _last_patch_processed_finished and in_flight, actually _last_patch_processed_finished is redudant, so the patch removes it.
2. synchorization in join on cid.

Fix for https://github.com/apache/incubator-doris/issues/8725.

# Proposed changes

Issue Number: close #8725 

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
4. Has unit tests been added: (Yes/No/No Need)
5. Has document been added or modified: (Yes/No/No Need)
6. Does it need to update dependencies: (Yes/No)
7. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
