### PR TITLE
set table property 'dynamic_partition.enable' to false after restore

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/backup/RestoreJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/backup/RestoreJob.java
@@ -641,6 +641,9 @@ public class RestoreJob extends AbstractJob {
                         return;
                     }
 
+                    // Reset properties to correct values.
+                    remoteOlapTbl.resetPropertiesForRestore();
+
                     // DO NOT set remote table's new name here, cause we will still need the origin name later
                     // remoteOlapTbl.setName(jobInfo.getAliasByOriginNameIfSet(tblInfo.name));
                     remoteOlapTbl.setState(allowLoad ? OlapTableState.RESTORE_WITH_LOAD : OlapTableState.RESTORE);

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
@@ -420,6 +420,16 @@ public class OlapTable extends Table {
         }
     }
 
+    /**
+     * Reset properties to correct values.
+     */
+    public void resetPropertiesForRestore() {
+        // disable dynamic partition
+        if (tableProperty != null) {
+            tableProperty.resetPropertiesForRestore();
+        }
+    }
+
     public Status resetIdsForRestore(Catalog catalog, Database db, ReplicaAllocation restoreReplicaAlloc) {
         // table id
         id = catalog.getNextId();

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/TableProperty.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/TableProperty.java
@@ -102,6 +102,18 @@ public class TableProperty implements Writable {
         return this;
     }
 
+    /**
+     * Reset properties to correct values.
+     * @return this for chained
+     */
+    public TableProperty resetPropertiesForRestore() {
+        if (properties.containsKey(DynamicPartitionProperty.ENABLE)) {
+            properties.put(DynamicPartitionProperty.ENABLE, "false");
+            executeBuildDynamicProperty();
+        }
+        return this;
+    }
+
     public TableProperty buildDynamicProperty() throws DdlException {
         if (properties.containsKey(DynamicPartitionProperty.ENABLE)
                 && Boolean.valueOf(properties.get(DynamicPartitionProperty.ENABLE))


### PR DESCRIPTION
# Proposed changes

set property 'dynamic_partition.enable' to 'false' when restore table with dynamic partition properties from snapshot.

Q: why do not turn on dynamic partition on restore table automatically?
A: since we may restore partition from long time ago, dynamic partition should set to false by default. And turn it on manually when user really need it.

## Problem Summary:

when restore table with dynamic partition properties, 'dynamic_partition.enable' is set to the backup time value.
but Doris could not turn on dynamic partition automatically when restore.
So we cloud see table never do dynamic partition with dynamic_partition.enable is set to 'true'.

## Checklist(Required)

1. Does it affect the original behavior: (Yes)
2. Has unit tests been added: (Yes)
3. Has document been added or modified: (No)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (No)

