### PR TITLE
[fix] Fix a compatibility problem caused by using a non-existent database when connecting via mysql client

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/MysqlProto.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/MysqlProto.java
@@ -282,6 +282,7 @@ public class MysqlProto {
                 String dbFullName = ClusterNamespace.getFullName(context.getClusterName(), db);
                 Catalog.getCurrentCatalog().changeDb(context, dbFullName);
             } catch (DdlException e) {
+                context.getState().setError(e.getMysqlErrorCode(), e.getMessage());
                 sendResponsePacket(context);
                 return false;
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectProcessor.java
@@ -91,7 +91,7 @@ public class ConnectProcessor {
         try {
             ctx.getCatalog().changeDb(ctx, dbName);
         } catch (DdlException e) {
-            ctx.getState().setError(e.getMessage());
+            ctx.getState().setError(e.getMysqlErrorCode(), e.getMessage());
             return;
         }
 


### PR DESCRIPTION
# Proposed changes

Fix a compatibility problem caused by using a non-existent database when connecting via mysql client

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (No)
2. Has unit tests been added: (No Need)
3. Has document been added or modified: (No Need)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
