### PR TITLE
[fix] (mem tracker) Fix cancel query deadlock during add_block, and query pool tracker error cancel query

### DIFF
--- a/be/src/runtime/exec_env_init.cpp
+++ b/be/src/runtime/exec_env_init.cpp
@@ -185,14 +185,12 @@ Status ExecEnv::_init_mem_tracker() {
         global_memory_limit_bytes = MemInfo::physical_mem();
     }
     MemTracker::get_process_tracker()->set_limit(global_memory_limit_bytes);
-    _query_pool_mem_tracker = MemTracker::create_tracker(global_memory_limit_bytes, "QueryPool",
-                                                         MemTracker::get_process_tracker(),
-                                                         MemTrackerLevel::OVERVIEW);
+    _query_pool_mem_tracker = MemTracker::create_tracker(
+            -1, "QueryPool", MemTracker::get_process_tracker(), MemTrackerLevel::OVERVIEW);
     REGISTER_HOOK_METRIC(query_mem_consumption,
                          [this]() { return _query_pool_mem_tracker->consumption(); });
-    _load_pool_mem_tracker = MemTracker::create_tracker(global_memory_limit_bytes, "LoadPool",
-                                                        MemTracker::get_process_tracker(),
-                                                        MemTrackerLevel::OVERVIEW);
+    _load_pool_mem_tracker = MemTracker::create_tracker(
+            -1, "LoadPool", MemTracker::get_process_tracker(), MemTrackerLevel::OVERVIEW);
     REGISTER_HOOK_METRIC(load_mem_consumption,
                          [this]() { return _load_pool_mem_tracker->consumption(); });
     LOG(INFO) << "Using global memory limit: "


### PR DESCRIPTION
# Proposed changes

Issue Number: close #10513

## Problem Summary:

1. Avoid deadlock when calling SenderQueue::cancel() in tcmalloc hook.
2. The limit of the query pool mem tracker is changed to -1, which will not affect the query memory statistics and limit.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
3. Has unit tests been added: (Yes/No/No Need)
4. Has document been added or modified: (Yes/No/No Need)
5. Does it need to update dependencies: (Yes/No)
6. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
