### PR TITLE
[fix] AggregationMethodOneNumber should handle ColumnNullable

### DIFF
--- a/be/src/vec/exec/vaggregation_node.h
+++ b/be/src/vec/exec/vaggregation_node.h
@@ -101,8 +101,8 @@ struct AggregationMethodOneNumber {
     static void insert_key_into_columns(const Key& key, MutableColumns& key_columns,
                                         const Sizes& /*key_sizes*/) {
         const auto* key_holder = reinterpret_cast<const char*>(&key);
-        auto* column = static_cast<ColumnVectorHelper*>(key_columns[0].get());
-        column->insert_raw_data<sizeof(FieldType)>(key_holder);
+        auto* column = key_columns[0].get();
+        column->insert_data(key_holder, sizeof(FieldType));
     }
 
     void init_once() {


### PR DESCRIPTION
It is a mistake to cast ColumnNullable* to ColumnVectorHelper*.
UBSAN reports below messages:
runtime error: member call on address 0x00002af70680 which does not point to a
n object of type 'doris::vectorized::ColumnVectorHelper'

The be core dump running tpcds q77 on 1T data set without UBSAN.

Fix https://github.com/apache/incubator-doris/issues/8815.

# Proposed changes

Issue Number: close #8815

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
