### PR TITLE
[fix] Hive scan node user

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/planner/BrokerScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/BrokerScanNode.java
@@ -152,7 +152,7 @@ public class BrokerScanNode extends LoadScanNode {
         this.fileStatusesList = fileStatusesList;
         this.filesAdded = filesAdded;
         if (ConnectContext.get() != null) {
-            this.userIdentity = ConnectContext.get().getUserIdentity();
+            this.userIdentity = ConnectContext.get().getCurrentUserIdentity();
         }
     }
 
@@ -163,7 +163,7 @@ public class BrokerScanNode extends LoadScanNode {
         this.fileStatusesList = fileStatusesList;
         this.filesAdded = filesAdded;
         if (ConnectContext.get() != null) {
-            this.userIdentity = ConnectContext.get().getUserIdentity();
+            this.userIdentity = ConnectContext.get().getCurrentUserIdentity();
         }
     }
 


### PR DESCRIPTION
# Proposed changes

## Problem Summary:

**Fix the hive external table scan node null exception
Now hive external table query will fail when use local user@ip**

## Checklist(Required)

1. Does it affect the original behavior: (No)
2. Has unit tests been added: (No Need)
3. Has document been added or modified: (No Need)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (No)

## Further comments

