### PR TITLE
[Bug][Vectorized] Fix UB when doing ORDER BY.

### DIFF
--- a/be/src/vec/core/sort_cursor.h
+++ b/be/src/vec/core/sort_cursor.h
@@ -222,7 +222,7 @@ struct SortBlockCursor {
     }
 
     /// Inverted so that the priority queue elements are removed in ascending order.
-    bool operator<(const SortBlockCursor& rhs) const { return less_at(rhs, impl->rows - 1) >= 0; }
+    bool operator<(const SortBlockCursor& rhs) const { return less_at(rhs, impl->rows - 1) == 1; }
 };
 
 } // namespace doris::vectorized


### PR DESCRIPTION
priority_queue needs strict weak ordering, or else it's UB.