### PR TITLE
[bugfix](load) fix coredump in ordinal index flush

### DIFF
--- a/be/src/olap/rowset/segment_v2/binary_dict_page.cpp
+++ b/be/src/olap/rowset/segment_v2/binary_dict_page.cpp
@@ -75,13 +75,13 @@ Status BinaryDictPageBuilder::add(const uint8_t* vals, size_t* count) {
         }
 
         for (int i = 0; i < *count; ++i, ++src) {
+            if (is_page_full()) {
+                break;
+            }
             auto iter = _dictionary.find(*src);
             if (iter != _dictionary.end()) {
                 value_code = iter->second;
             } else {
-                if (_dict_builder->is_page_full()) {
-                    break;
-                }
                 Slice dict_item(src->data, src->size);
                 if (src->size > 0) {
                     char* item_mem = (char*)_pool.allocate(src->size);

--- a/be/src/olap/rowset/segment_v2/bitshuffle_page.h
+++ b/be/src/olap/rowset/segment_v2/bitshuffle_page.h
@@ -105,7 +105,7 @@ public:
         DCHECK(!_finished);
         if (_remain_element_capacity <= 0) {
             *count = 0;
-            return Status::RuntimeError("page is full.");
+            return Status::OK();
         }
         int to_add = std::min<int>(_remain_element_capacity, *count);
         int to_add_size = to_add * SIZE_OF_TYPE;

--- a/be/src/olap/rowset/segment_v2/page_builder.h
+++ b/be/src/olap/rowset/segment_v2/page_builder.h
@@ -49,7 +49,9 @@ public:
     // Add a sequence of values to the page.
     // The number of values actually added will be returned through count, which may be less
     // than requested if the page is full.
-    //
+
+    // check page if full before truly add, return ok when page is full so that column write
+    // will switch to next page
     // vals size should be decided according to the page build type
     // TODO make sure vals is naturally-aligned to its type so that impls can use aligned load
     // instead of memcpy to copy values.


### PR DESCRIPTION
commit #9123 introduce the bug. bitshuffle page return error when
page is full, so scalar column write cannot switch to next page, which make
ordinal index is null when flush.

All page builder should return ok when page full, and column writer procedure
shoud be append_data, check is_page_full, switch to next page

# Proposed changes

Issue Number: close #xxx

## Problem Summary:
ScalarColumn write cannot switch to next page cause page builder return false when page full

coredump is here:
    @     0x556a329945f9  google::LogMessageFatal::~LogMessageFatal()
    @     0x556a329945f9  google::LogMessageFatal::~LogMessageFatal()
    @     0x556a316d7677  doris::segment_v2::OrdinalIndexWriter::finish()
    @     0x556a309d6809  doris::FlushToken::_flush_memtable()
    @     0x556a309d6809  doris::FlushToken::_flush_memtable()
    @     0x556a316d7677  doris::segment_v2::OrdinalIndexWriter::finish()
    @     0x556a309d7590  std::_Function_handler<>::_M_invoke()
    @     0x556a309d7590  std::_Function_handler<>::_M_invoke()
    @     0x556a316d0c8e  doris::segment_v2::ScalarColumnWriter::write_ordinal_index()
    @     0x556a316d0c8e  doris::segment_v2::ScalarColumnWriter::write_ordinal_index()
    @     0x556a30d7cacd  doris::ThreadPool::dispatch_thread()
    @     0x556a30d7cacd  doris::ThreadPool::dispatch_thread()
    @     0x556a316724b5  doris::segment_v2::SegmentWriter::finalize()
    @     0x556a30d7733f  doris::Thread::supervise_thread()
    @     0x556a30d7733f  doris::Thread::supervise_thread()
    @     0x556a316724b5  doris::segment_v2::SegmentWriter::finalize()

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
