### PR TITLE
[improvement]pre-serialize aggregation keys

### DIFF
--- a/be/src/vec/columns/column.h
+++ b/be/src/vec/columns/column.h
@@ -246,6 +246,23 @@ public:
     /// Returns pointer to the position after the read data.
     virtual const char* deserialize_and_insert_from_arena(const char* pos) = 0;
 
+    /// Return the size of largest row.
+    /// This is for calculating the memory size for vectorized serialization of aggregation keys.
+    virtual size_t get_max_row_byte_size() const {
+        LOG(FATAL) << "get_max_row_byte_size not supported";
+    }
+
+    virtual void serialize_vec(std::vector<StringRef>& keys, size_t num_rows,
+                               size_t max_row_byte_size) const {
+        LOG(FATAL) << "serialize_vec not supported";
+    }
+
+    virtual void serialize_vec_with_null_map(std::vector<StringRef>& keys, size_t num_rows,
+                                             const uint8_t* null_map,
+                                             size_t max_row_byte_size) const {
+        LOG(FATAL) << "serialize_vec_with_null_map not supported";
+    }
+
     /// Update state of hash function with value of n-th element.
     /// On subsequent calls of this method for sequence of column values of arbitrary types,
     ///  passed bytes to hash must identify sequence of values unambiguously.

--- a/be/src/vec/columns/column_const.h
+++ b/be/src/vec/columns/column_const.h
@@ -112,6 +112,19 @@ public:
         return res;
     }
 
+    size_t get_max_row_byte_size() const override { return data->get_max_row_byte_size(); }
+
+    void serialize_vec(std::vector<StringRef>& keys, size_t num_rows,
+                       size_t max_row_byte_size) const override {
+        data->serialize_vec(keys, num_rows, max_row_byte_size);
+    }
+
+    void serialize_vec_with_null_map(std::vector<StringRef>& keys, size_t num_rows,
+                                     const uint8_t* null_map,
+                                     size_t max_row_byte_size) const override {
+        data->serialize_vec_with_null_map(keys, num_rows, null_map, max_row_byte_size);
+    }
+
     void update_hash_with_value(size_t, SipHash& hash) const override {
         data->update_hash_with_value(0, hash);
     }

--- a/be/src/vec/columns/column_nullable.h
+++ b/be/src/vec/columns/column_nullable.h
@@ -89,6 +89,9 @@ public:
 
     StringRef serialize_value_into_arena(size_t n, Arena& arena, char const*& begin) const override;
     const char* deserialize_and_insert_from_arena(const char* pos) override;
+    size_t get_max_row_byte_size() const override;
+    void serialize_vec(std::vector<StringRef>& keys, size_t num_rows,
+                       size_t max_row_byte_size) const override;
     void insert_range_from(const IColumn& src, size_t start, size_t length) override;
     void insert_indices_from(const IColumn& src, const int* indices_begin,
                              const int* indices_end) override;

--- a/be/src/vec/columns/column_string.h
+++ b/be/src/vec/columns/column_string.h
@@ -208,6 +208,15 @@ public:
 
     const char* deserialize_and_insert_from_arena(const char* pos) override;
 
+    size_t get_max_row_byte_size() const override;
+
+    void serialize_vec(std::vector<StringRef>& keys, size_t num_rows,
+                       size_t max_row_byte_size) const override;
+
+    void serialize_vec_with_null_map(std::vector<StringRef>& keys, size_t num_rows,
+                                     const uint8_t* null_map,
+                                     size_t max_row_byte_size) const override;
+
     void update_hash_with_value(size_t n, SipHash& hash) const override {
         size_t string_size = size_at(n);
         size_t offset = offset_at(n);

--- a/be/src/vec/columns/column_vector.cpp
+++ b/be/src/vec/columns/column_vector.cpp
@@ -53,6 +53,32 @@ const char* ColumnVector<T>::deserialize_and_insert_from_arena(const char* pos) 
 }
 
 template <typename T>
+size_t ColumnVector<T>::get_max_row_byte_size() const {
+    return sizeof(T);
+}
+
+template <typename T>
+void ColumnVector<T>::serialize_vec(std::vector<StringRef>& keys, size_t num_rows,
+                                    size_t max_row_byte_size) const {
+    for (size_t i = 0; i < num_rows; ++i) {
+        memcpy(const_cast<char*>(keys[i].data + keys[i].size), &data[i], sizeof(T));
+        keys[i].size += sizeof(T);
+    }
+}
+
+template <typename T>
+void ColumnVector<T>::serialize_vec_with_null_map(std::vector<StringRef>& keys, size_t num_rows,
+                                                  const uint8_t* null_map,
+                                                  size_t max_row_byte_size) const {
+    for (size_t i = 0; i < num_rows; ++i) {
+        if (null_map[i] == 0) {
+            memcpy(const_cast<char*>(keys[i].data + keys[i].size), &data[i], sizeof(T));
+            keys[i].size += sizeof(T);
+        }
+    }
+}
+
+template <typename T>
 void ColumnVector<T>::update_hash_with_value(size_t n, SipHash& hash) const {
     hash.update(data[n]);
 }

--- a/be/src/vec/columns/column_vector.h
+++ b/be/src/vec/columns/column_vector.h
@@ -222,6 +222,15 @@ public:
 
     const char* deserialize_and_insert_from_arena(const char* pos) override;
 
+    size_t get_max_row_byte_size() const override;
+
+    void serialize_vec(std::vector<StringRef>& keys, size_t num_rows,
+                       size_t max_row_byte_size) const override;
+
+    void serialize_vec_with_null_map(std::vector<StringRef>& keys, size_t num_rows,
+                                     const uint8_t* null_map,
+                                     size_t max_row_byte_size) const override;
+
     void update_hash_with_value(size_t n, SipHash& hash) const override;
 
     size_t byte_size() const override { return data.size() * sizeof(data[0]); }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

Test with ssb-flat 100g with the SQL:
```sql
select count() from ( SELECT  C_CITY,   SUM(LO_REVENUE) AS revenue FROM lineorder_flat GROUP BY C_CITY, S_CITY) a;
```

||non-pre serialize|pre serialize|
|-|-|-|
|profile|<img width="446" alt="image" src="https://user-images.githubusercontent.com/1179834/177964945-8803ad98-923b-4468-848d-2dd83c31ebb8.png">|<img width="454" alt="image" src="https://user-images.githubusercontent.com/1179834/177964545-899a4045-179c-47ea-8ec7-18fefc1d7e71.png">|

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
