### PR TITLE
[improvement](load) reduce useless err_msg format in VOlapTableSink send

### DIFF
--- a/be/src/vec/sink/vtablet_sink.cpp
+++ b/be/src/vec/sink/vtablet_sink.cpp
@@ -491,26 +491,25 @@ Status VOlapTableSink::_validate_data(RuntimeState* state, vectorized::Block* bl
                 if (!filter_bitmap->Get(j)) {
                     auto str_val = column_string->get_data_at(j);
                     bool invalid = str_val.size > limit;
-
-                    error_msg.clear();
-                    if (str_val.size > desc->type().len) {
-                        fmt::format_to(error_msg, "{}",
-                                       "the length of input is too long than schema. ");
-                        fmt::format_to(error_msg, "column_name: {}; ", desc->col_name());
-                        fmt::format_to(error_msg, "input str: [{}] ", str_val.to_prefix(10));
-                        fmt::format_to(error_msg, "schema length: {}; ", desc->type().len);
-                        fmt::format_to(error_msg, "actual length: {}; ", str_val.size);
-                    } else if (str_val.size > limit) {
-                        fmt::format_to(error_msg, "{}",
-                                       "the length of input string is too long than vec schema. ");
-                        fmt::format_to(error_msg, "column_name: {}; ", desc->col_name());
-                        fmt::format_to(error_msg, "input str: [{}] ", str_val.to_prefix(10));
-                        fmt::format_to(error_msg, "schema length: {}; ", desc->type().len);
-                        fmt::format_to(error_msg, "limit length: {}; ", limit);
-                        fmt::format_to(error_msg, "actual length: {}; ", str_val.size);
-                    }
-
                     if (invalid) {
+                        error_msg.clear();
+                        if (str_val.size > desc->type().len) {
+                            fmt::format_to(error_msg, "{}",
+                                           "the length of input is too long than schema. ");
+                            fmt::format_to(error_msg, "column_name: {}; ", desc->col_name());
+                            fmt::format_to(error_msg, "input str: [{}] ", str_val.to_prefix(10));
+                            fmt::format_to(error_msg, "schema length: {}; ", desc->type().len);
+                            fmt::format_to(error_msg, "actual length: {}; ", str_val.size);
+                        } else if (str_val.size > limit) {
+                            fmt::format_to(
+                                    error_msg, "{}",
+                                    "the length of input string is too long than vec schema. ");
+                            fmt::format_to(error_msg, "column_name: {}; ", desc->col_name());
+                            fmt::format_to(error_msg, "input str: [{}] ", str_val.to_prefix(10));
+                            fmt::format_to(error_msg, "schema length: {}; ", desc->type().len);
+                            fmt::format_to(error_msg, "limit length: {}; ", limit);
+                            fmt::format_to(error_msg, "actual length: {}; ", str_val.size);
+                        }
                         RETURN_IF_ERROR(set_invalid_and_append_error_msg(j));
                     }
                 }
@@ -568,10 +567,10 @@ Status VOlapTableSink::_validate_data(RuntimeState* state, vectorized::Block* bl
         if ((!desc->is_nullable() || desc->type() == TYPE_OBJECT) && column_ptr) {
             const auto& null_map = column_ptr->get_null_map_data();
             for (int j = 0; j < null_map.size(); ++j) {
-                fmt::format_to(error_msg,
-                               "null value for not null column/or bitmap column, column={}; ",
-                               desc->col_name());
                 if (null_map[j] && !filter_bitmap->Get(j)) {
+                    error_msg.clear();
+                    fmt::format_to(error_msg, "null value for not null column, column={}; ",
+                                   desc->col_name());
                     RETURN_IF_ERROR(set_invalid_and_append_error_msg(j));
                 }
             }


### PR DESCRIPTION
error msg format but not used, waste a lot of cpu in fragment thread
in some case of load, just format it when needed

# Proposed changes

Issue Number: close #xxx

## Problem Summary:
improve olap tablet sink by reduce useless string format, thread perf below:

![utMxXfXd8q](https://user-images.githubusercontent.com/102007456/168084036-9be16d02-72dd-42a0-8bd1-8d0eebff8d08.png)


Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
