### PR TITLE
[Enhancement][Build] set default do not build benchmark-tool && use lld/gold first

### DIFF
--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -379,9 +379,25 @@ set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -DBOOST_SYSTEM_NO_DEPRECATED")
 # Enable the cpu and heap profile of brpc
 set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -DBRPC_ENABLE_CPU_PROFILER")
 
-if (USE_LLD)
-    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fuse-ld=lld")
-endif ()
+function(TRY_TO_CHANGE_LINKER LINKER_COMMAND LINKER_NAME)
+    if (CUSTUM_LINKER_COMMAND STREQUAL "ld")
+        execute_process(COMMAND ${CMAKE_C_COMPILER} -fuse-ld=${LINKER_COMMAND} -Wl,--version ERROR_QUIET OUTPUT_VARIABLE LD_VERSION)
+        if ("${LD_VERSION}" MATCHES ${LINKER_NAME})
+            message("Linker ${LINKER_NAME} is available, change linker to ${LINKER_NAME}")
+            set(CUSTUM_LINKER_COMMAND "${LINKER_COMMAND}" PARENT_SCOPE)
+        endif()
+    endif()
+endfunction()
+
+# In terms of performance, mold> lld> gold> ld
+set(CUSTUM_LINKER_COMMAND "ld")
+# TODO: mold will link fail on thirdparty brpc now, waiting for investigation.
+# TRY_TO_CHANGE_LINKER("mold" "mold")
+TRY_TO_CHANGE_LINKER("lld" "LLD")
+TRY_TO_CHANGE_LINKER("gold" "GNU gold")
+if (NOT CUSTUM_LINKER_COMMAND STREQUAL "ld")
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fuse-ld=${CUSTUM_LINKER_COMMAND}")
+endif()
 
 if (USE_LIBCPP AND COMPILER_CLANG)
     set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -stdlib=libc++ -lstdc++")

--- a/be/src/service/brpc.h
+++ b/be/src/service/brpc.h
@@ -25,15 +25,6 @@
 // clang-format on
 
 #include <brpc/channel.h>
-#include <brpc/closure_guard.h>
-#include <brpc/controller.h>
-#include <brpc/protocol.h>
-#include <brpc/reloadable_flags.h>
 #include <brpc/server.h>
-#include <bthread/bthread.h>
-#include <bthread/types.h>
-#include <butil/containers/flat_map.h>
-#include <butil/containers/flat_map_inl.h>
 #include <butil/endpoint.h>
 #include <butil/fd_utility.h>
-#include <butil/macros.h>

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -380,11 +380,13 @@ add_executable(doris_be_test
 target_link_libraries(doris_be_test ${TEST_LINK_LIBS})
 set_target_properties(doris_be_test PROPERTIES COMPILE_FLAGS "-fno-access-control" ENABLE_EXPORTS 1)
 
-add_executable(benchmark_tool
+if (BUILD_BENCHMARK_TOOL AND BUILD_BENCHMARK_TOOL STREQUAL "ON")
+    add_executable(benchmark_tool
     tools/benchmark_tool.cpp
     testutil/test_util.cpp
     olap/tablet_schema_helper.cpp
-)
+    )
 
-target_link_libraries(benchmark_tool ${TEST_LINK_LIBS})
-set_target_properties(benchmark_tool PROPERTIES COMPILE_FLAGS "-fno-access-control")
+    target_link_libraries(benchmark_tool ${TEST_LINK_LIBS})
+    set_target_properties(benchmark_tool PROPERTIES COMPILE_FLAGS "-fno-access-control")
+endif()

--- a/build.sh
+++ b/build.sh
@@ -205,9 +205,6 @@ fi
 if [[ -z ${USE_LIBCPP} ]]; then
     USE_LIBCPP=OFF
 fi
-if [[ -z ${USE_LLD} ]]; then
-    USE_LLD=OFF
-fi
 if [[ -z ${STRIP_DEBUG_INFO} ]]; then
     STRIP_DEBUG_INFO=OFF
 fi
@@ -234,7 +231,6 @@ echo "Get params:
     GLIBC_COMPATIBILITY -- $GLIBC_COMPATIBILITY
     USE_AVX2            -- $USE_AVX2
     USE_LIBCPP          -- $USE_LIBCPP
-    USE_LLD             -- $USE_LLD
     USE_DWARF           -- $USE_DWARF
     STRIP_DEBUG_INFO    -- $STRIP_DEBUG_INFO
     USE_MEM_TRACKER     -- $USE_MEM_TRACKER
@@ -247,7 +243,6 @@ fi
 echo "Build generated code"
 cd ${DORIS_HOME}/gensrc
 # DO NOT using parallel make(-j) for gensrc
-python --version
 make
 
 # Assesmble FE modules
@@ -295,7 +290,6 @@ if [ ${BUILD_BE} -eq 1 ] ; then
             -DWITH_LZO=${WITH_LZO} \
             -DUSE_LIBCPP=${USE_LIBCPP} \
             -DBUILD_META_TOOL=${BUILD_META_TOOL} \
-            -DUSE_LLD=${USE_LLD} \
             -DBUILD_JAVA_UDF=${BUILD_JAVA_UDF} \
             -DSTRIP_DEBUG_INFO=${STRIP_DEBUG_INFO} \
             -DUSE_DWARF=${USE_DWARF} \

--- a/run-be-ut.sh
+++ b/run-be-ut.sh
@@ -42,6 +42,7 @@ usage() {
   echo "
 Usage: $0 <options>
   Optional options:
+     --benchmark        build benchmark-tool
      --clean            clean and build ut
      --run              build and run all ut
      --run --filter=xx  build and run specified ut
@@ -63,7 +64,7 @@ Usage: $0 <options>
   exit 1
 }
 
-OPTS=$(getopt  -n $0 -o vhj:f: -l run,clean,filter: -- "$@")
+OPTS=$(getopt  -n $0 -o vhj:f: -l benchmark,run,clean,filter: -- "$@")
 if [ "$?" != "0" ]; then
   usage
 fi
@@ -74,18 +75,16 @@ eval set -- "$OPTS"
 
 PARALLEL=$[$(nproc)/5+1]
 
-if [[ -z ${USE_LLD} ]]; then
-    USE_LLD=OFF
-fi
-
 CLEAN=0
 RUN=0
+BUILD_BENCHMARK_TOOL=OFF
 FILTER=""
 if [ $# != 1 ] ; then
     while true; do 
         case "$1" in
             --clean) CLEAN=1 ; shift ;;
             --run) RUN=1 ; shift ;;
+            --benchmark) BUILD_BENCHMARK_TOOL=ON ; shift ;;
             -f | --filter) FILTER="--gtest_filter=$2"; shift 2;;
             -j) PARALLEL=$2; shift 2 ;;
             --) shift ;  break ;;
@@ -123,7 +122,6 @@ if [[ -z ${USE_DWARF} ]]; then
     USE_DWARF=OFF
 fi
 
-
 MAKE_PROGRAM="$(which "${BUILD_SYSTEM}")"
 echo "-- Make program: ${MAKE_PROGRAM}"
 
@@ -132,9 +130,9 @@ ${CMAKE_CMD} -G "${GENERATOR}" \
     -DCMAKE_MAKE_PROGRAM="${MAKE_PROGRAM}" \
     -DCMAKE_BUILD_TYPE="${CMAKE_BUILD_TYPE}" \
     -DMAKE_TEST=ON \
-    -DUSE_LLD=${USE_LLD} \
     -DGLIBC_COMPATIBILITY="${GLIBC_COMPATIBILITY}" \
     -DBUILD_META_TOOL=OFF \
+    -DBUILD_BENCHMARK_TOOL="${BUILD_BENCHMARK_TOOL}" \
     -DWITH_MYSQL=OFF \
     -DUSE_DWARF=${USE_DWARF} \
     -DUSE_MEM_TRACKER=ON \


### PR DESCRIPTION
# Proposed changes

1. add a config to enable build `benchmark-tool`
2.  If `lld/gold` detected, set `lld/gold` to linker.

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
