### PR TITLE
[refactor] use row_size as name of variable indicating rows rather than column_size

### DIFF
--- a/be/src/vec/data_types/data_type.cpp
+++ b/be/src/vec/data_types/data_type.cpp
@@ -42,9 +42,9 @@ String IDataType::do_get_name() const {
 
 void IDataType::update_avg_value_size_hint(const IColumn& column, double& avg_value_size_hint) {
     /// Update the average value size hint if amount of read rows isn't too small
-    size_t column_size = column.size();
-    if (column_size > 10) {
-        double current_avg_value_size = static_cast<double>(column.byte_size()) / column_size;
+    size_t row_size = column.size();
+    if (row_size > 10) {
+        double current_avg_value_size = static_cast<double>(column.byte_size()) / row_size;
 
         /// Heuristic is chosen so that avg_value_size_hint increases rapidly but decreases slowly.
         if (current_avg_value_size > avg_value_size_hint)

--- a/be/src/vec/exec/vrepeat_node.cpp
+++ b/be/src/vec/exec/vrepeat_node.cpp
@@ -108,7 +108,7 @@ Status VRepeatNode::get_repeated_block(Block* child_block, int repeat_id_idx, Bl
         bool is_repeat_slot =
                 _all_slot_ids.find(_output_slots[cur_col]->id()) != _all_slot_ids.end();
         bool is_set_null_slot = repeat_ids.find(_output_slots[cur_col]->id()) == repeat_ids.end();
-        const auto column_size = src_column.column->size();
+        const auto row_size = src_column.column->size();
 
         if (is_repeat_slot) {
             DCHECK(_output_slots[cur_col]->is_nullable());
@@ -118,19 +118,19 @@ Status VRepeatNode::get_repeated_block(Block* child_block, int repeat_id_idx, Bl
 
             // set slot null not in repeat_ids
             if (is_set_null_slot) {
-                nullable_column->resize(column_size);
-                memset(nullable_column->get_null_map_data().data(), 1, sizeof(UInt8) * column_size);
+                nullable_column->resize(row_size);
+                memset(nullable_column->get_null_map_data().data(), 1, sizeof(UInt8) * row_size);
             } else {
                 if (!src_column.type->is_nullable()) {
-                    for (size_t j = 0; j < column_size; ++j) {
+                    for (size_t j = 0; j < row_size; ++j) {
                         null_map.push_back(0);
                     }
                     column_ptr = &nullable_column->get_nested_column();
                 }
-                column_ptr->insert_range_from(*src_column.column, 0, column_size);
+                column_ptr->insert_range_from(*src_column.column, 0, row_size);
             }
         } else {
-            columns[cur_col]->insert_range_from(*src_column.column, 0, column_size);
+            columns[cur_col]->insert_range_from(*src_column.column, 0, row_size);
         }
         cur_col++;
     }

--- a/be/src/vec/sink/mysql_result_writer.cpp
+++ b/be/src/vec/sink/mysql_result_writer.cpp
@@ -58,7 +58,7 @@ Status VMysqlResultWriter::_add_one_column(const ColumnPtr& column_ptr,
                                            const DataTypePtr& nested_type_ptr) {
     SCOPED_TIMER(_convert_tuple_timer);
 
-    const auto column_size = column_ptr->size();
+    const auto row_size = column_ptr->size();
 
     doris::vectorized::ColumnPtr column;
     if constexpr (is_nullable) {
@@ -71,7 +71,7 @@ Status VMysqlResultWriter::_add_one_column(const ColumnPtr& column_ptr,
     int buf_ret = 0;
 
     if constexpr (type == TYPE_OBJECT || type == TYPE_VARCHAR) {
-        for (int i = 0; i < column_size; ++i) {
+        for (int i = 0; i < row_size; ++i) {
             if (0 != buf_ret) {
                 return Status::InternalError("pack mysql buffer failed.");
             }
@@ -109,7 +109,7 @@ Status VMysqlResultWriter::_add_one_column(const ColumnPtr& column_ptr,
     } else if constexpr (type == TYPE_ARRAY) {
         auto& column_array = assert_cast<const ColumnArray&>(*column);
         auto& offsets = column_array.get_offsets();
-        for (int i = 0; i < column_size; ++i) {
+        for (int i = 0; i < row_size; ++i) {
             if (0 != buf_ret) {
                 return Status::InternalError("pack mysql buffer failed.");
             }
@@ -146,7 +146,7 @@ Status VMysqlResultWriter::_add_one_column(const ColumnPtr& column_ptr,
         using ColumnType = typename PrimitiveTypeTraits<type>::ColumnType;
         auto& data = assert_cast<const ColumnType&>(*column).get_data();
 
-        for (int i = 0; i < column_size; ++i) {
+        for (int i = 0; i < row_size; ++i) {
             if (0 != buf_ret) {
                 return Status::InternalError("pack mysql buffer failed.");
             }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
