### PR TITLE
[Feature][Function] support group_concat_ordered

### DIFF
--- a/be/src/vec/aggregate_functions/aggregate_function_group_concat.cpp
+++ b/be/src/vec/aggregate_functions/aggregate_function_group_concat.cpp
@@ -19,20 +19,17 @@
 
 namespace doris::vectorized {
 
-const std::string AggregateFunctionGroupConcatImplStr::separator = ", ";
-
+template <typename Data>
 AggregateFunctionPtr create_aggregate_function_group_concat(const std::string& name,
                                                             const DataTypes& argument_types,
                                                             const Array& parameters,
                                                             const bool result_is_nullable) {
     if (argument_types.size() == 1) {
         return AggregateFunctionPtr(
-                new AggregateFunctionGroupConcat<AggregateFunctionGroupConcatImplStr>(
-                        argument_types));
+                new AggregateFunctionGroupConcat<Data, GroupConcatImplStr>(argument_types));
     } else if (argument_types.size() == 2) {
         return AggregateFunctionPtr(
-                new AggregateFunctionGroupConcat<AggregateFunctionGroupConcatImplStrStr>(
-                        argument_types));
+                new AggregateFunctionGroupConcat<Data, GroupConcatImplStrStr>(argument_types));
     }
 
     LOG(WARNING) << fmt::format("Illegal number {} of argument for aggregate function {}",
@@ -41,6 +38,9 @@ AggregateFunctionPtr create_aggregate_function_group_concat(const std::string& n
 }
 
 void register_aggregate_function_group_concat(AggregateFunctionSimpleFactory& factory) {
-    factory.register_function("group_concat", create_aggregate_function_group_concat);
+    factory.register_function("group_concat",
+                              create_aggregate_function_group_concat<GroupConcatData<false>>);
+    factory.register_function("group_concat_ordered",
+                              create_aggregate_function_group_concat<GroupConcatData<true>>);
 }
 } // namespace doris::vectorized

--- a/docs/en/docs/sql-manual/sql-functions/aggregate-functions/group_concat.md
+++ b/docs/en/docs/sql-manual/sql-functions/aggregate-functions/group_concat.md
@@ -29,9 +29,9 @@ under the License.
 #### Syntax
 
 `VARCHAR GROUP_CONCAT([DISTINCT] VARCHAR str[, VARCHAR sep])`
+`VARCHAR GROUP_CONCAT_ORDERED([DISTINCT] VARCHAR str[, VARCHAR sep])`
 
-
-This function is an aggregation function similar to sum (), and group_concat links multiple rows of results in the result set to a string. The second parameter, sep, is a connection symbol between strings, which can be omitted. This function usually needs to be used with group by statements.
+This function is an aggregation function similar to sum (), and group_concat links multiple rows of results in the result set to a string. The second parameter, sep, is a connection symbol between strings, which can be omitted. This function usually needs to be used with group by statements. Unlike group_concat, group_concat_ordered sorts strings lexicographically before concatenating them.
 
 ### example
 
@@ -40,8 +40,8 @@ mysql> select value from test;
 +-------+
 | value |
 +-------+
-| a     |
 | b     |
+| a     |
 | c     |
 | c     |
 +-------+
@@ -50,21 +50,28 @@ mysql> select GROUP_CONCAT(value) from test;
 +-----------------------+
 | GROUP_CONCAT(`value`) |
 +-----------------------+
-| a, b, c, c              |
+| b, a, c, c            |
++-----------------------+
+
+mysql> select GROUP_CONCAT_ORDERED(value) from test;
++-----------------------+
+| GROUP_CONCAT(`value`) |
++-----------------------+
+| a, b, c, c            |
 +-----------------------+
 
 mysql> select GROUP_CONCAT(value, " ") from test;
 +----------------------------+
 | GROUP_CONCAT(`value`, ' ') |
 +----------------------------+
-| a b c c                     |
+| b a c c                    |
 +----------------------------+
 
 mysql> select GROUP_CONCAT(DISTINCT value) from test;
 +-----------------------+
 | GROUP_CONCAT(`value`) |
 +-----------------------+
-| a, b, c               |
+| b, a, c               |
 +-----------------------+
 
 mysql> select GROUP_CONCAT(value, NULL) from test;

--- a/docs/zh-CN/docs/sql-manual/sql-functions/aggregate-functions/group_concat.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/aggregate-functions/group_concat.md
@@ -29,9 +29,9 @@ under the License.
 #### Syntax
 
 `VARCHAR GROUP_CONCAT([DISTINCT] VARCHAR str[, VARCHAR sep])`
+`VARCHAR GROUP_CONCAT_ORDERED([DISTINCT] VARCHAR str[, VARCHAR sep])`
 
-
-该函数是类似于 sum() 的聚合函数，group_concat 将结果集中的多行结果连接成一个字符串。第二个参数 sep 为字符串之间的连接符号，该参数可以省略。该函数通常需要和 group by 语句一起使用。
+该函数是类似于 sum() 的聚合函数，group_concat 将结果集中的多行结果连接成一个字符串。第二个参数 sep 为字符串之间的连接符号，该参数可以省略。该函数通常需要和 group by 语句一起使用。不同于group_concat，group_concat_ordered会在连接字符串前将它们按字典序排序。
 
 ### example
 
@@ -40,8 +40,8 @@ mysql> select value from test;
 +-------+
 | value |
 +-------+
-| a     |
 | b     |
+| a     |
 | c     |
 | c     |
 +-------+
@@ -50,22 +50,29 @@ mysql> select GROUP_CONCAT(value) from test;
 +-----------------------+
 | GROUP_CONCAT(`value`) |
 +-----------------------+
-| a, b, c, c               |
+| b, a, c, c            |
 +-----------------------+
 
-mysql> select GROUP_CONCAT(DISTINCT value) from test;
+mysql> select GROUP_CONCAT_ORDERED(value) from test;
 +-----------------------+
 | GROUP_CONCAT(`value`) |
 +-----------------------+
-| a, b, c               |
+| a, b, c, c            |
 +-----------------------+
 
 mysql> select GROUP_CONCAT(value, " ") from test;
 +----------------------------+
 | GROUP_CONCAT(`value`, ' ') |
 +----------------------------+
-| a b c c                    |
+| b a c c                    |
 +----------------------------+
+
+mysql> select GROUP_CONCAT(DISTINCT value) from test;
++-----------------------+
+| GROUP_CONCAT(`value`) |
++-----------------------+
+| b, a, c               |
++-----------------------+
 
 mysql> select GROUP_CONCAT(value, NULL) from test;
 +----------------------------+

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/FunctionCallExpr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/FunctionCallExpr.java
@@ -476,10 +476,10 @@ public class FunctionCallExpr extends Expr {
             return;
         }
 
-        if (fnName.getFunction().equalsIgnoreCase("group_concat")) {
+        if (fnName.getFunction().equalsIgnoreCase("group_concat")
+                || fnName.getFunction().equalsIgnoreCase("group_concat_ordered")) {
             if (children.size() > 2 || children.isEmpty()) {
-                throw new AnalysisException(
-                        "group_concat requires one or two parameters: " + this.toSql());
+                throw new AnalysisException("group_concat requires one or two parameters: " + this.toSql());
             }
 
             Expr arg0 = getChild(0);

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/FunctionSet.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/FunctionSet.java
@@ -2346,6 +2346,24 @@ public class FunctionSet<T> {
                         prefix + "22string_concat_finalizeEPN9doris_udf15FunctionContextERKNS1_9StringValE", false,
                         true, false, true));
 
+        // Group_concat_ordered(string) vectorized
+        addBuiltin(AggregateFunction.createBuiltin("group_concat_ordered", Lists.<Type>newArrayList(Type.VARCHAR),
+                        Type.VARCHAR, Type.VARCHAR, initNullString,
+                        prefix + "20string_concat_updateEPN9doris_udf15FunctionContextERKNS1_9StringValEPS4_",
+                        prefix + "19string_concat_mergeEPN9doris_udf15FunctionContextERKNS1_9StringValEPS4_",
+                        stringValSerializeOrFinalize,
+                        prefix + "22string_concat_finalizeEPN9doris_udf15FunctionContextERKNS1_9StringValE", false,
+                        true, false, true));
+        // Group_concat_ordered(string, string) vectorized
+        addBuiltin(AggregateFunction.createBuiltin("group_concat_ordered",
+                        Lists.<Type>newArrayList(Type.VARCHAR, Type.VARCHAR), Type.VARCHAR, Type.VARCHAR,
+                        initNullString,
+                        prefix + "20string_concat_updateEPN9doris_udf15FunctionContextERKNS1_9StringValES6_PS4_",
+                        prefix + "19string_concat_mergeEPN9doris_udf15FunctionContextERKNS1_9StringValEPS4_",
+                        stringValSerializeOrFinalize,
+                        prefix + "22string_concat_finalizeEPN9doris_udf15FunctionContextERKNS1_9StringValE", false,
+                        true, false, true));
+
         // analytic functions
         // Rank
         addBuiltin(AggregateFunction.createAnalyticBuiltin("rank",


### PR DESCRIPTION
# Proposed changes

related to #9744

this pr only support a new function `group_concat_ordered`, the next step we should support rewrite `group_concat(order by )` to `group_concat_ordered` @stalary 

todo: 
1. update document
2. add test
3. support non-vectorized (maybe not needed?)

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
4. Has unit tests been added: (Yes/No/No Need)
5. Has document been added or modified: (Yes/No/No Need)
6. Does it need to update dependencies: (Yes/No)
7. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
