### PR TITLE
[enhancement] using zone index to skip range predicate

### DIFF
--- a/be/src/olap/collect_iterator.cpp
+++ b/be/src/olap/collect_iterator.cpp
@@ -223,7 +223,7 @@ Status CollectIterator::Level0Iterator::_refresh_current_row_v1() {
         if (_row_block != nullptr && _row_block->has_remaining()) {
             size_t pos = _row_block->pos();
             _row_block->get_row(pos, &_row_cursor);
-            if (_row_block->block_status() == DEL_PARTIAL_SATISFIED &&
+            if (_row_block->block_status() == COND_PARTIAL_SATISFIED &&
                 _reader->_delete_handler.is_filter_data(version(), _row_cursor)) {
                 _reader->_stats.rows_del_filtered++;
                 _row_block->pos_inc();

--- a/be/src/olap/column_block.h
+++ b/be/src/olap/column_block.h
@@ -53,9 +53,9 @@ public:
 
     ColumnBlockCell cell(size_t idx) const;
 
-    void set_delete_state(DelCondSatisfied delete_state) { _batch->set_delete_state(delete_state); }
+    void set_delete_state(CondSatisfied delete_state) { _batch->set_delete_state(delete_state); }
 
-    DelCondSatisfied delete_state() const { return _batch->delete_state(); }
+    CondSatisfied delete_state() const { return _batch->delete_state(); }
 
 private:
     ColumnVectorBatch* _batch;

--- a/be/src/olap/column_predicate.h
+++ b/be/src/olap/column_predicate.h
@@ -98,9 +98,12 @@ public:
     }
     uint32_t column_id() const { return _column_id; }
 
+    void set_satisfy_state(int sat) { _satisfy_state = sat; }
+
 protected:
     uint32_t _column_id;
     bool _opposite;
+    int _satisfy_state = COND_PARTIAL_SATISFIED;
 };
 
 } //namespace doris

--- a/be/src/olap/column_vector.h
+++ b/be/src/olap/column_vector.h
@@ -57,7 +57,7 @@ public:
     explicit ColumnVectorBatch(const TypeInfo* type_info, bool is_nullable)
             : _type_info(type_info),
               _capacity(0),
-              _delete_state(DEL_NOT_SATISFIED),
+              _delete_state(COND_NOT_SATISFIED),
               _nullable(is_nullable),
               _null_signs(0) {}
 
@@ -85,9 +85,9 @@ public:
 
     const bool* null_signs() const { return _null_signs.data(); }
 
-    void set_delete_state(DelCondSatisfied delete_state) { _delete_state = delete_state; }
+    void set_delete_state(CondSatisfied delete_state) { _delete_state = delete_state; }
 
-    DelCondSatisfied delete_state() const { return _delete_state; }
+    CondSatisfied delete_state() const { return _delete_state; }
 
     /**
      * Change the number of slots to at least the given capacity.
@@ -111,7 +111,7 @@ public:
 private:
     const TypeInfo* _type_info;
     size_t _capacity;
-    DelCondSatisfied _delete_state;
+    CondSatisfied _delete_state;
     const bool _nullable;
     DataBuffer<bool> _null_signs;
 };

--- a/be/src/olap/comparison_predicate.h
+++ b/be/src/olap/comparison_predicate.h
@@ -137,13 +137,17 @@ public:
     uint16_t evaluate(const vectorized::IColumn& column, uint16_t* sel,
                       uint16_t size) const override {
         //evaluate by zone_map min/max
-        if (_satisfy_state == COND_SATISFIED){
-            if (_opposite) return 0;
-            else return size;
-        } 
-        if (_satisfy_state == COND_NOT_SATISFIED){
-            if (_opposite) return size;
-            else return 0;
+        if (_satisfy_state == COND_SATISFIED) {
+            if (_opposite)
+                return 0;
+            else
+                return size;
+        }
+        if (_satisfy_state == COND_NOT_SATISFIED) {
+            if (_opposite)
+                return size;
+            else
+                return 0;
         }
 
         if (column.is_nullable()) {
@@ -239,14 +243,18 @@ public:
     void evaluate_vec(const vectorized::IColumn& column, uint16_t size,
                       bool* flags) const override {
         //evaluate by zone_map min/max
-        if (_satisfy_state == COND_SATISFIED){
-            if (_opposite) memset(flags, 0, size);
-            else memset(flags, 1, size);
+        if (_satisfy_state == COND_SATISFIED) {
+            if (_opposite)
+                memset(flags, 0, size);
+            else
+                memset(flags, 1, size);
             return;
-        } 
-        if (_satisfy_state == COND_NOT_SATISFIED){
-            if (_opposite) memset(flags, 1, size);
-            else memset(flags, 0, size);
+        }
+        if (_satisfy_state == COND_NOT_SATISFIED) {
+            if (_opposite)
+                memset(flags, 1, size);
+            else
+                memset(flags, 0, size);
             return;
         }
         _evaluate_vec_internal<false>(column, size, flags);
@@ -255,11 +263,11 @@ public:
     void evaluate_and_vec(const vectorized::IColumn& column, uint16_t size,
                           bool* flags) const override {
         //evaluated by zone_map min/max
-        if (_satisfy_state == COND_SATISFIED){
+        if (_satisfy_state == COND_SATISFIED) {
             if (_opposite) memset(flags, 0, size);
             return;
-        } 
-        if (_satisfy_state == COND_NOT_SATISFIED){
+        }
+        if (_satisfy_state == COND_NOT_SATISFIED) {
             if (!_opposite) memset(flags, 0, size);
             return;
         }

--- a/be/src/olap/generic_iterators.cpp
+++ b/be/src/olap/generic_iterators.cpp
@@ -94,7 +94,7 @@ Status AutoIncrementIterator::next_batch(RowBlockV2* block) {
     }
     block->set_num_rows(row_idx);
     block->set_selected_size(row_idx);
-    block->set_delete_state(DEL_PARTIAL_SATISFIED);
+    block->set_delete_state(COND_PARTIAL_SATISFIED);
     if (row_idx > 0) {
         return Status::OK();
     }

--- a/be/src/olap/olap_common.h
+++ b/be/src/olap/olap_common.h
@@ -109,10 +109,10 @@ enum RangeCondition {
     LE = 3, // less or equal
 };
 
-enum DelCondSatisfied {
-    DEL_SATISFIED = 0,         //satisfy delete condition
-    DEL_NOT_SATISFIED = 1,     //not satisfy delete condition
-    DEL_PARTIAL_SATISFIED = 2, //partially satisfy delete condition
+enum CondSatisfied {
+    COND_SATISFIED = 0,         //satisfy condition
+    COND_NOT_SATISFIED = 1,     //not satisfy condition
+    COND_PARTIAL_SATISFIED = 2, //partially satisfy condition
 };
 // Define all data types supported by Field.
 // If new filed_type is defined, not only new TypeInfo may need be defined,

--- a/be/src/olap/olap_cond.cpp
+++ b/be/src/olap/olap_cond.cpp
@@ -499,7 +499,8 @@ CondColumn::~CondColumn() {
 }
 
 // PRECONDITION 1. index is valid; 2. at least has one operand
-Status CondColumn::add_cond(const TCondition& tcond, const TabletColumn& column, ColumnPredicate* predicate) {
+Status CondColumn::add_cond(const TCondition& tcond, const TabletColumn& column,
+                            ColumnPredicate* predicate) {
     std::unique_ptr<Cond> cond(new Cond());
     auto res = cond->init(tcond, column, predicate);
     if (!res.ok()) {

--- a/be/src/olap/olap_cond.h
+++ b/be/src/olap/olap_cond.h
@@ -76,7 +76,7 @@ public:
     bool eval(const KeyRange& statistic) const;
 
     // 通过单列上的单个删除条件对version进行过滤
-    int del_eval(const KeyRange& stat) const;
+    int cond_eval(const KeyRange& stat) const;
 
     // 通过单列上BloomFilter对block进行过滤
     bool eval(const BloomFilter& bf) const;
@@ -118,7 +118,7 @@ public:
     bool eval(const std::pair<WrapperField*, WrapperField*>& statistic) const;
 
     // Whether the rowset satisfied delete condition
-    int del_eval(const std::pair<WrapperField*, WrapperField*>& statistic) const;
+    int cond_eval(const std::pair<WrapperField*, WrapperField*>& statistic) const;
 
     // 通过一列上的所有BloomFilter索引信息对block进行过滤
     // Return true if the block should be filtered out

--- a/be/src/olap/olap_cond.h
+++ b/be/src/olap/olap_cond.h
@@ -26,11 +26,11 @@
 #include "gen_cpp/PaloInternalService_types.h"
 #include "gen_cpp/column_data_file.pb.h"
 #include "olap/bloom_filter.hpp"
+#include "olap/column_predicate.h"
 #include "olap/field.h"
 #include "olap/row_cursor.h"
 #include "olap/rowset/segment_v2/bloom_filter.h"
 #include "olap/stream_index_common.h"
-#include "olap/column_predicate.h"
 namespace doris {
 
 class WrapperField;
@@ -61,15 +61,14 @@ struct FieldEqual {
     }
 };
 
-
-
 // 条件二元组，描述了一个条件的操作类型和操作数(1个或者多个)
 struct Cond {
 public:
     Cond() = default;
     ~Cond();
 
-    Status init(const TCondition& tcond, const TabletColumn& column, ColumnPredicate* predicate=nullptr);
+    Status init(const TCondition& tcond, const TabletColumn& column,
+                ColumnPredicate* predicate = nullptr);
 
     // 用一行数据的指定列同条件进行比较，如果符合过滤条件，
     // 即按照此条件，行应被过滤掉，则返回true，否则返回false
@@ -108,7 +107,8 @@ public:
     }
     ~CondColumn();
 
-    Status add_cond(const TCondition& tcond, const TabletColumn& column, ColumnPredicate* predicate=nullptr);
+    Status add_cond(const TCondition& tcond, const TabletColumn& column,
+                    ColumnPredicate* predicate = nullptr);
 
     // 对一行数据中的指定列，用所有过滤条件进行比较，如果所有条件都满足，则过滤此行
     // Return true means this row should be filtered out, otherwise return false

--- a/be/src/olap/reader.cpp
+++ b/be/src/olap/reader.cpp
@@ -450,10 +450,10 @@ void TabletReader::_init_conditions_param(const ReaderParams& read_params) {
                 _value_col_predicates.push_back(predicate);
             } else {
                 _col_predicates.push_back(predicate);
-                Status status = _conditions.append_condition(condition);
+                Status status = _conditions.append_condition(condition, predicate);
                 DCHECK_EQ(Status::OK(), status);
             }
-            Status status = _all_conditions.append_condition(condition);
+            Status status = _all_conditions.append_condition(condition, predicate);
             DCHECK_EQ(Status::OK(), status);
         }
     }

--- a/be/src/olap/row_block.h
+++ b/be/src/olap/row_block.h
@@ -129,7 +129,7 @@ private:
     // Be careful to use this
     size_t _pos = 0;
     size_t _limit = 0;
-    uint8_t _block_status = DEL_PARTIAL_SATISFIED;
+    uint8_t _block_status = COND_PARTIAL_SATISFIED;
 
     std::unique_ptr<MemPool> _mem_pool;
     // 由于内部持有内存资源，所以这里禁止拷贝和赋值

--- a/be/src/olap/row_block2.h
+++ b/be/src/olap/row_block2.h
@@ -66,7 +66,7 @@ public:
         for (int i = 0; i < _selected_size; ++i) {
             _selection_vector[i] = i;
         }
-        _delete_state = DEL_NOT_SATISFIED;
+        _delete_state = COND_NOT_SATISFIED;
     }
 
     // convert RowBlockV2 to RowBlock
@@ -95,12 +95,12 @@ public:
 
     void set_selected_size(uint16_t selected_size) { _selected_size = selected_size; }
 
-    DelCondSatisfied delete_state() const { return _delete_state; }
+    CondSatisfied delete_state() const { return _delete_state; }
 
-    void set_delete_state(DelCondSatisfied delete_state) {
-        // if the set _delete_state is DEL_PARTIAL_SATISFIED,
-        // we can not change _delete_state to DEL_NOT_SATISFIED;
-        if (_delete_state == DEL_PARTIAL_SATISFIED && delete_state != DEL_SATISFIED) {
+    void set_delete_state(CondSatisfied delete_state) {
+        // if the set _delete_state is COND_PARTIAL_SATISFIED,
+        // we can not change _delete_state to COND_NOT_SATISFIED;
+        if (_delete_state == COND_PARTIAL_SATISFIED && delete_state != COND_SATISFIED) {
             return;
         }
         _delete_state = delete_state;
@@ -128,7 +128,7 @@ private:
     uint16_t _selected_size;
 
     // block delete state
-    DelCondSatisfied _delete_state;
+    CondSatisfied _delete_state;
 };
 
 // Stands for a row in RowBlockV2. It is consisted of a RowBlockV2 reference

--- a/be/src/olap/rowset/segment_v2/column_reader.cpp
+++ b/be/src/olap/rowset/segment_v2/column_reader.cpp
@@ -233,7 +233,7 @@ Status ColumnReader::_get_filtered_pages(CondColumn* cond_column, CondColumn* de
         for (auto& cond : cond_column->conds()) {
             if (cond->predicate != nullptr && (cond->op == OP_GT || cond->op == OP_GE ||
                                                cond->op == OP_LT || cond->op == OP_LE)) {
-                int statisfy_state = cond->del_eval({min_value.get(), max_value.get()});
+                int statisfy_state = cond->cond_eval({min_value.get(), max_value.get()});
                 cond->predicate->set_satisfy_state(statisfy_state);
             }
         }
@@ -248,7 +248,7 @@ Status ColumnReader::_get_filtered_pages(CondColumn* cond_column, CondColumn* de
                                           cond_column)) {
                 bool should_read = true;
                 if (delete_condition != nullptr) {
-                    int state = delete_condition->del_eval({min_value.get(), max_value.get()});
+                    int state = delete_condition->cond_eval({min_value.get(), max_value.get()});
                     if (state == COND_SATISFIED) {
                         should_read = false;
                     }

--- a/be/src/olap/rowset/segment_v2/zone_map_index.h
+++ b/be/src/olap/rowset/segment_v2/zone_map_index.h
@@ -132,6 +132,7 @@ public:
     bool has_segment_zone_map() const { return _index_meta->has_segment_zone_map(); }
 
     const ZoneMapPB& segment_zone_map() const { return _index_meta->segment_zone_map(); }
+
 private:
     io::FileSystem* _fs;
     std::string _path;

--- a/be/src/olap/rowset/segment_v2/zone_map_index.h
+++ b/be/src/olap/rowset/segment_v2/zone_map_index.h
@@ -129,6 +129,9 @@ public:
 
     int32_t num_pages() const { return _page_zone_maps.size(); }
 
+    bool has_segment_zone_map() const { return _index_meta->has_segment_zone_map(); }
+
+    const ZoneMapPB& segment_zone_map() const { return _index_meta->segment_zone_map(); }
 private:
     io::FileSystem* _fs;
     std::string _path;

--- a/be/test/olap/row_block_test.cpp
+++ b/be/test/olap/row_block_test.cpp
@@ -303,7 +303,7 @@ TEST_F(TestRowBlock, pos_limit) {
     EXPECT_EQ(0, block.pos());
     EXPECT_EQ(0, block.limit());
     EXPECT_FALSE(block.has_remaining());
-    EXPECT_EQ(DEL_PARTIAL_SATISFIED, block.block_status());
+    EXPECT_EQ(COND_PARTIAL_SATISFIED, block.block_status());
 
     block.set_limit(100);
     EXPECT_EQ(100, block.limit());

--- a/be/test/olap/row_block_test.cpp
+++ b/be/test/olap/row_block_test.cpp
@@ -318,7 +318,7 @@ TEST_F(TestRowBlock, pos_limit) {
     EXPECT_TRUE(block.has_remaining());
     EXPECT_EQ(97, block.remaining());
 
-    block.set_block_status(DEL_SATISFIED);
-    EXPECT_EQ(DEL_SATISFIED, block.block_status());
+    block.set_block_status(COND_SATISFIED);
+    EXPECT_EQ(COND_SATISFIED, block.block_status());
 }
 } // namespace doris

--- a/be/test/olap/rowset/segment_v2/segment_test.cpp
+++ b/be/test/olap/rowset/segment_v2/segment_test.cpp
@@ -182,7 +182,7 @@ TEST_F(SegmentReaderWriterTest, normal) {
                 int rows_read = left > 1024 ? 1024 : left;
                 block.clear();
                 EXPECT_TRUE(iter->next_batch(&block).ok());
-                EXPECT_EQ(DEL_NOT_SATISFIED, block.delete_state());
+                EXPECT_EQ(COND_NOT_SATISFIED, block.delete_state());
                 EXPECT_EQ(rows_read, block.num_rows());
                 left -= rows_read;
 
@@ -231,7 +231,7 @@ TEST_F(SegmentReaderWriterTest, normal) {
 
             RowBlockV2 block(schema, 100);
             EXPECT_TRUE(iter->next_batch(&block).ok());
-            EXPECT_EQ(DEL_NOT_SATISFIED, block.delete_state());
+            EXPECT_EQ(COND_NOT_SATISFIED, block.delete_state());
             EXPECT_EQ(11, block.num_rows());
             auto column_block = block.column_block(0);
             for (int i = 0; i < 11; ++i) {
@@ -492,7 +492,7 @@ TEST_F(SegmentReaderWriterTest, TestIndex) {
                 int rows_read = left > 1024 ? 1024 : left;
                 block.clear();
                 EXPECT_TRUE(iter->next_batch(&block).ok());
-                EXPECT_EQ(DEL_NOT_SATISFIED, block.delete_state());
+                EXPECT_EQ(COND_NOT_SATISFIED, block.delete_state());
                 EXPECT_EQ(rows_read, block.num_rows());
                 left -= rows_read;
 
@@ -554,7 +554,7 @@ TEST_F(SegmentReaderWriterTest, TestIndex) {
                 auto s = iter->next_batch(&block);
                 EXPECT_TRUE(s.ok()) << s.to_string();
                 EXPECT_EQ(rows_read, block.num_rows());
-                EXPECT_EQ(DEL_NOT_SATISFIED, block.delete_state());
+                EXPECT_EQ(COND_NOT_SATISFIED, block.delete_state());
                 left -= rows_read;
 
                 for (int j = 0; j < block.schema()->column_ids().size(); ++j) {
@@ -688,7 +688,7 @@ TEST_F(SegmentReaderWriterTest, TestDefaultValueColumn) {
                 int rows_read = left > 1024 ? 1024 : left;
                 block.clear();
                 EXPECT_TRUE(iter->next_batch(&block).ok());
-                EXPECT_EQ(DEL_NOT_SATISFIED, block.delete_state());
+                EXPECT_EQ(COND_NOT_SATISFIED, block.delete_state());
                 EXPECT_EQ(rows_read, block.num_rows());
                 left -= rows_read;
 
@@ -841,7 +841,7 @@ TEST_F(SegmentReaderWriterTest, TestStringDict) {
                 block.clear();
                 st = iter->next_batch(&block);
                 EXPECT_TRUE(st.ok());
-                EXPECT_EQ(DEL_NOT_SATISFIED, block.delete_state());
+                EXPECT_EQ(COND_NOT_SATISFIED, block.delete_state());
                 EXPECT_EQ(rows_read, block.num_rows());
                 left -= rows_read;
 
@@ -950,7 +950,7 @@ TEST_F(SegmentReaderWriterTest, TestStringDict) {
                 block.clear();
                 st = iter->next_batch(&block);
                 EXPECT_TRUE(st.ok());
-                EXPECT_EQ(DEL_NOT_SATISFIED, block.delete_state());
+                EXPECT_EQ(COND_NOT_SATISFIED, block.delete_state());
                 EXPECT_EQ(rows_read, block.num_rows());
                 left -= rows_read;
 


### PR DESCRIPTION
# Proposed changes
some range predicate could be evaluated by zone_map_index (min/max). This pr aims to skip range predicate at segment level.
on ssb100, 
test sql:
` select count(LO_ORDERDATE) from lineorder where LO_ORDERDATE >=19920101 AND LO_ORDERDATE <=19971231;`
before:
VectorPredEvalTime:  440.584ms

after:
VectorPredEvalTime:  319.41ms

Node: VectorPredEvalTime includes vec predicate evaluate time and time to generate selected rowId index.


Issue Number: close #xxx

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
