### PR TITLE
[fix]Set the memory size used when FE starts according to the user's available memory at startup

### DIFF
--- a/bin/start_fe.sh
+++ b/bin/start_fe.sh
@@ -132,13 +132,21 @@ fi
 
 # check java version and choose correct JAVA_OPTS
 java_version=$(jdk_version)
-final_java_opt=$JAVA_OPTS
+final_java_opt=$JAVA_OPTS_4G
+MemTotal=`free -g | grep "Mem"  | awk '{print $7}'`
+if [ $MemTotal > 8 ] ; then
+   final_java_opt=$JAVA_OPTS_8G
+if
 if [ $java_version -gt 8 ]; then
     if [ -z "$JAVA_OPTS_FOR_JDK_9" ]; then
         echo "JAVA_OPTS_FOR_JDK_9 is not set in fe.conf" >> $LOG_DIR/fe.out
         exit 1
     fi
-    final_java_opt=$JAVA_OPTS_FOR_JDK_9
+    if [ $MemTotal > 8 ] ; then
+       final_java_opt=$JAVA_OPTS_FOR_JDK_9_8G
+    else
+       final_java_opt=$JAVA_OPTS_FOR_JDK_9_4G
+    if
 fi
 echo "using java version $java_version" >> $LOG_DIR/fe.out
 echo $final_java_opt >> $LOG_DIR/fe.out

--- a/bin/start_fe.sh
+++ b/bin/start_fe.sh
@@ -132,6 +132,7 @@ fi
 
 # check java version and choose correct JAVA_OPTS
 java_version=$(jdk_version)
+final_java_opt=$JAVA_OPTS
 if [ $java_version -gt 8 ]; then
     if [ -z "$JAVA_OPTS_FOR_JDK_9" ]; then
         echo "JAVA_OPTS_FOR_JDK_9 is not set in fe.conf" >> $LOG_DIR/fe.out

--- a/bin/start_fe.sh
+++ b/bin/start_fe.sh
@@ -132,21 +132,12 @@ fi
 
 # check java version and choose correct JAVA_OPTS
 java_version=$(jdk_version)
-final_java_opt=$JAVA_OPTS_4G
-MemTotal="$(cat /proc/meminfo | grep 'MemAvailable' | awk '{print int($2 / 1024 / 1024)}')"
-if [ $MemTotal > 8 ] ; then
-   final_java_opt=$JAVA_OPTS_8G
-if
 if [ $java_version -gt 8 ]; then
     if [ -z "$JAVA_OPTS_FOR_JDK_9" ]; then
         echo "JAVA_OPTS_FOR_JDK_9 is not set in fe.conf" >> $LOG_DIR/fe.out
         exit 1
     fi
-    if [ $MemTotal > 8 ] ; then
-       final_java_opt=$JAVA_OPTS_FOR_JDK_9_8G
-    else
-       final_java_opt=$JAVA_OPTS_FOR_JDK_9_4G
-    if
+    final_java_opt=$JAVA_OPTS_FOR_JDK_9
 fi
 echo "using java version $java_version" >> $LOG_DIR/fe.out
 echo $final_java_opt >> $LOG_DIR/fe.out

--- a/bin/start_fe.sh
+++ b/bin/start_fe.sh
@@ -133,7 +133,7 @@ fi
 # check java version and choose correct JAVA_OPTS
 java_version=$(jdk_version)
 final_java_opt=$JAVA_OPTS_4G
-MemTotal=`free -g | grep "Mem"  | awk '{print $7}'`
+MemTotal="$(cat /proc/meminfo | grep 'MemAvailable' | awk '{print int($2 / 1024 / 1024)}')"
 if [ $MemTotal > 8 ] ; then
    final_java_opt=$JAVA_OPTS_8G
 if

--- a/conf/fe.conf
+++ b/conf/fe.conf
@@ -25,14 +25,11 @@
 LOG_DIR = ${DORIS_HOME}/log
 
 DATE = `date +%Y%m%d-%H%M%S`
-JAVA_OPTS_8G="-Xmx8192m -XX:+UseMembar -XX:SurvivorRatio=8 -XX:MaxTenuringThreshold=7 -XX:+PrintGCDateStamps -XX:+PrintGCDetails -XX:+UseConcMarkSweepGC -XX:+UseParNewGC -XX:+CMSClassUnloadingEnabled -XX:-CMSParallelRemarkEnabled -XX:CMSInitiatingOccupancyFraction=80 -XX:SoftRefLRUPolicyMSPerMB=0 -Xloggc:$DORIS_HOME/log/fe.gc.log.$DATE"
-
-JAVA_OPTS_4G="-Xmx4096m -XX:+UseMembar -XX:SurvivorRatio=8 -XX:MaxTenuringThreshold=7 -XX:+PrintGCDateStamps -XX:+PrintGCDetails -XX:+UseConcMarkSweepGC -XX:+UseParNewGC -XX:+CMSClassUnloadingEnabled -XX:-CMSParallelRemarkEnabled -XX:CMSInitiatingOccupancyFraction=80 -XX:SoftRefLRUPolicyMSPerMB=0 -Xloggc:$DORIS_HOME/log/fe.gc.log.$DATE"
+JAVA_OPTS="-Xmx8192m -XX:+UseMembar -XX:SurvivorRatio=8 -XX:MaxTenuringThreshold=7 -XX:+PrintGCDateStamps -XX:+PrintGCDetails -XX:+UseConcMarkSweepGC -XX:+UseParNewGC -XX:+CMSClassUnloadingEnabled -XX:-CMSParallelRemarkEnabled -XX:CMSInitiatingOccupancyFraction=80 -XX:SoftRefLRUPolicyMSPerMB=0 -Xloggc:$DORIS_HOME/log/fe.gc.log.$DATE"
 
 # For jdk 9+, this JAVA_OPTS will be used as default JVM options
-JAVA_OPTS_FOR_JDK_9_8G="-Xmx8192m -XX:SurvivorRatio=8 -XX:MaxTenuringThreshold=7 -XX:+CMSClassUnloadingEnabled -XX:-CMSParallelRemarkEnabled -XX:CMSInitiatingOccupancyFraction=80 -XX:SoftRefLRUPolicyMSPerMB=0 -Xlog:gc*:$DORIS_HOME/log/fe.gc.log.$DATE:time"
+JAVA_OPTS_FOR_JDK_9="-Xmx8192m -XX:SurvivorRatio=8 -XX:MaxTenuringThreshold=7 -XX:+CMSClassUnloadingEnabled -XX:-CMSParallelRemarkEnabled -XX:CMSInitiatingOccupancyFraction=80 -XX:SoftRefLRUPolicyMSPerMB=0 -Xlog:gc*:$DORIS_HOME/log/fe.gc.log.$DATE:time"
 
-JAVA_OPTS_FOR_JDK_9_4G="-Xmx4096m -XX:SurvivorRatio=8 -XX:MaxTenuringThreshold=7 -XX:+CMSClassUnloadingEnabled -XX:-CMSParallelRemarkEnabled -XX:CMSInitiatingOccupancyFraction=80 -XX:SoftRefLRUPolicyMSPerMB=0 -Xlog:gc*:$DORIS_HOME/log/fe.gc.log.$DATE:time"
 ##
 ## the lowercase properties are read by main program.
 ##

--- a/conf/fe.conf
+++ b/conf/fe.conf
@@ -25,11 +25,14 @@
 LOG_DIR = ${DORIS_HOME}/log
 
 DATE = `date +%Y%m%d-%H%M%S`
-JAVA_OPTS="-Xmx4096m -XX:+UseMembar -XX:SurvivorRatio=8 -XX:MaxTenuringThreshold=7 -XX:+PrintGCDateStamps -XX:+PrintGCDetails -XX:+UseConcMarkSweepGC -XX:+UseParNewGC -XX:+CMSClassUnloadingEnabled -XX:-CMSParallelRemarkEnabled -XX:CMSInitiatingOccupancyFraction=80 -XX:SoftRefLRUPolicyMSPerMB=0 -Xloggc:$DORIS_HOME/log/fe.gc.log.$DATE"
+JAVA_OPTS_8G="-Xmx8192m -XX:+UseMembar -XX:SurvivorRatio=8 -XX:MaxTenuringThreshold=7 -XX:+PrintGCDateStamps -XX:+PrintGCDetails -XX:+UseConcMarkSweepGC -XX:+UseParNewGC -XX:+CMSClassUnloadingEnabled -XX:-CMSParallelRemarkEnabled -XX:CMSInitiatingOccupancyFraction=80 -XX:SoftRefLRUPolicyMSPerMB=0 -Xloggc:$DORIS_HOME/log/fe.gc.log.$DATE"
+
+JAVA_OPTS_4G="-Xmx4096m -XX:+UseMembar -XX:SurvivorRatio=8 -XX:MaxTenuringThreshold=7 -XX:+PrintGCDateStamps -XX:+PrintGCDetails -XX:+UseConcMarkSweepGC -XX:+UseParNewGC -XX:+CMSClassUnloadingEnabled -XX:-CMSParallelRemarkEnabled -XX:CMSInitiatingOccupancyFraction=80 -XX:SoftRefLRUPolicyMSPerMB=0 -Xloggc:$DORIS_HOME/log/fe.gc.log.$DATE"
 
 # For jdk 9+, this JAVA_OPTS will be used as default JVM options
-JAVA_OPTS_FOR_JDK_9="-Xmx4096m -XX:SurvivorRatio=8 -XX:MaxTenuringThreshold=7 -XX:+CMSClassUnloadingEnabled -XX:-CMSParallelRemarkEnabled -XX:CMSInitiatingOccupancyFraction=80 -XX:SoftRefLRUPolicyMSPerMB=0 -Xlog:gc*:$DORIS_HOME/log/fe.gc.log.$DATE:time"
+JAVA_OPTS_FOR_JDK_9_8G="-Xmx8192m -XX:SurvivorRatio=8 -XX:MaxTenuringThreshold=7 -XX:+CMSClassUnloadingEnabled -XX:-CMSParallelRemarkEnabled -XX:CMSInitiatingOccupancyFraction=80 -XX:SoftRefLRUPolicyMSPerMB=0 -Xlog:gc*:$DORIS_HOME/log/fe.gc.log.$DATE:time"
 
+JAVA_OPTS_FOR_JDK_9_4G="-Xmx4096m -XX:SurvivorRatio=8 -XX:MaxTenuringThreshold=7 -XX:+CMSClassUnloadingEnabled -XX:-CMSParallelRemarkEnabled -XX:CMSInitiatingOccupancyFraction=80 -XX:SoftRefLRUPolicyMSPerMB=0 -Xlog:gc*:$DORIS_HOME/log/fe.gc.log.$DATE:time"
 ##
 ## the lowercase properties are read by main program.
 ##


### PR DESCRIPTION

When many users start fe in the production environment, they do not modify the JAVA_OPTS configuration according to the document, and there is an OOM problem. The modification here will judge the available memory of the user's machine when the user starts fe. If it is greater than 8G, directly set the JAVA_OPTS option in the The memory is set to 8G, and when it is less than 8G, it is set to 4G
Set the memory size used when FE starts according to the user's available memory at startup

# Proposed changes

Issue Number: close #xxx

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
