### PR TITLE
[Improvement](Docs)Apache Doris Developer Manual - Metadata Design Documentation D…

### DIFF
--- a/docs/zh-CN/internal/metadata-design.md
+++ b/docs/zh-CN/internal/metadata-design.md
@@ -72,7 +72,7 @@ Doris 的元数据是全内存的。每个 FE 内存中，都维护一个完整�
 
 2. 日志写入 bdbje 后，bdbje 会根据策略（写多数/全写），将日志复制到其他 non-leader 的 FE 节点。non-leader FE 节点通过对日志回放，修改自身的元数据内存镜像，完成与 leader 节点的元数据同步。
 
-3. leader fe 节点启动时，会创建并启动 leaderCheckpointer  线程（运行间隔默认六十秒）。checkpoint 会读取已有的 image 文件，和其之后的日志，重新在内存中回放出一份新的元数据镜像副本。然后将该副本写入到磁盘，形成一个新的 image。之所以是重新生成一份镜像副本，而不是将已有镜像写成 image，主要是考虑写 image 加读锁期间，会阻塞写操作。所以每次 checkpoint 会占用双倍内存空间。
+3. leader 节点的日志条数达到阈值（默认 10w 条）并且满足checkpoint线程执行周期（默认六十秒）。checkpoint 会读取已有的 image 文件，和其之后的日志，重新在内存中回放出一份新的元数据镜像副本。然后将该副本写入到磁盘，形成一个新的 image。之所以是重新生成一份镜像副本，而不是将已有镜像写成 image，主要是考虑写 image 加读锁期间，会阻塞写操作。所以每次 checkpoint 会占用双倍内存空间。
 
 4. image 文件生成后，leader 节点会通知其他 non-leader 节点新的 image 已生成。non-leader 主动通过 http 拉取最新的 image 文件，来更换本地的旧文件。
 

--- a/docs/zh-CN/internal/metadata-design.md
+++ b/docs/zh-CN/internal/metadata-design.md
@@ -72,7 +72,7 @@ Doris 的元数据是全内存的。每个 FE 内存中，都维护一个完整�
 
 2. 日志写入 bdbje 后，bdbje 会根据策略（写多数/全写），将日志复制到其他 non-leader 的 FE 节点。non-leader FE 节点通过对日志回放，修改自身的元数据内存镜像，完成与 leader 节点的元数据同步。
 
-3. leader 节点的日志条数达到阈值后（默认 10w 条），会启动 checkpoint 线程。checkpoint 会读取已有的 image 文件，和其之后的日志，重新在内存中回放出一份新的元数据镜像副本。然后将该副本写入到磁盘，形成一个新的 image。之所以是重新生成一份镜像副本，而不是将已有镜像写成 image，主要是考虑写 image 加读锁期间，会阻塞写操作。所以每次 checkpoint 会占用双倍内存空间。
+3. leader fe 节点启动时，会创建并启动 leaderCheckpointer  线程（运行间隔默认六十秒）。checkpoint 会读取已有的 image 文件，和其之后的日志，重新在内存中回放出一份新的元数据镜像副本。然后将该副本写入到磁盘，形成一个新的 image。之所以是重新生成一份镜像副本，而不是将已有镜像写成 image，主要是考虑写 image 加读锁期间，会阻塞写操作。所以每次 checkpoint 会占用双倍内存空间。
 
 4. image 文件生成后，leader 节点会通知其他 non-leader 节点新的 image 已生成。non-leader 主动通过 http 拉取最新的 image 文件，来更换本地的旧文件。
 


### PR DESCRIPTION
…escription Error
The content described in the developer manual does not match the source code
#9179

# Proposed changes
Modify the content of the developer manual

Issue Number: close #9179 

## Problem Summary:Fe Leader 节点启动时，会创建并启动 leaderCheckpointer  线程（运行间隔默认六十秒）。leaderCheckpointer 会读取已存在最新的image文件和最新同步Edit log（journal_id）,对已存在最新的image进行回放，然后形成新的image并保存。之所以是重新生成一份镜像副本，而不是将已有镜像写成 image，主要是考虑写 image 加读锁期间，会阻塞写操作。所以每次 checkpoint 会占用双倍内存空间。

Describe the overview of changes.
None

## Checklist(Required)

1. Does it affect the original behavior: Yes
2. Has unit tests been added: No Need
3. Has document been added or modified: Yes
4. Does it need to update dependencies: No
5. Are there any changes that cannot be rolled back: No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
