### PR TITLE
each tuple starting at aligned address to build with ubsan enabled

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -144,6 +144,7 @@ CONF_String(doris_cgroups, "");
 CONF_Int32(num_threads_per_core, "3");
 // if true, compresses tuple data in Serialize
 CONF_mBool(compress_rowbatches, "true");
+CONF_mBool(rowbatch_align_tuple_offset, "false");
 // interval between profile reports; in seconds
 CONF_mInt32(status_report_interval, "5");
 // if true, each disk will have a separate thread pool for scanner

--- a/be/src/runtime/row_batch.cpp
+++ b/be/src/runtime/row_batch.cpp
@@ -268,12 +268,7 @@ Status RowBatch::serialize(PRowBatch* output_batch, size_t* uncompressed_size,
             mutable_tuple_offsets->Add((int32_t)offset);
             mutable_new_tuple_offsets->Add(offset);
             row->get_tuple(j)->deep_copy(*desc, &tuple_data, &offset, /* convert_ptrs */ true);
-<<<<<<< HEAD
             CHECK_GE(offset, 0);
-=======
-            CHECK_LE(offset, size) << "offset: " << offset << " vs. size: " << size;
-            CHECK_GE(offset, 0) << "offset: " << offset << " vs. size: " << size;
->>>>>>> handle trailing null when aligning tuple offset
         }
     }
     CHECK_EQ(offset, tuple_byte_size)

--- a/be/src/runtime/row_batch.cpp
+++ b/be/src/runtime/row_batch.cpp
@@ -156,6 +156,10 @@ RowBatch::RowBatch(const RowDescriptor& row_desc, const PRowBatch& input_batch)
 
             for (auto slot : desc->string_slots()) {
                 DCHECK(slot->type().is_string_type());
+                if (tuple->is_null(slot->null_indicator_offset())) {
+                    continue;
+                }
+
                 StringValue* string_val = tuple->get_string_slot(slot->tuple_offset());
                 int64_t offset = convert_to<int64_t>(string_val->ptr);
                 string_val->ptr = tuple_data + offset;
@@ -209,6 +213,14 @@ RowBatch::~RowBatch() {
     clear();
 }
 
+static inline size_t align_tuple_offset(size_t offset) {
+    if (config::rowbatch_align_tuple_offset) {
+        return (offset + alignof(std::max_align_t) - 1) & (~(alignof(std::max_align_t) - 1));
+    }
+
+    return offset;
+}
+
 Status RowBatch::serialize(PRowBatch* output_batch, size_t* uncompressed_size,
                            size_t* compressed_size, bool allow_transfer_large_data) {
     // num_rows
@@ -240,6 +252,9 @@ Status RowBatch::serialize(PRowBatch* output_batch, size_t* uncompressed_size,
     for (int i = 0; i < _num_rows; ++i) {
         TupleRow* row = get_row(i);
         for (size_t j = 0; j < tuple_descs.size(); ++j) {
+            int64_t old_offset = offset;
+            offset = align_tuple_offset(offset);
+            tuple_data += offset - old_offset;
             auto desc = tuple_descs[j];
             if (row->get_tuple(j) == nullptr) {
                 // NULLs are encoded as -1
@@ -251,7 +266,7 @@ Status RowBatch::serialize(PRowBatch* output_batch, size_t* uncompressed_size,
             mutable_tuple_offsets->Add((int32_t)offset);
             mutable_new_tuple_offsets->Add(offset);
             row->get_tuple(j)->deep_copy(*desc, &tuple_data, &offset, /* convert_ptrs */ true);
-            CHECK_LE(offset, tuple_byte_size);
+            CHECK_GE(offset, 0);
         }
     }
     CHECK_EQ(offset, tuple_byte_size)
@@ -541,6 +556,7 @@ size_t RowBatch::total_byte_size() const {
             if (tuple == nullptr) {
                 continue;
             }
+            result = align_tuple_offset(result);
             result += desc->byte_size();
 
             for (auto slot : desc->string_slots()) {


### PR DESCRIPTION
When I builded doris be with ubsan enabled and enabled vectorization,
be core dump at doris::DecimalV2Value::operator long(). It cored
because accessing on a non-aligned address by sse.

With ubsan enabled, compile generates different assemble code including
sse instruction.

A sender serializes tuples to a continugous memory area, while a recver
just copy it. So we should align each tuple offset to 16 bytes.

For compatibility, we should use a config to control it.

BTW: with tools like ubsan, asan, tsan we can find bugs more easily,
e.g. https://github.com/apache/incubator-doris/issues/8815. It is
difficult to find the bug without ubsan.

Anyway, we should use mordern tools to be more productive.

# Proposed changes

Issue Number: close #8830

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
