### PR TITLE
[fix] (planner) passthrough child in SetOperationNode is wrong when enable vectorized engine

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/planner/SetOperationNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/SetOperationNode.java
@@ -25,6 +25,7 @@ import org.apache.doris.analysis.TupleDescriptor;
 import org.apache.doris.analysis.TupleId;
 import org.apache.doris.common.CheckedMath;
 import org.apache.doris.common.UserException;
+import org.apache.doris.common.util.VectorizedUtil;
 import org.apache.doris.thrift.TExceptNode;
 import org.apache.doris.thrift.TExplainLevel;
 import org.apache.doris.thrift.TExpr;
@@ -267,8 +268,14 @@ public abstract class SetOperationNode extends PlanNode {
             if (childSlotRef == null) {
                 return false;
             }
-            if (!childSlotRef.getDesc().layoutEquals(setOpSlotRef.getDesc())) {
-                return false;
+            if (VectorizedUtil.isVectorized()) {
+                if (childSlotRef.getDesc().getSlotOffset() != setOpSlotRef.getDesc().getSlotOffset()) {
+                    return false;
+                }
+            } else {
+                if (!childSlotRef.getDesc().layoutEquals(setOpSlotRef.getDesc())) {
+                    return false;
+                }
             }
         }
         return true;


### PR DESCRIPTION
# Proposed changes

Issue Number: close #9952 

## Problem Summary:

In SetOperationNode we do passthrough, if we child output is same with itself output. In method `isChildPassthrough` we only consider memory layout. When we use vectorized engine, we need to use SlotDesc offset in TupleDesc instead of memory layout to check whether  pass-through can be performed

## Checklist(Required)

1. Does it affect the original behavior: No
2. Has unit tests been added: No
3. Has document been added or modified: No Need
4. Does it need to update dependencies: No
5. Are there any changes that cannot be rolled back:No

## Further comments

Add UT and regression-test later.
