### PR TITLE
[improvement] Add new session variable `session_context`

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/profile/ProfileTreePrinter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/profile/ProfileTreePrinter.java
@@ -20,12 +20,12 @@ package org.apache.doris.common.profile;
 import hu.webarticum.treeprinter.BorderTreeNodeDecorator;
 import hu.webarticum.treeprinter.SimpleTreeNode;
 import hu.webarticum.treeprinter.TraditionalTreePrinter;
+import org.json.simple.JSONObject;
 
 public class ProfileTreePrinter {
 
-    public static enum PrintLevel {
-        FRAGMENT,
-        INSTANCE
+    public enum PrintLevel {
+        FRAGMENT, INSTANCE
     }
 
     // Fragment tree only print the entire query plan tree with node name
@@ -51,5 +51,11 @@ public class ProfileTreePrinter {
             node.addChild(buildNode(child, level));
         }
         return node;
+    }
+
+    public static JSONObject printFragmentTreeInJson(ProfileTreeNode root) {
+        JSONObject object = new JSONObject();
+        // TODO
+        return object;
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/ProfileManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/ProfileManager.java
@@ -66,6 +66,7 @@ public class ProfileManager {
     public static final String DEFAULT_DB = "Default Db";
     public static final String SQL_STATEMENT = "Sql Statement";
     public static final String IS_CACHED = "Is Cached";
+    public static final String TRACE_ID = "Trace ID";
 
     public enum ProfileType {
         QUERY,
@@ -73,8 +74,8 @@ public class ProfileManager {
     }
 
     public static final ArrayList<String> PROFILE_HEADERS = new ArrayList(
-            Arrays.asList(QUERY_ID, USER, DEFAULT_DB, SQL_STATEMENT, QUERY_TYPE,
-                    START_TIME, END_TIME, TOTAL_TIME, QUERY_STATE));
+            Arrays.asList(QUERY_ID, USER, DEFAULT_DB, SQL_STATEMENT, QUERY_TYPE, START_TIME, END_TIME, TOTAL_TIME,
+                    QUERY_STATE, TRACE_ID));
 
     private class ProfileElement {
         public Map<String, String> infoStrings = Maps.newHashMap();

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/ProfileManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/ProfileManager.java
@@ -278,10 +278,24 @@ public class ProfileManager {
         try {
             ProfileElement element = queryIdToProfileMap.get(jobId);
             if (element == null || element.builder == null) {
-                throw new AnalysisException("failed to get task ids. err: "
-                        + (element == null ? "not found" : element.errMsg));
+                throw new AnalysisException(
+                        "failed to get task ids. err: " + (element == null ? "not found" : element.errMsg));
             }
             return element.builder;
+        } finally {
+            readLock.unlock();
+        }
+    }
+
+    public String getQueryIdByTraceId(String traceId) {
+        readLock.lock();
+        try {
+            for (Map.Entry<String, ProfileElement> entry : queryIdToProfileMap.entrySet()) {
+                if (entry.getValue().infoStrings.getOrDefault(TRACE_ID, "").equals(traceId)) {
+                    return entry.getKey();
+                }
+            }
+            return "";
         } finally {
             readLock.unlock();
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/RuntimeProfile.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/RuntimeProfile.java
@@ -467,6 +467,6 @@ public class RuntimeProfile {
     // Returns the value to which the specified key is mapped;
     // or null if this map contains no mapping for the key.
     public String getInfoString(String key) {
-        return infoStrings.get(key);
+        return infoStrings.getOrDefault(key, "");
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/manager/QueryProfileAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/manager/QueryProfileAction.java
@@ -39,6 +39,9 @@ import com.google.gson.JsonParser;
 import com.google.gson.reflect.TypeToken;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.jetbrains.annotations.NotNull;
+import org.json.simple.JSONObject;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -195,8 +198,9 @@ public class QueryProfileAction extends RestBaseController {
                 }
             }
         } else {
-            List<List<String>> queries = ProfileManager.getInstance().getAllQueries().stream()
-                    .filter(query -> query.get(0).equals(queryId)).collect(Collectors.toList());
+            List<List<String>> queries =
+                    ProfileManager.getInstance().getAllQueries().stream().filter(query -> query.get(0).equals(queryId))
+                            .collect(Collectors.toList());
             if (!queries.isEmpty()) {
                 querySql.put("sql", queries.get(0).get(3));
             }
@@ -204,38 +208,39 @@ public class QueryProfileAction extends RestBaseController {
         return ResponseEntityBuilder.ok(querySql);
     }
 
-    // Returns the text profile for the specified query id.
-    @RequestMapping(path = "/profile/text/{query_id}", method = RequestMethod.GET)
+    /**
+     * Returns the text profile for the specified query id.
+     * There are 3 formats:
+     * 1. Text: return the entire profile of the specified query id
+     * eg: {"profile": "text_xxx"}
+     * <p>
+     * 2. Graph: return the profile in ascii graph. If fragmentId and instanceId are specified, it will
+     * return the instance profile, otherwise, it will return the fragment profile.
+     * eg: {"profile" : "graph_xxx"}
+     * <p>
+     * 3. Json: return the profile in json. If fragmentId and instanceId are specified, it will
+     * return the instance profile, otherwise, it will return the fragment profile.
+     * Json format is mainly used for front-end UI drawing.
+     * eg: {"profile" : "json_xxx"}
+     */
+    @RequestMapping(path = "/profile/{format}/{query_id}", method = RequestMethod.GET)
     public Object queryProfileText(HttpServletRequest request, HttpServletResponse response,
-                                   @PathVariable("query_id") String queryId,
-                                   @RequestParam(value = IS_ALL_NODE_PARA, required = false, defaultValue = "true")
-                                           boolean isAllNode) {
+            @PathVariable("format") String format, @PathVariable("query_id") String queryId,
+            @RequestParam(value = FRAGMENT_ID, required = false) String fragmentId,
+            @RequestParam(value = INSTANCE_ID, required = false) String instanceId,
+            @RequestParam(value = IS_ALL_NODE_PARA, required = false, defaultValue = "true") boolean isAllNode) {
         executeCheckPassword(request, response);
         checkGlobalAuth(ConnectContext.get().getCurrentUserIdentity(), PrivPredicate.ADMIN);
 
-        Map<String, String> profileMap = Maps.newHashMap();
-        if (isAllNode) {
-            String httpPath = "/rest/v2/manager/query/profile/text/" + queryId;
-            ImmutableMap<String, String> arguments = ImmutableMap.<String, String>builder()
-                    .put(IS_ALL_NODE_PARA, "false").build();
-            List<String> dataList = requestAllFe(httpPath, arguments, request.getHeader(NodeAction.AUTHORIZATION));
-            if (!dataList.isEmpty()) {
-                try {
-                    String profile =
-                            JsonParser.parseString(dataList.get(0)).getAsJsonObject().get("profile").getAsString();
-                    profileMap.put("profile", profile);
-                    return ResponseEntityBuilder.ok(profileMap);
-                } catch (Exception e) {
-                    LOG.warn("parse profile text error: {}", dataList.get(0), e);
-                }
-            }
+        if (format.equals("text")) {
+            return getTextProfile(request, queryId, isAllNode);
+        } else if (format.equals("graph")) {
+            return getGraphProfile(request, queryId, fragmentId, instanceId, isAllNode);
+        } else if (format.equals("json")) {
+            return getJsonProfile(request, queryId, fragmentId, instanceId, isAllNode);
         } else {
-            String profile = ProfileManager.getInstance().getProfile(queryId);
-            if (!Strings.isNullOrEmpty(profile)) {
-                profileMap.put("profile", profile);
-            }
+            return ResponseEntityBuilder.badRequest("Invalid profile format: " + format);
         }
-        return ResponseEntityBuilder.ok(profileMap);
     }
 
     // Returns the fragments and instances for the specified query id.
@@ -285,37 +290,27 @@ public class QueryProfileAction extends RestBaseController {
         return ResponseEntityBuilder.badRequest("not found query id");
     }
 
-    // Returns the graph profile for the specified query id.
-    @RequestMapping(path = "/profile/graph/{query_id}", method = RequestMethod.GET)
-    public Object queryProfileGraph(HttpServletRequest request, HttpServletResponse response,
-                                    @PathVariable("query_id") String queryId,
-                                    @RequestParam(value = FRAGMENT_ID, required = false) String fragmentId,
-                                    @RequestParam(value = INSTANCE_ID, required = false) String instanceId,
-                                    @RequestParam(value = IS_ALL_NODE_PARA, required = false, defaultValue = "true")
-                                            boolean isAllNode) {
-        executeCheckPassword(request, response);
-        checkGlobalAuth(ConnectContext.get().getCurrentUserIdentity(), PrivPredicate.ADMIN);
+    @NotNull
+    private ResponseEntity getTextProfile(HttpServletRequest request, String queryId, boolean isAllNode) {
+        Map<String, String> profileMap = Maps.newHashMap();
+        if (isAllNode) {
+            return getProfileFromAllFrontends(request, "text", queryId, "", "");
+        } else {
+            String profile = ProfileManager.getInstance().getProfile(queryId);
+            if (!Strings.isNullOrEmpty(profile)) {
+                profileMap.put("profile", profile);
+            }
+        }
+        return ResponseEntityBuilder.ok(profileMap);
+    }
 
+    @NotNull
+    private ResponseEntity getGraphProfile(HttpServletRequest request, String queryId, String fragmentId,
+            String instanceId, boolean isAllNode) {
         Map<String, String> graph = Maps.newHashMap();
         List<String> results;
-
         if (isAllNode) {
-            String httpPath = "/rest/v2/manager/query/profile/graph/" + queryId;
-            Map<String, String> arguments = Maps.newHashMap();
-            arguments.put(FRAGMENT_ID, fragmentId);
-            arguments.put(INSTANCE_ID, instanceId);
-            arguments.put(IS_ALL_NODE_PARA, "false");
-            List<String> dataList = requestAllFe(httpPath, arguments, request.getHeader(NodeAction.AUTHORIZATION));
-            if (!dataList.isEmpty()) {
-                try {
-                    String profileGraph =
-                            JsonParser.parseString(dataList.get(0)).getAsJsonObject().get("graph").getAsString();
-                    graph.put("graph", profileGraph);
-                    return ResponseEntityBuilder.ok(graph);
-                } catch (Exception e) {
-                    LOG.warn("parse profile graph error: {}", dataList.get(0), e);
-                }
-            }
+            return getProfileFromAllFrontends(request, "graph", queryId, fragmentId, instanceId);
         } else {
             try {
                 if (Strings.isNullOrEmpty(fragmentId) || Strings.isNullOrEmpty(instanceId)) {
@@ -328,10 +323,61 @@ public class QueryProfileAction extends RestBaseController {
                 }
                 graph.put("graph", results.get(0));
             } catch (Exception e) {
-                LOG.warn("get profile graph error, queryId:{}, fragementId:{}, instanceId:{}",
-                        queryId, fragmentId, instanceId, e);
+                LOG.warn("get profile graph error, queryId:{}, fragementId:{}, instanceId:{}", queryId, fragmentId,
+                        instanceId, e);
             }
         }
         return ResponseEntityBuilder.ok(graph);
+    }
+
+    @NotNull
+    private ResponseEntity getJsonProfile(HttpServletRequest request, String queryId, String fragmentId,
+            String instanceId, boolean isAllNode) {
+        Map<String, String> graph = Maps.newHashMap();
+        if (isAllNode) {
+            return getProfileFromAllFrontends(request, "json", queryId, fragmentId, instanceId);
+        } else {
+            try {
+                JSONObject json;
+                if (Strings.isNullOrEmpty(fragmentId) || Strings.isNullOrEmpty(instanceId)) {
+                    ProfileTreeNode treeRoot = ProfileManager.getInstance().getFragmentProfileTree(queryId, queryId);
+                    json = ProfileTreePrinter.printFragmentTreeInJson(treeRoot);
+                } else {
+                    ProfileTreeNode treeRoot = ProfileManager.getInstance()
+                            .getInstanceProfileTree(queryId, queryId, fragmentId, instanceId);
+                    json = ProfileTreePrinter.printFragmentTreeInJson(treeRoot);
+                }
+                graph.put("profile", json.toJSONString());
+            } catch (Exception e) {
+                LOG.warn("get profile graph error, queryId:{}, fragementId:{}, instanceId:{}", queryId, fragmentId,
+                        instanceId, e);
+            }
+        }
+        return ResponseEntityBuilder.ok(graph);
+    }
+
+    @NotNull
+    private ResponseEntity getProfileFromAllFrontends(HttpServletRequest request, String format, String queryId,
+            String fragmentId, String instanceId) {
+        String httpPath = "/rest/v2/manager/query/profile/" + format + "/" + queryId;
+        ImmutableMap.Builder<String, String> builder =
+                ImmutableMap.<String, String>builder().put(IS_ALL_NODE_PARA, "false");
+        if (!Strings.isNullOrEmpty(fragmentId)) {
+            builder.put(FRAGMENT_ID, fragmentId);
+        }
+        if (!Strings.isNullOrEmpty(instanceId)) {
+            builder.put(INSTANCE_ID, instanceId);
+        }
+        List<String> dataList = requestAllFe(httpPath, builder.build(), request.getHeader(NodeAction.AUTHORIZATION));
+        Map<String, String> result = Maps.newHashMap();
+        if (!dataList.isEmpty()) {
+            try {
+                String profile = JsonParser.parseString(dataList.get(0)).getAsJsonObject().get("profile").getAsString();
+                result.put("profile", profile);
+            } catch (Exception e) {
+                return ResponseEntityBuilder.badRequest(e.getMessage());
+            }
+        }
+        return ResponseEntityBuilder.ok(result);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -19,11 +19,13 @@ package org.apache.doris.qe;
 
 import org.apache.doris.common.io.Text;
 import org.apache.doris.common.io.Writable;
+import org.apache.doris.common.util.ProfileManager;
 import org.apache.doris.common.util.TimeUtils;
 import org.apache.doris.qe.VariableMgr.VarAttr;
 import org.apache.doris.thrift.TQueryOptions;
 import org.apache.doris.thrift.TResourceLimit;
 
+import com.google.common.base.Strings;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.json.simple.JSONObject;
@@ -180,9 +182,12 @@ public class SessionVariable implements Serializable, Writable {
 
     public static final String ENABLE_PROJECTION = "enable_projection";
 
-    public static final String TRIM_TAILING_SPACES_FOR_EXTERNAL_TABLE_QUERY = "trim_tailing_spaces_for_external_table_query";
+    public static final String TRIM_TAILING_SPACES_FOR_EXTERNAL_TABLE_QUERY =
+            "trim_tailing_spaces_for_external_table_query";
 
     static final String ENABLE_ARRAY_TYPE = "enable_array_type";
+
+    static final String SESSION_CONTEXT = "session_context";
 
     // session origin value
     public Map<Field, String> sessionOriginValue = new HashMap<Field, String>();
@@ -447,7 +452,15 @@ public class SessionVariable implements Serializable, Writable {
     public boolean trimTailingSpacesForExternalTableQuery = false;
 
     @VariableMgr.VarAttr(name = ENABLE_ARRAY_TYPE)
-    boolean enableArrayType = false;
+    public boolean enableArrayType = false;
+
+    /**
+     * The client can pass some special information by setting this session variable in the format: "k1:v1;k2:v2".
+     * For example, trace_id can be passed to trace the query request sent by the user.
+     * set session_context="trace_id:1234565678";
+     */
+    @VariableMgr.VarAttr(name = SESSION_CONTEXT, needForward = true)
+    public String sessionContext = "";
 
     public String getBlockEncryptionMode() {
         return blockEncryptionMode;
@@ -1153,5 +1166,30 @@ public class SessionVariable implements Serializable, Writable {
         if (queryOptions.isSetLoadMemLimit()) {
             setLoadMemLimit(queryOptions.getLoadMemLimit());
         }
+    }
+
+    /**
+     * The sessionContext is as follows:
+     * "k1:v1;k2:v2;..."
+     * Here we want to get value with key named "trace_id",
+     * Return empty string is not found.
+     *
+     * @return
+     */
+    public String getTraceId() {
+        if (Strings.isNullOrEmpty(sessionContext)) {
+            return "";
+        }
+        String[] parts = sessionContext.split(";");
+        for (String part : parts) {
+            String[] innerParts = part.split(":");
+            if (innerParts.length != 2) {
+                continue;
+            }
+            if (innerParts[0].equals(ProfileManager.TRACE_ID)) {
+                return innerParts[1];
+            }
+        }
+        return "";
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -230,6 +230,7 @@ public class StmtExecutor implements ProfileWriter {
             summaryProfile.addInfoString(ProfileManager.DEFAULT_DB, context.getDatabase());
             summaryProfile.addInfoString(ProfileManager.SQL_STATEMENT, originStmt.originStmt);
             summaryProfile.addInfoString(ProfileManager.IS_CACHED, isCached ? "Yes" : "No");
+            summaryProfile.addInfoString(ProfileManager.TRACE_ID, context.getSessionVariable().getTraceId());
 
             plannerRuntimeProfile = new RuntimeProfile("Execution Summary");
             summaryProfile.addChild(plannerRuntimeProfile);


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

Add a new session variable: `session_context` and it can be set like:
`set session_context="k1:v1;k2:v2;..."`
Where `k:v` is key-value pair.

This is used to pass some user-defined or pre-defined session variables from client to server.
For example, I add a pre-defined key: `trace_id`, And I can use the following stmt:
```
select /*+SET_VAR(session_context=trace_id:123456) */ xxxx from tbl ....;
```
And Doris will get this trace id and saved it in profile. After that, user can use this trace id to get the query id, then
get some other info (eg, query profile) by query id.

Also, user can pass the trace id to Doris, so that we can monitor Doris's execution in some tracing system.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
