### PR TITLE
[Enhancement] support different python version in build-support scripts

### DIFF
--- a/build-support/check-format.sh
+++ b/build-support/check-format.sh
@@ -30,5 +30,4 @@ export DORIS_HOME=`cd "${ROOT}/.."; pwd`
 
 CLANG_FORMAT=${CLANG_FORMAT_BINARY:=$(which clang-format)}
 
-python3 ${DORIS_HOME}/build-support/run_clang_format.py "--clang-format-executable" "${CLANG_FORMAT}" "-r" "--style" "file" "--inplace" "false" "--extensions" "c,h,C,H,cpp,hpp,cc,hh,c++,h++,cxx,hxx" "--exclude" "none" "be/src be/test"
-
+python ${DORIS_HOME}/build-support/run_clang_format.py "--clang-format-executable" "${CLANG_FORMAT}" "-r" "--style" "file" "--inplace" "false" "--extensions" "c,h,C,H,cpp,hpp,cc,hh,c++,h++,cxx,hxx" "--exclude" "none" "be/src be/test"

--- a/build-support/clang-format.sh
+++ b/build-support/clang-format.sh
@@ -30,6 +30,4 @@ export DORIS_HOME=`cd "${ROOT}/.."; pwd`
 
 CLANG_FORMAT=${CLANG_FORMAT_BINARY:=$(which clang-format)}
 
-python3 ${DORIS_HOME}/build-support/run_clang_format.py "--clang-format-executable" "${CLANG_FORMAT}" "-r" "--style" "file" "--inplace" "true" "--extensions" "c,h,C,H,cpp,hpp,cc,hh,c++,h++,cxx,hxx" "--exclude" "none" "be/src be/test"
-
-
+python ${DORIS_HOME}/build-support/run_clang_format.py "--clang-format-executable" "${CLANG_FORMAT}" "-r" "--style" "file" "--inplace" "true" "--extensions" "c,h,C,H,cpp,hpp,cc,hh,c++,h++,cxx,hxx" "--exclude" "none" "be/src be/test"


### PR DESCRIPTION
# Proposed changes
1. support different python version in build-support scripts which is more convenient for us.
Issue Number: close #xxx

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (No)
2. Has unit tests been added: (No Need)
3. Has document been added or modified: (No)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
