### PR TITLE
[fix] fix pr-10165 Constrain run-regression-test mem to 2G

### DIFF
--- a/run-regression-test.sh
+++ b/run-regression-test.sh
@@ -165,7 +165,7 @@ echo "===== Run Regression Test ====="
 
 JAVA_OPTS=${JAVA_OPTS}
 if [ ${TEAMCITY} -eq 1 ]; then
-  JAVA_OPTS="$JAVA_OPTS -DstdoutAppenderType=teamcity"
+  JAVA_OPTS="$JAVA_OPTS -DstdoutAppenderType=teamcity -Xmx2048m"
 fi
 
 $JAVA -DDORIS_HOME=$DORIS_HOME \
@@ -174,5 +174,4 @@ $JAVA -DDORIS_HOME=$DORIS_HOME \
       ${JAVA_OPTS} \
       -jar ${RUN_JAR} \
       -cf ${CONFIG_FILE} \
-      -Xmx2048m \
       ${REGRESSION_OPTIONS_PREFIX} "$@"


### PR DESCRIPTION
# Proposed changes

After pr 10165 merged(https://github.com/apache/doris/pull/10165), run single regression test do not work correctly.
Such as `sh run-regression-test.sh --run test_array_functions` command, still run all test cases.

The reason is param `-Xmx2048m` in wrong location.

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
