### PR TITLE
[improvement]Use phmap for aggregation with serialized key

### DIFF
--- a/be/src/vec/common/columns_hashing.h
+++ b/be/src/vec/common/columns_hashing.h
@@ -28,6 +28,7 @@
 #include "vec/common/columns_hashing_impl.h"
 #include "vec/common/hash_table/hash_table.h"
 #include "vec/common/hash_table/hash_table_key_holder.h"
+#include "vec/common/hash_table/ph_hash_map.h"
 #include "vec/common/unaligned.h"
 
 namespace doris::vectorized {

--- a/be/src/vec/common/hash_table/ph_hash_map.h
+++ b/be/src/vec/common/hash_table/ph_hash_map.h
@@ -1,0 +1,170 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <parallel_hashmap/phmap.h>
+
+ALWAYS_INLINE inline char** lookup_result_get_mapped(std::pair<const StringRef, char*>* it) {
+    return &(it->second);
+}
+
+template <typename Map>
+struct IsPhmapTraits {
+    constexpr static bool value = false;
+};
+
+template <typename Key, typename Mapped, typename Hash = DefaultHash<Key>>
+class PHHashMap : private boost::noncopyable {
+public:
+    using Self = PHHashMap;
+    using HashMapImpl = phmap::flat_hash_map<Key, Mapped, Hash>;
+
+    using key_type = Key;
+    using mapped_type = Mapped;
+    using value_type = Key;
+
+    using LookupResult = typename HashMapImpl::value_type*;
+
+    using const_iterator_impl = typename HashMapImpl::const_iterator;
+    using iterator_impl = typename HashMapImpl::iterator;
+
+    template <typename Derived, bool is_const>
+    class iterator_base {
+        using BaseIterator = std::conditional_t<is_const, const_iterator_impl, iterator_impl>;
+
+        BaseIterator base_iterator;
+        friend class PHHashMap;
+
+    public:
+        iterator_base() {}
+        iterator_base(BaseIterator it) : base_iterator(it) {}
+
+        bool operator==(const iterator_base& rhs) const {
+            return base_iterator == rhs.base_iterator;
+        }
+        bool operator!=(const iterator_base& rhs) const {
+            return base_iterator != rhs.base_iterator;
+        }
+
+        Derived& operator++() {
+            base_iterator++;
+            return static_cast<Derived&>(*this);
+        }
+
+        auto& operator*() const { return *this; }
+        auto* operator->() const { return this; }
+
+        auto& operator*() { return *this; }
+        auto* operator->() { return this; }
+
+        const auto& get_first() const { return base_iterator->first; }
+
+        const auto& get_second() const { return base_iterator->second; }
+
+        auto& get_second() { return base_iterator->second; }
+
+        auto get_ptr() const { return *base_iterator; }
+        size_t get_hash() const { return base_iterator->get_hash(); }
+
+        size_t get_collision_chain_length() const { return 0; }
+    };
+
+    class iterator : public iterator_base<iterator, false> {
+    public:
+        using iterator_base<iterator, false>::iterator_base;
+    };
+
+    class const_iterator : public iterator_base<const_iterator, true> {
+    public:
+        using iterator_base<const_iterator, true>::iterator_base;
+    };
+
+    const_iterator begin() const { return const_iterator(_hash_map.cbegin()); }
+
+    const_iterator cbegin() const { return const_iterator(_hash_map.cbegin()); }
+
+    iterator begin() { return iterator(_hash_map.begin()); }
+
+    const_iterator end() const { return const_iterator(_hash_map.cend()); }
+    const_iterator cend() const { return const_iterator(_hash_map.cend()); }
+    iterator end() { return iterator(_hash_map.end()); }
+
+    template <typename KeyHolder>
+    void ALWAYS_INLINE emplace(KeyHolder&& key_holder, LookupResult& it, bool& inserted) {
+        const auto& key = key_holder_get_key(key_holder);
+        inserted = false;
+        auto it_ = _hash_map.lazy_emplace(key, [&](const auto& ctor) {
+            inserted = true;
+            key_holder_persist_key(key_holder);
+            ctor(key_holder_get_key(key_holder), nullptr);
+        });
+        it = &*it_;
+    }
+
+    template <typename KeyHolder>
+    void ALWAYS_INLINE emplace(KeyHolder&& key_holder, LookupResult& it, size_t hash_value,
+                               bool& inserted) {
+        const auto& key = key_holder_get_key(key_holder);
+        inserted = false;
+        auto it_ = _hash_map.lazy_emplace_with_hash(key, hash_value, [&](const auto& ctor) {
+            inserted = true;
+            key_holder_persist_key(key_holder);
+            ctor(key, nullptr);
+        });
+        it = &*it_;
+    }
+
+    size_t hash(const Key& x) const { return _hash_map.hash(x); }
+
+    void ALWAYS_INLINE prefetch_by_hash(size_t hash_value) { _hash_map.prefetch_hash(hash_value); }
+
+    /// Call func(const Key &, Mapped &) for each hash map element.
+    template <typename Func>
+    void for_each_value(Func&& func) {
+        for (auto& v : *this) func(v.get_first(), v.get_second());
+    }
+
+    /// Call func(Mapped &) for each hash map element.
+    template <typename Func>
+    void for_each_mapped(Func&& func) {
+        for (auto& v : *this) func(v.get_second());
+    }
+
+    size_t get_buffer_size_in_bytes() const {
+        const auto capacity = _hash_map.capacity();
+        return capacity * sizeof(typename HashMapImpl::slot_type);
+    }
+
+    bool add_elem_size_overflow(size_t row) const {
+        const auto capacity = _hash_map.capacity();
+        // phmap use 7/8th as maximum load factor.
+        return (_hash_map.size() + row) > (capacity * 7 / 8);
+    }
+
+    size_t size() const { return _hash_map.size(); }
+
+    char* get_null_key_data() { return nullptr; }
+    bool has_null_key_data() const { return false; }
+
+    HashMapImpl _hash_map;
+};
+
+template <typename Key, typename Mapped, typename Hash>
+struct IsPhmapTraits<PHHashMap<Key, Mapped, Hash>> {
+    constexpr static bool value = true;
+};

--- a/be/src/vec/exec/vaggregation_node.cpp
+++ b/be/src/vec/exec/vaggregation_node.cpp
@@ -32,6 +32,9 @@
 
 namespace doris::vectorized {
 
+// Here is an empirical value.
+static constexpr size_t HASH_MAP_PREFETCH_DIST = 16;
+
 /// The minimum reduction factor (input rows divided by output rows) to grow hash tables
 /// in a streaming preaggregation, given that the hash tables are currently the given
 /// size or above. The sizes roughly correspond to hash table sizes where the bucket
@@ -762,17 +765,38 @@ Status AggregationNode::_pre_agg_with_serialized_key(doris::vectorized::Block* i
         std::visit(
                 [&](auto&& agg_method) -> void {
                     using HashMethodType = std::decay_t<decltype(agg_method)>;
+                    using HashTableType = std::decay_t<decltype(agg_method.data)>;
                     using AggState = typename HashMethodType::State;
                     AggState state(key_columns, _probe_key_sz, nullptr);
 
                     _pre_serialize_key_if_need(state, agg_method, key_columns, rows);
 
+                    std::vector<size_t> hash_values;
+
+                    if constexpr (IsPhmapTraits<HashTableType>::value) {
+                        if (hash_values.size() < rows) hash_values.resize(rows);
+                        for (size_t i = 0; i < rows; ++i) {
+                            hash_values[i] = agg_method.data.hash(agg_method.keys[i]);
+                        }
+                    }
+
                     /// For all rows.
                     for (size_t i = 0; i < rows; ++i) {
                         AggregateDataPtr aggregate_data = nullptr;
 
-                        auto emplace_result =
-                                state.emplace_key(agg_method.data, i, _agg_arena_pool);
+                        auto emplace_result = [&]() {
+                            if constexpr (IsPhmapTraits<HashTableType>::value) {
+                                if (LIKELY(i + HASH_MAP_PREFETCH_DIST < rows)) {
+                                    agg_method.data.prefetch_by_hash(
+                                            hash_values[i + HASH_MAP_PREFETCH_DIST]);
+                                }
+
+                                return state.emplace_key(agg_method.data, hash_values[i], i,
+                                                         _agg_arena_pool);
+                            } else {
+                                return state.emplace_key(agg_method.data, i, _agg_arena_pool);
+                            }
+                        }();
 
                         /// If a new key is inserted, initialize the states of the aggregate functions, and possibly something related to the key.
                         if (emplace_result.is_inserted()) {
@@ -826,16 +850,38 @@ Status AggregationNode::_execute_with_serialized_key(Block* block) {
     std::visit(
             [&](auto&& agg_method) -> void {
                 using HashMethodType = std::decay_t<decltype(agg_method)>;
+                using HashTableType = std::decay_t<decltype(agg_method.data)>;
                 using AggState = typename HashMethodType::State;
                 AggState state(key_columns, _probe_key_sz, nullptr);
 
                 _pre_serialize_key_if_need(state, agg_method, key_columns, rows);
 
+                std::vector<size_t> hash_values;
+
+                if constexpr (IsPhmapTraits<HashTableType>::value) {
+                    if (hash_values.size() < rows) hash_values.resize(rows);
+                    for (size_t i = 0; i < rows; ++i) {
+                        hash_values[i] = agg_method.data.hash(agg_method.keys[i]);
+                    }
+                }
+
                 /// For all rows.
                 for (size_t i = 0; i < rows; ++i) {
                     AggregateDataPtr aggregate_data = nullptr;
 
-                    auto emplace_result = state.emplace_key(agg_method.data, i, _agg_arena_pool);
+                    auto emplace_result = [&]() {
+                        if constexpr (IsPhmapTraits<HashTableType>::value) {
+                            if (LIKELY(i + HASH_MAP_PREFETCH_DIST < rows)) {
+                                agg_method.data.prefetch_by_hash(
+                                        hash_values[i + HASH_MAP_PREFETCH_DIST]);
+                            }
+
+                            return state.emplace_key(agg_method.data, hash_values[i], i,
+                                                     _agg_arena_pool);
+                        } else {
+                            return state.emplace_key(agg_method.data, i, _agg_arena_pool);
+                        }
+                    }();
 
                     /// If a new key is inserted, initialize the states of the aggregate functions, and possibly something related to the key.
                     if (emplace_result.is_inserted()) {
@@ -1048,16 +1094,38 @@ Status AggregationNode::_merge_with_serialized_key(Block* block) {
     std::visit(
             [&](auto&& agg_method) -> void {
                 using HashMethodType = std::decay_t<decltype(agg_method)>;
+                using HashTableType = std::decay_t<decltype(agg_method.data)>;
                 using AggState = typename HashMethodType::State;
                 AggState state(key_columns, _probe_key_sz, nullptr);
 
                 _pre_serialize_key_if_need(state, agg_method, key_columns, rows);
 
+                std::vector<size_t> hash_values;
+
+                if constexpr (IsPhmapTraits<HashTableType>::value) {
+                    if (hash_values.size() < rows) hash_values.resize(rows);
+                    for (size_t i = 0; i < rows; ++i) {
+                        hash_values[i] = agg_method.data.hash(agg_method.keys[i]);
+                    }
+                }
+
                 /// For all rows.
                 for (size_t i = 0; i < rows; ++i) {
                     AggregateDataPtr aggregate_data = nullptr;
 
-                    auto emplace_result = state.emplace_key(agg_method.data, i, _agg_arena_pool);
+                    auto emplace_result = [&]() {
+                        if constexpr (IsPhmapTraits<HashTableType>::value) {
+                            if (LIKELY(i + HASH_MAP_PREFETCH_DIST < rows)) {
+                                agg_method.data.prefetch_by_hash(
+                                        hash_values[i + HASH_MAP_PREFETCH_DIST]);
+                            }
+
+                            return state.emplace_key(agg_method.data, hash_values[i], i,
+                                                     _agg_arena_pool);
+                        } else {
+                            return state.emplace_key(agg_method.data, i, _agg_arena_pool);
+                        }
+                    }();
 
                     /// If a new key is inserted, initialize the states of the aggregate functions, and possibly something related to the key.
                     if (emplace_result.is_inserted()) {

--- a/be/src/vec/exec/vaggregation_node.h
+++ b/be/src/vec/exec/vaggregation_node.h
@@ -106,7 +106,7 @@ private:
 };
 
 using AggregatedDataWithoutKey = AggregateDataPtr;
-using AggregatedDataWithStringKey = HashMapWithSavedHash<StringRef, AggregateDataPtr>;
+using AggregatedDataWithStringKey = PHHashMap<StringRef, AggregateDataPtr, DefaultHash<StringRef>>;
 
 /// For the case where there is one numeric key.
 /// FieldType is UInt8/16/32/64 for any type with corresponding bit width.


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

Test on ssb-flat(100g)  with SQL:
```sql
SELECT
     C_CITY,
     S_CITY, 
     (LO_ORDERDATE DIV 10000) AS YEAR, 
    SUM(LO_REVENUE) AS revenue 
FROM 
     lineorder_flat 
GROUP BY 
     C_CITY, S_CITY, YEAR 
ORDER BY 
     YEAR ASC, revenue DESC limit 20;
```
master:  34 sec
agg_with_phmap:  28 sec

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
