### PR TITLE
[Enhancement]Add prefetch in join node

### DIFF
--- a/be/src/vec/aggregate_functions/aggregate_function_distinct.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_distinct.h
@@ -126,7 +126,7 @@ struct AggregateFunctionDistinctMultipleGenericData : public AggregateFunctionDi
 
         Set::LookupResult it;
         bool inserted;
-        auto key_holder = SerializedKeyHolder {value, *arena};
+        auto key_holder = SerializedKeyHolder {value, arena};
         set.emplace(key_holder, it, inserted);
     }
 

--- a/be/src/vec/aggregate_functions/key_holder_helpers.h
+++ b/be/src/vec/aggregate_functions/key_holder_helpers.h
@@ -33,7 +33,7 @@ static auto get_key_holder(const IColumn& column, size_t row_num, Arena& arena) 
         const char* begin = nullptr;
         StringRef serialized = column.serialize_value_into_arena(row_num, arena, begin);
         assert(serialized.data != nullptr);
-        return SerializedKeyHolder {serialized, arena};
+        return SerializedKeyHolder {serialized, &arena};
     }
 }
 

--- a/be/src/vec/common/columns_hashing.h
+++ b/be/src/vec/common/columns_hashing.h
@@ -125,12 +125,9 @@ struct HashMethodSerialized
                          const HashMethodContextPtr&)
             : key_columns(key_columns_), keys_size(key_columns_.size()) {}
 
-protected:
-    friend class columns_hashing_impl::HashMethodBase<Self, Value, Mapped, false>;
-
     ALWAYS_INLINE SerializedKeyHolder get_key_holder(size_t row, Arena& pool) const {
         return SerializedKeyHolder {
-                serialize_keys_to_pool_contiguous(row, keys_size, key_columns, pool), pool};
+                serialize_keys_to_pool_contiguous(row, keys_size, key_columns, pool), &pool};
     }
 };
 

--- a/be/src/vec/common/columns_hashing_impl.h
+++ b/be/src/vec/common/columns_hashing_impl.h
@@ -132,15 +132,30 @@ public:
         return emplaceImpl(key_holder, data);
     }
 
+    template <typename Data, typename KeyHolder>
+    ALWAYS_INLINE EmplaceResult emplace_key(Data& data, KeyHolder& key_holder, size_t hash_value) {
+        return emplaceImpl(key_holder, data, hash_value);
+    }
+
     template <typename Data>
     ALWAYS_INLINE FindResult find_key(Data& data, size_t row, Arena& pool) {
         auto key_holder = static_cast<Derived&>(*this).get_key_holder(row, pool);
         return find_key_impl(key_holder_get_key(key_holder), data);
     }
 
+    template <typename Data, typename KeyHolder>
+    ALWAYS_INLINE FindResult find_key(Data& data, KeyHolder& key_holder, size_t hash_value) {
+        return find_key_impl(key_holder_get_key(key_holder), data, hash_value);
+    }
+
     template <typename Data>
     ALWAYS_INLINE size_t get_hash(const Data& data, size_t row, Arena& pool) {
         auto key_holder = static_cast<Derived&>(*this).get_key_holder(row, pool);
+        return data.hash(key_holder_get_key(key_holder));
+    }
+
+    template <typename Data, typename KeyHolder>
+    ALWAYS_INLINE size_t get_hash(const Data& data, KeyHolder& key_holder) {
         return data.hash(key_holder_get_key(key_holder));
     }
 
@@ -207,6 +222,49 @@ protected:
             return EmplaceResult(inserted);
     }
 
+    template <typename Data, typename KeyHolder>
+    ALWAYS_INLINE EmplaceResult emplaceImpl(KeyHolder& key_holder, Data& data, size_t hash_value) {
+        if constexpr (Cache::consecutive_keys_optimization) {
+            if (cache.found && cache.check(key_holder_get_key(key_holder))) {
+                if constexpr (has_mapped)
+                    return EmplaceResult(cache.value.second, cache.value.second, false);
+                else
+                    return EmplaceResult(false);
+            }
+        }
+
+        typename Data::LookupResult it;
+        bool inserted = false;
+        data.emplace(key_holder, it, inserted, hash_value);
+
+        [[maybe_unused]] Mapped* cached = nullptr;
+        if constexpr (has_mapped) cached = lookup_result_get_mapped(it);
+
+        if (inserted) {
+            if constexpr (has_mapped) {
+                new (lookup_result_get_mapped(it)) Mapped();
+            }
+        }
+
+        if constexpr (consecutive_keys_optimization) {
+            cache.found = true;
+            cache.empty = false;
+
+            if constexpr (has_mapped) {
+                cache.value.first = *lookup_result_get_key(it);
+                cache.value.second = *lookup_result_get_mapped(it);
+                cached = &cache.value.second;
+            } else {
+                cache.value = *lookup_result_get_key(it);
+            }
+        }
+
+        if constexpr (has_mapped)
+            return EmplaceResult(*lookup_result_get_mapped(it), *cached, inserted);
+        else
+            return EmplaceResult(inserted);
+    }
+
     template <typename Data, typename Key>
     ALWAYS_INLINE FindResult find_key_impl(Key key, Data& data) {
         if constexpr (Cache::consecutive_keys_optimization) {
@@ -219,6 +277,39 @@ protected:
         }
 
         auto it = data.find(key);
+
+        if constexpr (consecutive_keys_optimization) {
+            cache.found = it != nullptr;
+            cache.empty = false;
+
+            if constexpr (has_mapped) {
+                cache.value.first = key;
+                if (it) {
+                    cache.value.second = *lookup_result_get_mapped(it);
+                }
+            } else {
+                cache.value = key;
+            }
+        }
+
+        if constexpr (has_mapped)
+            return FindResult(it ? lookup_result_get_mapped(it) : nullptr, it != nullptr);
+        else
+            return FindResult(it != nullptr);
+    }
+
+    template <typename Data, typename Key>
+    ALWAYS_INLINE FindResult find_key_impl(Key key, Data& data, size_t hash_value) {
+        if constexpr (Cache::consecutive_keys_optimization) {
+            if (cache.check(key)) {
+                if constexpr (has_mapped)
+                    return FindResult(&cache.value.second, cache.found);
+                else
+                    return FindResult(cache.found);
+            }
+        }
+
+        auto it = data.find(key, hash_value);
 
         if constexpr (consecutive_keys_optimization) {
             cache.found = it != nullptr;

--- a/be/src/vec/common/hash_table/hash_table.h
+++ b/be/src/vec/common/hash_table/hash_table.h
@@ -760,6 +760,12 @@ public:
         __builtin_prefetch(&buf[place_value]);
     }
 
+    template <const bool READ>
+    void ALWAYS_INLINE prefetch_by_hash(const size_t hash_value) {
+        auto place_value = grower.place(hash_value);
+        __builtin_prefetch(&buf[place_value], READ ? 0 : 1, 3);
+    }
+
     /// Reinsert node pointed to by iterator
     void ALWAYS_INLINE reinsert(iterator& it, size_t hash_value) {
         reinsert(*it.get_ptr(), hash_value);

--- a/be/src/vec/common/hash_table/hash_table_key_holder.h
+++ b/be/src/vec/common/hash_table/hash_table_key_holder.h
@@ -120,7 +120,7 @@ namespace doris::vectorized {
   */
 struct SerializedKeyHolder {
     StringRef key;
-    Arena& pool;
+    Arena* pool;
 };
 
 } // namespace doris::vectorized
@@ -132,7 +132,7 @@ inline StringRef& ALWAYS_INLINE key_holder_get_key(doris::vectorized::Serialized
 inline void ALWAYS_INLINE key_holder_persist_key(doris::vectorized::SerializedKeyHolder&) {}
 
 inline void ALWAYS_INLINE key_holder_discard_key(doris::vectorized::SerializedKeyHolder& holder) {
-    [[maybe_unused]] void* new_head = holder.pool.rollback(holder.key.size);
+    [[maybe_unused]] void* new_head = holder.pool->rollback(holder.key.size);
     assert(new_head == holder.key.data);
     holder.key.data = nullptr;
     holder.key.size = 0;


### PR DESCRIPTION
# Proposed changes

Issue Number: close #9664

## Problem Summary:

Test on SSB(100G)

|query|without prefetch|with prefetch|
|-|-|-|
|q1.1|98|110|
|q1.2|59|63|
|q1.3|55|61|
|q2.1|574|570|
|q2.2|526|540|
|q2.3|512|515|
|q3.1|1274|1124|
|q3.2|397|416|
|q3.3|355|355|
|q3.4|91|94|
|q4.1|1043|901|
|q4.2|475|419|
|q4.3|633|534|
|total|6092|5702|



Execute sql of TPC-H (100G):

```sql
select count(1) from lineitem l1, lineitem l2 where l1.l_orderkey = l2.l_orderkey and l1.l_linenumber = l2.l_linenumber;
```
With prefetch: 12.50 sec
Without prefetch: 21.29 sec

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
