### PR TITLE
[hot-fix] fix a typo error and limit the max wait time in VOlapTableSink::send

### DIFF
--- a/be/src/vec/sink/vtablet_sink.cpp
+++ b/be/src/vec/sink/vtablet_sink.cpp
@@ -116,13 +116,13 @@ Status VOlapTableSink::send(RuntimeState* state, vectorized::Block* input_block)
     if (findTabletMode == FindTabletMode::FIND_TABLET_EVERY_BATCH) {
         _partition_to_tablet_map.clear();
     }
-    
-    //if pending bytes is more than 500M, wait
+
+    //if pending bytes is more than 500M, wait at most 1 min
     constexpr size_t MAX_PENDING_BYTES = 500 * 1024 * 1024;
-    if ( get_pending_bytes() > MAX_PENDING_BYTES){
-        while(get_pending_bytes() < MAX_PENDING_BYTES){
-            std::this_thread::sleep_for(std::chrono::microseconds(500));
-        }
+    constexpr int max_retry = 120;
+    int retry = 0;
+    while (get_pending_bytes() > MAX_PENDING_BYTES && retry++ < max_retry) {
+        std::this_thread::sleep_for(std::chrono::microseconds(500));
     }
 
     for (int i = 0; i < num_rows; ++i) {


### PR DESCRIPTION
# Proposed changes
1. fix a typo-error
2. when total _pending_bytes of Table_Sink is over 500M, the wait time is at most 1 min.

Issue Number: close #xxx

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
4. Has unit tests been added: (Yes/No/No Need)
5. Has document been added or modified: (Yes/No/No Need)
6. Does it need to update dependencies: (Yes/No)
7. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
