### PR TITLE
[fix] let VAssertRowNumNode handle return value of child->get_next

### DIFF
--- a/be/src/vec/exec/vassert_num_rows_node.cpp
+++ b/be/src/vec/exec/vassert_num_rows_node.cpp
@@ -49,7 +49,7 @@ Status VAssertNumRowsNode::open(RuntimeState* state) {
 Status VAssertNumRowsNode::get_next(RuntimeState* state, Block* block, bool* eos) {
     RETURN_IF_ERROR(exec_debug_action(TExecNodePhase::GETNEXT));
     SCOPED_TIMER(_runtime_profile->total_time_counter());
-    child(0)->get_next(state, block, eos);
+    RETURN_IF_ERROR(child(0)->get_next(state, block, eos));
     _num_rows_returned += block->rows();
     bool assert_res = false;
     switch (_assertion) {


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (No)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
