### PR TITLE
[feature-wip](load) Support single replica load

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -35,6 +35,11 @@ CONF_Int32(brpc_port, "8060");
 // the number of bthreads for brpc, the default value is set to -1, which means the number of bthreads is #cpu-cores
 CONF_Int32(brpc_num_threads, "-1");
 
+// port to brpc server for single replica load
+CONF_Int32(single_replica_load_brpc_port, "8070");
+// the number of bthreads to brpc server for single replica load
+CONF_Int32(single_replica_load_brpc_num_threads, "64");
+
 // Declare a selection strategy for those servers have many ips.
 // Note that there should at most one ip match this list.
 // this is a list in semicolon-delimited format, in CIDR notation, e.g. 10.10.10.0/24
@@ -360,11 +365,19 @@ CONF_Int32(webserver_num_workers, "48");
 // Period to update rate counters and sampling counters in ms.
 CONF_mInt32(periodic_counter_update_period_ms, "500");
 
+CONF_Bool(enable_single_replica_load, "false");
+
+// Port to download server for single replica load
+CONF_Int32(single_replica_load_download_port, "8050");
+// Number of download workers for single replica load
+CONF_Int32(single_replica_load_download_num_workers, "64");
+
 // Used for mini Load. mini load data file will be removed after this time.
 CONF_Int64(load_data_reserve_hours, "4");
 // log error log will be removed after this time
 CONF_mInt64(load_error_log_reserve_hours, "48");
 CONF_Int32(number_tablet_writer_threads, "16");
+CONF_Int32(number_slave_replica_download_threads, "64");
 
 // The maximum amount of data that can be processed by a stream load
 CONF_mInt64(streaming_load_max_mb, "10240");
@@ -381,6 +394,7 @@ CONF_mInt32(streaming_load_rpc_max_alive_time_sec, "1200");
 CONF_Int32(tablet_writer_open_rpc_timeout_sec, "60");
 // You can ignore brpc error '[E1011]The server is overcrowded' when writing data.
 CONF_mBool(tablet_writer_ignore_eovercrowded, "false");
+CONF_mInt32(slave_replica_writer_rpc_timeout_sec, "60");
 // Whether to enable stream load record function, the default is false.
 // False: disable stream load record
 CONF_mBool(enable_stream_load_record, "false");

--- a/be/src/exec/tablet_sink.cpp
+++ b/be/src/exec/tablet_sink.cpp
@@ -21,6 +21,7 @@
 
 #include <sstream>
 #include <string>
+#include <unordered_map>
 
 #include "exprs/expr.h"
 #include "exprs/expr_context.h"
@@ -239,6 +240,29 @@ Status NodeChannel::open_wait() {
                         commit_info.tabletId = tablet.tablet_id();
                         commit_info.backendId = _node_id;
                         _tablet_commit_infos.emplace_back(std::move(commit_info));
+                        VLOG_CRITICAL
+                                << "master replica commit info: tabletId=" << tablet.tablet_id()
+                                << ", backendId=" << _node_id
+                                << ", master node id: " << this->node_id()
+                                << ", host: " << this->host() << ", txn_id=" << _parent->_txn_id;
+                    }
+
+                    if (_parent->_write_single_replica) {
+                        for (auto& tablet_slave_node_ids : result.success_slave_tablet_node_ids()) {
+                            for (auto slave_node_id :
+                                 tablet_slave_node_ids.second.slave_node_ids()) {
+                                TTabletCommitInfo commit_info;
+                                commit_info.tabletId = tablet_slave_node_ids.first;
+                                commit_info.backendId = slave_node_id;
+                                _tablet_commit_infos.emplace_back(std::move(commit_info));
+                                VLOG_CRITICAL << "slave replica commit info: tabletId="
+                                              << tablet_slave_node_ids.first
+                                              << ", backendId=" << slave_node_id
+                                              << ", master node id: " << this->node_id()
+                                              << ", host: " << this->host()
+                                              << ", txn_id=" << _parent->_txn_id;
+                            }
+                        }
                     }
                     _add_batches_finished = true;
                 }
@@ -504,6 +528,28 @@ void NodeChannel::try_send_batch(RuntimeState* state) {
             request.add_partition_ids(pid);
         }
 
+        request.set_write_single_replica(false);
+        if (_parent->_write_single_replica) {
+            request.set_write_single_replica(true);
+            for (std::unordered_map<int64_t, std::vector<int64_t>>::iterator iter =
+                         _slave_tablet_nodes.begin();
+                 iter != _slave_tablet_nodes.end(); iter++) {
+                PSlaveTabletNodes slave_tablet_nodes;
+                for (auto node_id : iter->second) {
+                    auto node = _parent->_nodes_info->find_node(node_id);
+                    if (node == nullptr) {
+                        return;
+                    }
+                    PNodeInfo* pnode = slave_tablet_nodes.add_slave_nodes();
+                    pnode->set_id(node->id);
+                    pnode->set_option(node->option);
+                    pnode->set_host(node->host);
+                    pnode->set_async_internal_port(config::single_replica_load_brpc_port);
+                }
+                request.mutable_slave_tablet_nodes()->insert({iter->first, slave_tablet_nodes});
+            }
+        }
+
         // eos request must be the last request
         _add_batch_closure->end_mark();
         _send_finished = true;
@@ -587,6 +633,12 @@ Status IndexChannel::init(RuntimeState* state, const std::vector<TTabletWithPart
                 channel = it->second;
             }
             channel->add_tablet(tablet);
+            if (_parent->_write_single_replica) {
+                auto slave_location = _parent->_slave_location->find_tablet(tablet.tablet_id);
+                if (slave_location != nullptr) {
+                    channel->add_slave_tablet_nodes(tablet.tablet_id, slave_location->node_ids);
+                }
+            }
             channels.push_back(channel);
             _tablets_by_channel[node_id].insert(tablet.tablet_id);
         }
@@ -685,6 +737,13 @@ Status OlapTableSink::init(const TDataSink& t_sink) {
     RETURN_IF_ERROR(_partition->init());
     _location = _pool->add(new OlapTableLocationParam(table_sink.location));
     _nodes_info = _pool->add(new DorisNodesInfo(table_sink.nodes_info));
+    if (table_sink.__isset.write_single_replica && table_sink.write_single_replica) {
+        _write_single_replica = true;
+        _slave_location = _pool->add(new OlapTableLocationParam(table_sink.slave_location));
+        if (!config::enable_single_replica_load) {
+            return Status::InternalError("single replica load is disabled on BE.");
+        }
+    }
 
     if (table_sink.__isset.load_channel_timeout_s) {
         _load_channel_timeout_s = table_sink.load_channel_timeout_s;

--- a/be/src/exec/tablet_sink.h
+++ b/be/src/exec/tablet_sink.h
@@ -174,6 +174,10 @@ public:
 
     virtual Status init(RuntimeState* state);
 
+    void add_slave_tablet_nodes(int64_t tablet_id, const std::vector<int64_t>& slave_nodes) {
+        _slave_tablet_nodes[tablet_id] = slave_nodes;
+    }
+
     // we use open/open_wait to parallel
     void open();
     virtual Status open_wait();
@@ -287,6 +291,8 @@ protected:
     RefCountClosure<PTabletWriterOpenResult>* _open_closure = nullptr;
 
     std::vector<TTabletWithPartition> _all_tablets;
+    // map from tablet_id to node_id where slave replicas locate in
+    std::unordered_map<int64_t, std::vector<int64_t>> _slave_tablet_nodes;
     std::vector<TTabletCommitInfo> _tablet_commit_infos;
 
     AddBatchCounter _add_batch_counter;
@@ -477,6 +483,8 @@ protected:
     // TODO(zc): think about cache this data
     std::shared_ptr<OlapTableSchemaParam> _schema;
     OlapTableLocationParam* _location = nullptr;
+    bool _write_single_replica = false;
+    OlapTableLocationParam* _slave_location = nullptr;
     DorisNodesInfo* _nodes_info = nullptr;
 
     RuntimeProfile* _profile = nullptr;

--- a/be/src/http/action/download_action.cpp
+++ b/be/src/http/action/download_action.cpp
@@ -104,7 +104,7 @@ void DownloadAction::handle_error_log(HttpRequest* req, const std::string& file_
 }
 
 void DownloadAction::handle(HttpRequest* req) {
-    LOG(INFO) << "accept one download request " << req->debug_string();
+    VLOG_CRITICAL << "accept one download request " << req->debug_string();
 
     // add tid to cgroup in order to limit read bandwidth
     CgroupsMgr::apply_system_cgroup();
@@ -124,7 +124,7 @@ void DownloadAction::handle(HttpRequest* req) {
         handle_normal(req, file_path);
     }
 
-    LOG(INFO) << "deal with download request finished! ";
+    VLOG_CRITICAL << "deal with download request finished! ";
 }
 
 Status DownloadAction::check_token(HttpRequest* req) {

--- a/be/src/olap/txn_manager.h
+++ b/be/src/olap/txn_manager.h
@@ -47,6 +47,7 @@
 #include "util/time.h"
 
 namespace doris {
+class DeltaWriter;
 
 struct TabletTxnInfo {
     PUniqueId load_id;
@@ -69,6 +70,8 @@ public:
         delete[] _txn_partition_maps;
         delete[] _txn_map_locks;
         delete[] _txn_mutex;
+        delete[] _txn_tablet_delta_writer_map;
+        delete[] _txn_tablet_delta_writer_map_locks;
     }
 
     Status prepare_txn(TPartitionId partition_id, const TabletSharedPtr& tablet,
@@ -137,6 +140,12 @@ public:
     void get_partition_ids(const TTransactionId transaction_id,
                            std::vector<TPartitionId>* partition_ids);
 
+    void add_txn_tablet_delta_writer(int64_t transaction_id, int64_t tablet_id,
+                                     DeltaWriter* delta_writer);
+    void clear_txn_tablet_delta_writer(int64_t transaction_id);
+    void finish_slave_tablet_pull_rowset(int64_t transaction_id, int64_t tablet_id, int64_t node_id,
+                                         bool is_succeed);
+
 private:
     using TxnKey = std::pair<int64_t, int64_t>; // partition_id, transaction_id;
 
@@ -159,6 +168,8 @@ private:
     typedef std::unordered_map<TxnKey, std::map<TabletInfo, TabletTxnInfo>, TxnKeyHash, TxnKeyEqual>
             txn_tablet_map_t;
     typedef std::unordered_map<int64_t, std::unordered_set<int64_t>> txn_partition_map_t;
+    typedef std::unordered_map<int64_t, std::map<int64_t, DeltaWriter*>>
+            txn_tablet_delta_writer_map_t;
 
     std::shared_mutex& _get_txn_map_lock(TTransactionId transactionId);
 
@@ -167,6 +178,10 @@ private:
     txn_partition_map_t& _get_txn_partition_map(TTransactionId transactionId);
 
     inline std::mutex& _get_txn_lock(TTransactionId transactionId);
+
+    std::shared_mutex& _get_txn_tablet_delta_writer_map_lock(TTransactionId transactionId);
+
+    txn_tablet_delta_writer_map_t& _get_txn_tablet_delta_writer_map(TTransactionId transactionId);
 
     // Insert or remove (transaction_id, partition_id) from _txn_partition_map
     // get _txn_map_lock before calling.
@@ -193,6 +208,9 @@ private:
     std::shared_mutex* _txn_map_locks;
 
     std::mutex* _txn_mutex;
+
+    txn_tablet_delta_writer_map_t* _txn_tablet_delta_writer_map;
+    std::shared_mutex* _txn_tablet_delta_writer_map_locks;
     DISALLOW_COPY_AND_ASSIGN(TxnManager);
 }; // TxnManager
 
@@ -211,6 +229,16 @@ inline TxnManager::txn_partition_map_t& TxnManager::_get_txn_partition_map(
 
 inline std::mutex& TxnManager::_get_txn_lock(TTransactionId transactionId) {
     return _txn_mutex[transactionId & (_txn_shard_size - 1)];
+}
+
+inline std::shared_mutex& TxnManager::_get_txn_tablet_delta_writer_map_lock(
+        TTransactionId transactionId) {
+    return _txn_tablet_delta_writer_map_locks[transactionId & (_txn_map_shard_size - 1)];
+}
+
+inline TxnManager::txn_tablet_delta_writer_map_t& TxnManager::_get_txn_tablet_delta_writer_map(
+        TTransactionId transactionId) {
+    return _txn_tablet_delta_writer_map[transactionId & (_txn_map_shard_size - 1)];
 }
 
 } // namespace doris

--- a/be/src/runtime/load_channel.h
+++ b/be/src/runtime/load_channel.h
@@ -81,9 +81,11 @@ protected:
                        Response* response) {
         bool finished = false;
         auto index_id = request.index_id();
-        RETURN_IF_ERROR(channel->close(request.sender_id(), request.backend_id(), &finished,
-                                       request.partition_ids(), response->mutable_tablet_vec(),
-                                       response->mutable_tablet_errors()));
+        RETURN_IF_ERROR(channel->close(
+                this, request.sender_id(), request.backend_id(), &finished, request.partition_ids(),
+                response->mutable_tablet_vec(), response->mutable_tablet_errors(),
+                request.slave_tablet_nodes(), response->mutable_success_slave_tablet_node_ids(),
+                request.write_single_replica()));
         if (finished) {
             std::lock_guard<std::mutex> l(_lock);
             _tablets_channels.erase(index_id);

--- a/be/src/service/CMakeLists.txt
+++ b/be/src/service/CMakeLists.txt
@@ -26,6 +26,7 @@ add_library(Service
     backend_service.cpp
     brpc_service.cpp
     http_service.cpp
+    single_replica_load_download_service.cpp
     internal_service.cpp
 )
 

--- a/be/src/service/brpc_service.cpp
+++ b/be/src/service/brpc_service.cpp
@@ -40,13 +40,13 @@ BRpcService::BRpcService(ExecEnv* exec_env) : _exec_env(exec_env), _server(new b
 
 BRpcService::~BRpcService() {}
 
-Status BRpcService::start(int port) {
+Status BRpcService::start(int port, int num_threads) {
     // Add service
     _server->AddService(new PInternalServiceImpl(_exec_env), brpc::SERVER_OWNS_SERVICE);
     // start service
     brpc::ServerOptions options;
-    if (config::brpc_num_threads != -1) {
-        options.num_threads = config::brpc_num_threads;
+    if (num_threads != -1) {
+        options.num_threads = num_threads;
     }
 
     if (_server->Start(port, &options) != 0) {

--- a/be/src/service/internal_service.h
+++ b/be/src/service/internal_service.h
@@ -148,6 +148,14 @@ public:
                            google::protobuf::Closure* done) override;
     void hand_shake(google::protobuf::RpcController* controller, const PHandShakeRequest* request,
                     PHandShakeResponse* response, google::protobuf::Closure* done) override;
+    void request_slave_tablet_pull_rowset(google::protobuf::RpcController* controller,
+                                          const PTabletWriteSlaveRequest* request,
+                                          PTabletWriteSlaveResult* response,
+                                          google::protobuf::Closure* done) override;
+    void response_slave_tablet_pull_rowset(google::protobuf::RpcController* controller,
+                                           const PTabletWriteSlaveDoneRequest* request,
+                                           PTabletWriteSlaveDoneResult* response,
+                                           google::protobuf::Closure* done) override;
 
 private:
     Status _exec_plan_fragment(const std::string& s_request, PFragmentRequestVersion version,
@@ -175,9 +183,14 @@ private:
                                   PTabletWriterAddBlockResult* response,
                                   google::protobuf::Closure* done);
 
+    void _response_pull_slave_rowset(const std::string& remote_host, int64_t brpc_port,
+                                     int64_t txn_id, int64_t tablet_id, int64_t node_id,
+                                     bool is_succeed);
+
 private:
     ExecEnv* _exec_env;
     PriorityThreadPool _tablet_worker_pool;
+    PriorityThreadPool _slave_replica_worker_pool;
 };
 
 } // namespace doris

--- a/be/src/service/single_replica_load_download_service.cpp
+++ b/be/src/service/single_replica_load_download_service.cpp
@@ -1,0 +1,56 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "service/single_replica_load_download_service.h"
+
+#include "http/action/download_action.h"
+#include "http/ev_http_server.h"
+#include "runtime/exec_env.h"
+
+namespace doris {
+
+SingleReplicaLoadDownloadService::SingleReplicaLoadDownloadService(ExecEnv* env, int port,
+                                                                   int num_threads)
+        : _env(env), _ev_http_server(new EvHttpServer(port, num_threads)) {}
+
+SingleReplicaLoadDownloadService::~SingleReplicaLoadDownloadService() {}
+
+Status SingleReplicaLoadDownloadService::start() {
+    // register download action
+    std::vector<std::string> allow_paths;
+    for (auto& path : _env->store_paths()) {
+        if (FilePathDesc::is_remote(path.storage_medium)) {
+            continue;
+        }
+        allow_paths.emplace_back(path.path);
+    }
+    DownloadAction* tablet_download_action = _pool.add(new DownloadAction(_env, allow_paths));
+    _ev_http_server->register_handler(HttpMethod::HEAD, "/api/_tablet/_download",
+                                      tablet_download_action);
+    _ev_http_server->register_handler(HttpMethod::GET, "/api/_tablet/_download",
+                                      tablet_download_action);
+
+    _ev_http_server->start();
+    return Status::OK();
+}
+
+void SingleReplicaLoadDownloadService::stop() {
+    _ev_http_server->stop();
+    _pool.clear();
+}
+
+} // namespace doris

--- a/be/src/service/single_replica_load_download_service.h
+++ b/be/src/service/single_replica_load_download_service.h
@@ -19,28 +19,28 @@
 
 #include <memory>
 
+#include "common/object_pool.h"
 #include "common/status.h"
-
-namespace brpc {
-class Server;
-}
 
 namespace doris {
 
 class ExecEnv;
+class EvHttpServer;
 
-// Class enclose brpc service
-class BRpcService {
+// HTTP service for Doris BE
+class SingleReplicaLoadDownloadService {
 public:
-    BRpcService(ExecEnv* exec_env);
-    ~BRpcService();
+    SingleReplicaLoadDownloadService(ExecEnv* env, int port, int num_threads);
+    ~SingleReplicaLoadDownloadService();
 
-    Status start(int port, int num_threads);
-    void join();
+    Status start();
+    void stop();
 
 private:
-    ExecEnv* _exec_env;
-    std::unique_ptr<brpc::Server> _server;
+    ExecEnv* _env;
+    ObjectPool _pool;
+
+    std::unique_ptr<EvHttpServer> _ev_http_server;
 };
 
 } // namespace doris

--- a/be/src/vec/sink/vtablet_sink.cpp
+++ b/be/src/vec/sink/vtablet_sink.cpp
@@ -123,6 +123,26 @@ Status VNodeChannel::open_wait() {
                     commit_info.tabletId = tablet.tablet_id();
                     commit_info.backendId = _node_id;
                     _tablet_commit_infos.emplace_back(std::move(commit_info));
+                    VLOG_CRITICAL << "master replica commit info: tabletId=" << tablet.tablet_id()
+                                  << ", backendId=" << _node_id
+                                  << ", master node id: " << this->node_id()
+                                  << ", host: " << this->host() << ", txn_id=" << _parent->_txn_id;
+                }
+                if (_parent->_write_single_replica) {
+                    for (auto& tablet_slave_node_ids : result.success_slave_tablet_node_ids()) {
+                        for (auto slave_node_id : tablet_slave_node_ids.second.slave_node_ids()) {
+                            TTabletCommitInfo commit_info;
+                            commit_info.tabletId = tablet_slave_node_ids.first;
+                            commit_info.backendId = slave_node_id;
+                            _tablet_commit_infos.emplace_back(std::move(commit_info));
+                            VLOG_CRITICAL << "slave replica commit info: tabletId="
+                                          << tablet_slave_node_ids.first
+                                          << ", backendId=" << slave_node_id
+                                          << ", master node id: " << this->node_id()
+                                          << ", host: " << this->host()
+                                          << ", txn_id=" << _parent->_txn_id;
+                        }
+                    }
                 }
                 _add_batches_finished = true;
             }
@@ -274,6 +294,28 @@ void VNodeChannel::try_send_block(RuntimeState* state) {
     if (request.eos()) {
         for (auto pid : _parent->_partition_ids) {
             request.add_partition_ids(pid);
+        }
+
+        request.set_write_single_replica(false);
+        if (_parent->_write_single_replica) {
+            request.set_write_single_replica(true);
+            for (std::unordered_map<int64_t, std::vector<int64_t>>::iterator iter =
+                         _slave_tablet_nodes.begin();
+                 iter != _slave_tablet_nodes.end(); iter++) {
+                PSlaveTabletNodes slave_tablet_nodes;
+                for (auto node_id : iter->second) {
+                    auto node = _parent->_nodes_info->find_node(node_id);
+                    if (node == nullptr) {
+                        return;
+                    }
+                    PNodeInfo* pnode = slave_tablet_nodes.add_slave_nodes();
+                    pnode->set_id(node->id);
+                    pnode->set_option(node->option);
+                    pnode->set_host(node->host);
+                    pnode->set_async_internal_port(node->brpc_port);
+                }
+                request.mutable_slave_tablet_nodes()->insert({iter->first, slave_tablet_nodes});
+            }
         }
 
         // eos request must be the last request

--- a/be/test/olap/delta_writer_test.cpp
+++ b/be/test/olap/delta_writer_test.cpp
@@ -25,6 +25,7 @@
 #include "gen_cpp/Descriptors_types.h"
 #include "gen_cpp/PaloInternalService_types.h"
 #include "gen_cpp/Types_types.h"
+#include "gen_cpp/internal_service.pb.h"
 #include "olap/field.h"
 #include "olap/options.h"
 #include "olap/storage_engine.h"
@@ -393,7 +394,7 @@ TEST_F(TestDeltaWriter, open) {
     EXPECT_NE(delta_writer, nullptr);
     res = delta_writer->close();
     EXPECT_EQ(Status::OK(), res);
-    res = delta_writer->close_wait();
+    res = delta_writer->close_wait(PSlaveTabletNodes(), false);
     EXPECT_EQ(Status::OK(), res);
     SAFE_DELETE(delta_writer);
 
@@ -402,7 +403,7 @@ TEST_F(TestDeltaWriter, open) {
     EXPECT_NE(delta_writer, nullptr);
     res = delta_writer->close();
     EXPECT_EQ(Status::OK(), res);
-    res = delta_writer->close_wait();
+    res = delta_writer->close_wait(PSlaveTabletNodes(), false);
     EXPECT_EQ(Status::OK(), res);
     SAFE_DELETE(delta_writer);
 
@@ -504,7 +505,7 @@ TEST_F(TestDeltaWriter, write) {
 
     res = delta_writer->close();
     EXPECT_EQ(Status::OK(), res);
-    res = delta_writer->close_wait();
+    res = delta_writer->close_wait(PSlaveTabletNodes(), false);
     EXPECT_EQ(Status::OK(), res);
 
     // publish version success
@@ -643,7 +644,7 @@ TEST_F(TestDeltaWriter, vec_write) {
 
     res = delta_writer->close();
     ASSERT_TRUE(res.ok());
-    res = delta_writer->close_wait();
+    res = delta_writer->close_wait(PSlaveTabletNodes(), false);
     ASSERT_TRUE(res.ok());
 
     // publish version success
@@ -717,7 +718,7 @@ TEST_F(TestDeltaWriter, sequence_col) {
 
     res = delta_writer->close();
     EXPECT_EQ(Status::OK(), res);
-    res = delta_writer->close_wait();
+    res = delta_writer->close_wait(PSlaveTabletNodes(), false);
     EXPECT_EQ(Status::OK(), res);
 
     // publish version success
@@ -803,7 +804,7 @@ TEST_F(TestDeltaWriter, vec_sequence_col) {
 
     res = delta_writer->close();
     ASSERT_TRUE(res.ok());
-    res = delta_writer->close_wait();
+    res = delta_writer->close_wait(PSlaveTabletNodes(), false);
     ASSERT_TRUE(res.ok());
 
     // publish version success

--- a/be/test/olap/engine_storage_migration_task_test.cpp
+++ b/be/test/olap/engine_storage_migration_task_test.cpp
@@ -25,6 +25,7 @@
 #include "gen_cpp/Descriptors_types.h"
 #include "gen_cpp/PaloInternalService_types.h"
 #include "gen_cpp/Types_types.h"
+#include "gen_cpp/internal_service.pb.h"
 #include "olap/delta_writer.h"
 #include "olap/field.h"
 #include "olap/options.h"
@@ -191,7 +192,7 @@ TEST_F(TestEngineStorageMigrationTask, write_and_migration) {
 
     res = delta_writer->close();
     EXPECT_EQ(Status::OK(), res);
-    res = delta_writer->close_wait();
+    res = delta_writer->close_wait(PSlaveTabletNodes(), false);
     EXPECT_EQ(Status::OK(), res);
 
     // publish version success

--- a/be/test/olap/remote_rowset_gc_test.cpp
+++ b/be/test/olap/remote_rowset_gc_test.cpp
@@ -21,6 +21,7 @@
 
 #include "common/config.h"
 #include "common/status.h"
+#include "gen_cpp/internal_service.pb.h"
 #include "io/fs/file_system_map.h"
 #include "io/fs/s3_file_system.h"
 #include "olap/delta_writer.h"
@@ -178,7 +179,7 @@ TEST_F(RemoteRowsetGcTest, normal) {
 
     st = delta_writer->close();
     ASSERT_EQ(Status::OK(), st);
-    st = delta_writer->close_wait();
+    st = delta_writer->close_wait(PSlaveTabletNodes(), false);
     ASSERT_EQ(Status::OK(), st);
 
     // publish version success

--- a/be/test/olap/tablet_cooldown_test.cpp
+++ b/be/test/olap/tablet_cooldown_test.cpp
@@ -21,6 +21,7 @@
 
 #include "common/config.h"
 #include "common/status.h"
+#include "gen_cpp/internal_service.pb.h"
 #include "io/fs/file_system_map.h"
 #include "io/fs/s3_file_system.h"
 #include "olap/delta_writer.h"
@@ -177,7 +178,7 @@ TEST_F(TabletCooldownTest, normal) {
 
     st = delta_writer->close();
     ASSERT_EQ(Status::OK(), st);
-    st = delta_writer->close_wait();
+    st = delta_writer->close_wait(PSlaveTabletNodes(), false);
     ASSERT_EQ(Status::OK(), st);
 
     // publish version success

--- a/docs/en/docs/admin-manual/config/be-config.md
+++ b/docs/en/docs/admin-manual/config/be-config.md
@@ -925,6 +925,12 @@ Default: 0
 
 The maximum number of threads per disk is also the maximum queue depth of each disk
 
+### `number_slave_replica_download_threads`
+
+Default: 64
+
+Number of threads for slave replica synchronize data, used for single replica load.
+
 ### `number_tablet_writer_threads`
 
 Default: 16
@@ -1099,6 +1105,36 @@ This configuration is used for the context gc thread scheduling cycle. Note: The
 
 * Type: int32
 * Description: The queue length of the SendBatch thread pool. In NodeChannels' sending data tasks,  the SendBatch operation of each NodeChannel will be submitted as a thread task to the thread pool waiting to be scheduled, and after the number of submitted tasks exceeds the length of the thread pool queue, subsequent submitted tasks will be blocked until there is a empty slot in the queue.
+
+### `single_replica_load_brpc_port`
+
+* Type: int32
+* Description: The port of BRPC on BE, used for single replica load. There is a independent BRPC thread pool for the communication between the Master replica and Slave replica during single replica load, which prevents data synchronization between the replicas from preempt the thread resources for data distribution and query tasks when the load concurrency is large.
+* Default value: 9070
+
+### `single_replica_load_brpc_num_threads`
+
+* Type: int32
+* Description: This configuration is mainly used to modify the number of bthreads for single replica load brpc. When the load concurrency increases, you can adjust this parameter to ensure that the Slave replica synchronizes data files from the Master replica timely.
+* Default value: 64
+
+### `single_replica_load_download_port`
+
+* Type: int32
+* Description: The port of http for segment download on BE, used for single replica load. There is a independent HTTP thread pool for the Slave replica to download segments during single replica load, which prevents data synchronization between the replicas from preempt the thread resources for other http tasks when the load concurrency is large.
+* Default value: 8050
+
+### `single_replica_load_download_num_workers`
+
+* Type: int32
+* Description: This configuration is mainly used to modify the number of http threads for segment download, used for single replica load. When the load concurrency increases, you can adjust this parameter to ensure that the Slave replica synchronizes data files from the Master replica timely.
+* Default value: 64
+
+### `slave_replica_writer_rpc_timeout_sec`
+
+* Type: int32
+* Description: This configuration is mainly used to modify timeout of brpc between master replica and slave replica, used for single replica load.
+* Default value: 60
 
 ### `sleep_one_second`
 

--- a/docs/en/docs/admin-manual/config/fe-config.md
+++ b/docs/en/docs/admin-manual/config/fe-config.md
@@ -1321,6 +1321,36 @@ MasterOnly：true
 
 fetch stream load record interval.
 
+### `enable_single_replica_stream_load`
+
+Default：false
+
+IsMutable：true
+
+MasterOnly：true
+
+Whether to enable the function of single replica load for stream load.
+
+### `enable_single_replica_broker_load`
+
+Default：false
+
+IsMutable：true
+
+MasterOnly：true
+
+Whether to enable the function of single replica load for broker load.
+
+### `enable_single_replica_insert`
+
+Default：false
+
+IsMutable：true
+
+MasterOnly：true
+
+Whether to enable the function of single replica load for insert.
+
 ### desired_max_waiting_jobs
 
 Default：100

--- a/docs/zh-CN/docs/admin-manual/config/be-config.md
+++ b/docs/zh-CN/docs/admin-manual/config/be-config.md
@@ -926,6 +926,12 @@ BE进程的文件句柄limit要求的下限
 
 每个磁盘的最大线程数也是每个磁盘的最大队列深度
 
+### `number_slave_replica_download_threads`
+
+默认值: 64
+
+每个BE节点上slave副本同步Master副本数据的线程数，用于单副本数据导入功能。
+
 ### `number_tablet_writer_threads`
 
 默认值：16
@@ -1107,6 +1113,36 @@ routine load任务的线程池大小。 这应该大于 FE 配置 'max_concurren
 默认值：false
 
 BE之间rpc通信是否序列化RowBatch，用于查询层之间的数据传输
+
+### `single_replica_load_brpc_port`
+
+* 类型: int32
+* 描述: 单副本数据导入功能中，Master副本和Slave副本之间通信的RPC端口。Master副本flush完成之后通过RPC通知Slave副本同步数据，以及Slave副本同步数据完成后通过RPC通知Master副本。系统为单副本数据导入过程中Master副本和Slave副本之间通信开辟了独立的BRPC线程池，以避免导入并发较大时副本之间的数据同步抢占导入数据分发和查询任务的线程资源。
+* 默认值: 9070
+
+### `single_replica_load_brpc_num_threads`
+
+* 类型: int32
+* 描述: 单副本数据导入功能中，Master副本和Slave副本之间通信的线程数量。导入并发增大时，可以适当调大该参数来保证Slave副本及时同步Master副本数据。
+* 默认值: 64
+
+### `single_replica_load_download_port`
+
+* 类型: int32
+* 描述: 单副本数据导入功能中，Slave副本通过HTTP从Master副本下载数据文件的端口。系统为单副本数据导入过程中Slave副本从Master副本下载数据文件开辟了独立的HTTP线程池，以避免导入并发较大时Slave副本下载数据文件抢占其他http任务的线程资源。
+* 默认值: 8050
+
+### `single_replica_load_download_num_workers`
+
+* 类型: int32
+* 描述: 单副本数据导入功能中，Slave副本通过HTTP从Master副本下载数据文件的线程数。导入并发增大时，可以适当调大该参数来保证Slave副本及时同步Master副本数据。
+* 默认值: 64
+
+### `slave_replica_writer_rpc_timeout_sec`
+
+* 类型: int32
+* 描述: 单副本数据导入功能中，Master副本和Slave副本之间通信的RPC超时时间。
+* 默认值: 60
 
 ### `sleep_one_second`
 + 类型：int32

--- a/docs/zh-CN/docs/admin-manual/config/fe-config.md
+++ b/docs/zh-CN/docs/admin-manual/config/fe-config.md
@@ -1329,6 +1329,36 @@ BE副本数的平衡阈值。
 
 获取 stream load 记录间隔
 
+### `enable_single_replica_stream_load`
+
+默认值：false
+
+是否可以动态配置：true
+
+是否为 Master FE 节点独有的配置项：true
+
+是否启动 stream load 的单副本数据导入功能。
+
+### `enable_single_replica_broker_load`
+
+默认值：false
+
+是否可以动态配置：true
+
+是否为 Master FE 节点独有的配置项：true
+
+是否启动 broker load 的单副本数据导入功能。
+
+### `enable_single_replica_insert`
+
+默认值：false
+
+是否可以动态配置：true
+
+是否为 Master FE 节点独有的配置项：true
+
+是否启动 insert 的单副本数据写入功能。
+
 ### `desired_max_waiting_jobs`
 
 默认值：100

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/InsertStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/InsertStmt.java
@@ -708,7 +708,8 @@ public class InsertStmt extends DdlStmt {
             return dataSink;
         }
         if (targetTable instanceof OlapTable) {
-            dataSink = new OlapTableSink((OlapTable) targetTable, olapTuple, targetPartitionIds);
+            dataSink = new OlapTableSink((OlapTable) targetTable, olapTuple, targetPartitionIds,
+                    analyzer.getContext().getSessionVariable().isEnableSingleReplicaInsert());
             dataPartition = dataSink.getOutputPartition();
         } else if (targetTable instanceof BrokerTable) {
             BrokerTable table = (BrokerTable) targetTable;

--- a/fe/fe-core/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/Config.java
@@ -727,6 +727,12 @@ public class Config extends ConfigBase {
     public static boolean disable_show_stream_load = false;
 
     /**
+     * Whether to enable to write single replica for stream load and broker load.
+     */
+    @ConfField(mutable = true, masterOnly = true)
+    public static boolean enable_single_replica_load = false;
+
+    /**
      * maximum concurrent running txn num including prepare, commit txns under a single db
      * txn manager will reject coming txns
      */

--- a/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/LoadingTaskPlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/LoadingTaskPlanner.java
@@ -131,7 +131,8 @@ public class LoadingTaskPlanner {
 
         // 2. Olap table sink
         List<Long> partitionIds = getAllPartitionIds();
-        OlapTableSink olapTableSink = new OlapTableSink(table, destTupleDesc, partitionIds);
+        OlapTableSink olapTableSink = new OlapTableSink(table, destTupleDesc, partitionIds,
+                Config.enable_single_replica_load);
         olapTableSink.init(loadId, txnId, dbId, timeoutS, sendBatchParallelism, false);
         olapTableSink.complete();
 

--- a/fe/fe-core/src/main/java/org/apache/doris/load/update/UpdatePlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/update/UpdatePlanner.java
@@ -92,7 +92,7 @@ public class UpdatePlanner extends OriginalPlanner {
         }
         scanNodeList.add(olapScanNode);
         // 2. gen olap table sink
-        OlapTableSink olapTableSink = new OlapTableSink(targetTable, computeTargetTupleDesc(), null);
+        OlapTableSink olapTableSink = new OlapTableSink(targetTable, computeTargetTupleDesc(), null, false);
         olapTableSink.init(analyzer.getContext().queryId(), txnId, targetDBId,
                 analyzer.getContext().getSessionVariable().queryTimeoutS,
                 analyzer.getContext().getSessionVariable().sendBatchParallelism, false);

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/StreamLoadPlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/StreamLoadPlanner.java
@@ -154,7 +154,8 @@ public class StreamLoadPlanner {
 
         // create dest sink
         List<Long> partitionIds = getAllPartitionIds();
-        OlapTableSink olapTableSink = new OlapTableSink(destTable, tupleDesc, partitionIds);
+        OlapTableSink olapTableSink = new OlapTableSink(destTable, tupleDesc, partitionIds,
+                Config.enable_single_replica_load);
         olapTableSink.init(loadId, taskInfo.getTxnId(), db.getId(), taskInfo.getTimeout(),
                 taskInfo.getSendBatchParallelism(), taskInfo.isLoadToSingleTablet());
         olapTableSink.complete();

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -205,6 +205,8 @@ public class SessionVariable implements Serializable, Writable {
 
     static final String SESSION_CONTEXT = "session_context";
 
+    public static final String ENABLE_SINGLE_REPLICA_INSERT = "enable_single_replica_insert";
+
     // session origin value
     public Map<Field, String> sessionOriginValue = new HashMap<Field, String>();
     // check stmt is or not [select /*+ SET_VAR(...)*/ ...]
@@ -510,6 +512,9 @@ public class SessionVariable implements Serializable, Writable {
      */
     @VariableMgr.VarAttr(name = SESSION_CONTEXT, needForward = true)
     public String sessionContext = "";
+
+    @VariableMgr.VarAttr(name = ENABLE_SINGLE_REPLICA_INSERT, needForward = true)
+    public boolean enableSingleReplicaInsert = false;
 
     public String getBlockEncryptionMode() {
         return blockEncryptionMode;
@@ -1037,6 +1042,14 @@ public class SessionVariable implements Serializable, Writable {
 
     public void setEnableNereidsReorderToEliminateCrossJoin(boolean value) {
         enableNereidsReorderToEliminateCrossJoin = value;
+    }
+
+    public boolean isEnableSingleReplicaInsert() {
+        return enableSingleReplicaInsert;
+    }
+
+    public void setEnableSingleReplicaInsert(boolean enableSingleReplicaInsert) {
+        this.enableSingleReplicaInsert = enableSingleReplicaInsert;
     }
 
     /**

--- a/fe/fe-core/src/test/java/org/apache/doris/planner/OlapTableSinkTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/planner/OlapTableSinkTest.java
@@ -102,7 +102,7 @@ public class OlapTableSinkTest {
             }
         };
 
-        OlapTableSink sink = new OlapTableSink(dstTable, tuple, Lists.newArrayList(2L));
+        OlapTableSink sink = new OlapTableSink(dstTable, tuple, Lists.newArrayList(2L), false);
         sink.init(new TUniqueId(1, 2), 3, 4, 1000, 1, false);
         sink.complete();
         LOG.info("sink is {}", sink.toThrift());
@@ -139,7 +139,7 @@ public class OlapTableSinkTest {
             }
         };
 
-        OlapTableSink sink = new OlapTableSink(dstTable, tuple, Lists.newArrayList(p1.getId()));
+        OlapTableSink sink = new OlapTableSink(dstTable, tuple, Lists.newArrayList(p1.getId()), false);
         sink.init(new TUniqueId(1, 2), 3, 4, 1000, 1, false);
         try {
             sink.complete();
@@ -164,7 +164,7 @@ public class OlapTableSinkTest {
             }
         };
 
-        OlapTableSink sink = new OlapTableSink(dstTable, tuple, Lists.newArrayList(unknownPartId));
+        OlapTableSink sink = new OlapTableSink(dstTable, tuple, Lists.newArrayList(unknownPartId), false);
         sink.init(new TUniqueId(1, 2), 3, 4, 1000, 1, false);
         sink.complete();
         LOG.info("sink is {}", sink.toThrift());
@@ -201,7 +201,7 @@ public class OlapTableSinkTest {
             }
         };
 
-        OlapTableSink sink = new OlapTableSink(dstTable, tuple, Lists.newArrayList(p1.getId()));
+        OlapTableSink sink = new OlapTableSink(dstTable, tuple, Lists.newArrayList(p1.getId()), false);
         sink.init(new TUniqueId(1, 2), 3, 4, 1000, 1, false);
         try {
             sink.complete();

--- a/gensrc/proto/internal_service.proto
+++ b/gensrc/proto/internal_service.proto
@@ -23,6 +23,7 @@ option java_package = "org.apache.doris.proto";
 import "data.proto";
 import "descriptors.proto";
 import "types.proto";
+import "olap_file.proto";
 
 option cc_generic_services = true;
 
@@ -107,6 +108,8 @@ message PTabletWriterAddBatchRequest {
     // transfer the RowBatch to the Controller Attachment
     optional bool transfer_by_attachment = 10 [default = false];
     optional bool is_high_priority = 11 [default = false];
+    optional bool write_single_replica = 12 [default = false];
+    map<int64, PSlaveTabletNodes> slave_tablet_nodes = 13;
 };
 
 message PTabletWriterAddBlockRequest {
@@ -129,7 +132,25 @@ message PTabletWriterAddBlockRequest {
     // transfer the vectorized::Block to the Controller Attachment
     optional bool transfer_by_attachment = 10 [default = false];
     optional bool is_high_priority = 11 [default = false];
+    optional bool write_single_replica = 12 [default = false];
+    map<int64, PSlaveTabletNodes> slave_tablet_nodes = 13;
 };
+
+message PSlaveTabletNodes {
+    repeated PNodeInfo slave_nodes = 1;
+}
+
+message PNodeInfo {
+    optional int64 id = 1;
+    optional int64 option = 2;
+    optional string host = 3;
+    // used to transfer data between nodes
+    optional int32 async_internal_port = 4;
+}
+
+message PSuccessSlaveTabletNodeIds {
+    repeated int64 slave_node_ids = 1;
+}
 
 message PTabletError {
     optional int64 tablet_id = 1;
@@ -143,6 +164,7 @@ message PTabletWriterAddBatchResult {
     optional int64 wait_lock_time_us = 4;
     optional int64 wait_execution_time_us = 5;
     repeated PTabletError tablet_errors = 6;
+    map<int64, PSuccessSlaveTabletNodeIds> success_slave_tablet_node_ids = 7;
 };
 
 message PTabletWriterAddBlockResult {
@@ -152,6 +174,7 @@ message PTabletWriterAddBlockResult {
     optional int64 wait_lock_time_us = 4;
     optional int64 wait_execution_time_us = 5;
     repeated PTabletError tablet_errors = 6;
+    map<int64, PSuccessSlaveTabletNodeIds> success_slave_tablet_node_ids = 7;
 };
 
 // tablet writer cancel
@@ -476,6 +499,32 @@ message PResetRPCChannelResponse {
 
 message PEmptyRequest {};
 
+message PTabletWriteSlaveRequest {
+    optional RowsetMetaPB rowset_meta = 1;
+    optional string rowset_path = 2;
+    map<int64, int64> segments_size = 3;
+    optional string host = 4;
+    optional int32 http_port = 5;
+    optional int32 brpc_port = 6;
+    optional string token = 7;
+    optional int32 node_id = 8;
+};
+
+message PTabletWriteSlaveResult {
+    optional PStatus status = 1;
+};
+
+message PTabletWriteSlaveDoneRequest {
+    optional int64 txn_id = 1;
+    optional int64 tablet_id = 2;
+    optional int64 node_id = 3;
+    optional bool is_succeed = 4 [default = false];
+};
+
+message PTabletWriteSlaveDoneResult {
+    optional PStatus status = 1;
+};
+
 service PBackendService {
     rpc transmit_data(PTransmitDataParams) returns (PTransmitDataResult);
     rpc transmit_data_by_http(PEmptyRequest) returns (PTransmitDataResult);
@@ -507,5 +556,7 @@ service PBackendService {
     rpc check_rpc_channel(PCheckRPCChannelRequest) returns (PCheckRPCChannelResponse);
     rpc reset_rpc_channel(PResetRPCChannelRequest) returns (PResetRPCChannelResponse);
     rpc hand_shake(PHandShakeRequest) returns (PHandShakeResponse);
+    rpc request_slave_tablet_pull_rowset(PTabletWriteSlaveRequest) returns (PTabletWriteSlaveResult);
+    rpc response_slave_tablet_pull_rowset(PTabletWriteSlaveDoneRequest) returns (PTabletWriteSlaveDoneResult);
 };
 

--- a/gensrc/thrift/DataSinks.thrift
+++ b/gensrc/thrift/DataSinks.thrift
@@ -131,6 +131,8 @@ struct TOlapTableSink {
     14: optional i64 load_channel_timeout_s // the timeout of load channels in second
     15: optional i32 send_batch_parallelism
     16: optional bool load_to_single_tablet
+    17: optional bool write_single_replica
+    18: optional Descriptors.TOlapTableLocationParam slave_location
 }
 
 struct TDataSink {


### PR DESCRIPTION
# Proposed changes

Issue Number: close #9847 

## Problem Summary:

During load process, the same operation are performed on all replicas such as sort and aggregation, which are resource-intensive. Concurrent data load would consume much CPU and memory resources. It's better to perform write process (writing data into MemTable and then data flush) on single replica and synchronize data files to other replicas before transaction finished.

## Checklist(Required)

1. Does it affect the original behavior: No
2. Has unit tests been added: No
3. Has document been added or modified: Yes
4. Does it need to update dependencies: No
5. Are there any changes that cannot be rolled back:No

