### PR TITLE
track all memory in VOlapScanNode and fix track leaf from bitmap and hll

### DIFF
--- a/be/src/exec/olap_scan_node.h
+++ b/be/src/exec/olap_scan_node.h
@@ -249,7 +249,7 @@ protected:
 
     TResourceInfo* _resource_info;
 
-    int64_t _buffered_bytes;
+    std::atomic<int64_t> _buffered_bytes;
     EvalConjunctsFn _eval_conjuncts_fn;
 
     bool _need_agg_finalize = true;

--- a/be/src/olap/aggregate_func.h
+++ b/be/src/olap/aggregate_func.h
@@ -505,8 +505,6 @@ struct AggregateFuncTraits<OLAP_FIELD_AGGREGATION_HLL_UNION, OLAP_FIELD_TYPE_HLL
 
         dst_slice->data = reinterpret_cast<char*>(hll);
 
-        mem_pool->mem_tracker()->Consume(hll->memory_consumed());
-
         agg_pool->add(hll);
     }
 
@@ -551,7 +549,6 @@ struct AggregateFuncTraits<OLAP_FIELD_AGGREGATION_BITMAP_UNION, OLAP_FIELD_TYPE_
         // we use zero size represent this slice is a agg object
         dst_slice->size = 0;
         auto bitmap = new BitmapValue(src_slice->data);
-        mem_pool->mem_tracker()->Consume(sizeof(BitmapValue));
         dst_slice->data = (char*)bitmap;
 
         agg_pool->add(bitmap);

--- a/be/src/vec/exec/volap_scan_node.cpp
+++ b/be/src/vec/exec/volap_scan_node.cpp
@@ -543,6 +543,7 @@ Block* VOlapScanNode::_alloc_block(bool& get_free_block) {
     get_free_block = false;
 
     auto block = new Block(_tuple_desc->slots(), _block_size);
+    _mem_tracker->Consume(block->allocated_bytes());
     _buffered_bytes += block->allocated_bytes();
     return block;
 }


### PR DESCRIPTION
I can not find a good place to release track for bitmap and hll.

# Proposed changes

Issue Number: close #xxx

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
