### PR TITLE
[fix](array-type) fix arrow column to doris array column

### DIFF
--- a/be/src/vec/utils/arrow_column_to_doris_column.cpp
+++ b/be/src/vec/utils/arrow_column_to_doris_column.cpp
@@ -274,12 +274,14 @@ static Status convert_offset_from_list_column(const arrow::Array* array, size_t 
     auto concrete_array = down_cast<const arrow::ListArray*>(array);
     auto arrow_offsets_array = concrete_array->offsets();
     auto arrow_offsets = down_cast<arrow::Int32Array*>(arrow_offsets_array.get());
+    auto prev_size = offsets_data.back();
     for (int64_t i = array_idx + 1; i < array_idx + num_elements + 1; ++i) {
-        // convert to doris offset, start from 0
-        offsets_data.emplace_back(arrow_offsets->Value(i) - arrow_offsets->Value(array_idx));
+        // convert to doris offset, start from offsets.bak()
+        offsets_data.emplace_back(prev_size + arrow_offsets->Value(i) -
+                                  arrow_offsets->Value(array_idx));
     }
     *start_idx_for_data = arrow_offsets->Value(array_idx);
-    *num_for_data = offsets_data.back();
+    *num_for_data = offsets_data.back() - prev_size;
 
     return Status::OK();
 }

--- a/be/src/vec/utils/arrow_column_to_doris_column.cpp
+++ b/be/src/vec/utils/arrow_column_to_doris_column.cpp
@@ -276,7 +276,7 @@ static Status convert_offset_from_list_column(const arrow::Array* array, size_t 
     auto arrow_offsets = down_cast<arrow::Int32Array*>(arrow_offsets_array.get());
     auto prev_size = offsets_data.back();
     for (int64_t i = array_idx + 1; i < array_idx + num_elements + 1; ++i) {
-        // convert to doris offset, start from offsets.bak()
+        // convert to doris offset, start from offsets.back()
         offsets_data.emplace_back(prev_size + arrow_offsets->Value(i) -
                                   arrow_offsets->Value(array_idx));
     }


### PR DESCRIPTION

# Proposed changes

Issue Number: close #7570

## Problem Summary:
While convert and merge doris array column from arrow array column, the offsets should start from offsets.back(), not zero.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
