### PR TITLE
[bug](multi-catalog) empty hadoop configuration when reading iceberg table

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/DescribeStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/DescribeStmt.java
@@ -88,8 +88,6 @@ public class DescribeStmt extends ShowStmt {
     private boolean isAllTables;
     private boolean isOlapTable;
 
-    private List<List<String>> hmsSchema = null;
-
     public DescribeStmt(TableName dbTableName, boolean isAllTables) {
         this.dbTableName = dbTableName;
         this.totalRows = new LinkedList<List<String>>();
@@ -236,9 +234,6 @@ public class DescribeStmt extends ShowStmt {
         if (isAllTables) {
             return totalRows;
         } else {
-            if (hmsSchema != null) {
-                return hmsSchema;
-            }
             Preconditions.checkNotNull(node);
             return node.fetchResult().getRows();
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/external/ExternalHiveScanProvider.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/external/ExternalHiveScanProvider.java
@@ -107,13 +107,13 @@ public class ExternalHiveScanProvider implements ExternalFileScanProvider {
         return inputFormat.getSplits(jobConf, 0);
     }
 
-    private Configuration setConfiguration() {
+    protected Configuration setConfiguration() {
         Configuration conf = new Configuration();
         Map<String, String> dfsProperties = hmsTable.getDfsProperties();
         for (Map.Entry<String, String> entry : dfsProperties.entrySet()) {
             conf.set(entry.getKey(), entry.getValue());
         }
-        Map<String, String> s3Properties = hmsTable.getDfsProperties();
+        Map<String, String> s3Properties = hmsTable.getS3Properties();
         for (Map.Entry<String, String> entry : s3Properties.entrySet()) {
             conf.set(entry.getKey(), entry.getValue());
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/external/ExternalIcebergScanProvider.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/external/ExternalIcebergScanProvider.java
@@ -101,7 +101,7 @@ public class ExternalIcebergScanProvider extends ExternalHiveScanProvider {
 
     private org.apache.iceberg.Table getIcebergTable() throws MetaNotFoundException {
         org.apache.iceberg.hive.HiveCatalog hiveCatalog = new org.apache.iceberg.hive.HiveCatalog();
-        Configuration conf = new Configuration();
+        Configuration conf = setConfiguration();
         hiveCatalog.setConf(conf);
         // initialize hive catalog
         Map<String, String> catalogProperties = new HashMap<>();


### PR DESCRIPTION
## Problem Summary:
ExternalIcebergScanProvider creates empty hadoop configuration.
ExternalHiveScanProvider gets wrong s3 properties.
```
MySQL [iceberg_test]> select * from test2 limit 1;
ERROR 1105 (HY000): errCode = 2, detailMessage = Unexpected exception: java.net.UnknownHostException: HDFS8000463
```

## Checklist(Required)

1. Does it affect the original behavior: (No)
2. Has unit tests been added: (No)
3. Has document been added or modified: (No)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
