### PR TITLE
[fix] move new add enum OFS of StorageType to last

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/StorageBackend.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/StorageBackend.java
@@ -111,10 +111,9 @@ public class StorageBackend extends StorageDesc implements ParseNode {
     public enum StorageType {
         BROKER("Doris Broker"),
         S3("Amazon S3 Simple Storage Service"),
-        OFS("Tencent CHDFS"),
-        // the following is not used currently
         HDFS("Hadoop Distributed File System"),
-        LOCAL("Local file system");
+        LOCAL("Local file system"),
+        OFS("Tencent CHDFS");
 
         private final String description;
 

--- a/gensrc/thrift/Types.thrift
+++ b/gensrc/thrift/Types.thrift
@@ -95,9 +95,9 @@ enum TTypeNodeType {
 enum TStorageBackendType {
     BROKER,
     S3,
-    OFS,
     HDFS,
-    LOCAL
+    LOCAL,
+    OFS
 }
 
 struct TScalarType {


### PR DESCRIPTION
# Proposed changes

move new add enum OFS of StorageType to last.  Avoid compatibility issues, this is imported at #8963 


## Checklist(Required)

1. Does it affect the original behavior: (No)
2. Has unit tests been added: (No Need)
3. Has document been added or modified: (No Need)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
