### PR TITLE
[stream-load-vec]: memtable flush only if necessary after aggregated

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -464,6 +464,8 @@ CONF_Int32(memory_max_alignment, "16");
 // write buffer size before flush
 CONF_mInt64(write_buffer_size, "209715200");
 
+CONF_mInt64(memtable_max_buffer_size, "419430400");
+
 // following 2 configs limit the memory consumption of load process on a Backend.
 // eg: memory limit to 80% of mem limit config but up to 100GB(default)
 // NOTICE(cmy): set these default values very large because we don't want to

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -464,6 +464,7 @@ CONF_Int32(memory_max_alignment, "16");
 // write buffer size before flush
 CONF_mInt64(write_buffer_size, "209715200");
 
+// max buffer size used in memtable for the aggregated table
 CONF_mInt64(memtable_max_buffer_size, "419430400");
 
 // following 2 configs limit the memory consumption of load process on a Backend.

--- a/be/src/olap/delta_writer.cpp
+++ b/be/src/olap/delta_writer.cpp
@@ -224,7 +224,7 @@ Status DeltaWriter::write(const vectorized::Block* block, const std::vector<int>
 
     if (_mem_table->need_to_agg()) {
         _mem_table->shrink_memtable_by_agg();
-        if (UNLIKELY(_mem_table->is_flush())) {
+        if (_mem_table->is_flush()) {
             RETURN_NOT_OK(_flush_memtable_async());
             _reset_mem_table();
         }

--- a/be/src/olap/delta_writer.cpp
+++ b/be/src/olap/delta_writer.cpp
@@ -222,9 +222,9 @@ Status DeltaWriter::write(const vectorized::Block* block, const std::vector<int>
         }
     }
 
-    if (_mem_table->is_full()) {
+    if (_mem_table->need_to_agg()) {
         _mem_table->shrink_memtable_by_agg();
-        if (_mem_table->is_full()) {
+        if (UNLIKELY(_mem_table->is_flush())) {
             RETURN_NOT_OK(_flush_memtable_async());
             _reset_mem_table();
         }

--- a/be/src/olap/delta_writer.cpp
+++ b/be/src/olap/delta_writer.cpp
@@ -222,9 +222,12 @@ Status DeltaWriter::write(const vectorized::Block* block, const std::vector<int>
         }
     }
 
-    if (_mem_table->memory_usage() >= config::write_buffer_size) {
-        RETURN_NOT_OK(_flush_memtable_async());
-        _reset_mem_table();
+    if (_mem_table->is_full()) {
+        _mem_table->shrink_memtable_by_agg();
+        if (_mem_table->is_full()) {
+            RETURN_NOT_OK(_flush_memtable_async());
+            _reset_mem_table();
+        }
     }
 
     return Status::OK();

--- a/be/src/olap/memtable.cpp
+++ b/be/src/olap/memtable.cpp
@@ -127,7 +127,7 @@ void MemTable::insert(const vectorized::Block* block, size_t row_pos, size_t num
     }
     size_t cursor_in_mutableblock = _input_mutable_block.rows();
     _input_mutable_block.add_rows(block, row_pos, num_rows);
-    size_t input_size = block->allocated_bytes() * num_rows / block->rows(); 
+    size_t input_size = block->allocated_bytes() * num_rows / block->rows();
     _mem_usage += input_size;
     _mem_tracker->consume(input_size);
     // when new data inserted, the mem_usage of memtable should be re-shrunk again.
@@ -243,7 +243,7 @@ void MemTable::_aggregate_two_row_in_block(RowInBlock* new_row, RowInBlock* row_
                                  new_row->_row_pos, nullptr);
     }
 }
-template<bool is_final>
+template <bool is_final>
 void MemTable::_collect_vskiplist_to_output() {
     VecTable::Iterator it(_vec_skip_list.get());
     vectorized::Block in_block = _input_mutable_block.to_block();
@@ -266,7 +266,7 @@ void MemTable::_collect_vskiplist_to_output() {
                 auto function = _agg_functions[i];
                 function->insert_result_into(it.key()->_agg_places[i],
                                              *(_output_mutable_block.get_column_by_position(i)));
-                if constexpr(is_final) {
+                if constexpr (is_final) {
                     function->destroy(it.key()->_agg_places[i]);
                 }
             }

--- a/be/src/olap/memtable.cpp
+++ b/be/src/olap/memtable.cpp
@@ -291,6 +291,9 @@ void MemTable::_collect_vskiplist_results() {
 }
 
 void MemTable::shrink_memtable_by_agg() {
+    if (_keys_type == KeysType::DUP_KEYS) {
+        return;
+    }
     _collect_vskiplist_results<false>();
 }
 
@@ -299,7 +302,8 @@ bool MemTable::is_flush() {
 }
 
 bool MemTable::need_to_agg() {
-    return memory_usage() >= config::memtable_max_buffer_size;
+    return _keys_type == KeysType::DUP_KEYS ? is_flush()
+                                            : memory_usage() >= config::memtable_max_buffer_size;
 }
 
 Status MemTable::flush() {

--- a/be/src/olap/memtable.h
+++ b/be/src/olap/memtable.h
@@ -202,7 +202,7 @@ private:
     vectorized::MutableBlock _input_mutable_block;
     vectorized::MutableBlock _output_mutable_block;
 
-    template<bool is_final>
+    template <bool is_final>
     void _collect_vskiplist_to_output();
     bool _is_first_insertion;
 

--- a/be/src/olap/memtable.h
+++ b/be/src/olap/memtable.h
@@ -58,7 +58,9 @@ public:
 
     void shrink_memtable_by_agg();
 
-    bool is_full();
+    bool is_flush();
+
+    bool need_to_agg();
 
     /// Flush
     Status flush();
@@ -218,7 +220,9 @@ private:
     //for vectorized
     vectorized::MutableBlock _input_mutable_block;
     vectorized::MutableBlock _output_mutable_block;
-    void _collect_vskiplist_to_output(bool final);
+
+    template<bool is_final>
+    void _collect_vskiplist_to_output();
     bool _is_first_insertion;
 
     bool _is_shrunk_by_agg = false;

--- a/be/src/olap/memtable.h
+++ b/be/src/olap/memtable.h
@@ -54,6 +54,10 @@ public:
     // insert tuple from (row_pos) to (row_pos+num_rows)
     void insert(const vectorized::Block* block, size_t row_pos, size_t num_rows);
 
+    void shrink_memtable_by_agg();
+
+    bool is_full();
+
     /// Flush
     Status flush();
     Status close();
@@ -195,8 +199,10 @@ private:
     //for vectorized
     vectorized::MutableBlock _input_mutable_block;
     vectorized::MutableBlock _output_mutable_block;
-    vectorized::Block _collect_vskiplist_results();
+    void _collect_vskiplist_to_output(bool final);
     bool _is_first_insertion;
+
+    bool _is_shrunk_by_agg = false;
 
     void _init_agg_functions(const vectorized::Block* block);
     std::vector<vectorized::AggregateFunctionPtr> _agg_functions;

--- a/be/src/olap/memtable.h
+++ b/be/src/olap/memtable.h
@@ -203,10 +203,8 @@ private:
     vectorized::MutableBlock _output_mutable_block;
 
     template <bool is_final>
-    void _collect_vskiplist_to_output();
+    void _collect_vskiplist_results();
     bool _is_first_insertion;
-
-    bool _is_shrunk_by_agg = false;
 
     void _init_agg_functions(const vectorized::Block* block);
     std::vector<vectorized::AggregateFunctionPtr> _agg_functions;

--- a/be/src/olap/memtable.h
+++ b/be/src/olap/memtable.h
@@ -18,13 +18,11 @@
 #pragma once
 
 #include <ostream>
-#include <time.h>
 
 #include "common/object_pool.h"
 #include "olap/olap_define.h"
 #include "olap/skiplist.h"
 #include "runtime/mem_tracker.h"
-#include "util/runtime_profile.h"
 #include "util/tuple_row_zorder_compare.h"
 #include "vec/aggregate_functions/aggregate_function.h"
 #include "vec/common/string_ref.h"
@@ -155,23 +153,6 @@ private:
     void _insert_one_row_from_block(RowInBlock* row_in_block);
     void _aggregate_two_row_in_block(RowInBlock* new_row, RowInBlock* row_in_skiplist);
 
-    void _init_profile() {
-        _profile.reset(new RuntimeProfile("Memtable"));
-        _insert_time = ADD_TIMER(_profile, "insert total time");
-        _sort_agg_time = ADD_TIMER(_profile, "sort and agg time");
-        _shrunk_agg_time = ADD_TIMER(_profile, "shrunk by agg time");
-    }
-
-    void print_profile() {
-        std::stringstream ss;
-        _profile->pretty_print(&ss);
-        LOG(INFO) << ss.str();
-    }
-
-    void on_flush_submit() {
-        _flush_submit_time = clock();
-    }
-
     int64_t _tablet_id;
     Schema* _schema;
     const TabletSchema* _tablet_schema;
@@ -231,14 +212,6 @@ private:
     std::vector<vectorized::AggregateFunctionPtr> _agg_functions;
     std::vector<RowInBlock*> _row_in_blocks;
     size_t _mem_usage;
-
-    std::unique_ptr<RuntimeProfile> _profile;
-    RuntimeProfile::Counter* _insert_time;
-    RuntimeProfile::Counter* _sort_agg_time;
-    RuntimeProfile::Counter* _shrunk_agg_time;
-    clock_t _flush_submit_time;
-
-    
 }; // class MemTable
 
 inline std::ostream& operator<<(std::ostream& os, const MemTable& table) {

--- a/be/src/vec/core/block.cpp
+++ b/be/src/vec/core/block.cpp
@@ -846,6 +846,18 @@ size_t MutableBlock::rows() const {
     return 0;
 }
 
+void MutableBlock::swap(MutableBlock& another) noexcept {
+    _columns.swap(another._columns);
+    _data_types.swap(another._data_types);
+}
+
+void MutableBlock::swap(MutableBlock&& another) noexcept {
+    clear();
+    _columns = std::move(another._columns);
+    _data_types = std::move(another._data_types);
+}
+
+
 void MutableBlock::add_row(const Block* block, int row) {
     auto& block_data = block->get_columns_with_type_and_name();
     for (size_t i = 0; i < _columns.size(); ++i) {
@@ -971,6 +983,14 @@ size_t MutableBlock::allocated_bytes() const {
     }
 
     return res;
+}
+
+void MutableBlock::clear_column_data() noexcept {
+    for (auto& col : _columns) {
+        if (col) {
+            col->clear();
+        }
+    }
 }
 
 } // namespace doris::vectorized

--- a/be/src/vec/core/block.cpp
+++ b/be/src/vec/core/block.cpp
@@ -857,7 +857,6 @@ void MutableBlock::swap(MutableBlock&& another) noexcept {
     _data_types = std::move(another._data_types);
 }
 
-
 void MutableBlock::add_row(const Block* block, int row) {
     auto& block_data = block->get_columns_with_type_and_name();
     for (size_t i = 0; i < _columns.size(); ++i) {

--- a/be/src/vec/core/block.h
+++ b/be/src/vec/core/block.h
@@ -425,6 +425,12 @@ public:
 
     Block to_block(int start_column, int end_column);
 
+
+    void swap(MutableBlock& other) noexcept;
+    
+    void swap(MutableBlock&& other) noexcept;
+
+
     void add_row(const Block* block, int row);
     void add_rows(const Block* block, const int* row_begin, const int* row_end);
     void add_rows(const Block* block, size_t row_begin, size_t length);
@@ -435,6 +441,9 @@ public:
         _columns.clear();
         _data_types.clear();
     }
+
+    void clear_column_data() noexcept;
+
     size_t allocated_bytes() const;
 };
 

--- a/be/src/vec/core/block.h
+++ b/be/src/vec/core/block.h
@@ -425,11 +425,9 @@ public:
 
     Block to_block(int start_column, int end_column);
 
-
     void swap(MutableBlock& other) noexcept;
-    
-    void swap(MutableBlock&& other) noexcept;
 
+    void swap(MutableBlock&& other) noexcept;
 
     void add_row(const Block* block, int row);
     void add_rows(const Block* block, const int* row_begin, const int* row_end);


### PR DESCRIPTION
# Proposed changes

When the input data in the current memtable is full, flush will be performed, and there is no logic to judge whether it is full after aggregation. 
I try to supplement this logic in this pr and do some performance tests later.


some tests:

1. cluster information 
- 1 BE
- 1 FE

2. test table schema：

```
CREATE TABLE `agg_table_heavy` (
  `id` int(11) NULL COMMENT "id",
  `year` int(11) NULL COMMENT "year",
  `value_min` int(11) MIN NULL COMMENT "value min",
  `value_max` int(11) MAX NULL COMMENT "value max",
  `value_sum` int(11) SUM NULL COMMENT "value sum",
  `value_replace` int(11) REPLACE NULL COMMENT "value replace",
  `decimal_min` decimal(15, 6) MIN NULL COMMENT "decimal min",
  `decimal_max` decimal(15, 6) MAX NULL COMMENT "decimal max",
  `decimal_sum` decimal(15, 6) SUM NULL COMMENT "decimal sum",
  `decimal_replace` decimal(15, 6) REPLACE NULL COMMENT "decimal replace",
  `string_replace` varchar(60) REPLACE NULL COMMENT "varchar replace"
) ENGINE=OLAP
AGGREGATE KEY(`id`, `year`)
COMMENT "OLAP"
PARTITION BY RANGE(`year`)
(PARTITION p2020 VALUES [("2020"), ("2021")),
PARTITION p2021 VALUES [("2021"), ("2022")))
DISTRIBUTED BY HASH(`id`) BUCKETS 1
PROPERTIES (
"replication_allocation" = "tag.location.default: 1",
"in_memory" = "false",
"storage_format" = "V2"
)
```





3. test results of aggregate table


version | description | sort and aggregation in memtable | total load time | num of input data in each stream load | num of input data after aggregation in each stream load | stream load concurrent
-- | -- | -- | -- | -- | -- | --
baseline | branch: master,commit: eec1df |  38s | 478s | 30000000 | 1000 | 5 |   |  
opt_a | sort and aggregation in batches, [details](https://docs.google.com/document/d/1DFSJJsdIqHq1B1s50_Nui25yZcYstWpNqD93pM_7OYE/edit?usp=sharing) | 34s | 475s | 30000000 | 1000 | 5
opt_b | this pr | 29s | 461s | 30000000 | 1000 | 5


4. some examples of test data
```
mysql> select * from agg_table_heavy limit 9;
+------+------+-----------+-----------+-----------+---------------+-------------+-------------+-------------+-----------------+----------------+
| id   | year | value_min | value_max | value_sum | value_replace | decimal_min | decimal_max | decimal_sum | decimal_replace | string_replace |
+------+------+-----------+-----------+-----------+---------------+-------------+-------------+-------------+-----------------+----------------+
|    0 | 2020 |       100 |     30099 | 234882704 |         12367 |     100.001 |   30099.001 |  4529850300 |       12367.001 | ok12367.001    |
|    1 | 2020 |       101 |     30100 | 235182704 |         10743 |     101.001 |   30100.001 |  4530150300 |       10743.001 | ok10743.001    |
|    2 | 2020 |       102 |     30101 | 235482704 |         18002 |     102.001 |   30101.001 |  4530450300 |       18002.001 | ok18002.001    |
|    3 | 2020 |       103 |     30102 | 235782704 |         28498 |     103.001 |   30102.001 |  4530750300 |       28498.001 | ok28498.001    |
|    4 | 2020 |       104 |     30103 | 236082704 |         14307 |     104.001 |   30103.001 |  4531050300 |       14307.001 | ok14307.001    |
|    5 | 2020 |       105 |     30104 | 236382704 |         16190 |     105.001 |   30104.001 |  4531350300 |       16190.001 | ok16190.001    |
|    6 | 2020 |       106 |     30105 | 236682704 |         20733 |     106.001 |   30105.001 |  4531650300 |       20733.001 | ok20733.001    |
|    7 | 2020 |       107 |     30106 | 236982704 |         16814 |     107.001 |   30106.001 |  4531950300 |       16814.001 | ok16814.001    |
|    8 | 2020 |       108 |     30107 | 237282704 |          9219 |     108.001 |   30107.001 |  4532250300 |        9219.001 | ok9219.001     |
+------+------+-----------+-----------+-----------+---------------+-------------+-------------+-------------+-----------------+----------------+
```

close #8656

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
5. Has unit tests been added: (Yes/No/No Need)
6. Has document been added or modified: (Yes/No/No Need)
7. Does it need to update dependencies: (Yes/No)
8. Are there any changes that cannot be rolled back: (Yes/No)


## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
