### PR TITLE
[Fix] fix vjson_scanner heap use after free when meet object or array…

### DIFF
--- a/be/src/vec/exec/vjson_scanner.cpp
+++ b/be/src/vec/exec/vjson_scanner.cpp
@@ -284,6 +284,7 @@ Status VJsonReader::_write_data_to_column(rapidjson::Value::ConstValueIterator v
     const char* str_value = nullptr;
     char tmp_buf[128] = {0};
     int32_t wbytes = 0;
+    std::string json_str;
 
     if (slot_desc->is_nullable()) {
         auto* nullable_column = reinterpret_cast<vectorized::ColumnNullable*>(column_ptr);
@@ -331,7 +332,7 @@ Status VJsonReader::_write_data_to_column(rapidjson::Value::ConstValueIterator v
         break;
     default:
         // for other type like array or object. we convert it to string to save
-        std::string json_str = JsonReader::_print_json_value(*value);
+        json_str = JsonReader::_print_json_value(*value);
         wbytes = json_str.size();
         str_value = json_str.c_str();
         break;


### PR DESCRIPTION
… type

# Proposed changes

Issue Number: close #xxx

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
