### PR TITLE
[fix](multi-catalog) fix the core dump on hms table

### DIFF
--- a/be/src/exec/text_converter.h
+++ b/be/src/exec/text_converter.h
@@ -53,7 +53,7 @@ public:
     bool write_column(const SlotDescriptor* slot_desc, vectorized::MutableColumnPtr* column_ptr,
                       const char* data, size_t len, bool copy_string, bool need_escape);
 
-    bool write_vec_column(const SlotDescriptor* slot_desc, vectorized::IColumn* column_ptr,
+    bool write_vec_column(const SlotDescriptor* slot_desc, vectorized::IColumn* nullable_col_ptr,
                           const char* data, size_t len, bool copy_string, bool need_escape);
 
     // Removes escape characters from len characters of the null-terminated string src,

--- a/be/src/vec/exec/file_scanner.cpp
+++ b/be/src/vec/exec/file_scanner.cpp
@@ -190,11 +190,6 @@ Status FileScanner::_fill_columns_from_path(vectorized::Block* _block) {
 
             auto doris_column = _block->get_by_name(slot_desc->col_name()).column;
             IColumn* col_ptr = const_cast<IColumn*>(doris_column.get());
-            if (slot_desc->is_nullable()) {
-                auto* nullable_column = reinterpret_cast<vectorized::ColumnNullable*>(col_ptr);
-                nullable_column->get_null_map_data().push_back(0);
-                col_ptr = &nullable_column->get_nested_column();
-            }
 
             for (size_t j = 0; j < rows; ++j) {
                 _text_converter->write_vec_column(slot_desc, col_ptr,

--- a/be/src/vec/exec/file_text_scanner.cpp
+++ b/be/src/vec/exec/file_text_scanner.cpp
@@ -132,16 +132,6 @@ Status FileTextScanner::_fill_file_columns(const Slice& line, vectorized::Block*
 
         auto doris_column = _block->get_by_name(slot_desc->col_name()).column;
         IColumn* col_ptr = const_cast<IColumn*>(doris_column.get());
-        if (slot_desc->is_nullable()) {
-            auto* nullable_column = reinterpret_cast<vectorized::ColumnNullable*>(col_ptr);
-            nullable_column->get_null_map_data().push_back(0);
-            col_ptr = &nullable_column->get_nested_column();
-        }
-
-        if (value.size == 2 && value.data[0] == '\\' && value[1] == 'N') {
-            col_ptr->insert_default();
-            continue;
-        }
         _text_converter->write_vec_column(slot_desc, col_ptr, value.data, value.size, true, false);
     }
     _rows++;

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/HiveMetaStoreClientHelper.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/HiveMetaStoreClientHelper.java
@@ -624,6 +624,7 @@ public class HiveMetaStoreClientHelper {
             case CHAR:
                 return TypeInfoFactory.charTypeInfo;
             case VARCHAR:
+            case STRING:
                 return TypeInfoFactory.varcharTypeInfo;
             default:
                 throw new DdlException("Unsupported column type: " + dorisType);


### PR DESCRIPTION
# Proposed changes

Issue Number: close #10572

## Problem Summary:
In the funciton `TextConverter::write_vec_column`, it should execute the statement `nullable_column->get_null_map_data().push_back(0);` for every row.
Otherwise the null map will get error and cause the core dump.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
