### PR TITLE
[Fix](migrate) ignore unnecessary error printing

### DIFF
--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -996,7 +996,8 @@ Status TaskWorkerPool::_check_migrate_request(const TStorageMediumMigrateReq& re
         if (src_storage_medium == storage_medium) {
             LOG(INFO) << "tablet is already on specified storage medium. "
                       << "storage_medium=" << storage_medium;
-            return Status::OLAPInternalError(OLAP_REQUEST_FAILED);
+            // it's ok to fe, and ignore unnecessary error printing
+            return Status::OK();
         }
         // get a random store of specified storage medium
         auto stores = StorageEngine::instance()->get_stores_for_create_tablet(storage_medium);
@@ -1010,7 +1011,7 @@ Status TaskWorkerPool::_check_migrate_request(const TStorageMediumMigrateReq& re
     if (tablet->data_dir()->path() == (*dest_store)->path()) {
         LOG(INFO) << "tablet is already on specified path. "
                   << "path=" << tablet->data_dir()->path();
-        // it's ok to ignore unnecessary error printing
+        // it's ok to fe, and ignore unnecessary error printing
         return Status::OK();
     }
 

--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -1010,7 +1010,8 @@ Status TaskWorkerPool::_check_migrate_request(const TStorageMediumMigrateReq& re
     if (tablet->data_dir()->path() == (*dest_store)->path()) {
         LOG(INFO) << "tablet is already on specified path. "
                   << "path=" << tablet->data_dir()->path();
-        return Status::OLAPInternalError(OLAP_REQUEST_FAILED);
+        // it's ok to ignore unnecessary error printing
+        return Status::OK();
     }
 
     // check disk capacity


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

W0513 14:47:57.078735 16965 status.h:514] warning: Status msg truncated, Internal error:  precise_code:-2  0# doris::Status::ConstructErrorStatus(short, doris::Slice const&) at /home/disk4/yintao03/baidu/bdg/doris/core/be/src/common/status.cpp:81
 1# doris::Status::OLAPInternalError(short) at /home/disk4/yintao03/baidu/bdg/doris/core/be/src/common/status.h:385
 2# doris::TaskWorkerPool::_check_migrate_request(doris::TStorageMediumMigrateReq const&, std::shared_ptr<doris::Tablet>&, doris::DataDir**) at /home/disk4/yintao03/baidu/bdg/doris/core/be/src/agent/task_worker_pool.cpp:1013
 3# doris::TaskWorkerPool::_storage_medium_migrate_worker_thread_callback() at /home/disk4/yintao03/baidu/bdg/doris/core/be/src/agent/task_worker_pool.cpp:935
 4# void std::__invoke_impl<void, void (doris::TaskWorkerPool::*&)(), doris::TaskWorkerPool*&>(std::__invoke_memfun_deref, void (doris::TaskWorkerPool::*&)(), doris::TaskWorkerPool*&) at /home/disk4/yintao03/baidu/bdg/doris/palo-toolchain/ldb_toolchain/include/c++/11/bits/invoke.h:74
 5# std::enable_if<is_invocable_r_v<void, void (doris::TaskWorkerPool::*&)(), doris::TaskWorkerPool*&>, void>::type std::__invoke_r<void, void (doris::TaskWorkerPool::*&)(), doris::TaskWorkerPool*&>(void (doris::TaskWorkerPool::*&)(), doris::TaskWorkerPool*&) at /home/disk4/yintao03/baidu/bdg/doris/palo-toolchain/ldb_toolchain/include/c++/11/bits/invoke.h:117
 6# void std::_Bind_result<void, void (doris::TaskWorkerPool::*(doris::TaskWorkerPool*))()>::__call<void, , 0ul>(std::tuple<>&&, std::_Index_tuple<0ul>) at /home/disk4/yintao03/baidu/bdg/doris/palo-toolchain/ldb_toolchain/include/c++/11/functional:571
 7# void std::_Bind_result<void, void (doris::TaskWorkerPool::*(doris::TaskWorkerPool*))()>::operator()<>() at /home/disk4/yintao03/baidu/bdg/doris/palo-toolchain/ldb_toolchain/include/c++/11/functional:631
 8# void std::__invoke_impl<void, std::_Bind_result<void, void (doris::TaskWorkerPool::*(doris::TaskWorkerPool*))()>&>(std::__invoke_other, std::_Bind_result<void, void (doris::TaskWorkerPool::*(doris::TaskWorkerPool*))()>&) at /home/disk4/yintao03/baidu/bdg/doris/palo-toolchain/ldb_toolchain/include/c++/11/bits/invoke.h:61

## Checklist(Required)

1. Does it affect the original behavior: (No)
2. Has unit tests been added: (No Need)
3. Has document been added or modified: (No Need)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
