### PR TITLE
[Refactor](Nereids) remove generic type from concrete expressions

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/analyzer/UnboundAlias.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/analyzer/UnboundAlias.java
@@ -32,11 +32,9 @@ import java.util.List;
 /**
  * Expression for unbound alias.
  */
-public class UnboundAlias<CHILD_TYPE extends Expression>
-        extends NamedExpression
-        implements UnaryExpression<CHILD_TYPE>, Unbound {
+public class UnboundAlias extends NamedExpression implements UnaryExpression, Unbound {
 
-    public UnboundAlias(CHILD_TYPE child) {
+    public UnboundAlias(Expression child) {
         super(NodeType.UNBOUND_ALIAS, child);
     }
 
@@ -58,6 +56,6 @@ public class UnboundAlias<CHILD_TYPE extends Expression>
     @Override
     public Expression withChildren(List<Expression> children) {
         Preconditions.checkArgument(children.size() == 1);
-        return new UnboundAlias<>(children.get(0));
+        return new UnboundAlias(children.get(0));
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/PhysicalPlanTranslator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/PhysicalPlanTranslator.java
@@ -93,13 +93,13 @@ public class PhysicalPlanTranslator extends PlanOperatorVisitor<PlanFragment, Pl
      * The left child of origin predicate is t2.id and the right child of origin predicate is t1.id.
      * In this situation, the children of predicate need to be swap => t1.id=t2.id.
      */
-    private static Expression swapEqualToForChildrenOrder(EqualTo<?, ?> equalTo, List<Slot> leftOutput) {
+    private static Expression swapEqualToForChildrenOrder(EqualTo equalTo, List<Slot> leftOutput) {
         Set<ExprId> leftSlots = SlotExtractor.extractSlot(equalTo.left()).stream()
                 .map(NamedExpression::getExprId).collect(Collectors.toSet());
         if (leftOutput.stream().map(NamedExpression::getExprId).collect(Collectors.toSet()).containsAll(leftSlots)) {
             return equalTo;
         } else {
-            return new EqualTo<>(equalTo.right(), equalTo.left());
+            return new EqualTo(equalTo.right(), equalTo.left());
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rewrite/rules/BetweenToCompoundRule.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rewrite/rules/BetweenToCompoundRule.java
@@ -37,8 +37,8 @@ public class BetweenToCompoundRule extends AbstractExpressionRewriteRule {
 
     @Override
     public Expression visitBetween(Between expr, ExpressionRewriteContext context) {
-        Expression left = new GreaterThanEqual<>(expr.getCompareExpr(), expr.getLowerBound());
-        Expression right = new LessThanEqual<>(expr.getCompareExpr(), expr.getUpperBound());
-        return new And<>(left, right);
+        Expression left = new GreaterThanEqual(expr.getCompareExpr(), expr.getLowerBound());
+        Expression right = new LessThanEqual(expr.getCompareExpr(), expr.getUpperBound());
+        return new And(left, right);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rewrite/rules/SimplifyNotExprRule.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rewrite/rules/SimplifyNotExprRule.java
@@ -78,9 +78,9 @@ public class SimplifyNotExprRule extends AbstractExpressionRewriteRule {
             NodeType type = cp.getType();
             switch (type) {
                 case AND:
-                    return new Or<>(left, right);
+                    return new Or(left, right);
                 case OR:
-                    return new And<>(left, right);
+                    return new And(left, right);
                 default:
                     return expr;
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/AggregateDisassemble.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/AggregateDisassemble.java
@@ -97,7 +97,7 @@ public class AggregateDisassemble extends OneRewriteRuleFactory {
                     inputSubstitutionMap.put(originGroupByExpr, originGroupByExpr);
                     localOutputExprs.add((SlotReference) originGroupByExpr);
                 } else {
-                    NamedExpression localOutputExpr = new Alias<>(originGroupByExpr, originGroupByExpr.toSql());
+                    NamedExpression localOutputExpr = new Alias(originGroupByExpr, originGroupByExpr.toSql());
                     inputSubstitutionMap.put(originGroupByExpr, localOutputExpr.toSlot());
                     localOutputExprs.add(localOutputExpr);
                 }
@@ -109,7 +109,7 @@ public class AggregateDisassemble extends OneRewriteRuleFactory {
                     if (inputSubstitutionMap.containsKey(aggregateFunction)) {
                         continue;
                     }
-                    NamedExpression localOutputExpr = new Alias<>(aggregateFunction, aggregateFunction.toSql());
+                    NamedExpression localOutputExpr = new Alias(aggregateFunction, aggregateFunction.toSql());
                     Expression substitutionValue = aggregateFunction.withChildren(
                             Lists.newArrayList(localOutputExpr.toSlot()));
                     inputSubstitutionMap.put(aggregateFunction, substitutionValue);

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/Add.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/Add.java
@@ -27,9 +27,8 @@ import java.util.List;
 /**
  * Add Expression.
  */
-public class Add<LEFT_CHILD_TYPE extends Expression, RIGHT_CHILD_TYPE extends Expression>
-        extends Arithmetic implements BinaryExpression<LEFT_CHILD_TYPE, RIGHT_CHILD_TYPE> {
-    public Add(LEFT_CHILD_TYPE left, RIGHT_CHILD_TYPE right) {
+public class Add extends Arithmetic implements BinaryExpression {
+    public Add(Expression left, Expression right) {
         super(ArithmeticOperator.ADD, left, right);
     }
 
@@ -42,7 +41,7 @@ public class Add<LEFT_CHILD_TYPE extends Expression, RIGHT_CHILD_TYPE extends Ex
     @Override
     public Expression withChildren(List<Expression> children) {
         Preconditions.checkArgument(children.size() == 2);
-        return new Add<>(children.get(0), children.get(1));
+        return new Add(children.get(0), children.get(1));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/Alias.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/Alias.java
@@ -30,8 +30,7 @@ import java.util.List;
 /**
  * Expression for alias, such as col1 as c1.
  */
-public class Alias<CHILD_TYPE extends Expression> extends NamedExpression
-        implements UnaryExpression<CHILD_TYPE> {
+public class Alias extends NamedExpression implements UnaryExpression {
 
     private final ExprId exprId;
     private final String name;
@@ -43,11 +42,11 @@ public class Alias<CHILD_TYPE extends Expression> extends NamedExpression
      * @param child expression that alias represents for
      * @param name alias name
      */
-    public Alias(CHILD_TYPE child, String name) {
+    public Alias(Expression child, String name) {
         this(NamedExpressionUtil.newExprId(), child, name);
     }
 
-    private Alias(ExprId exprId, CHILD_TYPE child, String name) {
+    private Alias(ExprId exprId, Expression child, String name) {
         super(NodeType.ALIAS, child);
         this.exprId = exprId;
         this.name = name;
@@ -101,7 +100,7 @@ public class Alias<CHILD_TYPE extends Expression> extends NamedExpression
     @Override
     public Expression withChildren(List<Expression> children) {
         Preconditions.checkArgument(children.size() == 1);
-        return new Alias<>(exprId, children.get(0), name);
+        return new Alias(exprId, children.get(0), name);
     }
 
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/And.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/And.java
@@ -26,21 +26,20 @@ import java.util.List;
 /**
  * And predicate expression.
  */
-public class And<LEFT_CHILD_TYPE extends Expression, RIGHT_CHILD_TYPE extends Expression>
-        extends CompoundPredicate<LEFT_CHILD_TYPE, RIGHT_CHILD_TYPE> {
+public class And extends CompoundPredicate {
     /**
      * Desc: Constructor for CompoundPredicate.
      *
      * @param left  left child of comparison predicate
      * @param right right child of comparison predicate
      */
-    public And(LEFT_CHILD_TYPE left, RIGHT_CHILD_TYPE right) {
+    public And(Expression left, Expression right) {
         super(NodeType.AND, left, right);
     }
 
     @Override
     public Expression withChildren(List<Expression> children) {
         Preconditions.checkArgument(children.size() == 2);
-        return new And<>(children.get(0), children.get(1));
+        return new And(children.get(0), children.get(1));
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/Between.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/Between.java
@@ -31,11 +31,7 @@ import java.util.Objects;
 /**
  * Between predicate expression.
  */
-public class Between<
-            FIRST_CHILD_TYPE extends Expression,
-            SECOND_CHILD_TYPE extends Expression,
-            THIRD_CHILD_TYPE extends Expression>
-        extends Expression implements TernaryExpression<FIRST_CHILD_TYPE, SECOND_CHILD_TYPE, THIRD_CHILD_TYPE> {
+public class Between extends Expression implements TernaryExpression {
 
     private Expression compareExpr;
     private Expression lowerBound;
@@ -95,7 +91,7 @@ public class Between<
     @Override
     public Expression withChildren(List<Expression> children) {
         Preconditions.checkArgument(children.size() == 3);
-        return new Between<>(children.get(0), children.get(1), children.get(2));
+        return new Between(children.get(0), children.get(1), children.get(2));
     }
 
     @Override
@@ -106,7 +102,7 @@ public class Between<
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        Between<?, ?, ?> between = (Between<?, ?, ?>) o;
+        Between between = (Between) o;
         return Objects.equals(compareExpr, between.compareExpr)
                 && Objects.equals(lowerBound, between.lowerBound)
                 && Objects.equals(upperBound, between.upperBound);

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/BinaryExpression.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/BinaryExpression.java
@@ -22,19 +22,16 @@ import org.apache.doris.nereids.trees.BinaryNode;
 /**
  * Interface for all expression that have two children.
  */
-public interface BinaryExpression<
-            LEFT_CHILD_TYPE extends Expression,
-            RIGHT_CHILD_TYPE extends Expression>
-        extends BinaryNode<Expression, LEFT_CHILD_TYPE, RIGHT_CHILD_TYPE> {
+public interface BinaryExpression extends BinaryNode<Expression, Expression, Expression> {
 
     @Override
-    default LEFT_CHILD_TYPE left() {
-        return (LEFT_CHILD_TYPE) child(0);
+    default Expression left() {
+        return child(0);
     }
 
     @Override
-    default RIGHT_CHILD_TYPE right() {
-        return (RIGHT_CHILD_TYPE) child(1);
+    default Expression right() {
+        return child(1);
     }
 
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/ComparisonPredicate.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/ComparisonPredicate.java
@@ -29,8 +29,7 @@ import java.util.Objects;
  * Comparison predicate expression.
  * Such as: "=", "<", "<=", ">", ">=", "<=>"
  */
-public abstract class ComparisonPredicate<LEFT_CHILD_TYPE extends Expression, RIGHT_CHILD_TYPE extends Expression>
-        extends Expression implements BinaryExpression<LEFT_CHILD_TYPE, RIGHT_CHILD_TYPE> {
+public abstract class ComparisonPredicate extends Expression implements BinaryExpression {
     /**
      * Constructor of ComparisonPredicate.
      *
@@ -38,7 +37,7 @@ public abstract class ComparisonPredicate<LEFT_CHILD_TYPE extends Expression, RI
      * @param left     left child of comparison predicate
      * @param right    right child of comparison predicate
      */
-    public ComparisonPredicate(NodeType nodeType, LEFT_CHILD_TYPE left, RIGHT_CHILD_TYPE right) {
+    public ComparisonPredicate(NodeType nodeType, Expression left, Expression right) {
         super(nodeType, left, right);
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/CompoundPredicate.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/CompoundPredicate.java
@@ -28,8 +28,7 @@ import java.util.Objects;
  * Compound predicate expression.
  * Such as &&,||,AND,OR.
  */
-public class CompoundPredicate<LEFT_CHILD_TYPE extends Expression, RIGHT_CHILD_TYPE extends Expression>
-        extends Expression implements BinaryExpression<LEFT_CHILD_TYPE, RIGHT_CHILD_TYPE> {
+public class CompoundPredicate extends Expression implements BinaryExpression {
 
     /**
      * Desc: Constructor for CompoundPredicate.
@@ -38,7 +37,7 @@ public class CompoundPredicate<LEFT_CHILD_TYPE extends Expression, RIGHT_CHILD_T
      * @param left  left child of comparison predicate
      * @param right right child of comparison predicate
      */
-    public CompoundPredicate(NodeType type, LEFT_CHILD_TYPE left, RIGHT_CHILD_TYPE right) {
+    public CompoundPredicate(NodeType type, Expression left, Expression right) {
         super(type, left, right);
     }
 
@@ -60,7 +59,7 @@ public class CompoundPredicate<LEFT_CHILD_TYPE extends Expression, RIGHT_CHILD_T
 
     @Override
     public Expression withChildren(List<Expression> children) {
-        return new CompoundPredicate<>(getType(), children.get(0), children.get(1));
+        return new CompoundPredicate(getType(), children.get(0), children.get(1));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/Divide.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/Divide.java
@@ -26,9 +26,8 @@ import java.util.List;
 /**
  * Divide Expression.
  */
-public class Divide<LEFT_CHILD_TYPE extends Expression, RIGHT_CHILD_TYPE extends Expression>
-        extends Arithmetic implements BinaryExpression<LEFT_CHILD_TYPE, RIGHT_CHILD_TYPE> {
-    public Divide(LEFT_CHILD_TYPE left, RIGHT_CHILD_TYPE right) {
+public class Divide extends Arithmetic implements BinaryExpression {
+    public Divide(Expression left, Expression right) {
         super(ArithmeticOperator.DIVIDE, left, right);
     }
 
@@ -41,7 +40,7 @@ public class Divide<LEFT_CHILD_TYPE extends Expression, RIGHT_CHILD_TYPE extends
     @Override
     public Expression withChildren(List<Expression> children) {
         Preconditions.checkArgument(children.size() == 2);
-        return new Divide<>(children.get(0), children.get(1));
+        return new Divide(children.get(0), children.get(1));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/EqualTo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/EqualTo.java
@@ -28,10 +28,9 @@ import java.util.List;
 /**
  * Equal to expression: a = b.
  */
-public class EqualTo<LEFT_CHILD_TYPE extends Expression, RIGHT_CHILD_TYPE extends Expression>
-        extends ComparisonPredicate<LEFT_CHILD_TYPE, RIGHT_CHILD_TYPE> {
+public class EqualTo extends ComparisonPredicate {
 
-    public EqualTo(LEFT_CHILD_TYPE left, RIGHT_CHILD_TYPE right) {
+    public EqualTo(Expression left, Expression right) {
         super(NodeType.EQUAL_TO, left, right);
     }
 
@@ -46,9 +45,9 @@ public class EqualTo<LEFT_CHILD_TYPE extends Expression, RIGHT_CHILD_TYPE extend
     }
 
     @Override
-    public EqualTo<Expression, Expression> withChildren(List<Expression> children) {
+    public EqualTo withChildren(List<Expression> children) {
         Preconditions.checkArgument(children.size() == 2);
-        return new EqualTo<>(children.get(0), children.get(1));
+        return new EqualTo(children.get(0), children.get(1));
     }
 
     public <R, C> R accept(ExpressionVisitor<R, C> visitor, C context) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/GreaterThan.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/GreaterThan.java
@@ -28,15 +28,14 @@ import java.util.List;
 /**
  * Greater than expression: a > b.
  */
-public class GreaterThan<LEFT_CHILD_TYPE extends Expression, RIGHT_CHILD_TYPE extends Expression>
-        extends ComparisonPredicate<LEFT_CHILD_TYPE, RIGHT_CHILD_TYPE> {
+public class GreaterThan extends ComparisonPredicate {
     /**
      * Constructor of Greater Than ComparisonPredicate.
      *
      * @param left  left child of greater than
      * @param right right child of greater than
      */
-    public GreaterThan(LEFT_CHILD_TYPE left, RIGHT_CHILD_TYPE right) {
+    public GreaterThan(Expression left, Expression right) {
         super(NodeType.GREATER_THAN, left, right);
     }
 
@@ -51,9 +50,9 @@ public class GreaterThan<LEFT_CHILD_TYPE extends Expression, RIGHT_CHILD_TYPE ex
     }
 
     @Override
-    public GreaterThan<Expression, Expression> withChildren(List<Expression> children) {
+    public GreaterThan withChildren(List<Expression> children) {
         Preconditions.checkArgument(children.size() == 2);
-        return new GreaterThan<>(children.get(0), children.get(1));
+        return new GreaterThan(children.get(0), children.get(1));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/GreaterThanEqual.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/GreaterThanEqual.java
@@ -28,15 +28,14 @@ import java.util.List;
 /**
  * Greater than and equal expression: a >= b.
  */
-public class GreaterThanEqual<LEFT_CHILD_TYPE extends Expression, RIGHT_CHILD_TYPE extends Expression>
-        extends ComparisonPredicate<LEFT_CHILD_TYPE, RIGHT_CHILD_TYPE> {
+public class GreaterThanEqual extends ComparisonPredicate {
     /**
      * Constructor of Greater Than And Equal.
      *
      * @param left  left child of Greater Than And Equal
      * @param right right child of Greater Than And Equal
      */
-    public GreaterThanEqual(LEFT_CHILD_TYPE left, RIGHT_CHILD_TYPE right) {
+    public GreaterThanEqual(Expression left, Expression right) {
         super(NodeType.GREATER_THAN_EQUAL, left, right);
     }
 
@@ -51,9 +50,9 @@ public class GreaterThanEqual<LEFT_CHILD_TYPE extends Expression, RIGHT_CHILD_TY
     }
 
     @Override
-    public GreaterThanEqual<Expression, Expression> withChildren(List<Expression> children) {
+    public GreaterThanEqual withChildren(List<Expression> children) {
         Preconditions.checkArgument(children.size() == 2);
-        return new GreaterThanEqual<>(children.get(0), children.get(1));
+        return new GreaterThanEqual(children.get(0), children.get(1));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/LessThan.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/LessThan.java
@@ -28,15 +28,14 @@ import java.util.List;
 /**
  * Less than expression: a < b.
  */
-public class LessThan<LEFT_CHILD_TYPE extends Expression, RIGHT_CHILD_TYPE extends Expression>
-        extends ComparisonPredicate<LEFT_CHILD_TYPE, RIGHT_CHILD_TYPE> {
+public class LessThan extends ComparisonPredicate {
     /**
      * Constructor of Less Than Comparison Predicate.
      *
      * @param left  left child of Less Than
      * @param right right child of Less Than
      */
-    public LessThan(LEFT_CHILD_TYPE left, RIGHT_CHILD_TYPE right) {
+    public LessThan(Expression left, Expression right) {
         super(NodeType.LESS_THAN, left, right);
     }
 
@@ -51,9 +50,9 @@ public class LessThan<LEFT_CHILD_TYPE extends Expression, RIGHT_CHILD_TYPE exten
     }
 
     @Override
-    public LessThan<Expression, Expression> withChildren(List<Expression> children) {
+    public LessThan withChildren(List<Expression> children) {
         Preconditions.checkArgument(children.size() == 2);
-        return new LessThan<>(children.get(0), children.get(1));
+        return new LessThan(children.get(0), children.get(1));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/LessThanEqual.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/LessThanEqual.java
@@ -28,15 +28,14 @@ import java.util.List;
 /**
  * Less than and equal expression: a <= b.
  */
-public class LessThanEqual<LEFT_CHILD_TYPE extends Expression, RIGHT_CHILD_TYPE extends Expression>
-        extends ComparisonPredicate<LEFT_CHILD_TYPE, RIGHT_CHILD_TYPE> {
+public class LessThanEqual extends ComparisonPredicate {
     /**
      * Constructor of Less Than And Equal.
      *
      * @param left  left child of Less Than And Equal
      * @param right right child of Less Than And Equal
      */
-    public LessThanEqual(LEFT_CHILD_TYPE left, RIGHT_CHILD_TYPE right) {
+    public LessThanEqual(Expression left, Expression right) {
         super(NodeType.LESS_THAN_EQUAL, left, right);
     }
 
@@ -51,9 +50,9 @@ public class LessThanEqual<LEFT_CHILD_TYPE extends Expression, RIGHT_CHILD_TYPE 
     }
 
     @Override
-    public LessThanEqual<Expression, Expression> withChildren(List<Expression> children) {
+    public LessThanEqual withChildren(List<Expression> children) {
         Preconditions.checkArgument(children.size() == 2);
-        return new LessThanEqual<>(children.get(0), children.get(1));
+        return new LessThanEqual(children.get(0), children.get(1));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/Like.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/Like.java
@@ -28,10 +28,9 @@ import java.util.List;
 /**
  * like expression: a like 'xxx%'.
  */
-public class Like<LEFT_CHILD_TYPE extends Expression, RIGHT_CHILD_TYPE extends Expression>
-        extends StringRegexPredicate<LEFT_CHILD_TYPE, RIGHT_CHILD_TYPE> {
+public class Like extends StringRegexPredicate {
 
-    public Like(LEFT_CHILD_TYPE left, RIGHT_CHILD_TYPE right) {
+    public Like(Expression left, Expression right) {
         super(NodeType.LIKE, left, right);
     }
 
@@ -46,9 +45,9 @@ public class Like<LEFT_CHILD_TYPE extends Expression, RIGHT_CHILD_TYPE extends E
     }
 
     @Override
-    public Like<Expression, Expression> withChildren(List<Expression> children) {
+    public Like withChildren(List<Expression> children) {
         Preconditions.checkArgument(children.size() == 2);
-        return new Like<>(children.get(0), children.get(1));
+        return new Like(children.get(0), children.get(1));
     }
 
     public <R, C> R accept(ExpressionVisitor<R, C> visitor, C context) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/Mod.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/Mod.java
@@ -26,9 +26,8 @@ import java.util.List;
 /**
  * Mod Expression.
  */
-public class Mod<LEFT_CHILD_TYPE extends Expression, RIGHT_CHILD_TYPE extends Expression>
-        extends Arithmetic implements BinaryExpression<LEFT_CHILD_TYPE, RIGHT_CHILD_TYPE> {
-    public Mod(LEFT_CHILD_TYPE left, RIGHT_CHILD_TYPE right) {
+public class Mod extends Arithmetic implements BinaryExpression {
+    public Mod(Expression left, Expression right) {
         super(ArithmeticOperator.MOD, left, right);
     }
 
@@ -41,7 +40,7 @@ public class Mod<LEFT_CHILD_TYPE extends Expression, RIGHT_CHILD_TYPE extends Ex
     @Override
     public Expression withChildren(List<Expression> children) {
         Preconditions.checkArgument(children.size() == 2);
-        return new Mod<>(children.get(0), children.get(1));
+        return new Mod(children.get(0), children.get(1));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/Multiply.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/Multiply.java
@@ -26,10 +26,9 @@ import java.util.List;
 /**
  * Multiply Expression.
  */
-public class Multiply<LEFT_CHILD_TYPE extends Expression, RIGHT_CHILD_TYPE extends Expression>
-        extends Arithmetic implements BinaryExpression<LEFT_CHILD_TYPE, RIGHT_CHILD_TYPE> {
+public class Multiply extends Arithmetic implements BinaryExpression {
 
-    public Multiply(LEFT_CHILD_TYPE left, RIGHT_CHILD_TYPE right) {
+    public Multiply(Expression left, Expression right) {
         super(ArithmeticOperator.MULTIPLY, left, right);
     }
 
@@ -47,6 +46,6 @@ public class Multiply<LEFT_CHILD_TYPE extends Expression, RIGHT_CHILD_TYPE exten
     @Override
     public Expression withChildren(List<Expression> children) {
         Preconditions.checkArgument(children.size() == 2);
-        return new Multiply<>(children.get(0), children.get(1));
+        return new Multiply(children.get(0), children.get(1));
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/Not.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/Not.java
@@ -29,10 +29,9 @@ import java.util.Objects;
 /**
  * Not expression: not a.
  */
-public class Not<CHILD_TYPE extends Expression> extends Expression
-        implements UnaryExpression<CHILD_TYPE> {
+public class Not extends Expression implements UnaryExpression {
 
-    public Not(CHILD_TYPE child) {
+    public Not(Expression child) {
         super(NodeType.NOT, child);
     }
 
@@ -54,7 +53,7 @@ public class Not<CHILD_TYPE extends Expression> extends Expression
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        Not<Expression> other = (Not) o;
+        Not other = (Not) o;
         return Objects.equals(child(), other.child());
     }
 
@@ -64,8 +63,8 @@ public class Not<CHILD_TYPE extends Expression> extends Expression
     }
 
     @Override
-    public Not<Expression> withChildren(List<Expression> children) {
+    public Not withChildren(List<Expression> children) {
         Preconditions.checkArgument(children.size() == 1);
-        return new Not<>(children.get(0));
+        return new Not(children.get(0));
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/NullSafeEqual.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/NullSafeEqual.java
@@ -29,15 +29,14 @@ import java.util.List;
  * Null safe equal expression: a <=> b.
  * Unlike normal equal to expression, null <=> null is true.
  */
-public class NullSafeEqual<LEFT_CHILD_TYPE extends Expression, RIGHT_CHILD_TYPE extends Expression>
-        extends ComparisonPredicate<LEFT_CHILD_TYPE, RIGHT_CHILD_TYPE> {
+public class NullSafeEqual extends ComparisonPredicate {
     /**
      * Constructor of Null Safe Equal ComparisonPredicate.
      *
      * @param left  left child of Null Safe Equal
      * @param right right child of Null Safe Equal
      */
-    public NullSafeEqual(LEFT_CHILD_TYPE left, RIGHT_CHILD_TYPE right) {
+    public NullSafeEqual(Expression left, Expression right) {
         super(NodeType.NULL_SAFE_EQUAL, left, right);
     }
 
@@ -59,6 +58,6 @@ public class NullSafeEqual<LEFT_CHILD_TYPE extends Expression, RIGHT_CHILD_TYPE 
     @Override
     public Expression withChildren(List<Expression> children) {
         Preconditions.checkArgument(children.size() == 2);
-        return new NullSafeEqual<>(children.get(0), children.get(1));
+        return new NullSafeEqual(children.get(0), children.get(1));
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/Or.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/Or.java
@@ -26,21 +26,20 @@ import java.util.List;
 /**
  * Or predicate expression.
  */
-public class Or<LEFT_CHILD_TYPE extends Expression, RIGHT_CHILD_TYPE extends Expression>
-        extends CompoundPredicate<LEFT_CHILD_TYPE, RIGHT_CHILD_TYPE> {
+public class Or extends CompoundPredicate {
     /**
      * Desc: Constructor for CompoundPredicate.
      *
      * @param left  left child of comparison predicate
      * @param right right child of comparison predicate
      */
-    public Or(LEFT_CHILD_TYPE left, RIGHT_CHILD_TYPE right) {
+    public Or(Expression left, Expression right) {
         super(NodeType.OR, left, right);
     }
 
     @Override
     public Expression withChildren(List<Expression> children) {
         Preconditions.checkArgument(children.size() == 2);
-        return new Or<>(children.get(0), children.get(1));
+        return new Or(children.get(0), children.get(1));
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/Regexp.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/Regexp.java
@@ -28,10 +28,9 @@ import java.util.List;
 /**
  * like expression: a regexp '^xxx$'.
  */
-public class Regexp<LEFT_CHILD_TYPE extends Expression, RIGHT_CHILD_TYPE extends Expression>
-        extends StringRegexPredicate<LEFT_CHILD_TYPE, RIGHT_CHILD_TYPE> {
+public class Regexp extends StringRegexPredicate {
 
-    public Regexp(LEFT_CHILD_TYPE left, RIGHT_CHILD_TYPE right) {
+    public Regexp(Expression left, Expression right) {
         super(NodeType.REGEXP, left, right);
     }
 
@@ -46,9 +45,9 @@ public class Regexp<LEFT_CHILD_TYPE extends Expression, RIGHT_CHILD_TYPE extends
     }
 
     @Override
-    public Regexp<Expression, Expression> withChildren(List<Expression> children) {
+    public Regexp withChildren(List<Expression> children) {
         Preconditions.checkArgument(children.size() == 2);
-        return new Regexp<>(children.get(0), children.get(1));
+        return new Regexp(children.get(0), children.get(1));
     }
 
     public <R, C> R accept(ExpressionVisitor<R, C> visitor, C context) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/StringRegexPredicate.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/StringRegexPredicate.java
@@ -29,8 +29,7 @@ import java.util.Objects;
  * string regex expression.
  * Such as: like, regexp
  */
-public abstract class StringRegexPredicate<LEFT_CHILD_TYPE extends Expression, RIGHT_CHILD_TYPE extends Expression>
-        extends Expression implements BinaryExpression<LEFT_CHILD_TYPE, RIGHT_CHILD_TYPE> {
+public abstract class StringRegexPredicate extends Expression implements BinaryExpression {
     /**
      * Constructor of StringRegexPredicate.
      *
@@ -38,7 +37,7 @@ public abstract class StringRegexPredicate<LEFT_CHILD_TYPE extends Expression, R
      * @param left     left child of string regex
      * @param right    right child of string regex
      */
-    public StringRegexPredicate(NodeType nodeType, LEFT_CHILD_TYPE left, RIGHT_CHILD_TYPE right) {
+    public StringRegexPredicate(NodeType nodeType, Expression left, Expression right) {
         super(nodeType, left, right);
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/Subtract.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/Subtract.java
@@ -26,9 +26,8 @@ import java.util.List;
 /**
  * Subtract Expression. BinaryExpression.
  */
-public class Subtract<LEFT_CHILD_TYPE extends Expression, RIGHT_CHILD_TYPE extends Expression>
-        extends Arithmetic implements BinaryExpression<LEFT_CHILD_TYPE, RIGHT_CHILD_TYPE> {
-    public Subtract(LEFT_CHILD_TYPE left, RIGHT_CHILD_TYPE right) {
+public class Subtract extends Arithmetic implements BinaryExpression {
+    public Subtract(Expression left, Expression right) {
         super(ArithmeticOperator.SUBTRACT, left, right);
     }
 
@@ -41,7 +40,7 @@ public class Subtract<LEFT_CHILD_TYPE extends Expression, RIGHT_CHILD_TYPE exten
     @Override
     public Expression withChildren(List<Expression> children) {
         Preconditions.checkArgument(children.size() == 2);
-        return new Subtract<>(children.get(0), children.get(1));
+        return new Subtract(children.get(0), children.get(1));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/TernaryExpression.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/TernaryExpression.java
@@ -22,22 +22,18 @@ import org.apache.doris.nereids.trees.TernaryNode;
 /**
  * Interface for all expression that have three children.
  */
-public interface TernaryExpression<
-            FIRST_CHILD_TYPE extends Expression,
-            SECOND_CHILD_TYPE extends Expression,
-            THIRD_CHILD_TYPE extends Expression>
-        extends TernaryNode<Expression, FIRST_CHILD_TYPE, SECOND_CHILD_TYPE, THIRD_CHILD_TYPE> {
+public interface TernaryExpression extends TernaryNode<Expression, Expression, Expression, Expression> {
 
 
-    default FIRST_CHILD_TYPE first() {
-        return (FIRST_CHILD_TYPE) child(0);
+    default Expression first() {
+        return child(0);
     }
 
-    default SECOND_CHILD_TYPE second() {
-        return (SECOND_CHILD_TYPE) child(1);
+    default Expression second() {
+        return child(1);
     }
 
-    default THIRD_CHILD_TYPE third() {
-        return (THIRD_CHILD_TYPE) child(2);
+    default Expression third() {
+        return child(2);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/UnaryExpression.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/UnaryExpression.java
@@ -22,11 +22,10 @@ import org.apache.doris.nereids.trees.UnaryNode;
 /**
  * Abstract class for all expression that have one child.
  */
-public interface UnaryExpression<CHILD_TYPE extends Expression>
-        extends UnaryNode<Expression, CHILD_TYPE> {
+public interface UnaryExpression extends UnaryNode<Expression, Expression> {
 
     @Override
-    default CHILD_TYPE child() {
-        return (CHILD_TYPE) child(0);
+    default Expression child() {
+        return child(0);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/Sum.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/Sum.java
@@ -30,7 +30,7 @@ import com.google.common.base.Preconditions;
 import java.util.List;
 
 /** sum agg function. */
-public class Sum extends AggregateFunction implements UnaryExpression<Expression> {
+public class Sum extends AggregateFunction implements UnaryExpression {
 
     public Sum(Expression child) {
         super("sum", child);

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/util/ExpressionUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/util/ExpressionUtils.java
@@ -103,7 +103,7 @@ public class ExpressionUtils {
         }
 
         Optional<Expression> result =
-                distinctExpressions.stream().reduce((left, right) -> new CompoundPredicate<>(op, left, right));
+                distinctExpressions.stream().reduce((left, right) -> new CompoundPredicate(op, left, right));
         return result.orElse(new Literal(op == NodeType.AND));
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/logical/AggregateDisassembleTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/logical/AggregateDisassembleTest.java
@@ -79,7 +79,7 @@ public class AggregateDisassembleTest implements Plans {
                 rStudent.getOutput().get(2).toSlot());
         List<NamedExpression> outputExpressionList = Lists.newArrayList(
                 rStudent.getOutput().get(2).toSlot(),
-                new Alias<>(new Sum(rStudent.getOutput().get(0).toSlot()), "sum"));
+                new Alias(new Sum(rStudent.getOutput().get(0).toSlot()), "sum"));
         Plan root = plan(new LogicalAggregate(groupExpressionList, outputExpressionList), rStudent);
 
         Memo memo = new Memo();
@@ -145,10 +145,10 @@ public class AggregateDisassembleTest implements Plans {
     @Test
     public void aliasGroupBy() {
         List<Expression> groupExpressionList = Lists.newArrayList(
-                new Add<>(rStudent.getOutput().get(2).toSlot(), new Literal(1)));
+                new Add(rStudent.getOutput().get(2).toSlot(), new Literal(1)));
         List<NamedExpression> outputExpressionList = Lists.newArrayList(
-                new Alias<>(new Add<>(rStudent.getOutput().get(2).toSlot(), new Literal(1)), "key"),
-                new Alias<>(new Sum(rStudent.getOutput().get(0).toSlot()), "sum"));
+                new Alias(new Add(rStudent.getOutput().get(2).toSlot(), new Literal(1)), "key"),
+                new Alias(new Sum(rStudent.getOutput().get(0).toSlot()), "sum"));
         Plan root = plan(new LogicalAggregate(groupExpressionList, outputExpressionList), rStudent);
 
         Memo memo = new Memo();
@@ -171,9 +171,9 @@ public class AggregateDisassembleTest implements Plans {
         Assertions.assertEquals(AggPhase.GLOBAL, global.getAggPhase());
         Assertions.assertEquals(AggPhase.LOCAL, local.getAggPhase());
 
-        Expression localOutput0 = new Add<>(rStudent.getOutput().get(2).toSlot(), new Literal(1));
+        Expression localOutput0 = new Add(rStudent.getOutput().get(2).toSlot(), new Literal(1));
         Expression localOutput1 = new Sum(rStudent.getOutput().get(0).toSlot());
-        Expression localGroupBy = new Add<>(rStudent.getOutput().get(2).toSlot(), new Literal(1));
+        Expression localGroupBy = new Add(rStudent.getOutput().get(2).toSlot(), new Literal(1));
 
         Assertions.assertEquals(2, local.getOutputExpressionList().size());
         Assertions.assertTrue(local.getOutputExpressionList().get(0) instanceof Alias);
@@ -215,7 +215,7 @@ public class AggregateDisassembleTest implements Plans {
     public void globalAggregate() {
         List<Expression> groupExpressionList = Lists.newArrayList();
         List<NamedExpression> outputExpressionList = Lists.newArrayList(
-                new Alias<>(new Sum(rStudent.getOutput().get(0).toSlot()), "sum"));
+                new Alias(new Sum(rStudent.getOutput().get(0).toSlot()), "sum"));
         Plan root = plan(new LogicalAggregate(groupExpressionList, outputExpressionList), rStudent);
 
         Memo memo = new Memo();
@@ -271,7 +271,7 @@ public class AggregateDisassembleTest implements Plans {
         List<Expression> groupExpressionList = Lists.newArrayList(
                 rStudent.getOutput().get(2).toSlot());
         List<NamedExpression> outputExpressionList = Lists.newArrayList(
-                new Alias<>(new Sum(rStudent.getOutput().get(0).toSlot()), "sum"));
+                new Alias(new Sum(rStudent.getOutput().get(0).toSlot()), "sum"));
         Plan root = plan(new LogicalAggregate(groupExpressionList, outputExpressionList), rStudent);
 
         Memo memo = new Memo();

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/logical/PushDownPredicateTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/logical/PushDownPredicateTest.java
@@ -103,13 +103,13 @@ public class PushDownPredicateTest implements Plans {
     public void pushDownPredicateIntoScanTest1() {
         // select id,name,grade from student join score on student.id = score.sid and student.id > 1
         // and score.cid > 2 where student.age > 18 and score.grade > 60
-        Expression onCondition1 = new EqualTo<>(rStudent.getOutput().get(0), rScore.getOutput().get(0));
-        Expression onCondition2 = new GreaterThan<>(rStudent.getOutput().get(0), Literal.of(1));
-        Expression onCondition3 = new GreaterThan<>(rScore.getOutput().get(0), Literal.of(2));
+        Expression onCondition1 = new EqualTo(rStudent.getOutput().get(0), rScore.getOutput().get(0));
+        Expression onCondition2 = new GreaterThan(rStudent.getOutput().get(0), Literal.of(1));
+        Expression onCondition3 = new GreaterThan(rScore.getOutput().get(0), Literal.of(2));
         Expression onCondition = ExpressionUtils.and(onCondition1, onCondition2, onCondition3);
 
-        Expression whereCondition1 = new GreaterThan<>(rStudent.getOutput().get(1), Literal.of(18));
-        Expression whereCondition2 = new GreaterThan<>(rScore.getOutput().get(2), Literal.of(60));
+        Expression whereCondition1 = new GreaterThan(rStudent.getOutput().get(1), Literal.of(18));
+        Expression whereCondition2 = new GreaterThan(rScore.getOutput().get(2), Literal.of(60));
         Expression whereCondition = ExpressionUtils.and(whereCondition1, whereCondition2);
 
 
@@ -157,10 +157,10 @@ public class PushDownPredicateTest implements Plans {
     public void pushDownPredicateIntoScanTest3() {
         //select id,name,grade from student left join score on student.id + 1 = score.sid - 2
         //where student.age > 18 and score.grade > 60
-        Expression whereCondition1 = new EqualTo<>(new Add<>(rStudent.getOutput().get(0), Literal.of(1)),
-                new Subtract<>(rScore.getOutput().get(0), Literal.of(2)));
-        Expression whereCondition2 = new GreaterThan<>(rStudent.getOutput().get(1), Literal.of(18));
-        Expression whereCondition3 = new GreaterThan<>(rScore.getOutput().get(2), Literal.of(60));
+        Expression whereCondition1 = new EqualTo(new Add(rStudent.getOutput().get(0), Literal.of(1)),
+                new Subtract(rScore.getOutput().get(0), Literal.of(2)));
+        Expression whereCondition2 = new GreaterThan(rStudent.getOutput().get(1), Literal.of(18));
+        Expression whereCondition3 = new GreaterThan(rScore.getOutput().get(2), Literal.of(60));
         Expression whereCondition = ExpressionUtils.and(whereCondition1, whereCondition2, whereCondition3);
 
         Plan join = plan(new LogicalJoin(JoinType.INNER_JOIN, Optional.empty()), rStudent, rScore);
@@ -213,18 +213,18 @@ public class PushDownPredicateTest implements Plans {
          */
 
         // student.id = score.sid
-        Expression whereCondition1 = new EqualTo<>(rStudent.getOutput().get(0), rScore.getOutput().get(0));
+        Expression whereCondition1 = new EqualTo(rStudent.getOutput().get(0), rScore.getOutput().get(0));
         // score.cid = course.cid
-        Expression whereCondition2 = new EqualTo<>(rScore.getOutput().get(1), rCourse.getOutput().get(0));
+        Expression whereCondition2 = new EqualTo(rScore.getOutput().get(1), rCourse.getOutput().get(0));
         // student.age between 18 and 20
-        Expression whereCondition3 = new Between<>(rStudent.getOutput().get(2), Literal.of(18), Literal.of(20));
+        Expression whereCondition3 = new Between(rStudent.getOutput().get(2), Literal.of(18), Literal.of(20));
         // student.age >= 18 and student.age <= 20
-        Expression whereCondition3result = new And<>(
-                new GreaterThanEqual<>(rStudent.getOutput().get(2), Literal.of(18)),
-                new LessThanEqual<>(rStudent.getOutput().get(2), Literal.of(20)));
+        Expression whereCondition3result = new And(
+                new GreaterThanEqual(rStudent.getOutput().get(2), Literal.of(18)),
+                new LessThanEqual(rStudent.getOutput().get(2), Literal.of(20)));
 
         // score.grade > 60
-        Expression whereCondition4 = new GreaterThan<>(rScore.getOutput().get(2), Literal.of(60));
+        Expression whereCondition4 = new GreaterThan(rScore.getOutput().get(2), Literal.of(60));
 
         Expression whereCondition = ExpressionUtils.and(whereCondition1, whereCondition2, whereCondition3, whereCondition4);
 


### PR DESCRIPTION
# Proposed changes

Issue Number: no issue

## Problem Summary:

in the past, we use generic type for plan and expression to support pattern match framework, it can support type inference without unsafely type cast. then, we observed that expression usually traverse or rewrite by visitor pattern, so generic type is useless for expression and introduces complexity. so we remove generic type from concrete expressions.
 
## Checklist(Required)

1. Does it affect the original behavior: No
2. Has unit tests been added: No Need
3. Has document been added or modified: No Need
4. Does it need to update dependencies: No
5. Are there any changes that cannot be rolled back: No