### PR TITLE
[enhancement](k8s) Support fqdn mode for be  in k8s enviroment

### DIFF
--- a/docs/en/docs/admin-manual/config/fe-config.md
+++ b/docs/en/docs/admin-manual/config/fe-config.md
@@ -2346,8 +2346,6 @@ Default: 3
 
 Is it possible to dynamically configure: true
 
-Is it a configuration item unique to the Master FE node: true
-
 ### `enable_storage_policy`
 
 Whether to enable the Storage Policy feature. This feature allows users to separate hot and cold data. This feature is still under development. Recommended for test environments only.
@@ -2355,6 +2353,16 @@ Whether to enable the Storage Policy feature. This feature allows users to separ
 Default: false
 
 Is it possible to dynamically configure: true
+
+Is it a configuration item unique to the Master FE node: true
+
+### `enable_fqdn_mode`
+
+This configuration is mainly used in the k8s cluster environment. When enable_fqdn_mode is true, the name of the pod where the be is located will remain unchanged after reconstruction, while the ip can be changed.
+
+Default: false
+
+Is it possible to dynamically configure: false
 
 Is it a configuration item unique to the Master FE node: true
 

--- a/docs/zh-CN/docs/admin-manual/config/fe-config.md
+++ b/docs/zh-CN/docs/admin-manual/config/fe-config.md
@@ -2259,7 +2259,7 @@ load 标签清理器将每隔 `label_clean_interval_second` 运行一次以清�
 
 ### backend_rpc_timeout_ms
 
- FE向BE的BackendService发送rpc请求时的超时时间，单位：毫秒。
+FE向BE的BackendService发送rpc请求时的超时时间，单位：毫秒。
 
 默认值：60000
 
@@ -2278,10 +2278,11 @@ load 标签清理器将每隔 `label_clean_interval_second` 运行一次以清�
 是否为 Master FE 节点独有的配置项：false
 
 
+### enable_fqdn_mode
 
- FE向BE的BackendService发送rpc请求时的超时时间，单位：毫秒。
+此配置用于 k8s 部署环境。当 enable_k8s_detect_container_drift_mode 为 true 时，将允许更改 be 或 broker 的重建 pod的 ip。
 
-默认值：60000
+默认值： false
 
 是否可以动态配置：false
 
@@ -2339,7 +2340,6 @@ load 标签清理器将每隔 `label_clean_interval_second` 运行一次以清�
 是否可以动态配置：true
 
 是否为 Master FE 节点独有的配置项：true
-
 
 ### `max_replica_count_when_schema_change`
 
@@ -2414,3 +2414,12 @@ hive partition 的最大缓存数量。
 
 是否为 Master FE 节点独有的配置项：true
 
+### `enable_fqdn_mode`
+
+此配置用于 k8s 部署环境。当 enable_fqdn_mode 为 true 时，将允许更改 be 的重建 pod的 ip。
+
+默认值： false
+
+是否可以动态配置：false
+
+是否为 Master FE 节点独有的配置项：true

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/BackendClause.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/BackendClause.java
@@ -20,18 +20,18 @@ package org.apache.doris.analysis;
 import org.apache.doris.alter.AlterOpType;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.system.SystemInfoService;
+import org.apache.doris.system.SystemInfoService.HostInfo;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import org.apache.commons.lang.NotImplementedException;
-import org.apache.commons.lang3.tuple.Triple;
 
 import java.util.List;
 import java.util.Map;
 
 public class BackendClause extends AlterClause {
     protected List<String> hostPorts;
-    protected List<Triple<String, String, Integer>> ipHostPortTriples;
+    protected List<HostInfo> hostInfos;
 
     public static final String MUTLI_TAG_DISABLED_MSG = "Not support multi tags for Backend now. "
             + "You can set 'enable_multi_tags=true' in fe.conf to enable this feature.";
@@ -41,20 +41,20 @@ public class BackendClause extends AlterClause {
     protected BackendClause(List<String> hostPorts) {
         super(AlterOpType.ALTER_OTHER);
         this.hostPorts = hostPorts;
-        this.ipHostPortTriples = Lists.newArrayList();
+        this.hostInfos = Lists.newArrayList();
     }
 
-    public List<Triple<String, String, Integer>> getIpHostPortTriples() {
-        return ipHostPortTriples;
+    public List<HostInfo> getHostInfos() {
+        return hostInfos;
     }
 
     @Override
     public void analyze(Analyzer analyzer) throws AnalysisException {
         for (String hostPort : hostPorts) {
-            Triple<String, String, Integer> triple = SystemInfoService.getIpHostAndPort(hostPort, true);
-            ipHostPortTriples.add(triple);
+            HostInfo hostInfo = SystemInfoService.getIpHostAndPort(hostPort, true);
+            hostInfos.add(hostInfo);
         }
-        Preconditions.checkState(!ipHostPortTriples.isEmpty());
+        Preconditions.checkState(!hostInfos.isEmpty());
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/BackendClause.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/BackendClause.java
@@ -19,19 +19,19 @@ package org.apache.doris.analysis;
 
 import org.apache.doris.alter.AlterOpType;
 import org.apache.doris.common.AnalysisException;
-import org.apache.doris.common.Pair;
 import org.apache.doris.system.SystemInfoService;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
 import org.apache.commons.lang.NotImplementedException;
+import org.apache.commons.lang3.tuple.Triple;
 
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
 public class BackendClause extends AlterClause {
     protected List<String> hostPorts;
-    protected List<Pair<String, Integer>> hostPortPairs;
+    protected List<Triple<String, String, Integer>> ipHostPortTriples;
 
     public static final String MUTLI_TAG_DISABLED_MSG = "Not support multi tags for Backend now. "
             + "You can set 'enable_multi_tags=true' in fe.conf to enable this feature.";
@@ -41,21 +41,20 @@ public class BackendClause extends AlterClause {
     protected BackendClause(List<String> hostPorts) {
         super(AlterOpType.ALTER_OTHER);
         this.hostPorts = hostPorts;
-        this.hostPortPairs = new LinkedList<Pair<String, Integer>>();
+        this.ipHostPortTriples = Lists.newArrayList();
     }
 
-    public List<Pair<String, Integer>> getHostPortPairs() {
-        return hostPortPairs;
+    public List<Triple<String, String, Integer>> getIpHostPortTriples() {
+        return ipHostPortTriples;
     }
 
     @Override
     public void analyze(Analyzer analyzer) throws AnalysisException {
         for (String hostPort : hostPorts) {
-            Pair<String, Integer> pair = SystemInfoService.validateHostAndPort(hostPort);
-            hostPortPairs.add(pair);
+            Triple<String, String, Integer> triple = SystemInfoService.getIpHostAndPort(hostPort, true);
+            ipHostPortTriples.add(triple);
         }
-
-        Preconditions.checkState(!hostPortPairs.isEmpty());
+        Preconditions.checkState(!ipHostPortTriples.isEmpty());
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/CancelAlterSystemStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/CancelAlterSystemStmt.java
@@ -20,35 +20,35 @@ package org.apache.doris.analysis;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.Config;
 import org.apache.doris.system.SystemInfoService;
+import org.apache.doris.system.SystemInfoService.HostInfo;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
-import org.apache.commons.lang3.tuple.Triple;
 
 import java.util.List;
 
 public class CancelAlterSystemStmt extends CancelStmt {
 
     protected List<String> hostPorts;
-    private List<Triple<String, String, Integer>> ipHostPortTriples;
+    private List<HostInfo> hostInfos;
 
     public CancelAlterSystemStmt(List<String> hostPorts) {
         this.hostPorts = hostPorts;
-        this.ipHostPortTriples = Lists.newArrayList();
+        this.hostInfos = Lists.newArrayList();
     }
 
-    public List<Triple<String, String, Integer>> getIpHostPortTriples() {
-        return ipHostPortTriples;
+    public List<HostInfo> getHostInfos() {
+        return hostInfos;
     }
 
     @Override
     public void analyze(Analyzer analyzer) throws AnalysisException {
         for (String hostPort : hostPorts) {
-            Triple<String, String, Integer> triple = SystemInfoService.getIpHostAndPort(hostPort,
+            HostInfo hostInfo = SystemInfoService.getIpHostAndPort(hostPort,
                     !Config.enable_fqdn_mode);
-            this.ipHostPortTriples.add(triple);
+            this.hostInfos.add(hostInfo);
         }
-        Preconditions.checkState(!this.ipHostPortTriples.isEmpty());
+        Preconditions.checkState(!this.hostInfos.isEmpty());
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/CancelAlterSystemStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/CancelAlterSystemStmt.java
@@ -18,36 +18,37 @@
 package org.apache.doris.analysis;
 
 import org.apache.doris.common.AnalysisException;
-import org.apache.doris.common.Pair;
+import org.apache.doris.common.Config;
 import org.apache.doris.system.SystemInfoService;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+import org.apache.commons.lang3.tuple.Triple;
 
-import java.util.LinkedList;
 import java.util.List;
 
 public class CancelAlterSystemStmt extends CancelStmt {
 
     protected List<String> hostPorts;
-    private List<Pair<String, Integer>> hostPortPairs;
+    private List<Triple<String, String, Integer>> ipHostPortTriples;
 
     public CancelAlterSystemStmt(List<String> hostPorts) {
         this.hostPorts = hostPorts;
-        this.hostPortPairs = new LinkedList<Pair<String, Integer>>();
+        this.ipHostPortTriples = Lists.newArrayList();
     }
 
-    public List<Pair<String, Integer>> getHostPortPairs() {
-        return hostPortPairs;
+    public List<Triple<String, String, Integer>> getIpHostPortTriples() {
+        return ipHostPortTriples;
     }
 
     @Override
     public void analyze(Analyzer analyzer) throws AnalysisException {
         for (String hostPort : hostPorts) {
-            Pair<String, Integer> pair = SystemInfoService.validateHostAndPort(hostPort);
-            this.hostPortPairs.add(pair);
+            Triple<String, String, Integer> triple = SystemInfoService.getIpHostAndPort(hostPort,
+                    !Config.enable_fqdn_mode);
+            this.ipHostPortTriples.add(triple);
         }
-
-        Preconditions.checkState(!this.hostPortPairs.isEmpty());
+        Preconditions.checkState(!this.ipHostPortTriples.isEmpty());
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/DropBackendClause.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/DropBackendClause.java
@@ -20,9 +20,9 @@ package org.apache.doris.analysis;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.Config;
 import org.apache.doris.system.SystemInfoService;
+import org.apache.doris.system.SystemInfoService.HostInfo;
 
 import com.google.common.base.Preconditions;
-import org.apache.commons.lang3.tuple.Triple;
 
 import java.util.List;
 
@@ -47,11 +47,11 @@ public class DropBackendClause extends BackendClause {
     public void analyze(Analyzer analyzer) throws AnalysisException {
         if (Config.enable_fqdn_mode) {
             for (String hostPort : hostPorts) {
-                Triple<String, String, Integer> triple = SystemInfoService.getIpHostAndPort(hostPort,
+                HostInfo hostInfo = SystemInfoService.getIpHostAndPort(hostPort,
                         !Config.enable_fqdn_mode);
-                ipHostPortTriples.add(triple);
+                hostInfos.add(hostInfo);
             }
-            Preconditions.checkState(!ipHostPortTriples.isEmpty());
+            Preconditions.checkState(!hostInfos.isEmpty());
         } else {
             super.analyze(analyzer);
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/DropBackendClause.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/DropBackendClause.java
@@ -17,6 +17,13 @@
 
 package org.apache.doris.analysis;
 
+import org.apache.doris.common.AnalysisException;
+import org.apache.doris.common.Config;
+import org.apache.doris.system.SystemInfoService;
+
+import com.google.common.base.Preconditions;
+import org.apache.commons.lang3.tuple.Triple;
+
 import java.util.List;
 
 public class DropBackendClause extends BackendClause {
@@ -34,6 +41,20 @@ public class DropBackendClause extends BackendClause {
 
     public boolean isForce() {
         return force;
+    }
+
+    @Override
+    public void analyze(Analyzer analyzer) throws AnalysisException {
+        if (Config.enable_fqdn_mode) {
+            for (String hostPort : hostPorts) {
+                Triple<String, String, Integer> triple = SystemInfoService.getIpHostAndPort(hostPort,
+                        !Config.enable_fqdn_mode);
+                ipHostPortTriples.add(triple);
+            }
+            Preconditions.checkState(!ipHostPortTriples.isEmpty());
+        } else {
+            super.analyze(analyzer);
+        }
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
@@ -216,6 +216,7 @@ import org.apache.doris.statistics.StatisticsManager;
 import org.apache.doris.statistics.StatisticsRepository;
 import org.apache.doris.statistics.StatisticsTaskScheduler;
 import org.apache.doris.system.Backend;
+import org.apache.doris.system.FQDNManager;
 import org.apache.doris.system.Frontend;
 import org.apache.doris.system.HeartbeatMgr;
 import org.apache.doris.system.SystemInfoService;
@@ -446,6 +447,8 @@ public class Env {
 
     private ExternalMetaCacheMgr extMetaCacheMgr;
 
+    private FQDNManager fqdnManager;
+
     public List<Frontend> getFrontends(FrontendNodeType nodeType) {
         if (nodeType == null) {
             // get all
@@ -647,6 +650,7 @@ public class Env {
         this.analysisJobScheduler = new AnalysisJobScheduler();
         this.statisticsCache = new StatisticsCache();
         this.extMetaCacheMgr = new ExternalMetaCacheMgr();
+        this.fqdnManager = new FQDNManager(systemInfo);
     }
 
     public static void destroyCheckpoint() {
@@ -1431,6 +1435,9 @@ public class Env {
         this.statisticsJobScheduler.start();
         this.statisticsTaskScheduler.start();
         new InternalSchemaInitializer().start();
+        if (Config.enable_fqdn_mode) {
+            fqdnManager.start();
+        }
     }
 
     // start threads that should running on all FE

--- a/fe/fe-core/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/Config.java
@@ -1925,5 +1925,14 @@ public class Config extends ConfigBase {
      */
     @ConfField(mutable = true, masterOnly = true)
     public static boolean enable_storage_policy = false;
+
+    /**
+     * This config is mainly used in the k8s cluster environment.
+     * When enable_fqdn_mode is true, the name of the pod where be is located will remain unchanged
+     * after reconstruction, while the ip can be changed.
+     */
+    @ConfField(mutable = false, masterOnly = true)
+    public static boolean enable_fqdn_mode = false;
+    
 }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/Config.java
@@ -1933,6 +1933,5 @@ public class Config extends ConfigBase {
      */
     @ConfField(mutable = false, masterOnly = true)
     public static boolean enable_fqdn_mode = false;
-    
 }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/common/FeConstants.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/FeConstants.java
@@ -35,6 +35,7 @@ public class FeConstants {
 
     public static int heartbeat_interval_second = 5;
     public static int checkpoint_interval_second = 60; // 1 minutes
+    public static int ip_check_interval_second = 5;
 
     // dpp version
     public static String dpp_version = "3_2_0";

--- a/fe/fe-core/src/main/java/org/apache/doris/common/proc/BackendsProcDir.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/proc/BackendsProcDir.java
@@ -119,7 +119,11 @@ public class BackendsProcDir implements ProcDirInterface {
             backendInfo.add(backend.getOwnerClusterName());
             backendInfo.add(backend.getHost());
             if (Strings.isNullOrEmpty(clusterName)) {
-                backendInfo.add(NetUtils.getHostnameByIp(backend.getHost()));
+                if (backend.getHostName() != null) {
+                    backendInfo.add(backend.getHostName());
+                } else {
+                    backendInfo.add(NetUtils.getHostnameByIp(backend.getHost()));
+                }
                 backendInfo.add(String.valueOf(backend.getHeartbeatPort()));
                 backendInfo.add(String.valueOf(backend.getBePort()));
                 backendInfo.add(String.valueOf(backend.getHttpPort()));

--- a/fe/fe-core/src/main/java/org/apache/doris/deploy/DeployManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/deploy/DeployManager.java
@@ -29,13 +29,13 @@ import org.apache.doris.ha.FrontendNodeType;
 import org.apache.doris.system.Backend;
 import org.apache.doris.system.Frontend;
 import org.apache.doris.system.SystemInfoService;
+import org.apache.doris.system.SystemInfoService.HostInfo;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import org.apache.commons.lang.NotImplementedException;
-import org.apache.commons.lang3.tuple.Triple;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -587,12 +587,12 @@ public class DeployManager extends MasterDaemon {
                             env.addFrontend(FrontendNodeType.OBSERVER, remoteIp, remotePort);
                             break;
                         case BACKEND:
-                            List<Triple<String, String, Integer>> newBackends = Lists.newArrayList();
-                            String hostName = NetUtils.getHostnameByIp(remoteIp);
-                            if (hostName.equals(remoteIp)) {
-                                hostName = null;
+                            List<HostInfo> newBackends = Lists.newArrayList();
+                            String remoteHostName = NetUtils.getHostnameByIp(remoteIp);
+                            if (remoteHostName.equals(remoteIp)) {
+                                remoteHostName = null;
                             }
-                            newBackends.add(Triple.of(remoteIp, hostName, remotePort));
+                            newBackends.add(new HostInfo(remoteIp, remoteHostName, remotePort));
                             Env.getCurrentSystemInfo().addBackends(newBackends, false);
                             break;
                         default:

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/CheckDecommissionAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/CheckDecommissionAction.java
@@ -25,10 +25,10 @@ import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.system.Backend;
 import org.apache.doris.system.SystemInfoService;
+import org.apache.doris.system.SystemInfoService.HostInfo;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
-import org.apache.commons.lang3.tuple.Triple;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
@@ -70,18 +70,18 @@ public class CheckDecommissionAction extends RestBaseController {
             return ResponseEntityBuilder.badRequest("No host:port specified");
         }
 
-        List<Triple<String, String, Integer>> ipHostPortTriples = Lists.newArrayList();
+        List<HostInfo> hostInfos = Lists.newArrayList();
         for (String hostPort : hostPortArr) {
             try {
-                Triple<String, String, Integer> triple = SystemInfoService.getIpHostAndPort(hostPort, true);
-                ipHostPortTriples.add(triple);
+                HostInfo hostInfo = SystemInfoService.getIpHostAndPort(hostPort, true);
+                hostInfos.add(hostInfo);
             } catch (AnalysisException e) {
                 return ResponseEntityBuilder.badRequest(e.getMessage());
             }
         }
 
         try {
-            List<Backend> backends = SystemHandler.checkDecommission(ipHostPortTriples);
+            List<Backend> backends = SystemHandler.checkDecommission(hostInfos);
             List<String> backendsList = backends.stream().map(b -> b.getHost() + ":"
                     + b.getHeartbeatPort()).collect(Collectors.toList());
             return ResponseEntityBuilder.ok(backendsList);

--- a/fe/fe-core/src/main/java/org/apache/doris/system/Backend.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/system/Backend.java
@@ -617,7 +617,7 @@ public class Backend implements Writable {
 
     @Override
     public String toString() {
-        return "Backend [id=" + id + ", ip=" + ip + ", heartbeatPort=" + heartbeatPort + ", alive=" + isAlive.get()
+        return "Backend [id=" + id + ", host=" + ip + ", heartbeatPort=" + heartbeatPort + ", alive=" + isAlive.get()
                 + ", tags: " + tagMap + "]";
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/system/Backend.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/system/Backend.java
@@ -69,7 +69,7 @@ public class Backend implements Writable {
     @SerializedName("id")
     private long id;
     @SerializedName("host")
-    private volatile String host;
+    private volatile String ip;
     @SerializedName("hostName")
     private String hostName;
     private String version;
@@ -143,7 +143,7 @@ public class Backend implements Writable {
     private int heartbeatFailureCounter = 0;
 
     public Backend() {
-        this.host = "";
+        this.ip = "";
         this.version = "";
         this.lastUpdateMs = 0;
         this.lastStartTime = 0;
@@ -167,7 +167,7 @@ public class Backend implements Writable {
 
     public Backend(long id, String ip, String hostName, int heartbeatPort) {
         this.id = id;
-        this.host = ip;
+        this.ip = ip;
         this.hostName = hostName;
         this.version = "";
         this.heartbeatPort = heartbeatPort;
@@ -192,7 +192,7 @@ public class Backend implements Writable {
     }
 
     public String getHost() {
-        return host;
+        return ip;
     }
 
     public String getHostName() {
@@ -288,8 +288,8 @@ public class Backend implements Writable {
         this.backendState = state.ordinal();
     }
 
-    public void setHost(String host) {
-        this.host = host;
+    public void setHost(String ip) {
+        this.ip = ip;
     }
 
     public void setAlive(boolean isAlive) {
@@ -597,7 +597,7 @@ public class Backend implements Writable {
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, host, heartbeatPort, bePort, isAlive);
+        return Objects.hash(id, ip, heartbeatPort, bePort, isAlive);
     }
 
     @Override
@@ -611,13 +611,13 @@ public class Backend implements Writable {
 
         Backend backend = (Backend) obj;
 
-        return (id == backend.id) && (host.equals(backend.host)) && (heartbeatPort == backend.heartbeatPort)
+        return (id == backend.id) && (ip.equals(backend.ip)) && (heartbeatPort == backend.heartbeatPort)
                 && (bePort == backend.bePort) && (isAlive.get() == backend.isAlive.get());
     }
 
     @Override
     public String toString() {
-        return "Backend [id=" + id + ", host=" + host + ", heartbeatPort=" + heartbeatPort + ", alive=" + isAlive.get()
+        return "Backend [id=" + id + ", ip=" + ip + ", heartbeatPort=" + heartbeatPort + ", alive=" + isAlive.get()
                 + ", tags: " + tagMap + "]";
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/system/FQDNManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/system/FQDNManager.java
@@ -1,0 +1,73 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.system;
+
+import org.apache.doris.catalog.Env;
+import org.apache.doris.common.ClientPool;
+import org.apache.doris.common.FeConstants;
+import org.apache.doris.common.util.MasterDaemon;
+import org.apache.doris.thrift.TNetworkAddress;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+public class FQDNManager extends MasterDaemon {
+    private static final Logger LOG = LogManager.getLogger(FQDNManager.class);
+
+    private SystemInfoService nodeMgr;
+
+    public FQDNManager(SystemInfoService nodeMgr) {
+        super("FQDN mgr", FeConstants.ip_check_interval_second * 1000L);
+        this.nodeMgr = nodeMgr;
+    }
+
+    /**
+     * At each round: check if ip of be has already been changed
+     */
+    @Override
+    protected void runAfterCatalogReady() {
+        for (Backend be : nodeMgr.getIdToBackend().values()) {
+            if (be.getHostName() != null) {
+                try {
+                    InetAddress inetAddress = InetAddress.getByName(be.getHostName());
+                    if (!be.getHost().equalsIgnoreCase(inetAddress.getHostAddress())) {
+                        String ip = be.getHost();
+                        if (!ip.equalsIgnoreCase("unknown")) {
+                            ClientPool.backendPool.clearPool(new TNetworkAddress(ip, be.getBePort()));
+                        }
+                        be.setHost(inetAddress.getHostAddress());
+                        Env.getCurrentEnv().getEditLog().logBackendStateChange(be);
+                        LOG.warn("ip for {} of be has been changed from {} to {}", be.getHostName(), ip, be.getHost());
+                    }
+                } catch (UnknownHostException e) {
+                    LOG.warn("unknown host name for be, {}", be.getHostName(), e);
+                    if (!be.isAlive() && !be.getHost().equalsIgnoreCase("unknown")) {
+                        String ip = be.getHost();
+                        ClientPool.backendPool.clearPool(new TNetworkAddress(ip, be.getBePort()));
+                        be.setHost("unknown");
+                        Env.getCurrentEnv().getEditLog().logBackendStateChange(be);
+                        LOG.warn("ip for {} of be has been changed from {} to {}", be.getHostName(), ip, "unknown");
+                    }
+                }
+            }
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/system/FQDNManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/system/FQDNManager.java
@@ -32,6 +32,8 @@ import java.net.UnknownHostException;
 public class FQDNManager extends MasterDaemon {
     private static final Logger LOG = LogManager.getLogger(FQDNManager.class);
 
+    public static final String  UNKNOWN_HOST_IP = "unknown";
+
     private SystemInfoService nodeMgr;
 
     public FQDNManager(SystemInfoService nodeMgr) {
@@ -50,7 +52,7 @@ public class FQDNManager extends MasterDaemon {
                     InetAddress inetAddress = InetAddress.getByName(be.getHostName());
                     if (!be.getHost().equalsIgnoreCase(inetAddress.getHostAddress())) {
                         String ip = be.getHost();
-                        if (!ip.equalsIgnoreCase("unknown")) {
+                        if (!ip.equalsIgnoreCase(UNKNOWN_HOST_IP)) {
                             ClientPool.backendPool.clearPool(new TNetworkAddress(ip, be.getBePort()));
                         }
                         be.setHost(inetAddress.getHostAddress());
@@ -59,10 +61,11 @@ public class FQDNManager extends MasterDaemon {
                     }
                 } catch (UnknownHostException e) {
                     LOG.warn("unknown host name for be, {}", be.getHostName(), e);
-                    if (!be.isAlive() && !be.getHost().equalsIgnoreCase("unknown")) {
+                    // add be alive check to make ip work when be is still alive and dns has some problem.
+                    if (!be.isAlive() && !be.getHost().equalsIgnoreCase(UNKNOWN_HOST_IP)) {
                         String ip = be.getHost();
                         ClientPool.backendPool.clearPool(new TNetworkAddress(ip, be.getBePort()));
-                        be.setHost("unknown");
+                        be.setHost(UNKNOWN_HOST_IP);
                         Env.getCurrentEnv().getEditLog().logBackendStateChange(be);
                         LOG.warn("ip for {} of be has been changed from {} to {}", be.getHostName(), ip, "unknown");
                     }

--- a/fe/fe-core/src/main/java/org/apache/doris/system/HeartbeatMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/system/HeartbeatMgr.java
@@ -145,7 +145,6 @@ public class HeartbeatMgr extends MasterDaemon {
                 }
             } catch (InterruptedException | ExecutionException e) {
                 LOG.warn("got exception when doing heartbeat", e);
-                continue;
             }
         } // end for all results
 

--- a/fe/fe-core/src/main/java/org/apache/doris/system/SystemInfoService.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/system/SystemInfoService.java
@@ -31,6 +31,7 @@ import org.apache.doris.common.Pair;
 import org.apache.doris.common.Status;
 import org.apache.doris.common.UserException;
 import org.apache.doris.common.io.CountingDataOutputStream;
+import org.apache.doris.common.util.NetUtils;
 import org.apache.doris.metric.MetricRepo;
 import org.apache.doris.resource.Tag;
 import org.apache.doris.system.Backend.BackendState;
@@ -44,6 +45,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
+import org.apache.commons.lang3.tuple.Triple;
 import org.apache.commons.validator.routines.InetAddressValidator;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -95,27 +97,33 @@ public class SystemInfoService {
     };
 
     // for deploy manager
-    public void addBackends(List<Pair<String, Integer>> hostPortPairs, boolean isFree) throws UserException {
-        addBackends(hostPortPairs, isFree, "", Tag.DEFAULT_BACKEND_TAG.toMap());
+    public void addBackends(List<Triple<String, String, Integer>> ipHostPortTriples, boolean isFree)
+            throws UserException {
+        addBackends(ipHostPortTriples, isFree, "", Tag.DEFAULT_BACKEND_TAG.toMap());
     }
 
     /**
-     * @param hostPortPairs : backend's host and port
+     * @param ipHostPortTriples : backend's ip, hostName and port
      * @param isFree : if true the backend is not owned by any cluster
      * @param destCluster : if not null or empty backend will be added to destCluster
      * @throws DdlException
      */
-    public void addBackends(List<Pair<String, Integer>> hostPortPairs, boolean isFree, String destCluster,
+    public void addBackends(List<Triple<String, String, Integer>> ipHostPortTriples, boolean isFree, String destCluster,
             Map<String, String> tagMap) throws UserException {
-        for (Pair<String, Integer> pair : hostPortPairs) {
+        for (Triple<String, String, Integer> triple : ipHostPortTriples) {
+            if (Config.enable_fqdn_mode && triple.getMiddle() == null) {
+                throw new DdlException("backend's hostName should not be null while enable_fqdn_mode is true");
+            }
             // check is already exist
-            if (getBackendWithHeartbeatPort(pair.first, pair.second) != null) {
-                throw new DdlException("Same backend already exists[" + pair.first + ":" + pair.second + "]");
+            if (getBackendWithHeartbeatPort(triple.getLeft(), triple.getMiddle(), triple.getRight()) != null) {
+                String backendIdentifier = (Config.enable_fqdn_mode ? triple.getMiddle() : triple.getLeft()) + ":"
+                        + triple.getRight();
+                throw new DdlException("Same backend already exists[" + backendIdentifier + "]");
             }
         }
 
-        for (Pair<String, Integer> pair : hostPortPairs) {
-            addBackend(pair.first, pair.second, isFree, destCluster, tagMap);
+        for (Triple<String, String, Integer> triple : ipHostPortTriples) {
+            addBackend(triple.getLeft(), triple.getMiddle(), triple.getRight(), isFree, destCluster, tagMap);
         }
     }
 
@@ -136,9 +144,9 @@ public class SystemInfoService {
     }
 
     // Final entry of adding backend
-    private void addBackend(String host, int heartbeatPort, boolean isFree, String destCluster,
+    private void addBackend(String ip, String hostName, int heartbeatPort, boolean isFree, String destCluster,
             Map<String, String> tagMap) {
-        Backend newBackend = new Backend(Env.getCurrentEnv().getNextId(), host, heartbeatPort);
+        Backend newBackend = new Backend(Env.getCurrentEnv().getNextId(), ip, hostName, heartbeatPort);
         // update idToBackend
         Map<Long, Backend> copiedBackends = Maps.newHashMap(idToBackendRef);
         copiedBackends.put(newBackend.getId(), newBackend);
@@ -172,16 +180,17 @@ public class SystemInfoService {
         MetricRepo.generateBackendsTabletMetrics();
     }
 
-    public void dropBackends(List<Pair<String, Integer>> hostPortPairs) throws DdlException {
-        for (Pair<String, Integer> pair : hostPortPairs) {
+    public void dropBackends(List<Triple<String, String, Integer>> ipHostPortTriples) throws DdlException {
+        for (Triple<String, String, Integer> triple : ipHostPortTriples) {
             // check is already exist
-            if (getBackendWithHeartbeatPort(pair.first, pair.second) == null) {
-                throw new DdlException("backend does not exists[" + pair.first + ":" + pair.second + "]");
+            if (getBackendWithHeartbeatPort(triple.getLeft(), triple.getMiddle(), triple.getRight()) == null) {
+                String backendIdentifier = (triple.getLeft() == null ? triple.getMiddle() : triple.getLeft()) + ":"
+                        + triple.getRight();
+                throw new DdlException("backend does not exists[" + backendIdentifier + "]");
             }
         }
-
-        for (Pair<String, Integer> pair : hostPortPairs) {
-            dropBackend(pair.first, pair.second);
+        for (Triple<String, String, Integer> triple : ipHostPortTriples) {
+            dropBackend(triple.getLeft(), triple.getMiddle(), triple.getRight());
         }
     }
 
@@ -192,17 +201,16 @@ public class SystemInfoService {
             throw new DdlException("Backend[" + backendId + "] does not exist");
         }
 
-        dropBackend(backend.getHost(), backend.getHeartbeatPort());
+        dropBackend(backend.getHost(), backend.getHostName(), backend.getHeartbeatPort());
     }
 
     // final entry of dropping backend
-    public void dropBackend(String host, int heartbeatPort) throws DdlException {
-        if (getBackendWithHeartbeatPort(host, heartbeatPort) == null) {
-            throw new DdlException("backend does not exists[" + host + ":" + heartbeatPort + "]");
+    public void dropBackend(String ip, String hostName, int heartbeatPort) throws DdlException {
+        Backend droppedBackend = getBackendWithHeartbeatPort(ip, hostName, heartbeatPort);
+        if (droppedBackend == null) {
+            throw new DdlException("backend does not exists[" + (ip == null ? hostName : ip)
+                    + ":" + heartbeatPort + "]");
         }
-
-        Backend droppedBackend = getBackendWithHeartbeatPort(host, heartbeatPort);
-
         // update idToBackend
         Map<Long, Backend> copiedBackends = Maps.newHashMap(idToBackendRef);
         copiedBackends.remove(droppedBackend.getId());
@@ -274,10 +282,16 @@ public class SystemInfoService {
         return true;
     }
 
-    public Backend getBackendWithHeartbeatPort(String host, int heartPort) {
+    public Backend getBackendWithHeartbeatPort(String ip, String hostName, int heartPort) {
         ImmutableMap<Long, Backend> idToBackend = idToBackendRef;
         for (Backend backend : idToBackend.values()) {
-            if (backend.getHost().equals(host) && backend.getHeartbeatPort() == heartPort) {
+            if (hostName != null) {
+                if (hostName.equals(backend.getHostName()) && backend.getHeartbeatPort() == heartPort) {
+                    return backend;
+                }
+            }
+
+            if (backend.getHost().equals(ip) && backend.getHeartbeatPort() == heartPort) {
                 return backend;
             }
         }
@@ -901,7 +915,8 @@ public class SystemInfoService {
         this.idToReportVersionRef = null;
     }
 
-    public static Pair<String, Integer> validateHostAndPort(String hostPort) throws AnalysisException {
+    public static Triple<String, String, Integer> getIpHostAndPort(String hostPort, boolean strictCheck)
+            throws AnalysisException {
         hostPort = hostPort.replaceAll("\\s+", "");
         if (hostPort.isEmpty()) {
             throw new AnalysisException("Invalid host port: " + hostPort);
@@ -912,36 +927,48 @@ public class SystemInfoService {
             throw new AnalysisException("Invalid host port: " + hostPort);
         }
 
-        String host = pair[0];
-        if (Strings.isNullOrEmpty(host)) {
+        String hostName = pair[0];
+        String ip = hostName;
+        if (Strings.isNullOrEmpty(hostName)) {
             throw new AnalysisException("Host is null");
         }
 
         int heartbeatPort = -1;
         try {
-            // validate host
-            if (!InetAddressValidator.getInstance().isValid(host)) {
-                // maybe this is a hostname
-                // if no IP address for the host could be found, 'getByName'
-                // will throw
-                // UnknownHostException
-                InetAddress inetAddress = InetAddress.getByName(host);
-                host = inetAddress.getHostAddress();
-            }
-
             // validate port
             heartbeatPort = Integer.parseInt(pair[1]);
-
             if (heartbeatPort <= 0 || heartbeatPort >= 65536) {
                 throw new AnalysisException("Port is out of range: " + heartbeatPort);
             }
 
-            return Pair.of(host, heartbeatPort);
+            // validate host
+            if (!InetAddressValidator.getInstance().isValid(ip)) {
+                // maybe this is a hostname
+                // if no IP address for the host could be found, 'getByName'
+                // will throw UnknownHostException
+                InetAddress inetAddress = InetAddress.getByName(hostName);
+                ip = inetAddress.getHostAddress();
+            } else {
+                hostName = NetUtils.getHostnameByIp(ip);
+                if (hostName.equals(ip)) {
+                    hostName = null;
+                }
+            }
+            return Triple.of(ip, hostName, heartbeatPort);
         } catch (UnknownHostException e) {
+            if (!strictCheck) {
+                return Triple.of(null, hostName, heartbeatPort);
+            }
             throw new AnalysisException("Unknown host: " + e.getMessage());
         } catch (Exception e) {
             throw new AnalysisException("Encounter unknown exception: " + e.getMessage());
         }
+    }
+
+
+    public static Pair<String, Integer> validateHostAndPort(String hostPort) throws AnalysisException {
+        Triple<String, String, Integer> ipHostPortTriple = getIpHostAndPort(hostPort, true);
+        return Pair.of(ipHostPortTriple.getLeft(), ipHostPortTriple.getRight());
     }
 
     public void replayAddBackend(Backend newBackend) {
@@ -996,25 +1023,25 @@ public class SystemInfoService {
     public void updateBackendState(Backend be) {
         long id = be.getId();
         Backend memoryBe = getBackend(id);
-        if (memoryBe == null) {
-            // backend may already be dropped. this may happen when
-            // 1. SystemHandler drop the decommission backend
-            // 2. at same time, user try to cancel the decommission of that backend.
-            // These two operations do not guarantee the order.
-            return;
+        // backend may already be dropped. this may happen when
+        // drop and modify operations do not guarantee the order.
+        if (memoryBe != null) {
+            if (be.getHostName() != null && !be.getHost().equalsIgnoreCase(memoryBe.getHost())) {
+                memoryBe.setHost(be.getHost());
+            }
+            memoryBe.setBePort(be.getBePort());
+            memoryBe.setAlive(be.isAlive());
+            memoryBe.setDecommissioned(be.isDecommissioned());
+            memoryBe.setHttpPort(be.getHttpPort());
+            memoryBe.setBeRpcPort(be.getBeRpcPort());
+            memoryBe.setBrpcPort(be.getBrpcPort());
+            memoryBe.setLastUpdateMs(be.getLastUpdateMs());
+            memoryBe.setLastStartTime(be.getLastStartTime());
+            memoryBe.setDisks(be.getDisks());
+            memoryBe.setBackendState(be.getBackendState());
+            memoryBe.setOwnerClusterName(be.getOwnerClusterName());
+            memoryBe.setDecommissionType(be.getDecommissionType());
         }
-        memoryBe.setBePort(be.getBePort());
-        memoryBe.setAlive(be.isAlive());
-        memoryBe.setDecommissioned(be.isDecommissioned());
-        memoryBe.setHttpPort(be.getHttpPort());
-        memoryBe.setBeRpcPort(be.getBeRpcPort());
-        memoryBe.setBrpcPort(be.getBrpcPort());
-        memoryBe.setLastUpdateMs(be.getLastUpdateMs());
-        memoryBe.setLastStartTime(be.getLastStartTime());
-        memoryBe.setDisks(be.getDisks());
-        memoryBe.setBackendState(be.getBackendState());
-        memoryBe.setOwnerClusterName(be.getOwnerClusterName());
-        memoryBe.setDecommissionType(be.getDecommissionType());
     }
 
     private long getClusterAvailableCapacityB(String clusterName) {
@@ -1110,12 +1137,14 @@ public class SystemInfoService {
     }
 
     public void modifyBackends(ModifyBackendClause alterClause) throws UserException {
-        List<Pair<String, Integer>> hostPortPairs = alterClause.getHostPortPairs();
+        List<Triple<String, String, Integer>> ipHostPortTriples = alterClause.getIpHostPortTriples();
         List<Backend> backends = Lists.newArrayList();
-        for (Pair<String, Integer> pair : hostPortPairs) {
-            Backend be = getBackendWithHeartbeatPort(pair.first, pair.second);
+        for (Triple<String, String, Integer> triple : ipHostPortTriples) {
+            Backend be = getBackendWithHeartbeatPort(triple.getLeft(), triple.getMiddle(), triple.getRight());
             if (be == null) {
-                throw new DdlException("backend does not exists[" + pair.first + ":" + pair.second + "]");
+                throw new DdlException("backend does not exists["
+                        + (Config.enable_fqdn_mode ? triple.getMiddle() : triple.getLeft())
+                        + ":" + triple.getRight() + "]");
             }
             backends.add(be);
         }

--- a/fe/fe-core/src/test/java/org/apache/doris/cluster/SystemInfoServiceTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/cluster/SystemInfoServiceTest.java
@@ -218,13 +218,13 @@ public class SystemInfoServiceTest {
         AddBackendClause stmt = new AddBackendClause(Lists.newArrayList("192.168.0.1:1234"));
         stmt.analyze(analyzer);
         try {
-            Env.getCurrentSystemInfo().addBackends(stmt.getIpHostPortTriples(), true);
+            Env.getCurrentSystemInfo().addBackends(stmt.getHostInfos(), true);
         } catch (DdlException e) {
             Assert.fail();
         }
 
         try {
-            Env.getCurrentSystemInfo().addBackends(stmt.getIpHostPortTriples(), true);
+            Env.getCurrentSystemInfo().addBackends(stmt.getHostInfos(), true);
         } catch (DdlException e) {
             Assert.assertTrue(e.getMessage().contains("already exists"));
         }
@@ -247,7 +247,7 @@ public class SystemInfoServiceTest {
         AddBackendClause stmt = new AddBackendClause(Lists.newArrayList("192.168.0.1:1234"));
         stmt.analyze(analyzer);
         try {
-            Env.getCurrentSystemInfo().addBackends(stmt.getIpHostPortTriples(), true);
+            Env.getCurrentSystemInfo().addBackends(stmt.getHostInfos(), true);
         } catch (DdlException e) {
             e.printStackTrace();
         }
@@ -255,14 +255,14 @@ public class SystemInfoServiceTest {
         DropBackendClause dropStmt = new DropBackendClause(Lists.newArrayList("192.168.0.1:1234"));
         dropStmt.analyze(analyzer);
         try {
-            Env.getCurrentSystemInfo().dropBackends(dropStmt.getIpHostPortTriples());
+            Env.getCurrentSystemInfo().dropBackends(dropStmt.getHostInfos());
         } catch (DdlException e) {
             e.printStackTrace();
             Assert.fail();
         }
 
         try {
-            Env.getCurrentSystemInfo().dropBackends(dropStmt.getIpHostPortTriples());
+            Env.getCurrentSystemInfo().dropBackends(dropStmt.getHostInfos());
         } catch (DdlException e) {
             Assert.assertTrue(e.getMessage().contains("does not exist"));
         }

--- a/fe/fe-core/src/test/java/org/apache/doris/cluster/SystemInfoServiceTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/cluster/SystemInfoServiceTest.java
@@ -218,19 +218,19 @@ public class SystemInfoServiceTest {
         AddBackendClause stmt = new AddBackendClause(Lists.newArrayList("192.168.0.1:1234"));
         stmt.analyze(analyzer);
         try {
-            Env.getCurrentSystemInfo().addBackends(stmt.getHostPortPairs(), true);
+            Env.getCurrentSystemInfo().addBackends(stmt.getIpHostPortTriples(), true);
         } catch (DdlException e) {
             Assert.fail();
         }
 
         try {
-            Env.getCurrentSystemInfo().addBackends(stmt.getHostPortPairs(), true);
+            Env.getCurrentSystemInfo().addBackends(stmt.getIpHostPortTriples(), true);
         } catch (DdlException e) {
             Assert.assertTrue(e.getMessage().contains("already exists"));
         }
 
         Assert.assertNotNull(Env.getCurrentSystemInfo().getBackend(backendId));
-        Assert.assertNotNull(Env.getCurrentSystemInfo().getBackendWithHeartbeatPort("192.168.0.1", 1234));
+        Assert.assertNotNull(Env.getCurrentSystemInfo().getBackendWithHeartbeatPort("192.168.0.1", null, 1234));
 
         Assert.assertTrue(Env.getCurrentSystemInfo().getBackendIds(false).size() == 1);
         Assert.assertTrue(Env.getCurrentSystemInfo().getBackendIds(false).get(0) == backendId);
@@ -247,7 +247,7 @@ public class SystemInfoServiceTest {
         AddBackendClause stmt = new AddBackendClause(Lists.newArrayList("192.168.0.1:1234"));
         stmt.analyze(analyzer);
         try {
-            Env.getCurrentSystemInfo().addBackends(stmt.getHostPortPairs(), true);
+            Env.getCurrentSystemInfo().addBackends(stmt.getIpHostPortTriples(), true);
         } catch (DdlException e) {
             e.printStackTrace();
         }
@@ -255,14 +255,14 @@ public class SystemInfoServiceTest {
         DropBackendClause dropStmt = new DropBackendClause(Lists.newArrayList("192.168.0.1:1234"));
         dropStmt.analyze(analyzer);
         try {
-            Env.getCurrentSystemInfo().dropBackends(dropStmt.getHostPortPairs());
+            Env.getCurrentSystemInfo().dropBackends(dropStmt.getIpHostPortTriples());
         } catch (DdlException e) {
             e.printStackTrace();
             Assert.fail();
         }
 
         try {
-            Env.getCurrentSystemInfo().dropBackends(dropStmt.getHostPortPairs());
+            Env.getCurrentSystemInfo().dropBackends(dropStmt.getIpHostPortTriples());
         } catch (DdlException e) {
             Assert.assertTrue(e.getMessage().contains("does not exist"));
         }

--- a/fe/fe-core/src/test/java/org/apache/doris/system/FQDNManagerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/system/FQDNManagerTest.java
@@ -1,0 +1,87 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.system;
+
+import org.apache.doris.catalog.Env;
+import org.apache.doris.common.Config;
+
+import mockit.Expectations;
+import mockit.Mock;
+import mockit.MockUp;
+import mockit.Mocked;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+public class FQDNManagerTest {
+    @Mocked
+    private InetAddress inetAddress;
+
+    @Mocked
+    private Env env;
+
+    private FQDNManager fdqnManager;
+
+    private SystemInfoService systemInfoService;
+
+    @Before
+    public void setUp() throws UnknownHostException {
+        new MockUp<InetAddress>(InetAddress.class) {
+            @Mock
+            public InetAddress getByName(String hostName) {
+                return inetAddress;
+            }
+        };
+
+        new MockUp<Env>(Env.class) {
+            @Mock
+            public Env getServingEnv() {
+                return env;
+            }
+        };
+
+        new Expectations() {
+            {
+                env.isReady();
+                minTimes = 0;
+                result = true;
+
+                inetAddress.getHostAddress();
+                minTimes = 0;
+                result = "193.88.67.99";
+            }
+        };
+
+        Config.enable_fqdn_mode = true;
+        systemInfoService = new SystemInfoService();
+        systemInfoService.addBackend(new Backend(1, "193.88.67.98", "doris.test.domain", 9090));
+        fdqnManager = new FQDNManager(systemInfoService);
+    }
+
+    @Test
+    public void testBackendIpChanged() throws InterruptedException {
+        Assert.assertEquals("193.88.67.98", systemInfoService.getBackend(1).getHost());
+        fdqnManager.start();
+        Thread.sleep(1000);
+        Assert.assertEquals("193.88.67.99", systemInfoService.getBackend(1).getHost());
+        fdqnManager.exit();
+    }
+}


### PR DESCRIPTION
# Proposed changes

Issue Number: close #9171 

## Problem Summary:

In the k8s environment, the ip of the pod  can be changed, but the  hostname of pod is stable. When the host machine of the pod fails, the k8s can schedule the failed pod to the new host machine for reconstruction. After that, the newly created pod's hostname remains unchanged, and the ip address has been changed. The change of the be node's ip address can be detected by FQDNManager when enable_fqdn_mode is true

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
