### PR TITLE
[Vectorized][refactor] refactor some agg functions template about nul…

### DIFF
--- a/be/src/vec/aggregate_functions/aggregate_function_bitmap.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_bitmap.h
@@ -127,11 +127,11 @@ public:
     }
 };
 
-template <bool nullable, typename ColVecType>
+template <bool arg_is_nullable, typename ColVecType>
 class AggregateFunctionBitmapCount final
         : public IAggregateFunctionDataHelper<
                   AggregateFunctionBitmapData<AggregateFunctionBitmapUnionOp>,
-                  AggregateFunctionBitmapCount<nullable, ColVecType>> {
+                  AggregateFunctionBitmapCount<arg_is_nullable, ColVecType>> {
 public:
     // using ColVecType = ColumnBitmap;
     using ColVecResult = ColumnVector<Int64>;
@@ -140,14 +140,15 @@ public:
     AggregateFunctionBitmapCount(const DataTypes& argument_types_)
             : IAggregateFunctionDataHelper<
                       AggregateFunctionBitmapData<AggregateFunctionBitmapUnionOp>,
-                      AggregateFunctionBitmapCount<nullable, ColVecType>>(argument_types_, {}) {}
+                      AggregateFunctionBitmapCount<arg_is_nullable, ColVecType>>(argument_types_,
+                                                                                 {}) {}
 
     String get_name() const override { return "count"; }
     DataTypePtr get_return_type() const override { return std::make_shared<DataTypeInt64>(); }
 
     void add(AggregateDataPtr __restrict place, const IColumn** columns, size_t row_num,
              Arena*) const override {
-        if constexpr (nullable) {
+        if constexpr (arg_is_nullable) {
             auto& nullable_column = assert_cast<const ColumnNullable&>(*columns[0]);
             if (!nullable_column.is_null_at(row_num)) {
                 const auto& column =

--- a/be/src/vec/aggregate_functions/aggregate_function_hll_union_agg.cpp
+++ b/be/src/vec/aggregate_functions/aggregate_function_hll_union_agg.cpp
@@ -22,37 +22,44 @@
 
 namespace doris::vectorized {
 
-template <bool is_nullable>
 AggregateFunctionPtr create_aggregate_function_HLL_union_agg(const std::string& name,
                                                              const DataTypes& argument_types,
                                                              const Array& parameters,
                                                              const bool result_is_nullable) {
     assert_no_parameters(name, parameters);
     assert_arity_at_most<1>(name, argument_types);
-
-    return std::make_shared<AggregateFunctionHLLUnion<
-            AggregateFunctionHLLUnionAggImpl<AggregateFunctionHLLData<is_nullable>>>>(
-            argument_types);
+    const bool arg_is_nullable = argument_types[0]->is_nullable();
+    if (arg_is_nullable) {
+        return std::make_shared<AggregateFunctionHLLUnion<
+                AggregateFunctionHLLUnionAggImpl<AggregateFunctionHLLData<true>>>>(argument_types);
+    } else {
+        return std::make_shared<AggregateFunctionHLLUnion<
+                AggregateFunctionHLLUnionAggImpl<AggregateFunctionHLLData<false>>>>(argument_types);
+    }
 }
 
-template <bool is_nullable>
 AggregateFunctionPtr create_aggregate_function_HLL_union(const std::string& name,
                                                          const DataTypes& argument_types,
                                                          const Array& parameters,
                                                          const bool result_is_nullable) {
     assert_no_parameters(name, parameters);
     assert_arity_at_most<1>(name, argument_types);
-
-    return std::make_shared<AggregateFunctionHLLUnion<
-            AggregateFunctionHLLUnionImpl<AggregateFunctionHLLData<is_nullable>>>>(argument_types);
+    const bool arg_is_nullable = argument_types[0]->is_nullable();
+    if (arg_is_nullable) {
+        return std::make_shared<AggregateFunctionHLLUnion<
+                AggregateFunctionHLLUnionImpl<AggregateFunctionHLLData<true>>>>(argument_types);
+    } else {
+        return std::make_shared<AggregateFunctionHLLUnion<
+                AggregateFunctionHLLUnionImpl<AggregateFunctionHLLData<false>>>>(argument_types);
+    }
 }
 
 void register_aggregate_function_HLL_union_agg(AggregateFunctionSimpleFactory& factory) {
-    factory.register_function("hll_union_agg", create_aggregate_function_HLL_union_agg<false>);
-    factory.register_function("hll_union_agg", create_aggregate_function_HLL_union_agg<true>, true);
+    factory.register_function("hll_union_agg", create_aggregate_function_HLL_union_agg);
+    factory.register_function("hll_union_agg", create_aggregate_function_HLL_union_agg, true);
 
-    factory.register_function("hll_union", create_aggregate_function_HLL_union<false>);
-    factory.register_function("hll_union", create_aggregate_function_HLL_union<true>, true);
+    factory.register_function("hll_union", create_aggregate_function_HLL_union);
+    factory.register_function("hll_union", create_aggregate_function_HLL_union, true);
     factory.register_alias("hll_union", "hll_raw_agg");
 }
 

--- a/be/src/vec/aggregate_functions/aggregate_function_hll_union_agg.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_hll_union_agg.h
@@ -30,7 +30,7 @@
 
 namespace doris::vectorized {
 
-template <bool is_nullable>
+template <bool arg_is_nullable>
 struct AggregateFunctionHLLData {
     HyperLogLog dst_hll {};
 
@@ -56,7 +56,7 @@ struct AggregateFunctionHLLData {
     void reset() { dst_hll.clear(); }
 
     void add(const IColumn* column, size_t row_num) {
-        if constexpr (is_nullable) {
+        if constexpr (arg_is_nullable) {
             auto* nullable_column = check_and_get_column<const ColumnNullable>(*column);
             if (nullable_column->is_null_at(row_num)) {
                 return;
@@ -132,7 +132,6 @@ public:
     void reset(AggregateDataPtr __restrict place) const override { this->data(place).reset(); }
 };
 
-template <bool is_nullable = false>
 AggregateFunctionPtr create_aggregate_function_HLL_union(const std::string& name,
                                                          const DataTypes& argument_types,
                                                          const Array& parameters,

--- a/be/src/vec/aggregate_functions/aggregate_function_percentile_approx.cpp
+++ b/be/src/vec/aggregate_functions/aggregate_function_percentile_approx.cpp
@@ -24,19 +24,19 @@
 
 namespace doris::vectorized {
 
-template <bool is_nullable>
+template <bool arg_is_nullable>
 AggregateFunctionPtr create_aggregate_function_percentile_approx(const std::string& name,
                                                                  const DataTypes& argument_types,
                                                                  const Array& parameters,
                                                                  const bool result_is_nullable) {
     if (argument_types.size() == 1) {
-        return std::make_shared<AggregateFunctionPercentileApproxMerge<is_nullable>>(
+        return std::make_shared<AggregateFunctionPercentileApproxMerge<arg_is_nullable>>(
                 argument_types);
     } else if (argument_types.size() == 2) {
-        return std::make_shared<AggregateFunctionPercentileApproxTwoParams<is_nullable>>(
+        return std::make_shared<AggregateFunctionPercentileApproxTwoParams<arg_is_nullable>>(
                 argument_types);
     } else if (argument_types.size() == 3) {
-        return std::make_shared<AggregateFunctionPercentileApproxThreeParams<is_nullable>>(
+        return std::make_shared<AggregateFunctionPercentileApproxThreeParams<arg_is_nullable>>(
                 argument_types);
     }
     LOG(WARNING) << fmt::format("Illegal number {} of argument for aggregate function {}",

--- a/be/src/vec/aggregate_functions/aggregate_function_percentile_approx.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_percentile_approx.h
@@ -169,7 +169,7 @@ public:
 };
 
 // only for merge
-template <bool is_nullable>
+template <bool arg_is_nullable>
 class AggregateFunctionPercentileApproxMerge : public AggregateFunctionPercentileApprox {
 public:
     AggregateFunctionPercentileApproxMerge(const DataTypes& argument_types_)
@@ -180,14 +180,14 @@ public:
     }
 };
 
-template <bool is_nullable>
+template <bool arg_is_nullable>
 class AggregateFunctionPercentileApproxTwoParams : public AggregateFunctionPercentileApprox {
 public:
     AggregateFunctionPercentileApproxTwoParams(const DataTypes& argument_types_)
             : AggregateFunctionPercentileApprox(argument_types_) {}
     void add(AggregateDataPtr __restrict place, const IColumn** columns, size_t row_num,
              Arena*) const override {
-        if constexpr (is_nullable) {
+        if constexpr (arg_is_nullable) {
             double column_data[2] = {0, 0};
 
             for (int i = 0; i < 2; ++i) {
@@ -220,14 +220,14 @@ public:
     }
 };
 
-template <bool is_nullable>
+template <bool arg_is_nullable>
 class AggregateFunctionPercentileApproxThreeParams : public AggregateFunctionPercentileApprox {
 public:
     AggregateFunctionPercentileApproxThreeParams(const DataTypes& argument_types_)
             : AggregateFunctionPercentileApprox(argument_types_) {}
     void add(AggregateDataPtr __restrict place, const IColumn** columns, size_t row_num,
              Arena*) const override {
-        if constexpr (is_nullable) {
+        if constexpr (arg_is_nullable) {
             double column_data[3] = {0, 0, 0};
 
             for (int i = 0; i < 3; ++i) {

--- a/be/src/vec/aggregate_functions/aggregate_function_reader.cpp
+++ b/be/src/vec/aggregate_functions/aggregate_function_reader.cpp
@@ -31,7 +31,7 @@ void register_aggregate_function_reader_load(AggregateFunctionSimpleFactory& fac
     register_function("max", create_aggregate_function_max);
     register_function("min", create_aggregate_function_min);
     register_function("bitmap_union", create_aggregate_function_bitmap_union);
-    register_function("hll_union", create_aggregate_function_HLL_union<false>);
+    register_function("hll_union", create_aggregate_function_HLL_union);
 }
 
 // only replace funtion in load/reader do different agg operation.

--- a/be/src/vec/aggregate_functions/aggregate_function_stddev.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_stddev.h
@@ -241,14 +241,14 @@ struct SampData : Data {
     }
 };
 
-template <bool is_pop, typename Data, bool is_nullable>
+template <bool is_pop, typename Data, bool arg_is_nullable>
 class AggregateFunctionSampVariance
         : public IAggregateFunctionDataHelper<
-                  Data, AggregateFunctionSampVariance<is_pop, Data, is_nullable>> {
+                  Data, AggregateFunctionSampVariance<is_pop, Data, arg_is_nullable>> {
 public:
     AggregateFunctionSampVariance(const DataTypes& argument_types_)
             : IAggregateFunctionDataHelper<
-                      Data, AggregateFunctionSampVariance<is_pop, Data, is_nullable>>(
+                      Data, AggregateFunctionSampVariance<is_pop, Data, arg_is_nullable>>(
                       argument_types_, {}) {}
 
     String get_name() const override { return Data::name(); }
@@ -266,7 +266,7 @@ public:
         if constexpr (is_pop) {
             this->data(place).add(columns[0], row_num);
         } else {
-            if constexpr (is_nullable) {
+            if constexpr (arg_is_nullable) {
                 const auto* nullable_column = check_and_get_column<ColumnNullable>(columns[0]);
                 if (!nullable_column->is_null_at(row_num)) {
                     this->data(place).add(&nullable_column->get_nested_column(), row_num);
@@ -300,19 +300,19 @@ public:
 
 //samp function it's always nullables, it's need to handle nullable column
 //so return type and add function should processing null values
-template <typename Data, bool is_nullable>
-class AggregateFunctionSamp final : public AggregateFunctionSampVariance<false, Data, is_nullable> {
+template <typename Data, bool arg_is_nullable>
+class AggregateFunctionSamp final : public AggregateFunctionSampVariance<false, Data, arg_is_nullable> {
 public:
     AggregateFunctionSamp(const DataTypes& argument_types_)
-            : AggregateFunctionSampVariance<false, Data, is_nullable>(argument_types_) {}
+            : AggregateFunctionSampVariance<false, Data, arg_is_nullable>(argument_types_) {}
 };
 
 //pop function have use AggregateFunctionNullBase function, so needn't processing null values
-template <typename Data, bool is_nullable>
-class AggregateFunctionPop final : public AggregateFunctionSampVariance<true, Data, is_nullable> {
+template <typename Data, bool arg_is_nullable>
+class AggregateFunctionPop final : public AggregateFunctionSampVariance<true, Data, arg_is_nullable> {
 public:
     AggregateFunctionPop(const DataTypes& argument_types_)
-            : AggregateFunctionSampVariance<true, Data, is_nullable>(argument_types_) {}
+            : AggregateFunctionSampVariance<true, Data, arg_is_nullable>(argument_types_) {}
 };
 
 } // namespace doris::vectorized

--- a/be/src/vec/aggregate_functions/aggregate_function_stddev.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_stddev.h
@@ -301,7 +301,8 @@ public:
 //samp function it's always nullables, it's need to handle nullable column
 //so return type and add function should processing null values
 template <typename Data, bool arg_is_nullable>
-class AggregateFunctionSamp final : public AggregateFunctionSampVariance<false, Data, arg_is_nullable> {
+class AggregateFunctionSamp final
+        : public AggregateFunctionSampVariance<false, Data, arg_is_nullable> {
 public:
     AggregateFunctionSamp(const DataTypes& argument_types_)
             : AggregateFunctionSampVariance<false, Data, arg_is_nullable>(argument_types_) {}
@@ -309,7 +310,8 @@ public:
 
 //pop function have use AggregateFunctionNullBase function, so needn't processing null values
 template <typename Data, bool arg_is_nullable>
-class AggregateFunctionPop final : public AggregateFunctionSampVariance<true, Data, arg_is_nullable> {
+class AggregateFunctionPop final
+        : public AggregateFunctionSampVariance<true, Data, arg_is_nullable> {
 public:
     AggregateFunctionPop(const DataTypes& argument_types_)
             : AggregateFunctionSampVariance<true, Data, arg_is_nullable>(argument_types_) {}


### PR DESCRIPTION
In vectorized agg functions register, there is a variables about return type is nullable,
so we always use it to indicate the input column type whether is nullable or not,
now in this PR, it's will be separated, use template of arg_is_null and result_is_null

window fucntions macor

# Proposed changes

Issue Number: close #xxx

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
