### PR TITLE
[BugFix] Column datas doesn't match nullmap when vectorization load

### DIFF
--- a/be/src/vec/olap/olap_data_convertor.cpp
+++ b/be/src/vec/olap/olap_data_convertor.cpp
@@ -195,7 +195,7 @@ Status OlapBlockDataConvertor::OlapColumnDataConvertorBitMap::convert_to_olap() 
 
     size_t total_size = 0;
     if (_nullmap) {
-        const UInt8* nullmap_cur = _nullmap + _row_pos;
+        const UInt8* nullmap_cur = _nullmap;
         while (bitmap_value_cur != bitmap_value_end) {
             if (!*nullmap_cur) {
                 total_size += bitmap_value_cur->getSizeInBytes();
@@ -216,7 +216,7 @@ Status OlapBlockDataConvertor::OlapColumnDataConvertorBitMap::convert_to_olap() 
     char* raw_data = _raw_data.data();
     Slice* slice = _slice.data();
     if (_nullmap) {
-        const UInt8* nullmap_cur = _nullmap + _row_pos;
+        const UInt8* nullmap_cur = _nullmap;
         while (bitmap_value_cur != bitmap_value_end) {
             if (!*nullmap_cur) {
                 slice_size = bitmap_value_cur->getSizeInBytes();
@@ -234,7 +234,7 @@ Status OlapBlockDataConvertor::OlapColumnDataConvertorBitMap::convert_to_olap() 
             ++nullmap_cur;
             ++bitmap_value_cur;
         }
-        assert(nullmap_cur == _nullmap + _row_pos + _num_rows && slice == _slice.get_end_ptr());
+        assert(nullmap_cur == _nullmap + _num_rows && slice == _slice.get_end_ptr());
     } else {
         while (bitmap_value_cur != bitmap_value_end) {
             slice_size = bitmap_value_cur->getSizeInBytes();
@@ -255,8 +255,7 @@ Status OlapBlockDataConvertor::OlapColumnDataConvertorBitMap::convert_to_olap() 
 Status OlapBlockDataConvertor::OlapColumnDataConvertorHLL::convert_to_olap() {
     assert(_typed_column.column);
     const vectorized::ColumnHLL* column_hll = nullptr;
-    const UInt8* nullmap = get_nullmap();
-    if (nullmap) {
+    if (_nullmap) {
         auto nullable_column =
                 assert_cast<const vectorized::ColumnNullable*>(_typed_column.column.get());
         column_hll = assert_cast<const vectorized::ColumnHLL*>(
@@ -271,8 +270,8 @@ Status OlapBlockDataConvertor::OlapColumnDataConvertorHLL::convert_to_olap() {
     HyperLogLog* hll_value_end = hll_value_cur + _num_rows;
 
     size_t total_size = 0;
-    if (nullmap) {
-        const UInt8* nullmap_cur = nullmap + _row_pos;
+    if (_nullmap) {
+        const UInt8* nullmap_cur = _nullmap;
         while (hll_value_cur != hll_value_end) {
             if (!*nullmap_cur) {
                 total_size += hll_value_cur->max_serialized_size();
@@ -293,8 +292,8 @@ Status OlapBlockDataConvertor::OlapColumnDataConvertorHLL::convert_to_olap() {
     Slice* slice = _slice.data();
 
     hll_value_cur = hll_value;
-    if (nullmap) {
-        const UInt8* nullmap_cur = nullmap + _row_pos;
+    if (_nullmap) {
+        const UInt8* nullmap_cur = _nullmap;
         while (hll_value_cur != hll_value_end) {
             if (!*nullmap_cur) {
                 slice_size = hll_value_cur->serialize((uint8_t*)raw_data);
@@ -311,7 +310,7 @@ Status OlapBlockDataConvertor::OlapColumnDataConvertorHLL::convert_to_olap() {
             ++nullmap_cur;
             ++hll_value_cur;
         }
-        assert(nullmap_cur == nullmap + _row_pos + _num_rows && slice == _slice.get_end_ptr());
+        assert(nullmap_cur == _nullmap + _num_rows && slice == _slice.get_end_ptr());
     } else {
         while (hll_value_cur != hll_value_end) {
             slice_size = hll_value_cur->serialize((uint8_t*)raw_data);
@@ -373,7 +372,7 @@ Status OlapBlockDataConvertor::OlapColumnDataConvertorChar::convert_to_olap() {
     }
 
     for (size_t i = 0; i < _num_rows; i++) {
-        if (!_nullmap || !_nullmap[i + _row_pos]) {
+        if (!_nullmap || !_nullmap[i]) {
             _slice[i] = column_string->get_data_at(i + _row_pos).to_slice();
             DCHECK(_slice[i].size == _length)
                     << "char type data length not equal to schema, schema=" << _length
@@ -431,7 +430,7 @@ Status OlapBlockDataConvertor::OlapColumnDataConvertorVarChar::convert_to_olap()
     Slice* slice = _slice.data();
     size_t string_offset = *(offset_cur - 1);
     if (_nullmap) {
-        const UInt8* nullmap_cur = _nullmap + _row_pos;
+        const UInt8* nullmap_cur = _nullmap;
         while (offset_cur != offset_end) {
             if (!*nullmap_cur) {
                 slice->data = const_cast<char*>(char_data + string_offset);
@@ -452,7 +451,7 @@ Status OlapBlockDataConvertor::OlapColumnDataConvertorVarChar::convert_to_olap()
             ++slice;
             ++offset_cur;
         }
-        assert(nullmap_cur == _nullmap + _row_pos + _num_rows && slice == _slice.get_end_ptr());
+        assert(nullmap_cur == _nullmap + _num_rows && slice == _slice.get_end_ptr());
     } else {
         while (offset_cur != offset_end) {
             slice->data = const_cast<char*>(char_data + string_offset);
@@ -504,7 +503,7 @@ Status OlapBlockDataConvertor::OlapColumnDataConvertorDate::convert_to_olap() {
         const DateV2Value* datetime_end = datetime_cur + _num_rows;
         uint24_t* value = _values.data();
         if (_nullmap) {
-            const UInt8* nullmap_cur = _nullmap + _row_pos;
+            const UInt8* nullmap_cur = _nullmap;
             while (datetime_cur != datetime_end) {
                 if (!*nullmap_cur) {
                     *value = datetime_cur->to_olap_date();
@@ -515,8 +514,7 @@ Status OlapBlockDataConvertor::OlapColumnDataConvertorDate::convert_to_olap() {
                 ++datetime_cur;
                 ++nullmap_cur;
             }
-            assert(nullmap_cur == _nullmap + _row_pos + _num_rows &&
-                   value == _values.get_end_ptr());
+            assert(nullmap_cur == _nullmap + _num_rows && value == _values.get_end_ptr());
         } else {
             while (datetime_cur != datetime_end) {
                 *value = datetime_cur->to_olap_date();
@@ -545,7 +543,7 @@ Status OlapBlockDataConvertor::OlapColumnDataConvertorDate::convert_to_olap() {
         const VecDateTimeValue* datetime_end = datetime_cur + _num_rows;
         uint24_t* value = _values.data();
         if (_nullmap) {
-            const UInt8* nullmap_cur = _nullmap + _row_pos;
+            const UInt8* nullmap_cur = _nullmap;
             while (datetime_cur != datetime_end) {
                 if (!*nullmap_cur) {
                     *value = datetime_cur->to_olap_date();
@@ -556,8 +554,7 @@ Status OlapBlockDataConvertor::OlapColumnDataConvertorDate::convert_to_olap() {
                 ++datetime_cur;
                 ++nullmap_cur;
             }
-            assert(nullmap_cur == _nullmap + _row_pos + _num_rows &&
-                   value == _values.get_end_ptr());
+            assert(nullmap_cur == _nullmap + _num_rows && value == _values.get_end_ptr());
         } else {
             while (datetime_cur != datetime_end) {
                 *value = datetime_cur->to_olap_date();
@@ -590,7 +587,7 @@ Status OlapBlockDataConvertor::OlapColumnDataConvertorDateTime::convert_to_olap(
     const VecDateTimeValue* datetime_end = datetime_cur + _num_rows;
     uint64_t* value = _values.data();
     if (_nullmap) {
-        const UInt8* nullmap_cur = _nullmap + _row_pos;
+        const UInt8* nullmap_cur = _nullmap;
         while (datetime_cur != datetime_end) {
             if (!*nullmap_cur) {
                 *value = datetime_cur->to_olap_datetime();
@@ -601,7 +598,7 @@ Status OlapBlockDataConvertor::OlapColumnDataConvertorDateTime::convert_to_olap(
             ++datetime_cur;
             ++nullmap_cur;
         }
-        assert(nullmap_cur == _nullmap + _row_pos + _num_rows && value == _values.get_end_ptr());
+        assert(nullmap_cur == _nullmap + _num_rows && value == _values.get_end_ptr());
     } else {
         while (datetime_cur != datetime_end) {
             *value = datetime_cur->to_olap_datetime();
@@ -633,7 +630,7 @@ Status OlapBlockDataConvertor::OlapColumnDataConvertorDecimal::convert_to_olap()
     const DecimalV2Value* decimal_end = decimal_cur + _num_rows;
     decimal12_t* value = _values.data();
     if (_nullmap) {
-        const UInt8* nullmap_cur = _nullmap + _row_pos;
+        const UInt8* nullmap_cur = _nullmap;
         while (decimal_cur != decimal_end) {
             if (!*nullmap_cur) {
                 value->integer = decimal_cur->int_value();
@@ -645,7 +642,7 @@ Status OlapBlockDataConvertor::OlapColumnDataConvertorDecimal::convert_to_olap()
             ++decimal_cur;
             ++nullmap_cur;
         }
-        assert(nullmap_cur == _nullmap + _row_pos + _num_rows && value == _values.get_end_ptr());
+        assert(nullmap_cur == _nullmap + _num_rows && value == _values.get_end_ptr());
     } else {
         while (decimal_cur != decimal_end) {
             value->integer = decimal_cur->int_value();
@@ -706,7 +703,7 @@ Status OlapBlockDataConvertor::OlapColumnDataConvertorArray::convert_to_olap(
     for (size_t i = 0; i < _num_rows; ++i, ++collection_value) {
         int64_t cur_pos = _row_pos + i;
         int64_t prev_pos = cur_pos - 1;
-        if (_nullmap && _nullmap[cur_pos]) {
+        if (_nullmap && _nullmap[cur_pos - _row_pos]) {
             continue;
         }
         auto offset = offsets[prev_pos];

--- a/be/src/vec/olap/olap_data_convertor.cpp
+++ b/be/src/vec/olap/olap_data_convertor.cpp
@@ -138,6 +138,7 @@ void OlapBlockDataConvertor::OlapColumnDataConvertorBase::set_source_column(
         auto nullable_column =
                 assert_cast<const vectorized::ColumnNullable*>(_typed_column.column.get());
         _nullmap = nullable_column->get_null_map_data().data();
+        _nullmap += row_pos;
     }
 }
 

--- a/be/src/vec/olap/olap_data_convertor.h
+++ b/be/src/vec/olap/olap_data_convertor.h
@@ -298,7 +298,7 @@ private:
                 const VecDateTimeValue* datetime_end = datetime_cur + _num_rows;
                 uint32_t* value = const_cast<uint32_t*>(values_);
                 if (_nullmap) {
-                    const UInt8* nullmap_cur = _nullmap + _row_pos;
+                    const UInt8* nullmap_cur = _nullmap;
                     while (datetime_cur != datetime_end) {
                         if (!*nullmap_cur) {
                             *value = datetime_cur->to_date_v2();


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:
In
```
SegmentWriter::append_block(const vectorized::Block* block, size_t row_pos, size_t num_rows)
```
if a block is divided into several parts to append, we need to use row_pos and num_rows to know the range to append. There is a problem when the column is nullable type.
In
```
void OlapBlockDataConvertor::OlapColumnDataConvertorBase::set_source_column(
        const ColumnWithTypeAndName& typed_column, size_t row_pos, size_t num_rows) {
    DCHECK(row_pos + num_rows <= typed_column.column->size())
            << "row_pos=" << row_pos << ", num_rows=" << num_rows
            << ", typed_column.column->size()=" << typed_column.column->size();
    _typed_column = typed_column;
    _row_pos = row_pos;
    _num_rows = num_rows;
    if (_typed_column.column->is_nullable()) {
        auto nullable_column =
                assert_cast<const vectorized::ColumnNullable*>(_typed_column.column.get());
        _nullmap = nullable_column->get_null_map_data().data();
    }
}
```
,OlapColumnDataConvertorBase will get the nullmap which associated with column.
When call convert_to_olap method
```
Status convert_to_olap() override {
            const vectorized::ColumnVector<T>* column_data = nullptr;
            if (_nullmap) {
                auto nullable_column =
                        assert_cast<const vectorized::ColumnNullable*>(_typed_column.column.get());
                column_data = assert_cast<const vectorized::ColumnVector<T>*>(
                        nullable_column->get_nested_column_ptr().get());
            } else {
                column_data =
                        assert_cast<const vectorized::ColumnVector<T>*>(_typed_column.column.get());
            }

            assert(column_data);
            _values = (const T*)(column_data->get_data().data()) + _row_pos;
            return Status::OK();
        }
```
it will move the ptr of values through the _row_pos. But nullmap doesn't do it and it will return directly.
and then when call append_nullable method
```
Status ColumnWriter::append_nullable(const uint8_t* null_map, const uint8_t** ptr,
                                     size_t num_rows) {
    size_t offset = 0;
    auto next_run_step = [&]() {
        size_t step = 1;
        for (auto i = offset + 1; i < num_rows; ++i) {
            if (null_map[offset] == null_map[i])
                step++;
            else
                break;
        }
        return step;
    };

    do {
        auto step = next_run_step();
        if (null_map[offset]) {
            RETURN_IF_ERROR(append_nulls(step));
            *ptr += get_field()->size() * step;
        } else {
            // TODO:
            //  1. `*ptr += get_field()->size() * step;` should do in this function, not append_data;
            //  2. support array vectorized load and ptr offset add
            RETURN_IF_ERROR(append_data(ptr, step));
        }
        offset += step;
    } while (offset < num_rows);

    return Status::OK();
}
```
it will always read the nullmap starting from zero so that the datas in block starting from row_pos doesn't match the nullmap. This can lead to that the position of nullmap is one, but the data exists.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
