### PR TITLE
[Bug] Case clause is not supported for column in grouping set

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/planner/RepeatNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/RepeatNode.java
@@ -19,7 +19,6 @@ package org.apache.doris.planner;
 
 import org.apache.doris.analysis.Analyzer;
 import org.apache.doris.analysis.Expr;
-import org.apache.doris.analysis.FunctionCallExpr;
 import org.apache.doris.analysis.GroupByClause;
 import org.apache.doris.analysis.GroupingFunctionCallExpr;
 import org.apache.doris.analysis.GroupingInfo;
@@ -161,7 +160,7 @@ public class RepeatNode extends PlanNode {
                             slotIdSet.add(slotId);
                             break;
                         }
-                    } else if (exprList.get(i) instanceof FunctionCallExpr) {
+                    } else {
                         List<SlotRef> slotRefs = getSlotRefChildren(exprList.get(i));
                         for (SlotRef slotRef : slotRefs) {
                             if (bitSet.get(i) && slotRef.getSlotId() == slotId) {

--- a/fe/fe-core/src/test/java/org/apache/doris/planner/QueryPlanTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/planner/QueryPlanTest.java
@@ -417,9 +417,11 @@ public class QueryPlanTest extends TestWithFeService {
     }
 
     @Test
-    public void testFunctionViewGroupingSet() throws Exception {
+    public void testGroupingSet() throws Exception {
         String queryStr = "select query_id, client_ip, concat from test.function_view group by rollup(query_id, client_ip, concat);";
         assertSQLPlanOrErrorMsgContains(queryStr, "repeat: repeat 3 lines [[], [0], [0, 1], [0, 1, 2, 3]]");
+        queryStr = "select query_id, client_ip, case when user='doris' then 'a' else 'b' end as u from test.test1 group by rollup(query_id, client_ip, u);";
+        assertSQLPlanOrErrorMsgContains(queryStr, "repeat: repeat 3 lines [[], [0], [0, 1], [0, 1, 2]]");
     }
 
     @Test


### PR DESCRIPTION
# Proposed changes

Support 'case when' expression in group set clause.

## Problem Summary:

If there is 'case when' expression in column of group set, the plan of query is not right. Because the RepeatNode can't recognize the expr.

For example, input a SQL like
`SELECT month, case when brand_code='1005' then 'mi' else 'others' end as code, brand_name, sum(sales_num), index_type from ads_market_cmp_m GROUP BY ROLLUP( brand_name, month, index_type, code);`
the query plan is:
` 1:REPEAT_NODE
   repeat: repeat 4 lines [[], [2], [0, 2], [0, 2, 4], [0, 2, 4]] `
but not
` 1:REPEAT_NODE                                                                                                                               |
  repeat: repeat 4 lines [[], [2], [0, 2], [0, 2, 4], [0, 1, 2, 4]]`

## Checklist(Required)

1. Does it affect the original behavior: (No)
2. Has unit tests been added: (No)
3. Has document been added or modified: (No Need)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (No)


