### PR TITLE
[Enhancement][Statistics] Store last visited time of partition

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/persist/VisitPartitionsInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/VisitPartitionsInfo.java
@@ -1,0 +1,47 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.persist;
+
+import org.apache.doris.persist.gson.GsonUtils;
+import com.google.gson.annotations.SerializedName;
+
+import java.util.Collection;
+
+/**
+ * used for store partitions visit info when a query arrive.
+ */
+
+public class VisitPartitionsInfo{
+    @SerializedName(value = "dbName")
+    private String dbName;
+    @SerializedName(value = "tableName")
+    private String tableName;
+    @SerializedName(value = "partitionNames")
+    private Collection<String> partitionNames;
+
+    public VisitPartitionsInfo(String dbName, String tableName, Collection<String> partitionNames) {
+        this.dbName = dbName;
+        this.tableName = tableName;
+        this.partitionNames = partitionNames;
+    }
+
+    @Override
+    public String toString() {
+        return GsonUtils.GSON.toJson(this);
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/plugin/AuditEvent.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/plugin/AuditEvent.java
@@ -84,6 +84,8 @@ public class AuditEvent {
     public String sqlHash = "";
     @AuditField(value = "peakMemoryBytes")
     public long peakMemoryBytes = -1;
+    @AuditField(value = "VisitPartitions")
+    public String visitPartitions = "";
 
     public static class AuditEventBuilder {
 
@@ -143,6 +145,11 @@ public class AuditEvent {
 
         public AuditEventBuilder setPeakMemoryBytes(long peakMemoryBytes) {
             auditEvent.peakMemoryBytes = peakMemoryBytes;
+            return this;
+        }
+
+        public AuditEventBuilder setVisitPartitions(String partitions) {
+            auditEvent.visitPartitions = partitions;
             return this;
         }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectContext.java
@@ -28,6 +28,7 @@ import org.apache.doris.mysql.MysqlChannel;
 import org.apache.doris.mysql.MysqlCommand;
 import org.apache.doris.mysql.MysqlSerializer;
 import org.apache.doris.mysql.privilege.PaloRole;
+import org.apache.doris.persist.VisitPartitionsInfo;
 import org.apache.doris.plugin.AuditEvent.AuditEventBuilder;
 import org.apache.doris.resource.Tag;
 import org.apache.doris.thrift.TResourceInfo;
@@ -130,6 +131,7 @@ public class ConnectContext {
     // If set to false, the system will not restrict query resources.
     private boolean isResourceTagsSet = false;
 
+    private Set<VisitPartitionsInfo> visitPartitionsInfos = Sets.newHashSet();
     private String sqlHash;
 
     // The FE ip current connected
@@ -260,6 +262,14 @@ public class ConnectContext {
 
     public AuditEventBuilder getAuditEventBuilder() {
         return auditEventBuilder;
+    }
+
+    public void setVisitPartitionInfos(Set<VisitPartitionsInfo> infos) {
+        this.visitPartitionsInfos = infos;
+    }
+
+    public Set<VisitPartitionsInfo> getVisitPartitionInfos() {
+        return visitPartitionsInfos;
     }
 
     public void setThreadLocalInfo() {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectProcessor.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.qe;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.doris.analysis.InsertStmt;
 import org.apache.doris.analysis.KillStmt;
 import org.apache.doris.analysis.SqlParser;
@@ -52,6 +53,7 @@ import org.apache.doris.thrift.TUniqueId;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.logging.log4j.LogManager;
@@ -120,9 +122,11 @@ public class ConnectProcessor {
                 .setScanRows(statistics == null ? 0 : statistics.getScanRows())
                 .setCpuTimeMs(statistics == null ? 0 : statistics.getCpuMs())
                 .setPeakMemoryBytes(statistics == null ? 0 : statistics.getMaxPeakMemoryBytes())
+                .setVisitPartitions(StringUtils.join(ctx.getVisitPartitionInfos()))
                 .setReturnRows(ctx.getReturnRows())
                 .setStmtId(ctx.getStmtId())
                 .setQueryId(ctx.queryId() == null ? "NaN" : DebugUtil.printId(ctx.queryId()));
+        ctx.setVisitPartitionInfos(Sets.newHashSet());
 
         if (ctx.getState().isQuery()) {
             MetricRepo.COUNTER_QUERY_ALL.increase(1L);

--- a/fe_plugins/auditloader/src/main/java/org/apache/doris/plugin/audit/AuditLoaderPlugin.java
+++ b/fe_plugins/auditloader/src/main/java/org/apache/doris/plugin/audit/AuditLoaderPlugin.java
@@ -160,6 +160,7 @@ public class AuditLoaderPlugin extends Plugin implements AuditPlugin {
         auditBuffer.append(event.cpuTimeMs).append("\t");
         auditBuffer.append(event.sqlHash).append("\t");
         auditBuffer.append(event.peakMemoryBytes).append("\t");
+        auditBuffer.append(event.visitPartitions).append("\t");
         // trim the query to avoid too long
         // use `getBytes().length` to get real byte length
         String stmt = truncateByBytes(event.stmt).replace("\t", " ");


### PR DESCRIPTION
# Proposed changes

When we start to do Data Governance in Doris, it's hard to tell data from warm to cold. 
I think it's better to store the last visited time of partition, as a sign of data heat.

## Problem Summary:

Can't tell data from warm to cold. 

## Checklist(Required)

1. Does it affect the original behavior: (No)
2. Has unit tests been added: (No Need)
3. Has document been added or modified: (No Need)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (Yes)

## Further comments

