### PR TITLE
keep at least one validated image file

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Catalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Catalog.java
@@ -1531,7 +1531,7 @@ public class Catalog {
     private void getNewImage(Pair<String, Integer> helperNode) throws IOException {
         long localImageVersion = 0;
         Storage storage = new Storage(this.imageDir);
-        localImageVersion = storage.getImageSeq();
+        localImageVersion = storage.getLatestImageSeq();
 
         try {
             URL infoUrl = new URL("http://" + helperNode.first + ":" + Config.http_port + "/info");
@@ -1617,7 +1617,7 @@ public class Catalog {
             LOG.info("image does not exist: {}", curFile.getAbsolutePath());
             return;
         }
-        replayedJournalId.set(storage.getImageSeq());
+        replayedJournalId.set(storage.getLatestImageSeq());
         MetaReader.read(curFile, this);
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/controller/HaController.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/controller/HaController.java
@@ -134,7 +134,7 @@ public class HaController {
             Map<String, Object> checkPoint = new HashMap<>();
             Storage storage = new Storage(Config.meta_dir + "/image");
             checkPoint.put("Name", "Version");
-            checkPoint.put("Value", storage.getImageSeq());
+            checkPoint.put("Value", storage.getLatestImageSeq());
             list.add(checkPoint);
             long lastCheckpointTime = storage.getCurrentImageFile().lastModified();
             Date date = new Date(lastCheckpointTime);

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/meta/MetaService.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/meta/MetaService.java
@@ -111,7 +111,7 @@ public class MetaService extends RestBaseController {
         try {
             Storage currentStorageInfo = new Storage(imageDir.getAbsolutePath());
             StorageInfo storageInfo = new StorageInfo(currentStorageInfo.getClusterID(),
-                    currentStorageInfo.getImageSeq(), currentStorageInfo.getEditsSeq());
+                    currentStorageInfo.getLatestImageSeq(), currentStorageInfo.getEditsSeq());
             return ResponseEntityBuilder.ok(storageInfo);
         } catch (IOException e) {
             return ResponseEntityBuilder.internalError(e.getMessage());

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/ShowAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/ShowAction.java
@@ -242,7 +242,7 @@ public class ShowAction extends RestBaseController {
         feInfo.put("is_ready", String.valueOf(Catalog.getCurrentCatalog().isReady()));
 
         Storage storage = new Storage(Config.meta_dir + "/image");
-        feInfo.put("last_checkpoint_version", String.valueOf(storage.getImageSeq()));
+        feInfo.put("last_checkpoint_version", String.valueOf(storage.getLatestImageSeq()));
         long lastCheckpointTime = storage.getCurrentImageFile().lastModified();
         feInfo.put("last_checkpoint_time", String.valueOf(lastCheckpointTime));
 

--- a/fe/fe-core/src/main/java/org/apache/doris/master/Checkpoint.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/master/Checkpoint.java
@@ -184,7 +184,9 @@ public class Checkpoint extends MasterDaemon {
         if (successPushed == otherNodesCount) {
             try {
                 long minOtherNodesJournalId = Long.MAX_VALUE;
-                long deleteVersion = checkPointVersion;
+                // Actually, storage.getLatestValidatedImageSeq returns number before this
+                // checkpoint.
+                long deleteVersion = storage.getLatestValidatedImageSeq();
                 if (successPushed > 0) {
                     for (Frontend fe : allFrontends) {
                         String host = fe.getHost();
@@ -220,7 +222,7 @@ public class Checkpoint extends MasterDaemon {
                             }
                         }
                     }
-                    deleteVersion = Math.min(minOtherNodesJournalId, checkPointVersion);
+                    deleteVersion = Math.min(minOtherNodesJournalId, deleteVersion);
                 }
 
                 editLog.deleteJournals(deleteVersion + 1);

--- a/fe/fe-core/src/main/java/org/apache/doris/master/Checkpoint.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/master/Checkpoint.java
@@ -83,7 +83,7 @@ public class Checkpoint extends MasterDaemon {
         try {
             storage = new Storage(imageDir);
             // get max image version
-            imageVersion = storage.getImageSeq();
+            imageVersion = storage.getLatestImageSeq();
             // get max finalized journal id
             checkPointVersion = editLog.getFinalizedJournalId();
             LOG.info("last checkpoint journal id: {}, current finalized journal id: {}", imageVersion, checkPointVersion);

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/MetaCleaner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/MetaCleaner.java
@@ -34,7 +34,7 @@ public class MetaCleaner {
 
     public void clean() throws IOException {
         Storage storage = new Storage(imageDir);
-        long currentVersion = storage.getImageSeq();
+        long currentVersion = storage.getLatestImageSeq();
         long imageDeleteVersion = currentVersion - 1;
 
         File currentImage = storage.getImageFile(currentVersion);

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/MetaCleaner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/MetaCleaner.java
@@ -34,7 +34,7 @@ public class MetaCleaner {
 
     public void clean() throws IOException {
         Storage storage = new Storage(imageDir);
-        long currentVersion = storage.getLatestImageSeq();
+        long currentVersion = storage.getLatestValidatedImageSeq();
         long imageDeleteVersion = currentVersion - 1;
 
         File currentImage = storage.getImageFile(currentVersion);

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/Storage.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/Storage.java
@@ -61,6 +61,7 @@ public class Storage {
     private String nodeName;
     private long editsSeq;
     private long latestImageSeq;
+    private long latestValidatedImageSeq;
     private String metaDir;
     private List<Long> editsFileSequenceNumbers;
 
@@ -126,7 +127,11 @@ public class Storage {
                 if (!name.equals(EDITS) && !name.equals(IMAGE_NEW)
                     && !name.endsWith(".part") && name.contains(".")) {
                     if (name.startsWith(IMAGE)) {
-                        latestImageSeq = Math.max(Long.parseLong(name.substring(name.lastIndexOf('.') + 1)), latestImageSeq);
+                        long fileSeq = Long.parseLong(name.substring(name.lastIndexOf('.') + 1));
+                        if (latestImageSeq < fileSeq) {
+                            latestValidatedImageSeq = latestImageSeq;
+                            latestImageSeq = fileSeq;
+                        }
                     } else if (name.startsWith(EDITS)) {
                         // Just record the sequence part of the file name
                         editsFileSequenceNumbers.add(Long.parseLong(name.substring(name.lastIndexOf('.') + 1)));
@@ -173,6 +178,10 @@ public class Storage {
 
     public long getLatestImageSeq() {
         return latestImageSeq;
+    }
+
+    public long getLatestValidatedImageSeq() {
+        return latestValidatedImageSeq;
     }
 
     public void setLatestImageSeq(long latestImageSeq) {

--- a/fe/fe-core/src/test/java/org/apache/doris/persist/StorageTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/persist/StorageTest.java
@@ -102,7 +102,7 @@ public class StorageTest {
 
         Storage storage2 = new Storage(1, "token", 2, 3, "test");
         Assert.assertEquals(1, storage2.getClusterID());
-        Assert.assertEquals(2, storage2.getImageSeq());
+        Assert.assertEquals(2, storage2.getLatestImageSeq());
         Assert.assertEquals(3, storage2.getEditsSeq());
         Assert.assertEquals("test", storage2.getMetaDir());
     }
@@ -116,7 +116,7 @@ public class StorageTest {
         Assert.assertEquals(966271669, storage.getClusterID());
         storage.setClusterID(1234);
         Assert.assertEquals(1234, storage.getClusterID());
-        Assert.assertEquals(0, storage.getImageSeq());
+        Assert.assertEquals(0, storage.getLatestImageSeq());
         Assert.assertEquals(10, Storage.getMetaSeq(new File("storageTestDir/edits.10")));
         Assert.assertTrue(Storage.getCurrentEditsFile(new File("storageTestDir"))
                 .equals(new File("storageTestDir/edits")));
@@ -133,8 +133,8 @@ public class StorageTest {
 
         Assert.assertTrue(storage.getVersionFile().equals(new File("storageTestDir/VERSION")));
 
-        storage.setImageSeq(100);
-        Assert.assertEquals(100, storage.getImageSeq());
+        storage.setLatestImageSeq(100);
+        Assert.assertEquals(100, storage.getLatestImageSeq());
 
         storage.setEditsSeq(100);
         Assert.assertEquals(100, storage.getEditsSeq());


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

We should keep at least one validated image file and edit log.  #9011 achieve the goal by running loadImage just after the image file is generated, then we keep an image file generated just now.  It works too. However, we should assure the newly generated file is flushed to disk, actually it is hard due to cache on disk itself especially if a power off happened.

Because I wrote the code yesterday, and noted by @caiconghui today that #9011 did the similar job. So I send out the code for discussing.

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
