### PR TITLE
[fix] wait _send_batch_thread_pool_token rather than shutdown.

### DIFF
--- a/be/src/exec/tablet_sink.cpp
+++ b/be/src/exec/tablet_sink.cpp
@@ -1108,7 +1108,10 @@ Status OlapTableSink::close(RuntimeState* state, Status close_status) {
     _stop_background_threads_latch.count_down();
     if (_sender_thread) {
         _sender_thread->join();
-        _send_batch_thread_pool_token->shutdown();
+        // We have to wait all task in _send_batch_thread_pool_token finished,
+        // because it is difficult to handle concurrent problem if we just
+        // shutdown it.
+        _send_batch_thread_pool_token->wait();
     }
 
     Expr::close(_output_expr_ctxs, state);


### PR DESCRIPTION
We can not shutdown _send_batch_thread_pool_token, because _packet_in_flight
has to be clear finally. Otherwise a never ended join on rpc would happen.

It is difficult to handle concurrent problem if a flag setter is not
guaranteed to run.

# Proposed changes

Issue Number: close #xxx

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
