### PR TITLE
[Bug] (load) Broker load kerberos auth fail

### DIFF
--- a/fs_brokers/apache_hdfs_broker/src/main/java/org/apache/doris/broker/hdfs/FileSystemManager.java
+++ b/fs_brokers/apache_hdfs_broker/src/main/java/org/apache/doris/broker/hdfs/FileSystemManager.java
@@ -45,6 +45,7 @@ import java.net.InetAddress;
 import java.net.URISyntaxException;
 import java.net.UnknownHostException;
 import java.nio.ByteBuffer;
+import java.nio.channels.FileLock;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.PrivilegedExceptionAction;
@@ -288,10 +289,13 @@ public class FileSystemManager {
                         tmpFilePath ="/tmp/." +
                                 principal.replace('/', '_') +
                                 "_" + Long.toString(currentTime) +
-                                "_" + Integer.toString(randNumber);
+                                "_" + Integer.toString(randNumber) +
+                                "_" + Thread.currentThread().getId();
                         logger.info("create kerberos tmp file" + tmpFilePath);
                         FileOutputStream fileOutputStream = new FileOutputStream(tmpFilePath);
+                        FileLock lock = fileOutputStream.getChannel().lock();
                         fileOutputStream.write(base64decodedBytes);
+                        lock.release();
                         fileOutputStream.close();
                         keytab = tmpFilePath;
                     } else {


### PR DESCRIPTION
# Proposed changes

Issue Number: close #9461

## Problem Summary:

Change the temperary kerberos file name and add file lock.

## Checklist(Required)

1. Does it affect the original behavior: (No)
2. Has unit tests been added: (No Need)
3. Has document been added or modified: (No Need)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (No)

## Further comments

