### PR TITLE
[Bug](tablet) Fix bug that segments are removed as trash but tablet meta is normal

### DIFF
--- a/be/src/olap/tablet_manager.cpp
+++ b/be/src/olap/tablet_manager.cpp
@@ -161,6 +161,16 @@ Status TabletManager::_add_tablet_unlocked(TTabletId tablet_id, const TabletShar
         res = _add_tablet_to_map_unlocked(tablet_id, tablet, update_meta, keep_files,
                                           true /*drop_old*/);
     } else {
+        tablet->set_tablet_state(TABLET_SHUTDOWN);
+        tablet->save_meta();
+        {
+            std::lock_guard<std::shared_mutex> shutdown_tablets_wrlock(_shutdown_tablets_lock);
+            _shutdown_tablets.push_back(tablet);
+        }
+        LOG(INFO) << "set tablet to shutdown state."
+                  << "tablet_id=" << tablet->tablet_id()
+                  << ", tablet_path=" << tablet->tablet_path();
+
         res = Status::OLAPInternalError(OLAP_ERR_ENGINE_INSERT_OLD_TABLET);
     }
     LOG(WARNING) << "add duplicated tablet. force=" << force << ", res=" << res


### PR DESCRIPTION
# Proposed changes

Issue Number: close #10720 

## Problem Summary:

We replaced the original disk on the BE node with a new disk by wrong operation when BE restarted. When we discovered the mistake and added the original disk. There is no unhealthy replica in the cluster after a period of time, and we removed the wrong disk. When query comes, exception information is thrown and the error code is `-3109` which means `failed to open segment`. We found that segment files for some tablets had been removed as trash but tablet meta is normal in original disk. These abnormal tablets can not be detected and repaired by FE.

## Checklist(Required)

1. Does it affect the original behavior: (No)
2. Has unit tests been added: (No Need)
3. Has document been added or modified: (No Need)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (No)
