### PR TITLE
[fix](vectorized) Query get wrong result when ColumnDict concurrent predicate eval

### DIFF
--- a/be/src/olap/column_predicate.h
+++ b/be/src/olap/column_predicate.h
@@ -41,7 +41,7 @@ enum class PredicateType {
     GT = 5,
     GE = 6,
     IN_LIST = 7,
-    NO_IN_LIST = 8,
+    NOT_IN_LIST = 8,
     IS_NULL = 9,
     NOT_IS_NULL = 10,
     BF = 11, // BloomFilter
@@ -84,8 +84,6 @@ public:
     // a vectorized eval way
     virtual void evaluate_vec(vectorized::IColumn& column, uint16_t size, bool* flags) const {};
     uint32_t column_id() const { return _column_id; }
-
-    virtual void set_dict_code_if_necessary(vectorized::IColumn& column) { }
 
 protected:
     uint32_t _column_id;

--- a/be/src/olap/comparison_predicate.h
+++ b/be/src/olap/comparison_predicate.h
@@ -46,11 +46,8 @@ class VectorizedRowBatch;
         void evaluate_or(vectorized::IColumn& column, uint16_t* sel, uint16_t size,                \
                          bool* flags) const override;                                              \
         void evaluate_vec(vectorized::IColumn& column, uint16_t size, bool* flags) const override; \
-        void set_dict_code_if_necessary(vectorized::IColumn& column) override;                     \
     private:                                                                                       \
         T _value;                                                                                  \
-        bool _dict_code_inited = false;                                                            \
-        int32_t _dict_code;                                                                        \
     };
 
 COMPARISON_PRED_CLASS_DEFINE(EqualPredicate, EQ)

--- a/be/src/olap/in_list_predicate.h
+++ b/be/src/olap/in_list_predicate.h
@@ -95,14 +95,11 @@ class VectorizedRowBatch;
         void evaluate(vectorized::IColumn& column, uint16_t* sel, uint16_t* size) const override; \
         void evaluate_and(vectorized::IColumn& column, uint16_t* sel, uint16_t size, bool* flags) const override {} \
         void evaluate_or(vectorized::IColumn& column, uint16_t* sel, uint16_t size, bool* flags) const override {} \
-        void set_dict_code_if_necessary(vectorized::IColumn& column) override;                    \
     private:                                                                                      \
         phmap::flat_hash_set<T> _values;                                                          \
-        bool _dict_code_inited = false;                                                           \
-        phmap::flat_hash_set<int32_t> _dict_codes;                                                \
     };
 
 IN_LIST_PRED_CLASS_DEFINE(InListPredicate, IN_LIST)
-IN_LIST_PRED_CLASS_DEFINE(NotInListPredicate, NO_IN_LIST)
+IN_LIST_PRED_CLASS_DEFINE(NotInListPredicate, NOT_IN_LIST)
 
 } //namespace doris

--- a/be/src/olap/rowset/segment_v2/segment_iterator.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.cpp
@@ -635,7 +635,7 @@ void SegmentIterator::_vec_init_lazy_materialization() {
             if (type == OLAP_FIELD_TYPE_VARCHAR || type == OLAP_FIELD_TYPE_CHAR ||
                 type == OLAP_FIELD_TYPE_STRING || predicate->type() == PredicateType::BF ||
                 predicate->type() == PredicateType::IN_LIST ||
-                predicate->type() == PredicateType::NO_IN_LIST) {
+                predicate->type() == PredicateType::NOT_IN_LIST) {
                 short_cir_pred_col_id_set.insert(cid);
                 _short_cir_eval_predicate.push_back(predicate);
                 _is_all_column_basic_type = false;
@@ -872,7 +872,6 @@ void SegmentIterator::_evaluate_short_circuit_predicate(uint16_t* vec_sel_rowid_
             predicate->type() == PredicateType::GT || predicate->type() == PredicateType::GE) {
             col_ptr->convert_dict_codes_if_necessary();
         }
-        predicate->set_dict_code_if_necessary(*short_cir_column);
         predicate->evaluate(*short_cir_column, vec_sel_rowid_idx, selected_size_ptr);
     }
 


### PR DESCRIPTION

# Proposed changes

Issue Number: close #9269 
The `ColumnPredicate` in `SegmentIterator` is shared by multiple Scanners.
One of the `SegmentIterators` modifies the internal member variable `dict_codes` of Predicate, which will affect the execution results of other `SegmentIterators`.


## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
