### PR TITLE
[fix](planner)VecNotImplException thrown when query need rewrite and some slot cannot changed to nullable

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/Analyzer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/Analyzer.java
@@ -300,17 +300,6 @@ public class Analyzer {
 
         private final long autoBroadcastJoinThreshold;
 
-        /**
-         * This property is mainly used to store the vectorized switch of the current query.
-         * true: the vectorization of the current query is turned on
-         * false: the vectorization of the current query is turned off.
-         * It is different from the vectorized switch`enableVectorizedEngine` of the session.
-         * It is only valid for a single query, while the session switch is valid for all queries in the session.
-         * It cannot be set directly by the user, only by inheritance from session`enableVectorizedEngine`
-         * or internal adjustment of the system.
-         */
-        private boolean enableQueryVec;
-
         public GlobalState(Catalog catalog, ConnectContext context) {
             this.catalog = catalog;
             this.context = context;
@@ -360,9 +349,6 @@ public class Analyzer {
             } else {
                 // autoBroadcastJoinThreshold is a "final" field, must set an initial value for it
                 autoBroadcastJoinThreshold = 0;
-            }
-            if (context != null) {
-                enableQueryVec = context.getSessionVariable().enableVectorizedEngine();
             }
         }
     }
@@ -666,27 +652,6 @@ public class Analyzer {
 
     public ExprRewriter getMVExprRewriter() {
         return globalState.mvExprRewriter;
-    }
-
-    /**
-     * Only the top-level `query vec` value of the query analyzer represents the value of the entire query.
-     * Other sub-analyzers cannot represent the value of `query vec`.
-     * @return
-     */
-    public boolean enableQueryVec() {
-        if (ancestors.isEmpty()) {
-            return globalState.enableQueryVec;
-        } else {
-            return ancestors.get(ancestors.size() - 1).enableQueryVec();
-        }
-    }
-
-    /**
-     * Since analyzer cannot get sub-analyzers from top to bottom.
-     * So I can only set the `query vec` variable of the top level analyzer of query to true.
-     */
-    public void disableQueryVec() {
-        globalState.enableQueryVec = false;
     }
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/VectorizedUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/VectorizedUtil.java
@@ -17,7 +17,12 @@
 
 package org.apache.doris.common.util;
 
+import org.apache.doris.analysis.SetVar;
+import org.apache.doris.analysis.StringLiteral;
+import org.apache.doris.common.DdlException;
 import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.qe.SessionVariable;
+import org.apache.doris.qe.VariableMgr;
 
 public class VectorizedUtil {
     /**
@@ -32,5 +37,35 @@ public class VectorizedUtil {
             return false;
         }
         return connectContext.getSessionVariable().enableVectorizedEngine();
+    }
+
+    /**
+     * The purpose of this function is to turn off the vectorization switch for the current query.
+     * When the vectorization engine cannot meet the requirements of the current query,
+     * it will convert the current query into a non-vectorized query.
+     * Note that this will only change the **vectorization switch for a single query**,
+     * and will not affect other queries in the same session.
+     * Therefore, even if the vectorization switch of the current query is turned off,
+     * the vectorization properties of subsequent queries will not be affected.
+     *
+     * Session: set enable_vectorized_engine=true;
+     * Query1: select * from table (vec)
+     * Query2: select * from t1 left join (select count(*) as count from t2) t3 on t1.k1=t3.count (switch to non-vec)
+     * Query3: select * from table (still vec)
+     */
+    public static void switchToQueryNonVec() {
+        ConnectContext connectContext = ConnectContext.get();
+        if (connectContext == null) {
+            return;
+        }
+        SessionVariable sessionVariable = connectContext.getSessionVariable();
+        sessionVariable.setIsSingleSetVar(true);
+        try {
+            VariableMgr.setVar(sessionVariable, new SetVar(
+                    "enable_vectorized_engine",
+                    new StringLiteral("false")));
+        } catch (DdlException e) {
+            // do nothing
+        }
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/VectorizedUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/VectorizedUtil.java
@@ -17,9 +17,7 @@
 
 package org.apache.doris.common.util;
 
-import org.apache.doris.analysis.Analyzer;
 import org.apache.doris.qe.ConnectContext;
-import org.apache.doris.qe.StmtExecutor;
 
 public class VectorizedUtil {
     /**
@@ -33,40 +31,6 @@ public class VectorizedUtil {
         if (connectContext == null) {
             return false;
         }
-        StmtExecutor stmtExecutor = connectContext.getExecutor();
-        if (stmtExecutor == null) {
-            return connectContext.getSessionVariable().enableVectorizedEngine();
-        }
-        Analyzer analyzer = stmtExecutor.getAnalyzer();
-        if (analyzer == null) {
-            return connectContext.getSessionVariable().enableVectorizedEngine();
-        }
-        return analyzer.enableQueryVec();
-    }
-
-    /**
-     * The purpose of this function is to turn off the vectorization switch for the current query.
-     * When the vectorization engine cannot meet the requirements of the current query,
-     * it will convert the current query into a non-vectorized query.
-     * Note that this will only change the **vectorization switch for a single query**,
-     * and will not affect other queries in the same session.
-     * Therefore, even if the vectorization switch of the current query is turned off,
-     * the vectorization properties of subsequent queries will not be affected.
-     *
-     * Session: set enable_vectorized_engine=true;
-     * Query1: select * from table (vec)
-     * Query2: select * from t1 left join (select count(*) as count from t2) t3 on t1.k1=t3.count (switch to non-vec)
-     * Query3: select * from table (still vec)
-     */
-    public static void switchToQueryNonVec() {
-        ConnectContext connectContext = ConnectContext.get();
-        if (connectContext == null) {
-            return;
-        }
-        Analyzer analyzer = connectContext.getExecutor().getAnalyzer();
-        if (analyzer == null) {
-            return;
-        }
-        analyzer.disableQueryVec();
+        return connectContext.getSessionVariable().enableVectorizedEngine();
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -78,6 +78,7 @@ import org.apache.doris.common.util.QueryPlannerProfile;
 import org.apache.doris.common.util.RuntimeProfile;
 import org.apache.doris.common.util.SqlParserUtils;
 import org.apache.doris.common.util.TimeUtils;
+import org.apache.doris.common.util.VectorizedUtil;
 import org.apache.doris.load.EtlJobType;
 import org.apache.doris.metric.MetricRepo;
 import org.apache.doris.mysql.MysqlChannel;
@@ -596,25 +597,7 @@ public class StmtExecutor implements ProfileWriter {
                         throw e;
                     } else {
                         resetAnalyzerAndStmt();
-                        // The purpose of this function is to turn off the vectorization switch for the current query.
-                        // When the vectorization engine cannot meet the requirements of the current query,
-                        // it will convert the current query into a non-vectorized query.
-                        // Note that this will only change the **vectorization switch for a single query**,
-                        // and will not affect other queries in the same session.
-                        // Therefore, even if the vectorization switch of the current query is turned off,
-                        // the vectorization properties of subsequent queries will not be affected.
-                        //
-                        // Session: set enable_vectorized_engine=true;
-                        // Query1: select * from table (vec)
-                        // Query2: select * from t1 left join
-                        //         (select count(*) as count from t2) t3
-                        //         on t1.k1=t3.count (switch to non-vec)
-                        // Query3: select * from table (still vec)
-                        SessionVariable sessionVariable = context.getSessionVariable();
-                        sessionVariable.setIsSingleSetVar(true);
-                        VariableMgr.setVar(sessionVariable, new SetVar(
-                                "enable_vectorized_engine",
-                                new StringLiteral("false")));
+                        VectorizedUtil.switchToQueryNonVec();
                     }
                 } catch (UserException e) {
                     throw e;

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -606,7 +606,9 @@ public class StmtExecutor implements ProfileWriter {
                         //
                         // Session: set enable_vectorized_engine=true;
                         // Query1: select * from table (vec)
-                        // Query2: select * from t1 left join (select count(*) as count from t2) t3 on t1.k1=t3.count (switch to non-vec)
+                        // Query2: select * from t1 left join
+                        //         (select count(*) as count from t2) t3
+                        //         on t1.k1=t3.count (switch to non-vec)
                         // Query3: select * from table (still vec)
                         SessionVariable sessionVariable = context.getSessionVariable();
                         sessionVariable.setIsSingleSetVar(true);

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/ReanalyzeTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/ReanalyzeTest.java
@@ -1,0 +1,47 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.analysis;
+
+import org.apache.doris.qe.QueryState.MysqlStateType;
+import org.apache.doris.qe.StmtExecutor;
+import org.apache.doris.utframe.TestWithFeService;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class ReanalyzeTest extends TestWithFeService {
+    @Override
+    protected void runBeforeAll() throws Exception {
+        createDatabase("test");
+        createTable("create table test.tbl1\n" + "(k1 int, k2 int, v1 int)\n" + "distributed by hash(k1)\n"
+                + "properties(\"replication_num\" = \"1\");");
+    }
+
+    @Test
+    public void testTurnoffVectorizedEngineWhenCannotChangeSlotToNullable() throws Exception {
+        String sql = "explain select * from test.tbl1 t1"
+                + " where (select count(*) from test.tbl1 t2 where t1.k1 = t2.k1) > 0";
+        connectContext.getSessionVariable().enableVectorizedEngine = true;
+        StmtExecutor stmtExecutor = new StmtExecutor(connectContext, sql);
+        connectContext.setExecutor(stmtExecutor);
+        stmtExecutor.execute();
+        connectContext.setExecutor(null);
+        Assertions.assertEquals(MysqlStateType.EOF, connectContext.getState().getStateType());
+        Assertions.assertTrue(connectContext.getSessionVariable().enableVectorizedEngine());
+    }
+}


### PR DESCRIPTION
…some slot cannot changed to nullable

# Proposed changes

Issue Number: close #9588

## Problem Summary:

Could reproduced by:

```sql
create table test.tbl1
(k1 int, k2 int, v1 int)
distributed by hash(k1)
properties("replication_num" = "1");

explain select * from test.tbl1 t1 where (select count(*) from test.tbl1 t2 where t1.k1 = t2.k1) > 0;
```

## Checklist(Required)

1. Does it affect the original behavior: (No)
2. Has unit tests been added: (Yes)
3. Has document been added or modified: (No Need)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
