### PR TITLE
[feature](hudi) Step2: Support query hudi external table(include cow and mor table)

### DIFF
--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -68,6 +68,13 @@ under the License.
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <!-- hadoop -->
+            <dependency>
+                <groupId>org.apache.hadoop</groupId>
+                <artifactId>hadoop-mapreduce-client</artifactId>
+                <version>2.7.4</version>
+                <scope>compile</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
     <dependencies>

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/Analyzer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/Analyzer.java
@@ -38,6 +38,8 @@ import org.apache.doris.common.IdGenerator;
 import org.apache.doris.common.Pair;
 import org.apache.doris.common.VecNotImplException;
 import org.apache.doris.common.util.TimeUtils;
+import org.apache.doris.external.hudi.HudiTable;
+import org.apache.doris.external.hudi.HudiUtils;
 import org.apache.doris.planner.PlanNode;
 import org.apache.doris.planner.RuntimeFilter;
 import org.apache.doris.qe.ConnectContext;
@@ -624,6 +626,11 @@ public class Analyzer {
                 // if doing restore with table, throw exception here
                 ErrorReport.reportAnalysisException(ErrorCode.ERR_BAD_TABLE_STATE, "RESTORING");
             }
+        }
+
+        if (table.getType() == TableType.HUDI && ((HudiTable) table).getFullSchema().isEmpty()) {
+            // resolve hudi table's schema when table schema is empty from doris meta
+            table = HudiUtils.resolveHudiTable((HudiTable)table);
         }
 
         // tableName.getTbl() stores the table name specified by the user in the from statement.

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/Analyzer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/Analyzer.java
@@ -619,7 +619,7 @@ public class Analyzer {
                     partition -> partition.getState() == PartitionState.RESTORE
             ).collect(Collectors.toList()).isEmpty();
 
-            if(!isNotRestoring){
+            if (!isNotRestoring) {
                 // if doing restore with partitions, the status check push down to OlapScanNode::computePartitionInfo to
                 // support query that partitions is not restoring.
             } else {
@@ -628,9 +628,9 @@ public class Analyzer {
             }
         }
 
-        if (table.getType() == TableType.HUDI && ((HudiTable) table).getFullSchema().isEmpty()) {
+        if (table.getType() == TableType.HUDI && table.getFullSchema().isEmpty()) {
             // resolve hudi table's schema when table schema is empty from doris meta
-            table = HudiUtils.resolveHudiTable((HudiTable)table);
+            table = HudiUtils.resolveHudiTable((HudiTable) table);
         }
 
         // tableName.getTbl() stores the table name specified by the user in the from statement.

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Catalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Catalog.java
@@ -4143,11 +4143,10 @@ public class Catalog {
             HudiUtils.validateColumns(hudiTable, hiveTable);
         }
         switch (hiveTable.getTableType()) {
-            case "VIRTUAL_VIEW":
-                throw new DdlException("VIRTUAL_VIEW table is not supported.");
             case "EXTERNAL_TABLE":
             case "MANAGED_TABLE":
                 break;
+            case "VIRTUAL_VIEW":
             default:
                 throw new DdlException("unsupported hudi table type [" + hiveTable.getTableType() + "].");
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Catalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Catalog.java
@@ -4142,6 +4142,15 @@ public class Catalog {
         if (!hudiTable.getFullSchema().isEmpty()) {
             HudiUtils.validateColumns(hudiTable, hiveTable);
         }
+        switch (hiveTable.getTableType()) {
+            case "VIRTUAL_VIEW":
+                throw new DdlException("VIRTUAL_VIEW table is not supported.");
+            case "EXTERNAL_TABLE":
+            case "MANAGED_TABLE":
+                break;
+            default:
+                throw new DdlException("unsupported hudi table type [" + hiveTable.getTableType() + "].");
+        }
         // check hive table if exists in doris database
         if (!db.createTableWithLock(hudiTable, false, stmt.isSetIfNotExists()).first) {
             ErrorReport.reportDdlException(ErrorCode.ERR_TABLE_EXISTS_ERROR, tableName);

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/HiveMetaStoreClientHelper.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/HiveMetaStoreClientHelper.java
@@ -167,7 +167,8 @@ public class HiveMetaStoreClientHelper {
      * @throws DdlException
      */
     public static String getHiveDataFiles(HiveTable hiveTable, ExprNodeGenericFuncDesc hivePartitionPredicate,
-                                          List<TBrokerFileStatus> fileStatuses, Table remoteHiveTbl) throws DdlException {
+                                          List<TBrokerFileStatus> fileStatuses,
+                                          Table remoteHiveTbl) throws DdlException {
         List<RemoteIterator<LocatedFileStatus>> remoteIterators;
         if (remoteHiveTbl.getPartitionKeys().size() > 0) {
             String metaStoreUris = hiveTable.getHiveProperties().get(HiveTable.HIVE_METASTORE_URIS);
@@ -209,6 +210,15 @@ public class HiveMetaStoreClientHelper {
         return hdfsUrl;
     }
 
+    /**
+     * list partitions from hiveMetaStore.
+     *
+     * @param metaStoreUris hiveMetaStore uris
+     * @param remoteHiveTbl Hive table
+     * @param hivePartitionPredicate filter when list partitions
+     * @return a list of hive partitions
+     * @throws DdlException when connect hiveMetaStore failed.
+     */
     public static List<Partition> getHivePartitions(String metaStoreUris, Table remoteHiveTbl,
                        ExprNodeGenericFuncDesc hivePartitionPredicate) throws DdlException {
         List<Partition> hivePartitions = new ArrayList<>();

--- a/fe/fe-core/src/main/java/org/apache/doris/external/hive/util/HiveUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/external/hive/util/HiveUtil.java
@@ -17,14 +17,13 @@
 
 package org.apache.doris.external.hive.util;
 
-import com.google.common.collect.Lists;
 import org.apache.doris.catalog.ArrayType;
 import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.Type;
 import org.apache.doris.common.AnalysisException;
-import org.apache.doris.common.Config;
 import org.apache.doris.common.UserException;
 
+import com.google.common.collect.Lists;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.ql.io.SymlinkTextInputFormat;
@@ -40,49 +39,29 @@ import org.apache.hadoop.mapred.TextInputFormat;
 import org.apache.hadoop.util.ReflectionUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.joda.time.format.DateTimeFormat;
-import org.joda.time.format.DateTimeFormatter;
-import org.joda.time.format.DateTimeFormatterBuilder;
-import org.joda.time.format.DateTimeParser;
-import org.joda.time.format.DateTimePrinter;
-import org.joda.time.format.ISODateTimeFormat;
 
-import java.lang.reflect.Field;
 import java.util.List;
 
+/**
+ * Hive util for create or query hive table.
+ */
 public final class HiveUtil {
     private static final Logger LOG = LogManager.getLogger(HiveUtil.class);
 
-    private static final DateTimeFormatter HIVE_DATE_PARSER = ISODateTimeFormat.date().withZoneUTC();
-    private static final DateTimeFormatter HIVE_TIMESTAMP_PARSER;
-    private static final Field COMPRESSION_CODECS_FIELD;
-
-    static {
-        DateTimeParser[] timestampWithoutTimeZoneParser = {
-                DateTimeFormat.forPattern("yyyy-M-d").getParser(),
-                DateTimeFormat.forPattern("yyyy-M-d H:m").getParser(),
-                DateTimeFormat.forPattern("yyyy-M-d H:m:s").getParser(),
-                DateTimeFormat.forPattern("yyyy-M-d H:m:s.SSS").getParser(),
-                DateTimeFormat.forPattern("yyyy-M-d H:m:s.SSSSSSS").getParser(),
-                DateTimeFormat.forPattern("yyyy-M-d H:m:s.SSSSSSSSS").getParser(),
-        };
-        DateTimePrinter timestampWithoutTimeZonePrinter = DateTimeFormat.forPattern("yyyy-MM-dd HH:mm:ss.SSSSSSSSS").getPrinter();
-        HIVE_TIMESTAMP_PARSER = new DateTimeFormatterBuilder().append(timestampWithoutTimeZonePrinter, timestampWithoutTimeZoneParser).toFormatter().withZoneUTC();
-
-        try {
-            COMPRESSION_CODECS_FIELD = TextInputFormat.class.getDeclaredField("compressionCodecs");
-            COMPRESSION_CODECS_FIELD.setAccessible(true);
-        }
-        catch (ReflectiveOperationException e) {
-            throw new AssertionError(e);
-        }
+    private HiveUtil() {
     }
 
-    private HiveUtil()
-    {
-    }
-
-    public static InputFormat<?, ?> getInputFormat(Configuration configuration, String inputFormatName, boolean symlinkTarget) throws UserException {
+    /**
+     * get input format class from inputFormatName.
+     *
+     * @param configuration jobConf used when getInputFormatClass
+     * @param inputFormatName inputFormat class name
+     * @param symlinkTarget use target inputFormat class when inputFormat is SymlinkTextInputFormat
+     * @return a class of inputFormat.
+     * @throws UserException  when class not found.
+     */
+    public static InputFormat<?, ?> getInputFormat(Configuration configuration,
+                                                   String inputFormatName, boolean symlinkTarget) throws UserException {
         try {
             JobConf jobConf = new JobConf(configuration);
 
@@ -93,19 +72,17 @@ public final class HiveUtil {
             }
 
             return ReflectionUtils.newInstance(inputFormatClass, jobConf);
-        }
-        catch (ClassNotFoundException | RuntimeException e) {
+        } catch (ClassNotFoundException | RuntimeException e) {
             throw new UserException("Unable to create input format " + inputFormatName, e);
         }
     }
 
     @SuppressWarnings({"unchecked", "RedundantCast"})
     private static Class<? extends InputFormat<?, ?>> getInputFormatClass(JobConf conf, String inputFormatName)
-            throws ClassNotFoundException
-    {
+            throws ClassNotFoundException {
         // CDH uses different names for Parquet
-        if ("parquet.hive.DeprecatedParquetInputFormat".equals(inputFormatName) ||
-                "parquet.hive.MapredParquetInputFormat".equals(inputFormatName)) {
+        if ("parquet.hive.DeprecatedParquetInputFormat".equals(inputFormatName)
+                || "parquet.hive.MapredParquetInputFormat".equals(inputFormatName)) {
             return MapredParquetInputFormat.class;
         }
 
@@ -113,23 +90,33 @@ public final class HiveUtil {
         return (Class<? extends InputFormat<?, ?>>) clazz.asSubclass(InputFormat.class);
     }
 
+    /**
+     * transform hiveSchema to Doris schema.
+     *
+     * @param hiveSchema hive schema
+     * @return doris schema
+     * @throws AnalysisException when transform failed.
+     */
     public static List<Column> transformHiveSchema(List<FieldSchema> hiveSchema) throws AnalysisException {
         List<Column> newSchema = Lists.newArrayList();
         for (FieldSchema hiveColumn : hiveSchema) {
             try {
                 newSchema.add(HiveUtil.transformHiveField(hiveColumn));
             } catch (UnsupportedOperationException e) {
-                if (Config.iceberg_table_creation_strict_mode) {
-                    throw e;
-                }
                 LOG.warn("Unsupported data type in Doris, ignore column[{}], with error: {}",
                         hiveColumn.getName(), e.getMessage());
-                continue;
+                throw e;
             }
         }
         return newSchema;
     }
 
+    /**
+     * tranform hive field to doris column.
+     *
+     * @param field hive field to be transformed
+     * @return doris column
+     */
     public static Column transformHiveField(FieldSchema field) {
         TypeInfo hiveTypeInfo = TypeInfoUtils.getTypeInfoFromTypeString(field.getType());
         Type type = convertHiveTypeToiveDoris(hiveTypeInfo);
@@ -140,8 +127,8 @@ public final class HiveUtil {
 
         switch (hiveTypeInfo.getCategory()) {
             case PRIMITIVE: {
-                PrimitiveTypeInfo pTypeInfo = (PrimitiveTypeInfo) hiveTypeInfo;
-                switch (pTypeInfo.getPrimitiveCategory()) {
+                PrimitiveTypeInfo primitiveTypeInfo = (PrimitiveTypeInfo) hiveTypeInfo;
+                switch (primitiveTypeInfo.getPrimitiveCategory()) {
                     case VOID:
                         return Type.NULL;
                     case BOOLEAN:
@@ -171,11 +158,12 @@ public final class HiveUtil {
                     case DECIMAL:
                         return Type.DECIMALV2;
                     default:
-                        throw new UnsupportedOperationException("Unsupported type: " + pTypeInfo.getPrimitiveCategory());
+                        throw new UnsupportedOperationException("Unsupported type: "
+                            + primitiveTypeInfo.getPrimitiveCategory());
                 }
             }
             case LIST:
-                TypeInfo elementTypeInfo = ((ListTypeInfo)hiveTypeInfo)
+                TypeInfo elementTypeInfo = ((ListTypeInfo) hiveTypeInfo)
                         .getListElementTypeInfo();
                 Type newType = null;
                 if (elementTypeInfo.getCategory() == ObjectInspector.Category.PRIMITIVE) {

--- a/fe/fe-core/src/main/java/org/apache/doris/external/hive/util/HiveUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/external/hive/util/HiveUtil.java
@@ -1,0 +1,195 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.external.hive.util;
+
+import com.google.common.collect.Lists;
+import org.apache.doris.catalog.ArrayType;
+import org.apache.doris.catalog.Column;
+import org.apache.doris.catalog.Type;
+import org.apache.doris.common.AnalysisException;
+import org.apache.doris.common.Config;
+import org.apache.doris.common.UserException;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.metastore.api.FieldSchema;
+import org.apache.hadoop.hive.ql.io.SymlinkTextInputFormat;
+import org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
+import org.apache.hadoop.hive.serde2.typeinfo.ListTypeInfo;
+import org.apache.hadoop.hive.serde2.typeinfo.PrimitiveTypeInfo;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoUtils;
+import org.apache.hadoop.mapred.InputFormat;
+import org.apache.hadoop.mapred.JobConf;
+import org.apache.hadoop.mapred.TextInputFormat;
+import org.apache.hadoop.util.ReflectionUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.joda.time.format.DateTimeFormat;
+import org.joda.time.format.DateTimeFormatter;
+import org.joda.time.format.DateTimeFormatterBuilder;
+import org.joda.time.format.DateTimeParser;
+import org.joda.time.format.DateTimePrinter;
+import org.joda.time.format.ISODateTimeFormat;
+
+import java.lang.reflect.Field;
+import java.util.List;
+
+public final class HiveUtil {
+    private static final Logger LOG = LogManager.getLogger(HiveUtil.class);
+
+    private static final DateTimeFormatter HIVE_DATE_PARSER = ISODateTimeFormat.date().withZoneUTC();
+    private static final DateTimeFormatter HIVE_TIMESTAMP_PARSER;
+    private static final Field COMPRESSION_CODECS_FIELD;
+
+    static {
+        DateTimeParser[] timestampWithoutTimeZoneParser = {
+                DateTimeFormat.forPattern("yyyy-M-d").getParser(),
+                DateTimeFormat.forPattern("yyyy-M-d H:m").getParser(),
+                DateTimeFormat.forPattern("yyyy-M-d H:m:s").getParser(),
+                DateTimeFormat.forPattern("yyyy-M-d H:m:s.SSS").getParser(),
+                DateTimeFormat.forPattern("yyyy-M-d H:m:s.SSSSSSS").getParser(),
+                DateTimeFormat.forPattern("yyyy-M-d H:m:s.SSSSSSSSS").getParser(),
+        };
+        DateTimePrinter timestampWithoutTimeZonePrinter = DateTimeFormat.forPattern("yyyy-MM-dd HH:mm:ss.SSSSSSSSS").getPrinter();
+        HIVE_TIMESTAMP_PARSER = new DateTimeFormatterBuilder().append(timestampWithoutTimeZonePrinter, timestampWithoutTimeZoneParser).toFormatter().withZoneUTC();
+
+        try {
+            COMPRESSION_CODECS_FIELD = TextInputFormat.class.getDeclaredField("compressionCodecs");
+            COMPRESSION_CODECS_FIELD.setAccessible(true);
+        }
+        catch (ReflectiveOperationException e) {
+            throw new AssertionError(e);
+        }
+    }
+
+    private HiveUtil()
+    {
+    }
+
+    public static InputFormat<?, ?> getInputFormat(Configuration configuration, String inputFormatName, boolean symlinkTarget) throws UserException {
+        try {
+            JobConf jobConf = new JobConf(configuration);
+
+            Class<? extends InputFormat<?, ?>> inputFormatClass = getInputFormatClass(jobConf, inputFormatName);
+            if (symlinkTarget && (inputFormatClass == SymlinkTextInputFormat.class)) {
+                // symlink targets are always TextInputFormat
+                inputFormatClass = TextInputFormat.class;
+            }
+
+            return ReflectionUtils.newInstance(inputFormatClass, jobConf);
+        }
+        catch (ClassNotFoundException | RuntimeException e) {
+            throw new UserException("Unable to create input format " + inputFormatName, e);
+        }
+    }
+
+    @SuppressWarnings({"unchecked", "RedundantCast"})
+    private static Class<? extends InputFormat<?, ?>> getInputFormatClass(JobConf conf, String inputFormatName)
+            throws ClassNotFoundException
+    {
+        // CDH uses different names for Parquet
+        if ("parquet.hive.DeprecatedParquetInputFormat".equals(inputFormatName) ||
+                "parquet.hive.MapredParquetInputFormat".equals(inputFormatName)) {
+            return MapredParquetInputFormat.class;
+        }
+
+        Class<?> clazz = conf.getClassByName(inputFormatName);
+        return (Class<? extends InputFormat<?, ?>>) clazz.asSubclass(InputFormat.class);
+    }
+
+    public static List<Column> transformHiveSchema(List<FieldSchema> hiveSchema) throws AnalysisException {
+        List<Column> newSchema = Lists.newArrayList();
+        for (FieldSchema hiveColumn : hiveSchema) {
+            try {
+                newSchema.add(HiveUtil.transformHiveField(hiveColumn));
+            } catch (UnsupportedOperationException e) {
+                if (Config.iceberg_table_creation_strict_mode) {
+                    throw e;
+                }
+                LOG.warn("Unsupported data type in Doris, ignore column[{}], with error: {}",
+                        hiveColumn.getName(), e.getMessage());
+                continue;
+            }
+        }
+        return newSchema;
+    }
+
+    public static Column transformHiveField(FieldSchema field) {
+        TypeInfo hiveTypeInfo = TypeInfoUtils.getTypeInfoFromTypeString(field.getType());
+        Type type = convertHiveTypeToiveDoris(hiveTypeInfo);
+        return new Column(field.getName(), type, false, null, true, null, field.getComment());
+    }
+
+    private static Type convertHiveTypeToiveDoris(TypeInfo hiveTypeInfo) {
+
+        switch (hiveTypeInfo.getCategory()) {
+            case PRIMITIVE: {
+                PrimitiveTypeInfo pTypeInfo = (PrimitiveTypeInfo) hiveTypeInfo;
+                switch (pTypeInfo.getPrimitiveCategory()) {
+                    case VOID:
+                        return Type.NULL;
+                    case BOOLEAN:
+                        return Type.BOOLEAN;
+                    case BYTE:
+                        return Type.TINYINT;
+                    case SHORT:
+                        return Type.SMALLINT;
+                    case INT:
+                        return Type.INT;
+                    case LONG:
+                        return Type.BIGINT;
+                    case FLOAT:
+                        return Type.FLOAT;
+                    case DOUBLE:
+                        return Type.DOUBLE;
+                    case STRING:
+                        return Type.STRING;
+                    case CHAR:
+                        return Type.CHAR;
+                    case VARCHAR:
+                        return Type.VARCHAR;
+                    case DATE:
+                        return Type.DATE;
+                    case TIMESTAMP:
+                        return Type.DATETIME;
+                    case DECIMAL:
+                        return Type.DECIMALV2;
+                    default:
+                        throw new UnsupportedOperationException("Unsupported type: " + pTypeInfo.getPrimitiveCategory());
+                }
+            }
+            case LIST:
+                TypeInfo elementTypeInfo = ((ListTypeInfo)hiveTypeInfo)
+                        .getListElementTypeInfo();
+                Type newType = null;
+                if (elementTypeInfo.getCategory() == ObjectInspector.Category.PRIMITIVE) {
+                    newType = convertHiveTypeToiveDoris(elementTypeInfo);
+                } else {
+                    throw new UnsupportedOperationException("Unsupported type: " + hiveTypeInfo.toString());
+                }
+                return new ArrayType(newType);
+            case MAP:
+            case STRUCT:
+            case UNION:
+            default:
+                throw new UnsupportedOperationException("Unsupported type: " + hiveTypeInfo.toString());
+        }
+    }
+
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/external/hudi/HudiTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/external/hudi/HudiTable.java
@@ -117,7 +117,7 @@ public class HudiTable extends Table {
         thriftHudiTable.setTableName(getHmsTableName());
         thriftHudiTable.setProperties(getTableProperties());
 
-        TTableDescriptor thriftTableDescriptor = new TTableDescriptor(getId(), TTableType.HUDI_TABLE,
+        TTableDescriptor thriftTableDescriptor = new TTableDescriptor(getId(), TTableType.BROKER_TABLE,
                 fullSchema.size(), 0, getName(), "");
         thriftTableDescriptor.setHudiTable(thriftHudiTable);
         return thriftTableDescriptor;

--- a/fe/fe-core/src/main/java/org/apache/doris/external/hudi/HudiUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/external/hudi/HudiUtils.java
@@ -166,9 +166,11 @@ public class HudiUtils {
         }
 
         List<Column> newSchema = HiveUtil.transformHiveSchema(remoteHiveTable.getSd().getCols());
-        table.setNewFullSchema(newSchema);
-        return table;
-
+        HudiTable tableWithSchema =  new HudiTable(table.getId(),
+            table.getName(),
+            newSchema,
+            table.getTableProperties());
+        return tableWithSchema;
     }
 
 

--- a/fe/fe-core/src/main/java/org/apache/doris/external/hudi/HudiUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/external/hudi/HudiUtils.java
@@ -167,9 +167,9 @@ public class HudiUtils {
 
         List<Column> newSchema = HiveUtil.transformHiveSchema(remoteHiveTable.getSd().getCols());
         HudiTable tableWithSchema =  new HudiTable(table.getId(),
-            table.getName(),
-            newSchema,
-            table.getTableProperties());
+                table.getName(),
+                newSchema,
+                table.getTableProperties());
         return tableWithSchema;
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/external/hudi/HudiUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/external/hudi/HudiUtils.java
@@ -21,14 +21,13 @@ import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.HiveMetaStoreClientHelper;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.DdlException;
+import org.apache.doris.common.ErrorCode;
+import org.apache.doris.external.hive.util.HiveUtil;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.Maps;
-import org.apache.doris.common.ErrorCode;
-import org.apache.doris.external.hive.util.HiveUtil;
 import org.apache.hudi.hadoop.HoodieParquetInputFormat;
 import org.apache.hudi.hadoop.realtime.HoodieParquetRealtimeInputFormat;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -138,6 +137,13 @@ public class HudiUtils {
         }
     }
 
+    /**
+     * resolve hudi table from hive metaStore.
+     *
+     * @param table a doris hudi table
+     * @return a doris hudi table which has been resolved.
+     * @throws AnalysisException when remoteTable is not exist or not a hudi table
+     */
     public static HudiTable resolveHudiTable(HudiTable table) throws AnalysisException {
         String metastoreUris = table.getTableProperties().get(HudiProperty.HUDI_HIVE_METASTORE_URIS);
         org.apache.hadoop.hive.metastore.api.Table remoteHiveTable = null;

--- a/fe/fe-core/src/main/java/org/apache/doris/external/hudi/HudiUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/external/hudi/HudiUtils.java
@@ -17,21 +17,32 @@
 
 package org.apache.doris.external.hudi;
 
+import org.apache.doris.catalog.Column;
+import org.apache.doris.catalog.HiveMetaStoreClientHelper;
+import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.DdlException;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.Maps;
+import org.apache.doris.common.ErrorCode;
+import org.apache.doris.external.hive.util.HiveUtil;
 import org.apache.hudi.hadoop.HoodieParquetInputFormat;
 import org.apache.hudi.hadoop.realtime.HoodieParquetRealtimeInputFormat;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Hudi utils.
  */
 public class HudiUtils {
+    private static final Logger LOG = LogManager.getLogger(HudiUtils.class);
 
     private static final String PROPERTY_MISSING_MSG =
             "Hudi table %s is null. Please add properties('%s'='xxx') when create table";
@@ -117,12 +128,44 @@ public class HudiUtils {
         Set<String> hudiColumnNames = table.getFullSchema().stream()
                 .map(x -> x.getName()).collect(Collectors.toSet());
 
-        Set<String> hiveTableColumnNames = hiveTable.getSd().getCols()
-                .stream().map(x -> x.getName()).collect(Collectors.toSet());
+        Set<String> hiveTableColumnNames =
+                Stream.concat(hiveTable.getSd().getCols().stream(), hiveTable.getPartitionKeys().stream())
+                .map(x -> x.getName()).collect(Collectors.toSet());
         hudiColumnNames.removeAll(hiveTableColumnNames);
         if (hudiColumnNames.size() > 0) {
             throw new DdlException(String.format("Hudi table's column(s): {%s} didn't exist in hive table. ",
                     String.join(", ", hudiColumnNames)));
         }
     }
+
+    public static HudiTable resolveHudiTable(HudiTable table) throws AnalysisException {
+        String metastoreUris = table.getTableProperties().get(HudiProperty.HUDI_HIVE_METASTORE_URIS);
+        org.apache.hadoop.hive.metastore.api.Table remoteHiveTable = null;
+        try {
+            remoteHiveTable = HiveMetaStoreClientHelper.getTable(
+                    table.getHmsDatabaseName(),
+                    table.getHmsTableName(),
+                    metastoreUris);
+        } catch (DdlException e) {
+            LOG.error("Failed to get table from HiveMetaStore", e);
+            throw new AnalysisException(ErrorCode.ERR_UNKNOWN_ERROR.formatErrorMsg());
+        }
+        if (remoteHiveTable == null) {
+            throw new AnalysisException(ErrorCode.ERR_UNKNOWN_TABLE.formatErrorMsg(table.getHmsTableName(),
+                    "HiveMetaStore"));
+        }
+        if (!HudiUtils.isHudiTable(remoteHiveTable)) {
+            throw new AnalysisException(ErrorCode.ERR_UNKNOWN_TABLE.formatErrorMsg(table.getHmsTableName(),
+                    "HiveMetaStore"));
+        }
+
+        List<Column> newSchema = HiveUtil.transformHiveSchema(remoteHiveTable.getSd().getCols());
+        table.setNewFullSchema(newSchema);
+        return table;
+
+    }
+
+
+
+
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/load/BrokerFileGroup.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/BrokerFileGroup.java
@@ -76,6 +76,7 @@ public class BrokerFileGroup implements Writable {
     private List<Long> fileSize;
 
     private List<String> fileFieldNames;
+    // partition columnNames
     private List<String> columnsFromPath;
     // columnExprList includes all fileFieldNames, columnsFromPath and column mappings
     // this param will be recreated by data desc when the log replay
@@ -144,6 +145,26 @@ public class BrokerFileGroup implements Writable {
         this.valueSeparator = "|";
         this.lineDelimiter = "\n";
         this.fileFormat = table.getFileFormat();
+    }
+
+    /**
+     * Should used for hive/iceberg/hudi external table.
+     */
+    public BrokerFileGroup(long tableId,
+            String columnSeparator,
+            String lineDelimiter,
+            String filePath,
+            String fileFormat,
+            List<String> columnsFromPath,
+            List<ImportColumnDesc> columnExprList) throws AnalysisException {
+        this.tableId = tableId;
+        this.valueSeparator = Separator.convertSeparator(columnSeparator);
+        this.lineDelimiter = Separator.convertSeparator(lineDelimiter);
+        this.isNegative = false;
+        this.filePaths = Lists.newArrayList(filePath);
+        this.fileFormat = fileFormat;
+        this.columnsFromPath = columnsFromPath;
+        this.columnExprList = columnExprList;
     }
 
     public BrokerFileGroup(DataDescription dataDescription) {

--- a/fe/fe-core/src/main/java/org/apache/doris/load/BrokerFileGroup.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/BrokerFileGroup.java
@@ -27,7 +27,6 @@ import org.apache.doris.catalog.BrokerTable;
 import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.Database;
 import org.apache.doris.catalog.HiveTable;
-import org.apache.doris.catalog.IcebergTable;
 import org.apache.doris.catalog.KeysType;
 import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.catalog.OlapTable.OlapTableState;
@@ -37,7 +36,6 @@ import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.DdlException;
 import org.apache.doris.common.FeConstants;
 import org.apache.doris.common.Pair;
-import org.apache.doris.common.UserException;
 import org.apache.doris.common.io.Text;
 import org.apache.doris.common.io.Writable;
 import org.apache.doris.load.loadv2.LoadTask;
@@ -120,31 +118,13 @@ public class BrokerFileGroup implements Writable {
         this.fileFormat = table.getFileFormat();
     }
 
-    // Used for hive table, no need to parse
-    public BrokerFileGroup(HiveTable table,
-                           String columnSeparator,
-                           String lineDelimiter,
+    /**
+     * Should used for hive/iceberg/hudi external table.
+     */
+    public BrokerFileGroup(long tableId,
                            String filePath,
-                           String fileFormat,
-                           List<String> columnsFromPath,
-                           List<ImportColumnDesc> columnExprList) throws AnalysisException {
-        this.tableId = table.getId();
-        this.valueSeparator = Separator.convertSeparator(columnSeparator);
-        this.lineDelimiter = Separator.convertSeparator(lineDelimiter);
-        this.isNegative = false;
-        this.filePaths = Lists.newArrayList(filePath);
-        this.fileFormat = fileFormat;
-        this.columnsFromPath = columnsFromPath;
-        this.columnExprList = columnExprList;
-    }
-
-    // Used for iceberg table, no need to parse
-    public BrokerFileGroup(IcebergTable table) throws UserException {
-        this.tableId = table.getId();
-        this.isNegative = false;
-        this.valueSeparator = "|";
-        this.lineDelimiter = "\n";
-        this.fileFormat = table.getFileFormat();
+                           String fileFormat) throws AnalysisException {
+        this(tableId,  "|", "\n", filePath, fileFormat, null, null);
     }
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/BrokerScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/BrokerScanNode.java
@@ -125,7 +125,7 @@ public class BrokerScanNode extends LoadScanNode {
 
     private Analyzer analyzer;
 
-    private static class ParamCreateContext {
+    protected static class ParamCreateContext {
         public BrokerFileGroup fileGroup;
         public TBrokerScanRangeParams params;
         public TupleDescriptor srcTupleDescriptor;
@@ -171,6 +171,10 @@ public class BrokerScanNode extends LoadScanNode {
             initParams(context);
             paramCreateContexts.add(context);
         }
+    }
+
+    public List<ParamCreateContext> getParamCreateContexts() {
+        return paramCreateContexts;
     }
 
     protected void initFileGroup() throws UserException {
@@ -267,13 +271,15 @@ public class BrokerScanNode extends LoadScanNode {
             }
         }
 
-        Load.initColumns(targetTable, columnDescs,
-                context.fileGroup.getColumnToHadoopFunction(), context.exprMap, analyzer,
-                context.srcTupleDescriptor, context.slotDescByName, context.params,
-                formatType(context.fileGroup.getFileFormat(), ""), VectorizedUtil.isVectorized());
+        if (targetTable != null) {
+            Load.initColumns(targetTable, columnDescs,
+                    context.fileGroup.getColumnToHadoopFunction(), context.exprMap, analyzer,
+                    context.srcTupleDescriptor, context.slotDescByName, context.params,
+                    formatType(context.fileGroup.getFileFormat(), ""), VectorizedUtil.isVectorized());
+        }
     }
 
-    private TScanRangeLocations newLocations(TBrokerScanRangeParams params, BrokerDesc brokerDesc)
+    protected TScanRangeLocations newLocations(TBrokerScanRangeParams params, BrokerDesc brokerDesc)
             throws UserException {
 
         Backend selectedBackend;
@@ -322,10 +328,6 @@ public class BrokerScanNode extends LoadScanNode {
         return locations;
     }
 
-    private TBrokerScanRange brokerScanRange(TScanRangeLocations locations) {
-        return locations.scan_range.broker_scan_range;
-    }
-
     private void getFileStatusAndCalcInstance() throws UserException {
         if (fileStatusesList == null || filesAdded == -1) {
             // FIXME(cmy): fileStatusesList and filesAdded can be set out of db lock when doing pull load,
@@ -336,7 +338,10 @@ public class BrokerScanNode extends LoadScanNode {
             filesAdded = 0;
             this.getFileStatus();
         }
-        Preconditions.checkState(fileStatusesList.size() == fileGroups.size());
+        // In hudiScanNode, calculate scan range using its own way which do not need fileStatusesList
+        if (!(this instanceof HudiScanNode)) {
+            Preconditions.checkState(fileStatusesList.size() == fileGroups.size());
+        }
 
         if (isLoad() && filesAdded == 0) {
             throw new UserException("No source file in this table(" + targetTable.getName() + ").");
@@ -503,7 +508,7 @@ public class BrokerScanNode extends LoadScanNode {
                         rangeDesc.setNumAsString(context.fileGroup.isNumAsString());
                         rangeDesc.setReadJsonByLine(context.fileGroup.isReadJsonByLine());
                     }
-                    brokerScanRange(curLocations).addToRanges(rangeDesc);
+                    curLocations.getScanRange().getBrokerScanRange().addToRanges(rangeDesc);
                     curFileOffset += rangeBytes;
 
                 } else {
@@ -516,7 +521,7 @@ public class BrokerScanNode extends LoadScanNode {
                     }
 
                     rangeDesc.setReadByColumnDef(true);
-                    brokerScanRange(curLocations).addToRanges(rangeDesc);
+                    curLocations.getScanRange().getBrokerScanRange().addToRanges(rangeDesc);
                     curFileOffset = 0;
                     i++;
                 }
@@ -544,7 +549,7 @@ public class BrokerScanNode extends LoadScanNode {
                 }
 
                 rangeDesc.setReadByColumnDef(true);
-                brokerScanRange(curLocations).addToRanges(rangeDesc);
+                curLocations.getScanRange().getBrokerScanRange().addToRanges(rangeDesc);
                 curFileOffset = 0;
                 curInstanceBytes += leftBytes;
                 i++;
@@ -552,7 +557,7 @@ public class BrokerScanNode extends LoadScanNode {
         }
 
         // Put the last file
-        if (brokerScanRange(curLocations).isSetRanges()) {
+        if (curLocations.getScanRange().getBrokerScanRange().isSetRanges()) {
             locationsList.add(curLocations);
         }
     }
@@ -568,7 +573,10 @@ public class BrokerScanNode extends LoadScanNode {
         rangeDesc.setSplittable(fileStatus.isSplitable);
         rangeDesc.setStartOffset(curFileOffset);
         rangeDesc.setSize(rangeBytes);
+        // fileSize only be used when format is orc or parquet and TFileType is broker
+        // When TFileType is other type, it is not necessary
         rangeDesc.setFileSize(fileStatus.size);
+        // In Backend, will append columnsFromPath to the end of row after data scanned from file.
         rangeDesc.setNumOfColumnsFromFile(numberOfColumnsFromFile);
         rangeDesc.setColumnsFromPath(columnsFromPath);
         rangeDesc.setHeaderType(headerType);

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/HiveScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/HiveScanNode.java
@@ -115,7 +115,7 @@ public class HiveScanNode extends BrokerScanNode {
 
         HiveTable hiveTable = (HiveTable) desc.getTable();
         fileGroups = Lists.newArrayList(
-                new BrokerFileGroup(hiveTable,
+                new BrokerFileGroup(hiveTable.getId(),
                         getColumnSeparator(),
                         getLineDelimiter(),
                         getPath(),

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/HudiScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/HudiScanNode.java
@@ -1,0 +1,364 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.planner;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import org.apache.doris.analysis.Analyzer;
+import org.apache.doris.analysis.BrokerDesc;
+import org.apache.doris.analysis.Expr;
+import org.apache.doris.analysis.ImportColumnDesc;
+import org.apache.doris.analysis.SlotDescriptor;
+import org.apache.doris.analysis.StorageBackend;
+import org.apache.doris.analysis.TupleDescriptor;
+import org.apache.doris.catalog.Column;
+import org.apache.doris.catalog.HiveMetaStoreClientHelper;
+import org.apache.doris.common.AnalysisException;
+import org.apache.doris.common.DdlException;
+import org.apache.doris.common.UserException;
+import org.apache.doris.common.util.BrokerUtil;
+import org.apache.doris.external.hive.util.HiveUtil;
+import org.apache.doris.external.hudi.HudiProperty;
+import org.apache.doris.external.hudi.HudiTable;
+import org.apache.doris.load.BrokerFileGroup;
+import org.apache.doris.thrift.TBrokerFileStatus;
+import org.apache.doris.thrift.TBrokerRangeDesc;
+import org.apache.doris.thrift.TBrokerScanRangeParams;
+import org.apache.doris.thrift.TExplainLevel;
+import org.apache.doris.thrift.TFileFormatType;
+import org.apache.doris.thrift.THdfsParams;
+import org.apache.doris.thrift.TScanRangeLocations;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.metastore.api.FieldSchema;
+import org.apache.hadoop.hive.metastore.api.Partition;
+import org.apache.hadoop.hive.metastore.api.Table;
+import org.apache.hadoop.hive.ql.plan.ExprNodeDesc;
+import org.apache.hadoop.hive.ql.plan.ExprNodeGenericFuncDesc;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
+import org.apache.hadoop.mapred.FileInputFormat;
+import org.apache.hadoop.mapred.FileSplit;
+import org.apache.hadoop.mapred.InputFormat;
+import org.apache.hadoop.mapred.InputSplit;
+import org.apache.hadoop.mapred.JobConf;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.mortbay.log.Log;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class HudiScanNode extends BrokerScanNode {
+    private static final Logger LOG = LogManager.getLogger(HudiScanNode.class);
+
+    private HudiTable hudiTable;
+    // partition column predicates of hive table
+    private List<ExprNodeDesc> hivePredicates = new ArrayList<>();
+    private ExprNodeGenericFuncDesc hivePartitionPredicate;
+    private List<ImportColumnDesc> parsedColumnExprList = new ArrayList<>();
+    private String hdfsUri;
+
+    private Table remoteHiveTable;
+
+    /* hudi table properties */
+    private String fileFormat;
+    private String inputFormatName;
+    private String basePath;
+    private List<String> partitionKeys = new ArrayList<>();
+    /* hudi table properties */
+
+    private List<TScanRangeLocations> scanRangeLocations;
+
+    public String getHdfsUri() {
+        return hdfsUri;
+    }
+
+    public List<ImportColumnDesc> getParsedColumnExprList() {
+        return parsedColumnExprList;
+    }
+
+    public String getFileFormat() {
+        return fileFormat;
+    }
+
+    public String getBasePath() {
+        return basePath;
+    }
+
+    public List<String> getPartitionKeys() {
+        return partitionKeys;
+    }
+
+    public HudiScanNode(PlanNodeId id, TupleDescriptor destTupleDesc, String planNodeName,
+                        List<List<TBrokerFileStatus>> fileStatusesList, int filesAdded) {
+        super(id, destTupleDesc, planNodeName, fileStatusesList, filesAdded);
+        this.hudiTable = (HudiTable) destTupleDesc.getTable();
+    }
+
+    /**
+     *  super init will invoke initFileGroup, In initFileGroup will do
+     *  1, get hudi table from hive metastore
+     *  2, resolve hudi table type, query mode, table base path, partition columns information.
+     *  3. generate fileGroup
+     *
+     * @param analyzer
+     * @throws UserException
+     */
+    @Override
+    public void init(Analyzer analyzer) throws UserException {
+        super.init(analyzer);
+        // init scan range params
+        initParams(analyzer);
+    }
+
+    @Override
+    public int getNumInstances() {
+        return scanRangeLocations.size();
+    }
+
+    @Override
+    protected void initFileGroup() throws UserException {
+        resolvHiveTable();
+        analyzeColumnFromPath();
+
+        HudiTable hudiTable = (HudiTable) desc.getTable();
+        fileGroups = Lists.newArrayList(
+                new BrokerFileGroup(hudiTable.getId(),
+                        "\t",
+                        "\n",
+                        getBasePath(),
+                        getFileFormat(),
+                        getPartitionKeys(),
+                        getParsedColumnExprList()));
+        brokerDesc = new BrokerDesc("HudiTableDesc", StorageBackend.StorageType.HDFS, hudiTable.getTableProperties());
+
+    }
+
+    /**
+     * Override this function just for skip parent's getFileStatus
+     */
+    @Override
+    protected void getFileStatus() throws DdlException {
+        if (partitionKeys.size() > 0) {
+            extractHivePartitionPredicate();
+        }
+        // set fileStatusesList as empty, we do not need fileStatusesList
+        fileStatusesList = Lists.newArrayList();
+        filesAdded = 0;
+    }
+
+    @Override
+    public void finalize(Analyzer analyzer) throws UserException {
+        try {
+            ParamCreateContext context = getParamCreateContexts().get(0);
+            finalizeParams(context.slotDescByName, context.exprMap, context.params,
+                    context.srcTupleDescriptor, false, context.fileGroup.isNegative(), analyzer);
+        } catch (AnalysisException e) {
+            throw new UserException(e.getMessage());
+        }
+        try {
+            buildScanRange();
+        } catch (IOException e) {
+            LOG.error("Build scan range failed.", e);
+            throw new UserException("Build scan range failed.", e);
+        }
+    }
+
+    @Override
+    public List<TScanRangeLocations> getScanRangeLocations(long maxScanRangeLength) {
+        return scanRangeLocations;
+    }
+
+    private void resolvHiveTable() throws DdlException {
+        this.remoteHiveTable = HiveMetaStoreClientHelper.getTable(
+                hudiTable.getHmsDatabaseName(),
+                hudiTable.getHmsTableName(),
+                hudiTable.getTableProperties().get(HudiProperty.HUDI_HIVE_METASTORE_URIS));
+
+        this.inputFormatName = remoteHiveTable.getSd().getInputFormat();
+        this.fileFormat = HiveMetaStoreClientHelper.HiveFileFormat.getFormat(this.inputFormatName);
+        this.basePath = remoteHiveTable.getSd().getLocation();
+        for (FieldSchema fieldSchema : remoteHiveTable.getPartitionKeys()) {
+            this.partitionKeys.add(fieldSchema.getName());
+        }
+        Log.info("Hudi inputFileFormat is " + inputFormatName + ", basePath is " + this.basePath);
+    }
+
+    private void initParams(Analyzer analyzer) {
+        ParamCreateContext context = getParamCreateContexts().get(0);
+        TBrokerScanRangeParams params = context.params;
+
+        Map<String, SlotDescriptor> slotDescByName = Maps.newHashMap();
+
+        List<Column> columns = hudiTable.getBaseSchema(false);
+        // init slot desc add expr map, also transform hadoop functions
+        for (Column column : columns) {
+            SlotDescriptor slotDesc = analyzer.getDescTbl().addSlotDescriptor(context.srcTupleDescriptor);
+            slotDesc.setType(column.getType());
+            slotDesc.setIsMaterialized(true);
+            slotDesc.setIsNullable(true);
+            slotDesc.setColumn(column);
+            params.addToSrcSlotIds(slotDesc.getId().asInt());
+            slotDescByName.put(column.getName(), slotDesc);
+        }
+        context.slotDescByName = slotDescByName;
+    }
+
+
+    /**
+     * Extracts partition predicate from SelectStmt.whereClause that can be pushed down to Hive
+     */
+    private void extractHivePartitionPredicate() throws DdlException {
+        ListIterator<Expr> it = conjuncts.listIterator();
+        while (it.hasNext()) {
+            ExprNodeGenericFuncDesc hiveExpr = HiveMetaStoreClientHelper.convertToHivePartitionExpr(
+                    it.next(), partitionKeys, hudiTable.getName());
+            if (hiveExpr != null) {
+                hivePredicates.add(hiveExpr);
+            }
+        }
+        int count = hivePredicates.size();
+        // combine all predicate by `and`
+        // compoundExprs must have at least 2 predicates
+        if (count >= 2) {
+            hivePartitionPredicate = HiveMetaStoreClientHelper.getCompoundExpr(hivePredicates, "and");
+        } else if (count == 1) {
+            // only one predicate
+            hivePartitionPredicate = (ExprNodeGenericFuncDesc) hivePredicates.get(0);
+        } else {
+            // have no predicate, make a dummy predicate "1=1" to get all partitions
+            HiveMetaStoreClientHelper.ExprBuilder exprBuilder =
+                    new HiveMetaStoreClientHelper.ExprBuilder(hudiTable.getName());
+            hivePartitionPredicate = exprBuilder.val(TypeInfoFactory.intTypeInfo, 1)
+                    .val(TypeInfoFactory.intTypeInfo, 1)
+                    .pred("=", 2).build();
+        }
+    }
+
+    private InputSplit[] getSplits() throws UserException, IOException {
+        String splitsPath = basePath;
+        if (partitionKeys.size() > 0) {
+            extractHivePartitionPredicate();
+
+            String metaStoreUris = hudiTable.getTableProperties().get(HudiProperty.HUDI_HIVE_METASTORE_URIS);
+            List<Partition> hivePartitions =
+                    HiveMetaStoreClientHelper.getHivePartitions(metaStoreUris, remoteHiveTable, hivePartitionPredicate);
+            splitsPath = hivePartitions.stream()
+                    .map(x -> x.getSd().getLocation()).collect(Collectors.joining(","));
+        }
+
+
+        Configuration configuration = new Configuration();
+        InputFormat<?, ?> inputFormat = HiveUtil.getInputFormat(configuration, inputFormatName, false);
+        // alway get fileSplits from inputformat,
+        // because all hoodie input format have UseFileSplitsFromInputFormat annotation
+        JobConf jobConf = new JobConf(configuration);
+        FileInputFormat.setInputPaths(jobConf, splitsPath);
+        InputSplit[] inputSplits = inputFormat.getSplits(jobConf,0);
+        return inputSplits;
+
+    }
+
+    // If fileFormat is not null, we use fileFormat instead of check file's suffix
+    protected void buildScanRange() throws UserException, IOException {
+        scanRangeLocations = Lists.newArrayList();
+        InputSplit[] inputSplits = getSplits();
+        if (inputSplits.length == 0) {
+            return;
+        }
+
+        THdfsParams tHdfsParams = new THdfsParams();
+        String fullPath = ((FileSplit)inputSplits[0]).getPath().toUri().toString();
+        String filePath = ((FileSplit)inputSplits[0]).getPath().toUri().getPath();
+        String fsName = fullPath.replace(filePath, "");
+        tHdfsParams.setFsName(fsName);
+        Log.info("Hudi  path's host is  " + fsName);
+
+        TFileFormatType formatType = TFileFormatType.FORMAT_PARQUET;
+        ParamCreateContext context = getParamCreateContexts().get(0);
+        for(InputSplit split: inputSplits) {
+            FileSplit fileSplit = (FileSplit)split;
+
+            TScanRangeLocations curLocations = newLocations(context.params, brokerDesc);
+            List<String> partitionValuesFromPath = BrokerUtil.parseColumnsFromPath(fileSplit.getPath().toString(),
+                    getPartitionKeys());
+            int numberOfColumnsFromFile = context.slotDescByName.size() - partitionValuesFromPath.size();
+
+            TBrokerRangeDesc rangeDesc = createBrokerRangeDesc(fileSplit, formatType,
+                    partitionValuesFromPath, numberOfColumnsFromFile, brokerDesc);
+            rangeDesc.setHdfsParams(tHdfsParams);
+            rangeDesc.setReadByColumnDef(true);
+
+            curLocations.getScanRange().getBrokerScanRange().addToRanges(rangeDesc);
+            Log.info("Assign to backend " + curLocations.getLocations().get(0).getBackendId()
+                    + " with hudi split: " +  fileSplit.getPath()
+                    + " ( " + fileSplit.getStart() + "," + fileSplit.getLength() + ")");
+
+            // Put the last file
+            if (curLocations.getScanRange().getBrokerScanRange().isSetRanges()) {
+                scanRangeLocations.add(curLocations);
+            }
+        }
+    }
+
+    private TBrokerRangeDesc createBrokerRangeDesc(FileSplit fileSplit,
+                                                   TFileFormatType formatType,
+                                                   List<String> columnsFromPath, int numberOfColumnsFromFile,
+                                                   BrokerDesc brokerDesc) {
+        TBrokerRangeDesc rangeDesc = new TBrokerRangeDesc();
+        rangeDesc.setFileType(brokerDesc.getFileType());
+        rangeDesc.setFormatType(formatType);
+        rangeDesc.setPath(fileSplit.getPath().toUri().getPath());
+        rangeDesc.setSplittable(true);
+        rangeDesc.setStartOffset(fileSplit.getStart());
+        rangeDesc.setSize(fileSplit.getLength());
+        rangeDesc.setNumOfColumnsFromFile(numberOfColumnsFromFile);
+        rangeDesc.setColumnsFromPath(columnsFromPath);
+        // set hdfs params for hdfs file type.
+        switch (brokerDesc.getFileType()) {
+            case FILE_HDFS:
+                BrokerUtil.generateHdfsParam(brokerDesc.getProperties(), rangeDesc);
+                break;
+        }
+        return rangeDesc;
+    }
+
+    @Override
+    public String getNodeExplainString(String prefix, TExplainLevel detailLevel) {
+        StringBuilder output = new StringBuilder();
+        if (!isLoad()) {
+            output.append(prefix).append("TABLE: ").append(hudiTable.getName()).append("\n");
+            output.append(prefix).append("PATH: ")
+                    .append(hudiTable.getTableProperties().get(HudiProperty.HUDI_HIVE_METASTORE_URIS)).append("\n");
+        }
+        return output.toString();
+    }
+
+    /**
+     * Analyze columns from path, the partition columns
+     */
+    private void analyzeColumnFromPath() {
+        for (String colName : partitionKeys) {
+            ImportColumnDesc importColumnDesc = new ImportColumnDesc(colName, null);
+            parsedColumnExprList.add(importColumnDesc);
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/HudiScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/HudiScanNode.java
@@ -26,6 +26,8 @@ import org.apache.doris.analysis.StorageBackend;
 import org.apache.doris.analysis.TupleDescriptor;
 import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.HiveMetaStoreClientHelper;
+import org.apache.doris.catalog.PrimitiveType;
+import org.apache.doris.catalog.ScalarType;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.DdlException;
 import org.apache.doris.common.UserException;
@@ -216,10 +218,10 @@ public class HudiScanNode extends BrokerScanNode {
         // init slot desc add expr map, also transform hadoop functions
         for (Column column : columns) {
             SlotDescriptor slotDesc = analyzer.getDescTbl().addSlotDescriptor(context.srcTupleDescriptor);
-            slotDesc.setType(column.getType());
+            slotDesc.setType(ScalarType.createType(PrimitiveType.VARCHAR));
             slotDesc.setIsMaterialized(true);
             slotDesc.setIsNullable(true);
-            slotDesc.setColumn(column);
+            slotDesc.setColumn(new Column(column.getName(), PrimitiveType.VARCHAR));
             params.addToSrcSlotIds(slotDesc.getId().asInt());
             slotDescByName.put(column.getName(), slotDesc);
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/IcebergScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/IcebergScanNode.java
@@ -57,7 +57,10 @@ public class IcebergScanNode extends BrokerScanNode {
 
     @Override
     protected void initFileGroup() throws UserException {
-        fileGroups = Lists.newArrayList(new BrokerFileGroup(icebergTable));
+        fileGroups = Lists.newArrayList(
+            new BrokerFileGroup(icebergTable.getId(),
+                null,
+                icebergTable.getFileFormat()));
         brokerDesc = new BrokerDesc("IcebergTableDesc", icebergTable.getStorageType(),
                 icebergTable.getIcebergProperties());
         targetTable = icebergTable;

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/SingleNodePlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/SingleNodePlanner.java
@@ -1708,6 +1708,10 @@ public class SingleNodePlanner {
                 scanNode = new IcebergScanNode(ctx.getNextNodeId(), tblRef.getDesc(), "IcebergScanNode",
                         null, -1);
                 break;
+            case HUDI:
+                scanNode = new HudiScanNode(ctx.getNextNodeId(), tblRef.getDesc(), "HudiScanNode",
+                        null, -1);
+                break;
             default:
                 break;
         }

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/CreateTableStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/CreateTableStmtTest.java
@@ -301,13 +301,14 @@ public class CreateTableStmtTest {
         CreateTableStmt stmt = new CreateTableStmt(false, true, tblName, "hudi", properties, "");
         ColumnDef idCol = new ColumnDef("id", TypeDef.create(PrimitiveType.INT));
         stmt.addColumnDef(idCol);
-        ColumnDef nameCol = new ColumnDef("name", TypeDef.create(PrimitiveType.STRING));
+        ColumnDef nameCol = new ColumnDef("name", TypeDef.create(PrimitiveType.STRING), false,
+                null, true, ColumnDef.DefaultValue.NOT_SET, "");
         stmt.addColumnDef(nameCol);
         stmt.analyze(analyzer);
 
         Assert.assertEquals("CREATE EXTERNAL TABLE `testCluster:db1`.`table1` (\n"
-                + "id int, \n"
-                + "name string\n"
+                + "  `id` int(11) NULL COMMENT \"\",\n"
+                + "  `name` text NULL COMMENT \"\"\n"
                 + ") ENGINE = hudi\n"
                 + "PROPERTIES (\"hudi.database\"  =  \"doris\",\n"
                 + "\"hudi.hive.metastore.uris\"  =  \"thrift://127.0.0.1:9087\",\n"

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/CreateTableStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/CreateTableStmtTest.java
@@ -291,4 +291,26 @@ public class CreateTableStmtTest {
                 + "\"hudi.hive.metastore.uris\"  =  \"thrift://127.0.0.1:9087\",\n"
                 + "\"hudi.table\"  =  \"test\")", stmt.toString());
     }
+
+    @Test
+    public void testCreateHudiTableWithSchema() throws UserException {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("hudi.database", "doris");
+        properties.put("hudi.table", "test");
+        properties.put("hudi.hive.metastore.uris", "thrift://127.0.0.1:9087");
+        CreateTableStmt stmt = new CreateTableStmt(false, true, tblName, "hudi", properties, "");
+        ColumnDef idCol = new ColumnDef("id", TypeDef.create(PrimitiveType.INT));
+        stmt.addColumnDef(idCol);
+        ColumnDef nameCol = new ColumnDef("name", TypeDef.create(PrimitiveType.STRING));
+        stmt.addColumnDef(nameCol);
+        stmt.analyze(analyzer);
+
+        Assert.assertEquals("CREATE EXTERNAL TABLE `testCluster:db1`.`table1` (\n"
+                + "id int, \n"
+                + "name string\n"
+                + ") ENGINE = hudi\n"
+                + "PROPERTIES (\"hudi.database\"  =  \"doris\",\n"
+                + "\"hudi.hive.metastore.uris\"  =  \"thrift://127.0.0.1:9087\",\n"
+                + "\"hudi.table\"  =  \"test\")", stmt.toString());
+    }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/CreateTableStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/CreateTableStmtTest.java
@@ -301,14 +301,14 @@ public class CreateTableStmtTest {
         CreateTableStmt stmt = new CreateTableStmt(false, true, tblName, "hudi", properties, "");
         ColumnDef idCol = new ColumnDef("id", TypeDef.create(PrimitiveType.INT));
         stmt.addColumnDef(idCol);
-        ColumnDef nameCol = new ColumnDef("name", TypeDef.create(PrimitiveType.STRING), false,
+        ColumnDef nameCol = new ColumnDef("name", TypeDef.create(PrimitiveType.INT), false,
                 null, true, ColumnDef.DefaultValue.NOT_SET, "");
         stmt.addColumnDef(nameCol);
         stmt.analyze(analyzer);
 
         Assert.assertEquals("CREATE EXTERNAL TABLE `testCluster:db1`.`table1` (\n"
-                + "  `id` int(11) NULL COMMENT \"\",\n"
-                + "  `name` text NULL COMMENT \"\"\n"
+                + "  `id` int(11) NOT NULL COMMENT \"\",\n"
+                + "  `name` int(11) NULL COMMENT \"\"\n"
                 + ") ENGINE = hudi\n"
                 + "PROPERTIES (\"hudi.database\"  =  \"doris\",\n"
                 + "\"hudi.hive.metastore.uris\"  =  \"thrift://127.0.0.1:9087\",\n"

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -324,6 +324,12 @@ under the License.
     <dependencyManagement>
         <dependencies>
             <dependency>
+                <groupId>org.apache.hadoop</groupId>
+                <artifactId>hadoop-client</artifactId>
+                <version>2.8.0</version>
+                <scope>compile</scope>
+            </dependency>
+            <dependency>
                 <groupId>${project.groupId}</groupId>
                 <artifactId>fe-common</artifactId>
                 <version>${project.version}</version>


### PR DESCRIPTION
# Proposed changes

Issue Number: https://github.com/apache/incubator-doris/issues/9557

Support query hudi external table in Doris.
This pr support query cow and mor hudi table.
When hudi table is a mor table, only support read optimized query mode.

This is the second pr to support hudi external table.

## Problem Summary:

Describe the overview of changes.


The propose of the pr is:
support query cow and mor hudi table.

### Design

1. generate scan range in Fe.
 Create a HudiScanNode to generate scan range parameters.
HudiScanNode use HoodieParquetInputFormat to get all scan splits and assemble brokerRangeDesc
2. Scan hudi data in Be.
we use broker_scan_node to scan parquet files that send by fe.
3. test case
#### query cow table
```
mysql> select * from t_hudi_cow;
+---------------------+-----------------------+--------------------+------------------------+--------------------------------------------------------------------------+------+------+-------+
| _hoodie_commit_time | _hoodie_commit_seqno  | _hoodie_record_key | _hoodie_partition_path | _hoodie_file_name                                                        | uuid | name | price |
+---------------------+-----------------------+--------------------+------------------------+--------------------------------------------------------------------------+------+------+-------+
| 20220520205304451   | 20220520205304451_0_1 | uuid:1             |                        | 6683497c-5a6c-4ccb-81f9-90673da5ab6a-0_0-42-42_20220520205304451.parquet |    1 | a1   |    20 |
+---------------------+-----------------------+--------------------+------------------------+--------------------------------------------------------------------------+------+------+-------+
1 row in set (0.45 sec)
```
#### query mor table
```sql
mysql> select * from t_hudi_mor;
+---------------------+-----------------------+--------------------+------------------------+-----------------------------------------------------------------------------+------+---------+-------+------+
| _hoodie_commit_time | _hoodie_commit_seqno  | _hoodie_record_key | _hoodie_partition_path | _hoodie_file_name                                                           | id   | name    | price | ts   |
+---------------------+-----------------------+--------------------+------------------------+-----------------------------------------------------------------------------+------+---------+-------+------+
| 20220520205326437   | 20220520205326437_0_2 | id:1               |                        | bbee0b74-9a04-45ae-b95d-12b448d82813-0_0-98-2079_20220520205326437.parquet  |    1 | a1      |    20 | 1000 |
| 20220522100249363   | 20220522100249363_0_1 | id:2               |                        | e9f6a051-2cfd-4cdd-94de-9d2d917dffb8-0_0-29-2007_20220522100249363.parquet  |    2 | b1      |    20 | 1000 |
| 20220522100310109   | 20220522100310109_0_2 | id:3               |                        | e9f6a051-2cfd-4cdd-94de-9d2d917dffb8-0_0-77-4028_20220522100310109.parquet  |    3 | b1      |    20 | 1000 |
| 20220522100324753   | 20220522100324753_0_3 | id:4               |                        | e9f6a051-2cfd-4cdd-94de-9d2d917dffb8-0_0-125-6049_20220522100324753.parquet |    4 | b1      |    20 | 1000 |
| 20220522100339091   | 20220522100339091_0_4 | id:5               |                        | e9f6a051-2cfd-4cdd-94de-9d2d917dffb8-0_0-173-8070_20220522100339091.parquet |    5 | b1      |    20 | 1000 |
| 20220522101838691   | 20220522101838691_0_1 | id:7               |                        | 018a955f-f1aa-4404-b997-e3abe72623fb-0_0-29-2009_20220522101838691.parquet  |    7 | insert1 |    20 | 1000 |
| 20220522101838691   | 20220522101838691_0_2 | id:6               |                        | 018a955f-f1aa-4404-b997-e3abe72623fb-0_0-29-2009_20220522101838691.parquet  |    6 | insert2 |    20 | 1000 |
+---------------------+-----------------------+--------------------+------------------------+-----------------------------------------------------------------------------+------+---------+-------+------+
7 rows in set (0.60 sec)
```
#### query cow partition table
```sql
mysql> select * from t_hudi_cow_partition;
mysql> select * from t_hudi_cow_partition where id >3;
+---------------------+-----------------------+--------------------+------------------------+-----------------------------------------------------------------------------+------+--------+-------+------+
| _hoodie_commit_time | _hoodie_commit_seqno  | _hoodie_record_key | _hoodie_partition_path | _hoodie_file_name                                                           | id   | name   | price | ts   |
+---------------------+-----------------------+--------------------+------------------------+-----------------------------------------------------------------------------+------+--------+-------+------+
| 20220522192429630   | 20220522192429630_0_3 | id:31              | dt=2022-5-21           | 27e3edf3-900f-45e9-adbc-b09d6b065aaf-0_0-137-6071_20220522192429630.parquet |   31 | name31 |   300 | NULL |
| 20220522192557945   | 20220522192557945_0_4 | id:41              | dt=2022-5-22           | 60c2d68c-3318-4896-9af1-54f63324bd48-0_0-193-8109_20220522192557945.parquet |   41 | name41 |   400 | NULL |
| 20220522192557945   | 20220522192557945_1_5 | id:51              | dt=2022-5-23           | 913fe002-b5ba-4106-8894-34a25fe2dbb3-0_1-199-8110_20220522192557945.parquet |   51 | name51 |   500 | NULL |
+---------------------+-----------------------+--------------------+------------------------+-----------------------------------------------------------------------------+------+--------+-------+------+
3 rows in set (0.61 sec)
```

#### query the hudi table with some column information specified
```sql
mysql> select * from t_hudi_mor_with_part_schema;
+------+---------+-------+------+
| id   | name    | price | ts   |
+------+---------+-------+------+
|    1 | a1      |    20 | 1000 |
|    2 | b1      |    20 | 1000 |
|    3 | b1      |    20 | 1000 |
|    4 | b1      |    20 | 1000 |
|    5 | b1      |    20 | 1000 |
|    7 | insert1 |    20 | 1000 |
|    6 | insert2 |    20 | 1000 |
+------+---------+-------+------+
7 rows in set (0.42 sec)
```
#### query two columns from hudi table 

```
mysql> select id, name  from t_hudi_cow_partition;
+------+--------+
| id   | name   |
+------+--------+
|    2 | name2  |
|    3 | name3  |
|   31 | name31 |
|   51 | name51 |
|    1 | a1     |
|   41 | name41 |
+------+--------+
6 rows in set (0.85 sec)
```



## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)No
5. Has unit tests been added: (Yes/No/No Need)Yes
6. Has document been added or modified: (Yes/No/No Need)No Need
7. Does it need to update dependencies: (Yes/No)Yes
8. Are there any changes that cannot be rolled back: (Yes/No)No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
