### PR TITLE
[improvement]complement the SHOW PROCESSLIST information

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowProcesslistStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowProcesslistStmt.java
@@ -32,10 +32,12 @@ public class ShowProcesslistStmt extends ShowStmt {
                     .addColumn(new Column("Host", ScalarType.createVarchar(16)))
                     .addColumn(new Column("Cluster", ScalarType.createVarchar(16)))
                     .addColumn(new Column("Db", ScalarType.createVarchar(16)))
+                    .addColumn(new Column("QueryId", ScalarType.createVarchar(64)))
                     .addColumn(new Column("Command", ScalarType.createVarchar(16)))
+                    .addColumn(new Column("StartTime", ScalarType.createType(PrimitiveType.DATETIME)))
                     .addColumn(new Column("Time", ScalarType.createType(PrimitiveType.INT)))
                     .addColumn(new Column("State", ScalarType.createVarchar(64)))
-                    .addColumn(new Column("Info", ScalarType.createVarchar(16)))
+                    .addColumn(new Column("Info", ScalarType.createVarchar(32 * 1024)))
                     .build();
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectContext.java
@@ -44,6 +44,8 @@ import org.apache.logging.log4j.Logger;
 import java.nio.channels.SocketChannel;
 import java.util.List;
 import java.util.Set;
+import java.util.Date;
+import java.text.SimpleDateFormat;
 
 // When one client connect in, we create a connect context for it.
 // We store session information here. Meanwhile ConnectScheduler all
@@ -549,11 +551,20 @@ public class ConnectContext {
             row.add(getMysqlChannel().getRemoteHostPortString());
             row.add(clusterName);
             row.add(ClusterNamespace.getNameFromFullName(currentDb));
+                        row.add(queryDetail.getQueryId());
             row.add(command.toString());
+            row.add(fromLongToDate(startTime));
             row.add("" + (nowMs - startTime) / 1000);
             row.add("");
-            row.add("");
+            String stmt = executor == null ? "" : executor.getOriginStmtInString();
+            row.add(stmt);
             return row;
+        }
+        
+        public String fromLongToDate(long time){
+            SimpleDateFormat sdf = new SimpleDateFormat("YYYY-MM-dd HH:mm:ss");
+            Date date = new Date(time);
+            return sdf.format(date);
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -1554,6 +1554,13 @@ public class StmtExecutor implements ProfileWriter {
         }
         return statisticsForAuditLog.build();
     }
+    
+    public String getOriginStmtInString(){
+        if (originStmt == null){
+            return "";
+        }
+        return originStmt.originStmt;
+    }
 
     private List<PrimitiveType> exprToType(List<Expr> exprs) {
         return exprs.stream().map(e -> e.getType().getPrimitiveType()).collect(Collectors.toList());


### PR DESCRIPTION
The SHOW PROCESSLIST Statement displays information about the processes that are currently running in the server.
but the information is incomplete, so we add some information: query_id, sql detail and query start time.

## Checklist(Required)

1. Does it affect the original behavior: (No)
2. Has unit tests been added: (No Need)
3. Has document been added or modified: (No Need)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
