### PR TITLE
[feature](vectorized) Support block aggregate in scanner

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -830,7 +830,7 @@ CONF_Int32(quick_compaction_batch_size, "10");
 CONF_Int32(quick_compaction_min_rowsets, "10");
 
 // if true, blocks are aggregated in the scanner thread to improve the parallelism of the aggregated queries.
-CONF_mBool(enable_block_aggregate_in_scanner, "false");
+CONF_mBool(enable_block_aggregate_in_scanner, "true");
 
 // For block aggregate in scanner thread, if the aggregation degree of the current block
 // is less than this value, skip the current block. valid range should be [0, 1].

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -830,7 +830,7 @@ CONF_Int32(quick_compaction_batch_size, "10");
 CONF_Int32(quick_compaction_min_rowsets, "10");
 
 // if true, blocks are aggregated in the scanner thread to improve the parallelism of the aggregated queries.
-CONF_mBool(enable_block_aggregate_in_scanner, "true");
+CONF_mBool(enable_block_aggregate_in_scanner, "false");
 
 // For block aggregate in scanner thread, if the aggregation degree of the current block
 // is less than this value, skip the current block. valid range should be [0, 1].

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -829,6 +829,14 @@ CONF_Int32(quick_compaction_batch_size, "10");
 // do compaction min rowsets
 CONF_Int32(quick_compaction_min_rowsets, "10");
 
+// if true, blocks are aggregated in the scanner thread to improve the parallelism of the aggregated queries.
+CONF_mBool(enable_block_aggregate_in_scanner, "false");
+
+// For block aggregate in scanner thread, if the aggregation degree of the current block
+// is less than this value, skip the current block. valid range should be [0, 1].
+// If set to 0, it means no limit.
+CONF_mDouble(block_aggregate_ratio, "0.25");
+
 // cooldown task configs
 CONF_Int32(cooldown_thread_num, "5");
 CONF_mInt64(generate_cooldown_task_interval_sec, "20");

--- a/be/src/olap/rowset/segment_v2/segment_iterator.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.cpp
@@ -1003,7 +1003,7 @@ uint16_t SegmentIterator::_evaluate_vectorization_predicate(uint16_t* sel_rowid_
         auto mask = simd::bytes64_mask_to_bits64_mask(ret_flags + sel_pos);
         if (0 == mask) {
             //pass
-        } else if (0xffffffffffffffff == mask) {
+        } else if (simd::UINT64_MAX_MASK == mask) {
             for (uint32_t i = 0; i < SIMD_BYTES; i++) {
                 sel_rowid_idx[new_size++] = sel_pos + i;
             }

--- a/be/src/olap/rowset/segment_v2/segment_iterator.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.cpp
@@ -996,14 +996,14 @@ uint16_t SegmentIterator::_evaluate_vectorization_predicate(uint16_t* sel_rowid_
 
     uint32_t sel_pos = 0;
     const uint32_t sel_end = sel_pos + selected_size;
-    static constexpr size_t SIMD_BYTES = 32;
+    static constexpr size_t SIMD_BYTES = 64;
     const uint32_t sel_end_simd = sel_pos + selected_size / SIMD_BYTES * SIMD_BYTES;
 
     while (sel_pos < sel_end_simd) {
-        auto mask = simd::bytes32_mask_to_bits32_mask(ret_flags + sel_pos);
+        auto mask = simd::bytes64_mask_to_bits64_mask(ret_flags + sel_pos);
         if (0 == mask) {
             //pass
-        } else if (0xffffffff == mask) {
+        } else if (0xffffffffffffffff == mask) {
             for (uint32_t i = 0; i < SIMD_BYTES; i++) {
                 sel_rowid_idx[new_size++] = sel_pos + i;
             }

--- a/be/src/util/simd/bits.h
+++ b/be/src/util/simd/bits.h
@@ -34,6 +34,8 @@
 
 namespace doris::simd {
 
+static constexpr size_t UINT64_MAX_MASK = 0xFFFFFFFFFFFFFFFF;
+
 inline uint64_t bytes64_mask_to_bits64_not_mask(const int8_t* bytes64) {
 #ifdef __AVX2__
     const auto zero32 = _mm256_setzero_si256();

--- a/be/src/util/simd/bits.h
+++ b/be/src/util/simd/bits.h
@@ -29,58 +29,61 @@
 #include <sse2neon.h>
 #endif
 
-namespace doris {
-namespace simd {
+#include "vec/columns/column.h"
+#include "vec/common/pod_array.h"
 
-/// todo(zeno) Compile add avx512 parameter, modify it to bytes64_mask_to_bits64_mask
-/// Transform 32-byte mask to 32-bit mask
-inline uint32_t bytes32_mask_to_bits32_mask(const uint8_t* data) {
+namespace doris::simd {
+
+inline uint64_t bytes64_mask_to_bits64_not_mask(const int8_t* bytes64) {
 #ifdef __AVX2__
-    auto zero32 = _mm256_setzero_si256();
-    uint32_t mask = static_cast<uint32_t>(_mm256_movemask_epi8(
-            _mm256_cmpgt_epi8(_mm256_loadu_si256(reinterpret_cast<const __m256i*>(data)), zero32)));
-#elif defined(__SSE2__) || defined(__aarch64__)
-    auto zero16 = _mm_setzero_si128();
-    uint32_t mask =
-            (static_cast<uint32_t>(_mm_movemask_epi8(_mm_cmpgt_epi8(
-                    _mm_loadu_si128(reinterpret_cast<const __m128i*>(data)), zero16)))) |
-            ((static_cast<uint32_t>(_mm_movemask_epi8(_mm_cmpgt_epi8(
-                      _mm_loadu_si128(reinterpret_cast<const __m128i*>(data + 16)), zero16)))
-              << 16) &
-             0xffff0000);
+    const auto zero32 = _mm256_setzero_si256();
+    uint64_t res =
+            static_cast<uint64_t>(
+                    _mm256_movemask_epi8(_mm256_cmpeq_epi8(
+                            _mm256_loadu_si256(reinterpret_cast<const __m256i*>(bytes64)),
+                            zero32)) &
+                    0xffffffff) |
+            (static_cast<uint64_t>(_mm256_movemask_epi8(_mm256_cmpeq_epi8(
+                     _mm256_loadu_si256(reinterpret_cast<const __m256i*>(bytes64 + 32)), zero32)))
+             << 32);
+#elif __SSE2__
+    static const __m128i zero16 = _mm_setzero_si128();
+    uint64_t res =
+            static_cast<uint64_t>(_mm_movemask_epi8(_mm_cmpeq_epi8(
+                    _mm_loadu_si128(reinterpret_cast<const __m128i*>(bytes64)), zero16))) |
+            (static_cast<uint64_t>(_mm_movemask_epi8(_mm_cmpeq_epi8(
+                     _mm_loadu_si128(reinterpret_cast<const __m128i*>(bytes64 + 16)), zero16)))
+             << 16) |
+            (static_cast<uint64_t>(_mm_movemask_epi8(_mm_cmpeq_epi8(
+                     _mm_loadu_si128(reinterpret_cast<const __m128i*>(bytes64 + 32)), zero16)))
+             << 32) |
+            (static_cast<uint64_t>(_mm_movemask_epi8(_mm_cmpeq_epi8(
+                     _mm_loadu_si128(reinterpret_cast<const __m128i*>(bytes64 + 48)), zero16)))
+             << 48);
 #else
-    uint32_t mask = 0;
-    for (std::size_t i = 0; i < 32; ++i) {
-        mask |= static_cast<uint32_t>(1 == *(data + i)) << i;
+    uint64_t res = 0;
+    for (std::size_t i = 0; i < 64; ++i) {
+        res |= static_cast<uint64_t>(0 == *(bytes64 + i)) << i;
     }
 #endif
-    return mask;
+    return res;
 }
 
-inline uint32_t bytes32_mask_to_bits32_mask(const bool* data) {
-    return bytes32_mask_to_bits32_mask(reinterpret_cast<const uint8_t*>(data));
+inline uint64_t bytes64_mask_to_bits64_mask(const uint8_t* data) {
+    return ~bytes64_mask_to_bits64_not_mask(reinterpret_cast<const int8_t*>(data));
 }
 
-inline size_t count_zero_num(const int8_t* __restrict data, size_t size) {
-    size_t num = 0;
+inline uint64_t bytes64_mask_to_bits64_mask(const bool* data) {
+    return ~bytes64_mask_to_bits64_not_mask(reinterpret_cast<const int8_t*>(data));
+}
+
+inline std::size_t count_zero_num(const int8_t* data, std::size_t size) {
+    std::size_t num = 0;
     const int8_t* end = data + size;
-#if defined(__SSE2__) && defined(__POPCNT__)
-    const __m128i zero16 = _mm_setzero_si128();
+#if defined(__POPCNT__)
     const int8_t* end64 = data + (size / 64 * 64);
-
     for (; data < end64; data += 64) {
-        num += __builtin_popcountll(
-                static_cast<uint64_t>(_mm_movemask_epi8(_mm_cmpeq_epi8(
-                        _mm_loadu_si128(reinterpret_cast<const __m128i*>(data)), zero16))) |
-                (static_cast<uint64_t>(_mm_movemask_epi8(_mm_cmpeq_epi8(
-                         _mm_loadu_si128(reinterpret_cast<const __m128i*>(data + 16)), zero16)))
-                 << 16u) |
-                (static_cast<uint64_t>(_mm_movemask_epi8(_mm_cmpeq_epi8(
-                         _mm_loadu_si128(reinterpret_cast<const __m128i*>(data + 32)), zero16)))
-                 << 32u) |
-                (static_cast<uint64_t>(_mm_movemask_epi8(_mm_cmpeq_epi8(
-                         _mm_loadu_si128(reinterpret_cast<const __m128i*>(data + 48)), zero16)))
-                 << 48u));
+        num += __builtin_popcountll(bytes64_mask_to_bits64_not_mask(data));
     }
 #endif
     for (; data < end; ++data) {
@@ -89,14 +92,29 @@ inline size_t count_zero_num(const int8_t* __restrict data, size_t size) {
     return num;
 }
 
-inline size_t count_zero_num(const int8_t* __restrict data, const uint8_t* __restrict null_map,
-                             size_t size) {
-    size_t num = 0;
+inline std::size_t count_zero_num(const int8_t* data, const uint8_t* null_map, std::size_t size) {
+    std::size_t num = 0;
     const int8_t* end = data + size;
     for (; data < end; ++data, ++null_map) {
         num += ((*data == 0) | *null_map);
     }
     return num;
+}
+
+/**
+ * Counts how many bytes of `data` are not equal zero.
+ * NOTE: In theory, `data` should only contain zeros and ones.
+ */
+inline std::size_t count_not_zero(const int8_t* data, std::size_t size) {
+    return size - count_zero_num(data, size);
+}
+
+inline std::size_t count_not_zero(std::vector<uint8_t>& vec) {
+    return count_not_zero(reinterpret_cast<const int8_t*>(vec.data()), vec.size());
+}
+
+inline std::size_t count_not_zero(const vectorized::IColumn::Filter& filter) {
+    return count_not_zero(reinterpret_cast<const int8_t*>(filter.data()), filter.size());
 }
 
 // TODO: compare with different SIMD implements
@@ -120,5 +138,4 @@ inline size_t find_zero(const std::vector<uint8_t>& vec, size_t start) {
     return find_byte<uint8_t>(vec, start, 0);
 }
 
-} // namespace simd
-} // namespace doris
+} // namespace doris::simd

--- a/be/src/vec/CMakeLists.txt
+++ b/be/src/vec/CMakeLists.txt
@@ -203,6 +203,7 @@ set(VEC_FILES
   olap/vgeneric_iterators.cpp
   olap/vcollect_iterator.cpp
   olap/block_reader.cpp
+  olap/block_aggregator.cpp
   olap/olap_data_convertor.cpp
   sink/vmysql_result_writer.cpp
   sink/vresult_sink.cpp

--- a/be/src/vec/aggregate_functions/aggregate_function_distinct.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_distinct.h
@@ -196,7 +196,6 @@ public:
         this->data(place).deserialize(buf, arena);
     }
 
-    // void insert_result_into(AggregateDataPtr place, IColumn & to, Arena * arena) const override
     void insert_result_into(ConstAggregateDataPtr targetplace, IColumn& to) const override {
         auto place = const_cast<AggregateDataPtr>(targetplace);
         auto arguments = this->data(place).get_arguments(this->argument_types);

--- a/be/src/vec/columns/column_const.cpp
+++ b/be/src/vec/columns/column_const.cpp
@@ -21,6 +21,7 @@
 #include "vec/columns/column_const.h"
 
 #include "runtime/raw_value.h"
+#include "util/simd/bits.h"
 #include "vec/columns/columns_common.h"
 #include "vec/common/pod_array.h"
 #include "vec/common/sip_hash.h"
@@ -36,7 +37,8 @@ ColumnConst::ColumnConst(const ColumnPtr& data_, size_t s_) : data(data_), s(s_)
 
     if (data->size() != 1) {
         LOG(FATAL) << fmt::format(
-                "Incorrect size of nested column in constructor of ColumnConst: {}, must be 1.");
+                "Incorrect size of nested column in constructor of ColumnConst: {}, must be "
+                "1.");
     }
 }
 
@@ -54,7 +56,7 @@ ColumnPtr ColumnConst::filter(const Filter& filt, ssize_t /*result_size_hint*/) 
                                   filt.size(), s);
     }
 
-    return ColumnConst::create(data, count_bytes_in_filter(filt));
+    return ColumnConst::create(data, simd::count_not_zero(filt));
 }
 
 ColumnPtr ColumnConst::replicate(const Offsets& offsets) const {

--- a/be/src/vec/columns/column_decimal.cpp
+++ b/be/src/vec/columns/column_decimal.cpp
@@ -283,13 +283,13 @@ ColumnPtr ColumnDecimal<T>::filter(const IColumn::Filter& filt, ssize_t result_s
         *  completely pass or do not pass the filter.
         * Therefore, we will optimistically check the parts of `SIMD_BYTES` values.
         */
-    static constexpr size_t SIMD_BYTES = 32;
+    static constexpr size_t SIMD_BYTES = 64;
     const UInt8* filt_end_sse = filt_pos + size / SIMD_BYTES * SIMD_BYTES;
 
     while (filt_pos < filt_end_sse) {
-        uint32_t mask = simd::bytes32_mask_to_bits32_mask(filt_pos);
+        auto mask = simd::bytes64_mask_to_bits64_mask(filt_pos);
 
-        if (0xFFFFFFFF == mask) {
+        if (0xFFFFFFFFFFFFFFFF == mask) {
             res_data.insert(data_pos, data_pos + SIMD_BYTES);
         } else {
             while (mask) {

--- a/be/src/vec/columns/column_decimal.cpp
+++ b/be/src/vec/columns/column_decimal.cpp
@@ -289,7 +289,7 @@ ColumnPtr ColumnDecimal<T>::filter(const IColumn::Filter& filt, ssize_t result_s
     while (filt_pos < filt_end_sse) {
         auto mask = simd::bytes64_mask_to_bits64_mask(filt_pos);
 
-        if (0xFFFFFFFFFFFFFFFF == mask) {
+        if (simd::UINT64_MAX_MASK == mask) {
             res_data.insert(data_pos, data_pos + SIMD_BYTES);
         } else {
             while (mask) {

--- a/be/src/vec/columns/column_dummy.h
+++ b/be/src/vec/columns/column_dummy.h
@@ -20,6 +20,7 @@
 
 #pragma once
 
+#include "util/simd/bits.h"
 #include "vec/columns/column.h"
 #include "vec/columns/columns_common.h"
 #include "vec/common/arena.h"
@@ -84,7 +85,7 @@ public:
     }
 
     ColumnPtr filter(const Filter& filt, ssize_t /*result_size_hint*/) const override {
-        return clone_dummy(count_bytes_in_filter(filt));
+        return clone_dummy(simd::count_not_zero(filt));
     }
 
     ColumnPtr permute(const Permutation& perm, size_t limit) const override {

--- a/be/src/vec/columns/column_vector.cpp
+++ b/be/src/vec/columns/column_vector.cpp
@@ -369,7 +369,7 @@ ColumnPtr ColumnVector<T>::filter(const IColumn::Filter& filt, ssize_t result_si
     while (filt_pos < filt_end_sse) {
         auto mask = simd::bytes64_mask_to_bits64_mask(filt_pos);
 
-        if (0xFFFFFFFFFFFFFFFF == mask) {
+        if (simd::UINT64_MAX_MASK == mask) {
             res_data.insert(data_pos, data_pos + SIMD_BYTES);
         } else {
             while (mask) {

--- a/be/src/vec/columns/column_vector.cpp
+++ b/be/src/vec/columns/column_vector.cpp
@@ -363,13 +363,13 @@ ColumnPtr ColumnVector<T>::filter(const IColumn::Filter& filt, ssize_t result_si
         *  completely pass or do not pass the filter.
         * Therefore, we will optimistically check the parts of `SIMD_BYTES` values.
         */
-    static constexpr size_t SIMD_BYTES = 32;
+    static constexpr size_t SIMD_BYTES = 64;
     const UInt8* filt_end_sse = filt_pos + size / SIMD_BYTES * SIMD_BYTES;
 
     while (filt_pos < filt_end_sse) {
-        uint32_t mask = simd::bytes32_mask_to_bits32_mask(filt_pos);
+        auto mask = simd::bytes64_mask_to_bits64_mask(filt_pos);
 
-        if (0xFFFFFFFF == mask) {
+        if (0xFFFFFFFFFFFFFFFF == mask) {
             res_data.insert(data_pos, data_pos + SIMD_BYTES);
         } else {
             while (mask) {

--- a/be/src/vec/columns/columns_common.cpp
+++ b/be/src/vec/columns/columns_common.cpp
@@ -153,7 +153,7 @@ void filter_arrays_impl_generic(const PaddedPODArray<T>& src_elems,
     while (filt_pos < filt_end_aligned) {
         auto mask = simd::bytes64_mask_to_bits64_mask(filt_pos);
 
-        if (0xFFFFFFFFFFFFFFFF == mask) {
+        if (simd::UINT64_MAX_MASK == mask) {
             /// SIMD_BYTES consecutive rows pass the filter
             const auto first = offsets_pos == offsets_begin;
 

--- a/be/src/vec/columns/columns_common.h
+++ b/be/src/vec/columns/columns_common.h
@@ -26,9 +26,6 @@
 
 namespace doris::vectorized {
 
-/// Counts how many bytes of `filt` are greater than zero.
-size_t count_bytes_in_filter(const IColumn::Filter& filt);
-
 /// Returns vector with num_columns elements. vector[i] is the count of i values in selector.
 /// Selector must contain values from 0 to num_columns - 1. NOTE: this is not checked.
 std::vector<size_t> count_columns_size_in_selector(IColumn::ColumnIndex num_columns,

--- a/be/src/vec/core/block.cpp
+++ b/be/src/vec/core/block.cpp
@@ -618,7 +618,7 @@ void Block::update_hash(SipHash& hash) const {
 
 void Block::filter_block_internal(Block* block, const IColumn::Filter& filter,
                                   uint32_t column_to_keep) {
-    size_t count = filter.size() - simd::count_zero_num((int8_t*)filter.data(), filter.size());
+    size_t count = simd::count_not_zero(filter);
     if (count == 0) {
         for (size_t i = 0; i < column_to_keep; ++i) {
             std::move(*block->get_by_position(i).column).assume_mutable()->clear();

--- a/be/src/vec/core/block.h
+++ b/be/src/vec/core/block.h
@@ -477,14 +477,12 @@ public:
                                    ->get_nested_type()
                                    ->equals(*block.get_by_position(i).type));
                     DCHECK(!block.get_by_position(i).type->is_nullable());
-                    const IColumn& src = *make_nullable(block.get_by_position(i).column)
-                                                  ->convert_to_full_column_if_const();
-                    _columns[i]->insert_range_from(src, 0, src.size());
+                    auto src = make_nullable(block.get_by_position(i).column)
+                                       ->convert_to_full_column_if_const();
+                    _columns[i]->insert_range_from(*src, 0, src->size());
                 } else {
-                    const IColumn& src = *block.get_by_position(i)
-                                                  .column->convert_to_full_column_if_const()
-                                                  .get();
-                    _columns[i]->insert_range_from(src, 0, src.size());
+                    auto src = block.get_by_position(i).column->convert_to_full_column_if_const();
+                    _columns[i]->insert_range_from(*src, 0, src->size());
                 }
             }
         }

--- a/be/src/vec/olap/block_aggregator.cpp
+++ b/be/src/vec/olap/block_aggregator.cpp
@@ -241,4 +241,10 @@ size_t BlockAggregator::agg_block_rows() {
     return 0;
 }
 
+void BlockAggregator::finalize_source() {
+    for (int i = 0; i < _num_columns; ++i) {
+        _column_aggregator[i]->finalize_source();
+    }
+}
+
 } // namespace doris::vectorized

--- a/be/src/vec/olap/block_aggregator.cpp
+++ b/be/src/vec/olap/block_aggregator.cpp
@@ -121,15 +121,25 @@ CompareFunc BlockAggregator::_get_comparator(const TabletColumn& col) {
     case OLAP_FIELD_TYPE_DOUBLE:
         return &compare_previous<ColumnFloat64>;
     case OLAP_FIELD_TYPE_DECIMAL:
-        return &compare_previous<ColumnDecimal<Decimal128>>;
+        return &compare_previous<ColumnDecimal128>;
+    case OLAP_FIELD_TYPE_DECIMAL32:
+        return &compare_previous<ColumnDecimal32>;
+    case OLAP_FIELD_TYPE_DECIMAL64:
+        return &compare_previous<ColumnDecimal64>;
+    case OLAP_FIELD_TYPE_DECIMAL128:
+        return &compare_previous<ColumnDecimal128>;
     case OLAP_FIELD_TYPE_CHAR:
     case OLAP_FIELD_TYPE_VARCHAR:
     case OLAP_FIELD_TYPE_STRING:
         return &compare_previous<ColumnString>;
     case OLAP_FIELD_TYPE_DATE:
         return &compare_previous<ColumnDate>;
+    case OLAP_FIELD_TYPE_DATEV2:
+        return &compare_previous<ColumnDateV2>;
     case OLAP_FIELD_TYPE_DATETIME:
         return &compare_previous<ColumnDateTime>;
+    case OLAP_FIELD_TYPE_DATETIMEV2:
+        return &compare_previous<ColumnDateTimeV2>;
     default:
         DCHECK(false) << "unhandled key column type: " << col.type();
         return nullptr;

--- a/be/src/vec/olap/block_aggregator.cpp
+++ b/be/src/vec/olap/block_aggregator.cpp
@@ -1,0 +1,227 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "vec/olap/block_aggregator.h"
+
+#include "util/simd/bits.h"
+#include "vec/columns/column_nullable.h"
+#include "vec/columns/columns_number.h"
+#include "vec/core/types.h"
+#include "vec/data_types/data_type_factory.hpp"
+
+namespace doris::vectorized {
+
+template <typename ColumnType>
+inline void compare_previous(const IColumn& col, uint8_t* flags) {
+    if (col.is_nullable()) {
+        auto col_ptr = reinterpret_cast<const ColumnNullable*>(&col);
+        for (int i = 1; i < col_ptr->size(); ++i) {
+            flags[i] &= (col_ptr->compare_at(i, i - 1, col, -1) == 0);
+        }
+    } else {
+        auto col_ptr = reinterpret_cast<const ColumnType*>(&col);
+        for (int i = 1; i < col_ptr->size(); ++i) {
+            flags[i] &= (col_ptr->compare_at(i, i - 1, col, -1) == 0);
+        }
+    }
+}
+
+BlockAggregator::BlockAggregator(const TabletSchema* tablet_schema,
+                                 const std::vector<uint32_t>& output_columns,
+                                 const std::vector<uint32_t>& return_columns,
+                                 const std::unordered_set<uint32_t>* null_set, const int batch_size)
+        : _tablet_schema(tablet_schema),
+          _output_columns(output_columns),
+          _sorted_output_columns(output_columns),
+          _return_columns(return_columns),
+          _null_set(null_set),
+          _batch_size(batch_size) {
+    _has_agg_data = false;
+    _do_aggregate = true;
+    _agg_ratio = config::block_aggregate_ratio;
+    _num_columns = _output_columns.size();
+    _num_key_columns = 0;
+
+    // todo(zeno) Make sure column prune done
+    std::sort(_sorted_output_columns.begin(), _sorted_output_columns.end());
+    _output_columns_loc.resize(_num_columns);
+    for (int i = 0; i < _num_columns; ++i) {
+        for (int j = 0; j < _num_columns; ++j) {
+            if (_sorted_output_columns[i] == output_columns[j]) {
+                _output_columns_loc[i] = j;
+                break;
+            }
+        }
+    }
+
+    for (auto index : _sorted_output_columns) {
+        if (_tablet_schema->column(index).is_key()) {
+            _num_key_columns++;
+        }
+    }
+
+    _current_row = 0;
+    _source_size = 0;
+    _eq_previous.reserve(_batch_size);
+    _agg_index.reserve(_batch_size);
+    _agg_range.reserve(_batch_size);
+
+    // init _key_comparator
+    for (int i = 0; i < _num_key_columns; ++i) {
+        _key_comparator.emplace_back(
+                _get_comparator(_tablet_schema->column(_sorted_output_columns[i])));
+    }
+
+    // init _column_aggregator
+    for (int i = 0; i < _num_key_columns; ++i) {
+        _column_aggregator.emplace_back(std::make_unique<KeyColumnAggregator>());
+    }
+
+    for (int i = _num_key_columns; i < _num_columns; ++i) {
+        bool is_nullable = (_null_set != nullptr &&
+                            _null_set->find(_sorted_output_columns[i]) != _null_set->end());
+        auto col = _tablet_schema->column(_sorted_output_columns[i]);
+        auto data_type = vectorized::DataTypeFactory::instance().create_data_type(col, is_nullable);
+        _column_aggregator.emplace_back(std::make_unique<ValueColumnAggregator>(col, data_type));
+    }
+
+    aggregate_reset();
+}
+
+CompareFunc BlockAggregator::_get_comparator(const TabletColumn& col) {
+    switch (col.type()) {
+    case OLAP_FIELD_TYPE_TINYINT:
+        return &compare_previous<ColumnInt8>;
+    case OLAP_FIELD_TYPE_SMALLINT:
+        return &compare_previous<ColumnInt16>;
+    case OLAP_FIELD_TYPE_INT:
+        return &compare_previous<ColumnInt32>;
+    case OLAP_FIELD_TYPE_BIGINT:
+        return &compare_previous<ColumnInt64>;
+    case OLAP_FIELD_TYPE_LARGEINT:
+        return &compare_previous<ColumnInt128>;
+    case OLAP_FIELD_TYPE_BOOL:
+        return &compare_previous<ColumnUInt8>;
+    case OLAP_FIELD_TYPE_FLOAT:
+        return &compare_previous<ColumnFloat32>;
+    case OLAP_FIELD_TYPE_DOUBLE:
+        return &compare_previous<ColumnFloat64>;
+    case OLAP_FIELD_TYPE_DECIMAL:
+        return &compare_previous<ColumnDecimal<Decimal128>>;
+    case OLAP_FIELD_TYPE_CHAR:
+    case OLAP_FIELD_TYPE_VARCHAR:
+    case OLAP_FIELD_TYPE_STRING:
+        return &compare_previous<ColumnString>;
+    case OLAP_FIELD_TYPE_DATE:
+        return &compare_previous<ColumnDate>;
+    case OLAP_FIELD_TYPE_DATETIME:
+        return &compare_previous<ColumnDateTime>;
+    default:
+        DCHECK(false) << "unhandled key column type: " << col.type();
+        return nullptr;
+    }
+}
+
+void BlockAggregator::update_source(const Block* block) {
+    _eq_previous.assign(block->rows(), 1);
+    _source_size = 0;
+    _current_row = 0;
+    _do_aggregate = true;
+
+    for (int i = _num_key_columns - 1; i >= 0; --i) {
+        _key_comparator[i](*block->get_column_by_position(_output_columns_loc[i]),
+                           _eq_previous.data());
+        size_t eq_count = simd::count_not_zero(_eq_previous);
+        if (_agg_ratio != 0 && eq_count + 1 < block->rows() * _agg_ratio) {
+            _do_aggregate = false;
+            return;
+        }
+    }
+
+    if (_result_block->rows() > 0 && _num_key_columns > 0) {
+        _eq_previous[0] = _result_block->compare_at(_result_block->rows() - 1, 0, _num_key_columns,
+                                                    *block, -1, _output_columns_loc) == 0;
+    } else {
+        _eq_previous[0] = 0;
+    }
+
+    // update source column
+    for (int i = 0; i < _num_columns; ++i) {
+        _column_aggregator[i]->update_source(block->get_column_by_position(_output_columns_loc[i]));
+    }
+    _source_size = block->rows();
+}
+
+void BlockAggregator::aggregate() {
+    if (source_exhausted()) {
+        return;
+    }
+
+    _agg_index.clear();
+    _agg_range.clear();
+
+    if (_eq_previous[_current_row] == 1) {
+        _agg_range.emplace_back(0);
+    }
+
+    uint32_t cur_row = _current_row;
+    uint32_t res_rows = _result_block->rows();
+    for (; cur_row < _source_size; ++cur_row) {
+        if (_eq_previous[cur_row] == 0) {
+            if (res_rows >= _batch_size) {
+                break;
+            }
+            res_rows++;
+            _agg_index.emplace_back(cur_row);
+            _agg_range.emplace_back(1);
+        } else {
+            _agg_range[_agg_range.size() - 1] += 1;
+        }
+    }
+
+    bool neq_previous = !_eq_previous[_current_row] && (_result_block->rows() != 0);
+
+    for (int i = 0; i < _num_key_columns; ++i) {
+        _column_aggregator[i]->aggregate_keys(_agg_index.size(), _agg_index.data());
+    }
+    for (int i = _num_key_columns; i < _num_columns; ++i) {
+        _column_aggregator[i]->aggregate_values(_current_row, _agg_range.size(), _agg_range.data(),
+                                                neq_previous);
+    }
+    _current_row = cur_row;
+    _has_agg_data = true;
+}
+
+std::shared_ptr<Block> BlockAggregator::aggregate_result() {
+    for (int i = 0; i < _num_columns; ++i) {
+        _column_aggregator[i]->finalize();
+    }
+    _has_agg_data = false;
+    return _result_block;
+}
+
+void BlockAggregator::aggregate_reset() {
+    _result_block =
+            std::make_shared<Block>(_tablet_schema->create_block(_return_columns, _null_set));
+    auto cols = _result_block->mutate_columns();
+    for (int i = 0; i < _num_columns; ++i) {
+        _column_aggregator[i]->update_aggregate(cols[_output_columns_loc[i]]);
+    }
+    _has_agg_data = false;
+}
+
+} // namespace doris::vectorized

--- a/be/src/vec/olap/block_aggregator.h
+++ b/be/src/vec/olap/block_aggregator.h
@@ -1,0 +1,82 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <vector>
+
+#include "olap/tablet_schema.h"
+#include "vec/columns/column.h"
+#include "vec/olap/column_aggregator.h"
+
+namespace doris::vectorized {
+
+using CompareFunc = void (*)(const vectorized::IColumn& col, uint8_t* flags);
+
+class BlockAggregator {
+public:
+    BlockAggregator(const TabletSchema* tablet_schema, const std::vector<uint32_t>& output_columns,
+                    const std::vector<uint32_t>& return_columns,
+                    const std::unordered_set<uint32_t>* null_set, int batch_size);
+
+    void update_source(const Block* block);
+
+    void aggregate();
+
+    bool source_exhausted() { return _current_row == _source_size; }
+
+    bool is_finish() { return _result_block->rows() >= _batch_size; }
+
+    std::shared_ptr<Block> aggregate_result();
+
+    bool has_agg_data() { return _has_agg_data; }
+
+    void aggregate_reset();
+
+    bool is_do_aggregate() { return _do_aggregate; }
+
+private:
+    CompareFunc _get_comparator(const TabletColumn& col);
+
+    const TabletSchema* _tablet_schema;
+    std::vector<uint32_t> _output_columns;
+    std::vector<uint32_t> _sorted_output_columns;
+    std::vector<uint32_t> _return_columns;
+    const std::unordered_set<uint32_t>* _null_set;
+    std::vector<uint32_t> _output_columns_loc;
+
+    size_t _num_key_columns;
+    size_t _num_columns;
+    bool _has_agg_data;
+    int _batch_size;
+    bool _do_aggregate;
+    double _agg_ratio;
+
+    uint32_t _current_row;
+    uint32_t _source_size;
+
+    std::vector<CompareFunc> _key_comparator;
+    std::vector<ColumnAggregatorPtr> _column_aggregator;
+    std::vector<uint8_t> _eq_previous;
+
+    std::vector<uint32_t> _agg_index;
+    std::vector<uint32_t> _agg_range;
+
+    std::shared_ptr<Block> _result_block;
+};
+
+} // namespace doris::vectorized

--- a/be/src/vec/olap/block_aggregator.h
+++ b/be/src/vec/olap/block_aggregator.h
@@ -51,6 +51,8 @@ public:
 
     size_t agg_block_rows();
 
+    void finalize_source();
+
 private:
     CompareFunc _get_comparator(const TabletColumn& col);
 

--- a/be/src/vec/olap/block_aggregator.h
+++ b/be/src/vec/olap/block_aggregator.h
@@ -39,7 +39,7 @@ public:
 
     bool source_exhausted() { return _current_row == _source_size; }
 
-    bool is_finish() { return _result_block->rows() >= _batch_size; }
+    bool is_finish() { return agg_block_rows() >= _batch_size; }
 
     std::shared_ptr<Block> aggregate_result();
 
@@ -48,6 +48,8 @@ public:
     void aggregate_reset();
 
     bool is_do_aggregate() { return _do_aggregate; }
+
+    size_t agg_block_rows();
 
 private:
     CompareFunc _get_comparator(const TabletColumn& col);

--- a/be/src/vec/olap/block_reader.cpp
+++ b/be/src/vec/olap/block_reader.cpp
@@ -184,6 +184,7 @@ Status BlockReader::_agg_next_block(Block* block, MemPool* mem_pool, ObjectPool*
     Status status;
     while (true) {
         if (_block_aggregator->source_exhausted()) {
+            _block_aggregator->finalize_source();
             status = _direct_next_block(block, mem_pool, agg_pool, eof);
             if (UNLIKELY(!status.ok())) {
                 return status;

--- a/be/src/vec/olap/block_reader.h
+++ b/be/src/vec/olap/block_reader.h
@@ -22,6 +22,7 @@
 #include "olap/reader.h"
 #include "olap/rowset/rowset_reader.h"
 #include "vec/aggregate_functions/aggregate_function.h"
+#include "vec/olap/block_aggregator.h"
 #include "vec/olap/vcollect_iterator.h"
 
 namespace doris {
@@ -41,9 +42,7 @@ public:
     }
 
     Status next_block_with_aggregation(Block* block, MemPool* mem_pool, ObjectPool* agg_pool,
-                                       bool* eof) override {
-        return (this->*_next_block_func)(block, mem_pool, agg_pool, eof);
-    }
+                                       bool* eof) override;
 
     std::vector<RowLocation> current_block_row_locations() { return _block_row_locations; }
 
@@ -80,6 +79,8 @@ private:
 
     void _update_agg_value(MutableColumns& columns, int begin, int end, bool is_close = true);
 
+    Status _agg_next_block(Block* block, MemPool* mem_pool, ObjectPool* agg_pool, bool* eof);
+
     VCollectIterator _vcollect_iter;
     IteratorRowRef _next_row {{}, -1, false};
 
@@ -109,6 +110,8 @@ private:
     std::vector<RowLocation> _block_row_locations;
 
     ColumnPtr _delete_filter_column;
+
+    std::unique_ptr<BlockAggregator> _block_aggregator;
 };
 
 } // namespace vectorized

--- a/be/src/vec/olap/block_reader.h
+++ b/be/src/vec/olap/block_reader.h
@@ -42,7 +42,9 @@ public:
     }
 
     Status next_block_with_aggregation(Block* block, MemPool* mem_pool, ObjectPool* agg_pool,
-                                       bool* eof) override;
+                                       bool* eof) override {
+        return (this->*_next_block_func)(block, mem_pool, agg_pool, eof);
+    }
 
     std::vector<RowLocation> current_block_row_locations() { return _block_row_locations; }
 

--- a/be/src/vec/olap/column_aggregator.h
+++ b/be/src/vec/olap/column_aggregator.h
@@ -43,6 +43,8 @@ public:
 
     virtual void finalize() { _agg_column = nullptr; }
 
+    virtual void finalize_source() { _source_column = nullptr; }
+
 public:
     ColumnPtr _source_column;
     IColumn* _agg_column;

--- a/be/src/vec/olap/column_aggregator.h
+++ b/be/src/vec/olap/column_aggregator.h
@@ -1,0 +1,139 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include "vec/aggregate_functions/aggregate_function.h"
+#include "vec/aggregate_functions/aggregate_function_reader.h"
+#include "vec/aggregate_functions/aggregate_function_simple_factory.h"
+#include "vec/columns/column.h"
+
+namespace doris::vectorized {
+
+class ColumnAggregator {
+public:
+    ColumnAggregator() : _source_column(nullptr) {}
+
+    virtual ~ColumnAggregator() = default;
+
+    // update input column
+    virtual void update_source(const ColumnPtr& col) { _source_column = col; }
+
+    // update output aggregate column
+    virtual void update_aggregate(IColumn* target) { _agg_column = target; }
+
+    virtual void aggregate_keys(int size, const uint32* agg_index) {}
+
+    virtual void aggregate_values(int start, int size, const uint32* agg_range, bool previous_neq) {
+    }
+
+    virtual void finalize() { _agg_column = nullptr; }
+
+public:
+    ColumnPtr _source_column;
+    IColumn* _agg_column;
+};
+
+class KeyColumnAggregator final : public ColumnAggregator {
+    void aggregate_keys(int size, const uint32* agg_index) override {
+        auto origin_size = _agg_column->size();
+        _agg_column->reserve(origin_size + size);
+        for (int i = 0; i < size; ++i) {
+            _agg_column->insert_from(*_source_column, agg_index[i]);
+        }
+    }
+};
+
+class ValueColumnAggregator : public ColumnAggregator {
+public:
+    ValueColumnAggregator(const TabletColumn& col, const DataTypePtr data_type) {
+        // create aggregate function
+        FieldAggregationMethod agg_method = col.aggregation();
+        std::string agg_name =
+                TabletColumn::get_string_by_aggregation_type(agg_method) + AGG_READER_SUFFIX;
+        std::transform(agg_name.begin(), agg_name.end(), agg_name.begin(),
+                       [](unsigned char c) { return std::tolower(c); });
+        Array params;
+        DataTypes argument_types;
+        argument_types.push_back(data_type);
+        _agg_function = AggregateFunctionSimpleFactory::instance().get(
+                agg_name, argument_types, params, data_type->is_nullable());
+        DCHECK(_agg_function != nullptr);
+
+        // create aggregate data
+        _agg_place = new char[_agg_function->size_of_data()];
+        _agg_function->create(_agg_place);
+    }
+
+    void update_aggregate(IColumn* col) override {
+        _agg_column = col;
+        reset();
+    }
+
+    void aggregate_values(int start, int size, const uint32* agg_range,
+                          bool neq_previous) override {
+        if (size <= 0) {
+            return;
+        }
+
+        // not equal to the last row of the previous block
+        if (neq_previous) {
+            append_data(_agg_column);
+            reset();
+        }
+
+        for (int i = 0; i < size - 1; ++i) {
+            aggregate_batch_impl(start, start + agg_range[i] - 1, _source_column);
+            append_data(_agg_column);
+
+            start += agg_range[i];
+            reset();
+        }
+
+        // last row just aggregate, not append
+        aggregate_batch_impl(start, start + agg_range[size - 1] - 1, _source_column);
+    }
+
+    void finalize() override {
+        append_data(_agg_column);
+        _agg_column = nullptr;
+    }
+
+    void reset() {
+        _agg_function->destroy(_agg_place);
+        _agg_function->create(_agg_place);
+    }
+
+    void append_data(IColumn* col) { _agg_function->insert_result_into(_agg_place, *col); }
+
+    void aggregate_batch_impl(int begin, int end, const ColumnPtr& src) {
+        auto column_ptr = src.get();
+        if (begin <= end) {
+            // todo(zeno) add has_null hint
+            _agg_function->add_batch_range(begin, end, _agg_place,
+                                           const_cast<const IColumn**>(&column_ptr), nullptr);
+        }
+    }
+
+private:
+    AggregateFunctionPtr _agg_function;
+    AggregateDataPtr _agg_place;
+};
+
+using ColumnAggregatorPtr = std::unique_ptr<ColumnAggregator>;
+
+} // namespace doris::vectorized


### PR DESCRIPTION
# Proposed changes

Issue Number: close #10083 
In scanner thread, the same key of adjacent rows is aggregated, which reduces data transmission and improves the parallelism of aggregation.

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
