### PR TITLE
[fix](storage) Fix core bug of convert to predicate column

### DIFF
--- a/be/src/olap/rowset/segment_v2/binary_dict_page.cpp
+++ b/be/src/olap/rowset/segment_v2/binary_dict_page.cpp
@@ -240,7 +240,7 @@ void BinaryDictPageDecoder::set_dict_decoder(PageDecoder* dict_decoder, StringRe
 
 Status BinaryDictPageDecoder::next_batch(size_t* n, vectorized::MutableColumnPtr &dst) {
     if (_encoding_type == PLAIN_ENCODING) {
-        dst = (*(std::move(dst->convert_to_predicate_column_if_dictionary()))).assume_mutable();
+        dst = dst->convert_to_predicate_column_if_dictionary();
         return _data_page_decoder->next_batch(n, dst);
     }
     // dictionary encoding

--- a/be/src/vec/columns/column.h
+++ b/be/src/vec/columns/column.h
@@ -66,7 +66,7 @@ public:
 
     /// If column isn't ColumnDictionary, return itself.
     /// If column is ColumnDictionary, transforms is to predicate column.
-    virtual Ptr convert_to_predicate_column_if_dictionary() { return get_ptr(); }
+    virtual MutablePtr convert_to_predicate_column_if_dictionary() { return get_ptr(); }
 
     /// If column is ColumnDictionary, and is a range comparison predicate, convert dict encoding
     virtual void convert_dict_codes_if_necessary() {}

--- a/be/src/vec/columns/column_dictionary.h
+++ b/be/src/vec/columns/column_dictionary.h
@@ -120,7 +120,10 @@ public:
         LOG(FATAL) << "get_permutation not supported in ColumnDictionary";
     }
 
-    void reserve(size_t n) override { _codes.reserve(n); }
+    void reserve(size_t n) override {
+        _reserve_size = n;
+        _codes.reserve(n);
+    }
 
     const char* get_family_name() const override { return "ColumnDictionary"; }
 
@@ -259,15 +262,15 @@ public:
 
     bool is_dict_code_converted() const { return _dict_code_converted; }
 
-    ColumnPtr convert_to_predicate_column_if_dictionary() override {
+    MutableColumnPtr convert_to_predicate_column_if_dictionary() override {
         auto res = vectorized::PredicateColumnType<StringValue>::create();
-        size_t size = _codes.size();
-        res->reserve(size);
-        for (size_t i = 0; i < size; ++i) {
+        res->reserve(_reserve_size);
+        for (size_t i = 0; i < _codes.size(); ++i) {
             auto& code = reinterpret_cast<T&>(_codes[i]);
             auto value = _dict.get_value(code);
             res->insert_data(value.ptr, value.len);
         }
+        clear();
         _dict.clear();
         return res;
     }
@@ -353,6 +356,7 @@ public:
     };
 
 private:
+    size_t _reserve_size;
     bool _dict_inited = false;
     bool _dict_sorted = false;
     bool _dict_code_converted = false;

--- a/be/src/vec/columns/column_nullable.h
+++ b/be/src/vec/columns/column_nullable.h
@@ -267,10 +267,8 @@ public:
         LOG(FATAL) << "should not call the method in column nullable";
     }
 
-    ColumnPtr convert_to_predicate_column_if_dictionary() override {
-        IColumn* nested_ptr = get_nested_column_ptr().get();
-        nested_ptr = (*(std::move(nested_ptr->convert_to_predicate_column_if_dictionary()
-                                  ))).assume_mutable();
+    MutableColumnPtr convert_to_predicate_column_if_dictionary() override {
+        nested_column = get_nested_column().convert_to_predicate_column_if_dictionary();
         return get_ptr();
     }
 


### PR DESCRIPTION
# Proposed changes

Issue Number: close #8315 #8835 
Fix core bug of convert to predicate column

## Problem Summary:

recurrent:
When `enable_low_cardinality_optimize = true`, for the TPCH dataset, using the following SQL query will Core
```sql
select count(*) from lineitem where l_comment = 'ously even exc';
```

This SQL will trigger the execution of `ColumnDictionary::convert_to_predicate_column_if_dictionary`, and `res->reserve(_codes.size())` is problematic because the current `_codes.size()` is smaller than its reserve value, so inserting a value into `PredicateColumn` will Core.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
