### PR TITLE
[opt] delete the redundant parameter of _execute_non_nullable

### DIFF
--- a/be/src/vec/functions/array/function_array_element.h
+++ b/be/src/vec/functions/array/function_array_element.h
@@ -69,11 +69,7 @@ public:
             args = {col_left, block.get_by_position(arguments[1])};
         }
 
-        auto result_type = remove_nullable(
-                check_and_get_data_type<DataTypeArray>(args[0].type.get())->get_nested_type());
-
-        auto res_column = _execute_non_nullable(args, result_type, input_rows_count, src_null_map,
-                                                dst_null_map);
+        auto res_column = _execute_non_nullable(args, input_rows_count, src_null_map, dst_null_map);
         if (!res_column) {
             return Status::RuntimeError(
                     fmt::format("unsupported types for function {}({}, {})", get_name(),
@@ -182,8 +178,8 @@ private:
     }
 
     ColumnPtr _execute_non_nullable(const ColumnsWithTypeAndName& arguments,
-                                    const DataTypePtr& result_type, size_t input_rows_count,
-                                    const UInt8* src_null_map, UInt8* dst_null_map) {
+                                    size_t input_rows_count, const UInt8* src_null_map,
+                                    UInt8* dst_null_map) {
         // check array nested column type and get data
         auto left_column = arguments[0].column->convert_to_full_column_if_const();
         const auto& array_column = reinterpret_cast<const ColumnArray&>(*left_column);


### PR DESCRIPTION
# Proposed changes
1. This pr is used to delete the redundant parameter of _execute_non_nullable.
2. This modification will not affect the function "element_at".

Issue Number: close #xxx

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (No)
4. Has unit tests been added: (No Need)
5. Has document been added or modified: (No Need)
6. Does it need to update dependencies: (No)
7. Are there any changes that cannot be rolled back: (No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
