### PR TITLE
[chore](FE Code Style) Fix wrong checkstyle action configuration

### DIFF
--- a/.github/workflows/checkstyle.yaml
+++ b/.github/workflows/checkstyle.yaml
@@ -35,7 +35,8 @@ jobs:
           checkstyle_config: fe/check/checkstyle/checkstyle.xml
           checkstyle_version: 9.3
           workdir: "./fe"
-          reporter: 'github-pr-review'
+          reporter: 'github-pr-check'
           github_token: ${{ secrets.GITHUB_TOKEN }}
           fail_on_error: true
+          level: error
 


### PR DESCRIPTION
## Problem Summary:

I submit a pull request https://github.com/apache/incubator-doris/pull/9366, but it build failed.
I checked the fail output[1], found that we should use `github-pr-check`.

https://github.com/apache/incubator-doris/runs/6300286759?check_suite_focus=true


1. `github-pr-check` or `github-pr-review`
github-pr-review reporter reports results to GitHub PullRequest review comments, and check the output.
github-pr-check report check the info from the output.

2. `fail_on_error`
This feature only works when level is set to error.

3. references
[1] https://github.com/reviewdog/reviewdog
[2] https://github.com/nikitasavinov/checkstyle-action


## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
5. Does it need to update dependencies: (Yes/No)
6. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
