### PR TITLE
[Bug][DataX]Fixed the problem of keyword error when importing datax

### DIFF
--- a/extension/DataX/doriswriter/src/main/java/com/alibaba/datax/plugin/writer/doriswriter/DorisWriterEmitter.java
+++ b/extension/DataX/doriswriter/src/main/java/com/alibaba/datax/plugin/writer/doriswriter/DorisWriterEmitter.java
@@ -53,6 +53,7 @@ import java.net.URL;
 import java.util.Base64;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 // Used to load batch of rows to Doris using stream load
 public class DorisWriterEmitter {
@@ -181,7 +182,7 @@ public class DorisWriterEmitter {
             final HttpPut httpPut = new HttpPut(loadUrl);
             final List<String> cols = this.keys.getColumns();
             if (null != cols && !cols.isEmpty()) {
-                httpPut.setHeader("columns", String.join(",", cols));
+                httpPut.setHeader("columns", String.join(",", cols.stream().map(item -> String.format("`%s`", item.trim().replace("`", ""))).collect(Collectors.toList())));
             }
 
             // put loadProps to http header


### PR DESCRIPTION
## Problem Summary:

Fixed the problem that there were keyword errors in columns when importing by datax.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
