### PR TITLE
[fixbug][catalog] catalog could not load from image

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/alter/AlterJobV2.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/AlterJobV2.java
@@ -58,7 +58,9 @@ public abstract class AlterJobV2 implements Writable {
     }
 
     public enum JobType {
-        ROLLUP, SCHEMA_CHANGE
+        // Must not remove it or change the order, because catalog depend on it to traverse the image
+        // and load meta data
+        ROLLUP, SCHEMA_CHANGE, DECOMMISSION_BACKEND
     }
 
     @SerializedName(value = "type")

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Catalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Catalog.java
@@ -2113,6 +2113,9 @@ public class Catalog {
             alterJobsV2 = this.getMaterializedViewHandler().getAlterJobsV2();
         } else if (type == JobType.SCHEMA_CHANGE) {
             alterJobsV2 = this.getSchemaChangeHandler().getAlterJobsV2();
+        } else if (type == JobType.DECOMMISSION_BACKEND) {
+            // Load alter job need decommission backend type to load image
+            alterJobsV2 = Maps.newHashMap();
         } else {
             throw new IOException("Invalid alter job type: " + type.name());
         }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

This bug is introduced by https://github.com/apache/incubator-doris/pull/9329

## Problem Summary:

2022-05-04 20:16:35,797 INFO (main|1) [SessionVariable.readFromJson():1038] failed to read session variable
java.lang.NullPointerException: null
        at org.apache.doris.qe.SessionVariable.readFromJson(SessionVariable.java:1007) ~[palo-fe.jar:1.0-SNAPSHOT]
        at org.apache.doris.qe.SessionVariable.readFields(SessionVariable.java:994) ~[palo-fe.jar:1.0-SNAPSHOT]
        at org.apache.doris.qe.VariableMgr.read(VariableMgr.java:312) ~[palo-fe.jar:1.0-SNAPSHOT]
        at org.apache.doris.catalog.Catalog.loadGlobalVariable(Catalog.java:1904) ~[palo-fe.jar:1.0-SNAPSHOT]
        at org.apache.doris.common.MetaReader.read(MetaReader.java:89) ~[palo-fe.jar:1.0-SNAPSHOT]
        at org.apache.doris.catalog.Catalog.loadImage(Catalog.java:1620) ~[palo-fe.jar:1.0-SNAPSHOT]
        at org.apache.doris.catalog.Catalog.initialize(Catalog.java:850) ~[palo-fe.jar:1.0-SNAPSHOT]
        at org.apache.doris.PaloFe.start(PaloFe.java:129) ~[palo-fe.jar:1.0-SNAPSHOT]
        at org.apache.doris.PaloFe.main(PaloFe.java:64) ~[palo-fe.jar:1.0-SNAPSHOT]

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
