### PR TITLE
[DOC Enhancement]update proxy_connect_timeout and proxy_timeout from 30s to 300s

### DIFF
--- a/docs/en/docs/admin-manual/cluster-management/load-balancing.md
+++ b/docs/en/docs/admin-manual/cluster-management/load-balancing.md
@@ -527,8 +527,8 @@ stream {
   ###这里是配置代理的端口，超时时间等
   server {
       listen 6030;
-      proxy_connect_timeout 30s;
-      proxy_timeout 30s;
+      proxy_connect_timeout 300s;
+      proxy_timeout 300s;
       proxy_pass mysqld;
   }
 }

--- a/docs/zh-CN/docs/admin-manual/cluster-management/load-balancing.md
+++ b/docs/zh-CN/docs/admin-manual/cluster-management/load-balancing.md
@@ -527,8 +527,8 @@ stream {
   ###这里是配置代理的端口，超时时间等
   server {
       listen 6030;
-      proxy_connect_timeout 30s;
-      proxy_timeout 30s;
+      proxy_connect_timeout 300s;
+      proxy_timeout 300s;
       proxy_pass mysqld;
   }
 }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #10752 https://github.com/apache/doris/issues/10752

## Problem Summary:
 1. default config  `proxy_connect_timeout 30s; proxy_timeout 30s ` and `query_timeout =300s`
 2. if use  default config, sometimes have error message like `No operations allow after statement closed.`
 3. so change to  proxy_connect_timeout default value equals query_timeout default value.



## Checklist(Required)

1. Does it affect the original behavior: (No)
3. Has unit tests been added: (No)
5. Has document been added or modified: (Yes)
6. Does it need to update dependencies: (No)
7. Are there any changes that cannot be rolled back: (Yes)

## Further comments


If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
