### PR TITLE
[fix](planner): fix pushdown predicate incompletely

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/planner/SingleNodePlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/SingleNodePlanner.java
@@ -1614,7 +1614,7 @@ public class SingleNodePlanner {
         final SelectStmt selectStmt = (SelectStmt) inlineViewRef.getViewStmt();
         if (selectStmt.hasAnalyticInfo()) {
             pushDownPredicates.addAll(getWindowsPushDownPredicates(candicatePredicates, viewPredicates,
-                    selectStmt.getAnalyticInfo(), pushDownFailedPredicates));
+                    selectStmt, pushDownFailedPredicates));
         } else {
             pushDownPredicates.addAll(candicatePredicates);
         }
@@ -1632,16 +1632,16 @@ public class SingleNodePlanner {
      */
     private List<Expr> getWindowsPushDownPredicates(
             List<Expr> predicates, List<Expr> viewPredicates,
-            AnalyticInfo analyticInfo, List<Expr> pushDownFailedPredicates) {
+            SelectStmt selectStmt, List<Expr> pushDownFailedPredicates) {
         final List<Expr> pushDownPredicates = Lists.newArrayList();
-        final List<Expr> partitionExprs = analyticInfo.getCommonPartitionExprs();
         final List<SlotId> partitionByIds = Lists.newArrayList();
-        for (Expr expr : partitionExprs) {
-            if (expr instanceof SlotRef) {
-                final SlotRef slotRef = (SlotRef) expr;
+
+        selectStmt.getSelectList().getItems().forEach(item -> {
+            if (item.getExpr() instanceof SlotRef) {
+                final SlotRef slotRef = (SlotRef) item.getExpr();
                 partitionByIds.add(slotRef.getSlotId());
             }
-        }
+        });
 
         if (partitionByIds.size() <= 0) {
             return pushDownPredicates;


### PR DESCRIPTION
# Proposed changes

Issue Number: close #9884 

## Problem Summary:

Describe the overview of changes.

Because determining whether a predicate can be pushed down is based on `PARTITION by` (it's CommonPartitionExprs in the code)

Correct way is according to the `select Items`

## Checklist(Required)

1. Does it affect the original behavior: (Yes)
2. Has unit tests been added: (No)
3. Has document been added or modified: (No need)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
