### PR TITLE
fix column reader compress codec unsafe problem

### DIFF
--- a/be/src/olap/rowset/segment_v2/column_reader.cpp
+++ b/be/src/olap/rowset/segment_v2/column_reader.cpp
@@ -104,7 +104,6 @@ Status ColumnReader::init() {
                 strings::Substitute("unsupported typeinfo, type=$0", _meta.type()));
     }
     RETURN_IF_ERROR(EncodingInfo::get(_type_info.get(), _meta.encoding(), &_encoding_info));
-    RETURN_IF_ERROR(get_block_compression_codec(_meta.compression(), _compress_codec));
 
     for (int i = 0; i < _meta.indexes_size(); i++) {
         auto& index_meta = _meta.indexes(i);
@@ -144,12 +143,13 @@ Status ColumnReader::new_bitmap_index_iterator(BitmapIndexIterator** iterator) {
 }
 
 Status ColumnReader::read_page(const ColumnIteratorOptions& iter_opts, const PagePointer& pp,
-                               PageHandle* handle, Slice* page_body, PageFooterPB* footer) {
+                               PageHandle* handle, Slice* page_body, PageFooterPB* footer,
+                               BlockCompressionCodec* codec) {
     iter_opts.sanity_check();
     PageReadOptions opts;
     opts.rblock = iter_opts.rblock;
     opts.page_pointer = pp;
-    opts.codec = _compress_codec.get();
+    opts.codec = codec;
     opts.stats = iter_opts.stats;
     opts.verify_checksum = _opts.verify_checksum;
     opts.use_page_cache = iter_opts.use_page_cache;
@@ -465,6 +465,12 @@ Status ArrayFileColumnIterator::next_batch(size_t* n, ColumnBlockView* dst, bool
 
 FileColumnIterator::FileColumnIterator(ColumnReader* reader) : _reader(reader) {}
 
+Status FileColumnIterator::init(const ColumnIteratorOptions& opts) {
+    _opts = opts;
+    RETURN_IF_ERROR(get_block_compression_codec(_reader->get_compression(), _compress_codec));
+    return Status::OK();
+}
+
 FileColumnIterator::~FileColumnIterator() = default;
 
 Status FileColumnIterator::seek_to_first() {
@@ -653,7 +659,8 @@ Status FileColumnIterator::_read_data_page(const OrdinalPageIndexIterator& iter)
     Slice page_body;
     PageFooterPB footer;
     _opts.type = DATA_PAGE;
-    RETURN_IF_ERROR(_reader->read_page(_opts, iter.page(), &handle, &page_body, &footer));
+    RETURN_IF_ERROR(_reader->read_page(_opts, iter.page(), &handle, &page_body, &footer,
+                                       _compress_codec.get()));
     // parse data page
     RETURN_IF_ERROR(ParsedPage::create(std::move(handle), page_body, footer.data_page_footer(),
                                        _reader->encoding_info(), iter.page(), iter.page_index(),
@@ -673,7 +680,8 @@ Status FileColumnIterator::_read_data_page(const OrdinalPageIndexIterator& iter)
                 PageFooterPB dict_footer;
                 _opts.type = INDEX_PAGE;
                 RETURN_IF_ERROR(_reader->read_page(_opts, _reader->get_dict_page_pointer(),
-                                                   &_dict_page_handle, &dict_data, &dict_footer));
+                                                   &_dict_page_handle, &dict_data, &dict_footer,
+                                                   _compress_codec.get()));
                 // ignore dict_footer.dict_page_footer().encoding() due to only
                 // PLAIN_ENCODING is supported for dict page right now
                 _dict_decoder = std::make_unique<BinaryPlainPageDecoder>(dict_data);

--- a/be/src/olap/rowset/segment_v2/column_reader.h
+++ b/be/src/olap/rowset/segment_v2/column_reader.h
@@ -103,7 +103,8 @@ public:
 
     // read a page from file into a page handle
     Status read_page(const ColumnIteratorOptions& iter_opts, const PagePointer& pp,
-                     PageHandle* handle, Slice* page_body, PageFooterPB* footer);
+                     PageHandle* handle, Slice* page_body, PageFooterPB* footer,
+                     BlockCompressionCodec* codec);
 
     bool is_nullable() const { return _meta.is_nullable(); }
 
@@ -130,6 +131,8 @@ public:
     PagePointer get_dict_page_pointer() const { return _meta.dict_page(); }
 
     bool is_empty() const { return _num_rows == 0; }
+
+    CompressionTypePB get_compression() const { return _meta.compression(); }
 
 private:
     ColumnReader(const ColumnReaderOptions& opts, const ColumnMetaPB& meta, uint64_t num_rows,
@@ -175,7 +178,6 @@ private:
             TypeInfoPtr(nullptr, nullptr); // initialized in init(), may changed by subclasses.
     const EncodingInfo* _encoding_info =
             nullptr; // initialized in init(), used for create PageDecoder
-    std::unique_ptr<BlockCompressionCodec> _compress_codec; // initialized in init()
 
     // meta for various column indexes (null if the index is absent)
     const ZoneMapIndexPB* _zone_map_index_meta = nullptr;
@@ -253,6 +255,8 @@ public:
     explicit FileColumnIterator(ColumnReader* reader);
     ~FileColumnIterator() override;
 
+    Status init(const ColumnIteratorOptions& opts) override;
+
     Status seek_to_first() override;
 
     Status seek_to_ordinal(ordinal_t ord) override;
@@ -284,6 +288,9 @@ private:
 
 private:
     ColumnReader* _reader;
+
+    // iterator owned compress codec, should NOT be shared by threads, initialized in init()
+    std::unique_ptr<BlockCompressionCodec> _compress_codec;
 
     // 1. The _page represents current page.
     // 2. We define an operation is one seek and following read,

--- a/be/src/olap/rowset/segment_v2/indexed_column_reader.h
+++ b/be/src/olap/rowset/segment_v2/indexed_column_reader.h
@@ -52,13 +52,16 @@ public:
 
     // read a page specified by `pp' from `file' into `handle'
     Status read_page(fs::ReadableBlock* rblock, const PagePointer& pp, PageHandle* handle,
-                     Slice* body, PageFooterPB* footer, PageTypePB type) const;
+                     Slice* body, PageFooterPB* footer, PageTypePB type,
+                     BlockCompressionCodec* codec) const;
 
     int64_t num_values() const { return _num_values; }
     const EncodingInfo* encoding_info() const { return _encoding_info; }
     const TypeInfo* type_info() const { return _type_info; }
     bool support_ordinal_seek() const { return _meta.has_ordinal_index_meta(); }
     bool support_value_seek() const { return _meta.has_value_index_meta(); }
+
+    CompressionTypePB get_compression() const { return _meta.compression(); }
 
 private:
     Status load_index_page(fs::ReadableBlock* rblock, const PagePointerPB& pp, PageHandle* handle,
@@ -84,7 +87,6 @@ private:
 
     const TypeInfo* _type_info = nullptr;
     const EncodingInfo* _encoding_info = nullptr;
-    std::unique_ptr<BlockCompressionCodec> _compress_codec;
     const KeyCoder* _value_key_coder = nullptr;
 };
 
@@ -145,6 +147,8 @@ private:
     ordinal_t _current_ordinal = 0;
     // open file handle
     std::unique_ptr<fs::ReadableBlock> _rblock;
+    // iterator owned compress codec, should NOT be shared by threads, initialized before used
+    std::unique_ptr<BlockCompressionCodec> _compress_codec;
 };
 
 } // namespace segment_v2

--- a/be/src/util/block_compression.h
+++ b/be/src/util/block_compression.h
@@ -30,6 +30,9 @@ namespace doris {
 // This class only used to compress a block data, which means all data
 // should given when call compress or decompress. This class don't handle
 // stream compression.
+//
+// NOTICE!! BlockCompressionCodec is NOT thread safe, it should NOT be shared by threads
+//
 class BlockCompressionCodec {
 public:
     virtual ~BlockCompressionCodec() {}
@@ -59,7 +62,9 @@ public:
 // Get a BlockCompressionCodec through type.
 // Return Status::OK if a valid codec is found. If codec is null, it means it is
 // NO_COMPRESSION. If codec is not null, user can use it to compress/decompress
-// data. And client doesn't have to release the codec.
+// data.
+//
+// NOTICE!! BlockCompressionCodec is NOT thread safe, it should NOT be shared by threads
 //
 // Return not OK, if error happens.
 Status get_block_compression_codec(segment_v2::CompressionTypePB type,


### PR DESCRIPTION
fix column reader compress codec unsafe problem by moving codec from shared reader to unshared iterator

# Proposed changes

Issue Number: close #9706, which was introduced by https://github.com/apache/incubator-doris/pull/9566

## Problem Summary:

ColumnReader is not thread safe and its `BlockCompressionCodec _compress_codec`  can be shared by multiple threads. But #9566 changed BlockCompressionCodec to be NOT thread safe for very promising performance reason.

The solution is to move _compress_codec from shared ColumnReader to unshared FileColumnIterator, and the same to IndexedColumnReader & IndexedColumnIterator.

The solution is better than the previous one #9714, which use thread_local compress/decompress context objects.

BTW, add a thread unsafe notice for BlockCompressionCodec.

## Checklist(Required)

1. Does it affect the original behavior: (No)
2. Has unit tests been added: (No)
3. Has document been added or modified: (No Need)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
