### PR TITLE
[Bug][Memtable] fix core dump on int128 because not aligned by 16 byte

### DIFF
--- a/be/src/olap/memtable.cpp
+++ b/be/src/olap/memtable.cpp
@@ -101,14 +101,19 @@ void MemTable::_init_agg_functions(const vectorized::Block* block) {
     }
 
     for (uint32_t cid = _schema->num_key_columns(); cid < _schema->num_columns(); ++cid) {
-        size_t alignment_of_state = _agg_functions[cid]->align_of_data();
-        size_t module = _total_size_of_aggregate_states % alignment_of_state;
-        if (module) {
-            _total_size_of_aggregate_states += alignment_of_state - module;
-        }
-
         _offsets_of_aggregate_states[cid] = _total_size_of_aggregate_states;
         _total_size_of_aggregate_states += _agg_functions[cid]->size_of_data();
+
+        // If not the last aggregate_state, we need pad it so that next aggregate_state will be aligned.
+        if (cid + 1 < _agg_functions.size()) {
+            size_t alignment_of_next_state = _agg_functions[cid + 1]->align_of_data();
+
+            /// Extend total_size to next alignment requirement
+            /// Add padding by rounding up 'total_size_of_aggregate_states' to be a multiplier of alignment_of_next_state.
+            _total_size_of_aggregate_states =
+                    (_total_size_of_aggregate_states + alignment_of_next_state - 1) /
+                    alignment_of_next_state * alignment_of_next_state;
+        }
     }
 }
 

--- a/be/src/olap/memtable.h
+++ b/be/src/olap/memtable.h
@@ -91,7 +91,7 @@ private:
             _agg_state_offset = agg_state_offset;
         }
 
-        char* agg_places(size_t offset) { return _agg_mem + _agg_state_offset[offset]; }
+        char* agg_places(size_t offset) const { return _agg_mem + _agg_state_offset[offset]; }
     };
 
     class RowInBlockComparator {

--- a/be/src/runtime/mem_pool.h
+++ b/be/src/runtime/mem_pool.h
@@ -104,7 +104,15 @@ public:
     /// of the current chunk. Creates a new chunk if there aren't any chunks
     /// with enough capacity.
     uint8_t* allocate(int64_t size, Status* rst = nullptr) {
+        // TODO: rethink if DEFAULT_ALIGNMENT should be 82, malloc is aligned by 16.
         return allocate<false>(size, DEFAULT_ALIGNMENT, rst);
+    }
+
+    uint8_t* allocate_aligned(int64_t size, int alignment, Status* rst = nullptr) {
+        DCHECK_GE(alignment, 1);
+        DCHECK_LE(alignment, config::memory_max_alignment);
+        DCHECK_EQ(BitUtil::RoundUpToPowerOfTwo(alignment), alignment);
+        return allocate<false>(size, alignment, rst);
     }
 
     /// Same as Allocate() expect add a check when return a nullptr

--- a/be/src/runtime/mem_pool.h
+++ b/be/src/runtime/mem_pool.h
@@ -104,7 +104,7 @@ public:
     /// of the current chunk. Creates a new chunk if there aren't any chunks
     /// with enough capacity.
     uint8_t* allocate(int64_t size, Status* rst = nullptr) {
-        // TODO: rethink if DEFAULT_ALIGNMENT should be 82, malloc is aligned by 16.
+        // TODO: rethink if DEFAULT_ALIGNMENT should be changed, malloc is aligned by 16.
         return allocate<false>(size, DEFAULT_ALIGNMENT, rst);
     }
 


### PR DESCRIPTION
# Proposed changes

Issue Number: close #10766
only core dump on clang
## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
