### PR TITLE
[fix](storage) fix core for string predicate in storage layer

### DIFF
--- a/be/src/vec/columns/predicate_column.h
+++ b/be/src/vec/columns/predicate_column.h
@@ -238,7 +238,7 @@ public:
             for (size_t i = 0; i < num; i++) {
                 total_mem_size += len_array[i];
             }
-            
+
             char* destination = (char*)_pool->allocate(total_mem_size);
             for (size_t i = 0; i < num; i++) {
                 uint32_t len = len_array[i];
@@ -253,8 +253,8 @@ public:
 
     void insert_default() override { data.push_back(T()); }
 
-    void clear() override { 
-        data.clear(); 
+    void clear() override {
+        data.clear();
         if (_pool != nullptr) {
             _pool->clear();
         }

--- a/be/src/vec/columns/predicate_column.h
+++ b/be/src/vec/columns/predicate_column.h
@@ -230,9 +230,8 @@ public:
     void insert_many_binary_data(char* data_array, uint32_t* len_array,
                                  uint32_t* start_offset_array, size_t num) override {
         if constexpr (std::is_same_v<T, StringValue>) {
-            if (!_is_mem_pool_inited) {
+            if (_pool == nullptr) {
                 _pool.reset(new MemPool("PredicateStringColumn"));
-                _is_mem_pool_inited = true;
             }
 
             size_t total_mem_size = 0;
@@ -256,7 +255,7 @@ public:
 
     void clear() override { 
         data.clear(); 
-        if (_is_mem_pool_inited) {
+        if (_pool != nullptr) {
             _pool->clear();
         }
     }
@@ -431,7 +430,6 @@ private:
     Container data;
     // manages the memory for slice's data(For string type)
     std::unique_ptr<MemPool> _pool;
-    bool _is_mem_pool_inited = false;;
 };
 using ColumnStringValue = PredicateColumnType<StringValue>;
 


### PR DESCRIPTION
# Proposed changes

Currently, for string read from plain page, we hold ptr from page to avoid memcpy.
But if page is released, the ptr from page is invalid, core dump happens.
So for string from plain page, memcpy is neccessary.

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
