### PR TITLE
[fix][mem tracker] Fix logout load task mem tracker dcheck fail

### DIFF
--- a/be/src/runtime/load_channel.cpp
+++ b/be/src/runtime/load_channel.cpp
@@ -34,8 +34,8 @@ LoadChannel::LoadChannel(const UniqueId& load_id, int64_t mem_limit, int64_t tim
           _is_vec(is_vec) {
     _mem_tracker = MemTracker::create_tracker(
             mem_limit, "LoadChannel:tabletId=" + _load_id.to_string(),
-            ExecEnv::GetInstance()->task_pool_mem_tracker_registry()->get_task_mem_tracker(
-                    _load_id.to_string()),
+            ExecEnv::GetInstance()->task_pool_mem_tracker_registry()->register_load_mem_tracker(
+                    _load_id.to_string(), mem_limit),
             MemTrackerLevel::TASK);
     // _last_updated_time should be set before being inserted to
     // _load_channels in load_channel_mgr, or it may be erased

--- a/be/src/runtime/mem_tracker_task_pool.cpp
+++ b/be/src/runtime/mem_tracker_task_pool.cpp
@@ -89,9 +89,14 @@ void MemTrackerTaskPool::logout_task_mem_tracker() {
         }
     }
     for (auto tid : expired_tasks) {
-        DCHECK(_task_mem_trackers[tid].use_count() == 1);
-        _task_mem_trackers.erase(tid);
-        VLOG_FILE << "Deregister task memory tracker, task id: " << tid;
+        // This means that after all RuntimeState is destructed,
+        // there are still task mem trackers that are get or register.
+        // The only known case: after an import task ends all fragments on a BE,`tablet_writer_open` is still
+        // called to create a channel, and the load task tracker will be re-registered in the channel open.
+        if (_task_mem_trackers[tid].use_count() == 1) {
+            _task_mem_trackers.erase(tid);
+            VLOG_FILE << "Deregister task memory tracker, task id: " << tid;
+        }
     }
 }
 

--- a/be/src/runtime/mem_tracker_task_pool.cpp
+++ b/be/src/runtime/mem_tracker_task_pool.cpp
@@ -91,7 +91,7 @@ void MemTrackerTaskPool::logout_task_mem_tracker() {
     for (auto tid : expired_tasks) {
         // This means that after all RuntimeState is destructed,
         // there are still task mem trackers that are get or register.
-        // The only known case: after an import task ends all fragments on a BE,`tablet_writer_open` is still
+        // The only known case: after an load task ends all fragments on a BE,`tablet_writer_open` is still
         // called to create a channel, and the load task tracker will be re-registered in the channel open.
         if (_task_mem_trackers[tid].use_count() == 1) {
             _task_mem_trackers.erase(tid);


### PR DESCRIPTION
# Proposed changes

Issue Number: close #9905

## Problem Summary:

The load task mem tracker is incorrectly logout, this happens when:
After an load task ends all fragments on a BE,`tablet_writer_open` is still called to create a channel, and the load task tracker will be re-registered in the channel open.

## Checklist(Required)

1. Does it affect the original behavior: (Yes)
2. Has unit tests been added: (No)
3. Has document been added or modified: (No Need)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
