### PR TITLE
[feature-wip](array-type) Add array type support for vectorized parquet-orc scanner

### DIFF
--- a/be/src/exec/arrow/orc_reader.h
+++ b/be/src/exec/arrow/orc_reader.h
@@ -29,7 +29,7 @@
 #include "exec/arrow/arrow_reader.h"
 namespace doris {
 
-// Reader of orc file
+// Reader of ORC file
 class ORCReaderWrap final : public ArrowReaderWrap {
 public:
     ORCReaderWrap(FileReader* file_reader, int64_t batch_size, int32_t num_of_columns_from_file);

--- a/be/src/exec/base_scanner.cpp
+++ b/be/src/exec/base_scanner.cpp
@@ -329,6 +329,7 @@ Status BaseScanner::_materialize_dest_block(vectorized::Block* dest_block) {
         // PT1 => dest primitive type
         RETURN_IF_ERROR(ctx->execute(&_src_block, &result_column_id));
         auto column_ptr = _src_block.get_by_position(result_column_id).column;
+        DCHECK(column_ptr != nullptr);
 
         // because of src_slot_desc is always be nullable, so the column_ptr after do dest_expr
         // is likely to be nullable

--- a/be/src/vec/data_types/data_type.cpp
+++ b/be/src/vec/data_types/data_type.cpp
@@ -82,6 +82,10 @@ std::string IDataType::to_string(const IColumn& column, size_t row_num) const {
     LOG(FATAL) << fmt::format("Data type {} to_string not implement.", get_name());
     return "";
 }
+Status IDataType::from_string(ReadBuffer& rb, IColumn* column) const {
+    LOG(FATAL) << fmt::format("Data type {} from_string not implement.", get_name());
+    return Status::OK();
+} 
 
 void IDataType::insert_default_into(IColumn& column) const {
     column.insert_default();

--- a/be/src/vec/data_types/data_type.cpp
+++ b/be/src/vec/data_types/data_type.cpp
@@ -85,7 +85,7 @@ std::string IDataType::to_string(const IColumn& column, size_t row_num) const {
 Status IDataType::from_string(ReadBuffer& rb, IColumn* column) const {
     LOG(FATAL) << fmt::format("Data type {} from_string not implement.", get_name());
     return Status::OK();
-} 
+}
 
 void IDataType::insert_default_into(IColumn& column) const {
     column.insert_default();

--- a/be/src/vec/data_types/data_type.h
+++ b/be/src/vec/data_types/data_type.h
@@ -71,7 +71,7 @@ public:
 
     virtual void to_string(const IColumn& column, size_t row_num, BufferWritable& ostr) const;
     virtual std::string to_string(const IColumn& column, size_t row_num) const;
-    virtual Status from_string(ReadBuffer& rb, IColumn* column) const; 
+    virtual Status from_string(ReadBuffer& rb, IColumn* column) const;
 
 protected:
     virtual String do_get_name() const;

--- a/be/src/vec/data_types/data_type.h
+++ b/be/src/vec/data_types/data_type.h
@@ -28,6 +28,7 @@
 #include "vec/common/cow.h"
 #include "vec/common/string_buffer.hpp"
 #include "vec/core/types.h"
+#include "vec/io/reader_buffer.h"
 
 namespace doris {
 class PBlock;
@@ -70,6 +71,7 @@ public:
 
     virtual void to_string(const IColumn& column, size_t row_num, BufferWritable& ostr) const;
     virtual std::string to_string(const IColumn& column, size_t row_num) const;
+    virtual Status from_string(ReadBuffer& rb, IColumn* column) const; 
 
 protected:
     virtual String do_get_name() const;

--- a/be/src/vec/data_types/data_type_array.cpp
+++ b/be/src/vec/data_types/data_type_array.cpp
@@ -96,7 +96,8 @@ void DataTypeArray::to_pb_column_meta(PColumnMeta* col_meta) const {
 }
 
 void DataTypeArray::to_string(const IColumn& column, size_t row_num, BufferWritable& ostr) const {
-    auto& data_column = assert_cast<const ColumnArray&>(*column.convert_to_full_column_if_const().get());
+    auto& data_column =
+            assert_cast<const ColumnArray&>(*column.convert_to_full_column_if_const().get());
     auto& offsets = data_column.get_offsets();
     // Since parquet is imported in batches, the offsets corresponding to each batch are continuous,
     // but the data in each batch(IColumn) are independent.
@@ -130,8 +131,9 @@ void DataTypeArray::to_string(const IColumn& column, size_t row_num, BufferWrita
     ostr.write("]", 1);
 }
 
-std::string DataTypeArray::to_string(const IColumn& column, size_t row_num) const  {
-    auto& data_column = assert_cast<const ColumnArray&>(*column.convert_to_full_column_if_const().get());
+std::string DataTypeArray::to_string(const IColumn& column, size_t row_num) const {
+    auto& data_column =
+            assert_cast<const ColumnArray&>(*column.convert_to_full_column_if_const().get());
     auto& offsets = data_column.get_offsets();
 
     // calc relative start offset
@@ -145,7 +147,7 @@ std::string DataTypeArray::to_string(const IColumn& column, size_t row_num) cons
         // if is the first row, use start_offset insteed
         offset = start_offset;
     }
-    const IColumn & nested_column = data_column.get_data();
+    const IColumn& nested_column = data_column.get_data();
     std::stringstream ss;
     ss << "[";
     for (size_t i = offset; i < next_offset; ++i) {
@@ -165,7 +167,8 @@ Status DataTypeArray::from_string(ReadBuffer& rb, IColumn* column) const {
 
     IColumn& nested_column = array_column->get_data();
     if (*rb.position() != '[') {
-        return Status::InvalidArgument("Array does not start with '[' character, found '{}'", *rb.position());
+        return Status::InvalidArgument("Array does not start with '[' character, found '{}'",
+                                       *rb.position());
     }
     ++rb.position();
     bool first = true;
@@ -175,8 +178,9 @@ Status DataTypeArray::from_string(ReadBuffer& rb, IColumn* column) const {
             if (*rb.position() == ',') {
                 ++rb.position();
             } else {
-                return Status::InvalidArgument(fmt::format("Cannot read array from text, expected comma or end of array, found '{}'",
-                    *rb.position()));
+                return Status::InvalidArgument(fmt::format(
+                        "Cannot read array from text, expected comma or end of array, found '{}'",
+                        *rb.position()));
             }
         }
         first = false;

--- a/be/src/vec/data_types/data_type_array.cpp
+++ b/be/src/vec/data_types/data_type_array.cpp
@@ -21,6 +21,7 @@
 #include "vec/data_types/data_type_array.h"
 
 #include "gen_cpp/data.pb.h"
+#include "vec/common/string_utils/string_utils.h"
 #include "vec/io/io_helper.h"
 
 namespace doris::vectorized {
@@ -92,6 +93,113 @@ void DataTypeArray::to_pb_column_meta(PColumnMeta* col_meta) const {
     IDataType::to_pb_column_meta(col_meta);
     auto children = col_meta->add_children();
     get_nested_type()->to_pb_column_meta(children);
+}
+
+void DataTypeArray::to_string(const IColumn& column, size_t row_num, BufferWritable& ostr) const {
+    auto& data_column = assert_cast<const ColumnArray&>(*column.convert_to_full_column_if_const().get());
+    auto& offsets = data_column.get_offsets();
+
+    // calc relative start offset
+    size_t data_size = data_column.get_data().size();
+    size_t last_offset = offsets.back();
+    size_t start_offset = last_offset - data_size;
+
+    size_t offset = offsets[row_num - 1];
+    size_t next_offset = offsets[row_num];
+    if (row_num == 0) {
+        // if is the first row, use start_offset insteed
+        offset = start_offset;
+    }
+
+    const IColumn& nested_column = data_column.get_data();
+    ostr.write("[", 1);
+    for (size_t i = offset; i < next_offset; ++i) {
+        if (i != offset) {
+            ostr.write(",", 1);
+        }
+        //LOG(INFO) << "DataTypeArray::to_string i:" << i << " offsets.front():" << offsets.front();
+        //nested->to_string(nested_column, i - offsets.front(), ostr);
+        // use relative offset
+        nested->to_string(nested_column, i - start_offset, ostr);
+    }
+    ostr.write("]", 1);
+}
+
+std::string DataTypeArray::to_string(const IColumn& column, size_t row_num) const  {
+    auto& data_column = assert_cast<const ColumnArray&>(*column.convert_to_full_column_if_const().get());
+    auto& offsets = data_column.get_offsets();
+
+    // calc relative start offset
+    size_t data_size = data_column.get_data().size();
+    size_t last_offset = offsets.back();
+    size_t start_offset = last_offset - data_size;
+
+    size_t offset = offsets[row_num - 1];
+    size_t next_offset = offsets[row_num];
+    if (row_num == 0) {
+        // if is the first row, use start_offset insteed
+        offset = start_offset;
+    }
+    const IColumn & nested_column = data_column.get_data();
+    std::stringstream ss;
+    ss << "[";
+    for (size_t i = offset; i < next_offset; ++i) {
+        if (i != offset) {
+            ss << ",";
+        }
+        //LOG(INFO) << "DataTypeArray::to_string i:" << i << " offsets.front():" << offsets.front();
+        ss << nested->to_string(nested_column, i - start_offset);
+    }
+    ss << "]";
+    return ss.str();
+}
+
+Status DataTypeArray::from_string(ReadBuffer& rb, IColumn* column) const {
+    // only support one level now
+    auto* data_column = assert_cast<ColumnArray*>(column);
+    auto& offsets = data_column->get_offsets();
+
+    IColumn& nested_column = data_column->get_data();
+    if (*rb.position() != '[') {
+        return Status::InvalidArgument("Array does not start with '[' character, found '{}'", *rb.position());
+    }
+    ++rb.position();
+    bool first = true;
+    size_t size = 0;
+    while (!rb.eof() && *rb.position() != ']') {
+        if (!first) {
+            if (*rb.position() == ',') {
+                ++rb.position();
+            } else {
+                return Status::InvalidArgument(fmt::format("Cannot read array from text, expected comma or end of array, found '{}'",
+                    *rb.position()));
+            }
+        }
+        first = false;
+        //skipWhitespaceIfAny(istr);
+        if (*rb.position() == ']') {
+            break;
+        }
+        size_t nested_str_len = 1;
+        char* temp_char = rb.position() + nested_str_len;
+        while (*(temp_char) != ']' && *(temp_char) != ',' && temp_char != rb.end()) {
+            ++nested_str_len;
+            temp_char = rb.position() + nested_str_len;
+        }
+
+        ReadBuffer read_buffer(rb.position(), nested_str_len);
+        // TODO may be we should do revert (nested->pop_back(size)) if error
+        RETURN_IF_ERROR(nested->from_string(read_buffer, &nested_column));
+        //LOG(INFO) << "rb:" << std::string(rb.position(), nested_str_len);
+        //LOG(INFO) << "nested_str_len:" << nested_str_len;
+        //LOG(INFO) << "before position:" << rb.position();
+        rb.position() += nested_str_len;
+        DCHECK_LE(rb.position(), rb.end());
+        //LOG(INFO) << "after position:" << rb.position();
+        ++size;
+    }
+    offsets.push_back(offsets.back() + size);
+    return Status::OK();
 }
 
 } // namespace doris::vectorized

--- a/be/src/vec/data_types/data_type_array.h
+++ b/be/src/vec/data_types/data_type_array.h
@@ -78,6 +78,10 @@ public:
     const char* deserialize(const char* buf, IColumn* column) const override;
 
     void to_pb_column_meta(PColumnMeta* col_meta) const override;
+
+    std::string to_string(const IColumn& column, size_t row_num) const override;
+    void to_string(const IColumn& column, size_t row_num, BufferWritable& ostr) const override;
+    Status from_string(ReadBuffer& rb, IColumn* column) const override; 
 };
 
 } // namespace doris::vectorized

--- a/be/src/vec/data_types/data_type_array.h
+++ b/be/src/vec/data_types/data_type_array.h
@@ -81,7 +81,7 @@ public:
 
     std::string to_string(const IColumn& column, size_t row_num) const override;
     void to_string(const IColumn& column, size_t row_num, BufferWritable& ostr) const override;
-    Status from_string(ReadBuffer& rb, IColumn* column) const override; 
+    Status from_string(ReadBuffer& rb, IColumn* column) const override;
 };
 
 } // namespace doris::vectorized

--- a/be/src/vec/data_types/data_type_date.cpp
+++ b/be/src/vec/data_types/data_type_date.cpp
@@ -23,8 +23,8 @@
 #include "runtime/datetime_value.h"
 #include "util/binary_cast.hpp"
 #include "vec/columns/columns_number.h"
-#include "vec/runtime/vdatetime_value.h"
 #include "vec/io/io_helper.h"
+#include "vec/runtime/vdatetime_value.h"
 namespace doris::vectorized {
 bool DataTypeDate::equals(const IDataType& rhs) const {
     return typeid(rhs) == typeid(*this);
@@ -60,11 +60,12 @@ void DataTypeDate::to_string(const IColumn& column, size_t row_num, BufferWritab
     ostr.write(buf, pos - buf - 1);
 }
 
-Status DataTypeDate::from_string(ReadBuffer& rb, IColumn* column) const { 
+Status DataTypeDate::from_string(ReadBuffer& rb, IColumn* column) const {
     auto* column_data = static_cast<ColumnInt64*>(column);
     Int64 val = 0;
     if (!read_date_text_impl<Int64>(val, rb)) {
-        return Status::InvalidArgument(fmt::format("parse date fail, string: '{}'", std::string(rb.position(), rb.count()).c_str()));
+        return Status::InvalidArgument(fmt::format("parse date fail, string: '{}'",
+                                                   std::string(rb.position(), rb.count()).c_str()));
     }
     column_data->insert_value(val);
     return Status::OK();

--- a/be/src/vec/data_types/data_type_date.h
+++ b/be/src/vec/data_types/data_type_date.h
@@ -36,7 +36,7 @@ public:
     bool equals(const IDataType& rhs) const override;
     std::string to_string(const IColumn& column, size_t row_num) const override;
     void to_string(const IColumn& column, size_t row_num, BufferWritable& ostr) const override;
-    Status from_string(ReadBuffer& rb, IColumn* column) const override; 
+    Status from_string(ReadBuffer& rb, IColumn* column) const override;
 
     static void cast_to_date(Int64& x);
 

--- a/be/src/vec/data_types/data_type_date.h
+++ b/be/src/vec/data_types/data_type_date.h
@@ -36,6 +36,7 @@ public:
     bool equals(const IDataType& rhs) const override;
     std::string to_string(const IColumn& column, size_t row_num) const override;
     void to_string(const IColumn& column, size_t row_num, BufferWritable& ostr) const override;
+    Status from_string(ReadBuffer& rb, IColumn* column) const override; 
 
     static void cast_to_date(Int64& x);
 

--- a/be/src/vec/data_types/data_type_date_time.cpp
+++ b/be/src/vec/data_types/data_type_date_time.cpp
@@ -24,6 +24,7 @@
 #include "util/binary_cast.hpp"
 #include "vec/columns/columns_number.h"
 #include "vec/runtime/vdatetime_value.h"
+#include "vec/io/io_helper.h"
 namespace doris::vectorized {
 
 DataTypeDateTime::DataTypeDateTime() {}
@@ -80,6 +81,16 @@ void DataTypeDateTime::to_string(const IColumn& column, size_t row_num,
     char* pos = value.to_string(buf);
     // DateTime to_string the end is /0
     ostr.write(buf, pos - buf - 1);
+}
+
+Status DataTypeDateTime::from_string(ReadBuffer& rb, IColumn* column) const { 
+    auto* column_data = static_cast<ColumnInt64*>(column);
+    Int64 val = 0;
+    if (!read_datetime_text_impl<Int64>(val, rb)) {
+        return Status::InvalidArgument(fmt::format("parse datetime fail, string: '{}'", std::string(rb.position(), rb.count()).c_str()));
+    }
+    column_data->insert_value(val);
+    return Status::OK();
 }
 
 void DataTypeDateTime::cast_to_date_time(Int64& x) {

--- a/be/src/vec/data_types/data_type_date_time.cpp
+++ b/be/src/vec/data_types/data_type_date_time.cpp
@@ -23,8 +23,8 @@
 #include "runtime/datetime_value.h"
 #include "util/binary_cast.hpp"
 #include "vec/columns/columns_number.h"
-#include "vec/runtime/vdatetime_value.h"
 #include "vec/io/io_helper.h"
+#include "vec/runtime/vdatetime_value.h"
 namespace doris::vectorized {
 
 DataTypeDateTime::DataTypeDateTime() {}
@@ -83,11 +83,12 @@ void DataTypeDateTime::to_string(const IColumn& column, size_t row_num,
     ostr.write(buf, pos - buf - 1);
 }
 
-Status DataTypeDateTime::from_string(ReadBuffer& rb, IColumn* column) const { 
+Status DataTypeDateTime::from_string(ReadBuffer& rb, IColumn* column) const {
     auto* column_data = static_cast<ColumnInt64*>(column);
     Int64 val = 0;
     if (!read_datetime_text_impl<Int64>(val, rb)) {
-        return Status::InvalidArgument(fmt::format("parse datetime fail, string: '{}'", std::string(rb.position(), rb.count()).c_str()));
+        return Status::InvalidArgument(fmt::format("parse datetime fail, string: '{}'",
+                                                   std::string(rb.position(), rb.count()).c_str()));
     }
     column_data->insert_value(val);
     return Status::OK();

--- a/be/src/vec/data_types/data_type_date_time.h
+++ b/be/src/vec/data_types/data_type_date_time.h
@@ -64,6 +64,8 @@ public:
 
     void to_string(const IColumn& column, size_t row_num, BufferWritable& ostr) const override;
 
+    Status from_string(ReadBuffer& rb, IColumn* column) const override; 
+
     static void cast_to_date_time(Int64& x);
 
     MutableColumnPtr create_column() const override;

--- a/be/src/vec/data_types/data_type_date_time.h
+++ b/be/src/vec/data_types/data_type_date_time.h
@@ -64,7 +64,7 @@ public:
 
     void to_string(const IColumn& column, size_t row_num, BufferWritable& ostr) const override;
 
-    Status from_string(ReadBuffer& rb, IColumn* column) const override; 
+    Status from_string(ReadBuffer& rb, IColumn* column) const override;
 
     static void cast_to_date_time(Int64& x);
 

--- a/be/src/vec/data_types/data_type_decimal.cpp
+++ b/be/src/vec/data_types/data_type_decimal.cpp
@@ -63,12 +63,12 @@ void DataTypeDecimal<T>::to_string(const IColumn& column, size_t row_num,
 }
 
 template <typename T>
-Status DataTypeDecimal<T>::from_string(ReadBuffer& rb, IColumn* column) const { 
-    auto& column_data =
-            static_cast<ColumnType&>(*column).get_data();
+Status DataTypeDecimal<T>::from_string(ReadBuffer& rb, IColumn* column) const {
+    auto& column_data = static_cast<ColumnType&>(*column).get_data();
     T val;
     if (!read_decimal_text_impl<T>(val, rb)) {
-        return Status::InvalidArgument(fmt::format("parse date fail, string: '{}'", std::string(rb.position(), rb.count()).c_str()));
+        return Status::InvalidArgument(fmt::format("parse date fail, string: '{}'",
+                                                   std::string(rb.position(), rb.count()).c_str()));
     }
     column_data.emplace_back(val);
     return Status::OK();

--- a/be/src/vec/data_types/data_type_decimal.cpp
+++ b/be/src/vec/data_types/data_type_decimal.cpp
@@ -65,7 +65,7 @@ void DataTypeDecimal<T>::to_string(const IColumn& column, size_t row_num,
 template <typename T>
 Status DataTypeDecimal<T>::from_string(ReadBuffer& rb, IColumn* column) const {
     auto& column_data = static_cast<ColumnType&>(*column).get_data();
-    T val;
+    T val = 0;
     if (!read_decimal_text_impl<T>(val, rb)) {
         return Status::InvalidArgument(fmt::format("parse date fail, string: '{}'",
                                                    std::string(rb.position(), rb.count()).c_str()));

--- a/be/src/vec/data_types/data_type_decimal.cpp
+++ b/be/src/vec/data_types/data_type_decimal.cpp
@@ -67,7 +67,7 @@ Status DataTypeDecimal<T>::from_string(ReadBuffer& rb, IColumn* column) const {
     auto& column_data = static_cast<ColumnType&>(*column).get_data();
     T val = 0;
     if (!read_decimal_text_impl<T>(val, rb)) {
-        return Status::InvalidArgument(fmt::format("parse date fail, string: '{}'",
+        return Status::InvalidArgument(fmt::format("parse decimal fail, string: '{}'",
                                                    std::string(rb.position(), rb.count()).c_str()));
     }
     column_data.emplace_back(val);

--- a/be/src/vec/data_types/data_type_decimal.cpp
+++ b/be/src/vec/data_types/data_type_decimal.cpp
@@ -62,6 +62,18 @@ void DataTypeDecimal<T>::to_string(const IColumn& column, size_t row_num,
     ostr.write(str.data(), str.size());
 }
 
+template <typename T>
+Status DataTypeDecimal<T>::from_string(ReadBuffer& rb, IColumn* column) const { 
+    auto& column_data =
+            static_cast<ColumnType&>(*column).get_data();
+    T val;
+    if (!read_decimal_text_impl<T>(val, rb)) {
+        return Status::InvalidArgument(fmt::format("parse date fail, string: '{}'", std::string(rb.position(), rb.count()).c_str()));
+    }
+    column_data.emplace_back(val);
+    return Status::OK();
+}
+
 // binary: row_num | value1 | value2 | ...
 template <typename T>
 int64_t DataTypeDecimal<T>::get_uncompressed_serialized_bytes(const IColumn& column) const {

--- a/be/src/vec/data_types/data_type_decimal.h
+++ b/be/src/vec/data_types/data_type_decimal.h
@@ -145,6 +145,7 @@ public:
     bool can_be_inside_nullable() const override { return true; }
     std::string to_string(const IColumn& column, size_t row_num) const override;
     void to_string(const IColumn& column, size_t row_num, BufferWritable& ostr) const override;
+    Status from_string(ReadBuffer& rb, IColumn* column) const override; 
 
     /// Decimal specific
 

--- a/be/src/vec/data_types/data_type_decimal.h
+++ b/be/src/vec/data_types/data_type_decimal.h
@@ -145,7 +145,7 @@ public:
     bool can_be_inside_nullable() const override { return true; }
     std::string to_string(const IColumn& column, size_t row_num) const override;
     void to_string(const IColumn& column, size_t row_num, BufferWritable& ostr) const override;
-    Status from_string(ReadBuffer& rb, IColumn* column) const override; 
+    Status from_string(ReadBuffer& rb, IColumn* column) const override;
 
     /// Decimal specific
 

--- a/be/src/vec/data_types/data_type_factory.cpp
+++ b/be/src/vec/data_types/data_type_factory.cpp
@@ -267,6 +267,7 @@ DataTypePtr DataTypeFactory::create_data_type(const arrow::DataType* type, bool 
         nested = std::make_shared<vectorized::DataTypeUInt8>();
         break;
     case ::arrow::Type::INT8:
+        LOG(INFO) << "INT8";
         nested = std::make_shared<vectorized::DataTypeInt8>();
         break;
     case ::arrow::Type::UINT8:
@@ -285,6 +286,7 @@ DataTypePtr DataTypeFactory::create_data_type(const arrow::DataType* type, bool 
         nested = std::make_shared<vectorized::DataTypeUInt32>();
         break;
     case ::arrow::Type::INT64:
+        LOG(INFO) << "INT64";
         nested = std::make_shared<vectorized::DataTypeInt64>();
         break;
     case ::arrow::Type::UINT64:
@@ -311,6 +313,12 @@ DataTypePtr DataTypeFactory::create_data_type(const arrow::DataType* type, bool 
         break;
     case ::arrow::Type::DECIMAL:
         nested = std::make_shared<vectorized::DataTypeDecimal<vectorized::Decimal128>>();
+        break;
+    case ::arrow::Type::LIST:
+        DCHECK(type->num_fields() == 1);
+        LOG(INFO) << "LIST";
+        nested =
+                std::make_shared<vectorized::DataTypeArray>(create_data_type(type->field(0)->type().get(), true));
         break;
     default:
         DCHECK(false) << "invalid arrow type:" << (int)(type->id());

--- a/be/src/vec/data_types/data_type_factory.cpp
+++ b/be/src/vec/data_types/data_type_factory.cpp
@@ -314,8 +314,8 @@ DataTypePtr DataTypeFactory::create_data_type(const arrow::DataType* type, bool 
         break;
     case ::arrow::Type::LIST:
         DCHECK(type->num_fields() == 1);
-        nested =
-                std::make_shared<vectorized::DataTypeArray>(create_data_type(type->field(0)->type().get(), true));
+        nested = std::make_shared<vectorized::DataTypeArray>(
+                create_data_type(type->field(0)->type().get(), true));
         break;
     default:
         DCHECK(false) << "invalid arrow type:" << (int)(type->id());

--- a/be/src/vec/data_types/data_type_factory.cpp
+++ b/be/src/vec/data_types/data_type_factory.cpp
@@ -267,7 +267,6 @@ DataTypePtr DataTypeFactory::create_data_type(const arrow::DataType* type, bool 
         nested = std::make_shared<vectorized::DataTypeUInt8>();
         break;
     case ::arrow::Type::INT8:
-        LOG(INFO) << "INT8";
         nested = std::make_shared<vectorized::DataTypeInt8>();
         break;
     case ::arrow::Type::UINT8:
@@ -286,7 +285,6 @@ DataTypePtr DataTypeFactory::create_data_type(const arrow::DataType* type, bool 
         nested = std::make_shared<vectorized::DataTypeUInt32>();
         break;
     case ::arrow::Type::INT64:
-        LOG(INFO) << "INT64";
         nested = std::make_shared<vectorized::DataTypeInt64>();
         break;
     case ::arrow::Type::UINT64:
@@ -316,7 +314,6 @@ DataTypePtr DataTypeFactory::create_data_type(const arrow::DataType* type, bool 
         break;
     case ::arrow::Type::LIST:
         DCHECK(type->num_fields() == 1);
-        LOG(INFO) << "LIST";
         nested =
                 std::make_shared<vectorized::DataTypeArray>(create_data_type(type->field(0)->type().get(), true));
         break;

--- a/be/src/vec/data_types/data_type_factory.hpp
+++ b/be/src/vec/data_types/data_type_factory.hpp
@@ -49,30 +49,64 @@ public:
         static std::once_flag oc;
         static DataTypeFactory instance;
         std::call_once(oc, []() {
-            instance.register_data_type("UInt8", std::make_shared<DataTypeUInt8>());
-            instance.register_data_type("UInt16", std::make_shared<DataTypeUInt16>());
-            instance.register_data_type("UInt32", std::make_shared<DataTypeUInt32>());
-            instance.register_data_type("UInt64", std::make_shared<DataTypeUInt64>());
-            instance.register_data_type("Int8", std::make_shared<DataTypeInt8>());
-            instance.register_data_type("Int16", std::make_shared<DataTypeInt16>());
-            instance.register_data_type("Int32", std::make_shared<DataTypeInt32>());
-            instance.register_data_type("Int64", std::make_shared<DataTypeInt64>());
-            instance.register_data_type("Int128", std::make_shared<DataTypeInt128>());
-            instance.register_data_type("Float32", std::make_shared<DataTypeFloat32>());
-            instance.register_data_type("Float64", std::make_shared<DataTypeFloat64>());
-            instance.register_data_type("Date", std::make_shared<DataTypeDate>());
-            instance.register_data_type("DateTime", std::make_shared<DataTypeDateTime>());
-            instance.register_data_type("String", std::make_shared<DataTypeString>());
-            instance.register_data_type("Decimal",
-                                        std::make_shared<DataTypeDecimal<Decimal128>>(27, 9));
+            std::unordered_map<std::string, DataTypePtr> base_type_map {
+            {"UInt8", std::make_shared<DataTypeUInt8>()},
+            {"UInt16", std::make_shared<DataTypeUInt16>()},
+            {"UInt32", std::make_shared<DataTypeUInt32>()},
+            {"UInt64", std::make_shared<DataTypeUInt64>()},
+            {"Int8", std::make_shared<DataTypeInt8>()},
+            {"Int16", std::make_shared<DataTypeInt16>()},
+            {"Int32", std::make_shared<DataTypeInt32>()},
+            {"Int64", std::make_shared<DataTypeInt64>()},
+            {"Int128", std::make_shared<DataTypeInt128>()},
+            {"Float32", std::make_shared<DataTypeFloat32>()},
+            {"Float64", std::make_shared<DataTypeFloat64>()},
+            {"Date", std::make_shared<DataTypeDate>()},
+            {"DateTime", std::make_shared<DataTypeDateTime>()},
+            {"String", std::make_shared<DataTypeString>()},
+            {"Decimal",
+             std::make_shared<DataTypeDecimal<Decimal128>>(27, 9)},
+
+            };
+            for (auto const& [key, val] : base_type_map) {
+                instance.register_data_type(key, val);
+                instance.register_data_type("Array("+key+")", std::make_shared<vectorized::DataTypeArray>(val));
+                instance.register_data_type("Array(Nullable("+key+"))", std::make_shared<vectorized::DataTypeArray>(std::make_shared<vectorized::DataTypeNullable>(val)));
+            }
+            //instance.register_data_type("UInt8", std::make_shared<DataTypeUInt8>());
+            //instance.register_data_type("UInt16", std::make_shared<DataTypeUInt16>());
+            //instance.register_data_type("UInt32", std::make_shared<DataTypeUInt32>());
+            //instance.register_data_type("UInt64", std::make_shared<DataTypeUInt64>());
+            //instance.register_data_type("Int8", std::make_shared<DataTypeInt8>());
+            //instance.register_data_type("Int16", std::make_shared<DataTypeInt16>());
+            //instance.register_data_type("Int32", std::make_shared<DataTypeInt32>());
+            //instance.register_data_type("Int64", std::make_shared<DataTypeInt64>());
+            //instance.register_data_type("Int128", std::make_shared<DataTypeInt128>());
+            //instance.register_data_type("Float32", std::make_shared<DataTypeFloat32>());
+            //instance.register_data_type("Float64", std::make_shared<DataTypeFloat64>());
+            //instance.register_data_type("Date", std::make_shared<DataTypeDate>());
+            //instance.register_data_type("DateTime", std::make_shared<DataTypeDateTime>());
+            //instance.register_data_type("String", std::make_shared<DataTypeString>());
+            //instance.register_data_type("Decimal",
+            //                            std::make_shared<DataTypeDecimal<Decimal128>>(27, 9));
         });
         return instance;
     }
-    DataTypePtr get(const std::string& name) { return _data_type_map[name]; }
+    DataTypePtr get(const std::string& name) {
+        LOG(INFO) << "get name:" << name;
+        return _data_type_map[name];
+    }
     const std::string& get(const DataTypePtr& data_type) const {
+        LOG(INFO) << "get string:" << data_type;
         auto type_ptr = data_type->is_nullable()
                                 ? ((DataTypeNullable*)(data_type.get()))->get_nested_type()
                                 : data_type;
+        //if (is_array(type_ptr)) {
+        //    auto type_name = get(((DataTypeArray*)(data_type.get()))->get_nested_type());
+        //    std::stringstream ss;
+        //    ss << "Array(" << type_name << ")";
+        //    return ss.str();
+        //}
         for (const auto& entity : _invert_data_type_map) {
             if (entity.first->equals(*type_ptr)) {
                 return entity.second;

--- a/be/src/vec/data_types/data_type_factory.hpp
+++ b/be/src/vec/data_types/data_type_factory.hpp
@@ -73,40 +73,16 @@ public:
                 instance.register_data_type("Array("+key+")", std::make_shared<vectorized::DataTypeArray>(val));
                 instance.register_data_type("Array(Nullable("+key+"))", std::make_shared<vectorized::DataTypeArray>(std::make_shared<vectorized::DataTypeNullable>(val)));
             }
-            //instance.register_data_type("UInt8", std::make_shared<DataTypeUInt8>());
-            //instance.register_data_type("UInt16", std::make_shared<DataTypeUInt16>());
-            //instance.register_data_type("UInt32", std::make_shared<DataTypeUInt32>());
-            //instance.register_data_type("UInt64", std::make_shared<DataTypeUInt64>());
-            //instance.register_data_type("Int8", std::make_shared<DataTypeInt8>());
-            //instance.register_data_type("Int16", std::make_shared<DataTypeInt16>());
-            //instance.register_data_type("Int32", std::make_shared<DataTypeInt32>());
-            //instance.register_data_type("Int64", std::make_shared<DataTypeInt64>());
-            //instance.register_data_type("Int128", std::make_shared<DataTypeInt128>());
-            //instance.register_data_type("Float32", std::make_shared<DataTypeFloat32>());
-            //instance.register_data_type("Float64", std::make_shared<DataTypeFloat64>());
-            //instance.register_data_type("Date", std::make_shared<DataTypeDate>());
-            //instance.register_data_type("DateTime", std::make_shared<DataTypeDateTime>());
-            //instance.register_data_type("String", std::make_shared<DataTypeString>());
-            //instance.register_data_type("Decimal",
-            //                            std::make_shared<DataTypeDecimal<Decimal128>>(27, 9));
         });
         return instance;
     }
     DataTypePtr get(const std::string& name) {
-        LOG(INFO) << "get name:" << name;
         return _data_type_map[name];
     }
     const std::string& get(const DataTypePtr& data_type) const {
-        LOG(INFO) << "get string:" << data_type;
         auto type_ptr = data_type->is_nullable()
                                 ? ((DataTypeNullable*)(data_type.get()))->get_nested_type()
                                 : data_type;
-        //if (is_array(type_ptr)) {
-        //    auto type_name = get(((DataTypeArray*)(data_type.get()))->get_nested_type());
-        //    std::stringstream ss;
-        //    ss << "Array(" << type_name << ")";
-        //    return ss.str();
-        //}
         for (const auto& entity : _invert_data_type_map) {
             if (entity.first->equals(*type_ptr)) {
                 return entity.second;

--- a/be/src/vec/data_types/data_type_factory.hpp
+++ b/be/src/vec/data_types/data_type_factory.hpp
@@ -50,35 +50,36 @@ public:
         static DataTypeFactory instance;
         std::call_once(oc, []() {
             std::unordered_map<std::string, DataTypePtr> base_type_map {
-            {"UInt8", std::make_shared<DataTypeUInt8>()},
-            {"UInt16", std::make_shared<DataTypeUInt16>()},
-            {"UInt32", std::make_shared<DataTypeUInt32>()},
-            {"UInt64", std::make_shared<DataTypeUInt64>()},
-            {"Int8", std::make_shared<DataTypeInt8>()},
-            {"Int16", std::make_shared<DataTypeInt16>()},
-            {"Int32", std::make_shared<DataTypeInt32>()},
-            {"Int64", std::make_shared<DataTypeInt64>()},
-            {"Int128", std::make_shared<DataTypeInt128>()},
-            {"Float32", std::make_shared<DataTypeFloat32>()},
-            {"Float64", std::make_shared<DataTypeFloat64>()},
-            {"Date", std::make_shared<DataTypeDate>()},
-            {"DateTime", std::make_shared<DataTypeDateTime>()},
-            {"String", std::make_shared<DataTypeString>()},
-            {"Decimal",
-             std::make_shared<DataTypeDecimal<Decimal128>>(27, 9)},
+                    {"UInt8", std::make_shared<DataTypeUInt8>()},
+                    {"UInt16", std::make_shared<DataTypeUInt16>()},
+                    {"UInt32", std::make_shared<DataTypeUInt32>()},
+                    {"UInt64", std::make_shared<DataTypeUInt64>()},
+                    {"Int8", std::make_shared<DataTypeInt8>()},
+                    {"Int16", std::make_shared<DataTypeInt16>()},
+                    {"Int32", std::make_shared<DataTypeInt32>()},
+                    {"Int64", std::make_shared<DataTypeInt64>()},
+                    {"Int128", std::make_shared<DataTypeInt128>()},
+                    {"Float32", std::make_shared<DataTypeFloat32>()},
+                    {"Float64", std::make_shared<DataTypeFloat64>()},
+                    {"Date", std::make_shared<DataTypeDate>()},
+                    {"DateTime", std::make_shared<DataTypeDateTime>()},
+                    {"String", std::make_shared<DataTypeString>()},
+                    {"Decimal", std::make_shared<DataTypeDecimal<Decimal128>>(27, 9)},
 
             };
             for (auto const& [key, val] : base_type_map) {
                 instance.register_data_type(key, val);
-                instance.register_data_type("Array("+key+")", std::make_shared<vectorized::DataTypeArray>(val));
-                instance.register_data_type("Array(Nullable("+key+"))", std::make_shared<vectorized::DataTypeArray>(std::make_shared<vectorized::DataTypeNullable>(val)));
+                instance.register_data_type("Array(" + key + ")",
+                                            std::make_shared<vectorized::DataTypeArray>(val));
+                instance.register_data_type(
+                        "Array(Nullable(" + key + "))",
+                        std::make_shared<vectorized::DataTypeArray>(
+                                std::make_shared<vectorized::DataTypeNullable>(val)));
             }
         });
         return instance;
     }
-    DataTypePtr get(const std::string& name) {
-        return _data_type_map[name];
-    }
+    DataTypePtr get(const std::string& name) { return _data_type_map[name]; }
     const std::string& get(const DataTypePtr& data_type) const {
         auto type_ptr = data_type->is_nullable()
                                 ? ((DataTypeNullable*)(data_type.get()))->get_nested_type()

--- a/be/src/vec/data_types/data_type_nullable.cpp
+++ b/be/src/vec/data_types/data_type_nullable.cpp
@@ -53,7 +53,8 @@ std::string DataTypeNullable::to_string(const IColumn& column, size_t row_num) c
     }
 }
 
-void DataTypeNullable::to_string(const IColumn& column, size_t row_num, BufferWritable& ostr) const {
+void DataTypeNullable::to_string(const IColumn& column, size_t row_num,
+                                 BufferWritable& ostr) const {
     const ColumnNullable& col =
             assert_cast<const ColumnNullable&>(*column.convert_to_full_column_if_const().get());
 

--- a/be/src/vec/data_types/data_type_nullable.h
+++ b/be/src/vec/data_types/data_type_nullable.h
@@ -81,6 +81,8 @@ public:
         return nested_data_type->can_be_inside_low_cardinality();
     }
     std::string to_string(const IColumn& column, size_t row_num) const override;
+    void to_string(const IColumn& column, size_t row_num, BufferWritable& ostr) const override;
+    Status from_string(ReadBuffer& rb, IColumn* column) const override; 
 
     const DataTypePtr& get_nested_type() const { return nested_data_type; }
 

--- a/be/src/vec/data_types/data_type_nullable.h
+++ b/be/src/vec/data_types/data_type_nullable.h
@@ -82,7 +82,7 @@ public:
     }
     std::string to_string(const IColumn& column, size_t row_num) const override;
     void to_string(const IColumn& column, size_t row_num, BufferWritable& ostr) const override;
-    Status from_string(ReadBuffer& rb, IColumn* column) const override; 
+    Status from_string(ReadBuffer& rb, IColumn* column) const override;
 
     const DataTypePtr& get_nested_type() const { return nested_data_type; }
 

--- a/be/src/vec/data_types/data_type_number_base.cpp
+++ b/be/src/vec/data_types/data_type_number_base.cpp
@@ -56,6 +56,29 @@ void DataTypeNumberBase<T>::to_string(const IColumn& column, size_t row_num,
 }
 
 template <typename T>
+Status DataTypeNumberBase<T>::from_string(ReadBuffer& rb, IColumn* column) const { 
+    auto* column_data = static_cast<ColumnVector<T>*>(column);
+    if constexpr (std::is_same<T, UInt128>::value) {
+        // TODO support for uint128
+        return Status::InvalidArgument("uint128 is not support");
+    } else if constexpr (std::is_same_v<T, float> || std::is_same_v<T, double>) {
+        T val;
+        if (!read_float_text_fast_impl(val, rb)) {
+            return Status::InvalidArgument(fmt::format("parse number fail, string: '{}'", std::string(rb.position(), rb.count()).c_str()));
+        }
+        column_data->insert_value(val);
+    } else if constexpr (std::is_integral<T>::value) {
+        T val;
+        if (!read_int_text_impl(val, rb)) {
+            return Status::InvalidArgument(fmt::format("parse number fail, string: '{}'", std::string(rb.position(), rb.count()).c_str()));
+        }
+        column_data->insert_value(val);
+//} || std::numeric_limits<T>::is_iec559) {
+    }
+    return Status::OK();
+}
+
+template <typename T>
 Field DataTypeNumberBase<T>::get_default() const {
     return NearestFieldType<FieldType>();
 }

--- a/be/src/vec/data_types/data_type_number_base.cpp
+++ b/be/src/vec/data_types/data_type_number_base.cpp
@@ -59,7 +59,7 @@ template <typename T>
 Status DataTypeNumberBase<T>::from_string(ReadBuffer& rb, IColumn* column) const { 
     auto* column_data = static_cast<ColumnVector<T>*>(column);
     if constexpr (std::is_same<T, UInt128>::value) {
-        // TODO support for uint128
+        // TODO support for Uint128
         return Status::InvalidArgument("uint128 is not support");
     } else if constexpr (std::is_same_v<T, float> || std::is_same_v<T, double>) {
         T val;
@@ -73,7 +73,8 @@ Status DataTypeNumberBase<T>::from_string(ReadBuffer& rb, IColumn* column) const
             return Status::InvalidArgument(fmt::format("parse number fail, string: '{}'", std::string(rb.position(), rb.count()).c_str()));
         }
         column_data->insert_value(val);
-//} || std::numeric_limits<T>::is_iec559) {
+    } else {
+        DCHECK(false);
     }
     return Status::OK();
 }

--- a/be/src/vec/data_types/data_type_number_base.cpp
+++ b/be/src/vec/data_types/data_type_number_base.cpp
@@ -56,7 +56,7 @@ void DataTypeNumberBase<T>::to_string(const IColumn& column, size_t row_num,
 }
 
 template <typename T>
-Status DataTypeNumberBase<T>::from_string(ReadBuffer& rb, IColumn* column) const { 
+Status DataTypeNumberBase<T>::from_string(ReadBuffer& rb, IColumn* column) const {
     auto* column_data = static_cast<ColumnVector<T>*>(column);
     if constexpr (std::is_same<T, UInt128>::value) {
         // TODO support for Uint128
@@ -64,13 +64,17 @@ Status DataTypeNumberBase<T>::from_string(ReadBuffer& rb, IColumn* column) const
     } else if constexpr (std::is_same_v<T, float> || std::is_same_v<T, double>) {
         T val;
         if (!read_float_text_fast_impl(val, rb)) {
-            return Status::InvalidArgument(fmt::format("parse number fail, string: '{}'", std::string(rb.position(), rb.count()).c_str()));
+            return Status::InvalidArgument(
+                    fmt::format("parse number fail, string: '{}'",
+                                std::string(rb.position(), rb.count()).c_str()));
         }
         column_data->insert_value(val);
     } else if constexpr (std::is_integral<T>::value) {
         T val;
         if (!read_int_text_impl(val, rb)) {
-            return Status::InvalidArgument(fmt::format("parse number fail, string: '{}'", std::string(rb.position(), rb.count()).c_str()));
+            return Status::InvalidArgument(
+                    fmt::format("parse number fail, string: '{}'",
+                                std::string(rb.position(), rb.count()).c_str()));
         }
         column_data->insert_value(val);
     } else {

--- a/be/src/vec/data_types/data_type_number_base.cpp
+++ b/be/src/vec/data_types/data_type_number_base.cpp
@@ -62,7 +62,7 @@ Status DataTypeNumberBase<T>::from_string(ReadBuffer& rb, IColumn* column) const
         // TODO support for Uint128
         return Status::InvalidArgument("uint128 is not support");
     } else if constexpr (std::is_same_v<T, float> || std::is_same_v<T, double>) {
-        T val;
+        T val = 0;
         if (!read_float_text_fast_impl(val, rb)) {
             return Status::InvalidArgument(
                     fmt::format("parse number fail, string: '{}'",
@@ -70,7 +70,7 @@ Status DataTypeNumberBase<T>::from_string(ReadBuffer& rb, IColumn* column) const
         }
         column_data->insert_value(val);
     } else if constexpr (std::is_integral<T>::value) {
-        T val;
+        T val = 0;
         if (!read_int_text_impl(val, rb)) {
             return Status::InvalidArgument(
                     fmt::format("parse number fail, string: '{}'",

--- a/be/src/vec/data_types/data_type_number_base.h
+++ b/be/src/vec/data_types/data_type_number_base.h
@@ -67,6 +67,7 @@ public:
 
     void to_string(const IColumn& column, size_t row_num, BufferWritable& ostr) const override;
     std::string to_string(const IColumn& column, size_t row_num) const override;
+    Status from_string(ReadBuffer& rb, IColumn* column) const override; 
 };
 
 } // namespace doris::vectorized

--- a/be/src/vec/data_types/data_type_number_base.h
+++ b/be/src/vec/data_types/data_type_number_base.h
@@ -67,7 +67,7 @@ public:
 
     void to_string(const IColumn& column, size_t row_num, BufferWritable& ostr) const override;
     std::string to_string(const IColumn& column, size_t row_num) const override;
-    Status from_string(ReadBuffer& rb, IColumn* column) const override; 
+    Status from_string(ReadBuffer& rb, IColumn* column) const override;
 };
 
 } // namespace doris::vectorized

--- a/be/src/vec/data_types/data_type_string.cpp
+++ b/be/src/vec/data_types/data_type_string.cpp
@@ -66,7 +66,7 @@ void DataTypeString::to_string(const class doris::vectorized::IColumn& column, s
     ostr.write(s.data, s.size);
 }
 
-Status DataTypeString::from_string(ReadBuffer& rb, IColumn* column) const { 
+Status DataTypeString::from_string(ReadBuffer& rb, IColumn* column) const {
     auto* column_data = static_cast<ColumnString*>(column);
     column_data->insert_data(rb.position(), rb.count());
     return Status::OK();

--- a/be/src/vec/data_types/data_type_string.cpp
+++ b/be/src/vec/data_types/data_type_string.cpp
@@ -66,6 +66,12 @@ void DataTypeString::to_string(const class doris::vectorized::IColumn& column, s
     ostr.write(s.data, s.size);
 }
 
+Status DataTypeString::from_string(ReadBuffer& rb, IColumn* column) const { 
+    auto* column_data = static_cast<ColumnString*>(column);
+    column_data->insert_data(rb.position(), rb.count());
+    return Status::OK();
+}
+
 Field DataTypeString::get_default() const {
     return String();
 }

--- a/be/src/vec/data_types/data_type_string.h
+++ b/be/src/vec/data_types/data_type_string.h
@@ -58,6 +58,7 @@ public:
     bool can_be_inside_low_cardinality() const override { return true; }
     std::string to_string(const IColumn& column, size_t row_num) const override;
     void to_string(const IColumn& column, size_t row_num, BufferWritable& ostr) const override;
+    Status from_string(ReadBuffer& rb, IColumn* column) const override; 
 };
 
 } // namespace doris::vectorized

--- a/be/src/vec/data_types/data_type_string.h
+++ b/be/src/vec/data_types/data_type_string.h
@@ -58,7 +58,7 @@ public:
     bool can_be_inside_low_cardinality() const override { return true; }
     std::string to_string(const IColumn& column, size_t row_num) const override;
     void to_string(const IColumn& column, size_t row_num, BufferWritable& ostr) const override;
-    Status from_string(ReadBuffer& rb, IColumn* column) const override; 
+    Status from_string(ReadBuffer& rb, IColumn* column) const override;
 };
 
 } // namespace doris::vectorized

--- a/be/src/vec/exec/varrow_scanner.cpp
+++ b/be/src/vec/exec/varrow_scanner.cpp
@@ -184,7 +184,6 @@ Status VArrowScanner::_init_src_block() {
         auto is_nullable = true;
         DataTypePtr data_type =
                 DataTypeFactory::instance().create_data_type(array->type().get(), is_nullable);
-        LOG(INFO) << "array name:" << array->type()->name();
         if (data_type == nullptr) {
             return Status::NotSupported(
                     fmt::format("Not support arrow type:{}", array->type()->name()));

--- a/be/src/vec/exec/varrow_scanner.cpp
+++ b/be/src/vec/exec/varrow_scanner.cpp
@@ -184,6 +184,7 @@ Status VArrowScanner::_init_src_block() {
         auto is_nullable = true;
         DataTypePtr data_type =
                 DataTypeFactory::instance().create_data_type(array->type().get(), is_nullable);
+        LOG(INFO) << "array name:" << array->type()->name();
         if (data_type == nullptr) {
             return Status::NotSupported(
                     fmt::format("Not support arrow type:{}", array->type()->name()));
@@ -291,7 +292,7 @@ Status VArrowScanner::_append_batch_to_src_block(Block* block) {
         auto* array = _batch->column(column_pos++).get();
         auto& column_with_type_and_name = block->get_by_name(slot_desc->col_name());
         RETURN_IF_ERROR(arrow_column_to_doris_column(array, _arrow_batch_cur_idx,
-                                                     column_with_type_and_name, num_elements,
+                                                     column_with_type_and_name.column, num_elements,
                                                      _state->timezone()));
     }
 

--- a/be/src/vec/exprs/vslot_ref.cpp
+++ b/be/src/vec/exprs/vslot_ref.cpp
@@ -57,6 +57,8 @@ Status VSlotRef::prepare(doris::RuntimeState* state, const doris::RowDescriptor&
 
 Status VSlotRef::execute(VExprContext* context, Block* block, int* result_column_id) {
     DCHECK_GE(_column_id, 0);
+    LOG(INFO) << "VSlotRef::execute _column_id:" << _column_id << " block size:" << block->columns();
+    LOG(INFO) << "VSlotRef::execute block dump_structure:" <<  block->dump_structure();
     *result_column_id = _column_id;
     return Status::OK();
 }

--- a/be/src/vec/exprs/vslot_ref.cpp
+++ b/be/src/vec/exprs/vslot_ref.cpp
@@ -57,8 +57,6 @@ Status VSlotRef::prepare(doris::RuntimeState* state, const doris::RowDescriptor&
 
 Status VSlotRef::execute(VExprContext* context, Block* block, int* result_column_id) {
     DCHECK_GE(_column_id, 0);
-    LOG(INFO) << "VSlotRef::execute _column_id:" << _column_id << " block size:" << block->columns();
-    LOG(INFO) << "VSlotRef::execute block dump_structure:" <<  block->dump_structure();
     *result_column_id = _column_id;
     return Status::OK();
 }

--- a/be/src/vec/functions/function_cast.h
+++ b/be/src/vec/functions/function_cast.h
@@ -1093,9 +1093,10 @@ private:
         bool from_empty_array = is_nothing(from_nested_type);
 
         if (from_type->get_number_of_dimensions() != to_type.get_number_of_dimensions() &&
-            !from_empty_array)
+            !from_empty_array) {
             LOG(FATAL)
                     << "CAST AS Array can only be performed between same-dimensional array types";
+        }
 
         const DataTypePtr& to_nested_type = to_type.get_nested_type();
 
@@ -1122,7 +1123,7 @@ private:
                 size_t nested_result = block.columns();
                 block.insert({to_nested_type, ""});
                 RETURN_IF_ERROR(nested_function(context, block, new_arguments, nested_result,
-                                                from_column->size()));
+                                                from_col_array->get_data_ptr()->size()));
                 auto nested_result_column = block.get_by_position(nested_result).column;
 
                 /// set converted nested column to result

--- a/be/src/vec/utils/arrow_column_to_doris_column.cpp
+++ b/be/src/vec/utils/arrow_column_to_doris_column.cpp
@@ -238,35 +238,35 @@ static Status convert_column_with_decimal_data(const arrow::Array* array, size_t
 }
 
 static Status convert_offset_from_list_column(const arrow::Array* array, size_t array_idx,
-                                                 MutableColumnPtr& data_column, size_t num_elements,
-                                                 size_t* start_idx_for_data, size_t* num_for_data) {
+                                              MutableColumnPtr& data_column, size_t num_elements,
+                                              size_t* start_idx_for_data, size_t* num_for_data) {
     auto& offsets_data = static_cast<ColumnArray&>(*data_column).get_offsets();
     auto concrete_array = down_cast<const arrow::ListArray*>(array);
     auto arrow_offsets_array = concrete_array->offsets();
-    auto arrow_offsets = down_cast<arrow::Int32Array* >(arrow_offsets_array.get());
+    auto arrow_offsets = down_cast<arrow::Int32Array*>(arrow_offsets_array.get());
     for (int64_t i = array_idx + 1; i < array_idx + num_elements + 1; ++i) {
         offsets_data.emplace_back(arrow_offsets->Value(i));
     }
-    *start_idx_for_data =  arrow_offsets->Value(array_idx);
-    *num_for_data =  offsets_data.back() - *start_idx_for_data;
+    *start_idx_for_data = arrow_offsets->Value(array_idx);
+    *num_for_data = offsets_data.back() - *start_idx_for_data;
 
     return Status::OK();
 }
 
 static Status convert_column_with_list_data(const arrow::Array* array, size_t array_idx,
-                                                 MutableColumnPtr& data_column, size_t num_elements,
-                                   const std::string& timezone) {
+                                            MutableColumnPtr& data_column, size_t num_elements,
+                                            const std::string& timezone) {
     size_t start_idx_for_data = 0;
     size_t num_for_data = 0;
     // get start idx and num of values from arrow offsets
-    RETURN_IF_ERROR(convert_offset_from_list_column(array, array_idx, data_column,
-                                            num_elements, &start_idx_for_data, &num_for_data));
+    RETURN_IF_ERROR(convert_offset_from_list_column(array, array_idx, data_column, num_elements,
+                                                    &start_idx_for_data, &num_for_data));
     auto& data_column_ptr = static_cast<ColumnArray&>(*data_column).get_data_ptr();
     auto concrete_array = down_cast<const arrow::ListArray*>(array);
     std::shared_ptr<arrow::Array> arrow_data = concrete_array->values();
-    
+
     return arrow_column_to_doris_column(arrow_data.get(), start_idx_for_data, data_column_ptr,
-                                            num_for_data, timezone);
+                                        num_for_data, timezone);
 }
 
 Status arrow_column_to_doris_column(const arrow::Array* arrow_column, size_t arrow_batch_cur_idx,
@@ -314,8 +314,8 @@ Status arrow_column_to_doris_column(const arrow::Array* arrow_column, size_t arr
         return convert_column_with_decimal_data(arrow_column, arrow_batch_cur_idx, data_column,
                                                 num_elements);
     case arrow::Type::LIST:
-        return convert_column_with_list_data(
-                arrow_column, arrow_batch_cur_idx, data_column, num_elements, timezone);
+        return convert_column_with_list_data(arrow_column, arrow_batch_cur_idx, data_column,
+                                             num_elements, timezone);
     default:
         break;
     }

--- a/be/src/vec/utils/arrow_column_to_doris_column.cpp
+++ b/be/src/vec/utils/arrow_column_to_doris_column.cpp
@@ -245,10 +245,11 @@ static Status convert_offset_from_list_column(const arrow::Array* array, size_t 
     auto arrow_offsets_array = concrete_array->offsets();
     auto arrow_offsets = down_cast<arrow::Int32Array*>(arrow_offsets_array.get());
     for (int64_t i = array_idx + 1; i < array_idx + num_elements + 1; ++i) {
-        offsets_data.emplace_back(arrow_offsets->Value(i));
+        // convert to doris offset, start from 0
+        offsets_data.emplace_back(arrow_offsets->Value(i) - arrow_offsets->Value(array_idx + 1));
     }
     *start_idx_for_data = arrow_offsets->Value(array_idx);
-    *num_for_data = offsets_data.back() - *start_idx_for_data;
+    *num_for_data = offsets_data.back();
 
     return Status::OK();
 }

--- a/be/src/vec/utils/arrow_column_to_doris_column.cpp
+++ b/be/src/vec/utils/arrow_column_to_doris_column.cpp
@@ -256,17 +256,17 @@ static Status convert_offset_from_list_column(const arrow::Array* array, size_t 
 static Status convert_column_with_list_data(const arrow::Array* array, size_t array_idx,
                                             MutableColumnPtr& data_column, size_t num_elements,
                                             const std::string& timezone) {
-    size_t start_idx_for_data = 0;
-    size_t num_for_data = 0;
+    size_t start_idx_of_data = 0;
+    size_t num_of_data = 0;
     // get start idx and num of values from arrow offsets
     RETURN_IF_ERROR(convert_offset_from_list_column(array, array_idx, data_column, num_elements,
-                                                    &start_idx_for_data, &num_for_data));
+                                                    &start_idx_of_data, &num_of_data));
     auto& data_column_ptr = static_cast<ColumnArray&>(*data_column).get_data_ptr();
     auto concrete_array = down_cast<const arrow::ListArray*>(array);
     std::shared_ptr<arrow::Array> arrow_data = concrete_array->values();
 
-    return arrow_column_to_doris_column(arrow_data.get(), start_idx_for_data, data_column_ptr,
-                                        num_for_data, timezone);
+    return arrow_column_to_doris_column(arrow_data.get(), start_idx_of_data, data_column_ptr,
+                                        num_of_data, timezone);
 }
 
 Status arrow_column_to_doris_column(const arrow::Array* arrow_column, size_t arrow_batch_cur_idx,

--- a/be/src/vec/utils/arrow_column_to_doris_column.cpp
+++ b/be/src/vec/utils/arrow_column_to_doris_column.cpp
@@ -244,20 +244,11 @@ static Status convert_offset_from_list_column(const arrow::Array* array, size_t 
     auto concrete_array = down_cast<const arrow::ListArray*>(array);
     auto arrow_offsets_array = concrete_array->offsets();
     auto arrow_offsets = down_cast<arrow::Int32Array* >(arrow_offsets_array.get());
-    //if (array_idx == 0) {
-    //    // init the first offset
-    //    offsets_data.emplace_back(0);
-    //}
-    //auto start = offsets_data.back();
     for (int64_t i = array_idx + 1; i < array_idx + num_elements + 1; ++i) {
-        //LOG(INFO) << "convert_offset_from_list_column offset - 1:" << arrow_offsets.Value(i - 1);
-        //LOG(INFO) << "convert_offset_from_list_column offset:" << arrow_offsets->Value(i);
         offsets_data.emplace_back(arrow_offsets->Value(i));
     }
     *start_idx_for_data =  arrow_offsets->Value(array_idx);
-    //*num_for_data =  arrow_offsets->Value(array_idx + num_elements - 1) - arrow_offsets->Value(array_idx) + 1;
     *num_for_data =  offsets_data.back() - *start_idx_for_data;
-    LOG(INFO) << "convert_offset_from_list_column start_idx_for_data:" << *start_idx_for_data << " num_for_data:" << *num_for_data;
 
     return Status::OK();
 }
@@ -288,7 +279,6 @@ Status arrow_column_to_doris_column(const arrow::Array* arrow_column, size_t arr
         auto* nullable_column = reinterpret_cast<vectorized::ColumnNullable*>(
                 (*std::move(doirs_column)).mutate().get());
         fill_nullable_column(arrow_column, arrow_batch_cur_idx, nullable_column, num_elements);
-        LOG(INFO) << "fill_nullable_column arrow_batch_cur_idx:" << arrow_batch_cur_idx << " num_elements:" << num_elements;
         data_column = nullable_column->get_nested_column_ptr();
     } else {
         data_column = (*std::move(doirs_column)).mutate();

--- a/be/src/vec/utils/arrow_column_to_doris_column.cpp
+++ b/be/src/vec/utils/arrow_column_to_doris_column.cpp
@@ -246,7 +246,7 @@ static Status convert_offset_from_list_column(const arrow::Array* array, size_t 
     auto arrow_offsets = down_cast<arrow::Int32Array*>(arrow_offsets_array.get());
     for (int64_t i = array_idx + 1; i < array_idx + num_elements + 1; ++i) {
         // convert to doris offset, start from 0
-        offsets_data.emplace_back(arrow_offsets->Value(i) - arrow_offsets->Value(array_idx + 1));
+        offsets_data.emplace_back(arrow_offsets->Value(i) - arrow_offsets->Value(array_idx));
     }
     *start_idx_for_data = arrow_offsets->Value(array_idx);
     *num_for_data = offsets_data.back();

--- a/be/src/vec/utils/arrow_column_to_doris_column.h
+++ b/be/src/vec/utils/arrow_column_to_doris_column.h
@@ -34,7 +34,7 @@ namespace doris::vectorized {
 const PrimitiveType arrow_type_to_primitive_type(::arrow::Type::type type);
 
 Status arrow_column_to_doris_column(const arrow::Array* arrow_column, size_t arrow_batch_cur_idx,
-                                    ColumnWithTypeAndName& doirs_column, size_t num_elements,
+                                    ColumnPtr& doirs_column, size_t num_elements,
                                     const std::string& timezone);
 
 } // namespace doris::vectorized


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

Only support one level array now.
for example:
- nullable(array(nullable(tinyint))) is **support**.
- nullable(array(nullable(array(xx))) is **not support**.

## Checklist(Required)

1. Does it affect the original behavior: (Yes)
2. Has unit tests been added: (No)
3. Has document been added or modified: (No Need)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
