### PR TITLE
[fix] NullPredicate should implement evaluate_vec

### DIFF
--- a/be/src/olap/column_predicate.h
+++ b/be/src/olap/column_predicate.h
@@ -82,7 +82,10 @@ public:
     // used to evaluate pre read column in lazy matertialization
     // now only support integer/float
     // a vectorized eval way
-    virtual void evaluate_vec(vectorized::IColumn& column, uint16_t size, bool* flags) const {};
+    virtual void evaluate_vec(vectorized::IColumn& column, uint16_t size, bool* flags) const {
+        DCHECK(false) << "should not reach here";
+    }
+
     uint32_t column_id() const { return _column_id; }
 
 protected:

--- a/be/src/olap/null_predicate.cpp
+++ b/be/src/olap/null_predicate.cpp
@@ -172,9 +172,9 @@ void NullPredicate::evaluate_vec(vectorized::IColumn& column, uint16_t size, boo
         for (uint16_t i = 0; i < size; ++i) {
             flags[i] = (null_map[i] == _is_null);
         }
-        return;
+    } else {
+        if (_is_null) memset(flags, false, size);
     }
-    if (_is_null) memset(flags, false, size);
 }
 
 } //namespace doris

--- a/be/src/olap/null_predicate.cpp
+++ b/be/src/olap/null_predicate.cpp
@@ -165,4 +165,17 @@ void NullPredicate::evaluate_and(IColumn& column, uint16_t* sel, uint16_t size, 
         if (_is_null) memset(flags, false, size);
     }
 }
+
+
+void NullPredicate::evaluate_vec(vectorized::IColumn& column, uint16_t size, bool* flags) const {
+    if (auto* nullable = check_and_get_column<ColumnNullable>(column)) {
+        auto& null_map = nullable->get_null_map_data();
+        for (uint16_t i = 0; i < size; ++i) {
+            flags[i] = (null_map[i] == _is_null);
+        }
+        return;
+    }
+    if (_is_null) memset(flags, false, size);
+}
+
 } //namespace doris

--- a/be/src/olap/null_predicate.cpp
+++ b/be/src/olap/null_predicate.cpp
@@ -166,7 +166,6 @@ void NullPredicate::evaluate_and(IColumn& column, uint16_t* sel, uint16_t size, 
     }
 }
 
-
 void NullPredicate::evaluate_vec(vectorized::IColumn& column, uint16_t size, bool* flags) const {
     if (auto* nullable = check_and_get_column<ColumnNullable>(column)) {
         auto& null_map = nullable->get_null_map_data();

--- a/be/src/olap/null_predicate.h
+++ b/be/src/olap/null_predicate.h
@@ -52,6 +52,8 @@ public:
     void evaluate_and(vectorized::IColumn& column, uint16_t* sel, uint16_t size,
                       bool* flags) const override;
 
+    void evaluate_vec(vectorized::IColumn& column, uint16_t size, bool* flags) const override;
+
 private:
     bool _is_null; //true for null, false for not null
 };


### PR DESCRIPTION
select column from table where column is null

# Proposed changes

Issue Number: close #xxx

## Problem Summary:

select from where is null does not work.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
