### PR TITLE
[bugfix][compaction][vectorized]fix compaction OOM

### DIFF
--- a/be/src/olap/rowset/segment_v2/segment_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_writer.cpp
@@ -165,8 +165,11 @@ Status SegmentWriter::append_block(const vectorized::Block* block, size_t row_po
 }
 
 int64_t SegmentWriter::max_row_to_add(size_t row_avg_size_in_bytes) {
-    int64_t size_rows =
-            ((int64_t)MAX_SEGMENT_SIZE - (int64_t)estimate_segment_size()) / row_avg_size_in_bytes;
+    auto segment_size = estimate_segment_size();
+    if (PREDICT_FALSE(segment_size >= MAX_SEGMENT_SIZE || _row_count >= _max_row_per_segment)) {
+        return 0;
+    }
+    int64_t size_rows = ((int64_t)MAX_SEGMENT_SIZE - (int64_t)segment_size) / row_avg_size_in_bytes;
     int64_t count_rows = (int64_t)_max_row_per_segment - _row_count;
 
     return std::min(size_rows, count_rows);


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

Row count caculation for segment writer will cause huge amount of data cached in memory when `estimate_segment_size()` is bigger than MAX_SEGMENT_SIZE, causing OOM:
```
int64_t SegmentWriter::max_row_to_add(size_t row_avg_size_in_bytes) {
    int64_t size_rows =
            ((int64_t)MAX_SEGMENT_SIZE - (int64_t)estimate_segment_size()) / row_avg_size_in_bytes;
    int64_t count_rows = (int64_t)_max_row_per_segment - _row_count;    return std::min(size_rows, count_rows);
} .
```

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
