### PR TITLE
[enhancement][MultiCatalog]Add strong checker for hms table

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/Analyzer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/Analyzer.java
@@ -31,6 +31,7 @@ import org.apache.doris.catalog.TableIf;
 import org.apache.doris.catalog.TableIf.TableType;
 import org.apache.doris.catalog.Type;
 import org.apache.doris.catalog.View;
+import org.apache.doris.catalog.external.HMSExternalTable;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.ErrorReport;
@@ -672,6 +673,15 @@ public class Analyzer {
         if (table.getType() == TableType.HUDI && table.getFullSchema().isEmpty()) {
             // resolve hudi table's schema when table schema is empty from doris meta
             table = HudiUtils.resolveHudiTable((HudiTable) table);
+        }
+
+        // Now hms table only support a bit of table kinds in the whole hive system.
+        // So Add this strong checker here to avoid some undefine behaviour in doris.
+        if (table.getType() == TableType.HMS_EXTERNAL_TABLE && !((HMSExternalTable) table).isSupportedHmsTable()) {
+            ErrorReport.reportAnalysisException(ErrorCode.ERR_NONSUPPORT_HMS_TABLE,
+                    table.getName(),
+                    ((HMSExternalTable) table).getDbName(),
+                    tableName.getCtl());
         }
 
         // tableName.getTbl() stores the table name specified by the user in the from statement.

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/external/ExternalTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/external/ExternalTable.java
@@ -44,7 +44,7 @@ public class ExternalTable implements TableIf {
     protected String name;
     protected ReentrantReadWriteLock rwLock = new ReentrantReadWriteLock(true);
     protected TableType type = null;
-    protected List<Column> fullSchema = null;
+    protected volatile List<Column> fullSchema = null;
 
     /**
      * Create external table.

--- a/fe/fe-core/src/main/java/org/apache/doris/common/ErrorCode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/ErrorCode.java
@@ -1689,7 +1689,9 @@ public enum ErrorCode {
     ERR_WRONG_CATALOG_NAME(5085, new byte[]{'4', '2', '0', '0', '0'}, "Incorrect catalog name '%s'"),
     ERR_UNKNOWN_CATALOG(5086, new byte[]{'4', '2', '0', '0', '0'}, "Unknown catalog '%s'"),
     ERR_CATALOG_ACCESS_DENIED(5087, new byte[]{'4', '2', '0', '0', '0'},
-            "Access denied for user '%s' to catalog '%s'");
+            "Access denied for user '%s' to catalog '%s'"),
+    ERR_NONSUPPORT_HMS_TABLE(5088, new byte[]{'4', '2', '0', '0', '0'},
+            "Nonsupport hive metastore table named '%s' in database '%s' with catalog '%s'.");
 
     // This is error code
     private final int code;

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/BrokerUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/BrokerUtil.java
@@ -89,6 +89,8 @@ public class BrokerUtil {
     public static String HADOOP_USER_NAME = "hadoop.username";
     public static String HADOOP_KERBEROS_PRINCIPAL = "hadoop.kerberos.principal";
     public static String HADOOP_KERBEROS_KEYTAB = "hadoop.kerberos.keytab";
+    public static String HADOOP_SHORT_CIRCUIT = "dfs.client.read.shortcircuit";
+    public static String HADOOP_SOCKET_PATH = "dfs.domain.socket.path";
 
     public static THdfsParams generateHdfsParam(Map<String, String> properties) {
         THdfsParams tHdfsParams = new THdfsParams();
@@ -108,6 +110,11 @@ public class BrokerUtil {
                 hdfsConf.setValue(property.getValue());
                 tHdfsParams.hdfs_conf.add(hdfsConf);
             }
+        }
+        // `dfs.client.read.shortcircuit` and `dfs.domain.socket.path` should be both set to enable short circuit read.
+        // We should disable short circuit read if they are not both set because it will cause performance down.
+        if (!properties.containsKey(HADOOP_SHORT_CIRCUIT) || !properties.containsKey(HADOOP_SOCKET_PATH)) {
+            tHdfsParams.addToHdfsConf(new THdfsConf(HADOOP_SHORT_CIRCUIT, "false"));
         }
         return tHdfsParams;
     }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #10723 

## Problem Summary:
Add a strong checker for the hms table. Now we only support a small subset of the hive table, so we need intercept the execution of this nonsupport table in the analyse phase.

Also this modify will fix issue #10723 
## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
