### PR TITLE
[feature-wip](multi-catalog)(fix) federation query failed

### DIFF
--- a/fe/fe-core/src/main/cup/sql_parser.cup
+++ b/fe/fe-core/src/main/cup/sql_parser.cup
@@ -4156,11 +4156,11 @@ star_expr ::=
     // on IDENT [DOT]
     ident:tbl DOT STAR
     {:
-        RESULT = SelectListItem.createStarItem(new TableName(null, tbl));
+        RESULT = SelectListItem.createStarItem(new TableName(null, null, tbl));
     :}
     | ident:db DOT ident:tbl DOT STAR
     {:
-        RESULT = SelectListItem.createStarItem(new TableName(db, tbl));
+        RESULT = SelectListItem.createStarItem(new TableName(null, db, tbl));
     :}
     | ident:ctl DOT ident:db DOT ident:tbl DOT STAR
     {:
@@ -4180,9 +4180,9 @@ opt_table_name ::=
 
 table_name ::=
     ident:tbl
-    {: RESULT = new TableName(null, tbl); :}
+    {: RESULT = new TableName(null, null, tbl); :}
     | ident:db DOT ident:tbl
-    {: RESULT = new TableName(db, tbl); :}
+    {: RESULT = new TableName(null, db, tbl); :}
     | ident:ctl DOT ident:db DOT ident:tbl
     {: RESULT = new TableName(ctl, db, tbl); :}
     ;
@@ -5311,9 +5311,9 @@ column_ref ::=
   {: RESULT = new SlotRef(null, col); :}
   // table_name:tblName DOT IDENT:col causes reduce/reduce conflicts
   | ident:tbl DOT ident:col
-  {: RESULT = new SlotRef(new TableName(null, tbl), col); :}
+  {: RESULT = new SlotRef(new TableName(null, null, tbl), col); :}
   | ident:db DOT ident:tbl DOT ident:col
-  {: RESULT = new SlotRef(new TableName(db, tbl), col); :}
+  {: RESULT = new SlotRef(new TableName(null, db, tbl), col); :}
   | ident:ctl DOT ident:db DOT ident:tbl DOT ident:col
   {: RESULT = new SlotRef(new TableName(ctl, db, tbl), col); :}
   ;

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/AlterTableStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/AlterTableStmt.java
@@ -47,7 +47,7 @@ public class AlterTableStmt extends DdlStmt {
     }
 
     public void setTableName(String newTableName) {
-        tbl = new TableName(tbl.getDb(), newTableName);
+        tbl = new TableName(tbl.getCtl(), tbl.getDb(), newTableName);
     }
 
     public TableName getTbl() {

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/Analyzer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/Analyzer.java
@@ -680,7 +680,7 @@ public class Analyzer {
         // which may not be the same as the user's reference to the table name, causing the table name not to be found
         // in registerColumnRef(). So here the tblName is constructed using tableName.getTbl()
         // instead of table.getName().
-        TableName tblName = new TableName(tableName.getDb(), tableName.getTbl());
+        TableName tblName = new TableName(tableName.getCtl(), tableName.getDb(), tableName.getTbl());
         if (table instanceof View) {
             return new InlineViewRef((View) table, tableRef);
         } else {

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/BaseTableRef.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/BaseTableRef.java
@@ -40,7 +40,7 @@ public class BaseTableRef extends TableRef {
         if (hasExplicitAlias()) {
             return;
         }
-        aliases = new String[] {name.toString(), tableName.getNoClusterString(), tableName.getTbl()};
+        aliases = tableName.tableAliases();
     }
 
     protected BaseTableRef(BaseTableRef other) {

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateTableStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateTableStmt.java
@@ -242,7 +242,7 @@ public class CreateTableStmt extends DdlStmt {
     }
 
     public void setTableName(String newTableName) {
-        tableName = new TableName(tableName.getDb(), newTableName);
+        tableName = new TableName(tableName.getCtl(), tableName.getDb(), newTableName);
     }
 
     public String getComment() {

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/LateralViewRef.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/LateralViewRef.java
@@ -75,7 +75,7 @@ public class LateralViewRef extends TableRef {
 
         // analyze lateral view
         desc = analyzer.registerTableRef(this);
-        explodeSlotRef = new SlotRef(new TableName(null, viewName), columnName);
+        explodeSlotRef = new SlotRef(new TableName(null, null, viewName), columnName);
         explodeSlotRef.analyze(analyzer);
         isAnalyzed = true;  // true now that we have assigned desc
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/SelectStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/SelectStmt.java
@@ -315,7 +315,8 @@ public class SelectStmt extends QueryStmt {
                     continue;
                 }
                 tblRef.getName().analyze(analyzer);
-                DatabaseIf db = analyzer.getCatalog().getCurrentDataSource().getDbOrAnalysisException(dbName);
+                DatabaseIf db = analyzer.getCatalog().getDataSourceMgr()
+                        .getCatalogOrAnalysisException(tblRef.getName().getCtl()).getDbOrAnalysisException(dbName);
                 TableIf table = db.getTableOrAnalysisException(tableName);
 
                 // check auth

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/SelectStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/SelectStmt.java
@@ -880,7 +880,8 @@ public class SelectStmt extends QueryStmt {
             if (analyzer.isSemiJoined(tableRef.getId())) {
                 continue;
             }
-            expandStar(new TableName(tableRef.getAliasAsName().getDb(),
+            expandStar(new TableName(tableRef.getAliasAsName().getCtl(),
+                            tableRef.getAliasAsName().getDb(),
                             tableRef.getAliasAsName().getTbl()),
                     tableRef.getDesc());
 

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowColumnStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowColumnStmt.java
@@ -22,6 +22,7 @@ import org.apache.doris.catalog.InfoSchemaDb;
 import org.apache.doris.catalog.ScalarType;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.util.Util;
+import org.apache.doris.datasource.InternalDataSource;
 import org.apache.doris.qe.ShowResultSetMetaData;
 
 import com.google.common.base.Strings;
@@ -29,7 +30,8 @@ import com.google.common.collect.Lists;
 
 // SHOW COLUMNS
 public class ShowColumnStmt extends ShowStmt {
-    private static final TableName TABLE_NAME = new TableName(InfoSchemaDb.DATABASE_NAME, "COLUMNS");
+    private static final TableName TABLE_NAME =
+            new TableName(InternalDataSource.INTERNAL_DS_NAME, InfoSchemaDb.DATABASE_NAME, "COLUMNS");
     private static final ShowResultSetMetaData META_DATA =
             ShowResultSetMetaData.builder()
                     .addColumn(new Column("Field", ScalarType.createVarchar(20)))

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowCreateTableStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowCreateTableStmt.java
@@ -23,7 +23,6 @@ import org.apache.doris.catalog.ScalarType;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.ErrorReport;
-import org.apache.doris.common.util.Util;
 import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.ShowResultSetMetaData;
@@ -56,6 +55,10 @@ public class ShowCreateTableStmt extends ShowStmt {
         this.isView = isView;
     }
 
+    public String getCtl() {
+        return tbl.getCtl();
+    }
+
     public String getDb() {
         return tbl.getDb();
     }
@@ -78,8 +81,6 @@ public class ShowCreateTableStmt extends ShowStmt {
             ErrorReport.reportAnalysisException(ErrorCode.ERR_NO_TABLES_USED);
         }
         tbl.analyze(analyzer);
-        // disallow external catalog
-        Util.prohibitExternalCatalog(tbl.getCtl(), this.getClass().getSimpleName());
 
         if (!Catalog.getCurrentCatalog().getAuth().checkTblPriv(ConnectContext.get(), tbl.getDb(), tbl.getTbl(),
                                                                 PrivPredicate.SHOW)) {

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowDbStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowDbStmt.java
@@ -22,13 +22,15 @@ import org.apache.doris.catalog.InfoSchemaDb;
 import org.apache.doris.catalog.ScalarType;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.UserException;
+import org.apache.doris.datasource.InternalDataSource;
 import org.apache.doris.qe.ShowResultSetMetaData;
 
 import com.google.common.collect.Lists;
 
 // Show database statement.
 public class ShowDbStmt extends ShowStmt {
-    private static final TableName TABLE_NAME = new TableName(InfoSchemaDb.DATABASE_NAME, "schemata");
+    private static final TableName TABLE_NAME =
+            new TableName(InternalDataSource.INTERNAL_DS_NAME, InfoSchemaDb.DATABASE_NAME, "schemata");
     private static final String DB_COL = "Database";
     private static final ShowResultSetMetaData META_DATA =
             ShowResultSetMetaData.builder()

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowTableStatusStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowTableStatusStmt.java
@@ -26,6 +26,7 @@ import org.apache.doris.cluster.ClusterNamespace;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.ErrorReport;
+import org.apache.doris.datasource.InternalDataSource;
 import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.ShowResultSetMetaData;
@@ -35,7 +36,8 @@ import com.google.common.collect.Lists;
 
 // SHOW TABLE STATUS
 public class ShowTableStatusStmt extends ShowStmt {
-    private static final TableName TABLE_NAME = new TableName(InfoSchemaDb.DATABASE_NAME, "tables");
+    private static final TableName TABLE_NAME =
+            new TableName(InternalDataSource.INTERNAL_DS_NAME, InfoSchemaDb.DATABASE_NAME, "tables");
     private static final ShowResultSetMetaData META_DATA =
             ShowResultSetMetaData.builder()
                     .addColumn(new Column("Name", ScalarType.createVarchar(64)))

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowTableStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowTableStmt.java
@@ -24,6 +24,7 @@ import org.apache.doris.cluster.ClusterNamespace;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.ErrorReport;
+import org.apache.doris.datasource.InternalDataSource;
 import org.apache.doris.qe.ShowResultSetMetaData;
 
 import com.google.common.base.Strings;
@@ -37,7 +38,8 @@ public class ShowTableStmt extends ShowStmt {
     private static final String NAME_COL_PREFIX = "Tables_in_";
     private static final String TYPE_COL = "Table_type";
     private static final String STORAGE_FORMAT_COL = "StorageFormat";
-    private static final TableName TABLE_NAME = new TableName(InfoSchemaDb.DATABASE_NAME, "tables");
+    private static final TableName TABLE_NAME =
+            new TableName(InternalDataSource.INTERNAL_DS_NAME, InfoSchemaDb.DATABASE_NAME, "tables");
     private String db;
     private boolean isVerbose;
     private String pattern;

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowVariablesStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowVariablesStmt.java
@@ -20,6 +20,7 @@ package org.apache.doris.analysis;
 import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.InfoSchemaDb;
 import org.apache.doris.catalog.ScalarType;
+import org.apache.doris.datasource.InternalDataSource;
 import org.apache.doris.qe.ShowResultSetMetaData;
 
 import com.google.common.collect.Lists;
@@ -82,9 +83,11 @@ public class ShowVariablesStmt extends ShowStmt {
         ExprSubstitutionMap aliasMap = new ExprSubstitutionMap(false);
         TableName tableName = null;
         if (type == SetType.GLOBAL) {
-            tableName = new TableName(InfoSchemaDb.DATABASE_NAME, "GLOBAL_VARIABLES");
+            tableName = new TableName(
+                    InternalDataSource.INTERNAL_DS_NAME, InfoSchemaDb.DATABASE_NAME, "GLOBAL_VARIABLES");
         } else {
-            tableName = new TableName(InfoSchemaDb.DATABASE_NAME, "SESSION_VARIABLES");
+            tableName = new TableName(
+                    InternalDataSource.INTERNAL_DS_NAME, InfoSchemaDb.DATABASE_NAME, "SESSION_VARIABLES");
         }
         // name
         SelectListItem item = new SelectListItem(new SlotRef(tableName, "VARIABLE_NAME"), NAME_COL);

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/StmtRewriter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/StmtRewriter.java
@@ -1108,7 +1108,7 @@ public class StmtRewriter {
             return null;
         }
         // Create a SlotRef from the first item of inlineView's select list
-        SlotRef slotRef = new SlotRef(new TableName(null, inlineView.getAlias()),
+        SlotRef slotRef = new SlotRef(new TableName(null, null, inlineView.getAlias()),
                 inlineView.getColLabels().get(0));
         slotRef.analyze(analyzer);
         Expr subquerySubstitute = slotRef;

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/TableName.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/TableName.java
@@ -63,13 +63,6 @@ public class TableName implements Writable {
         this.tbl = tbl;
     }
 
-    /**
-     * Initialize catalog in analyze.
-     */
-    public TableName(String db, String tbl) {
-        this(null, db, tbl);
-    }
-
     public void analyze(Analyzer analyzer) throws AnalysisException {
         if (Strings.isNullOrEmpty(ctl)) {
             ctl = analyzer.getDefaultCatalog();
@@ -131,17 +124,16 @@ public class TableName implements Writable {
 
     /**
      * Analyzer.registerTableRef task alias of index 1 as the legal implicit alias.
-     * Cluster is deprecated, so we'd better remove cluster in external catalog, and
-     * keep the same in internal catalog.
      */
     public String[] tableAliases() {
         if (ctl == null || ctl.equals(InternalDataSource.INTERNAL_DS_NAME)) {
             return new String[] {toString(), getNoClusterString(), tbl};
         } else {
-            // Three level table aliases: ctl.db.tbl, db.tbl, tbl
             return new String[] {
+                    toString(), // with cluster name
+                    getNoClusterString(), // without cluster name, legal implicit alias
+                    String.format("%s.%s", db, tbl),
                     String.format("%s.%s", ClusterNamespace.getNameFromFullName(db), tbl),
-                    getNoClusterString(), // legal implicit alias
                     tbl
             };
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/TableName.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/TableName.java
@@ -129,8 +129,26 @@ public class TableName implements Writable {
         return Stream.of(ctl, db, tbl).noneMatch(Strings::isNullOrEmpty);
     }
 
+    /**
+     * Analyzer.registerTableRef task alias of index 1 as the legal implicit alias.
+     * Cluster is deprecated, so we'd better remove cluster in external catalog, and
+     * keep the same in internal catalog.
+     */
+    public String[] tableAliases() {
+        if (ctl == null || ctl.equals(InternalDataSource.INTERNAL_DS_NAME)) {
+            return new String[] {toString(), getNoClusterString(), tbl};
+        } else {
+            return new String[] {
+                    String.format("%s.%s", db, tbl),
+                    getNoClusterString(), // legal implicit alias
+                    tbl
+            };
+        }
+    }
+
     public String getNoClusterString() {
-        return Stream.of(ctl, ClusterNamespace.getNameFromFullName(db), tbl)
+        return Stream.of(InternalDataSource.INTERNAL_DS_NAME.equals(ctl) ? null : ctl,
+                        ClusterNamespace.getNameFromFullName(db), tbl)
                 .filter(Objects::nonNull)
                 .collect(Collectors.joining("."));
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/TableName.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/TableName.java
@@ -138,8 +138,9 @@ public class TableName implements Writable {
         if (ctl == null || ctl.equals(InternalDataSource.INTERNAL_DS_NAME)) {
             return new String[] {toString(), getNoClusterString(), tbl};
         } else {
+            // Three level table aliases: ctl.db.tbl, db.tbl, tbl
             return new String[] {
-                    String.format("%s.%s", db, tbl),
+                    String.format("%s.%s", ClusterNamespace.getNameFromFullName(db), tbl),
                     getNoClusterString(), // legal implicit alias
                     tbl
             };

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/TableRef.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/TableRef.java
@@ -697,7 +697,7 @@ public class TableRef implements ParseNode, Writable {
 
     public TableName getAliasAsName() {
         if (hasExplicitAlias()) {
-            return new TableName(null, getUniqueAlias());
+            return new TableName(null, null, getUniqueAlias());
         }
         return name;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/TableValuedFunctionRef.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/TableValuedFunctionRef.java
@@ -29,7 +29,7 @@ public class TableValuedFunctionRef extends TableRef {
     private TableValuedFunctionInf tableFunction;
 
     public TableValuedFunctionRef(String funcName, String alias, List<String> params) throws UserException {
-        super(new TableName(null, "_table_valued_function_" + funcName), alias);
+        super(new TableName(null, null, "_table_valued_function_" + funcName), alias);
         this.tableFunction = TableValuedFunctionInf.getTableFunction(funcName, params);
         if (hasExplicitAlias()) {
             return;

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/TupleDescriptor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/TupleDescriptor.java
@@ -193,7 +193,7 @@ public class TupleDescriptor {
     }
 
     public TableName getAliasAsName() {
-        return (aliases != null) ? new TableName(null, aliases[0]) : null;
+        return (aliases != null) ? new TableName(null, null, aliases[0]) : null;
     }
 
     public TTupleDescriptor toThrift() {

--- a/fe/fe-core/src/main/java/org/apache/doris/backup/BackupHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/backup/BackupHandler.java
@@ -307,7 +307,7 @@ public class BackupHandler extends MasterDaemon implements Writable {
             tblRefs = abstractBackupTableRefClause.getTableRefList();
         } else {
             for (String tableName : tableNames) {
-                TableRef tableRef = new TableRef(new TableName(db.getFullName(), tableName), null);
+                TableRef tableRef = new TableRef(new TableName(null, db.getFullName(), tableName), null);
                 tblRefs.add(tableRef);
             }
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/RefreshManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/RefreshManager.java
@@ -82,7 +82,8 @@ public class RefreshManager {
         // Current database may have other types of table, which is not allowed to drop.
         for (Table table : db.getTables()) {
             if (table instanceof IcebergTable) {
-                DropTableStmt dropTableStmt = new DropTableStmt(true, new TableName(dbName, table.getName()), true);
+                DropTableStmt dropTableStmt =
+                        new DropTableStmt(true, new TableName(null, dbName, table.getName()), true);
                 catalog.dropTable(dropTableStmt);
             }
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/external/ExternalTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/external/ExternalTable.java
@@ -70,6 +70,10 @@ public class ExternalTable implements TableIf {
         this.type = type;
     }
 
+    public boolean isView() {
+        return false;
+    }
+
     @Override
     public void readLock() {
         this.rwLock.readLock().lock();

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/external/HMSExternalTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/external/HMSExternalTable.java
@@ -138,6 +138,11 @@ public class HMSExternalTable extends ExternalTable {
     }
 
     @Override
+    public boolean isView() {
+        return remoteTable.isSetViewOriginalText() || remoteTable.isSetViewExpandedText();
+    }
+
+    @Override
     public List<Column> getFullSchema() {
         makeSureInitialized();
         return fullSchema;

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/PhysicalPlanTranslator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/PhysicalPlanTranslator.java
@@ -185,7 +185,7 @@ public class PhysicalPlanTranslator extends PlanOperatorVisitor<PlanFragment, Pl
         tupleDescriptor.setTable(olapTable);
         OlapScanNode olapScanNode = new OlapScanNode(context.nextNodeId(), tupleDescriptor, olapTable.getName());
         // TODO: Do we really need tableName here?
-        TableName tableName = new TableName("", "");
+        TableName tableName = new TableName(null, "", "");
         TableRef ref = new TableRef(tableName, null, null);
         BaseTableRef tableRef = new BaseTableRef(ref, olapTable, tableName);
         tupleDescriptor.setRef(tableRef);

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/external/ExternalFileScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/external/ExternalFileScanNode.java
@@ -128,6 +128,10 @@ public class ExternalFileScanNode extends ExternalScanNode {
             nextBe = nextBe % backends.size();
             return selectedBackend;
         }
+
+        public int numBackends() {
+            return backends.size();
+        }
     }
 
     private final BackendPolicy backendPolicy = new BackendPolicy();
@@ -177,6 +181,7 @@ public class ExternalFileScanNode extends ExternalScanNode {
                     hmsTable.getDlaType(), hmsTable.getDbName(), hmsTable.getName()));
         }
         backendPolicy.init();
+        numNodes = backendPolicy.numBackends();
         initContext();
     }
 
@@ -242,10 +247,8 @@ public class ExternalFileScanNode extends ExternalScanNode {
         scanRangeLocations = Lists.newArrayList();
         InputSplit[] inputSplits = scanProvider.getSplits(conjuncts);
         if (0 == inputSplits.length) {
-            numNodes = 1;
             return;
         }
-        numNodes = Catalog.getCurrentSystemInfo().getBackendIds(true).size();
 
         String fullPath = ((FileSplit) inputSplits[0]).getPath().toUri().toString();
         String filePath = ((FileSplit) inputSplits[0]).getPath().toUri().getPath();

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/external/ExternalFileScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/external/ExternalFileScanNode.java
@@ -24,6 +24,7 @@ import org.apache.doris.analysis.TupleDescriptor;
 import org.apache.doris.catalog.Catalog;
 import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.external.HMSExternalTable;
+import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.DdlException;
 import org.apache.doris.common.MetaNotFoundException;
@@ -171,6 +172,10 @@ public class ExternalFileScanNode extends ExternalScanNode {
     @Override
     public void init(Analyzer analyzer) throws UserException {
         super.init(analyzer);
+        if (hmsTable.isView()) {
+            throw new AnalysisException(String.format("Querying external view '[%s].%s.%s' is not supported",
+                    hmsTable.getDlaType(), hmsTable.getDbName(), hmsTable.getName()));
+        }
         backendPolicy.init();
         initContext();
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ShowExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ShowExecutor.java
@@ -103,6 +103,7 @@ import org.apache.doris.catalog.DatabaseIf;
 import org.apache.doris.catalog.DynamicPartitionProperty;
 import org.apache.doris.catalog.EncryptKey;
 import org.apache.doris.catalog.Function;
+import org.apache.doris.catalog.HiveMetaStoreClientHelper;
 import org.apache.doris.catalog.Index;
 import org.apache.doris.catalog.MaterializedIndex;
 import org.apache.doris.catalog.MaterializedIndex.IndexExtState;
@@ -115,10 +116,12 @@ import org.apache.doris.catalog.ReplicaAllocation;
 import org.apache.doris.catalog.ScalarType;
 import org.apache.doris.catalog.Table;
 import org.apache.doris.catalog.TableIf;
+import org.apache.doris.catalog.TableIf.TableType;
 import org.apache.doris.catalog.Tablet;
 import org.apache.doris.catalog.TabletInvertedIndex;
 import org.apache.doris.catalog.TabletMeta;
 import org.apache.doris.catalog.View;
+import org.apache.doris.catalog.external.HMSExternalTable;
 import org.apache.doris.clone.DynamicPartitionScheduler;
 import org.apache.doris.cluster.BaseParam;
 import org.apache.doris.cluster.ClusterNamespace;
@@ -186,6 +189,7 @@ import java.io.InputStreamReader;
 import java.net.URL;
 import java.net.URLConnection;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
@@ -817,12 +821,19 @@ public class ShowExecutor {
     // Show create table
     private void handleShowCreateTable() throws AnalysisException {
         ShowCreateTableStmt showStmt = (ShowCreateTableStmt) stmt;
-        DatabaseIf db = ctx.getCurrentDataSource().getDbOrAnalysisException(showStmt.getDb());
+        DatabaseIf db = Catalog.getCurrentCatalog().getDataSourceMgr().getCatalog(showStmt.getCtl())
+                .getDbOrAnalysisException(showStmt.getDb());
         TableIf table = db.getTableOrAnalysisException(showStmt.getTable());
         List<List<String>> rows = Lists.newArrayList();
 
         table.readLock();
         try {
+            if (table.getType() == TableType.HMS_EXTERNAL_TABLE) {
+                rows.add(Arrays.asList(table.getName(),
+                        HiveMetaStoreClientHelper.showCreateTable(((HMSExternalTable) table).getRemoteTable())));
+                resultSet = new ShowResultSet(showStmt.getMetaData(), rows);
+                return;
+            }
             List<String> createTableStmt = Lists.newArrayList();
             Catalog.getDdlStmt(table, createTableStmt, null, null, false, true /* hide password */);
             if (createTableStmt.isEmpty()) {
@@ -841,6 +852,8 @@ public class ShowExecutor {
                 rows.add(Lists.newArrayList(table.getName(), createTableStmt.get(0)));
                 resultSet = new ShowResultSet(showStmt.getMetaData(), rows);
             }
+        } catch (MetaNotFoundException e) {
+            throw new AnalysisException(e.getMessage());
         } finally {
             table.readUnlock();
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ShowExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ShowExecutor.java
@@ -821,7 +821,7 @@ public class ShowExecutor {
     // Show create table
     private void handleShowCreateTable() throws AnalysisException {
         ShowCreateTableStmt showStmt = (ShowCreateTableStmt) stmt;
-        DatabaseIf db = Catalog.getCurrentCatalog().getDataSourceMgr().getCatalog(showStmt.getCtl())
+        DatabaseIf db = ctx.getCatalog().getDataSourceMgr().getCatalog(showStmt.getCtl())
                 .getDbOrAnalysisException(showStmt.getDb());
         TableIf table = db.getTableOrAnalysisException(showStmt.getTable());
         List<List<String>> rows = Lists.newArrayList();

--- a/fe/fe-core/src/test/java/org/apache/doris/alter/RollupJobV2Test.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/alter/RollupJobV2Test.java
@@ -51,6 +51,7 @@ import org.apache.doris.common.FeConstants;
 import org.apache.doris.common.FeMetaVersion;
 import org.apache.doris.common.UserException;
 import org.apache.doris.common.jmockit.Deencapsulation;
+import org.apache.doris.datasource.InternalDataSource;
 import org.apache.doris.meta.MetaContext;
 import org.apache.doris.qe.OriginStatement;
 import org.apache.doris.task.AgentTask;
@@ -335,7 +336,7 @@ public class RollupJobV2Test {
         out.close();
 
         List<Expr> params = Lists.newArrayList();
-        SlotRef param1 = new SlotRef(new TableName(null, "test"), "c1");
+        SlotRef param1 = new SlotRef(new TableName(InternalDataSource.INTERNAL_DS_NAME, null, "test"), "c1");
         params.add(param1);
         MVColumnItem mvColumnItem = new MVColumnItem(mvColumnName, Type.BITMAP);
         mvColumnItem.setDefineExpr(new FunctionCallExpr(new FunctionName("to_bitmap"), params));

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/AlterTableStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/AlterTableStmtTest.java
@@ -19,6 +19,7 @@ package org.apache.doris.analysis;
 
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.UserException;
+import org.apache.doris.datasource.InternalDataSource;
 import org.apache.doris.mysql.privilege.PaloAuth;
 import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.qe.ConnectContext;
@@ -36,6 +37,7 @@ import java.util.Map;
 
 public class AlterTableStmtTest {
     private Analyzer analyzer;
+    private String internalCtl = InternalDataSource.INTERNAL_DS_NAME;
 
     @Mocked
     private PaloAuth auth;
@@ -66,7 +68,7 @@ public class AlterTableStmtTest {
         List<AlterClause> ops = Lists.newArrayList();
         ops.add(new DropColumnClause("col1", "", null));
         ops.add(new DropColumnClause("col2", "", null));
-        AlterTableStmt stmt = new AlterTableStmt(new TableName("testDb", "testTbl"), ops);
+        AlterTableStmt stmt = new AlterTableStmt(new TableName(internalCtl, "testDb", "testTbl"), ops);
         stmt.analyze(analyzer);
         Assert.assertEquals("ALTER TABLE `testCluster:testDb`.`testTbl` DROP COLUMN `col1`, \nDROP COLUMN `col2`",
                 stmt.toSql());
@@ -79,7 +81,7 @@ public class AlterTableStmtTest {
         List<AlterClause> ops = Lists.newArrayList();
         ops.add(new AddRollupClause("index1", Lists.newArrayList("col1", "col2"), null, "testTbl", null));
         ops.add(new AddRollupClause("index2", Lists.newArrayList("col2", "col3"), null, "testTbl", null));
-        AlterTableStmt stmt = new AlterTableStmt(new TableName("testDb", "testTbl"), ops);
+        AlterTableStmt stmt = new AlterTableStmt(new TableName(internalCtl, "testDb", "testTbl"), ops);
         stmt.analyze(analyzer);
         Assert.assertEquals("ALTER TABLE `testCluster:testDb`.`testTbl`"
                         + " ADD ROLLUP `index1` (`col1`, `col2`) FROM `testTbl`, \n"
@@ -102,7 +104,7 @@ public class AlterTableStmtTest {
     @Test(expected = AnalysisException.class)
     public void testNoClause() throws UserException {
         List<AlterClause> ops = Lists.newArrayList();
-        AlterTableStmt stmt = new AlterTableStmt(new TableName("testDb", "testTbl"), ops);
+        AlterTableStmt stmt = new AlterTableStmt(new TableName(internalCtl, "testDb", "testTbl"), ops);
         stmt.analyze(analyzer);
 
         Assert.fail("No exception throws.");
@@ -114,7 +116,7 @@ public class AlterTableStmtTest {
         Map<String, String> properties = Maps.newHashMap();
         properties.put("function_column.sequence_type", "int");
         ops.add(new EnableFeatureClause("sequence_load", properties));
-        AlterTableStmt stmt = new AlterTableStmt(new TableName("testDb", "testTbl"), ops);
+        AlterTableStmt stmt = new AlterTableStmt(new TableName(internalCtl, "testDb", "testTbl"), ops);
         stmt.analyze(analyzer);
 
         Assert.assertEquals("ALTER TABLE `testCluster:testDb`.`testTbl` ENABLE FEATURE \"sequence_load\" WITH PROPERTIES (\"function_column.sequence_type\" = \"int\")",

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/BackupTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/BackupTest.java
@@ -18,6 +18,7 @@
 package org.apache.doris.analysis;
 
 import org.apache.doris.catalog.Catalog;
+import org.apache.doris.datasource.InternalDataSource;
 import org.apache.doris.qe.ConnectContext;
 
 import com.google.common.collect.Lists;
@@ -54,10 +55,10 @@ public class BackupTest {
         BackupStmt stmt;
         List<TableRef> tblRefs = Lists.newArrayList();
         String testDB = "test_db";
-        tblRefs.add(new TableRef(new TableName(null, "table1"), null));
+        tblRefs.add(new TableRef(new TableName(InternalDataSource.INTERNAL_DS_NAME, null, "table1"), null));
         if (caseSensitive) {
             // case sensitive
-            tblRefs.add(new TableRef(new TableName(null, "Table1"), null));
+            tblRefs.add(new TableRef(new TableName(InternalDataSource.INTERNAL_DS_NAME, null, "Table1"), null));
         }
         AbstractBackupTableRefClause tableRefClause = new AbstractBackupTableRefClause(false, tblRefs);
         stmt = new BackupStmt(new LabelName(testDB, "label1"), "repo",

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/CancelAlterStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/CancelAlterStmtTest.java
@@ -23,6 +23,7 @@ import org.apache.doris.catalog.Catalog;
 import org.apache.doris.catalog.FakeCatalog;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.UserException;
+import org.apache.doris.datasource.InternalDataSource;
 import org.apache.doris.qe.ConnectContext;
 
 import mockit.Expectations;
@@ -74,14 +75,14 @@ public class CancelAlterStmtTest {
         fakeCatalog = new FakeCatalog();
         FakeCatalog.setCatalog(catalog);
         // cancel alter column
-        CancelAlterTableStmt stmt = new CancelAlterTableStmt(AlterType.COLUMN, new TableName(null, "testTbl"));
+        CancelAlterTableStmt stmt = new CancelAlterTableStmt(AlterType.COLUMN, new TableName(InternalDataSource.INTERNAL_DS_NAME, null, "testTbl"));
         stmt.analyze(analyzer);
         Assert.assertEquals("CANCEL ALTER COLUMN FROM `testDb`.`testTbl`", stmt.toString());
         Assert.assertEquals("testDb", stmt.getDbName());
         Assert.assertEquals(AlterType.COLUMN, stmt.getAlterType());
         Assert.assertEquals("testTbl", stmt.getTableName());
 
-        stmt = new CancelAlterTableStmt(AlterType.ROLLUP, new TableName(null, "testTbl"));
+        stmt = new CancelAlterTableStmt(AlterType.ROLLUP, new TableName(InternalDataSource.INTERNAL_DS_NAME, null, "testTbl"));
         stmt.analyze(analyzer);
         Assert.assertEquals("CANCEL ALTER ROLLUP FROM `testDb`.`testTbl`", stmt.toString());
         Assert.assertEquals("testDb", stmt.getDbName());

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/ComparisonPredicateTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/ComparisonPredicateTest.java
@@ -21,6 +21,7 @@ import org.apache.doris.catalog.ScalarType;
 import org.apache.doris.catalog.Type;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.jmockit.Deencapsulation;
+import org.apache.doris.datasource.InternalDataSource;
 
 import com.google.common.collect.BoundType;
 import com.google.common.collect.Lists;
@@ -36,6 +37,7 @@ import org.junit.Test;
  * Comparison Predicate unit test.
  */
 public class ComparisonPredicateTest {
+    private static final String internalCtl = InternalDataSource.INTERNAL_DS_NAME;
 
     @Mocked
     Analyzer analyzer;
@@ -116,7 +118,7 @@ public class ComparisonPredicateTest {
 
     @Test
     public void testConvertToRange() {
-        SlotRef slotRef = new SlotRef(new TableName("db1", "tb1"), "k1");
+        SlotRef slotRef = new SlotRef(new TableName(internalCtl, "db1", "tb1"), "k1");
         LiteralExpr literalExpr = new IntLiteral(1);
         BinaryPredicate binaryPredicate = new BinaryPredicate(BinaryPredicate.Operator.LE, slotRef, literalExpr);
         Range<LiteralExpr> range = binaryPredicate.convertToRange();
@@ -127,7 +129,7 @@ public class ComparisonPredicateTest {
 
     @Test
     public void testConvertToRangeForDateV2() {
-        SlotRef slotRef = new SlotRef(new TableName("db1", "tb1"), "k1");
+        SlotRef slotRef = new SlotRef(new TableName(internalCtl, "db1", "tb1"), "k1");
         LiteralExpr dateExpr = new DateLiteral(2022, 5, 19, Type.DATE);
         LiteralExpr dateV2Expr = new DateLiteral(2022, 5, 19, Type.DATEV2);
         BinaryPredicate binaryPredicate1 = new BinaryPredicate(BinaryPredicate.Operator.LE, slotRef, dateExpr);
@@ -146,7 +148,7 @@ public class ComparisonPredicateTest {
 
     @Test
     public void testConvertToRangeForDateTimeV2() {
-        SlotRef slotRef = new SlotRef(new TableName("db1", "tb1"), "k1");
+        SlotRef slotRef = new SlotRef(new TableName(internalCtl, "db1", "tb1"), "k1");
         LiteralExpr dateTimeExpr = new DateLiteral(2022, 5, 19, 0, 0, 0, Type.DATETIME);
         LiteralExpr dateTimeV2Expr1 = new DateLiteral(2022, 5, 19, 0, 0, 0, Type.DEFAULT_DATETIMEV2);
         LiteralExpr dateTimeV2Expr2 = new DateLiteral(2022, 5, 19, 0, 0, 0, ScalarType.createDatetimeV2Type(6));

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/CreateIndexClauseTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/CreateIndexClauseTest.java
@@ -18,6 +18,7 @@
 package org.apache.doris.analysis;
 
 import org.apache.doris.common.AnalysisException;
+import org.apache.doris.datasource.InternalDataSource;
 
 import com.google.common.collect.Lists;
 import org.junit.Assert;
@@ -34,7 +35,7 @@ public class CreateIndexClauseTest {
 
     @Test
     public void testNormal() throws AnalysisException {
-        CreateIndexClause clause = new CreateIndexClause(new TableName("db", "table"), new IndexDef("index1", false,
+        CreateIndexClause clause = new CreateIndexClause(new TableName(InternalDataSource.INTERNAL_DS_NAME, "db", "table"), new IndexDef("index1", false,
                 Lists.newArrayList("col1"), IndexDef.IndexType.BITMAP, "balabala"), false);
         clause.analyze(analyzer);
         Assert.assertEquals("CREATE INDEX index1 ON `db`.`table` (`col1`) USING BITMAP COMMENT 'balabala'",
@@ -44,7 +45,7 @@ public class CreateIndexClauseTest {
 
     @Test(expected = AnalysisException.class)
     public void testDuplIndex() throws AnalysisException {
-        CreateIndexClause clause = new CreateIndexClause(new TableName("db", "table"), null, false);
+        CreateIndexClause clause = new CreateIndexClause(new TableName(InternalDataSource.INTERNAL_DS_NAME, "db", "table"), null, false);
         clause.analyze(analyzer);
 
     }

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/CreateMaterializedViewStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/CreateMaterializedViewStmtTest.java
@@ -29,6 +29,7 @@ import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.UserException;
 import org.apache.doris.common.jmockit.Deencapsulation;
+import org.apache.doris.datasource.InternalDataSource;
 import org.apache.doris.qe.ConnectContext;
 
 import com.google.common.collect.Lists;
@@ -43,6 +44,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class CreateMaterializedViewStmtTest {
+    private static final String internalCtl = InternalDataSource.INTERNAL_DS_NAME;
 
     @Mocked
     private Analyzer analyzer;
@@ -90,7 +92,7 @@ public class CreateMaterializedViewStmtTest {
         SelectListItem selectListItem = new SelectListItem(slotRef, null);
         selectList.addItem(selectListItem);
 
-        TableName tableName = new TableName("db", "table");
+        TableName tableName = new TableName(internalCtl, "db", "table");
         SlotRef slotRef2 = new SlotRef(tableName, "v1");
         List<Expr> fnChildren = Lists.newArrayList(slotRef2);
         Deencapsulation.setField(slotRef2, "desc", slotDescriptor);
@@ -329,7 +331,7 @@ public class CreateMaterializedViewStmtTest {
         SelectList selectList = new SelectList();
         SelectListItem selectListItem1 = new SelectListItem(slotRef1, null);
         selectList.addItem(selectListItem1);
-        TableName tableName = new TableName("db", "table");
+        TableName tableName = new TableName(internalCtl, "db", "table");
         SlotRef slotRef2 = new SlotRef(tableName, "v1");
         Deencapsulation.setField(slotRef2, "desc", slotDescriptor);
         List<Expr> fnChildren = Lists.newArrayList(slotRef2);
@@ -376,7 +378,7 @@ public class CreateMaterializedViewStmtTest {
     @Test
     public void testDuplicateColumn(@Injectable SelectStmt selectStmt, @Injectable AggregateFunction aggregateFunction) throws UserException {
         SelectList selectList = new SelectList();
-        TableName tableName = new TableName("db", "table");
+        TableName tableName = new TableName(internalCtl, "db", "table");
         SlotRef slotRef1 = new SlotRef(tableName, "k1");
         SelectListItem selectListItem1 = new SelectListItem(slotRef1, null);
         selectList.addItem(selectListItem1);
@@ -413,7 +415,7 @@ public class CreateMaterializedViewStmtTest {
         SelectList selectList = new SelectList();
         SelectListItem selectListItem1 = new SelectListItem(slotRef1, null);
         selectList.addItem(selectListItem1);
-        TableName tableName = new TableName("db", "table");
+        TableName tableName = new TableName(internalCtl, "db", "table");
         SlotRef slotRef2 = new SlotRef(tableName, "k2");
         Deencapsulation.setField(slotRef2, "desc", slotDescriptor);
         List<Expr> fn1Children = Lists.newArrayList(slotRef2);
@@ -463,7 +465,7 @@ public class CreateMaterializedViewStmtTest {
         selectList.addItem(selectListItem1);
         SelectListItem selectListItem2 = new SelectListItem(slotRef2, null);
         selectList.addItem(selectListItem2);
-        TableName tableName = new TableName("db", "table");
+        TableName tableName = new TableName(internalCtl, "db", "table");
         SlotRef functionChild0 = new SlotRef(tableName, "v1");
         Deencapsulation.setField(functionChild0, "desc", slotDescriptor);
         List<Expr> fn1Children = Lists.newArrayList(functionChild0);
@@ -528,7 +530,7 @@ public class CreateMaterializedViewStmtTest {
         selectList.addItem(selectListItem3);
         SelectListItem selectListItem4 = new SelectListItem(slotRef4, null);
         selectList.addItem(selectListItem4);
-        TableName tableName = new TableName("db", "table");
+        TableName tableName = new TableName(internalCtl, "db", "table");
         final String columnName5 = "sum_v2";
         SlotRef functionChild0 = new SlotRef(tableName, columnName5);
         Deencapsulation.setField(functionChild0, "desc", slotDescriptor);
@@ -1024,7 +1026,7 @@ public class CreateMaterializedViewStmtTest {
         selectList.addItem(selectListItem1);
         SelectListItem selectListItem2 = new SelectListItem(slotRef2, null);
         selectList.addItem(selectListItem2);
-        TableName tableName = new TableName("db", "table");
+        TableName tableName = new TableName(internalCtl, "db", "table");
         final String columnName3 = "sum_v2";
         SlotRef slotRef = new SlotRef(tableName, columnName3);
         Deencapsulation.setField(slotRef, "desc", slotDescriptor);
@@ -1152,7 +1154,7 @@ public class CreateMaterializedViewStmtTest {
                                       @Injectable SlotDescriptor slotDescriptor3,
                                       @Injectable SlotDescriptor slotDescriptor4) {
         CreateMaterializedViewStmt createMaterializedViewStmt = new CreateMaterializedViewStmt("test", selectStmt, null);
-        SlotRef slotRef = new SlotRef(new TableName("db", "table"), "a");
+        SlotRef slotRef = new SlotRef(new TableName(internalCtl, "db", "table"), "a");
         List<Expr> params = Lists.newArrayList();
         params.add(slotRef);
         FunctionCallExpr functionCallExpr = new FunctionCallExpr("sum", params);
@@ -1168,7 +1170,7 @@ public class CreateMaterializedViewStmtTest {
         MVColumnItem mvColumnItem = Deencapsulation.invoke(createMaterializedViewStmt, "buildMVColumnItem", functionCallExpr);
         Assert.assertEquals(Type.LARGEINT, mvColumnItem.getType());
 
-        SlotRef slotRef2 = new SlotRef(new TableName("db", "table"), "a");
+        SlotRef slotRef2 = new SlotRef(new TableName(internalCtl, "db", "table"), "a");
         List<Expr> params2 = Lists.newArrayList();
         params2.add(slotRef2);
         FunctionCallExpr functionCallExpr2 = new FunctionCallExpr("sum", params2);
@@ -1184,7 +1186,7 @@ public class CreateMaterializedViewStmtTest {
         MVColumnItem mvColumnItem2 = Deencapsulation.invoke(createMaterializedViewStmt, "buildMVColumnItem", functionCallExpr2);
         Assert.assertEquals(Type.BIGINT, mvColumnItem2.getType());
 
-        SlotRef slotRef3 = new SlotRef(new TableName("db", "table"), "a");
+        SlotRef slotRef3 = new SlotRef(new TableName(internalCtl, "db", "table"), "a");
         List<Expr> params3 = Lists.newArrayList();
         params3.add(slotRef3);
         FunctionCallExpr functionCallExpr3 = new FunctionCallExpr("min", params3);
@@ -1200,7 +1202,7 @@ public class CreateMaterializedViewStmtTest {
         MVColumnItem mvColumnItem3 = Deencapsulation.invoke(createMaterializedViewStmt, "buildMVColumnItem", functionCallExpr3);
         Assert.assertEquals(Type.VARCHAR, mvColumnItem3.getType());
 
-        SlotRef slotRef4 = new SlotRef(new TableName("db", "table"), "a");
+        SlotRef slotRef4 = new SlotRef(new TableName(internalCtl, "db", "table"), "a");
         List<Expr> params4 = Lists.newArrayList();
         params4.add(slotRef4);
         FunctionCallExpr functionCallExpr4 = new FunctionCallExpr("sum", params4);
@@ -1227,7 +1229,7 @@ public class CreateMaterializedViewStmtTest {
                                                 @Injectable SlotDescriptor slotDescriptor3,
                                                 @Injectable Column column3) {
         CreateMaterializedViewStmt createMaterializedViewStmt = new CreateMaterializedViewStmt("test", selectStmt, null);
-        SlotRef slotRef = new SlotRef(new TableName("db", "table"), "a");
+        SlotRef slotRef = new SlotRef(new TableName(internalCtl, "db", "table"), "a");
         List<Expr> params = Lists.newArrayList();
         params.add(slotRef);
         FunctionCallExpr functionCallExpr = new FunctionCallExpr("min", params);
@@ -1243,7 +1245,7 @@ public class CreateMaterializedViewStmtTest {
         MVColumnItem mvColumnItem = Deencapsulation.invoke(createMaterializedViewStmt, "buildMVColumnItem", functionCallExpr);
         Assert.assertEquals(50, mvColumnItem.getType().getLength());
 
-        SlotRef slotRef2 = new SlotRef(new TableName("db", "table"), "a");
+        SlotRef slotRef2 = new SlotRef(new TableName(internalCtl, "db", "table"), "a");
         List<Expr> params2 = Lists.newArrayList();
         params2.add(slotRef2);
         FunctionCallExpr functionCallExpr2 = new FunctionCallExpr("min", params2);
@@ -1260,7 +1262,7 @@ public class CreateMaterializedViewStmtTest {
         Assert.assertEquals(new Integer(10), mvColumnItem2.getType().getPrecision());
         Assert.assertEquals(1, ((ScalarType) mvColumnItem2.getType()).getScalarScale());
 
-        SlotRef slotRef3 = new SlotRef(new TableName("db", "table"), "a");
+        SlotRef slotRef3 = new SlotRef(new TableName(internalCtl, "db", "table"), "a");
         List<Expr> params3 = Lists.newArrayList();
         params3.add(slotRef3);
         FunctionCallExpr functionCallExpr3 = new FunctionCallExpr("min", params3);

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/CreateTableAsSelectStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/CreateTableAsSelectStmtTest.java
@@ -20,6 +20,7 @@ package org.apache.doris.analysis;
 import org.apache.doris.catalog.Catalog;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.ExceptionChecker;
+import org.apache.doris.datasource.InternalDataSource;
 import org.apache.doris.metric.MetricRepo;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.ShowExecutor;
@@ -109,7 +110,7 @@ public class CreateTableAsSelectStmtTest {
     }
 
     private static ShowResultSet showCreateTable(String tableName) throws Exception {
-        ShowCreateTableStmt stmt = new ShowCreateTableStmt(new TableName("test", tableName));
+        ShowCreateTableStmt stmt = new ShowCreateTableStmt(new TableName(InternalDataSource.INTERNAL_DS_NAME, "test", tableName));
         Analyzer dummyRootAnalyzer = new Analyzer(Catalog.getCurrentCatalog(), connectContext);
         stmt.analyze(dummyRootAnalyzer);
         ShowExecutor executor = new ShowExecutor(connectContext, stmt);

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/CreateTableStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/CreateTableStmtTest.java
@@ -23,6 +23,7 @@ import org.apache.doris.catalog.PrimitiveType;
 import org.apache.doris.catalog.ScalarType;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.UserException;
+import org.apache.doris.datasource.InternalDataSource;
 import org.apache.doris.mysql.privilege.MockedAuth;
 import org.apache.doris.mysql.privilege.PaloAuth;
 import org.apache.doris.qe.ConnectContext;
@@ -69,8 +70,8 @@ public class CreateTableStmtTest {
         // analyzer
         analyzer = AccessTestUtil.fetchAdminAnalyzer(false);
         // table name
-        tblName = new TableName("db1", "table1");
-        tblNameNoDb = new TableName("", "table1");
+        tblName = new TableName(InternalDataSource.INTERNAL_DS_NAME, "db1", "table1");
+        tblNameNoDb = new TableName(InternalDataSource.INTERNAL_DS_NAME, "", "table1");
         // col
         cols = Lists.newArrayList();
         cols.add(new ColumnDef("col1", new TypeDef(ScalarType.createType(PrimitiveType.INT))));

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/DeleteStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/DeleteStmtTest.java
@@ -20,6 +20,7 @@ package org.apache.doris.analysis;
 
 import org.apache.doris.analysis.BinaryPredicate.Operator;
 import org.apache.doris.common.UserException;
+import org.apache.doris.datasource.InternalDataSource;
 import org.apache.doris.mysql.privilege.MockedAuth;
 import org.apache.doris.mysql.privilege.PaloAuth;
 import org.apache.doris.qe.ConnectContext;
@@ -33,6 +34,7 @@ import org.junit.Test;
 import java.util.List;
 
 public class DeleteStmtTest {
+    private static final String internalCtl = InternalDataSource.INTERNAL_DS_NAME;
 
     Analyzer analyzer;
 
@@ -52,7 +54,7 @@ public class DeleteStmtTest {
     public void getMethodTest() {
         BinaryPredicate wherePredicate = new BinaryPredicate(Operator.EQ, new SlotRef(null, "k1"),
                                                              new StringLiteral("abc"));
-        DeleteStmt deleteStmt = new DeleteStmt(new TableName("testDb", "testTbl"),
+        DeleteStmt deleteStmt = new DeleteStmt(new TableName(internalCtl, "testDb", "testTbl"),
                 new PartitionNames(false, Lists.newArrayList("partition")), wherePredicate);
 
         Assert.assertEquals("testDb", deleteStmt.getDbName());
@@ -61,7 +63,7 @@ public class DeleteStmtTest {
         Assert.assertEquals("DELETE FROM `testDb`.`testTbl` PARTITION (partition) WHERE `k1` = 'abc'",
                             deleteStmt.toSql());
 
-        deleteStmt = new DeleteStmt(new TableName("testDb", "testTbl"), null, wherePredicate);
+        deleteStmt = new DeleteStmt(new TableName(internalCtl, "testDb", "testTbl"), null, wherePredicate);
         Assert.assertEquals("DELETE FROM `testDb`.`testTbl` WHERE `k1` = 'abc'",
                 deleteStmt.toSql());
     }
@@ -72,7 +74,7 @@ public class DeleteStmtTest {
         LikePredicate likePredicate = new LikePredicate(org.apache.doris.analysis.LikePredicate.Operator.LIKE,
                                                         new SlotRef(null, "k1"),
                                                         new StringLiteral("abc"));
-        DeleteStmt deleteStmt = new DeleteStmt(new TableName("testDb", "testTbl"),
+        DeleteStmt deleteStmt = new DeleteStmt(new TableName(internalCtl, "testDb", "testTbl"),
                 new PartitionNames(false, Lists.newArrayList("partition")), likePredicate);
         try {
             deleteStmt.analyze(analyzer);
@@ -87,7 +89,7 @@ public class DeleteStmtTest {
                 new CompoundPredicate(org.apache.doris.analysis.CompoundPredicate.Operator.OR, binaryPredicate,
                                       binaryPredicate);
 
-        deleteStmt = new DeleteStmt(new TableName("testDb", "testTbl"),
+        deleteStmt = new DeleteStmt(new TableName(internalCtl, "testDb", "testTbl"),
                 new PartitionNames(false, Lists.newArrayList("partition")), compoundPredicate);
 
         try {
@@ -101,7 +103,7 @@ public class DeleteStmtTest {
                                                   binaryPredicate,
                                                   likePredicate);
 
-        deleteStmt = new DeleteStmt(new TableName("testDb", "testTbl"),
+        deleteStmt = new DeleteStmt(new TableName(internalCtl, "testDb", "testTbl"),
                 new PartitionNames(false, Lists.newArrayList("partition")), compoundPredicate);
         try {
             deleteStmt.analyze(analyzer);
@@ -116,7 +118,7 @@ public class DeleteStmtTest {
                                                   binaryPredicate,
                                                   binaryPredicate);
 
-        deleteStmt = new DeleteStmt(new TableName("testDb", "testTbl"),
+        deleteStmt = new DeleteStmt(new TableName(internalCtl, "testDb", "testTbl"),
                 new PartitionNames(false, Lists.newArrayList("partition")), compoundPredicate);
         try {
             deleteStmt.analyze(analyzer);
@@ -131,7 +133,7 @@ public class DeleteStmtTest {
                                                   binaryPredicate,
                                                   binaryPredicate);
 
-        deleteStmt = new DeleteStmt(new TableName("testDb", "testTbl"),
+        deleteStmt = new DeleteStmt(new TableName(internalCtl, "testDb", "testTbl"),
                 new PartitionNames(false, Lists.newArrayList("partition")), compoundPredicate);
         try {
             deleteStmt.analyze(analyzer);
@@ -145,7 +147,7 @@ public class DeleteStmtTest {
                                                   binaryPredicate,
                                                   binaryPredicate);
 
-        deleteStmt = new DeleteStmt(new TableName("testDb", "testTbl"), null, compoundPredicate);
+        deleteStmt = new DeleteStmt(new TableName(internalCtl, "testDb", "testTbl"), null, compoundPredicate);
         try {
             deleteStmt.analyze(analyzer);
         } catch (UserException e) {
@@ -170,7 +172,7 @@ public class DeleteStmtTest {
                                                   binaryPredicate,
                                                   compoundPredicate2);
 
-        deleteStmt = new DeleteStmt(new TableName("testDb", "testTbl"),
+        deleteStmt = new DeleteStmt(new TableName(internalCtl, "testDb", "testTbl"),
                 new PartitionNames(false, Lists.newArrayList("partition")), compoundPredicate);
         try {
             deleteStmt.analyze(analyzer);
@@ -179,7 +181,7 @@ public class DeleteStmtTest {
         }
 
         // multi partition
-        deleteStmt = new DeleteStmt(new TableName("testDb", "testTbl"),
+        deleteStmt = new DeleteStmt(new TableName(internalCtl, "testDb", "testTbl"),
                 new PartitionNames(false, Lists.newArrayList("partition1", "partiton2")), compoundPredicate);
         try {
             deleteStmt.analyze(analyzer);
@@ -189,7 +191,7 @@ public class DeleteStmtTest {
         }
 
         // no partition
-        deleteStmt = new DeleteStmt(new TableName("testDb", "testTbl"), null, compoundPredicate);
+        deleteStmt = new DeleteStmt(new TableName(internalCtl, "testDb", "testTbl"), null, compoundPredicate);
         try {
             deleteStmt.analyze(analyzer);
             Assert.assertEquals(Lists.newArrayList(), deleteStmt.getPartitionNames());

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/DropIndexClauseTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/DropIndexClauseTest.java
@@ -19,6 +19,7 @@ package org.apache.doris.analysis;
 
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.UserException;
+import org.apache.doris.datasource.InternalDataSource;
 
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -35,14 +36,14 @@ public class DropIndexClauseTest {
 
     @Test
     public void testNormal() throws UserException {
-        DropIndexClause clause = new DropIndexClause("index1", false, new TableName("db", "table"), false);
+        DropIndexClause clause = new DropIndexClause("index1", false, new TableName(InternalDataSource.INTERNAL_DS_NAME, "db", "table"), false);
         clause.analyze(analyzer);
         Assert.assertEquals("DROP INDEX index1 ON `db`.`table`", clause.toSql());
     }
 
     @Test(expected = AnalysisException.class)
     public void testNoIndex() throws UserException {
-        DropIndexClause clause = new DropIndexClause("", false, new TableName("db", "table"), false);
+        DropIndexClause clause = new DropIndexClause("", false, new TableName(InternalDataSource.INTERNAL_DS_NAME, "db", "table"), false);
         clause.analyze(analyzer);
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/DropTableStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/DropTableStmtTest.java
@@ -31,6 +31,8 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class DropTableStmtTest {
+    private static final String internalCtl = InternalDataSource.INTERNAL_DS_NAME;
+
     private TableName tbl;
     private TableName noDbTbl;
     private Analyzer analyzer;
@@ -44,8 +46,8 @@ public class DropTableStmtTest {
 
     @Before
     public void setUp() {
-        tbl = new TableName("db1", "table1");
-        noDbTbl = new TableName("", "table1");
+        tbl = new TableName(internalCtl, "db1", "table1");
+        noDbTbl = new TableName(internalCtl, "", "table1");
         analyzer = AccessTestUtil.fetchAdminAnalyzer(true);
 
         new Expectations() {
@@ -95,7 +97,7 @@ public class DropTableStmtTest {
 
     @Test(expected = AnalysisException.class)
     public void testNoTableFail() throws UserException, AnalysisException {
-        DropTableStmt stmt = new DropTableStmt(false, new TableName("db1", ""), true);
+        DropTableStmt stmt = new DropTableStmt(false, new TableName(internalCtl, "db1", ""), true);
         stmt.analyze(noDbAnalyzer);
         Assert.fail("No Exception throws.");
     }

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/ExprTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/ExprTest.java
@@ -22,6 +22,7 @@ import org.apache.doris.catalog.Table;
 import org.apache.doris.catalog.Type;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.jmockit.Deencapsulation;
+import org.apache.doris.datasource.InternalDataSource;
 
 import com.google.common.collect.Maps;
 import mockit.Expectations;
@@ -36,6 +37,7 @@ import java.util.Map;
 import java.util.Set;
 
 public class ExprTest {
+    private static final String internalCtl = InternalDataSource.INTERNAL_DS_NAME;
 
     @Test
     public void testGetTableNameToColumnNames(@Mocked Analyzer analyzer,
@@ -45,8 +47,8 @@ public class ExprTest {
                                               @Injectable TupleDescriptor tupleDescriptor2,
                                               @Injectable Table tableA,
                                               @Injectable Table tableB) throws AnalysisException {
-        TableName tableAName = new TableName("test", "tableA");
-        TableName tableBName = new TableName("test", "tableB");
+        TableName tableAName = new TableName(internalCtl, "test", "tableA");
+        TableName tableBName = new TableName(internalCtl, "test", "tableB");
         SlotRef tableAColumn1 = new SlotRef(tableAName, "c1");
         SlotRef tableBColumn1 = new SlotRef(tableBName, "c1");
         Expr whereExpr = new BinaryPredicate(BinaryPredicate.Operator.EQ, tableAColumn1, tableBColumn1);
@@ -198,7 +200,7 @@ public class ExprTest {
 
     @Test
     public void testSrcSlotRef(@Injectable SlotDescriptor slotDescriptor) {
-        TableName tableName = new TableName("db1", "table1");
+        TableName tableName = new TableName(internalCtl, "db1", "table1");
         SlotRef slotRef = new SlotRef(tableName, "c1");
         slotRef.setDesc(slotDescriptor);
         Deencapsulation.setField(slotRef, "isAnalyzed", true);

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/GroupByClauseTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/GroupByClauseTest.java
@@ -18,6 +18,7 @@
 package org.apache.doris.analysis;
 
 import org.apache.doris.common.AnalysisException;
+import org.apache.doris.datasource.InternalDataSource;
 
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Multimap;
@@ -34,6 +35,7 @@ import java.util.List;
 import java.util.Set;
 
 public class GroupByClauseTest {
+    private static final String internalCtl = InternalDataSource.INTERNAL_DS_NAME;
 
     private Analyzer analyzer;
 
@@ -46,7 +48,7 @@ public class GroupByClauseTest {
             f.setAccessible(true);
             Multimap<String, TupleDescriptor> tupleByAlias = ArrayListMultimap.create();
             TupleDescriptor td = new TupleDescriptor(new TupleId(0));
-            td.setTable(analyzerBase.getTableOrAnalysisException(new TableName("testdb", "t")));
+            td.setTable(analyzerBase.getTableOrAnalysisException(new TableName(internalCtl, "testdb", "t")));
             tupleByAlias.put("testdb.t", td);
             f.set(analyzer, tupleByAlias);
         } catch (NoSuchFieldException e) {
@@ -70,13 +72,13 @@ public class GroupByClauseTest {
         for (String[] colsList : colsLists) {
             ArrayList<Expr> exprList = new ArrayList<>();
             for (String col : colsList) {
-                exprList.add(new SlotRef(new TableName("testdb", "t"), col));
+                exprList.add(new SlotRef(new TableName(internalCtl, "testdb", "t"), col));
             }
             groupingExprsList.add(exprList);
         }
         String[] groupByCols = {"k1", "k2", "k3", "k4"};
         for (String col : groupByCols) {
-            groupByExprs.add(new SlotRef(new TableName("testdb", "t"), col));
+            groupByExprs.add(new SlotRef(new TableName(internalCtl, "testdb", "t"), col));
         }
         GroupByClause groupByClause = new GroupByClause(groupingExprsList,
                 GroupByClause.GroupingType.GROUPING_SETS);
@@ -113,7 +115,7 @@ public class GroupByClauseTest {
         ArrayList<Expr> groupingExprs = new ArrayList<>();
         String[] cols = {"k2", "k3", "k4", "k3"};
         for (String col : cols) {
-            Expr expr = new SlotRef(new TableName("testdb", "t"), col);
+            Expr expr = new SlotRef(new TableName(internalCtl, "testdb", "t"), col);
             groupingExprs.add(expr);
         }
 
@@ -151,7 +153,7 @@ public class GroupByClauseTest {
         ArrayList<Expr> groupingExprs = new ArrayList<>();
         String[] cols = {"k1", "k2", "k3", "k1"};
         for (String col : cols) {
-            Expr expr = new SlotRef(new TableName("testdb", "t"), col);
+            Expr expr = new SlotRef(new TableName(internalCtl, "testdb", "t"), col);
             groupingExprs.add(expr);
         }
 
@@ -189,7 +191,7 @@ public class GroupByClauseTest {
         ArrayList<Expr> groupingExprs = new ArrayList<>();
         String[] cols = {"k2", "k2", "k3", "k1"};
         for (String col : cols) {
-            Expr expr = new SlotRef(new TableName("testdb", "t"), col);
+            Expr expr = new SlotRef(new TableName(internalCtl, "testdb", "t"), col);
             groupingExprs.add(expr);
         }
 
@@ -211,7 +213,7 @@ public class GroupByClauseTest {
         ArrayList<Expr> groupingExprs = new ArrayList<>();
         String[] cols = {"k2", "k2", "k3", "k1"};
         for (String col : cols) {
-            Expr expr = new SlotRef(new TableName("testdb", "t"), col);
+            Expr expr = new SlotRef(new TableName(internalCtl, "testdb", "t"), col);
             groupingExprs.add(expr);
         }
 
@@ -234,7 +236,7 @@ public class GroupByClauseTest {
         ArrayList<Expr> groupingExprs = new ArrayList<>();
         String[] cols = {"k1", "k2", "k3", "k1"};
         for (String col : cols) {
-            Expr expr = new SlotRef(new TableName("testdb", "t"), col);
+            Expr expr = new SlotRef(new TableName(internalCtl, "testdb", "t"), col);
             groupingExprs.add(expr);
         }
         GroupByClause groupByClause = new GroupByClause(Expr.cloneList(groupingExprs),
@@ -252,7 +254,7 @@ public class GroupByClauseTest {
         ArrayList<Expr> groupingExprs = new ArrayList<>();
         String[] cols = {"k1", "k2", "k3"};
         for (String col : cols) {
-            Expr expr = new SlotRef(new TableName("testdb", "t"), col);
+            Expr expr = new SlotRef(new TableName(internalCtl, "testdb", "t"), col);
             groupingExprs.add(expr);
         }
 
@@ -260,7 +262,7 @@ public class GroupByClauseTest {
                 GroupByClause.GroupingType.CUBE);
         List<Expr> slots = new ArrayList<>();
         for (String col : cols) {
-            SlotRef expr = new SlotRef(new TableName("testdb", "t"), col);
+            SlotRef expr = new SlotRef(new TableName(internalCtl, "testdb", "t"), col);
             slots.add(expr);
         }
         GroupingInfo groupingInfo = null;

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/InPredicateTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/InPredicateTest.java
@@ -19,6 +19,7 @@ package org.apache.doris.analysis;
 
 import org.apache.doris.catalog.Type;
 import org.apache.doris.common.AnalysisException;
+import org.apache.doris.datasource.InternalDataSource;
 
 import com.google.common.collect.Lists;
 import org.junit.Assert;
@@ -27,6 +28,7 @@ import org.junit.Test;
 import java.util.List;
 
 public class InPredicateTest {
+    private static final String internalCtl = InternalDataSource.INTERNAL_DS_NAME;
 
     /*
     InPredicate1: k1 in (1,2)
@@ -35,7 +37,7 @@ public class InPredicateTest {
      */
     @Test
     public void testIntersection() throws AnalysisException {
-        SlotRef slotRef1 = new SlotRef(new TableName("db1", "tb1"), "k1");
+        SlotRef slotRef1 = new SlotRef(new TableName(internalCtl, "db1", "tb1"), "k1");
         LiteralExpr literalChild1 = new IntLiteral(1);
         LiteralExpr literalChild2 = new IntLiteral(2);
         List<Expr> literalChildren1 = Lists.newArrayList();
@@ -43,7 +45,7 @@ public class InPredicateTest {
         literalChildren1.add(literalChild2);
         InPredicate inPredicate1 = new InPredicate(slotRef1, literalChildren1, false);
 
-        SlotRef slotRef2 = new SlotRef(new TableName("db1", "tb1"), "k1");
+        SlotRef slotRef2 = new SlotRef(new TableName(internalCtl, "db1", "tb1"), "k1");
         LiteralExpr literalChild3 = new LargeIntLiteral("2");
         LiteralExpr literalChild4 = new LargeIntLiteral("3");
         List<Expr> literalChildren2 = Lists.newArrayList();
@@ -76,7 +78,7 @@ public class InPredicateTest {
      */
     @Test
     public void testUnion() throws AnalysisException {
-        SlotRef slotRef1 = new SlotRef(new TableName("db1", "tb1"), "k1");
+        SlotRef slotRef1 = new SlotRef(new TableName(internalCtl, "db1", "tb1"), "k1");
         LiteralExpr literalChild1 = new IntLiteral(1);
         LiteralExpr literalChild2 = new IntLiteral(2);
         List<Expr> literalChildren1 = Lists.newArrayList();
@@ -84,7 +86,7 @@ public class InPredicateTest {
         literalChildren1.add(literalChild2);
         InPredicate inPredicate1 = new InPredicate(slotRef1, literalChildren1, false);
 
-        SlotRef slotRef2 = new SlotRef(new TableName("db1", "tb1"), "k1");
+        SlotRef slotRef2 = new SlotRef(new TableName(internalCtl, "db1", "tb1"), "k1");
         LiteralExpr literalChild3 = new LargeIntLiteral("1");
         List<Expr> literalChildren2 = Lists.newArrayList();
         literalChildren2.add(literalChild3);
@@ -110,7 +112,7 @@ public class InPredicateTest {
 
     @Test
     public void testIntersectionWithDateV2() throws AnalysisException {
-        SlotRef slotRef1 = new SlotRef(new TableName("db1", "tb1"), "k1");
+        SlotRef slotRef1 = new SlotRef(new TableName(internalCtl, "db1", "tb1"), "k1");
         LiteralExpr literalChild1 = new DateLiteral(2022, 5, 19, Type.DATE);
         LiteralExpr literalChild2 = new DateLiteral(2022, 5, 20, Type.DATEV2);
         List<Expr> literalChildren1 = Lists.newArrayList();
@@ -118,7 +120,7 @@ public class InPredicateTest {
         literalChildren1.add(literalChild2);
         InPredicate inPredicate1 = new InPredicate(slotRef1, literalChildren1, false);
 
-        SlotRef slotRef2 = new SlotRef(new TableName("db1", "tb1"), "k1");
+        SlotRef slotRef2 = new SlotRef(new TableName(internalCtl, "db1", "tb1"), "k1");
         LiteralExpr literalChild3 = new DateLiteral(2022, 5, 19, Type.DATEV2);
         LiteralExpr literalChild4 = new DateLiteral(2022, 5, 21, Type.DATE);
         List<Expr> literalChildren2 = Lists.newArrayList();
@@ -151,7 +153,7 @@ public class InPredicateTest {
      */
     @Test
     public void testUnionWithDateV2() throws AnalysisException {
-        SlotRef slotRef1 = new SlotRef(new TableName("db1", "tb1"), "k1");
+        SlotRef slotRef1 = new SlotRef(new TableName(internalCtl, "db1", "tb1"), "k1");
         LiteralExpr literalChild1 = new DateLiteral(2022, 5, 19, Type.DATE);
         LiteralExpr literalChild2 = new DateLiteral(2022, 5, 20, Type.DATEV2);
         LiteralExpr literalChild3 = new DateLiteral(2022, 5, 20, 0, 0, 0, Type.DATETIME);
@@ -161,7 +163,7 @@ public class InPredicateTest {
         literalChildren1.add(literalChild3);
         InPredicate inPredicate1 = new InPredicate(slotRef1, literalChildren1, false);
 
-        SlotRef slotRef2 = new SlotRef(new TableName("db1", "tb1"), "k1");
+        SlotRef slotRef2 = new SlotRef(new TableName(internalCtl, "db1", "tb1"), "k1");
         LiteralExpr literalChild4 = new DateLiteral(2022, 5, 19, Type.DATE);
         LiteralExpr literalChild5 = new DateLiteral(2022, 5, 20, 0, 0, 0, Type.DATETIMEV2);
         List<Expr> literalChildren2 = Lists.newArrayList();

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/MVColumnBitmapUnionPatternTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/MVColumnBitmapUnionPatternTest.java
@@ -22,6 +22,7 @@ import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.FunctionSet;
 import org.apache.doris.catalog.Type;
 import org.apache.doris.common.jmockit.Deencapsulation;
+import org.apache.doris.datasource.InternalDataSource;
 
 import com.google.common.collect.Lists;
 import mockit.Expectations;
@@ -32,10 +33,11 @@ import org.junit.Test;
 import java.util.List;
 
 public class MVColumnBitmapUnionPatternTest {
+    private static final String internalCtl = InternalDataSource.INTERNAL_DS_NAME;
 
     @Test
     public void testCorrectExpr1(@Injectable AggregateFunction aggregateFunction) {
-        TableName tableName = new TableName("db", "table");
+        TableName tableName = new TableName(internalCtl, "db", "table");
         SlotRef slotRef = new SlotRef(tableName, "c1");
         Deencapsulation.setField(slotRef, "type", Type.INT);
         List<Expr> child0Params = Lists.newArrayList();
@@ -51,7 +53,7 @@ public class MVColumnBitmapUnionPatternTest {
 
     @Test
     public void testCorrectExpr2(@Injectable CastExpr castExpr, @Injectable AggregateFunction aggregateFunction) {
-        TableName tableName = new TableName("db", "table");
+        TableName tableName = new TableName(internalCtl, "db", "table");
         SlotRef slotRef = new SlotRef(tableName, "c1");
         Deencapsulation.setField(slotRef, "type", Type.INT);
         new Expectations() {
@@ -73,7 +75,7 @@ public class MVColumnBitmapUnionPatternTest {
 
     @Test
     public void testUpperCaseOfFunction(@Injectable AggregateFunction aggregateFunction) {
-        TableName tableName = new TableName("db", "table");
+        TableName tableName = new TableName(internalCtl, "db", "table");
         SlotRef slotRef = new SlotRef(tableName, "c1");
         Deencapsulation.setField(slotRef, "type", Type.INT);
         List<Expr> child0Params = Lists.newArrayList();
@@ -89,7 +91,7 @@ public class MVColumnBitmapUnionPatternTest {
 
     @Test
     public void testIncorrectArithmeticExpr1(@Injectable AggregateFunction aggregateFunction) {
-        TableName tableName = new TableName("db", "table");
+        TableName tableName = new TableName(internalCtl, "db", "table");
         SlotRef slotRef1 = new SlotRef(tableName, "c1");
         SlotRef slotRef2 = new SlotRef(tableName, "c2");
         ArithmeticExpr arithmeticExpr = new ArithmeticExpr(ArithmeticExpr.Operator.ADD, slotRef1, slotRef2);
@@ -103,7 +105,7 @@ public class MVColumnBitmapUnionPatternTest {
 
     @Test
     public void testIncorrectArithmeticExpr2(@Injectable AggregateFunction aggregateFunction) {
-        TableName tableName = new TableName("db", "table");
+        TableName tableName = new TableName(internalCtl, "db", "table");
         SlotRef slotRef1 = new SlotRef(tableName, "c1");
         SlotRef slotRef2 = new SlotRef(tableName, "c2");
         ArithmeticExpr arithmeticExpr = new ArithmeticExpr(ArithmeticExpr.Operator.ADD, slotRef1, slotRef2);
@@ -120,7 +122,7 @@ public class MVColumnBitmapUnionPatternTest {
 
     @Test
     public void testIncorrectDecimalSlotRef(@Injectable AggregateFunction aggregateFunction) {
-        TableName tableName = new TableName("db", "table");
+        TableName tableName = new TableName(internalCtl, "db", "table");
         SlotRef slotRef1 = new SlotRef(tableName, "c1");
         Deencapsulation.setField(slotRef1, "type", Type.DECIMALV2);
         List<Expr> child0Params = Lists.newArrayList();
@@ -137,7 +139,7 @@ public class MVColumnBitmapUnionPatternTest {
     @Test
     public void testAggTableBitmapColumn(@Injectable SlotDescriptor desc,
             @Injectable Column column, @Injectable AggregateFunction aggregateFunction) {
-        TableName tableName = new TableName("db", "table");
+        TableName tableName = new TableName(internalCtl, "db", "table");
         SlotRef slotRef1 = new SlotRef(tableName, "c1");
         List<Expr> params = Lists.newArrayList();
         params.add(slotRef1);

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/MVColumnHLLUnionPatternTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/MVColumnHLLUnionPatternTest.java
@@ -22,6 +22,7 @@ import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.FunctionSet;
 import org.apache.doris.catalog.Type;
 import org.apache.doris.common.jmockit.Deencapsulation;
+import org.apache.doris.datasource.InternalDataSource;
 
 import com.google.common.collect.Lists;
 import mockit.Expectations;
@@ -32,10 +33,11 @@ import org.junit.Test;
 import java.util.List;
 
 public class MVColumnHLLUnionPatternTest {
+    private static final String internalCtl = InternalDataSource.INTERNAL_DS_NAME;
 
     @Test
     public void testCorrectExpr1(@Injectable AggregateFunction aggregateFunction) {
-        TableName tableName = new TableName("db", "table");
+        TableName tableName = new TableName(internalCtl, "db", "table");
         SlotRef slotRef = new SlotRef(tableName, "c1");
         List<Expr> child0Params = Lists.newArrayList();
         child0Params.add(slotRef);
@@ -50,7 +52,7 @@ public class MVColumnHLLUnionPatternTest {
 
     @Test
     public void testCorrectExpr2(@Injectable CastExpr castExpr, @Injectable AggregateFunction aggregateFunction) {
-        TableName tableName = new TableName("db", "table");
+        TableName tableName = new TableName(internalCtl, "db", "table");
         SlotRef slotRef = new SlotRef(tableName, "c1");
         new Expectations() {
             {
@@ -71,7 +73,7 @@ public class MVColumnHLLUnionPatternTest {
 
     @Test
     public void testUpperCaseOfFunction(@Injectable AggregateFunction aggregateFunction) {
-        TableName tableName = new TableName("db", "table");
+        TableName tableName = new TableName(internalCtl, "db", "table");
         SlotRef slotRef = new SlotRef(tableName, "c1");
         List<Expr> child0Params = Lists.newArrayList();
         child0Params.add(slotRef);
@@ -111,7 +113,7 @@ public class MVColumnHLLUnionPatternTest {
 
     @Test
     public void testIncorrectDecimalSlotRef(@Injectable AggregateFunction aggregateFunction) {
-        TableName tableName = new TableName("db", "table");
+        TableName tableName = new TableName(internalCtl, "db", "table");
         SlotRef slotRef = new SlotRef(tableName, "c1");
         Deencapsulation.setField(slotRef, "type", Type.DECIMALV2);
         List<Expr> child0Params = Lists.newArrayList();
@@ -128,7 +130,7 @@ public class MVColumnHLLUnionPatternTest {
     @Test
     public void testAggTableHLLColumn(@Injectable SlotDescriptor desc,
             @Injectable Column column, @Injectable AggregateFunction aggregateFunction) {
-        TableName tableName = new TableName("db", "table");
+        TableName tableName = new TableName(internalCtl, "db", "table");
         SlotRef slotRef1 = new SlotRef(tableName, "c1");
         List<Expr> params = Lists.newArrayList();
         params.add(slotRef1);

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/MVColumnOneChildPatternTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/MVColumnOneChildPatternTest.java
@@ -21,6 +21,7 @@ import org.apache.doris.catalog.AggregateFunction;
 import org.apache.doris.catalog.AggregateType;
 import org.apache.doris.catalog.FunctionSet;
 import org.apache.doris.common.jmockit.Deencapsulation;
+import org.apache.doris.datasource.InternalDataSource;
 
 import com.google.common.collect.Lists;
 import mockit.Expectations;
@@ -31,10 +32,11 @@ import org.junit.Test;
 import java.util.List;
 
 public class MVColumnOneChildPatternTest {
+    private static final String internalCtl = InternalDataSource.INTERNAL_DS_NAME;
 
     @Test
     public void testCorrectSum(@Injectable AggregateFunction aggregateFunction) {
-        TableName tableName = new TableName("db", "table");
+        TableName tableName = new TableName(internalCtl, "db", "table");
         SlotRef slotRef = new SlotRef(tableName, "c1");
         List<Expr> params = Lists.newArrayList();
         params.add(slotRef);
@@ -47,7 +49,7 @@ public class MVColumnOneChildPatternTest {
 
     @Test
     public void testCorrectMin(@Injectable CastExpr castExpr, @Injectable AggregateFunction aggregateFunction) {
-        TableName tableName = new TableName("db", "table");
+        TableName tableName = new TableName(internalCtl, "db", "table");
         SlotRef slotRef = new SlotRef(tableName, "c1");
         List<Expr> child0Params = Lists.newArrayList();
         child0Params.add(slotRef);
@@ -68,7 +70,7 @@ public class MVColumnOneChildPatternTest {
 
     @Test
     public void testCorrectCountField(@Injectable AggregateFunction aggregateFunction) {
-        TableName tableName = new TableName("db", "table");
+        TableName tableName = new TableName(internalCtl, "db", "table");
         SlotRef slotRef = new SlotRef(tableName, "c1");
         List<Expr> params = Lists.newArrayList();
         params.add(slotRef);
@@ -92,7 +94,7 @@ public class MVColumnOneChildPatternTest {
 
     @Test
     public void testIncorrectArithmeticExpr(@Injectable AggregateFunction aggregateFunction) {
-        TableName tableName = new TableName("db", "table");
+        TableName tableName = new TableName(internalCtl, "db", "table");
         SlotRef slotRef1 = new SlotRef(tableName, "c1");
         SlotRef slotRef2 = new SlotRef(tableName, "c2");
         ArithmeticExpr arithmeticExpr = new ArithmeticExpr(ArithmeticExpr.Operator.ADD, slotRef1, slotRef2);

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/ShowDataStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/ShowDataStmtTest.java
@@ -149,7 +149,7 @@ public class ShowDataStmtTest {
         SlotRef slotRefTwo = new SlotRef(null, "Size");
         OrderByElement orderByElementTwo = new OrderByElement(slotRefTwo, false, false);
 
-        stmt = new ShowDataStmt(new TableName("testDb", "test_tbl"), Arrays.asList(orderByElementOne, orderByElementTwo));
+        stmt = new ShowDataStmt(new TableName(InternalDataSource.INTERNAL_DS_NAME, "testDb", "test_tbl"), Arrays.asList(orderByElementOne, orderByElementTwo));
         stmt.analyze(analyzer);
         Assert.assertEquals("SHOW DATA FROM `default_cluster:testDb`.`test_tbl` ORDER BY `ReplicaCount` DESC, `Size` DESC", stmt.toString());
         Assert.assertEquals(5, stmt.getMetaData().getColumnCount());

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/ShowIndexStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/ShowIndexStmtTest.java
@@ -19,6 +19,7 @@ package org.apache.doris.analysis;
 
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.UserException;
+import org.apache.doris.datasource.InternalDataSource;
 import org.apache.doris.mysql.privilege.MockedAuth;
 import org.apache.doris.mysql.privilege.PaloAuth;
 import org.apache.doris.qe.ConnectContext;
@@ -29,6 +30,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class ShowIndexStmtTest {
+    private static final String internalCtl = InternalDataSource.INTERNAL_DS_NAME;
 
     private static Analyzer analyzer;
 
@@ -46,23 +48,23 @@ public class ShowIndexStmtTest {
 
     @Test
     public void testNormal() throws UserException {
-        ShowIndexStmt stmt = new ShowIndexStmt("testDb", new TableName("", "testTbl"));
+        ShowIndexStmt stmt = new ShowIndexStmt("testDb", new TableName(internalCtl, "", "testTbl"));
         stmt.analyze(analyzer);
         Assert.assertEquals("SHOW INDEX FROM `testCluster:testDb`.`testTbl`", stmt.toSql());
-        stmt = new ShowIndexStmt("", new TableName("", "testTbl"));
+        stmt = new ShowIndexStmt("", new TableName(internalCtl, "", "testTbl"));
         stmt.analyze(analyzer);
         Assert.assertEquals("SHOW INDEX FROM `testCluster:testDb`.`testTbl`", stmt.toSql());
-        stmt = new ShowIndexStmt(null, new TableName("testDb", "testTbl"));
+        stmt = new ShowIndexStmt(null, new TableName(internalCtl, "testDb", "testTbl"));
         stmt.analyze(analyzer);
         Assert.assertEquals("SHOW INDEX FROM `testCluster:testDb`.`testTbl`", stmt.toSql());
-        stmt = new ShowIndexStmt("testDb", new TableName("testDb2", "testTbl"));
+        stmt = new ShowIndexStmt("testDb", new TableName(internalCtl, "testDb2", "testTbl"));
         stmt.analyze(analyzer);
         Assert.assertEquals("SHOW INDEX FROM `testCluster:testDb`.`testTbl`", stmt.toSql());
     }
 
     @Test(expected = AnalysisException.class)
     public void testNoTbl() throws UserException {
-        ShowIndexStmt stmt = new ShowIndexStmt("testDb", new TableName("", ""));
+        ShowIndexStmt stmt = new ShowIndexStmt("testDb", new TableName(internalCtl, "", ""));
         stmt.analyze(analyzer);
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/ShowPartitionsStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/ShowPartitionsStmtTest.java
@@ -21,6 +21,7 @@ import org.apache.doris.catalog.Catalog;
 import org.apache.doris.catalog.FakeCatalog;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.UserException;
+import org.apache.doris.datasource.InternalDataSource;
 
 import mockit.Expectations;
 import mockit.Mocked;
@@ -34,6 +35,8 @@ import java.util.Arrays;
 
 
 public class ShowPartitionsStmtTest {
+    private static final String internalCtl = InternalDataSource.INTERNAL_DS_NAME;
+
     @Mocked
     private Analyzer analyzer;
     private Catalog catalog;
@@ -66,7 +69,7 @@ public class ShowPartitionsStmtTest {
 
     @Test
     public void testNormal() throws UserException {
-        ShowPartitionsStmt stmt = new ShowPartitionsStmt(new TableName("testDb", "testTable"), null, null, null, false);
+        ShowPartitionsStmt stmt = new ShowPartitionsStmt(new TableName(internalCtl, "testDb", "testTable"), null, null, null, false);
         stmt.analyzeImpl(analyzer);
         Assert.assertEquals("SHOW PARTITIONS FROM `testCluster:testDb`.`testTable`", stmt.toString());
     }
@@ -76,7 +79,7 @@ public class ShowPartitionsStmtTest {
         SlotRef slotRef = new SlotRef(null, "LastConsistencyCheckTime");
         StringLiteral stringLiteral = new StringLiteral("2019-12-22 10:22:11");
         BinaryPredicate binaryPredicate = new BinaryPredicate(BinaryPredicate.Operator.GT, slotRef, stringLiteral);
-        ShowPartitionsStmt stmt = new ShowPartitionsStmt(new TableName("testDb", "testTable"), binaryPredicate, null, null, false);
+        ShowPartitionsStmt stmt = new ShowPartitionsStmt(new TableName(internalCtl, "testDb", "testTable"), binaryPredicate, null, null, false);
         stmt.analyzeImpl(analyzer);
         Assert.assertEquals("SHOW PARTITIONS FROM `testCluster:testDb`.`testTable` WHERE `LastConsistencyCheckTime` > '2019-12-22 10:22:11'", stmt.toString());
     }
@@ -86,7 +89,7 @@ public class ShowPartitionsStmtTest {
         SlotRef slotRef = new SlotRef(null, "PartitionName");
         StringLiteral stringLiteral = new StringLiteral("%p2019%");
         LikePredicate likePredicate = new LikePredicate(LikePredicate.Operator.LIKE, slotRef, stringLiteral);
-        ShowPartitionsStmt stmt = new ShowPartitionsStmt(new TableName("testDb", "testTable"), likePredicate, null, null, false);
+        ShowPartitionsStmt stmt = new ShowPartitionsStmt(new TableName(internalCtl, "testDb", "testTable"), likePredicate, null, null, false);
         stmt.analyzeImpl(analyzer);
         Assert.assertEquals("SHOW PARTITIONS FROM `testCluster:testDb`.`testTable` WHERE `PartitionName` LIKE '%p2019%'", stmt.toString());
     }
@@ -96,7 +99,7 @@ public class ShowPartitionsStmtTest {
         SlotRef slotRef = new SlotRef(null, "PartitionId");
         OrderByElement orderByElement = new OrderByElement(slotRef, true, false);
         LimitElement limitElement = new LimitElement(10);
-        ShowPartitionsStmt stmt = new ShowPartitionsStmt(new TableName("testDb", "testTable"), null, Arrays.asList(orderByElement), limitElement, false);
+        ShowPartitionsStmt stmt = new ShowPartitionsStmt(new TableName(internalCtl, "testDb", "testTable"), null, Arrays.asList(orderByElement), limitElement, false);
         stmt.analyzeImpl(analyzer);
         Assert.assertEquals("SHOW PARTITIONS FROM `testCluster:testDb`.`testTable` ORDER BY `PartitionId` ASC LIMIT 10", stmt.toString());
     }
@@ -106,7 +109,7 @@ public class ShowPartitionsStmtTest {
         SlotRef slotRef = new SlotRef(null, "DataSize");
         StringLiteral stringLiteral = new StringLiteral("3.2 GB");
         BinaryPredicate binaryPredicate = new BinaryPredicate(BinaryPredicate.Operator.EQ, slotRef, stringLiteral);
-        ShowPartitionsStmt stmt = new ShowPartitionsStmt(new TableName("testDb", "testTable"), binaryPredicate, null, null, false);
+        ShowPartitionsStmt stmt = new ShowPartitionsStmt(new TableName(internalCtl, "testDb", "testTable"), binaryPredicate, null, null, false);
         expectedEx.expect(AnalysisException.class);
         expectedEx.expectMessage("Only the columns of PartitionId/PartitionName/"
                 + "State/Buckets/ReplicationNum/LastConsistencyCheckTime are supported.");

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/ShowRollupStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/ShowRollupStmtTest.java
@@ -18,12 +18,14 @@
 package org.apache.doris.analysis;
 
 import org.apache.doris.common.AnalysisException;
+import org.apache.doris.datasource.InternalDataSource;
 
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
 public class ShowRollupStmtTest {
+    private static final String internalCtl = InternalDataSource.INTERNAL_DS_NAME;
     private Analyzer analyzer;
 
     @Before
@@ -34,21 +36,21 @@ public class ShowRollupStmtTest {
     @Test
     public void testNormal() throws AnalysisException {
         // use default database
-        ShowRollupStmt stmt = new ShowRollupStmt(new TableName("", "tbl"), "");
+        ShowRollupStmt stmt = new ShowRollupStmt(new TableName(internalCtl, "", "tbl"), "");
         stmt.analyze(analyzer);
         Assert.assertEquals("testCluster:testDb", stmt.getDb());
         Assert.assertEquals("tbl", stmt.getTbl());
         Assert.assertEquals("SHOW ROLLUP FROM `testCluster:testDb`.`tbl`", stmt.toString());
 
         // use table database
-        stmt = new ShowRollupStmt(new TableName("testDb1", "tbl"), "");
+        stmt = new ShowRollupStmt(new TableName(internalCtl, "testDb1", "tbl"), "");
         stmt.analyze(analyzer);
         Assert.assertEquals("testCluster:testDb1", stmt.getDb());
         Assert.assertEquals("tbl", stmt.getTbl());
         Assert.assertEquals("SHOW ROLLUP FROM `testCluster:testDb1`.`tbl`", stmt.toString());
 
         // use db database
-        stmt = new ShowRollupStmt(new TableName("testDb1", "tbl"), "testDb2");
+        stmt = new ShowRollupStmt(new TableName(internalCtl, "testDb1", "tbl"), "testDb2");
         stmt.analyze(analyzer);
         Assert.assertEquals("testCluster:testDb2", stmt.getDb());
         Assert.assertEquals("tbl", stmt.getTbl());
@@ -58,7 +60,7 @@ public class ShowRollupStmtTest {
     @Test(expected = AnalysisException.class)
     public void testNoTbl() throws AnalysisException {
         // use default database
-        ShowRollupStmt stmt = new ShowRollupStmt(new TableName("testDb", ""), "");
+        ShowRollupStmt stmt = new ShowRollupStmt(new TableName(internalCtl, "testDb", ""), "");
         stmt.analyze(analyzer);
         Assert.fail("No exception throws.");
     }

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/ShowViewStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/ShowViewStmtTest.java
@@ -19,6 +19,7 @@ package org.apache.doris.analysis;
 
 import org.apache.doris.common.UserException;
 import org.apache.doris.common.util.SqlParserUtils;
+import org.apache.doris.datasource.InternalDataSource;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.ShowExecutor;
 import org.apache.doris.qe.ShowResultSet;
@@ -38,6 +39,7 @@ import java.util.Set;
 import java.util.UUID;
 
 public class ShowViewStmtTest {
+    private static final String internalCtl = InternalDataSource.INTERNAL_DS_NAME;
     private static String runningDir = "fe/mocked/ShowViewTest/" + UUID.randomUUID().toString() + "/";
     private static DorisAssert dorisAssert;
 
@@ -96,7 +98,7 @@ public class ShowViewStmtTest {
     @Test
     public void testNormal() throws Exception {
         ConnectContext ctx = UtFrameUtils.createDefaultCtx();
-        ShowViewStmt stmt = new ShowViewStmt("", new TableName("testDb", "test1"));
+        ShowViewStmt stmt = new ShowViewStmt("", new TableName(internalCtl, "testDb", "test1"));
         stmt.analyze(new Analyzer(ctx.getCatalog(), ctx));
         Assert.assertEquals("SHOW VIEW FROM `default_cluster:testDb`.`test1`", stmt.toString());
         Assert.assertEquals("default_cluster:testDb", stmt.getDb());
@@ -109,7 +111,7 @@ public class ShowViewStmtTest {
     @Test(expected = UserException.class)
     public void testNoDb() throws Exception {
         ConnectContext ctx = UtFrameUtils.createDefaultCtx();
-        ShowViewStmt stmt = new ShowViewStmt("", new TableName("", "testTbl"));
+        ShowViewStmt stmt = new ShowViewStmt("", new TableName(internalCtl, "", "testTbl"));
         stmt.analyze(new Analyzer(ctx.getCatalog(), ctx));
         Assert.fail();
     }
@@ -121,7 +123,7 @@ public class ShowViewStmtTest {
                 + "SELECT a, b FROM test1;";
         dorisAssert.withView(testView1);
 
-        ShowViewStmt stmt = new ShowViewStmt("", new TableName("testDb", "test1"));
+        ShowViewStmt stmt = new ShowViewStmt("", new TableName(internalCtl, "testDb", "test1"));
         stmt.analyze(new Analyzer(ctx.getCatalog(), ctx));
         ShowExecutor executor = new ShowExecutor(ctx, stmt);
         ShowResultSet resultSet = executor.execute();
@@ -143,7 +145,7 @@ public class ShowViewStmtTest {
                 + "ON test1.a = test2.c;";
         dorisAssert.withView(testView2);
 
-        ShowViewStmt stmt = new ShowViewStmt("", new TableName("testDb", "test1"));
+        ShowViewStmt stmt = new ShowViewStmt("", new TableName(internalCtl, "testDb", "test1"));
         stmt.analyze(new Analyzer(ctx.getCatalog(), ctx));
         ShowExecutor executor = new ShowExecutor(ctx, stmt);
         ShowResultSet resultSet = executor.execute();
@@ -153,7 +155,7 @@ public class ShowViewStmtTest {
         Assert.assertEquals("view2", resultSet.getString(0));
         Assert.assertFalse(resultSet.next());
 
-        stmt = new ShowViewStmt("", new TableName("testDb", "test2"));
+        stmt = new ShowViewStmt("", new TableName(internalCtl, "testDb", "test2"));
         stmt.analyze(new Analyzer(ctx.getCatalog(), ctx));
         executor = new ShowExecutor(ctx, stmt);
         resultSet = executor.execute();
@@ -176,7 +178,7 @@ public class ShowViewStmtTest {
                 + "ON test1.a = test4.e;";
         dorisAssert.withView(testView3);
 
-        ShowViewStmt stmt = new ShowViewStmt("", new TableName("testDb", "test1"));
+        ShowViewStmt stmt = new ShowViewStmt("", new TableName(internalCtl, "testDb", "test1"));
         stmt.analyze(new Analyzer(ctx.getCatalog(), ctx));
         ShowExecutor executor = new ShowExecutor(ctx, stmt);
         ShowResultSet resultSet = executor.execute();
@@ -186,7 +188,7 @@ public class ShowViewStmtTest {
         Assert.assertEquals("view3", resultSet.getString(0));
         Assert.assertFalse(resultSet.next());
 
-        stmt = new ShowViewStmt("", new TableName("testDb", "test2"));
+        stmt = new ShowViewStmt("", new TableName(internalCtl, "testDb", "test2"));
         stmt.analyze(new Analyzer(ctx.getCatalog(), ctx));
         executor = new ShowExecutor(ctx, stmt);
         resultSet = executor.execute();
@@ -196,7 +198,7 @@ public class ShowViewStmtTest {
         Assert.assertEquals("view3", resultSet.getString(0));
         Assert.assertFalse(resultSet.next());
 
-        stmt = new ShowViewStmt("", new TableName("testDb", "test3"));
+        stmt = new ShowViewStmt("", new TableName(internalCtl, "testDb", "test3"));
         stmt.analyze(new Analyzer(ctx.getCatalog(), ctx));
         executor = new ShowExecutor(ctx, stmt);
         resultSet = executor.execute();
@@ -221,7 +223,7 @@ public class ShowViewStmtTest {
         dorisAssert.withView(testView4);
         dorisAssert.withView(testView5);
 
-        ShowViewStmt stmt = new ShowViewStmt("", new TableName("testDb", "test1"));
+        ShowViewStmt stmt = new ShowViewStmt("", new TableName(internalCtl, "testDb", "test1"));
         stmt.analyze(new Analyzer(ctx.getCatalog(), ctx));
         ShowExecutor executor = new ShowExecutor(ctx, stmt);
         ShowResultSet resultSet = executor.execute();

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/UpdateStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/UpdateStmtTest.java
@@ -18,6 +18,7 @@
 package org.apache.doris.analysis;
 
 import org.apache.doris.common.UserException;
+import org.apache.doris.datasource.InternalDataSource;
 
 import com.google.common.collect.Lists;
 import mockit.Expectations;
@@ -31,7 +32,7 @@ public class UpdateStmtTest {
 
     @Test
     public void testAnalyze(@Injectable Analyzer analyzer) {
-        TableName tableName = new TableName("db", "table");
+        TableName tableName = new TableName(InternalDataSource.INTERNAL_DS_NAME, "db", "table");
         IntLiteral intLiteral = new IntLiteral(1);
         SlotRef slotRef = new SlotRef(tableName, "c1");
         BinaryPredicate binaryPredicate = new BinaryPredicate(BinaryPredicate.Operator.EQ, intLiteral, slotRef);

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/VirtualSlotRefTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/VirtualSlotRefTest.java
@@ -20,6 +20,7 @@ package org.apache.doris.analysis;
 import org.apache.doris.catalog.Type;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.FeMetaVersion;
+import org.apache.doris.datasource.InternalDataSource;
 import org.apache.doris.meta.MetaContext;
 
 import com.google.common.collect.ArrayListMultimap;
@@ -59,7 +60,7 @@ public class VirtualSlotRefTest {
         String[] cols = {"k1", "k2", "k3"};
         slots = new ArrayList<>();
         for (String col : cols) {
-            SlotRef expr = new SlotRef(new TableName("testdb", "t"), col);
+            SlotRef expr = new SlotRef(new TableName(InternalDataSource.INTERNAL_DS_NAME, "testdb", "t"), col);
             slots.add(expr);
         }
         try {
@@ -67,7 +68,7 @@ public class VirtualSlotRefTest {
             f.setAccessible(true);
             Multimap<String, TupleDescriptor> tupleByAlias = ArrayListMultimap.create();
             TupleDescriptor td = new TupleDescriptor(new TupleId(0));
-            TableName tableName = new TableName("testdb", "t");
+            TableName tableName = new TableName(InternalDataSource.INTERNAL_DS_NAME, "testdb", "t");
             tableName.analyze(analyzerBase);
             td.setTable(analyzerBase.getTableOrAnalysisException(tableName));
             tupleByAlias.put("testdb.t", td);

--- a/fe/fe-core/src/test/java/org/apache/doris/backup/BackupHandlerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/backup/BackupHandlerTest.java
@@ -251,7 +251,7 @@ public class BackupHandlerTest {
 
         // process backup
         List<TableRef> tblRefs = Lists.newArrayList();
-        tblRefs.add(new TableRef(new TableName(CatalogMocker.TEST_DB_NAME, CatalogMocker.TEST_TBL_NAME), null));
+        tblRefs.add(new TableRef(new TableName(InternalDataSource.INTERNAL_DS_NAME, CatalogMocker.TEST_DB_NAME, CatalogMocker.TEST_TBL_NAME), null));
         AbstractBackupTableRefClause tableRefClause = new AbstractBackupTableRefClause(false, tblRefs);
         BackupStmt backupStmt = new BackupStmt(new LabelName(CatalogMocker.TEST_DB_NAME, "label1"), "repo",
                 tableRefClause, null);
@@ -297,7 +297,7 @@ public class BackupHandlerTest {
 
         // process restore
         List<TableRef> tblRefs2 = Lists.newArrayList();
-        tblRefs2.add(new TableRef(new TableName(CatalogMocker.TEST_DB_NAME, CatalogMocker.TEST_TBL_NAME), null));
+        tblRefs2.add(new TableRef(new TableName(InternalDataSource.INTERNAL_DS_NAME, CatalogMocker.TEST_DB_NAME, CatalogMocker.TEST_TBL_NAME), null));
         Map<String, String> properties = Maps.newHashMap();
         properties.put("backup_timestamp", "2018-08-08-08-08-08");
         AbstractBackupTableRefClause abstractBackupTableRefClause = new AbstractBackupTableRefClause(false, tblRefs2);

--- a/fe/fe-core/src/test/java/org/apache/doris/backup/BackupJobTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/backup/BackupJobTest.java
@@ -207,7 +207,7 @@ public class BackupJobTest {
         };
 
         List<TableRef> tableRefs = Lists.newArrayList();
-        tableRefs.add(new TableRef(new TableName(UnitTestUtil.DB_NAME, UnitTestUtil.TABLE_NAME), null));
+        tableRefs.add(new TableRef(new TableName(InternalDataSource.INTERNAL_DS_NAME, UnitTestUtil.DB_NAME, UnitTestUtil.TABLE_NAME), null));
         job = new BackupJob("label", dbId, UnitTestUtil.DB_NAME, tableRefs, 13600 * 1000, BackupStmt.BackupContent.ALL,
                 catalog, repo.getId());
     }
@@ -342,7 +342,7 @@ public class BackupJobTest {
         AgentTaskQueue.clearAllTasks();
 
         List<TableRef> tableRefs = Lists.newArrayList();
-        tableRefs.add(new TableRef(new TableName(UnitTestUtil.DB_NAME, "unknown_tbl"), null));
+        tableRefs.add(new TableRef(new TableName(InternalDataSource.INTERNAL_DS_NAME, UnitTestUtil.DB_NAME, "unknown_tbl"), null));
         job = new BackupJob("label", dbId, UnitTestUtil.DB_NAME, tableRefs, 13600 * 1000, BackupStmt.BackupContent.ALL,
                 catalog, repo.getId());
         job.run();

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/HiveMetaStoreClientHelperTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/HiveMetaStoreClientHelperTest.java
@@ -52,7 +52,7 @@ public class HiveMetaStoreClientHelperTest {
     @BeforeClass
     public static void beforeAll() {
         tableNameString = "test_table";
-        tableName = new TableName("", tableNameString);
+        tableName = new TableName("hive", "", tableNameString);
         partitionKeys.add(p1);
         partitionKeys.add(p2);
     }

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/MaterializedIndexMetaTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/MaterializedIndexMetaTest.java
@@ -24,6 +24,7 @@ import org.apache.doris.analysis.FunctionName;
 import org.apache.doris.analysis.SlotRef;
 import org.apache.doris.analysis.TableName;
 import org.apache.doris.common.AnalysisException;
+import org.apache.doris.datasource.InternalDataSource;
 import org.apache.doris.qe.OriginStatement;
 import org.apache.doris.thrift.TStorageType;
 
@@ -90,7 +91,7 @@ public class MaterializedIndexMetaTest {
         out.close();
 
         List<Expr> params = Lists.newArrayList();
-        SlotRef param1 = new SlotRef(new TableName(null, "test"), "c1");
+        SlotRef param1 = new SlotRef(new TableName(InternalDataSource.INTERNAL_DS_NAME, null, "test"), "c1");
         params.add(param1);
         Map<String, Expr> columnNameToDefineExpr = Maps.newHashMap();
         columnNameToDefineExpr.put(mvColumnName, new FunctionCallExpr(new FunctionName("to_bitmap"), params));

--- a/fe/fe-core/src/test/java/org/apache/doris/common/proc/IndexSchemaProcNodeTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/common/proc/IndexSchemaProcNodeTest.java
@@ -24,6 +24,7 @@ import org.apache.doris.catalog.AggregateType;
 import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.Type;
 import org.apache.doris.common.AnalysisException;
+import org.apache.doris.datasource.InternalDataSource;
 
 import com.google.common.collect.Lists;
 import org.junit.Assert;
@@ -38,7 +39,7 @@ public class IndexSchemaProcNodeTest {
         List<Column> columnList = Lists.newArrayList();
         Column column1 = new Column("k1", Type.INT, true, null, true, "", "");
         Column column2 = new Column("mv_bitmap_union_v1", Type.BITMAP, false, AggregateType.BITMAP_UNION, true, "", "");
-        TableName tableName = new TableName("db1", "t1");
+        TableName tableName = new TableName(InternalDataSource.INTERNAL_DS_NAME, "db1", "t1");
         SlotRef slotRef = new SlotRef(tableName, "v1");
         FunctionCallExpr functionCallExpr = new FunctionCallExpr("to_bitmap", Lists.newArrayList(slotRef));
         column2.setDefineExpr(functionCallExpr);

--- a/fe/fe-core/src/test/java/org/apache/doris/load/DeleteHandlerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/load/DeleteHandlerTest.java
@@ -70,6 +70,7 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 public class DeleteHandlerTest {
+    private static final String internalCtl = InternalDataSource.INTERNAL_DS_NAME;
 
     private DeleteHandler deleteHandler;
 
@@ -199,7 +200,7 @@ public class DeleteHandlerTest {
         BinaryPredicate binaryPredicate = new BinaryPredicate(BinaryPredicate.Operator.GT, new SlotRef(null, "k1"),
                 new IntLiteral(3));
 
-        DeleteStmt deleteStmt = new DeleteStmt(new TableName("test_db", "test_tbl"),
+        DeleteStmt deleteStmt = new DeleteStmt(new TableName(internalCtl, "test_db", "test_tbl"),
                 new PartitionNames(false, Lists.newArrayList("test_tbl")), binaryPredicate);
 
         new Expectations(globalTransactionMgr) {
@@ -226,7 +227,7 @@ public class DeleteHandlerTest {
         BinaryPredicate binaryPredicate = new BinaryPredicate(BinaryPredicate.Operator.GT, new SlotRef(null, "k1"),
                 new IntLiteral(3));
 
-        DeleteStmt deleteStmt = new DeleteStmt(new TableName("test_db", "test_tbl"),
+        DeleteStmt deleteStmt = new DeleteStmt(new TableName(internalCtl, "test_db", "test_tbl"),
                 new PartitionNames(false, Lists.newArrayList("test_tbl")), binaryPredicate);
 
         Set<Replica> finishedReplica = Sets.newHashSet();
@@ -275,7 +276,7 @@ public class DeleteHandlerTest {
         BinaryPredicate binaryPredicate = new BinaryPredicate(BinaryPredicate.Operator.GT, new SlotRef(null, "k1"),
                 new IntLiteral(3));
 
-        DeleteStmt deleteStmt = new DeleteStmt(new TableName("test_db", "test_tbl"),
+        DeleteStmt deleteStmt = new DeleteStmt(new TableName(internalCtl, "test_db", "test_tbl"),
                 new PartitionNames(false, Lists.newArrayList("test_tbl")), binaryPredicate);
 
         Set<Replica> finishedReplica = Sets.newHashSet();
@@ -326,7 +327,7 @@ public class DeleteHandlerTest {
         BinaryPredicate binaryPredicate = new BinaryPredicate(BinaryPredicate.Operator.GT, new SlotRef(null, "k1"),
                 new IntLiteral(3));
 
-        DeleteStmt deleteStmt = new DeleteStmt(new TableName("test_db", "test_tbl"),
+        DeleteStmt deleteStmt = new DeleteStmt(new TableName(internalCtl, "test_db", "test_tbl"),
                 new PartitionNames(false, Lists.newArrayList("test_tbl")), binaryPredicate);
 
         Set<Replica> finishedReplica = Sets.newHashSet();
@@ -391,7 +392,7 @@ public class DeleteHandlerTest {
         BinaryPredicate binaryPredicate = new BinaryPredicate(BinaryPredicate.Operator.GT, new SlotRef(null, "k1"),
                 new IntLiteral(3));
 
-        DeleteStmt deleteStmt = new DeleteStmt(new TableName("test_db", "test_tbl"),
+        DeleteStmt deleteStmt = new DeleteStmt(new TableName(internalCtl, "test_db", "test_tbl"),
                 new PartitionNames(false, Lists.newArrayList("test_tbl")), binaryPredicate);
 
         Set<Replica> finishedReplica = Sets.newHashSet();
@@ -450,7 +451,7 @@ public class DeleteHandlerTest {
         BinaryPredicate binaryPredicate = new BinaryPredicate(BinaryPredicate.Operator.GT, new SlotRef(null, "k1"),
                 new IntLiteral(3));
 
-        DeleteStmt deleteStmt = new DeleteStmt(new TableName("test_db", "test_tbl"),
+        DeleteStmt deleteStmt = new DeleteStmt(new TableName(internalCtl, "test_db", "test_tbl"),
                 new PartitionNames(false, Lists.newArrayList("test_tbl")), binaryPredicate);
 
         Set<Replica> finishedReplica = Sets.newHashSet();

--- a/fe/fe-core/src/test/java/org/apache/doris/load/loadv2/ExportMgrTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/load/loadv2/ExportMgrTest.java
@@ -21,6 +21,7 @@ import org.apache.doris.analysis.BrokerDesc;
 import org.apache.doris.analysis.LoadStmt;
 import org.apache.doris.analysis.TableName;
 import org.apache.doris.common.jmockit.Deencapsulation;
+import org.apache.doris.datasource.InternalDataSource;
 import org.apache.doris.load.ExportJob;
 import org.apache.doris.load.ExportMgr;
 import org.apache.doris.mysql.privilege.MockedAuth;
@@ -82,7 +83,7 @@ public class ExportMgrTest {
         ExportJob job1 = new ExportJob(id);
         Deencapsulation.setField(job1, "label", label);
 
-        TableName tbl1 = new TableName("testCluster", "testDb");
+        TableName tbl1 = new TableName(InternalDataSource.INTERNAL_DS_NAME, "testCluster", "testDb");
         Deencapsulation.setField(job1, "tableName", tbl1);
 
         BrokerDesc bd = new BrokerDesc("broker", new HashMap<>());

--- a/fe/fe-core/src/test/java/org/apache/doris/load/update/UpdateStmtExecutorTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/load/update/UpdateStmtExecutorTest.java
@@ -30,6 +30,7 @@ import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.cluster.Cluster;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.jmockit.Deencapsulation;
+import org.apache.doris.datasource.InternalDataSource;
 import org.apache.doris.qe.Coordinator;
 import org.apache.doris.thrift.TUniqueId;
 import org.apache.doris.transaction.GlobalTransactionMgr;
@@ -67,7 +68,7 @@ public class UpdateStmtExecutorTest {
                                    @Mocked Catalog catalog,
                                    @Injectable Database db,
                                    @Injectable Analyzer analyzer) throws AnalysisException {
-        TableName tableName = new TableName("db", "test");
+        TableName tableName = new TableName(InternalDataSource.INTERNAL_DS_NAME, "db", "test");
         List<Expr> setExprs = Lists.newArrayList();
         SlotRef slotRef = new SlotRef(tableName, "v1");
         IntLiteral intLiteral = new IntLiteral(1);

--- a/fe/fe-core/src/test/java/org/apache/doris/planner/MaterializedViewSelectorTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/planner/MaterializedViewSelectorTest.java
@@ -34,6 +34,7 @@ import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.catalog.Table;
 import org.apache.doris.catalog.Type;
 import org.apache.doris.common.jmockit.Deencapsulation;
+import org.apache.doris.datasource.InternalDataSource;
 import org.apache.doris.thrift.TStorageType;
 
 import com.google.common.collect.Lists;
@@ -49,7 +50,7 @@ import java.util.Map;
 import java.util.Set;
 
 public class MaterializedViewSelectorTest {
-
+    private static final String internalCtl = InternalDataSource.INTERNAL_DS_NAME;
 
     @Test
     public void initTest(@Injectable SelectStmt selectStmt,
@@ -62,8 +63,8 @@ public class MaterializedViewSelectorTest {
                          @Injectable TupleDescriptor tableBDesc,
                          @Injectable Table tableB,
                          @Injectable Analyzer analyzer) {
-        TableName tableAName = new TableName("test", "tableA");
-        TableName tableBName = new TableName("test", "tableB");
+        TableName tableAName = new TableName(internalCtl, "test", "tableA");
+        TableName tableBName = new TableName(internalCtl, "test", "tableB");
         SlotRef tableAColumn1 = new SlotRef(tableAName, "c1");
         Deencapsulation.setField(tableAColumn1, "isAnalyzed", true);
         SlotRef tableAColumn2 = new SlotRef(tableAName, "c2");
@@ -292,7 +293,7 @@ public class MaterializedViewSelectorTest {
         };
 
         MaterializedViewSelector selector = new MaterializedViewSelector(selectStmt, analyzer);
-        TableName tableName = new TableName("db1", "table1");
+        TableName tableName = new TableName(internalCtl, "db1", "table1");
         SlotRef slotRef = new SlotRef(tableName, "C1");
         FunctionCallExpr functionCallExpr = new FunctionCallExpr("sum", Lists.newArrayList(slotRef));
         Set<FunctionCallExpr> aggregatedColumnsInQueryOutput = Sets.newHashSet();

--- a/fe/fe-core/src/test/java/org/apache/doris/planner/OlapScanNodeTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/planner/OlapScanNodeTest.java
@@ -26,6 +26,7 @@ import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.PartitionKey;
 import org.apache.doris.catalog.PrimitiveType;
 import org.apache.doris.common.AnalysisException;
+import org.apache.doris.datasource.InternalDataSource;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -54,7 +55,7 @@ public class OlapScanNodeTest {
         List<Expr> inList = Lists.newArrayList();
         inList.add(new IntLiteral(1));
 
-        Expr compareExpr = new SlotRef(new TableName("db", "tableName"), "columnA");
+        Expr compareExpr = new SlotRef(new TableName(InternalDataSource.INTERNAL_DS_NAME, "db", "tableName"), "columnA");
         InPredicate inPredicate = new InPredicate(compareExpr, inList, false);
 
         PartitionColumnFilter  columnFilter = new PartitionColumnFilter();
@@ -96,7 +97,7 @@ public class OlapScanNodeTest {
         inList.add(new IntLiteral(5));
         inList.add(new IntLiteral(6));
 
-        Expr compareExpr = new SlotRef(new TableName("db", "tableName"), "columnA");
+        Expr compareExpr = new SlotRef(new TableName(InternalDataSource.INTERNAL_DS_NAME, "db", "tableName"), "columnA");
         InPredicate inPredicate = new InPredicate(compareExpr, inList, false);
 
         PartitionColumnFilter  columnFilter = new PartitionColumnFilter();

--- a/fe/fe-core/src/test/java/org/apache/doris/planner/RepeatNodeTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/planner/RepeatNodeTest.java
@@ -25,6 +25,7 @@ import org.apache.doris.analysis.SlotRef;
 import org.apache.doris.analysis.TableName;
 import org.apache.doris.analysis.TupleDescriptor;
 import org.apache.doris.analysis.TupleId;
+import org.apache.doris.datasource.InternalDataSource;
 import org.apache.doris.thrift.TExplainLevel;
 import org.apache.doris.thrift.TPlanNode;
 import org.apache.doris.thrift.TPlanNodeType;
@@ -55,7 +56,7 @@ public class RepeatNodeTest {
         String[] cols = {"k1", "k2", "k3"};
         List<SlotRef> slots = new ArrayList<>();
         for (String col : cols) {
-            SlotRef expr = new SlotRef(new TableName("testdb", "t"), col);
+            SlotRef expr = new SlotRef(new TableName(InternalDataSource.INTERNAL_DS_NAME, "testdb", "t"), col);
             slots.add(expr);
         }
         try {
@@ -63,7 +64,7 @@ public class RepeatNodeTest {
             f.setAccessible(true);
             Multimap<String, TupleDescriptor> tupleByAlias = ArrayListMultimap.create();
             TupleDescriptor td = new TupleDescriptor(new TupleId(0));
-            td.setTable(analyzerBase.getTableOrAnalysisException(new TableName("testdb", "t")));
+            td.setTable(analyzerBase.getTableOrAnalysisException(new TableName(InternalDataSource.INTERNAL_DS_NAME, "testdb", "t")));
             tupleByAlias.put("testdb.t", td);
             f.set(analyzer, tupleByAlias);
         } catch (NoSuchFieldException | IllegalAccessException e) {

--- a/fe/fe-core/src/test/java/org/apache/doris/planner/RuntimeFilterGeneratorTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/planner/RuntimeFilterGeneratorTest.java
@@ -35,6 +35,7 @@ import org.apache.doris.catalog.PrimitiveType;
 import org.apache.doris.catalog.Table;
 import org.apache.doris.common.UserException;
 import org.apache.doris.common.jmockit.Deencapsulation;
+import org.apache.doris.datasource.InternalDataSource;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.thrift.TPartitionType;
 
@@ -72,7 +73,7 @@ public class RuntimeFilterGeneratorTest {
 
         TupleDescriptor lhsTupleDescriptor = new TupleDescriptor(new TupleId(0));
         lhsScanNode = new OlapScanNode(new PlanNodeId(0), lhsTupleDescriptor, "LEFT SCAN");
-        TableName lhsTableName = new TableName("default_cluster:test_db", "test_lhs_tbl");
+        TableName lhsTableName = new TableName(InternalDataSource.INTERNAL_DS_NAME, "default_cluster:test_db", "test_lhs_tbl");
         SlotRef lhsExpr = new SlotRef(lhsTableName, "test_lhs_col");
         SlotDescriptor lhsSlotDescriptor = new SlotDescriptor(new SlotId(0), lhsTupleDescriptor);
         Column k1 = new Column("test_lhs_col", PrimitiveType.BIGINT);
@@ -86,7 +87,7 @@ public class RuntimeFilterGeneratorTest {
 
         TupleDescriptor rhsTupleDescriptor = new TupleDescriptor(new TupleId(1));
         rhsScanNode = new OlapScanNode(new PlanNodeId(1), rhsTupleDescriptor, "RIGHT SCAN");
-        TableName rhsTableName = new TableName("default_cluster:test_db", "test_rhs_tbl");
+        TableName rhsTableName = new TableName(InternalDataSource.INTERNAL_DS_NAME, "default_cluster:test_db", "test_rhs_tbl");
         SlotRef rhsExpr = new SlotRef(rhsTableName, "test_rhs_col");
         SlotDescriptor rhsSlotDescriptor = new SlotDescriptor(new SlotId(1), rhsTupleDescriptor);
         Column k2 = new Column("test_rhs_col", PrimitiveType.INT);

--- a/fe/fe-core/src/test/java/org/apache/doris/planner/UpdatePlannerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/planner/UpdatePlannerTest.java
@@ -33,6 +33,7 @@ import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.IdGenerator;
 import org.apache.doris.common.jmockit.Deencapsulation;
+import org.apache.doris.datasource.InternalDataSource;
 import org.apache.doris.load.update.UpdatePlanner;
 
 import com.google.common.collect.Lists;
@@ -62,7 +63,7 @@ public class UpdatePlannerTest {
                                                                  @Injectable Column shadowV1,
                                                                  @Injectable Analyzer analyzer) {
         List<Expr> setExprs = Lists.newArrayList();
-        TableName tableName = new TableName(null, "test");
+        TableName tableName = new TableName(InternalDataSource.INTERNAL_DS_NAME, null, "test");
         SlotRef slotRef = new SlotRef(tableName, "V1");
         IntLiteral intLiteral = new IntLiteral(1);
         BinaryPredicate binaryPredicate = new BinaryPredicate(BinaryPredicate.Operator.EQ,
@@ -124,7 +125,7 @@ public class UpdatePlannerTest {
                                             @Injectable Column newV2,
                                             @Injectable Analyzer analyzer) throws AnalysisException {
         List<Expr> setExprs = Lists.newArrayList();
-        TableName tableName = new TableName(null, "test");
+        TableName tableName = new TableName(InternalDataSource.INTERNAL_DS_NAME, null, "test");
         SlotRef slotRef = new SlotRef(tableName, "V1");
         IntLiteral intLiteral = new IntLiteral(1);
         BinaryPredicate binaryPredicate = new BinaryPredicate(BinaryPredicate.Operator.EQ,

--- a/fe/fe-core/src/test/java/org/apache/doris/qe/ShowExecutorTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/qe/ShowExecutorTest.java
@@ -74,6 +74,7 @@ import java.util.List;
 import java.util.function.Function;
 
 public class ShowExecutorTest {
+    private static final String internalCtl = InternalDataSource.INTERNAL_DS_NAME;
     private ConnectContext ctx;
     private Catalog catalog;
     private InternalDataSource ds;
@@ -344,7 +345,7 @@ public class ShowExecutorTest {
             }
         };
 
-        DescribeStmt stmt = new DescribeStmt(new TableName("testCluster:testDb", "testTbl"), false);
+        DescribeStmt stmt = new DescribeStmt(new TableName(internalCtl, "testCluster:testDb", "testTbl"), false);
         try {
             stmt.analyze(analyzer);
         } catch (Exception e) {
@@ -444,7 +445,7 @@ public class ShowExecutorTest {
 
     @Test(expected = AnalysisException.class)
     public void testShowCreateTableEmptyDb() throws AnalysisException {
-        ShowCreateTableStmt stmt = new ShowCreateTableStmt(new TableName("testCluster:emptyDb", "testTable"));
+        ShowCreateTableStmt stmt = new ShowCreateTableStmt(new TableName(internalCtl, "testCluster:emptyDb", "testTable"));
         ShowExecutor executor = new ShowExecutor(ctx, stmt);
         executor.execute();
 
@@ -453,7 +454,7 @@ public class ShowExecutorTest {
 
     @Test(expected = AnalysisException.class)
     public void testShowCreateTableEmptyTbl() throws AnalysisException {
-        ShowCreateTableStmt stmt = new ShowCreateTableStmt(new TableName("testCluster:testDb", "emptyTable"));
+        ShowCreateTableStmt stmt = new ShowCreateTableStmt(new TableName(internalCtl, "testCluster:testDb", "emptyTable"));
         ShowExecutor executor = new ShowExecutor(ctx, stmt);
         ShowResultSet resultSet = executor.execute();
 
@@ -464,7 +465,7 @@ public class ShowExecutorTest {
     public void testShowColumn() throws AnalysisException {
         ctx.setCatalog(catalog);
         ctx.setQualifiedUser("testCluster:testUser");
-        ShowColumnStmt stmt = new ShowColumnStmt(new TableName("testCluster:testDb", "testTbl"), null, null, false);
+        ShowColumnStmt stmt = new ShowColumnStmt(new TableName(internalCtl, "testCluster:testDb", "testTbl"), null, null, false);
         stmt.analyze(AccessTestUtil.fetchAdminAnalyzer(false));
         ShowExecutor executor = new ShowExecutor(ctx, stmt);
         ShowResultSet resultSet = executor.execute();
@@ -477,7 +478,7 @@ public class ShowExecutorTest {
         Assert.assertFalse(resultSet.next());
 
         // verbose
-        stmt = new ShowColumnStmt(new TableName("testCluster:testDb", "testTbl"), null, null, true);
+        stmt = new ShowColumnStmt(new TableName(internalCtl, "testCluster:testDb", "testTbl"), null, null, true);
         stmt.analyze(AccessTestUtil.fetchAdminAnalyzer(false));
         executor = new ShowExecutor(ctx, stmt);
         resultSet = executor.execute();
@@ -491,7 +492,7 @@ public class ShowExecutorTest {
         Assert.assertFalse(resultSet.next());
 
         // pattern
-        stmt = new ShowColumnStmt(new TableName("testCluster:testDb", "testTable"), null, "%1", true);
+        stmt = new ShowColumnStmt(new TableName(internalCtl, "testCluster:testDb", "testTable"), null, "%1", true);
         stmt.analyze(AccessTestUtil.fetchAdminAnalyzer(false));
         executor = new ShowExecutor(ctx, stmt);
         resultSet = executor.execute();
@@ -506,7 +507,7 @@ public class ShowExecutorTest {
     public void testShowView() throws UserException {
         ctx.setCatalog(catalog);
         ctx.setQualifiedUser("testCluster:testUser");
-        ShowViewStmt stmt = new ShowViewStmt("", new TableName("testDb", "testTbl"));
+        ShowViewStmt stmt = new ShowViewStmt("", new TableName(internalCtl, "testDb", "testTbl"));
         stmt.analyze(AccessTestUtil.fetchAdminAnalyzer(true));
         ShowExecutor executor = new ShowExecutor(ctx, stmt);
         ShowResultSet resultSet = executor.execute();
@@ -516,7 +517,7 @@ public class ShowExecutorTest {
 
     @Test
     public void testShowColumnFromUnknownTable() throws AnalysisException {
-        ShowColumnStmt stmt = new ShowColumnStmt(new TableName("testCluster:emptyDb", "testTable"), null, null, false);
+        ShowColumnStmt stmt = new ShowColumnStmt(new TableName(internalCtl, "testCluster:emptyDb", "testTable"), null, null, false);
         stmt.analyze(AccessTestUtil.fetchAdminAnalyzer(false));
         ShowExecutor executor = new ShowExecutor(ctx, stmt);
 
@@ -525,7 +526,7 @@ public class ShowExecutorTest {
         executor.execute();
 
         // empty table
-        stmt = new ShowColumnStmt(new TableName("testCluster:testDb", "emptyTable"), null, null, true);
+        stmt = new ShowColumnStmt(new TableName(internalCtl, "testCluster:testDb", "emptyTable"), null, null, true);
         stmt.analyze(AccessTestUtil.fetchAdminAnalyzer(false));
         executor = new ShowExecutor(ctx, stmt);
 

--- a/fe/fe-core/src/test/java/org/apache/doris/rewrite/ExtractCommonFactorsRuleTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/rewrite/ExtractCommonFactorsRuleTest.java
@@ -25,6 +25,7 @@ import org.apache.doris.analysis.LiteralExpr;
 import org.apache.doris.analysis.SlotRef;
 import org.apache.doris.analysis.TableName;
 import org.apache.doris.common.jmockit.Deencapsulation;
+import org.apache.doris.datasource.InternalDataSource;
 
 import com.google.common.collect.BoundType;
 import com.google.common.collect.Lists;
@@ -40,13 +41,14 @@ import java.util.Map;
 import java.util.Set;
 
 public class ExtractCommonFactorsRuleTest {
+    private static final String internalCtl = InternalDataSource.INTERNAL_DS_NAME;
 
     // Input: k1 in (k2, 1)
     // Result: false
     @Test
     public void testSingleColumnPredicateInColumn() {
-        SlotRef child0 = new SlotRef(new TableName("db1", "tb1"), "k1");
-        SlotRef inColumn = new SlotRef(new TableName("db1", "tb1"), "k2");
+        SlotRef child0 = new SlotRef(new TableName(internalCtl, "db1", "tb1"), "k1");
+        SlotRef inColumn = new SlotRef(new TableName(internalCtl, "db1", "tb1"), "k2");
         IntLiteral intLiteral = new IntLiteral(1);
         List<Expr> inExprList = Lists.newArrayList();
         inExprList.add(inColumn);
@@ -63,8 +65,8 @@ public class ExtractCommonFactorsRuleTest {
     @Test
     public void testMergeTwoClauseRange() {
         // Clause1
-        SlotRef k1SlotRef = new SlotRef(new TableName("db1", "tb1"), "k1");
-        SlotRef k2SlotRef = new SlotRef(new TableName("db1", "tb1"), "k2");
+        SlotRef k1SlotRef = new SlotRef(new TableName(internalCtl, "db1", "tb1"), "k1");
+        SlotRef k2SlotRef = new SlotRef(new TableName(internalCtl, "db1", "tb1"), "k2");
         Range k1Range1 = Range.range(new IntLiteral(1), BoundType.OPEN, new IntLiteral(3), BoundType.OPEN);
         Range k2Range = Range.greaterThan(new IntLiteral(3));
         RangeSet<LiteralExpr> k1RangeSet1 = TreeRangeSet.create();
@@ -97,8 +99,8 @@ public class ExtractCommonFactorsRuleTest {
     @Test
     public void testMergeTwoClauseIn() {
         // Clause1
-        SlotRef k1SlotRef = new SlotRef(new TableName("db1", "tb1"), "k1");
-        SlotRef k2SlotRef = new SlotRef(new TableName("db1", "tb1"), "k2");
+        SlotRef k1SlotRef = new SlotRef(new TableName(internalCtl, "db1", "tb1"), "k1");
+        SlotRef k2SlotRef = new SlotRef(new TableName(internalCtl, "db1", "tb1"), "k2");
         IntLiteral intLiteral1 = new IntLiteral(1);
         IntLiteral intLiteral2 = new IntLiteral(2);
         List<Expr> k1Values1 = Lists.newArrayList();
@@ -140,7 +142,7 @@ public class ExtractCommonFactorsRuleTest {
         RangeSet<LiteralExpr> rangeSet = TreeRangeSet.create();
         rangeSet.add(range1);
         rangeSet.add(range2);
-        SlotRef slotRef = new SlotRef(new TableName("db1", "tb1"), "k1");
+        SlotRef slotRef = new SlotRef(new TableName(internalCtl, "db1", "tb1"), "k1");
 
         ExtractCommonFactorsRule extractCommonFactorsRule = new ExtractCommonFactorsRule();
         Expr result = Deencapsulation.invoke(extractCommonFactorsRule,

--- a/fe/fe-core/src/test/java/org/apache/doris/rewrite/mvrewrite/CountFieldToSumTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/rewrite/mvrewrite/CountFieldToSumTest.java
@@ -24,6 +24,7 @@ import org.apache.doris.analysis.SlotRef;
 import org.apache.doris.analysis.TableName;
 import org.apache.doris.catalog.FunctionSet;
 import org.apache.doris.common.AnalysisException;
+import org.apache.doris.datasource.InternalDataSource;
 import org.apache.doris.rewrite.ExprRewriter;
 
 import com.google.common.collect.Lists;
@@ -39,7 +40,7 @@ public class CountFieldToSumTest {
     @Test
     public void testCountDistinct(@Injectable Analyzer analyzer,
                                   @Injectable FunctionCallExpr functionCallExpr) {
-        TableName tableName = new TableName("db1", "table1");
+        TableName tableName = new TableName(InternalDataSource.INTERNAL_DS_NAME, "db1", "table1");
         SlotRef slotRef = new SlotRef(tableName, "c1");
         List<Expr>  params = Lists.newArrayList();
         params.add(slotRef);


### PR DESCRIPTION
# Proposed changes

## Problem Summary:
Fix https://github.com/apache/doris/pull/10521, multi-catalog query failed for two reasons:
1. The `SelectStmt` does not get the correct catalog.
2. External table should have three level aliases.

Disable querying external views.
Support show create table for external table&view.

## Usage
Without ambiguity, four formats of `select columns` and three formats of `from tables` are supported.
### select columns
1. select col from
2. select tbl.col from
4. select db.tbl.col from
5. select ctl.db.tbl.col from
### from tables
1. select col from tbl
2. select col from db.tbl
3. select col from ctl.db.tbl
### q3 in tpch
take q3 in tpch as an example:
```
SELECT
  l_orderkey, -- no table prefix
  sum(l_extendedprice * (1 - l_discount)) AS revenue,
  o_orderdate,
  o_shippriority
FROM
  dtest.customer,
  dtest.orders,
  hive.hdb.lineitem
WHERE
  c_mktsegment = 'BUILDING'
  AND c_custkey = o_custkey
  AND l_orderkey = o_orderkey
  AND o_orderdate < DATE '1995-03-15'
  AND l_shipdate > DATE '1995-03-15'
GROUP BY
  l_orderkey,
  o_orderdate,
  o_shippriority
ORDER BY
  revenue DESC,
  o_orderdate
LIMIT 10;
```
```
SELECT
  lineitem.l_orderkey, -- with table prefix
  sum(l_extendedprice * (1 - l_discount)) AS revenue,
  o_orderdate,
  o_shippriority
FROM
  dtest.customer,
  dtest.orders,
  hive.hdb.lineitem
WHERE
  c_mktsegment = 'BUILDING'
  AND c_custkey = o_custkey
  AND l_orderkey = o_orderkey
  AND o_orderdate < DATE '1995-03-15'
  AND l_shipdate > DATE '1995-03-15'
GROUP BY
  l_orderkey,
  o_orderdate,
  o_shippriority
ORDER BY
  revenue DESC,
  o_orderdate
LIMIT 10;
```
```
SELECT
  hdb.lineitem.l_orderkey, -- with database prefix
  sum(l_extendedprice * (1 - l_discount)) AS revenue,
  o_orderdate,
  o_shippriority
FROM
  dtest.customer,
  dtest.orders,
  hive.hdb.lineitem
WHERE
  c_mktsegment = 'BUILDING'
  AND c_custkey = o_custkey
  AND l_orderkey = o_orderkey
  AND o_orderdate < DATE '1995-03-15'
  AND l_shipdate > DATE '1995-03-15'
GROUP BY
  l_orderkey,
  o_orderdate,
  o_shippriority
ORDER BY
  revenue DESC,
  o_orderdate
LIMIT 10;
```
```
SELECT
  hive.hdb.lineitem.l_orderkey, -- with catalog prefix
  sum(hive.hdb.lineitem.l_extendedprice * (1 - hive.hdb.lineitem.l_discount)) AS revenue,
  internal.dtest.orders.o_orderdate,
  internal.dtest.orders.o_shippriority
FROM
  internal.dtest.customer,
  internal.dtest.orders,
  hive.hdb.lineitem
WHERE
  c_mktsegment = 'BUILDING'
  AND internal.dtest.customer.c_custkey = internal.dtest.orders.o_custkey
  AND hive.hdb.lineitem.l_orderkey = internal.dtest.orders.o_orderkey
  AND internal.dtest.orders.o_orderdate < DATE '1995-03-15'
  AND hive.hdb.lineitem.l_shipdate > DATE '1995-03-15'
GROUP BY
  hive.hdb.lineitem.l_orderkey,
  internal.dtest.orders.o_orderdate,
  internal.dtest.orders.o_shippriority
ORDER BY
  revenue DESC,
  internal.dtest.orders.o_orderdate
LIMIT 10;
```

## Checklist(Required)

1. Does it affect the original behavior: (No)
6. Has unit tests been added: (No)
7. Has document been added or modified: (No)
8. Does it need to update dependencies: (No)
9. Are there any changes that cannot be rolled back: (No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
