### PR TITLE
[fix] regression test fix for array

### DIFF
--- a/be/src/olap/rowset/segment_v2/column_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/column_writer.cpp
@@ -585,7 +585,9 @@ Status ArrayColumnWriter::append_data(const uint8_t** ptr, size_t num_rows) {
         }
         remaining -= num_written;
         col_cursor += num_written;
+        *ptr += num_written * sizeof(CollectionValue);
     }
+
     if (is_nullable()) {
         return write_null_column(num_rows, false);
     }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:
Some times regression test failed with BE crashed, the output log is like:

```
*** Aborted at 1657701407 (unix time) try "date -d @1657701407" if you are using GNU date ***
*** Current BE git commitID: bd982ac81 ***
*** SIGSEGV unkown detail explain (@0x0) received by PID 88829 (TID 0x7fb44e91d700) from PID 0; stack trace: ***
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /home/disk1/zhuxiaoli01/doris/baidu/bdg/doris/core/be/src/common/signal_handler.h:412
 1# 0x00007FB4D5577570 in /lib64/libc.so.6
 2# doris::CollectionValue::is_null_at(unsigned long) const at /home/disk1/zhuxiaoli01/doris/baidu/bdg/doris/core/be/src/runtime/collection_value.h:79
 3# doris::segment_v2::ArrayColumnWriter::append_data(unsigned char const**, unsigned long) at /home/disk1/zhuxiaoli01/doris/baidu/bdg/doris/core/be/src/olap/rowset/segment_v2/column_writer.cpp:576
 4# doris::segment_v2::ColumnWriter::append_nullable(unsigned char const*, unsigned char const**, unsigned long) at /home/disk1/zhuxiaoli01/doris/baidu/bdg/doris/core/be/src/olap/rowset/segment_v2/column_writer.cpp:219
 5# doris::segment_v2::ColumnWriter::append(unsigned char const*, void const*, unsigned long) at /home/disk1/zhuxiaoli01/doris/baidu/bdg/doris/core/be/src/olap/rowset/segment_v2/column_writer.cpp:231
 6# doris::segment_v2::SegmentWriter::append_block(doris::vectorized::Block const*, unsigned long, unsigned long) at /home/disk1/zhuxiaoli01/doris/baidu/bdg/doris/core/be/src/olap/rowset/segment_v2/segment_writer.cpp:146
 7# doris::BetaRowsetWriter::_add_block(doris::vectorized::Block const*, std::unique_ptr<doris::segment_v2::SegmentWriter, std::default_delete<doris::segment_v2::SegmentWriter> >*) at /home/disk1/zhuxiaoli01/doris/baidu/bdg/doris/core/be/src/olap/rowset/beta_rowset_writer.cpp:125
 8# doris::BetaRowsetWriter::add_block(doris::vectorized::Block const*) at /home/disk1/zhuxiaoli01/doris/baidu/bdg/doris/core/be/src/olap/rowset/beta_rowset_writer.cpp:103
 9# doris::Merger::vmerge_rowsets(std::shared_ptr<doris::Tablet>, doris::ReaderType, doris::TabletSchema const*, std::vector<std::shared_ptr<doris::RowsetReader>, std::allocator<std::shared_ptr<doris::RowsetReader> > > const&, doris::RowsetWriter*, doris::Merger::Statistics*) at /home/disk1/zhuxiaoli01/doris/baidu/bdg/doris/core/be/src/olap/merger.cpp:121
10# doris::Compaction::do_compaction_impl(long) at /home/disk1/zhuxiaoli01/doris/baidu/bdg/doris/core/be/src/olap/compaction.cpp:160
11# doris::Compaction::do_compaction(long) at /home/disk1/zhuxiaoli01/doris/baidu/bdg/doris/core/be/src/olap/compaction.cpp:117
12# doris::CumulativeCompaction::execute_compact_impl() at /home/disk1/zhuxiaoli01/doris/baidu/bdg/doris/core/be/src/olap/cumulative_compaction.cpp:75
13# doris::Compaction::execute_compact() at /home/disk1/zhuxiaoli01/doris/baidu/bdg/doris/core/be/src/olap/compaction.cpp:55
14# doris::Tablet::execute_compaction(doris::CompactionType) at /home/disk1/zhuxiaoli01/doris/baidu/bdg/doris/core/be/src/olap/tablet.cpp:1512
15# doris::StorageEngine::_submit_compaction_task(std::shared_ptr<doris::Tablet>, doris::CompactionType)::{lambda()#1}::operator()() const at /home/disk1/zhuxiaoli01/doris/baidu/bdg/doris/core/be/src/olap/olap_server.cpp:613
16# void std::__invoke_impl<void, doris::StorageEngine::_submit_compaction_task(std::shared_ptr<doris::Tablet>, doris::CompactionType)::{lambda()#1}&>(std::__invoke_other, doris::StorageEngine::_submit_compaction_task(std::shared_ptr<doris::Tablet>, doris::CompactionType)::{lambda()#1}&) at /home/disk1/zhuxiaoli01/doris/baidu/bdg/doris/palo-toolchain/ldb_toolchain/include/c++/11/bits/invoke.h:61
17# std::enable_if<is_invocable_r_v<void, doris::StorageEngine::_submit_compaction_task(std::shared_ptr<doris::Tablet>, doris::CompactionType)::{lambda()#1}&>, void>::type std::__invoke_r<void, doris::StorageEngine::_submit_compaction_task(std::shared_ptr<doris::Tablet>, doris::CompactionType)::{lambda()#1}&>(doris::StorageEngine::_submit_compaction_task(std::shared_ptr<doris::Tablet>, doris::CompactionType)::{lambda()#1}&) at /home/disk1/zhuxiaoli01/doris/baidu/bdg/doris/palo-toolchain/ldb_toolchain/include/c++/11/bits/invoke.h:117
```

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
