### PR TITLE
[fix][doc]fix max_send_batch_parallelism_per_job default value

### DIFF
--- a/docs/en/administrator-guide/config/be_config.md
+++ b/docs/en/administrator-guide/config/be_config.md
@@ -808,7 +808,7 @@ Max number of txns for every txn_partition_map in txn manager, this is a self pr
 
 * Type: int
 * Description: Max send batch parallelism for OlapTableSink. The value set by the user for `send_batch_parallelism` is not allowed to exceed `max_send_batch_parallelism_per_job`, if exceed, the value of `send_batch_parallelism` would be `max_send_batch_parallelism_per_job`.
-* Default value: 1
+* Default value: 5
 
 ### `max_tablet_num_per_shard`
 

--- a/docs/zh-CN/administrator-guide/config/be_config.md
+++ b/docs/zh-CN/administrator-guide/config/be_config.md
@@ -809,7 +809,7 @@ txn 管理器中每个 txn_partition_map 的最大 txns 数，这是一种自我
 
 * 类型：int
 * 描述：OlapTableSink 发送批处理数据的最大并行度，用户为 `send_batch_parallelism` 设置的值不允许超过 `max_send_batch_parallelism_per_job` ，如果超过， `send_batch_parallelism` 将被设置为 `max_send_batch_parallelism_per_job` 的值。
-* 默认值：1
+* 默认值：5
 
 ### `max_tablet_num_per_shard`
 

--- a/new-docs/en/admin-manual/config/be-config.md
+++ b/new-docs/en/admin-manual/config/be-config.md
@@ -808,7 +808,7 @@ Max number of txns for every txn_partition_map in txn manager, this is a self pr
 
 * Type: int
 * Description: Max send batch parallelism for OlapTableSink. The value set by the user for `send_batch_parallelism` is not allowed to exceed `max_send_batch_parallelism_per_job`, if exceed, the value of `send_batch_parallelism` would be `max_send_batch_parallelism_per_job`.
-* Default value: 1
+* Default value: 5
 
 ### `max_tablet_num_per_shard`
 

--- a/new-docs/zh-CN/admin-manual/config/be-config.md
+++ b/new-docs/zh-CN/admin-manual/config/be-config.md
@@ -809,7 +809,7 @@ txn 管理器中每个 txn_partition_map 的最大 txns 数，这是一种自我
 
 * 类型：int
 * 描述：OlapTableSink 发送批处理数据的最大并行度，用户为 `send_batch_parallelism` 设置的值不允许超过 `max_send_batch_parallelism_per_job` ，如果超过， `send_batch_parallelism` 将被设置为 `max_send_batch_parallelism_per_job` 的值。
-* 默认值：1
+* 默认值：5
 
 ### `max_tablet_num_per_shard`
 


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

The default value of the configuration item max_send_batch_parallelism_per_job in the documentation is different from that in the code.

https://github.com/apache/incubator-doris/blob/master/be/src/common/config.h#L658

## Checklist(Required)

1. Does it affect the original behavior: (No)
2. Has unit tests been added: (No)
3. Has document been added or modified: (Yes)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
