### PR TITLE
[fix] block dump_one_line assert error

### DIFF
--- a/be/src/vec/core/block.cpp
+++ b/be/src/vec/core/block.cpp
@@ -403,7 +403,7 @@ std::string Block::dump_data(size_t begin, size_t row_limit) const {
 }
 
 std::string Block::dump_one_line(size_t row, int column_end) const {
-    assert(column_end < columns());
+    assert(column_end <= columns());
     fmt::memory_buffer line;
     for (int i = 0; i < column_end; ++i) {
         if (LIKELY(i != 0)) {


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

While debug, we need to dump data in block, but it can not dump all columns.
Because the assert inside function Block::dump_one_line is not correct.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
