### PR TITLE
[refactor] add evaluate_and_vec() for ComparisonPredicateBase

### DIFF
--- a/be/src/olap/column_predicate.h
+++ b/be/src/olap/column_predicate.h
@@ -92,7 +92,10 @@ public:
     virtual void evaluate_vec(const vectorized::IColumn& column, uint16_t size, bool* flags) const {
         DCHECK(false) << "should not reach here";
     }
-
+    virtual void evaluate_and_vec(const vectorized::IColumn& column, uint16_t size,
+                                  bool* flags) const {
+        DCHECK(false) << "should not reach here";
+    }
     uint32_t column_id() const { return _column_id; }
 
 protected:

--- a/be/src/olap/comparison_predicate.h
+++ b/be/src/olap/comparison_predicate.h
@@ -161,8 +161,8 @@ public:
     }
 
     template <bool is_and>
-    __attribute__((flatten)) void evaluate_vec_internal(const vectorized::IColumn& column,
-                                                        uint16_t size, bool* flags) const {
+    __attribute__((flatten)) void _evaluate_vec_internal(const vectorized::IColumn& column,
+                                                         uint16_t size, bool* flags) const {
         if (column.is_nullable()) {
             auto* nullable_column_ptr =
                     vectorized::check_and_get_column<vectorized::ColumnNullable>(column);
@@ -228,12 +228,12 @@ public:
 
     void evaluate_vec(const vectorized::IColumn& column, uint16_t size,
                       bool* flags) const override {
-        evaluate_vec_internal<false>(column, size, flags);
+        _evaluate_vec_internal<false>(column, size, flags);
     }
 
     void evaluate_and_vec(const vectorized::IColumn& column, uint16_t size,
                           bool* flags) const override {
-        evaluate_vec_internal<true>(column, size, flags);
+        _evaluate_vec_internal<true>(column, size, flags);
     }
 
 private:

--- a/be/src/olap/rowset/segment_v2/segment_iterator.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.cpp
@@ -874,14 +874,15 @@ uint16_t SegmentIterator::_evaluate_vectorization_predicate(uint16_t* sel_rowid_
     }
 
     uint16_t original_size = selected_size;
-    bool ret_flags[selected_size];
+    bool ret_flags[original_size];
     DCHECK(_pre_eval_block_predicate.size() > 0);
-
-    auto& column = _get_column_for_vec_predicate(0);
-    _pre_eval_block_predicate[0]->evaluate_vec(*column, selected_size, ret_flags);
+    auto column_id = _pre_eval_block_predicate[0]->column_id();
+    auto& column = _current_return_columns[column_id];
+    _pre_eval_block_predicate[0]->evaluate_vec(*column, original_size, ret_flags);
     for (int i = 1; i < _pre_eval_block_predicate.size(); i++) {
-        auto& column2 = _get_column_for_vec_predicate(i);
-        _pre_eval_block_predicate[i]->evaluate_and_vec(*column2, selected_size, ret_flags);
+        auto column_id2 = _pre_eval_block_predicate[i]->column_id();
+        auto& column2 = _current_return_columns[column_id2];
+        _pre_eval_block_predicate[i]->evaluate_and_vec(*column2, original_size, ret_flags);
     }
 
     uint16_t new_size = 0;
@@ -930,15 +931,6 @@ uint16_t SegmentIterator::_evaluate_short_circuit_predicate(uint16_t* vec_sel_ro
     for (auto predicate : _short_cir_eval_predicate) {
         auto column_id = predicate->column_id();
         auto& short_cir_column = _current_return_columns[column_id];
-        auto* col_ptr = short_cir_column.get();
-
-        // Dictionary column should do something to initial.
-        if (PredicateTypeTraits::is_range(predicate->type())) {
-            col_ptr->convert_dict_codes_if_necessary();
-        } else if (PredicateTypeTraits::is_bloom_filter(predicate->type())) {
-            col_ptr->generate_hash_values_for_runtime_filter();
-        }
-
         selected_size = predicate->evaluate(*short_cir_column, vec_sel_rowid_idx, selected_size);
     }
     _opts.stats->rows_vec_cond_filtered += original_size - selected_size;
@@ -1026,6 +1018,7 @@ Status SegmentIterator::next_batch(vectorized::Block* block) {
     if (!_is_need_vec_eval && !_is_need_short_eval) {
         _output_non_pred_columns(block);
     } else {
+        _convert_dict_code_for_predicate_if_necessary();
         uint16_t selected_size = nrows_read;
         uint16_t sel_rowid_idx[selected_size];
 

--- a/be/src/olap/rowset/segment_v2/segment_iterator.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.cpp
@@ -877,9 +877,9 @@ uint16_t SegmentIterator::_evaluate_vectorization_predicate(uint16_t* sel_rowid_
     bool ret_flags[selected_size];
     DCHECK(_pre_eval_block_predicate.size() > 0);
 
-    auto& column = _get_column_for_vec_predicate(0); 
+    auto& column = _get_column_for_vec_predicate(0);
     _pre_eval_block_predicate[0]->evaluate_vec(*column, selected_size, ret_flags);
-    for( int i=1; i<_pre_eval_block_predicate.size(); i++){
+    for (int i = 1; i < _pre_eval_block_predicate.size(); i++) {
         auto& column2 = _get_column_for_vec_predicate(i);
         _pre_eval_block_predicate[i]->evaluate_and_vec(*column2, selected_size, ret_flags);
     }


### PR DESCRIPTION
# Proposed changes
1. add evaluate_and_vec() for ComparisonPredicateBase to avoid merging ret_flags when there are multiple vec_predicates.
2. using ComparisonPrediate directly in SegmentIterator, instead of wrapping predicate inside a BlockColumnPredicate.

性能有小幅提高
`select  count(LO_ORDERDATE)  from  lineorder  where  LO_ORDERDATE  >=19920101  AND  LO_ORDERDATE  <=19971231`
ssb100 
 VectorPredEvalTime: 从 388ms 提高到 370ms
 
Issue Number: close #xxx

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
4. Has unit tests been added: (Yes/No/No Need)
5. Has document been added or modified: (Yes/No/No Need)
6. Does it need to update dependencies: (Yes/No)
7. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
