### PR TITLE
[refactor][file result sink]remove file result writer from result sink

### DIFF
--- a/be/src/runtime/file_result_writer.cpp
+++ b/be/src/runtime/file_result_writer.cpp
@@ -44,28 +44,6 @@ namespace doris {
 
 const size_t FileResultWriter::OUTSTREAM_BUFFER_SIZE_BYTES = 1024 * 1024;
 
-// deprecated
-FileResultWriter::FileResultWriter(const ResultFileOptions* file_opts,
-                                   const std::vector<ExprContext*>& output_expr_ctxs,
-                                   RuntimeProfile* parent_profile, BufferControlBlock* sinker,
-                                   bool output_object_data)
-        : _file_opts(file_opts),
-          _output_expr_ctxs(output_expr_ctxs),
-          _parent_profile(parent_profile),
-          _sinker(sinker) {
-    if (_file_opts->is_local_file) {
-        _storage_type = TStorageBackendType::LOCAL;
-    } else {
-        _storage_type = TStorageBackendType::BROKER;
-    }
-    // The new file writer needs to use fragment instance id as part of the file prefix.
-    // But during the upgrade process, the old version of fe will be called to the new version of be,
-    // resulting in no such attribute. So we need a mock here.
-    _fragment_instance_id.hi = 12345678987654321;
-    _fragment_instance_id.lo = 98765432123456789;
-    _output_object_data = output_object_data;
-}
-
 FileResultWriter::FileResultWriter(const ResultFileOptions* file_opts,
                                    const TStorageBackendType::type storage_type,
                                    const TUniqueId fragment_instance_id,

--- a/be/src/runtime/file_result_writer.h
+++ b/be/src/runtime/file_result_writer.h
@@ -77,11 +77,6 @@ class BufferControlBlock;
 // write result to file
 class FileResultWriter final : public ResultWriter {
 public:
-    // [[deprecated]]
-    FileResultWriter(const ResultFileOptions* file_option,
-                     const std::vector<ExprContext*>& output_expr_ctxs,
-                     RuntimeProfile* parent_profile, BufferControlBlock* sinker,
-                     bool output_object_data);
     FileResultWriter(const ResultFileOptions* file_option,
                      const TStorageBackendType::type storage_type,
                      const TUniqueId fragment_instance_id,

--- a/be/src/runtime/result_sink.cpp
+++ b/be/src/runtime/result_sink.cpp
@@ -43,11 +43,6 @@ ResultSink::ResultSink(const RowDescriptor& row_desc, const std::vector<TExpr>& 
         _sink_type = sink.type;
     }
 
-    if (_sink_type == TResultSinkType::FILE) {
-        CHECK(sink.__isset.file_options);
-        _file_opts.reset(new ResultFileOptions(sink.file_options));
-    }
-
     _name = "ResultSink";
 }
 
@@ -80,13 +75,6 @@ Status ResultSink::prepare(RuntimeState* state) {
     case TResultSinkType::MYSQL_PROTOCAL:
         _writer.reset(new (std::nothrow) MysqlResultWriter(
                 _sender.get(), _output_expr_ctxs, _profile, state->return_object_data_as_binary()));
-        break;
-    // deprecated
-    case TResultSinkType::FILE:
-        CHECK(_file_opts.get() != nullptr);
-        _writer.reset(new (std::nothrow) FileResultWriter(_file_opts.get(), _output_expr_ctxs,
-                                                          _profile, _sender.get(),
-                                                          state->return_object_data_as_binary()));
         break;
     default:
         return Status::InternalError("Unknown result sink type");

--- a/be/src/runtime/result_sink.h
+++ b/be/src/runtime/result_sink.h
@@ -59,8 +59,6 @@ public:
 private:
     Status prepare_exprs(RuntimeState* state);
     TResultSinkType::type _sink_type;
-    // set file options when sink type is FILE
-    std::unique_ptr<ResultFileOptions> _file_opts;
 
     // Owned by the RuntimeState.
     const RowDescriptor& _row_desc;

--- a/be/src/vec/sink/result_sink.cpp
+++ b/be/src/vec/sink/result_sink.cpp
@@ -37,11 +37,6 @@ VResultSink::VResultSink(const RowDescriptor& row_desc, const std::vector<TExpr>
         _sink_type = sink.type;
     }
 
-    if (_sink_type == TResultSinkType::FILE) {
-        CHECK(sink.__isset.file_options);
-        _file_opts.reset(new ResultFileOptions(sink.file_options));
-    }
-
     _name = "ResultSink";
 }
 
@@ -75,13 +70,6 @@ Status VResultSink::prepare(RuntimeState* state) {
         _writer.reset(new (std::nothrow)
                               VMysqlResultWriter(_sender.get(), _output_vexpr_ctxs, _profile));
         break;
-    case TResultSinkType::FILE:
-        CHECK(_file_opts.get() != nullptr);
-        return Status::InternalError("Unsupport vfile result sink type");
-        // TODO:
-        /*      _writer.reset(new (std::nothrow) FileResultWriter(_file_opts.get(), _output_expr_ctxs,*/
-        /*_profile, _sender.get()));*/
-        //        break;
     default:
         return Status::InternalError("Unknown result sink type");
     }

--- a/gensrc/thrift/DataSinks.thrift
+++ b/gensrc/thrift/DataSinks.thrift
@@ -38,7 +38,7 @@ enum TDataSinkType {
 
 enum TResultSinkType {
     MYSQL_PROTOCAL,
-    FILE
+    FILE,    // deprecated, should not be used any more. FileResultSink is covered by TRESULT_FILE_SINK for concurrent purpose.
 }
 
 struct TResultFileSinkOptions {
@@ -75,7 +75,7 @@ struct TDataStreamSink {
 
 struct TResultSink {
     1: optional TResultSinkType type;
-    2: optional TResultFileSinkOptions file_options
+    2: optional TResultFileSinkOptions file_options // deprecated
 }
 
 struct TResultFileSink {


### PR DESCRIPTION
# Proposed changes

TResultSink not support file result any more. And it is already remove in FE in 0.15 https://github.com/apache/incubator-doris/blob/branch-0.15/fe/fe-core/src/main/java/org/apache/doris/planner/ResultSink.java.

I remove related code in BE in this PR.

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
