### PR TITLE
[improvement]Separate input and output parameters in ColumnPredicate

### DIFF
--- a/be/src/olap/block_column_predicate.h
+++ b/be/src/olap/block_column_predicate.h
@@ -43,8 +43,10 @@ public:
 
     virtual void get_all_column_ids(std::set<ColumnId>& column_id_set) const = 0;
 
-    virtual void evaluate(vectorized::MutableColumns& block, uint16_t* sel,
-                          uint16_t* selected_size) const {};
+    virtual uint16_t evaluate(vectorized::MutableColumns& block, uint16_t* sel,
+                              uint16_t selected_size) const {
+        return selected_size;
+    }
     virtual void evaluate_and(vectorized::MutableColumns& block, uint16_t* sel,
                               uint16_t selected_size, bool* flags) const {};
     virtual void evaluate_or(vectorized::MutableColumns& block, uint16_t* sel,
@@ -66,8 +68,8 @@ public:
         column_id_set.insert(_predicate->column_id());
     };
 
-    void evaluate(vectorized::MutableColumns& block, uint16_t* sel,
-                  uint16_t* selected_size) const override;
+    uint16_t evaluate(vectorized::MutableColumns& block, uint16_t* sel,
+                      uint16_t selected_size) const override;
     void evaluate_and(vectorized::MutableColumns& block, uint16_t* sel, uint16_t selected_size,
                       bool* flags) const override;
     void evaluate_or(vectorized::MutableColumns& block, uint16_t* sel, uint16_t selected_size,
@@ -115,8 +117,8 @@ public:
     void evaluate_and(RowBlockV2* block, uint16_t selected_size, bool* flags) const override;
     void evaluate_or(RowBlockV2* block, uint16_t selected_size, bool* flags) const override;
 
-    void evaluate(vectorized::MutableColumns& block, uint16_t* sel,
-                  uint16_t* selected_size) const override;
+    uint16_t evaluate(vectorized::MutableColumns& block, uint16_t* sel,
+                      uint16_t selected_size) const override;
     void evaluate_and(vectorized::MutableColumns& block, uint16_t* sel, uint16_t selected_size,
                       bool* flags) const override;
     void evaluate_or(vectorized::MutableColumns& block, uint16_t* sel, uint16_t selected_size,
@@ -135,8 +137,8 @@ public:
     // 2.Evaluate OR SEMANTICS in flags use 1 result to get proper select flags
     void evaluate_or(RowBlockV2* block, uint16_t selected_size, bool* flags) const override;
 
-    void evaluate(vectorized::MutableColumns& block, uint16_t* sel,
-                  uint16_t* selected_size) const override;
+    uint16_t evaluate(vectorized::MutableColumns& block, uint16_t* sel,
+                      uint16_t selected_size) const override;
     void evaluate_and(vectorized::MutableColumns& block, uint16_t* sel, uint16_t selected_size,
                       bool* flags) const override;
     void evaluate_or(vectorized::MutableColumns& block, uint16_t* sel, uint16_t selected_size,

--- a/be/src/olap/column_predicate.h
+++ b/be/src/olap/column_predicate.h
@@ -73,7 +73,9 @@ public:
 
     // evaluate predicate on IColumn
     // a short circuit eval way
-    virtual void evaluate(vectorized::IColumn& column, uint16_t* sel, uint16_t* size) const {};
+    virtual uint16_t evaluate(vectorized::IColumn& column, uint16_t* sel, uint16_t size) const {
+        return size;
+    };
     virtual void evaluate_and(vectorized::IColumn& column, uint16_t* sel, uint16_t size,
                               bool* flags) const {};
     virtual void evaluate_or(vectorized::IColumn& column, uint16_t* sel, uint16_t size,

--- a/be/src/olap/comparison_predicate.h
+++ b/be/src/olap/comparison_predicate.h
@@ -40,7 +40,8 @@ class VectorizedRowBatch;
         virtual Status evaluate(const Schema& schema,                                              \
                                 const std::vector<BitmapIndexIterator*>& iterators,                \
                                 uint32_t num_rows, roaring::Roaring* roaring) const override;      \
-        void evaluate(vectorized::IColumn& column, uint16_t* sel, uint16_t* size) const override;  \
+        uint16_t evaluate(vectorized::IColumn& column, uint16_t* sel,                              \
+                          uint16_t size) const override;                                           \
         void evaluate_and(vectorized::IColumn& column, uint16_t* sel, uint16_t size,               \
                           bool* flags) const override;                                             \
         void evaluate_or(vectorized::IColumn& column, uint16_t* sel, uint16_t size,                \

--- a/be/src/olap/null_predicate.cpp
+++ b/be/src/olap/null_predicate.cpp
@@ -125,19 +125,20 @@ Status NullPredicate::evaluate(const Schema& schema,
     return Status::OK();
 }
 
-void NullPredicate::evaluate(vectorized::IColumn& column, uint16_t* sel, uint16_t* size) const {
+uint16_t NullPredicate::evaluate(vectorized::IColumn& column, uint16_t* sel, uint16_t size) const {
     uint16_t new_size = 0;
     if (auto* nullable = check_and_get_column<ColumnNullable>(column)) {
         auto& null_map = nullable->get_null_map_data();
-        for (uint16_t i = 0; i < *size; ++i) {
+        for (uint16_t i = 0; i < size; ++i) {
             uint16_t idx = sel[i];
             sel[new_size] = idx;
             new_size += (null_map[idx] == _is_null);
         }
-        *size = new_size;
+        return new_size;
     } else {
-        if (_is_null) *size = 0;
+        if (_is_null) return 0;
     }
+    return size;
 }
 
 void NullPredicate::evaluate_or(IColumn& column, uint16_t* sel, uint16_t size, bool* flags) const {

--- a/be/src/olap/null_predicate.h
+++ b/be/src/olap/null_predicate.h
@@ -44,7 +44,7 @@ public:
     virtual Status evaluate(const Schema& schema, const vector<BitmapIndexIterator*>& iterators,
                             uint32_t num_rows, roaring::Roaring* roaring) const override;
 
-    void evaluate(vectorized::IColumn& column, uint16_t* sel, uint16_t* size) const override;
+    uint16_t evaluate(vectorized::IColumn& column, uint16_t* sel, uint16_t size) const override;
 
     void evaluate_or(vectorized::IColumn& column, uint16_t* sel, uint16_t size,
                      bool* flags) const override;

--- a/be/src/olap/rowset/segment_v2/segment_iterator.h
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.h
@@ -99,8 +99,8 @@ private:
                                   bool set_block_rowid);
     void _init_current_block(vectorized::Block* block,
                              std::vector<vectorized::MutableColumnPtr>& non_pred_vector);
-    void _evaluate_vectorization_predicate(uint16_t* sel_rowid_idx, uint16_t& selected_size);
-    void _evaluate_short_circuit_predicate(uint16_t* sel_rowid_idx, uint16_t* selected_size);
+    uint16_t _evaluate_vectorization_predicate(uint16_t* sel_rowid_idx, uint16_t selected_size);
+    uint16_t _evaluate_short_circuit_predicate(uint16_t* sel_rowid_idx, uint16_t selected_size);
     void _output_non_pred_columns(vectorized::Block* block);
     void _read_columns_by_rowids(std::vector<ColumnId>& read_column_ids,
                                  std::vector<rowid_t>& rowid_vector, uint16_t* sel_rowid_idx,


### PR DESCRIPTION
This code:
```cpp
for (uint16_t i = 0; i < *size; ++i) {
	// some code here
}
```
The value of size is read for each conditional test, which also prevents possible vectorization.

# Proposed changes

Issue Number: close #xxx

## Problem Summary:

Test with ssb-flat 100g  q2.3:
```sql
SELECT
SUM(LO_REVENUE), (LO_ORDERDATE DIV 10000) AS YEAR,
P_BRAND
FROM lineorder_flat
WHERE
P_BRAND = 'MFGR#2239'
AND S_REGION ='EUROPE'
GROUP BY YEAR, P_BRAND
ORDER BY YEAR, P_BRAND;
```
|master|column_predicate_opt|
|-|-|
|<img width="241" alt="image" src="https://user-images.githubusercontent.com/1179834/174489400-097402a9-9cd6-456e-a8a7-305c74f61a9a.png">|<img width="239" alt="image" src="https://user-images.githubusercontent.com/1179834/174489452-5c66a168-8093-4e52-a937-edf38c65907a.png">|
## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
