### PR TITLE
[fix] (mem tracker) Fix core dump during `transmit_block`

### DIFF
--- a/be/src/runtime/thread_context.h
+++ b/be/src/runtime/thread_context.h
@@ -123,8 +123,9 @@ public:
     void attach(const TaskType& type, const std::string& task_id,
                 const TUniqueId& fragment_instance_id,
                 const std::shared_ptr<doris::MemTracker>& mem_tracker) {
+        std::string new_tracker_label = mem_tracker == nullptr ? "null" : mem_tracker->label();
         DCHECK((_type == TaskType::UNKNOWN || _type == TaskType::BRPC) && _task_id == "")
-                << ",new tracker label: " << mem_tracker->label()
+                << ",new tracker label: " << new_tracker_label
                 << ",old tracker label: " << _thread_mem_tracker_mgr->mem_tracker()->label();
         DCHECK(type != TaskType::UNKNOWN);
         _type = type;


### PR DESCRIPTION
# Proposed changes

Issue Number: close #10118

## Problem Summary:

In some cases, query mem tracker does not exist in BE when transmit block.
This will result in a null pointer for get query mem tracker in brpc transmit_block

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
