### PR TITLE
[feature-wip](decimalv3)(step1) fe passes precision and scale of decimal to be

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ArithmeticExpr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ArithmeticExpr.java
@@ -24,6 +24,7 @@ import org.apache.doris.catalog.Function;
 import org.apache.doris.catalog.FunctionSet;
 import org.apache.doris.catalog.PrimitiveType;
 import org.apache.doris.catalog.ScalarFunction;
+import org.apache.doris.catalog.ScalarType;
 import org.apache.doris.catalog.Type;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.util.VectorizedUtil;
@@ -306,6 +307,126 @@ public class ArithmeticExpr extends Expr {
         }
     }
 
+    private void analyzeNoneDecimalOp(Type t1, Type t2) throws AnalysisException {
+        Type commonType;
+        switch (op) {
+            case MULTIPLY:
+            case ADD:
+            case SUBTRACT:
+                if (isConstant()) {
+                    castUpperInteger(t1, t2);
+                }
+                break;
+            case MOD:
+                if ((t1.isFloatingPointType() || t2.isFloatingPointType()) && !t1.equals(t2)) {
+                    castBinaryOp(Type.DOUBLE);
+                }
+                break;
+            case INT_DIVIDE:
+                if (!t1.isFixedPointType() || !t2.isFloatingPointType()) {
+                    castBinaryOp(Type.BIGINT);
+                }
+                break;
+            case DIVIDE:
+                t1 = getChild(0).getType().getNumResultType();
+                t2 = getChild(1).getType().getNumResultType();
+                commonType = findCommonType(t1, t2);
+                if (commonType.getPrimitiveType() == PrimitiveType.BIGINT
+                        || commonType.getPrimitiveType() == PrimitiveType.LARGEINT) {
+                    commonType = Type.DOUBLE;
+                }
+                castBinaryOp(commonType);
+                break;
+            case BITAND:
+            case BITOR:
+            case BITXOR:
+                if (t1 == Type.BOOLEAN && t2 == Type.BOOLEAN) {
+                    t1 = Type.TINYINT;
+                    t2 = Type.TINYINT;
+                }
+                commonType = Type.getAssignmentCompatibleType(t1, t2, false);
+                if (commonType.getPrimitiveType().ordinal() > PrimitiveType.LARGEINT.ordinal()) {
+                    commonType = Type.BIGINT;
+                }
+                type = castBinaryOp(commonType);
+                break;
+            default:
+                Preconditions.checkState(false,
+                        "Unknown arithmetic operation " + op.toString() + " in: " + this.toSql());
+                break;
+        }
+    }
+
+    public static Type convertIntToDecimalV2Type(Type type) throws AnalysisException {
+        if (type.isLargeIntType()) {
+            return ScalarType.createDecimalV2Type(ScalarType.MAX_DECIMAL128_PRECISION, 0);
+        } else if (type.isBigIntType()) {
+            return ScalarType.createDecimalV2Type(ScalarType.MAX_DECIMAL64_PRECISION, 0);
+        } else if (type.isInteger32Type()) {
+            return ScalarType.createDecimalV2Type(ScalarType.MAX_DECIMAL32_PRECISION, 0);
+        } else {
+            Preconditions.checkState(false,
+                    "Implicit converting to decimal for arithmetic operations only support integer");
+            return Type.INVALID;
+        }
+    }
+
+    private void analyzeDecimalOp(Type t1, Type t2) throws AnalysisException {
+        Type t1TargetType = t1;
+        Type t2TargetType = t2;
+        switch (op) {
+            case MULTIPLY:
+            case ADD:
+            case SUBTRACT:
+            case MOD:
+            case DIVIDE:
+                if (t1.isFloatingPointType() || t2.isFloatingPointType()) {
+                    castBinaryOp(type.DOUBLE);
+                    break;
+                }
+                if (!t1.isDecimalV2()) {
+                    t1TargetType = convertIntToDecimalV2Type(t1);
+                    castChild(t1TargetType, 0);
+                }
+                if (!t2.isDecimalV2()) {
+                    t2TargetType = convertIntToDecimalV2Type(t2);
+                    castChild(t2TargetType, 1);
+                }
+                final int t1Precision = ((ScalarType) t1TargetType).getScalarPrecision();
+                final int t2Precision = ((ScalarType) t2TargetType).getScalarPrecision();
+                final int t1Scale = ((ScalarType) t1TargetType).getScalarScale();
+                final int t2Scale = ((ScalarType) t2TargetType).getScalarScale();
+                final int precision = Math.max(t1Precision, t2Precision);
+                int scale = Math.max(t1Scale, t2Scale);
+                if (op == Operator.MULTIPLY) {
+                    scale = t1Scale + t2Scale;
+                }
+                if (op == Operator.DIVIDE) {
+                    scale = t1Scale;
+                }
+                type = ScalarType.createWiderDecimalV2Type(precision, scale);
+                break;
+            case INT_DIVIDE:
+                if (!t1.isFixedPointType() || !t2.isFloatingPointType()) {
+                    castBinaryOp(Type.BIGINT);
+                }
+                break;
+            case BITAND:
+            case BITOR:
+            case BITXOR:
+                type = castBinaryOp(Type.BIGINT);
+                break;
+            case BITNOT:
+                break;
+            case FACTORIAL:
+                break;
+            default:
+                Preconditions.checkState(false,
+                        "Unknown arithmetic operation " + op.toString() + " in: " + this.toSql());
+                break;
+        }
+    }
+
     @Override
     public void analyzeImpl(Analyzer analyzer) throws AnalysisException {
         if (VectorizedUtil.isVectorized()) {
@@ -333,7 +454,6 @@ public class ArithmeticExpr extends Expr {
 
             Type t1 = getChild(0).getType();
             Type t2 = getChild(1).getType();
-            Type commonType;
 
             // Support null operation
             if (t1.isNull() || t2.isNull()) {
@@ -352,55 +472,10 @@ public class ArithmeticExpr extends Expr {
                 t2 = t2.getNumResultType();
             }
 
-            switch (op) {
-                case MULTIPLY:
-                case ADD:
-                case SUBTRACT:
-                    if (t1.isDecimalV2() || t2.isDecimalV2()) {
-                        castBinaryOp(findCommonType(t1, t2));
-                    }
-                    if (isConstant()) {
-                        castUpperInteger(t1, t2);
-                    }
-                case MOD:
-                    if (t1.isDecimalV2() || t2.isDecimalV2()) {
-                        castBinaryOp(findCommonType(t1, t2));
-                    } else if ((t1.isFloatingPointType() || t2.isFloatingPointType()) && !t1.equals(t2)) {
-                        castBinaryOp(Type.DOUBLE);
-                    }
-                    break;
-                case INT_DIVIDE:
-                    if (!t1.isFixedPointType() || !t2.isFloatingPointType()) {
-                        castBinaryOp(Type.BIGINT);
-                    }
-                    break;
-                case DIVIDE:
-                    t1 = getChild(0).getType().getNumResultType();
-                    t2 = getChild(1).getType().getNumResultType();
-                    commonType = findCommonType(t1, t2);
-                    if (commonType.getPrimitiveType() == PrimitiveType.BIGINT
-                            || commonType.getPrimitiveType() == PrimitiveType.LARGEINT) {
-                        commonType = Type.DOUBLE;
-                    }
-                    castBinaryOp(commonType);
-                    break;
-                case BITAND:
-                case BITOR:
-                case BITXOR:
-                    if (t1 == Type.BOOLEAN && t2 == Type.BOOLEAN) {
-                        t1 = Type.TINYINT;
-                        t2 = Type.TINYINT;
-                    }
-                    commonType = Type.getAssignmentCompatibleType(t1, t2, false);
-                    if (commonType.getPrimitiveType().ordinal() > PrimitiveType.LARGEINT.ordinal()) {
-                        commonType = Type.BIGINT;
-                    }
-                    type = castBinaryOp(commonType);
-                    break;
-                default:
-                    Preconditions.checkState(false,
-                            "Unknown arithmetic operation " + op.toString() + " in: " + this.toSql());
-                    break;
+            if (t1.isDecimalV2() || t2.isDecimalV2()) {
+                analyzeDecimalOp(t1, t2);
+            } else {
+                analyzeNoneDecimalOp(t1, t2);
             }
             fn = getBuiltinFunction(analyzer, op.name, collectChildReturnTypes(),
                     Function.CompareMode.IS_IDENTICAL);
@@ -408,7 +483,9 @@ public class ArithmeticExpr extends Expr {
                 Preconditions.checkState(false, String.format(
                         "No match for vec function '%s' with operand types %s and %s", toSql(), t1, t2));
             }
-            type = fn.getReturnType();
+            if (!type.isValid()) {
+                type = fn.getReturnType();
+            }
         } else {
             // bitnot is the only unary op, deal with it here
             if (op == Operator.BITNOT) {

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/DecimalLiteral.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/DecimalLiteral.java
@@ -18,6 +18,7 @@
 package org.apache.doris.analysis;
 
 import org.apache.doris.catalog.PrimitiveType;
+import org.apache.doris.catalog.ScalarType;
 import org.apache.doris.catalog.Type;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.NotImplementedException;
@@ -73,9 +74,32 @@ public class DecimalLiteral extends LiteralExpr {
         return new DecimalLiteral(this);
     }
 
+    // The precision is the number of digits in the unscaled value for BigDecimal.
+    // The unscaled value of BigDecimal computes this * 10^this.scale().
+    // If zero or positive, the scale is the number of digits to the right of the decimal point.
+    // If negative, the unscaled value of the number is multiplied by ten to the power of the negation of the scale.
+    // There are two scenarios that do not meet the limit: 0 < P and 0 <= S <= P
+    // case1: S >= 0 and S > P. i.e. BigDecimal(0.01234), precision = 4, scale = 5
+    // case2: S < 0. i.e. BigDecimal(2000), precision = 1, scale = -3
+    public static int getBigDecimalPrecision(BigDecimal decimal) {
+        int scale = decimal.scale();
+        int precision = decimal.precision();
+        if (scale < 0) {
+            return Math.abs(scale) + precision;
+        } else {
+            return Math.max(scale, precision);
+        }
+    }
+
+    public static int getBigDecimalScale(BigDecimal decimal) {
+        return Math.max(0, decimal.scale());
+    }
+
     private void init(BigDecimal value) {
         this.value = value;
-        type = Type.DECIMALV2;
+        int precision = getBigDecimalPrecision(this.value);
+        int scale = getBigDecimalScale(this.value);
+        type = ScalarType.createDecimalV2Type(precision, scale);
     }
 
     public BigDecimal getValue() {

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/FunctionCallExpr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/FunctionCallExpr.java
@@ -81,20 +81,21 @@ public class FunctionCallExpr extends Expr {
 
     private static final ImmutableSet<String> STDDEV_FUNCTION_SET =
             new ImmutableSortedSet.Builder(String.CASE_INSENSITIVE_ORDER)
-                    .add("stddev").add("stddev_val").add("stddev_samp")
+                    .add("stddev").add("stddev_val").add("stddev_samp").add("stddev_pop")
                     .add("variance").add("variance_pop").add("variance_pop").add("var_samp").add("var_pop").build();
     private static final ImmutableSet<String> DECIMAL_SAME_TYPE_SET =
-        new ImmutableSortedSet.Builder(String.CASE_INSENSITIVE_ORDER)
-            .add("min").add("max").add("lead").add("lag")
-            .add("first_value").add("last_value").add("abs")
-            .add("positive").add("negative").build();
+            new ImmutableSortedSet.Builder(String.CASE_INSENSITIVE_ORDER)
+                    .add("min").add("max").add("lead").add("lag")
+                    .add("first_value").add("last_value").add("abs")
+                    .add("positive").add("negative").build();
     private static final ImmutableSet<String> DECIMAL_WIDER_TYPE_SET =
-        new ImmutableSortedSet.Builder(String.CASE_INSENSITIVE_ORDER)
-            .add("sum").add("avg").add("multi_distinct_sum").build();
+            new ImmutableSortedSet.Builder(String.CASE_INSENSITIVE_ORDER)
+                    .add("sum").add("avg").add("multi_distinct_sum").build();
     private static final  ImmutableSet<String> DECIMAL_FUNCTION_SET =
-        new ImmutableSortedSet.Builder<>(String.CASE_INSENSITIVE_ORDER)
-            .addAll(DECIMAL_SAME_TYPE_SET)
-            .addAll(DECIMAL_WIDER_TYPE_SET).build();
+            new ImmutableSortedSet.Builder<>(String.CASE_INSENSITIVE_ORDER)
+                    .addAll(DECIMAL_SAME_TYPE_SET)
+                    .addAll(DECIMAL_WIDER_TYPE_SET)
+                    .addAll(STDDEV_FUNCTION_SET).build();
     private static final String ELEMENT_EXTRACT_FN_NAME = "%element_extract%";
 
     // use to record the num of json_object parameters 
@@ -1042,6 +1043,8 @@ public class FunctionCallExpr extends Expr {
             } else if (DECIMAL_WIDER_TYPE_SET.contains(fnName.getFunction())) {
                 this.type = ScalarType.createDecimalV2Type(ScalarType.MAX_DECIMAL128_PRECISION,
                     ((ScalarType) argTypes[0]).getScalarScale());
+            } else if (STDDEV_FUNCTION_SET.contains(fnName.getFunction())) {
+                this.type = ScalarType.createDecimalV2Type(ScalarType.MAX_DECIMAL128_PRECISION, 9);
             }
         }
         // rewrite return type if is nested type function

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/ScalarType.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/ScalarType.java
@@ -73,6 +73,9 @@ public class ScalarType extends Type {
 
     // Hive, mysql, sql server standard.
     public static final int MAX_PRECISION = 38;
+    public static final int MAX_DECIMAL32_PRECISION = 9;
+    public static final int MAX_DECIMAL64_PRECISION = 18;
+    public static final int MAX_DECIMAL128_PRECISION = 38;
 
     @SerializedName(value = "type")
     private final PrimitiveType type;
@@ -276,6 +279,19 @@ public class ScalarType extends Type {
         ScalarType type = new ScalarType(PrimitiveType.DECIMALV2);
         type.precision = Math.min(precision, MAX_PRECISION);
         type.scale = Math.min(type.precision, scale);
+        return type;
+    }
+
+    public static ScalarType createWiderDecimalV2Type(int precision, int scale) {
+        ScalarType type = new ScalarType(PrimitiveType.DECIMALV2);
+        if (precision <= MAX_DECIMAL32_PRECISION) {
+            type.precision = MAX_DECIMAL32_PRECISION;
+        } else if (precision <= MAX_DECIMAL64_PRECISION) {
+            type.precision = MAX_DECIMAL64_PRECISION;
+        } else {
+            type.precision = MAX_DECIMAL128_PRECISION;
+        }
+        type.scale = scale;
         return type;
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Type.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Type.java
@@ -248,7 +248,11 @@ public abstract class Type {
         return isScalarType(PrimitiveType.TINYINT) || isScalarType(PrimitiveType.SMALLINT)
                 || isScalarType(PrimitiveType.INT);
     }
-    
+
+    public boolean isBigIntType() {
+        return isScalarType(PrimitiveType.BIGINT);
+    }
+
     public boolean isLargeIntType() {
         return isScalarType(PrimitiveType.LARGEINT);
     }

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/ArithmeticExprTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/ArithmeticExprTest.java
@@ -1,0 +1,173 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.analysis;
+
+import org.apache.doris.catalog.PrimitiveType;
+import org.apache.doris.catalog.ScalarType;
+import org.apache.doris.common.AnalysisException;
+import org.apache.doris.common.util.VectorizedUtil;
+
+import mockit.Expectations;
+import mockit.Mocked;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class ArithmeticExprTest {
+
+    @Test
+    public void testDecimalArithmetic(@Mocked VectorizedUtil vectorizedUtil) {
+        Expr lhsExpr = new SlotRef(new TableName("db", "table"), "c0");
+        Expr rhsExpr = new SlotRef(new TableName("db", "table"), "c1");
+        ScalarType t1;
+        ScalarType t2;
+        ScalarType res;
+        ArithmeticExpr arithmeticExpr;
+        boolean hasException = false;
+        new Expectations() {
+            {
+                vectorizedUtil.isVectorized();
+                result = true;
+            }
+        };
+        List<ArithmeticExpr.Operator> operators = Arrays.asList(ArithmeticExpr.Operator.ADD,
+                ArithmeticExpr.Operator.SUBTRACT, ArithmeticExpr.Operator.MOD,
+                ArithmeticExpr.Operator.MULTIPLY, ArithmeticExpr.Operator.DIVIDE);
+        try {
+            for (ArithmeticExpr.Operator operator : operators) {
+                t1 = ScalarType.createDecimalV2Type(9, 4);
+                t2 = ScalarType.createDecimalV2Type(19, 6);
+                lhsExpr.setType(t1);
+                rhsExpr.setType(t2);
+                arithmeticExpr = new ArithmeticExpr(operator, lhsExpr, rhsExpr);
+                res = ScalarType.createDecimalV2Type(38, 6);
+                if (operator == ArithmeticExpr.Operator.MULTIPLY) {
+                    res = ScalarType.createDecimalV2Type(38, 10);
+                }
+                if (operator == ArithmeticExpr.Operator.DIVIDE) {
+                    res = ScalarType.createDecimalV2Type(38, 4);
+                }
+                arithmeticExpr.analyzeImpl(null);
+                Assert.assertEquals(arithmeticExpr.type, res);
+
+                t1 = ScalarType.createDecimalV2Type(9, 4);
+                t2 = ScalarType.createDecimalV2Type(18, 5);
+                lhsExpr.setType(t1);
+                rhsExpr.setType(t2);
+                arithmeticExpr = new ArithmeticExpr(operator, lhsExpr, rhsExpr);
+                res = ScalarType.createDecimalV2Type(18, 5);
+                if (operator == ArithmeticExpr.Operator.MULTIPLY) {
+                    res = ScalarType.createDecimalV2Type(18, 9);
+                }
+                if (operator == ArithmeticExpr.Operator.DIVIDE) {
+                    res = ScalarType.createDecimalV2Type(18, 4);
+                }
+                arithmeticExpr.analyzeImpl(null);
+                Assert.assertEquals(arithmeticExpr.type, res);
+
+                t1 = ScalarType.createDecimalV2Type(9, 4);
+                t2 = ScalarType.createType(PrimitiveType.BIGINT);
+                lhsExpr.setType(t1);
+                rhsExpr.setType(t2);
+                arithmeticExpr = new ArithmeticExpr(operator, lhsExpr, rhsExpr);
+                res = ScalarType.createDecimalV2Type(18, 4);
+                arithmeticExpr.analyzeImpl(null);
+                Assert.assertEquals(arithmeticExpr.type, res);
+
+                t1 = ScalarType.createDecimalV2Type(9, 4);
+                t2 = ScalarType.createType(PrimitiveType.LARGEINT);
+                lhsExpr.setType(t1);
+                rhsExpr.setType(t2);
+                arithmeticExpr = new ArithmeticExpr(operator, lhsExpr, rhsExpr);
+                res = ScalarType.createDecimalV2Type(38, 4);
+                arithmeticExpr.analyzeImpl(null);
+                Assert.assertEquals(arithmeticExpr.type, res);
+
+                t1 = ScalarType.createDecimalV2Type(9, 4);
+                t2 = ScalarType.createType(PrimitiveType.INT);
+                lhsExpr.setType(t1);
+                rhsExpr.setType(t2);
+                arithmeticExpr = new ArithmeticExpr(operator, lhsExpr, rhsExpr);
+                res = ScalarType.createDecimalV2Type(9, 4);
+                arithmeticExpr.analyzeImpl(null);
+                Assert.assertEquals(arithmeticExpr.type, res);
+
+                t1 = ScalarType.createDecimalV2Type(9, 4);
+                t2 = ScalarType.createType(PrimitiveType.FLOAT);
+                lhsExpr.setType(t1);
+                rhsExpr.setType(t2);
+                arithmeticExpr = new ArithmeticExpr(operator, lhsExpr, rhsExpr);
+                res = ScalarType.createType(PrimitiveType.DOUBLE);
+                arithmeticExpr.analyzeImpl(null);
+                Assert.assertEquals(arithmeticExpr.type, res);
+
+                t1 = ScalarType.createDecimalV2Type(9, 4);
+                t2 = ScalarType.createType(PrimitiveType.DOUBLE);
+                lhsExpr.setType(t1);
+                rhsExpr.setType(t2);
+                arithmeticExpr = new ArithmeticExpr(operator, lhsExpr, rhsExpr);
+                res = ScalarType.createType(PrimitiveType.DOUBLE);
+                arithmeticExpr.analyzeImpl(null);
+                Assert.assertEquals(arithmeticExpr.type, res);
+            }
+        } catch (AnalysisException e) {
+            e.printStackTrace();
+            hasException = true;
+        }
+        Assert.assertFalse(hasException);
+    }
+
+    @Test
+    public void testDecimalBitOperation(@Mocked VectorizedUtil vectorizedUtil) {
+        Expr lhsExpr = new SlotRef(new TableName("db", "table"), "c0");
+        Expr rhsExpr = new SlotRef(new TableName("db", "table"), "c1");
+        ScalarType t1;
+        ScalarType t2;
+        ScalarType res;
+        ArithmeticExpr arithmeticExpr;
+        boolean hasException = false;
+        new Expectations() {
+            {
+                vectorizedUtil.isVectorized();
+                result = true;
+            }
+        };
+        List<ArithmeticExpr.Operator> operators = Arrays.asList(ArithmeticExpr.Operator.BITAND,
+                ArithmeticExpr.Operator.BITOR, ArithmeticExpr.Operator.BITXOR);
+        try {
+            for (ArithmeticExpr.Operator operator : operators) {
+                t1 = ScalarType.createDecimalV2Type(9, 4);
+                t2 = ScalarType.createDecimalV2Type(19, 6);
+                lhsExpr.setType(t1);
+                rhsExpr.setType(t2);
+                arithmeticExpr = new ArithmeticExpr(operator, lhsExpr, rhsExpr);
+                res = ScalarType.createType(PrimitiveType.BIGINT);
+                arithmeticExpr.analyzeImpl(null);
+                Assert.assertEquals(arithmeticExpr.type, res);
+                Assert.assertTrue(arithmeticExpr.getChild(0) instanceof CastExpr);
+                Assert.assertTrue(arithmeticExpr.getChild(1) instanceof CastExpr);
+            }
+        } catch (AnalysisException e) {
+            e.printStackTrace();
+            hasException = true;
+        }
+        Assert.assertFalse(hasException);
+    }
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/DecimalLiteralTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/DecimalLiteralTest.java
@@ -18,9 +18,10 @@
 package org.apache.doris.analysis;
 
 import org.apache.doris.catalog.PrimitiveType;
-
+import org.apache.doris.catalog.ScalarType;
 import org.apache.doris.catalog.Type;
 import org.apache.doris.common.AnalysisException;
+
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -47,5 +48,36 @@ public class DecimalLiteralTest {
         Assert.assertEquals(literal, literal.uncheckedCastTo(Type.DECIMALV2));
 
         Assert.assertEquals(1, literal.compareLiteral(new NullLiteral()));
+    }
+
+    @Test
+    public  void testTypePrecision() {
+        BigDecimal decimal = new BigDecimal("-123456789123456789.123456789");
+        DecimalLiteral literal = new DecimalLiteral(decimal);
+        int precision = ((ScalarType) literal.getType()).getScalarPrecision();
+        int scale = ((ScalarType) literal.getType()).getScalarScale();
+        Assert.assertEquals(27, precision);
+        Assert.assertEquals(9, scale);
+
+        decimal = new BigDecimal("-0.00123");
+        literal = new DecimalLiteral(decimal);
+        precision = ((ScalarType) literal.getType()).getScalarPrecision();
+        scale = ((ScalarType) literal.getType()).getScalarScale();
+        Assert.assertEquals(5, precision);
+        Assert.assertEquals(5, scale);
+
+        decimal = new BigDecimal("20000");
+        literal = new DecimalLiteral(decimal);
+        precision = ((ScalarType) literal.getType()).getScalarPrecision();
+        scale = ((ScalarType) literal.getType()).getScalarScale();
+        Assert.assertEquals(5, precision);
+        Assert.assertEquals(0, scale);
+
+        decimal = new BigDecimal("0.123");
+        literal = new DecimalLiteral(decimal);
+        precision = ((ScalarType) literal.getType()).getScalarPrecision();
+        scale = ((ScalarType) literal.getType()).getScalarScale();
+        Assert.assertEquals(3, precision);
+        Assert.assertEquals(3, scale);
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/FunctionCallExprTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/FunctionCallExprTest.java
@@ -1,0 +1,80 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.analysis;
+
+import org.apache.doris.catalog.ScalarType;
+import org.apache.doris.catalog.Type;
+import org.apache.doris.common.AnalysisException;
+
+import com.google.common.collect.ImmutableList;
+import mockit.Mock;
+import mockit.MockUp;
+import mockit.Mocked;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+
+public class FunctionCallExprTest {
+
+    @Test
+    public void testDecimalFunction(@Mocked Analyzer analyzer) throws AnalysisException {
+        new MockUp<SlotRef>(SlotRef.class) {
+            @Mock
+            public void analyzeImpl(Analyzer analyzer) throws AnalysisException {
+                return;
+            }
+        };
+        Expr argExpr = new SlotRef(new TableName("db", "table"), "c0");
+        FunctionCallExpr functionCallExpr;
+        boolean hasException = false;
+        Type res;
+        ImmutableList<String> sameTypeFunction = ImmutableList.<String>builder()
+                .add("min").add("max").add("lead").add("lag")
+                .add("first_value").add("last_value").add("abs")
+                .add("positive").add("negative").build();
+        ImmutableList<String> widerTypeFunction = ImmutableList.<String>builder()
+                .add("sum").add("avg").add("multi_distinct_sum").build();
+        try {
+            for (String func : sameTypeFunction) {
+                Type argType = ScalarType.createDecimalV2Type(9, 4);
+                argExpr.setType(argType);
+                functionCallExpr = new FunctionCallExpr(func, Arrays.asList(argExpr));
+                functionCallExpr.setIsAnalyticFnCall(true);
+                res = ScalarType.createDecimalV2Type(9, 4);
+                functionCallExpr.analyzeImpl(analyzer);
+                Assert.assertEquals(functionCallExpr.type, res);
+            }
+
+            for (String func : widerTypeFunction) {
+                Type argType = ScalarType.createDecimalV2Type(9, 4);
+                argExpr.setType(argType);
+                functionCallExpr = new FunctionCallExpr(func, Arrays.asList(argExpr));
+                res = ScalarType.createDecimalV2Type(38, 4);
+                functionCallExpr.analyzeImpl(analyzer);
+                Assert.assertEquals(functionCallExpr.type, res);
+            }
+
+        } catch (AnalysisException e) {
+            e.printStackTrace();
+            hasException = true;
+        }
+        Assert.assertFalse(hasException);
+    }
+
+}


### PR DESCRIPTION
fe passes precision and scale of decimal to be

# Proposed changes

Issue Number: #9208 

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (No)
2. Has unit tests been added: (Yes)
3. Has document been added or modified: (No Need)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
