### PR TITLE
[Improvement] make BE can exit normally and ASAN memory leak checking work  properly

### DIFF
--- a/be/src/runtime/minidump.cpp
+++ b/be/src/runtime/minidump.cpp
@@ -104,7 +104,7 @@ bool Minidump::_minidump_cb(const google_breakpad::MinidumpDescriptor& descripto
 }
 
 void Minidump::stop() {
-    if (_stop) {
+    if (config::disable_minidump || _stop) {
         return;
     }
     _stop = true;

--- a/be/src/util/priority_thread_pool.hpp
+++ b/be/src/util/priority_thread_pool.hpp
@@ -52,7 +52,6 @@ public:
     //  -- queue_size: the maximum size of the queue on which work items are offered. If the
     //     queue exceeds this size, subsequent calls to Offer will block until there is
     //     capacity available.
-    //  -- work_function: the function to run every time an item is consumed from the queue
     PriorityThreadPool(uint32_t num_threads, uint32_t queue_size)
             : _work_queue(queue_size), _shutdown(false) {
         for (int i = 0; i < num_threads; ++i) {
@@ -118,6 +117,15 @@ public:
 protected:
     virtual bool is_shutdown() { return _shutdown; }
 
+    // Collection of worker threads that process work from the queue.
+    ThreadGroup _threads;
+
+    // Guards _empty_cv
+    std::mutex _lock;
+
+    // Signalled when the queue becomes empty
+    std::condition_variable _empty_cv;
+
 private:
     // Driver method for each thread in the pool. Continues to read work from the queue
     // until the pool is shutdown.
@@ -137,17 +145,8 @@ private:
     // FIFO order.
     BlockingPriorityQueue<Task> _work_queue;
 
-    // Collection of worker threads that process work from the queue.
-    ThreadGroup _threads;
-
-    // Guards _empty_cv
-    std::mutex _lock;
-
     // Set to true when threads should stop doing work and terminate.
     std::atomic<bool> _shutdown;
-
-    // Signalled when the queue becomes empty
-    std::condition_variable _empty_cv;
 };
 
 } // namespace doris

--- a/be/src/util/priority_work_stealing_thread_pool.hpp
+++ b/be/src/util/priority_work_stealing_thread_pool.hpp
@@ -35,7 +35,6 @@ public:
     //  -- queue_size: the maximum size of the queue on which work items are offered. If the
     //     queue exceeds this size, subsequent calls to Offer will block until there is
     //     capacity available.
-    //  -- work_function: the function to run every time an item is consumed from the queue
     PriorityWorkStealingThreadPool(uint32_t num_threads, uint32_t num_queues, uint32_t queue_size)
             : PriorityThreadPool(0, 0) {
         DCHECK_GT(num_queues, 0);
@@ -48,6 +47,11 @@ public:
             _threads.create_thread(std::bind<void>(
                     std::mem_fn(&PriorityWorkStealingThreadPool::work_thread), this, i));
         }
+    }
+
+    virtual ~PriorityWorkStealingThreadPool() {
+        shutdown();
+        join();
     }
 
     // Blocking operation that puts a work item on the queue. If the queue is full, blocks
@@ -78,10 +82,6 @@ public:
             work_queue->shutdown();
         }
     }
-
-    // Blocks until all threads are finished. shutdown does not need to have been called,
-    // since it may be called on a separate thread.
-    void join() override { _threads.join_all(); }
 
     uint32_t get_queue_size() const override {
         uint32_t size = 0;
@@ -141,15 +141,6 @@ private:
     // Queue on which work items are held until a thread is available to process them in
     // FIFO order.
     std::vector<std::shared_ptr<BlockingPriorityQueue<Task>>> _work_queues;
-
-    // Collection of worker threads that process work from the queues.
-    ThreadGroup _threads;
-
-    // Guards _empty_cv
-    std::mutex _lock;
-
-    // Signalled when the queue becomes empty
-    std::condition_variable _empty_cv;
 };
 
 } // namespace doris


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

ASAN memory leak checking works only when process exit normally. Currently doris BE will coredump when receiving SIGINT or SIGTERM, caused by unproper use of Thread:
```
terminate called without an active exception
Minidump created at: /mnt/disk1/xxx/incubator-doris_master/output/be/minidump/c68b2f2d-5659-4c68-f03167b2-03a6c545.dmp
*** Aborted at 1652797366 (unix time) try "date -d @1652797366" if you are using GNU date ***
*** SIGABRT unkown detail explain (@0x3f50012844a) received by PID 1213514 (TID 0x7f43c07da4c0) from PID 1213514; stack trace: ***
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /mnt/disk1/xxx/incubator-doris_master/be/src/common/signal_handler.h:407
 1# 0x00007F43BFAB5AD0 in /lib64/libc.so.6
 2# __GI_raise in /lib64/libc.so.6
 3# abort in /lib64/libc.so.6
 4# __gnu_cxx::__verbose_terminate_handler() [clone .cold] in /mnt/disk1/xxx/incubator-doris_master/output/be/lib/palo_be
 5# __cxxabiv1::__terminate(void (*)()) in /mnt/disk1/xxx/incubator-doris_master/output/be/lib/palo_be
 6# 0x0000562CB2DA71D1 in /mnt/disk1/xxx/incubator-doris_master/output/be/lib/palo_be
 7# std::thread::~thread() at /mnt/disk1/xxx/local/ldb_toolchain/include/c++/11/bits/std_thread.h:153
 8# doris::ThreadGroup::~ThreadGroup() at /mnt/disk1/xxx/incubator-doris_master/be/src/util/thread_group.h:32
 9# doris::PriorityWorkStealingThreadPool::~PriorityWorkStealingThreadPool() in /mnt/disk1/xxx/incubator-doris_master/output/be/lib/palo_be
10# doris::PriorityWorkStealingThreadPool::~PriorityWorkStealingThreadPool() in /mnt/disk1/xxx/incubator-doris_master/output/be/lib/palo_be
11# doris::ExecEnv::_destroy() at /mnt/disk1/xxx/incubator-doris_master/be/src/runtime/exec_env_init.cpp:319
12# doris::ExecEnv::destroy(doris::ExecEnv*) at /mnt/disk1/xxx/incubator-doris_master/be/src/runtime/exec_env_init.cpp:340
13# main at /mnt/disk1/xxx/incubator-doris_master/be/src/service/doris_main.cpp:509
14# __libc_start_main in /lib64/libc.so.6
15# _start in /mnt/disk1/xxx/incubator-doris_master/output/be/lib/palo_be

bin/start_be.sh: line 175: 1213514 Aborted                 (core dumped) $LIMIT ${DORIS_HOME}/lib/palo_be "$@" 2>&1 < /dev/null
```

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
