### PR TITLE
[feature] Support hive on s3.

### DIFF
--- a/docs/en/docs/ecosystem/external-table/hive-of-doris.md
+++ b/docs/en/docs/ecosystem/external-table/hive-of-doris.md
@@ -91,7 +91,6 @@ PROPERTIES (
 'dfs.client.failover.proxy.provider.hacluster'='org.apache.hadoop.hdfs.server.namenode.ha.ConfiguredFailoverProxyProvider'
 );
 
-
 -- Example 3: Create the hive external table under hive_db in Hive cluster with HDFS HA and enable kerberos authentication. 
 CREATE TABLE `t_hive` (
   `k1` int NOT NULL COMMENT "",
@@ -114,6 +113,25 @@ PROPERTIES (
 'dfs.namenode.kerberos.principal'='hadoop/_HOST@REALM.COM'
 'hadoop.kerberos.principal'='doris_test@REALM.COM',
 'hadoop.kerberos.keytab'='/path/to/doris_test.keytab'
+);
+
+-- Example 4: Create the hive_table table under hive_db in a Hive cluster with data stored on S3
+CREATE TABLE `t_hive` (
+  `k1` int NOT NULL COMMENT "",
+  `k2` char(10) NOT NULL COMMENT "",
+  `k3` datetime NOT NULL COMMENT "",
+  `k5` varchar(20) NOT NULL COMMENT "",
+  `k6` double NOT NULL COMMENT ""
+) ENGINE=HIVE
+COMMENT "HIVE"
+PROPERTIES (
+'hive.metastore.uris' = 'thrift://192.168.0.1:9083',
+'database' = 'hive_db',
+'table' = 'hive_table',
+'AWS_ACCESS_KEY'='your_access_key',
+'AWS_SECRET_KEY'='your_secret_key',
+'AWS_ENDPOINT'='s3.us-east-1.amazonaws.com',
+'AWS_REGION'='us-east-1'
 );
 
 ```
@@ -139,6 +157,10 @@ PROPERTIES (
     - `hadoop.security.authentication`: HDFS authentication type please set kerberos, default simple
     - `hadoop.kerberos.principal`: The Kerberos pincipal that Doris will use when connectiong to HDFS.
     - `hadoop.kerberos.keytab`: HDFS client keytab location.
+    - `AWS_ACCESS_KEY`: AWS access key id.
+    - `AWS_SECRET_KEY`: AWS secret access key.
+    - `AWS_ENDPOINT`: S3 endpoint. e.g. s3.us-east-1.amazonaws.com
+    - `AWS_REGION`: AWS region. e.g. us-east-1
 
 **Note:**
 - To enable Doris to access the hadoop cluster with kerberos authentication enabled, you need to deploy the Kerberos client kinit on the Doris all FE and BE nodes, configure krb5.conf, and fill in the KDC service information.

--- a/docs/zh-CN/docs/ecosystem/external-table/hive-of-doris.md
+++ b/docs/zh-CN/docs/ecosystem/external-table/hive-of-doris.md
@@ -91,7 +91,6 @@ PROPERTIES (
 'dfs.client.failover.proxy.provider.hacluster'='org.apache.hadoop.hdfs.server.namenode.ha.ConfiguredFailoverProxyProvider'
 );
 
-
 -- 例子3：创建 Hive 集群中 hive_db 下的 hive_table 表, HDFS使用HA配置并开启kerberos认证方式
 CREATE TABLE `t_hive` (
   `k1` int NOT NULL COMMENT "",
@@ -114,6 +113,25 @@ PROPERTIES (
 'hadoop.security.authentication'='kerberos',
 'hadoop.kerberos.principal'='doris_test@REALM.COM',
 'hadoop.kerberos.keytab'='/path/to/doris_test.keytab'
+);
+
+-- 例子4：创建 Hive 集群中 hive_db 下的 hive_table 表, Hive数据存储在S3上
+CREATE TABLE `t_hive` (
+  `k1` int NOT NULL COMMENT "",
+  `k2` char(10) NOT NULL COMMENT "",
+  `k3` datetime NOT NULL COMMENT "",
+  `k5` varchar(20) NOT NULL COMMENT "",
+  `k6` double NOT NULL COMMENT ""
+) ENGINE=HIVE
+COMMENT "HIVE"
+PROPERTIES (
+'hive.metastore.uris' = 'thrift://192.168.0.1:9083',
+'database' = 'hive_db',
+'table' = 'hive_table',
+'AWS_ACCESS_KEY' = 'your_access_key',
+'AWS_SECRET_KEY' = 'your_secret_key',
+'AWS_ENDPOINT' = 's3.us-east-1.amazonaws.com',
+'AWS_REGION' = 'us-east-1'
 );
 
 ```
@@ -140,6 +158,10 @@ PROPERTIES (
     - `dfs.namenode.kerberos.principal`：HDFS namenode 服务的Kerberos 主体
     - `hadoop.kerberos.principal`：设置 Doris 连接 HDFS 时使用的 Kerberos 主体
     - `hadoop.kerberos.keytab`：设置 keytab 本地文件路径
+    - `AWS_ACCESS_KEY`: AWS账户的access key id.
+    - `AWS_SECRET_KEY`: AWS账户的secret access key.
+    - `AWS_ENDPOINT`: S3 endpoint. 例如：s3.us-east-1.amazonaws.com
+    - `AWS_REGION`: AWS区域. 例如：us-east-1
 
 **注意：**
 - 若要使 Doris 访问开启kerberos认证方式的hadoop集群，需要在 Doris 集群所有运行节点上部署 Kerberos 客户端 kinit，并配置 krb5.conf，填写KDC 服务信息等。

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/HiveTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/HiveTable.java
@@ -42,14 +42,18 @@ public class HiveTable extends Table {
     private static final String PROPERTY_MISSING_MSG = "Hive %s is null. Please add properties('%s'='xxx') when create table";
     private static final String PROPERTY_ERROR_MSG = "Hive table properties('%s'='%s') is illegal or not supported. Please check it";
 
-    private static final String HIVE_DB = "database";
-    private static final String HIVE_TABLE = "table";
-    public static final String HIVE_METASTORE_URIS = "hive.metastore.uris";
-    public static final String HIVE_HDFS_PREFIX = "dfs";
-
     private String hiveDb;
     private String hiveTable;
     private Map<String, String> hiveProperties = Maps.newHashMap();
+
+    public static final String HIVE_DB = "database";
+    public static final String HIVE_TABLE = "table";
+    public static final String HIVE_METASTORE_URIS = "hive.metastore.uris";
+    public static final String HIVE_HDFS_PREFIX = "dfs";
+    public static final String S3_PROPERTIES_PREFIX = "AWS";
+    public static final String S3_AK = "AWS_ACCESS_KEY";
+    public static final String S3_SK = "AWS_SECRET_KEY";
+    public static final String S3_ENDPOINT = "AWS_ENDPOINT";
 
     public HiveTable() {
         super(TableType.HIVE);
@@ -142,8 +146,9 @@ public class HiveTable extends Table {
             Iterator<Map.Entry<String, String>> iter = copiedProps.entrySet().iterator();
             while (iter.hasNext()) {
                 Map.Entry<String, String> entry = iter.next();
-                if (entry.getKey().startsWith(HIVE_HDFS_PREFIX)) {
-                    hiveProperties.put(entry.getKey(), entry.getValue());
+                String key = entry.getKey();
+                if (key.startsWith(HIVE_HDFS_PREFIX) || key.startsWith(S3_PROPERTIES_PREFIX)) {
+                    hiveProperties.put(key, entry.getValue());
                     iter.remove();
                 }
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/HiveScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/HiveScanNode.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.planner;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.doris.analysis.Analyzer;
 import org.apache.doris.analysis.BrokerDesc;
 import org.apache.doris.analysis.Expr;
@@ -68,6 +69,7 @@ public class HiveScanNode extends BrokerScanNode {
     private String fileFormat;
     private String path;
     private List<String> partitionKeys = new ArrayList<>();
+    private StorageBackend.StorageType storageType;
     /* hive table properties */
 
     public String getHostUri() {
@@ -123,13 +125,26 @@ public class HiveScanNode extends BrokerScanNode {
                         getFileFormat(),
                         getPartitionKeys(),
                         getParsedColumnExprList()));
-        brokerDesc = new BrokerDesc("HiveTableDesc", StorageBackend.StorageType.HDFS, hiveTable.getHiveProperties());
+        brokerDesc = new BrokerDesc("HiveTableDesc", storageType, hiveTable.getHiveProperties());
         targetTable = hiveTable;
     }
 
-    private void initHiveTblProperties() throws DdlException {
+    private void setStorageType(String location) throws UserException {
+        String[] strings = StringUtils.split(location, "/");
+        String storagePrefix = strings[0].split(":")[0];
+        if (storagePrefix.equalsIgnoreCase("s3")) {
+            this.storageType = StorageBackend.StorageType.S3;
+        } else if (storagePrefix.equalsIgnoreCase("hdfs")) {
+            this.storageType = StorageBackend.StorageType.HDFS;
+        } else {
+            throw new UserException("Not supported storage type: " + storagePrefix);
+        }
+    }
+
+    private void initHiveTblProperties() throws UserException {
         this.remoteHiveTable = HiveMetaStoreClientHelper.getTable(hiveTable);
         this.fileFormat = HiveMetaStoreClientHelper.HiveFileFormat.getFormat(remoteHiveTable.getSd().getInputFormat());
+        this.setStorageType(remoteHiveTable.getSd().getLocation());
 
         Map<String, String> serDeInfoParams = remoteHiveTable.getSd().getSerdeInfo().getParameters();
         this.columnSeparator = Strings.isNullOrEmpty(serDeInfoParams.get("field.delim"))
@@ -179,7 +194,7 @@ public class HiveScanNode extends BrokerScanNode {
         }
         List<TBrokerFileStatus> fileStatuses = new ArrayList<>();
         this.hdfsUri = HiveMetaStoreClientHelper.getHiveDataFiles(hiveTable, hivePartitionPredicate,
-            fileStatuses, remoteHiveTable);
+                fileStatuses, remoteHiveTable, storageType);
         fileStatusesList.add(fileStatuses);
         filesAdded += fileStatuses.size();
         for (TBrokerFileStatus fstatus : fileStatuses) {


### PR DESCRIPTION
# Proposed changes

Support query hive table on S3. Pass AK/SK, Region and s3 endpoint to hive table while creating the external table.

example create table sql:
```
CREATE TABLE `region_s3` (
`r_regionkey` integer NOT NULL,   
`r_name` char(25) NOT NULL,   
`r_comment` varchar(152) ) 
engine=hive 
properties 
("database"="default", 
"table"="region_s3", 
“hive.metastore.uris"="thrift://127.0.0.1:9083",
“AWS_ACCESS_KEY”=“YOUR_ACCESS_KEY",
“AWS_SECRET_KEY”=“YOUR_SECRET_KEY",
"AWS_ENDPOINT"="s3.us-east-1.amazonaws.com", 
“AWS_REGION”=“us-east-1”);
```

## Problem Summary:

Currently, user couldn't query hive external table when hive table is stored on S3. This pr is to support this kind of hive external table.

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
