### PR TITLE
[Compile] turn off java-udf by default when compliling in parallel

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -165,7 +165,6 @@ else
         BUILD_BROKER=1
         BUILD_META_TOOL=ON
         BUILD_SPARK_DPP=1
-        BUILD_JAVA_UDF=1
         BUILD_HIVE_UDF=1
         CLEAN=0
     fi


### PR DESCRIPTION
# Proposed changes

Issue Number: close #10568

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
