### PR TITLE
[bugfix](load) bitshuffle_page return ok when remaining element not e…

### DIFF
--- a/be/src/olap/rowset/segment_v2/bitshuffle_page.h
+++ b/be/src/olap/rowset/segment_v2/bitshuffle_page.h
@@ -103,11 +103,11 @@ public:
     template <bool single>
     inline Status add_internal(const uint8_t* vals, size_t* count) {
         DCHECK(!_finished);
-        if (_remain_element_capacity <= 0) {
-            *count = 0;
-            return Status::RuntimeError("page is full.");
-        }
         int to_add = std::min<int>(_remain_element_capacity, *count);
+        if (to_add == 0) {
+            *count = 0;
+            return Status::OK();
+        }
         int to_add_size = to_add * SIZE_OF_TYPE;
         size_t orig_size = _data.size();
         _data.resize(orig_size + to_add_size);


### PR DESCRIPTION
…nough to enable column writer write new page

# Proposed changes

Issue Number: close #xxx

## Problem Summary:

page write return error, colomn writer will not change to next_page， be will core when flush mem_table cause this column data is null

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
