### PR TITLE
[Bugfix](compaction) fix uniq key compaction bug

### DIFF
--- a/be/src/olap/generic_iterators.h
+++ b/be/src/olap/generic_iterators.h
@@ -25,7 +25,7 @@ namespace doris {
 //
 // Inputs iterators' ownership is taken by created merge iterator. And client
 // should delete returned iterator after usage.
-RowwiseIterator* new_merge_iterator(std::vector<RowwiseIterator*> inputs, std::shared_ptr<MemTracker> parent, int sequence_id_idx, bool is_unique);
+RowwiseIterator* new_merge_iterator(std::vector<RowwiseIterator*> inputs, std::shared_ptr<MemTracker> parent, int sequence_id_idx, bool is_unique, uint64_t* merged_rows);
 
 // Create a union iterator for input iterators. Union iterator will read
 // input iterators one by one.

--- a/be/src/olap/reader.cpp
+++ b/be/src/olap/reader.cpp
@@ -226,6 +226,7 @@ OLAPStatus TabletReader::_capture_rs_readers(const ReaderParams& read_params,
     _reader_context.is_unique = tablet()->keys_type() == UNIQUE_KEYS;
 
     *valid_rs_readers = *rs_readers;
+    _reader_context.merged_rows = &_merged_rows;
 
     return OLAP_SUCCESS;
 }

--- a/be/src/olap/rowset/beta_rowset_reader.cpp
+++ b/be/src/olap/rowset/beta_rowset_reader.cpp
@@ -120,14 +120,14 @@ OLAPStatus BetaRowsetReader::init(RowsetReaderContext* read_context) {
         if (read_context->need_ordered_result &&
             _rowset->rowset_meta()->is_segments_overlapping()) {
             final_iterator = vectorized::new_merge_iterator(
-                    iterators, _parent_tracker, read_context->sequence_id_idx,
-                    read_context->is_unique, read_context->tablet_columns_convert_to_null_set);
+                    iterators, _parent_tracker, read_context->sequence_id_idx, read_context->is_unique,
+                    read_context->merged_rows, read_context->tablet_columns_convert_to_null_set);
         } else {
             final_iterator = vectorized::new_union_iterator(iterators, _parent_tracker);
         }
     } else {
         if (read_context->need_ordered_result && _rowset->rowset_meta()->is_segments_overlapping()) {
-            final_iterator = new_merge_iterator(iterators, _parent_tracker, read_context->sequence_id_idx, read_context->is_unique);
+            final_iterator = new_merge_iterator(iterators, _parent_tracker, read_context->sequence_id_idx, read_context->is_unique, read_context->merged_rows);
         } else {
             final_iterator = new_union_iterator(iterators, _parent_tracker);
         }

--- a/be/src/olap/rowset/rowset_reader_context.h
+++ b/be/src/olap/rowset/rowset_reader_context.h
@@ -64,6 +64,7 @@ struct RowsetReaderContext {
     int batch_size = 1024;
     bool is_vec = false;
     bool is_unique = false;
+    uint64_t* merged_rows = nullptr;
 
     // need pass this info to VMergeIterator
     std::unordered_set<uint32_t>* tablet_columns_convert_to_null_set = nullptr;

--- a/be/src/vec/olap/vgeneric_iterators.h
+++ b/be/src/vec/olap/vgeneric_iterators.h
@@ -29,6 +29,7 @@ namespace vectorized {
 // should delete returned iterator after usage.
 RowwiseIterator* new_merge_iterator(
         std::vector<RowwiseIterator*>& inputs, std::shared_ptr<MemTracker> parent, int sequence_id_idx, bool is_unique,
+        uint64_t* merged_rows,
         const std::unordered_set<uint32_t>* tablet_columns_convert_to_null_set = nullptr);
 
 // Create a union iterator for input iterators. Union iterator will read


### PR DESCRIPTION
One rowset multi segments in uniq key compaction, segments rows will be
merged in generic_iterator but merged_rows not increased。
Compaction will failed in check_correctness, and make a tablet with
too much versions which lead to -235 load error.

# Proposed changes

Issue Number: close #xxx

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
