### PR TITLE
[refactor][storage]rename is_used to is_bad

### DIFF
--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -1154,7 +1154,7 @@ void TaskWorkerPool::_report_disk_state_worker_thread_callback() {
             disk.__set_disk_total_capacity(root_path_info.disk_capacity);
             disk.__set_data_used_capacity(root_path_info.data_used_capacity);
             disk.__set_disk_available_capacity(root_path_info.available);
-            disk.__set_used(root_path_info.is_bad);
+            disk.__set_used(root_path_info.normal);
             disks[root_path_info.path_desc.filepath] = disk;
         }
         request.__set_disks(disks);

--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -1154,7 +1154,7 @@ void TaskWorkerPool::_report_disk_state_worker_thread_callback() {
             disk.__set_disk_total_capacity(root_path_info.disk_capacity);
             disk.__set_data_used_capacity(root_path_info.data_used_capacity);
             disk.__set_disk_available_capacity(root_path_info.available);
-            disk.__set_used(root_path_info.is_used);
+            disk.__set_used(root_path_info.is_bad);
             disks[root_path_info.path_desc.filepath] = disk;
         }
         request.__set_disks(disks);

--- a/be/src/olap/data_dir.cpp
+++ b/be/src/olap/data_dir.cpp
@@ -71,7 +71,7 @@ DataDir::DataDir(const std::string& path, int64_t capacity_bytes,
           _available_bytes(0),
           _disk_capacity_bytes(0),
           _storage_medium(storage_medium),
-          _is_bad(false),
+          _is_normal(false),
           _tablet_manager(tablet_manager),
           _txn_manager(txn_manager),
           _cluster_id(-1),
@@ -108,7 +108,7 @@ Status DataDir::init() {
     RETURN_NOT_OK_STATUS_WITH_WARN(_init_capacity(), "_init_capacity failed");
     RETURN_NOT_OK_STATUS_WITH_WARN(_init_meta(), "_init_meta failed");
 
-    _is_bad = true;
+    _is_normal = true;
     return Status::OK();
 }
 
@@ -232,17 +232,17 @@ Status DataDir::_write_cluster_id_to_path(const FilePathDesc& path_desc, int32_t
 
 void DataDir::health_check() {
     // check disk
-    if (_is_bad) {
+    if (_is_normal) {
         Status res = _read_and_write_test_file();
         if (!res) {
             LOG(WARNING) << "store read/write test file occur IO Error. path="
                          << _path_desc.filepath;
             if (is_io_error(res)) {
-                _is_bad = false;
+                _is_normal = false;
             }
         }
     }
-    disks_state->set_value(_is_bad ? 1 : 0);
+    disks_state->set_value(_is_normal ? 1 : 0);
 }
 
 Status DataDir::_read_and_write_test_file() {

--- a/be/src/olap/data_dir.h
+++ b/be/src/olap/data_dir.h
@@ -54,8 +54,8 @@ public:
     const std::string& path() const { return _path_desc.filepath; }
     const FilePathDesc& path_desc() const { return _path_desc; }
     size_t path_hash() const { return _path_hash; }
-    bool bad() const { return _is_bad; }
-    void set_bad(bool is_bad) { _is_bad = is_bad; }
+    bool normal() const { return _is_normal; }
+    void set_normal(bool is_normal) { _is_normal = is_normal; }
     int32_t cluster_id() const { return _cluster_id; }
     bool cluster_id_incomplete() const { return _cluster_id_incomplete; }
 
@@ -65,7 +65,7 @@ public:
         info.path_hash = _path_hash;
         info.disk_capacity = _disk_capacity_bytes;
         info.available = _available_bytes;
-        info.is_bad = _is_bad;
+        info.is_normal = _is_normal;
         info.storage_medium = _storage_medium;
         return info;
     }
@@ -173,7 +173,7 @@ private:
     // the actual capacity of the disk of this data dir
     int64_t _disk_capacity_bytes;
     TStorageMedium::type _storage_medium;
-    bool _is_bad;
+    bool _is_normal;
 
     TabletManager* _tablet_manager;
     TxnManager* _txn_manager;

--- a/be/src/olap/data_dir.h
+++ b/be/src/olap/data_dir.h
@@ -54,8 +54,8 @@ public:
     const std::string& path() const { return _path_desc.filepath; }
     const FilePathDesc& path_desc() const { return _path_desc; }
     size_t path_hash() const { return _path_hash; }
-    bool is_used() const { return _is_used; }
-    void set_is_used(bool is_used) { _is_used = is_used; }
+    bool is_bad() const { return _is_bad; }
+    void set_is_bad(bool is_bad) { _is_bad = is_bad; }
     int32_t cluster_id() const { return _cluster_id; }
     bool cluster_id_incomplete() const { return _cluster_id_incomplete; }
 
@@ -65,7 +65,7 @@ public:
         info.path_hash = _path_hash;
         info.disk_capacity = _disk_capacity_bytes;
         info.available = _available_bytes;
-        info.is_used = _is_used;
+        info.is_bad = _is_bad;
         info.storage_medium = _storage_medium;
         return info;
     }
@@ -173,7 +173,7 @@ private:
     // the actual capacity of the disk of this data dir
     int64_t _disk_capacity_bytes;
     TStorageMedium::type _storage_medium;
-    bool _is_used;
+    bool _is_bad;
 
     TabletManager* _tablet_manager;
     TxnManager* _txn_manager;

--- a/be/src/olap/data_dir.h
+++ b/be/src/olap/data_dir.h
@@ -54,8 +54,8 @@ public:
     const std::string& path() const { return _path_desc.filepath; }
     const FilePathDesc& path_desc() const { return _path_desc; }
     size_t path_hash() const { return _path_hash; }
-    bool is_bad() const { return _is_bad; }
-    void set_is_bad(bool is_bad) { _is_bad = is_bad; }
+    bool bad() const { return _is_bad; }
+    void set_bad(bool is_bad) { _is_bad = is_bad; }
     int32_t cluster_id() const { return _cluster_id; }
     bool cluster_id_incomplete() const { return _cluster_id_incomplete; }
 

--- a/be/src/olap/olap_common.h
+++ b/be/src/olap/olap_common.h
@@ -56,7 +56,7 @@ struct DataDirInfo {
     int64_t disk_capacity = 1; // actual disk capacity
     int64_t available = 0;     // available space, in bytes unit
     int64_t data_used_capacity = 0;
-    bool is_used = false;                                      // whether available mark
+    bool is_bad = false;                                      // whether available mark
     TStorageMedium::type storage_medium = TStorageMedium::HDD; // Storage medium type: SSD|HDD
 };
 

--- a/be/src/olap/olap_common.h
+++ b/be/src/olap/olap_common.h
@@ -56,7 +56,8 @@ struct DataDirInfo {
     int64_t disk_capacity = 1; // actual disk capacity
     int64_t available = 0;     // available space, in bytes unit
     int64_t data_used_capacity = 0;
-    bool is_bad = false;                                      // whether available mark
+    // whether the disk is normal or crashed for example it could not do IO operations
+    bool normal = false;
     TStorageMedium::type storage_medium = TStorageMedium::HDD; // Storage medium type: SSD|HDD
 };
 

--- a/be/src/olap/storage_engine.cpp
+++ b/be/src/olap/storage_engine.cpp
@@ -280,7 +280,7 @@ void StorageEngine::_update_storage_medium_type_count() {
 
     std::lock_guard<std::mutex> l(_store_lock);
     for (auto& it : _store_map) {
-        if (it.second->bad()) {
+        if (it.second->is_normal) {
             available_storage_medium_types.insert(it.second->storage_medium());
         }
     }
@@ -323,7 +323,7 @@ std::vector<DataDir*> StorageEngine::get_stores() {
         }
     } else {
         for (auto& it : _store_map) {
-            if (it.second->bad()) {
+            if (it.second->normal()) {
                 stores.push_back(it.second);
             }
         }
@@ -472,7 +472,7 @@ std::vector<DataDir*> StorageEngine::get_stores_for_create_tablet(
     {
         std::lock_guard<std::mutex> l(_store_lock);
         for (auto& it : _store_map) {
-            if (it.second->bad()) {
+            if (it.second->normal()) {
                 if (_available_storage_medium_type_count == 1 ||
                     it.second->storage_medium() == storage_medium ||
                     (it.second->storage_medium() == TStorageMedium::REMOTE_CACHE &&
@@ -528,7 +528,7 @@ bool StorageEngine::_delete_tablets_on_unused_root_path() {
 
         for (auto& it : _store_map) {
             ++total_root_path_num;
-            if (it.second->bad()) {
+            if (it.second->normal()) {
                 continue;
             }
             it.second->clear_tablets(&tablet_info_vec);
@@ -672,7 +672,7 @@ Status StorageEngine::start_trash_sweep(double* usage, bool ignore_guard) {
     double tmp_usage = 0.0;
     for (DataDirInfo& info : data_dir_infos) {
         LOG(INFO) << "Start to sweep path " << info.path_desc.filepath;
-        if (!info.is_bad) {
+        if (!info.normal()) {
             continue;
         }
 

--- a/be/src/olap/storage_engine.cpp
+++ b/be/src/olap/storage_engine.cpp
@@ -280,7 +280,7 @@ void StorageEngine::_update_storage_medium_type_count() {
 
     std::lock_guard<std::mutex> l(_store_lock);
     for (auto& it : _store_map) {
-        if (it.second->is_bad()) {
+        if (it.second->bad()) {
             available_storage_medium_types.insert(it.second->storage_medium());
         }
     }
@@ -323,7 +323,7 @@ std::vector<DataDir*> StorageEngine::get_stores() {
         }
     } else {
         for (auto& it : _store_map) {
-            if (it.second->is_bad()) {
+            if (it.second->bad()) {
                 stores.push_back(it.second);
             }
         }
@@ -472,7 +472,7 @@ std::vector<DataDir*> StorageEngine::get_stores_for_create_tablet(
     {
         std::lock_guard<std::mutex> l(_store_lock);
         for (auto& it : _store_map) {
-            if (it.second->is_bad()) {
+            if (it.second->bad()) {
                 if (_available_storage_medium_type_count == 1 ||
                     it.second->storage_medium() == storage_medium ||
                     (it.second->storage_medium() == TStorageMedium::REMOTE_CACHE &&
@@ -528,7 +528,7 @@ bool StorageEngine::_delete_tablets_on_unused_root_path() {
 
         for (auto& it : _store_map) {
             ++total_root_path_num;
-            if (it.second->is_bad()) {
+            if (it.second->bad()) {
                 continue;
             }
             it.second->clear_tablets(&tablet_info_vec);

--- a/be/src/olap/storage_engine.h
+++ b/be/src/olap/storage_engine.h
@@ -91,9 +91,6 @@ public:
     template <bool include_unused = false>
     std::vector<DataDir*> get_stores();
 
-    // @brief 设置root_path是否可用
-    void set_store_used_flag(const std::string& root_path, bool is_used);
-
     // @brief 获取所有root_path信息
     Status get_all_data_dir_info(std::vector<DataDirInfo>* data_dir_infos, bool need_update);
 
@@ -290,12 +287,12 @@ private:
                   disk_index(index),
                   task_running(0),
                   task_remaining(0),
-                  is_used(used) {}
+                  is_bad(used) {}
         const std::string storage_path;
         const uint32_t disk_index;
         uint32_t task_running;
         uint32_t task_remaining;
-        bool is_used;
+        bool is_bad;
     };
 
     EngineOptions _options;

--- a/be/src/olap/storage_engine.h
+++ b/be/src/olap/storage_engine.h
@@ -282,17 +282,17 @@ private:
     };
 
     struct CompactionDiskStat {
-        CompactionDiskStat(std::string path, uint32_t index, bool bad)
+        CompactionDiskStat(std::string path, uint32_t index, bool normal)
                 : storage_path(path),
                   disk_index(index),
                   task_running(0),
                   task_remaining(0),
-                  is_bad(bad) {}
+                  is_normal(normal) {}
         const std::string storage_path;
         const uint32_t disk_index;
         uint32_t task_running;
         uint32_t task_remaining;
-        bool is_bad;
+        bool is_normal;
     };
 
     EngineOptions _options;

--- a/be/src/olap/storage_engine.h
+++ b/be/src/olap/storage_engine.h
@@ -282,12 +282,12 @@ private:
     };
 
     struct CompactionDiskStat {
-        CompactionDiskStat(std::string path, uint32_t index, bool used)
+        CompactionDiskStat(std::string path, uint32_t index, bool bad)
                 : storage_path(path),
                   disk_index(index),
                   task_running(0),
                   task_remaining(0),
-                  is_bad(used) {}
+                  is_bad(bad) {}
         const std::string storage_path;
         const uint32_t disk_index;
         uint32_t task_running;

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -698,7 +698,7 @@ bool Tablet::can_do_compaction(size_t path_hash, CompactionType compaction_type)
         return false;
     }
 
-    if (data_dir()->path_hash() != path_hash || !is_used() || !init_succeeded()) {
+    if (data_dir()->path_hash() != path_hash || !is_bad() || !init_succeeded()) {
         return false;
     }
 

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -65,7 +65,7 @@ TabletSharedPtr Tablet::create_tablet_from_meta(TabletMetaSharedPtr tablet_meta,
 Tablet::Tablet(TabletMetaSharedPtr tablet_meta, const StorageParamPB& storage_param,
                DataDir* data_dir, const std::string& cumulative_compaction_type)
         : BaseTablet(tablet_meta, storage_param, data_dir),
-          _bad(false),
+          _is_bad(false),
           _last_cumu_compaction_failure_millis(0),
           _last_base_compaction_failure_millis(0),
           _last_cumu_compaction_success_millis(0),

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -65,7 +65,7 @@ TabletSharedPtr Tablet::create_tablet_from_meta(TabletMetaSharedPtr tablet_meta,
 Tablet::Tablet(TabletMetaSharedPtr tablet_meta, const StorageParamPB& storage_param,
                DataDir* data_dir, const std::string& cumulative_compaction_type)
         : BaseTablet(tablet_meta, storage_param, data_dir),
-          _is_bad(false),
+          _is_normal(false),
           _last_cumu_compaction_failure_millis(0),
           _last_base_compaction_failure_millis(0),
           _last_cumu_compaction_success_millis(0),
@@ -698,7 +698,7 @@ bool Tablet::can_do_compaction(size_t path_hash, CompactionType compaction_type)
         return false;
     }
 
-    if (data_dir()->path_hash() != path_hash || !bad() || !init_succeeded()) {
+    if (data_dir()->path_hash() != path_hash || !normal() || !init_succeeded()) {
         return false;
     }
 

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -65,7 +65,7 @@ TabletSharedPtr Tablet::create_tablet_from_meta(TabletMetaSharedPtr tablet_meta,
 Tablet::Tablet(TabletMetaSharedPtr tablet_meta, const StorageParamPB& storage_param,
                DataDir* data_dir, const std::string& cumulative_compaction_type)
         : BaseTablet(tablet_meta, storage_param, data_dir),
-          _is_bad(false),
+          _bad(false),
           _last_cumu_compaction_failure_millis(0),
           _last_base_compaction_failure_millis(0),
           _last_cumu_compaction_success_millis(0),
@@ -698,7 +698,7 @@ bool Tablet::can_do_compaction(size_t path_hash, CompactionType compaction_type)
         return false;
     }
 
-    if (data_dir()->path_hash() != path_hash || !is_bad() || !init_succeeded()) {
+    if (data_dir()->path_hash() != path_hash || !bad() || !init_succeeded()) {
         return false;
     }
 

--- a/be/src/olap/tablet.h
+++ b/be/src/olap/tablet.h
@@ -62,7 +62,7 @@ public:
     Status init();
     bool init_succeeded();
 
-    bool bad();
+    bool normal();
 
     void register_tablet_into_dir();
     void deregister_tablet_from_dir();
@@ -170,7 +170,7 @@ public:
     Status split_range(const OlapTuple& start_key_strings, const OlapTuple& end_key_strings,
                        uint64_t request_block_row_count, std::vector<OlapTuple>* ranges);
 
-    void set_bad(bool is_bad) { _is_bad = is_bad; }
+    void set_bad(bool is_normal) { _is_normal = is_normal; }
 
     int64_t last_cumu_compaction_failure_time() { return _last_cumu_compaction_failure_millis; }
     void set_last_cumu_compaction_failure_time(int64_t millis) {
@@ -309,7 +309,7 @@ private:
     // this policy is judged and computed by TimestampedVersionTracker.
     std::unordered_map<Version, RowsetSharedPtr, HashOfVersion> _stale_rs_version_map;
     // if this tablet is broken, set to true. default is false
-    std::atomic<bool> _is_bad;
+    std::atomic<bool> _is_normal;
     // timestamp of last cumu compaction failure
     std::atomic<int64_t> _last_cumu_compaction_failure_millis;
     // timestamp of last base compaction failure
@@ -355,8 +355,8 @@ inline bool Tablet::init_succeeded() {
     return _init_once.has_called() && _init_once.stored_result().ok();
 }
 
-inline bool Tablet::bad() {
-    return !_is_bad && _data_dir->bad();
+inline bool Tablet::normal() {
+    return !_is_normal && _data_dir->normal();
 }
 
 inline void Tablet::register_tablet_into_dir() {

--- a/be/src/olap/tablet.h
+++ b/be/src/olap/tablet.h
@@ -62,7 +62,7 @@ public:
     Status init();
     bool init_succeeded();
 
-    bool is_bad();
+    bool bad();
 
     void register_tablet_into_dir();
     void deregister_tablet_from_dir();
@@ -355,8 +355,8 @@ inline bool Tablet::init_succeeded() {
     return _init_once.has_called() && _init_once.stored_result().ok();
 }
 
-inline bool Tablet::is_bad() {
-    return !_is_bad && _data_dir->is_bad();
+inline bool Tablet::bad() {
+    return !_is_bad && _data_dir->bad();
 }
 
 inline void Tablet::register_tablet_into_dir() {

--- a/be/src/olap/tablet.h
+++ b/be/src/olap/tablet.h
@@ -62,7 +62,7 @@ public:
     Status init();
     bool init_succeeded();
 
-    bool is_used();
+    bool is_bad();
 
     void register_tablet_into_dir();
     void deregister_tablet_from_dir();
@@ -355,8 +355,8 @@ inline bool Tablet::init_succeeded() {
     return _init_once.has_called() && _init_once.stored_result().ok();
 }
 
-inline bool Tablet::is_used() {
-    return !_is_bad && _data_dir->is_used();
+inline bool Tablet::is_bad() {
+    return !_is_bad && _data_dir->is_bad();
 }
 
 inline void Tablet::register_tablet_into_dir() {

--- a/be/src/olap/tablet_manager.cpp
+++ b/be/src/olap/tablet_manager.cpp
@@ -554,7 +554,7 @@ TabletSharedPtr TabletManager::_get_tablet_unlocked(TTabletId tablet_id, bool in
         return nullptr;
     }
 
-    if (!tablet->is_used()) {
+    if (!tablet->is_bad()) {
         LOG(WARNING) << "tablet cannot be used. tablet=" << tablet_id;
         if (err != nullptr) {
             *err = "tablet cannot be used. " + BackendOptions::get_localhost();
@@ -1116,7 +1116,7 @@ void TabletManager::update_root_path_info(std::map<string, DataDirInfo>* path_ma
             if (iter == path_map->end()) {
                 continue;
             }
-            if (iter->second.is_used) {
+            if (iter->second.is_bad) {
                 iter->second.data_used_capacity += data_size;
             }
         }
@@ -1143,7 +1143,7 @@ void TabletManager::do_tablet_meta_checkpoint(DataDir* data_dir) {
                 }
 
                 if (tablet_ptr->data_dir()->path_hash() != data_dir->path_hash() ||
-                    !tablet_ptr->is_used() || !tablet_ptr->init_succeeded()) {
+                    !tablet_ptr->is_bad() || !tablet_ptr->init_succeeded()) {
                     continue;
                 }
                 related_tablets.push_back(tablet_ptr);

--- a/be/src/olap/tablet_manager.cpp
+++ b/be/src/olap/tablet_manager.cpp
@@ -554,7 +554,7 @@ TabletSharedPtr TabletManager::_get_tablet_unlocked(TTabletId tablet_id, bool in
         return nullptr;
     }
 
-    if (!tablet->is_bad()) {
+    if (!tablet->bad()) {
         LOG(WARNING) << "tablet cannot be used. tablet=" << tablet_id;
         if (err != nullptr) {
             *err = "tablet cannot be used. " + BackendOptions::get_localhost();
@@ -1143,7 +1143,7 @@ void TabletManager::do_tablet_meta_checkpoint(DataDir* data_dir) {
                 }
 
                 if (tablet_ptr->data_dir()->path_hash() != data_dir->path_hash() ||
-                    !tablet_ptr->is_bad() || !tablet_ptr->init_succeeded()) {
+                    !tablet_ptr->bad() || !tablet_ptr->init_succeeded()) {
                     continue;
                 }
                 related_tablets.push_back(tablet_ptr);

--- a/be/src/olap/tablet_manager.cpp
+++ b/be/src/olap/tablet_manager.cpp
@@ -554,7 +554,7 @@ TabletSharedPtr TabletManager::_get_tablet_unlocked(TTabletId tablet_id, bool in
         return nullptr;
     }
 
-    if (!tablet->bad()) {
+    if (!tablet->normal()) {
         LOG(WARNING) << "tablet cannot be used. tablet=" << tablet_id;
         if (err != nullptr) {
             *err = "tablet cannot be used. " + BackendOptions::get_localhost();
@@ -1116,7 +1116,7 @@ void TabletManager::update_root_path_info(std::map<string, DataDirInfo>* path_ma
             if (iter == path_map->end()) {
                 continue;
             }
-            if (iter->second.is_bad) {
+            if (iter->second.normal()) {
                 iter->second.data_used_capacity += data_size;
             }
         }
@@ -1143,7 +1143,7 @@ void TabletManager::do_tablet_meta_checkpoint(DataDir* data_dir) {
                 }
 
                 if (tablet_ptr->data_dir()->path_hash() != data_dir->path_hash() ||
-                    !tablet_ptr->bad() || !tablet_ptr->init_succeeded()) {
+                    !tablet_ptr->normal() || !tablet_ptr->init_succeeded()) {
                     continue;
                 }
                 related_tablets.push_back(tablet_ptr);

--- a/be/src/service/backend_service.cpp
+++ b/be/src/service/backend_service.cpp
@@ -227,7 +227,7 @@ void BackendService::get_disk_trash_used_capacity(std::vector<TDiskTrashInfo>& d
 
         diskTrashInfo.__set_root_path(root_path_info.path_desc.filepath);
 
-        diskTrashInfo.__set_state(root_path_info.is_used ? "ONLINE" : "OFFLINE");
+        diskTrashInfo.__set_state(root_path_info.is_bad ? "ONLINE" : "OFFLINE");
 
         std::string lhs_trash_path = root_path_info.path_desc.filepath + TRASH_PREFIX;
         std::filesystem::path trash_path(lhs_trash_path);

--- a/be/src/service/backend_service.cpp
+++ b/be/src/service/backend_service.cpp
@@ -227,7 +227,7 @@ void BackendService::get_disk_trash_used_capacity(std::vector<TDiskTrashInfo>& d
 
         diskTrashInfo.__set_root_path(root_path_info.path_desc.filepath);
 
-        diskTrashInfo.__set_state(root_path_info.is_bad ? "ONLINE" : "OFFLINE");
+        diskTrashInfo.__set_state(root_path_info.normal ? "ONLINE" : "OFFLINE");
 
         std::string lhs_trash_path = root_path_info.path_desc.filepath + TRASH_PREFIX;
         std::filesystem::path trash_path(lhs_trash_path);


### PR DESCRIPTION
# Proposed changes

is_used = false means the disk is crashed or has something wrong. But it  is too ambiguous for users to understanding. Since isBad is used in FE, so I unify the name.

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
