### PR TITLE
[Enhancement] Support show proc BackendLoadStatistic

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/clone/ClusterLoadStatistic.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/ClusterLoadStatistic.java
@@ -280,10 +280,13 @@ public class ClusterLoadStatistic {
                 List<String> pathStat = Lists.newArrayList();
                 pathStat.add(pathStatistic.getPath());
                 pathStat.add(String.valueOf(pathStatistic.getPathHash()));
+                pathStat.add(pathStatistic.getStorageMedium().name());
                 pathStat.add(String.valueOf(pathStatistic.getUsedCapacityB()));
                 pathStat.add(String.valueOf(pathStatistic.getCapacityB()));
                 pathStat.add(String.valueOf(DebugUtil.DECIMAL_FORMAT_SCALE_3.format(pathStatistic.getUsedCapacityB() * 100
                         / (double) pathStatistic.getCapacityB())));
+                pathStat.add(pathStatistic.getClazz().name());
+                pathStat.add(pathStatistic.getDiskState().name());
                 statistics.add(pathStat);
             }
             break;

--- a/fe/fe-core/src/main/java/org/apache/doris/common/proc/BackendLoadStatisticProcNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/proc/BackendLoadStatisticProcNode.java
@@ -1,0 +1,50 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.common.proc;
+
+import org.apache.doris.clone.ClusterLoadStatistic;
+import org.apache.doris.common.AnalysisException;
+
+import com.google.common.collect.ImmutableList;
+
+
+public class BackendLoadStatisticProcNode implements ProcNodeInterface {
+    public static final ImmutableList<String> TITLE_NAMES = new ImmutableList.Builder<String>()
+        .add("RootPath").add("PathHash").add("StorageMedium")
+        .add("DataUsedCapacity").add("TotalCapacity").add("TotalUsedPct")
+        .add("Class").add("State")
+        .build();
+
+    private final ClusterLoadStatistic statistic;
+    private final long beId;
+
+    public BackendLoadStatisticProcNode(ClusterLoadStatistic statistic, long beId) {
+        this.statistic = statistic;
+        this.beId = beId;
+    }
+
+    @Override
+    public ProcResult fetchResult() throws AnalysisException {
+        BaseProcResult result = new BaseProcResult();
+        result.setNames(TITLE_NAMES);
+        if (statistic != null) {
+            result.setRows(statistic.getBackendStatistic(beId));
+        }
+        return result;
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/common/proc/ClusterLoadStatisticProcDir.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/proc/ClusterLoadStatisticProcDir.java
@@ -38,7 +38,6 @@ public class ClusterLoadStatisticProcDir implements ProcDirInterface {
             .add("Class")
             .build();
 
-    private Table<String, Tag, ClusterLoadStatistic> statMap;
     private Tag tag;
     private TStorageMedium medium;
 
@@ -52,8 +51,7 @@ public class ClusterLoadStatisticProcDir implements ProcDirInterface {
         BaseProcResult result = new BaseProcResult();
         result.setNames(TITLE_NAMES);
 
-        statMap = Catalog.getCurrentCatalog().getTabletScheduler().getStatisticMap();
-        Map<String, ClusterLoadStatistic> map = statMap.column(tag);
+        Map<String, ClusterLoadStatistic> map = Catalog.getCurrentCatalog().getTabletScheduler().getStatisticMap().column(tag);
 
         map.values().forEach(t -> {
             List<List<String>> statistics = t.getClusterStatistic(medium);
@@ -81,7 +79,9 @@ public class ClusterLoadStatisticProcDir implements ProcDirInterface {
         if (be == null) {
             throw new AnalysisException("backend " + beId + " does not exist");
         }
-        return new BackendProcNode(be);
+
+        Map<String, ClusterLoadStatistic> map = Catalog.getCurrentCatalog().getTabletScheduler().getStatisticMap().column(tag);
+        return new BackendLoadStatisticProcNode(map.get(be.getOwnerClusterName()), beId);
     }
 
 }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #9617

## Problem Summary:

The proc info method already exists in `ClusterLoadStatistic.getBackendStatistic`, I'll add a proc node to show it.

## Checklist(Required)

1. Does it affect the original behavior: (Yes)
2. Has unit tests been added: (No Need)
3. Has document been added or modified: (No Need)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (No)
