### PR TITLE
[feature](planner): push limit to olapscan when meet sort.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/OlapScanNode.java
@@ -27,6 +27,7 @@ import org.apache.doris.analysis.IntLiteral;
 import org.apache.doris.analysis.PartitionNames;
 import org.apache.doris.analysis.SlotDescriptor;
 import org.apache.doris.analysis.SlotRef;
+import org.apache.doris.analysis.SortInfo;
 import org.apache.doris.analysis.TupleDescriptor;
 import org.apache.doris.analysis.TupleId;
 import org.apache.doris.catalog.ColocateTableIndex;
@@ -67,6 +68,7 @@ import org.apache.doris.thrift.TPrimitiveType;
 import org.apache.doris.thrift.TScanRange;
 import org.apache.doris.thrift.TScanRangeLocation;
 import org.apache.doris.thrift.TScanRangeLocations;
+import org.apache.doris.thrift.TSortInfo;
 
 import com.google.common.base.Joiner;
 import com.google.common.base.MoreObjects;
@@ -145,6 +147,12 @@ public class OlapScanNode extends ScanNode {
     private Collection<Long> selectedPartitionIds = Lists.newArrayList();
     private long totalBytes = 0;
 
+    private SortInfo sortInfo = null;
+
+    // When scan match sort_info, we can push limit into OlapScanNode.
+    // It's limit for scanner instead of scanNode so we add a new limit.
+    private long sortLimit = -1;
+
     // List of tablets will be scanned by current olap_scan_node
     private ArrayList<Long> scanTabletIds = Lists.newArrayList();
 
@@ -203,8 +211,24 @@ public class OlapScanNode extends ScanNode {
         return selectedTabletsNum;
     }
 
+    public SortInfo getSortInfo() {
+        return sortInfo;
+    }
+
+    public void setSortInfo(SortInfo sortInfo) {
+        this.sortInfo = sortInfo;
+    }
+
+    public void setSortLimit(long sortLimit) {
+        this.sortLimit = sortLimit;
+    }
+
     public Collection<Long> getSelectedPartitionIds() {
         return selectedPartitionIds;
+    }
+
+    public void setTupleIds(ArrayList<TupleId> tupleIds) {
+        this.tupleIds = tupleIds;
     }
 
     // only used for UT
@@ -217,7 +241,7 @@ public class OlapScanNode extends ScanNode {
      * selectedIndexId.
      * It makes sure that the olap scan node must scan the base data rather than
      * scan the materialized view data.
-     *
+     * <p>
      * This function is mainly used to update stmt.
      * Update stmt also needs to scan data like normal queries.
      * But its syntax is different from ordinary queries,
@@ -274,7 +298,8 @@ public class OlapScanNode extends ScanNode {
         String scanRangeInfo = stringBuilder.toString();
         String situation;
         boolean update;
-        CHECK: { // CHECKSTYLE IGNORE THIS LINE
+        CHECK:
+        { // CHECKSTYLE IGNORE THIS LINE
             if (olapTable.getKeysType() == KeysType.DUP_KEYS) {
                 situation = "The key type of table is duplicate.";
                 update = true;
@@ -722,6 +747,45 @@ public class OlapScanNode extends ScanNode {
     }
 
     /**
+     * Check Parent sort node can push down to child olap scan.
+     */
+    public boolean checkPushSort(SortNode sortNode) {
+        // Ensure all isAscOrder is same, ande length != 0.
+        // Can't be zorder.
+        if (sortNode.getSortInfo().getIsAscOrder().stream().distinct().count() != 1
+                || olapTable.isZOrderSort()) {
+            return false;
+        }
+
+        // Tablet's order by key only can be the front part of schema.
+        // Like: schema: a.b.c.d.e.f.g order by key: a.b.c (no a,b,d)
+        // Do **prefix match** to check if order by key can be pushed down.
+        // olap order by key: a.b.c.d
+        // sort key: (a) (a,c) (a,c,d) ok, (a,c,b) (a,c,f) not ok
+        int sortSlotIndex = 0;
+        for (int i = 0; i < olapTable.getDataSortInfo().getColNum(); i++) {
+            // table key.
+            Column key = olapTable.getFullSchema().get(i);
+
+            // sort slot.
+            Expr expr = sortNode.getSortInfo().getMaterializedOrderingExprs().get(sortSlotIndex);
+            if (!(expr instanceof SlotRef)) {
+                return false;
+            }
+            SlotRef slotRef = (SlotRef) expr;
+
+            if (key.equals(slotRef.getColumn())) {
+                sortSlotIndex++;
+                if (sortSlotIndex == sortNode.getSortInfo().getMaterializedOrderingExprs().size()) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /**
      * We query Palo Meta to get request's data location
      * extra result info will pass to backend ScanNode
      */
@@ -746,10 +810,18 @@ public class OlapScanNode extends ScanNode {
         }
         output.append("\n");
 
-        if (null != sortColumn) {
+        if (sortColumn != null) {
             output.append(prefix).append("SORT COLUMN: ").append(sortColumn).append("\n");
         }
-
+        if (sortInfo != null) {
+            output.append(prefix).append("SORT INFO:\n");
+            sortInfo.getMaterializedOrderingExprs().forEach(expr -> {
+                output.append(prefix).append(prefix).append(expr.toSql()).append("\n");
+            });
+        }
+        if (sortLimit != -1) {
+            output.append(prefix).append("SORT LIMIT: ").append(sortLimit).append("\n");
+        }
         if (!conjuncts.isEmpty()) {
             output.append(prefix).append("PREDICATES: ").append(getExplainString(conjuncts)).append("\n");
         }
@@ -804,6 +876,19 @@ public class OlapScanNode extends ScanNode {
                 columnsDesc);
         if (null != sortColumn) {
             msg.olap_scan_node.setSortColumn(sortColumn);
+        }
+        if (sortInfo != null) {
+            TSortInfo tSortInfo = new TSortInfo(
+                    Expr.treesToThrift(sortInfo.getOrderingExprs()),
+                    sortInfo.getIsAscOrder(),
+                    sortInfo.getNullsFirst());
+            if (sortInfo.getSortTupleSlotExprs() != null) {
+                tSortInfo.setSortTupleSlotExprs(Expr.treesToThrift(sortInfo.getSortTupleSlotExprs()));
+            }
+            msg.olap_scan_node.setSortInfo(tSortInfo);
+        }
+        if (sortLimit != -1) {
+            msg.olap_scan_node.setSortLimit(sortLimit);
         }
         msg.olap_scan_node.setKeyType(olapTable.getKeysType().toThrift());
         msg.olap_scan_node.setTableName(olapTable.getName());

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/OriginalPlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/OriginalPlanner.java
@@ -86,6 +86,7 @@ public class OriginalPlanner extends Planner {
     }
 
     /**
+     *
      */
     private void setResultExprScale(Analyzer analyzer, ArrayList<Expr> outputExprs) {
         for (TupleDescriptor tupleDesc : analyzer.getDescTbl().getTupleDescs()) {
@@ -202,7 +203,9 @@ public class OriginalPlanner extends Planner {
 
         // Push sort node down to the bottom of olapscan.
         // Because the olapscan must be in the end. So get the last two nodes.
-        pushSortToOlapScan();
+        if (VectorizedUtil.isVectorized()) {
+            pushSortToOlapScan();
+        }
 
         // Optimize the transfer of query statistic when query doesn't contain limit.
         PlanFragment rootFragment = fragments.get(fragments.size() - 1);
@@ -278,7 +281,7 @@ public class OriginalPlanner extends Planner {
      * 1. The query enables the session variable of the concurrent export result set
      * 2. The top-level fragment is not a merge change node
      * 3. The export method uses the s3 method
-     *
+     * <p>
      * After satisfying the above three conditions,
      * the result file sink and the associated output expr will be pushed down to the next layer.
      * The second plan fragment performs expression calculation and derives the result set.

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/OriginalPlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/OriginalPlanner.java
@@ -200,6 +200,10 @@ public class OriginalPlanner extends Planner {
             fragments = distributedPlanner.createPlanFragments(singleNodePlan);
         }
 
+        // Push sort node down to the bottom of olapscan.
+        // Because the olapscan must be in the end. So get the last two nodes.
+        pushSortToOlapScan();
+
         // Optimize the transfer of query statistic when query doesn't contain limit.
         PlanFragment rootFragment = fragments.get(fragments.size() - 1);
         QueryStatisticsTransferOptimizer queryStatisticTransferOptimizer
@@ -317,6 +321,40 @@ public class OriginalPlanner extends Planner {
         topPlanFragment.resetSink(resultSink);
         topPlanFragment.resetOutputExprs(fileStatusDesc);
         topPlanFragment.getPlanRoot().resetTupleIds(Lists.newArrayList(fileStatusDesc.getId()));
+    }
+
+    /**
+     * Push sort down to olap scan.
+     */
+    private void pushSortToOlapScan() {
+        for (PlanFragment fragment : fragments) {
+            PlanNode node = fragment.getPlanRoot();
+            PlanNode parent = null;
+
+            // OlapScanNode is the last node.
+            // So, just get the last two node and check if they are SortNode and OlapScan.
+            while (node.getChildren().size() != 0) {
+                parent = node;
+                node = node.getChildren().get(0);
+            }
+
+            if (!(node instanceof OlapScanNode) || !(parent instanceof SortNode)) {
+                continue;
+            }
+            SortNode sortNode = (SortNode) parent;
+            OlapScanNode scanNode = (OlapScanNode) node;
+            if (!scanNode.checkPushSort(sortNode)) {
+                continue;
+            }
+            // If offset > 0, we push down (limit: limit + offset) to olap scan.
+            if (sortNode.getOffset() > 0) {
+                scanNode.setSortLimit(sortNode.getLimit() + sortNode.getOffset());
+            } else {
+                scanNode.setSortLimit(sortNode.getLimit());
+            }
+            scanNode.setSortInfo(sortNode.getSortInfo());
+            scanNode.getSortInfo().setSortTupleSlotExprs(sortNode.resolvedTupleExprs);
+        }
     }
 
     /**

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -412,6 +412,17 @@ struct TMetaScanNode {
   5: optional string user
 }
 
+struct TSortInfo {
+  1: required list<Exprs.TExpr> ordering_exprs
+  2: required list<bool> is_asc_order
+  // Indicates, for each expr, if nulls should be listed first or last. This is
+  // independent of is_asc_order.
+  3: required list<bool> nulls_first
+  // Expressions evaluated over the input row that materialize the tuple to be sorted.
+  // Contains one expr per slot in the materialized tuple.
+  4: optional list<Exprs.TExpr> sort_tuple_slot_exprs
+}
+
 struct TOlapScanNode {
   1: required Types.TTupleId tuple_id
   2: required list<string> key_column_name
@@ -421,6 +432,10 @@ struct TOlapScanNode {
   6: optional Types.TKeysType keyType
   7: optional string table_name
   8: required list<Descriptors.TColumn> columns_desc
+  9: optional TSortInfo sort_info
+  // When scan match sort_info, we can push limit into OlapScanNode.
+  // It's limit for scanner instead of scanNode so we add a new limit.
+  10: optional i64 sort_limit
 }
 
 struct TEqJoinCondition {
@@ -561,17 +576,6 @@ struct TRepeatNode {
 struct TPreAggregationNode {
   1: required list<Exprs.TExpr> group_exprs
   2: required list<Exprs.TExpr> aggregate_exprs
-}
-
-struct TSortInfo {
-  1: required list<Exprs.TExpr> ordering_exprs
-  2: required list<bool> is_asc_order
-  // Indicates, for each expr, if nulls should be listed first or last. This is
-  // independent of is_asc_order.
-  3: required list<bool> nulls_first
-  // Expressions evaluated over the input row that materialize the tuple to be sorted.
-  // Contains one expr per slot in the materialized tuple.
-  4: optional list<Exprs.TExpr> sort_tuple_slot_exprs
 }
 
 struct TSortNode {


### PR DESCRIPTION
# Proposed changes

Issue Number: close #10646.

## Problem Summary:

Describe the overview of changes.

push limit to olapscan when meet sort.

When sort keys are in the olapscan keys, and they are prefix matching.

We can push limit to the olapscan

## Checklist(Required)

1. Does it affect the original behavior: (Yes)
2. Has unit tests been added: (No)
3. Has document been added or modified: (No need)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
