### PR TITLE
[feature-wip](multi-catalog) support to switch catalog

### DIFF
--- a/fe/fe-core/src/main/cup/sql_parser.cup
+++ b/fe/fe-core/src/main/cup/sql_parser.cup
@@ -278,7 +278,8 @@ terminal String KW_ADD, KW_ADMIN, KW_AFTER, KW_AGGREGATE, KW_ALIAS, KW_ALL, KW_A
     KW_WARNINGS, KW_WEEK, KW_WHEN, KW_WHITELIST, KW_WHERE, KW_WITH, KW_WORK, KW_WRITE,
     KW_YEAR,
     KW_NOT_NULL,
-    KW_CATALOG, KW_CATALOGS;
+    KW_CATALOG, KW_CATALOGS,
+    KW_SWITCH;
 
 terminal COMMA, COLON, DOT, DOTDOTDOT, AT, STAR, LPAREN, RPAREN, SEMICOLON, LBRACKET, RBRACKET, DIVIDE, MOD, ADD, SUBTRACT;
 terminal BITAND, BITOR, BITXOR, BITNOT;
@@ -301,7 +302,7 @@ nonterminal StatementBase stmt, show_stmt, show_param, help_stmt, load_stmt,
     show_routine_load_stmt, show_routine_load_task_stmt, show_create_routine_load_stmt,
     describe_stmt, alter_stmt,
     use_stmt, kill_stmt, drop_stmt, recover_stmt, grant_stmt, revoke_stmt, create_stmt, set_stmt, sync_stmt, cancel_stmt, cancel_param, delete_stmt,
-    link_stmt, migrate_stmt, enter_stmt, transaction_stmt, unsupported_stmt, export_stmt, admin_stmt, truncate_stmt,
+    link_stmt, migrate_stmt, switch_stmt, enter_stmt, transaction_stmt, unsupported_stmt, export_stmt, admin_stmt, truncate_stmt,
     import_columns_stmt, import_delete_on_stmt, import_sequence_stmt, import_where_stmt, install_plugin_stmt, uninstall_plugin_stmt,
     import_preceding_filter_stmt, unlock_tables_stmt, lock_tables_stmt, refresh_stmt;
 
@@ -670,6 +671,8 @@ stmt ::=
     {: RESULT = query; :}
     | migrate_stmt:query
     {: RESULT = query; :}
+    | switch_stmt:stmt
+    {: RESULT = stmt; :}
     | enter_stmt:enter
     {: RESULT = enter; :}
     | query_stmt:query
@@ -3421,6 +3424,14 @@ opt_set_qualifier ::=
   | KW_ALL
   {: RESULT = Qualifier.ALL; :}
   ;
+
+// Change catalog
+switch_stmt ::=
+    KW_SWITCH ident:catalog
+    {:
+        RESULT = new SwitchStmt(catalog);
+    :}
+    ;
 
 // Change cluster
 enter_stmt ::=

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/GrantStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/GrantStmt.java
@@ -168,15 +168,21 @@ public class GrantStmt extends DdlStmt {
                 if (!Catalog.getCurrentCatalog().getAuth().checkGlobalPriv(ConnectContext.get(), PrivPredicate.GRANT)) {
                     ErrorReport.reportAnalysisException(ErrorCode.ERR_SPECIFIC_ACCESS_DENIED_ERROR, "GRANT");
                 }
+            } else if (tblPattern.getPrivLevel() == PrivLevel.CATALOG) {
+                if (!Catalog.getCurrentCatalog().getAuth().checkCtlPriv(ConnectContext.get(),
+                        tblPattern.getQualifiedCtl(), PrivPredicate.GRANT)) {
+                    ErrorReport.reportAnalysisException(ErrorCode.ERR_SPECIFIC_ACCESS_DENIED_ERROR, "GRANT");
+                }
             } else if (tblPattern.getPrivLevel() == PrivLevel.DATABASE) {
                 if (!Catalog.getCurrentCatalog().getAuth().checkDbPriv(ConnectContext.get(),
-                        tblPattern.getQualifiedDb(), PrivPredicate.GRANT)) {
+                        tblPattern.getQualifiedCtl(), tblPattern.getQualifiedDb(), PrivPredicate.GRANT)) {
                     ErrorReport.reportAnalysisException(ErrorCode.ERR_SPECIFIC_ACCESS_DENIED_ERROR, "GRANT");
                 }
             } else {
                 // table level
                 if (!Catalog.getCurrentCatalog().getAuth().checkTblPriv(ConnectContext.get(),
-                        tblPattern.getQualifiedDb(), tblPattern.getTbl(), PrivPredicate.GRANT)) {
+                        tblPattern.getQualifiedCtl(), tblPattern.getQualifiedDb(),
+                        tblPattern.getTbl(), PrivPredicate.GRANT)) {
                     ErrorReport.reportAnalysisException(ErrorCode.ERR_SPECIFIC_ACCESS_DENIED_ERROR, "GRANT");
                 }
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Catalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Catalog.java
@@ -4218,6 +4218,15 @@ public class Catalog {
         this.alter.getClusterHandler().cancel(stmt);
     }
 
+    // Switch catalog of this sesseion.
+    public void changeCatalog(ConnectContext ctx, String catalogName) throws DdlException {
+        if (dataSourceMgr.getCatalogNullable(catalogName) == null) {
+            throw new DdlException(ErrorCode.ERR_UNKNOWN_CATALOG.formatErrorMsg(
+                    catalogName), ErrorCode.ERR_UNKNOWN_CATALOG);
+        }
+        ctx.changeDefaultCatalog(catalogName);
+    }
+
     // Change current database of this session.
     public void changeDb(ConnectContext ctx, String qualifiedDb) throws DdlException {
         if (!auth.checkDbPriv(ctx, qualifiedDb, PrivPredicate.SHOW)) {

--- a/fe/fe-core/src/main/java/org/apache/doris/common/ErrorCode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/ErrorCode.java
@@ -1686,7 +1686,10 @@ public enum ErrorCode {
                     + "Use `SHOW PARTITIONS FROM %s` to see the currently partitions of this table. "),
     ERROR_SQL_AND_LIMITATIONS_SET_IN_ONE_RULE(5084, new byte[]{'4', '2', '0', '0', '0'},
             "sql/sqlHash and partition_num/tablet_num/cardinality cannot be set in one rule."),
-    ERR_WRONG_CATALOG_NAME(5085, new byte[]{'4', '2', '0', '0', '0'}, "Incorrect catalog name '%s'");
+    ERR_WRONG_CATALOG_NAME(5085, new byte[]{'4', '2', '0', '0', '0'}, "Incorrect catalog name '%s'"),
+    ERR_UNKNOWN_CATALOG(5086, new byte[]{'4', '2', '0', '0', '0'}, "Unknown catalog '%s'"),
+    ERR_CATALOG_ACCESS_DENIED(5087, new byte[]{'4', '2', '0', '0', '0'},
+            "Access denied for user '%s' to catalog '%s'");
 
     // This is error code
     private final int code;

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/Util.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/Util.java
@@ -20,6 +20,9 @@ package org.apache.doris.common.util;
 import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.PrimitiveType;
 import org.apache.doris.common.AnalysisException;
+import org.apache.doris.common.Config;
+import org.apache.doris.common.FeNameFormat;
+import org.apache.doris.datasource.InternalDataSource;
 import org.apache.doris.qe.ConnectContext;
 
 import com.google.common.base.Preconditions;
@@ -456,5 +459,30 @@ public class Util {
             return "\\" + s;
         }
         return s;
+    }
+
+    /**
+     * Multi-catalog feature is in experiment, and should be enabled by user manually.
+     */
+    public static void checkCatalogEnabled() throws AnalysisException {
+        if (!Config.enable_multi_catalog) {
+            throw new AnalysisException("The multi-catalog feature is still in experiment, and you can enable it "
+                    + "manually by set fe configuration named `enable_multi_catalog` to be ture.");
+        }
+    }
+
+    /**
+     * Check all rules of catalog.
+     */
+    public static void checkCatalogAllRules(String catalog) throws AnalysisException {
+        checkCatalogEnabled();
+
+        if (Strings.isNullOrEmpty(catalog)) {
+            throw new AnalysisException("Catalog name is empty.");
+        }
+
+        if (!catalog.equals(InternalDataSource.INTERNAL_DS_NAME)) {
+            FeNameFormat.checkCommonName("catalog", catalog);
+        }
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/DataSourceMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/DataSourceMgr.java
@@ -25,11 +25,15 @@ import org.apache.doris.analysis.ShowCatalogStmt;
 import org.apache.doris.catalog.Catalog;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.DdlException;
+import org.apache.doris.common.ErrorCode;
+import org.apache.doris.common.ErrorReport;
 import org.apache.doris.common.UserException;
 import org.apache.doris.common.io.Text;
 import org.apache.doris.common.io.Writable;
+import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.persist.OperationType;
 import org.apache.doris.persist.gson.GsonUtils;
+import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.ShowResultSet;
 
 import com.google.common.collect.Lists;
@@ -151,6 +155,13 @@ public class DataSourceMgr implements Writable {
     }
 
     /**
+     * Get catalog, or null if not exists.
+     */
+    public DataSourceIf getCatalogNullable(String catalogName) {
+        return nameToCatalogs.get(catalogName);
+    }
+
+    /**
      * List all catalog or get the special catalog with a name.
      */
     public ShowResultSet showCatalogs(ShowCatalogStmt showStmt) throws AnalysisException {
@@ -159,16 +170,24 @@ public class DataSourceMgr implements Writable {
         try {
             if (showStmt.getCatalogName() == null) {
                 for (DataSourceIf ds : nameToCatalogs.values()) {
-                    List<String> row = Lists.newArrayList();
-                    row.add(ds.getName());
-                    row.add(ds.getType());
-                    rows.add(row);
+                    if (Catalog.getCurrentCatalog().getAuth().checkCtlPriv(
+                            ConnectContext.get(), ds.getName(), PrivPredicate.SHOW)) {
+                        List<String> row = Lists.newArrayList();
+                        row.add(ds.getName());
+                        row.add(ds.getType());
+                        rows.add(row);
+                    }
                 }
             } else {
                 if (!nameToCatalogs.containsKey(showStmt.getCatalogName())) {
                     throw new AnalysisException("No catalog found with name: " + showStmt.getCatalogName());
                 }
                 DataSourceIf ds = nameToCatalogs.get(showStmt.getCatalogName());
+                if (!Catalog.getCurrentCatalog().getAuth().checkCtlPriv(
+                        ConnectContext.get(), ds.getName(), PrivPredicate.SHOW)) {
+                    ErrorReport.reportAnalysisException(ErrorCode.ERR_CATALOG_ACCESS_DENIED,
+                            ConnectContext.get().getQualifiedUser(), ds.getName());
+                }
                 for (Map.Entry<String, String>  elem : ds.getProperties().entrySet()) {
                     List<String> row = Lists.newArrayList();
                     row.add(elem.getKey());

--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/DbPrivTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/DbPrivTable.java
@@ -21,6 +21,7 @@ import org.apache.doris.analysis.UserIdentity;
 import org.apache.doris.common.io.Text;
 import org.apache.doris.qe.ConnectContext;
 
+import com.google.common.base.Preconditions;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -64,6 +65,23 @@ public class DbPrivTable extends PrivTable {
         }
 
         savedPrivs.or(matchedEntry.getPrivSet());
+    }
+
+    public boolean hasPrivsOfCatalog(UserIdentity currentUser, String ctl) {
+        for (PrivEntry entry : entries) {
+            DbPrivEntry dbPrivEntry = (DbPrivEntry) entry;
+
+            if (!dbPrivEntry.match(currentUser, true)) {
+                continue;
+            }
+
+            // check catalog
+            Preconditions.checkState(!dbPrivEntry.isAnyCtl());
+            if (dbPrivEntry.getCtlPattern().match(ctl)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     public boolean hasClusterPriv(ConnectContext ctx, String clusterName) {

--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/TablePrivTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/TablePrivTable.java
@@ -69,6 +69,23 @@ public class TablePrivTable extends PrivTable {
         savedPrivs.or(matchedEntry.getPrivSet());
     }
 
+    public boolean hasPrivsOfCatalog(UserIdentity currentUser, String ctl) {
+        for (PrivEntry entry : entries) {
+            TablePrivEntry tblPrivEntry = (TablePrivEntry) entry;
+
+            if (!tblPrivEntry.match(currentUser, true)) {
+                continue;
+            }
+
+            // check catalog
+            Preconditions.checkState(!tblPrivEntry.isAnyCtl());
+            if (tblPrivEntry.getCtlPattern().match(ctl)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     public boolean hasPrivsOfDb(UserIdentity currentUser, String ctl, String db) {
         for (PrivEntry entry : entries) {
             TablePrivEntry tblPrivEntry = (TablePrivEntry) entry;

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -44,6 +44,7 @@ import org.apache.doris.analysis.SqlScanner;
 import org.apache.doris.analysis.StatementBase;
 import org.apache.doris.analysis.StmtRewriter;
 import org.apache.doris.analysis.StringLiteral;
+import org.apache.doris.analysis.SwitchStmt;
 import org.apache.doris.analysis.TransactionBeginStmt;
 import org.apache.doris.analysis.TransactionCommitStmt;
 import org.apache.doris.analysis.TransactionRollbackStmt;
@@ -416,6 +417,8 @@ public class StmtExecutor implements ProfileWriter {
                 handleSetStmt();
             } else if (parsedStmt instanceof EnterStmt) {
                 handleEnterStmt();
+            } else if (parsedStmt instanceof SwitchStmt) {
+                handleSwitchStmt();
             } else if (parsedStmt instanceof UseStmt) {
                 handleUseStmt();
             } else if (parsedStmt instanceof TransactionStmt) {
@@ -1416,6 +1419,18 @@ public class StmtExecutor implements ProfileWriter {
     private void handleUnsupportedStmt() {
         context.getMysqlChannel().reset();
         // do nothing
+        context.getState().setOk();
+    }
+
+    // Process switch catalog
+    private void handleSwitchStmt() throws AnalysisException {
+        SwitchStmt switchStmt = (SwitchStmt) parsedStmt;
+        try {
+            context.getCatalog().changeCatalog(context, switchStmt.getCatalogName());
+        } catch (DdlException e) {
+            context.getState().setError(e.getMysqlErrorCode(), e.getMessage());
+            return;
+        }
         context.getState().setOk();
     }
 

--- a/fe/fe-core/src/main/jflex/sql_scanner.flex
+++ b/fe/fe-core/src/main/jflex/sql_scanner.flex
@@ -435,6 +435,7 @@ import org.apache.doris.qe.SqlModeHelper;
         keywordMap.put("not_null", new Integer(SqlParserSymbols.KW_NOT_NULL));
         keywordMap.put("catalog", new Integer(SqlParserSymbols.KW_CATALOG));
         keywordMap.put("catalogs", new Integer(SqlParserSymbols.KW_CATALOGS));
+        keywordMap.put("switch", new Integer(SqlParserSymbols.KW_SWITCH));
    }
     
   // map from token id to token description

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/AlterCatalogNameStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/AlterCatalogNameStmtTest.java
@@ -43,7 +43,7 @@ public class AlterCatalogNameStmtTest {
         Config.enable_multi_catalog = true;
         analyzer = AccessTestUtil.fetchAdminAnalyzer(false);
         MockedAuth.mockedAuth(auth);
-        MockedAuth.mockedConnectContext(ctx, "root", "127.0.0.1");
+        MockedAuth.mockedConnectContext(ctx, "root", "%");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/AlterCatalogPropsStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/AlterCatalogPropsStmtTest.java
@@ -46,7 +46,7 @@ public class AlterCatalogPropsStmtTest {
         Config.enable_multi_catalog = true;
         analyzer = AccessTestUtil.fetchAdminAnalyzer(false);
         MockedAuth.mockedAuth(auth);
-        MockedAuth.mockedConnectContext(ctx, "root", "127.0.0.1");
+        MockedAuth.mockedConnectContext(ctx, "root", "%");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/CreateCatalogStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/CreateCatalogStmtTest.java
@@ -47,7 +47,7 @@ public class CreateCatalogStmtTest {
         Config.enable_multi_catalog = true;
         analyzer = AccessTestUtil.fetchAdminAnalyzer(true);
         MockedAuth.mockedAuth(auth);
-        MockedAuth.mockedConnectContext(ctx, "root", "127.0.0.1");
+        MockedAuth.mockedConnectContext(ctx, "root", "%");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/DropCatalogStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/DropCatalogStmtTest.java
@@ -44,7 +44,7 @@ public class DropCatalogStmtTest {
         Config.enable_multi_catalog = true;
         analyzer = AccessTestUtil.fetchAdminAnalyzer(true);
         MockedAuth.mockedAuth(auth);
-        MockedAuth.mockedConnectContext(ctx, "root", "127.0.0.1");
+        MockedAuth.mockedConnectContext(ctx, "root", "%");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/SwitchStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/SwitchStmtTest.java
@@ -1,0 +1,161 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.analysis;
+
+import org.apache.doris.catalog.Catalog;
+import org.apache.doris.common.AnalysisException;
+import org.apache.doris.common.Config;
+import org.apache.doris.datasource.InternalDataSource;
+import org.apache.doris.mysql.privilege.PaloAuth;
+import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.utframe.DorisAssert;
+import org.apache.doris.utframe.UtFrameUtils;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.UUID;
+
+public class SwitchStmtTest {
+    private static String runningDir = "fe/mocked/DemoTest/" + UUID.randomUUID().toString() + "/";
+    private static DorisAssert dorisAssert;
+    private static String clusterName = "default_cluster";
+
+    private static PaloAuth auth;
+    private static Catalog catalog;
+    private static UserIdentity user1;
+    private static UserIdentity user2;
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        UtFrameUtils.cleanDorisFeDir(runningDir);
+    }
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        Config.enable_multi_catalog = true;
+        UtFrameUtils.createDorisCluster(runningDir);
+
+        // use root to initialize.
+        ConnectContext rootCtx = UtFrameUtils.createDefaultCtx();
+        catalog = Catalog.getCurrentCatalog();
+        auth = catalog.getAuth();
+
+        // grant with no catalog is switched, internal catalog works.
+        CreateRoleStmt createRole1 = (CreateRoleStmt) UtFrameUtils.parseAndAnalyzeStmt("create role role1;", rootCtx);
+        auth.createRole(createRole1);
+        GrantStmt grantRole1 = (GrantStmt) UtFrameUtils.parseAndAnalyzeStmt(
+                "grant grant_priv on tpch.* to role 'role1';", rootCtx);
+        auth.grant(grantRole1);
+        // user1 can't switch to hive
+        auth.createUser((CreateUserStmt) UtFrameUtils.parseAndAnalyzeStmt(
+                "create user 'user1'@'%' identified by 'pwd1' default role 'role1';", rootCtx));
+        user1 = new UserIdentity("user1", "%");
+        user1.analyze(clusterName);
+
+        // create catalog
+        CreateCatalogStmt hiveCatalog = (CreateCatalogStmt) UtFrameUtils.parseAndAnalyzeStmt(
+                "create catalog hive properties('type' = 'hms', 'hive.metastore.uris' = 'thrift://192.168.0.1:9083');",
+                rootCtx);
+        catalog.getDataSourceMgr().createCatalog(hiveCatalog);
+        CreateCatalogStmt iceBergCatalog = (CreateCatalogStmt) UtFrameUtils.parseAndAnalyzeStmt(
+                "create catalog iceberg properties('type' = 'hms', 'iceberg.hive.metastore.uris' = 'thrift://192.168.0.1:9083');",
+                rootCtx);
+        catalog.getDataSourceMgr().createCatalog(iceBergCatalog);
+
+        // switch to hive.
+        SwitchStmt switchHive = (SwitchStmt) UtFrameUtils.parseAndAnalyzeStmt("switch hive;", rootCtx);
+        catalog.changeCatalog(rootCtx, switchHive.getCatalogName());
+        CreateRoleStmt createRole2 = (CreateRoleStmt) UtFrameUtils.parseAndAnalyzeStmt("create role role2;", rootCtx);
+        auth.createRole(createRole2);
+        GrantStmt grantRole2 = (GrantStmt) UtFrameUtils.parseAndAnalyzeStmt(
+                "grant grant_priv on tpch.customer to role 'role2';", rootCtx);
+        auth.grant(grantRole2);
+        auth.createUser((CreateUserStmt) UtFrameUtils.parseAndAnalyzeStmt(
+                "create user 'user2'@'%' identified by 'pwd2' default role 'role2';", rootCtx));
+        user2 = new UserIdentity("user2", "%");
+        user2.analyze(clusterName);
+    }
+
+    @Test
+    public void testSwitchCommand() throws Exception {
+        // mock the login of user1
+        ConnectContext user1Ctx = UtFrameUtils.createDefaultCtx(user1, "127.0.0.1");
+        // user1 can switch to internal catalog
+        UtFrameUtils.parseAndAnalyzeStmt("switch " + InternalDataSource.INTERNAL_DS_NAME + ";", user1Ctx);
+        Assert.assertEquals(InternalDataSource.INTERNAL_DS_NAME, user1Ctx.getDefaultCatalog());
+        // user1 can't switch to hive
+        try {
+            UtFrameUtils.parseAndAnalyzeStmt("switch hive;", user1Ctx);
+            Assert.fail("user1 switch to hive with no privilege.");
+        } catch (AnalysisException e) {
+            Assert.assertEquals(e.getMessage(),
+                    "errCode = 2, detailMessage = Access denied for user 'default_cluster:user1' to catalog 'hive'");
+        }
+        Assert.assertEquals(InternalDataSource.INTERNAL_DS_NAME, user1Ctx.getDefaultCatalog());
+
+        // mock the login of user2
+        ConnectContext user2Ctx = UtFrameUtils.createDefaultCtx(user2, "127.0.0.1");
+        // user2 can switch to internal catalog
+        UtFrameUtils.parseAndAnalyzeStmt("switch " + InternalDataSource.INTERNAL_DS_NAME + ";", user2Ctx);
+        Assert.assertEquals(InternalDataSource.INTERNAL_DS_NAME, user2Ctx.getDefaultCatalog());
+        // user2 can switch to hive
+        SwitchStmt switchHive = (SwitchStmt) UtFrameUtils.parseAndAnalyzeStmt("switch hive;", user2Ctx);
+        catalog.changeCatalog(user2Ctx, switchHive.getCatalogName());
+        Assert.assertEquals(user2Ctx.getDefaultCatalog(), "hive");
+        // user2 can grant select_priv to tpch.customer
+        GrantStmt user2GrantHiveTable = (GrantStmt) UtFrameUtils.parseAndAnalyzeStmt(
+                "grant select_priv on tpch.customer to 'user2'@'%';", user2Ctx);
+        auth.grant(user2GrantHiveTable);
+    }
+
+    @Test
+    public void testShowCatalogStmtWithPrivileges() throws Exception {
+        // mock the login of user1
+        ConnectContext user1Ctx = UtFrameUtils.createDefaultCtx(user1, "127.0.0.1");
+        ShowCatalogStmt user1Show = (ShowCatalogStmt) UtFrameUtils.parseAndAnalyzeStmt("show catalogs;", user1Ctx);
+        List<List<String>> user1ShowResult = catalog.getDataSourceMgr().showCatalogs(user1Show).getResultRows();
+        Assert.assertEquals(user1ShowResult.size(), 1);
+        Assert.assertEquals(user1ShowResult.get(0).get(0), InternalDataSource.INTERNAL_DS_NAME);
+
+        // mock the login of user1
+        ConnectContext user2Ctx = UtFrameUtils.createDefaultCtx(user2, "127.0.0.1");
+        ShowCatalogStmt user2Show = (ShowCatalogStmt) UtFrameUtils.parseAndAnalyzeStmt("show catalogs;", user2Ctx);
+        List<List<String>> user2ShowResult = catalog.getDataSourceMgr().showCatalogs(user2Show).getResultRows();
+        Assert.assertEquals(user2ShowResult.size(), 2);
+        Assert.assertTrue(user2ShowResult.stream().map(l -> l.get(0)).anyMatch(c -> c.equals("hive")));
+
+        // access denied
+        ShowCatalogStmt user2ShowHive = (ShowCatalogStmt) UtFrameUtils.parseAndAnalyzeStmt("show catalog hive;",
+                user2Ctx);
+        List<List<String>> user2ShowHiveResult = catalog.getDataSourceMgr().showCatalogs(user2ShowHive).getResultRows();
+        Assert.assertTrue(
+                user2ShowHiveResult.stream().map(l -> l.get(0)).anyMatch(c -> c.equals("hive.metastore.uris")));
+        try {
+            catalog.getDataSourceMgr().showCatalogs(
+                    (ShowCatalogStmt) UtFrameUtils.parseAndAnalyzeStmt("show catalog iceberg;", user2Ctx));
+            Assert.fail("");
+        } catch (AnalysisException e) {
+            Assert.assertEquals(e.getMessage(),
+                    "errCode = 2, detailMessage = Access denied for user 'default_cluster:user2' to catalog 'iceberg'");
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/utframe/UtFrameUtils.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/utframe/UtFrameUtils.java
@@ -31,7 +31,6 @@ import org.apache.doris.common.Config;
 import org.apache.doris.common.DdlException;
 import org.apache.doris.common.FeConstants;
 import org.apache.doris.common.util.SqlParserUtils;
-import org.apache.doris.mysql.privilege.PaloAuth;
 import org.apache.doris.planner.Planner;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.OriginStatement;
@@ -74,16 +73,21 @@ import java.util.UUID;
 public class UtFrameUtils {
 
     // Help to create a mocked ConnectContext.
-    public static ConnectContext createDefaultCtx() throws IOException {
+    public static ConnectContext createDefaultCtx(UserIdentity userIdentity, String remoteIp) throws IOException {
         SocketChannel channel = SocketChannel.open();
         ConnectContext ctx = new ConnectContext(channel);
         ctx.setCluster(SystemInfoService.DEFAULT_CLUSTER);
-        ctx.setCurrentUserIdentity(UserIdentity.ROOT);
-        ctx.setQualifiedUser(PaloAuth.ROOT_USER);
-        ctx.setRemoteIP("127.0.0.1");
+        ctx.setCurrentUserIdentity(userIdentity);
+        ctx.setQualifiedUser(userIdentity.getQualifiedUser());
+        ctx.setRemoteIP(remoteIp);
         ctx.setCatalog(Catalog.getCurrentCatalog());
         ctx.setThreadLocalInfo();
         return ctx;
+    }
+
+    // Help to create a mocked ConnectContext for root.
+    public static ConnectContext createDefaultCtx() throws IOException {
+        return createDefaultCtx(UserIdentity.ROOT, "127.0.0.1");
     }
 
     // Parse an origin stmt and analyze it. Return a StatementBase instance.


### PR DESCRIPTION
## Usage:
set `enable_multi_catalog = true` in fe.conf to enable multi-catalog.
### CREATE CATALOG
create hive catalog
```
MySQL [tpch1]> create catalog hive properties('type' = 'hms', 'hive.metastore.uris' = 'thrift://192.168.0.1:9083');
MySQL [tpch1]> show catalogs;
+-------------+----------+
| CatalogName | Type     |
+-------------+----------+
| hive        | hms      |
| __internal  | internal |
+-------------+----------+
```
### SWITCH CATALOG
**Required Privileges**
If catalog does not exist, throw an exception.
The user with catalog-level's show_priv or any privilege of tables or databases within the catalog,
can switch to the catalog.
```
MySQL [tpch1]> show all grants;
+-----------------------------+----------+-------------------------------+--------------+----------------------------------------------------------------------------------------------------------------------------+------------+---------------+
| UserIdentity                | Password | GlobalPrivs                   | CatalogPrivs | DatabasePrivs                                                                                                              | TablePrivs | ResourcePrivs |
+-----------------------------+----------+-------------------------------+--------------+----------------------------------------------------------------------------------------------------------------------------+------------+---------------+
| 'root'@'%'                  | No       | Node_priv Admin_priv  (false) | NULL         | NULL                                                                                                                       | NULL       | NULL          |
| 'admin'@'%'                 | No       | Admin_priv  (false)           | NULL         | NULL                                                                                                                       | NULL       | NULL          |
| 'default_cluster:user1'@'%' | Yes      |  (false)                      | NULL         | __internal.default_cluster:information_schema: Select_priv  (false); __internal.default_cluster:tpch: Select_priv  (false) | NULL       | NULL          |
+-----------------------------+----------+-------------------------------+--------------+----------------------------------------------------------------------------------------------------------------------------+------------+---------------+
```
user1 can't switch to hive catalog.
```
MySQL [(none)]> switch __internal;
Query OK, 0 rows affected (0.00 sec)
MySQL [(none)]> switch hive;
ERROR 5087 (42000): errCode = 2, detailMessage = Access denied for user 'default_cluster:user1' to catalog 'hive'
```
**Supported**
Only grant stmt works now, a user can use two-segment-format 'db.tbl' to grant privileges within the catalog.
```
// root user
MySQL [tpch1]> switch hive;
grant create_priv on hive_tpch.* to 'user1'@'%';
grant create_priv on *.* to 'user1'@'%';
show all grants;
+-----------------------------+----------+-------------------------------+----------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------+---------------+
| UserIdentity                | Password | GlobalPrivs                   | CatalogPrivs               | DatabasePrivs                                                                                                                                                                    | TablePrivs | ResourcePrivs |
+-----------------------------+----------+-------------------------------+----------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------+---------------+
| 'root'@'%'                  | No       | Node_priv Admin_priv  (false) | NULL                       | NULL                                                                                                                                                                             | NULL       | NULL          |
| 'admin'@'%'                 | No       | Admin_priv  (false)           | NULL                       | NULL                                                                                                                                                                             | NULL       | NULL          |
| 'default_cluster:user1'@'%' | Yes      |  (false)                      | hive: Create_priv  (false) | __internal.default_cluster:information_schema: Select_priv  (false); __internal.default_cluster:tpch: Select_priv  (false); hive.default_cluster:hive_tpch: Create_priv  (false) | NULL       | NULL          |
+-----------------------------+----------+-------------------------------+----------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------+---------------+
```
### SHOW CATALOG(S)
Only the user with privileges the same as `switch catalog` can get information from `show catalog(s)`
**root user**: access to get all information about catalogs.
```
MySQL [(none)]> show catalogs;
+-------------+----------+
| CatalogName | Type     |
+-------------+----------+
| hive        | hms      |
| __internal  | internal |
| iceberg     | hms      |
+-------------+----------+
MySQL [(none)]> show catalog iceberg;
+-----------------------------+---------------------------+
| Key                         | Value                     |
+-----------------------------+---------------------------+
| iceberg.hive.metastore.uris | thrift://192.168.0.1:9083 |
| type                        | hms                       |
+-----------------------------+---------------------------+
```
**user1**: can only get the catalog information of '__internal' and 'hive'.
```
MySQL [(none)]> show catalogs;
+-------------+----------+
| CatalogName | Type     |
+-------------+----------+
| hive        | hms      |
| __internal  | internal |
+-------------+----------+
MySQL [(none)]> show catalog iceberg;
errCode = 2, detailMessage = Access denied for user 'default_cluster:user1' to catalog 'iceberg'
```
## Checklist(Required)

1. Does it affect the original behavior: (No)
2. Has unit tests been added: (Yes)
3. Has document been added or modified: (No)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
