### PR TITLE
[enhancement](nereids) add betweentocompound rewrite rule for ssb

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/AnalyzeRulesJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/AnalyzeRulesJob.java
@@ -18,6 +18,7 @@
 package org.apache.doris.nereids.jobs;
 
 import org.apache.doris.nereids.PlannerContext;
+import org.apache.doris.nereids.rules.analysis.BindFunction;
 import org.apache.doris.nereids.rules.analysis.BindRelation;
 import org.apache.doris.nereids.rules.analysis.BindSlotReference;
 
@@ -37,7 +38,8 @@ public class AnalyzeRulesJob extends BatchRulesJob {
         rulesJob.addAll(ImmutableList.of(
                 bottomUpBatch(ImmutableList.of(
                         new BindRelation(),
-                        new BindSlotReference())
+                        new BindSlotReference(),
+                        new BindFunction())
                 )));
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rewrite/ExpressionRuleExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rewrite/ExpressionRuleExecutor.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.nereids.rules.expression.rewrite;
 
+import org.apache.doris.nereids.rules.expression.rewrite.rules.BetweenToCompoundRule;
 import org.apache.doris.nereids.rules.expression.rewrite.rules.NormalizeExpressionRule;
 import org.apache.doris.nereids.rules.expression.rewrite.rules.SimplifyNotExprRule;
 import org.apache.doris.nereids.trees.expressions.Expression;
@@ -33,7 +34,8 @@ public class ExpressionRuleExecutor {
 
     public static final List<ExpressionRewriteRule> REWRITE_RULES = ImmutableList.of(
         new SimplifyNotExprRule(),
-        new NormalizeExpressionRule()
+        new NormalizeExpressionRule(),
+        new BetweenToCompoundRule()
     );
 
     private final ExpressionRewriteContext ctx;

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rewrite/ExpressionRuleExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rewrite/ExpressionRuleExecutor.java
@@ -33,9 +33,9 @@ import java.util.List;
 public class ExpressionRuleExecutor {
 
     public static final List<ExpressionRewriteRule> REWRITE_RULES = ImmutableList.of(
+        new BetweenToCompoundRule(),
         new SimplifyNotExprRule(),
-        new NormalizeExpressionRule(),
-        new BetweenToCompoundRule()
+        new NormalizeExpressionRule()
     );
 
     private final ExpressionRewriteContext ctx;

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rewrite/ExpressionRuleExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rewrite/ExpressionRuleExecutor.java
@@ -18,7 +18,7 @@
 package org.apache.doris.nereids.rules.expression.rewrite;
 
 import org.apache.doris.nereids.rules.expression.rewrite.rules.BetweenToCompoundRule;
-import org.apache.doris.nereids.rules.expression.rewrite.rules.NormalizeExpressionRule;
+import org.apache.doris.nereids.rules.expression.rewrite.rules.NormalizeBinaryPredicatesRule;
 import org.apache.doris.nereids.rules.expression.rewrite.rules.SimplifyNotExprRule;
 import org.apache.doris.nereids.trees.expressions.Expression;
 
@@ -35,7 +35,7 @@ public class ExpressionRuleExecutor {
     public static final List<ExpressionRewriteRule> REWRITE_RULES = ImmutableList.of(
         new BetweenToCompoundRule(),
         new SimplifyNotExprRule(),
-        new NormalizeExpressionRule()
+        new NormalizeBinaryPredicatesRule()
     );
 
     private final ExpressionRewriteContext ctx;

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rewrite/rules/BetweenToCompoundRule.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rewrite/rules/BetweenToCompoundRule.java
@@ -19,9 +19,8 @@ package org.apache.doris.nereids.rules.expression.rewrite.rules;
 
 import org.apache.doris.nereids.rules.expression.rewrite.AbstractExpressionRewriteRule;
 import org.apache.doris.nereids.rules.expression.rewrite.ExpressionRewriteContext;
-import org.apache.doris.nereids.trees.NodeType;
+import org.apache.doris.nereids.trees.expressions.And;
 import org.apache.doris.nereids.trees.expressions.Between;
-import org.apache.doris.nereids.trees.expressions.CompoundPredicate;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.GreaterThanEqual;
 import org.apache.doris.nereids.trees.expressions.LessThanEqual;
@@ -40,6 +39,6 @@ public class BetweenToCompoundRule extends AbstractExpressionRewriteRule {
     public Expression visitBetween(Between expr, ExpressionRewriteContext context) {
         Expression left = new GreaterThanEqual<>(expr.getCompareExpr(), expr.getLowerBound());
         Expression right = new LessThanEqual<>(expr.getCompareExpr(), expr.getUpperBound());
-        return new CompoundPredicate<>(NodeType.AND, left, right);
+        return new And<>(left, right);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rewrite/rules/BetweenToCompoundRule.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rewrite/rules/BetweenToCompoundRule.java
@@ -23,34 +23,18 @@ import org.apache.doris.nereids.trees.NodeType;
 import org.apache.doris.nereids.trees.expressions.Between;
 import org.apache.doris.nereids.trees.expressions.CompoundPredicate;
 import org.apache.doris.nereids.trees.expressions.Expression;
-import org.apache.doris.nereids.trees.expressions.GreaterThan;
 import org.apache.doris.nereids.trees.expressions.GreaterThanEqual;
-import org.apache.doris.nereids.trees.expressions.LessThan;
 import org.apache.doris.nereids.trees.expressions.LessThanEqual;
-import org.apache.doris.nereids.trees.expressions.Not;
 
 /**
- * Rewrites BetweenPredicates into an equivalent conjunctive/disjunctive
- * CompoundPredicate.
+ * Rewrites BetweenPredicates into an equivalent conjunctive CompoundPredicate,
+ * "not between" is first processed by the BetweenToCompoundRule and then by the SimplifyNotExprRule.
  * Examples:
  * A BETWEEN X AND Y ==> A >= X AND A <= Y
- * A NOT BETWEEN X AND Y ==> A < X OR A > Y
  */
 public class BetweenToCompoundRule extends AbstractExpressionRewriteRule {
 
     public static BetweenToCompoundRule INSTANCE = new BetweenToCompoundRule();
-
-    @Override
-    public Expression visitNot(Not expr, ExpressionRewriteContext context) {
-        Expression child = expr.child();
-        if (child instanceof Between) {
-            Between between = (Between) child;
-            Expression left = new LessThan<>(between.getCompareExpr(), between.getLowerBound());
-            Expression right = new GreaterThan<>(between.getCompareExpr(), between.getUpperBound());
-            return new CompoundPredicate<>(NodeType.OR, left, right);
-        }
-        return expr;
-    }
 
     @Override
     public Expression visitBetween(Between expr, ExpressionRewriteContext context) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rewrite/rules/BetweenToCompoundRule.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rewrite/rules/BetweenToCompoundRule.java
@@ -1,0 +1,61 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.rules.expression.rewrite.rules;
+
+import org.apache.doris.nereids.rules.expression.rewrite.AbstractExpressionRewriteRule;
+import org.apache.doris.nereids.rules.expression.rewrite.ExpressionRewriteContext;
+import org.apache.doris.nereids.trees.NodeType;
+import org.apache.doris.nereids.trees.expressions.Between;
+import org.apache.doris.nereids.trees.expressions.CompoundPredicate;
+import org.apache.doris.nereids.trees.expressions.Expression;
+import org.apache.doris.nereids.trees.expressions.GreaterThan;
+import org.apache.doris.nereids.trees.expressions.GreaterThanEqual;
+import org.apache.doris.nereids.trees.expressions.LessThan;
+import org.apache.doris.nereids.trees.expressions.LessThanEqual;
+import org.apache.doris.nereids.trees.expressions.Not;
+
+/**
+ * Rewrites BetweenPredicates into an equivalent conjunctive/disjunctive
+ * CompoundPredicate.
+ * Examples:
+ * A BETWEEN X AND Y ==> A >= X AND A <= Y
+ * A NOT BETWEEN X AND Y ==> A < X OR A > Y
+ */
+public class BetweenToCompoundRule extends AbstractExpressionRewriteRule {
+
+    public static BetweenToCompoundRule INSTANCE = new BetweenToCompoundRule();
+
+    @Override
+    public Expression visitNot(Not expr, ExpressionRewriteContext context) {
+        Expression child = expr.child();
+        if (child instanceof Between) {
+            Between between = (Between) child;
+            Expression left = new LessThan<>(between.getCompareExpr(), between.getLowerBound());
+            Expression right = new GreaterThan<>(between.getCompareExpr(), between.getUpperBound());
+            return new CompoundPredicate<>(NodeType.OR, left, right);
+        }
+        return expr;
+    }
+
+    @Override
+    public Expression visitBetween(Between expr, ExpressionRewriteContext context) {
+        Expression left = new GreaterThanEqual<>(expr.getCompareExpr(), expr.getLowerBound());
+        Expression right = new LessThanEqual<>(expr.getCompareExpr(), expr.getUpperBound());
+        return new CompoundPredicate<>(NodeType.AND, left, right);
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rewrite/rules/NormalizeBinaryPredicatesRule.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rewrite/rules/NormalizeBinaryPredicatesRule.java
@@ -34,9 +34,9 @@ import org.apache.doris.nereids.trees.expressions.LessThanEqual;
  * For example:
  * 5 > id -> id < 5
  */
-public class NormalizeExpressionRule extends AbstractExpressionRewriteRule {
+public class NormalizeBinaryPredicatesRule extends AbstractExpressionRewriteRule {
 
-    public static NormalizeExpressionRule INSTANCE = new NormalizeExpressionRule();
+    public static NormalizeBinaryPredicatesRule INSTANCE = new NormalizeBinaryPredicatesRule();
 
     @Override
     public Expression visitComparisonPredicate(ComparisonPredicate expr, ExpressionRewriteContext context) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rewrite/rules/SimplifyNotExprRule.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rewrite/rules/SimplifyNotExprRule.java
@@ -20,6 +20,7 @@ package org.apache.doris.nereids.rules.expression.rewrite.rules;
 import org.apache.doris.nereids.rules.expression.rewrite.AbstractExpressionRewriteRule;
 import org.apache.doris.nereids.rules.expression.rewrite.ExpressionRewriteContext;
 import org.apache.doris.nereids.trees.NodeType;
+import org.apache.doris.nereids.trees.expressions.And;
 import org.apache.doris.nereids.trees.expressions.ComparisonPredicate;
 import org.apache.doris.nereids.trees.expressions.CompoundPredicate;
 import org.apache.doris.nereids.trees.expressions.Expression;
@@ -28,6 +29,7 @@ import org.apache.doris.nereids.trees.expressions.GreaterThanEqual;
 import org.apache.doris.nereids.trees.expressions.LessThan;
 import org.apache.doris.nereids.trees.expressions.LessThanEqual;
 import org.apache.doris.nereids.trees.expressions.Not;
+import org.apache.doris.nereids.trees.expressions.Or;
 
 /**
  * Rewrite rule of NOT expression.
@@ -76,9 +78,9 @@ public class SimplifyNotExprRule extends AbstractExpressionRewriteRule {
             NodeType type = cp.getType();
             switch (type) {
                 case AND:
-                    return new CompoundPredicate<>(NodeType.OR, left, right);
+                    return new Or<>(left, right);
                 case OR:
-                    return new CompoundPredicate<>(NodeType.AND, left, right);
+                    return new And<>(left, right);
                 default:
                     return expr;
             }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/rewrite/ExpressionRewriteTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/rewrite/ExpressionRewriteTest.java
@@ -18,7 +18,7 @@
 package org.apache.doris.nereids.rules.expression.rewrite;
 
 import org.apache.doris.nereids.parser.NereidsParser;
-import org.apache.doris.nereids.rules.expression.rewrite.rules.NormalizeExpressionRule;
+import org.apache.doris.nereids.rules.expression.rewrite.rules.NormalizeBinaryPredicatesRule;
 import org.apache.doris.nereids.rules.expression.rewrite.rules.SimplifyNotExprRule;
 import org.apache.doris.nereids.trees.expressions.Expression;
 
@@ -47,7 +47,7 @@ public class ExpressionRewriteTest {
 
     @Test
     public void testNormalizeExpressionRewrite() {
-        executor = new ExpressionRuleExecutor(NormalizeExpressionRule.INSTANCE);
+        executor = new ExpressionRuleExecutor(NormalizeBinaryPredicatesRule.INSTANCE);
 
         assertRewrite("2 > x", "x < 2");
         assertRewrite("2 >= x", "x <= 2");


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

add betweentocompound rewrite rule for ssb.
for example:
1. A BETWEEN X AND Y ==> A >= X AND A <= Y
2. A NOT BETWEEN X AND Y ==> A < X OR A > Y

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
