### PR TITLE
[fix] change parameter type of hll_cardinality from STRING to HLL

### DIFF
--- a/gensrc/script/doris_builtins_functions.py
+++ b/gensrc/script/doris_builtins_functions.py
@@ -1175,7 +1175,7 @@ visible_functions = [
             '', '', 'vec', ''],
 
     #hll function
-    [['hll_cardinality'], 'BIGINT', ['VARCHAR'],
+    [['hll_cardinality'], 'BIGINT', ['HLL'],
         '_ZN5doris12HllFunctions15hll_cardinalityEPN9doris_udf15FunctionContextERKNS1_9StringValE',
         '', '', 'vec', 'ALWAYS_NOT_NULLABLE'],
     [['hll_hash'], 'HLL', ['VARCHAR'],
@@ -1183,9 +1183,6 @@ visible_functions = [
         '', '', 'vec', 'ALWAYS_NOT_NULLABLE'],
     [['hll_empty'], 'HLL', [],
         '_ZN5doris12HllFunctions9hll_emptyEPN9doris_udf15FunctionContextE',
-        '', '', 'vec', 'ALWAYS_NOT_NULLABLE'],
-    [['hll_cardinality'], 'BIGINT', ['STRING'],
-        '_ZN5doris12HllFunctions15hll_cardinalityEPN9doris_udf15FunctionContextERKNS1_9StringValE',
         '', '', 'vec', 'ALWAYS_NOT_NULLABLE'],
     [['hll_hash'], 'HLL', ['STRING'],
         '_ZN5doris12HllFunctions8hll_hashEPN9doris_udf15FunctionContextERKNS1_9StringValE',

--- a/regression-test/data/types/complex_types/basic_agg_test.out
+++ b/regression-test/data/types/complex_types/basic_agg_test.out
@@ -9,3 +9,8 @@
 2	\N
 3	\N
 
+-- !sql_hll_cardinality --
+1	0
+2	1
+3	2
+

--- a/regression-test/suites/types/complex_types/basic_agg_test.groovy
+++ b/regression-test/suites/types/complex_types/basic_agg_test.groovy
@@ -27,4 +27,6 @@ suite("basic_agg_test") {
     qt_sql_bitmap """select * from bitmap_basic_agg;"""
 
     qt_sql_hll """select * from hll_basic_agg;"""
+
+    qt_sql_hll_cardinality """select k1, hll_cardinality(hll_union(k2)) from hll_basic_agg group by k1 order by k1;"""
 }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

In #8882, we disabled the conversion from string to hll. So we need to change the  parameter type of hll_cardinality() too

## Checklist(Required)

1. Does it affect the original behavior: (No)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (No Need)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
