### PR TITLE
[hot-fix] fix a typo error and limit the max wait time in VOlapTableSink::send

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -721,6 +721,9 @@ CONF_Int32(quick_compaction_batch_size, "10");
 // do compaction min rowsets
 CONF_Int32(quick_compaction_min_rowsets, "10");
 
+//memory limitation for batches in pending queue, default 500M
+CONF_Int64(table_sink_pending_bytes_limitation, "524288000");
+
 } // namespace config
 
 } // namespace doris

--- a/be/src/vec/sink/vtablet_sink.cpp
+++ b/be/src/vec/sink/vtablet_sink.cpp
@@ -124,6 +124,11 @@ Status VOlapTableSink::send(RuntimeState* state, vectorized::Block* input_block)
     while (get_pending_bytes() > MAX_PENDING_BYTES && retry++ < max_retry) {
         std::this_thread::sleep_for(std::chrono::microseconds(500));
     }
+    if (get_pending_bytes() > MAX_PENDING_BYTES){
+        std::stringstream str;
+        str << "Load task " << _load_id << ": Memory exceed limit. ";
+        return Status::MemoryLimitExceeded(str.str());
+    }
 
     for (int i = 0; i < num_rows; ++i) {
         if (filtered_rows > 0 && _filter_bitmap.Get(i)) {

--- a/be/src/vec/sink/vtablet_sink.cpp
+++ b/be/src/vec/sink/vtablet_sink.cpp
@@ -117,16 +117,18 @@ Status VOlapTableSink::send(RuntimeState* state, vectorized::Block* input_block)
         _partition_to_tablet_map.clear();
     }
     
-    //if pending bytes is more than 500M, wait at most 1 min
-    constexpr size_t MAX_PENDING_BYTES = 500 * 1024 * 1024;
+    //if pending bytes is more than table_sink_pending_bytes_limitation, wait at most 1 min
+    size_t MAX_PENDING_BYTES = config::table_sink_pending_bytes_limitation;
     constexpr int max_retry = 120;
     int retry = 0;
     while (get_pending_bytes() > MAX_PENDING_BYTES && retry++ < max_retry) {
         std::this_thread::sleep_for(std::chrono::microseconds(500));
     }
-    if (get_pending_bytes() > MAX_PENDING_BYTES){
+    if (get_pending_bytes() > MAX_PENDING_BYTES) {
         std::stringstream str;
-        str << "Load task " << _load_id << ": Memory exceed limit. ";
+        str << "Load task " << _load_id
+            << ": pending bytes exceed limit (config::table_sink_pending_bytes_limitation):"
+            << MAX_PENDING_BYTES;
         return Status::MemoryLimitExceeded(str.str());
     }
 


### PR DESCRIPTION
# Proposed changes
1. fix a typo-error
2. add config::table_sink_pending_bytes_limitation for memory limitation of pending batches of a table sink.
3. when total _pending_bytes of Table_Sink is over table_sink_pending_bytes_limitation,  task waits at most 1 min.
4. after 1 min wait, if it is still exceeded, abort the load task.

this pr mainly aims to avoid OOM:
There is a limitation for pending batch size of every single node_channel, but no limitation for the total batch size of all the channels. When node number is large, even every node_channel's pending queue is not exceeded, there is a risk of OOM. In order to avoid this potential OOM, we set a limitation for the total size of all pending queues.

Issue Number: close #xxx

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
5. Has document been added or modified: (Yes/No/No Need)
6. Does it need to update dependencies: (Yes/No)
7. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
