### PR TITLE
opt column_dictinary range filter

### DIFF
--- a/be/src/vec/columns/column_dictionary.h
+++ b/be/src/vec/columns/column_dictionary.h
@@ -377,7 +377,7 @@ public:
         void clear() {
             _dict_data.clear();
             _inverted_index.clear();
-            _code_convert_map.clear();
+            _code_convert_table.clear();
             _hash_values.clear();
         }
 
@@ -385,14 +385,17 @@ public:
 
         void sort() {
             size_t dict_size = _dict_data.size();
+            _code_convert_table.reserve(dict_size);
             std::sort(_dict_data.begin(), _dict_data.end(), _comparator);
             for (size_t i = 0; i < dict_size; ++i) {
-                _code_convert_map[_inverted_index.find(_dict_data[i])->second] = (T)i;
+                _code_convert_table[_inverted_index.find(_dict_data[i])->second] = (T)i;
                 _inverted_index[_dict_data[i]] = (T)i;
             }
         }
 
-        T convert_code(const T& code) const { return _code_convert_map.find(code)->second; }
+        T convert_code(const T& code) const { 
+            return _code_convert_table[code]; 
+        }
 
         size_t byte_size() { return _dict_data.size() * sizeof(_dict_data[0]); }
 
@@ -405,8 +408,8 @@ public:
         DictContainer _dict_data;
         // dict value -> dict code
         phmap::flat_hash_map<StringValue, T, StringValue::HashOfStringValue> _inverted_index;
-        // data page code -> sorted dict code, only used for range comparison predicate
-        phmap::flat_hash_map<T, T> _code_convert_map;
+        // only used for range comparison predicate. _code_convert_table[i] = j, where i is dataPageCode, and j is sortedDictCode
+        std::vector<T> _code_convert_table;
         // hash value of origin string , used for bloom filter
         // It's a trade-off of space for performance
         // But in TPC-DS 1GB q60,we see no significant improvement.

--- a/be/src/vec/columns/column_dictionary.h
+++ b/be/src/vec/columns/column_dictionary.h
@@ -393,9 +393,7 @@ public:
             }
         }
 
-        T convert_code(const T& code) const { 
-            return _code_convert_table[code]; 
-        }
+        T convert_code(const T& code) const { return _code_convert_table[code]; }
 
         size_t byte_size() { return _dict_data.size() * sizeof(_dict_data[0]); }
 


### PR DESCRIPTION
# Proposed changes
字典重新排序后，前后两本字典的字典码转换关系原来实现使用map。改为vector保存对应关系，可以提高查找新字典码的速度。
测试数据 ssb_flat 5G
SQL： select    count(P_BRAND)    FROM    lineorder_flat        WHERE    P_BRAND    <=    'MFGR#2228'
测试对比细节如下（total是sql执行时间，字典转码包含在profile的ShortPredEvalTime counter中）
- 修改前 （total， ShortPredEvalTime）
1. 1251ms, 457ms
2. 1427ms, 512ms
3. 1247ms 438ms
- 修改后 （total， ShortPredEvalTime）
1.  1490ms， 332ms
4. 800ms， 167ms
5. 1266ms, 274ms

测试结论：sql执行时间从1317ms提高到1185ms，ShortPredEvalTime 从469 提高到257，提高 45%

Issue Number: close #xxx

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
6. Has unit tests been added: (Yes/No/No Need)
7. Has document been added or modified: (Yes/No/No Need)
8. Does it need to update dependencies: (Yes/No)
9. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
