### PR TITLE
[FIX]VMergeIterator should use nullable info from scanner instead of schema

### DIFF
--- a/be/src/olap/rowset/beta_rowset_reader.cpp
+++ b/be/src/olap/rowset/beta_rowset_reader.cpp
@@ -117,8 +117,11 @@ OLAPStatus BetaRowsetReader::init(RowsetReaderContext* read_context) {
     // merge or union segment iterator
     RowwiseIterator* final_iterator;
     if (config::enable_storage_vectorization && read_context->is_vec) {
-        if (read_context->need_ordered_result && _rowset->rowset_meta()->is_segments_overlapping()) {
-            final_iterator = vectorized::new_merge_iterator(iterators, _parent_tracker, read_context->sequence_id_idx, read_context->is_unique);
+        if (read_context->need_ordered_result &&
+            _rowset->rowset_meta()->is_segments_overlapping()) {
+            final_iterator = vectorized::new_merge_iterator(
+                    iterators, _parent_tracker, read_context->sequence_id_idx,
+                    read_context->is_unique, read_context->tablet_columns_convert_to_null_set);
         } else {
             final_iterator = vectorized::new_union_iterator(iterators, _parent_tracker);
         }

--- a/be/src/olap/rowset/rowset_reader_context.h
+++ b/be/src/olap/rowset/rowset_reader_context.h
@@ -64,6 +64,9 @@ struct RowsetReaderContext {
     int batch_size = 1024;
     bool is_vec = false;
     bool is_unique = false;
+
+    // need pass this info to VMergeIterator
+    std::unordered_set<uint32_t>* tablet_columns_convert_to_null_set = nullptr;
 };
 
 } // namespace doris

--- a/be/src/vec/olap/block_reader.cpp
+++ b/be/src/vec/olap/block_reader.cpp
@@ -52,6 +52,7 @@ OLAPStatus BlockReader::_init_collect_iter(const ReaderParams& read_params,
 
     _reader_context.batch_size = _batch_size;
     _reader_context.is_vec = true;
+    _reader_context.tablet_columns_convert_to_null_set = _tablet_columns_convert_to_null_set;
     for (auto& rs_reader : rs_readers) {
         RETURN_NOT_OK(rs_reader->init(&_reader_context));
         OLAPStatus res = _vcollect_iter.add_child(rs_reader);

--- a/be/src/vec/olap/vgeneric_iterators.h
+++ b/be/src/vec/olap/vgeneric_iterators.h
@@ -27,7 +27,9 @@ namespace vectorized {
 //
 // Inputs iterators' ownership is taken by created merge iterator. And client
 // should delete returned iterator after usage.
-RowwiseIterator* new_merge_iterator(std::vector<RowwiseIterator*>& inputs, std::shared_ptr<MemTracker> parent, int sequence_id_idx, bool is_unique);
+RowwiseIterator* new_merge_iterator(
+        std::vector<RowwiseIterator*>& inputs, std::shared_ptr<MemTracker> parent, int sequence_id_idx, bool is_unique,
+        const std::unordered_set<uint32_t>* tablet_columns_convert_to_null_set = nullptr);
 
 // Create a union iterator for input iterators. Union iterator will read
 // input iterators one by one.


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:
tpch UNIQUE key mode, q13.sql CORE

for outer join temp solution, the olap scanner will set the columns which need to be convert to nullable, this info is lost in VMergeIterator, so pass this info to VMergeIterator in order to create column using right nullable info.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
