### PR TITLE
[fix] Fix the bug of can't query the data of new added partition when set partition_prune_algorithm_version = 2

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/LiteralExpr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/LiteralExpr.java
@@ -76,6 +76,7 @@ public abstract class LiteralExpr extends Expr implements Comparable<LiteralExpr
             case HLL:
             case STRING:
                 literalExpr = new StringLiteral(value);
+                literalExpr.setType(type);
                 break;
             case DATE:
             case DATETIME:

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/ListPartitionPrunerV2.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/ListPartitionPrunerV2.java
@@ -132,14 +132,7 @@ public class ListPartitionPrunerV2 extends PartitionPrunerV2Base {
 
                 // Convert the grouped map to a RangeMap.
                 TreeRangeMap<ColumnBound, List<UniqueId>> candidateRangeMap = TreeRangeMap.create();
-                grouped.forEach((k, v) -> {
-                    List<UniqueId> uniqueIdList = candidateRangeMap.get(k.lowerEndpoint());
-                    if (uniqueIdList != null) {
-                        uniqueIdList.addAll(v);
-                        return;
-                    }
-                    candidateRangeMap.put(k, v);
-                });
+                grouped.forEach(candidateRangeMap::put);
 
                 return finalFilters.filters.stream()
                     .map(filter -> {

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/ListPartitionPrunerV2.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/ListPartitionPrunerV2.java
@@ -38,6 +38,10 @@ import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+/**
+ * ListPartitionPrunerV2
+ * @since 1.0
+ */
 @SuppressWarnings("UnstableApiUsage")
 public class ListPartitionPrunerV2 extends PartitionPrunerV2Base {
     private final Map<UniqueId, Range<PartitionKey>> uidToPartitionRange;


### PR DESCRIPTION
# Proposed changes

Issue Number: #9841

## Problem Summary:

Just change the logic of pruner v2 to prevent same key but different String types (e.g. TEXT and VARCHAR) overwrite each other in the map.

## Checklist(Required)

1. Does it affect the original behavior: (Yes)
2. Has unit tests been added: (No)
3. Has document been added or modified: (No Need)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (No)


