### PR TITLE
[vec](load) fix core of segment_writer while it is not thread-safe

### DIFF
--- a/be/src/olap/memtable.cpp
+++ b/be/src/olap/memtable.cpp
@@ -302,9 +302,11 @@ Status MemTable::_do_flush(int64_t& duration_ns) {
         }
     } else {
         vectorized::Block block = _collect_vskiplist_results();
-        RETURN_NOT_OK(_rowset_writer->add_block(&block));
+        // beta rowset flush parallel, segment write add block is not
+        // thread safe, so use tmp variable segment_write instead of
+        // member variable
+        RETURN_NOT_OK(_rowset_writer->flush_single_memtable(&block));
         _flush_size = block.allocated_bytes();
-        RETURN_NOT_OK(_rowset_writer->flush());
     }
     return Status::OK();
 }

--- a/be/src/olap/rowset/beta_rowset_writer.h
+++ b/be/src/olap/rowset/beta_rowset_writer.h
@@ -57,6 +57,7 @@ public:
 
     // Return the file size flushed to disk in "flush_size"
     Status flush_single_memtable(MemTable* memtable, int64_t* flush_size) override;
+    Status flush_single_memtable(const vectorized::Block* block) override;
 
     RowsetSharedPtr build() override;
 
@@ -71,6 +72,8 @@ public:
 private:
     template <typename RowType>
     Status _add_row(const RowType& row);
+    Status _add_block(const vectorized::Block* block,
+                      std::unique_ptr<segment_v2::SegmentWriter>* writer);
 
     Status _create_segment_writer(std::unique_ptr<segment_v2::SegmentWriter>* writer);
 

--- a/be/src/olap/rowset/rowset_writer.h
+++ b/be/src/olap/rowset/rowset_writer.h
@@ -64,6 +64,9 @@ public:
     virtual Status flush_single_memtable(MemTable* memtable, int64_t* flush_size) {
         return Status::OLAPInternalError(OLAP_ERR_FUNC_NOT_IMPLEMENTED);
     }
+    virtual Status flush_single_memtable(const vectorized::Block* block) {
+        return Status::OLAPInternalError(OLAP_ERR_FUNC_NOT_IMPLEMENTED);
+    }
 
     // finish building and return pointer to the built rowset (guaranteed to be inited).
     // return nullptr when failed


### PR DESCRIPTION
introduce in stream-load-vec #9280, it will bring multi-thread
operate to same segment_write cause BetaRowset enable multi-thread
of memtable flush, memtable flush call rowset_writer.add_block, it
use member variable _segment_writer to write, so it will cause
multi-thread in segment write.

# Proposed changes

Issue Number: close #xxx

## Problem Summary:

Multi-thread of SegmentWriter will introduce a lot of problems, one of them is
that ColumnWriter append_data goes to dead loop, and stream load hangs in 
wait channel close。stack is shown below:
#0  futex_wait_cancelable (private=<optimized out>, expected=0, futex_word=0x55d955416e54) at ../sysdeps/nptl/
futex-internal.h:183
#1  __pthread_cond_wait_common (abstime=0x0, clockid=0, mutex=0x55d944b2dc38, cond=0x55d955416e28) at pthread_
cond_wait.c:508
#2  __pthread_cond_wait (cond=0x55d955416e28, mutex=0x55d944b2dc38) at pthread_cond_wait.c:638
#3  0x000055d940a133fc in std::condition_variable::wait(std::unique_lock<std::mutex>&) ()
#4  0x000055d93cdb3b6b in doris::ThreadPoolToken::wait (this=0x55d955416dc0) at /mnt/data1/yixiu/selectdb/be/s
rc/util/threadpool.cpp:164
#5  0x000055d93ca14ef8 in doris::FlushToken::wait (this=0x55da8af64580) at /root/doris_env/ldb_toolchain/inclu
de/c++/11/bits/unique_ptr.h:421
#6  0x000055d93d67d81e in doris::DeltaWriter::close_wait (this=0x55d9e06dc7e0, tablet_vec=tablet_vec@entry=0x5
5da00c7f588, tablet_errors=tablet_errors@entry=0x55da00c7f5a0, is_broken=<optimized out>) at /root/doris_env/l
db_toolchain/include/c++/11/bits/unique_ptr.h:421
#7  0x000055d93cc430c9 in doris::TabletsChannel::close (this=0x55dacacf7400, sender_id=<optimized out>, backen
d_id=<optimized out>, finished=finished@entry=0x7f7620ef2bdf, partition_ids=..., tablet_vec=0x55da00c7f588, ta
blet_errors=0x55da00c7f5a0) at /root/doris_env/ldb_toolchain/include/c++/11/bits/hashtable_policy.h:337
#8  0x000055d93ccf449f in doris::LoadChannel::_handle_eos<doris::PTabletWriterAddBlockRequest, doris::PTabletW
riterAddBlockResult> (response=0x55da00c7f570, request=..., channel=..., this=0x55da3a611d00) at /mnt/data1/yi
xiu/selectdb/gensrc/build/gen_cpp/internal_service.pb.h:14430
#9  doris::LoadChannel::add_batch<doris::PTabletWriterAddBlockRequest, doris::PTabletWriterAddBlockResult> (this=this@entry=0x55da3a611d00, request=..., response=response@entry=0x55da00c7f570) at /mnt/data1/yixiu/selectdb/be/src/runtime/load_channel.h:157

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
