### PR TITLE
[Doc] Add Spark 3.2.0 description for spark-doris-connector

### DIFF
--- a/docs/en/ecosystem/spark-doris-connector.md
+++ b/docs/en/ecosystem/spark-doris-connector.md
@@ -41,6 +41,7 @@ Github: https://github.com/apache/incubator-doris-spark-connector
 |---------------| ----- | ------ | ---- | ----- |
 | 2.3.4-2.11.xx | 2.x   | 0.12+  | 8    | 2.11  |
 | 3.1.2-2.12.xx | 3.x   | 0.12.+ | 8    | 2.12  |
+| 3.2.0-2.12.xx | 3.2.x | 0.12.+ | 8    | 2.12  |
 
 ## Build and Install
 
@@ -91,8 +92,10 @@ Linux:
 Execute following command in source dir
 
 ```bash
-sh build.sh 2.3.4 2.11 ## spark 2.3.4 version, and scala 2.11
-sh build.sh 3.1.2 2.12 ## spark 3.1.2 version, and scala 2.12
+sh build.sh --spark 2.3.4 --scala 2.11 ## spark 2.3.4, scala 2.11
+sh build.sh --spark 3.1.2 --scala 2.12 ## spark 3.1.2, scala 2.12
+sh build.sh --spark 3.2.0 --scala 2.12 \
+--mvn-args "-Dnetty.version=4.1.68.Final -Dfasterxml.jackson.version=2.12.3" ## spark 3.2.0, scala 2.12
 ```
 > Note: If you check out the source code from tag, you can just run sh build.sh --tag without specifying the spark and scala versions. This is because the version in the tag source code is fixed.
 

--- a/docs/zh-CN/ecosystem/spark-doris-connector.md
+++ b/docs/zh-CN/ecosystem/spark-doris-connector.md
@@ -41,6 +41,7 @@ Spark Doris Connector 可以支持通过 Spark 读取 Doris 中存储的数据�
 |---------------| ----- | ------ | ---- | ----- |
 | 2.3.4-2.11.xx | 2.x   | 0.12+  | 8    | 2.11  |
 | 3.1.2-2.12.xx | 3.x   | 0.12.+ | 8    | 2.12  |
+| 3.2.0-2.12.xx | 3.2.x | 0.12.+ | 8    | 2.12  |
 
 ## 编译与安装
 
@@ -92,9 +93,10 @@ export THRIFT_BIN=/opt/homebrew/Cellar/thrift@0.13.0/0.13.0/bin/thrift
 在源码目录下执行：
 
 ```bash
-sh build.sh 2.3.4 2.11 ## spark 2.3.4, scala 2.11
-sh build.sh 3.1.2 2.12 ## spark 3.1.2, scala 2.12
-
+sh build.sh --spark 2.3.4 --scala 2.11 ## spark 2.3.4, scala 2.11
+sh build.sh --spark 3.1.2 --scala 2.12 ## spark 3.1.2, scala 2.12
+sh build.sh --spark 3.2.0 --scala 2.12 \
+--mvn-args "-Dnetty.version=4.1.68.Final -Dfasterxml.jackson.version=2.12.3" ## spark 3.2.0, scala 2.12
 ```
 > 注：如果你是从 tag 检出的源码，则可以直接执行 `sh build.sh --tag`，而无需指定 spark 和 scala 的版本。因为 tag 源码中的版本是固定的。
 


### PR DESCRIPTION
# Proposed changes

Because `spark-doris-connector` supports the compilation and testing of Spark 3.2.0, it needs to be updated in the documentation.

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
