### PR TITLE
[BUG] fix sequence bug in non-vec mode

### DIFF
--- a/be/src/olap/collect_iterator.cpp
+++ b/be/src/olap/collect_iterator.cpp
@@ -273,8 +273,8 @@ CollectIterator::Level1Iterator::Level1Iterator(
         const std::list<CollectIterator::LevelIterator*>& children,
         bool merge, bool reverse, int sequence_id_idx, uint64_t* merge_count,
         SortType sort_type, int sort_col_num)
-        : _children(children), _merge(merge), _reverse(reverse), _merged_rows(merge_count),
-        _sort_type(sort_type), _sort_col_num(sort_col_num) {}
+        : _children(children), _merge(merge), _reverse(reverse), _sequence_id_idx(sequence_id_idx),
+        _merged_rows(merge_count), _sort_type(sort_type), _sort_col_num(sort_col_num) {}
 
 CollectIterator::LevelIterator::~LevelIterator() = default;
 


### PR DESCRIPTION
# Proposed changes

fix sequence bug in non-vec mode

## Problem Summary:

add sequence idx init in rowest merge

## Checklist(Required)

1. Does it affect the original behavior: (No)
2. Has unit tests been added: (No Need)
3. Has document been added or modified: (No Need)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
