### PR TITLE
Fix lz4f optimization thread unsafe

### DIFF
--- a/be/src/olap/rowset/segment_v2/column_reader.cpp
+++ b/be/src/olap/rowset/segment_v2/column_reader.cpp
@@ -104,7 +104,7 @@ Status ColumnReader::init() {
                 strings::Substitute("unsupported typeinfo, type=$0", _meta.type()));
     }
     RETURN_IF_ERROR(EncodingInfo::get(_type_info.get(), _meta.encoding(), &_encoding_info));
-    RETURN_IF_ERROR(get_block_compression_codec(_meta.compression(), _compress_codec));
+    RETURN_IF_ERROR(get_block_compression_codec(_meta.compression(), &_compress_codec));
 
     for (int i = 0; i < _meta.indexes_size(); i++) {
         auto& index_meta = _meta.indexes(i);
@@ -149,7 +149,7 @@ Status ColumnReader::read_page(const ColumnIteratorOptions& iter_opts, const Pag
     PageReadOptions opts;
     opts.rblock = iter_opts.rblock;
     opts.page_pointer = pp;
-    opts.codec = _compress_codec.get();
+    opts.codec = _compress_codec;
     opts.stats = iter_opts.stats;
     opts.verify_checksum = _opts.verify_checksum;
     opts.use_page_cache = iter_opts.use_page_cache;

--- a/be/src/olap/rowset/segment_v2/column_reader.h
+++ b/be/src/olap/rowset/segment_v2/column_reader.h
@@ -175,7 +175,7 @@ private:
             TypeInfoPtr(nullptr, nullptr); // initialized in init(), may changed by subclasses.
     const EncodingInfo* _encoding_info =
             nullptr; // initialized in init(), used for create PageDecoder
-    std::unique_ptr<BlockCompressionCodec> _compress_codec; // initialized in init()
+    const BlockCompressionCodec* _compress_codec = nullptr; // initialized in init()
 
     // meta for various column indexes (null if the index is absent)
     const ZoneMapIndexPB* _zone_map_index_meta = nullptr;

--- a/be/src/olap/rowset/segment_v2/column_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/column_writer.cpp
@@ -264,7 +264,7 @@ ScalarColumnWriter::~ScalarColumnWriter() {
 }
 
 Status ScalarColumnWriter::init() {
-    RETURN_IF_ERROR(get_block_compression_codec(_opts.meta->compression(), _compress_codec));
+    RETURN_IF_ERROR(get_block_compression_codec(_opts.meta->compression(), &_compress_codec));
 
     PageBuilder* page_builder = nullptr;
 
@@ -420,7 +420,7 @@ Status ScalarColumnWriter::write_data() {
         footer.mutable_dict_page_footer()->set_encoding(PLAIN_ENCODING);
 
         PagePointer dict_pp;
-        RETURN_IF_ERROR(PageIO::compress_and_write_page(_compress_codec.get(),
+        RETURN_IF_ERROR(PageIO::compress_and_write_page(_compress_codec,
                                                         _opts.compression_min_space_saving, _wblock,
                                                         {dict_body.slice()}, footer, &dict_pp));
         dict_pp.to_proto(_opts.meta->mutable_dict_page());
@@ -508,8 +508,8 @@ Status ScalarColumnWriter::finish_current_page() {
     }
     // trying to compress page body
     OwnedSlice compressed_body;
-    RETURN_IF_ERROR(PageIO::compress_page_body(
-            _compress_codec.get(), _opts.compression_min_space_saving, body, &compressed_body));
+    RETURN_IF_ERROR(PageIO::compress_page_body(_compress_codec, _opts.compression_min_space_saving,
+                                               body, &compressed_body));
     if (compressed_body.slice().empty()) {
         // page body is uncompressed
         page->data.emplace_back(std::move(encoded_values));

--- a/be/src/olap/rowset/segment_v2/column_writer.h
+++ b/be/src/olap/rowset/segment_v2/column_writer.h
@@ -249,7 +249,7 @@ private:
     PageHead _pages;
     ordinal_t _first_rowid = 0;
 
-    std::unique_ptr<BlockCompressionCodec> _compress_codec;
+    const BlockCompressionCodec* _compress_codec = nullptr;
 
     std::unique_ptr<OrdinalIndexWriter> _ordinal_index_builder;
     std::unique_ptr<ZoneMapIndexWriter> _zone_map_index_builder;

--- a/be/src/olap/rowset/segment_v2/indexed_column_reader.cpp
+++ b/be/src/olap/rowset/segment_v2/indexed_column_reader.cpp
@@ -37,7 +37,7 @@ Status IndexedColumnReader::load(bool use_page_cache, bool kept_in_memory) {
                 strings::Substitute("unsupported typeinfo, type=$0", _meta.data_type()));
     }
     RETURN_IF_ERROR(EncodingInfo::get(_type_info, _meta.encoding(), &_encoding_info));
-    RETURN_IF_ERROR(get_block_compression_codec(_meta.compression(), _compress_codec));
+    RETURN_IF_ERROR(get_block_compression_codec(_meta.compression(), &_compress_codec));
     _value_key_coder = get_key_coder(_type_info->type());
 
     std::unique_ptr<fs::ReadableBlock> rblock;
@@ -83,7 +83,7 @@ Status IndexedColumnReader::read_page(fs::ReadableBlock* rblock, const PagePoint
     PageReadOptions opts;
     opts.rblock = rblock;
     opts.page_pointer = pp;
-    opts.codec = _compress_codec.get();
+    opts.codec = _compress_codec;
     OlapReaderStatistics tmp_stats;
     opts.stats = &tmp_stats;
     opts.use_page_cache = _use_page_cache;

--- a/be/src/olap/rowset/segment_v2/indexed_column_reader.h
+++ b/be/src/olap/rowset/segment_v2/indexed_column_reader.h
@@ -84,7 +84,7 @@ private:
 
     const TypeInfo* _type_info = nullptr;
     const EncodingInfo* _encoding_info = nullptr;
-    std::unique_ptr<BlockCompressionCodec> _compress_codec;
+    const BlockCompressionCodec* _compress_codec = nullptr;
     const KeyCoder* _value_key_coder = nullptr;
 };
 

--- a/be/src/olap/rowset/segment_v2/indexed_column_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/indexed_column_writer.cpp
@@ -72,7 +72,7 @@ Status IndexedColumnWriter::init() {
     }
 
     if (_options.compression != NO_COMPRESSION) {
-        RETURN_IF_ERROR(get_block_compression_codec(_options.compression, _compress_codec));
+        RETURN_IF_ERROR(get_block_compression_codec(_options.compression, &_compress_codec));
     }
     return Status::OK();
 }
@@ -110,7 +110,7 @@ Status IndexedColumnWriter::_finish_current_data_page() {
     footer.mutable_data_page_footer()->set_num_values(num_values_in_page);
     footer.mutable_data_page_footer()->set_nullmap_size(0);
 
-    RETURN_IF_ERROR(PageIO::compress_and_write_page(_compress_codec.get(),
+    RETURN_IF_ERROR(PageIO::compress_and_write_page(_compress_codec,
                                                     _options.compression_min_space_saving, _wblock,
                                                     {page_body.slice()}, footer, &_last_data_page));
     _num_data_pages++;
@@ -159,7 +159,7 @@ Status IndexedColumnWriter::_flush_index(IndexPageBuilder* index_builder, BTreeM
 
         PagePointer pp;
         RETURN_IF_ERROR(PageIO::compress_and_write_page(
-                _compress_codec.get(), _options.compression_min_space_saving, _wblock,
+                _compress_codec, _options.compression_min_space_saving, _wblock,
                 {page_body.slice()}, page_footer, &pp));
 
         meta->set_is_root_data_page(false);

--- a/be/src/olap/rowset/segment_v2/indexed_column_writer.h
+++ b/be/src/olap/rowset/segment_v2/indexed_column_writer.h
@@ -108,7 +108,7 @@ private:
     std::unique_ptr<IndexPageBuilder> _value_index_builder;
     // encoder for value index's key
     const KeyCoder* _value_key_coder;
-    std::unique_ptr<BlockCompressionCodec> _compress_codec;
+    const BlockCompressionCodec* _compress_codec;
 
     DISALLOW_COPY_AND_ASSIGN(IndexedColumnWriter);
 };

--- a/be/src/util/block_compression.cpp
+++ b/be/src/util/block_compression.cpp
@@ -26,8 +26,8 @@
 #include <limits>
 
 #include "gutil/strings/substitute.h"
-#include "util/faststring.h"
 #include "runtime/threadlocal.h"
+#include "util/faststring.h"
 
 namespace doris {
 
@@ -101,8 +101,9 @@ public:
         if (!is_compress && !ctx_d_inited) {
             auto ret2 = LZ4F_createDecompressionContext(&ctx_d, LZ4F_VERSION);
             if (LZ4F_isError(ret2)) {
-                return Status::InvalidArgument(strings::Substitute(
-                        "Fail to LZ4F_createDecompressionContext, msg=$0", LZ4F_getErrorName(ret2)));
+                return Status::InvalidArgument(
+                        strings::Substitute("Fail to LZ4F_createDecompressionContext, msg=$0",
+                                            LZ4F_getErrorName(ret2)));
             }
             ctx_d_inited = true;
         }
@@ -133,11 +134,13 @@ class Lz4fCompressionContextPtr {
 public:
     Lz4fCompressionContextPtr();
     Lz4fCompressionContext* get();
+
 private:
     DECLARE_STATIC_THREAD_LOCAL(Lz4fCompressionContext, thread_local_lz4f_ctx);
 };
 
-DEFINE_STATIC_THREAD_LOCAL(Lz4fCompressionContext, Lz4fCompressionContextPtr, thread_local_lz4f_ctx);
+DEFINE_STATIC_THREAD_LOCAL(Lz4fCompressionContext, Lz4fCompressionContextPtr,
+                           thread_local_lz4f_ctx);
 
 Lz4fCompressionContextPtr::Lz4fCompressionContextPtr() {
     INIT_STATIC_THREAD_LOCAL(Lz4fCompressionContext, thread_local_lz4f_ctx);

--- a/be/src/util/block_compression.cpp
+++ b/be/src/util/block_compression.cpp
@@ -88,7 +88,7 @@ public:
 
 class Lz4fCompressionContext {
 public:
-    Status init(bool is_compress) {
+    inline Status init(bool is_compress) {
         if (is_compress && !ctx_c_inited) {
             auto ret1 = LZ4F_createCompressionContext(&ctx_c, LZ4F_VERSION);
             if (LZ4F_isError(ret1)) {
@@ -118,10 +118,10 @@ public:
         if (ctx_d_inited) LZ4F_freeDecompressionContext(ctx_d);
     }
 
-    LZ4F_compressionContext_t get_compress_ctx() { return ctx_c; }
-    LZ4F_decompressionContext_t get_decompress_ctx() { return ctx_d; }
+    inline LZ4F_compressionContext_t get_compress_ctx() { return ctx_c; }
+    inline LZ4F_decompressionContext_t get_decompress_ctx() { return ctx_d; }
 
-public:
+private:
     LZ4F_compressionContext_t ctx_c;
     bool ctx_c_inited = false;
     LZ4F_decompressionContext_t ctx_d;
@@ -172,7 +172,7 @@ public:
     Status compress(const std::vector<Slice>& inputs, Slice* output) const override {
         auto pctx = lz4f_ctx.get();
         if (pctx && pctx->init(true).ok())
-            return _compress(pctx->ctx_c, inputs, output);
+            return _compress(pctx->get_compress_ctx(), inputs, output);
         else
             return Status::InvalidArgument("Fail to get thread local lz4f_ctx");
     }
@@ -180,7 +180,7 @@ public:
     Status decompress(const Slice& input, Slice* output) const override {
         auto pctx = lz4f_ctx.get();
         if (pctx && pctx->init(false).ok())
-            return _decompress(pctx->ctx_d, input, output);
+            return _decompress(pctx->get_decompress_ctx(), input, output);
         else
             return Status::InvalidArgument("Fail to get thread local lz4f_ctx");
     }

--- a/be/src/util/block_compression.h
+++ b/be/src/util/block_compression.h
@@ -34,8 +34,6 @@ class BlockCompressionCodec {
 public:
     virtual ~BlockCompressionCodec() {}
 
-    virtual Status init() { return Status::OK(); }
-
     // This function will compress input data into output.
     // output should be preallocated, and its capacity must be large enough
     // for compressed input, which can be get through max_compressed_len function.
@@ -63,6 +61,6 @@ public:
 //
 // Return not OK, if error happens.
 Status get_block_compression_codec(segment_v2::CompressionTypePB type,
-                                   std::unique_ptr<BlockCompressionCodec>& codec);
+                                   const BlockCompressionCodec** codec);
 
 } // namespace doris

--- a/be/test/util/block_compression_test.cpp
+++ b/be/test/util/block_compression_test.cpp
@@ -42,8 +42,8 @@ static std::string generate_str(size_t len) {
 }
 
 void test_single_slice(segment_v2::CompressionTypePB type) {
-    std::unique_ptr<BlockCompressionCodec> codec;
-    auto st = get_block_compression_codec(type, codec);
+    const BlockCompressionCodec* codec = nullptr;
+    auto st = get_block_compression_codec(type, &codec);
     EXPECT_TRUE(st.ok());
 
     size_t test_sizes[] = {0, 1, 10, 1000, 1000000};
@@ -104,8 +104,8 @@ TEST_F(BlockCompressionTest, single) {
 }
 
 void test_multi_slices(segment_v2::CompressionTypePB type) {
-    std::unique_ptr<BlockCompressionCodec> codec;
-    auto st = get_block_compression_codec(type, codec);
+    const BlockCompressionCodec* codec = nullptr;
+    auto st = get_block_compression_codec(type, &codec);
     EXPECT_TRUE(st.ok());
 
     size_t test_sizes[] = {0, 1, 10, 1000, 1000000};


### PR DESCRIPTION
# Proposed changes

Issue Number: close #9706 , which was introduced by https://github.com/apache/incubator-doris/pull/9566

Make reusing compress/decompress context object thread safe by using thread_local.

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (No)
2. Has unit tests been added: (No Need)
3. Has document been added or modified: (No Need)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (No)

