### PR TITLE
[fix]binlog load fails because txn exceeds the default value

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/load/sync/canal/CanalSyncChannel.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/sync/canal/CanalSyncChannel.java
@@ -22,6 +22,7 @@ import org.apache.doris.catalog.Catalog;
 import org.apache.doris.catalog.Database;
 import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.common.AnalysisException;
+import org.apache.doris.common.Config;
 import org.apache.doris.common.DuplicatedRequestException;
 import org.apache.doris.common.LabelAlreadyUsedException;
 import org.apache.doris.common.UserException;
@@ -41,6 +42,7 @@ import org.apache.doris.thrift.TStreamLoadPutRequest;
 import org.apache.doris.thrift.TTxnParams;
 import org.apache.doris.thrift.TUniqueId;
 import org.apache.doris.transaction.BeginTransactionException;
+import org.apache.doris.transaction.DatabaseTransactionMgr;
 import org.apache.doris.transaction.GlobalTransactionMgr;
 import org.apache.doris.transaction.TransactionEntry;
 import org.apache.doris.transaction.TransactionState;
@@ -121,53 +123,60 @@ public class CanalSyncChannel extends SyncChannel {
                     + "_batch" + batchId + "_" + currentTime;
             String targetColumn = Joiner.on(",").join(columns) + "," + DELETE_COLUMN;
             GlobalTransactionMgr globalTransactionMgr = Catalog.getCurrentGlobalTransactionMgr();
-            TransactionEntry txnEntry = txnExecutor.getTxnEntry();
-            TTxnParams txnConf = txnEntry.getTxnConf();
-            TransactionState.LoadJobSourceType sourceType = TransactionState.LoadJobSourceType.INSERT_STREAMING;
-            TStreamLoadPutRequest request = null;
-            try {
-                long txnId = globalTransactionMgr.beginTransaction(db.getId(), Lists.newArrayList(tbl.getId()), label,
-                        new TransactionState.TxnCoordinator(TransactionState.TxnSourceType.FE, FrontendOptions.getLocalHostAddress()), sourceType, timeoutSecond);
-                String authCodeUuid = Catalog.getCurrentGlobalTransactionMgr().getTransactionState(
-                        db.getId(), txnId).getAuthCode();
-                request = new TStreamLoadPutRequest()
-                        .setTxnId(txnId).setDb(txnConf.getDb()).setTbl(txnConf.getTbl())
-                        .setFileType(TFileType.FILE_STREAM).setFormatType(TFileFormatType.FORMAT_CSV_PLAIN)
-                        .setThriftRpcTimeoutMs(5000).setLoadId(txnExecutor.getLoadId())
-                        .setMergeType(TMergeType.MERGE).setDeleteCondition(DELETE_CONDITION)
-                        .setColumns(targetColumn);
-                txnConf.setTxnId(txnId).setAuthCodeUuid(authCodeUuid);
-                txnEntry.setLabel(label);
-                txnExecutor.setTxnId(txnId);
-            } catch (DuplicatedRequestException e) {
-                LOG.warn("duplicate request for sync channel. channel: {}, request id: {}, txn: {}, table: {}",
-                        id, e.getDuplicatedRequestId(), e.getTxnId(), targetTable);
-                txnExecutor.setTxnId(e.getTxnId());
-            } catch (LabelAlreadyUsedException e) {
-                // this happens when channel re-consume same batch, we should just pass through it without begin a new txn
-                LOG.warn("Label already used in channel {}, label: {}, table: {}, batch: {}", id, label, targetTable, batchId);
-                return;
-            } catch (AnalysisException | BeginTransactionException e) {
-                LOG.warn("encounter an error when beginning txn in channel {}, table: {}", id, targetTable);
-                throw e;
-            } catch (UserException e) {
-                LOG.warn("encounter an error when creating plan in channel {}, table: {}", id, targetTable);
-                throw e;
-            }
-            try {
-                // async exec begin transaction
-                long txnId = txnExecutor.getTxnId();
-                if (txnId != -1L) {
-                    this.txnExecutor.beginTransaction(request);
-                    LOG.info("begin txn in channel {}, table: {}, label:{}, txn id: {}", id, targetTable, label, txnExecutor.getTxnId());
+            DatabaseTransactionMgr databaseTransactionMgr = globalTransactionMgr.getDatabaseTransactionMgr(db.getId());
+            if(databaseTransactionMgr.getRunningTxnNums() < Config.max_running_txn_num_per_db ) {
+                TransactionEntry txnEntry = txnExecutor.getTxnEntry ();
+                TTxnParams txnConf = txnEntry.getTxnConf ();
+                TransactionState.LoadJobSourceType sourceType = TransactionState.LoadJobSourceType.INSERT_STREAMING;
+                TStreamLoadPutRequest request = null;
+                try {
+                    long txnId = globalTransactionMgr.beginTransaction (db.getId (), Lists.newArrayList (tbl.getId ()), label,
+                        new TransactionState.TxnCoordinator (TransactionState.TxnSourceType.FE, FrontendOptions.getLocalHostAddress ()), sourceType, timeoutSecond);
+                    String authCodeUuid = Catalog.getCurrentGlobalTransactionMgr ().getTransactionState (
+                        db.getId (), txnId).getAuthCode ();
+                    request = new TStreamLoadPutRequest ()
+                        .setTxnId (txnId).setDb (txnConf.getDb ()).setTbl (txnConf.getTbl ())
+                        .setFileType (TFileType.FILE_STREAM).setFormatType (TFileFormatType.FORMAT_CSV_PLAIN)
+                        .setThriftRpcTimeoutMs (5000).setLoadId (txnExecutor.getLoadId ())
+                        .setMergeType (TMergeType.MERGE).setDeleteCondition (DELETE_CONDITION)
+                        .setColumns (targetColumn);
+                    txnConf.setTxnId (txnId).setAuthCodeUuid (authCodeUuid);
+                    txnEntry.setLabel (label);
+                    txnExecutor.setTxnId (txnId);
+                } catch ( DuplicatedRequestException e ) {
+                    LOG.warn ("duplicate request for sync channel. channel: {}, request id: {}, txn: {}, table: {}",
+                        id, e.getDuplicatedRequestId (), e.getTxnId (), targetTable);
+                    txnExecutor.setTxnId (e.getTxnId ());
+                } catch ( LabelAlreadyUsedException e ) {
+                    // this happens when channel re-consume same batch, we should just pass through it without begin a new txn
+                    LOG.warn ("Label already used in channel {}, label: {}, table: {}, batch: {}", id, label, targetTable, batchId);
+                    return;
+                } catch ( AnalysisException | BeginTransactionException e ) {
+                    LOG.warn ("encounter an error when beginning txn in channel {}, table: {}", id, targetTable);
+                    throw e;
+                } catch ( UserException e ) {
+                    LOG.warn ("encounter an error when creating plan in channel {}, table: {}", id, targetTable);
+                    throw e;
                 }
-            } catch (TException e) {
-                LOG.warn("Failed to begin txn in channel {}, table: {}, txn: {}, msg:{}", id, targetTable, txnExecutor.getTxnId(), e.getMessage());
-                throw e;
-            } catch (TimeoutException | InterruptedException | ExecutionException e) {
-                LOG.warn("Error occur while waiting begin txn response in channel {}, table: {}, txn: {}, msg:{}",
-                        id, targetTable, txnExecutor.getTxnId(), e.getMessage());
-                throw e;
+                try {
+                    // async exec begin transaction
+                    long txnId = txnExecutor.getTxnId ();
+                    if ( txnId != - 1L ) {
+                        this.txnExecutor.beginTransaction (request);
+                        LOG.info ("begin txn in channel {}, table: {}, label:{}, txn id: {}", id, targetTable, label, txnExecutor.getTxnId ());
+                    }
+                } catch ( TException e ) {
+                    LOG.warn ("Failed to begin txn in channel {}, table: {}, txn: {}, msg:{}", id, targetTable, txnExecutor.getTxnId (), e.getMessage ());
+                    throw e;
+                } catch ( TimeoutException | InterruptedException | ExecutionException e ) {
+                    LOG.warn ("Error occur while waiting begin txn response in channel {}, table: {}, txn: {}, msg:{}",
+                        id, targetTable, txnExecutor.getTxnId (), e.getMessage ());
+                    throw e;
+                }
+            } else {
+                String failMsg = "current running txns on db " + db.getId () + " is "
+                    + databaseTransactionMgr.getRunningTxnNums () + ", larger than limit " + Config.max_running_txn_num_per_db
+                throw new BeginTransactionException(failMsg);
             }
         }
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/load/sync/canal/CanalSyncChannel.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/sync/canal/CanalSyncChannel.java
@@ -124,7 +124,7 @@ public class CanalSyncChannel extends SyncChannel {
             String targetColumn = Joiner.on(",").join(columns) + "," + DELETE_COLUMN;
             GlobalTransactionMgr globalTransactionMgr = Catalog.getCurrentGlobalTransactionMgr();
             DatabaseTransactionMgr databaseTransactionMgr = globalTransactionMgr.getDatabaseTransactionMgr(db.getId());
-            if(databaseTransactionMgr.getRunningTxnNums() < Config.max_running_txn_num_per_db ) {
+            if(databaseTransactionMgr.getRunningTxnNums() < Config.max_running_txn_num_per_db) {
                 TransactionEntry txnEntry = txnExecutor.getTxnEntry ();
                 TTxnParams txnConf = txnEntry.getTxnConf ();
                 TransactionState.LoadJobSourceType sourceType = TransactionState.LoadJobSourceType.INSERT_STREAMING;
@@ -174,8 +174,9 @@ public class CanalSyncChannel extends SyncChannel {
                     throw e;
                 }
             } else {
-                String failMsg = "current running txns on db " + db.getId () + " is "
+                String failMsg = "current running txns on db " + db.getId() + " is "
                     + databaseTransactionMgr.getRunningTxnNums () + ", larger than limit " + Config.max_running_txn_num_per_db;
+                LOG.warn(failMsg);
                 throw new BeginTransactionException(failMsg);
             }
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/load/sync/canal/CanalSyncChannel.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/sync/canal/CanalSyncChannel.java
@@ -175,7 +175,7 @@ public class CanalSyncChannel extends SyncChannel {
                 }
             } else {
                 String failMsg = "current running txns on db " + db.getId () + " is "
-                    + databaseTransactionMgr.getRunningTxnNums () + ", larger than limit " + Config.max_running_txn_num_per_db
+                    + databaseTransactionMgr.getRunningTxnNums () + ", larger than limit " + Config.max_running_txn_num_per_db;
                 throw new BeginTransactionException(failMsg);
             }
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/load/sync/canal/CanalSyncChannel.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/sync/canal/CanalSyncChannel.java
@@ -130,13 +130,13 @@ public class CanalSyncChannel extends SyncChannel {
                 TransactionState.LoadJobSourceType sourceType = TransactionState.LoadJobSourceType.INSERT_STREAMING;
                 TStreamLoadPutRequest request = null;
                 try {
-                    long txnId = globalTransactionMgr.beginTransaction(db.getId (),
+                    long txnId = globalTransactionMgr.beginTransaction(db.getId(),
                         Lists.newArrayList(tbl.getId()), label,
                         new TransactionState.TxnCoordinator(TransactionState.TxnSourceType.FE,
                             FrontendOptions.getLocalHostAddress()), sourceType, timeoutSecond);
                     String authCodeUuid = Catalog.getCurrentGlobalTransactionMgr().getTransactionState(
                         db.getId(), txnId).getAuthCode();
-                    request = new TStreamLoadPutRequest ()
+                    request = new TStreamLoadPutRequest()
                         .setTxnId(txnId).setDb(txnConf.getDb()).setTbl(txnConf.getTbl())
                         .setFileType(TFileType.FILE_STREAM).setFormatType(TFileFormatType.FORMAT_CSV_PLAIN)
                         .setThriftRpcTimeoutMs(5000).setLoadId(txnExecutor.getLoadId())
@@ -145,12 +145,13 @@ public class CanalSyncChannel extends SyncChannel {
                     txnConf.setTxnId(txnId).setAuthCodeUuid(authCodeUuid);
                     txnEntry.setLabel(label);
                     txnExecutor.setTxnId (txnId);
-                } catch (DuplicatedRequestException e ) {
+                } catch (DuplicatedRequestException e) {
                     LOG.warn ("duplicate request for sync channel. channel: {}, request id: {}, txn: {}, table: {}",
                         id, e.getDuplicatedRequestId(), e.getTxnId(), targetTable);
                     txnExecutor.setTxnId(e.getTxnId());
-                } catch (LabelAlreadyUsedException e ) {
-                    // this happens when channel re-consume same batch, we should just pass through it without begin a new txn
+                } catch (LabelAlreadyUsedException e) {
+                    // this happens when channel re-consume same batch,
+                    // we should just pass through it without begin a new txn
                     LOG.warn ("Label already used in channel {}, label: {}, table: {}, batch: {}",
                         id, label, targetTable, batchId);
                     return;
@@ -158,7 +159,7 @@ public class CanalSyncChannel extends SyncChannel {
                     LOG.warn ("encounter an error when beginning txn in channel {}, table: {}",
                         id, targetTable);
                     throw e;
-                } catch (UserException e ) {
+                } catch (UserException e) {
                     LOG.warn ("encounter an error when creating plan in channel {}, table: {}",
                         id, targetTable);
                     throw e;
@@ -169,20 +170,20 @@ public class CanalSyncChannel extends SyncChannel {
                     if ( txnId != - 1L ) {
                         this.txnExecutor.beginTransaction (request);
                         LOG.info ("begin txn in channel {}, table: {}, label:{}, txn id: {}",
-                            id, targetTable, label, txnExecutor.getTxnId ());
+                            id, targetTable, label, txnExecutor.getTxnId());
                     }
-                } catch ( TException e ) {
+                } catch ( TException e) {
                     LOG.warn ("Failed to begin txn in channel {}, table: {}, txn: {}, msg:{}",
-                        id, targetTable, txnExecutor.getTxnId (), e.getMessage ());
+                        id, targetTable, txnExecutor.getTxnId(), e.getMessage());
                     throw e;
-                } catch ( TimeoutException | InterruptedException | ExecutionException e ) {
+                } catch ( TimeoutException | InterruptedException | ExecutionException e) {
                     LOG.warn ("Error occur while waiting begin txn response in channel {}, table: {}, txn: {}, msg:{}",
-                        id, targetTable, txnExecutor.getTxnId (), e.getMessage ());
+                        id, targetTable, txnExecutor.getTxnId(), e.getMessage());
                     throw e;
                 }
             } else {
                 String failMsg = "current running txns on db " + db.getId() + " is "
-                    + databaseTransactionMgr.getRunningTxnNums () + ", larger than limit " + Config.max_running_txn_num_per_db;
+                    + databaseTransactionMgr.getRunningTxnNums() + ", larger than limit " + Config.max_running_txn_num_per_db;
                 LOG.warn(failMsg);
                 throw new BeginTransactionException(failMsg);
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/transaction/DatabaseTransactionMgr.java
@@ -195,7 +195,7 @@ public class DatabaseTransactionMgr {
         return labelToTxnIds.get(label);
     }
 
-    protected int getRunningTxnNums() {
+    public int getRunningTxnNums() {
         return runningTxnNums;
     }
 


### PR DESCRIPTION
# Proposed changes
binlog load Because txn exceeds the default value, resume is a failure, and a friendly prompt message is given to the user, instead of prompting success now, it still fails after a while, and the user will feel inexplicable


Issue Number: close #9468

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
