### PR TITLE
[fix](spark load) fix `getHashValue` of string type is always zero in…

### DIFF
--- a/fe/spark-dpp/src/main/java/org/apache/doris/load/loadv2/dpp/DppUtils.java
+++ b/fe/spark-dpp/src/main/java/org/apache/doris/load/loadv2/dpp/DppUtils.java
@@ -182,7 +182,10 @@ public class DppUtils {
             byte value = (byte) (b ? 1 : 0);
             buffer.put(value);
         }
-        buffer.flip();
+        // do not flip buffer when the buffer was created by wrap()
+        if (!type.equals(DataTypes.StringType)) {
+            buffer.flip();
+        }
         return buffer;
     }
 


### PR DESCRIPTION
# Proposed changes

close #9135 

This bug was introduced from #6087

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (No)
2. Has unit tests been added: (No Need)
3. Has document been added or modified: (No Need)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
