### PR TITLE
[opt] avoid memcpy when building page

### DIFF
--- a/be/src/olap/rowset/segment_v2/binary_dict_page.cpp
+++ b/be/src/olap/rowset/segment_v2/binary_dict_page.cpp
@@ -131,7 +131,8 @@ OwnedSlice BinaryDictPageBuilder::finish() {
 
 void BinaryDictPageBuilder::reset() {
     _finished = false;
-    _buffer.reserve(_options.data_page_size + BINARY_DICT_PAGE_HEADER_SIZE);
+    _buffer.reserve(_options.data_page_size + BINARY_DICT_PAGE_HEADER_SIZE +
+                    kPageExtraReserveBytes);
     _buffer.resize(BINARY_DICT_PAGE_HEADER_SIZE);
 
     if (_encoding_type == DICT_ENCODING && _dict_builder->is_page_full()) {

--- a/be/src/olap/rowset/segment_v2/binary_plain_page.h
+++ b/be/src/olap/rowset/segment_v2/binary_plain_page.h
@@ -98,7 +98,8 @@ public:
     void reset() override {
         _offsets.clear();
         _buffer.clear();
-        _buffer.reserve(_options.data_page_size == 0 ? 1024 : _options.data_page_size);
+        _buffer.reserve((_options.data_page_size == 0 ? 1024 : _options.data_page_size) +
+                        kPageExtraReserveBytes);
         _size_estimate = sizeof(uint32_t);
         _finished = false;
         _last_value_size = 0;

--- a/be/src/olap/rowset/segment_v2/binary_prefix_page.h
+++ b/be/src/olap/rowset/segment_v2/binary_prefix_page.h
@@ -57,6 +57,7 @@ public:
         _last_entry.clear();
         _count = 0;
         _buffer.clear();
+        _buffer.reserve(_options.data_page_size + kPageExtraReserveBytes);
         _finished = false;
     }
 

--- a/be/src/olap/rowset/segment_v2/bitshuffle_page.h
+++ b/be/src/olap/rowset/segment_v2/bitshuffle_page.h
@@ -150,7 +150,7 @@ public:
         auto block_size = _options.data_page_size;
         _count = 0;
         _data.clear();
-        _data.reserve(block_size);
+        _data.reserve(block_size + kPageExtraReserveBytes);
         DCHECK_EQ(reinterpret_cast<uintptr_t>(_data.data()) & (alignof(CppType) - 1), 0)
                 << "buffer must be naturally-aligned";
         _buffer.clear();

--- a/be/src/olap/rowset/segment_v2/frame_of_reference_page.h
+++ b/be/src/olap/rowset/segment_v2/frame_of_reference_page.h
@@ -31,6 +31,7 @@ class FrameOfReferencePageBuilder : public PageBuilder {
 public:
     explicit FrameOfReferencePageBuilder(const PageBuilderOptions& options)
             : _options(options), _count(0), _finished(false) {
+        _buf.reserve(_options.data_page_size + kPageExtraReserveBytes);
         _encoder.reset(new ForEncoder<CppType>(&_buf));
     }
 

--- a/be/src/olap/rowset/segment_v2/page_builder.h
+++ b/be/src/olap/rowset/segment_v2/page_builder.h
@@ -29,6 +29,8 @@
 namespace doris {
 namespace segment_v2 {
 
+const uint32_t kPageExtraReserveBytes = 4096;
+
 // PageBuilder is used to build page
 // Page is a data management unit, including:
 // 1. Data Page: store encoded and compressed data

--- a/be/src/olap/rowset/segment_v2/plain_page.h
+++ b/be/src/olap/rowset/segment_v2/plain_page.h
@@ -36,7 +36,7 @@ public:
     PlainPageBuilder(const PageBuilderOptions& options) : _options(options) {
         // Reserve enough space for the page, plus a bit of slop since
         // we often overrun the page by a few values.
-        _buffer.reserve(_options.data_page_size + 1024);
+        _buffer.reserve(_options.data_page_size + kPageExtraReserveBytes);
         reset();
     }
 

--- a/be/src/olap/rowset/segment_v2/rle_page.h
+++ b/be/src/olap/rowset/segment_v2/rle_page.h
@@ -65,6 +65,7 @@ public:
             break;
         }
         }
+        _buf.reserve(_options.data_page_size + kPageExtraReserveBytes);
         _rle_encoder = new RleEncoder<CppType>(&_buf, _bit_width);
         reset();
     }

--- a/be/src/util/faststring.cc
+++ b/be/src/util/faststring.cc
@@ -47,11 +47,11 @@ void faststring::GrowArray(size_t newcapacity) {
         }
     }
     capacity_ = newcapacity;
-    data_ = newdata;
     if (data_ == initial_data_) {
         ASAN_POISON_MEMORY_REGION(initial_data_, arraysize(initial_data_));
     }
-    ASAN_POISON_MEMORY_REGION(data_ + len_, capacity_ - len_);
+    data_ = newdata;
+    ASAN_POISON_MEMORY_REGION(data_, capacity_);
 }
 
 void faststring::ShrinkToFitInternal() {

--- a/be/src/util/faststring.h
+++ b/be/src/util/faststring.h
@@ -42,7 +42,7 @@ public:
     explicit faststring(size_t capacity)
             : data_(initial_data_), len_(0), capacity_(kInitialCapacity) {
         if (capacity > capacity_) {
-            data_ = new uint8_t[capacity];
+            data_ = (uint8_t*)malloc(capacity);
             capacity_ = capacity;
         }
         ASAN_POISON_MEMORY_REGION(data_, capacity_);
@@ -51,7 +51,7 @@ public:
     ~faststring() {
         ASAN_UNPOISON_MEMORY_REGION(initial_data_, arraysize(initial_data_));
         if (data_ != initial_data_) {
-            delete[] data_;
+            free(data_);
         }
     }
 
@@ -82,7 +82,7 @@ public:
     OwnedSlice build() {
         uint8_t* ret = data_;
         if (ret == initial_data_) {
-            ret = new uint8_t[len_];
+            ret = (uint8_t*)malloc(len_);
             memcpy(ret, data_, len_);
         }
         OwnedSlice result(ret, len_);

--- a/be/src/util/slice.h
+++ b/be/src/util/slice.h
@@ -272,7 +272,7 @@ public:
         return *this;
     }
 
-    ~OwnedSlice() { delete[] _slice.data; }
+    ~OwnedSlice() { free(_slice.data); }
 
     const Slice& slice() const { return _slice; }
 


### PR DESCRIPTION
PageBuilder finishes a page when the page is full, when the page is
full, its size is greater than page size, so the last row would
trigger an memcpy due to there is not enough space in faststring.

The patch fix the problem by 2 changes:
1. PageBuilder reserves extra bytes
   If the last row is less than extra bytes, then no memory copy is
   triggered.
2. faststring uses malloc/realloc/free rather than new/delete
   realloc can avoid memcopy some times.

The patch is not tested, so please do not merge.

# Proposed changes

Issue Number: close #xxx

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
