### PR TITLE
[Bug] runtime filter is not used as expected

### DIFF
--- a/be/src/exec/olap_scan_node.cpp
+++ b/be/src/exec/olap_scan_node.cpp
@@ -1566,7 +1566,7 @@ void OlapScanNode::scanner_thread(OlapScanner* scanner) {
     auto& scanner_filter_apply_marks = *scanner->mutable_runtime_filter_marks();
     DCHECK(scanner_filter_apply_marks.size() == _runtime_filter_descs.size());
     for (size_t i = 0; i < scanner_filter_apply_marks.size(); i++) {
-        if (!scanner_filter_apply_marks[i]) {
+        if (!scanner_filter_apply_marks[i] && !_runtime_filter_ctxs[i].apply_mark) {
             IRuntimeFilter* runtime_filter = nullptr;
             state->runtime_filter_mgr()->get_consume_filter(_runtime_filter_descs[i].filter_id,
                                                             &runtime_filter);
@@ -1574,7 +1574,6 @@ void OlapScanNode::scanner_thread(OlapScanner* scanner) {
             bool ready = runtime_filter->is_ready();
             if (ready) {
                 runtime_filter->get_prepared_context(&contexts, row_desc(), _expr_mem_tracker);
-                _runtime_filter_ctxs[i].apply_mark = true;
                 scanner_filter_apply_marks[i] = true;
             }
         }

--- a/be/src/exec/olap_scan_node.cpp
+++ b/be/src/exec/olap_scan_node.cpp
@@ -1566,7 +1566,7 @@ void OlapScanNode::scanner_thread(OlapScanner* scanner) {
     auto& scanner_filter_apply_marks = *scanner->mutable_runtime_filter_marks();
     DCHECK(scanner_filter_apply_marks.size() == _runtime_filter_descs.size());
     for (size_t i = 0; i < scanner_filter_apply_marks.size(); i++) {
-        if (!scanner_filter_apply_marks[i] && !_runtime_filter_ctxs[i].apply_mark) {
+        if (!scanner_filter_apply_marks[i]) {
             IRuntimeFilter* runtime_filter = nullptr;
             state->runtime_filter_mgr()->get_consume_filter(_runtime_filter_descs[i].filter_id,
                                                             &runtime_filter);
@@ -1575,6 +1575,7 @@ void OlapScanNode::scanner_thread(OlapScanner* scanner) {
             if (ready) {
                 runtime_filter->get_prepared_context(&contexts, row_desc(), _expr_mem_tracker);
                 _runtime_filter_ctxs[i].apply_mark = true;
+                scanner_filter_apply_marks[i] = true;
             }
         }
     }

--- a/be/src/exprs/runtime_filter.cpp
+++ b/be/src/exprs/runtime_filter.cpp
@@ -857,9 +857,7 @@ public:
         return Status::OK();
     }
 
-    PrimitiveType column_type() {
-        return _column_return_type;
-    }
+    PrimitiveType column_type() { return _column_return_type; }
 
     void ready_for_publish() {
         if (_filter_type == RuntimeFilterType::MINMAX_FILTER) {
@@ -881,17 +879,11 @@ public:
         }
     }
 
-    bool is_bloomfilter() const {
-        return _is_bloomfilter;
-    }
+    bool is_bloomfilter() const { return _is_bloomfilter; }
 
-    bool is_ignored_in_filter() const {
-        return _is_ignored_in_filter;
-    }
+    bool is_ignored_in_filter() const { return _is_ignored_in_filter; }
 
-    std::string* get_ignored_in_filter_msg() const {
-        return _ignored_in_filter_msg;
-    }
+    std::string* get_ignored_in_filter_msg() const { return _ignored_in_filter_msg; }
 
     void batch_assign(const PInFilter* filter,
                       void (*assign_func)(std::unique_ptr<HybridSetBase>& _hybrid_set,

--- a/be/src/vec/exec/volap_scan_node.cpp
+++ b/be/src/vec/exec/volap_scan_node.cpp
@@ -166,7 +166,7 @@ void VOlapScanNode::scanner_thread(VOlapScanner* scanner) {
     auto& scanner_filter_apply_marks = *scanner->mutable_runtime_filter_marks();
     DCHECK(scanner_filter_apply_marks.size() == _runtime_filter_descs.size());
     for (size_t i = 0; i < scanner_filter_apply_marks.size(); i++) {
-        if (!scanner_filter_apply_marks[i]) {
+        if (!scanner_filter_apply_marks[i] && !_runtime_filter_ctxs[i].apply_mark) {
             IRuntimeFilter* runtime_filter = nullptr;
             state->runtime_filter_mgr()->get_consume_filter(_runtime_filter_descs[i].filter_id,
                                                             &runtime_filter);
@@ -174,7 +174,6 @@ void VOlapScanNode::scanner_thread(VOlapScanner* scanner) {
             bool ready = runtime_filter->is_ready();
             if (ready) {
                 runtime_filter->get_prepared_context(&contexts, row_desc(), _expr_mem_tracker);
-                _runtime_filter_ctxs[i].apply_mark = true;
                 scanner_filter_apply_marks[i] = true;
             }
         }

--- a/be/src/vec/exec/volap_scan_node.cpp
+++ b/be/src/vec/exec/volap_scan_node.cpp
@@ -166,7 +166,7 @@ void VOlapScanNode::scanner_thread(VOlapScanner* scanner) {
     auto& scanner_filter_apply_marks = *scanner->mutable_runtime_filter_marks();
     DCHECK(scanner_filter_apply_marks.size() == _runtime_filter_descs.size());
     for (size_t i = 0; i < scanner_filter_apply_marks.size(); i++) {
-        if (!scanner_filter_apply_marks[i] && !_runtime_filter_ctxs[i].apply_mark) {
+        if (!scanner_filter_apply_marks[i]) {
             IRuntimeFilter* runtime_filter = nullptr;
             state->runtime_filter_mgr()->get_consume_filter(_runtime_filter_descs[i].filter_id,
                                                             &runtime_filter);
@@ -175,6 +175,7 @@ void VOlapScanNode::scanner_thread(VOlapScanner* scanner) {
             if (ready) {
                 runtime_filter->get_prepared_context(&contexts, row_desc(), _expr_mem_tracker);
                 _runtime_filter_ctxs[i].apply_mark = true;
+                scanner_filter_apply_marks[i] = true;
             }
         }
     }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #10000 

## Problem Summary:

OLAP scan node will continue to scan data files when runtime filters are not ready at beginning. As expected, runtime filter should be used once it's ready during scan thread running. But now, runtime filter is not used when it's not ready at beginning.

I tested this PR on SSB using query below:

select * from customer, lineorder where lineorder.lo_custkey = customer.c_custkey and customer.c_name = 'Customer#000200371' limit 1000;

And I got a performance comparison:

Before: 2 min 35.04 sec
After: 1 min 17.50 sec

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
