### PR TITLE
[improvement]No need to initialize selection array for predicates

### DIFF
--- a/be/src/olap/column_predicate.h
+++ b/be/src/olap/column_predicate.h
@@ -74,6 +74,9 @@ public:
     // evaluate predicate on IColumn
     // a short circuit eval way
     virtual void evaluate(vectorized::IColumn& column, uint16_t* sel, uint16_t* size) const {};
+    virtual void evaluate_uninitialized_selection(vectorized::IColumn& column, uint16_t* sel,
+                                                  uint16_t* size) const {};
+
     virtual void evaluate_and(vectorized::IColumn& column, uint16_t* sel, uint16_t size,
                               bool* flags) const {};
     virtual void evaluate_or(vectorized::IColumn& column, uint16_t* sel, uint16_t size,

--- a/be/src/olap/comparison_predicate.h
+++ b/be/src/olap/comparison_predicate.h
@@ -41,6 +41,8 @@ class VectorizedRowBatch;
                                 const std::vector<BitmapIndexIterator*>& iterators,                \
                                 uint32_t num_rows, roaring::Roaring* roaring) const override;      \
         void evaluate(vectorized::IColumn& column, uint16_t* sel, uint16_t* size) const override;  \
+        void evaluate_uninitialized_selection(vectorized::IColumn& column, uint16_t* sel,          \
+                                              uint16_t* size) const override;                      \
         void evaluate_and(vectorized::IColumn& column, uint16_t* sel, uint16_t size,               \
                           bool* flags) const override;                                             \
         void evaluate_or(vectorized::IColumn& column, uint16_t* sel, uint16_t size,                \

--- a/be/src/olap/in_list_predicate.h
+++ b/be/src/olap/in_list_predicate.h
@@ -224,6 +224,30 @@ public:
         }
     }
 
+    virtual void evaluate_uninitialized_selection(vectorized::IColumn& column, uint16_t* sel,
+                                                  uint16_t* size) const override {
+        if (column.is_nullable()) {
+            auto* nullable_col =
+                    vectorized::check_and_get_column<vectorized::ColumnNullable>(column);
+            auto& null_bitmap = reinterpret_cast<const vectorized::ColumnUInt8&>(
+                                        nullable_col->get_null_map_column())
+                                        .get_data();
+            auto& nested_col = nullable_col->get_nested_column();
+
+            if (_opposite) {
+                _base_evaluate<true, true, false>(&nested_col, &null_bitmap, sel, size);
+            } else {
+                _base_evaluate<true, false, false>(&nested_col, &null_bitmap, sel, size);
+            }
+        } else {
+            if (_opposite) {
+                _base_evaluate<false, true, false>(&column, nullptr, sel, size);
+            } else {
+                _base_evaluate<false, false, false>(&column, nullptr, sel, size);
+            }
+        }
+    }
+
     // todo(wb) support evaluate_and,evaluate_or
     void evaluate_and(vectorized::IColumn& column, uint16_t* sel, uint16_t size,
                       bool* flags) const override {
@@ -284,7 +308,7 @@ private:
         }
     }
 
-    template <bool is_nullable, bool is_opposite>
+    template <bool is_nullable, bool is_opposite, bool selection_initialized = true>
     void _base_evaluate(const vectorized::IColumn* column,
                         const vectorized::PaddedPODArray<vectorized::UInt8>* null_map,
                         uint16_t* sel, uint16_t* size) const {
@@ -299,7 +323,9 @@ private:
                 nested_col_ptr->find_codes(_values, selected);
 
                 for (uint16_t i = 0; i < *size; i++) {
-                    uint16_t idx = sel[i];
+                    uint16_t idx = i;
+                    if constexpr (selection_initialized) idx = sel[i];
+
                     if constexpr (is_nullable) {
                         if ((*null_map)[idx]) {
                             if constexpr (is_opposite) {
@@ -328,7 +354,8 @@ private:
             auto& data_array = nested_col_ptr->get_data();
 
             for (uint16_t i = 0; i < *size; i++) {
-                uint16_t idx = sel[i];
+                uint16_t idx = i;
+                if constexpr (selection_initialized) idx = sel[i];
                 if constexpr (is_nullable) {
                     if ((*null_map)[idx]) {
                         if constexpr (is_opposite) {


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

When there is no vectorized column predicate, it will take 200ms to initialize the selection array.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
