### PR TITLE
[imporement]Avoid unnecessary find_codes in predicate

### DIFF
--- a/be/src/olap/column_predicate.h
+++ b/be/src/olap/column_predicate.h
@@ -88,6 +88,8 @@ public:
 
     uint32_t column_id() const { return _column_id; }
 
+    virtual void set_dict_code_if_necessary(vectorized::IColumn& column, uint64_t segment_id) {}
+
 protected:
     uint32_t _column_id;
     bool _opposite;

--- a/be/src/olap/rowset/segment_v2/segment_iterator.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.cpp
@@ -914,6 +914,7 @@ void SegmentIterator::_evaluate_short_circuit_predicate(uint16_t* vec_sel_rowid_
             predicate->type() == PredicateType::GT || predicate->type() == PredicateType::GE) {
             col_ptr->convert_dict_codes_if_necessary();
         }
+        predicate->set_dict_code_if_necessary(*short_cir_column, _segment->id());
         predicate->evaluate(*short_cir_column, vec_sel_rowid_idx, selected_size_ptr);
     }
     _opts.stats->rows_vec_cond_filtered += original_size - *selected_size_ptr;


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

It's unnecessary to call `find_codes` in `InListPredicateBase::evaluate` for the same segment.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
