### PR TITLE
[fix](load) fix bug of infinite loop in orc scanner

### DIFF
--- a/be/src/exec/orc_scanner.cpp
+++ b/be/src/exec/orc_scanner.cpp
@@ -360,6 +360,11 @@ Status ORCScanner::get_next(Tuple* tuple, MemPool* tuple_pool, bool* eof, bool* 
             *fill_tuple = _success;
             break;
         }
+        if (_scanner_eof) {
+            *eof = true;
+        } else {
+            *eof = false;
+        }
         return Status::OK();
     } catch (orc::ParseError& e) {
         std::stringstream str_error;


### PR DESCRIPTION
# Proposed changes

Issue Number: close #9008

## Problem Summary:

When encounter unqualified data, orc scanner may not be able
to quit correctly.

## Checklist(Required)

1. Does it affect the original behavior: (No)
2. Has unit tests been added: (No Need)
3. Has document been added or modified: (No Need)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
