### PR TITLE
[docs] fix explode-json-array docs format

### DIFF
--- a/docs/en/docs/sql-manual/sql-functions/table-functions/explode-json-array.md
+++ b/docs/en/docs/sql-manual/sql-functions/table-functions/explode-json-array.md
@@ -24,7 +24,7 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-## `explode_json_array`
+## explode_json_array
 
 ### description
 

--- a/docs/zh-CN/docs/sql-manual/sql-functions/table-functions/explode-json-array.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/table-functions/explode-json-array.md
@@ -24,7 +24,7 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-## `explode_json_array`
+## explode_json_array
 
 ### description
 


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

While search explode in docs, explode-json-array has wrong format with other table functions:

<img width="415" alt="image" src="https://user-images.githubusercontent.com/10771715/177267630-1c53dee6-c3e6-479c-84d4-ec8bb9aa3256.png">

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
