### PR TITLE
[fix][compaction] Rowset::end_version null pointer

### DIFF
--- a/be/src/olap/compaction.cpp
+++ b/be/src/olap/compaction.cpp
@@ -136,7 +136,12 @@ Status Compaction::do_compaction_impl(int64_t permits) {
     int64_t current_max_version;
     {
         std::shared_lock rdlock(_tablet->get_header_lock());
-        current_max_version = _tablet->rowset_with_max_version()->end_version();
+        RowsetSharedPtr max_rowset = _tablet->rowset_with_max_version();
+        if (max_rowset == nullptr) {
+            current_max_version = -1;
+        } else {
+            current_max_version = _tablet->rowset_with_max_version()->end_version();
+        }
     }
 
     LOG(INFO) << "succeed to do " << merge_type << compaction_name()


### PR DESCRIPTION
# Proposed changes

Issue Number: close #9371

## Problem Summary:

After compaction, get tablet max version rowset returns null.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
