### PR TITLE
[Enhancement] add some metrics for cpu and memory

### DIFF
--- a/be/src/util/system_metrics.h
+++ b/be/src/util/system_metrics.h
@@ -31,6 +31,7 @@ struct NetworkMetrics;
 struct FileDescriptorMetrics;
 struct SnmpMetrics;
 struct LoadAverageMetrics;
+struct ProcMetrics;
 
 class SystemMetrics {
 public:
@@ -51,7 +52,7 @@ public:
                              int64_t interval_sec, int64_t* send_rate, int64_t* rcv_rate);
 
 private:
-    void _install_cpu_metrics(MetricEntity* entity);
+    void _install_cpu_metrics();
     // On Intel(R) Xeon(R) CPU E5-2450 0 @ 2.10GHz;
     // read /proc/stat would cost about 170us
     void _update_cpu_metrics();
@@ -74,10 +75,16 @@ private:
     void _install_load_avg_metrics(MetricEntity* entity);
     void _update_load_avg_metrics();
 
+    void _install_proc_metrics(MetricEntity* entity);
+    void _update_proc_metrics();
+
+    void get_metrics_from_proc_vmstat();
+    void get_cpu_name();
+
 private:
     static const char* _s_hook_name;
 
-    std::unique_ptr<CpuMetrics> _cpu_metrics;
+    std::map<std::string, CpuMetrics*> _cpu_metrics;
     std::unique_ptr<MemoryMetrics> _memory_metrics;
     std::map<std::string, DiskMetrics*> _disk_metrics;
     std::map<std::string, NetworkMetrics*> _network_metrics;
@@ -85,7 +92,9 @@ private:
     std::unique_ptr<LoadAverageMetrics> _load_average_metrics;
     int _proc_net_dev_version = 0;
     std::unique_ptr<SnmpMetrics> _snmp_metrics;
+    std::unique_ptr<ProcMetrics> _proc_metrics;
 
+    std::vector<std::string> _cpu_names;
     char* _line_ptr = nullptr;
     size_t _line_buf_size = 0;
     MetricRegistry* _registry = nullptr;

--- a/be/test/util/system_metrics_test.cpp
+++ b/be/test/util/system_metrics_test.cpp
@@ -39,6 +39,7 @@ extern const char* k_ut_net_dev_path;
 extern const char* k_ut_fd_path;
 extern const char* k_ut_net_snmp_path;
 extern const char* k_ut_load_avg_path;
+extern const char* k_ut_vmstat_path;
 
 TEST_F(SystemMetricsTest, normal) {
     std::string dir_path = GetCurrentRunningDir();
@@ -61,6 +62,9 @@ TEST_F(SystemMetricsTest, normal) {
     std::string load_avg_path(dir_path);
     load_avg_path += "/util/test_data/load_avg_normal";
     k_ut_load_avg_path = load_avg_path.c_str();
+    std::string vmstat_path(dir_path);
+    vmstat_path += "/util/test_data/vmstat_normal";
+    k_ut_vmstat_path = vmstat_path.c_str();
 
     MetricRegistry registry("test");
     {
@@ -75,39 +79,55 @@ TEST_F(SystemMetricsTest, normal) {
         metrics.update();
 
         // cpu
-        Metric* cpu_user = entity->get_metric("cpu_user", "cpu");
+        auto cpu_entity = registry.get_entity("cpu", {{"device", "cpu"}});
+        EXPECT_TRUE(cpu_entity != nullptr);
+        EXPECT_TRUE("cpu" == cpu_entity->name());
+        Metric* cpu_user = cpu_entity->get_metric("cpu_user", "cpu");
         EXPECT_TRUE(cpu_user != nullptr);
-        // EXPECT_STREQ("57199151", cpu_user->to_string().c_str());
-        Metric* cpu_nice = entity->get_metric("cpu_nice", "cpu");
+        EXPECT_STREQ("57199151", cpu_user->to_string().c_str());
+        Metric* cpu_nice = cpu_entity->get_metric("cpu_nice", "cpu");
         EXPECT_TRUE(cpu_nice != nullptr);
         EXPECT_STREQ("2616310", cpu_nice->to_string().c_str());
-        Metric* cpu_system = entity->get_metric("cpu_system", "cpu");
+        Metric* cpu_system = cpu_entity->get_metric("cpu_system", "cpu");
         EXPECT_TRUE(cpu_system != nullptr);
         EXPECT_STREQ("10600935", cpu_system->to_string().c_str());
-        Metric* cpu_idle = entity->get_metric("cpu_idle", "cpu");
+        Metric* cpu_idle = cpu_entity->get_metric("cpu_idle", "cpu");
         EXPECT_TRUE(cpu_idle != nullptr);
         EXPECT_STREQ("1517505423", cpu_idle->to_string().c_str());
-        Metric* cpu_iowait = entity->get_metric("cpu_iowait", "cpu");
+        Metric* cpu_iowait = cpu_entity->get_metric("cpu_iowait", "cpu");
         EXPECT_TRUE(cpu_iowait != nullptr);
         EXPECT_STREQ("2137148", cpu_iowait->to_string().c_str());
-        Metric* cpu_irq = entity->get_metric("cpu_irq", "cpu");
+        Metric* cpu_irq = cpu_entity->get_metric("cpu_irq", "cpu");
         EXPECT_TRUE(cpu_irq != nullptr);
         EXPECT_STREQ("0", cpu_irq->to_string().c_str());
-        Metric* cpu_softirq = entity->get_metric("cpu_soft_irq", "cpu");
+        Metric* cpu_softirq = cpu_entity->get_metric("cpu_soft_irq", "cpu");
         EXPECT_TRUE(cpu_softirq != nullptr);
         EXPECT_STREQ("108277", cpu_softirq->to_string().c_str());
-        Metric* cpu_steal = entity->get_metric("cpu_steal", "cpu");
+        Metric* cpu_steal = cpu_entity->get_metric("cpu_steal", "cpu");
         EXPECT_TRUE(cpu_steal != nullptr);
         EXPECT_STREQ("0", cpu_steal->to_string().c_str());
-        Metric* cpu_guest = entity->get_metric("cpu_guest", "cpu");
+        Metric* cpu_guest = cpu_entity->get_metric("cpu_guest", "cpu");
         EXPECT_TRUE(cpu_guest != nullptr);
         EXPECT_STREQ("0", cpu_guest->to_string().c_str());
-        Metric* cpu_guest_nice = entity->get_metric("cpu_guest_nice", "cpu");
+        Metric* cpu_guest_nice = cpu_entity->get_metric("cpu_guest_nice", "cpu");
         EXPECT_TRUE(cpu_guest_nice != nullptr);
         EXPECT_STREQ("0", cpu_guest_nice->to_string().c_str());
+
         // memroy
         Metric* memory_allocated_bytes = entity->get_metric("memory_allocated_bytes");
         EXPECT_TRUE(memory_allocated_bytes != nullptr);
+        Metric* memory_pgpgin = entity->get_metric("memory_pgpgin");
+        EXPECT_TRUE(memory_pgpgin != nullptr);
+        EXPECT_STREQ("21458611100", memory_pgpgin->to_string().c_str());
+        Metric* memory_pgpgout = entity->get_metric("memory_pgpgout");
+        EXPECT_TRUE(memory_pgpgout != nullptr);
+        EXPECT_STREQ("149080494692", memory_pgpgout->to_string().c_str());
+        Metric* memory_pswpin = entity->get_metric("memory_pswpin");
+        EXPECT_TRUE(memory_pswpin != nullptr);
+        EXPECT_STREQ("167785", memory_pswpin->to_string().c_str());
+        Metric* memory_pswpout = entity->get_metric("memory_pswpout");
+        EXPECT_TRUE(memory_pswpout != nullptr);
+        EXPECT_STREQ("203724", memory_pswpout->to_string().c_str());
 
         // network
         auto net_entity = registry.get_entity("network_metrics.xgbe0", {{"device", "xgbe0"}});
@@ -184,6 +204,20 @@ TEST_F(SystemMetricsTest, normal) {
                 entity->get_metric("load_average_15_minutes", "load_average");
         EXPECT_TRUE(fd_metric != nullptr);
         EXPECT_STREQ("2.020000", load_average_15_minutes->to_string().c_str());
+
+        // proc
+        Metric* proc_interrupt = entity->get_metric("proc_interrupt", "proc");
+        EXPECT_TRUE(proc_interrupt != nullptr);
+        EXPECT_STREQ("20935913098", proc_interrupt->to_string().c_str());
+        Metric* proc_ctxt_switch = entity->get_metric("proc_ctxt_switch", "proc");
+        EXPECT_TRUE(proc_ctxt_switch != nullptr);
+        EXPECT_STREQ("11043516832", proc_ctxt_switch->to_string().c_str());
+        Metric* proc_procs_running = entity->get_metric("proc_procs_running", "proc");
+        EXPECT_TRUE(proc_procs_running != nullptr);
+        EXPECT_STREQ("1", proc_procs_running->to_string().c_str());
+        Metric* proc_procs_blocked = entity->get_metric("proc_procs_blocked", "proc");
+        EXPECT_TRUE(proc_procs_blocked != nullptr);
+        EXPECT_STREQ("0", proc_procs_blocked->to_string().c_str());
     }
 }
 
@@ -201,6 +235,9 @@ TEST_F(SystemMetricsTest, no_proc_file) {
     k_ut_net_dev_path = net_dev_path.c_str();
     k_ut_fd_path = "";
     k_ut_net_snmp_path = "";
+    std::string vmstat_path(dir_path);
+    vmstat_path += "/util/test_data/no_vmstat_normal";
+    k_ut_vmstat_path = vmstat_path.c_str();
 
     MetricRegistry registry("test");
     {
@@ -214,24 +251,52 @@ TEST_F(SystemMetricsTest, no_proc_file) {
         EXPECT_TRUE(entity != nullptr);
 
         // cpu
-        Metric* cpu_user = entity->get_metric("cpu_user", "cpu");
-        EXPECT_TRUE(cpu_user != nullptr);
-        EXPECT_STREQ("0", cpu_user->to_string().c_str());
+        auto cpu_entity = registry.get_entity("cpu", {{"device", "cpu"}});
+        EXPECT_TRUE(cpu_entity == nullptr);
+
         // memroy
         Metric* memory_allocated_bytes = entity->get_metric("memory_allocated_bytes");
         EXPECT_TRUE(memory_allocated_bytes != nullptr);
+        Metric* memory_pgpgin = entity->get_metric("memory_pgpgin");
+        EXPECT_TRUE(memory_pgpgin != nullptr);
+        EXPECT_STREQ("0", memory_pgpgin->to_string().c_str());
+        Metric* memory_pgpgout = entity->get_metric("memory_pgpgout");
+        EXPECT_TRUE(memory_pgpgout != nullptr);
+        EXPECT_STREQ("0", memory_pgpgout->to_string().c_str());
+        Metric* memory_pswpin = entity->get_metric("memory_pswpin");
+        EXPECT_TRUE(memory_pswpin != nullptr);
+        EXPECT_STREQ("0", memory_pswpin->to_string().c_str());
+        Metric* memory_pswpout = entity->get_metric("memory_pswpout");
+        EXPECT_TRUE(memory_pswpout != nullptr);
+        EXPECT_STREQ("0", memory_pswpout->to_string().c_str());
+
         // network
         auto net_entity = registry.get_entity("network_metrics.xgbe0", {{"device", "xgbe0"}});
         EXPECT_TRUE(net_entity != nullptr);
         Metric* receive_bytes = net_entity->get_metric("network_receive_bytes");
         EXPECT_TRUE(receive_bytes != nullptr);
         EXPECT_STREQ("0", receive_bytes->to_string().c_str());
+
         // disk
         auto disk_entity = registry.get_entity("disk_metrics.sda", {{"device", "sda"}});
         EXPECT_TRUE(disk_entity != nullptr);
         Metric* bytes_read = disk_entity->get_metric("disk_bytes_read");
         EXPECT_TRUE(bytes_read != nullptr);
         EXPECT_STREQ("0", bytes_read->to_string().c_str());
+
+        // proc
+        Metric* proc_interrupt = entity->get_metric("proc_interrupt", "proc");
+        EXPECT_TRUE(proc_interrupt != nullptr);
+        EXPECT_STREQ("0", proc_interrupt->to_string().c_str());
+        Metric* proc_ctxt_switch = entity->get_metric("proc_ctxt_switch", "proc");
+        EXPECT_TRUE(proc_ctxt_switch != nullptr);
+        EXPECT_STREQ("0", proc_ctxt_switch->to_string().c_str());
+        Metric* proc_procs_running = entity->get_metric("proc_procs_running", "proc");
+        EXPECT_TRUE(proc_procs_running != nullptr);
+        EXPECT_STREQ("0", proc_procs_running->to_string().c_str());
+        Metric* proc_procs_blocked = entity->get_metric("proc_procs_blocked", "proc");
+        EXPECT_TRUE(proc_procs_blocked != nullptr);
+        EXPECT_STREQ("0", proc_procs_blocked->to_string().c_str());
     }
 }
 

--- a/be/test/util/test_data/vmstat_normal
+++ b/be/test/util/test_data/vmstat_normal
@@ -1,0 +1,12 @@
+nr_free_pages 4631912
+nr_zone_inactive_anon 2399241
+nr_zone_active_anon 62962233
+nr_zone_inactive_file 14358369
+nr_zone_active_file 11459904
+nr_zone_unevictable 0
+pgpgin 21458611100
+pgpgout 149080494692
+pswpin 167785
+pswpout 203724
+swap_ra 3521
+swap_ra_hit 2219


### PR DESCRIPTION
# Proposed changes
1. add some metrics for cpu monitor;
2. add metrics for process state monitor;
3. add metrics for memory monitor;

It is convenient for us to use grafana to filter through different conditions.

After the added, we can find the cpu metrics like this：
doris_be_cpu{device="cpu1",mode="guest_nice"} 0
doris_be_cpu{device="cpu1",mode="guest"} 0
doris_be_cpu{device="cpu1",mode="steal"} 0
doris_be_cpu{device="cpu1",mode="soft_irq"} 107168
doris_be_cpu{device="cpu1",mode="irq"} 0
doris_be_cpu{device="cpu1",mode="iowait"} 3726931
doris_be_cpu{device="cpu1",mode="idle"} 2358039214
doris_be_cpu{device="cpu1",mode="system"} 58699464
doris_be_cpu{device="cpu1",mode="nice"} 1700438
doris_be_cpu{device="cpu1",mode="user"} 54974091

we can find the memory metrics as follow：
doris_be_memory_pswpin 167785
doris_be_memory_pswpout 203724
doris_be_memory_pgpgin 22308762092
doris_be_memory_pgpgout 152101956232


we also can find the process metrics as follow:
doris_be_proc{mode="interrupt"} 421721020416
doris_be_proc{mode="ctxt_switch"} 2806640907317
doris_be_proc{mode="procs_running"} 8
doris_be_proc{mode="procs_blocked"} 3

Issue Number: close #xxx

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (No)
5. Has unit tests been added: (No)
6. Has document been added or modified: (No)
7. Does it need to update dependencies: (No)
8. Are there any changes that cannot be rolled back: (No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
