### PR TITLE
[bug] fix the compile error

### DIFF
--- a/be/src/exec/mysql_scan_node.cpp
+++ b/be/src/exec/mysql_scan_node.cpp
@@ -138,7 +138,7 @@ Status MysqlScanNode::write_text_slot(char* value, int value_length, SlotDescrip
     if (!_text_converter->write_slot(slot, _tuple, value, value_length, true, false,
                                      _tuple_pool.get())) {
         return Status::InternalError("Fail to convert mysql value:'{}' to {} on column:`{}`", value,
-                                     slot->type(), slot->col_name());
+                                     slot->type().debug_string(), slot->col_name());
     }
 
     return Status::OK();

--- a/be/src/runtime/mysql_table_writer.cpp
+++ b/be/src/runtime/mysql_table_writer.cpp
@@ -147,7 +147,7 @@ Status MysqlTableWriter::insert_row(TupleRow* row) {
 
         default: {
             return Status::InternalError("can't convert this type to mysql type. type = {}",
-                                         _output_expr_ctxs[i]->root()->type());
+                                         _output_expr_ctxs[i]->root()->type().type);
         }
         }
     }


### PR DESCRIPTION
# Proposed changes
1. fix the compile error caused by #9533 when we compile doris be.
the compile error is as follow:

/home/disk1/hugo_work/doris_dev/baidu/bdg/doris/core/be/src/exec/mysql_scan_node.cpp:140:37:   required from here
/home/disk1/hugo_work/doris_dev/baidu/bdg/doris/core/thirdparty/installed/include/fmt/core.h:1423:7: error: static assertion failed: Cannot format an argument. To make type T formattable provide a formatter<T> specialization: https://fmt.dev/latest/api.html#udt
 1423 |       formattable<T>(),

/home/disk1/hugo_work/doris_dev/baidu/bdg/doris/core/thirdparty/installed/include/fmt/core.h:1423:7: note: 'fmt::v7::formattable<doris::TypeDescriptor>{std::integral_constant<bool, false>()}' evaluates to false
Issue Number: close #xxx

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (No)
3. Has unit tests been added: (No)
4. Has document been added or modified: (No)
5. Does it need to update dependencies: (No)
6. Are there any changes that cannot be rolled back: (No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
