### PR TITLE
[fix] min and max window function bug fix

### DIFF
--- a/be/src/exprs/agg_fn_evaluator.cpp
+++ b/be/src/exprs/agg_fn_evaluator.cpp
@@ -346,7 +346,7 @@ inline void AggFnEvaluator::set_any_val(const void* slot, const TypeDescriptor& 
 
 inline void AggFnEvaluator::set_output_slot(const AnyVal* src, const SlotDescriptor* dst_slot_desc,
                                             Tuple* dst) {
-    if (src->is_null) {
+    if (src->is_null && dst_slot_desc->is_nullable()) {
         dst->set_null(dst_slot_desc->null_indicator_offset());
         return;
     }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #8814

## Problem Summary:
The difference between sql1 and sql2 is is_nullable, in sql1 TExprNode:is_nullable = true, but in sql2 TExprNode:is_nullable = false.

While is_nullable is false, min/max works not correctly. Because:
1. InitFn called by AggFnEvaluator::init, and _staging_intermediate_val is the return value;
2. At here _staging_intermediate_val->is_null == true and val = MAX for min aggregate;
3. next set_output_slot called, copy _staging_intermediate_val to destination Tuple;
4. becase _staging_intermediate_val is_null == true, set_output_slot do nothing, leave destination Tuple with default zero value;
5. Use zero value to calc min with positive number, always return zero.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
6. Has unit tests been added: (Yes/No/No Need)
7. Has document been added or modified: (Yes/No/No Need)
8. Does it need to update dependencies: (Yes/No)
9. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
