### PR TITLE
[Enhancement] improve the performance of multi distinct 

### DIFF
--- a/be/src/exprs/aggregate_functions.cpp
+++ b/be/src/exprs/aggregate_functions.cpp
@@ -1346,7 +1346,8 @@ private:
         }
     };
 
-    std::unordered_set<T, NumericHashHelper> _set;
+    phmap::flat_hash_set<T, NumericHashHelper> _set;
+
     // Because Anyval does not provide the hash function, in order
     // to adopt the type different from the template, the pointer is used
     // HybridSetBase* _set;
@@ -1503,7 +1504,8 @@ public:
 private:
     const int DECIMAL_BYTE_SIZE = 16;
 
-    std::unordered_set<DecimalV2Value> _set;
+    phmap::flat_hash_set<DecimalV2Value> _set;
+
     FunctionContext::Type _type;
 };
 
@@ -1588,7 +1590,8 @@ private:
     const int DATETIME_PACKED_TIME_BYTE_SIZE = 8;
     const int DATETIME_TYPE_BYTE_SIZE = 4;
 
-    std::unordered_set<DateTimeVal, DateTimeHashHelper> _set;
+    phmap::flat_hash_set<DateTimeVal, DateTimeHashHelper> _set;
+
     FunctionContext::Type _type;
 };
 


### PR DESCRIPTION
# Proposed changes

Issue Number: close #9400 

I replaced the unordered set with phmap flat hash set

```sql
SELECT COUNT(DISTINCT k1) , COUNT(DISTINCT k2) FROM tbl WHERE dt >= 20211001 AND dt <= 20220406 
```

### Before:  39.473 sec

```shell

agg node:

AGGREGATION_NODE (id=3):(Active: 39s454ms, % non-child: 97.41%)
           - Probe Method: HashTable Linear Probing
           - BuildTime: 38s311ms   # merge set for a single node  spent 38s+
           - GetResultsTime: 0ns
           - HTResize: 0
           - HTResizeTime: 0ns
           - HashBuckets: 0
           - HashCollisions: 0
           - HashFailedProbe: 0
           - HashFilledBuckets: 0
           - HashProbe: 0
           - HashTravelLength: 0
           - LargestPartitionPercent: 0
           - MaxPartitionLevel: 0
           - NumRepartitions: 0
           - PartitionsCreated: 0
           - PeakMemoryUsage: 20.02 MB
           - RowsProcessed: 0
           - RowsRepartitioned: 0
           - RowsReturned: 1
           - RowsReturnedRate: 0
           - SpilledPartitions: 0
          EXCHANGE_NODE (id=2):(Active: 1s4ms, % non-child: 2.54%)
             - BytesReceived: 288.58 MB
             - ConvertRowBatchTime: 126.815us
             - DataArrivalWaitTime: 968.407ms
             - DeserializeRowBatchTimer: 778.607ms
             - FirstBatchArrivalWaitTime: 913.916ms
             - PeakMemoryUsage: 488.00 MB
             - RowsReturned: 102
             - RowsReturnedRate: 101
             - SendersBlockedTotalTimer(*): 27m4s
            
 scan node:
 
 AGGREGATION_NODE (id=1):(Active: 1s112ms, % non-child: 2.72%)
           - Probe Method: HashTable Linear Probing
           - BuildTime: 919.479ms  # local set spent 919ms+
           - GetResultsTime: 0ns
           - HTResize: 0
           - HTResizeTime: 0ns
           - HashBuckets: 0
           - HashCollisions: 0
           - HashFailedProbe: 0
           - HashFilledBuckets: 0
           - HashProbe: 0
           - HashTravelLength: 0
           - LargestPartitionPercent: 0
           - MaxPartitionLevel: 0
           - NumRepartitions: 0
           - PartitionsCreated: 0
           - PeakMemoryUsage: 12.01 MB
           - RowsProcessed: 0
           - RowsRepartitioned: 0
           - RowsReturned: 1
           - RowsReturnedRate: 0
           - SpilledPartitions: 0
          OLAP_SCAN_NODE (id=0):(Active: 39.37ms, % non-child: 0.10%)
             - BlockLookupCacheTime: 1.602ms
             - BlockPutCacheTime: 432.573us
             - BytesRead: 35.85 MB
             - GetNextTime: 39.288ms
             - MaxWaitScanTime: 27.906ms
             - NumDiskAccess: 9
             - NumScanners: 56
             - PeakMemoryUsage: 0.00 
             - RowsRead: 1.280344M (1280344)
             - RowsReturned: 1.280344M (1280344)
             - RowsReturnedRate: 32.798031M /sec
             - RowsetNum: 112
             - RowsetReaderInitTime: 89.952ms
             - ScanCpuTime: 726.172ms
             - ScannerBlockPutTimer: 53.488ms
             - ScannerMaxPendingTimer: 20.618ms
             - SegmentNum: 56
             - StartScanTime: 3.192ms
             - TabletCount : 56
             - TotalReadThroughput: 1.0241899490356445 MB/sec
             - WaitScanTime: 26.609ms
```

### After:  6.286 sec

```shell

agg node:

AGGREGATION_NODE (id=3):(Active: 6s269ms, % non-child: 90.09%)
           - Probe Method: HashTable Linear Probing
           - BuildTime: 5s661ms  # It takes a lot less time
           - GetResultsTime: 0ns
           - HTResize: 0
           - HTResizeTime: 0ns
           - HashBuckets: 0
           - HashCollisions: 0
           - HashFailedProbe: 0
           - HashFilledBuckets: 0
           - HashProbe: 0
           - HashTravelLength: 0
           - LargestPartitionPercent: 0
           - MaxPartitionLevel: 0
           - NumRepartitions: 0
           - PartitionsCreated: 0
           - PeakMemoryUsage: 20.02 MB
           - RowsProcessed: 0
           - RowsRepartitioned: 0
           - RowsReturned: 1
           - RowsReturnedRate: 0
           - SpilledPartitions: 0
          EXCHANGE_NODE (id=2):(Active: 607.271ms, % non-child: 9.66%)
             - BytesReceived: 289.17 MB
             - ConvertRowBatchTime: 110.818us
             - DataArrivalWaitTime: 229.107ms
             - DeserializeRowBatchTimer: 587.722ms
             - FirstBatchArrivalWaitTime: 229.107ms
             - PeakMemoryUsage: 496.00 MB
             - RowsReturned: 102
             - RowsReturnedRate: 167
             - SendersBlockedTotalTimer(*): 4m23s
            
 scan node:
 
 AGGREGATION_NODE (id=1):(Active: 214.468ms, % non-child: 3.20%)
           - Probe Method: HashTable Linear Probing
           - BuildTime: 195.186ms  # local spent time take less
           - GetResultsTime: 0ns
           - HTResize: 0
           - HTResizeTime: 0ns
           - HashBuckets: 0
           - HashCollisions: 0
           - HashFailedProbe: 0
           - HashFilledBuckets: 0
           - HashProbe: 0
           - HashTravelLength: 0
           - LargestPartitionPercent: 0
           - MaxPartitionLevel: 0
           - NumRepartitions: 0
           - PartitionsCreated: 0
           - PeakMemoryUsage: 12.01 MB
           - RowsProcessed: 0
           - RowsRepartitioned: 0
           - RowsReturned: 1
           - RowsReturnedRate: 4
           - SpilledPartitions: 0
          OLAP_SCAN_NODE (id=0):(Active: 13.59ms, % non-child: 0.21%)
             - BlockLookupCacheTime: 1.332ms
             - BlockPutCacheTime: 2.76ms
             - BytesRead: 36.06 MB
             - GetNextTime: 13.219ms
             - MaxWaitScanTime: 7.818ms
             - NumDiskAccess: 12
             - NumScanners: 56
             - PeakMemoryUsage: 0.00 
             - RowsRead: 1.28595M (1285950)
             - RowsReturned: 1.28595M (1285950)
             - RowsReturnedRate: 98.467409M /sec
             - RowsetNum: 112
             - RowsetReaderInitTime: 62.814ms
             - ScanCpuTime: 382.649ms
             - ScannerBlockPutTimer: 1.656ms
             - ScannerMaxPendingTimer: 14.702ms
             - SegmentNum: 56
             - StartScanTime: 1.629ms
             - TabletCount : 56
             - TotalReadThroughput: 12.01884651184082 MB/sec
             - WaitScanTime: 5.195ms
```

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
