### PR TITLE
[fix](cache) Generate md5 value using utf8 encoding for sqlkey string

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/cache/CacheProxy.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/cache/CacheProxy.java
@@ -25,6 +25,7 @@ import org.apache.doris.proto.Types;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 
 /**
@@ -67,13 +68,15 @@ public abstract class CacheProxy {
 
     public static Types.PUniqueId getMd5(String str) {
         MessageDigest msgDigest;
+        final byte[] digest;
         try {
             //128 bit
             msgDigest = MessageDigest.getInstance("MD5");
+            digest = msgDigest.digest(str.getBytes(StandardCharsets.UTF_8));
         } catch (Exception e) {
             return null;
         }
-        final byte[] digest = msgDigest.digest(str.getBytes());
+
         Types.PUniqueId key = Types.PUniqueId.newBuilder()
                 .setLo(getLongFromByte(digest, 0))
                 .setHi(getLongFromByte(digest, 8))

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/cache/SqlCache.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/cache/SqlCache.java
@@ -22,6 +22,7 @@ import org.apache.doris.common.Status;
 import org.apache.doris.common.util.DebugUtil;
 import org.apache.doris.metric.MetricRepo;
 import org.apache.doris.proto.InternalService;
+import org.apache.doris.proto.Types;
 import org.apache.doris.qe.RowBatch;
 import org.apache.doris.thrift.TUniqueId;
 
@@ -42,6 +43,11 @@ public class SqlCache extends Cache {
 
     public String getSqlWithViewStmt() {
         return selectStmt.toSql() + "|" + allViewExpandStmtListStr;
+    }
+
+    // only used for UT
+    public Types.PUniqueId getSqlKey() {
+        return CacheProxy.getMd5(getSqlWithViewStmt());
     }
 
     public InternalService.PFetchCacheResult getCacheData(Status status) {


### PR DESCRIPTION
# Proposed changes

Issue Number: close #9120 
- Generate md5 value using utf8 encoding for sqlkey string
- Fix FE UT

## Problem Summary:

The current Chinese character strings with the same length and different contents have the same md5 value after encoding, which will cause different SQLs to generate the same cache key and hit the same cache.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
