### PR TITLE
[improvement]No need to memset flags for vectorization predicates

### DIFF
--- a/be/src/olap/block_column_predicate.cpp
+++ b/be/src/olap/block_column_predicate.cpp
@@ -234,12 +234,16 @@ void AndBlockColumnPredicate::evaluate_vec(vectorized::MutableColumns& block, ui
         _block_column_predicate_vec[0]->evaluate_vec(block, size, flags);
     } else {
         bool new_flags[size];
+        bool initialized = false;
         for (auto block_column_predicate : _block_column_predicate_vec) {
-            memset(new_flags, true, size);
-            block_column_predicate->evaluate_vec(block, size, new_flags);
-
-            for (uint16_t j = 0; j < size; j++) {
-                flags[j] &= new_flags[j];
+            if (initialized) {
+                block_column_predicate->evaluate_vec(block, size, new_flags);
+                for (uint16_t j = 0; j < size; j++) {
+                    flags[j] &= new_flags[j];
+                }
+            } else {
+                block_column_predicate->evaluate_vec(block, size, flags);
+                initialized = true;
             }
         }
     }

--- a/be/src/olap/rowset/segment_v2/segment_iterator.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.cpp
@@ -883,7 +883,6 @@ uint16_t SegmentIterator::_evaluate_vectorization_predicate(uint16_t* sel_rowid_
 
     uint16_t original_size = selected_size;
     bool ret_flags[selected_size];
-    memset(ret_flags, 1, selected_size);
     _pre_eval_block_predicate->evaluate_vec(_current_return_columns, selected_size, ret_flags);
 
     uint16_t new_size = 0;


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

Every calling of `evaluate_vec` will set every item of flags, so there is no need to memset the flags.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
