### PR TITLE
[feature](statistics) Statistics derivation.Step 1:ScanNode implement…

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/planner/BrokerScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/BrokerScanNode.java
@@ -143,6 +143,13 @@ public class BrokerScanNode extends LoadScanNode {
         this.filesAdded = filesAdded;
     }
 
+    public BrokerScanNode(PlanNodeId id, TupleDescriptor destTupleDesc, String planNodeName,
+                          List<List<TBrokerFileStatus>> fileStatusesList, int filesAdded) {
+        super(id, destTupleDesc, planNodeName, NodeType.BROKER_SCAN_NODE);
+        this.fileStatusesList = fileStatusesList;
+        this.filesAdded = filesAdded;
+    }
+
     @Override
     public void init(Analyzer analyzer) throws UserException {
         super.init(analyzer);

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/EsScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/EsScanNode.java
@@ -72,7 +72,7 @@ public class EsScanNode extends ScanNode {
     boolean isFinalized = false;
 
     public EsScanNode(PlanNodeId id, TupleDescriptor desc, String planNodeName) {
-        super(id, desc, planNodeName);
+        super(id, desc, planNodeName, NodeType.ES_SCAN_NODE);
         table = (EsTable) (desc.getTable());
         esTablePartitions = table.getEsTablePartitions();
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/LoadScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/LoadScanNode.java
@@ -54,7 +54,7 @@ public abstract class LoadScanNode extends ScanNode {
     protected LoadTask.MergeType mergeType = LoadTask.MergeType.APPEND;
 
     public LoadScanNode(PlanNodeId id, TupleDescriptor desc, String planNodeName) {
-        super(id, desc, planNodeName);
+        super(id, desc, planNodeName, NodeType.LOAD_SCAN_NODE);
     }
 
     protected void initAndSetWhereExpr(Expr whereExpr, TupleDescriptor tupleDesc, Analyzer analyzer) throws UserException {

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/MysqlScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/MysqlScanNode.java
@@ -56,7 +56,7 @@ public class MysqlScanNode extends ScanNode {
      * Constructs node to scan given data files of table 'tbl'.
      */
     public MysqlScanNode(PlanNodeId id, TupleDescriptor desc, MysqlTable tbl) {
-        super(id, desc, "SCAN MYSQL");
+        super(id, desc, "SCAN MYSQL", NodeType.MYSQL_SCAN_NODE);
         tblName = "`" + tbl.getMysqlTableName() + "`";
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/OdbcScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/OdbcScanNode.java
@@ -73,7 +73,7 @@ public class OdbcScanNode extends ScanNode {
      * Constructs node to scan given data files of table 'tbl'.
      */
     public OdbcScanNode(PlanNodeId id, TupleDescriptor desc, OdbcTable tbl) {
-        super(id, desc, "SCAN ODBC");
+        super(id, desc, "SCAN ODBC", NodeType.ODBC_SCAN_NODE);
         connectString = tbl.getConnectString();
         odbcType = tbl.getOdbcTableType();
         tblName = OdbcTable.databaseProperName(odbcType, tbl.getOdbcTableName());

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/PlanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/PlanNode.java
@@ -55,6 +55,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -136,7 +137,7 @@ abstract public class PlanNode extends TreeNode<PlanNode> {
 
     protected List<SlotId> outputSlotIds;
 
-    private NodeType nodeType = NodeType.DEFAULT;
+    protected NodeType nodeType = NodeType.DEFAULT;
     protected StatsDeriveResult statsDeriveResult = new StatsDeriveResult();
 
     protected PlanNode(PlanNodeId id, ArrayList<TupleId> tupleIds, String planNodeName) {
@@ -178,26 +179,32 @@ abstract public class PlanNode extends TreeNode<PlanNode> {
                 "V" + planNodeName : planNodeName;
         this.numInstances = 1;
         this.nodeType = node.getNodeType();
-        this.statsDeriveResult.set(node.getStatsDeriveResult());
+        this.statsDeriveResult = new StatsDeriveResult(
+                node.getStatsDeriveResult().get().getCardinality(),
+                node.getStatsDeriveResult().get().getRowCount(),
+                node.getStatsDeriveResult().get().getColumnToDataSize(),
+                node.getStatsDeriveResult().get().getColumnToNdv());
     }
 
     public enum NodeType {
         DEFAULT,
         AGG_NODE,
-        OLAP_SCAN_NODE,
         HASH_JOIN_NODE,
-        MERGE_NODE
+        MERGE_NODE,
+        ES_SCAN_NODE,
+        LOAD_SCAN_NODE,
+        MYSQL_SCAN_NODE,
+        ODBC_SCAN_NODE,
+        OLAP_SCAN_NODE,
+        SCHEMA_SCAN_NODE,
     }
 
     public String getPlanNodeName() {
         return planNodeName;
     }
 
-    public StatsDeriveResult getStatsDeriveResult() {
-        if (statsDeriveResult == null) {
-            statsDeriveResult = new StatsDeriveResult();
-        }
-        return statsDeriveResult;
+    public Optional<StatsDeriveResult> getStatsDeriveResult() {
+        return Optional.ofNullable(statsDeriveResult);
     }
 
     public NodeType getNodeType() {
@@ -206,10 +213,6 @@ abstract public class PlanNode extends TreeNode<PlanNode> {
 
     public void setStatsDeriveResult(StatsDeriveResult statsDeriveResult) {
         this.statsDeriveResult = statsDeriveResult;
-    }
-
-    public void setNodeType(NodeType nodeType) {
-        this.nodeType = nodeType;
     }
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/PlanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/PlanNode.java
@@ -55,7 +55,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -138,7 +137,7 @@ abstract public class PlanNode extends TreeNode<PlanNode> {
     protected List<SlotId> outputSlotIds;
 
     protected NodeType nodeType = NodeType.DEFAULT;
-    protected StatsDeriveResult statsDeriveResult = new StatsDeriveResult();
+    protected StatsDeriveResult statsDeriveResult;
 
     protected PlanNode(PlanNodeId id, ArrayList<TupleId> tupleIds, String planNodeName) {
         this.id = id;
@@ -178,12 +177,7 @@ abstract public class PlanNode extends TreeNode<PlanNode> {
         this.planNodeName = VectorizedUtil.isVectorized() ?
                 "V" + planNodeName : planNodeName;
         this.numInstances = 1;
-        this.nodeType = node.getNodeType();
-        this.statsDeriveResult = new StatsDeriveResult(
-                node.getStatsDeriveResult().get().getCardinality(),
-                node.getStatsDeriveResult().get().getRowCount(),
-                node.getStatsDeriveResult().get().getColumnToDataSize(),
-                node.getStatsDeriveResult().get().getColumnToNdv());
+        this.nodeType = nodeType;
     }
 
     public enum NodeType {
@@ -203,8 +197,8 @@ abstract public class PlanNode extends TreeNode<PlanNode> {
         return planNodeName;
     }
 
-    public Optional<StatsDeriveResult> getStatsDeriveResult() {
-        return Optional.ofNullable(statsDeriveResult);
+    public StatsDeriveResult getStatsDeriveResult() {
+        return statsDeriveResult;
     }
 
     public NodeType getNodeType() {

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/PlanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/PlanNode.java
@@ -36,6 +36,7 @@ import org.apache.doris.common.NotImplementedException;
 import org.apache.doris.common.TreeNode;
 import org.apache.doris.common.UserException;
 import org.apache.doris.common.util.VectorizedUtil;
+import org.apache.doris.statistics.StatsDeriveResult;
 import org.apache.doris.thrift.TExplainLevel;
 import org.apache.doris.thrift.TFunctionBinaryType;
 import org.apache.doris.thrift.TPlan;
@@ -135,6 +136,9 @@ abstract public class PlanNode extends TreeNode<PlanNode> {
 
     protected List<SlotId> outputSlotIds;
 
+    private NodeType nodeType = NodeType.DEFAULT;
+    protected StatsDeriveResult statsDeriveResult = new StatsDeriveResult();
+
     protected PlanNode(PlanNodeId id, ArrayList<TupleId> tupleIds, String planNodeName) {
         this.id = id;
         this.limit = -1;
@@ -173,10 +177,39 @@ abstract public class PlanNode extends TreeNode<PlanNode> {
         this.planNodeName = VectorizedUtil.isVectorized() ?
                 "V" + planNodeName : planNodeName;
         this.numInstances = 1;
+        this.nodeType = node.getNodeType();
+        this.statsDeriveResult.set(node.getStatsDeriveResult());
+    }
+
+    public enum NodeType {
+        DEFAULT,
+        AGG_NODE,
+        OLAP_SCAN_NODE,
+        HASH_JOIN_NODE,
+        MERGE_NODE
     }
 
     public String getPlanNodeName() {
         return planNodeName;
+    }
+
+    public StatsDeriveResult getStatsDeriveResult() {
+        if (statsDeriveResult == null) {
+            statsDeriveResult = new StatsDeriveResult();
+        }
+        return statsDeriveResult;
+    }
+
+    public NodeType getNodeType() {
+        return nodeType;
+    }
+
+    public void setStatsDeriveResult(StatsDeriveResult statsDeriveResult) {
+        this.statsDeriveResult = statsDeriveResult;
+    }
+
+    public void setNodeType(NodeType nodeType) {
+        this.nodeType = nodeType;
     }
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/ScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/ScanNode.java
@@ -65,8 +65,9 @@ abstract public class ScanNode extends PlanNode {
     protected String sortColumn = null;
     protected Analyzer analyzer;
 
-    public ScanNode(PlanNodeId id, TupleDescriptor desc, String planNodeName) {
+    public ScanNode(PlanNodeId id, TupleDescriptor desc, String planNodeName, NodeType nodeType) {
         super(id, desc.getId().asList(), planNodeName);
+        super.nodeType = nodeType;
         this.desc = desc;
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/SchemaScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/SchemaScanNode.java
@@ -57,7 +57,7 @@ public class SchemaScanNode extends ScanNode {
      * Constructs node to scan given data files of table 'tbl'.
      */
     public SchemaScanNode(PlanNodeId id, TupleDescriptor desc) {
-        super(id, desc, "SCAN SCHEMA");
+        super(id, desc, "SCAN SCHEMA", NodeType.SCHEMA_SCAN_NODE);
         this.tableName = desc.getTable().getName();
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/SingleNodePlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/SingleNodePlanner.java
@@ -71,6 +71,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 
+import org.apache.doris.statistics.StatsRecursiveDerive;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -96,6 +97,7 @@ public class SingleNodePlanner {
     private final PlannerContext ctx_;
     private final ArrayList<ScanNode> scanNodes = Lists.newArrayList();
     private Map<Analyzer, List<ScanNode>> selectStmtToScanNodes = Maps.newHashMap();
+    private StatsRecursiveDerive statsRecursiveDerive;
 
     public SingleNodePlanner(PlannerContext ctx) {
         ctx_ = ctx;
@@ -164,6 +166,8 @@ public class SingleNodePlanner {
         if (LOG.isTraceEnabled()) {
             LOG.trace("desctbl: " + analyzer.getDescTbl().debugString());
         }
+        statsRecursiveDerive = new StatsRecursiveDerive();
+        statsRecursiveDerive.creteNodeTypeToDeriveMap();
         PlanNode singleNodePlan = createQueryPlan(queryStmt, analyzer,
                 ctx_.getQueryOptions().getDefaultOrderByLimit());
         Preconditions.checkNotNull(singleNodePlan);
@@ -1725,7 +1729,11 @@ public class SingleNodePlanner {
         scanNodeList.add(scanNode);
 
         scanNode.init(analyzer);
-
+        if (analyzer.safeIsEnableJoinReorderBasedCost()) {
+            statsRecursiveDerive.statsRecursiveDerive(scanNode);
+            // Update the node's cardinality value for the current architecture
+            scanNode.cardinality = scanNode.getStatsDeriveResult().getCardinality();
+        }
         return scanNode;
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/SingleNodePlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/SingleNodePlanner.java
@@ -71,7 +71,6 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 
-import org.apache.doris.statistics.StatsRecursiveDerive;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -97,7 +96,6 @@ public class SingleNodePlanner {
     private final PlannerContext ctx_;
     private final ArrayList<ScanNode> scanNodes = Lists.newArrayList();
     private Map<Analyzer, List<ScanNode>> selectStmtToScanNodes = Maps.newHashMap();
-    private StatsRecursiveDerive statsRecursiveDerive;
 
     public SingleNodePlanner(PlannerContext ctx) {
         ctx_ = ctx;
@@ -166,8 +164,6 @@ public class SingleNodePlanner {
         if (LOG.isTraceEnabled()) {
             LOG.trace("desctbl: " + analyzer.getDescTbl().debugString());
         }
-        statsRecursiveDerive = new StatsRecursiveDerive();
-        statsRecursiveDerive.creteNodeTypeToDeriveMap();
         PlanNode singleNodePlan = createQueryPlan(queryStmt, analyzer,
                 ctx_.getQueryOptions().getDefaultOrderByLimit());
         Preconditions.checkNotNull(singleNodePlan);
@@ -1729,11 +1725,6 @@ public class SingleNodePlanner {
         scanNodeList.add(scanNode);
 
         scanNode.init(analyzer);
-        if (analyzer.safeIsEnableJoinReorderBasedCost()) {
-            statsRecursiveDerive.statsRecursiveDerive(scanNode);
-            // Update the node's cardinality value for the current architecture
-            scanNode.cardinality = scanNode.getStatsDeriveResult().getCardinality();
-        }
         return scanNode;
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -699,14 +699,6 @@ public class StmtExecutor implements ProfileWriter {
                 }
                 if (explainOptions != null) parsedStmt.setIsExplain(explainOptions);
             }
-
-            if (parsedStmt instanceof InsertStmt && parsedStmt.isExplain()) {
-                if (ConnectContext.get() != null &&
-                        ConnectContext.get().getExecutor() != null &&
-                        ConnectContext.get().getExecutor().getParsedStmt() != null) {
-                    ConnectContext.get().getExecutor().getParsedStmt().setIsExplain(new ExplainOptions(true, false));
-                }
-            }
         }
         plannerProfile.setQueryAnalysisFinishTime();
 

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/BaseStatsDerive.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/BaseStatsDerive.java
@@ -20,6 +20,7 @@ package org.apache.doris.statistics;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import org.apache.doris.analysis.Expr;
+import org.apache.doris.analysis.SlotId;
 import org.apache.doris.common.UserException;
 import org.apache.doris.planner.PlanNode;
 import org.apache.logging.log4j.LogManager;
@@ -133,22 +134,25 @@ public class BaseStatsDerive {
 
     // Currently it simply adds the number of rows of children
     protected long deriveRowCount() {
+        for (StatsDeriveResult statsDeriveResult : childrenStatsResult) {
+            rowCount = Math.max(rowCount, statsDeriveResult.getRowCount());
+        }
         applyConjunctsSelectivity();
         capRowCountAtLimit();
         return rowCount;
     }
 
 
-    protected HashMap<Long, Long> deriveColumnToDataSize() {
-        HashMap<Long, Long> columnToDataSize = new HashMap<>();
+    protected HashMap<SlotId, Float> deriveColumnToDataSize() {
+        HashMap<SlotId, Float> columnToDataSize = new HashMap<>();
         for (StatsDeriveResult child : childrenStatsResult) {
             columnToDataSize.putAll(child.getColumnToDataSize());
         }
         return columnToDataSize;
     }
 
-    protected HashMap<Long, Long> deriveColumnToNdv() {
-        HashMap<Long, Long> columnToNdv = new HashMap<>();
+    protected HashMap<SlotId, Long> deriveColumnToNdv() {
+        HashMap<SlotId, Long> columnToNdv = new HashMap<>();
         for (StatsDeriveResult child : childrenStatsResult) {
             columnToNdv.putAll(child.getColumnToNdv());
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/BaseStatsDerive.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/BaseStatsDerive.java
@@ -1,0 +1,122 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.statistics;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+import org.apache.doris.analysis.Expr;
+import org.apache.doris.planner.PlanNode;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public abstract class BaseStatsDerive {
+    // estimate of the output cardinality of this node;
+    // invalid: -1
+    protected long cardinality;
+    protected long limit;
+
+    protected List<Expr> conjuncts = Lists.newArrayList();
+    protected List<StatsDeriveResult> childrenStatsResult = Lists.newArrayList();
+
+    protected BaseStatsDerive init(PlanNode node) {
+        cardinality = -1;
+        limit = node.getLimit();
+        conjuncts.addAll(node.getConjuncts());
+
+        for (PlanNode childNode : node.getChildren()) {
+            childrenStatsResult.add(childNode.getStatsDeriveResult());
+        }
+        return this;
+    }
+
+    public abstract StatsDeriveResult deriveStats();
+
+    public boolean hasLimit() {
+        return limit > -1;
+    }
+
+    protected void applyConjunctsSelectivity() {
+        if (cardinality == -1) {
+            return;
+        }
+        applySelectivity();
+    }
+
+    private void applySelectivity() {
+        double selectivity = computeSelectivity();
+        Preconditions.checkState(cardinality >= 0);
+        long preConjunctCardinality = cardinality;
+        cardinality = Math.round(cardinality * selectivity);
+        // don't round cardinality down to zero for safety.
+        if (cardinality == 0 && preConjunctCardinality > 0) {
+            cardinality = 1;
+        }
+    }
+
+    protected double computeSelectivity() {
+        for (Expr expr : conjuncts) {
+            expr.setSelectivity();
+        }
+        return computeCombinedSelectivity(conjuncts);
+    }
+
+    /**
+     * Returns the estimated combined selectivity of all conjuncts. Uses heuristics to
+     * address the following estimation challenges:
+     * 1. The individual selectivities of conjuncts may be unknown.
+     * 2. Two selectivities, whether known or unknown, could be correlated. Assuming
+     * independence can lead to significant underestimation.
+     * <p>
+     * The first issue is addressed by using a single default selectivity that is
+     * representative of all conjuncts with unknown selectivities.
+     * The second issue is addressed by an exponential backoff when multiplying each
+     * additional selectivity into the final result.
+     */
+    static protected double computeCombinedSelectivity(List<Expr> conjuncts) {
+        // Collect all estimated selectivities.
+        List<Double> selectivities = new ArrayList<>();
+        for (Expr e : conjuncts) {
+            if (e.hasSelectivity()) selectivities.add(e.getSelectivity());
+        }
+        if (selectivities.size() != conjuncts.size()) {
+            // Some conjuncts have no estimated selectivity. Use a single default
+            // representative selectivity for all those conjuncts.
+            selectivities.add(Expr.DEFAULT_SELECTIVITY);
+        }
+        // Sort the selectivities to get a consistent estimate, regardless of the original
+        // conjunct order. Sort in ascending order such that the most selective conjunct
+        // is fully applied.
+        Collections.sort(selectivities);
+        double result = 1.0;
+        // selectivity = 1 * (s1)^(1/1) * (s2)^(1/2) * ... * (sn-1)^(1/(n-1)) * (sn)^(1/n)
+        for (int i = 0; i < selectivities.size(); ++i) {
+            // Exponential backoff for each selectivity multiplied into the final result.
+            result *= Math.pow(selectivities.get(i), 1.0 / (double) (i + 1));
+        }
+        // Bound result in [0, 1]
+        return Math.max(0.0, Math.min(1.0, result));
+    }
+
+    protected void capCardinalityAtLimit() {
+        if (hasLimit()) {
+            cardinality = cardinality == -1 ? limit : Math.min(cardinality, limit);
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/BaseStatsDerive.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/BaseStatsDerive.java
@@ -25,18 +25,18 @@ import org.apache.doris.planner.PlanNode;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 public abstract class BaseStatsDerive {
     // estimate of the output cardinality of this node;
     // invalid: -1
-    protected long cardinality;
-    protected long limit;
+    protected long cardinality = -1;
+    protected long limit = -1;
 
     protected List<Expr> conjuncts = Lists.newArrayList();
-    protected List<StatsDeriveResult> childrenStatsResult = Lists.newArrayList();
+    protected List<Optional<StatsDeriveResult>> childrenStatsResult = Lists.newArrayList();
 
     protected BaseStatsDerive init(PlanNode node) {
-        cardinality = -1;
         limit = node.getLimit();
         conjuncts.addAll(node.getConjuncts());
 

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/DeriveFactory.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/DeriveFactory.java
@@ -28,14 +28,9 @@ public class DeriveFactory {
             case MERGE_NODE:
                 break;
             case OLAP_SCAN_NODE:
-                return new ScanStatsDerive();
+                return new OlapScanStatsDerive();
             case DEFAULT:
         }
-        return new BaseStatsDerive() {
-            @Override
-            public StatsDeriveResult deriveStats() {
-                return new StatsDeriveResult();
-            }
-        };
+        return new BaseStatsDerive();
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/DeriveFactory.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/DeriveFactory.java
@@ -1,0 +1,41 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.statistics;
+
+import org.apache.doris.planner.PlanNode;
+
+public class DeriveFactory {
+
+    public BaseStatsDerive getStatsDerive(PlanNode.NodeType nodeType) {
+        switch (nodeType) {
+            case AGG_NODE:
+            case HASH_JOIN_NODE:
+            case MERGE_NODE:
+                break;
+            case OLAP_SCAN_NODE:
+                return new ScanStatsDerive();
+            case DEFAULT:
+        }
+        return new BaseStatsDerive() {
+            @Override
+            public StatsDeriveResult deriveStats() {
+                return new StatsDeriveResult();
+            }
+        };
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/Statistics.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/Statistics.java
@@ -70,4 +70,16 @@ public class Statistics {
         }
         return tableStats.getNameToColumnStats();
     }
+
+    public void mockTableStatsWithRowCount(long tableId, long rowCount) {
+        TableStats tableStats = idToTableStats.get(tableId);
+        if (tableStats == null) {
+            tableStats = new TableStats();
+            idToTableStats.put(tableId, tableStats);
+        }
+
+        if (tableStats.getRowCount() != rowCount) {
+            tableStats.setRowCount(rowCount);
+        }
+    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/Statistics.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/Statistics.java
@@ -71,6 +71,7 @@ public class Statistics {
         return tableStats.getNameToColumnStats();
     }
 
+    // TODO: mock statistics need to be removed in the future
     public void mockTableStatsWithRowCount(long tableId, long rowCount) {
         TableStats tableStats = idToTableStats.get(tableId);
         if (tableStats == null) {

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticsManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticsManager.java
@@ -136,4 +136,8 @@ public class StatisticsManager {
         Table table = db.getTableOrAnalysisException(tableName);
         return table;
     }
+
+    public Statistics getStatistics() {
+        return statistics;
+    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/StatsDeriveResult.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/StatsDeriveResult.java
@@ -18,6 +18,7 @@
 package org.apache.doris.statistics;
 
 import com.google.common.collect.Maps;
+import org.apache.doris.analysis.SlotId;
 
 import java.util.Map;
 
@@ -26,14 +27,12 @@ public class StatsDeriveResult {
     private long rowCount = -1;
     // The data size of the corresponding column in the operator
     // The actual key is slotId
-    private final Map<Long, Long> columnToDataSize = Maps.newHashMap();
+    private final Map<SlotId, Float> columnToDataSize = Maps.newHashMap();
     // The ndv of the corresponding column in the operator
     // The actual key is slotId
-    private final Map<Long, Long> columnToNdv = Maps.newHashMap();
+    private final Map<SlotId, Long> columnToNdv = Maps.newHashMap();
 
-    public StatsDeriveResult() {}
-
-    public StatsDeriveResult(long rowCount, Map<Long, Long> columnToDataSize, Map<Long, Long> columnToNdv) {
+    public StatsDeriveResult(long rowCount, Map<SlotId, Float> columnToDataSize, Map<SlotId, Long> columnToNdv) {
         this.rowCount = rowCount;
         this.columnToDataSize.putAll(columnToDataSize);
         this.columnToNdv.putAll(columnToNdv);
@@ -42,16 +41,16 @@ public class StatsDeriveResult {
     public void setRowCount(long rowCount) {
         this.rowCount = rowCount;
     }
-    
+
     public long getRowCount() {
         return rowCount;
     }
 
-    public Map<Long, Long> getColumnToNdv() {
+    public Map<SlotId, Long> getColumnToNdv() {
         return columnToNdv;
     }
 
-    public Map<Long, Long> getColumnToDataSize() {
+    public Map<SlotId, Float> getColumnToDataSize() {
         return columnToDataSize;
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/StatsDeriveResult.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/StatsDeriveResult.java
@@ -23,7 +23,6 @@ import java.util.Map;
 
 // This structure is maintained in each operator to store the statistical information results obtained by the operator.
 public class StatsDeriveResult {
-    private long cardinality = -1;
     private long rowCount = -1;
     // The data size of the corresponding column in the operator
     // The actual key is slotId
@@ -34,8 +33,7 @@ public class StatsDeriveResult {
 
     public StatsDeriveResult() {}
 
-    public StatsDeriveResult(long cardinality, long rowCount, Map<Long, Long> columnToDataSize, Map<Long, Long> columnToNdv) {
-        this.cardinality = cardinality;
+    public StatsDeriveResult(long rowCount, Map<Long, Long> columnToDataSize, Map<Long, Long> columnToNdv) {
         this.rowCount = rowCount;
         this.columnToDataSize.putAll(columnToDataSize);
         this.columnToNdv.putAll(columnToNdv);
@@ -44,19 +42,7 @@ public class StatsDeriveResult {
     public void setRowCount(long rowCount) {
         this.rowCount = rowCount;
     }
-
-    public void setCardinality(long cardinality) {
-        this.cardinality = cardinality;
-    }
-
-    public boolean isStatsDerived() {
-        return cardinality != -1 && rowCount != -1 && !columnToDataSize.isEmpty() && !columnToNdv.isEmpty();
-    }
-
-    public long getCardinality() {
-        return cardinality;
-    }
-
+    
     public long getRowCount() {
         return rowCount;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/StatsDeriveResult.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/StatsDeriveResult.java
@@ -1,0 +1,73 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.statistics;
+
+import com.google.common.collect.Maps;
+
+import java.util.Map;
+
+// This structure is maintained in each operator to store the statistical information results obtained by the operator.
+public class StatsDeriveResult {
+    private long cardinality;
+    private long rowCount;
+    // The data size of the corresponding column in the operator
+    // The actual key is slotId
+    private final Map<Long, Long> columnToDataSize = Maps.newHashMap();
+    // The ndv of the corresponding column in the operator
+    // The actual key is slotId
+    private final Map<Long, Long> columnToNdv = Maps.newHashMap();
+
+    public StatsDeriveResult() {
+        cardinality = -1;
+        rowCount = -1;
+    }
+
+    public StatsDeriveResult(long cardinality, long rowCount, Map<Long, Long> columnToDataSize, Map<Long, Long> columnToNdv) {
+        this.cardinality = cardinality;
+        this.rowCount = rowCount;
+        this.columnToDataSize.putAll(columnToDataSize);
+        this.columnToNdv.putAll(columnToNdv);
+    }
+
+    public void set(StatsDeriveResult statsDeriveResult) {
+        this.cardinality = statsDeriveResult.cardinality;
+        this.rowCount = statsDeriveResult.rowCount;
+        this.columnToDataSize.putAll(statsDeriveResult.columnToDataSize);
+        this.columnToNdv.putAll(statsDeriveResult.columnToNdv);
+    }
+
+    public void setRowCount(long rowCount) {
+        this.rowCount = rowCount;
+    }
+
+    public void setCardinality(long cardinality) {
+        this.cardinality = cardinality;
+    }
+
+    public boolean isStatsDerived() {
+        return cardinality != -1 && rowCount != -1 && columnToDataSize.isEmpty() && columnToNdv.isEmpty();
+    }
+
+    public Map<Long, Long> getColumnToNdv() {
+        return columnToNdv;
+    }
+
+    public long getCardinality() {
+        return cardinality;
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/StatsDeriveResult.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/StatsDeriveResult.java
@@ -23,8 +23,8 @@ import java.util.Map;
 
 // This structure is maintained in each operator to store the statistical information results obtained by the operator.
 public class StatsDeriveResult {
-    private long cardinality;
-    private long rowCount;
+    private long cardinality = -1;
+    private long rowCount = -1;
     // The data size of the corresponding column in the operator
     // The actual key is slotId
     private final Map<Long, Long> columnToDataSize = Maps.newHashMap();
@@ -32,23 +32,13 @@ public class StatsDeriveResult {
     // The actual key is slotId
     private final Map<Long, Long> columnToNdv = Maps.newHashMap();
 
-    public StatsDeriveResult() {
-        cardinality = -1;
-        rowCount = -1;
-    }
+    public StatsDeriveResult() {}
 
     public StatsDeriveResult(long cardinality, long rowCount, Map<Long, Long> columnToDataSize, Map<Long, Long> columnToNdv) {
         this.cardinality = cardinality;
         this.rowCount = rowCount;
         this.columnToDataSize.putAll(columnToDataSize);
         this.columnToNdv.putAll(columnToNdv);
-    }
-
-    public void set(StatsDeriveResult statsDeriveResult) {
-        this.cardinality = statsDeriveResult.cardinality;
-        this.rowCount = statsDeriveResult.rowCount;
-        this.columnToDataSize.putAll(statsDeriveResult.columnToDataSize);
-        this.columnToNdv.putAll(statsDeriveResult.columnToNdv);
     }
 
     public void setRowCount(long rowCount) {
@@ -60,14 +50,22 @@ public class StatsDeriveResult {
     }
 
     public boolean isStatsDerived() {
-        return cardinality != -1 && rowCount != -1 && columnToDataSize.isEmpty() && columnToNdv.isEmpty();
+        return cardinality != -1 && rowCount != -1 && !columnToDataSize.isEmpty() && !columnToNdv.isEmpty();
+    }
+
+    public long getCardinality() {
+        return cardinality;
+    }
+
+    public long getRowCount() {
+        return rowCount;
     }
 
     public Map<Long, Long> getColumnToNdv() {
         return columnToNdv;
     }
 
-    public long getCardinality() {
-        return cardinality;
+    public Map<Long, Long> getColumnToDataSize() {
+        return columnToDataSize;
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/StatsRecursiveDerive.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/StatsRecursiveDerive.java
@@ -1,0 +1,57 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.statistics;
+
+import org.apache.doris.planner.PlanNode;
+
+import java.util.HashMap;
+import java.util.Map;
+
+
+public class StatsRecursiveDerive {
+    Map<PlanNode.NodeType, BaseStatsDerive> typeToDerive = new HashMap<>();
+
+    /**
+     * Recursively complete the derivation of statistics for this node and all its children
+     * @param node
+     * This parameter is an input and output parameter,
+     * which will store the derivation result of statistical information in the corresponding node
+     */
+    public void statsRecursiveDerive(PlanNode node) {
+        if (node.getStatsDeriveResult().isStatsDerived()) {
+            return;
+        }
+        for (PlanNode childNode : node.getChildren()) {
+            if (!childNode.getStatsDeriveResult().isStatsDerived()) {
+                statsRecursiveDerive(childNode);
+            }
+        }
+
+        node.setStatsDeriveResult(typeToDerive.get(node.getNodeType()).init(node).deriveStats());
+    }
+
+    public void creteNodeTypeToDeriveMap() {
+        typeToDerive.put(PlanNode.NodeType.DEFAULT, new BaseStatsDerive() {
+            @Override
+            public StatsDeriveResult deriveStats() {
+                return new StatsDeriveResult();
+            }
+        });
+        typeToDerive.put(PlanNode.NodeType.OLAP_SCAN_NODE, new ScanStatsDerive());
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/TableStats.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/TableStats.java
@@ -94,4 +94,16 @@ public class TableStats {
     public Map<String, ColumnStats> getNameToColumnStats() {
         return nameToColumnStats;
     }
+
+    public long getRowCount() {
+        return rowCount;
+    }
+
+    public long getDataSize() {
+        return dataSize;
+    }
+
+    public void setRowCount(long rowCount) {
+        this.rowCount = rowCount;
+    }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/ExplainTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/ExplainTest.java
@@ -72,6 +72,20 @@ public class ExplainTest {
         Assert.assertEquals(dropDbStmt.toSql(), dropSchemaStmt.toSql());
     }
 
+    public void testExplainInsertInto() throws Exception {
+        String sql = "explain insert into test_explain.explain_t1 select * from test_explain.explain_t2";
+        String explainString = UtFrameUtils.getSQLPlanOrErrorMsg(ctx, sql, false);
+        System.out.println(explainString);
+        Assert.assertFalse(explainString.contains("CAST"));
+    }
+
+    public void testExplainVerboseInsertInto() throws Exception {
+        String sql = "explain verbose insert into test_explain.explain_t1 select * from test_explain.explain_t2";
+        String explainString = UtFrameUtils.getSQLPlanOrErrorMsg(ctx, sql, true);
+        System.out.println(explainString);
+        Assert.assertTrue(explainString.contains("CAST"));
+    }
+
     public void testExplainSelect() throws Exception {
         String sql = "explain select * from test_explain.explain_t1 where dt = '1001';";
         String explainString = UtFrameUtils.getSQLPlanOrErrorMsg(ctx, sql, false);

--- a/fe/fe-core/src/test/java/org/apache/doris/planner/QueryPlanTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/planner/QueryPlanTest.java
@@ -1991,6 +1991,8 @@ public class QueryPlanTest {
     public void testExplainInsertInto() throws Exception {
         ExplainTest explainTest = new ExplainTest();
         explainTest.before(connectContext);
+        explainTest.testExplainInsertInto();
+        explainTest.testExplainVerboseInsertInto();
         explainTest.testExplainSelect();
         explainTest.testExplainInsertInto();
         explainTest.testExplainVerboseSelect();
@@ -2088,7 +2090,7 @@ public class QueryPlanTest {
                 "\"storage_medium\" = \"HDD\",\n" +
                 "\"storage_format\" = \"V2\"\n" +
                 ");\n");
-        String queryStr = "EXPLAIN INSERT INTO result_exprs\n" +
+        String queryStr = "EXPLAIN VERBOSE INSERT INTO result_exprs\n" +
                 "SELECT a.aid,\n" +
                 "       b.bid\n" +
                 "FROM\n" +


### PR DESCRIPTION
# Proposed changes

Issue Number: close #9241 

association PR: #8947 

## Problem Summary:

The purpose of this function is to modify the derivation of the current statistics.
There are two modifications:

The statistical information derivation is removed from the Node node.
Modify the current way of obtaining cardinality, and change it to obtain it from statistical information.
For details on the modification method, see: https://shimo.im/docs/473QyOzWBjHMlZ3w
The implementation of this function is divided into multiple submissions, and this submission implements the derivation of scan_node statistics.

## Checklist(Required)

1. Does it affect the original behavior: (No)
2. Has unit tests been added: (No)
3. Has document been added or modified: (No)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
