### PR TITLE
[improvement][performance] improve lru cache resize performance and memory usage

### DIFF
--- a/be/src/olap/lru_cache.h
+++ b/be/src/olap/lru_cache.h
@@ -227,7 +227,6 @@ typedef struct LRUHandle {
     void* value;
     void (*deleter)(const CacheKey&, void* value);
     LRUHandle* next_hash = nullptr; // next entry in hash table
-    LRUHandle* prev_hash = nullptr; // previous entry in hash table
     LRUHandle* next = nullptr;      // next entry in lru list
     LRUHandle* prev = nullptr;      // previous entry in lru list
     size_t charge;
@@ -277,7 +276,8 @@ public:
 
     // Remove element from hash table by "h", it would be faster
     // than the function above.
-    void remove(const LRUHandle* h);
+    // Return whether h is found and removed.
+    bool remove(const LRUHandle* h);
 
 private:
     FRIEND_TEST(CacheTest, HandleTableTest);
@@ -292,9 +292,6 @@ private:
     // matches key/hash.  If there is no such cache entry, return a
     // pointer to the trailing slot in the corresponding linked list.
     LRUHandle** _find_pointer(const CacheKey& key, uint32_t hash);
-
-    // Insert "handle" after "head".
-    void _head_insert(LRUHandle* head, LRUHandle* handle);
 
     void _resize();
 };


### PR DESCRIPTION
# Proposed changes

## Problem Summary:

Previously we use doubly linked list for LRUCache's HandleTable, in order to support a lookup-free `remove(const LRUHandle* h)` function. However it 1) slows down the resize operation because we need to malloc/free the dummy LRUHandle node for each bucket 2) increases the overall memory usage.

It turns out that we can achieve fast `remove(const LRUHandle* h)` using just singly linked list.

## Checklist(Required)

1. Does it affect the original behavior: (No)
2. Has unit tests been added: (Yes)
3. Has document been added or modified: (No Need)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
