### PR TITLE
[Feature] Introducing OpenTelemetry to improve the observability of Doris.

### DIFF
--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -330,6 +330,27 @@ set_target_properties(minizip PROPERTIES IMPORTED_LOCATION ${THIRDPARTY_DIR}/lib
 add_library(idn STATIC IMPORTED)
 set_target_properties(idn PROPERTIES IMPORTED_LOCATION ${THIRDPARTY_DIR}/lib64/libidn.a)
 
+add_library(opentelemetry_common STATIC IMPORTED)
+set_target_properties(opentelemetry_common PROPERTIES IMPORTED_LOCATION ${THIRDPARTY_DIR}/lib64/libopentelemetry_common.a)
+
+add_library(opentelemetry_exporter_zipkin_trace STATIC IMPORTED)
+set_target_properties(opentelemetry_exporter_zipkin_trace PROPERTIES IMPORTED_LOCATION ${THIRDPARTY_DIR}/lib64/libopentelemetry_exporter_zipkin_trace.a)
+
+add_library(opentelemetry_resources STATIC IMPORTED)
+set_target_properties(opentelemetry_resources PROPERTIES IMPORTED_LOCATION ${THIRDPARTY_DIR}/lib64/libopentelemetry_resources.a)
+
+add_library(opentelemetry_version STATIC IMPORTED)
+set_target_properties(opentelemetry_version PROPERTIES IMPORTED_LOCATION ${THIRDPARTY_DIR}/lib64/libopentelemetry_version.a)
+
+add_library(opentelemetry_exporter_ostream_span STATIC IMPORTED)
+set_target_properties(opentelemetry_exporter_ostream_span PROPERTIES IMPORTED_LOCATION ${THIRDPARTY_DIR}/lib64/libopentelemetry_exporter_ostream_span.a)
+
+add_library(opentelemetry_trace STATIC IMPORTED)
+set_target_properties(opentelemetry_trace PROPERTIES IMPORTED_LOCATION ${THIRDPARTY_DIR}/lib64/libopentelemetry_trace.a)
+
+add_library(http_client_curl STATIC IMPORTED)
+set_target_properties(http_client_curl PROPERTIES IMPORTED_LOCATION ${THIRDPARTY_DIR}/lib64/libhttp_client_curl.a)
+
 if (WITH_KERBEROS)
     # kerberos lib for libhdfs3 
     add_library(gsasl STATIC IMPORTED)
@@ -628,6 +649,13 @@ set(COMMON_THIRDPARTY
     odbc
     cctz
     minizip
+    opentelemetry_common
+    opentelemetry_exporter_zipkin_trace
+    opentelemetry_resources
+    opentelemetry_version
+    opentelemetry_exporter_ostream_span
+    opentelemetry_trace
+    http_client_curl
     ${AWS_LIBS}
     # put this after lz4 to avoid using lz4 lib in librdkafka
     librdkafka_cpp

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -717,6 +717,10 @@ CONF_String(function_service_protocol, "h2:grpc");
 // use which load balancer to select server to connect
 CONF_String(rpc_load_balancer, "rr");
 
+CONF_Bool(enable_tracing, "false");
+
+CONF_String(trace_export_url, "http://127.0.0.1:9411/api/v2/spans")
+
 // a soft limit of string type length, the hard limit is 2GB - 4, but if too long will cause very low performance,
 // so we set a soft limit, default is 1MB
 CONF_mInt32(string_type_length_soft_limit_bytes, "1048576");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -719,7 +719,7 @@ CONF_String(rpc_load_balancer, "rr");
 
 CONF_Bool(enable_tracing, "false");
 
-CONF_String(trace_export_url, "http://127.0.0.1:9411/api/v2/spans")
+CONF_String(trace_export_url, "http://127.0.0.1:9411/api/v2/spans");
 
 // a soft limit of string type length, the hard limit is 2GB - 4, but if too long will cause very low performance,
 // so we set a soft limit, default is 1MB

--- a/be/src/runtime/fragment_mgr.cpp
+++ b/be/src/runtime/fragment_mgr.cpp
@@ -471,7 +471,7 @@ FragmentMgr::~FragmentMgr() {
 static void empty_function(PlanFragmentExecutor* exec) {}
 
 void FragmentMgr::_exec_actual(std::shared_ptr<FragmentExecState> exec_state, FinishCallback cb) {
-    std::string func_name{"PlanFragmentExecutor::_exec_actual"};
+    std::string func_name {"PlanFragmentExecutor::_exec_actual"};
     auto span = exec_state->get_tracer()->StartSpan(func_name);
     auto scope = opentelemetry::trace::Scope {span};
     span->SetAttribute("host", BackendOptions::get_localhost());

--- a/be/src/runtime/fragment_mgr.cpp
+++ b/be/src/runtime/fragment_mgr.cpp
@@ -464,7 +464,11 @@ static void empty_function(PlanFragmentExecutor* exec) {}
 
 void FragmentMgr::_exec_actual(std::shared_ptr<FragmentExecState> exec_state, FinishCallback cb) {
     std::string func_name {"PlanFragmentExecutor::_exec_actual"};
+#ifndef BE_TEST
     auto span = exec_state->executor()->runtime_state()->get_tracer()->StartSpan(func_name);
+#else
+    auto span = telemetry::get_noop_tracer()->StartSpan(func_name);
+#endif
     auto scope = opentelemetry::trace::Scope {span};
     span->SetAttribute("host", BackendOptions::get_localhost());
     span->SetAttribute("query_id", print_id(exec_state->query_id()));

--- a/be/src/runtime/plan_fragment_executor.cpp
+++ b/be/src/runtime/plan_fragment_executor.cpp
@@ -42,6 +42,7 @@
 #include "util/mem_info.h"
 #include "util/parse_util.h"
 #include "util/pretty_printer.h"
+#include "util/telemetry/telemetry.h"
 #include "util/uid_util.h"
 #include "vec/core/block.h"
 #include "vec/exec/vexchange_node.h"
@@ -109,6 +110,10 @@ Status PlanFragmentExecutor::prepare(const TExecPlanFragmentParams& request,
 
     if (request.query_options.__isset.is_report_success) {
         _is_report_success = request.query_options.is_report_success;
+    }
+
+    if (opentelemetry::trace::Tracer::GetCurrentSpan()->GetContext().IsValid()) {
+        _runtime_state->set_tracer(telemetry::get_tracer(print_id(_query_id)));
     }
 
     RETURN_IF_ERROR(_runtime_state->create_block_mgr());

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -38,6 +38,7 @@
 #include "runtime/thread_resource_mgr.h"
 #include "util/logging.h"
 #include "util/runtime_profile.h"
+#include "util/telemetry/telemetry.h"
 
 namespace doris {
 
@@ -366,6 +367,10 @@ public:
 
     QueryFragmentsCtx* get_query_fragments_ctx() { return _query_ctx; }
 
+    telemetry::OpentelemetryTracer get_tracer() { return _tracer; }
+
+    void set_tracer(telemetry::OpentelemetryTracer&& tracer) { _tracer = std::move(tracer); }
+
 private:
     // Use a custom block manager for the query for testing purposes.
     void set_block_mgr2(const std::shared_ptr<BufferedBlockMgr2>& block_mgr) {
@@ -513,6 +518,8 @@ private:
 
     // true if max_filter_ratio is 0
     bool _load_zero_tolerance = false;
+
+    telemetry::OpentelemetryTracer _tracer = telemetry::get_noop_tracer();
 
     // prohibit copies
     RuntimeState(const RuntimeState&);

--- a/be/src/service/doris_main.cpp
+++ b/be/src/service/doris_main.cpp
@@ -58,6 +58,7 @@
 #include "util/debug_util.h"
 #include "util/doris_metrics.h"
 #include "util/logging.h"
+#include "util/telemetry/telemetry.h"
 #include "util/thrift_rpc_helper.h"
 #include "util/thrift_server.h"
 #include "util/uid_util.h"
@@ -402,6 +403,8 @@ int main(int argc, char** argv) {
     // start all backgroud threads of storage engine.
     // SHOULD be called after exec env is initialized.
     EXIT_IF_ERROR(engine->start_bg_threads());
+
+    doris::telemetry::initTracerForZipkin();
 
     // begin to start services
     doris::ThriftRpcHelper::setup(exec_env);

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -114,7 +114,7 @@ void PInternalServiceImpl::exec_plan_fragment(google::protobuf::RpcController* c
     SCOPED_SWITCH_BTHREAD();
     brpc::ClosureGuard closure_guard(done);
     brpc::Controller* cntl = static_cast<brpc::Controller*>(cntl_base);
-    auto scope = trace_api::Scope{telemetry::get_span_from_rpc(cntl)};
+    auto scope = trace_api::Scope {telemetry::get_span_from_rpc(cntl)};
 
     auto st = Status::OK();
     bool compact = request->has_compact() ? request->compact() : false;

--- a/be/src/util/CMakeLists.txt
+++ b/be/src/util/CMakeLists.txt
@@ -105,6 +105,8 @@ set(UTIL_FILES
   s3_util.cpp
   topn_counter.cpp
   tuple_row_zorder_compare.cpp
+  telemetry/telemetry.cpp
+  telemetry/brpc_carrier.cpp
   quantile_state.cpp
   jni-util.cpp
 )

--- a/be/src/util/telemetry/brpc_carrier.cpp
+++ b/be/src/util/telemetry/brpc_carrier.cpp
@@ -1,0 +1,30 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "brpc_carrier.h"
+
+opentelemetry::nostd::string_view doris::telemetry::RpcServerCarrier::Get(
+        opentelemetry::nostd::string_view key) const noexcept {
+    auto it = cntl_->http_request().GetHeader(key.data());
+    if (it != nullptr) {
+        return it->data();
+    }
+    return "";
+}
+
+void doris::telemetry::RpcServerCarrier::Set(opentelemetry::nostd::string_view key,
+                                             opentelemetry::nostd::string_view value) noexcept {}

--- a/be/src/util/telemetry/brpc_carrier.h
+++ b/be/src/util/telemetry/brpc_carrier.h
@@ -1,0 +1,55 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <brpc/controller.h>
+
+#include "opentelemetry/context/propagation/global_propagator.h"
+#include "opentelemetry/context/propagation/text_map_propagator.h"
+#include "opentelemetry/context/runtime_context.h"
+#include "opentelemetry/trace/context.h"
+
+namespace doris::telemetry {
+
+class RpcServerCarrier : public opentelemetry::context::propagation::TextMapCarrier {
+public:
+    explicit RpcServerCarrier(const brpc::Controller* cntl) : cntl_(cntl) {}
+
+    RpcServerCarrier() = default;
+
+    opentelemetry::nostd::string_view Get(
+            opentelemetry::nostd::string_view key) const noexcept override;
+
+    void Set(opentelemetry::nostd::string_view key,
+             opentelemetry::nostd::string_view value) noexcept override;
+
+
+private:
+    const brpc::Controller* cntl_ {};
+};
+
+inline decltype(auto) get_span_from_rpc(brpc::Controller* controller) {
+    RpcServerCarrier carrier(controller);
+    auto current_ctx = opentelemetry::context::RuntimeContext::GetCurrent();
+
+    auto prop = opentelemetry::context::propagation::GlobalTextMapPropagator::GetGlobalPropagator();
+    auto new_context = prop->Extract(carrier, current_ctx);
+    return opentelemetry::trace::GetSpan(new_context);
+}
+
+} // namespace doris::telemetry

--- a/be/src/util/telemetry/brpc_carrier.h
+++ b/be/src/util/telemetry/brpc_carrier.h
@@ -38,7 +38,6 @@ public:
     void Set(opentelemetry::nostd::string_view key,
              opentelemetry::nostd::string_view value) noexcept override;
 
-
 private:
     const brpc::Controller* cntl_ {};
 };

--- a/be/src/util/telemetry/telemetry.cpp
+++ b/be/src/util/telemetry/telemetry.cpp
@@ -28,11 +28,11 @@
 #include "opentelemetry/trace/propagation/http_trace_context.h"
 #include "opentelemetry/trace/provider.h"
 
-namespace trace     = opentelemetry::trace;
-namespace nostd     = opentelemetry::nostd;
+namespace trace = opentelemetry::trace;
+namespace nostd = opentelemetry::nostd;
 namespace trace_sdk = opentelemetry::sdk::trace;
-namespace zipkin    = opentelemetry::exporter::zipkin;
-namespace resource  = opentelemetry::sdk::resource;
+namespace zipkin = opentelemetry::exporter::zipkin;
+namespace resource = opentelemetry::sdk::resource;
 namespace propagation = opentelemetry::context::propagation;
 
 void doris::telemetry::initTracerForZipkin() {
@@ -44,7 +44,7 @@ void doris::telemetry::initTracerForZipkin() {
     opts.endpoint = doris::config::trace_export_url;
     resource::ResourceAttributes attributes = {{"service.name", "Backend"}};
     auto resource = resource::Resource::Create(attributes);
-    auto exporter  = std::unique_ptr<trace_sdk::SpanExporter>(new zipkin::ZipkinExporter(opts));
+    auto exporter = std::unique_ptr<trace_sdk::SpanExporter>(new zipkin::ZipkinExporter(opts));
 
     trace_sdk::BatchSpanProcessorOptions batchOptions;
     auto processor = std::unique_ptr<trace_sdk::SpanProcessor>(

--- a/be/src/util/telemetry/telemetry.cpp
+++ b/be/src/util/telemetry/telemetry.cpp
@@ -1,0 +1,60 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "telemetry.h"
+
+#include "common/config.h"
+#include "opentelemetry/context/propagation/global_propagator.h"
+#include "opentelemetry/context/propagation/noop_propagator.h"
+#include "opentelemetry/context/propagation/text_map_propagator.h"
+#include "opentelemetry/exporters/zipkin/zipkin_exporter.h"
+#include "opentelemetry/nostd/shared_ptr.h"
+#include "opentelemetry/sdk/trace/batch_span_processor.h"
+#include "opentelemetry/trace/noop.h"
+#include "opentelemetry/trace/propagation/http_trace_context.h"
+#include "opentelemetry/trace/provider.h"
+
+namespace trace     = opentelemetry::trace;
+namespace nostd     = opentelemetry::nostd;
+namespace trace_sdk = opentelemetry::sdk::trace;
+namespace zipkin    = opentelemetry::exporter::zipkin;
+namespace resource  = opentelemetry::sdk::resource;
+namespace propagation = opentelemetry::context::propagation;
+
+void doris::telemetry::initTracerForZipkin() {
+    if (!doris::config::enable_tracing) {
+        return;
+    }
+
+    zipkin::ZipkinExporterOptions opts;
+    opts.endpoint = doris::config::trace_export_url;
+    resource::ResourceAttributes attributes = {{"service.name", "Backend"}};
+    auto resource = resource::Resource::Create(attributes);
+    auto exporter  = std::unique_ptr<trace_sdk::SpanExporter>(new zipkin::ZipkinExporter(opts));
+
+    trace_sdk::BatchSpanProcessorOptions batchOptions;
+    auto processor = std::unique_ptr<trace_sdk::SpanProcessor>(
+            new trace_sdk::BatchSpanProcessor(std::move(exporter), batchOptions));
+    auto provider = nostd::shared_ptr<trace::TracerProvider>(
+            new trace_sdk::TracerProvider(std::move(processor), resource));
+    // Set the global trace provider
+    trace::Provider::SetTracerProvider(std::move(provider));
+
+    propagation::GlobalTextMapPropagator::SetGlobalPropagator(
+            nostd::shared_ptr<propagation::TextMapPropagator>(
+                    new opentelemetry::trace::propagation::HttpTraceContext()));
+}

--- a/be/src/util/telemetry/telemetry.h
+++ b/be/src/util/telemetry/telemetry.h
@@ -1,0 +1,41 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include "opentelemetry/sdk/trace/tracer_provider.h"
+#include "opentelemetry/trace/provider.h"
+#include "opentelemetry/context/context.h"
+
+namespace doris::telemetry {
+
+using OpentelemetryTracer = opentelemetry::nostd::shared_ptr<opentelemetry::trace::Tracer>;
+
+void initTracerForZipkin();
+
+inline OpentelemetryTracer& get_noop_tracer() {
+    static OpentelemetryTracer noop_tracer =
+            opentelemetry::nostd::shared_ptr<opentelemetry::trace::NoopTracer>(
+                    new opentelemetry::trace::NoopTracer);
+    return noop_tracer;
+}
+
+inline OpentelemetryTracer get_tracer(const std::string& tracer_name) {
+    return opentelemetry::trace::Provider::GetTracerProvider()->GetTracer(tracer_name);
+}
+
+} // namespace doris::telemetry

--- a/be/src/util/telemetry/telemetry.h
+++ b/be/src/util/telemetry/telemetry.h
@@ -17,9 +17,9 @@
 
 #pragma once
 
+#include "opentelemetry/context/context.h"
 #include "opentelemetry/sdk/trace/tracer_provider.h"
 #include "opentelemetry/trace/provider.h"
-#include "opentelemetry/context/context.h"
 
 namespace doris::telemetry {
 

--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -605,6 +605,33 @@ under the License.
             <scope>provided</scope>
         </dependency>
 
+        <!-- https://mvnrepository.com/artifact/io.opentelemetry/opentelemetry-api -->
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+            <version>1.11.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk</artifactId>
+            <version>1.11.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-exporter-otlp-trace</artifactId>
+            <version>1.11.0</version>
+        </dependency>
+
+        <!-- https://mvnrepository.com/artifact/io.opentelemetry/opentelemetry-exporter-zipkin -->
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-exporter-zipkin</artifactId>
+            <version>1.11.0</version>
+        </dependency>
+
+
         <dependency>
             <groupId>org.apache.iceberg</groupId>
             <artifactId>iceberg-core</artifactId>

--- a/fe/fe-core/src/main/java/org/apache/doris/PaloFe.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/PaloFe.java
@@ -25,6 +25,7 @@ import org.apache.doris.common.Log4jConfig;
 import org.apache.doris.common.MetaReader;
 import org.apache.doris.common.ThreadPoolManager;
 import org.apache.doris.common.Version;
+import org.apache.doris.common.opentelemetry.Telemetry;
 import org.apache.doris.common.util.JdkUtils;
 import org.apache.doris.common.util.NetUtils;
 import org.apache.doris.httpv2.HttpServer;
@@ -117,6 +118,8 @@ public class PaloFe {
 
             // check all port
             checkAllPorts();
+
+            Telemetry.initOpenTelemetry();
 
             if (Config.enable_bdbje_debug_mode) {
                 // Start in BDB Debug mode

--- a/fe/fe-core/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/Config.java
@@ -1635,6 +1635,12 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true, masterOnly = true)
     public static int cbo_default_sample_percentage = 10;
 
+    @ConfField(mutable = false, masterOnly = false)
+    public static boolean enable_tracing = false;
+
+    @ConfField(mutable = false, masterOnly = false)
+    public static String trace_export_url = "http://127.0.0.1:9411/api/v2/spans";
+
     /**
      * If set to TRUE, the compaction slower replica will be skipped when select get queryable replicas
      * Default is true.

--- a/fe/fe-core/src/main/java/org/apache/doris/common/opentelemetry/Telemetry.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/opentelemetry/Telemetry.java
@@ -1,0 +1,97 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.common.opentelemetry;
+
+import org.apache.doris.common.Config;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.concurrent.TimeUnit;
+
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
+import io.opentelemetry.context.propagation.ContextPropagators;
+import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporter;
+import io.opentelemetry.exporter.zipkin.ZipkinSpanExporter;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.resources.Resource;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
+import io.opentelemetry.sdk.trace.export.SpanExporter;
+
+/**
+ * All SDK management takes place here, away from the instrumentation code, which should only access
+ * the OpenTelemetry APIs.
+ */
+public class Telemetry {
+    private static final Logger LOG = LogManager.getLogger(Telemetry.class);
+
+    private static final String SERVICE_NAME = "Frontend";
+
+    private static OpenTelemetry openTelemetry = OpenTelemetry.noop();
+
+    public static void initOpenTelemetry() {
+        if (!Config.enable_tracing) {
+            return;
+        }
+
+        // todo: It may be possible to use oltp exporter to export telemetry data to a collector,
+        //  which in turn processes and sends telemetry data to multiple back-ends (e.g. zipkin, Prometheus,
+        //  Fluent Bit, etc.) to improve scalability.
+        String httpUrl = Config.trace_export_url;
+        SpanExporter spanExporter = zipkinExporter(httpUrl);
+
+        Resource serviceNameResource =
+                Resource.create(Attributes.of(AttributeKey.stringKey("service.name"), SERVICE_NAME));
+        // Send a batch of spans if ScheduleDelay time or MaxExportBatchSize is reached
+        BatchSpanProcessor spanProcessor =
+                BatchSpanProcessor.builder(spanExporter)
+                        .setScheduleDelay(100, TimeUnit.MILLISECONDS)
+                        .setMaxExportBatchSize(1000)
+                        .build();
+
+        SdkTracerProvider tracerProvider =
+                SdkTracerProvider.builder()
+                        .addSpanProcessor(spanProcessor)
+                        .setResource(Resource.getDefault().merge(serviceNameResource))
+                        .build();
+        openTelemetry = OpenTelemetrySdk.builder()
+                .setTracerProvider(tracerProvider)
+                .setPropagators(ContextPropagators.create(W3CTraceContextPropagator.getInstance()))
+                .build();
+        // .buildAndRegisterGlobal();
+
+        // add a shutdown hook to shut down the SDK
+        Runtime.getRuntime().addShutdownHook(new Thread(tracerProvider::shutdown));
+    }
+
+    private static SpanExporter zipkinExporter(String httpUrl) {
+        return ZipkinSpanExporter.builder().setEndpoint(httpUrl).build();
+    }
+
+    private static SpanExporter oltpExporter(String httpUrl) {
+        return OtlpGrpcSpanExporter.builder().setEndpoint(httpUrl).build();
+    }
+
+    public static OpenTelemetry getOpenTelemetry() {
+        return openTelemetry;
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/common/opentelemetry/Telemetry.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/opentelemetry/Telemetry.java
@@ -47,6 +47,10 @@ public class Telemetry {
 
     private static OpenTelemetry openTelemetry = OpenTelemetry.noop();
 
+    /**
+     * Initialize {@link OpenTelemetry} with {@link SdkTracerProvider}, {@link BatchSpanProcessor},
+     * {@link ZipkinSpanExporter} and {@link W3CTraceContextPropagator}.
+     */
     public static void initOpenTelemetry() {
         if (!Config.enable_tracing) {
             return;

--- a/fe/fe-core/src/main/java/org/apache/doris/common/opentelemetry/Telemetry.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/opentelemetry/Telemetry.java
@@ -19,11 +19,6 @@ package org.apache.doris.common.opentelemetry;
 
 import org.apache.doris.common.Config;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
-import java.util.concurrent.TimeUnit;
-
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
@@ -36,6 +31,10 @@ import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
 import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.concurrent.TimeUnit;
 
 /**
  * All SDK management takes place here, away from the instrumentation code, which should only access
@@ -63,20 +62,13 @@ public class Telemetry {
                 Resource.create(Attributes.of(AttributeKey.stringKey("service.name"), SERVICE_NAME));
         // Send a batch of spans if ScheduleDelay time or MaxExportBatchSize is reached
         BatchSpanProcessor spanProcessor =
-                BatchSpanProcessor.builder(spanExporter)
-                        .setScheduleDelay(100, TimeUnit.MILLISECONDS)
-                        .setMaxExportBatchSize(1000)
-                        .build();
+                BatchSpanProcessor.builder(spanExporter).setScheduleDelay(100, TimeUnit.MILLISECONDS)
+                        .setMaxExportBatchSize(1000).build();
 
-        SdkTracerProvider tracerProvider =
-                SdkTracerProvider.builder()
-                        .addSpanProcessor(spanProcessor)
-                        .setResource(Resource.getDefault().merge(serviceNameResource))
-                        .build();
-        openTelemetry = OpenTelemetrySdk.builder()
-                .setTracerProvider(tracerProvider)
-                .setPropagators(ContextPropagators.create(W3CTraceContextPropagator.getInstance()))
-                .build();
+        SdkTracerProvider tracerProvider = SdkTracerProvider.builder().addSpanProcessor(spanProcessor)
+                .setResource(Resource.getDefault().merge(serviceNameResource)).build();
+        openTelemetry = OpenTelemetrySdk.builder().setTracerProvider(tracerProvider)
+                .setPropagators(ContextPropagators.create(W3CTraceContextPropagator.getInstance())).build();
         // .buildAndRegisterGlobal();
 
         // add a shutdown hook to shut down the SDK

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectContext.java
@@ -39,14 +39,13 @@ import org.apache.doris.transaction.TransactionStatus;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+import io.opentelemetry.api.trace.Tracer;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.nio.channels.SocketChannel;
 import java.util.List;
 import java.util.Set;
-
-import io.opentelemetry.api.trace.Tracer;
 
 // When one client connect in, we create a connect context for it.
 // We store session information here. Meanwhile ConnectScheduler all

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectContext.java
@@ -22,6 +22,7 @@ import org.apache.doris.catalog.Catalog;
 import org.apache.doris.catalog.Database;
 import org.apache.doris.cluster.ClusterNamespace;
 import org.apache.doris.common.UserException;
+import org.apache.doris.common.opentelemetry.Telemetry;
 import org.apache.doris.common.util.DebugUtil;
 import org.apache.doris.datasource.SessionContext;
 import org.apache.doris.mysql.MysqlCapability;
@@ -44,6 +45,8 @@ import org.apache.logging.log4j.Logger;
 import java.nio.channels.SocketChannel;
 import java.util.List;
 import java.util.Set;
+
+import io.opentelemetry.api.trace.Tracer;
 
 // When one client connect in, we create a connect context for it.
 // We store session information here. Meanwhile ConnectScheduler all
@@ -103,6 +106,8 @@ public class ConnectContext {
     protected volatile long startTime;
     // Cache thread info for this connection.
     protected volatile ThreadInfo threadInfo;
+
+    protected volatile Tracer tracer;
 
     // Catalog: put catalog here is convenient for unit test,
     // because catalog is singleton, hard to mock
@@ -463,6 +468,14 @@ public class ConnectContext {
 
     public void setSqlHash(String sqlHash) {
         this.sqlHash = sqlHash;
+    }
+
+    public Tracer getTracer() {
+        return tracer;
+    }
+
+    public void initTracer(String name) {
+        this.tracer = Telemetry.getOpenTelemetry().getTracer(name);
     }
 
     // kill operation with no protect.

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectProcessor.java
@@ -54,6 +54,8 @@ import org.apache.doris.thrift.TUniqueId;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.context.Scope;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -65,9 +67,6 @@ import java.nio.ByteBuffer;
 import java.nio.channels.AsynchronousCloseException;
 import java.util.List;
 import java.util.UUID;
-
-import io.opentelemetry.api.trace.Span;
-import io.opentelemetry.context.Scope;
 
 /**
  * Process one mysql connection, receive one packet, process, send one packet.

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -122,6 +122,9 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.google.protobuf.ByteString;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.Scope;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.thrift.TException;
@@ -139,10 +142,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
-
-import io.opentelemetry.api.trace.Span;
-import io.opentelemetry.context.Context;
-import io.opentelemetry.context.Scope;
 
 // Do one COM_QUERY process.
 // first: Parse receive byte array to statement struct.
@@ -337,8 +336,8 @@ public class StmtExecutor implements ProfileWriter {
 
             if (!context.isTxnModel()) {
                 Span queryAnalysisSpan = context.getTracer().spanBuilder("query analysis")
-                        .setParent(Context.current())
-                        .startSpan();
+                    .setParent(Context.current())
+                    .startSpan();
                 try (Scope scope = queryAnalysisSpan.makeCurrent()) {
                     // analyze this query
                     analyze(context.getSessionVariable().toThrift());
@@ -996,8 +995,8 @@ public class StmtExecutor implements ProfileWriter {
         }
 
         Span queryScheduleSpan = context.getTracer().spanBuilder("query schedule")
-                .setParent(Context.current())
-                .startSpan();
+            .setParent(Context.current())
+            .startSpan();
         // send result
         // 1. If this is a query with OUTFILE clause, eg: select * from tbl1 into outfile xxx,
         //    We will not send real query result to client. Instead, we only send OK to client with
@@ -1022,8 +1021,8 @@ public class StmtExecutor implements ProfileWriter {
         plannerProfile.setQueryScheduleFinishTime();
         writeProfile(false);
         Span fetchResultSpan = context.getTracer().spanBuilder("fetch result")
-                .setParent(Context.current())
-                .startSpan();
+            .setParent(Context.current())
+            .startSpan();
         try (Scope scope = fetchResultSpan.makeCurrent()) {
             while (true) {
                 batch = coord.getNext();

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -1024,8 +1024,8 @@ public class StmtExecutor implements ProfileWriter {
                 batch = coord.getNext();
                 // for outfile query, there will be only one empty batch send back with eos flag
                 if (batch.getBatch() != null) {
-                    // For some language driver, getting error packet after fields packet will be recognized as a success result
-                    // so We need to send fields after first batch arrived
+                    // For some language driver, getting error packet after fields packet will be recognized as a
+                    // success result. so We need to send fields after first batch arrived
                     if (!isSendFields) {
                         if (!isOutfileQuery) {
                             sendFields(queryStmt.getColLabels(), exprToType(queryStmt.getResultExprs()));

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -335,9 +335,8 @@ public class StmtExecutor implements ProfileWriter {
             analyzeVariablesInStmt();
 
             if (!context.isTxnModel()) {
-                Span queryAnalysisSpan = context.getTracer().spanBuilder("query analysis")
-                    .setParent(Context.current())
-                    .startSpan();
+                Span queryAnalysisSpan =
+                        context.getTracer().spanBuilder("query analysis").setParent(Context.current()).startSpan();
                 try (Scope scope = queryAnalysisSpan.makeCurrent()) {
                     // analyze this query
                     analyze(context.getSessionVariable().toThrift());
@@ -994,9 +993,8 @@ public class StmtExecutor implements ProfileWriter {
             return;
         }
 
-        Span queryScheduleSpan = context.getTracer().spanBuilder("query schedule")
-            .setParent(Context.current())
-            .startSpan();
+        Span queryScheduleSpan =
+                context.getTracer().spanBuilder("query schedule").setParent(Context.current()).startSpan();
         // send result
         // 1. If this is a query with OUTFILE clause, eg: select * from tbl1 into outfile xxx,
         //    We will not send real query result to client. Instead, we only send OK to client with
@@ -1020,9 +1018,7 @@ public class StmtExecutor implements ProfileWriter {
         }
         plannerProfile.setQueryScheduleFinishTime();
         writeProfile(false);
-        Span fetchResultSpan = context.getTracer().spanBuilder("fetch result")
-            .setParent(Context.current())
-            .startSpan();
+        Span fetchResultSpan = context.getTracer().spanBuilder("fetch result").setParent(Context.current()).startSpan();
         try (Scope scope = fetchResultSpan.makeCurrent()) {
             while (true) {
                 batch = coord.getNext();

--- a/fe/fe-core/src/main/java/org/apache/doris/rpc/BackendServiceClient.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/rpc/BackendServiceClient.java
@@ -136,8 +136,8 @@ public class BackendServiceClient {
         LOG.warn("shut down backend service client: {}", address);
     }
 
-    /***
-     * OpenTelemetry span interceptor
+    /**
+     * OpenTelemetry span interceptor.
      */
     public static class OpenTelemetryClientInterceptor implements ClientInterceptor {
         @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/rpc/BackendServiceClient.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/rpc/BackendServiceClient.java
@@ -136,6 +136,9 @@ public class BackendServiceClient {
         LOG.warn("shut down backend service client: {}", address);
     }
 
+    /***
+     * OpenTelemetry span interceptor
+     */
     public static class OpenTelemetryClientInterceptor implements ClientInterceptor {
         @Override
         public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(MethodDescriptor<ReqT, RespT> methodDescriptor,

--- a/fe/fe-core/src/main/java/org/apache/doris/rpc/BackendServiceClient.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/rpc/BackendServiceClient.java
@@ -18,17 +18,27 @@
 package org.apache.doris.rpc;
 
 import org.apache.doris.common.Config;
+import org.apache.doris.common.opentelemetry.Telemetry;
 import org.apache.doris.proto.InternalService;
 import org.apache.doris.proto.PBackendServiceGrpc;
 import org.apache.doris.thrift.TNetworkAddress;
 
-import io.grpc.ManagedChannel;
-import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.ClientCall;
+import io.grpc.ClientInterceptor;
+import io.grpc.ForwardingClientCall;
+import io.grpc.ManagedChannel;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder;
+import io.opentelemetry.context.Context;
 
 public class BackendServiceClient {
     public static final Logger LOG = LogManager.getLogger(BackendServiceClient.class);
@@ -45,6 +55,7 @@ public class BackendServiceClient {
                 .flowControlWindow(Config.grpc_max_message_size_bytes)
                 .maxInboundMessageSize(Config.grpc_max_message_size_bytes)
                 .enableRetry().maxRetryAttempts(MAX_RETRY_NUM)
+                .intercept(new OpenTelemetryClientInterceptor())
                 .usePlaintext().build();
         stub = PBackendServiceGrpc.newFutureStub(channel);
         blockingStub = PBackendServiceGrpc.newBlockingStub(channel);
@@ -124,5 +135,23 @@ public class BackendServiceClient {
         }
 
         LOG.warn("shut down backend service client: {}", address);
+    }
+
+    public static class OpenTelemetryClientInterceptor implements ClientInterceptor {
+        @Override
+        public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
+            MethodDescriptor<ReqT, RespT> methodDescriptor, CallOptions callOptions, Channel channel) {
+            return new ForwardingClientCall.SimpleForwardingClientCall<ReqT, RespT>(
+                channel.newCall(methodDescriptor, callOptions)) {
+                @Override
+                public void start(Listener<RespT> responseListener, Metadata headers) {
+                    // Inject the request with the current context
+                    Telemetry.getOpenTelemetry().getPropagators().getTextMapPropagator()
+                        .inject(Context.current(), headers, (carrier, key, value) ->
+                            carrier.put(Metadata.Key.of(key, Metadata.ASCII_STRING_MARSHALLER), value));
+                    super.start(responseListener, headers);
+                }
+            };
+        }
     }
 }

--- a/thirdparty/build-thirdparty.sh
+++ b/thirdparty/build-thirdparty.sh
@@ -1006,6 +1006,28 @@ build_simdjson() {
     cp -r $TP_SOURCE_DIR/$SIMDJSON_SOURCE/include/* $TP_INCLUDE_DIR/
 }
 
+# nlohmann_json
+build_nlohmann_json() {
+    check_if_source_exist $NLOHMANN_JSON_SOURCE
+    cd $TP_SOURCE_DIR/$NLOHMANN_JSON_SOURCE
+    mkdir -p $BUILD_DIR && cd $BUILD_DIR
+
+    $CMAKE_CMD -DCMAKE_INSTALL_PREFIX=$TP_INSTALL_DIR -DCMAKE_PREFIX_PATH=$TP_INSTALL_DIR ..
+    $CMAKE_CMD --build .
+    $CMAKE_CMD --install . --prefix $TP_INSTALL_DIR
+}
+
+# opentelemetry
+build_opentelemetry() {
+    check_if_source_exist $OPENTELEMETRY_SOURCE
+    cd $TP_SOURCE_DIR/$OPENTELEMETRY_SOURCE
+    mkdir -p $BUILD_DIR && cd $BUILD_DIR
+
+    $CMAKE_CMD -DCMAKE_INSTALL_PREFIX=$TP_INSTALL_DIR -DCMAKE_PREFIX_PATH=$TP_INSTALL_DIR -DBUILD_TESTING=OFF -DWITH_ZIPKIN=ON -DWITH_EXAMPLES=OFF ..
+    $CMAKE_CMD --build . --target all
+    $CMAKE_CMD --install . --prefix $TP_INSTALL_DIR
+}
+
 build_libunixodbc
 build_openssl
 build_libevent
@@ -1056,6 +1078,8 @@ build_hdfs3_with_kerberos
 build_benchmark
 build_breakpad
 build_simdjson
+build_nlohmann_json
+build_opentelemetry
 build_libbacktrace
 
 echo "Finished to build all thirdparties"

--- a/thirdparty/download-thirdparty.sh
+++ b/thirdparty/download-thirdparty.sh
@@ -301,6 +301,18 @@ if [ $ROCKSDB_SOURCE == "rocksdb-5.14.2" ]; then
 fi
 echo "Finished patching $ROCKSDB_SOURCE"
 
+# opentelemetry patch is used to solve the problem that threadlocal depends on GLIBC_2.18
+# see: https://github.com/apache/incubator-doris/pull/7911
+if [ $OPENTELEMETRY_SOURCE == "opentelemetry-cpp-1.2.0" ]; then
+    cd $TP_SOURCE_DIR/$OPENTELEMETRY_SOURCE
+    if [ ! -f $PATCHED_MARK ]; then
+        patch -p1 < $TP_PATCH_DIR/opentelemetry-cpp-1.2.0.patch
+        touch $PATCHED_MARK
+    fi
+    cd -
+fi
+echo "Finished patching $OPENTELEMETRY_SOURCE"
+
 # patch librdkafka to avoid crash
 if [ $LIBRDKAFKA_SOURCE = "librdkafka-1.8.2" ]; then
     cd $TP_SOURCE_DIR/$LIBRDKAFKA_SOURCE

--- a/thirdparty/patches/opentelemetry-cpp-1.2.0.patch
+++ b/thirdparty/patches/opentelemetry-cpp-1.2.0.patch
@@ -1,0 +1,374 @@
+diff --git a/api/include/opentelemetry/common/threadlocal.h b/api/include/opentelemetry/common/threadlocal.h
+new file mode 100644
+index 0000000..799ec6c
+--- /dev/null
++++ b/api/include/opentelemetry/common/threadlocal.h
+@@ -0,0 +1,206 @@
++// Copyright The OpenTelemetry Authors
++// SPDX-License-Identifier: Apache-2.0
++
++#pragma once
++
++#include <pthread.h>
++
++#include <memory>
++#include <mutex>
++#include <ostream>
++
++//
++// GCC can be told that a certain branch is not likely to be taken (for
++// instance, a CHECK failure), and use that information in static analysis.
++// Giving it this information can help it optimize for the common case in
++// the absence of better information (ie. -fprofile-arcs).
++//
++#ifndef PREDICT_FALSE
++#if defined(__GNUC__)
++#define PREDICT_FALSE(x) (__builtin_expect(x, 0))
++#else
++#define PREDICT_FALSE(x) x
++#endif
++#endif
++#ifndef PREDICT_TRUE
++#if defined(__GNUC__)
++#define PREDICT_TRUE(x) (__builtin_expect(!!(x), 1))
++#else
++#define PREDICT_TRUE(x) x
++#endif
++#endif
++
++// Block-scoped static thread local implementation.
++//
++// Usage is similar to a C++11 thread_local. The BLOCK_STATIC_THREAD_LOCAL_TELEMTRY macro
++// defines a thread-local pointer to the specified type, which is lazily
++// instantiated by any thread entering the block for the first time. The
++// constructor for the type T is invoked at macro execution time, as expected,
++// and its destructor is invoked when the corresponding thread's Runnable
++// returns, or when the thread exits.
++//
++// Inspired by Poco <http://pocoproject.org/docs/Poco.ThreadLocal.html>,
++// Andrew Tomazos <http://stackoverflow.com/questions/12049684/>, and
++// the C++11 thread_local API.
++//
++// Example usage:
++//
++// // Invokes a 3-arg constructor on SomeClass:
++// BLOCK_STATIC_THREAD_LOCAL_TELEMTRY(SomeClass, instance, arg1, arg2, arg3);
++// instance->DoSomething();
++//
++#define BLOCK_STATIC_THREAD_LOCAL_TELEMTRY(T, t, ...)                                    \
++static __thread T* t;                                                           \
++do {                                                                            \
++  if (PREDICT_FALSE(t == NULL)) {                                               \
++    t = new T(__VA_ARGS__);                                                     \
++    internal_threadlocal::ThreadLocal::AddDestructor(internal_threadlocal::ThreadLocal::Destroy<T>, t); \
++  }                                                                             \
++} while (false)
++
++// Class-scoped static thread local implementation.
++//
++// Very similar in implementation to the above block-scoped version, but
++// requires a bit more syntax and vigilance to use properly.
++//
++// DECLARE_STATIC_THREAD_LOCAL_TELEMETRY(Type, instance_var_) must be placed in the
++// class header, as usual for variable declarations.
++//
++// Because these variables are static, they must also be defined in the impl
++// file with DEFINE_STATIC_THREAD_LOCAL_TELEMETRY(Type, Classname, instance_var_),
++// which is very much like defining any static member, i.e. int Foo::member_.
++//
++// Finally, each thread must initialize the instance before using it by calling
++// INIT_STATIC_THREAD_LOCAL_TELEMETRY(Type, instance_var_, ...). This is a cheap
++// call, and may be invoked at the top of any method which may reference a
++// thread-local variable.
++//
++// Due to all of these requirements, you should probably declare TLS members
++// as private.
++//
++// Example usage:
++//
++// // foo.h
++// #include "kudu/utils/file.h"
++// class Foo {
++//  public:
++//   void DoSomething(std::string s);
++//  private:
++//   DECLARE_STATIC_THREAD_LOCAL_TELEMETRY(utils::File, file_);
++// };
++//
++// // foo.cc
++// #include "kudu/foo.h"
++// DEFINE_STATIC_THREAD_LOCAL_TELEMETRY(utils::File, Foo, file_);
++// void Foo::WriteToFile(std::string s) {
++//   // Call constructor if necessary.
++//   INIT_STATIC_THREAD_LOCAL_TELEMETRY(utils::File, file_, "/tmp/file_location.txt");
++//   file_->Write(s);
++// }
++
++// Goes in the class declaration (usually in a header file).
++// dtor must be destructed _after_ t, so it gets defined first.
++// Uses a mangled variable name for dtor since it must also be a member of the
++// class.
++#define DECLARE_STATIC_THREAD_LOCAL_TELEMETRY(T, t)                                                     \
++static __thread T* t
++
++// You must also define the instance in the .cc file.
++#define DEFINE_STATIC_THREAD_LOCAL_TELEMETRY(T, Class, t)                                               \
++__thread T* Class::t
++
++// Must be invoked at least once by each thread that will access t.
++#define INIT_STATIC_THREAD_LOCAL_TELEMETRY(T, t, ...)                                       \
++do {                                                                              \
++  if (PREDICT_FALSE(t == NULL)) {                                                 \
++    t = new T(__VA_ARGS__);                                                       \
++    internal_threadlocal::ThreadLocal::AddDestructor(internal_threadlocal::ThreadLocal::Destroy<T>, t);     \
++  }                                                                               \
++} while (false)
++
++// Internal implementation below.
++OPENTELEMETRY_BEGIN_NAMESPACE
++namespace internal_threadlocal
++{
++
++// One key used by the entire process to attach destructors on thread exit.
++static pthread_key_t destructors_key;
++
++static std::once_flag once_init;
++
++namespace
++{
++// List of destructors for all thread locals instantiated on a given thread.
++struct PerThreadDestructorList
++{
++  void (*destructor)(void *);
++  void *arg;
++  PerThreadDestructorList *next;
++};
++
++}  // anonymous namespace
++
++class ThreadLocal {
++public:
++// Destroy the passed object of type T.
++  template <class T>
++  static void Destroy(void *t)
++  {
++    // With tcmalloc, this should be pretty cheap (same thread as new).
++    delete reinterpret_cast<T *>(t);
++  }
++
++  // Call all the destructors associated with all THREAD_LOCAL instances in this
++// thread.
++  static void InvokeDestructors(void *t)
++  {
++    PerThreadDestructorList *d = reinterpret_cast<PerThreadDestructorList *>(t);
++    while (d != nullptr)
++    {
++      d->destructor(d->arg);
++      PerThreadDestructorList *next = d->next;
++      delete d;
++      d = next;
++    }
++  }
++
++// This key must be initialized only once.
++  static void CreateKey()
++  {
++    int ret = pthread_key_create(&destructors_key, &InvokeDestructors);
++    // Linux supports up to 1024 keys, we will use only one for all thread locals.
++/*    if (ret != 0)
++    {
++      std::stringstream ss;
++      ss << "[thread local] pthread_key_create() failed, cannot add destructor to thread: "
++         << "error " << ret;
++      OTEL_INTERNAL_LOG_ERROR(ss.str());
++    }*/
++  }
++
++// Adds a destructor to the list.
++  static void AddDestructor(void (*destructor)(void *), void *arg)
++  {
++    std::call_once(once_init, &CreateKey);
++
++    // Returns NULL if nothing is set yet.
++    std::unique_ptr<PerThreadDestructorList> p(new PerThreadDestructorList());
++    p->destructor = destructor;
++    p->arg        = arg;
++    p->next       = reinterpret_cast<PerThreadDestructorList *>(pthread_getspecific(destructors_key));
++    int ret       = pthread_setspecific(destructors_key, p.release());
++    // The only time this check should fail is if we are out of memory, or if
++    // somehow key creation failed, which should be caught by the above CHECK.
++/*    if (ret != 0)
++    {
++      std::stringstream ss;
++      ss << "[thread local] pthread_setspecific() failed, cannot update destructor list: "
++         << "error " << ret;
++      OTEL_INTERNAL_LOG_ERROR(ss.str());
++    }*/
++  }
++
++};
++
++}  // namespace threadlocal
++OPENTELEMETRY_END_NAMESPACE
+\ No newline at end of file
+diff --git a/api/include/opentelemetry/context/runtime_context.h b/api/include/opentelemetry/context/runtime_context.h
+index 5cb793b..24ba44b 100644
+--- a/api/include/opentelemetry/context/runtime_context.h
++++ b/api/include/opentelemetry/context/runtime_context.h
+@@ -4,6 +4,7 @@
+ #pragma once
+ 
+ #include "opentelemetry/context/context.h"
++#include "opentelemetry/common/threadlocal.h"
+ 
+ OPENTELEMETRY_BEGIN_NAMESPACE
+ namespace context
+@@ -178,7 +179,7 @@ class ThreadLocalContextStorage : public RuntimeContextStorage
+   ThreadLocalContextStorage() noexcept = default;
+ 
+   // Return the current context.
+-  Context GetCurrent() noexcept override { return GetStack().Top(); }
++  Context GetCurrent() noexcept override { return GetStack()->Top(); }
+ 
+   // Resets the context to the value previous to the passed in token. This will
+   // also detach all child contexts of the passed in token.
+@@ -186,23 +187,23 @@ class ThreadLocalContextStorage : public RuntimeContextStorage
+   bool Detach(Token &token) noexcept override
+   {
+     // In most cases, the context to be detached is on the top of the stack.
+-    if (token == GetStack().Top())
++    if (token == GetStack()->Top())
+     {
+-      GetStack().Pop();
++      GetStack()->Pop();
+       return true;
+     }
+ 
+-    if (!GetStack().Contains(token))
++    if (!GetStack()->Contains(token))
+     {
+       return false;
+     }
+ 
+-    while (!(token == GetStack().Top()))
++    while (!(token == GetStack()->Top()))
+     {
+-      GetStack().Pop();
++      GetStack()->Pop();
+     }
+ 
+-    GetStack().Pop();
++    GetStack()->Pop();
+ 
+     return true;
+   }
+@@ -211,14 +212,14 @@ class ThreadLocalContextStorage : public RuntimeContextStorage
+   // that can be used to reset to the previous Context.
+   nostd::unique_ptr<Token> Attach(const Context &context) noexcept override
+   {
+-    GetStack().Push(context);
++    GetStack()->Push(context);
+     return CreateToken(context);
+   }
+ 
+-private:
+   // A nested class to store the attached contexts in a stack.
+   class Stack
+   {
++  public:
+     friend class ThreadLocalContextStorage;
+ 
+     Stack() noexcept : size_(0), capacity_(0), base_(nullptr){};
+@@ -305,9 +306,10 @@ class ThreadLocalContextStorage : public RuntimeContextStorage
+     Context *base_;
+   };
+ 
+-  Stack &GetStack()
++  Stack *GetStack()
+   {
+-    static thread_local Stack stack_ = Stack();
++    // static thread_local Stack stack_ = Stack();
++    BLOCK_STATIC_THREAD_LOCAL_TELEMTRY(ThreadLocalContextStorage::Stack, stack_);
+     return stack_;
+   }
+ };
+diff --git a/sdk/CMakeLists.txt b/sdk/CMakeLists.txt
+index 9aa4588..e2c5a4a 100644
+--- a/sdk/CMakeLists.txt
++++ b/sdk/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-add_library(opentelemetry_sdk INTERFACE)
++add_library(opentelemetry_sdk INTERFACE ../api/include/opentelemetry/common/threadlocal.h)
+ target_include_directories(
+   opentelemetry_sdk
+   INTERFACE "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>"
+diff --git a/sdk/src/common/random.cc b/sdk/src/common/random.cc
+index 77b88cf..dc71f9c 100644
+--- a/sdk/src/common/random.cc
++++ b/sdk/src/common/random.cc
+@@ -3,6 +3,7 @@
+ // SPDX-License-Identifier: Apache-2.0
+ 
+ #include "src/common/random.h"
++#include "opentelemetry/common/threadlocal.h"
+ #include "src/common/platform/fork.h"
+ 
+ #include <cstring>
+@@ -29,33 +30,37 @@ class TlsRandomNumberGenerator
+     platform::AtFork(nullptr, nullptr, OnFork);
+   }
+ 
+-  static FastRandomNumberGenerator &engine() noexcept { return engine_; }
++  static FastRandomNumberGenerator *engine() noexcept { return engine_; }
+ 
+ private:
+-  static thread_local FastRandomNumberGenerator engine_;
++  // static thread_local FastRandomNumberGenerator engine_;
++  DECLARE_STATIC_THREAD_LOCAL_TELEMETRY(FastRandomNumberGenerator, engine_);
+ 
+   static void OnFork() noexcept { Seed(); }
+ 
+   static void Seed() noexcept
+   {
++    INIT_STATIC_THREAD_LOCAL_TELEMETRY(FastRandomNumberGenerator, engine_);
+     std::random_device random_device;
+     std::seed_seq seed_seq{random_device(), random_device(), random_device(), random_device()};
+-    engine_.seed(seed_seq);
++    engine_->seed(seed_seq);
+   }
+ };
+ 
+-thread_local FastRandomNumberGenerator TlsRandomNumberGenerator::engine_{};
++// thread_local FastRandomNumberGenerator TlsRandomNumberGenerator::engine_{};
++DEFINE_STATIC_THREAD_LOCAL_TELEMETRY(FastRandomNumberGenerator, TlsRandomNumberGenerator, engine_);
+ }  // namespace
+ 
+-FastRandomNumberGenerator &Random::GetRandomNumberGenerator() noexcept
++FastRandomNumberGenerator *Random::GetRandomNumberGenerator() noexcept
+ {
+-  static thread_local TlsRandomNumberGenerator random_number_generator{};
++  // static thread_local TlsRandomNumberGenerator random_number_generator{};
++  BLOCK_STATIC_THREAD_LOCAL_TELEMTRY(TlsRandomNumberGenerator, random_number_generator);
+   return TlsRandomNumberGenerator::engine();
+ }
+ 
+ uint64_t Random::GenerateRandom64() noexcept
+ {
+-  return GetRandomNumberGenerator()();
++  return GetRandomNumberGenerator()->operator()();
+ }
+ 
+ void Random::GenerateRandomBuffer(opentelemetry::nostd::span<uint8_t> buffer) noexcept
+diff --git a/sdk/src/common/random.h b/sdk/src/common/random.h
+index ecd6dab..1aaa220 100644
+--- a/sdk/src/common/random.h
++++ b/sdk/src/common/random.h
+@@ -34,7 +34,7 @@ class Random
+   /**
+    * @return a seeded thread-local random number generator.
+    */
+-  static FastRandomNumberGenerator &GetRandomNumberGenerator() noexcept;
++  static FastRandomNumberGenerator *GetRandomNumberGenerator() noexcept;
+ };
+ }  // namespace common
+ }  // namespace sdk

--- a/thirdparty/vars.sh
+++ b/thirdparty/vars.sh
@@ -386,6 +386,18 @@ SIMDJSON_NAME=simdjson-1.0.2.tar.gz
 SIMDJSON_SOURCE=simdjson-1.0.2
 SIMDJSON_MD5SUM="5bb34cca7087a99c450dbdfe406bdc7d"
 
+# nlohmann_json
+NLOHMANN_JSON_DOWNLOAD="https://github.com/nlohmann/json/archive/refs/tags/v3.10.1.tar.gz"
+NLOHMANN_JSON_NAME=json-3.10.1.tar.gz
+NLOHMANN_JSON_SOURCE=json-3.10.1
+NLOHMANN_JSON_MD5SUM="7b369d567afc0dffdcf5800fd9abb836"
+
+# opentelemetry
+OPENTELEMETRY_DOWNLOAD="https://github.com/open-telemetry/opentelemetry-cpp/archive/refs/tags/v1.2.0.tar.gz"
+OPENTELEMETRY_NAME=opentelemetry-cpp-1.2.0.tar.gz
+OPENTELEMETRY_SOURCE=opentelemetry-cpp-1.2.0
+OPENTELEMETRY_MD5SUM="c084abc742c6b3cd4c9c3684e559d4e1"
+
 # libbacktrace
 LIBBACKTRACE_DOWNLOAD="https://codeload.github.com/ianlancetaylor/libbacktrace/zip/2446c66076480ce07a6bd868badcbceb3eeecc2e"
 LIBBACKTRACE_NAME=libbacktrace-2446c66076480ce07a6bd868badcbceb3eeecc2e.zip
@@ -447,4 +459,6 @@ BENCHMARK
 BREAKPAD
 XSIMD
 SIMDJSON
+NLOHMANN_JSON
+OPENTELEMETRY
 LIBBACKTRACE"


### PR DESCRIPTION

The collection of query traces is implemented in fe and be, and the spans are exported to zipkin.

# Proposed changes

Issue Number: #9577 

I plan to introduce OpenTelemetry to collect telemetry data, such as traces, metrics, logs, to improve the observability of Doris.

### The first phase uses OpenTelemetry to implement the collection and export of traces.

A trace represents the execution process of a single request in the system, span represents a logical operation unit with start time and execution duration in the system, and multiple spans form a trace.

1. support the collection and export of query traces

2. support the collection and export of load traces

### The second phase integrates metrics and logs to OpenTelemtry standard.

## Problem Summary:

This pr implements the collection and sending of query traces. fe turns on traces, collects spans and propagates the traces information to be via prc. eventually each node exports the collected spans to zipkin. 

```
┌──────────────────────┐
│                   fe │
│                      │
│        span root     │
│            │         │
│    ┌───────┴────┐    ├────────────────┐
│    │            │    │                │
│  span A      span B  │                │
│                │     │                │
│                │     │                │
└────────────────┼─────┘                │
                 │                      │
           ┌─────┴───────────────┐      │
           │                     │      │
┌──────────┼───────────┐                │
│          │       be  │        be      │          ┌────────────┐
│          │           │                │          │            │
│         span C       │                │   span   │            │
│          │           ├────────────────┴──────────►   zipkin   │
│    ┌─────┴───────┐   │                           │            │
│    │             │   │                           │            │
│   span D      span E │                           │            │
│                      │                           └────────────┘
└──────────────────────┘
```

### Example：

1. Start zipkin:

```
curl -sSL https://zipkin.io/quickstart.sh | bash -s
java -jar zipkin.jar
```

2. Add Configuration：

fe.conf:
```
enable_tracing=true
trace_export_url=http://127.0.0.1:9411/api/v2/spans
```
be.conf:
```
enable_tracing=true
trace_export_url=http://127.0.0.1:9411/api/v2/spans
```

3.  Execute a query

4.  From zipkin UI：

![截屏2022-05-17 12 20 32](https://user-images.githubusercontent.com/37725793/168728478-e55dd1c0-9fcc-46e1-aac3-25ebaf996cbd.png)

## Checklist(Required)

1. Does it affect the original behavior: (No)
2. Has unit tests been added: (No)
3. Has document been added or modified: (No)
4. Does it need to update dependencies: (Yes)
5. Are there any changes that cannot be rolled back: (No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
