### PR TITLE
[bug] (init) Java version check fail

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/JdkUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/JdkUtils.java
@@ -66,7 +66,7 @@ public class JdkUtils {
      * Output: 13, 8
      */
     public static int getJavaVersionAsInteger(String javaVersionStr) {
-        String[] parts = javaVersionStr.split("\\.");
+        String[] parts = javaVersionStr.split("\\.|\\+");
         if (parts[0].equals("1")) {
             return Integer.valueOf(parts[1]);
         } else {


### PR DESCRIPTION
# Proposed changes

Fix java version check fail when there is no "." in java version.
![image](https://user-images.githubusercontent.com/15223868/168725513-222d9915-1fd1-4bd6-8e15-c67acb9e411b.png)
![image](https://user-images.githubusercontent.com/15223868/168725036-35d72b5d-87e3-48d1-8415-23249328855e.png)

## Problem Summary:

add delimiter of "+" in JdkUtils

## Checklist(Required)

1. Does it affect the original behavior: (No)
2. Has unit tests been added: (No Need)
3. Has document been added or modified: (No Need)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (No)

## Further comments

