### PR TITLE
[improvement]Support vectorized predicates for dict columns

### DIFF
--- a/be/src/olap/rowset/segment_v2/segment_iterator.h
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.h
@@ -119,6 +119,8 @@ private:
         return Status::OK();
     }
 
+    bool _can_evaluated_by_vectorized(ColumnPredicate* predicate);
+
 private:
     class BitmapRangeIterator;
 


### PR DESCRIPTION
# Proposed changes

Issue Number: close #10369

## Problem Summary:

String (char/varchar/string) columns with dict encoding can be used as int in EQ/NE/LE/LT/GE/GE predicates.

Test with SSB flat 100G, q2.3:
```sql
SELECT
    SUM(LO_REVENUE), (LO_ORDERDATE DIV 10000) AS YEAR,
    P_BRAND
FROM lineorder_flat
WHERE
    P_BRAND = 'MFGR#2239'
    AND S_REGION = 'EUROPE'
GROUP BY YEAR, P_BRAND
ORDER BY YEAR, P_BRAND;
```
||master|dict_vec_opt|
|-|-|-|
|time|2.03 sec|1.65 sec|
|profile|<img width="540" alt="image" src="https://user-images.githubusercontent.com/1179834/175255057-2284ffb1-a8ae-41c9-9093-c88b82d28916.png">|<img width="518" alt="image" src="https://user-images.githubusercontent.com/1179834/175255286-c9e6c71a-4bb2-4a46-84d4-55939b08e073.png">|

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
