### PR TITLE
[Enhancement] [Memory] [Vectorized] Stress test and optimize memory allocation

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -426,10 +426,14 @@ CONF_Bool(disable_mem_pools, "false");
 // to a relative large number or the performance is very very bad.
 CONF_Bool(use_mmap_allocate_chunk, "false");
 
-// Chunk Allocator's reserved bytes limit,
-// Default value is 2GB, increase this variable can improve performance, but will
-// acquire more free memory which can not be used by other modules
-CONF_Int64(chunk_reserved_bytes_limit, "2147483648");
+// The reserved bytes limit of Chunk Allocator, usually set as a percentage of mem_limit.
+// defaults to bytes if no unit is given, the number of bytes must be a multiple of 2.
+// must larger than 0. and if larger than physical memory size, it will be set to physical memory size.
+// increase this variable can improve performance,
+// but will acquire more free memory which can not be used by other modules.
+CONF_mString(chunk_reserved_bytes_limit, "20%");
+// 1024, The minimum chunk allocator size (in bytes)
+CONF_Int32(min_chunk_reserved_bytes, "1024");
 
 // The probing algorithm of partitioned hash table.
 // Enable quadratic probing hash table

--- a/be/src/common/daemon.cpp
+++ b/be/src/common/daemon.cpp
@@ -267,8 +267,6 @@ void Daemon::init(int argc, char** argv, const std::vector<StorePath>& paths) {
 
     init_doris_metrics(paths);
     init_signals();
-
-    ChunkAllocator::init_instance(config::chunk_reserved_bytes_limit);
 }
 
 void Daemon::start() {

--- a/be/src/runtime/memory/chunk_allocator.cpp
+++ b/be/src/runtime/memory/chunk_allocator.cpp
@@ -42,6 +42,7 @@ DEFINE_COUNTER_METRIC_PROTOTYPE_2ARG(chunk_pool_system_alloc_count, MetricUnit::
 DEFINE_COUNTER_METRIC_PROTOTYPE_2ARG(chunk_pool_system_free_count, MetricUnit::NOUNIT);
 DEFINE_COUNTER_METRIC_PROTOTYPE_2ARG(chunk_pool_system_alloc_cost_ns, MetricUnit::NANOSECONDS);
 DEFINE_COUNTER_METRIC_PROTOTYPE_2ARG(chunk_pool_system_free_cost_ns, MetricUnit::NANOSECONDS);
+DEFINE_GAUGE_METRIC_PROTOTYPE_2ARG(chunk_pool_reserved_bytes, MetricUnit::NOUNIT);
 
 static IntCounter* chunk_pool_local_core_alloc_count;
 static IntCounter* chunk_pool_other_core_alloc_count;
@@ -49,6 +50,7 @@ static IntCounter* chunk_pool_system_alloc_count;
 static IntCounter* chunk_pool_system_free_count;
 static IntCounter* chunk_pool_system_alloc_cost_ns;
 static IntCounter* chunk_pool_system_free_cost_ns;
+static IntGauge* chunk_pool_reserved_bytes;
 
 #ifdef BE_TEST
 static std::mutex s_mutex;
@@ -115,6 +117,7 @@ void ChunkAllocator::init_instance(size_t reserve_limit) {
 
 ChunkAllocator::ChunkAllocator(size_t reserve_limit)
         : _reserve_bytes_limit(reserve_limit),
+          _steal_arena_limit(reserve_limit * 0.1),
           _reserved_bytes(0),
           _arenas(CpuInfo::get_max_num_cores()) {
     _mem_tracker =
@@ -132,6 +135,7 @@ ChunkAllocator::ChunkAllocator(size_t reserve_limit)
     INT_COUNTER_METRIC_REGISTER(_chunk_allocator_metric_entity, chunk_pool_system_free_count);
     INT_COUNTER_METRIC_REGISTER(_chunk_allocator_metric_entity, chunk_pool_system_alloc_cost_ns);
     INT_COUNTER_METRIC_REGISTER(_chunk_allocator_metric_entity, chunk_pool_system_free_cost_ns);
+    INT_GAUGE_METRIC_REGISTER(_chunk_allocator_metric_entity, chunk_pool_reserved_bytes);
 }
 
 Status ChunkAllocator::allocate(size_t size, Chunk* chunk, MemTracker* tracker, bool check_limits) {
@@ -158,8 +162,11 @@ Status ChunkAllocator::allocate(size_t size, Chunk* chunk, MemTracker* tracker, 
         chunk_pool_local_core_alloc_count->increment(1);
         return Status::OK();
     }
-    if (_reserved_bytes > size) {
-        // try to allocate from other core's arena
+    // Second path: try to allocate from other core's arena
+    // When the reserved bytes is greater than the limit, the chunk is stolen from other arena.
+    // Otherwise, it is allocated from the system first, which can reserve enough memory as soon as possible.
+    // After that, allocate from current core arena as much as possible.
+    if (_reserved_bytes > _steal_arena_limit) {
         ++core_id;
         for (int i = 1; i < _arenas.size(); ++i, ++core_id) {
             if (_arenas[core_id % _arenas.size()]->pop_free_chunk(size, &chunk->data)) {
@@ -192,6 +199,7 @@ Status ChunkAllocator::allocate(size_t size, Chunk* chunk, MemTracker* tracker, 
 
 void ChunkAllocator::free(const Chunk& chunk, MemTracker* tracker) {
     // The chunk's memory ownership is transferred from tls tracker to ChunkAllocator.
+    DCHECK(chunk.core_id != -1);
     if (tracker) {
         tracker->transfer_to(_mem_tracker.get(), chunk.size);
     } else {
@@ -199,9 +207,6 @@ void ChunkAllocator::free(const Chunk& chunk, MemTracker* tracker) {
                                                                        chunk.size);
     }
     SCOPED_SWITCH_THREAD_LOCAL_MEM_TRACKER(_mem_tracker);
-    if (chunk.core_id == -1) {
-        return;
-    }
     int64_t old_reserved_bytes = _reserved_bytes;
     int64_t new_reserved_bytes = 0;
     do {
@@ -219,12 +224,29 @@ void ChunkAllocator::free(const Chunk& chunk, MemTracker* tracker) {
         }
     } while (!_reserved_bytes.compare_exchange_weak(old_reserved_bytes, new_reserved_bytes));
 
+    // The memory size of allocate/free is a multiple of 2, so `_reserved_bytes% 100 == 32`
+    // will definitely happen, and the latest `_reserved_bytes` value will be set every time.
+    // The real-time and accurate `_reserved_bytes` value is not required. Usually,
+    // the value of `_reserved_bytes` is equal to ChunkAllocator MemTracker.
+    // The `_reserved_bytes` metric is only concerned when verifying the accuracy of MemTracker.
+    // Therefore, reduce the number of sets and reduce the performance impact.
+    if (_reserved_bytes % 100 == 32) {
+        chunk_pool_reserved_bytes->set_value(_reserved_bytes);
+    }
     _arenas[chunk.core_id]->push_free_chunk(chunk.data, chunk.size);
 }
 
 Status ChunkAllocator::allocate_align(size_t size, Chunk* chunk, MemTracker* tracker,
                                       bool check_limits) {
     return allocate(BitUtil::RoundUpToPowerOfTwo(size), chunk, tracker, check_limits);
+}
+
+void ChunkAllocator::free_as_chunk(uint8_t* data, size_t size, MemTracker* tracker) {
+    Chunk chunk;
+    chunk.data = data;
+    chunk.size = size;
+    chunk.core_id = CpuInfo::get_current_core();
+    free(chunk, tracker);
 }
 
 } // namespace doris

--- a/be/src/runtime/memory/chunk_allocator.cpp
+++ b/be/src/runtime/memory/chunk_allocator.cpp
@@ -241,7 +241,7 @@ Status ChunkAllocator::allocate_align(size_t size, Chunk* chunk, MemTracker* tra
     return allocate(BitUtil::RoundUpToPowerOfTwo(size), chunk, tracker, check_limits);
 }
 
-void ChunkAllocator::free_as_chunk(uint8_t* data, size_t size, MemTracker* tracker) {
+void ChunkAllocator::free(uint8_t* data, size_t size, MemTracker* tracker) {
     Chunk chunk;
     chunk.data = data;
     chunk.size = size;

--- a/be/src/runtime/memory/chunk_allocator.h
+++ b/be/src/runtime/memory/chunk_allocator.h
@@ -78,7 +78,7 @@ public:
     // If the chunk allocator is full, then free to the system.
     // Note: make sure that the length of 'data' is equal to size,
     // otherwise the capacity of chunk allocator will be wrong.
-    void free_as_chunk(uint8_t* data, size_t size, MemTracker* tracker = nullptr);
+    void free(uint8_t* data, size_t size, MemTracker* tracker = nullptr);
 
 private:
     static ChunkAllocator* _s_instance;

--- a/be/src/runtime/memory/chunk_allocator.h
+++ b/be/src/runtime/memory/chunk_allocator.h
@@ -74,10 +74,19 @@ public:
     // Free chunk allocated from this allocator
     void free(const Chunk& chunk, MemTracker* tracker = nullptr);
 
+    // Transfer the memory ownership to the chunk allocator.
+    // If the chunk allocator is full, then free to the system.
+    // Note: make sure that the length of 'data' is equal to size,
+    // otherwise the capacity of chunk allocator will be wrong.
+    void free_as_chunk(uint8_t* data, size_t size, MemTracker* tracker = nullptr);
+
 private:
     static ChunkAllocator* _s_instance;
 
     size_t _reserve_bytes_limit;
+    // When the reserved chunk memory size is greater than the limit,
+    // it is allowed to steal the chunks of other arenas.
+    size_t _steal_arena_limit;
     std::atomic<int64_t> _reserved_bytes;
     // each core has a ChunkArena
     std::vector<std::unique_ptr<ChunkArena>> _arenas;

--- a/be/src/vec/common/allocator.h
+++ b/be/src/vec/common/allocator.h
@@ -178,7 +178,7 @@ public:
                 RELEASE_THREAD_LOCAL_MEM_TRACKER(size);
             }
         } else if (size >= CHUNK_THRESHOLD) {
-            doris::ChunkAllocator::instance()->free_as_chunk((uint8_t*)buf, size);
+            doris::ChunkAllocator::instance()->free((uint8_t*)buf, size);
         } else {
             ::free(buf);
         }

--- a/be/src/vec/common/allocator.h
+++ b/be/src/vec/common/allocator.h
@@ -20,7 +20,6 @@
 
 #pragma once
 
-// TODO: Tracker
 // TODO: Readable
 
 #include <fmt/format.h>
@@ -29,6 +28,8 @@
 #include <exception>
 
 #include "common/status.h"
+#include "runtime/memory/chunk.h"
+#include "runtime/memory/chunk_allocator.h"
 #include "runtime/thread_context.h"
 
 #ifdef NDEBUG
@@ -60,6 +61,7 @@
 #define MAP_ANONYMOUS MAP_ANON
 #endif
 
+#ifdef NDEBUG
 /**
   * Many modern allocators (for example, tcmalloc) do not do a mremap for
   * realloc, even in case of large enough chunks of memory. Although this allows
@@ -73,15 +75,25 @@
   * P.S. This is also required, because tcmalloc can not allocate a chunk of
   * memory greater than 16 GB.
   */
-#ifdef NDEBUG
 static constexpr size_t MMAP_THRESHOLD = 64 * (1ULL << 20);
+/**
+ * Memory allocation between 4KB and 64MB will be through ChunkAllocator,
+ * those less than 4KB will be through malloc (for example, tcmalloc),
+ * and those greater than 64MB will be through MMAP.
+ * In the actual test, chunkallocator allocates less than 4KB of memory slower than malloc,
+ * and chunkallocator allocates more than 64MB of memory slower than MMAP,
+ * but the 4KB threshold is an empirical value, which needs to be determined
+ * by more detailed test later.
+  */
+static constexpr size_t CHUNK_THRESHOLD = 4096;
 #else
 /**
-      * In debug build, use small mmap threshold to reproduce more memory
-      * stomping bugs. Along with ASLR it will hopefully detect more issues than
-      * ASan. The program may fail due to the limit on number of memory mappings.
-      */
+  * In debug build, use small mmap threshold to reproduce more memory
+  * stomping bugs. Along with ASLR it will hopefully detect more issues than
+  * ASan. The program may fail due to the limit on number of memory mappings.
+  */
 static constexpr size_t MMAP_THRESHOLD = 4096;
+static constexpr size_t CHUNK_THRESHOLD = 1024;
 #endif
 
 static constexpr size_t MMAP_MIN_ALIGNMENT = 4096;
@@ -101,12 +113,75 @@ template <bool clear_memory_, bool mmap_populate>
 class Allocator {
 public:
     /// Allocate memory range.
-    void* alloc(size_t size, size_t alignment = 0) { return alloc_no_track(size, alignment); }
+    void* alloc(size_t size, size_t alignment = 0) {
+        void* buf;
+
+        if (size >= MMAP_THRESHOLD) {
+            if (alignment > MMAP_MIN_ALIGNMENT)
+                throw doris::vectorized::Exception(
+                        fmt::format(
+                                "Too large alignment {}: more than page size when allocating {}.",
+                                alignment, size),
+                        doris::TStatusCode::VEC_BAD_ARGUMENTS);
+
+            CONSUME_THREAD_LOCAL_MEM_TRACKER(size);
+            buf = mmap(get_mmap_hint(), size, PROT_READ | PROT_WRITE, mmap_flags, -1, 0);
+            if (MAP_FAILED == buf) {
+                RELEASE_THREAD_LOCAL_MEM_TRACKER(size);
+                doris::vectorized::throwFromErrno(fmt::format("Allocator: Cannot mmap {}.", size),
+                                                  doris::TStatusCode::VEC_CANNOT_ALLOCATE_MEMORY);
+            }
+
+            /// No need for zero-fill, because mmap guarantees it.
+        } else if (size >= CHUNK_THRESHOLD) {
+            doris::Chunk chunk;
+            if (!doris::ChunkAllocator::instance()->allocate_align(size, &chunk)) {
+                doris::vectorized::throwFromErrno(
+                        fmt::format("Allocator: Cannot allocate chunk {}.", size),
+                        doris::TStatusCode::VEC_CANNOT_ALLOCATE_MEMORY);
+            }
+            buf = chunk.data;
+            if constexpr (clear_memory) memset(buf, 0, chunk.size);
+        } else {
+            if (alignment <= MALLOC_MIN_ALIGNMENT) {
+                if constexpr (clear_memory)
+                    buf = ::calloc(size, 1);
+                else
+                    buf = ::malloc(size);
+
+                if (nullptr == buf)
+                    doris::vectorized::throwFromErrno(
+                            fmt::format("Allocator: Cannot malloc {}.", size),
+                            doris::TStatusCode::VEC_CANNOT_ALLOCATE_MEMORY);
+            } else {
+                buf = nullptr;
+                int res = posix_memalign(&buf, alignment, size);
+
+                if (0 != res)
+                    doris::vectorized::throwFromErrno(
+                            fmt::format("Cannot allocate memory (posix_memalign) {}.", size),
+                            doris::TStatusCode::VEC_CANNOT_ALLOCATE_MEMORY, res);
+
+                if constexpr (clear_memory) memset(buf, 0, size);
+            }
+        }
+        return buf;
+    }
 
     /// Free memory range.
     void free(void* buf, size_t size) {
-        free_no_track(buf, size);
-        // CurrentMemoryTracker::free(size);
+        if (size >= MMAP_THRESHOLD) {
+            if (0 != munmap(buf, size)) {
+                doris::vectorized::throwFromErrno(fmt::format("Allocator: Cannot munmap {}.", size),
+                                                  doris::TStatusCode::VEC_CANNOT_MUNMAP);
+            } else {
+                RELEASE_THREAD_LOCAL_MEM_TRACKER(size);
+            }
+        } else if (size >= CHUNK_THRESHOLD) {
+            doris::ChunkAllocator::instance()->free_as_chunk((uint8_t*)buf, size);
+        } else {
+            ::free(buf);
+        }
     }
 
     /** Enlarge memory range.
@@ -117,11 +192,9 @@ public:
         if (old_size == new_size) {
             /// nothing to do.
             /// BTW, it's not possible to change alignment while doing realloc.
-        } else if (old_size < MMAP_THRESHOLD && new_size < MMAP_THRESHOLD &&
+        } else if (old_size < CHUNK_THRESHOLD && new_size < CHUNK_THRESHOLD &&
                    alignment <= MALLOC_MIN_ALIGNMENT) {
             /// Resize malloc'd memory region with no special alignment requirement.
-            // CurrentMemoryTracker::realloc(old_size, new_size);
-
             void* new_buf = ::realloc(buf, new_size);
             if (nullptr == new_buf)
                 doris::vectorized::throwFromErrno("Allocator: Cannot realloc from " +
@@ -135,7 +208,6 @@ public:
                     memset(reinterpret_cast<char*>(buf) + old_size, 0, new_size - old_size);
         } else if (old_size >= MMAP_THRESHOLD && new_size >= MMAP_THRESHOLD) {
             /// Resize mmap'd memory region.
-            // CurrentMemoryTracker::realloc(old_size, new_size);
             CONSUME_THREAD_LOCAL_MEM_TRACKER(new_size - old_size);
 
             // On apple and freebsd self-implemented mremap used (common/mremap.h)
@@ -157,16 +229,7 @@ public:
                 if (new_size > old_size)
                     memset(reinterpret_cast<char*>(buf) + old_size, 0, new_size - old_size);
             }
-        } else if (new_size < MMAP_THRESHOLD) {
-            /// Small allocs that requires a copy. Assume there's enough memory in system. Call CurrentMemoryTracker once.
-            // CurrentMemoryTracker::realloc(old_size, new_size);
-
-            void* new_buf = alloc_no_track(new_size, alignment);
-            memcpy(new_buf, buf, std::min(old_size, new_size));
-            free_no_track(buf, old_size);
-            buf = new_buf;
         } else {
-            /// Big allocs that requires a copy. MemoryTracker is called inside 'alloc', 'free' methods.
             void* new_buf = alloc(new_size, alignment);
             memcpy(new_buf, buf, std::min(old_size, new_size));
             free(buf, old_size);
@@ -195,65 +258,6 @@ protected:
             ;
 
 private:
-    void* alloc_no_track(size_t size, size_t alignment) {
-        void* buf;
-
-        if (size >= MMAP_THRESHOLD) {
-            if (alignment > MMAP_MIN_ALIGNMENT)
-                throw doris::vectorized::Exception(
-                        fmt::format(
-                                "Too large alignment {}: more than page size when allocating {}.",
-                                alignment, size),
-                        doris::TStatusCode::VEC_BAD_ARGUMENTS);
-
-            CONSUME_THREAD_LOCAL_MEM_TRACKER(size);
-            buf = mmap(get_mmap_hint(), size, PROT_READ | PROT_WRITE, mmap_flags, -1, 0);
-            if (MAP_FAILED == buf) {
-                RELEASE_THREAD_LOCAL_MEM_TRACKER(size);
-                doris::vectorized::throwFromErrno(fmt::format("Allocator: Cannot mmap {}.", size),
-                                                  doris::TStatusCode::VEC_CANNOT_ALLOCATE_MEMORY);
-            }
-
-            /// No need for zero-fill, because mmap guarantees it.
-        } else {
-            if (alignment <= MALLOC_MIN_ALIGNMENT) {
-                if constexpr (clear_memory)
-                    buf = ::calloc(size, 1);
-                else
-                    buf = ::malloc(size);
-
-                if (nullptr == buf)
-                    doris::vectorized::throwFromErrno(
-                            fmt::format("Allocator: Cannot malloc {}.", size),
-                            doris::TStatusCode::VEC_CANNOT_ALLOCATE_MEMORY);
-            } else {
-                buf = nullptr;
-                int res = posix_memalign(&buf, alignment, size);
-
-                if (0 != res)
-                    doris::vectorized::throwFromErrno(
-                            fmt::format("Cannot allocate memory (posix_memalign) {}.", size),
-                            doris::TStatusCode::VEC_CANNOT_ALLOCATE_MEMORY, res);
-
-                if constexpr (clear_memory) memset(buf, 0, size);
-            }
-        }
-        return buf;
-    }
-
-    void free_no_track(void* buf, size_t size) {
-        if (size >= MMAP_THRESHOLD) {
-            if (0 != munmap(buf, size)) {
-                doris::vectorized::throwFromErrno(fmt::format("Allocator: Cannot munmap {}.", size),
-                                                  doris::TStatusCode::VEC_CANNOT_MUNMAP);
-            } else {
-                RELEASE_THREAD_LOCAL_MEM_TRACKER(size);
-            }
-        } else {
-            ::free(buf);
-        }
-    }
-
 #ifndef NDEBUG
     /// In debug builds, request mmap() at random addresses (a kind of ASLR), to
     /// reproduce more memory stomping bugs. Note that Linux doesn't do it by

--- a/docs/en/docs/admin-manual/config/be-config.md
+++ b/docs/en/docs/admin-manual/config/be-config.md
@@ -238,9 +238,9 @@ The number of worker threads to calculate the checksum of the tablet
 
 ### `chunk_reserved_bytes_limit`
 
-Default: 2147483648
+Default: 20%
 
-The reserved bytes limit of Chunk Allocator is 2GB by default. Increasing this variable can improve performance, but it will get more free memory that other modules cannot use.
+The reserved bytes limit of Chunk Allocator, usually set as a percentage of mem_limit. defaults to bytes if no unit is given, the number of bytes must be a multiple of 2. must larger than 0. and if larger than physical memory size, it will be set to physical memory size. increase this variable can improve performance, but will acquire more free memory which can not be used by other modules.
 
 ### `clear_transaction_task_worker_count`
 

--- a/docs/zh-CN/docs/admin-manual/config/be-config.md
+++ b/docs/zh-CN/docs/admin-manual/config/be-config.md
@@ -231,9 +231,9 @@ BE缓存池最大的内存可用量，buffer pool是BE新的内存管理结构�
 
 ### `chunk_reserved_bytes_limit`
 
-默认值：2147483648
+默认值：20%
 
-Chunk Allocator的reserved bytes限制，默认为2GB，增加这个变量可以提高性能，但是会获得更多其他模块无法使用的空闲内存
+Chunk Allocator的reserved bytes限制，通常被设置为 mem_limit 的百分比。默认单位字节，值必须是2的倍数，且必须大于0，如果大于物理内存，将被设置为物理内存大小。增加这个变量可以提高性能，但是会获得更多其他模块无法使用的空闲内存。
 
 ### `clear_transaction_task_worker_count`
 


### PR DESCRIPTION
# Proposed changes

Issue Number: close #9540
#9580 

## Problem Summary:

1. High concurrency stress test on SSB and wide table. Compare the performance of turning the vectorization engine on and off. Turning on the vectorization engine is slower for most SSB queries.

2. Optimize the Allocator in the vectorization engine. In most queries, the performance is improved by about **10%**.
Memory allocation between 4KB and 64MB will be through ChunkAllocator, those less than 4KB will be through malloc, and those greater than 64MB will be through MMAP.

3. Optimize Chunk Allocator, increase the limit that allows chunks to be stolen from other core's arena, and optimize reserved bytes conf.

## Checklist(Required)

1. Does it affect the original behavior: (Yes)
2. Has unit tests been added: (No)
7. Has document been added or modified: (Yes)
8. Does it need to update dependencies: (No)
9. Are there any changes that cannot be rolled back: (Yes)

## Further comments

Stress testing the vectorization engine.
## 1. Env and Test Set
```
> Based on Doris V1.0

Env: 1 FE, 1 BE
Test Set: 
	SSB, 100G, lineorder 60003w rows
	Width table from online service, 419 columns, 1710549 rows
set global parallel_fragment_exec_instance_num=10

jmeter conf:
	<stringProp name="ThreadGroup.num_threads">100</stringProp>
	<stringProp name="ThreadGroup.ramp_time">1</stringProp>
	<boolProp name="ThreadGroup.scheduler">true</boolProp>
	<stringProp name="ThreadGroup.duration">30</stringProp>
	<stringProp name="ThreadGroup.delay">0</stringProp>

actual concurrency = parallel_fragment_exec_instance_num * ThreadGroup.num_threads
```

## 2. Test

- TO: Master, set global enable_vectorized_engine=false;
- T1: Master, set global enable_vectorized_engine=true;
- T2: Master, set global enable_vectorized_engine=true, tc_max_total_thread_cache_bytes=100G；
- T3: This PR, set global enable_vectorized_engine=true, allocate 4k < size < 64M use ChunkAllocator; 
- T4: This PR, set global enable_vectorized_engine=true, Allocator 4k < size < 64M use chunkAllocator, and compile USE_MEM_TRACKER=0；
- R1: (T0mid-T1mid)/T0mid, Compare the performance of turning the vectorization engine on and off.
- R2: (T1mid-T3mid)/T1mid, Performance changes brought by allocating 4K < size < 64M memory through ChunkAllocator in the vectorization engine.
- R3: (T1mid-T4mid)/T1mid, Same as above, close memtracker.

> Form Notes: "xxx,xxx,xxx": Repeat 3 times, the AvgTime(ms) of each time.

| query | num_threads | R1 | R2 | R3 | T0 | T1 | T2 | T3 | T4 |
| ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ |  ------ |
| Q1.1 | 100 | 4.7% | 9.2% | 12.1% | 36252,36903,36800 | 34297,35053,36087 | 35757,34483,33825 | 33314,31657,31838 | 30801,31496,30445 |
| Q1.2 | 100 | -3.8% | 7% | 6.2% | 24017,24338,25478 | 25273.25222,25914 | 26647,24651,25406 | 23453,23498,23604 | 23771,23084,23704 |
| Q1.3 | 100 | -2.6% | 9% | 7.9 | 24349,23780,22844 | 24073,24487,24401 | 23842,23149,24198 | 22614,22984,23050 | 22678,22466,22225 |
| Q2.1 | 20 | -11.2% | 0.6% | 19.3% | 89466,21528,21889 | 26300,24345,24222 | 89662,25042,24069 | 24094,24542,24197 | 20538,19651,19627 |
| Q2.2| 20 | 12.7% | 4.9% | 0.8% | 16963,21435,18154 | 15855,16936,15047 | 16006,17251,16593 | 15072,14407,15648 | 15716,16347,15588 |
| Q2.3 | 20 | 1% | 3.2% | 8.9% | 15183,16194,13977 | 15551,15033,14801 | 14338,14605,14531 | 14302,14548,15301 | 14318,13601,13689 |
| Q3.1 | 20 | 5.4% | 19.4% | 23.6% | 32021,32176,31427 | 31037,30283,30231 | 38002,30272,30016 | 25162,23187,24411 | 27673,23147,22492 |
| Q3.2 | 20 | -8% | 15.8% | 17.3% | 10379,10433,9893 | 11837,11184,11223 | 11403,11481,9788 | 9296,9452,9455 | 9576,9172,9283 |
| Q3.3 | 20 | -5% | 10.6% | 12.8% | 8559,8472,8639 | 8713,9390,8992 | 8367,8153,8133 | 7998,8618,8040 | 7952,7476,7845 |
| Q4.1 | 20 | -35% | 27.9% | 31.8% | 32249,29965,29136 | 47405,40357,40443 | 41912,36981,37571 | 31230,27683,29166 | 31848,27585,27435 |
| Q4.2 | 20 | -73.5 | 16.2% | 15.2% | 19979,18798,17169 | 34066,32614,30849 | 34560,34460,35194 | 27117,29645,27337 | 27651,29205,27149 |
| Q4.3 | 20 | -46.2% | -2.8% | 0.5% | 19357,20762,19992 | 28256,29862,29230 | 27647,29216,29091 | 30523,30067,29260 | 29092,26644,30017 |
| Width table (419 rows) | 100 | 100% | 17.6% | 17.9% | no work | 4211,4546,4710 | 4089,4479,4551 | 3679,3745,3816 | 3664,3732,3829 |

![image](https://user-images.githubusercontent.com/13197424/168499978-14eeadb1-b7a5-4bec-979f-7f9b95d2557c.png)


## 3. Detailed description
- T2:  Theoretically, when the capacity of the tcmalloc thread cache is sufficient, the spin lock in the central free list will be avoided to a great extent, but in practice, the spin lock cost is still large in high concurrency queries, I will test this matter in more detail below.
- T3:  Because tcmalloc thread cache cannot avoid spin lock, the introduction of ChunkAllocator is equivalent to adding a layer of cache in User Mode. 
	In allocator.h, Memory allocation between 4KB and 64MB will be through ChunkAllocator, those less than 4KB will be through malloc (for example, tcmalloc), and those greater than 64MB will be through MMAP.
	In the actual test, chunkallocator allocates less than 4KB of memory slower than malloc, and chunkallocator allocates more than 64MB of memory slower than MMAP, but the 4KB threshold is an empirical value, which needs to be determined by more detailed test later.
- T4: Close memtracker at compile time can be selected during POC. Memtracker records the consumption value through an atomic variable. In high query concurrency, the atomic variable spin lock has a high cost. I'll optimize memtracker. After that