### PR TITLE
[fix](nereids) Fix the substring compilation error caused by merge

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/Substring.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/Substring.java
@@ -18,7 +18,7 @@
 package org.apache.doris.nereids.trees.expressions.functions;
 
 import org.apache.doris.nereids.trees.expressions.Expression;
-import org.apache.doris.nereids.trees.expressions.Literal;
+import org.apache.doris.nereids.trees.expressions.IntegerLiteral;
 import org.apache.doris.nereids.trees.expressions.TernaryExpression;
 import org.apache.doris.nereids.types.DataType;
 import org.apache.doris.nereids.types.StringType;
@@ -37,7 +37,7 @@ public class Substring extends BoundFunction implements TernaryExpression {
     }
 
     public Substring(Expression str, Expression pos) {
-        super("substring", str, pos, new Literal(Integer.MAX_VALUE));
+        super("substring", str, pos, new IntegerLiteral(Integer.MAX_VALUE));
     }
 
     @Override


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:
Compilation error after merging due to Literal refactoring.
Compilation failure:
fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/Substring.java:[40,38] org.apache.doris.nereids.trees.expressions.Literal is abstract; cannot be instantiated

## Checklist(Required)

1. Does it affect the original behavior: (No)
2. Has unit tests been added: (No Need)
3. Has document been added or modified: (No Need)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
