### PR TITLE
[fix](ut) fix DeltaWriter::close_wait parameter mismatch in delta_writer_test

### DIFF
--- a/be/src/olap/delta_writer.cpp
+++ b/be/src/olap/delta_writer.cpp
@@ -324,9 +324,11 @@ Status DeltaWriter::close_wait(google::protobuf::RepeatedPtrField<PTabletInfo>* 
     // return error if previous flush failed
     Status s = _flush_token->wait();
     if (!s.ok()) {
+#ifndef BE_TEST
         PTabletError* tablet_error = tablet_errors->Add();
         tablet_error->set_tablet_id(_tablet->tablet_id());
         tablet_error->set_msg(s.get_error_msg());
+#endif
         return s;
     }
 

--- a/be/test/olap/delta_writer_test.cpp
+++ b/be/test/olap/delta_writer_test.cpp
@@ -367,7 +367,7 @@ TEST_F(TestDeltaWriter, open) {
     EXPECT_NE(delta_writer, nullptr);
     res = delta_writer->close();
     EXPECT_EQ(Status::OK(), res);
-    res = delta_writer->close_wait(nullptr, false);
+    res = delta_writer->close_wait(nullptr, nullptr, false);
     EXPECT_EQ(Status::OK(), res);
     SAFE_DELETE(delta_writer);
 
@@ -376,7 +376,7 @@ TEST_F(TestDeltaWriter, open) {
     EXPECT_NE(delta_writer, nullptr);
     res = delta_writer->close();
     EXPECT_EQ(Status::OK(), res);
-    res = delta_writer->close_wait(nullptr, false);
+    res = delta_writer->close_wait(nullptr, nullptr, false);
     EXPECT_EQ(Status::OK(), res);
     SAFE_DELETE(delta_writer);
 
@@ -475,7 +475,7 @@ TEST_F(TestDeltaWriter, write) {
 
     res = delta_writer->close();
     EXPECT_EQ(Status::OK(), res);
-    res = delta_writer->close_wait(nullptr, false);
+    res = delta_writer->close_wait(nullptr, nullptr, false);
     EXPECT_EQ(Status::OK(), res);
 
     // publish version success
@@ -609,7 +609,7 @@ TEST_F(TestDeltaWriter, vec_write) {
 
     res = delta_writer->close();
     ASSERT_TRUE(res.ok());
-    res = delta_writer->close_wait(nullptr, false);
+    res = delta_writer->close_wait(nullptr, nullptr, false);
     ASSERT_TRUE(res.ok());
 
     // publish version success
@@ -687,7 +687,7 @@ TEST_F(TestDeltaWriter, sequence_col) {
 
     res = delta_writer->close();
     EXPECT_EQ(Status::OK(), res);
-    res = delta_writer->close_wait(nullptr, false);
+    res = delta_writer->close_wait(nullptr, nullptr, false);
     EXPECT_EQ(Status::OK(), res);
 
     // publish version success
@@ -772,7 +772,7 @@ TEST_F(TestDeltaWriter, vec_sequence_col) {
 
     res = delta_writer->close();
     ASSERT_TRUE(res.ok());
-    res = delta_writer->close_wait(nullptr, false);
+    res = delta_writer->close_wait(nullptr, nullptr, false);
     ASSERT_TRUE(res.ok());
 
     // publish version success

--- a/be/test/olap/engine_storage_migration_task_test.cpp
+++ b/be/test/olap/engine_storage_migration_task_test.cpp
@@ -194,7 +194,7 @@ TEST_F(TestEngineStorageMigrationTask, write_and_migration) {
 
     res = delta_writer->close();
     EXPECT_EQ(Status::OK(), res);
-    res = delta_writer->close_wait(nullptr, false);
+    res = delta_writer->close_wait(nullptr, nullptr, false);
     EXPECT_EQ(Status::OK(), res);
 
     // publish version success


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

```
/home/disk3/zxy/baidu/bdg/doris/core/be/test/olap/delta_writer_test.cpp:370:50: error: too few arguments to function call, expected 3, have 2
    res = delta_writer->close_wait(nullptr, false);
          ~~~~~~~~~~~~~~~~~~~~~~~~               ^
/home/disk3/zxy/baidu/bdg/doris/core/be/src/olap/delta_writer.h:70:12: note: 'close_wait' declared here
    Status close_wait(google::protobuf::RepeatedPtrField<PTabletInfo>* tablet_vec,
           ^
/home/disk3/zxy/baidu/bdg/doris/core/be/test/olap/delta_writer_test.cpp:379:50: error: too few arguments to function call, expected 3, have 2
    res = delta_writer->close_wait(nullptr, false);
          ~~~~~~~~~~~~~~~~~~~~~~~~               ^
/home/disk3/zxy/baidu/bdg/doris/core/be/src/olap/delta_writer.h:70:12: note: 'close_wait' declared here
    Status close_wait(google::protobuf::RepeatedPtrField<PTabletInfo>* tablet_vec,
           ^
/home/disk3/zxy/baidu/bdg/doris/core/be/test/olap/delta_writer_test.cpp:478:50: error: too few arguments to function call, expected 3, have 2
    res = delta_writer->close_wait(nullptr, false);
          ~~~~~~~~~~~~~~~~~~~~~~~~               ^
/home/disk3/zxy/baidu/bdg/doris/core/be/src/olap/delta_writer.h:70:12: note: 'close_wait' declared here
    Status close_wait(google::protobuf::RepeatedPtrField<PTabletInfo>* tablet_vec,
           ^
/home/disk3/zxy/baidu/bdg/doris/core/be/test/olap/delta_writer_test.cpp:612:50: error: too few arguments to function call, expected 3, have 2
    res = delta_writer->close_wait(nullptr, false);
          ~~~~~~~~~~~~~~~~~~~~~~~~               ^
/home/disk3/zxy/baidu/bdg/doris/core/be/src/olap/delta_writer.h:70:12: note: 'close_wait' declared here
    Status close_wait(google::protobuf::RepeatedPtrField<PTabletInfo>* tablet_vec,
           ^
/home/disk3/zxy/baidu/bdg/doris/core/be/test/olap/delta_writer_test.cpp:690:50: error: too few arguments to function call, expected 3, have 2
    res = delta_writer->close_wait(nullptr, false);
          ~~~~~~~~~~~~~~~~~~~~~~~~               ^
/home/disk3/zxy/baidu/bdg/doris/core/be/src/olap/delta_writer.h:70:12: note: 'close_wait' declared here
    Status close_wait(google::protobuf::RepeatedPtrField<PTabletInfo>* tablet_vec,
           ^
/home/disk3/zxy/baidu/bdg/doris/core/be/test/olap/delta_writer_test.cpp:775:50: error: too few arguments to function call, expected 3, have 2
    res = delta_writer->close_wait(nullptr, false);
          ~~~~~~~~~~~~~~~~~~~~~~~~               ^
/home/disk3/zxy/baidu/bdg/doris/core/be/src/olap/delta_writer.h:70:12: note: 'close_wait' declared here
    Status close_wait(google::protobuf::RepeatedPtrField<PTabletInfo>* tablet_vec,
```

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
