### PR TITLE
[fix] [ubsan] Fix TCMalloc Hook deadlocks when ThreadContext is initialized

### DIFF
--- a/be/src/runtime/tcmalloc_hook.h
+++ b/be/src/runtime/tcmalloc_hook.h
@@ -36,11 +36,15 @@
 //  destructor to control the behavior of consume can lead to unexpected behavior,
 //  like this: if (LIKELY(doris::start_thread_mem_tracker)) {
 void new_hook(const void* ptr, size_t size) {
-    doris::tls_ctx()->consume_mem(tc_nallocx(size, 0));
+    if (doris::tls_ctx()) {
+        doris::tls_ctx()->consume_mem(tc_nallocx(size, 0));
+    }
 }
 
 void delete_hook(const void* ptr) {
-    doris::tls_ctx()->release_mem(tc_malloc_size(const_cast<void*>(ptr)));
+    if (doris::tls_ctx()) {
+        doris::tls_ctx()->release_mem(tc_malloc_size(const_cast<void*>(ptr)));
+    }
 }
 
 void init_hook() {

--- a/be/src/runtime/thread_context.cpp
+++ b/be/src/runtime/thread_context.cpp
@@ -26,6 +26,7 @@ DEFINE_STATIC_THREAD_LOCAL(ThreadContext, ThreadContextPtr, thread_local_ctx);
 
 ThreadContextPtr::ThreadContextPtr() {
     INIT_STATIC_THREAD_LOCAL(ThreadContext, thread_local_ctx);
+    _init = true;
 }
 
 ThreadContext* ThreadContextPtr::get() {

--- a/be/src/runtime/thread_context.h
+++ b/be/src/runtime/thread_context.h
@@ -211,6 +211,7 @@ public:
     ThreadContext* get();
 
     bool _init = false;
+
 private:
     DECLARE_STATIC_THREAD_LOCAL(ThreadContext, thread_local_ctx);
 };

--- a/be/src/runtime/thread_context.h
+++ b/be/src/runtime/thread_context.h
@@ -210,6 +210,7 @@ public:
 
     ThreadContext* get();
 
+    bool _init = false;
 private:
     DECLARE_STATIC_THREAD_LOCAL(ThreadContext, thread_local_ctx);
 };
@@ -221,7 +222,12 @@ static ThreadContext* tls_ctx() {
     if (tls != nullptr) {
         return tls;
     } else {
-        return thread_local_ctx.get();
+        if (thread_local_ctx._init) {
+            return thread_local_ctx.get();
+        } else {
+            // TCMalloc hook is triggered during ThreadContext construction, which may lead to deadlock.
+            return nullptr;
+        }
     }
 }
 


### PR DESCRIPTION
# Proposed changes

Issue Number: close #10309

## Problem Summary:

TCMalloc hook is triggered during ThreadContext construction, which may lead to deadlock.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
