### PR TITLE
[doc] Add 1.0.x version for build image

### DIFF
--- a/docs/en/installing/compilation.md
+++ b/docs/en/installing/compilation.md
@@ -57,7 +57,7 @@ This document focuses on how to code Doris through source code.
 | apache/incubator-doris:build-env-1.3.1 | [ad67dd3](https://github.com/apache/incubator-doris/commit/ad67dd34a04c1ca960cff38e5b335b30fc7d559f) or later | 0.14.x |
 | apache/incubator-doris:build-env-for-0.15.0 | [a81f4da](https://github.com/apache/incubator-doris/commit/a81f4da4e461a54782a96433b746d07be89e6b54) or later | 0.15.0          |
 | apache/incubator-doris:build-env-latest | before [0efef1b](https://github.com/apache/incubator-doris/commit/0efef1b332300887ee0473f9df9bdd9d7297d824) | |
-| apache/incubator-doris:build-env-ldb-toolchain-latest | trunk | trunk |
+| apache/incubator-doris:build-env-ldb-toolchain-latest | trunk | trunk, 1.0.x |
 
 **note**:
 

--- a/docs/zh-CN/installing/compilation.md
+++ b/docs/zh-CN/installing/compilation.md
@@ -56,7 +56,7 @@ under the License.
 | apache/incubator-doris:build-env-1.3.1 | [ad67dd3](https://github.com/apache/incubator-doris/commit/ad67dd34a04c1ca960cff38e5b335b30fc7d559f) | 0.14.x |
 | apache/incubator-doris:build-env-for-0.15.0 | [a81f4da](https://github.com/apache/incubator-doris/commit/a81f4da4e461a54782a96433b746d07be89e6b54) or later | 0.15.0 |
 | apache/incubator-doris:build-env-latest | before [0efef1b](https://github.com/apache/incubator-doris/commit/0efef1b332300887ee0473f9df9bdd9d7297d824) | |
-| apache/incubator-doris:build-env-ldb-toolchain-latest | trunk | |
+| apache/incubator-doris:build-env-ldb-toolchain-latest | trunk | trunk, 1.0.x |
 
 **注意**：
 

--- a/new-docs/en/install/source-install/compilation.md
+++ b/new-docs/en/install/source-install/compilation.md
@@ -57,7 +57,7 @@ This document focuses on how to code Doris through source code.
 | apache/incubator-doris:build-env-1.3.1 | [ad67dd3](https://github.com/apache/incubator-doris/commit/ad67dd34a04c1ca960cff38e5b335b30fc7d559f) or later | 0.14.x |
 | apache/incubator-doris:build-env-for-0.15.0 | [a81f4da](https://github.com/apache/incubator-doris/commit/a81f4da4e461a54782a96433b746d07be89e6b54) or later | 0.15.0          |
 | apache/incubator-doris:build-env-latest | before [0efef1b](https://github.com/apache/incubator-doris/commit/0efef1b332300887ee0473f9df9bdd9d7297d824) | |
-| apache/incubator-doris:build-env-ldb-toolchain-latest | trunk | trunk |
+| apache/incubator-doris:build-env-ldb-toolchain-latest | trunk | trunk, 1.0.x |
 
 **note**:
 

--- a/new-docs/zh-CN/install/source-install/compilation.md
+++ b/new-docs/zh-CN/install/source-install/compilation.md
@@ -56,7 +56,7 @@ under the License.
 | apache/incubator-doris:build-env-1.3.1 | [ad67dd3](https://github.com/apache/incubator-doris/commit/ad67dd34a04c1ca960cff38e5b335b30fc7d559f) | 0.14.x |
 | apache/incubator-doris:build-env-for-0.15.0 | [a81f4da](https://github.com/apache/incubator-doris/commit/a81f4da4e461a54782a96433b746d07be89e6b54) or later | 0.15.0 |
 | apache/incubator-doris:build-env-latest | before [0efef1b](https://github.com/apache/incubator-doris/commit/0efef1b332300887ee0473f9df9bdd9d7297d824) | |
-| apache/incubator-doris:build-env-ldb-toolchain-latest | trunk | |
+| apache/incubator-doris:build-env-ldb-toolchain-latest | trunk | trunk, 1.0.x |
 
 **注意**：
 


### PR DESCRIPTION
apache/incubator-doris:build-env-ldb-toolchain-latest is the right env for 1.0.x.

# Proposed changes

The doc isn't friend for new develop. 
I think it's more readable for new develop by this pr.

## Further comments

It's not the final solution!
Can we build a new image for every great release?