### PR TITLE
[Fix][multi-catalog]Fix coredump when reading the parquet file for multi-thread

### DIFF
--- a/be/src/exec/arrow/arrow_reader.h
+++ b/be/src/exec/arrow/arrow_reader.h
@@ -81,7 +81,7 @@ public:
     }
     // for vec
     virtual Status next_batch(std::shared_ptr<arrow::RecordBatch>* batch, bool* eof) = 0;
-    virtual void close();
+    void close();
     virtual Status size(int64_t* size) { return Status::NotSupported("Not Implemented size"); }
 
 protected:

--- a/be/src/exec/arrow/parquet_reader.cpp
+++ b/be/src/exec/arrow/parquet_reader.cpp
@@ -44,6 +44,12 @@ ParquetReaderWrap::ParquetReaderWrap(FileReader* file_reader, int64_t batch_size
           _current_line_of_group(0),
           _current_line_of_batch(0) {}
 
+ParquetReaderWrap::~ParquetReaderWrap() {
+    _closed = true;
+    _queue_writer_cond.notify_one();
+   _thread.join();
+}
+
 Status ParquetReaderWrap::init_reader(const std::vector<SlotDescriptor*>& tuple_slot_descs,
                                       const std::string& timezone) {
     try {
@@ -92,8 +98,7 @@ Status ParquetReaderWrap::init_reader(const std::vector<SlotDescriptor*>& tuple_
 
         RETURN_IF_ERROR(column_indices(tuple_slot_descs));
 
-        std::thread thread(&ParquetReaderWrap::prefetch_batch, this);
-        thread.detach();
+        _thread = std::thread(&ParquetReaderWrap::prefetch_batch, this);
 
         // read batch
         RETURN_IF_ERROR(read_next_batch());
@@ -115,12 +120,6 @@ Status ParquetReaderWrap::init_reader(const std::vector<SlotDescriptor*>& tuple_
         LOG(WARNING) << str_error.str();
         return Status::InternalError(str_error.str());
     }
-}
-
-void ParquetReaderWrap::close() {
-    _closed = true;
-    _queue_writer_cond.notify_one();
-    ArrowReaderWrap::close();
 }
 
 Status ParquetReaderWrap::size(int64_t* size) {
@@ -531,8 +530,9 @@ void ParquetReaderWrap::prefetch_batch() {
         _queue_reader_cond.notify_one();
     };
     int current_group = 0;
+    int total_groups = _total_groups;
     while (true) {
-        if (_closed || current_group >= _total_groups) {
+        if (_closed || current_group >= total_groups) {
             return;
         }
         _status = _reader->GetRecordBatchReader({current_group}, _include_column_ids, &_rb_reader);

--- a/be/src/exec/arrow/parquet_reader.cpp
+++ b/be/src/exec/arrow/parquet_reader.cpp
@@ -47,7 +47,7 @@ ParquetReaderWrap::ParquetReaderWrap(FileReader* file_reader, int64_t batch_size
 ParquetReaderWrap::~ParquetReaderWrap() {
     _closed = true;
     _queue_writer_cond.notify_one();
-   _thread.join();
+    _thread.join();
 }
 
 Status ParquetReaderWrap::init_reader(const std::vector<SlotDescriptor*>& tuple_slot_descs,

--- a/be/src/exec/arrow/parquet_reader.cpp
+++ b/be/src/exec/arrow/parquet_reader.cpp
@@ -47,7 +47,9 @@ ParquetReaderWrap::ParquetReaderWrap(FileReader* file_reader, int64_t batch_size
 ParquetReaderWrap::~ParquetReaderWrap() {
     _closed = true;
     _queue_writer_cond.notify_one();
-    _thread.join();
+    if (_thread.joinable()) {
+        _thread.join();
+    }
 }
 
 Status ParquetReaderWrap::init_reader(const std::vector<SlotDescriptor*>& tuple_slot_descs,

--- a/be/src/exec/arrow/parquet_reader.h
+++ b/be/src/exec/arrow/parquet_reader.h
@@ -62,7 +62,7 @@ public:
     // batch_size is not use here
     ParquetReaderWrap(FileReader* file_reader, int64_t batch_size,
                       int32_t num_of_columns_from_file);
-    ~ParquetReaderWrap() override = default;
+    ~ParquetReaderWrap() override;
 
     // Read
     Status read(Tuple* tuple, const std::vector<SlotDescriptor*>& tuple_slot_descs,
@@ -71,7 +71,6 @@ public:
     Status init_reader(const std::vector<SlotDescriptor*>& tuple_slot_descs,
                        const std::string& timezone) override;
     Status next_batch(std::shared_ptr<arrow::RecordBatch>* batch, bool* eof) override;
-    void close() override;
 
 private:
     void fill_slot(Tuple* tuple, SlotDescriptor* slot_desc, MemPool* mem_pool, const uint8_t* value,
@@ -107,6 +106,7 @@ private:
     std::condition_variable _queue_writer_cond;
     std::list<std::shared_ptr<arrow::RecordBatch>> _queue;
     const size_t _max_queue_size = config::parquet_reader_max_buffer_size;
+    std::thread _thread;
 };
 
 } // namespace doris


### PR DESCRIPTION
# Proposed changes

Issue Number: close #10634

## Problem Summary:
There is two issue fixed in this pr:

**The first issuse** is the C++ code rule of `do not call virtual function in constructor or deconstructor`. 
The deconstructor function of `ArrowReaderWrap` call the virtual function named `close()`.
When deconstructing, it will nerver call `ParquetReaderWrap::close()` just call the `ArrowReaderWrap::close()`

**The second issuse** is parallism deconstructing for `ParquetReaderWrap` and `prefetch_batch`.
`prefetch_batch` use `thread.detach()` to seprate the control from `ParquetReaderWrap`, but it rely on some local vars from `ParquetReaderWrap` such as **`_closed ` /`_total_groups ` and `_reader`**

In this case, `ParquetReaderWrap` may call deconstructor before `prefetch_batch` and then get the core dump.


## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
