### PR TITLE
[Bug][Vectorized] fix clang build fail

### DIFF
--- a/be/src/vec/functions/date_time_transforms.h
+++ b/be/src/vec/functions/date_time_transforms.h
@@ -227,11 +227,17 @@ struct DateFormatImpl {
 
     static DataTypes get_variadic_argument_types() {
         if constexpr (std::is_same_v<DateType, VecDateTimeValue>) {
-            return std::vector<DataTypePtr> {std::make_shared<vectorized::DataTypeDateTime>(),
-                                             std::make_shared<vectorized::DataTypeString>()};
+            return std::vector<DataTypePtr> {
+                    std::dynamic_pointer_cast<const IDataType>(
+                            std::make_shared<vectorized::DataTypeDateTime>()),
+                    std::dynamic_pointer_cast<const IDataType>(
+                            std::make_shared<vectorized::DataTypeString>())};
         } else {
-            return std::vector<DataTypePtr> {std::make_shared<vectorized::DataTypeDateV2>(),
-                                             std::make_shared<vectorized::DataTypeString>()};
+            return std::vector<DataTypePtr> {
+                    std::dynamic_pointer_cast<const IDataType>(
+                            std::make_shared<vectorized::DataTypeDateV2>()),
+                    std::dynamic_pointer_cast<const IDataType>(
+                            std::make_shared<vectorized::DataTypeString>())};
         }
     }
 };


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:
```cpp
be/src/vec/functions/date_time_transforms.h:230:20: error: no matching constructor for initialization of 'std::vector<DataTypePtr>' (aka 'vector<shared_ptr<const doris::vectorized::IDataType>>')
            return std::vector<DataTypePtr> {std::make_shared<vectorized::DataTypeDateTime>(),
```

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
