### PR TITLE
[Enhancement] Improve TCMalloc Hook consume MemTracker performance

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -658,7 +658,7 @@ CONF_mInt16(mem_tracker_level, "0");
 // smaller than this value will continue to accumulate. specified as number of bytes.
 // Decreasing this value will increase the frequency of consume/release.
 // Increasing this value will cause MemTracker statistics to be inaccurate.
-CONF_mInt32(mem_tracker_consume_min_size_bytes, "2097152");
+CONF_mInt32(mem_tracker_consume_min_size_bytes, "4194304");
 
 // When MemTracker is a negative value, it is considered that a memory leak has occurred,
 // but the actual MemTracker records inaccurately will also cause a negative value,

--- a/be/src/runtime/exec_env.h
+++ b/be/src/runtime/exec_env.h
@@ -73,8 +73,6 @@ class ClientCache;
 
 class HeartbeatFlags;
 
-static bool exec_env_existed = false;
-
 // Execution environment for queries/plan fragments.
 // Contains all required global structures, and handles to
 // singleton services. Clients must call StartServices exactly
@@ -90,7 +88,6 @@ public:
     /// we return the most recently created instance.
     static ExecEnv* GetInstance() {
         static ExecEnv s_exec_env;
-        exec_env_existed = true;
         return &s_exec_env;
     }
 

--- a/be/src/runtime/load_channel.h
+++ b/be/src/runtime/load_channel.h
@@ -40,7 +40,8 @@ class Cache;
 class LoadChannel {
 public:
     LoadChannel(const UniqueId& load_id, std::shared_ptr<MemTracker>& mem_tracker,
-                int64_t timeout_s, bool is_high_priority, const std::string& sender_ip, bool is_ve);
+                int64_t timeout_s, bool is_high_priority, const std::string& sender_ip,
+                bool is_vec);
     ~LoadChannel();
 
     // open a new load channel if not exist

--- a/be/src/runtime/mem_tracker.cpp
+++ b/be/src/runtime/mem_tracker.cpp
@@ -185,7 +185,7 @@ void MemTracker::init_virtual() {
 MemTracker::~MemTracker() {
     consume(_untracked_mem.exchange(0)); // before memory_leak_check
     // TCMalloc hook will be triggered during destructor memtracker, may cause crash.
-    if (_label == "Process") STOP_THREAD_LOCAL_MEM_TRACKER(false);
+    if (_label == "Process") doris::thread_local_ctx._init = false;
     if (!_virtual && config::memory_leak_detection) MemTracker::memory_leak_check(this);
     if (!_virtual && parent()) {
         // Do not call release on the parent tracker to avoid repeated releases.

--- a/be/src/runtime/thread_mem_tracker_mgr.h
+++ b/be/src/runtime/thread_mem_tracker_mgr.h
@@ -48,13 +48,6 @@ struct ConsumeErrCallBackInfo {
     }
 };
 
-// If there is a memory new/delete operation in the consume method, it may enter infinite recursion.
-// Note: After the tracker is stopped, the memory alloc in the consume method should be released in time,
-// otherwise the MemTracker statistics will be inaccurate.
-// In some cases, we want to turn off thread automatic memory statistics, manually call consume.
-// In addition, when ~RootTracker, TCMalloc delete hook release RootTracker will crash.
-inline thread_local bool start_thread_mem_tracker = false;
-
 // TCMalloc new/delete Hook is counted in the memory_tracker of the current thread.
 //
 // In the original design, the MemTracker consume method is called before the memory is allocated.
@@ -72,7 +65,6 @@ public:
         _mem_trackers.clear();
         _untracked_mems.clear();
         _mem_tracker_labels.clear();
-        start_thread_mem_tracker = false;
     }
 
     // After thread initialization, calling `init` again must call `clear_untracked_mems` first
@@ -177,6 +169,7 @@ private:
     phmap::flat_hash_map<int64_t, std::string> _mem_tracker_labels;
     // If true, call memtracker try_consume, otherwise call consume.
     bool _check_limit;
+    // If there is a memory new/delete operation in the consume method, it may enter infinite recursion.
     bool _stop_consume = false;
 
     int64_t _tracker_id;


### PR DESCRIPTION
# Proposed changes

Issue Number: close #10583

## Motivation
In the previous test, consume mem tracker based on tcmalloc hook is expected to bring 2% performance loss to the query.

But in extreme cases, when load JSON data, the tcmalloc hook may bring about a 30% performance loss.

The performance loss is divided into five parts:
1. Calculate the actual system memory size of this alloc/free;
2. After accumulating to 2M, consume mem tracker;
3. Get bthread tls;
4. The function call introduced for consuming mem tracker in tls;
5. The hook itself;
![image](https://user-images.githubusercontent.com/107781942/177357859-be166788-149e-4e28-bc51-922bdb46f91a.png)

## Solution
1. Avoid trying to get bthread tls in every hook;
2. Optimize unnecessary conditional judgments;
3. Reduce the number of function call layers in the hook;
4. Modified to consume mem tracker after accumulating 4M;

In the test environment, this can reduce the performance loss of tcmalloc hook from 6% to 2%.
Divided into three parts:
1. Calculate the actual system memory size of this alloc/free, 1/3 of the loss;
2. Consume mem tracker after accumulating 4M, 1/6 of the loss;
3. The hook itself, 1/2 of the loss;
![image](https://user-images.githubusercontent.com/107781942/177382753-2dc96d23-d1c5-4f0b-9b79-9882462a4f66.png)





## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
