### PR TITLE
[fix] Fix olap scan node normalize_in_and_eq_predicate infinite loop bug.

### DIFF
--- a/be/src/exec/olap_scan_node.cpp
+++ b/be/src/exec/olap_scan_node.cpp
@@ -1078,6 +1078,7 @@ Status OlapScanNode::normalize_in_and_eq_predicate(SlotDescriptor* slot,
                 // column in (nullptr) is always false so continue to
                 // dispose next item
                 if (nullptr == iter->get_value()) {
+                    iter->next();
                     continue;
                 }
                 auto value = const_cast<void*>(iter->get_value());

--- a/be/src/vec/exec/volap_scan_node.cpp
+++ b/be/src/vec/exec/volap_scan_node.cpp
@@ -1101,6 +1101,7 @@ Status VOlapScanNode::normalize_in_and_eq_predicate(SlotDescriptor* slot,
                 // column in (nullptr) is always false so continue to
                 // dispose next item
                 if (nullptr == iter->get_value()) {
+                    iter->next();
                     continue;
                 }
                 auto value = const_cast<void*>(iter->get_value());


### PR DESCRIPTION
# Proposed changes

The continue branch in normalize_in_and_eq_predicate may cause infinite loop.
call ```iter->next();``` before continue.

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
