### PR TITLE
[fix] croaringbitmap compile support USE_AVX2=0

### DIFF
--- a/thirdparty/build-thirdparty.sh
+++ b/thirdparty/build-thirdparty.sh
@@ -787,7 +787,7 @@ build_bitshuffle() {
 build_croaringbitmap() {
     avx_flag=
     if [ ! -z "$USE_AVX2" -a "$USE_AVX2" -eq 0 ];then
-        echo "FORCE disable AVX for croaringbitmap"
+        echo "set USE_AVX2=$USE_AVX2 to FORCE disable AVX2 in croaringbitmap"
         avx_flag="-DROARING_DISABLE_AVX=ON"
     fi
 

--- a/thirdparty/build-thirdparty.sh
+++ b/thirdparty/build-thirdparty.sh
@@ -785,13 +785,19 @@ build_bitshuffle() {
 
 # croaring bitmap
 build_croaringbitmap() {
+    avx_flag=
+    if [ ! -z "$USE_AVX2" -a "$USE_AVX2" -eq 0 ];then
+        echo "FORCE disable AVX for croaringbitmap"
+        avx_flag="-DROARING_DISABLE_AVX=ON"
+    fi
+
     check_if_source_exist $CROARINGBITMAP_SOURCE
     cd $TP_SOURCE_DIR/$CROARINGBITMAP_SOURCE
     mkdir -p $BUILD_DIR && cd $BUILD_DIR
     rm -rf CMakeCache.txt CMakeFiles/
     CXXFLAGS="-O3" \
     LDFLAGS="-L${TP_LIB_DIR} -static-libstdc++ -static-libgcc" \
-    ${CMAKE_CMD} -G "${GENERATOR}" -DROARING_BUILD_STATIC=ON -DCMAKE_INSTALL_PREFIX=$TP_INSTALL_DIR \
+    ${CMAKE_CMD} -G "${GENERATOR}" ${avx_flag} -DROARING_BUILD_STATIC=ON -DCMAKE_INSTALL_PREFIX=$TP_INSTALL_DIR \
     -DENABLE_ROARING_TESTS=OFF ..
     ${BUILD_SYSTEM} -j $PARALLEL && ${BUILD_SYSTEM} install
 }


### PR DESCRIPTION
Now third party package `CRoaring` will turn AVX2 dynamically.
We need to FORCE disable AVX2 while release `no-avx` Doris package.

# Proposed changes

Issue Number: close #10100 

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
