### PR TITLE
[Bug][Storage] fix core dump when backend start

### DIFF
--- a/be/src/olap/data_dir.cpp
+++ b/be/src/olap/data_dir.cpp
@@ -558,8 +558,8 @@ void DataDir::perform_path_gc_by_tablet() {
         }
         TTabletId tablet_id = -1;
         TSchemaHash schema_hash = -1;
-        bool is_valid = _tablet_manager->get_tablet_id_and_schema_hash_from_path(path, &tablet_id,
-                                                                                 &schema_hash);
+        bool is_valid = TabletManager::get_tablet_id_and_schema_hash_from_path(path, &tablet_id,
+                                                                               &schema_hash);
         if (!is_valid) {
             LOG(WARNING) << "unknown path:" << path;
             continue;
@@ -607,8 +607,8 @@ void DataDir::perform_path_gc_by_rowsetid() {
         }
         TTabletId tablet_id = -1;
         TSchemaHash schema_hash = -1;
-        bool is_valid = _tablet_manager->get_tablet_id_and_schema_hash_from_path(path, &tablet_id,
-                                                                                 &schema_hash);
+        bool is_valid = TabletManager::get_tablet_id_and_schema_hash_from_path(path, &tablet_id,
+                                                                               &schema_hash);
         if (!is_valid) {
             LOG(WARNING) << "unknown path:" << path;
             continue;


### PR DESCRIPTION
# Proposed changes

due to `a->tablet_schema()` is `nullptr`

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
