### PR TITLE
[Bug] fix datetimev2 decimal error.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/DateLiteral.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/DateLiteral.java
@@ -293,6 +293,7 @@ public class DateLiteral extends LiteralExpr {
         this.hour = dateTime.getHourOfDay();
         this.minute = dateTime.getMinuteOfHour();
         this.second = dateTime.getSecondOfMinute();
+        this.microsecond = dateTime.getMillisOfSecond() * 1000L;
         this.type = type;
     }
 
@@ -441,10 +442,14 @@ public class DateLiteral extends LiteralExpr {
             if (((ScalarType) type).decimalScale() == 0) {
                 return s;
             }
-            return s + "." + microsecond / (10L * (6 - ((ScalarType) type).decimalScale()));
+            return s + "." + getDecimalNumber();
         } else {
             return String.format("%04d-%02d-%02d %02d:%02d:%02d", year, month, day, hour, minute, second);
         }
+    }
+
+    public long getDecimalNumber() {
+        return Double.valueOf(microsecond / (Math.pow(10, 6 - ((ScalarType) type).decimalScale()))).longValue();
     }
 
     private String convertToString(PrimitiveType type) {

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/DateLiteralTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/DateLiteralTest.java
@@ -23,6 +23,7 @@ import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.InvalidFormatException;
 import org.apache.doris.common.jmockit.Deencapsulation;
 
+import org.joda.time.LocalDateTime;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -343,5 +344,16 @@ public class DateLiteralTest {
             hasException = true;
         }
         Assert.assertFalse(hasException);
+    }
+
+    @Test
+    public void testDateTimeV2Decimal() throws AnalysisException {
+        DateLiteral dateLiteral1 = new DateLiteral(LocalDateTime.now(),
+                DateLiteral.getDefaultDateType(ScalarType.createDatetimeV2Type(3)));
+        Assert.assertTrue(dateLiteral1.getDecimalNumber() >= 100 && dateLiteral1.getDecimalNumber() < 1000);
+
+        DateLiteral dateLiteral2 = new DateLiteral(LocalDateTime.now(),
+                DateLiteral.getDefaultDateType(ScalarType.createDatetimeV2Type(5)));
+        Assert.assertTrue(dateLiteral2.getDecimalNumber() >= 10000 && dateLiteral2.getDecimalNumber() < 100000);
     }
 }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:
Datetimev2's getStringValue method currently computs the decimal part incorrectly, It should be 10 to the power of the decimal place instead of multiplying.
