### PR TITLE
[deps] update libhdfs3 to fix a uuid set problem

### DIFF
--- a/thirdparty/CHANGELOG.md
+++ b/thirdparty/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 This file contains version of the third-party dependency libraries in the build-env image. The docker build-env image is apache/incubator-doris, and the tag is `build-env-${version}`
 
+## v20220613
+- Modified: update libhdfs3 from 2.3.0 to 2.3.1  fix client uuid set error
+
 ## v20220608
 - Remove: remove libhdfs3 without kerberos support
 - Modified: make libhdfs3 with kerberos support as default

--- a/thirdparty/vars.sh
+++ b/thirdparty/vars.sh
@@ -345,10 +345,10 @@ KRB5_SOURCE="krb5-1.19"
 KRB5_MD5SUM="aaf18447a5a014aa3b7e81814923f4c9"
 
 # hdfs3
-HDFS3_DOWNLOAD="https://github.com/yangzhg/libhdfs3/archive/refs/tags/v2.3.0.tar.gz"
-HDFS3_NAME="libhdfs3-2.3.0.tar.gz"
-HDFS3_SOURCE="libhdfs3-2.3.0"
-HDFS3_MD5SUM="f647975fb7ad03bf25a14f530b1a5c06"
+HDFS3_DOWNLOAD="https://github.com/yangzhg/libhdfs3/archive/refs/tags/v2.3.1.tar.gz"
+HDFS3_NAME="libhdfs3-2.3.1.tar.gz"
+HDFS3_SOURCE="libhdfs3-2.3.1"
+HDFS3_MD5SUM="64ab3004826d83b23522ccf26940db94"
 
 #libdivide
 LIBDIVIDE_DOWNLOAD="https://github.com/ridiculousfish/libdivide/archive/5.0.tar.gz"


### PR DESCRIPTION
# Proposed changes

in libhdfs3 2.3.0 when write uuid to rpc head use string not  int128 this will cause rpc failed, updated to 2.3.1

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (No)
2. Has unit tests been added: (No Need)
3. Has document been added or modified: (No Need)
4. Does it need to update dependencies: (Yes)
5. Are there any changes that cannot be rolled back: (No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
