### PR TITLE
[Enhancement](regression-test) Support suite plugin to add third-part…

### DIFF
--- a/docs/zh-CN/developer-guide/regression-testing.md
+++ b/docs/zh-CN/developer-guide/regression-testing.md
@@ -565,7 +565,7 @@ Suite.metaClass.testPlugin = { String info /* param */ ->
     Suite suite = delegate as Suite
 
     // function body
-    suite.getLogger().info("Test plugin: suiteName: ${suite.name}, info: ${info}")
+    suite.getLogger().info("Test plugin: suiteName: ${suite.name}, info: ${info}".toString())
 
     // optional return value
     return "OK"

--- a/docs/zh-CN/developer-guide/regression-testing.md
+++ b/docs/zh-CN/developer-guide/regression-testing.md
@@ -553,7 +553,7 @@ thread, lazyCheck, events, connect, selectUnionAll
 ```
 
 ## Suite插件
-有的时候我们需要拓展Suite类，但不便于修改Suite类的源码，则可以通过插件来进行拓展。默认插件目录为`${DORIS_HOME}/regression-test/plugins`，在其中可以通过groovy脚本定义拓展方法，如`plugin_example.groovy`为例，为Suite类增加了testPlugin函数用于打印日志：
+有的时候我们需要拓展Suite类，但不便于修改Suite类的源码，则可以通过插件来进行拓展。默认插件目录为`${DORIS_HOME}/regression-test/plugins`，在其中可以通过groovy脚本定义拓展方法，以`plugin_example.groovy`为例，为Suite类增加了testPlugin函数用于打印日志：
 ```groovy
 import org.apache.doris.regression.suite.Suite
 

--- a/docs/zh-CN/developer-guide/regression-testing.md
+++ b/docs/zh-CN/developer-guide/regression-testing.md
@@ -50,6 +50,7 @@ under the License.
 ./${DORIS_HOME}
     |-- **run-regression-test.sh**           回归测试启动脚本
     |-- regression-test
+    |   |-- plugins                          插件目录
     |   |-- conf
     |   |   |-- logback.xml                  日志配置文件
     |   |   |-- **regression-conf.groovy**   默认配置文件
@@ -100,6 +101,8 @@ feHttpPassword = ""
 suitePath = "${DORIS_HOME}/regression-test/suites"
 // 设置输入输出数据的目录
 dataPath = "${DORIS_HOME}/regression-test/data"
+// 设置插件的目录
+pluginPath = "${DORIS_HOME}/regression-test/plugins"
 
 // 默认会读所有的组,读多个组可以用半角逗号隔开，如: "demo,performance"
 // 一般不需要在配置文件中修改，而是通过run-regression-test.sh --run -g来动态指定和覆盖
@@ -547,6 +550,37 @@ thread, lazyCheck, events, connect, selectUnionAll
 
 # 使用查询结果自动生成sql_action用例的.out文件，如果.out文件存在则覆盖
 ./run-regression-test.sh --run sql_action -forceGenOut
+```
+
+## Suite插件
+有的时候我们需要拓展Suite类，但不便于修改Suite类的源码，则可以通过插件来进行拓展。默认插件目录为`${DORIS_HOME}/regression-test/plugins`，在其中可以通过groovy脚本定义拓展方法，如`plugin_example.groovy`为例，为Suite类增加了testPlugin函数用于打印日志：
+```groovy
+import org.apache.doris.regression.suite.Suite
+
+// register `testPlugin` function to Suite,
+// and invoke in ${DORIS_HOME}/regression-test/suites/demo/test_plugin.groovy
+Suite.metaClass.testPlugin = { String info /* param */ ->
+
+    // which suite invoke current function?
+    Suite suite = delegate as Suite
+
+    // function body
+    suite.getLogger().info("Test plugin: suiteName: ${suite.name}, info: ${info}")
+
+    // optional return value
+    return "OK"
+}
+
+logger.info("Added 'testPlugin' function to Suite")
+```
+
+增加了testPlugin函数后，则可以在普通用例中使用它，以`${DORIS_HOME}/regression-test/suites/demo/test_plugin.groovy`为例:
+```groovy
+suite("test_plugin", "demo") {
+    // register testPlugin function in ${DORIS_HOME}/regression-test/plugins/plugin_example.groovy
+    def result = testPlugin("message from suite")
+    assertEquals("OK", result)
+}
 ```
 
 ## CI/CD的支持

--- a/regression-test/conf/regression-conf.groovy
+++ b/regression-test/conf/regression-conf.groovy
@@ -32,6 +32,7 @@ feHttpPassword = ""
 // e.g. java -DDORIS_HOME=./
 suitePath = "${DORIS_HOME}/regression-test/suites"
 dataPath = "${DORIS_HOME}/regression-test/data"
+pluginPath = "${DORIS_HOME}/regression-test/plugins"
 
 // will test <group>/<suite>.groovy
 // empty group will test all group

--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/Config.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/Config.groovy
@@ -45,6 +45,7 @@ class Config {
 
     public String suitePath
     public String dataPath
+    public String pluginPath
 
     public String testGroups
     public String excludeGroups
@@ -79,6 +80,8 @@ class Config {
            String feHttpAddress, String feHttpUser, String feHttpPassword,
            String suitePath, String dataPath, String testGroups, String excludeGroups,
            String testSuites, String excludeSuites, String testDirectories, String excludeDirectories) {
+           String suitePath, String dataPath, String testGroups, String testSuites, String testDirectories,
+           String pluginPath) {
         this.defaultDb = defaultDb
         this.jdbcUrl = jdbcUrl
         this.jdbcUser = jdbcUser
@@ -94,6 +97,7 @@ class Config {
         this.excludeSuites = excludeSuites
         this.testDirectories = testDirectories
         this.excludeDirectories = excludeDirectories
+        this.pluginPath = pluginPath
     }
 
     static Config fromCommandLine(CommandLine cmd) {
@@ -113,6 +117,7 @@ class Config {
 
         config.suitePath = FileUtils.getCanonicalPath(cmd.getOptionValue(pathOpt, config.suitePath))
         config.dataPath = FileUtils.getCanonicalPath(cmd.getOptionValue(dataOpt, config.dataPath))
+        config.pluginPath = FileUtils.getCanonicalPath(cmd.getOptionValue(pluginOpt, config.pluginPath))
         config.suiteWildcard = cmd.getOptionValue(suiteOpt, config.testSuites)
                 .split(",")
                 .collect({s -> s.trim()})
@@ -194,6 +199,7 @@ class Config {
             configToString(obj.excludeSuites),
             configToString(obj.testDirectories),
             configToString(obj.excludeDirectories)
+            configToString(obj.pluginPath)
         )
 
         def declareFileNames = config.getClass()
@@ -253,6 +259,11 @@ class Config {
         if (config.dataPath == null) {
             config.dataPath = "regression-test/suites"
             log.info("Set dataPath to '${config.dataPath}' because not specify.".toString())
+        }
+
+        if (config.pluginPath == null) {
+            config.pluginPath = "regression-test/plugins"
+            log.info("Set dataPath to '${config.pluginPath}' because not specify.".toString())
         }
 
         if (config.testGroups == null) {

--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/Config.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/Config.groovy
@@ -79,8 +79,7 @@ class Config {
     Config(String defaultDb, String jdbcUrl, String jdbcUser, String jdbcPassword,
            String feHttpAddress, String feHttpUser, String feHttpPassword,
            String suitePath, String dataPath, String testGroups, String excludeGroups,
-           String testSuites, String excludeSuites, String testDirectories, String excludeDirectories) {
-           String suitePath, String dataPath, String testGroups, String testSuites, String testDirectories,
+           String testSuites, String excludeSuites, String testDirectories, String excludeDirectories,
            String pluginPath) {
         this.defaultDb = defaultDb
         this.jdbcUrl = jdbcUrl
@@ -198,7 +197,7 @@ class Config {
             configToString(obj.testSuites),
             configToString(obj.excludeSuites),
             configToString(obj.testDirectories),
-            configToString(obj.excludeDirectories)
+            configToString(obj.excludeDirectories),
             configToString(obj.pluginPath)
         )
 

--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/ConfigOptions.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/ConfigOptions.groovy
@@ -37,6 +37,7 @@ class ConfigOptions {
     static Option feHttpPasswordOpt
     static Option pathOpt
     static Option dataOpt
+    static Option pluginOpt
     static Option suiteOpt
     static Option excludeSuiteOpt
     static Option groupsOpt
@@ -116,6 +117,14 @@ class ConfigOptions {
                 .type(String.class)
                 .longOpt("dataPath")
                 .desc("the data path")
+                .build()
+        pluginOpt = Option.builder("plugin")
+                .argName("pluginPath")
+                .required(false)
+                .hasArg(true)
+                .type(String.class)
+                .longOpt("plugin")
+                .desc("the plugin path")
                 .build()
         suiteOpt = Option.builder("s")
                 .argName("suiteName")
@@ -267,6 +276,7 @@ class ConfigOptions {
                 .addOption(passwordOpt)
                 .addOption(pathOpt)
                 .addOption(dataOpt)
+                .addOption(pluginOpt)
                 .addOption(confOpt)
                 .addOption(suiteOpt)
                 .addOption(excludeSuiteOpt)

--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/RegressionTest.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/RegressionTest.groovy
@@ -279,7 +279,7 @@ class RegressionTest {
             return
         }
         def pluginPath = new File(config.pluginPath)
-        if (!pluginPath.exists() && !pluginPath.isDirectory()) {
+        if (!pluginPath.exists() || !pluginPath.isDirectory()) {
             return
         }
         pluginPath.eachFileRecurse { it ->

--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/RegressionTest.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/RegressionTest.groovy
@@ -286,13 +286,16 @@ class RegressionTest {
             if (it.name.endsWith(".groovy")) {
                 ScriptContext context = new ScriptContext(it, suiteExecutors, actionExecutors,
                         config, [], { name -> true })
-                try {
-                    SuiteScript pluginScript = new GroovyFileSource(it).toScript(context, shell)
-                    log.info("Begin to load plugin: ${it.getCanonicalPath()}")
-                    pluginScript.run()
-                    log.info("Loaded plugin: ${it.getCanonicalPath()}")
-                } catch (Throwable t) {
-                    log.error("Load plugin failed: ${it.getCanonicalPath()}", t)
+                File pluginFile = it
+                context.start {
+                    try {
+                        SuiteScript pluginScript = new GroovyFileSource(pluginFile).toScript(context, shell)
+                        log.info("Begin to load plugin: ${pluginFile.getCanonicalPath()}")
+                        pluginScript.run()
+                        log.info("Loaded plugin: ${pluginFile.getCanonicalPath()}")
+                    } catch (Throwable t) {
+                        log.error("Load plugin failed: ${pluginFile.getCanonicalPath()}", t)
+                    }
                 }
             }
         }

--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/RegressionTest.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/RegressionTest.groovy
@@ -286,8 +286,8 @@ class RegressionTest {
             if (it.name.endsWith(".groovy")) {
                 ScriptContext context = new ScriptContext(it, suiteExecutors, actionExecutors,
                         config, [], { name -> true })
-                SuiteScript pluginScript = new GroovyFileSource(it).toScript(context, shell)
                 try {
+                    SuiteScript pluginScript = new GroovyFileSource(it).toScript(context, shell)
                     log.info("Begin to load plugin: ${it.getCanonicalPath()}")
                     pluginScript.run()
                     log.info("Loaded plugin: ${it.getCanonicalPath()}")

--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/RegressionTest.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/RegressionTest.groovy
@@ -85,6 +85,8 @@ class RegressionTest {
         scriptExecutors = Executors.newFixedThreadPool(config.parallel)
         suiteExecutors = Executors.newFixedThreadPool(config.suiteParallel)
         actionExecutors = Executors.newFixedThreadPool(config.actionParallel)
+
+        loadPlugins(config)
     }
 
     static List<ScriptSource> findScriptSources(String root, Predicate<String> directoryFilter,
@@ -269,6 +271,30 @@ class RegressionTest {
         } else {
             printPassed()
             return true
+        }
+    }
+
+    static void loadPlugins(Config config) {
+        if (config.pluginPath.is(null) || config.pluginPath.isEmpty()) {
+            return
+        }
+        def pluginPath = new File(config.pluginPath)
+        if (!pluginPath.exists() && !pluginPath.isDirectory()) {
+            return
+        }
+        pluginPath.eachFileRecurse { it ->
+            if (it.name.endsWith(".groovy")) {
+                ScriptContext context = new ScriptContext(it, suiteExecutors, actionExecutors,
+                        config, [], { name -> true })
+                SuiteScript pluginScript = new GroovyFileSource(it).toScript(context, shell)
+                try {
+                    log.info("Begin to load plugin: ${it.getCanonicalPath()}")
+                    pluginScript.run()
+                    log.info("Loaded plugin: ${it.getCanonicalPath()}")
+                } catch (Throwable t) {
+                    log.error("Load plugin failed: ${it.getCanonicalPath()}", t)
+                }
+            }
         }
     }
 

--- a/regression-test/plugins/plugin_example.groovy
+++ b/regression-test/plugins/plugin_example.groovy
@@ -25,7 +25,7 @@ Suite.metaClass.testPlugin = { String info /* param */ ->
     Suite suite = delegate as Suite
 
     // function body
-    suite.getLogger().info("Test plugin: suiteName: ${suite.name}, info: ${info}")
+    suite.getLogger().info("Test plugin: suiteName: ${suite.name}, info: ${info}".toString())
 
     // optional return value
     return "OK"

--- a/regression-test/plugins/plugin_example.groovy
+++ b/regression-test/plugins/plugin_example.groovy
@@ -1,0 +1,34 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import org.apache.doris.regression.suite.Suite
+
+// register `testPlugin` function to Suite,
+// and invoke in ${DORIS_HOME}/regression-test/suites/demo/test_plugin.groovy
+Suite.metaClass.testPlugin = { String info /* param */ ->
+
+    // which suite invoke current function?
+    Suite suite = delegate as Suite
+
+    // function body
+    suite.getLogger().info("Test plugin: suiteName: ${suite.name}, info: ${info}")
+
+    // optional return value
+    return "OK"
+}
+
+logger.info("Added 'testPlugin' function to Suite")

--- a/regression-test/suites/demo/test_plugin.groovy
+++ b/regression-test/suites/demo/test_plugin.groovy
@@ -1,0 +1,22 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("test_plugin", "demo") {
+    // register testPlugin function in ${DORIS_HOME}/regression-test/plugins/plugin_example.groovy
+    def result = testPlugin("message from suite")
+    assertEquals("OK", result)
+}


### PR DESCRIPTION
# Proposed changes

Issue Number: No issue

## Problem Summary:

Support register suite plugin to add third-party function.

See 
1. register in: ${DORIS_HOME}/regression-test/plugins/plugin_example.groovy
2. usage: ${DORIS_HOME}/regression-test/suites/demo/test_plugin.groovy
3. doc: ${DORIS_HOME}/docs/zh-CN/developer-guide/regression-testing.md

## Checklist(Required)

1. Does it affect the original behavior: No
2. Has unit tests been added: No
4. Has document been added or modified: Yes
5. Does it need to update dependencies: No
6. Are there any changes that cannot be rolled back: Yes