### PR TITLE
[enhancement](singal) output git commit id when the program coredump

### DIFF
--- a/be/src/common/signal_handler.h
+++ b/be/src/common/signal_handler.h
@@ -40,7 +40,7 @@
 #include <csignal>
 #include <ctime>
 
-#include "util/debug_util.h"
+#include "gen_cpp/version.h"
 #ifdef HAVE_UCONTEXT_H
 #include <ucontext.h>
 #endif
@@ -256,9 +256,9 @@ void DumpTimeInfo() {
     formatter.AppendString(" try \"date -d @");
     formatter.AppendUint64(static_cast<uint64>(time_in_sec), 10);
     formatter.AppendString("\" if you are using GNU date ***\n");
-    formatter.AppendString("*** Current BE version: ");
-    formatter.AppendString(doris::get_build_version(true).c_str());
-    formatter.AppendString("***\n");
+    formatter.AppendString("*** Current BE git commitID: ");
+    formatter.AppendString(DORIS_BUILD_SHORT_HASH);
+    formatter.AppendString(" ***\n");
     g_failure_writer(buf, formatter.num_bytes_written());
 }
 

--- a/be/src/common/signal_handler.h
+++ b/be/src/common/signal_handler.h
@@ -39,6 +39,8 @@
 #include <boost/stacktrace.hpp>
 #include <csignal>
 #include <ctime>
+
+#include "util/debug_util.h"
 #ifdef HAVE_UCONTEXT_H
 #include <ucontext.h>
 #endif
@@ -254,6 +256,9 @@ void DumpTimeInfo() {
     formatter.AppendString(" try \"date -d @");
     formatter.AppendUint64(static_cast<uint64>(time_in_sec), 10);
     formatter.AppendString("\" if you are using GNU date ***\n");
+    formatter.AppendString("*** Current BE version: ");
+    formatter.AppendString(doris::get_build_version(true).c_str());
+    formatter.AppendString("***\n");
     g_failure_writer(buf, formatter.num_bytes_written());
 }
 


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

output git commit id when the program coredump。
like this:
![image](https://user-images.githubusercontent.com/43782773/178501571-86d43b04-b7dd-4b89-9d77-4b963f97bb39.png)



## Checklist(Required)

1. Does it affect the original behavior: (Yes)
2. Has unit tests been added: (No Need)
3. Has document been added or modified: (No Need)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
