### PR TITLE
[Enhancement](Vectorized)build hash table with new thread, as non-vec…

### DIFF
--- a/be/src/vec/exec/join/vhash_join_node.cpp
+++ b/be/src/vec/exec/join/vhash_join_node.cpp
@@ -971,10 +971,29 @@ Status HashJoinNode::open(RuntimeState* state) {
         RETURN_IF_ERROR((*_vother_join_conjunct_ptr)->open(state));
     }
 
-    RETURN_IF_ERROR(_hash_table_build(state));
-    RETURN_IF_ERROR(child(0)->open(state));
+    if (_runtime_filter_descs.empty()) {
+        std::promise<Status> thread_status;
+        std::thread(bind(&HashJoinNode::_hash_table_build_thread, this, state, &thread_status))
+            .detach();
 
-    return Status::OK();
+        // Open the probe-side child so that it may perform any initialisation in parallel.
+        // Don't exit even if we see an error, we still need to wait for the build thread
+        // to finish.
+        // ISSUE-1247, check open_status after buildThread execute.
+        // If this return first, build thread will use 'thread_status'
+        // which is already destructor and then coredump.
+        Status open_status = child(0)->open(state);
+        RETURN_IF_ERROR(thread_status.get_future().get());
+        return open_status;
+    } else {
+        RETURN_IF_ERROR(_hash_table_build(state));
+        RETURN_IF_ERROR(child(0)->open(state));
+        return Status::OK();
+    }
+}
+
+void HashJoinNode::_hash_table_build_thread(RuntimeState* state, std::promise<Status>* status) {
+    status->set_value(_hash_table_build(state));
 }
 
 Status HashJoinNode::_hash_table_build(RuntimeState* state) {

--- a/be/src/vec/exec/join/vhash_join_node.cpp
+++ b/be/src/vec/exec/join/vhash_join_node.cpp
@@ -974,7 +974,7 @@ Status HashJoinNode::open(RuntimeState* state) {
     if (_runtime_filter_descs.empty()) {
         std::promise<Status> thread_status;
         std::thread(bind(&HashJoinNode::_hash_table_build_thread, this, state, &thread_status))
-            .detach();
+                .detach();
 
         // Open the probe-side child so that it may perform any initialisation in parallel.
         // Don't exit even if we see an error, we still need to wait for the build thread

--- a/be/src/vec/exec/join/vhash_join_node.h
+++ b/be/src/vec/exec/join/vhash_join_node.h
@@ -16,6 +16,7 @@
 // under the License.
 
 #pragma once
+#include <future>
 #include <variant>
 
 #include "common/object_pool.h"
@@ -239,7 +240,10 @@ private:
     std::vector<bool> _right_output_slot_flags;
 
 private:
+    void _hash_table_build_thread(RuntimeState* state, std::promise<Status>* status);
+
     Status _hash_table_build(RuntimeState* state);
+
     Status _process_build_block(RuntimeState* state, Block& block, uint8_t offset);
 
     Status extract_build_join_column(Block& block, NullMap& null_map, ColumnRawPtrs& raw_ptrs,


### PR DESCRIPTION
## info

in HashJoinNode, build hash table with new thread, so that child(0) can open() async. in this way,  hash table from different HashJoinNode in the plan tree can build at same time.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (No Need)
3. Has document been added or modified: (No Need)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (No)

I made the test on tpch data which scale factor is 10. 1 fe and 3 be separately deployed on 4 cloud servers, 
set runtime_filter_mode=off, 
set enable_vectorized_engine=true,
set exec_mem_limit=50G;
set batch_size=4096;
other session values are default.
sql: `select count(*) from lineitem, orders, part where l_orderkey=o_orderkey and l_partkey = p_partkey and year(l_shipdate)=1995;`
run this query 3 times, 
| run | before | after |
| --| --| -- |
| first time | 2.79 | 2.67 | 
| second time | 2.26 | 2.11 | 
| third time | 2.24 | 2.02 | 