### PR TITLE
[refactor](policy) refactor some policy create and check logic

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/alter/Alter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/Alter.java
@@ -59,7 +59,6 @@ import org.apache.doris.common.UserException;
 import org.apache.doris.common.util.DynamicPartitionUtil;
 import org.apache.doris.common.util.MetaLockUtils;
 import org.apache.doris.common.util.PropertyAnalyzer;
-import org.apache.doris.datasource.InternalDataSource;
 import org.apache.doris.persist.AlterViewInfo;
 import org.apache.doris.persist.BatchModifyPartitionsInfo;
 import org.apache.doris.persist.ModifyCommentOperationLog;
@@ -161,7 +160,7 @@ public class Alter {
             }
             String currentStoragePolicy = currentAlterOps.getTableStoragePolicy(alterClauses);
             // check currentStoragePolicy resource exist.
-            InternalDataSource.checkStoragePolicyExist(currentStoragePolicy);
+            Catalog.getCurrentCatalog().getPolicyMgr().checkStoragePolicyExist(currentStoragePolicy);
 
             olapTable.setStoragePolicy(currentStoragePolicy);
             needProcessOutsideTableLock = true;
@@ -713,7 +712,7 @@ public class Alter {
             String currentStoragePolicy = PropertyAnalyzer.analyzeStoragePolicy(properties);
             if (!currentStoragePolicy.equals("")) {
                 // check currentStoragePolicy resource exist.
-                InternalDataSource.checkStoragePolicyExist(currentStoragePolicy);
+                Catalog.getCurrentCatalog().getPolicyMgr().checkStoragePolicyExist(currentStoragePolicy);
                 partitionInfo.setStoragePolicy(partition.getId(), currentStoragePolicy);
             }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/AlterPolicyStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/AlterPolicyStmt.java
@@ -19,7 +19,6 @@ package org.apache.doris.analysis;
 
 import org.apache.doris.catalog.Catalog;
 import org.apache.doris.common.AnalysisException;
-import org.apache.doris.common.Config;
 import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.ErrorReport;
 import org.apache.doris.common.UserException;
@@ -77,10 +76,10 @@ public class AlterPolicyStmt extends DdlStmt {
         StoragePolicy storagePolicy = (StoragePolicy) hasPolicy.get();
 
         // default storage policy use alter storage policy to add s3 resource.
-        if (!policyName.equalsIgnoreCase(Config.default_storage_policy)
-                && properties.containsKey(StoragePolicy.STORAGE_RESOURCE)) {
+        if (!policyName.equalsIgnoreCase(StoragePolicy.DEFAULT_STORAGE_POLICY_NAME) && properties.containsKey(
+                StoragePolicy.STORAGE_RESOURCE)) {
             throw new AnalysisException("not support change storage policy's storage resource"
-                + ", you can change s3 properties by alter resource");
+                    + ", you can change s3 properties by alter resource");
         }
 
         boolean hasCooldownDatetime = false;
@@ -114,7 +113,7 @@ public class AlterPolicyStmt extends DdlStmt {
         }
 
         do {
-            if (policyName.equalsIgnoreCase(Config.default_storage_policy)) {
+            if (policyName.equalsIgnoreCase(StoragePolicy.DEFAULT_STORAGE_POLICY_NAME)) {
                 // default storage policy
                 if (storagePolicy.getStorageResource() != null && hasCooldownDatetime) {
                     // alter cooldown datetime, can do

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Catalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Catalog.java
@@ -1261,6 +1261,8 @@ public class Catalog {
             initDefaultCluster();
         }
 
+        getPolicyMgr().createDefaultStoragePolicy();
+
         // MUST set master ip before starting checkpoint thread.
         // because checkpoint thread need this info to select non-master FE to push image
         this.masterIp = FrontendOptions.getLocalHostAddress();

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/ResourceMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/ResourceMgr.java
@@ -32,7 +32,6 @@ import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.persist.DropResourceOperationLog;
 import org.apache.doris.persist.gson.GsonUtils;
 import org.apache.doris.policy.Policy;
-import org.apache.doris.policy.PolicyTypeEnum;
 import org.apache.doris.policy.StoragePolicy;
 import org.apache.doris.qe.ConnectContext;
 
@@ -109,7 +108,7 @@ public class ResourceMgr implements Writable {
         }
 
         // Check whether the resource is in use before deleting it, except spark resource
-        StoragePolicy checkedStoragePolicy = new StoragePolicy(PolicyTypeEnum.STORAGE, null);
+        StoragePolicy checkedStoragePolicy = StoragePolicy.ofCheck(null);
         checkedStoragePolicy.setStorageResource(resourceName);
         if (Catalog.getCurrentCatalog().getPolicyMgr().existPolicy(checkedStoragePolicy)) {
             Policy policy = Catalog.getCurrentCatalog().getPolicyMgr().getPolicy(checkedStoragePolicy);

--- a/fe/fe-core/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/Config.java
@@ -1691,9 +1691,6 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true, masterOnly = true)
     public static boolean use_date_v2_by_default = false;
 
-    @ConfField
-    public static String default_storage_policy = "default_storage_policy";
-
     @ConfField(mutable = false, masterOnly = true)
     public static boolean enable_multi_tags = false;
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/DynamicPartitionUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/DynamicPartitionUtil.java
@@ -38,7 +38,6 @@ import org.apache.doris.common.ErrorReport;
 import org.apache.doris.common.FeConstants;
 import org.apache.doris.common.FeNameFormat;
 import org.apache.doris.common.UserException;
-import org.apache.doris.policy.PolicyTypeEnum;
 import org.apache.doris.policy.StoragePolicy;
 
 import com.google.common.base.Preconditions;
@@ -343,23 +342,24 @@ public class DynamicPartitionUtil {
         }
     }
 
-    private static void checkRemoteStoragePolicy(String val) throws DdlException {
-        if (Strings.isNullOrEmpty(val)) {
+    private static void checkRemoteStoragePolicy(String policyName) throws DdlException {
+        if (Strings.isNullOrEmpty(policyName)) {
             LOG.info(DynamicPartitionProperty.REMOTE_STORAGE_POLICY + " is null, remove this key");
             return;
         }
-        if (val.isEmpty()) {
+        if (policyName.isEmpty()) {
             throw new DdlException(DynamicPartitionProperty.REMOTE_STORAGE_POLICY + " is empty.");
         }
-        StoragePolicy checkedPolicyCondition = new StoragePolicy(PolicyTypeEnum.STORAGE, val);
+        StoragePolicy checkedPolicyCondition = StoragePolicy.ofCheck(policyName);
         if (!Catalog.getCurrentCatalog().getPolicyMgr().existPolicy(checkedPolicyCondition)) {
-            throw new DdlException(DynamicPartitionProperty.REMOTE_STORAGE_POLICY + ": " + val + " doesn't exist.");
+            throw new DdlException(
+                    DynamicPartitionProperty.REMOTE_STORAGE_POLICY + ": " + policyName + " doesn't exist.");
         }
         StoragePolicy storagePolicy = (StoragePolicy) Catalog.getCurrentCatalog()
                 .getPolicyMgr().getPolicy(checkedPolicyCondition);
         if (Strings.isNullOrEmpty(storagePolicy.getCooldownTtl())) {
             throw new DdlException("Storage policy cooldown type need to be cooldownTtl for properties "
-                    + DynamicPartitionProperty.REMOTE_STORAGE_POLICY + ": " + val);
+                    + DynamicPartitionProperty.REMOTE_STORAGE_POLICY + ": " + policyName);
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/PropertyAnalyzer.java
@@ -31,7 +31,6 @@ import org.apache.doris.catalog.Type;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.Config;
 import org.apache.doris.policy.Policy;
-import org.apache.doris.policy.PolicyTypeEnum;
 import org.apache.doris.policy.StoragePolicy;
 import org.apache.doris.resource.Tag;
 import org.apache.doris.thrift.TCompressionType;
@@ -196,7 +195,7 @@ public class PropertyAnalyzer {
 
         if (hasRemoteStoragePolicy) {
             // check remote storage policy
-            StoragePolicy checkedPolicy = new StoragePolicy(PolicyTypeEnum.STORAGE, remoteStoragePolicy);
+            StoragePolicy checkedPolicy = StoragePolicy.ofCheck(remoteStoragePolicy);
             Policy policy = Catalog.getCurrentCatalog().getPolicyMgr().getPolicy(checkedPolicy);
             if (!(policy instanceof StoragePolicy)) {
                 throw new AnalysisException("No PolicyStorage: " + remoteStoragePolicy);
@@ -521,7 +520,7 @@ public class PropertyAnalyzer {
         if (properties != null && properties.containsKey(PROPERTIES_REMOTE_STORAGE_POLICY)) {
             remoteStoragePolicy = properties.get(PROPERTIES_REMOTE_STORAGE_POLICY);
             // check remote storage policy existence
-            StoragePolicy checkedStoragePolicy = new StoragePolicy(PolicyTypeEnum.STORAGE, remoteStoragePolicy);
+            StoragePolicy checkedStoragePolicy = StoragePolicy.ofCheck(remoteStoragePolicy);
             Policy policy = Catalog.getCurrentCatalog().getPolicyMgr().getPolicy(checkedStoragePolicy);
             if (!(policy instanceof StoragePolicy)) {
                 throw new AnalysisException("StoragePolicy: " + remoteStoragePolicy + " does not exist.");

--- a/fe/fe-core/src/main/java/org/apache/doris/policy/Policy.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/policy/Policy.java
@@ -57,7 +57,8 @@ public abstract class Policy implements Writable, GsonPostProcessable {
     @SerializedName(value = "policyName")
     protected String policyName = null;
 
-    public Policy() {
+    public Policy(PolicyTypeEnum type) {
+        this.type = type;
     }
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/policy/Policy.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/policy/Policy.java
@@ -58,9 +58,6 @@ public abstract class Policy implements Writable, GsonPostProcessable {
     protected String policyName = null;
 
     public Policy() {
-        if (Catalog.getCurrentCatalog().isMaster()) {
-            policyId = Catalog.getCurrentCatalog().getNextId();
-        }
     }
 
     /**
@@ -69,8 +66,8 @@ public abstract class Policy implements Writable, GsonPostProcessable {
      * @param type policy type
      * @param policyName policy name
      */
-    public Policy(final PolicyTypeEnum type, final String policyName) {
-        policyId = Catalog.getCurrentCatalog().getNextId();
+    public Policy(long policyId, final PolicyTypeEnum type, final String policyName) {
+        this.policyId = policyId;
         this.type = type;
         this.policyName = policyName;
     }
@@ -79,13 +76,13 @@ public abstract class Policy implements Writable, GsonPostProcessable {
      * Trans stmt to Policy.
      **/
     public static Policy fromCreateStmt(CreatePolicyStmt stmt) throws AnalysisException {
+        long policyId = Catalog.getCurrentCatalog().getNextId();
         switch (stmt.getType()) {
             case STORAGE:
-                StoragePolicy storagePolicy = new StoragePolicy(stmt.getType(), stmt.getPolicyName());
+                StoragePolicy storagePolicy = new StoragePolicy(policyId, stmt.getPolicyName());
                 storagePolicy.init(stmt.getProperties(), stmt.isIfNotExists());
                 return storagePolicy;
             case ROW:
-            default:
                 // stmt must be analyzed.
                 DatabaseIf db = Catalog.getCurrentCatalog().getDataSourceMgr()
                         .getCatalogOrAnalysisException(stmt.getTableName().getCtl())
@@ -93,9 +90,10 @@ public abstract class Policy implements Writable, GsonPostProcessable {
                 UserIdentity userIdent = stmt.getUser();
                 userIdent.analyze(ConnectContext.get().getClusterName());
                 TableIf table = db.getTableOrAnalysisException(stmt.getTableName().getTbl());
-                return new RowPolicy(stmt.getType(), stmt.getPolicyName(), db.getId(), userIdent,
-                    stmt.getOrigStmt().originStmt, table.getId(), stmt.getFilterType(),
-                    stmt.getWherePredicate());
+                return new RowPolicy(policyId, stmt.getPolicyName(), db.getId(), userIdent,
+                        stmt.getOrigStmt().originStmt, table.getId(), stmt.getFilterType(), stmt.getWherePredicate());
+            default:
+                throw new AnalysisException("Unknown policy type: " + stmt.getType());
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/policy/RowPolicy.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/policy/RowPolicy.java
@@ -93,7 +93,7 @@ public class RowPolicy extends Policy {
     /**
      * Policy for Table. Policy of ROW or others.
      *
-     * @param type PolicyType
+     * @param policyId policy id
      * @param policyName policy name
      * @param dbId database i
      * @param user username
@@ -102,10 +102,9 @@ public class RowPolicy extends Policy {
      * @param filterType filter type
      * @param wherePredicate where predicate
      */
-    public RowPolicy(final PolicyTypeEnum type, final String policyName, long dbId,
-                     UserIdentity user, String originStmt, final long tableId,
-                     final FilterType filterType, final Expr wherePredicate) {
-        super(type, policyName);
+    public RowPolicy(long policyId, final String policyName, long dbId, UserIdentity user, String originStmt,
+            final long tableId, final FilterType filterType, final Expr wherePredicate) {
+        super(policyId, PolicyTypeEnum.ROW, policyName);
         this.user = user;
         this.dbId = dbId;
         this.tableId = tableId;
@@ -141,8 +140,8 @@ public class RowPolicy extends Policy {
 
     @Override
     public RowPolicy clone() {
-        return new RowPolicy(this.type, this.policyName, this.dbId, this.user, this.originStmt, this.tableId,
-                               this.filterType, this.wherePredicate);
+        return new RowPolicy(this.policyId, this.policyName, this.dbId, this.user, this.originStmt, this.tableId,
+                this.filterType, this.wherePredicate);
     }
 
     private boolean checkMatched(long dbId, long tableId, PolicyTypeEnum type,

--- a/fe/fe-core/src/main/java/org/apache/doris/policy/RowPolicy.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/policy/RowPolicy.java
@@ -88,7 +88,9 @@ public class RowPolicy extends Policy {
 
     private Expr wherePredicate = null;
 
-    public RowPolicy() {}
+    public RowPolicy() {
+        super(PolicyTypeEnum.ROW);
+    }
 
     /**
      * Policy for Table. Policy of ROW or others.

--- a/fe/fe-core/src/main/java/org/apache/doris/policy/StoragePolicy.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/policy/StoragePolicy.java
@@ -23,7 +23,6 @@ import org.apache.doris.catalog.Resource;
 import org.apache.doris.catalog.S3Resource;
 import org.apache.doris.catalog.ScalarType;
 import org.apache.doris.common.AnalysisException;
-import org.apache.doris.common.Config;
 import org.apache.doris.common.DdlException;
 import org.apache.doris.common.io.Text;
 import org.apache.doris.persist.gson.GsonUtils;
@@ -57,16 +56,18 @@ import java.util.Optional;
  **/
 @Data
 public class StoragePolicy extends Policy {
-    public static boolean checkDefaultStoragePolicyValid(final String storagePolicyName,
-                                                         Optional<Policy> defaultPolicy) throws DdlException {
+    public static final String DEFAULT_STORAGE_POLICY_NAME = "default_storage_policy";
+
+    public static boolean checkDefaultStoragePolicyValid(final String storagePolicyName, Optional<Policy> defaultPolicy)
+            throws DdlException {
         if (!defaultPolicy.isPresent()) {
             return false;
         }
 
-        if (storagePolicyName.equalsIgnoreCase(Config.default_storage_policy)
-                && (((StoragePolicy) defaultPolicy.get()).getStorageResource() == null)) {
+        if (storagePolicyName.equalsIgnoreCase(DEFAULT_STORAGE_POLICY_NAME) && (
+                ((StoragePolicy) defaultPolicy.get()).getStorageResource() == null)) {
             throw new DdlException("Use default storage policy, but not give s3 info,"
-                + " please use alter resource to add default storage policy S3 info.");
+                    + " please use alter resource to add default storage policy S3 info.");
         }
         return true;
     }
@@ -121,16 +122,16 @@ public class StoragePolicy extends Policy {
     /**
      * Policy for Storage Migration.
      *
-     * @param type PolicyType
+     * @param policyId policy id
      * @param policyName policy name
      * @param storageResource resource name for storage
      * @param cooldownDatetime cool down time
      * @param cooldownTtl cool down time cost after partition is created
      * @param cooldownTtlMs seconds for cooldownTtl
      */
-    public StoragePolicy(final PolicyTypeEnum type, final String policyName, final String storageResource,
-                         final Date cooldownDatetime, final String cooldownTtl, long cooldownTtlMs) {
-        super(type, policyName);
+    public StoragePolicy(long policyId, final String policyName, final String storageResource,
+            final Date cooldownDatetime, final String cooldownTtl, long cooldownTtlMs) {
+        super(policyId, PolicyTypeEnum.STORAGE, policyName);
         this.storageResource = storageResource;
         this.cooldownDatetime = cooldownDatetime;
         this.cooldownTtl = cooldownTtl;
@@ -140,11 +141,17 @@ public class StoragePolicy extends Policy {
     /**
      * Policy for Storage Migration.
      *
-     * @param type PolicyType
+     * @param policyId policy id
      * @param policyName policy name
      */
-    public StoragePolicy(final PolicyTypeEnum type, final String policyName) {
-        super(type, policyName);
+    public StoragePolicy(long policyId, final String policyName) {
+        super(policyId, PolicyTypeEnum.STORAGE, policyName);
+    }
+
+    public static StoragePolicy ofCheck(String policyName) {
+        StoragePolicy storagePolicy = new StoragePolicy();
+        storagePolicy.policyName = policyName;
+        return storagePolicy;
     }
 
     /**
@@ -240,8 +247,8 @@ public class StoragePolicy extends Policy {
 
     @Override
     public StoragePolicy clone() {
-        return new StoragePolicy(this.type, this.policyName, this.storageResource,
-                                 this.cooldownDatetime, this.cooldownTtl, this.cooldownTtlMs);
+        return new StoragePolicy(this.policyId, this.policyName, this.storageResource, this.cooldownDatetime,
+                this.cooldownTtl, this.cooldownTtlMs);
     }
 
     @Override
@@ -356,11 +363,10 @@ public class StoragePolicy extends Policy {
             }
         });
 
-        if (policyName.equalsIgnoreCase(Config.default_storage_policy) && storageResource == null) {
+        if (policyName.equalsIgnoreCase(DEFAULT_STORAGE_POLICY_NAME) && storageResource == null) {
             // here first time set S3 resource to default storage policy.
-            String alterStorageResource = Optional.ofNullable(properties.get(STORAGE_RESOURCE))
-                    .orElseThrow(() ->
-                        new DdlException("first time set default storage policy, but not give storageResource"));
+            String alterStorageResource = Optional.ofNullable(properties.get(STORAGE_RESOURCE)).orElseThrow(
+                    () -> new DdlException("first time set default storage policy, but not give storageResource"));
             // check alterStorageResource resource exist.
             checkIsS3ResourceAndExist(alterStorageResource);
             storageResource = alterStorageResource;

--- a/fe/fe-core/src/main/java/org/apache/doris/policy/StoragePolicy.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/policy/StoragePolicy.java
@@ -117,7 +117,9 @@ public class StoragePolicy extends Policy {
 
     private Map<String, String> props;
 
-    public StoragePolicy() {}
+    public StoragePolicy() {
+        super(PolicyTypeEnum.STORAGE);
+    }
 
     /**
      * Policy for Storage Migration.

--- a/fe/fe-core/src/test/java/org/apache/doris/policy/PolicyTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/policy/PolicyTest.java
@@ -201,13 +201,13 @@ public class PolicyTest extends TestWithFeService {
         long dbId = 10;
         UserIdentity user = new UserIdentity("test_policy", "%");
         String originStmt = "CREATE ROW POLICY test_row_policy ON test.table1"
-                            + " AS PERMISSIVE TO test_policy USING (k1 = 1)";
+                + " AS PERMISSIVE TO test_policy USING (k1 = 1)";
         long tableId = 100;
         FilterType filterType = FilterType.PERMISSIVE;
         Expr wherePredicate = null;
 
-        Policy rowPolicy = new RowPolicy(type, policyName, dbId, user,
-                                         originStmt, tableId, filterType, wherePredicate);
+        Policy rowPolicy = new RowPolicy(10000, policyName, dbId, user, originStmt, tableId, filterType,
+                wherePredicate);
 
         ByteArrayOutputStream emptyOutputStream = new ByteArrayOutputStream();
         DataOutputStream output = new DataOutputStream(emptyOutputStream);
@@ -218,6 +218,7 @@ public class PolicyTest extends TestWithFeService {
         Policy newPolicy = Policy.read(input);
         Assertions.assertTrue(newPolicy instanceof RowPolicy);
         RowPolicy newRowPolicy = (RowPolicy) newPolicy;
+        Assertions.assertEquals(rowPolicy.getPolicyId(), newRowPolicy.getPolicyId());
         Assertions.assertEquals(type, newRowPolicy.getType());
         Assertions.assertEquals(policyName, newRowPolicy.getPolicyName());
         Assertions.assertEquals(dbId, newRowPolicy.getDbId());


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

1. Remove `Config.default_storage_policy`
    Now the Doris will create default storage policy when first startup, and name is `default_storage_policy`

2. Do not call `Catalog.getCurrentCatalog().getNextId()` in Policy's constructors.
   Pass the policy id from outside, so that we can safely create a new policy instance anywhere.

## Checklist(Required)

1. Does it affect the original behavior: (Yes)
    The config has been removed
2. Has unit tests been added: (Yes)
3. Has document been added or modified: (No Need)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
