### PR TITLE
[Enhancement][Unit Test] remove unused parament on run-be-ut.sh

### DIFF
--- a/run-be-ut.sh
+++ b/run-be-ut.sh
@@ -43,7 +43,6 @@ Usage: $0 <options>
      --clean            clean and build ut
      --run              build and run all ut
      --run --filter=xx  build and run specified ut
-     -v                 build and run all vectorized ut
      -j                 build parallel
      -h                 print this help message
 
@@ -79,7 +78,6 @@ fi
 
 CLEAN=0
 RUN=0
-VECTORIZED_ONLY=0
 FILTER=""
 if [ $# != 1 ] ; then
     while true; do 
@@ -87,7 +85,6 @@ if [ $# != 1 ] ; then
             --clean) CLEAN=1 ; shift ;;
             --run) RUN=1 ; shift ;;
             -f | --filter) FILTER="--gtest_filter=$2"; shift 2;;
-            -v) VECTORIZED_ONLY=1 ; shift ;;
             -j) PARALLEL=$2; shift 2 ;;
             --) shift ;  break ;;
             *) usage ; exit 0 ;;
@@ -231,10 +228,6 @@ touch ${UT_TMP_DIR}/tmp_file
 
 # find all executable test files
 
-if [ ${VECTORIZED_ONLY} -eq 1 ]; then
-    echo "Run Vectorized ut only"
-    export DORIS_TEST_BINARY_DIR=${DORIS_TEST_BINARY_DIR}/vec
-fi
 test=${DORIS_TEST_BINARY_DIR}doris_be_test
 file_name=${test##*/}
 if [ -f "$test" ]; then


### PR DESCRIPTION
# Proposed changes

parament `-v` is not work on `run-be-ut.sh` now.

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
