### PR TITLE
[improvement](storage) not direct read when has streaming aggregation

### DIFF
--- a/be/src/exec/olap_scanner.cpp
+++ b/be/src/exec/olap_scanner.cpp
@@ -197,7 +197,6 @@ Status OlapScanner::_init_tablet_reader_params(
 
     if (_aggregation || single_version) {
         _tablet_reader_params.return_columns = _return_columns;
-        _tablet_reader_params.direct_mode = true;
     } else {
         // we need to fetch all key columns to do the right aggregation on storage engine side.
         for (size_t i = 0; i < _tablet->num_key_columns(); ++i) {

--- a/be/src/olap/reader.cpp
+++ b/be/src/olap/reader.cpp
@@ -230,7 +230,6 @@ Status TabletReader::_capture_rs_readers(const ReaderParams& read_params,
 Status TabletReader::_init_params(const ReaderParams& read_params) {
     read_params.check_validation();
 
-    _direct_mode = read_params.direct_mode;
     _aggregation = read_params.aggregation;
     _need_agg_finalize = read_params.need_agg_finalize;
     _reader_type = read_params.reader_type;

--- a/be/src/olap/reader.h
+++ b/be/src/olap/reader.h
@@ -68,7 +68,6 @@ public:
     struct ReaderParams {
         TabletSharedPtr tablet;
         ReaderType reader_type = READER_QUERY;
-        bool direct_mode = false;
         bool aggregation = false;
         bool need_agg_finalize = true;
         // 1. when read column data page:
@@ -215,7 +214,6 @@ protected:
     bool _next_delete_flag = false;
     bool _filter_delete = false;
     int32_t _sequence_col_idx = -1;
-    bool _direct_mode = false;
     int _batch_size = 1024;
 
     CollectIterator _collect_iter;

--- a/be/src/vec/olap/block_reader.cpp
+++ b/be/src/vec/olap/block_reader.cpp
@@ -146,11 +146,6 @@ Status BlockReader::init(const ReaderParams& read_params) {
         return status;
     }
 
-    if (_direct_mode) {
-        _next_block_func = &BlockReader::_direct_next_block;
-        return Status::OK();
-    }
-
     switch (tablet()->keys_type()) {
     case KeysType::DUP_KEYS:
         _next_block_func = &BlockReader::_direct_next_block;

--- a/be/src/vec/olap/vcollect_iterator.cpp
+++ b/be/src/vec/olap/vcollect_iterator.cpp
@@ -30,7 +30,7 @@ void VCollectIterator::init(TabletReader* reader) {
     // when aggregate is enabled or key_type is DUP_KEYS, we don't merge
     // multiple data to aggregate for better performance
     if (_reader->_reader_type == READER_QUERY &&
-        (_reader->_direct_mode || _reader->_tablet->keys_type() == KeysType::DUP_KEYS)) {
+        (_reader->_aggregation || _reader->_tablet->keys_type() == KeysType::DUP_KEYS)) {
         _merge = false;
     }
 }


### PR DESCRIPTION
# Proposed changes

**There is a problem with the test data, re-testing**


~Issue Number: close #9229~
- ~Enable PreAggregation when has SteamingAggregation on vectorized exec, consistent with non-vectorization.~
- ~In the future, we can use the query optimizer to decide whether to enable PreAggregation according to the amount of filtered data, whether there is a count distinct indicator, etc.~

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
