### PR TITLE
handle ComlumnDictionary in evaluate_and and evaluate_or

### DIFF
--- a/be/src/olap/comparison_predicate.cpp
+++ b/be/src/olap/comparison_predicate.cpp
@@ -261,9 +261,10 @@ COMPARISON_PRED_COLUMN_EVALUATE_VEC(LessEqualPredicate, <=)
 COMPARISON_PRED_COLUMN_EVALUATE_VEC(GreaterPredicate, >)
 COMPARISON_PRED_COLUMN_EVALUATE_VEC(GreaterEqualPredicate, >=)
 
-#define COMPARISON_PRED_COLUMN_BLOCK_EVALUATE_OR(CLASS, OP)                                    \
+#define COMPARISON_PRED_COLUMN_BLOCK_EVALUATE_BOOL(CLASS, OP, BOOL_NAME, BOOL_OP)              \
     template <class T>                                                                         \
-    void CLASS<T>::evaluate_or(ColumnBlock* block, uint16_t* sel, uint16_t size, bool* flags)  \
+    void CLASS<T>::evaluate_##BOOL_NAME(ColumnBlock* block, uint16_t* sel, uint16_t size,      \
+                                        bool* flags)                                           \
             const {                                                                            \
         if (block->is_nullable()) {                                                            \
             for (uint16_t i = 0; i < size; ++i) {                                              \
@@ -271,7 +272,7 @@ COMPARISON_PRED_COLUMN_EVALUATE_VEC(GreaterEqualPredicate, >=)
                 uint16_t idx = sel[i];                                                         \
                 const T* cell_value = reinterpret_cast<const T*>(block->cell(idx).cell_ptr()); \
                 auto result = (!block->cell(idx).is_null() && (*cell_value OP _value));        \
-                flags[i] |= _opposite ? !result : result;                                      \
+                flags[i] = flags[i] BOOL_OP (_opposite ? !result : result);                    \
             }                                                                                  \
         } else {                                                                               \
             for (uint16_t i = 0; i < size; ++i) {                                              \
@@ -279,22 +280,26 @@ COMPARISON_PRED_COLUMN_EVALUATE_VEC(GreaterEqualPredicate, >=)
                 uint16_t idx = sel[i];                                                         \
                 const T* cell_value = reinterpret_cast<const T*>(block->cell(idx).cell_ptr()); \
                 auto result = (*cell_value OP _value);                                         \
-                flags[i] |= _opposite ? !result : result;                                      \
+                flags[i] = flags[i] BOOL_OP (_opposite ? !result : result);                    \
             }                                                                                  \
         }                                                                                      \
     }
 
-COMPARISON_PRED_COLUMN_BLOCK_EVALUATE_OR(EqualPredicate, ==)
-COMPARISON_PRED_COLUMN_BLOCK_EVALUATE_OR(NotEqualPredicate, !=)
-COMPARISON_PRED_COLUMN_BLOCK_EVALUATE_OR(LessPredicate, <)
-COMPARISON_PRED_COLUMN_BLOCK_EVALUATE_OR(LessEqualPredicate, <=)
-COMPARISON_PRED_COLUMN_BLOCK_EVALUATE_OR(GreaterPredicate, >)
-COMPARISON_PRED_COLUMN_BLOCK_EVALUATE_OR(GreaterEqualPredicate, >=)
+#define COMPARISON_PRED_COLUMN_BLOCK_EVALUATE_BOOL2(BOOL_NAME, BOOL_OP)                        \
+    COMPARISON_PRED_COLUMN_BLOCK_EVALUATE_BOOL(EqualPredicate, ==, BOOL_NAME, BOOL_OP)         \
+    COMPARISON_PRED_COLUMN_BLOCK_EVALUATE_BOOL(NotEqualPredicate, !=, BOOL_NAME, BOOL_OP)      \
+    COMPARISON_PRED_COLUMN_BLOCK_EVALUATE_BOOL(LessPredicate, <, BOOL_NAME, BOOL_OP)           \
+    COMPARISON_PRED_COLUMN_BLOCK_EVALUATE_BOOL(LessEqualPredicate, <=, BOOL_NAME, BOOL_OP)     \
+    COMPARISON_PRED_COLUMN_BLOCK_EVALUATE_BOOL(GreaterPredicate, >, BOOL_NAME, BOOL_OP)        \
+    COMPARISON_PRED_COLUMN_BLOCK_EVALUATE_BOOL(GreaterEqualPredicate, >=, BOOL_NAME, BOOL_OP)
+ 
+COMPARISON_PRED_COLUMN_BLOCK_EVALUATE_BOOL2(or, |)
+COMPARISON_PRED_COLUMN_BLOCK_EVALUATE_BOOL2(and, &)
 
-#define COMPARISON_PRED_COLUMN_EVALUATE_OR(CLASS, OP, IS_RANGE)                             \
+#define COMPARISON_PRED_COLUMN_EVALUATE_BOOL(CLASS, OP, IS_RANGE, BOOL_NAME, BOOL_OP)       \
     template <class T>                                                                      \
-    void CLASS<T>::evaluate_or(vectorized::IColumn& column, uint16_t* sel, uint16_t size,   \
-                               bool* flags) const {                                         \
+    void CLASS<T>::evaluate_##BOOL_NAME(vectorized::IColumn& column, uint16_t* sel,         \
+                                uint16_t size, bool* flags) const {                         \
         if (column.is_nullable()) {                                                         \
             auto* nullable_column =                                                         \
                     vectorized::check_and_get_column<vectorized::ColumnNullable>(column);   \
@@ -314,7 +319,7 @@ COMPARISON_PRED_COLUMN_BLOCK_EVALUATE_OR(GreaterEqualPredicate, >=)
                         if (flags[i]) continue;                                             \
                         uint16_t idx = sel[i];                                              \
                         bool ret = !null_bitmap[idx] && (data_array[idx] OP dict_code);     \
-                        flags[i] |= _opposite ? !ret : ret;                                 \
+                        flags[i] = flags[i] BOOL_OP (_opposite ? !ret : ret);               \
                     }                                                                       \
                 }                                                                           \
             } else {                                                                        \
@@ -325,7 +330,7 @@ COMPARISON_PRED_COLUMN_BLOCK_EVALUATE_OR(GreaterEqualPredicate, >=)
                     if (flags[i]) continue;                                                 \
                     uint16_t idx = sel[i];                                                  \
                     bool ret = !null_bitmap[idx] && (data_array[idx] OP _value);            \
-                    flags[i] |= _opposite ? !ret : ret;                                     \
+                    flags[i] = flags[i] BOOL_OP (_opposite ? !ret : ret);                   \
                 }                                                                           \
             }                                                                               \
         } else if (column.is_column_dictionary()) {                                         \
@@ -340,7 +345,7 @@ COMPARISON_PRED_COLUMN_BLOCK_EVALUATE_OR(GreaterEqualPredicate, >=)
                     if (flags[i]) continue;                                                 \
                     uint16_t idx = sel[i];                                                  \
                     bool ret = data_array[idx] OP dict_code;                                \
-                    flags[i] |= _opposite ? !ret : ret;                                     \
+                    flags[i] = flags[i] BOOL_OP (_opposite ? !ret : ret);                   \
                 }                                                                           \
             }                                                                               \
         } else {                                                                            \
@@ -351,86 +356,21 @@ COMPARISON_PRED_COLUMN_BLOCK_EVALUATE_OR(GreaterEqualPredicate, >=)
                 if (flags[i]) continue;                                                     \
                 uint16_t idx = sel[i];                                                      \
                 bool ret = data_array[idx] OP _value;                                       \
-                flags[i] |= _opposite ? !ret : ret;                                         \
+                flags[i] = flags[i] BOOL_OP (_opposite ? !ret : ret);                       \
             }                                                                               \
         }                                                                                   \
     }
 
-COMPARISON_PRED_COLUMN_EVALUATE_OR(EqualPredicate, ==, false)
-COMPARISON_PRED_COLUMN_EVALUATE_OR(NotEqualPredicate, !=, false)
-COMPARISON_PRED_COLUMN_EVALUATE_OR(LessPredicate, <, true)
-COMPARISON_PRED_COLUMN_EVALUATE_OR(LessEqualPredicate, <=, true)
-COMPARISON_PRED_COLUMN_EVALUATE_OR(GreaterPredicate, >, true)
-COMPARISON_PRED_COLUMN_EVALUATE_OR(GreaterEqualPredicate, >=, true)
+#define COMPARISON_PRED_COLUMN_EVALUATE_BOOL2(BOOL_NAME, BOOL_OP)                           \
+    COMPARISON_PRED_COLUMN_EVALUATE_BOOL(EqualPredicate, ==, false, BOOL_NAME, BOOL_OP)     \
+    COMPARISON_PRED_COLUMN_EVALUATE_BOOL(NotEqualPredicate, !=, false, BOOL_NAME, BOOL_OP)  \
+    COMPARISON_PRED_COLUMN_EVALUATE_BOOL(LessPredicate, <, true, BOOL_NAME, BOOL_OP)        \
+    COMPARISON_PRED_COLUMN_EVALUATE_BOOL(LessEqualPredicate, <=, true, BOOL_NAME, BOOL_OP)  \
+    COMPARISON_PRED_COLUMN_EVALUATE_BOOL(GreaterPredicate, >, true, BOOL_NAME, BOOL_OP)     \
+    COMPARISON_PRED_COLUMN_EVALUATE_BOOL(GreaterEqualPredicate, >=, true, BOOL_NAME, BOOL_OP)
 
-#define COMPARISON_PRED_COLUMN_BLOCK_EVALUATE_AND(CLASS, OP)                                   \
-    template <class T>                                                                         \
-    void CLASS<T>::evaluate_and(ColumnBlock* block, uint16_t* sel, uint16_t size, bool* flags) \
-            const {                                                                            \
-        if (block->is_nullable()) {                                                            \
-            for (uint16_t i = 0; i < size; ++i) {                                              \
-                if (!flags[i]) continue;                                                       \
-                uint16_t idx = sel[i];                                                         \
-                const T* cell_value = reinterpret_cast<const T*>(block->cell(idx).cell_ptr()); \
-                auto result = (!block->cell(idx).is_null() && (*cell_value OP _value));        \
-                flags[i] &= _opposite ? !result : result;                                      \
-            }                                                                                  \
-        } else {                                                                               \
-            for (uint16_t i = 0; i < size; ++i) {                                              \
-                if (!flags[i]) continue;                                                       \
-                uint16_t idx = sel[i];                                                         \
-                const T* cell_value = reinterpret_cast<const T*>(block->cell(idx).cell_ptr()); \
-                auto result = (*cell_value OP _value);                                         \
-                flags[i] &= _opposite ? !result : result;                                      \
-            }                                                                                  \
-        }                                                                                      \
-    }
-
-COMPARISON_PRED_COLUMN_BLOCK_EVALUATE_AND(EqualPredicate, ==)
-COMPARISON_PRED_COLUMN_BLOCK_EVALUATE_AND(NotEqualPredicate, !=)
-COMPARISON_PRED_COLUMN_BLOCK_EVALUATE_AND(LessPredicate, <)
-COMPARISON_PRED_COLUMN_BLOCK_EVALUATE_AND(LessEqualPredicate, <=)
-COMPARISON_PRED_COLUMN_BLOCK_EVALUATE_AND(GreaterPredicate, >)
-COMPARISON_PRED_COLUMN_BLOCK_EVALUATE_AND(GreaterEqualPredicate, >=)
-
-#define COMPARISON_PRED_COLUMN_EVALUATE_AND(CLASS, OP)                                      \
-    template <class T>                                                                      \
-    void CLASS<T>::evaluate_and(vectorized::IColumn& column, uint16_t* sel, uint16_t size,  \
-                                bool* flags) const {                                        \
-        if (column.is_nullable()) {                                                         \
-            auto* nullable_column =                                                         \
-                    vectorized::check_and_get_column<vectorized::ColumnNullable>(column);   \
-            auto& data_array = reinterpret_cast<const vectorized::PredicateColumnType<T>&>( \
-                                       nullable_column->get_nested_column())                \
-                                       .get_data();                                         \
-            auto& null_bitmap = reinterpret_cast<const vectorized::ColumnVector<uint8_t>&>( \
-                                        *(nullable_column->get_null_map_column_ptr()))      \
-                                        .get_data();                                        \
-            for (uint16_t i = 0; i < size; i++) {                                           \
-                if (!flags[i]) continue;                                                    \
-                uint16_t idx = sel[i];                                                      \
-                bool ret = !null_bitmap[idx] && (data_array[idx] OP _value);                \
-                flags[i] &= _opposite ? !ret : ret;                                         \
-            }                                                                               \
-        } else {                                                                            \
-            auto& predicate_column =                                                        \
-                    reinterpret_cast<vectorized::PredicateColumnType<T>&>(column);          \
-            auto& data_array = predicate_column.get_data();                                 \
-            for (uint16_t i = 0; i < size; ++i) {                                           \
-                if (!flags[i]) continue;                                                    \
-                uint16_t idx = sel[i];                                                      \
-                bool ret = data_array[idx] OP _value;                                       \
-                flags[i] &= _opposite ? !ret : ret;                                         \
-            }                                                                               \
-        }                                                                                   \
-    }
-
-COMPARISON_PRED_COLUMN_EVALUATE_AND(EqualPredicate, ==)
-COMPARISON_PRED_COLUMN_EVALUATE_AND(NotEqualPredicate, !=)
-COMPARISON_PRED_COLUMN_EVALUATE_AND(LessPredicate, <)
-COMPARISON_PRED_COLUMN_EVALUATE_AND(LessEqualPredicate, <=)
-COMPARISON_PRED_COLUMN_EVALUATE_AND(GreaterPredicate, >)
-COMPARISON_PRED_COLUMN_EVALUATE_AND(GreaterEqualPredicate, >=)
+COMPARISON_PRED_COLUMN_EVALUATE_BOOL2(or, |)
+COMPARISON_PRED_COLUMN_EVALUATE_BOOL2(and, &)
 
 #define BITMAP_COMPARE_EqualPredicate(s, exact_match, seeked_ordinal, iterator, bitmap, roaring) \
     do {                                                                                         \

--- a/be/src/olap/comparison_predicate.cpp
+++ b/be/src/olap/comparison_predicate.cpp
@@ -284,13 +284,16 @@ COMPARISON_PRED_COLUMN_EVALUATE_VEC(GreaterEqualPredicate, >=)
         }                                                                                      \
     }
 
-#define COMPARISON_PRED_COLUMN_BLOCK_EVALUATE_BOOL2(BOOL_NAME, BOOL_OP, SHORT_OP)                       \
-    COMPARISON_PRED_COLUMN_BLOCK_EVALUATE_BOOL(EqualPredicate, ==, BOOL_NAME, BOOL_OP, SHORT_OP)        \
-    COMPARISON_PRED_COLUMN_BLOCK_EVALUATE_BOOL(NotEqualPredicate, !=, BOOL_NAME, BOOL_OP, SHORT_OP)     \
-    COMPARISON_PRED_COLUMN_BLOCK_EVALUATE_BOOL(LessPredicate, <, BOOL_NAME, BOOL_OP, SHORT_OP)          \
-    COMPARISON_PRED_COLUMN_BLOCK_EVALUATE_BOOL(LessEqualPredicate, <=, BOOL_NAME, BOOL_OP, SHORT_OP)    \
-    COMPARISON_PRED_COLUMN_BLOCK_EVALUATE_BOOL(GreaterPredicate, >, BOOL_NAME, BOOL_OP, SHORT_OP)       \
-    COMPARISON_PRED_COLUMN_BLOCK_EVALUATE_BOOL(GreaterEqualPredicate, >=, BOOL_NAME, BOOL_OP, SHORT_OP) \
+#define COMPARISON_PRED_COLUMN_BLOCK_EVALUATE_BOOL2(BOOL_NAME, BOOL_OP, SHORT_OP)                 \
+    COMPARISON_PRED_COLUMN_BLOCK_EVALUATE_BOOL(EqualPredicate, ==, BOOL_NAME, BOOL_OP, SHORT_OP)  \
+    COMPARISON_PRED_COLUMN_BLOCK_EVALUATE_BOOL(NotEqualPredicate, !=, BOOL_NAME, BOOL_OP,         \
+                                               SHORT_OP)                                          \
+    COMPARISON_PRED_COLUMN_BLOCK_EVALUATE_BOOL(LessPredicate, <, BOOL_NAME, BOOL_OP, SHORT_OP)    \
+    COMPARISON_PRED_COLUMN_BLOCK_EVALUATE_BOOL(LessEqualPredicate, <=, BOOL_NAME, BOOL_OP,        \
+                                               SHORT_OP)                                          \
+    COMPARISON_PRED_COLUMN_BLOCK_EVALUATE_BOOL(GreaterPredicate, >, BOOL_NAME, BOOL_OP, SHORT_OP) \
+    COMPARISON_PRED_COLUMN_BLOCK_EVALUATE_BOOL(GreaterEqualPredicate, >=, BOOL_NAME, BOOL_OP,     \
+                                               SHORT_OP)
 
 COMPARISON_PRED_COLUMN_BLOCK_EVALUATE_BOOL2(or, |, )
 COMPARISON_PRED_COLUMN_BLOCK_EVALUATE_BOOL2(and, &, !)
@@ -360,13 +363,16 @@ COMPARISON_PRED_COLUMN_BLOCK_EVALUATE_BOOL2(and, &, !)
         }                                                                                          \
     }
 
-#define COMPARISON_PRED_COLUMN_EVALUATE_BOOL2(BOOL_NAME, BOOL_OP, SHORT_OP)                \
-    COMPARISON_PRED_COLUMN_EVALUATE_BOOL(EqualPredicate, ==, false, BOOL_NAME, BOOL_OP, SHORT_OP)    \
-    COMPARISON_PRED_COLUMN_EVALUATE_BOOL(NotEqualPredicate, !=, false, BOOL_NAME, BOOL_OP, SHORT_OP) \
-    COMPARISON_PRED_COLUMN_EVALUATE_BOOL(LessPredicate, <, true, BOOL_NAME, BOOL_OP, SHORT_OP)       \
-    COMPARISON_PRED_COLUMN_EVALUATE_BOOL(LessEqualPredicate, <=, true, BOOL_NAME, BOOL_OP, SHORT_OP) \
-    COMPARISON_PRED_COLUMN_EVALUATE_BOOL(GreaterPredicate, >, true, BOOL_NAME, BOOL_OP, SHORT_OP)    \
-    COMPARISON_PRED_COLUMN_EVALUATE_BOOL(GreaterEqualPredicate, >=, true, BOOL_NAME, BOOL_OP, SHORT_OP)
+#define COMPARISON_PRED_COLUMN_EVALUATE_BOOL2(BOOL_NAME, BOOL_OP, SHORT_OP)                       \
+    COMPARISON_PRED_COLUMN_EVALUATE_BOOL(EqualPredicate, ==, false, BOOL_NAME, BOOL_OP, SHORT_OP) \
+    COMPARISON_PRED_COLUMN_EVALUATE_BOOL(NotEqualPredicate, !=, false, BOOL_NAME, BOOL_OP,        \
+                                         SHORT_OP)                                                \
+    COMPARISON_PRED_COLUMN_EVALUATE_BOOL(LessPredicate, <, true, BOOL_NAME, BOOL_OP, SHORT_OP)    \
+    COMPARISON_PRED_COLUMN_EVALUATE_BOOL(LessEqualPredicate, <=, true, BOOL_NAME, BOOL_OP,        \
+                                         SHORT_OP)                                                \
+    COMPARISON_PRED_COLUMN_EVALUATE_BOOL(GreaterPredicate, >, true, BOOL_NAME, BOOL_OP, SHORT_OP) \
+    COMPARISON_PRED_COLUMN_EVALUATE_BOOL(GreaterEqualPredicate, >=, true, BOOL_NAME, BOOL_OP,     \
+                                         SHORT_OP)
 
 COMPARISON_PRED_COLUMN_EVALUATE_BOOL2(or, |, )
 COMPARISON_PRED_COLUMN_EVALUATE_BOOL2(and, &, !)


### PR DESCRIPTION
# Proposed changes

Issue Number: close #9823

## Problem Summary:

Be core dump when handle delete predicates on key.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
