### PR TITLE
[Bug] Fix build failed

### DIFF
--- a/docs/build_help_zip.sh
+++ b/docs/build_help_zip.sh
@@ -30,15 +30,10 @@ ROOT=`cd "$ROOT"; pwd`
 BUILD_DIR=build
 HELP_DIR=contents
 HELP_ZIP_FILE=help-resource.zip
-SQL_REF_DOC_DIR=zh-CN/sql-reference/
 
 cd $ROOT
 rm -rf $BUILD_DIR $HELP_DIR $HELP_ZIP_FILE
 mkdir -p $BUILD_DIR $HELP_DIR
 
-cp -r $SQL_REF_DOC_DIR/* $HELP_DIR/
-
 zip -r $HELP_ZIP_FILE $HELP_DIR
 mv $HELP_ZIP_FILE $BUILD_DIR/
-
-


### PR DESCRIPTION
## Problem Summary:

`sql-reference` was removed in https://github.com/apache/incubator-doris/commit/267e8b67c210eaccebf35dbaaf9e749b3d1a0246, it causes the build failure.
```
Build docs
cp: cannot stat 'zh-CN/sql-reference//*': No such file or directory
```

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
