### PR TITLE
fix  the coredump when BE start after upgrade.

### DIFF
--- a/be/src/olap/data_dir.cpp
+++ b/be/src/olap/data_dir.cpp
@@ -442,6 +442,14 @@ Status DataDir::load() {
                   << ", error tablet: " << failed_tablet_ids.size() << ", path: " << _path;
     }
 
+    for (int64_t tablet_id : tablet_ids) {
+        TabletSharedPtr tablet = _tablet_manager->get_tablet(tablet_id);
+        if (tablet && tablet->set_tablet_schema_into_rowset_meta()) {
+            TabletMetaManager::save(this, tablet->tablet_id(), tablet->schema_hash(),
+                                    tablet->tablet_meta());
+        }
+    }
+
     // traverse rowset
     // 1. add committed rowset to txn map
     // 2. add visible rowset to tablet
@@ -469,6 +477,11 @@ Status DataDir::load() {
         }
         if (rowset_meta->rowset_state() == RowsetStatePB::COMMITTED &&
             rowset_meta->tablet_uid() == tablet->tablet_uid()) {
+            if (!rowset_meta->get_rowset_pb().has_tablet_schema()) {
+                rowset_meta->set_tablet_schema(&tablet->tablet_schema());
+                RowsetMetaManager::save(_meta, rowset_meta->tablet_uid(), rowset_meta->rowset_id(),
+                                        rowset_meta->get_rowset_pb());
+            }
             Status commit_txn_status = _txn_manager->commit_txn(
                     _meta, rowset_meta->partition_id(), rowset_meta->txn_id(),
                     rowset_meta->tablet_id(), rowset_meta->tablet_schema_hash(),
@@ -485,13 +498,13 @@ Status DataDir::load() {
                           << " schema hash: " << rowset_meta->tablet_schema_hash()
                           << " for txn: " << rowset_meta->txn_id();
             }
+        } else if (rowset_meta->rowset_state() == RowsetStatePB::VISIBLE &&
+                   rowset_meta->tablet_uid() == tablet->tablet_uid()) {
             if (!rowset_meta->get_rowset_pb().has_tablet_schema()) {
                 rowset_meta->set_tablet_schema(&tablet->tablet_schema());
                 RowsetMetaManager::save(_meta, rowset_meta->tablet_uid(), rowset_meta->rowset_id(),
                                         rowset_meta->get_rowset_pb());
             }
-        } else if (rowset_meta->rowset_state() == RowsetStatePB::VISIBLE &&
-                   rowset_meta->tablet_uid() == tablet->tablet_uid()) {
             Status publish_status = tablet->add_rowset(rowset);
             if (!publish_status &&
                 publish_status.precise_code() != OLAP_ERR_PUSH_VERSION_ALREADY_EXIST) {
@@ -509,14 +522,6 @@ Status DataDir::load() {
                          << " txn: " << rowset_meta->txn_id()
                          << " current valid tablet uid: " << tablet->tablet_uid();
             ++invalid_rowset_counter;
-        }
-    }
-
-    for (int64_t tablet_id : tablet_ids) {
-        TabletSharedPtr tablet = _tablet_manager->get_tablet(tablet_id);
-        if (tablet && tablet->set_tablet_schema_into_rowset_meta()) {
-            TabletMetaManager::save(this, tablet->tablet_id(), tablet->schema_hash(),
-                                    tablet->tablet_meta());
         }
     }
 

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -1813,12 +1813,8 @@ void Tablet::remove_all_remote_rowsets() {
 
 const TabletSchema& Tablet::tablet_schema() const {
     std::shared_lock wrlock(_meta_lock);
-    _tablet_meta->all_rs_metas();
     const RowsetMetaSharedPtr rowset_meta =
             rowset_meta_with_max_schema_version(_tablet_meta->all_rs_metas());
-    if (rowset_meta->tablet_schema() == nullptr) {
-        return _schema;
-    }
     return *rowset_meta->tablet_schema();
 }
 


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

When upgrade BE  to the latest version, there is a certain probability that BE will not get up after restarting. 
Core Stack
```
 6# __gnu_cxx::__normal_iterator<std::shared_ptr<doris::RowsetMeta> const*, std::vector<std::shared_ptr<doris::RowsetMeta>, std::allocator<std::shared_ptr<doris::RowsetMeta> > > > std::max_element<__gnu_cxx::__normal_iterator<std::shared_ptr<doris::RowsetMeta> const*, std::vector<std::shared_ptr<doris::RowsetMeta>, std::allocator<std::shared_ptr<doris::RowsetMeta> > > >, doris::Tablet::rowset_meta_with_max_schema_version(std::vector<std::shared_ptr<doris::RowsetMeta>, std::allocator<std::shared_ptr<doris::RowsetMeta> > > const&)::{lambda(std::shared_ptr<doris::RowsetMeta> const&, std::shared_ptr<doris::RowsetMeta> const&)#1}>(__gnu_cxx::__normal_iterator<std::shared_ptr<doris::RowsetMeta> const*, std::vector<std::shared_ptr<doris::RowsetMeta>, std::allocator<std::shared_ptr<doris::RowsetMeta> > > >, __gnu_cxx::__normal_iterator<std::shared_ptr<doris::RowsetMeta> const*, std::vector<std::shared_ptr<doris::RowsetMeta>, std::allocator<std::shared_ptr<doris::RowsetMeta> > > >, doris::Tablet::rowset_meta_with_max_schema_version(std::vector<std::shared_ptr<doris::RowsetMeta>, std::allocator<std::shared_ptr<doris::RowsetMeta> > > const&)::{lambda(std::shared_ptr<doris::RowsetMeta> const&, std::shared_ptr<doris::RowsetMeta> const&)#1}) at /var/local/ldb_toolchain/include/c++/11/bits/stl_algo.h:5740
 7# doris::Tablet::rowset_meta_with_max_schema_version(std::vector<std::shared_ptr<doris::RowsetMeta>, std::allocator<std::shared_ptr<doris::RowsetMeta> > > const&) at /home/zcp/repo_center/doris_master/be/src/olap/tablet.cpp:380
 8# doris::Tablet::tablet_schema() const at /home/zcp/repo_center/doris_master/be/src/olap/tablet.cpp:1819
 9# doris::Tablet::create_rowset(std::shared_ptr<doris::RowsetMeta>, std::shared_ptr<doris::Rowset>*) at /home/zcp/repo_center/doris_master/be/src/olap/tablet.cpp:1647
10# doris::DataDir::load() at /home/zcp/repo_center/doris_master/be/src/olap/data_dir.cpp:462
11# doris::StorageEngine::load_data_dirs(std::vector<doris::DataDir*, std::allocator<doris::DataDir*> > const&)::{lambda()#1}::operator()() const at /home/zcp/repo_center/doris_master/be/src/olap/storage_engine.cpp:179
12# void std::__invoke_impl<void, doris::StorageEngine::load_data_dirs(std::vector<doris::DataDir*, std::allocator<doris::DataDir*> > const&)::{lambda()#1}>(std::__invoke_other, doris::StorageEngine::load_data_dirs(std::vector<doris::DataDir*, std::allocator<doris::DataDir*> > const&)::{lambda()#1}&&) at /var/local/ldb_toolchain/include/c++/11/bits/invoke.h:61
```

It is because BE get tablet_schema from rowset, old rowset has no tablet_schema then rowset_meta->tablet_schema() will be nullptr. So need to add schema in rowset when starting

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
