### PR TITLE
[enhance]: remove the resolvedTupleExprs.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/SortInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/SortInfo.java
@@ -291,6 +291,9 @@ public class SortInfo {
                 Expr.treesToThrift(orderingExprs),
                 isAscOrder,
                 nullsFirstParams);
+        if (sortTupleSlotExprs != null) {
+            sortInfo.setSortTupleSlotExprs(Expr.treesToThrift(sortTupleSlotExprs));
+        }
         return sortInfo;
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/planner/PlannerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/planner/PlannerTest.java
@@ -382,11 +382,7 @@ public class PlannerTest extends TestWithFeService {
         Assert.assertTrue(node.getChildren().size() > 0);
         Assert.assertTrue(node instanceof SortNode);
         SortNode sortNode = (SortNode) node;
-        List<Expr> tupleExprs = sortNode.resolvedTupleExprs;
         List<Expr> sortTupleExprs = sortNode.getSortInfo().getSortTupleSlotExprs();
-        for (Expr expr : tupleExprs) {
-            expr.isBoundByTupleIds(sortNode.getChild(0).tupleIds);
-        }
         for (Expr expr : sortTupleExprs) {
             expr.isBoundByTupleIds(sortNode.getChild(0).tupleIds);
         }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

`resolvedTupleExprs` is so confusing and redundant.

So, I try to remove it.

## Checklist(Required)

1. Does it affect the original behavior: (No)
2. Has unit tests been added: (No Need)
3. Has document been added or modified: (No Need)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
