### PR TITLE
[feature-wip](decimalv3)(step2) be vectorization execution layer uses decimalv3 for calculation

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -737,6 +737,8 @@ CONF_Validator(string_type_length_soft_limit_bytes,
 // used for olap scanner to save memory, when the size of unused_object_pool
 // is greater than object_pool_buffer_size, release the object in the unused_object_pool.
 CONF_Int32(object_pool_buffer_size, "100");
+
+CONF_Bool(enable_decimalv3, "false");
 } // namespace config
 
 } // namespace doris

--- a/be/src/runtime/decimalv2_value.cpp
+++ b/be/src/runtime/decimalv2_value.cpp
@@ -352,7 +352,8 @@ int DecimalV2Value::parse_from_str(const char* decimal_str, int32_t length) {
     int32_t error = E_DEC_OK;
     StringParser::ParseResult result = StringParser::PARSE_SUCCESS;
 
-    _value = StringParser::string_to_decimal(decimal_str, length, PRECISION, SCALE, &result);
+    _value = StringParser::string_to_decimal<__int128>(decimal_str, length, PRECISION, SCALE,
+                                                       &result);
 
     if (result == StringParser::PARSE_FAILURE) {
         error = E_DEC_BAD_NUM;

--- a/be/src/util/string_parser.cpp
+++ b/be/src/util/string_parser.cpp
@@ -20,11 +20,28 @@
 
 #include "string_parser.hpp"
 
+#include "vec/common/int_exp.h"
+
 namespace doris {
 
 template <>
 __int128 StringParser::numeric_limits<__int128>(bool negative) {
     return negative ? MIN_INT128 : MAX_INT128;
+}
+
+template <>
+int32_t StringParser::get_scale_multiplier(int scale) {
+    return common::exp10_i32(scale);
+}
+
+template <>
+int64_t StringParser::get_scale_multiplier(int scale) {
+    return common::exp10_i64(scale);
+}
+
+template <>
+__int128 StringParser::get_scale_multiplier(int scale) {
+    return common::exp10_i128(scale);
 }
 
 } // namespace doris

--- a/be/src/util/string_parser.hpp
+++ b/be/src/util/string_parser.hpp
@@ -68,7 +68,8 @@ public:
     template <typename T>
     static T numeric_limits(bool negative);
 
-    static inline __int128 get_scale_multiplier(int scale);
+    template <typename T>
+    static T get_scale_multiplier(int scale);
 
     // This is considerably faster than glibc's implementation (25x).
     // In the case of overflow, the max/min value for the data type will be returned.
@@ -132,8 +133,9 @@ public:
         return string_to_bool_internal(s + i, len - i, result);
     }
 
-    static inline __int128 string_to_decimal(const char* s, int len, int type_precision,
-                                             int type_scale, ParseResult* result);
+    template <typename T>
+    static inline T string_to_decimal(const char* s, int len, int type_precision, int type_scale,
+                                      ParseResult* result);
 
     template <typename T>
     static Status split_string_to_map(const std::string& base, const T element_separator,
@@ -613,56 +615,9 @@ inline int StringParser::StringParseTraits<__int128>::max_ascii_len() {
     return 39;
 }
 
-inline __int128 StringParser::get_scale_multiplier(int scale) {
-    DCHECK_GE(scale, 0);
-    static const __int128 values[] = {
-            static_cast<__int128>(1ll),
-            static_cast<__int128>(10ll),
-            static_cast<__int128>(100ll),
-            static_cast<__int128>(1000ll),
-            static_cast<__int128>(10000ll),
-            static_cast<__int128>(100000ll),
-            static_cast<__int128>(1000000ll),
-            static_cast<__int128>(10000000ll),
-            static_cast<__int128>(100000000ll),
-            static_cast<__int128>(1000000000ll),
-            static_cast<__int128>(10000000000ll),
-            static_cast<__int128>(100000000000ll),
-            static_cast<__int128>(1000000000000ll),
-            static_cast<__int128>(10000000000000ll),
-            static_cast<__int128>(100000000000000ll),
-            static_cast<__int128>(1000000000000000ll),
-            static_cast<__int128>(10000000000000000ll),
-            static_cast<__int128>(100000000000000000ll),
-            static_cast<__int128>(1000000000000000000ll),
-            static_cast<__int128>(1000000000000000000ll) * 10ll,
-            static_cast<__int128>(1000000000000000000ll) * 100ll,
-            static_cast<__int128>(1000000000000000000ll) * 1000ll,
-            static_cast<__int128>(1000000000000000000ll) * 10000ll,
-            static_cast<__int128>(1000000000000000000ll) * 100000ll,
-            static_cast<__int128>(1000000000000000000ll) * 1000000ll,
-            static_cast<__int128>(1000000000000000000ll) * 10000000ll,
-            static_cast<__int128>(1000000000000000000ll) * 100000000ll,
-            static_cast<__int128>(1000000000000000000ll) * 1000000000ll,
-            static_cast<__int128>(1000000000000000000ll) * 10000000000ll,
-            static_cast<__int128>(1000000000000000000ll) * 100000000000ll,
-            static_cast<__int128>(1000000000000000000ll) * 1000000000000ll,
-            static_cast<__int128>(1000000000000000000ll) * 10000000000000ll,
-            static_cast<__int128>(1000000000000000000ll) * 100000000000000ll,
-            static_cast<__int128>(1000000000000000000ll) * 1000000000000000ll,
-            static_cast<__int128>(1000000000000000000ll) * 10000000000000000ll,
-            static_cast<__int128>(1000000000000000000ll) * 100000000000000000ll,
-            static_cast<__int128>(1000000000000000000ll) * 100000000000000000ll * 10ll,
-            static_cast<__int128>(1000000000000000000ll) * 100000000000000000ll * 100ll,
-            static_cast<__int128>(1000000000000000000ll) * 100000000000000000ll * 1000ll};
-    if (scale >= 0 && scale < 39) {
-        return values[scale];
-    }
-    return -1; // Overflow
-}
-
-inline __int128 StringParser::string_to_decimal(const char* s, int len, int type_precision,
-                                                int type_scale, ParseResult* result) {
+template <typename T>
+inline T StringParser::string_to_decimal(const char* s, int len, int type_precision, int type_scale,
+                                         ParseResult* result) {
     // Special cases:
     //   1) '' == Fail, an empty string fails to parse.
     //   2) '   #   ' == #, leading and trailing white space is ignored.
@@ -717,7 +672,7 @@ inline __int128 StringParser::string_to_decimal(const char* s, int len, int type
     int precision = 0;
     bool found_exponent = false;
     int8_t exponent = 0;
-    __int128 value = 0;
+    T value = 0;
     for (int i = 0; i < len; ++i) {
         const char& c = s[i];
         if (LIKELY('0' <= c && c <= '9')) {
@@ -750,7 +705,7 @@ inline __int128 StringParser::string_to_decimal(const char* s, int len, int type
                 return 0;
             }
             *result = StringParser::PARSE_SUCCESS;
-            value *= get_scale_multiplier(type_scale - scale);
+            value *= get_scale_multiplier<T>(type_scale - scale);
             return is_negative ? -value : value;
         }
     }
@@ -761,7 +716,7 @@ inline __int128 StringParser::string_to_decimal(const char* s, int len, int type
         // Ex: 0.1e3 (which at this point would have precision == 1 and scale == 1), the
         //     scale must be set to 0 and the value set to 100 which means a precision of 3.
         precision += exponent - scale;
-        value *= get_scale_multiplier(exponent - scale);
+        value *= get_scale_multiplier<T>(exponent - scale);
         scale = 0;
     } else {
         // Ex: 100e-4, the scale must be set to 4 but no adjustment to the value is needed,
@@ -787,10 +742,10 @@ inline __int128 StringParser::string_to_decimal(const char* s, int len, int type
             shift -= truncated_digit_count;
         }
         if (shift > 0) {
-            __int128 divisor = get_scale_multiplier(shift);
+            T divisor = get_scale_multiplier<T>(shift);
             if (LIKELY(divisor >= 0)) {
                 value /= divisor;
-                __int128 remainder = value % divisor;
+                T remainder = value % divisor;
                 if ((remainder > 0 ? remainder : -remainder) >= (divisor >> 1)) {
                     value += 1;
                 }
@@ -805,7 +760,7 @@ inline __int128 StringParser::string_to_decimal(const char* s, int len, int type
     }
 
     if (type_scale > scale) {
-        value *= get_scale_multiplier(type_scale - scale);
+        value *= get_scale_multiplier<T>(type_scale - scale);
     }
 
     return is_negative ? -value : value;

--- a/be/src/vec/aggregate_functions/aggregate_function_avg.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_avg.h
@@ -46,13 +46,15 @@ struct AggregateFunctionAvgData {
             // null is handled in AggregationNode::_get_without_key_result
             return static_cast<ResultT>(sum);
         }
-        // to keep the same result with row vesion; see AggregateFunctions::decimalv2_avg_get_value
-        if constexpr (std::is_same_v<ResultT, Decimal128> && std::is_same_v<T, Decimal128>) {
-            DecimalV2Value decimal_val_count(count, 0);
-            DecimalV2Value decimal_val_sum(static_cast<Int128>(sum));
-            DecimalV2Value cal_ret = decimal_val_sum / decimal_val_count;
-            Decimal128 ret(cal_ret.value());
-            return ret;
+        if (!config::enable_decimalv3) {
+            // to keep the same result with row vesion; see AggregateFunctions::decimalv2_avg_get_value
+            if constexpr (std::is_same_v<ResultT, Decimal128> && std::is_same_v<T, Decimal128>) {
+                DecimalV2Value decimal_val_count(count, 0);
+                DecimalV2Value decimal_val_sum(static_cast<Int128>(sum));
+                DecimalV2Value cal_ret = decimal_val_sum / decimal_val_count;
+                Decimal128 ret(cal_ret.value());
+                return ret;
+            }
         }
         return static_cast<ResultT>(sum) / count;
     }

--- a/be/src/vec/aggregate_functions/aggregate_function_min_max.cpp
+++ b/be/src/vec/aggregate_functions/aggregate_function_min_max.cpp
@@ -50,8 +50,16 @@ static IAggregateFunction* create_aggregate_function_single_value(const String& 
         return new AggregateFunctionTemplate<Data<SingleValueDataFixed<Int64>>, false>(
                 argument_type);
     }
+    if (which.idx == TypeIndex::Decimal32) {
+        return new AggregateFunctionTemplate<Data<SingleValueDataDecimal<Decimal32>>, false>(
+                argument_type);
+    }
+    if (which.idx == TypeIndex::Decimal64) {
+        return new AggregateFunctionTemplate<Data<SingleValueDataDecimal<Decimal64>>, false>(
+                argument_type);
+    }
     if (which.idx == TypeIndex::Decimal128) {
-        return new AggregateFunctionTemplate<Data<SingleValueDataFixed<DecimalV2Value>>, false>(
+        return new AggregateFunctionTemplate<Data<SingleValueDataDecimal<Decimal128>>, false>(
                 argument_type);
     }
     return nullptr;

--- a/be/src/vec/aggregate_functions/aggregate_function_min_max_by.cpp
+++ b/be/src/vec/aggregate_functions/aggregate_function_min_max_by.cpp
@@ -47,8 +47,16 @@ static IAggregateFunction* create_aggregate_function_min_max_by_impl(
         return new AggregateFunctionTemplate<Data<VT, SingleValueDataFixed<Int64>>, false>(
                 value_arg_type, key_arg_type);
     }
+    if (which.idx == TypeIndex::Decimal32) {
+        return new AggregateFunctionTemplate<Data<VT, SingleValueDataDecimal<Decimal32>>, false>(
+                value_arg_type, key_arg_type);
+    }
+    if (which.idx == TypeIndex::Decimal64) {
+        return new AggregateFunctionTemplate<Data<VT, SingleValueDataDecimal<Decimal64>>, false>(
+                value_arg_type, key_arg_type);
+    }
     if (which.idx == TypeIndex::Decimal128) {
-        return new AggregateFunctionTemplate<Data<VT, SingleValueDataFixed<DecimalV2Value>>, false>(
+        return new AggregateFunctionTemplate<Data<VT, SingleValueDataDecimal<Decimal128>>, false>(
                 value_arg_type, key_arg_type);
     }
     return nullptr;

--- a/be/src/vec/aggregate_functions/aggregate_function_stddev.cpp
+++ b/be/src/vec/aggregate_functions/aggregate_function_stddev.cpp
@@ -43,9 +43,20 @@ static IAggregateFunction* create_function_single_value(const String& name,
 
     FOR_NUMERIC_TYPES(DISPATCH)
 #undef DISPATCH
-    if (which.is_decimal()) {
-        return new AggregateFunctionTemplate<NameData<Data<Decimal128, BaseDatadecimal<is_stddev>>>,
-                                             is_nullable>(argument_types);
+    if (which.is_decimal32()) {
+        return new AggregateFunctionTemplate<
+                NameData<Data<Decimal32, BaseDatadecimal<Decimal32, is_stddev>>>, is_nullable>(
+                argument_types);
+    }
+    if (which.is_decimal64()) {
+        return new AggregateFunctionTemplate<
+                NameData<Data<Decimal64, BaseDatadecimal<Decimal64, is_stddev>>>, is_nullable>(
+                argument_types);
+    }
+    if (which.is_decimal128()) {
+        return new AggregateFunctionTemplate<
+                NameData<Data<Decimal128, BaseDatadecimal<Decimal128, is_stddev>>>, is_nullable>(
+                argument_types);
     }
     DCHECK(false) << "with unknowed type, failed in  create_aggregate_function_stddev_variance";
     return nullptr;

--- a/be/src/vec/aggregate_functions/aggregate_function_stddev.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_stddev.h
@@ -99,7 +99,7 @@ struct BaseData {
     int64_t count;
 };
 
-template <bool is_stddev>
+template <typename T, bool is_stddev>
 struct BaseDatadecimal {
     BaseDatadecimal() : mean(0), m2(0), count(0) {}
     virtual ~BaseDatadecimal() = default;
@@ -162,9 +162,12 @@ struct BaseDatadecimal {
     }
 
     void add(const IColumn* column, size_t row_num) {
-        DecimalV2Value source_data = DecimalV2Value();
-        const auto& sources = static_cast<const ColumnDecimal<Decimal128>&>(*column);
-        source_data = (DecimalV2Value)sources.get_data()[row_num];
+        const auto& sources = static_cast<const ColumnDecimal<T>&>(*column);
+        Field field = sources[row_num];
+        auto decimal_field = field.template get<DecimalField<T>>();
+        int128_t value = static_cast<int128_t>(decimal_field.get_value()) *
+                         (DecimalV2Value::ONE_BILLION / decimal_field.get_scale_multiplier());
+        DecimalV2Value source_data = DecimalV2Value(value);
 
         DecimalV2Value new_count = DecimalV2Value();
         new_count.assign_from_double(count);

--- a/be/src/vec/columns/column_decimal.h
+++ b/be/src/vec/columns/column_decimal.h
@@ -111,16 +111,8 @@ public:
         }
     }
 
-    void insert_many_fix_len_data(const char* data_ptr, size_t num) override {
-        for (int i = 0; i < num; i++) {
-            const char* cur_ptr = data_ptr + sizeof(decimal12_t) * i;
-            int64_t int_value = *(int64_t*)(cur_ptr);
-            int32_t frac_value = *(int32_t*)(cur_ptr + sizeof(int64_t));
-            DecimalV2Value decimal_val(int_value, frac_value);
-            this->insert_data(reinterpret_cast<char*>(&decimal_val), 0);
-        }
-    }
-
+    inline T get_scale_multiplier(UInt32 scale);
+    void insert_many_fix_len_data(const char* data_ptr, size_t num) override;
     void insert_data(const char* pos, size_t /*length*/) override;
     void insert_default() override { data.push_back(T()); }
     void insert(const Field& x) override {

--- a/be/src/vec/data_types/data_type_decimal.cpp
+++ b/be/src/vec/data_types/data_type_decimal.cpp
@@ -55,6 +55,16 @@ template <typename T>
 void DataTypeDecimal<T>::to_string(const IColumn& column, size_t row_num,
                                    BufferWritable& ostr) const {
     // TODO: Reduce the copy in std::string mem to ostr, like DataTypeNumber
+    if (config::enable_decimalv3) {
+        T value = assert_cast<const ColumnType&>(*column.convert_to_full_column_if_const().get())
+                          .get_data()[row_num];
+        std::ostringstream buf;
+        write_text(value, scale, buf);
+        std::string str = buf.str();
+        ostr.write(str.data(), str.size());
+        return;
+    }
+
     DecimalV2Value value = (DecimalV2Value)assert_cast<const ColumnType&>(
                                    *column.convert_to_full_column_if_const().get())
                                    .get_data()[row_num];

--- a/be/src/vec/data_types/data_type_decimal.cpp
+++ b/be/src/vec/data_types/data_type_decimal.cpp
@@ -118,6 +118,17 @@ MutableColumnPtr DataTypeDecimal<T>::create_column() const {
     return ColumnType::create(0, scale);
 }
 
+template <typename T>
+T DataTypeDecimal<T>::parse_from_string(const std::string& str) const {
+    StringParser::ParseResult result = StringParser::PARSE_SUCCESS;
+    T value = StringParser::string_to_decimal<__int128>(str.c_str(), str.size(), precision, scale,
+                                                        &result);
+    if (result != StringParser::PARSE_SUCCESS) {
+        LOG(FATAL) << "Failed to parse string of decimal";
+    }
+    return value;
+}
+
 DataTypePtr create_decimal(UInt64 precision_value, UInt64 scale_value) {
     if (precision_value < min_decimal_precision() ||
         precision_value > max_decimal_precision<Decimal128>()) {

--- a/be/src/vec/data_types/data_type_decimal.h
+++ b/be/src/vec/data_types/data_type_decimal.h
@@ -320,9 +320,12 @@ convert_from_decimal(const typename FromDataType::FieldType& value, UInt32 scale
     using FromFieldType = typename FromDataType::FieldType;
     using ToFieldType = typename ToDataType::FieldType;
 
-    if constexpr (std::is_floating_point_v<ToFieldType>)
+    if constexpr (std::is_floating_point_v<ToFieldType>) {
+        if (config::enable_decimalv3) {
+            return static_cast<ToFieldType>(value) / FromDataType::get_scale_multiplier(scale);
+        }
         return binary_cast<int128_t, DecimalV2Value>(value);
-    else {
+    } else {
         FromFieldType converted_value =
                 convert_decimals<FromDataType, FromDataType>(value, scale, 0);
 

--- a/be/src/vec/data_types/data_type_decimal.h
+++ b/be/src/vec/data_types/data_type_decimal.h
@@ -106,8 +106,8 @@ public:
         }
 
         // Now, Doris only support precision:27, scale: 9
-        DCHECK(precision == 27);
-        DCHECK(scale == 9);
+        // DCHECK(precision == 27);
+        // DCHECK(scale == 9);
     }
 
     DataTypeDecimal(const DataTypeDecimal& rhs) : precision(rhs.precision), scale(rhs.scale) {}

--- a/be/src/vec/data_types/data_type_decimal.h
+++ b/be/src/vec/data_types/data_type_decimal.h
@@ -21,6 +21,7 @@
 #pragma once
 #include <cmath>
 
+#include "common/config.h"
 #include "vec/columns/column_decimal.h"
 #include "vec/common/arithmetic_overflow.h"
 #include "vec/common/typeid_cast.h"
@@ -46,7 +47,7 @@ constexpr size_t max_decimal_precision<Decimal64>() {
 }
 template <>
 constexpr size_t max_decimal_precision<Decimal128>() {
-    return 27;
+    return 38;
 }
 
 DataTypePtr create_decimal(UInt64 precision, UInt64 scale);
@@ -190,6 +191,8 @@ public:
 
     static T get_scale_multiplier(UInt32 scale);
 
+    T parse_from_string(const std::string& str) const;
+
 private:
     const UInt32 precision;
     const UInt32 scale;
@@ -199,26 +202,54 @@ template <typename T, typename U>
 typename std::enable_if_t<(sizeof(T) >= sizeof(U)), const DataTypeDecimal<T>> decimal_result_type(
         const DataTypeDecimal<T>& tx, const DataTypeDecimal<U>& ty, bool is_multiply,
         bool is_divide) {
-    return DataTypeDecimal<T>(max_decimal_precision<T>(), 9);
+    if (config::enable_decimalv3) {
+        UInt32 scale = (tx.get_scale() > ty.get_scale() ? tx.get_scale() : ty.get_scale());
+        if (is_multiply) {
+            scale = tx.get_scale() + ty.get_scale();
+        } else if (is_divide) {
+            scale = tx.get_scale();
+        }
+        return DataTypeDecimal<T>(max_decimal_precision<T>(), scale);
+    } else {
+        return DataTypeDecimal<T>(max_decimal_precision<T>(), 9);
+    }
 }
 
 template <typename T, typename U>
 typename std::enable_if_t<(sizeof(T) < sizeof(U)), const DataTypeDecimal<U>> decimal_result_type(
         const DataTypeDecimal<T>& tx, const DataTypeDecimal<U>& ty, bool is_multiply,
         bool is_divide) {
-    return DataTypeDecimal<U>(max_decimal_precision<U>(), 9);
+    if (config::enable_decimalv3) {
+        UInt32 scale = (tx.get_scale() > ty.get_scale() ? tx.get_scale() : ty.get_scale());
+        if (is_multiply) {
+            scale = tx.get_scale() + ty.get_scale();
+        } else if (is_divide) {
+            scale = tx.get_scale();
+        }
+        return DataTypeDecimal<U>(max_decimal_precision<U>(), scale);
+    } else {
+        return DataTypeDecimal<U>(max_decimal_precision<U>(), 9);
+    }
 }
 
 template <typename T, typename U>
 const DataTypeDecimal<T> decimal_result_type(const DataTypeDecimal<T>& tx, const DataTypeNumber<U>&,
                                              bool, bool) {
-    return DataTypeDecimal<T>(max_decimal_precision<T>(), 9);
+    if (config::enable_decimalv3) {
+        return DataTypeDecimal<T>(max_decimal_precision<T>(), tx.get_scale());
+    } else {
+        return DataTypeDecimal<T>(max_decimal_precision<T>(), 9);
+    }
 }
 
 template <typename T, typename U>
 const DataTypeDecimal<U> decimal_result_type(const DataTypeNumber<T>&, const DataTypeDecimal<U>& ty,
                                              bool, bool) {
-    return DataTypeDecimal<U>(max_decimal_precision<U>(), 9);
+    if (config::enable_decimalv3) {
+        return DataTypeDecimal<U>(max_decimal_precision<U>(), ty.get_scale());
+    } else {
+        return DataTypeDecimal<U>(max_decimal_precision<U>(), 9);
+    }
 }
 
 template <typename T>

--- a/be/src/vec/data_types/data_type_factory.cpp
+++ b/be/src/vec/data_types/data_type_factory.cpp
@@ -100,7 +100,11 @@ DataTypePtr DataTypeFactory::create_data_type(const TypeDescriptor& col_desc, bo
         nested = std::make_shared<vectorized::DataTypeBitMap>();
         break;
     case TYPE_DECIMALV2:
-        nested = std::make_shared<vectorized::DataTypeDecimal<vectorized::Decimal128>>(27, 9);
+        if (config::enable_decimalv3) {
+            nested = vectorized::create_decimal(col_desc.precision, col_desc.scale);
+        } else {
+            nested = std::make_shared<vectorized::DataTypeDecimal<vectorized::Decimal128>>(27, 9);
+        }
         break;
     // Just Mock A NULL Type in Vec Exec Engine
     case TYPE_NULL:

--- a/be/src/vec/data_types/data_type_factory.hpp
+++ b/be/src/vec/data_types/data_type_factory.hpp
@@ -64,6 +64,12 @@ public:
             instance.register_data_type("String", std::make_shared<DataTypeString>());
             instance.register_data_type("Decimal",
                                         std::make_shared<DataTypeDecimal<Decimal128>>(27, 9));
+            instance.register_data_type("Decimal32",
+                                        std::make_shared<DataTypeDecimal<Decimal32>>(9, 0));
+            instance.register_data_type("Decimal64",
+                                        std::make_shared<DataTypeDecimal<Decimal64>>(18, 0));
+            instance.register_data_type("Decimal128",
+                                        std::make_shared<DataTypeDecimal<Decimal128>>(38, 0));
         });
         return instance;
     }
@@ -74,6 +80,9 @@ public:
                                 : data_type;
         for (const auto& entity : _invert_data_type_map) {
             if (entity.first->equals(*type_ptr)) {
+                return entity.second;
+            }
+            if (is_decimal(type_ptr) && type_ptr->get_type_id() == entity.first->get_type_id()) {
                 return entity.second;
             }
         }

--- a/be/src/vec/exec/vaggregation_node.cpp
+++ b/be/src/vec/exec/vaggregation_node.cpp
@@ -145,9 +145,22 @@ void AggregationNode::_init_hash_method(std::vector<VExprContext*>& probe_exprs)
             _agg_data.init(AggregatedDataVariants::Type::int64_key, is_nullable);
             return;
         case TYPE_LARGEINT:
-        case TYPE_DECIMALV2:
-            _agg_data.init(AggregatedDataVariants::Type::int128_key, is_nullable);
+        case TYPE_DECIMALV2: {
+            DataTypePtr& type_ptr = probe_exprs[0]->root()->data_type();
+            TypeIndex idx = is_nullable ? assert_cast<const DataTypeNullable&>(*type_ptr)
+                                                  .get_nested_type()
+                                                  ->get_type_id()
+                                        : type_ptr->get_type_id();
+            WhichDataType which(idx);
+            if (which.is_decimal32()) {
+                _agg_data.init(AggregatedDataVariants::Type::int32_key, is_nullable);
+            } else if (which.is_decimal64()) {
+                _agg_data.init(AggregatedDataVariants::Type::int64_key, is_nullable);
+            } else {
+                _agg_data.init(AggregatedDataVariants::Type::int128_key, is_nullable);
+            }
             return;
+        }
         default:
             _agg_data.init(AggregatedDataVariants::Type::serialized);
         }
@@ -199,7 +212,7 @@ void AggregationNode::_init_hash_method(std::vector<VExprContext*>& probe_exprs)
             _agg_data.init(AggregatedDataVariants::Type::serialized);
         }
     }
-}
+} // namespace doris::vectorized
 
 Status AggregationNode::prepare(RuntimeState* state) {
     SCOPED_TIMER(_runtime_profile->total_time_counter());

--- a/be/src/vec/exprs/vliteral.cpp
+++ b/be/src/vec/exprs/vliteral.cpp
@@ -109,8 +109,33 @@ void VLiteral::init(const TExprNode& node) {
         case TYPE_DECIMALV2: {
             DCHECK_EQ(node.node_type, TExprNodeType::DECIMAL_LITERAL);
             DCHECK(node.__isset.decimal_literal);
-            DecimalV2Value value(node.decimal_literal.value);
-            field = DecimalField<Decimal128>(value.value(), value.scale());
+            if (config::enable_decimalv3) {
+                DataTypePtr type_ptr = create_decimal(node.type.types[0].scalar_type.precision,
+                                                      node.type.types[0].scalar_type.scale);
+                WhichDataType which(type_ptr->get_type_id());
+                if (which.is_decimal32()) {
+                    auto val = typeid_cast<const DataTypeDecimal<Decimal32>*>(type_ptr.get())
+                                       ->parse_from_string(node.decimal_literal.value);
+                    auto scale = typeid_cast<const DataTypeDecimal<Decimal32>*>(type_ptr.get())
+                                         ->get_scale();
+                    field = DecimalField<Decimal32>(val, scale);
+                } else if (which.is_decimal64()) {
+                    auto val = typeid_cast<const DataTypeDecimal<Decimal64>*>(type_ptr.get())
+                                       ->parse_from_string(node.decimal_literal.value);
+                    auto scale = typeid_cast<const DataTypeDecimal<Decimal64>*>(type_ptr.get())
+                                         ->get_scale();
+                    field = DecimalField<Decimal64>(val, scale);
+                } else if (which.is_decimal128()) {
+                    auto val = typeid_cast<const DataTypeDecimal<Decimal128>*>(type_ptr.get())
+                                       ->parse_from_string(node.decimal_literal.value);
+                    auto scale = typeid_cast<const DataTypeDecimal<Decimal128>*>(type_ptr.get())
+                                         ->get_scale();
+                    field = DecimalField<Decimal128>(val, scale);
+                }
+            } else {
+                DecimalV2Value value(node.decimal_literal.value);
+                field = DecimalField<Decimal128>(value.value(), value.scale());
+            }
             break;
         }
         default: {

--- a/be/src/vec/functions/function.h
+++ b/be/src/vec/functions/function.h
@@ -293,7 +293,14 @@ public:
                 is_date_or_datetime(get_return_type(arguments)->is_nullable()
                                             ? ((DataTypeNullable*)get_return_type(arguments).get())
                                                       ->get_nested_type()
-                                            : get_return_type(arguments))))
+                                            : get_return_type(arguments))) ||
+               (is_decimal(return_type->is_nullable()
+                                   ? ((DataTypeNullable*)return_type.get())->get_nested_type()
+                                   : return_type) &&
+                is_decimal(get_return_type(arguments)->is_nullable()
+                                   ? ((DataTypeNullable*)get_return_type(arguments).get())
+                                             ->get_nested_type()
+                                   : get_return_type(arguments))))
                 << " with " << return_type->get_name() << " and " << func_return_type->get_name();
 
         return build_impl(arguments, return_type);

--- a/be/src/vec/functions/function_binary_arithmetic.h
+++ b/be/src/vec/functions/function_binary_arithmetic.h
@@ -249,7 +249,14 @@ struct DecimalBinaryOperation {
                               ArrayC& c, ResultType scale_a [[maybe_unused]],
                               ResultType scale_b [[maybe_unused]], NullMap& null_map) {
         size_t size = a.size();
-
+        if (config::enable_decimalv3) {
+            if constexpr (OpTraits::is_division && IsDecimalNumber<B>) {
+                for (size_t i = 0; i < size; ++i) {
+                    c[i] = apply_scaled_div(a[i], b[i], scale_a, null_map[i]);
+                }
+                return;
+            }
+        }
         /// default: use it if no return before
         for (size_t i = 0; i < size; ++i) {
             c[i] = apply(a[i], b[i], null_map[i]);
@@ -449,6 +456,18 @@ struct DecimalBinaryOperation {
 private:
     /// there's implicit type convertion here
     static NativeResultType apply(NativeResultType a, NativeResultType b) {
+        if (config::enable_decimalv3) {
+            if constexpr (OpTraits::can_overflow && check_overflow) {
+                NativeResultType res;
+                if (Op::template apply<NativeResultType>(a, b, res)) {
+                    LOG(FATAL) << "Decimal math overflow";
+                }
+                return res;
+            } else {
+                return Op::template apply<NativeResultType>(a, b);
+            }
+        }
+
         // Now, Doris only support decimal +-*/ decimal.
         // overflow in consider in operator
         DecimalV2Value l(a);
@@ -461,6 +480,10 @@ private:
 
     /// null_map for divide and mod
     static NativeResultType apply(NativeResultType a, NativeResultType b, UInt8& is_null) {
+        if (config::enable_decimalv3) {
+            return Op::template apply<NativeResultType>(a, b, is_null);
+        }
+
         DecimalV2Value l(a);
         DecimalV2Value r(b);
         auto ans = Op::template apply(l, r, is_null);


### PR DESCRIPTION
# Proposed changes

Issue Number: close #9208 

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (No)
2. Has unit tests been added: (No)
3. Has document been added or modified: (No)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
