### PR TITLE
[fix](account) use LOG.info instead of LOG.debug

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/PaloAuth.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/PaloAuth.java
@@ -588,7 +588,7 @@ public class PaloAuth implements Writable {
             // 2. check if user already exist
             if (userPrivTable.doesUserExist(userIdent)) {
                 if (ignoreIfExists) {
-                    LOG.debug("user exists, ignored to create user: {}, is replay: {}", userIdent, isReplay);
+                    LOG.info("user exists, ignored to create user: {}, is replay: {}", userIdent, isReplay);
                     return;
                 }
                 throw new DdlException("User " + userIdent + " already exist");


### PR DESCRIPTION
This complements (#8849)

## Problem Summary:

In #8849 I commented that I misused `LOG.debug`. However the PR has been merged before I fix it.