### PR TITLE
[feature-wip](array-type) Use uppercase to describe columns with array type

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/ArrayType.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/ArrayType.java
@@ -96,9 +96,9 @@ public class ArrayType extends Type {
     @Override
     public String toSql(int depth) {
         if (!containsNull) {
-            return "ARRAY<NOT_NULL(" + itemType.toSql(depth + 1) + ")>";
+            return "array<not_null(" + itemType.toSql(depth + 1) + ")>";
         } else {
-            return "ARRAY<" + itemType.toSql(depth + 1) + ">";
+            return "array<" + itemType.toSql(depth + 1) + ">";
         }
     }
 
@@ -158,7 +158,7 @@ public class ArrayType extends Type {
 
     @Override
     public String toString() {
-        return toSql(0);
+        return toSql(0).toUpperCase();
     }
 
     @Override


### PR DESCRIPTION
# Proposed changes

Issue Number: close #10192 

## Problem Summary:

Use uppercase to describe columns with array type.

## Checklist(Required)

1. Does it affect the original behavior: No
2. Has unit tests been added: No Need
3. Has document been added or modified: No Need
4. Does it need to update dependencies: No
5. Are there any changes that cannot be rolled back: No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
