### PR TITLE
[Optimize](Compaction) compaction task producer add quiet period

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -304,6 +304,13 @@ CONF_mInt32(scan_alpha_rowset_min_interval_sec, "3");
 // This config can be set to limit thread number in  smallcompaction thread pool.
 CONF_mInt32(quick_compaction_max_threads, "10");
 
+// max consecutive prepare failure interval before dir compaction quiet
+CONF_mInt32(max_prepare_failure_interval_before_quiet, "10");
+// dir quiet period time
+CONF_mInt32(data_dir_quiet_period_s, "60");
+// sleep time in compaction quiet period per shard
+CONF_mInt32(data_dir_sleep_time_in_quiet_period_ms, "100");
+
 // Thread count to do tablet meta checkpoint, -1 means use the data directories count.
 CONF_Int32(max_meta_checkpoint_threads, "-1");
 

--- a/be/src/olap/data_dir.cpp
+++ b/be/src/olap/data_dir.cpp
@@ -76,7 +76,8 @@ DataDir::DataDir(const std::string& path, int64_t capacity_bytes,
           _cluster_id_incomplete(false),
           _to_be_deleted(false),
           _current_shard(0),
-          _meta(nullptr) {
+          _meta(nullptr),
+          _compaction_quiet_period_s(0) {
     _path_desc.storage_medium = storage_medium;
     _data_dir_metric_entity = DorisMetrics::instance()->metric_registry()->register_entity(
             std::string("data_dir.") + path, {{"path", path}});

--- a/be/src/olap/olap_server.cpp
+++ b/be/src/olap/olap_server.cpp
@@ -572,6 +572,9 @@ std::vector<TabletSharedPtr> StorageEngine::_generate_compaction_tasks(
                     tablets_compaction.emplace_back(tablet);
                 }
                 max_compaction_score = std::max(max_compaction_score, disk_max_score);
+            } else {
+                // can't find a tablet to do compaction
+                data_dir->set_tablet_prepare_compact_failed(UnixSeconds(), true);
             }
         }
     }

--- a/be/src/olap/tablet_manager.cpp
+++ b/be/src/olap/tablet_manager.cpp
@@ -659,6 +659,9 @@ TabletSharedPtr TabletManager::find_best_tablet_to_compaction(
     double tablet_scan_frequency = 0.0;
     TabletSharedPtr best_tablet;
     for (const auto& tablets_shard : _tablets_shards) {
+        if (data_dir->is_in_quiet_period(now_ms / 1000)) {
+            data_dir->wait_in_quiet_period(config::data_dir_sleep_time_in_quiet_period_ms);
+        }
         std::shared_lock rdlock(tablets_shard.lock);
         for (const auto& tablet_map : tablets_shard.tablet_map) {
             const TabletSharedPtr& tablet_ptr = tablet_map.second;


### PR DESCRIPTION

In some case, if a dir has no more compaction tasks, it still
scan tablet meta to find best tablet to try compaction, which
makes compaction task producer thread always run full。
Add a quiet period if a dir continuely fails to do compaction to
optimize this case.

case:
![screenshot-20220627-105810](https://user-images.githubusercontent.com/102007456/175851977-392b213c-5762-41f2-a10f-a1e2794b3836.png)


# Proposed changes

Issue Number: close #xxx

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
