### PR TITLE
[fix] fix NPE when initialize GlobalState

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/master/ReportHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/master/ReportHandler.java
@@ -706,7 +706,7 @@ public class ReportHandler extends Daemon {
                                 needDelete = false;
                                 ++addToMetaCounter;
                             } catch (MetaNotFoundException e) {
-                                LOG.warn("failed add to meta. tablet[{}], backend[{}]. {}",
+                                LOG.info("failed add to meta. tablet[{}], backend[{}]. {}",
                                         tabletId, backendId, e.getMessage());
                                 needDelete = true;
                             }
@@ -719,7 +719,7 @@ public class ReportHandler extends Daemon {
                         // drop replica
                         DropReplicaTask task = new DropReplicaTask(backendId, tabletId, backendTabletInfo.getSchemaHash());
                         batchTask.addTask(task);
-                        LOG.warn("delete tablet[" + tabletId + " - " + backendTabletInfo.getSchemaHash()
+                        LOG.info("delete tablet[" + tabletId + " - " + backendTabletInfo.getSchemaHash()
                                 + "] from backend[" + backendId + "] because not found in meta");
                         ++deleteFromBackendCounter;
                     }


### PR DESCRIPTION
# Proposed changes

Introduced from #8695

## Problem Summary:

The context object may be null for StreamLoadPlanner

## Checklist(Required)

1. Does it affect the original behavior: (No)
2. Has unit tests been added: (No Need)
3. Has document been added or modified: (No Need)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
