### PR TITLE
[refactor](test) Refactor FE unit test framework that starts a FE server.

### DIFF
--- a/fe/fe-common/pom.xml
+++ b/fe/fe-common/pom.xml
@@ -79,10 +79,18 @@ under the License.
             <artifactId>jmockit</artifactId>
             <scope>test</scope>
         </dependency>
-        <!-- https://mvnrepository.com/artifact/junit/junit -->
+        <!-- https://mvnrepository.com/artifact/org.junit.jupiter/junit-jupiter-engine -->
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/org.junit.vintage/junit-vintage-engine -->
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -219,11 +219,25 @@ under the License.
         <dependency>
             <groupId>com.googlecode.json-simple</groupId>
             <artifactId>json-simple</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>junit</groupId>
+                    <artifactId>junit</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
-        <!-- https://mvnrepository.com/artifact/junit/junit -->
+        <!-- https://mvnrepository.com/artifact/org.junit.jupiter/junit-jupiter-engine -->
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/org.junit.vintage/junit-vintage-engine -->
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-api -->

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/AdminSetConfigStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/AdminSetConfigStmtTest.java
@@ -20,54 +20,37 @@ package org.apache.doris.analysis;
 import org.apache.doris.catalog.Catalog;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.DdlException;
-import org.apache.doris.qe.ConnectContext;
-import org.apache.doris.utframe.UtFrameUtils;
+import org.apache.doris.utframe.TestWithFeService;
 
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
-import java.util.UUID;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class AdminSetConfigStmtTest {
-    private static String runningDir = "fe/mocked/AdminSetConfigStmtTest/" + UUID.randomUUID().toString() + "/";
-
-    private static ConnectContext connectContext;
-
-    @Rule
-    public ExpectedException expectedEx = ExpectedException.none();
-
-    @BeforeClass
-    public static void beforeClass() throws Exception {
-        UtFrameUtils.createDorisCluster(runningDir);
-
-        // create connect context
-        connectContext = UtFrameUtils.createDefaultCtx();
-    }
-
+public class AdminSetConfigStmtTest extends TestWithFeService {
     @Test
     public void testNormal() throws Exception {
         String stmt = "admin set frontend config(\"alter_table_timeout_second\" = \"60\");";
-        AdminSetConfigStmt adminSetConfigStmt = (AdminSetConfigStmt) UtFrameUtils.parseAndAnalyzeStmt(stmt, connectContext);
+        AdminSetConfigStmt adminSetConfigStmt = (AdminSetConfigStmt) parseAndAnalyzeStmt(stmt);
         Catalog.getCurrentCatalog().setConfig(adminSetConfigStmt);
     }
 
     @Test
     public void testUnknownConfig() throws Exception {
         String stmt = "admin set frontend config(\"unknown_config\" = \"unknown\");";
-        AdminSetConfigStmt adminSetConfigStmt = (AdminSetConfigStmt) UtFrameUtils.parseAndAnalyzeStmt(stmt, connectContext);
-        expectedEx.expect(DdlException.class);
-        expectedEx.expectMessage("errCode = 2, detailMessage = Config 'unknown_config' does not exist");
-        Catalog.getCurrentCatalog().setConfig(adminSetConfigStmt);
+        AdminSetConfigStmt adminSetConfigStmt = (AdminSetConfigStmt) parseAndAnalyzeStmt(stmt);
+        DdlException exception = assertThrows(DdlException.class,
+            () -> Catalog.getCurrentCatalog().setConfig(adminSetConfigStmt));
+        assertEquals("errCode = 2, detailMessage = Config 'unknown_config' does not exist",
+            exception.getMessage());
     }
 
     @Test
-    public void testEmptyConfig() throws Exception {
-        String stmt = "admin set frontend config;";
-        expectedEx.expect(AnalysisException.class);
-        expectedEx.expectMessage("errCode = 2, detailMessage = config parameter size is not equal to 1");
-        AdminSetConfigStmt adminSetConfigStmt = (AdminSetConfigStmt) UtFrameUtils.parseAndAnalyzeStmt(stmt, connectContext);
+    public void testEmptyConfig() {
+        AnalysisException exception =
+            assertThrows(AnalysisException.class,
+                () -> parseAndAnalyzeStmt("admin set frontend config;"));
+        assertEquals("errCode = 2, detailMessage = config parameter size is not equal to 1",
+            exception.getMessage());
     }
 }
-

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/AggregateTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/AggregateTest.java
@@ -21,34 +21,26 @@ import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.FeConstants;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.utframe.DorisAssert;
+import org.apache.doris.utframe.TestWithFeService;
 import org.apache.doris.utframe.UtFrameUtils;
 
-import org.junit.AfterClass;
 import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import java.util.UUID;
-
-public class AggregateTest {
-
-    private static String baseDir = "fe";
-    private static String runningDir = baseDir + "/mocked/AggregateTest/"
-            + UUID.randomUUID().toString() + "/";
+public class AggregateTest extends TestWithFeService {
     private static final String TABLE_NAME = "table1";
     private static final String DB_NAME = "db1";
     private static DorisAssert dorisAssert;
 
-    @BeforeClass
-    public static void beforeClass() throws Exception{
+    @Override
+    protected void runBeforeAll() throws Exception {
         FeConstants.runningUnitTest = true;
-        UtFrameUtils.createDorisCluster(runningDir);
         dorisAssert = new DorisAssert();
         dorisAssert.withDatabase(DB_NAME).useDatabase(DB_NAME);
         String createTableSQL = "create table " + DB_NAME + "." + TABLE_NAME + " (empid int, name varchar, " +
-                "deptno int, salary int, commission int, time DATETIME) "
-                + "distributed by hash(empid) buckets 3 properties('replication_num' = '1');";
-        dorisAssert.withTable(createTableSQL);
+                                    "deptno int, salary int, commission int, time DATETIME) "
+                                    + "distributed by hash(empid) buckets 3 properties('replication_num' = '1');";
+        createTable(createTableSQL);
     }
 
     /**
@@ -180,10 +172,5 @@ public class AggregateTest {
             }
             Assert.fail("must be AnalysisException.");
         } while(false);
-    }
-
-    @AfterClass
-    public static void afterClass() throws Exception {
-        UtFrameUtils.cleanDorisFeDir(baseDir);
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/ListPartitionPrunerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/ListPartitionPrunerTest.java
@@ -17,29 +17,16 @@
 
 package org.apache.doris.analysis;
 
-import org.apache.doris.catalog.Catalog;
+import org.junit.jupiter.api.Test;
+
 import org.apache.doris.common.FeConstants;
-import org.apache.doris.utframe.UtFrameUtils;
-
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
-
-import java.util.UUID;
 
 public class ListPartitionPrunerTest extends PartitionPruneTestBase {
 
-    @BeforeClass
-    public static void beforeClass() throws Exception {
+    @Override
+    protected void runBeforeAll() throws Exception {
         FeConstants.runningUnitTest = true;
-        runningDir = "fe/mocked/ListPartitionPrunerTest/" + UUID.randomUUID().toString() + "/";
-        UtFrameUtils.createDorisCluster(runningDir);
-
-        connectContext = UtFrameUtils.createDefaultCtx();
-
-        String createDbStmtStr = "create database test;";
-        CreateDbStmt createDbStmt = (CreateDbStmt) UtFrameUtils.parseAndAnalyzeStmt(createDbStmtStr, connectContext);
-        Catalog.getCurrentCatalog().createDb(createDbStmt);
+        createDatabase("test");
 
         String createSinglePartColWithSinglePartKey =
             "create table test.t1\n"
@@ -84,15 +71,10 @@ public class ListPartitionPrunerTest extends PartitionPruneTestBase {
                 + "distributed by hash(k2) buckets 1\n"
                 + "properties('replication_num' = '1');";
 
-        createTable(createSinglePartColWithSinglePartKey);
-        createTable(createSinglePartColWithMultiPartKey);
-        createTable(createMultiPartColWithSinglePartKey);
-        createTable(createMultiPartColWithMultiPartKey);
-    }
-
-    @AfterClass
-    public static void tearDown() throws Exception {
-        UtFrameUtils.cleanDorisFeDir(runningDir);
+        createTables(createSinglePartColWithSinglePartKey,
+            createSinglePartColWithMultiPartKey,
+            createMultiPartColWithSinglePartKey,
+            createMultiPartColWithMultiPartKey);
     }
 
     private void initTestCases() {

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/ListPartitionPrunerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/ListPartitionPrunerTest.java
@@ -17,9 +17,9 @@
 
 package org.apache.doris.analysis;
 
-import org.junit.jupiter.api.Test;
-
 import org.apache.doris.common.FeConstants;
+
+import org.junit.jupiter.api.Test;
 
 public class ListPartitionPrunerTest extends PartitionPruneTestBase {
 

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/PartitionPruneTestBase.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/PartitionPruneTestBase.java
@@ -17,19 +17,14 @@
 
 package org.apache.doris.analysis;
 
-import org.apache.doris.catalog.Catalog;
-import org.apache.doris.qe.ConnectContext;
-import org.apache.doris.utframe.UtFrameUtils;
+import org.apache.doris.utframe.TestWithFeService;
 
 import org.junit.Assert;
 
 import java.util.ArrayList;
 import java.util.List;
 
-public class PartitionPruneTestBase {
-    protected static String runningDir;
-    protected static ConnectContext connectContext;
-
+public abstract class PartitionPruneTestBase extends TestWithFeService {
     protected List<TestCase> cases = new ArrayList<>();
 
     protected void doTest() throws Exception {
@@ -41,16 +36,10 @@ public class PartitionPruneTestBase {
         }
     }
 
-    protected static void createTable(String sql) throws Exception {
-        CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameUtils.parseAndAnalyzeStmt(sql, connectContext);
-        Catalog.getCurrentCatalog().createTable(createTableStmt);
-    }
-
     private void assertExplainContains(int version, String sql, String subString) throws Exception {
         Assert.assertTrue(String.format("version=%d, sql=%s, expectResult=%s",
-            version, sql, subString),
-            UtFrameUtils.getSQLPlanOrErrorMsg(connectContext, "explain " + sql)
-                .contains(subString));
+                version, sql, subString),
+            getSQLPlanOrErrorMsg("explain " + sql).contains(subString));
     }
 
     protected void addCase(String sql, String v1Result, String v2Result) {

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/RangePartitionPruneTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/RangePartitionPruneTest.java
@@ -17,9 +17,9 @@
 
 package org.apache.doris.analysis;
 
-import org.junit.jupiter.api.Test;
-
 import org.apache.doris.common.FeConstants;
+
+import org.junit.jupiter.api.Test;
 
 public class RangePartitionPruneTest extends PartitionPruneTestBase {
 

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/RangePartitionPruneTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/RangePartitionPruneTest.java
@@ -17,7 +17,7 @@
 
 package org.apache.doris.analysis;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.apache.doris.common.FeConstants;
 

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/RangePartitionPruneTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/RangePartitionPruneTest.java
@@ -17,29 +17,16 @@
 
 package org.apache.doris.analysis;
 
-import org.apache.doris.catalog.Catalog;
-import org.apache.doris.common.FeConstants;
-import org.apache.doris.utframe.UtFrameUtils;
-
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
-import java.util.UUID;
+import org.apache.doris.common.FeConstants;
 
 public class RangePartitionPruneTest extends PartitionPruneTestBase {
 
-    @BeforeClass
-    public static void beforeClass() throws Exception {
+    @Override
+    protected void runBeforeAll() throws Exception {
         FeConstants.runningUnitTest = true;
-        runningDir = "fe/mocked/RangePartitionPruneTest/" + UUID.randomUUID().toString() + "/";
-        UtFrameUtils.createDorisCluster(runningDir);
-
-        connectContext = UtFrameUtils.createDefaultCtx();
-
-        String createDbStmtStr = "create database test;";
-        CreateDbStmt createDbStmt = (CreateDbStmt) UtFrameUtils.parseAndAnalyzeStmt(createDbStmtStr, connectContext);
-        Catalog.getCurrentCatalog().createDb(createDbStmt);
+        createDatabase("test");
 
         String singleColumnPartitionTable =
             "CREATE TABLE `test`.`t1` (\n" +
@@ -117,15 +104,10 @@ public class RangePartitionPruneTest extends PartitionPruneTestBase {
                 "DISTRIBUTED BY HASH(`k1`) BUCKETS 10\n" +
                 "PROPERTIES ('replication_num' = '1');";
 
-        createTable(singleColumnPartitionTable);
-        createTable(notNullSingleColumnPartitionTable);
-        createTable(multipleColumnsPartitionTable);
-        createTable(notNullMultipleColumnsPartitionTable);
-    }
-
-    @AfterClass
-    public static void tearDown() throws Exception {
-        UtFrameUtils.cleanDorisFeDir(runningDir);
+        createTables(singleColumnPartitionTable,
+            notNullSingleColumnPartitionTable,
+            multipleColumnsPartitionTable,
+            notNullMultipleColumnsPartitionTable);
     }
 
     private void initTestCases() {

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/AdminStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/AdminStmtTest.java
@@ -18,22 +18,17 @@
 package org.apache.doris.catalog;
 
 import org.apache.doris.analysis.AdminSetReplicaStatusStmt;
-import org.apache.doris.analysis.CreateDbStmt;
-import org.apache.doris.analysis.CreateTableStmt;
 import org.apache.doris.catalog.MaterializedIndex.IndexExtState;
 import org.apache.doris.catalog.Replica.ReplicaStatus;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.Pair;
 import org.apache.doris.persist.SetReplicaStatusOperationLog;
-import org.apache.doris.qe.ConnectContext;
-import org.apache.doris.utframe.UtFrameUtils;
+import org.apache.doris.utframe.TestWithFeService;
 
 import com.google.common.collect.Lists;
 
-import org.junit.AfterClass;
 import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
@@ -42,44 +37,20 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.List;
-import java.util.UUID;
 
-public class AdminStmtTest {
-
-    // use a unique dir so that it won't be conflict with other unit test which
-    // may also start a Mocked Frontend
-    private static String runningDir = "fe/mocked/AdminStmtTest/" + UUID.randomUUID().toString() + "/";
-
-    private static ConnectContext connectContext;
-
-    @BeforeClass
-    public static void beforeClass() throws Exception {
-        UtFrameUtils.createDorisCluster(runningDir);
-
-        // create connect context
-        connectContext = UtFrameUtils.createDefaultCtx();
-        // create database
-        String createDbStmtStr = "create database test;";
-        CreateDbStmt createDbStmt = (CreateDbStmt) UtFrameUtils.parseAndAnalyzeStmt(createDbStmtStr, connectContext);
-        Catalog.getCurrentCatalog().createDb(createDbStmt);
-        
-        String sql = "CREATE TABLE test.tbl1 (\n" +
-                "  `id` int(11) NULL COMMENT \"\",\n" +
-                "  `id2` bitmap bitmap_union NULL\n" +
-                ") ENGINE=OLAP\n" +
-                "AGGREGATE KEY(`id`)\n" +
-                "DISTRIBUTED BY HASH(`id`) BUCKETS 3\n" +
-                "PROPERTIES (\n" +
-                " \"replication_num\" = \"1\"\n" +
-                ");";
-        CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameUtils.parseAndAnalyzeStmt(sql, connectContext);
-        Catalog.getCurrentCatalog().createTable(createTableStmt);
-    }
-
-    @AfterClass
-    public static void tearDown() {
-        File file = new File(runningDir);
-        file.delete();
+public class AdminStmtTest extends TestWithFeService {
+    @Override
+    protected void runBeforeAll() throws Exception {
+        createDatabase("test");
+        createTable( "CREATE TABLE test.tbl1 (\n" +
+                         "  `id` int(11) NULL COMMENT \"\",\n" +
+                         "  `id2` bitmap bitmap_union NULL\n" +
+                         ") ENGINE=OLAP\n" +
+                         "AGGREGATE KEY(`id`)\n" +
+                         "DISTRIBUTED BY HASH(`id`) BUCKETS 3\n" +
+                         "PROPERTIES (\n" +
+                         " \"replication_num\" = \"1\"\n" +
+                         ");");
     }
 
     @Test
@@ -108,7 +79,7 @@ public class AdminStmtTest {
         // set replica to bad
         String adminStmt = "admin set replica status properties ('tablet_id' = '" + tabletId + "', 'backend_id' = '"
                 + backendId + "', 'status' = 'bad');";
-        AdminSetReplicaStatusStmt stmt = (AdminSetReplicaStatusStmt) UtFrameUtils.parseAndAnalyzeStmt(adminStmt, connectContext);
+        AdminSetReplicaStatusStmt stmt = (AdminSetReplicaStatusStmt) parseAndAnalyzeStmt(adminStmt);
         Catalog.getCurrentCatalog().setReplicaStatus(stmt);
         replica = Catalog.getCurrentInvertedIndex().getReplica(tabletId, backendId);
         Assert.assertTrue(replica.isBad());
@@ -116,7 +87,7 @@ public class AdminStmtTest {
         // set replica to ok
         adminStmt = "admin set replica status properties ('tablet_id' = '" + tabletId + "', 'backend_id' = '"
                 + backendId + "', 'status' = 'ok');";
-        stmt = (AdminSetReplicaStatusStmt) UtFrameUtils.parseAndAnalyzeStmt(adminStmt, connectContext);
+        stmt = (AdminSetReplicaStatusStmt) parseAndAnalyzeStmt(adminStmt);
         Catalog.getCurrentCatalog().setReplicaStatus(stmt);
         replica = Catalog.getCurrentInvertedIndex().getReplica(tabletId, backendId);
         Assert.assertFalse(replica.isBad());

--- a/fe/fe-core/src/test/java/org/apache/doris/planner/PlannerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/planner/PlannerTest.java
@@ -31,6 +31,7 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class PlannerTest extends TestWithFeService {
 
@@ -432,11 +433,11 @@ public class PlannerTest extends TestWithFeService {
     }
 
     @Test
-    public void testStringType() throws Exception {
+    public void testStringType() {
         String createTbl1 = "create table db1.tbl1(k1 string, k2 varchar(32), k3 varchar(32), k4 int) "
                 + "AGGREGATE KEY(k1, k2,k3,k4) distributed by hash(k1) buckets 3 properties('replication_num' = '1')";
         AnalysisException exception =
             assertThrows(AnalysisException.class, () -> parseAndAnalyzeStmt(createTbl1));
-        assertEquals("String Type should not be used in key column[k1].", exception.getMessage());
+        assertTrue(exception.getMessage().contains("String Type should not be used in key column[k1]."));
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/planner/PlannerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/planner/PlannerTest.java
@@ -29,7 +29,6 @@ import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 

--- a/fe/fe-core/src/test/java/org/apache/doris/planner/QueryPlanTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/planner/QueryPlanTest.java
@@ -425,23 +425,23 @@ public class QueryPlanTest extends TestWithFeService {
     @Test
     public void testBitmapInsertInto() throws Exception {
         assertSQLPlanOrErrorMsgContains(
-            "explain INSERT INTO test.bitmap_table (id, id2) VALUES (1001, to_bitmap(1000)), (1001, to_bitmap(2000));",
+            "INSERT INTO test.bitmap_table (id, id2) VALUES (1001, to_bitmap(1000)), (1001, to_bitmap(2000));",
             "OLAP TABLE SINK");
 
         assertSQLPlanOrErrorMsgContains(
-            "explain insert into test.bitmap_table select id, bitmap_union(id2) from test.bitmap_table_2 group by id;",
+            "insert into test.bitmap_table select id, bitmap_union(id2) from test.bitmap_table_2 group by id;",
             "OLAP TABLE SINK",
             "bitmap_union",
             "1:AGGREGATE",
             "0:OlapScanNode");
 
         assertSQLPlanOrErrorMsgContains(
-            "explain insert into test.bitmap_table select id, id2 from test.bitmap_table_2;",
+            "insert into test.bitmap_table select id, id2 from test.bitmap_table_2;",
             "OLAP TABLE SINK",
             "OUTPUT EXPRS:`id` | `id2`",
             "0:OlapScanNode");
 
-        assertSQLPlanOrErrorMsgContains("explain insert into test.bitmap_table select id, id from test.bitmap_table_2;",
+        assertSQLPlanOrErrorMsgContains("insert into test.bitmap_table select id, id from test.bitmap_table_2;",
             "bitmap column require the function return type is BITMAP");
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/utframe/DorisAssert.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/utframe/DorisAssert.java
@@ -50,6 +50,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 
+/**
+ * This class is deprecated.
+ * If you want to start a FE server in unit test, please let your
+ * test class extend {@link TestWithFeService}.
+ */
+@Deprecated
 public class DorisAssert {
 
     private ConnectContext ctx;

--- a/fe/fe-core/src/test/java/org/apache/doris/utframe/TestWithFeService.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/utframe/TestWithFeService.java
@@ -368,6 +368,8 @@ public abstract class TestWithFeService {
     }
 
     protected void assertSQLPlanOrErrorMsgContains(String sql, String expect) throws Exception {
+        // Note: adding `EXPLAIN` is necessary for non-query SQL, e.g., DDL, DML, etc.
+        // TODO: Use a graceful way to get explain plan string, rather than modifying the SQL string.
         Assertions.assertTrue(getSQLPlanOrErrorMsg("EXPLAIN " + sql).contains(expect));
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/utframe/TestWithFeService.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/utframe/TestWithFeService.java
@@ -368,13 +368,13 @@ public abstract class TestWithFeService {
     }
 
     protected void assertSQLPlanOrErrorMsgContains(String sql, String expect) throws Exception {
-        Assertions.assertTrue(getSQLPlanOrErrorMsg("EXPLAIN " + sql).contains(expect));
+        Assertions.assertTrue(getSQLPlanOrErrorMsg(sql).contains(expect));
     }
 
     protected void assertSQLPlanOrErrorMsgContains(String sql, String... expects) throws Exception {
-        String str = getSQLPlanOrErrorMsg("EXPLAIN " + sql);
+        String str = getSQLPlanOrErrorMsg(sql);
         for (String expect : expects) {
-            Assertions.assertTrue(getSQLPlanOrErrorMsg("EXPLAIN " + sql).contains(expect));
+            Assertions.assertTrue(str.contains(expect));
         }
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/utframe/TestWithFeService.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/utframe/TestWithFeService.java
@@ -72,14 +72,14 @@ import org.junit.jupiter.api.TestInstance;
 
 /**
  * This is the base class for unit class that wants to start a FE service.
- *
+ * <p>
  * Concrete test class must be derived class of {@link TestWithFeService}, {@link DemoTest} is
  * an example.
- *
+ * <p>
  * This class use {@link TestInstance} in JUnit5 to do initialization and cleanup stuff. Unlike
  * deprecated legacy combination-based implementation {@link UtFrameUtils}, we use an inherit-manner,
  * thus we could wrap common logic in this base class. It's more easy to use.
- *
+ * <p>
  * Note:
  * Unit-test method in derived classes must use the JUnit5 {@link org.junit.jupiter.api.Test}
  * annotation, rather than the old JUnit4 {@link org.junit.Test} or others.
@@ -363,16 +363,16 @@ public abstract class TestWithFeService {
     }
 
     protected void createView(String sql) throws Exception {
-        CreateViewStmt createViewStmt = (CreateViewStmt) UtFrameUtils.parseAndAnalyzeStmt(sql, connectContext);
+        CreateViewStmt createViewStmt = (CreateViewStmt) parseAndAnalyzeStmt(sql);
         Catalog.getCurrentCatalog().createView(createViewStmt);
     }
 
     protected void assertSQLPlanOrErrorMsgContains(String sql, String expect) throws Exception {
-        Assertions.assertTrue(getSQLPlanOrErrorMsg(sql).contains(expect));
+        Assertions.assertTrue(getSQLPlanOrErrorMsg("EXPLAIN " + sql).contains(expect));
     }
 
     protected void assertSQLPlanOrErrorMsgContains(String sql, String... expects) throws Exception {
-        String str = getSQLPlanOrErrorMsg(sql);
+        String str = getSQLPlanOrErrorMsg("EXPLAIN " + sql);
         for (String expect : expects) {
             Assertions.assertTrue(str.contains(expect));
         }

--- a/fe/fe-core/src/test/java/org/apache/doris/utframe/TestWithFeService.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/utframe/TestWithFeService.java
@@ -92,8 +92,6 @@ public abstract class TestWithFeService {
 
     @BeforeAll
     public final void beforeAll() throws Exception {
-        // todo: delete
-        System.out.println("before all");
         connectContext = createDefaultCtx();
         createDorisCluster();
         runBeforeAll();
@@ -101,8 +99,6 @@ public abstract class TestWithFeService {
 
     @AfterAll
     public final void afterAll() throws Exception {
-        // todo: delete
-        System.out.println("after all");
         runAfterAll();
         cleanDorisFeDir(runningDir);
     }

--- a/fe/fe-core/src/test/java/org/apache/doris/utframe/TestWithFeService.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/utframe/TestWithFeService.java
@@ -282,6 +282,7 @@ public abstract class TestWithFeService {
         try {
             FileUtils.deleteDirectory(new File(baseDir));
         } catch (IOException e) {
+            e.printStackTrace();
         }
     }
 
@@ -349,7 +350,6 @@ public abstract class TestWithFeService {
         CreateDbStmt createDbStmt = (CreateDbStmt) parseAndAnalyzeStmt(createDbStmtStr);
         Catalog.getCurrentCatalog().createDb(createDbStmt);
     }
-
 
     protected void createTable(String sql) throws Exception {
         createTables(sql);

--- a/fe/fe-core/src/test/java/org/apache/doris/utframe/TestWithFeService.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/utframe/TestWithFeService.java
@@ -17,7 +17,27 @@
 
 package org.apache.doris.utframe;
 
+import java.io.File;
+import java.io.IOException;
+import java.io.StringReader;
+import java.net.DatagramSocket;
+import java.net.ServerSocket;
+import java.net.SocketException;
+import java.nio.channels.SocketChannel;
+import java.nio.file.Files;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
+import org.apache.commons.io.FileUtils;
+
 import org.apache.doris.analysis.Analyzer;
+import org.apache.doris.analysis.CreateDbStmt;
+import org.apache.doris.analysis.CreateTableStmt;
+import org.apache.doris.analysis.CreateViewStmt;
 import org.apache.doris.analysis.ExplainOptions;
 import org.apache.doris.analysis.SqlParser;
 import org.apache.doris.analysis.SqlScanner;
@@ -45,34 +65,56 @@ import org.apache.doris.utframe.MockedFrontend.EnvVarNotSetException;
 import org.apache.doris.utframe.MockedFrontend.FeStartException;
 import org.apache.doris.utframe.MockedFrontend.NotInitException;
 
-import com.google.common.base.Strings;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Maps;
-
-import org.apache.commons.io.FileUtils;
-
-import java.io.File;
-import java.io.IOException;
-import java.io.StringReader;
-import java.net.DatagramSocket;
-import java.net.ServerSocket;
-import java.net.SocketException;
-import java.nio.channels.SocketChannel;
-import java.nio.file.Files;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInstance;
 
 /**
- * This class is deprecated.
- * If you want to start a FE server in unit test, please let your test
- * class extend {@link TestWithFeService}.
+ * This is the base class for unit class that wants to start a FE service.
+ *
+ * Concrete test class must be derived class of {@link TestWithFeService}, {@link DemoTest} is
+ * an example.
+ *
+ * This class use {@link TestInstance} in JUnit5 to do initialization and cleanup stuff. Unlike
+ * deprecated legacy combination-based implementation {@link UtFrameUtils}, we use an inherit-manner,
+ * thus we could wrap common logic in this base class. It's more easy to use.
+ *
+ * Note:
+ * Unit-test method in derived classes must use the JUnit5 {@link org.junit.jupiter.api.Test}
+ * annotation, rather than the old JUnit4 {@link org.junit.Test} or others.
  */
-@Deprecated
-public class UtFrameUtils {
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public abstract class TestWithFeService {
+    protected String runningDir =
+        "fe/mocked/" + getClass().getSimpleName() + "/" + UUID.randomUUID() + "/";
+    protected ConnectContext connectContext;
+
+    @BeforeAll
+    public final void beforeAll() throws Exception {
+        // todo: delete
+        System.out.println("before all");
+        connectContext = createDefaultCtx();
+        createDorisCluster();
+        runBeforeAll();
+    }
+
+    @AfterAll
+    public final void afterAll() throws Exception {
+        // todo: delete
+        System.out.println("after all");
+        runAfterAll();
+        cleanDorisFeDir(runningDir);
+    }
+
+    protected void runBeforeAll() throws Exception {
+    }
+
+    protected void runAfterAll() throws Exception {
+    }
 
     // Help to create a mocked ConnectContext.
-    public static ConnectContext createDefaultCtx() throws IOException {
+    protected ConnectContext createDefaultCtx() throws IOException {
         SocketChannel channel = SocketChannel.open();
         ConnectContext ctx = new ConnectContext(channel);
         ctx.setCluster(SystemInfoService.DEFAULT_CLUSTER);
@@ -85,12 +127,14 @@ public class UtFrameUtils {
     }
 
     // Parse an origin stmt and analyze it. Return a StatementBase instance.
-    public static StatementBase parseAndAnalyzeStmt(String originStmt, ConnectContext ctx)
-            throws Exception {
+    protected StatementBase parseAndAnalyzeStmt(String originStmt)
+        throws Exception {
         System.out.println("begin to parse stmt: " + originStmt);
-        SqlScanner input = new SqlScanner(new StringReader(originStmt), ctx.getSessionVariable().getSqlMode());
+        SqlScanner input =
+            new SqlScanner(new StringReader(originStmt),
+                connectContext.getSessionVariable().getSqlMode());
         SqlParser parser = new SqlParser(input);
-        Analyzer analyzer = new Analyzer(ctx.getCatalog(), ctx);
+        Analyzer analyzer = new Analyzer(connectContext.getCatalog(), connectContext);
         StatementBase statementBase = null;
         try {
             statementBase = SqlParserUtils.getFirstStmt(parser);
@@ -108,11 +152,11 @@ public class UtFrameUtils {
     }
 
     // for analyzing multi statements
-    public static List<StatementBase> parseAndAnalyzeStmts(String originStmt, ConnectContext ctx) throws Exception {
+    protected List<StatementBase> parseAndAnalyzeStmts(String originStmt) throws Exception {
         System.out.println("begin to parse stmts: " + originStmt);
-        SqlScanner input = new SqlScanner(new StringReader(originStmt), ctx.getSessionVariable().getSqlMode());
+        SqlScanner input = new SqlScanner(new StringReader(originStmt), connectContext.getSessionVariable().getSqlMode());
         SqlParser parser = new SqlParser(input);
-        Analyzer analyzer = new Analyzer(ctx.getCatalog(), ctx);
+        Analyzer analyzer = new Analyzer(connectContext.getCatalog(), connectContext);
         List<StatementBase> statementBases = null;
         try {
             statementBases = SqlParserUtils.getMultiStmts(parser);
@@ -131,16 +175,16 @@ public class UtFrameUtils {
         return statementBases;
     }
 
-    public static String generateRandomFeRunningDir(Class testSuiteClass) {
+    protected String generateRandomFeRunningDir(Class testSuiteClass) {
         return generateRandomFeRunningDir(testSuiteClass.getSimpleName());
     }
 
-    public static String generateRandomFeRunningDir(String testSuiteName) {
+    protected String generateRandomFeRunningDir(String testSuiteName) {
         return "fe" + "/mocked/" + testSuiteName + "/" + UUID.randomUUID().toString() + "/";
     }
 
-    public static int startFEServer(String runningDir) throws EnvVarNotSetException, IOException,
-            FeStartException, NotInitException, DdlException, InterruptedException {
+    protected int startFEServer(String runningDir) throws EnvVarNotSetException, IOException,
+                                                              FeStartException, NotInitException, DdlException, InterruptedException {
         // get DORIS_HOME
         String dorisHome = System.getenv("DORIS_HOME");
         if (Strings.isNullOrEmpty(dorisHome)) {
@@ -172,13 +216,15 @@ public class UtFrameUtils {
         return fe_rpc_port;
     }
 
-    public static void createDorisCluster(String runningDir) throws InterruptedException, NotInitException,
-            IOException, DdlException, EnvVarNotSetException, FeStartException {
+    protected void createDorisCluster()
+        throws InterruptedException, NotInitException, IOException, DdlException,
+                   EnvVarNotSetException, FeStartException {
         createDorisCluster(runningDir, 1);
     }
 
-    public static void createDorisCluster(String runningDir, int backendNum) throws EnvVarNotSetException, IOException,
-            FeStartException, NotInitException, DdlException, InterruptedException {
+    protected void createDorisCluster(String runningDir, int backendNum)
+        throws EnvVarNotSetException, IOException, FeStartException,
+                   NotInitException, DdlException, InterruptedException {
         int fe_rpc_port = startFEServer(runningDir);
         for (int i = 0; i < backendNum; i++) {
             createBackend("127.0.0.1", fe_rpc_port);
@@ -189,8 +235,10 @@ public class UtFrameUtils {
 
     // Create multi backends with different host for unit test.
     // the host of BE will be "127.0.0.1", "127.0.0.2"
-    public static void createDorisClusterWithMultiTag(String runningDir, int backendNum) throws EnvVarNotSetException, IOException,
-            FeStartException, NotInitException, DdlException, InterruptedException {
+    protected void createDorisClusterWithMultiTag(String runningDir,
+                                                  int backendNum)
+        throws EnvVarNotSetException, IOException, FeStartException, NotInitException,
+                   DdlException, InterruptedException {
         // set runningUnitTest to true, so that for ut, the agent task will be send to "127.0.0.1" to make cluster running well.
         FeConstants.runningUnitTest = true;
         int fe_rpc_port = startFEServer(runningDir);
@@ -202,7 +250,8 @@ public class UtFrameUtils {
         Thread.sleep(6000);
     }
 
-    public static void createBackend(String beHost, int fe_rpc_port) throws IOException, InterruptedException {
+    protected void createBackend(String beHost, int fe_rpc_port)
+        throws IOException, InterruptedException {
         int be_heartbeat_port = findValidPort();
         int be_thrift_port = findValidPort();
         int be_brpc_port = findValidPort();
@@ -210,9 +259,9 @@ public class UtFrameUtils {
 
         // start be
         MockedBackend backend = MockedBackendFactory.createBackend(beHost,
-                be_heartbeat_port, be_thrift_port, be_brpc_port, be_http_port,
-                new DefaultHeartbeatServiceImpl(be_thrift_port, be_http_port, be_brpc_port),
-                new DefaultBeThriftServiceImpl(), new DefaultPBackendServiceImpl());
+            be_heartbeat_port, be_thrift_port, be_brpc_port, be_http_port,
+            new DefaultHeartbeatServiceImpl(be_thrift_port, be_http_port, be_brpc_port),
+            new DefaultBeThriftServiceImpl(), new DefaultPBackendServiceImpl());
         backend.setFeAddress(new TNetworkAddress("127.0.0.1", fe_rpc_port));
         backend.start();
 
@@ -233,14 +282,14 @@ public class UtFrameUtils {
         Catalog.getCurrentSystemInfo().addBackend(be);
     }
 
-    public static void cleanDorisFeDir(String baseDir) {
+    protected void cleanDorisFeDir(String baseDir) {
         try {
             FileUtils.deleteDirectory(new File(baseDir));
         } catch (IOException e) {
         }
     }
 
-    public static int findValidPort() {
+    protected int findValidPort() {
         int port = 0;
         while (true) {
             try (ServerSocket socket = new ServerSocket(0)) {
@@ -250,7 +299,7 @@ public class UtFrameUtils {
                     datagramSocket.setReuseAddress(true);
                     break;
                 } catch (SocketException e) {
-                    System.out.println("The port " + port  + " is invalid and try another port.");
+                    System.out.println("The port " + port + " is invalid and try another port.");
                 }
             } catch (IOException e) {
                 throw new IllegalStateException("Could not find a free TCP/IP port to start HTTP Server on");
@@ -259,44 +308,77 @@ public class UtFrameUtils {
         return port;
     }
 
-    public static String getSQLPlanOrErrorMsg(ConnectContext ctx, String queryStr) throws Exception {
-        return getSQLPlanOrErrorMsg(ctx, queryStr, false);
+    protected String getSQLPlanOrErrorMsg(String sql) throws Exception {
+        return getSQLPlanOrErrorMsg(sql, false);
     }
 
-    public static String getSQLPlanOrErrorMsg(ConnectContext ctx, String queryStr, boolean isVerbose) throws Exception {
-        ctx.getState().reset();
-        StmtExecutor stmtExecutor = new StmtExecutor(ctx, queryStr);
-        ctx.setExecutor(stmtExecutor);
+    protected String getSQLPlanOrErrorMsg(String sql, boolean isVerbose) throws Exception {
+        connectContext.getState().reset();
+        StmtExecutor stmtExecutor = new StmtExecutor(connectContext, sql);
+        connectContext.setExecutor(stmtExecutor);
         ConnectContext.get().setExecutor(stmtExecutor);
         stmtExecutor.execute();
-        if (ctx.getState().getStateType() != QueryState.MysqlStateType.ERR) {
+        if (connectContext.getState().getStateType() != QueryState.MysqlStateType.ERR) {
             Planner planner = stmtExecutor.planner();
             return planner.getExplainString(planner.getFragments(), new ExplainOptions(isVerbose, false));
         } else {
-            return ctx.getState().getErrorMessage();
+            return connectContext.getState().getErrorMessage();
         }
     }
 
-    public static Planner getSQLPlanner(ConnectContext ctx, String queryStr) throws Exception {
-        ctx.getState().reset();
-        StmtExecutor stmtExecutor = new StmtExecutor(ctx, queryStr);
+    protected Planner getSQLPlanner(String queryStr) throws Exception {
+        connectContext.getState().reset();
+        StmtExecutor stmtExecutor = new StmtExecutor(connectContext, queryStr);
         stmtExecutor.execute();
-        if (ctx.getState().getStateType() != QueryState.MysqlStateType.ERR) {
+        if (connectContext.getState().getStateType() != QueryState.MysqlStateType.ERR) {
             return stmtExecutor.planner();
         } else {
             return null;
         }
     }
 
-    public static StmtExecutor getSqlStmtExecutor(ConnectContext ctx, String queryStr) throws Exception {
-        ctx.getState().reset();
-        StmtExecutor stmtExecutor = new StmtExecutor(ctx, queryStr);
+    protected StmtExecutor getSqlStmtExecutor(String queryStr) throws Exception {
+        connectContext.getState().reset();
+        StmtExecutor stmtExecutor = new StmtExecutor(connectContext, queryStr);
         stmtExecutor.execute();
-        if (ctx.getState().getStateType() != QueryState.MysqlStateType.ERR) {
+        if (connectContext.getState().getStateType() != QueryState.MysqlStateType.ERR) {
             return stmtExecutor;
         } else {
             return null;
         }
     }
-}
 
+    protected void createDatabase(String db) throws Exception {
+        String createDbStmtStr = "CREATE DATABASE " + db;
+        CreateDbStmt createDbStmt = (CreateDbStmt) parseAndAnalyzeStmt(createDbStmtStr);
+        Catalog.getCurrentCatalog().createDb(createDbStmt);
+    }
+
+
+    protected void createTable(String sql) throws Exception {
+        createTables(sql);
+    }
+
+    protected void createTables(String... sqls) throws Exception {
+        for (String sql : sqls) {
+            CreateTableStmt stmt = (CreateTableStmt) parseAndAnalyzeStmt(sql);
+            Catalog.getCurrentCatalog().createTable(stmt);
+        }
+    }
+
+    protected void createView(String sql) throws Exception {
+        CreateViewStmt createViewStmt = (CreateViewStmt) UtFrameUtils.parseAndAnalyzeStmt(sql, connectContext);
+        Catalog.getCurrentCatalog().createView(createViewStmt);
+    }
+
+    protected void assertSQLPlanOrErrorMsgContains(String sql, String expect) throws Exception {
+        Assertions.assertTrue(getSQLPlanOrErrorMsg("EXPLAIN " + sql).contains(expect));
+    }
+
+    protected void assertSQLPlanOrErrorMsgContains(String sql, String... expects) throws Exception {
+        String str = getSQLPlanOrErrorMsg("EXPLAIN " + sql);
+        for (String expect : expects) {
+            Assertions.assertTrue(getSQLPlanOrErrorMsg("EXPLAIN " + sql).contains(expect));
+        }
+    }
+}

--- a/fe/java-udf/pom.xml
+++ b/fe/java-udf/pom.xml
@@ -56,6 +56,20 @@ under the License.
                 </exclusion>
             </exclusions>
         </dependency>
+        <!-- https://mvnrepository.com/artifact/org.junit.jupiter/junit-jupiter-engine -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/org.junit.vintage/junit-vintage-engine -->
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <finalName>java-udf</finalName>

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -211,7 +211,7 @@ under the License.
         <joda-time.version>2.10.1</joda-time.version>
         <commons-io.version>2.6</commons-io.version>
         <json-simple.version>1.1.1</json-simple.version>
-        <junit.version>4.12</junit.version>
+        <junit.version>5.8.2</junit.version>
         <thrift.version>0.13.0</thrift.version>
         <log4j2.version>2.17.2</log4j2.version>
         <metrics-core.version>4.0.2</metrics-core.version>
@@ -463,10 +463,17 @@ under the License.
                 <artifactId>json-simple</artifactId>
                 <version>${json-simple.version}</version>
             </dependency>
-            <!-- https://mvnrepository.com/artifact/junit/junit -->
+            <!-- https://mvnrepository.com/artifact/org.junit.jupiter/junit-jupiter-engine -->
             <dependency>
-                <groupId>junit</groupId>
-                <artifactId>junit</artifactId>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-engine</artifactId>
+                <version>${junit.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <!-- https://mvnrepository.com/artifact/org.junit.vintage/junit-vintage-engine -->
+            <dependency>
+                <groupId>org.junit.vintage</groupId>
+                <artifactId>junit-vintage-engine</artifactId>
                 <version>${junit.version}</version>
                 <scope>test</scope>
             </dependency>

--- a/fe/spark-dpp/pom.xml
+++ b/fe/spark-dpp/pom.xml
@@ -67,10 +67,18 @@ under the License.
             <artifactId>joda-time</artifactId>
             <scope>provided</scope>
         </dependency>
-        <!-- https://mvnrepository.com/artifact/junit/junit -->
+        <!-- https://mvnrepository.com/artifact/org.junit.jupiter/junit-jupiter-engine -->
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/org.junit.vintage/junit-vintage-engine -->
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

Currently, we use `UtFrameUtils` to start a FE server in the FE unit test.  Each test class has to do some initialization and clean up stuff with the JUnit4 `@BeforeClass` and `@AfterClass` annotation. It's redundant and boring. Besides, almost all the APIs in `UtFrameUtils` has a `ConnectContext` parameter, which is not easy to use.

This PR proposes to use an inherit-manner, i.e., wrap all the common logic in base class `TestWithFeService`, leveraging the 
JUnit5 `@BeforeAll` and `@AfterAll` annotation to narrow down the setup and cleanup lifecycle to each test class instance. At the same time, the derived concrete test class could directly use utility methods inherited from the base class, without calling a util class and passing a `ConnectContext` argument.

`UtFrameUtils` and `DorisAssert`  are marked as deprecated. We could remove these two classes if this refactor works well for a time.

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: no
2. Has unit tests been added: no
3. Has document been added or modified: no
4. Does it need to update dependencies: yes, bump up the JUnit version from 4.12 to 5.8.4
5. Are there any changes that cannot be rolled back: no

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
