### PR TITLE
[docs]fix typo in substring docs

### DIFF
--- a/docs/en/docs/sql-manual/sql-functions/string-functions/substring.md
+++ b/docs/en/docs/sql-manual/sql-functions/string-functions/substring.md
@@ -41,10 +41,11 @@ For all forms of SUBSTRING(),
 the position of the first character in the string from which the substring is to be extracted is reckoned as 1.
 
 If len is less than 1, the result is the empty string.
+
 ### example
 
 ```
-mysql> select substring('abc1', -2);
+mysql> select substring('abc1', 2);
 +-----------------------------+
 | substring('abc1', 2)        |
 +-----------------------------+
@@ -57,6 +58,13 @@ mysql> select substring('abc1', -2);
 +-----------------------------+
 | c1                          |
 +-----------------------------+
+
+mysql> select substring('abc1', 0);
++----------------------+
+| substring('abc1', 0) |
++----------------------+
+|                      |
++----------------------+
 
 mysql> select substring('abc1', 5);
 +-----------------------------+
@@ -74,4 +82,4 @@ mysql> select substring('abc1def', 2, 2);
 ```
 
 ### keywords
-SUBSTRING
+SUBSTRING,STRING

--- a/docs/en/docs/sql-manual/sql-functions/string-functions/substring.md
+++ b/docs/en/docs/sql-manual/sql-functions/string-functions/substring.md
@@ -82,4 +82,4 @@ mysql> select substring('abc1def', 2, 2);
 ```
 
 ### keywords
-SUBSTRING,STRING
+SUBSTRING, STRING

--- a/docs/zh-CN/docs/sql-manual/sql-functions/string-functions/substring.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/string-functions/substring.md
@@ -76,4 +76,4 @@ mysql> select substring('abc1def', 2, 2);
 +-----------------------------+
 ```
 ### keywords
-SUBSTRING,STRING
+SUBSTRING, STRING

--- a/docs/zh-CN/docs/sql-manual/sql-functions/string-functions/substring.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/string-functions/substring.md
@@ -54,6 +54,13 @@ mysql> select substring('abc1', -2);
 | c1                          |
 +-----------------------------+
 
+mysql> select substring('abc1', 0);
++----------------------+
+| substring('abc1', 0) |
++----------------------+
+|                      |
++----------------------+
+
 mysql> select substring('abc1', 5);
 +-----------------------------+
 | substring('abc1', 5)        |
@@ -69,4 +76,4 @@ mysql> select substring('abc1def', 2, 2);
 +-----------------------------+
 ```
 ### keywords
-SUBSTRING
+SUBSTRING,STRING


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

Describe the overview of changes.
1. fix typo in docs/en/docs/sql-manual/sql-functions/string-functions/substring.md
2. add another substring example with pos=0;

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
4. Has unit tests been added: (Yes/No/No Need)
5. Has document been added or modified: (Yes/No/No Need)
6. Does it need to update dependencies: (Yes/No)
7. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
