### PR TITLE
[enhancement] optmize 2 cases in seg_iter: all/none rows passed predicate

### DIFF
--- a/be/src/olap/rowset/segment_v2/segment_iterator.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.cpp
@@ -873,14 +873,14 @@ uint16_t SegmentIterator::_evaluate_vectorization_predicate(uint16_t* sel_rowid_
 
     uint16_t new_size = 0;
     size_t num_zeros = simd::count_zero_num(reinterpret_cast<int8_t*>(ret_flags), original_size);
-    if (0 == num_zeros){
-        for(uint16_t i=0; i<original_size; i++){
+    if (0 == num_zeros) {
+        for (uint16_t i = 0; i < original_size; i++) {
             sel_rowid_idx[i] = i;
         }
         new_size = original_size;
-    }else if (num_zeros == original_size){
+    } else if (num_zeros == original_size) {
         //no row pass, let new_size = 0
-    }else{
+    } else {
         uint32_t sel_pos = 0;
         const uint32_t sel_end = sel_pos + selected_size;
         static constexpr size_t SIMD_BYTES = 32;
@@ -888,13 +888,13 @@ uint16_t SegmentIterator::_evaluate_vectorization_predicate(uint16_t* sel_rowid_
 
         while (sel_pos < sel_end_simd) {
             auto mask = simd::bytes32_mask_to_bits32_mask(ret_flags + sel_pos);
-            if (0 == mask){
+            if (0 == mask) {
                 //pass
-            }else if (0xffffffff == mask){
-                for(uint32_t i=0; i<SIMD_BYTES; i++){
+            } else if (0xffffffff == mask) {
+                for (uint32_t i = 0; i < SIMD_BYTES; i++) {
                     sel_rowid_idx[new_size++] = sel_pos + i;
                 }
-            }else{
+            } else {
                 while (mask) {
                     const size_t bit_pos = __builtin_ctzll(mask);
                     sel_rowid_idx[new_size++] = sel_pos + bit_pos;


### PR DESCRIPTION
# Proposed changes
After vec_predicate, doris generates the array sel_rowid_idx for selected rows from 0/1 array ret_flags.
This pr implements a short cut for 2 cases:
- all rows are passed predicate
- none row is passed
Furthermore, if the 32-char part of ret_flags is 0 or 0xfffffff, the implementation also optimized.

test results：
select count(LO_ORDERDATE) from lineorder where LO_ORDERDATE >=19920101;
ssb100G
before：3.74sec
after: 3.37sec

Issue Number: close #xxx

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
