### PR TITLE
[improvement](profile) Add table name and predicates

### DIFF
--- a/be/src/util/to_string.h
+++ b/be/src/util/to_string.h
@@ -18,12 +18,12 @@
 
 #pragma once
 
+#include <fmt/format.h>
+
 #include <map>
 #include <set>
 #include <string>
 #include <vector>
-
-#include <fmt/format.h>
 
 namespace doris {
 template <typename T>
@@ -62,7 +62,7 @@ std::string to_string(const std::vector<T>& t) {
 
 template <typename K, typename V>
 std::string to_string(const std::map<K, V>& m) {
-    return "{" +  to_string(m.begin(), m.end()) + "}";
+    return "{" + to_string(m.begin(), m.end()) + "}";
 }
 
 template <typename T>

--- a/be/src/util/to_string.h
+++ b/be/src/util/to_string.h
@@ -1,0 +1,73 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+#pragma once
+
+#include <map>
+#include <set>
+#include <string>
+#include <vector>
+
+#include <fmt/format.h>
+
+namespace doris {
+template <typename T>
+std::string to_string(const T& t) {
+    return fmt::format("{}", t);
+}
+
+template <typename K, typename V>
+std::string to_string(const std::map<K, V>& m);
+
+template <typename T>
+std::string to_string(const std::set<T>& s);
+
+template <typename T>
+std::string to_string(const std::vector<T>& t);
+
+template <typename K, typename V>
+std::string to_string(const typename std::pair<K, V>& v) {
+    return fmt::format("{}: {}", to_string(v.first), to_string(v.second));
+}
+
+template <typename T>
+std::string to_string(const T& beg, const T& end) {
+    std::string out;
+    for (T it = beg; it != end; ++it) {
+        if (it != beg) out += ", ";
+        out += to_string(*it);
+    }
+    return out;
+}
+
+template <typename T>
+std::string to_string(const std::vector<T>& t) {
+    return "[" + to_string(t.begin(), t.end()) + "]";
+}
+
+template <typename K, typename V>
+std::string to_string(const std::map<K, V>& m) {
+    return "{" +  to_string(m.begin(), m.end()) + "}";
+}
+
+template <typename T>
+std::string to_string(const std::set<T>& s) {
+    return "{" + to_string(s.begin(), s.end()) + "}";
+}
+
+} // namespace doris

--- a/fe/fe-core/src/main/java/org/apache/doris/common/profile/ProfileTreeBuilder.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/profile/ProfileTreeBuilder.java
@@ -31,6 +31,7 @@ import lombok.Setter;
 import org.apache.commons.lang3.tuple.ImmutableTriple;
 import org.apache.commons.lang3.tuple.Triple;
 
+import java.util.ArrayList;
 import java.util.Formatter;
 import java.util.List;
 import java.util.Map;
@@ -265,6 +266,14 @@ public class ProfileTreeBuilder {
         node.setActiveTime(RuntimeProfile.printCounter(activeCounter.getValue(), activeCounter.getType()));
         try (Formatter fmt = new Formatter()) {
             node.setNonChild(fmt.format("%.2f", profile.getLocalTimePercent()).toString());
+        }
+
+        if (!profile.getInfoStrings().isEmpty()) {
+            ArrayList<String> infoStrings = new ArrayList<String>();
+            for (Map.Entry<String, String> entry : profile.getInfoStrings().entrySet()) {
+                infoStrings.add(entry.getKey() +  ": " + entry.getValue());
+            }
+            node.setInfoStrings(infoStrings);
         }
         CounterNode rootCounterNode = new CounterNode();
         buildCounterNode(profile, RuntimeProfile.ROOT_COUNTER, rootCounterNode);

--- a/fe/fe-core/src/main/java/org/apache/doris/common/profile/ProfileTreeNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/profile/ProfileTreeNode.java
@@ -18,8 +18,10 @@
 package org.apache.doris.common.profile;
 
 import org.apache.doris.common.TreeNode;
-
 import com.google.common.base.Strings;
+import com.google.common.collect.Lists;
+
+import java.util.List;
 
 public class ProfileTreeNode extends TreeNode<ProfileTreeNode> {
 
@@ -27,6 +29,7 @@ public class ProfileTreeNode extends TreeNode<ProfileTreeNode> {
     protected String id;
     protected CounterNode counterNode;
     protected String activeTime;
+    protected List<String> infoStrings = Lists.newArrayList();
     protected String nonChild;
 
     protected String fragmentId = "";
@@ -73,6 +76,14 @@ public class ProfileTreeNode extends TreeNode<ProfileTreeNode> {
 
     public String getActiveTime() {
         return activeTime;
+    }
+
+    public void setInfoStrings(List<String> infoStrings) {
+        this.infoStrings = infoStrings;
+    }
+
+    public List<String> getInfoStrings() {
+        return infoStrings;
     }
 
     public void setNonChild(String nonChild) {
@@ -129,6 +140,14 @@ public class ProfileTreeNode extends TreeNode<ProfileTreeNode> {
         if (level == ProfileTreePrinter.PrintLevel.INSTANCE) {
             sb.append("(Active: ").append(activeTime).append(", ");
             sb.append("non-child: ").append(nonChild).append(")").append("\n");
+            if (!infoStrings.isEmpty()) {
+                String infoStringIndent = printIndent(indent + 1);
+                sb.append(infoStringIndent).append(" - Info:").append("\n");
+                infoStringIndent = printIndent(indent + 5);
+                for (String info : infoStrings) {
+                    sb.append(infoStringIndent).append(" - ").append(info).append("\n");
+                }
+            }
             // print counters
             sb.append(counterNode.toTree(indent + 1));
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/RuntimeProfile.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/RuntimeProfile.java
@@ -469,4 +469,8 @@ public class RuntimeProfile {
     public String getInfoString(String key) {
         return infoStrings.get(key);
     }
+
+    public Map<String, String> getInfoStrings() {
+        return infoStrings;
+    }
 }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

Add information of table name and column predicates in profile:
<img width="1241" alt="image" src="https://user-images.githubusercontent.com/1179834/173505683-9abf2e57-8575-410a-9f92-a109ab7b3f84.png">


And add info strings in `show query profile "/xxxxx"`
<img width="1231" alt="image" src="https://user-images.githubusercontent.com/1179834/173505519-943761b1-9e22-4f43-ab0d-0d0ffefa5db9.png">


## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
