### PR TITLE
[Bug](compaction) fix uniq key compaction bug

### DIFF
--- a/be/src/olap/generic_iterators.h
+++ b/be/src/olap/generic_iterators.h
@@ -28,7 +28,7 @@ namespace doris {
 // Inputs iterators' ownership is taken by created merge iterator. And client
 // should delete returned iterator after usage.
 RowwiseIterator* new_merge_iterator(std::vector<RowwiseIterator*> inputs, int sequence_id_idx,
-                                    bool is_unique);
+                                    bool is_unique, uint64_t* merged_rows);
 
 // Create a union iterator for input iterators. Union iterator will read
 // input iterators one by one.

--- a/be/src/olap/reader.cpp
+++ b/be/src/olap/reader.cpp
@@ -224,6 +224,7 @@ Status TabletReader::_capture_rs_readers(const ReaderParams& read_params,
     _reader_context.sequence_id_idx = _sequence_col_idx;
     _reader_context.batch_size = _batch_size;
     _reader_context.is_unique = tablet()->keys_type() == UNIQUE_KEYS;
+    _reader_context.merged_rows = &_merged_rows;
 
     *valid_rs_readers = *rs_readers;
 

--- a/be/src/olap/rowset/beta_rowset_reader.cpp
+++ b/be/src/olap/rowset/beta_rowset_reader.cpp
@@ -114,7 +114,8 @@ Status BetaRowsetReader::init(RowsetReaderContext* read_context) {
         if (read_context->need_ordered_result &&
             _rowset->rowset_meta()->is_segments_overlapping()) {
             final_iterator = vectorized::new_merge_iterator(
-                    iterators, read_context->sequence_id_idx, read_context->is_unique);
+                    iterators, read_context->sequence_id_idx, read_context->is_unique,
+                    read_context->merged_rows);
         } else {
             final_iterator = vectorized::new_union_iterator(iterators);
         }
@@ -122,7 +123,7 @@ Status BetaRowsetReader::init(RowsetReaderContext* read_context) {
         if (read_context->need_ordered_result &&
             _rowset->rowset_meta()->is_segments_overlapping()) {
             final_iterator = new_merge_iterator(iterators, read_context->sequence_id_idx,
-                                                read_context->is_unique);
+                                                read_context->is_unique, read_context->merged_rows);
         } else {
             final_iterator = new_union_iterator(iterators);
         }

--- a/be/src/olap/rowset/rowset_reader_context.h
+++ b/be/src/olap/rowset/rowset_reader_context.h
@@ -64,6 +64,8 @@ struct RowsetReaderContext {
     int batch_size = 1024;
     bool is_vec = false;
     bool is_unique = false;
+    //record row num merged in generic iterator
+    uint64_t* merged_rows = nullptr;
 };
 
 } // namespace doris

--- a/be/src/vec/olap/vgeneric_iterators.h
+++ b/be/src/vec/olap/vgeneric_iterators.h
@@ -28,7 +28,7 @@ namespace vectorized {
 // Inputs iterators' ownership is taken by created merge iterator. And client
 // should delete returned iterator after usage.
 RowwiseIterator* new_merge_iterator(std::vector<RowwiseIterator*>& inputs, int sequence_id_idx,
-                                    bool is_unique);
+                                    bool is_unique, uint64_t* merged_rows);
 
 // Create a union iterator for input iterators. Union iterator will read
 // input iterators one by one.

--- a/be/test/olap/generic_iterators_test.cpp
+++ b/be/test/olap/generic_iterators_test.cpp
@@ -122,7 +122,7 @@ TEST(GenericIteratorsTest, MergeAgg) {
     inputs.push_back(new_auto_increment_iterator(schema, 200));
     inputs.push_back(new_auto_increment_iterator(schema, 300));
 
-    auto iter = new_merge_iterator(std::move(inputs), -1, false);
+    auto iter = new_merge_iterator(std::move(inputs), -1, false, nullptr);
     StorageReadOptions opts;
     auto st = iter->init(opts);
     EXPECT_TRUE(st.ok());
@@ -164,7 +164,7 @@ TEST(GenericIteratorsTest, MergeUnique) {
     inputs.push_back(new_auto_increment_iterator(schema, 200));
     inputs.push_back(new_auto_increment_iterator(schema, 300));
 
-    auto iter = new_merge_iterator(std::move(inputs), -1, true);
+    auto iter = new_merge_iterator(std::move(inputs), -1, true, nullptr);
     StorageReadOptions opts;
     auto st = iter->init(opts);
     EXPECT_TRUE(st.ok());

--- a/be/test/vec/exec/vgeneric_iterators_test.cpp
+++ b/be/test/vec/exec/vgeneric_iterators_test.cpp
@@ -145,7 +145,7 @@ TEST(VGenericIteratorsTest, MergeAgg) {
     inputs.push_back(vectorized::new_auto_increment_iterator(schema, 200));
     inputs.push_back(vectorized::new_auto_increment_iterator(schema, 300));
 
-    auto iter = vectorized::new_merge_iterator(inputs, -1, false);
+    auto iter = vectorized::new_merge_iterator(inputs, -1, false, nullptr);
     StorageReadOptions opts;
     auto st = iter->init(opts);
     EXPECT_TRUE(st.ok());
@@ -194,7 +194,7 @@ TEST(VGenericIteratorsTest, MergeUnique) {
     inputs.push_back(vectorized::new_auto_increment_iterator(schema, 200));
     inputs.push_back(vectorized::new_auto_increment_iterator(schema, 300));
 
-    auto iter = vectorized::new_merge_iterator(inputs, -1, true);
+    auto iter = vectorized::new_merge_iterator(inputs, -1, true, nullptr);
     StorageReadOptions opts;
     auto st = iter->init(opts);
     EXPECT_TRUE(st.ok());
@@ -316,7 +316,7 @@ TEST(VGenericIteratorsTest, MergeWithSeqColumn) {
                                                  seq_id_in_every_file));
     }
 
-    auto iter = vectorized::new_merge_iterator(inputs, seq_column_id, true);
+    auto iter = vectorized::new_merge_iterator(inputs, seq_column_id, true, nullptr);
     StorageReadOptions opts;
     auto st = iter->init(opts);
     EXPECT_TRUE(st.ok());


### PR DESCRIPTION
One rowset multi segments in uniq key compaction, segments rows will be
merged in generic_iterator but merged_rows not increased。
Compaction will failed in check_correctness, and make a tablet with
too much versions which lead to -235 load error.

# Proposed changes

Issue Number: close #xxx

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
