### PR TITLE
add zstd compression codec

### DIFF
--- a/be/src/util/block_compression.cpp
+++ b/be/src/util/block_compression.cpp
@@ -419,8 +419,7 @@ public:
     // follow ZSTD official example
     //  https://github.com/facebook/zstd/blob/dev/examples/streaming_compression.c
     Status compress(const std::vector<Slice>& inputs, Slice* output) const {
-        if (!ctx_c)
-            return Status::InvalidArgument("compression context NOT initialized");
+        if (!ctx_c) return Status::InvalidArgument("compression context NOT initialized");
 
         // reset ctx to start new compress session
         auto ret = ZSTD_CCtx_reset(ctx_c, ZSTD_reset_session_only);
@@ -481,8 +480,7 @@ public:
     // follow ZSTD official example
     //  https://github.com/facebook/zstd/blob/dev/examples/streaming_decompression.c
     Status decompress(const Slice& input, Slice* output) const {
-        if (!ctx_d)
-            return Status::InvalidArgument("decompression context NOT initialized");
+        if (!ctx_d) return Status::InvalidArgument("decompression context NOT initialized");
 
         // reset ctx to start a new decompress session
         auto ret = ZSTD_DCtx_reset(ctx_d, ZSTD_reset_session_only);

--- a/be/test/util/block_compression_test.cpp
+++ b/be/test/util/block_compression_test.cpp
@@ -101,6 +101,7 @@ TEST_F(BlockCompressionTest, single) {
     test_single_slice(segment_v2::CompressionTypePB::ZLIB);
     test_single_slice(segment_v2::CompressionTypePB::LZ4);
     test_single_slice(segment_v2::CompressionTypePB::LZ4F);
+    test_single_slice(segment_v2::CompressionTypePB::ZSTD);
 }
 
 void test_multi_slices(segment_v2::CompressionTypePB type) {
@@ -156,6 +157,7 @@ TEST_F(BlockCompressionTest, multi) {
     test_multi_slices(segment_v2::CompressionTypePB::ZLIB);
     test_multi_slices(segment_v2::CompressionTypePB::LZ4);
     test_multi_slices(segment_v2::CompressionTypePB::LZ4F);
+    test_multi_slices(segment_v2::CompressionTypePB::ZSTD);
 }
 
 } // namespace doris


### PR DESCRIPTION
# Proposed changes

ZSTD compression is fast with high compression ratio. It can be used to archive higher compression ratio than default Lz4f codec for storing cost sensitive data such as logs.

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (No)
2. Has unit tests been added: (Yes)
3. Has document been added or modified: (No)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
