### PR TITLE
[Improvement] remove `beHttpAddress` in regression test

### DIFF
--- a/regression-test/conf/regression-conf.groovy
+++ b/regression-test/conf/regression-conf.groovy
@@ -28,8 +28,6 @@ feHttpAddress = "127.0.0.1:8030"
 feHttpUser = "root"
 feHttpPassword = ""
 
-beHttpAddress = "127.0.0.1:8040"
-
 // set DORIS_HOME by system properties
 // e.g. java -DDORIS_HOME=./
 suitePath = "${DORIS_HOME}/regression-test/suites"

--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/Config.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/Config.groovy
@@ -43,8 +43,6 @@ class Config {
     public String feHttpUser
     public String feHttpPassword
 
-    public String beHttpAddress
-
     public String suitePath
     public String dataPath
     public String pluginPath
@@ -79,7 +77,7 @@ class Config {
     Config() {}
 
     Config(String defaultDb, String jdbcUrl, String jdbcUser, String jdbcPassword,
-           String feHttpAddress, String feHttpUser, String feHttpPassword, String beHttpAddress,
+           String feHttpAddress, String feHttpUser, String feHttpPassword,
            String suitePath, String dataPath, String testGroups, String excludeGroups,
            String testSuites, String excludeSuites, String testDirectories, String excludeDirectories,
            String pluginPath) {
@@ -90,7 +88,6 @@ class Config {
         this.feHttpAddress = feHttpAddress
         this.feHttpUser = feHttpUser
         this.feHttpPassword = feHttpPassword
-        this.beHttpAddress = beHttpAddress
         this.suitePath = suitePath
         this.dataPath = dataPath
         this.testGroups = testGroups
@@ -152,7 +149,6 @@ class Config {
                 .toSet()
 
         config.feHttpAddress = cmd.getOptionValue(feHttpAddressOpt, config.feHttpAddress)
-        config.beHttpAddress = cmd.getOptionValue(beHttpAddressOpt, config.beHttpAddress)
         try {
             Inet4Address host = Inet4Address.getByName(config.feHttpAddress.split(":")[0]) as Inet4Address
             int port = Integer.valueOf(config.feHttpAddress.split(":")[1])
@@ -194,7 +190,6 @@ class Config {
             configToString(obj.feHttpAddress),
             configToString(obj.feHttpUser),
             configToString(obj.feHttpPassword),
-            configToString(obj.beHttpAddress),
             configToString(obj.suitePath),
             configToString(obj.dataPath),
             configToString(obj.testGroups),
@@ -243,11 +238,6 @@ class Config {
         if (config.feHttpAddress == null) {
             config.feHttpAddress = "127.0.0.1:8030"
             log.info("Set feHttpAddress to '${config.feHttpAddress}' because not specify.".toString())
-        }
-
-        if (config.beHttpAddress == null) {
-            config.beHttpAddress = "127.0.0.1:8040"
-            log.info("Set beHttpAddress to '${config.beHttpAddress}' because not specify.".toString())
         }
 
         if (config.feHttpUser == null) {

--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/ConfigOptions.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/ConfigOptions.groovy
@@ -35,7 +35,6 @@ class ConfigOptions {
     static Option feHttpAddressOpt
     static Option feHttpUserOpt
     static Option feHttpPasswordOpt
-    static Option beHttpAddressOpt
     static Option pathOpt
     static Option dataOpt
     static Option pluginOpt
@@ -205,14 +204,6 @@ class ConfigOptions {
                 .longOpt("feHttpPassword")
                 .desc("the password of fe http server")
                 .build()
-        beHttpAddressOpt = Option.builder("ba")
-                .argName("beAddress")
-                .required(false)
-                .hasArg(true)
-                .type(String.class)
-                .longOpt("beHttpAddress")
-                .desc("the be http address, format is ip:port")
-                .build()
         genOutOpt = Option.builder("genOut")
                 .required(false)
                 .hasArg(false)
@@ -296,7 +287,6 @@ class ConfigOptions {
                 .addOption(feHttpAddressOpt)
                 .addOption(feHttpUserOpt)
                 .addOption(feHttpPasswordOpt)
-                .addOption(beHttpAddressOpt)
                 .addOption(genOutOpt)
                 .addOption(confFileOpt)
                 .addOption(forceGenOutOpt)


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

Remove config `beHttpAddress` from regression test.

Since we can't assume regression environment, it's recommended to get BE config by `show backends` statement in mysql client.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
