### PR TITLE
[bugfix] fix bug of ComparisonPredicate for nullable column

### DIFF
--- a/be/src/olap/comparison_predicate.h
+++ b/be/src/olap/comparison_predicate.h
@@ -406,7 +406,7 @@ private:
         for (uint16_t i = 0; i < size; ++i) {
             uint16_t idx = sel[i];
             if constexpr (is_nullable) {
-                if (_opposite ^ (!null_map[i] && _operator(data_array[idx], value))) {
+                if (_opposite ^ (!null_map[idx] && _operator(data_array[idx], value))) {
                     sel[new_size++] = idx;
                 }
             } else {


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

ComparisonPredicate::_base_loop use wrong index for null_map:
`                if (_opposite ^ (!null_map[i] && _operator(data_array[idx], value))) {
                    sel[new_size++] = idx;
                }`
should use idx.

How to reproduce the bug:

1.  create test table:
```
CREATE TABLE IF NOT EXISTS store_sales_test (
    ss_sold_date_sk bigint,
    ss_sold_time_sk bigint,
    ss_item_sk bigint,
    ss_customer_sk bigint,
    ss_cdemo_sk bigint,
    ss_hdemo_sk bigint,
    ss_addr_sk bigint,
    ss_store_sk bigint,
    ss_promo_sk bigint,
    ss_ticket_number bigint,
    ss_quantity integer,
    ss_wholesale_cost decimal(7,2),
    ss_list_price decimal(7,2),
    ss_sales_price decimal(7,2),
    ss_ext_discount_amt decimal(7,2),
    ss_ext_sales_price decimal(7,2),
    ss_ext_wholesale_cost decimal(7,2),
    ss_ext_list_price decimal(7,2),
    ss_ext_tax decimal(7,2),
    ss_coupon_amt decimal(7,2),
    ss_net_paid decimal(7,2),
    ss_net_paid_inc_tax decimal(7,2),
    ss_net_profit decimal(7,2)
)
DUPLICATE KEY(ss_sold_date_sk, ss_sold_time_sk, ss_item_sk, ss_customer_sk)
DISTRIBUTED BY HASH(ss_customer_sk) BUCKETS 3
PROPERTIES (
  "replication_num" = "1"
);
```

2. insert data:
```
INSERT INTO store_sales_test VALUES
(NULL,NULL,"8228","75780","1717258",NULL,"17414",NULL,"196","176884",NULL,"42.44","55.59","29.46","0","2592.48","3734.72",NULL,"25.92","0","2592.48","2618.4",NULL),
(NULL,NULL,"8229","2732","209963",NULL,NULL,NULL,NULL,"125886",NULL,"9.11",NULL,NULL,NULL,NULL,"501.05",NULL,NULL,NULL,NULL,NULL,NULL),
(NULL,NULL,"8229","58164","1570871","3931",NULL,NULL,"153","77823","5","35.47",NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL),
(NULL,NULL,"8230","40841","1704127",NULL,"3593","2","26","92486","84","3.17","4.08","1.34","0","112.56","266.28",NULL,NULL,"0","112.56",NULL,"-153.72"),
(NULL,NULL,"8230","51540","276182","3224",NULL,"7",NULL,"52815","52",NULL,"112.09",NULL,"0","4312.88","3202.68","5828.68",NULL,"0",NULL,NULL,NULL),
(NULL,NULL,"8233","3672","896823","3127",NULL,NULL,"12","90301",NULL,"60.21","77.67",NULL,NULL,NULL,NULL,"7378.65",NULL,NULL,"7230.45","7519.66",NULL),
(NULL,NULL,"8233","94065",NULL,NULL,NULL,NULL,NULL,"138701","35",NULL,"45.38","23.14","0",NULL,NULL,"1588.3",NULL,"0","809.9",NULL,NULL),
(NULL,NULL,"8234","48388","1103","7065",NULL,NULL,"75","72994","90","26.41",NULL,"31.05","0",NULL,NULL,NULL,NULL,"0","2794.5","3046","417.6"),
(NULL,NULL,"8234","79284",NULL,"3049","43555","2","110","196280","54","89.15",NULL,NULL,NULL,NULL,NULL,NULL,"6.02",NULL,NULL,"72.98","-4747.14"),
(NULL,NULL,"8236","91995",NULL,"3863",NULL,"4",NULL,"61797","65","99.87",NULL,"5.23",NULL,NULL,"6491.55","8503.3",NULL,NULL,"339.95","350.14",NULL);
```

3.  query
```
MySQL [regression_test_tpcds_sf1]> set enable_vectorized_engine = false;
Query OK, 0 rows affected (0.00 sec)

MySQL [regression_test_tpcds_sf1]> select * from store_sales_test where ss_net_paid > 0 and ss_quantity > 0; +-----------------+-----------------+------------+----------------+-------------+-------------+------------+-------------+-------------+------------------+-------------+-------------------+---------------+----------------+---------------------+--------------------+-----------------------+-------------------+------------+---------------+-------------+---------------------+---------------+
| ss_sold_date_sk | ss_sold_time_sk | ss_item_sk | ss_customer_sk | ss_cdemo_sk | ss_hdemo_sk | ss_addr_sk | ss_store_sk | ss_promo_sk | ss_ticket_number | ss_quantity | ss_wholesale_cost | ss_list_price | ss_sales_price | ss_ext_discount_amt | ss_ext_sales_price | ss_ext_wholesale_cost | ss_ext_list_price | ss_ext_tax | ss_coupon_amt | ss_net_paid | ss_net_paid_inc_tax | ss_net_profit |
+-----------------+-----------------+------------+----------------+-------------+-------------+------------+-------------+-------------+------------------+-------------+-------------------+---------------+----------------+---------------------+--------------------+-----------------------+-------------------+------------+---------------+-------------+---------------------+---------------+
|            NULL |            NULL |       8230 |          40841 |     1704127 |        NULL |       3593 |           2 |          26 |            92486 |          84 |              3.17 |          4.08 |           1.34 |                   0 |             112.56 |                266.28 |              NULL |       NULL |             0 |      112.56 |                NULL |       -153.72 |
|            NULL |            NULL |       8233 |          94065 |        NULL |        NULL |       NULL |        NULL |        NULL |           138701 |          35 |              NULL |         45.38 |          23.14 |                   0 |               NULL |                  NULL |            1588.3 |       NULL |             0 |       809.9 |                NULL |          NULL |
|            NULL |            NULL |       8234 |          48388 |        1103 |        7065 |       NULL |        NULL |          75 |            72994 |          90 |             26.41 |          NULL |          31.05 |                   0 |               NULL |                  NULL |              NULL |       NULL |             0 |      2794.5 |                3046 |         417.6 |
|            NULL |            NULL |       8236 |          91995 |        NULL |        3863 |       NULL |           4 |        NULL |            61797 |          65 |             99.87 |          NULL |           5.23 |                NULL |               NULL |               6491.55 |            8503.3 |       NULL |          NULL |      339.95 |              350.14 |          NULL |
+-----------------+-----------------+------------+----------------+-------------+-------------+------------+-------------+-------------+------------------+-------------+-------------------+---------------+----------------+---------------------+--------------------+-----------------------+-------------------+------------+---------------+-------------+---------------------+---------------+
4 rows in set (0.01 sec)

MySQL [regression_test_tpcds_sf1]> set enable_vectorized_engine = true;
Query OK, 0 rows affected (0.00 sec)

MySQL [regression_test_tpcds_sf1]> select * from store_sales_test where ss_net_paid > 0 and ss_quantity > 0; +-----------------+-----------------+------------+----------------+-------------+-------------+------------+-------------+-------------+------------------+-------------+-------------------+---------------+----------------+---------------------+--------------------+-----------------------+-------------------+------------+---------------+-------------+---------------------+---------------+
| ss_sold_date_sk | ss_sold_time_sk | ss_item_sk | ss_customer_sk | ss_cdemo_sk | ss_hdemo_sk | ss_addr_sk | ss_store_sk | ss_promo_sk | ss_ticket_number | ss_quantity | ss_wholesale_cost | ss_list_price | ss_sales_price | ss_ext_discount_amt | ss_ext_sales_price | ss_ext_wholesale_cost | ss_ext_list_price | ss_ext_tax | ss_coupon_amt | ss_net_paid | ss_net_paid_inc_tax | ss_net_profit |
+-----------------+-----------------+------------+----------------+-------------+-------------+------------+-------------+-------------+------------------+-------------+-------------------+---------------+----------------+---------------------+--------------------+-----------------------+-------------------+------------+---------------+-------------+---------------------+---------------+
|            NULL |            NULL |       8233 |          94065 |        NULL |        NULL |       NULL |        NULL |        NULL |           138701 |          35 |              NULL |         45.38 |          23.14 |                   0 |               NULL |                  NULL |            1588.3 |       NULL |             0 |       809.9 |                NULL |          NULL |
|            NULL |            NULL |       8236 |          91995 |        NULL |        3863 |       NULL |           4 |        NULL |            61797 |          65 |             99.87 |          NULL |           5.23 |                NULL |               NULL |               6491.55 |            8503.3 |       NULL |          NULL |      339.95 |              350.14 |          NULL |
+-----------------+-----------------+------------+----------------+-------------+-------------+------------+-------------+-------------+------------------+-------------+-------------------+---------------+----------------+---------------------+--------------------+-----------------------+-------------------+------------+---------------+-------------+---------------------+---------------+
```
result is wrong when `enable_vectorized_engine = true;`

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
5. Has unit tests been added: (Yes/No/No Need)
6. Has document been added or modified: (Yes/No/No Need)
7. Does it need to update dependencies: (Yes/No)
8. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
