### PR TITLE
[Bugfix](load) fix streamload failure due to false unhealthy replica in concurrent stream load

### DIFF
--- a/be/src/olap/tablet.h
+++ b/be/src/olap/tablet.h
@@ -226,7 +226,8 @@ public:
     // Rowset whose version range is not covered by this tablet is also useful.
     bool rowset_meta_is_useful(RowsetMetaSharedPtr rowset_meta);
 
-    void build_tablet_report_info(TTabletInfo* tablet_info);
+    void build_tablet_report_info(TTabletInfo* tablet_info,
+                                  bool enable_consecutive_missing_check = false);
 
     void generate_tablet_meta_copy(TabletMetaSharedPtr new_tablet_meta) const;
     // caller should hold the _meta_lock before calling this method
@@ -357,6 +358,9 @@ private:
     std::shared_ptr<BaseCompaction> _base_compaction;
     // whether clone task occurred during the tablet is in thread pool queue to wait for compaction
     std::atomic<bool> _is_clone_occurred;
+
+    int64_t _last_missed_version;
+    int64_t _last_missed_time_s;
 
     DISALLOW_COPY_AND_ASSIGN(Tablet);
 

--- a/be/src/olap/tablet_manager.cpp
+++ b/be/src/olap/tablet_manager.cpp
@@ -867,7 +867,7 @@ Status TabletManager::build_all_report_tablets_info(std::map<TTabletId, TTablet>
             TabletSharedPtr tablet_ptr = item.second;
             TTablet t_tablet;
             TTabletInfo tablet_info;
-            tablet_ptr->build_tablet_report_info(&tablet_info);
+            tablet_ptr->build_tablet_report_info(&tablet_info, true);
             // find expired transaction corresponding to this tablet
             TabletInfo tinfo(tablet_id, tablet_ptr->schema_hash(), tablet_ptr->tablet_uid());
             auto find = expire_txn_map.find(tinfo);


### PR DESCRIPTION
in concurrent stream load, fe will run publish version task concurrently,
which cause publish task disorder in be.
For example:
fe publish task with version 1 2 3 4
be may handle task with sequence 1 2 4 3
In case above, when report tablet info, be found that version 4
published but version 3 not visable, it'll report version miss to fe,
and fe will set replica lastFailedVersion, and finally makes transaction
commits fail while no quorum health replicas。

Add a strategy to handle this case, be must publish version in sequence,
if publish task version not match tablet max_version, it will be push
back to queue and wait.

# Proposed changes

Issue Number: close #xxx

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
