### PR TITLE
[multi-catalog] (information schema step 1) Add catalog name to information_schema getDbNames and SchemaSchemataScanner

### DIFF
--- a/be/src/exec/schema_scanner/schema_schemata_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_schemata_scanner.cpp
@@ -72,7 +72,14 @@ Status SchemaSchemataScanner::fill_one_row(Tuple* tuple, MemPool* pool) {
     memset((void*)tuple, 0, _tuple_desc->num_null_bytes());
 
     // catalog
-    { tuple->set_null(_tuple_desc->slots()[0]->null_indicator_offset()); }
+    {
+        void* slot = tuple->get_slot(_tuple_desc->slots()[0]->tuple_offset());
+        StringValue* str_slot = reinterpret_cast<StringValue*>(slot);
+        std::string catalog_name = _db_result.catalogs[_db_index];
+        str_slot->ptr = (char*)pool->allocate(catalog_name.size());
+        str_slot->len = catalog_name.size();
+        memcpy(str_slot->ptr, catalog_name.c_str(), str_slot->len);
+    }
     // schema
     {
         void* slot = tuple->get_slot(_tuple_desc->slots()[1]->tuple_offset());

--- a/be/src/exec/schema_scanner/schema_tables_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_tables_scanner.cpp
@@ -89,7 +89,14 @@ Status SchemaTablesScanner::fill_one_row(Tuple* tuple, MemPool* pool) {
     memset((void*)tuple, 0, _tuple_desc->num_null_bytes());
     const TTableStatus& tbl_status = _table_result.tables[_table_index];
     // catalog
-    { tuple->set_null(_tuple_desc->slots()[0]->null_indicator_offset()); }
+    {
+        void* slot = tuple->get_slot(_tuple_desc->slots()[0]->tuple_offset());
+        StringValue* str_slot = reinterpret_cast<StringValue*>(slot);
+        std::string catalog_name = _db_result.catalogs[_db_index - 1];
+        str_slot->ptr = (char*)pool->allocate(catalog_name.size());
+        str_slot->len = catalog_name.size();
+        memcpy(str_slot->ptr, catalog_name.c_str(), str_slot->len);
+    }
     // schema
     {
         void* slot = tuple->get_slot(_tuple_desc->slots()[1]->tuple_offset());
@@ -245,7 +252,9 @@ Status SchemaTablesScanner::fill_one_row(Tuple* tuple, MemPool* pool) {
 
 Status SchemaTablesScanner::get_new_table() {
     TGetTablesParams table_params;
-    table_params.__set_db(_db_result.dbs[_db_index++]);
+    table_params.__set_db(_db_result.dbs[_db_index]);
+    table_params.__set_catalog(_db_result.catalogs[_db_index]);
+    _db_index++;
     if (nullptr != _param->wild) {
         table_params.__set_pattern(*(_param->wild));
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/TableIf.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/TableIf.java
@@ -72,6 +72,22 @@ public interface TableIf {
 
     Column getColumn(String name);
 
+    String getMysqlType();
+
+    String getEngine();
+
+    String getComment();
+
+    long getCreateTime();
+
+    long getUpdateTime();
+
+    long getRowCount();
+
+    long getDataLength();
+
+    long getAvgRowLength();
+
     /**
      * Doris table type.
      */

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/external/ExternalTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/external/ExternalTable.java
@@ -200,4 +200,48 @@ public class ExternalTable implements TableIf {
     public Column getColumn(String name) {
         throw new NotImplementedException();
     }
+
+    @Override
+    public String getMysqlType() {
+        throw new NotImplementedException();
+    }
+
+    @Override
+    public String getEngine() {
+        throw new NotImplementedException();
+    }
+
+    @Override
+    public String getComment() {
+        throw new NotImplementedException();
+    }
+
+    @Override
+    public long getCreateTime() {
+        throw new NotImplementedException();
+    }
+
+    @Override
+    public long getUpdateTime() {
+        throw new NotImplementedException();
+    }
+
+    @Override
+    public long getRowCount() {
+        throw new NotImplementedException();
+    }
+
+    @Override
+    public long getDataLength() {
+        throw new NotImplementedException();
+    }
+
+    @Override
+    public long getAvgRowLength() {
+        throw new NotImplementedException();
+    }
+
+    public long getLastCheckTime() {
+        throw new NotImplementedException();
+    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/external/HMSExternalTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/external/HMSExternalTable.java
@@ -132,6 +132,59 @@ public class HMSExternalTable extends ExternalTable {
         return null;
     }
 
+    @Override
+    public String getMysqlType() {
+        return type.name();
+    }
+
+    @Override
+    public String getEngine() {
+        switch (type) {
+            case HIVE:
+                return "Hive";
+            case ICEBERG:
+                return "Iceberg";
+            case HUDI:
+                return "Hudi";
+            default:
+                return null;
+        }
+    }
+
+    @Override
+    public String getComment() {
+        return "";
+    }
+
+    @Override
+    public long getCreateTime() {
+        return 0;
+    }
+
+    @Override
+    public long getUpdateTime() {
+        return 0;
+    }
+
+    @Override
+    public long getRowCount() {
+        return 0;
+    }
+
+    @Override
+    public long getDataLength() {
+        return 0;
+    }
+
+    @Override
+    public long getAvgRowLength() {
+        return 0;
+    }
+
+    public long getLastCheckTime() {
+        return 0;
+    }
+
     /**
      * get database name of hms table.
      */

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/DataSourceMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/DataSourceMgr.java
@@ -43,6 +43,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.stream.Collectors;
 
 /**
  * DataSourceMgr will load all data sources at FE startup,
@@ -72,6 +73,10 @@ public class DataSourceMgr implements Writable {
 
     public InternalDataSource getInternalDataSource() {
         return internalDataSource;
+    }
+
+    public DataSourceIf getCatalog(String name) {
+        return nameToCatalogs.get(name);
     }
 
     private void writeLock() {
@@ -220,6 +225,10 @@ public class DataSourceMgr implements Writable {
         } finally {
             writeUnlock();
         }
+    }
+
+    public List<DataSourceIf> listCatalogs() {
+        return nameToCatalogs.values().stream().collect(Collectors.toList());
     }
 
     /**

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -287,9 +287,10 @@ struct TGetDbsParams {
   4: optional Types.TUserIdentity current_user_ident // to replace the user and user ip
 }
 
-// getDbNames returns a list of database names
+// getDbNames returns a list of database names and catalog names
 struct TGetDbsResult {
   1: list<string> dbs
+  2: list<string> catalogs
 }
 
 // Arguments to getTableNames, which returns a list of tables that match an 
@@ -304,6 +305,7 @@ struct TGetTablesParams {
   4: optional string user_ip    // deprecated
   5: optional Types.TUserIdentity current_user_ident // to replace the user and user ip
   6: optional string type
+  7: optional string catalog
 }
 
 struct TTableStatus {


### PR DESCRIPTION
# Proposed changes

Information schema database need to show catalog name after multi-catalog is supported. This part is step 1, add catalog name for schemata table.

## Problem Summary:

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
