### PR TITLE
[Enhancement] Refactor functions in int_exp by templates

### DIFF
--- a/be/src/vec/common/int_exp.h
+++ b/be/src/vec/common/int_exp.h
@@ -22,6 +22,30 @@
 
 #include <cstdint>
 #include <limits>
+#include <utility>
+
+namespace exp_details {
+
+template <typename T, T v, std::size_t n>
+constexpr inline const T exp = v * exp<T, v, n - 1>;
+
+template <typename T, T v>
+constexpr inline const T exp<T, v, 0> = 1;
+
+template <typename T, T v, std::size_t ...I>
+constexpr inline const T exp_table[] = { exp<T, v, I>... };
+
+template <typename T, T v, std::size_t ...I>
+constexpr T exp_maker_helper(std::size_t x, std::index_sequence<I...>) {
+    return exp_table<T, v, I...>[x];
+}
+
+template <typename T, T v, std::size_t N>
+constexpr T exp_maker(std::size_t x) {
+    return exp_maker_helper<T, v>(x, std::make_index_sequence<N>{});
+}
+
+}
 
 /// On overlow, the function returns unspecified value.
 
@@ -33,103 +57,21 @@ inline uint64_t int_exp10(int x) {
     if (x < 0) return 0;
     if (x > 19) return std::numeric_limits<uint64_t>::max();
 
-    static const uint64_t table[20] = {1ULL,
-                                       10ULL,
-                                       100ULL,
-                                       1000ULL,
-                                       10000ULL,
-                                       100000ULL,
-                                       1000000ULL,
-                                       10000000ULL,
-                                       100000000ULL,
-                                       1000000000ULL,
-                                       10000000000ULL,
-                                       100000000000ULL,
-                                       1000000000000ULL,
-                                       10000000000000ULL,
-                                       100000000000000ULL,
-                                       1000000000000000ULL,
-                                       10000000000000000ULL,
-                                       100000000000000000ULL,
-                                       1000000000000000000ULL,
-                                       10000000000000000000ULL};
-
-    return table[x];
+    return exp_details::exp_maker<uint64_t, 10, 20>(x);
 }
 
 namespace common {
 
-inline int exp10_i32(int x) {
-    static const int values[] = {1,      10,      100,      1000,      10000,
-                                 100000, 1000000, 10000000, 100000000, 1000000000};
-    return values[x];
+inline std::int32_t exp10_i32(int x) {
+    return exp_details::exp_maker<std::int32_t, 10, 10>(x);
 }
 
-inline int64_t exp10_i64(int x) {
-    static const int64_t values[] = {1ll,
-                                     10ll,
-                                     100ll,
-                                     1000ll,
-                                     10000ll,
-                                     100000ll,
-                                     1000000ll,
-                                     10000000ll,
-                                     100000000ll,
-                                     1000000000ll,
-                                     10000000000ll,
-                                     100000000000ll,
-                                     1000000000000ll,
-                                     10000000000000ll,
-                                     100000000000000ll,
-                                     1000000000000000ll,
-                                     10000000000000000ll,
-                                     100000000000000000ll,
-                                     1000000000000000000ll};
-    return values[x];
+inline std::int64_t exp10_i64(int x) {
+    return exp_details::exp_maker<std::int64_t, 10, 19>(x);
 }
 
 inline __int128 exp10_i128(int x) {
-    static const __int128 values[] = {
-            static_cast<__int128>(1ll),
-            static_cast<__int128>(10ll),
-            static_cast<__int128>(100ll),
-            static_cast<__int128>(1000ll),
-            static_cast<__int128>(10000ll),
-            static_cast<__int128>(100000ll),
-            static_cast<__int128>(1000000ll),
-            static_cast<__int128>(10000000ll),
-            static_cast<__int128>(100000000ll),
-            static_cast<__int128>(1000000000ll),
-            static_cast<__int128>(10000000000ll),
-            static_cast<__int128>(100000000000ll),
-            static_cast<__int128>(1000000000000ll),
-            static_cast<__int128>(10000000000000ll),
-            static_cast<__int128>(100000000000000ll),
-            static_cast<__int128>(1000000000000000ll),
-            static_cast<__int128>(10000000000000000ll),
-            static_cast<__int128>(100000000000000000ll),
-            static_cast<__int128>(1000000000000000000ll),
-            static_cast<__int128>(1000000000000000000ll) * 10ll,
-            static_cast<__int128>(1000000000000000000ll) * 100ll,
-            static_cast<__int128>(1000000000000000000ll) * 1000ll,
-            static_cast<__int128>(1000000000000000000ll) * 10000ll,
-            static_cast<__int128>(1000000000000000000ll) * 100000ll,
-            static_cast<__int128>(1000000000000000000ll) * 1000000ll,
-            static_cast<__int128>(1000000000000000000ll) * 10000000ll,
-            static_cast<__int128>(1000000000000000000ll) * 100000000ll,
-            static_cast<__int128>(1000000000000000000ll) * 1000000000ll,
-            static_cast<__int128>(1000000000000000000ll) * 10000000000ll,
-            static_cast<__int128>(1000000000000000000ll) * 100000000000ll,
-            static_cast<__int128>(1000000000000000000ll) * 1000000000000ll,
-            static_cast<__int128>(1000000000000000000ll) * 10000000000000ll,
-            static_cast<__int128>(1000000000000000000ll) * 100000000000000ll,
-            static_cast<__int128>(1000000000000000000ll) * 1000000000000000ll,
-            static_cast<__int128>(1000000000000000000ll) * 10000000000000000ll,
-            static_cast<__int128>(1000000000000000000ll) * 100000000000000000ll,
-            static_cast<__int128>(1000000000000000000ll) * 100000000000000000ll * 10ll,
-            static_cast<__int128>(1000000000000000000ll) * 100000000000000000ll * 100ll,
-            static_cast<__int128>(1000000000000000000ll) * 100000000000000000ll * 1000ll};
-    return values[x];
+    return exp_details::exp_maker<__int128, 10, 39>(x);
 }
 
 } // namespace common

--- a/be/src/vec/common/int_exp.h
+++ b/be/src/vec/common/int_exp.h
@@ -26,23 +26,27 @@
 
 namespace exp_details {
 
+// compile-time exp(v, n) by linear recursion
 template <typename T, T v, std::size_t n>
 constexpr inline const T exp = v * exp<T, v, n - 1>;
 
 template <typename T, T v>
 constexpr inline const T exp<T, v, 0> = 1;
 
+// compile-time exponentiation table { exp(v, I) ... }
 template <typename T, T v, std::size_t ...I>
 constexpr inline const T exp_table[] = { exp<T, v, I>... };
 
+// get value from compile-time exponentiation table by a (maybe) runtime offset
 template <typename T, T v, std::size_t ...I>
-constexpr T exp_maker_helper(std::size_t x, std::index_sequence<I...>) {
+constexpr T get_exp_helper(std::size_t x, std::index_sequence<I...>) {
     return exp_table<T, v, I...>[x];
 }
 
+// get_exp_helper with table { exp(v, 0), exp(v, 1) ... exp(v, N) }
 template <typename T, T v, std::size_t N>
-constexpr T exp_maker(std::size_t x) {
-    return exp_maker_helper<T, v>(x, std::make_index_sequence<N>{});
+constexpr T get_exp(std::size_t x) {
+    return get_exp_helper<T, v>(x, std::make_index_sequence<N>{});
 }
 
 }
@@ -57,21 +61,21 @@ inline uint64_t int_exp10(int x) {
     if (x < 0) return 0;
     if (x > 19) return std::numeric_limits<uint64_t>::max();
 
-    return exp_details::exp_maker<uint64_t, 10, 20>(x);
+    return exp_details::get_exp<uint64_t, 10, 20>(x);
 }
 
 namespace common {
 
 inline std::int32_t exp10_i32(int x) {
-    return exp_details::exp_maker<std::int32_t, 10, 10>(x);
+    return exp_details::get_exp<std::int32_t, 10, 10>(x);
 }
 
 inline std::int64_t exp10_i64(int x) {
-    return exp_details::exp_maker<std::int64_t, 10, 19>(x);
+    return exp_details::get_exp<std::int64_t, 10, 19>(x);
 }
 
 inline __int128 exp10_i128(int x) {
-    return exp_details::exp_maker<__int128, 10, 39>(x);
+    return exp_details::get_exp<__int128, 10, 39>(x);
 }
 
 } // namespace common

--- a/be/src/vec/common/int_exp.h
+++ b/be/src/vec/common/int_exp.h
@@ -28,7 +28,7 @@ namespace exp_details {
 
 // compile-time exp(v, n) by linear recursion
 template <typename T, T v, std::size_t n>
-constexpr inline const T exp = v* exp<T, v, n - 1>;
+constexpr inline const T exp = T(v) * exp<T, v, n - 1>;
 
 template <typename T, T v>
 constexpr inline const T exp<T, v, 0> = 1;

--- a/be/src/vec/common/int_exp.h
+++ b/be/src/vec/common/int_exp.h
@@ -28,28 +28,28 @@ namespace exp_details {
 
 // compile-time exp(v, n) by linear recursion
 template <typename T, T v, std::size_t n>
-constexpr inline const T exp = v * exp<T, v, n - 1>;
+constexpr inline const T exp = v* exp<T, v, n - 1>;
 
 template <typename T, T v>
 constexpr inline const T exp<T, v, 0> = 1;
 
 // compile-time exponentiation table { exp(v, I) ... }
-template <typename T, T v, std::size_t ...I>
-constexpr inline const T exp_table[] = { exp<T, v, I>... };
+template <typename T, T v, std::size_t... I>
+constexpr inline const T exp_table[] = {exp<T, v, I>...};
 
 // get value from compile-time exponentiation table by a (maybe) runtime offset
-template <typename T, T v, std::size_t ...I>
+template <typename T, T v, std::size_t... I>
 constexpr T get_exp_helper(std::size_t x, std::index_sequence<I...>) {
     return exp_table<T, v, I...>[x];
 }
 
-// get_exp_helper with table { exp(v, 0), exp(v, 1) ... exp(v, N) }
+// get_exp_helper with table { exp(v, 0), exp(v, 1) ... exp(v, N - 1) }
 template <typename T, T v, std::size_t N>
 constexpr T get_exp(std::size_t x) {
-    return get_exp_helper<T, v>(x, std::make_index_sequence<N>{});
+    return get_exp_helper<T, v>(x, std::make_index_sequence<N> {});
 }
 
-}
+} // namespace exp_details
 
 /// On overlow, the function returns unspecified value.
 


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

The current implementation of functions in `int_exp.h` used some hand-written, hard-coded arrays, which made the code lengthy. 
These functions can be rewritten using templates, which is more generalized and less error-prone.

Supervised by @jackwener. :kissing_heart:

## Checklist(Required)

1. Does it affect the original behavior: (No)
2. Has unit tests been added: (?)
3. Has document been added or modified: (No Need)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (No)

