### PR TITLE
[fix]Avoid error while runing stop_be.sh with no arg

### DIFF
--- a/bin/stop_be.sh
+++ b/bin/stop_be.sh
@@ -23,7 +23,7 @@ export DORIS_HOME=`cd "$curdir/.."; pwd`
 export PID_DIR=`cd "$curdir"; pwd`
 
 signum=9
-if [ $1 = "--grace" ]; then
+if [ "$1" = "--grace" ]; then
     signum=15
 fi
 


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

When run stop_be.sh without any argument:
```bash
be/output/bin/stop_be.sh: line 26: [: =: unary operator expected
```

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
