### PR TITLE
[fix](help) fix bug of help command

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/MarkDownParser.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/MarkDownParser.java
@@ -166,7 +166,9 @@ public class MarkDownParser {
         }
         // Note that multiple line breaks at content's end will be merged to be one,
         // and other whitespace characters will be deleted.
-        return Maps.immutableEntry(key.substring(headLevel).trim(),
+        // Also, the header in md file is like "## STREAM-LOAD", we need to convert it to "STREAM LOAD",
+        // so that we can execute "help stream load" to show the help doc.
+        return Maps.immutableEntry(key.substring(headLevel).trim().replaceAll("-", " "),
                 sb.toString().replaceAll("\\s+$", "\n"));
     }
 }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

This bug is introduced from #9306, that user need to execute
"help stream-load" to show the help doc.
But actually, it should be "help stream load".

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
