### PR TITLE
[feature-wip](unique-key-merge-on-write) add bloom filter index for primary key, DSIP-018[1.2]

### DIFF
--- a/be/src/olap/primary_key_index.cpp
+++ b/be/src/olap/primary_key_index.cpp
@@ -30,12 +30,17 @@ Status PrimaryKeyIndexBuilder::init() {
     options.encoding = segment_v2::EncodingInfo::get_default_encoding(type_info, true);
     // TODO(liaoxin) test to confirm whether it needs to be compressed
     options.compression = segment_v2::NO_COMPRESSION; // currently not compressed
-    _index_builder.reset(new segment_v2::IndexedColumnWriter(options, type_info, _file_writer));
-    return _index_builder->init();
+    _primary_key_index_builder.reset(
+            new segment_v2::IndexedColumnWriter(options, type_info, _file_writer));
+    RETURN_IF_ERROR(_primary_key_index_builder->init());
+
+    return segment_v2::BloomFilterIndexWriter::create(segment_v2::BloomFilterOptions(), type_info,
+                                                      &_bloom_filter_index_builder);
 }
 
 Status PrimaryKeyIndexBuilder::add_item(const Slice& key) {
-    _index_builder->add(&key);
+    RETURN_IF_ERROR(_primary_key_index_builder->add(&key));
+    _bloom_filter_index_builder->add_values(&key, 1);
     // the key is already sorted, so the first key is min_key, and
     // the last key is max_key.
     if (UNLIKELY(_num_rows == 0)) {
@@ -48,16 +53,29 @@ Status PrimaryKeyIndexBuilder::add_item(const Slice& key) {
     return Status::OK();
 }
 
-Status PrimaryKeyIndexBuilder::finalize(segment_v2::IndexedColumnMetaPB* meta) {
+Status PrimaryKeyIndexBuilder::finalize(segment_v2::PrimaryKeyIndexMetaPB* meta) {
     // finish primary key index
-    return _index_builder->finish(meta);
+    RETURN_IF_ERROR(_primary_key_index_builder->finish(meta->mutable_primary_key_index()));
+
+    // finish bloom filter index
+    RETURN_IF_ERROR(_bloom_filter_index_builder->flush());
+    return _bloom_filter_index_builder->finish(_file_writer, meta->mutable_bloom_filter_index());
 }
 
 Status PrimaryKeyIndexReader::parse(io::FileSystem* fs, const std::string& path,
-                                    const segment_v2::IndexedColumnMetaPB& meta) {
+                                    const segment_v2::PrimaryKeyIndexMetaPB& meta) {
     // parse primary key index
-    _index_reader.reset(new segment_v2::IndexedColumnReader(fs, path, meta));
+    _index_reader.reset(new segment_v2::IndexedColumnReader(fs, path, meta.primary_key_index()));
     RETURN_IF_ERROR(_index_reader->load(_use_page_cache, _kept_in_memory));
+
+    // parse bloom filter
+    segment_v2::ColumnIndexMetaPB column_index_meta = meta.bloom_filter_index();
+    segment_v2::BloomFilterIndexReader bf_index_reader(fs, path,
+                                                       &column_index_meta.bloom_filter_index());
+    RETURN_IF_ERROR(bf_index_reader.load(_use_page_cache, _kept_in_memory));
+    std::unique_ptr<segment_v2::BloomFilterIndexIterator> bf_iter;
+    RETURN_IF_ERROR(bf_index_reader.new_iterator(&bf_iter));
+    RETURN_IF_ERROR(bf_iter->read_bloom_filter(0, &_bf));
 
     _parsed = true;
     return Status::OK();

--- a/be/test/olap/primary_key_index_test.cpp
+++ b/be/test/olap/primary_key_index_test.cpp
@@ -67,7 +67,7 @@ TEST_F(PrimaryKeyIndexTest, builder) {
     }
     EXPECT_EQ("1000", builder.min_key().to_string());
     EXPECT_EQ("9998", builder.max_key().to_string());
-    segment_v2::IndexedColumnMetaPB index_meta;
+    segment_v2::PrimaryKeyIndexMetaPB index_meta;
     EXPECT_TRUE(builder.finalize(&index_meta));
     EXPECT_TRUE(file_writer->close().ok());
     EXPECT_EQ(num_rows, builder.num_rows());
@@ -81,6 +81,8 @@ TEST_F(PrimaryKeyIndexTest, builder) {
     bool exact_match = false;
     uint32_t row_id;
     for (size_t i = 0; i < keys.size(); i++) {
+        bool exists = index_reader.check_present(keys[i]);
+        EXPECT_TRUE(exists);
         auto status = index_iterator->seek_at_or_after(&keys[i], &exact_match);
         EXPECT_TRUE(status.ok());
         EXPECT_TRUE(exact_match);
@@ -91,6 +93,8 @@ TEST_F(PrimaryKeyIndexTest, builder) {
     {
         string key("8701");
         Slice slice(key);
+        bool exists = index_reader.check_present(slice);
+        EXPECT_FALSE(exists);
         auto status = index_iterator->seek_at_or_after(&slice, &exact_match);
         EXPECT_TRUE(status.ok());
         EXPECT_FALSE(exact_match);
@@ -102,6 +106,8 @@ TEST_F(PrimaryKeyIndexTest, builder) {
     {
         string key("87");
         Slice slice(key);
+        bool exists = index_reader.check_present(slice);
+        EXPECT_FALSE(exists);
         auto status = index_iterator->seek_at_or_after(&slice, &exact_match);
         EXPECT_TRUE(status.ok());
         EXPECT_FALSE(exact_match);
@@ -113,6 +119,8 @@ TEST_F(PrimaryKeyIndexTest, builder) {
     {
         string key("9999");
         Slice slice(key);
+        bool exists = index_reader.check_present(slice);
+        EXPECT_FALSE(exists);
         auto status = index_iterator->seek_at_or_after(&slice, &exact_match);
         EXPECT_FALSE(exact_match);
         EXPECT_TRUE(status.is_not_found());

--- a/gensrc/proto/segment_v2.proto
+++ b/gensrc/proto/segment_v2.proto
@@ -162,6 +162,13 @@ message ColumnMetaPB {
 
 }
 
+message PrimaryKeyIndexMetaPB {
+    // primary key index
+    optional IndexedColumnMetaPB primary_key_index = 1;
+    // bloom filter index
+    optional ColumnIndexMetaPB bloom_filter_index = 2;
+}
+
 message SegmentFooterPB {
     optional uint32 version = 1 [default = 1]; // file version
     repeated ColumnMetaPB columns = 2; // tablet schema
@@ -175,6 +182,9 @@ message SegmentFooterPB {
 
     // Short key index's page
     optional PagePointerPB short_key_index_page = 9;
+
+    // Primary key index meta
+    optional PrimaryKeyIndexMetaPB primary_key_index_meta = 10;
 }
 
 message BTreeMetaPB {


### PR DESCRIPTION
# Proposed changes

Add Bloom filter index for primary key. This patch is for step 1.2 in scheduling.
For the detail, see DSIP-018:https://cwiki.apache.org/confluence/display/DORIS/DSIP-018%3A+Support+Merge-On-Write+implementation+for+UNIQUE+KEY+data+model

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (No)
2. Has unit tests been added: (Yes)
3. Has document been added or modified: (No)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
