### PR TITLE
Revert "[Thirdparty]Add llvm for codegen"

### DIFF
--- a/thirdparty/build-thirdparty.sh
+++ b/thirdparty/build-thirdparty.sh
@@ -956,30 +956,6 @@ build_simdjson() {
     cp -r $TP_SOURCE_DIR/$SIMDJSON_SOURCE/include/* $TP_INCLUDE_DIR/
 }
 
-# llvm
-build_llvm() {
-    check_if_source_exist $LLVM_SOURCE
-    cd $TP_SOURCE_DIR/$LLVM_SOURCE
-
-    mkdir -p $BUILD_DIR && cd $BUILD_DIR
-    CXX_FLAGS="-O3" \
-    C_FLAGS="-O3" \
-    $CMAKE_CMD -DLLVM_INCLUDE_BENCHMARKS=OFF \
-               -DLLVM_TARGETS_TO_BUILD="X86;AArch64" \
-               -DLLVM_ENABLE_TERMINFO=OFF \
-               -DLLVM_INCLUDE_TOOLS=OFF \
-               -DLLVM_INCLUDE_UTILS=OFF \
-               -DLLVM_INCLUDE_TESTS=OFF \
-               -DLLVM_USE_FOLDERS=OFF \
-               -DLLVM_ENABLE_LIBEDIT=OFF \
-               -DLLVM_ENABLE_LIBPFM=OFF \
-               -DLLVM_ENABLE_RTTI=ON \
-               -DCMAKE_BUILD_TYPE=Release \
-               -DCMAKE_INSTALL_PREFIX=$TP_INSTALL_DIR ..
-    make -j $PARALLEL && make install
-}
-
-build_llvm
 build_libunixodbc
 build_openssl
 build_libevent

--- a/thirdparty/vars.sh
+++ b/thirdparty/vars.sh
@@ -377,12 +377,6 @@ LIBBACKTRACE_NAME=libbacktrace-2446c66076480ce07a6bd868badcbceb3eeecc2e.zip
 LIBBACKTRACE_SOURCE=libbacktrace-2446c66076480ce07a6bd868badcbceb3eeecc2e
 LIBBACKTRACE_MD5SUM="6c79a8012870a24610c0d9c3621b23fe"
 
-# llvm
-LLVM_DOWNLOAD="https://github.com/llvm/llvm-project/releases/download/llvmorg-14.0.0/llvm-14.0.0.src.tar.xz"
-LLVM_NAME="llvm-14.0.0.src.tar.xz"
-LLVM_SOURCE="llvm-14.0.0.src"
-LLVM_MD5SUM="91ad90cc054593ce95230f4b2118c9d1"
-
 # all thirdparties which need to be downloaded is set in array TP_ARCHIVES
 export TP_ARCHIVES="LIBEVENT
 OPENSSL
@@ -436,5 +430,4 @@ BENCHMARK
 BREAKPAD
 XSIMD
 SIMDJSON
-LIBBACKTRACE
-LLVM"
+LIBBACKTRACE"


### PR DESCRIPTION
Reverts apache/incubator-doris#8938
The LLVM requires GLIBC_2.15. I decided to create a branch for the llvm feature first.
And once we resolve the low version glibc issue, it will ba merged back to master.