### PR TITLE
[Fix] fix restore issue when  meta version is too low

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/backup/Repository.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/backup/Repository.java
@@ -423,6 +423,9 @@ public class Repository implements Writable {
             LOG.warn("failed to read backup meta from file", e);
             return new Status(ErrCode.COMMON_ERROR, "Failed create backup meta from file: "
                     + localMetaFile.getAbsolutePath() + ", msg: " + e.getMessage());
+        } catch (IllegalArgumentException e) {
+            LOG.warn("failed to set meta version", e);
+            return new Status(ErrCode.COMMON_ERROR, e.getMessage());
         } finally {
             localMetaFile.delete();
         }


### PR DESCRIPTION
# Proposed changes

when restore snapshot from 0.13 to master,  the restore job is pending for long time.   However,  we get error "Could not set meta version to 93 since it is lower than minimum required version 100" in log。  we should cancel restore job once get that error.


## Problem Summary:
when restore snapshot from 0.13 to master,  the restore job is pending for long time.   However,  we get error "Could not set meta version to 93 since it is lower than minimum required version 100" in log。  we should cancel restore job once get that error.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
