### PR TITLE
[fix](auth) Authentication exception when the name of database or table contains an underscore in grant statement.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/DbPrivEntry.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/DbPrivEntry.java
@@ -70,7 +70,7 @@ public class DbPrivEntry extends PrivEntry {
             dbCaseSensibility = false;
         }
 
-        return  PatternMatcher.createFlatPattern(db, dbCaseSensibility, db.equals(ANY_DB));
+        return PatternMatcher.createFlatPattern(db, dbCaseSensibility, db.equals(ANY_DB));
     }
 
     public PatternMatcher getDbPattern() {

--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/DbPrivEntry.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/DbPrivEntry.java
@@ -54,7 +54,7 @@ public class DbPrivEntry extends PrivEntry {
 
         PatternMatcher dbPattern = createDbPatternMatcher(db);
 
-        PatternMatcher userPattern = PatternMatcher.createMysqlPattern(user, CaseSensibility.USER.getCaseSensibility());
+        PatternMatcher userPattern = PatternMatcher.createFlatPattern(user, CaseSensibility.USER.getCaseSensibility());
 
         if (privs.containsNodePriv() || privs.containsResourcePriv()) {
             throw new AnalysisException("Db privilege can not contains global or resource privileges: " + privs);
@@ -70,8 +70,7 @@ public class DbPrivEntry extends PrivEntry {
             dbCaseSensibility = false;
         }
 
-        PatternMatcher dbPattern = PatternMatcher.createMysqlPattern(db.equals(ANY_DB) ? "%" : db, dbCaseSensibility);
-        return dbPattern;
+        return  PatternMatcher.createFlatPattern(db, dbCaseSensibility, db.equals(ANY_DB));
     }
 
     public PatternMatcher getDbPattern() {

--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/GlobalPrivEntry.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/GlobalPrivEntry.java
@@ -53,7 +53,7 @@ public class GlobalPrivEntry extends PrivEntry {
     public static GlobalPrivEntry create(String host, String user, boolean isDomain, byte[] password, PrivBitSet privs)
             throws AnalysisException {
         PatternMatcher hostPattern = PatternMatcher.createMysqlPattern(host, CaseSensibility.HOST.getCaseSensibility());
-        PatternMatcher userPattern = PatternMatcher.createMysqlPattern(user, CaseSensibility.USER.getCaseSensibility());
+        PatternMatcher userPattern = PatternMatcher.createFlatPattern(user, CaseSensibility.USER.getCaseSensibility());
         return new GlobalPrivEntry(hostPattern, host, userPattern, user, isDomain, password, privs);
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/PrivBitSet.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/PrivBitSet.java
@@ -47,7 +47,7 @@ public class PrivBitSet implements Writable {
 
     public void unset(int index) {
         Preconditions.checkState(index < PaloPrivilege.privileges.length, index);
-        set &= ~set;
+        set &= 1 << index;
     }
 
     public boolean get(int index) {

--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/TablePrivEntry.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/TablePrivEntry.java
@@ -50,12 +50,12 @@ public class TablePrivEntry extends DbPrivEntry {
     public static TablePrivEntry create(String host, String db, String user, String tbl, boolean isDomain,
             PrivBitSet privs) throws AnalysisException {
         PatternMatcher hostPattern = PatternMatcher.createMysqlPattern(host, CaseSensibility.HOST.getCaseSensibility());
-        PatternMatcher dbPattern = PatternMatcher.createMysqlPattern(db.equals(ANY_DB) ? "%" : db,
-                                                                     CaseSensibility.DATABASE.getCaseSensibility());
-        PatternMatcher userPattern = PatternMatcher.createMysqlPattern(user, CaseSensibility.USER.getCaseSensibility());
+        PatternMatcher dbPattern = PatternMatcher.createFlatPattern(
+                db, CaseSensibility.DATABASE.getCaseSensibility(), db.equals(ANY_DB));
+        PatternMatcher userPattern = PatternMatcher.createFlatPattern(user, CaseSensibility.USER.getCaseSensibility());
 
-        PatternMatcher tblPattern = PatternMatcher.createMysqlPattern(tbl.equals(ANY_TBL) ? "%" : tbl,
-                                                                      CaseSensibility.TABLE.getCaseSensibility());
+        PatternMatcher tblPattern = PatternMatcher.createFlatPattern(
+                tbl, CaseSensibility.TABLE.getCaseSensibility(), tbl.equals(ANY_TBL));
 
         if (privs.containsNodePriv() || privs.containsResourcePriv()) {
             throw new AnalysisException("Table privilege can not contains global or resource privileges: " + privs);

--- a/fe/fe-core/src/test/java/org/apache/doris/mysql/privilege/PrivEntryTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/mysql/privilege/PrivEntryTest.java
@@ -1,0 +1,48 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.mysql.privilege;
+
+import org.apache.doris.analysis.UserIdentity;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class PrivEntryTest {
+    @Test
+    public void testNameWithUnderscores() throws Exception {
+        TablePrivEntry tablePrivEntry = TablePrivEntry.create(
+                "127.%", "db_db1", "user1", "tbl_tbl1", false,
+                PrivBitSet.of(PaloPrivilege.SELECT_PRIV, PaloPrivilege.DROP_PRIV));
+        // pattern match
+        Assert.assertFalse(tablePrivEntry.getDbPattern().match("db-db1"));
+        Assert.assertFalse(tablePrivEntry.getTblPattern().match("tbl-tbl1"));
+        // create TablePrivTable
+        TablePrivTable tablePrivTable = new TablePrivTable();
+        tablePrivTable.addEntry(tablePrivEntry, false, false);
+        UserIdentity userIdentity = new UserIdentity("user1", "127.%", false);
+        userIdentity.setIsAnalyzed();
+
+        PrivBitSet privs1 = PrivBitSet.of();
+        tablePrivTable.getPrivs(userIdentity, "db#db1", "tbl#tbl1", privs1);
+        Assert.assertFalse(PaloPrivilege.satisfy(privs1, PrivPredicate.DROP));
+
+        PrivBitSet privs2 = PrivBitSet.of();
+        tablePrivTable.getPrivs(userIdentity, "db_db1", "tbl_tbl1", privs2);
+        Assert.assertTrue(PaloPrivilege.satisfy(privs2, PrivPredicate.DROP));
+    }
+}


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:
Authentication exception when the name of database or table contains an underscore in grant statement. 
Doris uses regular matching strings. If the name contains underscores, it will be converted to '.' wildcard.
```
// org.apache.doris.common.PatternMatcher#convertMysqlPattern
switch (ch) {
    case '%':
        sb.append(".*");
        break;
    case '.':
        sb.append("\\.");
        break;
    case '_':
        sb.append(".");
        break; 
```
If we build a TablePrivEntry contains underscores, any other table whose name changes one character  can get the same privileges:
```
TablePrivEntry tablePrivEntry = TablePrivEntry.create(
    "127.%", "db_db1", "user1", "tbl_tbl1", false,
    PrivBitSet.of(PaloPrivilege.SELECT_PRIV, PaloPrivilege.DROP_PRIV));

TablePrivTable tablePrivTable = new TablePrivTable();
tablePrivTable.addEntry(tablePrivEntry, false, false);
UserIdentity userIdentity = new UserIdentity("user1", "127.%", false);
userIdentity.setIsAnalyzed();

PrivBitSet privs1 = PrivBitSet.of();
tablePrivTable.getPrivs(userIdentity, "db#db1", "tbl#tbl1", privs1);
boolean canDrop1 = PaloPrivilege.satisfy(privs1, PrivPredicate.DROP); // canDrop1 equals true
```
In grant statement, database and table support matching a single '*' wildcard, the other cases are string case-sensitive equivalent matching.

Finally, fix a serious bug that won't be triggered in PrivBitSet.

## Checklist(Required)

1. Does it affect the original behavior: (No)
2. Has unit tests been added: (Yes)
3. Has document been added or modified: (No)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
