### PR TITLE
[Enhancement] Support select specify tablet id

### DIFF
--- a/fe/fe-core/src/main/cup/sql_parser.cup
+++ b/fe/fe-core/src/main/cup/sql_parser.cup
@@ -355,6 +355,7 @@ nonterminal ArrayList<Expr> expr_pipe_list;
 nonterminal String select_alias, opt_table_alias, lock_alias;
 nonterminal ArrayList<String> ident_list;
 nonterminal PartitionNames opt_partition_names, partition_names;
+nonterminal ArrayList<Long> opt_tablet_list, tablet_list;
 nonterminal ClusterName cluster_name;
 nonterminal ClusterName des_cluster_name;
 nonterminal TableName table_name, opt_table_name;
@@ -4230,9 +4231,9 @@ base_table_ref_list ::=
   ;
 
 base_table_ref ::=
-    table_name:name opt_partition_names:partitionNames opt_table_alias:alias opt_common_hints:commonHints
+    table_name:name opt_partition_names:partitionNames opt_tablet_list:tabletIds opt_table_alias:alias opt_common_hints:commonHints
     {:
-        RESULT = new TableRef(name, alias, partitionNames, commonHints);
+        RESULT = new TableRef(name, alias, partitionNames, tabletIds, commonHints);
     :}
     ;
 
@@ -4278,6 +4279,24 @@ opt_partition_names ::=
     | partition_names:partitionNames
     {:
         RESULT = partitionNames;
+    :}
+    ;
+
+opt_tablet_list ::=
+    /* empty */
+    {:
+        RESULT = null;
+    :}
+    | tablet_list:tabletList
+    {:
+        RESULT = tabletList;
+    :}
+    ;
+
+tablet_list ::=
+    KW_TABLET LPAREN integer_list:tabletIds RPAREN
+    {:
+        RESULT = Lists.newArrayList(tabletIds);
     :}
     ;
 

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/BaseTableRef.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/BaseTableRef.java
@@ -58,6 +58,7 @@ public class BaseTableRef extends TableRef {
     public TupleDescriptor createTupleDescriptor(Analyzer analyzer) {
         TupleDescriptor result = analyzer.getDescTbl().createTupleDescriptor();
         result.setTable(table);
+        result.setSampleTabletIds(getSampleTabletIds());
         return result;
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/TupleDescriptor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/TupleDescriptor.java
@@ -43,6 +43,7 @@ public class TupleDescriptor {
     private final TupleId id;
     private final String debugName; // debug only
     private final ArrayList<SlotDescriptor> slots;
+    private List<Long> sampleTabletIds = Lists.newArrayList();
 
     // underlying table, if there is one
     private Table table;
@@ -157,6 +158,14 @@ public class TupleDescriptor {
 
     public void setTable(Table tbl) {
         table = tbl;
+    }
+
+    public List<Long> getSampleTabletIds() {
+        return sampleTabletIds;
+    }
+
+    public void setSampleTabletIds(List<Long> tabletIds) {
+        sampleTabletIds = tabletIds;
     }
 
     public int getByteSize() {

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/OlapScanNode.java
@@ -653,6 +653,10 @@ public class OlapScanNode extends ScanNode {
             final List<Tablet> tablets = Lists.newArrayList();
             final Collection<Long> tabletIds = distributionPrune(selectedTable, partition.getDistributionInfo());
             LOG.debug("distribution prune tablets: {}", tabletIds);
+            if (desc.getSampleTabletIds().size() != 0) {
+                tabletIds.retainAll(desc.getSampleTabletIds());
+                LOG.debug("after sample tablets: {}", tabletIds);
+            }
 
             List<Long> allTabletIds = selectedTable.getTabletIdsInOrder();
             if (tabletIds != null) {

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/SelectStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/SelectStmtTest.java
@@ -808,4 +808,10 @@ public class SelectStmtTest {
         FunctionCallExpr expr = (FunctionCallExpr) stmt1.getSelectList().getItems().get(1).getExpr();
         Assert.assertTrue(expr.getFnParams().isDistinct());
     }
+
+    @Test
+    public void testSelectSampleTablet() throws Exception {
+        String sql1 = "SELECT * FROM db1.table1 TABLET(10031,10032,10033)";
+        Assert.assertFalse(dorisAssert.query(sql1).explainQuery().contains("tabletList=10031,10032,10033"));
+    }
 }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

select specifies the tablet id for data sampling, for example:
```
SELECT * FROM db1.table1 TABLET(10031,10032,10033)
```


## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
