### PR TITLE
[fix](partition) Fix wrong partition distribution key info for random hash olap table

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/proc/PartitionsProcDir.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/proc/PartitionsProcDir.java
@@ -260,7 +260,7 @@ public class PartitionsProcDir implements ProcDirInterface {
                     }
                     partitionInfo.add(sb.toString());
                 } else {
-                    partitionInfo.add("ALL KEY");
+                    partitionInfo.add("RANDOM");
                 }
 
                 partitionInfo.add(distributionInfo.getBucketNum());


### PR DESCRIPTION
# Proposed changes

Issue Number: close #9103 

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
