### PR TITLE
Do not send drop task when replay drop table

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/CatalogRecycleBin.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/CatalogRecycleBin.java
@@ -87,14 +87,14 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
         return true;
     }
 
-    public synchronized boolean recycleTable(long dbId, Table table) {
+    public synchronized boolean recycleTable(long dbId, Table table, boolean isReplay) {
         if (idToTable.containsKey(table.getId())) {
             LOG.error("table[{}] already in recycle bin.", table.getId());
             return false;
         }
 
         // erase table with same name
-        eraseTableWithSameName(dbId, table.getName());
+        eraseTableWithSameName(dbId, table.getName(), isReplay);
 
         // recycle table
         RecycleTableInfo tableInfo = new RecycleTableInfo(dbId, table);
@@ -196,7 +196,7 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
         } // end for tables
     }
 
-    private synchronized void eraseTableWithSameName(long dbId, String tableName) {
+    private synchronized void eraseTableWithSameName(long dbId, String tableName, boolean isReplay) {
         Iterator<Map.Entry<Long, RecycleTableInfo>> iterator = idToTable.entrySet().iterator();
         while (iterator.hasNext()) {
             Map.Entry<Long, RecycleTableInfo> entry = iterator.next();
@@ -208,7 +208,7 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
             Table table = tableInfo.getTable();
             if (table.getName().equals(tableName)) {
                 if (table.getType() == TableType.OLAP) {
-                    Catalog.getCurrentCatalog().onEraseOlapTable((OlapTable) table, false);
+                    Catalog.getCurrentCatalog().onEraseOlapTable((OlapTable) table, isReplay);
                 }
 
                 iterator.remove();

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalDataSource.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalDataSource.java
@@ -923,7 +923,7 @@ public class InternalDataSource implements DataSourceIf {
 
         db.dropTable(table.getName());
         if (!isForceDrop) {
-            Catalog.getCurrentRecycleBin().recycleTable(db.getId(), table);
+            Catalog.getCurrentRecycleBin().recycleTable(db.getId(), table, isReplay);
         } else {
             if (table.getType() == TableType.OLAP) {
                 Catalog.getCurrentCatalog().onEraseOlapTable((OlapTable) table, isReplay);


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

When doing checkpoint, FE will sends DropTask to BE.
This PR prohibit this conduct.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
