### PR TITLE
fix Level1Iterator memory leak

### DIFF
--- a/be/src/vec/olap/vcollect_iterator.cpp
+++ b/be/src/vec/olap/vcollect_iterator.cpp
@@ -260,6 +260,14 @@ VCollectIterator::Level1Iterator::~Level1Iterator() {
             child = nullptr;
         }
     }
+
+    if (_heap) {
+        while (!_heap->empty()) {
+            auto child = _heap->top();
+            _heap->pop();
+            if (child) delete child;
+        }
+    }
 }
 
 // Read next row into *row.


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

Describe the overview of changes.

VCollectIterator::Level1Iterator::~Level1Iterator() does not delete elements in _heap. Just check and delete like ~VMergeIterator().

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
