### PR TITLE
[Bug][Vectorized] Fix DCHECK failed in VExchangeNode close twice

### DIFF
--- a/be/src/vec/exec/vexchange_node.cpp
+++ b/be/src/vec/exec/vexchange_node.cpp
@@ -100,10 +100,13 @@ Status VExchangeNode::get_next(RuntimeState* state, Block* block, bool* eos) {
 }
 
 Status VExchangeNode::close(RuntimeState* state) {
+    if (is_closed()) {
+        return Status::OK();
+    }
+
     if (_stream_recvr != nullptr) {
         _stream_recvr->close();
     }
-
     if (_is_merging) _vsort_exec_exprs.close(state);
 
     return ExecNode::close(state);

--- a/be/src/vec/exec/vunion_node.cpp
+++ b/be/src/vec/exec/vunion_node.cpp
@@ -218,6 +218,7 @@ Status VUnionNode::get_next(RuntimeState* state, Block* block, bool* eos) {
     RETURN_IF_CANCELLED(state);
     // RETURN_IF_ERROR(QueryMaintenance(state));
 
+    // TODO: Rethink the logic, which cause close the exec node twice.
     if (_to_close_child_idx != -1) {
         // The previous child needs to be closed if passthrough was enabled for it. In the non
         // passthrough case, the child was already closed in the previous call to get_next().


### PR DESCRIPTION
# Proposed changes

Issue Number: close #10144

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
