### PR TITLE
[Bug] fix backup timeout on a table without partition

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/backup/BackupJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/backup/BackupJob.java
@@ -358,6 +358,18 @@ public class BackupJob extends AbstractJob {
         taskProgress.clear();
         taskErrMsg.clear();
         AgentBatchTask batchTask = new AgentBatchTask();
+
+        // remove table which has no partition
+        tableRefs = tableRefs.stream().filter(tableRef -> {
+            String tblName = tableRef.getName().getTbl();
+            Table tbl = db.getTableNullable(tblName);
+            if (tbl != null && tbl.getType() == TableType.OLAP) {
+                OlapTable olapTable = (OlapTable) tbl;
+                return !olapTable.getAllPartitions().isEmpty();
+            }
+            return true;
+        }).collect(Collectors.toList());
+
         for (TableRef tableRef : tableRefs) {
             String tblName = tableRef.getName().getTbl();
             Table tbl = db.getTableNullable(tblName);


### PR DESCRIPTION
# Proposed changes

Issue Number: close #8886 

## Problem Summary:

this pr is fix the bug which a user creates a table without partition，and the developer makes a backup for the database will timeout。

backup job skips the table which has no partition

## Checklist(Required)

1. Does it affect the original behavior: (No)
2. Has unit tests been added: (No)
3. Has document been added or modified: (No)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
