### PR TITLE
[Feature]Support create hive table without column info.

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/FeMetaVersion.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/FeMetaVersion.java
@@ -38,8 +38,10 @@ public final class FeMetaVersion {
     public static final int VERSION_108 = 108;
     // add row policy
     public static final int VERSION_109 = 109;
+    // add isLocalSchema field in HiveTable
+    public static final int VERSION_110 = 110;
     // note: when increment meta version, should assign the latest version to VERSION_CURRENT
-    public static final int VERSION_CURRENT = VERSION_109;
+    public static final int VERSION_CURRENT = VERSION_110;
 
     // all logs meta version should >= the minimum version, so that we could remove many if clause, for example
     // if (FE_METAVERSION < VERSION_94) ...

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateTableStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateTableStmt.java
@@ -359,7 +359,7 @@ public class CreateTableStmt extends DdlStmt {
         }
 
         // analyze column def
-        if (!(engineName.equals("iceberg") || engineName.equals("hudi"))
+        if (!(engineName.equals("iceberg") || engineName.equals("hudi") || engineName.equals("hive"))
                 && (columnDefs == null || columnDefs.isEmpty())) {
             ErrorReport.reportAnalysisException(ErrorCode.ERR_TABLE_MUST_HAVE_COLUMNS);
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/HiveMetaStoreClientHelper.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/HiveMetaStoreClientHelper.java
@@ -42,6 +42,7 @@ import org.apache.hadoop.fs.LocatedFileStatus;
 import org.apache.hadoop.fs.RemoteIterator;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.HiveMetaStoreClient;
+import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.metastore.api.MetaException;
 import org.apache.hadoop.hive.metastore.api.Partition;
 import org.apache.hadoop.hive.metastore.api.Table;
@@ -284,6 +285,18 @@ public class HiveMetaStoreClientHelper {
             throw new DdlException("Connect hive metastore failed. Error: " + e.getMessage());
         }
         return table;
+    }
+
+    public static List<FieldSchema> getSchema(HiveTable hiveTable) throws DdlException {
+        HiveMetaStoreClient client = getClient(hiveTable.getHiveProperties().get(HiveTable.HIVE_METASTORE_URIS));
+        List<FieldSchema> schema;
+        try {
+            schema = client.getSchema(hiveTable.getHiveDb(), hiveTable.getHiveTable());
+        } catch (TException e) {
+            LOG.warn("Hive metastore thrift exception: {}", e.getMessage());
+            throw new DdlException("Connect hive metastore failed. Error: " + e.getMessage());
+        }
+        return schema;
     }
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/HiveTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/HiveTable.java
@@ -18,13 +18,18 @@
 package org.apache.doris.catalog;
 
 import org.apache.doris.common.DdlException;
+import org.apache.doris.common.FeMetaVersion;
 import org.apache.doris.common.io.Text;
 import org.apache.doris.thrift.THiveTable;
 import org.apache.doris.thrift.TTableDescriptor;
 import org.apache.doris.thrift.TTableType;
 
 import com.google.common.base.Strings;
+import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import org.apache.hadoop.hive.metastore.api.FieldSchema;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.io.DataInput;
 import java.io.DataOutput;
@@ -32,12 +37,16 @@ import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * External hive table
  * Currently only support loading from hive table
  */
 public class HiveTable extends Table {
+    private static final Logger LOG = LogManager.getLogger(HiveTable.class);
+
     private static final String PROPERTY_MISSING_MSG = "Hive %s is null. Please add properties('%s'='xxx') when create table";
 
     private static final String HIVE_DB = "database";
@@ -49,6 +58,9 @@ public class HiveTable extends Table {
     private String hiveTable;
     private Map<String, String> hiveProperties = Maps.newHashMap();
 
+    private boolean isLocalSchema = true;
+    private Pattern digitPattern = null;
+
     public HiveTable() {
         super(TableType.HIVE);
     }
@@ -56,6 +68,10 @@ public class HiveTable extends Table {
     public HiveTable(long id, String name, List<Column> schema, Map<String, String> properties) throws DdlException {
         super(id, name, TableType.HIVE, schema);
         validate(properties);
+        if (schema == null || schema.size() == 0) {
+            isLocalSchema = false;
+            digitPattern = Pattern.compile("(\\d+)");
+        }
     }
 
     public String getHiveDbTable() {
@@ -72,6 +88,98 @@ public class HiveTable extends Table {
 
     public Map<String, String> getHiveProperties() {
         return hiveProperties;
+    }
+
+    @Override
+    public List<Column> getBaseSchema(boolean full) {
+        if (isLocalSchema) {
+            return super.getBaseSchema(full);
+        }
+        List<Column> hiveMetastoreSchema = Lists.newArrayList();
+        try {
+            for (FieldSchema field : HiveMetaStoreClientHelper.getSchema(this)) {
+                hiveMetastoreSchema.add(new Column(field.getName(), convertToDorisType(field.getType()),
+                        true, null, true, null, field.getComment()));
+            }
+        } catch (DdlException e) {
+            LOG.warn("Failed to get schema of hive table. DB {}, Table {}. {}",
+                    this.hiveDb, this.hiveTable, e.getMessage());
+            return null;
+        }
+        fullSchema = hiveMetastoreSchema;
+        return fullSchema;
+    }
+
+    @Override
+    public Column getColumn(String name) {
+        if (isLocalSchema) {
+            return nameToColumn.get(name);
+        }
+        Column col = null;
+        if (fullSchema == null || fullSchema.size() == 0) {
+            getBaseSchema(true);
+        }
+        for (Column column : fullSchema) {
+            if (column.getName().equals(name)) {
+                return column;
+            }
+        }
+        return col;
+    }
+
+    private Type convertToDorisType(String hiveType) {
+        String lowerCaseType = hiveType.toLowerCase();
+        if (lowerCaseType.equals("boolean")) {
+            return Type.BOOLEAN;
+        }
+        if (lowerCaseType.equals("tinyint")) {
+            return Type.TINYINT;
+        }
+        if (lowerCaseType.equals("smallint")) {
+            return Type.SMALLINT;
+        }
+        if (lowerCaseType.equals("int")) {
+            return Type.INT;
+        }
+        if (lowerCaseType.equals("bigint")) {
+            return Type.BIGINT;
+        }
+        if (lowerCaseType.startsWith("char")) {
+            ScalarType type = ScalarType.createType(PrimitiveType.CHAR);
+            Matcher match = digitPattern.matcher(lowerCaseType);
+            if (match.find()) {
+                type.setLength(Integer.parseInt(match.group(1)));
+            }
+            return type;
+        }
+        if (lowerCaseType.startsWith("varchar")) {
+            ScalarType type = ScalarType.createType(PrimitiveType.VARCHAR);
+            Matcher match = digitPattern.matcher(lowerCaseType);
+            if (match.find()) {
+                type.setLength(Integer.parseInt(match.group(1)));
+            }
+            return type;
+        }
+        if (lowerCaseType.startsWith("decimal")) {
+            Matcher match = digitPattern.matcher(lowerCaseType);
+            int precision = ScalarType.DEFAULT_PRECISION;
+            int scale = ScalarType.DEFAULT_SCALE;
+            if (match.find()) {
+                precision = Integer.parseInt(match.group(1));
+            }
+            if (match.find()) {
+                scale = Integer.parseInt(match.group(1));
+            }
+            return ScalarType.createDecimalV2Type(precision, scale);
+        }
+        if (lowerCaseType.equals("date")) {
+            return Type.DATE;
+        }
+        if (lowerCaseType.equals("timestamp")) {
+            return Type.DATETIME;
+        }
+        LOG.warn("Hive type {} may not supported, will use STRING instead.", hiveType);
+        return Type.STRING;
     }
 
     private void validate(Map<String, String> properties) throws DdlException {
@@ -129,11 +237,11 @@ public class HiveTable extends Table {
             Text.writeString(out, entry.getKey());
             Text.writeString(out, entry.getValue());
         }
+        out.writeBoolean(isLocalSchema);
     }
 
     public void readFields(DataInput in) throws IOException {
         super.readFields(in);
-
         hiveDb = Text.readString(in);
         hiveTable = Text.readString(in);
         int size = in.readInt();
@@ -141,6 +249,12 @@ public class HiveTable extends Table {
             String key = Text.readString(in);
             String val = Text.readString(in);
             hiveProperties.put(key, val);
+        }
+        if (Catalog.getCurrentCatalogJournalVersion() >= FeMetaVersion.VERSION_110) {
+            isLocalSchema = in.readBoolean();
+            if (!isLocalSchema) {
+                digitPattern = Pattern.compile("(\\d+)");
+            }
         }
     }
 


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

Support create hive external table without giving the schema. Doris would sync the schema from HMS automatically.
And user doesn't need to manually refresh the column info when the hive schema changes. 

Example:
CREATE TABLE `region` 
engine=hive 
properties ("database"="default", "table"="region", "hive.metastore.uris"="thrift://172.21.16.11:7004");

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know) No
2. Has unit tests been added: (Yes/No/No Need) No Need
3. Has document been added or modified: (Yes/No/No Need) No
4. Does it need to update dependencies: (Yes/No) No
5. Are there any changes that cannot be rolled back: (Yes/No) No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
