### PR TITLE
[fix]Compile UI error under Node.js 17 version, compatible with nodejs 17

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -310,6 +310,10 @@ function build_ui() {
         echo "Error: npm is not found"
         exit 1
     fi
+    NODE_VERSION=`bash -c "node --version" | sed 's/^v//'`
+    if [ $NODE_VERSION>16 ] ; then
+        export NODE_OPTIONS=--openssl-legacy-provider
+    fi    
     if [[ ! -z ${CUSTOM_NPM_REGISTRY} ]]; then
         ${NPM} config set registry ${CUSTOM_NPM_REGISTRY}
         npm_reg=`${NPM} get registry`


### PR DESCRIPTION

The recently released OpenSSL3.0 in Node.js 17 version, and OpenSSL3.0 has added strict restrictions on the allowable algorithm and key size, which may have some impact on the ecosystem. When compiling the UI, you need to add the environment variable to the A variable to drop OpenSSL back to the old strategy:
export NODE_OPTIONS=--openssl-legacy-provider

# Proposed changes

Issue Number: close #xxx

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
