### PR TITLE
[test] add an option to let regression stop when a failure happen

### DIFF
--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/Config.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/Config.groovy
@@ -58,6 +58,7 @@ class Config {
     public boolean generateOutputFile
     public boolean forceGenerateOutputFile
     public boolean randomOrder
+    public boolean stopWhenFail
 
     public Properties otherConfigs = new Properties()
 
@@ -176,6 +177,7 @@ class Config {
         config.actionParallel = Integer.parseInt(cmd.getOptionValue(actionParallelOpt, "10"))
         config.times = Integer.parseInt(cmd.getOptionValue(timesOpt, "1"))
         config.randomOrder = cmd.hasOption(randomOrderOpt)
+        config.stopWhenFail = cmd.hasOption(stopWhenFail)
         config.withOutLoadData = cmd.hasOption(withOutLoadDataOpt)
 
         Properties props = cmd.getOptionProperties("conf")
@@ -331,6 +333,11 @@ class Config {
         if (config.randomOrder == null) {
             config.randomOrder = false
             log.info("set randomOrder to false because not specify.".toString())
+        }
+
+        if (config.stopWhenFail == null) {
+            config.stopWhenFail = false
+            log.info("set stopWhenFail to false because not specify.".toString())
         }
 
         if (config.withOutLoadData == null) {

--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/ConfigOptions.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/ConfigOptions.groovy
@@ -53,6 +53,7 @@ class ConfigOptions {
     static Option suiteParallelOpt
     static Option actionParallelOpt
     static Option randomOrderOpt
+    static Option stopWhenFail
     static Option timesOpt
     static Option withOutLoadDataOpt
 
@@ -270,6 +271,11 @@ class ConfigOptions {
                 .hasArg(false)
                 .desc("run tests in random order")
                 .build()
+        stopWhenFail = Option.builder("stopWhenFail")
+                .required(false)
+                .hasArg(false)
+                .desc("stop when a failure happens")
+                .build()
         timesOpt = Option.builder("times")
                 .argName("times")
                 .required(false)
@@ -312,6 +318,7 @@ class ConfigOptions {
                 .addOption(suiteParallelOpt)
                 .addOption(actionParallelOpt)
                 .addOption(randomOrderOpt)
+                .addOption(stopWhenFail)
                 .addOption(timesOpt)
                 .addOption(withOutLoadDataOpt)
 

--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/suite/ScriptContext.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/suite/ScriptContext.groovy
@@ -121,6 +121,9 @@ class ScriptContext implements Closeable {
                     log.info("Run ${suiteName} in ${file.absolutePath} succeed".toString())
                 } catch (Throwable t) {
                     log.error("Run ${suiteName} in ${file.absolutePath} failed".toString(), t)
+                    if (config.stopWhenFail) {
+                        System.exit(-1);
+                    }
                     try {
                         // fail
                         if (suite != null) {


### PR DESCRIPTION
For community pipeline, it is a waste of resource to run tests with errors.

# Proposed changes

Issue Number: close #xxx

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
