### PR TITLE
[fix] fix to_string use memory after free

### DIFF
--- a/be/src/vec/data_types/data_type_nullable.cpp
+++ b/be/src/vec/data_types/data_type_nullable.cpp
@@ -43,8 +43,8 @@ bool DataTypeNullable::only_null() const {
 }
 
 std::string DataTypeNullable::to_string(const IColumn& column, size_t row_num) const {
-    const ColumnNullable& col =
-            assert_cast<const ColumnNullable&>(*column.convert_to_full_column_if_const().get());
+    auto ptr = column.convert_to_full_column_if_const();
+    const ColumnNullable& col = assert_cast<const ColumnNullable&>(*ptr.get());
 
     if (col.is_null_at(row_num)) {
         return "NULL";
@@ -55,8 +55,8 @@ std::string DataTypeNullable::to_string(const IColumn& column, size_t row_num) c
 
 void DataTypeNullable::to_string(const IColumn& column, size_t row_num,
                                  BufferWritable& ostr) const {
-    const ColumnNullable& col =
-            assert_cast<const ColumnNullable&>(*column.convert_to_full_column_if_const().get());
+    auto ptr = column.convert_to_full_column_if_const();
+    const ColumnNullable& col = assert_cast<const ColumnNullable&>(*ptr.get());
 
     if (col.is_null_at(row_num)) {
         ostr.write("NULL", 4);

--- a/be/src/vec/data_types/data_type_string.cpp
+++ b/be/src/vec/data_types/data_type_string.cpp
@@ -52,17 +52,15 @@ static inline void read(IColumn& column, Reader&& reader) {
 }
 
 std::string DataTypeString::to_string(const IColumn& column, size_t row_num) const {
-    const StringRef& s =
-            assert_cast<const ColumnString&>(*column.convert_to_full_column_if_const().get())
-                    .get_data_at(row_num);
+    auto ptr = column.convert_to_full_column_if_const();
+    const StringRef& s = assert_cast<const ColumnString&>(*ptr.get()).get_data_at(row_num);
     return s.to_string();
 }
 
 void DataTypeString::to_string(const class doris::vectorized::IColumn& column, size_t row_num,
                                class doris::vectorized::BufferWritable& ostr) const {
-    const StringRef& s =
-            assert_cast<const ColumnString&>(*column.convert_to_full_column_if_const().get())
-                    .get_data_at(row_num);
+    auto ptr = column.convert_to_full_column_if_const();
+    const StringRef& s = assert_cast<const ColumnString&>(*ptr.get()).get_data_at(row_num);
     ostr.write(s.data, s.size);
 }
 


### PR DESCRIPTION
# Proposed changes

Issue Number: close #10638

## Problem Summary:

After search all `convert_to_full_column_if_const` call, I find DataTypeNullable and DataTypeString have the same problem.

If we want to use column returned by `convert_to_full_column_if_const`, we need to keep at least one refcount to avoid the column be released.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
3. Has unit tests been added: (Yes/No/No Need)
4. Has document been added or modified: (Yes/No/No Need)
5. Does it need to update dependencies: (Yes/No)
6. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
