### PR TITLE
[bugfix]Clean the version.sh file before build, otherwise the version informa…

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -266,6 +266,7 @@ FE_MODULES=$(IFS=, ; echo "${modules[*]}")
 
 # Clean and build Backend
 if [ ${BUILD_BE} -eq 1 ] ; then
+    if [ -e ${DORIS_HOME}/gensrc/build/gen_cpp/version.h ]; then rm -f ${DORIS_HOME}/gensrc/build/gen_cpp/version.h ; fi
     CMAKE_BUILD_TYPE=${BUILD_TYPE:-Release}
     echo "Build Backend: ${CMAKE_BUILD_TYPE}"
     CMAKE_BUILD_DIR=${DORIS_HOME}/be/build_${CMAKE_BUILD_TYPE}


### PR DESCRIPTION

## Problem Summary:

During the testing process, it was found that the recompiled version information of the be was not updated, which made it easy to make mistakes when comparing the version performance during the development and testing process.

It has been modified simply, and there may be a better way to modify it.

## Checklist(Required)

1. Does it affect the original behavior: (No)
2. Has unit tests been added: (No)
3. Has document been added or modified: (No)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (No)

