### PR TITLE
[feature-wip] (memory tracker) (step5) Fix track bthread, fix track vectorized query

### DIFF
--- a/be/src/common/utils.h
+++ b/be/src/common/utils.h
@@ -21,7 +21,9 @@
 
 namespace doris {
 
+#ifndef ARRAY_SIZE
 #define ARRAY_SIZE(a) (sizeof(a)/sizeof((a)[0]))
+#endif
 
 struct AuthInfo {
     std::string user;

--- a/be/src/exec/exchange_node.cpp
+++ b/be/src/exec/exchange_node.cpp
@@ -80,6 +80,7 @@ Status ExchangeNode::prepare(RuntimeState* state) {
 Status ExchangeNode::open(RuntimeState* state) {
     SCOPED_TIMER(_runtime_profile->total_time_counter());
     SCOPED_SWITCH_TASK_THREAD_LOCAL_MEM_TRACKER(mem_tracker());
+    ADD_THREAD_LOCAL_MEM_TRACKER(_stream_recvr->mem_tracker());
     RETURN_IF_ERROR(ExecNode::open(state));
     if (_is_merging) {
         RETURN_IF_ERROR(_sort_exec_exprs.open(state));
@@ -215,7 +216,6 @@ Status ExchangeNode::get_next_merging(RuntimeState* state, RowBatch* output_batc
     RETURN_IF_CANCELLED(state);
     RETURN_IF_ERROR(state->check_query_state("Exchange, while merging next."));
 
-    ADD_THREAD_LOCAL_MEM_TRACKER(_stream_recvr->mem_tracker());
     RETURN_IF_ERROR(_stream_recvr->get_next(output_batch, eos));
     while ((_num_rows_skipped < _offset)) {
         _num_rows_skipped += output_batch->num_rows();

--- a/be/src/exec/olap_scanner.cpp
+++ b/be/src/exec/olap_scanner.cpp
@@ -52,7 +52,7 @@ OlapScanner::OlapScanner(RuntimeState* runtime_state, OlapScanNode* parent, bool
           _version(-1),
           _mem_tracker(MemTracker::create_tracker(
                   tracker->limit(),
-                  tracker->label() + ":OlapScanner:" + thread_local_ctx.get()->thread_id_str(),
+                  tracker->label() + ":OlapScanner:" + tls_ctx()->thread_id_str(),
                   tracker)) {}
 
 Status OlapScanner::prepare(

--- a/be/src/exec/tablet_sink.cpp
+++ b/be/src/exec/tablet_sink.cpp
@@ -50,7 +50,7 @@ NodeChannel::NodeChannel(OlapTableSink* parent, IndexChannel* index_channel, int
         _tuple_data_buffer_ptr = &_tuple_data_buffer;
     }
     _node_channel_tracker =
-            MemTracker::create_tracker(-1, "NodeChannel" + thread_local_ctx.get()->thread_id_str());
+            MemTracker::create_tracker(-1, "NodeChannel" + tls_ctx()->thread_id_str());
 }
 
 NodeChannel::~NodeChannel() noexcept {
@@ -654,6 +654,7 @@ void IndexChannel::add_row(BlockRow& block_row, int64_t tablet_id) {
 
 void IndexChannel::mark_as_failed(int64_t node_id, const std::string& host, const std::string& err,
                                   int64_t tablet_id) {
+    SCOPED_SWITCH_THREAD_LOCAL_MEM_TRACKER(_index_channel_tracker);
     const auto& it = _tablets_by_channel.find(node_id);
     if (it == _tablets_by_channel.end()) {
         return;

--- a/be/src/exec/tablet_sink.h
+++ b/be/src/exec/tablet_sink.h
@@ -33,6 +33,7 @@
 #include "exec/tablet_info.h"
 #include "gen_cpp/Types_types.h"
 #include "gen_cpp/internal_service.pb.h"
+#include "runtime/thread_context.h"
 #include "util/bitmap.h"
 #include "util/countdown_latch.h"
 #include "util/ref_count_closure.h"
@@ -325,6 +326,7 @@ public:
 
     void for_each_node_channel(
             const std::function<void(const std::shared_ptr<NodeChannel>&)>& func) {
+        SCOPED_SWITCH_THREAD_LOCAL_MEM_TRACKER(_index_channel_tracker);
         for (auto& it : _node_channels) {
             func(it.second);
         }
@@ -365,7 +367,7 @@ private:
     std::unordered_map<int64_t, std::string> _failed_channels_msgs;
     Status _intolerable_failure_status = Status::OK();
 
-    std::shared_ptr<MemTracker> _index_channel_tracker; // TODO(zxy) use after
+    std::shared_ptr<MemTracker> _index_channel_tracker;
 };
 
 // Write data to Olap Table.

--- a/be/src/olap/byte_buffer.cpp
+++ b/be/src/olap/byte_buffer.cpp
@@ -20,6 +20,7 @@
 #include <sys/mman.h>
 
 #include "olap/utils.h"
+#include "runtime/thread_context.h"
 
 namespace doris {
 
@@ -42,6 +43,8 @@ void StorageByteBuffer::BufDeleter::operator()(char* p) {
         if (0 != munmap(p, _mmap_length)) {
             LOG(FATAL) << "fail to munmap: mem=" << p << ", len=" << _mmap_length
                        << ", errno=" << Errno::no() << ", errno_str=" << Errno::str();
+        } else {
+            RELEASE_THREAD_LOCAL_MEM_TRACKER(_mmap_length);
         }
     } else {
         delete[] p;
@@ -93,6 +96,7 @@ StorageByteBuffer* StorageByteBuffer::reference_buffer(StorageByteBuffer* refere
 
 StorageByteBuffer* StorageByteBuffer::mmap(void* start, uint64_t length, int prot, int flags,
                                            int fd, uint64_t offset) {
+    CONSUME_THREAD_LOCAL_MEM_TRACKER(length);
     char* memory = (char*)::mmap(start, length, prot, flags, fd, offset);
 
     if (MAP_FAILED == memory) {
@@ -128,6 +132,7 @@ StorageByteBuffer* StorageByteBuffer::mmap(FileHandler* handler, uint64_t offset
 
     size_t length = handler->length();
     int fd = handler->fd();
+    CONSUME_THREAD_LOCAL_MEM_TRACKER(length);
     char* memory = (char*)::mmap(nullptr, length, prot, flags, fd, offset);
 
     if (MAP_FAILED == memory) {
@@ -173,7 +178,7 @@ Status StorageByteBuffer::put(uint64_t index, char src) {
 }
 
 Status StorageByteBuffer::put(const char* src, uint64_t src_size, uint64_t offset,
-                                  uint64_t length) {
+                              uint64_t length) {
     //没有足够的空间可以写
     if (length > remaining()) {
         return Status::OLAPInternalError(OLAP_ERR_BUFFER_OVERFLOW);

--- a/be/src/olap/byte_buffer.cpp
+++ b/be/src/olap/byte_buffer.cpp
@@ -101,6 +101,7 @@ StorageByteBuffer* StorageByteBuffer::mmap(void* start, uint64_t length, int pro
 
     if (MAP_FAILED == memory) {
         OLAP_LOG_WARNING("fail to mmap. [errno='%d' errno_str='%s']", Errno::no(), Errno::str());
+        RELEASE_THREAD_LOCAL_MEM_TRACKER(length);
         return nullptr;
     }
 
@@ -112,6 +113,7 @@ StorageByteBuffer* StorageByteBuffer::mmap(void* start, uint64_t length, int pro
     if (nullptr == buf) {
         deleter(memory);
         OLAP_LOG_WARNING("fail to allocate StorageByteBuffer.");
+        RELEASE_THREAD_LOCAL_MEM_TRACKER(length);
         return nullptr;
     }
 
@@ -137,6 +139,7 @@ StorageByteBuffer* StorageByteBuffer::mmap(FileHandler* handler, uint64_t offset
 
     if (MAP_FAILED == memory) {
         OLAP_LOG_WARNING("fail to mmap. [errno='%d' errno_str='%s']", Errno::no(), Errno::str());
+        RELEASE_THREAD_LOCAL_MEM_TRACKER(length);
         return nullptr;
     }
 
@@ -148,6 +151,7 @@ StorageByteBuffer* StorageByteBuffer::mmap(FileHandler* handler, uint64_t offset
     if (nullptr == buf) {
         deleter(memory);
         OLAP_LOG_WARNING("fail to allocate StorageByteBuffer.");
+        RELEASE_THREAD_LOCAL_MEM_TRACKER(length);
         return nullptr;
     }
 

--- a/be/src/olap/lru_cache.cpp
+++ b/be/src/olap/lru_cache.cpp
@@ -475,8 +475,7 @@ Cache::Handle* ShardedLRUCache::insert(const CacheKey& key, void* value, size_t 
                                        CachePriority priority) {
     // The memory of the parameter value should be recorded in the tls mem tracker,
     // transfer the memory ownership of the value to ShardedLRUCache::_mem_tracker.
-    thread_local_ctx.get()->_thread_mem_tracker_mgr->mem_tracker()->transfer_to(_mem_tracker.get(),
-                                                                                charge);
+    tls_ctx()->_thread_mem_tracker_mgr->mem_tracker()->transfer_to(_mem_tracker.get(), charge);
     SCOPED_SWITCH_THREAD_LOCAL_MEM_TRACKER(_mem_tracker);
     const uint32_t hash = _hash_slice(key);
     return _shards[_shard(hash)]->insert(key, hash, value, charge, deleter, priority);

--- a/be/src/olap/out_stream.cpp
+++ b/be/src/olap/out_stream.cpp
@@ -25,7 +25,7 @@
 namespace doris {
 
 OutStreamFactory::OutStreamFactory(CompressKind compress_kind, uint32_t stream_buffer_size)
-        : _compress_kind(compress_kind), _stream_buffer_size(stream_buffer_size) {
+        : _stream_buffer_size(stream_buffer_size) {
     switch (compress_kind) {
     case COMPRESS_NONE:
         _compressor = nullptr;

--- a/be/src/olap/out_stream.h
+++ b/be/src/olap/out_stream.h
@@ -141,7 +141,6 @@ public:
 
 private:
     std::map<StreamName, OutStream*> _streams; // All created streams
-    CompressKind _compress_kind;
     Compressor _compressor;
     uint32_t _stream_buffer_size;
 

--- a/be/src/olap/rowset/column_writer.cpp
+++ b/be/src/olap/rowset/column_writer.cpp
@@ -488,8 +488,7 @@ void ByteColumnWriter::record_position() {
 
 IntegerColumnWriter::IntegerColumnWriter(uint32_t column_id, uint32_t unique_column_id,
                                          OutStreamFactory* stream_factory, bool is_singed)
-        : _column_id(column_id),
-          _unique_column_id(unique_column_id),
+        : _unique_column_id(unique_column_id),
           _stream_factory(stream_factory),
           _writer(nullptr),
           _is_signed(is_singed) {}

--- a/be/src/olap/rowset/column_writer.h
+++ b/be/src/olap/rowset/column_writer.h
@@ -179,7 +179,6 @@ public:
     Status flush() { return _writer->flush(); }
 
 private:
-    uint32_t _column_id;
     uint32_t _unique_column_id;
     OutStreamFactory* _stream_factory;
     RunLengthIntegerWriter* _writer;

--- a/be/src/olap/rowset/segment_v2/segment.cpp
+++ b/be/src/olap/rowset/segment_v2/segment.cpp
@@ -51,10 +51,9 @@ Segment::Segment(const FilePathDesc& path_desc, uint32_t segment_id,
                  const TabletSchema* tablet_schema)
         : _path_desc(path_desc), _segment_id(segment_id), _tablet_schema(tablet_schema) {
 #ifndef BE_TEST
-    _mem_tracker = MemTracker::create_virtual_tracker(
-            -1, "Segment", StorageEngine::instance()->tablet_mem_tracker());
+    _mem_tracker = StorageEngine::instance()->tablet_mem_tracker();
 #else
-    _mem_tracker = MemTracker::create_virtual_tracker(-1, "Segment");
+    _mem_tracker = MemTracker::get_process_tracker();
 #endif
 }
 

--- a/be/src/runtime/bufferpool/system_allocator.cc
+++ b/be/src/runtime/bufferpool/system_allocator.cc
@@ -22,6 +22,7 @@
 
 #include "common/config.h"
 #include "gutil/strings/substitute.h"
+#include "runtime/thread_context.h"
 #include "util/bit_util.h"
 #include "util/error_util.h"
 
@@ -75,6 +76,7 @@ Status SystemAllocator::AllocateViaMMap(int64_t len, uint8_t** buffer_mem) {
         // Map an extra huge page so we can fix up the alignment if needed.
         map_len += HUGE_PAGE_SIZE;
     }
+    CONSUME_THREAD_LOCAL_MEM_TRACKER(map_len);
     uint8_t* mem = reinterpret_cast<uint8_t*>(
             mmap(nullptr, map_len, PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_PRIVATE, -1, 0));
     if (mem == MAP_FAILED) {
@@ -89,10 +91,12 @@ Status SystemAllocator::AllocateViaMMap(int64_t len, uint8_t** buffer_mem) {
         if (misalignment != 0) {
             uintptr_t fixup = HUGE_PAGE_SIZE - misalignment;
             munmap(mem, fixup);
+            RELEASE_THREAD_LOCAL_MEM_TRACKER(fixup);
             mem += fixup;
             map_len -= fixup;
         }
         munmap(mem + len, map_len - len);
+        RELEASE_THREAD_LOCAL_MEM_TRACKER(map_len - len);
         DCHECK_EQ(reinterpret_cast<uintptr_t>(mem) % HUGE_PAGE_SIZE, 0) << mem;
         // Mark the buffer as a candidate for promotion to huge pages. The Linux Transparent
         // Huge Pages implementation will try to back the memory with a huge page if it is
@@ -142,6 +146,7 @@ Status SystemAllocator::AllocateViaMalloc(int64_t len, uint8_t** buffer_mem) {
 void SystemAllocator::Free(BufferPool::BufferHandle&& buffer) {
     if (config::mmap_buffers) {
         int rc = munmap(buffer.data(), buffer.len());
+        RELEASE_THREAD_LOCAL_MEM_TRACKER(buffer.len());
         DCHECK_EQ(rc, 0) << "Unexpected munmap() error: " << errno;
     } else {
         bool use_huge_pages = buffer.len() % HUGE_PAGE_SIZE == 0 && config::madvise_huge_pages;

--- a/be/src/runtime/bufferpool/system_allocator.cc
+++ b/be/src/runtime/bufferpool/system_allocator.cc
@@ -80,6 +80,7 @@ Status SystemAllocator::AllocateViaMMap(int64_t len, uint8_t** buffer_mem) {
     uint8_t* mem = reinterpret_cast<uint8_t*>(
             mmap(nullptr, map_len, PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_PRIVATE, -1, 0));
     if (mem == MAP_FAILED) {
+        RELEASE_THREAD_LOCAL_MEM_TRACKER(map_len);
         return Status::BufferAllocFailed("mmap failed");
     }
 

--- a/be/src/runtime/disk_io_mgr.cc
+++ b/be/src/runtime/disk_io_mgr.cc
@@ -220,7 +220,7 @@ void DiskIoMgr::BufferDescriptor::reset(RequestContext* reader, ScanRange* range
     _eosr = false;
     _status = Status::OK();
     // Consume in the tls mem tracker when the buffer is allocated.
-    _buffer_mem_tracker = thread_local_ctx.get()->_thread_mem_tracker_mgr->mem_tracker().get();
+    _buffer_mem_tracker = tls_ctx()->_thread_mem_tracker_mgr->mem_tracker().get();
 }
 
 void DiskIoMgr::BufferDescriptor::return_buffer() {
@@ -739,7 +739,7 @@ char* DiskIoMgr::get_free_buffer(int64_t* buffer_size) {
         buffer = new char[*buffer_size];
     } else {
         // This means the buffer's memory ownership is transferred from DiskIoMgr to tls tracker.
-        _mem_tracker->transfer_to(thread_local_ctx.get()->_thread_mem_tracker_mgr->mem_tracker().get(), *buffer_size);
+        _mem_tracker->transfer_to(tls_ctx()->_thread_mem_tracker_mgr->mem_tracker().get(), *buffer_size);
         buffer = _free_buffers[idx].front();
         _free_buffers[idx].pop_front();
     }
@@ -767,7 +767,7 @@ void DiskIoMgr::gc_io_buffers(int64_t bytes_to_free) {
     // The deleted buffer is released in the tls mem tracker, the deleted buffer belongs to DiskIoMgr,
     // so the freed memory should be recorded in the DiskIoMgr mem tracker. So if the tls mem tracker
     // and the DiskIoMgr tracker are different, transfer memory ownership.
-    _mem_tracker->transfer_to(thread_local_ctx.get()->_thread_mem_tracker_mgr->mem_tracker().get(), bytes_freed);
+    _mem_tracker->transfer_to(tls_ctx()->_thread_mem_tracker_mgr->mem_tracker().get(), bytes_freed);
 }
 
 void DiskIoMgr::return_free_buffer(BufferDescriptor* desc) {
@@ -793,7 +793,7 @@ void DiskIoMgr::return_free_buffer(char* buffer, int64_t buffer_size, MemTracker
         // The deleted buffer is released in the tls mem tracker. When the buffer was allocated,
         // it was consumed in BufferDescriptor->buffer_mem_tracker, so if the tls mem tracker and
         // the tracker in the parameters are different, transfer memory ownership.
-        tracker->transfer_to(thread_local_ctx.get()->_thread_mem_tracker_mgr->mem_tracker().get(), buffer_size);
+        tracker->transfer_to(tls_ctx()->_thread_mem_tracker_mgr->mem_tracker().get(), buffer_size);
     }
 }
 

--- a/be/src/runtime/fold_constant_executor.cpp
+++ b/be/src/runtime/fold_constant_executor.cpp
@@ -44,6 +44,7 @@ TUniqueId FoldConstantExecutor::_dummy_id;
 
 Status FoldConstantExecutor::fold_constant_expr(
         const TFoldConstantParams& params, PConstantExprResult* response) {
+    SCOPED_SWITCH_THREAD_LOCAL_MEM_TRACKER(_mem_tracker);
     const auto& expr_map = params.expr_map;
     auto expr_result_map = response->mutable_expr_result_map();
 
@@ -53,7 +54,6 @@ Status FoldConstantExecutor::fold_constant_expr(
     if (UNLIKELY(!status.ok())) {
         return status;
     }
-    SCOPED_SWITCH_THREAD_LOCAL_MEM_TRACKER(_mem_tracker);
 
     for (const auto& m : expr_map) {
         PExprResultMap pexpr_result_map;

--- a/be/src/runtime/fragment_mgr.cpp
+++ b/be/src/runtime/fragment_mgr.cpp
@@ -467,8 +467,7 @@ void FragmentMgr::_exec_actual(std::shared_ptr<FragmentExecState> exec_state, Fi
             .instance_id(exec_state->fragment_instance_id())
             .tag("pthread_id", std::to_string((uintptr_t)pthread_self()));
 #ifndef BE_TEST
-    SCOPED_ATTACH_TASK_THREAD(exec_state->executor()->runtime_state()->query_type(),
-                              print_id(exec_state->query_id()), exec_state->fragment_instance_id(),
+    SCOPED_ATTACH_TASK_THREAD(exec_state->executor()->runtime_state(),
                               exec_state->executor()->runtime_state()->instance_mem_tracker());
 #endif
     exec_state->execute();

--- a/be/src/runtime/mem_pool.cpp
+++ b/be/src/runtime/mem_pool.cpp
@@ -65,7 +65,7 @@ MemPool::MemPool()
           total_allocated_bytes_(0),
           total_reserved_bytes_(0),
           peak_allocated_bytes_(0),
-          _mem_tracker(thread_local_ctx.get()->_thread_mem_tracker_mgr->mem_tracker().get()) {}
+          _mem_tracker(tls_ctx()->_thread_mem_tracker_mgr->mem_tracker().get()) {}
 
 MemPool::ChunkInfo::ChunkInfo(const Chunk& chunk_) : chunk(chunk_), allocated_bytes(0) {
     DorisMetrics::instance()->memory_pool_bytes_total->increment(chunk.size);

--- a/be/src/runtime/mem_tracker.cpp
+++ b/be/src/runtime/mem_tracker.cpp
@@ -65,9 +65,7 @@ static std::shared_ptr<MemTracker> brpc_server_tracker;
 static GoogleOnceType brpc_server_tracker_once = GOOGLE_ONCE_INIT;
 
 void MemTracker::create_brpc_server_tracker() {
-    brpc_server_tracker.reset(new MemTracker(-1, "Brpc", get_process_tracker(), MemTrackerLevel::OVERVIEW, nullptr));
-    get_process_tracker()->add_child_tracker(brpc_server_tracker);
-    brpc_server_tracker->init();
+    brpc_server_tracker = MemTracker::create_tracker(-1, "Brpc", get_process_tracker(), MemTrackerLevel::OVERVIEW);
 }
 
 std::shared_ptr<MemTracker> MemTracker::get_brpc_server_tracker() {
@@ -138,6 +136,7 @@ MemTracker::MemTracker(int64_t byte_limit, const std::string& label,
                        RuntimeProfile* profile)
         : _limit(byte_limit),
           _label(label),
+          // Not 100% sure the id is unique. This is generated because it is faster than converting to int after hash.
           _id((GetCurrentTimeMicros() % 1000000) * 100 + _label.length()),
           _parent(parent),
           _level(level) {

--- a/be/src/runtime/mem_tracker.cpp
+++ b/be/src/runtime/mem_tracker.cpp
@@ -60,6 +60,21 @@ MemTracker* MemTracker::get_raw_process_tracker() {
     return raw_process_tracker;
 }
 
+// Track memory for all brpc server responses.
+static std::shared_ptr<MemTracker> brpc_server_tracker;
+static GoogleOnceType brpc_server_tracker_once = GOOGLE_ONCE_INIT;
+
+void MemTracker::create_brpc_server_tracker() {
+    brpc_server_tracker.reset(new MemTracker(-1, "Brpc", get_process_tracker(), MemTrackerLevel::OVERVIEW, nullptr));
+    get_process_tracker()->add_child_tracker(brpc_server_tracker);
+    brpc_server_tracker->init();
+}
+
+std::shared_ptr<MemTracker> MemTracker::get_brpc_server_tracker() {
+    GoogleOnceInit(&brpc_server_tracker_once, &MemTracker::create_brpc_server_tracker);
+    return brpc_server_tracker;
+}
+
 void MemTracker::list_process_trackers(std::vector<std::shared_ptr<MemTracker>>* trackers) {
     trackers->clear();
     std::deque<std::shared_ptr<MemTracker>> to_process;
@@ -88,7 +103,8 @@ std::shared_ptr<MemTracker> MemTracker::create_tracker(int64_t byte_limit, const
                                                        const std::shared_ptr<MemTracker>& parent,
                                                        MemTrackerLevel level,
                                                        RuntimeProfile* profile) {
-    std::shared_ptr<MemTracker> reset_parent = parent ? parent : thread_local_ctx.get()->_thread_mem_tracker_mgr->mem_tracker();
+    std::shared_ptr<MemTracker> reset_parent =
+            parent ? parent : tls_ctx()->_thread_mem_tracker_mgr->mem_tracker();
     DCHECK(reset_parent);
 
     std::shared_ptr<MemTracker> tracker(
@@ -102,7 +118,8 @@ std::shared_ptr<MemTracker> MemTracker::create_tracker(int64_t byte_limit, const
 std::shared_ptr<MemTracker> MemTracker::create_virtual_tracker(
         int64_t byte_limit, const std::string& label, const std::shared_ptr<MemTracker>& parent,
         MemTrackerLevel level) {
-   std::shared_ptr<MemTracker> reset_parent = parent ? parent : thread_local_ctx.get()->_thread_mem_tracker_mgr->mem_tracker();
+    std::shared_ptr<MemTracker> reset_parent =
+            parent ? parent : tls_ctx()->_thread_mem_tracker_mgr->mem_tracker();
     DCHECK(reset_parent);
 
     std::shared_ptr<MemTracker> tracker(

--- a/be/src/runtime/mem_tracker.h
+++ b/be/src/runtime/mem_tracker.h
@@ -97,6 +97,8 @@ public:
     // Gets a shared_ptr to the "process" tracker, creating it if necessary.
     static std::shared_ptr<MemTracker> get_process_tracker();
     static MemTracker* get_raw_process_tracker();
+    // Gets a shared_ptr to the "brpc server" tracker, creating it if necessary.
+    static std::shared_ptr<MemTracker> get_brpc_server_tracker();
 
     Status check_sys_mem_info(int64_t bytes) {
         if (MemInfo::initialized() && MemInfo::current_mem() + bytes >= MemInfo::mem_limit()) {
@@ -464,6 +466,8 @@ private:
 
     // Creates the process tracker.
     static void create_process_tracker();
+    // Creates the brpc server tracker.
+    static void create_brpc_server_tracker();
 
     // Limit on memory consumption, in bytes. If limit_ == -1, there is no consumption limit.
     int64_t _limit;

--- a/be/src/runtime/memory/system_allocator.cpp
+++ b/be/src/runtime/memory/system_allocator.cpp
@@ -73,6 +73,7 @@ uint8_t* SystemAllocator::allocate_via_mmap(size_t length) {
         char buf[64];
         LOG(ERROR) << "fail to allocate memory via mmap, errno=" << errno
                    << ", errmsg=" << strerror_r(errno, buf, 64);
+        RELEASE_THREAD_LOCAL_MEM_TRACKER(length);
         return nullptr;
     }
     return ptr;

--- a/be/src/runtime/memory/system_allocator.cpp
+++ b/be/src/runtime/memory/system_allocator.cpp
@@ -23,6 +23,7 @@
 
 #include "common/config.h"
 #include "common/logging.h"
+#include "runtime/thread_context.h"
 
 namespace doris {
 
@@ -43,6 +44,8 @@ void SystemAllocator::free(uint8_t* ptr, size_t length) {
             char buf[64];
             LOG(ERROR) << "fail to free memory via munmap, errno=" << errno
                        << ", errmsg=" << strerror_r(errno, buf, 64);
+        } else {
+            RELEASE_THREAD_LOCAL_MEM_TRACKER(length);
         }
     } else {
         ::free(ptr);
@@ -63,6 +66,7 @@ uint8_t* SystemAllocator::allocate_via_malloc(size_t length) {
 }
 
 uint8_t* SystemAllocator::allocate_via_mmap(size_t length) {
+    CONSUME_THREAD_LOCAL_MEM_TRACKER(length);
     auto ptr = (uint8_t*)mmap(nullptr, length, PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_PRIVATE,
                               -1, 0);
     if (ptr == MAP_FAILED) {

--- a/be/src/runtime/plan_fragment_executor.cpp
+++ b/be/src/runtime/plan_fragment_executor.cpp
@@ -89,9 +89,7 @@ Status PlanFragmentExecutor::prepare(const TExecPlanFragmentParams& request,
     _runtime_state->set_query_fragments_ctx(fragments_ctx);
 
     RETURN_IF_ERROR(_runtime_state->init_mem_trackers(_query_id));
-    SCOPED_ATTACH_TASK_THREAD(_runtime_state->query_type(), print_id(_runtime_state->query_id()),
-                              _runtime_state->fragment_instance_id(),
-                              _runtime_state->instance_mem_tracker());
+    SCOPED_ATTACH_TASK_THREAD(_runtime_state.get(), _runtime_state->instance_mem_tracker());
     _runtime_state->set_be_number(request.backend_num);
     if (request.__isset.backend_id) {
         _runtime_state->set_backend_id(request.backend_id);
@@ -442,9 +440,7 @@ void PlanFragmentExecutor::_collect_node_statistics() {
 }
 
 void PlanFragmentExecutor::report_profile() {
-    SCOPED_ATTACH_TASK_THREAD(_runtime_state->query_type(), print_id(_runtime_state->query_id()),
-                              _runtime_state->fragment_instance_id(),
-                              _runtime_state->instance_mem_tracker());
+    SCOPED_ATTACH_TASK_THREAD(_runtime_state.get(), _runtime_state->instance_mem_tracker());
     VLOG_FILE << "report_profile(): instance_id=" << _runtime_state->fragment_instance_id();
     DCHECK(_report_status_cb);
 

--- a/be/src/runtime/row_batch.cpp
+++ b/be/src/runtime/row_batch.cpp
@@ -44,7 +44,7 @@ const int RowBatch::AT_CAPACITY_MEM_USAGE = 8 * 1024 * 1024;
 const int RowBatch::FIXED_LEN_BUFFER_LIMIT = AT_CAPACITY_MEM_USAGE / 2;
 
 RowBatch::RowBatch(const RowDescriptor& row_desc, int capacity)
-        : _mem_tracker(thread_local_ctx.get()->_thread_mem_tracker_mgr->mem_tracker()),
+        : _mem_tracker(tls_ctx()->_thread_mem_tracker_mgr->mem_tracker()),
           _has_in_flight_row(false),
           _num_rows(0),
           _num_uncommitted_rows(0),
@@ -70,7 +70,7 @@ RowBatch::RowBatch(const RowDescriptor& row_desc, int capacity)
 // to allocated string data in special mempool
 // (change via python script that runs over Data_types.cc)
 RowBatch::RowBatch(const RowDescriptor& row_desc, const PRowBatch& input_batch)
-        : _mem_tracker(thread_local_ctx.get()->_thread_mem_tracker_mgr->mem_tracker()),
+        : _mem_tracker(tls_ctx()->_thread_mem_tracker_mgr->mem_tracker()),
           _has_in_flight_row(false),
           _num_rows(input_batch.num_rows()),
           _num_uncommitted_rows(0),

--- a/be/src/runtime/runtime_filter_mgr.cpp
+++ b/be/src/runtime/runtime_filter_mgr.cpp
@@ -156,8 +156,8 @@ Status RuntimeFilterMergeControllerEntity::_init_with_desc(
     // LOG(INFO) << "entity filter id:" << filter_id;
     cntVal->filter->init_with_desc(&cntVal->runtime_filter_desc, query_options, _fragment_instance_id);
     cntVal->tracker = MemTracker::create_tracker(
-            -1, thread_local_ctx.get()->_thread_mem_tracker_mgr->mem_tracker()->label() + ":FilterID:" + filter_id,
-            thread_local_ctx.get()->_thread_mem_tracker_mgr->mem_tracker());
+            -1, tls_ctx()->_thread_mem_tracker_mgr->mem_tracker()->label() + ":FilterID:" + filter_id,
+            tls_ctx()->_thread_mem_tracker_mgr->mem_tracker());
     _filter_map.emplace(filter_id, cntVal);
     return Status::OK();
 }

--- a/be/src/runtime/sorted_run_merger.cc
+++ b/be/src/runtime/sorted_run_merger.cc
@@ -129,7 +129,7 @@ public:
         *done = false;
         _pull_task_thread =
         std::thread(&SortedRunMerger::ParallelBatchedRowSupplier::process_sorted_run_task,
-                    this, thread_local_ctx.get()->_thread_mem_tracker_mgr->mem_tracker());
+                    this, tls_ctx()->_thread_mem_tracker_mgr->mem_tracker());
 
         RETURN_IF_ERROR(next(nullptr, done));
         return Status::OK();

--- a/be/src/runtime/tcmalloc_hook.h
+++ b/be/src/runtime/tcmalloc_hook.h
@@ -36,11 +36,11 @@
 //  destructor to control the behavior of consume can lead to unexpected behavior,
 //  like this: if (LIKELY(doris::start_thread_mem_tracker)) {
 void new_hook(const void* ptr, size_t size) {
-    doris::thread_local_ctx.get()->consume_mem(tc_nallocx(size, 0));
+    doris::tls_ctx()->consume_mem(tc_nallocx(size, 0));
 }
 
 void delete_hook(const void* ptr) {
-    doris::thread_local_ctx.get()->release_mem(tc_malloc_size(const_cast<void*>(ptr)));
+    doris::tls_ctx()->release_mem(tc_malloc_size(const_cast<void*>(ptr)));
 }
 
 void init_hook() {

--- a/be/src/runtime/thread_context.cpp
+++ b/be/src/runtime/thread_context.cpp
@@ -102,7 +102,6 @@ SwitchThreadMemTracker<Existed>::SwitchThreadMemTracker(
 #endif
 #ifndef NDEBUG
         tls_ctx()->_thread_mem_tracker_mgr->switch_count += 1;
-        _tid = tls_ctx()->get_thread_id();
 #endif
     }
 }
@@ -116,7 +115,6 @@ SwitchThreadMemTracker<Existed>::~SwitchThreadMemTracker() {
 #endif
 #ifndef BE_TEST
         tls_ctx()->_thread_mem_tracker_mgr->update_tracker_id(_old_tracker_id);
-        DCHECK(_tid == tls_ctx()->get_thread_id());
 #endif
     }
 }

--- a/be/src/runtime/thread_context.cpp
+++ b/be/src/runtime/thread_context.cpp
@@ -17,6 +17,9 @@
 
 #include "runtime/thread_context.h"
 
+#include "runtime/runtime_state.h"
+#include "util/doris_metrics.h"
+
 namespace doris {
 
 DEFINE_STATIC_THREAD_LOCAL(ThreadContext, ThreadContextPtr, thread_local_ctx);
@@ -28,5 +31,131 @@ ThreadContextPtr::ThreadContextPtr() {
 ThreadContext* ThreadContextPtr::get() {
     return thread_local_ctx;
 }
+
+AttachTaskThread::AttachTaskThread(const ThreadContext::TaskType& type, const std::string& task_id,
+                                   const TUniqueId& fragment_instance_id,
+                                   const std::shared_ptr<doris::MemTracker>& mem_tracker) {
+    DCHECK(task_id != "");
+    tls_ctx()->attach(type, task_id, fragment_instance_id, mem_tracker);
+}
+
+AttachTaskThread::AttachTaskThread(const ThreadContext::TaskType& type,
+                                   const std::shared_ptr<doris::MemTracker>& mem_tracker) {
+#ifndef BE_TEST
+    DCHECK(mem_tracker);
+#endif
+    tls_ctx()->attach(type, "", TUniqueId(), mem_tracker);
+}
+
+AttachTaskThread::AttachTaskThread(const TQueryType::type& query_type,
+                                   const std::shared_ptr<doris::MemTracker>& mem_tracker) {
+#ifndef BE_TEST
+    DCHECK(mem_tracker);
+#endif
+    tls_ctx()->attach(query_to_task_type(query_type), "", TUniqueId(), mem_tracker);
+}
+
+AttachTaskThread::AttachTaskThread(const TQueryType::type& query_type,
+                                   const std::shared_ptr<doris::MemTracker>& mem_tracker,
+                                   const std::string& task_id,
+                                   const TUniqueId& fragment_instance_id) {
+#ifndef BE_TEST
+    DCHECK(task_id != "");
+    DCHECK(fragment_instance_id != TUniqueId());
+    DCHECK(mem_tracker);
+#endif
+    tls_ctx()->attach(query_to_task_type(query_type), task_id, fragment_instance_id, mem_tracker);
+}
+
+AttachTaskThread::AttachTaskThread(const RuntimeState* runtime_state,
+                                   const std::shared_ptr<doris::MemTracker>& mem_tracker) {
+#ifndef BE_TEST
+    DCHECK(print_id(runtime_state->query_id()) != "");
+    DCHECK(runtime_state->fragment_instance_id() != TUniqueId());
+    DCHECK(mem_tracker);
+#endif
+    tls_ctx()->attach(query_to_task_type(runtime_state->query_type()),
+                      print_id(runtime_state->query_id()), runtime_state->fragment_instance_id(),
+                      mem_tracker);
+}
+
+AttachTaskThread::~AttachTaskThread() {
+    tls_ctx()->detach();
+    DorisMetrics::instance()->attach_task_thread_count->increment(1);
+}
+
+template <bool Existed>
+SwitchThreadMemTracker<Existed>::SwitchThreadMemTracker(
+        const std::shared_ptr<doris::MemTracker>& mem_tracker, bool in_task) {
+    if (config::memory_verbose_track) {
+#ifndef BE_TEST
+        DCHECK(mem_tracker);
+        // The thread tracker must be switched after the attach task, otherwise switching
+        // in the main thread will cause the cached tracker not be cleaned up in time.
+        DCHECK(in_task == false || tls_ctx()->_thread_mem_tracker_mgr->is_attach_task());
+        if (Existed) {
+            _old_tracker_id = tls_ctx()->_thread_mem_tracker_mgr->update_tracker<true>(mem_tracker);
+        } else {
+            _old_tracker_id =
+                    tls_ctx()->_thread_mem_tracker_mgr->update_tracker<false>(mem_tracker);
+        }
+#endif
+#ifndef NDEBUG
+        tls_ctx()->_thread_mem_tracker_mgr->switch_count += 1;
+        _tid = tls_ctx()->get_thread_id();
+#endif
+    }
+}
+
+template <bool Existed>
+SwitchThreadMemTracker<Existed>::~SwitchThreadMemTracker() {
+    if (config::memory_verbose_track) {
+#ifndef NDEBUG
+        tls_ctx()->_thread_mem_tracker_mgr->switch_count -= 1;
+        DorisMetrics::instance()->switch_thread_mem_tracker_count->increment(1);
+#endif
+#ifndef BE_TEST
+        tls_ctx()->_thread_mem_tracker_mgr->update_tracker_id(_old_tracker_id);
+        DCHECK(_tid == tls_ctx()->get_thread_id());
+#endif
+    }
+}
+
+SwitchThreadMemTrackerErrCallBack::SwitchThreadMemTrackerErrCallBack(
+        const std::string& action_type, bool cancel_work, ERRCALLBACK err_call_back_func) {
+    DCHECK(action_type != std::string());
+    _old_tracker_cb = tls_ctx()->_thread_mem_tracker_mgr->update_consume_err_cb(
+            action_type, cancel_work, err_call_back_func);
+}
+
+SwitchThreadMemTrackerErrCallBack::~SwitchThreadMemTrackerErrCallBack() {
+    tls_ctx()->_thread_mem_tracker_mgr->update_consume_err_cb(_old_tracker_cb);
+    DorisMetrics::instance()->switch_thread_mem_tracker_err_cb_count->increment(1);
+}
+
+SwitchBthread::SwitchBthread() {
+    tls = static_cast<ThreadContext*>(bthread_getspecific(btls_key));
+    // First call to bthread_getspecific (and before any bthread_setspecific) returns NULL
+    if (tls == nullptr) {
+        // Create thread-local data on demand.
+        tls = new ThreadContext;
+        tls->_thread_mem_tracker_mgr->init_bthread();
+        // set the data so that next time bthread_getspecific in the thread returns the data.
+        CHECK_EQ(0, bthread_setspecific(btls_key, tls));
+    } else {
+        tls->_thread_mem_tracker_mgr->init_bthread();
+    }
+}
+
+SwitchBthread::~SwitchBthread() {
+    DCHECK(tls != nullptr);
+    tls->_thread_mem_tracker_mgr->clear_untracked_mems();
+#ifndef NDEBUG
+        DorisMetrics::instance()->switch_pthread_count->increment(1);
+#endif
+}
+
+template class SwitchThreadMemTracker<true>;
+template class SwitchThreadMemTracker<false>;
 
 } // namespace doris

--- a/be/src/runtime/thread_context.cpp
+++ b/be/src/runtime/thread_context.cpp
@@ -149,7 +149,7 @@ SwitchBthread::~SwitchBthread() {
     DCHECK(tls != nullptr);
     tls->_thread_mem_tracker_mgr->clear_untracked_mems();
 #ifndef NDEBUG
-        DorisMetrics::instance()->switch_pthread_count->increment(1);
+        DorisMetrics::instance()->switch_bthread_count->increment(1);
 #endif
 }
 

--- a/be/src/runtime/thread_context.h
+++ b/be/src/runtime/thread_context.h
@@ -63,9 +63,9 @@
 #define ADD_THREAD_LOCAL_MEM_TRACKER(mem_tracker) \
     doris::tls_ctx()->_thread_mem_tracker_mgr->add_tracker(mem_tracker)
 #define CONSUME_THREAD_LOCAL_MEM_TRACKER(size) \
-    doris::tls_ctx()->_thread_mem_tracker_mgr->mem_tracker()->consume(size)
+    doris::tls_ctx()->_thread_mem_tracker_mgr->noncache_consume(size)
 #define RELEASE_THREAD_LOCAL_MEM_TRACKER(size) \
-    doris::tls_ctx()->_thread_mem_tracker_mgr->mem_tracker()->release(size)
+    doris::tls_ctx()->_thread_mem_tracker_mgr->noncache_consume(-size)
 
 namespace doris {
 

--- a/be/src/runtime/thread_context.h
+++ b/be/src/runtime/thread_context.h
@@ -17,15 +17,17 @@
 
 #pragma once
 
+#include <service/brpc_conflict.h>
+// After brpc_conflict.h
+#include <bthread/bthread.h>
+
 #include <string>
 #include <thread>
 
 #include "common/logging.h"
-#include "gen_cpp/Types_types.h"
-#include "runtime/runtime_state.h"
+#include "gen_cpp/PaloInternalService_types.h" // for TQueryType
 #include "runtime/thread_mem_tracker_mgr.h"
 #include "runtime/threadlocal.h"
-#include "util/doris_metrics.h"
 
 // Attach to task when thread starts
 #define SCOPED_ATTACH_TASK_THREAD(type, ...) \
@@ -34,33 +36,42 @@
 // may be different from the order of execution of instructions, which will cause the position of
 // the memory track to be unexpected.
 #define SCOPED_STOP_THREAD_LOCAL_MEM_TRACKER() \
-    auto VARNAME_LINENUM(stop_tracker) = StopThreadMemTracker(true)
+    auto VARNAME_LINENUM(stop_tracker) = doris::StopThreadMemTracker(true)
 #define GLOBAL_STOP_THREAD_LOCAL_MEM_TRACKER() \
-    auto VARNAME_LINENUM(stop_tracker) = StopThreadMemTracker(false)
+    auto VARNAME_LINENUM(stop_tracker) = doris::StopThreadMemTracker(false)
 // Switch thread mem tracker during task execution.
 // After the non-query thread switches the mem tracker, if the thread will not switch the mem
 // tracker again in the short term, can consider manually clear_untracked_mems.
 // The query thread will automatically clear_untracked_mems when detach_task.
 #define SCOPED_SWITCH_THREAD_LOCAL_MEM_TRACKER(mem_tracker) \
-    auto VARNAME_LINENUM(switch_tracker) = SwitchThreadMemTracker<false>(mem_tracker, false)
+    auto VARNAME_LINENUM(switch_tracker) = doris::SwitchThreadMemTracker<false>(mem_tracker, false)
 #define SCOPED_SWITCH_TASK_THREAD_LOCAL_MEM_TRACKER(mem_tracker) \
-    auto VARNAME_LINENUM(switch_tracker) = SwitchThreadMemTracker<false>(mem_tracker, true);
+    auto VARNAME_LINENUM(switch_tracker) = doris::SwitchThreadMemTracker<false>(mem_tracker, true);
+#define SCOPED_SWITCH_THREAD_LOCAL_EXISTED_MEM_TRACKER(mem_tracker) \
+    auto VARNAME_LINENUM(switch_tracker) = doris::SwitchThreadMemTracker<true>(mem_tracker, false)
 #define SCOPED_SWITCH_TASK_THREAD_LOCAL_EXISTED_MEM_TRACKER(mem_tracker) \
-    auto VARNAME_LINENUM(switch_tracker) = SwitchThreadMemTracker<true>(mem_tracker, true)
+    auto VARNAME_LINENUM(switch_tracker) = doris::SwitchThreadMemTracker<true>(mem_tracker, true)
 // After the non-query thread switches the mem tracker, if the thread will not switch the mem
 // tracker again in the short term, can consider manually clear_untracked_mems.
 // The query thread will automatically clear_untracked_mems when detach_task.
 #define SCOPED_SWITCH_THREAD_LOCAL_MEM_TRACKER_END_CLEAR(mem_tracker) \
-    auto VARNAME_LINENUM(switch_tracker) = SwitchThreadMemTrackerEndClear(mem_tracker)
+    auto VARNAME_LINENUM(switch_tracker) = doris::SwitchThreadMemTrackerEndClear(mem_tracker)
 #define SCOPED_SWITCH_THREAD_LOCAL_MEM_TRACKER_ERR_CB(action_type, ...) \
     auto VARNAME_LINENUM(witch_tracker_cb) =                            \
-            SwitchThreadMemTrackerErrCallBack(action_type, ##__VA_ARGS__)
+            doris::SwitchThreadMemTrackerErrCallBack(action_type, ##__VA_ARGS__)
+#define SCOPED_SWITCH_BTHREAD() auto VARNAME_LINENUM(switch_bthread) = SwitchBthread()
 #define ADD_THREAD_LOCAL_MEM_TRACKER(mem_tracker) \
-    thread_local_ctx.get()->_thread_mem_tracker_mgr->add_tracker(mem_tracker)
+    doris::tls_ctx()->_thread_mem_tracker_mgr->add_tracker(mem_tracker)
+#define CONSUME_THREAD_LOCAL_MEM_TRACKER(size) \
+    doris::tls_ctx()->_thread_mem_tracker_mgr->mem_tracker()->consume(size)
+#define RELEASE_THREAD_LOCAL_MEM_TRACKER(size) \
+    doris::tls_ctx()->_thread_mem_tracker_mgr->mem_tracker()->release(size)
 
 namespace doris {
 
 class TUniqueId;
+
+extern bthread_key_t btls_key;
 
 // The thread context saves some info about a working thread.
 // 2 requried info:
@@ -80,19 +91,20 @@ public:
         STORAGE = 4
         // to be added ...
     };
-    inline static const std::string TaskTypeStr[] = {"UNKNOWN", "QUERY", "LOAD", "COMPACTION", "STORAGE"};
+    inline static const std::string TaskTypeStr[] = {"UNKNOWN", "QUERY", "LOAD", "COMPACTION",
+                                                     "STORAGE"};
 
 public:
-    ThreadContext() : _thread_id(std::this_thread::get_id()), _type(TaskType::UNKNOWN) {
+    ThreadContext() : _type(TaskType::UNKNOWN) {
         _thread_mem_tracker_mgr.reset(new ThreadMemTrackerMgr());
-        std::stringstream ss;
-        ss << _thread_id;
-        _thread_id_str = ss.str();
+        _thread_mem_tracker_mgr->init();
+        start_thread_mem_tracker = true;
+        _thread_id = get_thread_id();
     }
 
     void attach(const TaskType& type, const std::string& task_id,
                 const TUniqueId& fragment_instance_id,
-                const std::shared_ptr<MemTracker>& mem_tracker) {
+                const std::shared_ptr<doris::MemTracker>& mem_tracker) {
         DCHECK(_type == TaskType::UNKNOWN && _task_id == "")
                 << ",old tracker label: " << mem_tracker->label()
                 << ",new tracker label: " << _thread_mem_tracker_mgr->mem_tracker()->label();
@@ -111,9 +123,14 @@ public:
     }
 
     const std::string& task_id() const { return _task_id; }
-    const std::thread::id& thread_id() const { return _thread_id; }
-    const std::string& thread_id_str() const { return _thread_id_str; }
+    const std::string& thread_id_str() const { return _thread_id; }
     const TUniqueId& fragment_instance_id() const { return _fragment_instance_id; }
+
+    std::string get_thread_id() {
+        std::stringstream ss;
+        ss << std::this_thread::get_id();
+        return ss.str();
+    }
 
     void consume_mem(int64_t size) {
         if (start_thread_mem_tracker) {
@@ -136,8 +153,7 @@ public:
     std::unique_ptr<ThreadMemTrackerMgr> _thread_mem_tracker_mgr;
 
 private:
-    std::thread::id _thread_id;
-    std::string _thread_id_str;
+    std::string _thread_id;
     TaskType _type;
     std::string _task_id;
     TUniqueId _fragment_instance_id;
@@ -178,55 +194,33 @@ private:
 
 inline thread_local ThreadContextPtr thread_local_ctx;
 
+static ThreadContext* tls_ctx() {
+    ThreadContext* tls = static_cast<ThreadContext*>(bthread_getspecific(btls_key));
+    if (tls != nullptr) {
+        return tls;
+    } else {
+        return thread_local_ctx.get();
+    }
+}
+
 class AttachTaskThread {
 public:
     explicit AttachTaskThread(const ThreadContext::TaskType& type, const std::string& task_id,
                               const TUniqueId& fragment_instance_id = TUniqueId(),
-                              const std::shared_ptr<MemTracker>& mem_tracker = nullptr) {
-        DCHECK(task_id != "");
-        thread_local_ctx.get()->attach(type, task_id, fragment_instance_id, mem_tracker);
-    }
+                              const std::shared_ptr<doris::MemTracker>& mem_tracker = nullptr);
 
     explicit AttachTaskThread(const ThreadContext::TaskType& type,
-                              const std::shared_ptr<MemTracker>& mem_tracker) {
-#ifndef BE_TEST
-        DCHECK(mem_tracker);
-#endif
-        thread_local_ctx.get()->attach(type, "", TUniqueId(), mem_tracker);
-    }
+                              const std::shared_ptr<doris::MemTracker>& mem_tracker);
 
     explicit AttachTaskThread(const TQueryType::type& query_type,
-                              const std::shared_ptr<MemTracker>& mem_tracker) {
-#ifndef BE_TEST
-        DCHECK(mem_tracker);
-#endif
-        thread_local_ctx.get()->attach(query_to_task_type(query_type), "", TUniqueId(),
-                                       mem_tracker);
-    }
+                              const std::shared_ptr<doris::MemTracker>& mem_tracker);
 
-    explicit AttachTaskThread(const TQueryType::type& query_type, const std::string& task_id,
-                              const TUniqueId& fragment_instance_id,
-                              const std::shared_ptr<MemTracker>& mem_tracker) {
-#ifndef BE_TEST
-        DCHECK(task_id != "");
-        DCHECK(fragment_instance_id != TUniqueId());
-        DCHECK(mem_tracker);
-#endif
-        thread_local_ctx.get()->attach(query_to_task_type(query_type), task_id,
-                                       fragment_instance_id, mem_tracker);
-    }
+    explicit AttachTaskThread(const TQueryType::type& query_type,
+                              const std::shared_ptr<doris::MemTracker>& mem_tracker,
+                              const std::string& task_id, const TUniqueId& fragment_instance_id);
 
     explicit AttachTaskThread(const RuntimeState* runtime_state,
-                              const std::shared_ptr<MemTracker>& mem_tracker) {
-#ifndef BE_TEST
-        DCHECK(print_id(runtime_state->query_id()) != "");
-        DCHECK(runtime_state->fragment_instance_id() != TUniqueId());
-        DCHECK(mem_tracker);
-#endif
-        thread_local_ctx.get()->attach(query_to_task_type(runtime_state->query_type()),
-                                       print_id(runtime_state->query_id()),
-                                       runtime_state->fragment_instance_id(), mem_tracker);
-    }
+                              const std::shared_ptr<doris::MemTracker>& mem_tracker);
 
     const ThreadContext::TaskType query_to_task_type(const TQueryType::type& query_type) {
         switch (query_type) {
@@ -240,10 +234,7 @@ public:
         }
     }
 
-    ~AttachTaskThread() {
-        thread_local_ctx.get()->detach();
-        DorisMetrics::instance()->attach_task_thread_count->increment(1);
-    }
+    ~AttachTaskThread();
 };
 
 class StopThreadMemTracker {
@@ -263,48 +254,23 @@ private:
 template <bool Existed>
 class SwitchThreadMemTracker {
 public:
-    explicit SwitchThreadMemTracker(const std::shared_ptr<MemTracker>& mem_tracker,
-                                    bool in_task = true) {
-        if (config::memory_verbose_track) {
-#ifndef BE_TEST
-            DCHECK(mem_tracker);
-            // The thread tracker must be switched after the attach task, otherwise switching
-            // in the main thread will cause the cached tracker not be cleaned up in time.
-            DCHECK(in_task == false ||
-                   thread_local_ctx.get()->_thread_mem_tracker_mgr->is_attach_task());
-            if (Existed) {
-                _old_tracker_id =
-                        thread_local_ctx.get()->_thread_mem_tracker_mgr->update_tracker<true>(
-                                mem_tracker);
-            } else {
-                _old_tracker_id =
-                        thread_local_ctx.get()->_thread_mem_tracker_mgr->update_tracker<false>(
-                                mem_tracker);
-            }
-#endif
-        }
-    }
+    explicit SwitchThreadMemTracker(const std::shared_ptr<doris::MemTracker>& mem_tracker,
+                                    bool in_task = true);
 
-    ~SwitchThreadMemTracker() {
-        if (config::memory_verbose_track) {
-#ifndef BE_TEST
-            thread_local_ctx.get()->_thread_mem_tracker_mgr->update_tracker_id(_old_tracker_id);
-            DorisMetrics::instance()->switch_thread_mem_tracker_count->increment(1);
-#endif
-        }
-    }
+    ~SwitchThreadMemTracker();
 
 protected:
     int64_t _old_tracker_id = 0;
+    std::string _tid;
 };
 
 class SwitchThreadMemTrackerEndClear : public SwitchThreadMemTracker<false> {
 public:
-    explicit SwitchThreadMemTrackerEndClear(const std::shared_ptr<MemTracker>& mem_tracker)
+    explicit SwitchThreadMemTrackerEndClear(const std::shared_ptr<doris::MemTracker>& mem_tracker)
             : SwitchThreadMemTracker<false>(mem_tracker, false) {}
 
     ~SwitchThreadMemTrackerEndClear() {
-        thread_local_ctx.get()->_thread_mem_tracker_mgr->clear_untracked_mems();
+        tls_ctx()->_thread_mem_tracker_mgr->clear_untracked_mems();
     }
 };
 
@@ -312,19 +278,22 @@ class SwitchThreadMemTrackerErrCallBack {
 public:
     explicit SwitchThreadMemTrackerErrCallBack(const std::string& action_type,
                                                bool cancel_work = true,
-                                               ERRCALLBACK err_call_back_func = nullptr) {
-        DCHECK(action_type != std::string());
-        _old_tracker_cb = thread_local_ctx.get()->_thread_mem_tracker_mgr->update_consume_err_cb(
-                action_type, cancel_work, err_call_back_func);
-    }
+                                               ERRCALLBACK err_call_back_func = nullptr);
 
-    ~SwitchThreadMemTrackerErrCallBack() {
-        thread_local_ctx.get()->_thread_mem_tracker_mgr->update_consume_err_cb(_old_tracker_cb);
-        DorisMetrics::instance()->switch_thread_mem_tracker_err_cb_count->increment(1);
-    }
+    ~SwitchThreadMemTrackerErrCallBack();
 
 private:
     ConsumeErrCallBackInfo _old_tracker_cb;
+};
+
+class SwitchBthread {
+public:
+    explicit SwitchBthread();
+
+    ~SwitchBthread();
+
+private:
+    ThreadContext* tls;
 };
 
 } // namespace doris

--- a/be/src/runtime/thread_context.h
+++ b/be/src/runtime/thread_context.h
@@ -261,7 +261,6 @@ public:
 
 protected:
     int64_t _old_tracker_id = 0;
-    std::string _tid;
 };
 
 class SwitchThreadMemTrackerEndClear : public SwitchThreadMemTracker<false> {

--- a/be/src/runtime/thread_mem_tracker_mgr.cpp
+++ b/be/src/runtime/thread_mem_tracker_mgr.cpp
@@ -56,10 +56,6 @@ void ThreadMemTrackerMgr::detach_task() {
 }
 
 void ThreadMemTrackerMgr::exceeded_cancel_task(const std::string& cancel_details) {
-    _temp_task_mem_tracker =
-            ExecEnv::GetInstance()->task_pool_mem_tracker_registry()->get_task_mem_tracker(
-                    _task_id);
-    DCHECK(_temp_task_mem_tracker) << print_debug_string();
     if (_fragment_instance_id != TUniqueId()) {
         ExecEnv::GetInstance()->fragment_mgr()->cancel(
                 _fragment_instance_id, PPlanFragmentCancelReason::MEMORY_LIMIT_EXCEED,

--- a/be/src/runtime/thread_mem_tracker_mgr.cpp
+++ b/be/src/runtime/thread_mem_tracker_mgr.cpp
@@ -17,6 +17,8 @@
 
 #include "runtime/thread_mem_tracker_mgr.h"
 
+#include "runtime/exec_env.h"
+#include "runtime/fragment_mgr.h"
 #include "runtime/mem_tracker_task_pool.h"
 #include "service/backend_options.h"
 
@@ -25,6 +27,7 @@ namespace doris {
 void ThreadMemTrackerMgr::attach_task(const std::string& cancel_msg, const std::string& task_id,
                                       const TUniqueId& fragment_instance_id,
                                       const std::shared_ptr<MemTracker>& mem_tracker) {
+    DCHECK(switch_count == 0) << print_debug_string();
     _task_id = task_id;
     _fragment_instance_id = fragment_instance_id;
     _consume_err_cb.cancel_msg = cancel_msg;
@@ -44,26 +47,19 @@ void ThreadMemTrackerMgr::attach_task(const std::string& cancel_msg, const std::
 }
 
 void ThreadMemTrackerMgr::detach_task() {
+    DCHECK(switch_count == 0) << print_debug_string();
     _task_id = "";
     _fragment_instance_id = TUniqueId();
     _consume_err_cb.init();
     clear_untracked_mems();
-    _tracker_id = 0;
-    // The following memory changes for the two map operations of _untracked_mems and _mem_trackers
-    // will be re-recorded in _untracked_mem.
-    _untracked_mems.clear();
-    _untracked_mems[0] = 0;
-    _mem_trackers.clear();
-    _mem_trackers[0] = MemTracker::get_process_tracker();
-    _mem_tracker_labels.clear();
-    _mem_tracker_labels[0] = MemTracker::get_process_tracker()->label();
+    init();
 }
 
 void ThreadMemTrackerMgr::exceeded_cancel_task(const std::string& cancel_details) {
     _temp_task_mem_tracker =
             ExecEnv::GetInstance()->task_pool_mem_tracker_registry()->get_task_mem_tracker(
                     _task_id);
-    DCHECK(_temp_task_mem_tracker);
+    DCHECK(_temp_task_mem_tracker) << print_debug_string();
     if (_fragment_instance_id != TUniqueId()) {
         ExecEnv::GetInstance()->fragment_mgr()->cancel(
                 _fragment_instance_id, PPlanFragmentCancelReason::MEMORY_LIMIT_EXCEED,

--- a/be/src/runtime/thread_mem_tracker_mgr.h
+++ b/be/src/runtime/thread_mem_tracker_mgr.h
@@ -120,11 +120,11 @@ public:
     std::string print_debug_string() {
         std::string mem_trackers_str;
         for (const auto& [key, value] : _mem_trackers) {
-            mem_trackers_str += fmt::format("{}_{},", std::to_string(key), value);
+            mem_trackers_str += fmt::format("{}_{},", std::to_string(key), value->log_usage(1));
         }
         std::string untracked_mems_str;
         for (const auto& [key, value] : _untracked_mems) {
-            untracked_mems_str += fmt::format("{}_{},", std::to_string(key), value);
+            untracked_mems_str += fmt::format("{}_{},", std::to_string(key), std::to_string(value));
         }
         std::string mem_tracker_labels_str;
         for (const auto& [key, value] : _mem_tracker_labels) {

--- a/be/src/runtime/thread_mem_tracker_mgr.h
+++ b/be/src/runtime/thread_mem_tracker_mgr.h
@@ -270,13 +270,12 @@ inline void ThreadMemTrackerMgr::noncache_consume(int64_t size) {
 }
 
 inline void ThreadMemTrackerMgr::add_tracker(const std::shared_ptr<MemTracker>& mem_tracker) {
+    DCHECK(_mem_trackers.find(mem_tracker->id()) == _mem_trackers.end()) << print_debug_string();
     if (_mem_trackers.find(mem_tracker->id()) == _mem_trackers.end()) {
         _mem_trackers[mem_tracker->id()] = mem_tracker;
         DCHECK(_mem_trackers[mem_tracker->id()]) << print_debug_string();
         _untracked_mems[mem_tracker->id()] = 0;
         _mem_tracker_labels[_temp_tracker_id] = mem_tracker->label();
-    } else {
-        std::cout << "void add_tracker: " << mem_tracker->label() << std::endl;
     }
 }
 

--- a/be/src/runtime/thread_mem_tracker_mgr.h
+++ b/be/src/runtime/thread_mem_tracker_mgr.h
@@ -118,23 +118,25 @@ public:
     int64_t switch_count = 0;
 
     std::string print_debug_string() {
-        std::string mem_trackers_str;
+        fmt::memory_buffer mem_trackers_buf;
         for (const auto& [key, value] : _mem_trackers) {
-            mem_trackers_str += fmt::format("{}_{},", std::to_string(key), value->log_usage(1));
+            fmt::format_to(mem_trackers_buf, "{}_{},", std::to_string(key), value->log_usage(1));
         }
-        std::string untracked_mems_str;
+        fmt::memory_buffer untracked_mems_buf;
         for (const auto& [key, value] : _untracked_mems) {
-            untracked_mems_str += fmt::format("{}_{},", std::to_string(key), std::to_string(value));
+            fmt::format_to(untracked_mems_buf, "{}_{},", std::to_string(key),
+                           std::to_string(value));
         }
-        std::string mem_tracker_labels_str;
+        fmt::memory_buffer mem_tracker_labels_buf;
         for (const auto& [key, value] : _mem_tracker_labels) {
-            mem_tracker_labels_str += fmt::format("{}_{},", std::to_string(key), value);
+            fmt::format_to(mem_tracker_labels_buf, "{}_{},", std::to_string(key), value);
         }
         return fmt::format(
                 "ThreadMemTrackerMgr debug string, _tracker_id:{}, _untracked_mem:{}, _task_id:{}, "
                 "_mem_trackers:<{}>, _untracked_mems:<{}>, _mem_tracker_labels:<{}>",
                 std::to_string(_tracker_id), std::to_string(_untracked_mem), _task_id,
-                mem_trackers_str, untracked_mems_str, mem_tracker_labels_str);
+                fmt::to_string(mem_trackers_buf), fmt::to_string(untracked_mems_buf),
+                fmt::to_string(mem_tracker_labels_buf));
     }
 
 private:

--- a/be/src/service/brpc_conflict.h
+++ b/be/src/service/brpc_conflict.h
@@ -17,21 +17,32 @@
 
 #pragma once
 
-// all header need by brpc is contain in this file.
-// include this file instead of include <brpc/xxx.h>.
+// This file is used to fixed macro conflict between butil and gutil
+// and this file must put the first include in source file
 
-#include <service/brpc_conflict.h>
+#include "gutil/macros.h"
+// Macros in the guti/macros.h, use butil's define
+#ifdef DISALLOW_IMPLICIT_CONSTRUCTORS
+#undef DISALLOW_IMPLICIT_CONSTRUCTORS
+#endif
 
-#include <brpc/channel.h>
-#include <brpc/closure_guard.h>
-#include <brpc/controller.h>
-#include <brpc/protocol.h>
-#include <brpc/reloadable_flags.h>
-#include <brpc/server.h>
-#include <bthread/bthread.h>
-#include <bthread/types.h>
-#include <butil/containers/flat_map.h>
-#include <butil/containers/flat_map_inl.h>
-#include <butil/endpoint.h>
-#include <butil/fd_utility.h>
-#include <butil/macros.h>
+#ifdef arraysize
+#undef arraysize
+#endif
+
+#ifdef ARRAY_SIZE
+#undef ARRAY_SIZE
+#endif
+
+#undef OVERRIDE
+#undef FINAL
+
+// use be/src/gutil/integral_types.h override butil/basictypes.h
+#include "gutil/integral_types.h"
+#ifdef BASE_INTEGRAL_TYPES_H_
+#define BUTIL_BASICTYPES_H_
+#endif
+
+#ifdef DEBUG_MODE
+#undef DEBUG_MODE
+#endif

--- a/be/src/util/bit_util.h
+++ b/be/src/util/bit_util.h
@@ -25,7 +25,6 @@
 
 #include "common/compiler_util.h"
 #include "gutil/bits.h"
-#include "gutil/port.h"
 #include "util/cpu_info.h"
 #ifdef __aarch64__
 #include "sse2neon.h"

--- a/be/src/util/doris_metrics.cpp
+++ b/be/src/util/doris_metrics.cpp
@@ -137,6 +137,7 @@ DEFINE_COUNTER_METRIC_PROTOTYPE_2ARG(memtable_flush_duration_us, MetricUnit::MIC
 DEFINE_COUNTER_METRIC_PROTOTYPE_2ARG(attach_task_thread_count, MetricUnit::NOUNIT);
 DEFINE_COUNTER_METRIC_PROTOTYPE_2ARG(switch_thread_mem_tracker_count, MetricUnit::NOUNIT);
 DEFINE_COUNTER_METRIC_PROTOTYPE_2ARG(switch_thread_mem_tracker_err_cb_count, MetricUnit::NOUNIT);
+DEFINE_COUNTER_METRIC_PROTOTYPE_2ARG(switch_pthread_count, MetricUnit::NOUNIT);
 
 DEFINE_GAUGE_METRIC_PROTOTYPE_2ARG(memory_pool_bytes_total, MetricUnit::BYTES);
 DEFINE_GAUGE_CORE_METRIC_PROTOTYPE_2ARG(process_thread_num, MetricUnit::NOUNIT);
@@ -286,6 +287,7 @@ DorisMetrics::DorisMetrics() : _metric_registry(_s_registry_name) {
     INT_COUNTER_METRIC_REGISTER(_server_metric_entity, attach_task_thread_count);
     INT_COUNTER_METRIC_REGISTER(_server_metric_entity, switch_thread_mem_tracker_count);
     INT_COUNTER_METRIC_REGISTER(_server_metric_entity, switch_thread_mem_tracker_err_cb_count);
+    INT_COUNTER_METRIC_REGISTER(_server_metric_entity, switch_pthread_count);
 
     _server_metric_entity->register_hook(_s_hook_name, std::bind(&DorisMetrics::_update, this));
 

--- a/be/src/util/doris_metrics.cpp
+++ b/be/src/util/doris_metrics.cpp
@@ -137,7 +137,7 @@ DEFINE_COUNTER_METRIC_PROTOTYPE_2ARG(memtable_flush_duration_us, MetricUnit::MIC
 DEFINE_COUNTER_METRIC_PROTOTYPE_2ARG(attach_task_thread_count, MetricUnit::NOUNIT);
 DEFINE_COUNTER_METRIC_PROTOTYPE_2ARG(switch_thread_mem_tracker_count, MetricUnit::NOUNIT);
 DEFINE_COUNTER_METRIC_PROTOTYPE_2ARG(switch_thread_mem_tracker_err_cb_count, MetricUnit::NOUNIT);
-DEFINE_COUNTER_METRIC_PROTOTYPE_2ARG(switch_pthread_count, MetricUnit::NOUNIT);
+DEFINE_COUNTER_METRIC_PROTOTYPE_2ARG(switch_bthread_count, MetricUnit::NOUNIT);
 
 DEFINE_GAUGE_METRIC_PROTOTYPE_2ARG(memory_pool_bytes_total, MetricUnit::BYTES);
 DEFINE_GAUGE_CORE_METRIC_PROTOTYPE_2ARG(process_thread_num, MetricUnit::NOUNIT);
@@ -287,7 +287,7 @@ DorisMetrics::DorisMetrics() : _metric_registry(_s_registry_name) {
     INT_COUNTER_METRIC_REGISTER(_server_metric_entity, attach_task_thread_count);
     INT_COUNTER_METRIC_REGISTER(_server_metric_entity, switch_thread_mem_tracker_count);
     INT_COUNTER_METRIC_REGISTER(_server_metric_entity, switch_thread_mem_tracker_err_cb_count);
-    INT_COUNTER_METRIC_REGISTER(_server_metric_entity, switch_pthread_count);
+    INT_COUNTER_METRIC_REGISTER(_server_metric_entity, switch_bthread_count);
 
     _server_metric_entity->register_hook(_s_hook_name, std::bind(&DorisMetrics::_update, this));
 

--- a/be/src/util/doris_metrics.h
+++ b/be/src/util/doris_metrics.h
@@ -130,6 +130,8 @@ public:
     IntCounter* attach_task_thread_count;
     IntCounter* switch_thread_mem_tracker_count;
     IntCounter* switch_thread_mem_tracker_err_cb_count;
+    // brpc server response count
+    IntCounter* switch_pthread_count;
 
     IntGauge* memory_pool_bytes_total;
     IntGauge* process_thread_num;

--- a/be/src/util/doris_metrics.h
+++ b/be/src/util/doris_metrics.h
@@ -131,7 +131,7 @@ public:
     IntCounter* switch_thread_mem_tracker_count;
     IntCounter* switch_thread_mem_tracker_err_cb_count;
     // brpc server response count
-    IntCounter* switch_pthread_count;
+    IntCounter* switch_bthread_count;
 
     IntGauge* memory_pool_bytes_total;
     IntGauge* process_thread_num;

--- a/be/src/util/file_utils.cpp
+++ b/be/src/util/file_utils.cpp
@@ -34,6 +34,7 @@
 #include "gutil/strings/strip.h"
 #include "gutil/strings/substitute.h"
 #include "olap/file_helper.h"
+#include "runtime/thread_context.h"
 #include "util/defer_op.h"
 
 namespace doris {
@@ -196,11 +197,13 @@ Status FileUtils::md5sum(const std::string& file, std::string* md5sum) {
         return Status::InternalError("failed to stat file");
     }
     size_t file_len = statbuf.st_size;
+    CONSUME_THREAD_LOCAL_MEM_TRACKER(file_len);
     void* buf = mmap(0, file_len, PROT_READ, MAP_SHARED, fd, 0);
 
     unsigned char result[MD5_DIGEST_LENGTH];
     MD5((unsigned char*)buf, file_len, result);
     munmap(buf, file_len);
+    RELEASE_THREAD_LOCAL_MEM_TRACKER(file_len);
 
     std::stringstream ss;
     for (int32_t i = 0; i < MD5_DIGEST_LENGTH; i++) {

--- a/be/src/vec/exec/vexchange_node.cpp
+++ b/be/src/vec/exec/vexchange_node.cpp
@@ -66,6 +66,7 @@ Status VExchangeNode::prepare(RuntimeState* state) {
 Status VExchangeNode::open(RuntimeState* state) {
     SCOPED_TIMER(_runtime_profile->total_time_counter());
     SCOPED_SWITCH_TASK_THREAD_LOCAL_MEM_TRACKER(mem_tracker());
+    ADD_THREAD_LOCAL_MEM_TRACKER(_stream_recvr->mem_tracker());
     RETURN_IF_ERROR(ExecNode::open(state));
 
     if (_is_merging) {
@@ -84,7 +85,6 @@ Status VExchangeNode::get_next(RuntimeState* state, RowBatch* row_batch, bool* e
 Status VExchangeNode::get_next(RuntimeState* state, Block* block, bool* eos) {
     SCOPED_TIMER(runtime_profile()->total_time_counter());
     SCOPED_SWITCH_TASK_THREAD_LOCAL_EXISTED_MEM_TRACKER(mem_tracker());
-    ADD_THREAD_LOCAL_MEM_TRACKER(_stream_recvr->mem_tracker());
     auto status = _stream_recvr->get_next(block, eos);
     if (block != nullptr) {
         if (_num_rows_returned + block->rows() < _limit) {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -408,7 +408,7 @@ public class SessionVariable implements Serializable, Writable {
     @VariableMgr.VarAttr(name = RUNTIME_FILTER_MAX_IN_NUM)
     private int runtimeFilterMaxInNum = 1024;
     @VariableMgr.VarAttr(name = ENABLE_VECTORIZED_ENGINE)
-    public boolean enableVectorizedEngine = true;
+    public boolean enableVectorizedEngine = false;
     @VariableMgr.VarAttr(name = ENABLE_PARALLEL_OUTFILE)
     public boolean enableParallelOutfile = false;
 

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -408,7 +408,7 @@ public class SessionVariable implements Serializable, Writable {
     @VariableMgr.VarAttr(name = RUNTIME_FILTER_MAX_IN_NUM)
     private int runtimeFilterMaxInNum = 1024;
     @VariableMgr.VarAttr(name = ENABLE_VECTORIZED_ENGINE)
-    public boolean enableVectorizedEngine = false;
+    public boolean enableVectorizedEngine = true;
     @VariableMgr.VarAttr(name = ENABLE_PARALLEL_OUTFILE)
     public boolean enableParallelOutfile = false;
 


### PR DESCRIPTION
# Proposed changes

Issue Number: close #7196 

## Problem Summary:

1. fix track bthread
- Bthread, a high performance M:N thread library used by brpc. In Doris, a brpc server response runs on one bthread, possibly on multiple pthreads. Currently, MemTracker consumption relies on pthread local variables (TLS).
- This caused pthread TLS MemTracker confusion when switching pthread TLS MemTracker in brpc server response. So replacing pthread TLS with bthread TLS in the brpc server response saves the MemTracker.
Ref: https://github.com/apache/incubator-brpc/blob/731730da85f6af5c25012b4c83ab5bb371320cf8/docs/en/server.md#bthread-local

2. fix track vectorized query
- Added track mmap. Currently, mmap allocates memory in many places of the vectorized execution engine.
- Refactored ThreadContext to avoid dependency conflicts and make it easier to debug.
- Fix some bugs.

## Checklist(Required)

1. Does it affect the original behavior: (Yes)
2. Has unit tests been added: (No)
3. Has document been added or modified: (No)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (Yes)

## Further comments

## 1. Stability
### 1) mem_limit=10M
This means that the memory limit of the BE process is 10M. At this time, the BE process will still start normally, but cannot do anything, and the query will return an error:
This means that after BE is started, the process mem limit has left -156M.
````
ERROR 1105 (HY000): errCode = 2, detailMessage = Memory exceed limit. fragment=89c882f82fa74db1-b8010703e7974fed, details=PartitionedHashTableCtx::ExprValuesCache failed to allocate 53760 bytes, on backend=10.81.85.89. Memory left in process limit=-156100257.00 B . failed alloc=<Memory limit exceeded: ExecNode:Exprs:AGGREGATION_NODE (id=65): TryConsume failed, bytes=53760 process whole consumption=244424704 mem limit=10485760>. current tracker=ExecNode:Exprs:AGGREGATION_NODE (id=65) . If this is a query, can change the limit b
````

### 2) mem_limit=80% (default), set exec_mem_limit=10M
The query returns the error:
At this time, the query mem limit is 10485760B, 10464520B has been used, and the re-allocation of 32768B fails. 
The memory application information reported when switching the MemTracker is `aggregator, while execute get_next`.
The tracker belongs to `ExecNode:VAGGREGATION_NODE`, and the consumption of the tracker in the TCMalloc Hook fails.
````
ERROR 1105 (HY000): errCode = 2, detailMessage = Memory limit exceeded: Memory exceed limit. fragment=, details=In TCMalloc Hook, aggregator, while execute get_next., on backend=10.81.85.89. Memory left in process limit=300.81 GB. failed alloc=<Memory limit exceeded: label=queryId=fdb6664525fe40f9-8bc275d2c86d2546 TryConsume failed size=32768, used=10464520, limit=10485760>. current tracker=ExecNode:VAGGREGATION_NODE (id=24). If this is a query, can change the limit by session variable exec_mem_limit.
````

### 3) mem_limit=99%, set exec_mem_limit=20G
(waiting for the test..., expecting BE will not crash)

## 2. Performance
Similar to #8669  test conclusion on row storage, the new memory statistics framework will also bring about a 2% performance loss on vectorized queries.

For POC performance testing, consider turning off the detailed memory track `memory_verbose_track=false`, which will avoid a 1% performance loss, and further completely turn off the memory track `track_new_delete=false`, which will further avoid a 1% performance loss.

### 1) TEST 1 - SSB 600w
```
Env: 1 FE, 1 BE;
Test Set: ssb LINEORDER 600w;
Default session veriables;
jmeter thread=20;
```
| conf  |  Q1.1(qps, avg time ms) |  Q1.2 | Q1.3  | Q2,1  | Q2.2  | Q3.1  |  Q4.1 |
| ------------ | ------------ | ------------ | ------------ | ------------ | ------------ | ------------ | ------------ |
| track_new_delete=false  |  175.0/s, 110 ms |  214.1/s, 90 ms | 225.7/s, 86 ms  | 72.5/s, 268 ms  | 71.6/s, 272 ms  | 68.0/s, 286 ms  | 45.8/s, 424 ms  |
| track_new_delete=true | 170.1/s, 114 ms  |  211.6/s, 91 ms |  222.9/s, 87 ms | 72.1/s, 269 ms  | 71.3/s, 273 ms  | 67.5/s, 288 ms  |  45.7/s, 427 ms |

### 2) TEST 2 - SSB 60003w
```
Env: 1 FE, 1 BE;
Test Set: ssb LINEORDER 60003w;
Default session veriables;
jmeter thread=1;
```
| conf  |  Q1.1(qps, avg time ms) |  Q1.2 | Q1.3  | Q2,1  | Q2.2  | Q3.1  |  Q4.1 |
| ------------ | ------------ | ------------ | ------------ | ------------ | ------------ | ------------ | ------------ |
| track_new_delete=false  |  2.0/s, 490 ms | 12.7/s, 77 ms  | 13.8/s, 72 ms  | 0.0/s, 28306 ms  | 0.0/s, 20577 ms  | 0.0/s, 41081 ms  |  0.0/s, 48236 ms |
| track_new_delete=true | 1.9/s, 525 ms  |  11.8/s, 84 ms | 13.0/s, 76 ms  | 0.0/s, 28531 ms  | 0.0/s, 20970 ms  | 0.0/s, 42959 ms  | 0.0/s, 48723 ms  |

### 3) TEST 3 - small query
```
Env: 1 FE, 1 BE;
Test Set: ssb LINEORDER 600w;
Default session veriables;
jmeter thread=100;
```
|  conf | select LO_EXTENDEDPRICE from LINEORDER2 where LO_EXTENDEDPRICE = 5273584 limit 1;  |
| ------------ | ------------ |
|  track_new_delete=false | 8275.7/s, 11 ms  |
| track_new_delete=true  |  8203.6/s, 11 ms |

## 3. Observability
```
Env: 1 FE, 1 BE
Test Set: ssb LINEORDER 60003w
track_new_delete=true
memory_verbose_trace=true
set parallel_fragment_exec_instance_num=2;
```

```
Test SQL: SSB Q3.1
         SELECT C_NATION, S_NATION, D_YEAR,
          SUM(LO_REVENUE)  AS  REVENUE
          FROM customer, lineorder, supplier, dates
          WHERE  LO_CUSTKEY = C_CUSTKEY
          AND LO_SUPPKEY = S_SUPPKEY
          AND  LO_ORDERDATE = D_DATEKEY
          AND C_REGION = 'ASIA'
          AND S_REGION = 'ASIA'
          AND D_YEAR >= 1992 AND D_YEAR <= 1997
          GROUP BY C_NATION, S_NATION, D_YEAR
          ORDER BY D_YEAR ASC,  REVENUE DESC;
```

see: BeIP:HttpPort/mem_tracker

```
// The Level use to decide whether to show it in web page,
// each MemTracker have a Level less than or equal to parent, only be set explicit,
// TASK contains query, import, compaction, etc.
enum class MemTrackerLevel { OVERVIEW = 0, TASK, INSTANCE, VERBOSE };
````

1. mem_tracker_level=0 (default OVERVIEW)
> init
![image](https://user-images.githubusercontent.com/13197424/164361294-3b81862e-1086-42a5-919b-03a412e30ea8.png)

> query ing
![image](https://user-images.githubusercontent.com/13197424/164362910-2da037e9-c4c1-4cfa-8b4a-2496b071c633.png)

> query done
![image](https://user-images.githubusercontent.com/13197424/164364026-bb4e2a46-ea57-405f-9766-9dce0e176236.png)

2. mem_tracker_level=1 (TASK)
> query ing
![image](https://user-images.githubusercontent.com/13197424/164363613-d3bb11d6-e85f-4f18-b773-e785ec187fbe.png)

3. mem_tracker_level=2 (INSTANCE)
> query ing
![image](https://user-images.githubusercontent.com/13197424/164363991-40b00866-2f86-4a9e-8371-f87779302325.png)

5. mem_tracker_level=3 (VERBOSE)
> query ing
![image](https://user-images.githubusercontent.com/13197424/164364489-10272fc2-1796-4ba2-9e51-9ee4cadfbfbf.png)
![image](https://user-images.githubusercontent.com/13197424/164364505-8699ed53-2cc7-40c5-9860-66276babe103.png)
![image](https://user-images.githubusercontent.com/13197424/164364558-b5113c89-3cbd-4a8c-b78b-80deafb3ecc9.png)
![image](https://user-images.githubusercontent.com/13197424/164364576-bd3b1397-4658-4b3b-b075-b540683087ab.png)

> query done
![image](https://user-images.githubusercontent.com/13197424/164362163-07b8ac1a-9cff-4ce0-9e96-29379e35f62c.png)

> query ing,  set parallel_fragment_exec_instance_num=10;
```
ERROR 1105 (HY000): errCode = 2, detailMessage = Memory limit exceeded: Memory exceed limit. fragment=, details=In TCMalloc Hook, aggregator, while execute get_next., on backend=10.81.85.89. Memory left in process limit=293.08 GB. failed alloc=<Memory limit exceeded: label=queryId=5e72ea753ed5438b-89adf8b2a56f6bf1 TryConsume failed size=4096, used=2147853311, limit=2147483648>. current tracker=ExecNode:VAGGREGATION_NODE (id=7). If this is a query, can change the limit by session variable exec_mem_limit.
```

> query ing,  set parallel_fragment_exec_instance_num=10, set exec_mem_limit= 21474836480;
![image](https://user-images.githubusercontent.com/13197424/164362498-a870f17e-427a-4cf7-89d9-c6fe27fc1f56.png)