### PR TITLE
[Enhancement]Decode bitshuffle data before adding it into PageCache

### DIFF
--- a/be/src/olap/rowset/segment_v2/binary_dict_page.cpp
+++ b/be/src/olap/rowset/segment_v2/binary_dict_page.cpp
@@ -250,7 +250,7 @@ Status BinaryDictPageDecoder::next_batch(size_t* n, vectorized::MutableColumnPtr
                                                         _bit_shuffle_ptr->_cur_index));
     *n = max_fetch;
 
-    const auto* data_array = reinterpret_cast<const int32_t*>(_bit_shuffle_ptr->_chunk.data);
+    const auto* data_array = reinterpret_cast<const int32_t*>(_bit_shuffle_ptr->get_data(0));
     size_t start_index = _bit_shuffle_ptr->_cur_index;
 
     dst->insert_many_dict_data(data_array, start_index, _dict_word_info, max_fetch,

--- a/be/src/olap/rowset/segment_v2/bitshuffle_page_pre_decoder.h
+++ b/be/src/olap/rowset/segment_v2/bitshuffle_page_pre_decoder.h
@@ -1,0 +1,99 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include "olap/rowset/segment_v2/binary_dict_page.h"
+#include "olap/rowset/segment_v2/bitshuffle_page.h"
+#include "olap/rowset/segment_v2/encoding_info.h"
+
+namespace doris {
+namespace segment_v2 {
+
+template <bool USED_IN_DICT_ENCODING>
+struct BitShufflePagePreDecoder : public DataPagePreDecoder {
+    /**
+     * @brief Decode bitshuffle data
+     * The input should be data encoded by bitshuffle + lz4 or
+     * the input may be data of BinaryDictPage, if its encoding type is plain,
+     * it is no need to decode.
+     *
+     * @param page_slice data to decode
+     * @param footer footer info
+     * @param footer_size size of footer (including 4 bytes at the end of page)
+     * @return Status
+     */
+    virtual Status decode(Slice* page_slice, PageFooterPB* footer, uint32_t footer_size) override {
+        size_t num_elements, compressed_size, num_element_after_padding;
+        int size_of_element;
+
+        size_t size_of_dict_header = 0;
+        size_t size_of_nullmap = footer->data_page_footer().nullmap_size();
+        size_t size_of_tail = size_of_nullmap + footer_size + 4;
+        Slice data(page_slice->data, page_slice->size - size_of_tail);
+        if constexpr (USED_IN_DICT_ENCODING) {
+            auto type = decode_fixed32_le((const uint8_t*)&data.data[0]);
+            if (static_cast<EncodingTypePB>(type) != EncodingTypePB::DICT_ENCODING) {
+                return Status::OK();
+            }
+            size_of_dict_header = BINARY_DICT_PAGE_HEADER_SIZE;
+            data.remove_prefix(4);
+        }
+
+        RETURN_IF_ERROR(parse_bit_shuffle_header(data, num_elements, compressed_size,
+                                                 num_element_after_padding, size_of_element));
+
+        if (compressed_size != data.size) {
+            std::stringstream ss;
+            ss << "Size information unmatched, compressed_size:" << compressed_size
+               << ", num_elements:" << num_elements << ", data size:" << data.size;
+            return Status::InternalError(ss.str());
+        }
+
+        Slice decoded_slice;
+        decoded_slice.size = size_of_dict_header + BITSHUFFLE_PAGE_HEADER_SIZE +
+                             num_element_after_padding * size_of_element + size_of_tail;
+        std::unique_ptr<char[]> decoded_page(new char[decoded_slice.size]);
+        decoded_slice.data = decoded_page.get();
+
+        if constexpr (USED_IN_DICT_ENCODING) {
+            memcpy(decoded_slice.data, page_slice->data, size_of_dict_header);
+        }
+
+        memcpy(decoded_slice.data + size_of_dict_header, data.data, BITSHUFFLE_PAGE_HEADER_SIZE);
+
+        auto bytes = bitshuffle::decompress_lz4(
+                &data.data[BITSHUFFLE_PAGE_HEADER_SIZE],
+                decoded_slice.data + BITSHUFFLE_PAGE_HEADER_SIZE + size_of_dict_header,
+                num_element_after_padding, size_of_element, 0);
+        if (PREDICT_FALSE(bytes < 0)) {
+            // Ideally, this should not happen.
+            warn_with_bitshuffle_error(bytes);
+            return Status::RuntimeError("Unshuffle Process failed");
+        }
+
+        memcpy(decoded_slice.data + decoded_slice.size - size_of_tail,
+               page_slice->data + page_slice->size - size_of_tail, size_of_tail);
+
+        *page_slice = decoded_slice;
+        decoded_page.release();
+        return Status::OK();
+    }
+};
+
+} // namespace segment_v2
+} // namespace doris

--- a/be/src/olap/rowset/segment_v2/column_reader.cpp
+++ b/be/src/olap/rowset/segment_v2/column_reader.cpp
@@ -155,6 +155,7 @@ Status ColumnReader::read_page(const ColumnIteratorOptions& iter_opts, const Pag
     opts.use_page_cache = iter_opts.use_page_cache;
     opts.kept_in_memory = _opts.kept_in_memory;
     opts.type = iter_opts.type;
+    opts.encoding_info = _encoding_info;
 
     return PageIO::read_and_decompress_page(opts, handle, page_body, footer);
 }

--- a/be/src/olap/rowset/segment_v2/encoding_info.cpp
+++ b/be/src/olap/rowset/segment_v2/encoding_info.cpp
@@ -25,6 +25,7 @@
 #include "olap/rowset/segment_v2/binary_plain_page.h"
 #include "olap/rowset/segment_v2/binary_prefix_page.h"
 #include "olap/rowset/segment_v2/bitshuffle_page.h"
+#include "olap/rowset/segment_v2/bitshuffle_page_pre_decoder.h"
 #include "olap/rowset/segment_v2/frame_of_reference_page.h"
 #include "olap/rowset/segment_v2/plain_page.h"
 #include "olap/rowset/segment_v2/rle_page.h"
@@ -312,7 +313,13 @@ EncodingInfo::EncodingInfo(TraitsClass traits)
         : _create_builder_func(TraitsClass::create_page_builder),
           _create_decoder_func(TraitsClass::create_page_decoder),
           _type(TraitsClass::type),
-          _encoding(TraitsClass::encoding) {}
+          _encoding(TraitsClass::encoding) {
+    if (_encoding == BIT_SHUFFLE) {
+        _data_page_pre_decoder = std::make_unique<BitShufflePagePreDecoder<false>>();
+    } else if (_encoding == DICT_ENCODING) {
+        _data_page_pre_decoder = std::make_unique<BitShufflePagePreDecoder<true>>();
+    }
+}
 
 Status EncodingInfo::get(const TypeInfo* type_info, EncodingTypePB encoding_type,
                          const EncodingInfo** out) {

--- a/be/src/olap/rowset/segment_v2/encoding_info.h
+++ b/be/src/olap/rowset/segment_v2/encoding_info.h
@@ -37,7 +37,8 @@ struct PageDecoderOptions;
 // For better performance, some encodings (like BitShuffle) need to be decoded before being added to the PageCache.
 class DataPagePreDecoder {
 public:
-    virtual Status decode(Slice* page_slice, PageFooterPB* footer, uint32_t footer_size) = 0;
+    virtual Status decode(std::unique_ptr<char[]>* page, Slice* page_slice,
+                          size_t size_of_tail) = 0;
     virtual ~DataPagePreDecoder() = default;
 };
 

--- a/be/src/olap/rowset/segment_v2/encoding_info.h
+++ b/be/src/olap/rowset/segment_v2/encoding_info.h
@@ -34,6 +34,13 @@ class PageDecoder;
 struct PageBuilderOptions;
 struct PageDecoderOptions;
 
+// For better performance, some encodings (like BitShuffle) need to be decoded before being added to the PageCache.
+class DataPagePreDecoder {
+public:
+    virtual Status decode(Slice* page_slice, PageFooterPB* footer, uint32_t footer_size) = 0;
+    virtual ~DataPagePreDecoder() = default;
+};
+
 class EncodingInfo {
 public:
     // Get EncodingInfo for TypeInfo and EncodingTypePB
@@ -54,6 +61,8 @@ public:
     FieldType type() const { return _type; }
     EncodingTypePB encoding() const { return _encoding; }
 
+    DataPagePreDecoder* get_data_page_pre_decoder() const { return _data_page_pre_decoder.get(); };
+
 private:
     friend class EncodingInfoResolver;
 
@@ -69,6 +78,7 @@ private:
 
     FieldType _type;
     EncodingTypePB _encoding;
+    std::unique_ptr<DataPagePreDecoder> _data_page_pre_decoder = nullptr;
 };
 
 } // namespace segment_v2

--- a/be/src/olap/rowset/segment_v2/indexed_column_reader.cpp
+++ b/be/src/olap/rowset/segment_v2/indexed_column_reader.cpp
@@ -91,6 +91,7 @@ Status IndexedColumnReader::read_page(fs::ReadableBlock* rblock, const PagePoint
     opts.use_page_cache = _use_page_cache;
     opts.kept_in_memory = _kept_in_memory;
     opts.type = type;
+    opts.encoding_info = _encoding_info;
 
     return PageIO::read_and_decompress_page(opts, handle, body, footer);
 }

--- a/be/src/olap/rowset/segment_v2/page_io.cpp
+++ b/be/src/olap/rowset/segment_v2/page_io.cpp
@@ -195,6 +195,13 @@ Status PageIO::read_and_decompress_page(const PageReadOptions& opts, PageHandle*
         opts.stats->uncompressed_bytes_read += body_size;
     }
 
+    if (opts.encoding_info) {
+        auto* pre_decoder = opts.encoding_info->get_data_page_pre_decoder();
+        if (pre_decoder) {
+            RETURN_IF_ERROR(pre_decoder->decode(&page_slice, footer, footer_size));
+        }
+    }
+
     *body = Slice(page_slice.data, page_slice.size - 4 - footer_size);
     if (opts.use_page_cache && cache->is_cache_available(opts.type)) {
         // insert this page into cache and return the cache handle

--- a/be/src/olap/rowset/segment_v2/page_io.cpp
+++ b/be/src/olap/rowset/segment_v2/page_io.cpp
@@ -198,7 +198,9 @@ Status PageIO::read_and_decompress_page(const PageReadOptions& opts, PageHandle*
     if (opts.encoding_info) {
         auto* pre_decoder = opts.encoding_info->get_data_page_pre_decoder();
         if (pre_decoder) {
-            RETURN_IF_ERROR(pre_decoder->decode(&page_slice, footer, footer_size));
+            RETURN_IF_ERROR(pre_decoder->decode(
+                    &page, &page_slice,
+                    footer->data_page_footer().nullmap_size() + footer_size + 4));
         }
     }
 

--- a/be/src/olap/rowset/segment_v2/page_io.h
+++ b/be/src/olap/rowset/segment_v2/page_io.h
@@ -22,6 +22,7 @@
 #include "common/logging.h"
 #include "common/status.h"
 #include "gen_cpp/segment_v2.pb.h"
+#include "olap/rowset/segment_v2/encoding_info.h"
 #include "olap/rowset/segment_v2/page_handle.h"
 #include "olap/rowset/segment_v2/page_pointer.h"
 #include "util/slice.h"
@@ -58,6 +59,8 @@ struct PageReadOptions {
     // page types are divided into DATA_PAGE & INDEX_PAGE
     // INDEX_PAGE including index_page, dict_page and short_key_page
     PageTypePB type;
+
+    const EncodingInfo* encoding_info = nullptr;
 
     void sanity_check() const {
         CHECK_NOTNULL(rblock);

--- a/be/test/olap/rowset/segment_v2/bitshuffle_page_test.cpp
+++ b/be/test/olap/rowset/segment_v2/bitshuffle_page_test.cpp
@@ -21,6 +21,7 @@
 
 #include <memory>
 
+#include "olap/rowset/segment_v2/bitshuffle_page_pre_decoder.h"
 #include "olap/rowset/segment_v2/options.h"
 #include "olap/rowset/segment_v2/page_builder.h"
 #include "olap/rowset/segment_v2/page_decoder.h"
@@ -71,8 +72,16 @@ public:
         EXPECT_EQ(src[size - 1], last_value);
 
         segment_v2::PageDecoderOptions decoder_options;
-        PageDecoderType page_decoder(s.slice(), decoder_options);
-        Status status = page_decoder.init();
+        PageDecoderType page_decoder_(s.slice(), decoder_options);
+        Status status = page_decoder_.init();
+        EXPECT_FALSE(status.ok());
+
+        segment_v2::BitShufflePagePreDecoder<false> pre_decoder;
+        Slice page_slice = s.slice();
+        std::unique_ptr<char[]> auto_release;
+        pre_decoder.decode(&auto_release, &page_slice, 0);
+        PageDecoderType page_decoder(page_slice, decoder_options);
+        status = page_decoder.init();
         EXPECT_TRUE(status.ok());
         EXPECT_EQ(0, page_decoder.current_index());
 
@@ -121,8 +130,16 @@ public:
         OwnedSlice s = page_builder.finish();
 
         segment_v2::PageDecoderOptions decoder_options;
-        PageDecoderType page_decoder(s.slice(), decoder_options);
-        Status status = page_decoder.init();
+        PageDecoderType page_decoder_(s.slice(), decoder_options);
+        Status status = page_decoder_.init();
+        EXPECT_FALSE(status.ok());
+
+        segment_v2::BitShufflePagePreDecoder<false> pre_decoder;
+        Slice page_slice = s.slice();
+        std::unique_ptr<char[]> auto_release;
+        pre_decoder.decode(&auto_release, &page_slice, 0);
+        PageDecoderType page_decoder(page_slice, decoder_options);
+        status = page_decoder.init();
         EXPECT_TRUE(status.ok());
         EXPECT_EQ(0, page_decoder.current_index());
 


### PR DESCRIPTION
# Proposed changes

Issue Number: close #10015

## Problem Summary:

Describe the overview of changes.

### SSB(100G) flat query test:

|Query|master| bitshuffle_cached_decoded |
|-- | -- | --|
|q1.1 | 105 | 81|
|q1.2 | 82 | 68|
|q1.3 | 106 | 58|
|q2.1 | 462 | 321|
|q2.2 | 367 | 179|
|q2.3 | 325 | 152|
|q3.1 | 655 | 589|
|q3.2 | 370 | 195|
|q3.3 | 308 | 187|
|q3.4 | 55 | 38|
|q4.1 | 619 | 483|
|q4.2 | 233 | 156|
|q4.3 | 163 | 82|
| Sum | 3850 | 2589|

### Flame graph (SSB flat q3.3)
1. With no cache:
<img width="1196" alt="image" src="https://user-images.githubusercontent.com/1179834/172812418-1a5883c9-3e49-4f37-8e0e-3da73a83aea7.png">

2.  With cache
<img width="1193" alt="image" src="https://user-images.githubusercontent.com/1179834/172812502-c7369d2e-fb79-457c-8e03-614ac35edb02.png">

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
4. Has unit tests been added: (Yes/No/No Need)
5. Has document been added or modified: (Yes/No/No Need)
6. Does it need to update dependencies: (Yes/No)
7. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
