### PR TITLE
[Enhancement] tpch q3 rewrite, change join order, make lineitem on left side

### DIFF
--- a/tools/tpch-tools/queries/q3.sql
+++ b/tools/tpch-tools/queries/q3.sql
@@ -23,16 +23,14 @@ select /*+SET_VAR(parallel_fragment_exec_instance_num=8, enable_vectorized_engin
     o_orderdate,
     o_shippriority
 from
-    customer c join
     (
         select l_orderkey, l_extendedprice, l_discount, o_orderdate, o_shippriority, o_custkey from
         lineitem join orders
         where l_orderkey = o_orderkey
         and o_orderdate < date '1995-03-15'
         and l_shipdate > date '1995-03-15'
-    ) t1
+    ) t1 join customer c on c.c_custkey = t1.o_custkey
     where c_mktsegment = 'BUILDING'
-    and c.c_custkey = t1.o_custkey
 group by
     l_orderkey,
     o_orderdate,

--- a/tools/tpch-tools/queries/q3.sql
+++ b/tools/tpch-tools/queries/q3.sql
@@ -29,7 +29,8 @@ from
         where l_orderkey = o_orderkey
         and o_orderdate < date '1995-03-15'
         and l_shipdate > date '1995-03-15'
-    ) t1 join customer c on c.c_custkey = t1.o_custkey
+    ) t1 join customer c 
+    on c.c_custkey = t1.o_custkey
     where c_mktsegment = 'BUILDING'
 group by
     l_orderkey,


### PR DESCRIPTION
# Proposed changes
change join order for tpch q3. make lineitem on left side。
in tpch_100 database, the new sql spent 1.80 sec, while origin spend 2.88 sec.

Issue Number: close #xxx

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
