### PR TITLE
[fix](multi-catalog) should load datasource before loading cluster

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Catalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Catalog.java
@@ -1878,15 +1878,13 @@ public class Catalog {
      * Load datasource through file.
      **/
     public long loadDatasource(DataInputStream in, long checksum) throws IOException {
-        if (Config.enable_multi_catalog) {
-            DataSourceMgr mgr = DataSourceMgr.read(in);
-            // When enable the multi catalog in the first time, the mgr will be a null value.
-            // So ignore it to use default datasource manager.
-            if (mgr != null) {
-                this.dataSourceMgr = mgr;
-            }
-            LOG.info("finished replay datasource from image");
+        DataSourceMgr mgr = DataSourceMgr.read(in);
+        // When enable the multi catalog in the first time, the mgr will be a null value.
+        // So ignore it to use default datasource manager.
+        if (mgr != null) {
+            this.dataSourceMgr = mgr;
         }
+        LOG.info("finished replay datasource from image");
         return checksum;
     }
 
@@ -2159,10 +2157,7 @@ public class Catalog {
      * Save datasource image.
      */
     public long saveDatasource(CountingDataOutputStream out, long checksum) throws IOException {
-        // Do not write datasource image when enable multi catalog is false.
-        if (Config.enable_multi_catalog) {
-            Catalog.getCurrentCatalog().getDataSourceMgr().write(out);
-        }
+        Catalog.getCurrentCatalog().getDataSourceMgr().write(out);
         return checksum;
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/meta/PersistMetaModules.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/meta/PersistMetaModules.java
@@ -34,11 +34,11 @@ public class PersistMetaModules {
     // The write and read of meta modules should be in same order.
     public static final List<MetaPersistMethod> MODULES_IN_ORDER;
 
-    public static final ImmutableList<String> MODULE_NAMES = ImmutableList.copyOf(
-            new String[] {"masterInfo", "frontends", "backends", "db", "loadJob", "alterJob", "recycleBin",
-                    "globalVariable", "cluster", "broker", "resources", "exportJob", "syncJob", "backupHandler",
-                    "paloAuth", "transactionState", "colocateTableIndex", "routineLoadJobs", "loadJobV2", "smallFiles",
-                    "plugins", "deleteHandler", "sqlBlockRule", "policy", "datasource"});
+    public static final ImmutableList<String> MODULE_NAMES = ImmutableList.of(
+            "masterInfo", "frontends", "backends", "datasource", "db", "loadJob", "alterJob", "recycleBin",
+            "globalVariable", "cluster", "broker", "resources", "exportJob", "syncJob", "backupHandler",
+            "paloAuth", "transactionState", "colocateTableIndex", "routineLoadJobs", "loadJobV2", "smallFiles",
+            "plugins", "deleteHandler", "sqlBlockRule", "policy");
 
     static {
         MODULES_MAP = Maps.newHashMap();


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

When enable_multi_catalog=true, if doris is restarted three times,
the command `show databases;` will throw an exeception:
```
No cluster selected
```

A temp DataSourceMgr is created when catalog intializes, and will be
updated in the loadCluster process. However, the loadDatasource process
will create a new DataSourceMgr with no cluster updated, and write such
DatasourceMgr to image. Finally, when the doris starts to recover, no
cluster is available.

## Checklist(Required)

1. Does it affect the original behavior: (No)
2. Has unit tests been added: (No)
3. Has document been added or modified: (No)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
