### PR TITLE
[feat](sql) support star except modifier

### DIFF
--- a/docs/en/getting-started/basic-usage.md
+++ b/docs/en/getting-started/basic-usage.md
@@ -340,6 +340,16 @@ MySQL> SELECT * FROM table1 LIMIT 3;
 +--------+----------+----------+------+
 3 rows in set (0.01 sec)
 
+MySQL> SELECT * exclude (username, citycode) FROM table1 LIMIT 3;
++--------+------+
+| siteid | pv   |
++--------+------+
+|      2 |    2 |
+|      5 |    3 |
+|      3 |    2 |
++--------+----------+------+
+3 rows in set (0.01 sec)
+
 MySQL> SELECT * FROM table1 ORDER BY citycode;
 +--------+----------+----------+------+
 | siteid | citycode | username | pv   |
@@ -353,7 +363,7 @@ MySQL> SELECT * FROM table1 ORDER BY citycode;
 5 rows in set (0.01 sec)
 ```
 
-### 3.3 Join Query
+### 3.2 Join Query
 
 Examples:
 
@@ -367,7 +377,7 @@ MySQL> SELECT SUM(table1.pv) FROM table1 JOIN table2 WHERE table1.siteid = table
 1 row in set (0.20 sec)
 ```
 
-### 3.4 Subquery
+### 3.3 Subquery
 
 Examples:
 

--- a/docs/en/getting-started/basic-usage.md
+++ b/docs/en/getting-started/basic-usage.md
@@ -340,14 +340,14 @@ MySQL> SELECT * FROM table1 LIMIT 3;
 +--------+----------+----------+------+
 3 rows in set (0.01 sec)
 
-MySQL> SELECT * exclude (username, citycode) FROM table1 LIMIT 3;
+MySQL> SELECT * except (username, citycode) FROM table1 LIMIT 3;
 +--------+------+
 | siteid | pv   |
 +--------+------+
 |      2 |    2 |
 |      5 |    3 |
 |      3 |    2 |
-+--------+----------+------+
++--------+------+
 3 rows in set (0.01 sec)
 
 MySQL> SELECT * FROM table1 ORDER BY citycode;

--- a/docs/zh-CN/getting-started/basic-usage.md
+++ b/docs/zh-CN/getting-started/basic-usage.md
@@ -339,14 +339,14 @@ MySQL> SELECT * FROM table1 LIMIT 3;
 +--------+----------+----------+------+
 3 rows in set (0.01 sec)
 
-MySQL> SELECT * exclude (username, citycode) FROM table1 LIMIT 3;
+MySQL> SELECT * except (username, citycode) FROM table1 LIMIT 3;
 +--------+------+
 | siteid | pv   |
 +--------+------+
 |      2 |    2 |
 |      5 |    3 |
 |      3 |    2 |
-+--------+----------+------+
++--------+------+
 3 rows in set (0.01 sec)
 
 MySQL> SELECT * FROM table1 ORDER BY citycode;

--- a/docs/zh-CN/getting-started/basic-usage.md
+++ b/docs/zh-CN/getting-started/basic-usage.md
@@ -339,6 +339,16 @@ MySQL> SELECT * FROM table1 LIMIT 3;
 +--------+----------+----------+------+
 3 rows in set (0.01 sec)
 
+MySQL> SELECT * exclude (username, citycode) FROM table1 LIMIT 3;
++--------+------+
+| siteid | pv   |
++--------+------+
+|      2 |    2 |
+|      5 |    3 |
+|      3 |    2 |
++--------+----------+------+
+3 rows in set (0.01 sec)
+
 MySQL> SELECT * FROM table1 ORDER BY citycode;
 +--------+----------+----------+------+
 | siteid | citycode | username | pv   |
@@ -352,7 +362,7 @@ MySQL> SELECT * FROM table1 ORDER BY citycode;
 5 rows in set (0.01 sec)
 ```
 
-### 3.3 Join 查询
+### 3.2 Join 查询
 
 示例:
 
@@ -366,7 +376,7 @@ MySQL> SELECT SUM(table1.pv) FROM table1 JOIN table2 WHERE table1.siteid = table
 1 row in set (0.20 sec)
 ```
 
-### 3.4 子查询
+### 3.3 子查询
 
 示例:
 

--- a/fe/fe-core/src/main/cup/sql_parser.cup
+++ b/fe/fe-core/src/main/cup/sql_parser.cup
@@ -341,8 +341,8 @@ nonterminal AbstractBackupTableRefClause opt_backup_table_ref_list;
 nonterminal Boolean backup_exclude_or_not;
 nonterminal RestoreStmt restore_stmt;
 
-nonterminal SelectList select_clause, select_list, select_sublist, exclude_list, exclude_sublist;
-nonterminal SelectListItem select_list_item, star_expr, exclude_list_item;
+nonterminal SelectList select_clause, select_list, select_sublist, except_list, except_sublist;
+nonterminal SelectListItem select_list_item, star_expr, except_list_item;
 nonterminal Expr expr, non_pred_expr, arithmetic_expr, timestamp_arithmetic_expr, expr_or_default;
 nonterminal Expr set_expr_or_default;
 nonterminal ArrayList<Expr> expr_list, values, row_value, opt_values;
@@ -544,6 +544,7 @@ precedence left KW_LIKE, KW_REGEXP;
 precedence left EQUAL, LESSTHAN, GREATERTHAN;
 precedence left ADD, SUBTRACT;
 precedence left AT, STAR, DIVIDE, MOD, KW_DIV;
+precedence left KW_EXCEPT;
 precedence left BITAND, BITOR, BITXOR;
 precedence left KW_PIPE;
 precedence left BITNOT;
@@ -3994,11 +3995,11 @@ select_list ::=
         list.addItem(SelectListItem.createStarItem(null));
         RESULT = list;
     :}
-    | STAR exclude_list:excludeList
+    | STAR except_list:exceptList
     {:
         SelectList list = new SelectList();
         list.addItem(SelectListItem.createStarItem(null));
-        list.addItems(excludeList);
+        list.addItems(exceptList);
         RESULT = list;
     :}
     ;
@@ -4014,10 +4015,10 @@ select_sublist ::=
         list.addItem(SelectListItem.createStarItem(null));
         RESULT = list;
     :}
-    | select_sublist:list COMMA STAR exclude_list:excludeList
+    | select_sublist:list COMMA STAR except_list:exceptList
     {:
         list.addItem(SelectListItem.createStarItem(null));
-        list.addItems(excludeList);
+        list.addItems(exceptList);
         RESULT = list;
     :}
     // why not use "STAR COMMA select_sublist",for we analyze from left to right
@@ -4028,11 +4029,11 @@ select_sublist ::=
         list.addItem(item);
         RESULT = list;
     :}
-    | STAR exclude_list:excludeList COMMA select_list_item:item
+    | STAR except_list:exceptList COMMA select_list_item:item
     {:
         SelectList list = new SelectList();
         list.addItem(SelectListItem.createStarItem(null));
-        list.addItems(excludeList);
+        list.addItems(exceptList);
         list.addItem(item);
         RESULT = list;
     :}
@@ -4078,20 +4079,20 @@ select_alias ::=
     :}
     ;
 
-exclude_list ::=
-    KW_EXCLUDE LPAREN exclude_sublist:list RPAREN
+except_list ::=
+    KW_EXCEPT LPAREN except_sublist:list RPAREN
     {:
         RESULT = list;
     :}
     ;
     
-exclude_sublist ::=
-    exclude_sublist:list COMMA exclude_list_item:item
+except_sublist ::=
+    except_sublist:list COMMA except_list_item:item
     {:
         list.addItem(item);
         RESULT = list;
     :}
-    | exclude_list_item:item
+    | except_list_item:item
     {:
         SelectList list = new SelectList();
         list.addItem(item);
@@ -4099,10 +4100,10 @@ exclude_sublist ::=
     :}
     ;
 
-exclude_list_item ::=
+except_list_item ::=
     expr:expr
     {:
-        RESULT = SelectListItem.createExcludedItem(expr, true);
+        RESULT = SelectListItem.createExceptedItem(expr, true);
     :}
     ;
 

--- a/fe/fe-core/src/main/cup/sql_parser.cup
+++ b/fe/fe-core/src/main/cup/sql_parser.cup
@@ -4009,6 +4009,11 @@ select_sublist ::=
         list.addItem(item);
         RESULT = list;
     :}
+    | select_sublist:list COMMA STAR
+    {:
+        list.addItem(SelectListItem.createStarItem(null));
+        RESULT = list;
+    :}
     | select_sublist:list COMMA STAR exclude_list:excludeList
     {:
         list.addItem(SelectListItem.createStarItem(null));
@@ -4016,6 +4021,13 @@ select_sublist ::=
         RESULT = list;
     :}
     // why not use "STAR COMMA select_sublist",for we analyze from left to right
+    | STAR COMMA select_list_item:item
+    {:
+        SelectList list = new SelectList();
+        list.addItem(SelectListItem.createStarItem(null));
+        list.addItem(item);
+        RESULT = list;
+    :}
     | STAR exclude_list:excludeList COMMA select_list_item:item
     {:
         SelectList list = new SelectList();

--- a/fe/fe-core/src/main/cup/sql_parser.cup
+++ b/fe/fe-core/src/main/cup/sql_parser.cup
@@ -341,8 +341,8 @@ nonterminal AbstractBackupTableRefClause opt_backup_table_ref_list;
 nonterminal Boolean backup_exclude_or_not;
 nonterminal RestoreStmt restore_stmt;
 
-nonterminal SelectList select_clause, select_list, select_sublist;
-nonterminal SelectListItem select_list_item, star_expr;
+nonterminal SelectList select_clause, select_list, select_sublist, exclude_list, exclude_sublist;
+nonterminal SelectListItem select_list_item, star_expr, exclude_list_item;
 nonterminal Expr expr, non_pred_expr, arithmetic_expr, timestamp_arithmetic_expr, expr_or_default;
 nonterminal Expr set_expr_or_default;
 nonterminal ArrayList<Expr> expr_list, values, row_value, opt_values;
@@ -3994,6 +3994,13 @@ select_list ::=
         list.addItem(SelectListItem.createStarItem(null));
         RESULT = list;
     :}
+    | STAR exclude_list:excludeList
+    {:
+        SelectList list = new SelectList();
+        list.addItem(SelectListItem.createStarItem(null));
+        list.addItems(excludeList);
+        RESULT = list;
+    :}
     ;
 
 select_sublist ::=
@@ -4002,16 +4009,18 @@ select_sublist ::=
         list.addItem(item);
         RESULT = list;
     :}
-    | select_sublist:list COMMA STAR
+    | select_sublist:list COMMA STAR exclude_list:excludeList
     {:
         list.addItem(SelectListItem.createStarItem(null));
+        list.addItems(excludeList);
         RESULT = list;
     :}
     // why not use "STAR COMMA select_sublist",for we analyze from left to right
-    | STAR COMMA select_list_item:item
+    | STAR exclude_list:excludeList COMMA select_list_item:item
     {:
         SelectList list = new SelectList();
         list.addItem(SelectListItem.createStarItem(null));
+        list.addItems(excludeList);
         list.addItem(item);
         RESULT = list;
     :}
@@ -4054,6 +4063,34 @@ select_alias ::=
     | STRING_LITERAL:l
     {:
         RESULT = l;
+    :}
+    ;
+
+exclude_list ::=
+    KW_EXCLUDE LPAREN exclude_sublist:list RPAREN
+    {:
+        RESULT = list;
+    :}
+    ;
+    
+exclude_sublist ::=
+    exclude_sublist:list COMMA exclude_list_item:item
+    {:
+        list.addItem(item);
+        RESULT = list;
+    :}
+    | exclude_list_item:item
+    {:
+        SelectList list = new SelectList();
+        list.addItem(item);
+        RESULT = list;
+    :}
+    ;
+
+exclude_list_item ::=
+    expr:expr
+    {:
+        RESULT = SelectListItem.createExcludedItem(expr, true);
     :}
     ;
 

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/SelectList.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/SelectList.java
@@ -69,6 +69,10 @@ public class SelectList {
         items.add(item);
     }
 
+    public void addItems(SelectList addedItems) {
+        items.addAll(addedItems.getItems());
+    }
+
     public boolean isDistinct() {
         return isDistinct;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/SelectListItem.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/SelectListItem.java
@@ -24,7 +24,7 @@ public class SelectListItem {
     // for "[name.]*"
     private final TableName tblName;
     private final boolean isStar;
-    private final boolean isExcludedFromStar;
+    private final boolean isExceptedFromStar;
     private String alias;
 
     public SelectListItem(Expr expr, String alias) {
@@ -34,16 +34,16 @@ public class SelectListItem {
         this.alias = alias;
         this.tblName = null;
         this.isStar = false;
-        this.isExcludedFromStar = false;
+        this.isExceptedFromStar = false;
     }
 
-    private SelectListItem(Expr expr, Boolean isExcludedFromStar) {
+    private SelectListItem(Expr expr, Boolean isExceptedFromStar) {
         super();
         Preconditions.checkNotNull(expr);
         this.expr = expr;
         this.tblName = null;
         this.isStar = false;
-        this.isExcludedFromStar = isExcludedFromStar;
+        this.isExceptedFromStar = isExceptedFromStar;
     }
 
     private SelectListItem(TableName tblName) {
@@ -51,7 +51,7 @@ public class SelectListItem {
         this.expr = null;
         this.tblName = tblName;
         this.isStar = true;
-        this.isExcludedFromStar = false;
+        this.isExceptedFromStar = false;
     }
 
     protected SelectListItem(SelectListItem other) {
@@ -62,7 +62,7 @@ public class SelectListItem {
         }
         tblName = other.tblName;
         isStar = other.isStar;
-        isExcludedFromStar = other.isExcludedFromStar;
+        isExceptedFromStar = other.isExceptedFromStar;
         alias = other.alias;
     }
 
@@ -77,16 +77,16 @@ public class SelectListItem {
     }
 
     // select list item corresponding to "[exclude (item1[, item2, ...])]"
-    static public SelectListItem createExcludedItem(Expr expr, Boolean isExcludedFromStar) {
-        return new SelectListItem(expr, isExcludedFromStar);
+    static public SelectListItem createExceptedItem(Expr expr, Boolean isExceptedFromStar) {
+        return new SelectListItem(expr, isExceptedFromStar);
     }
 
     public boolean isStar() {
         return isStar;
     }
 
-    public boolean isExcludedFromStar() {
-        return isExcludedFromStar;
+    public boolean isExceptedFromStar() {
+        return isExceptedFromStar;
     }
 
     public TableName getTblName() {

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/SelectListItem.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/SelectListItem.java
@@ -24,6 +24,7 @@ public class SelectListItem {
     // for "[name.]*"
     private final TableName tblName;
     private final boolean isStar;
+    private final boolean isExcludedFromStar;
     private String alias;
 
     public SelectListItem(Expr expr, String alias) {
@@ -33,6 +34,16 @@ public class SelectListItem {
         this.alias = alias;
         this.tblName = null;
         this.isStar = false;
+        this.isExcludedFromStar = false;
+    }
+
+    private SelectListItem(Expr expr, Boolean isExcludedFromStar) {
+        super();
+        Preconditions.checkNotNull(expr);
+        this.expr = expr;
+        this.tblName = null;
+        this.isStar = false;
+        this.isExcludedFromStar = isExcludedFromStar;
     }
 
     private SelectListItem(TableName tblName) {
@@ -40,6 +51,7 @@ public class SelectListItem {
         this.expr = null;
         this.tblName = tblName;
         this.isStar = true;
+        this.isExcludedFromStar = false;
     }
 
     protected SelectListItem(SelectListItem other) {
@@ -50,6 +62,7 @@ public class SelectListItem {
         }
         tblName = other.tblName;
         isStar = other.isStar;
+        isExcludedFromStar = other.isExcludedFromStar;
         alias = other.alias;
     }
 
@@ -63,8 +76,17 @@ public class SelectListItem {
         return new SelectListItem(tblName);
     }
 
+    // select list item corresponding to "[exclude (item1[, item2, ...])]"
+    static public SelectListItem createExcludedItem(Expr expr, Boolean isExcludedFromStar) {
+        return new SelectListItem(expr, isExcludedFromStar);
+    }
+
     public boolean isStar() {
         return isStar;
+    }
+
+    public boolean isExcludedFromStar() {
+        return isExcludedFromStar;
     }
 
     public TableName getTblName() {

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/SelectStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/SelectStmt.java
@@ -877,7 +877,7 @@ public class SelectStmt extends QueryStmt {
         } else {
             expandStar(analyzer, tblName, excludedColLabels);
         }
-        return excludedIndex;
+        return excludedIndex - 1;
     }
 
     /**


### PR DESCRIPTION
When we query many fields in a wide-table,
but ignore one field or two fields,
we need to write out fields we need one by one.
Therefore, try to use `select * except (excepted_item1, excepted_item2, ...)`,
the sql will be simplified.


## Checklist(Required)

1. Does it affect the original behavior: (No)
2. Has unit tests been added: (No)
3. Has document been added or modified: (Yes)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
