### PR TITLE
[Bug] [Regression-Test] run test_outfile failed because not use regression-conf

### DIFF
--- a/regression-test/suites/export/test_outfile.groovy
+++ b/regression-test/suites/export/test_outfile.groovy
@@ -22,10 +22,9 @@ import java.nio.file.Files
 import java.nio.file.Paths
 
 suite("test_outfile", "export") {
-    StringBuilder strBuilder = new StringBuilder();
-    strBuilder.append("curl --location-trusted -u root: http://")
-    strBuilder.append(context.config.feHttpAddress)
-    strBuilder.append("/rest/v1/config/fe")
+    StringBuilder strBuilder = new StringBuilder()
+    strBuilder.append("curl --location-trusted -u " + context.config.jdbcUser + ":" + context.config.jdbcPassword)
+    strBuilder.append(" http://" + context.config.feHttpAddress + "/rest/v1/config/fe")
 
     String command = strBuilder.toString()
     def process = command.toString().execute()


### PR DESCRIPTION
# Proposed changes

Issue Number: close #10122

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
