### PR TITLE
avoiding a corrupt image file when there is image.ckpt with non-zero …

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Catalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Catalog.java
@@ -1966,8 +1966,13 @@ public class Catalog {
     }
 
     public void saveImage(File curFile, long replayedJournalId) throws IOException {
-        if (!curFile.exists()) {
-            curFile.createNewFile();
+        if (curFile.exists()) {
+            if (!curFile.delete()) {
+                throw new IOException(curFile.getName() + " can not be deleted.");
+            }
+        }
+        if (!curFile.createNewFile()) {
+            throw new IOException(curFile.getName() + " can not be created.");
         }
         MetaWriter.write(curFile, this);
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/common/MetaFooter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/MetaFooter.java
@@ -98,6 +98,7 @@ public class MetaFooter {
             long endIndex = raf.length();
             raf.writeLong(endIndex - startIndex);
             MetaMagicNumber.write(raf);
+            raf.getFD().sync();
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/common/MetaFooter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/MetaFooter.java
@@ -98,7 +98,7 @@ public class MetaFooter {
             long endIndex = raf.length();
             raf.writeLong(endIndex - startIndex);
             MetaMagicNumber.write(raf);
-            raf.getFD().sync();
+            raf.getChannel.force(true);
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/common/MetaHeader.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/MetaHeader.java
@@ -83,7 +83,7 @@ public class MetaHeader {
             raf.seek(0);
             MetaMagicNumber.write(raf);
             MetaJsonHeader.write(raf);
-            raf.getFD().sync();
+            raf.getChannel.force(true);
             return raf.getFilePointer();
         }
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/common/MetaHeader.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/MetaHeader.java
@@ -75,10 +75,15 @@ public class MetaHeader {
     }
 
     public static long write(File imageFile) throws IOException {
+        if (imageFile.length() != 0) {
+            throw new IOException("Meta header has to be written to an empty file.");
+        }
+
         try (RandomAccessFile raf = new RandomAccessFile(imageFile, "rw")) {
             raf.seek(0);
             MetaMagicNumber.write(raf);
             MetaJsonHeader.write(raf);
+            raf.getFD().sync();
             return raf.getFilePointer();
         }
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/common/MetaWriter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/MetaWriter.java
@@ -129,8 +129,8 @@ public class MetaWriter {
             checksum.setRef(writer.doWork("plugins", () -> catalog.savePlugins(dos, checksum.getRef())));
             checksum.setRef(writer.doWork("deleteHandler", () -> catalog.saveDeleteHandler(dos, checksum.getRef())));
             checksum.setRef(writer.doWork("sqlBlockRule", () -> catalog.saveSqlBlockRule(dos, checksum.getRef())));
+            imageFileOut.getChannel().force(true);
         }
-        imageFileOut.getFD().sync();
         MetaFooter.write(imageFile, metaIndices, checksum.getRef());
 
         long saveImageEndTime = System.currentTimeMillis();

--- a/fe/fe-core/src/main/java/org/apache/doris/common/MetaWriter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/MetaWriter.java
@@ -95,12 +95,12 @@ public class MetaWriter {
     public static void write(File imageFile, Catalog catalog) throws IOException {
         // save image does not need any lock. because only checkpoint thread will call this method.
         LOG.info("start to save image to {}. is ckpt: {}", imageFile.getAbsolutePath(), Catalog.isCheckpointThread());
-        FileOutputStream imageFileOut = new FileOutputStream(imageFile);
         final Reference<Long> checksum = new Reference<>(0L);
         long saveImageStartTime = System.currentTimeMillis();
         // MetaHeader should use output stream in the future.
         long startPosition = MetaHeader.write(imageFile);
         List<MetaIndex> metaIndices = Lists.newArrayList();
+        FileOutputStream imageFileOut = new FileOutputStream(imageFile, true);
         try (CountingDataOutputStream dos = new CountingDataOutputStream(new BufferedOutputStream(
                 imageFileOut), startPosition)) {
             writer.setDelegate(dos, metaIndices);


### PR DESCRIPTION
…size

For now, saveImage writes data to image.ckpt via an append FileOutputStream,
when there is a non-zero size file named image.ckpt, a disaster would happen
due to a corrupt image file. Even worse, fe only keeps the lastest image file
and removes others.

BTW, image file should be synced to disk.

It is dangerous to only keep the latest image file, because an image file is
validated when generating the next image file. Then we keep an non validated
image file but remove validated ones. So I will issue a pr which keeps at least
2 image file.

# Proposed changes
I have not tested the change, so please do not merge now.

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
