### PR TITLE
[fix](reader)replace an auto with size_t to avoid integer overflow

### DIFF
--- a/be/src/olap/rowset/segment_v2/binary_dict_page.cpp
+++ b/be/src/olap/rowset/segment_v2/binary_dict_page.cpp
@@ -291,7 +291,7 @@ Status BinaryDictPageDecoder::next_batch(size_t* n, ColumnBlockView* dst) {
     }
 
     // use SIMD instruction to speed up call function `RoundUpToPowerOfTwo`
-    auto mem_size = 0;
+    size_t mem_size = 0;
     for (int i = 0; i < len; ++i) {
         mem_len[i] = BitUtil::RoundUpToPowerOf2Int32(mem_len[i], MemPool::DEFAULT_ALIGNMENT);
         mem_size += mem_len[i];

--- a/be/src/olap/rowset/segment_v2/binary_plain_page.h
+++ b/be/src/olap/rowset/segment_v2/binary_plain_page.h
@@ -208,7 +208,7 @@ public:
         }
 
         // use SIMD instruction to speed up call function `RoundUpToPowerOfTwo`
-        auto mem_size = 0;
+        size_t mem_size = 0;
         for (int i = 0; i < max_fetch; ++i) {
             mem_len[i] = BitUtil::RoundUpToPowerOf2Int32(mem_len[i], MemPool::DEFAULT_ALIGNMENT);
             mem_size += mem_len[i];


### PR DESCRIPTION
# Proposed changes

Issue Number: close #10162

## Problem Summary:
The type of 'auto mem_size = 0' can't store the size_t data which return by BitUtil::RoundUpToPowerOf2Int32
Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
