### PR TITLE
[improvement](log) make compaction no suitable version log more friendly

### DIFF
--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -1335,7 +1335,7 @@ Status Tablet::prepare_compaction_and_calculate_permits(CompactionType compactio
                 DorisMetrics::instance()->cumulative_compaction_request_failed->increment(1);
             }
             *permits = 0;
-            return Status::InternalError(fmt::format("prepare compaction with err: {}", res));
+            return Status::InternalError(fmt::format("prepare compaction with err: {}", res), res);
         }
         compaction_rowsets = _cumulative_compaction->get_input_rowsets();
     } else {
@@ -1360,7 +1360,7 @@ Status Tablet::prepare_compaction_and_calculate_permits(CompactionType compactio
                 DorisMetrics::instance()->base_compaction_request_failed->increment(1);
             }
             *permits = 0;
-            return Status::InternalError(fmt::format("prepare compaction with err: {}", res));
+            return Status::InternalError(fmt::format("prepare compaction with err: {}", res), res);
         }
         compaction_rowsets = _base_compaction->get_input_rowsets();
     }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

[#8781](https://github.com/apache/incubator-doris/pull/8781) fixed a bug of compaction log, so that any failure of compaction submission will trigger a warning log.
But in the most time, the compaction submission failure is caused by "no suite version", which is a common case.
User may feel anxious when they found lots of logs like the following
```
W0406 17:42:17.825480 42660 olap_server.cpp:402] failed to submit compaction task for tablet: 10128, err: failed to prepare compaction task and calculate permits, tablet_id=10128, compaction_type=2, permit=0, current_permit=0, status=prepare compaction with err: -2000
``` 

This PR change the log in this case more friendly.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
