### PR TITLE
[feature](storage) rowset meta add tablet schema for future use

### DIFF
--- a/be/src/olap/data_dir.cpp
+++ b/be/src/olap/data_dir.cpp
@@ -493,6 +493,9 @@ Status DataDir::load() {
                           << " to tablet: " << rowset_meta->tablet_id()
                           << " schema hash: " << rowset_meta->tablet_schema_hash()
                           << " for txn: " << rowset_meta->txn_id();
+                if (rowset_meta->tablet_schema() == nullptr) {
+                    rowset_meta->set_tablet_schema(tablet->tablet_schema());
+                }
             }
         } else if (rowset_meta->rowset_state() == RowsetStatePB::VISIBLE &&
                    rowset_meta->tablet_uid() == tablet->tablet_uid()) {
@@ -504,6 +507,9 @@ Status DataDir::load() {
                              << " txn id:" << rowset_meta->txn_id()
                              << " start_version: " << rowset_meta->version().first
                              << " end_version: " << rowset_meta->version().second;
+            }
+            if (rowset_meta->tablet_schema() == nullptr) {
+                rowset_meta->set_tablet_schema(tablet->tablet_schema());
             }
         } else {
             LOG(WARNING) << "find invalid rowset: " << rowset_meta->rowset_id()

--- a/be/src/olap/rowset/beta_rowset_writer.cpp
+++ b/be/src/olap/rowset/beta_rowset_writer.cpp
@@ -93,6 +93,7 @@ Status BetaRowsetWriter::init(const RowsetWriterContext& rowset_writer_context) 
         _rowset_meta->set_version(_context.version);
     }
     _rowset_meta->set_tablet_uid(_context.tablet_uid);
+    _rowset_meta->set_tablet_schema(*_context.tablet_schema);
 
     return Status::OK();
 }

--- a/be/src/olap/rowset/rowset.cpp
+++ b/be/src/olap/rowset/rowset.cpp
@@ -35,6 +35,7 @@ Rowset::Rowset(const TabletSchema* schema, const FilePathDesc& rowset_path_desc,
         Version version = _rowset_meta->version();
         _is_cumulative = version.first != version.second;
     }
+    _schema = schema;
 }
 
 Status Rowset::load(bool use_cache) {

--- a/be/src/olap/rowset/rowset.h
+++ b/be/src/olap/rowset/rowset.h
@@ -252,6 +252,7 @@ public:
             }
         }
     }
+    const TabletSchema* tablet_schema() { return _schema; }
 
 protected:
     friend class RowsetFactory;

--- a/be/src/olap/tablet_schema.cpp
+++ b/be/src/olap/tablet_schema.cpp
@@ -350,7 +350,7 @@ void TabletColumn::init_from_pb(const ColumnPB& column) {
     }
 }
 
-void TabletColumn::to_schema_pb(ColumnPB* column) {
+void TabletColumn::to_schema_pb(ColumnPB* column) const {
     column->set_unique_id(_unique_id);
     column->set_name(_col_name);
     column->set_type(get_string_by_field_type(_type));
@@ -444,7 +444,7 @@ void TabletSchema::init_from_pb(const TabletSchemaPB& schema) {
     _compression_type = schema.compression_type();
 }
 
-void TabletSchema::to_schema_pb(TabletSchemaPB* tablet_meta_pb) {
+void TabletSchema::to_schema_pb(TabletSchemaPB* tablet_meta_pb) const {
     tablet_meta_pb->set_keys_type(_keys_type);
     for (auto& col : _cols) {
         ColumnPB* column = tablet_meta_pb->add_column();

--- a/be/src/olap/tablet_schema.h
+++ b/be/src/olap/tablet_schema.h
@@ -37,7 +37,7 @@ public:
     TabletColumn(FieldAggregationMethod agg, FieldType filed_type, bool is_nullable,
                  int32_t unique_id, size_t length);
     void init_from_pb(const ColumnPB& column);
-    void to_schema_pb(ColumnPB* column);
+    void to_schema_pb(ColumnPB* column) const;
     uint32_t mem_size() const;
 
     int32_t unique_id() const { return _unique_id; }
@@ -122,7 +122,7 @@ public:
     // void create_from_pb(const TabletSchemaPB& schema, TabletSchema* tablet_schema).
     TabletSchema() = default;
     void init_from_pb(const TabletSchemaPB& schema);
-    void to_schema_pb(TabletSchemaPB* tablet_meta_pb);
+    void to_schema_pb(TabletSchemaPB* tablet_meta_pb) const;
     uint32_t mem_size() const;
 
     size_t row_size() const;

--- a/gensrc/proto/olap_file.proto
+++ b/gensrc/proto/olap_file.proto
@@ -93,6 +93,8 @@ message RowsetMetaPB {
     optional int64 num_segments = 22;
     // rowset id definition, it will replace required rowset id 
     optional string rowset_id_v2 = 23;
+    // tablet schema,
+    optional TabletSchemaPB tablet_schema = 24;
     // spare field id for future use
     optional AlphaRowsetExtraMetaPB alpha_rowset_extra_meta_pb = 50;
     // to indicate whether the data between the segments overlap


### PR DESCRIPTION
rowset persist tablet schema for future use, such as fast schema change
or compatiable type upgrade. Init rowset meta while be start up so every
rowset will have a tablet schema so we can handle it without too much
code like:
if (rowset_meta.has_schema()) {
    xxxx
} else {
    xxxx
}

# Proposed changes

Issue Number: close #xxx

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
