### PR TITLE
[fix](executor) intersect operator takes too long time to execute

### DIFF
--- a/be/src/vec/common/hash_table/hash_table.h
+++ b/be/src/vec/common/hash_table/hash_table.h
@@ -886,8 +886,12 @@ public:
     }
 
     void delete_zero_key(Key key) {
-        if (Cell::is_zero(key, *this)) this->clear_get_has_zero();
+        if (this->get_has_zero() && Cell::is_zero(key, *this)) {
+            --m_size;
+            this->clear_get_has_zero();
+        }
     }
+
     void clear() {
         destroy_elements();
         this->clear_get_has_zero();

--- a/be/src/vec/exec/vset_operation_node.h
+++ b/be/src/vec/exec/vset_operation_node.h
@@ -115,8 +115,7 @@ void VSetOperationNode::refresh_hash_table() {
                     arg.init_once();
                     auto& iter = arg.iter;
                     auto iter_end = arg.hash_table.end();
-                    decltype(arg.iter) iter_prev;
-                    for (; iter != iter_end;) {
+                    while (iter != iter_end) {
                         auto& mapped = iter->get_second();
                         auto it = mapped.begin();
 
@@ -132,7 +131,7 @@ void VSetOperationNode::refresh_hash_table() {
                                     arg.hash_table.delete_zero_key(iter->get_first());
                                     // the ++iter would check if the current key is zero. if it does, the iterator will be moved to the container's head.
                                     // so we do ++iter before set_zero to make the iterator move to next valid key correctly.
-                                    iter_prev = iter;
+                                    auto iter_prev = iter;
                                     ++iter;
                                     iter_prev->set_zero();
                                 } else {

--- a/be/src/vec/exec/vset_operation_node.h
+++ b/be/src/vec/exec/vset_operation_node.h
@@ -114,23 +114,36 @@ void VSetOperationNode::refresh_hash_table() {
 
                     arg.init_once();
                     auto& iter = arg.iter;
-                    for (; iter != arg.hash_table.end(); ++iter) {
+                    auto iter_end = arg.hash_table.end();
+                    decltype(arg.iter) iter_prev;
+                    for (; iter != iter_end;) {
                         auto& mapped = iter->get_second();
                         auto it = mapped.begin();
 
                         if constexpr (keep_matched) { //intersected
                             if (it->visited) {
                                 it->visited = false;
-                                if (is_need_shrink)
+                                if (is_need_shrink) {
                                     tmp_hash_table.hash_table.insert(iter->get_value());
+                                }
+                                ++iter;
                             } else {
-                                arg.hash_table.delete_zero_key(iter->get_first());
-                                iter->set_zero();
+                                if (!is_need_shrink) {
+                                    arg.hash_table.delete_zero_key(iter->get_first());
+                                    // the ++iter would check if the current key is zero. if it does, the iterator will be moved to the container's head.
+                                    // so we do ++iter before set_zero to make the iterator move to next valid key correctly.
+                                    iter_prev = iter;
+                                    ++iter;
+                                    iter_prev->set_zero();
+                                } else {
+                                    ++iter;
+                                }
                             }
                         } else { //except
                             if (!it->visited && is_need_shrink) {
                                 tmp_hash_table.hash_table.insert(iter->get_value());
                             }
+                            ++iter;
                         }
                     }
 


### PR DESCRIPTION
# Proposed changes

Issue Number: close https://github.com/apache/incubator-doris/issues/10182

## Problem Summary:

After the first intersect operator, the hash table will be filled with matched and unmatched values. before doing the next intersect operation( assume there is one ), the hash table will be sweept in two ways:
1. if there is less than 1/4 cells are matched, the table would be shrinked by inserting the matched values into a new hash table and then deleting the old one
2. mark all unmached values as ZERO value to ensure these ZERO values can't be matched in the next intersect operation.

in case 2, there is a problem:
The original code iterate over all the hash table values, and set the unmatched ones to ZERO. But the iterator's operator++() method always check if the current value is ZERO. If it does, the iterator will be moved to the head of the container, and move forword step by step to find the next value( first NO-ZERO value ). So if changes the current value to ZERO before calling iterator's operator++ method, the iterator would always be moved to the head instead of move to the next value as we expected. So the code should be changed to move the iterator to next value, then set the unmatched cell to ZERO.

## Checklist(Required)

1. Does it affect the original behavior: (No)
2. Has unit tests been added: (No)
3. Has document been added or modified: (No)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
