### PR TITLE
[Enhancement] Column prune for olap scan node

### DIFF
--- a/be/src/exec/olap_scan_node.h
+++ b/be/src/exec/olap_scan_node.h
@@ -150,6 +150,8 @@ protected:
     // according to the calling relationship
     void init_scan_profile();
 
+    void init_output_slots();
+
     bool should_push_down_in_predicate(SlotDescriptor* slot, InPredicate* in_pred);
 
     template <typename T, typename ChangeFixedValueRangeFunc>
@@ -240,6 +242,10 @@ protected:
 
     int _total_assign_num;
     int _nice;
+
+    std::vector<SlotId> _output_slot_ids;
+
+    std::vector<bool> _output_slot_flags;
 
     // protect _status, for many thread may change _status
     SpinLock _status_mutex;

--- a/be/src/exec/olap_scanner.cpp
+++ b/be/src/exec/olap_scanner.cpp
@@ -237,7 +237,9 @@ Status OlapScanner::_init_tablet_reader_params(
 }
 
 Status OlapScanner::_init_return_columns() {
-    for (auto slot : _tuple_desc->slots()) {
+    auto slots = _tuple_desc->slots();
+    for (int i = 0; i < slots.size(); i++) {
+        auto slot = slots[i];
         if (!slot->is_materialized()) {
             continue;
         }

--- a/be/src/olap/rowset/segment_v2/segment_iterator.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.cpp
@@ -800,7 +800,9 @@ void SegmentIterator::_init_current_block(
         // the column in block must clear() here to insert new data
         if (_is_pred_column[cid] ||
             i >= block->columns()) { //todo(wb) maybe we can release it after output block
-            current_columns[cid]->clear();
+            if (current_columns[cid] != nullptr) {
+                current_columns[cid]->clear();
+            }
         } else { // non-predicate column
             current_columns[cid] = std::move(*block->get_by_position(i).column).mutate();
 

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/AggregationNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/AggregationNode.java
@@ -346,4 +346,5 @@ public class AggregationNode extends PlanNode {
         result.addAll(aggregateSlotIds);
         return result;
     }
+
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/HashJoinNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/HashJoinNode.java
@@ -723,14 +723,6 @@ public class HashJoinNode extends PlanNode {
         }
         output.append(detailPrefix).append(String.format(
                 "cardinality=%s", cardinality)).append("\n");
-        // todo unify in plan node
-        if (outputSlotIds != null) {
-            output.append(detailPrefix).append("output slot ids: ");
-            for (SlotId slotId : outputSlotIds) {
-                output.append(slotId).append(" ");
-            }
-            output.append("\n");
-        }
         if (hashOutputSlotIds != null) {
             output.append(detailPrefix).append("hash output slot ids: ");
             for (SlotId slotId : hashOutputSlotIds) {
@@ -738,6 +730,7 @@ public class HashJoinNode extends PlanNode {
             }
             output.append("\n");
         }
+        appendCommonExplainString(detailPrefix, output);
         return output.toString();
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/OlapScanNode.java
@@ -26,6 +26,7 @@ import org.apache.doris.analysis.InPredicate;
 import org.apache.doris.analysis.IntLiteral;
 import org.apache.doris.analysis.PartitionNames;
 import org.apache.doris.analysis.SlotDescriptor;
+import org.apache.doris.analysis.SlotId;
 import org.apache.doris.analysis.SlotRef;
 import org.apache.doris.analysis.TupleDescriptor;
 import org.apache.doris.analysis.TupleId;
@@ -48,6 +49,7 @@ import org.apache.doris.catalog.Tablet;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.ErrorReport;
+import org.apache.doris.common.NotImplementedException;
 import org.apache.doris.common.UserException;
 import org.apache.doris.common.util.Util;
 import org.apache.doris.qe.ConnectContext;
@@ -746,7 +748,7 @@ public class OlapScanNode extends ScanNode {
         output.append(prefix).append(String.format(
                 "numNodes=%s", numNodes));
         output.append("\n");
-
+        appendCommonExplainString(prefix, output);
         return output.toString();
     }
 
@@ -939,6 +941,19 @@ public class OlapScanNode extends ScanNode {
             return DataPartition.hashPartitioned(dataDistributeExprs);
         } else {
             return DataPartition.RANDOM;
+        }
+    }
+
+    @Override
+    public void initOutputSlotIds(Set<SlotId> requiredSlotIdSet, Analyzer analyzer) throws NotImplementedException {
+        outputSlotIds = Lists.newArrayList();
+        for (TupleId tupleId : tupleIds) {
+            for (SlotDescriptor slotDescriptor : analyzer.getTupleDesc(tupleId).getSlots()) {
+                if (slotDescriptor.isMaterialized() &&
+                    (requiredSlotIdSet == null || requiredSlotIdSet.contains(slotDescriptor.getId()))) {
+                    outputSlotIds.add(slotDescriptor.getId());
+                }
+            }
         }
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/PlanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/PlanNode.java
@@ -984,4 +984,17 @@ abstract public class PlanNode extends TreeNode<PlanNode> {
         sb.append("\n").append(getNodeExplainString("", TExplainLevel.BRIEF));
         return sb.toString();
     }
+
+    /**
+     * Used to append some common explains to output
+     */
+    protected void appendCommonExplainString(String detailPrefix, StringBuilder output) {
+        if (outputSlotIds != null) {
+            output.append(detailPrefix).append("output slot ids: ");
+            for (SlotId slotId : outputSlotIds) {
+                output.append(slotId).append(" ");
+            }
+            output.append("\n");
+        }
+    }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/planner/ProjectPlannerFunctionTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/planner/ProjectPlannerFunctionTest.java
@@ -108,4 +108,57 @@ public class ProjectPlannerFunctionTest {
         Assert.assertTrue(explainString.contains("output slot ids: 1"));
         Assert.assertTrue(explainString.contains("hash output slot ids: 1 2 3"));
     }
+
+    @Test
+    public void projectOlap() throws Exception {
+        String createOrdersTbl = "CREATE TABLE test.`orders` (\n" +
+            "  `o_orderkey` integer NOT NULL,\n" +
+            "  `o_custkey` integer NOT NULL,\n" +
+            "  `o_orderstatus` char(1) NOT NULL,\n" +
+            "  `o_totalprice` decimal(12, 2) NOT NULL,\n" +
+            "  `o_orderdate` date NOT NULL,\n" +
+            "  `o_orderpriority` char(15) NOT NULL,\n" +
+            "  `o_clerk` char(15) NOT NULL,\n" +
+            "  `o_shippriority` integer NOT NULL,\n" +
+            "  `o_comment` varchar(79) NOT NULL\n" +
+            ") DISTRIBUTED BY HASH(`o_orderkey`) BUCKETS 32 PROPERTIES (\"replication_num\" = \"1\");";
+        CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameUtils.parseAndAnalyzeStmt(createOrdersTbl, connectContext);
+        Catalog.getCurrentCatalog().createTable(createTableStmt);
+
+        String createCustomerTbl = "CREATE TABLE test.`customer` (\n" +
+            "  `c_custkey` integer NOT NULL,\n" +
+            "  `c_name` varchar(25) NOT NULL,\n" +
+            "  `c_address` varchar(40) NOT NULL,\n" +
+            "  `c_nationkey` integer NOT NULL,\n" +
+            "  `c_phone` char(15) NOT NULL,\n" +
+            "  `c_acctbal` decimal(12, 2) NOT NULL,\n" +
+            "  `c_mktsegment` char(10) NOT NULL,\n" +
+            "  `c_comment` varchar(117) NOT NULL\n" +
+            ") DISTRIBUTED BY HASH(`c_custkey`) BUCKETS 32 PROPERTIES (\"replication_num\" = \"1\");";
+        createTableStmt = (CreateTableStmt) UtFrameUtils.parseAndAnalyzeStmt(createCustomerTbl, connectContext);
+        Catalog.getCurrentCatalog().createTable(createTableStmt);
+        String tpcH13 = "select\n" +
+            "    c_count,\n" +
+            "    count(*) as custdist\n" +
+            "from\n" +
+            "    (\n" +
+            "        select\n" +
+            "            c_custkey,\n" +
+            "            count(o_orderkey) as c_count\n" +
+            "        from\n" +
+            "            test.customer left outer join test.orders on\n" +
+            "                c_custkey = o_custkey\n" +
+            "                and o_comment not like '%special%requests%'\n" +
+            "        group by\n" +
+            "            c_custkey\n" +
+            "    ) as c_orders\n" +
+            "group by\n" +
+            "    c_count\n" +
+            "order by\n" +
+            "    custdist desc,\n" +
+            "    c_count desc;";
+        String explainString = UtFrameUtils.getSQLPlanOrErrorMsg(connectContext, tpcH13);
+        Assert.assertTrue(explainString.contains("output slot ids: 1 3"));
+
+    }
 }


### PR DESCRIPTION
# Proposed changes

Add Column prune for olap scan node based on the project planner framework

## Problem Summary:

Implement the `initOutputSlotIds`  method

## Checklist(Required)

1. Does it affect the original behavior: (Yes)
2. Has unit tests been added: (Yes)
3. Has document been added or modified: (No Need)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (No)

