### PR TITLE
Remove the redundant ”this.”

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/ColocateGroupSchema.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/ColocateGroupSchema.java
@@ -126,7 +126,7 @@ public class ColocateGroupSchema implements Writable {
             ColumnType.write(out, type);
         }
         out.writeInt(bucketsNum);
-        this.replicaAlloc.write(out);
+        replicaAlloc.write(out);
     }
 
     public void readFields(DataInput in) throws IOException {
@@ -138,9 +138,9 @@ public class ColocateGroupSchema implements Writable {
         bucketsNum = in.readInt();
         if (Catalog.getCurrentCatalogJournalVersion() < FeMetaVersion.VERSION_105) {
             short replicationNum = in.readShort();
-            this.replicaAlloc = new ReplicaAllocation(replicationNum);
+            replicaAlloc = new ReplicaAllocation(replicationNum);
         } else {
-            this.replicaAlloc = ReplicaAllocation.read(in);
+            replicaAlloc = ReplicaAllocation.read(in);
         }
     }
 }


### PR DESCRIPTION
# Proposed changes

Issue Number: no relative issue

## Problem Summary:
In Java, we can use `this.` to access class member variables.
However, In most scenario, `this.` is redundant, just use in constructor functions.We can remove it from non-constructor functions.

## Checklist(Required)

1. Does it affect the original behavior: No
2. Has unit tests been added: No
3. Has document been added or modified: No
4. Does it need to update dependencies: No
5. Are there any changes that cannot be rolled back: No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
