### PR TITLE
[enhancement] CRC32 instructions compatible arm arch

### DIFF
--- a/be/src/vec/common/hash_table/hash.h
+++ b/be/src/vec/common/hash_table/hash.h
@@ -64,7 +64,7 @@ inline doris::vectorized::UInt64 int_hash64(doris::vectorized::UInt64 x) {
 #endif
 
 inline doris::vectorized::UInt64 int_hash_crc32(doris::vectorized::UInt64 x) {
-#if defined(__SSE4_2__) || defined(__aarch64__)
+#if defined(__SSE4_2__) || (defined(__aarch64__) && defined(__ARM_FEATURE_CRC32))
     return _mm_crc32_u64(-1ULL, x);
 #else
     /// On other platforms we do not have CRC32. NOTE This can be confusing.


### PR DESCRIPTION
The performance of some CPUs that do not implement CRC instructions is particularly poor

# Proposed changes

Issue Number: close #10260

## Problem Summary:

- The performance of some CPUs that do not implement CRC instructions is particularly poor
- add instruction compatible logic

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
