### PR TITLE
[fix]Add http header size parameter

### DIFF
--- a/docs/en/admin-manual/config/fe-config.md
+++ b/docs/en/admin-manual/config/fe-config.md
@@ -209,6 +209,12 @@ Default：100 * 1024 * 1024  （100MB）
 
 This is the maximum number of bytes of the file uploaded by the put or post method, the default value: 100MB
 
+### jetty_server_max_http_header_size
+
+Default：10240  （10K）
+
+http header size configuration parameter, the default value is 10K
+
 ### frontend_address
 
 Status: Deprecated, not recommended use. This parameter may be deleted later Type: string Description: Explicitly set the IP address of FE instead of using *InetAddress.getByName* to get the IP address. Usually in *InetAddress.getByName* When the expected results cannot be obtained. Only IP address is supported, not hostname. Default value: 0.0.0.0

--- a/docs/zh-CN/admin-manual/config/fe-config.md
+++ b/docs/zh-CN/admin-manual/config/fe-config.md
@@ -207,6 +207,12 @@ workers 线程池默认不做设置，根据自己需要进行设置
 
 这个是 put 或 post 方法上传文件的最大字节数，默认值：100MB
 
+### jetty_server_max_http_header_size
+
+默认值：10240  （10K）
+
+http header size 配置参数
+
 ### `default_max_filter_ratio`
 
 默认值：0

--- a/fe/fe-core/src/main/java/org/apache/doris/PaloFe.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/PaloFe.java
@@ -146,6 +146,7 @@ public class PaloFe {
             httpServer.setWorkers(Config.jetty_server_workers);
             httpServer.setMaxThreads(Config.jetty_threadPool_maxThreads);
             httpServer.setMinThreads(Config.jetty_threadPool_minThreads);
+            httpServer.setMaxHttpHeaderSize (Config.jetty_server_max_http_header_size);
             httpServer.start();
             
             qeService.start();

--- a/fe/fe-core/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/Config.java
@@ -359,6 +359,11 @@ public class Config extends ConfigBase {
     @ConfField public static int jetty_server_max_http_post_size = 100 * 1024 * 1024;
 
     /**
+     * http header size configuration parameter, the default value is 10K
+     */
+    @ConfField public static int jetty_server_max_http_header_size = 10240;
+
+    /**
      * Mini load disabled by default
      */
     @ConfField public static boolean disable_mini_load = true;

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/HttpServer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/HttpServer.java
@@ -41,9 +41,17 @@ public class HttpServer extends SpringBootServletInitializer {
     private int selectors;
     private int maxHttpPostSize ;
     private int workers;
-
+    private int maxHttpHeaderSize;
     private int minThreads;
     private int maxThreads;
+
+    public int getMaxHttpHeaderSize () {
+        return maxHttpHeaderSize;
+    }
+
+    public void setMaxHttpHeaderSize ( int maxHttpHeaderSize ) {
+        this.maxHttpHeaderSize = maxHttpHeaderSize;
+    }
 
     public int getMinThreads() { return minThreads; }
 
@@ -92,6 +100,7 @@ public class HttpServer extends SpringBootServletInitializer {
         properties.put("server.jetty.selectors", this.selectors);
         properties.put("server.jetty.threadPool.maxThreads", this.maxThreads);
         properties.put("server.jetty.threadPool.minThreads", this.minThreads);
+        properties.put("server.max-http-header-size", this.maxHttpHeaderSize);
         //Worker thread pool is not set by default, set according to your needs
         if(this.workers > 0) {
             properties.put("server.jetty.workers", this.workers);

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/HttpServer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/HttpServer.java
@@ -45,11 +45,11 @@ public class HttpServer extends SpringBootServletInitializer {
     private int minThreads;
     private int maxThreads;
 
-    public int getMaxHttpHeaderSize () {
+    public int getMaxHttpHeaderSize() {
         return maxHttpHeaderSize;
     }
 
-    public void setMaxHttpHeaderSize ( int maxHttpHeaderSize ) {
+    public void setMaxHttpHeaderSize(int maxHttpHeaderSize) {
         this.maxHttpHeaderSize = maxHttpHeaderSize;
     }
 


### PR DESCRIPTION
Add the http header size parameter to avoid failure due to too many fields when users import using stream load. The normal default is 8192, and 10K is given here.

# Proposed changes

Issue Number: close #9125

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
