### PR TITLE
[feature-wip](multi-catalog) Optimize threads and thrift interface of FileScanNode

### DIFF
--- a/be/src/vec/exec/file_arrow_scanner.cpp
+++ b/be/src/vec/exec/file_arrow_scanner.cpp
@@ -55,7 +55,7 @@ Status FileArrowScanner::_open_next_reader() {
         const TFileRangeDesc& range = _ranges[_next_range++];
         std::unique_ptr<FileReader> file_reader;
         FileReader* hdfs_reader = nullptr;
-        RETURN_IF_ERROR(HdfsReaderWriter::create_reader(range.hdfs_params, range.path,
+        RETURN_IF_ERROR(HdfsReaderWriter::create_reader(_params.hdfs_params, range.path,
                                                         range.start_offset, &hdfs_reader));
         file_reader.reset(new BufferedReader(_profile, hdfs_reader));
         RETURN_IF_ERROR(file_reader->open());

--- a/be/src/vec/exec/file_scan_node.h
+++ b/be/src/vec/exec/file_scan_node.h
@@ -105,7 +105,6 @@ private:
 
     Status _process_status;
 
-    std::vector<std::thread> _scanner_threads;
     std::vector<std::promise<Status>> _scanners_status;
 
     int _max_buffered_batches;

--- a/be/src/vec/exec/file_text_scanner.cpp
+++ b/be/src/vec/exec/file_text_scanner.cpp
@@ -156,7 +156,7 @@ Status FileTextScanner::_open_file_reader() {
     const TFileRangeDesc& range = _ranges[_next_range];
 
     FileReader* hdfs_reader = nullptr;
-    RETURN_IF_ERROR(HdfsReaderWriter::create_reader(range.hdfs_params, range.path,
+    RETURN_IF_ERROR(HdfsReaderWriter::create_reader(_params.hdfs_params, range.path,
                                                     range.start_offset, &hdfs_reader));
     _cur_file_reader.reset(new BufferedReader(_profile, hdfs_reader));
     return _cur_file_reader->open();
@@ -171,7 +171,7 @@ Status FileTextScanner::_open_line_reader() {
     const TFileRangeDesc& range = _ranges[_next_range];
     int64_t size = range.size;
     if (range.start_offset != 0) {
-        if (range.format_type != TFileFormatType::FORMAT_CSV_PLAIN) {
+        if (_params.format_type != TFileFormatType::FORMAT_CSV_PLAIN) {
             std::stringstream ss;
             ss << "For now we do not support split compressed file";
             return Status::InternalError(ss.str());
@@ -182,14 +182,14 @@ Status FileTextScanner::_open_line_reader() {
     }
 
     // open line reader
-    switch (range.format_type) {
+    switch (_params.format_type) {
     case TFileFormatType::FORMAT_CSV_PLAIN:
         _cur_line_reader = new PlainTextLineReader(_profile, _cur_file_reader.get(), nullptr, size,
                                                    _line_delimiter, _line_delimiter_length);
         break;
     default: {
         std::stringstream ss;
-        ss << "Unknown format type, cannot init line reader, type=" << range.format_type;
+        ss << "Unknown format type, cannot init line reader, type=" << _params.format_type;
         return Status::InternalError(ss.str());
     }
     }

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -226,29 +226,28 @@ struct TFileScanSlotInfo {
 }
 
 struct TFileScanRangeParams {
+  1: optional Types.TFileType file_type;
+  2: optional TFileFormatType format_type;
   // use src_tuple_id to get all slots from src table include both file slot and partition slot.
-  1: optional Types.TTupleId src_tuple_id;
+  3: optional Types.TTupleId src_tuple_id;
   // num_of_columns_from_file can spilt the all_file_slot and all_partition_slot
-  2: optional i32 num_of_columns_from_file;
+  4: optional i32 num_of_columns_from_file;
   // all selected slots which may compose from file and partiton value.
-  3: optional list<TFileScanSlotInfo> required_slots;
+  5: optional list<TFileScanSlotInfo> required_slots;
 
-  4: optional TFileTextScanRangeParams text_params;
+  6: optional THdfsParams hdfs_params;
+  7: optional TFileTextScanRangeParams text_params;
 }
 
 struct TFileRangeDesc {
-    1: optional Types.TFileType file_type;
-    2: optional TFileFormatType format_type;
     // Path of this range
-    3: optional string path;
+    1: optional string path;
     // Offset of this file start
-    4: optional i64 start_offset;
+    2: optional i64 start_offset;
     // Size of this range, if size = -1, this means that will read to the end of file
-    5: optional i64 size;
+    3: optional i64 size;
     // columns parsed from file path should be after the columns read from file
-    6: optional list<string> columns_from_path;
-
-    7: optional THdfsParams hdfs_params;
+    4: optional list<string> columns_from_path;
 }
 
 // HDFS file scan range


### PR DESCRIPTION
# Proposed changes

Optimize threads and thrift interface of FileScanNode

## Problem Summary:

FileScanNode in be will launch as many threads as the number of splits.
The thrift interface of FileScanNode is excessive redundant.

## Checklist(Required)

1. Does it affect the original behavior: (No)
2. Has unit tests been added: (No)
3. Has document been added or modified: (No)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
