### PR TITLE
[fix](array-type) fix vec arrow scanner using wrong type when choosing cast function

### DIFF
--- a/be/src/vec/exec/varrow_scanner.cpp
+++ b/be/src/vec/exec/varrow_scanner.cpp
@@ -248,7 +248,7 @@ Status VArrowScanner::_cast_src_block(Block* block) {
         ColumnsWithTypeAndName arguments {
                 arg,
                 {DataTypeString().create_column_const(
-                         arg.column->size(), remove_nullable(return_type)->get_family_name()),
+                         arg.column->size(), remove_nullable(return_type)->get_name()),
                  std::make_shared<DataTypeString>(), ""}};
         auto func_cast =
                 SimpleFunctionFactory::instance().get_function("CAST", arguments, return_type);


### PR DESCRIPTION
# Proposed changes

Issue Number: close #7570
## Problem Summary:

when parsing Array type column, get_family_name() will only return "Array". This family name is insufficient for the data type factory to choose a proper function. The data type factory requires such as "Array(Int32)" or "Array(String)". So we must use  get_name() here.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
