### PR TITLE
[bug-fix] fix two coredump of vec-stream-load

### DIFF
--- a/be/src/olap/memtable.h
+++ b/be/src/olap/memtable.h
@@ -103,10 +103,8 @@ private:
             NullState null_state = is_null ? NullState::IS_NULL : NullState::NOT_NULL;
             return RowCursorCell(ref.data, null_state);
         }
-        ~ RowInBlock(){
-            for( auto place: _agg_places){
-                delete place;
-            }
+        ~RowInBlock() {
+            std::vector<vectorized::AggregateDataPtr>().swap(_agg_places);
         }
     };
     class RowInBlockComparator {

--- a/be/src/vec/aggregate_functions/aggregate_function_window.cpp
+++ b/be/src/vec/aggregate_functions/aggregate_function_window.cpp
@@ -58,7 +58,7 @@ template <template <typename> class AggregateFunctionTemplate, template <typenam
 static IAggregateFunction* create_function_single_value(const String& name,
                                                         const DataTypes& argument_types,
                                                         const Array& parameters) {
-    using StoreType = std::conditional_t<is_copy, CopiedValue, Value>;
+    using StoreType = CopiedValue;
 
     assert_arity_at_most<3>(name, argument_types);
 


### PR DESCRIPTION
# Proposed changes
 **fix two coredump of vec-stream-load**

@HappenLee @zhangstar333 @BiteTheDDDDt @spaces-X

### bug-1:

when stream-load `replace` table data, with varchar(20000) `union_id` as value column

```
CREATE TABLE `test_table_stream_load_vec` (
  `k1` int(11) NULL COMMENT "a",
  `k2` varchar(20000) NULL ,
  `k3` varchar(20000) NULL ,
  `union_id` varchar(20000) REPLACE NULL 
) ENGINE=OLAP
AGGREGATE KEY(`k1`, `k2`, `k3`)
...
```
it will coredump, because `Value` has been free, we need use `CopiedValue ` instead.
```
start time: Mon Apr 11 14:31:42 CST 2022
WARNING: Logging before InitGoogleLogging() is written to STDERR
I0411 14:31:42.030472 179842 env.cpp:46] Env init successfully.
*** Aborted at 1649658858 (unix time) try "date -d @1649658858" if you are using GNU date ***
*** SIGSEGV address not mapped to object (@0x7fc5f64a0d82) received by PID 179842 (TID 0x7fc7869f5700) from PID 18446744073546632578; stack trace: ***
0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /root/zbt/incubator-doris-stream-load-vec/be/src/common/signal_handler.h:420
1# 0x00007FC78CEC4400 in /lib64/[libc.so](http://libc.so/).6
2# memcpy at /root/zbt/incubator-doris-stream-load-vec/be/src/glibc-compatibility/memcpy/memcpy_x86_64.cpp:219
3# doris::vectorized::ColumnString::insert_data(char const*, unsigned long) at /root/zbt/incubator-doris-stream-load-vec/be/src/vec/columns/column_string.h:156
4# doris::vectorized::ColumnNullable::insert_data(char const*, unsigned long) at /root/zbt/incubator-doris-stream-load-vec/be/src/vec/columns/column_nullable.cpp:95
5# doris::MemTable::collect_skiplist_results() at /root/zbt/incubator-doris-stream-load-vec/be/src/olap/memtable.cpp:293
6# doris::MemTable::_vflush() at /root/zbt/incubator-doris-stream-load-vec/be/src/olap/memtable.cpp:332
7# doris::FlushToken::_flush_memtable(std::shared_ptr<doris::MemTable>, long) at /root/zbt/incubator-doris-stream-load-vec/be/src/olap/memtable_flush_executor.cpp:68
```

### bug-2:
destructor of RowInBlock can't clear totally, it will coredump
I prefer way-1 to solve it.

way-1
```
~RowInBlock(){
    std::vector<vectorized::AggregateDataPtr>().swap(_agg_places);
}
```

way-2
```
~RowInBlock(){
    for(auto place: _agg_places){
      delete[] place; 
      // delete place can only delete memory space of place[0]
    }
 }
```




## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
