### PR TITLE
[enhance] improve dict in-predicate evaluate

### DIFF
--- a/be/src/olap/in_list_predicate.cpp
+++ b/be/src/olap/in_list_predicate.cpp
@@ -132,13 +132,14 @@ IN_LIST_PRED_COLUMN_BLOCK_EVALUATE(NotInListPredicate, ==)
                     auto* nested_col_ptr = vectorized::check_and_get_column<                     \
                             vectorized::ColumnDictionary<vectorized::Int32>>(nested_col);        \
                     auto& data_array = nested_col_ptr->get_data();                               \
-                    auto dict_codes = nested_col_ptr->find_codes(_values);                       \
+                    std::vector<bool> selected;                                                  \
+                    nested_col_ptr->find_codes(_values, selected);                               \
                     for (uint16_t i = 0; i < *size; i++) {                                       \
                         uint16_t idx = sel[i];                                                   \
                         sel[new_size] = idx;                                                     \
                         const auto& cell_value = data_array[idx];                                \
-                        bool ret = !null_bitmap[idx] &&                                          \
-                                   (dict_codes.find(cell_value) OP dict_codes.end());            \
+                        DCHECK(cell_value < selected.size());                                    \
+                        bool ret = !null_bitmap[idx] && (selected[cell_value] OP false);         \
                         new_size += _opposite ? !ret : ret;                                      \
                     }                                                                            \
                 }                                                                                \
@@ -161,12 +162,14 @@ IN_LIST_PRED_COLUMN_BLOCK_EVALUATE(NotInListPredicate, ==)
                         reinterpret_cast<vectorized::ColumnDictionary<vectorized::Int32>&>(      \
                                 column);                                                         \
                 auto& data_array = dict_col.get_data();                                          \
-                auto dict_codes = dict_col.find_codes(_values);                                  \
+                std::vector<bool> selected;                                                      \
+                dict_col.find_codes(_values, selected);                                          \
                 for (uint16_t i = 0; i < *size; i++) {                                           \
                     uint16_t idx = sel[i];                                                       \
                     sel[new_size] = idx;                                                         \
                     const auto& cell_value = data_array[idx];                                    \
-                    auto result = (dict_codes.find(cell_value) OP dict_codes.end());             \
+                    DCHECK(cell_value < selected.size());                                        \
+                    auto result = (selected[cell_value] OP false);                               \
                     new_size += _opposite ? !result : result;                                    \
                 }                                                                                \
             }                                                                                    \

--- a/be/src/vec/columns/column_dictionary.h
+++ b/be/src/vec/columns/column_dictionary.h
@@ -258,9 +258,9 @@ public:
 
     uint32_t get_hash_value(uint32_t idx) const { return _dict.get_hash_value(_codes[idx]); }
 
-    phmap::flat_hash_set<int32_t> find_codes(
-            const phmap::flat_hash_set<StringValue>& values) const {
-        return _dict.find_codes(values);
+    void find_codes(const phmap::flat_hash_set<StringValue>& values,
+                    std::vector<bool>& selected) const {
+        return _dict.find_codes(values, selected);
     }
 
     bool is_dict_sorted() const { return _dict_sorted; }
@@ -362,16 +362,17 @@ public:
             return greater ? bound - greater + eq : bound - eq;
         }
 
-        phmap::flat_hash_set<int32_t> find_codes(
-                const phmap::flat_hash_set<StringValue>& values) const {
-            phmap::flat_hash_set<int32_t> code_set;
+        void find_codes(const phmap::flat_hash_set<StringValue>& values,
+                        std::vector<bool>& selected) const {
+            size_t dict_word_num = _dict_data.size();
+            selected.resize(dict_word_num);
+            selected.assign(dict_word_num, false);
             for (const auto& value : values) {
                 auto it = _inverted_index.find(value);
                 if (it != _inverted_index.end()) {
-                    code_set.insert(it->second);
+                    selected[it->second] = true;
                 }
             }
-            return code_set;
         }
 
         void clear() {


### PR DESCRIPTION
# Proposed changes
when column is dict encoded, in_predicate::evaluate() put dict code of IN_LIST into a set, and then compare the selected codes with column cells. The selected dict codes are put into a map, by which the evaluate time is O(logN)
It is better to use a std::vector to indicated if a dict word is in IN_LIST, by which the evaluate time shrinks to O(1).

test evn: ssb_flat 5G
test sql: simplified from ssb q.3.3
SELECT count(c_city) FROM lineorder_flat WHERE C_CITY in ('UNITED KI1','UNITED KI5');

ShortPredEvalTime is decreased from 240ms to 170ms by average.

在测试环境中 ssb100-flat， 3BE q3.3 从291ms下降到248ms

Issue Number: close #xxx

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
