### PR TITLE
[Enhancement][fix] Add a rewrite rule to optimize InPredicate.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/Analyzer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/Analyzer.java
@@ -54,6 +54,7 @@ import org.apache.doris.rewrite.RewriteBinaryPredicatesRule;
 import org.apache.doris.rewrite.RewriteDateLiteralRule;
 import org.apache.doris.rewrite.RewriteEncryptKeyRule;
 import org.apache.doris.rewrite.RewriteFromUnixTimeRule;
+import org.apache.doris.rewrite.RewriteInPredicateRule;
 import org.apache.doris.rewrite.mvrewrite.CountDistinctToBitmap;
 import org.apache.doris.rewrite.mvrewrite.CountDistinctToBitmapOrHLLRule;
 import org.apache.doris.rewrite.mvrewrite.CountFieldToSum;
@@ -324,6 +325,7 @@ public class Analyzer {
             rules.add(CompoundPredicateWriteRule.INSTANCE);
             rules.add(RewriteDateLiteralRule.INSTANCE);
             rules.add(RewriteEncryptKeyRule.INSTANCE);
+            rules.add(RewriteInPredicateRule.INSTANCE);
             rules.add(RewriteAliasFunctionRule.INSTANCE);
             List<ExprRewriteRule> onceRules = Lists.newArrayList();
             onceRules.add(ExtractCommonFactorsRule.INSTANCE);

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/DecimalLiteral.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/DecimalLiteral.java
@@ -249,6 +249,8 @@ public class DecimalLiteral extends LiteralExpr {
             return new IntLiteral(value.longValue(), targetType);
         } else if (targetType.isStringType()) {
             return new StringLiteral(value.toString());
+        } else if (targetType.isLargeIntType()) {
+            return new LargeIntLiteral(value.toBigInteger().toString());
         }
         return super.uncheckedCastTo(targetType);
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/Expr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/Expr.java
@@ -302,7 +302,6 @@ abstract public class Expr extends TreeNode<Expr> implements ParseNode, Cloneabl
         return isAnalyzed;
     }
 
-    // todo: Why define checkValueValid() in Expr that are only implemented in IntLiteral？
     public void checkValueValid() throws AnalysisException {}
 
     public ExprId getId() {

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/Expr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/Expr.java
@@ -302,6 +302,7 @@ abstract public class Expr extends TreeNode<Expr> implements ParseNode, Cloneabl
         return isAnalyzed;
     }
 
+    // todo: Why define checkValueValid() in Expr that are only implemented in IntLiteral？
     public void checkValueValid() throws AnalysisException {}
 
     public ExprId getId() {

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/FloatLiteral.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/FloatLiteral.java
@@ -168,7 +168,8 @@ public class FloatLiteral extends LiteralExpr {
             }
             return this;
         } else if (targetType.isDecimalV2()) {
-            return new DecimalLiteral(new BigDecimal(value));
+            // the double constructor does an exact translation, use valueOf() instead.
+            return new DecimalLiteral(BigDecimal.valueOf(value));
         }
         return this;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/rewrite/RewriteInPredicateRule.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/rewrite/RewriteInPredicateRule.java
@@ -1,0 +1,114 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.rewrite;
+
+import org.apache.doris.analysis.Analyzer;
+import org.apache.doris.analysis.BoolLiteral;
+import org.apache.doris.analysis.Expr;
+import org.apache.doris.analysis.InPredicate;
+import org.apache.doris.analysis.LiteralExpr;
+import org.apache.doris.analysis.SlotRef;
+import org.apache.doris.analysis.Subquery;
+import org.apache.doris.catalog.Type;
+import org.apache.doris.common.AnalysisException;
+import org.apache.doris.rewrite.ExprRewriter.ClauseType;
+
+import com.clearspring.analytics.util.Lists;
+
+import java.util.List;
+
+/**
+ * Optimize the InPredicate when the child expr type is integerType, largeIntType, floatingPointType, decimalV2,
+ * char, varchar, string and the column type is integerType, largeIntType: convert the child expr type to the column
+ * type and discard the expressions that cannot be converted exactly.
+ * <p>
+ * For example:
+ * column type is integerType or largeIntType, then
+ * col in (1, 2.5, 2.0, "3.0", "4.6") -> col in (1, 2, 3)
+ * col in (2.5, "4.6") -> false
+ * <p>
+ * column type is tinyType, then
+ * col in (1, 2.0, 128, "1000") -> col in (1, 2)
+ */
+public class RewriteInPredicateRule implements ExprRewriteRule {
+    public static ExprRewriteRule INSTANCE = new RewriteInPredicateRule();
+
+    @Override
+    public Expr apply(Expr expr, Analyzer analyzer, ClauseType clauseType) throws AnalysisException {
+        if (!(expr instanceof InPredicate)) {
+            return expr;
+        }
+        InPredicate inPredicate = (InPredicate) expr;
+        if (inPredicate.contains(Subquery.class) || !inPredicate.isLiteralChildren() || inPredicate.isNotIn() ||
+                !(inPredicate.getChild(0).unwrapExpr(false) instanceof SlotRef)) {
+            return expr;
+        }
+        SlotRef slotRef = inPredicate.getChild(0).getSrcSlotRef();
+        Type columnType = slotRef.getColumn().getType();
+        if (!columnType.isFixedPointType()) {
+            return expr;
+        }
+
+        InPredicate newInPredicate = inPredicate.clone();
+        boolean isCast = false;
+        List<Expr> invalidChildren = Lists.newArrayList();
+        for (int i = 1; i < newInPredicate.getChildren().size(); ++i) {
+            LiteralExpr childExpr = (LiteralExpr) newInPredicate.getChild(i);
+            if (childExpr.getType().getPrimitiveType().equals(columnType.getPrimitiveType())) {
+                continue;
+            }
+
+            if (childExpr.getType().getPrimitiveType().isCharFamily() || childExpr.getType().isFloatingPointType()) {
+                try {
+                    childExpr = (LiteralExpr) childExpr.castTo(Type.DECIMALV2);
+                } catch (Exception e) {
+                    newInPredicate.setChild(i, childExpr);
+                    invalidChildren.add(childExpr);
+                    continue;
+                }
+            }
+
+            if (childExpr.getType().isNumericType()) {
+                try {
+                    LiteralExpr newExpr = (LiteralExpr) childExpr.castTo(columnType);
+                    newExpr.checkValueValid();
+                    if (childExpr.compareLiteral(newExpr) == 0) {
+                        newInPredicate.setChild(i, newExpr);
+                        isCast = true;
+                    } else {
+                        throw new AnalysisException("Converting the type will result in a loss of accuracy.");
+                    }
+                } catch (Exception e) {
+                    newInPredicate.setChild(i, childExpr);
+                    invalidChildren.add(childExpr);
+                }
+            } else {
+                return expr;
+            }
+        }
+        if (invalidChildren.size() == newInPredicate.getChildren().size() - 1) {
+            return new BoolLiteral(false);
+        }
+        if (newInPredicate.getChild(0).getType().getPrimitiveType() != columnType.getPrimitiveType()) {
+            newInPredicate.castChild(columnType, 0);
+            isCast = true;
+        }
+        newInPredicate.getChildren().removeAll(invalidChildren);
+        return !isCast && invalidChildren.isEmpty() ? expr : newInPredicate;
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/rewrite/RewriteInPredicateRule.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/rewrite/RewriteInPredicateRule.java
@@ -28,7 +28,7 @@ import org.apache.doris.catalog.Type;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.rewrite.ExprRewriter.ClauseType;
 
-import com.clearspring.analytics.util.Lists;
+import com.google.common.collect.Lists;
 
 import java.util.List;
 

--- a/fe/fe-core/src/main/java/org/apache/doris/rewrite/RewriteInPredicateRule.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/rewrite/RewriteInPredicateRule.java
@@ -36,13 +36,12 @@ import java.util.List;
  * Optimize the InPredicate when the child expr type is integerType, largeIntType, floatingPointType, decimalV2,
  * char, varchar, string and the column type is integerType, largeIntType: convert the child expr type to the column
  * type and discard the expressions that cannot be converted exactly.
- * <p>
- * For example:
- * column type is integerType or largeIntType, then
- * col in (1, 2.5, 2.0, "3.0", "4.6") -> col in (1, 2, 3)
- * col in (2.5, "4.6") -> false
- * <p>
- * column type is tinyType, then
+ *
+ * <p>For example:<br>
+ * column type is integerType or largeIntType, then:<br>
+ * col in (1, 2.5, 2.0, "3.0", "4.6") -> col in (1, 2, 3)<br>
+ * col in (2.5, "4.6") -> false<br>
+ * column type is tinyType, then:<br>
  * col in (1, 2.0, 128, "1000") -> col in (1, 2)
  */
 public class RewriteInPredicateRule implements ExprRewriteRule {
@@ -54,8 +53,8 @@ public class RewriteInPredicateRule implements ExprRewriteRule {
             return expr;
         }
         InPredicate inPredicate = (InPredicate) expr;
-        if (inPredicate.contains(Subquery.class) || !inPredicate.isLiteralChildren() || inPredicate.isNotIn() ||
-                !(inPredicate.getChild(0).unwrapExpr(false) instanceof SlotRef)) {
+        if (inPredicate.contains(Subquery.class) || !inPredicate.isLiteralChildren() || inPredicate.isNotIn()
+                || !(inPredicate.getChild(0).unwrapExpr(false) instanceof SlotRef)) {
             return expr;
         }
         SlotRef slotRef = inPredicate.getChild(0).getSrcSlotRef();

--- a/fe/fe-core/src/test/java/org/apache/doris/rewrite/RewriteInPredicateRuleTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/rewrite/RewriteInPredicateRuleTest.java
@@ -45,9 +45,9 @@ public class RewriteInPredicateRuleTest extends TestWithFeService {
         connectContext = createDefaultCtx();
         createDatabase(DB_NAME);
         useDatabase(DB_NAME);
-        String createTableFormat = "create table %s(id %s, `date` datetime, cost bigint sum) " +
-                "aggregate key(`id`, `date`) distributed by hash (`id`) buckets 4 " +
-                "properties (\"replication_num\"=\"1\");";
+        String createTableFormat = "create table %s(id %s, `date` datetime, cost bigint sum) "
+                + "aggregate key(`id`, `date`) distributed by hash (`id`) buckets 4 "
+                + "properties (\"replication_num\"=\"1\");";
         createTable(String.format(createTableFormat, TABLE_SMALL, PrimitiveType.SMALLINT));
         createTable(String.format(createTableFormat, TABLE_LARGE, PrimitiveType.LARGEINT));
     }

--- a/fe/fe-core/src/test/java/org/apache/doris/rewrite/RewriteInPredicateRuleTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/rewrite/RewriteInPredicateRuleTest.java
@@ -1,0 +1,144 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.rewrite;
+
+import org.apache.doris.analysis.BoolLiteral;
+import org.apache.doris.analysis.Expr;
+import org.apache.doris.analysis.InPredicate;
+import org.apache.doris.analysis.IntLiteral;
+import org.apache.doris.analysis.LargeIntLiteral;
+import org.apache.doris.analysis.LiteralExpr;
+import org.apache.doris.analysis.SelectStmt;
+import org.apache.doris.catalog.PrimitiveType;
+import org.apache.doris.qe.StmtExecutor;
+import org.apache.doris.utframe.TestWithFeService;
+
+import com.google.common.base.Joiner;
+import com.google.common.collect.Lists;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+public class RewriteInPredicateRuleTest extends TestWithFeService {
+    private static final String DB_NAME = "testdb";
+    private static final String TABLE_SMALL = "table_small";
+    private static final String TABLE_LARGE = "table_large";
+
+    @Override
+    protected void runBeforeAll() throws Exception {
+        connectContext = createDefaultCtx();
+        createDatabase(DB_NAME);
+        useDatabase(DB_NAME);
+        String createTableFormat = "create table %s(id %s, `date` datetime, cost bigint sum) " +
+                "aggregate key(`id`, `date`) distributed by hash (`id`) buckets 4 " +
+                "properties (\"replication_num\"=\"1\");";
+        createTable(String.format(createTableFormat, TABLE_SMALL, PrimitiveType.SMALLINT));
+        createTable(String.format(createTableFormat, TABLE_LARGE, PrimitiveType.LARGEINT));
+    }
+
+    @Test
+    public void testIntLiteralAndLargeIntLiteral() throws Exception {
+        // id in (TINY_INT_MIN, SMALL_INT_MIN, INT_MIN, BIG_INT_MAX, LARGE_INT_MAX)
+        // => id in (TINY_INT_MIN, SMALL_INT_MIN)
+        testBase(3, PrimitiveType.SMALLINT, IntLiteral.TINY_INT_MIN, TABLE_SMALL,
+                String.valueOf(IntLiteral.TINY_INT_MIN), String.valueOf(IntLiteral.SMALL_INT_MAX),
+                String.valueOf(IntLiteral.INT_MIN), String.valueOf(IntLiteral.BIG_INT_MAX),
+                LargeIntLiteral.LARGE_INT_MAX.toString());
+
+        // id in (TINY_INT_MIN, SMALL_INT_MIN, INT_MIN, BIG_INT_MAX, LARGE_INT_MAX)
+        // => id in (TINY_INT_MIN, SMALL_INT_MIN, INT_MIN, BIG_INT_MAX, LARGE_INT_MAX)
+        testBase(6, PrimitiveType.LARGEINT, IntLiteral.TINY_INT_MIN, TABLE_LARGE,
+                String.valueOf(IntLiteral.TINY_INT_MIN), String.valueOf(IntLiteral.SMALL_INT_MAX),
+                String.valueOf(IntLiteral.INT_MIN), String.valueOf(IntLiteral.BIG_INT_MAX),
+                LargeIntLiteral.LARGE_INT_MAX.toString());
+    }
+
+    @Test
+    public void testDecimalLiteral() throws Exception {
+        // type of id is smallint: id in (2.0, 3.5) => id in (2)
+        testBase(2, PrimitiveType.SMALLINT, 2, TABLE_SMALL, "2.0", "3.5");
+
+        testBase(2, PrimitiveType.SMALLINT, 3, TABLE_SMALL, "2.1", "3.0", "3.5");
+
+        // type of id is largeint: id in (2.0, 3.5) => id in (2)
+        testBase(2, PrimitiveType.LARGEINT, 2, TABLE_LARGE, "2.0", "3.5");
+    }
+
+    @Test
+    public void testStringLiteral() throws Exception {
+        // type of id is smallint: id in ("2.0", "3.5") => id in (2)
+        testBase(2, PrimitiveType.SMALLINT, 2, TABLE_SMALL, "\"2.0\"", "\"3.5\"");
+
+        // type of id is largeint: id in ("2.0", "3.5") => id in (2)
+        testBase(2, PrimitiveType.LARGEINT, 2, TABLE_LARGE, "\"2.0\"", "\"3.5\"");
+    }
+
+    @Test
+    public void testBooleanLiteral() throws Exception {
+        // type of id is smallint: id in (true, false) => id in (1, 0)
+        testBase(3, PrimitiveType.SMALLINT, 0, TABLE_SMALL, "false", "true");
+
+        // type of id is largeint: id in (true, false) => id in (1, 0)
+        testBase(3, PrimitiveType.LARGEINT, 1, TABLE_LARGE, "true", "false");
+    }
+
+    @Test
+    public void testMixedLiteralExpr() throws Exception {
+        // type of id is smallint: id in (1, 2.0, 3.3) -> id in (1, 2)
+        testBase(3, PrimitiveType.SMALLINT, 1, TABLE_SMALL, "1", "2.0", "3.3");
+        // type of id is smallint: id in (1, 1.0, 1.1) => id in (1, 1)
+        testBase(3, PrimitiveType.SMALLINT, 1, TABLE_SMALL, "1", "1.0", "1.1");
+        // type of id is smallint: id in ("1.0", 2.0, 3.3, "5.2") => id in (1, 2)
+        testBase(3, PrimitiveType.SMALLINT, 1, TABLE_SMALL, "\"1.0\"", "2.0", "3.3", "\"5.2\"");
+        // type of id is smallint: id in (false, 2.0, 3.3, "5.2", true) => id in (0, 2, 1)
+        testBase(4, PrimitiveType.SMALLINT, 0, TABLE_SMALL, "false", "2.0", "3.3", "\"5.2\"", "true");
+
+        // largeint
+        testBase(3, PrimitiveType.LARGEINT, 1, TABLE_LARGE, "1", "2.0", "3.3");
+        testBase(3, PrimitiveType.LARGEINT, 1, TABLE_LARGE, "1", "1.0", "1.1");
+        testBase(3, PrimitiveType.LARGEINT, 1, TABLE_LARGE, "\"1.0\"", "2.0", "3.3", "\"5.2\"");
+        testBase(4, PrimitiveType.LARGEINT, 0, TABLE_LARGE, "false", "2.0", "3.3", "\"5.2\"", "true");
+    }
+
+    @Test
+    public void testEmpty() throws Exception {
+        // type of id is smallint: id in (5.5, "6.2") => false
+        String query = "select * from table_small where id in (5.5, \"6.2\");";
+        StmtExecutor executor1 = getSqlStmtExecutor(query);
+        Expr expr1 = ((SelectStmt) executor1.getParsedStmt()).getWhereClause();
+        Assertions.assertTrue(expr1 instanceof BoolLiteral);
+        Assertions.assertFalse(((BoolLiteral) expr1).getValue());
+    }
+
+    private void testBase(int childrenNum, PrimitiveType type, long expectedOfChild1, String... literals)
+            throws Exception {
+        List<String> list = Lists.newArrayList();
+        Lists.newArrayList(literals).forEach(e -> list.add("%s"));
+        list.remove(list.size() - 1);
+        String queryFormat = "select * from %s where id in (" + Joiner.on(", ").join(list) + ");";
+        String query = String.format(queryFormat, literals);
+        StmtExecutor executor1 = getSqlStmtExecutor(query);
+        Expr expr1 = ((SelectStmt) executor1.getParsedStmt()).getWhereClause();
+        Assertions.assertTrue(expr1 instanceof InPredicate);
+        Assertions.assertEquals(childrenNum, expr1.getChildren().size());
+        Assertions.assertEquals(type, expr1.getChild(0).getType().getPrimitiveType());
+        Assertions.assertEquals(type, expr1.getChild(1).getType().getPrimitiveType());
+        Assertions.assertEquals(expectedOfChild1, ((LiteralExpr) expr1.getChild(1)).getLongValue());
+    }
+}


### PR DESCRIPTION
1. Convert child expressions in InPredicate to column type and discard child expressions in them that cannot be converted exactly.
2. Fix the bug of ColumnRange exception caused by InPredicate child expressions type conversion.
3. Fix the problem that the tablet could not be hit due caused by InPredicate child expressions type conversion.

# Proposed changes

Issue Number: close #9738 

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (No)
2. Has unit tests been added: (Yes)
3. Has document been added or modified: (No Need)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
