### PR TITLE
[Fix](Lateral View) Error view includes lateral view

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/InlineViewRef.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/InlineViewRef.java
@@ -440,26 +440,21 @@ public class InlineViewRef extends TableRef {
     }
 
     @Override
-    public String tableRefToSql() {
+    public String tableNameToSql() {
         // Enclose the alias in quotes if Hive cannot parse it without quotes.
         // This is needed for view compatibility between Impala and Hive.
-        String aliasSql = null;
-        String alias = getExplicitAlias();
-        if (alias != null) {
-            aliasSql = ToSqlUtils.getIdentSql(alias);
-        }
-
         if (view != null) {
             // FIXME: this may result in a sql cache problem
             // See pr #6736 and issue #6735
-            return name.toSql() + (aliasSql == null ? "" : " " + aliasSql);
+            return super.tableNameToSql();
         }
 
+        String aliasSql = null;
+        String alias = getExplicitAlias();
+        if (alias != null) aliasSql = ToSqlUtils.getIdentSql(alias);
         StringBuilder sb = new StringBuilder();
-        sb.append("(")
-                .append(queryStmt.toSql())
-                .append(") ")
-                .append(aliasSql);
+        sb.append("(").append(queryStmt.toSql()).append(") ")
+            .append(aliasSql);
 
         return sb.toString();
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/InlineViewRef.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/InlineViewRef.java
@@ -451,7 +451,9 @@ public class InlineViewRef extends TableRef {
 
         String aliasSql = null;
         String alias = getExplicitAlias();
-        if (alias != null) aliasSql = ToSqlUtils.getIdentSql(alias);
+        if (alias != null) {
+            aliasSql = ToSqlUtils.getIdentSql(alias);
+        }
         StringBuilder sb = new StringBuilder();
         sb.append("(").append(queryStmt.toSql()).append(") ")
             .append(aliasSql);

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/QueryStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/QueryStmt.java
@@ -206,8 +206,7 @@ public abstract class QueryStmt extends StatementBase {
      * (3) a mix of correlated table refs and table refs rooted at those refs
      *     (the statement is 'self-contained' with respect to correlation)
      */
-    public List<TupleId> getCorrelatedTupleIds(Analyzer analyzer)
-        throws AnalysisException {
+    public List<TupleId> getCorrelatedTupleIds(Analyzer analyzer) throws AnalysisException {
         // Correlated tuple ids of this stmt.
         List<TupleId> correlatedTupleIds = Lists.newArrayList();
         // First correlated and absolute table refs. Used for error detection/reporting.

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/QueryStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/QueryStmt.java
@@ -207,7 +207,7 @@ public abstract class QueryStmt extends StatementBase {
      *     (the statement is 'self-contained' with respect to correlation)
      */
     public List<TupleId> getCorrelatedTupleIds(Analyzer analyzer)
-            throws AnalysisException {
+        throws AnalysisException {
         // Correlated tuple ids of this stmt.
         List<TupleId> correlatedTupleIds = Lists.newArrayList();
         // First correlated and absolute table refs. Used for error detection/reporting.

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/TableRef.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/TableRef.java
@@ -627,25 +627,25 @@ public class TableRef implements ParseNode, Writable {
     /**
      * Return the table ref presentation to be used in the toSql string
      */
+    // tbl1
+    // tbl1 alias_tbl1
+    // tbl1 alias_tbl1 lateral view explode_split(k1, ",") tmp1 as e1
+    // (select xxx from xxx) t1 alias_tbl1 xxx
     public String tableRefToSql() {
-        String aliasSql = null;
-        String alias = getExplicitAlias();
-        if (alias != null) aliasSql = ToSqlUtils.getIdentSql(alias);
-
-        // TODO(zc):
-        // List<String> path = rawPath_;
-        // if (resolvedPath_ != null) path = resolvedPath_.getFullyQualifiedRawPath();
-        // return ToSqlUtils.getPathSql(path) + ((aliasSql != null) ? " " + aliasSql : "");
-
-        // tbl1
-        // tbl1 alias_tbl1
-        // tbl1 alias_tbl1 lateral view explode_split(k1, ",") tmp1 as e1
-        String tblName = name.toSql() + ((aliasSql != null) ? " " + aliasSql : "");
+        String tblName = tableNameToSql();
         if (lateralViewRefs != null) {
             for (LateralViewRef viewRef : lateralViewRefs) {
                 tblName += " " + viewRef.toSql();
             }
         }
+        return tblName;
+    }
+
+    protected String tableNameToSql() {
+        String aliasSql = null;
+        String alias = getExplicitAlias();
+        if (alias != null) aliasSql = ToSqlUtils.getIdentSql(alias);
+        String tblName = name.toSql() + ((aliasSql != null) ? " " + aliasSql : "");
         return tblName;
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/TableRef.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/TableRef.java
@@ -35,7 +35,6 @@ import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
-
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -644,7 +643,9 @@ public class TableRef implements ParseNode, Writable {
     protected String tableNameToSql() {
         String aliasSql = null;
         String alias = getExplicitAlias();
-        if (alias != null) aliasSql = ToSqlUtils.getIdentSql(alias);
+        if (alias != null) {
+            aliasSql = ToSqlUtils.getIdentSql(alias);
+        }
         String tblName = name.toSql() + ((aliasSql != null) ? " " + aliasSql : "");
         return tblName;
     }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #9529

## Problem Summary:

Fixed #9529

When the lateral view based on a inline view which belongs to a view,
Doris could not resolve the column of lateral view in query.
When a query uses a view, it mainly refers to the string representation of the view.
That is, if the view's string representation is wrong, the view is wrong.
The string representation of the inline view lacks the handling of the lateral view.
This leads to query errors when using such views.
This PR mainly fixes the string representation of inline views.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
