### PR TITLE
[compiler] use static link of glibc to support build doris in linux with old glibc

### DIFF
--- a/thirdparty/build-thirdparty.sh
+++ b/thirdparty/build-thirdparty.sh
@@ -509,6 +509,7 @@ build_re2() {
 build_hyperscan() {
     check_if_source_exist $RAGEL_SOURCE
     cd $TP_SOURCE_DIR/$RAGEL_SOURCE
+    CFLAGS="-static -g -O2" CXXFLAGS="-static -g -O2" \
     ./configure --prefix=$TP_INSTALL_DIR && make install
 
     check_if_source_exist $HYPERSCAN_SOURCE


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
