### PR TITLE
[enhancement](singal) output fetal log to stderr

### DIFF
--- a/be/src/common/logconfig.cpp
+++ b/be/src/common/logconfig.cpp
@@ -58,8 +58,9 @@ bool init_glog(const char* basename) {
         FLAGS_alsologtostderr = true;
     }
 
-    // don't log to stderr
-    FLAGS_stderrthreshold = 5;
+    // don't log to stderr except fatal level
+    // so fatal log can output to be.out .
+    FLAGS_stderrthreshold = google::FATAL;
     // set glog log dir
     FLAGS_log_dir = config::sys_log_dir;
     // 0 means buffer INFO only


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

output fetal log to stderr so that we can see the log in `be.out` file when be is started as a daemon.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
