### PR TITLE
[fix]fix agg_memleak

### DIFF
--- a/be/src/vec/exec/vaggregation_node.cpp
+++ b/be/src/vec/exec/vaggregation_node.cpp
@@ -719,6 +719,10 @@ Status AggregationNode::_pre_agg_with_serialized_key(doris::vectorized::Block* i
                             }
                         }
 
+                        for (size_t i = 0; i < rows; ++i) {
+                            _destory_agg_status(_streaming_pre_places[i]);
+                        }
+
                         if (!mem_reuse) {
                             ColumnsWithTypeAndName columns_with_schema;
                             for (int i = 0; i < key_size; ++i) {

--- a/be/src/vec/exec/vaggregation_node.cpp
+++ b/be/src/vec/exec/vaggregation_node.cpp
@@ -720,7 +720,7 @@ Status AggregationNode::_pre_agg_with_serialized_key(doris::vectorized::Block* i
                         }
 
                         for (size_t i = 0; i < rows; ++i) {
-                            _destory_agg_status(_streaming_pre_places[i]);
+                            _destroy_agg_status(_streaming_pre_places[i]);
                         }
 
                         if (!mem_reuse) {


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

The previous code did not call 'destroy' to release the resource after the' create 'operation, resulting in a memory leak. So I added Destroy

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
