### PR TITLE
[Improvement] Remove redundant imports

### DIFF
--- a/fe/checkstyle.xml
+++ b/fe/checkstyle.xml
@@ -29,5 +29,12 @@
     <module name="TreeWalker">
         <module name="AvoidStarImport"/>
         <module name="UnusedImports"/>
+
+        <module name="RedundantImport">
+            <property name="severity" value="error"/>
+            <message key="import.redundancy" value="Redundant import {0}."/>
+        </module>
+
+        <module name="EmptyStatement"/>
     </module>
 </module>

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/AggregateInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/AggregateInfo.java
@@ -79,7 +79,7 @@ public final class AggregateInfo extends AggregateInfoBase {
         SECOND_MERGE;
 
         public boolean isMerge() { return this == FIRST_MERGE || this == SECOND_MERGE; }
-    };
+    }
 
     // created by createMergeAggInfo()
     private AggregateInfo mergeAggInfo_;

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/StmtRewriter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/StmtRewriter.java
@@ -327,7 +327,7 @@ public class StmtRewriter {
     private static boolean hasSubqueryInDisjunction(Expr expr) {
         if (!(expr instanceof CompoundPredicate)) {
             return false;
-        };
+        }
         if (Expr.IS_OR_PREDICATE.apply(expr)) {
             return expr.contains(Subquery.class);
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/CatalogRecycleBin.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/CatalogRecycleBin.java
@@ -439,7 +439,7 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
         if (partitionInfo.getType() == PartitionType.RANGE) {
             recoverItem = new RangePartitionItem(recoverRange);
         } else if (partitionInfo.getType() == PartitionType.LIST) {
-            recoverItem = recoverPartitionInfo.getListPartitionItem();;
+            recoverItem = recoverPartitionInfo.getListPartitionItem();
         }
         // check if partition item is invalid
         if (partitionInfo.getAnyIntersectItem(recoverItem, false) != null) {

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Function.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Function.java
@@ -622,7 +622,7 @@ public class Function implements Writable {
         public static FunctionType read(DataInput input) throws IOException {
             return fromCode(input.readInt());
         }
-    };
+    }
 
     protected void writeFields(DataOutput output) throws IOException {
         output.writeLong(id);

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/HashDistributionInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/HashDistributionInfo.java
@@ -142,7 +142,7 @@ public class HashDistributionInfo extends DistributionInfo {
         }
         builder.append("]; ");
 
-        builder.append("bucket num: ").append(bucketNum).append("; ");;
+        builder.append("bucket num: ").append(bucketNum).append("; ");
 
         return builder.toString();
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/ShowAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/ShowAction.java
@@ -158,7 +158,7 @@ public class ShowAction extends RestBaseController {
              parentThread.getParent() != null;
              parentThread = parentThread.getParent()) {
         }
-        ;
+
         feInfo.put("thread_cnt", String.valueOf(parentThread.activeCount()));
 
         return ResponseEntityBuilder.ok(feInfo);

--- a/fe/fe-core/src/main/java/org/apache/doris/load/LoadJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/LoadJob.java
@@ -489,7 +489,6 @@ public class LoadJob implements Writable {
     public void setHadoopEtlJobId(String etlJobId) {
         if (etlJobType == EtlJobType.HADOOP) {
             ((HadoopEtlJobInfo) etlJobInfo).setEtlJobId(etlJobId);
-            ;
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/BulkLoadJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/BulkLoadJob.java
@@ -55,10 +55,6 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 
-import org.apache.commons.lang.StringUtils;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;

--- a/fe/fe-core/src/main/java/org/apache/doris/metric/Metric.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/metric/Metric.java
@@ -41,7 +41,7 @@ public abstract class Metric<T> {
         CONNECTIONS,
         PACKETS,
         NOUNIT
-    };
+    }
 
     protected String name;
     protected MetricType type;

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/PartitionPruner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/PartitionPruner.java
@@ -24,4 +24,4 @@ import java.util.Collection;
 public interface PartitionPruner {
     // return partition after pruning
     Collection<Long> prune() throws AnalysisException;
-};
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/QueryDetail.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/QueryDetail.java
@@ -23,7 +23,7 @@ public class QueryDetail {
         FINISHED,
         FAILED,
         CANCELLED 
-    };
+    }
 
     // When query received, FE will construct a QueryDetail
     // object. This object will set queryId, startTime, sql

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/QueryDetailQueue.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/QueryDetailQueue.java
@@ -23,7 +23,6 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import org.apache.doris.qe.QueryDetail;
 
 // Queue of QueryDetail.
 // It's used to collect queries for monitor.

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/cache/PartitionRange.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/cache/PartitionRange.java
@@ -562,7 +562,7 @@ public class PartitionRange {
             return null;
         }
         PartitionColumnFilter partitionColumnFilter = new PartitionColumnFilter();
-        ;
+
         for (Expr expr : partitionKeyPredicate.getChildren()) {
             if (expr instanceof BinaryPredicate) {
                 BinaryPredicate binPredicate = (BinaryPredicate) expr;

--- a/fe/spark-dpp/src/main/java/org/apache/doris/load/loadv2/dpp/SparkDpp.java
+++ b/fe/spark-dpp/src/main/java/org/apache/doris/load/loadv2/dpp/SparkDpp.java
@@ -455,7 +455,7 @@ public final class SparkDpp implements java.io.Serializable {
                     if(!validateData(columnObject, baseIndex.getColumn(columnName), parsers.get(i), row)) {
                         abnormalRowAcc.add(1);
                         return result.iterator();
-                    };
+                    }
                     keyColumns.add(columnObject);
                 }
 
@@ -465,7 +465,7 @@ public final class SparkDpp implements java.io.Serializable {
                     if(!validateData(columnObject,  baseIndex.getColumn(columnName), parsers.get(i + keyColumnNames.size()),row)) {
                         abnormalRowAcc.add(1);
                         return result.iterator();
-                    };
+                    }
                     valueColumns.add(columnObject);
                 }
 


### PR DESCRIPTION
# Proposed changes

Add `RedundantImport` `EmptyStatement` style rule.

RedundantImport: Checks for redundant import statements. An import statement is considered redundant.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
