### PR TITLE
[fix](tools) Access denied when creating tpch tables

### DIFF
--- a/tools/tpch-tools/create-tpch-tables.sh
+++ b/tools/tpch-tools/create-tpch-tables.sh
@@ -85,6 +85,7 @@ check_prerequest() {
 check_prerequest "mysql --version" "mysql"
 
 source $CURDIR/doris-cluster.conf
+export MYSQL_PWD=$PASSWORD
 
 echo "FE_HOST: $FE_HOST"
 echo "FE_QUERY_PORT: $FE_QUERY_PORT"
@@ -92,7 +93,7 @@ echo "USER: $USER"
 echo "PASSWORD: $PASSWORD"
 echo "DB: $DB"
 
-mysql -h$FE_HOST -u$USER -p$PASSWORD -P$FE_QUERY_PORT -e "CREATE DATABASE IF NOT EXISTS $DB"
+mysql -h$FE_HOST -u$USER -P$FE_QUERY_PORT -e "CREATE DATABASE IF NOT EXISTS $DB"
 
 echo $CURDIR/create-tpch-tables.sql
-mysql -h$FE_HOST -u$USER -p$PASSWORD -P$FE_QUERY_PORT -D$DB <$CURDIR/create-tpch-tables.sql
+mysql -h$FE_HOST -u$USER -P$FE_QUERY_PORT -D$DB <$CURDIR/create-tpch-tables.sql

--- a/tools/tpch-tools/create-tpch-tables.sh
+++ b/tools/tpch-tools/create-tpch-tables.sh
@@ -92,7 +92,7 @@ echo "USER: $USER"
 echo "PASSWORD: $PASSWORD"
 echo "DB: $DB"
 
-mysql -h$FE_HOST -u$USER -P$FE_QUERY_PORT -e "CREATE DATABASE IF NOT EXISTS $DB"
+mysql -h$FE_HOST -u$USER -p$PASSWORD -P$FE_QUERY_PORT -e "CREATE DATABASE IF NOT EXISTS $DB"
 
 echo $CURDIR/create-tpch-tables.sql
-mysql -h$FE_HOST -u$USER -P$FE_QUERY_PORT -D$DB <$CURDIR/create-tpch-tables.sql
+mysql -h$FE_HOST -u$USER -p$PASSWORD -P$FE_QUERY_PORT -D$DB <$CURDIR/create-tpch-tables.sql

--- a/tools/tpch-tools/run-tpch-queries.sh
+++ b/tools/tpch-tools/run-tpch-queries.sh
@@ -86,6 +86,7 @@ check_prerequest() {
 check_prerequest "mysql --version" "mysql"
 
 source $CURDIR/doris-cluster.conf
+export MYSQL_PWD=$PASSWORD
 
 echo "FE_HOST: $FE_HOST"
 echo "FE_QUERY_PORT: $FE_QUERY_PORT"


### PR DESCRIPTION
# Proposed changes

- Fix the password is not configured when the TPCH tool uses mysql to connect.
- Use `MYSQL_PWD` instead of `-p` to get rid of the warning

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
