### PR TITLE
Remove the redundant "this."

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/task/AgentBatchTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/task/AgentBatchTask.java
@@ -64,7 +64,7 @@ public class AgentBatchTask implements Runnable {
     private Map<Long, List<AgentTask>> backendIdToTasks;
 
     public AgentBatchTask() {
-         backendIdToTasks = new HashMap<Long, List<AgentTask>>();
+        backendIdToTasks = new HashMap<Long, List<AgentTask>>();
     }
 
     public AgentBatchTask(AgentTask singleTask) {
@@ -89,8 +89,8 @@ public class AgentBatchTask implements Runnable {
 
     public List<AgentTask> getAllTasks() {
         List<AgentTask> tasks = new LinkedList<AgentTask>();
-        for (Long backendId :  backendIdToTasks.keySet()) {
-            tasks.addAll( backendIdToTasks.get(backendId));
+        for (Long backendId : backendIdToTasks.keySet()) {
+            tasks.addAll(backendIdToTasks.get(backendId));
         }
         return tasks;
     }
@@ -107,7 +107,7 @@ public class AgentBatchTask implements Runnable {
     // NOTICE that even if AgentTask.isFinished() return false, it does not mean that task is not finished.
     // this depends on caller's logic. See comments on 'isFinished' member.
     public boolean isFinished() {
-        for (List<AgentTask> tasks :  backendIdToTasks.values()) {
+        for (List<AgentTask> tasks : backendIdToTasks.values()) {
             for (AgentTask agentTask : tasks) {
                 if (!agentTask.isFinished()) {
                     return false;
@@ -120,7 +120,7 @@ public class AgentBatchTask implements Runnable {
     // return the limit number of unfinished tasks.
     public List<AgentTask> getUnfinishedTasks(int limit) {
         List<AgentTask> res = Lists.newArrayList();
-        for (List<AgentTask> tasks :  backendIdToTasks.values()) {
+        for (List<AgentTask> tasks : backendIdToTasks.values()) {
             for (AgentTask agentTask : tasks) {
                 if (!agentTask.isFinished()) {
                     if (res.size() < limit) {
@@ -134,7 +134,7 @@ public class AgentBatchTask implements Runnable {
 
     public int getFinishedTaskNum() {
         int count = 0;
-        for (List<AgentTask> tasks :  backendIdToTasks.values()) {
+        for (List<AgentTask> tasks : backendIdToTasks.values()) {
             for (AgentTask agentTask : tasks) {
                 if (agentTask.isFinished()) {
                     count++;
@@ -146,7 +146,7 @@ public class AgentBatchTask implements Runnable {
 
     @Override
     public void run() {
-        for (Long backendId :  backendIdToTasks.keySet()) {
+        for (Long backendId : backendIdToTasks.keySet()) {
             BackendService.Client client = null;
             TNetworkAddress address = null;
             boolean ok = false;
@@ -155,7 +155,7 @@ public class AgentBatchTask implements Runnable {
                 if (backend == null || !backend.isAlive()) {
                     continue;
                 }
-                List<AgentTask> tasks =  backendIdToTasks.get(backendId);
+                List<AgentTask> tasks = backendIdToTasks.get(backendId);
                 // create AgentClient
                 String host = FeConstants.runningUnitTest ? "127.0.0.1" : backend.getHost();
                 address = new TNetworkAddress(host, backend.getBePort());

--- a/fe/fe-core/src/main/java/org/apache/doris/task/AgentBatchTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/task/AgentBatchTask.java
@@ -64,7 +64,7 @@ public class AgentBatchTask implements Runnable {
     private Map<Long, List<AgentTask>> backendIdToTasks;
 
     public AgentBatchTask() {
-        this.backendIdToTasks = new HashMap<Long, List<AgentTask>>();
+         backendIdToTasks = new HashMap<Long, List<AgentTask>>();
     }
 
     public AgentBatchTask(AgentTask singleTask) {
@@ -89,8 +89,8 @@ public class AgentBatchTask implements Runnable {
 
     public List<AgentTask> getAllTasks() {
         List<AgentTask> tasks = new LinkedList<AgentTask>();
-        for (Long backendId : this.backendIdToTasks.keySet()) {
-            tasks.addAll(this.backendIdToTasks.get(backendId));
+        for (Long backendId :  backendIdToTasks.keySet()) {
+            tasks.addAll( backendIdToTasks.get(backendId));
         }
         return tasks;
     }
@@ -107,7 +107,7 @@ public class AgentBatchTask implements Runnable {
     // NOTICE that even if AgentTask.isFinished() return false, it does not mean that task is not finished.
     // this depends on caller's logic. See comments on 'isFinished' member.
     public boolean isFinished() {
-        for (List<AgentTask> tasks : this.backendIdToTasks.values()) {
+        for (List<AgentTask> tasks :  backendIdToTasks.values()) {
             for (AgentTask agentTask : tasks) {
                 if (!agentTask.isFinished()) {
                     return false;
@@ -120,7 +120,7 @@ public class AgentBatchTask implements Runnable {
     // return the limit number of unfinished tasks.
     public List<AgentTask> getUnfinishedTasks(int limit) {
         List<AgentTask> res = Lists.newArrayList();
-        for (List<AgentTask> tasks : this.backendIdToTasks.values()) {
+        for (List<AgentTask> tasks :  backendIdToTasks.values()) {
             for (AgentTask agentTask : tasks) {
                 if (!agentTask.isFinished()) {
                     if (res.size() < limit) {
@@ -134,7 +134,7 @@ public class AgentBatchTask implements Runnable {
 
     public int getFinishedTaskNum() {
         int count = 0;
-        for (List<AgentTask> tasks : this.backendIdToTasks.values()) {
+        for (List<AgentTask> tasks :  backendIdToTasks.values()) {
             for (AgentTask agentTask : tasks) {
                 if (agentTask.isFinished()) {
                     count++;
@@ -146,7 +146,7 @@ public class AgentBatchTask implements Runnable {
 
     @Override
     public void run() {
-        for (Long backendId : this.backendIdToTasks.keySet()) {
+        for (Long backendId :  backendIdToTasks.keySet()) {
             BackendService.Client client = null;
             TNetworkAddress address = null;
             boolean ok = false;
@@ -155,7 +155,7 @@ public class AgentBatchTask implements Runnable {
                 if (backend == null || !backend.isAlive()) {
                     continue;
                 }
-                List<AgentTask> tasks = this.backendIdToTasks.get(backendId);
+                List<AgentTask> tasks =  backendIdToTasks.get(backendId);
                 // create AgentClient
                 String host = FeConstants.runningUnitTest ? "127.0.0.1" : backend.getHost();
                 address = new TNetworkAddress(host, backend.getBePort());

--- a/fe/fe-core/src/main/java/org/apache/doris/task/AgentTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/task/AgentTask.java
@@ -71,15 +71,15 @@ public abstract class AgentTask {
     }
 
     public long getSignature() {
-        return this.signature;
+        return signature;
     }
 
     public long getBackendId() {
-        return this.backendId;
+        return backendId;
     }
 
     public TTaskType getTaskType() {
-        return this.taskType;
+        return taskType;
     }
 
     public long getDbId() {
@@ -107,15 +107,15 @@ public abstract class AgentTask {
     }
 
     public void failed() {
-        ++this.failedTimes;
+        ++failedTimes;
     }
 
     public int getFailedTimes() {
-        return this.failedTimes;
+        return failedTimes;
     }
 
     public void setErrorMsg(String errorMsg) {
-        this.errorMsg = errorMsg;
+        errorMsg = errorMsg;
     }
 
     public String getErrorMsg() {
@@ -123,7 +123,7 @@ public abstract class AgentTask {
     }
 
     public void setFinished(boolean isFinished) {
-        this.isFinished = isFinished;
+        isFinished = isFinished;
     }
 
     public boolean isFinished() {

--- a/fe/fe-core/src/main/java/org/apache/doris/task/ClearAlterTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/task/ClearAlterTask.java
@@ -28,7 +28,7 @@ public class ClearAlterTask extends AgentTask {
         super(null, backendId, TTaskType.CLEAR_ALTER_TASK, dbId, tableId, partitionId, indexId, tabletId);
 
         this.schemaHash = schemaHash;
-        this.isFinished = false;
+        isFinished = false;
     }
 
     public TClearAlterTaskRequest toThrift() {

--- a/fe/fe-core/src/main/java/org/apache/doris/task/CloneTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/task/CloneTask.java
@@ -68,7 +68,7 @@ public class CloneTask extends AgentTask {
     public void setPathHash(long srcPathHash, long destPathHash) {
         this.srcPathHash = srcPathHash;
         this.destPathHash = destPathHash;
-        this.taskVersion = VERSION_2;
+        taskVersion = VERSION_2;
     }
 
     public int getTaskVersion() {

--- a/fe/fe-core/src/main/java/org/apache/doris/task/LoadEtlTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/task/LoadEtlTask.java
@@ -60,8 +60,8 @@ public abstract class LoadEtlTask extends MasterTask {
     public LoadEtlTask(LoadJob job) {
         super();
         this.job = job;
-        this.signature = job.getId();
-        this.load = Catalog.getCurrentCatalog().getLoadInstance();
+        signature = job.getId();
+        load = Catalog.getCurrentCatalog().getLoadInstance();
     }
 
     protected String getErrorMsg() {

--- a/fe/fe-core/src/main/java/org/apache/doris/task/SerialExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/task/SerialExecutor.java
@@ -44,7 +44,7 @@ public class SerialExecutor extends AbstractExecutorService {
 
     public SerialExecutor(final ExecutorService executor) {
         Preconditions.checkNotNull(executor);
-        this.taskPool = executor;
+        taskPool = executor;
     }
 
     public void execute(final Runnable r) {

--- a/fe/fe-core/src/main/java/org/apache/doris/task/SerialExecutorService.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/task/SerialExecutorService.java
@@ -37,7 +37,7 @@ public class SerialExecutorService {
 
     private SerialExecutorService(int numOfSlots, ExecutorService taskPool) {
         this.numOfSlots = numOfSlots;
-        this.slots = new SerialExecutor[numOfSlots];
+        slots = new SerialExecutor[numOfSlots];
         this.taskPool = taskPool;
         for (int i = 0; i < numOfSlots; i++) {
             slots[i] = new SerialExecutor(taskPool);

--- a/fe/fe-core/src/main/java/org/apache/doris/task/StreamLoadTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/task/StreamLoadTask.java
@@ -82,12 +82,12 @@ public class StreamLoadTask implements LoadTaskInfo {
         this.txnId = txnId;
         this.fileType = fileType;
         this.formatType = formatType;
-        this.jsonPaths = "";
-        this.jsonRoot = "";
-        this.stripOuterArray = false;
-        this.numAsString = false;
-        this.fuzzyParse = false;
-        this.readJsonByLine = false;
+        jsonPaths = "";
+        jsonRoot = "";
+        stripOuterArray = false;
+        numAsString = false;
+        fuzzyParse = false;
+        readJsonByLine = false;
     }
 
     public TUniqueId getId() {

--- a/fe/fe-core/src/main/java/org/apache/doris/task/SyncTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/task/SyncTask.java
@@ -61,7 +61,7 @@ public abstract class SyncTask implements SerialRunnable {
     }
 
     public int getIndex() {
-        return this.index;
+        return index;
     }
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/task/UpdateTabletMetaInfoTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/task/UpdateTabletMetaInfoTask.java
@@ -71,12 +71,12 @@ public class UpdateTabletMetaInfoTask extends AgentTask {
                                     List<Triple<Long, Integer, Boolean>> tabletToInMemory) {
         super(null, backendId, TTaskType.UPDATE_TABLET_META_INFO,
                 -1L, -1L, -1L, -1L, -1L, tabletToInMemory.hashCode());
-        this.metaType = TTabletMetaType.INMEMORY;
+        metaType = TTabletMetaType.INMEMORY;
         this.tabletToInMemory = tabletToInMemory;
     }
 
     public void countDownLatch(long backendId, Set<Pair<Long, Integer>> tablets) {
-        if (this.latch != null) {
+        if (latch != null) {
             if (latch.markedCountDown(backendId, tablets)) {
                 LOG.debug("UpdateTabletMetaInfoTask current latch count: {}, backend: {}, tablets:{}",
                         latch.getCount(), backendId, tablets);
@@ -86,7 +86,7 @@ public class UpdateTabletMetaInfoTask extends AgentTask {
 
     // call this always means one of tasks is failed. count down to zero to finish entire task
     public void countDownToZero(String errMsg) {
-        if (this.latch != null) {
+        if (latch != null) {
             latch.countDownToZero(new Status(TStatusCode.CANCELLED, errMsg));
             LOG.debug("UpdateTabletMetaInfoTask count down to zero. error msg: {}", errMsg);
         }


### PR DESCRIPTION
# Proposed changes

Issue Number: no relative issue

## Problem Summary:

In Java, we can use `this.` to access class member variables .
But, in most scenario, it's redundant. We can remove it from non-constructor functions.

## Checklist(Required)

1. Does it affect the original behavior: No
2. Has unit tests been added: No
3. Has document been added or modified: No
4. Does it need to update dependencies: No
5. Are there any changes that cannot be rolled back: No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
