### PR TITLE
[Fix](build) ignore clang building problem of unused-private-field

### DIFF
--- a/be/src/util/runtime_profile.cpp
+++ b/be/src/util/runtime_profile.cpp
@@ -15,6 +15,10 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#ifdef __clang__
+#pragma clang diagnostic ignored "-Wunused-private-field"
+#endif
+
 #include "util/runtime_profile.h"
 
 #include <iomanip>


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

add 'clang diagnostic ignored "-Wunused-private-field"'  in runtime_profile.cpp to ignore building error for unused private variable _own_pool

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
