### PR TITLE
[FIX] need check if aggregate_function_changed_flags is set by fe

### DIFF
--- a/be/src/vec/exec/vaggregation_node.cpp
+++ b/be/src/vec/exec/vaggregation_node.cpp
@@ -77,7 +77,10 @@ static constexpr int STREAMING_HT_MIN_REDUCTION_SIZE =
 AggregationNode::AggregationNode(ObjectPool* pool, const TPlanNode& tnode,
                                  const DescriptorTbl& descs)
         : ExecNode(pool, tnode, descs),
-          _aggregate_evaluators_changed_flags(tnode.agg_node.aggregate_function_changed_flags),
+          _aggregate_evaluators_changed_flags(
+                  tnode.agg_node.__isset.aggregate_function_changed_flags
+                          ? tnode.agg_node.aggregate_function_changed_flags
+                          : std::vector<bool> {}),
           _intermediate_tuple_id(tnode.agg_node.intermediate_tuple_id),
           _intermediate_tuple_desc(NULL),
           _output_tuple_id(tnode.agg_node.output_tuple_id),


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

aggregate_function_changed_flags is an optional field, be shoud check if it is set before using it

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
