### PR TITLE
[Improvement] remove olap filters when use in key ranges

### DIFF
--- a/be/src/exec/olap_common.h
+++ b/be/src/exec/olap_common.h
@@ -863,7 +863,7 @@ template <class T>
 Status OlapScanKeys::extend_scan_key(ColumnValueRange<T>& range, int32_t max_scan_key_num,
                                      bool* exact_value) {
     using namespace std;
-    typedef typename set<T>::const_iterator const_iterator_type;
+    using ConstIterator = typename set<T>::const_iterator;
 
     // 1. clear ScanKey if some column range is empty
     if (range.is_empty_value_range()) {
@@ -901,7 +901,7 @@ Status OlapScanKeys::extend_scan_key(ColumnValueRange<T>& range, int32_t max_sca
         // 3.1.1 construct num of fixed value ScanKey (begin_key == end_key)
         if (_begin_scan_keys.empty()) {
             const set<T>& fixed_value_set = range.get_fixed_value_set();
-            const_iterator_type iter = fixed_value_set.begin();
+            ConstIterator iter = fixed_value_set.begin();
 
             for (; iter != fixed_value_set.end(); ++iter) {
                 _begin_scan_keys.emplace_back();
@@ -925,7 +925,7 @@ Status OlapScanKeys::extend_scan_key(ColumnValueRange<T>& range, int32_t max_sca
                 OlapTuple start_base_key_range = _begin_scan_keys[i];
                 OlapTuple end_base_key_range = _end_scan_keys[i];
 
-                const_iterator_type iter = fixed_value_set.begin();
+                ConstIterator iter = fixed_value_set.begin();
 
                 for (; iter != fixed_value_set.end(); ++iter) {
                     // alter the first ScanKey in original place

--- a/be/src/exec/olap_common.h
+++ b/be/src/exec/olap_common.h
@@ -258,6 +258,9 @@ public:
     template <class T>
     Status extend_scan_key(ColumnValueRange<T>& range, int32_t max_scan_key_num);
 
+    template <class T>
+    Status extend_scan_key(ColumnValueRange<T>& range, int32_t max_scan_key_num, bool* exact_value);
+
     Status get_key_range(std::vector<std::unique_ptr<OlapScanRange>>* key_range);
 
     bool has_range_value() { return _has_range_value; }
@@ -760,6 +763,127 @@ Status OlapScanKeys::extend_scan_key(ColumnValueRange<T>& range, int32_t max_sca
         if (range.get_fixed_value_size() > max_scan_key_num / scan_keys_size) {
             if (range.is_range_value_convertible()) {
                 range.convert_to_range_value();
+            } else {
+                return Status::OK();
+            }
+        }
+    } else {
+        if (range.is_fixed_value_convertible() && _is_convertible) {
+            if (range.get_convertible_fixed_value_size() < max_scan_key_num / scan_keys_size) {
+                range.convert_to_fixed_value();
+            }
+        }
+    }
+
+    // 3.1 extend ScanKey with FixedValueRange
+    if (range.is_fixed_value_range()) {
+        // 3.1.1 construct num of fixed value ScanKey (begin_key == end_key)
+        if (_begin_scan_keys.empty()) {
+            const set<T>& fixed_value_set = range.get_fixed_value_set();
+            const_iterator_type iter = fixed_value_set.begin();
+
+            for (; iter != fixed_value_set.end(); ++iter) {
+                _begin_scan_keys.emplace_back();
+                _begin_scan_keys.back().add_value(cast_to_string(*iter));
+                _end_scan_keys.emplace_back();
+                _end_scan_keys.back().add_value(cast_to_string(*iter));
+            }
+
+            if (range.contain_null()) {
+                _begin_scan_keys.emplace_back();
+                _begin_scan_keys.back().add_null();
+                _end_scan_keys.emplace_back();
+                _end_scan_keys.back().add_null();
+            }
+        } // 3.1.2 produces the Cartesian product of ScanKey and fixed_value
+        else {
+            const set<T>& fixed_value_set = range.get_fixed_value_set();
+            int original_key_range_size = _begin_scan_keys.size();
+
+            for (int i = 0; i < original_key_range_size; ++i) {
+                OlapTuple start_base_key_range = _begin_scan_keys[i];
+                OlapTuple end_base_key_range = _end_scan_keys[i];
+
+                const_iterator_type iter = fixed_value_set.begin();
+
+                for (; iter != fixed_value_set.end(); ++iter) {
+                    // alter the first ScanKey in original place
+                    if (iter == fixed_value_set.begin()) {
+                        _begin_scan_keys[i].add_value(cast_to_string(*iter));
+                        _end_scan_keys[i].add_value(cast_to_string(*iter));
+                    } // append follow ScanKey
+                    else {
+                        _begin_scan_keys.push_back(start_base_key_range);
+                        _begin_scan_keys.back().add_value(cast_to_string(*iter));
+                        _end_scan_keys.push_back(end_base_key_range);
+                        _end_scan_keys.back().add_value(cast_to_string(*iter));
+                    }
+                }
+
+                if (range.contain_null()) {
+                    _begin_scan_keys.push_back(start_base_key_range);
+                    _begin_scan_keys.back().add_null();
+                    _end_scan_keys.push_back(end_base_key_range);
+                    _end_scan_keys.back().add_null();
+                }
+            }
+        }
+
+        _begin_include = true;
+        _end_include = true;
+    } // Extend ScanKey with range value
+    else {
+        _has_range_value = true;
+
+        if (_begin_scan_keys.empty()) {
+            _begin_scan_keys.emplace_back();
+            _begin_scan_keys.back().add_value(cast_to_string(range.get_range_min_value()),
+                                              range.contain_null());
+            _end_scan_keys.emplace_back();
+            _end_scan_keys.back().add_value(cast_to_string(range.get_range_max_value()));
+        } else {
+            for (int i = 0; i < _begin_scan_keys.size(); ++i) {
+                _begin_scan_keys[i].add_value(cast_to_string(range.get_range_min_value()),
+                                              range.contain_null());
+            }
+
+            for (int i = 0; i < _end_scan_keys.size(); ++i) {
+                _end_scan_keys[i].add_value(cast_to_string(range.get_range_max_value()));
+            }
+        }
+
+        _begin_include = range.is_begin_include();
+        _end_include = range.is_end_include();
+    }
+
+    return Status::OK();
+}
+
+template <class T>
+Status OlapScanKeys::extend_scan_key(ColumnValueRange<T>& range, int32_t max_scan_key_num,
+                                     bool* exact_value) {
+    using namespace std;
+    typedef typename set<T>::const_iterator const_iterator_type;
+
+    // 1. clear ScanKey if some column range is empty
+    if (range.is_empty_value_range()) {
+        _begin_scan_keys.clear();
+        _end_scan_keys.clear();
+        return Status::OK();
+    }
+
+    // 2. stop extend ScanKey when it's already extend a range value
+    if (_has_range_value) {
+        return Status::OK();
+    }
+
+    //if a column doesn't have any predicate, we will try converting the range to fixed values
+    auto scan_keys_size = _begin_scan_keys.empty() ? 1 : _begin_scan_keys.size();
+    if (range.is_fixed_value_range()) {
+        if (range.get_fixed_value_size() > max_scan_key_num / scan_keys_size) {
+            if (range.is_range_value_convertible()) {
+                range.convert_to_range_value();
+                *exact_value = false;
             } else {
                 return Status::OK();
             }

--- a/be/src/exec/olap_scan_node.cpp
+++ b/be/src/exec/olap_scan_node.cpp
@@ -479,21 +479,17 @@ Status OlapScanNode::start_scan(RuntimeState* state) {
         return Status::OK();
     }
 
-    VLOG_CRITICAL << "BuildOlapFilters";
+    VLOG_CRITICAL << "BuildKeyRangesAndFilters";
     // 3. Using ColumnValueRange to Build StorageEngine filters
-    RETURN_IF_ERROR(build_olap_filters());
-
-    VLOG_CRITICAL << "BuildScanKey";
-    // 4. Using `Key Column`'s ColumnValueRange to split ScanRange to several `Sub ScanRange`
-    RETURN_IF_ERROR(build_scan_key());
+    RETURN_IF_ERROR(build_key_ranges_and_filters());
 
     VLOG_CRITICAL << "Filter idle conjuncts";
-    // 5. Filter idle conjunct which already trans to olap filters
+    // 4. Filter idle conjunct which already trans to olap filters
     // this must be after build_scan_key, it will free the StringValue memory
     remove_pushed_conjuncts(state);
 
     VLOG_CRITICAL << "StartScanThread";
-    // 6. Start multi thread to read several `Sub Sub ScanRange`
+    // 5. Start multi thread to read several `Sub Sub ScanRange`
     RETURN_IF_ERROR(start_scan_thread(state));
 
     return Status::OK();
@@ -683,7 +679,35 @@ static std::string olap_filters_to_string(const std::vector<doris::TCondition>& 
     return filters_string;
 }
 
-Status OlapScanNode::build_olap_filters() {
+Status OlapScanNode::build_key_ranges_and_filters() {
+    const std::vector<std::string>& column_names = _olap_scan_node.key_column_name;
+    const std::vector<TPrimitiveType::type>& column_types = _olap_scan_node.key_column_type;
+    DCHECK(column_types.size() == column_names.size());
+
+    // 1. construct scan key except last olap engine short key
+    _scan_keys.set_is_convertible(limit() == -1);
+
+    // we use `exact_range` to identify a key range is an exact range or not when we convert
+    // it to `_scan_keys`. If `exact_range` is true, we can just discard it from `_olap_filter`.
+    bool exact_range = true;
+    for (int column_index = 0; column_index < column_names.size() && !_scan_keys.has_range_value();
+         ++column_index) {
+        auto iter = _column_value_ranges.find(column_names[column_index]);
+        if (_column_value_ranges.end() == iter) {
+            break;
+        }
+
+        RETURN_IF_ERROR(std::visit(
+                [&](auto&& range) {
+                    RETURN_IF_ERROR(
+                            _scan_keys.extend_scan_key(range, _max_scan_key_num, &exact_range));
+                    if (exact_range) {
+                        _column_value_ranges.erase(iter->first);
+                    }
+                    return Status::OK();
+                },
+                iter->second));
+    }
     for (auto& iter : _column_value_ranges) {
         std::vector<TCondition> filters;
         std::visit([&](auto&& range) { range.to_olap_filter(filters); }, iter.second);
@@ -695,28 +719,7 @@ Status OlapScanNode::build_olap_filters() {
 
     _runtime_profile->add_info_string("PushdownPredicate", olap_filters_to_string(_olap_filter));
 
-    return Status::OK();
-}
-
-Status OlapScanNode::build_scan_key() {
-    const std::vector<std::string>& column_names = _olap_scan_node.key_column_name;
-    const std::vector<TPrimitiveType::type>& column_types = _olap_scan_node.key_column_type;
-    DCHECK(column_types.size() == column_names.size());
-
-    // 1. construct scan key except last olap engine short key
-    _scan_keys.set_is_convertible(limit() == -1);
-
-    for (int column_index = 0; column_index < column_names.size() && !_scan_keys.has_range_value();
-         ++column_index) {
-        auto iter = _column_value_ranges.find(column_names[column_index]);
-        if (_column_value_ranges.end() == iter) {
-            break;
-        }
-
-        RETURN_IF_ERROR(std::visit(
-                [&](auto&& range) { return _scan_keys.extend_scan_key(range, _max_scan_key_num); },
-                iter->second));
-    }
+    _runtime_profile->add_info_string("KeyRanges", _scan_keys.debug_string());
 
     VLOG_CRITICAL << _scan_keys.debug_string();
 

--- a/be/src/exec/olap_scan_node.h
+++ b/be/src/exec/olap_scan_node.h
@@ -107,8 +107,7 @@ protected:
 
     void eval_const_conjuncts();
     Status normalize_conjuncts();
-    Status build_olap_filters();
-    Status build_scan_key();
+    Status build_key_ranges_and_filters();
     Status start_scan_thread(RuntimeState* state);
 
     template <class T>

--- a/be/src/vec/exec/volap_scan_node.cpp
+++ b/be/src/vec/exec/volap_scan_node.cpp
@@ -780,16 +780,16 @@ Status VOlapScanNode::start_scan(RuntimeState* state) {
     }
 
     VLOG_CRITICAL << "BuildKeyRangesAndFilters";
-    // 4. Using `Key Column`'s ColumnValueRange to split ScanRange to several `Sub ScanRange`
+    // 3. Using `Key Column`'s ColumnValueRange to split ScanRange to several `Sub ScanRange`
     RETURN_IF_ERROR(build_key_ranges_and_filters());
 
     VLOG_CRITICAL << "Filter idle conjuncts";
-    // 5. Filter idle conjunct which already trans to olap filters
+    // 4. Filter idle conjunct which already trans to olap filters
     // this must be after build_scan_key, it will free the StringValue memory
     remove_pushed_conjuncts(state);
 
     VLOG_CRITICAL << "StartScanThread";
-    // 6. Start multi thread to read several `Sub Sub ScanRange`
+    // 5. Start multi thread to read several `Sub Sub ScanRange`
     RETURN_IF_ERROR(start_scan_thread(state));
 
     return Status::OK();

--- a/be/src/vec/exec/volap_scan_node.cpp
+++ b/be/src/vec/exec/volap_scan_node.cpp
@@ -714,7 +714,36 @@ static std::string olap_filters_to_string(const std::vector<doris::TCondition>& 
     return filters_string;
 }
 
-Status VOlapScanNode::build_olap_filters() {
+Status VOlapScanNode::build_key_ranges_and_filters() {
+    const std::vector<std::string>& column_names = _olap_scan_node.key_column_name;
+    const std::vector<TPrimitiveType::type>& column_types = _olap_scan_node.key_column_type;
+    DCHECK(column_types.size() == column_names.size());
+
+    // 1. construct scan key except last olap engine short key
+    _scan_keys.set_is_convertible(limit() == -1);
+
+    // we use `exact_range` to identify a key range is an exact range or not when we convert
+    // it to `_scan_keys`. If `exact_range` is true, we can just discard it from `_olap_filter`.
+    bool exact_range = true;
+    for (int column_index = 0; column_index < column_names.size() && !_scan_keys.has_range_value();
+         ++column_index) {
+        auto iter = _column_value_ranges.find(column_names[column_index]);
+        if (_column_value_ranges.end() == iter) {
+            break;
+        }
+
+        RETURN_IF_ERROR(std::visit(
+                [&](auto&& range) {
+                    RETURN_IF_ERROR(
+                            _scan_keys.extend_scan_key(range, _max_scan_key_num, &exact_range));
+                    if (exact_range) {
+                        _column_value_ranges.erase(iter->first);
+                    }
+                    return Status::OK();
+                },
+                iter->second));
+    }
+
     for (auto& iter : _column_value_ranges) {
         std::vector<TCondition> filters;
         std::visit([&](auto&& range) { range.to_olap_filter(filters); }, iter.second);
@@ -726,28 +755,7 @@ Status VOlapScanNode::build_olap_filters() {
 
     _runtime_profile->add_info_string("PushdownPredicate", olap_filters_to_string(_olap_filter));
 
-    return Status::OK();
-}
-
-Status VOlapScanNode::build_scan_key() {
-    const std::vector<std::string>& column_names = _olap_scan_node.key_column_name;
-    const std::vector<TPrimitiveType::type>& column_types = _olap_scan_node.key_column_type;
-    DCHECK(column_types.size() == column_names.size());
-
-    // 1. construct scan key except last olap engine short key
-    _scan_keys.set_is_convertible(limit() == -1);
-
-    for (int column_index = 0; column_index < column_names.size() && !_scan_keys.has_range_value();
-         ++column_index) {
-        auto iter = _column_value_ranges.find(column_names[column_index]);
-        if (_column_value_ranges.end() == iter) {
-            break;
-        }
-
-        RETURN_IF_ERROR(std::visit(
-                [&](auto&& range) { return _scan_keys.extend_scan_key(range, _max_scan_key_num); },
-                iter->second));
-    }
+    _runtime_profile->add_info_string("KeyRanges", _scan_keys.debug_string());
 
     VLOG_CRITICAL << _scan_keys.debug_string();
 
@@ -771,13 +779,9 @@ Status VOlapScanNode::start_scan(RuntimeState* state) {
         return Status::OK();
     }
 
-    VLOG_CRITICAL << "BuildOlapFilters";
-    // 3. Using ColumnValueRange to Build StorageEngine filters
-    RETURN_IF_ERROR(build_olap_filters());
-
-    VLOG_CRITICAL << "BuildScanKey";
+    VLOG_CRITICAL << "BuildKeyRangesAndFilters";
     // 4. Using `Key Column`'s ColumnValueRange to split ScanRange to several `Sub ScanRange`
-    RETURN_IF_ERROR(build_scan_key());
+    RETURN_IF_ERROR(build_key_ranges_and_filters());
 
     VLOG_CRITICAL << "Filter idle conjuncts";
     // 5. Filter idle conjunct which already trans to olap filters

--- a/be/src/vec/exec/volap_scan_node.h
+++ b/be/src/vec/exec/volap_scan_node.h
@@ -65,8 +65,7 @@ private:
     Status start_scan(RuntimeState* state);
     void eval_const_conjuncts();
     Status normalize_conjuncts();
-    Status build_olap_filters();
-    Status build_scan_key();
+    Status build_key_ranges_and_filters();
     template <class T>
     Status normalize_predicate(ColumnValueRange<T>& range, SlotDescriptor* slot);
 

--- a/be/test/exec/olap_common_test.cpp
+++ b/be/test/exec/olap_common_test.cpp
@@ -443,7 +443,9 @@ TEST_F(OlapScanKeysTest, ExtendFixedTest) {
         EXPECT_TRUE(range1.add_fixed_value(i).ok());
     }
 
-    scan_keys.extend_scan_key(range1, 1024);
+    bool exact_range = true;
+    scan_keys.extend_scan_key(range1, 1024, &exact_range);
+    EXPECT_EQ(exact_range, true);
 
     std::vector<std::unique_ptr<OlapScanRange>> key_range;
     scan_keys.get_key_range(&key_range);
@@ -465,7 +467,9 @@ TEST_F(OlapScanKeysTest, ExtendFixedTest) {
         EXPECT_TRUE(range2.add_fixed_value(i).ok());
     }
 
-    scan_keys.extend_scan_key(range2, 1024);
+    exact_range = true;
+    scan_keys.extend_scan_key(range2, 1024, &exact_range);
+    EXPECT_EQ(exact_range, true);
 
     scan_keys.get_key_range(&key_range);
 
@@ -492,7 +496,9 @@ TEST_F(OlapScanKeysTest, ExtendFixedTest) {
     range2.set_whole_value_range();
     EXPECT_TRUE(range2.add_range(FILTER_LARGER_OR_EQUAL, 100).ok());
 
-    scan_keys.extend_scan_key(range2, 1024);
+    exact_range = true;
+    scan_keys.extend_scan_key(range2, 1024, &exact_range);
+    EXPECT_EQ(exact_range, true);
 
     scan_keys.get_key_range(&key_range);
 
@@ -526,15 +532,18 @@ TEST_F(OlapScanKeysTest, ExtendFixedAndRangeTest) {
         EXPECT_TRUE(range1.add_fixed_value(i).ok());
     }
 
-    scan_keys.extend_scan_key(range1, 1024);
+    bool exact_range = true;
+    scan_keys.extend_scan_key(range1, 1024, &exact_range);
+    EXPECT_EQ(exact_range, true);
 
     ColumnValueRange<int32_t> range2("col", TYPE_BIGINT);
     EXPECT_TRUE(range2.add_range(FILTER_LARGER_OR_EQUAL, 20).ok());
 
-    scan_keys.extend_scan_key(range2, 1024);
+    exact_range = true;
+    scan_keys.extend_scan_key(range2, 1024, &exact_range);
+    EXPECT_EQ(exact_range, true);
 
     std::vector<std::unique_ptr<OlapScanRange>> key_range;
-    ;
 
     scan_keys.get_key_range(&key_range);
 
@@ -551,7 +560,9 @@ TEST_F(OlapScanKeysTest, ExtendFixedAndRangeTest) {
 
     EXPECT_TRUE(range2.add_range(FILTER_LESS, 100).ok());
 
-    scan_keys.extend_scan_key(range2, 1024);
+    exact_range = true;
+    scan_keys.extend_scan_key(range2, 1024, &exact_range);
+    EXPECT_EQ(exact_range, true);
 
     scan_keys.get_key_range(&key_range);
 
@@ -575,10 +586,11 @@ TEST_F(OlapScanKeysTest, ExtendRangeTest) {
     EXPECT_TRUE(range2.add_range(FILTER_LARGER_OR_EQUAL, 20).ok());
     EXPECT_TRUE(range2.add_range(FILTER_LESS_OR_EQUAL, 100).ok());
 
-    EXPECT_TRUE(scan_keys.extend_scan_key(range2, 1024).ok());
+    bool exact_range = true;
+    EXPECT_TRUE(scan_keys.extend_scan_key(range2, 1024, &exact_range).ok());
+    EXPECT_EQ(exact_range, true);
 
     std::vector<std::unique_ptr<OlapScanRange>> key_range;
-    ;
 
     scan_keys.get_key_range(&key_range);
 
@@ -589,7 +601,9 @@ TEST_F(OlapScanKeysTest, ExtendRangeTest) {
 
     EXPECT_TRUE(range2.add_range(FILTER_LESS, 50).ok());
 
-    EXPECT_TRUE(scan_keys.extend_scan_key(range2, 1024).ok());
+    exact_range = true;
+    EXPECT_TRUE(scan_keys.extend_scan_key(range2, 1024, &exact_range).ok());
+    EXPECT_EQ(exact_range, false);
 
     scan_keys.get_key_range(&key_range);
 
@@ -606,7 +620,9 @@ TEST_F(OlapScanKeysTest, EachtypeTest) {
     {
         OlapScanKeys scan_keys;
         ColumnValueRange<int8_t> range("col", TYPE_TINYINT);
-        EXPECT_TRUE(scan_keys.extend_scan_key(range, 1024).ok());
+        bool exact_range = true;
+        EXPECT_TRUE(scan_keys.extend_scan_key(range, 1024, &exact_range).ok());
+        EXPECT_EQ(exact_range, true);
         scan_keys.get_key_range(&key_range);
         // contain null, [-128, 127]
         EXPECT_EQ(key_range.size(), 257);
@@ -615,7 +631,9 @@ TEST_F(OlapScanKeysTest, EachtypeTest) {
 
         EXPECT_TRUE(range.add_range(FILTER_LESS, 50).ok());
         scan_keys.clear();
-        EXPECT_TRUE(scan_keys.extend_scan_key(range, 1024).ok());
+        exact_range = true;
+        EXPECT_TRUE(scan_keys.extend_scan_key(range, 1024, &exact_range).ok());
+        EXPECT_EQ(exact_range, true);
         scan_keys.get_key_range(&key_range);
 
         EXPECT_EQ(key_range.size(), 178);
@@ -626,7 +644,9 @@ TEST_F(OlapScanKeysTest, EachtypeTest) {
     {
         OlapScanKeys scan_keys;
         ColumnValueRange<int16_t> range("col", TYPE_SMALLINT);
-        EXPECT_TRUE(scan_keys.extend_scan_key(range, 1024).ok());
+        bool exact_range = true;
+        EXPECT_TRUE(scan_keys.extend_scan_key(range, 1024, &exact_range).ok());
+        EXPECT_EQ(exact_range, true);
         scan_keys.get_key_range(&key_range);
         EXPECT_EQ(key_range.size(), 1);
         EXPECT_EQ(OlapScanKeys::to_print_key(key_range[0]->begin_scan_range), "null");
@@ -634,7 +654,9 @@ TEST_F(OlapScanKeysTest, EachtypeTest) {
 
         EXPECT_TRUE(range.add_range(FILTER_LARGER, 0).ok());
         scan_keys.clear();
-        EXPECT_TRUE(scan_keys.extend_scan_key(range, 1024).ok());
+        exact_range = true;
+        EXPECT_TRUE(scan_keys.extend_scan_key(range, 1024, &exact_range).ok());
+        EXPECT_EQ(exact_range, true);
         scan_keys.get_key_range(&key_range);
 
         EXPECT_EQ(key_range.size(), 1);
@@ -643,7 +665,9 @@ TEST_F(OlapScanKeysTest, EachtypeTest) {
 
         EXPECT_TRUE(range.add_range(FILTER_LESS, 32766).ok());
         scan_keys.clear();
-        EXPECT_TRUE(scan_keys.extend_scan_key(range, 1024).ok());
+        exact_range = true;
+        EXPECT_TRUE(scan_keys.extend_scan_key(range, 1024, &exact_range).ok());
+        EXPECT_EQ(exact_range, true);
         scan_keys.get_key_range(&key_range);
 
         EXPECT_EQ(key_range.size(), 1);


### PR DESCRIPTION
# Proposed changes

Issue Number: close #10277

## Problem Summary:

### perf test:
table: 
![image](https://user-images.githubusercontent.com/37700562/174597321-a1040dfa-df57-48d2-9a2e-e58b1e6add77.png)

records: 59986052

sql:
select count(*) from lineitem where l_orderkey < 60000001;

before this PR:
![aAPSIZ3FgK](https://user-images.githubusercontent.com/37700562/174597430-c71210ab-0caa-4770-9db5-0976fc61c773.jpg)
after this PR:
![jjuin9nN59](https://user-images.githubusercontent.com/37700562/174597499-cbda9bd8-c193-4a6e-829c-3a2e1226c055.jpg)


## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
