### PR TITLE
Revert "[chore][nereids] Bump the version of antlr4 to 4.10.1"

### DIFF
--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -33,7 +33,7 @@ under the License.
         <fe_ut_parallel>1</fe_ut_parallel>
         <doris.thirdparty>${basedir}/../../thirdparty</doris.thirdparty>
         <log4j2.version>2.17.2</log4j2.version>
-        <antlr4.version>4.10.1</antlr4.version>
+        <antlr4.version>4.9.3</antlr4.version>
     </properties>
     <profiles>
         <profile>


### PR DESCRIPTION
Reverts apache/doris#10780
4.10.1 rely on jdk11, not work with jdk8