### PR TITLE
[fix] insert-select oom

### DIFF
--- a/be/src/olap/delta_writer.cpp
+++ b/be/src/olap/delta_writer.cpp
@@ -345,15 +345,23 @@ Status DeltaWriter::cancel() {
     return Status::OK();
 }
 
-int64_t DeltaWriter::save_mem_consumption_snapshot() {
-    _mem_consumption_snapshot = mem_consumption();
-    return _mem_consumption_snapshot;
+int64_t DeltaWriter::save_memtable_consumption_snapshot() {
+    _memtable_consumption_snapshot = memtable_consumption();
+    return _memtable_consumption_snapshot;
 }
 
-int64_t DeltaWriter::get_mem_consumption_snapshot() const {
-    return _mem_consumption_snapshot;
+int64_t DeltaWriter::get_memtable_consumption_snapshot() const {
+    return _memtable_consumption_snapshot;
 }
 
+int64_t DeltaWriter::memtable_consumption() const {
+    if (_mem_table == nullptr) {
+        // This method may be called before this writer is initialized.
+        // So _mem_tracker may be null.
+        return 0;
+    }
+    return _mem_table->memory_usage();
+}
 int64_t DeltaWriter::mem_consumption() const {
     if (_mem_tracker == nullptr) {
         // This method may be called before this writer is initialized.

--- a/be/src/olap/delta_writer.h
+++ b/be/src/olap/delta_writer.h
@@ -84,6 +84,8 @@ public:
 
     int64_t mem_consumption() const;
 
+    int64_t memtable_consumption() const;
+
     // Wait all memtable in flush queue to be flushed
     Status wait_flush();
 
@@ -91,9 +93,9 @@ public:
 
     int32_t schema_hash() { return _tablet->schema_hash(); }
 
-    int64_t save_mem_consumption_snapshot();
+    int64_t save_memtable_consumption_snapshot();
 
-    int64_t get_mem_consumption_snapshot() const;
+    int64_t get_memtable_consumption_snapshot() const;
 
 private:
     DeltaWriter(WriteRequest* req, StorageEngine* storage_engine, bool is_vec);
@@ -130,7 +132,7 @@ private:
     bool _is_vec;
 
     //only used for std::sort more detail see issue(#9237)
-    int64_t _mem_consumption_snapshot = 0;
+    int64_t _memtable_consumption_snapshot = 0;
 };
 
 } // namespace doris

--- a/be/src/olap/memtable_flush_executor.cpp
+++ b/be/src/olap/memtable_flush_executor.cpp
@@ -145,4 +145,8 @@ Status MemTableFlushExecutor::create_flush_token(std::unique_ptr<FlushToken>* fl
     return Status::OK();
 }
 
+bool MemTableFlushExecutor::thread_pool_overloaded() {
+    return _flush_pool->get_queue_size() > 0 && _flush_pool->num_active_threads() > _flush_pool->min_threads();
+}
+
 } // namespace doris

--- a/be/src/olap/memtable_flush_executor.h
+++ b/be/src/olap/memtable_flush_executor.h
@@ -103,7 +103,10 @@ public:
 
     Status create_flush_token(std::unique_ptr<FlushToken>* flush_token, RowsetTypePB rowset_type,
                               bool is_high_priority);
-
+    
+    //thread pool overload: if thread_pool runs more than _min_threads tasks, and there are some tasks in quey
+    bool thread_pool_overloaded();
+    
 private:
     std::unique_ptr<ThreadPool> _flush_pool;
     std::unique_ptr<ThreadPool> _high_prio_flush_pool;

--- a/be/src/runtime/load_channel.cpp
+++ b/be/src/runtime/load_channel.cpp
@@ -109,7 +109,7 @@ void LoadChannel::handle_mem_exceed_limit(bool force) {
 
     std::shared_ptr<TabletsChannel> channel;
     if (_find_largest_consumption_channel(&channel)) {
-        channel->reduce_mem_usage(_mem_tracker->limit());
+        channel->reduce_mem_usage(_mem_tracker->consumption());
     } else {
         // should not happen, add log to observe
         LOG(WARNING) << "fail to find suitable tablets-channel when memory exceed. "

--- a/be/src/runtime/tablets_channel.cpp
+++ b/be/src/runtime/tablets_channel.cpp
@@ -163,11 +163,11 @@ Status TabletsChannel::reduce_mem_usage(int64_t mem_limit) {
     // Sort the DeltaWriters by mem consumption in descend order.
     std::vector<DeltaWriter*> writers;
     for (auto& it : _tablet_writers) {
-        it.second->save_mem_consumption_snapshot();
+        it.second->save_memtable_consumption_snapshot();
         writers.push_back(it.second);
     }
     std::sort(writers.begin(), writers.end(), [](const DeltaWriter* lhs, const DeltaWriter* rhs) {
-        return lhs->get_mem_consumption_snapshot() > rhs->get_mem_consumption_snapshot();
+        return lhs->get_memtable_consumption_snapshot() > rhs->get_memtable_consumption_snapshot();
     });
 
     // Decide which writes should be flushed to reduce mem consumption.


### PR DESCRIPTION
# Proposed changes
1. if flush thread pool already have tasks waiting in queue, wait at most 2 sec
compared with current strategy, it could avoid flushing small segment files
2. After waiting for 2 sec, if the thread pool is still overloaded, we choose the delta_writer whose current mem-table is big, the submitted mem-table is not counted.
3. when mem exceeded, the size of mem to reduce is calculated by the _mem_tracker->consumption(), not by _mem_tracker->limit().

Issue Number: close #xxx

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
5. Has unit tests been added: (Yes/No/No Need)
6. Has document been added or modified: (Yes/No/No Need)
7. Does it need to update dependencies: (Yes/No)
8. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
