### PR TITLE
[enhancement](signal) output query_id when 'be' core dumped.

### DIFF
--- a/be/src/common/signal_handler.h
+++ b/be/src/common/signal_handler.h
@@ -49,6 +49,9 @@
 
 namespace doris::signal {
 
+inline thread_local uint64 query_id_hi;
+inline thread_local uint64 query_id_lo;
+
 namespace {
 
 // We'll install the failure signal handler for these signals.  We could
@@ -248,6 +251,11 @@ void DumpTimeInfo() {
     time_t time_in_sec = time(NULL);
     char buf[256]; // Big enough for time info.
     MinimalFormatter formatter(buf, sizeof(buf));
+    formatter.AppendString("*** Query id: ");
+    formatter.AppendUint64(query_id_hi, 16);
+    formatter.AppendString("-");
+    formatter.AppendUint64(query_id_lo, 16);
+    formatter.AppendString(" ***\n");
     formatter.AppendString("*** Aborted at ");
     formatter.AppendUint64(static_cast<uint64>(time_in_sec), 10);
     formatter.AppendString(" (unix time)");
@@ -416,7 +424,7 @@ void FailureSignalHandler(int signal_number, siginfo_t* signal_info, void* ucont
 
 } // namespace
 
-void InstallFailureSignalHandler() {
+inline void InstallFailureSignalHandler() {
     // Build the sigaction struct.
     struct sigaction sig_action;
     memset(&sig_action, 0, sizeof(sig_action));

--- a/be/src/runtime/fragment_mgr.cpp
+++ b/be/src/runtime/fragment_mgr.cpp
@@ -26,6 +26,7 @@
 #include "agent/cgroups_mgr.h"
 #include "common/object_pool.h"
 #include "common/resource_tls.h"
+#include "common/signal_handler.h"
 #include "gen_cpp/DataSinks_types.h"
 #include "gen_cpp/FrontendService.h"
 #include "gen_cpp/HeartbeatService.h"
@@ -483,6 +484,10 @@ void FragmentMgr::_exec_actual(std::shared_ptr<FragmentExecState> exec_state, Fi
     auto scope = opentelemetry::trace::Scope {span};
     span->SetAttribute("query_id", print_id(exec_state->query_id()));
     span->SetAttribute("instance_id", print_id(exec_state->fragment_instance_id()));
+
+    // these two are used to output query_id when be cored dump.
+    doris::signal::query_id_hi = exec_state->query_id().hi;
+    doris::signal::query_id_lo = exec_state->query_id().lo;
 
     TAG(LOG(INFO))
             .log(std::move(func_name))


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

![image](https://user-images.githubusercontent.com/43782773/178869128-fb583183-958e-4b68-98e2-de5ad2c377fa.png)


## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
