### PR TITLE
[feature](resource-tag) support multi tag for a single Backend

### DIFF
--- a/docs/en/docs/sql-manual/sql-reference/Cluster-Management-Statements/ALTER-SYSTEM-ADD-BACKEND.md
+++ b/docs/en/docs/sql-manual/sql-reference/Cluster-Management-Statements/ALTER-SYSTEM-ADD-BACKEND.md
@@ -39,10 +39,6 @@ grammar:
 ```sql
 -- Add nodes (add this method if you do not use the multi-tenancy function)
    ALTER SYSTEM ADD BACKEND "host:heartbeat_port"[,"host:heartbeat_port"...];
--- Add idle nodes (that is, add BACKEND that does not belong to any cluster)
-   ALTER SYSTEM ADD FREE BACKEND "host:heartbeat_port"[,"host:heartbeat_port"...];
--- Add nodes to a cluster
-   ALTER SYSTEM ADD BACKEND TO cluster_name "host:heartbeat_port"[,"host:heartbeat_port"...];
 ````
 
  illustrate:
@@ -57,12 +53,6 @@ grammar:
 
     ```sql
     ALTER SYSTEM ADD BACKEND "host:port";
-    ````
-
- 1. Add an idle node
-
-    ```sql
-    ALTER SYSTEM ADD FREE BACKEND "host:port";
     ````
 
 ### Keywords

--- a/docs/en/docs/sql-manual/sql-reference/Cluster-Management-Statements/ALTER-SYSTEM-MODIFY-BACKEND.md
+++ b/docs/en/docs/sql-manual/sql-reference/Cluster-Management-Statements/ALTER-SYSTEM-MODIFY-BACKEND.md
@@ -47,9 +47,12 @@ ALTER SYSTEM MODIFY BACKEND "host:heartbeat_port" SET ("key" = "value"[, ...]);
 2. heartbeat_port is the heartbeat port of the node
 3. Modify BE node properties The following properties are currently supported:
 
-- tag.location: resource tag
+- tag.xxxx: resource tag
 - disable_query: query disable attribute
 - disable_load: import disable attribute
+
+Note:
+1. A backend can be set multi resource tags. But must contain "tag.location" type.
 
 ### Example
 
@@ -57,6 +60,7 @@ ALTER SYSTEM MODIFY BACKEND "host:heartbeat_port" SET ("key" = "value"[, ...]);
 
     ```sql
     ALTER SYSTEM MODIFY BACKEND "host1:9050" SET ("tag.location" = "group_a");
+    ALTER SYSTEM MODIFY BACKEND "host1:9050" SET ("tag.location" = "group_a", "tag.compute" = "c1");
     ````
 
 2. Modify the query disable property of BE

--- a/docs/zh-CN/docs/sql-manual/sql-reference/Cluster-Management-Statements/ALTER-SYSTEM-ADD-BACKEND.md
+++ b/docs/zh-CN/docs/sql-manual/sql-reference/Cluster-Management-Statements/ALTER-SYSTEM-ADD-BACKEND.md
@@ -37,18 +37,14 @@ ALTER SYSTEM ADD BACKEND
 语法：
 
 ```sql
-1) 增加节点(不使用多租户功能则按照此方法添加)
+1) 增加节点
    ALTER SYSTEM ADD BACKEND "host:heartbeat_port"[,"host:heartbeat_port"...];
-2) 增加空闲节点(即添加不属于任何cluster的BACKEND)
-   ALTER SYSTEM ADD FREE BACKEND "host:heartbeat_port"[,"host:heartbeat_port"...];
-3) 增加节点到某个cluster
-   ALTER SYSTEM ADD BACKEND TO cluster_name "host:heartbeat_port"[,"host:heartbeat_port"...];
 ```
 
  说明：
 
 1. host 可以是主机名或者ip地址
-2.  heartbeat_port 为该节点的心跳端口
+2. heartbeat_port 为该节点的心跳端口
 3. 增加和删除节点为同步操作。这两种操作不考虑节点上已有的数据，节点直接从元数据中删除，请谨慎使用。
 
 ### Example
@@ -57,12 +53,6 @@ ALTER SYSTEM ADD BACKEND
     
      ```sql
     ALTER SYSTEM ADD BACKEND "host:port";
-    ```
-
- 1. 增加一个空闲节点
-    
-    ```sql
-    ALTER SYSTEM ADD FREE BACKEND "host:port";
     ```
 
 ### Keywords

--- a/docs/zh-CN/docs/sql-manual/sql-reference/Cluster-Management-Statements/ALTER-SYSTEM-MODIFY-BACKEND.md
+++ b/docs/zh-CN/docs/sql-manual/sql-reference/Cluster-Management-Statements/ALTER-SYSTEM-MODIFY-BACKEND.md
@@ -47,9 +47,12 @@ ALTER SYSTEM MODIFY BACKEND "host:heartbeat_port" SET ("key" = "value"[, ...]);
 2. heartbeat_port 为该节点的心跳端口
 3. 修改 BE 节点属性目前支持以下属性：
 
-- tag.location：资源标签
+- tag.xxx：资源标签
 - disable_query: 查询禁用属性
 - disable_load: 导入禁用属性        
+
+注：
+1. 可以给一个 Backend 设置多种资源标签。但必须包含 "tag.location"。
 
 ### Example
 
@@ -57,6 +60,7 @@ ALTER SYSTEM MODIFY BACKEND "host:heartbeat_port" SET ("key" = "value"[, ...]);
 
    ```sql
    ALTER SYSTEM MODIFY BACKEND "host1:9050" SET ("tag.location" = "group_a");
+   ALTER SYSTEM MODIFY BACKEND "host1:9050" SET ("tag.location" = "group_a", "tag.compute" = "c1");
    ```
 
 2. 修改 BE 的查询禁用属性

--- a/fe/fe-core/src/main/java/org/apache/doris/alter/SystemHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/SystemHandler.java
@@ -126,8 +126,8 @@ public class SystemHandler extends AlterHandler {
                     && Catalog.getCurrentCatalog().getCluster(destClusterName) == null) {
                 throw new DdlException("Cluster: " + destClusterName + " does not exist.");
             }
-            Catalog.getCurrentSystemInfo().addBackends(addBackendClause.getHostPortPairs(),
-                    addBackendClause.isFree(), addBackendClause.getDestCluster(), addBackendClause.getTag());
+            Catalog.getCurrentSystemInfo().addBackends(addBackendClause.getHostPortPairs(), addBackendClause.isFree(),
+                    addBackendClause.getDestCluster(), addBackendClause.getTagMap());
         } else if (alterClause instanceof DropBackendClause) {
             // drop backend
             DropBackendClause dropBackendClause = (DropBackendClause) alterClause;

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/AddBackendClause.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/AddBackendClause.java
@@ -18,6 +18,7 @@
 package org.apache.doris.analysis;
 
 import org.apache.doris.common.AnalysisException;
+import org.apache.doris.common.Config;
 import org.apache.doris.common.util.PropertyAnalyzer;
 import org.apache.doris.resource.Tag;
 
@@ -33,7 +34,7 @@ public class AddBackendClause extends BackendClause {
     // cluster that backend will be added to
     protected String destCluster;
     protected Map<String, String> properties = Maps.newHashMap();
-    private Tag tag;
+    private Map<String, String> tagMap;
 
     public AddBackendClause(List<String> hostPorts) {
         super(hostPorts);
@@ -57,14 +58,20 @@ public class AddBackendClause extends BackendClause {
         this.destCluster = destCluster;
     }
 
-    public Tag getTag() {
-        return tag;
+    public Map<String, String> getTagMap() {
+        return tagMap;
     }
 
     @Override
     public void analyze(Analyzer analyzer) throws AnalysisException {
         super.analyze(analyzer);
-        tag = PropertyAnalyzer.analyzeBackendTagProperties(properties, Tag.DEFAULT_BACKEND_TAG);
+        tagMap = PropertyAnalyzer.analyzeBackendTagsProperties(properties, Tag.DEFAULT_BACKEND_TAG);
+        if (!tagMap.containsKey(Tag.TYPE_LOCATION)) {
+            throw new AnalysisException(NEED_LOCATION_TAG_MSG);
+        }
+        if (!Config.enable_multi_tags && tagMap.size() > 1) {
+            throw new AnalysisException(MUTLI_TAG_DISABLED_MSG);
+        }
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/BackendClause.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/BackendClause.java
@@ -33,8 +33,8 @@ public class BackendClause extends AlterClause {
     protected List<String> hostPorts;
     protected List<Pair<String, Integer>> hostPortPairs;
 
-    public static final String MUTLI_TAG_DISABLED_MSG
-            = "Not support multi tags for Backend now. You can set 'enable_multi_tags=true' in fe.conf to enable this feature.";
+    public static final String MUTLI_TAG_DISABLED_MSG = "Not support multi tags for Backend now. "
+            + "You can set 'enable_multi_tags=true' in fe.conf to enable this feature.";
     public static final String NEED_LOCATION_TAG_MSG
             = "Backend must have location type tag. Eg: 'tag.location' = 'xxx'.";
 

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/BackendClause.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/BackendClause.java
@@ -33,6 +33,11 @@ public class BackendClause extends AlterClause {
     protected List<String> hostPorts;
     protected List<Pair<String, Integer>> hostPortPairs;
 
+    public static final String MUTLI_TAG_DISABLED_MSG
+            = "Not support multi tags for Backend now. You can set 'enable_multi_tags=true' in fe.conf to enable this feature.";
+    public static final String NEED_LOCATION_TAG_MSG
+            = "Backend must have location type tag. Eg: 'tag.location' = 'xxx'.";
+
     protected BackendClause(List<String> hostPorts) {
         super(AlterOpType.ALTER_OTHER);
         this.hostPorts = hostPorts;

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ModifyBackendClause.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ModifyBackendClause.java
@@ -18,6 +18,7 @@
 package org.apache.doris.analysis;
 
 import org.apache.doris.common.AnalysisException;
+import org.apache.doris.common.Config;
 import org.apache.doris.common.util.PropertyAnalyzer;
 import org.apache.doris.resource.Tag;
 
@@ -30,7 +31,7 @@ import java.util.Map;
 public class ModifyBackendClause extends BackendClause {
     protected Map<String, String> properties = Maps.newHashMap();
     protected Map<String, String> analyzedProperties = Maps.newHashMap();
-    private Tag tag = null;
+    private Map<String, String> tagMap = null;
     private Boolean isQueryDisabled = null;
     private Boolean isLoadDisabled = null;
 
@@ -42,13 +43,21 @@ public class ModifyBackendClause extends BackendClause {
     @Override
     public void analyze(Analyzer analyzer) throws AnalysisException {
         super.analyze(analyzer);
-        tag = PropertyAnalyzer.analyzeBackendTagProperties(properties, null);
+        tagMap = PropertyAnalyzer.analyzeBackendTagsProperties(properties, null);
         isQueryDisabled = PropertyAnalyzer.analyzeBackendDisableProperties(properties,
                 PropertyAnalyzer.PROPERTIES_DISABLE_QUERY, null);
         isLoadDisabled = PropertyAnalyzer.analyzeBackendDisableProperties(properties,
                 PropertyAnalyzer.PROPERTIES_DISABLE_LOAD, null);
-        if (tag != null) {
-            analyzedProperties.put(tag.type, tag.value);
+        if (!tagMap.isEmpty()) {
+            if (!tagMap.containsKey(Tag.TYPE_LOCATION)) {
+                throw new AnalysisException(NEED_LOCATION_TAG_MSG);
+            }
+            if (!Config.enable_multi_tags && tagMap.size() > 1) {
+                throw new AnalysisException(MUTLI_TAG_DISABLED_MSG);
+            }
+            for (Map.Entry<String, String> entry : tagMap.entrySet()) {
+                analyzedProperties.put("tag." + entry.getKey(), entry.getValue());
+            }
         }
         if (isQueryDisabled != null) {
             analyzedProperties.put(PropertyAnalyzer.PROPERTIES_DISABLE_QUERY, String.valueOf(isQueryDisabled));
@@ -57,13 +66,13 @@ public class ModifyBackendClause extends BackendClause {
             analyzedProperties.put(PropertyAnalyzer.PROPERTIES_DISABLE_LOAD, String.valueOf(isLoadDisabled));
         }
         if (!properties.isEmpty()) {
-            throw new AnalysisException("unknown properties setting for key ("
-                    + StringUtils.join(properties.keySet(), ",") + ")");
+            throw new AnalysisException(
+                    "unknown properties setting for key (" + StringUtils.join(properties.keySet(), ",") + ")");
         }
     }
 
-    public Tag getTag() {
-        return tag;
+    public Map<String, String> getTagMap() {
+        return tagMap;
     }
 
     public Boolean isQueryDisabled() {

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ModifyBackendClause.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ModifyBackendClause.java
@@ -55,6 +55,9 @@ public class ModifyBackendClause extends BackendClause {
             if (!Config.enable_multi_tags && tagMap.size() > 1) {
                 throw new AnalysisException(MUTLI_TAG_DISABLED_MSG);
             }
+            // TODO:
+            //  here we can add some privilege check so that only authorized user can modify specified type of tag.
+            //  For example, only root user can set tag with type 'computation'
             for (Map.Entry<String, String> entry : tagMap.entrySet()) {
                 analyzedProperties.put("tag." + entry.getKey(), entry.getValue());
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
@@ -1445,11 +1445,11 @@ public class OlapTable extends Table {
                     if (be == null) {
                         continue;
                     }
-                    short num = currentReplicaAlloc.getOrDefault(be.getTag(), (short) 0);
-                    currentReplicaAlloc.put(be.getTag(), (short) (num + 1));
-                    List<Long> beIds = tag2beIds.getOrDefault(be.getTag(), Lists.newArrayList());
+                    short num = currentReplicaAlloc.getOrDefault(be.getLocationTag(), (short) 0);
+                    currentReplicaAlloc.put(be.getLocationTag(), (short) (num + 1));
+                    List<Long> beIds = tag2beIds.getOrDefault(be.getLocationTag(), Lists.newArrayList());
                     beIds.add(beId);
-                    tag2beIds.put(be.getTag(), beIds);
+                    tag2beIds.put(be.getLocationTag(), beIds);
                 }
                 if (!currentReplicaAlloc.equals(replicaAlloc.getAllocMap())) {
                     throw new DdlException("The relica allocation is " + currentReplicaAlloc.toString()
@@ -1840,8 +1840,8 @@ public class OlapTable extends Table {
                         if (be == null) {
                             continue;
                         }
-                        short num = curMap.getOrDefault(be.getTag(), (short) 0);
-                        curMap.put(be.getTag(), (short) (num + 1));
+                        short num = curMap.getOrDefault(be.getLocationTag(), (short) 0);
+                        curMap.put(be.getLocationTag(), (short) (num + 1));
                     }
                     if (!curMap.equals(allocMap)) {
                         throw new UserException("replica allocation of tablet " + tablet.getId() + " is not expected"

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Tablet.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Tablet.java
@@ -463,8 +463,8 @@ public class Tablet extends MetaObject implements Writable {
 
             versions.add(replica.getVersionCount());
 
-            short curNum = currentAllocMap.getOrDefault(backend.getTag(), (short) 0);
-            currentAllocMap.put(backend.getTag(), (short) (curNum + 1));
+            short curNum = currentAllocMap.getOrDefault(backend.getLocationTag(), (short) 0);
+            currentAllocMap.put(backend.getLocationTag(), (short) (curNum + 1));
         }
 
         // 1. alive replicas are not enough

--- a/fe/fe-core/src/main/java/org/apache/doris/clone/ClusterLoadStatistic.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/ClusterLoadStatistic.java
@@ -90,8 +90,8 @@ public class ClusterLoadStatistic {
                 // So balance will be blocked.
                 continue;
             }
-            BackendLoadStatistic beStatistic = new BackendLoadStatistic(backend.getId(),
-                    backend.getOwnerClusterName(), backend.getTag(), infoService, invertedIndex);
+            BackendLoadStatistic beStatistic = new BackendLoadStatistic(backend.getId(), backend.getOwnerClusterName(),
+                    backend.getLocationTag(), infoService, invertedIndex);
             try {
                 beStatistic.init();
             } catch (LoadBalanceException e) {

--- a/fe/fe-core/src/main/java/org/apache/doris/clone/ColocateTableCheckerAndBalancer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/ColocateTableCheckerAndBalancer.java
@@ -587,13 +587,12 @@ public class ColocateTableCheckerAndBalancer extends MasterDaemon {
         Backend be = infoService.getBackend(backendId);
         if (be == null) {
             return false;
-        } else if (!be.getTag().equals(tag) || excludedBeIds.contains(be.getId())) {
+        } else if (!be.getLocationTag().equals(tag) || excludedBeIds.contains(be.getId())) {
             return false;
         } else if (!be.isScheduleAvailable()) {
             // 1. BE is dead longer than "delaySecond"
             // 2. BE is under decommission
-            if ((!be.isAlive() && (currTime - be.getLastUpdateMs()) > delaySecond * 1000L)
-                    || be.isDecommissioned()) {
+            if ((!be.isAlive() && (currTime - be.getLastUpdateMs()) > delaySecond * 1000L) || be.isDecommissioned()) {
                 return false;
             }
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/clone/TabletScheduler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/TabletScheduler.java
@@ -714,8 +714,8 @@ public class TabletScheduler extends MasterDaemon {
         for (Replica replica : replicas) {
             Backend be = infoService.getBackend(replica.getBackendId());
             if (be != null && be.isScheduleAvailable() && replica.isAlive() && !replica.tooSlow()) {
-                Short num = currentAllocMap.getOrDefault(be.getTag(), (short) 0);
-                currentAllocMap.put(be.getTag(), (short) (num + 1));
+                Short num = currentAllocMap.getOrDefault(be.getLocationTag(), (short) 0);
+                currentAllocMap.put(be.getLocationTag(), (short) (num + 1));
             }
         }
 
@@ -979,7 +979,7 @@ public class TabletScheduler extends MasterDaemon {
         Map<Tag, Short> allocMap = tabletCtx.getReplicaAlloc().getAllocMap();
         for (Replica replica : replicas) {
             Backend be = infoService.getBackend(replica.getBackendId());
-            if (!allocMap.containsKey(be.getTag())) {
+            if (!allocMap.containsKey(be.getLocationTag())) {
                 deleteReplicaInternal(tabletCtx, replica, "not in valid tag", force);
                 return true;
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/Config.java
@@ -1693,4 +1693,7 @@ public class Config extends ConfigBase {
 
     @ConfField
     public static String default_storage_policy = "default_storage_policy";
+
+    @ConfField(mutable = false, masterOnly = true)
+    public static boolean enable_multi_tags = false;
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/common/proc/BackendsProcDir.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/proc/BackendsProcDir.java
@@ -164,7 +164,7 @@ public class BackendsProcDir implements ProcDirInterface {
             backendInfo.add(String.format("%.2f", used) + " %");
             backendInfo.add(String.format("%.2f", backend.getMaxDiskUsedPct() * 100) + " %");
             // tag
-            backendInfo.add(backend.getTag().toString());
+            backendInfo.add(backend.getLocationTag().toString());
             // err msg
             backendInfo.add(backend.getHeartbeatErrMsg());
             // version

--- a/fe/fe-core/src/main/java/org/apache/doris/common/proc/BackendsProcDir.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/proc/BackendsProcDir.java
@@ -163,8 +163,8 @@ public class BackendsProcDir implements ProcDirInterface {
             }
             backendInfo.add(String.format("%.2f", used) + " %");
             backendInfo.add(String.format("%.2f", backend.getMaxDiskUsedPct() * 100) + " %");
-            // tag
-            backendInfo.add(backend.getLocationTag().toString());
+            // tags
+            backendInfo.add(backend.getTagMapString());
             // err msg
             backendInfo.add(backend.getHeartbeatErrMsg());
             // version

--- a/fe/fe-core/src/main/java/org/apache/doris/common/proc/ClusterLoadStatByTag.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/proc/ClusterLoadStatByTag.java
@@ -72,7 +72,7 @@ public class ClusterLoadStatByTag implements ProcDirInterface {
         for (long beId : beIds) {
             Backend be = Catalog.getCurrentSystemInfo().getBackend(beId);
             if (be != null) {
-                tags.add(be.getTag());
+                tags.add(be.getLocationTag());
             }
         }
         return tags;

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/OlapScanNode.java
@@ -569,15 +569,15 @@ public class OlapScanNode extends ScanNode {
             for (Replica replica : replicas) {
                 Backend backend = Catalog.getCurrentSystemInfo().getBackend(replica.getBackendId());
                 if (backend == null || !backend.isAlive()) {
-                    LOG.debug("backend {} not exists or is not alive for replica {}",
-                            replica.getBackendId(), replica.getId());
+                    LOG.debug("backend {} not exists or is not alive for replica {}", replica.getBackendId(),
+                            replica.getId());
                     errs.add(replica.getId() + "'s backend " + replica.getBackendId() + " does not exist or not alive");
                     continue;
                 }
-                if (needCheckTags && !allowedTags.isEmpty() && !allowedTags.contains(backend.getTag())) {
-                    String err = String.format("Replica on backend %d with tag %s,"
-                                    + " which is not in user's resource tags: %s",
-                            backend.getId(), backend.getTag(), allowedTags);
+                if (needCheckTags && !allowedTags.isEmpty() && !allowedTags.contains(backend.getLocationTag())) {
+                    String err = String.format(
+                            "Replica on backend %d with tag %s," + " which is not in user's resource tags: %s",
+                            backend.getId(), backend.getLocationTag(), allowedTags);
                     if (LOG.isDebugEnabled()) {
                         LOG.debug(err);
                     }

--- a/fe/fe-core/src/main/java/org/apache/doris/resource/Tag.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/resource/Tag.java
@@ -23,11 +23,13 @@ import org.apache.doris.common.io.Writable;
 import org.apache.doris.persist.gson.GsonUtils;
 
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Maps;
 import com.google.gson.annotations.SerializedName;
 
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
+import java.util.Map;
 import java.util.Objects;
 
 /*
@@ -96,8 +98,18 @@ public class Tag implements Writable {
         return new Tag(type, value);
     }
 
+    public static Tag createNotCheck(String type, String value) {
+        return new Tag(type, value);
+    }
+
     public String toKey() {
         return type + "_" + value;
+    }
+
+    public Map<String, String> toMap() {
+        Map<String, String> map = Maps.newHashMap();
+        map.put(type, value);
+        return map;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/system/Backend.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/system/Backend.java
@@ -119,13 +119,13 @@ public class Backend implements Writable {
     // additional backendStatus information for BE, display in JSON format
     @SerializedName("backendStatus")
     private BackendStatus backendStatus = new BackendStatus();
-    @SerializedName("tag")
     // the locationTag is also saved in tagMap, use a single field here to avoid
     // creating this everytime we get it.
+    @SerializedName(value = "locationTag", alternate = {"tag"})
     private Tag locationTag = Tag.DEFAULT_BACKEND_TAG;
-    @SerializedName("tagMap")
     // tag type -> tag value.
     // A backend can only be assigned to one tag type, and each type can only have one value.
+    @SerializedName("tagMap")
     private Map<String, String> tagMap = Maps.newHashMap();
 
     public Backend() {

--- a/fe/fe-core/src/main/java/org/apache/doris/system/Backend.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/system/Backend.java
@@ -550,22 +550,24 @@ public class Backend implements Writable {
      * But in new version, a Backend can have multi tag, so we need to put locationTag to
      * the new tagMap
      */
-    private void convertToTagMap() {
+    private void convertToTagMapAndSetLocationTag() {
         if (tagMap == null) {
             // When first upgrade from old version, tags may be null
             tagMap = Maps.newHashMap();
         }
-        // ATTN: here we use Tag.TYPE_LOCATION directly, not locationTag.type,
-        // because we need to make sure the previous tag must be a location type tag,
-        // and if not, convert it to location type.
-        tagMap.put(Tag.TYPE_LOCATION, locationTag.value);
-        locationTag = Tag.createNotCheck(Tag.TYPE_LOCATION, locationTag.value);
+        if (!tagMap.containsKey(Tag.TYPE_LOCATION)) {
+            // ATTN: here we use Tag.TYPE_LOCATION directly, not locationTag.type,
+            // because we need to make sure the previous tag must be a location type tag,
+            // and if not, convert it to location type.
+            tagMap.put(Tag.TYPE_LOCATION, locationTag.value);
+        }
+        locationTag = Tag.createNotCheck(Tag.TYPE_LOCATION, tagMap.get(Tag.TYPE_LOCATION));
     }
 
     public static Backend read(DataInput in) throws IOException {
         String json = Text.readString(in);
         Backend be = GsonUtils.GSON.fromJson(json, Backend.class);
-        be.convertToTagMap();
+        be.convertToTagMapAndSetLocationTag();
         return be;
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/system/BeSelectionPolicy.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/system/BeSelectionPolicy.java
@@ -98,11 +98,10 @@ public class BeSelectionPolicy {
     }
 
     public boolean isMatch(Backend backend) {
-        if (needScheduleAvailable && !backend.isScheduleAvailable()
-                || needQueryAvailable && !backend.isQueryAvailable()
-                || needLoadAvailable && !backend.isLoadAvailable()
-                || !resourceTags.isEmpty() && !resourceTags.contains(backend.getTag())
-                || storageMedium != null && !backend.hasSpecifiedStorageMedium(storageMedium)) {
+        if (needScheduleAvailable && !backend.isScheduleAvailable() || needQueryAvailable && !backend.isQueryAvailable()
+                || needLoadAvailable && !backend.isLoadAvailable() || !resourceTags.isEmpty() && !resourceTags.contains(
+                backend.getLocationTag()) || storageMedium != null && !backend.hasSpecifiedStorageMedium(
+                storageMedium)) {
             return false;
         }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/BackendTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/BackendTest.java
@@ -19,11 +19,13 @@ package org.apache.doris.catalog;
 
 import org.apache.doris.analysis.AccessTestUtil;
 import org.apache.doris.common.FeConstants;
+import org.apache.doris.resource.Tag;
 import org.apache.doris.system.Backend;
 import org.apache.doris.thrift.TDisk;
 import org.apache.doris.thrift.TStorageMedium;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -192,9 +194,15 @@ public class BackendTest {
         back1.updateOnce(1, 1, 1);
         back2 = new Backend(1, "a", 2);
         back2.updateOnce(1, 1, 1);
+        Map<String, String> tagMap = Maps.newHashMap();
+        tagMap.put(Tag.TYPE_LOCATION, "l1");
+        tagMap.put("compute", "c1");
+        back2.setTagMap(tagMap);
         Assert.assertFalse(back1.equals(back2));
 
-        Assert.assertEquals("Backend [id=1, host=a, heartbeatPort=1, alive=true, tag: {\"location\" : \"default\"}]", back1.toString());
+        Assert.assertEquals("Backend [id=1, host=a, heartbeatPort=1, alive=true, tags: {location=default}]",
+                back1.toString());
+        Assert.assertEquals("{\"compute\" : \"c1\", \"location\" : \"l1\"}", back2.getTagMapString());
 
         // 3. delete files
         dis.close();

--- a/fe/fe-core/src/test/java/org/apache/doris/clone/ColocateTableCheckerAndBalancerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/clone/ColocateTableCheckerAndBalancerTest.java
@@ -346,7 +346,7 @@ public class ColocateTableCheckerAndBalancerTest {
                 myBackend2.isScheduleAvailable();
                 result = true;
                 minTimes = 0;
-                myBackend2.getTag();
+                myBackend2.getLocationTag();
                 result = Tag.DEFAULT_BACKEND_TAG;
                 minTimes = 0;
 
@@ -363,7 +363,7 @@ public class ColocateTableCheckerAndBalancerTest {
                 myBackend3.getLastUpdateMs();
                 result = System.currentTimeMillis() - (Config.colocate_group_relocate_delay_second + 20) * 1000;
                 minTimes = 0;
-                myBackend3.getTag();
+                myBackend3.getLocationTag();
                 result = Tag.DEFAULT_BACKEND_TAG;
                 minTimes = 0;
 
@@ -380,7 +380,7 @@ public class ColocateTableCheckerAndBalancerTest {
                 myBackend4.getLastUpdateMs();
                 result = System.currentTimeMillis();
                 minTimes = 0;
-                myBackend4.getTag();
+                myBackend4.getLocationTag();
                 result = Tag.DEFAULT_BACKEND_TAG;
                 minTimes = 0;
 
@@ -397,7 +397,7 @@ public class ColocateTableCheckerAndBalancerTest {
                 myBackend5.isDecommissioned();
                 result = true;
                 minTimes = 0;
-                myBackend5.getTag();
+                myBackend5.getLocationTag();
                 result = Tag.DEFAULT_BACKEND_TAG;
                 minTimes = 0;
 
@@ -439,7 +439,7 @@ public class ColocateTableCheckerAndBalancerTest {
                 myBackend2.isScheduleAvailable();
                 result = true;
                 minTimes = 0;
-                myBackend2.getTag();
+                myBackend2.getLocationTag();
                 result = Tag.DEFAULT_BACKEND_TAG;
                 minTimes = 0;
 
@@ -456,7 +456,7 @@ public class ColocateTableCheckerAndBalancerTest {
                 myBackend3.getLastUpdateMs();
                 result = System.currentTimeMillis() - (Config.colocate_group_relocate_delay_second + 20) * 1000;
                 minTimes = 0;
-                myBackend3.getTag();
+                myBackend3.getLocationTag();
                 result = Tag.DEFAULT_BACKEND_TAG;
                 minTimes = 0;
 
@@ -473,7 +473,7 @@ public class ColocateTableCheckerAndBalancerTest {
                 myBackend4.getLastUpdateMs();
                 result = System.currentTimeMillis();
                 minTimes = 0;
-                myBackend4.getTag();
+                myBackend4.getLocationTag();
                 result = Tag.DEFAULT_BACKEND_TAG;
                 minTimes = 0;
 
@@ -490,7 +490,7 @@ public class ColocateTableCheckerAndBalancerTest {
                 myBackend5.isDecommissioned();
                 result = true;
                 minTimes = 0;
-                myBackend5.getTag();
+                myBackend5.getLocationTag();
                 result = Tag.DEFAULT_BACKEND_TAG;
                 minTimes = 0;
 
@@ -507,7 +507,7 @@ public class ColocateTableCheckerAndBalancerTest {
                 myBackend6.isDecommissioned();
                 result = false;
                 minTimes = 0;
-                myBackend6.getTag();
+                myBackend6.getLocationTag();
                 result = Tag.create(Tag.TYPE_LOCATION, "new_loc");
                 minTimes = 0;
 
@@ -524,7 +524,7 @@ public class ColocateTableCheckerAndBalancerTest {
                 myBackend7.isDecommissioned();
                 result = false;
                 minTimes = 0;
-                myBackend7.getTag();
+                myBackend7.getLocationTag();
                 result = Tag.DEFAULT_BACKEND_TAG;
                 minTimes = 0;
                 myBackend7.getId();

--- a/fe/fe-core/src/test/java/org/apache/doris/planner/ResourceTagQueryTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/planner/ResourceTagQueryTest.java
@@ -239,9 +239,9 @@ public class ResourceTagQueryTest {
             AlterSystemStmt stmt = (AlterSystemStmt) UtFrameUtils.parseAndAnalyzeStmt(stmtStr, connectContext);
             DdlExecutor.execute(Catalog.getCurrentCatalog(), stmt);
         }
-        Assert.assertEquals(tag1, backends.get(0).getTag());
-        Assert.assertEquals(tag1, backends.get(1).getTag());
-        Assert.assertEquals(tag1, backends.get(2).getTag());
+        Assert.assertEquals(tag1, backends.get(0).getLocationTag());
+        Assert.assertEquals(tag1, backends.get(1).getLocationTag());
+        Assert.assertEquals(tag1, backends.get(2).getLocationTag());
 
         queryStr = "explain select * from test.tbl1";
         explainString = UtFrameUtils.getSQLPlanOrErrorMsg(connectContext, queryStr);
@@ -251,7 +251,8 @@ public class ResourceTagQueryTest {
         // for now, 3 backends with tag zone1, 2 with tag default, so table is not stable.
         ExceptionChecker.expectThrows(UserException.class, () -> tbl.checkReplicaAllocation());
         // alter table's replication allocation to zone1:2 and default:1
-        String alterStr = "alter table test.tbl1 modify partition (p1, p2, p3) set ('replication_allocation' = 'tag.location.zone1:2, tag.location.default:1')";
+        String alterStr
+                = "alter table test.tbl1 modify partition (p1, p2, p3) set ('replication_allocation' = 'tag.location.zone1:2, tag.location.default:1')";
         ExceptionChecker.expectThrowsNoException(() -> alterTable(alterStr));
         Map<Tag, Short> expectedAllocMap = Maps.newHashMap();
         expectedAllocMap.put(Tag.DEFAULT_BACKEND_TAG, (short) 1);

--- a/fe/fe-core/src/test/java/org/apache/doris/system/SystemInfoServiceTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/system/SystemInfoServiceTest.java
@@ -152,22 +152,22 @@ public class SystemInfoServiceTest {
 
         Tag taga = Tag.create(Tag.TYPE_LOCATION, "taga");
         Tag tagb = Tag.create(Tag.TYPE_LOCATION, "tagb");
-        be1.setTag(taga);
-        be2.setTag(taga);
-        be3.setTag(tagb);
-        be4.setTag(tagb);
-        be5.setTag(tagb);
+        be1.setTagMap(taga.toMap());
+        be2.setTagMap(taga.toMap());
+        be3.setTagMap(tagb.toMap());
+        be4.setTagMap(tagb.toMap());
+        be5.setTagMap(tagb.toMap());
 
-        BeSelectionPolicy policy7 = new BeSelectionPolicy.Builder().needQueryAvailable()
-                .addTags(Sets.newHashSet(taga)).build();
+        BeSelectionPolicy policy7 = new BeSelectionPolicy.Builder().needQueryAvailable().addTags(Sets.newHashSet(taga))
+                .build();
         Assert.assertEquals(1, infoService.selectBackendIdsByPolicy(policy7, 1).size());
         Assert.assertEquals(2, infoService.selectBackendIdsByPolicy(policy7, 2).size());
         Assert.assertTrue(infoService.selectBackendIdsByPolicy(policy7, 2).contains(10001L));
         Assert.assertTrue(infoService.selectBackendIdsByPolicy(policy7, 2).contains(10002L));
         Assert.assertEquals(0, infoService.selectBackendIdsByPolicy(policy7, 3).size());
 
-        BeSelectionPolicy policy8 = new BeSelectionPolicy.Builder()
-                .needQueryAvailable().addTags(Sets.newHashSet(tagb)).build();
+        BeSelectionPolicy policy8 = new BeSelectionPolicy.Builder().needQueryAvailable().addTags(Sets.newHashSet(tagb))
+                .build();
         Assert.assertEquals(3, infoService.selectBackendIdsByPolicy(policy8, 3).size());
         Assert.assertTrue(infoService.selectBackendIdsByPolicy(policy8, 3).contains(10003L));
         Assert.assertTrue(infoService.selectBackendIdsByPolicy(policy8, 3).contains(10004L));
@@ -209,7 +209,7 @@ public class SystemInfoServiceTest {
         // 8. check same host
         addBackend(10006, "192.168.1.1", 9051);
         Backend be6 = infoService.getBackend(10006);
-        be6.setTag(taga);
+        be6.setTagMap(taga.toMap());
         be6.setAlive(true);
         addDisk(be1, "path1", TStorageMedium.HDD, 200 * 1024 * 1024L, 100 * 1024 * 1024L);
         addDisk(be6, "path1", TStorageMedium.HDD, 200 * 1024 * 1024L, 100 * 1024 * 1024L);


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

Previously, Doris only support set one tag for a Backend, like: "tag.location" = "default".
This CL mainly changes:

Support multi tag for a single Backend

`alter system modify backend "host:port" set ("tag.location" = "default", "tag.compute" = "c1");`

And there are some limitations:

1. The tag of Backend must contain the tag type of location(tag.location).
     This ensures that the original logic will not change.
2. There can only be one tag type on the same BE.
    This ensures that the original logic for replica allocation remains unchanged.
3. And a new FE config `enable_multi_tags` to enable or disable it. Default is `false`.

## Checklist(Required)

1. Does it affect the original behavior: (No)
3. Has unit tests been added: (Yes)
4. Has document been added or modified: (Yes)
5. Does it need to update dependencies: (No)
6. Are there any changes that cannot be rolled back: (Yes)
    The persist meta of Backend is changed.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
