### PR TITLE
[feature-wip](unique-key-merge-on-write) add primary key index

### DIFF
--- a/be/src/olap/CMakeLists.txt
+++ b/be/src/olap/CMakeLists.txt
@@ -90,6 +90,7 @@ add_library(Olap STATIC
     types.cpp 
     utils.cpp
     wrapper_field.cpp
+    primary_key_index.cpp
     rowset/segment_v2/bitmap_index_reader.cpp
     rowset/segment_v2/bitmap_index_writer.cpp
     rowset/segment_v2/bitshuffle_page.cpp

--- a/be/src/olap/primary_key_index.h
+++ b/be/src/olap/primary_key_index.h
@@ -1,0 +1,84 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include "common/status.h"
+#include "gen_cpp/segment_v2.pb.h"
+#include "olap/rowset/segment_v2/indexed_column_reader.h"
+#include "olap/rowset/segment_v2/indexed_column_writer.h"
+#include "util/faststring.h"
+#include "util/slice.h"
+
+namespace doris {
+
+// Build index for primary key.
+// The primary key index is designed in a similar way like RocksDB
+// Partitioned Index, which is created in the segment file when MemTable flushes.
+// Index is stored in multiple pages to leverage the IndexedColumnWriter.
+class PrimaryKeyIndexBuilder {
+public:
+    PrimaryKeyIndexBuilder(fs::WritableBlock* wblock) : _wblock(wblock), _num_rows(0), _size(0) {}
+
+    Status init();
+
+    Status add_item(const Slice& key);
+
+    uint32_t num_rows() const { return _num_rows; }
+
+    uint64_t size() { return _size; }
+
+    Slice min_key() { return Slice(_min_key); }
+    Slice max_key() { return Slice(_max_key); }
+
+    Status finalize(segment_v2::IndexedColumnMetaPB* meta);
+
+private:
+    fs::WritableBlock* _wblock = nullptr;
+    uint32_t _num_rows;
+    uint64_t _size;
+
+    faststring _min_key;
+    faststring _max_key;
+    std::unique_ptr<segment_v2::IndexedColumnWriter> _index_builder;
+};
+
+class PrimaryKeyIndexReader {
+public:
+    PrimaryKeyIndexReader() : _parsed(false) {}
+
+    Status parse(const FilePathDesc& path_desc, const segment_v2::IndexedColumnMetaPB& meta);
+
+    Status new_iterator(std::unique_ptr<segment_v2::IndexedColumnIterator>* index_iterator) const {
+        DCHECK(_parsed);
+        index_iterator->reset(new segment_v2::IndexedColumnIterator(_index_reader.get()));
+        return Status::OK();
+    }
+
+    uint32_t num_rows() const {
+        DCHECK(_parsed);
+        return _index_reader->num_values();
+    }
+
+private:
+    bool _parsed;
+    bool _use_page_cache = true;
+    bool _kept_in_memory = true;
+    std::unique_ptr<segment_v2::IndexedColumnReader> _index_reader;
+};
+
+} // namespace doris

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -199,6 +199,7 @@ set(OLAP_TEST_FILES
     olap/options_test.cpp
     olap/fs/file_block_manager_test.cpp
     olap/common_test.cpp
+    olap/primary_key_index_test.cpp
     # olap/memtable_flush_executor_test.cpp
     # olap/push_handler_test.cpp
 )

--- a/be/test/olap/primary_key_index_test.cpp
+++ b/be/test/olap/primary_key_index_test.cpp
@@ -1,0 +1,123 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "olap/primary_key_index.h"
+
+#include <gtest/gtest.h>
+
+#include "olap/fs/block_manager.h"
+#include "olap/fs/fs_util.h"
+#include "olap/row_cursor.h"
+#include "olap/tablet_schema_helper.h"
+#include "util/debug_util.h"
+#include "util/file_utils.h"
+
+namespace doris {
+
+class PrimaryKeyIndexTest : public testing::Test {
+public:
+    PrimaryKeyIndexTest() {}
+    virtual ~PrimaryKeyIndexTest() {}
+
+    void SetUp() override {
+        if (FileUtils::check_exist(kTestDir)) {
+            EXPECT_TRUE(FileUtils::remove_all(kTestDir).ok());
+        }
+        EXPECT_TRUE(FileUtils::create_dir(kTestDir).ok());
+    }
+    void TearDown() override {
+        if (FileUtils::check_exist(kTestDir)) {
+            EXPECT_TRUE(FileUtils::remove_all(kTestDir).ok());
+        }
+    }
+
+private:
+    const std::string kTestDir = "./ut_dir/primary_key_index_test";
+};
+
+TEST_F(PrimaryKeyIndexTest, builder) {
+    std::string filename = kTestDir + "/builder";
+    std::unique_ptr<fs::WritableBlock> wblock;
+    fs::CreateBlockOptions opts(filename);
+    std::string storage_name;
+    EXPECT_TRUE(fs::fs_util::block_manager(storage_name)->create_block(opts, &wblock).ok());
+
+    PrimaryKeyIndexBuilder builder(wblock.get());
+    builder.init();
+    size_t num_rows = 0;
+    std::vector<std::string> keys;
+    for (int i = 1000; i < 10000; i += 2) {
+        keys.push_back(std::to_string(i));
+        builder.add_item(std::to_string(i));
+        num_rows++;
+    }
+    EXPECT_EQ("1000", builder.min_key().to_string());
+    EXPECT_EQ("9998", builder.max_key().to_string());
+    segment_v2::IndexedColumnMetaPB index_meta;
+    EXPECT_TRUE(builder.finalize(&index_meta));
+    EXPECT_TRUE(wblock->close().ok());
+    EXPECT_EQ(num_rows, builder.num_rows());
+
+    FilePathDesc path_desc(filename);
+    PrimaryKeyIndexReader index_reader;
+    EXPECT_TRUE(index_reader.parse(path_desc, index_meta).ok());
+    EXPECT_EQ(num_rows, index_reader.num_rows());
+
+    std::unique_ptr<segment_v2::IndexedColumnIterator> index_iterator;
+    EXPECT_TRUE(index_reader.new_iterator(&index_iterator).ok());
+    bool exact_match = false;
+    uint32_t row_id;
+    for (size_t i = 0; i < keys.size(); i++) {
+        auto status = index_iterator->seek_at_or_after(&keys[i], &exact_match);
+        EXPECT_TRUE(status.ok());
+        EXPECT_TRUE(exact_match);
+        row_id = index_iterator->get_current_ordinal();
+        EXPECT_EQ(i, row_id);
+    }
+    // find a non-existing key "8701"
+    {
+        string key("8701");
+        Slice slice(key);
+        auto status = index_iterator->seek_at_or_after(&slice, &exact_match);
+        EXPECT_TRUE(status.ok());
+        EXPECT_FALSE(exact_match);
+        row_id = index_iterator->get_current_ordinal();
+        EXPECT_EQ(3851, row_id);
+    }
+
+    // find prefix "87"
+    {
+        string key("87");
+        Slice slice(key);
+        auto status = index_iterator->seek_at_or_after(&slice, &exact_match);
+        EXPECT_TRUE(status.ok());
+        EXPECT_FALSE(exact_match);
+        row_id = index_iterator->get_current_ordinal();
+        EXPECT_EQ(3850, row_id);
+    }
+
+    // find prefix "9999"
+    {
+        string key("9999");
+        Slice slice(key);
+        auto status = index_iterator->seek_at_or_after(&slice, &exact_match);
+        EXPECT_FALSE(exact_match);
+        EXPECT_TRUE(status.is_not_found());
+    }
+}
+
+} // namespace doris


### PR DESCRIPTION
# Proposed changes

See the DISP-18:https://cwiki.apache.org/confluence/display/DORIS/DSIP-018%3A+Support+Merge-On-Write+implementation+for+UNIQUE+KEY+data+model
This patch is for step 1.1 in scheduling.


## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
