### PR TITLE
[feature-wip][multi-catalog] Support s3 storage for file scan node

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ package-lock.json
 # ignore project file
 .cproject
 .project
+.cache
 .settings/
 **/.idea/
 **/.vscode/

--- a/be/src/io/file_factory.h
+++ b/be/src/io/file_factory.h
@@ -48,6 +48,16 @@ public:
                                      const TBrokerRangeDesc& range, int64_t start_offset,
                                      std::shared_ptr<FileReader>& file_reader);
 
+    static Status create_file_reader(ExecEnv* env, RuntimeProfile* profile,
+                                     const TFileScanRangeParams& params,
+                                     const TFileRangeDesc& range,
+                                     std::unique_ptr<FileReader>& file_reader);
+
+    static Status create_file_reader(ExecEnv* env, RuntimeProfile* profile,
+                                     const TFileScanRangeParams& params,
+                                     const TFileRangeDesc& range,
+                                     std::shared_ptr<FileReader>& file_reader);
+
     static TFileType::type convert_storage_type(TStorageBackendType::type type) {
         switch (type) {
         case TStorageBackendType::LOCAL:
@@ -71,6 +81,10 @@ private:
                                    const std::vector<TNetworkAddress>& broker_addresses,
                                    const std::map<std::string, std::string>& properties,
                                    const TBrokerRangeDesc& range, int64_t start_offset,
+                                   FileReader*& file_reader);
+
+    static Status _new_file_reader(ExecEnv* env, RuntimeProfile* profile,
+                                   const TFileScanRangeParams& params, const TFileRangeDesc& range,
                                    FileReader*& file_reader);
 };
 

--- a/be/src/vec/exec/file_arrow_scanner.cpp
+++ b/be/src/vec/exec/file_arrow_scanner.cpp
@@ -17,8 +17,11 @@
 
 #include "vec/exec/file_arrow_scanner.h"
 
+#include <memory>
+
 #include "exec/arrow/parquet_reader.h"
 #include "io/buffered_reader.h"
+#include "io/file_factory.h"
 #include "io/hdfs_reader_writer.h"
 #include "runtime/descriptors.h"
 #include "vec/utils/arrow_column_to_doris_column.h"
@@ -54,10 +57,9 @@ Status FileArrowScanner::_open_next_reader() {
         }
         const TFileRangeDesc& range = _ranges[_next_range++];
         std::unique_ptr<FileReader> file_reader;
-        FileReader* hdfs_reader = nullptr;
-        RETURN_IF_ERROR(HdfsReaderWriter::create_reader(_params.hdfs_params, range.path,
-                                                        range.start_offset, &hdfs_reader));
-        file_reader.reset(new BufferedReader(_profile, hdfs_reader));
+
+        RETURN_IF_ERROR(FileFactory::create_file_reader(_state->exec_env(), _profile, _params,
+                                                        range, file_reader));
         RETURN_IF_ERROR(file_reader->open());
         if (file_reader->size() == 0) {
             file_reader->close();

--- a/be/src/vec/exec/file_text_scanner.cpp
+++ b/be/src/vec/exec/file_text_scanner.cpp
@@ -28,6 +28,7 @@
 #include "exec/text_converter.hpp"
 #include "exprs/expr_context.h"
 #include "io/buffered_reader.h"
+#include "io/file_factory.h"
 #include "io/hdfs_reader_writer.h"
 #include "util/types.h"
 #include "util/utf8_check.h"
@@ -152,11 +153,8 @@ Status FileTextScanner::_open_next_reader() {
 
 Status FileTextScanner::_open_file_reader() {
     const TFileRangeDesc& range = _ranges[_next_range];
-
-    FileReader* hdfs_reader = nullptr;
-    RETURN_IF_ERROR(HdfsReaderWriter::create_reader(_params.hdfs_params, range.path,
-                                                    range.start_offset, &hdfs_reader));
-    _cur_file_reader.reset(new BufferedReader(_profile, hdfs_reader));
+    RETURN_IF_ERROR(FileFactory::create_file_reader(_state->exec_env(), _profile, _params, range,
+                                                    _cur_file_reader));
     return _cur_file_reader->open();
 }
 

--- a/bin/start_be.sh
+++ b/bin/start_be.sh
@@ -31,10 +31,15 @@ OPTS=$(getopt \
 eval set -- "$OPTS"
 
 RUN_DAEMON=0
+RUN_IN_AWS=0
 while true; do
     case "$1" in
     --daemon)
         RUN_DAEMON=1
+        shift
+        ;;
+    --aws)
+        RUN_IN_AWS=1
         shift
         ;;
     --)
@@ -168,6 +173,11 @@ if [ ! -f /bin/limit3 ]; then
     LIMIT=
 else
     LIMIT="/bin/limit3 -c 0 -n 65536"
+fi
+
+## If you are not running in aws cloud, disable this env since https://github.com/aws/aws-sdk-cpp/issues/1410.
+if [ ${RUN_IN_AWS} -eq 0 ]; then
+    export AWS_EC2_METADATA_DISABLED=true
 fi
 
 if [ ${RUN_DAEMON} -eq 1 ]; then

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/HiveTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/HiveTable.java
@@ -53,10 +53,15 @@ public class HiveTable extends Table {
     public static final String HIVE_TABLE = "table";
     public static final String HIVE_METASTORE_URIS = "hive.metastore.uris";
     public static final String HIVE_HDFS_PREFIX = "dfs.";
+    public static final String S3_FS_PREFIX = "fs.s3";
     public static final String S3_PROPERTIES_PREFIX = "AWS";
     public static final String S3_AK = "AWS_ACCESS_KEY";
     public static final String S3_SK = "AWS_SECRET_KEY";
     public static final String S3_ENDPOINT = "AWS_ENDPOINT";
+    public static final String AWS_REGION = "AWS_REGION";
+    public static final String AWS_MAX_CONN_SIZE = "AWS_MAX_CONN_SIZE";
+    public static final String AWS_REQUEST_TIMEOUT_MS = "AWS_REQUEST_TIMEOUT_MS";
+    public static final String AWS_CONN_TIMEOUT_MS = "AWS_CONN_TIMEOUT_MS";
 
     public HiveTable() {
         super(TableType.HIVE);

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/DataSourceProperty.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/DataSourceProperty.java
@@ -57,16 +57,40 @@ public class DataSourceProperty implements Writable {
         Map<String, String> s3Properties = Maps.newHashMap();
         if (properties.containsKey(HiveTable.S3_AK)) {
             s3Properties.put("fs.s3a.access.key", properties.get(HiveTable.S3_AK));
+            s3Properties.put(HiveTable.S3_AK, properties.get(HiveTable.S3_AK));
         }
         if (properties.containsKey(HiveTable.S3_SK)) {
             s3Properties.put("fs.s3a.secret.key", properties.get(HiveTable.S3_SK));
+            s3Properties.put(HiveTable.S3_SK, properties.get(HiveTable.S3_SK));
         }
         if (properties.containsKey(HiveTable.S3_ENDPOINT)) {
             s3Properties.put("fs.s3a.endpoint", properties.get(HiveTable.S3_ENDPOINT));
+            s3Properties.put(HiveTable.S3_ENDPOINT, properties.get(HiveTable.S3_ENDPOINT));
+        }
+        if (properties.containsKey(HiveTable.AWS_REGION)) {
+            s3Properties.put("fs.s3a.endpoint.region", properties.get(HiveTable.AWS_REGION));
+            s3Properties.put(HiveTable.AWS_REGION, properties.get(HiveTable.AWS_REGION));
+        }
+        if (properties.containsKey(HiveTable.AWS_MAX_CONN_SIZE)) {
+            s3Properties.put("fs.s3a.connection.maximum", properties.get(HiveTable.AWS_MAX_CONN_SIZE));
+            s3Properties.put(HiveTable.AWS_MAX_CONN_SIZE, properties.get(HiveTable.AWS_MAX_CONN_SIZE));
+        }
+        if (properties.containsKey(HiveTable.AWS_REQUEST_TIMEOUT_MS)) {
+            s3Properties.put("fs.s3a.connection.request.timeout", properties.get(HiveTable.AWS_REQUEST_TIMEOUT_MS));
+            s3Properties.put(HiveTable.AWS_REQUEST_TIMEOUT_MS, properties.get(HiveTable.AWS_REQUEST_TIMEOUT_MS));
+        }
+        if (properties.containsKey(HiveTable.AWS_CONN_TIMEOUT_MS)) {
+            s3Properties.put("fs.s3a.connection.timeout", properties.get(HiveTable.AWS_CONN_TIMEOUT_MS));
+            s3Properties.put(HiveTable.AWS_CONN_TIMEOUT_MS, properties.get(HiveTable.AWS_CONN_TIMEOUT_MS));
         }
         s3Properties.put("fs.s3.impl.disable.cache", "true");
         s3Properties.put("fs.s3.impl", "org.apache.hadoop.fs.s3a.S3AFileSystem");
         s3Properties.put("fs.s3a.attempts.maximum", "2");
+        for (Map.Entry<String, String> entry : properties.entrySet()) {
+            if (entry.getKey().startsWith(HiveTable.S3_FS_PREFIX)) {
+                s3Properties.put(entry.getKey(), entry.getValue());
+            }
+        }
         return s3Properties;
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/external/ExternalFileScanProvider.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/external/ExternalFileScanProvider.java
@@ -37,11 +37,11 @@ import java.util.Map;
 public interface ExternalFileScanProvider {
     TFileFormatType getTableFormatType() throws DdlException, MetaNotFoundException;
 
-    TFileType getTableFileType();
+    TFileType getTableFileType() throws DdlException, MetaNotFoundException;
 
     String getMetaStoreUrl();
 
-    InputSplit[] getSplits(List<Expr> exprs) throws IOException, UserException;
+    List<InputSplit> getSplits(List<Expr> exprs) throws IOException, UserException;
 
     Table getRemoteHiveTable() throws DdlException, MetaNotFoundException;
 

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/external/ExternalHiveScanProvider.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/external/ExternalHiveScanProvider.java
@@ -27,6 +27,7 @@ import org.apache.doris.external.hive.util.HiveUtil;
 import org.apache.doris.thrift.TFileFormatType;
 import org.apache.doris.thrift.TFileType;
 
+import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
@@ -39,6 +40,7 @@ import org.apache.hadoop.mapred.InputSplit;
 import org.apache.hadoop.mapred.JobConf;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -69,8 +71,16 @@ public class ExternalHiveScanProvider implements ExternalFileScanProvider {
     }
 
     @Override
-    public TFileType getTableFileType() {
-        return TFileType.FILE_HDFS;
+    public TFileType getTableFileType() throws DdlException, MetaNotFoundException {
+        String location = hmsTable.getRemoteTable().getSd().getLocation();
+        if (location != null && !location.isEmpty()) {
+            if (location.startsWith("s3a") || location.startsWith("s3n")) {
+                return TFileType.FILE_S3;
+            } else if (location.startsWith("hdfs:")) {
+                return TFileType.FILE_HDFS;
+            }
+        }
+        throw new DdlException("Unknown file type for hms table.");
     }
 
     @Override
@@ -79,33 +89,49 @@ public class ExternalHiveScanProvider implements ExternalFileScanProvider {
     }
 
     @Override
-    public InputSplit[] getSplits(List<Expr> exprs)
+    public List<InputSplit> getSplits(List<Expr> exprs)
             throws IOException, UserException {
         String splitsPath = getRemoteHiveTable().getSd().getLocation();
         List<String> partitionKeys = getRemoteHiveTable().getPartitionKeys()
                 .stream().map(FieldSchema::getName).collect(Collectors.toList());
+        List<Partition> hivePartitions = new ArrayList<>();
 
         if (partitionKeys.size() > 0) {
             ExprNodeGenericFuncDesc hivePartitionPredicate = HiveMetaStoreClientHelper.convertToHivePartitionExpr(
                     exprs, partitionKeys, hmsTable.getName());
 
             String metaStoreUris = getMetaStoreUrl();
-            List<Partition> hivePartitions = HiveMetaStoreClientHelper.getHivePartitions(
-                    metaStoreUris,  getRemoteHiveTable(), hivePartitionPredicate);
-            if (!hivePartitions.isEmpty()) {
-                splitsPath = hivePartitions.stream().map(x -> x.getSd().getLocation())
-                        .collect(Collectors.joining(","));
-            }
+            hivePartitions.addAll(HiveMetaStoreClientHelper.getHivePartitions(
+                    metaStoreUris,  getRemoteHiveTable(), hivePartitionPredicate));
         }
 
         String inputFormatName = getRemoteHiveTable().getSd().getInputFormat();
 
         Configuration configuration = setConfiguration();
         InputFormat<?, ?> inputFormat = HiveUtil.getInputFormat(configuration, inputFormatName, false);
+        if (!hivePartitions.isEmpty()) {
+            return hivePartitions.parallelStream()
+                    .flatMap(x -> getSplitsByPath(inputFormat, configuration, x.getSd().getLocation()).stream())
+                    .collect(Collectors.toList());
+        } else {
+            return getSplitsByPath(inputFormat, configuration, splitsPath);
+        }
+    }
+
+    private List<InputSplit> getSplitsByPath(
+            InputFormat<?, ?> inputFormat,
+            Configuration configuration,
+            String splitsPath) {
         JobConf jobConf = new JobConf(configuration);
         FileInputFormat.setInputPaths(jobConf, splitsPath);
-        return inputFormat.getSplits(jobConf, 0);
+        try {
+            InputSplit[] splits = inputFormat.getSplits(jobConf, 0);
+            return Lists.newArrayList(splits);
+        } catch (IOException e) {
+            return new ArrayList<InputSplit>();
+        }
     }
+
 
     protected Configuration setConfiguration() {
         Configuration conf = new Configuration();

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -237,6 +237,8 @@ struct TFileScanRangeParams {
 
   6: optional THdfsParams hdfs_params;
   7: optional TFileTextScanRangeParams text_params;
+  // properties for file such as s3 information
+  8: optional map<string, string> properties;
 }
 
 struct TFileRangeDesc {


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

This is an example of s3 hms_catalog:
```sql
CREATE CATALOG hms_catalog properties(  "type" = "hms",   "hive.metastore.uris"="thrift://localhost:9083", "AWS_ACCESS_KEY" = "your access key", "AWS_SECRET_KEY"="your secret key", "AWS_ENDPOINT"="s3 endpoint", "AWS_REGION"="s3-region", "fs.s3a.paging.maximum"="1000");
```
All these params are necessary;



## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
