### PR TITLE
[feature](compaction) add some optimize for compaction

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -251,6 +251,10 @@ CONF_mInt64(base_compaction_num_cumulative_deltas, "5");
 CONF_mDouble(base_cumulative_delta_ratio, "0.3");
 CONF_mInt64(base_compaction_interval_seconds_since_last_operation, "86400");
 CONF_mInt32(base_compaction_write_mbytes_per_sec, "5");
+CONF_mInt32(base_compaction_max_rowset_num, "10");
+
+// dup key max base compaction size if no delete exist
+CONF_mInt32(max_dup_key_base_compaction_size_mbytes_when_no_delete, "1024");
 
 // config the cumulative compaction policy
 // Valid configs: num_based, size_based
@@ -292,7 +296,8 @@ CONF_mInt32(cumulative_compaction_skip_window_seconds, "30");
 CONF_mInt64(min_compaction_failure_interval_sec, "5"); // 5 seconds
 
 // This config can be set to limit thread number in compaction thread pool.
-CONF_mInt32(max_compaction_threads, "10");
+CONF_mInt32(max_base_compaction_threads, "4");
+CONF_mInt32(max_cumu_compaction_threads, "10");
 
 // This config can be set to limit thread number in convert rowset thread pool.
 CONF_mInt32(convert_rowset_thread_num, "0");

--- a/be/src/olap/compaction.cpp
+++ b/be/src/olap/compaction.cpp
@@ -158,6 +158,8 @@ Status Compaction::do_compaction_impl(int64_t permits) {
               << ". tablet=" << _tablet->full_name() << ", output_version=" << _output_version
               << ", current_max_version=" << current_max_version
               << ", disk=" << _tablet->data_dir()->path() << ", segments=" << segments_num
+              << ", input_row_num=" << _input_row_num
+              << ", output_row_num=" << _output_rowset->num_rows()
               << ". elapsed time=" << watch.get_elapse_second()
               << "s. cumulative_compaction_policy="
               << _tablet->cumulative_compaction_policy()->name() << ".";

--- a/be/src/olap/olap_server.cpp
+++ b/be/src/olap/olap_server.cpp
@@ -67,11 +67,16 @@ Status StorageEngine::start_bg_threads() {
         data_dirs.push_back(tmp_store.second);
     }
 
-    int32_t max_thread_num = config::max_compaction_threads;
-    ThreadPoolBuilder("CompactionTaskThreadPool")
+    int32_t max_thread_num = config::max_base_compaction_threads;
+    ThreadPoolBuilder("BaseCompactionTaskThreadPool")
             .set_min_threads(max_thread_num)
             .set_max_threads(max_thread_num)
-            .build(&_compaction_thread_pool);
+            .build(&_base_compaction_thread_pool);
+    max_thread_num = config::max_cumu_compaction_threads;
+    ThreadPoolBuilder("CumuCompactionTaskThreadPool")
+            .set_min_threads(max_thread_num)
+            .set_max_threads(max_thread_num)
+            .build(&_cumu_compaction_thread_pool);
 
     int32_t convert_rowset_thread_num = config::convert_rowset_thread_num;
     if (convert_rowset_thread_num > 0) {
@@ -320,6 +325,7 @@ void StorageEngine::_tablet_checkpoint_callback(const std::vector<DataDir*>& dat
     } while (!_stop_background_threads_latch.wait_for(std::chrono::seconds(interval)));
 }
 
+<<<<<<< HEAD
 void StorageEngine::_alpha_rowset_scan_thread_callback() {
     LOG(INFO) << "try to start alpha rowset scan thread!";
 
@@ -352,6 +358,46 @@ void StorageEngine::_alpha_rowset_scan_thread_callback() {
             scan_interval_sec = config::scan_alpha_rowset_min_interval_sec;
         }
     } while (!_stop_background_threads_latch.wait_for(std::chrono::seconds(scan_interval_sec)));
+=======
+void StorageEngine::_adjust_compaction_thread_num() {
+    if (_base_compaction_thread_pool->max_threads() != config::max_base_compaction_threads) {
+        int old_max_threads = _base_compaction_thread_pool->max_threads();
+        Status status =
+                _base_compaction_thread_pool->set_max_threads(config::max_base_compaction_threads);
+        if (status.ok()) {
+            VLOG_NOTICE << "update base compaction thread pool max_threads from " << old_max_threads
+                        << " to " << config::max_base_compaction_threads;
+        }
+    }
+    if (_base_compaction_thread_pool->min_threads() != config::max_base_compaction_threads) {
+        int old_min_threads = _base_compaction_thread_pool->min_threads();
+        Status status =
+                _base_compaction_thread_pool->set_min_threads(config::max_base_compaction_threads);
+        if (status.ok()) {
+            VLOG_NOTICE << "update base compaction thread pool min_threads from " << old_min_threads
+                        << " to " << config::max_base_compaction_threads;
+        }
+    }
+
+    if (_cumu_compaction_thread_pool->max_threads() != config::max_cumu_compaction_threads) {
+        int old_max_threads = _cumu_compaction_thread_pool->max_threads();
+        Status status =
+                _cumu_compaction_thread_pool->set_max_threads(config::max_cumu_compaction_threads);
+        if (status.ok()) {
+            VLOG_NOTICE << "update cumu compaction thread pool max_threads from " << old_max_threads
+                        << " to " << config::max_cumu_compaction_threads;
+        }
+    }
+    if (_cumu_compaction_thread_pool->min_threads() != config::max_cumu_compaction_threads) {
+        int old_min_threads = _cumu_compaction_thread_pool->min_threads();
+        Status status =
+                _cumu_compaction_thread_pool->set_min_threads(config::max_cumu_compaction_threads);
+        if (status.ok()) {
+            VLOG_NOTICE << "update cumu compaction thread pool min_threads from " << old_min_threads
+                        << " to " << config::max_cumu_compaction_threads;
+        }
+    }
+>>>>>>> [feature](compaction) add some optimize for compaction
 }
 
 void StorageEngine::_compaction_tasks_producer_callback() {
@@ -384,35 +430,7 @@ void StorageEngine::_compaction_tasks_producer_callback() {
     int64_t interval = config::generate_compaction_tasks_min_interval_ms;
     do {
         if (!config::disable_auto_compaction) {
-            VLOG_CRITICAL << "compaction thread pool. num_threads: "
-                          << _compaction_thread_pool->num_threads()
-                          << ", num_threads_pending_start: "
-                          << _compaction_thread_pool->num_threads_pending_start()
-                          << ", num_active_threads: "
-                          << _compaction_thread_pool->num_active_threads()
-                          << ", max_threads: " << _compaction_thread_pool->max_threads()
-                          << ", min_threads: " << _compaction_thread_pool->min_threads()
-                          << ", num_total_queued_tasks: "
-                          << _compaction_thread_pool->get_queue_size();
-
-            if (_compaction_thread_pool->max_threads() != config::max_compaction_threads) {
-                int old_max_threads = _compaction_thread_pool->max_threads();
-                Status status =
-                        _compaction_thread_pool->set_max_threads(config::max_compaction_threads);
-                if (status.ok()) {
-                    LOG(INFO) << "update compaction thread pool max_threads from "
-                              << old_max_threads << " to " << config::max_compaction_threads;
-                }
-            }
-            if (_compaction_thread_pool->min_threads() != config::max_compaction_threads) {
-                int old_min_threads = _compaction_thread_pool->min_threads();
-                Status status =
-                        _compaction_thread_pool->set_min_threads(config::max_compaction_threads);
-                if (status.ok()) {
-                    LOG(INFO) << "update compaction thread pool min_threads from "
-                              << old_min_threads << " to " << config::max_compaction_threads;
-                }
-            }
+            _adjust_compaction_thread_num();
 
             bool check_score = false;
             int64_t cur_time = UnixMillis();
@@ -431,6 +449,20 @@ void StorageEngine::_compaction_tasks_producer_callback() {
                     last_base_score_update_time = cur_time;
                 }
             }
+            std::unique_ptr<ThreadPool>& thread_pool =
+                    (compaction_type == CompactionType::CUMULATIVE_COMPACTION)
+                            ? _cumu_compaction_thread_pool
+                            : _base_compaction_thread_pool;
+            VLOG_CRITICAL << "compaction thread pool. type: "
+                          << (compaction_type == CompactionType::CUMULATIVE_COMPACTION ? "CUMU"
+                                                                                       : "BASE")
+                          << ", num_threads: " << thread_pool->num_threads()
+                          << ", num_threads_pending_start: "
+                          << thread_pool->num_threads_pending_start()
+                          << ", num_active_threads: " << thread_pool->num_active_threads()
+                          << ", max_threads: " << thread_pool->max_threads()
+                          << ", min_threads: " << thread_pool->min_threads()
+                          << ", num_total_queued_tasks: " << thread_pool->get_queue_size();
             std::vector<TabletSharedPtr> tablets_compaction =
                     _generate_compaction_tasks(compaction_type, data_dirs, check_score);
             if (tablets_compaction.size() == 0) {
@@ -613,7 +645,11 @@ Status StorageEngine::_submit_compaction_task(TabletSharedPtr tablet,
     int64_t permits = 0;
     Status st = tablet->prepare_compaction_and_calculate_permits(compaction_type, tablet, &permits);
     if (st.ok() && permits > 0 && _permit_limiter.request(permits)) {
-        auto st = _compaction_thread_pool->submit_func([=]() {
+        std::unique_ptr<ThreadPool>& thread_pool =
+                (compaction_type == CompactionType::CUMULATIVE_COMPACTION)
+                        ? _cumu_compaction_thread_pool
+                        : _base_compaction_thread_pool;
+        auto st = thread_pool->submit_func([=]() {
             SCOPED_ATTACH_TASK_THREAD(ThreadContext::TaskType::COMPACTION,
                                       tablet->get_compaction_mem_tracker(compaction_type));
             CgroupsMgr::apply_system_cgroup();

--- a/be/src/olap/storage_engine.cpp
+++ b/be/src/olap/storage_engine.cpp
@@ -157,8 +157,11 @@ StorageEngine::~StorageEngine() {
     DEREGISTER_HOOK_METRIC(schema_change_mem_consumption);
     _clear();
 
-    if (_compaction_thread_pool) {
-        _compaction_thread_pool->shutdown();
+    if (_base_compaction_thread_pool) {
+        _base_compaction_thread_pool->shutdown();
+    }
+    if (_cumu_compaction_thread_pool) {
+        _cumu_compaction_thread_pool->shutdown();
     }
     if (_convert_rowset_thread_pool) {
         _convert_rowset_thread_pool->shutdown();

--- a/be/src/olap/storage_engine.h
+++ b/be/src/olap/storage_engine.h
@@ -271,6 +271,8 @@ private:
 
     Status _submit_compaction_task(TabletSharedPtr tablet, CompactionType compaction_type);
 
+    void _adjust_compaction_thread_num();
+
 private:
     struct CompactionCandidate {
         CompactionCandidate(uint32_t nicumulative_compaction_, int64_t tablet_id_, uint32_t index_)
@@ -378,7 +380,8 @@ private:
 
     HeartbeatFlags* _heartbeat_flags;
 
-    std::unique_ptr<ThreadPool> _compaction_thread_pool;
+    std::unique_ptr<ThreadPool> _base_compaction_thread_pool;
+    std::unique_ptr<ThreadPool> _cumu_compaction_thread_pool;
 
     scoped_refptr<Thread> _alpha_rowset_scan_thread;
     std::unique_ptr<ThreadPool> _convert_rowset_thread_pool;

--- a/be/src/olap/tablet_manager.cpp
+++ b/be/src/olap/tablet_manager.cpp
@@ -650,7 +650,6 @@ TabletSharedPtr TabletManager::find_best_tablet_to_compaction(
                            << ", tablet_id=" << tablet_ptr->tablet_id();
                 continue;
             }
-
             if (compaction_type == CompactionType::BASE_COMPACTION) {
                 std::unique_lock<std::mutex> lock(tablet_ptr->get_base_compaction_lock(),
                                                   std::try_to_lock);

--- a/be/src/util/thread.cpp
+++ b/be/src/util/thread.cpp
@@ -73,6 +73,8 @@ public:
 
     static void set_thread_name(const std::string& name, int64_t tid);
 
+    static void set_thread_idle_sched(int64_t tid);
+
     // not the system TID, since pthread_t is less prone to being recycled.
     void add_thread(const pthread_t& pthread_id, const std::string& name,
                     const std::string& category, int64_t tid);
@@ -134,6 +136,17 @@ void ThreadMgr::set_thread_name(const std::string& name, int64_t tid) {
     int err = prctl(PR_SET_NAME, name.c_str());
     if (err < 0 && errno != EPERM) {
         LOG(ERROR) << "set_thread_name";
+    }
+}
+
+void ThreadMgr::set_thread_idle_sched(int64_t tid) {
+    if (tid == getpid()) {
+        return;
+    }
+    struct sched_param sp = {.sched_priority = 0};
+    int err = sched_setscheduler(0, SCHED_IDLE, &sp);
+    if (err < 0 && errno != EPERM) {
+        LOG(ERROR) << "set_thread_idle_sched";
     }
 }
 
@@ -260,6 +273,10 @@ Thread::~Thread() {
 
 void Thread::set_self_name(const std::string& name) {
     ThreadMgr::set_thread_name(name, current_thread_id());
+}
+
+void Thread::set_thread_idle_sched() {
+    ThreadMgr::set_thread_idle_sched(current_thread_id());
 }
 
 void Thread::join() {

--- a/be/src/util/thread.h
+++ b/be/src/util/thread.h
@@ -89,6 +89,8 @@ public:
 
     static void set_self_name(const std::string& name);
 
+    static void set_thread_idle_sched();
+
     ~Thread();
 
     // Blocks until this thread finishes execution. Once this method returns, the thread


### PR DESCRIPTION
1. seperate base and cu compaction thread pool
origin thread pool may all be held by base compaction, a case is
be has 8 dirs, each dir can have 4 task at the same time, even
every dir will reserve one slot for cumu compaction, (4-1)*8=24 is
much more bigger than max compaction thread num 10.

2.set base compaction idle schedule to run in low priority

3.remove base compaction for dup key if no delete_predict applied,
  base compaction waste a lot of cpu&io for dup model.

4.add a max_rowset_num limit for base compaction in case base compaction
  run too long

# Proposed changes

Issue Number: close #xxx

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
