### PR TITLE
[style] Fix the code style defined by class member variables in query…

### DIFF
--- a/be/src/runtime/query_statistics.cpp
+++ b/be/src/runtime/query_statistics.cpp
@@ -20,22 +20,22 @@
 namespace doris {
 
 void NodeStatistics::merge(const NodeStatistics& other) {
-    peak_memory_bytes += other.peak_memory_bytes;
+    _peak_memory_bytes += other._peak_memory_bytes;
 }
 
 void NodeStatistics::to_pb(PNodeStatistics* node_statistics) {
     DCHECK(node_statistics != nullptr);
-    node_statistics->set_peak_memory_bytes(peak_memory_bytes);
+    node_statistics->set_peak_memory_bytes(_peak_memory_bytes);
 }
 
 void NodeStatistics::from_pb(const PNodeStatistics& node_statistics) {
-    peak_memory_bytes = node_statistics.peak_memory_bytes();
+    _peak_memory_bytes = node_statistics.peak_memory_bytes();
 }
 
 void QueryStatistics::merge(const QueryStatistics& other) {
-    scan_rows += other.scan_rows;
-    scan_bytes += other.scan_bytes;
-    cpu_ms += other.cpu_ms;
+    _scan_rows += other._scan_rows;
+    _scan_bytes += other._scan_bytes;
+    _cpu_ms += other._cpu_ms;
     for (auto& other_node_statistics : other._nodes_statistics_map) {
         int64_t node_id = other_node_statistics.first;
         auto node_statistics = add_nodes_statistics(node_id);
@@ -45,11 +45,11 @@ void QueryStatistics::merge(const QueryStatistics& other) {
 
 void QueryStatistics::to_pb(PQueryStatistics* statistics) {
     DCHECK(statistics != nullptr);
-    statistics->set_scan_rows(scan_rows);
-    statistics->set_scan_bytes(scan_bytes);
-    statistics->set_cpu_ms(cpu_ms);
-    statistics->set_returned_rows(returned_rows);
-    statistics->set_max_peak_memory_bytes(max_peak_memory_bytes);
+    statistics->set_scan_rows(_scan_rows);
+    statistics->set_scan_bytes(_scan_bytes);
+    statistics->set_cpu_ms(_cpu_ms);
+    statistics->set_returned_rows(_returned_rows);
+    statistics->set_max_peak_memory_bytes(_max_peak_memory_bytes);
     for (auto iter = _nodes_statistics_map.begin(); iter != _nodes_statistics_map.end(); ++iter) {
         auto node_statistics = statistics->add_nodes_statistics();
         node_statistics->set_node_id(iter->first);
@@ -58,9 +58,9 @@ void QueryStatistics::to_pb(PQueryStatistics* statistics) {
 }
 
 void QueryStatistics::from_pb(const PQueryStatistics& statistics) {
-    scan_rows = statistics.scan_rows();
-    scan_bytes = statistics.scan_bytes();
-    cpu_ms = statistics.cpu_ms();
+    _scan_rows = statistics.scan_rows();
+    _scan_bytes = statistics.scan_bytes();
+    _cpu_ms = statistics.cpu_ms();
     for (auto& p_node_statistics : statistics.nodes_statistics()) {
         int64_t node_id = p_node_statistics.node_id();
         auto node_statistics = add_nodes_statistics(node_id);
@@ -71,8 +71,8 @@ void QueryStatistics::from_pb(const PQueryStatistics& statistics) {
 int64_t QueryStatistics::calculate_max_peak_memory_bytes() {
     int64_t max_peak_memory_bytes = 0;
     for (auto iter = _nodes_statistics_map.begin(); iter != _nodes_statistics_map.end(); ++iter) {
-        if (max_peak_memory_bytes < iter->second->peak_memory_bytes) {
-            max_peak_memory_bytes = iter->second->peak_memory_bytes;
+        if (max_peak_memory_bytes < iter->second->_peak_memory_bytes) {
+            max_peak_memory_bytes = iter->second->_peak_memory_bytes;
         }
     }
     return max_peak_memory_bytes;

--- a/be/src/runtime/query_statistics.h
+++ b/be/src/runtime/query_statistics.h
@@ -29,9 +29,9 @@ class QueryStatisticsRecvr;
 
 class NodeStatistics {
 public:
-    NodeStatistics() : peak_memory_bytes(0) {};
+    NodeStatistics() : _peak_memory_bytes(0) {};
 
-    void add_peak_memory(int64_t peak_memory) { this->peak_memory_bytes += peak_memory; }
+    void add_peak_memory(int64_t peak_memory) { _peak_memory_bytes += peak_memory; }
 
     void merge(const NodeStatistics& other);
 
@@ -41,7 +41,7 @@ public:
 
 private:
     friend class QueryStatistics;
-    int64_t peak_memory_bytes;
+    int64_t _peak_memory_bytes;
 };
 
 // This is responsible for collecting query statistics, usually it consists of
@@ -50,16 +50,20 @@ private:
 class QueryStatistics {
 public:
     QueryStatistics()
-            : scan_rows(0), scan_bytes(0), cpu_ms(0), returned_rows(0), max_peak_memory_bytes(0) {}
+            : _scan_rows(0),
+              _scan_bytes(0),
+              _cpu_ms(0),
+              _returned_rows(0),
+              _max_peak_memory_bytes(0) {}
     ~QueryStatistics();
 
     void merge(const QueryStatistics& other);
 
-    void add_scan_rows(int64_t scan_rows) { this->scan_rows += scan_rows; }
+    void add_scan_rows(int64_t scan_rows) { _scan_rows += scan_rows; }
 
-    void add_scan_bytes(int64_t scan_bytes) { this->scan_bytes += scan_bytes; }
+    void add_scan_bytes(int64_t scan_bytes) { _scan_bytes += scan_bytes; }
 
-    void add_cpu_ms(int64_t cpu_ms) { this->cpu_ms += cpu_ms; }
+    void add_cpu_ms(int64_t cpu_ms) { _cpu_ms += cpu_ms; }
 
     NodeStatistics* add_nodes_statistics(int64_t node_id) {
         NodeStatistics* nodeStatistics = nullptr;
@@ -73,10 +77,10 @@ public:
         return nodeStatistics;
     }
 
-    void set_returned_rows(int64_t num_rows) { this->returned_rows = num_rows; }
+    void set_returned_rows(int64_t num_rows) { _returned_rows = num_rows; }
 
     void set_max_peak_memory_bytes(int64_t max_peak_memory_bytes) {
-        this->max_peak_memory_bytes = max_peak_memory_bytes;
+        _max_peak_memory_bytes = max_peak_memory_bytes;
     }
 
     void merge(QueryStatisticsRecvr* recvr);
@@ -87,11 +91,11 @@ public:
     void clearNodeStatistics();
 
     void clear() {
-        scan_rows = 0;
-        scan_bytes = 0;
-        cpu_ms = 0;
-        returned_rows = 0;
-        max_peak_memory_bytes = 0;
+        _scan_rows = 0;
+        _scan_bytes = 0;
+        _cpu_ms = 0;
+        _returned_rows = 0;
+        _max_peak_memory_bytes = 0;
         clearNodeStatistics();
     }
 
@@ -100,15 +104,15 @@ public:
     void from_pb(const PQueryStatistics& statistics);
 
 private:
-    int64_t scan_rows;
-    int64_t scan_bytes;
-    int64_t cpu_ms;
+    int64_t _scan_rows;
+    int64_t _scan_bytes;
+    int64_t _cpu_ms;
     // number rows returned by query.
     // only set once by result sink when closing.
-    int64_t returned_rows;
+    int64_t _returned_rows;
     // Maximum memory peak for all backends.
     // only set once by result sink when closing.
-    int64_t max_peak_memory_bytes;
+    int64_t _max_peak_memory_bytes;
     // The statistics of the query on each backend.
     typedef std::unordered_map<int64_t, NodeStatistics*> NodeStatisticsMap;
     NodeStatisticsMap _nodes_statistics_map;


### PR DESCRIPTION
# Proposed changes

fix code style in QueryStatistics

## Problem Summary:

The definition of class member variables in Doris BE usually starts with an underscore, but in the two classes NodeStatistics and QueryStatistics, class member variables are not defined in this form. Should this be modified to this form?

## Checklist(Required)

1. Does it affect the original behavior: (No)
2. Has unit tests been added: (No)
3. Has document been added or modified: (No)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
