### PR TITLE
[fix](rewrite) The where condition cannot be pushed down because ther…

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -422,7 +422,7 @@ public class SessionVariable implements Serializable, Writable {
     private boolean disableJoinReorder = false;
 
     @VariableMgr.VarAttr(name = ENABLE_INFER_PREDICATE)
-    private boolean enableInferPredicate = false;
+    private boolean enableInferPredicate = true;
 
     @VariableMgr.VarAttr(name = SQL_QUOTE_SHOW_CREATE)
     public boolean sqlQuoteShowCreate = true;

--- a/fe/fe-core/src/main/java/org/apache/doris/rewrite/InferFiltersRule.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/rewrite/InferFiltersRule.java
@@ -70,16 +70,14 @@ public class InferFiltersRule implements ExprRewriteRule {
         } 
 
         // slotEqSlotExpr: Record existing and infer equivalent connections
-        List<Expr> slotEqSlotExpr =
-                (clauseType == ExprRewriter.ClauseType.ON_CLAUSE) ? analyzer.getOnSlotEqSlotExpr() : new ArrayList<>();
+        List<Expr> slotEqSlotExpr = analyzer.getOnSlotEqSlotExpr();
 
         // slotEqSlotDeDuplication: De-Duplication for slotEqSlotExpr
         Set<Pair<Expr, Expr>> slotEqSlotDeDuplication =
                 (clauseType == ExprRewriter.ClauseType.ON_CLAUSE) ? analyzer.getOnSlotEqSlotDeDuplication() : Sets.newHashSet();
 
         // slotToLiteralExpr: Record existing and infer expr which slot and literal are equal
-        List<Expr> slotToLiteralExpr =
-                (clauseType == ExprRewriter.ClauseType.ON_CLAUSE) ? analyzer.getOnSlotToLiteralExpr() : new ArrayList<>();
+        List<Expr> slotToLiteralExpr = analyzer.getOnSlotToLiteralExpr();
 
         // slotToLiteralDeDuplication: De-Duplication for slotToLiteralExpr
         Set<Pair<Expr, Expr>> slotToLiteralDeDuplication =
@@ -91,16 +89,14 @@ public class InferFiltersRule implements ExprRewriteRule {
         List<Pair<Expr, Boolean>> newExprWithState = new ArrayList<>();
 
         // isNullExpr: Record existing and infer not null predicate
-        List<Expr> isNullExpr =
-                (clauseType == ExprRewriter.ClauseType.ON_CLAUSE) ? analyzer.getOnIsNullExpr() : new ArrayList<>();
+        List<Expr> isNullExpr = analyzer.getOnIsNullExpr();
 
         // isNullDeDuplication: De-Duplication for isNullExpr
         Set<Expr> isNullDeDuplication =
                 (clauseType == ExprRewriter.ClauseType.ON_CLAUSE) ? analyzer.getOnIsNullDeDuplication() : Sets.newHashSet();
 
         // inExpr: Record existing and infer in predicate
-        List<Expr> inExpr =
-                (clauseType == ExprRewriter.ClauseType.ON_CLAUSE) ? analyzer.getInExpr() : new ArrayList<>();
+        List<Expr> inExpr = analyzer.getInExpr();
 
         // inDeDuplication: De-Duplication for inExpr
         Set<Expr> inDeDuplication =

--- a/fe/fe-core/src/test/java/org/apache/doris/rewrite/InferFiltersRuleTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/rewrite/InferFiltersRuleTest.java
@@ -299,4 +299,25 @@ public class InferFiltersRuleTest {
         Assert.assertTrue(planString.contains("`tb2`.`k1` >= 1"));
         Assert.assertTrue(planString.contains("`tb2`.`k1` <= 2"));
     }
+
+    @Test
+    public void testOnAndWhere2TablesLeftJoin() throws Exception {
+        SessionVariable sessionVariable = dorisAssert.getSessionVariable();
+        sessionVariable.setEnableInferPredicate(true);
+        Assert.assertTrue(sessionVariable.isEnableInferPredicate());
+        String query = "select * from tb1 left join tb2 on tb1.k1 = tb2.k1 where tb2.k1 = 1";
+        String planString = dorisAssert.query(query).explainQuery();
+        Assert.assertTrue(planString.contains("`tb1`.`k1` = 1"));
+    }
+
+    @Test
+    public void testOnAndWhere2TablesInnerJoin() throws Exception {
+        SessionVariable sessionVariable = dorisAssert.getSessionVariable();
+        sessionVariable.setEnableInferPredicate(true);
+        Assert.assertTrue(sessionVariable.isEnableInferPredicate());
+        String query = "select * from tb1 inner join tb2 on tb1.k1 = tb2.k1 where tb2.k1 = 1";
+        String planString = dorisAssert.query(query).explainQuery();
+        Assert.assertTrue(planString.contains("`tb1`.`k1` = 1"));
+    }
+
 }


### PR DESCRIPTION
Fix a bug.
The where condition cannot be pushed down because there is no derivation

eg:
select * from tb1 left join tb2 on tb1.id = tb2.id where tb2.id = 1;

The correct case is that the condition of "=1" needs to be deduced to tb1.id, but the current implementation does not do the deduction

# Proposed changes

Issue Number: close #xxx

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes)
2. Has unit tests been added: (Yes)
3. Has document been added or modified: (No Need)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
