### PR TITLE
[fix] fix master compile TYPE_DECIMAL_DEPRACTED error

### DIFF
--- a/be/src/util/array_parser.cpp
+++ b/be/src/util/array_parser.cpp
@@ -29,7 +29,6 @@ std::unordered_map<FunctionContext::Type, PrimitiveType> ArrayParser::_types_map
         {FunctionContext::TYPE_LARGEINT, PrimitiveType::TYPE_LARGEINT},
         {FunctionContext::TYPE_FLOAT, PrimitiveType::TYPE_FLOAT},
         {FunctionContext::TYPE_DOUBLE, PrimitiveType::TYPE_DOUBLE},
-        {FunctionContext::TYPE_DECIMAL_DEPRACTED, PrimitiveType::TYPE_DECIMAL_DEPRACTED},
         {FunctionContext::TYPE_DATE, PrimitiveType::TYPE_DATE},
         {FunctionContext::TYPE_DATETIME, PrimitiveType::TYPE_DATETIME},
         {FunctionContext::TYPE_CHAR, PrimitiveType::TYPE_CHAR},


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

TYPE_DECIMAL already deprecated, remove TYPE_DECIMAL_DEPRACTED support in array data type.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
