### PR TITLE
[enhancement] take all previous broadcast join consumption into account when choose join algorithm

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/planner/DistributedPlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/DistributedPlanner.java
@@ -360,9 +360,9 @@ public class DistributedPlanner {
                 int fragmentId = leftChildFragment.getFragmentId().asInt();
                 long spaceUsedByOtherJoinNodes = ctx_.getHashTableSpaceUsedInFragment(fragmentId);
                 long spaceUsedByCurrentNode = joinCostEvaluation.constructHashTableSpace();
-                long SpaceUsedInFragment = spaceUsedByOtherJoinNodes + spaceUsedByCurrentNode;
-                if (SpaceUsedInFragment <= ctx_.getRootAnalyzer().getAutoBroadcastJoinThreshold()) {
-                    ctx_.setHashTableSpaceUsedInFragment(fragmentId, SpaceUsedInFragment);
+                long spaceUsedInFragment = spaceUsedByOtherJoinNodes + spaceUsedByCurrentNode;
+                if (spaceUsedInFragment <= ctx_.getRootAnalyzer().getAutoBroadcastJoinThreshold()) {
+                    ctx_.setHashTableSpaceUsedInFragment(fragmentId, spaceUsedInFragment);
                     doBroadcast = true;
                 } else {
                     doBroadcast = false;

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/PlannerContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/PlannerContext.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.planner;
 
+import com.google.common.collect.Maps;
 import org.apache.doris.analysis.Analyzer;
 import org.apache.doris.analysis.InsertStmt;
 import org.apache.doris.analysis.QueryStmt;
@@ -26,6 +27,8 @@ import org.apache.doris.thrift.TQueryOptions;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+
+import java.util.Map;
 
 /**
  * Contains the analysis result of a query as well as planning-specific
@@ -49,6 +52,8 @@ public class PlannerContext {
     private final QueryStmt queryStmt_;
     private final StatementBase statement_;
 
+    private final Map<Integer, Long> fragmentIdToHashTableSpaceMap = Maps.newHashMap();
+
     public PlannerContext(Analyzer analyzer, QueryStmt queryStmt, TQueryOptions queryOptions, StatementBase statement) {
         this.analyzer_ = analyzer;
         this.queryStmt_ = queryStmt;
@@ -64,4 +69,11 @@ public class PlannerContext {
     public PlanFragmentId getNextFragmentId() { return fragmentIdGenerator_.getNextId(); }
 
     public boolean isInsert() { return statement_ instanceof InsertStmt; }
+
+    public long getHashTableSpaceUsedInFragment(int fragmentId) {
+        return fragmentIdToHashTableSpaceMap.getOrDefault(fragmentId, 0L);
+    }
+    public void setHashTableSpaceUsedInFragment(int fragmentId, long space) {
+        fragmentIdToHashTableSpaceMap.put(fragmentId, space);
+    }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/planner/DistributedPlannerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/planner/DistributedPlannerTest.java
@@ -199,6 +199,7 @@ public class DistributedPlannerTest {
             joinCostEvaluation.isBroadcastCostSmaller();
             result = true;
             joinCostEvaluation.constructHashTableSpace();
+            // value that larger than one of third of auto broadcast join threshold in analyzer.
             result = 600000000L;
         }};
 


### PR DESCRIPTION
# Proposed changes

According to discussion in the issue #8695
https://github.com/apache/incubator-doris/pull/8695#discussion_r838442611
We need to take all broadcast cost in one fragment when compute current node broadcast join consumption.
This patch is a simple implement to do this.
The algorithm is very simple:
```
long spaceUsedInFragment = spaceUsedByPreviousJoinNodes + spaceUsedByCurrentNode;
if (spaceUsedInFragment <= threshold) {
     doBroadcast = true;
} else {
     doBroadcast = false;
}
```
we could update this algorithm to choose best split position in future.

## Checklist(Required)

1. Does it affect the original behavior: (Yes)
2. Has unit tests been added: (Yes)
3. Has document been added or modified: (No)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (No)