### PR TITLE
[feature](optimizer) : convert out join to inner join

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/Analyzer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/Analyzer.java
@@ -1611,15 +1611,15 @@ public class Analyzer {
         return globalState.sjClauseByConjunct.containsKey(e.getId());
     }
 
-    public Map<ExprId, TableRef> getFullOuterJoinedConjuncts(){
+    public Map<ExprId, TableRef> getFullOuterJoinedConjuncts() {
         return globalState.fullOuterJoinedConjuncts;
     }
 
-    public Map<TupleId, TableRef> getFullOuterJoinedTupleIds(){
+    public Map<TupleId, TableRef> getFullOuterJoinedTupleIds() {
         return globalState.fullOuterJoinedTupleIds;
     }
 
-    public Map<TupleId, TableRef> getOuterJoinedTupleIds(){
+    public Map<TupleId, TableRef> getOuterJoinedTupleIds() {
         return globalState.outerJoinedTupleIds;
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/Analyzer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/Analyzer.java
@@ -1611,6 +1611,18 @@ public class Analyzer {
         return globalState.sjClauseByConjunct.containsKey(e.getId());
     }
 
+    public Map<ExprId, TableRef> getFullOuterJoinedConjuncts(){
+        return globalState.fullOuterJoinedConjuncts;
+    }
+
+    public Map<TupleId, TableRef> getFullOuterJoinedTupleIds(){
+        return globalState.fullOuterJoinedTupleIds;
+    }
+
+    public Map<TupleId, TableRef> getOuterJoinedTupleIds(){
+        return globalState.outerJoinedTupleIds;
+    }
+
     public TableRef getFullOuterJoinRef(Expr e) {
         return globalState.fullOuterJoinedConjuncts.get(e.getId());
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/BetweenPredicate.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/BetweenPredicate.java
@@ -32,7 +32,8 @@ public class BetweenPredicate extends Predicate {
 
     private final boolean isNotBetween;
 
-    // First child is the comparison expr which should be in [lowerBound, upperBound].
+    // First child is the comparison expr which should be in [lowerBound,
+    // upperBound].
     public BetweenPredicate(Expr compareExpr, Expr lowerBound, Expr upperBound, boolean isNotBetween) {
         children.add(compareExpr);
         children.add(lowerBound);
@@ -45,12 +46,17 @@ public class BetweenPredicate extends Predicate {
         isNotBetween = other.isNotBetween;
     }
 
-//    @Override
-//    public Expr reset() {
-//      super.reset();
-//      originalChildren = Expr.resetList(originalChildren);
-//      return this;
-//    }
+    // @Override
+    // public Expr reset() {
+    // super.reset();
+    // originalChildren = Expr.resetList(originalChildren);
+    // return this;
+    // }
+
+    @Override
+    public boolean isNotNullPred() {
+        return true;
+    }
 
     @Override
     public Expr clone() {
@@ -78,10 +84,10 @@ public class BetweenPredicate extends Predicate {
         analyzer.castAllToCompatibleType(children);
     }
 
-   @Override
-   public boolean isVectorized() {
-       return false;
-   }
+    @Override
+    public boolean isVectorized() {
+        return false;
+    }
 
     @Override
     protected void toThrift(TExprNode msg) {
@@ -93,11 +99,13 @@ public class BetweenPredicate extends Predicate {
     public String toSqlImpl() {
         String notStr = (isNotBetween) ? "NOT " : "";
         return children.get(0).toSql() + " " + notStr + "BETWEEN " +
-          children.get(1).toSql() + " AND " + children.get(2).toSql();
+                children.get(1).toSql() + " AND " + children.get(2).toSql();
     }
 
     @Override
-    public Expr clone(ExprSubstitutionMap sMap) { return new BetweenPredicate(this); }
+    public Expr clone(ExprSubstitutionMap sMap) {
+        return new BetweenPredicate(this);
+    }
 
     @Override
     public int hashCode() {

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/BetweenPredicate.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/BetweenPredicate.java
@@ -32,8 +32,7 @@ public class BetweenPredicate extends Predicate {
 
     private final boolean isNotBetween;
 
-    // First child is the comparison expr which should be in [lowerBound,
-    // upperBound].
+    // First child is the comparison expr which should be in [lowerBound, upperBound].
     public BetweenPredicate(Expr compareExpr, Expr lowerBound, Expr upperBound, boolean isNotBetween) {
         children.add(compareExpr);
         children.add(lowerBound);
@@ -46,17 +45,12 @@ public class BetweenPredicate extends Predicate {
         isNotBetween = other.isNotBetween;
     }
 
-    // @Override
-    // public Expr reset() {
-    // super.reset();
-    // originalChildren = Expr.resetList(originalChildren);
-    // return this;
-    // }
-
-    @Override
-    public boolean isNotNullPred() {
-        return true;
-    }
+//    @Override
+//    public Expr reset() {
+//      super.reset();
+//      originalChildren = Expr.resetList(originalChildren);
+//      return this;
+//    }
 
     @Override
     public Expr clone() {
@@ -84,10 +78,10 @@ public class BetweenPredicate extends Predicate {
         analyzer.castAllToCompatibleType(children);
     }
 
-    @Override
-    public boolean isVectorized() {
-        return false;
-    }
+   @Override
+   public boolean isVectorized() {
+       return false;
+   }
 
     @Override
     protected void toThrift(TExprNode msg) {
@@ -99,16 +93,19 @@ public class BetweenPredicate extends Predicate {
     public String toSqlImpl() {
         String notStr = (isNotBetween) ? "NOT " : "";
         return children.get(0).toSql() + " " + notStr + "BETWEEN " +
-                children.get(1).toSql() + " AND " + children.get(2).toSql();
+          children.get(1).toSql() + " AND " + children.get(2).toSql();
     }
 
     @Override
-    public Expr clone(ExprSubstitutionMap sMap) {
-        return new BetweenPredicate(this);
-    }
+    public Expr clone(ExprSubstitutionMap sMap) { return new BetweenPredicate(this); }
 
     @Override
     public int hashCode() {
         return 31 * super.hashCode() + Boolean.hashCode(isNotBetween);
+    }
+
+    @Override
+    public boolean isNotNullPred() {
+        return true;
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/BinaryPredicate.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/BinaryPredicate.java
@@ -49,8 +49,7 @@ import java.util.Objects;
 public class BinaryPredicate extends Predicate implements Writable {
     private final static Logger LOG = LogManager.getLogger(BinaryPredicate.class);
 
-    // true if this BinaryPredicate is inferred from slot equivalences, false
-    // otherwise.
+    // true if this BinaryPredicate is inferred from slot equivalences, false otherwise.
     private boolean isInferred_ = false;
 
     public enum Operator {
@@ -67,8 +66,8 @@ public class BinaryPredicate extends Predicate implements Writable {
         private final TExprOpcode opcode;
 
         Operator(String description,
-                String name,
-                TExprOpcode opcode) {
+                 String name,
+                 TExprOpcode opcode) {
             this.description = description;
             this.name = name;
             this.opcode = opcode;
@@ -132,17 +131,11 @@ public class BinaryPredicate extends Predicate implements Writable {
             }
         }
 
-        public boolean isEquivalence() {
-            return this == EQ || this == EQ_FOR_NULL;
-        };
+        public boolean isEquivalence() { return this == EQ || this == EQ_FOR_NULL; };
 
-        public boolean isUnNullSafeEquivalence() {
-            return this == EQ;
-        };
+        public boolean isUnNullSafeEquivalence() { return this == EQ; };
 
-        public boolean isUnequivalence() {
-            return this == NE;
-        }
+        public boolean isUnequivalence() { return this == NE; }
     }
 
     private Operator op;
@@ -167,31 +160,16 @@ public class BinaryPredicate extends Predicate implements Writable {
     protected BinaryPredicate(BinaryPredicate other) {
         super(other);
         op = other.op;
-        slotIsleft = other.slotIsleft;
+        slotIsleft= other.slotIsleft;
         isInferred_ = other.isInferred_;
     }
 
-    public boolean isInferred() {
-        return isInferred_;
-    }
-
-    public void setIsInferred() {
-        isInferred_ = true;
-    }
-
-    @Override
-    public boolean isNotNullPred() {
-        if (op != Operator.EQ_FOR_NULL) {
-            return true;
-        } else {
-            return false;
-        }
-    }
+    public boolean isInferred() { return isInferred_; }
+    public void setIsInferred() { isInferred_ = true; }
 
     public static void initBuiltins(FunctionSet functionSet) {
-        for (Type t : Type.getSupportedTypes()) {
-            if (t.isNull())
-                continue; // NULL is handled through type promotion.
+        for (Type t: Type.getSupportedTypes()) {
+            if (t.isNull()) continue; // NULL is handled through type promotion.
             functionSet.addBuiltinBothScalaAndVectorized(ScalarFunction.createBuiltinOperator(
                     Operator.EQ.getName(), Lists.newArrayList(t, t), Type.BOOLEAN));
             functionSet.addBuiltinBothScalaAndVectorized(ScalarFunction.createBuiltinOperator(
@@ -218,9 +196,7 @@ public class BinaryPredicate extends Predicate implements Writable {
         return op;
     }
 
-    public void setOp(Operator op) {
-        this.op = op;
-    }
+    public void setOp(Operator op) { this.op = op; }
 
     @Override
     public Expr negate() {
@@ -276,19 +252,18 @@ public class BinaryPredicate extends Predicate implements Writable {
         super.vectorizedAnalyze(analyzer);
         Function match = null;
 
-        // OpcodeRegistry.BuiltinFunction match =
-        // OpcodeRegistry.instance().getFunctionInfo(
-        // op.toFilterFunctionOp(), true, true, cmpType, cmpType);
+        //OpcodeRegistry.BuiltinFunction match = OpcodeRegistry.instance().getFunctionInfo(
+        //        op.toFilterFunctionOp(), true, true, cmpType, cmpType);
         try {
             match = getBuiltinFunction(analyzer, op.name, collectChildReturnTypes(),
-                    Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
+                Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
         } catch (AnalysisException e) {
             Preconditions.checkState(false);
         }
         Preconditions.checkState(match != null);
         Preconditions.checkState(match.getReturnType().getPrimitiveType() == PrimitiveType.BOOLEAN);
-        // todo(dhc): should add oppCode
-        // this.vectorOpcode = match.opcode;
+        //todo(dhc): should add oppCode
+        //this.vectorOpcode = match.opcode;
         LOG.debug(debugString() + " opcode: " + vectorOpcode);
     }
 
@@ -326,7 +301,7 @@ public class BinaryPredicate extends Predicate implements Writable {
         }
 
         // Following logical is compatible with MySQL:
-        // Cast to DOUBLE by default, because DOUBLE has the largest range of values.
+        //    Cast to DOUBLE by default, because DOUBLE has the largest range of values.
         if (t1 == PrimitiveType.VARCHAR && t2 == PrimitiveType.VARCHAR) {
             return Type.VARCHAR;
         }
@@ -354,17 +329,17 @@ public class BinaryPredicate extends Predicate implements Writable {
         // When int column compares with string, Mysql will convert string to int.
         // So it is also compatible with Mysql.
 
-        if (t1 == PrimitiveType.BIGINT && (t2 == PrimitiveType.VARCHAR || t2 == PrimitiveType.STRING)) {
+        if (t1 == PrimitiveType.BIGINT && (t2 == PrimitiveType.VARCHAR || t2 ==PrimitiveType.STRING)) {
             Expr rightChild = getChild(1);
             Long parsedLong = Type.tryParseToLong(rightChild);
-            if (parsedLong != null) {
+            if(parsedLong != null) {
                 return Type.BIGINT;
             }
         }
-        if ((t1 == PrimitiveType.VARCHAR || t1 == PrimitiveType.STRING) && t2 == PrimitiveType.BIGINT) {
+        if ((t1 == PrimitiveType.VARCHAR || t1 ==PrimitiveType.STRING) && t2 == PrimitiveType.BIGINT) {
             Expr leftChild = getChild(0);
             Long parsedLong = Type.tryParseToLong(leftChild);
-            if (parsedLong != null) {
+            if(parsedLong != null) {
                 return Type.BIGINT;
             }
         }
@@ -383,7 +358,7 @@ public class BinaryPredicate extends Predicate implements Writable {
                     String msg = "Subquery of binary predicate must return a single column: " + expr.toSql();
                     throw new AnalysisException(msg);
                 }
-                /*-
+                /**
                  * Situation: The expr is a binary predicate and the type of subquery is not scalar type.
                  * Add assert: The stmt of subquery is added an assert condition (return error if row count > 1).
                  * Input params:
@@ -420,7 +395,7 @@ public class BinaryPredicate extends Predicate implements Writable {
         // determine selectivity
         Reference<SlotRef> slotRefRef = new Reference<SlotRef>();
         if (op == Operator.EQ && isSingleColumnPredicate(slotRefRef,
-                null) && slotRefRef.getRef().getNumDistinctValues() > 0) {
+          null) && slotRefRef.getRef().getNumDistinctValues() > 0) {
             Preconditions.checkState(slotRefRef.getRef() != null);
             selectivity = 1.0 / slotRefRef.getRef().getNumDistinctValues();
             selectivity = Math.max(0, Math.min(1, selectivity));
@@ -473,8 +448,7 @@ public class BinaryPredicate extends Predicate implements Writable {
      * casts, returns those two slots; otherwise returns null.
      */
     public static Pair<SlotId, SlotId> getEqSlots(Expr e) {
-        if (!(e instanceof BinaryPredicate))
-            return null;
+        if (!(e instanceof BinaryPredicate)) return null;
         return ((BinaryPredicate) e).getEqSlots();
     }
 
@@ -484,16 +458,14 @@ public class BinaryPredicate extends Predicate implements Writable {
      */
     @Override
     public Pair<SlotId, SlotId> getEqSlots() {
-        if (op != Operator.EQ)
-            return null;
+        if (op != Operator.EQ) return null;
         SlotRef lhs = getChild(0).unwrapSlotRef(true);
-        if (lhs == null)
-            return null;
+        if (lhs == null) return null;
         SlotRef rhs = getChild(1).unwrapSlotRef(true);
-        if (rhs == null)
-            return null;
+        if (rhs == null) return null;
         return new Pair<SlotId, SlotId>(lhs.getSlotId(), rhs.getSlotId());
     }
+
 
     public boolean slotIsLeft() {
         Preconditions.checkState(slotIsleft != null);
@@ -521,41 +493,40 @@ public class BinaryPredicate extends Predicate implements Writable {
         }
     }
 
-    /**
-     * public static enum Operator2 {
-     * EQ("=", FunctionOperator.EQ, FunctionOperator.FILTER_EQ),
-     * NE("!=", FunctionOperator.NE, FunctionOperator.FILTER_NE),
-     * LE("<=", FunctionOperator.LE, FunctionOperator.FILTER_LE),
-     * GE(">=", FunctionOperator.GE, FunctionOperator.FILTER_GE),
-     * LT("<", FunctionOperator.LT, FunctionOperator.FILTER_LT),
-     * GT(">", FunctionOperator.GT, FunctionOperator.FILTER_LE);
-     * 
-     * private final String description;
-     * private final FunctionOperator functionOp;
-     * private final FunctionOperator filterFunctionOp;
-     * 
-     * private Operator(String description,
-     * FunctionOperator functionOp,
-     * FunctionOperator filterFunctionOp) {
-     * this.description = description;
-     * this.functionOp = functionOp;
-     * this.filterFunctionOp = filterFunctionOp;
-     * }
-     * 
-     * @Override
-     *           public String toString() {
-     *           return description;
-     *           }
-     * 
-     *           public FunctionOperator toFunctionOp() {
-     *           return functionOp;
-     *           }
-     * 
-     *           public FunctionOperator toFilterFunctionOp() {
-     *           return filterFunctionOp;
-     *           }
-     *           }
-     */
+    //    public static enum Operator2 {
+    //        EQ("=", FunctionOperator.EQ, FunctionOperator.FILTER_EQ),
+    //        NE("!=", FunctionOperator.NE, FunctionOperator.FILTER_NE),
+    //        LE("<=", FunctionOperator.LE, FunctionOperator.FILTER_LE),
+    //        GE(">=", FunctionOperator.GE, FunctionOperator.FILTER_GE),
+    //        LT("<", FunctionOperator.LT, FunctionOperator.FILTER_LT),
+    //        GT(">", FunctionOperator.GT, FunctionOperator.FILTER_LE);
+    //
+    //        private final String           description;
+    //        private final FunctionOperator functionOp;
+    //        private final FunctionOperator filterFunctionOp;
+    //
+    //        private Operator(String description, 
+    //                         FunctionOperator functionOp, 
+    //                         FunctionOperator filterFunctionOp) {
+    //            this.description = description;
+    //            this.functionOp = functionOp;
+    //            this.filterFunctionOp = filterFunctionOp;
+    //        }
+    //
+    //        @Override
+    //        public String toString() {
+    //            return description;
+    //        }
+    //
+    //        public FunctionOperator toFunctionOp() {
+    //            return functionOp;
+    //        }
+    //
+    //        public FunctionOperator toFilterFunctionOp() {
+    //            return filterFunctionOp;
+    //        }
+    //    }
+
     /*
      * the follow persistence code is only for TableFamilyDeleteInfo.
      * Maybe useless
@@ -615,11 +586,11 @@ public class BinaryPredicate extends Predicate implements Writable {
         recursiveResetChildrenResult();
         final Expr leftChildValue = getChild(0);
         final Expr rightChildValue = getChild(1);
-        if (!(leftChildValue instanceof LiteralExpr)
+        if(!(leftChildValue instanceof LiteralExpr)
                 || !(rightChildValue instanceof LiteralExpr)) {
             return this;
         }
-        return compareLiteral((LiteralExpr) leftChildValue, (LiteralExpr) rightChildValue);
+        return compareLiteral((LiteralExpr)leftChildValue, (LiteralExpr)rightChildValue);
     }
 
     private Expr compareLiteral(LiteralExpr first, LiteralExpr second) throws AnalysisException {
@@ -631,14 +602,14 @@ public class BinaryPredicate extends Predicate implements Writable {
             } else if (isFirstNull || isSecondNull) {
                 return new BoolLiteral(false);
             }
-        } else {
-            if (isFirstNull || isSecondNull) {
+        } else  {
+            if (isFirstNull || isSecondNull){
                 return new NullLiteral();
             }
         }
 
         final int compareResult = first.compareLiteral(second);
-        switch (op) {
+        switch(op) {
             case EQ:
             case EQ_FOR_NULL:
                 return new BoolLiteral(compareResult == 0);
@@ -660,7 +631,7 @@ public class BinaryPredicate extends Predicate implements Writable {
 
     @Override
     public void setSelectivity() {
-        switch (op) {
+        switch(op) {
             case EQ:
             case EQ_FOR_NULL: {
                 Reference<SlotRef> slotRefRef = new Reference<SlotRef>();
@@ -672,8 +643,7 @@ public class BinaryPredicate extends Predicate implements Writable {
                     }
                 }
                 break;
-            }
-            default: {
+            } default: {
                 // Reference hive
                 selectivity = 1.0 / 3.0;
                 break;
@@ -694,5 +664,14 @@ public class BinaryPredicate extends Predicate implements Writable {
             return false;
         }
         return hasNullableChild();
+    }
+
+    @Override
+    public boolean isNotNullPred() {
+        if (op != Operator.EQ_FOR_NULL) {
+            return true;
+        } else {
+            return false;
+        }
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/CompoundPredicate.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/CompoundPredicate.java
@@ -56,7 +56,7 @@ public class CompoundPredicate extends Predicate {
         Preconditions.checkNotNull(e1);
         children.add(e1);
         Preconditions.checkArgument(
-          op == Operator.NOT && e2 == null || op != Operator.NOT && e2 != null);
+                op == Operator.NOT && e2 == null || op != Operator.NOT && e2 != null);
         if (e2 != null) {
             children.add(e2);
         }
@@ -110,14 +110,14 @@ public class CompoundPredicate extends Predicate {
         for (Expr e : children) {
             if (!e.getType().equals(Type.BOOLEAN) && !e.getType().isNull()) {
                 throw new AnalysisException(String.format(
-                  "Operand '%s' part of predicate " + "'%s' should return type 'BOOLEAN' but " +
-                    "returns type '%s'.",
-                  e.toSql(), toSql(), e.getType()));
+                        "Operand '%s' part of predicate " + "'%s' should return type 'BOOLEAN' but " +
+                                "returns type '%s'.",
+                        e.toSql(), toSql(), e.getType()));
             }
         }
 
         if (getChild(0).selectivity == -1 || children.size() == 2 && getChild(
-          1).selectivity == -1) {
+                1).selectivity == -1) {
             // give up if we're missing an input
             selectivity = -1;
             return;
@@ -129,7 +129,7 @@ public class CompoundPredicate extends Predicate {
                 break;
             case OR:
                 selectivity = getChild(0).selectivity + getChild(1).selectivity - getChild(
-                  0).selectivity * getChild(1).selectivity;
+                        0).selectivity * getChild(1).selectivity;
                 break;
             case NOT:
                 selectivity = 1.0 - getChild(0).selectivity;
@@ -146,7 +146,7 @@ public class CompoundPredicate extends Predicate {
         OR("OR", TExprOpcode.COMPOUND_OR),
         NOT("NOT", TExprOpcode.COMPOUND_NOT);
 
-        private final String      description;
+        private final String description;
         private final TExprOpcode thriftOp;
 
         Operator(String description, TExprOpcode thriftOp) {
@@ -169,11 +169,17 @@ public class CompoundPredicate extends Predicate {
      */
     @Override
     public Expr negate() {
-        if (op == Operator.NOT) return getChild(0);
+        if (op == Operator.NOT)
+            return getChild(0);
         Expr negatedLeft = getChild(0).negate();
         Expr negatedRight = getChild(1).negate();
         Operator newOp = (op == Operator.OR) ? Operator.AND : Operator.OR;
         return new CompoundPredicate(newOp, negatedLeft, negatedRight);
+    }
+
+    @Override
+    public boolean isNotNullPred() {
+        return false;
     }
 
     // Create an AND predicate between two exprs, 'lhs' and 'rhs'. If
@@ -190,37 +196,37 @@ public class CompoundPredicate extends Predicate {
      */
     public static Expr createConjunctivePredicate(List<Expr> conjuncts) {
         Expr conjunctivePred = null;
-        for (Expr expr: conjuncts) {
-          if (conjunctivePred == null) {
-            conjunctivePred = expr;
-            continue;
-          }
-          conjunctivePred = new CompoundPredicate(CompoundPredicate.Operator.AND,
-              expr, conjunctivePred);
+        for (Expr expr : conjuncts) {
+            if (conjunctivePred == null) {
+                conjunctivePred = expr;
+                continue;
+            }
+            conjunctivePred = new CompoundPredicate(CompoundPredicate.Operator.AND,
+                    expr, conjunctivePred);
         }
         return conjunctivePred;
     }
 
-   @Override
+    @Override
     public Expr getResultValue() throws AnalysisException {
         recursiveResetChildrenResult();
         boolean compoundResult = false;
         if (op == Operator.NOT) {
             final Expr childValue = getChild(0);
-            if(!(childValue instanceof BoolLiteral)) {
+            if (!(childValue instanceof BoolLiteral)) {
                 return this;
             }
-            final BoolLiteral boolChild = (BoolLiteral)childValue;
+            final BoolLiteral boolChild = (BoolLiteral) childValue;
             compoundResult = !boolChild.getValue();
         } else {
             final Expr leftChildValue = getChild(0);
             final Expr rightChildValue = getChild(1);
-            if(!(leftChildValue instanceof BoolLiteral)
+            if (!(leftChildValue instanceof BoolLiteral)
                     || !(rightChildValue instanceof BoolLiteral)) {
                 return this;
             }
-            final BoolLiteral leftBoolValue = (BoolLiteral)leftChildValue;
-            final BoolLiteral rightBoolValue = (BoolLiteral)rightChildValue;
+            final BoolLiteral leftBoolValue = (BoolLiteral) leftChildValue;
+            final BoolLiteral rightBoolValue = (BoolLiteral) rightChildValue;
             switch (op) {
                 case AND:
                     compoundResult = leftBoolValue.getValue() && rightBoolValue.getValue();

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/CompoundPredicate.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/CompoundPredicate.java
@@ -56,7 +56,7 @@ public class CompoundPredicate extends Predicate {
         Preconditions.checkNotNull(e1);
         children.add(e1);
         Preconditions.checkArgument(
-                op == Operator.NOT && e2 == null || op != Operator.NOT && e2 != null);
+          op == Operator.NOT && e2 == null || op != Operator.NOT && e2 != null);
         if (e2 != null) {
             children.add(e2);
         }
@@ -110,14 +110,14 @@ public class CompoundPredicate extends Predicate {
         for (Expr e : children) {
             if (!e.getType().equals(Type.BOOLEAN) && !e.getType().isNull()) {
                 throw new AnalysisException(String.format(
-                        "Operand '%s' part of predicate " + "'%s' should return type 'BOOLEAN' but " +
-                                "returns type '%s'.",
-                        e.toSql(), toSql(), e.getType()));
+                  "Operand '%s' part of predicate " + "'%s' should return type 'BOOLEAN' but " +
+                    "returns type '%s'.",
+                  e.toSql(), toSql(), e.getType()));
             }
         }
 
         if (getChild(0).selectivity == -1 || children.size() == 2 && getChild(
-                1).selectivity == -1) {
+          1).selectivity == -1) {
             // give up if we're missing an input
             selectivity = -1;
             return;
@@ -129,7 +129,7 @@ public class CompoundPredicate extends Predicate {
                 break;
             case OR:
                 selectivity = getChild(0).selectivity + getChild(1).selectivity - getChild(
-                        0).selectivity * getChild(1).selectivity;
+                  0).selectivity * getChild(1).selectivity;
                 break;
             case NOT:
                 selectivity = 1.0 - getChild(0).selectivity;
@@ -146,7 +146,7 @@ public class CompoundPredicate extends Predicate {
         OR("OR", TExprOpcode.COMPOUND_OR),
         NOT("NOT", TExprOpcode.COMPOUND_NOT);
 
-        private final String description;
+        private final String      description;
         private final TExprOpcode thriftOp;
 
         Operator(String description, TExprOpcode thriftOp) {
@@ -169,17 +169,11 @@ public class CompoundPredicate extends Predicate {
      */
     @Override
     public Expr negate() {
-        if (op == Operator.NOT)
-            return getChild(0);
+        if (op == Operator.NOT) return getChild(0);
         Expr negatedLeft = getChild(0).negate();
         Expr negatedRight = getChild(1).negate();
         Operator newOp = (op == Operator.OR) ? Operator.AND : Operator.OR;
         return new CompoundPredicate(newOp, negatedLeft, negatedRight);
-    }
-
-    @Override
-    public boolean isNotNullPred() {
-        return false;
     }
 
     // Create an AND predicate between two exprs, 'lhs' and 'rhs'. If
@@ -196,37 +190,37 @@ public class CompoundPredicate extends Predicate {
      */
     public static Expr createConjunctivePredicate(List<Expr> conjuncts) {
         Expr conjunctivePred = null;
-        for (Expr expr : conjuncts) {
-            if (conjunctivePred == null) {
-                conjunctivePred = expr;
-                continue;
-            }
-            conjunctivePred = new CompoundPredicate(CompoundPredicate.Operator.AND,
-                    expr, conjunctivePred);
+        for (Expr expr: conjuncts) {
+          if (conjunctivePred == null) {
+            conjunctivePred = expr;
+            continue;
+          }
+          conjunctivePred = new CompoundPredicate(CompoundPredicate.Operator.AND,
+              expr, conjunctivePred);
         }
         return conjunctivePred;
     }
 
-    @Override
+   @Override
     public Expr getResultValue() throws AnalysisException {
         recursiveResetChildrenResult();
         boolean compoundResult = false;
         if (op == Operator.NOT) {
             final Expr childValue = getChild(0);
-            if (!(childValue instanceof BoolLiteral)) {
+            if(!(childValue instanceof BoolLiteral)) {
                 return this;
             }
-            final BoolLiteral boolChild = (BoolLiteral) childValue;
+            final BoolLiteral boolChild = (BoolLiteral)childValue;
             compoundResult = !boolChild.getValue();
         } else {
             final Expr leftChildValue = getChild(0);
             final Expr rightChildValue = getChild(1);
-            if (!(leftChildValue instanceof BoolLiteral)
+            if(!(leftChildValue instanceof BoolLiteral)
                     || !(rightChildValue instanceof BoolLiteral)) {
                 return this;
             }
-            final BoolLiteral leftBoolValue = (BoolLiteral) leftChildValue;
-            final BoolLiteral rightBoolValue = (BoolLiteral) rightChildValue;
+            final BoolLiteral leftBoolValue = (BoolLiteral)leftChildValue;
+            final BoolLiteral rightBoolValue = (BoolLiteral)rightChildValue;
             switch (op) {
                 case AND:
                     compoundResult = leftBoolValue.getValue() && rightBoolValue.getValue();
@@ -249,5 +243,10 @@ public class CompoundPredicate extends Predicate {
     @Override
     public boolean isNullable() {
         return hasNullableChild();
+    }
+
+    @Override
+    public boolean isNotNullPred() {
+        return false;
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ExistsPredicate.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ExistsPredicate.java
@@ -75,8 +75,8 @@ public class ExistsPredicate extends Predicate {
     }
 
     @Override
-    public Expr clone() {
-        return new ExistsPredicate(this);
+    public boolean isNotNullPred() {
+        return true;
     }
 }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ExistsPredicate.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ExistsPredicate.java
@@ -28,12 +28,10 @@ import com.google.common.base.Preconditions;
  */
 public class ExistsPredicate extends Predicate {
     private static final Logger LOG = LoggerFactory.getLogger(
-            ExistsPredicate.class);
+        ExistsPredicate.class);
     private boolean notExists = false;
 
-    public boolean isNotExists() {
-        return notExists;
-    }
+    public boolean isNotExists() { return notExists; }
 
     public ExistsPredicate(Subquery subquery, boolean notExists) {
         Preconditions.checkNotNull(subquery);
@@ -58,14 +56,7 @@ public class ExistsPredicate extends Predicate {
     }
 
     @Override
-    public boolean isNotNullPred() {
-        return true;
-    }
-
-    @Override
-    public Expr clone() {
-        return new ExistsPredicate(this);
-    }
+    public Expr clone() { return new ExistsPredicate(this); }
 
     public String toSqlImpl() {
         StringBuilder strBuilder = new StringBuilder();
@@ -82,4 +73,10 @@ public class ExistsPredicate extends Predicate {
     public int hashCode() {
         return 31 * super.hashCode() + Boolean.hashCode(notExists);
     }
+
+    @Override
+    public Expr clone() {
+        return new ExistsPredicate(this);
+    }
 }
+

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ExistsPredicate.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ExistsPredicate.java
@@ -28,10 +28,12 @@ import com.google.common.base.Preconditions;
  */
 public class ExistsPredicate extends Predicate {
     private static final Logger LOG = LoggerFactory.getLogger(
-        ExistsPredicate.class);
+            ExistsPredicate.class);
     private boolean notExists = false;
 
-    public boolean isNotExists() { return notExists; }
+    public boolean isNotExists() {
+        return notExists;
+    }
 
     public ExistsPredicate(Subquery subquery, boolean notExists) {
         Preconditions.checkNotNull(subquery);
@@ -56,7 +58,14 @@ public class ExistsPredicate extends Predicate {
     }
 
     @Override
-    public Expr clone() { return new ExistsPredicate(this); }
+    public boolean isNotNullPred() {
+        return true;
+    }
+
+    @Override
+    public Expr clone() {
+        return new ExistsPredicate(this);
+    }
 
     public String toSqlImpl() {
         StringBuilder strBuilder = new StringBuilder();
@@ -74,4 +83,3 @@ public class ExistsPredicate extends Predicate {
         return 31 * super.hashCode() + Boolean.hashCode(notExists);
     }
 }
-

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/InPredicate.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/InPredicate.java
@@ -48,7 +48,7 @@ public class InPredicate extends Predicate {
 
     private static final String IN_SET_LOOKUP = "in_set_lookup";
     private static final String NOT_IN_SET_LOOKUP = "not_in_set_lookup";
-    private static final String IN_ITERATE = "in_iterate";
+    private static final String IN_ITERATE= "in_iterate";
     private static final String NOT_IN_ITERATE = "not_in_iterate";
     private final boolean isNotIn;
     private static final String IN = "in";
@@ -57,15 +57,13 @@ public class InPredicate extends Predicate {
     private static final NullLiteral NULL_LITERAL = new NullLiteral();
 
     public static void initBuiltins(FunctionSet functionSet) {
-        for (Type t : Type.getSupportedTypes()) {
-            if (t.isNull())
-                continue;
-            // TODO: we do not support codegen for CHAR and the In predicate must be
-            // codegened, because it has variable number of arguments. This will force CHARs
-            // to be cast up to strings; meaning that "in" comparisons will not have CHAR
-            // comparison semantics.
-            if (t.getPrimitiveType() == PrimitiveType.CHAR)
-                continue;
+        for (Type t: Type.getSupportedTypes()) {
+            if (t.isNull()) continue;
+            // TODO we do not support codegen for CHAR and the In predicate must be codegened
+            // because it has variable number of arguments. This will force CHARs to be
+            // cast up to strings; meaning that "in" comparisons will not have CHAR comparison
+            // semantics.
+            if (t.getPrimitiveType() == PrimitiveType.CHAR) continue;
 
             String typeString = Function.getUdfTypeName(t.getPrimitiveType());
 
@@ -135,7 +133,7 @@ public class InPredicate extends Predicate {
     }
 
     public List<Expr> getListChildren() {
-        return children.subList(1, children.size());
+        return  children.subList(1, children.size());
     }
 
     public boolean isNotIn() {
@@ -157,31 +155,29 @@ public class InPredicate extends Predicate {
 
         PrimitiveType type = getChild(0).getType().getPrimitiveType();
 
-        // OpcodeRegistry.BuiltinFunction match =
-        // OpcodeRegistry.instance().getFunctionInfo(
-        // FunctionOperator.FILTER_IN, true, true, type);
-        // Preconditions.checkState(match != null);
-        // Preconditions.checkState(match.getReturnType().equals(Type.BOOLEAN));
-        // this.vectorOpcode = match.opcode;
-        // LOG.info(debugString() + " opcode: " + vectorOpcode);
+//       OpcodeRegistry.BuiltinFunction match = OpcodeRegistry.instance().getFunctionInfo(
+//               FunctionOperator.FILTER_IN, true, true, type);
+//       Preconditions.checkState(match != null);
+//       Preconditions.checkState(match.getReturnType().equals(Type.BOOLEAN));
+//       this.vectorOpcode = match.opcode;
+//       LOG.info(debugString() + " opcode: " + vectorOpcode);
     }
 
     @Override
     public void analyzeImpl(Analyzer analyzer) throws AnalysisException {
         super.analyzeImpl(analyzer);
-
+        
         if (contains(Subquery.class)) {
-            // An [NOT] IN predicate with a subquery must contain two children, the second
-            // of
+            // An [NOT] IN predicate with a subquery must contain two children, the second of
             // which is a Subquery.
             if (children.size() != 2 || !(getChild(1) instanceof Subquery)) {
                 throw new AnalysisException("Unsupported IN predicate with a subquery: " +
-                        toSql());
-            }
-            Subquery subquery = (Subquery) getChild(1);
+                    toSql());
+            } 
+            Subquery subquery = (Subquery)getChild(1);
             if (!subquery.returnsScalarColumn()) {
                 throw new AnalysisException("Subquery must return a single column: " +
-                        subquery.toSql());
+                subquery.toSql());
             }
 
             // Ensure that the column in the lhs of the IN predicate and the result of
@@ -205,13 +201,12 @@ public class InPredicate extends Predicate {
             }
         }
         boolean useSetLookup = allConstant;
-        // Only lookup fn_ if all subqueries have been rewritten. If the second child is
-        // a subquery, it will have type ArrayType, which cannot be resolved to a
-        // builtin function and will fail analysis.
-        Type[] argTypes = { getChild(0).type, getChild(1).type };
+        // Only lookup fn_ if all subqueries have been rewritten. If the second child is a
+        // subquery, it will have type ArrayType, which cannot be resolved to a builtin
+        // function and will fail analysis.
+        Type[] argTypes = {getChild(0).type, getChild(1).type};
         if (useSetLookup) {
-            // fn = getBuiltinFunction(analyzer, isNotIn ? NOT_IN_SET_LOOKUP :
-            // IN_SET_LOOKUP,
+            // fn = getBuiltinFunction(analyzer, isNotIn ? NOT_IN_SET_LOOKUP : IN_SET_LOOKUP,
             // argTypes, Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
             opcode = isNotIn ? TExprOpcode.FILTER_NOT_IN : TExprOpcode.FILTER_IN;
         } else {

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/InPredicate.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/InPredicate.java
@@ -48,7 +48,7 @@ public class InPredicate extends Predicate {
 
     private static final String IN_SET_LOOKUP = "in_set_lookup";
     private static final String NOT_IN_SET_LOOKUP = "not_in_set_lookup";
-    private static final String IN_ITERATE= "in_iterate";
+    private static final String IN_ITERATE = "in_iterate";
     private static final String NOT_IN_ITERATE = "not_in_iterate";
     private final boolean isNotIn;
     private static final String IN = "in";
@@ -57,13 +57,15 @@ public class InPredicate extends Predicate {
     private static final NullLiteral NULL_LITERAL = new NullLiteral();
 
     public static void initBuiltins(FunctionSet functionSet) {
-        for (Type t: Type.getSupportedTypes()) {
-            if (t.isNull()) continue;
-            // TODO we do not support codegen for CHAR and the In predicate must be codegened
-            // because it has variable number of arguments. This will force CHARs to be
-            // cast up to strings; meaning that "in" comparisons will not have CHAR comparison
-            // semantics.
-            if (t.getPrimitiveType() == PrimitiveType.CHAR) continue;
+        for (Type t : Type.getSupportedTypes()) {
+            if (t.isNull())
+                continue;
+            // TODO: we do not support codegen for CHAR and the In predicate must be
+            // codegened, because it has variable number of arguments. This will force CHARs
+            // to be cast up to strings; meaning that "in" comparisons will not have CHAR
+            // comparison semantics.
+            if (t.getPrimitiveType() == PrimitiveType.CHAR)
+                continue;
 
             String typeString = Function.getUdfTypeName(t.getPrimitiveType());
 
@@ -109,6 +111,11 @@ public class InPredicate extends Predicate {
         return new InPredicate(this);
     }
 
+    @Override
+    public boolean isNotNullPred() {
+        return true;
+    }
+
     // C'tor for initializing an [NOT] IN predicate with a subquery child.
     public InPredicate(Expr compareExpr, Expr subquery, boolean isNotIn) {
         Preconditions.checkNotNull(compareExpr);
@@ -123,12 +130,12 @@ public class InPredicate extends Predicate {
      */
     @Override
     public Expr negate() {
-      return new InPredicate(getChild(0), children.subList(1, children.size()),
-          !isNotIn);
+        return new InPredicate(getChild(0), children.subList(1, children.size()),
+                !isNotIn);
     }
 
     public List<Expr> getListChildren() {
-        return  children.subList(1, children.size());
+        return children.subList(1, children.size());
     }
 
     public boolean isNotIn() {
@@ -144,35 +151,37 @@ public class InPredicate extends Predicate {
         return true;
     }
 
-   @Override
-   public void vectorizedAnalyze(Analyzer analyzer) {
+    @Override
+    public void vectorizedAnalyze(Analyzer analyzer) {
         super.vectorizedAnalyze(analyzer);
 
-       PrimitiveType type = getChild(0).getType().getPrimitiveType();
+        PrimitiveType type = getChild(0).getType().getPrimitiveType();
 
-//       OpcodeRegistry.BuiltinFunction match = OpcodeRegistry.instance().getFunctionInfo(
-//               FunctionOperator.FILTER_IN, true, true, type);
-//       Preconditions.checkState(match != null);
-//       Preconditions.checkState(match.getReturnType().equals(Type.BOOLEAN));
-//       this.vectorOpcode = match.opcode;
-//       LOG.info(debugString() + " opcode: " + vectorOpcode);
-   }
+        // OpcodeRegistry.BuiltinFunction match =
+        // OpcodeRegistry.instance().getFunctionInfo(
+        // FunctionOperator.FILTER_IN, true, true, type);
+        // Preconditions.checkState(match != null);
+        // Preconditions.checkState(match.getReturnType().equals(Type.BOOLEAN));
+        // this.vectorOpcode = match.opcode;
+        // LOG.info(debugString() + " opcode: " + vectorOpcode);
+    }
 
     @Override
     public void analyzeImpl(Analyzer analyzer) throws AnalysisException {
         super.analyzeImpl(analyzer);
-        
+
         if (contains(Subquery.class)) {
-            // An [NOT] IN predicate with a subquery must contain two children, the second of
+            // An [NOT] IN predicate with a subquery must contain two children, the second
+            // of
             // which is a Subquery.
             if (children.size() != 2 || !(getChild(1) instanceof Subquery)) {
                 throw new AnalysisException("Unsupported IN predicate with a subquery: " +
-                    toSql());
-            } 
-            Subquery subquery = (Subquery)getChild(1);
+                        toSql());
+            }
+            Subquery subquery = (Subquery) getChild(1);
             if (!subquery.returnsScalarColumn()) {
                 throw new AnalysisException("Subquery must return a single column: " +
-                subquery.toSql());
+                        subquery.toSql());
             }
 
             // Ensure that the column in the lhs of the IN predicate and the result of
@@ -196,12 +205,13 @@ public class InPredicate extends Predicate {
             }
         }
         boolean useSetLookup = allConstant;
-        // Only lookup fn_ if all subqueries have been rewritten. If the second child is a
-        // subquery, it will have type ArrayType, which cannot be resolved to a builtin
-        // function and will fail analysis.
-        Type[] argTypes = {getChild(0).type, getChild(1).type};
+        // Only lookup fn_ if all subqueries have been rewritten. If the second child is
+        // a subquery, it will have type ArrayType, which cannot be resolved to a
+        // builtin function and will fail analysis.
+        Type[] argTypes = { getChild(0).type, getChild(1).type };
         if (useSetLookup) {
-            // fn = getBuiltinFunction(analyzer, isNotIn ? NOT_IN_SET_LOOKUP : IN_SET_LOOKUP,
+            // fn = getBuiltinFunction(analyzer, isNotIn ? NOT_IN_SET_LOOKUP :
+            // IN_SET_LOOKUP,
             // argTypes, Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
             opcode = isNotIn ? TExprOpcode.FILTER_NOT_IN : TExprOpcode.FILTER_IN;
         } else {

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/IsNullPredicate.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/IsNullPredicate.java
@@ -35,8 +35,9 @@ public class IsNullPredicate extends Predicate {
     private static final String IS_NOT_NULL = "is_not_null_pred";
 
     public static void initBuiltins(FunctionSet functionSet) {
-        for (Type t: Type.getSupportedTypes()) {
-            if (t.isNull()) continue;
+        for (Type t : Type.getSupportedTypes()) {
+            if (t.isNull())
+                continue;
             String isNullSymbol;
             if (t == Type.BOOLEAN) {
                 isNullSymbol = "_ZN5doris15IsNullPredicate7is_nullIN9doris_udf10BooleanValE" +
@@ -57,7 +58,6 @@ public class IsNullPredicate extends Predicate {
         }
     }
 
-
     private final boolean isNotNull;
 
     public IsNullPredicate(Expr e, boolean isNotNull) {
@@ -74,6 +74,11 @@ public class IsNullPredicate extends Predicate {
 
     public boolean isNotNull() {
         return isNotNull;
+    }
+
+    @Override
+    public boolean isNotNullPred() {
+        return false;
     }
 
     @Override
@@ -132,6 +137,7 @@ public class IsNullPredicate extends Predicate {
     public boolean isNullable() {
         return false;
     }
+
     /**
      * fix issue 6390
      */
@@ -139,7 +145,7 @@ public class IsNullPredicate extends Predicate {
     public Expr getResultValue() throws AnalysisException {
         recursiveResetChildrenResult();
         final Expr childValue = getChild(0);
-        if(!(childValue instanceof LiteralExpr)) {
+        if (!(childValue instanceof LiteralExpr)) {
             return this;
         }
         return childValue instanceof NullLiteral ? new BoolLiteral(!isNotNull) : new BoolLiteral(isNotNull);

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/IsNullPredicate.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/IsNullPredicate.java
@@ -35,9 +35,8 @@ public class IsNullPredicate extends Predicate {
     private static final String IS_NOT_NULL = "is_not_null_pred";
 
     public static void initBuiltins(FunctionSet functionSet) {
-        for (Type t : Type.getSupportedTypes()) {
-            if (t.isNull())
-                continue;
+        for (Type t: Type.getSupportedTypes()) {
+            if (t.isNull()) continue;
             String isNullSymbol;
             if (t == Type.BOOLEAN) {
                 isNullSymbol = "_ZN5doris15IsNullPredicate7is_nullIN9doris_udf10BooleanValE" +
@@ -58,6 +57,7 @@ public class IsNullPredicate extends Predicate {
         }
     }
 
+
     private final boolean isNotNull;
 
     public IsNullPredicate(Expr e, boolean isNotNull) {
@@ -74,11 +74,6 @@ public class IsNullPredicate extends Predicate {
 
     public boolean isNotNull() {
         return isNotNull;
-    }
-
-    @Override
-    public boolean isNotNullPred() {
-        return false;
     }
 
     @Override
@@ -137,7 +132,6 @@ public class IsNullPredicate extends Predicate {
     public boolean isNullable() {
         return false;
     }
-
     /**
      * fix issue 6390
      */
@@ -145,9 +139,14 @@ public class IsNullPredicate extends Predicate {
     public Expr getResultValue() throws AnalysisException {
         recursiveResetChildrenResult();
         final Expr childValue = getChild(0);
-        if (!(childValue instanceof LiteralExpr)) {
+        if(!(childValue instanceof LiteralExpr)) {
             return this;
         }
         return childValue instanceof NullLiteral ? new BoolLiteral(!isNotNull) : new BoolLiteral(isNotNull);
+    }
+
+    @Override
+    public boolean isNotNullPred() {
+        return false;
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/JoinOperator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/JoinOperator.java
@@ -96,6 +96,14 @@ public enum JoinOperator {
     public boolean isRightOuterJoin() {
         return this == RIGHT_OUTER_JOIN;
     }
+
+    public boolean isLeftOrInnerJoin() {
+        return this == LEFT_OUTER_JOIN || this == INNER_JOIN;
+    }
+
+    public boolean isRightOrInnerJoin() {
+        return this == RIGHT_OUTER_JOIN || this == INNER_JOIN;
+    }
 }
 
 

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/LikePredicate.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/LikePredicate.java
@@ -84,11 +84,6 @@ public class LikePredicate extends Predicate {
     }
 
     @Override
-    public boolean isNotNullPred() {
-        return true;
-    }
-
-    @Override
     public Expr clone() {
         return new LikePredicate(this);
     }
@@ -150,4 +145,8 @@ public class LikePredicate extends Predicate {
         return 31 * super.hashCode() + Objects.hashCode(op);
     }
 
+    @Override
+    public boolean isNotNullPred() {
+        return true;
+    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/LikePredicate.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/LikePredicate.java
@@ -84,6 +84,11 @@ public class LikePredicate extends Predicate {
     }
 
     @Override
+    public boolean isNotNullPred() {
+        return true;
+    }
+
+    @Override
     public Expr clone() {
         return new LikePredicate(this);
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/Predicate.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/Predicate.java
@@ -64,7 +64,7 @@ public abstract class Predicate extends Expr {
      * what we want.
      */
     public boolean isSingleColumnPredicate(Reference<SlotRef> slotRefRef,
-            Reference<Integer> idxRef) {
+      Reference<Integer> idxRef) {
         // find slotref
         SlotRef slotRef = null;
         int i = 0;
@@ -120,21 +120,19 @@ public abstract class Predicate extends Expr {
                 // because isSingleColumnPredicate
                 Preconditions.checkState(right != null);
 
-                /*-
-                 * ATTN(cmy): Usually, the BinaryPredicate in the query will be rewritten through ExprRewriteRule,
-                 * and all SingleColumnPredicate will be rewritten as "column on the left and the constant on the right".
-                 * So usually the right child is constant.
-                 *
-                 * But if there is a subquery in where clause, the planner will equal the subquery to join.
-                 * During the equal, some auxiliary BinaryPredicate will be automatically generated,
-                 * and these BinaryPredicates will not go through ExprRewriteRule.
-                 * As a result, these BinaryPredicates may be as "column on the right and the constant on the left".
-                 * Example can be found in QueryPlanTest.java -> testJoinPredicateTransitivityWithSubqueryInWhereClause().
-                 *
-                 * Because our current planner implementation is very error-prone, so when this happens,
-                 * we simply assume that these kind of BinaryPredicates cannot be pushed down,
-                 * to ensure that this change will not affect other query plans.
-                 */
+                // ATTN(cmy): Usually, the BinaryPredicate in the query will be rewritten through ExprRewriteRule,
+                // and all SingleColumnPredicate will be rewritten as "column on the left and the constant on the right".
+                // So usually the right child is constant.
+                //
+                // But if there is a subquery in where clause, the planner will equal the subquery to join.
+                // During the equal, some auxiliary BinaryPredicate will be automatically generated,
+                // and these BinaryPredicates will not go through ExprRewriteRule.
+                // As a result, these BinaryPredicates may be as "column on the right and the constant on the left".
+                // Example can be found in QueryPlanTest.java -> testJoinPredicateTransitivityWithSubqueryInWhereClause().
+                //
+                // Because our current planner implementation is very error-prone, so when this happens,
+                // we simply assume that these kind of BinaryPredicates cannot be pushed down,
+                // to ensure that this change will not affect other query plans.
                 if (!right.isConstant()) {
                     return false;
                 }
@@ -150,6 +148,7 @@ public abstract class Predicate extends Expr {
 
         return false;
     }
+
 
     /**
      * If predicate is of the form "<slotref> = <slotref>", returns both SlotRefs,

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/Predicate.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/Predicate.java
@@ -41,8 +41,10 @@ public abstract class Predicate extends Expr {
         return isEqJoinConjunct;
     }
 
-    // It's used for judging predicate output not-null value (and column is in a
-    // tableRef)
+    /**
+     * It's used for judging predicate output not-null value (and column is in a
+     * tableRef)
+     */
     public abstract boolean isNotNullPred();
 
     public void setIsEqJoinConjunct(boolean v) {

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/Predicate.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/Predicate.java
@@ -41,6 +41,10 @@ public abstract class Predicate extends Expr {
         return isEqJoinConjunct;
     }
 
+    // It's used for judging predicate output not-null value (and column is in a
+    // tableRef)
+    public abstract boolean isNotNullPred();
+
     public void setIsEqJoinConjunct(boolean v) {
         isEqJoinConjunct = v;
     }
@@ -60,7 +64,7 @@ public abstract class Predicate extends Expr {
      * what we want.
      */
     public boolean isSingleColumnPredicate(Reference<SlotRef> slotRefRef,
-      Reference<Integer> idxRef) {
+            Reference<Integer> idxRef) {
         // find slotref
         SlotRef slotRef = null;
         int i = 0;
@@ -116,19 +120,21 @@ public abstract class Predicate extends Expr {
                 // because isSingleColumnPredicate
                 Preconditions.checkState(right != null);
 
-                // ATTN(cmy): Usually, the BinaryPredicate in the query will be rewritten through ExprRewriteRule,
-                // and all SingleColumnPredicate will be rewritten as "column on the left and the constant on the right".
-                // So usually the right child is constant.
-                //
-                // But if there is a subquery in where clause, the planner will equal the subquery to join.
-                // During the equal, some auxiliary BinaryPredicate will be automatically generated,
-                // and these BinaryPredicates will not go through ExprRewriteRule.
-                // As a result, these BinaryPredicates may be as "column on the right and the constant on the left".
-                // Example can be found in QueryPlanTest.java -> testJoinPredicateTransitivityWithSubqueryInWhereClause().
-                //
-                // Because our current planner implementation is very error-prone, so when this happens,
-                // we simply assume that these kind of BinaryPredicates cannot be pushed down,
-                // to ensure that this change will not affect other query plans.
+                /*-
+                 * ATTN(cmy): Usually, the BinaryPredicate in the query will be rewritten through ExprRewriteRule,
+                 * and all SingleColumnPredicate will be rewritten as "column on the left and the constant on the right".
+                 * So usually the right child is constant.
+                 *
+                 * But if there is a subquery in where clause, the planner will equal the subquery to join.
+                 * During the equal, some auxiliary BinaryPredicate will be automatically generated,
+                 * and these BinaryPredicates will not go through ExprRewriteRule.
+                 * As a result, these BinaryPredicates may be as "column on the right and the constant on the left".
+                 * Example can be found in QueryPlanTest.java -> testJoinPredicateTransitivityWithSubqueryInWhereClause().
+                 *
+                 * Because our current planner implementation is very error-prone, so when this happens,
+                 * we simply assume that these kind of BinaryPredicates cannot be pushed down,
+                 * to ensure that this change will not affect other query plans.
+                 */
                 if (!right.isConstant()) {
                     return false;
                 }
@@ -144,7 +150,6 @@ public abstract class Predicate extends Expr {
 
         return false;
     }
-
 
     /**
      * If predicate is of the form "<slotref> = <slotref>", returns both SlotRefs,

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/PredicateUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/PredicateUtils.java
@@ -24,8 +24,8 @@ import com.google.common.collect.Lists;
 
 public class PredicateUtils {
     /**
-     * Split predicates in disjunctive form recursively, i.e., split the input expression
-     * if the root node of the expression tree is `or` predicate.
+     * Split predicates in disjunctive form recursively, i.e., split the input
+     * expression, if the root node of the expression tree is `or` predicate.
      *
      * Some examples:
      * a or b -> a, b
@@ -50,6 +50,48 @@ public class PredicateUtils {
             splitDisjunctivePredicates(expr.getChild(1), result);
         } else {
             result.add(expr);
+        }
+    }
+
+    /**
+     * Split predicates in conjunctive form recursively, i.e., split the input
+     * expression, if the root node of the expression tree is `and` predicate.
+     *
+     * Some examples:
+     * a and b -> a, b
+     * a and b and c -> a, b, c
+     * (a or b) and (c or d) -> (a or b), (c or d)
+     * (a and b) or c -> (a and b) or c
+     * a -> a
+     */
+    public static List<Expr> flatAnd(Expr expr) {
+        ArrayList<Expr> result = Lists.newArrayList();
+        if (expr == null) {
+            return result;
+        }
+
+        flatAnd(expr, result);
+        return result;
+    }
+
+    private static void flatAnd(Expr expr, List<Expr> result) {
+        if (expr instanceof CompoundPredicate && ((CompoundPredicate) expr).getOp() == CompoundPredicate.Operator.AND) {
+            flatAnd(expr.getChild(0), result);
+            flatAnd(expr.getChild(1), result);
+        } else {
+            result.add(expr);
+        }
+    }
+
+    public static boolean existOr(Expr expr) {
+        if (expr == null) {
+            return false;
+        }
+
+        if (expr instanceof CompoundPredicate && ((CompoundPredicate) expr).getOp() == CompoundPredicate.Operator.OR) {
+            return true;
+        } else {
+            return existOr(expr.getChild(0)) || existOr(expr.getChild(1));
         }
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/PredicateUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/PredicateUtils.java
@@ -24,8 +24,8 @@ import com.google.common.collect.Lists;
 
 public class PredicateUtils {
     /**
-     * Split predicates in disjunctive form recursively, i.e., split the input
-     * expression, if the root node of the expression tree is `or` predicate.
+     * Split predicates in disjunctive form recursively, i.e., split the input expression
+     * if the root node of the expression tree is `or` predicate.
      *
      * Some examples:
      * a or b -> a, b

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/PredicateUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/PredicateUtils.java
@@ -91,6 +91,10 @@ public class PredicateUtils {
         if (expr instanceof CompoundPredicate && ((CompoundPredicate) expr).getOp() == CompoundPredicate.Operator.OR) {
             return true;
         } else {
+            // Operator is NOT
+            if (expr.getChild(1) == null) {
+                return false;
+            }
             return existOr(expr.getChild(0)) || existOr(expr.getChild(1));
         }
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/SetOperationStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/SetOperationStmt.java
@@ -724,7 +724,7 @@ public class SetOperationStmt extends QueryStmt {
             }
             // union statement support const expr, so not need to equal
             if (operation != Operation.UNION && queryStmt instanceof SelectStmt
-                    && ((SelectStmt) queryStmt).fromClause_.isEmpty()) {
+                    && ((SelectStmt) queryStmt).fromClause.isEmpty()) {
                 // equal select 1 to select * from (select 1) __DORIS_DUAL__ , because when using select 1 it will be
                 // transformed to a union node, select 1 is a literal, it doesn't have a tuple but will produce a slot,
                 // this will cause be core dump
@@ -742,7 +742,7 @@ public class SetOperationStmt extends QueryStmt {
                                 .set(i, new SelectListItem(item.getExpr(), col + "_" + count.toString()));
                     }
                 }
-                ((SelectStmt) queryStmt).fromClause_.add(new InlineViewRef("__DORIS_DUAL__", inlineQuery));
+                ((SelectStmt) queryStmt).fromClause.add(new InlineViewRef("__DORIS_DUAL__", inlineQuery));
                 List<SelectListItem> slist = ((SelectStmt) queryStmt).selectList.getItems();
                 slist.clear();
                 slist.add(SelectListItem.createStarItem(null));

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/StmtRewriter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/StmtRewriter.java
@@ -85,7 +85,7 @@ public class StmtRewriter {
             throws AnalysisException {
         SelectStmt result = stmt;
         // Rewrite all the subqueries in the FROM clause.
-        for (TableRef tblRef: result.fromClause_) {
+        for (TableRef tblRef: result.fromClause) {
             if (!(tblRef instanceof InlineViewRef)) continue;
             InlineViewRef inlineViewRef = (InlineViewRef)tblRef;
             QueryStmt rewrittenQueryStmt = rewriteQueryStatement(inlineViewRef.getViewStmt(),
@@ -392,7 +392,7 @@ public class StmtRewriter {
     private static void rewriteWhereClauseSubqueries(
             SelectStmt stmt, Analyzer analyzer)
             throws AnalysisException {
-        int numTableRefs = stmt.fromClause_.size();
+        int numTableRefs = stmt.fromClause.size();
         ArrayList<Expr> exprsWithSubqueries = Lists.newArrayList();
         ExprSubstitutionMap smap = new ExprSubstitutionMap();
         // Check if all the conjuncts in the WHERE clause that contain subqueries
@@ -602,9 +602,9 @@ public class StmtRewriter {
         } catch (UserException e) {
             throw new AnalysisException(e.getMessage());
         }
-        inlineView.setLeftTblRef(stmt.fromClause_.get(stmt.fromClause_.size() - 1));
+        inlineView.setLeftTblRef(stmt.fromClause.get(stmt.fromClause.size() - 1));
 
-        stmt.fromClause_.add(inlineView);
+        stmt.fromClause.add(inlineView);
         JoinOperator joinOp = JoinOperator.LEFT_SEMI_JOIN;
 
         // Create a join conjunct from the expr that contains a subquery.
@@ -771,7 +771,7 @@ public class StmtRewriter {
      * replacing an unqualified star item.
      */
     private static void replaceUnqualifiedStarItems(SelectStmt stmt, int tableIdx) {
-        Preconditions.checkState(tableIdx < stmt.fromClause_.size());
+        Preconditions.checkState(tableIdx < stmt.fromClause.size());
         ArrayList<SelectListItem> newItems = Lists.newArrayList();
         for (int i = 0; i < stmt.selectList.getItems().size(); ++i) {
             SelectListItem item = stmt.selectList.getItems().get(i);
@@ -782,7 +782,7 @@ public class StmtRewriter {
             // '*' needs to be replaced by tbl1.*,...,tbln.*, where
             // tbl1,...,tbln are the visible tableRefs in stmt.
             for (int j = 0; j < tableIdx; ++j) {
-                TableRef tableRef = stmt.fromClause_.get(j);
+                TableRef tableRef = stmt.fromClause.get(j);
                 if (tableRef.getJoinOp() == JoinOperator.LEFT_SEMI_JOIN ||
                         tableRef.getJoinOp() == JoinOperator.LEFT_ANTI_JOIN) {
                     continue;

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/TupleIsNullPredicate.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/TupleIsNullPredicate.java
@@ -30,10 +30,9 @@ import com.google.common.collect.Lists;
 import java.util.List;
 
 /**
- * Internal expr that returns true if all of the given tuples are NULL,
- * otherwise false. Used to make exprs originating from an inline view nullable
- * in an outer join. The given tupleIds must be materialized and nullable at the
- * appropriate PlanNode.
+ * Internal expr that returns true if all of the given tuples are NULL, otherwise false.
+ * Used to make exprs originating from an inline view nullable in an outer join.
+ * The given tupleIds must be materialized and nullable at the appropriate PlanNode.
  */
 public class TupleIsNullPredicate extends Predicate {
 
@@ -62,14 +61,8 @@ public class TupleIsNullPredicate extends Predicate {
     @Override
     public boolean isBoundByTupleIds(List<TupleId> tids) {
         for (TupleId tid : tids) {
-            if (tupleIds.contains(tid))
-                return true;
+            if (tupleIds.contains(tid)) return true;
         }
-        return false;
-    }
-
-    @Override
-    public boolean isNotNullPred() {
         return false;
     }
 
@@ -91,6 +84,7 @@ public class TupleIsNullPredicate extends Predicate {
         return tupleIds;
     }
 
+
     @Override
     public boolean equals(Object o) {
         if (!super.equals(o)) {
@@ -108,14 +102,14 @@ public class TupleIsNullPredicate extends Predicate {
      * Makes each input expr nullable, if necessary, by wrapping it as follows:
      * IF(TupleIsNull(tids), NULL, expr)
      * <p>
-     * The given tids must be materialized. The given inputExprs are expected to be
-     * bound by tids once fully substituted against base tables. However, inputExprs
-     * may not yet be fully substituted at this point.
+     * The given tids must be materialized. The given inputExprs are expected to be bound
+     * by tids once fully substituted against base tables. However, inputExprs may not yet
+     * be fully substituted at this point.
      * <p>
      * Returns a new list with the nullable exprs.
      */
     public static List<Expr> wrapExprs(List<Expr> inputExprs,
-            List<TupleId> tids, Analyzer analyzer) throws UserException {
+                                       List<TupleId> tids, Analyzer analyzer) throws UserException {
         // Assert that all tids are materialized.
         for (TupleId tid : tids) {
             TupleDescriptor tupleDesc = analyzer.getTupleDesc(tid);
@@ -144,18 +138,12 @@ public class TupleIsNullPredicate extends Predicate {
         params.add(expr);
         Expr ifExpr = new FunctionCallExpr("if", params);
         ifExpr.analyzeNoThrow(analyzer);
-
-        /*-
-         * The type of function which is different from the type of expr will return
-         * the
-         * incorrect result in query.
-         * Example:
-         *   the type of expr is date
-         *   the type of function is int
-         * So, the upper fragment will receive a int value instead of date while the
-         * result expr is date.
-         * If there is no cast function, the result of query will be incorrect.
-         */
+        // The type of function which is different from the type of expr will return the incorrect result in query.
+        // Example:
+        //   the type of expr is date
+        //   the type of function is int
+        //   So, the upper fragment will receive a int value instead of date while the result expr is date.
+        // If there is no cast function, the result of query will be incorrect.
         if (expr.getType().getPrimitiveType() != ifExpr.getType().getPrimitiveType()) {
             ifExpr = ifExpr.uncheckedCastTo(expr.getType());
         }
@@ -163,9 +151,9 @@ public class TupleIsNullPredicate extends Predicate {
     }
 
     /**
-     * Returns true if the given expr evaluates to a non-NULL value if all its
-     * contained SlotRefs evaluate to NULL, false otherwise. Throws an
-     * InternalException if expr evaluation in the BE failed.
+     * Returns true if the given expr evaluates to a non-NULL value if all its contained
+     * SlotRefs evaluate to NULL, false otherwise.
+     * Throws an InternalException if expr evaluation in the BE failed.
      */
     private static boolean requiresNullWrapping(Expr expr, Analyzer analyzer) {
         return !expr.getType().isNull();
@@ -198,6 +186,11 @@ public class TupleIsNullPredicate extends Predicate {
 
     @Override
     public boolean isNullable() {
+        return false;
+    }
+
+    @Override
+    public boolean isNotNullPred() {
         return false;
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/planner/PlannerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/planner/PlannerTest.java
@@ -62,8 +62,7 @@ public class PlannerTest {
         // 3. create table tbl1
         String createTblStmtStr = "create table db1.tbl1(k1 varchar(32), k2 varchar(32), k3 varchar(32), k4 int) "
                 + "AGGREGATE KEY(k1, k2,k3,k4) distributed by hash(k1) buckets 3 properties('replication_num' = '1');";
-        CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameUtils.parseAndAnalyzeStmt(createTblStmtStr,
-                ctx);
+        CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameUtils.parseAndAnalyzeStmt(createTblStmtStr, ctx);
         Catalog.getCurrentCatalog().createTable(createTableStmt);
 
         createTblStmtStr = "create table db1.tbl2(k1 int, k2 int sum) "
@@ -272,7 +271,7 @@ public class PlannerTest {
         StmtExecutor stmtExecutor11 = new StmtExecutor(ctx, sql11);
         stmtExecutor11.execute();
         Planner planner11 = stmtExecutor11.planner();
-        SetOperationNode setNode11 = (SetOperationNode) (planner11.getFragments().get(1).getPlanRoot());
+        SetOperationNode setNode11 = (SetOperationNode)(planner11.getFragments().get(1).getPlanRoot());
         Assert.assertEquals(2, setNode11.getMaterializedConstExprLists_().size());
 
         String sql12 = "SELECT a.x \n" +
@@ -284,13 +283,14 @@ public class PlannerTest {
         StmtExecutor stmtExecutor12 = new StmtExecutor(ctx, sql12);
         stmtExecutor12.execute();
         Planner planner12 = stmtExecutor12.planner();
-        SetOperationNode setNode12 = (SetOperationNode) (planner12.getFragments().get(1).getPlanRoot());
+        SetOperationNode setNode12 = (SetOperationNode)(planner12.getFragments().get(1).getPlanRoot());
         Assert.assertEquals(2, setNode12.getMaterializedResultExprLists_().size());
     }
 
     @Test
-    public void testPushDown() throws Exception {
-        String sql1 = "SELECT\n" +
+    public void testPushDown() throws Exception{
+        String sql1 =
+                "SELECT\n" +
                 "    IF(k2 IS NULL, 'ALL', k2) AS k2,\n" +
                 "    IF(k3 IS NULL, 'ALL', k3) AS k3,\n" +
                 "    k4\n" +
@@ -322,24 +322,25 @@ public class PlannerTest {
                 fragments1.get(0).getPlanRoot().conjuncts.get(0).getChild(0).getFn().functionName());
         Assert.assertEquals(3, fragments1.get(0).getPlanRoot().getChild(0).getChild(0).conjuncts.size());
 
-        String sql2 = "SELECT\n" +
-                "    IF(k2 IS NULL, 'ALL', k2) AS k2,\n" +
-                "    IF(k3 IS NULL, 'ALL', k3) AS k3,\n" +
-                "    k4\n" +
-                "FROM\n" +
-                "(\n" +
-                "    SELECT\n" +
-                "        k1,\n" +
-                "        k2,\n" +
-                "        k3,\n" +
-                "        SUM(k4) AS k4\n" +
-                "    FROM  db1.tbl1\n" +
-                "    WHERE k1 = 0\n" +
-                "        AND k4 = 1\n" +
-                "        AND k3 = 'foo'\n" +
-                "    GROUP BY k1, k2, k3\n" +
-                ") t\n" +
-                "WHERE IF(k2 IS NULL, 'ALL', k2) = 'ALL'";
+        String sql2 =
+                "SELECT\n" +
+                        "    IF(k2 IS NULL, 'ALL', k2) AS k2,\n" +
+                        "    IF(k3 IS NULL, 'ALL', k3) AS k3,\n" +
+                        "    k4\n" +
+                        "FROM\n" +
+                        "(\n" +
+                        "    SELECT\n" +
+                        "        k1,\n" +
+                        "        k2,\n" +
+                        "        k3,\n" +
+                        "        SUM(k4) AS k4\n" +
+                        "    FROM  db1.tbl1\n" +
+                        "    WHERE k1 = 0\n" +
+                        "        AND k4 = 1\n" +
+                        "        AND k3 = 'foo'\n" +
+                        "    GROUP BY k1, k2, k3\n" +
+                        ") t\n" +
+                        "WHERE IF(k2 IS NULL, 'ALL', k2) = 'ALL'";
         StmtExecutor stmtExecutor2 = new StmtExecutor(ctx, sql2);
         stmtExecutor2.execute();
         Planner planner2 = stmtExecutor2.planner();
@@ -380,6 +381,7 @@ public class PlannerTest {
                 "GROUP BY a.k1, a.k3";
         StmtExecutor stmtExecutor = new StmtExecutor(ctx, sql);
         stmtExecutor.execute();
+        Assert.assertNotNull(stmtExecutor.planner());
         Planner planner = stmtExecutor.planner();
         List<PlanFragment> fragments = planner.getFragments();
         Assert.assertTrue(fragments.size() > 0);
@@ -396,6 +398,7 @@ public class PlannerTest {
             expr.isBoundByTupleIds(sortNode.getChild(0).tupleIds);
         }
     }
+
 
     @Test
     public void testBigintSlotRefCompareDecimalLiteral() {


### PR DESCRIPTION
# Proposed changes

Issue Number: close #7698

## Problem Summary:

Add optimizer feature: outer join to inner join when there is not null predicate in joined table.

Such as 

```sql
select * 
from table1 left join table2 
on table1.siteid = table2.siteid 
where table2.siteid > 0;

->

select * 
from table1 inner join table2 
on table1.siteid = table2.siteid 
where table2.siteid > 0;
``` 

In this PR, if a table exist a non-null predicate in it, I will convert it join type
- full outer join -> right outer join
- left outer join -> inner join 

to its next table:
- full outer join -> left outer join
- right outer join -> inner join

## Checklist(Required)

1. Does it affect the original behavior: (NO)
2. Has unit tests been added: (No)
3. Has document been added or modified: (No)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (No)

## Further comments

in #7698. Just talk about two table join 

- full outer -> inner if both sides have such predicates
- left outer -> inner if the right side has such predicates
- right outer -> inner if the left side has such predicates
- full outer -> left outer if only the left side has such predicates
- full outer -> right outer if only the right side has such predicates

But for multi-table Join, it is worth noticing.

