### PR TITLE
[fix](nereids) extractPlan should use physical expressions but is logical expressions actually

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/Group.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/Group.java
@@ -184,7 +184,7 @@ public class Group {
      * @return {@link Optional} of cost and {@link GroupExpression} of physical plan pair.
      */
     public Optional<Pair<Double, GroupExpression>> getLowestCostPlan(PhysicalProperties physicalProperties) {
-        if (physicalProperties == null || lowestCostPlans.isEmpty()) {
+        if (physicalProperties == null || lowestCostPlans == null || lowestCostPlans.isEmpty()) {
             return Optional.empty();
         }
         return Optional.ofNullable(lowestCostPlans.get(physicalProperties));
@@ -194,7 +194,7 @@ public class Group {
      * Get the first Plan from Memo.
      */
     public PhysicalPlan extractPlan() throws AnalysisException {
-        GroupExpression groupExpression = this.logicalExpressionsAt(0);
+        GroupExpression groupExpression = this.physicalExpressions.get(0);
 
         List<Plan> planChildren = com.google.common.collect.Lists.newArrayList();
         for (int i = 0; i < groupExpression.arity(); i++) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/Group.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/Group.java
@@ -184,7 +184,7 @@ public class Group {
      * @return {@link Optional} of cost and {@link GroupExpression} of physical plan pair.
      */
     public Optional<Pair<Double, GroupExpression>> getLowestCostPlan(PhysicalProperties physicalProperties) {
-        if (physicalProperties == null || lowestCostPlans == null || lowestCostPlans.isEmpty()) {
+        if (physicalProperties == null || lowestCostPlans.isEmpty()) {
             return Optional.empty();
         }
         return Optional.ofNullable(lowestCostPlans.get(physicalProperties));


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

extractPlan should use physical expressions but is logical expressions actually

## Checklist(Required)

1. Does it affect the original behavior: (No)
2. Has unit tests been added: (No Need)
3. Has document been added or modified: (No Need)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
