### PR TITLE
[fix]Make sure only call once set_dict_encoding_type for each ColumnReader

### DIFF
--- a/be/src/olap/rowset/segment_v2/column_reader.h
+++ b/be/src/olap/rowset/segment_v2/column_reader.h
@@ -138,7 +138,9 @@ public:
 
     uint64_t num_rows() { return _num_rows; }
 
-    void set_dict_encoding_type(DictEncodingType type) { _dict_encoding_type = type; }
+    void set_dict_encoding_type(DictEncodingType type) {
+        std::call_once(_set_dict_encoding_type_flag, [&] { _dict_encoding_type = type; });
+    }
 
     DictEncodingType get_dict_encoding_type() { return _dict_encoding_type; }
 
@@ -202,6 +204,8 @@ private:
     std::unique_ptr<BloomFilterIndexReader> _bloom_filter_index;
 
     std::vector<std::unique_ptr<ColumnReader>> _sub_readers;
+
+    std::once_flag _set_dict_encoding_type_flag;
 };
 
 // Base iterator to read one column data


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
