### PR TITLE
[optimize](storage) Use column dictionary only when all pages are dict encoding

### DIFF
--- a/be/src/olap/column_predicate.h
+++ b/be/src/olap/column_predicate.h
@@ -86,6 +86,9 @@ public:
     virtual void evaluate_vec(vectorized::IColumn& column, uint16_t size, bool* flags) const {};
     uint32_t column_id() const { return _column_id; }
 
+    virtual bool is_in_predicate() const { return false; }
+    virtual bool is_comparison_predicate() const { return false; }
+
     virtual void set_dict_code_if_necessary(vectorized::IColumn& column) { }
 
 protected:

--- a/be/src/olap/comparison_predicate.h
+++ b/be/src/olap/comparison_predicate.h
@@ -47,6 +47,7 @@ class VectorizedRowBatch;
         void evaluate_or(vectorized::IColumn& column, uint16_t* sel, uint16_t size,                \
                          bool* flags) const override;                                              \
         void evaluate_vec(vectorized::IColumn& column, uint16_t size, bool* flags) const override; \
+        bool is_comparison_predicate() const override { return true; }                             \
         void set_dict_code_if_necessary(vectorized::IColumn& column) override;                     \
     private:                                                                                       \
         T _value;                                                                                  \

--- a/be/src/olap/in_list_predicate.h
+++ b/be/src/olap/in_list_predicate.h
@@ -96,6 +96,7 @@ class VectorizedRowBatch;
         void evaluate(vectorized::IColumn& column, uint16_t* sel, uint16_t* size) const override; \
         void evaluate_and(vectorized::IColumn& column, uint16_t* sel, uint16_t size, bool* flags) const override {} \
         void evaluate_or(vectorized::IColumn& column, uint16_t* sel, uint16_t size, bool* flags) const override {} \
+        bool is_in_predicate() const override { return true; }                                    \
         void set_dict_code_if_necessary(vectorized::IColumn& column) override;                    \
     private:                                                                                      \
         phmap::flat_hash_set<T> _values;                                                          \

--- a/be/src/olap/rowset/segment_v2/binary_dict_page.cpp
+++ b/be/src/olap/rowset/segment_v2/binary_dict_page.cpp
@@ -240,7 +240,6 @@ void BinaryDictPageDecoder::set_dict_decoder(PageDecoder* dict_decoder, StringRe
 
 Status BinaryDictPageDecoder::next_batch(size_t* n, vectorized::MutableColumnPtr &dst) {
     if (_encoding_type == PLAIN_ENCODING) {
-        dst = (*(std::move(dst->convert_to_predicate_column_if_dictionary()))).assume_mutable();
         return _data_page_decoder->next_batch(n, dst);
     }
     // dictionary encoding

--- a/be/src/olap/rowset/segment_v2/binary_dict_page.h
+++ b/be/src/olap/rowset/segment_v2/binary_dict_page.h
@@ -113,6 +113,8 @@ public:
 
     bool is_dict_encoding() const;
 
+    EncodingTypePB encoding_type() const override { return _encoding_type; }
+
     void set_dict_decoder(PageDecoder* dict_decoder, StringRef* dict_word_info);
 
     ~BinaryDictPageDecoder();

--- a/be/src/olap/rowset/segment_v2/binary_plain_page.h
+++ b/be/src/olap/rowset/segment_v2/binary_plain_page.h
@@ -286,6 +286,8 @@ public:
         dict_word_info[_num_elems-1].size = (data_begin + _offsets_pos) - (char*)dict_word_info[_num_elems-1].data;
     }
 
+    EncodingTypePB encoding_type() const override { return PLAIN_ENCODING; }
+
 private:
     // Return the offset within '_data' where the string value with index 'idx' can be found.
     uint32_t offset(size_t idx) const {

--- a/be/src/olap/rowset/segment_v2/binary_prefix_page.h
+++ b/be/src/olap/rowset/segment_v2/binary_prefix_page.h
@@ -127,6 +127,8 @@ public:
         return _cur_pos;
     }
 
+    EncodingTypePB encoding_type() const override { return PREFIX_ENCODING; }
+
 private:
     // decode shared and non-shared entry length from `ptr`.
     // return ptr past the parsed value when success.

--- a/be/src/olap/rowset/segment_v2/bitshuffle_page.h
+++ b/be/src/olap/rowset/segment_v2/bitshuffle_page.h
@@ -373,6 +373,8 @@ public:
 
     size_t current_index() const override { return _cur_index; }
 
+    EncodingTypePB encoding_type() const override { return BIT_SHUFFLE; }
+
 private:
     void _copy_next_values(size_t n, void* data) {
         memcpy(data, &_chunk.data[_cur_index * SIZE_OF_TYPE], n * SIZE_OF_TYPE);

--- a/be/src/olap/rowset/segment_v2/frame_of_reference_page.h
+++ b/be/src/olap/rowset/segment_v2/frame_of_reference_page.h
@@ -173,6 +173,8 @@ public:
 
     size_t current_index() const override { return _cur_index; }
 
+    EncodingTypePB encoding_type() const override { return FOR_ENCODING; }
+
 private:
     typedef typename TypeTraits<Type>::CppType CppType;
 

--- a/be/src/olap/rowset/segment_v2/page_decoder.h
+++ b/be/src/olap/rowset/segment_v2/page_decoder.h
@@ -102,6 +102,10 @@ public:
 
     bool has_remaining() const { return current_index() < count(); }
 
+    // Usually encoding_type is fixed, but DictPageDecoder is special,
+    // it may be Dict or Plain encoding
+    virtual EncodingTypePB encoding_type() const = 0;
+
 private:
     DISALLOW_COPY_AND_ASSIGN(PageDecoder);
 };

--- a/be/src/olap/rowset/segment_v2/parsed_page.h
+++ b/be/src/olap/rowset/segment_v2/parsed_page.h
@@ -102,6 +102,8 @@ struct ParsedPage {
     bool has_remaining() const { return offset_in_page < num_rows; }
 
     size_t remaining() const { return num_rows - offset_in_page; }
+
+    EncodingTypePB encoding_type() { return data_decoder->encoding_type(); }
 };
 
 } // namespace segment_v2

--- a/be/src/olap/rowset/segment_v2/plain_page.h
+++ b/be/src/olap/rowset/segment_v2/plain_page.h
@@ -223,6 +223,8 @@ public:
         return _cur_idx;
     }
 
+    EncodingTypePB encoding_type() const override { return PLAIN_ENCODING; }
+
 private:
     Slice _data;
     PageDecoderOptions _options;

--- a/be/src/olap/rowset/segment_v2/rle_page.h
+++ b/be/src/olap/rowset/segment_v2/rle_page.h
@@ -257,6 +257,8 @@ public:
 
     size_t current_index() const override { return _cur_index; }
 
+    EncodingTypePB encoding_type() const override { return RLE; }
+
 private:
     typedef typename TypeTraits<Type>::CppType CppType;
     enum { SIZE_OF_TYPE = TypeTraits<Type>::size };

--- a/be/src/olap/rowset/segment_v2/segment_iterator.h
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.h
@@ -62,7 +62,7 @@ public:
 private:
     Status _init(bool is_vec = false);
 
-    Status _init_return_column_iterators();
+    Status _init_return_column_iterators(bool is_vec = false);
     Status _init_bitmap_index_iterators();
 
     // calculate row ranges that fall into requested key ranges using short key index
@@ -159,6 +159,11 @@ private:
     // so we need a field to stand for columns first time to read
     std::vector<ColumnId> _first_read_column_ids;
     std::vector<int> _schema_block_id_map; // map from schema column id to column idx in Block
+
+    std::vector<bool> _is_all_page_dict_encoded_column;
+    // Use local dictionary optimization only if all data_pages are dict encoding
+    // and the column has comparison or in predicates
+    std::vector<bool> _use_local_dict_column;
 
     // the actual init process is delayed to the first call to next_batch()
     bool _inited;

--- a/be/src/olap/schema.h
+++ b/be/src/olap/schema.h
@@ -106,6 +106,9 @@ public:
 
     static vectorized::IColumn::MutablePtr get_predicate_column_nullable_ptr(FieldType type, bool is_null = false);
 
+    static vectorized::IColumn::MutablePtr get_column_dictionary_nullable_ptr(FieldType type,
+                                                                              bool is_null = false);
+
     const std::vector<Field*>& columns() const { return _cols; }
 
     const Field* column(ColumnId cid) const { return _cols[cid]; }

--- a/be/src/vec/columns/column.h
+++ b/be/src/vec/columns/column.h
@@ -64,10 +64,6 @@ public:
     /// If column is ColumnLowCardinality, transforms is to full column.
     virtual Ptr convert_to_full_column_if_low_cardinality() const { return get_ptr(); }
 
-    /// If column isn't ColumnDictionary, return itself.
-    /// If column is ColumnDictionary, transforms is to predicate column.
-    virtual Ptr convert_to_predicate_column_if_dictionary() { return get_ptr(); }
-
     /// If column is ColumnDictionary, and is a range comparison predicate, convert dict encoding
     virtual void convert_dict_codes_if_necessary() {}
 

--- a/be/src/vec/columns/column_dictionary.h
+++ b/be/src/vec/columns/column_dictionary.h
@@ -259,19 +259,6 @@ public:
 
     bool is_dict_code_converted() const { return _dict_code_converted; }
 
-    ColumnPtr convert_to_predicate_column_if_dictionary() override {
-        auto res = vectorized::PredicateColumnType<StringValue>::create();
-        size_t size = _codes.size();
-        res->reserve(size);
-        for (size_t i = 0; i < size; ++i) {
-            auto& code = reinterpret_cast<T&>(_codes[i]);
-            auto value = _dict.get_value(code);
-            res->insert_data(value.ptr, value.len);
-        }
-        _dict.clear();
-        return res;
-    }
-
     class Dictionary {
     public:
         Dictionary() = default;

--- a/be/src/vec/columns/column_nullable.h
+++ b/be/src/vec/columns/column_nullable.h
@@ -267,13 +267,6 @@ public:
         LOG(FATAL) << "should not call the method in column nullable";
     }
 
-    ColumnPtr convert_to_predicate_column_if_dictionary() override {
-        IColumn* nested_ptr = get_nested_column_ptr().get();
-        nested_ptr = (*(std::move(nested_ptr->convert_to_predicate_column_if_dictionary()
-                                  ))).assume_mutable();
-        return get_ptr();
-    }
-
     void convert_dict_codes_if_necessary() override {
         get_nested_column().convert_dict_codes_if_necessary();
     }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #8315 
Use column dictionary only when all pages are dict encoding.

## Problem Summary:

The current storage layer creates a `ColumnDictionary` type for string columns with predicates. When the `BinaryDictPageDecoder` reads the PLAIN_ENCODING data_page, it converts the `ColumnDictionary` to a `PredicateColumn`, causing unnecessary overhead. Especially when the string columns are all high cardinality.

Therefore, when `SegmentIterator::init` is executed, the last data_page of the string column is read in advance. If the last data_page is DICT_ENCODING, it means that all data_pages are DICT_ENCODING.
`ColumnDictionary` is used to optimize queries only if all data_pages of a string column are DICT_ENCODING, and the column has `comparison` or `in_list` predicates.


## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
