### PR TITLE
Fix bug for nullptr on replayEraseTable

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/CatalogRecycleBin.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/CatalogRecycleBin.java
@@ -223,6 +223,11 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
         RecycleTableInfo tableInfo = idToTable.remove(tableId);
         idToRecycleTime.remove(tableId);
 
+        if (tableInfo == null) {
+            LOG.warn("replayEraseTable, idToTable has no tableId: {}, ignore it", tableId);
+            return;
+        }
+
         Table table = tableInfo.getTable();
         if (table.getType() == TableType.OLAP && !Catalog.isCheckpointThread()) {
             Catalog.getCurrentCatalog().onEraseOlapTable((OlapTable) table, true);

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/CatalogRecycleBin.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/CatalogRecycleBin.java
@@ -223,6 +223,8 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
         RecycleTableInfo tableInfo = idToTable.remove(tableId);
         idToRecycleTime.remove(tableId);
 
+        // tableInfo == null means tableId is not in image. replayEraseTable is used to drop this table.
+        // If it is not exist, table is already dropped, this replay operation is duplicate, so nothing to do.
         if (tableInfo == null) {
             LOG.warn("replayEraseTable, idToTable has no tableId: {}, ignore it", tableId);
             return;


### PR DESCRIPTION
# Proposed changes

Issue Number: close #9265

## Problem Summary:

Add null checker

## Checklist(Required)

1. Does it affect the original behavior: (No)
2. Has unit tests been added: (No)
3. Has document been added or modified: (No)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (No)

## Further comments

