### PR TITLE
[fix] (mem tracker) Fix BE hangs at startup, stuck in tcmalloc hook call ExecEnv::GetInstance()

### DIFF
--- a/be/src/runtime/exec_env.h
+++ b/be/src/runtime/exec_env.h
@@ -72,6 +72,8 @@ class ClientCache;
 
 class HeartbeatFlags;
 
+static bool exec_env_existed = false;
+
 // Execution environment for queries/plan fragments.
 // Contains all required global structures, and handles to
 // singleton services. Clients must call StartServices exactly
@@ -87,6 +89,7 @@ public:
     /// we return the most recently created instance.
     static ExecEnv* GetInstance() {
         static ExecEnv s_exec_env;
+        exec_env_existed = true;
         return &s_exec_env;
     }
 

--- a/be/src/runtime/tcmalloc_hook.h
+++ b/be/src/runtime/tcmalloc_hook.h
@@ -37,17 +37,17 @@
 //  destructor to control the behavior of consume can lead to unexpected behavior,
 //  like this: if (LIKELY(doris::start_thread_mem_tracker)) {
 void new_hook(const void* ptr, size_t size) {
-    if (doris::tls_ctx()) {
+    if (doris::thread_local_ctx._init) {
         doris::tls_ctx()->consume_mem(tc_nallocx(size, 0));
-    } else if (doris::ExecEnv::GetInstance()->initialized()) {
+    } else if (doris::exec_env_existed && doris::ExecEnv::GetInstance()->initialized()) {
         doris::MemTracker::get_process_tracker()->consume(tc_nallocx(size, 0));
     }
 }
 
 void delete_hook(const void* ptr) {
-    if (doris::tls_ctx()) {
+    if (doris::thread_local_ctx._init) {
         doris::tls_ctx()->release_mem(tc_malloc_size(const_cast<void*>(ptr)));
-    } else if (doris::ExecEnv::GetInstance()->initialized()) {
+    } else if (doris::exec_env_existed && doris::ExecEnv::GetInstance()->initialized()) {
         doris::MemTracker::get_process_tracker()->release(tc_malloc_size(const_cast<void*>(ptr)));
     }
 }

--- a/be/src/runtime/thread_context.h
+++ b/be/src/runtime/thread_context.h
@@ -214,6 +214,7 @@ public:
 
     ThreadContext* get();
 
+    // TCMalloc hook is triggered during ThreadContext construction, which may lead to deadlock.
     bool _init = false;
 
 private:
@@ -227,12 +228,7 @@ static ThreadContext* tls_ctx() {
     if (tls != nullptr) {
         return tls;
     } else {
-        if (thread_local_ctx._init) {
-            return thread_local_ctx.get();
-        } else {
-            // TCMalloc hook is triggered during ThreadContext construction, which may lead to deadlock.
-            return nullptr;
-        }
+        return thread_local_ctx.get();
     }
 }
 

--- a/be/src/runtime/thread_mem_tracker_mgr.h
+++ b/be/src/runtime/thread_mem_tracker_mgr.h
@@ -292,13 +292,13 @@ inline void ThreadMemTrackerMgr::noncache_try_consume(int64_t size) {
 }
 
 inline void ThreadMemTrackerMgr::add_tracker(const std::shared_ptr<MemTracker>& mem_tracker) {
-    #ifdef USE_MEM_TRACKER
+#ifdef USE_MEM_TRACKER
     DCHECK(_mem_trackers.find(mem_tracker->id()) == _mem_trackers.end()) << print_debug_string();
     _mem_trackers[mem_tracker->id()] = mem_tracker;
     DCHECK(_mem_trackers[mem_tracker->id()]) << print_debug_string();
     _untracked_mems[mem_tracker->id()] = 0;
     _mem_tracker_labels[mem_tracker->id()] = mem_tracker->label();
-    #endif
+#endif
 }
 
 inline std::shared_ptr<MemTracker> ThreadMemTrackerMgr::mem_tracker() {

--- a/be/src/runtime/thread_mem_tracker_mgr.h
+++ b/be/src/runtime/thread_mem_tracker_mgr.h
@@ -292,10 +292,13 @@ inline void ThreadMemTrackerMgr::noncache_try_consume(int64_t size) {
 }
 
 inline void ThreadMemTrackerMgr::add_tracker(const std::shared_ptr<MemTracker>& mem_tracker) {
+    #ifdef USE_MEM_TRACKER
+    DCHECK(_mem_trackers.find(mem_tracker->id()) == _mem_trackers.end()) << print_debug_string();
     _mem_trackers[mem_tracker->id()] = mem_tracker;
     DCHECK(_mem_trackers[mem_tracker->id()]) << print_debug_string();
     _untracked_mems[mem_tracker->id()] = 0;
     _mem_tracker_labels[mem_tracker->id()] = mem_tracker->label();
+    #endif
 }
 
 inline std::shared_ptr<MemTracker> ThreadMemTrackerMgr::mem_tracker() {

--- a/be/src/runtime/thread_mem_tracker_mgr.h
+++ b/be/src/runtime/thread_mem_tracker_mgr.h
@@ -292,7 +292,6 @@ inline void ThreadMemTrackerMgr::noncache_try_consume(int64_t size) {
 }
 
 inline void ThreadMemTrackerMgr::add_tracker(const std::shared_ptr<MemTracker>& mem_tracker) {
-    DCHECK(_mem_trackers.find(mem_tracker->id()) == _mem_trackers.end()) << print_debug_string();
     _mem_trackers[mem_tracker->id()] = mem_tracker;
     DCHECK(_mem_trackers[mem_tracker->id()]) << print_debug_string();
     _untracked_mems[mem_tracker->id()] = 0;


### PR DESCRIPTION
# Proposed changes

Issue Number: close #10516

## Problem Summary:

1. Added flag `exec_env_existed` to indicate whether ExecEnv Instance is created.
2. `ThreadMemTrackerMgr::add_tracker`  fail when `USE_MEM_TRACKER=OFF`, add `USE_MEM_TRACKER` compile option.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
3. Has unit tests been added: (Yes/No/No Need)
4. Has document been added or modified: (Yes/No/No Need)
5. Does it need to update dependencies: (Yes/No)
6. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
