### PR TITLE
[fix](planner)nullable info in IntermediateTuple do not be serialized in hash join node

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/planner/HashJoinNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/HashJoinNode.java
@@ -583,6 +583,7 @@ public class HashJoinNode extends PlanNode {
                 originToIntermediateSmap.put(new SlotRef(slotDescriptor), new SlotRef(intermediateSlotDesc));
             }
         }
+        vIntermediateLeftTupleDesc.computeMemLayout();
         // right
         originTidsToIntermediateTidMap.put(getChild(1).getOutputTupleIds(), vIntermediateRightTupleDesc.getId());
         for (TupleDescriptor tupleDescriptor : analyzer.getDescTbl().getTupleDesc(getChild(1).getOutputTupleIds())) {
@@ -595,6 +596,7 @@ public class HashJoinNode extends PlanNode {
                 originToIntermediateSmap.put(new SlotRef(slotDescriptor), new SlotRef(intermediateSlotDesc));
             }
         }
+        vIntermediateRightTupleDesc.computeMemLayout();
         // 3. replace srcExpr by intermediate tuple
         Preconditions.checkState(vSrcToOutputSMap != null);
         vSrcToOutputSMap.substituteLhs(originToIntermediateSmap, analyzer);


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
