### PR TITLE
[BugFix](Array) fix DataTypeArray to_string use after free

### DIFF
--- a/be/src/vec/data_types/data_type_array.cpp
+++ b/be/src/vec/data_types/data_type_array.cpp
@@ -96,8 +96,8 @@ void DataTypeArray::to_pb_column_meta(PColumnMeta* col_meta) const {
 }
 
 void DataTypeArray::to_string(const IColumn& column, size_t row_num, BufferWritable& ostr) const {
-    auto& data_column =
-            assert_cast<const ColumnArray&>(*column.convert_to_full_column_if_const().get());
+    auto ptr = column.convert_to_full_column_if_const();
+    auto& data_column = assert_cast<const ColumnArray&>(*ptr.get());
     auto& offsets = data_column.get_offsets();
 
     size_t offset = offsets[row_num - 1];
@@ -115,8 +115,8 @@ void DataTypeArray::to_string(const IColumn& column, size_t row_num, BufferWrita
 }
 
 std::string DataTypeArray::to_string(const IColumn& column, size_t row_num) const {
-    auto& data_column =
-            assert_cast<const ColumnArray&>(*column.convert_to_full_column_if_const().get());
+    auto ptr = column.convert_to_full_column_if_const();
+    auto& data_column = assert_cast<const ColumnArray&>(*ptr.get());
     auto& offsets = data_column.get_offsets();
 
     size_t offset = offsets[row_num - 1];


### PR DESCRIPTION
ColumnArray::convert_to_full_column_if_const override the base function
and ColumnArray::create generate a temporary variable

# Proposed changes

Issue Number: close #10638

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
