### PR TITLE
[Load][Vectorized] load opt code by change `replace` and `replace_if_not_null` do not copy value

### DIFF
--- a/be/src/vec/aggregate_functions/aggregate_function_reader.cpp
+++ b/be/src/vec/aggregate_functions/aggregate_function_reader.cpp
@@ -48,18 +48,19 @@ void register_aggregate_function_replace_reader_load(AggregateFunctionSimpleFact
                       false);
     register_function("replace", AGG_READER_SUFFIX, create_aggregate_function_first<true, true>,
                       true);
-    register_function("replace", AGG_LOAD_SUFFIX, create_aggregate_function_last<false, true>,
+    register_function("replace", AGG_LOAD_SUFFIX, create_aggregate_function_last<false, false>,
                       false);
-    register_function("replace", AGG_LOAD_SUFFIX, create_aggregate_function_last<true, true>, true);
+    register_function("replace", AGG_LOAD_SUFFIX, create_aggregate_function_last<true, false>,
+                      true);
 
     register_function("replace_if_not_null", AGG_READER_SUFFIX,
                       create_aggregate_function_first_non_null_value<false, true>, false);
     register_function("replace_if_not_null", AGG_READER_SUFFIX,
                       create_aggregate_function_first_non_null_value<true, true>, true);
     register_function("replace_if_not_null", AGG_LOAD_SUFFIX,
-                      create_aggregate_function_last_non_null_value<false, true>, false);
+                      create_aggregate_function_last_non_null_value<false, false>, false);
     register_function("replace_if_not_null", AGG_LOAD_SUFFIX,
-                      create_aggregate_function_last_non_null_value<true, true>, true);
+                      create_aggregate_function_last_non_null_value<true, false>, true);
 }
 
 } // namespace doris::vectorized

--- a/be/src/vec/aggregate_functions/aggregate_function_window.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_window.h
@@ -210,26 +210,30 @@ public:
 struct Value {
 public:
     bool is_null() const { return _is_null; }
-    StringRef get_value() const { return _value; }
-
     void set_null(bool is_null) { _is_null = is_null; }
-    void set_value(StringRef value) { _value = value; }
+    StringRef get_value() const { return _ptr->get_data_at(_offset); }
+
+    void set_value(StringRef ref) {
+        _ptr = (IColumn*)ref.data;
+        _offset = ref.size;
+    }
     void reset() {
         _is_null = false;
-        _value = {};
+        _ptr = nullptr;
+        _offset = 0;
     }
 
 protected:
-    StringRef _value;
+    IColumn* _ptr = nullptr;
+    size_t _offset = 0;
     bool _is_null;
 };
 
 struct CopiedValue : public Value {
 public:
-    void set_value(StringRef value) {
-        _copied_value = value.to_string();
-        _value = StringRef(_copied_value);
-    }
+    StringRef get_value() const { return _copied_value; }
+
+    void set_value(StringRef value) { _copied_value = value.to_string(); }
 
 private:
     std::string _copied_value;
@@ -262,50 +266,23 @@ public:
                 col.insert_default();
             } else {
                 auto& col = assert_cast<ColumnNullable&>(to);
-                if constexpr (is_string) {
-                    StringRef value = _data_value.get_value();
-                    col.insert_data(value.data, value.size);
-                } else {
-                    StringRef value = _data_value.get_value();
-                    col.insert_data(value.data, 0);
-                }
-            }
-        } else {
-            if constexpr (is_string) {
-                auto& col = assert_cast<ColumnString&>(to);
                 StringRef value = _data_value.get_value();
                 col.insert_data(value.data, value.size);
-            } else {
-                StringRef value = _data_value.get_value();
-                to.insert_data(value.data, 0);
             }
+        } else {
+            StringRef value = _data_value.get_value();
+            to.insert_data(value.data, value.size);
         }
     }
 
-    void set_value(const IColumn** columns, int64_t pos) {
-        if (is_column_nullable(*columns[0])) {
-            const auto* nullable_column = assert_cast<const ColumnNullable*>(columns[0]);
-            if (nullable_column && nullable_column->is_null_at(pos)) {
-                _data_value.set_null(true);
-                _has_value = true;
-                return;
-            }
-            if constexpr (is_string) {
-                const auto* sources = check_and_get_column<ColumnString>(
-                        nullable_column->get_nested_column_ptr().get());
-                _data_value.set_value(sources->get_data_at(pos));
-            } else {
-                _data_value.set_value(nullable_column->get_nested_column_ptr()->get_data_at(pos));
-            }
+    void set_value(const IColumn** columns, size_t pos) {
+        if (columns[0]->is_nullable() &&
+            assert_cast<const ColumnNullable*>(columns[0])->is_null_at(pos)) {
+            _data_value.set_null(true);
         } else {
-            if constexpr (is_string) {
-                const auto* sources = check_and_get_column<ColumnString>(columns[0]);
-                _data_value.set_value(sources->get_data_at(pos));
-            } else {
-                _data_value.set_value(columns[0]->get_data_at(pos));
-            }
+            _data_value.set_value(StringRef {(const char*)columns[0], pos});
+            _data_value.set_null(false);
         }
-        _data_value.set_null(false);
         _has_value = true;
     }
 
@@ -313,7 +290,7 @@ public:
 
     void set_is_null() { _data_value.set_null(true); }
 
-    void set_value_from_default() { _data_value.set_value(_default_value.get_value()); }
+    void set_value_from_default() { _data_value = _default_value; }
 
     bool has_set_value() { return _has_value; }
 
@@ -325,12 +302,7 @@ public:
                     _default_value.set_null(true);
                 }
             } else {
-                if constexpr (is_string) {
-                    const auto& col = static_cast<const ColumnString&>(*column);
-                    _default_value.set_value(col.get_data_at(0));
-                } else {
-                    _default_value.set_value(column->get_data_at(0));
-                }
+                _default_value.set_value(StringRef {(const char*)column, 0});
             }
             _is_init = true;
         }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

After do the opt of this

unique_table 1000W data load time

before:45s -> after:35s

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
