### PR TITLE
[bug] Fix BE core about vectorized join build thread memtracker switch, and FileStat duplicate

### DIFF
--- a/be/src/runtime/minidump.cpp
+++ b/be/src/runtime/minidump.cpp
@@ -32,11 +32,12 @@ int Minidump::_signo = SIGUSR1;
 std::unique_ptr<google_breakpad::ExceptionHandler> Minidump::_error_handler = nullptr;
 
 // Save the absolute path and create_time of a minidump file
-struct FileStat {
+struct MinidumpFileStat {
     std::string abs_path;
     time_t create_time;
 
-    FileStat(const std::string& path_, time_t ctime) : abs_path(path_), create_time(ctime) {}
+    MinidumpFileStat(const std::string& path_, time_t ctime)
+            : abs_path(path_), create_time(ctime) {}
 };
 
 Status Minidump::init() {
@@ -134,7 +135,7 @@ void Minidump::_clean_old_minidump() {
 
         // check file create time and sort and save in stats
         int ret = 0;
-        std::vector<FileStat> stats;
+        std::vector<MinidumpFileStat> stats;
         for (auto it = files.begin(); it != files.end(); ++it) {
             std::string path = config::minidump_dir + "/" + *it;
 
@@ -150,13 +151,14 @@ void Minidump::_clean_old_minidump() {
         }
 
         // sort file by ctime ascending
-        std::sort(stats.begin(), stats.end(), [](const FileStat& f1, const FileStat& f2) {
-            if (f1.create_time > f2.create_time) {
-                return false;
-            } else {
-                return true;
-            }
-        });
+        std::sort(stats.begin(), stats.end(),
+                  [](const MinidumpFileStat& f1, const MinidumpFileStat& f2) {
+                      if (f1.create_time > f2.create_time) {
+                          return false;
+                      } else {
+                          return true;
+                      }
+                  });
 
         int to_delete = stats.size() - config::max_minidump_file_number;
         int deleted = 0;

--- a/be/src/vec/exec/join/vhash_join_node.cpp
+++ b/be/src/vec/exec/join/vhash_join_node.cpp
@@ -999,6 +999,7 @@ Status HashJoinNode::open(RuntimeState* state) {
 }
 
 void HashJoinNode::_hash_table_build_thread(RuntimeState* state, std::promise<Status>* status) {
+    SCOPED_ATTACH_TASK_THREAD(state, mem_tracker());
     status->set_value(_hash_table_build(state));
 }
 


### PR DESCRIPTION
# Proposed changes

Issue Number: close #9865 #9869

## Problem Summary:

1. Vectorized join builds the hash table in a separate thread, but does not attach the query mem tracker in TLS when the thread starts, which will result in missing query memory statistics.

2. Minidump FileStat and StorageBackend FileStat have the same name, resulting in an incorrect destructor call.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
