### PR TITLE
[refactor] (Nereids) Memo.copyIn() return a pair<newly, GroupExpression>

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/cascades/ApplyRuleJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/cascades/ApplyRuleJob.java
@@ -65,7 +65,9 @@ public class ApplyRuleJob extends Job {
             for (Plan newPlan : newPlans) {
                 Pair<Boolean, GroupExpression> pair = context.getPlannerContext().getMemo()
                         .copyIn(newPlan, groupExpression.getOwnerGroup(), rule.isRewrite());
-                if (pair.first) continue;
+                if (!pair.first) {
+                    continue;
+                }
                 GroupExpression newGroupExpression = pair.second;
 
                 if (newPlan instanceof LogicalPlan) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/cascades/ApplyRuleJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/cascades/ApplyRuleJob.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.nereids.jobs.cascades;
 
+import org.apache.doris.common.Pair;
 import org.apache.doris.nereids.exceptions.AnalysisException;
 import org.apache.doris.nereids.jobs.Job;
 import org.apache.doris.nereids.jobs.JobContext;
@@ -62,8 +63,11 @@ public class ApplyRuleJob extends Job {
         for (Plan plan : groupExpressionMatching) {
             List<Plan> newPlans = rule.transform(plan, context.getPlannerContext());
             for (Plan newPlan : newPlans) {
-                GroupExpression newGroupExpression = context.getPlannerContext().getMemo()
-                        .copyIn(newPlan, groupExpression.getOwnerGroup(), rule.isRewrite()).second;
+                Pair<Boolean, GroupExpression> pair = context.getPlannerContext().getMemo()
+                        .copyIn(newPlan, groupExpression.getOwnerGroup(), rule.isRewrite());
+                if (pair.first) continue;
+                GroupExpression newGroupExpression = pair.second;
+
                 if (newPlan instanceof LogicalPlan) {
                     pushTask(new DeriveStatsJob(newGroupExpression, context));
                     if (exploredOnly) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/cascades/ApplyRuleJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/cascades/ApplyRuleJob.java
@@ -63,7 +63,7 @@ public class ApplyRuleJob extends Job {
             List<Plan> newPlans = rule.transform(plan, context.getPlannerContext());
             for (Plan newPlan : newPlans) {
                 GroupExpression newGroupExpression = context.getPlannerContext().getMemo()
-                        .copyIn(newPlan, groupExpression.getOwnerGroup(), rule.isRewrite());
+                        .copyIn(newPlan, groupExpression.getOwnerGroup(), rule.isRewrite()).second;
                 if (newPlan instanceof LogicalPlan) {
                     pushTask(new DeriveStatsJob(newGroupExpression, context));
                     if (exploredOnly) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/rewrite/RewriteBottomUpJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/rewrite/RewriteBottomUpJob.java
@@ -83,7 +83,7 @@ public class RewriteBottomUpJob extends Job {
                 if (after != before) {
                     GroupExpression groupExpr = context.getPlannerContext()
                             .getMemo()
-                            .copyIn(after, group, rule.isRewrite());
+                            .copyIn(after, group, rule.isRewrite()).second;
                     groupExpr.setApplied(rule);
                     pushTask(new RewriteBottomUpJob(group, rules, context, false));
                     return;

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/rewrite/RewriteBottomUpJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/rewrite/RewriteBottomUpJob.java
@@ -85,12 +85,10 @@ public class RewriteBottomUpJob extends Job {
                     Pair<Boolean, GroupExpression> pair = context.getPlannerContext()
                             .getMemo()
                             .copyIn(after, group, rule.isRewrite());
-                    GroupExpression groupExpr = pair.second;
-                    groupExpr.setApplied(rule);
-                    if (!pair.first) {
+                    if (pair.first) {
                         pushTask(new RewriteBottomUpJob(group, rules, context, false));
+                        return;
                     }
-                    return;
                 }
             }
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/rewrite/RewriteBottomUpJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/rewrite/RewriteBottomUpJob.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.nereids.jobs.rewrite;
 
+import org.apache.doris.common.Pair;
 import org.apache.doris.nereids.exceptions.AnalysisException;
 import org.apache.doris.nereids.jobs.Job;
 import org.apache.doris.nereids.jobs.JobContext;
@@ -81,11 +82,14 @@ public class RewriteBottomUpJob extends Job {
                 Preconditions.checkArgument(afters.size() == 1);
                 Plan after = afters.get(0);
                 if (after != before) {
-                    GroupExpression groupExpr = context.getPlannerContext()
+                    Pair<Boolean, GroupExpression> pair = context.getPlannerContext()
                             .getMemo()
-                            .copyIn(after, group, rule.isRewrite()).second;
+                            .copyIn(after, group, rule.isRewrite());
+                    GroupExpression groupExpr = pair.second;
                     groupExpr.setApplied(rule);
-                    pushTask(new RewriteBottomUpJob(group, rules, context, false));
+                    if (!pair.first) {
+                        pushTask(new RewriteBottomUpJob(group, rules, context, false));
+                    }
                     return;
                 }
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/rewrite/RewriteTopDownJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/rewrite/RewriteTopDownJob.java
@@ -73,7 +73,7 @@ public class RewriteTopDownJob extends Job {
                 Plan after = afters.get(0);
                 if (after != before) {
                     GroupExpression expression = context.getPlannerContext()
-                            .getMemo().copyIn(after, group, rule.isRewrite());
+                            .getMemo().copyIn(after, group, rule.isRewrite()).second;
                     expression.setApplied(rule);
                     pushTask(new RewriteTopDownJob(group, rules, context));
                     return;

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/rewrite/RewriteTopDownJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/rewrite/RewriteTopDownJob.java
@@ -66,8 +66,12 @@ public class RewriteTopDownJob extends Job {
 
         List<Rule> validRules = getValidRules(logicalExpression, rules);
         for (Rule rule : validRules) {
+            Preconditions.checkArgument(rule.isRewrite(),
+                    "in top down job, rules must be rewritable");
             GroupExpressionMatching groupExpressionMatching
                     = new GroupExpressionMatching(rule.getPattern(), logicalExpression);
+            //In topdown job, there must be only one matching plan.
+            //This `for` loop runs at most once.
             for (Plan before : groupExpressionMatching) {
                 List<Plan> afters = rule.transform(before, context.getPlannerContext());
                 Preconditions.checkArgument(afters.size() == 1);
@@ -75,10 +79,12 @@ public class RewriteTopDownJob extends Job {
                 if (after != before) {
                     Pair<Boolean, GroupExpression> pair = context.getPlannerContext()
                             .getMemo().copyIn(after, group, rule.isRewrite());
-
-                    pair.second.setApplied(rule);
-                    pushTask(new RewriteTopDownJob(group, rules, context));
-                    return;
+                    if (pair.first) {
+                        //new group-expr replaced the origin group-expr in `group`,
+                        //run this rule against this `group` again.
+                        pushTask(new RewriteTopDownJob(group, rules, context));
+                        return;
+                    }
                 }
             }
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/rewrite/RewriteTopDownJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/rewrite/RewriteTopDownJob.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.nereids.jobs.rewrite;
 
+import org.apache.doris.common.Pair;
 import org.apache.doris.nereids.jobs.Job;
 import org.apache.doris.nereids.jobs.JobContext;
 import org.apache.doris.nereids.jobs.JobType;
@@ -72,9 +73,10 @@ public class RewriteTopDownJob extends Job {
                 Preconditions.checkArgument(afters.size() == 1);
                 Plan after = afters.get(0);
                 if (after != before) {
-                    GroupExpression expression = context.getPlannerContext()
-                            .getMemo().copyIn(after, group, rule.isRewrite()).second;
-                    expression.setApplied(rule);
+                    Pair<Boolean, GroupExpression> pair = context.getPlannerContext()
+                            .getMemo().copyIn(after, group, rule.isRewrite());
+
+                    pair.second.setApplied(rule);
                     pushTask(new RewriteTopDownJob(group, rules, context));
                     return;
                 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/Memo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/Memo.java
@@ -48,7 +48,7 @@ public class Memo {
     private Group root;
 
     public Memo(Plan plan) {
-        root = copyIn(plan, null, false).getOwnerGroup();
+        root = copyIn(plan, null, false).second.getOwnerGroup();
     }
 
     public Group getRoot() {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/Memo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/Memo.java
@@ -70,12 +70,13 @@ public class Memo {
      * @param node {@link Plan} or {@link Expression} to be added
      * @param target target group to add node. null to generate new Group
      * @param rewrite whether to rewrite the node to the target group
-     * @return Reference of node in Memo
+     * @return a pair, in which the first element is true if a newly generated groupExpression added into memo,
+     *         and the second element is a reference of node in Memo
      */
     public Pair<Boolean, GroupExpression> copyIn(Plan node, @Nullable Group target, boolean rewrite) {
         Optional<GroupExpression> groupExpr = node.getGroupExpression();
         if (!rewrite && groupExpr.isPresent() && groupExpressions.containsKey(groupExpr.get())) {
-            return new Pair(true, groupExpr.get());
+            return new Pair(false, groupExpr.get());
         }
         List<Group> childrenGroups = Lists.newArrayList();
         for (int i = 0; i < node.children().size(); i++) {
@@ -129,10 +130,11 @@ public class Memo {
      * @param groupExpression groupExpression to insert
      * @param target target group to insert or rewrite groupExpression
      * @param rewrite whether to rewrite the groupExpression to target group
-     * @return existing groupExpression in memo or newly generated groupExpression
+     * @return a pair, in which the first element is true if a newly generated groupExpression added into memo,
+     *         and the second element is a reference of node in Memo
      */
     private Pair<Boolean, GroupExpression> insertOrRewriteGroupExpression(GroupExpression groupExpression, Group target,
-                                                                          boolean rewrite, LogicalProperties logicalProperties) {
+            boolean rewrite, LogicalProperties logicalProperties) {
         GroupExpression existedGroupExpression = groupExpressions.get(groupExpression);
         if (existedGroupExpression != null) {
             Group mergedGroup = existedGroupExpression.getOwnerGroup();
@@ -142,7 +144,7 @@ public class Memo {
             if (rewrite) {
                 mergedGroup.setLogicalProperties(logicalProperties);
             }
-            return new Pair(true, existedGroupExpression);
+            return new Pair(false, existedGroupExpression);
         }
         if (target != null) {
             if (rewrite) {
@@ -157,7 +159,7 @@ public class Memo {
             groups.add(group);
         }
         groupExpressions.put(groupExpression, groupExpression);
-        return new Pair(false, groupExpression);
+        return new Pair(true, groupExpression);
     }
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/Memo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/Memo.java
@@ -91,9 +91,8 @@ public class Memo {
         node = replaceChildrenToGroupPlan(node, childrenGroups);
         GroupExpression newGroupExpression = new GroupExpression(node);
         newGroupExpression.setChildren(childrenGroups);
-        newGroupExpression = insertOrRewriteGroupExpression(newGroupExpression, target, rewrite,
+        return insertOrRewriteGroupExpression(newGroupExpression, target, rewrite,
                 node.getLogicalProperties());
-        return new Pair(groupExpressions.containsKey(newGroupExpression), newGroupExpression);
         // TODO: need to derive logical property if generate new group. currently we not copy logical plan into
     }
 
@@ -132,8 +131,8 @@ public class Memo {
      * @param rewrite whether to rewrite the groupExpression to target group
      * @return existing groupExpression in memo or newly generated groupExpression
      */
-    private GroupExpression insertOrRewriteGroupExpression(GroupExpression groupExpression, Group target,
-            boolean rewrite, LogicalProperties logicalProperties) {
+    private Pair<Boolean, GroupExpression> insertOrRewriteGroupExpression(GroupExpression groupExpression, Group target,
+                                                                          boolean rewrite, LogicalProperties logicalProperties) {
         GroupExpression existedGroupExpression = groupExpressions.get(groupExpression);
         if (existedGroupExpression != null) {
             Group mergedGroup = existedGroupExpression.getOwnerGroup();
@@ -143,7 +142,7 @@ public class Memo {
             if (rewrite) {
                 mergedGroup.setLogicalProperties(logicalProperties);
             }
-            return existedGroupExpression;
+            return new Pair(true, existedGroupExpression);
         }
         if (target != null) {
             if (rewrite) {
@@ -158,7 +157,7 @@ public class Memo {
             groups.add(group);
         }
         groupExpressions.put(groupExpression, groupExpression);
-        return groupExpression;
+        return new Pair(false, groupExpression);
     }
 
     /**

--- a/fe/fe-core/src/test/java/org/apache/doris/utframe/TestWithFeService.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/utframe/TestWithFeService.java
@@ -108,7 +108,7 @@ public abstract class TestWithFeService {
     @AfterAll
     public final void afterAll() throws Exception {
         runAfterAll();
-        Catalog.getCurrentCatalog().clear();
+        Env.getCurrentEnv().clear();
         cleanDorisFeDir(runningDir);
     }
 


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:
When we copy a plan into memo, we will check if this plan is already in memo or it is a new plan.
In the new version of Memo.copyIn(), we encapsulate is_new and the plan's corresponding group-expression.

The is_new is used to avoid repeatedly apply rules against the same plan, and hence save optimize efforts.

Describe the overview of changes.
1. change Memo.copyIn() and related function interfaces
2. every time Memo.copyIn() is invoked, we check if the  plan is already recorded by memo or not. if plan is not new, we do not put its group into stack for further optimization.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
5. Has unit tests been added: (Yes/No/No Need)
6. Has document been added or modified: (Yes/No/No Need)
7. Does it need to update dependencies: (Yes/No)
8. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
