### PR TITLE
[fix] (planner) Hudi scan node inputformat type should use lowercase words

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/planner/HudiScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/HudiScanNode.java
@@ -300,9 +300,9 @@ public class HudiScanNode extends BrokerScanNode {
         Log.debug("Hudi path's host is " + fsName);
 
         TFileFormatType formatType = null;
-        if (this.inputFormatName.toUpperCase(Locale.ROOT).contains("parquet")) {
+        if (this.inputFormatName.toLowerCase(Locale.ROOT).contains("parquet")) {
             formatType = TFileFormatType.FORMAT_PARQUET;
-        } else if (this.inputFormatName.toUpperCase(Locale.ROOT).contains("orc")) {
+        } else if (this.inputFormatName.toLowerCase(Locale.ROOT).contains("orc")) {
             formatType = TFileFormatType.FORMAT_ORC;
         } else {
             throw new UserException("unsupported hudi table type [" + this.inputFormatName + "].");


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:
![image](https://user-images.githubusercontent.com/18522955/172290662-97a95afc-c573-4dac-b34d-37e9e86bf8fb.png)

## Checklist(Required)

1. Does it affect the original behavior: (No)
2. Has unit tests been added: (No Need)
3. Has document been added or modified: (No Need)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
