### PR TITLE
[fix] (mem tracker) Refactor memtable mem tracker, fix flush memtable DCHECK failed

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -632,7 +632,14 @@ CONF_Bool(track_new_delete, "true");
 
 // If true, switch TLS MemTracker to count more detailed memory,
 // including caches such as ExecNode operators and TabletManager.
-CONF_Bool(memory_verbose_track, "true");
+//
+// At present, there is a performance problem in the frequent switch thread mem tracker.
+// This is because the mem tracker exists as a shared_ptr in the thread local. When switching,
+// the shared_ptr use_count of the current tracker will be -1, and the tracker use_count to be replaced will be +1.
+// Frequent changes are the same as A tracker shared_ptr is very time consuming.
+// TODO: 1. Reduce unnecessary thread mem tracker switches,
+//       2. Consider using raw pointers for mem tracker in thread local
+CONF_Bool(memory_verbose_track, "false");
 
 // Default level of MemTracker to show in web page
 // now MemTracker support two level:

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -634,9 +634,9 @@ CONF_Bool(track_new_delete, "true");
 // including caches such as ExecNode operators and TabletManager.
 //
 // At present, there is a performance problem in the frequent switch thread mem tracker.
-// This is because the mem tracker exists as a shared_ptr in the thread local. When switching,
-// the shared_ptr use_count of the current tracker will be -1, and the tracker use_count to be replaced will be +1.
-// Frequent changes are the same as A tracker shared_ptr is very time consuming.
+// This is because the mem tracker exists as a shared_ptr in the thread local. Each time it is switched,
+// the atomic variable use_count in the shared_ptr of the current tracker will be -1, and the tracker to be
+// replaced use_count +1, multi-threading Frequent changes to the same tracker shared_ptr are slow.
 // TODO: 1. Reduce unnecessary thread mem tracker switches,
 //       2. Consider using raw pointers for mem tracker in thread local
 CONF_Bool(memory_verbose_track, "false");

--- a/be/src/olap/delta_writer.cpp
+++ b/be/src/olap/delta_writer.cpp
@@ -234,12 +234,8 @@ Status DeltaWriter::flush_memtable_and_wait(bool need_wait) {
         RETURN_NOT_OK(_flush_memtable_async());
         _reset_mem_table();
     } else {
+        DCHECK(mem_consumption() > _mem_table->memory_usage());
         // this means there should be at least one memtable in flush queue.
-        // At this time, mem_consumption() > _mem_table->memory_usage(),
-        // but affected by the consumption order of mem tracker, the child tracker is consumed first,
-        // and then the parent tracker is consumed recursively. Therefore, when entering this judgment
-        // during the consumption process, the DeltaWriter tracker and the memtable tracker consume Inconsistent,
-        // mem_consumption() < _mem_table->memory_usage() may appear. This probability is small and will not matter.
     }
 
     if (need_wait) {

--- a/be/src/olap/delta_writer.cpp
+++ b/be/src/olap/delta_writer.cpp
@@ -232,8 +232,12 @@ Status DeltaWriter::flush_memtable_and_wait(bool need_wait) {
         RETURN_NOT_OK(_flush_memtable_async());
         _reset_mem_table();
     } else {
-        DCHECK(mem_consumption() > _mem_table->memory_usage());
         // this means there should be at least one memtable in flush queue.
+        // At this time, mem_consumption() > _mem_table->memory_usage(),
+        // but affected by the consumption order of mem tracker, the child tracker is consumed first,
+        // and then the parent tracker is consumed recursively. Therefore, when entering this judgment
+        // during the consumption process, the DeltaWriter tracker and the memtable tracker consume Inconsistent,
+        // mem_consumption() < _mem_table->memory_usage() may appear. This probability is small and will not matter.
     }
 
     if (need_wait) {
@@ -295,6 +299,11 @@ Status DeltaWriter::close_wait() {
     // return error if previous flush failed
     RETURN_NOT_OK(_flush_token->wait());
 
+    _mem_table.reset();
+    // In allocate/free of mem_pool, the consume_cache of _mem_tracker will be called,
+    // and _untracked_mem must be flushed first.
+    MemTracker::memory_leak_check(_mem_tracker.get());
+
     // use rowset meta manager to save meta
     _cur_rowset = _rowset_writer->build();
     if (_cur_rowset == nullptr) {
@@ -327,6 +336,7 @@ Status DeltaWriter::cancel() {
         // cancel and wait all memtables in flush queue to be finished
         _flush_token->cancel();
     }
+    MemTracker::memory_leak_check(_mem_tracker.get());
     _is_cancelled = true;
     return Status::OK();
 }

--- a/be/src/olap/delta_writer.cpp
+++ b/be/src/olap/delta_writer.cpp
@@ -94,8 +94,10 @@ Status DeltaWriter::init() {
         return Status::OLAPInternalError(OLAP_ERR_TABLE_NOT_FOUND);
     }
 
-    _mem_tracker =
-            MemTracker::create_tracker(-1, "DeltaWriter:" + std::to_string(_tablet->tablet_id()));
+    // Only consume mem tracker manually in mem table. Using the virtual tracker can avoid
+    // frequent recursive consumption of the parent tracker, thereby improving performance.
+    _mem_tracker = MemTracker::create_virtual_tracker(
+            -1, "DeltaWriter:" + std::to_string(_tablet->tablet_id()));
     // check tablet version number
     if (_tablet->version_count() > config::max_tablet_version_num) {
         LOG(WARNING) << "failed to init delta writer. version count: " << _tablet->version_count()

--- a/be/src/olap/memtable.cpp
+++ b/be/src/olap/memtable.cpp
@@ -39,9 +39,7 @@ MemTable::MemTable(int64_t tablet_id, Schema* schema, const TabletSchema* tablet
           _tablet_schema(tablet_schema),
           _slot_descs(slot_descs),
           _keys_type(keys_type),
-          // The insert block needs to manually consume the mem tracker. Using the virtual tracker can avoid
-          // frequent recursive consumption of the parent tracker, thereby improving performance.
-          _mem_tracker(MemTracker::create_virtual_tracker(-1, "MemTable", parent_tracker)),
+          _mem_tracker(MemTracker::create_tracker(-1, "MemTable", parent_tracker)),
           _buffer_mem_pool(new MemPool(_mem_tracker.get())),
           _table_mem_pool(new MemPool(_mem_tracker.get())),
           _schema_size(_schema->schema_size()),

--- a/be/src/olap/memtable_flush_executor.cpp
+++ b/be/src/olap/memtable_flush_executor.cpp
@@ -61,6 +61,7 @@ Status FlushToken::wait() {
 }
 
 void FlushToken::_flush_memtable(std::shared_ptr<MemTable> memtable, int64_t submit_task_time) {
+#ifndef BE_TEST
     // The memtable mem tracker needs to be completely accurate,
     // because DeltaWriter judges whether to flush memtable according to the memtable memory usage.
     // The macro of attach thread mem tracker is affected by the destructuring order of local variables,
@@ -69,6 +70,7 @@ void FlushToken::_flush_memtable(std::shared_ptr<MemTable> memtable, int64_t sub
     DCHECK(memtable->mem_tracker()->parent_task_mem_tracker_no_own());
     SCOPED_ATTACH_TASK_THREAD(ThreadContext::TaskType::LOAD,
                               memtable->mem_tracker()->parent_task_mem_tracker_no_own());
+#endif
     _stats.flush_wait_time_ns += (MonotonicNanos() - submit_task_time);
     SCOPED_CLEANUP({ memtable.reset(); });
     // If previous flush has failed, return directly

--- a/be/src/olap/memtable_flush_executor.cpp
+++ b/be/src/olap/memtable_flush_executor.cpp
@@ -61,7 +61,14 @@ Status FlushToken::wait() {
 }
 
 void FlushToken::_flush_memtable(std::shared_ptr<MemTable> memtable, int64_t submit_task_time) {
-    SCOPED_ATTACH_TASK_THREAD(ThreadContext::TaskType::LOAD, memtable->mem_tracker());
+    // The memtable mem tracker needs to be completely accurate,
+    // because DeltaWriter judges whether to flush memtable according to the memtable memory usage.
+    // The macro of attach thread mem tracker is affected by the destructuring order of local variables,
+    // so it cannot completely correspond to the number of new/delete bytes recorded in scoped,
+    // and there is a small range of errors. So direct track load mem tracker.
+    DCHECK(memtable->mem_tracker()->parent_task_mem_tracker_no_own());
+    SCOPED_ATTACH_TASK_THREAD(ThreadContext::TaskType::LOAD,
+                              memtable->mem_tracker()->parent_task_mem_tracker_no_own());
     _stats.flush_wait_time_ns += (MonotonicNanos() - submit_task_time);
     SCOPED_CLEANUP({ memtable.reset(); });
     // If previous flush has failed, return directly

--- a/be/src/olap/memtable_flush_executor.cpp
+++ b/be/src/olap/memtable_flush_executor.cpp
@@ -67,9 +67,11 @@ void FlushToken::_flush_memtable(std::shared_ptr<MemTable> memtable, int64_t sub
     // The macro of attach thread mem tracker is affected by the destructuring order of local variables,
     // so it cannot completely correspond to the number of new/delete bytes recorded in scoped,
     // and there is a small range of errors. So direct track load mem tracker.
-    DCHECK(memtable->mem_tracker()->parent_task_mem_tracker_no_own());
-    SCOPED_ATTACH_TASK_THREAD(ThreadContext::TaskType::LOAD,
-                              memtable->mem_tracker()->parent_task_mem_tracker_no_own());
+    // TODO(zxy) After rethinking the use of switch thread mem tracker, choose the appropriate way to get
+    // load mem tracke here.
+    // DCHECK(memtable->mem_tracker()->parent_task_mem_tracker_no_own());
+    // SCOPED_ATTACH_TASK_THREAD(ThreadContext::TaskType::LOAD,
+    //                           memtable->mem_tracker()->parent_task_mem_tracker_no_own());
 #endif
     _stats.flush_wait_time_ns += (MonotonicNanos() - submit_task_time);
     SCOPED_CLEANUP({ memtable.reset(); });

--- a/be/src/runtime/mem_tracker.cpp
+++ b/be/src/runtime/mem_tracker.cpp
@@ -162,9 +162,13 @@ MemTracker::MemTracker(int64_t byte_limit, const std::string& label,
 void MemTracker::init() {
     DCHECK_GE(_limit, -1);
     MemTracker* tracker = this;
-    while (tracker != nullptr && tracker->_virtual == false) {
+    while (tracker != nullptr) {
         _all_trackers.push_back(tracker);
         if (tracker->has_limit()) _limit_trackers.push_back(tracker);
+        // This means that it terminates when recursively consume/release from the current tracker up to the virtual tracker.
+        if (tracker->_virtual == true) {
+            break;
+        }
         tracker = tracker->_parent.get();
     }
     DCHECK_GT(_all_trackers.size(), 0);

--- a/be/src/runtime/mem_tracker.h
+++ b/be/src/runtime/mem_tracker.h
@@ -416,9 +416,17 @@ public:
 
     // If an ancestor of this tracker is a Task MemTracker, return that tracker. Otherwise return nullptr.
     MemTracker* parent_task_mem_tracker() {
-        MemTracker* tracker = this;
+        if (this->_level == MemTrackerLevel::TASK) {
+            return this;
+        } else {
+            return parent_task_mem_tracker_no_own().get();
+        }
+    }
+
+    std::shared_ptr<MemTracker> parent_task_mem_tracker_no_own() {
+        std::shared_ptr<MemTracker> tracker = this->_parent;
         while (tracker != nullptr && tracker->_level != MemTrackerLevel::TASK) {
-            tracker = tracker->_parent.get();
+            tracker = tracker->_parent;
         }
         return tracker;
     }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #10154

## Problem Summary:

1. Added memory leak detection for `DeltaWriter` and `MemTable` mem tracker

2. Modify memtable mem tracker to virtual to avoid frequent recursive consumption of parent tracker.

3. Disable memtable flush thread attach memtable tracker, ensure that memtable mem tracker is completely accurate.

4. Modify `memory_verbose_track=false`. At present, there is a performance problem in the frequent switch thread mem tracker. 

      - <s>Because the mem tracker exists as a shared_ptr in the thread local. Each time it is switched, the atomic variable use_count in the shared_ptr of the current tracker will be -1, and the tracker to be replaced use_count +1, multi-threading Frequent changes to the same tracker shared_ptr are slow</s>.
      - TODO: 1. Reduce unnecessary thread mem tracker switch, 2. Consider using raw pointers for mem tracker in thread local.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
7. Does it need to update dependencies: (Yes/No)
8. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
