### PR TITLE
[Enhancement] (image) check image validity as soon as generated

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Catalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Catalog.java
@@ -1950,7 +1950,8 @@ public class Catalog {
     }
 
     // Only called by checkpoint thread
-    public void saveImage() throws IOException {
+    // return the latest image file's absolute path
+    public String saveImage() throws IOException {
         // Write image.ckpt
         Storage storage = new Storage(this.imageDir);
         File curFile = storage.getImageFile(replayedJournalId.get());
@@ -1963,6 +1964,7 @@ public class Catalog {
             curFile.delete();
             throw new IOException();
         }
+        return curFile.getAbsolutePath();
     }
 
     public void saveImage(File curFile, long replayedJournalId) throws IOException {

--- a/fe/fe-core/src/main/java/org/apache/doris/master/Checkpoint.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/master/Checkpoint.java
@@ -35,6 +35,8 @@ import org.apache.doris.system.Frontend;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import com.google.common.base.Strings;
+
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;

--- a/fe/fe-core/src/main/java/org/apache/doris/master/Checkpoint.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/master/Checkpoint.java
@@ -121,6 +121,17 @@ public class Checkpoint extends MasterDaemon {
             catalog.fixBugAfterMetadataReplayed(false);
             catalog.saveImage();
             replayedJournalId = catalog.getReplayedJournalId();
+
+            // destroy checkpoint catalog, reclaim memory
+            catalog = null;
+            Catalog.destroyCheckpoint();
+            destroyStaticFieldForCkpt();
+
+            // Load image to verify if the newly generated image file is valid
+            // If success, do all the following jobs
+            // If failed, just return
+            catalog = Catalog.getCurrentCatalog();
+            catalog.loadImage(imageDir);
             if (MetricRepo.isInit) {
                 MetricRepo.COUNTER_IMAGE_WRITE_SUCCESS.increase(1L);
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/MetaCleaner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/MetaCleaner.java
@@ -70,13 +70,13 @@ public class MetaCleaner {
 
     public void cleanTheLatestInvalidImageFile() throws IOException {
         Storage storage = new Storage(imageDir);
-        long currentVersion = storage.getImageSeq();
-        File currentImage = storage.getImageFile(currentVersion);
-        if (currentImage.exists()) {
-            if (currentImage.delete()) {
-                LOG.info(currentImage.getAbsoluteFile() + " deleted.");
+        long latestVersion = storage.getImageSeq();
+        File latestInvalidImage = storage.getImageFile(latestVersion);
+        if (latestInvalidImage.exists()) {
+            if (latestInvalidImage.delete()) {
+                LOG.info(latestInvalidImage.getAbsoluteFile() + " deleted.");
             } else {
-                LOG.warn(currentImage.getAbsoluteFile() + " delete failed.");
+                LOG.warn(latestInvalidImage.getAbsoluteFile() + " delete failed.");
             }
         }
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/MetaCleaner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/MetaCleaner.java
@@ -68,10 +68,8 @@ public class MetaCleaner {
         }
     }
 
-    public void cleanTheLatestInvalidImageFile() throws IOException {
-        Storage storage = new Storage(imageDir);
-        long latestVersion = storage.getImageSeq();
-        File latestInvalidImage = storage.getImageFile(latestVersion);
+    public void cleanTheLatestInvalidImageFile(String path) throws IOException {
+        File latestInvalidImage = new File(path);
         if (latestInvalidImage.exists()) {
             if (latestInvalidImage.delete()) {
                 LOG.info(latestInvalidImage.getAbsoluteFile() + " deleted.");

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/MetaCleaner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/MetaCleaner.java
@@ -67,6 +67,19 @@ public class MetaCleaner {
             }
         }
     }
+
+    public void cleanTheLatestInvalidImageFile() throws IOException {
+        Storage storage = new Storage(imageDir);
+        long currentVersion = storage.getImageSeq();
+        File currentImage = storage.getImageFile(currentVersion);
+        if (currentImage.exists()) {
+            if (currentImage.delete()) {
+                LOG.info(currentImage.getAbsoluteFile() + " deleted.");
+            } else {
+                LOG.warn(currentImage.getAbsoluteFile() + " delete failed.");
+            }
+        }
+    }
     
     private String fileType(File file) throws IOException {
         String type = null;


### PR DESCRIPTION
load newly generated image file as soon as generated to check if it is valid.

# Proposed changes

Issue Number: close #9010 

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes)
2. Has unit tests been added: (No Need)
3. Has document been added or modified: (No Need)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
