### PR TITLE
[Bug] Missing error tablet list when close_wait return error

### DIFF
--- a/be/src/olap/delta_writer.cpp
+++ b/be/src/olap/delta_writer.cpp
@@ -311,6 +311,7 @@ Status DeltaWriter::close() {
 }
 
 Status DeltaWriter::close_wait(google::protobuf::RepeatedPtrField<PTabletInfo>* tablet_vec,
+                               google::protobuf::RepeatedPtrField<PTabletError>* tablet_errors,
                                bool is_broken) {
     std::lock_guard<std::mutex> l(_lock);
     DCHECK(_is_init)
@@ -321,7 +322,13 @@ Status DeltaWriter::close_wait(google::protobuf::RepeatedPtrField<PTabletInfo>* 
     }
 
     // return error if previous flush failed
-    RETURN_NOT_OK(_flush_token->wait());
+    Status s = Status::OK();
+    if (!(s = _flush_token->wait()).ok()) {
+        PTabletError* tablet_error = tablet_errors->Add();
+        tablet_error->set_tablet_id(_tablet->tablet_id());
+        tablet_error->set_msg(s.get_error_msg());
+        return s;
+    }
 
     // use rowset meta manager to save meta
     _cur_rowset = _rowset_writer->build();

--- a/be/src/olap/delta_writer.cpp
+++ b/be/src/olap/delta_writer.cpp
@@ -322,8 +322,8 @@ Status DeltaWriter::close_wait(google::protobuf::RepeatedPtrField<PTabletInfo>* 
     }
 
     // return error if previous flush failed
-    Status s = Status::OK();
-    if (!(s = _flush_token->wait()).ok()) {
+    Status s = _flush_token->wait();
+    if (!s.ok()) {
         PTabletError* tablet_error = tablet_errors->Add();
         tablet_error->set_tablet_id(_tablet->tablet_id());
         tablet_error->set_msg(s.get_error_msg());

--- a/be/src/olap/delta_writer.h
+++ b/be/src/olap/delta_writer.h
@@ -67,7 +67,8 @@ public:
     Status close();
     // wait for all memtables to be flushed.
     // mem_consumption() should be 0 after this function returns.
-    Status close_wait(google::protobuf::RepeatedPtrField<PTabletInfo>* tablet_vec, bool is_broken);
+    Status close_wait(google::protobuf::RepeatedPtrField<PTabletInfo>* tablet_vec,
+                      google::protobuf::RepeatedPtrField<PTabletError>* tablet_errors, bool is_broken);
 
     // abandon current memtable and wait for all pending-flushing memtables to be destructed.
     // mem_consumption() should be 0 after this function returns.

--- a/be/src/olap/delta_writer.h
+++ b/be/src/olap/delta_writer.h
@@ -68,7 +68,8 @@ public:
     // wait for all memtables to be flushed.
     // mem_consumption() should be 0 after this function returns.
     Status close_wait(google::protobuf::RepeatedPtrField<PTabletInfo>* tablet_vec,
-                      google::protobuf::RepeatedPtrField<PTabletError>* tablet_errors, bool is_broken);
+                      google::protobuf::RepeatedPtrField<PTabletError>* tablet_errors,
+                      bool is_broken);
 
     // abandon current memtable and wait for all pending-flushing memtables to be destructed.
     // mem_consumption() should be 0 after this function returns.

--- a/be/src/runtime/load_channel.h
+++ b/be/src/runtime/load_channel.h
@@ -81,7 +81,8 @@ protected:
         bool finished = false;
         auto index_id = request.index_id();
         RETURN_IF_ERROR(channel->close(request.sender_id(), request.backend_id(), &finished,
-                                       request.partition_ids(), response->mutable_tablet_vec()));
+                                       request.partition_ids(), response->mutable_tablet_vec(),
+                                       response->mutable_tablet_errors()));
         if (finished) {
             std::lock_guard<std::mutex> l(_lock);
             _tablets_channels.erase(index_id);

--- a/be/src/runtime/tablets_channel.cpp
+++ b/be/src/runtime/tablets_channel.cpp
@@ -131,8 +131,7 @@ Status TabletsChannel::close(int sender_id, int64_t backend_id, bool* finished,
             // tablet_vec will only contains success tablet, and then let FE judge it.
             writer->close_wait(
                     tablet_vec, tablet_errors,
-                    (_broken_tablets.find(writer->tablet_id()) !=
-                                            _broken_tablets.end()));
+                    (_broken_tablets.find(writer->tablet_id()) != _broken_tablets.end()));
         }
     }
     return Status::OK();

--- a/be/src/runtime/tablets_channel.cpp
+++ b/be/src/runtime/tablets_channel.cpp
@@ -129,7 +129,9 @@ Status TabletsChannel::close(int sender_id, int64_t backend_id, bool* finished,
         for (auto writer : need_wait_writers) {
             // close may return failed, but no need to handle it here.
             // tablet_vec will only contains success tablet, and then let FE judge it.
-            writer->close_wait(tablet_vec, tablet_errors, (_broken_tablets.find(writer->tablet_id()) !=
+            writer->close_wait(
+                    tablet_vec, tablet_errors,
+                    (_broken_tablets.find(writer->tablet_id()) !=
                                             _broken_tablets.end()));
         }
     }

--- a/be/src/runtime/tablets_channel.cpp
+++ b/be/src/runtime/tablets_channel.cpp
@@ -80,7 +80,8 @@ Status TabletsChannel::open(const PTabletWriterOpenRequest& request) {
 
 Status TabletsChannel::close(int sender_id, int64_t backend_id, bool* finished,
                              const google::protobuf::RepeatedField<int64_t>& partition_ids,
-                             google::protobuf::RepeatedPtrField<PTabletInfo>* tablet_vec) {
+                             google::protobuf::RepeatedPtrField<PTabletInfo>* tablet_vec,
+                             google::protobuf::RepeatedPtrField<PTabletError>* tablet_errors) {
     std::lock_guard<std::mutex> l(_lock);
     if (_state == kFinished) {
         return _close_status;
@@ -128,7 +129,7 @@ Status TabletsChannel::close(int sender_id, int64_t backend_id, bool* finished,
         for (auto writer : need_wait_writers) {
             // close may return failed, but no need to handle it here.
             // tablet_vec will only contains success tablet, and then let FE judge it.
-            writer->close_wait(tablet_vec, (_broken_tablets.find(writer->tablet_id()) !=
+            writer->close_wait(tablet_vec, tablet_errors, (_broken_tablets.find(writer->tablet_id()) !=
                                             _broken_tablets.end()));
         }
     }

--- a/be/src/runtime/tablets_channel.h
+++ b/be/src/runtime/tablets_channel.h
@@ -77,7 +77,8 @@ public:
     // no-op when this channel has been closed or cancelled
     Status close(int sender_id, int64_t backend_id, bool* finished,
                  const google::protobuf::RepeatedField<int64_t>& partition_ids,
-                 google::protobuf::RepeatedPtrField<PTabletInfo>* tablet_vec);
+                 google::protobuf::RepeatedPtrField<PTabletInfo>* tablet_vec,
+                 google::protobuf::RepeatedPtrField<PTabletError>* tablet_error);
 
     // no-op when this channel has been closed or cancelled
     Status cancel();


### PR DESCRIPTION
# Proposed changes

Issue Number: close #9417

## Problem Summary:

In function close_wait() of delta_writer.cpp, if _flush_token->wait() return an error, it will not be returned to front.
Because in PInternalServiceImpl::tablet_writer_add_batch, _exec_env->load_channel_mgr()->add_batch(*request, response); will not return an error, but only return error_tablets. However error_tablets in close_wait() is not returned.

## Checklist(Required)

1. Does it affect the original behavior: (No)
2. Has unit tests been added: (No)
3. Has document been added or modified: (No)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
