### PR TITLE
[improvement](storage) Add more detailed timer on SegmentIter in profile

### DIFF
--- a/be/src/exec/olap_scan_node.cpp
+++ b/be/src/exec/olap_scan_node.cpp
@@ -129,6 +129,7 @@ void OlapScanNode::_init_counter(RuntimeState* state) {
     _short_cond_timer = ADD_TIMER(_segment_profile, "ShortPredEvalTime");
     _pred_col_read_timer = ADD_TIMER(_segment_profile, "PredColumnReadTime");
     _lazy_read_timer = ADD_TIMER(_segment_profile, "LazyReadTime");
+    _output_col_timer = ADD_TIMER(_segment_profile, "OutputColumnTime");
 
     _stats_filtered_counter = ADD_COUNTER(_segment_profile, "RowsStatsFiltered", TUnit::UNIT);
     _bf_filtered_counter = ADD_COUNTER(_segment_profile, "RowsBloomFilterFiltered", TUnit::UNIT);

--- a/be/src/exec/olap_scan_node.cpp
+++ b/be/src/exec/olap_scan_node.cpp
@@ -126,6 +126,9 @@ void OlapScanNode::_init_counter(RuntimeState* state) {
 
     _rows_vec_cond_counter = ADD_COUNTER(_segment_profile, "RowsVectorPredFiltered", TUnit::UNIT);
     _vec_cond_timer = ADD_TIMER(_segment_profile, "VectorPredEvalTime");
+    _short_cond_timer = ADD_TIMER(_segment_profile, "ShortPredEvalTime");
+    _pred_col_read_timer = ADD_TIMER(_segment_profile, "PredColumnReadTime");
+    _lazy_read_timer = ADD_TIMER(_segment_profile, "LazyReadTime");
 
     _stats_filtered_counter = ADD_COUNTER(_segment_profile, "RowsStatsFiltered", TUnit::UNIT);
     _bf_filtered_counter = ADD_COUNTER(_segment_profile, "RowsBloomFilterFiltered", TUnit::UNIT);

--- a/be/src/exec/olap_scan_node.h
+++ b/be/src/exec/olap_scan_node.h
@@ -292,6 +292,7 @@ protected:
     RuntimeProfile::Counter* _short_cond_timer = nullptr;
     RuntimeProfile::Counter* _pred_col_read_timer = nullptr;
     RuntimeProfile::Counter* _lazy_read_timer = nullptr;
+    RuntimeProfile::Counter* _output_col_timer = nullptr;
 
     RuntimeProfile::Counter* _stats_filtered_counter = nullptr;
     RuntimeProfile::Counter* _bf_filtered_counter = nullptr;

--- a/be/src/exec/olap_scan_node.h
+++ b/be/src/exec/olap_scan_node.h
@@ -289,6 +289,9 @@ protected:
 
     RuntimeProfile::Counter* _rows_vec_cond_counter = nullptr;
     RuntimeProfile::Counter* _vec_cond_timer = nullptr;
+    RuntimeProfile::Counter* _short_cond_timer = nullptr;
+    RuntimeProfile::Counter* _pred_col_read_timer = nullptr;
+    RuntimeProfile::Counter* _lazy_read_timer = nullptr;
 
     RuntimeProfile::Counter* _stats_filtered_counter = nullptr;
     RuntimeProfile::Counter* _bf_filtered_counter = nullptr;

--- a/be/src/exec/olap_scanner.cpp
+++ b/be/src/exec/olap_scanner.cpp
@@ -529,6 +529,7 @@ void OlapScanner::update_counter() {
     COUNTER_UPDATE(_parent->_short_cond_timer, stats.short_cond_ns);
     COUNTER_UPDATE(_parent->_pred_col_read_timer, stats.pred_col_read_ns);
     COUNTER_UPDATE(_parent->_lazy_read_timer, stats.lazy_read_ns);
+    COUNTER_UPDATE(_parent->_output_col_timer, stats.output_col_ns);
     COUNTER_UPDATE(_parent->_rows_vec_cond_counter, stats.rows_vec_cond_filtered);
 
     COUNTER_UPDATE(_parent->_stats_filtered_counter, stats.rows_stats_filtered);

--- a/be/src/exec/olap_scanner.cpp
+++ b/be/src/exec/olap_scanner.cpp
@@ -526,6 +526,9 @@ void OlapScanner::update_counter() {
     _raw_rows_read += _tablet_reader->mutable_stats()->raw_rows_read;
     // COUNTER_UPDATE(_parent->_filtered_rows_counter, stats.num_rows_filtered);
     COUNTER_UPDATE(_parent->_vec_cond_timer, stats.vec_cond_ns);
+    COUNTER_UPDATE(_parent->_short_cond_timer, stats.short_cond_ns);
+    COUNTER_UPDATE(_parent->_pred_col_read_timer, stats.pred_col_read_ns);
+    COUNTER_UPDATE(_parent->_lazy_read_timer, stats.lazy_read_ns);
     COUNTER_UPDATE(_parent->_rows_vec_cond_counter, stats.rows_vec_cond_filtered);
 
     COUNTER_UPDATE(_parent->_stats_filtered_counter, stats.rows_stats_filtered);

--- a/be/src/olap/olap_common.h
+++ b/be/src/olap/olap_common.h
@@ -263,6 +263,9 @@ struct OlapReaderStatistics {
     int64_t rows_vec_cond_filtered = 0;
     int64_t rows_vec_del_cond_filtered = 0;
     int64_t vec_cond_ns = 0;
+    int64_t short_cond_ns = 0;
+    int64_t pred_col_read_ns = 0;
+    int64_t lazy_read_ns = 0;
 
     int64_t rows_key_range_filtered = 0;
     int64_t rows_stats_filtered = 0;

--- a/be/src/olap/olap_common.h
+++ b/be/src/olap/olap_common.h
@@ -266,6 +266,7 @@ struct OlapReaderStatistics {
     int64_t short_cond_ns = 0;
     int64_t pred_col_read_ns = 0;
     int64_t lazy_read_ns = 0;
+    int64_t output_col_ns = 0;
 
     int64_t rows_key_range_filtered = 0;
     int64_t rows_stats_filtered = 0;

--- a/be/src/olap/rowset/segment_v2/segment_iterator.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.cpp
@@ -762,6 +762,7 @@ void SegmentIterator::_init_current_block(
 }
 
 void SegmentIterator::_output_non_pred_columns(vectorized::Block* block, bool is_block_mem_reuse) {
+    SCOPED_RAW_TIMER(&_opts.stats->output_col_ns);
     for (auto cid : _non_predicate_columns) {
         block->replace_by_position(_schema_block_id_map[cid],
                                    std::move(_current_return_columns[cid]));
@@ -978,7 +979,7 @@ Status SegmentIterator::next_batch(vectorized::Block* block) {
         }
     }
 
-    // shink char_type suffix zero data
+    // shrink char_type suffix zero data
     block->shrink_char_type_column_suffix_zero(_char_type_idx);
 
     return Status::OK();

--- a/be/src/olap/rowset/segment_v2/segment_iterator.h
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.h
@@ -106,6 +106,7 @@ private:
     Status _output_column_by_sel_idx(vectorized::Block* block, const Container& column_ids,
                                      uint16_t* sel_rowid_idx, uint16_t select_size,
                                      bool is_block_mem_reuse) {
+        SCOPED_RAW_TIMER(&_opts.stats->output_col_ns);
         for (auto cid : column_ids) {
             int block_cid = _schema_block_id_map[cid];
             RETURN_IF_ERROR(block->copy_column_data_to_block(

--- a/be/src/vec/exec/volap_scanner.cpp
+++ b/be/src/vec/exec/volap_scanner.cpp
@@ -51,23 +51,26 @@ Status VOlapScanner::get_block(RuntimeState* state, vectorized::Block* block, bo
         }
     }
 
-    do {
-        // Read one block from block reader
-        auto res = _tablet_reader->next_block_with_aggregation(block, nullptr, nullptr, eof);
-        if (res != OLAP_SUCCESS) {
-            std::stringstream ss;
-            ss << "Internal Error: read storage fail. res=" << res
-               << ", tablet=" << _tablet->full_name()
-               << ", backend=" << BackendOptions::get_localhost();
-            return Status::InternalError(ss.str());
-        }
-        _num_rows_read += block->rows();
-        _update_realtime_counter();
+    {
+        SCOPED_TIMER(_parent->_scan_timer);
+        do {
+            // Read one block from block reader
+            auto res = _tablet_reader->next_block_with_aggregation(block, nullptr, nullptr, eof);
+            if (res != OLAP_SUCCESS) {
+                std::stringstream ss;
+                ss << "Internal Error: read storage fail. res=" << res
+                   << ", tablet=" << _tablet->full_name()
+                   << ", backend=" << BackendOptions::get_localhost();
+                return Status::InternalError(ss.str());
+            }
+            _num_rows_read += block->rows();
+            _update_realtime_counter();
 
-        RETURN_IF_ERROR(
-                VExprContext::filter_block(_vconjunct_ctx, block, _tuple_desc->slots().size()));
-    } while (block->rows() == 0 && !(*eof) && raw_rows_read() < raw_rows_threshold &&
-             block->allocated_bytes() < raw_bytes_threshold);
+            RETURN_IF_ERROR(
+                    VExprContext::filter_block(_vconjunct_ctx, block, _tuple_desc->slots().size()));
+        } while (block->rows() == 0 && !(*eof) && raw_rows_read() < raw_rows_threshold &&
+                 block->allocated_bytes() < raw_bytes_threshold);
+    }
     // NOTE:
     // There is no need to check raw_bytes_threshold since block->rows() == 0 is checked first.
     // But checking raw_bytes_threshold is still added here for consistency with raw_rows_threshold

--- a/docs/en/administrator-guide/running-profile.md
+++ b/docs/en/administrator-guide/running-profile.md
@@ -240,6 +240,7 @@ OLAP_SCAN_NODE (id=0):(Active: 1.2ms,% non-child: 0.00%)
       - ShortPredEvalTime: 0ns          # Time-consuming of short-circuiting predicate condition filtering operations.
       - PredColumnReadTime: 0ns         # Time-consuming of predicate column read.
       - LazyReadTime: 0ns               # Time-consuming of non-predicate column read.
+      - OutputColumnTime: 0ns           # Time-consuming of materialize columns.
 ```
 
 The predicate push down and index usage can be inferred from the related indicators of the number of data rows in the profile. The following only describes the profile in the reading process of segment V2 format data. In segment V1 format, the meaning of these indicators is slightly different.

--- a/docs/en/administrator-guide/running-profile.md
+++ b/docs/en/administrator-guide/running-profile.md
@@ -237,6 +237,9 @@ OLAP_SCAN_NODE (id=0):(Active: 1.2ms,% non-child: 0.00%)
       - TotalPagesNum: 30               # Only in V2, the total number of pages read.
       - UncompressedBytesRead: 0.00     # V1 is the decompressed size of the read data file (if the file does not need to be decompressed, the file size is directly counted). In V2, only the decompressed size of the Page that missed PageCache is counted (if the Page does not need to be decompressed, the Page size is directly counted)
       - VectorPredEvalTime: 0ns         # Time-consuming of vectorized condition filtering operation.
+      - ShortPredEvalTime: 0ns          # Time-consuming of short-circuiting predicate condition filtering operations.
+      - PredColumnReadTime: 0ns         # Time-consuming of predicate column read.
+      - LazyReadTime: 0ns               # Time-consuming of non-predicate column read.
 ```
 
 The predicate push down and index usage can be inferred from the related indicators of the number of data rows in the profile. The following only describes the profile in the reading process of segment V2 format data. In segment V1 format, the meaning of these indicators is slightly different.

--- a/docs/zh-CN/administrator-guide/running-profile.md
+++ b/docs/zh-CN/administrator-guide/running-profile.md
@@ -236,6 +236,9 @@ OLAP_SCAN_NODE (id=0):(Active: 1.2ms, % non-child: 0.00%)
       - TotalPagesNum: 30               # 仅 V2 中，读取的总 Page 数量。
       - UncompressedBytesRead: 0.00     # V1 中为读取的数据文件解压后的大小（如果文件无需解压，则直接统计文件大小）。V2 中，仅统计未命中 PageCache 的 Page 解压后的大小（如果Page无需解压，直接统计Page大小）
       - VectorPredEvalTime: 0ns         # 向量化条件过滤操作的耗时。
+      - ShortPredEvalTime: 0ns          # 短路谓词过滤操作的耗时。
+      - PredColumnReadTime: 0ns         # 谓词列读取的耗时。
+      - LazyReadTime: 0ns               # 非谓词列读取的耗时。
 ```
 
 通过 Profile 中数据行数相关指标可以推断谓词条件下推和索引使用情况。以下仅针对 Segment V2 格式数据读取流程中的 Profile 进行说明。Segment V1 格式中，这些指标的含义略有不同。

--- a/docs/zh-CN/administrator-guide/running-profile.md
+++ b/docs/zh-CN/administrator-guide/running-profile.md
@@ -239,6 +239,7 @@ OLAP_SCAN_NODE (id=0):(Active: 1.2ms, % non-child: 0.00%)
       - ShortPredEvalTime: 0ns          # 短路谓词过滤操作的耗时。
       - PredColumnReadTime: 0ns         # 谓词列读取的耗时。
       - LazyReadTime: 0ns               # 非谓词列读取的耗时。
+      - OutputColumnTime: 0ns           # 物化列的耗时。
 ```
 
 通过 Profile 中数据行数相关指标可以推断谓词条件下推和索引使用情况。以下仅针对 Segment V2 格式数据读取流程中的 Profile 进行说明。Segment V1 格式中，这些指标的含义略有不同。


### PR DESCRIPTION
# Proposed changes

- Fix some profile indicators of vectorized query were not counted: ScanTime, VectorPredEvalTime
- Add some metrics for analyzing storage layer performance consumption: LazyReadTime, PredColumnReadTime, ShortPredEvalTime, OutputColumnTime


## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
