### PR TITLE
set 512 as default value of page cache shard num

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -229,7 +229,7 @@ CONF_Int64(index_stream_cache_capacity, "10737418240");
 CONF_String(storage_page_cache_limit, "20%");
 // Shard size for page cache, the value must be power of two.
 // It's recommended to set it to a value close to the number of BE cores in order to reduce lock contentions.
-CONF_Int32(storage_page_cache_shard_size, "16");
+CONF_Int32(storage_page_cache_shard_size, "512");
 // Percentage for index page cache
 // all storage page cache will be divided into data_page_cache and index_page_cache
 CONF_Int32(index_page_cache_percentage, "10");


### PR DESCRIPTION
When there are high concurrency query running on the same data,
there is lock contention on cache lock.

# Proposed changes

Issue Number: close #xxx

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
