### PR TITLE
[Fix] select nested type of string within type array should be wrappe…

### DIFF
--- a/be/src/vec/sink/mysql_result_writer.cpp
+++ b/be/src/vec/sink/mysql_result_writer.cpp
@@ -136,7 +136,13 @@ Status VMysqlResultWriter::_add_one_column(const ColumnPtr& column_ptr,
                 if (data->is_null_at(j)) {
                     buf_ret = _buffer.push_string("NULL", strlen("NULL"));
                 } else {
-                    buf_ret = _add_one_cell(data, j, nested_type_ptr, _buffer);
+                    if (WhichDataType(remove_nullable(nested_type_ptr)).is_string()) {
+                        buf_ret = _buffer.push_string("'", 1);
+                        buf_ret = _add_one_cell(data, j, nested_type_ptr, _buffer);
+                        buf_ret = _buffer.push_string("'", 1);
+                    } else {
+                        buf_ret = _add_one_cell(data, j, nested_type_ptr, _buffer);
+                    }
                 }
                 begin = false;
             }


### PR DESCRIPTION
…d with '' in vectorized path

```
eg.
mysql> set enable_vectorized_engine = true;
mysql> select k3 from test_array_string order by k2 limit 1;
+----------------------------------------------+
| k3                                           |
+----------------------------------------------+
| ['cdsdasd', 'xxxx', '3', '4', '5', NULL] |
+----------------------------------------------+
```
# Proposed changes

Issue Number: close #10497 

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
