### PR TITLE
[improvement]Speed up pre-serialization of aggregation keys by using strings::memcpy_inlined

### DIFF
--- a/be/src/vec/columns/column_decimal.cpp
+++ b/be/src/vec/columns/column_decimal.cpp
@@ -20,6 +20,7 @@
 
 #include "vec/columns/column_decimal.h"
 
+#include "gutil/strings/fastmem.h"
 #include "util/simd/bits.h"
 #include "vec/common/arena.h"
 #include "vec/common/assert_cast.h"
@@ -67,7 +68,8 @@ template <typename T>
 void ColumnDecimal<T>::serialize_vec(std::vector<StringRef>& keys, size_t num_rows,
                                      size_t max_row_byte_size) const {
     for (size_t i = 0; i < num_rows; ++i) {
-        memcpy(const_cast<char*>(keys[i].data + keys[i].size), &data[i], sizeof(T));
+        strings::memcpy_inlined(const_cast<char*>(keys[i].data + keys[i].size), &data[i],
+                                sizeof(T));
         keys[i].size += sizeof(T);
     }
 }
@@ -78,7 +80,8 @@ void ColumnDecimal<T>::serialize_vec_with_null_map(std::vector<StringRef>& keys,
                                                    size_t max_row_byte_size) const {
     for (size_t i = 0; i < num_rows; ++i) {
         if (null_map[i] == 0) {
-            memcpy(const_cast<char*>(keys[i].data + keys[i].size), &data[i], sizeof(T));
+            strings::memcpy_inlined(const_cast<char*>(keys[i].data + keys[i].size), &data[i],
+                                    sizeof(T));
             keys[i].size += sizeof(T);
         }
     }

--- a/be/src/vec/columns/column_string.cpp
+++ b/be/src/vec/columns/column_string.cpp
@@ -20,6 +20,7 @@
 
 #include "vec/columns/column_string.h"
 
+#include "gutil/strings/fastmem.h"
 #include "vec/columns/columns_common.h"
 #include "vec/common/arena.h"
 #include "vec/common/assert_cast.h"
@@ -206,7 +207,7 @@ void ColumnString::serialize_vec(std::vector<StringRef>& keys, size_t num_rows,
         size_t string_size = size_at(i);
 
         auto* ptr = const_cast<char*>(keys[i].data + keys[i].size);
-        memcpy(ptr, &string_size, sizeof(string_size));
+        strings::memcpy_inlined(ptr, &string_size, sizeof(string_size));
         memcpy(ptr + sizeof(string_size), &chars[offset], string_size);
         keys[i].size += sizeof(string_size) + string_size;
     }
@@ -221,7 +222,7 @@ void ColumnString::serialize_vec_with_null_map(std::vector<StringRef>& keys, siz
             size_t string_size = size_at(i);
 
             auto* ptr = const_cast<char*>(keys[i].data + keys[i].size);
-            memcpy(ptr, &string_size, sizeof(string_size));
+            strings::memcpy_inlined(ptr, &string_size, sizeof(string_size));
             memcpy(ptr + sizeof(string_size), &chars[offset], string_size);
             keys[i].size += sizeof(string_size) + string_size;
         }

--- a/be/src/vec/columns/column_vector.cpp
+++ b/be/src/vec/columns/column_vector.cpp
@@ -26,6 +26,7 @@
 #include <cmath>
 #include <cstring>
 
+#include "gutil/strings/fastmem.h"
 #include "runtime/datetime_value.h"
 #include "util/simd/bits.h"
 #include "vec/common/arena.h"
@@ -61,7 +62,8 @@ template <typename T>
 void ColumnVector<T>::serialize_vec(std::vector<StringRef>& keys, size_t num_rows,
                                     size_t max_row_byte_size) const {
     for (size_t i = 0; i < num_rows; ++i) {
-        memcpy(const_cast<char*>(keys[i].data + keys[i].size), &data[i], sizeof(T));
+        strings::memcpy_inlined(const_cast<char*>(keys[i].data + keys[i].size), &data[i],
+                                sizeof(T));
         keys[i].size += sizeof(T);
     }
 }
@@ -72,7 +74,8 @@ void ColumnVector<T>::serialize_vec_with_null_map(std::vector<StringRef>& keys, 
                                                   size_t max_row_byte_size) const {
     for (size_t i = 0; i < num_rows; ++i) {
         if (null_map[i] == 0) {
-            memcpy(const_cast<char*>(keys[i].data + keys[i].size), &data[i], sizeof(T));
+            strings::memcpy_inlined(const_cast<char*>(keys[i].data + keys[i].size), &data[i],
+                                    sizeof(T));
             keys[i].size += sizeof(T);
         }
     }


### PR DESCRIPTION

# Proposed changes

Issue Number: close #xxx

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
