### PR TITLE
[fix][docs] Fix the "Doris Team" documentation.

### DIFF
--- a/docs/en/community/team.md
+++ b/docs/en/community/team.md
@@ -36,7 +36,7 @@ under the License.
 
 We'd like to thank the following committers to the Apache Doris (incubating) project who have helped get the project to where it is today. This list might be stale, the canonical list is located on [Apache's website](https://people.apache.org/committers-by-project.html#doris).
 
-## PPMC (22)
+## PMC (22)
 
 (the listing below excludes mentors)
 
@@ -64,7 +64,7 @@ We'd like to thank the following committers to the Apache Doris (incubating) pro
 
 ## Committers (33)
 
-(the listing excludes PPMC members above)
+(the listing excludes PMC members above)
 
 | Apache ID                                                    | Github Username  | Public Name    |
 | :----------------------------------------------------------- | :--------------- | :------------- |

--- a/docs/zh-CN/community/team.md
+++ b/docs/zh-CN/community/team.md
@@ -36,7 +36,7 @@ under the License.
 
 我们要感谢以下提交者，他们帮助Apache Doris (incubating) 取得了今天的进展。此列表可能已过时，正式列表位于 [Apache 的网站上](https://people.apache.org/committers-by-project.html#doris) 。
 
-## PPMC (22)
+## PMC (22)
 
 (如下列表不包含 mentors)
 
@@ -64,7 +64,7 @@ under the License.
 
 ## Committers (33)
 
-(如下列表不包含上述 PPMC 成员)
+(如下列表不包含上述 PMC 成员)
 
 | Apache ID                                                    | Github 用户名    | 公开名         |
 | :----------------------------------------------------------- | :--------------- | :------------- |


### PR DESCRIPTION
# Proposed changes

- Since Apache Doris has graduated as a top-level project, “PPMC” should be changed to “PMC”.

## Problem Summary:

- Fix the "Doris Team" documentation.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
