### PR TITLE
[fix](unique-key-merge-on-write) Fix missing delete bitmap introduced by #10548

### DIFF
--- a/be/src/olap/tablet_meta.cpp
+++ b/be/src/olap/tablet_meta.cpp
@@ -209,7 +209,8 @@ TabletMeta::TabletMeta(const TabletMeta& b)
           _preferred_rowset_type(b._preferred_rowset_type),
           _remote_storage_name(b._remote_storage_name),
           _storage_medium(b._storage_medium),
-          _cooldown_resource(b._cooldown_resource) {};
+          _cooldown_resource(b._cooldown_resource),
+          _delete_bitmap(new DeleteBitmap(*b._delete_bitmap)) {};
 
 void TabletMeta::init_column_from_tcolumn(uint32_t unique_id, const TColumn& tcolumn,
                                           ColumnPB* column) {


### PR DESCRIPTION

Missing delete bitmap for copy constructor of `TabletMeta(TabletMeta&)`.

# Proposed changes

## Problem Summary:

## Checklist(Required)

1. Does it affect the original behavior: (No)
2. Has unit tests been added: (No Need)
3. Has the document been added or modified: (No Need)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (No)

## Further comments

We should eliminate the copy constructor of `TabletMeta(TabletMeta&)`, this ctor will lead to this kind of issue easily.
