### PR TITLE
[regression] fix the regression case fail in test_compaction

### DIFF
--- a/regression-test/suites/compaction/test_compaction.groovy
+++ b/regression-test/suites/compaction/test_compaction.groovy
@@ -19,11 +19,12 @@ import org.codehaus.groovy.runtime.IOGroovyMethods
 
 suite("test_compaction") {
     def tableName = "compaction_regression_test"
+    def beHttpAddress = getConf("beHttpAddress")
 
     try {
         StringBuilder showConfigCommand = new StringBuilder();
         showConfigCommand.append("curl -X GET http://")
-        showConfigCommand.append(context.config.beHttpAddress)
+        showConfigCommand.append(beHttpAddress)
         showConfigCommand.append("/api/show_config")
         def process = showConfigCommand.toString().execute()
         int code = process.waitFor()
@@ -110,7 +111,7 @@ suite("test_compaction") {
             String tablet_id = tablet[0]
             StringBuilder sb = new StringBuilder();
             sb.append("curl -X POST http://")
-            sb.append(context.config.beHttpAddress)
+            sb.append(beHttpAddress)
             sb.append("/api/compaction/run?tablet_id=")
             sb.append(tablet_id)
             sb.append("&compact_type=cumulative")
@@ -140,7 +141,7 @@ suite("test_compaction") {
                 String tablet_id = tablet[0]
                 StringBuilder sb = new StringBuilder();
                 sb.append("curl -X GET http://")
-                sb.append(context.config.beHttpAddress)
+                sb.append(beHttpAddress)
                 sb.append("/api/compaction/run_status?tablet_id=")
                 sb.append(tablet_id)
 
@@ -162,7 +163,7 @@ suite("test_compaction") {
             String tablet_id = tablet[0]
             StringBuilder sb = new StringBuilder();
             sb.append("curl -X GET http://")
-            sb.append(context.config.beHttpAddress)
+            sb.append(beHttpAddress)
             sb.append("/api/compaction/show?tablet_id=")
             sb.append(tablet_id)
             String command = sb.toString()


### PR DESCRIPTION
# Proposed changes
This pr is used to solve the regression test encounter fails in test_compaction.

Issue Number: close #xxx

## Problem Summary:
if you run regression test and the test_compaction report "No such property: beHttpAdderss fo class: org.apache.doris.regression.config", you can use this pr to solve.

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (No)
2. Has unit tests been added: (No)
3. Has document been added or modified: (No)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
