### PR TITLE
[feature-wip](unique-key-merge-on-write) add interface for segment key bounds, DSIP-018[3/2]

### DIFF
--- a/be/src/olap/rowset/rowset.h
+++ b/be/src/olap/rowset/rowset.h
@@ -258,6 +258,11 @@ public:
         }
     }
 
+    virtual Status get_segments_key_bounds(std::vector<KeyBoundsPB>* segments_key_bounds) {
+        _rowset_meta->get_segments_key_bounds(segments_key_bounds);
+        return Status::OK();
+    }
+
 protected:
     friend class RowsetFactory;
 

--- a/be/src/olap/rowset/rowset_meta.h
+++ b/be/src/olap/rowset/rowset_meta.h
@@ -298,6 +298,19 @@ public:
         return score;
     }
 
+    void get_segments_key_bounds(std::vector<KeyBoundsPB>* segments_key_bounds) const {
+        for (const KeyBoundsPB& key_range : _rowset_meta_pb.segments_key_bounds()) {
+            segments_key_bounds->push_back(key_range);
+        }
+    }
+
+    void set_segments_key_bounds(const std::vector<KeyBoundsPB>& segments_key_bounds) {
+        for (const KeyBoundsPB& key_bounds : segments_key_bounds) {
+            KeyBoundsPB* new_key_bounds = _rowset_meta_pb.add_segments_key_bounds();
+            *new_key_bounds = key_bounds;
+        }
+    }
+
     const AlphaRowsetExtraMetaPB& alpha_rowset_extra_meta_pb() const {
         return _rowset_meta_pb.alpha_rowset_extra_meta_pb();
     }

--- a/gensrc/proto/olap_file.proto
+++ b/gensrc/proto/olap_file.proto
@@ -104,13 +104,13 @@ message RowsetMetaPB {
     optional int64 oldest_write_timestamp = 25 [default = -1];
     // latest write time
     optional int64 newest_write_timestamp = 26 [default = -1];
+    // the encoded segment min/max key of segments in this rowset,
+    // only used in unique key data model with primary_key_index support.
+    repeated KeyBoundsPB segments_key_bounds = 27;
     // spare field id for future use
     optional AlphaRowsetExtraMetaPB alpha_rowset_extra_meta_pb = 50;
     // to indicate whether the data between the segments overlap
     optional SegmentsOverlapPB segments_overlap_pb = 51 [default = OVERLAP_UNKNOWN];
-    // the encoded segment min/max key of segments in this rowset,
-    // only used in unique key data model with primary_key_index support.
-    repeated KeyBoundsPB segments_key_bounds = 24;
 }
 
 message AlphaRowsetExtraMetaPB {

--- a/gensrc/proto/olap_file.proto
+++ b/gensrc/proto/olap_file.proto
@@ -53,6 +53,11 @@ enum SegmentsOverlapPB {
     NONOVERLAPPING = 2;
 }
 
+message KeyBoundsPB {
+    required bytes min_key = 1;
+    required bytes max_key = 2;
+}
+
 message RowsetMetaPB {
     required int64 rowset_id = 1;
     optional int64 partition_id = 2;
@@ -103,6 +108,9 @@ message RowsetMetaPB {
     optional AlphaRowsetExtraMetaPB alpha_rowset_extra_meta_pb = 50;
     // to indicate whether the data between the segments overlap
     optional SegmentsOverlapPB segments_overlap_pb = 51 [default = OVERLAP_UNKNOWN];
+    // the encoded segment min/max key of segments in this rowset,
+    // only used in unique key data model with primary_key_index support.
+    repeated KeyBoundsPB segments_key_bounds = 24;
 }
 
 message AlphaRowsetExtraMetaPB {


### PR DESCRIPTION
Add interfaces for segment key bounds, key bounds will be used to speed up point lookup on the primary key index of each segment.
For the detail, see DSIP-018:https://cwiki.apache.org/confluence/display/DORIS/DSIP-018%3A+Support+Merge-On-Write+implementation+for+UNIQUE+KEY+data+model

KeyBounds will be updated by BetaRowsetWriter, will be used to construct a RowsetTree(based on IntervalTree, will be added through next patch)