### PR TITLE
[fix](nereids) fix ut,check bound should be called recursively on the plan node

### DIFF
--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/AnalyzeSSBTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/AnalyzeSSBTest.java
@@ -161,13 +161,6 @@ public class AnalyzeSSBTest extends TestWithFeService {
         if (!checkPlanBound(root))  {
             return false;
         }
-
-        List<Plan> children = root.children();
-        for (Plan child : children) {
-            if (!checkPlanBound((LogicalPlan) child)) {
-                return false;
-            }
-        }
         return true;
     }
 
@@ -177,6 +170,13 @@ public class AnalyzeSSBTest extends TestWithFeService {
     private boolean checkPlanBound(LogicalPlan plan) {
         if (plan instanceof Unbound) {
             return false;
+        }
+
+        List<Plan> children = plan.children();
+        for (Plan child : children) {
+            if (!checkPlanBound((LogicalPlan) child)) {
+                return false;
+            }
         }
 
         List<Expression> expressions = plan.getOperator().getExpressions();


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:
fix ut,check bound should be called recursively on the plan node

## Checklist(Required)

1. Does it affect the original behavior: (No)
3. Has unit tests been added: (No Need)
4. Has document been added or modified: (No Need)
5. Does it need to update dependencies: (No)
6. Are there any changes that cannot be rolled back: (No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
