### PR TITLE
[refactor](be)remove redundant code in column writer

### DIFF
--- a/be/src/olap/rowset/segment_v2/column_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/column_writer.cpp
@@ -18,8 +18,6 @@
 #include "olap/rowset/segment_v2/column_writer.h"
 
 #include <cstddef>
-#include <cstdint>
-#include <type_traits>
 
 #include "common/logging.h"
 #include "env/env.h"

--- a/be/src/olap/rowset/segment_v2/column_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/column_writer.cpp
@@ -360,7 +360,7 @@ Status ScalarColumnWriter::append_data_in_current_page(const uint8_t* data, size
 
 Status ScalarColumnWriter::append_data_in_current_page(const uint8_t** data, size_t* num_written) {
     RETURN_IF_ERROR(append_data_in_current_page(*data, num_written));
-    data += get_field()->size() * (*num_written);
+    *data += get_field()->size() * (*num_written);
     return Status::OK();
 }
 

--- a/be/src/olap/rowset/segment_v2/column_writer.h
+++ b/be/src/olap/rowset/segment_v2/column_writer.h
@@ -185,7 +185,6 @@ public:
     }
     Status append_data(const uint8_t** ptr, size_t num_rows) override;
 
-
     // used for append not null data. When page is full, will append data not reach num_rows.
     template <typename DataPtr>
     Status append_data_in_current_page(DataPtr ptr, size_t* num_written);

--- a/be/src/olap/rowset/segment_v2/column_writer.h
+++ b/be/src/olap/rowset/segment_v2/column_writer.h
@@ -17,10 +17,7 @@
 
 #pragma once
 
-#include <cstddef>
 #include <memory> // for unique_ptr
-#include <type_traits>
-#include <variant>
 
 #include "common/status.h"         // for Status
 #include "gen_cpp/segment_v2.pb.h" // for EncodingTypePB

--- a/be/src/olap/rowset/segment_v2/column_writer.h
+++ b/be/src/olap/rowset/segment_v2/column_writer.h
@@ -17,7 +17,10 @@
 
 #pragma once
 
+#include <cstddef>
 #include <memory> // for unique_ptr
+#include <type_traits>
+#include <variant>
 
 #include "common/status.h"         // for Status
 #include "gen_cpp/segment_v2.pb.h" // for EncodingTypePB
@@ -133,12 +136,6 @@ public:
     // used for append not null data.
     virtual Status append_data(const uint8_t** ptr, size_t num_rows) = 0;
 
-    // used for append not null data. When page is full, will append data not reach num_rows.
-    virtual Status append_data_in_current_page(const uint8_t** ptr, size_t* num_rows) = 0;
-
-    // used for append not null data. When page is full, will append data not reach num_rows.
-    virtual Status append_data_in_current_page(const uint8_t* ptr, size_t* num_rows) = 0;
-
     bool is_nullable() const { return _is_nullable; }
 
     Field* get_field() const { return _field.get(); }
@@ -188,8 +185,10 @@ public:
     }
     Status append_data(const uint8_t** ptr, size_t num_rows) override;
 
-    Status append_data_in_current_page(const uint8_t** ptr, size_t* num_rows) override;
-    Status append_data_in_current_page(const uint8_t* ptr, size_t* num_rows) override;
+
+    // used for append not null data. When page is full, will append data not reach num_rows.
+    template <typename DataPtr>
+    Status append_data_in_current_page(DataPtr ptr, size_t* num_written);
 
 private:
     std::unique_ptr<PageBuilder> _page_builder;
@@ -267,14 +266,6 @@ public:
     Status init() override;
 
     Status append_data(const uint8_t** ptr, size_t num_rows) override;
-    Status append_data_in_current_page(const uint8_t** ptr, size_t* num_rows) override {
-        return Status::NotSupported(
-                "array writer has no data, can not append_data_in_current_page");
-    }
-    Status append_data_in_current_page(const uint8_t* ptr, size_t* num_rows) override {
-        return Status::NotSupported(
-                "array writer has no data, can not append_data_in_current_page");
-    }
 
     uint64_t estimate_buffer_size() override;
 

--- a/be/src/olap/rowset/segment_v2/column_writer.h
+++ b/be/src/olap/rowset/segment_v2/column_writer.h
@@ -186,8 +186,9 @@ public:
     Status append_data(const uint8_t** ptr, size_t num_rows) override;
 
     // used for append not null data. When page is full, will append data not reach num_rows.
-    template <typename DataPtr>
-    Status append_data_in_current_page(DataPtr ptr, size_t* num_written);
+    Status append_data_in_current_page(const uint8_t** ptr, size_t* num_written);
+
+    Status append_data_in_current_page(const uint8_t* ptr, size_t* num_written);
 
 private:
     std::unique_ptr<PageBuilder> _page_builder;


### PR DESCRIPTION
remove redundant code in column writer

# Proposed changes

Issue Number: #10914 

## Problem Summary:

There are redundant code in column writer's two kind of flush_data_in_current_page function implementations. It can simplified as one single function using template.

## Checklist(Required)

1. Does it affect the original behavior: NO
2. Has unit tests been added: No
3. Has document been added or modified: No
4. Does it need to update dependencies: No
5. Are there any changes that cannot be rolled back: No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
