### PR TITLE
[security]Upgrade Jackson version to resolve CVE-2020-36518 vulnerability

### DIFF
--- a/dist/LICENSE-dist.txt
+++ b/dist/LICENSE-dist.txt
@@ -941,23 +941,23 @@ The Apache Software License, Version 2.0
         - io.dropwizard.metrics:metrics-json:3.1.5 (http://metrics.codahale.com/metrics-json/)
         - io.dropwizard.metrics:metrics-json:4.2.7 (https://metrics.dropwizard.io/metrics-json)
     * Jackson dataformat: CBOR:
-        - com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.13.1 (http://github.com/FasterXML/jackson-dataformats-binary)
+        - com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.13.2.2 (http://github.com/FasterXML/jackson-dataformats-binary)
     * Jackson datatype: JSR310:
-        - com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.1 (https://github.com/FasterXML/jackson-modules-java8/jackson-datatype-jsr310)
+        - com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.2.2 (https://github.com/FasterXML/jackson-modules-java8/jackson-datatype-jsr310)
     * Jackson datatype: jdk8:
-        - com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.13.1 (https://github.com/FasterXML/jackson-modules-java8/jackson-datatype-jdk8)
+        - com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.13.2.2 (https://github.com/FasterXML/jackson-modules-java8/jackson-datatype-jdk8)
     * Jackson module: JAXB Annotations:
-        - com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.12.1 (https://github.com/FasterXML/jackson-modules-base)
+        - com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.13.2.2 (https://github.com/FasterXML/jackson-modules-base)
     * Jackson module: Paranamer:
         - com.fasterxml.jackson.module:jackson-module-paranamer:2.7.9 (https://github.com/FasterXML/jackson-modules-base)
     * Jackson-annotations:
-        - com.fasterxml.jackson.core:jackson-annotations:2.12.1 (http://github.com/FasterXML/jackson)
+        - com.fasterxml.jackson.core:jackson-annotations:2.13.2.2 (http://github.com/FasterXML/jackson)
     * Jackson-core:
-        - com.fasterxml.jackson.core:jackson-core:2.12.1 (https://github.com/FasterXML/jackson-core)
+        - com.fasterxml.jackson.core:jackson-core:2.13.2.2 (https://github.com/FasterXML/jackson-core)
     * Jackson-dataformat-YAML:
-        - com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.12.1 (https://github.com/FasterXML/jackson-dataformats-text)
+        - com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.2.2 (https://github.com/FasterXML/jackson-dataformats-text)
     * Jackson-module-parameter-names:
-        - com.fasterxml.jackson.module:jackson-module-parameter-names:2.13.1 (https://github.com/FasterXML/jackson-modules-java8/jackson-module-parameter-names)
+        - com.fasterxml.jackson.module:jackson-module-parameter-names:2.13.2.2 (https://github.com/FasterXML/jackson-modules-java8/jackson-module-parameter-names)
     * Jakarta Bean Validation API:
         - jakarta.validation:jakarta.validation-api:2.0.2 (https://beanvalidation.org)
     * Java Authentication SPI for Containers:
@@ -1185,7 +1185,7 @@ The Apache Software License, Version 2.0
     * io.grpc:grpc-stub:
         - io.grpc:grpc-stub:1.30.0 (https://github.com/grpc/grpc-java)
     * jackson-databind:
-        - com.fasterxml.jackson.core:jackson-databind:2.12.1 (http://github.com/FasterXML/jackson)
+        - com.fasterxml.jackson.core:jackson-databind:2.13.2.2 (http://github.com/FasterXML/jackson)
     * jackson-module-scala:
         - com.fasterxml.jackson.module:jackson-module-scala_2.12:2.13.1 (http://wiki.fasterxml.com/JacksonModuleScala)
         - com.fasterxml.jackson.module:jackson-module-scala_2.12:2.6.7.1 (http://wiki.fasterxml.com/JacksonModuleScala)

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -142,7 +142,7 @@ under the License.
         <commons-validator.version>1.4.1</commons-validator.version>
         <gson.version>2.8.6</gson.version>
         <guava.version>29.0-jre</guava.version>
-        <jackson.version>2.12.1</jackson.version>
+        <jackson.version>2.13.2.2</jackson.version>
         <jackson-mapper-asl.version>1.9.13</jackson-mapper-asl.version>
         <java-cup.version>0.11-a-czt02-cdh</java-cup.version>
         <javassist.version>3.18.2-GA</javassist.version>


### PR DESCRIPTION
Upgrade Jackson version to resolve CVE-2020-36518 vulnerability
For details, see：
https://nvd.nist.gov/vuln/detail/CVE-2020-36518

# Proposed changes

Issue Number: close #xxx

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
