### PR TITLE
[enhancement](nereids) make filter node and join node work in Nereids

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ArithmeticExpr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ArithmeticExpr.java
@@ -321,8 +321,7 @@ public class ArithmeticExpr extends Expr {
                 } else {
                     type = t;
                 }
-                fn = getBuiltinFunction(
-                        analyzer, op.getName(), collectChildReturnTypes(), Function.CompareMode.IS_SUPERTYPE_OF);
+                fn = getBuiltinFunction(op.getName(), collectChildReturnTypes(), Function.CompareMode.IS_SUPERTYPE_OF);
                 if (fn == null) {
                     Preconditions.checkState(false, String.format("No match for op with operand types", toSql()));
                 }
@@ -406,8 +405,7 @@ public class ArithmeticExpr extends Expr {
                             "Unknown arithmetic operation " + op.toString() + " in: " + this.toSql());
                     break;
             }
-            fn = getBuiltinFunction(analyzer, op.name, collectChildReturnTypes(),
-                    Function.CompareMode.IS_IDENTICAL);
+            fn = getBuiltinFunction(op.name, collectChildReturnTypes(), Function.CompareMode.IS_IDENTICAL);
             if (fn == null) {
                 Preconditions.checkState(false, String.format(
                         "No match for vec function '%s' with operand types %s and %s", toSql(), t1, t2));
@@ -420,8 +418,7 @@ public class ArithmeticExpr extends Expr {
                 if (getChild(0).getType().getPrimitiveType() != PrimitiveType.BIGINT) {
                     castChild(type, 0);
                 }
-                fn = getBuiltinFunction(
-                        analyzer, op.getName(), collectChildReturnTypes(), Function.CompareMode.IS_SUPERTYPE_OF);
+                fn = getBuiltinFunction(op.getName(), collectChildReturnTypes(), Function.CompareMode.IS_SUPERTYPE_OF);
                 if (fn == null) {
                     Preconditions.checkState(false, String.format("No match for op with operand types", toSql()));
                 }
@@ -467,8 +464,7 @@ public class ArithmeticExpr extends Expr {
                     break;
             }
             type = castBinaryOp(commonType);
-            fn = getBuiltinFunction(analyzer, fnName, collectChildReturnTypes(),
-                    Function.CompareMode.IS_IDENTICAL);
+            fn = getBuiltinFunction(fnName, collectChildReturnTypes(), Function.CompareMode.IS_IDENTICAL);
             if (fn == null) {
                 Preconditions.checkState(false, String.format(
                         "No match for '%s' with operand types %s and %s", toSql(), t1, t2));

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ArithmeticExpr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ArithmeticExpr.java
@@ -502,4 +502,16 @@ public class ArithmeticExpr extends Expr {
         return 31 * super.hashCode() + Objects.hashCode(op);
     }
 
+    @Override
+    public void finalizeImplForNereids() throws AnalysisException {
+        if (op == Operator.BITNOT) {
+            fn = getBuiltinFunction(op.getName(), collectChildReturnTypes(), Function.CompareMode.IS_SUPERTYPE_OF);
+        } else {
+            fn = getBuiltinFunction(op.name, collectChildReturnTypes(), Function.CompareMode.IS_IDENTICAL);
+        }
+        if (fn == null) {
+            Preconditions.checkState(false, String.format("No match for op with operand types. %s", toSql()));
+        }
+        type = fn.getReturnType();
+    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/BetweenPredicate.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/BetweenPredicate.java
@@ -124,4 +124,9 @@ public class BetweenPredicate extends Predicate {
     public int hashCode() {
         return 31 * super.hashCode() + Boolean.hashCode(isNotBetween);
     }
+
+    @Override
+    public void finalizeImplForNereids() throws AnalysisException {
+        throw new AnalysisException("analyze between predicate for Nereids do not implementation.");
+    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/BinaryPredicate.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/BinaryPredicate.java
@@ -370,15 +370,6 @@ public class BinaryPredicate extends Predicate implements Writable {
         return Type.DOUBLE;
     }
 
-    public void analyzeForNereids() throws AnalysisException {
-        if (isAnalyzed()) {
-            return;
-        }
-        type = Type.BOOLEAN;
-        fn = getBuiltinFunction(op.name, collectChildReturnTypes(), Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
-        analysisDone();
-    }
-
     @Override
     public void analyzeImpl(Analyzer analyzer) throws AnalysisException {
         super.analyzeImpl(analyzer);
@@ -704,5 +695,11 @@ public class BinaryPredicate extends Predicate implements Writable {
             return false;
         }
         return hasNullableChild();
+    }
+
+    @Override
+    public void finalizeImplForNereids() throws AnalysisException {
+        super.finalizeImplForNereids();
+        fn = getBuiltinFunction(op.name, collectChildReturnTypes(), Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/BinaryPredicate.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/BinaryPredicate.java
@@ -278,8 +278,8 @@ public class BinaryPredicate extends Predicate implements Writable {
         //OpcodeRegistry.BuiltinFunction match = OpcodeRegistry.instance().getFunctionInfo(
         //        op.toFilterFunctionOp(), true, true, cmpType, cmpType);
         try {
-            match = getBuiltinFunction(analyzer, op.name, collectChildReturnTypes(),
-                Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
+            match = getBuiltinFunction(op.name, collectChildReturnTypes(),
+                    Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
         } catch (AnalysisException e) {
             Preconditions.checkState(false);
         }
@@ -370,6 +370,15 @@ public class BinaryPredicate extends Predicate implements Writable {
         return Type.DOUBLE;
     }
 
+    public void analyzeForNereids() throws AnalysisException {
+        if (isAnalyzed()) {
+            return;
+        }
+        type = Type.BOOLEAN;
+        fn = getBuiltinFunction(op.name, collectChildReturnTypes(), Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
+        analysisDone();
+    }
+
     @Override
     public void analyzeImpl(Analyzer analyzer) throws AnalysisException {
         super.analyzeImpl(analyzer);
@@ -408,8 +417,7 @@ public class BinaryPredicate extends Predicate implements Writable {
 
         this.opcode = op.getOpcode();
         String opName = op.getName();
-        fn = getBuiltinFunction(analyzer, opName, collectChildReturnTypes(),
-                Function.CompareMode.IS_SUPERTYPE_OF);
+        fn = getBuiltinFunction(opName, collectChildReturnTypes(), Function.CompareMode.IS_SUPERTYPE_OF);
         if (fn == null) {
             Preconditions.checkState(false, String.format(
                     "No match for '%s' with operand types %s and %s", toSql()));

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/CompoundPredicate.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/CompoundPredicate.java
@@ -256,4 +256,9 @@ public class CompoundPredicate extends Predicate {
     public boolean isNullable() {
         return hasNullableChild();
     }
+
+    @Override
+    public void finalizeImplForNereids() throws AnalysisException {
+
+    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/DefaultValueExpr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/DefaultValueExpr.java
@@ -40,4 +40,9 @@ public class DefaultValueExpr extends Expr {
     public Expr clone() {
         return null;
     }
+
+    @Override
+    public void finalizeImplForNereids() throws AnalysisException {
+
+    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/Expr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/Expr.java
@@ -1973,4 +1973,19 @@ public abstract class Expr extends TreeNode<Expr> implements ParseNode, Cloneabl
         }
         return true;
     }
+
+    public final void finalizeForNereids() throws AnalysisException {
+        if (isAnalyzed()) {
+            return;
+        }
+        for (Expr child : children) {
+            child.finalizeForNereids();
+        }
+        finalizeImplForNereids();
+        analysisDone();
+    }
+
+    public void finalizeImplForNereids() throws AnalysisException {
+        throw new AnalysisException("analyze for Nereids do not implementation.");
+    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/Expr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/Expr.java
@@ -1617,8 +1617,7 @@ public abstract class Expr extends TreeNode<Expr> implements ParseNode, Cloneabl
      * Looks up in the catalog the builtin for 'name' and 'argTypes'.
      * Returns null if the function is not found.
      */
-    protected Function getBuiltinFunction(
-            Analyzer analyzer, String name, Type[] argTypes, Function.CompareMode mode)
+    protected Function getBuiltinFunction(String name, Type[] argTypes, Function.CompareMode mode)
             throws AnalysisException {
         FunctionName fnName = new FunctionName(name);
         Function searchDesc = new Function(fnName, Arrays.asList(argTypes), Type.INVALID, false,
@@ -1633,8 +1632,7 @@ public abstract class Expr extends TreeNode<Expr> implements ParseNode, Cloneabl
         return f;
     }
 
-    protected Function getTableFunction(String name, Type[] argTypes,
-                                        Function.CompareMode mode) {
+    protected Function getTableFunction(String name, Type[] argTypes, Function.CompareMode mode) {
         FunctionName fnName = new FunctionName(name);
         Function searchDesc = new Function(fnName, Arrays.asList(argTypes), Type.INVALID, false,
                 VectorizedUtil.isVectorized());

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/FunctionCallExpr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/FunctionCallExpr.java
@@ -793,15 +793,13 @@ public class FunctionCallExpr extends Expr {
      * @throws AnalysisException
      */
     public void analyzeImplForDefaultValue() throws AnalysisException {
-        fn = getBuiltinFunction(null, fnName.getFunction(), new Type[0],
-                Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
+        fn = getBuiltinFunction(fnName.getFunction(), new Type[0], Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
         type = fn.getReturnType();
         for (int i = 0; i < children.size(); ++i) {
             if (getChild(i).getType().isNull()) {
                 uncheckedCastChild(Type.BOOLEAN, i);
             }
         }
-        return;
     }
 
     @Override
@@ -825,8 +823,7 @@ public class FunctionCallExpr extends Expr {
             // There is no version of COUNT() that takes more than 1 argument but after
             // the equal, we only need count(*).
             // TODO: fix how we equal count distinct.
-            fn = getBuiltinFunction(analyzer, fnName.getFunction(), new Type[0],
-                    Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
+            fn = getBuiltinFunction(fnName.getFunction(), new Type[0], Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
             type = fn.getReturnType();
 
             // Make sure BE doesn't see any TYPE_NULL exprs
@@ -854,7 +851,7 @@ public class FunctionCallExpr extends Expr {
             if (!VectorizedUtil.isVectorized()) {
                 type = getChild(0).type.getMaxResolutionType();
             }
-            fn = getBuiltinFunction(analyzer, fnName.getFunction(), new Type[]{type},
+            fn = getBuiltinFunction(fnName.getFunction(), new Type[]{type},
                     Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
         } else if (fnName.getFunction().equalsIgnoreCase("count_distinct")) {
             Type compatibleType = this.children.get(0).getType();
@@ -867,7 +864,7 @@ public class FunctionCallExpr extends Expr {
                 }
             }
 
-            fn = getBuiltinFunction(analyzer, fnName.getFunction(), new Type[]{compatibleType},
+            fn = getBuiltinFunction(fnName.getFunction(), new Type[]{compatibleType},
                     Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
         } else if (fnName.getFunction().equalsIgnoreCase(FunctionSet.WINDOW_FUNNEL)) {
             if (fnParams.exprs() == null || fnParams.exprs().size() < 4) {
@@ -895,14 +892,14 @@ public class FunctionCallExpr extends Expr {
                 }
                 childTypes[i] = children.get(i).type;
             }
-            fn = getBuiltinFunction(analyzer, fnName.getFunction(), childTypes,
+            fn = getBuiltinFunction(fnName.getFunction(), childTypes,
                     Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
         } else if (fnName.getFunction().equalsIgnoreCase("if")) {
             Type[] childTypes = collectChildReturnTypes();
             Type assignmentCompatibleType = ScalarType.getAssignmentCompatibleType(childTypes[1], childTypes[2], true);
             childTypes[1] = assignmentCompatibleType;
             childTypes[2] = assignmentCompatibleType;
-            fn = getBuiltinFunction(analyzer, fnName.getFunction(), childTypes,
+            fn = getBuiltinFunction(fnName.getFunction(), childTypes,
                     Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
         } else {
             // now first find table function in table function sets
@@ -917,7 +914,7 @@ public class FunctionCallExpr extends Expr {
                 // now first find function in built-in functions
                 if (Strings.isNullOrEmpty(fnName.getDb())) {
                     Type[] childTypes = collectChildReturnTypes();
-                    fn = getBuiltinFunction(analyzer, fnName.getFunction(), childTypes,
+                    fn = getBuiltinFunction(fnName.getFunction(), childTypes,
                             Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
                 }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/FunctionCallExpr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/FunctionCallExpr.java
@@ -1254,4 +1254,9 @@ public class FunctionCallExpr extends Expr {
         }
         return result.toString();
     }
+
+    @Override
+    public void finalizeImplForNereids() throws AnalysisException {
+        super.finalizeImplForNereids();
+    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/GroupingFunctionCallExpr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/GroupingFunctionCallExpr.java
@@ -73,8 +73,7 @@ public class GroupingFunctionCallExpr extends FunctionCallExpr {
         }
         Type[] childTypes = new Type[1];
         childTypes[0] = Type.BIGINT;
-        fn = getBuiltinFunction(analyzer, getFnName().getFunction(), childTypes,
-                Function.CompareMode.IS_IDENTICAL);
+        fn = getBuiltinFunction(getFnName().getFunction(), childTypes, Function.CompareMode.IS_IDENTICAL);
         this.type = fn.getReturnType();
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/InPredicate.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/InPredicate.java
@@ -319,4 +319,29 @@ public class InPredicate extends Predicate {
     public boolean isNullable() {
         return hasNullableChild();
     }
+
+    @Override
+    public void finalizeImplForNereids() throws AnalysisException {
+        super.finalizeImplForNereids();
+        boolean allConstant = true;
+        for (int i = 1; i < children.size(); ++i) {
+            if (!children.get(i).isConstant()) {
+                allConstant = false;
+                break;
+            }
+        }
+        // Only lookup fn_ if all subqueries have been rewritten. If the second child is a
+        // subquery, it will have type ArrayType, which cannot be resolved to a builtin
+        // function and will fail analysis.
+        Type[] argTypes = {getChild(0).type, getChild(1).type};
+        if (allConstant) {
+            // fn = getBuiltinFunction(analyzer, isNotIn ? NOT_IN_SET_LOOKUP : IN_SET_LOOKUP,
+            // argTypes, Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
+            opcode = isNotIn ? TExprOpcode.FILTER_NOT_IN : TExprOpcode.FILTER_IN;
+        } else {
+            fn = getBuiltinFunction(isNotIn ? NOT_IN_ITERATE : IN_ITERATE,
+                    argTypes, Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
+            opcode = isNotIn ? TExprOpcode.FILTER_NEW_NOT_IN : TExprOpcode.FILTER_NEW_IN;
+        }
+    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/InPredicate.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/InPredicate.java
@@ -199,7 +199,7 @@ public class InPredicate extends Predicate {
             // argTypes, Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
             opcode = isNotIn ? TExprOpcode.FILTER_NOT_IN : TExprOpcode.FILTER_IN;
         } else {
-            fn = getBuiltinFunction(analyzer, isNotIn ? NOT_IN_ITERATE : IN_ITERATE,
+            fn = getBuiltinFunction(isNotIn ? NOT_IN_ITERATE : IN_ITERATE,
                     argTypes, Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
             opcode = isNotIn ? TExprOpcode.FILTER_NEW_NOT_IN : TExprOpcode.FILTER_NEW_IN;
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/IsNullPredicate.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/IsNullPredicate.java
@@ -113,11 +113,9 @@ public class IsNullPredicate extends Predicate {
     public void analyzeImpl(Analyzer analyzer) throws AnalysisException {
         super.analyzeImpl(analyzer);
         if (isNotNull) {
-            fn = getBuiltinFunction(
-                    analyzer, IS_NOT_NULL, collectChildReturnTypes(), Function.CompareMode.IS_INDISTINGUISHABLE);
+            fn = getBuiltinFunction(IS_NOT_NULL, collectChildReturnTypes(), Function.CompareMode.IS_INDISTINGUISHABLE);
         } else {
-            fn = getBuiltinFunction(
-                    analyzer, IS_NULL, collectChildReturnTypes(), Function.CompareMode.IS_INDISTINGUISHABLE);
+            fn = getBuiltinFunction(IS_NULL, collectChildReturnTypes(), Function.CompareMode.IS_INDISTINGUISHABLE);
         }
         Preconditions.checkState(fn != null, "tupleisNull fn == NULL");
 

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/IsNullPredicate.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/IsNullPredicate.java
@@ -154,4 +154,15 @@ public class IsNullPredicate extends Predicate {
         }
         return childValue instanceof NullLiteral ? new BoolLiteral(!isNotNull) : new BoolLiteral(isNotNull);
     }
+
+    @Override
+    public void finalizeImplForNereids() throws AnalysisException {
+        super.finalizeImplForNereids();
+        if (isNotNull) {
+            fn = getBuiltinFunction(IS_NOT_NULL, collectChildReturnTypes(), Function.CompareMode.IS_INDISTINGUISHABLE);
+        } else {
+            fn = getBuiltinFunction(IS_NULL, collectChildReturnTypes(), Function.CompareMode.IS_INDISTINGUISHABLE);
+        }
+        Preconditions.checkState(fn != null, "tupleisNull fn == NULL");
+    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/LikePredicate.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/LikePredicate.java
@@ -154,4 +154,10 @@ public class LikePredicate extends Predicate {
         return 31 * super.hashCode() + Objects.hashCode(op);
     }
 
+    @Override
+    public void finalizeImplForNereids() throws AnalysisException {
+        super.finalizeImplForNereids();
+        fn = getBuiltinFunction(op.toString(), collectChildReturnTypes(),
+                Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
+    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/LikePredicate.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/LikePredicate.java
@@ -134,8 +134,8 @@ public class LikePredicate extends Predicate {
             uncheckedCastChild(Type.VARCHAR, 0);
         }
 
-        fn = getBuiltinFunction(analyzer, op.toString(),
-                collectChildReturnTypes(), Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
+        fn = getBuiltinFunction(op.toString(), collectChildReturnTypes(),
+                Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
 
         if (!getChild(1).getType().isNull() && getChild(1).isLiteral() && (op == Operator.REGEXP)) {
             // let's make sure the pattern works

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/LiteralExpr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/LiteralExpr.java
@@ -247,4 +247,9 @@ public abstract class LiteralExpr extends Expr implements Comparable<LiteralExpr
     public boolean isNullable() {
         return this instanceof NullLiteral;
     }
+
+    @Override
+    public void finalizeImplForNereids() throws AnalysisException {
+
+    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/Predicate.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/Predicate.java
@@ -156,4 +156,9 @@ public abstract class Predicate extends Expr {
     public Pair<SlotId, SlotId> getEqSlots() {
         return null;
     }
+
+    @Override
+    public void finalizeImplForNereids() throws AnalysisException {
+        type = Type.BOOLEAN;
+    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/SlotRef.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/SlotRef.java
@@ -441,4 +441,9 @@ public class SlotRef extends Expr {
         Preconditions.checkNotNull(desc);
         return desc.getIsNullable();
     }
+
+    @Override
+    public void finalizeImplForNereids() throws AnalysisException {
+
+    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/TimestampArithmeticExpr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/TimestampArithmeticExpr.java
@@ -213,8 +213,8 @@ public class TimestampArithmeticExpr extends Expr {
                     (op == ArithmeticExpr.Operator.ADD) ? "ADD" : "SUB");
         }
 
-        fn = getBuiltinFunction(analyzer, funcOpName.toLowerCase(),
-                collectChildReturnTypes(), Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
+        fn = getBuiltinFunction(funcOpName.toLowerCase(), collectChildReturnTypes(),
+                Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
         LOG.debug("fn is {} name is {}", fn, funcOpName);
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/TupleIsNullPredicate.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/TupleIsNullPredicate.java
@@ -198,4 +198,9 @@ public class TupleIsNullPredicate extends Predicate {
     public boolean isNullable() {
         return false;
     }
+
+    @Override
+    public void finalizeImplForNereids() throws AnalysisException {
+        super.finalizeImplForNereids();
+    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/NereidsPlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/NereidsPlanner.java
@@ -31,6 +31,7 @@ import org.apache.doris.nereids.glue.translator.PhysicalPlanTranslator;
 import org.apache.doris.nereids.glue.translator.PlanTranslatorContext;
 import org.apache.doris.nereids.jobs.AnalyzeRulesJob;
 import org.apache.doris.nereids.jobs.OptimizeRulesJob;
+import org.apache.doris.nereids.jobs.PredicatePushDownRulesJob;
 import org.apache.doris.nereids.memo.Group;
 import org.apache.doris.nereids.memo.GroupExpression;
 import org.apache.doris.nereids.memo.Memo;
@@ -135,6 +136,9 @@ public class NereidsPlanner extends Planner {
     private PhysicalPlan doPlan() {
         AnalyzeRulesJob analyzeRulesJob = new AnalyzeRulesJob(plannerContext);
         analyzeRulesJob.execute();
+
+        PredicatePushDownRulesJob predicatePushDownRulesJob = new PredicatePushDownRulesJob(plannerContext);
+        predicatePushDownRulesJob.execute();
 
         OptimizeRulesJob optimizeRulesJob = new OptimizeRulesJob(plannerContext);
         optimizeRulesJob.execute();

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/ExpressionTranslator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/ExpressionTranslator.java
@@ -73,9 +73,11 @@ public class ExpressionTranslator extends DefaultExpressionVisitor<Expr, PlanTra
 
     @Override
     public Expr visitEqualTo(EqualTo equalTo, PlanTranslatorContext context) {
-        return new BinaryPredicate(Operator.EQ,
+        BinaryPredicate binaryPredicate = new BinaryPredicate(Operator.EQ,
                 equalTo.child(0).accept(this, context),
                 equalTo.child(1).accept(this, context));
+        binaryPredicate.setType(Type.BOOLEAN);
+        return binaryPredicate;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/ExpressionTranslator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/ExpressionTranslator.java
@@ -78,7 +78,7 @@ public class ExpressionTranslator extends DefaultExpressionVisitor<Expr, PlanTra
                 equalTo.child(0).accept(this, context),
                 equalTo.child(1).accept(this, context));
         try {
-            binaryPredicate.analyze(null);
+            binaryPredicate.analyzeForNereids();
         } catch (AnalysisException e) {
             throw new RuntimeException(e);
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/ExpressionTranslator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/ExpressionTranslator.java
@@ -28,6 +28,7 @@ import org.apache.doris.analysis.IntLiteral;
 import org.apache.doris.analysis.NullLiteral;
 import org.apache.doris.analysis.StringLiteral;
 import org.apache.doris.catalog.Type;
+import org.apache.doris.common.AnalysisException;
 import org.apache.doris.nereids.trees.NodeType;
 import org.apache.doris.nereids.trees.expressions.Arithmetic;
 import org.apache.doris.nereids.trees.expressions.Between;
@@ -76,7 +77,11 @@ public class ExpressionTranslator extends DefaultExpressionVisitor<Expr, PlanTra
         BinaryPredicate binaryPredicate = new BinaryPredicate(Operator.EQ,
                 equalTo.child(0).accept(this, context),
                 equalTo.child(1).accept(this, context));
-        binaryPredicate.setType(Type.BOOLEAN);
+        try {
+            binaryPredicate.analyze(null);
+        } catch (AnalysisException e) {
+            throw new RuntimeException(e);
+        }
         return binaryPredicate;
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/PhysicalPlanTranslator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/PhysicalPlanTranslator.java
@@ -41,6 +41,7 @@ import org.apache.doris.nereids.operators.plans.physical.PhysicalOperator;
 import org.apache.doris.nereids.operators.plans.physical.PhysicalProject;
 import org.apache.doris.nereids.properties.OrderKey;
 import org.apache.doris.nereids.trees.expressions.EqualTo;
+import org.apache.doris.nereids.trees.expressions.ExprId;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.NamedExpression;
 import org.apache.doris.nereids.trees.expressions.Slot;
@@ -376,8 +377,9 @@ public class PhysicalPlanTranslator extends PlanOperatorVisitor<PlanFragment, Pl
     }
 
     private static Expression swapEqualToForChildrenOrder(EqualTo equalTo, List<Slot> leftOutput) {
-        Set<Slot> leftSlots = SlotExtractor.extractSlot(equalTo.left());
-        if (leftSlots.containsAll(leftOutput)) {
+        Set<ExprId> leftSlots = SlotExtractor.extractSlot(equalTo.left()).stream()
+                .map(NamedExpression::getExprId).collect(Collectors.toSet());
+        if (leftOutput.stream().map(NamedExpression::getExprId).collect(Collectors.toSet()).containsAll(leftSlots)) {
             return equalTo;
         } else {
             return new EqualTo(equalTo.right(), equalTo.left());

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/PhysicalPlanTranslator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/PhysicalPlanTranslator.java
@@ -329,15 +329,6 @@ public class PhysicalPlanTranslator extends PlanOperatorVisitor<PlanFragment, Pl
                 requiredSlotIdList.add(((SlotRef) expr).getDesc().getId().asInt());
             }
         }
-//        for (TupleId tupleId : inputPlanNode.getTupleIds()) {
-//            TupleDescriptor tupleDescriptor = context.getTupleDesc(tupleId);
-//            Preconditions.checkNotNull(tupleDescriptor);
-//            List<SlotDescriptor> slotDescList = tupleDescriptor.getSlots();
-//            slotDescList.removeIf(slotDescriptor -> !requiredSlotIdList.contains(slotDescriptor.getId().asInt()));
-//            for (int i = 0; i < slotDescList.size(); i++) {
-//                slotDescList.get(i).setSlotOffset(i);
-//            }
-//        }
         return inputFragment;
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/PhysicalPlanTranslator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/PhysicalPlanTranslator.java
@@ -21,13 +21,11 @@ import org.apache.doris.analysis.AggregateInfo;
 import org.apache.doris.analysis.BaseTableRef;
 import org.apache.doris.analysis.Expr;
 import org.apache.doris.analysis.FunctionCallExpr;
-import org.apache.doris.analysis.SlotDescriptor;
 import org.apache.doris.analysis.SlotRef;
 import org.apache.doris.analysis.SortInfo;
 import org.apache.doris.analysis.TableName;
 import org.apache.doris.analysis.TableRef;
 import org.apache.doris.analysis.TupleDescriptor;
-import org.apache.doris.analysis.TupleId;
 import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.catalog.Table;
 import org.apache.doris.nereids.exceptions.AnalysisException;
@@ -331,15 +329,15 @@ public class PhysicalPlanTranslator extends PlanOperatorVisitor<PlanFragment, Pl
                 requiredSlotIdList.add(((SlotRef) expr).getDesc().getId().asInt());
             }
         }
-        for (TupleId tupleId : inputPlanNode.getTupleIds()) {
-            TupleDescriptor tupleDescriptor = context.getTupleDesc(tupleId);
-            Preconditions.checkNotNull(tupleDescriptor);
-            List<SlotDescriptor> slotDescList = tupleDescriptor.getSlots();
-            slotDescList.removeIf(slotDescriptor -> !requiredSlotIdList.contains(slotDescriptor.getId().asInt()));
-            for (int i = 0; i < slotDescList.size(); i++) {
-                slotDescList.get(i).setSlotOffset(i);
-            }
-        }
+//        for (TupleId tupleId : inputPlanNode.getTupleIds()) {
+//            TupleDescriptor tupleDescriptor = context.getTupleDesc(tupleId);
+//            Preconditions.checkNotNull(tupleDescriptor);
+//            List<SlotDescriptor> slotDescList = tupleDescriptor.getSlots();
+//            slotDescList.removeIf(slotDescriptor -> !requiredSlotIdList.contains(slotDescriptor.getId().asInt()));
+//            for (int i = 0; i < slotDescList.size(); i++) {
+//                slotDescList.get(i).setSlotOffset(i);
+//            }
+//        }
         return inputFragment;
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/PhysicalPlanTranslator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/PhysicalPlanTranslator.java
@@ -242,8 +242,9 @@ public class PhysicalPlanTranslator extends PlanOperatorVisitor<PlanFragment, Pl
     @Override
     public PlanFragment visitPhysicalHashJoin(
             PhysicalBinaryPlan<PhysicalHashJoin, Plan, Plan> hashJoin, PlanTranslatorContext context) {
-        PlanFragment leftFragment = visit(hashJoin.child(0), context);
+        // NOTICE: We must visit from right to left, to ensure the last fragment is root fragment
         PlanFragment rightFragment = visit(hashJoin.child(1), context);
+        PlanFragment leftFragment = visit(hashJoin.child(0), context);
         PhysicalHashJoin physicalHashJoin = hashJoin.getOperator();
         Expression predicateExpr = physicalHashJoin.getCondition().get();
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/PhysicalPlanTranslator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/PhysicalPlanTranslator.java
@@ -242,7 +242,7 @@ public class PhysicalPlanTranslator extends PlanOperatorVisitor<PlanFragment, Pl
     public PlanFragment visitPhysicalHashJoin(
             PhysicalBinaryPlan<PhysicalHashJoin, Plan, Plan> hashJoin, PlanTranslatorContext context) {
         PlanFragment leftFragment = visit(hashJoin.child(0), context);
-        PlanFragment rightFragment = visit(hashJoin.child(0), context);
+        PlanFragment rightFragment = visit(hashJoin.child(1), context);
         PhysicalHashJoin physicalHashJoin = hashJoin.getOperator();
         Expression predicateExpr = physicalHashJoin.getCondition().get();
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/PredicatePushDownRulesJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/PredicatePushDownRulesJob.java
@@ -1,0 +1,33 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.jobs;
+
+import org.apache.doris.nereids.PlannerContext;
+import org.apache.doris.nereids.rules.rewrite.logical.PushPredicateThroughJoin;
+
+import com.google.common.collect.ImmutableList;
+
+public class PredicatePushDownRulesJob extends BatchRulesJob {
+    public PredicatePushDownRulesJob(PlannerContext plannerContext) {
+        super(plannerContext);
+        rulesJob.addAll(ImmutableList.of(
+                topDownBatch(ImmutableList.of(
+                        new PushPredicateThroughJoin())
+                )));
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/PredicatePushDownRulesJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/PredicatePushDownRulesJob.java
@@ -22,6 +22,9 @@ import org.apache.doris.nereids.rules.rewrite.logical.PushPredicateThroughJoin;
 
 import com.google.common.collect.ImmutableList;
 
+/**
+ * execute predicate push down job.
+ */
 public class PredicatePushDownRulesJob extends BatchRulesJob {
     public PredicatePushDownRulesJob(PlannerContext plannerContext) {
         super(plannerContext);

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/util/Utils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/util/Utils.java
@@ -20,6 +20,8 @@ package org.apache.doris.nereids.util;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.Slot;
 
+import com.google.common.collect.Lists;
+
 import java.util.List;
 
 /**
@@ -47,6 +49,6 @@ public class Utils {
 
     // TODO: implement later
     public static List<Expression> extractConjuncts(Expression expr) {
-        return null;
+        return Lists.newArrayList(expr);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/util/Utils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/util/Utils.java
@@ -17,13 +17,6 @@
 
 package org.apache.doris.nereids.util;
 
-import org.apache.doris.nereids.trees.expressions.Expression;
-import org.apache.doris.nereids.trees.expressions.Slot;
-
-import com.google.common.collect.Lists;
-
-import java.util.List;
-
 /**
  * Utils for Nereids.
  */
@@ -40,15 +33,5 @@ public class Utils {
         } else {
             return part.replace("`", "``");
         }
-    }
-
-    // TODO: implement later
-    public static List<Expression> getEqConjuncts(List<Slot> left, List<Slot> right, Expression eqExpr) {
-        return null;
-    }
-
-    // TODO: implement later
-    public static List<Expression> extractConjuncts(Expression expr) {
-        return Lists.newArrayList(expr);
     }
 }


### PR DESCRIPTION
# Proposed changes

enhancement
- add functions `finalizeForNereids` and `finalizeImplForNereids` in stale expression to generate some attributes using in BE.
- remove unnecessary parameter `Analyzer` in function `getBuiltinFunction`
- swap join condition if its left hand expression related to right table
- change join physical implementation to broadcast hash join 
- add push predicate rule into planner

fix
- swap join children visit order to ensure the last fragment is root
- avoid visit join left child twice

known issues
- expression compute will generate a wrong answer when expression include arithmetic with two literal children.

## Checklist(Required)

1. Does it affect the original behavior: No
2. Has unit tests been added: No
3. Has document been added or modified: No Need
4. Does it need to update dependencies: No
5. Are there any changes that cannot be rolled back: No
