### PR TITLE
[fix]arrow_work_flow_test UT mem leak fix

### DIFF
--- a/be/test/util/arrow/arrow_work_flow_test.cpp
+++ b/be/test/util/arrow/arrow_work_flow_test.cpp
@@ -65,6 +65,12 @@ protected:
         EXPECT_EQ(system("rm -rf ./test_run"), 0);
 
         delete _state;
+
+        if (_exec_env) {
+            delete _exec_env->_result_queue_mgr;
+            delete _exec_env->_thread_mgr;
+            delete _exec_env->_buffer_reservation;
+        }
     }
 
     void init();


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

dynamic allocated memory inside _exec_env, do not release after test case finished:
    _exec_env->_result_queue_mgr = new ResultQueueMgr();
    _exec_env->_thread_mgr = new ThreadResourceMgr();
    _exec_env->_buffer_reservation = new ReservationTracker();

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
