### PR TITLE
[Feature]Add multi-thread probe to hash join

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,12 @@ docs/.temp
 output/
 conf/
 rpc_data/
+docs/.vuepress/dist
+docs/node_modules
+docs/build
+gensrc/build
+fe/fe-core/target
+fe/fe-core/bin
 thirdparty/src
 thirdparty/installed
 
@@ -63,6 +69,9 @@ samples/doris-demo/remote-udf-cpp-demo/*.o
 samples/doris-demo/remote-udf-cpp-demo/*.pb.h
 samples/doris-demo/remote-udf-cpp-demo/*.pb.cc
 samples/doris-demo/remote-udf-cpp-demo/function_server_demo
+regression-test/framework/target
+regression-test/framework/dependency-reduced-pom.xml
+regression-test/framework/bin
 
 # FE
 fe/mocked/

--- a/be/src/vec/exec/join/vhash_join_node.cpp
+++ b/be/src/vec/exec/join/vhash_join_node.cpp
@@ -681,10 +681,10 @@ public:
         _work_queue.shutdown();
     }
 
-    virtual void join() { _threads.join_all(); }
+    void join() { _threads.join_all(); }
 
 private:
-    virtual bool is_shutdown() { return _shutdown; }
+    bool is_shutdown() { return _shutdown; }
 
     void work_thread(int thread_id) {
         while (!is_shutdown()) {
@@ -1199,13 +1199,13 @@ Status HashJoinNode::open(RuntimeState* state) {
     RETURN_IF_ERROR(_hash_table_build(state));
     RETURN_IF_ERROR(child(0)->open(state));
 
-    if (state->query_options().hash_join_probe_thread_count > 1) {
+    if (state->query_options().hash_join_probe_thread_num > 1) {
         std::visit(
                 [&](auto&& arg) {
                     using HashTableCtxType = std::decay_t<decltype(arg)>;
                     if constexpr (!std::is_same_v<HashTableCtxType, std::monostate>) {
                         if constexpr (!HashTableCtxType::State::Cache::consecutive_keys_optimization) {
-                            _probe_thread_count = state->query_options().hash_join_probe_thread_count;
+                            _probe_thread_count = state->query_options().hash_join_probe_thread_num;
                         }
                     } else {
                         LOG(FATAL) << "FATAL: uninited hash table";

--- a/docs/en/administrator-guide/variables.md
+++ b/docs/en/administrator-guide/variables.md
@@ -140,7 +140,7 @@ Note that the comment must start with /*+ and can only follow the SELECT.
 
     Used to set the level of LLVM codegen. (Not currently in effect).
 
-- `hash_join_probe_thread_count`
+- `hash_join_probe_thread_num`
 
     The number of worker threads for probe when setting hash join
 

--- a/docs/en/administrator-guide/variables.md
+++ b/docs/en/administrator-guide/variables.md
@@ -139,7 +139,11 @@ Note that the comment must start with /*+ and can only follow the SELECT.
 * `codegen_level`
 
     Used to set the level of LLVM codegen. (Not currently in effect).
-    
+
+- `hash_join_probe_thread_count`
+
+    The number of worker threads for probe when setting hash join
+
 * `collation_connection`
 
     Used for compatibility with MySQL clients. No practical effect.

--- a/docs/zh-CN/administrator-guide/variables.md
+++ b/docs/zh-CN/administrator-guide/variables.md
@@ -137,7 +137,11 @@ SELECT /*+ SET_VAR(query_timeout = 1, enable_partition_cache=true) */ sleep(3);
 * `codegen_level`
 
     用于设置 LLVM codegen 的等级。（当前未生效）。
-    
+
+- `hash_join_probe_thread_count`
+
+    用于设置 hash join 时 probe 的工作线程数
+
 * `collation_connection`
 
     用于兼容 MySQL 客户端。无实际作用。

--- a/docs/zh-CN/administrator-guide/variables.md
+++ b/docs/zh-CN/administrator-guide/variables.md
@@ -138,7 +138,7 @@ SELECT /*+ SET_VAR(query_timeout = 1, enable_partition_cache=true) */ sleep(3);
 
     用于设置 LLVM codegen 的等级。（当前未生效）。
 
-- `hash_join_probe_thread_count`
+- `hash_join_probe_thread_num`
 
     用于设置 hash join 时 probe 的工作线程数
 

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -71,7 +71,7 @@ public class SessionVariable implements Serializable, Writable {
     public static final String SQL_SAFE_UPDATES = "sql_safe_updates";
     public static final String NET_BUFFER_LENGTH = "net_buffer_length";
     public static final String CODEGEN_LEVEL = "codegen_level";
-    public static final String HASH_JOIN_PROBE_THREAD_COUNT = "hash_join_probe_thread_count";
+    public static final String HASH_JOIN_PROBE_THREAD_NUM = "hash_join_probe_thread_num";
     // mem limit can't smaller than bufferpool's default page size
     public static final int MIN_EXEC_MEM_LIMIT = 2097152;
     public static final String BATCH_SIZE = "batch_size";
@@ -304,8 +304,8 @@ public class SessionVariable implements Serializable, Writable {
     @VariableMgr.VarAttr(name = CODEGEN_LEVEL)
     public int codegenLevel = 0;
 
-    @VariableMgr.VarAttr(name = HASH_JOIN_PROBE_THREAD_COUNT)
-    public int hashJoinProbeThreadCount = 1;
+    @VariableMgr.VarAttr(name = HASH_JOIN_PROBE_THREAD_NUM)
+    public int hashJoinProbeThreadNum = 1;
 
     @VariableMgr.VarAttr(name = BATCH_SIZE)
     public int batchSize = 1024;
@@ -587,8 +587,8 @@ public class SessionVariable implements Serializable, Writable {
         return codegenLevel;
     }
 
-    public int getHashJoinProbeThreadCount() {
-        return hashJoinProbeThreadCount;
+    public int getHashJoinProbeThreadNum() {
+        return hashJoinProbeThreadNum;
     }
 
     public void setMaxExecMemByte(long maxExecMemByte) {
@@ -935,7 +935,7 @@ public class SessionVariable implements Serializable, Writable {
         tResult.setCodegenLevel(codegenLevel);
         tResult.setEnableVectorizedEngine(enableVectorizedEngine);
         tResult.setReturnObjectDataAsBinary(returnObjectDataAsBinary);
-        tResult.setHashJoinProbeThreadCount(hashJoinProbeThreadCount);
+        tResult.setHashJoinProbeThreadNum(hashJoinProbeThreadNum);
 
         tResult.setBatchSize(batchSize);
         tResult.setDisableStreamPreaggregations(disableStreamPreaggregations);

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -71,6 +71,7 @@ public class SessionVariable implements Serializable, Writable {
     public static final String SQL_SAFE_UPDATES = "sql_safe_updates";
     public static final String NET_BUFFER_LENGTH = "net_buffer_length";
     public static final String CODEGEN_LEVEL = "codegen_level";
+    public static final String HASH_JOIN_PROBE_THREAD_COUNT = "hash_join_probe_thread_count";
     // mem limit can't smaller than bufferpool's default page size
     public static final int MIN_EXEC_MEM_LIMIT = 2097152;
     public static final String BATCH_SIZE = "batch_size";
@@ -302,6 +303,9 @@ public class SessionVariable implements Serializable, Writable {
     // if true, need report to coordinator when plan fragment execute successfully.
     @VariableMgr.VarAttr(name = CODEGEN_LEVEL)
     public int codegenLevel = 0;
+
+    @VariableMgr.VarAttr(name = HASH_JOIN_PROBE_THREAD_COUNT)
+    public int hashJoinProbeThreadCount = 1;
 
     @VariableMgr.VarAttr(name = BATCH_SIZE)
     public int batchSize = 1024;
@@ -581,6 +585,10 @@ public class SessionVariable implements Serializable, Writable {
 
     public int getCodegenLevel() {
         return codegenLevel;
+    }
+
+    public int getHashJoinProbeThreadCount() {
+        return hashJoinProbeThreadCount;
     }
 
     public void setMaxExecMemByte(long maxExecMemByte) {
@@ -927,6 +935,7 @@ public class SessionVariable implements Serializable, Writable {
         tResult.setCodegenLevel(codegenLevel);
         tResult.setEnableVectorizedEngine(enableVectorizedEngine);
         tResult.setReturnObjectDataAsBinary(returnObjectDataAsBinary);
+        tResult.setHashJoinProbeThreadCount(hashJoinProbeThreadCount);
 
         tResult.setBatchSize(batchSize);
         tResult.setDisableStreamPreaggregations(disableStreamPreaggregations);

--- a/gensrc/thrift/PaloInternalService.thrift
+++ b/gensrc/thrift/PaloInternalService.thrift
@@ -160,6 +160,8 @@ struct TQueryOptions {
   // show bitmap data in result, if use this in mysql cli may make the terminal
   // output corrupted character
   43: optional bool return_object_data_as_binary = false
+
+  44: optional i32 hash_join_probe_thread_count = 1
 }
     
 

--- a/gensrc/thrift/PaloInternalService.thrift
+++ b/gensrc/thrift/PaloInternalService.thrift
@@ -161,7 +161,7 @@ struct TQueryOptions {
   // output corrupted character
   43: optional bool return_object_data_as_binary = false
 
-  44: optional i32 hash_join_probe_thread_count = 1
+  44: optional i32 hash_join_probe_thread_num = 1
 }
     
 

--- a/new-docs/en/advanced/variables.md
+++ b/new-docs/en/advanced/variables.md
@@ -140,7 +140,7 @@ Note that the comment must start with /*+ and can only follow the SELECT.
 
     Used to set the level of LLVM codegen. (Not currently in effect).
 
-- `hash_join_probe_thread_count`
+- `hash_join_probe_thread_num`
 
     The number of worker threads for probe when setting hash join
 

--- a/new-docs/en/advanced/variables.md
+++ b/new-docs/en/advanced/variables.md
@@ -139,7 +139,11 @@ Note that the comment must start with /*+ and can only follow the SELECT.
 * `codegen_level`
 
     Used to set the level of LLVM codegen. (Not currently in effect).
-    
+
+- `hash_join_probe_thread_count`
+
+    The number of worker threads for probe when setting hash join
+
 * `collation_connection`
 
     Used for compatibility with MySQL clients. No practical effect.

--- a/new-docs/zh-CN/advanced/variables.md
+++ b/new-docs/zh-CN/advanced/variables.md
@@ -136,6 +136,10 @@ SELECT /*+ SET_VAR(query_timeout = 1, enable_partition_cache=true) */ sleep(3);
 
   用于设置 LLVM codegen 的等级。（当前未生效）。
 
+- `hash_join_probe_thread_count`
+
+  用于设置 hash join 时 probe 的工作线程数
+
 - `collation_connection`
 
   用于兼容 MySQL 客户端。无实际作用。

--- a/new-docs/zh-CN/advanced/variables.md
+++ b/new-docs/zh-CN/advanced/variables.md
@@ -136,7 +136,7 @@ SELECT /*+ SET_VAR(query_timeout = 1, enable_partition_cache=true) */ sleep(3);
 
   用于设置 LLVM codegen 的等级。（当前未生效）。
 
-- `hash_join_probe_thread_count`
+- `hash_join_probe_thread_num`
 
   用于设置 hash join 时 probe 的工作线程数
 


### PR DESCRIPTION
# Proposed changes

Issue Number: close #9207

## Problem Summary:

This PR can speed up from `2s994ms` to `1s637ms` (ProbeTime)

Probe with single thread:
```bash
    VHASH_JOIN_NODE (id=2):(Active: 4s416ms, non-child: 94.74%)
       - BuildBuckets: 33.55M
       - PeakMemoryUsage: 64.01 MB
       - PushDownComputeTime: 272.247ms
       - PushDownTime: 5.502ms
       - RowsReturned: 59.99M
       - RowsReturnedRate: 13.58 M/sec
      ProbePhase:
         - ProbeExprCallTime: 5.595ms
         - ProbeFindNextTime: 142.053ms
         - ProbeRows: 59.99M
         - ProbeTime: 2s994ms
         - ProbeWhenBuildSideOutputTime: 64.291ms
         - ProbeWhenProbeSideOutputTime: 147.390ms
         - ProbeWhenSearchHashTableTime: 2s538ms
```

With multi-thread(4 threads for probe, 1 thread for child get_next):
```bash
    VHASH_JOIN_NODE (id=2):(Active: 3s084ms, non-child: 85.80%)
       - BuildBuckets: 33.55M
       - PeakMemoryUsage: 64.01 MB
       - PushDownComputeTime: 275.238ms
       - PushDownTime: 5.053ms
       - RowsReturned: 59.99M
       - RowsReturnedRate: 19.45 M/sec
      ProbePhase:
         - ProbeExprCallTime: 8.637ms
         - ProbeFindNextTime: 343.064ms
         - ProbeRows: 59.99M
         - ProbeTime: 1s637ms
         - ProbeWhenBuildSideOutputTime: 90.551ms
         - ProbeWhenProbeSideOutputTime: 330.718ms
         - ProbeWhenSearchHashTableTime: 3s670ms
```

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
