### PR TITLE
[Enhancement] [vectorized] Runtime Filter support equivalent slot of outer join 

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ExprSubstitutionMap.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ExprSubstitutionMap.java
@@ -18,6 +18,7 @@
 package org.apache.doris.analysis;
 
 import java.util.List;
+import java.util.Objects;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -156,7 +157,7 @@ public final class ExprSubstitutionMap {
      * f [A.id, B.id] g [A.id, C.id]
      * return: g-f [B,id, C,id]
      */
-    public static ExprSubstitutionMap subtraction(ExprSubstitutionMap f, ExprSubstitutionMap g) {
+    public static ExprSubstitutionMap subtraction(ExprSubstitutionMap f, ExprSubstitutionMap g, Analyzer analyzer) {
         if (f == null && g == null) {
             return new ExprSubstitutionMap();
         }
@@ -170,6 +171,7 @@ public final class ExprSubstitutionMap {
         for (int i = 0; i < g.size(); i++) {
             if (f.containsMappingFor(g.lhs_.get(i))) {
                 result.put(f.get(g.lhs_.get(i)), g.rhs_.get(i));
+                analyzer.putEquivalentSlot(((SlotRef) Objects.requireNonNull(f.get(g.lhs_.get(i)))).getSlotId(), ((SlotRef) g.lhs_.get(i)).getSlotId());
             } else {
                 result.put(g.lhs_.get(i), g.rhs_.get(i));
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/HashJoinNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/HashJoinNode.java
@@ -398,7 +398,7 @@ public class HashJoinNode extends PlanNode {
             }
         }
         // 2. compute srcToOutputMap
-        vSrcToOutputSMap = ExprSubstitutionMap.subtraction(outputSmap, srcTblRefToOutputTupleSmap);
+        vSrcToOutputSMap = ExprSubstitutionMap.subtraction(outputSmap, srcTblRefToOutputTupleSmap, analyzer);
         for (int i = 0; i < vSrcToOutputSMap.size(); i++) {
             Preconditions.checkState(vSrcToOutputSMap.getRhs().get(i) instanceof SlotRef);
             SlotRef rSlotRef = (SlotRef) vSrcToOutputSMap.getRhs().get(i);


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

> v1.0.1

In TPCH-q7, the runtime filter `RF002[in_or_bloom] <- n1.n_nationkey` generated by the outer join of `equal join conjunct: s_nationkey = n1.n_nationkey` cannot be pushed down to `1:VOlapScanNode TABLE: supplier`. TPCH-q2 has the same problem.

After applying this pr, a runtime filter can be generated:
```
|   6:VHASH JOIN                                                                                                                                          |
|   |  join op: INNER JOIN(BROADCAST)[The src data has been redistributed]                                                                                |
|   |  equal join conjunct: <slot 40> = `n1`.`n_nationkey`                                                                                                |
|   |  runtime filters: RF002[in_or_bloom] <- `n1`.`n_nationkey`                                                                                          |
|   |  cardinality=6001214                                                                                                                                |
|   |  vec output tuple id: 11  |  output slot ids: 43 44 45 51 52                                                                                        |
|   |  hash output slot ids: 0 34 35 36 42

|   1:VOlapScanNode                                                                                                                                       |
|      TABLE: supplier(supplier), PREAGGREGATION: ON                                                                                                      |
|      runtime filters: RF002[in_or_bloom] -> <slot 11>                                                                                                   |
|      partitions=1/1, tablets=32/32, tabletList=10084,10086,10088 ...                                                                                    |
|      cardinality=9999, avgRowSize=506.7262, numNodes=1                                                                                                  |
```

TPCH performance
| TPCH | before | after |
| - | - | - |
| q2 | 0.25 | 0.20 |
| q7 | 0.51 | 0.17 |


## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
